### PR TITLE
Jetpack Settings: Migrate header to unified pattern and left-align tabs

### DIFF
--- a/projects/js-packages/components/changelog/pr-47388
+++ b/projects/js-packages/components/changelog/pr-47388
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin page: Fix Hello Dolly banner display and clear floats on Jetpack admin pages.

--- a/projects/js-packages/components/components/admin-page/style.module.scss
+++ b/projects/js-packages/components/components/admin-page/style.module.scss
@@ -17,6 +17,12 @@
 		position: relative;
 	}
 
+	// Normalize admin headers: implementation of admin-ui needs to
+	// comprehend old wp-admin floating containers, such as Hello Dolly.
+	:global(.admin-ui-page) {
+		clear: both;
+	}
+
 	.admin-page-header {
 		display: flex;
 		align-items: center;
@@ -33,4 +39,9 @@
 		cursor: pointer;
 		color: #fff;
 	}
+}
+
+// Make Hello Dolly background white for Jetpack admin pages.
+:global(.jetpack-admin-page #dolly) {
+	background-color: #fff;
 }

--- a/projects/packages/my-jetpack/_inc/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/style.module.scss
@@ -4,6 +4,7 @@
 	body.jetpack_page_my-jetpack p#dolly {
 		position: absolute;
 		inset-inline-end: 0;
+		z-index: 2;
 
 		@media (max-width: 782px) {
 			padding-inline-end: 10px;

--- a/projects/packages/my-jetpack/changelog/pr-47388
+++ b/projects/packages/my-jetpack/changelog/pr-47388
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Hello Dolly banner z-index to prevent overlap on the My Jetpack page.

--- a/projects/packages/newsletter/changelog/pr-47388
+++ b/projects/packages/newsletter/changelog/pr-47388
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Settings: Fix Hello Dolly banner display and box-sizing on the newsletter settings page.

--- a/projects/packages/newsletter/src/settings/style.scss
+++ b/projects/packages/newsletter/src/settings/style.scss
@@ -1,6 +1,15 @@
 // Import dataviews styles for DataForm component
 @import "@wordpress/dataviews/build-style/style.css";
 
+#newsletter-settings-root * {
+	box-sizing: border-box;
+}
+
+.jetpack_page_jetpack-newsletter #dolly {
+	width: 100%;
+	text-align: right;
+}
+
 .newsletter-settings {
 	max-width: 1200px;
 	margin-inline: auto;

--- a/projects/packages/search/changelog/pr-47388
+++ b/projects/packages/search/changelog/pr-47388
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Dashboard: Remove global CSS overrides and move admin notices inside the main container.

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -107,11 +107,6 @@ export default function DashboardPage( { isLoading = false } ) {
 
 	return (
 		<>
-			<Container horizontalSpacing={ 0 }>
-				<Col>
-					<div id="jp-admin-notices" className="jetpack-search-jitm-card" />
-				</Col>
-			</Container>
 			{ isPageLoading && <Loading /> }
 			{ ! isPageLoading && (
 				<div className="jp-search-dashboard-page">
@@ -131,13 +126,16 @@ export default function DashboardPage( { isLoading = false } ) {
 						className="uses-new-admin-ui"
 						showFooter={ false }
 					>
-						{ hasConnectionError && (
-							<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
+						<Container horizontalSpacing={ 0 } horizontalGap={ 3 }>
+							{ hasConnectionError && (
 								<Col lg={ 12 } md={ 12 } sm={ 12 }>
 									<ConnectionError />
 								</Col>
-							</Container>
-						) }
+							) }
+							<Col>
+								<div id="jp-admin-notices" className="jetpack-search-jitm-card" />
+							</Col>
+						</Container>
 						<MockedSearchInterface
 							supportsInstantSearch={ supportsInstantSearch }
 							supportsOnlyClassicSearch={ supportsOnlyClassicSearch }

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.scss
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.scss
@@ -1,30 +1,6 @@
 @use "scss/variables";
 @use "scss/rna-styles";
 
-* {
-	box-sizing: border-box;
-}
-
-body {
-	min-height: 100%;
-	margin: 0;
-	padding: 0;
-	font-family:
-		-apple-system,
-		BlinkMacSystemFont,
-		"Segoe UI",
-		Roboto,
-		Oxygen-Sans,
-		Ubuntu,
-		Cantarell,
-		"Helvetica Neue",
-		sans-serif;
-}
-
-#wpcontent:not:has(.uses-new-admin-ui) {
-	padding-left: 0 !important;
-}
-
 #screen-meta,
 #screen-meta-links {
 	display: none;

--- a/projects/plugins/boost/app/assets/src/css/main/wp-admin.scss
+++ b/projects/plugins/boost/app/assets/src/css/main/wp-admin.scss
@@ -31,6 +31,7 @@ p {
 	flex-direction: column;
 	position: relative;
 	background-color: #f9f9f6;
+	clear: both;
 
 
 	&--main {
@@ -109,4 +110,8 @@ p {
 .jetpack_page_jetpack-boost #wpcontent {
 	padding-left: 0;
 	min-height: 100vh;
+}
+
+.jetpack_page_jetpack-boost #dolly {
+	background: #fff;
 }

--- a/projects/plugins/boost/changelog/pr-47388
+++ b/projects/plugins/boost/changelog/pr-47388
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Hello Dolly banner background color and clear floats in admin layout.

--- a/projects/plugins/jetpack/_inc/client/components/masthead/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/masthead/index.jsx
@@ -1,5 +1,6 @@
 import { JetpackLogo } from '@automattic/jetpack-components';
 import { isWoASite } from '@automattic/jetpack-script-data';
+import { __ } from '@wordpress/i18n';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import analytics from 'lib/analytics';
@@ -22,6 +23,30 @@ export class Masthead extends Component {
 		return this.props.testConnection();
 	};
 
+	getTitle() {
+		const { pathname = '' } = this.props.location || {};
+
+		if (
+			[
+				'/settings',
+				'/security',
+				'/performance',
+				'/writing',
+				'/sharing',
+				'/discussion',
+				'/earn',
+				'/newsletter',
+				'/reader',
+				'/traffic',
+				'/privacy',
+			].includes( pathname )
+		) {
+			return __( 'Settings', 'jetpack' );
+		}
+
+		return __( 'Jetpack', 'jetpack' );
+	}
+
 	render() {
 		const { sandboxDomain, siteConnectionStatus } = this.props;
 
@@ -43,18 +68,19 @@ export class Masthead extends Component {
 			);
 
 		return (
-			<div className="jp-masthead">
+			<header className="jp-masthead">
 				<div className="jp-masthead__inside-container">
-					<div className="jp-masthead__logo-container">
+					<div className="jp-masthead__title-container">
 						<a onClick={ this.trackLogoClick } className="jp-masthead__logo-link" href="#dashboard">
-							<JetpackLogo className="jetpack-logo__masthead" height={ 40 } />
+							<JetpackLogo showText={ false } height={ 20 } />
 						</a>
+						<h2 className="jp-masthead__title">{ this.getTitle() }</h2>
 						{ offlineNotice }
 						{ sandboxedBadge }
 					</div>
 					{ isWoASite() && <HeaderNav location={ this.props.location } /> }
 				</div>
-			</div>
+			</header>
 		);
 	}
 }

--- a/projects/plugins/jetpack/_inc/client/components/masthead/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/masthead/style.scss
@@ -1,90 +1,60 @@
-@use "../../scss/functions/rem";
-@use "../../scss/calypso-colors";
-@use "../../scss/mixins/breakpoints";
 @use "../../scss/variables/colors";
 
 .jp-masthead {
 	background-color: colors.$white;
-	text-align: center;
-
-	@media (max-width: rem.convert( 782px ) ) {
-		padding: 0 rem.convert(24px);
-
-		.jetpack-masterbar & {
-			padding-left: rem.convert(64px);
-		}
-	}
+	padding: 16px 24px;
+	position: sticky;
+	top: 0;
+	z-index: 1;
 }
 
 .jp-masthead__inside-container {
 	display: flex;
-	flex-wrap: wrap;
-	width: 100%;
-	padding-bottom: rem.convert(6px);
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
 }
 
-.jp-masthead-middle .jp-masthead__inside-container {
-	margin: 0 auto;
-	max-width: rem.convert(1040px);
-
-	@media (max-width: 1360px) {
-		max-width: 95%;
-	}
-}
-
-.jp-masthead__logo-container {
-	flex-grow: 0;
-	flex-shrink: 0;
-	padding: rem.convert(40px) 0 rem.convert(20px) 0;
-
-	@include breakpoints.breakpoint( "<480px" ) {
-		padding: rem.convert(11px) 0 0;
-		margin-right: rem.convert(16px);
-	}
+.jp-masthead__title-container {
+	display: flex;
+	align-items: center;
+	gap: 8px;
 }
 
 .jp-masthead__logo-link {
-	display: inline-block;
+	display: inline-flex;
 	outline: none;
-	vertical-align: middle;
+	line-height: 0;
 
 	&:focus {
-		line-height: 0; // fixes rectangle gap
 		box-shadow: 0 0 0 2px colors.$blue-light;
-	}
-
-	+ code {
-		margin: 0 10px;
-		padding: 5px 9px;
 		border-radius: 2px;
-		background: #e6ecf1;
-		color: #647a88;
 	}
+}
+
+.jp-masthead__title {
+	font-family: -apple-system, system-ui, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 20px;
+	font-weight: 500;
+	line-height: 1.4;
+	margin: 0;
+	color: #1e1e1e;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .jp-masthead__nav {
 	display: flex;
 	flex-wrap: nowrap;
-	flex-grow: 1;
 	flex-shrink: 0;
-	text-align: right;
-	margin-top: rem.convert(6px);
-	padding: rem.convert(4px) 0;
 
 	.dops-button-group {
-		flex-grow: 1;
 		align-self: center;
 
 		/* This fixes an unwanted space between the buttons in the
 		 * network settings caused by a line break. */
-
-		/* Fixed here to keep PHP code readable. It's safe:
-		 * .dops-button and .dops-button.is-compact specify a font size. */
 		font-size: 0;
-	}
-
-	@include breakpoints.breakpoint( "<480px" ) {
-		text-align: left;
 	}
 
 	.dops-button {

--- a/projects/plugins/jetpack/_inc/client/components/masthead/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/masthead/style.scss
@@ -3,9 +3,6 @@
 .jp-masthead {
 	background-color: colors.$white;
 	padding: 16px 24px;
-	position: sticky;
-	top: 0;
-	z-index: 1;
 }
 
 .jp-masthead__inside-container {
@@ -24,7 +21,6 @@
 .jp-masthead__logo-link {
 	display: inline-flex;
 	outline: none;
-	line-height: 0;
 
 	&:focus {
 		box-shadow: 0 0 0 2px colors.$blue-light;
@@ -54,6 +50,9 @@
 
 		/* This fixes an unwanted space between the buttons in the
 		 * network settings caused by a line break. */
+
+		/* Fixed here to keep PHP code readable. It's safe:
+		 * .dops-button and .dops-button.is-compact specify a font size. */
 		font-size: 0;
 	}
 

--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -845,8 +845,8 @@ class Main extends Component {
 
 				{ showHeader && (
 					<div className="jp-top">
+						{ this.shouldShowMasthead() && <Masthead location={ this.props.location } /> }
 						<div className="jp-top-inside">
-							{ this.shouldShowMasthead() && <Masthead location={ this.props.location } /> }
 							{ this.shouldShowRewindStatus() && <QueryRewindStatus /> }
 							{ mainNav }
 						</div>

--- a/projects/plugins/jetpack/_inc/client/scss/shared/_main.scss
+++ b/projects/plugins/jetpack/_inc/client/scss/shared/_main.scss
@@ -76,12 +76,7 @@
 	width: 100%;
 
 	.jp-top-inside {
-		max-width: rem.convert(1040px);
-		margin: 0 auto;
-
-		@media (max-width: 1360px) {
-			max-width: 95%;
-		}
+		padding-inline: 24px;
 
 		.jitm-banner.jitm-card {
 			margin: 0 0 24px;

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -282,8 +282,11 @@ abstract class Jetpack_Admin_Page {
 						<h2 class="jp-masthead__title">
 							<?php
 							// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- View logic only.
-							if ( isset( $_GET['page'] ) && 'jetpack_modules' === $_GET['page'] ) {
+							$page = isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : '';
+							if ( 'jetpack_modules' === $page ) {
 								esc_html_e( 'Modules', 'jetpack' );
+							} elseif ( 'jetpack_about' === $page ) {
+								esc_html_e( 'About', 'jetpack' );
 							} else {
 								esc_html_e( 'Jetpack', 'jetpack' );
 							}

--- a/projects/plugins/jetpack/changelog/update-jetpack-settings-lightweight-header
+++ b/projects/plugins/jetpack/changelog/update-jetpack-settings-lightweight-header
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Migrate Settings page header to unified header pattern and left-align navigation tabs.


### PR DESCRIPTION
Part of the JETPACK-1352 project.

Part of JETPACK-1411

## Proposed changes:
* Replace the old `Masthead` header with a lightweight version that uses the Jetpack bolt logo + dynamic title ("Settings" on settings pages, "Jetpack" elsewhere).
* Move the Masthead outside `.jp-top-inside` so it renders full-width with 24px padding, matching the admin-ui Page header pattern used by other products.
* Left-align the navigation tabs by replacing the centered `max-width + margin: 0 auto` container with `padding-inline: 24px` to match the header alignment.
* Simplify Masthead styles: remove old logo-container layout, align with unified header conventions.

### Before / After

| Before | After |
|--------|-------|
| _screenshot to be added_ | _screenshot to be added_ |

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

* Build the Jetpack plugin: `jetpack build plugins/jetpack --deps`
* **Settings page** (`wp-admin/admin.php?page=jetpack#/settings`):
  * Verify the header shows the Jetpack bolt logo and "Settings" title
  * Verify the navigation tabs (Security, Performance, Writing, etc.) are left-aligned with the header text at 24px
  * Verify all tabs still navigate correctly
  * Verify the search icon still works
* **Dashboard page** (`wp-admin/admin.php?page=jetpack#/dashboard`):
  * Verify the header shows the Jetpack bolt logo and "Jetpack" title

## Changelog

- [x] Generate changelog entries for this PR (using AI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)