### PR TITLE
test-results-to-slack: add workflow_dispatch event support

### DIFF
--- a/projects/github-actions/test-results-to-slack/src/message.js
+++ b/projects/github-actions/test-results-to-slack/src/message.js
@@ -77,6 +77,30 @@ export async function createMessage( isFailure ) {
 		buttons.push( getButton( `Commit ${ sha.substring( 0, 8 ) }`, commitUrl ) );
 	}
 
+	if ( eventName === 'workflow_dispatch' ) {
+		target = `for manual run on ${ refType } _*${ refName }*_`;
+
+		if ( payload.inputs?.sha ) {
+			const upstreamSha = payload.inputs.sha;
+			msgId = `workflow_dispatch-${ upstreamSha }`;
+			contextElements.push(
+				getTextContextElement( `Last commit: ${ upstreamSha.substring( 0, 8 ) }` )
+			);
+
+			if ( payload.inputs?.repository ) {
+				const commitUrl = `${ serverUrl }/${ payload.inputs.repository }/commit/${ upstreamSha }`;
+				buttons.push( getButton( `Commit ${ upstreamSha.substring( 0, 8 ) }`, commitUrl ) );
+			}
+		} else {
+			msgId = `workflow_dispatch-${ Date.now() }`;
+			const commitUrl = `${ serverUrl }/${ repository }/commit/${ sha }`;
+			contextElements.push(
+				getTextContextElement( `Last commit: ${ sha.substring( 0, 8 ) }` )
+			);
+			buttons.push( getButton( `Commit ${ sha.substring( 0, 8 ) }`, commitUrl ) );
+		}
+	}
+
 	if ( eventName === 'repository_dispatch' ) {
 		target = `for event _*${ payload.action }*_`;
 

--- a/projects/github-actions/test-results-to-slack/tests/message.test.js
+++ b/projects/github-actions/test-results-to-slack/tests/message.test.js
@@ -25,6 +25,9 @@ describe( 'Message content', () => {
 		${ 'pull_request' }        | ${ true }  | ${ undefined }    | ${ { text: `:x:	Tests failed for pull request *#${ prNumber }*` } }
 		${ 'repository_dispatch' } | ${ true }  | ${ undefined }    | ${ { text: `:x:	Tests failed for event _*${ action }*_` } }
 		${ 'repository_dispatch' } | ${ false } | ${ 'test-suite' } | ${ { text: `:white_check_mark:	_*test-suite*_ tests passed for event _*${ action }*_` } }
+		${ 'workflow_dispatch' }   | ${ false } | ${ undefined }    | ${ { text: `:white_check_mark:	Tests passed for manual run on ${ refType } _*${ refName }*_` } }
+		${ 'workflow_dispatch' }   | ${ true }  | ${ undefined }    | ${ { text: `:x:	Tests failed for manual run on ${ refType } _*${ refName }*_` } }
+		${ 'workflow_dispatch' }   | ${ true }  | ${ 'suite name' } | ${ { text: `:x:	_*suite name*_ tests failed for manual run on ${ refType } _*${ refName }*_` } }
 		${ 'unsupported' }         | ${ true }  | ${ undefined }    | ${ { text: `:x:	Tests failed for ${ sha }` } }
 	`(
 		`Message text is correct for $eventName and workflow failed=$isFailure and suiteName=$suiteName`,
@@ -114,6 +117,7 @@ describe( 'Message content', () => {
 		${ 'push' }
 		${ 'schedule' }
 		${ 'workflow_run' }
+		${ 'workflow_dispatch' }
 		${ 'repository_dispatch' }
 		${ 'unsupported' }
 	`( 'There are no empty blocks elements lists for $eventName event', async ( { eventName } ) => {
@@ -155,6 +159,32 @@ describe( 'Message content', () => {
 				},
 				eventName: 'repository_dispatch',
 			} );
+
+			const { createMessage } = await import( '../src/message.js' );
+			const { mainMsgBlocks } = await createMessage( true );
+
+			expect( mainMsgBlocks[ 1 ].elements ).toHaveLength( expectedContextLength );
+			expect( mainMsgBlocks[ 2 ].elements ).toHaveLength( expectedButtonsLength );
+		}
+	);
+
+	test.each`
+		description                                      | inputs                                                 | expectedContextLength | expectedButtonsLength
+		${ 'upstream sha, upstream repository' }         | ${ { sha: '123456789', repository: 'upstream/repo' } } | ${ 2 }                | ${ 2 }
+		${ 'upstream sha, missing upstream repository' } | ${ { sha: '123456789' } }                              | ${ 2 }                | ${ 1 }
+		${ 'missing upstream sha' }                      | ${ {} }                                                | ${ 2 }                | ${ 2 }
+		${ 'no inputs' }                                 | ${ undefined }                                         | ${ 2 }                | ${ 2 }
+	`(
+		`Workflow dispatch blocks for #description`,
+		async ( { inputs, expectedContextLength, expectedButtonsLength } ) => {
+			await mockGitHubContext( {
+				payload: {
+					inputs,
+				},
+				sha,
+				eventName: 'workflow_dispatch',
+			} );
+			mockContextExtras( { repository, refType, refName } );
 
 			const { createMessage } = await import( '../src/message.js' );
 			const { mainMsgBlocks } = await createMessage( true );


### PR DESCRIPTION
## Summary

Add handling for `workflow_dispatch` events in the `test-results-to-slack` GitHub Action so that manually triggered workflow runs produce properly formatted Slack notifications instead of falling through to the generic fallback.

**The problem:** All `workflow_dispatch` events are grouped into a single Slack message because the `eventName` is not handled, making it easy to lose track of individual test runs.

**The fix:**
- When `sha` and `repository` are provided via workflow inputs, the message includes commit context and a link to the commit (mirroring the existing `repository_dispatch` behavior with `payload.inputs` instead of `payload.client_payload`, as suggested by @anomiex)
- Without those inputs, each run gets a unique message ID based on timestamp (like `schedule` events) to prevent unrelated runs from being grouped, and falls back to showing the current SHA context
- Added corresponding test cases for all workflow_dispatch scenarios

### Changes

- `projects/github-actions/test-results-to-slack/src/message.js` — New `workflow_dispatch` event handler
- `projects/github-actions/test-results-to-slack/tests/message.test.js` — 8 new test cases covering text formatting, block structure, and edge cases

### Usage

Users can optionally pass `sha` and `repository` as workflow inputs for richer messages:

```yaml
on:
  workflow_dispatch:
    inputs:
      sha:
        description: 'Commit tested'
        type: string
      repository:
        description: 'Repository tested'
        type: string
```

Fixes #39412


Made with [Cursor](https://cursor.com)