### PR TITLE
Forms: Hide Jetpack block collection from form editor inserter

### DIFF
--- a/projects/packages/forms/changelog/fix-hide-jetpack-category-from-form-editor
+++ b/projects/packages/forms/changelog/fix-hide-jetpack-category-from-form-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms: Hide the Jetpack block collection from the form editor block inserter.

--- a/projects/packages/forms/src/form-editor/class-form-editor.php
+++ b/projects/packages/forms/src/form-editor/class-form-editor.php
@@ -32,6 +32,7 @@ class Form_Editor {
 		add_filter( 'block_editor_settings_all', array( __CLASS__, 'block_editor_settings_all' ), 10, 2 );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_admin_scripts' ) );
 		add_action( 'current_screen', array( __CLASS__, 'disable_block_directory' ) );
+		add_action( 'current_screen', array( __CLASS__, 'disable_block_collection' ) );
 	}
 
 	/**
@@ -154,6 +155,26 @@ class Form_Editor {
 		}
 		if ( Contact_Form::POST_TYPE === $screen->post_type ) {
 			remove_action( 'enqueue_block_editor_assets', 'wp_enqueue_editor_block_directory_assets' );
+		}
+	}
+
+	/**
+	 * Disable the Jetpack block collection in the form editor.
+	 *
+	 * Filters `jetpack_register_block_collection` to prevent the "Jetpack"
+	 * collection label from appearing in the block inserter, since form field
+	 * blocks are organized into their own granular categories.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param \WP_Screen $screen The current screen object.
+	 */
+	public static function disable_block_collection( $screen ) {
+		if ( ! isset( $screen->post_type ) ) {
+			return;
+		}
+		if ( Contact_Form::POST_TYPE === $screen->post_type ) {
+			add_filter( 'jetpack_register_block_collection', '__return_false' );
 		}
 	}
 

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -22,6 +22,10 @@ import {
 	activateBlockCategoryOverrides,
 	deactivateBlockCategoryOverrides,
 } from './utils/block-category-override';
+import {
+	removeJetpackBlockCollection,
+	restoreJetpackBlockCollection,
+} from './utils/block-collection';
 import { determineBlockNestingAction } from './utils/block-nesting-logic';
 import { BlockLock, findFormBlock, shouldLockBlock, getBlocksToMove } from './utils/block-utils';
 import {
@@ -382,6 +386,7 @@ const setupFormEditorSubscription = () => {
 						restoreOriginalCategories( state.previousCategories || [] );
 					}
 					restoreBlockDirectory();
+					restoreJetpackBlockCollection();
 					restoreAllowedBlocks();
 					if ( requestAnimationFrameId ) {
 						cancelAnimationFrame( requestAnimationFrameId );
@@ -401,12 +406,13 @@ const setupFormEditorSubscription = () => {
 				return;
 			}
 
-			// 3. One-time category setup and block directory disable
+			// 3. One-time category setup, block directory disable, and collection removal
 			if ( ! state.categoriesSetUp ) {
 				state.categoriesSetUp = true;
 				state.previousCategories = setupFormEditorCategories();
 
 				disableBlockDirectory();
+				removeJetpackBlockCollection();
 			}
 
 			// 4. React to root block changes (locate, select, nest)

--- a/projects/packages/forms/src/form-editor/utils/block-collection.ts
+++ b/projects/packages/forms/src/form-editor/utils/block-collection.ts
@@ -41,15 +41,16 @@ export const removeJetpackBlockCollection = () => {
 		return;
 	}
 
-	savedCollection = jetpackCollection;
-
 	const blocksDispatch = dispatch( 'core/blocks' ) as {
 		removeBlockCollection?: ( namespace: string ) => void;
 	};
 
-	if ( typeof blocksDispatch.removeBlockCollection === 'function' ) {
-		blocksDispatch.removeBlockCollection( JETPACK_COLLECTION_NAMESPACE );
+	if ( typeof blocksDispatch.removeBlockCollection !== 'function' ) {
+		return;
 	}
+
+	savedCollection = jetpackCollection;
+	blocksDispatch.removeBlockCollection( JETPACK_COLLECTION_NAMESPACE );
 };
 
 /**

--- a/projects/packages/forms/src/form-editor/utils/block-collection.ts
+++ b/projects/packages/forms/src/form-editor/utils/block-collection.ts
@@ -1,0 +1,78 @@
+/**
+ * Block collection utility functions
+ *
+ * Manages the Jetpack block collection visibility in the form editor.
+ * The collection is removed when entering the form editor to declutter
+ * the block inserter, and restored when leaving.
+ *
+ * @package
+ */
+
+import { select, dispatch } from '@wordpress/data';
+
+interface BlockCollectionData {
+	title: string;
+	icon?: unknown;
+}
+
+const JETPACK_COLLECTION_NAMESPACE = 'jetpack';
+
+let savedCollection: BlockCollectionData | null = null;
+
+/**
+ * Remove the Jetpack block collection from the block inserter.
+ *
+ * Saves the collection data so it can be restored later.
+ * No-op if the collection doesn't exist or the store API is unavailable.
+ */
+export const removeJetpackBlockCollection = () => {
+	const blocksStore = select( 'core/blocks' ) as {
+		getCollections?: () => Record< string, BlockCollectionData >;
+	};
+
+	if ( typeof blocksStore.getCollections !== 'function' ) {
+		return;
+	}
+
+	const collections = blocksStore.getCollections();
+	const jetpackCollection = collections[ JETPACK_COLLECTION_NAMESPACE ];
+
+	if ( ! jetpackCollection ) {
+		return;
+	}
+
+	savedCollection = jetpackCollection;
+
+	const blocksDispatch = dispatch( 'core/blocks' ) as {
+		removeBlockCollection?: ( namespace: string ) => void;
+	};
+
+	if ( typeof blocksDispatch.removeBlockCollection === 'function' ) {
+		blocksDispatch.removeBlockCollection( JETPACK_COLLECTION_NAMESPACE );
+	}
+};
+
+/**
+ * Restore the Jetpack block collection to the block inserter.
+ *
+ * Re-registers the collection using the data saved during removal.
+ * No-op if no collection was previously saved or the store API is unavailable.
+ */
+export const restoreJetpackBlockCollection = () => {
+	if ( ! savedCollection ) {
+		return;
+	}
+
+	const blocksDispatch = dispatch( 'core/blocks' ) as {
+		addBlockCollection?: ( namespace: string, title: string, icon?: unknown ) => void;
+	};
+
+	if ( typeof blocksDispatch.addBlockCollection === 'function' ) {
+		blocksDispatch.addBlockCollection(
+			JETPACK_COLLECTION_NAMESPACE,
+			savedCollection.title,
+			savedCollection.icon
+		);
+	}
+	savedCollection = null;
+};

--- a/projects/packages/forms/src/form-editor/utils/block-collection.ts
+++ b/projects/packages/forms/src/form-editor/utils/block-collection.ts
@@ -68,12 +68,14 @@ export const restoreJetpackBlockCollection = () => {
 		addBlockCollection?: ( namespace: string, title: string, icon?: unknown ) => void;
 	};
 
-	if ( typeof blocksDispatch.addBlockCollection === 'function' ) {
-		blocksDispatch.addBlockCollection(
-			JETPACK_COLLECTION_NAMESPACE,
-			savedCollection.title,
-			savedCollection.icon
-		);
+	if ( typeof blocksDispatch.addBlockCollection !== 'function' ) {
+		return;
 	}
+
+	blocksDispatch.addBlockCollection(
+		JETPACK_COLLECTION_NAMESPACE,
+		savedCollection.title,
+		savedCollection.icon
+	);
 	savedCollection = null;
 };

--- a/projects/packages/forms/src/form-editor/utils/block-collection.ts
+++ b/projects/packages/forms/src/form-editor/utils/block-collection.ts
@@ -72,10 +72,14 @@ export const restoreJetpackBlockCollection = () => {
 		return;
 	}
 
-	blocksDispatch.addBlockCollection(
-		JETPACK_COLLECTION_NAMESPACE,
-		savedCollection.title,
-		savedCollection.icon
-	);
-	savedCollection = null;
+	try {
+		blocksDispatch.addBlockCollection(
+			JETPACK_COLLECTION_NAMESPACE,
+			savedCollection.title,
+			savedCollection.icon
+		);
+		savedCollection = null;
+	} catch {
+		// If re-registration fails, keep savedCollection so it can be retried later.
+	}
 };

--- a/projects/packages/forms/tests/js/form-editor/utils/block-collection.test.js
+++ b/projects/packages/forms/tests/js/form-editor/utils/block-collection.test.js
@@ -8,30 +8,37 @@ const mockSelect = jest.fn( () => ( {
 	getCollections: mockGetCollections,
 } ) );
 
+const mockDispatch = jest.fn( () => ( {
+	removeBlockCollection: mockRemoveBlockCollection,
+	addBlockCollection: mockAddBlockCollection,
+} ) );
+
 await jest.unstable_mockModule( '@wordpress/data', () => ( {
 	select: ( ...args ) => mockSelect( ...args ),
-	dispatch: () => ( {
-		removeBlockCollection: mockRemoveBlockCollection,
-		addBlockCollection: mockAddBlockCollection,
-	} ),
+	dispatch: ( ...args ) => mockDispatch( ...args ),
 } ) );
 
 const { removeJetpackBlockCollection, restoreJetpackBlockCollection } = await import(
 	'../../../../src/form-editor/utils/block-collection'
 );
 
+const resetMocks = () => {
+	jest.clearAllMocks();
+	mockSelect.mockImplementation( () => ( {
+		getCollections: mockGetCollections,
+	} ) );
+	mockDispatch.mockImplementation( () => ( {
+		removeBlockCollection: mockRemoveBlockCollection,
+		addBlockCollection: mockAddBlockCollection,
+	} ) );
+};
+
 describe( 'block-collection', () => {
 	beforeEach( () => {
-		jest.clearAllMocks();
-		mockSelect.mockImplementation( () => ( {
-			getCollections: mockGetCollections,
-		} ) );
+		resetMocks();
 		// Reset module state between tests by restoring any saved collection
 		restoreJetpackBlockCollection();
-		jest.clearAllMocks();
-		mockSelect.mockImplementation( () => ( {
-			getCollections: mockGetCollections,
-		} ) );
+		resetMocks();
 	} );
 
 	describe( 'removeJetpackBlockCollection', () => {
@@ -54,12 +61,26 @@ describe( 'block-collection', () => {
 		} );
 
 		it( 'should not call removeBlockCollection when getCollections is unavailable', () => {
-			// Return a store object without getCollections
 			mockSelect.mockReturnValue( {} );
 
 			removeJetpackBlockCollection();
 
 			expect( mockRemoveBlockCollection ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should not save state when removeBlockCollection is unavailable', () => {
+			mockGetCollections.mockReturnValue( {
+				jetpack: { title: 'Jetpack', icon: 'jetpack-icon' },
+			} );
+			// dispatch returns object without removeBlockCollection
+			mockDispatch.mockReturnValue( {} );
+
+			removeJetpackBlockCollection();
+			resetMocks();
+
+			// Restore should be a no-op since nothing was actually saved
+			restoreJetpackBlockCollection();
+			expect( mockAddBlockCollection ).not.toHaveBeenCalled();
 		} );
 	} );
 
@@ -95,6 +116,26 @@ describe( 'block-collection', () => {
 			restoreJetpackBlockCollection();
 
 			expect( mockAddBlockCollection ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'should preserve savedCollection when addBlockCollection is unavailable', () => {
+			mockGetCollections.mockReturnValue( {
+				jetpack: { title: 'Jetpack', icon: 'jetpack-icon' },
+			} );
+			removeJetpackBlockCollection();
+			jest.clearAllMocks();
+
+			// dispatch returns object without addBlockCollection
+			mockDispatch.mockReturnValue( {} );
+			restoreJetpackBlockCollection();
+
+			expect( mockAddBlockCollection ).not.toHaveBeenCalled();
+
+			// Restore the full dispatch mock — restore should still work
+			resetMocks();
+			restoreJetpackBlockCollection();
+
+			expect( mockAddBlockCollection ).toHaveBeenCalledWith( 'jetpack', 'Jetpack', 'jetpack-icon' );
 		} );
 	} );
 

--- a/projects/packages/forms/tests/js/form-editor/utils/block-collection.test.js
+++ b/projects/packages/forms/tests/js/form-editor/utils/block-collection.test.js
@@ -1,7 +1,4 @@
-import {
-	removeJetpackBlockCollection,
-	restoreJetpackBlockCollection,
-} from '../../../../src/form-editor/utils/block-collection';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 const mockGetCollections = jest.fn();
 const mockRemoveBlockCollection = jest.fn();
@@ -11,13 +8,17 @@ const mockSelect = jest.fn( () => ( {
 	getCollections: mockGetCollections,
 } ) );
 
-jest.mock( '@wordpress/data', () => ( {
+await jest.unstable_mockModule( '@wordpress/data', () => ( {
 	select: ( ...args ) => mockSelect( ...args ),
 	dispatch: () => ( {
 		removeBlockCollection: mockRemoveBlockCollection,
 		addBlockCollection: mockAddBlockCollection,
 	} ),
 } ) );
+
+const { removeJetpackBlockCollection, restoreJetpackBlockCollection } = await import(
+	'../../../../src/form-editor/utils/block-collection'
+);
 
 describe( 'block-collection', () => {
 	beforeEach( () => {

--- a/projects/packages/forms/tests/js/form-editor/utils/block-collection.test.js
+++ b/projects/packages/forms/tests/js/form-editor/utils/block-collection.test.js
@@ -1,0 +1,116 @@
+import {
+	removeJetpackBlockCollection,
+	restoreJetpackBlockCollection,
+} from '../../../../src/form-editor/utils/block-collection';
+
+const mockGetCollections = jest.fn();
+const mockRemoveBlockCollection = jest.fn();
+const mockAddBlockCollection = jest.fn();
+
+jest.mock( '@wordpress/data', () => ( {
+	select: () => ( {
+		getCollections: mockGetCollections,
+	} ),
+	dispatch: () => ( {
+		removeBlockCollection: mockRemoveBlockCollection,
+		addBlockCollection: mockAddBlockCollection,
+	} ),
+} ) );
+
+describe( 'block-collection', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		// Reset module state between tests by restoring any saved collection
+		restoreJetpackBlockCollection();
+		jest.clearAllMocks();
+	} );
+
+	describe( 'removeJetpackBlockCollection', () => {
+		it( 'should remove the jetpack collection when it exists', () => {
+			mockGetCollections.mockReturnValue( {
+				jetpack: { title: 'Jetpack', icon: 'jetpack-icon' },
+			} );
+
+			removeJetpackBlockCollection();
+
+			expect( mockRemoveBlockCollection ).toHaveBeenCalledWith( 'jetpack' );
+		} );
+
+		it( 'should not call removeBlockCollection when no jetpack collection exists', () => {
+			mockGetCollections.mockReturnValue( {} );
+
+			removeJetpackBlockCollection();
+
+			expect( mockRemoveBlockCollection ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should not call removeBlockCollection when getCollections is unavailable', () => {
+			mockGetCollections.mockImplementation( () => {
+				throw new Error( 'not a function' );
+			} );
+
+			// Override select to return an object without getCollections
+			const dataModule = require( '@wordpress/data' );
+			const originalSelect = dataModule.select;
+			dataModule.select = () => ( {} );
+
+			removeJetpackBlockCollection();
+
+			expect( mockRemoveBlockCollection ).not.toHaveBeenCalled();
+
+			dataModule.select = originalSelect;
+		} );
+	} );
+
+	describe( 'restoreJetpackBlockCollection', () => {
+		it( 'should restore a previously removed collection', () => {
+			mockGetCollections.mockReturnValue( {
+				jetpack: { title: 'Jetpack', icon: 'jetpack-icon' },
+			} );
+
+			removeJetpackBlockCollection();
+			jest.clearAllMocks();
+
+			restoreJetpackBlockCollection();
+
+			expect( mockAddBlockCollection ).toHaveBeenCalledWith( 'jetpack', 'Jetpack', 'jetpack-icon' );
+		} );
+
+		it( 'should not call addBlockCollection when no collection was previously saved', () => {
+			restoreJetpackBlockCollection();
+
+			expect( mockAddBlockCollection ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should only restore once after removal', () => {
+			mockGetCollections.mockReturnValue( {
+				jetpack: { title: 'Jetpack', icon: 'jetpack-icon' },
+			} );
+
+			removeJetpackBlockCollection();
+			jest.clearAllMocks();
+
+			restoreJetpackBlockCollection();
+			restoreJetpackBlockCollection();
+
+			expect( mockAddBlockCollection ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	describe( 'removeJetpackBlockCollection and restoreJetpackBlockCollection', () => {
+		it( 'should be reversible operations', () => {
+			const collectionData = { title: 'Jetpack', icon: 'jetpack-icon' };
+			mockGetCollections.mockReturnValue( { jetpack: collectionData } );
+
+			removeJetpackBlockCollection();
+			expect( mockRemoveBlockCollection ).toHaveBeenCalledWith( 'jetpack' );
+
+			restoreJetpackBlockCollection();
+			expect( mockAddBlockCollection ).toHaveBeenCalledWith(
+				'jetpack',
+				collectionData.title,
+				collectionData.icon
+			);
+		} );
+	} );
+} );

--- a/projects/packages/forms/tests/js/form-editor/utils/block-collection.test.js
+++ b/projects/packages/forms/tests/js/form-editor/utils/block-collection.test.js
@@ -7,10 +7,12 @@ const mockGetCollections = jest.fn();
 const mockRemoveBlockCollection = jest.fn();
 const mockAddBlockCollection = jest.fn();
 
+const mockSelect = jest.fn( () => ( {
+	getCollections: mockGetCollections,
+} ) );
+
 jest.mock( '@wordpress/data', () => ( {
-	select: () => ( {
-		getCollections: mockGetCollections,
-	} ),
+	select: ( ...args ) => mockSelect( ...args ),
 	dispatch: () => ( {
 		removeBlockCollection: mockRemoveBlockCollection,
 		addBlockCollection: mockAddBlockCollection,
@@ -20,9 +22,15 @@ jest.mock( '@wordpress/data', () => ( {
 describe( 'block-collection', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
+		mockSelect.mockImplementation( () => ( {
+			getCollections: mockGetCollections,
+		} ) );
 		// Reset module state between tests by restoring any saved collection
 		restoreJetpackBlockCollection();
 		jest.clearAllMocks();
+		mockSelect.mockImplementation( () => ( {
+			getCollections: mockGetCollections,
+		} ) );
 	} );
 
 	describe( 'removeJetpackBlockCollection', () => {
@@ -45,20 +53,12 @@ describe( 'block-collection', () => {
 		} );
 
 		it( 'should not call removeBlockCollection when getCollections is unavailable', () => {
-			mockGetCollections.mockImplementation( () => {
-				throw new Error( 'not a function' );
-			} );
-
-			// Override select to return an object without getCollections
-			const dataModule = require( '@wordpress/data' );
-			const originalSelect = dataModule.select;
-			dataModule.select = () => ( {} );
+			// Return a store object without getCollections
+			mockSelect.mockReturnValue( {} );
 
 			removeJetpackBlockCollection();
 
 			expect( mockRemoveBlockCollection ).not.toHaveBeenCalled();
-
-			dataModule.select = originalSelect;
 		} );
 	} );
 


### PR DESCRIPTION
Before:
<img width="225" height="243" alt="Screenshot 2026-02-27 at 12 33 49 PM" src="https://github.com/user-attachments/assets/5ee87bcb-e2be-4c5c-8921-ec50b49cb3a5" />

After:
Jetpack collection doesn't exist anymore.


## Proposed changes:
* Remove the "Jetpack" block collection from the block inserter when editing forms (`jetpack_form` post type).
* The collection is saved on removal and re-registered when navigating away from the form editor, so it remains available in other editing contexts.
* Form field blocks are already organized into their own granular categories (Basic, Contact Info, Choice, Advanced, Multistep), making the Jetpack collection unnecessary and cluttering in the form editor.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
1. Enable central form management. 
```
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );
function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```
* Open the page editor. 
* Add a form. Select a variation. 
* Click the Editor form. Notice that Jetpack is not there in the block inserter. 
* Click the back button. 
Notice that Jetpack is in the block inserter. 

* Open a Jetpack Form in the form editor (create or edit a `jetpack_form` post type).
* Open the block inserter.
* Verify that the "Jetpack" collection label no longer appears in the inserter — form blocks should be grouped under their granular form categories (Basic, Contact Info, Choice, etc.) instead.
* Navigate away from the form editor to a regular post/page editor.
* Open the block inserter again and verify the "Jetpack" collection is visible as expected.

## Changelog

- [x] Generate changelog entries for this PR (using AI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)