### PR TITLE
Boost: Migrate header to lightweight unified pattern

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/layout/header/header.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/layout/header/header.module.scss
@@ -1,6 +1,25 @@
 .header {
 	background-color: var(--primary-white);
 	padding: 16px 24px 0;
+
+	// Nested under .header for specificity over .jb-dashboard h2 global reset.
+	.title {
+		font-family: -apple-system, system-ui, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+		font-size: 20px;
+		font-weight: 500;
+		line-height: 1.4;
+		margin: 0;
+		color: #1e1e1e;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.subtitle {
+		font-size: 13px;
+		color: #757575;
+		margin: 4px 0 0;
+	}
 }
 
 .masthead {
@@ -28,24 +47,6 @@
 		border-radius: 2px;
 		outline: none;
 	}
-}
-
-.title {
-	font-family: -apple-system, system-ui, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	font-size: 20px;
-	font-weight: 500;
-	line-height: 1.4;
-	margin: 0;
-	color: #1e1e1e;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
-
-.subtitle {
-	font-size: 13px;
-	color: #757575;
-	margin: 4px 0 0;
 }
 
 .chevron {

--- a/projects/plugins/boost/app/assets/src/js/layout/header/header.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/layout/header/header.module.scss
@@ -1,36 +1,54 @@
 .header {
 	background-color: var(--primary-white);
-	overflow: auto;
+	padding: 16px 24px 0;
 }
 
 .masthead {
 	display: flex;
 	justify-content: space-between;
-	margin-top: 40px;
-	margin-bottom: 20px;
 	align-items: center;
 	flex-wrap: wrap;
-	gap: 24px;
+	gap: 8px;
 }
 
 .nav-area {
 	display: flex;
 	align-items: center;
 	flex-direction: row;
+	gap: 8px;
 }
 
 .logo {
 	cursor: pointer;
+	display: inline-flex;
+	line-height: 0;
 
-	:global(svg) {
-		height: 42px;
-		width: 100%;
+	&:focus {
+		box-shadow: 0 0 0 2px var(--jp-blue, #3858e9);
+		border-radius: 2px;
+		outline: none;
 	}
 }
 
+.title {
+	font-family: -apple-system, system-ui, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 20px;
+	font-weight: 500;
+	line-height: 1.4;
+	margin: 0;
+	color: #1e1e1e;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.subtitle {
+	font-size: 13px;
+	color: #757575;
+	margin: 4px 0 0;
+}
+
 .chevron {
-	margin-left: 16px;
-	margin-right: 16px;
 	width: 24px;
 	height: 24px;
 	padding-top: 2px;

--- a/projects/plugins/boost/app/assets/src/js/layout/header/header.tsx
+++ b/projects/plugins/boost/app/assets/src/js/layout/header/header.tsx
@@ -1,9 +1,10 @@
+import { JetpackLogo } from '@automattic/jetpack-components';
+import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import styles from './header.module.scss';
 import { BackButton } from '$features/ui';
 import ChevronRight from '$svg/chevron-right';
-import Logo from '$svg/logo';
 import { useNavigate } from 'react-router';
 
 type HeaderProps = {
@@ -15,7 +16,7 @@ const Header = ( { subPageTitle = '', children }: HeaderProps ) => {
 	const navigate = useNavigate();
 	return (
 		<div className={ clsx( styles.header ) }>
-			<div className={ clsx( 'jb-container', styles.masthead ) }>
+			<div className={ clsx( styles.masthead ) }>
 				<div className={ clsx( styles[ 'nav-area' ] ) }>
 					<div
 						className={ clsx( styles.logo ) }
@@ -28,8 +29,9 @@ const Header = ( { subPageTitle = '', children }: HeaderProps ) => {
 						role="button"
 						tabIndex={ 0 }
 					>
-						<Logo />
+						<JetpackLogo showText={ false } height={ 20 } />
 					</div>
+					<h2 className={ clsx( styles.title ) }>{ __( 'Boost', 'jetpack-boost' ) }</h2>
 
 					{ subPageTitle !== '' && (
 						<>
@@ -43,6 +45,12 @@ const Header = ( { subPageTitle = '', children }: HeaderProps ) => {
 
 				{ children }
 			</div>
+
+			{ ! subPageTitle && (
+				<p className={ clsx( styles.subtitle ) }>
+					{ __( 'Optimize your site performance and loading speed.', 'jetpack-boost' ) }
+				</p>
+			) }
 
 			{ subPageTitle !== '' && (
 				<div className="jb-container">

--- a/projects/plugins/boost/changelog/update-boost-unified-header
+++ b/projects/plugins/boost/changelog/update-boost-unified-header
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Replaced the large Jetpack Boost logo header with a compact unified header pattern (Jetpack icon + title + subtitle) for consistent product identity.


### PR DESCRIPTION
## Proposed changes:
* Replace the large custom "Jetpack Boost" SVG logo header with the compact unified header pattern: small Jetpack icon + "Boost" title + descriptive subtitle
* Update header styles: compact padding (16px 24px), flex gap, proper focus state on logo
* Remove `jb-container` centering from masthead for left-aligned layout consistent with other products
* Nest `.title` and `.subtitle` under `.header` for CSS specificity over Boost's global `.jb-dashboard h2 { font-size: 36px }` reset
* Hide subtitle on subpages (e.g., Cache Debug Log) where the breadcrumb already provides context

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
Part of the unified header standardization effort across Jetpack products (parent PR #47313).

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
* Go to WP Admin → Boost (or `/wp-admin/admin.php?page=jetpack-boost`)
* Verify the header shows a small Jetpack icon + "Boost" title (20px, weight 500) + subtitle "Optimize your site performance and loading speed."
* Verify the header is left-aligned with 24px padding, no longer centered via `jb-container`
* Verify the title font size matches other products (Protect, Settings) — should be ~20px, not the old 36px
* If possible, navigate to the Cache Debug Log subpage and verify the subtitle is hidden and the breadcrumb (chevron + page title) still renders correctly

| Before | After |
|--------|-------|
| <!-- screenshot --> | <!-- screenshot --> |

## Changelog
- [x] Generate changelog entries for this PR (using AI).