### PR TITLE
Forms: Show name modal before navigating to form editor

### DIFF
--- a/projects/packages/forms/src/dashboard/components/create-form-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/create-form-button/index.tsx
@@ -3,13 +3,14 @@
  */
 import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { Button } from '@wordpress/components';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
 import useCreateForm from '../../hooks/use-create-form.ts';
+import { FormNameModal } from '../form-name-modal';
 
 type CreateFormButtonProps = {
 	label?: string;
@@ -35,29 +36,57 @@ export default function CreateFormButton( {
 	showIcon = true,
 }: CreateFormButtonProps ): JSX.Element {
 	const { openNewForm } = useCreateForm();
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
 
-	const onButtonClickHandler = useCallback(
-		() =>
-			openNewForm( {
+	const analyticsEvent = useCallback( () => {
+		jetpackAnalytics.tracks.recordEvent( 'jetpack_wpa_forms_landing_page_cta_click', {
+			button: 'forms',
+		} );
+	}, [] );
+
+	const handleModalSave = useCallback(
+		async ( formTitle: string ) => {
+			await openNewForm( {
 				showPatterns,
-				analyticsEvent: () => {
-					jetpackAnalytics.tracks.recordEvent( 'jetpack_wpa_forms_landing_page_cta_click', {
-						button: 'forms',
-					} );
-				},
-			} ),
-		[ openNewForm, showPatterns ]
+				formTitle,
+				analyticsEvent,
+			} );
+		},
+		[ openNewForm, showPatterns, analyticsEvent ]
 	);
 
+	const handleModalClose = useCallback( () => {
+		setIsModalOpen( false );
+		openNewForm( {
+			showPatterns,
+			analyticsEvent,
+		} );
+	}, [ openNewForm, showPatterns, analyticsEvent ] );
+
+	const handleButtonClick = useCallback( () => {
+		setIsModalOpen( true );
+	}, [] );
+
 	return (
-		<Button
-			size="compact"
-			variant={ variant }
-			onClick={ onButtonClickHandler }
-			icon={ showIcon ? plus : undefined }
-			className="create-form-button"
-		>
-			{ label }
-		</Button>
+		<>
+			<Button
+				size="compact"
+				variant={ variant }
+				onClick={ handleButtonClick }
+				icon={ showIcon ? plus : undefined }
+				className="create-form-button"
+			>
+				{ label }
+			</Button>
+			<FormNameModal
+				isOpen={ isModalOpen }
+				onClose={ handleModalClose }
+				onSave={ handleModalSave }
+				title={ __( 'Create form', 'jetpack-forms' ) }
+				primaryButtonLabel={ __( 'Create', 'jetpack-forms' ) }
+				secondaryButtonLabel={ __( 'Skip', 'jetpack-forms' ) }
+				placeholder={ __( 'Enter form name', 'jetpack-forms' ) }
+			/>
+		</>
 	);
 }

--- a/projects/packages/forms/src/dashboard/hooks/use-create-form.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-create-form.ts
@@ -23,6 +23,7 @@ const openFormLink = ( url: string ) => {
 
 type ClickHandlerProps = {
 	formPattern?: string;
+	formTitle?: string;
 	showPatterns?: boolean;
 	analyticsEvent?: ( { formPattern }: { formPattern: string } ) => void;
 };
@@ -73,14 +74,17 @@ export default function useCreateForm(): CreateFormReturn {
 	);
 
 	const openNewForm = useCallback(
-		async ( { formPattern, showPatterns, analyticsEvent }: ClickHandlerProps ) => {
+		async ( { formPattern, formTitle, showPatterns, analyticsEvent }: ClickHandlerProps ) => {
 			try {
 				// When centralized form management is enabled, create a jetpack_form post via wp-admin.
 				// Keep existing behavior when disabled (or not yet loaded).
 				if ( isCentralFormManagementEnabled === true ) {
 					analyticsEvent?.( { formPattern: formPattern ?? '' } );
 					// Use config adminUrl to build full URL for external admin contexts.
-					const url = `${ adminUrl || '' }post-new.php?post_type=jetpack_form`;
+					let url = `${ adminUrl || '' }post-new.php?post_type=jetpack_form`;
+					if ( formTitle ) {
+						url += `&formTitle=${ encodeURIComponent( formTitle ) }`;
+					}
 					openFormLink( url );
 					return;
 				}
@@ -90,9 +94,12 @@ export default function useCreateForm(): CreateFormReturn {
 				if ( postUrl ) {
 					analyticsEvent?.( { formPattern } );
 
-					const url = `${ postUrl }${
+					let url = `${ postUrl }${
 						showPatterns && ! formPattern ? '&showJetpackFormsPatterns' : ''
 					}`;
+					if ( formTitle ) {
+						url += `&formTitle=${ encodeURIComponent( formTitle ) }`;
+					}
 					openFormLink( url );
 				}
 			} catch ( error ) {

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -7,7 +7,7 @@ import { Breadcrumbs } from '@wordpress/admin-ui';
 import { DropdownMenu, Button } from '@wordpress/components';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
-import { useMemo } from '@wordpress/element';
+import { useCallback, useMemo, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
@@ -23,6 +23,7 @@ import EmptyTrashButton from '../../components/empty-trash-button';
 import EmptyTrashConfirmationModal from '../../components/empty-trash-button/confirmation-modal';
 import ExportResponsesButton from '../../components/export-responses/button';
 import ExportResponsesModal from '../../components/export-responses/modal';
+import { FormNameModal } from '../../components/form-name-modal';
 import useCreateForm from '../../hooks/use-create-form';
 import useEmptySpam from '../../hooks/use-empty-spam';
 import useEmptyTrash from '../../hooks/use-empty-trash';
@@ -149,6 +150,30 @@ export default function usePageHeaderDetails(
 
 	const { duplicateForm, previewForm, copyEmbed, copyShortcode } = useFormItemActions();
 
+	// Modal state for mobile "Create a form" dropdown action
+	const [ isCreateFormModalOpen, setIsCreateFormModalOpen ] = useState( false );
+	const [ createFormShowPatterns, setCreateFormShowPatterns ] = useState( false );
+
+	const handleOpenCreateFormModal = useCallback( ( showPatterns: boolean ) => {
+		setCreateFormShowPatterns( showPatterns );
+		setIsCreateFormModalOpen( true );
+	}, [] );
+
+	const handleCreateFormModalSave = useCallback(
+		async ( newFormTitle: string ) => {
+			await openNewForm( {
+				showPatterns: createFormShowPatterns,
+				formTitle: newFormTitle,
+			} );
+		},
+		[ openNewForm, createFormShowPatterns ]
+	);
+
+	const handleCreateFormModalClose = useCallback( () => {
+		setIsCreateFormModalOpen( false );
+		openNewForm( { showPatterns: createFormShowPatterns } );
+	}, [ openNewForm, createFormShowPatterns ] );
+
 	const formItemControls = useMemo( () => {
 		if ( ! sourceIdNumber ) {
 			return [];
@@ -251,7 +276,7 @@ export default function usePageHeaderDetails(
 				}
 
 				dropdownControls.push( {
-					onClick: () => openNewForm( {} ),
+					onClick: () => handleOpenCreateFormModal( false ),
 					title: __( 'Create a form', 'jetpack-forms' ),
 				} );
 			} else if ( isSingleFormScreen ) {
@@ -300,7 +325,7 @@ export default function usePageHeaderDetails(
 
 				if ( statusView === 'inbox' ) {
 					dropdownControls.push( {
-						onClick: () => openNewForm( { showPatterns: false } ),
+						onClick: () => handleOpenCreateFormModal( false ),
 						title: __( 'Create a form', 'jetpack-forms' ),
 					} );
 				}
@@ -375,6 +400,16 @@ export default function usePageHeaderDetails(
 							/>,
 					  ]
 					: [] ),
+				<FormNameModal
+					key="create-form-modal"
+					isOpen={ isCreateFormModalOpen }
+					onClose={ handleCreateFormModalClose }
+					onSave={ handleCreateFormModalSave }
+					title={ __( 'Create form', 'jetpack-forms' ) }
+					primaryButtonLabel={ __( 'Create', 'jetpack-forms' ) }
+					secondaryButtonLabel={ __( 'Skip', 'jetpack-forms' ) }
+					placeholder={ __( 'Enter form name', 'jetpack-forms' ) }
+				/>,
 			];
 		}
 
@@ -447,7 +482,10 @@ export default function usePageHeaderDetails(
 		isSingleFormScreen,
 		formItemControls,
 		statusView,
-		openNewForm,
+		handleOpenCreateFormModal,
+		isCreateFormModalOpen,
+		handleCreateFormModalClose,
+		handleCreateFormModalSave,
 		openExportModal,
 		showExportModal,
 		closeExportModal,

--- a/projects/packages/forms/src/form-editor/plugins/form-title-modal.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/form-title-modal.tsx
@@ -8,7 +8,7 @@
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useState, useCallback, useEffect, useRef } from '@wordpress/element';
+import { useState, useCallback, useEffect, useMemo, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { FORM_POST_TYPE } from '../../blocks/shared/util/constants.js';
@@ -70,6 +70,12 @@ export const FormTitleModal = () => {
 	const isNewForm =
 		! currentPostTitle || currentPostTitle === __( 'Untitled Form', 'jetpack-forms' );
 
+	// Check for formTitle URL parameter (set by the dashboard's Create Form modal)
+	const urlFormTitle = useMemo( () => {
+		const params = new URLSearchParams( window.location.search );
+		return params.get( 'formTitle' );
+	}, [] );
+
 	const handleClose = useCallback( () => {
 		setIsOpen( false );
 	}, [] );
@@ -117,13 +123,46 @@ export const FormTitleModal = () => {
 		]
 	);
 
-	// Show modal on first render if this is a new placeholder form in the form editor
+	// If formTitle URL param is present, apply it directly and skip the modal
 	useEffect( () => {
-		if ( isFormEditor && ! hasInnerBlocks && isNewForm && ! hasShown ) {
+		if ( isFormEditor && isNewForm && urlFormTitle && currentPostId && ! hasShown ) {
+			setHasShown( true );
+			editEntityRecord( 'postType', FORM_POST_TYPE, currentPostId, {
+				title: urlFormTitle,
+			} );
+			saveEditedEntityRecord( 'postType', FORM_POST_TYPE, currentPostId ).then(
+				() => {
+					createSuccessNotice( __( 'Form created.', 'jetpack-forms' ), {
+						type: 'snackbar',
+					} );
+				},
+				() => {
+					createErrorNotice( __( 'Failed to set form name.', 'jetpack-forms' ), {
+						type: 'snackbar',
+					} );
+				}
+			);
+		}
+	}, [
+		isFormEditor,
+		isNewForm,
+		urlFormTitle,
+		currentPostId,
+		hasShown,
+		editEntityRecord,
+		saveEditedEntityRecord,
+		createSuccessNotice,
+		createErrorNotice,
+	] );
+
+	// Show modal on first render if this is a new placeholder form in the form editor
+	// (only when no formTitle URL param was provided)
+	useEffect( () => {
+		if ( isFormEditor && ! hasInnerBlocks && isNewForm && ! hasShown && ! urlFormTitle ) {
 			setIsOpen( true );
 			setHasShown( true );
 		}
-	}, [ isFormEditor, hasInnerBlocks, isNewForm, hasShown ] );
+	}, [ isFormEditor, hasInnerBlocks, isNewForm, hasShown, urlFormTitle ] );
 
 	// Don't render anything if not in the form editor
 	if ( ! isFormEditor ) {


### PR DESCRIPTION
## Summary
- When clicking "Create a form" in the Forms dashboard (desktop or mobile), a `FormNameModal` now appears asking for the form name before navigating to the editor
- The name is passed via a `formTitle` URL parameter and applied automatically in the form editor, skipping the editor's own title modal
- Clicking "Skip" preserves the previous behavior — navigates without a name, and the editor's title modal appears as before

## Changes
- **`use-create-form.ts`** — Added optional `formTitle` to `ClickHandlerProps`, appended as an encoded URL parameter to the navigation URL in both code paths
- **`create-form-button/index.tsx`** — Button click now opens `FormNameModal` instead of immediately navigating; on save passes the title, on skip navigates without one
- **`form-title-modal.tsx`** — Reads `formTitle` URL param on load; if present, applies it directly via `editEntityRecord`/`saveEditedEntityRecord` and skips showing the modal
- **`use-page-header-details.tsx`** — Mobile dropdown "Create a form" items now open the same modal, with `FormNameModal` rendered alongside other mobile modals

## Test plan
- [ ] Click "Create a form" on the Forms dashboard — modal should appear asking for a name
- [ ] Enter a name and click "Create" — should navigate to form editor with the title pre-set
- [ ] Click "Skip" — should navigate to form editor, editor modal should appear there as before
- [ ] Test on mobile viewport — dropdown "Create a form" should also show the modal
- [ ] Test the empty state "Create a new form" button — should also show the modal
- [ ] Direct access to `post-new.php?post_type=jetpack_form` (no `formTitle` param) — editor title modal should appear as before

- [x] Generate changelog entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)