### PR TITLE
Forms: Fix MailPoet subscriber not created on form submission

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-mailpoet-subscription
+++ b/projects/packages/forms/changelog/fix-forms-mailpoet-subscription
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix MailPoet subscriber not created on form submission due to list ID type mismatch and email field not detected by type attribute.

--- a/projects/packages/forms/src/service/class-mailpoet-integration.php
+++ b/projects/packages/forms/src/service/class-mailpoet-integration.php
@@ -49,7 +49,7 @@ class MailPoet_Integration {
 			try {
 				$lists = $mailpoet_api->getLists();
 				foreach ( $lists as $list ) {
-					if ( $list['id'] === $list_id && empty( $list['deleted_at'] ) ) {
+					if ( (string) $list['id'] === (string) $list_id && empty( $list['deleted_at'] ) ) {
 						return $list['id'];
 					}
 				}
@@ -175,6 +175,7 @@ class MailPoet_Integration {
 
 		$subscriber_data = array();
 		foreach ( $form->fields as $field ) {
+			$type  = strtolower( (string) $field->get_attribute( 'type' ) );
 			$id    = strtolower( str_replace( array( ' ', '_' ), '', $field->get_attribute( 'id' ) ) );
 			$label = strtolower( str_replace( array( ' ', '_' ), '', $field->get_attribute( 'label' ) ) );
 
@@ -185,7 +186,7 @@ class MailPoet_Integration {
 
 			$value = trim( $field->value );
 
-			if ( ( $id === 'email' || $label === 'email' ) && ! empty( $value ) ) {
+			if ( ( $type === 'email' || $id === 'email' || $label === 'email' ) && ! empty( $value ) ) {
 				$subscriber_data['email'] = $value;
 			} elseif ( ( $id === 'firstname' || $label === 'firstname' ) && ! empty( $value ) ) {
 				$subscriber_data['first_name'] = $value;

--- a/projects/packages/forms/src/service/class-mailpoet-integration.php
+++ b/projects/packages/forms/src/service/class-mailpoet-integration.php
@@ -176,8 +176,8 @@ class MailPoet_Integration {
 		$subscriber_data = array();
 		foreach ( $form->fields as $field ) {
 			$type  = strtolower( (string) $field->get_attribute( 'type' ) );
-			$id    = strtolower( str_replace( array( ' ', '_' ), '', $field->get_attribute( 'id' ) ) );
-			$label = strtolower( str_replace( array( ' ', '_' ), '', $field->get_attribute( 'label' ) ) );
+			$id    = strtolower( str_replace( array( ' ', '_' ), '', (string) $field->get_attribute( 'id' ) ) );
+			$label = strtolower( str_replace( array( ' ', '_' ), '', (string) $field->get_attribute( 'label' ) ) );
 
 			// If value is not a string, we already know it's not a valid name or email.
 			if ( ! is_string( $field->value ) ) {


### PR DESCRIPTION
Fixes FORMS-546

## Proposed changes:

Two bugs in `MailPoet_Integration` prevented subscribers from being added when a form with MailPoet integration was submitted:

* **List ID type mismatch**: `get_or_create_list_id()` used strict `===` to compare list IDs from the MailPoet API (integers) with IDs from block attributes (strings). `3 === "3"` is `false`, so valid lists were never matched and the code fell through to creating a new list. Fixed by casting both sides to `(string)`, matching the pattern already used in `add_subscriber_to_list()`.

* **Email field not detected by type**: `get_subscriber_data_from_fields()` only identified email fields by checking if the `id` or `label` attribute was exactly `"email"`. For `jetpack/field-email` blocks with custom labels (e.g. "Enter your email…"), neither matched. Added a check on the field's `type` attribute, which is always `"email"` for email field blocks.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Set up a WordPress site with Jetpack Forms and MailPoet active
* Create a page with a `jetpack/contact-form` block that has MailPoet integration enabled (select a newsletter list from the Integrations modal)
* Use a custom label on the email field (e.g. "Enter your email…") rather than the default "Email"
* Submit the form from the frontend with a test email address
* Verify that a new subscriber appears in MailPoet > Subscribers with "Unconfirmed" status
* Verify that a confirmation email is sent to the test email address

## Changelog

- [ ] Generate changelog entries for this PR (using AI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)