### PR TITLE
Forms: Add form name modal to wp-build dashboard

### DIFF
--- a/projects/packages/forms/changelog/update-form-wp-build-create-form
+++ b/projects/packages/forms/changelog/update-form-wp-build-create-form
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added a form name modal to the wp-build forms dashboard, prompting users to name their form before entering the editor.

--- a/projects/packages/forms/src/dashboard/components/create-form-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/create-form-button/index.tsx
@@ -61,10 +61,10 @@ export default function CreateFormButton( {
 	}, [] );
 
 	const handleModalSave = useCallback(
-		async ( formName: string ) => {
+		async ( formTitle: string ) => {
 			await openNewForm( {
 				showPatterns,
-				formTitle: formName,
+				formTitle,
 				analyticsEvent: () => {
 					jetpackAnalytics.tracks.recordEvent( 'jetpack_wpa_forms_landing_page_cta_click', {
 						button: 'forms',
@@ -93,7 +93,7 @@ export default function CreateFormButton( {
 				title={ __( 'Create form', 'jetpack-forms' ) }
 				primaryButtonLabel={ __( 'Create', 'jetpack-forms' ) }
 				secondaryButtonLabel={ __( 'Cancel', 'jetpack-forms' ) }
-				placeholder={ __( 'Enter form name', 'jetpack-forms' ) }
+				placeholder={ __( 'Enter form title', 'jetpack-forms' ) }
 			/>
 		</>
 	);

--- a/projects/packages/forms/src/dashboard/components/create-form-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/create-form-button/index.tsx
@@ -3,61 +3,98 @@
  */
 import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { Button } from '@wordpress/components';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
 import useCreateForm from '../../hooks/use-create-form.ts';
+import { FormNameModal } from '../form-name-modal';
 
 type CreateFormButtonProps = {
 	label?: string;
 	showPatterns?: boolean;
 	variant?: 'primary' | 'secondary';
 	showIcon?: boolean;
+	showNameModal?: boolean;
 };
 
 /**
  * Renders a button to create a new form.
  *
- * @param {object}  props              - The component props.
- * @param {string}  props.label        - The label for the button.
- * @param {boolean} props.showPatterns - Whether to show the patterns on the editor immediately.
- * @param {string}  props.variant      - The button variant (primary or secondary).
- * @param {boolean} props.showIcon     - Whether to show the plus icon.
- * @return {JSX.Element}                 The button to create a new form.
+ * @param {object}  props               - The component props.
+ * @param {string}  props.label         - The label for the button.
+ * @param {boolean} props.showPatterns  - Whether to show the patterns on the editor immediately.
+ * @param {string}  props.variant       - The button variant (primary or secondary).
+ * @param {boolean} props.showIcon      - Whether to show the plus icon.
+ * @param {boolean} props.showNameModal - Whether to show a modal asking for the form name before creating.
+ * @return {JSX.Element}                  The button to create a new form.
  */
 export default function CreateFormButton( {
 	label = __( 'Create a form', 'jetpack-forms' ),
 	showPatterns = false,
 	variant = 'secondary',
 	showIcon = true,
+	showNameModal = false,
 }: CreateFormButtonProps ): JSX.Element {
 	const { openNewForm } = useCreateForm();
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
 
-	const onButtonClickHandler = useCallback(
-		() =>
-			openNewForm( {
+	const onButtonClickHandler = useCallback( () => {
+		if ( showNameModal ) {
+			setIsModalOpen( true );
+			return;
+		}
+		openNewForm( {
+			showPatterns,
+			analyticsEvent: () => {
+				jetpackAnalytics.tracks.recordEvent( 'jetpack_wpa_forms_landing_page_cta_click', {
+					button: 'forms',
+				} );
+			},
+		} );
+	}, [ showNameModal, openNewForm, showPatterns ] );
+
+	const handleModalClose = useCallback( () => {
+		setIsModalOpen( false );
+	}, [] );
+
+	const handleModalSave = useCallback(
+		async ( formName: string ) => {
+			await openNewForm( {
 				showPatterns,
+				formTitle: formName,
 				analyticsEvent: () => {
 					jetpackAnalytics.tracks.recordEvent( 'jetpack_wpa_forms_landing_page_cta_click', {
 						button: 'forms',
 					} );
 				},
-			} ),
+			} );
+		},
 		[ openNewForm, showPatterns ]
 	);
 
 	return (
-		<Button
-			size="compact"
-			variant={ variant }
-			onClick={ onButtonClickHandler }
-			icon={ showIcon ? plus : undefined }
-			className="create-form-button"
-		>
-			{ label }
-		</Button>
+		<>
+			<Button
+				size="compact"
+				variant={ variant }
+				onClick={ onButtonClickHandler }
+				icon={ showIcon ? plus : undefined }
+				className="create-form-button"
+			>
+				{ label }
+			</Button>
+			<FormNameModal
+				isOpen={ isModalOpen }
+				onClose={ handleModalClose }
+				onSave={ handleModalSave }
+				title={ __( 'Create form', 'jetpack-forms' ) }
+				primaryButtonLabel={ __( 'Create', 'jetpack-forms' ) }
+				secondaryButtonLabel={ __( 'Cancel', 'jetpack-forms' ) }
+				placeholder={ __( 'Enter form name', 'jetpack-forms' ) }
+			/>
+		</>
 	);
 }

--- a/projects/packages/forms/src/dashboard/hooks/use-create-form.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-create-form.ts
@@ -82,8 +82,9 @@ export default function useCreateForm(): CreateFormReturn {
 					analyticsEvent?.( { formPattern: formPattern ?? '' } );
 					// Use config adminUrl to build full URL for external admin contexts.
 					let url = `${ adminUrl || '' }post-new.php?post_type=jetpack_form`;
-					if ( formTitle ) {
-						url += `&post_title=${ encodeURIComponent( formTitle ) }`;
+					const trimmedFormTitle = formTitle?.trim();
+					if ( trimmedFormTitle ) {
+						url += `&post_title=${ encodeURIComponent( trimmedFormTitle ) }`;
 					}
 					openFormLink( url );
 					return;

--- a/projects/packages/forms/src/dashboard/hooks/use-create-form.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-create-form.ts
@@ -23,6 +23,7 @@ const openFormLink = ( url: string ) => {
 
 type ClickHandlerProps = {
 	formPattern?: string;
+	formTitle?: string;
 	showPatterns?: boolean;
 	analyticsEvent?: ( { formPattern }: { formPattern: string } ) => void;
 };
@@ -73,14 +74,17 @@ export default function useCreateForm(): CreateFormReturn {
 	);
 
 	const openNewForm = useCallback(
-		async ( { formPattern, showPatterns, analyticsEvent }: ClickHandlerProps ) => {
+		async ( { formPattern, formTitle, showPatterns, analyticsEvent }: ClickHandlerProps ) => {
 			try {
 				// When centralized form management is enabled, create a jetpack_form post via wp-admin.
 				// Keep existing behavior when disabled (or not yet loaded).
 				if ( isCentralFormManagementEnabled === true ) {
 					analyticsEvent?.( { formPattern: formPattern ?? '' } );
 					// Use config adminUrl to build full URL for external admin contexts.
-					const url = `${ adminUrl || '' }post-new.php?post_type=jetpack_form`;
+					let url = `${ adminUrl || '' }post-new.php?post_type=jetpack_form`;
+					if ( formTitle ) {
+						url += `&post_title=${ encodeURIComponent( formTitle ) }`;
+					}
 					openFormLink( url );
 					return;
 				}

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -100,7 +100,12 @@ export default function usePageHeaderDetails(
 	const closeCreateFormModal = useCallback( () => setIsCreateFormModalOpen( false ), [] );
 	const handleCreateFormSave = useCallback(
 		async ( formName: string ) => {
-			await openNewForm( { formTitle: formName } );
+			const trimmedName = formName.trim();
+			if ( trimmedName ) {
+				await openNewForm( { formTitle: trimmedName } );
+			} else {
+				await openNewForm( {} );
+			}
 		},
 		[ openNewForm ]
 	);

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -7,7 +7,7 @@ import { Breadcrumbs } from '@wordpress/admin-ui';
 import { DropdownMenu, Button } from '@wordpress/components';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
-import { useMemo } from '@wordpress/element';
+import { useMemo, useState, useCallback } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
@@ -23,6 +23,7 @@ import EmptyTrashButton from '../../components/empty-trash-button';
 import EmptyTrashConfirmationModal from '../../components/empty-trash-button/confirmation-modal';
 import ExportResponsesButton from '../../components/export-responses/button';
 import ExportResponsesModal from '../../components/export-responses/modal';
+import { FormNameModal } from '../../components/form-name-modal';
 import { getFormStatusLabel } from '../../constants';
 import useCreateForm from '../../hooks/use-create-form';
 import useEmptySpam from '../../hooks/use-empty-spam';
@@ -92,6 +93,17 @@ export default function usePageHeaderDetails(
 
 	// Hooks for mobile dropdown menu actions
 	const { openNewForm } = useCreateForm();
+	const [ isCreateFormModalOpen, setIsCreateFormModalOpen ] = useState( false );
+	const handleCreateFormClick = useCallback( () => {
+		setIsCreateFormModalOpen( true );
+	}, [] );
+	const closeCreateFormModal = useCallback( () => setIsCreateFormModalOpen( false ), [] );
+	const handleCreateFormSave = useCallback(
+		async ( formName: string ) => {
+			await openNewForm( { formTitle: formName } );
+		},
+		[ openNewForm ]
+	);
 	const {
 		showExportModal,
 		openModal: openExportModal,
@@ -259,7 +271,7 @@ export default function usePageHeaderDetails(
 				}
 
 				dropdownControls.push( {
-					onClick: () => openNewForm( {} ),
+					onClick: handleCreateFormClick,
 					title: __( 'Create a form', 'jetpack-forms' ),
 				} );
 			} else if ( isSingleFormScreen ) {
@@ -308,7 +320,7 @@ export default function usePageHeaderDetails(
 
 				if ( statusView === 'inbox' ) {
 					dropdownControls.push( {
-						onClick: () => openNewForm( { showPatterns: false } ),
+						onClick: handleCreateFormClick,
 						title: __( 'Create a form', 'jetpack-forms' ),
 					} );
 				}
@@ -349,6 +361,20 @@ export default function usePageHeaderDetails(
 					toggleProps={ { size: 'compact' } }
 				/>,
 				// Include modals when on mobile
+				...( isCreateFormModalOpen
+					? [
+							<FormNameModal
+								key="create-form-modal"
+								isOpen={ isCreateFormModalOpen }
+								onClose={ closeCreateFormModal }
+								onSave={ handleCreateFormSave }
+								title={ __( 'Create form', 'jetpack-forms' ) }
+								primaryButtonLabel={ __( 'Create', 'jetpack-forms' ) }
+								secondaryButtonLabel={ __( 'Cancel', 'jetpack-forms' ) }
+								placeholder={ __( 'Enter form name', 'jetpack-forms' ) }
+							/>,
+					  ]
+					: [] ),
 				...( showExportModal
 					? [
 							<ExportResponsesModal
@@ -392,7 +418,7 @@ export default function usePageHeaderDetails(
 				...( isIntegrationsEnabled && showDashboardIntegrations
 					? [ <ManageIntegrationsButton key="integrations" onClick={ onOpenIntegrations } /> ]
 					: [] ),
-				<CreateFormButton key="create" variant="primary" showIcon={ false } />,
+				<CreateFormButton key="create" variant="primary" showIcon={ false } showNameModal />,
 			];
 		}
 
@@ -434,6 +460,7 @@ export default function usePageHeaderDetails(
 							variant="secondary"
 							showPatterns={ false }
 							showIcon={ false }
+							showNameModal
 						/>,
 				  ]
 				: [] ),
@@ -455,7 +482,10 @@ export default function usePageHeaderDetails(
 		isSingleFormScreen,
 		formItemControls,
 		statusView,
-		openNewForm,
+		handleCreateFormClick,
+		isCreateFormModalOpen,
+		closeCreateFormModal,
+		handleCreateFormSave,
 		openExportModal,
 		showExportModal,
 		closeExportModal,

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -100,12 +100,7 @@ export default function usePageHeaderDetails(
 	const closeCreateFormModal = useCallback( () => setIsCreateFormModalOpen( false ), [] );
 	const handleCreateFormSave = useCallback(
 		async ( formName: string ) => {
-			const trimmedName = formName.trim();
-			if ( trimmedName ) {
-				await openNewForm( { formTitle: trimmedName } );
-			} else {
-				await openNewForm( {} );
-			}
+			await openNewForm( { formTitle: formName } );
 		},
 		[ openNewForm ]
 	);

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -371,7 +371,7 @@ export default function usePageHeaderDetails(
 								title={ __( 'Create form', 'jetpack-forms' ) }
 								primaryButtonLabel={ __( 'Create', 'jetpack-forms' ) }
 								secondaryButtonLabel={ __( 'Cancel', 'jetpack-forms' ) }
-								placeholder={ __( 'Enter form name', 'jetpack-forms' ) }
+								placeholder={ __( 'Enter form title', 'jetpack-forms' ) }
 							/>,
 					  ]
 					: [] ),


### PR DESCRIPTION
Fixes FORMS-NEW

https://github.com/user-attachments/assets/faed2e7d-666a-4e13-a478-47f9a0f6c936

## Proposed changes

- When clicking "Create a form" on the wp-build forms dashboard, a modal now prompts the user to name their form before navigating to the editor
- Added `showNameModal` prop to `CreateFormButton` (defaults to `false`) so the modal only appears in wp-build contexts
- The `useCreateForm` hook now accepts an optional `formTitle` parameter, passed to the editor via `post_title` URL parameter
- The editor's `FormTitleModal` checks for the `post_title` URL parameter and skips showing the duplicate naming modal when the user already named the form from the dashboard
- Updated mobile dropdown menu entries in `usePageHeaderDetails` to also use the form name modal

## Other information

All changes are scoped to `projects/packages/forms`. The modal reuses the existing `FormNameModal` component.

## Does this pull request change what data or activity we track or use?

No

## Testing instructions

1. Enable `jetpack_forms_alpha` and central form management

3. Go to the Forms dashboard (wp-build route)
4. Click "Create a form" — a modal should appear asking for the form name
5. Enter a name and click "Create" — you should be navigated to the form editor with the title set
6. Verify the editor's own naming modal does **not** appear (since you already named the form)
7. Go back to dashboard, click "Create a form" again, and click "Cancel" — modal should close without navigating
8. Click "Create a form" and click "Create" without entering a name — the editor should open and NOT show its own naming modal
9. On mobile, use the dropdown menu's "Create a form" option — same modal behavior
10. Disable `jetpack_forms_alpha` / central form management and verify the old dashboard's "Create a form" button still works without showing a modal

