### PR TITLE
Forms: fix MailPoet subscriber not created when enabledForForm is missing

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-mailpoet-subscriber
+++ b/projects/packages/forms/changelog/fix-forms-mailpoet-subscriber
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix MailPoet integration silently skipping subscribers when enabledForForm flag is missing from block attributes.

--- a/projects/packages/forms/src/service/class-mailpoet-integration.php
+++ b/projects/packages/forms/src/service/class-mailpoet-integration.php
@@ -260,7 +260,23 @@ class MailPoet_Integration {
 			return;
 		}
 
-		if ( empty( $form->attributes['mailpoet']['enabledForForm'] ?? null ) ) {
+		$mailpoet_config = $form->attributes['mailpoet'] ?? null;
+		if ( ! is_array( $mailpoet_config ) ) {
+			return;
+		}
+
+		// If the user explicitly disabled the toggle, respect that.
+		if ( array_key_exists( 'enabledForForm', $mailpoet_config ) && ! $mailpoet_config['enabledForForm'] ) {
+			return;
+		}
+
+		// Otherwise, consider MailPoet enabled if explicitly flagged or if a list was configured
+		// (covers patterns/legacy forms where enabledForForm is absent from block attributes).
+		$is_enabled = ! empty( $mailpoet_config['enabledForForm'] )
+			|| ! empty( $mailpoet_config['listId'] )
+			|| ! empty( $mailpoet_config['listName'] );
+
+		if ( ! $is_enabled ) {
 			return;
 		}
 
@@ -301,9 +317,8 @@ class MailPoet_Integration {
 		}
 
 		// Get listId and listName from the mailpoet attribute
-		$mailpoet_attr = is_array( $form->attributes['mailpoet'] ) ? $form->attributes['mailpoet'] : array();
-		$list_id       = $mailpoet_attr['listId'] ?? null;
-		$list_name     = $mailpoet_attr['listName'] ?? null;
+		$list_id   = $mailpoet_config['listId'] ?? null;
+		$list_name = $mailpoet_config['listName'] ?? null;
 
 		$list_id = self::get_or_create_list_id( $mailpoet_api, $list_id, $list_name );
 		if ( ! $list_id ) {


### PR DESCRIPTION
Fixes FORMS-546

## Proposed changes:

* Fix MailPoet integration silently skipping subscriber creation when the `enabledForForm` flag is absent from the form block's `mailpoet` attribute.

The MailPoet integration handler checked only for `enabledForForm` to decide whether to process a submission. However, block patterns (e.g. subscription form patterns from pattern libraries) may configure `mailpoet` with a `listId` and `listName` but omit `enabledForForm`, because that flag is only injected dynamically by `use-form-block-defaults.js` in the editor — it's not part of the block attribute schema defaults.

This caused forms to show "success" while silently skipping the MailPoet subscriber creation.

The fix considers MailPoet enabled if **any** of these are set:
- `enabledForForm` (explicit flag, existing behavior)
- `listId` (a list was configured)
- `listName` (a list name was configured)

### Other information:

- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

## Testing instructions:

1. Install and activate MailPoet plugin
2. Create a page with a Jetpack contact form block
3. In the block markup, set mailpoet config **without** `enabledForForm`:
   ```
   <!-- wp:jetpack/contact-form {"mailpoet":{"listId":"3","listName":"Newsletter mailing list"}} -->
   ```
4. Add an email field and a name field, publish the page
5. Submit the form on the frontend
6. **Before fix:** Form shows success, but no subscriber in Marketing > Subscribers
7. **After fix:** Subscriber is created in the configured MailPoet list

## Does this pull request change what data or activity we track or use?

No.

## Changelog

- [x] Generate changelog entries for this PR (using AI).