### PR TITLE
Update/admin header normalization css override

### DIFF
--- a/projects/js-packages/components/changelog/update-admin-header-normalization-css-override
+++ b/projects/js-packages/components/changelog/update-admin-header-normalization-css-override
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AdminPage: override admin-ui header position so it's not sticky

--- a/projects/js-packages/components/components/admin-page/style.module.scss
+++ b/projects/js-packages/components/components/admin-page/style.module.scss
@@ -14,6 +14,7 @@
 	// CSS custom property for this — revisit if the upstream API changes.
 	:global(.admin-ui-page__header) {
 		border-bottom: none;
+		position: relative;
 	}
 
 	.admin-page-header {


### PR DESCRIPTION
## Proposed changes:
Override admin-ui-page__header position: relative

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
p1772221150641619/1772213915.946189-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
Load Social admin page, scroll down. See that header is not sticky

## Changelog
<!-- Check one of the boxes below. -->

- [ ] Generate changelog entries for this PR (using AI).