### PR TITLE
Modules page: Migrate PHP-rendered header to unified pattern

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -273,12 +273,22 @@ abstract class Jetpack_Admin_Page {
 		?>
 		">
 
-			<div class="jp-masthead jp-masthead-middle">
+			<header class="jp-masthead">
 				<div class="jp-masthead__inside-container">
-					<div class="jp-masthead__logo-container">
+					<div class="jp-masthead__title-container">
 						<a class="jp-masthead__logo-link" href="<?php echo esc_url( $jetpack_admin_url ); ?>">
-							<svg class="jetpack-logo__masthead" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" height="40" viewBox="0 0 118 32"><path fill="#069e08" d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z M15,19H7l8-16V19z M17,29V13h8L17,29z"></path><path d="M41.3,26.6c-0.5-0.7-0.9-1.4-1.3-2.1c2.3-1.4,3-2.5,3-4.6V8h-3V6h6v13.4C46,22.8,45,24.8,41.3,26.6z"></path><path d="M65,18.4c0,1.1,0.8,1.3,1.4,1.3c0.5,0,2-0.2,2.6-0.4v2.1c-0.9,0.3-2.5,0.5-3.7,0.5c-1.5,0-3.2-0.5-3.2-3.1V12H60v-2h2.1V7.1 H65V10h4v2h-4V18.4z"></path><path d="M71,10h3v1.3c1.1-0.8,1.9-1.3,3.3-1.3c2.5,0,4.5,1.8,4.5,5.6s-2.2,6.3-5.8,6.3c-0.9,0-1.3-0.1-2-0.3V28h-3V10z M76.5,12.3 c-0.8,0-1.6,0.4-2.5,1.2v5.9c0.6,0.1,0.9,0.2,1.8,0.2c2,0,3.2-1.3,3.2-3.9C79,13.4,78.1,12.3,76.5,12.3z"></path><path d="M93,22h-3v-1.5c-0.9,0.7-1.9,1.5-3.5,1.5c-1.5,0-3.1-1.1-3.1-3.2c0-2.9,2.5-3.4,4.2-3.7l2.4-0.3v-0.3c0-1.5-0.5-2.3-2-2.3 c-0.7,0-2.3,0.5-3.7,1.1L84,11c1.2-0.4,3-1,4.4-1c2.7,0,4.6,1.4,4.6,4.7L93,22z M90,16.4l-2.2,0.4c-0.7,0.1-1.4,0.5-1.4,1.6 c0,0.9,0.5,1.4,1.3,1.4s1.5-0.5,2.3-1V16.4z"></path><path d="M104.5,21.3c-1.1,0.4-2.2,0.6-3.5,0.6c-4.2,0-5.9-2.4-5.9-5.9c0-3.7,2.3-6,6.1-6c1.4,0,2.3,0.2,3.2,0.5V13 c-0.8-0.3-2-0.6-3.2-0.6c-1.7,0-3.2,0.9-3.2,3.6c0,2.9,1.5,3.8,3.3,3.8c0.9,0,1.9-0.2,3.2-0.7V21.3z"></path><path d="M110,15.2c0.2-0.3,0.2-0.8,3.8-5.2h3.7l-4.6,5.7l5,6.3h-3.7l-4.2-5.8V22h-3V6h3V15.2z"></path><path d="M58.5,21.3c-1.5,0.5-2.7,0.6-4.2,0.6c-3.6,0-5.8-1.8-5.8-6c0-3.1,1.9-5.9,5.5-5.9s4.9,2.5,4.9,4.9c0,0.8,0,1.5-0.1,2h-7.3 c0.1,2.5,1.5,2.8,3.6,2.8c1.1,0,2.2-0.3,3.4-0.7C58.5,19,58.5,21.3,58.5,21.3z M56,15c0-1.4-0.5-2.9-2-2.9c-1.4,0-2.3,1.3-2.4,2.9 C51.6,15,56,15,56,15z"></path></svg>
+							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" height="20" aria-label="<?php esc_attr_e( 'Jetpack logo', 'jetpack' ); ?>"><path fill="#069e08" d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z M15,19H7l8-16V19z M17,29V13h8L17,29z"></path></svg>
 						</a>
+						<h2 class="jp-masthead__title">
+							<?php
+							// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- View logic only.
+							if ( isset( $_GET['page'] ) && 'jetpack_modules' === $_GET['page'] ) {
+								esc_html_e( 'Modules', 'jetpack' );
+							} else {
+								esc_html_e( 'Jetpack', 'jetpack' );
+							}
+							?>
+						</h2>
 					</div>
 					<?php
 					if ( $args['show-nav'] && ! ( new Host() )->is_wpcom_platform() ) :
@@ -319,7 +329,7 @@ abstract class Jetpack_Admin_Page {
 						</div>
 					<?php endif; ?>
 				</div>
-			</div>
+			</header>
 			<div class="wrap"><div id="jp-admin-notices" aria-live="polite"></div></div>
 			<!-- START OF CALLBACK -->
 			<?php


### PR DESCRIPTION
Part of the JETPACK-1352 project.

## Proposed changes:
* Replace the large inline Jetpack wordmark SVG (118x32, height 40) in the PHP-rendered wrap_ui() template with the bolt icon only (32x32, height 20)
* Add a dynamic h2 title: Modules on the modules page, Jetpack elsewhere
* Change wrapper from div to semantic header element
* Rename jp-masthead__logo-container to jp-masthead__title-container to match the React Masthead update in #47388
* Remove jp-masthead-middle class (centering) to match left-aligned layout

This updates the PHP-rendered masthead used by the Modules page (?page=jetpack_modules) and the Debugger page. The React-rendered Masthead (used by Dashboard/Settings) is updated separately in #47388.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
* Build the Jetpack plugin: jetpack build plugins/jetpack
* Navigate to the Modules page: wp-admin/admin.php?page=jetpack_modules
  * Verify the header shows the Jetpack bolt icon (small, green) and Modules title
  * Verify the old large Jetpack wordmark logo is gone
  * Verify Dashboard/Settings nav buttons still work (if visible)
* Navigate to the Debugger page: wp-admin/admin.php?page=jetpack-debugger
  * Verify the header shows the bolt icon and Jetpack title

## Changelog
- [x] Generate changelog entries for this PR (using AI).