### PR TITLE
wpcomsh: Include webfinger handle in ActivityPub activation sync data

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-wpcomsh-activitypub-webfinger
+++ b/projects/plugins/wpcomsh/changelog/update-wpcomsh-activitypub-webfinger
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-ActivityPub: include webfinger handle alongside actor URI in plugin activation sync data.
+ActivityPub: include WebFinger handle alongside actor URI in plugin activation sync data.

--- a/projects/plugins/wpcomsh/changelog/update-wpcomsh-activitypub-webfinger
+++ b/projects/plugins/wpcomsh/changelog/update-wpcomsh-activitypub-webfinger
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+ActivityPub: include webfinger handle alongside actor URI in plugin activation sync data.

--- a/projects/plugins/wpcomsh/feature-plugins/activitypub.php
+++ b/projects/plugins/wpcomsh/feature-plugins/activitypub.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Connection\Manager;
  * already expanded the original positional args into the three-element array below.
  *
  * When the activated plugin is ActivityPub, this function appends a fourth element
- * containing the Jetpack connection owner's ActivityPub actor URI and webfinger handle
+ * containing the Jetpack connection owner's ActivityPub actor URI and WebFinger handle
  * so they can be synced to WordPress.com.
  *
  * @param array|false $args {
@@ -25,7 +25,7 @@ use Automattic\Jetpack\Connection\Manager;
  *     @type bool   $1 Whether the plugin was network-activated. Default false.
  *     @type array  $2 Plugin header data added by `expand_plugin_data()` (keys: 'name', 'version').
  *     @type array  $3 Optional. Added by this function when the plugin is ActivityPub.
- *                     Contains 'actor' (URI) and 'webfinger' (acct handle).
+ *                     Contains 'actor' (URI) and 'WebFinger' (acct handle).
  * }
  *
  * @return array|false The (possibly augmented) args, or false if a previous filter aborted.

--- a/projects/plugins/wpcomsh/feature-plugins/activitypub.php
+++ b/projects/plugins/wpcomsh/feature-plugins/activitypub.php
@@ -15,7 +15,8 @@ use Automattic\Jetpack\Connection\Manager;
  * already expanded the original positional args into the three-element array below.
  *
  * When the activated plugin is ActivityPub, this function appends a fourth element
- * containing the Jetpack connection owner's ActivityPub actor URI so it can be synced to WordPress.com.
+ * containing the Jetpack connection owner's ActivityPub actor URI and webfinger handle
+ * so they can be synced to WordPress.com.
  *
  * @param array|false $args {
  *     Positional activated_plugin hook arguments. False if a previous filter aborted.
@@ -24,7 +25,7 @@ use Automattic\Jetpack\Connection\Manager;
  *     @type bool   $1 Whether the plugin was network-activated. Default false.
  *     @type array  $2 Plugin header data added by `expand_plugin_data()` (keys: 'name', 'version').
  *     @type array  $3 Optional. Added by this function when the plugin is ActivityPub.
- *                     Contains 'actor' — the Jetpack connection owner's ActivityPub actor URI.
+ *                     Contains 'actor' (URI) and 'webfinger' (acct handle).
  * }
  *
  * @return array|false The (possibly augmented) args, or false if a previous filter aborted.
@@ -51,7 +52,11 @@ function wpcomsh_activitypub_sync_plugin_activation( $args ) {
 	// @phan-suppress-next-line PhanUndeclaredClassMethod We're checking the class exists above, and that class exists in the ActivityPub plugin.
 	$actor = Activitypub\Collection\Actors::get_by_id( $connection_owner_id );
 	if ( ! is_wp_error( $actor ) ) {
-		$args[] = array( 'actor' => $actor->get_id() );
+		$args[] = array(
+			'actor'     => $actor->get_id(),
+			// @phan-suppress-next-line PhanUndeclaredClassMethod
+			'webfinger' => $actor->get_webfinger(),
+		);
 	}
 
 	return $args;

--- a/projects/plugins/wpcomsh/feature-plugins/activitypub.php
+++ b/projects/plugins/wpcomsh/feature-plugins/activitypub.php
@@ -54,7 +54,6 @@ function wpcomsh_activitypub_sync_plugin_activation( $args ) {
 	if ( ! is_wp_error( $actor ) ) {
 		$args[] = array(
 			'actor'     => $actor->get_id(),
-			// @phan-suppress-next-line PhanUndeclaredClassMethod
 			'webfinger' => $actor->get_webfinger(),
 		);
 	}

--- a/projects/plugins/wpcomsh/tests/ActivityPubTest.php
+++ b/projects/plugins/wpcomsh/tests/ActivityPubTest.php
@@ -93,10 +93,11 @@ class ActivityPubTest extends WP_UnitTestCase {
 	 * and the actor is found successfully.
 	 */
 	public function test_appends_actor_data_when_actor_is_found() {
-		$actor_id = 'https://example.com/author/test';
+		$actor_id  = 'https://example.com/author/test';
+		$webfinger = 'test@example.com';
 
 		\Activitypub\Collection\Actors::set_mock_return(
-			new \Activitypub\Collection\Actor( $actor_id )
+			new \Activitypub\Collection\Actor( $actor_id, $webfinger )
 		);
 
 		$args   = array( 'activitypub/activitypub.php', false );
@@ -105,7 +106,13 @@ class ActivityPubTest extends WP_UnitTestCase {
 		$this->assertCount( 3, $result );
 		$this->assertSame( 'activitypub/activitypub.php', $result[0] );
 		$this->assertFalse( $result[1] );
-		$this->assertSame( array( 'actor' => $actor_id ), $result[2] );
+		$this->assertSame(
+			array(
+				'actor'     => $actor_id,
+				'webfinger' => $webfinger,
+			),
+			$result[2]
+		);
 	}
 
 	/**

--- a/projects/plugins/wpcomsh/tests/lib/mocks/mock-activitypub-actors.php
+++ b/projects/plugins/wpcomsh/tests/lib/mocks/mock-activitypub-actors.php
@@ -22,12 +22,21 @@ if ( ! class_exists( 'Activitypub\Collection\Actors' ) ) {
 		private $id;
 
 		/**
+		 * Webfinger handle.
+		 *
+		 * @var string|null
+		 */
+		private $webfinger;
+
+		/**
 		 * Constructor.
 		 *
-		 * @param string $id Actor ID.
+		 * @param string      $id        Actor ID.
+		 * @param string|null $webfinger Webfinger handle.
 		 */
-		public function __construct( $id ) {
-			$this->id = $id;
+		public function __construct( $id, $webfinger = null ) {
+			$this->id        = $id;
+			$this->webfinger = $webfinger;
 		}
 
 		/**
@@ -37,6 +46,15 @@ if ( ! class_exists( 'Activitypub\Collection\Actors' ) ) {
 		 */
 		public function get_id() {
 			return $this->id;
+		}
+
+		/**
+		 * Get the webfinger handle.
+		 *
+		 * @return string|null
+		 */
+		public function get_webfinger() {
+			return $this->webfinger;
 		}
 	}
 

--- a/projects/plugins/wpcomsh/tests/lib/mocks/mock-activitypub-actors.php
+++ b/projects/plugins/wpcomsh/tests/lib/mocks/mock-activitypub-actors.php
@@ -22,7 +22,7 @@ if ( ! class_exists( 'Activitypub\Collection\Actors' ) ) {
 		private $id;
 
 		/**
-		 * Webfinger handle.
+		 * WebFinger handle.
 		 *
 		 * @var string|null
 		 */
@@ -49,7 +49,7 @@ if ( ! class_exists( 'Activitypub\Collection\Actors' ) ) {
 		}
 
 		/**
-		 * Get the webfinger handle.
+		 * Get the WebFinger handle.
 		 *
 		 * @return string|null
 		 */


### PR DESCRIPTION
Fixes CM-570

## Proposed changes:
* Include the actor's webfinger handle (e.g. `blog@example.com`) alongside the actor URI when syncing ActivityPub plugin activation data to WordPress.com.
* This allows WordPress.com to use the webfinger as a fallback when resolving the actor on mastodon.social, improving reliability of the `@wapuunaut` seed-follow mechanism.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
Counterpart of 205802-ghe-Automattic/wpcom/.

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions:
* Activate the ActivityPub plugin on an Atomic site.
* Verify that the Jetpack Sync activation event includes both `actor` (URI) and `webfinger` (acct handle) in the appended data.
* Confirm existing tests pass: `jetpack docker phpunit wpcomsh -- --filter="ActivityPubTest"`
