### PR TITLE
MU WPCOM: Unregister the Gutenberg RTC setting on the Writing page if there are no RTC providers

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/feat-gb-rtc-disable-rtc-setting-and-option
+++ b/projects/packages/jetpack-mu-wpcom/changelog/feat-gb-rtc-disable-rtc-setting-and-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+MU WPCOM: Unregister the Gutenberg RTC setting on the Writing page if there are no RTC providers

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -413,6 +413,7 @@ class Jetpack_Mu_Wpcom {
 			return;
 		}
 
+		require_once __DIR__ . '/features/gutenberg-rtc/gutenberg-rtc.php';
 		require_once __DIR__ . '/features/jetpack-global-styles/class-global-styles.php';
 		require_once __DIR__ . '/features/mailerlite/subscriber-popup.php';
 		require_once __DIR__ . '/features/wpcom-fse/wpcom-fse.php';
@@ -425,7 +426,6 @@ class Jetpack_Mu_Wpcom {
 		if ( ( isset( $pagenow ) && in_array( $pagenow, $allowed_pages, true ) ) || ! is_admin() ) {
 			require_once __DIR__ . '/features/block-editor/custom-line-height.php';
 			require_once __DIR__ . '/features/block-inserter-modifications/block-inserter-modifications.php';
-			require_once __DIR__ . '/features/gutenberg-rtc/gutenberg-rtc.php';
 			require_once __DIR__ . '/features/hide-homepage-title/hide-homepage-title.php';
 			require_once __DIR__ . '/features/override-preview-button-url/override-preview-button-url.php';
 			require_once __DIR__ . '/features/paragraph-block-placeholder/paragraph-block-placeholder.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
@@ -75,7 +75,7 @@ add_action( 'admin_init', 'wpcom_unregister_rtc_setting', 11 );
  * Disable the `wp_enable_real_time_collaboration` option if there are no RTC providers.
  *
  * @param mixed $pre_option The value to return instead of the option value.
- * @return string Filtered wp_enable_real_time_collaboration option
+ * @return string|false Filtered wp_enable_real_time_collaboration option
  */
 function wpcom_disable_rtc_option( $pre_option ) {
 	$providers = wpcom_get_gutenberg_rtc_providers();

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
@@ -10,10 +10,21 @@
  */
 
 /**
+ * Check whether Gutenberg RTC is enabled or not
+ */
+function wpcom_is_gutenberg_rtc_enabled() {
+	return apply_filters( 'wpcom_is_gutenberg_rtc_enabled', false );
+}
+
+/**
  * Get WPCOM RTC providers.
  */
 function wpcom_get_gutenberg_rtc_providers() {
-	return array();
+	if ( ! wpcom_is_gutenberg_rtc_enabled() ) {
+		return array();
+	}
+
+	return apply_filters( 'wpcom_gutenberg_rtc_providers', array() );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
@@ -9,22 +9,64 @@
  * @package automattic/jetpack-mu-wpcom
  */
 
-use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+/**
+ * Get WPCOM RTC providers.
+ */
+function wpcom_get_gutenberg_rtc_providers() {
+	return array();
+}
 
 /**
  * Enqueue block editor assets for Gutenberg RTC customizations.
  */
 function wpcom_enqueue_gutenberg_rtc_assets() {
-	$asset_file          = include Jetpack_Mu_Wpcom::BASE_DIR . 'build/gutenberg-rtc/gutenberg-rtc.asset.php';
-	$script_dependencies = $asset_file['dependencies'] ?? array();
-	$version             = $asset_file['version'] ?? filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/gutenberg-rtc/gutenberg-rtc.js' );
+	$handle = jetpack_mu_wpcom_enqueue_assets( 'gutenberg-rtc', array( 'js' ) );
 
-	wp_enqueue_script(
-		'gutenberg-rtc-script',
-		plugins_url( 'build/gutenberg-rtc/gutenberg-rtc.js', Jetpack_Mu_Wpcom::BASE_FILE ),
-		$script_dependencies,
-		$version,
-		true
+	$data = wp_json_encode(
+		array(
+			'providers' => wpcom_get_gutenberg_rtc_providers(),
+		),
+		JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
+	);
+
+	wp_add_inline_script(
+		$handle,
+		"var wpcomGutenbergRTC = $data;",
+		'before'
 	);
 }
 add_action( 'enqueue_block_editor_assets', 'wpcom_enqueue_gutenberg_rtc_assets' );
+
+/**
+ * Unregister the RTC setting field, Collaboration, on the Writing page if there are no RTC providers.
+ */
+function wpcom_unregister_rtc_setting() {
+	global $wp_settings_fields;
+
+	$providers   = wpcom_get_gutenberg_rtc_providers();
+	$option_name = 'wp_enable_real_time_collaboration';
+	if ( isset( $wp_settings_fields['writing']['default'][ $option_name ] ) && count( $providers ) === 0 ) {
+		unset( $wp_settings_fields['writing']['default'][ $option_name ] );
+	}
+
+	// TODO: Clean up the old name. See https://github.com/WordPress/gutenberg/pull/75837.
+	$option_name = 'enable_real_time_collaboration';
+	if ( isset( $wp_settings_fields['writing']['default'][ $option_name ] ) && count( $providers ) === 0 ) {
+		unset( $wp_settings_fields['writing']['default'][ $option_name ] );
+	}
+}
+add_action( 'admin_init', 'wpcom_unregister_rtc_setting', 11 );
+
+/**
+ * Disable the `wp_enable_real_time_collaboration` option if there are no RTC providers.
+ */
+function wpcom_disable_rtc_option() {
+	$providers = wpcom_get_gutenberg_rtc_providers();
+	if ( count( $providers ) === 0 ) {
+		return '0';
+	}
+
+	return false;
+}
+add_filter( 'pre_option_wp_enable_real_time_collaboration', 'wpcom_disable_rtc_option' );
+add_filter( 'pre_option_enable_real_time_collaboration', 'wpcom_disable_rtc_option' ); // TODO: Clean up the old name. See https://github.com/WordPress/gutenberg/pull/75837.

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
@@ -10,7 +10,10 @@
  */
 
 /**
- * Check whether Gutenberg RTC is enabled or not
+ * Determines whether Gutenberg RTC is enabled.
+ *
+ * Disabled by default until the PingHub provider is ready
+ * and we are confident in proceeding with the rollout.
  */
 function wpcom_is_gutenberg_rtc_enabled() {
 	return apply_filters( 'wpcom_is_gutenberg_rtc_enabled', false );
@@ -70,14 +73,17 @@ add_action( 'admin_init', 'wpcom_unregister_rtc_setting', 11 );
 
 /**
  * Disable the `wp_enable_real_time_collaboration` option if there are no RTC providers.
+ *
+ * @param mixed $pre_option The value to return instead of the option value.
+ * @return string Filtered wp_enable_real_time_collaboration option
  */
-function wpcom_disable_rtc_option() {
+function wpcom_disable_rtc_option( $pre_option ) {
 	$providers = wpcom_get_gutenberg_rtc_providers();
 	if ( count( $providers ) === 0 ) {
 		return '0';
 	}
 
-	return false;
+	return $pre_option;
 }
 add_filter( 'pre_option_wp_enable_real_time_collaboration', 'wpcom_disable_rtc_option' );
 add_filter( 'pre_option_enable_real_time_collaboration', 'wpcom_disable_rtc_option' ); // TODO: Clean up the old name. See https://github.com/WordPress/gutenberg/pull/75837.

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.ts
@@ -1,6 +1,6 @@
 import { addFilter } from '@wordpress/hooks';
 
-// Register PingHub provider and disable Http polling by returning only this provider.
+// Register providers (e.g. PingHub) supplied by the server, and disable HTTP polling by returning only this provider.
 ( function register() {
 	if ( typeof window === 'undefined' ) {
 		return;

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.ts
@@ -5,5 +5,5 @@ import { addFilter } from '@wordpress/hooks';
 	if ( typeof window === 'undefined' ) {
 		return;
 	}
-	addFilter( 'sync.providers', 'wpcom/pinghub-provider', () => [] );
+	addFilter( 'sync.providers', 'wpcom/pinghub-provider', () => window.wpcomGutenbergRTC.providers );
 } )();

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
@@ -30,9 +30,27 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
 
 	/**
-	 * Clean up filters after each test.
+	 * Original value of $wp_settings_fields to restore after each test.
+	 *
+	 * @var mixed
+	 */
+	private $original_wp_settings_fields;
+
+	/**
+	 * Save global state before each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		global $wp_settings_fields;
+		$this->original_wp_settings_fields = $wp_settings_fields;
+	}
+
+	/**
+	 * Clean up filters and restore global state after each test.
 	 */
 	public function tear_down(): void {
+		global $wp_settings_fields;
+		$wp_settings_fields = $this->original_wp_settings_fields; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		remove_all_filters( 'wpcom_is_gutenberg_rtc_enabled' );
 		remove_all_filters( 'wpcom_gutenberg_rtc_providers' );
 		parent::tear_down();

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
@@ -115,13 +115,13 @@ class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
 	 * Tests that wpcom_disable_rtc_option returns '0' when no providers.
 	 */
 	public function test_wpcom_disable_rtc_option_returns_zero_when_no_providers() {
-		$this->assertSame( '0', wpcom_disable_rtc_option() );
+		$this->assertSame( '0', wpcom_disable_rtc_option( false ) );
 	}
 
 	/**
-	 * Tests that wpcom_disable_rtc_option returns false when providers exist (allowing the real option value through).
+	 * Tests that wpcom_disable_rtc_option passes through the pre_option value when providers exist.
 	 */
-	public function test_wpcom_disable_rtc_option_returns_false_when_providers_exist() {
+	public function test_wpcom_disable_rtc_option_passes_through_when_providers_exist() {
 		add_filter( 'wpcom_is_gutenberg_rtc_enabled', '__return_true' );
 		add_filter(
 			'wpcom_gutenberg_rtc_providers',
@@ -130,7 +130,8 @@ class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
 			}
 		);
 
-		$this->assertFalse( wpcom_disable_rtc_option() );
+		$this->assertFalse( wpcom_disable_rtc_option( false ) );
+		$this->assertSame( '1', wpcom_disable_rtc_option( '1' ) );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
@@ -16,16 +16,173 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 /**
  * Tests for Gutenberg RTC feature.
  *
+ * @covers ::wpcom_disable_rtc_option
  * @covers ::wpcom_enqueue_gutenberg_rtc_assets
+ * @covers ::wpcom_get_gutenberg_rtc_providers
+ * @covers ::wpcom_is_gutenberg_rtc_enabled
+ * @covers ::wpcom_unregister_rtc_setting
  */
+#[CoversFunction( 'wpcom_is_gutenberg_rtc_enabled' )]
+#[CoversFunction( 'wpcom_get_gutenberg_rtc_providers' )]
 #[CoversFunction( 'wpcom_enqueue_gutenberg_rtc_assets' )]
+#[CoversFunction( 'wpcom_unregister_rtc_setting' )]
+#[CoversFunction( 'wpcom_disable_rtc_option' )]
 class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
+
+	/**
+	 * Clean up filters after each test.
+	 */
+	public function tear_down(): void {
+		remove_all_filters( 'wpcom_is_gutenberg_rtc_enabled' );
+		remove_all_filters( 'wpcom_gutenberg_rtc_providers' );
+		parent::tear_down();
+	}
+
 	/**
 	 * Tests whether the gutenberg-rtc assets enqueue function is hooked correctly.
-	 *
-	 * @return void
 	 */
 	public function test_wpcom_enqueue_gutenberg_rtc_assets_hooked() {
 		$this->assertSame( 10, has_action( 'enqueue_block_editor_assets', 'wpcom_enqueue_gutenberg_rtc_assets' ) );
+	}
+
+	/**
+	 * Tests whether the unregister RTC setting function is hooked to admin_init.
+	 */
+	public function test_wpcom_unregister_rtc_setting_hooked() {
+		$this->assertSame( 11, has_action( 'admin_init', 'wpcom_unregister_rtc_setting' ) );
+	}
+
+	/**
+	 * Tests whether the disable RTC option filters are hooked.
+	 */
+	public function test_wpcom_disable_rtc_option_hooked() {
+		$this->assertSame( 10, has_filter( 'pre_option_wp_enable_real_time_collaboration', 'wpcom_disable_rtc_option' ) );
+		$this->assertSame( 10, has_filter( 'pre_option_enable_real_time_collaboration', 'wpcom_disable_rtc_option' ) );
+	}
+
+	/**
+	 * Tests that RTC is disabled by default.
+	 */
+	public function test_wpcom_is_gutenberg_rtc_enabled_default() {
+		$this->assertFalse( wpcom_is_gutenberg_rtc_enabled() );
+	}
+
+	/**
+	 * Tests that RTC can be enabled via filter.
+	 */
+	public function test_wpcom_is_gutenberg_rtc_enabled_via_filter() {
+		add_filter( 'wpcom_is_gutenberg_rtc_enabled', '__return_true' );
+		$this->assertTrue( wpcom_is_gutenberg_rtc_enabled() );
+	}
+
+	/**
+	 * Tests that providers returns an empty array when RTC is disabled.
+	 */
+	public function test_wpcom_get_gutenberg_rtc_providers_empty_when_disabled() {
+		$this->assertSame( array(), wpcom_get_gutenberg_rtc_providers() );
+	}
+
+	/**
+	 * Tests that providers filter is not applied when RTC is disabled.
+	 */
+	public function test_wpcom_get_gutenberg_rtc_providers_ignores_filter_when_disabled() {
+		add_filter(
+			'wpcom_gutenberg_rtc_providers',
+			function () {
+				return array( 'pinghub' );
+			}
+		);
+
+		$this->assertSame( array(), wpcom_get_gutenberg_rtc_providers() );
+	}
+
+	/**
+	 * Tests that providers are returned when RTC is enabled.
+	 */
+	public function test_wpcom_get_gutenberg_rtc_providers_returns_providers_when_enabled() {
+		add_filter( 'wpcom_is_gutenberg_rtc_enabled', '__return_true' );
+		add_filter(
+			'wpcom_gutenberg_rtc_providers',
+			function () {
+				return array( 'pinghub' );
+			}
+		);
+
+		$this->assertSame( array( 'pinghub' ), wpcom_get_gutenberg_rtc_providers() );
+	}
+
+	/**
+	 * Tests that wpcom_disable_rtc_option returns '0' when no providers.
+	 */
+	public function test_wpcom_disable_rtc_option_returns_zero_when_no_providers() {
+		$this->assertSame( '0', wpcom_disable_rtc_option() );
+	}
+
+	/**
+	 * Tests that wpcom_disable_rtc_option returns false when providers exist (allowing the real option value through).
+	 */
+	public function test_wpcom_disable_rtc_option_returns_false_when_providers_exist() {
+		add_filter( 'wpcom_is_gutenberg_rtc_enabled', '__return_true' );
+		add_filter(
+			'wpcom_gutenberg_rtc_providers',
+			function () {
+				return array( 'pinghub' );
+			}
+		);
+
+		$this->assertFalse( wpcom_disable_rtc_option() );
+	}
+
+	/**
+	 * Tests that wpcom_unregister_rtc_setting removes the setting when no providers.
+	 */
+	public function test_wpcom_unregister_rtc_setting_removes_when_no_providers() {
+		global $wp_settings_fields;
+
+		// Set up a fake settings field for both option names.
+		$wp_settings_fields['writing']['default']['wp_enable_real_time_collaboration'] = array( 'id' => 'wp_enable_real_time_collaboration' );
+		$wp_settings_fields['writing']['default']['enable_real_time_collaboration']    = array( 'id' => 'enable_real_time_collaboration' );
+
+		wpcom_unregister_rtc_setting();
+
+		$this->assertArrayNotHasKey( 'wp_enable_real_time_collaboration', $wp_settings_fields['writing']['default'] );
+		$this->assertArrayNotHasKey( 'enable_real_time_collaboration', $wp_settings_fields['writing']['default'] );
+	}
+
+	/**
+	 * Tests that wpcom_unregister_rtc_setting keeps the setting when providers exist.
+	 */
+	public function test_wpcom_unregister_rtc_setting_keeps_when_providers_exist() {
+		global $wp_settings_fields;
+
+		add_filter( 'wpcom_is_gutenberg_rtc_enabled', '__return_true' );
+		add_filter(
+			'wpcom_gutenberg_rtc_providers',
+			function () {
+				return array( 'pinghub' );
+			}
+		);
+
+		$wp_settings_fields['writing']['default']['wp_enable_real_time_collaboration'] = array( 'id' => 'wp_enable_real_time_collaboration' );
+		$wp_settings_fields['writing']['default']['enable_real_time_collaboration']    = array( 'id' => 'enable_real_time_collaboration' );
+
+		wpcom_unregister_rtc_setting();
+
+		$this->assertArrayHasKey( 'wp_enable_real_time_collaboration', $wp_settings_fields['writing']['default'] );
+		$this->assertArrayHasKey( 'enable_real_time_collaboration', $wp_settings_fields['writing']['default'] );
+	}
+
+	/**
+	 * Tests that wpcom_unregister_rtc_setting does not error when settings fields are not set.
+	 */
+	public function test_wpcom_unregister_rtc_setting_handles_missing_fields() {
+		global $wp_settings_fields;
+
+		$wp_settings_fields = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		// Should not throw any errors.
+		wpcom_unregister_rtc_setting();
+
+		$this->assertSame( array(), $wp_settings_fields );
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/changelog/feat-gb-rtc-disable-rtc-setting-and-option
+++ b/projects/plugins/mu-wpcom-plugin/changelog/feat-gb-rtc-disable-rtc-setting-and-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+MU WPCOM: Unregister the Gutenberg RTC setting on the Writing page if there are no RTC providers

--- a/projects/plugins/wpcomsh/changelog/feat-gb-rtc-disable-rtc-setting-and-option
+++ b/projects/plugins/wpcomsh/changelog/feat-gb-rtc-disable-rtc-setting-and-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+MU WPCOM: Unregister the Gutenberg RTC setting on the Writing page if there are no RTC providers


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes DOTCOM-16143

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* When the filter removes the registered RTC providers (used as a safety measure to disable the default core implementation), the “Enable real-time collaboration” setting should not appear in Writing Settings. As a result, this PR proposes to add the `wpcom_unregister_rtc_setting` to remove the settings when the RTC providers are empty. Also, if the RTC providers are empty, we should disable the `wp_enable_real_time_collaboration` option.
* Move the value of RTC providers to server side so it's consistent on both server and client
* Load `gutenberg-rtc.php` anyway as it's required on `Settings > Writing` page. The hook `enqueue_block_editor_assets` is called only in the editor, so it should be fine.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply changes to your sandbox
* Sandbox your simple site with Gutenberg edge
* Visit WP Admin on your site
* Navigate to Settings > Writing
* Ensure the `Collaboration:  Enable real-time collaboration` disappears

## Changelog
<!-- Check one of the boxes below. -->

- [ ] Generate changelog entries for this PR (using AI).
