### PR TITLE
tsgo: Fix packages/jetpack-mu-wpcom verbum-comments type errors

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-tsgo-fix-jetpack-mu-wpcom-type-errors
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-tsgo-fix-jetpack-mu-wpcom-type-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix TypeScript type errors in verbum-comments for tsgo compatibility

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/comments-moderation.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/comments-moderation.js
@@ -5,7 +5,7 @@
  */
 /* global VerbumComments, verbumBlockEditor */
 document.addEventListener( 'DOMContentLoaded', function () {
-	const embedContentCallback = embedUrl => {
+	const embedContentCallback = ( /** @type {string} */ embedUrl ) => {
 		return {
 			path: '/verbum/embed',
 			query: `embed_url=${ encodeURIComponent( embedUrl ) }&embed_nonce=${ encodeURIComponent(

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/dynamic-loader.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/assets/dynamic-loader.js
@@ -5,7 +5,7 @@ window.addEventListener( 'DOMContentLoaded', function () {
 	if ( commentForm ) {
 		// only load Verbum if the comment field is visible or the browser doesn't support IntersectionObserver
 		if ( window.IntersectionObserver ) {
-			new IntersectionObserver( function ( entries ) {
+			const observer = new IntersectionObserver( entries => {
 				for ( const el of entries ) {
 					if ( el.isIntersecting ) {
 						const startedLoadingAt = Date.now();
@@ -15,11 +15,12 @@ window.addEventListener( 'DOMContentLoaded', function () {
 
 							VerbumComments.fullyLoadedTime = finishedLoadingAt - startedLoadingAt;
 						} );
-						this.disconnect();
+						observer.disconnect();
 						return;
 					}
 				}
-			} ).observe( commentForm );
+			} );
+			observer.observe( commentForm );
 		} else {
 			WP_Enqueue_Dynamic_Script.loadScript( 'verbum' );
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/EmailForm/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/EmailForm/index.tsx
@@ -9,10 +9,12 @@ import { getUserInfoCookie, isAuthRequired } from '../../utils';
 import { NewCommentEmail } from '../new-comment-email';
 import { NewPostsEmail } from '../new-posts-email';
 import { EmailFormCookieConsent } from './email-form-cookie-consent';
-import { getProfile } from './profile-get';
+import { getProfile, type CommentUser } from './profile-get';
 import type { ChangeEvent } from 'preact/compat';
 import './style.scss';
 import '@gravatar-com/hovercards/dist/style.css';
+
+type UserProfileData = Partial< CommentUser > | null;
 
 interface EmailFormProps {
 	shouldShowEmailForm: boolean;
@@ -35,7 +37,7 @@ export const EmailForm = ( { shouldShowEmailForm }: EmailFormProps ) => {
 	const isNameTouched = useSignal( false );
 	const isValidAuthor = useSignal( true );
 	const isLoadingProfile = useSignal( false );
-	const userProfile = useSignal( null );
+	const userProfile = useSignal< UserProfileData >( null );
 	const userEmail = useComputed( () => mailLoginData.value.email || '' );
 	const userName = useComputed( () => mailLoginData.value.author || '' );
 	const userUrl = useComputed( () => mailLoginData.value.url || '' );
@@ -133,11 +135,9 @@ export const EmailForm = ( { shouldShowEmailForm }: EmailFormProps ) => {
 
 		if ( userCookie?.service === 'guest' ) {
 			mailLoginData.value = {
-				...( userCookie?.email && { email: userCookie?.email } ),
-				...( userCookie?.author && {
-					author: userCookie?.author,
-				} ),
-				...( userCookie?.url && { url: userCookie?.url } ),
+				email: userCookie?.email ?? '',
+				author: userCookie?.author ?? '',
+				url: userCookie?.url ?? '',
 			};
 
 			if ( userCookie?.email ) {
@@ -166,7 +166,10 @@ export const EmailForm = ( { shouldShowEmailForm }: EmailFormProps ) => {
 						<label htmlFor="verbum-email-form-email" className="verbum__label">
 							{ userProfile?.value?.emailHash ? (
 								<Suspense fallback={ <Email /> }>
-									<ProfileImage key={ userProfile.value.email } profile={ userProfile.value } />
+									<ProfileImage
+										key={ userProfile.value.email }
+										profile={ userProfile.value as CommentUser }
+									/>
 								</Suspense>
 							) : (
 								<Email />

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/EmailForm/profile-image.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/EmailForm/profile-image.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import { useEffect, useRef, useState } from 'preact/hooks';
 import getHovercard from '../quick-editor';
 import { CommentUser } from './profile-get';
+import type { GravatarQuickEditorCore } from '@gravatar-com/quick-editor';
 
 const getAvatarUrl = ( profile: CommentUser, cacheBuster: number ) => {
 	if ( ! profile.avatarUrl ) {
@@ -12,11 +13,11 @@ const getAvatarUrl = ( profile: CommentUser, cacheBuster: number ) => {
 	return `${ profile.avatarUrl }?v=${ cacheBuster }`;
 };
 
-const ProfileImage = ( { profile } ) => {
-	const profileImageRef = useRef( null );
-	const quickEditorRef = useRef( null );
-	const hovercardRef = useRef( null );
-	const timerRef = useRef( null );
+const ProfileImage = ( { profile }: { profile: CommentUser } ) => {
+	const profileImageRef = useRef< HTMLImageElement >( null );
+	const quickEditorRef = useRef< GravatarQuickEditorCore | null >( null );
+	const hovercardRef = useRef< Hovercards | null >( null );
+	const timerRef = useRef< ReturnType< typeof setTimeout > | null >( null );
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ cacheBuster, setCacheBuster ] = useState( new Date().getTime() );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/FrequencyToggle/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/FrequencyToggle/index.tsx
@@ -1,16 +1,18 @@
 import { Fragment } from 'preact';
 import './style.scss';
 
+type DeliveryFrequency = 'instantly' | 'daily' | 'weekly';
+
 type FrequencyToggleProps = {
 	initialOptions: Option[];
-	onChange?: ( deliveryFrequency: string ) => void;
+	onChange?: ( deliveryFrequency: DeliveryFrequency ) => void;
 	selectedOption: string;
 	disabled?: boolean;
 	name: string;
 };
 
 type Option = {
-	value: string;
+	value: DeliveryFrequency;
 	checked: boolean;
 	label: string;
 };
@@ -45,7 +47,7 @@ export function FrequencyToggle( {
 							id={ option.value }
 							value={ option.value }
 							checked={ option.value === selectedOption }
-							onChange={ () => onChange( option.value ) }
+							onChange={ () => onChange?.( option.value ) }
 							disabled={ disabled }
 						/>
 						<label aria-label={ option.value } htmlFor={ option.value } className="label-wrapper">

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/SimpleSubscribeModal/logged-in.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/SimpleSubscribeModal/logged-in.tsx
@@ -16,8 +16,8 @@ export const SimpleSubscribeSetModalShowLoggedIn = () => {
 		},
 	};
 	subscribeModalStatus.value = shouldShowSubscriptionModal(
-		email?.send_posts,
-		userInfo.value?.uid
+		email?.send_posts ?? false,
+		userInfo.value?.uid ?? 0
 	);
 	return null;
 };
@@ -35,13 +35,13 @@ export const SimpleSubscribeModalLoggedIn = ( {
 	 * Handle the subscribe button click.
 	 */
 	async function handleOnSubscribeClick() {
-		setSubscribeState( 'SUBSCRIBING' );
+		setSubscribeState?.( 'SUBSCRIBING' );
 		await setEmailPostsSubscription( {
 			type: 'subscribe',
 			value: true,
 			trackSource: 'verbum-subscription-modal',
 		} );
-		setSubscribeState( 'SUBSCRIBED' );
+		setSubscribeState?.( 'SUBSCRIBED' );
 	}
 
 	if ( ! commentUrl.value ) {
@@ -64,8 +64,8 @@ export const SimpleSubscribeModalLoggedIn = ( {
 				</>
 			) : (
 				<SubscriptionModal
-					userEmail={ userInfo.value?.email }
-					subscribeState={ subscribeState }
+					userEmail={ userInfo.value?.email ?? '' }
+					subscribeState={ subscribeState ?? '' }
 					handleOnSubscribeClick={ handleOnSubscribeClick }
 					closeModalHandler={ closeModalHandler }
 					disabled={ true }

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/SimpleSubscribeModal/logged-out.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/SimpleSubscribeModal/logged-out.tsx
@@ -43,7 +43,7 @@ export const SimpleSubscribeModalLoggedOut = ( {
 			if ( data && data.action === 'close' ) {
 				window.removeEventListener( 'message', handleIframeResult );
 				closeModalHandler();
-				setHasIframe( false );
+				setHasIframe?.( false );
 				setIframeUrl( '' );
 			}
 		}
@@ -58,13 +58,13 @@ export const SimpleSubscribeModalLoggedOut = ( {
 			return;
 		}
 
-		setSubscribeState( 'SUBSCRIBING' );
-		setHasIframe( true );
+		setSubscribeState?.( 'SUBSCRIBING' );
+		setHasIframe?.( true );
 		const subscribeData = {
 			email: userEmail,
-			post_id: VerbumComments.postId.toString(),
+			post_id: String( VerbumComments.postId ?? '' ),
 			plan: 'newsletter',
-			blog: VerbumComments.siteId.toString(),
+			blog: String( VerbumComments.siteId ?? '' ),
 			source: 'jetpack_subscribe',
 			display: 'alternate',
 			app_source: 'verbum-subscription-modal',
@@ -99,7 +99,7 @@ export const SimpleSubscribeModalLoggedOut = ( {
 	return (
 		<SubscriptionModal
 			userEmail={ userEmail }
-			subscribeState={ subscribeState }
+			subscribeState={ subscribeState ?? '' }
 			handleOnSubscribeClick={ handleOnSubscribeClick }
 			onInput={ setSubscriptionEmail }
 			disabled={ false }

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/comment-input-field.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/comment-input-field.tsx
@@ -1,12 +1,11 @@
 /* global verbumBlockEditor */
 import clsx from 'clsx';
-import { forwardRef, type TargetedEvent } from 'preact/compat';
+import { forwardRef, type TargetedEvent, type ForwardedRef } from 'preact/compat';
 import { useContext, useEffect, useState } from 'preact/hooks';
 import { translate } from '../i18n';
 import { VerbumSignals } from '../state';
 import { isFastConnection } from '../utils';
 import { EditorPlaceholder } from './editor-placeholder';
-import type { MutableRefObject } from 'react';
 
 type CommentInputFieldProps = {
 	handleOnKeyUp: () => void;
@@ -33,17 +32,16 @@ const embedContentCallback = ( embedUrl: string ) => {
 };
 
 export const CommentInputField = forwardRef(
-	(
-		{ handleOnKeyUp }: CommentInputFieldProps,
-		ref: MutableRefObject< HTMLTextAreaElement | null >
-	) => {
+	( { handleOnKeyUp }: CommentInputFieldProps, ref: ForwardedRef< HTMLTextAreaElement > ) => {
 		const { commentParent, commentValue } = useContext( VerbumSignals );
-		const [ editorState, setEditorState ] = useState< 'LOADING' | 'LOADED' | 'ERROR' >( null );
+		const [ editorState, setEditorState ] = useState< 'LOADING' | 'LOADED' | 'ERROR' | null >(
+			null
+		);
 		const [ isGBEditorEnabled, setIsGBEditorEnabled ] = useState( false );
 
 		useEffect( () => {
 			setTimeout( () => {
-				setIsGBEditorEnabled( VerbumComments.enableBlocks && isFastConnection() );
+				setIsGBEditorEnabled( Boolean( VerbumComments.enableBlocks ) && isFastConnection() );
 			} );
 		}, [] );
 
@@ -66,7 +64,7 @@ export const CommentInputField = forwardRef(
 						VerbumComments.vbeCacheBuster
 				);
 				verbumBlockEditor.attachGutenberg(
-					ref.current,
+					( ref as { current: HTMLTextAreaElement | null } ).current!,
 					content => {
 						commentValue.value = content;
 						handleOnKeyUp();

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/editor-placeholder.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/editor-placeholder.tsx
@@ -4,7 +4,13 @@ import { translate } from '../i18n';
 import { VerbumSignals } from '../state';
 import { CustomLoadingSpinner } from './custom-loading-spinner';
 
-export const EditorPlaceholder = ( { onClick, loading } ) => {
+export const EditorPlaceholder = ( {
+	onClick,
+	loading,
+}: {
+	onClick: VoidFunction;
+	loading: boolean;
+} ) => {
 	const { commentParent } = useContext( VerbumSignals );
 	return (
 		<div

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/email-frequency-group.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/email-frequency-group.tsx
@@ -3,16 +3,16 @@ import { translate } from '../i18n';
 import { FrequencyToggle } from './FrequencyToggle';
 
 const options = [
-	{ value: 'instantly', label: translate( 'Instantly' ), checked: true },
-	{ value: 'daily', label: translate( 'Daily' ), checked: false },
-	{ value: 'weekly', label: translate( 'Weekly' ), checked: false },
+	{ value: 'instantly' as const, label: translate( 'Instantly' ), checked: true },
+	{ value: 'daily' as const, label: translate( 'Daily' ), checked: false },
+	{ value: 'weekly' as const, label: translate( 'Weekly' ), checked: false },
 ];
 
 interface EmailFrequencyGroupProps {
 	isChecked: boolean;
 	onChange: ( value: 'instantly' | 'daily' | 'weekly' ) => void;
 	selectedOption: string;
-	label: string;
+	label?: string | null;
 	disabled: boolean;
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/logged-in.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/logged-in.tsx
@@ -20,10 +20,12 @@ function sprintf( s: string, param: string ): string {
 }
 
 interface LoggedInProps {
-	siteId: number;
+	siteId?: number;
 	toggleTray: () => void;
 	logout: () => void;
 }
+
+type ServiceName = keyof typeof serviceData;
 
 export const LoggedIn = ( { toggleTray, logout }: LoggedInProps ) => {
 	const { isTrayOpen, subscriptionSettings, userInfo } = useContext( VerbumSignals );
@@ -45,14 +47,14 @@ export const LoggedIn = ( { toggleTray, logout }: LoggedInProps ) => {
 
 	const getUsername = () => {
 		if ( VerbumComments.isJetpackCommentsLoggedIn ) {
-			return `${ sprintf( translate( 'Logged in as %s' ), userInfo.value?.name ) }`;
+			return `${ sprintf( translate( 'Logged in as %s' ), userInfo.value?.name ?? '' ) }`;
 		}
 		return (
 			<>
 				{ userInfo.value.name }
 				{ ` - ${ sprintf(
 					translate( 'Logged in via %s' ),
-					serviceData[ userInfo.value.service ]?.name
+					serviceData[ userInfo.value.service as ServiceName ]?.name
 				) } - ` }
 			</>
 		);
@@ -70,7 +72,7 @@ export const LoggedIn = ( { toggleTray, logout }: LoggedInProps ) => {
 	// Atomic logging out
 	if ( window.location.host === 'jetpack.wordpress.com' ) {
 		logoutProps.href =
-			baseLogoutUrl + '&redirect_to=' + window.location.hash.match( /#parent=(.*)/ )[ 1 ];
+			baseLogoutUrl + '&redirect_to=' + window.location.hash.match( /#parent=(.*)/ )?.[ 1 ];
 		logoutProps.target = '_parent';
 	} else {
 		logoutProps.href = baseLogoutUrl + '&redirect_to=' + encodeURIComponent( window.location.href );
@@ -114,15 +116,15 @@ export const LoggedIn = ( { toggleTray, logout }: LoggedInProps ) => {
 									{ userInfo.value.service === 'wordpress' && (
 										<NewPostsNotifications
 											handleOnChange={ setNotificationSubscription }
-											isChecked={ notification?.send_posts }
+											isChecked={ notification?.send_posts ?? false }
 											disabled={ ! isTrayOpen.value }
 										/>
 									) }
 									<NewPostsEmail
 										disabled={ ! isTrayOpen.value }
 										handleOnChange={ setEmailPostsSubscription }
-										isChecked={ email?.send_posts }
-										selectedOption={ email?.post_delivery_frequency }
+										isChecked={ email?.send_posts ?? false }
+										selectedOption={ email?.post_delivery_frequency ?? 'instantly' }
 									/>
 								</>
 							) }
@@ -130,7 +132,7 @@ export const LoggedIn = ( { toggleTray, logout }: LoggedInProps ) => {
 								<NewCommentEmail
 									disabled={ ! isTrayOpen.value }
 									handleOnChange={ setCommentSubscription }
-									isChecked={ email?.send_comments }
+									isChecked={ email?.send_comments ?? false }
 								/>
 							) }
 						</div>

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/logged-out.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/logged-out.tsx
@@ -5,10 +5,11 @@ import { translate } from '../i18n';
 import { VerbumSignals } from '../state';
 import { serviceData } from '../utils';
 import { EmailForm } from './EmailForm';
+import type { SocialServiceName } from '../hooks/useSocialLogin';
 
 const { mustLogIn, requireNameEmail, commentRegistration } = VerbumComments;
 interface LoggedOutProps {
-	login: ( service: string ) => void;
+	login: ( service: SocialServiceName ) => void;
 	canWeAccessCookies: boolean;
 	loginWindow: Window | null;
 }
@@ -136,7 +137,7 @@ export const LoggedOut = ( { login, canWeAccessCookies, loginWindow }: LoggedOut
 											className="components-button is-link"
 											onClick={ () => {
 												setActiveService( closeLoginPopupService );
-												loginWindow.close();
+												loginWindow?.close();
 											} }
 										>
 											{ translate( 'Cancel' ) }

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/quick-editor.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/quick-editor.tsx
@@ -6,7 +6,7 @@ const LOCALE_MAP = {
 	en: '',
 	zh_TW: 'zh-TW',
 	fr_ca: 'fr-CA',
-};
+} as Record< string, string >;
 
 const getLocale = ( locale: string ) => {
 	// Convert special locales to Gravatar locales
@@ -30,7 +30,7 @@ export default function getQuickEditor(
 	email: string,
 	setIsLoading: ( value: boolean ) => void,
 	setCacheBuster: ( value: number ) => void,
-	timer: string | number | NodeJS.Timeout
+	timer: ReturnType< typeof setTimeout > | null
 ): GravatarQuickEditorCore {
 	return new GravatarQuickEditorCore( {
 		scope: [ 'avatars' ],
@@ -40,7 +40,9 @@ export default function getQuickEditor(
 		onProfileUpdated: () => {
 			setIsLoading( true );
 
-			clearTimeout( timer );
+			if ( timer !== null ) {
+				clearTimeout( timer );
+			}
 
 			// Reload the new avatar
 			timer = setTimeout( () => {

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/settings-button.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/settings-button.tsx
@@ -3,6 +3,7 @@ import { useContext, useRef, useState } from 'preact/hooks';
 import { translate } from '../i18n';
 import { VerbumSignals } from '../state';
 import { hasSubscriptionOptionsVisible } from '../utils';
+import type { GravatarQuickEditorCore } from '@gravatar-com/quick-editor';
 
 interface SettingsButtonProps {
 	expanded: boolean;
@@ -19,8 +20,8 @@ export const SettingsButton = ( { expanded, toggleSubscriptionTray }: SettingsBu
 
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ cacheBuster, setCacheBuster ] = useState( new Date().getTime() );
-	const timerRef = useRef( null );
-	const quickEditorRef = useRef( null );
+	const timerRef = useRef< ReturnType< typeof setTimeout > | null >( null );
+	const quickEditorRef = useRef< GravatarQuickEditorCore | null >( null );
 
 	const handleOnClick = ( event: MouseEvent ) => {
 		if ( subscriptionOptionsVisible ) {
@@ -28,7 +29,7 @@ export const SettingsButton = ( { expanded, toggleSubscriptionTray }: SettingsBu
 		}
 	};
 
-	const openEditor = async ev => {
+	const openEditor = async ( ev: MouseEvent ) => {
 		ev.preventDefault();
 
 		if ( ! quickEditorRef.current ) {
@@ -37,14 +38,14 @@ export const SettingsButton = ( { expanded, toggleSubscriptionTray }: SettingsBu
 			);
 
 			quickEditorRef.current = getQuickEditor(
-				userInfo.value?.email,
+				userInfo.value?.email ?? '',
 				setIsLoading,
 				setCacheBuster,
 				timerRef.current
 			);
 		}
 
-		quickEditorRef.current.open();
+		quickEditorRef.current?.open();
 	};
 
 	return (
@@ -57,7 +58,7 @@ export const SettingsButton = ( { expanded, toggleSubscriptionTray }: SettingsBu
 					className={ clsx( 'verbum-form__profile', isLoading && 'loading' ) }
 				>
 					<img
-						src={ getAvatarUrl( userInfo.value?.avatar, cacheBuster ) }
+						src={ getAvatarUrl( userInfo.value?.avatar ?? '', cacheBuster ) }
 						alt={ userInfo.value?.name }
 						className={ userInfo.value?.avatar_classes }
 						loading="lazy"

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/hooks/useSocialLogin.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/hooks/useSocialLogin.tsx
@@ -1,8 +1,10 @@
 import { useState, useEffect, useContext } from 'preact/hooks';
 import wpcomRequest from 'wpcom-proxy-request';
 import { VerbumSignals } from '../state';
-import { UserInfo } from '../types';
 import { serviceData, setUserInfoCookie } from '../utils';
+import type { UserInfo } from '../types';
+
+export type SocialServiceName = Exclude< keyof typeof serviceData, 'mail' >;
 
 export const addIframe = ( src: string ) => {
 	const iframe = document.createElement( 'iframe' );
@@ -63,14 +65,14 @@ export default function useSocialLogin() {
 	}
 
 	const logout = () => {
-		const serviceName = userInfo.value?.service;
+		const serviceName = userInfo.value?.service as SocialServiceName;
 		const cookieName = serviceData[ serviceName ].cookieName;
 
 		// Firefox: Logout from Verbum UI and clear cookies
 		document.cookie = `${ cookieName }=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; SameSite=None; Secure=True;${ addWordPressDomain }`;
 	};
 
-	const login = async ( service: string ) => {
+	const login = async ( service: SocialServiceName ) => {
 		const { connectURL } = VerbumComments;
 		const broadcastChannel = new BroadcastChannel( 'verbum_post_message' );
 
@@ -80,7 +82,7 @@ export default function useSocialLogin() {
 			`status=0,toolbar=0,location=1,menubar=0,directories=0,resizable=1,scrollbars=0${ serviceData[ service ].popup }`
 		);
 
-		const waitForLogin = event => {
+		const waitForLogin = ( event: MessageEvent ) => {
 			if (
 				event.origin !== document.location.origin &&
 				! event.origin.endsWith( '.wordpress.com' )
@@ -103,7 +105,7 @@ export default function useSocialLogin() {
 
 				// Ensure that the login window is closed after success
 				if ( ! loginWindow?.closed ) {
-					loginWindow.close();
+					loginWindow?.close();
 				}
 			}
 		};
@@ -123,7 +125,7 @@ export default function useSocialLogin() {
 			}
 		}, 100 );
 
-		setLoginWindowRef( loginWindow );
+		setLoginWindowRef( loginWindow ?? undefined );
 	};
 
 	return { login, loginWindowRef, logout };

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/hooks/useSubscriptionApi.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/hooks/useSubscriptionApi.tsx
@@ -12,7 +12,7 @@ const getSubscriptionDetails = async () => {
 
 	return await wpcomRequest( {
 		path: `/read/sites/${ siteId }/subscription-details?post_id=${ encodeURIComponent(
-			VerbumComments.postId
+			VerbumComments.postId ?? ''
 		) }`,
 		apiNamespace: 'wpcom/v2',
 		apiVersion: '2',
@@ -42,7 +42,8 @@ export default function useSubscriptionApi() {
 	useEffect( () => {
 		setSubscriptionSettingsIsLoading( true );
 		getSubscriptionDetails()
-			.then( ( data: Record< string, string | SubscriptionDetails > ) => {
+			.then( result => {
+				const data = result as Record< string, string | SubscriptionDetails >;
 				setSubscriptionSettingsIsLoading( false );
 				// When a Facebook user doesn't have a subscription, it does not return delivery_methods object.
 				// We set the default values for the subscription settings.
@@ -66,7 +67,7 @@ export default function useSubscriptionApi() {
 	}, [] );
 
 	const setEmailPostsSubscription = async function ( change: EmailPostsChange ) {
-		let response: EmailSubscriptionResponse;
+		let response: EmailSubscriptionResponse | undefined;
 		if ( change.type === 'frequency' ) {
 			response = await wpcomRequest< EmailSubscriptionResponse >( {
 				path: `/read/site/${ siteId }/post_email_subscriptions/update`,
@@ -91,11 +92,11 @@ export default function useSubscriptionApi() {
 		}
 
 		const subscriptionSettingsValue = subscriptionSettings.peek();
-		if ( response.success ) {
+		if ( response?.success ) {
 			subscriptionSettings.value = {
 				...subscriptionSettingsValue,
 				email: {
-					...subscriptionSettingsValue.email,
+					...subscriptionSettingsValue?.email,
 					send_posts: response.subscribed,
 					post_delivery_frequency: response.subscription?.delivery_frequency ?? 'instantly',
 				},
@@ -107,7 +108,7 @@ export default function useSubscriptionApi() {
 		const comments = await wpcomRequest< Record< string, boolean > >( {
 			path: `/read/site/${ siteId }/comment_email_subscriptions/${
 				subscribe ? 'new' : 'delete'
-			}/?post_id=${ encodeURIComponent( VerbumComments.postId ) }`,
+			}/?post_id=${ encodeURIComponent( VerbumComments.postId ?? '' ) }`,
 			apiVersion: '1.2',
 			method: 'POST',
 		} );
@@ -117,7 +118,7 @@ export default function useSubscriptionApi() {
 			subscriptionSettings.value = {
 				...subscriptionSettingsValue,
 				email: {
-					...subscriptionSettingsValue.email,
+					...subscriptionSettingsValue?.email,
 					send_comments: comments.subscribed,
 				},
 			};
@@ -135,7 +136,7 @@ export default function useSubscriptionApi() {
 		const subscriptionSettingsValue = subscriptionSettings.peek();
 		if ( notifications.success ) {
 			subscriptionSettings.value = {
-				...subscriptionSettingsValue,
+				...subscriptionSettingsValue!,
 				notification: {
 					send_posts: notifications.subscribed,
 				},

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/index.tsx
@@ -40,7 +40,7 @@ const Verbum = ( { siteId, parentForm }: VerbumAppProps ) => {
 	const [ showMessage, setShowMessage ] = useState( '' );
 	const [ isErrorMessage, setIsErrorMessage ] = useState( false );
 
-	const commentTextarea = useRef< HTMLTextAreaElement >();
+	const commentTextarea = useRef< HTMLTextAreaElement >( null );
 	const [ email, setEmail ] = useState( '' );
 	const [ ignoreSubscriptionModal, setIgnoreSubscriptionModal ] = useState( false );
 	const { login, loginWindowRef, logout } = useSocialLogin();
@@ -113,7 +113,7 @@ const Verbum = ( { siteId, parentForm }: VerbumAppProps ) => {
 		}
 	};
 
-	const handleSubscriptionModal = async event => {
+	const handleSubscriptionModal = async ( event: Event ) => {
 		event.preventDefault();
 		setShowMessage( '' );
 
@@ -125,9 +125,9 @@ const Verbum = ( { siteId, parentForm }: VerbumAppProps ) => {
 			setEmail( formData.get( 'email' ) as string );
 		}
 
-		formData.set( 'verbum_show_subscription_modal', subscribeModalStatus.value );
+		formData.set( 'verbum_show_subscription_modal', subscribeModalStatus.value ?? '' );
 
-		const response = await fetch( formAction, {
+		const response = await fetch( formAction!, {
 			method: 'POST',
 			body: formData,
 		} );
@@ -159,7 +159,7 @@ const Verbum = ( { siteId, parentForm }: VerbumAppProps ) => {
 		submitFormFunction.call( parentForm );
 	};
 
-	const handleCommentSubmit = async event => {
+	const handleCommentSubmit = async ( event: Event ) => {
 		window.removeEventListener( 'beforeunload', handleBeforeUnload );
 		if ( userInfo.value?.service === 'guest' ) {
 			if ( shouldStoreEmailData.value ) {
@@ -191,7 +191,7 @@ const Verbum = ( { siteId, parentForm }: VerbumAppProps ) => {
 	};
 
 	const handleTrayToggle = () => {
-		commentTextarea.current.focus();
+		commentTextarea.current?.focus();
 
 		if ( isTrayOpen.value && ! subscriptionTraySeen && userLoggedIn.value ) {
 			setSubscriptionTraySeen();
@@ -224,12 +224,12 @@ const Verbum = ( { siteId, parentForm }: VerbumAppProps ) => {
 				} ) }
 			>
 				{ userLoggedIn.value ? (
-					<LoggedIn siteId={ siteId } toggleTray={ handleTrayToggle } logout={ logout } />
+					<LoggedIn siteId={ siteId } toggleTray={ handleTrayToggle } logout={ logout! } />
 				) : (
 					<LoggedOut
-						login={ login }
+						login={ login! }
 						canWeAccessCookies={ canWeAccessCookies() }
-						loginWindow={ loginWindowRef }
+						loginWindow={ loginWindowRef ?? null }
 					/>
 				) }
 			</div>

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/state.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/state.tsx
@@ -103,7 +103,7 @@ export function createSignals() {
 	const shouldStoreEmailData = signal( false );
 
 	//
-	const subscriptionSettings: Signal< SubscriptionDetails > = signal( undefined );
+	const subscriptionSettings: Signal< SubscriptionDetails | undefined > = signal( undefined );
 
 	/*
 	 * Store the comment parent which is updated by external scripts
@@ -114,7 +114,7 @@ export function createSignals() {
 	 * Store the subscription modal status calculated for the user.
 	 * Can be one of these values: 'showed', 'hidden_cookies_disabled', 'hidden_subscribe_not_enabled', 'hidden_views_limit' and 'hidden_already_subscribed'.
 	 */
-	const subscribeModalStatus = signal( undefined );
+	const subscribeModalStatus: Signal< string | undefined > = signal( undefined );
 
 	return {
 		userInfo,

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/types.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/types.tsx
@@ -15,9 +15,9 @@ export interface UserInfo {
 
 export interface SubscriptionDetails {
 	email: {
-		send_posts: boolean;
-		send_comments: boolean;
-		post_delivery_frequency: string;
+		send_posts?: boolean;
+		send_comments?: boolean;
+		post_delivery_frequency?: string;
 	};
 	notification?: {
 		send_posts: boolean;
@@ -91,8 +91,8 @@ export interface SimpleSubscribeModalProps {
 	closeModalHandler: () => void;
 	email: string;
 	subscribeState?: string;
-	setSubscribeState?: ( boolean ) => void;
-	setHasIframe?: ( boolean ) => void;
+	setSubscribeState?: ( value: 'SUBSCRIBING' | 'LOADING' | 'SUBSCRIBED' ) => void;
+	setHasIframe?: ( value: boolean ) => void;
 }
 
 export type MailLoginData = {

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/utils.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/utils.ts
@@ -190,9 +190,9 @@ export const setUserInfoCookie = ( userData: UserInfo ) => {
 		} ),
 		...( userData?.uid && { uid: userData.uid.toString() } ),
 		...( userData?.url && { url: encodeURIComponent( userData.url ) } ),
-	} ).toString();
+	} as Record< string, string > ).toString();
 
-	document.cookie = `${ cookieName }=${ cookieData }; path=/; SameSite=None; Secure=True;${ addWordPressDomain }`;
+	document.cookie = `${ cookieName! }=${ cookieData }; path=/; SameSite=None; Secure=True;${ addWordPressDomain }`;
 };
 
 /**
@@ -217,12 +217,14 @@ export const getUserInfoCookie = () => {
 			}
 
 			const data = cookie.slice( 8 );
-			userData = data && {
-				service: serviceName,
-				...Object.fromEntries( new URLSearchParams( decodeURIComponent( data ) ) ),
-			};
+			if ( data ) {
+				userData = {
+					service: serviceName,
+					...Object.fromEntries( new URLSearchParams( decodeURIComponent( data ) ) ),
+				};
+			}
 
-			if ( serviceName === 'wordpress' ) {
+			if ( serviceName === 'wordpress' && userData.avatar ) {
 				const avatarUrl = new URL( userData.avatar );
 				userData.avatar = avatarUrl.origin + avatarUrl.pathname + '?s=64';
 			}


### PR DESCRIPTION
Fixes MONOREP-380

## Proposed changes:

- Fix ~80 TypeScript type errors in the `verbum-comments` feature for tsgo compatibility
- Add proper type annotations for event handlers, refs, component props, and signal types
- Add null/undefined guards for optional properties throughout
- Make `SubscriptionDetails.email` fields optional to match runtime data shape

## Does this pull request change what data or activity we track or use?

No

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:

- Run `pnpm typecheck` in `projects/packages/jetpack-mu-wpcom` and verify it passes with no errors

## Changelog

- [x] Generate changelog entries for this PR (using AI).
