### PR TITLE
tsgo: Fix packages/my-jetpack type errors

### DIFF
--- a/projects/js-packages/connection/changelog/update-tsgo-fix-my-jetpack-type-errors
+++ b/projects/js-packages/connection/changelog/update-tsgo-fix-my-jetpack-type-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix TS errors detected by tsgo.

--- a/projects/js-packages/connection/components/connection-error-notice/index.tsx
+++ b/projects/js-packages/connection/components/connection-error-notice/index.tsx
@@ -3,22 +3,15 @@ import { Icon, Notice, Path, SVG } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import styles from './styles.module.scss';
+import type { ConnectionErrorNoticeProps } from './types';
 
-/**
- * The RNA Connection Error Notice component.
- *
- * @param {object} props -- The properties.
- * @return {import('react').Component} The `ConnectionErrorNotice` component.
- */
-const ConnectionErrorNotice = props => {
-	const {
-		message,
-		isRestoringConnection,
-		restoreConnectionCallback,
-		restoreConnectionError,
-		actions = [], // New prop for custom actions
-	} = props;
-
+const ConnectionErrorNotice = ( {
+	message,
+	isRestoringConnection,
+	restoreConnectionCallback,
+	restoreConnectionError,
+	actions = [],
+}: ConnectionErrorNoticeProps ) => {
 	const wrapperClassName = styles.notice;
 
 	const icon = (

--- a/projects/js-packages/connection/components/connection-error-notice/types.ts
+++ b/projects/js-packages/connection/components/connection-error-notice/types.ts
@@ -1,0 +1,17 @@
+import type { ReactElement } from 'react';
+
+export interface ActionItem {
+	label: string;
+	onClick: () => void;
+	isLoading?: boolean;
+	loadingText?: string;
+	variant?: 'primary' | 'secondary';
+}
+
+export interface ConnectionErrorNoticeProps {
+	message: string | ReactElement;
+	restoreConnectionCallback?: ( () => void ) | null;
+	isRestoringConnection?: boolean;
+	restoreConnectionError?: string | null;
+	actions?: ActionItem[];
+}

--- a/projects/js-packages/connection/components/manage-connection-dialog/index.jsx
+++ b/projects/js-packages/connection/components/manage-connection-dialog/index.jsx
@@ -15,7 +15,7 @@ import { useCallback, useEffect, useState, useMemo } from 'react';
 /**
  * Internal dependencies
  */
-import ConnectionErrorNotice from '../connection-error-notice/index.jsx';
+import ConnectionErrorNotice from '../connection-error-notice';
 import DisconnectDialog from '../disconnect-dialog';
 import OwnerDisconnectDialog from '../owner-disconnect-dialog';
 import './style.scss';

--- a/projects/js-packages/connection/hooks/use-connection-error-notice/index.tsx
+++ b/projects/js-packages/connection/hooks/use-connection-error-notice/index.tsx
@@ -1,7 +1,17 @@
 import { __ } from '@wordpress/i18n';
 import ConnectionErrorNotice from '../../components/connection-error-notice';
 import useConnection from '../../components/use-connection';
-import useRestoreConnection from '../../hooks/use-restore-connection/index.jsx';
+import useRestoreConnection from '../../hooks/use-restore-connection';
+import type {
+	Action,
+	ConnectionErrorData,
+	ConnectionErrorMap,
+	ConnectionErrorObject,
+	ConnectionErrorProps,
+} from './types';
+import type { ReactElement } from 'react';
+
+export type { ConnectionErrorData, ConnectionErrorMap, ConnectionErrorObject } from './types';
 
 /**
  * Connection error notice hook.
@@ -12,13 +22,15 @@ import useRestoreConnection from '../../hooks/use-restore-connection/index.jsx';
  */
 export default function useConnectionErrorNotice() {
 	const { connectionErrors } = useConnection( {} );
-	const connectionErrorList = Object.values( connectionErrors ).shift();
-	const firstError =
-		connectionErrorList &&
-		Object.values( connectionErrorList ).length &&
-		Object.values( connectionErrorList ).shift();
+	// connectionErrors is typed as Array<string|object> but is actually a nested object at runtime.
+	const errorMap = connectionErrors as unknown as ConnectionErrorMap;
+	const connectionErrorList = Object.values( errorMap ).shift();
+	const firstError: ConnectionErrorObject | undefined =
+		connectionErrorList && Object.values( connectionErrorList ).length
+			? Object.values( connectionErrorList ).shift()
+			: undefined;
 
-	const connectionErrorMessage = firstError && firstError.error_message;
+	const connectionErrorMessage = firstError?.error_message;
 
 	// Return all connection errors
 	const hasConnectionError = Boolean( connectionErrorMessage );
@@ -27,15 +39,15 @@ export default function useConnectionErrorNotice() {
 		hasConnectionError,
 		connectionErrorMessage,
 		connectionError: firstError, // Full error object with error_type, etc.
-		connectionErrors, // All errors for advanced use cases
+		connectionErrors: errorMap, // All errors for advanced use cases
 	};
 }
 
 export const ConnectionError = ( {
-	actionHandlers = {}, // Handlers for specific actions like { create_missing_account: () => {}, custom_action: () => {} }
-	trackingCallback = null, // Custom tracking function
-	customActions = null, // Function that returns custom actions based on error (takes precedence)
-} = {} ) => {
+	actionHandlers = {},
+	trackingCallback = null,
+	customActions = null,
+}: ConnectionErrorProps = {} ): ReactElement | null => {
 	const { hasConnectionError, connectionErrorMessage, connectionError } =
 		useConnectionErrorNotice();
 	const { restoreConnection, isRestoringConnection, restoreConnectionError } =
@@ -46,21 +58,24 @@ export const ConnectionError = ( {
 	}
 
 	// Build actions array based on error data
-	let actions = [];
+	let actions: Action[] = [];
 
 	if ( customActions ) {
 		// Use provided custom actions function
 		try {
-			actions = customActions( connectionError, { restoreConnection, isRestoringConnection } );
+			actions = customActions( connectionError as ConnectionErrorObject, {
+				restoreConnection,
+				isRestoringConnection,
+			} );
 		} catch {
 			// Silently fall back to default behavior if customActions fails
 			actions = [];
 		}
 	} else {
 		// Get action info from error data
-		const errorData = connectionError?.error_data || {};
+		const errorData = connectionError?.error_data || ( {} as ConnectionErrorData );
 		const suggestedAction = errorData.action;
-		const actionHandler = actionHandlers[ suggestedAction ];
+		const actionHandler = suggestedAction ? actionHandlers[ suggestedAction ] : undefined;
 
 		if ( suggestedAction && actionHandler ) {
 			// Use action data from the error
@@ -76,7 +91,7 @@ export const ConnectionError = ( {
 							if ( trackingCallback && trackingEvent ) {
 								trackingCallback( trackingEvent, {} );
 							}
-							actionHandler( connectionError );
+							actionHandler( connectionError as ConnectionErrorObject );
 						} catch {
 							// Silently fail if action handler throws
 						}
@@ -98,7 +113,7 @@ export const ConnectionError = ( {
 							if ( trackingCallback && trackingEvent ) {
 								trackingCallback( trackingEvent, {} );
 							}
-							window.location.href = errorData.action_url;
+							window.location.href = errorData.action_url as string;
 						} catch {
 							// Silently fail if navigation throws
 						}
@@ -130,7 +145,9 @@ export const ConnectionError = ( {
 		// Add secondary action if available (only for custom errors, not default restore)
 		if ( actions.length > 0 && ( suggestedAction || errorData.action_url ) ) {
 			const secondaryAction = errorData.secondary_action;
-			const secondaryActionHandler = actionHandlers[ secondaryAction ];
+			const secondaryActionHandler = secondaryAction
+				? actionHandlers[ secondaryAction ]
+				: undefined;
 			const secondaryActionUrl = errorData.secondary_action_url;
 			const secondaryActionLabel = errorData.secondary_action_label;
 
@@ -146,7 +163,7 @@ export const ConnectionError = ( {
 							if ( trackingCallback && secondaryTrackingEvent ) {
 								trackingCallback( secondaryTrackingEvent, {} );
 							}
-							secondaryActionHandler( connectionError );
+							secondaryActionHandler( connectionError as ConnectionErrorObject );
 						} catch {
 							// Silently fail if secondary action handler throws
 						}
@@ -186,7 +203,7 @@ export const ConnectionError = ( {
 		<ConnectionErrorNotice
 			isRestoringConnection={ isRestoringConnection }
 			restoreConnectionError={ restoreConnectionError }
-			restoreConnectionCallback={ actions.length === 0 ? restoreConnection : null } // Fallback for backward compatibility
+			restoreConnectionCallback={ actions.length === 0 ? restoreConnection : null }
 			message={ connectionErrorMessage }
 			actions={ actions }
 		/>

--- a/projects/js-packages/connection/hooks/use-connection-error-notice/types.ts
+++ b/projects/js-packages/connection/hooks/use-connection-error-notice/types.ts
@@ -1,0 +1,49 @@
+export interface ConnectionErrorData {
+	action?: string;
+	action_label?: string;
+	action_variant?: 'primary' | 'secondary';
+	action_url?: string;
+	tracking_event?: string;
+	secondary_action?: string;
+	secondary_action_url?: string;
+	secondary_action_label?: string;
+	secondary_action_variant?: 'primary' | 'secondary';
+	secondary_tracking_event?: string;
+	[ key: string ]: unknown;
+}
+
+export interface ConnectionErrorObject {
+	error_message: string;
+	error_code?: string;
+	user_id?: string;
+	error_type?: string;
+	error_data?: ConnectionErrorData;
+	[ key: string ]: unknown;
+}
+
+/**
+ * The shape of connectionErrors from the store: a nested object keyed by error code, then user ID.
+ */
+export type ConnectionErrorMap = Record< string, Record< string, ConnectionErrorObject > >;
+
+export interface Action {
+	label: string;
+	onClick: () => void;
+	isLoading?: boolean;
+	loadingText?: string;
+	variant?: 'primary' | 'secondary';
+}
+
+export interface ConnectionErrorProps {
+	actionHandlers?: Record< string, ( error: ConnectionErrorObject ) => void >;
+	trackingCallback?: ( ( event: string, data: object ) => void ) | null;
+	customActions?:
+		| ( (
+				error: ConnectionErrorObject,
+				helpers: {
+					restoreConnection: () => void;
+					isRestoringConnection: boolean;
+				}
+		  ) => Action[] )
+		| null;
+}

--- a/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.tsx
+++ b/projects/js-packages/connection/hooks/use-product-checkout-workflow/index.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState, useMemo } from 'react';
 import { getCalypsoOrigin } from '@automattic/jetpack-connection';
 import useConnection from '../../components/use-connection';
 import { STORE_ID } from '../../state/store.jsx';
+import type { UseProductCheckoutWorkflowProps } from './types';
 
 const debug = debugFactory( 'jetpack:connection:useProductCheckoutWorkflow' );
 
@@ -16,35 +17,31 @@ const {
 	siteSuffix: defaultSiteSuffix,
 } = window?.JP_CONNECTION_INITIAL_STATE || getScriptData()?.connection || {};
 const defaultAdminUrl = () =>
-	typeof window !== 'undefined' ? window?.myJetpackInitialState?.adminUrl : null;
+	typeof window !== 'undefined'
+		? ( window as Window & { myJetpackInitialState?: { adminUrl?: string } } )
+				?.myJetpackInitialState?.adminUrl
+		: null;
 
 /**
  * Custom hook that performs the needed steps
  * to concrete the checkout workflow.
  *
- * @param {object}   props                                  - The props passed to the hook.
- * @param {string}   props.productSlug                      - The WordPress product slug.
- * @param {string}   props.redirectUrl                      - The URI to redirect to after checkout.
- * @param {string}   [props.siteSuffix]                     - The site suffix.
- * @param {string}   [props.adminUrl]                       - The site wp-admin url.
- * @param {boolean}  [props.connectAfterCheckout]           - Whether or not to conect after checkout if not connected (default false - connect before).
- * @param {Function} [props.siteProductAvailabilityHandler] - The function used to check whether the site already has the requested product. This will be checked after registration and the checkout page will be skipped if the promise returned resloves true.
- * @param {string}   props.from                             - The plugin slug initiated the flow.
- * @param {number}   [props.quantity]                       - The quantity of the product to purchase.
- * @param {boolean}  [props.useBlogIdSuffix]                - Use blog ID instead of site suffix in the checkout URL.
- * @return {object}                                      The useEffect hook.
+ * @param {UseProductCheckoutWorkflowProps} props - The checkout workflow properties.
+ * @return The checkout workflow hook data.
  */
-export default function useProductCheckoutWorkflow( {
-	productSlug,
-	redirectUrl,
-	siteSuffix = defaultSiteSuffix,
-	adminUrl = defaultAdminUrl(),
-	connectAfterCheckout = false,
-	siteProductAvailabilityHandler = null,
-	quantity = null,
-	from,
-	useBlogIdSuffix = false,
-} = {} ) {
+export default function useProductCheckoutWorkflow(
+	{
+		productSlug,
+		redirectUrl,
+		siteSuffix = defaultSiteSuffix,
+		adminUrl = defaultAdminUrl(),
+		connectAfterCheckout = false,
+		siteProductAvailabilityHandler = null,
+		quantity = null,
+		from,
+		useBlogIdSuffix = false,
+	}: UseProductCheckoutWorkflowProps = {} as UseProductCheckoutWorkflowProps
+) {
 	debug( 'productSlug is %s', productSlug );
 	debug( 'redirectUrl is %s', redirectUrl );
 	debug( 'siteSuffix is %s', siteSuffix );
@@ -52,7 +49,10 @@ export default function useProductCheckoutWorkflow( {
 	const [ hasCheckoutStarted, setCheckoutStarted ] = useState( false );
 	const { registerSite } = useDispatch( STORE_ID );
 
-	const blogID = useSelect( select => select( STORE_ID ).getBlogId(), [] );
+	const blogID = useSelect(
+		select => ( select( STORE_ID ) as { getBlogId: () => string } ).getBlogId(),
+		[]
+	);
 	debug( 'blogID is %s', blogID ?? 'undefined' );
 
 	useBlogIdSuffix = useBlogIdSuffix && !! blogID;
@@ -78,7 +78,7 @@ export default function useProductCheckoutWorkflow( {
 		);
 
 		if ( shouldConnectAfterCheckout ) {
-			productCheckoutUrl.searchParams.set( 'connect_after_checkout', true );
+			productCheckoutUrl.searchParams.set( 'connect_after_checkout', 'true' );
 			productCheckoutUrl.searchParams.set( 'admin_url', adminUrl );
 			/**
 			 * `from_site_slug` is the Jetpack site slug (siteSuffix) passed 'from the site' via url
@@ -135,7 +135,7 @@ export default function useProductCheckoutWorkflow( {
 				'handleAfterRegistration: Site does not have a product associated. Redirecting to checkout %s',
 				checkoutUrl
 			);
-			window.location.href = checkoutUrl;
+			window.location.href = checkoutUrl.toString();
 		} );
 	};
 
@@ -146,17 +146,18 @@ export default function useProductCheckoutWorkflow( {
 
 		debug( 'Redirecting to connectAfterCheckout flow: %s', checkoutUrl );
 
-		window.location.href = checkoutUrl;
+		window.location.href = checkoutUrl.toString();
 	};
 
 	/**
 	 * Handler to run the checkout workflow.
 	 *
-	 * @param {Event}  [event]  - Event that dispatched run
-	 * @param {string} redirect - A possible redirect URL to go to after the checkout
-	 * @return {void}          Nothing.
+	 * @param {object}   [event]              - Event that dispatched run.
+	 * @param {Function} event.preventDefault - Prevents the default event behavior.
+	 * @param {string}   redirect             - A possible redirect URL to go to after the checkout.
+	 * @return {void} Nothing.
 	 */
-	const run = ( event, redirect = null ) => {
+	const run = ( event?: { preventDefault: () => void }, redirect: string | null = null ) => {
 		event && event.preventDefault();
 		setCheckoutStarted( true );
 		// By default we will connect first prior to checkout unless `props.connectAfterCheckout`

--- a/projects/js-packages/connection/hooks/use-product-checkout-workflow/types.ts
+++ b/projects/js-packages/connection/hooks/use-product-checkout-workflow/types.ts
@@ -1,0 +1,20 @@
+export interface UseProductCheckoutWorkflowProps {
+	/** The WordPress product slug. */
+	productSlug: string;
+	/** The URI to redirect to after checkout. */
+	redirectUrl: string;
+	/** The site suffix. */
+	siteSuffix?: string;
+	/** The site wp-admin url. */
+	adminUrl?: string;
+	/** Whether or not to connect after checkout if not connected (default false - connect before). */
+	connectAfterCheckout?: boolean;
+	/** The function used to check whether the site already has the requested product. This will be checked after registration and the checkout page will be skipped if the promise returned resolves true. */
+	siteProductAvailabilityHandler?: ( () => Promise< boolean > | boolean ) | null;
+	/** The plugin slug that initiated the flow. */
+	from: string;
+	/** The quantity of the product to purchase. */
+	quantity?: number | null;
+	/** Use blog ID instead of site suffix in the checkout URL. */
+	useBlogIdSuffix?: boolean;
+}

--- a/projects/js-packages/connection/hooks/use-restore-connection/index.tsx
+++ b/projects/js-packages/connection/hooks/use-restore-connection/index.tsx
@@ -8,6 +8,11 @@ import { STORE_ID } from '../../state/store';
 const { apiRoot, apiNonce } =
 	window?.JP_CONNECTION_INITIAL_STATE || getScriptData()?.connection || {};
 
+interface ConnectionStoreDispatch {
+	disconnectUserSuccess: () => void;
+	setConnectionErrors: ( errors: Record< string, unknown > ) => void;
+}
+
 /**
  * Restore connection hook.
  * It will initiate an API request attempting to restore the connection, or reconnect if it cannot be restored.
@@ -16,9 +21,11 @@ const { apiRoot, apiNonce } =
  */
 export default function useRestoreConnection() {
 	const [ isRestoringConnection, setIsRestoringConnection ] = useState( false );
-	const [ restoreConnectionError, setRestoreConnectionError ] = useState( null );
+	const [ restoreConnectionError, setRestoreConnectionError ] = useState< string | null >( null );
 
-	const { disconnectUserSuccess, setConnectionErrors } = useDispatch( STORE_ID );
+	const { disconnectUserSuccess, setConnectionErrors } = useDispatch(
+		STORE_ID
+	) as ConnectionStoreDispatch;
 
 	const USER_CONNECTION_URL = getUserConnectionUrl();
 
@@ -34,7 +41,7 @@ export default function useRestoreConnection() {
 
 		return restApi
 			.reconnect()
-			.then( connectionStatusData => {
+			.then( ( connectionStatusData: { status: string } ) => {
 				// status 'in_progress' means the user needs to re-connect their WP.com account.
 				if ( 'in_progress' === connectionStatusData.status ) {
 					disconnectUserSuccess();
@@ -48,7 +55,7 @@ export default function useRestoreConnection() {
 
 				return connectionStatusData;
 			} )
-			.catch( error => {
+			.catch( ( error: string ) => {
 				setRestoreConnectionError( error );
 				setIsRestoringConnection( false );
 

--- a/projects/js-packages/licensing/changelog/update-tsgo-fix-my-jetpack-type-errors
+++ b/projects/js-packages/licensing/changelog/update-tsgo-fix-my-jetpack-type-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix TS errors detected by tsgo.

--- a/projects/js-packages/licensing/components/golden-token-modal/index.jsx
+++ b/projects/js-packages/licensing/components/golden-token-modal/index.jsx
@@ -23,7 +23,7 @@ const onModalCloseDefault = event => {
  *
  * @param {object}   props                - Component props.
  * @param {Function} [props.redeemClick]  - Callback function to handle redeem click.
- * @param {object}   props.displayName    - Connected user data.
+ * @param {string}   props.displayName    - Connected user display name.
  * @param {Function} [props.onModalClose] - Callback function to handle module closure.
  * @param {boolean}  props.tokenRedeemed  - If their token is already redeemed.
  * @return {import('react').ReactNode} - GoldenToken component.

--- a/projects/packages/my-jetpack/_inc/components/a4a-banner/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/a4a-banner/index.tsx
@@ -9,7 +9,7 @@ import icon from './icon.svg';
  *
  * @param {object}  props                 - Component props.
  * @param {boolean} props.isAgencyAccount - Whether users account is an Agency account or not.
- * @return {object} The rendered component.
+ * @return The rendered component.
  */
 const A4ABanner = props => {
 	const { isAgencyAccount = false } = props;

--- a/projects/packages/my-jetpack/_inc/components/connections-section/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connections-section/index.tsx
@@ -1,19 +1,16 @@
 import { getUserConnectionUrl } from '@automattic/jetpack-connection';
-import { useCallback, useMemo } from 'react';
-import { useAllProducts } from '../../data/products/use-all-products';
+import { useCallback } from 'react';
 import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
-import getProductSlugsThatRequireUserConnection from '../../data/utils/get-product-slugs-that-require-user-connection';
 import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 import ConnectionStatusCard from '../connection-status-card';
 
 /**
  * Plan section component.
  *
- * @return {object} ConnectionsSection React component.
+ * @return ConnectionsSection React component.
  */
 export default function ConnectionsSection() {
 	const { apiRoot, apiNonce, topJetpackMenuItemUrl, connectedPlugins } = useMyJetpackConnection();
-	const { data: products, isLoading, isError } = useAllProducts();
 	const { adminUrl } = getMyJetpackWindowInitialState();
 
 	// Handle full site disconnection - redirect to admin
@@ -21,22 +18,14 @@ export default function ConnectionsSection() {
 		if ( adminUrl ) {
 			window.location.href = adminUrl;
 		} else {
-			document?.location?.reload( true );
+			document?.location?.reload();
 		}
 	};
 
 	// Handle user unlink only - stay in admin, just reload
 	const onUserUnlinked = () => {
-		document?.location?.reload( true );
+		document?.location?.reload();
 	};
-
-	const productsThatRequireUserConnection = useMemo( () => {
-		if ( isLoading || isError ) {
-			return [];
-		}
-
-		return getProductSlugsThatRequireUserConnection( products );
-	}, [ products, isLoading, isError ] );
 
 	const onConnectUser = useCallback( () => {
 		window.location.href = getUserConnectionUrl();
@@ -47,8 +36,7 @@ export default function ConnectionsSection() {
 			apiNonce={ apiNonce }
 			redirectUri={ topJetpackMenuItemUrl }
 			onConnectUser={ onConnectUser }
-			connectedPlugins={ connectedPlugins }
-			requiresUserConnection={ productsThatRequireUserConnection.length > 0 }
+			connectedPlugins={ connectedPlugins as { name: string; slug: string }[] }
 			// eslint-disable-next-line react/jsx-no-bind
 			onDisconnected={ onFullyDisconnected }
 			// eslint-disable-next-line react/jsx-no-bind

--- a/projects/packages/my-jetpack/_inc/components/go-back-link/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/go-back-link/index.tsx
@@ -2,16 +2,23 @@ import { __ } from '@wordpress/i18n';
 import { Icon, arrowLeft } from '@wordpress/icons';
 import { Link } from 'react-router';
 import styles from './styles.module.scss';
+import type { MouseEvent } from 'react';
 
 /**
- * Simple component that renders a go back link
+ * Go Back Link component.
  *
  * @param {object}   props         - Component props.
- * @param {Function} props.onClick - A callback to execute on click
- * @param {boolean}  props.reload  - Whether to reload the page after going back
- * @return {object}                 GoBackLink component.
+ * @param {Function} props.onClick - Optional click handler for the link.
+ * @param {boolean}  props.reload  - Whether the link should trigger a reload when clicked.
+ * @return The rendered component.
  */
-function GoBackLink( { onClick = () => {}, reload } ) {
+function GoBackLink( {
+	onClick,
+	reload,
+}: {
+	onClick?: ( event: MouseEvent ) => void;
+	reload: boolean;
+} ) {
 	const to = reload ? '/?reload=true' : '/';
 
 	return (

--- a/projects/packages/my-jetpack/_inc/components/golden-token/tooltip/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/golden-token/tooltip/index.tsx
@@ -14,25 +14,29 @@ import './style.global.scss';
  * We created this one because <IconTooltip> is (at the time of writing)
  * hardcoded to only support Grid icons, and we're on a rather tight deadline.
  *
- * @param {object} props             - Component properties.
- * @param {string} props.productName - A product/plan name.
- * @param {string} props.giftedDate  - The date the product/plan was gifted.
- * @return {object} - A Golden Token Tooltip.
+ * @param {{productName: string;giftedDate: string}} props - Component properties.
+ * @return A Golden Token Tooltip.
  */
-export function GoldenTokenTooltip( { productName, giftedDate } ) {
+export function GoldenTokenTooltip( {
+	productName,
+	giftedDate,
+}: {
+	productName: string;
+	giftedDate: string;
+} ) {
 	const [ isVisible, setIsVisible ] = useState( false );
 	const showTooltip = useCallback( () => setIsVisible( true ), [ setIsVisible ] );
 	const hideTooltip = useCallback( () => setIsVisible( false ), [ setIsVisible ] );
 
 	const popoverArgs = {
-		position: 'top center',
-		placement: 'top',
+		position: 'top center' as const,
+		placement: 'top' as const,
 		animate: true,
 		noArrow: false,
 		resize: false,
 		flip: false,
 		offset: 6, // The distance (in px) between the anchor and the popover.
-		focusOnMount: 'container',
+		focusOnMount: 'firstElement' as const,
 		onClose: hideTooltip,
 		className: styles.container,
 	};

--- a/projects/packages/my-jetpack/changelog/update-tsgo-fix-my-jetpack-type-errors
+++ b/projects/packages/my-jetpack/changelog/update-tsgo-fix-my-jetpack-type-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix TS errors detected by tsgo.

--- a/projects/plugins/protect/changelog/update-tsgo-fix-my-jetpack-type-errors
+++ b/projects/plugins/protect/changelog/update-tsgo-fix-my-jetpack-type-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix TS type errors detected by tsgo.

--- a/projects/plugins/protect/src/js/api.ts
+++ b/projects/plugins/protect/src/js/api.ts
@@ -17,8 +17,8 @@ const API = {
 			path: 'jetpack-protect/v1/toggle-account-protection',
 		} ),
 
-	getWaf: (): Promise< WafStatus > =>
-		apiFetch( {
+	getWaf: () =>
+		apiFetch< WafStatus >( {
 			path: 'jetpack-protect/v1/waf',
 			method: 'GET',
 		} ).then( camelize ),
@@ -61,8 +61,8 @@ const API = {
 			data: { step_ids: stepIds },
 		} ),
 
-	getScanHistory: (): Promise< ScanStatus | false > =>
-		apiFetch( {
+	getScanHistory: () =>
+		apiFetch< ScanStatus | false >( {
 			path: 'jetpack-protect/v1/scan-history',
 			method: 'GET',
 		} ).then( camelize ),
@@ -73,8 +73,8 @@ const API = {
 			method: 'POST',
 		} ),
 
-	getScanStatus: (): Promise< ScanStatus > =>
-		apiFetch( {
+	getScanStatus: () =>
+		apiFetch< ScanStatus >( {
 			path: 'jetpack-protect/v1/status?hard_refresh=true',
 			method: 'GET',
 		} ).then( camelize ),
@@ -110,24 +110,22 @@ const API = {
 		} ),
 
 	checkCredentials: () =>
-		apiFetch( {
+		apiFetch< [ Record< string, unknown > ] >( {
 			path: 'jetpack-protect/v1/check-credentials',
 			method: 'POST',
-		} ) as Promise< [ Record< string, unknown > ] >,
+		} ),
 
 	checkPlan: () =>
-		apiFetch( {
+		apiFetch< boolean >( {
 			path: 'jetpack-protect/v1/check-plan',
 			method: 'GET',
 		} ),
 
 	getProductData: () =>
-		(
-			apiFetch( {
-				path: '/my-jetpack/v1/site/products?products=scan',
-				method: 'GET',
-			} ) as Promise< { [ key: string ]: ProductData } >
-		 ).then( products => camelize( products?.scan ) ),
+		apiFetch< { [ key: string ]: ProductData } >( {
+			path: '/my-jetpack/v1/site/products?products=scan',
+			method: 'GET',
+		} ).then( products => camelize( products?.scan ) ),
 };
 
 export default API;


### PR DESCRIPTION
Fixes MONOREP-381

## Proposed changes:
* Convert several JSX/JS files in `js-packages/connection` and `packages/my-jetpack` to TypeScript to fix `tsgo` type errors.
* Add co-located `types.ts` files for `ConnectionErrorNotice`, `useConnectionErrorNotice`, and `useProductCheckoutWorkflow`.
* Fix minor bugs uncovered during conversion: deprecated `reload(true)` argument, incorrect JSDoc types, `URL` object assigned to `string`, and `boolean` passed to `searchParams.set`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

* Run `pnpm typecheck` in `projects/packages/my-jetpack` — should pass with zero errors.
* Run `pnpm typecheck` in `projects/js-packages/connection` — should pass with zero errors.
* Verify My Jetpack dashboard loads and connection error notices still render correctly.

## Changelog

- [ ] Generate changelog entries for this PR (using AI).
