### PR TITLE
Form Editor: Auto-open the block inserter on load

### DIFF
--- a/projects/packages/forms/changelog/add-forms-auto-open-inserter
+++ b/projects/packages/forms/changelog/add-forms-auto-open-inserter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Form Editor: Auto-open the block inserter on load so form field blocks are immediately discoverable.

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -122,6 +122,7 @@ const state = {
 	lastRootBlockIds: '',
 	lastSelectedBlockId: null as string | null | undefined,
 	isFormBlockLocked: false,
+	hasOpenedInserter: false,
 };
 
 const BLOCK_DIRECTORY_PLUGIN_NAME = 'block-directory';
@@ -223,6 +224,16 @@ const enforceBlockSelection = () => {
 	if ( hasMultiSelection() ) {
 		return;
 	}
+
+	// Don't force-select when the inserter is open — selecting a block
+	// can close the inserter or change its context.
+	const { isInserterOpened } = select( 'core/editor' ) as {
+		isInserterOpened: () => boolean;
+	};
+	if ( isInserterOpened() ) {
+		return;
+	}
+
 	const selectedBlockId = getSelectedBlockClientId();
 	if ( ! selectedBlockId ) {
 		const { selectBlock } = dispatch( 'core/block-editor' ) as {
@@ -406,6 +417,7 @@ const setupFormEditorSubscription = () => {
 					state.lastRootBlockIds = '';
 					state.lastSelectedBlockId = null;
 					state.isFormBlockLocked = false;
+					state.hasOpenedInserter = false;
 				}
 			}
 
@@ -469,7 +481,47 @@ const setupFormEditorSubscription = () => {
 				enforceBlockNesting();
 			}
 
-			// 5. React to selection changes
+			// 5. Auto-open the block inserter (once) after blocks are ready
+			if ( ! state.hasOpenedInserter && state.formBlockClientId ) {
+				const { getBlock: getBlockForInserter } = select( 'core/block-editor' );
+				const currentFormBlock = getBlockForInserter( state.formBlockClientId );
+				const hasAnyInnerBlocks = currentFormBlock && currentFormBlock.innerBlocks.length > 0;
+
+				if ( hasAnyInnerBlocks ) {
+					state.hasOpenedInserter = true;
+
+					// Skip on mobile — inserter takes over the full screen.
+					const isDesktop = window.innerWidth >= 782;
+
+					// Skip if user prefers the list view sidebar (same slot).
+					const showListView = (
+						select( 'core/preferences' ) as {
+							get: ( scope: string, name: string ) => boolean;
+						}
+					 ).get( 'core', 'showListViewByDefault' );
+
+					// Skip in distraction-free mode — Gutenberg hides the inserter.
+					const distractionFree = (
+						select( 'core/preferences' ) as {
+							get: ( scope: string, name: string ) => boolean;
+						}
+					 ).get( 'core', 'distractionFree' );
+
+					if ( isDesktop && ! showListView && ! distractionFree ) {
+						requestAnimationFrame( () => {
+							if ( ! state.isFormEditor ) {
+								return;
+							}
+							const { setIsInserterOpened } = dispatch( 'core/editor' ) as {
+								setIsInserterOpened: ( isOpened: boolean ) => void;
+							};
+							setIsInserterOpened( true );
+						} );
+					}
+				}
+			}
+
+			// 6. React to selection changes
 			const { getSelectedBlockClientId } = select( 'core/block-editor' );
 			const currentSelectedBlockId = getSelectedBlockClientId();
 			if ( currentSelectedBlockId !== state.lastSelectedBlockId ) {
@@ -477,7 +529,7 @@ const setupFormEditorSubscription = () => {
 				enforceBlockSelection();
 			}
 
-			// 6. Ensure form block is locked
+			// 7. Ensure form block is locked
 			if ( ! state.isFormBlockLocked && state.formBlockClientId ) {
 				lockFormBlock();
 				const { getBlock } = select( 'core/block-editor' );

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -36,6 +36,7 @@ import {
 	unregisterFormCategories,
 } from './utils/category-utils';
 import { getAllowedBlocks } from './utils/get-allowed-blocks';
+import { shouldAutoOpenInserter } from './utils/inserter-utils';
 import type { WPPlugin } from '@wordpress/plugins';
 
 type PluginSettings = Omit< WPPlugin, 'name' >;
@@ -343,6 +344,7 @@ const enforceBlockNesting = () => {
 
 let unsubscribe: ( () => void ) | null = null;
 let requestAnimationFrameId: number | null = null;
+let inserterAnimationFrameId: number | null = null;
 
 /**
  * Sets up a subscription to monitor editor state changes and enforce form editor behavior.
@@ -411,6 +413,10 @@ const setupFormEditorSubscription = () => {
 					if ( requestAnimationFrameId ) {
 						cancelAnimationFrame( requestAnimationFrameId );
 						requestAnimationFrameId = null;
+					}
+					if ( inserterAnimationFrameId ) {
+						cancelAnimationFrame( inserterAnimationFrameId );
+						inserterAnimationFrameId = null;
 					}
 
 					state.formBlockClientId = null;
@@ -483,32 +489,25 @@ const setupFormEditorSubscription = () => {
 
 			// 5. Auto-open the block inserter (once) after blocks are ready
 			if ( ! state.hasOpenedInserter && state.formBlockClientId ) {
-				const { getBlock: getBlockForInserter } = select( 'core/block-editor' );
-				const currentFormBlock = getBlockForInserter( state.formBlockClientId );
+				const currentFormBlock = select( 'core/block-editor' ).getBlock( state.formBlockClientId );
 				const hasAnyInnerBlocks = currentFormBlock && currentFormBlock.innerBlocks.length > 0;
 
 				if ( hasAnyInnerBlocks ) {
 					state.hasOpenedInserter = true;
 
-					// Skip on mobile — inserter takes over the full screen.
-					const isDesktop = window.innerWidth >= 782;
+					const { get: getPreference } = select( 'core/preferences' ) as {
+						get: ( scope: string, name: string ) => boolean;
+					};
 
-					// Skip if user prefers the list view sidebar (same slot).
-					const showListView = (
-						select( 'core/preferences' ) as {
-							get: ( scope: string, name: string ) => boolean;
-						}
-					 ).get( 'core', 'showListViewByDefault' );
-
-					// Skip in distraction-free mode — Gutenberg hides the inserter.
-					const distractionFree = (
-						select( 'core/preferences' ) as {
-							get: ( scope: string, name: string ) => boolean;
-						}
-					 ).get( 'core', 'distractionFree' );
-
-					if ( isDesktop && ! showListView && ! distractionFree ) {
-						requestAnimationFrame( () => {
+					if (
+						shouldAutoOpenInserter( {
+							viewportWidth: window.innerWidth,
+							showListViewByDefault: getPreference( 'core', 'showListViewByDefault' ),
+							distractionFree: getPreference( 'core', 'distractionFree' ),
+						} )
+					) {
+						inserterAnimationFrameId = requestAnimationFrame( () => {
+							inserterAnimationFrameId = null;
 							if ( ! state.isFormEditor ) {
 								return;
 							}
@@ -557,6 +556,10 @@ const setupFormEditorSubscription = () => {
 		if ( requestAnimationFrameId ) {
 			cancelAnimationFrame( requestAnimationFrameId );
 			requestAnimationFrameId = null;
+		}
+		if ( inserterAnimationFrameId ) {
+			cancelAnimationFrame( inserterAnimationFrameId );
+			inserterAnimationFrameId = null;
 		}
 		window.removeEventListener( 'beforeunload', handleUnload );
 	};

--- a/projects/packages/forms/src/form-editor/utils/inserter-utils.ts
+++ b/projects/packages/forms/src/form-editor/utils/inserter-utils.ts
@@ -1,0 +1,43 @@
+/**
+ * Inserter utility functions
+ *
+ * Pure functions for determining inserter behavior with no side effects.
+ *
+ * @package
+ */
+
+export interface AutoOpenInserterContext {
+	/** The viewport width in pixels. */
+	viewportWidth: number;
+	/** Whether the user prefers the list view sidebar by default. */
+	showListViewByDefault: boolean;
+	/** Whether the user is in distraction-free mode. */
+	distractionFree: boolean;
+}
+
+const DESKTOP_MIN_WIDTH = 782;
+
+/**
+ * Determines whether the block inserter should be automatically opened.
+ *
+ * Returns false when the viewport is below 782px (mobile), the user
+ * prefers list view by default (same sidebar slot), or distraction-free
+ * mode is active (Gutenberg hides the inserter).
+ *
+ * @param context - Current editor environment context
+ * @return Whether the inserter should be auto-opened
+ */
+export function shouldAutoOpenInserter( context: AutoOpenInserterContext ): boolean {
+	if ( context.viewportWidth < DESKTOP_MIN_WIDTH ) {
+		return false;
+	}
+
+	if ( context.showListViewByDefault ) {
+		return false;
+	}
+
+	if ( context.distractionFree ) {
+		return false;
+	}
+	return true;
+}

--- a/projects/packages/forms/tests/js/form-editor/utils/inserter-utils.test.js
+++ b/projects/packages/forms/tests/js/form-editor/utils/inserter-utils.test.js
@@ -1,0 +1,68 @@
+/**
+ * Tests for inserter-utils
+ *
+ * These tests verify the pure function that determines whether
+ * the block inserter should be auto-opened in the form editor.
+ */
+
+import { shouldAutoOpenInserter } from '../../../../src/form-editor/utils/inserter-utils';
+
+describe( 'inserter-utils', () => {
+	describe( 'shouldAutoOpenInserter', () => {
+		const defaultContext = {
+			viewportWidth: 1024,
+			showListViewByDefault: false,
+			distractionFree: false,
+		};
+
+		test( 'returns true on desktop with no conflicting preferences', () => {
+			expect( shouldAutoOpenInserter( defaultContext ) ).toBe( true );
+		} );
+
+		test( 'returns false when viewport is below 782px', () => {
+			expect(
+				shouldAutoOpenInserter( {
+					...defaultContext,
+					viewportWidth: 781,
+				} )
+			).toBe( false );
+		} );
+
+		test( 'returns true when viewport is exactly 782px', () => {
+			expect(
+				shouldAutoOpenInserter( {
+					...defaultContext,
+					viewportWidth: 782,
+				} )
+			).toBe( true );
+		} );
+
+		test( 'returns false when showListViewByDefault is true', () => {
+			expect(
+				shouldAutoOpenInserter( {
+					...defaultContext,
+					showListViewByDefault: true,
+				} )
+			).toBe( false );
+		} );
+
+		test( 'returns false when distractionFree is true', () => {
+			expect(
+				shouldAutoOpenInserter( {
+					...defaultContext,
+					distractionFree: true,
+				} )
+			).toBe( false );
+		} );
+
+		test( 'returns false when all conditions prevent opening', () => {
+			expect(
+				shouldAutoOpenInserter( {
+					viewportWidth: 400,
+					showListViewByDefault: true,
+					distractionFree: true,
+				} )
+			).toBe( false );
+		} );
+	} );
+} );


### PR DESCRIPTION


https://github.com/user-attachments/assets/a86f9d40-2c67-4b1a-af9a-ea6cafe39d8f


https://github.com/user-attachments/assets/9aed47ec-0a7f-4ed1-95bd-908f224d0f86

Testing site: 


https://github.com/user-attachments/assets/4b5c9240-66d8-4f07-a786-1dc2f747631b


https://github.com/user-attachments/assets/84dce617-be69-42de-859e-0f2c775497b1



## Proposed changes:
* Auto-open the block inserter sidebar when entering the Jetpack Forms dedicated editor (`jetpack_form` post type), so form field blocks are immediately visible and discoverable — instead of requiring the user to find and click the inserter toggle.
* Add a guard in `enforceBlockSelection()` to prevent the block selection enforcer from fighting the open inserter.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- p2 shortlink if applicable -->

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

### 1. Desktop — existing form (inserter should open):
1. Go to wp-admin → **Forms** → edit an existing form that already has fields.
2. Wait for the editor to fully load.
3. **Expected:** The block inserter sidebar opens automatically. Form field blocks should appear at the top of the panel (via `PRIORITIZED_INSERTER_BLOCKS`).

### 2. Desktop — new form (inserter opens after variation pick):
1. Go to wp-admin → **Forms** → **Add New**.
2. The FormTitleModal appears — name the form, dismiss the modal, and pick a form variation (e.g. "Contact Form").
3. **Expected:** Once inner blocks appear, the inserter should auto-open.

### 3. Mobile viewport (inserter should NOT open):
1. Resize the browser window to less than 782px wide.
2. Open an existing form with fields.
3. **Expected:** The inserter does **not** auto-open (on mobile it takes over the full screen).

### 4. Form block in a regular post/page (inserter should NOT open):
1. Create or edit a regular post or page.
2. Add a Jetpack Form block.
3. **Expected:** The inserter does **not** auto-open — this feature only applies to the dedicated form editor.

### 5. User with "Always open list view" preference (inserter should NOT open):
1. In the editor, open Preferences → enable "Always open list view".
2. Open an existing form.
3. **Expected:** The inserter does **not** auto-open — list view and inserter share the same sidebar slot.

### 6. Distraction-free mode (inserter should NOT open):
1. Enable distraction-free mode in editor preferences.
2. Open an existing form.
3. **Expected:** The inserter does **not** auto-open — Gutenberg hides the inserter in this mode.

### 7. User manually closes inserter (should stay closed):
1. Open an existing form — inserter auto-opens.
2. Close the inserter manually (click the X or the toggle).
3. **Expected:** The inserter stays closed and does not re-open.

### 8. Verify enforceBlockSelection doesn't fight the inserter:
1. Open an existing form — inserter auto-opens.
2. Click inside the inserter panel (e.g. browse blocks, use search).
3. **Expected:** The inserter stays open and functional — no flickering or unexpected block selection changes.
