### PR TITLE
Charts: Trim AGENTS.md to non-discoverable facts

### DIFF
--- a/projects/js-packages/charts/AGENTS.md
+++ b/projects/js-packages/charts/AGENTS.md
@@ -1,42 +1,13 @@
 # AGENTS.md
 
-This file is the package-specific source of truth for AI coding agents working in `projects/js-packages/charts`.
-
-## Project Scope
-
-`@automattic/charts` is a React + TypeScript charting library used across Automattic products.
-
-Key implementation details agents usually miss:
-
-- Build system is `tsup`.
-- Package exports are explicit subpath exports in `package.json`.
-- Styling is primarily Sass-based CSS Modules (`*.module.scss`) compiled via tsup plugins.
-- The docs workflow uses paired Storybook docs files (`.docs.mdx` + `.api.mdx`).
-
 ## CRITICAL Rules
 
-- CRITICAL: Keep this file focused on package-specific facts and workflows that are hard to infer from code search.
-- CRITICAL: Do not invent behavior in docs. If unsure, verify implementation and stories first.
-- CRITICAL: Do not assume wildcard exports. Follow the explicit exports in `projects/js-packages/charts/package.json`.
+- Do not invent behavior in docs. If unsure, verify implementation and stories first.
+- Do not assume wildcard exports like `./*` or `./providers/*` — they don't exist. Check the explicit exports in `package.json`.
 
-## Commands
+## Changelog
 
-Run these from `projects/js-packages/charts` unless noted otherwise.
-
-```bash
-# Build + type safety
-pnpm run build
-pnpm run typecheck
-
-# Tests
-pnpm run test
-pnpm run test-coverage
-
-# Storybook (delegates to ../storybook)
-pnpm run storybook
-```
-
-Changelog command (run from monorepo root):
+Run from monorepo root:
 
 ```bash
 jp changelog add js-packages/charts -s patch -t changed -e "Charts: <user-facing change>."
@@ -44,93 +15,44 @@ jp changelog add js-packages/charts -s patch -t changed -e "Charts: <user-facing
 
 ## Architecture Decisions (Do Not "Fix" These)
 
-- Charts are built around composition patterns (for example, chart components with attached subcomponents).
-- Theme values and chart element styles flow through `GlobalChartsProvider` and related provider hooks.
-- Accessibility behavior (keyboard navigation, accessible tooltips) is part of chart behavior, not optional polish.
-- CSS Modules are intentionally used for scoped styles and stable local class handling.
-- Charts are responsive by default.
+- Accessibility behavior (keyboard navigation, accessible tooltips) is core chart behavior, not optional polish.
+- Charts are responsive by default — do not add external responsive wrappers that conflict with built-in sizing semantics.
 
 ## Documentation Workflow
 
-Before changing chart docs or stories, read:
-
-- `projects/js-packages/charts/docs/ai-documentation-guide.md`
-- `projects/js-packages/charts/docs/feature-documentation.mdx.template`
-- `projects/js-packages/charts/docs/feature-api-documentation.mdx.template`
-
-Docs standards:
-
-- For public chart/component docs, maintain the standard docs set when applicable:
-  - `[feature-name].stories.tsx`
-  - `[feature-name].docs.mdx` (usage, examples, behavior, accessibility)
-  - `[feature-name].api.mdx` (API reference only; no usage examples)
-- Some docs are intentionally guide-only or scope-specific (for example introduction, provider docs, or focused feature guides) and may not use the full triplet.
-- MUST keep props/types in docs aligned with implementation.
-- MUST include animation docs only when the component actually supports an `animation` prop.
-
-For docs-heavy tasks with many repeated steps, agents may use the optional skill:
-
-- `.agents/skills/charts-docs.md`
+- For docs tasks agents should use the skill at `.agents/skills/charts-docs.md`.
+- For public chart/component docs, maintain the standard set when applicable: `[feature-name].stories.tsx` + `.docs.mdx` + `.api.mdx`. Some docs are intentionally guide-only and skip the full triplet.
+- Only include animation docs when the component actually supports an `animation` prop.
 
 ## Conventions
-
-### Code and APIs
 
 - Preserve backward compatibility for existing public APIs unless a breaking change is explicitly requested.
 - Prefer extending existing chart components/patterns over introducing new surface area.
 - Reuse existing hooks/providers/utilities before adding new abstractions.
-
-### Styling
-
-- Follow existing CSS Module + Sass patterns.
-- Use existing chart theme integration patterns instead of ad-hoc color/style logic.
 - Avoid `!important` unless there is no viable alternative and the rationale is documented.
-
-### Testing
-
-- Use Jest + Testing Library patterns already present in this package.
-- Add focused behavioral tests for changed behavior (interaction, rendering state, accessibility behavior).
-- For behavior or UI changes, verify in Storybook using browser automation (browser MCP) against relevant stories/states, not only unit tests.
-- Avoid speculative tests for behavior not implemented in code.
-
-### PR and Changelog
-
-- Prefer charts-scoped PR titles consistent with current repo patterns (e.g. `Charts: ...`, `CHARTS-###: ...`).
-- Include a changelog entry for user-facing changes under `projects/js-packages/charts/changelog/`.
-- Include test steps and outcomes in PR descriptions.
-- Include visual evidence (screenshots/GIFs) for visible UI changes.
+- Add focused behavioral tests for changed behavior; avoid speculative tests for unimplemented behavior.
+- Verify behavior/UI changes in Storybook using browser automation, not only unit tests.
+- Include test steps and visual evidence (screenshots/GIFs) in PR descriptions for UI changes.
 
 ## Common Pitfalls
 
-- Claiming Rollup is used for charts builds.
-- Referring to wildcard exports like `./*` or `./providers/*` (which don't exist). Use explicit exports like `./providers` instead.
-- Updating `.docs.mdx` without the corresponding `.api.mdx` when API docs are affected.
-- Not checking CSF file references in `.docs.mdx` when changing or removing stories.
+- Claiming Rollup is used for builds (it's tsup).
 - Documenting props or behavior not present in stories and implementation.
 - Refactoring core composition/provider patterns as if they are accidental complexity.
-- Using ad-hoc flexbox layouts where established shared layout primitives/patterns (for example, `Stack`) should be preferred.
-- Accessing colors and styles directly from the `theme` rather than using `getElementStyles` from the `GlobalChartsProvider`.
 - Defining new chart prop interfaces that diverge from established base chart contracts (for example, not aligning with `BaseChartProps` when appropriate).
-- Implementing responsive wrappers that conflict with component sizing semantics (fixed-height charts, resize behavior, or aspect-ratio assumptions).
-- Adding stories that do not visibly demonstrate the documented behavior/props, or stories that render clipped due to container sizing.
-- Breaking MDX `<Source code={\`...\` } />` rendering by using malformed/flattened indentation inside multiline template literals; keep consistent indentation and formatting in code blocks so docs render correctly.
-- Tooltip styles/positioning that only work on default backgrounds or fail at chart edges (for example, shadows fading to opaque white instead of transparent).
+- Using ad-hoc flexbox layouts where established layout primitives (e.g. `Stack`) should be preferred.
+- Accessing colors/styles directly from `theme` rather than using `getElementStyles` from `GlobalChartsProvider`.
+- Responsive wrappers that conflict with component sizing semantics (fixed-height charts, resize behavior, aspect-ratio assumptions).
+- Stories that don't visibly demonstrate documented behavior/props, or render clipped due to container sizing.
+- Breaking MDX `<Source code={\`...\` } />` rendering by malformed/flattened indentation inside template literals.
+- Tooltip styles/positioning that only work on default backgrounds or fail at chart edges.
 - Using mock/placeholder series data in production code.
-- Introducing avoidable multi-pass data transformations in render paths when a single pass is sufficient.
-- Adding CSS layout/overflow workarounds without documenting why the workaround is needed.
+- Avoidable multi-pass data transformations in render paths when a single pass suffices.
+- CSS layout/overflow workarounds without documenting why they're needed.
 
 ## Definition of Done
 
-Before handing off, verify:
+- Behavior verified in Storybook and/or tests, not only by static checks.
+- Edits remain in package boundaries; avoid unrelated refactors.
 
-- Guidelines: changes follow this file, root monorepo guidance, and charts docs standards.
-- Build/tests: `pnpm run typecheck` and relevant tests pass for modified behavior.
-- Behavior verification: changed chart behavior is validated in Storybook and/or tests, not only by static checks.
-- Safe scope: edits remain in package boundaries and avoid unrelated refactors.
-
-## References
-
-- Root repo guidance: `AGENTS.md`
-- Package docs guide: `projects/js-packages/charts/docs/ai-documentation-guide.md`
-- Package readme: `projects/js-packages/charts/README.md`
-- Published Storybook docs: `https://automattic.github.io/jetpack-storybook/?path=/docs/js-packages-charts-library`
+Published Storybook: `https://automattic.github.io/jetpack-storybook/?path=/docs/js-packages-charts-library`

--- a/projects/js-packages/charts/AGENTS.md
+++ b/projects/js-packages/charts/AGENTS.md
@@ -1,5 +1,7 @@
 # AGENTS.md
 
+Package-specific guidance for AI agents working in `projects/js-packages/charts`.
+
 ## CRITICAL Rules
 
 - Do not invent behavior in docs. If unsure, verify implementation and stories first.
@@ -32,6 +34,7 @@ jp changelog add js-packages/charts -s patch -t changed -e "Charts: <user-facing
 - Avoid `!important` unless there is no viable alternative and the rationale is documented.
 - Add focused behavioral tests for changed behavior; avoid speculative tests for unimplemented behavior.
 - Verify behavior/UI changes in Storybook using browser automation, not only unit tests.
+- Prefer charts-scoped PR titles (e.g. `Charts: ...`, `CHARTS-###: ...`).
 - Include test steps and visual evidence (screenshots/GIFs) in PR descriptions for UI changes.
 
 ## Common Pitfalls
@@ -43,6 +46,8 @@ jp changelog add js-packages/charts -s patch -t changed -e "Charts: <user-facing
 - Using ad-hoc flexbox layouts where established layout primitives (e.g. `Stack`) should be preferred.
 - Accessing colors/styles directly from `theme` rather than using `getElementStyles` from `GlobalChartsProvider`.
 - Responsive wrappers that conflict with component sizing semantics (fixed-height charts, resize behavior, aspect-ratio assumptions).
+- Updating `.docs.mdx` without the corresponding `.api.mdx` when API docs are affected.
+- Not checking CSF file references in `.docs.mdx` when changing or removing stories.
 - Stories that don't visibly demonstrate documented behavior/props, or render clipped due to container sizing.
 - Breaking MDX `<Source code={\`...\` } />` rendering by malformed/flattened indentation inside template literals.
 - Tooltip styles/positioning that only work on default backgrounds or fail at chart edges.

--- a/projects/js-packages/charts/AGENTS.md
+++ b/projects/js-packages/charts/AGENTS.md
@@ -55,4 +55,6 @@ jp changelog add js-packages/charts -s patch -t changed -e "Charts: <user-facing
 - Behavior verified in Storybook and/or tests, not only by static checks.
 - Edits remain in package boundaries; avoid unrelated refactors.
 
-Published Storybook: `https://automattic.github.io/jetpack-storybook/?path=/docs/js-packages-charts-library`
+## References
+
+- Published Storybook: `https://automattic.github.io/jetpack-storybook/?path=/docs/js-packages-charts-library`

--- a/projects/js-packages/charts/changelog/pr-47414
+++ b/projects/js-packages/charts/changelog/pr-47414
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Internal AGENTS.md cleanup; no user-facing changes.
+
+


### PR DESCRIPTION
Related to [CHARTS-173: Agentic readiness](https://linear.app/a8c/issue/CHARTS-173/agentic-readiness)

These changes are the result of running an audit using p1772458710397919-slack-C050S8KG677.

## Proposed changes:

* Audit the charts `AGENTS.md` using a blind sub-agent that tested whether each documented fact is easily discoverable from code search alone.
* Remove ~53% of the file (99 lines deleted, 28 added — 137 lines down to 64) — facts about build system, package exports, commands, file patterns, and component structure that agents find trivially from `package.json`, `tsup.config.ts`, and source code.
* Keep conventions, anti-hallucination guards, and gotchas that agents consistently miss from code search alone.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Review the diff — every removed line should be a fact that an AI agent can discover from `package.json`, config files, or source code without needing documentation.
* Verify no conventions, anti-patterns, or gotchas were removed.

## Changelog

- [x] Generate changelog entries for this PR (using AI).

Made with [Cursor](https://cursor.com)