### PR TITLE
Disable client-side media processing on Simple + Atomic sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/disable-client-side-media-processing
+++ b/projects/packages/jetpack-mu-wpcom/changelog/disable-client-side-media-processing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Temporarily disable client-side media processing to prevent cross-origin isolation headers from breaking authenticated API requests

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -294,6 +294,18 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/wpcom-widgets/wpcom-widgets.php';
 		require_once __DIR__ . '/features/wpcom-wpadmin-page-view/wpcom-wpadmin-page-view.php';
 
+		/*
+		 * Temporarily disable client-side media processing.
+		 *
+		 * Client-side media processing enables cross-origin isolation (COEP/COOP headers)
+		 * which can break authenticated API requests. This should be removed once client-side
+		 * media processing is compatible with Dotcom's infrastructure.
+		 *
+		 * @see gutenberg_set_up_cross_origin_isolation() in Gutenberg's lib/media/load.php
+		 * @see https://a8c.slack.com/archives/CBTN58FTJ/p1771950744814189
+		 */
+		add_filter( 'wp_client_side_media_processing_enabled', '__return_false' );
+
 		// Initializers, if needed.
 		\Marketplace_Products_Updater::init();
 		\Automattic\Jetpack\Code_Editor::setup();


### PR DESCRIPTION
## Summary

Due to bugs we also found in Atomic sites (more context here: p1772487793970979/1772383722.168529-slack-CBTN58FTJ), we'll need to apply the same fix we did for Simple sites before (205316-ghe-Automattic/wpcom). Once we release this, I'll rollback that code.



- Temporarily disables Gutenberg's client-side media processing on both Simple and Atomic sites by adding `add_filter( 'wp_client_side_media_processing_enabled', '__return_false' )` to `jetpack-mu-wpcom`'s `load_features()` method
- Client-side media processing enables cross-origin isolation (COEP/COOP headers) which breaks authenticated API requests
- This should be removed once client-side media processing is compatible with Dotcom's infrastructure

## Does this pull request change what data or activity we track or use?
no

## Testing instructions:

- Open the e2e Gutenberg Atomic test site
- Open the Jetpack Beta Tester (I already installed it there), in this page: `/wp-admin/admin.php?page=jetpack-beta&plugin=jetpack-mu-wpcom-plugin`
- Make sure we're using the `disable-client-side-media-processing` branch there
- Edit the `wp-config.php` and add this line: `define('JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN', true);`
- Run the test `TEST_ON_ATOMIC=true GUTENBERG_EDGE=true yarn workspace wp-e2e-tests test -- specs/blocks/blocks__jetpack-media.ts` and ensure it passes
- If for any reason the test doesn't pass, you can run this command on browser's console when inside the e2e site's editor to and make sure it returns `undefined`: `window.__clientSideMediaProcessing.`


<img width="1335" height="755" alt="image" src="https://github.com/user-attachments/assets/fded8b93-50ea-487b-8141-7fbdc929ba1e" />