### PR TITLE
tsgo: Fix plugins/protect type errors

### DIFF
--- a/projects/plugins/protect/changelog/update-tsgo-fix-plugins-protect-type-errors
+++ b/projects/plugins/protect/changelog/update-tsgo-fix-plugins-protect-type-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix TS errors detected by tsgo.

--- a/projects/plugins/protect/src/js/components/progress-bar/index.jsx
+++ b/projects/plugins/protect/src/js/components/progress-bar/index.jsx
@@ -8,7 +8,7 @@ import styles from './style.module.scss';
  * @param {string} props.className - Additional classnames
  * @param {number} props.total     - Total integer
  * @param {number} props.value     - Progress integer
- * @return {object} ProgressBar React component.
+ * @return {import('react').ReactNode} ProgressBar React component.
  */
 const ProgressBar = ( { className, total = 100, value = 0 } ) => {
 	// The percentage should not be allowed to be more than 100

--- a/projects/plugins/protect/src/js/components/threats-list/use-threats-list.js
+++ b/projects/plugins/protect/src/js/components/threats-list/use-threats-list.js
@@ -41,16 +41,16 @@ const flattenThreats = ( data, newData ) => {
 /**
  * Threats List Hook
  *
- * @param    {object}   args        - Arguments for the hook.
- * @param    {string}   args.source - "scan" or "history".
- * @param    {string}   args.status - "all", "fixed", or "ignored".
- *                                  ---
+ * @param    {object}                         args        - Arguments for the hook.
+ * @param    {string}                         args.source - "scan" or "history".
+ * @param    {string}                         args.status - "all", "fixed", or "ignored".
+ *                                                        ---
  * @typedef {object} UseThreatsList
- * @property {object}   item        - The selected threat category.
- * @property {object[]} list        - The list of threats to display.
- * @property {string}   selected    - The selected threat category.
- * @property {Function} setSelected - Sets the selected threat category.
- *                                  ---
+ * @property {object}                         item        - The selected threat category.
+ * @property {Array<{firstDetected: string}>} list        - The list of threats to display.
+ * @property {string}                         selected    - The selected threat category.
+ * @property {Function}                       setSelected - Sets the selected threat category.
+ *                                                        ---
  * @return {UseThreatsList} useThreatsList hook.
  */
 const useThreatsList = ( { source, status } = { source: 'scan', status: 'all' } ) => {

--- a/projects/plugins/protect/src/js/hooks/use-analytics-tracks/index.ts
+++ b/projects/plugins/protect/src/js/hooks/use-analytics-tracks/index.ts
@@ -2,12 +2,19 @@ import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { useConnection } from '@automattic/jetpack-connection';
 import { useCallback, useEffect } from 'react';
 
+type AnalyticsTracksOptions = {
+	pageViewEventName?: string;
+	pageViewNamespace?: string;
+	pageViewSuffix?: string;
+	pageViewEventProperties?: Record< string, unknown >;
+};
+
 const useAnalyticsTracks = ( {
 	pageViewEventName,
 	pageViewNamespace = 'jetpack',
 	pageViewSuffix = 'page_view',
 	pageViewEventProperties = {},
-} = {} ) => {
+}: AnalyticsTracksOptions = {} ) => {
 	const { isUserConnected, isRegistered, userConnectionData } = useConnection();
 	const { login, ID } = userConnectionData.currentUser?.wpcomUser || {};
 
@@ -16,14 +23,18 @@ const useAnalyticsTracks = ( {
 	const { recordEvent } = tracks;
 
 	const recordEventAsync = useCallback(
-		async ( event, properties ) => {
+		async ( event: string, properties?: Record< string, unknown > ) => {
 			recordEvent( event, properties );
 		},
 		[ recordEvent ]
 	);
 
 	const recordEventHandler = useCallback(
-		( eventName, properties, callback = () => {} ) => {
+		(
+			eventName: string,
+			properties?: Record< string, unknown > | VoidFunction,
+			callback = () => {}
+		) => {
 			/*
 			 * `properties` is optional,
 			 * meaning it can be actually the `callback`.

--- a/projects/plugins/protect/src/js/hooks/use-waf-data/index.ts
+++ b/projects/plugins/protect/src/js/hooks/use-waf-data/index.ts
@@ -7,7 +7,7 @@ import useAnalyticsTracks from '../use-analytics-tracks';
 /**
  * Use WAF Data Hook
  *
- * @return {object} WAF data and methods for interacting with it.
+ * @return WAF data and methods for interacting with it.
  */
 const useWafData = () => {
 	const { recordEvent } = useAnalyticsTracks();
@@ -21,7 +21,7 @@ const useWafData = () => {
 	 * Flips the switch on the WAF module, and then refreshes the data.
 	 */
 	const toggleWaf = useCallback( async () => {
-		toggleWafMutation.mutate();
+		toggleWafMutation.mutate( undefined );
 	}, [ toggleWafMutation ] );
 
 	/**
@@ -131,7 +131,10 @@ const useWafData = () => {
 	 */
 	const toggleShareData = useCallback( async () => {
 		const value = ! waf.config.jetpackWafShareData;
-		const mutationObj = { jetpack_waf_share_data: value };
+		const mutationObj: {
+			jetpack_waf_share_data: boolean;
+			jetpack_waf_share_debug_data?: boolean;
+		} = { jetpack_waf_share_data: value };
 		if ( ! value ) {
 			mutationObj.jetpack_waf_share_debug_data = false;
 		}
@@ -148,7 +151,10 @@ const useWafData = () => {
 	 */
 	const toggleShareDebugData = useCallback( async () => {
 		const value = ! waf.config.jetpackWafShareDebugData;
-		const mutationObj = { jetpack_waf_share_debug_data: value };
+		const mutationObj: {
+			jetpack_waf_share_debug_data: boolean;
+			jetpack_waf_share_data?: boolean;
+		} = { jetpack_waf_share_debug_data: value };
 		if ( value ) {
 			mutationObj.jetpack_waf_share_data = true;
 		}


### PR DESCRIPTION
Completes MONOREP-382

## Proposed changes:

- Type `useAnalyticsTracks` options and event payloads to satisfy tsgo expectations.
- Align WAF hook mutations and analytics calls with explicit parameters to remove TypeScript errors.
- Guard threat history date selection and annotate ProgressBar return type to keep JSX usage type-safe.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

- Run `cd projects/plugins/protect && pnpm typecheck` and confirm it passes.

## Changelog

- [ ] Generate changelog entries for this PR (using AI).
