### PR TITLE
tsgo: Fix type errors in forms, shared-extension-utils, woocommerce-analytics, and jetpack

### DIFF
--- a/.pnpm-patches/@wordpress__interactivity@6.40.0.patch
+++ b/.pnpm-patches/@wordpress__interactivity@6.40.0.patch
@@ -1,0 +1,35 @@
+diff --git a/build-types/utils.d.ts b/build-types/utils.d.ts
+index 16555add6792388ec57f942828805c84d566d3f5..90d5fec9259ec2ed1fcd83c90424b0a1df381bd4 100644
+--- a/build-types/utils.d.ts
++++ b/build-types/utils.d.ts
+@@ -4,8 +4,9 @@
+ import { type EffectCallback, type Inputs } from 'preact/hooks';
+ declare global {
+     interface Window {
+-        scheduler?: {
+-            readonly yield?: () => Promise<void>;
++        scheduler: {
++            postTask: (callback: () => unknown, options?: object) => Promise<unknown>;
++            yield: () => Promise<void>;
+         };
+     }
+ }
+diff --git a/src/utils.ts b/src/utils.ts
+index 9c5095ffe6b29f51e32c506462f302dc83eba859..3ee839e3ab7418876e7f9a17eebc63c55133d176 100644
+--- a/src/utils.ts
++++ b/src/utils.ts
+@@ -24,8 +24,12 @@ interface Flusher {
+ 
+ declare global {
+ 	interface Window {
+-		scheduler?: {
+-			readonly yield?: () => Promise< void >;
++		scheduler: {
++			postTask: (
++				callback: () => unknown,
++				options?: object
++			) => Promise< unknown >;
++			yield: () => Promise< void >;
+ 		};
+ 	}
+ }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ settings:
 pnpmfileChecksum: sha256-6WB2gwhE5lz5Qeo33gw4dkwjk8Lg/7L3m78A1iFmKjQ=
 
 patchedDependencies:
+  '@wordpress/interactivity@6.40.0':
+    hash: 039f44ff8916ecf1b577be87e074db282f525892f6b4c127f54f7be145b77f98
+    path: .pnpm-patches/@wordpress__interactivity@6.40.0.patch
   uuid@<11:
     hash: 87a713b75995ed86c0ecd0cadfd1b9f85092ca16fdff7132ff98b62fc3cf2db0
     path: .pnpm-patches/uuid.patch
@@ -2439,7 +2442,7 @@ importers:
         version: 11.7.0(react@18.3.1)
       '@wordpress/interactivity':
         specifier: 6.40.0
-        version: 6.40.0
+        version: 6.40.0(patch_hash=039f44ff8916ecf1b577be87e074db282f525892f6b4c127f54f7be145b77f98)
       '@wordpress/lazy-editor':
         specifier: 1.6.1
         version: 1.6.1(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1)
@@ -23633,7 +23636,7 @@ snapshots:
       '@wordpress/i18n': 6.13.0
       '@wordpress/icons': 11.7.0(react@18.3.1)
       '@wordpress/image-cropper': 1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/interactivity': 6.40.0
+      '@wordpress/interactivity': 6.40.0(patch_hash=039f44ff8916ecf1b577be87e074db282f525892f6b4c127f54f7be145b77f98)
       '@wordpress/is-shallow-equal': 5.40.0
       '@wordpress/keyboard-shortcuts': 5.40.0(react@18.3.1)
       '@wordpress/keycodes': 4.40.0
@@ -23696,7 +23699,7 @@ snapshots:
       '@wordpress/i18n': 6.13.0
       '@wordpress/icons': 11.7.0(react@18.3.1)
       '@wordpress/image-cropper': 1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/interactivity': 6.40.0
+      '@wordpress/interactivity': 6.40.0(patch_hash=039f44ff8916ecf1b577be87e074db282f525892f6b4c127f54f7be145b77f98)
       '@wordpress/is-shallow-equal': 5.40.0
       '@wordpress/keyboard-shortcuts': 5.40.0(react@18.3.1)
       '@wordpress/keycodes': 4.40.0
@@ -23759,7 +23762,7 @@ snapshots:
       '@wordpress/i18n': 6.13.0
       '@wordpress/icons': 11.7.0(react@18.3.1)
       '@wordpress/image-cropper': 1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/interactivity': 6.40.0
+      '@wordpress/interactivity': 6.40.0(patch_hash=039f44ff8916ecf1b577be87e074db282f525892f6b4c127f54f7be145b77f98)
       '@wordpress/is-shallow-equal': 5.40.0
       '@wordpress/keyboard-shortcuts': 5.40.0(react@18.3.1)
       '@wordpress/keycodes': 4.40.0
@@ -23819,7 +23822,7 @@ snapshots:
       '@wordpress/html-entities': 4.40.0
       '@wordpress/i18n': 6.13.0
       '@wordpress/icons': 11.7.0(react@18.3.1)
-      '@wordpress/interactivity': 6.40.0
+      '@wordpress/interactivity': 6.40.0(patch_hash=039f44ff8916ecf1b577be87e074db282f525892f6b4c127f54f7be145b77f98)
       '@wordpress/interactivity-router': 2.40.0
       '@wordpress/keyboard-shortcuts': 5.40.0(react@18.3.1)
       '@wordpress/keycodes': 4.40.0
@@ -23875,7 +23878,7 @@ snapshots:
       '@wordpress/html-entities': 4.40.0
       '@wordpress/i18n': 6.13.0
       '@wordpress/icons': 11.7.0(react@18.3.1)
-      '@wordpress/interactivity': 6.40.0
+      '@wordpress/interactivity': 6.40.0(patch_hash=039f44ff8916ecf1b577be87e074db282f525892f6b4c127f54f7be145b77f98)
       '@wordpress/interactivity-router': 2.40.0
       '@wordpress/keyboard-shortcuts': 5.40.0(react@18.3.1)
       '@wordpress/keycodes': 4.40.0
@@ -23931,7 +23934,7 @@ snapshots:
       '@wordpress/html-entities': 4.40.0
       '@wordpress/i18n': 6.13.0
       '@wordpress/icons': 11.7.0(react@18.3.1)
-      '@wordpress/interactivity': 6.40.0
+      '@wordpress/interactivity': 6.40.0(patch_hash=039f44ff8916ecf1b577be87e074db282f525892f6b4c127f54f7be145b77f98)
       '@wordpress/interactivity-router': 2.40.0
       '@wordpress/keyboard-shortcuts': 5.40.0(react@18.3.1)
       '@wordpress/keycodes': 4.40.0
@@ -25225,10 +25228,10 @@ snapshots:
   '@wordpress/interactivity-router@2.40.0':
     dependencies:
       '@wordpress/a11y': 4.40.0
-      '@wordpress/interactivity': 6.40.0
+      '@wordpress/interactivity': 6.40.0(patch_hash=039f44ff8916ecf1b577be87e074db282f525892f6b4c127f54f7be145b77f98)
       es-module-lexer: 1.7.0
 
-  '@wordpress/interactivity@6.40.0':
+  '@wordpress/interactivity@6.40.0(patch_hash=039f44ff8916ecf1b577be87e074db282f525892f6b4c127f54f7be145b77f98)':
     dependencies:
       '@preact/signals': 1.3.4(preact@10.28.2)
       preact: 10.28.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -89,3 +89,7 @@ patchedDependencies:
   # uuid up to v11 had CommonJS files with ESM content too.
   # No bug report, because it's already fixed in the latest versions.
   "uuid@<11": .pnpm-patches/uuid.patch
+
+  # @wordpress/interactivity@6.40.0 emitted an incomplete Window.scheduler type
+  # Upstream fix: https://github.com/WordPress/gutenberg/pull/76070
+  "@wordpress/interactivity@6.40.0": .pnpm-patches/@wordpress__interactivity@6.40.0.patch

--- a/projects/js-packages/shared-extension-utils/changelog/update-tsgo-fix-type-errors-in-multiple-packages
+++ b/projects/js-packages/shared-extension-utils/changelog/update-tsgo-fix-type-errors-in-multiple-packages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix TS type errors detected by tsgo.

--- a/projects/js-packages/shared-extension-utils/src/get-jetpack-data.js
+++ b/projects/js-packages/shared-extension-utils/src/get-jetpack-data.js
@@ -3,6 +3,8 @@ export const JETPACK_DATA_PATH = 'Jetpack_Editor_Initial_State';
 /**
  * Retrieves Jetpack editor state
  *
+ * @deprecated Use the consolidated initial state using `getScriptData` from `@automattic/jetpack-script-data` instead. Feel free to extend it if needed.
+ *
  * @return {object|null}Object The Jetpack Editor State.
  */
 export default function getJetpackData() {

--- a/projects/js-packages/shared-extension-utils/src/get-jetpack-data.js
+++ b/projects/js-packages/shared-extension-utils/src/get-jetpack-data.js
@@ -5,7 +5,7 @@ export const JETPACK_DATA_PATH = 'Jetpack_Editor_Initial_State';
  *
  * @deprecated Use the consolidated initial state using `getScriptData` from `@automattic/jetpack-script-data` instead. Feel free to extend it if needed.
  *
- * @return {object|null}Object The Jetpack Editor State.
+ * @return {object|null} The Jetpack Editor State.
  */
 export default function getJetpackData() {
 	return 'object' === typeof window ? window?.[ JETPACK_DATA_PATH ] ?? null : null;

--- a/projects/js-packages/shared-extension-utils/src/hooks/use-module-status/index.js
+++ b/projects/js-packages/shared-extension-utils/src/hooks/use-module-status/index.js
@@ -3,10 +3,18 @@ import { useMemo, useCallback } from '@wordpress/element';
 import { JETPACK_MODULES_STORE_ID } from '../../modules-state';
 
 /**
+ * @typedef {object} ModuleStatus
+ * @property {boolean}  isModuleActive   - Whether the module is active.
+ * @property {boolean}  isChangingStatus - Whether the module's status is currently being changed.
+ * @property {boolean}  isLoadingModules - Whether the modules are currently being loaded.
+ * @property {Function} changeStatus     - Function to change the module's status.
+ */
+
+/**
  * Manage a Jetpack module's status (get and set).
  *
  * @param {string} name - The module's name.
- * @return {object} Module status/control object.
+ * @return {ModuleStatus} Module status/control object.
  */
 const useModuleStatus = name => {
 	const { isModuleActive, isChangingStatus, isLoadingModules } = useSelect(

--- a/projects/packages/forms/changelog/update-tsgo-fix-type-errors-in-multiple-packages
+++ b/projects/packages/forms/changelog/update-tsgo-fix-type-errors-in-multiple-packages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix TS type errors detected by tsgo.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integration-controls.js
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integration-controls.js
@@ -17,7 +17,7 @@ import IntegrationsModal from './jetpack-integrations-modal/index.tsx';
  * @param {object}   props               - Component props.
  * @param {object}   props.attributes    - Block attributes.
  * @param {Function} props.setAttributes - Function to set block attributes.
- * @return {object} The IntegrationControls component.
+ * @return {import('react').ReactNode} The IntegrationControls component.
  */
 export default function IntegrationControls( { attributes, setAttributes } ) {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );

--- a/projects/packages/forms/src/blocks/shared/hooks/use-find-block-recursively.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-find-block-recursively.js
@@ -2,11 +2,18 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 
 /**
+ * @typedef {object} Block
+ * @property {string}                                    clientId    - The unique identifier for the block.
+ * @property {Array}                                     innerBlocks - An array of child blocks nested within this block.
+ * @property {{lock:{ move: boolean, remove: boolean }}} attributes  - An object containing the block's attributes.
+ */
+
+/**
  * Custom hook to find a block recursively within the inner blocks of a given root block ID.
  *
  * @param {string}   searchRootClientId - The client ID of the block whose descendants will be searched.
  * @param {Function} predicateFn        - A function that takes a block and returns true if it's the desired block.
- * @return  {Object|null} The first block found that satisfies the predicate, or null if not found or if searchRootClientId is invalid.
+ * @return  {Block|null} The first block found that satisfies the predicate, or null if not found or if searchRootClientId is invalid.
  */
 export const useFindBlockRecursively = ( searchRootClientId, predicateFn ) => {
 	const blocksToSearch = useSelect(

--- a/projects/packages/forms/src/store/form-step-preview.js
+++ b/projects/packages/forms/src/store/form-step-preview.js
@@ -74,13 +74,21 @@ const selectors = {
 	},
 
 	/**
+	 * @typedef {object} StepInfo
+	 * @property {string}  stepLabel   - The label of the current step.
+	 * @property {number}  index       - The index of the current step in the steps array.
+	 * @property {boolean} isFirstStep - Whether the current step is the first step.
+	 * @property {boolean} isLastStep  - Whether the current step is the last step.
+	 */
+
+	/**
 	 * Gets information about the current step (label and index) based on the steps array.
 	 * This is a higher-level selector that requires the steps array from the block editor.
 	 *
 	 * @param {object} state        - The store state
 	 * @param {string} formClientId - The ID of the form
 	 * @param {Array}  steps        - The array of step blocks from the block editor
-	 * @return {object} An object with step information
+	 * @return {StepInfo} An object with step information
 	 */
 	getCurrentStepInfo( state, formClientId, steps ) {
 		const selectedStepId = selectors.getActiveStepId( state, formClientId );

--- a/projects/packages/woocommerce-analytics/changelog/update-tsgo-fix-type-errors-in-multiple-packages
+++ b/projects/packages/woocommerce-analytics/changelog/update-tsgo-fix-type-errors-in-multiple-packages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix TS type errors detected by tsgo.

--- a/projects/packages/woocommerce-analytics/src/client/utils.ts
+++ b/projects/packages/woocommerce-analytics/src/client/utils.ts
@@ -20,7 +20,7 @@ export function getCookie( name: string ): string | null {
  * @return string
  */
 export function generateRandomToken( randomBytesLength: number ): string {
-	let randomBytes: Uint8Array | number[];
+	let randomBytes: Uint8Array< ArrayBuffer >;
 
 	if ( window.crypto && window.crypto.getRandomValues ) {
 		randomBytes = new Uint8Array( randomBytesLength );

--- a/projects/plugins/jetpack/changelog/update-tsgo-fix-type-errors-in-multiple-packages
+++ b/projects/plugins/jetpack/changelog/update-tsgo-fix-type-errors-in-multiple-packages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix TS type errors detected by tsgo.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-product-page/index.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/hooks/use-ai-product-page/index.ts
@@ -2,9 +2,8 @@
  * External dependencies
  */
 import { getRedirectUrl } from '@automattic/jetpack-components';
-import { isSimpleSite } from '@automattic/jetpack-script-data';
+import { isSimpleSite, getMyJetpackUrl } from '@automattic/jetpack-script-data';
 import {
-	getJetpackData,
 	isMyJetpackAvailable,
 	useAutosaveAndRedirect,
 } from '@automattic/jetpack-shared-extension-utils';
@@ -21,7 +20,7 @@ export default function useAiProductPage(): {
 } {
 	const isMyJetpackReallyAvailable = isMyJetpackAvailable() && ! isSimpleSite();
 	const productPageUrl = isMyJetpackReallyAvailable
-		? `${ getJetpackData()?.adminUrl || '' }admin.php?page=my-jetpack#/jetpack-ai`
+		? getMyJetpackUrl( '#/jetpack-ai' )
 		: getRedirectUrl( 'org-ai' );
 
 	const { autosaveAndRedirect, isRedirecting } = useAutosaveAndRedirect( productPageUrl );


### PR DESCRIPTION
Completes MONOREP-383, MONOREP-384, MONOREP-385

## Proposed changes:

- `js-packages/shared-extension-utils`: Add `@typedef` for `ModuleStatus` return type; add `@deprecated` to `getJetpackData()`.
- `packages/forms`: Tighten JSDoc `@return`/`@typedef` tags; patch `@wordpress/interactivity@6.40.0` to fix incomplete `Window.scheduler` type (upstream fix: https://github.com/WordPress/gutenberg/pull/76070).
- `packages/woocommerce-analytics`: Change `randomBytes` type to `Uint8Array<ArrayBuffer>` to match `crypto.getRandomValues` return type.
- `plugins/jetpack` (AI Assistant block): Replace deprecated `getJetpackData()?.adminUrl` with `getMyJetpackUrl()` from `@automattic/jetpack-script-data`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

- Run `pnpm typecheck`
- All should exit cleanly with no errors.

## Changelog

- [ ] Generate changelog entries for this PR (using AI).
