### PR TITLE
tsgo: Fix TypeScript type errors in e2e test projects

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5569,6 +5569,9 @@ importers:
       '@types/node':
         specifier: ^22.19.11
         version: 22.19.11
+      '@types/shell-escape':
+        specifier: 0.2.3
+        version: 0.2.3
       _jetpack-e2e-commons:
         specifier: workspace:*
         version: link:../../../../../tools/e2e-commons
@@ -9960,6 +9963,9 @@ packages:
 
   '@types/serve-static@1.15.10':
     resolution: {integrity: sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==}
+
+  '@types/shell-escape@0.2.3':
+    resolution: {integrity: sha512-xZWkMuQkn1I20gEzhYRa4/t1pwZ8XiIkqGA1Iee1D2IgAUIRLr57nrgJgF2QmHEfkfVzOM59gi/4xp6V+Aq+4A==}
 
   '@types/shimmer@1.2.0':
     resolution: {integrity: sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==}
@@ -22975,6 +22981,8 @@ snapshots:
       '@types/http-errors': 2.0.5
       '@types/node': 22.19.11
       '@types/send': 0.17.6
+
+  '@types/shell-escape@0.2.3': {}
 
   '@types/shimmer@1.2.0': {}
 

--- a/projects/plugins/boost/changelog/update-tsgo-fix-type-errors-in-e2e-projects
+++ b/projects/plugins/boost/changelog/update-tsgo-fix-type-errors-in-e2e-projects
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix TS errors detected by tsgo.

--- a/projects/plugins/boost/tests/e2e/lib/utils/boost-utils.ts
+++ b/projects/plugins/boost/tests/e2e/lib/utils/boost-utils.ts
@@ -174,7 +174,9 @@ export async function createTestPosts( testPostTitles: string[] ): Promise< void
 				logger.debug( 'The test content post already exists' );
 			} else {
 				logger.debug( 'Creating test content post...' );
-				await executeWpCommand( testPostTitlesCommands[ testPostTitle ] );
+				await executeWpCommand(
+					testPostTitlesCommands[ testPostTitle as keyof typeof testPostTitlesCommands ]
+				);
 			}
 		}
 	}

--- a/projects/plugins/boost/tests/e2e/specs/modules/score-auto-refresh.test.ts
+++ b/projects/plugins/boost/tests/e2e/specs/modules/score-auto-refresh.test.ts
@@ -50,7 +50,7 @@ test.describe( 'Auto refresh of speed scores', () => {
 			await new Promise( resolve => setTimeout( resolve, 1000 ) );
 		} );
 
-		let renderBlockingPromise;
+		let renderBlockingPromise: Promise< void > | undefined;
 
 		await test.step( 'Toggle minify_js module before automatic score refresh starts', async () => {
 			renderBlockingPromise = jetpackBoostPage.toggleModule( 'minify_js', true );

--- a/projects/plugins/jetpack/changelog/update-tsgo-fix-type-errors-in-e2e-projects
+++ b/projects/plugins/jetpack/changelog/update-tsgo-fix-type-errors-in-e2e-projects
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix TS errors detected by tsgo.

--- a/projects/plugins/jetpack/tests/e2e/specs/forms/submission.test.ts
+++ b/projects/plugins/jetpack/tests/e2e/specs/forms/submission.test.ts
@@ -17,7 +17,7 @@ test.afterEach( async ( { requestUtils } ) => {
 	// https://developer.wordpress.org/rest-api/reference/posts/#delete-a-post
 	// "/wp/v2/feedback" does not yet support batch requests.
 	await Promise.all(
-		feedbackSubmissions.map( feedback =>
+		feedbackSubmissions.map( ( feedback: { id: number } ) =>
 			requestUtils.rest( {
 				method: 'DELETE',
 				path: `/wp/v2/feedback/${ feedback.id }`,

--- a/projects/plugins/jetpack/tests/e2e/specs/sync/sync.test.ts
+++ b/projects/plugins/jetpack/tests/e2e/specs/sync/sync.test.ts
@@ -12,7 +12,7 @@ import {
 test.describe( 'Sync', () => {
 	const wpcomRestAPIBase = 'https://public-api.wordpress.com/rest/';
 	let wpcomBlogId;
-	let wpcomForcedPostsUrl;
+	let wpcomForcedPostsUrl: string;
 	let wpcomPostsResponse;
 	let wpcomPosts;
 

--- a/projects/plugins/search/changelog/update-tsgo-fix-type-errors-in-e2e-projects
+++ b/projects/plugins/search/changelog/update-tsgo-fix-type-errors-in-e2e-projects
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix TS errors detected by tsgo.

--- a/projects/plugins/search/tests/e2e/fixtures/test.ts
+++ b/projects/plugins/search/tests/e2e/fixtures/test.ts
@@ -400,13 +400,13 @@ const test = baseTest.extend< object, { searchUtils: SearchUtils } >( {
 
 			if ( category ) {
 				body.results = body.results.filter(
-					( v: { categories: string | string[] } ) => v?.categories?.includes( category )
+					( v: { categories?: string | string[] } ) => v?.categories?.includes( category )
 				);
 			}
 
 			if ( tag ) {
 				body.results = body.results.filter(
-					( v: { tags: string | string[] } ) => v?.tags?.includes( tag )
+					( v: { tags?: string | string[] } ) => v?.tags?.includes( tag )
 				);
 			}
 

--- a/projects/plugins/social/changelog/update-tsgo-fix-type-errors-in-e2e-projects
+++ b/projects/plugins/social/changelog/update-tsgo-fix-type-errors-in-e2e-projects
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix TS errors detected by tsgo.

--- a/projects/plugins/social/tests/e2e/specs/connection.test.ts
+++ b/projects/plugins/social/tests/e2e/specs/connection.test.ts
@@ -14,7 +14,7 @@ test( 'Jetpack Social connection', async ( { page, admin, requestUtils } ) => {
 	await test.step( 'Connect wordpress.com account to Jetpack Social', async () => {
 		await onboarding.connect( {
 			admin,
-			baseURL: requestUtils.baseURL,
+			baseURL: requestUtils.baseURL!,
 		} );
 	} );
 

--- a/projects/plugins/social/tests/e2e/specs/social-sidebar.test.ts
+++ b/projects/plugins/social/tests/e2e/specs/social-sidebar.test.ts
@@ -14,7 +14,7 @@ test( 'Jetpack Social sidebar', async ( { page, admin, editor, requestUtils } ) 
 	await test.step( 'Connect wordpress.com account', async () => {
 		await onboarding.connect( {
 			admin,
-			baseURL: requestUtils.baseURL,
+			baseURL: requestUtils.baseURL!,
 		} );
 	} );
 

--- a/projects/plugins/super-cache/changelog/update-tsgo-fix-type-errors-in-e2e-projects
+++ b/projects/plugins/super-cache/changelog/update-tsgo-fix-type-errors-in-e2e-projects
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix TS errors detected by tsgo.

--- a/projects/plugins/super-cache/tests/e2e/lib/CheerioForm.ts
+++ b/projects/plugins/super-cache/tests/e2e/lib/CheerioForm.ts
@@ -22,7 +22,7 @@ export default class CheerioForm {
 	 */
 	public setCheckbox( name: string, value: boolean ): void {
 		if ( value ) {
-			this.fields[ name ] = this.element( name ).val().toString();
+			this.fields[ name ] = ( this.element( name ).val() ?? '' ).toString();
 		} else {
 			delete this.fields[ name ];
 		}
@@ -44,7 +44,7 @@ export default class CheerioForm {
 	 * @param {string} authCookie - Auth cookie for form submission.
 	 */
 	public async submit( authCookie: string ): Promise< void > {
-		await authenticatedRequest( authCookie, 'POST', this.form.attr( 'action' ), this.fields );
+		await authenticatedRequest( authCookie, 'POST', this.form.attr( 'action' )!, this.fields );
 	}
 
 	private element( name: string ): Cheerio< AnyNode > {

--- a/projects/plugins/super-cache/tests/e2e/lib/plugin-settings.ts
+++ b/projects/plugins/super-cache/tests/e2e/lib/plugin-settings.ts
@@ -66,7 +66,12 @@ type Settings = {
  */
 export async function updateSettings( authCookie: string, settings: Partial< Settings > ) {
 	for ( const [ name, value ] of Object.entries( settings ) ) {
-		await settingsHandlers[ name ]( authCookie, value );
+		await (
+			settingsHandlers as Record<
+				string,
+				( authCookie: string, value: unknown ) => Promise< void >
+			>
+		 )[ name ]( authCookie, value );
 	}
 }
 

--- a/projects/plugins/super-cache/tests/e2e/lib/plugin-tools.ts
+++ b/projects/plugins/super-cache/tests/e2e/lib/plugin-tools.ts
@@ -48,8 +48,11 @@ export async function getAuthCookie(): Promise< string > {
 	expect( response.status ).toBe( 200 );
 
 	const cookies = response.headers[ 'set-cookie' ];
+	if ( ! cookies ) {
+		throw new Error( 'No set-cookie header found in response' );
+	}
 
-	return cookies.map( c => c.replace( ' HttpOnly', '' ) ).join( '; ' );
+	return cookies.map( ( c: string ) => c.replace( ' HttpOnly', '' ) ).join( '; ' );
 }
 
 /**
@@ -64,7 +67,7 @@ export async function authenticatedRequest(
 	authCookie: string,
 	method: Method,
 	url: string,
-	data: Record< string, string > = undefined
+	data: Record< string, string > | undefined = undefined
 ): Promise< string > {
 	const response = await axios( url, {
 		method,

--- a/projects/plugins/super-cache/tests/e2e/lib/wordpress-tools.ts
+++ b/projects/plugins/super-cache/tests/e2e/lib/wordpress-tools.ts
@@ -13,7 +13,7 @@ import { deleteCacheDirectory, readPluginFile } from './plugin-tools';
  *
  * @param {...any} command - The command to run.
  */
-export async function wpcli( ...command ) {
+export async function wpcli( ...command: string[] ) {
 	return dockerExec( 'wp', ...command );
 }
 

--- a/projects/plugins/super-cache/tests/e2e/lib/wordpress-tools.ts
+++ b/projects/plugins/super-cache/tests/e2e/lib/wordpress-tools.ts
@@ -11,7 +11,7 @@ import { deleteCacheDirectory, readPluginFile } from './plugin-tools';
 /**
  * Run the given wp-cli command (provided as a string array) in wp-cli in the docker.
  *
- * @param {...any} command - The command to run.
+ * @param {...string} command - The command to run.
  */
 export async function wpcli( ...command: string[] ) {
 	return dockerExec( 'wp', ...command );

--- a/projects/plugins/super-cache/tests/e2e/package.json
+++ b/projects/plugins/super-cache/tests/e2e/package.json
@@ -14,6 +14,7 @@
 	"devDependencies": {
 		"@jest/globals": "^30.0.0",
 		"@types/node": "^22.19.11",
+		"@types/shell-escape": "0.2.3",
 		"_jetpack-e2e-commons": "workspace:*",
 		"axios": "1.13.5",
 		"cheerio": "1.2.0",


### PR DESCRIPTION
Fixes MONOREP-386

## Proposed changes:

Fix TypeScript type errors in e2e test projects that surface when running `pnpm typecheck` with `tsgo`. Five projects were failing:

- **plugins/boost/tests/e2e**
- **plugins/jetpack/tests/e2e**
- **plugins/search/tests/e2e**
- **plugins/social/tests/e2e**
- **plugins/super-cache/tests/e2e**

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A — type-only fix, no behaviour changes.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

- Run `pnpm typecheck` from the monorepo root and confirm exit code 0 with no type errors.

## Changelog

- [ ] Generate changelog entries for this PR (using AI).
