### PR TITLE
Fix mobile overflow of license activation link in admin headers

### DIFF
--- a/projects/packages/backup/changelog/fix-jetpack-admin-headers-long-cta
+++ b/projects/packages/backup/changelog/fix-jetpack-admin-headers-long-cta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Constrain license activation link width on mobile to prevent header overflow.

--- a/projects/packages/backup/src/js/components/Admin/index.js
+++ b/projects/packages/backup/src/js/components/Admin/index.js
@@ -446,7 +446,7 @@ const ActivateLicenseLink = () => {
 	}, [] );
 
 	return (
-		<p>
+		<p className="jetpack-backup-activate-license">
 			{ createInterpolateElement(
 				__(
 					'Already have an existing plan or license key? <a>Click here to get started</a>',

--- a/projects/packages/backup/src/js/components/Admin/style.scss
+++ b/projects/packages/backup/src/js/components/Admin/style.scss
@@ -1,4 +1,5 @@
 @use "@automattic/jetpack-base-styles/style" as jpbs;
+@use "@automattic/jetpack-base-styles/gutenberg-base-styles" as gb;
 @use "../masthead/calypso-mixins";
 
 .jp-header,
@@ -147,6 +148,13 @@
 
 	.jitm-card {
 		margin-right: 0;
+	}
+}
+
+.jetpack-backup-activate-license {
+
+	@media ( max-width: gb.$break-medium ) {
+		max-width: 40vw;
 	}
 }
 

--- a/projects/packages/publicize/_inc/components/admin-page/index.tsx
+++ b/projects/packages/publicize/_inc/components/admin-page/index.tsx
@@ -23,8 +23,8 @@ import { features, getSocialScriptData, hasSocialPaidFeatures } from '../../util
 import ConnectionScreen from './connection-screen';
 import Header from './header';
 import InfoSection from './info-section';
-import './styles.module.scss';
 import PricingPage from './pricing-page';
+import styles from './styles.module.scss';
 import SupportSection from './support-section';
 import SocialImageGeneratorToggle from './toggles/social-image-generator-toggle';
 import SocialModuleToggle from './toggles/social-module-toggle';
@@ -81,8 +81,9 @@ export const SocialAdminPage = () => {
 	}
 
 	const licenseAction =
-		! hasSocialPaidFeatures() && isJetpackSite
-			? createInterpolateElement(
+		! hasSocialPaidFeatures() && isJetpackSite ? (
+			<div className={ styles[ 'mobile-action-container' ] }>
+				{ createInterpolateElement(
 					__(
 						'Already have an existing plan or license key? <a>Click here to get started</a>',
 						'jetpack-publicize-pkg'
@@ -90,8 +91,9 @@ export const SocialAdminPage = () => {
 					{
 						a: <a href={ getMyJetpackUrl( '#/add-license' ) } />,
 					}
-			  )
-			: null;
+				) }
+			</div>
+		) : null;
 
 	return (
 		<AdminPage

--- a/projects/packages/publicize/_inc/components/admin-page/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/admin-page/styles.module.scss
@@ -1,3 +1,5 @@
+@use "@automattic/jetpack-base-styles/gutenberg-base-styles" as gb;
+
 :global {
 
 	#wpbody-content {
@@ -22,4 +24,11 @@
 
 .notice {
 	grid-column: 1 / -1;
+}
+
+.mobile-action-container {
+
+	@media ( max-width: gb.$break-medium ) {
+		max-width: 40vw;
+	}
 }

--- a/projects/packages/publicize/changelog/fix-jetpack-admin-headers-long-cta
+++ b/projects/packages/publicize/changelog/fix-jetpack-admin-headers-long-cta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Constrain license activation link width on mobile to prevent header overflow.

--- a/projects/packages/search/changelog/fix-jetpack-admin-headers-long-cta
+++ b/projects/packages/search/changelog/fix-jetpack-admin-headers-long-cta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Constrain license activation link width on mobile to prevent header overflow.

--- a/projects/packages/search/src/dashboard/components/pages/upsell-page/index.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/upsell-page/index.jsx
@@ -92,8 +92,9 @@ export default function UpsellPage( { isLoading = false } ) {
 		[ isLoading, hasCheckoutStartedPaid, hasCheckoutStartedFree ]
 	);
 
-	const licenseAction = ! isWpcom
-		? createInterpolateElement(
+	const licenseAction = ! isWpcom ? (
+		<div className="jetpack-search-activate-license">
+			{ createInterpolateElement(
 				__(
 					'Already have an existing plan or license key? <a>Click here to get started</a>',
 					'jetpack-search-pkg'
@@ -101,8 +102,9 @@ export default function UpsellPage( { isLoading = false } ) {
 				{
 					a: <a href={ activateLicenseUrl } />,
 				}
-		  )
-		: null;
+			) }
+		</div>
+	) : null;
 
 	return (
 		<>

--- a/projects/packages/search/src/dashboard/components/pages/upsell-page/styles.scss
+++ b/projects/packages/search/src/dashboard/components/pages/upsell-page/styles.scss
@@ -1,4 +1,12 @@
 @use "scss/variables";
+@use "@automattic/jetpack-base-styles/gutenberg-base-styles" as gb;
+
+.jetpack-search-activate-license {
+
+	@media ( max-width: gb.$break-medium ) {
+		max-width: 40vw;
+	}
+}
 
 .price-tip {
 	display: flex;

--- a/projects/plugins/protect/changelog/fix-jetpack-admin-headers-long-cta
+++ b/projects/plugins/protect/changelog/fix-jetpack-admin-headers-long-cta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Constrain license activation link width on mobile to prevent header overflow.

--- a/projects/plugins/protect/src/js/routes/setup/index.jsx
+++ b/projects/plugins/protect/src/js/routes/setup/index.jsx
@@ -9,6 +9,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import ConnectedPricingTable from '../../components/pricing-table';
 import useAnalyticsTracks from '../../hooks/use-analytics-tracks';
+import styles from './styles.module.scss';
 
 const ACTIVATE_LICENSE_URL = 'admin.php?page=my-jetpack#/add-license';
 
@@ -23,7 +24,7 @@ const SetupRoute = () => {
 			title={ 'Protect' /** "Protect" is a product name, do not translate. */ }
 			subTitle={ __( 'Automated malware scanning and firewall protection.', 'jetpack-protect' ) }
 			actions={
-				<Text variant="body-small">
+				<Text variant="body-small" className={ styles[ 'mobile-action-container' ] }>
 					{ createInterpolateElement(
 						__(
 							'Already have an existing plan or license key? <a>Click here to get started</a>',

--- a/projects/plugins/protect/src/js/routes/setup/styles.module.scss
+++ b/projects/plugins/protect/src/js/routes/setup/styles.module.scss
@@ -1,0 +1,8 @@
+@use "@automattic/jetpack-base-styles/gutenberg-base-styles" as gb;
+
+.mobile-action-container {
+
+	@media ( max-width: gb.$break-medium ) {
+		max-width: 40vw;
+	}
+}


### PR DESCRIPTION
## Summary
- Constrain the "Already have an existing plan or license key?" action text in admin page headers on mobile (max-width: 40vw at $break-medium)
- Affects: Social (publicize), Protect, Backup, Search
- Boost and My Jetpack not affected (license link renders below title or in page body)

## Changes per product
- **Social**: Wrap license action in a mobile-action-container div (CSS module)
- **Protect**: Add mobile-action-container class to the Text wrapper + new CSS module
- **Backup**: Add jetpack-backup-activate-license class to the p tag + style rule
- **Search**: Wrap license action in a jetpack-search-activate-license div + style rule

All breakpoints use $break-medium from @wordpress/base-styles/breakpoints (via gutenberg-base-styles).

## Jetpack product discussion
p1772532572184729/1772524005.701139-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
- [ ] Social admin page (wp-admin/admin.php?page=jetpack-social): resize to mobile width, verify license link does not overflow header
- [ ] Protect setup page (wp-admin/admin.php?page=jetpack-protect#/setup): same check
- [ ] Backup admin page (wp-admin/admin.php?page=jetpack-backup): same check (when not connected or no plan)
- [ ] Search upsell page (wp-admin/admin.php?page=jetpack-search): same check