### PR TITLE
I18N: Fix Jetpack Boost translatable strings extraction

### DIFF
--- a/projects/plugins/boost/changelog/fix-translatable-strings-extraction
+++ b/projects/plugins/boost/changelog/fix-translatable-strings-extraction
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+I18N: Fix translatable strings extraction

--- a/projects/plugins/boost/webpack.config.js
+++ b/projects/plugins/boost/webpack.config.js
@@ -29,6 +29,15 @@ module.exports = [
 		},
 		optimization: {
 			...jetpackWebpackConfig.optimization,
+			minimizer: [
+				jetpackWebpackConfig.TerserPlugin( {
+					terserOptions: {
+						enclose: true,
+					},
+				} ),
+				jetpackWebpackConfig.CssMinimizerPlugin(),
+			],
+
 			splitChunks: {
 				minChunks: 2,
 			},

--- a/projects/plugins/boost/webpack.config.js
+++ b/projects/plugins/boost/webpack.config.js
@@ -30,6 +30,10 @@ module.exports = [
 		optimization: {
 			...jetpackWebpackConfig.optimization,
 			minimizer: [
+				/**
+				 * mck89/peast (used by wp i18n make-pot) can't correctly parse a ParenthesizedExpression generated from react-router.
+				 * Somehow, setting this causes that code from react-router to be tree-shaken out.
+				 */
 				jetpackWebpackConfig.TerserPlugin( {
 					terserOptions: {
 						enclose: true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes I18N-315. 

## Proposed changes:

Minimization breaks translate.wordpress.org string extraction. Set the `enclose` Terser option to true. 

Some strings in the Jetpack Boost admin interface are not translated and have not been extracted by [the .org project](https://translate.wordpress.org/projects/wp-plugins/jetpack-boost/stable/ro/default/).

translate.wordpress.com uses `wp i18n make-pot` to correctly extract the strings and determine the references. 

Running `wp i18n make-pot` on the plugin, we can notice the following error on some of the minified `.js` files:

```
php -d memory_limit=1G -d error_reporting=E_ERROR /opt/homebrew/bin/wp i18n make-pot . --debug
```

```
: Parsing file serve-minified-content.php (0.143s)
Debug (make-pot): Parsing file wp-js-data-sync.php (0.143s)
Debug (make-pot): Parsing file app/assets/dist/jetpack-boost.js (0.161s)
Debug (make-pot): Could not parse file app/assets/dist/jetpack-boost.js: Unexpected: new (line 43, column 94629) (1.149s)
Debug (make-pot): Parsing file app/assets/dist/jetpack-critical-css-gen.js (1.202s)
```

Based on a discussion with @anomiex, we found that Peast fails to correctly parse ParenthesizedExpressions:
```
([...new Set()])
```

I've [opened a PR ](https://github.com/mck89/peast/pull/75)  with a fix for the issue. In the meantime, setting the `enclose` Terser option causes that code from react-router to be tree-shaken out, allowing `wp i18n make-pot` to correctly extract the strings.



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

*  Visit the `Boost` admin page and confirm no JS errors.
* Run `wp i18n make-pot . --debug` and confirm the `jetpack-boost.js` file is now parsed correctly.

## Changelog
<!-- Check one of the boxes below. -->

- [ ] Generate changelog entries for this PR (using AI).
