### PR TITLE
CRM: Fix Contact List Rendering in Local Dev Environment

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-error-in-local-dev
+++ b/projects/plugins/crm/changelog/fix-crm-error-in-local-dev
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed issue with list rendering in local dev.

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.php
@@ -544,7 +544,6 @@ class zeroBSCRM_list {
 
 			// this assumes is contact for now, just sends to prefill - perhaps later add mailto: optional (wh wants lol)
 			var zbsObjectEmailLinkPrefix = '<?php echo jpcrm_esc_link( 'email', -1, 'zerobs_customer', true ); ?>';
-			
 			var zbsObjectViewLinkPrefixCustomer = '<?php echo jpcrm_esc_link( 'view', -1, 'zerobs_customer', true ); ?>';
 			var zbsObjectViewLinkPrefixCompany = '<?php echo jpcrm_esc_link( 'view', -1, 'zerobs_company', true ); ?>';
 			var zbsObjectViewLinkPrefixQuote = '<?php echo jpcrm_esc_link( 'edit', -1, 'zerobs_quote', true ); ?>';

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.php
@@ -166,7 +166,7 @@ class zeroBSCRM_list {
 			$sort = sanitize_text_field( $_GET['sort'] );
 		}
 		$sortOrder = false;
-		if ( isset( $_GET['sortdirection'] ) && ( $_GET['sortdirection'] == 'asc' || $_GET['sortdirection'] == 'desc' ) ) {
+		if ( isset( $_GET['sortdirection'] ) && ( $_GET['sortdirection'] === 'asc' || $_GET['sortdirection'] === 'desc' ) ) {
 			$sortOrder = sanitize_text_field( $_GET['sortdirection'] );
 		}
 
@@ -188,7 +188,7 @@ class zeroBSCRM_list {
 		if ( isset( $customViews ) && isset( $customViews[ $this->objType ] ) ) {
 			$currentColumns = $customViews[ $this->objType ];
 		}
-		if ( $currentColumns == false ) {
+		if ( $currentColumns === false ) {
 			$currentColumns = $defaultColumns;
 		}
 
@@ -270,7 +270,7 @@ class zeroBSCRM_list {
 										if ( ! array_key_exists( $colKey, $currentColumns ) ) {
 
 											// split em up
-											if ( isset( $col[2] ) && $col[2] == 'basefield' ) {
+											if ( isset( $col[2] ) && $col[2] === 'basefield' ) {
 												$allColumnsSorted['basefields'][ $colKey ] = $col;
 												$hasMultiColumnGroups                      = true;
 											} else {
@@ -334,7 +334,7 @@ class zeroBSCRM_list {
 									}
 
 									// if NONE output, we need to always have smt to drop to, so put empty:
-									if ( $colGroupCount == 0 ) {
+									if ( $colGroupCount === 0 ) {
 										echo '<div class="zbs-column-manager-connected">';
 										echo '</div>';
 									}
@@ -426,7 +426,7 @@ class zeroBSCRM_list {
 
 			<?php
 
-			$allowinlineedits = ( zeroBSCRM_getSetting( 'allowinlineedits' ) == '1' );
+			$allowinlineedits = ( zeroBSCRM_getSetting( 'allowinlineedits' ) === '1' );
 			$inlineEditStr    = array();
 			$columns          = array();
 
@@ -440,7 +440,7 @@ class zeroBSCRM_list {
 					// overrides
 
 					// Invoicing: Ref
-					if ( $this->objType == 'invoice' && $colKey == 'ref' ) {
+					if ( $this->objType === 'invoice' && $colKey === 'ref' ) {
 						$column_title = $zbs->settings->get( 'reflabel' );
 					}
 
@@ -542,14 +542,9 @@ class zeroBSCRM_list {
 			var zbsDrawListViewColUpdateBlocker = false;
 			var zbsDrawListViewColUpdateAJAXBlocker = false;
 
-			var zbsObjectEmailLinkPrefix = '
-			<?php
-
-				// this assumes is contact for now, just sends to prefill - perhaps later add mailto: optional (wh wants lol)
-				echo jpcrm_esc_link( 'email', -1, 'zerobs_customer', true );
-
-			?>
-			';
+			// this assumes is contact for now, just sends to prefill - perhaps later add mailto: optional (wh wants lol)
+			var zbsObjectEmailLinkPrefix = '<?php echo jpcrm_esc_link( 'email', -1, 'zerobs_customer', true ); ?>';
+			
 			var zbsObjectViewLinkPrefixCustomer = '<?php echo jpcrm_esc_link( 'view', -1, 'zerobs_customer', true ); ?>';
 			var zbsObjectViewLinkPrefixCompany = '<?php echo jpcrm_esc_link( 'view', -1, 'zerobs_company', true ); ?>';
 			var zbsObjectViewLinkPrefixQuote = '<?php echo jpcrm_esc_link( 'edit', -1, 'zerobs_quote', true ); ?>';
@@ -639,12 +634,12 @@ class zeroBSCRM_list {
 				// make simplified
 				$simple_tags = array();
 				if ( is_array( $tags ) && count( $tags ) > 0 ) {
-					foreach ( $tags as $t ) {
-						$simple_tags[] = array(
-							'id'   => $t['id'],
-							'name' => $t['name'],
-							'slug' => $t['slug'],
-						);
+				foreach ( $tags as $t ) {
+					$simple_tags[] = array(
+						'id'   => $t['id'],
+						'name' => $t['name'],
+						'slug' => $t['slug'],
+					);
 					}
 				}
 
@@ -664,9 +659,9 @@ class zeroBSCRM_list {
 							// phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 							global $zbsCustomerFields;
 							if ( is_array( $zbsCustomerFields['status'][3] ) ) {
-								echo wp_json_encode( $zbsCustomerFields['status'][3] );
+							echo wp_json_encode( $zbsCustomerFields['status'][3] );
 							} else {
-								echo '[]';
+							echo '[]';
 							}
 							// phpcs:enable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 						?>
@@ -678,9 +673,9 @@ class zeroBSCRM_list {
 						// hardcoded customer perms atm
 						$possible_owners = zeroBS_getPossibleOwners( array( 'zerobs_admin', 'zerobs_customermgr' ), true );
 						if ( ! is_array( $possible_owners ) ) {
-							echo wp_json_encode( array() );
+						echo wp_json_encode( array() );
 						} else {
-							echo wp_json_encode( $possible_owners );
+						echo wp_json_encode( $possible_owners );
 						}
 
 					?>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes JETCRM-1405 on Linear

## Proposed changes:

* The core of this change is here: https://github.com/Automattic/jetpack/compare/fix/crm-errors-in-studio?expand=1#diff-f2d892bfdf601b4879b7101be8379f4d9774ef8c292c56340299ebe88ef468daL545-R547

It fixes a broken string by consolidating it into a single line to prevent JS errors that prevent Contacts, Transactions, and Invoices from being properly listed.

The linter also changed some stuff with the formatting in the file.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:

To test, build CRM and run locally from Studio by symlinking, i.e.:

`ln -s /jetpack/projects/plugins/crm zero-bs-crm`

Activate Jetpack CRM and go to the contact list. Observe that it doesn't render properly:

<img width="4196" height="2020" alt="image" src="https://github.com/user-attachments/assets/f9da6a34-2c49-4e2e-8f7b-e37fca81394d" />

Apply the PR and see that the list renders properly:

<img width="1545" height="917" alt="image" src="https://github.com/user-attachments/assets/f82c94ac-e3f1-42e1-89f7-e95b1923c52a" />


<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

## Changelog
<!-- Check one of the boxes below. -->

- [ ] Generate changelog entries for this PR (using AI).
