### PR TITLE
Forms: update button handling for core/button migration

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-ai-button-migration
+++ b/projects/packages/forms/changelog/fix-forms-ai-button-migration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Update submit button handling to support core/button blocks as part of the jetpack/button to core/button migration.

--- a/projects/packages/forms/changelog/fix-forms-ai-button-migration
+++ b/projects/packages/forms/changelog/fix-forms-ai-button-migration
@@ -1,4 +1,4 @@
 Significance: patch
-Type: bugfix
+Type: fixed
 
 Update submit button handling to support core/button blocks as part of the jetpack/button to core/button migration.

--- a/projects/packages/forms/changelog/fix-forms-ai-button-migration
+++ b/projects/packages/forms/changelog/fix-forms-ai-button-migration
@@ -1,4 +1,4 @@
 Significance: patch
-Type: fixed
+Type: bugfix
 
 Update submit button handling to support core/button blocks as part of the jetpack/button to core/button migration.

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -250,7 +250,9 @@ function JetpackContactFormEdit( {
 	);
 
 	const findButtonsBlock = useCallback(
-		block => block.name === 'core/button' || block.name === 'jetpack/button',
+		block =>
+			block.name === 'jetpack/button' ||
+			( block.name === 'core/button' && block.attributes?.tagName === 'button' ),
 		[]
 	);
 	const submitButton = useFindBlockRecursively( clientId, findButtonsBlock );
@@ -289,8 +291,9 @@ function JetpackContactFormEdit( {
 
 			const isSingleButtonBlock =
 				innerBlocksData.length === 1 &&
-				( innerBlocksData[ 0 ].name === 'core/button' ||
-					innerBlocksData[ 0 ].name === 'jetpack/button' );
+				( innerBlocksData[ 0 ].name === 'jetpack/button' ||
+					( innerBlocksData[ 0 ].name === 'core/button' &&
+						innerBlocksData[ 0 ].attributes?.tagName === 'button' ) );
 
 			const title = getEditedPostAttribute( 'title' );
 			const authorId = getEditedPostAttribute( 'author' );
@@ -643,7 +646,9 @@ function JetpackContactFormEdit( {
 		// Helper functions
 		const findButtonBlock = () => {
 			const buttonIndex = currentInnerBlocks.findIndex(
-				block => block.name === 'core/button' || block.name === 'jetpack/button'
+				block =>
+					block.name === 'jetpack/button' ||
+					( block.name === 'core/button' && block.attributes?.tagName === 'button' )
 			);
 			return buttonIndex !== -1
 				? {

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -465,7 +465,9 @@ function JetpackContactFormEdit( {
 			const submitButtonIndex = currentInnerBlocks.findIndex(
 				block =>
 					( block.name === 'core/button' || block.name === 'jetpack/button' ) &&
-					( block.attributes?.customVariant === 'submit' || block.attributes?.element === 'button' )
+					( block.attributes?.customVariant === 'submit' ||
+						block.attributes?.element === 'button' ||
+						block.attributes?.tagName === 'button' )
 			);
 
 			// If there's a submit button and it's not the last block, reorder

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -297,6 +297,7 @@ const enforceBlockNesting = () => {
 		// Form was empty, add a submit button after the moved blocks
 		const submitButton = createBlock( 'core/button', {
 			tagName: 'button',
+			type: 'submit',
 			text: __( 'Submit', 'jetpack-forms' ),
 			lock: { move: false, remove: true },
 		} );

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -295,8 +295,8 @@ const enforceBlockNesting = () => {
 
 	if ( action.addSubmitButton ) {
 		// Form was empty, add a submit button after the moved blocks
-		const submitButton = createBlock( 'jetpack/button', {
-			element: 'button',
+		const submitButton = createBlock( 'core/button', {
+			tagName: 'button',
 			text: __( 'Submit', 'jetpack-forms' ),
 			lock: { move: false, remove: true },
 		} );

--- a/projects/plugins/jetpack/changelog/fix-forms-ai-button-migration
+++ b/projects/plugins/jetpack/changelog/fix-forms-ai-button-migration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Update AI form assistant to detect and create core/button blocks instead of jetpack/button.

--- a/projects/plugins/jetpack/changelog/fix-forms-ai-button-migration
+++ b/projects/plugins/jetpack/changelog/fix-forms-ai-button-migration
@@ -1,4 +1,4 @@
 Significance: patch
-Type: fixed
+Type: bugfix
 
 Update AI form assistant to detect and create core/button blocks instead of jetpack/button.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/text-blocks/jetpack-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/text-blocks/jetpack-form/index.tsx
@@ -112,7 +112,8 @@ export class JetpackFormHandler extends BlockHandler {
 			 * - if it does not exist, create one (unless there's a navigation block).
 			 */
 			const isButtonBlock = ( block: ( typeof validBlocks )[ number ] ) =>
-				block.name === 'core/button' || block.name === 'jetpack/button';
+				block.name === 'jetpack/button' ||
+				( block.name === 'core/button' && block.attributes?.tagName === 'button' );
 
 			const allButtonBlocks = validBlocks.filter( isButtonBlock );
 			const hasNavigationBlock = validBlocks.some(

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/text-blocks/jetpack-form/index.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/text-blocks/jetpack-form/index.tsx
@@ -107,11 +107,14 @@ export class JetpackFormHandler extends BlockHandler {
 
 			/*
 			 * Inspect generated blocks list,
-			 * checking if the jetpack/button block:
+			 * checking the submit button block (core/button or jetpack/button):
 			 * - if it exists twice or more, remove the first one.
 			 * - if it does not exist, create one (unless there's a navigation block).
 			 */
-			const allButtonBlocks = validBlocks.filter( block => block.name === 'jetpack/button' );
+			const isButtonBlock = ( block: ( typeof validBlocks )[ number ] ) =>
+				block.name === 'core/button' || block.name === 'jetpack/button';
+
+			const allButtonBlocks = validBlocks.filter( isButtonBlock );
 			const hasNavigationBlock = validBlocks.some(
 				block => block.name === 'jetpack/form-step-navigation'
 			);
@@ -121,7 +124,7 @@ export class JetpackFormHandler extends BlockHandler {
 				// Remove all button blocks, less the last one.
 				let buttonCounter = 0;
 				this.currentListOfValidBlocks = this.currentListOfValidBlocks.filter( block => {
-					if ( block.name !== 'jetpack/button' ) {
+					if ( ! isButtonBlock( block ) ) {
 						return true;
 					}
 
@@ -137,11 +140,10 @@ export class JetpackFormHandler extends BlockHandler {
 				// One button block is required for non-multistep forms.
 				replaceInnerBlocks( this.clientId, [
 					...this.currentListOfValidBlocks,
-					createBlock( 'jetpack/button', {
-						label: __( 'Submit', 'jetpack' ),
-						element: 'button',
+					createBlock( 'core/button', {
+						tagName: 'button',
+						type: 'submit',
 						text: __( 'Submit', 'jetpack' ),
-						borderRadius: 8,
 						lock: {
 							remove: true,
 						},


### PR DESCRIPTION
Part of FORMS-607

## Proposed changes:

Continue the jetpack/button to core/button migration across three areas:

- **Form editor** (form-editor/index.tsx): Switch fallback submit button creation from jetpack/button to core/button with tagName attribute
- **Contact form edit** (contact-form/edit.tsx): Add tagName === button check to submit button detection so core/button blocks are recognized alongside the legacy element attribute
- **AI form assistant** (jetpack-form/index.tsx): Update the AI response handler to detect both core/button and jetpack/button when inspecting generated blocks, and create core/button for the fallback submit button

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

1. Create a new post, add a Jetpack Form block
2. Verify the submit button is a core/button block (check block name in block inspector)
3. Use the AI assistant to generate a form - verify the submit button in the result is core/button, not jetpack/button
4. Use the AI assistant to generate a form that already contains a button - verify no duplicate buttons appear
5. In the form editor (standalone), drag fields into an empty form - verify the auto-added submit button is core/button