### PR TITLE
Charts: Nest legend theme props under `legend` and restructure docs

### DIFF
--- a/projects/js-packages/charts/changelog/pr-47439
+++ b/projects/js-packages/charts/changelog/pr-47439
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+Legend: Consolidate top-level legend theme properties (`legendShapeStyles`, `legendLabelStyles`, `legendContainerStyles`) into a nested `legend` object (`legend.shapeStyles`, `legend.labelStyles`, `legend.containerStyles`) in `ChartTheme`.

--- a/projects/js-packages/charts/changelog/pr-47439
+++ b/projects/js-packages/charts/changelog/pr-47439
@@ -1,4 +1,4 @@
-Significance: major
+Significance: minor
 Type: changed
 
-Legend: Consolidate top-level legend theme properties (`legendShapeStyles`, `legendLabelStyles`, `legendContainerStyles`) into a nested `legend` object (`legend.shapeStyles`, `legend.labelStyles`, `legend.containerStyles`) in `ChartTheme`.
+Breaking: Legend theme properties (`legendShapeStyles`, `legendLabelStyles`, `legendContainerStyles`) are now nested under a `legend` object (`legend.shapeStyles`, `legend.labelStyles`, `legend.containerStyles`) in `ChartTheme`.

--- a/projects/js-packages/charts/src/components/legend/private/base-legend.tsx
+++ b/projects/js-packages/charts/src/components/legend/private/base-legend.tsx
@@ -176,7 +176,7 @@ export const BaseLegend: ForwardRefExoticComponent<
 						) }
 						style={ {
 							flexDirection: orientationToFlexDirection[ orientation ],
-							...theme.legendContainerStyles,
+							...theme.legend?.containerStyles,
 						} }
 					>
 						{ labels.map( ( label, i ) => {
@@ -251,7 +251,7 @@ export const BaseLegend: ForwardRefExoticComponent<
 											justifyContent: labelAlign,
 											flex: labelFlex,
 											margin: labelMargin,
-											...theme.legendLabelStyles,
+											...theme.legend?.labelStyles,
 										} }
 										{ ...legendLabelProps }
 									>

--- a/projects/js-packages/charts/src/components/legend/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/components/legend/stories/index.api.mdx
@@ -38,7 +38,7 @@ The Legend component displays chart legends with support for both standalone usa
 | `itemMargin`          | `string \| number`                       | `'0'`                   | Margin around each legend item.                                                                                                                                                            |
 | `itemDirection`       | `'row' \| 'column'`                      | `'row'`                 | Flex direction for items within each legend entry.                                                                                                                                         |
 | `legendLabelProps`    | `object`                                 | -                       | Additional props to pass to the underlying LegendLabel component from visx.                                                                                                                |
-| `interactive`         | `boolean`                                | `false`                 | Enable interactive legend items that can toggle series visibility. Currently only supported for LineChart. Requires `chartId` and `GlobalChartsProvider`.                                  |
+| `interactive`         | `boolean`                                | `false`                 | Enable interactive legend items that can toggle series visibility. Requires `chartId` and `GlobalChartsProvider`.                                                                          |
 
 ## BaseLegendItem Type
 

--- a/projects/js-packages/charts/src/components/legend/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/components/legend/stories/index.docs.mdx
@@ -7,7 +7,7 @@ import * as LegendStories from './index.stories';
 
 The Legend component provides a flexible way to display chart legends either as standalone components or integrated with charts through the chart context.
 
-<Canvas of={ LegendStories.Horizontal } />
+<Canvas of={ LegendStories.Default } />
 
 ## Overview
 
@@ -39,11 +39,11 @@ For detailed information about component props, types, and method signatures, se
 
 ## Basic Usage
 
-### Horizontal Legend
+### Default Legend
 
-The horizontal orientation displays legend items in a row, ideal for legends positioned above or below charts:
+The default horizontal orientation displays legend items in a row, ideal for legends positioned above or below charts:
 
-<Canvas of={ LegendStories.Horizontal } />
+<Canvas of={ LegendStories.Default } />
 
 <Source
 	language="tsx"
@@ -85,6 +85,13 @@ When using the Legend component in standalone mode, you need either:
 
 For detailed information about all optional props, see the [Legend API Reference](./?path=/docs/js-packages-charts-library-components-legend-api-reference--docs).
 
+### Important Notes
+
+- When both `items` and `chartId` are provided, `items` takes precedence
+- The `render` prop provides complete control over legend rendering, bypassing the default layout
+- Text overflow features require both `maxWidth` and `textOverflow` props to be set
+- The component uses visx LegendOrdinal internally but provides a simplified, more flexible API
+
 ## Integration with Charts
 
 ### Using with LineChart
@@ -93,11 +100,42 @@ Legends can be positioned independently from the chart, retrieving data automati
 
 <Canvas of={ LegendStories.WithLineChart } />
 
+<Source
+	language="tsx"
+	code={ `import { Legend, LineChart } from '@automattic/charts';
+	import { useChartLegendItems } from '@automattic/charts';
+
+	const legendItems = useChartLegendItems( lineChartData, {
+		showValues: false,
+	} );
+
+	<LineChart
+		data={ lineChartData }
+		showLegend={ false }
+		width={ 600 }
+		height={ 300 }
+	/>
+	<Legend items={ legendItems } orientation="horizontal" shape="line" />` }
+/>
+
 ### Using with BarChart
 
 Position legends vertically beside charts for a side-by-side layout:
 
 <Canvas of={ LegendStories.WithBarChart } />
+
+<Source
+	language="tsx"
+	code={ `import { Legend, BarChart } from '@automattic/charts';
+	import { useChartLegendItems } from '@automattic/charts';
+
+	const legendItems = useChartLegendItems( barChartData );
+
+	<div style={ { display: 'flex', gap: '20px', alignItems: 'flex-start' } }>
+		<BarChart data={ barChartData } showLegend={ false } width={ 400 } height={ 300 } />
+		<Legend items={ legendItems } orientation="vertical" />
+	</div>` }
+/>
 
 ### Standalone Legend with Chart Context
 
@@ -146,27 +184,68 @@ The Legend component's most powerful feature is its ability to automatically ret
 - Charts with `showLegend={false}` still register their legend data
 - If no chart with the given `chartId` exists, the legend will render nothing
 
-## Real-World Example
+## Interactive Legends
 
-### Dashboard with Centralized Legends
+Interactive legends allow users to toggle series visibility by clicking or using keyboard navigation.
 
-This example demonstrates a complete dashboard implementation using Legend with chart context integration:
+### Basic Interactive Legend
 
-<Canvas of={ LegendStories.DashboardExample } />
+Enable interactive legends by setting the `legendInteractive` prop on the chart. The Legend component will automatically become interactive when connected via `chartId`:
 
-Key implementation details:
+<Canvas of={ LegendStories.InteractiveLegend } />
 
-1. **Chart Setup**: Each chart has a unique `chartId` and `showLegend={false}`
-2. **Centralized Legends**: All legends are placed in a dedicated sidebar
-3. **Automatic Data Sync**: Legends automatically retrieve data from their respective charts
-4. **Clean Layout**: Charts remain uncluttered while legends are easily accessible
+<Source
+	language="tsx"
+	code={ `import { LineChart } from '@automattic/charts';
 
-Benefits of this approach:
+	<LineChart
+		data={ data }
+		showLegend={ true }
+		legendInteractive={ true }
+	/>` }
+/>
 
-- **Consistent Legend Styling**: All legends share the same visual style
-- **Space Efficiency**: Charts can use full width without legend taking up space
-- **Better Mobile Experience**: Legends can be collapsed or repositioned on smaller screens
-- **Easier Maintenance**: Legend updates only need to happen in one place
+### Standalone Interactive Legend
+
+Interactive legends also work with standalone Legend components. Set `legendInteractive` on the chart so it filters visible series, and `interactive` on the Legend so it renders clickable toggle controls:
+
+<Source
+	language="tsx"
+	code={ `<GlobalChartsProvider>
+		<LineChart
+			chartId="sales-chart"
+			data={ salesData }
+			showLegend={ false }
+			legendInteractive={ true }
+		/>
+
+		<Legend
+			chartId="sales-chart"
+			orientation="horizontal"
+			interactive={ true }
+		/>
+	</GlobalChartsProvider>` }
+/>
+
+### Features
+
+- **Click/Tap Interaction**: Toggle series visibility by clicking on legend items
+- **Keyboard Support**: Use Tab to focus items, Enter or Space to toggle
+- **Visual Feedback**: Hidden series appear with reduced opacity and strikethrough text
+- **Color Stability**: Series colors remain consistent when toggling visibility
+- **Accessibility**: Full ARIA support with `role="button"`, `aria-pressed`, and descriptive `aria-label`
+
+### Requirements
+
+Interactive legends require:
+
+1. **GlobalChartsProvider**: Must wrap both chart and legend
+2. **chartId**: A unique identifier to connect chart and legend
+3. **legendInteractive prop**: Set to `true` on the chart component
+
+### Current Limitations
+
+- The `render` prop is not compatible with interactive legends (legendInteractive mode will be disabled)
 
 ## Styling and Customization
 
@@ -188,12 +267,6 @@ The Legend component provides comprehensive text overflow handling for long labe
 
 - **Wrap** (default): Text wraps naturally to multiple lines when it exceeds maxWidth
 - **Ellipsis**: Truncates text with ellipsis (...) and shows tooltip on hover
-
-#### Features
-
-- **Orientation**: Switch between horizontal and vertical layouts
-- **Max Width**: Set maximum width constraint for legend items
-- **Position & Alignment**: Control legend placement
 
 #### Use Cases
 
@@ -229,7 +302,7 @@ By default, legends use rectangular shapes, but you can customize the glyph shap
 
 Available shapes: `'rect'` (default), `'circle'`, `'line'`
 
-### Theme Integration
+## Theming Integration
 
 The legend's appearance can be customized globally through the `legend` property on the chart theme. This applies consistent styling to all legends rendered within a `GlobalChartsProvider`:
 
@@ -321,81 +394,18 @@ Provide custom glyph rendering functions for unique symbols or complex visualiza
 
 Custom glyphs should be centered at the provided `x` and `y` coordinates. The glyph will be rendered at `glyphSize * 2` dimensions.
 
-### Important Notes
+### Dashboard with Centralized Legends
 
-- When both `items` and `chartId` are provided, `items` takes precedence
-- The `render` prop provides complete control over legend rendering, bypassing the default layout
-- Text overflow features require both `maxWidth` and `textOverflow` props to be set
-- The component uses visx LegendOrdinal internally but provides a simplified, more flexible API
+This example demonstrates a complete dashboard implementation using Legend with chart context integration:
 
-## Interactive Legends
+<Canvas of={ LegendStories.DashboardExample } />
 
-Interactive legends allow users to toggle series visibility by clicking or using keyboard navigation. This feature is currently supported for LineChart only.
+Key implementation details:
 
-### Basic Interactive Legend
-
-Enable interactive legends by setting the `legendInteractive` prop on the chart. The Legend component will automatically become interactive when connected via `chartId`:
-
-<Source
-	language="tsx"
-	code={ `import { GlobalChartsProvider, LineChart, Legend } from '@automattic/charts';
-
-	<GlobalChartsProvider>
-		<LineChart
-			chartId="sales-chart"
-			data={ salesData }
-			showLegend={ true }
-			legendInteractive={ true }
-		/>
-	</GlobalChartsProvider>` }
-/>
-
-### Standalone Interactive Legend
-
-Interactive legends also work with standalone Legend components when using `chartId`.
-The Legend automatically inherits the interactive state from the chart component via the `GlobalChartsProvider`, so you only need to set `legendInteractive` on the chart itself:
-
-<Source
-	language="tsx"
-	code={ `<GlobalChartsProvider>
-		<LineChart
-			chartId="sales-chart"
-			data={ salesData }
-			showLegend={ false }
-			legendInteractive={ true }
-		/>
-
-		<Legend
-			chartId="sales-chart"
-			orientation="horizontal"
-		/>
-	</GlobalChartsProvider>` }
-/>
-
-**Note**: The standalone `Legend` component does not need an `legendInteractive` prop. When connected to a chart via `chartId`, it automatically becomes interactive if the chart has `legendInteractive={true}`.
-
-### Features
-
-- **Click/Tap Interaction**: Toggle series visibility by clicking on legend items
-- **Keyboard Support**: Use Tab to focus items, Enter or Space to toggle
-- **Visual Feedback**: Hidden series appear with reduced opacity and strikethrough text
-- **Color Stability**: Series colors remain consistent when toggling visibility
-- **Accessibility**: Full ARIA support with `role="button"`, `aria-pressed`, and descriptive `aria-label`
-
-### Requirements
-
-Interactive legends require:
-
-1. **GlobalChartsProvider**: Must wrap both chart and legend
-2. **chartId**: A unique identifier to connect chart and legend
-3. **legendInteractive prop**: Set to `true` on the chart component
-4. **Chart Support**: Currently LineChart and BarChart support interactive legends
-
-### Current Limitations
-
-- Interactive legends are only supported for LineChart and BarChart
-- Support for other chart types (PieChart, etc.) will be added in future releases
-- The `render` prop is not compatible with interactive legends (legendInteractive mode will be disabled)
+1. **Chart Setup**: Each chart has a unique `chartId` and `showLegend={false}`
+2. **Centralized Legends**: All legends are placed in a dedicated sidebar
+3. **Automatic Data Sync**: Legends automatically retrieve data from their respective charts
+4. **Clean Layout**: Charts remain uncluttered while legends are easily accessible
 
 ## Accessibility
 

--- a/projects/js-packages/charts/src/components/legend/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/components/legend/stories/index.docs.mdx
@@ -229,6 +229,44 @@ By default, legends use rectangular shapes, but you can customize the glyph shap
 
 Available shapes: `'rect'` (default), `'circle'`, `'line'`
 
+### Theme Integration
+
+The legend's appearance can be customized globally through the `legend` property on the chart theme. This applies consistent styling to all legends rendered within a `GlobalChartsProvider`:
+
+<Source
+	language="tsx"
+	code={ `import { GlobalChartsProvider, LineChart } from '@automattic/charts';
+
+	<GlobalChartsProvider theme={ {
+		legend: {
+			// Styles applied to every legend label
+			labelStyles: {
+				color: '#1e3a5f',
+				fontWeight: 600,
+			},
+			// Styles applied to the legend container
+			containerStyles: {
+				gap: '12px',
+			},
+			// Per-index styles applied to legend shapes
+			shapeStyles: [
+				{ fill: '#3858E9', rx: 4 },
+				{ fill: '#80C8FF', rx: 4 },
+			],
+		},
+	} }>
+		<LineChart data={ data } />
+	</GlobalChartsProvider>` }
+/>
+
+#### Theme Legend Properties
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `legend.labelStyles` | `CSSProperties` | CSS styles spread onto every legend label element. |
+| `legend.containerStyles` | `CSSProperties` | CSS styles spread onto the legend container element. |
+| `legend.shapeStyles` | `Record<string, unknown>[]` | Per-index styles applied to legend shape glyphs. Used as a fallback when series data does not provide its own `legendShapeStyle`. |
+
 ## Advanced Usage
 
 ### Custom Rendering with Render Prop

--- a/projects/js-packages/charts/src/components/legend/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/components/legend/stories/index.docs.mdx
@@ -189,7 +189,7 @@ Interactive legends allow users to toggle series visibility by clicking or using
 
 ### Basic Interactive Legend
 
-Enable interactive legends by setting the `legendInteractive` prop on the chart. The Legend component will automatically become interactive when connected via `chartId`:
+Enable interactive legends by setting the `legendInteractive` prop on the chart. When `showLegend` is enabled, the chart's built-in legend will automatically become interactive:
 
 <Canvas of={ LegendStories.InteractiveLegend } />
 
@@ -206,7 +206,7 @@ Enable interactive legends by setting the `legendInteractive` prop on the chart.
 
 ### Standalone Interactive Legend
 
-Interactive legends also work with standalone Legend components. Set `legendInteractive` on the chart so it filters visible series, and `interactive` on the Legend so it renders clickable toggle controls:
+Interactive legends also work with standalone Legend components. Set `legendInteractive` on the chart so it filters visible series, and `interactive` on the Legend so it renders clickable toggle controls. `chartId` is also required for this to work.
 
 <Source
 	language="tsx"

--- a/projects/js-packages/charts/src/components/legend/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/components/legend/stories/index.docs.mdx
@@ -52,7 +52,6 @@ The default horizontal orientation displays legend items in a row, ideal for leg
 			{ label: 'Desktop', value: '65%', color: '#3858E9' },
 			{ label: 'Mobile', value: '35%', color: '#80C8FF' },
 		] }
-		orientation="horizontal"
 	/>` }
 />
 

--- a/projects/js-packages/charts/src/components/legend/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/legend/stories/index.stories.tsx
@@ -74,7 +74,7 @@ const pieChartData: DataPointPercentage[] = [
 ];
 
 // Basic standalone legends
-export const Horizontal: Story = {
+export const Default: Story = {
 	render: args => {
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		const { themeName, accentColor, ...legendProps } = args;
@@ -170,6 +170,22 @@ const StandaloneLegendWithChartIdComponent = () => {
 
 export const StandaloneLegendWithChartId: Story = {
 	render: () => <StandaloneLegendWithChartIdComponent />,
+};
+
+const InteractiveLegendComponent = () => (
+	<LineChart
+		chartId="interactive-legend-demo"
+		data={ lineChartData }
+		showLegend={ true }
+		width={ 600 }
+		height={ 300 }
+		withGradientFill={ false }
+		withLegendGlyph={ false }
+		legendInteractive={ true }
+	/>
+);
+export const InteractiveLegend: Story = {
+	render: () => <InteractiveLegendComponent />,
 };
 
 // Story showing a real-world dashboard layout with centralized legends

--- a/projects/js-packages/charts/src/components/legend/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/legend/stories/index.stories.tsx
@@ -193,28 +193,49 @@ const DashboardWithCentralizedLegend = () => {
 						chartId="dashboard-revenue"
 						data={ lineChartData }
 						showLegend={ false }
-						width={ 600 }
-						height={ 200 }
+						height={ 300 }
 						withGradientFill={ false }
 						withLegendGlyph={ false }
 					/>
 				</div>
 
-				<div style={ { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '20px' } }>
-					<div style={ { backgroundColor: 'white', padding: '20px', borderRadius: '4px' } }>
+				<div
+					style={ {
+						display: 'grid',
+						gridTemplateColumns: '1fr 1fr',
+						gap: '20px',
+					} }
+				>
+					<div
+						style={ {
+							backgroundColor: 'white',
+							padding: '20px',
+							borderRadius: '4px',
+						} }
+					>
 						<h3 style={ { margin: '0 0 20px 0' } }>Sales by Quarter</h3>
 						<BarChart
 							chartId="dashboard-sales"
 							data={ barChartData }
 							showLegend={ false }
-							width={ 280 }
-							height={ 200 }
+							height={ 300 }
 						/>
 					</div>
 
-					<div style={ { backgroundColor: 'white', padding: '20px', borderRadius: '4px' } }>
+					<div
+						style={ {
+							backgroundColor: 'white',
+							padding: '20px',
+							borderRadius: '4px',
+						} }
+					>
 						<h3 style={ { margin: '0 0 20px 0' } }>Device Distribution</h3>
-						<PieChart chartId="dashboard-devices" data={ pieChartData } showLegend={ false } />
+						<PieChart
+							chartId="dashboard-devices"
+							data={ pieChartData }
+							showLegend={ false }
+							height={ 300 }
+						/>
 					</div>
 				</div>
 			</div>

--- a/projects/js-packages/charts/src/components/legend/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/legend/stories/index.stories.tsx
@@ -86,7 +86,6 @@ export const Default: Story = {
 			{ label: 'Desktop', value: '65%', color: '#3858E9' },
 			{ label: 'Mobile', value: '35%', color: '#80C8FF' },
 		],
-		orientation: 'horizontal',
 	},
 };
 

--- a/projects/js-packages/charts/src/providers/chart-context/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/providers/chart-context/stories/index.docs.mdx
@@ -121,8 +121,10 @@ The Global Charts Context uses a comprehensive theme system that controls all vi
 		xAxisLineStyles: { stroke: '#DCDCDE', strokeWidth: 1 },
 
 		// Legend appearance
-		legendLabelStyles: {
-			color: 'var(--jp-gray-80, #2c3338)',
+		legend: {
+			labelStyles: {
+				color: 'var(--jp-gray-80, #2c3338)',
+			},
 		},
 
 		// Chart-specific theming
@@ -232,7 +234,7 @@ Access just the theme when you only need styling information:
 		return (
 			<div style={ {
 				backgroundColor: theme.backgroundColor,
-				color: theme.legendLabelStyles?.color
+				color: theme.legend?.labelStyles?.color
 			} }>
 				Styled using global chart theme
 			</div>

--- a/projects/js-packages/charts/src/providers/chart-context/test/chart-context.test.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/test/chart-context.test.tsx
@@ -987,10 +987,12 @@ describe( 'ChartContext', () => {
 
 			const extendedTheme = {
 				...mockTheme,
-				legendShapeStyles: [
-					{ fill: '#LEGEND1', stroke: '#BORDER1' },
-					{ fill: '#LEGEND2', strokeWidth: 3 },
-				],
+				legend: {
+					shapeStyles: [
+						{ fill: '#LEGEND1', stroke: '#BORDER1' },
+						{ fill: '#LEGEND2', strokeWidth: 3 },
+					],
+				},
 			};
 
 			render(
@@ -1087,7 +1089,9 @@ describe( 'ChartContext', () => {
 						},
 					},
 				},
-				legendShapeStyles: [ { fill: '#LEGEND1', stroke: '#BORDER1' } ],
+				legend: {
+					shapeStyles: [ { fill: '#LEGEND1', stroke: '#BORDER1' } ],
+				},
 			};
 
 			render(
@@ -1234,7 +1238,9 @@ describe( 'ChartContext', () => {
 				...mockTheme,
 				glyphs: [ mockGlyph ],
 				seriesLineStyles: [ { strokeWidth: 2 } ],
-				legendShapeStyles: [ { fill: '#SHAPE1' } ],
+				legend: {
+					shapeStyles: [ { fill: '#SHAPE1' } ],
+				},
 			};
 
 			render(

--- a/projects/js-packages/charts/src/providers/chart-context/themes.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/themes.ts
@@ -17,12 +17,14 @@ const defaultTheme: CompleteChartTheme = {
 	gridColorDark: '',
 	xTickLineStyles: { stroke: 'black' },
 	xAxisLineStyles: { stroke: '#DCDCDE', strokeWidth: 1 },
-	legendLabelStyles: {
-		color: 'var(--jp-gray-80, #2c3338)',
+	legend: {
+		labelStyles: {
+			color: 'var(--jp-gray-80, #2c3338)',
+		},
+		containerStyles: {},
+		shapeStyles: [],
 	},
-	legendContainerStyles: {},
 	seriesLineStyles: [],
-	legendShapeStyles: [],
 	glyphs: [],
 	svgLabelSmall: { fill: 'var(--jp-gray-80, #2c3338)' },
 	annotationStyles: {

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -450,7 +450,7 @@ export type BaseChartProps< T = DataPoint | DataPointDate | LeaderboardEntry > =
 	legendItemClassName?: string;
 	/**
 	 * Enable interactive legend items that can toggle series visibility.
-	 * Supported for LineChart, PieChart, and PieSemiCircleChart.
+	 * Supported for all chart types that render series.
 	 * Requires chartId and GlobalChartsProvider.
 	 * For pie charts, percentages are recalculated so visible segments total 100%.
 	 */

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -210,14 +210,17 @@ export type ChartTheme = {
 	xAxisLineStyles?: LineStyles;
 	/** Styles for series lines */
 	seriesLineStyles?: LineStyles[];
-	/** Styles for legend shapes */
-	legendShapeStyles?: Record< string, unknown >[];
 	/** Array of render functions for glyphs */
 	glyphs?: Array< < Datum extends object >( props: GlyphProps< Datum > ) => ReactNode >;
-	/** Styles for legend labels */
-	legendLabelStyles?: CSSProperties;
-	/** Styles for legend container */
-	legendContainerStyles?: CSSProperties;
+	/** Legend specific settings */
+	legend?: {
+		/** Styles for legend shapes */
+		shapeStyles?: Record< string, unknown >[];
+		/** Styles for legend labels */
+		labelStyles?: CSSProperties;
+		/** Styles for legend container */
+		containerStyles?: CSSProperties;
+	};
 	/** Styles for small SVG text (eg. axis tick labels), passed through to the XYChart theme. */
 	svgLabelSmall?: TextProps;
 	annotationStyles?: AnnotationStyles;
@@ -287,6 +290,7 @@ export type CompleteChartTheme = Required< ChartTheme > & {
 	lineChart: {
 		lineStyles: Record< NonNullable< SeriesDataOptions[ 'type' ] >, LineStyles >;
 	};
+	legend: Required< NonNullable< ChartTheme[ 'legend' ] > >;
 	sparkline: Required< NonNullable< ChartTheme[ 'sparkline' ] > > & {
 		margin: Required< NonNullable< ChartTheme[ 'sparkline' ] >[ 'margin' ] >;
 	};

--- a/projects/js-packages/charts/src/utils/get-styles.ts
+++ b/projects/js-packages/charts/src/utils/get-styles.ts
@@ -62,7 +62,7 @@ export function getItemShapeStyles(
 ): Record< string, unknown > {
 	const seriesShapeStyles = series.options?.legendShapeStyle ?? {};
 	const lineStyles = legendShape === 'line' ? getSeriesLineStyles( series, index, theme ) : {};
-	const themeShapeStyles = theme.legendShapeStyles?.[ index ];
+	const themeShapeStyles = theme.legend?.shapeStyles?.[ index ];
 
 	const itemShapeStyles = {
 		...seriesShapeStyles,

--- a/projects/js-packages/charts/src/utils/test/get-styles.test.ts
+++ b/projects/js-packages/charts/src/utils/test/get-styles.test.ts
@@ -20,10 +20,12 @@ describe( 'Series styling utility functions', () => {
 			},
 		},
 		seriesLineStyles: [ { strokeWidth: 2 }, { strokeWidth: 3, strokeDasharray: '2 2' } ],
-		legendShapeStyles: [
-			{ fill: '#LEGEND1', stroke: '#BORDER1' },
-			{ fill: '#LEGEND2', strokeWidth: 3 },
-		],
+		legend: {
+			shapeStyles: [
+				{ fill: '#LEGEND1', stroke: '#BORDER1' },
+				{ fill: '#LEGEND2', strokeWidth: 3 },
+			],
+		},
 	};
 
 	describe( 'getSeriesStroke', () => {
@@ -152,7 +154,7 @@ describe( 'Series styling utility functions', () => {
 			};
 
 			const result = getItemShapeStyles( comparisonSeries, 0, mockTheme as ChartTheme, 'rect' );
-			expect( result ).toEqual( mockTheme.legendShapeStyles[ 0 ] );
+			expect( result ).toEqual( mockTheme.legend.shapeStyles[ 0 ] );
 		} );
 
 		it( 'merges custom shape styles with line styles for line shape', () => {
@@ -186,13 +188,13 @@ describe( 'Series styling utility functions', () => {
 				mockTheme as ChartTheme,
 				'rect'
 			);
-			expect( result ).toEqual( mockTheme.legendShapeStyles[ 1 ] );
+			expect( result ).toEqual( mockTheme.legend.shapeStyles[ 1 ] );
 		} );
 
 		it( 'returns empty object when no theme shape styles and no meaningful custom styles', () => {
 			const themeWithoutShapeStyles = {
 				...mockTheme,
-				legendShapeStyles: undefined,
+				legend: { shapeStyles: undefined },
 			} as ChartTheme;
 
 			const result = getItemShapeStyles( mockSeriesData, 0, themeWithoutShapeStyles, 'rect' );
@@ -254,7 +256,7 @@ describe( 'Series styling utility functions', () => {
 
 		it( 'works without legendShape parameter', () => {
 			const result = getItemShapeStyles( mockSeriesData, 0, mockTheme as ChartTheme );
-			expect( result ).toEqual( mockTheme.legendShapeStyles[ 0 ] );
+			expect( result ).toEqual( mockTheme.legend.shapeStyles[ 0 ] );
 		} );
 
 		it( 'handles other legendShape string values like "circle"', () => {
@@ -265,7 +267,7 @@ describe( 'Series styling utility functions', () => {
 
 			const result = getItemShapeStyles( comparisonSeries, 0, mockTheme as ChartTheme, 'circle' );
 			// Should not include line styles for circle shape
-			expect( result ).toEqual( mockTheme.legendShapeStyles[ 0 ] );
+			expect( result ).toEqual( mockTheme.legend.shapeStyles[ 0 ] );
 		} );
 
 		it( 'handles React component as legendShape parameter', () => {
@@ -282,7 +284,7 @@ describe( 'Series styling utility functions', () => {
 				CustomShape
 			);
 			// Should not include line styles for component shape
-			expect( result ).toEqual( mockTheme.legendShapeStyles[ 0 ] );
+			expect( result ).toEqual( mockTheme.legend.shapeStyles[ 0 ] );
 		} );
 
 		it( 'prioritizes series line styles over theme line styles when legendShape is line', () => {


### PR DESCRIPTION
Fixes [CHARTS-36: Legends: group all legend options to a property rather than put everything on the top level](https://linear.app/a8c/issue/CHARTS-36/legends-group-all-legend-options-to-a-property-rather-than-put)

## Summary

Consolidate the three top-level `ChartTheme` legend properties into a nested `legend` object and restructure the legend documentation to follow the charts documentation guide.

## Proposed changes:

* Nest `legendShapeStyles`, `legendLabelStyles`, and `legendContainerStyles` under a single `legend` property (`legend.shapeStyles`, `legend.labelStyles`, `legend.containerStyles`) to align with established theme patterns (e.g. `leaderboardChart`, `sparkline`).
* Update all component, utility, test, and documentation references to use the new nested paths.
* Restructure legend docs to follow the charts documentation guide — correct section order, promote Theming Integration to a top-level heading, move Interactive Legends before Styling, add missing code examples.
* Add an `InteractiveLegend` story with Canvas and rename `Horizontal` story to `Default`.
* Fix inaccurate docs claiming interactive legends are limited to LineChart/BarChart — all chart types support `legendInteractive`.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Verify types: the `ChartTheme` type should have a `legend` property with `shapeStyles`, `labelStyles`, and `containerStyles` nested within it. The old `legendShapeStyles`, `legendLabelStyles`, `legendContainerStyles` properties should no longer exist.
* Run `jp test js js-packages/charts` — all tests should pass with the updated theme property paths.
* Open Storybook and navigate to **JS Packages / Charts Library / Components / Legend**:
  * The Default story should render (previously named Horizontal).
  * The InteractiveLegend story should show a LineChart with clickable legend items that toggle series visibility.
  * Verify docs render correctly with all Canvas + Source block pairings.

## Changelog

- [x] Generate changelog entries for this PR (using AI).
