### PR TITLE
Forms: use title at dashboard when at top level

### DIFF
--- a/projects/packages/forms/changelog/pr-47446
+++ b/projects/packages/forms/changelog/pr-47446
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms dashboard: Use title header on top-level pages for consistency with other Jetpack pages.

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -508,6 +508,7 @@ function StageInner() {
 	}, [] );
 
 	const {
+		title,
 		breadcrumbs,
 		subtitle,
 		actions: headerActions,
@@ -531,6 +532,7 @@ function StageInner() {
 		<Page
 			showSidebarToggle={ false }
 			breadcrumbs={ breadcrumbs }
+			title={ title }
 			subTitle={ subtitle }
 			actions={ headerActions }
 			hasPadding={ false }

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -546,6 +546,7 @@ function StageInner() {
 		breadcrumbs,
 		badges,
 		subtitle,
+		title,
 		actions: headerActions,
 	} = usePageHeaderDetails( {
 		screen: 'responses',
@@ -571,6 +572,7 @@ function StageInner() {
 			showSidebarToggle={ false }
 			breadcrumbs={ breadcrumbs }
 			badges={ badges }
+			title={ title }
 			subTitle={ subtitle }
 			actions={ headerActions }
 			hasPadding={ false }

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -47,6 +47,7 @@ type UsePageHeaderDetailsProps = {
 
 type UsePageHeaderDetailsReturn = {
 	breadcrumbs: ReactNode;
+	title?: ReactNode;
 	badges?: ReactNode;
 	subtitle: ReactNode;
 	actions?: ReactNode;
@@ -182,25 +183,37 @@ export default function usePageHeaderDetails(
 		return controls;
 	}, [ sourceIdNumber, formTitle, duplicateForm, previewForm, copyEmbed, copyShortcode ] );
 
-	const breadcrumbsItems = useMemo( () => {
-		if ( isSingleFormScreen ) {
-			return [
-				{ label: __( 'Forms', 'jetpack-forms' ), to: '/forms' },
-				{ label: formTitle || __( 'Form responses', 'jetpack-forms' ) },
-			];
-		}
+	const WrapWithJetpackLogo = ( { children }: { children: ReactNode } ) => (
+		<Stack align="center" gap="xs">
+			<JetpackLogo showText={ false } width={ 20 } />
+			{ children }
+		</Stack>
+	);
 
-		return [ { label: __( 'Forms', 'jetpack-forms' ) } ];
-	}, [ formTitle, isSingleFormScreen ] );
+	const title = useMemo( () => {
+		if ( isSingleFormScreen ) {
+			return null;
+		}
+		// "Forms" is a product name, do not translate.
+		return <WrapWithJetpackLogo>Forms</WrapWithJetpackLogo>;
+	}, [ isSingleFormScreen ] );
 
 	const breadcrumbs = useMemo( () => {
+		if ( ! isSingleFormScreen ) {
+			return null;
+		}
+
 		return (
-			<Stack align="center" gap="xs">
-				<JetpackLogo showText={ false } width={ 20 } />
-				<Breadcrumbs items={ breadcrumbsItems } />
-			</Stack>
+			<WrapWithJetpackLogo>
+				<Breadcrumbs
+					items={ [
+						{ label: __( 'Forms', 'jetpack-forms' ), to: '/forms' },
+						{ label: formTitle || __( 'Form responses', 'jetpack-forms' ) },
+					] }
+				/>
+			</WrapWithJetpackLogo>
 		);
-	}, [ breadcrumbsItems ] );
+	}, [ isSingleFormScreen, formTitle ] );
 
 	const subtitle = useMemo( () => {
 		if ( isFormsScreen ) {
@@ -473,5 +486,5 @@ export default function usePageHeaderDetails(
 		emptySpam.selectedResponsesCount,
 	] );
 
-	return { breadcrumbs, badges, subtitle, actions };
+	return { breadcrumbs, title, badges, subtitle, actions };
 }

--- a/projects/plugins/jetpack/changelog/pr-47446
+++ b/projects/plugins/jetpack/changelog/pr-47446
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Forms: Use title header on top-level dashboard pages for consistency with other Jetpack pages.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Fixes JETPACK-1400

Make the header more consistent across all other Jetpack pages by using `title` (bigger text) rather than `breadcrumbs` (smaller text) on top-level pages.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Use `title` in `Page` component for Forms dashboard when at top level (forms list, all responses) and breadcrumbs only when deeper into the hierarchy (Forms -> Form responses)
* Don't translate "Forms" as it's a product name

### Before

<img width="1512" height="252" alt="image" src="https://github.com/user-attachments/assets/7b0db09d-788d-42fe-9cac-a1f0f81e8342" />
<img width="1512" height="298" alt="image" src="https://github.com/user-attachments/assets/8695860b-6888-49b2-b8c1-22100f866d1f" />
<img width="1512" height="299" alt="image" src="https://github.com/user-attachments/assets/b081c111-edfb-4c83-b703-18d2554fc06d" />


### After

<img width="1520" height="331" alt="image" src="https://github.com/user-attachments/assets/6571a540-6758-4318-98a9-585833210e0b" />
<img width="1512" height="264" alt="image" src="https://github.com/user-attachments/assets/cf762759-6213-4c9f-ab86-35c570eeb4d3" />
<img width="1512" height="221" alt="image" src="https://github.com/user-attachments/assets/a0f2b8c9-ed66-494d-b8d7-2b954b4aec4d" />



### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test old dashboard continues to look good
* Test new dashboard, use flags:
```php
add_filter('jetpack_forms_alpha', '__return_true');
add_filter( 'jetpack_block_editor_feature_flags', 'central_form_management_feature' );
function central_form_management_feature( $flags ) {
	$flags['reusable-forms'] = true;
	$flags['central-form-management'] = true;
	return $flags;
}
```
* Test forms screen, responses screen, and individual forms responses screen
* Compare to other Jetpack screens around
    <img width="717" height="152" alt="image" src="https://github.com/user-attachments/assets/84cda08c-064a-4b7b-a830-b0a4a9da8573" />


## Changelog
<!-- Check one of the boxes below. -->

- [x] Generate changelog entries for this PR (using AI).
