### PR TITLE
Backup: use core components for popup modal

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1912,6 +1912,9 @@ importers:
       '@wordpress/i18n':
         specifier: 6.13.0
         version: 6.13.0
+      '@wordpress/icons':
+        specifier: 11.7.0
+        version: 11.7.0(react@18.3.1)
       moment:
         specifier: 2.30.1
         version: 2.30.1

--- a/projects/packages/backup/changelog/pr-47448
+++ b/projects/packages/backup/changelog/pr-47448
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Storage popover: use core components and remove custom CSS.

--- a/projects/packages/backup/package.json
+++ b/projects/packages/backup/package.json
@@ -41,6 +41,7 @@
 		"@wordpress/date": "5.40.0",
 		"@wordpress/element": "6.40.0",
 		"@wordpress/i18n": "6.13.0",
+		"@wordpress/icons": "11.7.0",
 		"moment": "2.30.1",
 		"prop-types": "^15.8.1",
 		"react": "18.3.1",

--- a/projects/packages/backup/src/js/components/backup-storage-space/storage-help-popover/index.jsx
+++ b/projects/packages/backup/src/js/components/backup-storage-space/storage-help-popover/index.jsx
@@ -1,8 +1,14 @@
-import { Button, Gridicon, getProductCheckoutUrl } from '@automattic/jetpack-components';
-import { ExternalLink, Popover } from '@wordpress/components';
+import { getProductCheckoutUrl } from '@automattic/jetpack-components';
+import {
+	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	Button,
+	ExternalLink,
+	Popover,
+} from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { createInterpolateElement, useCallback, useRef, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { closeSmall, info } from '@wordpress/icons';
 import useAnalytics from '../../../hooks/useAnalytics';
 import { STORE_ID } from '../../../store';
 import './style.scss';
@@ -45,27 +51,17 @@ const StorageHelpPopover = ( { className, forecastInDays } ) => {
 		true
 	);
 
-	const forecastStatement = sprintf(
-		/* translators: %d: is number of days of the forecast */
-		_n(
-			'Based on the current size of your site, Jetpack will save <strong>%d day of full backup</strong>.',
-			'Based on the current size of your site, Jetpack will save <strong>%d days of full backups</strong>.',
-			forecastInDays,
-			'jetpack-backup-pkg'
-		),
-		forecastInDays
-	);
 	return (
 		<span className={ className }>
 			<Button
-				size="small"
-				variant="tertiary"
-				className="backup-storage-space__toggle-popover"
+				__next40pxDefaultSize
+				icon={ info }
+				label={ __( 'Backup archive size', 'jetpack-backup-pkg' ) }
 				onClick={ toggleHelpPopover }
 				ref={ popover }
-			>
-				<Gridicon icon="info-outline" size={ 20 } />
-			</Button>
+				size="small"
+				className="backup-storage-space__help-popover"
+			/>
 			{ isPopoverVisible && (
 				<Popover
 					className="backup-storage-space__popover"
@@ -73,19 +69,30 @@ const StorageHelpPopover = ( { className, forecastInDays } ) => {
 					context={ popover.current }
 					noArrow={ false }
 				>
+					<Button
+						__next40pxDefaultSize
+						className="backup-storage-space__close-popover"
+						icon={ closeSmall }
+						onClick={ toggleHelpPopover }
+						label={ __( 'Close', 'jetpack-backup-pkg' ) }
+					/>
 					<h3> { __( 'Backup archive size', 'jetpack-backup-pkg' ) }</h3>
 					<p>
-						{ createInterpolateElement( forecastStatement, {
-							strong: <strong />,
-						} ) }
-						<Button
-							size="small"
-							variant="tertiary"
-							className="backup-storage-space__close-popover"
-							onClick={ toggleHelpPopover }
-						>
-							<Gridicon icon="cross" size={ 18 } />
-						</Button>
+						{ createInterpolateElement(
+							sprintf(
+								/* translators: %d: is number of days of the forecast */
+								_n(
+									'Based on the current size of your site, Jetpack will save <strong>%d day of full backup</strong>.',
+									'Based on the current size of your site, Jetpack will save <strong>%d days of full backups</strong>.',
+									forecastInDays,
+									'jetpack-backup-pkg'
+								),
+								forecastInDays
+							),
+							{
+								strong: <strong />,
+							}
+						) }
 					</p>
 					<p>
 						{ createInterpolateElement(
@@ -100,7 +107,7 @@ const StorageHelpPopover = ( { className, forecastInDays } ) => {
 							}
 						) }
 					</p>
-					<div className="backup-storage-space__button-section">
+					<HStack justify="flex-end" className="backup-storage-space__button-section">
 						<Button
 							variant="primary"
 							href={ storageUpgradeUrl }
@@ -108,7 +115,7 @@ const StorageHelpPopover = ( { className, forecastInDays } ) => {
 						>
 							{ __( 'Add more storage', 'jetpack-backup-pkg' ) }
 						</Button>
-					</div>
+					</HStack>
 				</Popover>
 			) }
 		</span>

--- a/projects/packages/backup/src/js/components/backup-storage-space/storage-help-popover/style.scss
+++ b/projects/packages/backup/src/js/components/backup-storage-space/storage-help-popover/style.scss
@@ -1,7 +1,8 @@
+@use "@automattic/jetpack-base-styles/gutenberg-base-styles" as gb;
+
 .backup-storage-space {
 
 	&__help-popover {
-		line-height: 28px;
 		vertical-align: top;
 		display: inline-block;
 	}
@@ -9,83 +10,18 @@
 	&__popover.components-popover {
 
 		.components-popover__content {
-			padding: 24px;
-			color: var(--jp-gray-70);
-			background: #fff;
-			border-radius: 2px;
-			box-shadow: 0 12px 20px rgba(0, 0, 0, 0.08);
-			border: 1px solid #dcdcde;
-			text-align: start;
-			width: 304px;
-
-			h3 {
-				margin-bottom: 16px;
-			}
-
-			p {
-				font-size: 1rem;
-				color: var(--jp-gray-80);
-			}
-
-			hr {
-				margin-bottom: 0.25rem;
-			}
-
-			p > a {
-				text-decoration: underline;
-			}
-		}
-	}
-
-	&__toggle-popover {
-
-		&.components-button {
-			padding: 0 4px !important;
-			height: auto !important;
-			box-shadow: none !important;
-			background: transparent;
-
-			.gridicon {
-				color: var(--jp-gray-30);
-			}
-		}
-
-		&.components-button:focus {
-			box-shadow: none !important;
-			background: transparent;
+			min-width: 300px;
+			padding: gb.$grid-unit-20;
 		}
 	}
 
 	&__close-popover {
 		position: absolute;
-		right: 24px;
-		top: 24px;
-
-		&.components-button {
-			height: 24px;
-			width: 24px;
-			padding: 0 !important;
-			color: var(--jp-gray-50);
-			box-shadow: none !important;
-
-			span {
-				height: 18px;
-				border: none;
-			}
-		}
-
-		&.components-button:hover {
-			border: 0 !important;
-		}
+		right: gb.$grid-unit-20;
+		top: gb.$grid-unit-20;
 	}
 
 	&__button-section {
-		display: flex;
-		justify-content: flex-end;
 		margin-top: 24px;
-
-		.button {
-			padding: 8px 24px;
-		}
 	}
 }

--- a/projects/packages/backup/src/js/components/backup-storage-space/storage-usage-details/style.scss
+++ b/projects/packages/backup/src/js/components/backup-storage-space/storage-usage-details/style.scss
@@ -9,13 +9,6 @@
 		gap: 4px;
 	}
 
-	div,
-	a {
-		color: var(--jp-gray-80);
-		font-weight: 400;
-		line-height: 20px;
-	}
-
 	.backup-storage-space__usage-text {
 		font-size: 16px;
 	}

--- a/projects/plugins/backup/changelog/pr-47448
+++ b/projects/plugins/backup/changelog/pr-47448
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Storage popover: use core components and remove custom CSS.

--- a/projects/plugins/jetpack/changelog/pr-47448
+++ b/projects/plugins/jetpack/changelog/pr-47448
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Backup: use core components for storage popover.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Uses core components and removes custom CSS for storage popover in Backup plugin. This was already visually broken in production so also a bugfix. :-(
 
I was testing things for color switch work https://github.com/Automattic/jetpack/pull/47317 and the broken button caught my attention, but it's best to just switch to core components here.

### Before

<img width="1428" height="393" alt="Screenshot 2026-03-04 at 15 44 34" src="https://github.com/user-attachments/assets/fc3f9092-1994-49dc-8aaa-36e58227168a" />
<img width="1419" height="473" alt="Screenshot 2026-03-04 at 15 44 29" src="https://github.com/user-attachments/assets/fe5d9671-a9f3-456c-89a9-ed2a082814e4" />


### After

<img width="1414" height="397" alt="Screenshot 2026-03-04 at 15 43 22" src="https://github.com/user-attachments/assets/ee2aa7c8-7fe5-4e0f-bd1a-499a58d35761" />
<img width="1421" height="393" alt="Screenshot 2026-03-04 at 15 43 27" src="https://github.com/user-attachments/assets/726dc0df-ab6a-4b1e-8cff-66c805d82045" />


### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Build backup ` jetpack build plugins/backup`
* In backup UI, see the popover.

## Changelog
<!-- Check one of the boxes below. -->

- [x] Generate changelog entries for this PR (using AI).
