### PR TITLE
Forms: Add missing 'Trash' status label in stage component

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-trash-label
+++ b/projects/packages/forms/changelog/fix-forms-trash-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add missing 'Trash' status label in stage component.

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -240,6 +240,8 @@ function StageInner() {
 				return __( 'Scheduled', 'jetpack-forms' );
 			case 'private':
 				return __( 'Private', 'jetpack-forms' );
+			case 'trash':
+				return __( 'Trash', 'jetpack-forms' );
 			default:
 				return status;
 		}

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -25,7 +25,7 @@ import { FORM_POST_TYPE } from '../../src/blocks/shared/util/constants.js';
 import CreateFormButton from '../../src/dashboard/components/create-form-button/index.tsx';
 import { EmptyWrapper } from '../../src/dashboard/components/empty-responses/index.tsx';
 import { FormNameModal } from '../../src/dashboard/components/form-name-modal';
-import { NON_TRASH_FORM_STATUSES } from '../../src/dashboard/constants';
+import { NON_TRASH_FORM_STATUSES, getFormStatusLabel } from '../../src/dashboard/constants';
 import useDeleteForm from '../../src/dashboard/hooks/use-delete-form.ts';
 import useFormsData from '../../src/dashboard/hooks/use-forms-data.ts';
 import WpRouteDashboardSearchParamsProvider from '../../src/dashboard/router/wp-route-dashboard-search-params-provider.tsx';
@@ -228,25 +228,6 @@ function StageInner() {
 		[ renameFormItem, saveEntityRecord, createSuccessNotice, createErrorNotice ]
 	);
 
-	const statusLabel = useCallback( ( status: string ) => {
-		switch ( status ) {
-			case 'publish':
-				return __( 'Published', 'jetpack-forms' );
-			case 'draft':
-				return __( 'Draft', 'jetpack-forms' );
-			case 'pending':
-				return __( 'Pending review', 'jetpack-forms' );
-			case 'future':
-				return __( 'Scheduled', 'jetpack-forms' );
-			case 'private':
-				return __( 'Private', 'jetpack-forms' );
-			case 'trash':
-				return __( 'Trash', 'jetpack-forms' );
-			default:
-				return status;
-		}
-	}, [] );
-
 	const fields = useMemo(
 		() => [
 			{
@@ -270,7 +251,7 @@ function StageInner() {
 				label: __( 'Status', 'jetpack-forms' ),
 				getValue: ( { item }: { item: FormListItem } ) => item.status,
 				render: ( { item }: { item: FormListItem } ) => (
-					<Badge intent="draft">{ statusLabel( item.status ) }</Badge>
+					<Badge intent="draft">{ getFormStatusLabel( item.status ) }</Badge>
 				),
 				elements: [
 					{ label: __( 'All', 'jetpack-forms' ), value: 'all' },
@@ -293,7 +274,7 @@ function StageInner() {
 				enableSorting: false,
 			},
 		],
-		[ dateSettings.formats.datetime, statusLabel ]
+		[ dateSettings.formats.datetime ]
 	);
 
 	const openSingleFormView = useCallback(

--- a/projects/packages/forms/src/dashboard/constants.ts
+++ b/projects/packages/forms/src/dashboard/constants.ts
@@ -1,6 +1,7 @@
 /**
  * Shared dashboard constants (JS/TS).
  */
+import { __ } from '@wordpress/i18n';
 
 /**
  * Non-trash form statuses (matches WP core list behavior).
@@ -8,3 +9,28 @@
  * Used for global counts and default "All" filters where trash should be excluded.
  */
 export const NON_TRASH_FORM_STATUSES = 'publish,draft,pending,future,private';
+
+/**
+ * Get the translated label for a form post status.
+ *
+ * @param status - WordPress post status slug.
+ * @return Translated status label.
+ */
+export function getFormStatusLabel( status: string ): string {
+	switch ( status ) {
+		case 'publish':
+			return __( 'Published', 'jetpack-forms' );
+		case 'draft':
+			return __( 'Draft', 'jetpack-forms' );
+		case 'pending':
+			return __( 'Pending review', 'jetpack-forms' );
+		case 'future':
+			return __( 'Scheduled', 'jetpack-forms' );
+		case 'private':
+			return __( 'Private', 'jetpack-forms' );
+		case 'trash':
+			return __( 'Trash', 'jetpack-forms' );
+		default:
+			return status;
+	}
+}

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -23,6 +23,7 @@ import EmptyTrashButton from '../../components/empty-trash-button';
 import EmptyTrashConfirmationModal from '../../components/empty-trash-button/confirmation-modal';
 import ExportResponsesButton from '../../components/export-responses/button';
 import ExportResponsesModal from '../../components/export-responses/modal';
+import { getFormStatusLabel } from '../../constants';
 import useCreateForm from '../../hooks/use-create-form';
 import useEmptySpam from '../../hooks/use-empty-spam';
 import useEmptyTrash from '../../hooks/use-empty-trash';
@@ -123,22 +124,7 @@ export default function usePageHeaderDetails(
 
 	const formStatus = formRecord?.status;
 
-	const statusLabel = useMemo( () => {
-		switch ( formStatus ) {
-			case 'publish':
-				return __( 'Published', 'jetpack-forms' );
-			case 'draft':
-				return __( 'Draft', 'jetpack-forms' );
-			case 'pending':
-				return __( 'Pending review', 'jetpack-forms' );
-			case 'future':
-				return __( 'Scheduled', 'jetpack-forms' );
-			case 'private':
-				return __( 'Private', 'jetpack-forms' );
-			default:
-				return formStatus;
-		}
-	}, [ formStatus ] );
+	const statusLabel = formStatus ? getFormStatusLabel( formStatus ) : undefined;
 
 	const badges = useMemo( () => {
 		if ( ! isSingleFormScreen || ! formStatus || formStatus === 'publish' ) {

--- a/projects/packages/forms/tests/js/dashboard/constants.test.js
+++ b/projects/packages/forms/tests/js/dashboard/constants.test.js
@@ -1,0 +1,18 @@
+import { getFormStatusLabel } from '../../../src/dashboard/constants';
+
+describe( 'getFormStatusLabel', () => {
+	it.each( [
+		[ 'publish', 'Published' ],
+		[ 'draft', 'Draft' ],
+		[ 'pending', 'Pending review' ],
+		[ 'future', 'Scheduled' ],
+		[ 'private', 'Private' ],
+		[ 'trash', 'Trash' ],
+	] )( 'returns "%s" label for "%s" status', ( status, expected ) => {
+		expect( getFormStatusLabel( status ) ).toBe( expected );
+	} );
+
+	it( 'returns the raw status string for unknown statuses', () => {
+		expect( getFormStatusLabel( 'custom-status' ) ).toBe( 'custom-status' );
+	} );
+} );


### PR DESCRIPTION
## Proposed changes:
* Add the missing `trash` case to the `statusLabel` function in the forms list stage component, so trashed forms display "Trash" instead of the raw `trash` status string.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

* Open the Jetpack Forms management page (wp-admin → Jetpack → Forms)
* Move a form to the Trash
* Click the "Trash" filter to view trashed forms
* Verify the status column shows the translated "Trash" label instead of the raw `trash` string

## Changelog

- [x] Generate changelog entries for this PR (using AI).