### PR TITLE
Forms: scope useBlockEditingMode to widget editor context only

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-test-missing-edit
+++ b/projects/packages/forms/changelog/fix-forms-test-missing-edit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Extract WidgetEditorReadonlyView into its own component to scope useBlockEditingMode to widget editor context only

--- a/projects/packages/forms/src/blocks/contact-form/components/convert-form-toolbar.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/convert-form-toolbar.tsx
@@ -9,34 +9,11 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { addQueryArgs } from '@wordpress/url';
-import { FORM_POST_TYPE } from '../../shared/util/constants.js';
 import { createSyncedForm } from '../util/create-synced-form.ts';
-import { getEditorContext, type EditorContext } from '../util/get-editor-context.ts';
+import { getEditorContext } from '../util/get-editor-context.ts';
+import { navigateToForm } from '../util/navigate-to-form.ts';
 
 const FORM_CONVERSION_LOCK = 'jetpack-form-conversion';
-
-/**
- * Navigate to edit a form post.
- * - Widget/Site editor: redirects in same page (no in-editor navigation available)
- * - Post editor: uses in-editor navigation if available
- *
- * @param formId                   - The form post ID to edit.
- * @param editorContext            - The current editor context.
- * @param onNavigateToEntityRecord - Optional callback for in-editor navigation.
- */
-export const navigateToForm = (
-	formId: number,
-	editorContext: EditorContext,
-	onNavigateToEntityRecord?: ( params: { postId: number; postType: string } ) => void
-) => {
-	if ( editorContext === 'widget' || editorContext === 'site' ) {
-		const editUrl = addQueryArgs( 'post.php', { post: formId, action: 'edit' } );
-		window.location.href = editUrl;
-	} else if ( onNavigateToEntityRecord ) {
-		onNavigateToEntityRecord( { postId: formId, postType: FORM_POST_TYPE } );
-	}
-};
 
 interface ConvertFormToolbarProps {
 	clientId: string;

--- a/projects/packages/forms/src/blocks/contact-form/components/widget-editor-readonly-view.scss
+++ b/projects/packages/forms/src/blocks/contact-form/components/widget-editor-readonly-view.scss
@@ -1,0 +1,11 @@
+.wp-block-jetpack-contact-form {
+
+	.jetpack-contact-form-widget-readonly-notice {
+		margin: 8px 0 4px;
+
+		.components-notice__action.components-button {
+			margin-left: 0;
+			margin-top: 8px;
+		}
+	}
+}

--- a/projects/packages/forms/src/blocks/contact-form/components/widget-editor-readonly-view.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/widget-editor-readonly-view.tsx
@@ -1,4 +1,4 @@
-import { useBlockEditingMode } from '@wordpress/block-editor';
+import { useBlockEditingMode, useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 import { Disabled, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { navigateToForm } from '../util/navigate-to-form.ts';
@@ -12,8 +12,8 @@ export default function WidgetEditorReadonlyView( {
 	formRef,
 	flushPendingSave,
 }: {
-	blockProps: Record< string, unknown >;
-	innerBlocksProps: Record< string, unknown >;
+	blockProps: ReturnType< typeof useBlockProps >;
+	innerBlocksProps: ReturnType< typeof useInnerBlocksProps >;
 	isResolvingSyncedForm: boolean;
 	formRef: number;
 	flushPendingSave: () => void;

--- a/projects/packages/forms/src/blocks/contact-form/components/widget-editor-readonly-view.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/widget-editor-readonly-view.tsx
@@ -1,0 +1,56 @@
+import { useBlockEditingMode } from '@wordpress/block-editor';
+import { Disabled, Notice } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { navigateToForm } from './convert-form-toolbar.tsx';
+import ContactFormSkeletonLoader from './jetpack-contact-form-skeleton-loader.js';
+import './widget-editor-readonly-view.scss';
+
+export default function WidgetEditorReadonlyView( {
+	blockProps,
+	innerBlocksProps,
+	isResolvingSyncedForm,
+	formRef,
+	flushPendingSave,
+}: {
+	blockProps: Record< string, unknown >;
+	innerBlocksProps: Record< string, unknown >;
+	isResolvingSyncedForm: boolean;
+	formRef: number;
+	flushPendingSave: () => void;
+} ) {
+	useBlockEditingMode( 'contentOnly' );
+
+	const handleEditForm = () => {
+		flushPendingSave();
+		navigateToForm( formRef, 'widget' );
+	};
+
+	return (
+		<div { ...blockProps }>
+			<Notice
+				className="jetpack-contact-form-widget-readonly-notice"
+				status="info"
+				isDismissible={ false }
+				actions={ [
+					{
+						label: __( 'Edit Form', 'jetpack-forms' ),
+						onClick: handleEditForm,
+						variant: 'primary',
+					},
+				] }
+			>
+				{ __(
+					'Forms are edited in the Form Editor. Changes will sync back to this widget.',
+					'jetpack-forms'
+				) }
+			</Notice>
+			{ isResolvingSyncedForm ? (
+				<ContactFormSkeletonLoader />
+			) : (
+				<Disabled>
+					<div { ...innerBlocksProps } />
+				</Disabled>
+			) }
+		</div>
+	);
+}

--- a/projects/packages/forms/src/blocks/contact-form/components/widget-editor-readonly-view.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/widget-editor-readonly-view.tsx
@@ -1,7 +1,7 @@
 import { useBlockEditingMode } from '@wordpress/block-editor';
 import { Disabled, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { navigateToForm } from './convert-form-toolbar.tsx';
+import { navigateToForm } from '../util/navigate-to-form.ts';
 import ContactFormSkeletonLoader from './jetpack-contact-form-skeleton-loader.js';
 import './widget-editor-readonly-view.scss';
 

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -13,11 +13,9 @@ import {
 	store as blockEditorStore,
 	BlockControls,
 	BlockContextProvider,
-	useBlockEditingMode,
 } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import {
-	Disabled,
 	ExternalLink,
 	Notice,
 	PanelBody,
@@ -51,12 +49,13 @@ import useFormSteps from '../shared/hooks/use-form-steps.js';
 import { SyncedAttributeProvider } from '../shared/hooks/use-synced-attributes.js';
 import { CORE_BLOCKS, FORM_POST_TYPE } from '../shared/util/constants.js';
 import { childBlocks } from './child-blocks.js';
-import { ConvertFormToolbar, navigateToForm } from './components/convert-form-toolbar.tsx';
+import { ConvertFormToolbar } from './components/convert-form-toolbar.tsx';
 import FormStatusNotice from './components/form-status-notice.tsx';
 import { ContactFormPlaceholder } from './components/jetpack-contact-form-placeholder.js';
 import ContactFormSkeletonLoader from './components/jetpack-contact-form-skeleton-loader.js';
 import NotificationsSettings from './components/notifications-settings.js';
 import WebhooksSettings from './components/webhooks-settings.js';
+import WidgetEditorReadonlyView from './components/widget-editor-readonly-view.tsx';
 import { useSyncedFormAutoSave } from './hooks/use-synced-form-auto-save.ts';
 import { useSyncedFormLoader } from './hooks/use-synced-form-loader.ts';
 import { useSyncedForm } from './hooks/use-synced-form.ts';
@@ -215,8 +214,6 @@ function JetpackContactFormEdit( {
 
 	// Check if we're in widget editor with a synced form (ref)
 	const isWidgetEditorWithRef = !! ref && getEditorContext() === 'widget';
-
-	useBlockEditingMode( isWidgetEditorWithRef ? 'contentOnly' : 'default' );
 
 	// Load synced form data from the jetpack_form post type
 	const {
@@ -1022,38 +1019,14 @@ function JetpackContactFormEdit( {
 	}
 	// In widget editor, synced forms (with ref) are not editable
 	else if ( isWidgetEditorWithRef ) {
-		const handleEditForm = () => {
-			flushPendingSave();
-			navigateToForm( ref as number, 'widget' );
-		};
-
 		return (
-			<div { ...blockProps }>
-				<Notice
-					className="jetpack-contact-form-widget-readonly-notice"
-					status="info"
-					isDismissible={ false }
-					actions={ [
-						{
-							label: __( 'Edit Form', 'jetpack-forms' ),
-							onClick: handleEditForm,
-							variant: 'primary',
-						},
-					] }
-				>
-					{ __(
-						'Forms are edited in the Form Editor. Changes will sync back to this widget.',
-						'jetpack-forms'
-					) }
-				</Notice>
-				{ isResolvingSyncedForm ? (
-					<ContactFormSkeletonLoader />
-				) : (
-					<Disabled>
-						<div { ...innerBlocksProps } />
-					</Disabled>
-				) }
-			</div>
+			<WidgetEditorReadonlyView
+				blockProps={ blockProps }
+				innerBlocksProps={ innerBlocksProps }
+				isResolvingSyncedForm={ isResolvingSyncedForm }
+				formRef={ ref as number }
+				flushPendingSave={ flushPendingSave }
+			/>
 		);
 	} else if ( ! isModuleActive ) {
 		if ( isLoadingModules ) {

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -210,15 +210,6 @@
 		}
 	}
 
-	/* Fixes notices styling when Gutenberg is not there */
-	.jetpack-contact-form-widget-readonly-notice {
-		margin: 8px 0 4px;
-
-		.components-notice__action.components-button {
-			margin-left: 0;
-			margin-top: 8px;
-		}
-	}
 }
 
 .jetpack-contact-form .components-placeholder {

--- a/projects/packages/forms/src/blocks/contact-form/util/navigate-to-form.ts
+++ b/projects/packages/forms/src/blocks/contact-form/util/navigate-to-form.ts
@@ -1,0 +1,25 @@
+import { addQueryArgs } from '@wordpress/url';
+import { FORM_POST_TYPE } from '../../shared/util/constants.js';
+import type { EditorContext } from './get-editor-context.ts';
+
+/**
+ * Navigate to edit a form post.
+ * - Widget/Site editor: redirects in same page (no in-editor navigation available)
+ * - Post editor: uses in-editor navigation if available
+ *
+ * @param formId                   - The form post ID to edit.
+ * @param editorContext            - The current editor context.
+ * @param onNavigateToEntityRecord - Optional callback for in-editor navigation.
+ */
+export const navigateToForm = (
+	formId: number,
+	editorContext: EditorContext,
+	onNavigateToEntityRecord?: ( params: { postId: number; postType: string } ) => void
+) => {
+	if ( editorContext === 'widget' || editorContext === 'site' ) {
+		const editUrl = addQueryArgs( 'post.php', { post: formId, action: 'edit' } );
+		window.location.href = editUrl;
+	} else if ( onNavigateToEntityRecord ) {
+		onNavigateToEntityRecord( { postId: formId, postType: FORM_POST_TYPE } );
+	}
+};

--- a/projects/packages/forms/tests/js/contact-form/components/convert-form-toolbar.test.js
+++ b/projects/packages/forms/tests/js/contact-form/components/convert-form-toolbar.test.js
@@ -85,8 +85,11 @@ await jest.unstable_mockModule(
 	} )
 );
 
-const { ConvertFormToolbar, navigateToForm } = await import(
+const { ConvertFormToolbar } = await import(
 	'../../../../src/blocks/contact-form/components/convert-form-toolbar'
+);
+const { navigateToForm } = await import(
+	'../../../../src/blocks/contact-form/util/navigate-to-form'
 );
 
 describe( 'ConvertFormToolbar', () => {


### PR DESCRIPTION
Fixes p1772581662124869/1772575553.036159-slack-C01U2KGS2PQ 

## Proposed changes:
* Extract the widget editor readonly view into a dedicated `WidgetEditorReadonlyView` component
* Move `useBlockEditingMode('contentOnly')` into this component so it's only called when the widget editor view renders
* Previously, `useBlockEditingMode('default')` was called unconditionally for all non-widget contexts, which could interfere with the expected editing mode
* Move associated CSS styles into a co-located SCSS file

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
See p1772581662124869/1772575553.036159-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
* Open a widget editor that contains a synced Jetpack form (with a `ref` attribute)
* Verify the form shows the readonly notice with "Edit Form" button and `contentOnly` editing mode is active
* Open a regular post/page editor with a Jetpack form block
* Verify the form editing behavior is unchanged — no `'default'` editing mode is being forced

on .com 
Open a pattern with the form on it. 
Notice that you can open the pattern editor by clicking on the form. 

## Changelog

- [x] Generate changelog entries for this PR (using AI).