### PR TITLE
Forms: Fix dashboard loading styles

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-loading
+++ b/projects/packages/forms/changelog/fix-forms-loading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed dashboard loading styles to prevent rounded corners and grey background flash caused by WordPress boot view-transitions.

--- a/projects/packages/forms/src/dashboard/style.scss
+++ b/projects/packages/forms/src/dashboard/style.scss
@@ -22,6 +22,11 @@
 	--jp-forms-z-modal: 10010;
 }
 
+
+#wpwrap {
+	background-color: #fff !important;
+}
+
 body[class*="_page_jetpack-forms"],
 body.jetpack_page_jetpack-forms-admin {
 
@@ -31,6 +36,14 @@ body.jetpack_page_jetpack-forms-admin {
 
 	#wpfooter {
 		display: none;
+	}
+
+	.boot-layout__inspector,
+	.boot-layout__stage {
+		border-radius: 0 !important;
+		// Disable view-transition animations that apply border-radius: 8px
+		// on ::view-transition-new/old pseudo-elements from @wordpress/boot.
+		view-transition-name: none !important;
 	}
 }
 


### PR DESCRIPTION
Before

<img width="1099" height="360" alt="Screenshot 2026-03-04 at 4 29 13 PM" src="https://github.com/user-attachments/assets/578afc33-4686-45ce-8e06-85c753817b14" />


After
<img width="1103" height="343" alt="Screenshot 2026-03-04 at 4 29 24 PM" src="https://github.com/user-attachments/assets/59bffed2-9b13-4ca3-baff-0b092aea8dcb" />

This is how the loading looks like now. 

https://github.com/user-attachments/assets/4e064500-7807-4374-a5f0-b05fa76cbc55


## Proposed changes:
* Set `#wpwrap` background to white to prevent a grey flash during Forms dashboard loading
* Disable `view-transition-name` on `.boot-layout__inspector` and `.boot-layout__stage` elements to prevent `@wordpress/boot` from applying `border-radius: 8px` via `::view-transition-new/old` pseudo-elements

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
Make sure you have the new wp build UI enabled. 
```
add_filter( 'jetpack_forms_alpha', '__return_true');
```
* Go to the Jetpack Forms dashboard (wp-admin → Jetpack → Forms)
* Observe the page loads without rounded corners on the inspector and stage panels
* Observe no grey background flash during initial page load

## Changelog
- [x] Generate changelog entries for this PR (using AI).