### PR TITLE
Forms Dashboard: Improve empty state messaging for new users

### DIFF
--- a/projects/packages/forms/changelog/add-forms-auto-open-inserter
+++ b/projects/packages/forms/changelog/add-forms-auto-open-inserter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Form Editor: Auto-open the block inserter on load so form field blocks are immediately discoverable.

--- a/projects/packages/forms/changelog/claude-competent-hawking
+++ b/projects/packages/forms/changelog/claude-competent-hawking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Dashboard: Improve "Missing forms?" empty state for new users by removing it from the empty state and updating the subtitle copy to "Not seeing all your forms?" shown only when the user has existing forms.

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -4,8 +4,6 @@
 import { Page } from '@wordpress/admin-ui';
 import {
 	__experimentalConfirmDialog as ConfirmDialog, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-	Button,
-	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -549,16 +547,11 @@ function StageInner() {
 							'jetpack-forms'
 						) }
 						actions={
-							<HStack justify="center" spacing="2">
-								<CreateFormButton
-									label={ __( 'Create a new form', 'jetpack-forms' ) }
-									variant="primary"
-									showIcon={ false }
-								/>
-								<Button size="compact" variant="secondary" onClick={ openFormsHelpModal }>
-									{ __( 'Missing forms?', 'jetpack-forms' ) }
-								</Button>
-							</HStack>
+							<CreateFormButton
+								label={ __( 'Create a new form', 'jetpack-forms' ) }
+								variant="primary"
+								showIcon={ false }
+							/>
 						}
 					/>
 				}

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -208,13 +208,13 @@ export default function usePageHeaderDetails(
 			const longMessage = __( 'View and manage all your forms in one place.', 'jetpack-forms' );
 
 			const shouldShowFormsHelpLink =
-				!! onOpenFormsHelp && ( typeof formsCount !== 'number' || formsCount < 5 );
+				!! onOpenFormsHelp && typeof formsCount === 'number' && formsCount > 0 && formsCount < 5;
 
 			return shouldShowFormsHelpLink ? (
 				<>
 					{ shortMessage }{ ' ' }
 					<Button variant="link" onClick={ onOpenFormsHelp }>
-						{ __( 'Missing forms?', 'jetpack-forms' ) }
+						{ __( 'Not seeing all your forms?', 'jetpack-forms' ) }
 					</Button>
 				</>
 			) : (

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -117,6 +117,7 @@ const state = {
 	lastRootBlockIds: '',
 	lastSelectedBlockId: null as string | null | undefined,
 	isFormBlockLocked: false,
+	hasOpenedInserter: false,
 };
 
 const BLOCK_DIRECTORY_PLUGIN_NAME = 'block-directory';
@@ -218,6 +219,16 @@ const enforceBlockSelection = () => {
 	if ( hasMultiSelection() ) {
 		return;
 	}
+
+	// Don't force-select when the inserter is open — selecting a block
+	// can close the inserter or change its context.
+	const { isInserterOpened } = select( 'core/editor' ) as {
+		isInserterOpened: () => boolean;
+	};
+	if ( isInserterOpened() ) {
+		return;
+	}
+
 	const selectedBlockId = getSelectedBlockClientId();
 	if ( ! selectedBlockId ) {
 		const { selectBlock } = dispatch( 'core/block-editor' ) as {
@@ -392,6 +403,7 @@ const setupFormEditorSubscription = () => {
 					state.lastRootBlockIds = '';
 					state.lastSelectedBlockId = null;
 					state.isFormBlockLocked = false;
+					state.hasOpenedInserter = false;
 				}
 			}
 
@@ -454,7 +466,47 @@ const setupFormEditorSubscription = () => {
 				enforceBlockNesting();
 			}
 
-			// 5. React to selection changes
+			// 5. Auto-open the block inserter (once) after blocks are ready
+			if ( ! state.hasOpenedInserter && state.formBlockClientId ) {
+				const { getBlock: getBlockForInserter } = select( 'core/block-editor' );
+				const currentFormBlock = getBlockForInserter( state.formBlockClientId );
+				const hasAnyInnerBlocks = currentFormBlock && currentFormBlock.innerBlocks.length > 0;
+
+				if ( hasAnyInnerBlocks ) {
+					state.hasOpenedInserter = true;
+
+					// Skip on mobile — inserter takes over the full screen.
+					const isDesktop = window.innerWidth >= 782;
+
+					// Skip if user prefers the list view sidebar (same slot).
+					const showListView = (
+						select( 'core/preferences' ) as {
+							get: ( scope: string, name: string ) => boolean;
+						}
+					 ).get( 'core', 'showListViewByDefault' );
+
+					// Skip in distraction-free mode — Gutenberg hides the inserter.
+					const distractionFree = (
+						select( 'core/preferences' ) as {
+							get: ( scope: string, name: string ) => boolean;
+						}
+					 ).get( 'core', 'distractionFree' );
+
+					if ( isDesktop && ! showListView && ! distractionFree ) {
+						requestAnimationFrame( () => {
+							if ( ! state.isFormEditor ) {
+								return;
+							}
+							const { setIsInserterOpened } = dispatch( 'core/editor' ) as {
+								setIsInserterOpened: ( isOpened: boolean ) => void;
+							};
+							setIsInserterOpened( true );
+						} );
+					}
+				}
+			}
+
+			// 6. React to selection changes
 			const { getSelectedBlockClientId } = select( 'core/block-editor' );
 			const currentSelectedBlockId = getSelectedBlockClientId();
 			if ( currentSelectedBlockId !== state.lastSelectedBlockId ) {
@@ -462,7 +514,7 @@ const setupFormEditorSubscription = () => {
 				enforceBlockSelection();
 			}
 
-			// 6. Ensure form block is locked
+			// 7. Ensure form block is locked
 			if ( ! state.isFormBlockLocked && state.formBlockClientId ) {
 				lockFormBlock();
 				const { getBlock } = select( 'core/block-editor' );


### PR DESCRIPTION
## Proposed changes:
* Remove the "Missing forms?" button from the empty state in the Forms list. New users who have never created any forms now see only the "Create a new form" button, avoiding confusion that implies their forms were lost.
* Update the subtitle help link to only appear when the user has 1–4 existing managed forms (previously it showed when `formsCount < 5`, including 0).
* Change the help link copy from "Missing forms?" to "Not seeing all your forms?" to match the modal title and use less alarming language.

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:
* Open the Jetpack Forms dashboard on a site with **no managed forms** (new user scenario).
* Verify that the empty state shows only the heading "You're set up. No forms yet." with a single "Create a new form" button — no "Missing forms?" button.
* On a site with **1–4 managed forms**, verify the page subtitle shows "View and manage all your forms. Not seeing all your forms?" with a clickable link.
* On a site with **5+ managed forms**, verify the subtitle shows only "View and manage all your forms in one place." with no help link.
* Click "Not seeing all your forms?" and verify the help modal opens correctly with instructions on converting form blocks.

## Changelog
- [x] Generate changelog entries for this PR (using AI).