### PR TITLE
Forms Dashboard: Improve empty state messaging for new users

### DIFF
--- a/projects/packages/forms/changelog/claude-competent-hawking
+++ b/projects/packages/forms/changelog/claude-competent-hawking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Dashboard: Improve "Missing forms?" empty state for new users by removing it from the empty state and updating the subtitle copy to "Not seeing all your forms?" shown only when the user has existing forms.

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -4,7 +4,9 @@
 import { formatNumber } from '@automattic/number-formatters';
 import { Page } from '@wordpress/admin-ui';
 import {
+	Button,
 	__experimentalConfirmDialog as ConfirmDialog, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -88,6 +90,7 @@ function StageInner() {
 	const adminUrl = ( useConfigValue( 'adminUrl' ) as string ) || '';
 	const isIntegrationsEnabled = useConfigValue( 'isIntegrationsEnabled' );
 	const showDashboardIntegrations = useConfigValue( 'showDashboardIntegrations' );
+	const hasFormBlocks = useConfigValue( 'hasFormBlocks' );
 
 	const [ view, setView ] = useState< View >( () => ( {
 		...DEFAULT_VIEW,
@@ -589,6 +592,7 @@ function StageInner() {
 	} = usePageHeaderDetails( {
 		screen: 'forms',
 		formsCount: statusCounts.all,
+		hasFormBlocks: !! hasFormBlocks,
 		isIntegrationsEnabled: !! isIntegrationsEnabled,
 		showDashboardIntegrations: !! showDashboardIntegrations,
 		onOpenIntegrations: openIntegrationsModal,
@@ -633,6 +637,22 @@ function StageInner() {
 								'jetpack-forms'
 							) }
 							actions={
+								hasFormBlocks ? (
+								<HStack justify="center" spacing="2">
+									<CreateFormButton
+										label={ __( 'Create a new form', 'jetpack-forms' ) }
+										variant="primary"
+										showIcon={ false }
+									/>
+									<Button
+										size="compact"
+										variant="secondary"
+										onClick={ openFormsHelpModal }
+									>
+										{ __( 'Not seeing all your forms?', 'jetpack-forms' ) }
+									</Button>
+								</HStack>
+							) : (
 								<CreateFormButton
 									label={ __( 'Create a new form', 'jetpack-forms' ) }
 									variant="primary"

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -636,24 +636,18 @@ function StageInner() {
 								'jetpack-forms'
 							) }
 							actions={
-								hasClassicForms ? (
-									<HStack justify="center" spacing="2">
-										<CreateFormButton
-											label={ __( 'Create a new form', 'jetpack-forms' ) }
-											variant="primary"
-											showIcon={ false }
-										/>
-										<Button size="compact" variant="secondary" onClick={ openFormsHelpModal }>
-											{ __( 'Not seeing all your forms?', 'jetpack-forms' ) }
-										</Button>
-									</HStack>
-								) : (
+								<HStack justify="center" spacing="2">
 									<CreateFormButton
 										label={ __( 'Create a new form', 'jetpack-forms' ) }
 										variant="primary"
 										showIcon={ false }
 									/>
-								)
+									{ hasClassicForms && (
+										<Button size="compact" variant="secondary" onClick={ openFormsHelpModal }>
+											{ __( 'Not seeing all your forms?', 'jetpack-forms' ) }
+										</Button>
+									) }
+								</HStack>
 							}
 						/>
 					)

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -90,7 +90,7 @@ function StageInner() {
 	const adminUrl = ( useConfigValue( 'adminUrl' ) as string ) || '';
 	const isIntegrationsEnabled = useConfigValue( 'isIntegrationsEnabled' );
 	const showDashboardIntegrations = useConfigValue( 'showDashboardIntegrations' );
-	const hasFormBlocks = useConfigValue( 'hasFormBlocks' );
+	const hasClassicForms = useConfigValue( 'hasClassicForms' );
 
 	const [ view, setView ] = useState< View >( () => ( {
 		...DEFAULT_VIEW,
@@ -591,8 +591,7 @@ function StageInner() {
 		actions: headerActions,
 	} = usePageHeaderDetails( {
 		screen: 'forms',
-		formsCount: statusCounts.all,
-		hasFormBlocks: !! hasFormBlocks,
+		hasClassicForms: !! hasClassicForms,
 		isIntegrationsEnabled: !! isIntegrationsEnabled,
 		showDashboardIntegrations: !! showDashboardIntegrations,
 		onOpenIntegrations: openIntegrationsModal,
@@ -637,27 +636,24 @@ function StageInner() {
 								'jetpack-forms'
 							) }
 							actions={
-								hasFormBlocks ? (
-								<HStack justify="center" spacing="2">
+								hasClassicForms ? (
+									<HStack justify="center" spacing="2">
+										<CreateFormButton
+											label={ __( 'Create a new form', 'jetpack-forms' ) }
+											variant="primary"
+											showIcon={ false }
+										/>
+										<Button size="compact" variant="secondary" onClick={ openFormsHelpModal }>
+											{ __( 'Not seeing all your forms?', 'jetpack-forms' ) }
+										</Button>
+									</HStack>
+								) : (
 									<CreateFormButton
 										label={ __( 'Create a new form', 'jetpack-forms' ) }
 										variant="primary"
 										showIcon={ false }
 									/>
-									<Button
-										size="compact"
-										variant="secondary"
-										onClick={ openFormsHelpModal }
-									>
-										{ __( 'Not seeing all your forms?', 'jetpack-forms' ) }
-									</Button>
-								</HStack>
-							) : (
-								<CreateFormButton
-									label={ __( 'Create a new form', 'jetpack-forms' ) }
-									variant="primary"
-									showIcon={ false }
-								/>
+								)
 							}
 						/>
 					)

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -5,8 +5,6 @@ import { formatNumber } from '@automattic/number-formatters';
 import { Page } from '@wordpress/admin-ui';
 import {
 	__experimentalConfirmDialog as ConfirmDialog, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-	Button,
-	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -635,16 +633,11 @@ function StageInner() {
 								'jetpack-forms'
 							) }
 							actions={
-								<HStack justify="center" spacing="2">
-									<CreateFormButton
-										label={ __( 'Create a new form', 'jetpack-forms' ) }
-										variant="primary"
-										showIcon={ false }
-									/>
-									<Button size="compact" variant="secondary" onClick={ openFormsHelpModal }>
-										{ __( 'Missing forms?', 'jetpack-forms' ) }
-									</Button>
-								</HStack>
+								<CreateFormButton
+									label={ __( 'Create a new form', 'jetpack-forms' ) }
+									variant="primary"
+									showIcon={ false }
+								/>
 							}
 						/>
 					)

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -1560,7 +1560,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'fileIconsUrl'                   => Jetpack_Forms::plugin_url() . 'contact-form/images/file-icons/',
 			'siteURL'                        => ( new Status() )->get_site_suffix(),
 			'hasFeedback'                    => ( new Forms_Dashboard() )->has_feedback(),
-			'hasFormBlocks'                  => ( new Forms_Dashboard() )->has_form_blocks(),
+			'hasClassicForms'                => ( new Forms_Dashboard() )->get_classic_forms_state() === 'classic',
 			'isNotesEnabled'                 => Forms_Dashboard::is_notes_enabled(),
 			'isIntegrationsEnabled'          => Jetpack_Forms::is_integrations_enabled(),
 			'isWebhooksEnabled'              => Jetpack_Forms::is_webhooks_enabled(),

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -307,6 +307,17 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			)
 		);
 
+		// Dismiss the classic forms notice.
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/dismiss-classic-forms-notice',
+			array(
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'dismiss_classic_forms_notice' ),
+				'permission_callback' => array( $this, 'get_items_permissions_check' ),
+			)
+		);
+
 		// Get optimized status counts.
 		register_rest_route(
 			$this->namespace,
@@ -1537,6 +1548,17 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				'count'     => Contact_Form_Plugin::get_unread_count(),
 			)
 		);
+	}
+
+	/**
+	 * Dismiss the classic forms notice by updating the option to 'dismissed'.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function dismiss_classic_forms_notice() {
+		update_option( Forms_Dashboard::CLASSIC_FORMS_OPTION, 'dismissed', false );
+
+		return rest_ensure_response( array( 'success' => true ) );
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -1560,6 +1560,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'fileIconsUrl'                   => Jetpack_Forms::plugin_url() . 'contact-form/images/file-icons/',
 			'siteURL'                        => ( new Status() )->get_site_suffix(),
 			'hasFeedback'                    => ( new Forms_Dashboard() )->has_feedback(),
+			'hasFormBlocks'                  => ( new Forms_Dashboard() )->has_form_blocks(),
 			'isNotesEnabled'                 => Forms_Dashboard::is_notes_enabled(),
 			'isIntegrationsEnabled'          => Jetpack_Forms::is_integrations_enabled(),
 			'isWebhooksEnabled'              => Jetpack_Forms::is_webhooks_enabled(),

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -1556,7 +1556,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function dismiss_classic_forms_notice() {
-		update_option( Forms_Dashboard::CLASSIC_FORMS_OPTION, 'dismissed', false );
+		update_option( Forms_Dashboard::CLASSIC_FORMS_OPTION, Forms_Dashboard::CLASSIC_FORMS_STATE_DISMISSED, false );
 
 		return rest_ensure_response( array( 'success' => true ) );
 	}
@@ -1582,7 +1582,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'fileIconsUrl'                   => Jetpack_Forms::plugin_url() . 'contact-form/images/file-icons/',
 			'siteURL'                        => ( new Status() )->get_site_suffix(),
 			'hasFeedback'                    => ( new Forms_Dashboard() )->has_feedback(),
-			'hasClassicForms'                => ( new Forms_Dashboard() )->get_classic_forms_state() === 'classic',
+			'hasClassicForms'                => ( new Forms_Dashboard() )->get_classic_forms_state() === Forms_Dashboard::CLASSIC_FORMS_STATE_CLASSIC,
 			'isNotesEnabled'                 => Forms_Dashboard::is_notes_enabled(),
 			'isIntegrationsEnabled'          => Jetpack_Forms::is_integrations_enabled(),
 			'isWebhooksEnabled'              => Jetpack_Forms::is_webhooks_enabled(),

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Forms\ContactForm;
 
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Device_Detection\User_Agent_Info;
+use Automattic\Jetpack\Forms\Dashboard\Dashboard as Forms_Dashboard;
 use WP_Post;
 /**
  * Handles the response for a contact form submission.
@@ -1316,6 +1317,12 @@ class Feedback {
 				'comment_status' => self::STATUS_UNREAD, // New feedback is unread by default.
 			)
 		);
+
+		// If this feedback does not have a jetpack_form parent,
+		// it's a classic form — mark the state accordingly.
+		if ( empty( $this->form_id ) ) {
+			Forms_Dashboard::mark_classic_form_detected();
+		}
 
 		$feedback_post = get_post( $post_id );
 		return $feedback_post ?? 0;

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -359,6 +359,31 @@ class Dashboard {
 	}
 
 	/**
+	 * Returns true if there are any posts or pages containing a Jetpack form block or shortcode.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return boolean
+	 */
+	public function has_form_blocks() {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$result = $wpdb->get_var(
+			"SELECT 1 FROM {$wpdb->posts}
+			WHERE post_status IN ('publish', 'draft', 'pending', 'future', 'private')
+			AND post_type IN ('post', 'page')
+			AND (
+				post_content LIKE '%<!-- wp:jetpack/contact-form%'
+				OR post_content LIKE '%[contact-form%'
+			)
+			LIMIT 1"
+		);
+
+		return (bool) $result;
+	}
+
+	/**
 	 * Returns url of forms admin page.
 	 *
 	 * @param string|null $tab Tab to open in the forms admin page.

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -365,10 +365,26 @@ class Dashboard {
 	const CLASSIC_FORMS_OPTION = 'jetpack_forms_classic_state';
 
 	/**
+	 * Classic forms state: site has classic (non-synced) form submissions.
+	 */
+	const CLASSIC_FORMS_STATE_CLASSIC = 'classic';
+
+	/**
+	 * Classic forms state: no classic form submissions detected.
+	 */
+	const CLASSIC_FORMS_STATE_HIDDEN = 'hidden';
+
+	/**
+	 * Classic forms state: user dismissed the classic forms notice.
+	 */
+	const CLASSIC_FORMS_STATE_DISMISSED = 'dismissed';
+
+	/**
 	 * Returns the classic forms state for the current site.
 	 *
 	 * Returns 'classic' if the site has form submissions (feedback posts) that were not
-	 * created by a synced/reusable jetpack_form, or 'hidden' otherwise.
+	 * created by a synced/reusable jetpack_form, 'dismissed' if the user dismissed the
+	 * classic forms notice, or 'hidden' otherwise.
 	 *
 	 * The result is persisted in a WP option so the detection query only runs once per site.
 	 * After that, the cached value is returned on every subsequent call. The cache is also
@@ -376,7 +392,7 @@ class Dashboard {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return string 'classic' or 'hidden'.
+	 * @return string 'classic', 'hidden', or 'dismissed'.
 	 */
 	public function get_classic_forms_state() {
 		$state = get_option( self::CLASSIC_FORMS_OPTION );
@@ -433,7 +449,7 @@ class Dashboard {
 			)
 		);
 
-		return $result ? 'classic' : 'hidden';
+		return $result ? self::CLASSIC_FORMS_STATE_CLASSIC : self::CLASSIC_FORMS_STATE_HIDDEN;
 	}
 
 	/**
@@ -443,10 +459,19 @@ class Dashboard {
 	 * This avoids re-running the detection query — once a classic submission is observed, the
 	 * state is permanently set without needing to scan the database again.
 	 *
+	 * If the user has already dismissed the classic forms notice, the state is left as
+	 * 'dismissed' so the notice does not reappear.
+	 *
 	 * @since $$next-version$$
 	 */
 	public static function mark_classic_form_detected() {
-		update_option( self::CLASSIC_FORMS_OPTION, 'classic', false );
+		$current = get_option( self::CLASSIC_FORMS_OPTION );
+
+		if ( self::CLASSIC_FORMS_STATE_DISMISSED === $current ) {
+			return;
+		}
+
+		update_option( self::CLASSIC_FORMS_OPTION, self::CLASSIC_FORMS_STATE_CLASSIC, false );
 	}
 
 	/**

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -10,6 +10,7 @@ namespace Automattic\Jetpack\Forms\Dashboard;
 use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
+use Automattic\Jetpack\Forms\ContactForm\Contact_Form;
 use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin;
 use Automattic\Jetpack\Tracking;
 use Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills;
@@ -359,28 +360,93 @@ class Dashboard {
 	}
 
 	/**
-	 * Returns true if there are any posts or pages containing a Jetpack form block or shortcode.
+	 * Option name for storing classic forms state.
+	 */
+	const CLASSIC_FORMS_OPTION = 'jetpack_forms_classic_state';
+
+	/**
+	 * Returns the classic forms state for the current site.
+	 *
+	 * Returns 'classic' if the site has form submissions (feedback posts) that were not
+	 * created by a synced/reusable jetpack_form, or 'hidden' otherwise.
+	 *
+	 * The result is persisted in a WP option so the detection query only runs once per site.
+	 * After that, the cached value is returned on every subsequent call. The cache is also
+	 * updated eagerly via mark_classic_form_detected() when new classic submissions arrive.
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @return boolean
+	 * @return string 'classic' or 'hidden'.
 	 */
-	public function has_form_blocks() {
+	public function get_classic_forms_state() {
+		$state = get_option( self::CLASSIC_FORMS_OPTION );
+
+		if ( $state ) {
+			return $state;
+		}
+
+		$state = $this->detect_classic_forms();
+		update_option( self::CLASSIC_FORMS_OPTION, $state, false );
+
+		return $state;
+	}
+
+	/**
+	 * Detects whether any feedback posts exist that are not linked to a jetpack_form post,
+	 * indicating the site has classic (inline, widget, or template) forms.
+	 *
+	 * A feedback post is considered "classic" if:
+	 * - It has no parent (post_parent = 0), meaning it was created by a form embedded in a
+	 *   widget, page template, or other non-post context.
+	 * - Its parent exists but is not a jetpack_form post, meaning it was created by a form
+	 *   block or shortcode placed directly in a post or page.
+	 *
+	 * The query uses a LEFT JOIN on the posts table to find feedback posts with no matching
+	 * jetpack_form parent. This leverages the primary key index for the join and the
+	 * type_status_date index for filtering by post_type, making it efficient even on large
+	 * sites. The LIMIT 1 ensures early exit as soon as one classic form is found.
+	 *
+	 * Note: An alternative approach would be to search post_content for the form block markup
+	 * (<!-- wp:jetpack/contact-form) or shortcode ([contact-form]). However, that requires a
+	 * full-text scan of the posts table (LIKE '%...%' on a TEXT column) with no usable index,
+	 * making it significantly more expensive. The feedback-based approach also better fits the
+	 * use case: we only need to surface the "Not seeing all your forms?" prompt when there are
+	 * actual submissions that won't appear under any synced form in the dashboard.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string 'classic' or 'hidden'.
+	 */
+	private function detect_classic_forms() {
 		global $wpdb;
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$result = $wpdb->get_var(
-			"SELECT 1 FROM {$wpdb->posts}
-			WHERE post_status IN ('publish', 'draft', 'pending', 'future', 'private')
-			AND post_type IN ('post', 'page')
-			AND (
-				post_content LIKE '%<!-- wp:jetpack/contact-form%'
-				OR post_content LIKE '%[contact-form%'
+			$wpdb->prepare(
+				"SELECT 1 FROM {$wpdb->posts} AS f
+				LEFT JOIN {$wpdb->posts} AS p
+					ON p.ID = f.post_parent AND p.post_type = %s
+				WHERE f.post_type = 'feedback'
+				AND p.ID IS NULL
+				LIMIT 1",
+				Contact_Form::POST_TYPE
 			)
-			LIMIT 1"
 		);
 
-		return (bool) $result;
+		return $result ? 'classic' : 'hidden';
+	}
+
+	/**
+	 * Eagerly marks the site as having classic forms by setting the option to 'classic'.
+	 *
+	 * Called when a new form submission is saved that does not belong to a synced jetpack_form.
+	 * This avoids re-running the detection query — once a classic submission is observed, the
+	 * state is permanently set without needing to scan the database again.
+	 *
+	 * @since $$next-version$$
+	 */
+	public static function mark_classic_form_detected() {
+		update_option( self::CLASSIC_FORMS_OPTION, 'classic', false );
 	}
 
 	/**

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -3,7 +3,11 @@
  */
 import { JetpackLogo } from '@automattic/jetpack-components';
 import apiFetch from '@wordpress/api-fetch';
-import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import {
+	Button,
+	__experimentalConfirmDialog as ConfirmDialog, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews/wp';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
@@ -23,6 +27,7 @@ import { NON_TRASH_FORM_STATUSES } from '../constants.ts';
 import useDeleteForm from '../hooks/use-delete-form.ts';
 import useFormsData from '../hooks/use-forms-data.ts';
 import { getFormEditUrl } from '../utils.ts';
+import FormsHelpModal from '../wp-build/components/forms-help-modal/index.tsx';
 import { defaultLayouts, useView } from './views.ts';
 import './style.scss';
 import type { FormListItem } from '../hooks/use-forms-data.ts';
@@ -38,6 +43,11 @@ export default function FormsDashboardForms(): JSX.Element | null {
 	const adminUrl = ( useConfigValue( 'adminUrl' ) as string ) || '';
 	const isCentralFormManagementEnabled = useConfigValue( 'isCentralFormManagementEnabled' );
 	const isCentralFormManagementDisabled = isCentralFormManagementEnabled === false;
+	const hasClassicForms = useConfigValue( 'hasClassicForms' );
+
+	const [ isFormsHelpModalOpen, setIsFormsHelpModalOpen ] = useState( false );
+	const openFormsHelpModal = useCallback( () => setIsFormsHelpModalOpen( true ), [] );
+	const closeFormsHelpModal = useCallback( () => setIsFormsHelpModalOpen( false ), [] );
 
 	const dateSettings = getDateSettings();
 	const [ view, setView ] = useView();
@@ -410,7 +420,18 @@ export default function FormsDashboardForms(): JSX.Element | null {
 						{ __( 'Forms', 'jetpack-forms' ) }
 					</div>
 				}
-				subTitle={ __( 'View and manage all your forms in one place.', 'jetpack-forms' ) }
+				subTitle={
+					hasClassicForms ? (
+						<>
+							{ __( 'View and manage all your forms.', 'jetpack-forms' ) }{ ' ' }
+							<Button variant="link" onClick={ openFormsHelpModal }>
+								{ __( 'Not seeing all your forms?', 'jetpack-forms' ) }
+							</Button>
+						</>
+					) : (
+						__( 'View and manage all your forms in one place.', 'jetpack-forms' )
+					)
+				}
 				actions={ headerActions }
 				hasPadding={ false }
 			>
@@ -428,10 +449,22 @@ export default function FormsDashboardForms(): JSX.Element | null {
 								'jetpack-forms'
 							) }
 							actions={
-								<CreateFormButton
-									label={ __( 'Create a new form', 'jetpack-forms' ) }
-									variant="primary"
-								/>
+								hasClassicForms ? (
+									<HStack justify="center" spacing="2">
+										<CreateFormButton
+											label={ __( 'Create a new form', 'jetpack-forms' ) }
+											variant="primary"
+										/>
+										<Button size="compact" variant="secondary" onClick={ openFormsHelpModal }>
+											{ __( 'Not seeing all your forms?', 'jetpack-forms' ) }
+										</Button>
+									</HStack>
+								) : (
+									<CreateFormButton
+										label={ __( 'Create a new form', 'jetpack-forms' ) }
+										variant="primary"
+									/>
+								)
 							}
 						/>
 					}
@@ -475,6 +508,7 @@ export default function FormsDashboardForms(): JSX.Element | null {
 					</div>
 				</DataViews>
 			</Page>
+			<FormsHelpModal isOpen={ isFormsHelpModalOpen } onClose={ closeFormsHelpModal } />
 		</div>
 	);
 }

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -449,22 +449,17 @@ export default function FormsDashboardForms(): JSX.Element | null {
 								'jetpack-forms'
 							) }
 							actions={
-								hasClassicForms ? (
-									<HStack justify="center" spacing="2">
-										<CreateFormButton
-											label={ __( 'Create a new form', 'jetpack-forms' ) }
-											variant="primary"
-										/>
-										<Button size="compact" variant="secondary" onClick={ openFormsHelpModal }>
-											{ __( 'Not seeing all your forms?', 'jetpack-forms' ) }
-										</Button>
-									</HStack>
-								) : (
+								<HStack justify="center" spacing="2">
 									<CreateFormButton
 										label={ __( 'Create a new form', 'jetpack-forms' ) }
 										variant="primary"
 									/>
-								)
+									{ hasClassicForms && (
+										<Button size="compact" variant="secondary" onClick={ openFormsHelpModal }>
+											{ __( 'Not seeing all your forms?', 'jetpack-forms' ) }
+										</Button>
+									) }
+								</HStack>
 							}
 						/>
 					}

--- a/projects/packages/forms/src/dashboard/wp-build/components/forms-help-modal/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/forms-help-modal/index.tsx
@@ -1,13 +1,22 @@
 /**
  * WordPress dependencies
  */
+import apiFetch from '@wordpress/api-fetch';
 import {
 	Button,
+	CheckboxControl,
 	Modal,
+	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { useState, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import { CONFIG_STORE } from '../../../../store/config/index.ts';
 
 type Props = {
 	isOpen: boolean;
@@ -25,12 +34,29 @@ type Props = {
  * @return The modal element, or null when closed.
  */
 export default function FormsHelpModal( { isOpen, onClose }: Props ) {
+	const [ dontShowAgain, setDontShowAgain ] = useState( false );
+	const { receiveConfigValue } = useDispatch( CONFIG_STORE );
+
+	const handleClose = useCallback( () => {
+		if ( dontShowAgain ) {
+			receiveConfigValue( 'hasClassicForms', false );
+			apiFetch( {
+				path: '/wp/v2/feedback/dismiss-classic-forms-notice',
+				method: 'POST',
+			} );
+		}
+		onClose();
+	}, [ dontShowAgain, onClose, receiveConfigValue ] );
+
 	if ( ! isOpen ) {
 		return null;
 	}
 
 	return (
-		<Modal title={ __( 'Not seeing all your forms?', 'jetpack-forms' ) } onRequestClose={ onClose }>
+		<Modal
+			title={ __( 'Not seeing all your forms?', 'jetpack-forms' ) }
+			onRequestClose={ handleClose }
+		>
 			<VStack spacing="4">
 				<Text>
 					{ __( 'The Forms list shows reusable forms, not simple form blocks.', 'jetpack-forms' ) }
@@ -45,16 +71,22 @@ export default function FormsHelpModal( { isOpen, onClose }: Props ) {
 						</li>
 						<li>{ __( 'Select the form block.', 'jetpack-forms' ) }</li>
 						<li>
-							{ __( 'Click “Edit Form” in the block toolbar to convert it.', 'jetpack-forms' ) }
+							{ __( 'Click "Edit Form" in the block toolbar to convert it.', 'jetpack-forms' ) }
 						</li>
 						<li>{ __( 'Save the page or post.', 'jetpack-forms' ) }</li>
 					</ol>
 				</div>
-				<div>
-					<Button variant="primary" onClick={ onClose }>
+				<HStack justify="space-between" alignment="center">
+					<CheckboxControl
+						__nextHasNoMarginBottom
+						label={ __( "Don't show this again", 'jetpack-forms' ) }
+						checked={ dontShowAgain }
+						onChange={ setDontShowAgain }
+					/>
+					<Button variant="primary" onClick={ handleClose }>
 						{ __( 'Got it', 'jetpack-forms' ) }
 					</Button>
-				</div>
+				</HStack>
 			</VStack>
 		</Modal>
 	);

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -519,13 +519,13 @@ export default function usePageHeaderDetails(
 			const longMessage = __( 'View and manage all your forms in one place.', 'jetpack-forms' );
 
 			const shouldShowFormsHelpLink =
-				!! onOpenFormsHelp && ( typeof formsCount !== 'number' || formsCount < 5 );
+				!! onOpenFormsHelp && typeof formsCount === 'number' && formsCount > 0 && formsCount < 5;
 
 			return shouldShowFormsHelpLink ? (
 				<>
 					{ shortMessage }{ ' ' }
 					<Button variant="link" onClick={ onOpenFormsHelp }>
-						{ __( 'Missing forms?', 'jetpack-forms' ) }
+						{ __( 'Not seeing all your forms?', 'jetpack-forms' ) }
 					</Button>
 				</>
 			) : (

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -51,6 +51,7 @@ type UsePageHeaderDetailsProps = {
 	statusView?: ResponsesStatusView;
 	sourceId?: string | number;
 	formsCount?: number;
+	hasFormBlocks?: boolean;
 	isIntegrationsEnabled: boolean;
 	showDashboardIntegrations: boolean;
 	onOpenIntegrations: () => void;
@@ -82,6 +83,7 @@ export default function usePageHeaderDetails(
 		screen,
 		sourceId,
 		formsCount,
+		hasFormBlocks,
 		isIntegrationsEnabled,
 		showDashboardIntegrations,
 		onOpenIntegrations,
@@ -519,7 +521,7 @@ export default function usePageHeaderDetails(
 			const longMessage = __( 'View and manage all your forms in one place.', 'jetpack-forms' );
 
 			const shouldShowFormsHelpLink =
-				!! onOpenFormsHelp && typeof formsCount === 'number' && formsCount > 0 && formsCount < 5;
+				!! onOpenFormsHelp && !! hasFormBlocks && ( typeof formsCount !== 'number' || formsCount < 5 );
 
 			return shouldShowFormsHelpLink ? (
 				<>
@@ -545,7 +547,7 @@ export default function usePageHeaderDetails(
 		}
 
 		return __( 'View and manage all your form responses in one place.', 'jetpack-forms' );
-	}, [ formTitle, isFormsScreen, isSingleFormScreen, onOpenFormsHelp, formsCount ] );
+	}, [ formTitle, isFormsScreen, isSingleFormScreen, onOpenFormsHelp, formsCount, hasFormBlocks ] );
 
 	const actions = useMemo( () => {
 		// Mobile: show dropdown menu with actions

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -50,8 +50,7 @@ type UsePageHeaderDetailsProps = {
 	screen: 'forms' | 'responses';
 	statusView?: ResponsesStatusView;
 	sourceId?: string | number;
-	formsCount?: number;
-	hasFormBlocks?: boolean;
+	hasClassicForms?: boolean;
 	isIntegrationsEnabled: boolean;
 	showDashboardIntegrations: boolean;
 	onOpenIntegrations: () => void;
@@ -82,8 +81,7 @@ export default function usePageHeaderDetails(
 	const {
 		screen,
 		sourceId,
-		formsCount,
-		hasFormBlocks,
+		hasClassicForms,
 		isIntegrationsEnabled,
 		showDashboardIntegrations,
 		onOpenIntegrations,
@@ -520,10 +518,7 @@ export default function usePageHeaderDetails(
 			const shortMessage = __( 'View and manage all your forms.', 'jetpack-forms' );
 			const longMessage = __( 'View and manage all your forms in one place.', 'jetpack-forms' );
 
-			const shouldShowFormsHelpLink =
-				!! onOpenFormsHelp && !! hasFormBlocks && ( typeof formsCount !== 'number' || formsCount < 5 );
-
-			return shouldShowFormsHelpLink ? (
+			return hasClassicForms ? (
 				<>
 					{ shortMessage }{ ' ' }
 					<Button variant="link" onClick={ onOpenFormsHelp }>
@@ -547,7 +542,7 @@ export default function usePageHeaderDetails(
 		}
 
 		return __( 'View and manage all your form responses in one place.', 'jetpack-forms' );
-	}, [ formTitle, isFormsScreen, isSingleFormScreen, onOpenFormsHelp, formsCount, hasFormBlocks ] );
+	}, [ formTitle, isFormsScreen, isSingleFormScreen, onOpenFormsHelp, hasClassicForms ] );
 
 	const actions = useMemo( () => {
 		// Mobile: show dropdown menu with actions

--- a/projects/packages/forms/src/types/index.ts
+++ b/projects/packages/forms/src/types/index.ts
@@ -322,8 +322,8 @@ export interface FormsConfigData {
 	canActivatePlugins?: boolean;
 	/** Whether there are any feedback (form response) posts on the site. */
 	hasFeedback?: boolean;
-	/** Whether there are any posts or pages containing a Jetpack form block or shortcode. */
-	hasFormBlocks?: boolean;
+	/** Whether the site has classic (non-synced) form submissions. */
+	hasClassicForms?: boolean;
 	/** Whether form notes are enabled. */
 	isNotesEnabled?: boolean;
 	/** The URL of the Forms responses list in wp-admin. */

--- a/projects/packages/forms/src/types/index.ts
+++ b/projects/packages/forms/src/types/index.ts
@@ -322,6 +322,8 @@ export interface FormsConfigData {
 	canActivatePlugins?: boolean;
 	/** Whether there are any feedback (form response) posts on the site. */
 	hasFeedback?: boolean;
+	/** Whether there are any posts or pages containing a Jetpack form block or shortcode. */
+	hasFormBlocks?: boolean;
 	/** Whether form notes are enabled. */
 	isNotesEnabled?: boolean;
 	/** The URL of the Forms responses list in wp-admin. */

--- a/projects/packages/forms/tests/php/dashboard/Dashboard_Classic_Forms_Test.php
+++ b/projects/packages/forms/tests/php/dashboard/Dashboard_Classic_Forms_Test.php
@@ -24,6 +24,13 @@ class Dashboard_Classic_Forms_Test extends BaseTestCase {
 	private const OPTION_NAME = 'jetpack_forms_classic_state';
 
 	/**
+	 * Shorthand constants for readability.
+	 */
+	private const STATE_CLASSIC   = Dashboard::CLASSIC_FORMS_STATE_CLASSIC;
+	private const STATE_HIDDEN    = Dashboard::CLASSIC_FORMS_STATE_HIDDEN;
+	private const STATE_DISMISSED = Dashboard::CLASSIC_FORMS_STATE_DISMISSED;
+
+	/**
 	 * Clean up after each test.
 	 */
 	protected function tear_down() {
@@ -75,8 +82,8 @@ class Dashboard_Classic_Forms_Test extends BaseTestCase {
 		$dashboard = new Dashboard();
 		$state     = $dashboard->get_classic_forms_state();
 
-		$this->assertEquals( 'hidden', $state );
-		$this->assertEquals( 'hidden', get_option( self::OPTION_NAME ) );
+		$this->assertEquals( self::STATE_HIDDEN, $state );
+		$this->assertEquals( self::STATE_HIDDEN, get_option( self::OPTION_NAME ) );
 	}
 
 	/**
@@ -88,32 +95,32 @@ class Dashboard_Classic_Forms_Test extends BaseTestCase {
 		$dashboard = new Dashboard();
 		$state     = $dashboard->get_classic_forms_state();
 
-		$this->assertEquals( 'classic', $state );
-		$this->assertEquals( 'classic', get_option( self::OPTION_NAME ) );
+		$this->assertEquals( self::STATE_CLASSIC, $state );
+		$this->assertEquals( self::STATE_CLASSIC, get_option( self::OPTION_NAME ) );
 	}
 
 	/**
 	 * Test that when option is already 'classic', it returns 'classic' without querying.
 	 */
 	public function test_option_classic_returns_classic() {
-		update_option( self::OPTION_NAME, 'classic' );
+		update_option( self::OPTION_NAME, self::STATE_CLASSIC );
 
 		$dashboard = new Dashboard();
 		$state     = $dashboard->get_classic_forms_state();
 
-		$this->assertEquals( 'classic', $state );
+		$this->assertEquals( self::STATE_CLASSIC, $state );
 	}
 
 	/**
 	 * Test that when option is already 'hidden', it returns 'hidden' without querying.
 	 */
 	public function test_option_hidden_returns_hidden() {
-		update_option( self::OPTION_NAME, 'hidden' );
+		update_option( self::OPTION_NAME, self::STATE_HIDDEN );
 
 		$dashboard = new Dashboard();
 		$state     = $dashboard->get_classic_forms_state();
 
-		$this->assertEquals( 'hidden', $state );
+		$this->assertEquals( self::STATE_HIDDEN, $state );
 	}
 
 	/**
@@ -126,7 +133,7 @@ class Dashboard_Classic_Forms_Test extends BaseTestCase {
 
 		// First call detects classic and caches.
 		$state = $dashboard->get_classic_forms_state();
-		$this->assertEquals( 'classic', $state );
+		$this->assertEquals( self::STATE_CLASSIC, $state );
 
 		// Remove the SQL simulation — if option caching works, it won't matter.
 		remove_all_filters( 'wordbless_wpdb_query_results' );
@@ -134,7 +141,7 @@ class Dashboard_Classic_Forms_Test extends BaseTestCase {
 
 		// Second call should use cached option, not re-query.
 		$state = $dashboard->get_classic_forms_state();
-		$this->assertEquals( 'classic', $state );
+		$this->assertEquals( self::STATE_CLASSIC, $state );
 	}
 
 	/**
@@ -143,18 +150,18 @@ class Dashboard_Classic_Forms_Test extends BaseTestCase {
 	public function test_mark_classic_form_detected_sets_option() {
 		Dashboard::mark_classic_form_detected();
 
-		$this->assertEquals( 'classic', get_option( self::OPTION_NAME ) );
+		$this->assertEquals( self::STATE_CLASSIC, get_option( self::OPTION_NAME ) );
 	}
 
 	/**
 	 * Test that mark_classic_form_detected overwrites 'hidden' with 'classic'.
 	 */
 	public function test_mark_classic_form_detected_overwrites_hidden() {
-		update_option( self::OPTION_NAME, 'hidden' );
+		update_option( self::OPTION_NAME, self::STATE_HIDDEN );
 
 		Dashboard::mark_classic_form_detected();
 
-		$this->assertEquals( 'classic', get_option( self::OPTION_NAME ) );
+		$this->assertEquals( self::STATE_CLASSIC, get_option( self::OPTION_NAME ) );
 	}
 
 	/**
@@ -166,30 +173,41 @@ class Dashboard_Classic_Forms_Test extends BaseTestCase {
 		$dashboard = new Dashboard();
 		$state     = $dashboard->get_classic_forms_state();
 
-		$this->assertEquals( 'classic', $state );
+		$this->assertEquals( self::STATE_CLASSIC, $state );
 	}
 
 	/**
 	 * Test that when option is 'dismissed', it returns 'dismissed' without querying.
 	 */
 	public function test_option_dismissed_returns_dismissed() {
-		update_option( self::OPTION_NAME, 'dismissed' );
+		update_option( self::OPTION_NAME, self::STATE_DISMISSED );
 
 		$dashboard = new Dashboard();
 		$state     = $dashboard->get_classic_forms_state();
 
-		$this->assertEquals( 'dismissed', $state );
+		$this->assertEquals( self::STATE_DISMISSED, $state );
 	}
 
 	/**
 	 * Test that 'dismissed' state is not treated as 'classic' by the config endpoint.
 	 */
 	public function test_dismissed_state_is_not_classic() {
-		update_option( self::OPTION_NAME, 'dismissed' );
+		update_option( self::OPTION_NAME, self::STATE_DISMISSED );
 
 		$dashboard = new Dashboard();
 		$state     = $dashboard->get_classic_forms_state();
 
-		$this->assertNotEquals( 'classic', $state );
+		$this->assertNotEquals( self::STATE_CLASSIC, $state );
+	}
+
+	/**
+	 * Test that mark_classic_form_detected does not overwrite 'dismissed'.
+	 */
+	public function test_mark_classic_form_detected_does_not_overwrite_dismissed() {
+		update_option( self::OPTION_NAME, self::STATE_DISMISSED );
+
+		Dashboard::mark_classic_form_detected();
+
+		$this->assertEquals( self::STATE_DISMISSED, get_option( self::OPTION_NAME ) );
 	}
 }

--- a/projects/packages/forms/tests/php/dashboard/Dashboard_Classic_Forms_Test.php
+++ b/projects/packages/forms/tests/php/dashboard/Dashboard_Classic_Forms_Test.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Unit Tests for classic forms state detection.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\Dashboard;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+
+/**
+ * Test class for classic forms state detection in Dashboard.
+ *
+ * @covers \Automattic\Jetpack\Forms\Dashboard\Dashboard
+ */
+#[CoversClass( Dashboard::class )]
+class Dashboard_Classic_Forms_Test extends BaseTestCase {
+
+	/**
+	 * The option name used to store classic forms state.
+	 */
+	private const OPTION_NAME = 'jetpack_forms_classic_state';
+
+	/**
+	 * Clean up after each test.
+	 */
+	protected function tear_down() {
+		parent::tear_down();
+		delete_option( self::OPTION_NAME );
+		remove_all_filters( 'wordbless_wpdb_query_results' );
+	}
+
+	/**
+	 * Simulate detect_classic_forms SQL query returning a result (classic forms found).
+	 */
+	private function simulate_classic_forms_detected() {
+		add_filter(
+			'wordbless_wpdb_query_results',
+			function ( $results, $query ) {
+				if ( strpos( $query, "post_type = 'feedback'" ) !== false && strpos( $query, 'p.ID IS NULL' ) !== false ) {
+					return array( (object) array( '1' => '1' ) );
+				}
+				return $results;
+			},
+			10,
+			2
+		);
+	}
+
+	/**
+	 * Simulate detect_classic_forms SQL query returning no result (no classic forms).
+	 */
+	private function simulate_no_classic_forms() {
+		add_filter(
+			'wordbless_wpdb_query_results',
+			function ( $results, $query ) {
+				if ( strpos( $query, "post_type = 'feedback'" ) !== false && strpos( $query, 'p.ID IS NULL' ) !== false ) {
+					return array();
+				}
+				return $results;
+			},
+			10,
+			2
+		);
+	}
+
+	/**
+	 * Test that when option is not set and no classic feedback posts exist, state is 'hidden'.
+	 */
+	public function test_no_option_no_classic_feedback_returns_hidden() {
+		$this->simulate_no_classic_forms();
+
+		$dashboard = new Dashboard();
+		$state     = $dashboard->get_classic_forms_state();
+
+		$this->assertEquals( 'hidden', $state );
+		$this->assertEquals( 'hidden', get_option( self::OPTION_NAME ) );
+	}
+
+	/**
+	 * Test that when option is not set and classic feedback exists, state is 'classic'.
+	 */
+	public function test_no_option_with_classic_feedback_returns_classic() {
+		$this->simulate_classic_forms_detected();
+
+		$dashboard = new Dashboard();
+		$state     = $dashboard->get_classic_forms_state();
+
+		$this->assertEquals( 'classic', $state );
+		$this->assertEquals( 'classic', get_option( self::OPTION_NAME ) );
+	}
+
+	/**
+	 * Test that when option is already 'classic', it returns 'classic' without querying.
+	 */
+	public function test_option_classic_returns_classic() {
+		update_option( self::OPTION_NAME, 'classic' );
+
+		$dashboard = new Dashboard();
+		$state     = $dashboard->get_classic_forms_state();
+
+		$this->assertEquals( 'classic', $state );
+	}
+
+	/**
+	 * Test that when option is already 'hidden', it returns 'hidden' without querying.
+	 */
+	public function test_option_hidden_returns_hidden() {
+		update_option( self::OPTION_NAME, 'hidden' );
+
+		$dashboard = new Dashboard();
+		$state     = $dashboard->get_classic_forms_state();
+
+		$this->assertEquals( 'hidden', $state );
+	}
+
+	/**
+	 * Test that option caching prevents subsequent DB queries.
+	 */
+	public function test_option_caching_prevents_db_queries() {
+		$this->simulate_classic_forms_detected();
+
+		$dashboard = new Dashboard();
+
+		// First call detects classic and caches.
+		$state = $dashboard->get_classic_forms_state();
+		$this->assertEquals( 'classic', $state );
+
+		// Remove the SQL simulation — if option caching works, it won't matter.
+		remove_all_filters( 'wordbless_wpdb_query_results' );
+		$this->simulate_no_classic_forms();
+
+		// Second call should use cached option, not re-query.
+		$state = $dashboard->get_classic_forms_state();
+		$this->assertEquals( 'classic', $state );
+	}
+
+	/**
+	 * Test that mark_classic_form_detected sets the option to 'classic'.
+	 */
+	public function test_mark_classic_form_detected_sets_option() {
+		Dashboard::mark_classic_form_detected();
+
+		$this->assertEquals( 'classic', get_option( self::OPTION_NAME ) );
+	}
+
+	/**
+	 * Test that mark_classic_form_detected overwrites 'hidden' with 'classic'.
+	 */
+	public function test_mark_classic_form_detected_overwrites_hidden() {
+		update_option( self::OPTION_NAME, 'hidden' );
+
+		Dashboard::mark_classic_form_detected();
+
+		$this->assertEquals( 'classic', get_option( self::OPTION_NAME ) );
+	}
+
+	/**
+	 * Test that get_classic_forms_state returns 'classic' after mark is called.
+	 */
+	public function test_get_state_after_mark_returns_classic() {
+		Dashboard::mark_classic_form_detected();
+
+		$dashboard = new Dashboard();
+		$state     = $dashboard->get_classic_forms_state();
+
+		$this->assertEquals( 'classic', $state );
+	}
+}

--- a/projects/packages/forms/tests/php/dashboard/Dashboard_Classic_Forms_Test.php
+++ b/projects/packages/forms/tests/php/dashboard/Dashboard_Classic_Forms_Test.php
@@ -168,4 +168,28 @@ class Dashboard_Classic_Forms_Test extends BaseTestCase {
 
 		$this->assertEquals( 'classic', $state );
 	}
+
+	/**
+	 * Test that when option is 'dismissed', it returns 'dismissed' without querying.
+	 */
+	public function test_option_dismissed_returns_dismissed() {
+		update_option( self::OPTION_NAME, 'dismissed' );
+
+		$dashboard = new Dashboard();
+		$state     = $dashboard->get_classic_forms_state();
+
+		$this->assertEquals( 'dismissed', $state );
+	}
+
+	/**
+	 * Test that 'dismissed' state is not treated as 'classic' by the config endpoint.
+	 */
+	public function test_dismissed_state_is_not_classic() {
+		update_option( self::OPTION_NAME, 'dismissed' );
+
+		$dashboard = new Dashboard();
+		$state     = $dashboard->get_classic_forms_state();
+
+		$this->assertNotEquals( 'classic', $state );
+	}
 }


### PR DESCRIPTION
part of FORMS-617

<img width="1509" height="878" alt="Screenshot 2026-03-05 at 15 27 48" src="https://github.com/user-attachments/assets/d7f8af2e-2a83-4d32-a92e-170631c63388" />

<img width="1512" height="871" alt="Screenshot 2026-03-05 at 15 45 45" src="https://github.com/user-attachments/assets/1bbf4d61-0628-4b92-b0bd-da68107a6bf1" />

<img width="1507" height="869" alt="Screenshot 2026-03-05 at 15 47 36" src="https://github.com/user-attachments/assets/95776af1-1a95-4e4a-aed0-8d9a14989d19" />

Modal. 

<img width="599" height="503" alt="Screenshot 2026-03-17 at 9 18 13 AM" src="https://github.com/user-attachments/assets/da0d708c-500f-49c7-ad1d-c667df6eb340" />


## Proposed changes:

The Forms dashboard list previously showed a "Missing forms?" link/button that was confusing for new users — it implied their forms were lost, when they simply hadn't created any yet.

This PR improves the messaging by making it context-aware:

1. **Added a `has_form_blocks()` PHP method** that checks whether any posts or pages contain a Jetpack form block (`<!-- wp:jetpack/contact-form -->`) or shortcode (`[contact-form]`). This is exposed via the `/wp/v2/feedback/config` REST endpoint as `hasFormBlocks`.

2. **Empty state and subtitle now use `hasFormBlocks`** to decide whether to show the help link:
   - If the user has non-reusable form blocks in their content, they see a "Not seeing all your forms?" link that opens a modal explaining how to convert them to reusable forms.
   - If the user has no form blocks at all (brand new user), they see a clean experience with just "Create a new form."

3. **Renamed the copy** from "Missing forms?" to "Not seeing all your forms?" to match the modal title and use less alarming language.

### Behavior matrix:

* With reusable forms + form blocks (non-reusable) in posts/pages: Subtitle shows "View and manage all your forms. Not seeing all your forms?"
* With reusable forms + no form blocks: Subtitle shows "View and manage all your forms in one place."
* Empty list + form blocks exist: Empty state shows both "Create a new form" and "Not seeing all your forms?"
* Empty list + no form blocks (new user): Empty state shows only "Create a new form"

### Structure:

```
config endpoint (PHP)
  └── hasFormBlocks: bool    ← has_form_blocks() queries posts for form blocks/shortcodes
        │
        ├── stage.tsx (empty state)
        │     └── if hasFormBlocks → show "Not seeing all your forms?" button
        │        else → show only "Create a new form"
        │
        └── use-page-header-details.tsx (subtitle)
              └── if hasFormBlocks && formsCount < 5 → show "Not seeing all your forms?" link
                 else → show static subtitle
```

### Other information:
- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Testing instructions:

**Prerequisites:** Enable the wp-build Forms dashboard by adding this filter:
```php
add_filter( 'jetpack_forms_alpha', '__return_true' );
```

**Test 1 — New user (no forms, no form blocks):**
1. Go to the Jetpack Forms dashboard
2. Verify the empty state shows only "You're set up. No forms yet." with a single "Create a new form" button — no help link

**Test 2 — Existing user with non-reusable forms (no managed forms, but form blocks in posts):**
1. Create a post/page with a Jetpack form block (don't convert it to reusable)
2. Go to the Forms dashboard
3. Verify the empty state shows "Create a new form" AND "Not seeing all your forms?"
4. Click "Not seeing all your forms?" and verify the help modal opens

**Test 3 — User with 1–4 managed forms + form blocks:**
1. Create 1–4 managed forms and ensure form blocks exist in posts
2. The subtitle should show "View and manage all your forms. Not seeing all your forms?"

**Test 4 — User with 5+ managed forms:**
1. Create 5+ managed forms
2. The subtitle should show only "View and manage all your forms in one place."

## Changelog
- [x] Generate changelog entries for this PR (using AI).