### PR TITLE
Newsletter: Fix resetting of post access value on Jetpack Paywall block

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-resetting-of-post-access-value
+++ b/projects/plugins/jetpack/changelog/fix-resetting-of-post-access-value
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Paywall Block: Fix a race condition which resets the post access value in Gutenberg.

--- a/projects/plugins/jetpack/changelog/fix-resetting-of-post-access-value
+++ b/projects/plugins/jetpack/changelog/fix-resetting-of-post-access-value
@@ -1,4 +1,4 @@
 Significance: patch
-Type: other
+Type: bugfix
 
 Paywall Block: Fix a race condition which resets the post access value in Gutenberg.

--- a/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
@@ -45,7 +45,7 @@ function PaywallEdit() {
 		// Only set default access level if data is loaded and not already set.
 		if ( hasSetDefaultAccess.current === false && savedAccessLevel !== undefined ) {
 			// Set to "subscribers" if access is "everybody" (paywall + everybody doesn't make sense)
-			if ( savedAccessLevel === accessOptions.everybody.key ) {
+			if ( ! savedAccessLevel || savedAccessLevel === accessOptions.everybody.key ) {
 				setAccess( accessOptions.subscribers.key );
 			}
 

--- a/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
@@ -36,6 +36,7 @@ function PaywallEdit() {
 	const [ showDialog, setShowDialog ] = useState( false );
 	const closeDialog = () => setShowDialog( false );
 
+	// Set default access.
 	const hasSetDefaultAccess = useRef( false );
 	const savedAccessLevel = useSelect( select => {
 		const meta = select( editorStore ).getCurrentPostAttribute( 'meta' );
@@ -45,15 +46,17 @@ function PaywallEdit() {
 		// Only set default access level if data is loaded and not already set.
 		if ( hasSetDefaultAccess.current === false && savedAccessLevel !== undefined ) {
 			// Set to "subscribers" if access is "everybody" (paywall + everybody doesn't make sense)
-			if ( ! savedAccessLevel || savedAccessLevel === accessOptions.everybody.key ) {
+			if ( savedAccessLevel === '' || savedAccessLevel === accessOptions.everybody.key ) {
 				setAccess( accessOptions.subscribers.key );
 			}
 
 			hasSetDefaultAccess.current = true;
 		}
+	}, [ setAccess, savedAccessLevel ] );
 
+	// Cleanup on unmount only.
+	useEffect( () => {
 		return () => {
-			// Reset to access level "everybody" when paywall block is removed
 			const { getBlocks } = window.wp.data.select( 'core/block-editor' );
 			const hasPaywallBlock = getBlocks().some( block => block.name === paywallBlockMetadata.name );
 
@@ -62,7 +65,7 @@ function PaywallEdit() {
 				hasSetDefaultAccess.current = false;
 			}
 		};
-	}, [ setAccess, savedAccessLevel ] );
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	function selectAccess( value ) {
 		if ( accessOptions.paid_subscribers.key === value && ( stripeConnectUrl || ! hasTierPlans ) ) {

--- a/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
@@ -65,7 +65,7 @@ function PaywallEdit() {
 				hasSetDefaultAccess.current = false;
 			}
 		};
-	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
+	}, [ setAccess ] );
 
 	function selectAccess( value ) {
 		if ( accessOptions.paid_subscribers.key === value && ( stripeConnectUrl || ! hasTierPlans ) ) {

--- a/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/edit.js
@@ -4,15 +4,19 @@ import { BlockControls, InspectorControls, useBlockProps } from '@wordpress/bloc
 import { MenuGroup, MenuItem, PanelBody, ToolbarDropdownMenu } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { arrowDown, Icon, people, check } from '@wordpress/icons';
 import ConnectBanner from '../../shared/components/connect-banner';
 import PlansSetupDialog from '../../shared/components/plans-setup-dialog';
-import { accessOptions } from '../../shared/memberships/constants';
+import {
+	accessOptions,
+	META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS,
+} from '../../shared/memberships/constants';
 import { useAccessLevel } from '../../shared/memberships/edit';
 import { NewsletterAccessRadioButtons, useSetAccess } from '../../shared/memberships/settings';
 import useIsUserConnected from '../../shared/use-is-user-connected';
+import paywallBlockMetadata from './block.json';
 
 function PaywallEdit() {
 	const blockProps = useBlockProps();
@@ -20,16 +24,6 @@ function PaywallEdit() {
 	const accessLevel = useAccessLevel( postType );
 	const isUserConnected = useIsUserConnected();
 	const setAccess = useSetAccess();
-
-	// Add cleanup effect to reset access level when paywall is removed
-	useEffect( () => {
-		// This function will run when the component unmounts
-		return () => {
-			// Reset access level to "everybody" when the paywall block is removed
-			setAccess( accessOptions.everybody.key );
-		};
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] );
 
 	const { stripeConnectUrl, hasTierPlans } = useSelect( select => {
 		const { getNewsletterTierProducts, getConnectUrl } = select( 'jetpack/membership-products' );
@@ -42,11 +36,33 @@ function PaywallEdit() {
 	const [ showDialog, setShowDialog ] = useState( false );
 	const closeDialog = () => setShowDialog( false );
 
+	const hasSetDefaultAccess = useRef( false );
+	const savedAccessLevel = useSelect( select => {
+		const meta = select( editorStore ).getCurrentPostAttribute( 'meta' );
+		return meta ? meta[ META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS ] : undefined;
+	} );
 	useEffect( () => {
-		if ( ! accessLevel || accessLevel === accessOptions.everybody.key ) {
-			setAccess( accessOptions.subscribers.key );
+		// Only set default access level if data is loaded and not already set.
+		if ( hasSetDefaultAccess.current === false && savedAccessLevel !== undefined ) {
+			// Set to "subscribers" if access is "everybody" (paywall + everybody doesn't make sense)
+			if ( savedAccessLevel === accessOptions.everybody.key ) {
+				setAccess( accessOptions.subscribers.key );
+			}
+
+			hasSetDefaultAccess.current = true;
 		}
-	}, [ accessLevel, setAccess ] );
+
+		return () => {
+			// Reset to access level "everybody" when paywall block is removed
+			const { getBlocks } = window.wp.data.select( 'core/block-editor' );
+			const hasPaywallBlock = getBlocks().some( block => block.name === paywallBlockMetadata.name );
+
+			if ( ! hasPaywallBlock ) {
+				setAccess( accessOptions.everybody.key );
+				hasSetDefaultAccess.current = false;
+			}
+		};
+	}, [ setAccess, savedAccessLevel ] );
 
 	function selectAccess( value ) {
 		if ( accessOptions.paid_subscribers.key === value && ( stripeConnectUrl || ! hasTierPlans ) ) {

--- a/projects/plugins/jetpack/extensions/blocks/paywall/test/edit.test.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/test/edit.test.js
@@ -91,6 +91,22 @@ describe( 'PaywallEdit', () => {
 		mockGetBlocks.mockReturnValue( [ { name: 'jetpack/paywall' } ] );
 	} );
 
+	test( 'does not set access saved access is undefined', () => {
+		mockSavedAccessLevel = undefined;
+
+		render( <PaywallEdit /> );
+
+		expect( mockSetAccess ).not.toHaveBeenCalled();
+	} );
+
+	test( 'sets access to "subscribers" when saved access is ""', () => {
+		mockSavedAccessLevel = '';
+
+		render( <PaywallEdit /> );
+
+		expect( mockSetAccess ).toHaveBeenCalledWith( accessOptions.subscribers.key );
+	} );
+
 	test( 'sets access to "subscribers" when saved access is "everybody"', () => {
 		mockSavedAccessLevel = 'everybody';
 

--- a/projects/plugins/jetpack/extensions/blocks/paywall/test/edit.test.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/test/edit.test.js
@@ -134,7 +134,6 @@ describe( 'PaywallEdit', () => {
 		mockGetBlocks.mockReturnValue( [] ); // No paywall block
 
 		const { unmount } = render( <PaywallEdit /> );
-		mockSetAccess.mockClear();
 		unmount();
 
 		expect( mockSetAccess ).toHaveBeenCalledWith( accessOptions.everybody.key );

--- a/projects/plugins/jetpack/extensions/blocks/paywall/test/edit.test.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/test/edit.test.js
@@ -1,0 +1,160 @@
+import { render, screen } from '@testing-library/react';
+import { accessOptions } from '../../../shared/memberships/constants';
+import PaywallEdit from '../edit';
+
+// Mock variables - must start with "mock" to be accessible in jest.mock factories
+const mockSetAccess = jest.fn();
+const mockGetBlocks = jest.fn();
+let mockSavedAccessLevel = 'everybody';
+let mockAccessLevel = 'everybody';
+
+// Mock window.wp.data for cleanup function
+window.wp = {
+	data: {
+		select: jest.fn().mockReturnValue( {
+			getBlocks: mockGetBlocks,
+		} ),
+	},
+};
+
+jest.mock( '../../../shared/use-is-user-connected', () => ( {
+	__esModule: true,
+	default: jest.fn( () => true ),
+} ) );
+
+jest.mock( '../../../shared/memberships/edit', () => ( {
+	useAccessLevel: jest.fn( () => mockAccessLevel ),
+} ) );
+
+jest.mock( '../../../shared/memberships/settings', () => ( {
+	useSetAccess: () => mockSetAccess,
+	NewsletterAccessRadioButtons: () => {},
+} ) );
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	useBlockProps: () => {},
+	BlockControls: () => {},
+	InspectorControls: () => {},
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	MenuGroup: () => {},
+	MenuItem: () => {},
+	PanelBody: () => {},
+	ToolbarDropdownMenu: () => {},
+} ) );
+
+jest.mock( '@wordpress/editor', () => ( {
+	store: 'core/editor',
+} ) );
+
+jest.mock( '@automattic/jetpack-shared-extension-utils/components', () => ( {
+	JetpackEditorPanelLogo: () => {},
+} ) );
+
+jest.mock( '../../../shared/components/connect-banner', () => {} );
+
+jest.mock( '../../../shared/components/plans-setup-dialog', () => ( {
+	__esModule: true,
+	default: () => {},
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn( selector => {
+		const mockSelect = storeName => {
+			if ( storeName === 'core/editor' ) {
+				return {
+					getCurrentPostType: () => 'post',
+					getCurrentPostAttribute: attr => {
+						if ( attr === 'meta' ) {
+							return { _jetpack_newsletter_access: mockSavedAccessLevel };
+						}
+						return undefined;
+					},
+				};
+			}
+			if ( storeName === 'jetpack/membership-products' ) {
+				return {
+					getNewsletterTierProducts: () => [ { id: 1 } ],
+					getConnectUrl: () => null,
+				};
+			}
+			return {};
+		};
+		return selector( mockSelect );
+	} ),
+} ) );
+
+describe( 'PaywallEdit', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockGetBlocks.mockReturnValue( [ { name: 'jetpack/paywall' } ] );
+	} );
+
+	test( 'sets access to "subscribers" when saved access is "everybody"', () => {
+		mockSavedAccessLevel = 'everybody';
+
+		render( <PaywallEdit /> );
+
+		expect( mockSetAccess ).toHaveBeenCalledWith( accessOptions.subscribers.key );
+	} );
+
+	test( 'does not change access when saved access is "subscribers"', () => {
+		mockSavedAccessLevel = 'subscribers';
+
+		render( <PaywallEdit /> );
+
+		expect( mockSetAccess ).not.toHaveBeenCalled();
+	} );
+
+	test( 'does not change access when saved access is "paid_subscribers"', () => {
+		mockSavedAccessLevel = 'paid_subscribers';
+
+		render( <PaywallEdit /> );
+
+		expect( mockSetAccess ).not.toHaveBeenCalled();
+	} );
+
+	test( 'only sets default access once even on re-render', () => {
+		mockSavedAccessLevel = 'everybody';
+
+		const { rerender } = render( <PaywallEdit /> );
+
+		expect( mockSetAccess ).toHaveBeenCalledTimes( 1 );
+		expect( mockSetAccess ).toHaveBeenCalledWith( accessOptions.subscribers.key );
+
+		mockSetAccess.mockClear();
+		rerender( <PaywallEdit /> );
+
+		expect( mockSetAccess ).not.toHaveBeenCalled();
+	} );
+
+	test( 'resets access to "everybody" when paywall block is removed', () => {
+		mockSavedAccessLevel = 'subscribers';
+		mockGetBlocks.mockReturnValue( [] ); // No paywall block
+
+		const { unmount } = render( <PaywallEdit /> );
+		mockSetAccess.mockClear();
+		unmount();
+
+		expect( mockSetAccess ).toHaveBeenCalledWith( accessOptions.everybody.key );
+	} );
+
+	test( 'renders subscribers only content when access level is "subscribers"', () => {
+		mockSavedAccessLevel = 'subscribers';
+		mockAccessLevel = 'subscribers';
+
+		render( <PaywallEdit /> );
+
+		expect( screen.getByText( 'Subscriber-only content below' ) ).toBeInTheDocument();
+	} );
+
+	test( 'renders paid content text when access is "paid_subscribers"', () => {
+		mockSavedAccessLevel = 'paid_subscribers';
+		mockAccessLevel = 'paid_subscribers';
+
+		render( <PaywallEdit /> );
+
+		expect( screen.getByText( 'Paid content below this line' ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/plugins/jetpack/extensions/blocks/paywall/test/edit.test.js
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/test/edit.test.js
@@ -172,4 +172,27 @@ describe( 'PaywallEdit', () => {
 
 		expect( screen.getByText( 'Paid content below this line' ) ).toBeInTheDocument();
 	} );
+
+	test( 'sets access to "subscribers" when paywall block is re-added after removal', () => {
+		mockSavedAccessLevel = 'everybody';
+		mockGetBlocks.mockReturnValue( [ { name: 'jetpack/paywall' } ] );
+
+		// First render.
+		const { unmount } = render( <PaywallEdit /> );
+		expect( mockSetAccess ).toHaveBeenCalledWith( accessOptions.subscribers.key );
+
+		// Simulate block removal - cleanup should reset to 'everybody'.
+		mockSetAccess.mockClear();
+		mockGetBlocks.mockReturnValue( [] ); // No paywall block
+		unmount();
+		expect( mockSetAccess ).toHaveBeenCalledWith( accessOptions.everybody.key );
+
+		// Re-adding the block.
+		mockSetAccess.mockClear();
+		mockSavedAccessLevel = 'everybody'; // Access was reset to 'everybody' by cleanup
+		mockGetBlocks.mockReturnValue( [ { name: 'jetpack/paywall' } ] );
+
+		render( <PaywallEdit /> );
+		expect( mockSetAccess ).toHaveBeenCalledWith( accessOptions.subscribers.key );
+	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/paywall/test/edit.test.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/test/edit.test.tsx
@@ -5,11 +5,12 @@ import PaywallEdit from '../edit';
 // Mock variables - must start with "mock" to be accessible in jest.mock factories
 const mockSetAccess = jest.fn();
 const mockGetBlocks = jest.fn();
-let mockSavedAccessLevel = 'everybody';
+let mockSavedAccessLevel: string | undefined = 'everybody';
 let mockAccessLevel = 'everybody';
 
 // Mock window.wp.data for cleanup function
-window.wp = {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+( window as any ).wp = {
 	data: {
 		select: jest.fn().mockReturnValue( {
 			getBlocks: mockGetBlocks,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Closes: [NL-467](https://linear.app/a8c/issue/NL-467/paid-subscriber-setting-reverts-to-subscribers-in-editor)

## Proposed changes:
<!--- Explain what functional changes your PR includes -->

- Set default access value only if the data is already loaded and block is rendering first time. Before we were setting the default access value even when the meta was yet to load.
- Improves cleanup function to only change access level if the Paywall block is actually removed. Before in development it was getting called twice due to React strict mode.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

View issue.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Note: The root cause of the bug is a race condition so it is hard to test.

1. Go to Jurassic Ninja site.
1. Create a new post with Paywall block. Set access level as "paid_subscribers".
1. Publish the post.
1. Refresh the editor and note the status is now "subscribers". (can be "paid_subscribers" as well due to race condition. In production it was difficult to reproduce this case but while doing development via "Jurassic Tube" site this issue was always reproducible)
1. Checkout this PR.
1. Repeat 2,3,4 and verify the access level value is appearing correctly now.
1. Remove Paywall block and verify the post access value is correctly setting as "everybody".
1. Add the block again to verify that it starts from scratch instead of some previous saved state.