### PR TITLE
CRM: Add doc link to empty state in Transactions, Quotes, and Invoices view

### DIFF
--- a/projects/plugins/crm/changelog/add-crm-transaction-docs
+++ b/projects/plugins/crm/changelog/add-crm-transaction-docs
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Transactions: Added link to docs in empty state. Did the same for empty Quotes and Invoices view.
+Transactions: Added link to docs in empty state. Did the same for the empty Quotes and Invoices views.

--- a/projects/plugins/crm/changelog/add-crm-transaction-docs
+++ b/projects/plugins/crm/changelog/add-crm-transaction-docs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Transactions: Added link to docs in empty state. Did the same for empty Quotes and Invoices view.

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.php
@@ -658,12 +658,12 @@ class zeroBSCRM_list {
 				// make simplified
 				$simple_tags = array();
 				if ( is_array( $tags ) && count( $tags ) > 0 ) {
-				foreach ( $tags as $t ) {
-					$simple_tags[] = array(
-						'id'   => $t['id'],
-						'name' => $t['name'],
-						'slug' => $t['slug'],
-					);
+					foreach ( $tags as $t ) {
+						$simple_tags[] = array(
+							'id'   => $t['id'],
+							'name' => $t['name'],
+							'slug' => $t['slug'],
+						);
 					}
 				}
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.php
@@ -683,9 +683,9 @@ class zeroBSCRM_list {
 							// phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 							global $zbsCustomerFields;
 							if ( is_array( $zbsCustomerFields['status'][3] ) ) {
-							echo wp_json_encode( $zbsCustomerFields['status'][3] );
+								echo wp_json_encode( $zbsCustomerFields['status'][3] );
 							} else {
-							echo '[]';
+								echo '[]';
 							}
 							// phpcs:enable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 						?>
@@ -697,9 +697,9 @@ class zeroBSCRM_list {
 						// hardcoded customer perms atm
 						$possible_owners = zeroBS_getPossibleOwners( array( 'zerobs_admin', 'zerobs_customermgr' ), true );
 						if ( ! is_array( $possible_owners ) ) {
-						echo wp_json_encode( array() );
+							echo wp_json_encode( array() );
 						} else {
-						echo wp_json_encode( $possible_owners );
+							echo wp_json_encode( $possible_owners );
 						}
 
 					?>

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.php
@@ -392,12 +392,24 @@ class zeroBSCRM_list {
 					echo zeroBSCRM_UI2_messageHTML( 'warning hidden', sprintf( __( 'Error updating columns %s', 'zero-bs-crm' ), $this->plural ), __( 'There has been a problem saving your column configuration. If this issue persists, please contact support.', 'zero-bs-crm' ), 'disabled warning sign', 'zbsCantSaveCols' );
 					echo zeroBSCRM_UI2_messageHTML( 'warning hidden', sprintf( __( 'Error updating columns %s', 'zero-bs-crm' ), $this->plural ), __( 'There has been a problem saving your filter button configuration. If this issue persists, please contact support.', 'zero-bs-crm' ), 'disabled warning sign', 'zbsCantSaveButtons' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 					$no_results_msg = sprintf( __( 'There are no %1$s here. Do you want to <a href="%2$s">create one</a>?', 'zero-bs-crm' ), $this->plural, jpcrm_esc_link( 'create', -1, $this->postType ) );
-					if ( $this->objType === 'transaction' ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-						$no_results_msg .= ' ' . sprintf( __( 'Learn more about <a href="%1$s">how to create a transaction</a>.', 'zero-bs-crm' ), esc_url( 'https://kb.jetpackcrm.com/knowledge-base/how-do-i-create-a-transaction/' ) );
-					} elseif ( $this->objType === 'invoice' ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-						$no_results_msg .= ' ' . sprintf( __( 'Learn more about <a href="%1$s">how to create an invoice</a>.', 'zero-bs-crm' ), esc_url( 'https://kb.jetpackcrm.com/knowledge-base/how-to-use-the-invoice-builder/' ) );
-					} elseif ( $this->objType === 'quote' ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-						$no_results_msg .= ' ' . sprintf( __( 'Learn more about <a href="%1$s">how to create a quote</a>.', 'zero-bs-crm' ), esc_url( 'https://kb.jetpackcrm.com/knowledge-base/how-do-i-create-a-quote/' ) );
+					$doc_links      = array(
+						'transaction' => array(
+							'url'  => 'https://kb.jetpackcrm.com/knowledge-base/how-do-i-create-a-transaction/',
+							'text' => __( 'Learn more about <a href="%1$s">how to create a transaction</a>.', 'zero-bs-crm' ),
+						),
+						'invoice'     => array(
+							'url'  => 'https://kb.jetpackcrm.com/knowledge-base/how-to-use-the-invoice-builder/',
+							'text' => __( 'Learn more about <a href="%1$s">how to create an invoice</a>.', 'zero-bs-crm' ),
+						),
+						'quote'       => array(
+							'url'  => 'https://kb.jetpackcrm.com/knowledge-base/how-do-i-create-a-quote/',
+							'text' => __( 'Learn more about <a href="%1$s">how to create a quote</a>.', 'zero-bs-crm' ),
+						),
+					);
+					// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+					if ( isset( $doc_links[ $this->objType ] ) ) {
+						$link            = $doc_links[ $this->objType ];
+						$no_results_msg .= ' ' . sprintf( $link['text'], esc_url( $link['url'] ) );
 					}
 					echo zeroBSCRM_UI2_messageHTML( 'info hidden', sprintf( __( 'No %s Found', 'zero-bs-crm' ), $this->plural ), $no_results_msg, 'disabled warning sign', 'zbsNoResults' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 					// any additional messages?

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.php
@@ -166,7 +166,7 @@ class zeroBSCRM_list {
 			$sort = sanitize_text_field( $_GET['sort'] );
 		}
 		$sortOrder = false;
-		if ( isset( $_GET['sortdirection'] ) && ( $_GET['sortdirection'] == 'asc' || $_GET['sortdirection'] == 'desc' ) ) {
+		if ( isset( $_GET['sortdirection'] ) && ( $_GET['sortdirection'] === 'asc' || $_GET['sortdirection'] === 'desc' ) ) {
 			$sortOrder = sanitize_text_field( $_GET['sortdirection'] );
 		}
 
@@ -188,7 +188,7 @@ class zeroBSCRM_list {
 		if ( isset( $customViews ) && isset( $customViews[ $this->objType ] ) ) {
 			$currentColumns = $customViews[ $this->objType ];
 		}
-		if ( $currentColumns == false ) {
+		if ( $currentColumns === false ) {
 			$currentColumns = $defaultColumns;
 		}
 
@@ -270,7 +270,7 @@ class zeroBSCRM_list {
 										if ( ! array_key_exists( $colKey, $currentColumns ) ) {
 
 											// split em up
-											if ( isset( $col[2] ) && $col[2] == 'basefield' ) {
+											if ( isset( $col[2] ) && $col[2] === 'basefield' ) {
 												$allColumnsSorted['basefields'][ $colKey ] = $col;
 												$hasMultiColumnGroups                      = true;
 											} else {
@@ -334,7 +334,7 @@ class zeroBSCRM_list {
 									}
 
 									// if NONE output, we need to always have smt to drop to, so put empty:
-									if ( $colGroupCount == 0 ) {
+									if ( $colGroupCount === 0 ) {
 										echo '<div class="zbs-column-manager-connected">';
 										echo '</div>';
 									}
@@ -391,8 +391,15 @@ class zeroBSCRM_list {
 					echo zeroBSCRM_UI2_messageHTML( 'warning hidden', sprintf( __( 'Error retrieving %s', 'zero-bs-crm' ), $this->plural ), sprintf( __( 'There has been a problem retrieving your %s. If this issue persists, please contact support.', 'zero-bs-crm' ), $this->plural ), 'disabled warning sign', 'zbsCantLoadData' );
 					echo zeroBSCRM_UI2_messageHTML( 'warning hidden', sprintf( __( 'Error updating columns %s', 'zero-bs-crm' ), $this->plural ), __( 'There has been a problem saving your column configuration. If this issue persists, please contact support.', 'zero-bs-crm' ), 'disabled warning sign', 'zbsCantSaveCols' );
 					echo zeroBSCRM_UI2_messageHTML( 'warning hidden', sprintf( __( 'Error updating columns %s', 'zero-bs-crm' ), $this->plural ), __( 'There has been a problem saving your filter button configuration. If this issue persists, please contact support.', 'zero-bs-crm' ), 'disabled warning sign', 'zbsCantSaveButtons' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-					echo zeroBSCRM_UI2_messageHTML( 'info hidden', sprintf( __( 'No %s Found', 'zero-bs-crm' ), $this->plural ), sprintf( __( 'There are no %1$s here. Do you want to <a href="%2$s">create one</a>?', 'zero-bs-crm' ), $this->plural, jpcrm_esc_link( 'create', -1, $this->postType ) ), 'disabled warning sign', 'zbsNoResults' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-
+					$no_results_msg = sprintf( __( 'There are no %1$s here. Do you want to <a href="%2$s">create one</a>?', 'zero-bs-crm' ), $this->plural, jpcrm_esc_link( 'create', -1, $this->postType ) );
+					if ( $this->objType === 'transaction' ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+						$no_results_msg .= ' ' . sprintf( __( 'Learn more about <a href="%1$s">how to create a transaction</a>.', 'zero-bs-crm' ), esc_url( 'https://kb.jetpackcrm.com/knowledge-base/how-do-i-create-a-transaction/' ) );
+					} elseif ( $this->objType === 'invoice' ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+						$no_results_msg .= ' ' . sprintf( __( 'Learn more about <a href="%1$s">how to create an invoice</a>.', 'zero-bs-crm' ), esc_url( 'https://kb.jetpackcrm.com/knowledge-base/how-to-use-the-invoice-builder/' ) );
+					} elseif ( $this->objType === 'quote' ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+						$no_results_msg .= ' ' . sprintf( __( 'Learn more about <a href="%1$s">how to create a quote</a>.', 'zero-bs-crm' ), esc_url( 'https://kb.jetpackcrm.com/knowledge-base/how-do-i-create-a-quote/' ) );
+					}
+					echo zeroBSCRM_UI2_messageHTML( 'info hidden', sprintf( __( 'No %s Found', 'zero-bs-crm' ), $this->plural ), $no_results_msg, 'disabled warning sign', 'zbsNoResults' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 					// any additional messages?
 					if ( isset( $this->messages ) && is_array( $this->messages ) && count( $this->messages ) > 0 ) {
 						foreach ( $this->messages as $message ) {
@@ -426,7 +433,7 @@ class zeroBSCRM_list {
 
 			<?php
 
-			$allowinlineedits = ( zeroBSCRM_getSetting( 'allowinlineedits' ) == '1' );
+			$allowinlineedits = ( zeroBSCRM_getSetting( 'allowinlineedits' ) === '1' );
 			$inlineEditStr    = array();
 			$columns          = array();
 
@@ -440,7 +447,7 @@ class zeroBSCRM_list {
 					// overrides
 
 					// Invoicing: Ref
-					if ( $this->objType == 'invoice' && $colKey == 'ref' ) {
+					if ( $this->objType === 'invoice' && $colKey === 'ref' ) {
 						$column_title = $zbs->settings->get( 'reflabel' );
 					}
 
@@ -639,12 +646,12 @@ class zeroBSCRM_list {
 				// make simplified
 				$simple_tags = array();
 				if ( is_array( $tags ) && count( $tags ) > 0 ) {
-					foreach ( $tags as $t ) {
-						$simple_tags[] = array(
-							'id'   => $t['id'],
-							'name' => $t['name'],
-							'slug' => $t['slug'],
-						);
+				foreach ( $tags as $t ) {
+					$simple_tags[] = array(
+						'id'   => $t['id'],
+						'name' => $t['name'],
+						'slug' => $t['slug'],
+					);
 					}
 				}
 
@@ -664,9 +671,9 @@ class zeroBSCRM_list {
 							// phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 							global $zbsCustomerFields;
 							if ( is_array( $zbsCustomerFields['status'][3] ) ) {
-								echo wp_json_encode( $zbsCustomerFields['status'][3] );
+							echo wp_json_encode( $zbsCustomerFields['status'][3] );
 							} else {
-								echo '[]';
+							echo '[]';
 							}
 							// phpcs:enable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 						?>
@@ -678,9 +685,9 @@ class zeroBSCRM_list {
 						// hardcoded customer perms atm
 						$possible_owners = zeroBS_getPossibleOwners( array( 'zerobs_admin', 'zerobs_customermgr' ), true );
 						if ( ! is_array( $possible_owners ) ) {
-							echo wp_json_encode( array() );
+						echo wp_json_encode( array() );
 						} else {
-							echo wp_json_encode( $possible_owners );
+						echo wp_json_encode( $possible_owners );
 						}
 
 					?>

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.php
@@ -395,15 +395,15 @@ class zeroBSCRM_list {
 					$doc_links      = array(
 						'transaction' => array(
 							'url'  => 'https://kb.jetpackcrm.com/knowledge-base/how-do-i-create-a-transaction/',
-							'text' => __( 'Learn more about <a href="%1$s">how to create a transaction</a>.', 'zero-bs-crm' ),
+							'text' => __( 'Learn more about <a href="%1$s" target="_blank">how to create a transaction</a>.', 'zero-bs-crm' ),
 						),
 						'invoice'     => array(
 							'url'  => 'https://kb.jetpackcrm.com/knowledge-base/how-to-use-the-invoice-builder/',
-							'text' => __( 'Learn more about <a href="%1$s">how to create an invoice</a>.', 'zero-bs-crm' ),
+							'text' => __( 'Learn more about <a href="%1$s" target="_blank">how to create an invoice</a>.', 'zero-bs-crm' ),
 						),
 						'quote'       => array(
 							'url'  => 'https://kb.jetpackcrm.com/knowledge-base/how-do-i-create-a-quote/',
-							'text' => __( 'Learn more about <a href="%1$s">how to create a quote</a>.', 'zero-bs-crm' ),
+							'text' => __( 'Learn more about <a href="%1$s" target="_blank">how to create a quote</a>.', 'zero-bs-crm' ),
 						),
 					);
 					// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

This PR adds links to the Jetpack CRM documentation for the user to get more information on how to create a Transaction, Quote, and Invoice when those lists have an empty state.

Resolves the suggestion in JETCRM-13 on Linear

## Proposed changes:

<!--- Explain what functional changes your PR includes -->
* Adds a conditional message to the empty list state to provide links to our documentation on how to create a new Transaction, Quote, and Invoice.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->


1. Go to http://example.com/wp-admin/admin.php?page=manage-transactions
2. See that a link has been added to the empty state pointing to documentation on how to create a transaction.

You can see the same has been done for Quotes and Invoices.

## Changelog
<!-- Check one of the boxes below. -->

- [ ] Generate changelog entries for this PR (using AI).
