### PR TITLE
Forms: Decode HTML entities in form dropdown titles

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-dropdown-entities
+++ b/projects/packages/forms/changelog/fix-forms-dropdown-entities
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Decode HTML entities in form dropdown titles in the variation picker

--- a/projects/packages/forms/src/blocks/contact-form/variation-picker.js
+++ b/projects/packages/forms/src/blocks/contact-form/variation-picker.js
@@ -10,6 +10,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useEffect, useState } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import clsx from 'clsx';
@@ -180,7 +181,8 @@ export default function VariationPicker( { blockName, setAttributes, clientId, c
 						options={ [
 							{ label: __( 'Select a form…', 'jetpack-forms' ), value: '' },
 							...jetpackForms.map( form => ( {
-								label: form.title?.rendered || __( '(Untitled)', 'jetpack-forms' ),
+								label:
+									decodeEntities( form.title?.rendered ) || __( '(Untitled)', 'jetpack-forms' ),
 								value: form.id.toString(),
 							} ) ),
 						] }

--- a/projects/packages/forms/src/blocks/contact-form/variation-picker.js
+++ b/projects/packages/forms/src/blocks/contact-form/variation-picker.js
@@ -182,7 +182,8 @@ export default function VariationPicker( { blockName, setAttributes, clientId, c
 							{ label: __( 'Select a form…', 'jetpack-forms' ), value: '' },
 							...jetpackForms.map( form => ( {
 								label:
-									decodeEntities( form.title?.rendered ) || __( '(Untitled)', 'jetpack-forms' ),
+									decodeEntities( form.title?.rendered || '' ) ||
+									__( '(Untitled)', 'jetpack-forms' ),
 								value: form.id.toString(),
 							} ) ),
 						] }


### PR DESCRIPTION
Fixes #

## Proposed changes:
* Decode HTML entities in the form titles shown in the "Select a form" dropdown in the variation picker
* Form titles containing special characters (e.g. `&`, `<`, `>`, quotes) were displaying as raw HTML entities instead of their decoded equivalents
* Uses `decodeEntities` from `@wordpress/html-entities` to properly render form titles

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

* Create a new post and add a Jetpack Form block
* Ensure you have at least one existing form with special characters in its title (e.g. a form titled "Contact & Support")
* In the variation picker, scroll down to the "Select a form" dropdown
* Verify that the form titles display correctly with decoded entities (e.g. "Contact & Support" instead of "Contact &amp; Support")

## Changelog
- [x] Generate changelog entries for this PR (using AI).