### PR TITLE
Help Center: Use distinct sectionName for forum sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/DOTCOM-16234-help-center-sectionname-is-wpcomsupport
+++ b/projects/packages/jetpack-mu-wpcom/changelog/DOTCOM-16234-help-center-sectionname-is-wpcomsupport
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Tracking now know we are in forums and not in support
+Tracking now knows when we're on forums vs support.

--- a/projects/packages/jetpack-mu-wpcom/changelog/DOTCOM-16234-help-center-sectionname-is-wpcomsupport
+++ b/projects/packages/jetpack-mu-wpcom/changelog/DOTCOM-16234-help-center-sectionname-is-wpcomsupport
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Tracking now know we are in forums and not in support

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -30,6 +30,13 @@ class Help_Center {
 	private $is_support_site = false;
 
 	/**
+	 * Whether the current site is a forum site.
+	 *
+	 * @var bool
+	 */
+	private $is_forum_site = false;
+
+	/**
 	 * The purchases of the current site.
 	 *
 	 * @var array
@@ -45,6 +52,7 @@ class Help_Center {
 		}
 
 		$blog_id               = get_current_blog_id();
+		$this->is_forum_site   = defined( 'WPCOM_FORUM_BLOG_IDS' ) && in_array( $blog_id, (array) WPCOM_FORUM_BLOG_IDS, true );
 		$this->is_support_site = ( defined( 'WPCOM_SUPPORT_BLOG_IDS' ) && in_array( $blog_id, (array) WPCOM_SUPPORT_BLOG_IDS, true ) ) || ( defined( 'WPCOM_FORUM_BLOG_IDS' ) && in_array( $blog_id, (array) WPCOM_FORUM_BLOG_IDS, true ) );
 
 		// Always register REST API endpoints.
@@ -289,7 +297,7 @@ class Help_Center {
 						'isProxied'        => boolval( self::is_proxied() ),
 						'isSU'             => defined( 'WPCOM_SUPPORT_SESSION' ) && WPCOM_SUPPORT_SESSION,
 						'isSSP'            => isset( $_COOKIE['ssp'] ),
-						'sectionName'      => $this->is_support_site ? 'wp.com/support' : $variant,
+						'sectionName'      => $this->is_forum_site ? 'wp.com/forums' : ( $this->is_support_site ? 'wp.com/support' : $variant ),
 						'isCommerceGarden' => $is_commerce_garden,
 						'currentUser'      => array(
 							'ID'           => $user_id,

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -53,7 +53,7 @@ class Help_Center {
 
 		$blog_id               = get_current_blog_id();
 		$this->is_forum_site   = defined( 'WPCOM_FORUM_BLOG_IDS' ) && in_array( $blog_id, (array) WPCOM_FORUM_BLOG_IDS, true );
-		$this->is_support_site = ( defined( 'WPCOM_SUPPORT_BLOG_IDS' ) && in_array( $blog_id, (array) WPCOM_SUPPORT_BLOG_IDS, true ) ) || ( defined( 'WPCOM_FORUM_BLOG_IDS' ) && in_array( $blog_id, (array) WPCOM_FORUM_BLOG_IDS, true ) );
+		$this->is_support_site = ( defined( 'WPCOM_SUPPORT_BLOG_IDS' ) && in_array( $blog_id, (array) WPCOM_SUPPORT_BLOG_IDS, true ) ) || $this->is_forum_site;
 
 		// Always register REST API endpoints.
 		add_action( 'rest_api_init', array( $this, 'register_rest_api' ) );

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -290,6 +290,14 @@ class Help_Center {
 			$avatar_url         = $user_data ? ( function_exists( 'wpcom_get_avatar_url' ) ? wpcom_get_avatar_url( $user_email, 64, '', true )[0] : get_avatar_url( $user_id ) ) : null;
 			$is_commerce_garden = defined( 'IS_COMMERCE_GARDEN' );
 
+			if ( $this->is_forum_site ) {
+				$section_name = 'wp.com/forums';
+			} elseif ( $this->is_support_site ) {
+				$section_name = 'wp.com/support';
+			} else {
+				$section_name = $variant;
+			}
+
 			wp_add_inline_script(
 				'help-center',
 				'const helpCenterData = ' . wp_json_encode(
@@ -297,7 +305,7 @@ class Help_Center {
 						'isProxied'        => boolval( self::is_proxied() ),
 						'isSU'             => defined( 'WPCOM_SUPPORT_SESSION' ) && WPCOM_SUPPORT_SESSION,
 						'isSSP'            => isset( $_COOKIE['ssp'] ),
-						'sectionName'      => $this->is_forum_site ? 'wp.com/forums' : ( $this->is_support_site ? 'wp.com/support' : $variant ),
+						'sectionName'      => $section_name,
 						'isCommerceGarden' => $is_commerce_garden,
 						'currentUser'      => array(
 							'ID'           => $user_id,


### PR DESCRIPTION
Fixes DOTCOM-16234

## Proposed changes:
* Forum sites (matching `WPCOM_FORUM_BLOG_IDS`) currently get `sectionName` set to `'wp.com/support'` because they're grouped with support sites. This separates forum sites so they report `sectionName` as `'wp.com/forums'` instead, allowing them to be distinguished in analytics and routing.

## Testing instructions:
* On a site whose blog ID is in `WPCOM_FORUM_BLOG_IDS`, open the Help Center and verify `sectionName` in the inline script data is `'wp.com/forums'`.
* On a support site (blog ID in `WPCOM_SUPPORT_BLOG_IDS` but not in `WPCOM_FORUM_BLOG_IDS`), verify `sectionName` is still `'wp.com/support'`.
* On a regular site, verify `sectionName` falls back to the default `$variant`.
