### PR TITLE
Forms: Fix aria-label attribute by passing string values to Page 

### DIFF
--- a/projects/packages/forms/changelog/update-forms-aria-label
+++ b/projects/packages/forms/changelog/update-forms-aria-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix aria-label attribute by passing a string value to the Page component.

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -492,6 +492,7 @@ function StageInner() {
 
 	const {
 		title,
+		ariaLabel,
 		breadcrumbs,
 		subtitle,
 		actions: headerActions,
@@ -520,6 +521,7 @@ function StageInner() {
 			showSidebarToggle={ false }
 			breadcrumbs={ breadcrumbs }
 			title={ title }
+			ariaLabel={ ariaLabel }
 			subTitle={ subtitle }
 			actions={ headerActions }
 			hasPadding={ false }

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -543,6 +543,7 @@ function StageInner() {
 	}, [] );
 
 	const {
+		ariaLabel,
 		breadcrumbs,
 		badges,
 		subtitle,
@@ -573,6 +574,7 @@ function StageInner() {
 			breadcrumbs={ breadcrumbs }
 			badges={ badges }
 			title={ title }
+			ariaLabel={ ariaLabel }
 			subTitle={ subtitle }
 			actions={ headerActions }
 			hasPadding={ false }

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -47,6 +47,7 @@ type UsePageHeaderDetailsProps = {
 };
 
 type UsePageHeaderDetailsReturn = {
+	ariaLabel: string;
 	breadcrumbs: ReactNode;
 	title?: ReactNode;
 	badges?: ReactNode;
@@ -175,6 +176,14 @@ export default function usePageHeaderDetails(
 			{ children }
 		</Stack>
 	);
+
+	const ariaLabel = useMemo( () => {
+		if ( isSingleFormScreen ) {
+			return formTitle || __( 'Form responses', 'jetpack-forms' );
+		}
+		// "Forms" is a product name, do not translate.
+		return 'Forms';
+	}, [ isSingleFormScreen, formTitle ] );
 
 	const title = useMemo( () => {
 		if ( isSingleFormScreen ) {
@@ -472,5 +481,5 @@ export default function usePageHeaderDetails(
 		emptySpam.selectedResponsesCount,
 	] );
 
-	return { breadcrumbs, title, badges, subtitle, actions };
+	return { ariaLabel, breadcrumbs, title, badges, subtitle, actions };
 }

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -182,7 +182,7 @@ export default function usePageHeaderDetails(
 			return formTitle || __( 'Form responses', 'jetpack-forms' );
 		}
 		// "Forms" is a product name, do not translate.
-		return 'Forms';
+		return 'Jetpack Forms';
 	}, [ isSingleFormScreen, formTitle ] );
 
 	const title = useMemo( () => {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Part of JETPACK-1400
Part of JETPACK-1392

Follow up to https://github.com/Automattic/jetpack/pull/47461 to cover Forms, as previous PR covered everything else.

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Adds `ariaLabel` to Page since we're using React components in `title` and aria-label requires string.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Forms dashboards using wp-build now includes ariaLabel that works: In DOM, see navigable region element aria-label go from `[object object]` to `Jetpack Forms`
* Old dashboard still uses an internal component, so we can leave that be.



## Changelog
<!-- Check one of the boxes below. -->

- [x] Generate changelog entries for this PR (using AI).
