### PR TITLE
Social logos: fix build by using tsgo instead of tsc

### DIFF
--- a/projects/js-packages/social-logos/changelog/pr-47482
+++ b/projects/js-packages/social-logos/changelog/pr-47482
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Build tooling fix with no user-facing impact.
+
+

--- a/projects/js-packages/social-logos/tools/build-react
+++ b/projects/js-packages/social-logos/tools/build-react
@@ -16,7 +16,7 @@ cd "$root_dir"
 mkdir -p "$dest_react_dir"
 
 # Build files using TypeScript.
-pnpm tsc
+pnpm tsgo
 
 # Copy example CSS.
 if [[ ! -d "$dest_css_dir" ]]; then

--- a/projects/js-packages/social-logos/tsconfig.json
+++ b/projects/js-packages/social-logos/tsconfig.json
@@ -1,7 +1,8 @@
 {
 	"extends": "jetpack-js-tools/tsconfig.tsc.json",
 	"compilerOptions": {
-		"outDir": "./build/react"
+		"outDir": "./build/react",
+		"rootDir": "./src/react"
 	},
 	"include": [ "./src/react" ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->


## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Fixes:
```
[js-packages/social-logos] == Build js-packages/social-logos [building] ==
[js-packages/social-logos]
[js-packages/social-logos] > ./tools/build
[js-packages/social-logos] Starting full build...
[js-packages/social-logos] Cleaned up old build files.
[js-packages/social-logos] Created optimized SVGs in 'build/svg-clean'.
[js-packages/social-logos] Created SVG sprite file in 'build/svg-sprite'
[js-packages/social-logos] Created font files in 'build/font'.
[js-packages/social-logos] Created React SVG data file in 'build/react'.
[js-packages/social-logos] undefined
[js-packages/social-logos]  ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "tsc" not found
[js-packages/social-logos]
[js-packages/social-logos] Did you mean "pnpm tsgo"?
[js-packages/social-logos] Build failure!
[js-packages/social-logos] Script ./tools/build handling the build-development event returned with error code 1
[js-packages/social-logos]
[js-packages/social-logos] Build failed: Error: Command failed with exit code 1: composer run --timeout=0 build-development
[js-packages/social-logos]     at makeError (file:///Users/mikael/Documents/Work/Automattic/jetpack/node_modules/.pnpm/execa@7.0.0/node_modules/execa/lib/error.js:59:11)
[js-packages/social-logos]     at handlePromise (file:///Users/mikael/Documents/Work/Automattic/jetpack/node_modules/.pnpm/execa@7.0.0/node_modules/execa/index.js:119:26)
[js-packages/social-logos]     at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
[js-packages/social-logos]     at async buildProject (file:///Users/mikael/Documents/Work/Automattic/jetpack/tools/cli/commands/build.js:792:3)
[js-packages/social-logos]     at async file:///Users/mikael/Documents/Work/Automattic/jetpack/tools/cli/commands/build.js:374:7
[js-packages/social-logos]
[js-packages/social-logos] == Build js-packages/social-logos [complete] ==
[js-packages/social-logos]

The following builds failed:
 - js-packages/social-logos
 ```

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Wipe out built files from social-logos and run the build
* `jetpack build js-packages/social-logos -v`

## Changelog
<!-- Check one of the boxes below. -->

- [x] Generate changelog entries for this PR (using AI).
