### PR TITLE
Gutenberg RTC: Support HTTP polling provider

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/pr-47485
+++ b/projects/packages/jetpack-mu-wpcom/changelog/pr-47485
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Gutenberg RTC: Add support for HTTP polling provider as an allowed real-time collaboration provider.

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
@@ -27,13 +27,35 @@ function wpcom_get_gutenberg_rtc_providers() {
 		return array();
 	}
 
-	return apply_filters( 'wpcom_gutenberg_rtc_providers', array( 'pinghub' ) );
+	$allowed_providers = array( 'http-polling', 'pinghub' );
+	$providers         = apply_filters( 'wpcom_gutenberg_rtc_providers', array( 'pinghub' ) );
+	if ( ! is_array( $providers ) ) {
+		return array();
+	}
+
+	return array_values(
+		array_filter(
+			$providers,
+			function ( $provider ) use ( $allowed_providers ) {
+				return in_array( $provider, $allowed_providers, true );
+			}
+		)
+	);
 }
 
 /**
  * Enqueue block editor assets for Gutenberg RTC customizations.
  */
 function wpcom_enqueue_gutenberg_rtc_assets() {
+	$providers = wpcom_get_gutenberg_rtc_providers();
+
+	// If HTTP polling (Gutenberg’s built-in default provider when this script isn’t enqueued)
+	// is the only provider being used, then we don’t need to inject any assets since that’s
+	// already the default behavior.
+	if ( count( $providers ) === 1 && in_array( 'http-polling', $providers, true ) ) {
+		return;
+	}
+
 	$handle = jetpack_mu_wpcom_enqueue_assets( 'gutenberg-rtc', array( 'js' ) );
 
 	$data = wp_json_encode(

--- a/projects/packages/jetpack-mu-wpcom/src/utils.php
+++ b/projects/packages/jetpack-mu-wpcom/src/utils.php
@@ -105,16 +105,22 @@ function wpcom_get_calypso_origin() {
  */
 function jetpack_mu_wpcom_enqueue_assets( $asset_name, $asset_types = array() ) {
 	$asset_handle = "jetpack-mu-wpcom-$asset_name";
-	$asset_file   = include Jetpack_Mu_Wpcom::BASE_DIR . "build/$asset_name/$asset_name.asset.php";
+	$asset_path   = Jetpack_Mu_Wpcom::BASE_DIR . "build/$asset_name/$asset_name.asset.php";
+	$asset_file   = file_exists( $asset_path ) ? include $asset_path : array();
+	if ( ! is_array( $asset_file ) ) {
+		$asset_file = array();
+	}
 
 	if ( in_array( 'js', $asset_types, true ) ) {
 		$js_file      = "build/$asset_name/$asset_name.js";
+		$js_path      = Jetpack_Mu_Wpcom::BASE_DIR . $js_file;
 		$dependencies = $asset_file['dependencies'] ?? array();
+		$version      = $asset_file['version'] ?? ( file_exists( $js_path ) ? filemtime( $js_path ) : null );
 		wp_enqueue_script(
 			"jetpack-mu-wpcom-$asset_name",
 			plugins_url( $js_file, Jetpack_Mu_Wpcom::BASE_FILE ),
 			$dependencies,
-			$asset_file['version'] ?? filemtime( Jetpack_Mu_Wpcom::BASE_DIR . $js_file ),
+			$version,
 			true
 		);
 		if ( in_array( 'wp-i18n', $dependencies, true ) ) {
@@ -125,11 +131,12 @@ function jetpack_mu_wpcom_enqueue_assets( $asset_name, $asset_types = array() ) 
 	if ( in_array( 'css', $asset_types, true ) ) {
 		$css_ext  = is_rtl() ? 'rtl.css' : 'css';
 		$css_file = "build/$asset_name/$asset_name.$css_ext";
+		$css_path = Jetpack_Mu_Wpcom::BASE_DIR . $css_file;
 		wp_enqueue_style(
 			"jetpack-mu-wpcom-$asset_name",
 			plugins_url( $css_file, Jetpack_Mu_Wpcom::BASE_FILE ),
 			array(),
-			filemtime( Jetpack_Mu_Wpcom::BASE_DIR . $css_file )
+			file_exists( $css_path ) ? filemtime( $css_path ) : null
 		);
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
@@ -37,20 +37,38 @@ class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
 	private $original_wp_settings_fields;
 
 	/**
+	 * Original WP_Scripts instance to restore after each test.
+	 *
+	 * @var \WP_Scripts|null
+	 */
+	private $original_wp_scripts;
+
+	/**
+	 * Original WP_Styles instance to restore after each test.
+	 *
+	 * @var \WP_Styles|null
+	 */
+	private $original_wp_styles;
+
+	/**
 	 * Save global state before each test.
 	 */
 	public function set_up(): void {
 		parent::set_up();
-		global $wp_settings_fields;
+		global $wp_settings_fields, $wp_scripts, $wp_styles;
 		$this->original_wp_settings_fields = $wp_settings_fields;
+		$this->original_wp_scripts         = $wp_scripts;
+		$this->original_wp_styles          = $wp_styles;
 	}
 
 	/**
 	 * Clean up filters and restore global state after each test.
 	 */
 	public function tear_down(): void {
-		global $wp_settings_fields;
+		global $wp_settings_fields, $wp_scripts, $wp_styles;
 		$wp_settings_fields = $this->original_wp_settings_fields; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$wp_scripts         = $this->original_wp_scripts; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$wp_styles          = $this->original_wp_styles; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		remove_all_filters( 'wpcom_is_gutenberg_rtc_enabled' );
 		remove_all_filters( 'wpcom_gutenberg_rtc_providers' );
 		parent::tear_down();
@@ -127,6 +145,129 @@ class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
 		);
 
 		$this->assertSame( array( 'pinghub' ), wpcom_get_gutenberg_rtc_providers() );
+	}
+
+	/**
+	 * Tests that unknown providers are filtered out by the allowlist.
+	 */
+	public function test_wpcom_get_gutenberg_rtc_providers_filters_unknown_providers() {
+		add_filter( 'wpcom_is_gutenberg_rtc_enabled', '__return_true' );
+		add_filter(
+			'wpcom_gutenberg_rtc_providers',
+			function () {
+				return array( 'pinghub', 'unknown-provider', 'http-polling' );
+			}
+		);
+
+		$this->assertSame( array( 'pinghub', 'http-polling' ), wpcom_get_gutenberg_rtc_providers() );
+	}
+
+	/**
+	 * Tests that a non-array filter return is handled gracefully.
+	 */
+	public function test_wpcom_get_gutenberg_rtc_providers_handles_non_array_filter() {
+		add_filter( 'wpcom_is_gutenberg_rtc_enabled', '__return_true' );
+		add_filter(
+			'wpcom_gutenberg_rtc_providers',
+			function () {
+				return 'pinghub';
+			}
+		);
+
+		$this->assertSame( array(), wpcom_get_gutenberg_rtc_providers() );
+	}
+
+	/**
+	 * Tests that all unknown providers are removed and result is re-indexed.
+	 */
+	public function test_wpcom_get_gutenberg_rtc_providers_reindexes_after_filtering() {
+		add_filter( 'wpcom_is_gutenberg_rtc_enabled', '__return_true' );
+		add_filter(
+			'wpcom_gutenberg_rtc_providers',
+			function () {
+				return array( 'unknown', 'pinghub' );
+			}
+		);
+
+		// array_values should re-index so 'pinghub' is at index 0, not 1.
+		$result = wpcom_get_gutenberg_rtc_providers();
+		$this->assertSame( array( 'pinghub' ), $result );
+		$this->assertSame( 0, array_key_first( $result ) );
+	}
+
+	/**
+	 * Tests that an empty array from filter is handled.
+	 */
+	public function test_wpcom_get_gutenberg_rtc_providers_handles_empty_filter() {
+		add_filter( 'wpcom_is_gutenberg_rtc_enabled', '__return_true' );
+		add_filter(
+			'wpcom_gutenberg_rtc_providers',
+			function () {
+				return array();
+			}
+		);
+
+		$this->assertSame( array(), wpcom_get_gutenberg_rtc_providers() );
+	}
+
+	/**
+	 * Tests that the default providers (without filter override) pass the allowlist.
+	 */
+	public function test_wpcom_get_gutenberg_rtc_providers_default_passes_allowlist() {
+		add_filter( 'wpcom_is_gutenberg_rtc_enabled', '__return_true' );
+
+		$this->assertSame( array( 'pinghub' ), wpcom_get_gutenberg_rtc_providers() );
+	}
+
+	/**
+	 * Tests that enqueue skips when http-polling is the only provider.
+	 */
+	public function test_wpcom_enqueue_gutenberg_rtc_assets_skips_http_polling_only() {
+		add_filter( 'wpcom_is_gutenberg_rtc_enabled', '__return_true' );
+		add_filter(
+			'wpcom_gutenberg_rtc_providers',
+			function () {
+				return array( 'http-polling' );
+			}
+		);
+
+		wpcom_enqueue_gutenberg_rtc_assets();
+
+		$this->assertFalse( wp_script_is( 'jetpack-mu-wpcom-gutenberg-rtc', 'enqueued' ) );
+	}
+
+	/**
+	 * Tests that the script is enqueued when pinghub provider is active.
+	 */
+	public function test_wpcom_enqueue_gutenberg_rtc_assets_enqueues_when_pinghub() {
+		add_filter( 'wpcom_is_gutenberg_rtc_enabled', '__return_true' );
+		add_filter(
+			'wpcom_gutenberg_rtc_providers',
+			function () {
+				return array( 'pinghub' );
+			}
+		);
+
+		wpcom_enqueue_gutenberg_rtc_assets();
+
+		$this->assertTrue( wp_script_is( 'jetpack-mu-wpcom-gutenberg-rtc', 'enqueued' ) );
+	}
+
+	/**
+	 * Tests that the script is enqueued when multiple providers including non-http-polling are active.
+	 */
+	public function test_wpcom_enqueue_gutenberg_rtc_assets_enqueues_with_multiple_providers() {
+		add_filter( 'wpcom_is_gutenberg_rtc_enabled', '__return_true' );
+		add_filter(
+			'wpcom_gutenberg_rtc_providers',
+			function () {
+				return array( 'http-polling', 'pinghub' );
+			}
+		);
+
+		wpcom_enqueue_gutenberg_rtc_assets();
+
+		$this->assertTrue( wp_script_is( 'jetpack-mu-wpcom-gutenberg-rtc', 'enqueued' ) );
 	}
 
 	/**

--- a/projects/plugins/wpcomsh/changelog/pr-47485
+++ b/projects/plugins/wpcomsh/changelog/pr-47485
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Gutenberg RTC: Add support for HTTP polling provider for real-time collaboration.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->
<!-- a12s: If you have an expected version that you're aiming for the PR to add, please use the Milestone field to communicate it. If you leave it blank, that indicates there isn't a preference. -->

Related DOTCOM-16238

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
* Support HTTP polling provider as we want to enable it for free sites and limit 2 collaborators

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply changes to your sandbox
* Add following filters to `mu-plugins/0-sandbox.php`
  ```php
  add_filter( 'wpcom_is_gutenberg_rtc_enabled', '__return_true' );

  add_filter( 'wpcom_gutenberg_rtc_providers', function() {
    return [ 'http-polling' ];
  } );
  ```
* Go to edit a page/post
* Check the network request
* Ensure it polls `/wp-sync/v1/sites/:site/updates` endpoint

## Changelog
<!-- Check one of the boxes below. -->

- [x] Generate changelog entries for this PR (using AI).
