### PR TITLE
Settings: migrate to shared AdminPage component

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/settings-admin-page/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-admin-page/index.jsx
@@ -109,17 +109,19 @@ function buildFooterMenuItems( props ) {
 }
 
 const SettingsAdminPage = props => {
-	const { apiRoot, apiNonce, siteConnectionStatus, location, children } = props;
+	const { apiRoot, apiNonce, siteConnectionStatus, location, tabs, children } = props;
 
 	const footerMenuItems = buildFooterMenuItems( props );
 
 	return (
 		<AdminPage
+			className="jp-settings-admin-page"
 			title={ __( 'Settings', 'jetpack' ) }
 			apiRoot={ apiRoot }
 			apiNonce={ apiNonce }
 			showFooter={ true }
-			showBackground={ false }
+			showBackground={ true }
+			tabs={ tabs }
 			optionalMenuItems={ footerMenuItems }
 			moduleNameHref={ getRedirectUrl( 'jetpack' ) }
 			useInternalLinks={ !! siteConnectionStatus }

--- a/projects/plugins/jetpack/_inc/client/components/settings-admin-page/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-admin-page/index.jsx
@@ -1,0 +1,156 @@
+import { AdminPage, getRedirectUrl } from '@automattic/jetpack-components';
+import { isJetpackSelfHostedSite, isWoASite } from '@automattic/jetpack-script-data';
+import { __, _x, sprintf } from '@wordpress/i18n';
+import { connect } from 'react-redux';
+import analytics from 'lib/analytics';
+import { getSiteConnectionStatus } from 'state/connection';
+import { enableDevCard, resetOptions } from 'state/dev-version';
+import {
+	isDevVersion as _isDevVersion,
+	getCurrentVersion,
+	userCanManageOptions,
+	getApiNonce,
+	getApiRootUrl,
+	getSiteAdminUrl,
+} from 'state/initial-state';
+import onKeyDownCallback from 'utils/onkeydown-callback';
+import { HeaderNav } from '../masthead/header-nav';
+
+/**
+ * Build footer menu items matching the legacy Footer component.
+ *
+ * Note: The legacy Footer also rendered a DevCard component (a floating dev
+ * panel toggled via "Dev Tools" in the footer). DevCard is NOT included here
+ * because AdminPage's footer only supports menu item arrays. DevCard was a
+ * dev-only diagnostic tool — if needed, it can be rendered separately.
+ *
+ * @param {object} props - Component props from Redux.
+ * @return {Array} Footer menu items.
+ */
+function buildFooterMenuItems( props ) {
+	const { currentVersion, isDevVersion, siteAdminUrl, siteConnectionStatus, canManageOptions } =
+		props;
+
+	const menu = [];
+
+	if ( isJetpackSelfHostedSite() ) {
+		menu.push( {
+			label: sprintf(
+				/* Translators: %s: a version number. */
+				__( 'Version %s', 'jetpack' ),
+				currentVersion
+			),
+			href: getRedirectUrl( 'jetpack' ),
+			target: '_blank',
+			onClick: () => {
+				analytics.tracks.recordJetpackClick( {
+					target: 'footer_link',
+					link: 'version',
+				} );
+			},
+		} );
+	}
+
+	if ( siteConnectionStatus && canManageOptions ) {
+		menu.push( {
+			label: _x(
+				'Modules',
+				'Navigation item. Noun. Links to a list of modules for Jetpack.',
+				'jetpack'
+			),
+			title: __( 'Access the full list of Jetpack modules available on your site.', 'jetpack' ),
+			href: siteAdminUrl + 'admin.php?page=jetpack_modules',
+			onClick: () => {
+				analytics.tracks.recordJetpackClick( {
+					target: 'footer_link',
+					link: 'modules',
+				} );
+			},
+		} );
+	}
+
+	if ( canManageOptions ) {
+		menu.push( {
+			label: _x(
+				'Debug',
+				'Navigation item. Noun. Links to a debugger tool for Jetpack.',
+				'jetpack'
+			),
+			title: __( "Test your site's compatibility with Jetpack.", 'jetpack' ),
+			href: siteAdminUrl + 'admin.php?page=jetpack-debugger',
+			onClick: () => {
+				analytics.tracks.recordJetpackClick( {
+					target: 'footer_link',
+					link: 'debug',
+				} );
+			},
+		} );
+	}
+
+	if ( isDevVersion && canManageOptions ) {
+		menu.push( {
+			label: _x( 'Reset Options (dev only)', 'Navigation item.', 'jetpack' ),
+			role: 'button',
+			onKeyDown: onKeyDownCallback( props.doResetOptions ),
+			onClick: props.doResetOptions,
+		} );
+	}
+
+	if ( isDevVersion ) {
+		menu.push( {
+			label: _x( 'Dev Tools', 'Navigation item.', 'jetpack' ),
+			role: 'button',
+			onKeyDown: onKeyDownCallback( props.doEnableDevCard ),
+			onClick: props.doEnableDevCard,
+		} );
+	}
+
+	return menu;
+}
+
+const SettingsAdminPage = props => {
+	const { apiRoot, apiNonce, siteConnectionStatus, location, children } = props;
+
+	const footerMenuItems = buildFooterMenuItems( props );
+
+	return (
+		<AdminPage
+			title={ __( 'Settings', 'jetpack' ) }
+			apiRoot={ apiRoot }
+			apiNonce={ apiNonce }
+			showFooter={ true }
+			showBackground={ false }
+			optionalMenuItems={ footerMenuItems }
+			moduleNameHref={ getRedirectUrl( 'jetpack' ) }
+			useInternalLinks={ !! siteConnectionStatus }
+			actions={ isWoASite() && <HeaderNav location={ location } /> }
+		>
+			{ children }
+		</AdminPage>
+	);
+};
+
+export default connect(
+	state => ( {
+		apiRoot: getApiRootUrl( state ),
+		apiNonce: getApiNonce( state ),
+		currentVersion: getCurrentVersion( state ),
+		isDevVersion: _isDevVersion( state ),
+		canManageOptions: userCanManageOptions( state ),
+		siteAdminUrl: getSiteAdminUrl( state ),
+		siteConnectionStatus: getSiteConnectionStatus( state ),
+	} ),
+	dispatch => ( {
+		doResetOptions: () => {
+			if (
+				// eslint-disable-next-line no-alert -- @todo Is there a better dialog we could use?
+				window.confirm( __( 'This will reset all Jetpack options, are you sure?', 'jetpack' ) )
+			) {
+				dispatch( resetOptions( 'options' ) );
+			}
+		},
+		doEnableDevCard: () => {
+			dispatch( enableDevCard() );
+		},
+	} )
+)( SettingsAdminPage );

--- a/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/index.jsx
@@ -1,0 +1,207 @@
+import { __, _x } from '@wordpress/i18n';
+import { connect } from 'react-redux';
+import { NavLink, useLocation } from 'react-router';
+import QuerySitePlugins from 'components/data/query-site-plugins';
+import Search from 'components/search';
+import analytics from 'lib/analytics';
+import {
+	userCanManageModules as _userCanManageModules,
+	userIsSubscriber as _userIsSubscriber,
+	userCanPublish,
+} from 'state/initial-state';
+import {
+	hasAnyOfTheseModules,
+	hasAnyPerformanceFeature,
+	hasAnySecurityFeature,
+	isModuleActivated,
+} from 'state/modules';
+import { filterSearch, getSearchTerm } from 'state/search';
+
+const Tab = ( { to, label, onClick } ) => (
+	<NavLink
+		to={ to }
+		// eslint-disable-next-line react/jsx-no-bind
+		className={ ( { isActive } ) =>
+			isActive ? 'jp-settings-nav__tab jp-settings-nav__tab--active' : 'jp-settings-nav__tab'
+		}
+		onClick={ onClick }
+	>
+		{ label }
+	</NavLink>
+);
+
+const SettingsNavTabs = props => {
+	const {
+		userCanManageModules,
+		isSubscriber,
+		userCanPublishPosts,
+		hasSecurityFeature,
+		hasPerformanceFeature,
+		hasModules,
+		isModuleActive,
+		searchTerm,
+		searchForTerm,
+	} = props;
+
+	const location = useLocation();
+
+	const trackNavClick = target => {
+		analytics.tracks.recordJetpackClick( {
+			target: 'nav_item',
+			path: target,
+		} );
+	};
+
+	const doSearch = keywords => {
+		const splitUrl = window.location.href.split( '#' ),
+			splitHash = splitUrl[ 1 ].split( '?' );
+
+		searchForTerm( keywords );
+		const searchURL = '#' + splitHash[ 0 ] + ( keywords ? '?term=' + keywords : '' );
+		window.location.href = searchURL;
+	};
+
+	let tabs;
+
+	/* eslint-disable react/jsx-no-bind -- Arrow callbacks for analytics tracking. */
+	if ( userCanManageModules ) {
+		tabs = (
+			<>
+				{ hasSecurityFeature && (
+					<Tab
+						to="/security"
+						label={ _x( 'Security', 'Navigation item.', 'jetpack' ) }
+						onClick={ () => trackNavClick( 'security' ) }
+					/>
+				) }
+				{ hasPerformanceFeature && (
+					<Tab
+						to="/performance"
+						label={ _x( 'Performance', 'Navigation item.', 'jetpack' ) }
+						onClick={ () => trackNavClick( 'performance' ) }
+					/>
+				) }
+				{ ( hasModules( [ 'markdown', 'post-by-email', 'infinite-scroll', 'copy-post' ] ) ||
+					window.CUSTOM_CONTENT_TYPE__INITIAL_STATE.active ) && (
+					<Tab
+						to="/writing"
+						label={ _x( 'Writing', 'Navigation item.', 'jetpack' ) }
+						onClick={ () => trackNavClick( 'writing' ) }
+					/>
+				) }
+				{ hasModules( [ 'publicize', 'sharedaddy', 'likes' ] ) && (
+					<Tab
+						to="/sharing"
+						label={ _x( 'Sharing', 'Navigation item.', 'jetpack' ) }
+						onClick={ () => trackNavClick( 'sharing' ) }
+					/>
+				) }
+				{ hasModules( [ 'comments', 'gravatar-hovercards', 'markdown' ] ) && (
+					<Tab
+						to="/discussion"
+						label={ _x( 'Discussion', 'Navigation item.', 'jetpack' ) }
+						onClick={ () => trackNavClick( 'discussion' ) }
+					/>
+				) }
+				{ hasModules( [
+					'seo-tools',
+					'stats',
+					'related-posts',
+					'verification-tools',
+					'sitemaps',
+					'google-analytics',
+				] ) && (
+					<Tab
+						to="/traffic"
+						label={ _x( 'Traffic', 'Navigation item.', 'jetpack' ) }
+						onClick={ () => trackNavClick( 'traffic' ) }
+					/>
+				) }
+				{ hasModules( [ 'subscriptions' ] ) && (
+					<Tab
+						to="/newsletter"
+						label={ _x( 'Newsletter', 'Navigation item.', 'jetpack' ) }
+						onClick={ () => trackNavClick( 'newsletter' ) }
+					/>
+				) }
+				{ hasModules( [ 'wordads' ] ) && (
+					<Tab
+						to="/earn"
+						label={ _x( 'Monetize', 'Navigation item.', 'jetpack' ) }
+						onClick={ () => trackNavClick( 'earn' ) }
+					/>
+				) }
+			</>
+		);
+	} else if ( isSubscriber ) {
+		tabs = null;
+	} else {
+		tabs = (
+			<>
+				{ isModuleActive( 'post-by-email' ) &&
+					userCanPublishPosts &&
+					hasModules( [ 'post-by-email' ] ) && (
+						<Tab
+							to="/writing"
+							label={ _x( 'Writing', 'Navigation item.', 'jetpack' ) }
+							onClick={ () => trackNavClick( 'writing' ) }
+						/>
+					) }
+				{ isModuleActive( 'publicize' ) && userCanPublishPosts && hasModules( [ 'publicize' ] ) && (
+					<Tab
+						to="/sharing"
+						label={ _x( 'Sharing', 'Navigation item.', 'jetpack' ) }
+						onClick={ () => trackNavClick( 'sharing' ) }
+					/>
+				) }
+			</>
+		);
+	}
+
+	// Handle search term from URL on initial load.
+	const searchFromUrl = ( () => {
+		const search = location.search || '';
+		const pairs = search.substr( 1 ).split( '&' );
+		const term = pairs.filter( item => 0 === item.indexOf( 'term=' ) );
+		if ( term.length > 0 ) {
+			return decodeURIComponent( term[ 0 ].split( '=' )[ 1 ] );
+		}
+		return '';
+	} )();
+
+	return (
+		<div className="jp-settings-nav">
+			<QuerySitePlugins />
+			<nav className="jp-settings-nav__tabs">{ tabs }</nav>
+			{ userCanManageModules && (
+				<Search
+					pinned={ true }
+					fitsContainer={ true }
+					placeholder={ __( 'Search for a Jetpack feature.', 'jetpack' ) }
+					delaySearch={ true }
+					delayTimeout={ 500 }
+					onSearch={ doSearch }
+					isOpen={ !! searchTerm }
+					initialValue={ searchTerm || searchFromUrl }
+				/>
+			) }
+		</div>
+	);
+	/* eslint-enable react/jsx-no-bind */
+};
+
+export default connect(
+	state => ( {
+		userCanManageModules: _userCanManageModules( state ),
+		isSubscriber: _userIsSubscriber( state ),
+		userCanPublishPosts: userCanPublish( state ),
+		hasSecurityFeature: hasAnySecurityFeature( state ),
+		hasPerformanceFeature: hasAnyPerformanceFeature( state ),
+		hasModules: modules => hasAnyOfTheseModules( state, modules ),
+		isModuleActive: module => isModuleActivated( state, module ),
+		searchTerm: getSearchTerm( state ),
+	} ),
+	dispatch => ( {
+		searchForTerm: term => dispatch( filterSearch( term ) ),
+	} )
+)( SettingsNavTabs );

--- a/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/style.scss
@@ -1,0 +1,43 @@
+// AdminPage uses margin-left: -20px to neutralize #wpcontent's default 20px
+// padding. But Jetpack's own CSS zeros out that padding (admin-static.scss,
+// _main.scss), so the -20px just shifts everything into the sidebar. Reset it.
+// Double class for specificity over the CSS module rule.
+.jp-settings-admin-page.jp-settings-admin-page {
+	margin-left: 0;
+}
+
+.jp-settings-nav {
+	display: flex;
+	align-items: center;
+	border-bottom: 1px solid #f0f0f0;
+	padding-inline: 24px;
+}
+
+.jp-settings-nav__tabs {
+	display: flex;
+	flex: 1;
+}
+
+.jp-settings-nav__tab {
+	color: #1e1e1e;
+	font-size: 16px;
+	line-height: 1.5;
+	text-decoration: none;
+	padding: 8px 0;
+	margin-right: 32px;
+	white-space: nowrap;
+
+	&:last-child {
+		margin-right: 0;
+	}
+
+	&:hover,
+	&:focus {
+		box-shadow: none;
+		color: #069e08;
+	}
+
+	&--active {
+		border-bottom: 2px solid #1e1e1e;
+	}
+}

--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -24,6 +24,7 @@ import NavigationSettings from 'components/navigation-settings';
 import NonAdminView from 'components/non-admin-view';
 import ReconnectModal from 'components/reconnect-modal';
 import SettingsAdminPage from 'components/settings-admin-page';
+import SettingsNavTabs from 'components/settings-nav-tabs';
 import SupportCard from 'components/support-card';
 import Tracker from 'components/tracker';
 import { imagePath } from 'constants/urls';
@@ -849,8 +850,7 @@ class Main extends Component {
 					{ this.shouldShowReconnectModal() && (
 						<ReconnectModal show={ true } onHide={ this.closeReconnectModal } />
 					) }
-					<SettingsAdminPage location={ this.props.location }>
-						<div className="jp-top-inside">{ mainNav }</div>
+					<SettingsAdminPage location={ this.props.location } tabs={ <SettingsNavTabs /> }>
 						<div className={ jpClasses.join( ' ' ) }>
 							<AdminNotices />
 							<JetpackNotices />

--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -23,6 +23,7 @@ import Navigation from 'components/navigation';
 import NavigationSettings from 'components/navigation-settings';
 import NonAdminView from 'components/non-admin-view';
 import ReconnectModal from 'components/reconnect-modal';
+import SettingsAdminPage from 'components/settings-admin-page';
 import SupportCard from 'components/support-card';
 import Tracker from 'components/tracker';
 import { imagePath } from 'constants/urls';
@@ -819,6 +820,10 @@ class Main extends Component {
 		this.props.fetchSettings();
 	}
 
+	isSettingsRoute() {
+		return settingsRoutes.includes( this.props.location.pathname );
+	}
+
 	render() {
 		const jpClasses = [ 'jp-lower' ];
 
@@ -834,7 +839,30 @@ class Main extends Component {
 			jpClasses.push( 'jp-licensing-screen' );
 		}
 
-		const mainNav = this.renderMainNav( this.props.location.pathname );
+		const pathname = this.props.location.pathname;
+		const mainNav = this.renderMainNav( pathname );
+
+		// Settings routes use the shared AdminPage component for header and footer.
+		if ( this.isSettingsRoute() ) {
+			return (
+				<div>
+					{ this.shouldShowReconnectModal() && (
+						<ReconnectModal show={ true } onHide={ this.closeReconnectModal } />
+					) }
+					<SettingsAdminPage location={ this.props.location }>
+						<div className="jp-top-inside">{ mainNav }</div>
+						<div className={ jpClasses.join( ' ' ) }>
+							<AdminNotices />
+							<JetpackNotices />
+							{ this.shouldConnectUser() && this.connectUser() }
+							{ this.renderMainContent( pathname ) }
+						</div>
+					</SettingsAdminPage>
+					<Tracker analytics={ analytics } />
+				</div>
+			);
+		}
+
 		const showHeader = mainNav || this.shouldShowMasthead() || this.shouldShowRewindStatus();
 
 		return (
@@ -858,14 +886,14 @@ class Main extends Component {
 					<JetpackNotices />
 					{ this.shouldConnectUser() && this.connectUser() }
 
-					{ this.renderMainContent( this.props.location.pathname ) }
+					{ this.renderMainContent( pathname ) }
 					{ this.shouldShowJetpackManageBanner() && (
 						<JetpackManageBanner
-							path={ this.props.location.pathname }
+							path={ pathname }
 							isAgencyAccount={ this.props.jetpackManage.isAgencyAccount }
 						/>
 					) }
-					{ this.shouldShowSupportCard() && <SupportCard path={ this.props.location.pathname } /> }
+					{ this.shouldShowSupportCard() && <SupportCard path={ pathname } /> }
 					{ this.shouldShowAppsCard() && <AppsCard /> }
 				</div>
 				{ this.shouldShowFooter() && <Footer siteAdminUrl={ this.props.siteAdminUrl } /> }

--- a/projects/plugins/jetpack/_inc/client/scss/style.scss
+++ b/projects/plugins/jetpack/_inc/client/scss/style.scss
@@ -41,6 +41,7 @@
 @include meta.load-css( "../components/admin-notices/style" );
 @include meta.load-css( "../components/module-toggle/style" );
 @include meta.load-css( "../components/navigation-settings/style" );
+@include meta.load-css( "../components/settings-nav-tabs/style" );
 @include meta.load-css( "../components/settings-card/style" );
 @include meta.load-css( "../components/settings-group/style" );
 @include meta.load-css( "../components/apps-card/style" );

--- a/projects/plugins/jetpack/changelog/update-settings-use-adminpage
+++ b/projects/plugins/jetpack/changelog/update-settings-use-adminpage
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Migrated the Settings page header and navigation to use the shared AdminPage component, replacing the legacy Masthead and Calypso SectionNav with a standardized layout matching other Jetpack admin pages.


### PR DESCRIPTION
## Summary

- Migrates the Jetpack Settings page to use the shared `AdminPage` component from `@automattic/jetpack-components`, replacing the legacy `Masthead` and `Footer` with the standardized header/footer pattern used by Protect and other Jetpack admin pages.
- Introduces a new `SettingsNavTabs` component (react-router `NavLink`-based) to replace the Calypso `SectionNav`/`NavTabs`/`NavItem` navigation, passed via AdminPage's `tabs` prop.
- Fixes a margin mismatch where Jetpack's CSS zeroes `#wpcontent` padding-left but AdminPage assumes the default 20px padding exists (applying `margin-left: -20px` to neutralize it). The override resets the margin to 0 for the Settings wrapper.

JETPACK-1411

## Test plan

- [ ] Navigate to **Jetpack > Settings** — verify the header shows bolt icon + "Settings" title with proper left alignment (matching Dashboard)
- [ ] Verify all nav tabs (Security, Performance, Writing, etc.) render correctly and route to the expected settings sections
- [ ] Verify the active tab has an underline indicator
- [ ] Verify the search bar still works (type a search term, confirm results filter)
- [ ] Verify the footer shows version, modules, debug links
- [ ] Compare header/tab positioning with the Dashboard page — left alignment should match
- [ ] Test on a WoA site to verify the `HeaderNav` actions render in the header
- [ ] Check that the Dashboard page still uses the old `Masthead` layout (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)