### PR TITLE
Settings: migrate to shared AdminPage component

### DIFF
--- a/projects/js-packages/components/changelog/fix-adminpage-footer-horizontal-scroll
+++ b/projects/js-packages/components/changelog/fix-adminpage-footer-horizontal-scroll
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix AdminPage footer Container causing horizontal scroll on narrow viewports by explicitly setting box-sizing: border-box.

--- a/projects/js-packages/components/components/admin-page/index.tsx
+++ b/projects/js-packages/components/components/admin-page/index.tsx
@@ -90,7 +90,7 @@ const AdminPage: FC< AdminPageProps > = ( {
 	) : undefined;
 
 	const footer = showFooter && (
-		<Container horizontalSpacing={ 5 }>
+		<Container className={ styles[ 'admin-page-footer' ] } horizontalSpacing={ 5 }>
 			<Col>
 				<JetpackFooter
 					moduleName={ moduleName }

--- a/projects/js-packages/components/components/admin-page/style.module.scss
+++ b/projects/js-packages/components/components/admin-page/style.module.scss
@@ -35,6 +35,13 @@
 		gap: 8px;
 	}
 
+	// Ensure footer Container padding is included in its max-width,
+	// preventing horizontal scroll when the content area is narrower
+	// than the Container's max-width + padding (JETPACK-1424).
+	.admin-page-footer {
+		box-sizing: border-box;
+	}
+
 	.sandbox-domain-badge {
 		background: #d63638;
 		text-transform: uppercase;

--- a/projects/plugins/jetpack/_inc/client/components/settings-admin-page/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-admin-page/index.jsx
@@ -109,17 +109,19 @@ function buildFooterMenuItems( props ) {
 }
 
 const SettingsAdminPage = props => {
-	const { apiRoot, apiNonce, siteConnectionStatus, location, children } = props;
+	const { apiRoot, apiNonce, siteConnectionStatus, location, tabs, children } = props;
 
 	const footerMenuItems = buildFooterMenuItems( props );
 
 	return (
 		<AdminPage
+			className="jp-settings-admin-page"
 			title={ __( 'Settings', 'jetpack' ) }
 			apiRoot={ apiRoot }
 			apiNonce={ apiNonce }
 			showFooter={ true }
-			showBackground={ false }
+			showBackground={ true }
+			tabs={ tabs }
 			optionalMenuItems={ footerMenuItems }
 			moduleNameHref={ getRedirectUrl( 'jetpack' ) }
 			useInternalLinks={ !! siteConnectionStatus }

--- a/projects/plugins/jetpack/_inc/client/components/settings-admin-page/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-admin-page/index.jsx
@@ -1,0 +1,156 @@
+import { AdminPage, getRedirectUrl } from '@automattic/jetpack-components';
+import { isJetpackSelfHostedSite, isWoASite } from '@automattic/jetpack-script-data';
+import { __, _x, sprintf } from '@wordpress/i18n';
+import { connect } from 'react-redux';
+import analytics from 'lib/analytics';
+import { getSiteConnectionStatus } from 'state/connection';
+import { enableDevCard, resetOptions } from 'state/dev-version';
+import {
+	isDevVersion as _isDevVersion,
+	getCurrentVersion,
+	userCanManageOptions,
+	getApiNonce,
+	getApiRootUrl,
+	getSiteAdminUrl,
+} from 'state/initial-state';
+import onKeyDownCallback from 'utils/onkeydown-callback';
+import { HeaderNav } from '../masthead/header-nav';
+
+/**
+ * Build footer menu items matching the legacy Footer component.
+ *
+ * Note: The legacy Footer also rendered a DevCard component (a floating dev
+ * panel toggled via "Dev Tools" in the footer). DevCard is NOT included here
+ * because AdminPage's footer only supports menu item arrays. DevCard was a
+ * dev-only diagnostic tool — if needed, it can be rendered separately.
+ *
+ * @param {object} props - Component props from Redux.
+ * @return {Array} Footer menu items.
+ */
+function buildFooterMenuItems( props ) {
+	const { currentVersion, isDevVersion, siteAdminUrl, siteConnectionStatus, canManageOptions } =
+		props;
+
+	const menu = [];
+
+	if ( isJetpackSelfHostedSite() ) {
+		menu.push( {
+			label: sprintf(
+				/* Translators: %s: a version number. */
+				__( 'Version %s', 'jetpack' ),
+				currentVersion
+			),
+			href: getRedirectUrl( 'jetpack' ),
+			target: '_blank',
+			onClick: () => {
+				analytics.tracks.recordJetpackClick( {
+					target: 'footer_link',
+					link: 'version',
+				} );
+			},
+		} );
+	}
+
+	if ( siteConnectionStatus && canManageOptions ) {
+		menu.push( {
+			label: _x(
+				'Modules',
+				'Navigation item. Noun. Links to a list of modules for Jetpack.',
+				'jetpack'
+			),
+			title: __( 'Access the full list of Jetpack modules available on your site.', 'jetpack' ),
+			href: siteAdminUrl + 'admin.php?page=jetpack_modules',
+			onClick: () => {
+				analytics.tracks.recordJetpackClick( {
+					target: 'footer_link',
+					link: 'modules',
+				} );
+			},
+		} );
+	}
+
+	if ( canManageOptions ) {
+		menu.push( {
+			label: _x(
+				'Debug',
+				'Navigation item. Noun. Links to a debugger tool for Jetpack.',
+				'jetpack'
+			),
+			title: __( "Test your site's compatibility with Jetpack.", 'jetpack' ),
+			href: siteAdminUrl + 'admin.php?page=jetpack-debugger',
+			onClick: () => {
+				analytics.tracks.recordJetpackClick( {
+					target: 'footer_link',
+					link: 'debug',
+				} );
+			},
+		} );
+	}
+
+	if ( isDevVersion && canManageOptions ) {
+		menu.push( {
+			label: _x( 'Reset Options (dev only)', 'Navigation item.', 'jetpack' ),
+			role: 'button',
+			onKeyDown: onKeyDownCallback( props.doResetOptions ),
+			onClick: props.doResetOptions,
+		} );
+	}
+
+	if ( isDevVersion ) {
+		menu.push( {
+			label: _x( 'Dev Tools', 'Navigation item.', 'jetpack' ),
+			role: 'button',
+			onKeyDown: onKeyDownCallback( props.doEnableDevCard ),
+			onClick: props.doEnableDevCard,
+		} );
+	}
+
+	return menu;
+}
+
+const SettingsAdminPage = props => {
+	const { apiRoot, apiNonce, siteConnectionStatus, location, children } = props;
+
+	const footerMenuItems = buildFooterMenuItems( props );
+
+	return (
+		<AdminPage
+			title={ __( 'Settings', 'jetpack' ) }
+			apiRoot={ apiRoot }
+			apiNonce={ apiNonce }
+			showFooter={ true }
+			showBackground={ false }
+			optionalMenuItems={ footerMenuItems }
+			moduleNameHref={ getRedirectUrl( 'jetpack' ) }
+			useInternalLinks={ !! siteConnectionStatus }
+			actions={ isWoASite() && <HeaderNav location={ location } /> }
+		>
+			{ children }
+		</AdminPage>
+	);
+};
+
+export default connect(
+	state => ( {
+		apiRoot: getApiRootUrl( state ),
+		apiNonce: getApiNonce( state ),
+		currentVersion: getCurrentVersion( state ),
+		isDevVersion: _isDevVersion( state ),
+		canManageOptions: userCanManageOptions( state ),
+		siteAdminUrl: getSiteAdminUrl( state ),
+		siteConnectionStatus: getSiteConnectionStatus( state ),
+	} ),
+	dispatch => ( {
+		doResetOptions: () => {
+			if (
+				// eslint-disable-next-line no-alert -- @todo Is there a better dialog we could use?
+				window.confirm( __( 'This will reset all Jetpack options, are you sure?', 'jetpack' ) )
+			) {
+				dispatch( resetOptions( 'options' ) );
+			}
+		},
+		doEnableDevCard: () => {
+			dispatch( enableDevCard() );
+		},
+	} )
+)( SettingsAdminPage );

--- a/projects/plugins/jetpack/_inc/client/components/settings-admin-page/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-admin-page/index.jsx
@@ -119,7 +119,6 @@ const SettingsAdminPage = props => {
 			title={ __( 'Settings', 'jetpack' ) }
 			apiRoot={ apiRoot }
 			apiNonce={ apiNonce }
-			showFooter={ true }
 			showBackground={ true }
 			tabs={ tabs }
 			optionalMenuItems={ footerMenuItems }

--- a/projects/plugins/jetpack/_inc/client/components/settings-admin-page/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-admin-page/index.jsx
@@ -2,9 +2,10 @@ import { AdminPage, getRedirectUrl } from '@automattic/jetpack-components';
 import { isJetpackSelfHostedSite, isWoASite } from '@automattic/jetpack-script-data';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { connect } from 'react-redux';
+import DevCard from 'components/dev-card';
 import analytics from 'lib/analytics';
 import { getSiteConnectionStatus } from 'state/connection';
-import { enableDevCard, resetOptions } from 'state/dev-version';
+import { canDisplayDevCard, enableDevCard, resetOptions } from 'state/dev-version';
 import {
 	isDevVersion as _isDevVersion,
 	getCurrentVersion,
@@ -18,11 +19,6 @@ import { HeaderNav } from '../masthead/header-nav';
 
 /**
  * Build footer menu items matching the legacy Footer component.
- *
- * Note: The legacy Footer also rendered a DevCard component (a floating dev
- * panel toggled via "Dev Tools" in the footer). DevCard is NOT included here
- * because AdminPage's footer only supports menu item arrays. DevCard was a
- * dev-only diagnostic tool — if needed, it can be rendered separately.
  *
  * @param {object} props - Component props from Redux.
  * @return {Array} Footer menu items.
@@ -109,25 +105,37 @@ function buildFooterMenuItems( props ) {
 }
 
 const SettingsAdminPage = props => {
-	const { apiRoot, apiNonce, siteConnectionStatus, location, tabs, children } = props;
+	const {
+		apiRoot,
+		apiNonce,
+		isDevVersion,
+		displayDevCard,
+		siteConnectionStatus,
+		location,
+		tabs,
+		children,
+	} = props;
 
 	const footerMenuItems = buildFooterMenuItems( props );
 
 	return (
-		<AdminPage
-			className="jp-settings-admin-page"
-			title={ __( 'Settings', 'jetpack' ) }
-			apiRoot={ apiRoot }
-			apiNonce={ apiNonce }
-			showBackground={ true }
-			tabs={ tabs }
-			optionalMenuItems={ footerMenuItems }
-			moduleNameHref={ getRedirectUrl( 'jetpack' ) }
-			useInternalLinks={ !! siteConnectionStatus }
-			actions={ isWoASite() && <HeaderNav location={ location } /> }
-		>
-			{ children }
-		</AdminPage>
+		<>
+			<AdminPage
+				className="jp-settings-admin-page"
+				title={ __( 'Settings', 'jetpack' ) }
+				apiRoot={ apiRoot }
+				apiNonce={ apiNonce }
+				showBackground={ true }
+				tabs={ tabs }
+				optionalMenuItems={ footerMenuItems }
+				moduleNameHref={ getRedirectUrl( 'jetpack' ) }
+				useInternalLinks={ !! siteConnectionStatus }
+				actions={ isWoASite() && <HeaderNav location={ location } /> }
+			>
+				{ children }
+			</AdminPage>
+			{ isDevVersion && displayDevCard && <DevCard /> }
+		</>
 	);
 };
 
@@ -137,6 +145,7 @@ export default connect(
 		apiNonce: getApiNonce( state ),
 		currentVersion: getCurrentVersion( state ),
 		isDevVersion: _isDevVersion( state ),
+		displayDevCard: canDisplayDevCard( state ),
 		canManageOptions: userCanManageOptions( state ),
 		siteAdminUrl: getSiteAdminUrl( state ),
 		siteConnectionStatus: getSiteConnectionStatus( state ),

--- a/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/index.jsx
@@ -68,7 +68,8 @@ const SettingsNavTabs = props => {
 				splitHash = splitUrl[ 1 ].split( '?' );
 
 			searchForTerm( keywords );
-			const searchURL = '#' + splitHash[ 0 ] + ( keywords ? '?term=' + keywords : '' );
+			const searchURL =
+				'#' + splitHash[ 0 ] + ( keywords ? '?term=' + encodeURIComponent( keywords ) : '' );
 			window.location.href = searchURL;
 		},
 		[ searchForTerm ]

--- a/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/index.jsx
@@ -1,5 +1,6 @@
 import { isWoASite as _isWoASite } from '@automattic/jetpack-script-data';
 import { __, _x } from '@wordpress/i18n';
+import clsx from 'clsx';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { connect } from 'react-redux';
 import { NavLink, useLocation } from 'react-router';
@@ -19,18 +20,33 @@ import {
 } from 'state/modules';
 import { filterSearch, getSearchTerm } from 'state/search';
 
+// Map route paths to their translated tab labels.
+// Used both for rendering tabs and for the mobile dropdown header text.
+const TAB_LABELS = {
+	'/security': _x( 'Security', 'Navigation item.', 'jetpack' ),
+	'/performance': _x( 'Performance', 'Navigation item.', 'jetpack' ),
+	'/writing': _x( 'Writing', 'Navigation item.', 'jetpack' ),
+	'/sharing': _x( 'Sharing', 'Navigation item.', 'jetpack' ),
+	'/discussion': _x( 'Discussion', 'Navigation item.', 'jetpack' ),
+	'/traffic': _x( 'Traffic', 'Navigation item.', 'jetpack' ),
+	'/newsletter': _x( 'Newsletter', 'Navigation item.', 'jetpack' ),
+	'/reader': _x( 'Reader', 'Navigation item.', 'jetpack' ),
+	'/earn': _x( 'Monetize', 'Navigation item.', 'jetpack' ),
+};
+
 const Tab = ( { to, label, onClick, alsoActiveFor } ) => {
-	const location = useLocation();
-	const extraActive = alsoActiveFor ? alsoActiveFor.includes( location.pathname ) : false;
+	const { pathname } = useLocation();
+	const extraActive = alsoActiveFor?.includes( pathname );
 
 	return (
 		<NavLink
 			to={ to }
+			// NavLink's className API requires a function — not a bind issue.
 			// eslint-disable-next-line react/jsx-no-bind
 			className={ ( { isActive } ) =>
-				isActive || extraActive
-					? 'jp-settings-nav__tab jp-settings-nav__tab--active'
-					: 'jp-settings-nav__tab'
+				clsx( 'jp-settings-nav__tab', {
+					'jp-settings-nav__tab--active': isActive || extraActive,
+				} )
 			}
 			onClick={ onClick }
 		>
@@ -56,23 +72,7 @@ const SettingsNavTabs = props => {
 	const location = useLocation();
 	const [ mobileOpen, setMobileOpen ] = useState( false );
 
-	// Map route paths to their translated tab labels for the mobile header.
-	const tabLabels = useMemo(
-		() => ( {
-			'/security': _x( 'Security', 'Navigation item.', 'jetpack' ),
-			'/performance': _x( 'Performance', 'Navigation item.', 'jetpack' ),
-			'/writing': _x( 'Writing', 'Navigation item.', 'jetpack' ),
-			'/sharing': _x( 'Sharing', 'Navigation item.', 'jetpack' ),
-			'/discussion': _x( 'Discussion', 'Navigation item.', 'jetpack' ),
-			'/traffic': _x( 'Traffic', 'Navigation item.', 'jetpack' ),
-			'/newsletter': _x( 'Newsletter', 'Navigation item.', 'jetpack' ),
-			'/reader': _x( 'Reader', 'Navigation item.', 'jetpack' ),
-			'/earn': _x( 'Monetize', 'Navigation item.', 'jetpack' ),
-		} ),
-		[]
-	);
-
-	const selectedTabText = tabLabels[ location.pathname ] || __( 'Settings', 'jetpack' );
+	const selectedTabText = TAB_LABELS[ location.pathname ] || __( 'Settings', 'jetpack' );
 
 	// Close the mobile dropdown when navigating to a new tab.
 	useEffect( () => {
@@ -108,7 +108,7 @@ const SettingsNavTabs = props => {
 				{ hasSecurityFeature && (
 					<Tab
 						to="/security"
-						label={ _x( 'Security', 'Navigation item.', 'jetpack' ) }
+						label={ TAB_LABELS[ '/security' ] }
 						onClick={ () => trackNavClick( 'security' ) }
 						alsoActiveFor={ [ '/settings' ] }
 					/>
@@ -116,7 +116,7 @@ const SettingsNavTabs = props => {
 				{ hasPerformanceFeature && (
 					<Tab
 						to="/performance"
-						label={ _x( 'Performance', 'Navigation item.', 'jetpack' ) }
+						label={ TAB_LABELS[ '/performance' ] }
 						onClick={ () => trackNavClick( 'performance' ) }
 					/>
 				) }
@@ -124,21 +124,21 @@ const SettingsNavTabs = props => {
 					window.CUSTOM_CONTENT_TYPE__INITIAL_STATE?.active ) && (
 					<Tab
 						to="/writing"
-						label={ _x( 'Writing', 'Navigation item.', 'jetpack' ) }
+						label={ TAB_LABELS[ '/writing' ] }
 						onClick={ () => trackNavClick( 'writing' ) }
 					/>
 				) }
 				{ hasModules( [ 'publicize', 'sharedaddy', 'likes' ] ) && (
 					<Tab
 						to="/sharing"
-						label={ _x( 'Sharing', 'Navigation item.', 'jetpack' ) }
+						label={ TAB_LABELS[ '/sharing' ] }
 						onClick={ () => trackNavClick( 'sharing' ) }
 					/>
 				) }
 				{ hasModules( [ 'comments', 'gravatar-hovercards', 'markdown' ] ) && (
 					<Tab
 						to="/discussion"
-						label={ _x( 'Discussion', 'Navigation item.', 'jetpack' ) }
+						label={ TAB_LABELS[ '/discussion' ] }
 						onClick={ () => trackNavClick( 'discussion' ) }
 					/>
 				) }
@@ -152,28 +152,28 @@ const SettingsNavTabs = props => {
 				] ) && (
 					<Tab
 						to="/traffic"
-						label={ _x( 'Traffic', 'Navigation item.', 'jetpack' ) }
+						label={ TAB_LABELS[ '/traffic' ] }
 						onClick={ () => trackNavClick( 'traffic' ) }
 					/>
 				) }
 				{ hasModules( [ 'subscriptions' ] ) && (
 					<Tab
 						to="/newsletter"
-						label={ _x( 'Newsletter', 'Navigation item.', 'jetpack' ) }
+						label={ TAB_LABELS[ '/newsletter' ] }
 						onClick={ () => trackNavClick( 'newsletter' ) }
 					/>
 				) }
 				{ hasModules( [ 'wpcom-reader' ] ) && ! isWoASite && (
 					<Tab
 						to="/reader"
-						label={ _x( 'Reader', 'Navigation item.', 'jetpack' ) }
+						label={ TAB_LABELS[ '/reader' ] }
 						onClick={ () => trackNavClick( 'reader' ) }
 					/>
 				) }
 				{ hasModules( [ 'wordads' ] ) && (
 					<Tab
 						to="/earn"
-						label={ _x( 'Monetize', 'Navigation item.', 'jetpack' ) }
+						label={ TAB_LABELS[ '/earn' ] }
 						onClick={ () => trackNavClick( 'earn' ) }
 					/>
 				) }
@@ -189,14 +189,14 @@ const SettingsNavTabs = props => {
 					hasModules( [ 'post-by-email' ] ) && (
 						<Tab
 							to="/writing"
-							label={ _x( 'Writing', 'Navigation item.', 'jetpack' ) }
+							label={ TAB_LABELS[ '/writing' ] }
 							onClick={ () => trackNavClick( 'writing' ) }
 						/>
 					) }
 				{ isModuleActive( 'publicize' ) && userCanPublishPosts && hasModules( [ 'publicize' ] ) && (
 					<Tab
 						to="/sharing"
-						label={ _x( 'Sharing', 'Navigation item.', 'jetpack' ) }
+						label={ TAB_LABELS[ '/sharing' ] }
 						onClick={ () => trackNavClick( 'sharing' ) }
 						alsoActiveFor={ [ '/settings' ] }
 					/>
@@ -204,6 +204,7 @@ const SettingsNavTabs = props => {
 			</>
 		);
 	}
+	/* eslint-enable react/jsx-no-bind */
 
 	const searchFromUrl = useMemo(
 		() => new URLSearchParams( location.search ).get( 'term' ) || '',
@@ -216,19 +217,21 @@ const SettingsNavTabs = props => {
 		searchForTerm( searchFromUrl );
 	}, [ searchFromUrl, searchForTerm ] );
 
+	/* eslint-disable react/jsx-no-bind -- Trivial toggle callback. */
 	return (
-		<div className={ `jp-settings-nav ${ mobileOpen ? 'is-open' : '' }` }>
+		<div className={ clsx( 'jp-settings-nav', { 'is-open': mobileOpen } ) }>
 			<QuerySitePlugins />
 			<button
-				className={ `jp-settings-nav__mobile-header ${ mobileOpen ? 'is-open' : '' }` }
+				className={ clsx( 'jp-settings-nav__mobile-header', { 'is-open': mobileOpen } ) }
 				onClick={ () => setMobileOpen( ! mobileOpen ) }
 				aria-expanded={ mobileOpen }
 			>
 				<span>{ selectedTabText }</span>
 				<span
-					className={ `dashicons jp-settings-nav__mobile-chevron ${
-						mobileOpen ? 'dashicons-arrow-up-alt2' : 'dashicons-arrow-down-alt2'
-					}` }
+					className={ clsx( 'dashicons', 'jp-settings-nav__mobile-chevron', {
+						'dashicons-arrow-up-alt2': mobileOpen,
+						'dashicons-arrow-down-alt2': ! mobileOpen,
+					} ) }
 				/>
 			</button>
 			<nav

--- a/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/index.jsx
@@ -1,4 +1,6 @@
+import { isWoASite as _isWoASite } from '@automattic/jetpack-script-data';
 import { __, _x } from '@wordpress/i18n';
+import { useCallback, useMemo } from 'react';
 import { connect } from 'react-redux';
 import { NavLink, useLocation } from 'react-router';
 import QuerySitePlugins from 'components/data/query-site-plugins';
@@ -34,6 +36,7 @@ const SettingsNavTabs = props => {
 	const {
 		userCanManageModules,
 		isSubscriber,
+		isWoASite,
 		userCanPublishPosts,
 		hasSecurityFeature,
 		hasPerformanceFeature,
@@ -52,14 +55,17 @@ const SettingsNavTabs = props => {
 		} );
 	};
 
-	const doSearch = keywords => {
-		const splitUrl = window.location.href.split( '#' ),
-			splitHash = splitUrl[ 1 ].split( '?' );
+	const doSearch = useCallback(
+		keywords => {
+			const splitUrl = window.location.href.split( '#' ),
+				splitHash = splitUrl[ 1 ].split( '?' );
 
-		searchForTerm( keywords );
-		const searchURL = '#' + splitHash[ 0 ] + ( keywords ? '?term=' + keywords : '' );
-		window.location.href = searchURL;
-	};
+			searchForTerm( keywords );
+			const searchURL = '#' + splitHash[ 0 ] + ( keywords ? '?term=' + keywords : '' );
+			window.location.href = searchURL;
+		},
+		[ searchForTerm ]
+	);
 
 	let tabs;
 
@@ -124,6 +130,13 @@ const SettingsNavTabs = props => {
 						onClick={ () => trackNavClick( 'newsletter' ) }
 					/>
 				) }
+				{ hasModules( [ 'wpcom-reader' ] ) && ! isWoASite && (
+					<Tab
+						to="/reader"
+						label={ _x( 'Reader', 'Navigation item.', 'jetpack' ) }
+						onClick={ () => trackNavClick( 'reader' ) }
+					/>
+				) }
 				{ hasModules( [ 'wordads' ] ) && (
 					<Tab
 						to="/earn"
@@ -158,16 +171,10 @@ const SettingsNavTabs = props => {
 		);
 	}
 
-	// Handle search term from URL on initial load.
-	const searchFromUrl = ( () => {
-		const search = location.search || '';
-		const pairs = search.substr( 1 ).split( '&' );
-		const term = pairs.filter( item => 0 === item.indexOf( 'term=' ) );
-		if ( term.length > 0 ) {
-			return decodeURIComponent( term[ 0 ].split( '=' )[ 1 ] );
-		}
-		return '';
-	} )();
+	const searchFromUrl = useMemo(
+		() => new URLSearchParams( location.search ).get( 'term' ) || '',
+		[ location.search ]
+	);
 
 	return (
 		<div className="jp-settings-nav">
@@ -194,6 +201,7 @@ export default connect(
 	state => ( {
 		userCanManageModules: _userCanManageModules( state ),
 		isSubscriber: _userIsSubscriber( state ),
+		isWoASite: _isWoASite( state ),
 		userCanPublishPosts: userCanPublish( state ),
 		hasSecurityFeature: hasAnySecurityFeature( state ),
 		hasPerformanceFeature: hasAnyPerformanceFeature( state ),

--- a/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/index.jsx
@@ -1,0 +1,207 @@
+import { __, _x } from '@wordpress/i18n';
+import { connect } from 'react-redux';
+import { NavLink, useLocation } from 'react-router';
+import QuerySitePlugins from 'components/data/query-site-plugins';
+import Search from 'components/search';
+import analytics from 'lib/analytics';
+import {
+	userCanManageModules as _userCanManageModules,
+	userIsSubscriber as _userIsSubscriber,
+	userCanPublish,
+} from 'state/initial-state';
+import {
+	hasAnyOfTheseModules,
+	hasAnyPerformanceFeature,
+	hasAnySecurityFeature,
+	isModuleActivated,
+} from 'state/modules';
+import { filterSearch, getSearchTerm } from 'state/search';
+
+const Tab = ( { to, label, onClick } ) => (
+	<NavLink
+		to={ to }
+		// eslint-disable-next-line react/jsx-no-bind
+		className={ ( { isActive } ) =>
+			isActive ? 'jp-settings-nav__tab jp-settings-nav__tab--active' : 'jp-settings-nav__tab'
+		}
+		onClick={ onClick }
+	>
+		{ label }
+	</NavLink>
+);
+
+const SettingsNavTabs = props => {
+	const {
+		userCanManageModules,
+		isSubscriber,
+		userCanPublishPosts,
+		hasSecurityFeature,
+		hasPerformanceFeature,
+		hasModules,
+		isModuleActive,
+		searchTerm,
+		searchForTerm,
+	} = props;
+
+	const location = useLocation();
+
+	const trackNavClick = target => {
+		analytics.tracks.recordJetpackClick( {
+			target: 'nav_item',
+			path: target,
+		} );
+	};
+
+	const doSearch = keywords => {
+		const splitUrl = window.location.href.split( '#' ),
+			splitHash = splitUrl[ 1 ].split( '?' );
+
+		searchForTerm( keywords );
+		const searchURL = '#' + splitHash[ 0 ] + ( keywords ? '?term=' + keywords : '' );
+		window.location.href = searchURL;
+	};
+
+	let tabs;
+
+	/* eslint-disable react/jsx-no-bind -- Arrow callbacks for analytics tracking. */
+	if ( userCanManageModules ) {
+		tabs = (
+			<>
+				{ hasSecurityFeature && (
+					<Tab
+						to="/security"
+						label={ _x( 'Security', 'Navigation item.', 'jetpack' ) }
+						onClick={ () => trackNavClick( 'security' ) }
+					/>
+				) }
+				{ hasPerformanceFeature && (
+					<Tab
+						to="/performance"
+						label={ _x( 'Performance', 'Navigation item.', 'jetpack' ) }
+						onClick={ () => trackNavClick( 'performance' ) }
+					/>
+				) }
+				{ ( hasModules( [ 'markdown', 'post-by-email', 'infinite-scroll', 'copy-post' ] ) ||
+					window.CUSTOM_CONTENT_TYPE__INITIAL_STATE.active ) && (
+					<Tab
+						to="/writing"
+						label={ _x( 'Writing', 'Navigation item.', 'jetpack' ) }
+						onClick={ () => trackNavClick( 'writing' ) }
+					/>
+				) }
+				{ hasModules( [ 'publicize', 'sharedaddy', 'likes' ] ) && (
+					<Tab
+						to="/sharing"
+						label={ _x( 'Sharing', 'Navigation item.', 'jetpack' ) }
+						onClick={ () => trackNavClick( 'sharing' ) }
+					/>
+				) }
+				{ hasModules( [ 'comments', 'gravatar-hovercards', 'markdown' ] ) && (
+					<Tab
+						to="/discussion"
+						label={ _x( 'Discussion', 'Navigation item.', 'jetpack' ) }
+						onClick={ () => trackNavClick( 'discussion' ) }
+					/>
+				) }
+				{ hasModules( [
+					'seo-tools',
+					'stats',
+					'related-posts',
+					'verification-tools',
+					'sitemaps',
+					'google-analytics',
+				] ) && (
+					<Tab
+						to="/traffic"
+						label={ _x( 'Traffic', 'Navigation item.', 'jetpack' ) }
+						onClick={ () => trackNavClick( 'traffic' ) }
+					/>
+				) }
+				{ hasModules( [ 'subscriptions' ] ) && (
+					<Tab
+						to="/newsletter"
+						label={ _x( 'Newsletter', 'Navigation item.', 'jetpack' ) }
+						onClick={ () => trackNavClick( 'newsletter' ) }
+					/>
+				) }
+				{ hasModules( [ 'wordads' ] ) && (
+					<Tab
+						to="/earn"
+						label={ _x( 'Monetize', 'Navigation item.', 'jetpack' ) }
+						onClick={ () => trackNavClick( 'earn' ) }
+					/>
+				) }
+			</>
+		);
+	} else if ( isSubscriber ) {
+		tabs = null;
+	} else {
+		tabs = (
+			<>
+				{ isModuleActive( 'post-by-email' ) &&
+					userCanPublishPosts &&
+					hasModules( [ 'post-by-email' ] ) && (
+						<Tab
+							to="/writing"
+							label={ _x( 'Writing', 'Navigation item.', 'jetpack' ) }
+							onClick={ () => trackNavClick( 'writing' ) }
+						/>
+					) }
+				{ isModuleActive( 'publicize' ) && userCanPublishPosts && hasModules( [ 'publicize' ] ) && (
+					<Tab
+						to="/sharing"
+						label={ _x( 'Sharing', 'Navigation item.', 'jetpack' ) }
+						onClick={ () => trackNavClick( 'sharing' ) }
+					/>
+				) }
+			</>
+		);
+	}
+
+	// Handle search term from URL on initial load.
+	const searchFromUrl = ( () => {
+		const search = location.search || '';
+		const pairs = search.substr( 1 ).split( '&' );
+		const term = pairs.filter( item => 0 === item.indexOf( 'term=' ) );
+		if ( term.length > 0 ) {
+			return decodeURIComponent( term[ 0 ].split( '=' )[ 1 ] );
+		}
+		return '';
+	} )();
+
+	return (
+		<div className="jp-settings-nav">
+			<QuerySitePlugins />
+			<nav className="jp-settings-nav__tabs">{ tabs }</nav>
+			{ userCanManageModules && (
+				<Search
+					pinned={ true }
+					fitsContainer={ true }
+					placeholder={ __( 'Search for a Jetpack feature.', 'jetpack' ) }
+					delaySearch={ true }
+					delayTimeout={ 500 }
+					onSearch={ doSearch }
+					isOpen={ !! searchTerm }
+					initialValue={ searchTerm || searchFromUrl }
+				/>
+			) }
+		</div>
+	);
+	/* eslint-enable react/jsx-no-bind */
+};
+
+export default connect(
+	state => ( {
+		userCanManageModules: _userCanManageModules( state ),
+		isSubscriber: _userIsSubscriber( state ),
+		userCanPublishPosts: userCanPublish( state ),
+		hasSecurityFeature: hasAnySecurityFeature( state ),
+		hasPerformanceFeature: hasAnyPerformanceFeature( state ),
+		hasModules: modules => hasAnyOfTheseModules( state, modules ),
+		isModuleActive: module => isModuleActivated( state, module ),
+		searchTerm: getSearchTerm( state ),
+	} ),
+	dispatch => ( {
+		searchForTerm: term => dispatch( filterSearch( term ) ),
+	} )
+)( SettingsNavTabs );

--- a/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/index.jsx
@@ -1,6 +1,6 @@
 import { isWoASite as _isWoASite } from '@automattic/jetpack-script-data';
 import { __, _x } from '@wordpress/i18n';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { connect } from 'react-redux';
 import { NavLink, useLocation } from 'react-router';
 import QuerySitePlugins from 'components/data/query-site-plugins';
@@ -54,6 +54,30 @@ const SettingsNavTabs = props => {
 	} = props;
 
 	const location = useLocation();
+	const [ mobileOpen, setMobileOpen ] = useState( false );
+
+	// Map route paths to their translated tab labels for the mobile header.
+	const tabLabels = useMemo(
+		() => ( {
+			'/security': _x( 'Security', 'Navigation item.', 'jetpack' ),
+			'/performance': _x( 'Performance', 'Navigation item.', 'jetpack' ),
+			'/writing': _x( 'Writing', 'Navigation item.', 'jetpack' ),
+			'/sharing': _x( 'Sharing', 'Navigation item.', 'jetpack' ),
+			'/discussion': _x( 'Discussion', 'Navigation item.', 'jetpack' ),
+			'/traffic': _x( 'Traffic', 'Navigation item.', 'jetpack' ),
+			'/newsletter': _x( 'Newsletter', 'Navigation item.', 'jetpack' ),
+			'/reader': _x( 'Reader', 'Navigation item.', 'jetpack' ),
+			'/earn': _x( 'Monetize', 'Navigation item.', 'jetpack' ),
+		} ),
+		[]
+	);
+
+	const selectedTabText = tabLabels[ location.pathname ] || __( 'Settings', 'jetpack' );
+
+	// Close the mobile dropdown when navigating to a new tab.
+	useEffect( () => {
+		setMobileOpen( false );
+	}, [ location.pathname ] );
 
 	const trackNavClick = target => {
 		analytics.tracks.recordJetpackClick( {
@@ -193,8 +217,20 @@ const SettingsNavTabs = props => {
 	}, [ searchFromUrl, searchForTerm ] );
 
 	return (
-		<div className="jp-settings-nav">
+		<div className={ `jp-settings-nav ${ mobileOpen ? 'is-open' : '' }` }>
 			<QuerySitePlugins />
+			<button
+				className={ `jp-settings-nav__mobile-header ${ mobileOpen ? 'is-open' : '' }` }
+				onClick={ () => setMobileOpen( ! mobileOpen ) }
+				aria-expanded={ mobileOpen }
+			>
+				<span>{ selectedTabText }</span>
+				<span
+					className={ `dashicons jp-settings-nav__mobile-chevron ${
+						mobileOpen ? 'dashicons-arrow-up-alt2' : 'dashicons-arrow-down-alt2'
+					}` }
+				/>
+			</button>
 			<nav
 				className="jp-settings-nav__tabs"
 				aria-label={ __( 'Jetpack settings sections', 'jetpack' ) }

--- a/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/index.jsx
@@ -195,7 +195,12 @@ const SettingsNavTabs = props => {
 	return (
 		<div className="jp-settings-nav">
 			<QuerySitePlugins />
-			<nav className="jp-settings-nav__tabs">{ tabs }</nav>
+			<nav
+				className="jp-settings-nav__tabs"
+				aria-label={ __( 'Jetpack settings sections', 'jetpack' ) }
+			>
+				{ tabs }
+			</nav>
 			{ userCanManageModules && (
 				<Search
 					pinned={ true }

--- a/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/index.jsx
@@ -1,6 +1,6 @@
 import { isWoASite as _isWoASite } from '@automattic/jetpack-script-data';
 import { __, _x } from '@wordpress/i18n';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { connect } from 'react-redux';
 import { NavLink, useLocation } from 'react-router';
 import QuerySitePlugins from 'components/data/query-site-plugins';
@@ -19,18 +19,25 @@ import {
 } from 'state/modules';
 import { filterSearch, getSearchTerm } from 'state/search';
 
-const Tab = ( { to, label, onClick } ) => (
-	<NavLink
-		to={ to }
-		// eslint-disable-next-line react/jsx-no-bind
-		className={ ( { isActive } ) =>
-			isActive ? 'jp-settings-nav__tab jp-settings-nav__tab--active' : 'jp-settings-nav__tab'
-		}
-		onClick={ onClick }
-	>
-		{ label }
-	</NavLink>
-);
+const Tab = ( { to, label, onClick, alsoActiveFor } ) => {
+	const location = useLocation();
+	const extraActive = alsoActiveFor ? alsoActiveFor.includes( location.pathname ) : false;
+
+	return (
+		<NavLink
+			to={ to }
+			// eslint-disable-next-line react/jsx-no-bind
+			className={ ( { isActive } ) =>
+				isActive || extraActive
+					? 'jp-settings-nav__tab jp-settings-nav__tab--active'
+					: 'jp-settings-nav__tab'
+			}
+			onClick={ onClick }
+		>
+			{ label }
+		</NavLink>
+	);
+};
 
 const SettingsNavTabs = props => {
 	const {
@@ -78,6 +85,7 @@ const SettingsNavTabs = props => {
 						to="/security"
 						label={ _x( 'Security', 'Navigation item.', 'jetpack' ) }
 						onClick={ () => trackNavClick( 'security' ) }
+						alsoActiveFor={ [ '/settings' ] }
 					/>
 				) }
 				{ hasPerformanceFeature && (
@@ -88,7 +96,7 @@ const SettingsNavTabs = props => {
 					/>
 				) }
 				{ ( hasModules( [ 'markdown', 'post-by-email', 'infinite-scroll', 'copy-post' ] ) ||
-					window.CUSTOM_CONTENT_TYPE__INITIAL_STATE.active ) && (
+					window.CUSTOM_CONTENT_TYPE__INITIAL_STATE?.active ) && (
 					<Tab
 						to="/writing"
 						label={ _x( 'Writing', 'Navigation item.', 'jetpack' ) }
@@ -165,6 +173,7 @@ const SettingsNavTabs = props => {
 						to="/sharing"
 						label={ _x( 'Sharing', 'Navigation item.', 'jetpack' ) }
 						onClick={ () => trackNavClick( 'sharing' ) }
+						alsoActiveFor={ [ '/settings' ] }
 					/>
 				) }
 			</>
@@ -175,6 +184,12 @@ const SettingsNavTabs = props => {
 		() => new URLSearchParams( location.search ).get( 'term' ) || '',
 		[ location.search ]
 	);
+
+	// Sync URL search term to Redux on mount and route changes,
+	// matching the old NavigationSettings.onRouteChange behavior.
+	useEffect( () => {
+		searchForTerm( searchFromUrl );
+	}, [ searchFromUrl, searchForTerm ] );
 
 	return (
 		<div className="jp-settings-nav">

--- a/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/style.scss
@@ -10,6 +10,15 @@ $spacing-base: var(--spacing-base, 8px);
 // Double class for specificity over the CSS module rule.
 .jp-settings-admin-page.jp-settings-admin-page {
 	margin-left: 0;
+
+	// Override AdminPage's --jp-white background with the
+	// admin-ui token equivalent (#fcfcfc) and fill the viewport
+	// so the wp-admin beige body doesn't bleed through.
+	&:global(.background) {
+		background-color: #fcfcfc;
+		// 32px = wpadminbar height, 32px = wp-admin footer estimate
+		min-height: calc(100vh - 32px);
+	}
 }
 
 .jp-settings-nav {
@@ -18,6 +27,12 @@ $spacing-base: var(--spacing-base, 8px);
 	position: relative;
 	border-bottom: 1px solid gb.$gray-100;
 	padding-inline: calc(#{$spacing-base} * 3); // 24px — matches admin-ui header
+
+	// On small screens, stack tabs above the search icon and let tabs scroll.
+	@media (max-width: 660px) {
+		flex-wrap: wrap;
+		padding-inline: calc(#{$spacing-base} * 2); // tighter padding on mobile
+	}
 
 	// The Search component uses position: absolute with fitsContainer, which
 	// positions relative to the padding edge (ignoring padding). Offset it to
@@ -35,6 +50,14 @@ $spacing-base: var(--spacing-base, 8px);
 .jp-settings-nav__tabs {
 	display: flex;
 	flex: 1;
+	overflow-x: auto;
+	-webkit-overflow-scrolling: touch;
+
+	// Hide the scrollbar but keep scroll functionality.
+	scrollbar-width: none; // Firefox
+	&::-webkit-scrollbar {
+		display: none; // Chrome, Safari, Edge
+	}
 }
 
 .jp-settings-nav__tab {
@@ -46,6 +69,11 @@ $spacing-base: var(--spacing-base, 8px);
 	margin-inline-end: calc(#{$spacing-base} * 4);
 	white-space: nowrap;
 
+	@media (max-width: 660px) {
+		font-size: 13px;
+		margin-inline-end: calc(#{$spacing-base} * 2);
+	}
+
 	&:last-child {
 		margin-inline-end: 0;
 	}
@@ -53,11 +81,12 @@ $spacing-base: var(--spacing-base, 8px);
 	&:hover,
 	&:focus {
 		box-shadow: none;
-		color: var(--jp-green);
+		color: var(--jp-black);
+		opacity: 0.7;
 	}
 
 	&:focus-visible {
-		outline: 2px solid var(--jp-green);
+		outline: 2px solid var(--jp-black);
 		outline-offset: -2px;
 	}
 

--- a/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/style.scss
@@ -27,11 +27,19 @@ $spacing-base: var(--spacing-base, 8px);
 	position: relative;
 	border-bottom: 1px solid gb.$gray-100;
 	padding-inline: calc(#{$spacing-base} * 3); // 24px — matches admin-ui header
+	background-color: #fff; // Match search component background; prevents beige bleed-through
 
-	// On small screens, stack tabs above the search icon and let tabs scroll.
 	@media (max-width: 660px) {
 		flex-wrap: wrap;
 		padding-inline: calc(#{$spacing-base} * 2); // tighter padding on mobile
+		border-bottom: none;
+		box-shadow: 0 0 0 1px gb.$gray-100, 0 1px 1px 1px rgba(0, 0, 0, 0.04);
+		margin: calc(#{$spacing-base} * 1.5) calc(#{$spacing-base} * 2);
+		border-radius: 2px;
+
+		&.is-open {
+			box-shadow: 0 0 0 1px gb.$gray-300, 0 2px 4px rgba(0, 0, 0, 0.1);
+		}
 	}
 
 	// The Search component uses position: absolute with fitsContainer, which
@@ -40,9 +48,61 @@ $spacing-base: var(--spacing-base, 8px);
 	.dops-search.is-expanded-to-container {
 		inset-inline-end: calc(#{$spacing-base} * 3);
 
+		@media (max-width: 660px) {
+			inset-inline-end: 0;
+		}
+
 		&.is-open {
 			inset-inline-start: calc(#{$spacing-base} * 3);
 			width: auto;
+
+			@media (max-width: 660px) {
+				// Slide over the entire dropdown box (header + tabs).
+				// Don't set inset-inline-start — keep the element right-anchored
+				// so the width transition creates a smooth leftward slide.
+				// (auto → 0 isn't animatable and would cause an instant snap.)
+				inset-inline-start: auto;
+				inset-block: 0;
+				z-index: 1;
+				background-color: #fff;
+				// Concrete value enables CSS width transition.
+				// (auto is not interpolatable, so it snaps instead of animating.)
+				width: 100%;
+				border-radius: 2px;
+			}
+		}
+	}
+}
+
+// Mobile dropdown header — hidden on desktop, visible at <=660px.
+.jp-settings-nav__mobile-header {
+	display: none;
+
+	@media (max-width: 660px) {
+		display: flex;
+		align-items: center;
+		width: 100%;
+		gap: calc(#{$spacing-base} / 2);
+		padding: calc(#{$spacing-base} * 1.5) 0;
+		background: none;
+		border: none;
+		cursor: pointer;
+		font-size: var(--font-body);
+		font-weight: 400;
+		color: var(--jp-black);
+		font-family: inherit;
+
+		&:focus,
+		&:focus-visible {
+			outline-color: gb.$gray-100;
+		}
+
+		.jp-settings-nav__mobile-chevron {
+			font-size: 16px;
+			width: 16px;
+			height: 16px;
+			flex-shrink: 0;
+			color: gb.$gray-700;
 		}
 	}
 }
@@ -58,6 +118,20 @@ $spacing-base: var(--spacing-base, 8px);
 	&::-webkit-scrollbar {
 		display: none; // Chrome, Safari, Edge
 	}
+
+	// On mobile, tabs are hidden by default and shown as a vertical dropdown.
+	@media (max-width: 660px) {
+		display: none;
+		flex-direction: column;
+		width: 100%;
+		overflow-x: visible;
+
+		.is-open > & {
+			display: flex;
+			border-top: 1px solid gb.$gray-100;
+			padding-top: calc(#{$spacing-base} / 2);
+		}
+	}
 }
 
 .jp-settings-nav__tab {
@@ -70,8 +144,9 @@ $spacing-base: var(--spacing-base, 8px);
 	white-space: nowrap;
 
 	@media (max-width: 660px) {
-		font-size: 13px;
-		margin-inline-end: calc(#{$spacing-base} * 2);
+		margin-inline-end: 0;
+		padding: calc(#{$spacing-base} * 1.5) calc(#{$spacing-base} * 2);
+		border-inline-start: 3px solid transparent;
 	}
 
 	&:last-child {
@@ -85,12 +160,18 @@ $spacing-base: var(--spacing-base, 8px);
 		opacity: 0.7;
 	}
 
+	&:focus,
 	&:focus-visible {
-		outline: 2px solid var(--jp-black);
-		outline-offset: -2px;
+		outline-color: gb.$gray-100;
 	}
 
 	&--active {
 		border-bottom: var(--jp-underline-thickness) solid var(--jp-black);
+
+		@media (max-width: 660px) {
+			border-bottom: none;
+			border-inline-start-color: var(--jp-black);
+			font-weight: 600;
+		}
 	}
 }

--- a/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/style.scss
@@ -1,5 +1,9 @@
 @use "@automattic/jetpack-base-styles/gutenberg-base-styles" as gb;
 
+// --spacing-base is provided by admin-ui's ThemeProvider in some contexts,
+// but not guaranteed here. Define a local fallback.
+$spacing-base: var(--spacing-base, 8px);
+
 // AdminPage uses margin-left: -20px to neutralize #wpcontent's default 20px
 // padding. But Jetpack's own CSS zeros out that padding (admin-static.scss,
 // _main.scss), so the -20px just shifts everything into the sidebar. Reset it.
@@ -13,16 +17,16 @@
 	align-items: center;
 	position: relative;
 	border-bottom: 1px solid gb.$gray-100;
-	padding-inline: calc(var(--spacing-base) * 3); // 24px — matches admin-ui header
+	padding-inline: calc(#{$spacing-base} * 3); // 24px — matches admin-ui header
 
 	// The Search component uses position: absolute with fitsContainer, which
 	// positions relative to the padding edge (ignoring padding). Offset it to
 	// stay within the padded content area.
 	.dops-search.is-expanded-to-container {
-		right: calc(var(--spacing-base) * 3);
+		right: calc(#{$spacing-base} * 3);
 
 		&.is-open {
-			left: calc(var(--spacing-base) * 3);
+			left: calc(#{$spacing-base} * 3);
 			width: auto;
 		}
 	}
@@ -38,8 +42,8 @@
 	font-size: var(--font-body);
 	line-height: 1.5;
 	text-decoration: none;
-	padding: var(--spacing-base) 0;
-	margin-inline-end: calc(var(--spacing-base) * 4);
+	padding: #{$spacing-base} 0;
+	margin-inline-end: calc(#{$spacing-base} * 4);
 	white-space: nowrap;
 
 	&:last-child {

--- a/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/style.scss
@@ -9,8 +9,21 @@
 .jp-settings-nav {
 	display: flex;
 	align-items: center;
+	position: relative;
 	border-bottom: 1px solid #f0f0f0;
 	padding-inline: 24px;
+
+	// The Search component uses position: absolute with fitsContainer, which
+	// positions relative to the padding edge (ignoring padding). Offset it to
+	// stay within the padded content area.
+	.dops-search.is-expanded-to-container {
+		right: 24px;
+
+		&.is-open {
+			left: 24px;
+			width: auto;
+		}
+	}
 }
 
 .jp-settings-nav__tabs {

--- a/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/style.scss
@@ -24,11 +24,11 @@
 	line-height: 1.5;
 	text-decoration: none;
 	padding: 8px 0;
-	margin-right: 32px;
+	margin-inline-end: 32px;
 	white-space: nowrap;
 
 	&:last-child {
-		margin-right: 0;
+		margin-inline-end: 0;
 	}
 
 	&:hover,

--- a/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/style.scss
@@ -4,28 +4,21 @@
 // but not guaranteed here. Define a local fallback.
 $spacing-base: var(--spacing-base, 8px);
 
-// AdminPage uses margin-left: -20px to neutralize #wpcontent's
-// default 20px padding. Jetpack zeros that padding
-// (admin-static.scss, _main.scss), so the negative margin just
-// shifts into the sidebar. Reset it.
+// AdminPage uses margin-left: -20px to neutralize #wpcontent's default 20px
+// padding. But Jetpack's own CSS zeros out that padding (admin-static.scss,
+// _main.scss), so the -20px just shifts everything into the sidebar. Reset it.
 // Double class for specificity over the CSS module rule.
 .jp-settings-admin-page.jp-settings-admin-page {
 	margin-left: 0;
-	// Prevent the footer Container (non-fluid, max-width 1088px
-	// + padding) from causing horizontal scroll on narrow
-	// viewports.
-	overflow-x: hidden;
-	// Use #FCFCFC (admin-ui token equivalent) instead of
-	// AdminPage's --jp-white, and fill the viewport so the
-	// wp-admin beige body doesn't bleed through.
-	background-color: #fcfcfc;
-	min-height: calc(100vh - 32px);
-}
 
-// Override the beige #wpbody-content background so it doesn't
-// bleed through around the Settings page edges.
-#wpbody-content:has(.jp-settings-admin-page) {
-	background-color: #fcfcfc;
+	// Override AdminPage's --jp-white background with the
+	// admin-ui token equivalent (#fcfcfc) and fill the viewport
+	// so the wp-admin beige body doesn't bleed through.
+	&:global(.background) {
+		background-color: #fcfcfc;
+		// 32px = wpadminbar height, 32px = wp-admin footer estimate
+		min-height: calc(100vh - 32px);
+	}
 }
 
 .jp-settings-nav {

--- a/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/style.scss
@@ -56,6 +56,11 @@ $spacing-base: var(--spacing-base, 8px);
 		color: var(--jp-green);
 	}
 
+	&:focus-visible {
+		outline: 2px solid var(--jp-green);
+		outline-offset: -2px;
+	}
+
 	&--active {
 		border-bottom: var(--jp-underline-thickness) solid var(--jp-black);
 	}

--- a/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/style.scss
@@ -1,3 +1,10 @@
+// Colors sourced from @wordpress/admin-ui and Gutenberg's $gray-900/$gray-100.
+// Jetpack's own token scale (--jp-gray-*) uses an inverted numbering, so these
+// don't map cleanly. Defined here for single-source-of-truth within this file.
+$admin-ui-border-color: #f0f0f0; // Matches admin-ui Page header border
+$admin-ui-text-color: #1e1e1e; // Gutenberg $gray-900, standard WP body text
+$nav-inline-padding: 24px; // Matches admin-ui Page header padding
+
 // AdminPage uses margin-left: -20px to neutralize #wpcontent's default 20px
 // padding. But Jetpack's own CSS zeros out that padding (admin-static.scss,
 // _main.scss), so the -20px just shifts everything into the sidebar. Reset it.
@@ -10,17 +17,17 @@
 	display: flex;
 	align-items: center;
 	position: relative;
-	border-bottom: 1px solid #f0f0f0;
-	padding-inline: 24px;
+	border-bottom: 1px solid $admin-ui-border-color;
+	padding-inline: $nav-inline-padding;
 
 	// The Search component uses position: absolute with fitsContainer, which
 	// positions relative to the padding edge (ignoring padding). Offset it to
 	// stay within the padded content area.
 	.dops-search.is-expanded-to-container {
-		right: 24px;
+		right: $nav-inline-padding;
 
 		&.is-open {
-			left: 24px;
+			left: $nav-inline-padding;
 			width: auto;
 		}
 	}
@@ -32,12 +39,12 @@
 }
 
 .jp-settings-nav__tab {
-	color: #1e1e1e;
-	font-size: 16px;
+	color: $admin-ui-text-color;
+	font-size: var(--font-body);
 	line-height: 1.5;
 	text-decoration: none;
-	padding: 8px 0;
-	margin-inline-end: 32px;
+	padding: var(--jp-button-padding) 0;
+	margin-inline-end: var(--jp-modal-padding-large);
 	white-space: nowrap;
 
 	&:last-child {
@@ -47,10 +54,10 @@
 	&:hover,
 	&:focus {
 		box-shadow: none;
-		color: #069e08;
+		color: var(--jp-green);
 	}
 
 	&--active {
-		border-bottom: 2px solid #1e1e1e;
+		border-bottom: var(--jp-underline-thickness) solid $admin-ui-text-color;
 	}
 }

--- a/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/style.scss
@@ -1,0 +1,43 @@
+// AdminPage uses margin-left: -20px to neutralize #wpcontent's default 20px
+// padding. But Jetpack's own CSS zeros out that padding (admin-static.scss,
+// _main.scss), so the -20px just shifts everything into the sidebar. Reset it.
+// Double class for specificity over the CSS module rule.
+.jp-settings-admin-page.jp-settings-admin-page {
+	margin-left: 0;
+}
+
+.jp-settings-nav {
+	display: flex;
+	align-items: center;
+	border-bottom: 1px solid #f0f0f0;
+	padding-inline: 24px;
+}
+
+.jp-settings-nav__tabs {
+	display: flex;
+	flex: 1;
+}
+
+.jp-settings-nav__tab {
+	color: #1e1e1e;
+	font-size: 16px;
+	line-height: 1.5;
+	text-decoration: none;
+	padding: 8px 0;
+	margin-right: 32px;
+	white-space: nowrap;
+
+	&:last-child {
+		margin-right: 0;
+	}
+
+	&:hover,
+	&:focus {
+		box-shadow: none;
+		color: #069e08;
+	}
+
+	&--active {
+		border-bottom: 2px solid #1e1e1e;
+	}
+}

--- a/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/style.scss
@@ -1,9 +1,4 @@
-// Colors sourced from @wordpress/admin-ui and Gutenberg's $gray-900/$gray-100.
-// Jetpack's own token scale (--jp-gray-*) uses an inverted numbering, so these
-// don't map cleanly. Defined here for single-source-of-truth within this file.
-$admin-ui-border-color: #f0f0f0; // Matches admin-ui Page header border
-$admin-ui-text-color: #1e1e1e; // Gutenberg $gray-900, standard WP body text
-$nav-inline-padding: 24px; // Matches admin-ui Page header padding
+@use "@automattic/jetpack-base-styles/gutenberg-base-styles" as gb;
 
 // AdminPage uses margin-left: -20px to neutralize #wpcontent's default 20px
 // padding. But Jetpack's own CSS zeros out that padding (admin-static.scss,
@@ -17,17 +12,17 @@ $nav-inline-padding: 24px; // Matches admin-ui Page header padding
 	display: flex;
 	align-items: center;
 	position: relative;
-	border-bottom: 1px solid $admin-ui-border-color;
-	padding-inline: $nav-inline-padding;
+	border-bottom: 1px solid gb.$gray-100;
+	padding-inline: calc(var(--spacing-base) * 3); // 24px — matches admin-ui header
 
 	// The Search component uses position: absolute with fitsContainer, which
 	// positions relative to the padding edge (ignoring padding). Offset it to
 	// stay within the padded content area.
 	.dops-search.is-expanded-to-container {
-		right: $nav-inline-padding;
+		right: calc(var(--spacing-base) * 3);
 
 		&.is-open {
-			left: $nav-inline-padding;
+			left: calc(var(--spacing-base) * 3);
 			width: auto;
 		}
 	}
@@ -39,12 +34,12 @@ $nav-inline-padding: 24px; // Matches admin-ui Page header padding
 }
 
 .jp-settings-nav__tab {
-	color: $admin-ui-text-color;
+	color: var(--jp-black);
 	font-size: var(--font-body);
 	line-height: 1.5;
 	text-decoration: none;
-	padding: var(--jp-button-padding) 0;
-	margin-inline-end: var(--jp-modal-padding-large);
+	padding: var(--spacing-base) 0;
+	margin-inline-end: calc(var(--spacing-base) * 4);
 	white-space: nowrap;
 
 	&:last-child {
@@ -58,6 +53,6 @@ $nav-inline-padding: 24px; // Matches admin-ui Page header padding
 	}
 
 	&--active {
-		border-bottom: var(--jp-underline-thickness) solid $admin-ui-text-color;
+		border-bottom: var(--jp-underline-thickness) solid var(--jp-black);
 	}
 }

--- a/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/style.scss
@@ -23,10 +23,10 @@ $spacing-base: var(--spacing-base, 8px);
 	// positions relative to the padding edge (ignoring padding). Offset it to
 	// stay within the padded content area.
 	.dops-search.is-expanded-to-container {
-		right: calc(#{$spacing-base} * 3);
+		inset-inline-end: calc(#{$spacing-base} * 3);
 
 		&.is-open {
-			left: calc(#{$spacing-base} * 3);
+			inset-inline-start: calc(#{$spacing-base} * 3);
 			width: auto;
 		}
 	}

--- a/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/style.scss
@@ -4,21 +4,28 @@
 // but not guaranteed here. Define a local fallback.
 $spacing-base: var(--spacing-base, 8px);
 
-// AdminPage uses margin-left: -20px to neutralize #wpcontent's default 20px
-// padding. But Jetpack's own CSS zeros out that padding (admin-static.scss,
-// _main.scss), so the -20px just shifts everything into the sidebar. Reset it.
+// AdminPage uses margin-left: -20px to neutralize #wpcontent's
+// default 20px padding. Jetpack zeros that padding
+// (admin-static.scss, _main.scss), so the negative margin just
+// shifts into the sidebar. Reset it.
 // Double class for specificity over the CSS module rule.
 .jp-settings-admin-page.jp-settings-admin-page {
 	margin-left: 0;
+	// Prevent the footer Container (non-fluid, max-width 1088px
+	// + padding) from causing horizontal scroll on narrow
+	// viewports.
+	overflow-x: hidden;
+	// Use #FCFCFC (admin-ui token equivalent) instead of
+	// AdminPage's --jp-white, and fill the viewport so the
+	// wp-admin beige body doesn't bleed through.
+	background-color: #fcfcfc;
+	min-height: calc(100vh - 32px);
+}
 
-	// Override AdminPage's --jp-white background with the
-	// admin-ui token equivalent (#fcfcfc) and fill the viewport
-	// so the wp-admin beige body doesn't bleed through.
-	&:global(.background) {
-		background-color: #fcfcfc;
-		// 32px = wpadminbar height, 32px = wp-admin footer estimate
-		min-height: calc(100vh - 32px);
-	}
+// Override the beige #wpbody-content background so it doesn't
+// bleed through around the Settings page edges.
+#wpbody-content:has(.jp-settings-admin-page) {
+	background-color: #fcfcfc;
 }
 
 .jp-settings-nav {

--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -23,6 +23,7 @@ import Navigation from 'components/navigation';
 import NavigationSettings from 'components/navigation-settings';
 import NonAdminView from 'components/non-admin-view';
 import ReconnectModal from 'components/reconnect-modal';
+import SettingsAdminPage from 'components/settings-admin-page';
 import SupportCard from 'components/support-card';
 import Tracker from 'components/tracker';
 import { imagePath } from 'constants/urls';
@@ -835,6 +836,10 @@ class Main extends Component {
 		this.props.fetchSettings();
 	}
 
+	isSettingsRoute() {
+		return settingsRoutes.includes( this.props.location.pathname );
+	}
+
 	render() {
 		const jpClasses = [ 'jp-lower' ];
 
@@ -850,7 +855,30 @@ class Main extends Component {
 			jpClasses.push( 'jp-licensing-screen' );
 		}
 
-		const mainNav = this.renderMainNav( this.props.location.pathname );
+		const pathname = this.props.location.pathname;
+		const mainNav = this.renderMainNav( pathname );
+
+		// Settings routes use the shared AdminPage component for header and footer.
+		if ( this.isSettingsRoute() ) {
+			return (
+				<div>
+					{ this.shouldShowReconnectModal() && (
+						<ReconnectModal show={ true } onHide={ this.closeReconnectModal } />
+					) }
+					<SettingsAdminPage location={ this.props.location }>
+						<div className="jp-top-inside">{ mainNav }</div>
+						<div className={ jpClasses.join( ' ' ) }>
+							<AdminNotices />
+							<JetpackNotices />
+							{ this.shouldConnectUser() && this.connectUser() }
+							{ this.renderMainContent( pathname ) }
+						</div>
+					</SettingsAdminPage>
+					<Tracker analytics={ analytics } />
+				</div>
+			);
+		}
+
 		const showHeader = mainNav || this.shouldShowMasthead() || this.shouldShowRewindStatus();
 
 		return (
@@ -874,14 +902,14 @@ class Main extends Component {
 					<JetpackNotices />
 					{ this.shouldConnectUser() && this.connectUser() }
 
-					{ this.renderMainContent( this.props.location.pathname ) }
+					{ this.renderMainContent( pathname ) }
 					{ this.shouldShowJetpackManageBanner() && (
 						<JetpackManageBanner
-							path={ this.props.location.pathname }
+							path={ pathname }
 							isAgencyAccount={ this.props.jetpackManage.isAgencyAccount }
 						/>
 					) }
-					{ this.shouldShowSupportCard() && <SupportCard path={ this.props.location.pathname } /> }
+					{ this.shouldShowSupportCard() && <SupportCard path={ pathname } /> }
 					{ this.shouldShowAppsCard() && <AppsCard /> }
 				</div>
 				{ this.shouldShowFooter() && <Footer siteAdminUrl={ this.props.siteAdminUrl } /> }

--- a/projects/plugins/jetpack/_inc/client/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/main.jsx
@@ -24,6 +24,7 @@ import NavigationSettings from 'components/navigation-settings';
 import NonAdminView from 'components/non-admin-view';
 import ReconnectModal from 'components/reconnect-modal';
 import SettingsAdminPage from 'components/settings-admin-page';
+import SettingsNavTabs from 'components/settings-nav-tabs';
 import SupportCard from 'components/support-card';
 import Tracker from 'components/tracker';
 import { imagePath } from 'constants/urls';
@@ -865,8 +866,7 @@ class Main extends Component {
 					{ this.shouldShowReconnectModal() && (
 						<ReconnectModal show={ true } onHide={ this.closeReconnectModal } />
 					) }
-					<SettingsAdminPage location={ this.props.location }>
-						<div className="jp-top-inside">{ mainNav }</div>
+					<SettingsAdminPage location={ this.props.location } tabs={ <SettingsNavTabs /> }>
 						<div className={ jpClasses.join( ' ' ) }>
 							<AdminNotices />
 							<JetpackNotices />

--- a/projects/plugins/jetpack/_inc/client/scss/style.scss
+++ b/projects/plugins/jetpack/_inc/client/scss/style.scss
@@ -41,6 +41,7 @@
 @include meta.load-css( "../components/admin-notices/style" );
 @include meta.load-css( "../components/module-toggle/style" );
 @include meta.load-css( "../components/navigation-settings/style" );
+@include meta.load-css( "../components/settings-nav-tabs/style" );
 @include meta.load-css( "../components/settings-card/style" );
 @include meta.load-css( "../components/settings-group/style" );
 @include meta.load-css( "../components/apps-card/style" );

--- a/projects/plugins/jetpack/changelog/update-settings-use-adminpage
+++ b/projects/plugins/jetpack/changelog/update-settings-use-adminpage
@@ -1,4 +1,4 @@
 Significance: patch
-Type: changed
+Type: enhancement
 
 Migrated the Settings page header and navigation to use the shared AdminPage component, replacing the legacy Masthead and Calypso SectionNav with a standardized layout matching other Jetpack admin pages.

--- a/projects/plugins/jetpack/changelog/update-settings-use-adminpage
+++ b/projects/plugins/jetpack/changelog/update-settings-use-adminpage
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Migrated the Settings page header and navigation to use the shared AdminPage component, replacing the legacy Masthead and Calypso SectionNav with a standardized layout matching other Jetpack admin pages.


### PR DESCRIPTION
Part of JETPACK-1411

## Proposed changes:

* Migrates the Jetpack Settings page header and footer to use the shared `AdminPage` component from `@automattic/jetpack-components`, replacing the legacy `Masthead` and `Footer` with the standardized pattern used by Protect and other Jetpack admin pages.
* Introduces a `SettingsNavTabs` component using react-router `NavLink` to replace the Calypso `SectionNav`/`NavTabs`/`NavItem` navigation. Passed via AdminPage's `tabs` prop so it renders between the header and content.
* Fixes a margin mismatch: Jetpack's own CSS zeroes out `#wpcontent` padding-left, but AdminPage applies `margin-left: -20px` assuming the default 20px padding still exists. The fix overrides the margin back to 0 for the Settings page wrapper.
* Uses `useCallback` for the search handler to preserve debounce behavior, `useMemo` for URL search param parsing, and `margin-inline-end` for RTL support.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

No changes to tracking or data usage.

## Screenshots
<img width="2293" height="1398" alt="Screenshot 2026-03-12 at 10 55 19" src="https://github.com/user-attachments/assets/2297ada6-280d-4ef8-ba56-cc8aef1715f4" />
<img width="2301" height="1402" alt="Screenshot 2026-03-12 at 10 55 27" src="https://github.com/user-attachments/assets/d615541e-6529-4039-9abe-ec05589c8ca3" />
<img width="2293" height="1396" alt="Screenshot 2026-03-12 at 10 55 40" src="https://github.com/user-attachments/assets/f1b40b3f-6776-4ed5-856e-29636272cfcb" />
<img width="2296" height="1397" alt="Screenshot 2026-03-12 at 10 55 55" src="https://github.com/user-attachments/assets/0ae4e051-f31c-480d-95be-87af072486d4" />
<img width="486" height="1042" alt="Screenshot 2026-03-16 at 13 28 22" src="https://github.com/user-attachments/assets/48580739-f335-4736-9af8-4976f97dba02" />
<img width="484" height="1040" alt="Screenshot 2026-03-16 at 13 28 38" src="https://github.com/user-attachments/assets/7c1311a7-8017-4b53-b740-49a31bb4b4f5" />
<img width="464" height="1038" alt="Screenshot 2026-03-16 at 13 29 17" src="https://github.com/user-attachments/assets/b67f195a-3779-49f5-8aae-db8df252eca5" />



## Testing instructions:

* Go to **Jetpack > Settings** in wp-admin
* Verify the header shows the Jetpack bolt icon + "Settings" title with proper left alignment (should match the Dashboard header positioning)
* Verify all nav tabs (Security, Performance, Writing, Sharing, Discussion, Traffic, Newsletter, Reader, Monetize) render and route correctly
* Verify the active tab shows an underline indicator
* Verify the search bar still works — type a term, wait for debounce (500ms), confirm settings filter
* Verify the footer shows version, modules, and debug links
* Navigate to **Jetpack > Dashboard** and confirm it still uses the old Masthead layout (no regression)

## Changelog

- [x] Generate changelog entries for this PR (using AI).