### PR TITLE
Forms: fix submit button layout in flex containers

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-submit-button-layout
+++ b/projects/packages/forms/changelog/fix-forms-submit-button-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix submit button layout in flex containers by adding flex-basis and inline-flex display properties.

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1559,6 +1559,7 @@ on production builds, the attributes are being reordered, causing side-effects
 	align-items: center;
 	gap: 0.5em;
 	width: 100%;
+	flex-basis: 100%;
 }
 
 .contact-form .contact-form__spinner {

--- a/projects/packages/forms/src/contact-form/css/jetpack-forms-layout.scss
+++ b/projects/packages/forms/src/contact-form/css/jetpack-forms-layout.scss
@@ -15,6 +15,7 @@
 			// align-self: flex-end;
 			// this is so button has the same style on editor and frontend.
 			flex: 0 0 auto;
+			display: inline-flex;
 
 			.wp-block-button__link {
 				word-break: normal;


### PR DESCRIPTION
## Proposed changes:
* Add `flex-basis: 100%` to the submit button (`:is([type="submit"])`) in `grunion.scss` so it properly fills its container width in flex layouts.
* Add `display: inline-flex` to `.wp-block-button` / `.wp-block-jetpack-button` in horizontal form layouts (`jetpack-forms-layout.scss`) for consistent alignment between editor and frontend.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?
No changes to tracking or data usage.

## Testing instructions:

* Create a new post and add a Jetpack Form block.
* Switch the form layout to **horizontal** (row layout).
* Verify the submit button properly fills its container and aligns correctly with other form fields.
* Compare the editor preview with the frontend — both should render the button layout consistently.
* Test with different button width settings (25%, 50%, 75%, 100%) to ensure they still work as expected.

## Changelog
- [x] Generate changelog entries for this PR (using AI).
