### PR TITLE
Claude: improve jetpack-pr command reliability

### DIFF
--- a/.claude/commands/jetpack-pr.md
+++ b/.claude/commands/jetpack-pr.md
@@ -12,21 +12,22 @@ Instructions:
    - If changes are only to .claude/, docs, or non-project files, skip changelog check
 3. Ensure the branch is pushed to remote (push if needed)
 4. CRITICAL: Read the file `.github/PULL_REQUEST_TEMPLATE.md` using the Read tool. You MUST read this file every time — do not rely on memory for the template structure.
-5. Prepare the PR body following the EXACT section structure from the template you just read:
-   - Title: Clear summary of changes
-   - Fixes #: Link to issue if applicable (or remove if none)
+5. Prepare the PR title and body following the EXACT section structure from the template you just read:
+   - Title (for `--title`, NOT included in the body file): Clear summary of changes
+   - Fixes #: Link to issue if applicable, or leave blank / "N/A" if none
    - Proposed changes: Bullet points of functional changes
    - Testing instructions: Step-by-step how to test the changes
-   - Include ALL sections from the template, filling in what's relevant and leaving defaults for the rest
+   - Include all sections from the template, filling in what's relevant and leaving defaults for the rest
 6. Create the PR using `gh pr create`:
    - IMPORTANT: To avoid bash escaping issues, ALWAYS use `--body-file` instead of `--body`
-   - First, use Bash with a heredoc to write the PR body to `/tmp/pr-body.md`:
+   - Write the PR body to a temporary file using a heredoc, then pass it to `gh`. Use a safe, non-hardcoded path (e.g., `mktemp` or a project-local temp file) — avoid fixed paths in shared directories like `/tmp`.
      ```bash
-     cat > /tmp/pr-body.md << 'EOF'
+     BODY_FILE="$(mktemp)"
+     cat > "$BODY_FILE" << 'EOF'
      [PR body content here]
      EOF
+     gh pr create --title "..." --body-file "$BODY_FILE" --label "..." --assignee @me
      ```
-   - Then run: `gh pr create --title "..." --body-file /tmp/pr-body.md --label "..." --assignee @me`
 7. Add required labels:
    - `[Status] *` - use `[Status] In Progress` by default, or `[Status] Needs Review` if ready for review
 

--- a/.claude/commands/jetpack-pr.md
+++ b/.claude/commands/jetpack-pr.md
@@ -11,13 +11,23 @@ Instructions:
    - If no changelog exists, run `/jetpack-changelog` first to create one
    - If changes are only to .claude/, docs, or non-project files, skip changelog check
 3. Ensure the branch is pushed to remote (push if needed)
-4. Prepare the PR content using the sections from .github/PULL_REQUEST_TEMPLATE.md:
+4. CRITICAL: Read the file `.github/PULL_REQUEST_TEMPLATE.md` using the Read tool. You MUST read this file every time — do not rely on memory for the template structure.
+5. Prepare the PR body following the EXACT section structure from the template you just read:
    - Title: Clear summary of changes
    - Fixes #: Link to issue if applicable (or remove if none)
    - Proposed changes: Bullet points of functional changes
    - Testing instructions: Step-by-step how to test the changes
-5. Create the PR using `gh pr create`, providing the prepared content for the title and body (e.g., with `--title` and `--body` flags)
-6. Add required labels:
+   - Include ALL sections from the template, filling in what's relevant and leaving defaults for the rest
+6. Create the PR using `gh pr create`:
+   - IMPORTANT: To avoid bash escaping issues, ALWAYS use `--body-file` instead of `--body`
+   - First, use Bash with a heredoc to write the PR body to `/tmp/pr-body.md`:
+     ```bash
+     cat > /tmp/pr-body.md << 'EOF'
+     [PR body content here]
+     EOF
+     ```
+   - Then run: `gh pr create --title "..." --body-file /tmp/pr-body.md --label "..." --assignee @me`
+7. Add required labels:
    - `[Status] *` - use `[Status] In Progress` by default, or `[Status] Needs Review` if ready for review
 
-When using `--title` and `--body` with `gh pr create`, the template is not auto-filled; you must format the PR body to match the template structure yourself. Alternatively, omit `--body` to open an editor with the template pre-filled. Deduce all information from git history and code changes - do not ask the user for input.
+Deduce all information from git history and code changes - do not ask the user for input.


### PR DESCRIPTION
## Proposed changes:

* Require reading `.github/PULL_REQUEST_TEMPLATE.md` via the Read tool every time a PR is created — no more relying on memory for the template structure
* Switch from `--body` to `--body-file` to avoid bash escaping issues with backticks, quotes, and special characters
* Ensure all template sections are included in the PR body

### Other information:

- [x] Have you written new tests for your changes, if applicable? N/A — Claude command file only
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them? N/A
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)? N/A

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* Run `/jetpack-pr` from Claude Code on any branch with changes
* Verify that Claude reads `.github/PULL_REQUEST_TEMPLATE.md` before composing the PR body
* Verify that `--body-file` is used instead of `--body`
* Verify the resulting PR body matches the template structure

## Changelog

N/A — `.claude/` files only, no changelog needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
