### PR TITLE
renovate: Improve PR creation reliability

### DIFF
--- a/.github/files/renovate-post-upgrade.sh
+++ b/.github/files/renovate-post-upgrade.sh
@@ -8,6 +8,7 @@ export CI=1
 BASE="$PWD"
 BRANCH="$1"
 CHANGEFILE="$(sed 's/[<>:"/\\|?*]/-/g' <<<"$BRANCH")"
+EXIT=0
 
 . "$BASE/tools/includes/changelogger.sh"
 . "$BASE/tools/includes/alpha-tag.sh"
@@ -47,10 +48,9 @@ cd "$BASE"
 TMP=$(< pnpm-workspace.yaml )
 pnpm config set --location project strict-peer-dependencies false
 pnpm config set --location project strict-dep-builds false
-EXIT=0
+pnpm config set --location project allow-unused-patches true
 pnpm install || EXIT=$?
 echo "$TMP" > pnpm-workspace.yaml
-[[ $EXIT == 0 ]] || exit $EXIT
 
 # Install changelogger too.
 cd "$BASE/projects/packages/changelogger"
@@ -73,9 +73,11 @@ done
 
 if ! $ANY; then
 	echo "No projects are touched in this renovate PR, so nothing to do."
-	exit 0
+	exit $EXIT
 fi
 
 # Update deps and lock files.
 echo "Updating dependencies on changed projects"
 tools/check-intra-monorepo-deps.sh -ua -n "${CHANGEFILE}"
+
+exit $EXIT


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
Set pnpm's `allowUnusedPatches` to avoid erroring out for cases like https://github.com/Automattic/jetpack/pull/47472#issuecomment-4007148761. Too bad pnpm 11 is removing `ignorePatchFailures`, that'd be useful for the PR creation too.

Also, try creating the change entries even if `pnpm install` fails, as the change entry creation doesn't depend on pnpm. The later `tools/check-intra-monorepo-deps.sh` run will fail, but getting change entries created is still an improvement.

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
None really

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* 🤷