### PR TITLE
CRM: Escape DOM-sourced values

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-dom_text_reinterpretation_complaints
+++ b/projects/plugins/crm/changelog/fix-crm-dom_text_reinterpretation_complaints
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+CRM: Escape DOM-sourced values.

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.global.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.global.js
@@ -2628,27 +2628,6 @@ function jpcrm_bind_licensing_modals() {
 			}
 		);
 	} );
-
-	// licensing modal "you have updates" -> set transient for 1h and load updates page
-	jQuery( '.jpcrm-licensing-modal-set-transient-and-go' ).on( 'click', function () {
-		const target_url = jQuery( this ).attr( 'data-href' );
-
-		// set transient & close
-		jpcrm_set_jpcrm_transient(
-			window.jpcrm_modal_message_licensing_nonce,
-			'jpcrm-license-modal',
-			'nag',
-			3600,
-			function () {
-				// successfully set
-				window.location = target_url;
-			},
-			function () {
-				// failed to set (hide anyway)
-				window.location = target_url;
-			}
-		);
-	} );
 }
 /* ==========================================================================================
     / Licensing related functions

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.listview.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.listview.js
@@ -5372,7 +5372,7 @@ function zeroBSCRMJS_listView_bindInlineEditSave() {
 							// replace html  + do classes
 							jQuery( lThis )
 								.closest( '.zbs-inline-editing' )
-								.html( lLabel )
+								.text( lLabel )
 								.removeClass( 'zbs-inline-editing' )
 								.addClass( 'zbs-inline-edit' );
 
@@ -5402,7 +5402,7 @@ function zeroBSCRMJS_listView_bindInlineEditSave() {
 				// replace html  + do classes
 				jQuery( lThis )
 					.closest( '.zbs-inline-editing' )
-					.html( lLabel )
+					.text( lLabel )
 					.removeClass( 'zbs-inline-editing' )
 					.addClass( 'zbs-inline-edit' );
 

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.segmentedit.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.segmentedit.js
@@ -426,7 +426,7 @@ function zeroBSCRMJS_segment_buildConditionCascadesForEle( ele ) {
 			// add in as a 'disabled' option (so saving doesn't remove it, but user can remove it/not edit it)
 			html +=
 				'<input type="text" disabled="disabled" class="zbs-segment-edit-var-condition-operator segment-condition-errored" value="' +
-				original_value +
+				jpcrm.esc_attr( original_value ) +
 				'" />';
 		}
 

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.singleview.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.singleview.js
@@ -153,19 +153,10 @@ function zeroBSCRMJS_viewContactInit() {
 	jQuery( '.zbs-contact-action' )
 		.off( 'click' )
 		.on( 'click', function () {
-			// get action type (at launch, only url)
-			const actionType = jQuery( this ).attr( 'data-action' );
-
-			if ( typeof actionType !== 'undefined' ) {
-				switch ( actionType ) {
-					case 'url': {
-						const u = jQuery( this ).attr( 'data-url' );
-						if ( typeof u !== 'undefined' && u ) {
-							window.location = u;
-						}
-
-						break;
-					}
+			if ( this.dataset.action === 'url' ) {
+				const u = this.dataset.url;
+				if ( u && ( u.startsWith( 'https://' ) || u.startsWith( 'http://' ) ) ) {
+					window.location = u;
 				}
 			}
 		} );

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.tags.metabox.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.tags.metabox.js
@@ -10,7 +10,7 @@
 /* eslint-disable jsdoc/require-param-type */
 /* eslint-disable jsdoc/require-param-description */
 /* eslint-disable jsdoc/require-description */
-/* global zbsCustomTagInitFunc, ajaxurl, swal, zbscrm_JS_addDirty */
+/* global zbsCustomTagInitFunc, ajaxurl, swal, zbscrm_JS_addDirty, jpcrm */
 
 /**
  * Build tags
@@ -58,14 +58,16 @@ function zeroBSCRMJS_buildTagsInput() {
  * @param tagID
  */
 function zbsJS_drawTag( tagStr, tagID ) {
-	const html =
-		'<div class="ui small basic label black" data-id="' +
-		tagID +
-		'"><i class="window close icon zbs-remove-tag"></i> <span>' +
-		tagStr +
-		'</span></div>';
-
-	jQuery( '#zbs-tags-wrap' ).append( html );
+	document
+		.getElementById( 'zbs-tags-wrap' )
+		.insertAdjacentHTML(
+			'beforeend',
+			'<div class="ui small basic label black" data-id="' +
+				jpcrm.esc_attr( tagID ) +
+				'"><i class="window close icon zbs-remove-tag"></i> <span>' +
+				jpcrm.esc_html( tagStr ) +
+				'</span></div>'
+		);
 
 	setTimeout( function () {
 		zbsJS_bindTags();
@@ -208,18 +210,25 @@ function zbsJS_bindTagManagerInit() {
 						jQuery( '#zbs-add-tag-value' ).val( '' );
 
 						// add to table
-						const tagTR =
-							'<tr><td><span class="ui large label">' +
-							ltag +
-							'</span></td><td>' +
-							newTagSlug +
-							'</td><td class="center aligned">0</td><td class="center aligned"><button type="button" class="ui mini button black zbs-delete-tag" data-tagid="' +
-							newTagID +
-							'"><i class="trash alternate icon"></i> ' +
-							window.zbsTagListLang.delete +
-							'</button></td></tr>';
-						jQuery( '#zbs-tag-manager tbody' ).append( tagTR );
-
+						document
+							.querySelector( '#zbs-tag-manager tbody' )
+							.insertAdjacentHTML(
+								'beforeend',
+								'<tr>' +
+									'<td><span class="ui large label">' +
+									jpcrm.esc_html( ltag ) +
+									'</span></td>' +
+									'<td>' +
+									jpcrm.esc_html( newTagSlug ) +
+									'</td>' +
+									'<td class="center aligned">0</td>' +
+									'<td class="center aligned"><button type="button" class="ui mini button black zbs-delete-tag" data-tagid="' +
+									jpcrm.esc_attr( newTagID ) +
+									'"><i class="trash alternate icon"></i> ' +
+									jpcrm.esc_html( window.zbsTagListLang.delete ) +
+									'</button></td>' +
+									'</tr>'
+							);
 						// rebind
 						setTimeout( function () {
 							zeroBSCRMJS_tagManager_bindTagEditButtons();

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.transactioneditor.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.transactioneditor.js
@@ -226,11 +226,10 @@ function zbscrmjs_build_custInv_dropdown( custID, preSelectedInvID ) {
 				}
 
 				// NOTE THIS IS DUPE BELOW... REFACTOR
-				jQuery( '#invoiceFieldWrap' ).html(
-					'<input style="max-width:200px;" id="invoice_id" name="invoice_id" value="' +
-						previousInvValL +
-						'" class="form-control">'
-				);
+				document.getElementById( 'invoiceFieldWrap' ).innerHTML =
+					'<input style="max-width: 200px;" id="invoice_id" name="invoice_id" class="form-control" value="' +
+					jpcrm.esc_attr( previousInvValL ) +
+					'">';
 			}
 		);
 	} else {
@@ -242,11 +241,10 @@ function zbscrmjs_build_custInv_dropdown( custID, preSelectedInvID ) {
 			previousInvVal = '';
 		}
 		// NOTE THIS IS DUPE ABOVE... REFACTOR
-		jQuery( '#invoiceFieldWrap' ).html(
-			'<input style="max-width:200px;" id="invoice_id" name="invoice_id" value="' +
-				previousInvVal +
-				'" class="form-control">'
-		);
+		document.getElementById( 'invoiceFieldWrap' ).innerHTML =
+			'<input style="max-width: 200px;" id="invoice_id" name="invoice_id" class="form-control" value="' +
+			jpcrm.esc_attr( previousInvVal ) +
+			'">';
 
 		// bind
 		setTimeout( function () {


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
This escapes various values that are sourced from the DOM and then reoutput. They were discovered by automated GH scans.

Changes included:
* Removal of dead code (`projects/plugins/crm/js/ZeroBSCRM.admin.global.js`)
* Switching from `html()` to `text()`
* Wrapping values with `jpcrm.esc_*` functions
* Doing an explicit string comparison check to verify the string started with https/http

In most cases I also switched from jQuery to native JS calls.

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

I'm not sure how to best test these, but looking at the code should be adequate.