### PR TITLE
Enable newsletter settings package via blog sticker

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-15287-make-available-sticker
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-15287-make-available-sticker
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Enable newsletter settings package for sites with the newsletter-package-202503 sticker.
+Enable newsletter settings package for sites with the newsletter-package-202603 sticker.

--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-15287-make-available-sticker
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-15287-make-available-sticker
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Enable newsletter settings package for sites with the newsletter-package-202503 sticker.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -363,6 +363,9 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/wpcom-themes/wpcom-themes.php';
 		require_once __DIR__ . '/features/wpcom-user-edit/wpcom-user-edit.php';
 
+		// Enable newsletter settings for sites with the newsletter-package-202503 sticker.
+		add_filter( 'jetpack_wp_admin_newsletter_settings_enabled', 'wpcom_maybe_enable_newsletter_settings' );
+
 		// Initialize Newsletter Settings so hooks like the Reading page notice
 		// are registered on Simple sites (where load-jetpack.php doesn't run).
 		\Automattic\Jetpack\Newsletter\Settings::init();

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -363,7 +363,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/wpcom-themes/wpcom-themes.php';
 		require_once __DIR__ . '/features/wpcom-user-edit/wpcom-user-edit.php';
 
-		// Enable newsletter settings for sites with the newsletter-package-202503 sticker.
+		// Enable newsletter settings for sites with the newsletter-package-202603 sticker.
 		add_filter( 'jetpack_wp_admin_newsletter_settings_enabled', 'wpcom_maybe_enable_newsletter_settings' );
 
 		// Initialize Newsletter Settings so hooks like the Reading page notice

--- a/projects/packages/jetpack-mu-wpcom/src/utils.php
+++ b/projects/packages/jetpack-mu-wpcom/src/utils.php
@@ -230,4 +230,3 @@ function wpcom_maybe_enable_newsletter_settings( $enabled ) {
 	// Stickered sites (will always be simple, as we don't sync this sticker. WoW sites can just add their own mu-plugin/snippet)
 	return function_exists( 'has_blog_sticker' ) && has_blog_sticker( 'newsletter-package-202503' );
 }
-add_filter( 'jetpack_wp_admin_newsletter_settings_enabled', 'wpcom_maybe_enable_newsletter_settings' );

--- a/projects/packages/jetpack-mu-wpcom/src/utils.php
+++ b/projects/packages/jetpack-mu-wpcom/src/utils.php
@@ -215,7 +215,7 @@ function wpcom_has_blog_sticker( $blog_sticker, $blog_id ) {
 }
 
 /**
- * Enable the newsletter settings package for sites with the newsletter-package-202503 sticker.
+ * Enable the newsletter settings package for sites with the newsletter-package-202603 sticker.
  *
  * This allows opt-in testing of the newsletter settings package on wpcom infrastructure.
  *
@@ -228,5 +228,5 @@ function wpcom_maybe_enable_newsletter_settings( $enabled ) {
 	}
 
 	// Stickered sites (will always be simple, as we don't sync this sticker. WoW sites can just add their own mu-plugin/snippet)
-	return function_exists( 'has_blog_sticker' ) && has_blog_sticker( 'newsletter-package-202503' );
+	return function_exists( 'has_blog_sticker' ) && has_blog_sticker( 'newsletter-package-202603' );
 }

--- a/projects/packages/jetpack-mu-wpcom/src/utils.php
+++ b/projects/packages/jetpack-mu-wpcom/src/utils.php
@@ -213,3 +213,21 @@ function wpcom_has_blog_sticker( $blog_sticker, $blog_id ) {
 	}
 	return false;
 }
+
+/**
+ * Enable the newsletter settings package for sites with the newsletter-package-202503 sticker.
+ *
+ * This allows opt-in testing of the newsletter settings package on wpcom infrastructure.
+ *
+ * @param bool $enabled Whether the newsletter settings are enabled.
+ * @return bool
+ */
+function wpcom_maybe_enable_newsletter_settings( $enabled ) {
+	if ( $enabled ) {
+		return $enabled;
+	}
+
+	// Stickered sites (will always be simple, as we don't sync this sticker. WoW sites can just add their own mu-plugin/snippet)
+	return function_exists( 'has_blog_sticker' ) && has_blog_sticker( 'newsletter-package-202503' );
+}
+add_filter( 'jetpack_wp_admin_newsletter_settings_enabled', 'wpcom_maybe_enable_newsletter_settings' );


### PR DESCRIPTION
Part of DOTCOM-16248

## Proposed changes

* Add a filter on `jetpack_wp_admin_newsletter_settings_enabled` to enable the newsletter settings package for sites with the `newsletter-package-202603` blog sticker.
* This allows opt-in testing of the newsletter settings package on wpcom infrastructure via stickered sites.
* WoW sites can continue to test with a mu-plugin snippet.

### Other information

- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions


1. You can toggle the sticker via 161334-ghe-Automattic/missioncontrol or by using `wp blog-stickers add --sticker=newsletter-package-202603 --who=deansas --blog_id=xxx --url=yourtestsite.wordpress.com`
2. Verify that sites with the `newsletter-package-202603` blog sticker have the newsletter settings package enabled - it appears in the menu and clicking it shows the new newsletter screen.
3. Verify that sites without the sticker are unaffected (the filter returns `false` for them) - the old settings screen is displayed.
4. Verify that if the newsletter settings are already enabled via another mechanism, the filter does not override that. i.e. you don't need the sticker if you have `add_filter( 'jetpack_wp_admin_newsletter_settings_enabled', '__return_true' );` in your 0-sandbox file.