### PR TITLE
Fix input handling min/max

### DIFF
--- a/projects/packages/forms/changelog/fix-number-field-min-max-ui
+++ b/projects/packages/forms/changelog/fix-number-field-min-max-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix number field min and max values not displaying in the UI after page reload.

--- a/projects/packages/forms/src/blocks/input/deprecated.js
+++ b/projects/packages/forms/src/blocks/input/deprecated.js
@@ -18,8 +18,8 @@ export default [
 			const { min, max, ...restAttributes } = attributes;
 			return {
 				...restAttributes,
-				min: min ? parseFloat( min ) : undefined,
-				max: max ? parseFloat( max ) : undefined,
+				min: min != null && min !== '' ? parseFloat( min ) : undefined,
+				max: max != null && max !== '' ? parseFloat( max ) : undefined,
 			};
 		},
 		isEligible: attributes => {

--- a/projects/packages/forms/src/blocks/input/deprecated.js
+++ b/projects/packages/forms/src/blocks/input/deprecated.js
@@ -16,10 +16,6 @@ export default [
 		save: () => null,
 		migrate: attributes => {
 			const { min, max, ...restAttributes } = attributes;
-			return {
-				...restAttributes,
-				min: min != null && min !== '' ? parseFloat( min ) : undefined,
-				max: max != null && max !== '' ? parseFloat( max ) : undefined,
 			const parsedMin = parseFloat( min );
 			const parsedMax = parseFloat( max );
 			return {

--- a/projects/packages/forms/src/blocks/input/deprecated.js
+++ b/projects/packages/forms/src/blocks/input/deprecated.js
@@ -1,0 +1,29 @@
+export default [
+	{
+		attributes: {
+			placeholder: {
+				type: 'string',
+				default: '',
+			},
+			type: { type: 'string' },
+			min: { type: 'string' },
+			max: { type: 'string' },
+		},
+		supports: {
+			reusable: false,
+			html: false,
+		},
+		save: () => null,
+		migrate: attributes => {
+			const { min, max, ...restAttributes } = attributes;
+			return {
+				...restAttributes,
+				min: min ? parseFloat( min ) : undefined,
+				max: max ? parseFloat( max ) : undefined,
+			};
+		},
+		isEligible: attributes => {
+			return typeof attributes.min === 'string' || typeof attributes.max === 'string';
+		},
+	},
+];

--- a/projects/packages/forms/src/blocks/input/deprecated.js
+++ b/projects/packages/forms/src/blocks/input/deprecated.js
@@ -20,6 +20,12 @@ export default [
 				...restAttributes,
 				min: min != null && min !== '' ? parseFloat( min ) : undefined,
 				max: max != null && max !== '' ? parseFloat( max ) : undefined,
+			const parsedMin = parseFloat( min );
+			const parsedMax = parseFloat( max );
+			return {
+				...restAttributes,
+				min: Number.isFinite( parsedMin ) ? parsedMin : undefined,
+				max: Number.isFinite( parsedMax ) ? parsedMax : undefined,
 			};
 		},
 		isEligible: attributes => {

--- a/projects/packages/forms/src/blocks/input/edit.js
+++ b/projects/packages/forms/src/blocks/input/edit.js
@@ -104,7 +104,10 @@ const InputEdit = ( { attributes, clientId, isSelected, name, setAttributes, con
 							key="min"
 							label={ __( 'Minimum value', 'jetpack-forms' ) }
 							value={ min }
-							onChange={ value => setAttributes( { min: parseFloat( value ) } ) }
+							onChange={ value => {
+								const parsed = parseFloat( value );
+								setAttributes( { min: Number.isNaN( parsed ) ? undefined : parsed } );
+							} }
 							max={ max }
 							__nextHasNoMarginBottom={ true }
 							__next40pxDefaultSize={ true }
@@ -117,7 +120,10 @@ const InputEdit = ( { attributes, clientId, isSelected, name, setAttributes, con
 							key="max"
 							label={ __( 'Maximum value', 'jetpack-forms' ) }
 							value={ max }
-							onChange={ value => setAttributes( { max: parseFloat( value ) } ) }
+							onChange={ value => {
+								const parsed = parseFloat( value );
+								setAttributes( { max: Number.isNaN( parsed ) ? undefined : parsed } );
+							} }
 							min={ min }
 							__nextHasNoMarginBottom={ true }
 							__next40pxDefaultSize={ true }

--- a/projects/packages/forms/src/blocks/input/edit.js
+++ b/projects/packages/forms/src/blocks/input/edit.js
@@ -104,7 +104,7 @@ const InputEdit = ( { attributes, clientId, isSelected, name, setAttributes, con
 							key="min"
 							label={ __( 'Minimum value', 'jetpack-forms' ) }
 							value={ min }
-							onChange={ value => setAttributes( { min: value } ) }
+							onChange={ value => setAttributes( { min: parseFloat( value ) } ) }
 							max={ max }
 							__nextHasNoMarginBottom={ true }
 							__next40pxDefaultSize={ true }
@@ -117,7 +117,7 @@ const InputEdit = ( { attributes, clientId, isSelected, name, setAttributes, con
 							key="max"
 							label={ __( 'Maximum value', 'jetpack-forms' ) }
 							value={ max }
-							onChange={ value => setAttributes( { max: value } ) }
+							onChange={ value => setAttributes( { max: parseFloat( value ) } ) }
 							min={ min }
 							__nextHasNoMarginBottom={ true }
 							__next40pxDefaultSize={ true }

--- a/projects/packages/forms/src/blocks/input/edit.js
+++ b/projects/packages/forms/src/blocks/input/edit.js
@@ -116,12 +116,8 @@ const InputEdit = ( { attributes, clientId, isSelected, name, setAttributes, con
 						<NumberControl
 							key="max"
 							label={ __( 'Maximum value', 'jetpack-forms' ) }
-							value={ attributes.max }
-							onChange={ value =>
-								setAttributes( {
-									max: value,
-								} )
-							}
+							value={ max }
+							onChange={ value => setAttributes( { max: value } ) }
 							min={ min }
 							__nextHasNoMarginBottom={ true }
 							__next40pxDefaultSize={ true }

--- a/projects/packages/forms/src/blocks/input/edit.js
+++ b/projects/packages/forms/src/blocks/input/edit.js
@@ -106,7 +106,7 @@ const InputEdit = ( { attributes, clientId, isSelected, name, setAttributes, con
 							value={ min }
 							onChange={ value => {
 								const parsed = parseFloat( value );
-								setAttributes( { min: Number.isNaN( parsed ) ? undefined : parsed } );
+								setAttributes( { min: Number.isFinite( parsed ) ? parsed : undefined } );
 							} }
 							max={ max }
 							__nextHasNoMarginBottom={ true }

--- a/projects/packages/forms/src/blocks/input/edit.js
+++ b/projects/packages/forms/src/blocks/input/edit.js
@@ -122,7 +122,7 @@ const InputEdit = ( { attributes, clientId, isSelected, name, setAttributes, con
 							value={ max }
 							onChange={ value => {
 								const parsed = parseFloat( value );
-								setAttributes( { max: Number.isNaN( parsed ) ? undefined : parsed } );
+								setAttributes( { max: Number.isFinite( parsed ) ? parsed : undefined } );
 							} }
 							min={ min }
 							__nextHasNoMarginBottom={ true }

--- a/projects/packages/forms/src/blocks/input/index.js
+++ b/projects/packages/forms/src/blocks/input/index.js
@@ -1,6 +1,7 @@
 import { Path } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import renderMaterialIcon from '../shared/components/render-material-icon.jsx';
+import deprecated from './deprecated.js';
 import edit from './edit.js';
 import save from './save.js';
 
@@ -71,6 +72,7 @@ const settings = {
 		max: { type: 'number' },
 	},
 	edit,
+	deprecated,
 	save,
 };
 

--- a/projects/plugins/jetpack/changelog/fix-number-field-min-max-ui
+++ b/projects/plugins/jetpack/changelog/fix-number-field-min-max-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Fix number field min and max values not displaying in the UI after page reload.


### PR DESCRIPTION
Fixes FORMS-610

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Fix min/max values not showing up in settings after page refresh.

Issue happened because of a type mismatch:
- The block schema expects min and max to be numbers (type: 'number')
- But they were being saved as strings ("10", "20")
- The fix is `parseFloat()` in the setter, and migration is there to help with existing blocks which already had string values. `isEligible` makes sure deprecation is applied only to inputs that need it.

### Before

<img width="684" height="96" alt="image" src="https://github.com/user-attachments/assets/825a25b8-e973-48f3-8901-fbb47c45838f" />


https://github.com/user-attachments/assets/62297a41-cf6f-431d-9fcd-2559eb71b3c8



### After

<img width="687" height="87" alt="image" src="https://github.com/user-attachments/assets/7204e105-5e54-4ead-a041-a2818d0c5b34" />


https://github.com/user-attachments/assets/a749684b-4e86-4b6d-ba92-bd70edc9d825



### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Add number input to content, try save min/max. Note how they are stored in attributes, but UI doesn't show anything after page refresh.
* Keep the input in content to confirm nothing breaks when switching to new branch
* Now create new form and update min/max.
* Refresh the page.
* Now you can still see the numbers.
* In frontend, min max are applied correctly
    <img width="395" height="154" alt="image" src="https://github.com/user-attachments/assets/6637ad1a-9afe-4f23-8d95-e2cf184b6a79" />
