### PR TITLE
MU WPCOM: Enable Gutenberg RTC for sites with the REAL_TIME_COLLABORATION feature

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/pr-47512
+++ b/projects/packages/jetpack-mu-wpcom/changelog/pr-47512
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Gutenberg RTC: Enable Real-Time Collaboration feature for sites with the wpcom-gutenberg-rtc-enabled blog sticker.
+Gutenberg RTC: Enable Real-Time Collaboration feature for sites with the REAL_TIME_COLLABORATION feature.

--- a/projects/packages/jetpack-mu-wpcom/changelog/pr-47512
+++ b/projects/packages/jetpack-mu-wpcom/changelog/pr-47512
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Gutenberg RTC: Enable Real-Time Collaboration feature for sites with the wpcom-gutenberg-rtc-enabled blog sticker.

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
@@ -17,7 +17,7 @@
  */
 function wpcom_is_gutenberg_rtc_enabled() {
 	$blog_id    = get_wpcom_blog_id();
-	$is_enabled = wpcom_has_blog_sticker( 'wpcom-gutenberg-rtc-enabled', $blog_id );
+	$is_enabled = wpcom_site_has_feature( WPCOM_Features::REAL_TIME_COLLABORATION, $blog_id );
 
 	return apply_filters( 'wpcom_is_gutenberg_rtc_enabled', $is_enabled );
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
@@ -16,7 +16,10 @@
  * and we are confident in proceeding with the rollout.
  */
 function wpcom_is_gutenberg_rtc_enabled() {
-	return apply_filters( 'wpcom_is_gutenberg_rtc_enabled', false );
+	$blog_id    = get_wpcom_blog_id();
+	$is_enabled = wpcom_has_blog_sticker( 'wpcom-gutenberg-rtc-enabled', $blog_id );
+
+	return apply_filters( 'wpcom_is_gutenberg_rtc_enabled', $is_enabled );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
@@ -16,8 +16,11 @@
  * and we are confident in proceeding with the rollout.
  */
 function wpcom_is_gutenberg_rtc_enabled() {
-	$blog_id    = get_wpcom_blog_id();
-	$is_enabled = wpcom_site_has_feature( WPCOM_Features::REAL_TIME_COLLABORATION, $blog_id );
+	$is_enabled = false;
+	if ( function_exists( 'wpcom_site_has_feature' ) && class_exists( 'WPCOM_Features' ) ) {
+		$blog_id    = get_wpcom_blog_id();
+		$is_enabled = wpcom_site_has_feature( WPCOM_Features::REAL_TIME_COLLABORATION, $blog_id );
+	}
 
 	return apply_filters( 'wpcom_is_gutenberg_rtc_enabled', $is_enabled );
 }

--- a/projects/plugins/mu-wpcom-plugin/changelog/pr-47512
+++ b/projects/plugins/mu-wpcom-plugin/changelog/pr-47512
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Gutenberg RTC: Enable Real-Time Collaboration feature for sites with the wpcom-gutenberg-rtc-enabled blog sticker.
+Gutenberg RTC: Enable Real-Time Collaboration feature for sites with the REAL_TIME_COLLABORATION feature.

--- a/projects/plugins/mu-wpcom-plugin/changelog/pr-47512
+++ b/projects/plugins/mu-wpcom-plugin/changelog/pr-47512
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Gutenberg RTC: Enable Real-Time Collaboration feature for sites with the wpcom-gutenberg-rtc-enabled blog sticker.

--- a/projects/plugins/wpcomsh/changelog/pr-47512
+++ b/projects/plugins/wpcomsh/changelog/pr-47512
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Gutenberg RTC: Enable Real-Time Collaboration feature for sites with the wpcom-gutenberg-rtc-enabled blog sticker.
+Gutenberg RTC: Enable Real-Time Collaboration feature for sites with the REAL_TIME_COLLABORATION feature.

--- a/projects/plugins/wpcomsh/changelog/pr-47512
+++ b/projects/plugins/wpcomsh/changelog/pr-47512
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Gutenberg RTC: Enable Real-Time Collaboration feature for sites with the wpcom-gutenberg-rtc-enabled blog sticker.


### PR DESCRIPTION
Related to DOTCOM-16207

## Proposed changes

Enable the Gutenberg RTC (Real-Time Collaboration) feature for sites with the `REAL_TIME_COLLABORATION` feature flag, instead of being disabled by default for all sites.

* Update `wpcom_is_gutenberg_rtc_enabled()` to check for the `REAL_TIME_COLLABORATION` feature using `wpcom_site_has_feature()` and `get_wpcom_blog_id()`.
* The result is still filterable via the `wpcom_is_gutenberg_rtc_enabled` filter, so it can be overridden per-site if needed.

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

0. Apply changes to your WoA dev site by Jetpack Beta Tester
1. Ensure the test site has the `REAL_TIME_COLLABORATION` feature enabled. See https://github.com/Automattic/jetpack/pull/47483
2. Edit a page/post
3. Ensure the value of `window._wpCollaborationEnabled` is `true`
4. On a site **without** the feature, verify that Gutenberg RTC remains disabled.
5. Ensure the value of `window._wpCollaborationEnabled` is `undefined`