### PR TITLE
tsgo: Replace tsc in docs and CLI genereate command

### DIFF
--- a/.github/files/lint-project-structure.sh
+++ b/.github/files/lint-project-structure.sh
@@ -213,7 +213,7 @@ for PROJECT in projects/*/*; do
 	if [[ -e "$PROJECT/package.json" ]] && jq -e '.dependencies["ts-loader"] // .devDependencies["ts-loader"] // .optionalDependencies["ts-loader"]' "$PROJECT/package.json" >/dev/null; then
 		EXIT=1
 		LINE=$(jq --stream -r 'if length == 1 then .[0][:-1] else .[0] end | if . == ["dependencies","ts-loader"] or . == ["devDependencies","ts-loader"] or . == ["optionalDependencies","ts-loader"] then ",line=\( input_line_number )" else empty end' "$PROJECT/package.json" | head -1)
-		echo "::error file=$PROJECT/package.json${LINE}::For consistency we've settled on using \`@babel/preset-typescript\` (and \`fork-ts-checker-webpack-plugin\` or \`tsc\` for definition files) rather than \`ts-loader\`. Please switch to that."
+		echo "::error file=$PROJECT/package.json${LINE}::For consistency we've settled on using \`@babel/preset-typescript\` (and \`fork-ts-checker-webpack-plugin\` or \`tsgo\` for definition files) rather than \`ts-loader\`. Please switch to that."
 	fi
 
 	# - certain tsconfig options should not be used directly.

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -7,10 +7,10 @@ These are some things to keep in mind when writing code for the Jetpack Monorepo
 - **PHP**: Jetpack Monorepo projects rely on WordPress' minimum PHP version requirements by default. There are several exceptions, however, which we will get to later in this document.
 - **PHP Standards**: Jetpack follows [WordPress Core's standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/), with a few additions. The best way to ensure that you adhere to those standards is to set up your IDE [as per the recommendations here](./development-environment.md#use-php-codesniffer-and-eslint-to-make-sure-your-code-respects-coding-standards).
 - **WordPress**: Jetpack supports the current version of WordPress and the immediate previous version. So if the current version is 4.6, Jetpack will support it, as well as 4.5. It's desirable that when Jetpack is installed in older versions, it doesn't fail in a severe way.
-- **JavaScript**: Jetpack Monorepo uses NodeJS as the engine, and version wise it follows Calypso, usually meaning staying on the current LTS version. The package manager is the latest version of PNPM. 
+- **JavaScript**: Jetpack Monorepo uses NodeJS as the engine, and version wise it follows Calypso, usually meaning staying on the current LTS version. The package manager is the latest version of PNPM.
 - **Frontend JavaScript**: The Jetpack Monorepo standard is Webpack, Babel, Gutenberg, and React stack. (The preferred configuration)[https://github.com/Automattic/jetpack/blob/trunk/projects/js-packages/webpack-config/README.md] that is shared among all projects is in the `projects/js-packages/webpack-config` project. This is done to make sure that Babel handles browser compatibility.
 - **Other JavaScript**: Teams are free to use other stacks for their projects, and we do have projects that use Svelte with Rollup, for example. In practice it usually means that the team is largely responsible for supporting custom solutions like this, including i18n and updates. There's a notable "conflict" where we would like to avoid bringing in `18n-calypso` for i18n, since Jetpack generally uses translate.wordpress.org which requires Gutenberg's `@wordpress/i18n`.
-- **Linting and testing JavaScript**: We have generally settled on `jest` and `@testing-library/*` for unit testing.  Linting is done with `eslint`, with most configuration at the Monorepo level. Ideally projects should be sparing in overriding the eslint config beyond selecting the appropriate presets for `react`/`typescript`/etc.
+- **Linting and testing JavaScript**: We have generally settled on `jest` and `@testing-library/*` for unit testing. Linting is done with `eslint`, with most configuration at the Monorepo level. Ideally projects should be sparing in overriding the eslint config beyond selecting the appropriate presets for `react`/`typescript`/etc.
 - **E2E tests**: The situation is a bit complicated:
   - We've settled on `playwright` for standalone E2E tests. `allure-playwright` is the direct dependency that brings in `playwright` as a sub-dependency.
   - For tests against Simple and Atomic, however, those live in [the Calypso repo](https://github.com/Automattic/wp-calypso).
@@ -19,9 +19,9 @@ These are some things to keep in mind when writing code for the Jetpack Monorepo
   - When consuming monorepo `js-packages` within the Monorepo, the package should provide `jetpack:src` entries in `.exports` in `package.json` to avoid having to build before `eslint` can run. Do not use `.scripts.prepare` or the like to try to compile on installation, as that slows down and complicates installation for everyone even if they're not using that js-package.
 - **Browsers**: Jetpack Monorepo follows Gutenberg's browser support guidelines by [relying on the `browserlist-config` package](https://make.wordpress.org/core/handbook/best-practices/browser-support/).
 
-### Project based language and tool versions 
+### Project based language and tool versions
 
-If you take a look at the contents of the `projects` folder, you can see that the Monorepo has several types of projects. Some of them can have specific requirements that further extend the base requirements. The most obvious examples of that are plugins that require later PHP versions than what is required by default. For instance, Jetpack CRM's `readme.txt` file states that [the minimum PHP version is 7.4](https://github.com/Automattic/jetpack/blob/a8b161eb5c6b23972d728271e0b210df4f9e586c/projects/plugins/crm/readme.txt#L7). 
+If you take a look at the contents of the `projects` folder, you can see that the Monorepo has several types of projects. Some of them can have specific requirements that further extend the base requirements. The most obvious examples of that are plugins that require later PHP versions than what is required by default. For instance, Jetpack CRM's `readme.txt` file states that [the minimum PHP version is 7.4](https://github.com/Automattic/jetpack/blob/a8b161eb5c6b23972d728271e0b210df4f9e586c/projects/plugins/crm/readme.txt#L7).
 
 ## The Jetpack Monorepo and its CLI
 
@@ -32,7 +32,7 @@ Jetpack CLI is a requirement to work with Jetpack Monorepo, and it depends on th
 - **Composer**: [the PHP dependency management tool](https://getcomposer.org/) is required to work with the Monorepo.
 - **PNPM**: [the drop-in replacement for NPM](https://pnpm.io/) is also a requirement.
 
-This is all you need to get going, please check the [Quick Start][quick-start.md] guide if you need help getting the correct versions installed. 
+This is all you need to get going, please check the [Quick Start][quick-start.md] guide if you need help getting the correct versions installed.
 
 ## General guidelines
 
@@ -67,9 +67,9 @@ Example usage for deprecating a function:
  * @return string
  */
 function example_function() {
- 
+
     _deprecated_function( __FUNCTION__, '{plugin/package}-$$next-version$$' );
- 
+
    return 'example';
 }
 ```
@@ -98,11 +98,11 @@ For more information on how to use `$$next-version$$`, please see the [packages 
 - Use an appropriate unique text domain in your JS code.
 - Make use of [@automattic/babel-plugin-replace-textdomain](https://www.npmjs.com/package/@automattic/babel-plugin-replace-textdomain) when bundling to ensure i18n works in the published plugin.
 - When using TypeScript in Webpack, use `@babel/preset-typescript` rather than `ts-loader`.
-  - To generate `.d.ts` files, either `fork-ts-checker-webpack-plugin` or `tsc --emitDeclarationOnly` may be used.
+  - To generate `.d.ts` files, either `fork-ts-checker-webpack-plugin` or `tsgo --emitDeclarationOnly` may be used.
 
-## Where should my code live? 
+## Where should my code live?
 
-Here are some general guidelines when considering adding new functionality: 
+Here are some general guidelines when considering adding new functionality:
 
 - [Packages](../projects/packages/README.md#should-my-code-be-in-a-package)
 - Modules (@todo)

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -151,7 +151,7 @@ We use `composer.json` to hold metadata about projects. Much of our generic tool
 * `.extra.wp-svn-autopublish`: Set truthy to enable automatic publishing of tagged versions to WordPress.org. See [Mirror repositories > WordPress.org SVN Auto-publisher](#wordpressorg-svn-auto-publisher) for details.
 
 There are a few things in `package.json` as well:
-* `.scripts.typecheck`: If the package contains TypeScript code, this should run tsc to check types without building. See [TypeScript type checking](#typescript-type-checking) for details.
+* `.scripts.typecheck`: If the package contains TypeScript code, this should run tsgo to check types without building. See [TypeScript type checking](#typescript-type-checking) for details.
 
 Our mirroring tooling also uses `.gitattributes` to specify built files to include in the mirror and unnecessary files to exclude.
 
@@ -296,11 +296,11 @@ JavaScript tests should use `jest`, not `mocha`/`chai`/`sinon`. For React testin
 
 ### TypeScript type checking
 
-If a project contains TypeScript code, it should define `.scripts.typecheck` in `package.json` to run `tsc` in a manner that will check types without building. The CI environment will run `pnpm install` beforehand, but if `composer install` or a build step is required before running tests the necessary commands for that should also be included in `.scripts.typecheck`.
+If a project contains TypeScript code, it should define `.scripts.typecheck` in `package.json` to run `tsgo` in a manner that will check types without building. The CI environment will run `pnpm install` beforehand, but if `composer install` or a build step is required before running tests the necessary commands for that should also be included in `.scripts.typecheck`.
 
-Note the ideal configuration for a TypeScript project using `tsc` to build will have two tsconfig files:
+Note the ideal configuration for a TypeScript project using `tsgo` to build will have two tsconfig files:
 * `tsconfig.json` will be used for linting and type checking all code in the project. It will set `include` to reference all TS files and TS-containing subdirs
-* `tsconfig.build.json` will be used for the build (by passing `--project tsconfig.build.json` to `tsc`). This will extend `tsconfig.json` to override `include` to specify only the entry point files.
+* `tsconfig.build.json` will be used for the build (by passing `--project tsconfig.build.json` to `tsgo`). This will extend `tsconfig.json` to override `include` to specify only the entry point files.
 
 ### E2E tests
 

--- a/tools/cli/commands/generate.js
+++ b/tools/cli/commands/generate.js
@@ -710,9 +710,12 @@ function createPackageJson( packageJson, answers ) {
 		if ( ts ) {
 			packageJson.devDependencies.typescript = findVersionFromPnpmLock( 'typescript' );
 			if ( answers.typescript === 'ts-tsc' ) {
+				packageJson.devDependencies[ '@typescript/native-preview' ] = findVersionFromPnpmLock(
+					'@typescript/native-preview'
+				);
 				packageJson.scripts = {
 					...packageJson.scripts,
-					build: 'pnpm run clean && pnpm exec tsc --pretty',
+					build: 'pnpm run clean && pnpm exec tsgo --pretty',
 					clean: 'rm -rf build/',
 				};
 				packageJson.exports = {

--- a/tools/cli/commands/generate.js
+++ b/tools/cli/commands/generate.js
@@ -222,7 +222,7 @@ export function getQuestions( type ) {
 				},
 				{
 					message:
-						'This TypeScript package will contain pre-built code, built using tsc (no bundling or minification).',
+						'This TypeScript package will contain pre-built code, built using tsgo (no bundling or minification).',
 					value: 'ts-tsc',
 				},
 			],


### PR DESCRIPTION
A follow up to #47375

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Replace `tsc` in docs and CLI genereate command with `tsgo`

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Try the `jetpack generate` command with a pure ts package and confirm that the package build step uses `tsgo`
