### PR TITLE
Fix incomplete string sanitization in grunion.js

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-grunion-sanitization
+++ b/projects/packages/forms/changelog/fix-forms-grunion-sanitization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Fix incomplete string sanitization in legacy classic editor form builder (esc_attr and newline replacement now escape all occurrences, not just the first).

--- a/projects/packages/forms/src/contact-form/js/grunion.js
+++ b/projects/packages/forms/src/contact-form/js/grunion.js
@@ -29,7 +29,7 @@ GrunionFB_i18n = jQuery.extend(
 	GrunionFB_i18n
 );
 
-GrunionFB_i18n.moveInstructions = GrunionFB_i18n.moveInstructions.replace( '\n', '<br />' );
+GrunionFB_i18n.moveInstructions = GrunionFB_i18n.moveInstructions.replace( /\n/g, '<br />' );
 
 FB.span = jQuery( '<span>' );
 FB.esc_html = function ( string ) {
@@ -38,7 +38,7 @@ FB.esc_html = function ( string ) {
 
 FB.esc_attr = function ( string ) {
 	string = FB.esc_html( string );
-	return string.replace( '"', '&quot;' ).replace( "'", '&#039;' );
+	return string.replace( /"/g, '&quot;' ).replace( /'/g, '&#039;' );
 };
 
 FB.ContactForm = ( function () {

--- a/projects/packages/forms/tools/webpack.config.contact-form.js
+++ b/projects/packages/forms/tools/webpack.config.contact-form.js
@@ -132,10 +132,13 @@ const RenamerPlugin = {
 export default [
 	{
 		...sharedWebpackConfig,
-		entry: glob.sync( path.join( scriptSrcDir, '*.{js,ts,tsx}' ) ).reduce( ( acc, filepath ) => {
-			acc[ 'js/' + path.parse( filepath ).name ] = filepath;
-			return acc;
-		}, {} ),
+		entry: glob
+			.sync( path.join( scriptSrcDir, '*.{js,ts,tsx}' ) )
+			.filter( filepath => ! filepath.endsWith( '/grunion.js' ) )
+			.reduce( ( acc, filepath ) => {
+				acc[ 'js/' + path.parse( filepath ).name ] = filepath;
+				return acc;
+			}, {} ),
 	},
 	{
 		...sharedWebpackConfig,


### PR DESCRIPTION
Part of FORMS-611

## Proposed changes

* **Fix incomplete string sanitization** in the legacy classic editor form builder (`grunion.js`).
  - `String.replace()` with a string (non-regex) argument only replaces the **first** occurrence. This meant `esc_attr()` only escaped the first `"` and first `'`, and `moveInstructions` newline replacement only converted the first `\n` to `<br />`.
  - Switch to regex with global flag (`/pattern/g`) to escape all occurrences.
  - Resolves 3 of the 17 open code scanning alerts (alerts 146, 147, 148 — `js/incomplete-sanitization`, severity: high).

* **Exclude `grunion.js` from the webpack build.** Investigation confirmed this file is dead code:
  - No PHP code enqueues it (no `wp_enqueue_script` or `wp_register_script` referencing `grunion`)
  - Its AJAX endpoints (`grunion_shortcode`, `grunion_shortcode_to_json`) have no registered `wp_ajax_*` handlers
  - Its public API (`FB.ContactForm`) is not referenced anywhere in the codebase
  - It was replaced by `editor-view.js` (`Editor_View`), which renders forms inline in TinyMCE
  - The webpack config was globbing all JS files in the source directory, so the dead file was being built and shipped unnecessarily

* **Follow-up likely needed:** A separate PR should fully remove `grunion.js` from the source tree. Leaving the source file in place for now out of caution, but excluding it from the build so it is no longer shipped. Full removal would also clear the remaining 14 code scanning alerts (`js/xss-through-dom`) against this file.

### Other information

- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
p1773040012138699-slack-C052XEUUBL4

* Code scanning alerts: `js/incomplete-sanitization` on `projects/packages/forms/src/contact-form/js/grunion.js`

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Verify the Forms package builds successfully without `grunion.js`:
  - `cd projects/packages/forms && pnpm build`
  - Confirm no `dist/contact-form/js/grunion*` files are produced
* Open the classic editor (not Gutenberg) on a post
* Verify the "Add Contact Form" button still works (it uses `editor-view.js`, not `grunion.js`)
* Confirm no JS console errors related to missing scripts