### PR TITLE
Newsletter: Add spacing below warning notice in settings

### DIFF
--- a/projects/packages/newsletter/changelog/fix-notice-spacing
+++ b/projects/packages/newsletter/changelog/fix-notice-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add spacing below warning notice in Email content settings section

--- a/projects/packages/newsletter/src/settings/style.scss
+++ b/projects/packages/newsletter/src/settings/style.scss
@@ -15,6 +15,6 @@
 	margin-inline: auto;
 
 	.components-notice {
-		margin-block-end: var(--wpds-dimension-gap-lg);
+		margin-block-end: var(--wpds-dimension-gap-lg, 24px);
 	}
 }

--- a/projects/packages/newsletter/src/settings/style.scss
+++ b/projects/packages/newsletter/src/settings/style.scss
@@ -13,4 +13,8 @@
 .newsletter-settings {
 	max-width: 1200px;
 	margin-inline: auto;
+
+	.components-notice {
+		margin-block-end: var(--wpds-dimension-gap-lg);
+	}
 }


### PR DESCRIPTION
Fixes DOTCOM-16253

## Proposed changes

* Add `margin-block-end` spacing to the `.components-notice` element in the newsletter settings page, using the WPDS `--wpds-dimension-gap-lg` design token for responsive spacing.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions
 * Enable the new newsletter settings screen. e.g. via adding `add_filter( 'jetpack_wp_admin_newsletter_settings_enabled', '__return_true' );` to a mu-plugin
 * Go to the Newsletter settings page at `/wp-admin/admin.php?page=jetpack-newsletter` on a private site (so the "Featured images will not be used" warning is visible)
 * Verify there is visible spacing between the warning notice and the "Include the post's featured image" toggle below it

**Before:**
The warning notice sits directly against the toggle with no gap.
<img width="1086" height="324" alt="Screenshot 2026-03-09 at 16 18 02" src="https://github.com/user-attachments/assets/4c9f381d-715f-4515-8660-e27dff5e9405" />



**After:**
There is consistent spacing between the notice and the toggle, using the WPDS design token.
<img width="1086" height="324" alt="Screenshot 2026-03-09 at 15 34 18" src="https://github.com/user-attachments/assets/c588c3dc-1dca-4c52-bf78-fe47a03e4264" />

