### PR TITLE
Newline before php tag

### DIFF
--- a/projects/plugins/crm/changelog/fix-newline-before-php-tag
+++ b/projects/plugins/crm/changelog/fix-newline-before-php-tag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix JavaScript syntax error in list view caused by newline before PHP tag.

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.php
@@ -542,14 +542,7 @@ class zeroBSCRM_list {
 			var zbsDrawListViewColUpdateBlocker = false;
 			var zbsDrawListViewColUpdateAJAXBlocker = false;
 
-			var zbsObjectEmailLinkPrefix = '
-			<?php
-
-				// this assumes is contact for now, just sends to prefill - perhaps later add mailto: optional (wh wants lol)
-				echo jpcrm_esc_link( 'email', -1, 'zerobs_customer', true );
-
-			?>
-			';
+			var zbsObjectEmailLinkPrefix = '<?php echo jpcrm_esc_link( 'email', -1, 'zerobs_customer', true ); // phpcs:ignore Squiz.PHP.EmbeddedPhp.ContentBeforeOpen,Squiz.PHP.EmbeddedPhp.ContentAfterEnd -- this assumes is contact for now, just sends to prefill - perhaps later add mailto: optional (wh wants lol) ?>';
 			var zbsObjectViewLinkPrefixCustomer = '<?php echo jpcrm_esc_link( 'view', -1, 'zerobs_customer', true ); ?>';
 			var zbsObjectViewLinkPrefixCompany = '<?php echo jpcrm_esc_link( 'view', -1, 'zerobs_company', true ); ?>';
 			var zbsObjectViewLinkPrefixQuote = '<?php echo jpcrm_esc_link( 'edit', -1, 'zerobs_quote', true ); ?>';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #JETCRM-1409

## Proposed changes
*   Removed an unintended newline character between a single quote and a `<?php` tag within a JavaScript variable declaration in `ZeroBSCRM.List.php`.
*   This newline caused a JavaScript syntax error, preventing the list view from loading objects.
*   Ensured the PHP echo statement is on a single line to resolve the syntax error and prevent similar issues.
*   Searched for similar patterns in the `projects/plugins/crm` directory; no other instances were found.

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
*   N/A

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
*   Go to any CRM list view (e.g., ZBS CRM > Contacts, ZBS CRM > Companies).
*   Verify that the list view loads correctly and all objects are displayed as expected.