### PR TITLE
Forms: Add missing social-logos dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2539,6 +2539,9 @@ importers:
       semver:
         specifier: 7.7.3
         version: 7.7.3
+      social-logos:
+        specifier: workspace:*
+        version: link:../../js-packages/social-logos
       webpack:
         specifier: 5.105.2
         version: 5.105.2(webpack-cli@6.0.1)

--- a/projects/packages/forms/changelog/fix-forms-add-social-logos-dependency
+++ b/projects/packages/forms/changelog/fix-forms-add-social-logos-dependency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add missing social-logos dependency to fix wp-build failure

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -92,6 +92,7 @@
 		"redux": "4.2.1",
 		"redux-thunk": "2.3.0",
 		"semver": "7.7.3",
+		"social-logos": "workspace:*",
 		"webpack": "5.105.2",
 		"webpack-cli": "6.0.1"
 	},


### PR DESCRIPTION
Fixes #

## Proposed changes:
* Add `social-logos` as a dependency of the forms package to fix the `wp-build` esbuild failure. The `@automattic/jetpack-components` built output imports `social-logos`, but it wasn't listed in forms' `package.json`, causing esbuild to fail with "Could not resolve social-logos".

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:
* Run `pnpm run build` in `projects/packages/forms`
* Verify the build completes without "Could not resolve social-logos" errors

## Changelog
- [x] Generate changelog entries for this PR (using AI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)