### PR TITLE
Forms Dashboard: Remove modified date filter and add entries response filter

### DIFF
--- a/projects/packages/forms/changelog/fix-filters-forms-dashboard
+++ b/projects/packages/forms/changelog/fix-filters-forms-dashboard
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms Dashboard: Remove modified date filter and add entries filter to filter forms by whether they have responses

--- a/projects/packages/forms/routes/forms/package.json
+++ b/projects/packages/forms/routes/forms/package.json
@@ -4,6 +4,7 @@
 	"private": true,
 	"dependencies": {
 		"@automattic/jetpack-components": "workspace:*",
+		"@automattic/number-formatters": "workspace:*",
 		"@types/react": "18.3.28",
 		"@wordpress/admin-ui": "1.9.0",
 		"@wordpress/api-fetch": "7.41.0",

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { formatNumber } from '@automattic/number-formatters';
 import { Page } from '@wordpress/admin-ui';
 import {
 	__experimentalConfirmDialog as ConfirmDialog, // eslint-disable-line @wordpress/no-unsafe-wp-apis
@@ -256,7 +257,7 @@ function StageInner() {
 				label: __( 'Responses', 'jetpack-forms' ),
 				getValue: ( { item }: { item: FormListItem } ) =>
 					( item.entriesCount ?? 0 ) > 0 ? 'has_responses' : 'no_responses',
-				render: ( { item }: { item: FormListItem } ) => item.entriesCount ?? 0,
+				render: ( { item }: { item: FormListItem } ) => formatNumber( item.entriesCount ?? 0 ),
 				elements: [
 					{ label: __( 'Has responses', 'jetpack-forms' ), value: 'has_responses' },
 					{ label: __( 'No responses', 'jetpack-forms' ), value: 'no_responses' },

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -112,6 +112,17 @@ function StageInner() {
 		return statusFilterValue === 'trash';
 	}, [ view.filters ] );
 
+	const hasResponsesQuery = useMemo( () => {
+		const entriesFilterValue = view.filters?.find( filter => filter.field === 'entries' )?.value;
+		if ( entriesFilterValue === 'has_responses' ) {
+			return 'true';
+		}
+		if ( entriesFilterValue === 'no_responses' ) {
+			return 'false';
+		}
+		return undefined;
+	}, [ view.filters ] );
+
 	// Stable (non-trash) managed forms count, independent of the current DataViews search/filter state.
 	const { totalItems: totalNonTrashForms } = useFormsData( 1, 1, '', NON_TRASH_FORM_STATUSES );
 
@@ -119,7 +130,8 @@ function StageInner() {
 		view.page ?? 1,
 		view.perPage ?? 20,
 		view.search ?? '',
-		statusQuery
+		statusQuery,
+		hasResponsesQuery
 	);
 
 	const { duplicateForm, previewForm, copyEmbed, copyShortcode } = useFormItemActions();
@@ -242,8 +254,14 @@ function StageInner() {
 			{
 				id: 'entries',
 				label: __( 'Responses', 'jetpack-forms' ),
-				type: 'integer',
-				getValue: ( { item }: { item: FormListItem } ) => item.entriesCount ?? 0,
+				getValue: ( { item }: { item: FormListItem } ) =>
+					( item.entriesCount ?? 0 ) > 0 ? 'has_responses' : 'no_responses',
+				render: ( { item }: { item: FormListItem } ) => item.entriesCount ?? 0,
+				elements: [
+					{ label: __( 'Has responses', 'jetpack-forms' ), value: 'has_responses' },
+					{ label: __( 'No responses', 'jetpack-forms' ), value: 'no_responses' },
+				],
+				filterBy: { operators: [ 'is' ] as Operator[] },
 				enableSorting: false,
 			},
 			{

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -272,6 +272,7 @@ function StageInner() {
 				render: ( { item }: { item: FormListItem } ) =>
 					dateI18n( dateSettings.formats.datetime, item.modified ),
 				enableSorting: false,
+				filterBy: false,
 			},
 		],
 		[ dateSettings.formats.datetime ]

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -479,6 +479,7 @@ function StageInner() {
 				),
 				...( isSingleFormView ? {} : { filterBy: { operators: [ 'is' ] as Operator[] } } ),
 				enableSorting: false,
+				filterBy: false,
 			},
 			{
 				id: 'read_status',

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -477,9 +477,8 @@ function StageInner() {
 							__( '(no title)', 'jetpack-forms' ),
 					} )
 				),
-				...( isSingleFormView ? {} : { filterBy: { operators: [ 'is' ] as Operator[] } } ),
+				filterBy: isSingleFormView ? false : { operators: [ 'is' ] as Operator[] },
 				enableSorting: false,
-				filterBy: false,
 			},
 			{
 				id: 'read_status',

--- a/projects/packages/forms/src/contact-form/class-jetpack-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-jetpack-form-endpoint.php
@@ -21,6 +21,13 @@ class Jetpack_Form_Endpoint extends \WP_REST_Posts_Controller {
 	private $entries_count_by_form_id = null;
 
 	/**
+	 * Whether the current request filters by has_responses.
+	 *
+	 * @var bool
+	 */
+	private $has_responses_filter = true;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -92,6 +99,13 @@ class Jetpack_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'sanitize_callback' => 'sanitize_key',
 		);
 
+		$params['has_responses'] = array(
+			'description' => __( 'Filter forms by whether they have responses. "true" returns only forms with responses, "false" returns only forms without.', 'jetpack-forms' ),
+			'type'        => 'string',
+			'enum'        => array( '', 'true', 'false' ),
+			'default'     => '',
+		);
+
 		return $params;
 	}
 
@@ -104,7 +118,17 @@ class Jetpack_Form_Endpoint extends \WP_REST_Posts_Controller {
 	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public function get_items( $request ) {
+		$has_responses = (string) $request->get_param( 'has_responses' );
+		if ( '' !== $has_responses ) {
+			$this->has_responses_filter = ( 'true' === $has_responses );
+			add_filter( 'posts_clauses', array( $this, 'filter_by_responses' ) );
+		}
+
 		$response = parent::get_items( $request );
+
+		if ( '' !== $has_responses ) {
+			remove_filter( 'posts_clauses', array( $this, 'filter_by_responses' ) );
+		}
 
 		if ( is_wp_error( $response ) ) {
 			return $response;
@@ -190,6 +214,34 @@ class Jetpack_Form_Endpoint extends \WP_REST_Posts_Controller {
 
 		wp_cache_set( $cache_key, $counts_by_form_id, $cache_group, 15 ); // 15 seconds.
 		return $counts_by_form_id;
+	}
+
+	/**
+	 * Filter posts_clauses to include/exclude forms that have feedback responses.
+	 *
+	 * @param array $clauses SQL clauses.
+	 * @return array Modified clauses.
+	 */
+	public function filter_by_responses( $clauses ) {
+		global $wpdb;
+
+		$feedback_type = Feedback::POST_TYPE;
+		$operator      = $this->has_responses_filter ? 'EXISTS' : 'NOT EXISTS';
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$subquery = $wpdb->prepare(
+			"SELECT 1 FROM {$wpdb->posts} AS feedback
+			WHERE feedback.post_parent = {$wpdb->posts}.ID
+			AND feedback.post_type = %s
+			AND feedback.post_status IN (%s, %s)",
+			$feedback_type,
+			'publish',
+			'draft'
+		);
+
+		$clauses['where'] .= " AND $operator ($subquery)";
+
+		return $clauses;
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-jetpack-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-jetpack-form-endpoint.php
@@ -100,10 +100,11 @@ class Jetpack_Form_Endpoint extends \WP_REST_Posts_Controller {
 		);
 
 		$params['has_responses'] = array(
-			'description' => __( 'Filter forms by whether they have responses. "true" returns only forms with responses, "false" returns only forms without.', 'jetpack-forms' ),
-			'type'        => 'string',
-			'enum'        => array( '', 'true', 'false' ),
-			'default'     => '',
+			'description'       => __( 'Filter forms by whether they have responses. "true" returns only forms with responses, "false" returns only forms without.', 'jetpack-forms' ),
+			'type'              => 'string',
+			'enum'              => array( '', 'true', 'false' ),
+			'default'           => '',
+			'sanitize_callback' => 'sanitize_key',
 		);
 
 		return $params;
@@ -121,13 +122,13 @@ class Jetpack_Form_Endpoint extends \WP_REST_Posts_Controller {
 		$has_responses = (string) $request->get_param( 'has_responses' );
 		if ( '' !== $has_responses ) {
 			$this->has_responses_filter = ( 'true' === $has_responses );
-			add_filter( 'posts_clauses', array( $this, 'filter_by_responses' ) );
+			add_filter( 'posts_clauses', array( $this, 'filter_by_responses' ), 10, 2 );
 		}
 
 		$response = parent::get_items( $request );
 
 		if ( '' !== $has_responses ) {
-			remove_filter( 'posts_clauses', array( $this, 'filter_by_responses' ) );
+			remove_filter( 'posts_clauses', array( $this, 'filter_by_responses' ), 10 );
 		}
 
 		if ( is_wp_error( $response ) ) {
@@ -219,11 +220,17 @@ class Jetpack_Form_Endpoint extends \WP_REST_Posts_Controller {
 	/**
 	 * Filter posts_clauses to include/exclude forms that have feedback responses.
 	 *
-	 * @param array $clauses SQL clauses.
+	 * @param array     $clauses SQL clauses.
+	 * @param \WP_Query $query   The current WP_Query instance.
 	 * @return array Modified clauses.
 	 */
-	public function filter_by_responses( $clauses ) {
+	public function filter_by_responses( $clauses, $query ) {
 		global $wpdb;
+
+		// Only modify the query for jetpack_form post type.
+		if ( $query->get( 'post_type' ) !== $this->post_type ) {
+			return $clauses;
+		}
 
 		$feedback_type = Feedback::POST_TYPE;
 		$operator      = $this->has_responses_filter ? 'EXISTS' : 'NOT EXISTS';

--- a/projects/packages/forms/src/contact-form/class-jetpack-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-jetpack-form-endpoint.php
@@ -25,7 +25,7 @@ class Jetpack_Form_Endpoint extends \WP_REST_Posts_Controller {
 	 *
 	 * @var bool
 	 */
-	private $has_responses_filter = true;
+	public $has_responses_filter = true;
 
 	/**
 	 * Constructor.

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -60,11 +60,23 @@ export default function FormsDashboardForms(): JSX.Element | null {
 		return statusFilterValue === 'trash';
 	}, [ view.filters ] );
 
+	const hasResponsesQuery = useMemo( () => {
+		const entriesFilterValue = view.filters?.find( filter => filter.field === 'entries' )?.value;
+		if ( entriesFilterValue === 'has_responses' ) {
+			return 'true';
+		}
+		if ( entriesFilterValue === 'no_responses' ) {
+			return 'false';
+		}
+		return undefined;
+	}, [ view.filters ] );
+
 	const { records, isLoading, totalItems, totalPages } = useFormsData(
 		view.page,
 		view.perPage,
 		view.search,
-		statusQuery
+		statusQuery,
+		hasResponsesQuery
 	);
 	const {
 		isDeleting,
@@ -150,8 +162,14 @@ export default function FormsDashboardForms(): JSX.Element | null {
 			{
 				id: 'entries',
 				label: __( 'Entries', 'jetpack-forms' ),
-				getValue: ( { item }: { item: FormListItem } ) => item.entriesCount ?? 0,
+				getValue: ( { item }: { item: FormListItem } ) =>
+					( item.entriesCount ?? 0 ) > 0 ? 'has_responses' : 'no_responses',
 				render: ( { item }: { item: FormListItem } ) => item.entriesCount ?? 0,
+				elements: [
+					{ label: __( 'Has responses', 'jetpack-forms' ), value: 'has_responses' },
+					{ label: __( 'No responses', 'jetpack-forms' ), value: 'no_responses' },
+				],
+				filterBy: { operators: [ 'is' ] as Operator[] },
 				enableSorting: false,
 			},
 			{

--- a/projects/packages/forms/src/dashboard/hooks/use-forms-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-forms-data.ts
@@ -14,14 +14,21 @@ export type FormListItem = {
 /**
  * Build the query object for fetching Forms list records from core-data.
  *
- * @param page    - Current page number.
- * @param perPage - Items per page.
- * @param search  - Search term.
- * @param status  - REST `status` query param (comma-separated list or single status).
+ * @param page         - Current page number.
+ * @param perPage      - Items per page.
+ * @param search       - Search term.
+ * @param status       - REST `status` query param (comma-separated list or single status).
  *
+ * @param hasResponses - Filter by whether forms have responses ("true"/"false").
  * @return Query params for useEntityRecords / core-data.
  */
-export function getFormsListQuery( page: number, perPage: number, search: string, status: string ) {
+export function getFormsListQuery(
+	page: number,
+	perPage: number,
+	search: string,
+	status: string,
+	hasResponses?: string
+) {
 	const queryParams: Record< string, unknown > = {
 		context: 'edit',
 		jetpack_forms_context: 'dashboard',
@@ -34,6 +41,10 @@ export function getFormsListQuery( page: number, perPage: number, search: string
 
 	if ( search ) {
 		queryParams.search = search;
+	}
+
+	if ( hasResponses ) {
+		queryParams.has_responses = hasResponses;
 	}
 
 	return queryParams;
@@ -58,22 +69,24 @@ type UseFormsDataReturn = {
 /**
  * Fetch Forms list records for the Forms dashboard table.
  *
- * @param page    - Current page number.
- * @param perPage - Items per page.
- * @param search  - Search term.
- * @param status  - REST `status` query param (comma-separated list or single status).
+ * @param page         - Current page number.
+ * @param perPage      - Items per page.
+ * @param search       - Search term.
+ * @param status       - REST `status` query param (comma-separated list or single status).
  *
+ * @param hasResponses - Filter by whether forms have responses ("true"/"false").
  * @return Forms list data for the current query.
  */
 export default function useFormsData(
 	page: number,
 	perPage: number,
 	search: string,
-	status: string
+	status: string,
+	hasResponses?: string
 ): UseFormsDataReturn {
 	const query = useMemo( () => {
-		return getFormsListQuery( page, perPage, search, status );
-	}, [ page, perPage, search, status ] );
+		return getFormsListQuery( page, perPage, search, status, hasResponses );
+	}, [ page, perPage, search, status, hasResponses ] );
 
 	const {
 		records: rawRecords,

--- a/projects/packages/forms/tests/js/dashboard/hooks/use-forms-data.test.js
+++ b/projects/packages/forms/tests/js/dashboard/hooks/use-forms-data.test.js
@@ -1,0 +1,54 @@
+import { describe, expect, it } from '@jest/globals';
+import { getFormsListQuery } from '../../../../src/dashboard/hooks/use-forms-data.ts';
+
+describe( 'getFormsListQuery', () => {
+	it( 'returns base query params without optional filters', () => {
+		const query = getFormsListQuery( 1, 20, '', 'publish' );
+
+		expect( query ).toEqual( {
+			context: 'edit',
+			jetpack_forms_context: 'dashboard',
+			order: 'desc',
+			orderby: 'modified',
+			page: 1,
+			per_page: 20,
+			status: 'publish',
+		} );
+	} );
+
+	it( 'includes search param when provided', () => {
+		const query = getFormsListQuery( 1, 20, 'contact', 'publish' );
+
+		expect( query.search ).toBe( 'contact' );
+	} );
+
+	it( 'does not include search param when empty', () => {
+		const query = getFormsListQuery( 1, 20, '', 'publish' );
+
+		expect( query ).not.toHaveProperty( 'search' );
+	} );
+
+	it( 'includes has_responses param when set to "true"', () => {
+		const query = getFormsListQuery( 1, 20, '', 'publish', 'true' );
+
+		expect( query.has_responses ).toBe( 'true' );
+	} );
+
+	it( 'includes has_responses param when set to "false"', () => {
+		const query = getFormsListQuery( 1, 20, '', 'publish', 'false' );
+
+		expect( query.has_responses ).toBe( 'false' );
+	} );
+
+	it( 'does not include has_responses param when undefined', () => {
+		const query = getFormsListQuery( 1, 20, '', 'publish', undefined );
+
+		expect( query ).not.toHaveProperty( 'has_responses' );
+	} );
+
+	it( 'does not include has_responses param when empty string', () => {
+		const query = getFormsListQuery( 1, 20, '', 'publish', '' );
+
+		expect( query ).not.toHaveProperty( 'has_responses' );
+	} );
+} );

--- a/projects/packages/forms/tests/php/contact-form/Jetpack_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Jetpack_Form_Endpoint_Test.php
@@ -326,6 +326,17 @@ class Jetpack_Form_Endpoint_Test extends TestCase {
 	}
 
 	/**
+	 * Create a WP_Query instance targeting the jetpack_form post type, for use in filter_by_responses tests.
+	 *
+	 * @return \WP_Query
+	 */
+	private function get_jetpack_form_query(): \WP_Query {
+		$query = new \WP_Query();
+		$query->set( 'post_type', Contact_Form::POST_TYPE );
+		return $query;
+	}
+
+	/**
 	 * Test that the has_responses REST parameter is registered in collection params.
 	 */
 	public function test_has_responses_param_is_registered() {
@@ -350,7 +361,7 @@ class Jetpack_Form_Endpoint_Test extends TestCase {
 		$endpoint = new Jetpack_Form_Endpoint();
 		$this->set_has_responses_filter( $endpoint, true );
 
-		$clauses = $endpoint->filter_by_responses( array( 'where' => '' ) );
+		$clauses = $endpoint->filter_by_responses( array( 'where' => '' ), $this->get_jetpack_form_query() );
 
 		$this->assertStringContainsString( 'EXISTS', $clauses['where'] );
 		$this->assertStringNotContainsString( 'NOT EXISTS', $clauses['where'] );
@@ -367,7 +378,7 @@ class Jetpack_Form_Endpoint_Test extends TestCase {
 		$endpoint = new Jetpack_Form_Endpoint();
 		$this->set_has_responses_filter( $endpoint, false );
 
-		$clauses = $endpoint->filter_by_responses( array( 'where' => '' ) );
+		$clauses = $endpoint->filter_by_responses( array( 'where' => '' ), $this->get_jetpack_form_query() );
 
 		$this->assertStringContainsString( 'NOT EXISTS', $clauses['where'] );
 		$this->assertStringContainsString( 'feedback', $clauses['where'] );
@@ -383,7 +394,7 @@ class Jetpack_Form_Endpoint_Test extends TestCase {
 		$endpoint = new Jetpack_Form_Endpoint();
 		$this->set_has_responses_filter( $endpoint, true );
 
-		$clauses = $endpoint->filter_by_responses( array( 'where' => '' ) );
+		$clauses = $endpoint->filter_by_responses( array( 'where' => '' ), $this->get_jetpack_form_query() );
 
 		$this->assertStringContainsString( "'publish'", $clauses['where'] );
 		$this->assertStringContainsString( "'draft'", $clauses['where'] );
@@ -399,7 +410,7 @@ class Jetpack_Form_Endpoint_Test extends TestCase {
 		$this->set_has_responses_filter( $endpoint, true );
 
 		$existing_where = "AND post_type = 'jetpack_form'";
-		$clauses        = $endpoint->filter_by_responses( array( 'where' => $existing_where ) );
+		$clauses        = $endpoint->filter_by_responses( array( 'where' => $existing_where ), $this->get_jetpack_form_query() );
 
 		$this->assertStringContainsString( $existing_where, $clauses['where'] );
 		$this->assertStringContainsString( 'EXISTS', $clauses['where'] );

--- a/projects/packages/forms/tests/php/contact-form/Jetpack_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Jetpack_Form_Endpoint_Test.php
@@ -321,6 +321,7 @@ class Jetpack_Form_Endpoint_Test extends TestCase {
 	 */
 	private function set_has_responses_filter( Jetpack_Form_Endpoint $endpoint, bool $value ): void {
 		$ref = new \ReflectionProperty( Jetpack_Form_Endpoint::class, 'has_responses_filter' );
+		$ref->setAccessible( true );
 		$ref->setValue( $endpoint, $value );
 	}
 

--- a/projects/packages/forms/tests/php/contact-form/Jetpack_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Jetpack_Form_Endpoint_Test.php
@@ -321,7 +321,6 @@ class Jetpack_Form_Endpoint_Test extends TestCase {
 	 */
 	private function set_has_responses_filter( Jetpack_Form_Endpoint $endpoint, bool $value ): void {
 		$ref = new \ReflectionProperty( Jetpack_Form_Endpoint::class, 'has_responses_filter' );
-		$ref->setAccessible( true );
 		$ref->setValue( $endpoint, $value );
 	}
 

--- a/projects/packages/forms/tests/php/contact-form/Jetpack_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Jetpack_Form_Endpoint_Test.php
@@ -68,8 +68,9 @@ class Jetpack_Form_Endpoint_Test extends TestCase {
 		unset( $_SERVER['REQUEST_METHOD'] );
 		$_GET = array();
 
-		// Unregister the post type if it was registered
+		// Unregister the post types if they were registered
 		unregister_post_type( 'jetpack_form' );
+		unregister_post_type( 'feedback' );
 	}
 
 	/**
@@ -310,6 +311,98 @@ class Jetpack_Form_Endpoint_Test extends TestCase {
 		$this->assertEquals( 'edit_posts', $post_type_object->cap->read, 'Read capability should be edit_posts' );
 		$this->assertEquals( 'publish_posts', $post_type_object->cap->create_posts, 'Create capability should be publish_posts' );
 		$this->assertEquals( 'edit_posts', $post_type_object->cap->edit_posts, 'Edit posts capability should be edit_posts' );
+	}
+
+	/**
+	 * Set the private has_responses_filter property on the endpoint via reflection.
+	 *
+	 * @param Jetpack_Form_Endpoint $endpoint The endpoint instance.
+	 * @param bool                  $value    The filter value.
+	 */
+	private function set_has_responses_filter( Jetpack_Form_Endpoint $endpoint, bool $value ): void {
+		$ref = new \ReflectionProperty( Jetpack_Form_Endpoint::class, 'has_responses_filter' );
+		$ref->setAccessible( true );
+		$ref->setValue( $endpoint, $value );
+	}
+
+	/**
+	 * Test that the has_responses REST parameter is registered in collection params.
+	 */
+	public function test_has_responses_param_is_registered() {
+		Contact_Form::register_post_type();
+
+		$endpoint = new Jetpack_Form_Endpoint();
+		$params   = $endpoint->get_collection_params();
+
+		$this->assertArrayHasKey( 'has_responses', $params );
+		$this->assertEquals( 'string', $params['has_responses']['type'] );
+		$this->assertContains( 'true', $params['has_responses']['enum'] );
+		$this->assertContains( 'false', $params['has_responses']['enum'] );
+		$this->assertSame( '', $params['has_responses']['default'] );
+	}
+
+	/**
+	 * Test that filter_by_responses adds an EXISTS subquery when has_responses_filter is true.
+	 */
+	public function test_filter_by_responses_adds_exists_clause() {
+		Contact_Form::register_post_type();
+
+		$endpoint = new Jetpack_Form_Endpoint();
+		$this->set_has_responses_filter( $endpoint, true );
+
+		$clauses = $endpoint->filter_by_responses( array( 'where' => '' ) );
+
+		$this->assertStringContainsString( 'EXISTS', $clauses['where'] );
+		$this->assertStringNotContainsString( 'NOT EXISTS', $clauses['where'] );
+		$this->assertStringContainsString( 'feedback', $clauses['where'] );
+		$this->assertStringContainsString( 'post_parent', $clauses['where'] );
+	}
+
+	/**
+	 * Test that filter_by_responses adds a NOT EXISTS subquery when has_responses_filter is false.
+	 */
+	public function test_filter_by_responses_adds_not_exists_clause() {
+		Contact_Form::register_post_type();
+
+		$endpoint = new Jetpack_Form_Endpoint();
+		$this->set_has_responses_filter( $endpoint, false );
+
+		$clauses = $endpoint->filter_by_responses( array( 'where' => '' ) );
+
+		$this->assertStringContainsString( 'NOT EXISTS', $clauses['where'] );
+		$this->assertStringContainsString( 'feedback', $clauses['where'] );
+		$this->assertStringContainsString( 'post_parent', $clauses['where'] );
+	}
+
+	/**
+	 * Test that filter_by_responses only checks publish and draft feedback statuses.
+	 */
+	public function test_filter_by_responses_checks_publish_and_draft_statuses() {
+		Contact_Form::register_post_type();
+
+		$endpoint = new Jetpack_Form_Endpoint();
+		$this->set_has_responses_filter( $endpoint, true );
+
+		$clauses = $endpoint->filter_by_responses( array( 'where' => '' ) );
+
+		$this->assertStringContainsString( "'publish'", $clauses['where'] );
+		$this->assertStringContainsString( "'draft'", $clauses['where'] );
+	}
+
+	/**
+	 * Test that filter_by_responses preserves existing where clauses.
+	 */
+	public function test_filter_by_responses_preserves_existing_where() {
+		Contact_Form::register_post_type();
+
+		$endpoint = new Jetpack_Form_Endpoint();
+		$this->set_has_responses_filter( $endpoint, true );
+
+		$existing_where = "AND post_type = 'jetpack_form'";
+		$clauses        = $endpoint->filter_by_responses( array( 'where' => $existing_where ) );
+
+		$this->assertStringContainsString( $existing_where, $clauses['where'] );
+		$this->assertStringContainsString( 'EXISTS', $clauses['where'] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes FORMS-NEW

## Proposed changes

* Remove the modified date filter from the forms dashboard (both wp-build and React Router views) by setting `filterBy: false` on the modified field
* Add a new "Responses" filter on the entries field with "Has responses" / "No responses" options for filtering forms by whether they have feedback entries
* Add `has_responses` REST API parameter to the `jetpack-forms` endpoint that uses an `EXISTS`/`NOT EXISTS` subquery to filter server-side, ensuring correct results with pagination
* Add PHP tests verifying the SQL clause generation and parameter registration
* Add JS tests verifying the `getFormsListQuery` function correctly builds query params

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Go to the Jetpack Forms dashboard (wp-admin → Jetpack → Forms)
* Verify the "Last updated" column no longer shows a date filter dropdown
* Look for the "Responses" filter option (click "Add filter" or the filters toggle)
* Select "Has responses" — verify only forms with at least one response are shown
* Select "No responses" — verify only forms with zero responses are shown
* Clear the filter — verify all forms are shown again
* Verify the entries count column still displays the correct numeric count for each form
* Test pagination works correctly when the filter is active (forms on page 2+ should still respect the filter)
