### PR TITLE
Forms: Show 'No results found' when filters yield no forms

### DIFF
--- a/projects/packages/forms/changelog/fix-empty-state-filters
+++ b/projects/packages/forms/changelog/fix-empty-state-filters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Show 'No results found' empty state when search or filters are active in the forms list view instead of the onboarding empty state.

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -23,7 +23,7 @@ import * as React from 'react';
 import IntegrationsModal from '../../src/blocks/contact-form/components/jetpack-integrations-modal';
 import { FORM_POST_TYPE } from '../../src/blocks/shared/util/constants.js';
 import CreateFormButton from '../../src/dashboard/components/create-form-button/index.tsx';
-import { EmptyWrapper } from '../../src/dashboard/components/empty-responses/index.tsx';
+import { EmptyWrapper, NoResults } from '../../src/dashboard/components/empty-responses/index.tsx';
 import { FormNameModal } from '../../src/dashboard/components/form-name-modal';
 import { NON_TRASH_FORM_STATUSES, getFormStatusLabel } from '../../src/dashboard/constants';
 import useDeleteForm from '../../src/dashboard/hooks/use-delete-form.ts';
@@ -506,9 +506,7 @@ function StageInner() {
 	const hasActiveFilters =
 		!! view.search ||
 		( () => {
-			const statusFilterValue = view.filters?.find(
-				( filter ) => filter.field === 'status'
-			)?.value;
+			const statusFilterValue = view.filters?.find( filter => filter.field === 'status' )?.value;
 			return !! statusFilterValue && statusFilterValue !== 'all';
 		} )();
 
@@ -537,13 +535,7 @@ function StageInner() {
 				isLoading={ isLoading }
 				empty={
 					hasActiveFilters ? (
-						<EmptyWrapper
-							heading={ __( 'No results found', 'jetpack-forms' ) }
-							body={ __(
-								"Try adjusting your search or filters to find what you're looking for.",
-								'jetpack-forms'
-							) }
-						/>
+						<NoResults />
 					) : (
 						<EmptyWrapper
 							heading={ __( "You're set up. No forms yet.", 'jetpack-forms' ) }

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -503,13 +503,14 @@ function StageInner() {
 		onOpenIntegrations: openIntegrationsModal,
 		onOpenFormsHelp: openFormsHelpModal,
 	} );
-	const hasActiveFilters = useMemo( () => {
-		if ( view.search ) {
-			return true;
-		}
-		const statusFilterValue = view.filters?.find( filter => filter.field === 'status' )?.value;
-		return !! statusFilterValue && statusFilterValue !== 'all';
-	}, [ view.search, view.filters ] );
+	const hasActiveFilters =
+		!! view.search ||
+		( () => {
+			const statusFilterValue = view.filters?.find(
+				( filter ) => filter.field === 'status'
+			)?.value;
+			return !! statusFilterValue && statusFilterValue !== 'all';
+		} )();
 
 	const getItemId = useCallback( ( item: FormListItem ) => String( item.id ), [] );
 	const onClickItem = useCallback(

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -503,12 +503,9 @@ function StageInner() {
 		onOpenIntegrations: openIntegrationsModal,
 		onOpenFormsHelp: openFormsHelpModal,
 	} );
+	const statusFilterValue = view.filters?.find( filter => filter.field === 'status' )?.value;
 	const hasActiveFilters =
-		!! view.search ||
-		( () => {
-			const statusFilterValue = view.filters?.find( filter => filter.field === 'status' )?.value;
-			return !! statusFilterValue && statusFilterValue !== 'all';
-		} )();
+		!! view.search?.trim() || ( !! statusFilterValue && statusFilterValue !== 'all' );
 
 	const getItemId = useCallback( ( item: FormListItem ) => String( item.id ), [] );
 	const onClickItem = useCallback(

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -503,6 +503,14 @@ function StageInner() {
 		onOpenIntegrations: openIntegrationsModal,
 		onOpenFormsHelp: openFormsHelpModal,
 	} );
+	const hasActiveFilters = useMemo( () => {
+		if ( view.search ) {
+			return true;
+		}
+		const statusFilterValue = view.filters?.find( filter => filter.field === 'status' )?.value;
+		return !! statusFilterValue && statusFilterValue !== 'all';
+	}, [ view.search, view.filters ] );
+
 	const getItemId = useCallback( ( item: FormListItem ) => String( item.id ), [] );
 	const onClickItem = useCallback(
 		( item: FormListItem ) => {
@@ -527,25 +535,35 @@ function StageInner() {
 				data={ records || [] }
 				isLoading={ isLoading }
 				empty={
-					<EmptyWrapper
-						heading={ __( "You're set up. No forms yet.", 'jetpack-forms' ) }
-						body={ __(
-							'Create a shared form pattern to manage and reuse it across your site.',
-							'jetpack-forms'
-						) }
-						actions={
-							<HStack justify="center" spacing="2">
-								<CreateFormButton
-									label={ __( 'Create a new form', 'jetpack-forms' ) }
-									variant="primary"
-									showIcon={ false }
-								/>
-								<Button size="compact" variant="secondary" onClick={ openFormsHelpModal }>
-									{ __( 'Missing forms?', 'jetpack-forms' ) }
-								</Button>
-							</HStack>
-						}
-					/>
+					hasActiveFilters ? (
+						<EmptyWrapper
+							heading={ __( 'No results found', 'jetpack-forms' ) }
+							body={ __(
+								"Try adjusting your search or filters to find what you're looking for.",
+								'jetpack-forms'
+							) }
+						/>
+					) : (
+						<EmptyWrapper
+							heading={ __( "You're set up. No forms yet.", 'jetpack-forms' ) }
+							body={ __(
+								'Create a shared form pattern to manage and reuse it across your site.',
+								'jetpack-forms'
+							) }
+							actions={
+								<HStack justify="center" spacing="2">
+									<CreateFormButton
+										label={ __( 'Create a new form', 'jetpack-forms' ) }
+										variant="primary"
+										showIcon={ false }
+									/>
+									<Button size="compact" variant="secondary" onClick={ openFormsHelpModal }>
+										{ __( 'Missing forms?', 'jetpack-forms' ) }
+									</Button>
+								</HStack>
+							}
+						/>
+					)
 				}
 				view={ view }
 				onChangeView={ onChangeView }

--- a/projects/packages/forms/src/dashboard/components/empty-responses/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/empty-responses/index.tsx
@@ -164,6 +164,16 @@ export const EmptyWrapper = ( { heading = '', body = '', actions = null }: Empty
 	</VStack>
 );
 
+export const NoResults = () => (
+	<EmptyWrapper
+		heading={ __( 'No results found', 'jetpack-forms' ) }
+		body={ __(
+			"Try adjusting your search or filters to find what you're looking for.",
+			'jetpack-forms'
+		) }
+	/>
+);
+
 const EmptyResponses = ( {
 	isSearch,
 	isSingleFormView = false,
@@ -182,13 +192,8 @@ const EmptyResponses = ( {
 
 	// Handle search and filter states first
 	const hasReadStatusFilter = !! readStatusFilter;
-	const searchHeading = __( 'No results found', 'jetpack-forms' );
-	const searchMessage = __(
-		"Try adjusting your search or filters to find what you're looking for.",
-		'jetpack-forms'
-	);
 	if ( isSearch || hasReadStatusFilter ) {
-		return <EmptyWrapper heading={ searchHeading } body={ searchMessage } />;
+		return <NoResults />;
 	}
 
 	const noTrashHeading = __( 'Trash is empty', 'jetpack-forms' );


### PR DESCRIPTION
Fixes FORMS-NEW

## Proposed changes
* Show "No results found" empty state when search or status filters are active in the forms list view, instead of the onboarding "You're set up. No forms yet." empty state.
* Adds a `hasActiveFilters` memo that detects non-default search or status filter values.
* Uses the same `EmptyWrapper` component and wording ("No results found" / "Try adjusting your search or filters") already used in the responses view.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Go to the Jetpack Forms dashboard (Forms list view).
* With no forms created, verify you see the onboarding empty state: "You're set up. No forms yet." with the "Create a new form" button.
* Type a search query in the search box — verify the empty state changes to "No results found" / "Try adjusting your search or filters to find what you're looking for."
* Clear the search, then change the status filter to a specific status (e.g., "Draft") — verify the same "No results found" message appears.
* Set the status filter back to "All" and clear search — verify the onboarding empty state returns.
