### PR TITLE
Forms: Hide Browse form patterns button when central form management is enabled

### DIFF
--- a/projects/packages/forms/changelog/fix-form-editor-placeholder-button
+++ b/projects/packages/forms/changelog/fix-form-editor-placeholder-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Hide "Browse form patterns" button in the form placeholder when central form management is enabled

--- a/projects/packages/forms/src/blocks/contact-form/variation-picker.js
+++ b/projects/packages/forms/src/blocks/contact-form/variation-picker.js
@@ -91,10 +91,17 @@ export default function VariationPicker( { blockName, setAttributes, clientId, c
 			<BlockVariationPicker
 				icon={ blockType?.icon?.src }
 				label={ blockType?.title }
-				instructions={ __(
-					'Start by selecting one of these templates, browse patterns, or select an existing form below.',
-					'jetpack-forms'
-				) }
+				instructions={
+					isCentralFormManagementEnabled
+						? __(
+								'Start by selecting one of these templates or select an existing form below.',
+								'jetpack-forms'
+						  )
+						: __(
+								'Start by selecting one of these templates, browse patterns, or select an existing form below.',
+								'jetpack-forms'
+						  )
+				}
 				variations={ variations.filter( v => ! v.hiddenFromPicker ) }
 				onSelect={ async ( nextVariation = defaultVariation ) => {
 					// If we're editing a jetpack-form post directly, or central form management
@@ -164,15 +171,17 @@ export default function VariationPicker( { blockName, setAttributes, clientId, c
 					}
 				} }
 			/>
-			<div className="form-placeholder__shell">
-				<Button
-					__next40pxDefaultSize
-					variant="secondary"
-					onClick={ () => setIsPatternsModalOpen( true ) }
-				>
-					{ __( 'Browse form patterns', 'jetpack-forms' ) }
-				</Button>
-			</div>
+			{ ! isCentralFormManagementEnabled && (
+				<div className="form-placeholder__shell">
+					<Button
+						__next40pxDefaultSize
+						variant="secondary"
+						onClick={ () => setIsPatternsModalOpen( true ) }
+					>
+						{ __( 'Browse form patterns', 'jetpack-forms' ) }
+					</Button>
+				</div>
+			) }
 			{ ! isEditingJetpackFormPost && isCentralFormManagementEnabled && jetpackForms.length > 0 && (
 				<div className="form-placeholder__shell">
 					<SelectControl

--- a/projects/packages/forms/src/blocks/contact-form/variation-picker.js
+++ b/projects/packages/forms/src/blocks/contact-form/variation-picker.js
@@ -86,32 +86,33 @@ export default function VariationPicker( { blockName, setAttributes, clientId, c
 		} );
 	};
 
+	const hasExistingForms = jetpackForms && jetpackForms.length > 0;
+
+	const getInstructions = () => {
+		if ( isCentralFormManagementEnabled && hasExistingForms ) {
+			return __(
+				'Start by selecting one of these templates or select an existing form below.',
+				'jetpack-forms'
+			);
+		}
+		if ( isCentralFormManagementEnabled ) {
+			return __( 'Start by selecting one of these templates.', 'jetpack-forms' );
+		}
+		if ( hasExistingForms ) {
+			return __(
+				'Start by selecting one of these templates, browse patterns, or select an existing form below.',
+				'jetpack-forms'
+			);
+		}
+		return __( 'Start by selecting one of these templates or browse patterns.', 'jetpack-forms' );
+	};
+
 	return (
 		<div className={ clsx( classNames, 'is-placeholder' ) }>
 			<BlockVariationPicker
 				icon={ blockType?.icon?.src }
 				label={ blockType?.title }
-				instructions={
-					isCentralFormManagementEnabled
-						? ( jetpackForms && jetpackForms.length > 0
-								? __(
-										'Start by selecting one of these templates or select an existing form below.',
-										'jetpack-forms'
-								  )
-								: __(
-										'Start by selecting one of these templates.',
-										'jetpack-forms'
-								  ) )
-						: ( jetpackForms && jetpackForms.length > 0
-								? __(
-										'Start by selecting one of these templates, browse patterns, or select an existing form below.',
-										'jetpack-forms'
-								  )
-								: __(
-										'Start by selecting one of these templates or browse patterns.',
-										'jetpack-forms'
-								  ) )
-				}
+				instructions={ getInstructions() }
 				variations={ variations.filter( v => ! v.hiddenFromPicker ) }
 				onSelect={ async ( nextVariation = defaultVariation ) => {
 					// If we're editing a jetpack-form post directly, or central form management

--- a/projects/packages/forms/src/blocks/contact-form/variation-picker.js
+++ b/projects/packages/forms/src/blocks/contact-form/variation-picker.js
@@ -93,14 +93,24 @@ export default function VariationPicker( { blockName, setAttributes, clientId, c
 				label={ blockType?.title }
 				instructions={
 					isCentralFormManagementEnabled
-						? __(
-								'Start by selecting one of these templates or select an existing form below.',
-								'jetpack-forms'
-						  )
-						: __(
-								'Start by selecting one of these templates, browse patterns, or select an existing form below.',
-								'jetpack-forms'
-						  )
+						? ( jetpackForms && jetpackForms.length > 0
+								? __(
+										'Start by selecting one of these templates or select an existing form below.',
+										'jetpack-forms'
+								  )
+								: __(
+										'Start by selecting one of these templates.',
+										'jetpack-forms'
+								  ) )
+						: ( jetpackForms && jetpackForms.length > 0
+								? __(
+										'Start by selecting one of these templates, browse patterns, or select an existing form below.',
+										'jetpack-forms'
+								  )
+								: __(
+										'Start by selecting one of these templates or browse patterns.',
+										'jetpack-forms'
+								  ) )
 				}
 				variations={ variations.filter( v => ! v.hiddenFromPicker ) }
 				onSelect={ async ( nextVariation = defaultVariation ) => {

--- a/projects/packages/forms/src/blocks/contact-form/variation-picker.js
+++ b/projects/packages/forms/src/blocks/contact-form/variation-picker.js
@@ -88,8 +88,11 @@ export default function VariationPicker( { blockName, setAttributes, clientId, c
 
 	const hasExistingForms = jetpackForms && jetpackForms.length > 0;
 
+	const showFormPicker =
+		! isEditingJetpackFormPost && isCentralFormManagementEnabled && hasExistingForms;
+
 	const getInstructions = () => {
-		if ( isCentralFormManagementEnabled && hasExistingForms ) {
+		if ( isCentralFormManagementEnabled && showFormPicker ) {
 			return __(
 				'Start by selecting one of these templates or select an existing form below.',
 				'jetpack-forms'
@@ -193,7 +196,7 @@ export default function VariationPicker( { blockName, setAttributes, clientId, c
 					</Button>
 				</div>
 			) }
-			{ ! isEditingJetpackFormPost && isCentralFormManagementEnabled && jetpackForms.length > 0 && (
+			{ showFormPicker && (
 				<div className="form-placeholder__shell">
 					<SelectControl
 						__next40pxDefaultSize

--- a/projects/packages/forms/src/blocks/contact-form/variation-picker.js
+++ b/projects/packages/forms/src/blocks/contact-form/variation-picker.js
@@ -92,22 +92,32 @@ export default function VariationPicker( { blockName, setAttributes, clientId, c
 		! isEditingJetpackFormPost && isCentralFormManagementEnabled && hasExistingForms;
 
 	const getInstructions = () => {
+		// Each translated string is assigned to a variable to prevent the minifier
+		// from collapsing them into a single __() call with a ternary argument,
+		// which breaks the i18n string literal requirement.
 		if ( isCentralFormManagementEnabled && showFormPicker ) {
-			return __(
+			const msg = __(
 				'Start by selecting one of these templates or select an existing form below.',
 				'jetpack-forms'
 			);
+			return msg;
 		}
 		if ( isCentralFormManagementEnabled ) {
-			return __( 'Start by selecting one of these templates.', 'jetpack-forms' );
+			const msg = __( 'Start by selecting one of these templates.', 'jetpack-forms' );
+			return msg;
 		}
 		if ( hasExistingForms ) {
-			return __(
+			const msg = __(
 				'Start by selecting one of these templates, browse patterns, or select an existing form below.',
 				'jetpack-forms'
 			);
+			return msg;
 		}
-		return __( 'Start by selecting one of these templates or browse patterns.', 'jetpack-forms' );
+		const msg = __(
+			'Start by selecting one of these templates or browse patterns.',
+			'jetpack-forms'
+		);
+		return msg;
 	};
 
 	return (


### PR DESCRIPTION
Fixes FORMS-NEW

Before:

<img width="862" height="439" alt="Screenshot 2026-03-09 at 2 26 06 PM" src="https://github.com/user-attachments/assets/24a8e6fb-f609-43d0-9e14-29e82f1240ea" />


After:

<img width="848" height="365" alt="Screenshot 2026-03-09 at 2 26 12 PM" src="https://github.com/user-attachments/assets/325b435f-b60c-45eb-9a04-e61e7d019001" />



## Proposed changes
* Hide the "Browse form patterns" button in the form editor placeholder when central form management is enabled, since the button doesn't work in that mode.
* Update the placeholder instructions text to remove the "browse patterns" mention when central form management is enabled.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Enable the `central-form-management` feature flag.
* Edit a post or page and add a new Jetpack Form block.
* Verify that the "Browse form patterns" button is **not** shown in the placeholder.
* Verify that the instructions text says "Start by selecting one of these templates or select an existing form below."
* Disable the `central-form-management` feature flag.
* Add a new Jetpack Form block again.
* Verify that the "Browse form patterns" button **is** shown.
* Verify that the instructions text includes "browse patterns".
