### PR TITLE
Form Editor: Hide word count and reading time panel

### DIFF
--- a/projects/packages/forms/changelog/hide-post-content-information
+++ b/projects/packages/forms/changelog/hide-post-content-information
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Form Editor: Hide word count and reading time panel

--- a/projects/packages/forms/src/form-editor/style.scss
+++ b/projects/packages/forms/src/form-editor/style.scss
@@ -8,6 +8,7 @@
 	padding-block-end: 48px;
 }
 
-.post-type-jetpack_form .editor-post-last-edited-panel {
+.post-type-jetpack_form .editor-post-last-edited-panel,
+.post-type-jetpack_form .editor-post-content-information {
 	display: none;
 }


### PR DESCRIPTION
Fixes [FORMS-613](https://linear.app/a8c/issue/FORMS-613/hide-word-count-and-reading-time-panel-in-form-editor)

Before:

<img width="296" height="281" alt="Screenshot 2026-03-09 at 2 40 59 PM" src="https://github.com/user-attachments/assets/1b1863d8-bbf9-4779-abab-30c082173763" />

After:

<img width="308" height="307" alt="Screenshot 2026-03-09 at 2 37 10 PM" src="https://github.com/user-attachments/assets/5b5d0e36-482d-4c06-ab45-b7b82ae8018b" />


## Proposed changes

* Hide the `editor-post-content-information` panel (word count / reading time) in the Jetpack Form Editor, as it is not relevant for forms.
* Follows the existing pattern used to hide the `editor-post-last-edited-panel`.

### Other information

- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Open the Jetpack Form Editor (create or edit a `jetpack_form` post type).
* Open the sidebar and verify that the word count / reading time info is no longer displayed.
* Open a regular post editor and verify the word count / reading time info is still visible.
