### PR TITLE
Forms: Link View Form Responses button to form-specific responses

### DIFF
--- a/projects/packages/forms/changelog/fix-view-form-responses-button
+++ b/projects/packages/forms/changelog/fix-view-form-responses-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update 'View form responses' button to link to the specific form's responses when the form has a ref.

--- a/projects/packages/forms/src/blocks/shared/components/jetpack-manage-responses-settings.js
+++ b/projects/packages/forms/src/blocks/shared/components/jetpack-manage-responses-settings.js
@@ -1,6 +1,6 @@
 import { Button, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { getResponsesUrl } from '../../../form-editor/plugins/utils';
+import { getResponsesUrl } from '../../../form-editor/plugins/utils.ts';
 import { FULL_RESPONSES_PATH } from '../../../util/get-preferred-responses-view.js';
 
 const JetpackManageResponsesSettings = ( { attributes, setAttributes } ) => {

--- a/projects/packages/forms/src/blocks/shared/components/jetpack-manage-responses-settings.js
+++ b/projects/packages/forms/src/blocks/shared/components/jetpack-manage-responses-settings.js
@@ -1,22 +1,12 @@
 import { Button, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { addQueryArgs } from '@wordpress/url';
+import { getResponsesUrl } from '../../../form-editor/plugins/utils';
 import { FULL_RESPONSES_PATH } from '../../../util/get-preferred-responses-view.js';
-
-const getResponsesHref = ref => {
-	const baseUrl = window.jpFormsBlocks?.defaults?.formsResponsesUrl || FULL_RESPONSES_PATH;
-
-	if ( ref ) {
-		return addQueryArgs( baseUrl, { p: `/responses/inbox?sourceId=${ ref }` } );
-	}
-
-	return baseUrl;
-};
 
 const JetpackManageResponsesSettings = ( { attributes, setAttributes } ) => {
 	const { saveResponses = true, ref } = attributes;
 
-	const responsesHref = getResponsesHref( ref );
+	const responsesHref = ref ? getResponsesUrl( ref ) : FULL_RESPONSES_PATH;
 
 	return (
 		<>

--- a/projects/packages/forms/src/blocks/shared/components/jetpack-manage-responses-settings.js
+++ b/projects/packages/forms/src/blocks/shared/components/jetpack-manage-responses-settings.js
@@ -1,9 +1,22 @@
 import { Button, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 import { FULL_RESPONSES_PATH } from '../../../util/get-preferred-responses-view.js';
 
+const getResponsesHref = ref => {
+	const baseUrl = window.jpFormsBlocks?.defaults?.formsResponsesUrl || FULL_RESPONSES_PATH;
+
+	if ( ref ) {
+		return addQueryArgs( baseUrl, { p: `/responses/inbox?sourceId=${ ref }` } );
+	}
+
+	return baseUrl;
+};
+
 const JetpackManageResponsesSettings = ( { attributes, setAttributes } ) => {
-	const { saveResponses = true } = attributes;
+	const { saveResponses = true, ref } = attributes;
+
+	const responsesHref = getResponsesHref( ref );
 
 	return (
 		<>
@@ -18,7 +31,7 @@ const JetpackManageResponsesSettings = ( { attributes, setAttributes } ) => {
 				__nextHasNoMarginBottom={ true }
 			/>
 			{ saveResponses && (
-				<Button variant="secondary" href={ FULL_RESPONSES_PATH } __next40pxDefaultSize={ true }>
+				<Button variant="secondary" href={ responsesHref } __next40pxDefaultSize={ true }>
 					{ __( 'View form responses', 'jetpack-forms' ) }
 				</Button>
 			) }


### PR DESCRIPTION
Fixes FORMS-NEW

## Proposed changes
* Update the "View form responses" button in the contact form block's Responses Storage panel to link directly to the specific form's responses view when the form has a `ref` (synced form ID).
* Uses `addQueryArgs` with the `sourceId` parameter, consistent with how `getResponsesUrl` works in the form editor.
* Falls back to the general responses page when no `ref` is present.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Open the block editor and add or select a Contact Form block.
* In the block's sidebar settings, open the **Responses storage** panel.
* Ensure **Save responses** is toggled on so the "View form responses" button appears.
* For a **synced form** (one with a `ref` attribute — e.g., a form created via the Forms dashboard):
  * Verify the "View form responses" button links to the form-specific responses view (URL should contain `sourceId=<form_id>`).
* For a **non-synced form** (no `ref` attribute — e.g., a freshly inserted form block):
  * Verify the button links to the general responses page as before.
