### PR TITLE
Forms: Fix HTML entities in form title on pre-publish panel

### DIFF
--- a/projects/packages/forms/changelog/fix-form-title-html-entities
+++ b/projects/packages/forms/changelog/fix-form-title-html-entities
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix HTML entities not being decoded in form title on pre-publish panel

--- a/projects/packages/forms/src/form-editor/plugins/form-pre-publish-panel.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/form-pre-publish-panel.tsx
@@ -11,6 +11,7 @@ import {
 import { useSelect, useDispatch } from '@wordpress/data';
 import { PluginPrePublishPanel, store as editorStore } from '@wordpress/editor';
 import { useCallback, useMemo, useState } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
 import { __, _n, _nx, _x, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 /**
@@ -278,7 +279,7 @@ export const FormPrePublishPanel = () => {
 					{ formBlockSettings.icon.src() }
 				</span>
 				<span className="jetpack-form-pre-publish__form-title">
-					{ postTitle || __( 'Untitled Form', 'jetpack-forms' ) }
+					{ decodeEntities( postTitle ) || __( 'Untitled Form', 'jetpack-forms' ) }
 				</span>
 			</div>
 			<Button


### PR DESCRIPTION
Fixes FORMS-NEW

Before:

<img width="292" height="218" alt="Screenshot 2026-03-09 at 3 11 22 PM" src="https://github.com/user-attachments/assets/09d7f641-899b-40e7-a7d6-ab3bd5f16903" />


After:

<img width="289" height="230" alt="Screenshot 2026-03-09 at 3 11 52 PM" src="https://github.com/user-attachments/assets/cf0273d8-e65b-4f7c-85d1-292cd8840d28" />


## Proposed changes
* Fix HTML entities (e.g. `&amp;` → `&`) not being decoded in the form title displayed on the pre-publish sidebar panel.
* Uses `decodeEntities` from `@wordpress/html-entities` to properly render the post title.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Create or edit a Jetpack Form with a title containing special characters like `&` (e.g. "howdy & this").
* Click the "Publish" button to open the pre-publish sidebar.
* Verify the form title displays correctly (e.g. "howdy & this") instead of showing HTML entities (e.g. "howdy &amp; this").
