### PR TITLE
Forms: Purge edge cache on jetpack_form publish/update/unpublish

### DIFF
--- a/projects/packages/forms/changelog/fix-reset-site-cache-on-form-update
+++ b/projects/packages/forms/changelog/fix-reset-site-cache-on-form-update
@@ -1,4 +1,4 @@
 Significance: patch
-Type: added
+Type: fixed
 
 Purge edge cache when a jetpack_form post is published, updated, or unpublished.

--- a/projects/packages/forms/changelog/fix-reset-site-cache-on-form-update
+++ b/projects/packages/forms/changelog/fix-reset-site-cache-on-form-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Purge edge cache when a jetpack_form post is published, updated, or unpublished.

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -3728,6 +3728,9 @@ class Contact_Form_Plugin {
 		if ( 'publish' === $new_status || 'publish' === $old_status ) {
 			/**
 			 * Fires when the edge cache for the entire domain should be purged.
+			 *
+			 * This action is handled by the WordPress.com hosting platform
+			 * and has no effect in self-hosted WordPress environments.
 			 */
 			do_action( 'edge_cache_purge_domain' );
 		}

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -326,6 +326,9 @@ class Contact_Form_Plugin {
 		// Track when post status changes to feedback posts types.
 		add_action( 'transition_post_status', array( $this, 'track_feedback_status_change' ), 10, 3 );
 
+		// Purge edge cache when a jetpack_form post is published, updated, or unpublished.
+		add_action( 'transition_post_status', array( $this, 'purge_edge_cache_on_form_status_change' ), 10, 3 );
+
 		// POST handler
 		if (
 			isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === strtoupper( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) )
@@ -3704,6 +3707,30 @@ class Contact_Form_Plugin {
 		}
 		$this->track_spam_status( $new_status, $old_status, $post->ID );
 		$this->track_recount_unread( $new_status, $old_status, $post );
+	}
+
+	/**
+	 * Purges the edge cache when a jetpack_form post is published, updated while published, or unpublished.
+	 *
+	 * @param string       $new_status The new post status.
+	 * @param string       $old_status The old post status.
+	 * @param WP_Post|null $post       The post object, when available.
+	 */
+	public function purge_edge_cache_on_form_status_change( $new_status, $old_status, ?WP_Post $post = null ) {
+		if ( ! $post instanceof WP_Post ) {
+			return;
+		}
+
+		if ( Contact_Form::POST_TYPE !== $post->post_type ) {
+			return;
+		}
+
+		if ( 'publish' === $new_status || 'publish' === $old_status ) {
+			/**
+			 * Fires when the edge cache for the entire domain should be purged.
+			 */
+			do_action( 'edge_cache_purge_domain' );
+		}
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -1506,4 +1506,70 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$spam_meta = get_post_meta( $post_id, '_spam_status_changed_gmt', true );
 		$this->assertEmpty( $spam_meta, 'Spam meta should not be set for non-feedback posts' );
 	}
+
+	/**
+	 * Data provider for edge cache purge tests.
+	 */
+	public static function edge_cache_purge_cases() {
+		return array(
+			'published'              => array( 'publish', 'draft', Contact_Form::POST_TYPE, true ),
+			'updated while publish'  => array( 'publish', 'publish', Contact_Form::POST_TYPE, true ),
+			'unpublished'            => array( 'draft', 'publish', Contact_Form::POST_TYPE, true ),
+			'non-publish transition' => array( 'pending', 'draft', Contact_Form::POST_TYPE, false ),
+			'other post type'        => array( 'publish', 'draft', 'post', false ),
+		);
+	}
+
+	/**
+	 * Test edge cache purge behavior on form status changes.
+	 *
+	 * @dataProvider edge_cache_purge_cases
+	 */
+	#[DataProvider( 'edge_cache_purge_cases' )]
+	public function test_edge_cache_purge_on_form_status_change( $new_status, $old_status, $post_type, $expected ) {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => $post_type,
+				'post_status' => $old_status,
+			)
+		);
+
+		$post   = get_post( $post_id );
+		$plugin = Contact_Form_Plugin::init();
+		$purged = false;
+
+		add_action(
+			'edge_cache_purge_domain',
+			function () use ( &$purged ) {
+				$purged = true;
+			}
+		);
+
+		$plugin->purge_edge_cache_on_form_status_change( $new_status, $old_status, $post );
+
+		$this->assertSame( $expected, $purged );
+
+		remove_all_actions( 'edge_cache_purge_domain' );
+	}
+
+	/**
+	 * Test edge cache purge handles null post gracefully.
+	 */
+	public function test_no_edge_cache_purge_for_null_post() {
+		$plugin = Contact_Form_Plugin::init();
+		$purged = false;
+
+		add_action(
+			'edge_cache_purge_domain',
+			function () use ( &$purged ) {
+				$purged = true;
+			}
+		);
+
+		$plugin->purge_edge_cache_on_form_status_change( 'publish', 'draft', null );
+
+		$this->assertFalse( $purged );
+
+		remove_all_actions( 'edge_cache_purge_domain' );
+	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -1512,11 +1512,11 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 	 */
 	public static function edge_cache_purge_cases() {
 		return array(
-			'published'              => array( 'publish', 'draft', Contact_Form::POST_TYPE, true ),
-			'updated while publish'  => array( 'publish', 'publish', Contact_Form::POST_TYPE, true ),
-			'unpublished'            => array( 'draft', 'publish', Contact_Form::POST_TYPE, true ),
-			'non-publish transition' => array( 'pending', 'draft', Contact_Form::POST_TYPE, false ),
-			'other post type'        => array( 'publish', 'draft', 'post', false ),
+			'published'               => array( 'publish', 'draft', Contact_Form::POST_TYPE, true ),
+			'updated while published' => array( 'publish', 'publish', Contact_Form::POST_TYPE, true ),
+			'unpublished'             => array( 'draft', 'publish', Contact_Form::POST_TYPE, true ),
+			'non-publish transition'  => array( 'pending', 'draft', Contact_Form::POST_TYPE, false ),
+			'other post type'         => array( 'publish', 'draft', 'post', false ),
 		);
 	}
 


### PR DESCRIPTION
Fixes FORMS-NEW

## Proposed changes

* Add `edge_cache_purge_domain` action when a `jetpack_form` post is published, updated while published, or transitions from published to another status
* Ensures the site's edge cache is purged whenever form changes affect what visitors see

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

### Unit tests

```bash
cd projects/packages/forms && composer phpunit -- --filter='edge_cache'
```

All 6 tests should pass.

### Manual testing

1. Add a temporary observer to confirm the action fires. In a plugin or `functions.php`:
   ```php
   add_action( 'edge_cache_purge_domain', function() {
       error_log( 'edge_cache_purge_domain fired!' );
   }, 10 );
   ```
   (Or use `l( 'edge_cache_purge_domain fired!' )` on a wpcom sandbox.)

2. Make sure `WP_DEBUG` and `WP_DEBUG_LOG` are enabled, then tail the log:
   ```bash
   tail -f wp-content/debug.log
   ```

3. Test the following scenarios and confirm the log message appears:
   - Create a new `jetpack_form` post and **publish** it
   - **Edit** a published form and save/update it
   - Move a published form to **draft** (unpublish)

4. Confirm the action does **not** fire when:
   - Moving a draft form to pending (no publish involved)
   - Publishing a regular `post` (wrong post type)
