### PR TITLE
Sharing buttons: Fix the Facebook official sharing button not rendering

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-sharedaddy-official-fb-sharing-button
+++ b/projects/plugins/jetpack/changelog/fix-sharedaddy-official-fb-sharing-button
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Fix the Facebook official sharing button not rendering.
+Sharing buttons: Fix the Facebook official sharing button not rendering.

--- a/projects/plugins/jetpack/changelog/fix-sharedaddy-official-fb-sharing-button
+++ b/projects/plugins/jetpack/changelog/fix-sharedaddy-official-fb-sharing-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix the Facebook official sharing button not rendering.

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php
@@ -1960,7 +1960,7 @@ class Share_Facebook extends Sharing_Source {
 	public function get_display( $post ) {
 		if ( $this->smart ) {
 			$share_url     = $this->get_share_url( $post->ID );
-			$fb_share_html = '<div class="fb-share-button" data-href="' . esc_attr( $share_url ) . '" data-layout="button_count"></div>';
+			$fb_share_html = '<div class="fb-share-button" data-href="' . esc_url( $share_url ) . '" data-layout="button_count"></div>';
 			/**
 			 * Filter the output of the Facebook Sharing button.
 			 *
@@ -2016,7 +2016,6 @@ class Share_Facebook extends Sharing_Source {
 	 * Add content specific to a service in the footer.
 	 */
 	public function display_footer() {
-		$this->js_dialog( $this->shortname );
 		if ( $this->smart ) {
 			$locale = $this->guess_locale_from_lang( get_locale() );
 			if ( ! $locale ) {
@@ -2030,14 +2029,14 @@ class Share_Facebook extends Sharing_Source {
 			 * @param int $fb_app_id Facebook App ID. Default to 249643311490 (WordPress.com's App ID).
 			 */
 			$fb_app_id = apply_filters( 'jetpack_sharing_facebook_app_id', '249643311490' );
+
+			$sdk_url = 'https://connect.facebook.net/' . rawurlencode( $locale ) . '/sdk.js#xfbml=1&version=v21.0';
 			if ( is_numeric( $fb_app_id ) ) {
-				$fb_app_id = '&appId=' . $fb_app_id;
-			} else {
-				$fb_app_id = '';
+				$sdk_url .= '&appId=' . rawurlencode( $fb_app_id );
 			}
 			?>
-			<div id="fb-root"></div>
-			<script>(function(d, s, id) { var js, fjs = d.getElementsByTagName(s)[0]; if (d.getElementById(id)) return; js = d.createElement(s); js.id = id; js.src = 'https://connect.facebook.net/<?php echo esc_attr( $locale ); ?>/sdk.js#xfbml=1<?php echo esc_attr( $fb_app_id ); ?>&version=v2.3'; fjs.parentNode.insertBefore(js, fjs); }(document, 'script', 'facebook-jssdk'));</script>
+			<div id="fb-root" data-sdk-url="<?php echo esc_url( $sdk_url ); ?>"></div>
+			<script>(function(d, s, id) { var js, fjs = d.getElementsByTagName(s)[0]; if (d.getElementById(id)) return; js = d.createElement(s); js.id = id; js.src = d.getElementById('fb-root').getAttribute('data-sdk-url'); fjs.parentNode.insertBefore(js, fjs); }(document, 'script', 'facebook-jssdk'));</script>
 			<script>
 			document.body.addEventListener( 'is.post-load', function() {
 				if ( 'undefined' !== typeof FB ) {
@@ -2046,6 +2045,8 @@ class Share_Facebook extends Sharing_Source {
 			} );
 			</script>
 			<?php
+		} else {
+			$this->js_dialog( $this->shortname );
 		}
 	}
 }

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.css
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.css
@@ -506,14 +506,14 @@ body .sd-content ul li.share-custom.no-icon a span {
 
 .sd-social-official .fb-share-button > span {
 	vertical-align: top !important;
-	width: 96px !important;
-	height: 20px !important;
+	min-width: 96px !important;
+	min-height: 20px !important;
 	overflow: visible !important;
 }
 
 .sd-social-official .fb-share-button > span > iframe {
-	width: 96px !important;
-	height: 20px !important;
+	min-width: 96px !important;
+	min-height: 20px !important;
 }
 
 /* Individual official buttons */

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.css
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.css
@@ -500,8 +500,20 @@ body .sd-content ul li.share-custom.no-icon a span {
 	margin-right: 8px;
 }
 
+.sd-social-official .fb-share-button {
+	min-width: 110px;
+}
+
 .sd-social-official .fb-share-button > span {
 	vertical-align: top !important;
+	width: 96px !important;
+	height: 20px !important;
+	overflow: visible !important;
+}
+
+.sd-social-official .fb-share-button > span > iframe {
+	width: 96px !important;
+	height: 20px !important;
 }
 
 /* Individual official buttons */


### PR DESCRIPTION
Fixes SOCIAL-381

## Proposed changes

Fix the Facebook official sharing button not rendering on the front end when the "Official buttons" style is selected in the Sharedaddy sharing settings.

The root causes were:

1. **`esc_attr()` encoding bug in `<script>` tag**: The Facebook SDK URL was built inline inside a `<script>` tag using `esc_attr()`, which encoded `&` to `&amp;`. Unlike HTML attributes, `<script>` content does not decode HTML entities, so the SDK URL fragment (`#xfbml=1&amp;appId=...&amp;version=v2.3`) was malformed and the SDK never received the `appId` parameter.

2. **Outdated SDK version**: The Facebook SDK version was set to `v2.3`, which has been deprecated. Updated to `v21.0`.

3. **Facebook SDK iframe renders at 0x0**: The Facebook SDK's cross-domain `postMessage` for resizing the share button iframe fails in modern browsers (due to third-party cookie/privacy restrictions). This causes the SDK to leave the iframe wrapper `<span>` and `<iframe>` at `width: 0px; height: 0px`. Added CSS overrides to force the correct dimensions.

### Changes

* **`sharing-sources.php`**:
  * Changed `esc_attr()` to `esc_url()` for the `data-href` attribute on the `fb-share-button` div.
  * Moved the SDK URL into a `data-sdk-url` attribute on the `#fb-root` div (where `esc_url()` works correctly with browser HTML entity decoding), then read it via `getAttribute()` in JavaScript.
  * Updated Facebook SDK version from `v2.3` to `v21.0`.
  * Moved `js_dialog()` call into an `else` branch so it only runs for the non-official button style.

* **`sharing.css`**:
  * Added `min-width: 110px` on `.fb-share-button` to provide a proper `container_width` for the SDK.
  * Added CSS overrides with `!important` to force the Facebook share button `<span>` and `<iframe>` to `96px x 20px`, working around the SDK's 0x0 sizing issue.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* SOCIAL-381

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This needs to be tested on a WPCOM site because official buttons are not supported in Jetpack sites yet - #34580

1. Apply the changes to your sandbox

```bash
bin/jetpack-downloader test jetpack fix/sharedaddy/official-fb-sharing-button
```

2. Point your Simple site and public API to your sandbox
3. Go to **Settings > Sharing** (on WP.com).
4. Under **Button style**, select **Official buttons**.
5. Ensure **Facebook** is in the "Enabled Services" area. Save.
6. Visit a published post on the front end.
7. Verify the Facebook **Share** button is visible next to other sharing buttons.
8. Click the Facebook Share button and verify it opens the Facebook share dialog.
9. Switch **Button style** back to **Icon + text** or **Icon only**, save, and verify the Facebook button still works as a regular share link (opens a dialog/popup).

<img width="359" height="171" alt="image" src="https://github.com/user-attachments/assets/1cf7705d-f688-4268-89e6-475d940cac17" />
