### PR TITLE
Social: Add X connection support

### DIFF
--- a/projects/js-packages/components/changelog/add-social-x-connection
+++ b/projects/js-packages/components/changelog/add-social-x-connection
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add support for X connection.

--- a/projects/js-packages/components/components/icons/style.module.scss
+++ b/projects/js-packages/components/components/icons/style.module.scss
@@ -67,5 +67,9 @@
 			border-radius: 40%;
 		}
 	}
+
+	&.x {
+		fill: var(--color-x);
+	}
 }
 

--- a/projects/packages/publicize/_inc/components/services/use-supported-services.tsx
+++ b/projects/packages/publicize/_inc/components/services/use-supported-services.tsx
@@ -159,6 +159,22 @@ export function useSupportedServices(): Array< SupportedService > {
 			],
 		},
 		{
+			...availableServices.x,
+			icon: props => <SocialServiceIcon serviceName="x" { ...props } />,
+			badges: [ badgeNew ],
+			description: __( 'Share posts to X.', 'jetpack-publicize-pkg' ),
+			examples: [
+				() => (
+					<>
+						{ __(
+							'Reach your audience by automatically sharing your posts to X when you publish.',
+							'jetpack-publicize-pkg'
+						) }
+					</>
+				),
+			],
+		},
+		{
 			...availableServices.linkedin,
 			icon: props => <SocialServiceIcon serviceName="linkedin" { ...props } />,
 			description: __( 'Share with your LinkedIn community.', 'jetpack-publicize-pkg' ),

--- a/projects/packages/publicize/_inc/components/services/use-supported-services.tsx
+++ b/projects/packages/publicize/_inc/components/services/use-supported-services.tsx
@@ -145,7 +145,6 @@ export function useSupportedServices(): Array< SupportedService > {
 			...availableServices.bluesky,
 			needsCustomInputs: true,
 			icon: props => <SocialServiceIcon serviceName="bluesky" { ...props } />,
-			badges: [ badgeNew ],
 			description: __( 'Share with your network.', 'jetpack-publicize-pkg' ),
 			examples: [
 				() => (

--- a/projects/packages/publicize/changelog/add-social-x-connection
+++ b/projects/packages/publicize/changelog/add-social-x-connection
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add support for X connection.

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -371,6 +371,8 @@ abstract class Publicize_Base {
 				return 'Google Drive';
 			case 'instagram-business':
 				return 'Instagram';
+			case 'x':
+				return 'X';
 			case 'twitter':
 			case 'facebook':
 			case 'tumblr':
@@ -531,6 +533,10 @@ abstract class Publicize_Base {
 			return 'https://twitter.com/' . substr( $cmeta['external_display'], 1 ); // Has a leading '@'.
 		}
 
+		if ( 'x' === $service_name && isset( $cmeta['external_name'] ) ) {
+			return 'https://x.com/' . $cmeta['external_name'];
+		}
+
 		if ( 'bluesky' === $service_name ) {
 			return 'https://bsky.app/profile/' . $cmeta['external_id'];
 		}
@@ -600,6 +606,7 @@ abstract class Publicize_Base {
 			case 'mastodon':
 				return $cmeta['external_display'] ?? null;
 
+			case 'x':
 			case 'bluesky':
 			case 'threads':
 				return $cmeta['external_name'] ?? null;

--- a/projects/packages/publicize/src/class-publicize.php
+++ b/projects/packages/publicize/src/class-publicize.php
@@ -551,6 +551,7 @@ class Publicize extends Publicize_Base {
 			'instagram-business' => array(),
 			'nextdoor'           => array(),
 			'threads'            => array(),
+			'x'                  => array(),
 			'bluesky'            => array(),
 		);
 


### PR DESCRIPTION
Fixes SOCIAL-383
Fixes SOCIAL-384

## Proposed changes

* Register `x` as a supported Publicize service in `class-publicize.php`
* Add service label, profile link (`https://x.com/{username}`), and external handle for X in `class-publicize-base.php`
* Add X entry to the supported services list in the connections UI with icon and description
* Add X icon fill styling in `style.module.scss`

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links

* WPCOM PR: 206884-ghe-Automattic/wpcom

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Follow instructions on 206884-ghe-Automattic/wpcom

1. Ensure the `jetpack-social-x-connection` blog sticker is applied to a test site
2. Go to the Social Connections settings
3. Verify that X appears in the list of available services with the X icon and "New" badge
4. Connect an X account via OAuth 2.0
5. Verify the connection shows the correct display name, profile link (`https://x.com/{username}`), and icon
6. Publish a post with X sharing enabled and verify the post is shared

<img width="2114" height="1310" alt="CleanShot 2026-03-10 at 14 57 39@2x" src="https://github.com/user-attachments/assets/7c3ab413-b839-4fd9-8e0b-230dcd0283e0" />
<img width="666" height="328" alt="CleanShot 2026-03-10 at 14 57 43@2x" src="https://github.com/user-attachments/assets/de236bd1-bb15-427d-8e1c-f3db03dc97a1" />