### PR TITLE
Forms Dashboard: Improve the "Not seeing all your forms?" help modal UX

### DIFF
--- a/projects/packages/forms/changelog/update-improve-missing-forms-modal
+++ b/projects/packages/forms/changelog/update-improve-missing-forms-modal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms Dashboard: Improve the "Not seeing all your forms?" help modal with clearer copy, a helpful tip, and a "Create a new form" action button.

--- a/projects/packages/forms/src/dashboard/wp-build/components/forms-help-modal/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/forms-help-modal/index.tsx
@@ -17,6 +17,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { CONFIG_STORE } from '../../../../store/config/index.ts';
+import CreateFormButton from '../../../components/create-form-button';
 
 type Props = {
 	isOpen: boolean;
@@ -59,23 +60,33 @@ export default function FormsHelpModal( { isOpen, onClose }: Props ) {
 		>
 			<VStack spacing="4">
 				<Text>
-					{ __( 'The Forms list shows reusable forms, not simple form blocks.', 'jetpack-forms' ) }
+					{ __(
+						'This page only lists forms created from the Forms dashboard. Forms added directly inside pages or posts with the form block won\u2019t appear here.',
+						'jetpack-forms'
+					) }
 				</Text>
 				<div>
 					<Text as="p" weight="500">
-						{ __( 'To convert a form block to a reusable form:', 'jetpack-forms' ) }
+						{ __( 'To bring an existing form here:', 'jetpack-forms' ) }
 					</Text>
 					<ol>
-						<li>
-							{ __( 'Open the page or post where your form block is embedded.', 'jetpack-forms' ) }
-						</li>
+						<li>{ __( 'Open the page or post that contains your form.', 'jetpack-forms' ) }</li>
 						<li>{ __( 'Select the form block.', 'jetpack-forms' ) }</li>
 						<li>
-							{ __( 'Click "Edit Form" in the block toolbar to convert it.', 'jetpack-forms' ) }
+							{ __(
+								'Click "Edit Form" in the toolbar \u2014 this converts it to a managed form.',
+								'jetpack-forms'
+							) }
 						</li>
 						<li>{ __( 'Save the page or post.', 'jetpack-forms' ) }</li>
 					</ol>
 				</div>
+				<Text variant="muted" size="12px">
+					{ __(
+						'Tip: New forms created from this dashboard are automatically listed here.',
+						'jetpack-forms'
+					) }
+				</Text>
 				<HStack justify="space-between" alignment="center">
 					<CheckboxControl
 						__nextHasNoMarginBottom
@@ -83,9 +94,13 @@ export default function FormsHelpModal( { isOpen, onClose }: Props ) {
 						checked={ dontShowAgain }
 						onChange={ setDontShowAgain }
 					/>
-					<Button variant="primary" onClick={ handleClose }>
+					<Button variant="primary" onClick={ onClose }>
 						{ __( 'Got it', 'jetpack-forms' ) }
 					</Button>
+					<CreateFormButton
+						label={ __( 'Create a new form', 'jetpack-forms' ) }
+						showIcon={ false }
+					/>
 				</HStack>
 			</VStack>
 		</Modal>


### PR DESCRIPTION
## Proposed changes

- Replace technical jargon ("reusable forms", "simple form blocks") with clearer, user-friendly language that explains the concept without assuming prior knowledge
- Add a helpful tip explaining that forms created from the dashboard are automatically listed
- Add a "Create a new form" secondary action button alongside "Got it" so users can take immediate action instead of just dismissing the modal
- Reword the conversion steps to be more approachable (e.g., "To bring an existing form here:" instead of "To convert a form block to a reusable form:")

## Other information

This is a copy-only change to the Forms help modal component (`forms-help-modal/index.tsx`). No new styles or dependencies are added — the `CreateFormButton` component is reused from the existing dashboard components.

## Testing instructions

1. Open the Jetpack Forms dashboard (wp-admin → Forms)
2. Click the "Not seeing all your forms?" link in the page subtitle (visible when you have fewer than 5 forms) or the "Missing forms?" button in the empty state
3. Verify the modal shows:
   - Clear explanation of why some forms don't appear
   - Steps to bring an existing form to the dashboard
   - A tip about dashboard-created forms
   - Two buttons: "Got it" (primary) and "Create a new form" (secondary)
4. Click "Got it" — modal should close
5. Reopen the modal and click "Create a new form" — should open the form editor

- [x] Changelog entry added