### PR TITLE
Help Center: guard helpCenterData against redeclaration  

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-help-center-feature-flags-redeclaration
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-help-center-feature-flags-redeclaration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix helpCenterFeatureFlags and helpCenterData redeclaration error in CIAB admin.

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -177,18 +177,6 @@ class Help_Center {
 	}
 
 	/**
-	 * Acts as a feature flag, returning a boolean for whether we should show the next steps tutorial UI.
-	 *
-	 * @return boolean
-	 */
-	public static function is_next_steps_tutorial_enabled() {
-		return apply_filters(
-			'help_center_should_enable_next_steps_tutorial',
-			false
-		);
-	}
-
-	/**
 	 * Enqueue Help Center assets.
 	 *
 	 * @param string $variant The variant of the asset file to get.
@@ -270,18 +258,6 @@ class Help_Center {
 
 		// This information is only needed for the connected version of the help center.
 		if ( $variant !== 'wp-admin-disconnected' && $variant !== 'gutenberg-disconnected' ) {
-			// Adds feature flags for development.
-			wp_add_inline_script(
-				'help-center',
-				'const helpCenterFeatureFlags = ' . wp_json_encode(
-					array(
-						'loadNextStepsTutorial' => self::is_next_steps_tutorial_enabled(),
-					),
-					JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
-				),
-				'before'
-			);
-
 			$user_id            = get_current_user_id();
 			$user_data          = get_userdata( $user_id );
 			$username           = $user_data ? $user_data->user_login : null;
@@ -300,7 +276,7 @@ class Help_Center {
 
 			wp_add_inline_script(
 				'help-center',
-				'const helpCenterData = ' . wp_json_encode(
+				'if ( typeof helpCenterData === "undefined" ) { var helpCenterData = ' . wp_json_encode(
 					array(
 						'isProxied'        => boolval( self::is_proxied() ),
 						'isSU'             => defined( 'WPCOM_SUPPORT_SESSION' ) && WPCOM_SUPPORT_SESSION,
@@ -318,7 +294,7 @@ class Help_Center {
 						'locale'           => self::determine_iso_639_locale(),
 					),
 					JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
-				),
+				) . '; }',
 				'before'
 			);
 		}


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/DOTCOM-16285/remove-helpcenterfeatureflags
Fixes https://linear.app/a8c/issue/DOTCOM-16282/fix-helpcenterfeatureflags-redeclaration-error

 ## Summary                                                                                                                                                                    
                                                                         
  - Remove the unused `helpCenterFeatureFlags` inline script and its associated `is_next_steps_tutorial_enabled()` method, which was causing `SyntaxError: redeclaration of
  const helpCenterFeatureFlags` in CIAB admin (DOTCOM-16282).
  - Guard `helpCenterData` with a `typeof` check and `var` to prevent the same redeclaration issue.

The root cause is that in CIAB admin, the `load-assets` package re-injects inline scripts that were already output in the initial page HTML. Since `const` cannot be redeclared in the same scope, the browser throws a SyntaxError. 

Also the feature flags global is no longer consumed, so it can be removed entirely. `helpCenterData` is still needed but is now safe against double-injection.

## Does this pull request change what data or activity we track or use?

No

  ## Testing instructions

  - [ ] Verify Help Center still loads correctly on Simple/Atomic sites.
  - [ ] Verify Help Center still loads correctly in CIAB admin without console errors.
  - [ ] Verify the `helpCenterFeatureFlags` redeclaration error no longer appears in PostHog.