### PR TITLE
Editor: Fix plan upgrade notice for Simple sites

### DIFF
--- a/projects/plugins/jetpack/changelog/ai-agent-edi-122-1773101166
+++ b/projects/plugins/jetpack/changelog/ai-agent-edi-122-1773101166
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Editor: Fix plan upgrade notice for Simple sites

--- a/projects/plugins/jetpack/extensions/shared/plan-upgrade-notification.js
+++ b/projects/plugins/jetpack/extensions/shared/plan-upgrade-notification.js
@@ -41,16 +41,21 @@ function getPlanUrl() {
 		if ( queryParams.get( 'plan_upgraded' ) ) {
 			let planName = null;
 
-			getPlanNameFromApi: try {
-				// not updating if simple site
+			try {
 				if ( isSimpleSite() ) {
-					break getPlanNameFromApi;
+					const siteObj = await apiFetch( {
+						path: `/sites/${ parseInt( window?.Jetpack_Editor_Initial_State?.wpcomBlogId ) || 0 }`,
+						apiNamespace: 'rest/v1.1',
+					} );
+					if ( siteObj?.plan ) {
+						planName = siteObj.plan.product_name_short;
+					}
+				} else {
+					const jetpackSiteInfo = await apiFetch( { path: '/jetpack/v4/site' } );
+					const data = JSON.parse( jetpackSiteInfo.data );
+
+					planName = data.plan.product_name;
 				}
-
-				const jetpackSiteInfo = await apiFetch( { path: '/jetpack/v4/site' } );
-				const data = JSON.parse( jetpackSiteInfo.data );
-
-				planName = data.plan.product_name;
 			} finally {
 				const planUrl = getPlanUrl();
 


### PR DESCRIPTION
Fixes EDI-122

## Proposed changes

Changes the editor plan upgrade notice so it displays the name of the current plan after checkout on Simple sites.

Before | After
--- | ---
<img width="1281" height="362" alt="Screenshot 2026-03-10 at 17 26 45" src="https://github.com/user-attachments/assets/0de04082-4f38-4f58-aa9e-908cdecb7a22" /> | <img width="1259" height="255" alt="Screenshot 2026-03-10 at 18 34 48" src="https://github.com/user-attachments/assets/bf2709aa-59ac-42f3-8e18-6969e95d5c3a" />


### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links

N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions
- Apply this PR to your WP.com sandbox
- Sandbox a Simple site with a Free or Personal plan.
- Open the editor
- Add a Premium block (e.g. video) to see an upgrade prompt.
- Upgrade + check out.
- After redirection back to the Editor, make sure you see a notice that includes the name of the plan: "Congratulations! Your site is now on the Premium plan." 
