### PR TITLE
Charts: Standardize Legend stories and documentation

### DIFF
--- a/projects/js-packages/charts/changelog/CHARTS-183-legend-stories-and-documentation
+++ b/projects/js-packages/charts/changelog/CHARTS-183-legend-stories-and-documentation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Standardize legend stories and documentation across all chart types.

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
@@ -238,18 +238,16 @@ SmartFormatting.parameters = {
 	},
 };
 
-export const WithInteractiveLegend: Story = {
+export const WithLegend: Story = {
 	args: {
 		...Default.args,
 		showLegend: true,
-		legendInteractive: true,
-		chartId: 'bar-chart-with-interactive-legend',
 	},
 	parameters: {
 		docs: {
 			description: {
 				story:
-					'Bar chart with interactive legend. Click on legend items to toggle series visibility. When all series are hidden, a message will be displayed prompting you to click legend items to show data again.',
+					'Props-based legend using `showLegend` and the `legend` config object. Use Storybook controls to adjust legend position, alignment, orientation, shape, and interactivity.',
 			},
 		},
 	},
@@ -269,32 +267,7 @@ export const WithCompositionLegend: StoryObj< typeof BarChart > = {
 		docs: {
 			description: {
 				story:
-					'Demonstrates using the composition API with `<BarChart.Legend />` as a child component. This provides the same functionality as the `showLegend` prop but allows for more flexible composition patterns.',
-			},
-		},
-	},
-};
-
-// Story showcasing legend customization controls
-export const CustomLegendPositioning: Story = {
-	args: {
-		withTooltips: true,
-		data: medalCountsData.slice( 0, 3 ), // Use first 3 series for cleaner legend
-		gridVisibility: 'x',
-		maxWidth: 1200,
-		resizeDebounceTime: 300,
-		containerHeight: '400px',
-		// showLegend defaults to false, explicitly enabling for demonstration
-		showLegend: true,
-		legendOrientation: 'vertical',
-		legendAlignment: 'start',
-		legendPosition: 'top',
-	},
-	parameters: {
-		docs: {
-			description: {
-				story:
-					'Bar chart with top-left positioned vertical legend. This demonstrates non-default legend positioning to showcase different legend placement possibilities.',
+					'Composition API using `<BarChart.Legend />` as a child component for explicit legend placement and configuration. This is the recommended approach for flexible legend positioning.',
 			},
 		},
 	},

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
@@ -268,6 +268,9 @@ export const WithCompositionLegend: StoryObj< typeof BarChart > = {
 			</BarChart>
 		);
 	},
+	args: {
+		...Default.args,
+	},
 	parameters: {
 		docs: {
 			description: {

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
@@ -258,7 +258,12 @@ export const WithCompositionLegend: StoryObj< typeof BarChart > = {
 	render: args => {
 		const legend = extractLegendConfig( args );
 		return (
-			<BarChart { ...Default.args } { ...args } chartId="composition-bar-chart">
+			<BarChart
+				{ ...Default.args }
+				{ ...args }
+				legend={ { interactive: legend?.interactive } }
+				chartId="composition-bar-chart"
+			>
 				<BarChart.Legend { ...legend } />
 			</BarChart>
 		);

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.stories.tsx
@@ -398,7 +398,11 @@ export const WithCompositionLegend: Story = {
 	render: args => {
 		const legend = extractLegendConfig( args );
 		return (
-			<LeaderboardChart { ...args } chartId="composition-leaderboard-chart">
+			<LeaderboardChart
+				{ ...args }
+				legend={ { interactive: legend?.interactive } }
+				chartId="composition-leaderboard-chart"
+			>
 				<LeaderboardChart.Legend
 					{ ...legend }
 					shapeStyles={ { width: 8, height: 8, ...legend?.shapeStyles } }

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.stories.tsx
@@ -384,17 +384,12 @@ export const WithLegend: Story = {
 		loading: false,
 		showLegend: true,
 	},
-};
-
-export const CustomLegendLabels: Story = {
-	args: {
-		data: sampleData,
-		withComparison: true,
-		loading: false,
-		showLegend: true,
-		legendLabels: {
-			primary: 'Aug 11-Sep 9, 2025',
-			comparison: 'Jul 11-Aug 11, 2025',
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Props-based legend using `showLegend` and the `legend` config object. Use Storybook controls to adjust legend position, alignment, orientation, shape, and interactivity.',
+			},
 		},
 	},
 };
@@ -424,29 +419,7 @@ export const WithCompositionLegend: Story = {
 		docs: {
 			description: {
 				story:
-					'Demonstrates the composition API allowing flexible component composition. The chart can be used with traditional props or with explicit child components for more control over legend positioning and styling.',
-			},
-		},
-	},
-};
-
-export const InteractiveLegend: Story = {
-	args: {
-		data: sampleData,
-		withComparison: true,
-		loading: false,
-		showLegend: true,
-		legendInteractive: true,
-		legendLabels: {
-			primary: 'Current period',
-			comparison: 'Previous period',
-		},
-	},
-	parameters: {
-		docs: {
-			description: {
-				story:
-					'Interactive legend allows users to click legend items to toggle the visibility of current and previous period data. Click on the legend items to show/hide the corresponding bars and values. When all series are hidden, a message is displayed.',
+					'Composition API using `<LeaderboardChart.Legend />` as a child component for explicit legend placement and configuration. This is the recommended approach for flexible legend positioning.',
 			},
 		},
 	},

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.stories.tsx
@@ -141,38 +141,17 @@ Animation.args = {
 	animation: true,
 };
 
-export const WithInteractiveLegend: StoryObj< typeof LineChart > = Template.bind( {} );
-WithInteractiveLegend.args = {
+export const WithLegend: StoryObj< typeof LineChart > = Template.bind( {} );
+WithLegend.args = {
 	...lineChartStoryArgs,
-	chartId: 'interactive-legend-demo',
 	showLegend: true,
-	legendInteractive: true,
 };
 
-WithInteractiveLegend.parameters = {
+WithLegend.parameters = {
 	docs: {
 		description: {
 			story:
-				'Line chart with interactive legend. Click or tap legend items to toggle series visibility. Use Tab to focus legend items, then Enter or Space to toggle. Series colors remain stable when toggling visibility.',
-		},
-	},
-};
-
-export const CustomLegendPositioning: StoryObj< typeof LineChart > = Template.bind( {} );
-CustomLegendPositioning.args = {
-	...lineChartStoryArgs,
-	showLegend: true,
-	legendAlignment: 'start',
-	legendPosition: 'top',
-	legendOrientation: 'horizontal',
-	withLegendGlyph: true,
-};
-
-CustomLegendPositioning.parameters = {
-	docs: {
-		description: {
-			story:
-				'Line chart with top-left positioned horizontal legend. This demonstrates non-default legend positioning to showcase different legend placement possibilities with temperature data for London, Canberra, and Mars.',
+				'Props-based legend using `showLegend` and the `legend` config object. Use Storybook controls to adjust legend position, alignment, orientation, shape, and interactivity.',
 		},
 	},
 };
@@ -190,7 +169,8 @@ export const WithCompositionLegend: StoryObj< typeof LineChart > = {
 	parameters: {
 		docs: {
 			description: {
-				story: 'Legend used with LineChart using the composition API, positioned below the chart.',
+				story:
+					'Composition API using `<LineChart.Legend />` as a child component for explicit legend placement and configuration. This is the recommended approach for flexible legend positioning.',
 			},
 		},
 	},

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.stories.tsx
@@ -171,6 +171,9 @@ export const WithCompositionLegend: StoryObj< typeof LineChart > = {
 			</LineChart>
 		);
 	},
+	args: {
+		...Default.args,
+	},
 	parameters: {
 		docs: {
 			description: {

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.stories.tsx
@@ -161,7 +161,12 @@ export const WithCompositionLegend: StoryObj< typeof LineChart > = {
 	render: args => {
 		const legend = extractLegendConfig( args );
 		return (
-			<LineChart { ...Default.args } { ...args } chartId="composition-line-chart">
+			<LineChart
+				{ ...Default.args }
+				{ ...args }
+				legend={ { interactive: legend?.interactive } }
+				chartId="composition-line-chart"
+			>
 				<LineChart.Legend { ...legend } />
 			</LineChart>
 		);

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/donut.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/donut.stories.tsx
@@ -222,7 +222,13 @@ export const WithCompositionLegend: Story = {
 	render: args => {
 		const legend = extractLegendConfig( args );
 		return (
-			<PieChart { ...args } size={ 300 } thickness={ 0.5 } chartId="composition-donut-chart">
+			<PieChart
+				{ ...args }
+				size={ 300 }
+				thickness={ 0.5 }
+				legend={ { interactive: legend?.interactive } }
+				chartId="composition-donut-chart"
+			>
 				<Group>
 					<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 16 } y={ -8 }>
 						User Stats

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/donut.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/donut.stories.tsx
@@ -1,3 +1,10 @@
+/* eslint-disable @wordpress/no-unsafe-wp-apis */
+import {
+	__experimentalText as WPText,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+import { Fragment } from 'react';
+import { BaseLegendItem } from '../../../components/legend/types';
 import {
 	chartDecorator,
 	sharedChartArgTypes,
@@ -7,9 +14,10 @@ import {
 	legendArgTypes,
 	themeArgTypes,
 } from '../../../stories';
+import { customerRevenueData, customerRevenueLegendData } from '../../../stories/sample-data';
 import { Group } from '../../../visx/group';
 import { Text } from '../../../visx/text';
-import { PieChart } from '../../pie-chart';
+import { PieChart, PieChartUnresponsive } from '../../pie-chart';
 import type { Meta, StoryObj } from '@storybook/react';
 
 type StoryArgs = ChartStoryArgs< React.ComponentProps< typeof PieChart > >;
@@ -250,6 +258,87 @@ export const WithCompositionLegend: Story = {
 			description: {
 				story:
 					'Composition API using `<PieChart.Legend />` as a child component for explicit legend placement and configuration. This is the recommended approach for flexible legend positioning.',
+			},
+		},
+	},
+};
+
+const CustomPieLegend = ( {
+	chartItems,
+	items,
+	withComparison,
+}: {
+	chartItems: BaseLegendItem[];
+	items: { label: string; value: number; formattedValue: string; comparison: string }[];
+	withComparison: boolean;
+} ) => (
+	<div
+		style={ {
+			display: 'inline-grid',
+			gridTemplateColumns: '1fr auto auto',
+			gap: 'var(--wpds-dimension-gap-xs, 4px) var(--wpds-dimension-gap-sm, 8px)',
+		} }
+	>
+		{ items.map( ( item, index ) => {
+			const { color } = chartItems[ index ];
+
+			return (
+				<Fragment key={ index }>
+					<HStack direction="row" justify="flex-start" spacing={ 2 }>
+						<div
+							style={ {
+								width: '8px',
+								height: '8px',
+								borderRadius: '50%',
+								flexShrink: 0,
+								backgroundColor: color,
+							} }
+						/>
+						<WPText size="small">{ item.label }</WPText>
+					</HStack>
+					<WPText size="small" weight={ 600 } style={ { textAlign: 'right' } }>
+						{ item.formattedValue }
+					</WPText>
+					<WPText size="small" style={ { textAlign: 'right', color: '#008a20' } }>
+						{ withComparison && item.comparison }
+					</WPText>
+				</Fragment>
+			);
+		} ) }
+	</div>
+);
+
+export const CustomLegend: Story = {
+	render: args => (
+		<PieChartUnresponsive { ...args }>
+			<PieChartUnresponsive.Legend
+				// eslint-disable-next-line react/jsx-no-bind
+				render={ items => (
+					<CustomPieLegend
+						chartItems={ items }
+						items={ customerRevenueLegendData }
+						withComparison={ args.withComparison }
+					/>
+				) }
+			/>
+		</PieChartUnresponsive>
+	),
+	args: {
+		...Default.args,
+		data: customerRevenueData,
+		showLabels: false,
+		thickness: 0.3,
+		cornerScale: 0.03,
+		gapScale: 0.01,
+		size: 164,
+		withComparison: true,
+		withTooltips: false,
+		containerHeight: '300px',
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: 'Demonstrates how to customize the legend using the render prop.',
 			},
 		},
 	},

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/donut.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/donut.stories.tsx
@@ -248,4 +248,3 @@ export const WithCompositionLegend: Story = {
 		},
 	},
 };
-

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/donut.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/donut.stories.tsx
@@ -1,11 +1,3 @@
-/* eslint-disable @wordpress/no-unsafe-wp-apis */
-import {
-	__experimentalText as WPText,
-	__experimentalHStack as HStack,
-} from '@wordpress/components';
-import { Fragment } from 'react';
-import { BaseLegendItem } from '../../../components/legend/types';
-import { GlobalChartsProvider } from '../../../providers';
 import {
 	chartDecorator,
 	sharedChartArgTypes,
@@ -15,10 +7,9 @@ import {
 	legendArgTypes,
 	themeArgTypes,
 } from '../../../stories';
-import { customerRevenueData, customerRevenueLegendData } from '../../../stories/sample-data';
 import { Group } from '../../../visx/group';
 import { Text } from '../../../visx/text';
-import { PieChart, PieChartUnresponsive } from '../../pie-chart';
+import { PieChart } from '../../pie-chart';
 import type { Meta, StoryObj } from '@storybook/react';
 
 type StoryArgs = ChartStoryArgs< React.ComponentProps< typeof PieChart > >;
@@ -217,6 +208,14 @@ export const WithLegend: Story = {
 		showLegend: true,
 		containerHeight: '500px',
 	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Props-based legend using `showLegend` and the `legend` config object. Use Storybook controls to adjust legend position, alignment, orientation, shape, and interactivity.',
+			},
+		},
+	},
 };
 
 export const WithCompositionLegend: Story = {
@@ -244,176 +243,9 @@ export const WithCompositionLegend: Story = {
 		docs: {
 			description: {
 				story:
-					'Demonstrates the donut chart composition API, allowing flexible combination of chart elements and legends.',
+					'Composition API using `<PieChart.Legend />` as a child component for explicit legend placement and configuration. This is the recommended approach for flexible legend positioning.',
 			},
 		},
 	},
 };
 
-export const InteractiveLegend: Story = {
-	render: args => (
-		<GlobalChartsProvider>
-			<PieChartUnresponsive
-				chartId="interactive-donut-chart"
-				size={ args.size }
-				data={ args.data }
-				thickness={ 0.5 }
-				showLegend={ true }
-				legend={ extractLegendConfig( args ) }
-				legendValueDisplay={ args.legendValueDisplay }
-			>
-				<Group>
-					<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 16 } y={ -8 }>
-						User Stats
-					</Text>
-					<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 14 } y={ 12 } fill="#666">
-						100K Total
-					</Text>
-				</Group>
-				<p style={ { color: '#666' } }>
-					Click legend items to show/hide segments. The total value updates dynamically.
-				</p>
-			</PieChartUnresponsive>
-		</GlobalChartsProvider>
-	),
-	args: {
-		data,
-		thickness: 0.5,
-		legendInteractive: true,
-	},
-	parameters: {
-		docs: {
-			description: {
-				story:
-					'Interactive donut chart with clickable legend. Segments can be hidden/shown, and percentages recalculate automatically. Requires chartId and GlobalChartsProvider.',
-			},
-		},
-	},
-};
-
-export const CustomLegendPositioning: Story = {
-	args: {
-		...Default.args,
-		thickness: 0.4,
-		showLegend: true,
-		legendOrientation: 'vertical',
-		legendAlignment: 'start',
-		legendPosition: 'top',
-		containerHeight: '450px',
-		data: [
-			{
-				label: 'Desktop',
-				value: 45000,
-				valueDisplay: '45K',
-				percentage: 45,
-			},
-			{
-				label: 'Mobile',
-				value: 35000,
-				valueDisplay: '35K',
-				percentage: 35,
-			},
-			{
-				label: 'Tablet',
-				value: 20000,
-				valueDisplay: '20K',
-				percentage: 20,
-			},
-		],
-		children: (
-			<Group>
-				<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 18 } y={ -8 }>
-					Distribution
-				</Text>
-			</Group>
-		),
-	},
-	parameters: {
-		docs: {
-			description: {
-				story: 'Donut chart with vertical legend positioned at the top left.',
-			},
-		},
-	},
-};
-
-const CustomPieLegend = ( {
-	chartItems,
-	items,
-	withComparison,
-}: {
-	chartItems: BaseLegendItem[];
-	items: { label: string; value: number; formattedValue: string; comparison: string }[];
-	withComparison: boolean;
-} ) => (
-	<div
-		style={ {
-			display: 'inline-grid',
-			gridTemplateColumns: '1fr auto auto',
-			gap: 'var(--wpds-dimension-gap-xs, 4px) var(--wpds-dimension-gap-sm, 8px)',
-		} }
-	>
-		{ items.map( ( item, index ) => {
-			const { color } = chartItems[ index ];
-
-			return (
-				<Fragment key={ index }>
-					<HStack direction="row" justify="flex-start" spacing={ 2 }>
-						<div
-							style={ {
-								width: '8px',
-								height: '8px',
-								borderRadius: '50%',
-								flexShrink: 0,
-								backgroundColor: color,
-							} }
-						/>
-						<WPText size="small">{ item.label }</WPText>
-					</HStack>
-					<WPText size="small" weight={ 600 } style={ { textAlign: 'right' } }>
-						{ item.formattedValue }
-					</WPText>
-					<WPText size="small" style={ { textAlign: 'right', color: '#008a20' } }>
-						{ withComparison && item.comparison }
-					</WPText>
-				</Fragment>
-			);
-		} ) }
-	</div>
-);
-
-export const CustomLegend: Story = {
-	render: args => (
-		<PieChartUnresponsive { ...args }>
-			<PieChartUnresponsive.Legend
-				// eslint-disable-next-line react/jsx-no-bind
-				render={ items => (
-					<CustomPieLegend
-						chartItems={ items }
-						items={ customerRevenueLegendData }
-						withComparison={ args.withComparison }
-					/>
-				) }
-			/>
-		</PieChartUnresponsive>
-	),
-	args: {
-		...Default.args,
-		data: customerRevenueData,
-		showLabels: false,
-		thickness: 0.3,
-		cornerScale: 0.03,
-		gapScale: 0.01,
-		size: 164,
-		withComparison: true,
-		withTooltips: false,
-		containerHeight: '300px',
-	},
-	parameters: {
-		docs: {
-			description: {
-				story: 'Demonstrates how to customize the legend using the render prop.',
-			},
-		},
-	},
-};

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/index.stories.tsx
@@ -194,7 +194,11 @@ export const WithCompositionLegend: Story = {
 	render: args => {
 		const legend = extractLegendConfig( args );
 		return (
-			<PieChart { ...args } chartId="composition-pie-chart">
+			<PieChart
+				{ ...args }
+				legend={ { interactive: legend?.interactive } }
+				chartId="composition-pie-chart"
+			>
 				<PieChart.Legend { ...legend } />
 			</PieChart>
 		);

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/index.stories.tsx
@@ -180,6 +180,14 @@ export const WithLegend: Story = {
 		...Default.args,
 		showLegend: true,
 	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Props-based legend using `showLegend` and the `legend` config object. Use Storybook controls to adjust legend position, alignment, orientation, shape, and interactivity.',
+			},
+		},
+	},
 };
 
 export const WithCompositionLegend: Story = {
@@ -198,86 +206,7 @@ export const WithCompositionLegend: Story = {
 		docs: {
 			description: {
 				story:
-					'Demonstrates the new composition API allowing flexible component composition. The chart can be used with traditional props or with explicit child components for more control.',
-			},
-		},
-	},
-};
-
-export const InteractiveLegend: Story = {
-	render: args => (
-		<GlobalChartsProvider>
-			<PieChartUnresponsive
-				chartId="interactive-pie-chart"
-				size={ args.size }
-				data={ args.data }
-				showLegend={ true }
-				legend={ extractLegendConfig( args ) }
-				legendValueDisplay={ args.legendValueDisplay }
-			>
-				<p style={ { color: '#666' } }>
-					Click legend items to show/hide segments. Percentages recalculate automatically for
-					visible segments.
-				</p>
-			</PieChartUnresponsive>
-		</GlobalChartsProvider>
-	),
-	args: {
-		data,
-		size: 400,
-		legendInteractive: true,
-	},
-	parameters: {
-		docs: {
-			description: {
-				story:
-					'Interactive legends allow users to toggle segment visibility by clicking legend items. When segments are hidden, the visible segments are recalculated to total 100%. Requires chartId and GlobalChartsProvider.',
-			},
-		},
-	},
-};
-
-export const CustomLegendPositioning: Story = {
-	args: {
-		data: [
-			{
-				label: 'Desktop',
-				value: 45000,
-				valueDisplay: '45K',
-				percentage: 45,
-			},
-			{
-				label: 'Mobile',
-				value: 35000,
-				valueDisplay: '35K',
-				percentage: 35,
-			},
-			{
-				label: 'Tablet',
-				value: 20000,
-				valueDisplay: '20K',
-				percentage: 20,
-			},
-		],
-		thickness: 1, // Full pie chart
-		gapScale: 0.03,
-		padding: 20,
-		cornerScale: 0.03,
-		withTooltips: true,
-		showLegend: true,
-		legendOrientation: 'vertical',
-		legendAlignment: 'center',
-		legendPosition: 'top',
-		legendShape: 'circle',
-		size: 400,
-		containerWidth: '432px',
-		containerHeight: '432px',
-	},
-	parameters: {
-		docs: {
-			description: {
-				story:
-					'Pie chart with top-end positioned vertical legend. This demonstrates non-default legend positioning to showcase different legend placement possibilities with device usage data.',
+					'Composition API using `<PieChart.Legend />` as a child component for explicit legend placement and configuration. This is the recommended approach for flexible legend positioning.',
 			},
 		},
 	},

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/index.stories.tsx
@@ -1,6 +1,5 @@
 import { Group } from '@visx/group';
 import { Text } from '@visx/text';
-import { GlobalChartsProvider } from '../../../providers';
 import {
 	chartDecorator,
 	sharedChartArgTypes,
@@ -141,6 +140,14 @@ export const WithLegend: Story = {
 		...Default.args,
 		showLegend: true,
 	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Props-based legend using `showLegend` and the `legend` config object. Use Storybook controls to adjust legend position, alignment, orientation, shape, and interactivity.',
+			},
+		},
+	},
 };
 
 export const WithCompositionLegend: Story = {
@@ -159,81 +166,7 @@ export const WithCompositionLegend: Story = {
 		docs: {
 			description: {
 				story:
-					'Demonstrates the semi-circle chart composition API, allowing flexible component composition with explicit legend placement.',
-			},
-		},
-	},
-};
-
-export const InteractiveLegend: Story = {
-	render: args => (
-		<GlobalChartsProvider>
-			<PieSemiCircleChart
-				chartId="interactive-semi-circle-chart"
-				data={ args.data }
-				label="Performance Metrics"
-				note="Click legend to filter"
-				showLegend={ true }
-				legend={ extractLegendConfig( args ) }
-				legendValueDisplay={ args.legendValueDisplay }
-			>
-				<p style={ { marginBottom: '20px', color: '#666' } }>
-					Click legend items to show/hide segments. Percentages adjust automatically.
-				</p>
-			</PieSemiCircleChart>
-		</GlobalChartsProvider>
-	),
-	args: {
-		data,
-		legendInteractive: true,
-	},
-	parameters: {
-		docs: {
-			description: {
-				story:
-					'Interactive semi-circle chart with clickable legend items. Hidden segments are excluded and percentages recalculate. Requires chartId and GlobalChartsProvider.',
-			},
-		},
-	},
-};
-
-export const CustomLegendPositioning: Story = {
-	args: {
-		thickness: 0.4,
-		data: [
-			{
-				label: 'MacOS',
-				value: 30000,
-				valueDisplay: '30K',
-				percentage: 30,
-			},
-			{
-				label: 'Linux',
-				value: 22000,
-				valueDisplay: '22K',
-				percentage: 22,
-			},
-			{
-				label: 'Windows',
-				value: 48000,
-				valueDisplay: '48K',
-				percentage: 48,
-			},
-		],
-		label: 'OS',
-		note: 'Windows +10%',
-		withTooltips: true,
-		showLegend: true,
-		legendOrientation: 'vertical',
-		legendAlignment: 'end',
-		legendPosition: 'top',
-		legendShape: 'circle',
-	},
-	parameters: {
-		docs: {
-			description: {
-				story:
-					'Semi-circle pie chart with right-top positioned vertical legend. This demonstrates non-default legend positioning to showcase different legend placement possibilities with OS usage data.',
+					'Composition API using `<PieSemiCircleChart.Legend />` as a child component for explicit legend placement and configuration. This is the recommended approach for flexible legend positioning.',
 			},
 		},
 	},

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/index.stories.tsx
@@ -154,7 +154,12 @@ export const WithCompositionLegend: Story = {
 	render: args => {
 		const legend = extractLegendConfig( args );
 		return (
-			<PieSemiCircleChart { ...Default.args } { ...args } chartId="composition-semi-circle-chart">
+			<PieSemiCircleChart
+				{ ...Default.args }
+				{ ...args }
+				legend={ { interactive: legend?.interactive } }
+				chartId="composition-semi-circle-chart"
+			>
 				<PieSemiCircleChart.Legend { ...legend } />
 			</PieSemiCircleChart>
 		);

--- a/projects/js-packages/charts/src/components/legend/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/components/legend/stories/index.docs.mdx
@@ -17,6 +17,12 @@ The Legend component offers multiple ways to display chart legends, from simple 
 	language="tsx"
 	code={ `import { Legend, LineChart } from '@automattic/charts';
 
+	// Composition API (recommended)
+
+	<LineChart data={ salesData } chartId="sales-chart">
+		<LineChart.Legend orientation="horizontal" />
+	</LineChart>
+
 	// Standalone usage with manual data
 
 	<Legend
@@ -25,12 +31,7 @@ The Legend component offers multiple ways to display chart legends, from simple 
 			{ label: 'Series 2', value: '35%', color: '#80C8FF' },
 		] }
 		orientation="horizontal"
-	/>
-
-	// Automatic data from chart context
-
-	<LineChart chartId="sales-chart" data={ salesData } showLegend={ false } />
-	<Legend chartId="sales-chart" orientation="vertical" />`
+	/>`
 } />
 
 ## API Reference
@@ -93,52 +94,44 @@ For detailed information about all optional props, see the [Legend API Reference
 
 ## Integration with Charts
 
-### Using with LineChart
+### Composition API (Recommended)
 
-Legends can be positioned independently from the chart, retrieving data automatically via hooks:
+The recommended way to add legends to charts is the composition API. Use the chart's `Legend` compound component as a child for explicit placement and configuration:
 
 <Canvas of={ LegendStories.WithLineChart } />
 
 <Source
 	language="tsx"
-	code={ `import { Legend, LineChart } from '@automattic/charts';
-	import { useChartLegendItems } from '@automattic/charts';
+	code={ `import { LineChart } from '@automattic/charts';
 
-	const legendItems = useChartLegendItems( lineChartData, {
-		showValues: false,
-	} );
-
-	<LineChart
-		data={ lineChartData }
-		showLegend={ false }
-		width={ 600 }
-		height={ 300 }
-	/>
-	<Legend items={ legendItems } orientation="horizontal" shape="line" />` }
+	<LineChart data={ lineChartData } chartId="sales-chart">
+		<LineChart.Legend orientation="horizontal" />
+	</LineChart>` }
 />
 
-### Using with BarChart
-
-Position legends vertically beside charts for a side-by-side layout:
+This works with all chart types that support legends:
 
 <Canvas of={ LegendStories.WithBarChart } />
 
 <Source
 	language="tsx"
-	code={ `import { Legend, BarChart } from '@automattic/charts';
-	import { useChartLegendItems } from '@automattic/charts';
+	code={ `import { BarChart } from '@automattic/charts';
 
-	const legendItems = useChartLegendItems( barChartData );
-
-	<div style={ { display: 'flex', gap: '20px', alignItems: 'flex-start' } }>
-		<BarChart data={ barChartData } showLegend={ false } width={ 400 } height={ 300 } />
-		<Legend items={ legendItems } orientation="vertical" />
-	</div>` }
+	<BarChart data={ barChartData } chartId="quarterly-sales">
+		<BarChart.Legend orientation="vertical" />
+	</BarChart>` }
 />
+
+#### Key Benefits
+
+- **Explicit Placement**: The legend is part of the chart's component tree, making placement clear and predictable
+- **Automatic Data**: Legend items are derived from the chart's data automatically
+- **Full Configuration**: Supports all legend props including `position`, `alignment`, `orientation`, `shape`, and `interactive`
+- **Type Safety**: Full TypeScript support with chart-specific legend types
 
 ### Standalone Legend with Chart Context
 
-The Legend component's most powerful feature is its ability to automatically retrieve data from charts using the chart context:
+For decoupled layouts such as dashboards, the Legend component can retrieve data from charts automatically using the chart context:
 
 <Canvas of={ LegendStories.StandaloneLegendWithChartId } />
 
@@ -169,13 +162,6 @@ The Legend component's most powerful feature is its ability to automatically ret
 2. **Data Retrieval**: The Legend component can then retrieve this data using the same `chartId`
 3. **Decoupled Display**: The legend can be placed anywhere in your layout, completely independent from the chart
 
-#### Key Benefits
-
-- **Flexible Layouts**: Create complex dashboard layouts with centralized legend areas
-- **Consistent Legends**: Multiple charts can share legend styles and positioning
-- **Dynamic Updates**: Legend automatically updates when chart data changes
-- **No Prop Drilling**: No need to pass legend data through multiple component levels
-
 #### Important Notes
 
 - The chart and legend must be wrapped in the same GlobalChartsProvider context
@@ -189,7 +175,7 @@ Interactive legends allow users to toggle series visibility by clicking or using
 
 ### Basic Interactive Legend
 
-Enable interactive legends by setting `legend.interactive` on the chart. When `showLegend` is enabled, the chart's built-in legend will automatically become interactive:
+Enable interactive legends using the composition API by passing `interactive` to the chart's Legend compound component:
 
 <Canvas of={ LegendStories.InteractiveLegend } />
 
@@ -197,8 +183,18 @@ Enable interactive legends by setting `legend.interactive` on the chart. When `s
 	language="tsx"
 	code={ `import { LineChart } from '@automattic/charts';
 
-	<LineChart
+	<LineChart data={ data } chartId="sales-chart">
+		<LineChart.Legend interactive={ true } />
+	</LineChart>` }
+/>
+
+Alternatively, use the props-based approach with `showLegend` and the `legend` config object:
+
+<Source
+	language="tsx"
+	code={ `<LineChart
 		data={ data }
+		chartId="sales-chart"
 		showLegend={ true }
 		legend={{ interactive: true }}
 	/>` }

--- a/projects/js-packages/charts/src/components/legend/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/components/legend/stories/index.docs.mdx
@@ -20,7 +20,7 @@ The Legend component offers multiple ways to display chart legends, from simple 
 	// Composition API (recommended)
 
 	<LineChart data={ salesData } chartId="sales-chart">
-		<LineChart.Legend orientation="horizontal" />
+		<LineChart.Legend />
 	</LineChart>
 
 	// Standalone usage with manual data
@@ -30,7 +30,6 @@ The Legend component offers multiple ways to display chart legends, from simple 
 			{ label: 'Series 1', value: '25%', color: '#3858E9' },
 			{ label: 'Series 2', value: '35%', color: '#80C8FF' },
 		] }
-		orientation="horizontal"
 	/>`
 } />
 
@@ -105,7 +104,7 @@ The recommended way to add legends to charts is the composition API. Use the cha
 	code={ `import { LineChart } from '@automattic/charts';
 
 	<LineChart data={ lineChartData } chartId="sales-chart">
-		<LineChart.Legend orientation="horizontal" />
+		<LineChart.Legend />
 	</LineChart>` }
 />
 
@@ -118,7 +117,7 @@ This works with all chart types that support legends:
 	code={ `import { BarChart } from '@automattic/charts';
 
 	<BarChart data={ barChartData } chartId="quarterly-sales">
-		<BarChart.Legend orientation="vertical" />
+		<BarChart.Legend />
 	</BarChart>` }
 />
 
@@ -150,7 +149,6 @@ For decoupled layouts such as dashboards, the Legend component can retrieve data
 		{/* Standalone legend that automatically gets data from chart context */}
 		<Legend
 			chartId="standalone-legend-chart"
-			orientation="horizontal"
 		/>
 
 	</div>` }
@@ -216,7 +214,6 @@ Interactive legends also work with standalone Legend components. Set `legend.int
 
 		<Legend
 			chartId="sales-chart"
-			orientation="horizontal"
 			interactive={ true }
 		/>
 	</GlobalChartsProvider>` }
@@ -273,7 +270,6 @@ The Legend component provides comprehensive text overflow handling for long labe
 	language="tsx"
 	code={ `<Legend
 		items={ items }
-		orientation="horizontal"
 		labelStyles={ { maxWidth: '150px', textOverflow: 'ellipsis' } }
 		alignment="center"
 	/>` }
@@ -289,7 +285,6 @@ By default, legends use rectangular shapes, but you can customize the glyph shap
 	language="tsx"
 	code={ `<Legend
 		items={ items }
-		orientation="horizontal"
 		shape="circle"
 	/>` }
 />

--- a/projects/js-packages/charts/src/components/legend/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/legend/stories/index.stories.tsx
@@ -116,7 +116,7 @@ export const WithLineChart: Story = {
 			withLegendGlyph={ false }
 			chartId="legend-line-chart"
 		>
-			<LineChart.Legend orientation="horizontal" />
+			<LineChart.Legend />
 		</LineChart>
 	),
 };
@@ -125,7 +125,7 @@ export const WithLineChart: Story = {
 export const WithBarChart: Story = {
 	render: () => (
 		<BarChart data={ barChartData } width={ 400 } height={ 300 } chartId="legend-bar-chart">
-			<BarChart.Legend orientation="vertical" />
+			<BarChart.Legend />
 		</BarChart>
 	),
 };
@@ -145,7 +145,7 @@ const StandaloneLegendWithChartIdComponent = () => {
 				withLegendGlyph={ false }
 			/>
 			{ /* Standalone legend that automatically gets data from chart context */ }
-			<Legend chartId="standalone-legend-chart" orientation="horizontal" shape="line" />
+			<Legend chartId="standalone-legend-chart" shape="line" />
 		</div>
 	);
 };
@@ -300,7 +300,6 @@ export const AlignmentOptions: Story = {
 			{ label: 'Series 2', value: '35%', color: '#80C8FF' },
 			{ label: 'Series 3', value: '40%', color: '#44B556' },
 		],
-		orientation: 'horizontal',
 		alignment: 'start',
 	},
 };
@@ -376,7 +375,6 @@ export const CustomShape: Story = {
 			{ label: 'Desktop', value: '65%', color: '#3858E9' },
 			{ label: 'Mobile', value: '35%', color: '#80C8FF' },
 		],
-		orientation: 'horizontal',
 		shape: 'circle',
 	},
 };

--- a/projects/js-packages/charts/src/components/legend/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/legend/stories/index.stories.tsx
@@ -8,7 +8,6 @@ import {
 	themeArgTypes,
 	sharedThemeArgs,
 } from '../../../stories';
-import { useChartLegendItems } from '../hooks/use-chart-legend-items';
 import { Legend } from '../legend';
 import type { SeriesData, DataPointPercentage } from '../../../types';
 
@@ -106,45 +105,29 @@ export const Vertical: Story = {
 	},
 };
 
-// Story showing use with LineChart data
-const WithLineChartData = () => {
-	const legendItems = useChartLegendItems( lineChartData, {
-		showValues: false,
-	} );
-
-	return (
-		<div style={ { display: 'flex', flexDirection: 'column', gap: '20px' } }>
-			<LineChart
-				data={ lineChartData }
-				showLegend={ false }
-				width={ 600 }
-				height={ 300 }
-				withGradientFill={ false }
-				withLegendGlyph={ false }
-			/>
-			<Legend items={ legendItems } orientation="horizontal" shape="line" />
-		</div>
-	);
-};
-
+// Story showing composition API with LineChart
 export const WithLineChart: Story = {
-	render: () => <WithLineChartData />,
+	render: () => (
+		<LineChart
+			data={ lineChartData }
+			width={ 600 }
+			height={ 300 }
+			withGradientFill={ false }
+			withLegendGlyph={ false }
+			chartId="legend-line-chart"
+		>
+			<LineChart.Legend orientation="horizontal" />
+		</LineChart>
+	),
 };
 
-// Story showing use with BarChart data
-const WithBarChartData = () => {
-	const legendItems = useChartLegendItems( barChartData );
-
-	return (
-		<div style={ { display: 'flex', gap: '20px', alignItems: 'flex-start' } }>
-			<BarChart data={ barChartData } showLegend={ false } width={ 400 } height={ 300 } />
-			<Legend items={ legendItems } orientation="vertical" />
-		</div>
-	);
-};
-
+// Story showing composition API with BarChart
 export const WithBarChart: Story = {
-	render: () => <WithBarChartData />,
+	render: () => (
+		<BarChart data={ barChartData } width={ 400 } height={ 300 } chartId="legend-bar-chart">
+			<BarChart.Legend orientation="vertical" />
+		</BarChart>
+	),
 };
 
 // Story showing standalone legend using chartId to automatically get data from context


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [CHARTS-183: Standardize legend stories and docs](https://linear.app/a8c/issue/CHARTS-183/standardize-legend-stories-and-docs)
Fixes [CHARTS-187: Fix composition legend interactivity in WithCompositionLegend stories](https://linear.app/a8c/issue/CHARTS-187/fix-composition-legend-interactivity-in-withcompositionlegend-stories)

## Proposed changes
*   Standardized legend stories for BarChart, LineChart, PieChart, Donut, PieSemiCircleChart, and LeaderboardChart to `WithLegend` (props-based) and `WithCompositionLegend` (composition API).
*   Removed redundant legend stories (e.g., `WithInteractiveLegend`, `CustomLegendPositioning`) as their functionality is now covered by the standardized stories and shared controls.
*   Retained the `CustomLegend` donut story — it demonstrates the render prop API, a distinct pattern not covered by the standard two.
*   Updated the `Legend` component documentation (`index.docs.mdx`) to prioritize composition API examples for chart integration.
*   Updated the `Legend` component stories (`index.stories.tsx`) to include composition examples.
*   Removed redundant `orientation="horizontal"` from stories and docs Source blocks where it matched the default.
*   Fixed `WithCompositionLegend` stories not wiring `legend.interactive` to the parent chart component, so toggling interactivity in Storybook now correctly filters series visibility (CHARTS-187).
*   Added explicit `args` to BarChart and LineChart `WithCompositionLegend` stories so Storybook Controls panel shows initialized values.

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
*   [CHARTS-183](https://linear.app/a8c/issue/CHARTS-183/standardize-legend-stories-and-docs) Standardize legend stories and docs
*   [CHARTS-187](https://linear.app/a8c/issue/CHARTS-187/fix-composition-legend-interactivity-in-withcompositionlegend-stories) Fix composition legend interactivity

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
*   **Verify Chart Stories:**
    *   Go to Storybook for each of the following charts: BarChart, LineChart, PieChart, Donut, PieSemiCircleChart, LeaderboardChart.
    *   Confirm that each chart has two legend stories: "WithLegend" and "WithCompositionLegend". Donut additionally has "CustomLegend".
    *   For both stories, verify that all legend controls (position, alignment, orientation, shape, interactive, styles) are available and functional.
*   **Verify Composition Legend Interactivity (CHARTS-187):**
    *   In any `WithCompositionLegend` story, enable the `legendInteractive` control.
    *   Click a legend item to toggle series visibility — the chart should update accordingly.
*   **Verify Legend Component Documentation:**
    *   Go to the `Legend` component documentation in Storybook (`/charts/?path=/docs/components-legend--docs`).
    *   Ensure the "Integration with Charts" section prominently features the composition API pattern as the primary example.
*   **Verify Donut CustomLegend:**
    *   Go to the Donut Chart stories and confirm the `CustomLegend` story renders with the custom render prop layout (grid with formatted values and comparison deltas).

Linear Issues: [CHARTS-183](https://linear.app/a8c/issue/CHARTS-183/standardize-legend-stories-and-docs), [CHARTS-187](https://linear.app/a8c/issue/CHARTS-187/fix-composition-legend-interactivity-in-withcompositionlegend-stories)
<!-- CURSOR_AGENT_PR_BODY_END -->