### PR TITLE
Revert "MU WPCOM: Load wpcom-gutenberg-rtc from widgets.wp.com"

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2809,6 +2809,9 @@ importers:
       '@wordpress/router':
         specifier: ^1.8.11
         version: 1.41.0(react@18.3.1)
+      '@wordpress/sync':
+        specifier: 1.41.0
+        version: 1.41.0
       '@wordpress/url':
         specifier: 4.41.0
         version: 4.41.0
@@ -2824,6 +2827,9 @@ importers:
       events:
         specifier: ^3.3.0
         version: 3.3.0
+      lib0:
+        specifier: 0.2.99
+        version: 0.2.99
       lodash:
         specifier: 4.17.23
         version: 4.17.23
@@ -2848,6 +2854,12 @@ importers:
       wpcom-proxy-request:
         specifier: ^7.0.3
         version: 7.0.7
+      y-protocols:
+        specifier: ^1.0.7
+        version: 1.0.7(yjs@13.6.29)
+      yjs:
+        specifier: 13.6.29
+        version: 13.6.29
     devDependencies:
       '@automattic/jetpack-webpack-config':
         specifier: workspace:*

--- a/projects/packages/jetpack-mu-wpcom/changelog/pr-47535
+++ b/projects/packages/jetpack-mu-wpcom/changelog/pr-47535
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Gutenberg RTC: Load wpcom-gutenberg-rtc script from widgets.wp.com instead of bundling it, enabling independent script deployments.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -78,11 +78,13 @@
 		"@wordpress/private-apis": "^1.8.1",
 		"@wordpress/rich-text": "7.41.0",
 		"@wordpress/router": "^1.8.11",
+		"@wordpress/sync": "1.41.0",
 		"@wordpress/url": "4.41.0",
 		"canvas-confetti": "^1.9.4",
 		"clsx": "2.1.1",
 		"debug": "4.4.3",
 		"events": "^3.3.0",
+		"lib0": "0.2.99",
 		"lodash": "4.17.23",
 		"moment": "2.30.1",
 		"preact": "10.28.2",
@@ -92,7 +94,9 @@
 		"redux": "^4.2.1",
 		"redux-saga": "^1.3.0",
 		"swiper": "^12.0.0",
-		"wpcom-proxy-request": "^7.0.3"
+		"wpcom-proxy-request": "^7.0.3",
+		"y-protocols": "^1.0.7",
+		"yjs": "13.6.29"
 	},
 	"devDependencies": {
 		"@automattic/jetpack-webpack-config": "workspace:*",

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
@@ -56,10 +56,7 @@ function wpcom_enqueue_gutenberg_rtc_assets() {
 		return;
 	}
 
-	$handle = jetpack_mu_wpcom_enqueue_calypso_app( 'wpcom-gutenberg-rtc' );
-	if ( ! $handle ) {
-		return;
-	}
+	$handle = jetpack_mu_wpcom_enqueue_assets( 'gutenberg-rtc', array( 'js' ) );
 
 	$data = wp_json_encode(
 		array(

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.ts
@@ -1,0 +1,29 @@
+import { addFilter } from '@wordpress/hooks';
+import { createPingHubProvider } from './providers/pinghub';
+
+/**
+ * Register providers (e.g. PingHub) supplied by the server, and disable HTTP polling by returning only this provider.
+ */
+function registerWpcomGutenbergProviders() {
+	const getProviders = () => {
+		if ( ! window.wpcomGutenbergRTC?.providers ) {
+			return [];
+		}
+
+		return window.wpcomGutenbergRTC.providers
+			.map( ( provider: string ) => {
+				switch ( provider ) {
+					case 'pinghub': {
+						return createPingHubProvider();
+					}
+					default:
+						return null;
+				}
+			} )
+			.filter( Boolean );
+	};
+
+	addFilter( 'sync.providers', 'wpcom/gutenberg-rtc-providers', () => getProviders() );
+}
+
+registerWpcomGutenbergProviders();

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/providers/pinghub/README.md
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/providers/pinghub/README.md
@@ -1,0 +1,258 @@
+# PingHub Yjs Provider
+
+A Yjs provider for Gutenberg that enables real-time collaborative editing via PingHub WebSockets. It uses persistent WebSocket connections through a hidden iframe bridge to the WordPress.com REST proxy, providing push-based, low-latency updates.
+
+## Architecture
+
+```
+┌─────────────────┐                              ┌─────────────────┐
+│    Client A      │                             │    Client B     │
+│  ┌───────────┐  │                              │  ┌───────────┐  │
+│  │  Y.Doc    │  │                              │  │  Y.Doc    │  │
+│  │ Awareness │  │                              │  │ Awareness │  │
+│  └─────┬─────┘  │                              │  └─────┬─────┘  │
+│        │        │                              │        │        │
+│  ┌─────┴─────┐  │                              │  ┌─────┴─────┐  │
+│  │ PingHub   │  │                              │  │ PingHub   │  │
+│  │ Provider  │  │                              │  │ Provider  │  │
+│  └─────┬─────┘  │                              │  └─────┴─────┘  │
+│  ┌─────┴─────┐  │                              │  ┌─────┴─────┐  │
+│  │ PingHub   │  │                              │  │ PingHub   │  │
+│  │ Manager   │  │                              │  │ Manager   │  │
+│  └─────┬─────┘  │                              │  └─────┴─────┘  │
+└────────┼────────┘                              └────────┼────────┘
+         │                                                │
+         │            WebSocket (PingHub)                 │
+         └────────────────────┬───────────────────────────┘
+                              │
+                    ┌─────────┴─────────┐
+                    │  WordPress.com    │
+                    │  PingHub Service  │
+                    │  (WebSocket relay)│
+                    └───────────────────┘
+```
+
+## File Structure
+
+| File                 | Role                                                                                   |
+| -------------------- | -------------------------------------------------------------------------------------- |
+| `index.ts`           | Public export: `createPingHubProvider`                                                 |
+| `pinghub-provider.ts`| `PingHubProvider` class + `createPingHubProvider` factory: thin shell that delegates to the manager |
+| `pinghub-manager.ts` | `pinghubManager` module: per-room Yjs sync protocol, awareness, reconnection logic |
+| `pinghub-bridge.ts`  | `PingHubBridge` class: WebSocket communication with PingHub via the REST proxy iframe  |
+
+## Usage
+
+### Basic Setup
+
+```ts
+import { createPingHubProvider } from './providers/pinghub';
+```
+
+#### 1. Register the provider creator
+
+`createPingHubProvider` returns a `ProviderCreator` compatible with Gutenberg's sync manager. The bridge is created lazily on first use.
+
+```ts
+import { addFilter } from '@wordpress/hooks';
+
+const providerCreator = createPingHubProvider();
+
+addFilter( 'sync.providers', 'my-plugin/pinghub', ( providers ) => {
+    return [ ...providers, providerCreator ];
+} );
+```
+
+The sync manager calls the provider creator for each entity being edited. Currently only `postType/post` and `postType/page` entities with a non-null `objectId` get a PingHub channel; all other entity types receive a no-op provider.
+
+#### 2. Listen for connection status
+
+```ts
+const result = await providerCreator( { objectType, objectId, ydoc, awareness } );
+
+result.on( 'status', ( { status } ) => {
+    // status: 'connecting' | 'connected' | 'disconnected'
+    console.log( 'PingHub status:', status );
+} );
+```
+
+#### 3. Clean up
+
+```ts
+result.destroy();
+```
+
+This broadcasts a final awareness removal to peers and tears down all listeners. Window-level event handlers are automatically removed when the last provider is destroyed.
+
+## How It Works
+
+### 1. Initialization
+
+When the editor loads, `gutenberg-rtc.ts` checks `window.wpcomGutenbergRTC.providers` for enabled providers. If `"pinghub"` is present, it registers a `ProviderCreator` via the `sync.providers` filter.
+
+Gutenberg's sync manager calls the provider creator for each entity being edited. Currently only `postType/post` and `postType/page` entities with a non-null `objectId` get a PingHub channel; all other entity types (collections, patterns, etc.) receive a no-op provider.
+
+### 2. Provider → Manager → Bridge
+
+The layered architecture separates concerns:
+
+- **`PingHubProvider`** — thin shell per entity. Owns the `Awareness` instance and emits `status` events. Delegates all transport to the manager via `pinghubManager.registerRoom()` / `pinghubManager.unregisterRoom()`.
+- **`pinghubManager`** — manages all rooms. Each `registerRoom()` call creates a per-room connection that handles Yjs sync protocol, awareness broadcasting, and reconnection with exponential backoff. Also owns the shared bridge and window event listeners (`beforeunload`, `pagehide`, `visibilitychange`).
+- **`PingHubBridge`** — singleton (lazy-created on first room registration). Manages the hidden iframe and multiplexes all PingHub channels over it via `postMessage`.
+
+### 3. Channel Path
+
+Each post maps to a PingHub channel:
+
+```
+/pinghub/wpcom/rtc/{blogId}/{objectType}-{objectId}
+```
+
+For example: `/pinghub/wpcom/rtc/12345/postType-post-42`
+
+The blog ID is resolved from WordPress globals (`_currentSiteId`, `wpcomGutenberg.blogId`, or `currentBlogId`). The room name (`postType-post-42`) is constructed by the provider; the bridge prepends the `/pinghub/wpcom/rtc/{blogId}/` prefix internally.
+
+### 4. PingHub Bridge
+
+#### Why a PingHub Bridge?
+
+PingHub is a WebSocket service on `public-api.wordpress.com`, and the user's auth cookies are scoped to that domain. The editor page runs on a different origin (e.g., `wordpress.com/post/...` or a custom site domain), so it **cannot directly open a WebSocket** to PingHub — the browser won't attach the cookies.
+
+The solution is the **REST proxy iframe pattern** already used elsewhere in WordPress.com:
+
+```
+Editor page (origin A)              Hidden iframe (origin B = public-api.wordpress.com)
+┌──────────────────┐                ┌──────────────────────────┐
+│                  │  postMessage   │                          │
+│  PingHubBridge   │ ─────────────→ | REST proxy page          │
+│  (JS)            │ ←───────────── | ● Has auth cookies       │
+│                  │  postMessage   │ ● Opens real WebSocket   │
+└──────────────────┘                └──────────────────────────┘
+```
+
+The iframe loads a page from `public-api.wordpress.com`, so the browser attaches the user's cookies. The iframe internally opens the real WebSocket to PingHub. The editor communicates with the iframe via `postMessage`, which works cross-origin by design.
+
+#### PingHub Bridge setup
+
+On construction, the bridge either reuses an existing REST-proxy iframe already in the DOM or creates a new hidden one (1×1 px, off-screen). When the proxy page inside the iframe loads, it posts `"ready"` back to the parent. The bridge queues any `connect`/`send` calls until this ready signal arrives.
+
+#### Connect flow
+
+```
+Editor (Bridge)             PingHub Bridge (REST proxy)      PingHub server
+  │                                │                                │
+  │ postMessage({                  │                                │
+  │   action: 'connect',           │                                │
+  │   path: '/pinghub/…',          │                                │
+  │   callback: '1'                │                                │
+  │ })                             │                                │
+  │ ──────────────────────────────→│                                │
+  │                                │  WebSocket.open(path)          │
+  │                                │ ──────────────────────────────→│
+  │                                │                                │
+  │                                │  onopen                        │
+  │                                │ ←──────────────────────────────│
+  │  postMessage(                  │                                │
+  │    [{type:'open'}, 200, '1']   │                                │
+  │  )                             │                                │
+  │ ←──────────────────────────────│                                │
+  │                                │                                │
+  │  connect() Promise resolves    │                                │
+```
+
+The `callback` ID links each response back to the original request. The bridge maintains `callbackToPath` / `pathToCallback` maps to route incoming messages to the right path handlers.
+
+#### Message transport
+
+**Sending:** Manager calls `bridge.send(room, Uint8Array)` → bridge base64-encodes the bytes (because `postMessage` JSON can't carry binary) → posts `{ action: 'send', path, message: '<base64>' }` to iframe → iframe forwards over the real WebSocket.
+
+**Receiving:** PingHub pushes a message to the WebSocket inside the iframe → iframe posts it back as `[{type:'message', data:'<base64>'}, 200, callbackId]` → bridge decodes base64 to `Uint8Array` and invokes registered `onMessage` handlers for that path.
+
+#### Multiplexing
+
+One iframe serves **all** PingHub channels. Each channel is identified by its `path` string. The bridge maintains per-path handler sets (`openHandlers`, `closeHandlers`, `messageHandlers`), so multiple rooms (one per open post) share the same bridge and iframe, each listening on their own path.
+
+#### Edge cases
+
+| Scenario | How the bridge handles it |
+| --- | --- |
+| **Already connected** | If `connectedPaths` has the path, fires open handlers immediately without sending another connect |
+| **Duplicate connect in flight** | Subsequent `connect()` calls for the same path join the existing waiter list instead of opening a second socket |
+| **Already subscribed (444)** | Proxy returns status 444 — bridge treats it as a successful open |
+| **Non-base64 text frames** | Falls back to `textToBytes()` if base64 decode throws |
+| **Blob data** | Converts asynchronously via `blob.arrayBuffer()` |
+
+#### Chunking
+
+PingHub has a per-frame size limit. The bridge automatically **chunks** outgoing messages larger than 256 bytes and **reassembles** incoming chunked frames:
+
+- Messages ≤ 256 bytes are sent as a single frame.
+- Larger messages are split into chunks of up to 251 bytes (256 minus the 5-byte chunk header).
+- Each chunk frame: `[0xFE magic, msgId high, msgId low, totalChunks, chunkIndex, ...payload]`.
+- The receiver buffers chunks by `path:msgId` and delivers the full reassembled message once all chunks arrive.
+
+Both sender and receiver handle chunking transparently — the manager layer sees only complete `Uint8Array` messages.
+
+### 5. Wire Protocol
+
+Every message sent by the manager is a `Uint8Array` with the following structure:
+
+```
+[varuint senderClientID] [varuint msgType] [type-specific payload]
+```
+
+The `senderClientID` prefix lets each client filter out its own messages (echoed back by PingHub's broadcast relay).
+
+| `msgType` | Value | Payload |
+| --- | --- | --- |
+| `MSG_SYNC` | `0x00` | Yjs sync protocol data (sync step 1, sync step 2, or update) |
+| `MSG_AWARENESS` | `0x01` | `varuint8array`-encoded awareness update |
+
+### 6. Sync Protocol
+
+The Yjs sync handshake runs over the PingHub channel:
+
+1. **Client A connects** → sends `sync_step1` (its state vector) as a `MSG_SYNC` frame.
+2. **PingHub relays** the message to all other subscribers on the channel.
+3. **Client B receives** → processes the sync step, generates `sync_step2` (the updates A is missing), and sends it back. Because this is pub/sub (not point-to-point), Client B also sends its own `sync_step1` the first time it sees a peer's `sync_step1`, so both sides complete the handshake.
+4. **Ongoing edits** → each client sends `MSG_SYNC` update frames for every Yjs `update` event (ignoring updates originated from `pinghub-manager` to avoid echo loops).
+
+### 7. Awareness
+
+Awareness state (presence, cursor positions) is synchronized alongside document updates:
+
+- **On connect**: the manager broadcasts the local awareness state to all peers.
+- **On local change**: awareness updates (`added`, `updated`, `removed` client IDs) are sent immediately as `MSG_AWARENESS` frames.
+- **On remote message**: incoming awareness updates are applied locally via `y-protocols/awareness`.
+- **On page hide**: the manager broadcasts a removal for the local client ID so peers immediately learn the user has left (uses synchronous `postMessage` which survives page teardown).
+- **On destroy**: a final awareness removal is broadcast before tearing down listeners.
+
+### 8. Reconnection
+
+When the WebSocket connection drops:
+
+1. Emit `disconnected` status (suppressed during page unload to avoid a brief flash).
+2. Schedule a reconnect with **exponential backoff**: starting at 1 s, doubling each attempt, capped at 30 s.
+3. Emit `connecting` before each retry.
+4. On success: `handleWsOpen` fires, re-sends `sync_step1` and broadcasts awareness.
+5. When the tab returns to the foreground (`visibilitychange`), any disconnected rooms reconnect immediately (backoff resets).
+
+### 9. Connection Status
+
+The provider emits `status` events compatible with Gutenberg's `ConnectionStatus` interface:
+
+| Status | When |
+| --- | --- |
+| `connecting` | Initial connection or reconnect attempt |
+| `connected` | WebSocket open, sync step 1 sent |
+| `disconnected` | WebSocket closed or provider destroyed |
+
+### 10. Lifecycle
+
+Window-level event handlers are shared across all active rooms:
+
+- `beforeunload` → sets an unload flag so `handleWsClose` suppresses the disconnect status.
+- `pagehide` → broadcasts awareness removal for every connected room.
+- `visibilitychange` → reconnects any disconnected rooms when the tab becomes visible.
+
+Listeners are registered when the first room is created and removed when the last one is unregistered.

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/providers/pinghub/index.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/providers/pinghub/index.ts
@@ -1,0 +1,1 @@
+export { createPingHubProvider } from './pinghub-provider';

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/providers/pinghub/keepalive-worker.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/providers/pinghub/keepalive-worker.ts
@@ -1,0 +1,9 @@
+/**
+ * Tiny Web Worker that sends a 'tick' message at a fixed interval.
+ *
+ * Web Worker timers are not throttled by browsers when the tab is in the
+ * background, unlike main-thread setInterval which slows to ~1/min.
+ * The main thread uses these ticks to re-broadcast awareness keepalives
+ * so that remote peers don't time out this client after 30 seconds.
+ */
+setInterval( () => postMessage( 'tick' ), 25 * 1000 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/providers/pinghub/pinghub-bridge.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/providers/pinghub/pinghub-bridge.ts
@@ -1,0 +1,684 @@
+type BridgeEventMap = {
+	open: () => void;
+	close: ( code: number, reason: string ) => void;
+	message: ( data: Uint8Array ) => void;
+};
+
+/** Body of a PingHub proxy response (open, close, message, or error). */
+type ProxyResponseBody = {
+	type: 'open' | 'close' | 'message' | 'error';
+	code?: number;
+	reason?: string;
+	text?: string;
+	data?: ArrayBuffer | Blob | string;
+};
+
+/** Normalized proxy response we can handle in one place. */
+type NormalizedProxyResponse = {
+	body: ProxyResponseBody;
+	code: number;
+	callback: string;
+};
+
+const IFRAME_SRC_BASE = 'https://public-api.wordpress.com/wp-admin/rest-proxy/';
+const PROXY_ORIGIN = 'https://public-api.wordpress.com';
+const PROXY_ALREADY_SUBSCRIBED = 444;
+const PROXY_READY_TIMEOUT_MS = 30 * 1000;
+
+const CHUNK_MAGIC = 0xfe;
+const CHUNK_HEADER_LEN = 5; // magic(1) + msgId(2) + totalChunks(1) + chunkIndex(1)
+const MAX_PAYLOAD_BEFORE_CHUNK = 256;
+const MAX_CHUNK_BUFFERS = 64;
+
+/**
+ * Encode a Uint8Array into a base64 string for text-frame transport.
+ *
+ * @param u8 - Bytes to encode.
+ * @return Base64-encoded string.
+ */
+function uint8ArrayToBase64( u8: Uint8Array ): string {
+	let binary = '';
+	for ( let i = 0; i < u8.length; i++ ) {
+		binary += String.fromCharCode( u8[ i ] );
+	}
+	return btoa( binary );
+}
+
+/**
+ * Decode a base64 string back into a Uint8Array.
+ *
+ * @param base64 - Base64-encoded string.
+ * @return Decoded bytes.
+ */
+function base64ToUint8Array( base64: string ): Uint8Array {
+	const binary = atob( base64 );
+	const u8 = new Uint8Array( binary.length );
+	for ( let i = 0; i < binary.length; i++ ) {
+		u8[ i ] = binary.charCodeAt( i );
+	}
+	return u8;
+}
+
+/**
+ * Build a single chunk buffer: [CHUNK_MAGIC, msgIdHi, msgIdLo, totalChunks, chunkIndex, ...payload].
+ *
+ * @param msgId       - Message identifier (per path).
+ * @param totalChunks - Total chunks for this message.
+ * @param chunkIndex  - Zero-based index of this chunk.
+ * @param payload     - Slice of the original payload for this chunk.
+ * @return Encoded chunk including header and payload.
+ */
+function buildChunk(
+	msgId: number,
+	totalChunks: number,
+	chunkIndex: number,
+	payload: Uint8Array
+): Uint8Array {
+	const out = new Uint8Array( CHUNK_HEADER_LEN + payload.length );
+	out[ 0 ] = CHUNK_MAGIC;
+	out[ 1 ] = ( msgId >> 8 ) & 0xff; // eslint-disable-line no-bitwise
+	out[ 2 ] = msgId & 0xff; // eslint-disable-line no-bitwise
+	out[ 3 ] = totalChunks;
+	out[ 4 ] = chunkIndex;
+	out.set( payload, CHUNK_HEADER_LEN );
+	return out;
+}
+
+/**
+ * Parse chunk header. Returns null if not a chunk or invalid.
+ *
+ * @param data - Candidate frame bytes.
+ * @return Parsed header and payload, or null if not a chunk.
+ */
+function parseChunkHeader( data: Uint8Array ): {
+	msgId: number;
+	totalChunks: number;
+	chunkIndex: number;
+	payload: Uint8Array;
+} | null {
+	if ( data.length < CHUNK_HEADER_LEN || data[ 0 ] !== CHUNK_MAGIC ) {
+		return null;
+	}
+	return {
+		msgId: data[ 1 ] * 256 + data[ 2 ],
+		totalChunks: data[ 3 ],
+		chunkIndex: data[ 4 ],
+		payload: data.subarray( CHUNK_HEADER_LEN ),
+	};
+}
+
+/**
+ * Convert a string to bytes by taking the low byte of each char code.
+ *
+ * @param str - The string to convert.
+ * @return Byte array.
+ */
+function textToBytes( str: string ): Uint8Array {
+	const u8 = new Uint8Array( str.length );
+	for ( let i = 0; i < str.length; i++ ) {
+		// eslint-disable-next-line no-bitwise
+		u8[ i ] = str.charCodeAt( i ) & 0xff;
+	}
+	return u8;
+}
+
+/**
+ * Parse event.data (string or already an object) into a plain value.
+ *
+ * @param data - The postMessage data (possibly a JSON string).
+ * @return Parsed value or null.
+ */
+function parseRaw( data: unknown ): unknown {
+	if ( typeof data === 'string' ) {
+		try {
+			return JSON.parse( data );
+		} catch {
+			return null;
+		}
+	}
+	return data;
+}
+
+/**
+ * Try to parse the array format: [ body, code, headers?, callback ] or [ code, body, headers?, callback ].
+ *
+ * @param raw - The array payload from the proxy.
+ * @return Normalized response or null if not a valid array response.
+ */
+function parseArrayResponse( raw: unknown[] ): NormalizedProxyResponse | null {
+	if ( raw.length < 3 ) {
+		return null;
+	}
+
+	const callbackRaw = raw[ raw.length - 1 ];
+	const callback = callbackRaw != null ? String( callbackRaw ) : '';
+	if ( ! callback ) {
+		return null;
+	}
+
+	let code: number;
+	let bodyObj: unknown;
+	const first = raw[ 0 ];
+	const second = raw[ 1 ];
+	const firstIsCode =
+		typeof first === 'number' ||
+		( typeof first === 'string' && first !== '' && ! Number.isNaN( Number( first ) ) );
+
+	// Order A: [ body, code, headers?, callback ]
+	if ( typeof first === 'object' && first !== null ) {
+		bodyObj = first;
+		code = Number( raw[ raw.length - 2 ] );
+	}
+	// Order B: [ code, body, headers?, callback ] (code may be number or string from JSON)
+	else if ( firstIsCode && typeof second === 'object' && second !== null ) {
+		bodyObj = second;
+		code = Number( first );
+	} else {
+		return null;
+	}
+
+	// Inner body may be at .body or the object itself (e.g. { type: 'open' } or { body: { type, ... } })
+	const body =
+		( bodyObj as { body?: ProxyResponseBody } ).body ??
+		( ( bodyObj as { type?: string } ).type !== undefined ? bodyObj : null );
+	if (
+		typeof body !== 'object' ||
+		! body ||
+		typeof ( body as ProxyResponseBody ).type !== 'string'
+	) {
+		return null;
+	}
+	return { body: body as ProxyResponseBody, code, callback };
+}
+
+/**
+ * Try to parse the legacy object format: { callback, body: { type, ... }, code? }.
+ *
+ * @param raw - The object payload from the proxy.
+ * @return Normalized response or null if not a valid legacy response.
+ */
+function parseLegacyObjectResponse(
+	raw: Record< string, unknown >
+): NormalizedProxyResponse | null {
+	const o = raw as { callback?: string; body?: ProxyResponseBody; code?: number };
+	if ( typeof o.callback !== 'string' || ! o.body || typeof o.body !== 'object' ) {
+		return null;
+	}
+	return {
+		body: o.body as ProxyResponseBody,
+		code: typeof o.code === 'number' ? o.code : 0,
+		callback: o.callback,
+	};
+}
+
+/**
+ * Normalize proxy response (array or legacy object) into a single shape.
+ *
+ * Proxy sends either an array `[ body, code, headers?, callback ]` (supports_args)
+ * or a legacy object with `.callback` and `.body`.
+ *
+ * @param raw - The parsed postMessage payload.
+ * @return Normalized response or null if not a valid proxy response.
+ */
+function normalizeProxyResponse( raw: unknown ): NormalizedProxyResponse | null {
+	if ( ! raw || typeof raw !== 'object' ) {
+		return null;
+	}
+
+	if ( Array.isArray( raw ) ) {
+		return parseArrayResponse( raw );
+	}
+
+	return parseLegacyObjectResponse( raw as Record< string, unknown > );
+}
+
+/**
+ * Get the blog ID from the WordPress globals.
+ *
+ * @return The blog ID or null if it cannot be determined.
+ */
+function getBlogId(): number | null {
+	if ( typeof window._currentSiteId === 'number' ) {
+		return window._currentSiteId;
+	}
+	if ( typeof window.wpcomGutenberg?.blogId === 'number' ) {
+		return window.wpcomGutenberg.blogId;
+	}
+	if ( typeof window.currentBlogId === 'number' ) {
+		return window.currentBlogId;
+	}
+	return null;
+}
+
+export class PingHubBridge {
+	private iframe: HTMLIFrameElement;
+	private ready = false;
+	private readyResolvers: Array< () => void > = [];
+	private openHandlers = new Map< string, Set< () => void > >();
+	private closeHandlers = new Map< string, Set< ( code: number, reason: string ) => void > >();
+	private messageHandlers = new Map< string, Set< ( data: Uint8Array ) => void > >();
+	private callbackSeq = 1;
+	private pending = new Map< string, () => void >();
+	private callbackToPath = new Map< string, string >();
+	private pathToCallback = new Map< string, string >();
+	/** Paths that have received 'open' and not yet 'close' or disconnect – one socket per path. */
+	private connectedPaths = new Set< string >();
+	/** Paths with a connect request in flight; waiters are resolved when we get open or error. */
+	private connectingPathWaiters = new Map<
+		string,
+		Array< { resolve: () => void; reject: ( err: Error ) => void } >
+	>();
+	/** Per-path message id for chunked sends. */
+	private chunkMsgIdByPath = new Map< string, number >();
+	/** Reassembly buffer: key = path + ':' + msgId, value = { totalChunks, chunks } */
+	private chunkBuffers = new Map<
+		string,
+		{ totalChunks: number; chunks: Map< number, Uint8Array > }
+	>();
+
+	/** Reuse an existing proxy iframe or create a new one and start listening for messages. */
+	constructor() {
+		const existing = document.querySelector(
+			`iframe[src^="${ IFRAME_SRC_BASE }"]`
+		) as HTMLIFrameElement | null;
+		this.iframe = existing ?? this.createIframe();
+		window.addEventListener( 'message', this.handleMessage );
+	}
+
+	/**
+	 * Build the full PingHub path for a room name.
+	 *
+	 * @param room - Short room identifier (e.g. "postType-post-42").
+	 * @return Full PingHub channel path.
+	 */
+	private fullPath( room: string ): string {
+		const blogId = getBlogId();
+		if ( ! blogId ) {
+			throw new Error( 'Cannot determine blog ID for PingHub bridge' );
+		}
+
+		return `/pinghub/wpcom/rtc/${ blogId }/${ room }`;
+	}
+
+	/**
+	 * Create and append a hidden proxy iframe to the document body.
+	 *
+	 * @return The created iframe element.
+	 */
+	private createIframe(): HTMLIFrameElement {
+		const iframe = document.createElement( 'iframe' );
+		iframe.style.cssText = 'position:absolute;left:-9999px;width:1px;height:1px;';
+		iframe.src = `${ IFRAME_SRC_BASE }?v=2.0#${ window.location.origin }`;
+		document.body.appendChild( iframe );
+		return iframe;
+	}
+
+	/**
+	 * Post a structured message to the proxy iframe.
+	 *
+	 * @param msg - The message to send.
+	 */
+	private postToProxy( msg: Record< string, unknown > ): void {
+		this.iframe.contentWindow?.postMessage( msg, PROXY_ORIGIN );
+	}
+
+	/**
+	 * Return a promise that resolves once the proxy iframe signals readiness.
+	 *
+	 * @return Resolves when the proxy is ready.
+	 */
+	private waitReady(): Promise< void > {
+		if ( this.ready ) {
+			return Promise.resolve();
+		}
+		return new Promise( ( resolve, reject ) => {
+			this.readyResolvers.push( resolve );
+			setTimeout( () => {
+				if ( ! this.ready ) {
+					reject( new Error( 'PingHub proxy iframe did not become ready in time' ) );
+				}
+			}, PROXY_READY_TIMEOUT_MS );
+		} );
+	}
+
+	/**
+	 * Handle incoming postMessage events from the proxy iframe.
+	 *
+	 * @param event - The MessageEvent from the proxy.
+	 */
+	private handleMessage = ( event: MessageEvent ): void => {
+		if ( event.origin !== PROXY_ORIGIN ) {
+			return;
+		}
+
+		const data = event.data;
+
+		// 1) Ready / cookie-auth
+		if (
+			data === 'ready' ||
+			( data?.type === 'pinghub-proxy' && data?.body?.type === 'cookie-auth' )
+		) {
+			this.ready = true;
+			this.readyResolvers.splice( 0 ).forEach( r => r() );
+			return;
+		}
+
+		// 2) Proxy JSON response (array or object)
+		const raw = parseRaw( data );
+		const response = normalizeProxyResponse( raw );
+		if ( response ) {
+			this.handleProxyResponse( response );
+		}
+	};
+
+	/**
+	 * Resolve or reject all connect waiters for a path.
+	 *
+	 * @param path    - The PingHub path.
+	 * @param success - Whether the connect succeeded.
+	 */
+	private settleConnectWaiters( path: string | undefined, success: boolean ): void {
+		const waiters = path ? this.connectingPathWaiters.get( path ) : undefined;
+		if ( waiters ) {
+			const err = new Error( 'PingHub connect failed' );
+			waiters.forEach( w => ( success ? w.resolve() : w.reject( err ) ) );
+			this.connectingPathWaiters.delete( path! );
+		}
+	}
+
+	/**
+	 * Route a normalized proxy response to the appropriate handler by message type.
+	 *
+	 * @param res - The normalized proxy response.
+	 */
+	private handleProxyResponse( res: NormalizedProxyResponse ): void {
+		const { body, code, callback } = res;
+		const path = this.callbackToPath.get( callback );
+		const resolvePending = this.pending.get( callback );
+		if ( resolvePending ) {
+			this.pending.delete( callback );
+		}
+
+		switch ( body.type ) {
+			case 'open':
+				if ( path ) {
+					this.connectedPaths.add( path );
+					this.openHandlers.get( path )?.forEach( h => h() );
+				}
+				this.settleConnectWaiters( path, true );
+				break;
+			case 'close':
+				if ( path ) {
+					this.connectedPaths.delete( path );
+					this.closeHandlers.get( path )?.forEach( h => h( body.code ?? 1000, body.reason ?? '' ) );
+				}
+				if ( resolvePending ) {
+					resolvePending();
+				}
+				break;
+			case 'message':
+				if ( path && body.data !== undefined ) {
+					this.dispatchToHandlers( path, body.data );
+				}
+				break;
+			case 'error':
+				// Proxy returns 444 "already subscribed" when we connect the same path twice – treat as success.
+				if ( path && ( code === PROXY_ALREADY_SUBSCRIBED || body.text === 'already subscribed' ) ) {
+					this.connectedPaths.add( path );
+					this.openHandlers.get( path )?.forEach( h => h() );
+					this.settleConnectWaiters( path, true );
+				} else {
+					if ( path ) {
+						this.callbackToPath.delete( callback );
+						this.pathToCallback.delete( path );
+					}
+					this.settleConnectWaiters( path, false );
+					if ( resolvePending ) {
+						resolvePending();
+					}
+				}
+				break;
+			default:
+				if ( resolvePending ) {
+					resolvePending();
+				}
+		}
+	}
+
+	/**
+	 * Dispatches received data to path handlers.
+	 *
+	 * Incoming frames may be:
+	 * - Base64 string (text frame): decoded to Uint8Array, then treated as chunk or whole message.
+	 * - Chunk (first byte CHUNK_MAGIC): buffered by path+msgId; when all chunks received, reassembled in order (chunk 0, 1, …) and passed once to handlers. Non-chunk messages are passed through.
+	 *
+	 * @param path - PingHub path for the message.
+	 * @param data - Raw payload from the proxy.
+	 */
+	private dispatchToHandlers( path: string, data: ArrayBuffer | Blob | string ): void {
+		const handlers = this.messageHandlers.get( path );
+		if ( ! handlers?.size ) {
+			return;
+		}
+
+		const run = ( u8: Uint8Array ) => {
+			const parsed = parseChunkHeader( u8 );
+			if ( parsed ) {
+				this.reassembleChunk( path, parsed, handlers );
+				return;
+			}
+			handlers.forEach( h => h( u8 ) );
+		};
+		if ( typeof data === 'string' ) {
+			try {
+				run( base64ToUint8Array( data ) );
+			} catch {
+				// Fallback: treat as raw bytes (e.g. proxy sent non-base64 text)
+				run( textToBytes( data ) );
+			}
+		} else if ( data instanceof ArrayBuffer ) {
+			run( new Uint8Array( data ) );
+		} else if ( data instanceof Blob ) {
+			data.arrayBuffer().then( ab => run( new Uint8Array( ab ) ) );
+		}
+	}
+
+	/**
+	 * Buffer incoming chunks and dispatch the reassembled message when all chunks have arrived.
+	 *
+	 * @param path               - PingHub path for the message.
+	 * @param parsed             - Parsed chunk header and payload.
+	 * @param parsed.msgId       - Message identifier shared across all chunks of one message.
+	 * @param parsed.totalChunks - Total number of chunks expected.
+	 * @param parsed.chunkIndex  - Zero-based index of this chunk.
+	 * @param parsed.payload     - Payload bytes for this chunk.
+	 * @param handlers           - Set of handlers to invoke with the reassembled message.
+	 */
+	private reassembleChunk(
+		path: string,
+		parsed: { msgId: number; totalChunks: number; chunkIndex: number; payload: Uint8Array },
+		handlers: Set< ( data: Uint8Array ) => void >
+	): void {
+		const key = `${ path }:${ parsed.msgId }`;
+		let buf = this.chunkBuffers.get( key );
+		if ( ! buf ) {
+			// Drop oldest incomplete buffers when the cap is reached.
+			if ( this.chunkBuffers.size >= MAX_CHUNK_BUFFERS ) {
+				const oldest = this.chunkBuffers.keys().next().value;
+				if ( oldest !== undefined ) {
+					this.chunkBuffers.delete( oldest );
+				}
+			}
+			buf = { totalChunks: parsed.totalChunks, chunks: new Map() };
+			this.chunkBuffers.set( key, buf );
+		}
+		buf.chunks.set( parsed.chunkIndex, parsed.payload );
+		if ( buf.chunks.size !== buf.totalChunks ) {
+			return;
+		}
+
+		this.chunkBuffers.delete( key );
+		const parts: Uint8Array[] = [];
+		for ( let i = 0; i < buf.totalChunks; i++ ) {
+			const chunk = buf.chunks.get( i );
+			if ( ! chunk ) {
+				// Missing chunk index — discard the incomplete message.
+				return;
+			}
+			parts.push( chunk );
+		}
+		const totalLen = parts.reduce( ( s, p ) => s + p.length, 0 );
+		const reassembled = new Uint8Array( totalLen );
+		let offset = 0;
+		for ( const p of parts ) {
+			reassembled.set( p, offset );
+			offset += p.length;
+		}
+		handlers.forEach( h => h( reassembled ) );
+	}
+
+	/**
+	 * Return the handler map for a given event type.
+	 *
+	 * @param event - The event name.
+	 * @return The corresponding handler map.
+	 */
+	private handlersFor< E extends keyof BridgeEventMap >(
+		event: E
+	): Map< string, Set< BridgeEventMap[ E ] > > {
+		switch ( event ) {
+			case 'open':
+				return this.openHandlers as Map< string, Set< BridgeEventMap[ E ] > >;
+			case 'close':
+				return this.closeHandlers as Map< string, Set< BridgeEventMap[ E ] > >;
+			case 'message':
+				return this.messageHandlers as Map< string, Set< BridgeEventMap[ E ] > >;
+			default:
+				throw new Error( `Unknown bridge event: ${ String( event ) }` );
+		}
+	}
+
+	/**
+	 * Register an event handler for a channel path.
+	 *
+	 * @param path    - PingHub channel path.
+	 * @param event   - Event name: 'open', 'close', or 'message'.
+	 * @param handler - Callback for the event.
+	 */
+	on< E extends keyof BridgeEventMap >(
+		path: string,
+		event: E,
+		handler: BridgeEventMap[ E ]
+	): void {
+		const map = this.handlersFor( event );
+		let set = map.get( path );
+		if ( ! set ) {
+			set = new Set();
+			map.set( path, set );
+		}
+		set.add( handler );
+	}
+
+	/**
+	 * Remove a previously registered event handler.
+	 *
+	 * @param path    - PingHub channel path.
+	 * @param event   - Event name: 'open', 'close', or 'message'.
+	 * @param handler - The handler to remove.
+	 */
+	off< E extends keyof BridgeEventMap >(
+		path: string,
+		event: E,
+		handler: BridgeEventMap[ E ]
+	): void {
+		this.handlersFor( event ).get( path )?.delete( handler );
+	}
+
+	async connect( room: string ): Promise< void > {
+		await this.waitReady();
+
+		// Already connected: no new socket, just notify so handlers run.
+		if ( this.connectedPaths.has( room ) ) {
+			this.openHandlers.get( room )?.forEach( h => h() );
+			return;
+		}
+
+		// Connect already in flight for this room: wait for it instead of sending another.
+		const existing = this.connectingPathWaiters.get( room );
+		if ( existing ) {
+			return new Promise( ( resolve, reject ) => existing.push( { resolve, reject } ) );
+		}
+
+		const waiters: Array< { resolve: () => void; reject: ( err: Error ) => void } > = [];
+		this.connectingPathWaiters.set( room, waiters );
+
+		const callback = String( this.callbackSeq++ );
+		this.callbackToPath.set( callback, room );
+		this.pathToCallback.set( room, callback );
+
+		this.postToProxy( {
+			type: 'pinghub-proxy',
+			action: 'connect',
+			path: this.fullPath( room ),
+			callback,
+			supports_args: true,
+			binary: false,
+		} );
+
+		return new Promise( ( resolve, reject ) => {
+			waiters.push( { resolve, reject } );
+		} );
+	}
+
+	async disconnect( room: string ): Promise< void > {
+		await this.waitReady();
+		this.connectedPaths.delete( room );
+		const callback = this.pathToCallback.get( room );
+		if ( callback ) {
+			this.callbackToPath.delete( callback );
+			this.pathToCallback.delete( room );
+		}
+		return new Promise( resolve => {
+			const discCallback = String( this.callbackSeq++ );
+			this.pending.set( discCallback, () => resolve() );
+			this.postToProxy( {
+				type: 'pinghub-proxy',
+				action: 'disconnect',
+				path: this.fullPath( room ),
+				callback: discCallback,
+			} );
+		} );
+	}
+
+	send( room: string, data: Uint8Array ): void {
+		if ( ! this.iframe.contentWindow ) {
+			return;
+		}
+
+		const proxyPath = this.fullPath( room );
+		const sendOne = ( payload: Uint8Array ) => {
+			this.postToProxy( {
+				type: 'pinghub-proxy',
+				action: 'send',
+				path: proxyPath,
+				message: uint8ArrayToBase64( payload ),
+			} );
+		};
+
+		if ( data.length <= MAX_PAYLOAD_BEFORE_CHUNK ) {
+			sendOne( data );
+			return;
+		}
+
+		const msgId = ( this.chunkMsgIdByPath.get( room ) ?? 0 ) & 0xffff; // eslint-disable-line no-bitwise
+		this.chunkMsgIdByPath.set( room, msgId + 1 );
+		const chunkSize = MAX_PAYLOAD_BEFORE_CHUNK - CHUNK_HEADER_LEN;
+		const totalChunks = Math.ceil( data.length / chunkSize );
+		for ( let i = 0; i < totalChunks; i++ ) {
+			const start = i * chunkSize;
+			const payload = data.subarray( start, Math.min( start + chunkSize, data.length ) );
+			const chunk = buildChunk( msgId, totalChunks, i, payload );
+			sendOne( chunk );
+		}
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/providers/pinghub/pinghub-manager.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/providers/pinghub/pinghub-manager.ts
@@ -1,0 +1,455 @@
+import * as decoding from 'lib0/decoding';
+import * as encoding from 'lib0/encoding';
+import * as awarenessProtocol from 'y-protocols/awareness';
+import * as syncProtocol from 'y-protocols/sync';
+import { PingHubBridge } from './pinghub-bridge';
+import type { Awareness, ConnectionStatus } from '@wordpress/sync';
+import type * as Y from 'yjs';
+
+const MSG_SYNC = 0x00;
+const MSG_AWARENESS = 0x01;
+const RECONNECT_BASE_DELAY_MS = 1000;
+const RECONNECT_MAX_DELAY_MS = 30 * 1000;
+const PINGHUB_MANAGER_ORIGIN = 'pinghub-manager';
+
+interface RegisterRoomOptions {
+	room: string;
+	doc: Y.Doc;
+	awareness: Awareness;
+	onStatusChange: ( status: ConnectionStatus ) => void;
+	onSync: () => void;
+}
+
+const rooms: Map< string, PingHubConnection > = new Map();
+let bridge: PingHubBridge | null = null;
+let isUnloadPending = false;
+let areListenersRegistered = false;
+let keepaliveWorker: Worker | null = null;
+
+/**
+ * Manages a single room's real-time synchronization via PingHub.
+ *
+ * Handles Yjs sync protocol, awareness broadcasting, and reconnection with
+ * exponential backoff. Delegates transport to the shared PingHubBridge.
+ */
+class PingHubConnection {
+	private readonly room: string;
+	private readonly clientId: number;
+	private readonly doc: Y.Doc;
+	private readonly awareness: Awareness;
+	private readonly onStatusChange: ( status: ConnectionStatus ) => void;
+	private readonly onSync: () => void;
+
+	public connected = false;
+	private syncStep1RepliedTo = new Set< number >();
+	public reconnectTimer: ReturnType< typeof setTimeout > | null = null;
+	public reconnectDelay = RECONNECT_BASE_DELAY_MS;
+
+	public constructor( options: RegisterRoomOptions ) {
+		this.room = options.room;
+		this.doc = options.doc;
+		this.clientId = options.doc.clientID;
+		this.awareness = options.awareness;
+		this.onStatusChange = options.onStatusChange;
+		this.onSync = options.onSync;
+
+		this.doc.on( 'update', this.handleDocUpdate );
+		this.awareness.on( 'change', this.handleAwarenessChange );
+		if ( bridge ) {
+			bridge.on( this.room, 'open', this.handleWsOpen );
+			bridge.on( this.room, 'close', this.handleWsClose );
+			bridge.on( this.room, 'message', this.handleWsMessage );
+		}
+	}
+
+	/**
+	 * Tear down the connection: remove listeners, cancel reconnection, disconnect.
+	 */
+	public destroy(): void {
+		if ( this.connected ) {
+			this.removeAwareness( 'provider-destroy' );
+		}
+
+		if ( this.reconnectTimer !== null ) {
+			clearTimeout( this.reconnectTimer );
+			this.reconnectTimer = null;
+		}
+
+		this.doc.off( 'update', this.handleDocUpdate );
+		this.awareness.off( 'change', this.handleAwarenessChange );
+		if ( bridge ) {
+			bridge.off( this.room, 'open', this.handleWsOpen );
+			bridge.off( this.room, 'close', this.handleWsClose );
+			bridge.off( this.room, 'message', this.handleWsMessage );
+			bridge.disconnect( this.room );
+		}
+	}
+
+	/**
+	 * Connect the room to PingHub via the shared bridge.
+	 */
+	public connect(): void {
+		if ( ! bridge ) {
+			return;
+		}
+		this.onStatusChange( { status: 'connecting' } );
+		bridge.connect( this.room ).catch( () => {
+			this.onStatusChange( { status: 'disconnected' } );
+			this.scheduleReconnect();
+		} );
+	}
+
+	/**
+	 * Broadcast awareness removal to peers.
+	 *
+	 * @param reason - Reason for removal (e.g. 'page-hide', 'provider-destroy').
+	 */
+	public removeAwareness( reason: string ): void {
+		awarenessProtocol.removeAwarenessStates( this.awareness, [ this.clientId ], reason );
+	}
+
+	/**
+	 * Re-broadcast local awareness state to peers.
+	 *
+	 * Called periodically by the keepalive worker to prevent the y-protocols
+	 * awareness timeout (30s) from removing this client on remote peers.
+	 */
+	public broadcastLocalAwareness(): void {
+		if ( ! this.connected ) {
+			return;
+		}
+		const localState = this.awareness.getLocalState();
+		if ( localState ) {
+			// setLocalState updates the clock and lastUpdated in meta, but
+			// does NOT emit 'change' when the state is deep-equal to the
+			// previous one. We call it to bump the meta, then manually
+			// encode and broadcast so the update reaches remote peers.
+			this.awareness.setLocalState( localState );
+			const update = awarenessProtocol.encodeAwarenessUpdate( this.awareness, [ this.clientId ] );
+			this.broadcastAwareness( update );
+		}
+	}
+
+	/**
+	 * Send a message, prepending the client ID.
+	 *
+	 * @param u8 - Encoded message payload.
+	 */
+	private send( u8: Uint8Array ): void {
+		if ( ! bridge ) {
+			return;
+		}
+		const enc = encoding.createEncoder();
+		encoding.writeVarUint( enc, this.clientId );
+		encoding.writeUint8Array( enc, u8 );
+		bridge.send( this.room, encoding.toUint8Array( enc ) );
+	}
+
+	/**
+	 * Send a Yjs sync step 1 message to initiate document synchronization.
+	 */
+	private sendSyncStep1(): void {
+		const enc = encoding.createEncoder();
+		encoding.writeVarUint( enc, MSG_SYNC );
+		syncProtocol.writeSyncStep1( enc, this.doc );
+		this.send( encoding.toUint8Array( enc ) );
+	}
+
+	/**
+	 * Broadcast an awareness update to all peers.
+	 *
+	 * @param awarenessUpdate - Encoded awareness update.
+	 */
+	private broadcastAwareness( awarenessUpdate: Uint8Array ): void {
+		const enc = encoding.createEncoder();
+		encoding.writeVarUint( enc, MSG_AWARENESS );
+		encoding.writeVarUint8Array( enc, awarenessUpdate );
+		this.send( encoding.toUint8Array( enc ) );
+	}
+
+	/**
+	 * Schedule a reconnection attempt with exponential backoff.
+	 */
+	private scheduleReconnect(): void {
+		if ( this.reconnectTimer !== null ) {
+			return;
+		}
+		this.reconnectTimer = setTimeout( () => {
+			this.reconnectTimer = null;
+			if ( rooms.has( this.room ) ) {
+				this.connect();
+			}
+		}, this.reconnectDelay );
+		this.reconnectDelay = Math.min( this.reconnectDelay * 2, RECONNECT_MAX_DELAY_MS );
+	}
+
+	/**
+	 * Handle WebSocket open. Sends sync step 1 and local awareness state.
+	 */
+	private handleWsOpen = (): void => {
+		if ( ! rooms.has( this.room ) ) {
+			return;
+		}
+		this.connected = true;
+		this.syncStep1RepliedTo.clear();
+		this.reconnectDelay = RECONNECT_BASE_DELAY_MS;
+		this.onStatusChange( { status: 'connected' } );
+
+		this.sendSyncStep1();
+
+		// Only broadcast our own awareness state. Other peers will
+		// announce themselves; re-broadcasting their states could
+		// resurrect stale entries and cause duplicate peers.
+		if ( this.awareness.getLocalState() ) {
+			const update = awarenessProtocol.encodeAwarenessUpdate( this.awareness, [ this.clientId ] );
+			this.broadcastAwareness( update );
+		}
+	};
+
+	/**
+	 * Handle WebSocket close. Schedules reconnection.
+	 */
+	private handleWsClose = (): void => {
+		this.connected = false;
+		if ( ! rooms.has( this.room ) ) {
+			return;
+		}
+		if ( ! isUnloadPending ) {
+			this.onStatusChange( { status: 'disconnected' } );
+		}
+		this.scheduleReconnect();
+	};
+
+	/**
+	 * Handle incoming WebSocket messages. Dispatches sync and awareness messages.
+	 *
+	 * @param data - Raw message payload.
+	 */
+	private handleWsMessage = ( data: Uint8Array ): void => {
+		if ( ! rooms.has( this.room ) ) {
+			return;
+		}
+
+		const dec = decoding.createDecoder( data );
+		const senderClientID = decoding.readVarUint( dec );
+
+		if ( senderClientID === this.clientId ) {
+			return;
+		}
+
+		const msgType = decoding.readVarUint( dec );
+
+		switch ( msgType ) {
+			case MSG_SYNC: {
+				const innerType = dec.arr[ dec.pos ];
+
+				const enc = encoding.createEncoder();
+				encoding.writeVarUint( enc, MSG_SYNC );
+				syncProtocol.readSyncMessage( dec, enc, this.doc, PINGHUB_MANAGER_ORIGIN );
+				this.onSync();
+
+				const reply = encoding.toUint8Array( enc );
+				if ( reply.length > 1 ) {
+					this.send( reply );
+				}
+
+				if (
+					innerType === syncProtocol.messageYjsSyncStep1 &&
+					! this.syncStep1RepliedTo.has( senderClientID )
+				) {
+					this.syncStep1RepliedTo.add( senderClientID );
+					this.sendSyncStep1();
+					// Send our awareness so the new peer sees us immediately.
+					const awarenessUpdate = awarenessProtocol.encodeAwarenessUpdate( this.awareness, [
+						this.clientId,
+					] );
+					this.broadcastAwareness( awarenessUpdate );
+				}
+				return;
+			}
+			case MSG_AWARENESS: {
+				const update = decoding.readVarUint8Array( dec );
+				awarenessProtocol.applyAwarenessUpdate( this.awareness, update, PINGHUB_MANAGER_ORIGIN );
+				break;
+			}
+			default:
+				break;
+		}
+	};
+
+	/**
+	 * Handle local Yjs document updates. Broadcasts the update to peers.
+	 *
+	 * @param update - Yjs document update.
+	 * @param origin - Origin of the update.
+	 */
+	private handleDocUpdate = ( update: Uint8Array, origin: unknown ): void => {
+		if ( ! rooms.has( this.room ) || origin === PINGHUB_MANAGER_ORIGIN || ! this.connected ) {
+			return;
+		}
+
+		const enc = encoding.createEncoder();
+		encoding.writeVarUint( enc, MSG_SYNC );
+		syncProtocol.writeUpdate( enc, update );
+		this.send( encoding.toUint8Array( enc ) );
+	};
+
+	/**
+	 * Handle local awareness changes. Broadcasts the changes to peers.
+	 *
+	 * @param changes         - Changed client IDs.
+	 * @param changes.added   - Newly added client IDs.
+	 * @param changes.updated - Updated client IDs.
+	 * @param changes.removed - Removed client IDs.
+	 */
+	private handleAwarenessChange = ( {
+		added,
+		updated,
+		removed,
+	}: {
+		added: number[];
+		updated: number[];
+		removed: number[];
+	} ): void => {
+		if ( ! this.connected ) {
+			return;
+		}
+		const changed = added.concat( updated ).concat( removed );
+		const update = awarenessProtocol.encodeAwarenessUpdate( this.awareness, changed );
+		this.broadcastAwareness( update );
+	};
+}
+
+/**
+ * Create a Web Worker that sends periodic 'tick' messages for awareness keepalive.
+ *
+ * @return Worker
+ */
+function createKeepaliveWorker(): Worker {
+	const worker = new Worker( new URL( './keepalive-worker', import.meta.url ) );
+	worker.onmessage = () => {
+		for ( const [ , connection ] of rooms ) {
+			connection.broadcastLocalAwareness();
+		}
+	};
+	return worker;
+}
+
+/**
+ * Tear down the keepalive worker.
+ */
+function destroyKeepaliveWorker(): void {
+	if ( keepaliveWorker ) {
+		keepaliveWorker.terminate();
+		keepaliveWorker = null;
+	}
+}
+
+/**
+ * Suppress disconnect status flash during page navigation.
+ */
+function handleBeforeUnload(): void {
+	isUnloadPending = true;
+}
+
+/**
+ * Broadcast awareness removal for all connected rooms when the page is hidden.
+ */
+function handlePageHide(): void {
+	for ( const [ , connection ] of rooms ) {
+		if ( connection.connected ) {
+			connection.removeAwareness( 'page-hide' );
+		}
+	}
+}
+
+/**
+ * Reconnect all disconnected rooms when the page becomes visible again.
+ */
+function handleVisibilityChange(): void {
+	if ( document.visibilityState !== 'visible' ) {
+		return;
+	}
+	isUnloadPending = false;
+	for ( const [ , connection ] of rooms ) {
+		if ( connection.connected ) {
+			continue;
+		}
+		if ( connection.reconnectTimer !== null ) {
+			clearTimeout( connection.reconnectTimer );
+			connection.reconnectTimer = null;
+		}
+		connection.reconnectDelay = RECONNECT_BASE_DELAY_MS;
+		connection.connect();
+	}
+}
+
+/**
+ * Register a room for real-time synchronization via PingHub.
+ *
+ * Creates the shared bridge lazily on first call. Each room gets its own
+ * PingHubConnection that handles sync protocol, awareness, and reconnection.
+ *
+ * @param options                - Registration options.
+ * @param options.room           - Room name.
+ * @param options.doc            - Yjs document to synchronize.
+ * @param options.awareness      - Awareness instance for cursor/presence data.
+ * @param options.onStatusChange - Callback for connection status changes.
+ * @param options.onSync         - Callback invoked on each sync message.
+ */
+function registerRoom( options: RegisterRoomOptions ): void {
+	if ( rooms.has( options.room ) ) {
+		return;
+	}
+
+	// Lazy-create bridge on first registration.
+	if ( ! bridge ) {
+		bridge = new PingHubBridge();
+	}
+
+	const connection = new PingHubConnection( options );
+	rooms.set( options.room, connection );
+
+	if ( ! areListenersRegistered ) {
+		window.addEventListener( 'beforeunload', handleBeforeUnload );
+		window.addEventListener( 'pagehide', handlePageHide );
+		document.addEventListener( 'visibilitychange', handleVisibilityChange );
+		areListenersRegistered = true;
+	}
+
+	if ( ! keepaliveWorker ) {
+		keepaliveWorker = createKeepaliveWorker();
+	}
+
+	connection.connect();
+}
+
+/**
+ * Unregister a room, removing all listeners and disconnecting from PingHub.
+ *
+ * @param room - Room name.
+ */
+function unregisterRoom( room: string ): void {
+	const connection = rooms.get( room );
+	if ( ! connection ) {
+		return;
+	}
+
+	connection.destroy();
+	rooms.delete( room );
+
+	if ( rooms.size === 0 ) {
+		if ( areListenersRegistered ) {
+			window.removeEventListener( 'beforeunload', handleBeforeUnload );
+			window.removeEventListener( 'pagehide', handlePageHide );
+			document.removeEventListener( 'visibilitychange', handleVisibilityChange );
+			areListenersRegistered = false;
+		}
+		destroyKeepaliveWorker();
+	}
+}
+
+export const pinghubManager = {
+	registerRoom,
+	unregisterRoom,
+};

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/providers/pinghub/pinghub-provider.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/providers/pinghub/pinghub-provider.ts
@@ -1,0 +1,163 @@
+import { ObservableV2 } from 'lib0/observable';
+import { Awareness } from 'y-protocols/awareness';
+import { pinghubManager } from './pinghub-manager';
+import type { ConnectionStatus, ProviderCreator, ProviderCreatorResult } from '@wordpress/sync';
+import type * as Y from 'yjs';
+
+interface ProviderOptions {
+	awareness?: Awareness;
+	debug?: boolean;
+	room: string;
+	ydoc: Y.Doc;
+}
+
+type PingHubEvents = {
+	status: ( status: ConnectionStatus ) => void;
+};
+
+/**
+ * Yjs provider that uses PingHub WebSockets for real-time synchronization.
+ * Thin shell that delegates transport, sync protocol, and reconnection to
+ * the shared pinghub-manager module.
+ */
+class PingHubProvider extends ObservableV2< PingHubEvents > {
+	protected readonly awareness: Awareness;
+	protected status: ConnectionStatus[ 'status' ] = 'disconnected';
+	protected synced = false;
+	public constructor( private readonly options: ProviderOptions ) {
+		super();
+		this.log( 'Initializing', { room: options.room } );
+
+		this.awareness = options.awareness ?? new Awareness( options.ydoc );
+		this.connect();
+	}
+
+	/**
+	 * Connect to the endpoint and initialize sync.
+	 */
+	public connect(): void {
+		this.log( 'Connecting' );
+
+		pinghubManager.registerRoom( {
+			room: this.options.room,
+			doc: this.options.ydoc,
+			awareness: this.awareness,
+			onStatusChange: this.emitStatus,
+			onSync: this.onSync,
+		} );
+	}
+
+	/**
+	 * Disconnect the provider and allow reconnection later.
+	 */
+	public disconnect(): void {
+		this.log( 'Disconnecting' );
+
+		pinghubManager.unregisterRoom( this.options.room );
+		this.emitStatus( { status: 'disconnected' } );
+	}
+
+	/**
+	 * Destroy the provider and cleanup resources.
+	 */
+	public override destroy(): void {
+		this.disconnect();
+		super.destroy();
+	}
+
+	/**
+	 * Emit connection status, mirroring HttpPollingProvider semantics:
+	 * - Avoid duplicate emissions for the same status (unless there is an error).
+	 * - Only emit `connecting` when transitioning from `disconnected`.
+	 *
+	 * @param options        - Connection status object.
+	 * @param options.error  - Optional error details.
+	 * @param options.status - New connection status.
+	 */
+	protected emitStatus = ( { error, status }: ConnectionStatus ): void => {
+		if ( this.status === status && ! error ) {
+			return;
+		}
+		if ( status === 'connecting' && this.status !== 'disconnected' ) {
+			return;
+		}
+
+		this.log( 'Status change', { status, error } );
+
+		this.status = status;
+		this.emit( 'status', [ { error, status } ] );
+	};
+
+	/**
+	 * Log debug messages if debugging is enabled.
+	 *
+	 * @param message - Log message.
+	 * @param debug   - Optional debug context.
+	 */
+	protected log = ( message: string, debug: object = {} ): void => {
+		if ( this.options.debug ) {
+			// eslint-disable-next-line no-console
+			console.log( `[${ this.constructor.name }]: ${ message }`, {
+				room: this.options.room,
+				...debug,
+			} );
+		}
+	};
+
+	/**
+	 * Handle synchronization events from the manager.
+	 */
+	protected onSync = (): void => {
+		if ( ! this.synced ) {
+			this.synced = true;
+			this.log( 'Synced' );
+		}
+	};
+}
+
+/**
+ * Build a room name from an object type and ID.
+ *
+ * @param objectType - The type of the object.
+ * @param objectId   - The ID of the object.
+ * @return The room name (e.g. "postType-post-42").
+ */
+function getRoom( objectType: string, objectId: string | null ): string {
+	const normalizedType = objectType.replaceAll( '/', '-' );
+	const id = objectId ?? 'collection';
+	return `${ normalizedType }-${ id }`;
+}
+
+/**
+ * Create a provider creator function for the PingHubProvider.
+ *
+ * @return Provider creator compatible with the sync manager.
+ */
+export function createPingHubProvider(): ProviderCreator {
+	return async ( { awareness, objectType, objectId, ydoc } ): Promise< ProviderCreatorResult > => {
+		/**
+		 * Only post-like entities with a concrete ID are supported now.
+		 */
+		const SUPPORTED_OBJECT_TYPES = new Set( [ 'postType/post', 'postType/page' ] );
+		if ( ! SUPPORTED_OBJECT_TYPES.has( objectType ) || ! objectId ) {
+			return {
+				destroy: () => {},
+				on: () => {},
+			};
+		}
+
+		const room = getRoom( objectType, objectId );
+		const provider = new PingHubProvider( {
+			awareness,
+			room,
+			ydoc,
+		} );
+
+		return {
+			destroy: () => provider.destroy(),
+			on: ( event, callback ) => {
+				provider.on( event, callback );
+			},
+		};
+	};
+}

--- a/projects/packages/jetpack-mu-wpcom/src/utils.php
+++ b/projects/packages/jetpack-mu-wpcom/src/utils.php
@@ -144,59 +144,6 @@ function jetpack_mu_wpcom_enqueue_assets( $asset_name, $asset_types = array() ) 
 }
 
 /**
- * Enqueue a Calypso app script hosted on widgets.wp.com.
- *
- * Fetches the asset file (dependencies + version) from widgets.wp.com,
- * caches it with a transient, and enqueues the script.
- *
- * @param string $app_name The name of the app (used for handle, URL path, and asset file name).
- * @param string $entry    The entry file name without extension. Defaults to $app_name.
- *
- * @return string|null The script handle, or null if the asset file could not be loaded.
- */
-function jetpack_mu_wpcom_enqueue_calypso_app( $app_name, $entry = null ) {
-	if ( $entry === null ) {
-		$entry = $app_name;
-	}
-	$handle     = "jetpack-mu-wpcom-$app_name";
-	$cache_key  = $handle . '.asset.json';
-	$asset_file = get_transient( $cache_key );
-
-	if ( ! $asset_file ) {
-		$filepath            = "widgets.wp.com/$app_name/$app_name.asset.json";
-		$accessible_directly = file_exists( ABSPATH . '/' . $filepath );
-		if ( $accessible_directly ) {
-			$asset_file = json_decode( file_get_contents( ABSPATH . $filepath ), true ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-		} else {
-			$request = wp_remote_get( 'https://' . $filepath );
-			if ( is_wp_error( $request ) ) {
-				return null;
-			}
-			$asset_file = json_decode( wp_remote_retrieve_body( $request ), true );
-		}
-
-		if ( ! $asset_file ) {
-			return null;
-		}
-		set_transient( $cache_key, $asset_file, HOUR_IN_SECONDS );
-	}
-
-	$debug = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
-
-	wp_enqueue_script(
-		$handle,
-		$debug
-			? "//widgets.wp.com/$app_name/$entry.js?minify=false"
-			: "//widgets.wp.com/$app_name/$entry.min.js",
-		$asset_file['dependencies'] ?? array(),
-		$asset_file['version'] ?? gmdate( 'Ymd' ),
-		true
-	);
-
-	return $handle;
-}
-
-/**
  * Returns the WP.com blog ID for the current site.
  *
  * @return int|false The WP.com blog ID, or false if the site does not have a WP.com blog ID.

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
@@ -69,7 +69,6 @@ class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
 		$wp_settings_fields = $this->original_wp_settings_fields; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$wp_scripts         = $this->original_wp_scripts; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$wp_styles          = $this->original_wp_styles; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		delete_transient( 'jetpack-mu-wpcom-wpcom-gutenberg-rtc.asset.json' );
 		remove_all_filters( 'wpcom_is_gutenberg_rtc_enabled' );
 		remove_all_filters( 'wpcom_gutenberg_rtc_providers' );
 		parent::tear_down();
@@ -234,7 +233,7 @@ class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
 
 		wpcom_enqueue_gutenberg_rtc_assets();
 
-		$this->assertFalse( wp_script_is( 'jetpack-mu-wpcom-wpcom-gutenberg-rtc', 'enqueued' ) );
+		$this->assertFalse( wp_script_is( 'jetpack-mu-wpcom-gutenberg-rtc', 'enqueued' ) );
 	}
 
 	/**
@@ -249,17 +248,9 @@ class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
 			}
 		);
 
-		set_transient(
-			'jetpack-mu-wpcom-wpcom-gutenberg-rtc.asset.json',
-			array(
-				'dependencies' => array(),
-				'version'      => 'test',
-			)
-		);
-
 		wpcom_enqueue_gutenberg_rtc_assets();
 
-		$this->assertTrue( wp_script_is( 'jetpack-mu-wpcom-wpcom-gutenberg-rtc', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'jetpack-mu-wpcom-gutenberg-rtc', 'enqueued' ) );
 	}
 
 	/**
@@ -274,17 +265,9 @@ class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
 			}
 		);
 
-		set_transient(
-			'jetpack-mu-wpcom-wpcom-gutenberg-rtc.asset.json',
-			array(
-				'dependencies' => array(),
-				'version'      => 'test',
-			)
-		);
-
 		wpcom_enqueue_gutenberg_rtc_assets();
 
-		$this->assertTrue( wp_script_is( 'jetpack-mu-wpcom-wpcom-gutenberg-rtc', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'jetpack-mu-wpcom-gutenberg-rtc', 'enqueued' ) );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/webpack.config.js
+++ b/projects/packages/jetpack-mu-wpcom/webpack.config.js
@@ -18,6 +18,7 @@ module.exports = async () => {
 					'./src/features/custom-css/custom-css/js/core-customizer-css-preview.js',
 				'customizer-control': './src/features/custom-css/custom-css/css/customizer-control.css',
 				'error-reporting': './src/features/error-reporting/index.js',
+				'gutenberg-rtc': './src/features/gutenberg-rtc/gutenberg-rtc.ts',
 				'holiday-snow': './src/features/holiday-snow/holiday-snow.scss',
 				'html-block-restricted-tags':
 					'./src/features/html-block-restricted-tags/html-block-restricted-tags.tsx',
@@ -139,6 +140,12 @@ module.exports = async () => {
 				jetpackConfig: JSON.stringify( {
 					consumer_slug: 'jetpack-mu-wpcom',
 				} ),
+				// Resolve @wordpress/sync to the global `wp.sync` provided by WordPress.
+				'@wordpress/sync': 'wp.sync',
+				// Resolve Yjs to the global `wp.sync.Y` to avoid two separate Yjs
+				// instances, which breaks shared document types. See:
+				// https://github.com/yjs/yjs/issues/438
+				yjs: 'wp.sync.Y',
 			},
 		},
 	];

--- a/projects/plugins/mu-wpcom-plugin/changelog/pr-47535
+++ b/projects/plugins/mu-wpcom-plugin/changelog/pr-47535
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Gutenberg RTC: Load wpcom-gutenberg-rtc script from widgets.wp.com instead of bundling it, enabling independent script deployments.

--- a/projects/plugins/wpcomsh/changelog/pr-47535
+++ b/projects/plugins/wpcomsh/changelog/pr-47535
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Gutenberg RTC: Load wpcom-gutenberg-rtc script from widgets.wp.com instead of bundling it, enabling independent script deployments.


### PR DESCRIPTION
Reverts Automattic/jetpack#47535 because it cannot bypass the origin limitation either

> Related to [DOTCOM-16207](https://linear.app/a8c/issue/DOTCOM-16207)
> 
> ## Proposed changes
> Move the `wpcom-gutenberg-rtc` script from being bundled with jetpack-mu-wpcom to being loaded from `widgets.wp.com` (built in Calypso apps). This allows us to deploy RTC script changes independently without requiring a full jetpack-mu-wpcom release.
> 
> ### Gutenberg RTC changes
> * Updated `wpcom_enqueue_gutenberg_rtc_assets()` to use the new utility, loading the script from `//widgets.wp.com/wpcom-gutenberg-rtc/wpcom-gutenberg-rtc.min.js`.
> * Removed the webpack entry for `gutenberg-rtc` and the `@wordpress/sync` / `yjs` externals (only used by that entry).
> * Removed JS/TS source files (`gutenberg-rtc.ts`, `providers/pinghub/*`, `types.d.ts`) — these now live in the Calypso apps repo.
> * Removed `@wordpress/sync`, `lib0`, `y-protocols`, and `yjs` from `package.json` dependencies.
> * Updated tests to use the new script handle and mock the asset file transient.
> 
> #### New utility: `jetpack_mu_wpcom_enqueue_calypso_app()`
> * Added to `utils.php` — a reusable helper that fetches an app's asset manifest (`dependencies` + `version`) from `widgets.wp.com`, caches it via a transient (1 hour), and enqueues the script.
> * Supports configurable entry file name (defaults to `$app_name`), `SCRIPT_DEBUG` for unminified builds, and falls back to local filesystem on Simple sites.
> 
> ## Related product discussion/links
> ## Does this pull request change what data or activity we track or use?
> ## Testing instructions
> 1. Install `wpcom-gutenberg-rtc` from [WPCOM Gutenberg RTC: Introduce wpcom-gutenberg-rtc app wp-calypso#109167](https://github.com/Automattic/wp-calypso/pull/109167) to your sandbox
> 2. Sandbox `widgets.wp.com` and your simple site
> 3. Add following code to enable the feature on your sandbox
>    ```
>    // mu-plugins/0-sandbox.php
>    add_filter( 'wpcom_is_gutenberg_rtc_enabled', '__return_true' );
>    ```
> 4. Go to WP Admin > Settings > Writing to enable RTC
> 5. Edit a post with 2 different accounts
> 6. Ensure the changes can be synced to each other correctly
> 
> ### Other information
> * [ ]  Generate changelog entries for this PR (using AI).

