### PR TITLE
MU WPCOM: Add wpcom-dashboard feature with holdout experiment

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-16260-task-11-dashboard-prepare-replacement-holdout
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-16260-task-11-dashboard-prepare-replacement-holdout
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add wpcom-dashboard feature with holdout experiment support.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -287,6 +287,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/wpcom-attachment-pages/wpcom-attachment-pages.php';
 		require_once __DIR__ . '/features/wpcom-block-editor/class-jetpack-wpcom-block-editor.php';
 		require_once __DIR__ . '/features/wpcom-block-editor/functions.editor-type.php';
+		require_once __DIR__ . '/features/wpcom-dashboard/class-wpcom-dashboard.php';
 		require_once __DIR__ . '/features/wpcom-hotfixes/wpcom-hotfixes.php';
 		require_once __DIR__ . '/features/wpcom-logout/wpcom-logout.php';
 		require_once __DIR__ . '/features/wpcom-themes/wpcom-theme-fixes.php';
@@ -314,6 +315,7 @@ class Jetpack_Mu_Wpcom {
 		\Automattic\Jetpack\Classic_Theme_Helper\Featured_Content::setup();
 
 		\Automattic\Jetpack\Jetpack_Mu_Wpcom\Holiday_Snow::init();
+		\Automattic\Jetpack\Jetpack_Mu_Wpcom\Wpcom_Dashboard::init();
 
 		// Gets autoloaded from the Scheduled_Updates package.
 		if ( class_exists( 'Automattic\Jetpack\Scheduled_Updates' ) ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard/class-wpcom-dashboard.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard/class-wpcom-dashboard.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Wpcom Dashboard feature.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Status\Host;
+
+/**
+ * Manages the WordPress.com Dashboard replacement holdout experiment.
+ */
+class Wpcom_Dashboard {
+
+	const EXPERIMENT_NAME = 'wpcom_custom_dashboard_holdout';
+
+	/**
+	 * Initialize the feature.
+	 */
+	public static function init() {
+		add_filter( 'wpcom_dashboard_replacement_enabled', array( __CLASS__, 'is_feature_flag_enabled' ) );
+		add_filter( 'wpcom_dashboard_replacement_holdout_is_treatment', array( __CLASS__, 'is_holdout_treatment' ) );
+		add_action( 'admin_notices', array( __CLASS__, 'render_admin_notice' ) );
+	}
+
+	/**
+	 * Feature flag filter callback. Defaults to false.
+	 * Override this filter to true to force-enable for testing.
+	 *
+	 * @param bool $enabled Whether the feature is enabled.
+	 * @return bool
+	 */
+	public static function is_feature_flag_enabled( $enabled = false ) {
+		return (bool) $enabled;
+	}
+
+	/**
+	 * Check whether the current user is in the holdout treatment group.
+	 *
+	 * On Simple sites, uses \ExPlat\assign_current_user() directly.
+	 * On Atomic sites with a connected user, uses the REST API.
+	 * Caches the result in a transient for 1 hour.
+	 *
+	 * @return bool
+	 */
+	public static function is_holdout_treatment() {
+		$user_id = get_current_user_id();
+		if ( ! $user_id ) {
+			return false;
+		}
+
+		$cache_key     = 'wpcom-dashboard-holdout-' . $user_id . '-' . self::EXPERIMENT_NAME;
+		$cached_result = get_transient( $cache_key );
+
+		if ( false !== $cached_result ) {
+			return (bool) $cached_result;
+		}
+
+		$result = false;
+
+		if ( ( new Host() )->is_wpcom_simple() ) {
+			if ( function_exists( '\ExPlat\assign_current_user' ) ) {
+				// In a holdout experiment, null = control group, non-null = treatment (held out).
+				$result = null !== \ExPlat\assign_current_user( self::EXPERIMENT_NAME );
+			}
+		} elseif ( ( new Connection_Manager() )->is_user_connected() ) {
+			$request_path = '/experiments/0.1.0/assignments/wpcom';
+			$response     = Client::wpcom_json_api_request_as_user(
+				add_query_arg( array( 'experiment_name' => self::EXPERIMENT_NAME ), $request_path ),
+				'v2'
+			);
+
+			if ( ! is_wp_error( $response ) && 200 === wp_remote_retrieve_response_code( $response ) ) {
+				$data = json_decode( wp_remote_retrieve_body( $response ), true );
+				if ( isset( $data['variations'][ self::EXPERIMENT_NAME ] ) ) {
+					// In a holdout experiment, null = control group, non-null = treatment (held out).
+					$result = null !== $data['variations'][ self::EXPERIMENT_NAME ];
+				}
+			}
+		}
+
+		set_transient( $cache_key, $result ? 1 : 0, HOUR_IN_SECONDS );
+
+		return $result;
+	}
+
+	/**
+	 * Whether the dashboard replacement is active.
+	 *
+	 * Returns true if the feature flag is enabled OR the holdout experiment
+	 * assigns the user to the treatment group.
+	 *
+	 * @return bool
+	 */
+	public static function is_active() {
+		/** This filter is documented in class-wpcom-dashboard.php */
+		$feature_flag = apply_filters( 'wpcom_dashboard_replacement_enabled', false );
+
+		if ( $feature_flag ) {
+			return true;
+		}
+
+		/** This filter is documented in class-wpcom-dashboard.php */
+		return (bool) apply_filters( 'wpcom_dashboard_replacement_holdout_is_treatment', false );
+	}
+
+	/**
+	 * Render an admin notice on the Dashboard page showing the current state.
+	 * Temporary dev aid — remove before shipping.
+	 */
+	public static function render_admin_notice() {
+		$screen = get_current_screen();
+		if ( ! $screen || 'dashboard' !== $screen->id ) {
+			return;
+		}
+
+		$is_active = self::is_active();
+		$status    = $is_active ? 'active' : 'inactive';
+		$type      = $is_active ? 'info' : 'warning';
+
+		printf(
+			'<div class="notice notice-%s"><p>%s</p></div>',
+			esc_attr( $type ),
+			esc_html(
+				sprintf(
+					/* translators: %s is either "active" or "inactive". */
+					__( 'Dashboard replacement: %s', 'jetpack-mu-wpcom' ),
+					$status
+				)
+			)
+		);
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard/class-wpcom-dashboard.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard/class-wpcom-dashboard.php
@@ -16,7 +16,8 @@ use Automattic\Jetpack\Status\Host;
  */
 class Wpcom_Dashboard {
 
-	const EXPERIMENT_NAME = 'wpcom_custom_dashboard_holdout';
+	const EXPERIMENT_NAME                = 'wpcom_custom_dashboard_holdout'; // Temporary name!
+	const EXPERIMENT_TREATMENT_VARIATION = 'treatment';
 
 	/**
 	 * Initialize the feature.
@@ -45,9 +46,15 @@ class Wpcom_Dashboard {
 	 * On Atomic sites with a connected user, uses the REST API.
 	 * Caches the result in a transient for 1 hour.
 	 *
+	 * @param bool $is_treatment Whether the user is in the treatment group.
 	 * @return bool
 	 */
-	public static function is_holdout_treatment() {
+	public static function is_holdout_treatment( $is_treatment = false ) {
+		// Respect earlier filter overrides.
+		if ( $is_treatment ) {
+			return true;
+		}
+
 		$user_id = get_current_user_id();
 		if ( ! $user_id ) {
 			return false;
@@ -64,8 +71,7 @@ class Wpcom_Dashboard {
 
 		if ( ( new Host() )->is_wpcom_simple() ) {
 			if ( function_exists( '\ExPlat\assign_current_user' ) ) {
-				// In a holdout experiment, null = control group, non-null = treatment (held out).
-				$result = null !== \ExPlat\assign_current_user( self::EXPERIMENT_NAME );
+				$result = self::EXPERIMENT_TREATMENT_VARIATION === \ExPlat\assign_current_user( self::EXPERIMENT_NAME );
 			}
 		} elseif ( ( new Connection_Manager() )->is_user_connected() ) {
 			$request_path = '/experiments/0.1.0/assignments/wpcom';
@@ -77,8 +83,7 @@ class Wpcom_Dashboard {
 			if ( ! is_wp_error( $response ) && 200 === wp_remote_retrieve_response_code( $response ) ) {
 				$data = json_decode( wp_remote_retrieve_body( $response ), true );
 				if ( isset( $data['variations'][ self::EXPERIMENT_NAME ] ) ) {
-					// In a holdout experiment, null = control group, non-null = treatment (held out).
-					$result = null !== $data['variations'][ self::EXPERIMENT_NAME ];
+					$result = self::EXPERIMENT_TREATMENT_VARIATION === $data['variations'][ self::EXPERIMENT_NAME ];
 				}
 			}
 		}
@@ -113,21 +118,27 @@ class Wpcom_Dashboard {
 	 * Temporary dev aid — remove before shipping.
 	 */
 	public static function render_admin_notice() {
+		if ( ! self::is_active() ) {
+			return;
+		}
+
 		$screen = get_current_screen();
 		if ( ! $screen || 'dashboard' !== $screen->id ) {
 			return;
 		}
 
-		$is_active = self::is_active();
-		$status    = $is_active ? 'active' : 'inactive';
-		$type      = $is_active ? 'info' : 'warning';
+		/** This filter is documented in class-wpcom-dashboard.php */
+		$is_treatment = (bool) apply_filters( 'wpcom_dashboard_replacement_holdout_is_treatment', false );
+
+		$status = $is_treatment ? 'active/treatment' : 'active/control';
+		$type   = $is_treatment ? 'success' : 'info';
 
 		printf(
 			'<div class="notice notice-%s"><p>%s</p></div>',
 			esc_attr( $type ),
 			esc_html(
 				sprintf(
-					/* translators: %s is either "active" or "inactive". */
+					/* translators: %s is "active/treatment" or "active/control". */
 					__( 'Dashboard replacement: %s', 'jetpack-mu-wpcom' ),
 					$status
 				)

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-dashboard/Wpcom_Dashboard_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-dashboard/Wpcom_Dashboard_Test.php
@@ -61,22 +61,6 @@ class Wpcom_Dashboard_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Test that feature flag takes priority (short-circuits before holdout check).
-	 */
-	public function test_feature_flag_short_circuits_holdout() {
-		add_filter( 'wpcom_dashboard_replacement_enabled', '__return_true' );
-		// Holdout is false, but feature flag is true — should still be active.
-		$this->assertTrue( Wpcom_Dashboard::is_active() );
-	}
-
-	/**
-	 * Test that is_feature_flag_enabled defaults to false.
-	 */
-	public function test_is_feature_flag_enabled_defaults_to_false() {
-		$this->assertFalse( Wpcom_Dashboard::is_feature_flag_enabled() );
-	}
-
-	/**
 	 * Test that is_holdout_treatment returns false when no user is logged in.
 	 */
 	public function test_is_holdout_treatment_returns_false_for_logged_out_user() {
@@ -85,10 +69,19 @@ class Wpcom_Dashboard_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Test the experiment name constant.
+	 * Test that is_holdout_treatment respects an earlier filter that already set it to true.
 	 */
-	public function test_experiment_name_constant() {
-		$this->assertSame( 'wpcom_custom_dashboard_holdout', Wpcom_Dashboard::EXPERIMENT_NAME );
+	public function test_is_holdout_treatment_respects_earlier_filter_override() {
+		// Register a filter at a lower priority than init()'s default (10)
+		// so it runs first and sets the value to true.
+		add_filter( 'wpcom_dashboard_replacement_holdout_is_treatment', '__return_true', 5 );
+
+		// When invoked through the filter chain, is_holdout_treatment receives
+		// $is_treatment = true from the earlier filter and should return true
+		// immediately (guard clause), even without a logged-in user.
+		wp_set_current_user( 0 );
+		$result = apply_filters( 'wpcom_dashboard_replacement_holdout_is_treatment', false );
+		$this->assertTrue( $result );
 	}
 
 	/**
@@ -116,5 +109,44 @@ class Wpcom_Dashboard_Test extends \WorDBless\BaseTestCase {
 
 		// Clean up.
 		delete_transient( $cache_key );
+	}
+
+	/**
+	 * Test that is_holdout_treatment caches false for a logged-in user
+	 * who is neither on Simple nor Jetpack-connected (fallthrough path).
+	 */
+	public function test_is_holdout_treatment_caches_false_for_unconnected_user() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_user_' . wp_rand(),
+				'user_pass'  => 'password',
+				'user_email' => 'test_' . wp_rand() . '@example.com',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		$cache_key = 'wpcom-dashboard-holdout-' . $user_id . '-' . Wpcom_Dashboard::EXPERIMENT_NAME;
+
+		// Ensure no cached value exists.
+		delete_transient( $cache_key );
+
+		// In the test environment the user is neither on Simple nor connected,
+		// so the method should return false and cache the result.
+		$this->assertFalse( Wpcom_Dashboard::is_holdout_treatment() );
+		$this->assertSame( '0', (string) get_transient( $cache_key ) );
+
+		// Clean up.
+		delete_transient( $cache_key );
+	}
+
+	/**
+	 * Test that render_admin_notice produces no output when the feature is inactive.
+	 */
+	public function test_render_admin_notice_not_shown_when_inactive() {
+		ob_start();
+		Wpcom_Dashboard::render_admin_notice();
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-dashboard/Wpcom_Dashboard_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-dashboard/Wpcom_Dashboard_Test.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Wpcom Dashboard Tests.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/wpcom-dashboard/class-wpcom-dashboard.php';
+
+/**
+ * Tests for the Wpcom_Dashboard class.
+ */
+class Wpcom_Dashboard_Test extends \WorDBless\BaseTestCase {
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+		remove_all_filters( 'wpcom_dashboard_replacement_enabled' );
+		remove_all_filters( 'wpcom_dashboard_replacement_holdout_is_treatment' );
+		Wpcom_Dashboard::init();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tear_down() {
+		remove_all_filters( 'wpcom_dashboard_replacement_enabled' );
+		remove_all_filters( 'wpcom_dashboard_replacement_holdout_is_treatment' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Test that is_active returns false by default (no feature flag, no experiment).
+	 */
+	public function test_is_active_returns_false_by_default() {
+		$this->assertFalse( Wpcom_Dashboard::is_active() );
+	}
+
+	/**
+	 * Test that is_active returns true when the feature flag filter is overridden.
+	 */
+	public function test_is_active_returns_true_when_feature_flag_enabled() {
+		add_filter( 'wpcom_dashboard_replacement_enabled', '__return_true' );
+		$this->assertTrue( Wpcom_Dashboard::is_active() );
+	}
+
+	/**
+	 * Test that is_active returns true when the holdout filter returns true.
+	 */
+	public function test_is_active_returns_true_when_holdout_is_treatment() {
+		add_filter( 'wpcom_dashboard_replacement_holdout_is_treatment', '__return_true' );
+		$this->assertTrue( Wpcom_Dashboard::is_active() );
+	}
+
+	/**
+	 * Test that feature flag takes priority (short-circuits before holdout check).
+	 */
+	public function test_feature_flag_short_circuits_holdout() {
+		add_filter( 'wpcom_dashboard_replacement_enabled', '__return_true' );
+		// Holdout is false, but feature flag is true — should still be active.
+		$this->assertTrue( Wpcom_Dashboard::is_active() );
+	}
+
+	/**
+	 * Test that is_feature_flag_enabled defaults to false.
+	 */
+	public function test_is_feature_flag_enabled_defaults_to_false() {
+		$this->assertFalse( Wpcom_Dashboard::is_feature_flag_enabled() );
+	}
+
+	/**
+	 * Test that is_holdout_treatment returns false when no user is logged in.
+	 */
+	public function test_is_holdout_treatment_returns_false_for_logged_out_user() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( Wpcom_Dashboard::is_holdout_treatment() );
+	}
+
+	/**
+	 * Test the experiment name constant.
+	 */
+	public function test_experiment_name_constant() {
+		$this->assertSame( 'wpcom_custom_dashboard_holdout', Wpcom_Dashboard::EXPERIMENT_NAME );
+	}
+
+	/**
+	 * Test that is_holdout_treatment returns the cached transient value.
+	 */
+	public function test_is_holdout_treatment_returns_cached_value() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_user_' . wp_rand(),
+				'user_pass'  => 'password',
+				'user_email' => 'test_' . wp_rand() . '@example.com',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		$cache_key = 'wpcom-dashboard-holdout-' . $user_id . '-' . Wpcom_Dashboard::EXPERIMENT_NAME;
+
+		// Seed the transient with a truthy value.
+		set_transient( $cache_key, 1, HOUR_IN_SECONDS );
+		$this->assertTrue( Wpcom_Dashboard::is_holdout_treatment() );
+
+		// Seed the transient with a falsy value.
+		set_transient( $cache_key, 0, HOUR_IN_SECONDS );
+		$this->assertFalse( Wpcom_Dashboard::is_holdout_treatment() );
+
+		// Clean up.
+		delete_transient( $cache_key );
+	}
+}


### PR DESCRIPTION
Fixes DOTCOM-16260

## Proposed changes

* Add a new `wpcom-dashboard` feature in `jetpack-mu-wpcom` that prepares the infrastructure for the Dashboard replacement holdout experiment.
* Expose two filters: `wpcom_dashboard_replacement_enabled` (feature flag) and `wpcom_dashboard_replacement_holdout_is_treatment` (ExPlat holdout check).
* Provide a `Wpcom_Dashboard::is_active()` public API that returns `true` if either filter is true.
* Show a temporary admin notice on the Dashboard page indicating "active/treatment" or "active/control" for dev testing.
* Support both WPCOM Simple sites (via `\ExPlat\assign_current_user()`) and Atomic sites (via REST API).

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* https://linear.app/a8c/issue/DOTCOM-16260

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Enable the feature flag by adding to a mu-plugin or theme's `functions.php`:
  ```php
  add_filter( 'wpcom_dashboard_replacement_enabled', '__return_true' );
  ```
* Go to the wp-admin Dashboard (`/wp-admin/index.php`).
* Verify a blue "Dashboard replacement: active/control" notice appears.
* Additionally enable the holdout treatment override:
  ```php
  add_filter( 'wpcom_dashboard_replacement_holdout_is_treatment', '__return_true' );
  ```
* Verify the notice changes to a green "Dashboard replacement: active/treatment".
* Remove both filters and verify no notice appears.