### PR TITLE
Boost: init identity crisis

### DIFF
--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -115,11 +115,11 @@ class Jetpack_Boost {
 		$cornerstone_pages = new Cornerstone_Pages();
 		Setup::add( $cornerstone_pages );
 
+		// Initialize Jetpack packages (connection, sync, identity crisis).
+		$this->init_jetpack_config();
+
 		// Initialize the Admin experience.
 		$this->init_admin( $modules_setup );
-
-		// Initiate jetpack sync.
-		$this->init_sync();
 
 		add_action( 'admin_init', array( $this, 'schedule_version_change' ) );
 
@@ -324,12 +324,37 @@ class Jetpack_Boost {
 		REST_API::register( List_Cornerstone_Pages::class );
 		REST_API::register( List_LCP_Analysis::class );
 
-		$this->connection->ensure_connection();
 		( new Admin() )->init( $modules_setup );
 	}
 
-	public function init_sync() {
+	/**
+	 * Initialize Jetpack packages via the Config class.
+	 *
+	 * Consolidates connection, sync, and identity crisis initialization
+	 * into a single Config instance, matching the pattern used by other
+	 * standalone Jetpack plugins (Protect, Social, VideoPress, etc.).
+	 */
+	private function init_jetpack_config() {
 		$jetpack_config = new Jetpack_Config();
+
+		/**
+		 * Filter that fakes the connection to WordPress.com. Useful for testing.
+		 *
+		 * @param bool $connection Return true to fake the connection.
+		 *
+		 * @since 1.0.0
+		 */
+		if ( ! apply_filters( 'jetpack_boost_connection_bypass', false ) ) {
+			$jetpack_config->ensure(
+				'connection',
+				array(
+					'slug'     => JETPACK_BOOST_SLUG,
+					'name'     => 'Jetpack Boost',
+					'url_info' => '',
+				)
+			);
+		}
+
 		$jetpack_config->ensure(
 			'sync',
 			array(
@@ -343,6 +368,8 @@ class Jetpack_Boost {
 				),
 			)
 		);
+
+		$jetpack_config->ensure( 'identity_crisis' );
 	}
 
 	/**

--- a/projects/plugins/boost/app/lib/class-connection.php
+++ b/projects/plugins/boost/app/lib/class-connection.php
@@ -9,7 +9,6 @@
 
 namespace Automattic\Jetpack_Boost\Lib;
 
-use Automattic\Jetpack\Config as Jetpack_Config;
 use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Terms_Of_Service;
 
@@ -271,26 +270,5 @@ class Connection {
 	 */
 	public static function rest_authorization_required_code() {
 		return is_user_logged_in() ? 403 : 401;
-	}
-
-	public function ensure_connection() {
-		/**
-		 * Filter that fakes the connection to WordPress.com. Useful for testing.
-		 *
-		 * @param bool $connection Return true to fake the connection.
-		 *
-		 * @since   1.0.0
-		 */
-		if ( ! apply_filters( 'jetpack_boost_connection_bypass', false ) ) {
-			$jetpack_config = new Jetpack_Config();
-			$jetpack_config->ensure(
-				'connection',
-				array(
-					'slug'     => 'jetpack-boost',
-					'name'     => 'Jetpack Boost',
-					'url_info' => '', // Optional, URL of the plugin.
-				)
-			);
-		}
 	}
 }

--- a/projects/plugins/boost/changelog/add-boost-gets-idc
+++ b/projects/plugins/boost/changelog/add-boost-gets-idc
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Connection: init identity crisis package.


### PR DESCRIPTION
This PR does light refactoring for connection and sync initializations in Boost so they match what other monorepo plugins do.

Discussion: p1770137635650109-slack-C016BBAFHHS

Closes CONNECT-164

## Proposed changes

* Initialize the Identity Crisis (IDC) package in Jetpack Boost, matching the pattern used by every other standalone Jetpack plugin (Protect, Social, VideoPress, Search, Backup, Starter Plugin).
* Consolidate Jetpack Config initialization (`connection`, `sync`, `identity_crisis`) into a single `init_jetpack_config()` method with one `Jetpack_Config` instance, instead of splitting `connection` and `sync` across two separate classes with two separate Config instances.
* Remove `Connection::ensure_connection()` (its logic moved into `Jetpack_Boost::init_jetpack_config()`), and clean up the unused `Jetpack_Config` import from `class-connection.php`.

### Why

Boost was the only standalone Jetpack plugin that did not initialize the Identity Crisis package. Without IDC, if a site's URL changes (domain migration, cloning to staging, etc.), Boost's connection could silently break or send data to the wrong WPCOM blog, with no warning to the user.

The `Identity_Crisis` class already ships inside the `jetpack-connection` package (which Boost depends on), so no new Composer dependency is needed.


### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Activate Boost (alone) and connect site.
* Load this branch.
* Use Debug Tools plugin to simulate IDC.
* Confirm the Safe Mode screen shows up.