### PR TITLE
Social Previews: Pass site favicon to GoogleSearchPreview

### DIFF
--- a/projects/js-packages/social-previews/changelog/pr-47551
+++ b/projects/js-packages/social-previews/changelog/pr-47551
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Google Search Preview: Add optional siteIcon prop to allow passing a custom favicon URL.

--- a/projects/js-packages/social-previews/src/google-search-preview/index.tsx
+++ b/projects/js-packages/social-previews/src/google-search-preview/index.tsx
@@ -37,11 +37,13 @@ const googleDescription = firstValid(
 );
 
 export type GoogleSearchPreviewProps = Omit< SocialPreviewBaseProps, 'image' > & {
+	siteIcon?: string;
 	siteTitle?: string;
 };
 
 export const GoogleSearchPreview: React.FC< Partial< GoogleSearchPreviewProps > > = ( {
 	description = '',
+	siteIcon,
 	siteTitle,
 	title = '',
 	url = '',
@@ -55,7 +57,7 @@ export const GoogleSearchPreview: React.FC< Partial< GoogleSearchPreviewProps > 
 					<div className="search-preview__branding">
 						<img
 							className="search-preview__icon"
-							src={ `https://www.google.com/s2/favicons?sz=128&domain_url=${ domain }` }
+							src={ siteIcon || `https://www.google.com/s2/favicons?sz=128&domain_url=${ domain }` }
 							alt=""
 						/>
 						<div className="search-preview__site">

--- a/projects/packages/publicize/_inc/exports/link-preview/types.ts
+++ b/projects/packages/publicize/_inc/exports/link-preview/types.ts
@@ -15,6 +15,11 @@ export type LinkPreviewData = {
 	siteTitle?: string;
 
 	/**
+	 * The URL of the site icon to use in the Google Search preview.
+	 */
+	siteIcon?: string;
+
+	/**
 	 * The description of the resource to preview.
 	 */
 	description?: string;

--- a/projects/packages/publicize/_inc/hooks/use-link-preview-post-data/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-link-preview-post-data/index.ts
@@ -59,13 +59,25 @@ export function useLinkPreviewPostData(): LinkPreviewData {
 		return imageUrl;
 	}, [] );
 
-	const siteTitle = useSelect( select => {
+	const { siteTitle, siteIcon } = useSelect( select => {
 		const site = select( coreStore ).getSite(
 			// The id param is optional
 			undefined
 		);
 
-		return site?.title || '';
+		const { getEntityRecord } = select( coreStore );
+
+		const siteIconId = site?.site_icon;
+		let siteIconUrl = '';
+
+		if ( siteIconId ) {
+			siteIconUrl = getMediaSourceUrl( getEntityRecord( 'postType', 'attachment', siteIconId ) );
+		}
+
+		return {
+			siteTitle: site?.title || '',
+			siteIcon: siteIconUrl,
+		};
 	}, [] );
 
 	const title = useSelect( select => {
@@ -86,9 +98,10 @@ export function useLinkPreviewPostData(): LinkPreviewData {
 		return {
 			description: decodeEntities( description ),
 			image,
+			siteIcon,
 			siteTitle: decodeEntities( siteTitle ),
 			title: decodeEntities( title ),
 			url,
 		};
-	}, [ description, image, siteTitle, title, url ] );
+	}, [ description, image, siteIcon, siteTitle, title, url ] );
 }

--- a/projects/packages/publicize/_inc/hooks/use-link-preview-post-data/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-link-preview-post-data/index.ts
@@ -60,23 +60,12 @@ export function useLinkPreviewPostData(): LinkPreviewData {
 	}, [] );
 
 	const { siteTitle, siteIcon } = useSelect( select => {
-		const site = select( coreStore ).getSite(
-			// The id param is optional
-			undefined
-		);
-
-		const { getEntityRecord } = select( coreStore );
-
-		const siteIconId = site?.site_icon;
-		let siteIconUrl = '';
-
-		if ( siteIconId ) {
-			siteIconUrl = getMediaSourceUrl( getEntityRecord( 'postType', 'attachment', siteIconId ) );
-		}
+		const { getUnstableBase } = select( coreStore );
+		const base = getUnstableBase( undefined );
 
 		return {
-			siteTitle: site?.title || '',
-			siteIcon: siteIconUrl,
+			siteTitle: base?.name || '',
+			siteIcon: base?.site_icon_url || '',
 		};
 	}, [] );
 

--- a/projects/packages/publicize/_inc/hooks/use-link-preview-post-data/test/index.test.ts
+++ b/projects/packages/publicize/_inc/hooks/use-link-preview-post-data/test/index.test.ts
@@ -43,12 +43,12 @@ const getDefaultAttributes = (): Record< string, unknown > => ( {
 
 const setupMocks = ( {
 	attributes = getDefaultAttributes(),
-	site = { title: 'Test Site' },
+	site = { name: 'Test Site', site_icon_url: '' },
 	featuredMediaRecord = null,
 	editedPostContent = '',
 }: {
 	attributes?: Record< string, unknown >;
-	site?: { title: string } | null;
+	site?: { name: string; site_icon_url?: string } | null;
 	featuredMediaRecord?: Record< string, unknown > | null;
 	editedPostContent?: string;
 } = {} ) => {
@@ -61,6 +61,7 @@ const setupMocks = ( {
 				getEditedPostAttribute: mockGetEditedPostAttribute,
 				getEditedPostContent: jest.fn().mockReturnValue( editedPostContent ),
 				getSite: jest.fn().mockReturnValue( site ),
+				getUnstableBase: jest.fn().mockReturnValue( site ),
 			} );
 			return selectorOrMapper( mockSelect );
 		}

--- a/projects/packages/publicize/changelog/pr-47551
+++ b/projects/packages/publicize/changelog/pr-47551
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Google Search Preview: Wire up site icon to display the actual site favicon in the link preview.

--- a/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
@@ -19,7 +19,11 @@ import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import analytics from 'lib/analytics';
 import { FEATURE_ADVANCED_SEO } from 'lib/plans/constants';
-import { isSeoEnhancerAvailable, getSiteRepresentativeImage } from 'state/initial-state';
+import {
+	getSiteIcon,
+	isSeoEnhancerAvailable,
+	getSiteRepresentativeImage,
+} from 'state/initial-state';
 import { siteHasFeature } from 'state/site';
 import { isFetchingPluginsData, isPluginActive } from 'state/site/plugins';
 import CustomSeoTitles from './seo/custom-seo-titles.jsx';
@@ -100,6 +104,7 @@ export const SEO = withModuleSettingsFormHelpers(
 
 		SocialPreviewGoogle = siteData => (
 			<GoogleSearchPreview
+				siteIcon={ siteData.siteIcon }
 				siteTitle={ siteData.title }
 				title={ siteData.title }
 				url={ siteData.url }
@@ -160,6 +165,7 @@ export const SEO = withModuleSettingsFormHelpers(
 				title: this.props.siteData.name || '',
 				tagline: this.props.siteData.description || '',
 				url: this.props.siteData.URL || '',
+				siteIcon: this.props.siteIcon || '',
 				frontPageMetaDescription: frontPageMetaDescription
 					? frontPageMetaDescription
 					: this.props.siteData.description || '',
@@ -415,6 +421,7 @@ export const SEO = withModuleSettingsFormHelpers(
 export default connect( state => {
 	return {
 		siteData: state.jetpack.siteData.data,
+		siteIcon: getSiteIcon( state ),
 		siteRepresentativeImage: getSiteRepresentativeImage( state ),
 		seoEnhancerAvailable: isSeoEnhancerAvailable( state ),
 		state,

--- a/projects/plugins/jetpack/changelog/pr-47551
+++ b/projects/plugins/jetpack/changelog/pr-47551
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Google Search Preview: Add optional siteIcon prop to allow passing a custom favicon URL.
+Google Search Preview: Fix site icon not being shown on some sites.

--- a/projects/plugins/jetpack/changelog/pr-47551
+++ b/projects/plugins/jetpack/changelog/pr-47551
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Google Search Preview: Add optional siteIcon prop to allow passing a custom favicon URL.

--- a/projects/plugins/social/changelog/pr-47551
+++ b/projects/plugins/social/changelog/pr-47551
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Google Search Preview: Add optional siteIcon prop to allow passing a custom favicon URL.
+Google Search Preview: Fix site icon not being shown on some sites.

--- a/projects/plugins/social/changelog/pr-47551
+++ b/projects/plugins/social/changelog/pr-47551
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Google Search Preview: Add optional siteIcon prop to allow passing a custom favicon URL.


### PR DESCRIPTION
Related to WOOPRD-2701

## Proposed changes

* Add an optional `siteIcon` prop to the `GoogleSearchPreview` component that overrides the hardcoded Google favicon service URL, falling back to the existing behavior when not provided.
* Wire up the `siteIcon` prop in the **Publicize link preview** (editor sidebar) by resolving the site's `site_icon` attachment ID to a URL via `getEntityRecord` + `getMediaSourceUrl`.
* Wire up the `siteIcon` prop in the **Jetpack SEO dashboard** by passing the existing `getSiteIcon()` selector value through to the component.

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

### Prerequisites
* Ensure the site has a **Site Icon** set. You can configure this in:
  * **Block themes**: Settings → General → Site Icon
  * **Classic themes**: Appearance → Customize → Site Identity → Site Icon

### Editor link preview (Publicize)
* Open a post in the block editor.
* Open the Jetpack sidebar -> Link Preview -> Preview and look at the **Google Search** preview tab.
* Verify the favicon shown next to the site name matches the site icon, not Google's generic favicon service.
* Remove the site icon and verify the preview falls back to the Google favicon service URL.

### SEO dashboard (Jetpack settings)
* Go to Jetpack → Settings → Traffic → SEO.
* Expand the Google Search preview card.
* Verify the favicon matches the site icon when one is set.