### PR TITLE
MU WPCOM: Connect to Pinghub socket by JWT token directly

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/pr-47556
+++ b/projects/packages/jetpack-mu-wpcom/changelog/pr-47556
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Gutenberg RTC: Connect to PingHub WebSocket directly using a server-generated JWT token, replacing the iframe-based proxy and fixing real-time collaboration on custom-domain sites with third-party cookie restrictions.

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/class-wp-rest-gutenberg-rtc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/class-wp-rest-gutenberg-rtc.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * REST API endpoint for Gutenberg RTC PingHub token generation.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * REST controller that generates short-lived JWTs for PingHub WebSocket auth.
+ */
+class WP_REST_Gutenberg_RTC extends WP_REST_Controller {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'wpcom/v2';
+		$this->rest_base = 'gutenberg-rtc/pinghub-token';
+	}
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_item' ),
+					'permission_callback' => array( $this, 'create_item_permissions_check' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Permission check: current user must be a member of the blog.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error
+	 */
+	public function create_item_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( ! is_user_member_of_blog() ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'You are not allowed to access this endpoint.', 'jetpack-mu-wpcom' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Generate a short-lived JWT for authenticating PingHub WebSocket connections.
+	 *
+	 * On simple WordPress.com sites sign_JWT() is called directly — the REST
+	 * endpoint files are not loaded in the admin context so rest_do_request
+	 * cannot be used. On Jetpack/Atomic sites it is fetched from the WPCOM API
+	 * over the Jetpack connection.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function create_item( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$blog_id = get_wpcom_blog_id();
+
+		if ( ! $blog_id ) {
+			return new WP_Error(
+				'rest_pinghub_token_error',
+				__( 'Could not determine blog ID.', 'jetpack-mu-wpcom' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$token = $this->generate_token( $blog_id );
+
+		if ( $token === null ) {
+			return new WP_Error(
+				'rest_pinghub_token_error',
+				__( 'Could not generate PingHub token.', 'jetpack-mu-wpcom' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		return rest_ensure_response( array( 'token' => $token ) );
+	}
+
+	/**
+	 * Generate the JWT token for PingHub authentication.
+	 *
+	 * @param int $blog_id The blog ID.
+	 * @return string|null Signed JWT, or null on failure.
+	 */
+	private function generate_token( $blog_id ) {
+		// Simple WordPress.com sites: use the internal REST endpoint.
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			$request  = new \WP_REST_Request( 'POST', "/wpcom/v2/sites/$blog_id/jetpack-pinghub/jwt/sign" );
+			$response = rest_do_request( $request );
+
+			if ( $response->is_error() ) {
+				return null;
+			}
+
+			$data = $response->get_data();
+			return $data['jwt'] ?? null;
+		}
+
+		// Jetpack/Atomic: call the WPCOM endpoint over the Jetpack connection.
+		if ( ! class_exists( 'Automattic\Jetpack\Connection\Client' ) ) {
+			return null;
+		}
+
+		$response = \Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(
+			"/sites/$blog_id/jetpack-pinghub/jwt/sign",
+			'2',
+			array( 'method' => 'POST' )
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return null;
+		}
+
+		$body = json_decode( wp_remote_retrieve_body( $response ), true );
+		return $body['jwt'] ?? null;
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
@@ -50,54 +50,15 @@ function wpcom_get_gutenberg_rtc_providers() {
 }
 
 /**
- * Generate a short-lived JWT for authenticating PingHub WebSocket connections.
- *
- * On simple WordPress.com sites sign_JWT() is called directly — the REST
- * endpoint files are not loaded in the admin context so rest_do_request
- * cannot be used. On Jetpack/Atomic sites it is fetched from the WPCOM API
- * over the Jetpack connection.
- *
- * @return string|null Signed JWT, or null on failure.
+ * Register the Gutenberg RTC REST endpoint.
  */
-function wpcom_gutenberg_rtc_get_pinghub_jwt() {
-	$user_id = get_current_user_id();
-	$blog_id = get_wpcom_blog_id();
-
-	if ( ! $user_id || ! $blog_id ) {
-		return null;
+add_action(
+	'rest_api_init',
+	function () {
+		require_once __DIR__ . '/class-wp-rest-gutenberg-rtc.php';
+		( new WP_REST_Gutenberg_RTC() )->register_routes();
 	}
-
-	// Simple WordPress.com sites: use the internal REST endpoint.
-	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-		$request  = new \WP_REST_Request( 'POST', "/wpcom/v2/sites/$blog_id/jetpack-pinghub/jwt/sign" );
-		$response = rest_do_request( $request );
-
-		if ( $response->is_error() ) {
-			return null;
-		}
-
-		$data = $response->get_data();
-		return $data['jwt'] ?? null;
-	}
-
-	// Jetpack/Atomic: call the WPCOM endpoint over the Jetpack connection.
-	if ( ! class_exists( 'Automattic\Jetpack\Connection\Client' ) ) {
-		return null;
-	}
-
-	$response = \Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(
-		"/sites/$blog_id/jetpack-pinghub/jwt/sign",
-		'2',
-		array( 'method' => 'POST' )
-	);
-
-	if ( is_wp_error( $response ) ) {
-		return null;
-	}
-
-	$body = json_decode( wp_remote_retrieve_body( $response ), true );
-	return $body['jwt'] ?? null;
-}
+);
 
 /**
  * Enqueue block editor assets for Gutenberg RTC customizations.
@@ -116,9 +77,7 @@ function wpcom_enqueue_gutenberg_rtc_assets() {
 
 	$data = wp_json_encode(
 		array(
-			'providers'       => wpcom_get_gutenberg_rtc_providers(),
-			// TODO: We need the endpoint on Jetpack site for client to refresh the token per hour.
-			'pinghubJWTToken' => wpcom_gutenberg_rtc_get_pinghub_jwt(),
+			'providers' => wpcom_get_gutenberg_rtc_providers(),
 		),
 		JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 	);

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
@@ -117,6 +117,7 @@ function wpcom_enqueue_gutenberg_rtc_assets() {
 	$data = wp_json_encode(
 		array(
 			'providers'       => wpcom_get_gutenberg_rtc_providers(),
+			// TODO: We need the endpoint on Jetpack site for client to refresh the token per hour.
 			'pinghubJWTToken' => wpcom_gutenberg_rtc_get_pinghub_jwt(),
 		),
 		JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
@@ -17,7 +17,7 @@
  */
 function wpcom_is_gutenberg_rtc_enabled() {
 	$is_enabled = false;
-	if ( function_exists( 'wpcom_site_has_feature' ) && class_exists( 'WPCOM_Features' ) ) {
+	if ( function_exists( 'wpcom_site_has_feature' ) && class_exists( 'WPCOM_Features' ) && defined( 'WPCOM_Features::REAL_TIME_COLLABORATION' ) ) {
 		$blog_id    = get_wpcom_blog_id();
 		$is_enabled = wpcom_site_has_feature( WPCOM_Features::REAL_TIME_COLLABORATION, $blog_id );
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
@@ -50,6 +50,56 @@ function wpcom_get_gutenberg_rtc_providers() {
 }
 
 /**
+ * Generate a short-lived JWT for authenticating PingHub WebSocket connections.
+ *
+ * On simple WordPress.com sites sign_JWT() is called directly — the REST
+ * endpoint files are not loaded in the admin context so rest_do_request
+ * cannot be used. On Jetpack/Atomic sites it is fetched from the WPCOM API
+ * over the Jetpack connection.
+ *
+ * @return string|null Signed JWT, or null on failure.
+ */
+function wpcom_gutenberg_rtc_get_pinghub_jwt() {
+	$user_id = get_current_user_id();
+	$blog_id = get_wpcom_blog_id();
+
+	if ( ! $user_id || ! $blog_id ) {
+		return null;
+	}
+
+	// Simple WordPress.com sites: use the internal REST endpoint.
+	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+		$request  = new \WP_REST_Request( 'POST', "/wpcom/v2/sites/$blog_id/jetpack-pinghub/jwt/sign" );
+		$response = rest_do_request( $request );
+
+		if ( $response->is_error() ) {
+			return null;
+		}
+
+		$data = $response->get_data();
+		return isset( $data['jwt'] ) ? $data['jwt'] : null;
+	}
+
+	// Jetpack/Atomic: call the WPCOM endpoint over the Jetpack connection.
+	if ( ! class_exists( 'Automattic\Jetpack\Connection\Client' ) ) {
+		return null;
+	}
+
+	$response = \Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(
+		"/sites/$blog_id/jetpack-pinghub/jwt/sign",
+		'2',
+		array( 'method' => 'POST' )
+	);
+
+	if ( is_wp_error( $response ) ) {
+		return null;
+	}
+
+	$body = json_decode( wp_remote_retrieve_body( $response ), true );
+	return $body['jwt'] ?? null;
+}
+
+/**
  * Enqueue block editor assets for Gutenberg RTC customizations.
  */
 function wpcom_enqueue_gutenberg_rtc_assets() {
@@ -66,7 +116,8 @@ function wpcom_enqueue_gutenberg_rtc_assets() {
 
 	$data = wp_json_encode(
 		array(
-			'providers' => wpcom_get_gutenberg_rtc_providers(),
+			'providers'       => wpcom_get_gutenberg_rtc_providers(),
+			'pinghubJWTToken' => wpcom_gutenberg_rtc_get_pinghub_jwt(),
 		),
 		JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 	);

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
@@ -55,6 +55,11 @@ function wpcom_get_gutenberg_rtc_providers() {
 add_action(
 	'rest_api_init',
 	function () {
+		$providers = wpcom_get_gutenberg_rtc_providers();
+		if ( ! in_array( 'pinghub', $providers, true ) ) {
+			return;
+		}
+
 		require_once __DIR__ . '/class-wp-rest-gutenberg-rtc.php';
 		( new WP_REST_Gutenberg_RTC() )->register_routes();
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
@@ -77,7 +77,7 @@ function wpcom_gutenberg_rtc_get_pinghub_jwt() {
 		}
 
 		$data = $response->get_data();
-		return isset( $data['jwt'] ) ? $data['jwt'] : null;
+		return $data['jwt'] ?? null;
 	}
 
 	// Jetpack/Atomic: call the WPCOM endpoint over the Jetpack connection.

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/providers/pinghub/pinghub-bridge.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/providers/pinghub/pinghub-bridge.ts
@@ -128,6 +128,58 @@ function getPinghubJwt(): string | null {
 	return window.wpcomGutenbergRTC?.pinghubJWTToken ?? null;
 }
 
+let detectedBrowser: string | null = null;
+
+/**
+ * Detect the current browser for analytics tagging.
+ *
+ * @return Browser name string.
+ */
+function detectBrowser(): string {
+	if ( detectedBrowser ) {
+		return detectedBrowser;
+	}
+
+	const ua = navigator.userAgent;
+	if ( /OPR\//.test( ua ) ) {
+		detectedBrowser = 'opera';
+	} else if ( /Firefox\//.test( ua ) ) {
+		detectedBrowser = 'firefox';
+	} else if ( /^((?!chrome|android).)*safari/i.test( ua ) ) {
+		detectedBrowser = 'safari';
+	} else if ( /Chrome\//.test( ua ) && ! /Edg\//.test( ua ) ) {
+		detectedBrowser = 'chrome';
+	} else if ( /Edg\//.test( ua ) ) {
+		detectedBrowser = 'edge';
+	} else {
+		detectedBrowser = 'unknown';
+	}
+
+	return detectedBrowser;
+}
+
+/**
+ * Send an analytics pixel event for PingHub connection tracking.
+ *
+ * @param key   - Dot-delimited metric key.
+ * @param value - Metric value.
+ * @param unit  - Unit indicator ('ms' for milliseconds, 'c' for counter).
+ */
+function pixel( key: string, value: string | number, unit: string ): void {
+	new Image().src =
+		'https://pixel.wp.com/boom.gif?' +
+		'v=0.9&u=https://public-api.wordpress.com/pinghub&' +
+		'json={"beacons":["' +
+		key +
+		'.' +
+		detectBrowser() +
+		':' +
+		value +
+		'|' +
+		unit +
+		'"]}';
+}
+
 export class PingHubBridge {
 	private openHandlers = new Map< string, Set< () => void > >();
 	private closeHandlers = new Map< string, Set< ( code: number, reason: string ) => void > >();
@@ -309,13 +361,17 @@ export class PingHubBridge {
 		ws.binaryType = 'arraybuffer';
 		this.sockets.set( room, ws );
 
+		const start = Date.now();
+
 		ws.addEventListener( 'open', () => {
+			pixel( 'pinghub.conn_open', Date.now() - start, 'ms' );
 			this.connectingWaiters.delete( room );
 			waiters.splice( 0 ).forEach( ( { resolve } ) => resolve() );
 			this.openHandlers.get( room )?.forEach( h => h() );
 		} );
 
 		ws.addEventListener( 'close', event => {
+			pixel( 'pinghub.conn_close_code.' + event.code, Date.now() - start, 'ms' );
 			this.sockets.delete( room );
 			if ( this.connectingWaiters.has( room ) ) {
 				this.connectingWaiters.delete( room );
@@ -323,6 +379,10 @@ export class PingHubBridge {
 				waiters.splice( 0 ).forEach( ( { reject } ) => reject( err ) );
 			}
 			this.closeHandlers.get( room )?.forEach( h => h( event.code, event.reason ) );
+		} );
+
+		ws.addEventListener( 'error', () => {
+			pixel( 'pinghub.conn_err', Date.now() - start, 'ms' );
 		} );
 
 		ws.addEventListener( 'message', event => {

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/providers/pinghub/pinghub-bridge.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/providers/pinghub/pinghub-bridge.ts
@@ -1,3 +1,5 @@
+import apiFetch from '@wordpress/api-fetch';
+
 type BridgeEventMap = {
 	open: () => void;
 	close: ( code: number, reason: string ) => void;
@@ -119,14 +121,7 @@ function getBlogId(): number | null {
 	return null;
 }
 
-/**
- * Read the pre-generated pinghub JWT token embedded by the server.
- *
- * @return JWT string, or null if absent.
- */
-function getPinghubJwt(): string | null {
-	return window.wpcomGutenbergRTC?.pinghubJWTToken ?? null;
-}
+const JWT_CACHE_TTL_MS = 60 * 1000; // 1 minute
 
 let detectedBrowser: string | null = null;
 
@@ -193,6 +188,9 @@ export class PingHubBridge {
 	>();
 	/** Per-room message ID for chunked sends. */
 	private chunkMsgIdByRoom = new Map< string, number >();
+	/** Cached JWT for PingHub authentication. */
+	private cachedJwt: string | null = null;
+	private cachedJwtTimestamp = 0;
 	/** Reassembly buffer: key = room + ':' + msgId, value = { totalChunks, chunks } */
 	private chunkBuffers = new Map<
 		string,
@@ -321,17 +319,40 @@ export class PingHubBridge {
 	}
 
 	/**
+	 * Fetch a short-lived JWT for PingHub authentication via the REST endpoint.
+	 * Caches the token for 1 minute to avoid redundant requests on reconnects.
+	 *
+	 * @return JWT string, or null on failure.
+	 */
+	private async fetchPinghubJwt(): Promise< string | null > {
+		if ( this.cachedJwt && Date.now() - this.cachedJwtTimestamp < JWT_CACHE_TTL_MS ) {
+			return this.cachedJwt;
+		}
+		try {
+			const response = await apiFetch< { token: string } >( {
+				path: '/wpcom/v2/gutenberg-rtc/pinghub-token',
+				method: 'POST',
+			} );
+			this.cachedJwt = response?.token ?? null;
+			this.cachedJwtTimestamp = Date.now();
+			return this.cachedJwt;
+		} catch {
+			return null;
+		}
+	}
+
+	/**
 	 * Open a direct WebSocket connection to PingHub for the given room.
 	 *
-	 * Appends the JWT pre-generated server-side (wpcomGutenbergRTC.pinghubJWTToken)
-	 * as ?jwt=<token> so pinghub-auth.php can authenticate the connection when
+	 * Fetches a short-lived JWT from the REST endpoint and appends it as
+	 * ?jwt=<token> so pinghub-auth.php can authenticate the connection when
 	 * WPCOM cookies are absent (third-party cookie blocking on custom-domain
 	 * Jetpack/Atomic sites).
 	 *
 	 * @param room - Room name.
 	 * @return Promise
 	 */
-	connect( room: string ): Promise< void > {
+	async connect( room: string ): Promise< void > {
 		// Already open: fire open handlers and return.
 		const existing = this.sockets.get( room );
 		if ( existing?.readyState === WebSocket.OPEN ) {
@@ -348,11 +369,11 @@ export class PingHubBridge {
 		const waiters: Array< { resolve: () => void; reject: ( err: Error ) => void } > = [];
 		this.connectingWaiters.set( room, waiters );
 
-		// Use the JWT pre-generated server-side (gutenberg-rtc.php) so the
-		// connection authenticates even when WPCOM cookies are absent
-		// (third-party cookie blocking on custom-domain Jetpack/Atomic sites).
+		// Fetch a short-lived JWT so the connection authenticates even when
+		// WPCOM cookies are absent (third-party cookie blocking on
+		// custom-domain Jetpack/Atomic sites).
 		let wsUrl = this.fullPath( room );
-		const jwt = getPinghubJwt();
+		const jwt = await this.fetchPinghubJwt();
 		if ( jwt ) {
 			wsUrl += '?jwt=' + encodeURIComponent( jwt );
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/providers/pinghub/pinghub-bridge.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/providers/pinghub/pinghub-bridge.ts
@@ -4,45 +4,10 @@ type BridgeEventMap = {
 	message: ( data: Uint8Array ) => void;
 };
 
-/** Body of a PingHub proxy response (open, close, message, or error). */
-type ProxyResponseBody = {
-	type: 'open' | 'close' | 'message' | 'error';
-	code?: number;
-	reason?: string;
-	text?: string;
-	data?: ArrayBuffer | Blob | string;
-};
-
-/** Normalized proxy response we can handle in one place. */
-type NormalizedProxyResponse = {
-	body: ProxyResponseBody;
-	code: number;
-	callback: string;
-};
-
-const IFRAME_SRC_BASE = 'https://public-api.wordpress.com/wp-admin/rest-proxy/';
-const PROXY_ORIGIN = 'https://public-api.wordpress.com';
-const PROXY_ALREADY_SUBSCRIBED = 444;
-const PROXY_READY_TIMEOUT_MS = 30 * 1000;
-
 const CHUNK_MAGIC = 0xfe;
 const CHUNK_HEADER_LEN = 5; // magic(1) + msgId(2) + totalChunks(1) + chunkIndex(1)
-const MAX_PAYLOAD_BEFORE_CHUNK = 256;
-const MAX_CHUNK_BUFFERS = 64;
-
-/**
- * Encode a Uint8Array into a base64 string for text-frame transport.
- *
- * @param u8 - Bytes to encode.
- * @return Base64-encoded string.
- */
-function uint8ArrayToBase64( u8: Uint8Array ): string {
-	let binary = '';
-	for ( let i = 0; i < u8.length; i++ ) {
-		binary += String.fromCharCode( u8[ i ] );
-	}
-	return btoa( binary );
-}
+const MAX_PAYLOAD_BEFORE_CHUNK = 1024;
+const MAX_CHUNK_BUFFERS = 256;
 
 /**
  * Decode a base64 string back into a Uint8Array.
@@ -62,7 +27,7 @@ function base64ToUint8Array( base64: string ): Uint8Array {
 /**
  * Build a single chunk buffer: [CHUNK_MAGIC, msgIdHi, msgIdLo, totalChunks, chunkIndex, ...payload].
  *
- * @param msgId       - Message identifier (per path).
+ * @param msgId       - Message identifier (per room).
  * @param totalChunks - Total chunks for this message.
  * @param chunkIndex  - Zero-based index of this chunk.
  * @param payload     - Slice of the original payload for this chunk.
@@ -108,6 +73,20 @@ function parseChunkHeader( data: Uint8Array ): {
 }
 
 /**
+ * Encode a Uint8Array as a base64 string.
+ *
+ * @param u8 - Byte array.
+ * @return Base64-encoded string.
+ */
+function uint8ArrayToBase64( u8: Uint8Array ): string {
+	let binary = '';
+	for ( let i = 0; i < u8.length; i++ ) {
+		binary += String.fromCharCode( u8[ i ] );
+	}
+	return btoa( binary );
+}
+
+/**
  * Convert a string to bytes by taking the low byte of each char code.
  *
  * @param str - The string to convert.
@@ -120,116 +99,6 @@ function textToBytes( str: string ): Uint8Array {
 		u8[ i ] = str.charCodeAt( i ) & 0xff;
 	}
 	return u8;
-}
-
-/**
- * Parse event.data (string or already an object) into a plain value.
- *
- * @param data - The postMessage data (possibly a JSON string).
- * @return Parsed value or null.
- */
-function parseRaw( data: unknown ): unknown {
-	if ( typeof data === 'string' ) {
-		try {
-			return JSON.parse( data );
-		} catch {
-			return null;
-		}
-	}
-	return data;
-}
-
-/**
- * Try to parse the array format: [ body, code, headers?, callback ] or [ code, body, headers?, callback ].
- *
- * @param raw - The array payload from the proxy.
- * @return Normalized response or null if not a valid array response.
- */
-function parseArrayResponse( raw: unknown[] ): NormalizedProxyResponse | null {
-	if ( raw.length < 3 ) {
-		return null;
-	}
-
-	const callbackRaw = raw[ raw.length - 1 ];
-	const callback = callbackRaw != null ? String( callbackRaw ) : '';
-	if ( ! callback ) {
-		return null;
-	}
-
-	let code: number;
-	let bodyObj: unknown;
-	const first = raw[ 0 ];
-	const second = raw[ 1 ];
-	const firstIsCode =
-		typeof first === 'number' ||
-		( typeof first === 'string' && first !== '' && ! Number.isNaN( Number( first ) ) );
-
-	// Order A: [ body, code, headers?, callback ]
-	if ( typeof first === 'object' && first !== null ) {
-		bodyObj = first;
-		code = Number( raw[ raw.length - 2 ] );
-	}
-	// Order B: [ code, body, headers?, callback ] (code may be number or string from JSON)
-	else if ( firstIsCode && typeof second === 'object' && second !== null ) {
-		bodyObj = second;
-		code = Number( first );
-	} else {
-		return null;
-	}
-
-	// Inner body may be at .body or the object itself (e.g. { type: 'open' } or { body: { type, ... } })
-	const body =
-		( bodyObj as { body?: ProxyResponseBody } ).body ??
-		( ( bodyObj as { type?: string } ).type !== undefined ? bodyObj : null );
-	if (
-		typeof body !== 'object' ||
-		! body ||
-		typeof ( body as ProxyResponseBody ).type !== 'string'
-	) {
-		return null;
-	}
-	return { body: body as ProxyResponseBody, code, callback };
-}
-
-/**
- * Try to parse the legacy object format: { callback, body: { type, ... }, code? }.
- *
- * @param raw - The object payload from the proxy.
- * @return Normalized response or null if not a valid legacy response.
- */
-function parseLegacyObjectResponse(
-	raw: Record< string, unknown >
-): NormalizedProxyResponse | null {
-	const o = raw as { callback?: string; body?: ProxyResponseBody; code?: number };
-	if ( typeof o.callback !== 'string' || ! o.body || typeof o.body !== 'object' ) {
-		return null;
-	}
-	return {
-		body: o.body as ProxyResponseBody,
-		code: typeof o.code === 'number' ? o.code : 0,
-		callback: o.callback,
-	};
-}
-
-/**
- * Normalize proxy response (array or legacy object) into a single shape.
- *
- * Proxy sends either an array `[ body, code, headers?, callback ]` (supports_args)
- * or a legacy object with `.callback` and `.body`.
- *
- * @param raw - The parsed postMessage payload.
- * @return Normalized response or null if not a valid proxy response.
- */
-function normalizeProxyResponse( raw: unknown ): NormalizedProxyResponse | null {
-	if ( ! raw || typeof raw !== 'object' ) {
-		return null;
-	}
-
-	if ( Array.isArray( raw ) ) {
-		return parseArrayResponse( raw );
-	}
-
-	return parseLegacyObjectResponse( raw as Record< string, unknown > );
 }
 
 /**
@@ -250,40 +119,33 @@ function getBlogId(): number | null {
 	return null;
 }
 
+/**
+ * Read the pre-generated pinghub JWT token embedded by the server.
+ *
+ * @return JWT string, or null if absent.
+ */
+function getPinghubJwt(): string | null {
+	return window.wpcomGutenbergRTC?.pinghubJWTToken ?? null;
+}
+
 export class PingHubBridge {
-	private iframe: HTMLIFrameElement;
-	private ready = false;
-	private readyResolvers: Array< () => void > = [];
 	private openHandlers = new Map< string, Set< () => void > >();
 	private closeHandlers = new Map< string, Set< ( code: number, reason: string ) => void > >();
 	private messageHandlers = new Map< string, Set< ( data: Uint8Array ) => void > >();
-	private callbackSeq = 1;
-	private pending = new Map< string, () => void >();
-	private callbackToPath = new Map< string, string >();
-	private pathToCallback = new Map< string, string >();
-	/** Paths that have received 'open' and not yet 'close' or disconnect – one socket per path. */
-	private connectedPaths = new Set< string >();
-	/** Paths with a connect request in flight; waiters are resolved when we get open or error. */
-	private connectingPathWaiters = new Map<
+	/** Active WebSocket per room. */
+	private sockets = new Map< string, WebSocket >();
+	/** Waiters for an in-flight connect per room. */
+	private connectingWaiters = new Map<
 		string,
 		Array< { resolve: () => void; reject: ( err: Error ) => void } >
 	>();
-	/** Per-path message id for chunked sends. */
-	private chunkMsgIdByPath = new Map< string, number >();
-	/** Reassembly buffer: key = path + ':' + msgId, value = { totalChunks, chunks } */
+	/** Per-room message ID for chunked sends. */
+	private chunkMsgIdByRoom = new Map< string, number >();
+	/** Reassembly buffer: key = room + ':' + msgId, value = { totalChunks, chunks } */
 	private chunkBuffers = new Map<
 		string,
 		{ totalChunks: number; chunks: Map< number, Uint8Array > }
 	>();
-
-	/** Reuse an existing proxy iframe or create a new one and start listening for messages. */
-	constructor() {
-		const existing = document.querySelector(
-			`iframe[src^="${ IFRAME_SRC_BASE }"]`
-		) as HTMLIFrameElement | null;
-		this.iframe = existing ?? this.createIframe();
-		window.addEventListener( 'message', this.handleMessage );
-	}
 
 	/**
 	 * Build the full PingHub path for a room name.
@@ -296,245 +158,7 @@ export class PingHubBridge {
 		if ( ! blogId ) {
 			throw new Error( 'Cannot determine blog ID for PingHub bridge' );
 		}
-
-		return `/pinghub/wpcom/rtc/${ blogId }/${ room }`;
-	}
-
-	/**
-	 * Create and append a hidden proxy iframe to the document body.
-	 *
-	 * @return The created iframe element.
-	 */
-	private createIframe(): HTMLIFrameElement {
-		const iframe = document.createElement( 'iframe' );
-		iframe.style.cssText = 'position:absolute;left:-9999px;width:1px;height:1px;';
-		iframe.src = `${ IFRAME_SRC_BASE }?v=2.0#${ window.location.origin }`;
-		document.body.appendChild( iframe );
-		return iframe;
-	}
-
-	/**
-	 * Post a structured message to the proxy iframe.
-	 *
-	 * @param msg - The message to send.
-	 */
-	private postToProxy( msg: Record< string, unknown > ): void {
-		this.iframe.contentWindow?.postMessage( msg, PROXY_ORIGIN );
-	}
-
-	/**
-	 * Return a promise that resolves once the proxy iframe signals readiness.
-	 *
-	 * @return Resolves when the proxy is ready.
-	 */
-	private waitReady(): Promise< void > {
-		if ( this.ready ) {
-			return Promise.resolve();
-		}
-		return new Promise( ( resolve, reject ) => {
-			this.readyResolvers.push( resolve );
-			setTimeout( () => {
-				if ( ! this.ready ) {
-					reject( new Error( 'PingHub proxy iframe did not become ready in time' ) );
-				}
-			}, PROXY_READY_TIMEOUT_MS );
-		} );
-	}
-
-	/**
-	 * Handle incoming postMessage events from the proxy iframe.
-	 *
-	 * @param event - The MessageEvent from the proxy.
-	 */
-	private handleMessage = ( event: MessageEvent ): void => {
-		if ( event.origin !== PROXY_ORIGIN ) {
-			return;
-		}
-
-		const data = event.data;
-
-		// 1) Ready / cookie-auth
-		if (
-			data === 'ready' ||
-			( data?.type === 'pinghub-proxy' && data?.body?.type === 'cookie-auth' )
-		) {
-			this.ready = true;
-			this.readyResolvers.splice( 0 ).forEach( r => r() );
-			return;
-		}
-
-		// 2) Proxy JSON response (array or object)
-		const raw = parseRaw( data );
-		const response = normalizeProxyResponse( raw );
-		if ( response ) {
-			this.handleProxyResponse( response );
-		}
-	};
-
-	/**
-	 * Resolve or reject all connect waiters for a path.
-	 *
-	 * @param path    - The PingHub path.
-	 * @param success - Whether the connect succeeded.
-	 */
-	private settleConnectWaiters( path: string | undefined, success: boolean ): void {
-		const waiters = path ? this.connectingPathWaiters.get( path ) : undefined;
-		if ( waiters ) {
-			const err = new Error( 'PingHub connect failed' );
-			waiters.forEach( w => ( success ? w.resolve() : w.reject( err ) ) );
-			this.connectingPathWaiters.delete( path! );
-		}
-	}
-
-	/**
-	 * Route a normalized proxy response to the appropriate handler by message type.
-	 *
-	 * @param res - The normalized proxy response.
-	 */
-	private handleProxyResponse( res: NormalizedProxyResponse ): void {
-		const { body, code, callback } = res;
-		const path = this.callbackToPath.get( callback );
-		const resolvePending = this.pending.get( callback );
-		if ( resolvePending ) {
-			this.pending.delete( callback );
-		}
-
-		switch ( body.type ) {
-			case 'open':
-				if ( path ) {
-					this.connectedPaths.add( path );
-					this.openHandlers.get( path )?.forEach( h => h() );
-				}
-				this.settleConnectWaiters( path, true );
-				break;
-			case 'close':
-				if ( path ) {
-					this.connectedPaths.delete( path );
-					this.closeHandlers.get( path )?.forEach( h => h( body.code ?? 1000, body.reason ?? '' ) );
-				}
-				if ( resolvePending ) {
-					resolvePending();
-				}
-				break;
-			case 'message':
-				if ( path && body.data !== undefined ) {
-					this.dispatchToHandlers( path, body.data );
-				}
-				break;
-			case 'error':
-				// Proxy returns 444 "already subscribed" when we connect the same path twice – treat as success.
-				if ( path && ( code === PROXY_ALREADY_SUBSCRIBED || body.text === 'already subscribed' ) ) {
-					this.connectedPaths.add( path );
-					this.openHandlers.get( path )?.forEach( h => h() );
-					this.settleConnectWaiters( path, true );
-				} else {
-					if ( path ) {
-						this.callbackToPath.delete( callback );
-						this.pathToCallback.delete( path );
-					}
-					this.settleConnectWaiters( path, false );
-					if ( resolvePending ) {
-						resolvePending();
-					}
-				}
-				break;
-			default:
-				if ( resolvePending ) {
-					resolvePending();
-				}
-		}
-	}
-
-	/**
-	 * Dispatches received data to path handlers.
-	 *
-	 * Incoming frames may be:
-	 * - Base64 string (text frame): decoded to Uint8Array, then treated as chunk or whole message.
-	 * - Chunk (first byte CHUNK_MAGIC): buffered by path+msgId; when all chunks received, reassembled in order (chunk 0, 1, …) and passed once to handlers. Non-chunk messages are passed through.
-	 *
-	 * @param path - PingHub path for the message.
-	 * @param data - Raw payload from the proxy.
-	 */
-	private dispatchToHandlers( path: string, data: ArrayBuffer | Blob | string ): void {
-		const handlers = this.messageHandlers.get( path );
-		if ( ! handlers?.size ) {
-			return;
-		}
-
-		const run = ( u8: Uint8Array ) => {
-			const parsed = parseChunkHeader( u8 );
-			if ( parsed ) {
-				this.reassembleChunk( path, parsed, handlers );
-				return;
-			}
-			handlers.forEach( h => h( u8 ) );
-		};
-		if ( typeof data === 'string' ) {
-			try {
-				run( base64ToUint8Array( data ) );
-			} catch {
-				// Fallback: treat as raw bytes (e.g. proxy sent non-base64 text)
-				run( textToBytes( data ) );
-			}
-		} else if ( data instanceof ArrayBuffer ) {
-			run( new Uint8Array( data ) );
-		} else if ( data instanceof Blob ) {
-			data.arrayBuffer().then( ab => run( new Uint8Array( ab ) ) );
-		}
-	}
-
-	/**
-	 * Buffer incoming chunks and dispatch the reassembled message when all chunks have arrived.
-	 *
-	 * @param path               - PingHub path for the message.
-	 * @param parsed             - Parsed chunk header and payload.
-	 * @param parsed.msgId       - Message identifier shared across all chunks of one message.
-	 * @param parsed.totalChunks - Total number of chunks expected.
-	 * @param parsed.chunkIndex  - Zero-based index of this chunk.
-	 * @param parsed.payload     - Payload bytes for this chunk.
-	 * @param handlers           - Set of handlers to invoke with the reassembled message.
-	 */
-	private reassembleChunk(
-		path: string,
-		parsed: { msgId: number; totalChunks: number; chunkIndex: number; payload: Uint8Array },
-		handlers: Set< ( data: Uint8Array ) => void >
-	): void {
-		const key = `${ path }:${ parsed.msgId }`;
-		let buf = this.chunkBuffers.get( key );
-		if ( ! buf ) {
-			// Drop oldest incomplete buffers when the cap is reached.
-			if ( this.chunkBuffers.size >= MAX_CHUNK_BUFFERS ) {
-				const oldest = this.chunkBuffers.keys().next().value;
-				if ( oldest !== undefined ) {
-					this.chunkBuffers.delete( oldest );
-				}
-			}
-			buf = { totalChunks: parsed.totalChunks, chunks: new Map() };
-			this.chunkBuffers.set( key, buf );
-		}
-		buf.chunks.set( parsed.chunkIndex, parsed.payload );
-		if ( buf.chunks.size !== buf.totalChunks ) {
-			return;
-		}
-
-		this.chunkBuffers.delete( key );
-		const parts: Uint8Array[] = [];
-		for ( let i = 0; i < buf.totalChunks; i++ ) {
-			const chunk = buf.chunks.get( i );
-			if ( ! chunk ) {
-				// Missing chunk index — discard the incomplete message.
-				return;
-			}
-			parts.push( chunk );
-		}
-		const totalLen = parts.reduce( ( s, p ) => s + p.length, 0 );
-		const reassembled = new Uint8Array( totalLen );
-		let offset = 0;
-		for ( const p of parts ) {
-			reassembled.set( p, offset );
-			offset += p.length;
-		}
-		handlers.forEach( h => h( reassembled ) );
+		return `wss://public-api.wordpress.com/pinghub/wpcom/rtc/${ blogId }/${ room }`;
 	}
 
 	/**
@@ -559,22 +183,72 @@ export class PingHubBridge {
 	}
 
 	/**
-	 * Register an event handler for a channel path.
+	 * Buffer incoming chunks and dispatch the reassembled message when all chunks have arrived.
 	 *
-	 * @param path    - PingHub channel path.
+	 * @param room               - Room name.
+	 * @param parsed             - Parsed chunk header and payload.
+	 * @param parsed.msgId       - Message identifier shared across all chunks of one message.
+	 * @param parsed.totalChunks - Total number of chunks expected.
+	 * @param parsed.chunkIndex  - Zero-based index of this chunk.
+	 * @param parsed.payload     - Payload bytes for this chunk.
+	 */
+	private reassembleChunk(
+		room: string,
+		parsed: { msgId: number; totalChunks: number; chunkIndex: number; payload: Uint8Array }
+	): void {
+		const key = `${ room }:${ parsed.msgId }`;
+		let buf = this.chunkBuffers.get( key );
+		if ( ! buf ) {
+			if ( this.chunkBuffers.size >= MAX_CHUNK_BUFFERS ) {
+				const oldest = this.chunkBuffers.keys().next().value;
+				if ( oldest !== undefined ) {
+					this.chunkBuffers.delete( oldest );
+				}
+			}
+			buf = { totalChunks: parsed.totalChunks, chunks: new Map() };
+			this.chunkBuffers.set( key, buf );
+		}
+		buf.chunks.set( parsed.chunkIndex, parsed.payload );
+		if ( buf.chunks.size !== buf.totalChunks ) {
+			return;
+		}
+
+		this.chunkBuffers.delete( key );
+		const parts: Uint8Array[] = [];
+		for ( let i = 0; i < buf.totalChunks; i++ ) {
+			const chunk = buf.chunks.get( i );
+			if ( ! chunk ) {
+				return;
+			}
+			parts.push( chunk );
+		}
+		const totalLen = parts.reduce( ( s, p ) => s + p.length, 0 );
+		const reassembled = new Uint8Array( totalLen );
+		let offset = 0;
+		for ( const p of parts ) {
+			reassembled.set( p, offset );
+			offset += p.length;
+		}
+		this.messageHandlers.get( room )?.forEach( h => h( reassembled ) );
+	}
+
+	/**
+	 * Register an event handler for a room.
+	 *
+	 * @param room    - Room name.
 	 * @param event   - Event name: 'open', 'close', or 'message'.
 	 * @param handler - Callback for the event.
 	 */
 	on< E extends keyof BridgeEventMap >(
-		path: string,
+		room: string,
 		event: E,
 		handler: BridgeEventMap[ E ]
 	): void {
 		const map = this.handlersFor( event );
-		let set = map.get( path );
+		let set = map.get( room );
 		if ( ! set ) {
 			set = new Set();
-			map.set( path, set );
+			map.set( room, set );
 		}
 		set.add( handler );
 	}
@@ -582,47 +256,95 @@ export class PingHubBridge {
 	/**
 	 * Remove a previously registered event handler.
 	 *
-	 * @param path    - PingHub channel path.
+	 * @param room    - Room name.
 	 * @param event   - Event name: 'open', 'close', or 'message'.
 	 * @param handler - The handler to remove.
 	 */
 	off< E extends keyof BridgeEventMap >(
-		path: string,
+		room: string,
 		event: E,
 		handler: BridgeEventMap[ E ]
 	): void {
-		this.handlersFor( event ).get( path )?.delete( handler );
+		this.handlersFor( event ).get( room )?.delete( handler );
 	}
 
-	async connect( room: string ): Promise< void > {
-		await this.waitReady();
-
-		// Already connected: no new socket, just notify so handlers run.
-		if ( this.connectedPaths.has( room ) ) {
+	/**
+	 * Open a direct WebSocket connection to PingHub for the given room.
+	 *
+	 * Appends the JWT pre-generated server-side (wpcomGutenbergRTC.pinghubJWTToken)
+	 * as ?jwt=<token> so pinghub-auth.php can authenticate the connection when
+	 * WPCOM cookies are absent (third-party cookie blocking on custom-domain
+	 * Jetpack/Atomic sites).
+	 *
+	 * @param room - Room name.
+	 * @return Promise
+	 */
+	connect( room: string ): Promise< void > {
+		// Already open: fire open handlers and return.
+		const existing = this.sockets.get( room );
+		if ( existing?.readyState === WebSocket.OPEN ) {
 			this.openHandlers.get( room )?.forEach( h => h() );
-			return;
+			return Promise.resolve();
 		}
 
-		// Connect already in flight for this room: wait for it instead of sending another.
-		const existing = this.connectingPathWaiters.get( room );
-		if ( existing ) {
-			return new Promise( ( resolve, reject ) => existing.push( { resolve, reject } ) );
+		// Connect already in flight: wait for it instead of opening another socket.
+		const existingWaiters = this.connectingWaiters.get( room );
+		if ( existingWaiters ) {
+			return new Promise( ( resolve, reject ) => existingWaiters.push( { resolve, reject } ) );
 		}
 
 		const waiters: Array< { resolve: () => void; reject: ( err: Error ) => void } > = [];
-		this.connectingPathWaiters.set( room, waiters );
+		this.connectingWaiters.set( room, waiters );
 
-		const callback = String( this.callbackSeq++ );
-		this.callbackToPath.set( callback, room );
-		this.pathToCallback.set( room, callback );
+		// Use the JWT pre-generated server-side (gutenberg-rtc.php) so the
+		// connection authenticates even when WPCOM cookies are absent
+		// (third-party cookie blocking on custom-domain Jetpack/Atomic sites).
+		let wsUrl = this.fullPath( room );
+		const jwt = getPinghubJwt();
+		if ( jwt ) {
+			wsUrl += '?jwt=' + encodeURIComponent( jwt );
+		}
 
-		this.postToProxy( {
-			type: 'pinghub-proxy',
-			action: 'connect',
-			path: this.fullPath( room ),
-			callback,
-			supports_args: true,
-			binary: false,
+		const ws = new WebSocket( wsUrl );
+		ws.binaryType = 'arraybuffer';
+		this.sockets.set( room, ws );
+
+		ws.addEventListener( 'open', () => {
+			this.connectingWaiters.delete( room );
+			waiters.splice( 0 ).forEach( ( { resolve } ) => resolve() );
+			this.openHandlers.get( room )?.forEach( h => h() );
+		} );
+
+		ws.addEventListener( 'close', event => {
+			this.sockets.delete( room );
+			if ( this.connectingWaiters.has( room ) ) {
+				this.connectingWaiters.delete( room );
+				const err = new Error( 'PingHub connect failed' );
+				waiters.splice( 0 ).forEach( ( { reject } ) => reject( err ) );
+			}
+			this.closeHandlers.get( room )?.forEach( h => h( event.code, event.reason ) );
+		} );
+
+		ws.addEventListener( 'message', event => {
+			const { data } = event;
+			let u8: Uint8Array;
+			if ( data instanceof ArrayBuffer ) {
+				u8 = new Uint8Array( data );
+			} else if ( typeof data === 'string' ) {
+				try {
+					u8 = base64ToUint8Array( data );
+				} catch {
+					u8 = textToBytes( data );
+				}
+			} else {
+				return;
+			}
+			const parsed = parseChunkHeader( u8 );
+			if ( parsed ) {
+				this.reassembleChunk( room, parsed );
+			} else {
+				this.messageHandlers.get( room )?.forEach( h => h( u8 ) );
+			}
 		} );
 
 		return new Promise( ( resolve, reject ) => {
@@ -630,55 +352,51 @@ export class PingHubBridge {
 		} );
 	}
 
+	/**
+	 * Close the WebSocket for the given room.
+	 *
+	 * @param room - Room name.
+	 */
 	async disconnect( room: string ): Promise< void > {
-		await this.waitReady();
-		this.connectedPaths.delete( room );
-		const callback = this.pathToCallback.get( room );
-		if ( callback ) {
-			this.callbackToPath.delete( callback );
-			this.pathToCallback.delete( room );
+		const ws = this.sockets.get( room );
+		this.sockets.delete( room );
+		this.connectingWaiters.delete( room );
+		if ( ws && ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING ) {
+			ws.close( 1000, 'disconnect' );
 		}
-		return new Promise( resolve => {
-			const discCallback = String( this.callbackSeq++ );
-			this.pending.set( discCallback, () => resolve() );
-			this.postToProxy( {
-				type: 'pinghub-proxy',
-				action: 'disconnect',
-				path: this.fullPath( room ),
-				callback: discCallback,
-			} );
-		} );
 	}
 
+	/**
+	 * Send binary data to peers in the given room.
+	 *
+	 * Messages larger than MAX_PAYLOAD_BEFORE_CHUNK bytes are split into chunks
+	 * so all peers (regardless of transport) can reassemble them.
+	 *
+	 * @param room - Room name.
+	 * @param data - Payload to send.
+	 */
 	send( room: string, data: Uint8Array ): void {
-		if ( ! this.iframe.contentWindow ) {
+		const ws = this.sockets.get( room );
+		if ( ! ws || ws.readyState !== WebSocket.OPEN ) {
 			return;
 		}
 
-		const proxyPath = this.fullPath( room );
-		const sendOne = ( payload: Uint8Array ) => {
-			this.postToProxy( {
-				type: 'pinghub-proxy',
-				action: 'send',
-				path: proxyPath,
-				message: uint8ArrayToBase64( payload ),
-			} );
-		};
+		const sendOne = ( payload: Uint8Array ) => ws.send( uint8ArrayToBase64( payload ) );
 
 		if ( data.length <= MAX_PAYLOAD_BEFORE_CHUNK ) {
 			sendOne( data );
 			return;
 		}
 
-		const msgId = ( this.chunkMsgIdByPath.get( room ) ?? 0 ) & 0xffff; // eslint-disable-line no-bitwise
-		this.chunkMsgIdByPath.set( room, msgId + 1 );
+		// eslint-disable-next-line no-bitwise
+		const msgId = ( this.chunkMsgIdByRoom.get( room ) ?? 0 ) & 0xffff;
+		this.chunkMsgIdByRoom.set( room, msgId + 1 );
 		const chunkSize = MAX_PAYLOAD_BEFORE_CHUNK - CHUNK_HEADER_LEN;
 		const totalChunks = Math.ceil( data.length / chunkSize );
 		for ( let i = 0; i < totalChunks; i++ ) {
 			const start = i * chunkSize;
 			const payload = data.subarray( start, Math.min( start + chunkSize, data.length ) );
-			const chunk = buildChunk( msgId, totalChunks, i, payload );
-			sendOne( chunk );
+			sendOne( buildChunk( msgId, totalChunks, i, payload ) );
 		}
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
@@ -19,14 +19,12 @@ use PHPUnit\Framework\Attributes\CoversFunction;
  * @covers ::wpcom_disable_rtc_option
  * @covers ::wpcom_enqueue_gutenberg_rtc_assets
  * @covers ::wpcom_get_gutenberg_rtc_providers
- * @covers ::wpcom_gutenberg_rtc_get_pinghub_jwt
  * @covers ::wpcom_is_gutenberg_rtc_enabled
  * @covers ::wpcom_unregister_rtc_setting
  */
 #[CoversFunction( 'wpcom_is_gutenberg_rtc_enabled' )]
 #[CoversFunction( 'wpcom_get_gutenberg_rtc_providers' )]
 #[CoversFunction( 'wpcom_enqueue_gutenberg_rtc_assets' )]
-#[CoversFunction( 'wpcom_gutenberg_rtc_get_pinghub_jwt' )]
 #[CoversFunction( 'wpcom_unregister_rtc_setting' )]
 #[CoversFunction( 'wpcom_disable_rtc_option' )]
 class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
@@ -335,36 +333,9 @@ class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that wpcom_gutenberg_rtc_get_pinghub_jwt returns null when no user is logged in.
+	 * Tests that the inline script data does not include pinghubJWTToken when assets are enqueued.
 	 */
-	public function test_wpcom_gutenberg_rtc_get_pinghub_jwt_returns_null_when_no_user() {
-		wp_set_current_user( 0 );
-		$this->assertNull( wpcom_gutenberg_rtc_get_pinghub_jwt() );
-	}
-
-	/**
-	 * Tests that wpcom_gutenberg_rtc_get_pinghub_jwt returns null when no blog ID is available.
-	 */
-	public function test_wpcom_gutenberg_rtc_get_pinghub_jwt_returns_null_when_no_blog_id() {
-		$user_id = wp_insert_user(
-			array(
-				'user_login' => 'rtc_test_user',
-				'user_pass'  => 'password',
-				'user_email' => 'rtc_test@example.com',
-			)
-		);
-		wp_set_current_user( $user_id );
-
-		// Without IS_WPCOM and without Jetpack Connection Client, should return null.
-		$this->assertNull( wpcom_gutenberg_rtc_get_pinghub_jwt() );
-
-		wp_delete_user( $user_id );
-	}
-
-	/**
-	 * Tests that the inline script data includes the pinghubJWTToken key when assets are enqueued.
-	 */
-	public function test_wpcom_enqueue_gutenberg_rtc_assets_includes_jwt_token_key() {
+	public function test_wpcom_enqueue_gutenberg_rtc_assets_does_not_include_jwt_token() {
 		add_filter( 'wpcom_is_gutenberg_rtc_enabled', '__return_true' );
 		add_filter(
 			'wpcom_gutenberg_rtc_providers',
@@ -378,9 +349,9 @@ class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
 		$handle = 'jetpack-mu-wpcom-gutenberg-rtc';
 		$this->assertTrue( wp_script_is( $handle, 'enqueued' ) );
 
-		// Check that the inline script contains the pinghubJWTToken key.
+		// Ensure the inline script does NOT contain pinghubJWTToken.
 		$inline_script = wp_scripts()->get_inline_script_data( $handle, 'before' );
-		$this->assertStringContainsString( 'pinghubJWTToken', $inline_script );
+		$this->assertStringNotContainsString( 'pinghubJWTToken', $inline_script );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
@@ -19,12 +19,14 @@ use PHPUnit\Framework\Attributes\CoversFunction;
  * @covers ::wpcom_disable_rtc_option
  * @covers ::wpcom_enqueue_gutenberg_rtc_assets
  * @covers ::wpcom_get_gutenberg_rtc_providers
+ * @covers ::wpcom_gutenberg_rtc_get_pinghub_jwt
  * @covers ::wpcom_is_gutenberg_rtc_enabled
  * @covers ::wpcom_unregister_rtc_setting
  */
 #[CoversFunction( 'wpcom_is_gutenberg_rtc_enabled' )]
 #[CoversFunction( 'wpcom_get_gutenberg_rtc_providers' )]
 #[CoversFunction( 'wpcom_enqueue_gutenberg_rtc_assets' )]
+#[CoversFunction( 'wpcom_gutenberg_rtc_get_pinghub_jwt' )]
 #[CoversFunction( 'wpcom_unregister_rtc_setting' )]
 #[CoversFunction( 'wpcom_disable_rtc_option' )]
 class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
@@ -330,6 +332,55 @@ class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
 
 		$this->assertArrayHasKey( 'wp_enable_real_time_collaboration', $wp_settings_fields['writing']['default'] );
 		$this->assertArrayHasKey( 'enable_real_time_collaboration', $wp_settings_fields['writing']['default'] );
+	}
+
+	/**
+	 * Tests that wpcom_gutenberg_rtc_get_pinghub_jwt returns null when no user is logged in.
+	 */
+	public function test_wpcom_gutenberg_rtc_get_pinghub_jwt_returns_null_when_no_user() {
+		wp_set_current_user( 0 );
+		$this->assertNull( wpcom_gutenberg_rtc_get_pinghub_jwt() );
+	}
+
+	/**
+	 * Tests that wpcom_gutenberg_rtc_get_pinghub_jwt returns null when no blog ID is available.
+	 */
+	public function test_wpcom_gutenberg_rtc_get_pinghub_jwt_returns_null_when_no_blog_id() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'rtc_test_user',
+				'user_pass'  => 'password',
+				'user_email' => 'rtc_test@example.com',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		// Without IS_WPCOM and without Jetpack Connection Client, should return null.
+		$this->assertNull( wpcom_gutenberg_rtc_get_pinghub_jwt() );
+
+		wp_delete_user( $user_id );
+	}
+
+	/**
+	 * Tests that the inline script data includes the pinghubJWTToken key when assets are enqueued.
+	 */
+	public function test_wpcom_enqueue_gutenberg_rtc_assets_includes_jwt_token_key() {
+		add_filter( 'wpcom_is_gutenberg_rtc_enabled', '__return_true' );
+		add_filter(
+			'wpcom_gutenberg_rtc_providers',
+			function () {
+				return array( 'pinghub' );
+			}
+		);
+
+		wpcom_enqueue_gutenberg_rtc_assets();
+
+		$handle = 'jetpack-mu-wpcom-gutenberg-rtc';
+		$this->assertTrue( wp_script_is( $handle, 'enqueued' ) );
+
+		// Check that the inline script contains the pinghubJWTToken key.
+		$inline_script = wp_scripts()->get_inline_script_data( $handle, 'before' );
+		$this->assertStringContainsString( 'pinghubJWTToken', $inline_script );
 	}
 
 	/**

--- a/projects/plugins/mu-wpcom-plugin/changelog/pr-47556
+++ b/projects/plugins/mu-wpcom-plugin/changelog/pr-47556
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Gutenberg RTC: Connect to PingHub WebSocket directly using a server-generated JWT token, fixing real-time collaboration on custom-domain sites with third-party cookie restrictions.

--- a/projects/plugins/wpcomsh/changelog/pr-47556
+++ b/projects/plugins/wpcomsh/changelog/pr-47556
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Gutenberg RTC: Connect to PingHub WebSocket directly using a server-generated JWT token, fixing real-time collaboration on custom-domain Atomic sites with third-party cookie restrictions.


### PR DESCRIPTION
Related to DOTCOM-16207

## Proposed changes

Replace the iframe-based REST proxy transport in `PingHubBridge` with direct WebSocket connections to PingHub, authenticated via a short-lived JWT fetched on-demand from a new REST endpoint.

* **PHP (`class-wp-rest-gutenberg-rtc.php`)**: New `POST /wpcom/v2/gutenberg-rtc/pinghub-token` REST endpoint (`WP_REST_Gutenberg_RTC` controller) that generates a JWT for PingHub auth. Permission callback checks `is_user_member_of_blog()`.
* **PHP (`gutenberg-rtc.php`)**: Register the new endpoint via `rest_api_init`.
* **JS (`pinghub-bridge.ts`)**:
  * Remove all iframe/REST-proxy plumbing (iframe creation, `postMessage` handling, proxy response parsing). 
  * On `connect()`, fetch a short-lived JWT from the REST endpoint, then connect to `wss://public-api.wordpress.com/pinghub/…?jwt=<token>` directly.
  * Cache the token on the `PingHubBridge` instance for 1 minute to avoid redundant requests on reconnects. This fixes third-party cookie blocking on custom-domain Jetpack/Atomic sites where the proxy iframe can't authenticate.
* Increase chunk size from 256 to 1024 bytes and chunk buffer cap from 64 to 256 to reduce overhead for larger sync messages.

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* DOTCOM-16207

## Does this pull request change what data or activity we track or use?

No changes to tracking. The JWT contains the same user/blog identity already used by the cookie-based proxy; it is short-lived and scoped to `pinghub`.

## Testing instructions

1. Add following filter to enable RTC or add your site ID to `wpcom_gutenberg_rtc_is_pinghub_enabled` on your sandbox
```php
// mu-plugins/0-sandbox.php
add_filter( 'wpcom_is_gutenberg_rtc_enabled', '__return_true', 100 );
```
2. Sandbox the request and your site
3. Apply changes to your sandbox
4. Edit a page/post
5. Check the Network tab — verify a `POST /wpcom/v2/gutenberg-rtc/pinghub-token` request fires before the WebSocket connects
6. Verify the WebSocket connects to `wss://public-api.wordpress.com/pinghub/wpcom/rtc/<blogId>/…?jwt=…`
7. Verify the page source does **not** contain `pinghubJWTToken` (token is no longer inlined)
8. Open the same post in a second browser/incognito tab — verify real-time sync and awareness (cursors) work
9. Apply changes to your Atomic site with the `wpcom-features-edge` sticker by Jetpack Beta Tester
10. Confirm JWT auth bypasses third-party cookie blocking and everything works as expected
