### PR TITLE
Enforce room limits in the front-end

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/gutenberg-rtc-room-limit
+++ b/projects/packages/jetpack-mu-wpcom/changelog/gutenberg-rtc-room-limit
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+GutenbergRTC: add default room limit

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
@@ -57,8 +57,9 @@ function wpcom_enqueue_gutenberg_rtc_assets() {
 
 	$data = wp_json_encode(
 		array(
-			'providers'       => wpcom_get_gutenberg_rtc_providers(),
-			'maxPeersPerRoom' => 2,
+			'providers'         => wpcom_get_gutenberg_rtc_providers(),
+			'maxPeersPerRoom'   => wpcom_get_gutenberg_rtc_max_peers_per_room(),
+			'maxClientsPerUser' => wpcom_get_gutenberg_rtc_max_clients_per_user(),
 		),
 		JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 	);
@@ -70,6 +71,24 @@ function wpcom_enqueue_gutenberg_rtc_assets() {
 	);
 }
 add_action( 'enqueue_block_editor_assets', 'wpcom_enqueue_gutenberg_rtc_assets' );
+
+/**
+ * Get the maximum number of peers allowed per room.
+ *
+ * @return int Max peers per room.
+ */
+function wpcom_get_gutenberg_rtc_max_peers_per_room() {
+	return (int) apply_filters( 'wpcom_gutenberg_rtc_max_peers_per_room', 2 );
+}
+
+/**
+ * Get the maximum number of clients (tabs) allowed per user in a room.
+ *
+ * @return int Max clients per user.
+ */
+function wpcom_get_gutenberg_rtc_max_clients_per_user() {
+	return (int) apply_filters( 'wpcom_gutenberg_rtc_max_clients_per_user', 2 );
+}
 
 /**
  * Unregister the RTC setting field, Collaboration, on the Writing page if there are no RTC providers.

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
@@ -58,8 +58,7 @@ function wpcom_enqueue_gutenberg_rtc_assets() {
 	$data = wp_json_encode(
 		array(
 			'providers'         => wpcom_get_gutenberg_rtc_providers(),
-			'maxPeersPerRoom'   => wpcom_get_gutenberg_rtc_max_peers_per_room(),
-			'maxClientsPerUser' => wpcom_get_gutenberg_rtc_max_clients_per_user(),
+			'maxClientsPerRoom' => wpcom_get_gutenberg_rtc_max_clients_per_room(),
 		),
 		JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 	);
@@ -73,21 +72,13 @@ function wpcom_enqueue_gutenberg_rtc_assets() {
 add_action( 'enqueue_block_editor_assets', 'wpcom_enqueue_gutenberg_rtc_assets' );
 
 /**
- * Get the maximum number of peers allowed per room.
+ * Get the maximum number of clients allowed per room.
  *
- * @return int Max peers per room.
+ * @return int Max clients per room.
  */
-function wpcom_get_gutenberg_rtc_max_peers_per_room() {
-	return (int) apply_filters( 'wpcom_gutenberg_rtc_max_peers_per_room', 2 );
+function wpcom_get_gutenberg_rtc_max_clients_per_room() {
+	return (int) apply_filters( 'wpcom_gutenberg_rtc_max_clients_per_room', 2 );
 }
-
-/**
- * Get the maximum number of clients (tabs) allowed per user in a room.
- *
- * @return int Max clients per user.
- */
-function wpcom_get_gutenberg_rtc_max_clients_per_user() {
-	return (int) apply_filters( 'wpcom_gutenberg_rtc_max_clients_per_user', 2 );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
@@ -53,20 +53,12 @@ function wpcom_get_gutenberg_rtc_providers() {
  * Enqueue block editor assets for Gutenberg RTC customizations.
  */
 function wpcom_enqueue_gutenberg_rtc_assets() {
-	$providers = wpcom_get_gutenberg_rtc_providers();
-
-	// If HTTP polling (Gutenberg’s built-in default provider when this script isn’t enqueued)
-	// is the only provider being used, then we don’t need to inject any assets since that’s
-	// already the default behavior.
-	if ( count( $providers ) === 1 && in_array( 'http-polling', $providers, true ) ) {
-		return;
-	}
-
 	$handle = jetpack_mu_wpcom_enqueue_assets( 'gutenberg-rtc', array( 'js' ) );
 
 	$data = wp_json_encode(
 		array(
-			'providers' => wpcom_get_gutenberg_rtc_providers(),
+			'providers'     => wpcom_get_gutenberg_rtc_providers(),
+			'roomUserLimit' => 2,
 		),
 		JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 	);

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
@@ -57,8 +57,8 @@ function wpcom_enqueue_gutenberg_rtc_assets() {
 
 	$data = wp_json_encode(
 		array(
-			'providers'     => wpcom_get_gutenberg_rtc_providers(),
-			'roomUserLimit' => 2,
+			'providers'       => wpcom_get_gutenberg_rtc_providers(),
+			'maxPeersPerRoom' => 2,
 		),
 		JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 	);

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.ts
@@ -3,6 +3,16 @@ import { createPingHubProvider } from './providers/pinghub';
 import { withRoomLimit } from './room-limit';
 import type { ProviderCreator } from '@wordpress/sync';
 
+declare global {
+	interface Window {
+		wpcomGutenbergRTC?: {
+			providers?: string[];
+			maxPeersPerRoom?: number;
+			maxClientsPerUser?: number;
+		};
+	}
+}
+
 /**
  * Register providers (e.g. PingHub, HTTP polling) supplied by the server,
  * each wrapped with a room-user-limit enforcer.
@@ -14,6 +24,7 @@ function registerWpcomGutenbergProviders() {
 		}
 
 		const maxPeersPerRoom = window.wpcomGutenbergRTC.maxPeersPerRoom;
+		const maxClientsPerUser = window.wpcomGutenbergRTC.maxClientsPerUser;
 
 		return window.wpcomGutenbergRTC.providers
 			.map( ( provider: string ) => {
@@ -27,7 +38,7 @@ function registerWpcomGutenbergProviders() {
 				}
 			} )
 			.filter( ( creator ): creator is ProviderCreator => Boolean( creator ) )
-			.map( creator => withRoomLimit( creator, maxPeersPerRoom ) );
+			.map( creator => withRoomLimit( creator, maxPeersPerRoom, maxClientsPerUser ) );
 	};
 
 	addFilter( 'sync.providers', 'wpcom/gutenberg-rtc-providers', getProviders );

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.ts
@@ -1,20 +1,36 @@
 import { addFilter } from '@wordpress/hooks';
 import { createPingHubProvider } from './providers/pinghub';
+import { withRoomLimit } from './room-limit';
+import type { ProviderCreator } from '@wordpress/sync';
 
 /**
- * Register providers (e.g. PingHub) supplied by the server, and disable HTTP polling by returning only this provider.
+ * Register providers (e.g. PingHub, HTTP polling) supplied by the server,
+ * each wrapped with a room-user-limit enforcer.
  */
 function registerWpcomGutenbergProviders() {
-	const getProviders = () => {
+	const getProviders = ( defaultProviders: unknown[] ) => {
 		if ( ! window.wpcomGutenbergRTC?.providers ) {
-			return [];
+			return defaultProviders;
 		}
+
+		const httpPollingCreator =
+			typeof defaultProviders?.[ 0 ] === 'function'
+				? ( defaultProviders[ 0 ] as ProviderCreator )
+				: null;
+
+		const roomUserLimit = window.wpcomGutenbergRTC.roomUserLimit;
 
 		return window.wpcomGutenbergRTC.providers
 			.map( ( provider: string ) => {
 				switch ( provider ) {
+					case 'http-polling': {
+						if ( httpPollingCreator ) {
+							return withRoomLimit( httpPollingCreator, roomUserLimit );
+						}
+						return null;
+					}
 					case 'pinghub': {
-						return createPingHubProvider();
+						return withRoomLimit( createPingHubProvider(), roomUserLimit );
 					}
 					default:
 						return null;
@@ -23,7 +39,7 @@ function registerWpcomGutenbergProviders() {
 			.filter( Boolean );
 	};
 
-	addFilter( 'sync.providers', 'wpcom/gutenberg-rtc-providers', () => getProviders() );
+	addFilter( 'sync.providers', 'wpcom/gutenberg-rtc-providers', getProviders );
 }
 
 registerWpcomGutenbergProviders();

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.ts
@@ -13,30 +13,21 @@ function registerWpcomGutenbergProviders() {
 			return defaultProviders;
 		}
 
-		const httpPollingCreator =
-			typeof defaultProviders?.[ 0 ] === 'function'
-				? ( defaultProviders[ 0 ] as ProviderCreator )
-				: null;
-
-		const roomUserLimit = window.wpcomGutenbergRTC.roomUserLimit;
+		const maxPeersPerRoom = window.wpcomGutenbergRTC.maxPeersPerRoom;
 
 		return window.wpcomGutenbergRTC.providers
 			.map( ( provider: string ) => {
 				switch ( provider ) {
-					case 'http-polling': {
-						if ( httpPollingCreator ) {
-							return withRoomLimit( httpPollingCreator, roomUserLimit );
-						}
-						return null;
-					}
-					case 'pinghub': {
-						return withRoomLimit( createPingHubProvider(), roomUserLimit );
-					}
+					case 'http-polling':
+						return defaultProviders?.[ 0 ];
+					case 'pinghub':
+						return createPingHubProvider();
 					default:
 						return null;
 				}
 			} )
-			.filter( Boolean );
+			.filter( ( creator ): creator is ProviderCreator => Boolean( creator ) )
+			.map( creator => withRoomLimit( creator, maxPeersPerRoom ) );
 	};
 
 	addFilter( 'sync.providers', 'wpcom/gutenberg-rtc-providers', getProviders );

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/room-limit.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/room-limit.ts
@@ -40,6 +40,29 @@ function countOtherUsers( awareness: Awareness ): number {
 }
 
 /**
+ * Count other connected clients (tabs) for the local WordPress user.
+ *
+ * @param awareness - The Yjs awareness instance.
+ * @return Number of additional local-user clients, or -1 when the local user/client is not identifiable yet.
+ */
+function countOtherClientsForLocalUser( awareness: Awareness ): number {
+	const localUserId = awareness.getLocalState()?.collaboratorInfo?.id;
+	const localClientId = ( awareness as Awareness & { clientID?: unknown } ).clientID;
+	if ( typeof localUserId !== 'number' || typeof localClientId !== 'number' ) {
+		return -1;
+	}
+
+	let count = 0;
+	for ( const [ clientId, state ] of awareness.getStates() ) {
+		const uid = state?.collaboratorInfo?.id;
+		if ( typeof uid === 'number' && uid === localUserId && clientId !== localClientId ) {
+			count++;
+		}
+	}
+	return count;
+}
+
+/**
  * Wraps a provider creator to enforce a per-room user limit.
  *
  * On every awareness change the wrapper counts unique WordPress user IDs
@@ -47,19 +70,24 @@ function countOtherUsers( awareness: Awareness ): number {
  * reaches the given limit every provider created through `withRoomLimit`
  * is destroyed, which causes the shared polling manager to stop entirely.
  *
- * @param creator         - The provider creator to wrap.
- * @param maxPeersPerRoom - Max other unique users allowed. Undefined or ≤ 0 disables enforcement.
+ * @param creator           - The provider creator to wrap.
+ * @param maxPeersPerRoom   - Max other unique users allowed. Undefined or <= 0 disables peer enforcement.
+ * @param maxClientsPerUser - Max additional clients (tabs) for the same user. Undefined or <= 0 disables per-user enforcement.
  * @return Wrapped provider creator.
  */
 export function withRoomLimit(
 	creator: ProviderCreator,
-	maxPeersPerRoom?: number
+	maxPeersPerRoom?: number,
+	maxClientsPerUser?: number
 ): ProviderCreator {
-	if ( ! maxPeersPerRoom || maxPeersPerRoom <= 0 ) {
+	const hasPeerLimit = Boolean( maxPeersPerRoom && maxPeersPerRoom > 0 );
+	const hasClientLimit = Boolean( maxClientsPerUser && maxClientsPerUser > 0 );
+	if ( ! hasPeerLimit && ! hasClientLimit ) {
 		return creator;
 	}
 
-	const limit = maxPeersPerRoom;
+	const peerLimit = maxPeersPerRoom ?? 0;
+	const clientLimit = maxClientsPerUser ?? 0;
 
 	return async ( options ): Promise< ProviderCreatorResult > => {
 		if ( breached ) {
@@ -86,8 +114,11 @@ export function withRoomLimit(
 				return;
 			}
 
-			const others = countOtherUsers( awareness );
-			if ( others >= limit ) {
+			const otherUsers = countOtherUsers( awareness );
+			const otherLocalUserClients = countOtherClientsForLocalUser( awareness );
+			const isPeerLimitReached = hasPeerLimit && otherUsers >= peerLimit;
+			const isClientLimitReached = hasClientLimit && otherLocalUserClients >= clientLimit;
+			if ( isPeerLimitReached || isClientLimitReached ) {
 				breached = true;
 				for ( const fn of teardowns ) {
 					fn();

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/room-limit.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/room-limit.ts
@@ -1,0 +1,72 @@
+import type { ProviderCreator, ProviderCreatorResult } from '@wordpress/sync';
+
+/**
+ * Wraps a provider creator to enforce a per-room user limit.
+ *
+ * On every awareness change the wrapper counts unique WordPress user IDs
+ * (from `collaboratorInfo.id`) excluding the local user. When the count
+ * reaches the given limit the inner provider is destroyed.
+ * When `roomUserLimit` is undefined or ≤ 0 the limit is not enforced.
+ *
+ * @param creator       - The provider creator to wrap.
+ * @param roomUserLimit - Max other unique users before disabling.
+ * @return Wrapped provider creator.
+ */
+export function withRoomLimit( creator: ProviderCreator, roomUserLimit?: number ): ProviderCreator {
+	if ( ! roomUserLimit || roomUserLimit <= 0 ) {
+		return creator;
+	}
+
+	const limit = roomUserLimit;
+
+	return async ( options ): Promise< ProviderCreatorResult > => {
+		const { awareness } = options;
+		const innerProvider = await creator( options );
+		let isDestroyed = false;
+
+		/** Check awareness states and destroy the provider when the limit is reached. */
+		function checkRoomLimit(): void {
+			if ( isDestroyed || ! awareness ) {
+				return;
+			}
+
+			const localState = awareness.getLocalState();
+			const localUserId = localState?.collaboratorInfo?.id;
+			if ( typeof localUserId !== 'number' ) {
+				return;
+			}
+
+			const states = awareness.getStates();
+			const otherUserIds = new Set< number >();
+
+			for ( const [ , state ] of states ) {
+				const userId = state?.collaboratorInfo?.id;
+				if ( typeof userId === 'number' && userId !== localUserId ) {
+					otherUserIds.add( userId );
+				}
+			}
+
+			if ( otherUserIds.size >= limit ) {
+				isDestroyed = true;
+				awareness.off( 'change', checkRoomLimit );
+				innerProvider.destroy();
+			}
+		}
+
+		if ( awareness ) {
+			awareness.on( 'change', checkRoomLimit );
+			checkRoomLimit();
+		}
+
+		return {
+			destroy: () => {
+				if ( ! isDestroyed ) {
+					isDestroyed = true;
+					awareness?.off( 'change', checkRoomLimit );
+					innerProvider.destroy();
+				}
+			},
+			on: innerProvider.on.bind( innerProvider ),
+		};
+	};
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/room-limit.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/room-limit.ts
@@ -47,16 +47,19 @@ function countOtherUsers( awareness: Awareness ): number {
  * reaches the given limit every provider created through `withRoomLimit`
  * is destroyed, which causes the shared polling manager to stop entirely.
  *
- * @param creator       - The provider creator to wrap.
- * @param roomUserLimit - Max other unique users allowed. Undefined or ≤ 0 disables enforcement.
+ * @param creator         - The provider creator to wrap.
+ * @param maxPeersPerRoom - Max other unique users allowed. Undefined or ≤ 0 disables enforcement.
  * @return Wrapped provider creator.
  */
-export function withRoomLimit( creator: ProviderCreator, roomUserLimit?: number ): ProviderCreator {
-	if ( ! roomUserLimit || roomUserLimit <= 0 ) {
+export function withRoomLimit(
+	creator: ProviderCreator,
+	maxPeersPerRoom?: number
+): ProviderCreator {
+	if ( ! maxPeersPerRoom || maxPeersPerRoom <= 0 ) {
 		return creator;
 	}
 
-	const limit = roomUserLimit;
+	const limit = maxPeersPerRoom;
 
 	return async ( options ): Promise< ProviderCreatorResult > => {
 		if ( breached ) {
@@ -84,7 +87,7 @@ export function withRoomLimit( creator: ProviderCreator, roomUserLimit?: number 
 			}
 
 			const others = countOtherUsers( awareness );
-			if ( others >= 0 && others >= limit ) {
+			if ( others >= limit ) {
 				breached = true;
 				for ( const fn of teardowns ) {
 					fn();

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/room-limit.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/room-limit.ts
@@ -7,7 +7,8 @@ import type { Awareness } from 'y-protocols/awareness';
  * The polling manager in `@wordpress/sync` is a singleton that sends a single
  * HTTP request for every registered room. To fully stop polling when the
  * room limit is reached we must destroy *all* wrapped providers — entity
- * rooms AND collection rooms — in one shot.
+ * rooms AND collection rooms — in one shot. We only trigger that global
+ * teardown when the current client is in the overflow set (newest by enteredAt).
  */
 let breached = false;
 const teardowns: Array< () => void > = [];
@@ -18,57 +19,86 @@ const NOOP_RESULT: ProviderCreatorResult = {
 };
 
 /**
- * Count unique WordPress user IDs in the room, excluding the local user.
+ * Build a sorted list of unique collaborators (by WordPress user ID), ordered
+ * by the time they entered the room.
+ *
+ * The earliest `enteredAt` value for each user is used so that multiple tabs
+ * for the same user share a single, stable "join time".
  *
  * @param awareness - The Yjs awareness instance.
- * @return Number of other unique users, or -1 when the local user is not identifiable yet.
+ * @return Array of user descriptors sorted by enter time.
  */
-function countOtherUsers( awareness: Awareness ): number {
-	const localUserId = awareness.getLocalState()?.collaboratorInfo?.id;
-	if ( typeof localUserId !== 'number' ) {
-		return -1;
-	}
+function getSortedCollaborators(
+	awareness: Awareness
+): Array< { id: number; enteredAt: number } > {
+	const byId = new Map< number, number >();
 
-	const ids = new Set< number >();
 	for ( const [ , state ] of awareness.getStates() ) {
-		const uid = state?.collaboratorInfo?.id;
-		if ( typeof uid === 'number' && uid !== localUserId ) {
-			ids.add( uid );
+		const info = state?.collaboratorInfo as { id?: unknown; enteredAt?: unknown } | undefined;
+		const id = info?.id;
+		const enteredAt = info?.enteredAt;
+		if ( typeof id !== 'number' || typeof enteredAt !== 'number' ) {
+			continue;
+		}
+		const prev = byId.get( id );
+		if ( prev === undefined || enteredAt < prev ) {
+			byId.set( id, enteredAt );
 		}
 	}
-	return ids.size;
+
+	return Array.from( byId.entries() )
+		.map( ( [ id, enteredAt ] ) => ( { id, enteredAt } ) )
+		.sort( ( a, b ) => {
+			if ( a.enteredAt !== b.enteredAt ) {
+				return a.enteredAt - b.enteredAt;
+			}
+			return a.id - b.id;
+		} );
 }
 
 /**
- * Count other connected clients (tabs) for the local WordPress user.
+ * Build a sorted list of clients (tabs) for the local WordPress user, ordered
+ * by when they entered the room (earliest enteredAt per clientId).
  *
- * @param awareness - The Yjs awareness instance.
- * @return Number of additional local-user clients, or -1 when the local user/client is not identifiable yet.
+ * @param awareness   - The Yjs awareness instance.
+ * @param localUserId - The WordPress user ID to filter by.
+ * @return Array of client descriptors sorted by enter time.
  */
-function countOtherClientsForLocalUser( awareness: Awareness ): number {
-	const localUserId = awareness.getLocalState()?.collaboratorInfo?.id;
-	const localClientId = ( awareness as Awareness & { clientID?: unknown } ).clientID;
-	if ( typeof localUserId !== 'number' || typeof localClientId !== 'number' ) {
-		return -1;
-	}
+function getSortedClientsForLocalUser(
+	awareness: Awareness,
+	localUserId: number
+): Array< { clientId: number; enteredAt: number } > {
+	const byClientId = new Map< number, number >();
 
-	let count = 0;
 	for ( const [ clientId, state ] of awareness.getStates() ) {
-		const uid = state?.collaboratorInfo?.id;
-		if ( typeof uid === 'number' && uid === localUserId && clientId !== localClientId ) {
-			count++;
+		const info = state?.collaboratorInfo as { id?: unknown; enteredAt?: unknown } | undefined;
+		if ( info?.id !== localUserId || typeof info?.enteredAt !== 'number' ) {
+			continue;
+		}
+		const enteredAt = info.enteredAt as number;
+		const prev = byClientId.get( clientId );
+		if ( prev === undefined || enteredAt < prev ) {
+			byClientId.set( clientId, enteredAt );
 		}
 	}
-	return count;
+
+	return Array.from( byClientId.entries() )
+		.map( ( [ clientId, enteredAt ] ) => ( { clientId, enteredAt } ) )
+		.sort( ( a, b ) => {
+			if ( a.enteredAt !== b.enteredAt ) {
+				return a.enteredAt - b.enteredAt;
+			}
+			return a.clientId - b.clientId;
+		} );
 }
 
 /**
  * Wraps a provider creator to enforce a per-room user limit.
  *
- * On every awareness change the wrapper counts unique WordPress user IDs
- * (via `collaboratorInfo.id`) excluding the local user. When the count
- * reaches the given limit every provider created through `withRoomLimit`
- * is destroyed, which causes the shared polling manager to stop entirely.
+ * Collaborators are ordered by `enteredAt`. When the total number of unique
+ * users (or clients for the same user) exceeds the allowed maximum, only the
+ * current client is considered "overflow" if it is among the newest (by enteredAt).
+ * In that case all wrapped providers in this window are destroyed.
  *
  * @param creator           - The provider creator to wrap.
  * @param maxPeersPerRoom   - Max other unique users allowed. Undefined or <= 0 disables peer enforcement.
@@ -86,9 +116,6 @@ export function withRoomLimit(
 		return creator;
 	}
 
-	const peerLimit = maxPeersPerRoom ?? 0;
-	const clientLimit = maxClientsPerUser ?? 0;
-
 	return async ( options ): Promise< ProviderCreatorResult > => {
 		if ( breached ) {
 			return NOOP_RESULT;
@@ -97,6 +124,15 @@ export function withRoomLimit(
 		const { awareness } = options;
 		const innerProvider = await creator( options );
 		let destroyed = false;
+
+		/** Trigger a global teardown for all wrapped providers in this window. */
+		function destroyAll(): void {
+			breached = true;
+			for ( const fn of teardowns ) {
+				fn();
+			}
+			teardowns.length = 0;
+		}
 
 		/** Tear down this single provider and detach the awareness listener. */
 		function destroy(): void {
@@ -108,22 +144,42 @@ export function withRoomLimit(
 			innerProvider.destroy();
 		}
 
-		/** React to awareness changes and trigger a global teardown when the limit is reached. */
+		/** React to awareness changes; trigger global teardown only when this client is in the overflow. */
 		function onAwarenessChange(): void {
 			if ( destroyed || ! awareness ) {
 				return;
 			}
 
-			const otherUsers = countOtherUsers( awareness );
-			const otherLocalUserClients = countOtherClientsForLocalUser( awareness );
-			const isPeerLimitReached = hasPeerLimit && otherUsers >= peerLimit;
-			const isClientLimitReached = hasClientLimit && otherLocalUserClients >= clientLimit;
-			if ( isPeerLimitReached || isClientLimitReached ) {
-				breached = true;
-				for ( const fn of teardowns ) {
-					fn();
+			const localUserId = awareness.getLocalState()?.collaboratorInfo?.id;
+			if ( typeof localUserId !== 'number' ) {
+				return;
+			}
+
+			// Peer limit: too many unique users; only newest users (by enteredAt) are overflow.
+			if ( hasPeerLimit ) {
+				const collaborators = getSortedCollaborators( awareness );
+				if ( collaborators.length > maxPeersPerRoom ) {
+					const overflow = collaborators.slice( maxPeersPerRoom );
+					if ( overflow.some( user => user.id === localUserId ) ) {
+						destroyAll();
+						return;
+					}
 				}
-				teardowns.length = 0;
+			}
+
+			// Client limit: too many tabs for this user; only newest clients (by enteredAt) are overflow.
+			if ( hasClientLimit ) {
+				const localClientId = ( awareness as Awareness & { clientID?: unknown } ).clientID;
+				if ( typeof localClientId !== 'number' ) {
+					return;
+				}
+				const clientsForUser = getSortedClientsForLocalUser( awareness, localUserId );
+				if ( clientsForUser.length > maxClientsPerUser ) {
+					const overflow = clientsForUser.slice( maxClientsPerUser );
+					if ( overflow.some( c => c.clientId === localClientId ) ) {
+						destroyAll();
+					}
+				}
 			}
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/room-limit.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/room-limit.ts
@@ -1,15 +1,54 @@
 import type { ProviderCreator, ProviderCreatorResult } from '@wordpress/sync';
+import type { Awareness } from 'y-protocols/awareness';
+
+/*
+ * Module-level state shared across all `withRoomLimit` wrappers.
+ *
+ * The polling manager in `@wordpress/sync` is a singleton that sends a single
+ * HTTP request for every registered room. To fully stop polling when the
+ * room limit is reached we must destroy *all* wrapped providers — entity
+ * rooms AND collection rooms — in one shot.
+ */
+let breached = false;
+const teardowns: Array< () => void > = [];
+
+const NOOP_RESULT: ProviderCreatorResult = {
+	destroy: () => {},
+	on: () => {},
+};
+
+/**
+ * Count unique WordPress user IDs in the room, excluding the local user.
+ *
+ * @param awareness - The Yjs awareness instance.
+ * @return Number of other unique users, or -1 when the local user is not identifiable yet.
+ */
+function countOtherUsers( awareness: Awareness ): number {
+	const localUserId = awareness.getLocalState()?.collaboratorInfo?.id;
+	if ( typeof localUserId !== 'number' ) {
+		return -1;
+	}
+
+	const ids = new Set< number >();
+	for ( const [ , state ] of awareness.getStates() ) {
+		const uid = state?.collaboratorInfo?.id;
+		if ( typeof uid === 'number' && uid !== localUserId ) {
+			ids.add( uid );
+		}
+	}
+	return ids.size;
+}
 
 /**
  * Wraps a provider creator to enforce a per-room user limit.
  *
  * On every awareness change the wrapper counts unique WordPress user IDs
- * (from `collaboratorInfo.id`) excluding the local user. When the count
- * reaches the given limit the inner provider is destroyed.
- * When `roomUserLimit` is undefined or ≤ 0 the limit is not enforced.
+ * (via `collaboratorInfo.id`) excluding the local user. When the count
+ * reaches the given limit every provider created through `withRoomLimit`
+ * is destroyed, which causes the shared polling manager to stop entirely.
  *
  * @param creator       - The provider creator to wrap.
- * @param roomUserLimit - Max other unique users before disabling.
+ * @param roomUserLimit - Max other unique users allowed. Undefined or ≤ 0 disables enforcement.
  * @return Wrapped provider creator.
  */
 export function withRoomLimit( creator: ProviderCreator, roomUserLimit?: number ): ProviderCreator {
@@ -20,51 +59,54 @@ export function withRoomLimit( creator: ProviderCreator, roomUserLimit?: number 
 	const limit = roomUserLimit;
 
 	return async ( options ): Promise< ProviderCreatorResult > => {
+		if ( breached ) {
+			return NOOP_RESULT;
+		}
+
 		const { awareness } = options;
 		const innerProvider = await creator( options );
-		let isDestroyed = false;
+		let destroyed = false;
 
-		/** Check awareness states and destroy the provider when the limit is reached. */
-		function checkRoomLimit(): void {
-			if ( isDestroyed || ! awareness ) {
+		/** Tear down this single provider and detach the awareness listener. */
+		function destroy(): void {
+			if ( destroyed ) {
+				return;
+			}
+			destroyed = true;
+			awareness?.off( 'change', onAwarenessChange );
+			innerProvider.destroy();
+		}
+
+		/** React to awareness changes and trigger a global teardown when the limit is reached. */
+		function onAwarenessChange(): void {
+			if ( destroyed || ! awareness ) {
 				return;
 			}
 
-			const localState = awareness.getLocalState();
-			const localUserId = localState?.collaboratorInfo?.id;
-			if ( typeof localUserId !== 'number' ) {
-				return;
-			}
-
-			const states = awareness.getStates();
-			const otherUserIds = new Set< number >();
-
-			for ( const [ , state ] of states ) {
-				const userId = state?.collaboratorInfo?.id;
-				if ( typeof userId === 'number' && userId !== localUserId ) {
-					otherUserIds.add( userId );
+			const others = countOtherUsers( awareness );
+			if ( others >= 0 && others >= limit ) {
+				breached = true;
+				for ( const fn of teardowns ) {
+					fn();
 				}
-			}
-
-			if ( otherUserIds.size >= limit ) {
-				isDestroyed = true;
-				awareness.off( 'change', checkRoomLimit );
-				innerProvider.destroy();
+				teardowns.length = 0;
 			}
 		}
 
+		teardowns.push( destroy );
+
 		if ( awareness ) {
-			awareness.on( 'change', checkRoomLimit );
-			checkRoomLimit();
+			awareness.on( 'change', onAwarenessChange );
+			onAwarenessChange();
 		}
 
 		return {
 			destroy: () => {
-				if ( ! isDestroyed ) {
-					isDestroyed = true;
-					awareness?.off( 'change', checkRoomLimit );
-					innerProvider.destroy();
+				const idx = teardowns.indexOf( destroy );
+				if ( idx >= 0 ) {
+					teardowns.splice( idx, 1 );
 				}
+				destroy();
 			},
 			on: innerProvider.on.bind( innerProvider ),
 		};

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
@@ -328,4 +328,77 @@ class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
 
 		$this->assertSame( array(), $wp_settings_fields );
 	}
+
+	/**
+	 * Tests that the script is always enqueued, even when RTC is disabled.
+	 */
+	public function test_wpcom_enqueue_gutenberg_rtc_assets_always_enqueues() {
+		wpcom_enqueue_gutenberg_rtc_assets();
+
+		$this->assertTrue( wp_script_is( 'jetpack-mu-wpcom-gutenberg-rtc', 'enqueued' ) );
+	}
+
+	/**
+	 * Retrieve the inline script attached before the gutenberg-rtc handle.
+	 *
+	 * @return string The concatenated inline script content.
+	 */
+	private function get_inline_script(): string {
+		global $wp_scripts;
+		$extra = $wp_scripts->registered['jetpack-mu-wpcom-gutenberg-rtc']->extra['before'] ?? array();
+		return implode( "\n", array_filter( $extra ) );
+	}
+
+	/**
+	 * Tests that the inline script data includes roomUserLimit.
+	 */
+	public function test_wpcom_enqueue_gutenberg_rtc_assets_includes_room_user_limit() {
+		wpcom_enqueue_gutenberg_rtc_assets();
+
+		$inline = $this->get_inline_script();
+
+		$this->assertStringContainsString( 'wpcomGutenbergRTC', $inline );
+		$this->assertStringContainsString( '"roomUserLimit":', $inline );
+	}
+
+	/**
+	 * Tests that the inline script data includes providers array.
+	 */
+	public function test_wpcom_enqueue_gutenberg_rtc_assets_includes_providers() {
+		wpcom_enqueue_gutenberg_rtc_assets();
+
+		$inline = $this->get_inline_script();
+
+		$this->assertStringContainsString( '"providers":', $inline );
+	}
+
+	/**
+	 * Tests that the inline script data contains the correct providers when RTC is enabled.
+	 */
+	public function test_wpcom_enqueue_gutenberg_rtc_assets_inline_data_matches_providers() {
+		add_filter( 'wpcom_is_gutenberg_rtc_enabled', '__return_true' );
+		add_filter(
+			'wpcom_gutenberg_rtc_providers',
+			function () {
+				return array( 'pinghub' );
+			}
+		);
+
+		wpcom_enqueue_gutenberg_rtc_assets();
+
+		$inline = $this->get_inline_script();
+
+		$this->assertStringContainsString( '"providers":["pinghub"]', $inline );
+	}
+
+	/**
+	 * Tests that the inline script data contains an empty providers array when RTC is disabled.
+	 */
+	public function test_wpcom_enqueue_gutenberg_rtc_assets_inline_data_empty_providers_when_disabled() {
+		wpcom_enqueue_gutenberg_rtc_assets();
+
+		$inline = $this->get_inline_script();
+
+		$this->assertStringContainsString( '"providers":[]', $inline );
+	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
@@ -350,7 +350,7 @@ class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that the inline script data includes roomUserLimit.
+	 * Tests that the inline script data includes maxPeersPerRoom.
 	 */
 	public function test_wpcom_enqueue_gutenberg_rtc_assets_includes_room_user_limit() {
 		wpcom_enqueue_gutenberg_rtc_assets();
@@ -358,7 +358,7 @@ class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
 		$inline = $this->get_inline_script();
 
 		$this->assertStringContainsString( 'wpcomGutenbergRTC', $inline );
-		$this->assertStringContainsString( '"roomUserLimit":', $inline );
+		$this->assertStringContainsString( '"maxPeersPerRoom":', $inline );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
@@ -19,6 +19,8 @@ use PHPUnit\Framework\Attributes\CoversFunction;
  * @covers ::wpcom_disable_rtc_option
  * @covers ::wpcom_enqueue_gutenberg_rtc_assets
  * @covers ::wpcom_get_gutenberg_rtc_providers
+ * @covers ::wpcom_get_gutenberg_rtc_max_clients_per_user
+ * @covers ::wpcom_get_gutenberg_rtc_max_peers_per_room
  * @covers ::wpcom_is_gutenberg_rtc_enabled
  * @covers ::wpcom_unregister_rtc_setting
  */
@@ -27,6 +29,8 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 #[CoversFunction( 'wpcom_enqueue_gutenberg_rtc_assets' )]
 #[CoversFunction( 'wpcom_unregister_rtc_setting' )]
 #[CoversFunction( 'wpcom_disable_rtc_option' )]
+#[CoversFunction( 'wpcom_get_gutenberg_rtc_max_peers_per_room' )]
+#[CoversFunction( 'wpcom_get_gutenberg_rtc_max_clients_per_user' )]
 class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
 
 	/**
@@ -71,6 +75,8 @@ class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
 		$wp_styles          = $this->original_wp_styles; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		remove_all_filters( 'wpcom_is_gutenberg_rtc_enabled' );
 		remove_all_filters( 'wpcom_gutenberg_rtc_providers' );
+		remove_all_filters( 'wpcom_gutenberg_rtc_max_peers_per_room' );
+		remove_all_filters( 'wpcom_gutenberg_rtc_max_clients_per_user' );
 		parent::tear_down();
 	}
 
@@ -359,6 +365,42 @@ class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
 
 		$this->assertStringContainsString( 'wpcomGutenbergRTC', $inline );
 		$this->assertStringContainsString( '"maxPeersPerRoom":', $inline );
+	}
+
+	/**
+	 * Tests that the inline script data includes maxClientsPerUser.
+	 */
+	public function test_wpcom_enqueue_gutenberg_rtc_assets_includes_max_clients_per_user() {
+		wpcom_enqueue_gutenberg_rtc_assets();
+
+		$inline = $this->get_inline_script();
+
+		$this->assertStringContainsString( '"maxClientsPerUser":', $inline );
+	}
+
+	/**
+	 * Tests that max peer and client limits are filterable.
+	 */
+	public function test_wpcom_enqueue_gutenberg_rtc_assets_uses_filtered_limits() {
+		add_filter(
+			'wpcom_gutenberg_rtc_max_peers_per_room',
+			function () {
+				return 4;
+			}
+		);
+		add_filter(
+			'wpcom_gutenberg_rtc_max_clients_per_user',
+			function () {
+				return 3;
+			}
+		);
+
+		wpcom_enqueue_gutenberg_rtc_assets();
+
+		$inline = $this->get_inline_script();
+
+		$this->assertStringContainsString( '"maxPeersPerRoom":4', $inline );
+		$this->assertStringContainsString( '"maxClientsPerUser":3', $inline );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
@@ -220,23 +220,6 @@ class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that enqueue skips when http-polling is the only provider.
-	 */
-	public function test_wpcom_enqueue_gutenberg_rtc_assets_skips_http_polling_only() {
-		add_filter( 'wpcom_is_gutenberg_rtc_enabled', '__return_true' );
-		add_filter(
-			'wpcom_gutenberg_rtc_providers',
-			function () {
-				return array( 'http-polling' );
-			}
-		);
-
-		wpcom_enqueue_gutenberg_rtc_assets();
-
-		$this->assertFalse( wp_script_is( 'jetpack-mu-wpcom-gutenberg-rtc', 'enqueued' ) );
-	}
-
-	/**
 	 * Tests that the script is enqueued when pinghub provider is active.
 	 */
 	public function test_wpcom_enqueue_gutenberg_rtc_assets_enqueues_when_pinghub() {


### PR DESCRIPTION
Fixes DOTCOM-16307

## Proposed changes

* Add client-side room user limit enforcement to Gutenberg RTC. When the number of other unique WordPress users (by `collaboratorInfo.id`) in a sync room reaches the configured limit, all sync providers (HTTP polling and PingHub) are destroyed, fully stopping poll traffic.
* The limit value (`roomUserLimit`) is defined in PHP and passed to JS via the inline `wpcomGutenbergRTC` config object, currently hardcoded to 2.
* The `gutenberg-rtc` JS asset is now always enqueued (the early return that skipped it for HTTP-polling-only setups is removed), so the room limit wrapper can intercept the default polling provider.

### How it works

1. **`room-limit.ts`** — a `withRoomLimit` higher-order function wraps any `ProviderCreator`. On every Yjs awareness change it counts unique WordPress user IDs (excluding the local user). When the count reaches the limit it destroys *all* wrapped providers globally — entity rooms and collection rooms — so the shared `@wordpress/sync` polling manager stops entirely.
2. **`gutenberg-rtc.ts`** — the `sync.providers` filter callback now receives the default providers array, extracts Gutenberg's built-in HTTP polling creator from it, and wraps both it and the PingHub creator with `withRoomLimit`.
3. **`gutenberg-rtc.php`** — always enqueues the JS asset and passes `roomUserLimit => 2` in the inline config.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* DOTCOM-16307

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Open a post for editing with real-time collaboration enabled. You can force `wpcom_get_gutenberg_rtc_providers` to return `array('http-pooling')`.

### Room limits
* Open the same post in two other browser sessions (different users or incognito with different accounts) so that three distinct WordPress users are editing simultaneously.
* Open the Network tab in DevTools on the third user's browser.
* Verify that after the third user's awareness state is received, requests to `/wp-json/wp-sync/v1/updates` stop completely for that user (no more polling).
* Verify the first two users continue to collaborate normally.
* Reload the page on the third user's browser and verify that the limit is re-evaluated.

### Client id limits
* Client id limits have also been added / defaulting to 2
* To test this open the same post with a user in 3 different tabs
* In the third tab the provider should disconnect.