### PR TITLE
Newsletter: Fix punctuation and casing on settings screen

### DIFF
--- a/projects/packages/newsletter/changelog/fix-newsletter-toggle-label-punctuation
+++ b/projects/packages/newsletter/changelog/fix-newsletter-toggle-label-punctuation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Fix inconsistent punctuation and casing on settings screen labels

--- a/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
@@ -205,7 +205,7 @@ export function NewsletterCategoriesSection( {
 									'edit-tags.php?taxonomy=category&referer=newsletter-categories'
 								) }
 							>
-								{ __( 'Add New Category', 'jetpack-newsletter' ) }
+								{ __( 'Add new category', 'jetpack-newsletter' ) }
 							</ExternalLink>
 						</p>
 					) }

--- a/projects/packages/newsletter/src/settings/sections/paid-newsletter-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/paid-newsletter-section.tsx
@@ -49,8 +49,8 @@ export function PaidNewsletterSection( {
 	}
 
 	// Button text based on whether they have an active plan
-	const addPlansText = __( 'Add Plans', 'jetpack-newsletter' );
-	const managePlansText = __( 'Manage Plans', 'jetpack-newsletter' );
+	const addPlansText = __( 'Add plans', 'jetpack-newsletter' );
+	const managePlansText = __( 'Manage plans', 'jetpack-newsletter' );
 	const buttonText = hasActivePlan ? managePlansText : addPlansText;
 
 	return (

--- a/projects/packages/newsletter/src/settings/sections/subscriptions-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/subscriptions-section.tsx
@@ -78,7 +78,7 @@ export function SubscriptionsSection( {
 	const fields: Field< NewsletterSettings >[] = [
 		{
 			id: 'jetpack_subscriptions_subscribe_post_end_enabled',
-			label: __( 'Add the Subscribe Block at the end of each post.', 'jetpack-newsletter' ),
+			label: __( 'Add the Subscribe Block at the end of each post', 'jetpack-newsletter' ),
 			type: 'boolean' as const,
 			Edit: canShowSubscriptionEditorLinks
 				? ( { data: formData, field, onChange: fieldOnChange }: FieldRenderProps ) => (
@@ -96,7 +96,7 @@ export function SubscriptionsSection( {
 		},
 		{
 			id: 'sm_enabled',
-			label: __( 'Show subscription pop-up when scrolling a post.', 'jetpack-newsletter' ),
+			label: __( 'Show subscription pop-up when scrolling a post', 'jetpack-newsletter' ),
 			type: 'boolean' as const,
 			Edit: canShowBlockThemeEditorLinks
 				? ( { data: formData, field, onChange: fieldOnChange }: FieldRenderProps ) => (


### PR DESCRIPTION
Part of DOTCOM-16310

## Proposed changes
* Remove trailing periods from two toggle labels in the Subscriptions section to match WordPress core conventions
* Use sentence case for "Add plans", "Manage plans" buttons and "Add new category" link

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* pdtkmj-4rt-p2#comment-8642

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Go to Jetpack → Newsletter settings screen
* Verify toggle labels "Add the Subscribe Block at the end of each post" and "Show subscription pop-up when scrolling a post" no longer have trailing periods
* In the "Paid newsletter" section, verify the button reads "Add plans" (or "Manage plans") in sentence case
* In the "Newsletter categories" section, enable categories and verify the link reads "Add new category" in sentence case