### PR TITLE
Newsletter: Fix mobile alignment of toggle links on settings screen

### DIFF
--- a/projects/packages/newsletter/changelog/fix-newsletter-mobile-alignment
+++ b/projects/packages/newsletter/changelog/fix-newsletter-mobile-alignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix mobile alignment of Preview and edit links in Subscriptions settings

--- a/projects/packages/newsletter/src/settings/components/toggle-with-link.scss
+++ b/projects/packages/newsletter/src/settings/components/toggle-with-link.scss
@@ -1,5 +1,0 @@
-.toggle-with-link__label {
-	display: inline-flex;
-	align-items: center;
-	gap: 0.5em;
-}

--- a/projects/packages/newsletter/src/settings/components/toggle-with-link.tsx
+++ b/projects/packages/newsletter/src/settings/components/toggle-with-link.tsx
@@ -8,7 +8,6 @@ import { type Field } from '@wordpress/dataviews/wp';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
-import './toggle-with-link.scss';
 
 interface ToggleWithLinkProps {
 	data: Record< string, unknown >;
@@ -52,8 +51,8 @@ export function ToggleWithLink( {
 			checked={ !! data[ field.id ] }
 			onChange={ handleChange }
 			label={
-				<span className="toggle-with-link__label">
-					{ field.label }
+				<span>
+					{ field.label }{ ' ' }
 					{ isExternal ? (
 						<ExternalLink href={ url } onClick={ onLinkClick }>
 							{ linkText }


### PR DESCRIPTION
Part of DOTCOM-16310

## Proposed changes
* Fix mobile alignment of "Preview and edit" links on the Newsletter settings screen
* The toggle labels used `inline-flex` which pushed the links to the far right, disconnected from the label text on narrow screens
* Changed to `inline` display so the links flow naturally after the label text and wrap correctly on mobile

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* pdtkmj-4rt-p2#comment-8642

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Go to Jetpack → Newsletter settings screen
* Resize the browser to a narrow mobile width (~400px)
* Verify the "Preview and edit" links in the Subscriptions section sit right after the toggle label text and wrap naturally, rather than floating to the far right
* Also verify at desktop width the links still appear inline after the label with proper spacing


Before | After
-------|------
 <img width="527" height="808" alt="Screenshot 2026-03-12 at 14 13 20" src="https://github.com/user-attachments/assets/a4e6084c-88d3-4706-9ec2-d8f1609eed54" />| <img width="527" height="808" alt="Screenshot 2026-03-12 at 14 42 11" src="https://github.com/user-attachments/assets/525ca265-1614-4ad9-89b7-9a171bd52aa4" />
