### PR TITLE
MU WPCOM: Restrict dashboard layout to two columns

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-16256-task-12-dashboard-restrict-layout-to-two-columns
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-16256-task-12-dashboard-restrict-layout-to-two-columns
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Dashboard: Restrict layout to two responsive columns for holdout treatment group.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard/class-wpcom-dashboard.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard/class-wpcom-dashboard.php
@@ -23,40 +23,35 @@ class Wpcom_Dashboard {
 	 * Initialize the feature.
 	 */
 	public static function init() {
-		add_filter( 'wpcom_dashboard_replacement_enabled', array( __CLASS__, 'is_feature_flag_enabled' ) );
-		add_filter( 'wpcom_dashboard_replacement_holdout_is_treatment', array( __CLASS__, 'is_holdout_treatment' ) );
-		add_action( 'admin_notices', array( __CLASS__, 'render_admin_notice' ) );
-
 		add_filter( 'screen_layout_columns', array( __CLASS__, 'limit_dashboard_columns' ) );
 		add_filter( 'get_user_option_screen_layout_dashboard', array( __CLASS__, 'cap_dashboard_column_preference' ) );
 		add_filter( 'get_user_option_meta-box-order_dashboard', array( __CLASS__, 'redistribute_meta_box_order' ) );
 	}
 
 	/**
-	 * Feature flag filter callback. Defaults to false.
-	 * Override this filter to true to force-enable for testing.
+	 * Whether the current user is in the holdout treatment group.
 	 *
-	 * @param bool $enabled Whether the feature is enabled.
-	 * @return bool
-	 */
-	public static function is_feature_flag_enabled( $enabled = false ) {
-		return (bool) $enabled;
-	}
-
-	/**
-	 * Check whether the current user is in the holdout treatment group.
-	 *
-	 * On Simple sites, uses \ExPlat\assign_current_user() directly.
-	 * On Atomic sites with a connected user, uses the REST API.
+	 * Checks the ExPlat experiment assignment. On Simple sites, uses
+	 * \ExPlat\assign_current_user() directly. On Atomic sites with a
+	 * connected user, uses the REST API.
 	 * Caches the result in a transient for 1 hour.
 	 *
-	 * @param bool $is_treatment Whether the user is in the treatment group.
+	 * The result can be overridden via the
+	 * {@see 'wpcom_dashboard_override_is_treatment'} filter.
+	 *
 	 * @return bool
 	 */
-	public static function is_holdout_treatment( $is_treatment = false ) {
-		// Respect earlier filter overrides.
-		if ( $is_treatment ) {
-			return true;
+	public static function is_treatment() {
+		/**
+		 * Overrides the holdout experiment assignment.
+		 * Return true to force-enable the treatment for testing.
+		 *
+		 * @param bool|null $override Return a bool to override, or null to use the experiment value.
+		 */
+		$override = apply_filters( 'wpcom_dashboard_override_is_treatment', null );
+
+		if ( null !== $override ) {
+			return (bool) $override;
 		}
 
 		$user_id = get_current_user_id();
@@ -95,73 +90,6 @@ class Wpcom_Dashboard {
 		set_transient( $cache_key, $result ? 1 : 0, HOUR_IN_SECONDS );
 
 		return $result;
-	}
-
-	/**
-	 * Whether the dashboard replacement is active.
-	 *
-	 * Returns true if the feature flag is enabled OR the holdout experiment
-	 * assigns the user to the treatment group.
-	 *
-	 * @return bool
-	 */
-	public static function is_active() {
-		/** This filter is documented in class-wpcom-dashboard.php */
-		$feature_flag = apply_filters( 'wpcom_dashboard_replacement_enabled', false );
-
-		if ( $feature_flag ) {
-			return true;
-		}
-
-		/** This filter is documented in class-wpcom-dashboard.php */
-		return (bool) apply_filters( 'wpcom_dashboard_replacement_holdout_is_treatment', false );
-	}
-
-	/**
-	 * Render an admin notice on the Dashboard page showing the current state.
-	 * Temporary dev aid — remove before shipping.
-	 */
-	public static function render_admin_notice() {
-		if ( ! self::is_active() ) {
-			return;
-		}
-
-		$screen = get_current_screen();
-		if ( ! $screen || 'dashboard' !== $screen->id ) {
-			return;
-		}
-
-		/** This filter is documented in class-wpcom-dashboard.php */
-		$is_treatment = (bool) apply_filters( 'wpcom_dashboard_replacement_holdout_is_treatment', false );
-
-		$status = $is_treatment ? 'active/treatment' : 'active/control';
-		$type   = $is_treatment ? 'success' : 'info';
-
-		printf(
-			'<div class="notice notice-%s"><p>%s</p></div>',
-			esc_attr( $type ),
-			esc_html(
-				sprintf(
-					/* translators: %s is "active/treatment" or "active/control". */
-					__( 'Dashboard replacement: %s', 'jetpack-mu-wpcom' ),
-					$status
-				)
-			)
-		);
-	}
-
-	/**
-	 * Whether the current user is in the treatment group.
-	 *
-	 * Unlike is_active(), this returns false for control-group users even
-	 * when the feature flag is on, so that only treatment users receive
-	 * the actual dashboard changes.
-	 *
-	 * @return bool
-	 */
-	public static function is_treatment() {
-		/** This filter is documented in class-wpcom-dashboard.php */
-		return (bool) apply_filters( 'wpcom_dashboard_replacement_holdout_is_treatment', false );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard/class-wpcom-dashboard.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard/class-wpcom-dashboard.php
@@ -26,7 +26,7 @@ class Wpcom_Dashboard {
 		add_filter( 'screen_layout_columns', array( __CLASS__, 'limit_dashboard_columns' ) );
 		add_filter( 'get_user_option_screen_layout_dashboard', array( __CLASS__, 'cap_dashboard_column_preference' ) );
 		add_filter( 'get_user_option_meta-box-order_dashboard', array( __CLASS__, 'redistribute_meta_box_order' ) );
-		add_action( 'admin_head-index.php', array( __CLASS__, 'render_dashboard_styles' ) );
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_dashboard_styles' ) );
 	}
 
 	/**
@@ -94,46 +94,21 @@ class Wpcom_Dashboard {
 	}
 
 	/**
-	 * Output responsive dashboard column styles.
+	 * Enqueue responsive dashboard column styles on the Dashboard screen.
 	 *
-	 * Overrides the default equal-width float layout with flexbox so that
-	 * the primary column is roughly 2x the sidebar column, both columns
-	 * have a 350px minimum, and the sidebar wraps below when space is tight.
+	 * @param string $hook_suffix The current admin page hook suffix.
 	 */
-	public static function render_dashboard_styles() {
-		if ( ! self::is_treatment() ) {
+	public static function enqueue_dashboard_styles( $hook_suffix ) {
+		if ( 'index.php' !== $hook_suffix || ! self::is_treatment() ) {
 			return;
 		}
-		?>
-		<style>
-			#dashboard-widgets.columns-2 {
-				display: flex;
-				flex-wrap: wrap;
-				max-width: 1200px;
-				margin: 0 auto;
-			}
 
-			#dashboard-widgets.columns-2 #postbox-container-1,
-			#dashboard-widgets.columns-2 #postbox-container-2 {
-				float: none;
-				width: auto;
-				min-width: 350px;
-			}
-
-			#dashboard-widgets.columns-2 #postbox-container-1 {
-				flex: 2 1 350px;
-			}
-
-			#dashboard-widgets.columns-2 #postbox-container-2 {
-				flex: 0 1 350px;
-			}
-
-			#dashboard-widgets.columns-2 #postbox-container-3,
-			#dashboard-widgets.columns-2 #postbox-container-4 {
-				display: none;
-			}
-		</style>
-		<?php
+		wp_enqueue_style(
+			'wpcom-dashboard-styles',
+			plugins_url( 'wpcom-dashboard.css', __FILE__ ),
+			array(),
+			\Automattic\Jetpack\Jetpack_Mu_Wpcom::PACKAGE_VERSION
+		);
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard/class-wpcom-dashboard.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard/class-wpcom-dashboard.php
@@ -26,6 +26,10 @@ class Wpcom_Dashboard {
 		add_filter( 'wpcom_dashboard_replacement_enabled', array( __CLASS__, 'is_feature_flag_enabled' ) );
 		add_filter( 'wpcom_dashboard_replacement_holdout_is_treatment', array( __CLASS__, 'is_holdout_treatment' ) );
 		add_action( 'admin_notices', array( __CLASS__, 'render_admin_notice' ) );
+
+		add_filter( 'screen_layout_columns', array( __CLASS__, 'limit_dashboard_columns' ) );
+		add_filter( 'get_user_option_screen_layout_dashboard', array( __CLASS__, 'cap_dashboard_column_preference' ) );
+		add_filter( 'get_user_option_meta-box-order_dashboard', array( __CLASS__, 'redistribute_meta_box_order' ) );
 	}
 
 	/**
@@ -144,5 +148,104 @@ class Wpcom_Dashboard {
 				)
 			)
 		);
+	}
+
+	/**
+	 * Whether the current user is in the treatment group.
+	 *
+	 * Unlike is_active(), this returns false for control-group users even
+	 * when the feature flag is on, so that only treatment users receive
+	 * the actual dashboard changes.
+	 *
+	 * @return bool
+	 */
+	public static function is_treatment() {
+		/** This filter is documented in class-wpcom-dashboard.php */
+		return (bool) apply_filters( 'wpcom_dashboard_replacement_holdout_is_treatment', false );
+	}
+
+	/**
+	 * Limit the dashboard screen to a maximum of 2 columns.
+	 *
+	 * @param array $columns Screen layout columns keyed by screen ID.
+	 * @return array
+	 */
+	public static function limit_dashboard_columns( $columns ) {
+		if ( ! self::is_treatment() ) {
+			return $columns;
+		}
+
+		$columns['dashboard'] = 2;
+
+		return $columns;
+	}
+
+	/**
+	 * Cap the user's saved dashboard column preference to 2.
+	 *
+	 * @param int|false $value The user's saved column count, or false if not set.
+	 * @return int|false
+	 */
+	public static function cap_dashboard_column_preference( $value ) {
+		if ( ! self::is_treatment() ) {
+			return $value;
+		}
+
+		if ( false !== $value && (int) $value > 2 ) {
+			return 2;
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Move widgets from columns 3 and 4 into columns 1 and 2.
+	 *
+	 * WordPress stores the dashboard meta box order as an array with keys:
+	 * 'normal' (column 1), 'side' (column 2), 'column3', 'column4'.
+	 *
+	 * @param array|false $order The saved meta box order, or false if not set.
+	 * @return array|false
+	 */
+	public static function redistribute_meta_box_order( $order ) {
+		if ( ! self::is_treatment() || ! is_array( $order ) ) {
+			return $order;
+		}
+
+		// Append column3 widgets to normal (column 1).
+		if ( ! empty( $order['column3'] ) ) {
+			$order['normal']  = self::merge_widget_lists( $order['normal'] ?? '', $order['column3'] );
+			$order['column3'] = '';
+		}
+
+		// Append column4 widgets to side (column 2).
+		if ( ! empty( $order['column4'] ) ) {
+			$order['side']    = self::merge_widget_lists( $order['side'] ?? '', $order['column4'] );
+			$order['column4'] = '';
+		}
+
+		return $order;
+	}
+
+	/**
+	 * Merge two comma-separated widget ID lists.
+	 *
+	 * @param string $target Existing comma-separated list.
+	 * @param string $source List to append.
+	 * @return string
+	 */
+	private static function merge_widget_lists( $target, $source ) {
+		$target = trim( $target, ',' );
+		$source = trim( $source, ',' );
+
+		if ( '' === $target ) {
+			return $source;
+		}
+
+		if ( '' === $source ) {
+			return $target;
+		}
+
+		return $target . ',' . $source;
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard/class-wpcom-dashboard.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard/class-wpcom-dashboard.php
@@ -26,6 +26,7 @@ class Wpcom_Dashboard {
 		add_filter( 'screen_layout_columns', array( __CLASS__, 'limit_dashboard_columns' ) );
 		add_filter( 'get_user_option_screen_layout_dashboard', array( __CLASS__, 'cap_dashboard_column_preference' ) );
 		add_filter( 'get_user_option_meta-box-order_dashboard', array( __CLASS__, 'redistribute_meta_box_order' ) );
+		add_action( 'admin_head-index.php', array( __CLASS__, 'render_dashboard_styles' ) );
 	}
 
 	/**
@@ -90,6 +91,49 @@ class Wpcom_Dashboard {
 		set_transient( $cache_key, $result ? 1 : 0, HOUR_IN_SECONDS );
 
 		return $result;
+	}
+
+	/**
+	 * Output responsive dashboard column styles.
+	 *
+	 * Overrides the default equal-width float layout with flexbox so that
+	 * the primary column is roughly 2x the sidebar column, both columns
+	 * have a 350px minimum, and the sidebar wraps below when space is tight.
+	 */
+	public static function render_dashboard_styles() {
+		if ( ! self::is_treatment() ) {
+			return;
+		}
+		?>
+		<style>
+			#dashboard-widgets.columns-2 {
+				display: flex;
+				flex-wrap: wrap;
+				max-width: 1200px;
+				margin: 0 auto;
+			}
+
+			#dashboard-widgets.columns-2 #postbox-container-1,
+			#dashboard-widgets.columns-2 #postbox-container-2 {
+				float: none;
+				width: auto;
+				min-width: 350px;
+			}
+
+			#dashboard-widgets.columns-2 #postbox-container-1 {
+				flex: 2 1 350px;
+			}
+
+			#dashboard-widgets.columns-2 #postbox-container-2 {
+				flex: 0 1 350px;
+			}
+
+			#dashboard-widgets.columns-2 #postbox-container-3,
+			#dashboard-widgets.columns-2 #postbox-container-4 {
+				display: none;
+			}
+		</style>
+		<?php
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard/wpcom-dashboard.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard/wpcom-dashboard.css
@@ -1,0 +1,26 @@
+#dashboard-widgets.columns-2 {
+	display: flex;
+	flex-wrap: wrap;
+	max-width: 1200px;
+	margin: 0 auto;
+}
+
+#dashboard-widgets.columns-2 #postbox-container-1,
+#dashboard-widgets.columns-2 #postbox-container-2 {
+	float: none;
+	width: auto;
+	min-width: 350px;
+}
+
+#dashboard-widgets.columns-2 #postbox-container-1 {
+	flex: 2 1 350px;
+}
+
+#dashboard-widgets.columns-2 #postbox-container-2 {
+	flex: 0 1 350px;
+}
+
+#dashboard-widgets.columns-2 #postbox-container-3,
+#dashboard-widgets.columns-2 #postbox-container-4 {
+	display: none;
+}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-dashboard/Wpcom_Dashboard_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-dashboard/Wpcom_Dashboard_Test.php
@@ -23,8 +23,10 @@ class Wpcom_Dashboard_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
-		remove_all_filters( 'wpcom_dashboard_replacement_enabled' );
-		remove_all_filters( 'wpcom_dashboard_replacement_holdout_is_treatment' );
+		remove_all_filters( 'wpcom_dashboard_override_is_treatment' );
+		remove_all_filters( 'screen_layout_columns' );
+		remove_all_filters( 'get_user_option_screen_layout_dashboard' );
+		remove_all_filters( 'get_user_option_meta-box-order_dashboard' );
 		Wpcom_Dashboard::init();
 	}
 
@@ -32,62 +34,53 @@ class Wpcom_Dashboard_Test extends \WorDBless\BaseTestCase {
 	 * Tear down test fixtures.
 	 */
 	public function tear_down() {
-		remove_all_filters( 'wpcom_dashboard_replacement_enabled' );
-		remove_all_filters( 'wpcom_dashboard_replacement_holdout_is_treatment' );
+		remove_all_filters( 'wpcom_dashboard_override_is_treatment' );
+		remove_all_filters( 'screen_layout_columns' );
+		remove_all_filters( 'get_user_option_screen_layout_dashboard' );
+		remove_all_filters( 'get_user_option_meta-box-order_dashboard' );
 		parent::tear_down();
 	}
 
-	/**
-	 * Test that is_active returns false by default (no feature flag, no experiment).
-	 */
-	public function test_is_active_returns_false_by_default() {
-		$this->assertFalse( Wpcom_Dashboard::is_active() );
-	}
+	// -------------------------------------------------------------------------
+	// is_treatment()
+	// -------------------------------------------------------------------------
 
 	/**
-	 * Test that is_active returns true when the feature flag filter is overridden.
+	 * Test that is_treatment returns false by default.
 	 */
-	public function test_is_active_returns_true_when_feature_flag_enabled() {
-		add_filter( 'wpcom_dashboard_replacement_enabled', '__return_true' );
-		$this->assertTrue( Wpcom_Dashboard::is_active() );
-	}
-
-	/**
-	 * Test that is_active returns true when the holdout filter returns true.
-	 */
-	public function test_is_active_returns_true_when_holdout_is_treatment() {
-		add_filter( 'wpcom_dashboard_replacement_holdout_is_treatment', '__return_true' );
-		$this->assertTrue( Wpcom_Dashboard::is_active() );
-	}
-
-	/**
-	 * Test that is_holdout_treatment returns false when no user is logged in.
-	 */
-	public function test_is_holdout_treatment_returns_false_for_logged_out_user() {
+	public function test_is_treatment_returns_false_by_default() {
 		wp_set_current_user( 0 );
-		$this->assertFalse( Wpcom_Dashboard::is_holdout_treatment() );
+		$this->assertFalse( Wpcom_Dashboard::is_treatment() );
 	}
 
 	/**
-	 * Test that is_holdout_treatment respects an earlier filter that already set it to true.
+	 * Test that is_treatment returns true when the override filter returns true.
 	 */
-	public function test_is_holdout_treatment_respects_earlier_filter_override() {
-		// Register a filter at a lower priority than init()'s default (10)
-		// so it runs first and sets the value to true.
-		add_filter( 'wpcom_dashboard_replacement_holdout_is_treatment', '__return_true', 5 );
+	public function test_is_treatment_returns_true_when_override_filter_is_true() {
+		add_filter( 'wpcom_dashboard_override_is_treatment', '__return_true' );
+		$this->assertTrue( Wpcom_Dashboard::is_treatment() );
+	}
 
-		// When invoked through the filter chain, is_holdout_treatment receives
-		// $is_treatment = true from the earlier filter and should return true
-		// immediately (guard clause), even without a logged-in user.
+	/**
+	 * Test that is_treatment returns false when the override filter returns false.
+	 */
+	public function test_is_treatment_returns_false_when_override_filter_is_false() {
+		add_filter( 'wpcom_dashboard_override_is_treatment', '__return_false' );
+		$this->assertFalse( Wpcom_Dashboard::is_treatment() );
+	}
+
+	/**
+	 * Test that is_treatment returns false for logged-out users when no override is set.
+	 */
+	public function test_is_treatment_returns_false_for_logged_out_user() {
 		wp_set_current_user( 0 );
-		$result = apply_filters( 'wpcom_dashboard_replacement_holdout_is_treatment', false );
-		$this->assertTrue( $result );
+		$this->assertFalse( Wpcom_Dashboard::is_treatment() );
 	}
 
 	/**
-	 * Test that is_holdout_treatment returns the cached transient value.
+	 * Test that is_treatment returns the cached transient value.
 	 */
-	public function test_is_holdout_treatment_returns_cached_value() {
+	public function test_is_treatment_returns_cached_value() {
 		$user_id = wp_insert_user(
 			array(
 				'user_login' => 'test_user_' . wp_rand(),
@@ -101,21 +94,20 @@ class Wpcom_Dashboard_Test extends \WorDBless\BaseTestCase {
 
 		// Seed the transient with a truthy value.
 		set_transient( $cache_key, 1, HOUR_IN_SECONDS );
-		$this->assertTrue( Wpcom_Dashboard::is_holdout_treatment() );
+		$this->assertTrue( Wpcom_Dashboard::is_treatment() );
 
 		// Seed the transient with a falsy value.
 		set_transient( $cache_key, 0, HOUR_IN_SECONDS );
-		$this->assertFalse( Wpcom_Dashboard::is_holdout_treatment() );
+		$this->assertFalse( Wpcom_Dashboard::is_treatment() );
 
-		// Clean up.
 		delete_transient( $cache_key );
 	}
 
 	/**
-	 * Test that is_holdout_treatment caches false for a logged-in user
-	 * who is neither on Simple nor Jetpack-connected (fallthrough path).
+	 * Test that is_treatment caches false for a logged-in user
+	 * who is neither on Simple nor Jetpack-connected.
 	 */
-	public function test_is_holdout_treatment_caches_false_for_unconnected_user() {
+	public function test_is_treatment_caches_false_for_unconnected_user() {
 		$user_id = wp_insert_user(
 			array(
 				'user_login' => 'test_user_' . wp_rand(),
@@ -126,27 +118,183 @@ class Wpcom_Dashboard_Test extends \WorDBless\BaseTestCase {
 		wp_set_current_user( $user_id );
 
 		$cache_key = 'wpcom-dashboard-holdout-' . $user_id . '-' . Wpcom_Dashboard::EXPERIMENT_NAME;
-
-		// Ensure no cached value exists.
 		delete_transient( $cache_key );
 
-		// In the test environment the user is neither on Simple nor connected,
-		// so the method should return false and cache the result.
-		$this->assertFalse( Wpcom_Dashboard::is_holdout_treatment() );
+		$this->assertFalse( Wpcom_Dashboard::is_treatment() );
 		$this->assertSame( '0', (string) get_transient( $cache_key ) );
 
-		// Clean up.
 		delete_transient( $cache_key );
 	}
 
 	/**
-	 * Test that render_admin_notice produces no output when the feature is inactive.
+	 * Test that the override filter bypasses the cache entirely.
 	 */
-	public function test_render_admin_notice_not_shown_when_inactive() {
-		ob_start();
-		Wpcom_Dashboard::render_admin_notice();
-		$output = ob_get_clean();
+	public function test_is_treatment_override_bypasses_cache() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_user_' . wp_rand(),
+				'user_pass'  => 'password',
+				'user_email' => 'test_' . wp_rand() . '@example.com',
+			)
+		);
+		wp_set_current_user( $user_id );
 
-		$this->assertEmpty( $output );
+		$cache_key = 'wpcom-dashboard-holdout-' . $user_id . '-' . Wpcom_Dashboard::EXPERIMENT_NAME;
+		set_transient( $cache_key, 0, HOUR_IN_SECONDS );
+
+		add_filter( 'wpcom_dashboard_override_is_treatment', '__return_true' );
+		$this->assertTrue( Wpcom_Dashboard::is_treatment() );
+
+		delete_transient( $cache_key );
+	}
+
+	// -------------------------------------------------------------------------
+	// limit_dashboard_columns()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test that limit_dashboard_columns sets dashboard to 2 when treatment is active.
+	 */
+	public function test_limit_dashboard_columns_sets_two_when_treatment() {
+		add_filter( 'wpcom_dashboard_override_is_treatment', '__return_true' );
+
+		$columns = Wpcom_Dashboard::limit_dashboard_columns( array( 'dashboard' => 4 ) );
+		$this->assertSame( 2, $columns['dashboard'] );
+	}
+
+	/**
+	 * Test that limit_dashboard_columns preserves existing value when not treatment.
+	 */
+	public function test_limit_dashboard_columns_unchanged_when_not_treatment() {
+		add_filter( 'wpcom_dashboard_override_is_treatment', '__return_false' );
+
+		$columns = Wpcom_Dashboard::limit_dashboard_columns( array( 'dashboard' => 4 ) );
+		$this->assertSame( 4, $columns['dashboard'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// cap_dashboard_column_preference()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test that cap_dashboard_column_preference caps values above 2 when treatment.
+	 */
+	public function test_cap_dashboard_column_preference_caps_above_two() {
+		add_filter( 'wpcom_dashboard_override_is_treatment', '__return_true' );
+
+		$this->assertSame( 2, Wpcom_Dashboard::cap_dashboard_column_preference( 4 ) );
+		$this->assertSame( 2, Wpcom_Dashboard::cap_dashboard_column_preference( 3 ) );
+	}
+
+	/**
+	 * Test that cap_dashboard_column_preference preserves values of 2 or below.
+	 */
+	public function test_cap_dashboard_column_preference_preserves_two_or_below() {
+		add_filter( 'wpcom_dashboard_override_is_treatment', '__return_true' );
+
+		$this->assertSame( 2, Wpcom_Dashboard::cap_dashboard_column_preference( 2 ) );
+		$this->assertSame( 1, Wpcom_Dashboard::cap_dashboard_column_preference( 1 ) );
+	}
+
+	/**
+	 * Test that cap_dashboard_column_preference passes through false (no saved preference).
+	 */
+	public function test_cap_dashboard_column_preference_passes_through_false() {
+		add_filter( 'wpcom_dashboard_override_is_treatment', '__return_true' );
+
+		$this->assertFalse( Wpcom_Dashboard::cap_dashboard_column_preference( false ) );
+	}
+
+	/**
+	 * Test that cap_dashboard_column_preference is a no-op when not treatment.
+	 */
+	public function test_cap_dashboard_column_preference_unchanged_when_not_treatment() {
+		add_filter( 'wpcom_dashboard_override_is_treatment', '__return_false' );
+
+		$this->assertSame( 4, Wpcom_Dashboard::cap_dashboard_column_preference( 4 ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// redistribute_meta_box_order()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test that redistribute_meta_box_order moves column3 widgets to normal.
+	 */
+	public function test_redistribute_moves_column3_to_normal() {
+		add_filter( 'wpcom_dashboard_override_is_treatment', '__return_true' );
+
+		$order  = array(
+			'normal'  => 'widget_a,widget_b',
+			'side'    => 'widget_c',
+			'column3' => 'widget_d',
+			'column4' => '',
+		);
+		$result = Wpcom_Dashboard::redistribute_meta_box_order( $order );
+
+		$this->assertSame( 'widget_a,widget_b,widget_d', $result['normal'] );
+		$this->assertSame( '', $result['column3'] );
+	}
+
+	/**
+	 * Test that redistribute_meta_box_order moves column4 widgets to side.
+	 */
+	public function test_redistribute_moves_column4_to_side() {
+		add_filter( 'wpcom_dashboard_override_is_treatment', '__return_true' );
+
+		$order  = array(
+			'normal'  => 'widget_a',
+			'side'    => 'widget_b',
+			'column3' => '',
+			'column4' => 'widget_e',
+		);
+		$result = Wpcom_Dashboard::redistribute_meta_box_order( $order );
+
+		$this->assertSame( 'widget_b,widget_e', $result['side'] );
+		$this->assertSame( '', $result['column4'] );
+	}
+
+	/**
+	 * Test that redistribute_meta_box_order handles empty normal/side targets.
+	 */
+	public function test_redistribute_handles_empty_targets() {
+		add_filter( 'wpcom_dashboard_override_is_treatment', '__return_true' );
+
+		$order  = array(
+			'normal'  => '',
+			'side'    => '',
+			'column3' => 'widget_a',
+			'column4' => 'widget_b',
+		);
+		$result = Wpcom_Dashboard::redistribute_meta_box_order( $order );
+
+		$this->assertSame( 'widget_a', $result['normal'] );
+		$this->assertSame( 'widget_b', $result['side'] );
+	}
+
+	/**
+	 * Test that redistribute_meta_box_order is a no-op when not treatment.
+	 */
+	public function test_redistribute_unchanged_when_not_treatment() {
+		add_filter( 'wpcom_dashboard_override_is_treatment', '__return_false' );
+
+		$order  = array(
+			'normal'  => 'widget_a',
+			'side'    => 'widget_b',
+			'column3' => 'widget_c',
+			'column4' => 'widget_d',
+		);
+		$result = Wpcom_Dashboard::redistribute_meta_box_order( $order );
+
+		$this->assertSame( $order, $result );
+	}
+
+	/**
+	 * Test that redistribute_meta_box_order passes through false.
+	 */
+	public function test_redistribute_passes_through_false() {
+		add_filter( 'wpcom_dashboard_override_is_treatment', '__return_true' );
+
+		$this->assertFalse( Wpcom_Dashboard::redistribute_meta_box_order( false ) );
 	}
 }


### PR DESCRIPTION
Fixes DOTCOM-16256

- Restricts the WordPress.com dashboard to a two-column layout for users in the holdout treatment group.
- Simplifies the holdout conditionals to a single `is_treatment()` method with a `wpcom_dashboard_override_is_treatment` filter for testing overrides.
- Adds responsive flexbox styles: primary column is ~2x the sidebar (350px fixed), both wrap to single column on narrow viewports.
- Redistributes any widgets from columns 3/4 into columns 1/2 and hides the empty containers.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

- Sync these changes to a Dotcom site.
- Enable treatment via `add_filter( 'wpcom_dashboard_override_is_treatment', '__return_true' );`
- Verify Dashboard shows two columns with the primary column wider than the sidebar.
- Resize the browser and confirm columns wrap to single column when viewport is narrow.
- Verify Screen Options shows max 2 columns.
- [Disable the override filter and confirm the default dashboard layout is unchanged.