### PR TITLE
Newsletter: Add Send newsletter by default toggle to settings

### DIFF
--- a/projects/packages/newsletter/changelog/add-newsletter-send-default-setting
+++ b/projects/packages/newsletter/changelog/add-newsletter-send-default-setting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Add Send newsletter by default toggle to Newsletter settings section.

--- a/projects/packages/newsletter/src/settings/index.tsx
+++ b/projects/packages/newsletter/src/settings/index.tsx
@@ -9,7 +9,7 @@ import {
 	GlobalNotices,
 	useGlobalNotices,
 } from '@automattic/jetpack-components';
-import { getSiteType, isSimpleSite } from '@automattic/jetpack-script-data';
+import { getSiteType } from '@automattic/jetpack-script-data';
 import { Notice, Disabled, Spinner } from '@wordpress/components';
 import { createRoot, useCallback, useEffect, useState, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -391,7 +391,7 @@ function NewsletterSettingsApp(): JSX.Element | null {
 			<Container horizontalSpacing={ 3 }>
 				<Col>
 					<Stack gap="md" direction="column" className="newsletter-settings">
-						{ ! isSimpleSite() && <NewsletterSection data={ data } onChange={ handleAutoSave } /> }
+						<NewsletterSection data={ data } onChange={ handleAutoSave } />
 
 						<Disabled isDisabled={ ! data.subscriptions }>
 							<Stack gap="md" direction="column">

--- a/projects/packages/newsletter/src/settings/sections/email-content-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/email-content-section.tsx
@@ -38,16 +38,6 @@ export function EmailContentSection( {
 	const isSitePublic = getNewsletterScriptData()?.isSitePublic ?? true;
 	const fields: Field< NewsletterSettings >[] = [
 		{
-			id: 'wpcom_newsletter_send_default',
-			label: __( 'Email new posts to subscribers by default', 'jetpack-newsletter' ),
-			type: 'boolean' as const,
-			Edit: 'toggle' as const,
-			description: __(
-				'When on, the newsletter option will be pre-selected each time you publish. You can change it in the newsletter panel in the editor before publishing any post.',
-				'jetpack-newsletter'
-			),
-		},
-		{
 			id: 'wpcom_featured_image_in_email',
 			label: __( "Include the post's featured image in the new post emails", 'jetpack-newsletter' ),
 			type: 'boolean' as const,
@@ -99,11 +89,7 @@ export function EmailContentSection( {
 								type: 'regular',
 								labelPosition: 'top',
 							},
-							fields: [
-								'wpcom_newsletter_send_default',
-								'wpcom_featured_image_in_email',
-								'wpcom_subscription_emails_use_excerpt',
-							],
+							fields: [ 'wpcom_featured_image_in_email', 'wpcom_subscription_emails_use_excerpt' ],
 						} }
 						onChange={ onChange }
 					/>

--- a/projects/packages/newsletter/src/settings/sections/email-content-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/email-content-section.tsx
@@ -38,6 +38,16 @@ export function EmailContentSection( {
 	const isSitePublic = getNewsletterScriptData()?.isSitePublic ?? true;
 	const fields: Field< NewsletterSettings >[] = [
 		{
+			id: 'wpcom_newsletter_send_default',
+			label: __( 'Email new posts to subscribers by default', 'jetpack-newsletter' ),
+			type: 'boolean' as const,
+			Edit: 'toggle' as const,
+			description: __(
+				'When on, the newsletter option will be pre-selected each time you publish. You can change it in the newsletter panel in the editor before publishing any post.',
+				'jetpack-newsletter'
+			),
+		},
+		{
 			id: 'wpcom_featured_image_in_email',
 			label: __( "Include the post's featured image in the new post emails", 'jetpack-newsletter' ),
 			type: 'boolean' as const,
@@ -89,7 +99,11 @@ export function EmailContentSection( {
 								type: 'regular',
 								labelPosition: 'top',
 							},
-							fields: [ 'wpcom_featured_image_in_email', 'wpcom_subscription_emails_use_excerpt' ],
+							fields: [
+								'wpcom_newsletter_send_default',
+								'wpcom_featured_image_in_email',
+								'wpcom_subscription_emails_use_excerpt',
+							],
 						} }
 						onChange={ onChange }
 					/>

--- a/projects/packages/newsletter/src/settings/sections/newsletter-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-section.tsx
@@ -72,6 +72,16 @@ export function NewsletterSection( { data, onChange }: NewsletterSectionProps ):
 			type: 'boolean' as const,
 			Edit: 'toggle' as const,
 		},
+		{
+			id: 'wpcom_newsletter_send_default',
+			label: __( 'Send newsletter by default', 'jetpack-newsletter' ),
+			type: 'boolean' as const,
+			Edit: 'toggle' as const,
+			description: __(
+				'When on, the newsletter option will be pre-selected each time you publish. You can change it before publishing any post.',
+				'jetpack-newsletter'
+			),
+		},
 	];
 
 	return (
@@ -88,7 +98,7 @@ export function NewsletterSection( { data, onChange }: NewsletterSectionProps ):
 							type: 'regular',
 							labelPosition: 'top',
 						},
-						fields: [ 'subscriptions' ],
+						fields: [ 'subscriptions', 'wpcom_newsletter_send_default' ],
 					} }
 					onChange={ handleChange }
 				/>

--- a/projects/packages/newsletter/src/settings/sections/newsletter-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-section.tsx
@@ -10,6 +10,7 @@ import {
 	CardBody,
 	CardFooter,
 	ExternalLink,
+	ToggleControl,
 	__experimentalHeading as Heading, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
 import { DataForm, type Field } from '@wordpress/dataviews/wp';
@@ -80,7 +81,25 @@ export function NewsletterSection( { data, onChange }: NewsletterSectionProps ):
 			id: 'wpcom_newsletter_send_default',
 			label: __( 'Email new posts to subscribers by default', 'jetpack-newsletter' ),
 			type: 'boolean' as const,
-			Edit: 'toggle' as const,
+			Edit( { field, onChange: onChangeField, data: formData } ) {
+				const handleToggle = useCallback( () => {
+					onChangeField(
+						field.setValue( {
+							item: formData,
+							value: ! field.getValue( { item: formData } ),
+						} )
+					);
+				}, [ onChangeField, field, formData ] );
+				return (
+					<ToggleControl
+						label={ field.label }
+						help={ field.description }
+						checked={ !! field.getValue( { item: formData } ) }
+						onChange={ handleToggle }
+						disabled={ ! isSimpleSite() && ! formData.subscriptions }
+					/>
+				);
+			},
 			description: __(
 				'When on, the newsletter option will be pre-selected each time you publish. You can change it in the newsletter panel in the editor before publishing any post.',
 				'jetpack-newsletter'

--- a/projects/packages/newsletter/src/settings/sections/newsletter-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-section.tsx
@@ -3,7 +3,7 @@
  */
 import analytics from '@automattic/jetpack-analytics';
 import { getRedirectUrl } from '@automattic/jetpack-components';
-import { getSiteType } from '@automattic/jetpack-script-data';
+import { getSiteType, isSimpleSite } from '@automattic/jetpack-script-data';
 import {
 	Card,
 	CardHeader,
@@ -63,15 +63,34 @@ export function NewsletterSection( { data, onChange }: NewsletterSectionProps ):
 	}, [ siteType ] );
 
 	const fields: Field< NewsletterSettings >[] = [
+		...( ! isSimpleSite()
+			? [
+					{
+						id: 'subscriptions',
+						label: __(
+							'Let visitors subscribe to this site and receive emails when you publish a post',
+							'jetpack-newsletter'
+						),
+						type: 'boolean' as const,
+						Edit: 'toggle' as const,
+					},
+			  ]
+			: [] ),
 		{
-			id: 'subscriptions',
-			label: __(
-				'Let visitors subscribe to this site and receive emails when you publish a post',
-				'jetpack-newsletter'
-			),
+			id: 'wpcom_newsletter_send_default',
+			label: __( 'Email new posts to subscribers by default', 'jetpack-newsletter' ),
 			type: 'boolean' as const,
 			Edit: 'toggle' as const,
+			description: __(
+				'When on, the newsletter option will be pre-selected each time you publish. You can change it in the newsletter panel in the editor before publishing any post.',
+				'jetpack-newsletter'
+			),
 		},
+	];
+
+	const formFields = [
+		...( ! isSimpleSite() ? [ 'subscriptions' ] : [] ),
+		'wpcom_newsletter_send_default',
 	];
 
 	return (
@@ -88,7 +107,7 @@ export function NewsletterSection( { data, onChange }: NewsletterSectionProps ):
 							type: 'regular',
 							labelPosition: 'top',
 						},
-						fields: [ 'subscriptions' ],
+						fields: formFields,
 					} }
 					onChange={ handleChange }
 				/>

--- a/projects/packages/newsletter/src/settings/sections/newsletter-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-section.tsx
@@ -78,7 +78,7 @@ export function NewsletterSection( { data, onChange }: NewsletterSectionProps ):
 			type: 'boolean' as const,
 			Edit: 'toggle' as const,
 			description: __(
-				'When on, the newsletter option will be pre-selected each time you publish. You can change it before publishing any post.',
+				'When on, the newsletter option will be pre-selected each time you publish. You can change it in the newsletter panel in the editor before publishing any post.',
 				'jetpack-newsletter'
 			),
 		},

--- a/projects/packages/newsletter/src/settings/sections/newsletter-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-section.tsx
@@ -72,16 +72,6 @@ export function NewsletterSection( { data, onChange }: NewsletterSectionProps ):
 			type: 'boolean' as const,
 			Edit: 'toggle' as const,
 		},
-		{
-			id: 'wpcom_newsletter_send_default',
-			label: __( 'Send newsletter by default', 'jetpack-newsletter' ),
-			type: 'boolean' as const,
-			Edit: 'toggle' as const,
-			description: __(
-				'When on, the newsletter option will be pre-selected each time you publish. You can change it in the newsletter panel in the editor before publishing any post.',
-				'jetpack-newsletter'
-			),
-		},
 	];
 
 	return (
@@ -98,7 +88,7 @@ export function NewsletterSection( { data, onChange }: NewsletterSectionProps ):
 							type: 'regular',
 							labelPosition: 'top',
 						},
-						fields: [ 'subscriptions', 'wpcom_newsletter_send_default' ],
+						fields: [ 'subscriptions' ],
 					} }
 					onChange={ handleChange }
 				/>

--- a/projects/packages/newsletter/src/settings/types.ts
+++ b/projects/packages/newsletter/src/settings/types.ts
@@ -22,6 +22,7 @@ export interface NewsletterSettings {
 	jetpack_post_date_in_email: boolean;
 	jetpack_subscriptions_reply_to: 'comment' | 'author' | 'no-reply';
 	jetpack_subscriptions_from_name: string;
+	wpcom_newsletter_send_default: boolean;
 	wpcom_newsletter_categories_enabled: boolean;
 	wpcom_newsletter_categories: string[];
 	subscription_options?: {

--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter.jsx
@@ -168,7 +168,7 @@ function Newsletter( props ) {
 					onChange={ handleEmailPostToSubsDefaultToggle }
 					label={
 						<span className="jp-form-toggle-explanation">
-							{ __( 'Send newsletter by default', 'jetpack' ) }
+							{ __( 'Email new posts to subscribers by default', 'jetpack' ) }
 						</span>
 					}
 				/>

--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter.jsx
@@ -78,7 +78,7 @@ function Newsletter( props ) {
 	const handleEmailPostToSubsDefaultToggle = useCallback( () => {
 		const newValue = ! newsletterSendDefault;
 		updateFormStateAndSaveOptionValue( NEWSLETTER_SEND_DEFAULT_OPTION, newValue );
-		analytics.tracks.recordEvent( 'jetpack_newsletter_set_send_default', {
+		analytics.tracks.recordEvent( 'jetpack_set_wpcom_newsletter_send_default', {
 			enabled: newValue,
 		} );
 	}, [ newsletterSendDefault, updateFormStateAndSaveOptionValue ] );
@@ -148,7 +148,7 @@ function Newsletter( props ) {
 				module={ subscriptions }
 				support={ {
 					text: __(
-						'When on, the newsletter option will be pre-selected each time you publish. You can change it before publishing any post.',
+						'When on, the newsletter option will be pre-selected each time you publish. You can change it in the newsletter panel in the editor before publishing any post.',
 						'jetpack'
 					),
 					link: getRedirectUrl( 'jetpack-support-subscriptions', {

--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter.jsx
@@ -1,4 +1,4 @@
-import { getRedirectUrl } from '@automattic/jetpack-components';
+import { getRedirectUrl, ToggleControl } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
 import { useCallback } from 'react';
 import { connect } from 'react-redux';
@@ -18,6 +18,8 @@ import {
 import { isWpAdminSubscriberManagementEnabled, getSiteAdminUrl } from 'state/initial-state';
 import { getModule } from 'state/modules';
 import { SUBSCRIPTIONS_MODULE_NAME } from './constants';
+
+const NEWSLETTER_SEND_DEFAULT_OPTION = 'wpcom_newsletter_send_default';
 
 const trackViewSubsClick = () => {
 	analytics.tracks.recordJetpackClick( 'manage-subscribers' );
@@ -41,7 +43,9 @@ function Newsletter( props ) {
 		siteHasConnectedUser,
 		wpAdminSubscriberManagementEnabled,
 		siteAdminUrl,
+		newsletterSendDefault,
 		updateOptions,
+		updateFormStateAndSaveOptionValue,
 		getOptionValue,
 		refreshSettings,
 	} = props;
@@ -70,6 +74,14 @@ function Newsletter( props ) {
 			</Card>
 		);
 	};
+
+	const handleEmailPostToSubsDefaultToggle = useCallback( () => {
+		const newValue = ! newsletterSendDefault;
+		updateFormStateAndSaveOptionValue( NEWSLETTER_SEND_DEFAULT_OPTION, newValue );
+		analytics.tracks.recordEvent( 'jetpack_newsletter_set_send_default', {
+			enabled: newValue,
+		} );
+	}, [ newsletterSendDefault, updateFormStateAndSaveOptionValue ] );
 
 	const toggleModule = useCallback(
 		module => {
@@ -129,6 +141,39 @@ function Newsletter( props ) {
 				</ModuleToggle>
 			</SettingsGroup>
 
+			<SettingsGroup
+				hasChild
+				disableInOfflineMode
+				disableInSiteConnectionMode={ ! siteHasConnectedUser }
+				module={ subscriptions }
+				support={ {
+					text: __(
+						'When on, the newsletter option will be pre-selected each time you publish. You can change it before publishing any post.',
+						'jetpack'
+					),
+					link: getRedirectUrl( 'jetpack-support-subscriptions', {
+						anchor: 'post-email-vs-post-only-options',
+					} ),
+				} }
+			>
+				<ToggleControl
+					checked={ isSubscriptionsActive && !! newsletterSendDefault }
+					disabled={
+						! isSubscriptionsActive ||
+						! siteHasConnectedUser ||
+						unavailableInOfflineMode ||
+						isSavingAnyOption( [ SUBSCRIPTIONS_MODULE_NAME, NEWSLETTER_SEND_DEFAULT_OPTION ] )
+					}
+					toggling={ isSavingAnyOption( [ NEWSLETTER_SEND_DEFAULT_OPTION ] ) }
+					onChange={ handleEmailPostToSubsDefaultToggle }
+					label={
+						<span className="jp-form-toggle-explanation">
+							{ __( 'Send newsletter by default', 'jetpack' ) }
+						</span>
+					}
+				/>
+			</SettingsGroup>
+
 			{ getSubClickableCard() }
 		</SettingsCard>
 	);
@@ -145,6 +190,7 @@ export default withModuleSettingsFormHelpers(
 			siteHasConnectedUser: hasConnectedOwner( state ),
 			wpAdminSubscriberManagementEnabled: isWpAdminSubscriberManagementEnabled( state ),
 			siteAdminUrl: getSiteAdminUrl( state ),
+			newsletterSendDefault: ownProps.getOptionValue( NEWSLETTER_SEND_DEFAULT_OPTION ),
 		};
 	} )( Newsletter )
 );

--- a/projects/plugins/jetpack/_inc/client/newsletter/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/newsletter/test/component.js
@@ -23,7 +23,9 @@ describe( 'Newsletter', () => {
 		wpAdminSubscriberManagementEnabled: true,
 		siteAdminUrl: 'https://example.org/wp-admin/',
 		getOptionValue: () => true,
+		newsletterSendDefault: true,
 		updateOptions: jest.fn().mockResolvedValue( {} ),
+		updateFormStateAndSaveOptionValue: jest.fn(),
 		refreshSettings: jest.fn(),
 	};
 
@@ -114,6 +116,40 @@ describe( 'Newsletter', () => {
 				screen.getByText( 'Newsletter' ).closest( '.dops-section-header' )
 			).toBeInTheDocument();
 			expect( screen.getByRole( 'link', { name: 'Manage all subscribers' } ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'Send newsletter by default toggle', () => {
+		it( 'renders the toggle', () => {
+			render( <Newsletter { ...defaultProps } />, { initialState } );
+			expect( screen.getByText( 'Send newsletter by default' ) ).toBeInTheDocument();
+		} );
+
+		it( 'is checked when newsletterSendDefault is true', () => {
+			render( <Newsletter { ...defaultProps } />, { initialState } );
+			const toggle = screen.getByLabelText( 'Send newsletter by default' );
+			expect( toggle ).toBeChecked();
+		} );
+
+		it( 'is unchecked when newsletterSendDefault is false', () => {
+			const propsWithSendDefaultFalse = {
+				...defaultProps,
+				getOptionValue: option => ( option === 'wpcom_newsletter_send_default' ? false : true ),
+			};
+			render( <Newsletter { ...propsWithSendDefaultFalse } />, { initialState } );
+			const toggle = screen.getByLabelText( 'Send newsletter by default' );
+			expect( toggle ).not.toBeChecked();
+		} );
+
+		it( 'is disabled and unchecked when subscriptions are inactive', () => {
+			const propsWithSubscriptionsInactive = {
+				...defaultProps,
+				getOptionValue: option => ( option === 'subscriptions' ? false : true ),
+			};
+			render( <Newsletter { ...propsWithSubscriptionsInactive } />, { initialState } );
+			const toggle = screen.getByLabelText( 'Send newsletter by default' );
+			expect( toggle ).not.toBeChecked();
+			expect( toggle ).toBeDisabled();
 		} );
 	} );
 } );

--- a/projects/plugins/jetpack/_inc/client/newsletter/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/newsletter/test/component.js
@@ -119,15 +119,15 @@ describe( 'Newsletter', () => {
 		} );
 	} );
 
-	describe( 'Send newsletter by default toggle', () => {
+	describe( 'Email new posts to subscribers by default toggle', () => {
 		it( 'renders the toggle', () => {
 			render( <Newsletter { ...defaultProps } />, { initialState } );
-			expect( screen.getByText( 'Send newsletter by default' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Email new posts to subscribers by default' ) ).toBeInTheDocument();
 		} );
 
 		it( 'is checked when newsletterSendDefault is true', () => {
 			render( <Newsletter { ...defaultProps } />, { initialState } );
-			const toggle = screen.getByLabelText( 'Send newsletter by default' );
+			const toggle = screen.getByLabelText( 'Email new posts to subscribers by default' );
 			expect( toggle ).toBeChecked();
 		} );
 
@@ -137,7 +137,7 @@ describe( 'Newsletter', () => {
 				getOptionValue: option => ( option === 'wpcom_newsletter_send_default' ? false : true ),
 			};
 			render( <Newsletter { ...propsWithSendDefaultFalse } />, { initialState } );
-			const toggle = screen.getByLabelText( 'Send newsletter by default' );
+			const toggle = screen.getByLabelText( 'Email new posts to subscribers by default' );
 			expect( toggle ).not.toBeChecked();
 		} );
 
@@ -147,7 +147,7 @@ describe( 'Newsletter', () => {
 				getOptionValue: option => ( option === 'subscriptions' ? false : true ),
 			};
 			render( <Newsletter { ...propsWithSubscriptionsInactive } />, { initialState } );
-			const toggle = screen.getByLabelText( 'Send newsletter by default' );
+			const toggle = screen.getByLabelText( 'Email new posts to subscribers by default' );
 			expect( toggle ).not.toBeChecked();
 			expect( toggle ).toBeDisabled();
 		} );

--- a/projects/plugins/jetpack/changelog/add-newsletter-send-default-setting
+++ b/projects/plugins/jetpack/changelog/add-newsletter-send-default-setting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Newsletter: Add Send newsletter by default toggle to settings.


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/NL-486/allow-site-owners-to-set-default-newsletter-send-behavior-post-only-vs

## Proposed changes

| Jetpack | Simple |
|--------|--------|
| <img width="1574" height="670" alt="Screen Shot 2026-03-18 at 00 43 39" src="https://github.com/user-attachments/assets/42fcbd82-2216-47e6-ab96-ca116963904a" /> |  Cell |
| <img width="1644" height="938" alt="Screen Shot 2026-03-18 at 00 44 05" src="https://github.com/user-attachments/assets/3f5ca156-cbc4-4b2e-bd51-2bc584167fa7" /> | Cell |

* Adds a "Send newsletter by default" toggle to the Newsletter settings card in both the new newsletter settings page and the old Jetpack dashboard
* The toggle controls the `wpcom_newsletter_send_default` option introduced in #47564
* When subscriptions are disabled, the toggle shows as off and disabled
* Uses `ToggleControl` (matching the existing subscriptions toggle pattern) with an info popover for the description
* Removes all references to the old `wpcom_newsletter_default_publish_behavior` radio control

### Other information
- [x] Generate changelog entries for this PR (using AI).
- Depends on #47564

## Does this pull request change what data or activity we track or use?
Adds a new Tracks event `jetpack_newsletter_set_send_default` when the toggle is changed.

## Testing instructions
* Merge or check out #47564 first (this PR is based on it)
* Go to Jetpack > Settings > Newsletter
* Verify the "Send newsletter by default" toggle appears below the subscriptions toggle
* Toggle it off - verify the setting saves and the editor now defaults to "Post only"
* Toggle it on - verify the editor defaults to "Post & email"
* Disable the subscriptions module - verify the send default toggle becomes disabled and unchecked
* Click the info popover icon - verify it shows the description text and Learn more link
* For the new newsletter settings page (wp-admin/admin.php?page=jetpack-newsletter), verify the same toggle appears and functions correctly