### PR TITLE
SSO: validate user token after login

### DIFF
--- a/projects/packages/connection/changelog/add-sso-validate-user-token
+++ b/projects/packages/connection/changelog/add-sso-validate-user-token
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+SSO: Validate user tokens during SSO login to detect and replace stale tokens after database migration.

--- a/projects/packages/connection/src/sso/class-sso.php
+++ b/projects/packages/connection/src/sso/class-sso.php
@@ -1580,8 +1580,14 @@ class SSO {
 	 *
 	 * Uses the `user_token_valid` field from the SSO validate response when the
 	 * signed token was sent for the same user that was resolved during login.
-	 * Falls back to the token-health API when the validate response can't be
-	 * trusted for this user (different user resolved, or no signed token was sent).
+	 *
+	 * When the validate response can't be trusted for this user (a different user
+	 * was resolved, or no signed token was sent), login proceeds without an extra
+	 * verification call. In that case `set_wpcom_user_id_meta()` records the
+	 * mapping during this login, so the fast path validates the token on the next
+	 * SSO login. This avoids an extra HTTP request on every first-SSO login and
+	 * keeps the Error_Handler from being triggered for users whose token state can
+	 * only be resolved by a direct token-health check.
 	 *
 	 * If the token is found to be invalid, it is removed locally so the user will be
 	 * prompted to re-authorize and obtain a fresh token.
@@ -1604,14 +1610,10 @@ class SSO {
 			return true;
 		}
 
-		// The signed token was for a different user (or wasn't sent at all).
-		// Fall back to the token-health API to verify this user's token directly.
-		$validation = $tokens->validate( $user_id );
-		if ( is_array( $validation ) && isset( $validation['user_token_is_healthy'] ) && false === $validation['user_token_is_healthy'] ) {
-			$tokens->disconnect_user( $user_id );
-			return false;
-		}
-
+		// The signed token was for a different user (or wasn't sent at all), so the
+		// validateResult response can't be trusted for this user. Let login proceed;
+		// the wpcom_user_id meta set during this login means the next SSO login will
+		// validate the token via the fast path.
 		return true;
 	}
 

--- a/projects/packages/connection/src/sso/class-sso.php
+++ b/projects/packages/connection/src/sso/class-sso.php
@@ -1006,8 +1006,16 @@ class SSO {
 		$wpcom_nonce   = isset( $_GET['sso_nonce'] ) ? sanitize_key( $_GET['sso_nonce'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$wpcom_user_id = isset( $_GET['user_id'] ) ? (int) $_GET['user_id'] : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
+		$token_lookup             = $this->get_signed_user_token_for_wpcom_id( $wpcom_user_id );
+		$signed_user_token        = $token_lookup['signed_token'];
+		$token_validated_for_user = $token_lookup['local_user_id'];
+
 		$xml = new Jetpack_IXR_Client();
-		$xml->query( 'jetpack.sso.validateResult', $wpcom_nonce, $wpcom_user_id );
+		if ( $signed_user_token ) {
+			$xml->query( 'jetpack.sso.validateResult', $wpcom_nonce, $wpcom_user_id, $signed_user_token );
+		} else {
+			$xml->query( 'jetpack.sso.validateResult', $wpcom_nonce, $wpcom_user_id );
+		}
 
 		$user_data = $xml->isError() ? false : $xml->getResponse();
 		if ( empty( $user_data ) ) {
@@ -1071,7 +1079,7 @@ class SSO {
 					add_filter( 'login_message', array( Notices::class, 'error_invalid_response_data' ) ); // @todo Need to have a better notice. This is only for the sake of testing the validation.
 					return;
 				}
-				update_user_meta( $user->ID, 'wpcom_user_id', $user_data->ID );
+				self::set_wpcom_user_id_meta( $user->ID, $user_data->ID );
 			}
 		}
 
@@ -1080,7 +1088,7 @@ class SSO {
 			$user_found_with = 'match_by_email';
 			$user            = get_user_by( 'email', $user_data->email );
 			if ( $user ) {
-				update_user_meta( $user->ID, 'wpcom_user_id', $user_data->ID );
+				self::set_wpcom_user_id_meta( $user->ID, $user_data->ID );
 			}
 		}
 
@@ -1112,6 +1120,10 @@ class SSO {
 					add_filter( 'login_message', array( Notices::class, 'error_unable_to_create_user' ) );
 					return;
 				}
+
+				// generate_user() sets wpcom_user_id meta on the new user,
+				// but another user may still have stale meta for this WP.com ID.
+				self::set_wpcom_user_id_meta( $user->ID, $user_data->ID );
 
 				$user_found_with = $new_user_override_role
 				? 'user_created_new_user_override'
@@ -1199,8 +1211,20 @@ class SSO {
 			$json_api_auth_environment = Helpers::get_json_api_auth_environment();
 
 			$is_json_api_auth  = ! empty( $json_api_auth_environment );
-			$is_user_connected = ( new Manager() )->is_user_connected( $user->ID );
-			$roles             = new Roles();
+			$manager           = new Manager();
+			$tokens            = $manager->get_tokens();
+			$is_user_connected = $manager->is_user_connected( $user->ID );
+
+			if ( $is_user_connected ) {
+				$is_user_connected = $this->verify_user_token(
+					$user->ID,
+					$user_data,
+					$tokens,
+					$token_validated_for_user
+				);
+			}
+
+			$roles = new Roles();
 			$tracking->record_user_event(
 				'sso_user_logged_in',
 				array(
@@ -1455,6 +1479,37 @@ class SSO {
 	}
 
 	/**
+	 * Sets the wpcom_user_id meta on a local user, removing it from any other user first.
+	 *
+	 * Multiple local users should never share the same wpcom_user_id. This can happen
+	 * when user resolution changes (e.g., external_user_id points to a different local
+	 * user than the one that previously had the meta).
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int $user_id       The local WordPress user ID to set the meta on.
+	 * @param int $wpcom_user_id The WordPress.com user ID.
+	 */
+	private static function set_wpcom_user_id_meta( $user_id, $wpcom_user_id ) {
+		$existing = new WP_User_Query(
+			array(
+				'meta_key'   => 'wpcom_user_id',
+				'meta_value' => (int) $wpcom_user_id,
+				'exclude'    => array( $user_id ),
+				'fields'     => 'ID',
+			)
+		);
+
+		foreach ( $existing->get_results() as $stale_user_id ) {
+			delete_user_meta( $stale_user_id, 'wpcom_user_id' );
+			clean_user_cache( $stale_user_id );
+		}
+
+		update_user_meta( $user_id, 'wpcom_user_id', $wpcom_user_id );
+		clean_user_cache( $user_id );
+	}
+
+	/**
 	 * Determines local user associated with a given WordPress.com user ID.
 	 *
 	 * @since jetpack-2.6.0
@@ -1473,6 +1528,91 @@ class SSO {
 
 		$users = $user_query->get_results();
 		return $users ? array_shift( $users ) : null;
+	}
+
+	/**
+	 * Retrieves the signed user token for a given WP.com user ID, if one exists locally.
+	 *
+	 * Looks up the local WordPress user associated with the WP.com user ID and returns
+	 * a signed representation of their user token along with the local user ID.
+	 * The signed token is sent to WP.com during SSO validation so WP.com can verify
+	 * the token is still valid on its side.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int $wpcom_user_id The WordPress.com user ID.
+	 * @return array{signed_token: string, local_user_id: int} The signed token and local user ID.
+	 *               Both values are 0/empty when no valid token exists.
+	 */
+	private function get_signed_user_token_for_wpcom_id( $wpcom_user_id ) {
+		$result = array(
+			'signed_token'  => '',
+			'local_user_id' => 0,
+		);
+
+		if ( ! $wpcom_user_id ) {
+			return $result;
+		}
+
+		$local_user = self::get_user_by_wpcom_id( $wpcom_user_id );
+		if ( ! $local_user ) {
+			return $result;
+		}
+
+		$tokens     = new Tokens();
+		$user_token = $tokens->get_access_token( $local_user->ID );
+		if ( ! $user_token ) {
+			return $result;
+		}
+
+		$signed = $tokens->get_signed_token( $user_token );
+		if ( is_wp_error( $signed ) ) {
+			return $result;
+		}
+
+		$result['signed_token']  = $signed;
+		$result['local_user_id'] = $local_user->ID;
+		return $result;
+	}
+
+	/**
+	 * Verifies that a locally-stored user token is still valid on WP.com.
+	 *
+	 * Uses the `user_token_valid` field from the SSO validate response when the
+	 * signed token was sent for the same user that was resolved during login.
+	 * Falls back to the token-health API when the validate response can't be
+	 * trusted for this user (different user resolved, or no signed token was sent).
+	 *
+	 * If the token is found to be invalid, it is removed locally so the user will be
+	 * prompted to re-authorize and obtain a fresh token.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int    $user_id                  The local WordPress user ID (the resolved user).
+	 * @param object $user_data                The WP.com user data from jetpack.sso.validateResult.
+	 * @param Tokens $tokens                   The Tokens instance.
+	 * @param int    $token_validated_for_user  The local user ID whose token was sent to WP.com, or 0 if none.
+	 * @return bool True if the user token is valid (or could not be verified), false if invalid and removed.
+	 */
+	private function verify_user_token( $user_id, $user_data, Tokens $tokens, $token_validated_for_user ) {
+		// Only trust the validateResult response if the signed token was for this same user.
+		if ( $token_validated_for_user === $user_id && isset( $user_data->user_token_valid ) ) {
+			if ( false === $user_data->user_token_valid ) {
+				$tokens->disconnect_user( $user_id );
+				return false;
+			}
+			return true;
+		}
+
+		// The signed token was for a different user (or wasn't sent at all).
+		// Fall back to the token-health API to verify this user's token directly.
+		$validation = $tokens->validate( $user_id );
+		if ( is_array( $validation ) && isset( $validation['user_token_is_healthy'] ) && false === $validation['user_token_is_healthy'] ) {
+			$tokens->disconnect_user( $user_id );
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/projects/packages/connection/src/sso/class-sso.php
+++ b/projects/packages/connection/src/sso/class-sso.php
@@ -1212,14 +1212,13 @@ class SSO {
 
 			$is_json_api_auth  = ! empty( $json_api_auth_environment );
 			$manager           = new Manager();
-			$tokens            = $manager->get_tokens();
 			$is_user_connected = $manager->is_user_connected( $user->ID );
 
 			if ( $is_user_connected ) {
 				$is_user_connected = $this->verify_user_token(
 					$user->ID,
 					$user_data,
-					$tokens,
+					$manager->get_tokens(),
 					$token_validated_for_user
 				);
 			}

--- a/projects/packages/connection/src/sso/class-sso.php
+++ b/projects/packages/connection/src/sso/class-sso.php
@@ -778,8 +778,16 @@ class SSO {
 		$wpcom_nonce   = isset( $_GET['sso_nonce'] ) ? sanitize_key( $_GET['sso_nonce'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$wpcom_user_id = isset( $_GET['user_id'] ) ? (int) $_GET['user_id'] : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
+		$token_lookup             = $this->get_signed_user_token_for_wpcom_id( $wpcom_user_id );
+		$signed_user_token        = $token_lookup['signed_token'];
+		$token_validated_for_user = $token_lookup['local_user_id'];
+
 		$xml = new Jetpack_IXR_Client();
-		$xml->query( 'jetpack.sso.validateResult', $wpcom_nonce, $wpcom_user_id );
+		if ( $signed_user_token ) {
+			$xml->query( 'jetpack.sso.validateResult', $wpcom_nonce, $wpcom_user_id, $signed_user_token );
+		} else {
+			$xml->query( 'jetpack.sso.validateResult', $wpcom_nonce, $wpcom_user_id );
+		}
 
 		$user_data = $xml->isError() ? false : $xml->getResponse();
 		if ( empty( $user_data ) ) {
@@ -843,7 +851,7 @@ class SSO {
 					add_filter( 'login_message', array( Notices::class, 'error_invalid_response_data' ) ); // @todo Need to have a better notice. This is only for the sake of testing the validation.
 					return;
 				}
-				update_user_meta( $user->ID, 'wpcom_user_id', $user_data->ID );
+				self::set_wpcom_user_id_meta( $user->ID, $user_data->ID );
 			}
 		}
 
@@ -852,7 +860,7 @@ class SSO {
 			$user_found_with = 'match_by_email';
 			$user            = get_user_by( 'email', $user_data->email );
 			if ( $user ) {
-				update_user_meta( $user->ID, 'wpcom_user_id', $user_data->ID );
+				self::set_wpcom_user_id_meta( $user->ID, $user_data->ID );
 			}
 		}
 
@@ -884,6 +892,10 @@ class SSO {
 					add_filter( 'login_message', array( Notices::class, 'error_unable_to_create_user' ) );
 					return;
 				}
+
+				// generate_user() sets wpcom_user_id meta on the new user,
+				// but another user may still have stale meta for this WP.com ID.
+				self::set_wpcom_user_id_meta( $user->ID, $user_data->ID );
 
 				$user_found_with = $new_user_override_role
 				? 'user_created_new_user_override'
@@ -940,8 +952,20 @@ class SSO {
 			$json_api_auth_environment = Helpers::get_json_api_auth_environment();
 
 			$is_json_api_auth  = ! empty( $json_api_auth_environment );
-			$is_user_connected = ( new Manager() )->is_user_connected( $user->ID );
-			$roles             = new Roles();
+			$manager           = new Manager();
+			$tokens            = $manager->get_tokens();
+			$is_user_connected = $manager->is_user_connected( $user->ID );
+
+			if ( $is_user_connected ) {
+				$is_user_connected = $this->verify_user_token(
+					$user->ID,
+					$user_data,
+					$tokens,
+					$token_validated_for_user
+				);
+			}
+
+			$roles = new Roles();
 			$tracking->record_user_event(
 				'sso_user_logged_in',
 				array(
@@ -1149,6 +1173,37 @@ class SSO {
 	}
 
 	/**
+	 * Sets the wpcom_user_id meta on a local user, removing it from any other user first.
+	 *
+	 * Multiple local users should never share the same wpcom_user_id. This can happen
+	 * when user resolution changes (e.g., external_user_id points to a different local
+	 * user than the one that previously had the meta).
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int $user_id       The local WordPress user ID to set the meta on.
+	 * @param int $wpcom_user_id The WordPress.com user ID.
+	 */
+	private static function set_wpcom_user_id_meta( $user_id, $wpcom_user_id ) {
+		$existing = new WP_User_Query(
+			array(
+				'meta_key'   => 'wpcom_user_id',
+				'meta_value' => (int) $wpcom_user_id,
+				'exclude'    => array( $user_id ),
+				'fields'     => 'ID',
+			)
+		);
+
+		foreach ( $existing->get_results() as $stale_user_id ) {
+			delete_user_meta( $stale_user_id, 'wpcom_user_id' );
+			clean_user_cache( $stale_user_id );
+		}
+
+		update_user_meta( $user_id, 'wpcom_user_id', $wpcom_user_id );
+		clean_user_cache( $user_id );
+	}
+
+	/**
 	 * Determines local user associated with a given WordPress.com user ID.
 	 *
 	 * @since jetpack-2.6.0
@@ -1167,6 +1222,91 @@ class SSO {
 
 		$users = $user_query->get_results();
 		return $users ? array_shift( $users ) : null;
+	}
+
+	/**
+	 * Retrieves the signed user token for a given WP.com user ID, if one exists locally.
+	 *
+	 * Looks up the local WordPress user associated with the WP.com user ID and returns
+	 * a signed representation of their user token along with the local user ID.
+	 * The signed token is sent to WP.com during SSO validation so WP.com can verify
+	 * the token is still valid on its side.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int $wpcom_user_id The WordPress.com user ID.
+	 * @return array{signed_token: string, local_user_id: int} The signed token and local user ID.
+	 *               Both values are 0/empty when no valid token exists.
+	 */
+	private function get_signed_user_token_for_wpcom_id( $wpcom_user_id ) {
+		$result = array(
+			'signed_token'  => '',
+			'local_user_id' => 0,
+		);
+
+		if ( ! $wpcom_user_id ) {
+			return $result;
+		}
+
+		$local_user = self::get_user_by_wpcom_id( $wpcom_user_id );
+		if ( ! $local_user ) {
+			return $result;
+		}
+
+		$tokens     = new Tokens();
+		$user_token = $tokens->get_access_token( $local_user->ID );
+		if ( ! $user_token ) {
+			return $result;
+		}
+
+		$signed = $tokens->get_signed_token( $user_token );
+		if ( is_wp_error( $signed ) ) {
+			return $result;
+		}
+
+		$result['signed_token']  = $signed;
+		$result['local_user_id'] = $local_user->ID;
+		return $result;
+	}
+
+	/**
+	 * Verifies that a locally-stored user token is still valid on WP.com.
+	 *
+	 * Uses the `user_token_valid` field from the SSO validate response when the
+	 * signed token was sent for the same user that was resolved during login.
+	 * Falls back to the token-health API when the validate response can't be
+	 * trusted for this user (different user resolved, or no signed token was sent).
+	 *
+	 * If the token is found to be invalid, it is removed locally so the user will be
+	 * prompted to re-authorize and obtain a fresh token.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int    $user_id                  The local WordPress user ID (the resolved user).
+	 * @param object $user_data                The WP.com user data from jetpack.sso.validateResult.
+	 * @param Tokens $tokens                   The Tokens instance.
+	 * @param int    $token_validated_for_user  The local user ID whose token was sent to WP.com, or 0 if none.
+	 * @return bool True if the user token is valid (or could not be verified), false if invalid and removed.
+	 */
+	private function verify_user_token( $user_id, $user_data, Tokens $tokens, $token_validated_for_user ) {
+		// Only trust the validateResult response if the signed token was for this same user.
+		if ( $token_validated_for_user === $user_id && isset( $user_data->user_token_valid ) ) {
+			if ( false === $user_data->user_token_valid ) {
+				$tokens->disconnect_user( $user_id );
+				return false;
+			}
+			return true;
+		}
+
+		// The signed token was for a different user (or wasn't sent at all).
+		// Fall back to the token-health API to verify this user's token directly.
+		$validation = $tokens->validate( $user_id );
+		if ( is_array( $validation ) && isset( $validation['user_token_is_healthy'] ) && false === $validation['user_token_is_healthy'] ) {
+			$tokens->disconnect_user( $user_id );
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/sso/SSO_Test.php
+++ b/projects/packages/connection/tests/php/sso/SSO_Test.php
@@ -675,21 +675,18 @@ class SSO_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test verify_user_token ignores user_token_valid when the token was for a different user.
+	 * Test verify_user_token proceeds without verifying when the token was validated for a different user.
+	 *
+	 * The validateResult response can't be trusted for this user, so login proceeds
+	 * (no extra token-health call) and the wpcom_user_id meta set during this login
+	 * means the next SSO login validates the token via the fast path.
 	 */
-	public function test_verify_user_token_user_mismatch_forces_fallback() {
+	public function test_verify_user_token_user_mismatch_proceeds_without_verification() {
 		$tokens = $this->createMock( Tokens::class );
 		$tokens->expects( $this->never() )
 			->method( 'disconnect_user' );
-		$tokens->expects( $this->once() )
-			->method( 'validate' )
-			->with( 42 )
-			->willReturn(
-				array(
-					'user_token_is_healthy' => true,
-					'blog_token_is_healthy' => true,
-				)
-			);
+		$tokens->expects( $this->never() )
+			->method( 'validate' );
 
 		// user_token_valid is false, but it was validated for user 99, not user 42.
 		$user_data = (object) array( 'user_token_valid' => false );
@@ -704,96 +701,18 @@ class SSO_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test verify_user_token falls back to Tokens::validate when no user_token_valid in response.
+	 * Test verify_user_token proceeds without verifying when no signed token was sent.
+	 *
+	 * When no signed token was sent (no wpcom_user_id meta), the validateResult
+	 * response has no user_token_valid field to trust, so login proceeds without an
+	 * extra token-health call.
 	 */
-	public function test_verify_user_token_fallback_healthy() {
+	public function test_verify_user_token_no_signed_token_proceeds_without_verification() {
 		$tokens = $this->createMock( Tokens::class );
 		$tokens->expects( $this->never() )
 			->method( 'disconnect_user' );
-		$tokens->expects( $this->once() )
-			->method( 'validate' )
-			->with( 42 )
-			->willReturn(
-				array(
-					'user_token_is_healthy' => true,
-					'blog_token_is_healthy' => true,
-				)
-			);
-
-		$user_data = (object) array( 'ID' => 123 );
-
-		$result = $this->invoke_private_method(
-			$this->sso,
-			'verify_user_token',
-			array( 42, $user_data, $tokens, 0 )
-		);
-
-		$this->assertTrue( $result );
-	}
-
-	/**
-	 * Test verify_user_token fallback disconnects when token is unhealthy.
-	 */
-	public function test_verify_user_token_fallback_unhealthy() {
-		$tokens = $this->createMock( Tokens::class );
-		$tokens->expects( $this->once() )
-			->method( 'disconnect_user' )
-			->with( 42 );
-		$tokens->expects( $this->once() )
-			->method( 'validate' )
-			->with( 42 )
-			->willReturn(
-				array(
-					'user_token_is_healthy' => false,
-					'blog_token_is_healthy' => true,
-				)
-			);
-
-		$user_data = (object) array( 'ID' => 123 );
-
-		$result = $this->invoke_private_method(
-			$this->sso,
-			'verify_user_token',
-			array( 42, $user_data, $tokens, 0 )
-		);
-
-		$this->assertFalse( $result );
-	}
-
-	/**
-	 * Test verify_user_token fails open when Tokens::validate returns false (network error).
-	 */
-	public function test_verify_user_token_fail_open_on_error() {
-		$tokens = $this->createMock( Tokens::class );
 		$tokens->expects( $this->never() )
-			->method( 'disconnect_user' );
-		$tokens->expects( $this->once() )
-			->method( 'validate' )
-			->with( 42 )
-			->willReturn( false );
-
-		$user_data = (object) array( 'ID' => 123 );
-
-		$result = $this->invoke_private_method(
-			$this->sso,
-			'verify_user_token',
-			array( 42, $user_data, $tokens, 0 )
-		);
-
-		$this->assertTrue( $result );
-	}
-
-	/**
-	 * Test verify_user_token fails open when Tokens::validate returns WP_Error.
-	 */
-	public function test_verify_user_token_fail_open_on_wp_error() {
-		$tokens = $this->createMock( Tokens::class );
-		$tokens->expects( $this->never() )
-			->method( 'disconnect_user' );
-		$tokens->expects( $this->once() )
-			->method( 'validate' )
-			->with( 42 )
-			->willReturn( new WP_Error( 'site_not_registered', 'Site not registered.' ) );
+			->method( 'validate' );
 
 		$user_data = (object) array( 'ID' => 123 );
 

--- a/projects/packages/connection/tests/php/sso/SSO_Test.php
+++ b/projects/packages/connection/tests/php/sso/SSO_Test.php
@@ -827,7 +827,7 @@ class SSO_Test extends BaseTestCase {
 			array( $user_id, 12345 )
 		);
 
-		$this->assertSame( '12345', get_user_meta( $user_id, 'wpcom_user_id', true ) );
+		$this->assertEquals( 12345, get_user_meta( $user_id, 'wpcom_user_id', true ) );
 
 		wp_delete_user( $user_id );
 	}
@@ -875,7 +875,7 @@ class SSO_Test extends BaseTestCase {
 			array( $user_a, 12345 )
 		);
 
-		$this->assertSame( '12345', get_user_meta( $user_a, 'wpcom_user_id', true ) );
+		$this->assertEquals( 12345, get_user_meta( $user_a, 'wpcom_user_id', true ) );
 		$this->assertEmpty( get_user_meta( $user_b, 'wpcom_user_id', true ) );
 
 		wp_delete_user( $user_a );
@@ -928,7 +928,7 @@ class SSO_Test extends BaseTestCase {
 			array( $user_a, 99999 )
 		);
 
-		$this->assertSame( '99999', get_user_meta( $user_a, 'wpcom_user_id', true ) );
+		$this->assertEquals( 99999, get_user_meta( $user_a, 'wpcom_user_id', true ) );
 		$this->assertEmpty( get_user_meta( $user_b, 'wpcom_user_id', true ) );
 		$this->assertEmpty( get_user_meta( $user_c, 'wpcom_user_id', true ) );
 
@@ -957,7 +957,7 @@ class SSO_Test extends BaseTestCase {
 			array( $user_id, 55555 )
 		);
 
-		$this->assertSame( '55555', get_user_meta( $user_id, 'wpcom_user_id', true ) );
+		$this->assertEquals( 55555, get_user_meta( $user_id, 'wpcom_user_id', true ) );
 
 		wp_delete_user( $user_id );
 	}

--- a/projects/packages/connection/tests/php/sso/SSO_Test.php
+++ b/projects/packages/connection/tests/php/sso/SSO_Test.php
@@ -785,6 +785,8 @@ class SSO_Test extends BaseTestCase {
 			)
 		);
 		if ( empty( $probe->get_results() ) ) {
+			wp_delete_user( $user_a );
+			wp_delete_user( $user_b );
 			$this->markTestSkipped( 'WP_User_Query meta queries not supported in this environment.' );
 		}
 
@@ -838,6 +840,9 @@ class SSO_Test extends BaseTestCase {
 			)
 		);
 		if ( empty( $probe->get_results() ) ) {
+			wp_delete_user( $user_a );
+			wp_delete_user( $user_b );
+			wp_delete_user( $user_c );
 			$this->markTestSkipped( 'WP_User_Query meta queries not supported in this environment.' );
 		}
 

--- a/projects/packages/connection/tests/php/sso/SSO_Test.php
+++ b/projects/packages/connection/tests/php/sso/SSO_Test.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Connection;
 
 use Automattic\Jetpack\Connection\SSO\Helpers;
 use Automattic\Jetpack\Constants;
+use PHPUnit\Framework\Attributes\RequiresMethod;
 use WorDBless\BaseTestCase;
 use WP_Error;
 
@@ -46,7 +47,42 @@ class SSO_Test extends BaseTestCase {
 			$_SERVER['HTTP_REFERER'],
 			$GLOBALS['action']
 		);
+		wp_set_current_user( 0 );
 		parent::tear_down();
+	}
+
+	/**
+	 * Invoke a private method on an object via reflection.
+	 *
+	 * @param object $object     The object.
+	 * @param string $method     The method name.
+	 * @param array  $parameters The parameters.
+	 * @return mixed
+	 */
+	private function invoke_private_method( $object, $method, $parameters = array() ) {
+		$reflection = new \ReflectionClass( get_class( $object ) );
+		$method     = $reflection->getMethod( $method );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+		return $method->invokeArgs( $object, $parameters );
+	}
+
+	/**
+	 * Invoke a private static method via reflection.
+	 *
+	 * @param string $class      The class name.
+	 * @param string $method     The method name.
+	 * @param array  $parameters The parameters.
+	 * @return mixed
+	 */
+	private function invoke_private_static_method( $class, $method, $parameters = array() ) {
+		$reflection = new \ReflectionClass( $class );
+		$method     = $reflection->getMethod( $method );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+		return $method->invokeArgs( null, $parameters );
 	}
 
 	// ──────────────────────────────────────────────
@@ -261,6 +297,41 @@ class SSO_Test extends BaseTestCase {
 	 */
 	public function test_get_user_by_wpcom_id_returns_null_when_not_found() {
 		$this->assertNull( SSO::get_user_by_wpcom_id( 99999 ) );
+	}
+
+	/**
+	 * Test get_user_by_wpcom_id returns the correct user.
+	 *
+	 * @requires function WP_User_Query::prepare_query
+	 */
+	#[RequiresMethod( \WP_User_Query::class, 'prepare_query' )]
+	public function test_get_user_by_wpcom_id_returns_correct_user() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'sso_wpcom_lookup',
+				'user_pass'  => 'password',
+			)
+		);
+		update_user_meta( $user_id, 'wpcom_user_id', 44444 );
+
+		$probe = new \WP_User_Query(
+			array(
+				'meta_key'   => 'wpcom_user_id',
+				'meta_value' => 44444,
+				'number'     => 1,
+			)
+		);
+		if ( empty( $probe->get_results() ) ) {
+			wp_delete_user( $user_id );
+			$this->markTestSkipped( 'WP_User_Query meta queries not supported in this environment.' );
+		}
+
+		$found = SSO::get_user_by_wpcom_id( 44444 );
+
+		$this->assertNotNull( $found );
+		$this->assertEquals( $user_id, $found->ID );
+
+		wp_delete_user( $user_id );
 	}
 
 	// ──────────────────────────────────────────────
@@ -561,5 +632,389 @@ class SSO_Test extends BaseTestCase {
 	 */
 	public function test_broker_cookie_constant_defined() {
 		$this->assertSame( 'jetpack_sso_broker', SSO::BROKER_COOKIE );
+	}
+
+	// ──────────────────────────────────────────────
+	// verify_user_token
+	// ──────────────────────────────────────────────
+
+	/**
+	 * Test verify_user_token returns true when user_token_valid is true and user matches.
+	 */
+	public function test_verify_user_token_fast_path_valid() {
+		$tokens    = $this->createMock( Tokens::class );
+		$user_data = (object) array( 'user_token_valid' => true );
+
+		$result = $this->invoke_private_method(
+			$this->sso,
+			'verify_user_token',
+			array( 42, $user_data, $tokens, 42 )
+		);
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test verify_user_token disconnects and returns false when user_token_valid is false.
+	 */
+	public function test_verify_user_token_fast_path_invalid() {
+		$tokens = $this->createMock( Tokens::class );
+		$tokens->expects( $this->once() )
+			->method( 'disconnect_user' )
+			->with( 42 );
+
+		$user_data = (object) array( 'user_token_valid' => false );
+
+		$result = $this->invoke_private_method(
+			$this->sso,
+			'verify_user_token',
+			array( 42, $user_data, $tokens, 42 )
+		);
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test verify_user_token ignores user_token_valid when the token was for a different user.
+	 */
+	public function test_verify_user_token_user_mismatch_forces_fallback() {
+		$tokens = $this->createMock( Tokens::class );
+		$tokens->expects( $this->never() )
+			->method( 'disconnect_user' );
+		$tokens->expects( $this->once() )
+			->method( 'validate' )
+			->with( 42 )
+			->willReturn(
+				array(
+					'user_token_is_healthy' => true,
+					'blog_token_is_healthy' => true,
+				)
+			);
+
+		// user_token_valid is false, but it was validated for user 99, not user 42.
+		$user_data = (object) array( 'user_token_valid' => false );
+
+		$result = $this->invoke_private_method(
+			$this->sso,
+			'verify_user_token',
+			array( 42, $user_data, $tokens, 99 )
+		);
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test verify_user_token falls back to Tokens::validate when no user_token_valid in response.
+	 */
+	public function test_verify_user_token_fallback_healthy() {
+		$tokens = $this->createMock( Tokens::class );
+		$tokens->expects( $this->never() )
+			->method( 'disconnect_user' );
+		$tokens->expects( $this->once() )
+			->method( 'validate' )
+			->with( 42 )
+			->willReturn(
+				array(
+					'user_token_is_healthy' => true,
+					'blog_token_is_healthy' => true,
+				)
+			);
+
+		$user_data = (object) array( 'ID' => 123 );
+
+		$result = $this->invoke_private_method(
+			$this->sso,
+			'verify_user_token',
+			array( 42, $user_data, $tokens, 0 )
+		);
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test verify_user_token fallback disconnects when token is unhealthy.
+	 */
+	public function test_verify_user_token_fallback_unhealthy() {
+		$tokens = $this->createMock( Tokens::class );
+		$tokens->expects( $this->once() )
+			->method( 'disconnect_user' )
+			->with( 42 );
+		$tokens->expects( $this->once() )
+			->method( 'validate' )
+			->with( 42 )
+			->willReturn(
+				array(
+					'user_token_is_healthy' => false,
+					'blog_token_is_healthy' => true,
+				)
+			);
+
+		$user_data = (object) array( 'ID' => 123 );
+
+		$result = $this->invoke_private_method(
+			$this->sso,
+			'verify_user_token',
+			array( 42, $user_data, $tokens, 0 )
+		);
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test verify_user_token fails open when Tokens::validate returns false (network error).
+	 */
+	public function test_verify_user_token_fail_open_on_error() {
+		$tokens = $this->createMock( Tokens::class );
+		$tokens->expects( $this->never() )
+			->method( 'disconnect_user' );
+		$tokens->expects( $this->once() )
+			->method( 'validate' )
+			->with( 42 )
+			->willReturn( false );
+
+		$user_data = (object) array( 'ID' => 123 );
+
+		$result = $this->invoke_private_method(
+			$this->sso,
+			'verify_user_token',
+			array( 42, $user_data, $tokens, 0 )
+		);
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test verify_user_token fails open when Tokens::validate returns WP_Error.
+	 */
+	public function test_verify_user_token_fail_open_on_wp_error() {
+		$tokens = $this->createMock( Tokens::class );
+		$tokens->expects( $this->never() )
+			->method( 'disconnect_user' );
+		$tokens->expects( $this->once() )
+			->method( 'validate' )
+			->with( 42 )
+			->willReturn( new WP_Error( 'site_not_registered', 'Site not registered.' ) );
+
+		$user_data = (object) array( 'ID' => 123 );
+
+		$result = $this->invoke_private_method(
+			$this->sso,
+			'verify_user_token',
+			array( 42, $user_data, $tokens, 0 )
+		);
+
+		$this->assertTrue( $result );
+	}
+
+	// ──────────────────────────────────────────────
+	// set_wpcom_user_id_meta
+	// ──────────────────────────────────────────────
+
+	/**
+	 * Test set_wpcom_user_id_meta sets meta on the target user.
+	 */
+	public function test_set_wpcom_user_id_meta_sets_meta() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'sso_meta_test_user',
+				'user_pass'  => 'password',
+			)
+		);
+
+		$this->invoke_private_static_method(
+			SSO::class,
+			'set_wpcom_user_id_meta',
+			array( $user_id, 12345 )
+		);
+
+		$this->assertSame( '12345', get_user_meta( $user_id, 'wpcom_user_id', true ) );
+
+		wp_delete_user( $user_id );
+	}
+
+	/**
+	 * Test set_wpcom_user_id_meta removes stale meta from other users.
+	 *
+	 * Note: WP_User_Query meta queries require a full WordPress database.
+	 * This test is skipped in WorDBless environments.
+	 *
+	 * @requires function WP_User_Query::prepare_query
+	 */
+	#[RequiresMethod( \WP_User_Query::class, 'prepare_query' )]
+	public function test_set_wpcom_user_id_meta_removes_stale_meta() {
+		$user_a = wp_insert_user(
+			array(
+				'user_login' => 'sso_meta_user_a',
+				'user_pass'  => 'password',
+			)
+		);
+		$user_b = wp_insert_user(
+			array(
+				'user_login' => 'sso_meta_user_b',
+				'user_pass'  => 'password',
+			)
+		);
+
+		update_user_meta( $user_b, 'wpcom_user_id', 12345 );
+
+		// Verify WP_User_Query meta queries work in this environment.
+		$probe = new \WP_User_Query(
+			array(
+				'meta_key'   => 'wpcom_user_id',
+				'meta_value' => 12345,
+				'fields'     => 'ID',
+			)
+		);
+		if ( empty( $probe->get_results() ) ) {
+			$this->markTestSkipped( 'WP_User_Query meta queries not supported in this environment.' );
+		}
+
+		$this->invoke_private_static_method(
+			SSO::class,
+			'set_wpcom_user_id_meta',
+			array( $user_a, 12345 )
+		);
+
+		$this->assertSame( '12345', get_user_meta( $user_a, 'wpcom_user_id', true ) );
+		$this->assertEmpty( get_user_meta( $user_b, 'wpcom_user_id', true ) );
+
+		wp_delete_user( $user_a );
+		wp_delete_user( $user_b );
+	}
+
+	/**
+	 * Test set_wpcom_user_id_meta handles multiple stale users.
+	 *
+	 * @requires function WP_User_Query::prepare_query
+	 */
+	#[RequiresMethod( \WP_User_Query::class, 'prepare_query' )]
+	public function test_set_wpcom_user_id_meta_removes_from_multiple_stale_users() {
+		$user_a = wp_insert_user(
+			array(
+				'user_login' => 'sso_multi_a',
+				'user_pass'  => 'password',
+			)
+		);
+		$user_b = wp_insert_user(
+			array(
+				'user_login' => 'sso_multi_b',
+				'user_pass'  => 'password',
+			)
+		);
+		$user_c = wp_insert_user(
+			array(
+				'user_login' => 'sso_multi_c',
+				'user_pass'  => 'password',
+			)
+		);
+
+		update_user_meta( $user_b, 'wpcom_user_id', 99999 );
+		update_user_meta( $user_c, 'wpcom_user_id', 99999 );
+
+		$probe = new \WP_User_Query(
+			array(
+				'meta_key'   => 'wpcom_user_id',
+				'meta_value' => 99999,
+				'fields'     => 'ID',
+			)
+		);
+		if ( empty( $probe->get_results() ) ) {
+			$this->markTestSkipped( 'WP_User_Query meta queries not supported in this environment.' );
+		}
+
+		$this->invoke_private_static_method(
+			SSO::class,
+			'set_wpcom_user_id_meta',
+			array( $user_a, 99999 )
+		);
+
+		$this->assertSame( '99999', get_user_meta( $user_a, 'wpcom_user_id', true ) );
+		$this->assertEmpty( get_user_meta( $user_b, 'wpcom_user_id', true ) );
+		$this->assertEmpty( get_user_meta( $user_c, 'wpcom_user_id', true ) );
+
+		wp_delete_user( $user_a );
+		wp_delete_user( $user_b );
+		wp_delete_user( $user_c );
+	}
+
+	/**
+	 * Test set_wpcom_user_id_meta does not remove meta from the target user when re-setting.
+	 */
+	public function test_set_wpcom_user_id_meta_preserves_target_user_meta() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'sso_preserve_test',
+				'user_pass'  => 'password',
+			)
+		);
+
+		update_user_meta( $user_id, 'wpcom_user_id', 55555 );
+
+		// Re-set the same meta on the same user.
+		$this->invoke_private_static_method(
+			SSO::class,
+			'set_wpcom_user_id_meta',
+			array( $user_id, 55555 )
+		);
+
+		$this->assertSame( '55555', get_user_meta( $user_id, 'wpcom_user_id', true ) );
+
+		wp_delete_user( $user_id );
+	}
+
+	// ──────────────────────────────────────────────
+	// get_signed_user_token_for_wpcom_id
+	// ──────────────────────────────────────────────
+
+	/**
+	 * Test get_signed_user_token_for_wpcom_id returns empty when wpcom_user_id is 0.
+	 */
+	public function test_get_signed_token_returns_empty_for_zero_wpcom_id() {
+		$result = $this->invoke_private_method(
+			$this->sso,
+			'get_signed_user_token_for_wpcom_id',
+			array( 0 )
+		);
+
+		$this->assertSame( '', $result['signed_token'] );
+		$this->assertSame( 0, $result['local_user_id'] );
+	}
+
+	/**
+	 * Test get_signed_user_token_for_wpcom_id returns empty when no local user has the meta.
+	 */
+	public function test_get_signed_token_returns_empty_when_no_user_found() {
+		$result = $this->invoke_private_method(
+			$this->sso,
+			'get_signed_user_token_for_wpcom_id',
+			array( 999999 )
+		);
+
+		$this->assertSame( '', $result['signed_token'] );
+		$this->assertSame( 0, $result['local_user_id'] );
+	}
+
+	/**
+	 * Test get_signed_user_token_for_wpcom_id returns empty when user exists but has no token.
+	 */
+	public function test_get_signed_token_returns_empty_when_no_token() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'sso_no_token_user',
+				'user_pass'  => 'password',
+			)
+		);
+		update_user_meta( $user_id, 'wpcom_user_id', 77777 );
+
+		$result = $this->invoke_private_method(
+			$this->sso,
+			'get_signed_user_token_for_wpcom_id',
+			array( 77777 )
+		);
+
+		$this->assertSame( '', $result['signed_token'] );
+		$this->assertSame( 0, $result['local_user_id'] );
+
+		wp_delete_user( $user_id );
 	}
 }

--- a/projects/packages/connection/tests/php/sso/SSO_Test.php
+++ b/projects/packages/connection/tests/php/sso/SSO_Test.php
@@ -265,7 +265,7 @@ class SSO_Test extends BaseTestCase {
 			array( $user_id, 12345 )
 		);
 
-		$this->assertSame( '12345', get_user_meta( $user_id, 'wpcom_user_id', true ) );
+		$this->assertEquals( 12345, get_user_meta( $user_id, 'wpcom_user_id', true ) );
 
 		wp_delete_user( $user_id );
 	}
@@ -313,7 +313,7 @@ class SSO_Test extends BaseTestCase {
 			array( $user_a, 12345 )
 		);
 
-		$this->assertSame( '12345', get_user_meta( $user_a, 'wpcom_user_id', true ) );
+		$this->assertEquals( 12345, get_user_meta( $user_a, 'wpcom_user_id', true ) );
 		$this->assertEmpty( get_user_meta( $user_b, 'wpcom_user_id', true ) );
 
 		wp_delete_user( $user_a );
@@ -366,7 +366,7 @@ class SSO_Test extends BaseTestCase {
 			array( $user_a, 99999 )
 		);
 
-		$this->assertSame( '99999', get_user_meta( $user_a, 'wpcom_user_id', true ) );
+		$this->assertEquals( 99999, get_user_meta( $user_a, 'wpcom_user_id', true ) );
 		$this->assertEmpty( get_user_meta( $user_b, 'wpcom_user_id', true ) );
 		$this->assertEmpty( get_user_meta( $user_c, 'wpcom_user_id', true ) );
 
@@ -395,7 +395,7 @@ class SSO_Test extends BaseTestCase {
 			array( $user_id, 55555 )
 		);
 
-		$this->assertSame( '55555', get_user_meta( $user_id, 'wpcom_user_id', true ) );
+		$this->assertEquals( 55555, get_user_meta( $user_id, 'wpcom_user_id', true ) );
 
 		wp_delete_user( $user_id );
 	}

--- a/projects/packages/connection/tests/php/sso/SSO_Test.php
+++ b/projects/packages/connection/tests/php/sso/SSO_Test.php
@@ -1,0 +1,502 @@
+<?php
+/**
+ * SSO functionality testing.
+ *
+ * @package automattic/jetpack-connection
+ */
+
+namespace Automattic\Jetpack\Connection\SSO;
+
+use Automattic\Jetpack\Connection\SSO;
+use Automattic\Jetpack\Connection\Tokens;
+use PHPUnit\Framework\Attributes\RequiresMethod;
+use WorDBless\BaseTestCase;
+
+/**
+ * SSO functionality testing.
+ */
+class SSO_Test extends BaseTestCase {
+
+	/**
+	 * SSO instance created via reflection (bypasses private constructor).
+	 *
+	 * @var SSO
+	 */
+	private $sso;
+
+	/**
+	 * Set up.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$reflection = new \ReflectionClass( SSO::class );
+		$this->sso  = $reflection->newInstanceWithoutConstructor();
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down() {
+		parent::tear_down();
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * Invoke a private method on an object via reflection.
+	 *
+	 * @param object $object     The object.
+	 * @param string $method     The method name.
+	 * @param array  $parameters The parameters.
+	 * @return mixed
+	 */
+	private function invoke_private_method( $object, $method, $parameters = array() ) {
+		$reflection = new \ReflectionClass( get_class( $object ) );
+		$method     = $reflection->getMethod( $method );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+		return $method->invokeArgs( $object, $parameters );
+	}
+
+	/**
+	 * Invoke a private static method via reflection.
+	 *
+	 * @param string $class      The class name.
+	 * @param string $method     The method name.
+	 * @param array  $parameters The parameters.
+	 * @return mixed
+	 */
+	private function invoke_private_static_method( $class, $method, $parameters = array() ) {
+		$reflection = new \ReflectionClass( $class );
+		$method     = $reflection->getMethod( $method );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+		return $method->invokeArgs( null, $parameters );
+	}
+
+	// ---- verify_user_token tests ----
+
+	/**
+	 * Test verify_user_token returns true when user_token_valid is true and user matches.
+	 */
+	public function test_verify_user_token_fast_path_valid() {
+		$tokens    = $this->createMock( Tokens::class );
+		$user_data = (object) array( 'user_token_valid' => true );
+
+		$result = $this->invoke_private_method(
+			$this->sso,
+			'verify_user_token',
+			array( 42, $user_data, $tokens, 42 )
+		);
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test verify_user_token disconnects and returns false when user_token_valid is false.
+	 */
+	public function test_verify_user_token_fast_path_invalid() {
+		$tokens = $this->createMock( Tokens::class );
+		$tokens->expects( $this->once() )
+			->method( 'disconnect_user' )
+			->with( 42 );
+
+		$user_data = (object) array( 'user_token_valid' => false );
+
+		$result = $this->invoke_private_method(
+			$this->sso,
+			'verify_user_token',
+			array( 42, $user_data, $tokens, 42 )
+		);
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test verify_user_token ignores user_token_valid when the token was for a different user.
+	 */
+	public function test_verify_user_token_user_mismatch_forces_fallback() {
+		$tokens = $this->createMock( Tokens::class );
+		$tokens->expects( $this->never() )
+			->method( 'disconnect_user' );
+		$tokens->expects( $this->once() )
+			->method( 'validate' )
+			->with( 42 )
+			->willReturn(
+				array(
+					'user_token_is_healthy' => true,
+					'blog_token_is_healthy' => true,
+				)
+			);
+
+		// user_token_valid is false, but it was validated for user 99, not user 42.
+		$user_data = (object) array( 'user_token_valid' => false );
+
+		$result = $this->invoke_private_method(
+			$this->sso,
+			'verify_user_token',
+			array( 42, $user_data, $tokens, 99 )
+		);
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test verify_user_token falls back to Tokens::validate when no user_token_valid in response.
+	 */
+	public function test_verify_user_token_fallback_healthy() {
+		$tokens = $this->createMock( Tokens::class );
+		$tokens->expects( $this->never() )
+			->method( 'disconnect_user' );
+		$tokens->expects( $this->once() )
+			->method( 'validate' )
+			->with( 42 )
+			->willReturn(
+				array(
+					'user_token_is_healthy' => true,
+					'blog_token_is_healthy' => true,
+				)
+			);
+
+		$user_data = (object) array( 'ID' => 123 );
+
+		$result = $this->invoke_private_method(
+			$this->sso,
+			'verify_user_token',
+			array( 42, $user_data, $tokens, 0 )
+		);
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test verify_user_token fallback disconnects when token is unhealthy.
+	 */
+	public function test_verify_user_token_fallback_unhealthy() {
+		$tokens = $this->createMock( Tokens::class );
+		$tokens->expects( $this->once() )
+			->method( 'disconnect_user' )
+			->with( 42 );
+		$tokens->expects( $this->once() )
+			->method( 'validate' )
+			->with( 42 )
+			->willReturn(
+				array(
+					'user_token_is_healthy' => false,
+					'blog_token_is_healthy' => true,
+				)
+			);
+
+		$user_data = (object) array( 'ID' => 123 );
+
+		$result = $this->invoke_private_method(
+			$this->sso,
+			'verify_user_token',
+			array( 42, $user_data, $tokens, 0 )
+		);
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test verify_user_token fails open when Tokens::validate returns false (network error).
+	 */
+	public function test_verify_user_token_fail_open_on_error() {
+		$tokens = $this->createMock( Tokens::class );
+		$tokens->expects( $this->never() )
+			->method( 'disconnect_user' );
+		$tokens->expects( $this->once() )
+			->method( 'validate' )
+			->with( 42 )
+			->willReturn( false );
+
+		$user_data = (object) array( 'ID' => 123 );
+
+		$result = $this->invoke_private_method(
+			$this->sso,
+			'verify_user_token',
+			array( 42, $user_data, $tokens, 0 )
+		);
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test verify_user_token fails open when Tokens::validate returns WP_Error.
+	 */
+	public function test_verify_user_token_fail_open_on_wp_error() {
+		$tokens = $this->createMock( Tokens::class );
+		$tokens->expects( $this->never() )
+			->method( 'disconnect_user' );
+		$tokens->expects( $this->once() )
+			->method( 'validate' )
+			->with( 42 )
+			->willReturn( new \WP_Error( 'site_not_registered', 'Site not registered.' ) );
+
+		$user_data = (object) array( 'ID' => 123 );
+
+		$result = $this->invoke_private_method(
+			$this->sso,
+			'verify_user_token',
+			array( 42, $user_data, $tokens, 0 )
+		);
+
+		$this->assertTrue( $result );
+	}
+
+	// ---- set_wpcom_user_id_meta tests ----
+
+	/**
+	 * Test set_wpcom_user_id_meta sets meta on the target user.
+	 */
+	public function test_set_wpcom_user_id_meta_sets_meta() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'sso_meta_test_user',
+				'user_pass'  => 'password',
+			)
+		);
+
+		$this->invoke_private_static_method(
+			SSO::class,
+			'set_wpcom_user_id_meta',
+			array( $user_id, 12345 )
+		);
+
+		$this->assertSame( '12345', get_user_meta( $user_id, 'wpcom_user_id', true ) );
+
+		wp_delete_user( $user_id );
+	}
+
+	/**
+	 * Test set_wpcom_user_id_meta removes stale meta from other users.
+	 *
+	 * Note: WP_User_Query meta queries require a full WordPress database.
+	 * This test is skipped in WorDBless environments.
+	 *
+	 * @requires function WP_User_Query::prepare_query
+	 */
+	#[RequiresMethod( \WP_User_Query::class, 'prepare_query' )]
+	public function test_set_wpcom_user_id_meta_removes_stale_meta() {
+		$user_a = wp_insert_user(
+			array(
+				'user_login' => 'sso_meta_user_a',
+				'user_pass'  => 'password',
+			)
+		);
+		$user_b = wp_insert_user(
+			array(
+				'user_login' => 'sso_meta_user_b',
+				'user_pass'  => 'password',
+			)
+		);
+
+		update_user_meta( $user_b, 'wpcom_user_id', 12345 );
+
+		// Verify WP_User_Query meta queries work in this environment.
+		$probe = new \WP_User_Query(
+			array(
+				'meta_key'   => 'wpcom_user_id',
+				'meta_value' => 12345,
+				'fields'     => 'ID',
+			)
+		);
+		if ( empty( $probe->get_results() ) ) {
+			$this->markTestSkipped( 'WP_User_Query meta queries not supported in this environment.' );
+		}
+
+		$this->invoke_private_static_method(
+			SSO::class,
+			'set_wpcom_user_id_meta',
+			array( $user_a, 12345 )
+		);
+
+		$this->assertSame( '12345', get_user_meta( $user_a, 'wpcom_user_id', true ) );
+		$this->assertEmpty( get_user_meta( $user_b, 'wpcom_user_id', true ) );
+
+		wp_delete_user( $user_a );
+		wp_delete_user( $user_b );
+	}
+
+	/**
+	 * Test set_wpcom_user_id_meta handles multiple stale users.
+	 *
+	 * @requires function WP_User_Query::prepare_query
+	 */
+	#[RequiresMethod( \WP_User_Query::class, 'prepare_query' )]
+	public function test_set_wpcom_user_id_meta_removes_from_multiple_stale_users() {
+		$user_a = wp_insert_user(
+			array(
+				'user_login' => 'sso_multi_a',
+				'user_pass'  => 'password',
+			)
+		);
+		$user_b = wp_insert_user(
+			array(
+				'user_login' => 'sso_multi_b',
+				'user_pass'  => 'password',
+			)
+		);
+		$user_c = wp_insert_user(
+			array(
+				'user_login' => 'sso_multi_c',
+				'user_pass'  => 'password',
+			)
+		);
+
+		update_user_meta( $user_b, 'wpcom_user_id', 99999 );
+		update_user_meta( $user_c, 'wpcom_user_id', 99999 );
+
+		$probe = new \WP_User_Query(
+			array(
+				'meta_key'   => 'wpcom_user_id',
+				'meta_value' => 99999,
+				'fields'     => 'ID',
+			)
+		);
+		if ( empty( $probe->get_results() ) ) {
+			$this->markTestSkipped( 'WP_User_Query meta queries not supported in this environment.' );
+		}
+
+		$this->invoke_private_static_method(
+			SSO::class,
+			'set_wpcom_user_id_meta',
+			array( $user_a, 99999 )
+		);
+
+		$this->assertSame( '99999', get_user_meta( $user_a, 'wpcom_user_id', true ) );
+		$this->assertEmpty( get_user_meta( $user_b, 'wpcom_user_id', true ) );
+		$this->assertEmpty( get_user_meta( $user_c, 'wpcom_user_id', true ) );
+
+		wp_delete_user( $user_a );
+		wp_delete_user( $user_b );
+		wp_delete_user( $user_c );
+	}
+
+	/**
+	 * Test set_wpcom_user_id_meta does not remove meta from the target user when re-setting.
+	 */
+	public function test_set_wpcom_user_id_meta_preserves_target_user_meta() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'sso_preserve_test',
+				'user_pass'  => 'password',
+			)
+		);
+
+		update_user_meta( $user_id, 'wpcom_user_id', 55555 );
+
+		// Re-set the same meta on the same user.
+		$this->invoke_private_static_method(
+			SSO::class,
+			'set_wpcom_user_id_meta',
+			array( $user_id, 55555 )
+		);
+
+		$this->assertSame( '55555', get_user_meta( $user_id, 'wpcom_user_id', true ) );
+
+		wp_delete_user( $user_id );
+	}
+
+	// ---- get_signed_user_token_for_wpcom_id tests ----
+
+	/**
+	 * Test get_signed_user_token_for_wpcom_id returns empty when wpcom_user_id is 0.
+	 */
+	public function test_get_signed_token_returns_empty_for_zero_wpcom_id() {
+		$result = $this->invoke_private_method(
+			$this->sso,
+			'get_signed_user_token_for_wpcom_id',
+			array( 0 )
+		);
+
+		$this->assertSame( '', $result['signed_token'] );
+		$this->assertSame( 0, $result['local_user_id'] );
+	}
+
+	/**
+	 * Test get_signed_user_token_for_wpcom_id returns empty when no local user has the meta.
+	 */
+	public function test_get_signed_token_returns_empty_when_no_user_found() {
+		$result = $this->invoke_private_method(
+			$this->sso,
+			'get_signed_user_token_for_wpcom_id',
+			array( 999999 )
+		);
+
+		$this->assertSame( '', $result['signed_token'] );
+		$this->assertSame( 0, $result['local_user_id'] );
+	}
+
+	/**
+	 * Test get_signed_user_token_for_wpcom_id returns empty when user exists but has no token.
+	 */
+	public function test_get_signed_token_returns_empty_when_no_token() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'sso_no_token_user',
+				'user_pass'  => 'password',
+			)
+		);
+		update_user_meta( $user_id, 'wpcom_user_id', 77777 );
+
+		$result = $this->invoke_private_method(
+			$this->sso,
+			'get_signed_user_token_for_wpcom_id',
+			array( 77777 )
+		);
+
+		$this->assertSame( '', $result['signed_token'] );
+		$this->assertSame( 0, $result['local_user_id'] );
+
+		wp_delete_user( $user_id );
+	}
+
+	// ---- get_user_by_wpcom_id tests ----
+
+	/**
+	 * Test get_user_by_wpcom_id returns the correct user.
+	 *
+	 * @requires function WP_User_Query::prepare_query
+	 */
+	#[RequiresMethod( \WP_User_Query::class, 'prepare_query' )]
+	public function test_get_user_by_wpcom_id_returns_correct_user() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'sso_wpcom_lookup',
+				'user_pass'  => 'password',
+			)
+		);
+		update_user_meta( $user_id, 'wpcom_user_id', 44444 );
+
+		$probe = new \WP_User_Query(
+			array(
+				'meta_key'   => 'wpcom_user_id',
+				'meta_value' => 44444,
+				'number'     => 1,
+			)
+		);
+		if ( empty( $probe->get_results() ) ) {
+			wp_delete_user( $user_id );
+			$this->markTestSkipped( 'WP_User_Query meta queries not supported in this environment.' );
+		}
+
+		$found = SSO::get_user_by_wpcom_id( 44444 );
+
+		$this->assertNotNull( $found );
+		$this->assertEquals( $user_id, $found->ID );
+
+		wp_delete_user( $user_id );
+	}
+
+	/**
+	 * Test get_user_by_wpcom_id returns null when no user matches.
+	 */
+	public function test_get_user_by_wpcom_id_returns_null_when_not_found() {
+		$found = SSO::get_user_by_wpcom_id( 11111 );
+
+		$this->assertNull( $found );
+	}
+}


### PR DESCRIPTION
Closes CONNECT-199

## Proposed changes

* **SSO: Validate user tokens during login to detect stale tokens after database migration.**

After a database migration, user tokens can remain in the local database while no longer being valid on the WP.com side. Previously, `is_user_connected()` only checked for local token existence and SSO login would silently proceed with a broken token. The connection owner's stale token would eventually be caught by the Error_Handler (via incoming request signature failures), but non-owner user tokens — primarily used for SSO — were never validated.

  This PR adds token verification to the SSO login flow via a single **fast path**: if the local user is known by `wpcom_user_id` meta, their token is signed and sent with the `jetpack.sso.validateResult` call. WP.com validates it and returns `user_token_valid` in the response. This costs zero extra HTTP calls.

  If a token is found to be invalid, it is removed locally and the user is redirected to the authorization flow to obtain a fresh token. If verification cannot be completed for the resolved user (no `wpcom_user_id` meta yet, or a different local user was resolved than the one whose token was sent), login proceeds normally — the `wpcom_user_id` meta set during this login means the token is validated via the fast path on the next SSO login.

  > **Note:** An earlier revision of this PR also included a fallback path that called the `jetpack-token-health` API after user resolution when the fast path couldn't run. That fallback has been intentionally removed for now — see the note below on the excluded scenario and the Error_Handler limitation.

* **SSO: Enforce unique `wpcom_user_id` meta mapping.**

  Replaces direct `update_user_meta` calls with a new `set_wpcom_user_id_meta()` helper that removes stale `wpcom_user_id` meta from other users before setting it on the correct one. This ensures a 1:1 mapping between WP.com accounts and local users, preventing the token lookup from returning the wrong user on subsequent SSO logins. Includes targeted cache invalidation via `clean_user_cache()`.

### Excluded scenario / follow-up

The fast path fully covers the core use case (user has `wpcom_user_id` meta + stale token from a DB migration). The one scenario left at the pre-PR baseline is: a user connected via the **authorization flow** (never SSO, so no `wpcom_user_id` meta) whose token is **stale** and who is doing SSO **for the first time**. Their stale token isn't caught on that first SSO login; the meta gets set during it, so the **second** SSO login catches it via the fast path. This is the same behavior as before this PR existed — no regression, just a deferred improvement.

This fallback was removed (rather than shipped) because validating the token directly via `jetpack-token-health` in that scenario can surface a Connection error in the dashboard through the Error_Handler. The Error_Handler currently can't differentiate users and only offers "reconnect the site", which on large multi-admin sites (VIP, Newspack) has caused a secondary admin to disconnect everyone while trying to fix their own connection. Re-enabling the fallback should be done only after the Error_Handler can scope errors per-user. See the in-PR note for details.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?

No new data is tracked. The existing `sso_user_logged_in` tracking event already includes `user_connected` which now accurately reflects post-validation status.

## Testing instructions

### Scenario 1: Normal SSO login (valid token, meta exists)
1. Set up a site with SSO enabled and a user connected to WP.com
2. Ensure the user has `wpcom_user_id` in their user meta (had previously logged in via SSO)
3. Log in via SSO
4. Verify the user lands in wp-admin without any extra prompts
5. Confirm no re-authorization redirect occurs

### Scenario 2: Stale token detection (simulated migration)
1. Connect a non-owner user to WP.com via SSO (so `wpcom_user_id` meta is set)
2. Manually invalidate their user token (e.g., modify the token value using Debug Tools plugin / Broken token tool)
3. Log in via SSO as that user
4. Verify the stale token is detected: user should be redirected to the authorization flow
5. After re-authorization, confirm the user has a valid token and can log in normally

### Scenario 3: First SSO login without `wpcom_user_id` meta
1. Connect a user via the Jetpack authorization flow (not SSO)
2. Verify the user has a token but no `wpcom_user_id` meta (CLI)
3. Log in via SSO for the first time
4. Verify the user logs in successfully (no extra verification call is made)
5. Verify `wpcom_user_id` meta is now set on the user, so the next SSO login uses the fast path

### Scenario 4: Meta deduplication
1. Manually set `wpcom_user_id` meta with the same WP.com ID on two different local users
2. Log in via SSO
3. After login, verify only the resolved user has the `wpcom_user_id` meta; the other user's stale meta should be removed
