### PR TITLE
Email blocks: Apply horizontal padding from email_attrs

### DIFF
--- a/projects/packages/forms/changelog/fix-email-block-horizontal-padding
+++ b/projects/packages/forms/changelog/fix-email-block-horizontal-padding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Email rendering: Apply horizontal padding from email_attrs to contact form fallback.

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -788,7 +788,18 @@ class Contact_Form_Block {
 	public static function render_email( $block_content, array $parsed_block, $rendering_context ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$atts = $parsed_block['attrs'] ?? array();
 
-		return self::render_fallback( $atts );
+		$html = self::render_fallback( $atts );
+
+		// Apply horizontal padding from distributed root padding
+		$email_attrs = $parsed_block['email_attrs'] ?? array();
+		if ( ! empty( $email_attrs ) && class_exists( '\WP_Style_Engine' ) ) {
+			$padding_style = \WP_Style_Engine::compile_css( array_intersect_key( $email_attrs, array_flip( array( 'padding-left', 'padding-right' ) ) ), '' ) ?? '';
+			if ( ! empty( $padding_style ) ) {
+				$html = '<div style="' . esc_attr( $padding_style ) . '">' . $html . '</div>';
+			}
+		}
+
+		return $html;
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -446,6 +446,74 @@ class Contact_Form_Block_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test render_email applies horizontal padding from email_attrs.
+	 */
+	public function test_render_email_with_email_attrs_padding() {
+		// Create a test post to get a valid permalink
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Test Post',
+				'post_content' => 'Test content',
+				'post_status'  => 'publish',
+			)
+		);
+		global $post;
+		$post = get_post( $post_id );
+
+		$parsed_block = array(
+			'attrs'       => array( 'className' => 'test-class' ),
+			'email_attrs' => array(
+				'padding-left'  => '20px',
+				'padding-right' => '20px',
+			),
+		);
+
+		$mock_context = (object) array();
+
+		$result = Contact_Form_Block::render_email( '', $parsed_block, $mock_context );
+
+		// Should wrap output with horizontal padding
+		$this->assertStringContainsString( 'padding-left', $result );
+		$this->assertStringContainsString( 'padding-right', $result );
+		$this->assertStringContainsString( '20px', $result );
+		$this->assertStringContainsString( 'Submit a form.', $result );
+
+		// Cleanup
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * Test render_email without email_attrs does not add padding wrapper.
+	 */
+	public function test_render_email_without_email_attrs_no_padding() {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Test Post',
+				'post_content' => 'Test content',
+				'post_status'  => 'publish',
+			)
+		);
+		global $post;
+		$post = get_post( $post_id );
+
+		$parsed_block = array(
+			'attrs' => array( 'className' => 'test-class' ),
+		);
+
+		$mock_context = (object) array();
+
+		$result = Contact_Form_Block::render_email( '', $parsed_block, $mock_context );
+
+		// Should not contain padding styles when no email_attrs
+		$this->assertStringNotContainsString( 'padding-left', $result );
+		$this->assertStringNotContainsString( 'padding-right', $result );
+		$this->assertStringContainsString( 'Submit a form.', $result );
+
+		// Cleanup
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
 	 * Test render_email with empty attrs.
 	 */
 	public function test_render_email_with_empty_attrs() {

--- a/projects/plugins/jetpack/changelog/fix-email-block-horizontal-padding
+++ b/projects/plugins/jetpack/changelog/fix-email-block-horizontal-padding
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Email blocks: Apply horizontal padding from email_attrs for tiled-gallery, button, and subscriptions blocks.
+Email blocks: Apply horizontal padding from email_attrs for tiled-gallery, button, subscriptions, and payment-buttons blocks.

--- a/projects/plugins/jetpack/changelog/fix-email-block-horizontal-padding
+++ b/projects/plugins/jetpack/changelog/fix-email-block-horizontal-padding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Email blocks: Apply horizontal padding from email_attrs for tiled-gallery, button, and subscriptions blocks.

--- a/projects/plugins/jetpack/extensions/blocks/button/button.php
+++ b/projects/plugins/jetpack/extensions/blocks/button/button.php
@@ -148,7 +148,18 @@ function render_email( $block_content, array $parsed_block, $rendering_context )
 	// Use WooCommerce's core button renderer
 	$woo_button_renderer = new \Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Button();
 
-	return $woo_button_renderer->render( $block_content, $mock_parsed_block, $rendering_context );
+	$html = $woo_button_renderer->render( $block_content, $mock_parsed_block, $rendering_context );
+
+	// Wrap in div with horizontal padding from distributed root padding
+	$email_attrs = $parsed_block['email_attrs'] ?? array();
+	if ( ! empty( $email_attrs ) && class_exists( '\WP_Style_Engine' ) ) {
+		$padding_style = \WP_Style_Engine::compile_css( array_intersect_key( $email_attrs, array_flip( array( 'padding-left', 'padding-right' ) ) ), '' ) ?? '';
+		if ( ! empty( $padding_style ) ) {
+			$html = '<div style="' . esc_attr( $padding_style ) . '">' . $html . '</div>';
+		}
+	}
+
+	return $html;
 }
 
 /**

--- a/projects/plugins/jetpack/extensions/blocks/button/button.php
+++ b/projects/plugins/jetpack/extensions/blocks/button/button.php
@@ -11,6 +11,7 @@ namespace Automattic\Jetpack\Extensions\Button;
 
 use Automattic\Jetpack\Blocks;
 use Jetpack_Gutenberg;
+use function Automattic\Jetpack\Extensions\Shared\apply_email_horizontal_padding;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
@@ -151,15 +152,8 @@ function render_email( $block_content, array $parsed_block, $rendering_context )
 	$html = $woo_button_renderer->render( $block_content, $mock_parsed_block, $rendering_context );
 
 	// Wrap in div with horizontal padding from distributed root padding
-	$email_attrs = $parsed_block['email_attrs'] ?? array();
-	if ( ! empty( $email_attrs ) && class_exists( '\WP_Style_Engine' ) ) {
-		$padding_style = \WP_Style_Engine::compile_css( array_intersect_key( $email_attrs, array_flip( array( 'padding-left', 'padding-right' ) ) ), '' ) ?? '';
-		if ( ! empty( $padding_style ) ) {
-			$html = '<div style="' . esc_attr( $padding_style ) . '">' . $html . '</div>';
-		}
-	}
-
-	return $html;
+	require_once __DIR__ . '/../../shared/email-utils.php';
+	return apply_email_horizontal_padding( $html, $parsed_block['email_attrs'] ?? array() );
 }
 
 /**

--- a/projects/plugins/jetpack/extensions/blocks/button/button.php
+++ b/projects/plugins/jetpack/extensions/blocks/button/button.php
@@ -140,8 +140,9 @@ function render_email( $block_content, array $parsed_block, $rendering_context )
 
 	// Create a mock parsed block that WooCommerce's button renderer can handle
 	$mock_parsed_block = array(
-		'innerHTML' => $inner_html,
-		'attrs'     => $formatted_attributes,
+		'innerHTML'   => $inner_html,
+		'attrs'       => $formatted_attributes,
+		'email_attrs' => $parsed_block['email_attrs'] ?? array(),
 	);
 
 	// Use WooCommerce's core button renderer

--- a/projects/plugins/jetpack/extensions/blocks/payment-buttons/payment-buttons.php
+++ b/projects/plugins/jetpack/extensions/blocks/payment-buttons/payment-buttons.php
@@ -10,6 +10,7 @@
 namespace Automattic\Jetpack\Extensions\PaymentButtons;
 
 use Automattic\Jetpack\Blocks;
+use function Automattic\Jetpack\Extensions\Shared\apply_email_horizontal_padding;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
@@ -100,13 +101,6 @@ function render_block_email( $block_content, array $parsed_block, $rendering_con
 	$html = $flex_layout_renderer->render_inner_blocks_in_layout( $parsed_block, $rendering_context );
 
 	// Wrap in div with horizontal padding from distributed root padding
-	$email_attrs = $parsed_block['email_attrs'] ?? array();
-	if ( ! empty( $email_attrs ) && class_exists( '\WP_Style_Engine' ) ) {
-		$padding_style = \WP_Style_Engine::compile_css( array_intersect_key( $email_attrs, array_flip( array( 'padding-left', 'padding-right' ) ) ), '' ) ?? '';
-		if ( ! empty( $padding_style ) ) {
-			$html = '<div style="' . esc_attr( $padding_style ) . '">' . $html . '</div>';
-		}
-	}
-
-	return $html;
+	require_once __DIR__ . '/../../shared/email-utils.php';
+	return apply_email_horizontal_padding( $html, $parsed_block['email_attrs'] ?? array() );
 }

--- a/projects/plugins/jetpack/extensions/blocks/payment-buttons/payment-buttons.php
+++ b/projects/plugins/jetpack/extensions/blocks/payment-buttons/payment-buttons.php
@@ -97,5 +97,16 @@ function render_block_email( $block_content, array $parsed_block, $rendering_con
 	}
 
 	// We are checking for the method existence above, so we know it exists.
-	return $flex_layout_renderer->render_inner_blocks_in_layout( $parsed_block, $rendering_context );
+	$html = $flex_layout_renderer->render_inner_blocks_in_layout( $parsed_block, $rendering_context );
+
+	// Wrap in div with horizontal padding from distributed root padding
+	$email_attrs = $parsed_block['email_attrs'] ?? array();
+	if ( ! empty( $email_attrs ) && class_exists( '\WP_Style_Engine' ) ) {
+		$padding_style = \WP_Style_Engine::compile_css( array_intersect_key( $email_attrs, array_flip( array( 'padding-left', 'padding-right' ) ) ), '' ) ?? '';
+		if ( ! empty( $padding_style ) ) {
+			$html = '<div style="' . esc_attr( $padding_style ) . '">' . $html . '</div>';
+		}
+	}
+
+	return $html;
 }

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -238,15 +238,12 @@ class Tiled_Gallery {
 		}
 
 		// Get spacing from email_attrs for better consistency with core blocks
-		$email_attrs         = $parsed_block['email_attrs'] ?? array();
-		$table_margin_style  = '';
-		$table_padding_style = '';
+		$email_attrs        = $parsed_block['email_attrs'] ?? array();
+		$table_margin_style = '';
 
 		if ( ! empty( $email_attrs ) && class_exists( '\WP_Style_Engine' ) ) {
 			// Get margin for table styling
 			$table_margin_style = \WP_Style_Engine::compile_css( array_intersect_key( $email_attrs, array_flip( array( 'margin' ) ) ), '' ) ?? '';
-			// Get horizontal padding from distributed root padding
-			$table_padding_style = \WP_Style_Engine::compile_css( array_intersect_key( $email_attrs, array_flip( array( 'padding-left', 'padding-right' ) ) ), '' ) ?? '';
 		}
 
 		// Email cell padding
@@ -285,11 +282,8 @@ class Tiled_Gallery {
 		$html = \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_table_wrapper( $grid_content, $image_table_attrs );
 
 		// Wrap in div with horizontal padding — tables ignore padding in email clients
-		if ( ! empty( $table_padding_style ) ) {
-			$html = '<div style="' . esc_attr( $table_padding_style ) . '">' . $html . '</div>';
-		}
-
-		return $html;
+		require_once __DIR__ . '/../../shared/email-utils.php';
+		return \Automattic\Jetpack\Extensions\Shared\apply_email_horizontal_padding( $html, $email_attrs );
 	}
 
 	/**

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -238,12 +238,15 @@ class Tiled_Gallery {
 		}
 
 		// Get spacing from email_attrs for better consistency with core blocks
-		$email_attrs        = $parsed_block['email_attrs'] ?? array();
-		$table_margin_style = '';
+		$email_attrs         = $parsed_block['email_attrs'] ?? array();
+		$table_margin_style  = '';
+		$table_padding_style = '';
 
 		if ( ! empty( $email_attrs ) && class_exists( '\WP_Style_Engine' ) ) {
 			// Get margin for table styling
 			$table_margin_style = \WP_Style_Engine::compile_css( array_intersect_key( $email_attrs, array_flip( array( 'margin' ) ) ), '' ) ?? '';
+			// Get horizontal padding from distributed root padding
+			$table_padding_style = \WP_Style_Engine::compile_css( array_intersect_key( $email_attrs, array_flip( array( 'padding-left', 'padding-right' ) ) ), '' ) ?? '';
 		}
 
 		// Email cell padding
@@ -268,11 +271,14 @@ class Tiled_Gallery {
 		$grid_content = self::build_email_layout_content( $images, $layout_info, $email_cell_padding, $attr );
 
 		// Use Table_Wrapper_Helper for consistent email rendering
-		$table_style = sprintf( 'width: 100%%; max-width: %dpx; padding: 0; border-collapse: collapse;', $target_width );
+		$table_style = sprintf( 'width: 100%%; max-width: %dpx; border-collapse: collapse;', $target_width );
 		if ( ! empty( $table_margin_style ) ) {
 			$table_style = $table_margin_style . '; ' . $table_style;
 		} else {
 			$table_style = 'margin: 16px 0; ' . $table_style;
+		}
+		if ( ! empty( $table_padding_style ) ) {
+			$table_style .= ' ' . $table_padding_style;
 		}
 
 		$image_table_attrs = array(

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -277,15 +277,17 @@ class Tiled_Gallery {
 		} else {
 			$table_style = 'margin: 16px 0; ' . $table_style;
 		}
-		if ( ! empty( $table_padding_style ) ) {
-			$table_style .= ' ' . $table_padding_style;
-		}
 
 		$image_table_attrs = array(
 			'style' => $table_style,
 		);
 
 		$html = \Automattic\WooCommerce\EmailEditor\Integrations\Utils\Table_Wrapper_Helper::render_table_wrapper( $grid_content, $image_table_attrs );
+
+		// Wrap in div with horizontal padding — tables ignore padding in email clients
+		if ( ! empty( $table_padding_style ) ) {
+			$html = '<div style="' . esc_attr( $table_padding_style ) . '">' . $html . '</div>';
+		}
 
 		return $html;
 	}

--- a/projects/plugins/jetpack/extensions/shared/email-utils.php
+++ b/projects/plugins/jetpack/extensions/shared/email-utils.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Shared email rendering utilities for Jetpack blocks.
+ *
+ * @package automattic/jetpack
+ * @since $$next-version$$
+ */
+
+namespace Automattic\Jetpack\Extensions\Shared;
+
+/**
+ * Wrap HTML with horizontal padding from email_attrs.
+ *
+ * The email preprocessor distributes root horizontal padding to blocks via
+ * email_attrs (padding-left, padding-right). This helper wraps rendered HTML
+ * in a div that applies those values, since tables and some renderers don't
+ * handle padding from email_attrs natively.
+ *
+ * @since $$next-version$$
+ *
+ * @param string $html        The rendered HTML to wrap.
+ * @param array  $email_attrs The email_attrs from the parsed block.
+ * @return string The HTML, optionally wrapped with horizontal padding.
+ */
+function apply_email_horizontal_padding( $html, $email_attrs ) {
+	if ( empty( $email_attrs ) || ! class_exists( '\WP_Style_Engine' ) ) {
+		return $html;
+	}
+
+	$padding_style = \WP_Style_Engine::compile_css(
+		array_intersect_key( $email_attrs, array_flip( array( 'padding-left', 'padding-right' ) ) ),
+		''
+	) ?? '';
+
+	if ( ! empty( $padding_style ) ) {
+		$html = '<div style="' . esc_attr( $padding_style ) . '">' . $html . '</div>';
+	}
+
+	return $html;
+}

--- a/projects/plugins/jetpack/tests/php/extensions/shared/Email_Utils_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/shared/Email_Utils_Test.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Email Utils tests
+ *
+ * @package automattic/jetpack
+ */
+
+require_once JETPACK__PLUGIN_DIR . 'extensions/shared/email-utils.php';
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+
+/**
+ * Tests for the shared email utility functions.
+ *
+ * @covers ::Automattic\Jetpack\Extensions\Shared\apply_email_horizontal_padding
+ */
+#[CoversFunction( 'Automattic\Jetpack\Extensions\Shared\apply_email_horizontal_padding' )]
+class Email_Utils_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Test that horizontal padding is applied when email_attrs contains padding values.
+	 */
+	public function test_apply_email_horizontal_padding_with_padding() {
+		$html        = '<table><tr><td>Content</td></tr></table>';
+		$email_attrs = array(
+			'padding-left'  => '20px',
+			'padding-right' => '20px',
+		);
+
+		$result = \Automattic\Jetpack\Extensions\Shared\apply_email_horizontal_padding( $html, $email_attrs );
+
+		$this->assertStringContainsString( 'padding-left', $result );
+		$this->assertStringContainsString( 'padding-right', $result );
+		$this->assertStringContainsString( '20px', $result );
+		$this->assertStringContainsString( '<div style="', $result );
+		$this->assertStringContainsString( $html, $result );
+	}
+
+	/**
+	 * Test that HTML is returned unchanged when email_attrs is empty.
+	 */
+	public function test_apply_email_horizontal_padding_with_empty_attrs() {
+		$html = '<table><tr><td>Content</td></tr></table>';
+
+		$result = \Automattic\Jetpack\Extensions\Shared\apply_email_horizontal_padding( $html, array() );
+
+		$this->assertSame( $html, $result );
+	}
+
+	/**
+	 * Test that HTML is returned unchanged when email_attrs has no padding keys.
+	 */
+	public function test_apply_email_horizontal_padding_with_no_padding_keys() {
+		$html        = '<table><tr><td>Content</td></tr></table>';
+		$email_attrs = array(
+			'margin' => '16px 0',
+		);
+
+		$result = \Automattic\Jetpack\Extensions\Shared\apply_email_horizontal_padding( $html, $email_attrs );
+
+		$this->assertSame( $html, $result );
+	}
+
+	/**
+	 * Test that only padding-left is applied when only it is present.
+	 */
+	public function test_apply_email_horizontal_padding_with_only_left() {
+		$html        = '<div>Content</div>';
+		$email_attrs = array(
+			'padding-left' => '15px',
+		);
+
+		$result = \Automattic\Jetpack\Extensions\Shared\apply_email_horizontal_padding( $html, $email_attrs );
+
+		$this->assertStringContainsString( 'padding-left', $result );
+		$this->assertStringNotContainsString( 'padding-right', $result );
+		$this->assertStringContainsString( '<div style="', $result );
+	}
+}


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/NL-518/follow-up-on-jetpack-email-block-padding-support

## Proposed changes

Several Jetpack blocks were not reading distributed horizontal root padding from `email_attrs` during email rendering (from [woocommerce/woocommerce#63359](https://github.com/woocommerce/woocommerce/pull/63359)). This PR fixes the following blocks:

* **Tiled Gallery** — Now extracts `padding-left`/`padding-right` from `email_attrs` and wraps the rendered table in a `<div>` with horizontal padding (tables ignore padding in email clients).
* **Contact Form** — `render_email()` now reads horizontal padding from `email_attrs` and wraps the fallback HTML in a `<div>` with the padding styles.
* **Button** — Passes `email_attrs` through to WooCommerce's Button renderer and wraps output with horizontal padding. This also fixes the **Subscriptions** block, which delegates to the button renderer.
* **Payment Buttons** — Wraps the Flex Layout Renderer output with horizontal padding from `email_attrs`.
* **Slideshow** — Already correctly forwards `email_attrs` to WooCommerce's Gallery renderer; no change needed.

A shared helper `apply_email_horizontal_padding()` was extracted to `extensions/shared/email-utils.php` to avoid duplicating the padding-wrapper logic across blocks. The contact-form block keeps inline logic since it lives in a separate package (`projects/packages/forms/`).

Before | After
---- | ----
<img width="756" height="645" alt="Screenshot 2026-03-12 at 4 08 51 PM" src="https://github.com/user-attachments/assets/270d8969-1983-476d-980d-4772a19c23c9" /> | <img width="769" height="595" alt="Screenshot 2026-03-12 at 4 09 13 PM" src="https://github.com/user-attachments/assets/ff9379ed-a193-4db1-ac41-ecef79fd2168" />


### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* NL-518

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Apply these changes to your sandbox.
* Sandbox the API and turn on write access.
* Create a post that includes a tiled gallery, contact form, subscription button, payment button, or slideshow block.
* Send a test email or preview the email rendering.
* Verify that these blocks respect the root horizontal padding — they should be inset from the edges consistent with other blocks like paragraphs and headings.

**Known issue:** The email content is no longer left-aligned with the email header and footer. This change is only to align the blocks with each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)