### PR TITLE
Components: Fix AdminPage footer horizontal scroll on narrow viewports

### DIFF
--- a/projects/js-packages/components/changelog/fix-adminpage-footer-horizontal-scroll
+++ b/projects/js-packages/components/changelog/fix-adminpage-footer-horizontal-scroll
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix AdminPage footer Container causing horizontal scroll on narrow viewports by explicitly setting box-sizing: border-box.

--- a/projects/js-packages/components/components/admin-page/index.tsx
+++ b/projects/js-packages/components/components/admin-page/index.tsx
@@ -90,7 +90,7 @@ const AdminPage: FC< AdminPageProps > = ( {
 	) : undefined;
 
 	const footer = showFooter && (
-		<Container horizontalSpacing={ 5 }>
+		<Container className={ styles[ 'admin-page-footer' ] } horizontalSpacing={ 5 }>
 			<Col>
 				<JetpackFooter
 					moduleName={ moduleName }

--- a/projects/js-packages/components/components/admin-page/style.module.scss
+++ b/projects/js-packages/components/components/admin-page/style.module.scss
@@ -35,6 +35,13 @@
 		gap: 8px;
 	}
 
+	// Ensure footer Container padding is included in its max-width,
+	// preventing horizontal scroll when the content area is narrower
+	// than the Container's max-width + padding (JETPACK-1424).
+	.admin-page-footer {
+		box-sizing: border-box;
+	}
+
 	.sandbox-domain-badge {
 		background: #d63638;
 		text-transform: uppercase;


### PR DESCRIPTION
Fixes JETPACK-1424

## Proposed changes

* Explicitly set `box-sizing: border-box` on the AdminPage footer Container to prevent horizontal scroll on narrow viewports.

The footer Container uses a non-fluid layout with `max-width: 1088px` and `padding: 0 24px`. With `content-box` sizing, the effective rendered width becomes `1088 + 48 = 1136px`, which overflows when the wp-admin content area is narrower (viewport ≤ ~1296px accounting for the 160px sidebar).

Setting `box-sizing: border-box` ensures the 24px side padding is always included *within* the 1088px max-width, capping the total rendered width at 1088px regardless of inherited box-sizing.

### Other information

- [x] Generate changelog entries for this PR (using AI).

**Note:** WordPress admin globally sets `box-sizing: border-box` via CSS inheritance (`html { box-sizing: border-box } *, *::before, *::after { box-sizing: inherit }`), which masks this bug in standard wp-admin. This fix is defensive — it protects against environments where that inheritance chain breaks (CSS resets, third-party themes, or non-wp-admin contexts like Storybook).

## Related product discussion/links

* https://linear.app/a8c/issue/JETPACK-1424
* https://linear.app/a8c/project/standardize-the-jetpack-header-and-footer-a1cb7d275fe3
* https://github.com/Automattic/jetpack/pull/47490#issuecomment-4042585287

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This fix is defensive — the overflow is masked by wp-admin's global `border-box` in standard environments. To verify the fix works:

### Reproduce the bug (without the fix)

1. Check out `trunk` (before this PR).
2. Build: `jetpack build js-packages/components` then `jetpack build plugins/protect`.
3. Go to `wp-admin/admin.php?page=jetpack-protect`.
4. Open DevTools → Inspector and find the footer Container element (a `<div>` with class `container--xxxxx` wrapping the `<footer class="jp-dashboard-footer ...">` element).
5. In the Styles panel, add `box-sizing: content-box` to that Container element.
6. **Result:** A horizontal scrollbar appears. The Container's rendered width becomes 1136px (1088px max-width + 2×24px padding), overflowing the content area.

### Verify the fix

1. Check out this branch.
2. Build: `jetpack build js-packages/components` then `jetpack build plugins/protect`.
3. Go to `wp-admin/admin.php?page=jetpack-protect`.
4. Find the footer Container in DevTools — it should now have an explicit `box-sizing: border-box` rule from the `admin-page-footer--xxxxx` CSS module class.
5. Try removing that rule in DevTools and adding `box-sizing: content-box` instead — the horizontal scrollbar should appear, confirming the class was protecting against it.

### Visual regression check

The fix should have **zero visual impact** — same max-width, same side padding, same centered layout. Spot-check these consumer pages:

* `wp-admin/admin.php?page=jetpack-protect`
* `wp-admin/admin.php?page=jetpack-backup`
* `wp-admin/admin.php?page=jetpack-social`
* `wp-admin/admin.php?page=my-jetpack`
