### PR TITLE
Enable Image Studio in CIAB

### DIFF
--- a/projects/plugins/jetpack/changelog/enable-image-studio-ciab
+++ b/projects/plugins/jetpack/changelog/enable-image-studio-ciab
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Enable Image Studio for Big Sky and CIAB sites, regardless of Jetpack AI enabled status.

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -34,11 +34,15 @@ const ASSET_TRANSIENT        = 'jetpack_image_studio_asset';
  * @return bool
  */
 function is_image_studio_enabled() {
-	if ( ! has_ai_features() ) {
+	if ( is_ciab_environment() || is_big_sky_enabled() ) {
+		return true;
+	}
+
+	if ( ! has_jetpack_ai_features() ) {
 		return false;
 	}
-	return is_dev_mode()
-		|| is_big_sky_enabled();
+
+	return is_dev_mode();
 }
 
 /**
@@ -48,6 +52,17 @@ function is_image_studio_enabled() {
  */
 function is_big_sky_enabled() {
 	return class_exists( 'Big_Sky' ) && get_option( 'big_sky_enable', '1' );
+}
+
+/**
+ * Check if current environment is CIAB (Commerce in a Box) / Next Admin.
+ *
+ * Uses the same detection method as Help Center and Agents Manager
+ *
+ * @return bool True if CIAB/Next Admin environment.
+ */
+function is_ciab_environment() {
+	return (bool) did_action( 'next_admin_init' );
 }
 
 /**
@@ -70,13 +85,12 @@ add_action( 'init', __NAMESPACE__ . '\signal_image_studio_active' );
  * Check whether AI features are available.
  *
  * - wpcom simple: always available.
- * - Atomic: requires Big Sky or AI Assistant feature flags.
- * - Self-hosted: requires a connected owner with AI not disabled
+ * - Otherwise requires a connected owner with AI not disabled
  *   (same conditions the AI Assistant plugin uses to register).
  *
  * @return bool
  */
-function has_ai_features() {
+function has_jetpack_ai_features() {
 	$host = new Host();
 
 	if ( $host->is_wpcom_simple() ) {

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -95,7 +95,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Simulate a connected Jetpack owner so has_ai_features() returns true.
+	 * Simulate a connected Jetpack owner so has_jetpack_ai_features() returns true.
 	 *
 	 * Called in set_up() so every test starts with AI features available.
 	 * Tests that need AI features off should use disable_ai_features() instead.
@@ -247,22 +247,22 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	}
 
 	// -------------------------------------------------------------------------
-	// has_ai_features() tests
+	// has_jetpack_ai_features() tests
 	// -------------------------------------------------------------------------
 
 	/**
 	 * AI features available by default in the test environment.
 	 */
-	public function test_has_ai_features_true_by_default() {
-		$this->assertTrue( ImageStudio\has_ai_features() );
+	public function test_has_jetpack_ai_features_true_by_default() {
+		$this->assertTrue( ImageStudio\has_jetpack_ai_features() );
 	}
 
 	/**
 	 * AI features disabled via jetpack_ai_enabled kill switch.
 	 */
-	public function test_has_ai_features_false_when_ai_disabled() {
+	public function test_has_jetpack_ai_features_false_when_ai_disabled() {
 		$this->disable_ai_features();
-		$this->assertFalse( ImageStudio\has_ai_features() );
+		$this->assertFalse( ImageStudio\has_jetpack_ai_features() );
 	}
 
 	// -------------------------------------------------------------------------
@@ -285,10 +285,9 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Not enabled when AI features are disabled, even with Big Sky active.
+	 * Not enabled when AI features are disabled and no Big Sky/CIAB override.
 	 */
 	public function test_is_not_enabled_when_ai_features_disabled() {
-		$this->enable_big_sky();
 		$this->disable_ai_features();
 		$this->assertFalse( ImageStudio\is_image_studio_enabled() );
 	}
@@ -622,7 +621,6 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	 * Test nothing enqueued when AI features are disabled.
 	 */
 	public function test_nothing_enqueued_when_ai_features_disabled() {
-		$this->enable_big_sky();
 		$this->disable_ai_features();
 		$this->set_block_editor_screen();
 		ImageStudio\register_plugin();
@@ -744,7 +742,6 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	 * Test nothing enqueued on Media Library when AI features are disabled.
 	 */
 	public function test_media_library_nothing_enqueued_when_disabled() {
-		$this->enable_big_sky();
 		$this->disable_ai_features();
 		$this->set_media_library_screen();
 		ImageStudio\register_plugin();
@@ -940,7 +937,6 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	 * Test AI image extensions are NOT disabled when Image Studio is not available.
 	 */
 	public function test_ai_extensions_not_disabled_when_not_available() {
-		$this->enable_big_sky();
 		$this->disable_ai_features();
 		ImageStudio\register_plugin();
 		$this->make_ai_extensions_available();


### PR DESCRIPTION
Part of FORNO-250

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Always enable Image Studio for Big Sky and CIAB sites

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* CIAB PR 3814
* p1772643243585589-slack-CLKJLBFB8

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Run `bin/jetpack-downloader test jetpack enable-image-studio-ciab`
* Sandbox your test site
* Verify Image Studio is enabled for Big Sky sites whether proxied or not
* Verify Image Studio is disabled for other simple sites except when proxied
* Follow testing steps in CIAB PR 3814
