### PR TITLE
Publicize: Clean up Twitter deprecation blocks

### DIFF
--- a/projects/packages/publicize/changelog/update-publicize-clean-up-twitter-deprecation-blocks
+++ b/projects/packages/publicize/changelog/update-publicize-clean-up-twitter-deprecation-blocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Clean up Twitter deprecation blocks.

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1487,11 +1487,6 @@ abstract class Publicize_Base {
 
 		$labels = array();
 		foreach ( $services as $service_name => $display_names ) {
-			// Twitter connections do not trigger Publicize anymore. Skip.
-			if ( 'Twitter' === $service_name ) {
-				continue;
-			}
-
 			$labels[] = sprintf(
 				/* translators: Service name is %1$s, and account name is %2$s. */
 				esc_html__( '%1$s (%2$s)', 'jetpack-publicize-pkg' ),


### PR DESCRIPTION
Related to SOCIAL-386 and 207572-ghe-Automattic/wpcom

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Clean up Twitter deprecation blocks which is no longer used

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* A sanity check for the Social admin page and the editor should be enough.