### PR TITLE
Remove "feedback" menu creation code

### DIFF
--- a/projects/packages/forms/changelog/remove-polldaddy-feedback-menu
+++ b/projects/packages/forms/changelog/remove-polldaddy-feedback-menu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Remove legacy polldaddy plugin feedback menu creation code.

--- a/projects/packages/forms/changelog/remove-polldaddy-feedback-menu
+++ b/projects/packages/forms/changelog/remove-polldaddy-feedback-menu
@@ -1,4 +1,4 @@
 Significance: patch
-Type: removed
+Type: deprecated
 
-Remove legacy polldaddy plugin feedback menu creation code.
+Deprecate admin_menu() function as feedback menu management is no longer needed.

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -236,7 +236,6 @@ class Contact_Form_Plugin {
 			add_action( 'wp_ajax_create_new_form', array( $this, 'create_new_form' ) );
 			add_action( 'wp_ajax_grunion_export_to_gdrive', array( $this, 'export_to_gdrive' ) );
 		}
-		add_action( 'admin_menu', array( $this, 'admin_menu' ) );
 		add_action( 'current_screen', array( $this, 'unread_count' ) );
 		add_action( 'current_screen', array( $this, 'redirect_edit_feedback_to_jetpack_forms' ) );
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -236,7 +236,6 @@ class Contact_Form_Plugin {
 			add_action( 'wp_ajax_create_new_form', array( $this, 'create_new_form' ) );
 			add_action( 'wp_ajax_grunion_export_to_gdrive', array( $this, 'export_to_gdrive' ) );
 		}
-		add_action( 'admin_menu', array( $this, 'admin_menu' ) );
 		add_action( 'current_screen', array( $this, 'unread_count' ) );
 		add_action( 'current_screen', array( $this, 'redirect_edit_feedback_to_jetpack_forms' ) );
 
@@ -1472,34 +1471,6 @@ class Contact_Form_Plugin {
 		}
 
 		return Contact_Form::parse_contact_field( $atts, $content, $block );
-	}
-
-	/**
-	 * Add the 'Form Responses' menu item as a submenu of Feedback.
-	 */
-	public function admin_menu() {
-		$slug = 'feedback';
-
-		add_submenu_page(
-			$slug,
-			__( 'Form Responses', 'jetpack-forms' ),
-			__( 'Form Responses', 'jetpack-forms' ),
-			'edit_pages',
-			'edit.php?post_type=feedback',
-			null,
-			0
-		);
-
-		remove_submenu_page(
-			$slug,
-			$slug
-		);
-
-		// remove the first default submenu item
-		remove_submenu_page(
-			$slug,
-			'edit.php?post_type=feedback'
-		);
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1480,20 +1480,6 @@ class Contact_Form_Plugin {
 	public function admin_menu() {
 		$slug = 'feedback';
 
-		// Do we still need to create the Feedback menu item for polldaddy?
-		// WPCOM already handles this. Self hosted will depend on us until we produce a new release for polldaddy.
-		if ( is_plugin_active( 'polldaddy/polldaddy.php' ) || ! Jetpack_Forms::is_legacy_menu_item_retired() ) {
-			add_menu_page(
-				__( 'Feedback', 'jetpack-forms' ),
-				__( 'Feedback', 'jetpack-forms' ),
-				'edit_pages',
-				$slug,
-				null,
-				'dashicons-feedback',
-				45
-			);
-		}
-
 		add_submenu_page(
 			$slug,
 			__( 'Form Responses', 'jetpack-forms' ),

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -236,6 +236,7 @@ class Contact_Form_Plugin {
 			add_action( 'wp_ajax_create_new_form', array( $this, 'create_new_form' ) );
 			add_action( 'wp_ajax_grunion_export_to_gdrive', array( $this, 'export_to_gdrive' ) );
 		}
+		add_action( 'admin_menu', array( $this, 'admin_menu' ) );
 		add_action( 'current_screen', array( $this, 'unread_count' ) );
 		add_action( 'current_screen', array( $this, 'redirect_edit_feedback_to_jetpack_forms' ) );
 
@@ -1471,6 +1472,15 @@ class Contact_Form_Plugin {
 		}
 
 		return Contact_Form::parse_contact_field( $atts, $content, $block );
+	}
+
+	/**
+	 * Add the 'Form Responses' menu item as a submenu of Feedback.
+	 *
+	 * @deprecated $$next-version$$
+	 */
+	public function admin_menu() {
+		_deprecated_function( __METHOD__, 'jetpack-forms-$$next-version$$' );
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1479,20 +1479,6 @@ class Contact_Form_Plugin {
 	public function admin_menu() {
 		$slug = 'feedback';
 
-		// Do we still need to create the Feedback menu item for polldaddy?
-		// WPCOM already handles this. Self hosted will depend on us until we produce a new release for polldaddy.
-		if ( is_plugin_active( 'polldaddy/polldaddy.php' ) || ! Jetpack_Forms::is_legacy_menu_item_retired() ) {
-			add_menu_page(
-				__( 'Feedback', 'jetpack-forms' ),
-				__( 'Feedback', 'jetpack-forms' ),
-				'edit_pages',
-				$slug,
-				null,
-				'dashicons-feedback',
-				45
-			);
-		}
-
 		add_submenu_page(
 			$slug,
 			__( 'Form Responses', 'jetpack-forms' ),

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -236,6 +236,7 @@ class Contact_Form_Plugin {
 			add_action( 'wp_ajax_create_new_form', array( $this, 'create_new_form' ) );
 			add_action( 'wp_ajax_grunion_export_to_gdrive', array( $this, 'export_to_gdrive' ) );
 		}
+		add_action( 'admin_menu', array( $this, 'admin_menu' ) );
 		add_action( 'current_screen', array( $this, 'unread_count' ) );
 		add_action( 'current_screen', array( $this, 'redirect_edit_feedback_to_jetpack_forms' ) );
 
@@ -1470,6 +1471,15 @@ class Contact_Form_Plugin {
 		}
 
 		return Contact_Form::parse_contact_field( $atts, $content, $block );
+	}
+
+	/**
+	 * Add the 'Form Responses' menu item as a submenu of Feedback.
+	 *
+	 * @deprecated $$next-version$$
+	 */
+	public function admin_menu() {
+		_deprecated_function( __METHOD__, 'jetpack-forms-$$next-version$$' );
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -236,7 +236,6 @@ class Contact_Form_Plugin {
 			add_action( 'wp_ajax_create_new_form', array( $this, 'create_new_form' ) );
 			add_action( 'wp_ajax_grunion_export_to_gdrive', array( $this, 'export_to_gdrive' ) );
 		}
-		add_action( 'admin_menu', array( $this, 'admin_menu' ) );
 		add_action( 'current_screen', array( $this, 'unread_count' ) );
 		add_action( 'current_screen', array( $this, 'redirect_edit_feedback_to_jetpack_forms' ) );
 
@@ -1471,34 +1470,6 @@ class Contact_Form_Plugin {
 		}
 
 		return Contact_Form::parse_contact_field( $atts, $content, $block );
-	}
-
-	/**
-	 * Add the 'Form Responses' menu item as a submenu of Feedback.
-	 */
-	public function admin_menu() {
-		$slug = 'feedback';
-
-		add_submenu_page(
-			$slug,
-			__( 'Form Responses', 'jetpack-forms' ),
-			__( 'Form Responses', 'jetpack-forms' ),
-			'edit_pages',
-			'edit.php?post_type=feedback',
-			null,
-			0
-		);
-
-		remove_submenu_page(
-			$slug,
-			$slug
-		);
-
-		// remove the first default submenu item
-		remove_submenu_page(
-			$slug,
-			'edit.php?post_type=feedback'
-		);
 	}
 
 	/**


### PR DESCRIPTION
Part of FORMS-619


## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Clean up creating the "feedback" menu for CrowdSignal plugin. This is legacy code from the time when Forms itself was situated under the same "Feedback" menu.

Pairs with https://github.com/Automattic/crowdsignal-plugin/pull/152


### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Go to '..'
*
