### PR TITLE
Social: Update media restrictions

### DIFF
--- a/projects/packages/publicize/_inc/hooks/use-media-restrictions/restrictions.ts
+++ b/projects/packages/publicize/_inc/hooks/use-media-restrictions/restrictions.ts
@@ -94,22 +94,23 @@ export const DEFAULT_RESTRICTIONS = {
 };
 
 export const RESTRICTIONS = {
-	// https://docs.x.com/x-api/media/quickstart/best-practices
-	x: {
-		allowedMediaTypes: allowedImageTypes.concat( [ 'image/gif', 'image/webp', MP4, VIDEOPRESS ] ),
+	// https://docs.bsky.app/docs/advanced-guides/posts#images-and-media
+	bluesky: {
+		allowedMediaTypes: allowedImageTypes.concat( [
+			MP4,
+			VIDEOPRESS,
+			MOV,
+			'video/webm',
+			'video/mpeg',
+		] ),
 		image: {
-			maxSize: 5,
+			maxSize: 1,
 		},
 		video: {
-			maxSize: 512,
-			maxLength: 140,
-			minLength: 0.5,
-			maxWidth: 1280,
-			aspectRatio: {
-				min: 1 / 3,
-				max: 3,
-			},
+			maxSize: 10000,
+			maxLength: 60,
 		},
+		charLimit: 300,
 	},
 	// https://developers.facebook.com/docs/graph-api/reference/photo/
 	// https://developers.facebook.com/docs/video-api/guides/publishing
@@ -123,33 +124,6 @@ export const RESTRICTIONS = {
 			maxLength: 14400,
 		},
 		charLimit: 10000,
-	},
-	// https://www.tumblr.com/docs/en/api/v2
-	tumblr: {
-		allowedMediaTypes: allowedImageTypes.concat( [ MP4, MOV, VIDEOPRESS ] ),
-		image: {
-			maxSize: 20,
-		},
-		video: {
-			maxSize: 500,
-			maxLength: 600,
-		},
-		charLimit: 4096,
-	},
-	// https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/images-api
-	// https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/videos-api
-	linkedin: {
-		allowedMediaTypes: allowedImageTypes.concat( [ 'image/gif', MP4, VIDEOPRESS ] ),
-		image: {
-			maxSize: 20,
-		},
-		video: {
-			minSize: 0.075,
-			maxSize: 500,
-			maxLength: 1800,
-			minLength: 3,
-		},
-		charLimit: 3000,
 	},
 	// https://developers.facebook.com/docs/instagram-platform/instagram-api-with-instagram-login/content-publishing
 	'instagram-business': {
@@ -175,6 +149,21 @@ export const RESTRICTIONS = {
 			},
 		},
 		charLimit: 2200,
+	},
+	// https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/images-api
+	// https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/videos-api
+	linkedin: {
+		allowedMediaTypes: allowedImageTypes.concat( [ 'image/gif', MP4, VIDEOPRESS ] ),
+		image: {
+			maxSize: 20,
+		},
+		video: {
+			minSize: 0.075,
+			maxSize: 500,
+			maxLength: 1800,
+			minLength: 3,
+		},
+		charLimit: 3000,
 	},
 	// https://docs.joinmastodon.org/user/posting/#media
 	mastodon: {
@@ -204,23 +193,34 @@ export const RESTRICTIONS = {
 		},
 		charLimit: 10000,
 	},
-	// https://docs.bsky.app/docs/advanced-guides/posts#images-and-media
-	bluesky: {
-		allowedMediaTypes: allowedImageTypes.concat( [
-			MP4,
-			VIDEOPRESS,
-			MOV,
-			'video/webm',
-			'video/mpeg',
-		] ),
+	// https://www.tumblr.com/docs/en/api/v2
+	tumblr: {
+		allowedMediaTypes: allowedImageTypes.concat( [ MP4, MOV, VIDEOPRESS ] ),
 		image: {
-			maxSize: 1,
+			maxSize: 20,
 		},
 		video: {
-			maxSize: 10000,
-			maxLength: 60,
+			maxSize: 500,
+			maxLength: 600,
 		},
-		charLimit: 300,
+		charLimit: 4096,
+	},
+	// https://docs.x.com/x-api/media/quickstart/best-practices
+	x: {
+		allowedMediaTypes: allowedImageTypes.concat( [ 'image/gif', 'image/webp', MP4, VIDEOPRESS ] ),
+		image: {
+			maxSize: 5,
+		},
+		video: {
+			maxSize: 512,
+			maxLength: 140,
+			minLength: 0.5,
+			maxWidth: 1280,
+			aspectRatio: {
+				min: 1 / 3,
+				max: 3,
+			},
+		},
 	},
 };
 

--- a/projects/packages/publicize/_inc/hooks/use-media-restrictions/restrictions.ts
+++ b/projects/packages/publicize/_inc/hooks/use-media-restrictions/restrictions.ts
@@ -94,6 +94,7 @@ export const DEFAULT_RESTRICTIONS = {
 };
 
 export const RESTRICTIONS = {
+	// https://docs.x.com/x-api/media/quickstart/best-practices
 	x: {
 		allowedMediaTypes: allowedImageTypes.concat( [ 'image/gif', 'image/webp', MP4, VIDEOPRESS ] ),
 		image: {
@@ -110,10 +111,12 @@ export const RESTRICTIONS = {
 			},
 		},
 	},
+	// https://developers.facebook.com/docs/graph-api/reference/photo/
+	// https://developers.facebook.com/docs/video-api/guides/publishing
 	facebook: {
 		allowedMediaTypes: facebookImageTypes.concat( [ VIDEOPRESS, ...facebookVideoTypes ] ),
 		image: {
-			maxSize: 8,
+			maxSize: 10,
 		},
 		video: {
 			maxSize: 10000,
@@ -121,6 +124,7 @@ export const RESTRICTIONS = {
 		},
 		charLimit: 10000,
 	},
+	// https://www.tumblr.com/docs/en/api/v2
 	tumblr: {
 		allowedMediaTypes: allowedImageTypes.concat( [ MP4, MOV, VIDEOPRESS ] ),
 		image: {
@@ -132,19 +136,22 @@ export const RESTRICTIONS = {
 		},
 		charLimit: 4096,
 	},
+	// https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/images-api
+	// https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/videos-api
 	linkedin: {
-		allowedMediaTypes: allowedImageTypes.concat( [ MP4, VIDEOPRESS ] ),
+		allowedMediaTypes: allowedImageTypes.concat( [ 'image/gif', MP4, VIDEOPRESS ] ),
 		image: {
 			maxSize: 20,
 		},
 		video: {
 			minSize: 0.075,
-			maxSize: 200,
-			maxLength: 600,
+			maxSize: 500,
+			maxLength: 1800,
 			minLength: 3,
 		},
 		charLimit: 3000,
 	},
+	// https://developers.facebook.com/docs/instagram-platform/instagram-api-with-instagram-login/content-publishing
 	'instagram-business': {
 		requiresMedia: true,
 		allowedMediaTypes: [ 'image/jpg', 'image/jpeg', MP4, MOV, VIDEOPRESS ],
@@ -169,16 +176,24 @@ export const RESTRICTIONS = {
 		},
 		charLimit: 2200,
 	},
+	// https://docs.joinmastodon.org/user/posting/#media
 	mastodon: {
-		allowedMediaTypes: mastodonImageTypes.concat( [ ...mastodonVideoTypes, MP4, VIDEOPRESS ] ),
+		allowedMediaTypes: mastodonImageTypes.concat( [
+			...mastodonVideoTypes,
+			MP4,
+			'video/m4v',
+			MOV,
+			VIDEOPRESS,
+		] ),
 		image: {
-			maxSize: 10,
+			maxSize: 16,
 		},
 		video: {
-			maxSize: 40,
+			maxSize: 99,
 		},
 		charLimit: 500,
 	},
+	// https://developer.nextdoor.com/reference/media-upload
 	nextdoor: {
 		allowedMediaTypes: nextdoorImageTypes.concat( [ ...nextdoorVideoTypes, MP4, VIDEOPRESS ] ),
 		image: {
@@ -189,6 +204,7 @@ export const RESTRICTIONS = {
 		},
 		charLimit: 10000,
 	},
+	// https://docs.bsky.app/docs/advanced-guides/posts#images-and-media
 	bluesky: {
 		allowedMediaTypes: allowedImageTypes.concat( [
 			MP4,

--- a/projects/packages/publicize/_inc/hooks/use-media-restrictions/restrictions.ts
+++ b/projects/packages/publicize/_inc/hooks/use-media-restrictions/restrictions.ts
@@ -1,5 +1,5 @@
 /**
- * These restrictions were updated on: November 18, 2022.
+ * These restrictions were updated on: March 13, 2026.
  *
  * Image and video size is in MB.
  * Video length is in seconds.
@@ -94,14 +94,20 @@ export const DEFAULT_RESTRICTIONS = {
 };
 
 export const RESTRICTIONS = {
-	twitter: {
-		allowedMediaTypes: allowedImageTypes.concat( [ MP4, VIDEOPRESS ] ),
+	x: {
+		allowedMediaTypes: allowedImageTypes.concat( [ 'image/gif', 'image/webp', MP4, VIDEOPRESS ] ),
 		image: {
 			maxSize: 5,
 		},
 		video: {
 			maxSize: 512,
 			maxLength: 140,
+			minLength: 0.5,
+			maxWidth: 1280,
+			aspectRatio: {
+				min: 1 / 3,
+				max: 3,
+			},
 		},
 	},
 	facebook: {

--- a/projects/packages/publicize/changelog/update-social-x-media-restrictions
+++ b/projects/packages/publicize/changelog/update-social-x-media-restrictions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update media restrictions for all the networks.


### PR DESCRIPTION
Completes SOCIAL-391

## Proposed changes

Update media restrictions for all social networks to match current API documentation.

### X (Twitter)

- Renamed key from `twitter` to `x`
- Added `image/gif` and `image/webp` to allowed media types
- Added video `minLength` (0.5s), `maxWidth` (1280px), and `aspectRatio` (1:3 to 3:1)
- Ref: https://docs.x.com/x-api/media/quickstart/best-practices

### Facebook

- Updated image `maxSize` from 8 MB to 10 MB
- Ref: https://developers.facebook.com/docs/graph-api/reference/photo/

### LinkedIn

- Added `image/gif` to allowed media types
- Updated video `maxSize` from 200 MB to 500 MB
- Updated video `maxLength` from 600s (10 min) to 1800s (30 min)
- Ref: https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/videos-api

### Mastodon

- Added `video/m4v` and `video/mov` to allowed media types
- Updated image `maxSize` from 10 MB to 16 MB
- Updated video `maxSize` from 40 MB to 99 MB
- Ref: https://docs.joinmastodon.org/user/posting/#media

### General

- Sorted the network entries alphabetically
- Added documentation reference links as comments for each network

### Other information

- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links

- SOCIAL-391

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- Go to the block editor and create a new post
- Connect social accounts for X, Facebook, LinkedIn, and Mastodon
- Try attaching media (images and videos) to shared posts
- Verify that the media validation respects the updated limits:
  - X: GIF and WebP images are now accepted; video aspect ratio and min length are enforced
  - Facebook: Images up to 10 MB are accepted (previously 8 MB)
  - LinkedIn: Videos up to 500 MB and 30 minutes are accepted (previously 200 MB / 10 min)
  - Mastodon: Images up to 16 MB (previously 10 MB) and videos up to 99 MB (previously 40 MB) are accepted

<img width="361" height="456" alt="Screenshot 2026-03-13 at 2 39 38 PM" src="https://github.com/user-attachments/assets/eaab7f04-4fa4-4397-a61b-a9c4d69c8811" />
<img width="374" height="484" alt="Screenshot 2026-03-13 at 2 39 21 PM" src="https://github.com/user-attachments/assets/90a18c5d-9af7-458f-ba19-f3362b6b8d95" />
