### PR TITLE
Newsletter settings: remove top margin for first p in cards

### DIFF
--- a/projects/packages/newsletter/changelog/fix-newsletter-settings-card-paragraph-top-margi
+++ b/projects/packages/newsletter/changelog/fix-newsletter-settings-card-paragraph-top-margi
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Settings cards: remove top margin for the first paragraph in each card
+
+

--- a/projects/packages/newsletter/src/settings/style.scss
+++ b/projects/packages/newsletter/src/settings/style.scss
@@ -17,4 +17,8 @@
 	.components-notice {
 		margin-block-end: var(--wpds-dimension-gap-lg, 24px);
 	}
+
+	.components-card__body > p:first-child {
+		margin-top: 0;
+	}
 }


### PR DESCRIPTION
## Proposed changes

The padding on the paragraphs adds extra space that creates a small layout difference between the cards starting with a paragraph and the cards that start with a toggle.

Let's remove that top margin for better consistency across cards.

**before**

<img width="1474" height="674" alt="Screenshot 2026-03-12 at 19 36 39" src="https://github.com/user-attachments/assets/21be3115-fe68-48c6-bff3-5f8ee4ed6c59" />

**after**

<img width="798" height="384" alt="Screenshot 2026-03-13 at 10 49 45" src="https://github.com/user-attachments/assets/c8e12e10-ef7d-44c2-951f-e947ff1949dc" />


### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links

* See pdtkmj-4rt-p2#comment-8658

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions

* In an mu-plugin, add `add_filter( 'jetpack_wp_admin_newsletter_settings_enabled', '__return_true' );`
* Go to Jetpack > Newsletter
* Check the top margin for each card

