### PR TITLE
wpcomsh: Allow content-guidelines Gutenberg experiment on Atomic

### DIFF
--- a/projects/plugins/wpcomsh/changelog/enable-content-guidelines-experiment
+++ b/projects/plugins/wpcomsh/changelog/enable-content-guidelines-experiment
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Allow the content-guidelines Gutenberg experiment on Atomic sites instead of blanket-disabling all experiments.

--- a/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
+++ b/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
@@ -33,7 +33,7 @@ function wpcomsh_remove_gutenberg_experiments() {
 	);
 
 	if ( in_array( $blog_id, $allowed_blogs, true ) ) {
-		// Undo the early filters for allowed blogs so they keep all experiments.
+		// Undo the early filters for allowed blogs so they can still manage Gutenberg experiments.
 		remove_filter( 'default_option_gutenberg-experiments', 'wpcomsh_filter_gutenberg_experiments' );
 		remove_filter( 'option_gutenberg-experiments', 'wpcomsh_filter_gutenberg_experiments' );
 		return;

--- a/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
+++ b/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
@@ -8,8 +8,12 @@
  * @package wpcomsh
  */
 
+// Enable allowed experiments early so Gutenberg's load.php include-time check picks them up.
+// This runs at MU plugin load time, before Gutenberg (a regular plugin) is loaded.
+add_filter( 'default_option_gutenberg-experiments', 'wpcomsh_filter_gutenberg_experiments' );
+
 /**
- * Disable all Gutenberg experiments.
+ * Disable all Gutenberg experiments except explicitly allowed ones.
  *
  * @see https://github.com/WordPress/gutenberg/blob/e6d8284b03799136915495654e821ca6212ae6d8/lib/load.php#L22
  */
@@ -29,10 +33,31 @@ function wpcomsh_remove_gutenberg_experiments() {
 		return;
 	}
 
-	add_filter( 'option_gutenberg-experiments', '__return_false' );
+	add_filter( 'option_gutenberg-experiments', 'wpcomsh_filter_gutenberg_experiments' );
 	add_action( 'admin_menu', 'wpcomsh_remove_gutenberg_experimental_menu' );
 }
 add_action( 'init', 'wpcomsh_remove_gutenberg_experiments' );
+
+/**
+ * Disable all Gutenberg experiments except explicitly allowed ones.
+ *
+ * Allowed experiments are always enabled regardless of the option value.
+ *
+ * @param mixed $experiments The gutenberg-experiments option value.
+ * @return array Filtered experiments with only allowed experiments enabled.
+ */
+function wpcomsh_filter_gutenberg_experiments( $experiments ) {
+	$allowed_experiments = array(
+		'gutenberg-content-guidelines',
+	);
+
+	$filtered = array();
+	foreach ( $allowed_experiments as $experiment ) {
+		$filtered[ $experiment ] = true;
+	}
+
+	return $filtered;
+}
 
 /**
  * Remove Gutenberg's Experiments submenu item.

--- a/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
+++ b/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
@@ -8,6 +8,10 @@
  * @package wpcomsh
  */
 
+// Enable allowed experiments early so Gutenberg's load.php include-time check picks them up.
+// This runs at MU plugin load time, before Gutenberg (a regular plugin) is loaded.
+add_filter( 'default_option_gutenberg-experiments', 'wpcomsh_filter_gutenberg_experiments' );
+
 /**
  * Disable all Gutenberg experiments except explicitly allowed ones.
  *

--- a/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
+++ b/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
@@ -8,10 +8,6 @@
  * @package wpcomsh
  */
 
-// Enable allowed experiments early so Gutenberg's load.php include-time check picks them up.
-// This runs at MU plugin load time, before Gutenberg (a regular plugin) is loaded.
-add_filter( 'default_option_gutenberg-experiments', 'wpcomsh_filter_gutenberg_experiments' );
-
 /**
  * Disable all Gutenberg experiments except explicitly allowed ones.
  *
@@ -43,10 +39,9 @@ add_action( 'init', 'wpcomsh_remove_gutenberg_experiments' );
  *
  * Allowed experiments are always enabled regardless of the option value.
  *
- * @param mixed $experiments The gutenberg-experiments option value.
  * @return array Filtered experiments with only allowed experiments enabled.
  */
-function wpcomsh_filter_gutenberg_experiments( $experiments ) {
+function wpcomsh_filter_gutenberg_experiments() {
 	$allowed_experiments = array(
 		'gutenberg-content-guidelines',
 	);

--- a/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
+++ b/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
@@ -10,7 +10,10 @@
 
 // Enable allowed experiments early so Gutenberg's load.php include-time check picks them up.
 // This runs at MU plugin load time, before Gutenberg (a regular plugin) is loaded.
+// Both filters are needed: default_option_ fires when the option doesn't exist in the DB,
+// option_ fires when it does.
 add_filter( 'default_option_gutenberg-experiments', 'wpcomsh_filter_gutenberg_experiments' );
+add_filter( 'option_gutenberg-experiments', 'wpcomsh_filter_gutenberg_experiments' );
 
 /**
  * Disable all Gutenberg experiments except explicitly allowed ones.
@@ -30,10 +33,11 @@ function wpcomsh_remove_gutenberg_experiments() {
 	);
 
 	if ( in_array( $blog_id, $allowed_blogs, true ) ) {
+		// Undo the early filters for allowed blogs so they keep all experiments.
+		remove_filter( 'default_option_gutenberg-experiments', 'wpcomsh_filter_gutenberg_experiments' );
+		remove_filter( 'option_gutenberg-experiments', 'wpcomsh_filter_gutenberg_experiments' );
 		return;
 	}
-
-	add_filter( 'option_gutenberg-experiments', 'wpcomsh_filter_gutenberg_experiments' );
 	add_action( 'admin_menu', 'wpcomsh_remove_gutenberg_experimental_menu' );
 }
 add_action( 'init', 'wpcomsh_remove_gutenberg_experiments' );
@@ -41,21 +45,14 @@ add_action( 'init', 'wpcomsh_remove_gutenberg_experiments' );
 /**
  * Disable all Gutenberg experiments except explicitly allowed ones.
  *
- * Allowed experiments are always enabled regardless of the option value.
+ * Allowed experiments are always enabled regardless of the option value in the database.
  *
- * @return array Filtered experiments with only allowed experiments enabled.
+ * @return array List of the enabled experiments.
  */
 function wpcomsh_filter_gutenberg_experiments() {
-	$allowed_experiments = array(
-		'gutenberg-content-guidelines',
+	return array(
+		'gutenberg-content-guidelines' => true,
 	);
-
-	$filtered = array();
-	foreach ( $allowed_experiments as $experiment ) {
-		$filtered[ $experiment ] = true;
-	}
-
-	return $filtered;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Replaces the blanket `__return_false` filter on `option_gutenberg-experiments` with a new `wpcomsh_filter_gutenberg_experiments()` function that uses an allowlist pattern
- Enables the `gutenberg-content-guidelines` experiment on Atomic sites, allowing the editorial voice and tone Guidelines feature under Settings
- Adds `default_option_gutenberg-experiments` filter at MU plugin load time so the experiment is available at Gutenberg's include-time check in `load.php`

## Testing instructions

- Deploy to a WoA dev site (via Jetpack Beta plugin or `jetpack rsync`)
- Verify **Settings > Guidelines** page appears in wp-admin
- Run in browser console: `wp.apiFetch({path: '/wp/v2/content-guidelines'}).then(console.log)` — should return data, not 404
- Verify other Gutenberg experiments remain disabled (not in the allowlist)
- Verify the Gutenberg **Experiments** submenu is still hidden under Gutenberg menu

## Does this pull request change what data or activity we track or use?

No, this PR does not change what data or activity we track or use. It only enables an existing Gutenberg experiment feature.