### PR TITLE
Newsletter - update disabled message for private sites not set for coming soon.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-private-newsletter-message
+++ b/projects/plugins/jetpack/changelog/fix-private-newsletter-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Update disabled newsletter notice to have a better copy for private sites not set for coming soon.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -296,4 +296,4 @@ export default function SubscribePanels() {
 	);
 }
 
-export { NewsletterRepublishTracker };
+export { NewsletterRepublishTracker, getNewsletterDisabledMessage };

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -108,7 +108,7 @@ function NewsletterEditorSettingsPanel( { accessLevel } ) {
 	);
 }
 
-const NewsletterDisabledNotice = ( isComingSoonEnabled = false ) => {
+const NewsletterDisabledNotice = ( { isComingSoonEnabled = false } ) => {
 	const message = isComingSoonEnabled
 		? __( 'You will be able to send newsletters once the site is published', 'jetpack' )
 		: __( 'Emails will not be sent to subscribers while the site is private', 'jetpack', 0 ); // 0 dummy arg to prevent bad minification

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -108,34 +108,40 @@ function NewsletterEditorSettingsPanel( { accessLevel } ) {
 	);
 }
 
-const NewsletterDisabledNotice = () => (
-	<Notice status="info" isDismissible={ false } className="edit-post-post-visibility__notice">
-		{ __( 'You will be able to send newsletters once the site is published', 'jetpack' ) }
-	</Notice>
-);
+const NewsletterDisabledNotice = ( isComingSoonEnabled = false ) => {
+	const message = isComingSoonEnabled
+		? __( 'You will be able to send newsletters once the site is published', 'jetpack' )
+		: __( 'Emails will not be sent to subscribers while the site is private', 'jetpack', 0 ); // 0 dummy arg to prevent bad minification
 
-const NewsletterDisabledPanels = () => (
+	return (
+		<Notice status="info" isDismissible={ false } className="edit-post-post-visibility__notice">
+			{ message }
+		</Notice>
+	);
+};
+
+const NewsletterDisabledPanels = ( isComingSoonEnabled = false ) => (
 	<>
 		<PluginDocumentSettingPanel
 			className="jetpack-subscribe-newsletters-panel"
 			title={ __( 'Access', 'jetpack' ) }
 			icon={ <JetpackEditorPanelLogo /> }
 		>
-			<NewsletterDisabledNotice />
+			<NewsletterDisabledNotice isComingSoonEnabled={ isComingSoonEnabled } />
 		</PluginDocumentSettingPanel>
 		<PluginPrePublishPanel
 			className="jetpack-subscribe-newsletters-panel"
 			title={ __( 'Newsletter', 'jetpack' ) }
 			icon={ <JetpackEditorPanelLogo /> }
 		>
-			<NewsletterDisabledNotice />
+			<NewsletterDisabledNotice isComingSoonEnabled={ isComingSoonEnabled } />
 		</PluginPrePublishPanel>
 		<PluginPostPublishPanel
 			className="jetpack-subscribe-newsletters-panel"
 			title={ __( 'Newsletter', 'jetpack' ) }
 			icon={ <JetpackEditorPanelLogo /> }
 		>
-			<NewsletterDisabledNotice />
+			<NewsletterDisabledNotice isComingSoonEnabled={ isComingSoonEnabled } />
 		</PluginPostPublishPanel>
 	</>
 );
@@ -259,7 +265,7 @@ export default function SubscribePanels() {
 	// Subscriptions will not be triggered on private sites ( on WordPress.com simple and WoA ),
 	// nor on sites that have not been launched yet.
 	if ( isPrivateSite() || isComingSoon() ) {
-		return <NewsletterDisabledPanels />;
+		return <NewsletterDisabledPanels isComingSoonEnabled={ isComingSoon() } />;
 	}
 
 	return (

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -111,7 +111,16 @@ function NewsletterEditorSettingsPanel( { accessLevel } ) {
 const NewsletterDisabledNotice = ( { isComingSoonEnabled = false } ) => {
 	const message = isComingSoonEnabled
 		? __( 'You will be able to send newsletters once the site is published', 'jetpack' )
-		: __( 'Emails will not be sent to subscribers while the site is private', 'jetpack', 0 ); // 0 dummy arg to prevent bad minification
+	if ( ! isComingSoon() && ! isPrivateSite() ) {
+		return null;
+	}
+
+	let message = '';
+	if ( isComingSoon() ) {
+		message = __( 'You will be able to send newsletters once the site is published', 'jetpack' );
+	} else if ( isPrivateSite() ) {
+		message = __( 'You cannot send newsletters from a private site', 'jetpack' );
+	}
 
 	return (
 		<Notice status="info" isDismissible={ false } className="edit-post-post-visibility__notice">

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -108,18 +108,22 @@ function NewsletterEditorSettingsPanel( { accessLevel } ) {
 	);
 }
 
-const isNewsletterDisabled = () => isComingSoon() || isPrivateSite();
+// Subscriptions will not be triggered on private sites ( on WordPress.com simple and WoA ),
+// nor on sites that have not been launched yet.
+const getNewsletterDisabledMessage = () => {
+	if ( isComingSoon() ) {
+		return __( 'You will be able to send newsletters once the site is published', 'jetpack' );
+	}
+	if ( isPrivateSite() ) {
+		return __( 'You cannot send newsletters from a private site', 'jetpack' );
+	}
+	return null;
+};
 
 const NewsletterDisabledNotice = () => {
-	if ( ! isNewsletterDisabled() ) {
+	const message = getNewsletterDisabledMessage();
+	if ( ! message ) {
 		return null;
-	}
-
-	let message = '';
-	if ( isComingSoon() ) {
-		message = __( 'You will be able to send newsletters once the site is published', 'jetpack' );
-	} else if ( isPrivateSite() ) {
-		message = __( 'You cannot send newsletters from a private site', 'jetpack' );
 	}
 
 	return (
@@ -271,9 +275,7 @@ export default function SubscribePanels() {
 		return null;
 	}
 
-	// Subscriptions will not be triggered on private sites ( on WordPress.com simple and WoA ),
-	// nor on sites that have not been launched yet.
-	if ( isNewsletterDisabled() ) {
+	if ( getNewsletterDisabledMessage() ) {
 		return <NewsletterDisabledPanels />;
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -120,7 +120,7 @@ const NewsletterDisabledNotice = ( { isComingSoonEnabled = false } ) => {
 	);
 };
 
-const NewsletterDisabledPanels = ( isComingSoonEnabled = false ) => (
+const NewsletterDisabledPanels = ( { isComingSoonEnabled = false } ) => (
 	<>
 		<PluginDocumentSettingPanel
 			className="jetpack-subscribe-newsletters-panel"

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -115,7 +115,7 @@ const getNewsletterDisabledMessage = () => {
 		return __( 'You will be able to send newsletters once the site is published', 'jetpack' );
 	}
 	if ( isPrivateSite() ) {
-		return __( 'You cannot send newsletters from a private site', 'jetpack' );
+		return __( 'Emails will not be sent to subscribers while your site is private', 'jetpack' );
 	}
 	return null;
 };

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.js
@@ -108,10 +108,10 @@ function NewsletterEditorSettingsPanel( { accessLevel } ) {
 	);
 }
 
-const NewsletterDisabledNotice = ( { isComingSoonEnabled = false } ) => {
-	const message = isComingSoonEnabled
-		? __( 'You will be able to send newsletters once the site is published', 'jetpack' )
-	if ( ! isComingSoon() && ! isPrivateSite() ) {
+const isNewsletterDisabled = () => isComingSoon() || isPrivateSite();
+
+const NewsletterDisabledNotice = () => {
+	if ( ! isNewsletterDisabled() ) {
 		return null;
 	}
 
@@ -129,28 +129,28 @@ const NewsletterDisabledNotice = ( { isComingSoonEnabled = false } ) => {
 	);
 };
 
-const NewsletterDisabledPanels = ( { isComingSoonEnabled = false } ) => (
+const NewsletterDisabledPanels = () => (
 	<>
 		<PluginDocumentSettingPanel
 			className="jetpack-subscribe-newsletters-panel"
 			title={ __( 'Access', 'jetpack' ) }
 			icon={ <JetpackEditorPanelLogo /> }
 		>
-			<NewsletterDisabledNotice isComingSoonEnabled={ isComingSoonEnabled } />
+			<NewsletterDisabledNotice />
 		</PluginDocumentSettingPanel>
 		<PluginPrePublishPanel
 			className="jetpack-subscribe-newsletters-panel"
 			title={ __( 'Newsletter', 'jetpack' ) }
 			icon={ <JetpackEditorPanelLogo /> }
 		>
-			<NewsletterDisabledNotice isComingSoonEnabled={ isComingSoonEnabled } />
+			<NewsletterDisabledNotice />
 		</PluginPrePublishPanel>
 		<PluginPostPublishPanel
 			className="jetpack-subscribe-newsletters-panel"
 			title={ __( 'Newsletter', 'jetpack' ) }
 			icon={ <JetpackEditorPanelLogo /> }
 		>
-			<NewsletterDisabledNotice isComingSoonEnabled={ isComingSoonEnabled } />
+			<NewsletterDisabledNotice />
 		</PluginPostPublishPanel>
 	</>
 );
@@ -273,8 +273,8 @@ export default function SubscribePanels() {
 
 	// Subscriptions will not be triggered on private sites ( on WordPress.com simple and WoA ),
 	// nor on sites that have not been launched yet.
-	if ( isPrivateSite() || isComingSoon() ) {
-		return <NewsletterDisabledPanels isComingSoonEnabled={ isComingSoon() } />;
+	if ( isNewsletterDisabled() ) {
+		return <NewsletterDisabledPanels />;
 	}
 
 	return (

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/test/panel-test.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/test/panel-test.js
@@ -255,66 +255,19 @@ describe( 'SubscribePanels', () => {
 		isNewsletterFeatureEnabled.mockReturnValue( true );
 		useSelectSpy = jest.spyOn( wpData, 'useSelect' );
 		useDispatchSpy = jest.spyOn( wpData, 'useDispatch' );
-		useDispatchSpy.mockImplementation( store => {
-			if ( store === editorStore || store === 'core/editor' ) {
-				return {
-					toggleEditorPanelOpened: jest.fn(),
-					__unstableSaveForPreview: jest.fn(),
-				};
-			}
-			if ( store === 'core/block-editor' ) {
-				return { selectBlock: jest.fn() };
-			}
-			if ( store === 'core/edit-post' ) {
-				return { closeGeneralSidebar: jest.fn() };
-			}
-			return {
-				setPublishedWithEmailEnabledInSession: mockSetPublishedWithEmailEnabledInSession,
-				setAlreadySentPostModifiedInSession: mockSetAlreadySentPostModifiedInSession,
-			};
-		} );
+		useDispatchSpy.mockReturnValue( {} );
 	} );
 
 	afterEach( () => {
 		jest.restoreAllMocks();
 	} );
 
-	const createSubscribePanelsMockSelect = ( {
-		postType = 'post',
-		postId = 123,
-		postMeta = {},
-		postEmailSentState = null,
-		status = 'draft',
-		isSavingPost = false,
-		getConnectUrl = () => 'https://connect.example.com',
-	} = {} ) => {
+	const createSubscribePanelsMockSelect = ( { postType = 'post' } = {} ) => {
 		const editorSelect = {
-			getCurrentPost: () => ( postId ? { id: postId, status } : null ),
-			getCurrentPostId: () => postId,
 			getCurrentPostType: () => postType,
-			getEditedPostAttribute: attr => ( attr === 'meta' ? postMeta : undefined ),
-			getEditedPostVisibility: () => 'public',
-			isSavingPost: () => isSavingPost,
-			isEditorPanelOpened: () => true,
-			isEditorPanelEnabled: () => true,
 		};
-		const membershipSelect = {
-			getConnectUrl,
-			getPostEmailSentState: () => postEmailSentState,
-			isApiStateLoading: () => false,
-			getNewsletterTierProducts: () => [],
-		};
-		const blockEditorSelect = {
-			getBlocks: () => [],
-			selectBlock: () => {},
-		};
-		const editPostSelect = {};
 		return store => {
 			if ( store === editorStore || store === 'core/editor' ) return editorSelect;
-			if ( store === membershipProductsStore || store === 'jetpack/membership-products' )
-				return membershipSelect;
-			if ( store === 'core/block-editor' ) return blockEditorSelect;
-			if ( store === 'core/edit-post' ) return editPostSelect;
 			return {};
 		};
 	};

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/test/panel-test.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/test/panel-test.js
@@ -1,15 +1,39 @@
 import { isComingSoon, isPrivateSite } from '@automattic/jetpack-shared-extension-utils';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import * as wpData from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { META_NAME_FOR_POST_DONT_EMAIL_TO_SUBS } from '../../../shared/memberships/constants';
+import { isNewsletterFeatureEnabled } from '../../../shared/memberships/edit';
 import { store as membershipProductsStore } from '../../../store/membership-products';
-import { NewsletterRepublishTracker, getNewsletterDisabledMessage } from '../panel';
+import {
+	NewsletterRepublishTracker,
+	getNewsletterDisabledMessage,
+	default as SubscribePanels,
+} from '../panel';
 
 jest.mock( '@automattic/jetpack-shared-extension-utils', () => ( {
 	...jest.requireActual( '@automattic/jetpack-shared-extension-utils' ),
 	isComingSoon: jest.fn( () => false ),
 	isPrivateSite: jest.fn( () => false ),
+	useAnalytics: jest.fn( () => ( { tracks: { recordEvent: jest.fn() } } ) ),
+} ) );
+
+jest.mock( '../../../shared/memberships/edit', () => ( {
+	useAccessLevel: jest.fn( () => 'everybody' ),
+	isNewsletterFeatureEnabled: jest.fn( () => true ),
+} ) );
+
+jest.mock( '@wordpress/editor', () => ( {
+	...jest.requireActual( '@wordpress/editor' ),
+	PluginDocumentSettingPanel: ( { children } ) => (
+		<div data-testid="document-panel">{ children }</div>
+	),
+	PluginPrePublishPanel: ( { children } ) => (
+		<div data-testid="pre-publish-panel">{ children }</div>
+	),
+	PluginPostPublishPanel: ( { children } ) => (
+		<div data-testid="post-publish-panel">{ children }</div>
+	),
 } ) );
 
 const mockSetPublishedWithEmailEnabledInSession = jest.fn();
@@ -217,5 +241,125 @@ describe( 'getNewsletterDisabledMessage', () => {
 		const message = getNewsletterDisabledMessage();
 
 		expect( message ).toBe( 'You will be able to send newsletters once the site is published' );
+	} );
+} );
+
+describe( 'SubscribePanels', () => {
+	let useSelectSpy;
+	let useDispatchSpy;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		isComingSoon.mockReturnValue( false );
+		isPrivateSite.mockReturnValue( false );
+		isNewsletterFeatureEnabled.mockReturnValue( true );
+		useSelectSpy = jest.spyOn( wpData, 'useSelect' );
+		useDispatchSpy = jest.spyOn( wpData, 'useDispatch' );
+		useDispatchSpy.mockImplementation( store => {
+			if ( store === editorStore || store === 'core/editor' ) {
+				return {
+					toggleEditorPanelOpened: jest.fn(),
+					__unstableSaveForPreview: jest.fn(),
+				};
+			}
+			if ( store === 'core/block-editor' ) {
+				return { selectBlock: jest.fn() };
+			}
+			if ( store === 'core/edit-post' ) {
+				return { closeGeneralSidebar: jest.fn() };
+			}
+			return {
+				setPublishedWithEmailEnabledInSession: mockSetPublishedWithEmailEnabledInSession,
+				setAlreadySentPostModifiedInSession: mockSetAlreadySentPostModifiedInSession,
+			};
+		} );
+	} );
+
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	const createSubscribePanelsMockSelect = ( {
+		postType = 'post',
+		postId = 123,
+		postMeta = {},
+		postEmailSentState = null,
+		status = 'draft',
+		isSavingPost = false,
+		getConnectUrl = () => 'https://connect.example.com',
+	} = {} ) => {
+		const editorSelect = {
+			getCurrentPost: () => ( postId ? { id: postId, status } : null ),
+			getCurrentPostId: () => postId,
+			getCurrentPostType: () => postType,
+			getEditedPostAttribute: attr => ( attr === 'meta' ? postMeta : undefined ),
+			getEditedPostVisibility: () => 'public',
+			isSavingPost: () => isSavingPost,
+			isEditorPanelOpened: () => true,
+			isEditorPanelEnabled: () => true,
+		};
+		const membershipSelect = {
+			getConnectUrl,
+			getPostEmailSentState: () => postEmailSentState,
+			isApiStateLoading: () => false,
+			getNewsletterTierProducts: () => [],
+		};
+		const blockEditorSelect = {
+			getBlocks: () => [],
+			selectBlock: () => {},
+		};
+		const editPostSelect = {};
+		return store => {
+			if ( store === editorStore || store === 'core/editor' ) return editorSelect;
+			if ( store === membershipProductsStore || store === 'jetpack/membership-products' )
+				return membershipSelect;
+			if ( store === 'core/block-editor' ) return blockEditorSelect;
+			if ( store === 'core/edit-post' ) return editPostSelect;
+			return {};
+		};
+	};
+
+	test( 'returns null when postType is not post', () => {
+		useSelectSpy.mockImplementation( selector =>
+			selector( createSubscribePanelsMockSelect( { postType: 'page' } ) )
+		);
+
+		const { container } = render( <SubscribePanels /> );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	test( 'returns null when newsletter feature is not enabled', () => {
+		isNewsletterFeatureEnabled.mockReturnValue( false );
+		useSelectSpy.mockImplementation( selector => selector( createSubscribePanelsMockSelect() ) );
+
+		const { container } = render( <SubscribePanels /> );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	test( 'renders NewsletterDisabledPanels with coming soon message when site is coming soon', () => {
+		isComingSoon.mockReturnValue( true );
+		isPrivateSite.mockReturnValue( false );
+		useSelectSpy.mockImplementation( selector => selector( createSubscribePanelsMockSelect() ) );
+
+		render( <SubscribePanels /> );
+
+		expect(
+			screen.getAllByText( 'You will be able to send newsletters once the site is published' )
+				.length
+		).toBeGreaterThanOrEqual( 3 );
+	} );
+
+	test( 'renders NewsletterDisabledPanels with private site message when site is private', () => {
+		isComingSoon.mockReturnValue( false );
+		isPrivateSite.mockReturnValue( true );
+		useSelectSpy.mockImplementation( selector => selector( createSubscribePanelsMockSelect() ) );
+
+		render( <SubscribePanels /> );
+
+		expect(
+			screen.getAllByText( 'You cannot send newsletters from a private site' ).length
+		).toBeGreaterThanOrEqual( 3 );
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/test/panel-test.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/test/panel-test.js
@@ -222,7 +222,7 @@ describe( 'getNewsletterDisabledMessage', () => {
 
 		const message = getNewsletterDisabledMessage();
 
-		expect( message ).toBe( 'You cannot send newsletters from a private site' );
+		expect( message ).toBe( 'Emails will not be sent to subscribers while your site is private' );
 	} );
 
 	test( 'returns null when site is neither coming soon nor private', () => {
@@ -312,7 +312,8 @@ describe( 'SubscribePanels', () => {
 		render( <SubscribePanels /> );
 
 		expect(
-			screen.getAllByText( 'You cannot send newsletters from a private site' ).length
+			screen.getAllByText( 'Emails will not be sent to subscribers while your site is private' )
+				.length
 		).toBeGreaterThanOrEqual( 3 );
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/test/panel-test.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/test/panel-test.js
@@ -1,9 +1,16 @@
+import { isComingSoon, isPrivateSite } from '@automattic/jetpack-shared-extension-utils';
 import { render } from '@testing-library/react';
 import * as wpData from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { META_NAME_FOR_POST_DONT_EMAIL_TO_SUBS } from '../../../shared/memberships/constants';
 import { store as membershipProductsStore } from '../../../store/membership-products';
-import { NewsletterRepublishTracker } from '../panel';
+import { NewsletterRepublishTracker, getNewsletterDisabledMessage } from '../panel';
+
+jest.mock( '@automattic/jetpack-shared-extension-utils', () => ( {
+	...jest.requireActual( '@automattic/jetpack-shared-extension-utils' ),
+	isComingSoon: jest.fn( () => false ),
+	isPrivateSite: jest.fn( () => false ),
+} ) );
 
 const mockSetPublishedWithEmailEnabledInSession = jest.fn();
 const mockSetAlreadySentPostModifiedInSession = jest.fn();
@@ -166,5 +173,49 @@ describe( 'NewsletterRepublishTracker', () => {
 		render( <NewsletterRepublishTracker /> );
 		expect( mockSetPublishedWithEmailEnabledInSession ).not.toHaveBeenCalled();
 		expect( mockSetAlreadySentPostModifiedInSession ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'getNewsletterDisabledMessage', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		isComingSoon.mockReturnValue( false );
+		isPrivateSite.mockReturnValue( false );
+	} );
+
+	test( 'returns coming soon message when site is coming soon', () => {
+		isComingSoon.mockReturnValue( true );
+		isPrivateSite.mockReturnValue( false );
+
+		const message = getNewsletterDisabledMessage();
+
+		expect( message ).toBe( 'You will be able to send newsletters once the site is published' );
+	} );
+
+	test( 'returns private site message when site is private', () => {
+		isComingSoon.mockReturnValue( false );
+		isPrivateSite.mockReturnValue( true );
+
+		const message = getNewsletterDisabledMessage();
+
+		expect( message ).toBe( 'You cannot send newsletters from a private site' );
+	} );
+
+	test( 'returns null when site is neither coming soon nor private', () => {
+		isComingSoon.mockReturnValue( false );
+		isPrivateSite.mockReturnValue( false );
+
+		const message = getNewsletterDisabledMessage();
+
+		expect( message ).toBeNull();
+	} );
+
+	test( 'prioritizes coming soon over private when both are true', () => {
+		isComingSoon.mockReturnValue( true );
+		isPrivateSite.mockReturnValue( true );
+
+		const message = getNewsletterDisabledMessage();
+
+		expect( message ).toBe( 'You will be able to send newsletters once the site is published' );
 	} );
 } );


### PR DESCRIPTION
Fixes NL-519
Fixes NL-197
Closes #45941

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Adds a separate copy in the newsletters publish panel for private sites when not set to coming soon.

Private message:
<img width="295" height="153" alt="Screenshot 2026-03-13 at 2 57 14 PM" src="https://github.com/user-attachments/assets/89b915d3-8dd8-42b1-9216-312fe12a3635" />

Previous message still used for "Coming soon":
<img width="301" height="152" alt="Screenshot 2026-03-13 at 2 58 43 PM" src="https://github.com/user-attachments/assets/2c222c0c-31c3-403b-8386-0a6281dceca8" />

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Install this build on a newsletter test site
* Set the site to "private"
* Create a new post draft. Select "publish" so the publish panel opens.
* Open the newsletter dropdown, verify the private site message is present.
* Exit the editor, switch the site to "coming soon".
* Go back to the editor for the post, select publish to open the panel, and verify the previous coming soon message is present.
* Exit the editor, switch the site to public.
* Now back in the editor, select publish and verify the newsletter dropdown does not have a notice and shows its general expected state.
