### PR TITLE
Fix newsletter module configure URL to point to new settings page

### DIFF
--- a/projects/packages/newsletter/changelog/fix-newsletter-module-configure-url
+++ b/projects/packages/newsletter/changelog/fix-newsletter-module-configure-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix module configure URL not pointing to the new newsletter settings page

--- a/projects/packages/newsletter/src/class-settings.php
+++ b/projects/packages/newsletter/src/class-settings.php
@@ -99,12 +99,13 @@ class Settings {
 		}
 
 		// Hijack the config URLs to point to our settings page.
-		// Customize the configuration URL to lead to the Subscriptions settings.
+		// Priority 20 to override the default URL set in subscriptions.php.
 		add_filter(
 			'jetpack_module_configuration_url_subscriptions',
 			function () {
 				return Urls::get_newsletter_settings_url( ( new Status() )->get_site_suffix() );
-			}
+			},
+			20
 		);
 
 		$host = new Host();


### PR DESCRIPTION
Part of DOTCOM-16310

## Proposed changes
* Fix the "Configure" link on the Jetpack modules page for the Newsletter module to point to the new newsletter settings page (`admin.php?page=jetpack-newsletter`) instead of the old URL (`admin.php?page=jetpack#/newsletter`).
* The `jetpack_module_configuration_url_subscriptions` filter in the newsletter package was not reliably overriding the default URL set in `subscriptions.php` because both used the default priority (10). Setting the newsletter package's filter to priority 20 ensures it takes precedence.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* CFT feedback: pdtkmj-4rt-p2#comment-8655

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Ensure the new newsletter settings screen is enabled (`jetpack_wp_admin_newsletter_settings_enabled` filter returns true)
* Go to **Jetpack → Modules** (`admin.php?page=jetpack_modules`)
* Search for "newsletter"
* Click the **Configure** link on the Newsletter module
* Verify it navigates to `admin.php?page=jetpack-newsletter` (the new settings page), not `admin.php?page=jetpack#/newsletter`