### PR TITLE
Dotcom Dashboard: Redesign the CelebrateLaunchModal with Core styles

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-16264-task-22-site-launch-celebration-modal
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-16264-task-22-site-launch-celebration-modal
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Dotcom Dashboard: Redesign the celebrate launch modal with Core styles.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/celebrate-launch/celebrate-launch-modal.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/celebrate-launch/celebrate-launch-modal.js
@@ -116,50 +116,48 @@ export default function CelebrateLaunchModal( {
 	const ref = useCopyToClipboard( siteSlug, () => setClipboardCopied( true ) );
 
 	return (
-		<Modal onRequestClose={ onRequestClose } className="launched__modal">
+		<Modal
+			className="launched__modal"
+			onRequestClose={ onRequestClose }
+			size="medium"
+			title={ __( 'Congrats, your site is live!', 'jetpack-mu-wpcom' ) }
+		>
 			<ConfettiAnimation />
-			<div className="launched__modal-content">
-				<div className="launched__modal-text">
-					<h1 className="launched__modal-heading">
-						{ __( 'Congrats, your site is live!', 'jetpack-mu-wpcom' ) }
-					</h1>
-					<p className="launched__modal-body">
-						{ __(
-							'Now you can head over to your site and share it with the world.',
-							'jetpack-mu-wpcom'
-						) }
-					</p>
-				</div>
-				<div className="launched__modal-actions">
-					<div className="launched__modal-site">
-						<div className="launched__modal-domain">
-							<p className="launched__modal-domain-text">{ siteSlug }</p>
-							<Tooltip
-								text={ clipboardCopied ? __( 'Copied to clipboard!', 'jetpack-mu-wpcom' ) : '' }
-								delay={ 0 }
-								hideOnClick={ false }
-							>
-								<Button
-									label={ __( 'Copy URL', 'jetpack-mu-wpcom' ) }
-									className="launchpad__clipboard-button"
-									borderless
-									size="compact"
-									ref={ ref }
-									onMouseLeave={ () => setClipboardCopied( false ) }
-								>
-									<Icon icon={ copy } size={ 18 } />
-								</Button>
-							</Tooltip>
-						</div>
 
-						<Button href={ siteUrl } target="_blank" className="launched__modal-view-site">
-							<Gridicon icon="domains" size={ 18 } />
-							<span className="launched__modal-view-site-text">
-								{ __( 'View site', 'jetpack-mu-wpcom' ) }
-							</span>
+			<p>
+				{ __(
+					'Now you can head over to your site and share it with the world.',
+					'jetpack-mu-wpcom'
+				) }
+			</p>
+
+			<div className="launched__modal-site">
+				<div className="launched__modal-domain">
+					<p className="launched__modal-domain-text">{ siteSlug }</p>
+					<Tooltip
+						text={ clipboardCopied ? __( 'Copied to clipboard!', 'jetpack-mu-wpcom' ) : '' }
+						delay={ 0 }
+						hideOnClick={ false }
+					>
+						<Button
+							label={ __( 'Copy URL', 'jetpack-mu-wpcom' ) }
+							className="launchpad__clipboard-button"
+							borderless
+							size="compact"
+							ref={ ref }
+							onMouseLeave={ () => setClipboardCopied( false ) }
+						>
+							<Icon icon={ copy } size={ 18 } />
 						</Button>
-					</div>
+					</Tooltip>
 				</div>
+
+				<Button href={ siteUrl } target="_blank" className="launched__modal-view-site">
+					<Gridicon icon="domains" size={ 18 } />
+					<span className="launched__modal-view-site-text">
+						{ __( 'View site', 'jetpack-mu-wpcom' ) }
+					</span>
+				</Button>
 			</div>
 			{ renderUpsellContent() }
 		</Modal>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/celebrate-launch/celebrate-launch-modal.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/celebrate-launch/celebrate-launch-modal.scss
@@ -1,168 +1,94 @@
-$breakpoint-mobile: 782px; //Mobile size.
+@use "@wordpress/base-styles/breakpoints" as *;
+@use "@wordpress/base-styles/colors" as *;
+@use "@wordpress/base-styles/variables" as *;
 
-.launched__modal {
+.launched__modal .components-modal__children-container p:first-child {
+	margin-top: 0;
+}
 
-	p {
-		font-size: 16px;
+.launched__modal-site {
+	align-items: center;
+	border: 1px solid $gray-600;
+	border-radius: $radius-small;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	padding: $grid-unit-05 $grid-unit-10;
+
+	@media (min-width: $break-small) {
+		flex-direction: row;
+	}
+
+	&:hover .launchpad__clipboard-button {
+		opacity: 1;
+	}
+}
+
+.launched__modal-domain {
+	align-items: center;
+	display: flex;
+	justify-content: center;
+	max-width: 100%;
+	min-width: 0;
+
+	.launched__modal-domain-text {
 		margin: 0;
-	}
-
-	&.components-modal__frame {
-		max-width: 640px;
-	}
-
-	.components-modal__header {
-		padding: 48px;
-	}
-
-	.components-modal__content {
-		margin: 0;
-		padding: 0;
-	}
-
-	&-content {
-		padding: 48px;
-		padding-bottom: 40px;
-		display: flex;
-		flex-direction: column;
-		gap: 32px;
-
-		@media (min-width: $breakpoint-mobile) {
-			min-width: 640px;
-		}
-	}
-
-	&-heading {
-		color: var(--studio-gray-100);
-		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
-		font-size: 2rem;
-		line-height: 40px;
-		font-weight: 400;
-		letter-spacing: 0.2px;
-		margin: 0;
-		padding-bottom: 8px;
-	}
-
-	&-domain {
-		display: flex;
-		justify-content: center;
-		align-items: center;
-		max-width: 100%;
-
-		@media (min-width: $breakpoint-mobile) {
-			max-width: 75%;
-		}
-	}
-
-	&-body,
-	&-domain-text {
-		margin: 0;
-		color: var(--studio-gray-80);
-		font-size: 1rem;
-		line-height: 24px;
-	}
-
-	&-domain-text {
-		padding: 0 8px;
-
-		// prevent text overflow
+		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
-		overflow: hidden;
 	}
+}
 
-	&-buttons {
-		display: flex;
-		flex-direction: row;
-		justify-content: end;
-		gap: 16px;
-	}
+.launchpad__clipboard-button {
+	margin-left: $grid-unit-05;
+	opacity: 1;
 
-	&-site {
-		padding: 8px;
-		background: var(--studio-gray-0);
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-		align-items: center;
-
-		@media (min-width: $breakpoint-mobile) {
-			flex-direction: row;
-		}
-	}
-
-	.launchpad__clipboard-button {
-		min-width: 18px;
+	@media (min-width: $break-small) {
 		opacity: 0;
 	}
 
-	.launchpad__clipboard-button:focus {
+	&:focus {
 		opacity: 1;
 	}
+}
 
-	&-site:hover {
+.launched__modal-view-site {
+	color: $gray-900;
+	display: flex;
+	gap: $grid-unit-05;
 
-		.launchpad__clipboard-button {
-			opacity: 1;
-		}
+	&:visited {
+		color: $gray-900;
 	}
 
-	&-customize {
-		color: var(--studio-blue-50);
-		font-size: 0.875rem;
-		display: inline-flex;
-		flex-direction: row;
-		justify-content: start;
-		gap: 6px;
-		padding: 0;
-		margin: 0;
-		margin-top: 16px;
-	}
-
-	&-upsell {
-		border-top: 1px solid var(--studio-gray-5);
-		background: var(--studio-gray-0);
-		display: flex;
-		justify-content: center;
-		align-items: center;
-		padding: 32px 48px;
-		gap: 32px;
-		flex-direction: column;
-
-		@media (min-width: $breakpoint-mobile) {
-			flex-direction: row;
-		}
-
-		.components-button {
-			height: 42px;
-		}
-	}
-
-	&-upsell-content p {
-		margin-bottom: 0;
-	}
-
-	&-upsell-content-highlight {
-		font-weight: 700;
-	}
-
-	&-view-site {
-		display: flex;
-		gap: 4px;
-
-		font-weight: 500;
-		/* stylelint-disable-next-line */
-		font-size: 14px;
-		line-height: 20px;
-		letter-spacing: -0.154px;
-		color: #101517;
-	}
-
-	&-view-site:visited {
-		color: #101517;
-	}
-
-	&-view-site:hover {
+	&:hover {
 		text-decoration: underline;
+	}
+
+	.launched__modal-view-site-text {
+		font-weight: $font-weight-medium;
+		font-size: $font-size-x-small;
+		line-height: $font-line-height-small;
+		white-space: nowrap;
+	}
+}
+
+.launched__modal-upsell {
+	align-items: center;
+	background-color: $gray-100;
+	display: flex;
+	flex-direction: column;
+	gap: $grid-unit-15;
+	justify-content: center;
+	margin: $grid-unit-30 -#{$grid-unit-30} -#{$grid-unit-30} -#{$grid-unit-30};
+	padding: $grid-unit-30;
+
+	p {
+		margin: 0;
+	}
+
+	@media (min-width: $break-small) {
+		flex-direction: row;
+		gap: $grid-unit-30;
 	}
 }


### PR DESCRIPTION
Fixes DOTCOM-16264

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* We are redesigning the existing CelebrateLaunchModal to use Core styles instead of Calypso ones.

| Before | After |
|--------|--------|
| <img width="655" height="371" alt="Screenshot 2026-03-13 at 14 13 30" src="https://github.com/user-attachments/assets/16d258a0-3656-4538-8855-802c822fb351" /> | <img width="533" height="306" alt="Screenshot 2026-03-13 at 14 12 21" src="https://github.com/user-attachments/assets/2078f789-5ed7-4046-94e9-8078d7283c6d" /> | 

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* DOTCOM-16264

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Apply these changes to the sandbox, and sandbox a test site.
* Open the site's dashboard with the `?celebrate-launch` query param (e.g. `/wp-admin/index.php?celebrate-launch`).
* Play around with the modal, and ensure it looks nice and feels good.
