### PR TITLE
Map block: fix markers displaying as bullet points on Simple sites

### DIFF
--- a/projects/plugins/jetpack/changelog/ai-agent-edi-153-1771832428
+++ b/projects/plugins/jetpack/changelog/ai-agent-edi-153-1771832428
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Map block: fix markers displaying as bullet points on Simple sites by moving data to inline JS and hiding fallback list via CSS.

--- a/projects/plugins/jetpack/extensions/blocks/map/map.php
+++ b/projects/plugins/jetpack/extensions/blocks/map/map.php
@@ -127,11 +127,90 @@ function load_assets( $attr, $content ) {
 	Jetpack_Gutenberg::load_assets_as_required( __DIR__ );
 
 	$map_provider = get_map_provider( $content );
-	if ( $map_provider === 'mapkit' ) {
-		return preg_replace( '/<div /', '<div data-map-provider="mapkit" data-api-key="' . esc_attr( $access_token['key'] ) . '"  data-blog-id="' . \Jetpack_Options::get_option( 'id' ) . '" ', $content, 1 );
+
+	return rebuild_map_block_div( $attr, $content, $map_provider, $access_token );
+}
+
+/**
+ * Rebuild the map block div to move large JSON data from HTML attributes
+ * into an inline JS payload, keeping the DOM lightweight.
+ *
+ * @param array  $attr         Array containing the map block attributes.
+ * @param string $content      String containing the map block content.
+ * @param string $map_provider The map provider (mapbox or mapkit).
+ * @param array  $access_token The Mapbox/MapKit access token data.
+ *
+ * @return string
+ */
+function rebuild_map_block_div( $attr, $content, $map_provider, $access_token ) {
+	static $did_inline = false;
+
+	$block_id = wp_unique_id( 'jp-map-' );
+
+	// Extract map-style from the saved HTML since it's no longer a block attribute
+	// (was deprecated and converted to CSS class names like is-style-terrain).
+	$map_style = 'default';
+	if ( preg_match( '/data-map-style="([^"]*)"/', $content, $matches ) ) {
+		$map_style = $matches[1];
 	}
 
-	return preg_replace( '/<div /', '<div data-map-provider="mapbox" data-api-key="' . esc_attr( $access_token['key'] ) . '" ', $content, 1 );
+	$classes = array( 'wp-block-jetpack-map' );
+	if ( ! empty( $attr['align'] ) ) {
+		$classes[] = 'align' . $attr['align'];
+	}
+	if ( ! empty( $attr['className'] ) ) {
+		$classes[] = $attr['className'];
+	}
+
+	// Keep the tag small: no giant JSON in attributes.
+	$data_attrs = array(
+		'class'             => implode( ' ', $classes ),
+		'data-map-id'       => $block_id,
+		'data-map-provider' => $map_provider,
+		'data-api-key'      => $access_token['key'],
+		'data-map-style'    => $map_style,
+	);
+
+	if ( 'mapkit' === $map_provider ) {
+		$data_attrs['data-blog-id'] = \Jetpack_Options::get_option( 'id' );
+	}
+
+	// Put everything else in the JS payload (including points).
+	$payload = array(
+		'points'               => $attr['points'] ?? null,
+		'zoom'                 => $attr['zoom'] ?? null,
+		'mapCenter'            => $attr['mapCenter'] ?? null,
+		'markerColor'          => $attr['markerColor'] ?? null,
+		'scrollToZoom'         => $attr['scrollToZoom'] ?? null,
+		'mapDetails'           => $attr['mapDetails'] ?? null,
+		'mapHeight'            => $attr['mapHeight'] ?? null,
+		'showFullscreenButton' => $attr['showFullscreenButton'] ?? null,
+		'mapStyle'             => $map_style,
+	);
+
+	$handle = 'jetpack-block-map';
+
+	// Seed global once.
+	if ( ! $did_inline ) {
+		wp_add_inline_script( $handle, 'window.JetpackMapBlockData = window.JetpackMapBlockData || {};', 'before' );
+		$did_inline = true;
+	}
+
+	// Add this block's payload keyed by ID.
+	wp_add_inline_script(
+		$handle,
+		'window.JetpackMapBlockData[' . wp_json_encode( $block_id, JSON_HEX_TAG | JSON_HEX_AMP ) . '] = ' . wp_json_encode( $payload, JSON_HEX_TAG | JSON_HEX_AMP ) . ';',
+		'before'
+	);
+
+	$div_open = '<div';
+	foreach ( $data_attrs as $key => $value ) {
+		$div_open .= ' ' . $key . '="' . esc_attr( $value ) . '"';
+	}
+	$div_open .= '>';
+
+	$result = preg_replace( '/<div[^>]*>/', $div_open, $content, 1 );
+	return null !== $result ? $result : $content;
 }
 
 /**

--- a/projects/plugins/jetpack/extensions/blocks/map/map.php
+++ b/projects/plugins/jetpack/extensions/blocks/map/map.php
@@ -210,7 +210,7 @@ function rebuild_map_block_div( $attr, $content, $map_provider, $access_token ) 
 	$div_open .= '>';
 
 	$result = preg_replace( '/<div[^>]*>/', $div_open, $content, 1 );
-	return null !== $result ? $result : $content;
+	return $result ?? $content;
 }
 
 /**

--- a/projects/plugins/jetpack/extensions/blocks/map/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/map/style.scss
@@ -2,12 +2,6 @@
 
 .wp-block-jetpack-map {
 
-	// Hide the fallback list of markers so they don't render as bullet points
-	// when the map JavaScript hasn't loaded yet.
-	> ul {
-		display: none;
-	}
-
 	.wp-block-group-is-layout-flex:not(.is-vertical) > & {
 		flex-basis: 100%;
 	}

--- a/projects/plugins/jetpack/extensions/blocks/map/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/map/style.scss
@@ -2,6 +2,12 @@
 
 .wp-block-jetpack-map {
 
+	// Hide the fallback list of markers so they don't render as bullet points
+	// when the map JavaScript hasn't loaded yet.
+	> ul {
+		display: none;
+	}
+
 	.wp-block-group-is-layout-flex:not(.is-vertical) > & {
 		flex-basis: 100%;
 	}

--- a/projects/plugins/jetpack/extensions/blocks/map/view/mapbox.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/view/mapbox.js
@@ -28,18 +28,26 @@ class MapBoxBlock {
 		this.window = currentWindow;
 		this.onError = onError;
 
+		// Read payload from JS global (set by PHP inline script), fall back to data attributes.
+		const mapId = this.root.getAttribute( 'data-map-id' );
+		const data = window.JetpackMapBlockData && mapId ? window.JetpackMapBlockData[ mapId ] : null;
+
 		// Block attributes.
-		this.mapStyle = this.root.getAttribute( 'data-map-style' ) || 'default';
-		this.mapDetails = this.root.getAttribute( 'data-map-details' ) === 'true';
+		this.mapStyle = data?.mapStyle || this.root.getAttribute( 'data-map-style' ) || 'default';
+		this.mapDetails = data?.mapDetails ?? this.root.getAttribute( 'data-map-details' ) === 'true';
 		this.apiKey = this.root.getAttribute( 'data-api-key' ) || null;
-		this.scrollToZoom = this.root.getAttribute( 'data-scroll-to-zoom' ) === 'true';
-		this.showFullscreenButton = this.root.getAttribute( 'data-show-fullscreen-button' ) === 'true';
-		this.points = JSON.parse( this.root.getAttribute( 'data-points' ) || '[]' );
-		this.mapCenter = JSON.parse( this.root.getAttribute( 'data-map-center' ) || '{}' );
-		this.mapHeight = this.root.getAttribute( 'data-map-height' ) || null;
-		this.markerColor = this.root.getAttribute( 'data-marker-color' ) || 'red';
-		const zoom = this.root.getAttribute( 'data-zoom' );
-		this.zoom = zoom && zoom.length ? parseInt( this.root.getAttribute( 'data-zoom' ), 10 ) : 13;
+		this.scrollToZoom =
+			data?.scrollToZoom ?? this.root.getAttribute( 'data-scroll-to-zoom' ) === 'true';
+		this.showFullscreenButton =
+			data?.showFullscreenButton ??
+			this.root.getAttribute( 'data-show-fullscreen-button' ) === 'true';
+		this.points = data?.points || JSON.parse( this.root.getAttribute( 'data-points' ) || '[]' );
+		this.mapCenter =
+			data?.mapCenter || JSON.parse( this.root.getAttribute( 'data-map-center' ) || '{}' );
+		this.mapHeight = data?.mapHeight || this.root.getAttribute( 'data-map-height' ) || null;
+		this.markerColor = data?.markerColor || this.root.getAttribute( 'data-marker-color' ) || 'red';
+		const zoom = data?.zoom ?? this.root.getAttribute( 'data-zoom' );
+		this.zoom = zoom != null ? parseInt( zoom, 10 ) : 13;
 
 		this.activeMarker = null;
 

--- a/projects/plugins/jetpack/extensions/blocks/map/view/mapkit.js
+++ b/projects/plugins/jetpack/extensions/blocks/map/view/mapkit.js
@@ -9,14 +9,21 @@ import resizeMapContainer from '../utils/resize-map-container';
 class MapkitBlock {
 	constructor( root ) {
 		this.root = root;
+
+		// Read payload from JS global (set by PHP inline script), fall back to data attributes.
+		const mapId = this.root.getAttribute( 'data-map-id' );
+		const data = window.JetpackMapBlockData && mapId ? window.JetpackMapBlockData[ mapId ] : null;
+
 		this.blog_id = this.root.getAttribute( 'data-blog-id' );
-		this.center = JSON.parse( this.root.getAttribute( 'data-map-center' ) || '{}' );
-		this.points = JSON.parse( this.root.getAttribute( 'data-points' ) || '[]' );
-		this.color = this.root.getAttribute( 'data-marker-color' ) || 'red';
-		this.zoom = parseFloat( this.root.getAttribute( 'data-zoom' ) ) || 10;
-		this.scrollToZoom = this.root.getAttribute( 'data-scroll-to-zoom' ) === 'true';
-		this.mapStyle = this.root.getAttribute( 'data-map-style' ) || 'default';
-		this.mapHeight = this.root.getAttribute( 'data-map-height' ) || null;
+		this.center =
+			data?.mapCenter || JSON.parse( this.root.getAttribute( 'data-map-center' ) || '{}' );
+		this.points = data?.points || JSON.parse( this.root.getAttribute( 'data-points' ) || '[]' );
+		this.color = data?.markerColor || this.root.getAttribute( 'data-marker-color' ) || 'red';
+		this.zoom = parseFloat( data?.zoom ?? this.root.getAttribute( 'data-zoom' ) ) || 10;
+		this.scrollToZoom =
+			data?.scrollToZoom ?? this.root.getAttribute( 'data-scroll-to-zoom' ) === 'true';
+		this.mapStyle = data?.mapStyle || this.root.getAttribute( 'data-map-style' ) || 'default';
+		this.mapHeight = data?.mapHeight || this.root.getAttribute( 'data-map-height' ) || null;
 		this.onError = () => {};
 	}
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/EDI-153

## Proposed changes

* Hide the map block's fallback marker `<ul>` via CSS (`display: none`) so it doesn't render as bullet points when JavaScript fails to load on Simple sites.
* Move large JSON data (`points`, `mapCenter`, `markerColor`, etc.) from HTML `data-*` attributes into a `window.JetpackMapBlockData` JS global injected via `wp_add_inline_script()`, keeping the rendered DOM lightweight.
* Update both `mapbox.js` and `mapkit.js` view scripts to read from the JS global first, falling back to data attributes for backward compatibility with existing saved content.

| Header | After |
|--------|--------|
| <img width="1100" height="781" alt="Screenshot 2026-03-16 at 18 23 06" src="https://github.com/user-attachments/assets/2bd61156-9ad5-4c9d-8cea-6caff1623174" />|<img width="732" height="643" alt="Screenshot 2026-03-16 at 18 21 20" src="https://github.com/user-attachments/assets/66278681-a41c-45ba-bb59-8aed5a4dc744" />| 

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* https://linear.app/a8c/issue/EDI-153/map-block-displays-markers-as-bullet-points-on-simple-sites

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. Create a post with a Map block and add a few markers.
2. Publish the post and view it on the frontend.
3. Verify the map renders correctly with markers (no bullet points visible).
4. In browser DevTools, confirm the opening `<div>` no longer contains large `data-points` or `data-map-center` JSON attributes — instead check that `window.JetpackMapBlockData` contains the payload.
5. Disable JavaScript in the browser and reload — verify the marker list does not appear as bullet points.
6. Test with both Mapbox and MapKit providers if possible.
