### PR TITLE
Add privacy information link to newsletter settings

### DIFF
--- a/projects/packages/newsletter/changelog/fix-newsletter-privacy-info-link
+++ b/projects/packages/newsletter/changelog/fix-newsletter-privacy-info-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add privacy information link to the newsletter settings section

--- a/projects/packages/newsletter/src/settings/sections/newsletter-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-section.tsx
@@ -2,11 +2,13 @@
  * External dependencies
  */
 import analytics from '@automattic/jetpack-analytics';
+import { getRedirectUrl } from '@automattic/jetpack-components';
 import { getSiteType } from '@automattic/jetpack-script-data';
 import {
 	Card,
 	CardHeader,
 	CardBody,
+	CardFooter,
 	ExternalLink,
 	__experimentalHeading as Heading, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
@@ -101,6 +103,13 @@ export function NewsletterSection( { data, onChange }: NewsletterSectionProps ):
 					</div>
 				) }
 			</CardBody>
+			<CardFooter>
+				<ExternalLink
+					href={ getRedirectUrl( 'jetpack-support-subscriptions', { anchor: 'privacy' } ) }
+				>
+					{ __( 'Privacy information', 'jetpack-newsletter' ) }
+				</ExternalLink>
+			</CardFooter>
 		</Card>
 	);
 }


### PR DESCRIPTION
Part of DOTCOM-16310

## Proposed changes
* Add a "Privacy information" link to the Newsletter settings card footer, pointing to the Jetpack subscriptions support page privacy section (`#privacy` anchor).
* This was present in the old Jetpack settings UI (inside an info popover) but missing from the new newsletter settings screen.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* CFT feedback: pdtkmj-4rt-p2#comment-8653

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Ensure the new newsletter settings screen is enabled on a WoA / Jetpack site (`jetpack_wp_admin_newsletter_settings_enabled` filter returns true)
* Go to **Jetpack → Newsletter** (`admin.php?page=jetpack-newsletter`)
* In the **Newsletter** card, verify a "Privacy information" link appears in the card footer (below the toggle and "Manage all subscribers" link)
* Click the link and verify it navigates to the Jetpack subscriptions support page, scrolled to the privacy section

Before | After
-------|------
<img width="1008" height="501" alt="Screenshot 2026-03-13 at 16 48 15" src="https://github.com/user-attachments/assets/1c458415-5bc5-4b0c-a7db-f0e303c8bdf7" /> | <img width="1008" height="501" alt="Screenshot 2026-03-13 at 16 40 46" src="https://github.com/user-attachments/assets/61365560-29ff-4437-b484-d29f827b18d9" />

I feel like this along with the "manage all subscribers" link could do with some design love and an exploration into also applying to simple sites (which have neither at present), but that can happen in a later change.