### PR TITLE
number-formatters: disable broken IDR test

### DIFF
--- a/projects/js-packages/number-formatters/changelog/disable-number-formatters-IDR_test
+++ b/projects/js-packages/number-formatters/changelog/disable-number-formatters-IDR_test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Tests: Disable test incompatible with newer Node versions (22.22.1+).

--- a/projects/js-packages/number-formatters/src/test/number-format-currency.test.ts
+++ b/projects/js-packages/number-formatters/src/test/number-format-currency.test.ts
@@ -411,15 +411,20 @@ describe( 'numberFormatCurrency()', () => {
 			} );
 			expect( money ).toBe( 'R$ 9.800.900,32' );
 		} );
-		it( 'IDR', () => {
-			const money = numberFormatCurrency( {
-				number: 107280000,
-				currency: 'IDR',
-				browserSafeLocale: 'in-ID',
-				isSmallestUnit: true,
-			} );
-			expect( money ).toBe( 'Rp 1.072.800,00' );
-		} );
+		// Disabled temporarily due to the smallest unit being changed:
+		// https://unicode-org.atlassian.net/browse/CLDR-11586
+		// See also: p1773338482018929-slack-C034JEXD1RD
+		// eslint-disable-next-line jest/no-commented-out-tests
+		// it( 'IDR', () => {
+		// 	const money = numberFormatCurrency( {
+		// 		number: 107280000,
+		// 		currency: 'IDR',
+		// 		browserSafeLocale: 'in-ID',
+		// 		isSmallestUnit: true,
+		// 	} );
+		// eslint-disable-next-line no-irregular-whitespace
+		// 	expect( money ).toBe( 'Rp 1.072.800,00' );
+		// } );
 	} );
 } );
 


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
The IDR test is currently broken:
* The GH runners for the Tests workflow oscillate between Node `22.22.0` and `22.22.1`.
* The latter updates ICU from `77.1` → `78.2`
* As part of that change, there's a CLDR change found here: https://unicode-org.atlassian.net/browse/CLDR-11586

That changes the smallest unit for `IDR` and a few other currencies from `0.01` to `1`, and the GH workflow thus sometimes fails, particularly when run on `trunk`.

I'm not sure the implication of this change (e.g. are there values stored elsewhere that need to take this into account?), so instead of changing the "expected" value, I'm disabling the test for now and reaching out to relevant teams in other channels.

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* p1773338482018929-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

JS Tests and Code Coverage should run successfully on the `20260309.50.1` runner.