### PR TITLE
Forms: Add rename and trash actions to single form dropdown

### DIFF
--- a/projects/packages/forms/changelog/update-single-form-dropdown-actions
+++ b/projects/packages/forms/changelog/update-single-form-dropdown-actions
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Add rename, duplicate, and trash actions to the single form dashboard dropdown menu.
+Add rename and trash actions to the single form dashboard dropdown menu, and reorder menu items.

--- a/projects/packages/forms/changelog/update-single-form-dropdown-actions
+++ b/projects/packages/forms/changelog/update-single-form-dropdown-actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add rename, duplicate, and trash actions to the single form dashboard dropdown menu.

--- a/projects/packages/forms/src/dashboard/components/form-name-modal/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/form-name-modal/index.tsx
@@ -129,7 +129,6 @@ export function FormNameModal( {
 			await onSave( finalName );
 		} catch {
 			// Error handling is left to the caller via onSave
-			// Modal stays open on error
 		} finally {
 			setIsSaving( false );
 			onClose();

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -4,7 +4,11 @@
 import { useBreakpointMatch } from '@automattic/jetpack-components';
 import JetpackLogo from '@automattic/jetpack-components/jetpack-logo';
 import { Breadcrumbs } from '@wordpress/admin-ui';
-import { DropdownMenu, Button } from '@wordpress/components';
+import {
+	DropdownMenu,
+	Button,
+	__experimentalConfirmDialog as ConfirmDialog, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/components';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useMemo, useState, useCallback, useRef } from '@wordpress/element';
@@ -20,7 +24,6 @@ import { Badge, Stack } from '@wordpress/ui';
 import { FORM_POST_TYPE } from '../../../blocks/shared/util/constants.js';
 import useConfigValue from '../../../hooks/use-config-value';
 import CreateFormButton from '../../components/create-form-button';
-import EditFormButton from '../../components/edit-form-button';
 import EmptySpamButton from '../../components/empty-spam-button';
 import EmptySpamConfirmationModal from '../../components/empty-spam-button/confirmation-modal';
 import EmptyTrashButton from '../../components/empty-trash-button';
@@ -126,6 +129,10 @@ export default function usePageHeaderDetails(
 	// Empty spam/trash hooks
 	const emptySpam = useEmptySpam();
 	const emptyTrash = useEmptyTrash();
+
+	// Permanent delete confirmation state
+	const [ isPermanentDeleteConfirmOpen, setIsPermanentDeleteConfirmOpen ] = useState( false );
+	const permanentDeleteItemRef = useRef< { id: number } | null >( null );
 
 	// Rename form state
 	const [ renameFormItem, setRenameFormItem ] = useState< { id: number; title: string } | null >(
@@ -302,38 +309,52 @@ export default function usePageHeaderDetails(
 		[ saveEntityRecord, invalidateFormStatusCounts, createSuccessNotice, createErrorNotice ]
 	);
 
-	const permanentlyDeleteForm = useCallback(
-		async ( item: { id: number } ) => {
-			try {
-				await deleteEntityRecord(
-					'postType',
-					FORM_POST_TYPE,
-					item.id,
-					{ force: true },
-					{ throwOnError: true }
-				);
+	const openPermanentDeleteConfirm = useCallback( ( item: { id: number } ) => {
+		permanentDeleteItemRef.current = item;
+		setIsPermanentDeleteConfirmOpen( true );
+	}, [] );
 
-				invalidateFormStatusCounts();
-				createSuccessNotice( __( 'Form deleted permanently.', 'jetpack-forms' ), {
-					type: 'snackbar',
-				} );
-				navigate( { to: '/forms' } );
-			} catch ( error ) {
-				createErrorNotice( __( 'Could not delete form.', 'jetpack-forms' ), {
-					type: 'snackbar',
-				} );
-				// eslint-disable-next-line no-console
-				console.error( 'Failed to permanently delete form:', error );
-			}
-		},
-		[
-			deleteEntityRecord,
-			invalidateFormStatusCounts,
-			createSuccessNotice,
-			createErrorNotice,
-			navigate,
-		]
-	);
+	const closePermanentDeleteConfirm = useCallback( () => {
+		setIsPermanentDeleteConfirmOpen( false );
+		permanentDeleteItemRef.current = null;
+	}, [] );
+
+	const confirmPermanentDelete = useCallback( async () => {
+		const item = permanentDeleteItemRef.current;
+		if ( ! item ) {
+			return;
+		}
+		setIsPermanentDeleteConfirmOpen( false );
+		permanentDeleteItemRef.current = null;
+
+		try {
+			await deleteEntityRecord(
+				'postType',
+				FORM_POST_TYPE,
+				item.id,
+				{ force: true },
+				{ throwOnError: true }
+			);
+
+			invalidateFormStatusCounts();
+			createSuccessNotice( __( 'Form deleted permanently.', 'jetpack-forms' ), {
+				type: 'snackbar',
+			} );
+			navigate( { to: '/forms' } );
+		} catch ( error ) {
+			createErrorNotice( __( 'Could not delete form.', 'jetpack-forms' ), {
+				type: 'snackbar',
+			} );
+			// eslint-disable-next-line no-console
+			console.error( 'Failed to permanently delete form:', error );
+		}
+	}, [
+		deleteEntityRecord,
+		invalidateFormStatusCounts,
+		createSuccessNotice,
+		createErrorNotice,
+		navigate,
+	] );
 
 	const formStatus = formRecord?.status;
 
@@ -371,7 +392,7 @@ export default function usePageHeaderDetails(
 				},
 				{
 					title: __( 'Delete permanently', 'jetpack-forms' ),
-					onClick: () => permanentlyDeleteForm( formItem ),
+					onClick: () => openPermanentDeleteConfirm( formItem ),
 				},
 			];
 		}
@@ -438,7 +459,7 @@ export default function usePageHeaderDetails(
 		duplicateForm,
 		trashForm,
 		restoreForm,
-		permanentlyDeleteForm,
+		openPermanentDeleteConfirm,
 		formRecord?.status,
 		formTitle,
 		isUpdatingStatus,
@@ -685,6 +706,25 @@ export default function usePageHeaderDetails(
 							/>,
 					  ]
 					: [] ),
+				...( isPermanentDeleteConfirmOpen
+					? [
+							<ConfirmDialog
+								key="permanent-delete-confirm"
+								onCancel={ closePermanentDeleteConfirm }
+								onConfirm={ confirmPermanentDelete }
+								isOpen={ isPermanentDeleteConfirmOpen }
+								confirmButtonText={ __( 'Delete permanently', 'jetpack-forms' ) }
+							>
+								<h3>{ __( 'Delete permanently', 'jetpack-forms' ) }</h3>
+								<p>
+									{ __(
+										'This will permanently delete this form. This action cannot be undone.',
+										'jetpack-forms'
+									) }
+								</p>
+							</ConfirmDialog>,
+					  ]
+					: [] ),
 			];
 		}
 
@@ -700,9 +740,6 @@ export default function usePageHeaderDetails(
 
 		if ( isSingleFormScreen ) {
 			return [
-				...( sourceIdNumber
-					? [ <EditFormButton key="edit-form" formId={ sourceIdNumber } /> ]
-					: [] ),
 				<ExportResponsesButton
 					key="export"
 					isPrimary={ statusView === 'inbox' }
@@ -731,6 +768,25 @@ export default function usePageHeaderDetails(
 								title={ __( 'Rename form', 'jetpack-forms' ) }
 								initialValue={ renameRetryRef.current?.title || renameFormItem?.title || '' }
 							/>,
+					  ]
+					: [] ),
+				...( isPermanentDeleteConfirmOpen
+					? [
+							<ConfirmDialog
+								key="permanent-delete-confirm"
+								onCancel={ closePermanentDeleteConfirm }
+								onConfirm={ confirmPermanentDelete }
+								isOpen={ isPermanentDeleteConfirmOpen }
+								confirmButtonText={ __( 'Delete permanently', 'jetpack-forms' ) }
+							>
+								<h3>{ __( 'Delete permanently', 'jetpack-forms' ) }</h3>
+								<p>
+									{ __(
+										'This will permanently delete this form. This action cannot be undone.',
+										'jetpack-forms'
+									) }
+								</p>
+							</ConfirmDialog>,
 					  ]
 					: [] ),
 			];
@@ -801,6 +857,9 @@ export default function usePageHeaderDetails(
 		renameFormItem,
 		closeRenameModal,
 		handleRename,
+		isPermanentDeleteConfirmOpen,
+		closePermanentDeleteConfirm,
+		confirmPermanentDelete,
 	] );
 
 	return { ariaLabel, breadcrumbs, title, badges, subtitle, actions };

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -152,6 +152,23 @@ export default function usePageHeaderDetails(
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { invalidateFormStatusCounts } = useDispatch( dashboardStore );
 
+	const formRecord = useSelect(
+		select =>
+			sourceIdNumber
+				? ( select( coreDataStore ).getEntityRecord(
+						'postType',
+						'jetpack_form',
+						sourceIdNumber
+				  ) as { title?: { rendered?: string }; status?: string } | undefined )
+				: undefined,
+		[ sourceIdNumber ]
+	);
+
+	const formTitle = useMemo( () => {
+		const rendered = formRecord?.title?.rendered || '';
+		return decodeEntities( rendered );
+	}, [ formRecord?.title?.rendered ] );
+
 	const closeRenameModal = useCallback( () => {
 		setRenameFormItem( null );
 		renameRetryRef.current = null;
@@ -259,23 +276,6 @@ export default function usePageHeaderDetails(
 			navigate,
 		]
 	);
-
-	const formRecord = useSelect(
-		select =>
-			sourceIdNumber
-				? ( select( coreDataStore ).getEntityRecord(
-						'postType',
-						'jetpack_form',
-						sourceIdNumber
-				  ) as { title?: { rendered?: string }; status?: string } | undefined )
-				: undefined,
-		[ sourceIdNumber ]
-	);
-
-	const formTitle = useMemo( () => {
-		const rendered = formRecord?.title?.rendered || '';
-		return decodeEntities( rendered );
-	}, [ formRecord?.title?.rendered ] );
 
 	const formStatus = formRecord?.status;
 

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -6,15 +6,17 @@ import JetpackLogo from '@automattic/jetpack-components/jetpack-logo';
 import { Breadcrumbs } from '@wordpress/admin-ui';
 import { DropdownMenu, Button } from '@wordpress/components';
 import { store as coreDataStore } from '@wordpress/core-data';
-import { useSelect } from '@wordpress/data';
-import { useMemo, useState, useCallback } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useMemo, useState, useCallback, useRef } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
 import { Badge, Stack } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
+import { FORM_POST_TYPE } from '../../../blocks/shared/util/constants.js';
 import useConfigValue from '../../../hooks/use-config-value';
 import CreateFormButton from '../../components/create-form-button';
 import EditFormButton from '../../components/edit-form-button';
@@ -122,6 +124,69 @@ export default function usePageHeaderDetails(
 	const emptySpam = useEmptySpam();
 	const emptyTrash = useEmptyTrash();
 
+	// Rename form state
+	const [ renameFormItem, setRenameFormItem ] = useState< { id: number; title: string } | null >(
+		null
+	);
+	const renameRetryRef = useRef< { item: { id: number; title: string }; title: string } | null >(
+		null
+	);
+	const { saveEntityRecord } = useDispatch( 'core' ) as {
+		saveEntityRecord: (
+			kind: string,
+			name: string,
+			record: Record< string, unknown >,
+			options?: { throwOnError?: boolean }
+		) => Promise< unknown >;
+	};
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	const closeRenameModal = useCallback( () => {
+		setRenameFormItem( null );
+		renameRetryRef.current = null;
+	}, [] );
+
+	const handleRename = useCallback(
+		async ( newTitle: string ) => {
+			if ( ! renameFormItem ) {
+				return;
+			}
+			try {
+				await saveEntityRecord(
+					'postType',
+					FORM_POST_TYPE,
+					{
+						id: renameFormItem.id,
+						title: newTitle,
+					},
+					{ throwOnError: true }
+				);
+
+				createSuccessNotice( __( 'Form renamed.', 'jetpack-forms' ), { type: 'snackbar' } );
+				renameRetryRef.current = null;
+			} catch ( error ) {
+				const retryItem = renameFormItem;
+				const retryTitle = newTitle;
+
+				createErrorNotice( __( 'Failed to rename form.', 'jetpack-forms' ), {
+					type: 'snackbar',
+					actions: [
+						{
+							label: __( 'Retry', 'jetpack-forms' ),
+							onClick: () => {
+								renameRetryRef.current = { item: retryItem, title: retryTitle };
+								setRenameFormItem( retryItem );
+							},
+						},
+					],
+				} );
+				// eslint-disable-next-line no-console
+				console.error( 'Failed to rename form:', error );
+			}
+		},
+		[ renameFormItem, saveEntityRecord, createSuccessNotice, createErrorNotice ]
+	);
+
 	const formRecord = useSelect(
 		select =>
 			sourceIdNumber
@@ -167,6 +232,10 @@ export default function usePageHeaderDetails(
 
 		const formItem = { id: sourceIdNumber, title: formTitle };
 		const controls: Array< { title: string; onClick: () => void } > = [
+			{
+				title: __( 'Rename', 'jetpack-forms' ),
+				onClick: () => setRenameFormItem( formItem ),
+			},
 			{
 				title: __( 'Duplicate', 'jetpack-forms' ),
 				onClick: () => duplicateForm( formItem ),
@@ -449,6 +518,18 @@ export default function usePageHeaderDetails(
 							/>,
 					  ]
 					: [] ),
+				...( renameFormItem
+					? [
+							<FormNameModal
+								key="rename-form-modal"
+								isOpen={ !! renameFormItem }
+								onClose={ closeRenameModal }
+								onSave={ handleRename }
+								title={ __( 'Rename form', 'jetpack-forms' ) }
+								initialValue={ renameRetryRef.current?.title || renameFormItem?.title || '' }
+							/>,
+					  ]
+					: [] ),
 			];
 		}
 
@@ -482,6 +563,18 @@ export default function usePageHeaderDetails(
 								icon={ moreVertical }
 								label={ __( 'More actions', 'jetpack-forms' ) }
 								toggleProps={ { size: 'compact' } }
+							/>,
+					  ]
+					: [] ),
+				...( renameFormItem
+					? [
+							<FormNameModal
+								key="rename-form-modal"
+								isOpen={ !! renameFormItem }
+								onClose={ closeRenameModal }
+								onSave={ handleRename }
+								title={ __( 'Rename form', 'jetpack-forms' ) }
+								initialValue={ renameRetryRef.current?.title || renameFormItem?.title || '' }
 							/>,
 					  ]
 					: [] ),
@@ -550,6 +643,9 @@ export default function usePageHeaderDetails(
 		emptySpam.onConfirmEmptying,
 		emptySpam.totalItemsSpam,
 		emptySpam.selectedResponsesCount,
+		renameFormItem,
+		closeRenameModal,
+		handleRename,
 	] );
 
 	return { ariaLabel, breadcrumbs, title, badges, subtitle, actions };

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -279,14 +279,6 @@ export default function usePageHeaderDetails(
 		const formItem = { id: sourceIdNumber, title: formTitle };
 		const controls: Array< { title: string; onClick: () => void } > = [
 			{
-				title: __( 'Rename', 'jetpack-forms' ),
-				onClick: () => setRenameFormItem( formItem ),
-			},
-			{
-				title: __( 'Duplicate', 'jetpack-forms' ),
-				onClick: () => duplicateForm( formItem ),
-			},
-			{
 				title: __( 'Preview', 'jetpack-forms' ),
 				onClick: () => previewForm( formItem ),
 			},
@@ -325,10 +317,20 @@ export default function usePageHeaderDetails(
 			} );
 		}
 
-		controls.push( {
-			title: __( 'Move to trash', 'jetpack-forms' ),
-			onClick: () => trashForm( formItem ),
-		} );
+		controls.push(
+			{
+				title: __( 'Rename', 'jetpack-forms' ),
+				onClick: () => setRenameFormItem( formItem ),
+			},
+			{
+				title: __( 'Duplicate', 'jetpack-forms' ),
+				onClick: () => duplicateForm( formItem ),
+			},
+			{
+				title: __( 'Trash', 'jetpack-forms' ),
+				onClick: () => trashForm( formItem ),
+			}
+		);
 
 		return controls;
 	}, [

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -277,6 +277,71 @@ export default function usePageHeaderDetails(
 		]
 	);
 
+	const restoreForm = useCallback(
+		async ( item: { id: number } ) => {
+			try {
+				await saveEntityRecord(
+					'postType',
+					FORM_POST_TYPE,
+					{ id: item.id, status: 'publish' },
+					{ throwOnError: true }
+				);
+
+				invalidateFormStatusCounts();
+				createSuccessNotice( __( 'Form restored.', 'jetpack-forms' ), {
+					type: 'snackbar',
+				} );
+				navigate( { to: '/forms' } );
+			} catch ( error ) {
+				createErrorNotice( __( 'Could not restore form.', 'jetpack-forms' ), {
+					type: 'snackbar',
+				} );
+				// eslint-disable-next-line no-console
+				console.error( 'Failed to restore form:', error );
+			}
+		},
+		[
+			saveEntityRecord,
+			invalidateFormStatusCounts,
+			createSuccessNotice,
+			createErrorNotice,
+			navigate,
+		]
+	);
+
+	const permanentlyDeleteForm = useCallback(
+		async ( item: { id: number } ) => {
+			try {
+				await deleteEntityRecord(
+					'postType',
+					FORM_POST_TYPE,
+					item.id,
+					{ force: true },
+					{ throwOnError: true }
+				);
+
+				invalidateFormStatusCounts();
+				createSuccessNotice( __( 'Form deleted permanently.', 'jetpack-forms' ), {
+					type: 'snackbar',
+				} );
+				navigate( { to: '/forms' } );
+			} catch ( error ) {
+				createErrorNotice( __( 'Could not delete form.', 'jetpack-forms' ), {
+					type: 'snackbar',
+				} );
+				// eslint-disable-next-line no-console
+				console.error( 'Failed to permanently delete form:', error );
+			}
+		},
+		[
+			deleteEntityRecord,
+			invalidateFormStatusCounts,
+			createSuccessNotice,
+			createErrorNotice,
+			navigate,
+		]
+	);
+
 	const formStatus = formRecord?.status;
 
 	const statusLabel = formStatus ? getFormStatusLabel( formStatus ) : undefined;
@@ -304,6 +369,20 @@ export default function usePageHeaderDetails(
 		}
 
 		const formItem = { id: sourceIdNumber, title: formTitle };
+
+		if ( formRecord?.status === 'trash' ) {
+			return [
+				{
+					title: __( 'Restore', 'jetpack-forms' ),
+					onClick: () => restoreForm( formItem ),
+				},
+				{
+					title: __( 'Delete permanently', 'jetpack-forms' ),
+					onClick: () => permanentlyDeleteForm( formItem ),
+				},
+			];
+		}
+
 		const controls: Array< { title: string; onClick: () => void } > = [
 			{
 				title: __( 'Preview', 'jetpack-forms' ),
@@ -324,42 +403,40 @@ export default function usePageHeaderDetails(
 			);
 		}
 
-		if ( formRecord?.status !== 'trash' ) {
-			if ( formRecord?.status === 'publish' ) {
-				controls.push( {
-					title: __( 'Unpublish', 'jetpack-forms' ),
-					onClick: () => {
-						if ( ! isUpdatingStatus ) {
-							setFormsToDraft( [ formItem ] );
-						}
-					},
-				} );
-			} else {
-				controls.push( {
-					title: __( 'Publish', 'jetpack-forms' ),
-					onClick: () => {
-						if ( ! isUpdatingStatus ) {
-							publishForms( [ formItem ] );
-						}
-					},
-				} );
-			}
-
-			controls.push(
-				{
-					title: __( 'Rename', 'jetpack-forms' ),
-					onClick: () => setRenameFormItem( formItem ),
+		if ( formRecord?.status === 'publish' ) {
+			controls.push( {
+				title: __( 'Unpublish', 'jetpack-forms' ),
+				onClick: () => {
+					if ( ! isUpdatingStatus ) {
+						setFormsToDraft( [ formItem ] );
+					}
 				},
-				{
-					title: __( 'Duplicate', 'jetpack-forms' ),
-					onClick: () => duplicateForm( formItem ),
+			} );
+		} else {
+			controls.push( {
+				title: __( 'Publish', 'jetpack-forms' ),
+				onClick: () => {
+					if ( ! isUpdatingStatus ) {
+						publishForms( [ formItem ] );
+					}
 				},
-				{
-					title: __( 'Trash', 'jetpack-forms' ),
-					onClick: () => trashForm( formItem ),
-				}
-			);
+			} );
 		}
+
+		controls.push(
+			{
+				title: __( 'Rename', 'jetpack-forms' ),
+				onClick: () => setRenameFormItem( formItem ),
+			},
+			{
+				title: __( 'Duplicate', 'jetpack-forms' ),
+				onClick: () => duplicateForm( formItem ),
+			},
+			{
+				title: __( 'Trash', 'jetpack-forms' ),
+				onClick: () => trashForm( formItem ),
+			}
+		);
 
 		return controls;
 	}, [
@@ -367,6 +444,8 @@ export default function usePageHeaderDetails(
 		copyShortcode,
 		duplicateForm,
 		trashForm,
+		restoreForm,
+		permanentlyDeleteForm,
 		formRecord?.status,
 		formTitle,
 		isUpdatingStatus,

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -12,6 +12,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
+import { useNavigate } from '@wordpress/route';
 import { Badge, Stack } from '@wordpress/ui';
 /**
  * Internal dependencies
@@ -33,6 +34,7 @@ import useEmptySpam from '../../hooks/use-empty-spam';
 import useEmptyTrash from '../../hooks/use-empty-trash';
 import useExportResponses from '../../hooks/use-export-responses';
 import useInboxData from '../../hooks/use-inbox-data';
+import { store as dashboardStore } from '../../store/index.js';
 import { getFormEditUrl } from '../../utils.ts';
 import ManageIntegrationsButton from '../components/manage-integrations-button';
 import useFormItemActions from './use-form-item-actions';
@@ -91,6 +93,7 @@ export default function usePageHeaderDetails(
 
 	// Detect mobile viewport
 	const [ isSm ] = useBreakpointMatch( 'sm' );
+	const navigate = useNavigate();
 
 	// Mutually-exclusive screen flags.
 	const isFormsScreen = screen === 'forms';
@@ -131,15 +134,23 @@ export default function usePageHeaderDetails(
 	const renameRetryRef = useRef< { item: { id: number; title: string }; title: string } | null >(
 		null
 	);
-	const { saveEntityRecord } = useDispatch( 'core' ) as {
+	const { saveEntityRecord, deleteEntityRecord } = useDispatch( 'core' ) as {
 		saveEntityRecord: (
 			kind: string,
 			name: string,
 			record: Record< string, unknown >,
 			options?: { throwOnError?: boolean }
 		) => Promise< unknown >;
+		deleteEntityRecord: (
+			kind: string,
+			name: string,
+			recordId: number,
+			query?: Record< string, unknown >,
+			options?: { throwOnError?: boolean }
+		) => Promise< unknown >;
 	};
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const { invalidateFormStatusCounts } = useDispatch( dashboardStore );
 
 	const closeRenameModal = useCallback( () => {
 		setRenameFormItem( null );
@@ -185,6 +196,41 @@ export default function usePageHeaderDetails(
 			}
 		},
 		[ renameFormItem, saveEntityRecord, createSuccessNotice, createErrorNotice ]
+	);
+
+	const trashForm = useCallback(
+		async ( item: { id: number } ) => {
+			try {
+				await deleteEntityRecord(
+					'postType',
+					FORM_POST_TYPE,
+					item.id,
+					{ force: false },
+					{ throwOnError: true }
+				);
+
+				invalidateFormStatusCounts();
+				createSuccessNotice( __( 'Form moved to trash.', 'jetpack-forms' ), {
+					type: 'snackbar',
+				} );
+
+				// Navigate back to the forms list since the form no longer exists.
+				navigate( { to: '/forms' } );
+			} catch ( error ) {
+				createErrorNotice( __( 'Failed to move form to trash.', 'jetpack-forms' ), {
+					type: 'snackbar',
+				} );
+				// eslint-disable-next-line no-console
+				console.error( 'Failed to trash form:', error );
+			}
+		},
+		[
+			deleteEntityRecord,
+			invalidateFormStatusCounts,
+			createSuccessNotice,
+			createErrorNotice,
+			navigate,
+		]
 	);
 
 	const formRecord = useSelect(
@@ -279,11 +325,17 @@ export default function usePageHeaderDetails(
 			} );
 		}
 
+		controls.push( {
+			title: __( 'Move to trash', 'jetpack-forms' ),
+			onClick: () => trashForm( formItem ),
+		} );
+
 		return controls;
 	}, [
 		copyEmbed,
 		copyShortcode,
 		duplicateForm,
+		trashForm,
 		formRecord?.status,
 		formTitle,
 		isUpdatingStatus,

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -24,6 +24,7 @@ import { Badge, Stack } from '@wordpress/ui';
 import { FORM_POST_TYPE } from '../../../blocks/shared/util/constants.js';
 import useConfigValue from '../../../hooks/use-config-value';
 import CreateFormButton from '../../components/create-form-button';
+import EditFormButton from '../../components/edit-form-button';
 import EmptySpamButton from '../../components/empty-spam-button';
 import EmptySpamConfirmationModal from '../../components/empty-spam-button/confirmation-modal';
 import EmptyTrashButton from '../../components/empty-trash-button';
@@ -160,14 +161,17 @@ export default function usePageHeaderDetails(
 	const { invalidateFormStatusCounts } = useDispatch( dashboardStore );
 
 	const formRecord = useSelect(
-		select =>
-			sourceIdNumber
-				? ( select( coreDataStore ).getEntityRecord(
-						'postType',
-						'jetpack_form',
-						sourceIdNumber
-				  ) as { title?: { rendered?: string }; status?: string } | undefined )
-				: undefined,
+		select => {
+			if ( ! sourceIdNumber ) {
+				return undefined;
+			}
+			const record = select( coreDataStore ).getEntityRecord(
+				'postType',
+				'jetpack_form',
+				sourceIdNumber
+			) as { title?: { rendered?: string }; status?: string } | undefined;
+			return record;
+		},
 		[ sourceIdNumber ]
 	);
 
@@ -740,6 +744,9 @@ export default function usePageHeaderDetails(
 
 		if ( isSingleFormScreen ) {
 			return [
+				...( sourceIdNumber && formStatus !== 'trash'
+					? [ <EditFormButton key="edit-form" formId={ sourceIdNumber } /> ]
+					: [] ),
 				<ExportResponsesButton
 					key="export"
 					isPrimary={ statusView === 'inbox' }
@@ -860,6 +867,7 @@ export default function usePageHeaderDetails(
 		isPermanentDeleteConfirmOpen,
 		closePermanentDeleteConfirm,
 		confirmPermanentDelete,
+		formStatus,
 	] );
 
 	return { ariaLabel, breadcrumbs, title, badges, subtitle, actions };

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -142,7 +142,7 @@ export default function usePageHeaderDetails(
 	const renameRetryRef = useRef< { item: { id: number; title: string }; title: string } | null >(
 		null
 	);
-	const { saveEntityRecord, deleteEntityRecord } = useDispatch( 'core' ) as {
+	const { saveEntityRecord, deleteEntityRecord } = useDispatch( coreDataStore ) as {
 		saveEntityRecord: (
 			kind: string,
 			name: string,

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -200,6 +200,7 @@ export default function usePageHeaderDetails(
 
 	const trashForm = useCallback(
 		async ( item: { id: number } ) => {
+			const previousStatus = formRecord?.status || 'draft';
 			try {
 				await deleteEntityRecord(
 					'postType',
@@ -212,6 +213,30 @@ export default function usePageHeaderDetails(
 				invalidateFormStatusCounts();
 				createSuccessNotice( __( 'Form moved to trash.', 'jetpack-forms' ), {
 					type: 'snackbar',
+					actions: [
+						{
+							label: __( 'Undo', 'jetpack-forms' ),
+							onClick: () => {
+								saveEntityRecord(
+									'postType',
+									FORM_POST_TYPE,
+									{ id: item.id, status: previousStatus },
+									{ throwOnError: true }
+								)
+									.then( () => {
+										invalidateFormStatusCounts();
+										createSuccessNotice( __( 'Form restored.', 'jetpack-forms' ), {
+											type: 'snackbar',
+										} );
+									} )
+									.catch( () => {
+										createErrorNotice( __( 'Could not restore form.', 'jetpack-forms' ), {
+											type: 'snackbar',
+										} );
+									} );
+							},
+						},
+					],
 				} );
 
 				// Navigate back to the forms list since the form no longer exists.
@@ -226,9 +251,11 @@ export default function usePageHeaderDetails(
 		},
 		[
 			deleteEntityRecord,
+			formRecord?.status,
 			invalidateFormStatusCounts,
 			createSuccessNotice,
 			createErrorNotice,
+			saveEntityRecord,
 			navigate,
 		]
 	);
@@ -297,40 +324,42 @@ export default function usePageHeaderDetails(
 			);
 		}
 
-		if ( formRecord?.status === 'publish' ) {
-			controls.push( {
-				title: __( 'Unpublish', 'jetpack-forms' ),
-				onClick: () => {
-					if ( ! isUpdatingStatus ) {
-						setFormsToDraft( [ formItem ] );
-					}
-				},
-			} );
-		} else {
-			controls.push( {
-				title: __( 'Publish', 'jetpack-forms' ),
-				onClick: () => {
-					if ( ! isUpdatingStatus ) {
-						publishForms( [ formItem ] );
-					}
-				},
-			} );
-		}
-
-		controls.push(
-			{
-				title: __( 'Rename', 'jetpack-forms' ),
-				onClick: () => setRenameFormItem( formItem ),
-			},
-			{
-				title: __( 'Duplicate', 'jetpack-forms' ),
-				onClick: () => duplicateForm( formItem ),
-			},
-			{
-				title: __( 'Trash', 'jetpack-forms' ),
-				onClick: () => trashForm( formItem ),
+		if ( formRecord?.status !== 'trash' ) {
+			if ( formRecord?.status === 'publish' ) {
+				controls.push( {
+					title: __( 'Unpublish', 'jetpack-forms' ),
+					onClick: () => {
+						if ( ! isUpdatingStatus ) {
+							setFormsToDraft( [ formItem ] );
+						}
+					},
+				} );
+			} else {
+				controls.push( {
+					title: __( 'Publish', 'jetpack-forms' ),
+					onClick: () => {
+						if ( ! isUpdatingStatus ) {
+							publishForms( [ formItem ] );
+						}
+					},
+				} );
 			}
-		);
+
+			controls.push(
+				{
+					title: __( 'Rename', 'jetpack-forms' ),
+					onClick: () => setRenameFormItem( formItem ),
+				},
+				{
+					title: __( 'Duplicate', 'jetpack-forms' ),
+					onClick: () => duplicateForm( formItem ),
+				},
+				{
+					title: __( 'Trash', 'jetpack-forms' ),
+					onClick: () => trashForm( formItem ),
+				}
+			);
+		}
 
 		return controls;
 	}, [

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -291,7 +291,6 @@ export default function usePageHeaderDetails(
 				createSuccessNotice( __( 'Form restored.', 'jetpack-forms' ), {
 					type: 'snackbar',
 				} );
-				navigate( { to: '/forms' } );
 			} catch ( error ) {
 				createErrorNotice( __( 'Could not restore form.', 'jetpack-forms' ), {
 					type: 'snackbar',
@@ -300,13 +299,7 @@ export default function usePageHeaderDetails(
 				console.error( 'Failed to restore form:', error );
 			}
 		},
-		[
-			saveEntityRecord,
-			invalidateFormStatusCounts,
-			createSuccessNotice,
-			createErrorNotice,
-			navigate,
-		]
+		[ saveEntityRecord, invalidateFormStatusCounts, createSuccessNotice, createErrorNotice ]
 	);
 
 	const permanentlyDeleteForm = useCallback(

--- a/projects/packages/forms/tests/js/dashboard/hooks/use-page-header-details.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/hooks/use-page-header-details.test.jsx
@@ -366,7 +366,7 @@ describe( 'usePageHeaderDetails', () => {
 			expect( titles ).toEqual( [ 'Restore', 'Delete permanently' ] );
 		} );
 
-		it( 'calls saveEntityRecord with publish status on restore', async () => {
+		it( 'calls saveEntityRecord with publish status on restore and stays on page', async () => {
 			mockFormRecord = { title: { rendered: 'Trashed Form' }, status: 'trash' };
 			const { result } = renderHook( () =>
 				usePageHeaderDetails( { ...defaultProps, statusView: 'trash' } )
@@ -387,7 +387,7 @@ describe( 'usePageHeaderDetails', () => {
 				expect( mockCreateSuccessNotice ).toHaveBeenCalledWith( 'Form restored.', {
 					type: 'snackbar',
 				} );
-				expect( mockNavigate ).toHaveBeenCalledWith( { to: '/forms' } );
+				expect( mockNavigate ).not.toHaveBeenCalled();
 			} );
 		} );
 

--- a/projects/packages/forms/tests/js/dashboard/hooks/use-page-header-details.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/hooks/use-page-header-details.test.jsx
@@ -1,0 +1,482 @@
+/**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+// ── Mock external dependencies ──────────────────────────────────────────────
+
+const mockUseBreakpointMatch = jest.fn( () => [ false ] );
+await jest.unstable_mockModule( '@automattic/jetpack-components', () => ( {
+	useBreakpointMatch: mockUseBreakpointMatch,
+} ) );
+await jest.unstable_mockModule( '@automattic/jetpack-components/jetpack-logo', () => ( {
+	default: () => null,
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/admin-ui', () => ( {
+	Breadcrumbs: ( { items } ) => items.map( item => item.label ).join( ' > ' ),
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/components', () => ( {
+	DropdownMenu: () => null,
+	Button: ( { children } ) => children,
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/core-data', () => ( {
+	store: 'core',
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/html-entities', () => ( {
+	decodeEntities: jest.fn( str => str ),
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/i18n', () => ( {
+	__: jest.fn( str => str ),
+	sprintf: jest.fn( ( format, ...args ) => {
+		let result = format;
+		args.forEach( arg => {
+			result = result.replace( '%s', arg );
+		} );
+		return result;
+	} ),
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/icons', () => ( {
+	moreVertical: 'moreVertical',
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/notices', () => ( {
+	store: 'notices',
+} ) );
+
+const mockNavigate = jest.fn();
+await jest.unstable_mockModule( '@wordpress/route', () => ( {
+	useNavigate: () => mockNavigate,
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/ui', () => ( {
+	Badge: ( { children } ) => children,
+	Stack: ( { children } ) => children,
+} ) );
+
+// ── Mock internal dependencies ──────────────────────────────────────────────
+
+await jest.unstable_mockModule( '../../../../src/blocks/shared/util/constants.js', () => ( {
+	FORM_POST_TYPE: 'jetpack_form',
+} ) );
+
+await jest.unstable_mockModule( '../../../../src/dashboard/components/create-form-button', () => ( {
+	default: () => null,
+} ) );
+await jest.unstable_mockModule( '../../../../src/dashboard/components/edit-form-button', () => ( {
+	default: () => null,
+} ) );
+await jest.unstable_mockModule( '../../../../src/dashboard/components/empty-spam-button', () => ( {
+	default: () => null,
+} ) );
+await jest.unstable_mockModule(
+	'../../../../src/dashboard/components/empty-spam-button/confirmation-modal',
+	() => ( { default: () => null } )
+);
+await jest.unstable_mockModule( '../../../../src/dashboard/components/empty-trash-button', () => ( {
+	default: () => null,
+} ) );
+await jest.unstable_mockModule(
+	'../../../../src/dashboard/components/empty-trash-button/confirmation-modal',
+	() => ( { default: () => null } )
+);
+await jest.unstable_mockModule(
+	'../../../../src/dashboard/components/export-responses/button',
+	() => ( { default: () => null } )
+);
+await jest.unstable_mockModule(
+	'../../../../src/dashboard/components/export-responses/modal',
+	() => ( { default: () => null } )
+);
+await jest.unstable_mockModule( '../../../../src/dashboard/components/form-name-modal', () => ( {
+	FormNameModal: () => null,
+} ) );
+await jest.unstable_mockModule(
+	'../../../../src/dashboard/wp-build/components/manage-integrations-button',
+	() => ( { default: () => null } )
+);
+
+await jest.unstable_mockModule( '../../../../src/dashboard/constants', () => ( {
+	getFormStatusLabel: jest.fn( status => status ),
+} ) );
+
+await jest.unstable_mockModule( '../../../../src/dashboard/hooks/use-create-form', () => ( {
+	default: () => ( { openNewForm: jest.fn() } ),
+} ) );
+
+await jest.unstable_mockModule( '../../../../src/dashboard/hooks/use-empty-spam', () => ( {
+	default: () => ( {
+		openConfirmDialog: jest.fn(),
+		closeConfirmDialog: jest.fn(),
+		onConfirmEmptying: jest.fn(),
+		isEmpty: false,
+		isEmptying: false,
+		isConfirmDialogOpen: false,
+		totalItemsSpam: 0,
+		selectedResponsesCount: 0,
+	} ),
+} ) );
+
+await jest.unstable_mockModule( '../../../../src/dashboard/hooks/use-empty-trash', () => ( {
+	default: () => ( {
+		openConfirmDialog: jest.fn(),
+		closeConfirmDialog: jest.fn(),
+		onConfirmEmptying: jest.fn(),
+		isEmpty: false,
+		isEmptying: false,
+		isConfirmDialogOpen: false,
+		totalItemsTrash: 0,
+		selectedResponsesCount: 0,
+	} ),
+} ) );
+
+await jest.unstable_mockModule( '../../../../src/dashboard/hooks/use-export-responses', () => ( {
+	default: () => ( {
+		showExportModal: false,
+		openModal: jest.fn(),
+		closeModal: jest.fn(),
+		onExport: jest.fn(),
+		autoConnectGdrive: false,
+		exportLabel: 'Export',
+	} ),
+} ) );
+
+await jest.unstable_mockModule( '../../../../src/dashboard/hooks/use-inbox-data', () => ( {
+	default: () => ( { totalItems: 10, isLoadingData: false } ),
+} ) );
+
+await jest.unstable_mockModule( '../../../../src/dashboard/store/index.js', () => ( {
+	store: 'dashboard',
+} ) );
+
+// ── Mock @wordpress/data (core mock with configurable form record) ──────────
+
+const mockSaveEntityRecord = jest.fn( () => Promise.resolve() );
+const mockDeleteEntityRecord = jest.fn( () => Promise.resolve() );
+const mockCreateSuccessNotice = jest.fn();
+const mockCreateErrorNotice = jest.fn();
+const mockInvalidateFormStatusCounts = jest.fn();
+
+const mockDuplicateForm = jest.fn();
+const mockPreviewForm = jest.fn();
+const mockCopyEmbed = jest.fn();
+const mockCopyShortcode = jest.fn();
+const mockPublishForms = jest.fn();
+const mockSetFormsToDraft = jest.fn();
+
+let mockFormRecord = { title: { rendered: 'My Form' }, status: 'publish' };
+
+await jest.unstable_mockModule( '@wordpress/data', () => ( {
+	useSelect: jest.fn( callback => {
+		const fakeSelect = () => ( {
+			getEntityRecord: () => mockFormRecord,
+		} );
+		return callback( fakeSelect );
+	} ),
+	useDispatch: jest.fn( store => {
+		if ( store === 'core' ) {
+			return {
+				saveEntityRecord: mockSaveEntityRecord,
+				deleteEntityRecord: mockDeleteEntityRecord,
+			};
+		}
+		if ( store === 'notices' ) {
+			return {
+				createSuccessNotice: mockCreateSuccessNotice,
+				createErrorNotice: mockCreateErrorNotice,
+			};
+		}
+		if ( store === 'dashboard' ) {
+			return {
+				invalidateFormStatusCounts: mockInvalidateFormStatusCounts,
+			};
+		}
+		return {};
+	} ),
+} ) );
+
+await jest.unstable_mockModule(
+	'../../../../src/dashboard/wp-build/hooks/use-form-item-actions',
+	() => ( {
+		default: () => ( {
+			duplicateForm: mockDuplicateForm,
+			previewForm: mockPreviewForm,
+			copyEmbed: mockCopyEmbed,
+			copyShortcode: mockCopyShortcode,
+			publishForms: mockPublishForms,
+			setFormsToDraft: mockSetFormsToDraft,
+			isDuplicating: false,
+			isUpdatingStatus: false,
+		} ),
+	} )
+);
+
+// ── Import hook under test (after all mocks) ────────────────────────────────
+
+const usePageHeaderDetailsModule = await import(
+	'../../../../src/dashboard/wp-build/hooks/use-page-header-details'
+);
+const usePageHeaderDetails = usePageHeaderDetailsModule.default;
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+const defaultProps = {
+	screen: 'responses',
+	statusView: 'inbox',
+	sourceId: 42,
+	isIntegrationsEnabled: false,
+	showDashboardIntegrations: false,
+	onOpenIntegrations: jest.fn(),
+};
+
+/**
+ * Extract dropdown control titles from the hook result's actions array.
+ *
+ * @param {object} result - The renderHook result ref.
+ * @return {string[]} Array of control title strings.
+ */
+function getControlTitles( result ) {
+	// Actions is an array of React elements; find the DropdownMenu and extract its controls prop.
+	const actions = result.current.actions;
+	if ( ! actions || ! Array.isArray( actions ) ) {
+		return [];
+	}
+	for ( const action of actions ) {
+		if ( action?.props?.controls ) {
+			return action.props.controls.map( c => c.title );
+		}
+	}
+	return [];
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe( 'usePageHeaderDetails', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockFormRecord = { title: { rendered: 'My Form' }, status: 'publish' };
+		mockUseBreakpointMatch.mockReturnValue( [ false ] ); // Desktop
+	} );
+
+	describe( 'return shape', () => {
+		it( 'returns expected keys', () => {
+			const { result } = renderHook( () => usePageHeaderDetails( defaultProps ) );
+
+			expect( result.current ).toHaveProperty( 'ariaLabel' );
+			expect( result.current ).toHaveProperty( 'breadcrumbs' );
+			expect( result.current ).toHaveProperty( 'title' );
+			expect( result.current ).toHaveProperty( 'badges' );
+			expect( result.current ).toHaveProperty( 'subtitle' );
+			expect( result.current ).toHaveProperty( 'actions' );
+		} );
+	} );
+
+	describe( 'ariaLabel', () => {
+		it( 'returns form title for single form screen', () => {
+			const { result } = renderHook( () => usePageHeaderDetails( defaultProps ) );
+
+			expect( result.current.ariaLabel ).toBe( 'My Form' );
+		} );
+
+		it( 'returns fallback when no form title', () => {
+			mockFormRecord = { title: { rendered: '' }, status: 'publish' };
+			const { result } = renderHook( () => usePageHeaderDetails( defaultProps ) );
+
+			expect( result.current.ariaLabel ).toBe( 'Form responses' );
+		} );
+
+		it( 'returns Jetpack Forms for forms screen', () => {
+			const { result } = renderHook( () =>
+				usePageHeaderDetails( { ...defaultProps, screen: 'forms', sourceId: undefined } )
+			);
+
+			expect( result.current.ariaLabel ).toBe( 'Jetpack Forms' );
+		} );
+	} );
+
+	describe( 'title and breadcrumbs', () => {
+		it( 'returns null title and breadcrumbs for single form screen', () => {
+			const { result } = renderHook( () => usePageHeaderDetails( defaultProps ) );
+
+			expect( result.current.title ).toBeNull();
+			expect( result.current.breadcrumbs ).not.toBeNull();
+		} );
+
+		it( 'returns title and null breadcrumbs for forms screen', () => {
+			const { result } = renderHook( () =>
+				usePageHeaderDetails( { ...defaultProps, screen: 'forms', sourceId: undefined } )
+			);
+
+			expect( result.current.title ).not.toBeNull();
+			expect( result.current.breadcrumbs ).toBeNull();
+		} );
+	} );
+
+	describe( 'subtitle', () => {
+		it( 'includes form title for single form screen', () => {
+			const { result } = renderHook( () => usePageHeaderDetails( defaultProps ) );
+
+			expect( result.current.subtitle ).toContain( 'My Form' );
+		} );
+
+		it( 'returns generic message for responses list', () => {
+			const { result } = renderHook( () =>
+				usePageHeaderDetails( { ...defaultProps, sourceId: undefined } )
+			);
+
+			expect( result.current.subtitle ).toBe(
+				'View and manage all your form responses in one place.'
+			);
+		} );
+	} );
+
+	describe( 'formItemControls order', () => {
+		it( 'returns controls in the correct order for a published form', () => {
+			const { result } = renderHook( () => usePageHeaderDetails( defaultProps ) );
+			const titles = getControlTitles( result );
+
+			// navigator.clipboard is undefined in jsdom, so Copy embed/shortcode are excluded.
+			expect( titles ).toEqual( [ 'Preview', 'Unpublish', 'Rename', 'Duplicate', 'Trash' ] );
+		} );
+
+		it( 'shows Publish instead of Unpublish for draft form', () => {
+			mockFormRecord = { title: { rendered: 'Draft Form' }, status: 'draft' };
+			const { result } = renderHook( () => usePageHeaderDetails( defaultProps ) );
+			const titles = getControlTitles( result );
+
+			expect( titles ).toContain( 'Publish' );
+			expect( titles ).not.toContain( 'Unpublish' );
+		} );
+	} );
+
+	describe( 'trashed form guard', () => {
+		it( 'hides Rename, Duplicate, Trash, and Publish for trashed forms', () => {
+			mockFormRecord = { title: { rendered: 'Trashed Form' }, status: 'trash' };
+			const { result } = renderHook( () =>
+				usePageHeaderDetails( { ...defaultProps, statusView: 'trash' } )
+			);
+			const titles = getControlTitles( result );
+
+			expect( titles ).toContain( 'Preview' );
+			expect( titles ).not.toContain( 'Rename' );
+			expect( titles ).not.toContain( 'Duplicate' );
+			expect( titles ).not.toContain( 'Trash' );
+			expect( titles ).not.toContain( 'Publish' );
+			expect( titles ).not.toContain( 'Unpublish' );
+		} );
+	} );
+
+	describe( 'badges', () => {
+		it( 'returns no badge for published form', () => {
+			const { result } = renderHook( () => usePageHeaderDetails( defaultProps ) );
+
+			expect( result.current.badges ).toBeUndefined();
+		} );
+
+		it( 'returns a badge for draft form', () => {
+			mockFormRecord = { title: { rendered: 'Draft Form' }, status: 'draft' };
+			const { result } = renderHook( () => usePageHeaderDetails( defaultProps ) );
+
+			expect( result.current.badges ).toBeDefined();
+		} );
+	} );
+
+	describe( 'trashForm', () => {
+		it( 'calls deleteEntityRecord and navigates to /forms on success', async () => {
+			const { result } = renderHook( () => usePageHeaderDetails( defaultProps ) );
+			const titles = getControlTitles( result );
+			const trashIndex = titles.indexOf( 'Trash' );
+
+			await act( async () => {
+				result.current.actions
+					.find( a => a?.props?.controls )
+					.props.controls[ trashIndex ].onClick();
+			} );
+
+			await waitFor( () => {
+				expect( mockDeleteEntityRecord ).toHaveBeenCalledWith(
+					'postType',
+					'jetpack_form',
+					42,
+					{ force: false },
+					{ throwOnError: true }
+				);
+				expect( mockInvalidateFormStatusCounts ).toHaveBeenCalled();
+				expect( mockCreateSuccessNotice ).toHaveBeenCalledWith(
+					'Form moved to trash.',
+					expect.objectContaining( {
+						type: 'snackbar',
+						actions: expect.arrayContaining( [ expect.objectContaining( { label: 'Undo' } ) ] ),
+					} )
+				);
+				expect( mockNavigate ).toHaveBeenCalledWith( { to: '/forms' } );
+			} );
+		} );
+
+		it( 'shows error notice when trashing fails', async () => {
+			mockDeleteEntityRecord.mockRejectedValueOnce( new Error( 'fail' ) );
+			const { result } = renderHook( () => usePageHeaderDetails( defaultProps ) );
+			const titles = getControlTitles( result );
+			const trashIndex = titles.indexOf( 'Trash' );
+
+			await act( async () => {
+				result.current.actions
+					.find( a => a?.props?.controls )
+					.props.controls[ trashIndex ].onClick();
+			} );
+
+			await waitFor( () => {
+				expect( mockCreateErrorNotice ).toHaveBeenCalledWith(
+					'Failed to move form to trash.',
+					expect.objectContaining( { type: 'snackbar' } )
+				);
+				expect( mockNavigate ).not.toHaveBeenCalled();
+			} );
+
+			expect( console ).toHaveErrored();
+		} );
+	} );
+
+	describe( 'handleRename', () => {
+		it( 'calls saveEntityRecord with new title on rename', async () => {
+			const { result } = renderHook( () => usePageHeaderDetails( defaultProps ) );
+			const titles = getControlTitles( result );
+			const renameIndex = titles.indexOf( 'Rename' );
+
+			// Click rename to open modal
+			act( () => {
+				result.current.actions
+					.find( a => a?.props?.controls )
+					.props.controls[ renameIndex ].onClick();
+			} );
+
+			// The FormNameModal should now be rendered; find it and call onSave
+			await waitFor( () => {
+				const renameModal = result.current.actions.find( a => a?.key === 'rename-form-modal' );
+				expect( renameModal ).toBeTruthy();
+			} );
+
+			const renameModal = result.current.actions.find( a => a?.key === 'rename-form-modal' );
+
+			await act( async () => {
+				await renameModal.props.onSave( 'New Title' );
+			} );
+
+			expect( mockSaveEntityRecord ).toHaveBeenCalledWith(
+				'postType',
+				'jetpack_form',
+				{ id: 42, title: 'New Title' },
+				{ throwOnError: true }
+			);
+			expect( mockCreateSuccessNotice ).toHaveBeenCalledWith( 'Form renamed.', {
+				type: 'snackbar',
+			} );
+		} );
+	} );
+} );

--- a/projects/packages/forms/tests/js/dashboard/hooks/use-page-header-details.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/hooks/use-page-header-details.test.jsx
@@ -21,6 +21,7 @@ await jest.unstable_mockModule( '@wordpress/admin-ui', () => ( {
 await jest.unstable_mockModule( '@wordpress/components', () => ( {
 	DropdownMenu: () => null,
 	Button: ( { children } ) => children,
+	__experimentalConfirmDialog: ( { children } ) => children,
 } ) );
 
 await jest.unstable_mockModule( '@wordpress/core-data', () => ( {
@@ -391,15 +392,44 @@ describe( 'usePageHeaderDetails', () => {
 			} );
 		} );
 
-		it( 'calls deleteEntityRecord with force on permanent delete', async () => {
+		it( 'opens confirmation dialog on Delete permanently click', () => {
 			mockFormRecord = { title: { rendered: 'Trashed Form' }, status: 'trash' };
 			const { result } = renderHook( () =>
 				usePageHeaderDetails( { ...defaultProps, statusView: 'trash' } )
 			);
 			const controls = result.current.actions.find( a => a?.props?.controls )?.props?.controls;
 
-			await act( async () => {
+			act( () => {
 				controls[ 1 ].onClick();
+			} );
+
+			// ConfirmDialog should now be rendered in actions
+			const confirmDialog = result.current.actions.find(
+				a => a?.key === 'permanent-delete-confirm'
+			);
+			expect( confirmDialog ).toBeTruthy();
+			expect( confirmDialog.props.isOpen ).toBe( true );
+		} );
+
+		it( 'deletes form after confirming permanent delete', async () => {
+			mockFormRecord = { title: { rendered: 'Trashed Form' }, status: 'trash' };
+			const { result } = renderHook( () =>
+				usePageHeaderDetails( { ...defaultProps, statusView: 'trash' } )
+			);
+			const controls = result.current.actions.find( a => a?.props?.controls )?.props?.controls;
+
+			// Open the confirmation dialog
+			act( () => {
+				controls[ 1 ].onClick();
+			} );
+
+			// Confirm the deletion
+			const confirmDialog = result.current.actions.find(
+				a => a?.key === 'permanent-delete-confirm'
+			);
+
+			await act( async () => {
+				await confirmDialog.props.onConfirm();
 			} );
 
 			await waitFor( () => {

--- a/projects/packages/forms/tests/js/dashboard/hooks/use-page-header-details.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/hooks/use-page-header-details.test.jsx
@@ -174,9 +174,12 @@ const mockSetFormsToDraft = jest.fn();
 let mockFormRecord = { title: { rendered: 'My Form' }, status: 'publish' };
 
 await jest.unstable_mockModule( '@wordpress/data', () => ( {
+	createReduxStore: jest.fn( () => 'mock-store' ),
+	register: jest.fn(),
 	useSelect: jest.fn( callback => {
 		const fakeSelect = () => ( {
 			getEntityRecord: () => mockFormRecord,
+			getConfig: () => ( {} ),
 		} );
 		return callback( fakeSelect );
 	} ),

--- a/projects/packages/forms/tests/js/dashboard/hooks/use-page-header-details.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/hooks/use-page-header-details.test.jsx
@@ -355,20 +355,66 @@ describe( 'usePageHeaderDetails', () => {
 		} );
 	} );
 
-	describe( 'trashed form guard', () => {
-		it( 'hides Rename, Duplicate, Trash, and Publish for trashed forms', () => {
+	describe( 'trashed form actions', () => {
+		it( 'shows only Restore and Delete permanently for trashed forms', () => {
 			mockFormRecord = { title: { rendered: 'Trashed Form' }, status: 'trash' };
 			const { result } = renderHook( () =>
 				usePageHeaderDetails( { ...defaultProps, statusView: 'trash' } )
 			);
 			const titles = getControlTitles( result );
 
-			expect( titles ).toContain( 'Preview' );
-			expect( titles ).not.toContain( 'Rename' );
-			expect( titles ).not.toContain( 'Duplicate' );
-			expect( titles ).not.toContain( 'Trash' );
-			expect( titles ).not.toContain( 'Publish' );
-			expect( titles ).not.toContain( 'Unpublish' );
+			expect( titles ).toEqual( [ 'Restore', 'Delete permanently' ] );
+		} );
+
+		it( 'calls saveEntityRecord with publish status on restore', async () => {
+			mockFormRecord = { title: { rendered: 'Trashed Form' }, status: 'trash' };
+			const { result } = renderHook( () =>
+				usePageHeaderDetails( { ...defaultProps, statusView: 'trash' } )
+			);
+			const controls = result.current.actions.find( a => a?.props?.controls )?.props?.controls;
+
+			await act( async () => {
+				controls[ 0 ].onClick();
+			} );
+
+			await waitFor( () => {
+				expect( mockSaveEntityRecord ).toHaveBeenCalledWith(
+					'postType',
+					'jetpack_form',
+					{ id: 42, status: 'publish' },
+					{ throwOnError: true }
+				);
+				expect( mockCreateSuccessNotice ).toHaveBeenCalledWith( 'Form restored.', {
+					type: 'snackbar',
+				} );
+				expect( mockNavigate ).toHaveBeenCalledWith( { to: '/forms' } );
+			} );
+		} );
+
+		it( 'calls deleteEntityRecord with force on permanent delete', async () => {
+			mockFormRecord = { title: { rendered: 'Trashed Form' }, status: 'trash' };
+			const { result } = renderHook( () =>
+				usePageHeaderDetails( { ...defaultProps, statusView: 'trash' } )
+			);
+			const controls = result.current.actions.find( a => a?.props?.controls )?.props?.controls;
+
+			await act( async () => {
+				controls[ 1 ].onClick();
+			} );
+
+			await waitFor( () => {
+				expect( mockDeleteEntityRecord ).toHaveBeenCalledWith(
+					'postType',
+					'jetpack_form',
+					42,
+					{ force: true },
+					{ throwOnError: true }
+				);
+				expect( mockCreateSuccessNotice ).toHaveBeenCalledWith( 'Form deleted permanently.', {
+					type: 'snackbar',
+				} );
+				expect( mockNavigate ).toHaveBeenCalledWith( { to: '/forms' } );
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
Before:

<img width="283" height="271" alt="Screenshot 2026-03-13 at 2 07 59 PM" src="https://github.com/user-attachments/assets/0bbe6e82-6b5e-46e0-9dec-a1daaeb85663" />


After:
<img width="268" height="330" alt="Screenshot 2026-03-13 at 2 03 37 PM" src="https://github.com/user-attachments/assets/d1a8bb3a-d744-4713-8844-927a8c4a2bc0" />



## Proposed changes

* Add a "Rename" action to the single form dashboard dropdown menu, reusing the existing `FormNameModal` component and the same rename pattern from the forms list view.
* Add a "Trash" action that moves the form to trash and navigates back to the forms list.
* Reorder dropdown menu items to match the design: Preview, Copy embed, Copy shortcode, Publish/Unpublish, Rename, Duplicate, Trash.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Go to the Jetpack Forms dashboard (`/wp-admin/admin.php?page=jetpack-forms-responses`)
* Navigate to a single form's responses page (click on a form name)
* Click the "more actions" (⋮) dropdown in the page header
* Verify the menu items appear in this order: Preview, Copy embed, Copy shortcode, Publish/Unpublish, Rename, Duplicate, Trash
* Click **Rename** — a modal should open with the current form name pre-filled. Enter a new name and save. Verify the breadcrumb title updates.
* Click **Duplicate** — verify a new form is created (success snackbar appears).
* Click **Trash** — verify the form is moved to trash (success snackbar) and you are navigated back to the forms list.
* Test on a narrow viewport (mobile) — all actions should appear in the collapsed mobile dropdown menu as well.
