### PR TITLE
Forms: Set duplicated form status to draft when original is published

### DIFF
--- a/projects/packages/forms/changelog/fix-form-duplicate-status
+++ b/projects/packages/forms/changelog/fix-form-duplicate-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Set duplicated form status to draft when the original form is published, preserving the original status otherwise.

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-duplicate-form.ts
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-duplicate-form.ts
@@ -78,9 +78,6 @@ export default function useDuplicateForm(): UseDuplicateFormReturn {
 				const typedOriginal = original as JetpackFormEntityRecord;
 				const raw = typedOriginal.content?.raw;
 				const originalContentRaw = typeof raw === 'string' ? raw : '';
-				const originalStatus = typedOriginal.status;
-				const duplicateStatus = originalStatus === 'publish' ? 'draft' : originalStatus;
-
 				const originalTitle = item.title || __( 'Untitled Form', 'jetpack-forms' );
 				const newTitle = sprintf(
 					/* translators: %s: original form title */
@@ -95,7 +92,7 @@ export default function useDuplicateForm(): UseDuplicateFormReturn {
 						title: newTitle,
 						// Duplicate the raw block content so the form is an exact copy.
 						content: originalContentRaw,
-						status: duplicateStatus,
+						status: typedOriginal.status === 'publish' ? 'draft' : typedOriginal.status,
 						meta: {
 							[ FORM_SOURCE_META_KEY ]: item.id,
 						},

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-duplicate-form.ts
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-duplicate-form.ts
@@ -29,6 +29,7 @@ type CoreDispatch = {
 
 type JetpackFormEntityRecord = {
 	content?: { raw?: unknown };
+	status?: string;
 };
 
 type UseDuplicateFormReturn = {
@@ -74,8 +75,11 @@ export default function useDuplicateForm(): UseDuplicateFormReturn {
 					);
 					return;
 				}
-				const raw = ( original as JetpackFormEntityRecord ).content?.raw;
+				const typedOriginal = original as JetpackFormEntityRecord;
+				const raw = typedOriginal.content?.raw;
 				const originalContentRaw = typeof raw === 'string' ? raw : '';
+				const originalStatus = typedOriginal.status;
+				const duplicateStatus = originalStatus === 'publish' ? 'draft' : originalStatus;
 
 				const originalTitle = item.title || __( 'Untitled Form', 'jetpack-forms' );
 				const newTitle = sprintf(
@@ -91,7 +95,7 @@ export default function useDuplicateForm(): UseDuplicateFormReturn {
 						title: newTitle,
 						// Duplicate the raw block content so the form is an exact copy.
 						content: originalContentRaw,
-						status: 'publish',
+						status: duplicateStatus,
 						meta: {
 							[ FORM_SOURCE_META_KEY ]: item.id,
 						},


### PR DESCRIPTION
Fixes #

## Proposed changes

* When duplicating a form, set the duplicated form's status to `draft` if the original is `publish`, otherwise preserve the original status (e.g. a draft form duplicates as draft).
* Previously the status was hardcoded to `publish`, meaning duplicating any form always produced a published copy.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Go to the Jetpack Forms dashboard
* Create or ensure you have a **published** form and a **draft** form
* Duplicate the **published** form → verify the new copy has **draft** status
* Duplicate the **draft** form → verify the new copy also has **draft** status
* Also test duplicating from the single form view header (the duplicate action there uses the same hook)
