### PR TITLE
Forms: Restore trashed forms as draft instead of publish

### DIFF
--- a/projects/packages/forms/changelog/fix-restore-form-set-as-draft
+++ b/projects/packages/forms/changelog/fix-restore-form-set-as-draft
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Dashboard: Restore trashed forms as draft instead of publish

--- a/projects/packages/forms/src/dashboard/hooks/use-delete-form.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-delete-form.ts
@@ -116,10 +116,15 @@ export default function useDeleteForm( {
 			if ( restoredCount ) {
 				const successMessage =
 					restoredCount === 1
-						? __( 'Form restored.', 'jetpack-forms' )
+						? __( 'Form restored as draft.', 'jetpack-forms' )
 						: sprintf(
 								/* translators: %d: number of forms. */
-								_n( '%d form restored.', '%d forms restored.', restoredCount, 'jetpack-forms' ),
+								_n(
+									'%d form restored as draft.',
+									'%d forms restored as draft.',
+									restoredCount,
+									'jetpack-forms'
+								),
 								restoredCount
 						  );
 

--- a/projects/packages/forms/src/dashboard/hooks/use-delete-form.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-delete-form.ts
@@ -91,7 +91,7 @@ export default function useDeleteForm( {
 		[ invalidateResolution ]
 	);
 
-	const restoreItemsToPublish = useCallback(
+	const restoreItemsToDraft = useCallback(
 		async (
 			items: FormListItem[],
 			{
@@ -104,7 +104,7 @@ export default function useDeleteForm( {
 					saveEntityRecord(
 						'postType',
 						'jetpack_form',
-						{ id: item.id, status: 'publish' },
+						{ id: item.id, status: 'draft' },
 						{ throwOnError: true }
 					)
 				)
@@ -162,7 +162,7 @@ export default function useDeleteForm( {
 			let shouldNavigateToPreviousPage = false;
 
 			try {
-				const { restoredCount } = await restoreItemsToPublish( items, {
+				const { restoredCount } = await restoreItemsToDraft( items, {
 					successNoticeIdPrefix: 'restore-forms',
 					errorNoticeIdPrefix: 'restore-forms-error',
 				} );
@@ -194,7 +194,7 @@ export default function useDeleteForm( {
 			page,
 			perPage,
 			recordsLength,
-			restoreItemsToPublish,
+			restoreItemsToDraft,
 			search,
 			setView,
 			statusQuery,
@@ -212,7 +212,7 @@ export default function useDeleteForm( {
 			const currentQuerySnapshot = currentQuery;
 
 			try {
-				await restoreItemsToPublish( items, {
+				await restoreItemsToDraft( items, {
 					successNoticeIdPrefix: 'undo-trash-forms',
 					errorNoticeIdPrefix: 'undo-trash-forms-error',
 				} );
@@ -227,7 +227,7 @@ export default function useDeleteForm( {
 			invalidateFormStatusCounts,
 			invalidateListQueries,
 			isDeleting,
-			restoreItemsToPublish,
+			restoreItemsToDraft,
 		]
 	);
 


### PR DESCRIPTION
Fixes #

## Proposed changes

* When restoring a form from the trash, set its status to `draft` instead of `publish` to prevent forms from going live immediately after restoration.
* Renamed internal helper `restoreItemsToPublish` → `restoreItemsToDraft` to reflect the new behavior.
* Applies to both the explicit "Restore" action and the "Undo" snackbar action after trashing.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Go to the Forms dashboard in wp-admin
* Create and publish a form if you don't have one already
* Trash the form from the Forms list
* Navigate to the Trash view
* Click "Restore" on the trashed form
* Verify the form appears in the **Draft** tab, not the Published tab
* Trash a form again, then click "Undo" in the snackbar notification
* Verify the form is restored as a **Draft**
