### PR TITLE
Hovercard i18n: prep translations for private profile error state

### DIFF
--- a/projects/packages/forms/changelog/fix-gravatar-hovercards-breaking-for-some
+++ b/projects/packages/forms/changelog/fix-gravatar-hovercards-breaking-for-some
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Gravatar hovercard: Add translation string for private profile error state.

--- a/projects/packages/forms/src/dashboard/components/gravatar/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/gravatar/index.tsx
@@ -58,6 +58,7 @@ export default function Gravatar( {
 						'jetpack-forms'
 					),
 					'Gravatar not found.': __( 'Gravatar not found.', 'jetpack-forms' ),
+					'This profile is private.': __( 'This profile is private.', 'jetpack-forms' ),
 					'Too Many Requests.': __( 'Too many requests.', 'jetpack-forms' ),
 					'Internal Server Error.': __( 'Internal server error.', 'jetpack-forms' ),
 					'Is this you?': __( 'Is this you?', 'jetpack-forms' ),

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-gravatar-hovercards-breaking-for-some
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-gravatar-hovercards-breaking-for-some
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Verbum comments: Fix incorrect hovercard i18n key for 'Gravatar not found' error; add translation string for private profile error state.

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
@@ -209,13 +209,14 @@ class Verbum_Comments {
 		$color_scheme     = get_blog_option( $this->blog_id, 'jetpack_comment_form_color_scheme' );
 
 		$hovercard_i18n = array(
-			'Edit your profile →'    => __( 'Edit your profile →', 'jetpack-mu-wpcom' ),
-			'View profile →'         => __( 'View profile →', 'jetpack-mu-wpcom' ),
-			'Contact'                => __( 'Contact', 'jetpack-mu-wpcom' ),
-			'Send money'             => __( 'Send money', 'jetpack-mu-wpcom' ),
-			'Profile not found.'     => __( 'Profile not found.', 'jetpack-mu-wpcom' ),
-			'Too Many Requests.'     => __( 'Too Many Requests.', 'jetpack-mu-wpcom' ),
-			'Internal Server Error.' => __( 'Internal Server Error.', 'jetpack-mu-wpcom' ),
+			'Edit your profile →'      => __( 'Edit your profile →', 'jetpack-mu-wpcom' ),
+			'View profile →'           => __( 'View profile →', 'jetpack-mu-wpcom' ),
+			'Contact'                  => __( 'Contact', 'jetpack-mu-wpcom' ),
+			'Send money'               => __( 'Send money', 'jetpack-mu-wpcom' ),
+			'Gravatar not found.'      => __( 'Gravatar not found.', 'jetpack-mu-wpcom' ),
+			'This profile is private.' => __( 'This profile is private.', 'jetpack-mu-wpcom' ),
+			'Too Many Requests.'       => __( 'Too Many Requests.', 'jetpack-mu-wpcom' ),
+			'Internal Server Error.'   => __( 'Internal Server Error.', 'jetpack-mu-wpcom' ),
 			'Sorry, we are unable to load this Gravatar profile.' => __( 'Sorry, we are unable to load this Gravatar profile.', 'jetpack-mu-wpcom' ),
 		);
 


### PR DESCRIPTION
Fixes JETPACK-1427

## Proposed changes

Private Gravatar profiles currently show a misleading hovercard: **"Gravatar not found. Is this you? Claim your free profile."** — even though the user _does_ have a Gravatar; they've simply set their profile to private.

The fix is a two-part change being tracked together:

1. **Upstream hovercards library** ([Automattic/gravatar#253](https://github.com/Automattic/gravatar/pull/253)): Add `case 403` to the fetch error handler in `core.ts` so that HTTP 403 (private profile) shows **"This profile is private."** instead of the "not found" error state.

2. **Gravatar API** (internal): Return HTTP 403 (Forbidden) for private profiles instead of 404. This is the correct HTTP semantics — the resource exists but access is denied.

This PR prepares the Jetpack monorepo for when the upstream package is updated and a new version is released:

* **`packages/forms` — `gravatar/index.tsx`**: Add `'This profile is private.'` i18n translation key to the hovercard i18n map.
* **`packages/jetpack-mu-wpcom` — `class-verbum-comments.php`**: Add `'This profile is private.'` i18n key. Also fixes a pre-existing bug: the key `'Profile not found.'` was wrong — the hovercards library uses `'Gravatar not found.'` — meaning the "not found" translation was never being applied in Verbum comments.

## Related product discussion/links

* Upstream hovercards PR: https://github.com/Automattic/gravatar/pull/253

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Hover over a Gravatar avatar that belongs to an account with a **private** profile.
* Before this fix + the upstream package update: the hovercard shows "Gravatar not found. Is this you? Claim your free profile."
* After: the hovercard shows "This profile is private." with no "Claim your profile" CTA.