### PR TITLE
Forms: Fix edit URL by removing unnecessary post_type param

### DIFF
--- a/projects/packages/forms/changelog/fix-edit
+++ b/projects/packages/forms/changelog/fix-edit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Remove unnecessary post_type parameter from form edit URLs that caused incorrect redirects.

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -378,7 +378,7 @@ function StageInner() {
 				if ( ! item ) {
 					return;
 				}
-				const fallbackEditUrl = `post.php?post=${ item.id }&action=edit&post_type=jetpack_form`;
+				const fallbackEditUrl = `post.php?post=${ item.id }&action=edit`;
 				const editUrl = item.editUrl || fallbackEditUrl;
 				const url = new URL( editUrl, window.location.origin );
 				window.location.href = url.toString();

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -35,6 +35,7 @@ import useDeleteForm from '../../src/dashboard/hooks/use-delete-form.ts';
 import useFormStatusCounts from '../../src/dashboard/hooks/use-form-status-counts.ts';
 import useFormsData, { getFormsListQuery } from '../../src/dashboard/hooks/use-forms-data.ts';
 import WpRouteDashboardSearchParamsProvider from '../../src/dashboard/router/wp-route-dashboard-search-params-provider.tsx';
+import { getFormEditUrl } from '../../src/dashboard/utils.ts';
 import DataViewsHeaderRow from '../../src/dashboard/wp-build/components/dataviews-header-row';
 import FormsHelpModal from '../../src/dashboard/wp-build/components/forms-help-modal';
 import useFormItemActions from '../../src/dashboard/wp-build/hooks/use-form-item-actions';
@@ -378,8 +379,7 @@ function StageInner() {
 				if ( ! item ) {
 					return;
 				}
-				const fallbackEditUrl = `post.php?post=${ item.id }&action=edit`;
-				const editUrl = item.editUrl || fallbackEditUrl;
+				const editUrl = item.editUrl || getFormEditUrl( item.id );
 				const url = new URL( editUrl, window.location.origin );
 				window.location.href = url.toString();
 			},

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -87,6 +87,7 @@ function StageInner() {
 		[]
 	);
 	const { refreshIntegrations } = useDispatch( INTEGRATIONS_STORE );
+	const adminUrl = ( useConfigValue( 'adminUrl' ) as string ) || '';
 	const isIntegrationsEnabled = useConfigValue( 'isIntegrationsEnabled' );
 	const showDashboardIntegrations = useConfigValue( 'showDashboardIntegrations' );
 
@@ -379,9 +380,8 @@ function StageInner() {
 				if ( ! item ) {
 					return;
 				}
-				const editUrl = item.editUrl || getFormEditUrl( item.id );
-				const url = new URL( editUrl, window.location.origin );
-				window.location.href = url.toString();
+				const editUrl = item.editUrl || getFormEditUrl( item.id, adminUrl );
+				window.location.href = editUrl;
 			},
 		} );
 
@@ -523,6 +523,7 @@ function StageInner() {
 
 		return actionsList;
 	}, [
+		adminUrl,
 		copyEmbed,
 		copyShortcode,
 		duplicateForm,

--- a/projects/packages/forms/src/blocks/contact-form/util/navigate-to-form.ts
+++ b/projects/packages/forms/src/blocks/contact-form/util/navigate-to-form.ts
@@ -1,4 +1,4 @@
-import { addQueryArgs } from '@wordpress/url';
+import { getFormEditUrl } from '../../../dashboard/utils.ts';
 import { FORM_POST_TYPE } from '../../shared/util/constants.js';
 import type { EditorContext } from './get-editor-context.ts';
 
@@ -17,8 +17,7 @@ export const navigateToForm = (
 	onNavigateToEntityRecord?: ( params: { postId: number; postType: string } ) => void
 ) => {
 	if ( editorContext === 'widget' || editorContext === 'site' ) {
-		const editUrl = addQueryArgs( 'post.php', { post: formId, action: 'edit' } );
-		window.location.href = editUrl;
+		window.location.href = getFormEditUrl( formId );
 	} else if ( onNavigateToEntityRecord ) {
 		onNavigateToEntityRecord( { postId: formId, postType: FORM_POST_TYPE } );
 	}

--- a/projects/packages/forms/src/dashboard/components/edit-form-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/edit-form-button/index.tsx
@@ -22,11 +22,10 @@ type EditFormButtonProps = {
  * @return JSX element.
  */
 export default function EditFormButton( { formId }: EditFormButtonProps ): JSX.Element {
-	const adminUrl = useConfigValue( 'adminUrl' ) || '';
+	const adminUrl = ( useConfigValue( 'adminUrl' ) as string ) || '';
 
 	const onClick = useCallback( () => {
-		const editPath = getFormEditUrl( formId );
-		window.location.href = adminUrl ? `${ adminUrl }${ editPath }` : editPath;
+		window.location.href = getFormEditUrl( formId, adminUrl );
 	}, [ adminUrl, formId ] );
 
 	return (

--- a/projects/packages/forms/src/dashboard/components/edit-form-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/edit-form-button/index.tsx
@@ -8,6 +8,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import useConfigValue from '../../../hooks/use-config-value';
+import { getFormEditUrl } from '../../utils.ts';
 
 type EditFormButtonProps = {
 	formId: number;
@@ -24,7 +25,7 @@ export default function EditFormButton( { formId }: EditFormButtonProps ): JSX.E
 	const adminUrl = useConfigValue( 'adminUrl' ) || '';
 
 	const onClick = useCallback( () => {
-		const editPath = `post.php?post=${ formId }&action=edit`;
+		const editPath = getFormEditUrl( formId );
 		window.location.href = adminUrl ? `${ adminUrl }${ editPath }` : editPath;
 	}, [ adminUrl, formId ] );
 

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -35,6 +35,7 @@ import type { Action, Operator } from '@wordpress/dataviews/wp';
  */
 export default function FormsDashboardForms(): JSX.Element | null {
 	const navigate = useNavigate();
+	const adminUrl = ( useConfigValue( 'adminUrl' ) as string ) || '';
 	const isCentralFormManagementEnabled = useConfigValue( 'isCentralFormManagementEnabled' );
 	const isCentralFormManagementDisabled = isCentralFormManagementEnabled === false;
 
@@ -229,9 +230,8 @@ export default function FormsDashboardForms(): JSX.Element | null {
 					if ( ! item ) {
 						return;
 					}
-					const editUrl = item.editUrl || getFormEditUrl( item.id );
-					const url = new URL( editUrl, window.location.origin );
-					window.location.href = url.toString();
+					const editUrl = item.editUrl || getFormEditUrl( item.id, adminUrl );
+					window.location.href = editUrl;
 				},
 			},
 			{
@@ -366,6 +366,7 @@ export default function FormsDashboardForms(): JSX.Element | null {
 
 		return actionsList;
 	}, [
+		adminUrl,
 		createErrorNotice,
 		createSuccessNotice,
 		isDeleting,

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -22,6 +22,7 @@ import Page from '../components/page/index.tsx';
 import { NON_TRASH_FORM_STATUSES } from '../constants.ts';
 import useDeleteForm from '../hooks/use-delete-form.ts';
 import useFormsData from '../hooks/use-forms-data.ts';
+import { getFormEditUrl } from '../utils.ts';
 import { defaultLayouts, useView } from './views.ts';
 import './style.scss';
 import type { FormListItem } from '../hooks/use-forms-data.ts';
@@ -228,8 +229,7 @@ export default function FormsDashboardForms(): JSX.Element | null {
 					if ( ! item ) {
 						return;
 					}
-					const fallbackEditUrl = `post.php?post=${ item.id }&action=edit`;
-					const editUrl = item.editUrl || fallbackEditUrl;
+					const editUrl = item.editUrl || getFormEditUrl( item.id );
 					const url = new URL( editUrl, window.location.origin );
 					window.location.href = url.toString();
 				},

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -228,7 +228,7 @@ export default function FormsDashboardForms(): JSX.Element | null {
 					if ( ! item ) {
 						return;
 					}
-					const fallbackEditUrl = `post.php?post=${ item.id }&action=edit&post_type=jetpack_form`;
+					const fallbackEditUrl = `post.php?post=${ item.id }&action=edit`;
 					const editUrl = item.editUrl || fallbackEditUrl;
 					const url = new URL( editUrl, window.location.origin );
 					window.location.href = url.toString();

--- a/projects/packages/forms/src/dashboard/utils.ts
+++ b/projects/packages/forms/src/dashboard/utils.ts
@@ -1,0 +1,9 @@
+/**
+ * Get the edit URL for a form post.
+ *
+ * @param formId - The form post ID.
+ * @return The relative edit URL path.
+ */
+export function getFormEditUrl( formId: number ): string {
+	return `post.php?post=${ formId }&action=edit`;
+}

--- a/projects/packages/forms/src/dashboard/utils.ts
+++ b/projects/packages/forms/src/dashboard/utils.ts
@@ -1,9 +1,10 @@
 /**
  * Get the edit URL for a form post.
  *
- * @param formId - The form post ID.
- * @return The relative edit URL path.
+ * @param formId   - The form post ID.
+ * @param adminUrl - The wp-admin base URL (e.g. "https://example.com/wp-admin/").
+ * @return           The edit URL.
  */
-export function getFormEditUrl( formId: number ): string {
-	return `post.php?post=${ formId }&action=edit`;
+export function getFormEditUrl( formId: number, adminUrl?: string ): string {
+	return `${ adminUrl ?? '' }post.php?post=${ formId }&action=edit`;
 }

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-duplicate-form.ts
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-duplicate-form.ts
@@ -115,7 +115,7 @@ export default function useDuplicateForm(): UseDuplicateFormReturn {
 							label: __( 'Edit', 'jetpack-forms' ),
 							onClick: () => {
 								if ( adminUrl ) {
-									window.location.href = `${ adminUrl }${ getFormEditUrl( createdId ) }`;
+									window.location.href = getFormEditUrl( createdId, adminUrl );
 								}
 							},
 						},

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-duplicate-form.ts
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-duplicate-form.ts
@@ -11,6 +11,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { FORM_SOURCE_META_KEY } from '../../../blocks/shared/util/constants.js';
 import useConfigValue from '../../../hooks/use-config-value';
 import { store as dashboardStore } from '../../store/index.js';
+import { getFormEditUrl } from '../../utils.ts';
 /**
  * Types
  */
@@ -114,7 +115,7 @@ export default function useDuplicateForm(): UseDuplicateFormReturn {
 							label: __( 'Edit', 'jetpack-forms' ),
 							onClick: () => {
 								if ( adminUrl ) {
-									window.location.href = `${ adminUrl }post.php?post=${ createdId }&action=edit`;
+									window.location.href = `${ adminUrl }${ getFormEditUrl( createdId ) }`;
 								}
 							},
 						},

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-duplicate-form.ts
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-duplicate-form.ts
@@ -114,7 +114,7 @@ export default function useDuplicateForm(): UseDuplicateFormReturn {
 							label: __( 'Edit', 'jetpack-forms' ),
 							onClick: () => {
 								if ( adminUrl ) {
-									window.location.href = `${ adminUrl }post.php?post=${ createdId }&action=edit&post_type=jetpack_form`;
+									window.location.href = `${ adminUrl }post.php?post=${ createdId }&action=edit`;
 								}
 							},
 						},

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -15,6 +15,7 @@ import { Badge, Stack } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
+import useConfigValue from '../../../hooks/use-config-value';
 import CreateFormButton from '../../components/create-form-button';
 import EditFormButton from '../../components/edit-form-button';
 import EmptySpamButton from '../../components/empty-spam-button';
@@ -78,6 +79,7 @@ export default function usePageHeaderDetails(
 		onOpenIntegrations,
 		onOpenFormsHelp,
 	} = props;
+	const adminUrl = ( useConfigValue( 'adminUrl' ) as string ) || '';
 	const statusView: ResponsesStatusView = props.statusView ?? 'inbox';
 	const sourceIdNumber = useMemo( () => {
 		const value = sourceId;
@@ -319,8 +321,7 @@ export default function usePageHeaderDetails(
 				if ( statusView === 'inbox' && sourceIdNumber ) {
 					dropdownControls.push( {
 						onClick: () => {
-							const url = new URL( getFormEditUrl( sourceIdNumber ), window.location.origin );
-							window.location.href = url.toString();
+							window.location.href = getFormEditUrl( sourceIdNumber, adminUrl );
 						},
 						title: __( 'Edit form', 'jetpack-forms' ),
 					} );
@@ -512,6 +513,7 @@ export default function usePageHeaderDetails(
 			...( statusView === 'spam' ? [ <EmptySpamButton key="empty-spam" /> ] : [] ),
 		];
 	}, [
+		adminUrl,
 		isSm,
 		isIntegrationsEnabled,
 		onOpenIntegrations,

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -30,6 +30,7 @@ import useEmptySpam from '../../hooks/use-empty-spam';
 import useEmptyTrash from '../../hooks/use-empty-trash';
 import useExportResponses from '../../hooks/use-export-responses';
 import useInboxData from '../../hooks/use-inbox-data';
+import { getFormEditUrl } from '../../utils.ts';
 import ManageIntegrationsButton from '../components/manage-integrations-button';
 import useFormItemActions from './use-form-item-actions';
 import type { ReactNode } from 'react';
@@ -318,8 +319,7 @@ export default function usePageHeaderDetails(
 				if ( statusView === 'inbox' && sourceIdNumber ) {
 					dropdownControls.push( {
 						onClick: () => {
-							const fallbackEditUrl = `post.php?post=${ sourceIdNumber }&action=edit`;
-							const url = new URL( fallbackEditUrl, window.location.origin );
+							const url = new URL( getFormEditUrl( sourceIdNumber ), window.location.origin );
 							window.location.href = url.toString();
 						},
 						title: __( 'Edit form', 'jetpack-forms' ),

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -318,7 +318,7 @@ export default function usePageHeaderDetails(
 				if ( statusView === 'inbox' && sourceIdNumber ) {
 					dropdownControls.push( {
 						onClick: () => {
-							const fallbackEditUrl = `post.php?post=${ sourceIdNumber }&action=edit&post_type=jetpack_form`;
+							const fallbackEditUrl = `post.php?post=${ sourceIdNumber }&action=edit`;
 							const url = new URL( fallbackEditUrl, window.location.origin );
 							window.location.href = url.toString();
 						},

--- a/projects/packages/forms/tests/js/contact-form/components/convert-form-toolbar.test.js
+++ b/projects/packages/forms/tests/js/contact-form/components/convert-form-toolbar.test.js
@@ -17,6 +17,9 @@ const mockOnNavigateToEntityRecord = jest.fn();
 const mockAddQueryArgs = jest.fn(
 	( base, args ) => `${ base }?post=${ args.post }&action=${ args.action }`
 );
+const mockGetFormEditUrl = jest.fn(
+	( formId, adminUrl ) => `${ adminUrl ?? '' }post.php?post=${ formId }&action=edit`
+);
 
 let mockIsLocked = false;
 let mockEditorContext = 'post';
@@ -38,6 +41,9 @@ await jest.unstable_mockModule( '@wordpress/block-editor', () => ( {
 await jest.unstable_mockModule( '@wordpress/editor', () => ( { store: 'core/editor' } ) );
 await jest.unstable_mockModule( '@wordpress/notices', () => ( { store: 'core/notices' } ) );
 await jest.unstable_mockModule( '@wordpress/url', () => ( { addQueryArgs: mockAddQueryArgs } ) );
+await jest.unstable_mockModule( '../../../../src/dashboard/utils', () => ( {
+	getFormEditUrl: mockGetFormEditUrl,
+} ) );
 
 await jest.unstable_mockModule( '@wordpress/data', () => ( {
 	useSelect: jest.fn( callback =>
@@ -175,10 +181,7 @@ describe( 'ConvertFormToolbar', () => {
 			render( <ConvertFormToolbar clientId="test-id" attributes={ { ref: 456 } } /> );
 			await userEvent.click( screen.getByRole( 'button' ) );
 
-			expect( mockAddQueryArgs ).toHaveBeenCalledWith( 'post.php', {
-				post: 456,
-				action: 'edit',
-			} );
+			expect( mockGetFormEditUrl ).toHaveBeenCalledWith( 456 );
 			expect( mockOnNavigateToEntityRecord ).not.toHaveBeenCalled();
 			// jsdom logs an error for unimplemented navigation
 			expect( console ).toHaveErrored();
@@ -191,10 +194,7 @@ describe( 'ConvertFormToolbar', () => {
 			await userEvent.click( screen.getByRole( 'button' ) );
 
 			await waitFor( () => {
-				expect( mockAddQueryArgs ).toHaveBeenCalledWith( 'post.php', {
-					post: 789,
-					action: 'edit',
-				} );
+				expect( mockGetFormEditUrl ).toHaveBeenCalledWith( 789 );
 			} );
 
 			expect( mockOnNavigateToEntityRecord ).not.toHaveBeenCalled();
@@ -214,10 +214,7 @@ describe( 'ConvertFormToolbar', () => {
 			render( <ConvertFormToolbar clientId="test-id" attributes={ { ref: 456 } } /> );
 			await userEvent.click( screen.getByRole( 'button' ) );
 
-			expect( mockAddQueryArgs ).toHaveBeenCalledWith( 'post.php', {
-				post: 456,
-				action: 'edit',
-			} );
+			expect( mockGetFormEditUrl ).toHaveBeenCalledWith( 456 );
 			expect( mockOnNavigateToEntityRecord ).not.toHaveBeenCalled();
 			// jsdom logs an error for unimplemented navigation
 			expect( console ).toHaveErrored();
@@ -230,10 +227,7 @@ describe( 'ConvertFormToolbar', () => {
 			await userEvent.click( screen.getByRole( 'button' ) );
 
 			await waitFor( () => {
-				expect( mockAddQueryArgs ).toHaveBeenCalledWith( 'post.php', {
-					post: 789,
-					action: 'edit',
-				} );
+				expect( mockGetFormEditUrl ).toHaveBeenCalledWith( 789 );
 			} );
 
 			expect( mockOnNavigateToEntityRecord ).not.toHaveBeenCalled();
@@ -283,23 +277,20 @@ describe( 'navigateToForm', () => {
 			postId: 123,
 			postType: 'jetpack_form',
 		} );
-		expect( mockAddQueryArgs ).not.toHaveBeenCalled();
+		expect( mockGetFormEditUrl ).not.toHaveBeenCalled();
 	} );
 
 	it( 'does nothing in post context when onNavigateToEntityRecord is not available', () => {
 		navigateToForm( 123, 'post', undefined );
 
-		expect( mockAddQueryArgs ).not.toHaveBeenCalled();
+		expect( mockGetFormEditUrl ).not.toHaveBeenCalled();
 	} );
 
 	it( 'navigates via URL in site editor context', () => {
 		const mockNavigate = jest.fn();
 		navigateToForm( 123, 'site', mockNavigate );
 
-		expect( mockAddQueryArgs ).toHaveBeenCalledWith( 'post.php', {
-			post: 123,
-			action: 'edit',
-		} );
+		expect( mockGetFormEditUrl ).toHaveBeenCalledWith( 123 );
 		expect( mockNavigate ).not.toHaveBeenCalled();
 		// jsdom logs an error for unimplemented navigation
 		expect( console ).toHaveErrored();
@@ -309,10 +300,7 @@ describe( 'navigateToForm', () => {
 		const mockNavigate = jest.fn();
 		navigateToForm( 123, 'widget', mockNavigate );
 
-		expect( mockAddQueryArgs ).toHaveBeenCalledWith( 'post.php', {
-			post: 123,
-			action: 'edit',
-		} );
+		expect( mockGetFormEditUrl ).toHaveBeenCalledWith( 123 );
 		expect( mockNavigate ).not.toHaveBeenCalled();
 		// jsdom logs an error for unimplemented navigation
 		expect( console ).toHaveErrored();

--- a/projects/packages/forms/tests/js/dashboard/utils.test.js
+++ b/projects/packages/forms/tests/js/dashboard/utils.test.js
@@ -1,0 +1,11 @@
+import { getFormEditUrl } from '../../../src/dashboard/utils';
+
+describe( 'getFormEditUrl', () => {
+	it( 'returns the correct edit URL for a given form ID', () => {
+		expect( getFormEditUrl( 123 ) ).toBe( 'post.php?post=123&action=edit' );
+	} );
+
+	it( 'does not include post_type parameter', () => {
+		expect( getFormEditUrl( 456 ) ).not.toContain( 'post_type' );
+	} );
+} );

--- a/projects/packages/forms/tests/js/dashboard/utils.test.js
+++ b/projects/packages/forms/tests/js/dashboard/utils.test.js
@@ -1,11 +1,17 @@
 import { getFormEditUrl } from '../../../src/dashboard/utils';
 
 describe( 'getFormEditUrl', () => {
-	it( 'returns the correct edit URL for a given form ID', () => {
+	it( 'returns a full URL when adminUrl is provided', () => {
+		expect( getFormEditUrl( 123, 'https://example.com/wp-admin/' ) ).toBe(
+			'https://example.com/wp-admin/post.php?post=123&action=edit'
+		);
+	} );
+
+	it( 'returns a relative path when adminUrl is omitted', () => {
 		expect( getFormEditUrl( 123 ) ).toBe( 'post.php?post=123&action=edit' );
 	} );
 
 	it( 'does not include post_type parameter', () => {
-		expect( getFormEditUrl( 456 ) ).not.toContain( 'post_type' );
+		expect( getFormEditUrl( 456, 'https://example.com/wp-admin/' ) ).not.toContain( 'post_type' );
 	} );
 } );


### PR DESCRIPTION
Fixes #

## Proposed changes
* Remove the unnecessary `&post_type=jetpack_form` parameter from form edit URLs that caused incorrect redirects (e.g. `post.php?post=ID&action=edit&post_type=jetpack_form` instead of `post.php?post=ID&action=edit`)
* Extract a shared `getFormEditUrl()` utility function to consolidate duplicated URL construction across 6 call sites
* Add unit tests for the new utility function

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Go to the Jetpack Forms dashboard in wp-admin
* Click the "Edit" action on any form in the list
* Verify the URL navigates to `wp-admin/post.php?post=<ID>&action=edit` without the `post_type=jetpack_form` parameter
* Also verify the edit button works from:
  - The mobile dropdown menu on a single form screen
  - The "Edit" link in the snackbar after duplicating a form
  - The EditFormButton component in the page header
