### PR TITLE
CLI: Add `jetpack playground` command for quick WordPress Playground sessions

### DIFF
--- a/tools/cli/cliRouter.js
+++ b/tools/cli/cliRouter.js
@@ -13,7 +13,7 @@ import { generateDefine } from './commands/generate.js';
 import * as installCommand from './commands/install.js';
 import * as noopCommand from './commands/noop.js';
 import * as phanCommand from './commands/phan.js';
-import { playgroundDefine } from './commands/playground.js';
+import * as playgroundCommand from './commands/playground.js';
 import * as pnpmCommand from './commands/pnpm.js';
 import { releaseDefine } from './commands/release.js';
 import { rsyncDefine } from './commands/rsync.js';
@@ -50,7 +50,7 @@ export async function cli() {
 	argv.command( installCommand );
 	argv.command( noopCommand );
 	argv.command( phanCommand );
-	argv = playgroundDefine( argv );
+	argv.command( playgroundCommand );
 	argv.command( pnpmCommand );
 	argv = releaseDefine( argv );
 	argv = rsyncDefine( argv );

--- a/tools/cli/cliRouter.js
+++ b/tools/cli/cliRouter.js
@@ -13,6 +13,7 @@ import { generateDefine } from './commands/generate.js';
 import * as installCommand from './commands/install.js';
 import * as noopCommand from './commands/noop.js';
 import * as phanCommand from './commands/phan.js';
+import { playgroundDefine } from './commands/playground.js';
 import * as pnpmCommand from './commands/pnpm.js';
 import { releaseDefine } from './commands/release.js';
 import { rsyncDefine } from './commands/rsync.js';
@@ -49,6 +50,7 @@ export async function cli() {
 	argv.command( installCommand );
 	argv.command( noopCommand );
 	argv.command( phanCommand );
+	argv = playgroundDefine( argv );
 	argv.command( pnpmCommand );
 	argv = releaseDefine( argv );
 	argv = rsyncDefine( argv );

--- a/tools/cli/commands/playground.js
+++ b/tools/cli/commands/playground.js
@@ -57,20 +57,6 @@ export async function handler( argv ) {
 		}
 	}
 
-	// Warn if @wp-playground/cli needs to be downloaded (first run).
-	const playgroundCheck = child_process.spawnSync(
-		'npx',
-		[ '--no-install', '@wp-playground/cli@^3', '--version' ],
-		{ stdio: 'ignore' }
-	);
-	if ( playgroundCheck.status !== 0 ) {
-		console.log(
-			chalk.yellow(
-				'@wp-playground/cli is not yet cached. The first run will download it, which may take a moment.'
-			)
-		);
-	}
-
 	const pluginPath = projectDir( `plugins/${ argv.plugin }` );
 
 	// Read the plugin slug from composer.json so the mount path inside

--- a/tools/cli/commands/playground.js
+++ b/tools/cli/commands/playground.js
@@ -2,45 +2,175 @@ import child_process from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import chalk from 'chalk';
-import { dirs } from '../helpers/projectHelpers.js';
-import { chalkJetpackGreen } from '../helpers/styling.js';
+import { projectDir } from '../helpers/install.js';
+import { maybePromptForPlugin } from './rsync.js';
+
+const cliPath = fileURLToPath( new URL( '../bin/jetpack.js', import.meta.url ) );
+
+export const command = 'playground [plugin]';
+export const describe = 'Starts a WordPress Playground instance with a plugin mounted';
 
 /**
- * Command definition for the playground subcommand.
+ * Options definition for the playground subcommand.
  *
  * @param {object} yargs - The Yargs dependency.
  * @return {object} Yargs with the playground commands defined.
  */
-export function playgroundDefine( yargs ) {
-	yargs.command(
-		'playground <plugin>',
-		'Starts a WordPress Playground instance with a plugin mounted',
-		yarg => {
-			yarg
-				.positional( 'plugin', {
-					describe: 'Plugin name, e.g. jetpack',
-					type: 'string',
-				} )
-				.option( 'blueprint', {
-					alias: 'b',
-					type: 'string',
-					description: 'Path to a custom blueprint.json file',
-				} )
-				.option( 'port', {
-					alias: 'p',
-					type: 'number',
-					description: 'Port to run the Playground server on',
-				} )
-				.example( 'jetpack playground jetpack', 'Start Playground with the Jetpack plugin' )
-				.example( 'jetpack playground crm', 'Start Playground with the CRM plugin' );
-		},
-		async argv => {
-			await playgroundCli( argv );
-		}
-	);
+export function builder( yargs ) {
+	return yargs
+		.positional( 'plugin', {
+			describe: 'Plugin name, e.g. jetpack',
+			type: 'string',
+		} )
+		.option( 'blueprint', {
+			alias: 'b',
+			type: 'string',
+			description: 'Path to a custom blueprint.json file',
+		} )
+		.option( 'port', {
+			alias: 'p',
+			type: 'number',
+			description: 'Port to run the Playground server on',
+		} )
+		.example( 'jetpack playground jetpack', 'Start Playground with the Jetpack plugin' )
+		.example( 'jetpack playground crm', 'Start Playground with the CRM plugin' );
+}
 
-	return yargs;
+/**
+ * Entry point for the playground CLI.
+ *
+ * @param {object} argv - The argv for the command line.
+ */
+export async function handler( argv ) {
+	argv = await maybePromptForPlugin( argv );
+
+	// Validate port if provided.
+	if ( argv.port !== undefined ) {
+		if ( ! Number.isInteger( argv.port ) || argv.port < 1 || argv.port > 65535 ) {
+			console.error( chalk.red( 'Port must be an integer between 1 and 65535.' ) );
+			process.exit( 1 );
+		}
+	}
+
+	// Warn if @wp-playground/cli needs to be downloaded (first run).
+	const playgroundCheck = child_process.spawnSync(
+		'npx',
+		[ '--no-install', '@wp-playground/cli', '--version' ],
+		{ stdio: 'ignore' }
+	);
+	if ( playgroundCheck.status !== 0 ) {
+		console.log(
+			chalk.yellow(
+				'@wp-playground/cli is not yet cached. The first run will download it, which may take a moment.'
+			)
+		);
+	}
+
+	const pluginPath = projectDir( `plugins/${ argv.plugin }` );
+
+	// Read the plugin slug from composer.json so the mount path inside
+	// Playground uses the correct wp-plugin-slug (e.g. zero-bs-crm for crm).
+	const composerJsonPath = path.join( pluginPath, 'composer.json' );
+	let wpPluginSlug = argv.plugin;
+	if ( fs.existsSync( composerJsonPath ) ) {
+		try {
+			const composerJson = JSON.parse( fs.readFileSync( composerJsonPath, 'utf8' ) );
+			wpPluginSlug =
+				composerJson?.extra?.[ 'wp-plugin-slug' ] ??
+				composerJson?.extra?.[ 'beta-plugin-slug' ] ??
+				argv.plugin;
+		} catch {
+			// Fall back to directory name if composer.json is unreadable.
+		}
+	}
+
+	// If the plugin hasn't been built, run the build first.
+	if (
+		! fs.existsSync( path.join( pluginPath, 'vendor' ) ) ||
+		! fs.existsSync( path.join( pluginPath, 'node_modules' ) )
+	) {
+		console.log(
+			chalk.yellow( `Plugin "${ argv.plugin }" does not appear to be built. Building...` )
+		);
+		const build = child_process.spawnSync(
+			process.execPath,
+			[ cliPath, 'build', `plugins/${ argv.plugin }` ],
+			{ stdio: 'inherit' }
+		);
+		if ( build.status !== 0 ) {
+			console.error(
+				chalk.red( 'Build failed. Please run "jetpack build" manually and try again.' )
+			);
+			process.exit( 1 );
+		}
+	}
+
+	// Build the blueprint into a temp directory.
+	const tmpDir = fs.mkdtempSync( path.join( os.tmpdir(), `jetpack-playground-${ argv.plugin }-` ) );
+
+	// The vendor/jetpack_vendor directories contain symlinks like
+	// ../../../../packages/<name>/ which, from the plugin location at
+	// /wordpress/wp-content/plugins/<slug>/jetpack_vendor/automattic/<pkg>,
+	// resolve to /wordpress/wp-content/packages/<name>/. We mount
+	// projects/packages there so these symlinks resolve to real files and
+	// plugins_url() can generate correct URLs (paths stay under wp-content).
+	const packagesPath = projectDir( 'packages' );
+
+	try {
+		const blueprintPath = buildBlueprint( pluginPath, tmpDir, argv, wpPluginSlug );
+
+		const port = argv.port ?? 9400;
+
+		const args = [
+			'@wp-playground/cli',
+			'server',
+			`--mount=${ pluginPath }:/wordpress/wp-content/plugins/${ wpPluginSlug }`,
+			`--mount=${ packagesPath }:/wordpress/wp-content/packages`,
+			`--blueprint=${ blueprintPath }`,
+		];
+
+		if ( argv.port !== undefined ) {
+			args.push( `--port=${ argv.port }` );
+		}
+
+		if ( argv.verbose ) {
+			console.log( chalk.gray( `Running: npx ${ args.join( ' ' ) }` ) );
+		}
+
+		await new Promise( ( resolve, reject ) => {
+			const proc = child_process.spawn( 'npx', args, {
+				stdio: [ 'inherit', 'pipe', 'inherit' ],
+			} );
+
+			proc.stdout.on( 'data', data => {
+				process.stdout.write( data );
+
+				// After Playground prints its "Ready!" line, show helpful info.
+				if ( data.toString().includes( 'Ready!' ) ) {
+					console.log();
+					console.log( `  Admin:  ${ chalk.cyan( `http://127.0.0.1:${ port }/wp-admin/` ) }` );
+					console.log( chalk.gray( '  Login:  admin / password' ) );
+					console.log( chalk.gray( '  Stop:   Ctrl+C' ) );
+					console.log();
+				}
+			} );
+
+			proc.on( 'close', code => {
+				if ( code !== 0 && code !== null ) {
+					reject( new Error( `Playground exited with code ${ code }` ) );
+				} else {
+					resolve();
+				}
+			} );
+
+			proc.on( 'error', reject );
+		} );
+	} finally {
+		console.log( chalk.gray( 'Cleaning up temporary files...' ) );
+		fs.rmSync( tmpDir, { recursive: true, force: true } );
+	}
 }
 
 /**
@@ -50,23 +180,18 @@ export function playgroundDefine( yargs ) {
  * runs in offline mode without needing a WordPress.com connection. If the plugin
  * ships its own blueprint, the steps are merged.
  *
- * @param {string} pluginPath - Absolute path to the plugin source directory.
- * @param {string} mountPath  - Absolute path to the resolved plugin copy in the temp dir.
- * @param {object} options    - CLI options (may include a custom blueprint path).
+ * @param {string} pluginPath   - Absolute path to the plugin source directory.
+ * @param {string} tmpDir       - Temporary directory to write the blueprint into.
+ * @param {object} options      - CLI options (may include a custom blueprint path and plugin name).
+ * @param {string} wpPluginSlug - The WordPress plugin slug (used for activation).
  * @return {string} Path to the generated blueprint file.
  */
-function buildBlueprint( pluginPath, mountPath, options ) {
-	const tmpDir = path.dirname( mountPath );
-
+function buildBlueprint( pluginPath, tmpDir, options, wpPluginSlug ) {
 	// Start with a base blueprint.
 	let blueprint = {
 		$schema: 'https://playground.wordpress.net/blueprint-schema.json',
 		landingPage: '/wp-admin/',
 		login: true,
-		preferredVersions: {
-			php: '8.0',
-			wp: 'latest',
-		},
 		features: {
 			networking: true,
 		},
@@ -77,6 +202,10 @@ function buildBlueprint( pluginPath, mountPath, options ) {
 	let sourceBlueprint = null;
 	if ( options.blueprint ) {
 		sourceBlueprint = path.resolve( options.blueprint );
+		if ( ! fs.existsSync( sourceBlueprint ) ) {
+			console.error( chalk.red( `Blueprint file not found: ${ sourceBlueprint }` ) );
+			process.exit( 1 );
+		}
 	} else {
 		const pluginBlueprintPath = path.join(
 			pluginPath,
@@ -91,14 +220,40 @@ function buildBlueprint( pluginPath, mountPath, options ) {
 
 	if ( sourceBlueprint ) {
 		console.log( chalk.gray( `Using blueprint: ${ path.relative( '.', sourceBlueprint ) }` ) );
-		const custom = JSON.parse( fs.readFileSync( sourceBlueprint, 'utf8' ) );
+		let custom;
+		try {
+			custom = JSON.parse( fs.readFileSync( sourceBlueprint, 'utf8' ) );
+		} catch ( err ) {
+			console.error( chalk.red( `Failed to parse blueprint: ${ err.message }` ) );
+			process.exit( 1 );
+		}
 		blueprint = {
 			...blueprint,
 			...custom,
 			// Merge steps — custom steps run first, then ours.
-			steps: [ ...( custom.steps || [] ) ],
+			steps: [ ...( custom.steps || [] ), ...blueprint.steps ],
 		};
 	}
+
+	// The vendor symlinks resolve to /wordpress/wp-content/packages/ which is
+	// outside WP_PLUGIN_DIR, so plugins_url() generates broken URLs like
+	// /wp-content/plugins/wordpress/wp-content/packages/... Install a mu-plugin
+	// that rewrites these URLs to the correct /wp-content/packages/ path.
+	blueprint.steps.push( {
+		step: 'writeFile',
+		path: '/wordpress/wp-content/mu-plugins/playground-fix-symlinks.php',
+		data: `<?php
+/**
+ * Fix plugins_url() for monorepo vendor symlinks in Playground.
+ *
+ * Vendor symlinks resolve outside WP_PLUGIN_DIR to /wordpress/wp-content/packages/.
+ * This filter rewrites the broken URLs so the assets load correctly.
+ */
+add_filter( 'plugins_url', function ( $url ) {
+	return str_replace( '/wp-content/plugins/wordpress/wp-content/packages/', '/wp-content/packages/', $url );
+} );
+`,
+	} );
 
 	// Inject the offline mode step: define JETPACK_DEV_DEBUG in wp-config.php.
 	blueprint.steps.push( {
@@ -108,6 +263,15 @@ function buildBlueprint( pluginPath, mountPath, options ) {
 		},
 	} );
 
+	// Activate the plugin using the WordPress plugin identifier (slug/main-file.php).
+	const mainFile = findMainPluginFile( pluginPath );
+	if ( mainFile ) {
+		blueprint.steps.push( {
+			step: 'activatePlugin',
+			pluginPath: `${ wpPluginSlug }/${ mainFile }`,
+		} );
+	}
+
 	// Write the merged blueprint to the temp directory.
 	const blueprintOutPath = path.join( tmpDir, 'blueprint.json' );
 	fs.writeFileSync( blueprintOutPath, JSON.stringify( blueprint, null, '\t' ) );
@@ -116,102 +280,22 @@ function buildBlueprint( pluginPath, mountPath, options ) {
 }
 
 /**
- * Entry point for the playground CLI.
+ * Find the main plugin PHP file by looking for the "Plugin Name:" header
+ * in root-level PHP files.
  *
- * @param {object} options - The argv for the command line.
+ * @param {string} pluginPath - Absolute path to the plugin directory.
+ * @return {string|null} The filename of the main plugin file, or null if not found.
  */
-async function playgroundCli( options ) {
-	const pluginPath = path.resolve( `projects/plugins/${ options.plugin }` );
-
-	// Validate that the plugin exists.
-	if ( ! fs.existsSync( pluginPath ) ) {
-		const available = dirs( './projects/plugins' );
-		console.error( chalk.red( `Plugin "${ options.plugin }" not found.` ) );
-		if ( available.length > 0 ) {
-			console.error( `\nAvailable plugins: ${ available.join( ', ' ) }` );
+function findMainPluginFile( pluginPath ) {
+	const entries = fs.readdirSync( pluginPath, { withFileTypes: true } );
+	for ( const entry of entries ) {
+		if ( ! entry.isFile() || ! entry.name.endsWith( '.php' ) ) {
+			continue;
 		}
-		process.exit( 1 );
-	}
-
-	// Check if the plugin has been built (vendor directories must exist).
-	const vendorPath = path.join( pluginPath, 'vendor' );
-	const jetpackVendorPath = path.join( pluginPath, 'jetpack_vendor' );
-	if ( ! fs.existsSync( vendorPath ) || ! fs.existsSync( jetpackVendorPath ) ) {
-		console.log(
-			chalk.yellow(
-				`Plugin "${ options.plugin }" has not been built yet. Running install and build...`
-			)
-		);
-
-		const install = child_process.spawnSync(
-			'jetpack',
-			[ 'install', `plugins/${ options.plugin }` ],
-			{ shell: true, stdio: 'inherit' }
-		);
-		if ( install.status !== 0 ) {
-			console.error( chalk.red( 'Install failed. Please run "jetpack install" manually.' ) );
-			process.exit( 1 );
-		}
-
-		const build = child_process.spawnSync( 'jetpack', [ 'build', `plugins/${ options.plugin }` ], {
-			shell: true,
-			stdio: 'inherit',
-		} );
-		if ( build.status !== 0 ) {
-			console.error( chalk.red( 'Build failed. Please run "jetpack build" manually.' ) );
-			process.exit( 1 );
+		const content = fs.readFileSync( path.join( pluginPath, entry.name ), 'utf8' );
+		if ( /^\s*\*?\s*Plugin Name:/m.test( content ) ) {
+			return entry.name;
 		}
 	}
-
-	// Use `jetpack rsync` to create a resolved copy in a temp dir.
-	// This reuses the existing rsync logic which properly resolves monorepo
-	// symlinks and only includes production files.
-	const tmpDir = fs.mkdtempSync(
-		path.join( os.tmpdir(), `jetpack-playground-${ options.plugin }-` )
-	);
-	const mountPath = path.join( tmpDir, options.plugin );
-
-	console.log( chalk.gray( 'Syncing plugin files (resolving monorepo symlinks)...' ) );
-
-	const rsyncResult = child_process.spawnSync(
-		'jetpack',
-		[ 'rsync', options.plugin, mountPath, '--non-interactive' ],
-		{ shell: true, stdio: 'inherit' }
-	);
-	if ( rsyncResult.status !== 0 ) {
-		console.error( chalk.red( 'Failed to sync plugin files.' ) );
-		fs.rmSync( tmpDir, { recursive: true, force: true } );
-		process.exit( 1 );
-	}
-
-	// Build the blueprint. We always inject a step to enable Jetpack offline mode
-	// (JETPACK_DEV_DEBUG) so the plugin works without a WordPress.com connection.
-	const blueprintPath = buildBlueprint( pluginPath, mountPath, options );
-
-	console.log(
-		chalkJetpackGreen( `Starting WordPress Playground with plugins/${ options.plugin }...` )
-	);
-
-	const args = [ '@wp-playground/cli', 'server', '--auto-mount', `--blueprint=${ blueprintPath }` ];
-
-	if ( options.port ) {
-		args.push( `--port=${ options.port }` );
-	}
-
-	if ( options.verbose ) {
-		console.log( chalk.gray( `Running: npx ${ args.join( ' ' ) }` ) );
-		console.log( chalk.gray( `Synced copy: ${ mountPath }` ) );
-	}
-
-	try {
-		child_process.spawnSync( 'npx', args, {
-			cwd: mountPath,
-			shell: true,
-			stdio: 'inherit',
-		} );
-	} finally {
-		// Clean up the temporary copy.
-		console.log( chalk.gray( 'Cleaning up temporary files...' ) );
-		fs.rmSync( tmpDir, { recursive: true, force: true } );
-	}
+	return null;
 }

--- a/tools/cli/commands/playground.js
+++ b/tools/cli/commands/playground.js
@@ -1,0 +1,217 @@
+import child_process from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import chalk from 'chalk';
+import { dirs } from '../helpers/projectHelpers.js';
+import { chalkJetpackGreen } from '../helpers/styling.js';
+
+/**
+ * Command definition for the playground subcommand.
+ *
+ * @param {object} yargs - The Yargs dependency.
+ * @return {object} Yargs with the playground commands defined.
+ */
+export function playgroundDefine( yargs ) {
+	yargs.command(
+		'playground <plugin>',
+		'Starts a WordPress Playground instance with a plugin mounted',
+		yarg => {
+			yarg
+				.positional( 'plugin', {
+					describe: 'Plugin name, e.g. jetpack',
+					type: 'string',
+				} )
+				.option( 'blueprint', {
+					alias: 'b',
+					type: 'string',
+					description: 'Path to a custom blueprint.json file',
+				} )
+				.option( 'port', {
+					alias: 'p',
+					type: 'number',
+					description: 'Port to run the Playground server on',
+				} )
+				.example( 'jetpack playground jetpack', 'Start Playground with the Jetpack plugin' )
+				.example( 'jetpack playground crm', 'Start Playground with the CRM plugin' );
+		},
+		async argv => {
+			await playgroundCli( argv );
+		}
+	);
+
+	return yargs;
+}
+
+/**
+ * Build a blueprint JSON file for the Playground session.
+ *
+ * Always injects a step to define JETPACK_DEV_DEBUG in wp-config.php so Jetpack
+ * runs in offline mode without needing a WordPress.com connection. If the plugin
+ * ships its own blueprint, the steps are merged.
+ *
+ * @param {string} pluginPath - Absolute path to the plugin source directory.
+ * @param {string} mountPath  - Absolute path to the resolved plugin copy in the temp dir.
+ * @param {object} options    - CLI options (may include a custom blueprint path).
+ * @return {string} Path to the generated blueprint file.
+ */
+function buildBlueprint( pluginPath, mountPath, options ) {
+	const tmpDir = path.dirname( mountPath );
+
+	// Start with a base blueprint.
+	let blueprint = {
+		$schema: 'https://playground.wordpress.net/blueprint-schema.json',
+		landingPage: '/wp-admin/',
+		login: true,
+		preferredVersions: {
+			php: '8.0',
+			wp: 'latest',
+		},
+		features: {
+			networking: true,
+		},
+		steps: [],
+	};
+
+	// Merge a user-provided or plugin-shipped blueprint.
+	let sourceBlueprint = null;
+	if ( options.blueprint ) {
+		sourceBlueprint = path.resolve( options.blueprint );
+	} else {
+		const pluginBlueprintPath = path.join(
+			pluginPath,
+			'.wordpress-org',
+			'blueprints',
+			'blueprint.json'
+		);
+		if ( fs.existsSync( pluginBlueprintPath ) ) {
+			sourceBlueprint = pluginBlueprintPath;
+		}
+	}
+
+	if ( sourceBlueprint ) {
+		console.log( chalk.gray( `Using blueprint: ${ path.relative( '.', sourceBlueprint ) }` ) );
+		const custom = JSON.parse( fs.readFileSync( sourceBlueprint, 'utf8' ) );
+		blueprint = {
+			...blueprint,
+			...custom,
+			// Merge steps — custom steps run first, then ours.
+			steps: [ ...( custom.steps || [] ) ],
+		};
+	}
+
+	// Inject the offline mode step: define JETPACK_DEV_DEBUG in wp-config.php.
+	blueprint.steps.push( {
+		step: 'defineWpConfigConsts',
+		consts: {
+			JETPACK_DEV_DEBUG: true,
+		},
+	} );
+
+	// Write the merged blueprint to the temp directory.
+	const blueprintOutPath = path.join( tmpDir, 'blueprint.json' );
+	fs.writeFileSync( blueprintOutPath, JSON.stringify( blueprint, null, '\t' ) );
+
+	return blueprintOutPath;
+}
+
+/**
+ * Entry point for the playground CLI.
+ *
+ * @param {object} options - The argv for the command line.
+ */
+async function playgroundCli( options ) {
+	const pluginPath = path.resolve( `projects/plugins/${ options.plugin }` );
+
+	// Validate that the plugin exists.
+	if ( ! fs.existsSync( pluginPath ) ) {
+		const available = dirs( './projects/plugins' );
+		console.error( chalk.red( `Plugin "${ options.plugin }" not found.` ) );
+		if ( available.length > 0 ) {
+			console.error( `\nAvailable plugins: ${ available.join( ', ' ) }` );
+		}
+		process.exit( 1 );
+	}
+
+	// Check if the plugin has been built (vendor directories must exist).
+	const vendorPath = path.join( pluginPath, 'vendor' );
+	const jetpackVendorPath = path.join( pluginPath, 'jetpack_vendor' );
+	if ( ! fs.existsSync( vendorPath ) || ! fs.existsSync( jetpackVendorPath ) ) {
+		console.log(
+			chalk.yellow(
+				`Plugin "${ options.plugin }" has not been built yet. Running install and build...`
+			)
+		);
+
+		const install = child_process.spawnSync(
+			'jetpack',
+			[ 'install', `plugins/${ options.plugin }` ],
+			{ shell: true, stdio: 'inherit' }
+		);
+		if ( install.status !== 0 ) {
+			console.error( chalk.red( 'Install failed. Please run "jetpack install" manually.' ) );
+			process.exit( 1 );
+		}
+
+		const build = child_process.spawnSync( 'jetpack', [ 'build', `plugins/${ options.plugin }` ], {
+			shell: true,
+			stdio: 'inherit',
+		} );
+		if ( build.status !== 0 ) {
+			console.error( chalk.red( 'Build failed. Please run "jetpack build" manually.' ) );
+			process.exit( 1 );
+		}
+	}
+
+	// Use `jetpack rsync` to create a resolved copy in a temp dir.
+	// This reuses the existing rsync logic which properly resolves monorepo
+	// symlinks and only includes production files.
+	const tmpDir = fs.mkdtempSync(
+		path.join( os.tmpdir(), `jetpack-playground-${ options.plugin }-` )
+	);
+	const mountPath = path.join( tmpDir, options.plugin );
+
+	console.log( chalk.gray( 'Syncing plugin files (resolving monorepo symlinks)...' ) );
+
+	const rsyncResult = child_process.spawnSync(
+		'jetpack',
+		[ 'rsync', options.plugin, mountPath, '--non-interactive' ],
+		{ shell: true, stdio: 'inherit' }
+	);
+	if ( rsyncResult.status !== 0 ) {
+		console.error( chalk.red( 'Failed to sync plugin files.' ) );
+		fs.rmSync( tmpDir, { recursive: true, force: true } );
+		process.exit( 1 );
+	}
+
+	// Build the blueprint. We always inject a step to enable Jetpack offline mode
+	// (JETPACK_DEV_DEBUG) so the plugin works without a WordPress.com connection.
+	const blueprintPath = buildBlueprint( pluginPath, mountPath, options );
+
+	console.log(
+		chalkJetpackGreen( `Starting WordPress Playground with plugins/${ options.plugin }...` )
+	);
+
+	const args = [ '@wp-playground/cli', 'server', '--auto-mount', `--blueprint=${ blueprintPath }` ];
+
+	if ( options.port ) {
+		args.push( `--port=${ options.port }` );
+	}
+
+	if ( options.verbose ) {
+		console.log( chalk.gray( `Running: npx ${ args.join( ' ' ) }` ) );
+		console.log( chalk.gray( `Synced copy: ${ mountPath }` ) );
+	}
+
+	try {
+		child_process.spawnSync( 'npx', args, {
+			cwd: mountPath,
+			shell: true,
+			stdio: 'inherit',
+		} );
+	} finally {
+		// Clean up the temporary copy.
+		console.log( chalk.gray( 'Cleaning up temporary files...' ) );
+		fs.rmSync( tmpDir, { recursive: true, force: true } );
+	}
+}

--- a/tools/cli/commands/playground.js
+++ b/tools/cli/commands/playground.js
@@ -57,7 +57,7 @@ export async function handler( argv ) {
 	// Warn if @wp-playground/cli needs to be downloaded (first run).
 	const playgroundCheck = child_process.spawnSync(
 		'npx',
-		[ '--no-install', '@wp-playground/cli', '--version' ],
+		[ '--no-install', '@wp-playground/cli@^3', '--version' ],
 		{ stdio: 'ignore' }
 	);
 	if ( playgroundCheck.status !== 0 ) {
@@ -87,10 +87,14 @@ export async function handler( argv ) {
 	}
 
 	// If the plugin hasn't been built, run the build first.
-	if (
-		! fs.existsSync( path.join( pluginPath, 'vendor' ) ) ||
-		! fs.existsSync( path.join( pluginPath, 'node_modules' ) )
-	) {
+	// Only check for vendor/ when composer.json exists, and node_modules/ when package.json exists.
+	const hasComposerJson = fs.existsSync( path.join( pluginPath, 'composer.json' ) );
+	const hasPackageJson = fs.existsSync( path.join( pluginPath, 'package.json' ) );
+	const needsBuild =
+		( hasComposerJson && ! fs.existsSync( path.join( pluginPath, 'vendor' ) ) ) ||
+		( hasPackageJson && ! fs.existsSync( path.join( pluginPath, 'node_modules' ) ) );
+
+	if ( needsBuild ) {
 		console.log(
 			chalk.yellow( `Plugin "${ argv.plugin }" does not appear to be built. Building...` )
 		);
@@ -119,12 +123,12 @@ export async function handler( argv ) {
 	const packagesPath = projectDir( 'packages' );
 
 	try {
-		const blueprintPath = buildBlueprint( pluginPath, tmpDir, argv, wpPluginSlug );
+		const blueprintPath = buildBlueprint( pluginPath, tmpDir, argv, wpPluginSlug, argv.plugin );
 
 		const port = argv.port ?? 9400;
 
 		const args = [
-			'@wp-playground/cli',
+			'@wp-playground/cli@^3',
 			'server',
 			`--mount=${ pluginPath }:/wordpress/wp-content/plugins/${ wpPluginSlug }`,
 			`--mount=${ packagesPath }:/wordpress/wp-content/packages`,
@@ -167,6 +171,9 @@ export async function handler( argv ) {
 
 			proc.on( 'error', reject );
 		} );
+	} catch ( err ) {
+		console.error( chalk.red( err.message ) );
+		process.exit( 1 );
 	} finally {
 		console.log( chalk.gray( 'Cleaning up temporary files...' ) );
 		fs.rmSync( tmpDir, { recursive: true, force: true } );
@@ -176,17 +183,18 @@ export async function handler( argv ) {
 /**
  * Build a blueprint JSON file for the Playground session.
  *
- * Always injects a step to define JETPACK_DEV_DEBUG in wp-config.php so Jetpack
- * runs in offline mode without needing a WordPress.com connection. If the plugin
+ * For the Jetpack plugin, injects a step to define JETPACK_DEV_DEBUG in wp-config.php
+ * so it runs in offline mode without needing a WordPress.com connection. If the plugin
  * ships its own blueprint, the steps are merged.
  *
  * @param {string} pluginPath   - Absolute path to the plugin source directory.
  * @param {string} tmpDir       - Temporary directory to write the blueprint into.
  * @param {object} options      - CLI options (may include a custom blueprint path and plugin name).
  * @param {string} wpPluginSlug - The WordPress plugin slug (used for activation).
+ * @param {string} pluginName   - The monorepo plugin directory name (e.g. 'jetpack').
  * @return {string} Path to the generated blueprint file.
  */
-function buildBlueprint( pluginPath, tmpDir, options, wpPluginSlug ) {
+function buildBlueprint( pluginPath, tmpDir, options, wpPluginSlug, pluginName ) {
 	// Start with a base blueprint.
 	let blueprint = {
 		$schema: 'https://playground.wordpress.net/blueprint-schema.json',
@@ -203,8 +211,7 @@ function buildBlueprint( pluginPath, tmpDir, options, wpPluginSlug ) {
 	if ( options.blueprint ) {
 		sourceBlueprint = path.resolve( options.blueprint );
 		if ( ! fs.existsSync( sourceBlueprint ) ) {
-			console.error( chalk.red( `Blueprint file not found: ${ sourceBlueprint }` ) );
-			process.exit( 1 );
+			throw new Error( `Blueprint file not found: ${ sourceBlueprint }` );
 		}
 	} else {
 		const pluginBlueprintPath = path.join(
@@ -224,8 +231,7 @@ function buildBlueprint( pluginPath, tmpDir, options, wpPluginSlug ) {
 		try {
 			custom = JSON.parse( fs.readFileSync( sourceBlueprint, 'utf8' ) );
 		} catch ( err ) {
-			console.error( chalk.red( `Failed to parse blueprint: ${ err.message }` ) );
-			process.exit( 1 );
+			throw new Error( `Failed to parse blueprint: ${ err.message }` );
 		}
 		blueprint = {
 			...blueprint,
@@ -255,13 +261,15 @@ add_filter( 'plugins_url', function ( $url ) {
 `,
 	} );
 
-	// Inject the offline mode step: define JETPACK_DEV_DEBUG in wp-config.php.
-	blueprint.steps.push( {
-		step: 'defineWpConfigConsts',
-		consts: {
-			JETPACK_DEV_DEBUG: true,
-		},
-	} );
+	// Inject the offline mode step only for the Jetpack plugin itself.
+	if ( pluginName === 'jetpack' ) {
+		blueprint.steps.push( {
+			step: 'defineWpConfigConsts',
+			consts: {
+				JETPACK_DEV_DEBUG: true,
+			},
+		} );
+	}
 
 	// Activate the plugin using the WordPress plugin identifier (slug/main-file.php).
 	const mainFile = findMainPluginFile( pluginPath );

--- a/tools/cli/commands/playground.js
+++ b/tools/cli/commands/playground.js
@@ -93,10 +93,8 @@ export async function handler( argv ) {
 	try {
 		const blueprintPath = buildBlueprint( pluginPath, tmpDir, argv, wpPluginSlug, argv.plugin );
 
-		const port = argv.port ?? 9400;
-
 		const args = [
-			'@wp-playground/cli@^3',
+			'@wp-playground/cli',
 			'server',
 			`--mount=${ pluginPath }:/wordpress/wp-content/plugins/${ wpPluginSlug }`,
 			`--mount=${ packagesPath }:/wordpress/wp-content/packages`,
@@ -119,10 +117,13 @@ export async function handler( argv ) {
 			proc.stdout.on( 'data', data => {
 				process.stdout.write( data );
 
-				// After Playground prints its "Ready!" line, show helpful info.
-				if ( data.toString().includes( 'Ready!' ) ) {
+				// Parse the actual URL from Playground's output
+				// (e.g. "WordPress is running on http://127.0.0.1:9400").
+				const match = data.toString().match( /running on (http:\/\/[^\s]+)/ );
+				if ( match ) {
+					const siteUrl = match[ 1 ].replace( /\/$/, '' );
 					console.log();
-					console.log( `  Admin:  ${ chalk.cyan( `http://127.0.0.1:${ port }/wp-admin/` ) }` );
+					console.log( `  Admin:  ${ chalk.cyan( `${ siteUrl }/wp-admin/` ) }` );
 					console.log( chalk.gray( '  Login:  admin / password' ) );
 					console.log( chalk.gray( '  Stop:   Ctrl+C' ) );
 					console.log();

--- a/tools/cli/commands/playground.js
+++ b/tools/cli/commands/playground.js
@@ -2,12 +2,10 @@ import child_process from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { fileURLToPath } from 'url';
 import chalk from 'chalk';
 import { projectDir } from '../helpers/install.js';
+import { readComposerJson } from '../helpers/json.js';
 import { maybePromptForPlugin } from './rsync.js';
-
-const cliPath = fileURLToPath( new URL( '../bin/jetpack.js', import.meta.url ) );
 
 export const command = 'playground [plugin]';
 export const describe = 'Starts a WordPress Playground instance with a plugin mounted';
@@ -33,6 +31,11 @@ export function builder( yargs ) {
 			alias: 'p',
 			type: 'number',
 			description: 'Port to run the Playground server on',
+		} )
+		.option( 'debug', {
+			type: 'boolean',
+			default: false,
+			description: 'Enable WP_DEBUG and SCRIPT_DEBUG (errors logged to /wp-content/debug.log)',
 		} )
 		.example( 'jetpack playground jetpack', 'Start Playground with the Jetpack plugin' )
 		.example( 'jetpack playground crm', 'Start Playground with the CRM plugin' );
@@ -72,44 +75,11 @@ export async function handler( argv ) {
 
 	// Read the plugin slug from composer.json so the mount path inside
 	// Playground uses the correct wp-plugin-slug (e.g. zero-bs-crm for crm).
-	const composerJsonPath = path.join( pluginPath, 'composer.json' );
-	let wpPluginSlug = argv.plugin;
-	if ( fs.existsSync( composerJsonPath ) ) {
-		try {
-			const composerJson = JSON.parse( fs.readFileSync( composerJsonPath, 'utf8' ) );
-			wpPluginSlug =
-				composerJson?.extra?.[ 'wp-plugin-slug' ] ??
-				composerJson?.extra?.[ 'beta-plugin-slug' ] ??
-				argv.plugin;
-		} catch {
-			// Fall back to directory name if composer.json is unreadable.
-		}
-	}
-
-	// If the plugin hasn't been built, run the build first.
-	// Only check for vendor/ when composer.json exists, and node_modules/ when package.json exists.
-	const hasComposerJson = fs.existsSync( path.join( pluginPath, 'composer.json' ) );
-	const hasPackageJson = fs.existsSync( path.join( pluginPath, 'package.json' ) );
-	const needsBuild =
-		( hasComposerJson && ! fs.existsSync( path.join( pluginPath, 'vendor' ) ) ) ||
-		( hasPackageJson && ! fs.existsSync( path.join( pluginPath, 'node_modules' ) ) );
-
-	if ( needsBuild ) {
-		console.log(
-			chalk.yellow( `Plugin "${ argv.plugin }" does not appear to be built. Building...` )
-		);
-		const build = child_process.spawnSync(
-			process.execPath,
-			[ cliPath, 'build', `plugins/${ argv.plugin }` ],
-			{ stdio: 'inherit' }
-		);
-		if ( build.status !== 0 ) {
-			console.error(
-				chalk.red( 'Build failed. Please run "jetpack build" manually and try again.' )
-			);
-			process.exit( 1 );
-		}
-	}
+	const composerJson = readComposerJson( `plugins/${ argv.plugin }`, false );
+	const wpPluginSlug =
+		composerJson?.extra?.[ 'wp-plugin-slug' ] ??
+		composerJson?.extra?.[ 'beta-plugin-slug' ] ??
+		argv.plugin;
 
 	// Build the blueprint into a temp directory.
 	const tmpDir = fs.mkdtempSync( path.join( os.tmpdir(), `jetpack-playground-${ argv.plugin }-` ) );
@@ -121,6 +91,18 @@ export async function handler( argv ) {
 	// projects/packages there so these symlinks resolve to real files and
 	// plugins_url() can generate correct URLs (paths stay under wp-content).
 	const packagesPath = projectDir( 'packages' );
+
+	const cleanup = () => {
+		console.log( chalk.gray( 'Cleaning up temporary files...' ) );
+		fs.rmSync( tmpDir, { recursive: true, force: true } );
+	};
+
+	// Ensure temp directory is cleaned up on Ctrl+C.
+	const onSigInt = () => {
+		cleanup();
+		process.exit( 130 );
+	};
+	process.on( 'SIGINT', onSigInt );
 
 	try {
 		const blueprintPath = buildBlueprint( pluginPath, tmpDir, argv, wpPluginSlug, argv.plugin );
@@ -171,12 +153,9 @@ export async function handler( argv ) {
 
 			proc.on( 'error', reject );
 		} );
-	} catch ( err ) {
-		console.error( chalk.red( err.message ) );
-		process.exit( 1 );
 	} finally {
-		console.log( chalk.gray( 'Cleaning up temporary files...' ) );
-		fs.rmSync( tmpDir, { recursive: true, force: true } );
+		process.removeListener( 'SIGINT', onSigInt );
+		cleanup();
 	}
 }
 
@@ -241,6 +220,29 @@ function buildBlueprint( pluginPath, tmpDir, options, wpPluginSlug, pluginName )
 		};
 	}
 
+	// Playground enables WP_DEBUG by default, which causes PHP notices (e.g.
+	// early textdomain loading) to produce output before headers are sent,
+	// breaking the auto-login redirect. When debug is off we disable WP_DEBUG
+	// entirely; when on we log errors to file instead of displaying them.
+	if ( options.debug ) {
+		blueprint.steps.push( {
+			step: 'defineWpConfigConsts',
+			consts: {
+				WP_DEBUG: true,
+				WP_DEBUG_DISPLAY: false,
+				WP_DEBUG_LOG: true,
+				SCRIPT_DEBUG: true,
+			},
+		} );
+	} else {
+		blueprint.steps.push( {
+			step: 'defineWpConfigConsts',
+			consts: {
+				WP_DEBUG: false,
+			},
+		} );
+	}
+
 	// The vendor symlinks resolve to /wordpress/wp-content/packages/ which is
 	// outside WP_PLUGIN_DIR, so plugins_url() generates broken URLs like
 	// /wp-content/plugins/wordpress/wp-content/packages/... Install a mu-plugin
@@ -271,39 +273,15 @@ add_filter( 'plugins_url', function ( $url ) {
 		} );
 	}
 
-	// Activate the plugin using the WordPress plugin identifier (slug/main-file.php).
-	const mainFile = findMainPluginFile( pluginPath );
-	if ( mainFile ) {
-		blueprint.steps.push( {
-			step: 'activatePlugin',
-			pluginPath: `${ wpPluginSlug }/${ mainFile }`,
-		} );
-	}
+	// Activate the plugin.
+	blueprint.steps.push( {
+		step: 'activatePlugin',
+		pluginPath: `/wordpress/wp-content/plugins/${ wpPluginSlug }`,
+	} );
 
 	// Write the merged blueprint to the temp directory.
 	const blueprintOutPath = path.join( tmpDir, 'blueprint.json' );
 	fs.writeFileSync( blueprintOutPath, JSON.stringify( blueprint, null, '\t' ) );
 
 	return blueprintOutPath;
-}
-
-/**
- * Find the main plugin PHP file by looking for the "Plugin Name:" header
- * in root-level PHP files.
- *
- * @param {string} pluginPath - Absolute path to the plugin directory.
- * @return {string|null} The filename of the main plugin file, or null if not found.
- */
-function findMainPluginFile( pluginPath ) {
-	const entries = fs.readdirSync( pluginPath, { withFileTypes: true } );
-	for ( const entry of entries ) {
-		if ( ! entry.isFile() || ! entry.name.endsWith( '.php' ) ) {
-			continue;
-		}
-		const content = fs.readFileSync( path.join( pluginPath, entry.name ), 'utf8' );
-		if ( /^\s*\*?\s*Plugin Name:/m.test( content ) ) {
-			return entry.name;
-		}
-	}
-	return null;
 }


### PR DESCRIPTION
This PR make it possible to quickly spin up a playground instance. This could be useful for LLM agents to check their work. 

The initial step might 

See

https://github.com/user-attachments/assets/f37a5845-6057-4879-be72-4bdc99ab9d21

## Proposed changes

* Add a new `jetpack playground <plugin>` CLI command that starts a local WordPress Playground instance with the specified plugin mounted
* Uses `jetpack rsync` to create a temporary copy with monorepo symlinks resolved (vendor/jetpack_vendor symlinks point outside the plugin directory and break in Playground's sandbox)
* Automatically injects `JETPACK_DEV_DEBUG` via a blueprint step so Jetpack runs in offline mode without requiring a WordPress.com connection
* Auto-discovers plugin blueprints at `.wordpress-org/blueprints/blueprint.json` (e.g., CRM already has one)
* Runs `jetpack install` + `jetpack build` automatically if the plugin hasn't been built yet
* Cleans up temporary files when Playground exits

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Ensure you have Node.js installed and the monorepo set up (`jetpack cli link`)
* Run `jetpack playground jetpack`
  * Verify it syncs plugin files, starts Playground, and Jetpack loads in offline mode (no connection prompt)
* Run `jetpack playground crm`
  * Verify it picks up the existing CRM blueprint at `projects/plugins/crm/.wordpress-org/blueprints/blueprint.json`
* Run `jetpack playground nonexistent`
  * Verify it shows an error with the list of available plugins
* Run `jetpack playground jetpack -p 9999`
  * Verify Playground starts on port 9999
* After stopping Playground (Ctrl+C), verify the temp directory is cleaned up
