### PR TITLE
Forms: send blog_lang and permalink to Akismet

### DIFF
--- a/projects/packages/forms/changelog/update-forms-akismet-context
+++ b/projects/packages/forms/changelog/update-forms-akismet-context
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Send blog_lang and permalink to Akismet for improved spam detection on contact form submissions.

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2279,6 +2279,7 @@ class Contact_Form_Plugin {
 		$form['user_agent']       = isset( $_SERVER['HTTP_USER_AGENT'] ) ? filter_var( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : '';
 		$form['referrer']         = isset( $_SERVER['HTTP_REFERER'] ) ? esc_url_raw( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : '';
 		$form['blog']             = get_option( 'home' );
+		$form['blog_lang']        = get_bloginfo( 'language' );
 		$form['comment_date_gmt'] = gmdate( DATE_ATOM, time() ); // ISO 8601. See https://www.php.net/manual/en/class.datetimeinterface.php#datetimeinterface.constants.types
 
 		foreach ( $_SERVER as $key => $value ) {

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -802,6 +802,7 @@ class Feedback {
 			'contact_form_subject' => $this->get_subject(),
 			'comment_author_ip'    => $this->get_ip_address(),
 			'comment_content'      => empty( $this->get_comment_content() ) ? null : $this->get_comment_content(),
+			'permalink'            => $this->get_entry_permalink(),
 		);
 
 		foreach ( $this->fields as $field ) {


### PR DESCRIPTION
## Summary

- Add `blog_lang` to `prepare_for_akismet()` so Akismet can use the site language for classification
- Add `permalink` to `get_akismet_vars()` so Akismet knows which page the form lives on

Both fields are standard Akismet API parameters that were previously missing from contact form submissions. They flow through to `submit-spam`/`submit-ham` automatically via stored `_feedback_akismet_values` post meta.

Fixes FORMS-618

## Test plan

- [ ] Submit a contact form on a site with Akismet enabled
- [ ] Inspect `_feedback_akismet_values` post meta on the created feedback post — verify `blog_lang` and `permalink` are present
- [ ] Verify `blog_lang` matches `get_bloginfo('language')` (e.g. `en-US`)
- [ ] Verify `permalink` is the URL of the page containing the form (not the home URL)
- [ ] Mark the submission as spam, verify the new fields are included in the `submit-spam` request
- [ ] Run PHP tests: `jetpack test php packages/forms`

🤖 Generated with [Claude Code](https://claude.com/claude-code)