### PR TITLE
Forms: send blog_lang and permalink to Akismet for improved spam detection

### DIFF
--- a/projects/packages/forms/changelog/update-forms-akismet-context
+++ b/projects/packages/forms/changelog/update-forms-akismet-context
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Send blog_lang and permalink to Akismet for improved spam detection on contact form submissions.

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -2279,6 +2279,7 @@ class Contact_Form_Plugin {
 		$form['user_agent']       = isset( $_SERVER['HTTP_USER_AGENT'] ) ? filter_var( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : '';
 		$form['referrer']         = isset( $_SERVER['HTTP_REFERER'] ) ? esc_url_raw( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : '';
 		$form['blog']             = get_option( 'home' );
+		$form['blog_lang']        = get_bloginfo( 'language' );
 		$form['comment_date_gmt'] = gmdate( DATE_ATOM, time() ); // ISO 8601. See https://www.php.net/manual/en/class.datetimeinterface.php#datetimeinterface.constants.types
 
 		foreach ( $_SERVER as $key => $value ) {

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -802,6 +802,7 @@ class Feedback {
 			'contact_form_subject' => $this->get_subject(),
 			'comment_author_ip'    => $this->get_ip_address(),
 			'comment_content'      => empty( $this->get_comment_content() ) ? null : $this->get_comment_content(),
+			'permalink'            => $this->get_entry_permalink(),
 		);
 
 		foreach ( $this->fields as $field ) {

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -1572,4 +1572,50 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 
 		remove_all_actions( 'edge_cache_purge_domain' );
 	}
+
+	/**
+	 * Test that prepare_for_akismet includes blog_lang.
+	 */
+	public function test_prepare_for_akismet_includes_blog_lang() {
+		$plugin = Contact_Form_Plugin::init();
+		$form   = array(
+			'comment_author'  => 'Test',
+			'comment_content' => 'Hello',
+		);
+
+		$result = $plugin->prepare_for_akismet( $form );
+
+		$this->assertArrayHasKey( 'blog_lang', $result, 'prepare_for_akismet should include blog_lang' );
+		$this->assertEquals( get_bloginfo( 'language' ), $result['blog_lang'], 'blog_lang should match site language' );
+	}
+
+	/**
+	 * Test that prepare_for_akismet includes blog and other standard fields.
+	 */
+	public function test_prepare_for_akismet_includes_standard_fields() {
+		$plugin = Contact_Form_Plugin::init();
+		$form   = array(
+			'comment_author'  => 'Test',
+			'comment_content' => 'Hello',
+		);
+
+		$result = $plugin->prepare_for_akismet( $form );
+
+		$expected_keys = array(
+			'comment_type',
+			'user_ip',
+			'user_agent',
+			'referrer',
+			'blog',
+			'blog_lang',
+			'comment_date_gmt',
+		);
+
+		foreach ( $expected_keys as $key ) {
+			$this->assertArrayHasKey( $key, $result, "prepare_for_akismet should include '$key'" );
+		}
+
+		$this->assertEquals( 'contact_form', $result['comment_type'] );
+		$this->assertEquals( get_option( 'home' ), $result['blog'] );
+	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Legacy_Compatibility_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Legacy_Compatibility_Test.php
@@ -49,7 +49,8 @@ class Feedback_Legacy_Compatibility_Test extends BaseTestCase {
 		$response = Feedback::from_submission( $_post_data, $form, $current_post );
 		$post_id  = $response->save();
 
-		$saved_response = Feedback::get( $post_id );
+		$saved_response     = Feedback::get( $post_id );
+		$expected_permalink = get_permalink( $current_post->ID );
 		Utility::destroy_post_context( $current_post );
 
 		$this->assertNotEmpty( $response->get_akismet_vars(), 'Akismet vars should not be empty for the form submission' );
@@ -61,6 +62,7 @@ class Feedback_Legacy_Compatibility_Test extends BaseTestCase {
 			'contact_form_subject',
 			'comment_author_ip',
 			'comment_content',
+			'permalink',
 			'contact_form_field_text',
 		);
 
@@ -68,6 +70,10 @@ class Feedback_Legacy_Compatibility_Test extends BaseTestCase {
 			$this->assertArrayHasKey( $key, $response->get_akismet_vars(), "Akismet vars should contain '$key'" );
 			$this->assertArrayHasKey( $key, $saved_response->get_akismet_vars(), "Akismet vars should contain '$key'" );
 		}
+
+		// Verify permalink points to the post the form was submitted on.
+		$this->assertEquals( $expected_permalink, $response->get_akismet_vars()['permalink'], 'Akismet permalink should match the entry permalink' );
+		$this->assertEquals( $expected_permalink, $saved_response->get_akismet_vars()['permalink'], 'Saved Akismet permalink should match the entry permalink' );
 	}
 
 	public function test_legacy_get_all_legacy_values() {


### PR DESCRIPTION
Fixes FORMS-618

## Proposed changes

* Add `blog_lang` to `prepare_for_akismet()` — sends the site language (e.g. `en-US`) so Akismet can factor language context into classification
* Add `permalink` to `get_akismet_vars()` — sends the URL of the page containing the form, using the existing `get_entry_permalink()` method

Both are standard Akismet API parameters that were previously missing from contact form `comment-check` requests. They flow through to `submit-spam`/`submit-ham` automatically via stored `_feedback_akismet_values` post meta.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* `p1773331860068309-slack-C029E4HPT`
* [NOSPAM-590](https://linear.app/a8c/issue/NOSPAM-590)

## Does this pull request change what data or activity we track or use?

This adds two fields to the data sent to Akismet during spam checks:
- `blog_lang`: the site language from `get_bloginfo('language')`
- `permalink`: the URL of the page the form is embedded on

Both are already available server-side and are standard Akismet API fields. No new user data is collected.

## Testing instructions

* Set up a local site with Jetpack Forms and Akismet enabled
* Submit a contact form on a page
* Check the `_feedback_akismet_values` post meta on the created feedback post (e.g. via WP-CLI: `wp post meta get <ID> _feedback_akismet_values`)
* Verify `blog_lang` is present and matches `get_bloginfo('language')` (e.g. `en-US`)
* Verify `permalink` is present and is the URL of the page containing the form (not the home URL)
* Mark the submission as spam and verify the new fields are included in the `submit-spam` request (check Akismet debug logs if available)
