### PR TITLE
Rtc provider based setting

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/rtc-provider-based-setting
+++ b/projects/packages/jetpack-mu-wpcom/changelog/rtc-provider-based-setting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
@@ -148,8 +148,8 @@ function wpcom_default_rtc_option() {
 	// Providers exist and option is not stored yet → default to enabled.
 	return '1';
 }
-add_filter( 'default_option_wp_enable_real_time_collaboration', 'wpcom_default_rtc_option', 10 );
-add_filter( 'default_option_enable_real_time_collaboration', 'wpcom_default_rtc_option', 10 );
+add_filter( 'default_option_wp_enable_real_time_collaboration', 'wpcom_default_rtc_option', 20 );
+add_filter( 'default_option_enable_real_time_collaboration', 'wpcom_default_rtc_option', 20 );
 
 /**
  * Override the default for the Gutenberg RTC setting so that

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
@@ -116,18 +116,64 @@ function wpcom_unregister_rtc_setting() {
 add_action( 'admin_init', 'wpcom_unregister_rtc_setting', 11 );
 
 /**
- * Disable the `wp_enable_real_time_collaboration` option if there are no RTC providers.
+ * When there are no providers, always force the option off.
+ * When there are providers, respect the stored option value.
  *
- * @param mixed $pre_option The value to return instead of the option value.
- * @return string|false Filtered wp_enable_real_time_collaboration option
+ * @param mixed $value  The value of the option.
+ * @return mixed
  */
-function wpcom_disable_rtc_option( $pre_option ) {
+function wpcom_filter_rtc_option( $value ) {
 	$providers = wpcom_get_gutenberg_rtc_providers();
+	// No providers: force the option off, regardless of what's in the DB.
 	if ( count( $providers ) === 0 ) {
 		return '0';
 	}
-
-	return $pre_option;
+	// Providers exist: respect whatever is stored.
+	return $value;
 }
-add_filter( 'pre_option_wp_enable_real_time_collaboration', 'wpcom_disable_rtc_option' );
-add_filter( 'pre_option_enable_real_time_collaboration', 'wpcom_disable_rtc_option' ); // TODO: Clean up the old name. See https://github.com/WordPress/gutenberg/pull/75837.
+add_filter( 'option_wp_enable_real_time_collaboration', 'wpcom_filter_rtc_option', 10 );
+add_filter( 'option_enable_real_time_collaboration', 'wpcom_filter_rtc_option', 10 ); // Old name.
+/**
+ * When there ARE providers and the option is NOT stored yet,
+ * default the option to enabled (1).
+ *
+ * @return mixed
+ */
+function wpcom_default_rtc_option() {
+	$providers = wpcom_get_gutenberg_rtc_providers();
+	// No providers: keep default disabled.
+	if ( count( $providers ) === 0 ) {
+		return '0';
+	}
+	// Providers exist and option is not stored yet → default to enabled.
+	return '1';
+}
+add_filter( 'default_option_wp_enable_real_time_collaboration', 'wpcom_default_rtc_option', 10 );
+add_filter( 'default_option_enable_real_time_collaboration', 'wpcom_default_rtc_option', 10 );
+
+/**
+ * Override the default for the Gutenberg RTC setting so that
+ * when providers exist, it defaults to enabled in the UI.
+ */
+function wpcom_override_rtc_setting_default() {
+	$providers   = wpcom_get_gutenberg_rtc_providers();
+	$option_name = 'wp_enable_real_time_collaboration';
+
+	// Ensure the Gutenberg setting is unregistered first.
+	unregister_setting( 'writing', $option_name );
+
+	register_setting(
+		'writing',
+		$option_name,
+		array(
+			'type'              => 'boolean',
+			'description'       => __( 'Enable Real-Time Collaboration', 'jetpack-mu-wpcom' ),
+			'sanitize_callback' => 'rest_sanitize_boolean',
+			// Dynamic default: true when providers exist, false otherwise.
+			'default'           => count( $providers ) > 0,
+			'show_in_rest'      => true,
+		)
+	);
+}
+// Run after Gutenberg's own registration (default priority 10).
+add_action( 'admin_init', 'wpcom_override_rtc_setting_default', 20 );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
@@ -20,11 +20,17 @@ use PHPUnit\Framework\Attributes\CoversFunction;
  * @covers ::wpcom_get_gutenberg_rtc_providers
  * @covers ::wpcom_is_gutenberg_rtc_enabled
  * @covers ::wpcom_unregister_rtc_setting
+ * @covers ::wpcom_filter_rtc_option
+ * @covers ::wpcom_default_rtc_option
+ * @covers ::wpcom_override_rtc_setting_default
  */
 #[CoversFunction( 'wpcom_is_gutenberg_rtc_enabled' )]
 #[CoversFunction( 'wpcom_get_gutenberg_rtc_providers' )]
 #[CoversFunction( 'wpcom_enqueue_gutenberg_rtc_assets' )]
 #[CoversFunction( 'wpcom_unregister_rtc_setting' )]
+#[CoversFunction( 'wpcom_filter_rtc_option' )]
+#[CoversFunction( 'wpcom_default_rtc_option' )]
+#[CoversFunction( 'wpcom_override_rtc_setting_default' )]
 class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
 
 	/**
@@ -84,6 +90,38 @@ class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_wpcom_unregister_rtc_setting_hooked() {
 		$this->assertSame( 11, has_action( 'admin_init', 'wpcom_unregister_rtc_setting' ) );
+	}
+
+	/**
+	 * Tests whether the filter RTC option function is hooked to the option filters.
+	 */
+	public function test_wpcom_filter_rtc_option_hooked() {
+		$this->assertSame( 10, has_filter( 'option_wp_enable_real_time_collaboration', 'wpcom_filter_rtc_option' ) );
+		$this->assertSame( 10, has_filter( 'option_enable_real_time_collaboration', 'wpcom_filter_rtc_option' ) );
+	}
+
+	/**
+	 * Tests that wpcom_filter_rtc_option forces the option to '0' when there are no providers.
+	 */
+	public function test_wpcom_filter_rtc_option_forces_zero_without_providers() {
+		// By default, RTC is disabled and providers list is empty.
+		$this->assertSame( '0', wpcom_filter_rtc_option( '1' ) );
+	}
+
+	/**
+	 * Tests that wpcom_filter_rtc_option respects the stored value when providers exist.
+	 */
+	public function test_wpcom_filter_rtc_option_respects_value_with_providers() {
+		add_filter( 'wpcom_is_gutenberg_rtc_enabled', '__return_true' );
+		add_filter(
+			'wpcom_gutenberg_rtc_providers',
+			function () {
+				return array( 'pinghub' );
+			}
+		);
+
+		$this->assertSame( '1', wpcom_filter_rtc_option( '1' ) );
+		$this->assertSame( '0', wpcom_filter_rtc_option( '0' ) );
 	}
 
 	/**
@@ -258,6 +296,36 @@ class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
 		wpcom_enqueue_gutenberg_rtc_assets();
 
 		$this->assertTrue( wp_script_is( 'jetpack-mu-wpcom-gutenberg-rtc', 'enqueued' ) );
+	}
+
+	/**
+	 * Tests that wpcom_default_rtc_option returns '0' when there are no providers.
+	 */
+	public function test_wpcom_default_rtc_option_returns_zero_without_providers() {
+		// By default, RTC is disabled and providers list is empty.
+		$this->assertSame( '0', wpcom_default_rtc_option() );
+	}
+
+	/**
+	 * Tests that wpcom_default_rtc_option returns '1' when providers exist.
+	 */
+	public function test_wpcom_default_rtc_option_returns_one_with_providers() {
+		add_filter( 'wpcom_is_gutenberg_rtc_enabled', '__return_true' );
+		add_filter(
+			'wpcom_gutenberg_rtc_providers',
+			function () {
+				return array( 'pinghub' );
+			}
+		);
+
+		$this->assertSame( '1', wpcom_default_rtc_option() );
+	}
+
+	/**
+	 * Tests that the override RTC setting function is hooked to admin_init.
+	 */
+	public function test_wpcom_override_rtc_setting_default_hooked() {
+		$this->assertSame( 20, has_action( 'admin_init', 'wpcom_override_rtc_setting_default' ) );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
@@ -16,7 +16,6 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 /**
  * Tests for Gutenberg RTC feature.
  *
- * @covers ::wpcom_disable_rtc_option
  * @covers ::wpcom_enqueue_gutenberg_rtc_assets
  * @covers ::wpcom_get_gutenberg_rtc_providers
  * @covers ::wpcom_is_gutenberg_rtc_enabled
@@ -26,7 +25,6 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 #[CoversFunction( 'wpcom_get_gutenberg_rtc_providers' )]
 #[CoversFunction( 'wpcom_enqueue_gutenberg_rtc_assets' )]
 #[CoversFunction( 'wpcom_unregister_rtc_setting' )]
-#[CoversFunction( 'wpcom_disable_rtc_option' )]
 class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
 
 	/**
@@ -86,14 +84,6 @@ class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_wpcom_unregister_rtc_setting_hooked() {
 		$this->assertSame( 11, has_action( 'admin_init', 'wpcom_unregister_rtc_setting' ) );
-	}
-
-	/**
-	 * Tests whether the disable RTC option filters are hooked.
-	 */
-	public function test_wpcom_disable_rtc_option_hooked() {
-		$this->assertSame( 10, has_filter( 'pre_option_wp_enable_real_time_collaboration', 'wpcom_disable_rtc_option' ) );
-		$this->assertSame( 10, has_filter( 'pre_option_enable_real_time_collaboration', 'wpcom_disable_rtc_option' ) );
 	}
 
 	/**
@@ -268,29 +258,6 @@ class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
 		wpcom_enqueue_gutenberg_rtc_assets();
 
 		$this->assertTrue( wp_script_is( 'jetpack-mu-wpcom-gutenberg-rtc', 'enqueued' ) );
-	}
-
-	/**
-	 * Tests that wpcom_disable_rtc_option returns '0' when no providers.
-	 */
-	public function test_wpcom_disable_rtc_option_returns_zero_when_no_providers() {
-		$this->assertSame( '0', wpcom_disable_rtc_option( false ) );
-	}
-
-	/**
-	 * Tests that wpcom_disable_rtc_option passes through the pre_option value when providers exist.
-	 */
-	public function test_wpcom_disable_rtc_option_passes_through_when_providers_exist() {
-		add_filter( 'wpcom_is_gutenberg_rtc_enabled', '__return_true' );
-		add_filter(
-			'wpcom_gutenberg_rtc_providers',
-			function () {
-				return array( 'pinghub' );
-			}
-		);
-
-		$this->assertFalse( wpcom_disable_rtc_option( false ) );
-		$this->assertSame( '1', wpcom_disable_rtc_option( '1' ) );
 	}
 
 	/**


### PR DESCRIPTION
### PR description

Fixes #DOTCOM-16342

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Ensure the real‑time collaboration setting defaults to **enabled** when at least one RTC provider is available (e.g. http‑polling), both in the UI and in runtime calls to `get_option()`.
* Respect the user’s choice after they change the setting: once saved, the stored value is always used as long as there is at least one provider.
* When there are **no** RTC providers, hide the Collaboration setting from the Writing page and force the underlying options to behave as disabled, regardless of any stored value.
* Override Gutenberg’s registered `wp_enable_real_time_collaboration` setting in `gutenberg-rtc.php` so that its default is dynamic (enabled when providers exist, disabled otherwise).

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
* No, this PR does not change what data we track or use.

## Testing instructions

* Preconditions:
  * A site running the patched Jetpack MU plugin.
  * Gutenberg 7.0 compat layer active (so `lib/compat/wordpress-7.0/collaboration.php` is in use).

### Case 1: HTTP‑polling provider only, no existing option value

1. Ensure only `http-polling` is present as an RTC provider (no `pinghub`).
2. Delete any existing options:
   * `wp option delete wp_enable_real_time_collaboration`
   * `wp option delete enable_real_time_collaboration`
3. Go to `Settings → Writing` in `wp-admin`.
4. **Expected:**  
   * The “Collaboration → Enable real‑time collaboration” checkbox is **checked by default**.
   * Running `wp option get wp_enable_real_time_collaboration` returns `1`.

### Case 2: User disables the setting with providers available

1. With http‑polling still configured as a provider, go to `Settings → Writing`.
2. Uncheck “Enable real‑time collaboration” and click “Save Changes.”
3. Reload the page.
4. **Expected:**  
   * The checkbox remains **unchecked**.  
   * `wp option get wp_enable_real_time_collaboration` returns `0`.  
   * Reloading multiple times does not flip it back to checked.

### Case 3: No providers

1. Configure the environment so that `wpcom_get_gutenberg_rtc_providers()` returns an empty array (e.g. disable the RTC feature or remove providers).
2. Go to `Settings → Writing`.
3. **Expected:**  
   * The Collaboration setting is not shown on the Writing settings page.  
   * Any calls to `get_option( 'wp_enable_real_time_collaboration' )` behave as if the option is `0`, regardless of any stored value.

### Case 4: Regression checks

1. With providers available and the setting enabled, open the post editor.
2. **Expected:**  
   * Real‑time collaboration still works as before (no regressions in editor behavior).