### PR TITLE
Newsletter: Fix i18n translator comment concatenation from dataviews

### DIFF
--- a/projects/packages/newsletter/.babelrc
+++ b/projects/packages/newsletter/.babelrc
@@ -1,9 +1,0 @@
-{
-	"presets": [
-		["@babel/preset-env", {
-			"targets": {
-				"node": "current"
-			}
-		}]
-	]
-}

--- a/projects/packages/newsletter/babel.config.js
+++ b/projects/packages/newsletter/babel.config.js
@@ -1,0 +1,10 @@
+const config = {
+	presets: [
+		[
+			'@automattic/jetpack-webpack-config/babel/preset',
+			{ pluginReplaceTextdomain: { textdomain: 'jetpack-newsletter' } },
+		],
+	],
+};
+
+export default config;

--- a/projects/packages/newsletter/changelog/dotcom-16375-jetpack-github-issue-47449
+++ b/projects/packages/newsletter/changelog/dotcom-16375-jetpack-github-issue-47449
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixes #47449
+
+Fix i18n translator comment concatenation caused by dataviews function aliasing

--- a/projects/packages/newsletter/webpack.config.js
+++ b/projects/packages/newsletter/webpack.config.js
@@ -62,17 +62,6 @@ export default {
 			// Transpile JavaScript and TypeScript
 			jetpackWebpackConfig.TranspileRule( {
 				exclude: /node_modules\//,
-				babelOpts: {
-					configFile: false,
-					plugins: [
-						[
-							require.resolve( '@automattic/babel-plugin-replace-textdomain' ),
-							{
-								textdomain: 'jetpack-newsletter',
-							},
-						],
-					],
-				},
 			} ),
 
 			// Transpile @automattic/* in node_modules too.
@@ -82,6 +71,11 @@ export default {
 
 			/**
 			 * Transpile `@wordpress/dataviews` in node_modules too.
+			 *
+			 * Uses configFile: false to avoid inheriting babel.config.js, and
+			 * manually applies textdomain replacement with i18n function variants
+			 * to handle the aliased function names (e.g. __1, _x2) in the
+			 * dataviews build-wp bundle.
 			 *
 			 * @see https://github.com/Automattic/jetpack/issues/39907
 			 */


### PR DESCRIPTION
Fixes #47449

## Proposed changes

* Replace `.babelrc` with `babel.config.js` using `@automattic/jetpack-webpack-config/babel/preset`, matching the pattern used in the Forms package
* This ensures Babel properly normalizes i18n function names (e.g. `__1`, `_x2`) before minification, preventing `wp i18n` from concatenating translator comments across multiple dataviews strings into one massive block
* The dataviews `TranspileRule` keeps `configFile: false` with explicit textdomain replacement to avoid inheriting the babel config while still replacing the textdomain for bundled dataviews strings

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* https://github.com/Automattic/jetpack/issues/47449 (comment by @anomiex with the fix proposal)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Run `pnpm run build` in `projects/packages/newsletter` and verify it builds successfully
* Generate a POT file: `php -d memory_limit=1G -d error_reporting=0 $(which wp) i18n make-pot projects/packages/newsletter/build /tmp/newsletter-test.pot --domain=jetpack-newsletter --skip-audit`
* Verify translator comments in the POT are clean and individual — no concatenated comments from multiple dataviews strings
* Verify dataviews strings still appear in the POT with the `jetpack-newsletter` textdomain
* Check the newsletter settings page still works correctly in wp-admin