### PR TITLE
Custom Colors: Fix block editor CSS in Gutenberg 22.6.0+ iframe context

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-custom-colors-block-editor-iframe
+++ b/projects/plugins/wpcomsh/changelog/fix-custom-colors-block-editor-iframe
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Custom Colors: Fix block editor CSS not applying in Gutenberg 22.6.0+ iframe context.

--- a/projects/plugins/wpcomsh/custom-colors/colors.php
+++ b/projects/plugins/wpcomsh/custom-colors/colors.php
@@ -201,7 +201,7 @@ class Colors_Manager_Common {
 			// If colors are set, print them in the Block Editor as well.
 			if ( self::theme_has_set_colors() ) {
 				self::override_themecolors();
-				add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'print_theme_css' ), 20 );
+				add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'print_block_editor_css' ), 20 );
 			}
 		}
 	}
@@ -1459,6 +1459,32 @@ class Colors_Manager_Common {
 			wp_strip_all_tags( $css ), // phpcs:ignore -- CSS can't be properly escaped with esc_html
 			"\n"
 		);
+	}
+
+	/**
+	 * Enqueue theme CSS for the block editor.
+	 *
+	 * @since $$next-version$$
+	 */
+	public static function print_block_editor_css() {
+		if ( ! self::should_enable_colors() ) {
+			return;
+		}
+		$css = self::get_theme_css();
+
+		// Gutenberg 22.6.0+ renders the editor in an iframe for all themes.
+		// #editor no longer exists inside the iframe, so extend any
+		// "#editor .editor-styles-wrapper" selector to also match the
+		// iframe context while keeping the original for older versions.
+		$css = str_replace(
+			'#editor .editor-styles-wrapper',
+			'#editor .editor-styles-wrapper, :root :where(.editor-styles-wrapper)',
+			$css
+		);
+
+		wp_register_style( 'custom-colors-editor-css', false, null, '20210311' ); // Register an empty stylesheet to append custom CSS to.
+		wp_enqueue_style( 'custom-colors-editor-css' );
+		wp_add_inline_style( 'custom-colors-editor-css', $css ); // Append inline style to our new stylesheet
 	}
 
 	/**

--- a/projects/plugins/wpcomsh/custom-colors/colors.php
+++ b/projects/plugins/wpcomsh/custom-colors/colors.php
@@ -1482,7 +1482,7 @@ class Colors_Manager_Common {
 			$css
 		);
 
-		wp_register_style( 'custom-colors-editor-css', false, null, '20210311' ); // Register an empty stylesheet to append custom CSS to.
+		wp_register_style( 'custom-colors-editor-css', false, array(), '20210311' ); // Register an empty stylesheet to append custom CSS to.
 		wp_enqueue_style( 'custom-colors-editor-css' );
 		wp_add_inline_style( 'custom-colors-editor-css', $css ); // Append inline style to our new stylesheet
 	}


### PR DESCRIPTION
Related to THEME-132

## Proposed changes

* Add a dedicated `print_block_editor_css()` method to `Colors_Manager_Common` that adapts Custom Colors CSS selectors for the block editor iframe context introduced in Gutenberg 22.6.0+.
* Update the `enqueue_block_editor_assets` hook to use the new method instead of `print_theme_css()`.
* The new method extends `#editor .editor-styles-wrapper` selectors to also match `:root :where(.editor-styles-wrapper)` inside the iframe, while preserving the original selector for backwards compatibility with older Gutenberg versions.
* Enqueue custom colors as an inline style via `wp_add_inline_style()` instead of printing a raw `<style>` tag, which is the correct approach for the `enqueue_block_editor_assets` hook.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Activate a theme that supports Custom Colors (e.g. Morden).
2. Set custom colors via **Appearance → Customize → Colors & Backgrounds**, especially the one with dark background
3. Open the block editor (post or page editor).
4. **Before this patch**: Custom color CSS does not apply inside the editor iframe on Gutenberg 22.6.0+.
5. **After this patch**: Custom color CSS correctly applies inside the editor iframe. The editor preview should reflect the custom color choices.
6. Verify that the frontend (`wp_head`) still renders custom colors correctly (no regression).
