### PR TITLE
Social: Expose X usage data via API

### DIFF
--- a/projects/packages/publicize/.phan/baseline.php
+++ b/projects/packages/publicize/.phan/baseline.php
@@ -9,8 +9,8 @@
  */
 return [
     // # Issue statistics:
+    // PhanPluginMixedKeyNoKey : 8 occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 7 occurrences
-    // PhanPluginMixedKeyNoKey : 7 occurrences
     // PhanPluginUnreachableCode : 4 occurrences
     // PhanTypeMismatchArgument : 3 occurrences
     // PhanUndeclaredClassMethod : 3 occurrences
@@ -42,6 +42,7 @@ return [
         'src/rest-api/class-scheduled-actions-controller.php' => ['PhanPluginMixedKeyNoKey'],
         'src/rest-api/class-services-controller.php' => ['PhanPluginMixedKeyNoKey'],
         'src/rest-api/class-share-status-controller.php' => ['PhanPluginMixedKeyNoKey'],
+        'src/rest-api/class-x-usage-controller.php' => ['PhanPluginMixedKeyNoKey'],
         'src/social-image-generator/class-post-settings.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'src/social-image-generator/class-rest-settings-controller.php' => ['PhanPluginMixedKeyNoKey'],
         'src/social-image-generator/class-settings.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],

--- a/projects/packages/publicize/changelog/add-social-x-usage-endpoint
+++ b/projects/packages/publicize/changelog/add-social-x-usage-endpoint
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Expose X usage data via API.

--- a/projects/packages/publicize/src/class-publicize-setup.php
+++ b/projects/packages/publicize/src/class-publicize-setup.php
@@ -139,6 +139,7 @@ class Publicize_Setup {
 			REST_API\Services_Controller::class,
 			REST_API\Share_Post_Controller::class,
 			REST_API\Share_Status_Controller::class,
+			REST_API\X_Usage_Controller::class,
 			REST_API\Social_Image_Generator_Controller::class,
 			Jetpack_Social_Settings\Settings::class,
 		);

--- a/projects/packages/publicize/src/rest-api/class-x-usage-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-x-usage-controller.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * X Usage Controller.
+ *
+ * Exposes X share quota and per-month usage data for client UI.
+ *
+ * @package automattic/jetpack-publicize
+ */
+
+namespace Automattic\Jetpack\Publicize\REST_API;
+
+use Automattic\Jetpack\Connection\Traits\WPCOM_REST_API_Proxy_Request;
+use Automattic\Jetpack\Publicize\Publicize_Utils as Utils;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * X Usage Controller class.
+ *
+ * @phan-constructor-used-for-side-effects
+ */
+class X_Usage_Controller extends Base_Controller {
+
+	use WPCOM_REST_API_Proxy_Request;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+
+		$this->base_api_path = 'wpcom';
+		$this->version       = 'v2';
+
+		$this->namespace = "{$this->base_api_path}/{$this->version}";
+		$this->rest_base = 'publicize/x-usage';
+
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Register the routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Check permissions.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|\WP_Error
+	 */
+	public function get_items_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		return $this->publicize_permissions_check();
+	}
+
+	/**
+	 * Get X usage data.
+	 *
+	 * Returns the quota limit, plan type, and usage breakdown.
+	 * Each period with data includes counts of 'used' (done) and 'pending'
+	 * (scheduled/future) shares. Only periods with entries are included.
+	 *
+	 * For paid plans, usage is keyed by yyyy-mm with per-month quota.
+	 * For free plans, usage is keyed by 'free' with a lifetime limit.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response
+	 */
+	public function get_items( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( Utils::is_wpcom() ) {
+			require_lib( 'publicize/util/x-usage' );
+
+			$blog_id = get_current_blog_id();
+			$usage   = \Publicize\get_x_usage( $blog_id );
+			$is_free = \Publicize\is_free_x_plan( $blog_id );
+			$limit   = \Publicize\get_x_share_limit( $blog_id );
+
+			// Build per-month breakdown.
+			$months = array();
+			foreach ( $usage as $month => $entries ) {
+				if ( ! is_array( $entries ) || empty( $entries ) ) {
+					continue;
+				}
+
+				$used    = 0;
+				$pending = 0;
+				foreach ( $entries as $entry ) {
+					if ( 'done' === ( $entry['status'] ?? '' ) ) {
+						++$used;
+					} else {
+						++$pending;
+					}
+				}
+
+				$months[ $month ] = array(
+					'used'    => $used,
+					'pending' => $pending,
+					'total'   => $used + $pending,
+				);
+			}
+
+			// Sort by month key.
+			ksort( $months );
+
+			$data = array(
+				'limit'   => $limit,
+				'is_free' => $is_free,
+				'usage'   => $months,
+			);
+
+			return rest_ensure_response( $data );
+		}
+
+		return rest_ensure_response(
+			$this->proxy_request_to_wpcom_as_user( $request )
+		);
+	}
+
+	/**
+	 * Schema for the endpoint.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'publicize-x-usage',
+			'type'       => 'object',
+			'properties' => array(
+				'limit'   => array(
+					'type'        => 'integer',
+					'description' => __( 'Maximum number of X shares allowed (per month for paid, lifetime for free).', 'jetpack-publicize-pkg' ),
+				),
+				'is_free' => array(
+					'type'        => 'boolean',
+					'description' => __( 'Whether the site is on the free plan (lifetime limit vs monthly).', 'jetpack-publicize-pkg' ),
+				),
+				'usage'   => array(
+					'type'                 => 'object',
+					'description'          => __( 'Usage breakdown keyed by yyyy-mm for paid plans or "free" for free plans. Only periods with data are included.', 'jetpack-publicize-pkg' ),
+					'additionalProperties' => array(
+						'type'       => 'object',
+						'properties' => array(
+							'used'    => array(
+								'type'        => 'integer',
+								'description' => __( 'Number of shares successfully sent.', 'jetpack-publicize-pkg' ),
+							),
+							'pending' => array(
+								'type'        => 'integer',
+								'description' => __( 'Number of shares scheduled or awaiting publish.', 'jetpack-publicize-pkg' ),
+							),
+							'total'   => array(
+								'type'        => 'integer',
+								'description' => __( 'Total shares counting toward quota (used + pending).', 'jetpack-publicize-pkg' ),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+}

--- a/projects/packages/publicize/src/rest-api/class-x-usage-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-x-usage-controller.php
@@ -36,6 +36,8 @@ class X_Usage_Controller extends Base_Controller {
 		$this->namespace = "{$this->base_api_path}/{$this->version}";
 		$this->rest_base = 'publicize/x-usage';
 
+		$this->allow_requests_as_blog = true;
+
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
 	}
 
@@ -126,7 +128,7 @@ class X_Usage_Controller extends Base_Controller {
 		}
 
 		return rest_ensure_response(
-			$this->proxy_request_to_wpcom_as_user( $request )
+			$this->proxy_request_to_wpcom_as_blog( $request )
 		);
 	}
 

--- a/projects/packages/publicize/src/rest-api/class-x-usage-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-x-usage-controller.php
@@ -2,7 +2,7 @@
 /**
  * X Usage Controller.
  *
- * Exposes X share quota and per-month usage data for client UI.
+ * Exposes X share usage data as a collection.
  *
  * @package automattic/jetpack-publicize
  */
@@ -70,14 +70,11 @@ class X_Usage_Controller extends Base_Controller {
 	}
 
 	/**
-	 * Get X usage data.
+	 * Get X usage data as a collection.
 	 *
-	 * Returns the quota limit, plan type, and usage breakdown.
-	 * Each period with data includes counts of 'used' (done) and 'pending'
-	 * (scheduled/future) shares. Only periods with entries are included.
-	 *
-	 * For paid plans, usage is keyed by yyyy-mm with per-month quota.
-	 * For free plans, usage is keyed by 'free' with a lifetime limit.
+	 * Returns an array of usage items, one per period. For paid plans,
+	 * each item represents a calendar month (id = yyyy-mm). For free
+	 * plans, a single item with id = 'free' covers lifetime usage.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response
@@ -86,14 +83,10 @@ class X_Usage_Controller extends Base_Controller {
 		if ( Utils::is_wpcom() ) {
 			require_lib( 'publicize/util/x-usage' );
 
-			$blog_id = get_current_blog_id();
-			$usage   = \Publicize\get_x_usage( $blog_id );
-			$is_free = \Publicize\is_free_x_plan( $blog_id );
-			$limit   = \Publicize\get_x_share_limit( $blog_id );
+			$usage = \Publicize\get_x_usage( get_current_blog_id() );
 
-			// Build per-month breakdown.
-			$months = array();
-			foreach ( $usage as $month => $entries ) {
+			$items = array();
+			foreach ( $usage as $period => $entries ) {
 				if ( ! is_array( $entries ) || empty( $entries ) ) {
 					continue;
 				}
@@ -108,23 +101,22 @@ class X_Usage_Controller extends Base_Controller {
 					}
 				}
 
-				$months[ $month ] = array(
+				$item = array(
+					'period'  => $period,
 					'used'    => $used,
 					'pending' => $pending,
 					'total'   => $used + $pending,
 				);
+
+				$data    = $this->prepare_item_for_response( $item, $request );
+				$items[] = $this->prepare_response_for_collection( $data );
 			}
 
-			// Sort by month key.
-			ksort( $months );
+			$response = rest_ensure_response( $items );
+			$response->header( 'X-WP-Total', (string) count( $items ) );
+			$response->header( 'X-WP-TotalPages', '1' );
 
-			$data = array(
-				'limit'   => $limit,
-				'is_free' => $is_free,
-				'usage'   => $months,
-			);
-
-			return rest_ensure_response( $data );
+			return $response;
 		}
 
 		return rest_ensure_response(
@@ -138,42 +130,35 @@ class X_Usage_Controller extends Base_Controller {
 	 * @return array
 	 */
 	public function get_item_schema() {
+		if ( $this->schema ) {
+			return $this->add_additional_fields_schema( $this->schema );
+		}
+
 		$schema = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => 'publicize-x-usage',
 			'type'       => 'object',
 			'properties' => array(
-				'limit'   => array(
+				'period'  => array(
+					'type'        => 'string',
+					'description' => __( 'Period identifier: yyyy-mm for paid plans, "free" for free plans.', 'jetpack-publicize-pkg' ),
+				),
+				'used'    => array(
 					'type'        => 'integer',
-					'description' => __( 'Maximum number of X shares allowed (per month for paid, lifetime for free).', 'jetpack-publicize-pkg' ),
+					'description' => __( 'Number of shares successfully sent.', 'jetpack-publicize-pkg' ),
 				),
-				'is_free' => array(
-					'type'        => 'boolean',
-					'description' => __( 'Whether the site is on the free plan (lifetime limit vs monthly).', 'jetpack-publicize-pkg' ),
+				'pending' => array(
+					'type'        => 'integer',
+					'description' => __( 'Number of shares scheduled or awaiting publish.', 'jetpack-publicize-pkg' ),
 				),
-				'usage'   => array(
-					'type'                 => 'object',
-					'description'          => __( 'Usage breakdown keyed by yyyy-mm for paid plans or "free" for free plans. Only periods with data are included.', 'jetpack-publicize-pkg' ),
-					'additionalProperties' => array(
-						'type'       => 'object',
-						'properties' => array(
-							'used'    => array(
-								'type'        => 'integer',
-								'description' => __( 'Number of shares successfully sent.', 'jetpack-publicize-pkg' ),
-							),
-							'pending' => array(
-								'type'        => 'integer',
-								'description' => __( 'Number of shares scheduled or awaiting publish.', 'jetpack-publicize-pkg' ),
-							),
-							'total'   => array(
-								'type'        => 'integer',
-								'description' => __( 'Total shares counting toward quota (used + pending).', 'jetpack-publicize-pkg' ),
-							),
-						),
-					),
+				'total'   => array(
+					'type'        => 'integer',
+					'description' => __( 'Total shares counting toward quota (used + pending).', 'jetpack-publicize-pkg' ),
 				),
 			),
 		);
+
+		$this->schema = $schema;
 
 		return $this->add_additional_fields_schema( $schema );
 	}


### PR DESCRIPTION
Completes SOCIAL-389 and uses 207626-ghe-Automattic/wpcom

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Add `wpcom/v2/publicize/x-usage` endpoint to expose the X usage data.

> [!NOTE]
> This PR needs stubs added in 207626-ghe-Automattic/wpcom before merge

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Apply 207626-ghe-Automattic/wpcom on your sandbox
* Apply this branch on top of the above branch instead of trunk
* Point your site and public API to your sandbox
* Go to [WPCOM developer console](https://developer.wordpress.com/docs/api/console/)
* Hit the `GET` `wpcom/v2/sites/202566705/publicize/x-usage` endpoint
* Confirm that you see the data as expected.


<img width="777" height="442" alt="image" src="https://github.com/user-attachments/assets/6ec8801c-23c9-4a7f-a639-4ac50f590964" />