### PR TITLE
Newsletters - update "will send to" subscribers affirmation copies.

### DIFF
--- a/projects/plugins/jetpack/changelog/update-newsletter-will-send-copies
+++ b/projects/plugins/jetpack/changelog/update-newsletter-will-send-copies
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+updates subscribers affirmation copies for newsletters "will send to" message to better include access and categories both, and remove misrepresentative numbers"

--- a/projects/plugins/jetpack/changelog/update-newsletter-will-send-copies
+++ b/projects/plugins/jetpack/changelog/update-newsletter-will-send-copies
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-updates subscribers affirmation copies for newsletters "will send to" message to better include access and categories both, and remove misrepresentative numbers"
+Update subscribers affirmation copies for newsletters "will send to" message to better include access and categories both, and remove misrepresentative numbers.

--- a/projects/plugins/jetpack/extensions/shared/memberships/subscribers-affirmation.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/subscribers-affirmation.js
@@ -5,6 +5,7 @@ import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
+import paywallBlockMetadata from '../../blocks/paywall/block.json';
 import {
 	accessOptions,
 	META_NAME_FOR_POST_DONT_EMAIL_TO_SUBS,
@@ -106,6 +107,22 @@ export function getAccessLevelLabel( accessLevel, tierName = null ) {
 		);
 	}
 	return label;
+}
+
+/**
+ * Get access label for affirmation copy, accounting for paywall.
+ * When paid_subscribers post has a paywall block, email goes to all subscribers.
+ *
+ * @param {string}      accessLevel           - Base key e.g. 'paid_subscribers'.
+ * @param {string|null} [tierName]            - Optional tier name.
+ * @param {boolean}     [postHasPaywallBlock] - Whether the post contains a paywall block.
+ * @return {string} Access level label for display.
+ */
+export function getAccessLabelForCopy( accessLevel, tierName = null, postHasPaywallBlock = false ) {
+	if ( accessLevel === 'paid_subscribers' && postHasPaywallBlock ) {
+		return __( 'all subscribers', 'jetpack' );
+	}
+	return getAccessLevelLabel( accessLevel, tierName );
 }
 
 /**
@@ -269,6 +286,12 @@ export function getSentCopyLine( { accessLabel, categoryNames, tense, dateStr } 
  * Determines copy to show in pre/post-publish panels to confirm number and type of subscribers receiving the post as email.
  */
 function SubscribersAffirmation( { accessLevel, prePublish = false } ) {
+	const postHasPaywallBlock = useSelect( select =>
+		select( 'core/block-editor' )
+			.getBlocks()
+			.some( block => block.name === paywallBlockMetadata.name )
+	);
+
 	const { isScheduledPost, postCategories, postId, postMeta, publishDate, status } = useSelect(
 		select => {
 			const { isCurrentPostScheduled, getEditedPostAttribute, getCurrentPost } =
@@ -425,7 +448,7 @@ function SubscribersAffirmation( { accessLevel, prePublish = false } ) {
 		);
 	} else if ( isSendingInProgress ) {
 		const currentTierName = getCurrentTierName( accessLevel, postMeta, tierProducts );
-		const accessLabel = getAccessLevelLabel( accessLevel, currentTierName );
+		const accessLabel = getAccessLabelForCopy( accessLevel, currentTierName, postHasPaywallBlock );
 		const categoryNames =
 			newsletterCategoriesEnabled && newsletterCategories?.length && postCategories?.length
 				? getFormattedCategories( postCategories, newsletterCategories )
@@ -446,7 +469,7 @@ function SubscribersAffirmation( { accessLevel, prePublish = false } ) {
 	} else {
 		// Pre-send (prepublish/scheduled) — unified access + categories
 		const currentTierName = getCurrentTierName( accessLevel, postMeta, tierProducts );
-		const accessLabel = getAccessLevelLabel( accessLevel, currentTierName );
+		const accessLabel = getAccessLabelForCopy( accessLevel, currentTierName, postHasPaywallBlock );
 		const categoryNames =
 			newsletterCategoriesEnabled && newsletterCategories?.length && postCategories?.length
 				? getFormattedCategories( postCategories, newsletterCategories )

--- a/projects/plugins/jetpack/extensions/shared/memberships/subscribers-affirmation.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/subscribers-affirmation.js
@@ -4,14 +4,12 @@ import { Animate } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { createInterpolateElement } from '@wordpress/element';
-import { sprintf, __, _n } from '@wordpress/i18n';
-import paywallBlockMetadata from '../../blocks/paywall/block.json';
+import { sprintf, __ } from '@wordpress/i18n';
 import {
 	accessOptions,
 	META_NAME_FOR_POST_DONT_EMAIL_TO_SUBS,
 	META_NAME_FOR_POST_TIER_ID_SETTINGS,
 } from '../../shared/memberships/constants';
-import { getReachForAccessLevelKey } from '../../shared/memberships/settings';
 import { store as membershipProductsStore } from '../../store/membership-products';
 
 /**
@@ -70,106 +68,6 @@ export const getFormattedCategories = (
 	}
 
 	return formattedCategories;
-};
-
-export const getCopyForCategorySubscribers = ( {
-	futureTense,
-	newsletterCategories,
-	postCategories,
-	reachCount,
-} ) => {
-	const formattedCategoryNames = getFormattedCategories( postCategories, newsletterCategories );
-	// This needs a more elegant solution, but for now it stops the crash when the count is undefined.
-	const reachCountString = undefined === reachCount ? '0' : reachCount.toLocaleString();
-
-	if ( futureTense ) {
-		return sprintf(
-			// translators: %1s is the list of categories, %2d is subscriptions count
-			_n(
-				'This post will be sent to everyone subscribed to %1$s (%2$s subscriber).',
-				'This post will be sent to everyone subscribed to %1$s (%2$s subscribers).',
-				reachCount ?? 0,
-				'jetpack'
-			),
-			formattedCategoryNames,
-			reachCountString
-		);
-	}
-
-	return sprintf(
-		// translators: %1s is the list of categories, %2d is subscriptions count
-		_n(
-			'This post was sent to everyone subscribed to %1$s (<link>%2$s subscriber</link>).',
-			'This post was sent to everyone subscribed to %1$s (<link>%2$s subscribers</link>).',
-			reachCount ?? 0,
-			'jetpack'
-		),
-		formattedCategoryNames,
-		reachCountString
-	);
-};
-
-// Determines copy to show in post-publish panel to confirm number and type of subscribers who received the post as email, or will receive in case of scheduled post.
-export const getCopyForSubscribers = ( {
-	futureTense,
-	isPaidPost,
-	postHasPaywallBlock,
-	reachCount,
-} ) => {
-	const reachCountString = reachCount.toLocaleString();
-
-	// Schedulled post
-	if ( futureTense ) {
-		// Paid post without paywall: sent only to paid subscribers
-		if ( isPaidPost && ! postHasPaywallBlock ) {
-			return sprintf(
-				/* translators: %s is the number of subscribers */
-				_n(
-					'This post will be sent to <strong>%s paid subscriber</strong>.',
-					'This post will be sent to <strong>%s paid subscribers</strong>.',
-					reachCount,
-					'jetpack'
-				),
-				reachCountString
-			);
-		}
-		// Paid post with paywall or Free post, sent to all subscribers
-		return sprintf(
-			/* translators: %s is the number of subscribers */
-			_n(
-				'This post will be sent to <strong>%s subscriber</strong>.',
-				'This post will be sent to <strong>%s subscribers</strong>.',
-				reachCount,
-				'jetpack'
-			),
-			reachCountString
-		);
-	}
-	// Paid post without paywall: sent only to paid subscribers
-	if ( isPaidPost && ! postHasPaywallBlock ) {
-		return sprintf(
-			/* translators: %s is the number of subscribers */
-			_n(
-				'This post was sent to <link>%s paid subscriber</link>.',
-				'This post was sent to <link>%s paid subscribers</link>.',
-				reachCount,
-				'jetpack'
-			),
-			reachCountString
-		);
-	}
-
-	// Paid post with paywall or Free post, sent to all subscribers, post is already published
-	return sprintf(
-		/* translators: %s is the number of subscribers */
-		_n(
-			'This post was sent to <link>%s subscriber</link>.',
-			'This post was sent to <link>%s subscribers</link>.',
-			reachCount,
-			'jetpack'
-		),
-		reachCountString
-	);
 };
 
 const SENDING_IN_PROGRESS_WINDOW_MS = 15 * 60 * 1000;
@@ -270,17 +168,20 @@ export function shouldShowWontResendMessage( {
 }
 
 /**
- * Build "was sent" or "is being sent" copy for access + categories.
+ * Build "was sent", "is being sent", or "will be sent" copy for access + categories.
  *
- * @param {object}  opts
- * @param {string}  opts.accessLabel   - "all subscribers" or "paid subscribers" (may be empty for date-only case)
- * @param {string}  opts.categoryNames - Formatted category list (or empty)
- * @param {boolean} opts.pastTense     - "was emailed" vs "is being emailed"
- * @param {string}  opts.dateStr       - For past tense only
- * @return {string} Formatted sentence for "was sent" or "is being sent" copy.
+ * @param {object} opts               - Options object.
+ * @param {string} opts.accessLabel   - "all subscribers" or "paid subscribers" (may be empty for date-only case).
+ * @param {string} opts.categoryNames - Formatted category list (or empty).
+ * @param {string} opts.tense         - 'past' | 'present' | 'future'.
+ * @param {string} opts.dateStr       - For past tense only.
+ * @return {string} Formatted sentence for "was sent", "is being sent", or "will be sent" copy.
  */
-export function getSentCopyLine( { accessLabel, categoryNames, pastTense, dateStr } ) {
-	if ( pastTense && dateStr && ! accessLabel ) {
+export function getSentCopyLine( { accessLabel, categoryNames, tense, dateStr } ) {
+	const isPast = tense === 'past';
+	const isFuture = tense === 'future';
+
+	if ( isPast && dateStr && ! accessLabel ) {
 		return sprintf(
 			/* translators: %s: formatted date */
 			__( 'This post was emailed on %s. View <link>delivery details</link>.', 'jetpack' ),
@@ -288,7 +189,7 @@ export function getSentCopyLine( { accessLabel, categoryNames, pastTense, dateSt
 		);
 	}
 	if ( categoryNames ) {
-		if ( pastTense ) {
+		if ( isPast ) {
 			if ( dateStr ) {
 				return sprintf(
 					/* translators: %1$s: access (e.g. "all subscribers"), %2$s: category list, %3$s: date */
@@ -311,6 +212,14 @@ export function getSentCopyLine( { accessLabel, categoryNames, pastTense, dateSt
 				categoryNames
 			);
 		}
+		if ( isFuture ) {
+			return sprintf(
+				/* translators: %1$s: access, %2$s: category list */
+				__( 'This post will be emailed to %1$s of %2$s.', 'jetpack' ),
+				accessLabel,
+				categoryNames
+			);
+		}
 		return sprintf(
 			/* translators: %1$s: access, %2$s: category list */
 			__(
@@ -321,7 +230,7 @@ export function getSentCopyLine( { accessLabel, categoryNames, pastTense, dateSt
 			categoryNames
 		);
 	}
-	if ( pastTense ) {
+	if ( isPast ) {
 		if ( dateStr ) {
 			return sprintf(
 				/* translators: %1$s: access, %2$s: date */
@@ -339,6 +248,13 @@ export function getSentCopyLine( { accessLabel, categoryNames, pastTense, dateSt
 			accessLabel
 		);
 	}
+	if ( isFuture ) {
+		return sprintf(
+			/* translators: %s: access level */
+			__( 'This post will be emailed to %s.', 'jetpack' ),
+			accessLabel
+		);
+	}
 	return sprintf(
 		/* translators: %s: access level */
 		__(
@@ -353,12 +269,6 @@ export function getSentCopyLine( { accessLabel, categoryNames, pastTense, dateSt
  * Determines copy to show in pre/post-publish panels to confirm number and type of subscribers receiving the post as email.
  */
 function SubscribersAffirmation( { accessLevel, prePublish = false } ) {
-	const postHasPaywallBlock = useSelect( select =>
-		select( 'core/block-editor' )
-			.getBlocks()
-			.some( block => block.name === paywallBlockMetadata.name )
-	);
-
 	const { isScheduledPost, postCategories, postId, postMeta, publishDate, status } = useSelect(
 		select => {
 			const { isCurrentPostScheduled, getEditedPostAttribute, getCurrentPost } =
@@ -386,12 +296,9 @@ function SubscribersAffirmation( { accessLevel, prePublish = false } ) {
 
 	const blogId = window.Jetpack_Editor_Initial_State?.wpcomBlogId;
 	const {
-		emailSubscribersCount,
 		hasFinishedLoading,
 		newsletterCategories,
 		newsletterCategoriesEnabled,
-		newsletterCategorySubscriberCount,
-		paidSubscribersCount,
 		postEmailSentState,
 		tierProducts,
 		totalEmailsSentCount,
@@ -402,17 +309,13 @@ function SubscribersAffirmation( { accessLevel, prePublish = false } ) {
 			const {
 				getNewsletterCategories,
 				getNewsletterCategoriesEnabled,
-				getNewsletterCategoriesSubscriptionsCount,
 				getNewsletterTierProducts,
 				getPostEmailSentState,
 				getPublishedWithEmailEnabledInSession,
 				getAlreadySentPostModifiedInSession,
-				getSubscriberCounts,
 				getTotalEmailsSentCount,
 				hasFinishedResolution,
 			} = select( membershipProductsStore );
-
-			const { emailSubscribers, paidSubscribers } = getSubscriberCounts();
 
 			// Trigger fetch when we have a postId so we have email_sent_at / stats_on_send (including for draft)
 			if ( postId ) {
@@ -428,16 +331,11 @@ function SubscribersAffirmation( { accessLevel, prePublish = false } ) {
 
 			return {
 				hasFinishedLoading: [
-					hasFinishedResolution( 'getSubscriberCounts' ),
 					hasFinishedResolution( 'getNewsletterCategories' ),
-					hasFinishedResolution( 'getNewsletterCategoriesSubscriptionsCount' ),
 					postEmailResolved,
 				].every( Boolean ),
-				emailSubscribersCount: emailSubscribers,
 				newsletterCategories: getNewsletterCategories(),
 				newsletterCategoriesEnabled: getNewsletterCategoriesEnabled(),
-				newsletterCategorySubscriberCount: getNewsletterCategoriesSubscriptionsCount(),
-				paidSubscribersCount: paidSubscribers,
 				postEmailSentState: _postEmailSentState,
 				alreadySentPostModifiedInSession: postId
 					? getAlreadySentPostModifiedInSession( postId )
@@ -466,7 +364,6 @@ function SubscribersAffirmation( { accessLevel, prePublish = false } ) {
 		);
 	}
 
-	const isPaidPost = accessLevel === accessOptions.paid_subscribers.key;
 	const isPrepublishOrScheduled = prePublish || isScheduledPost;
 
 	const emailSentAt = postEmailSentState?.email_sent_at ?? null;
@@ -494,13 +391,6 @@ function SubscribersAffirmation( { accessLevel, prePublish = false } ) {
 	const isPublishedWithoutEmail =
 		status === 'publish' && emailSentAt == null && ! isSendingInProgress;
 
-	const reachForAccessLevel = getReachForAccessLevelKey( {
-		accessLevel,
-		subscribers: emailSubscribersCount,
-		paidSubscribers: paidSubscribersCount,
-		postHasPaywallBlock,
-	} );
-
 	let text;
 	let showWontResendMessage = false;
 
@@ -508,7 +398,7 @@ function SubscribersAffirmation( { accessLevel, prePublish = false } ) {
 		text = getSentCopyLine( {
 			accessLabel: sentAccessLabel,
 			categoryNames: sentCategoryNames,
-			pastTense: true,
+			tense: 'past',
 			dateStr,
 		} );
 
@@ -543,7 +433,7 @@ function SubscribersAffirmation( { accessLevel, prePublish = false } ) {
 		text = getSentCopyLine( {
 			accessLabel,
 			categoryNames,
-			pastTense: false,
+			tense: 'present',
 			dateStr: '',
 		} );
 	} else if ( isPublishedWithoutEmail ) {
@@ -553,21 +443,19 @@ function SubscribersAffirmation( { accessLevel, prePublish = false } ) {
 		);
 	} else if ( ! isSendEmailEnabled() ) {
 		text = __( 'Not sent via email.', 'jetpack' );
-	} else if ( newsletterCategoriesEnabled && newsletterCategories.length > 0 && ! isPaidPost ) {
-		// Pre-send (prepublish/scheduled) or published fallback — category subscribers
-		text = getCopyForCategorySubscribers( {
-			futureTense: isPrepublishOrScheduled,
-			newsletterCategories,
-			postCategories,
-			reachCount: newsletterCategorySubscriberCount,
-		} );
 	} else {
-		// Pre-send (prepublish/scheduled) or published fallback — all/paid subscribers
-		text = getCopyForSubscribers( {
-			futureTense: isPrepublishOrScheduled,
-			isPaidPost,
-			postHasPaywallBlock,
-			reachCount: reachForAccessLevel,
+		// Pre-send (prepublish/scheduled) — unified access + categories
+		const currentTierName = getCurrentTierName( accessLevel, postMeta, tierProducts );
+		const accessLabel = getAccessLevelLabel( accessLevel, currentTierName );
+		const categoryNames =
+			newsletterCategoriesEnabled && newsletterCategories?.length && postCategories?.length
+				? getFormattedCategories( postCategories, newsletterCategories )
+				: '';
+		text = getSentCopyLine( {
+			accessLabel,
+			categoryNames,
+			tense: isPrepublishOrScheduled ? 'future' : 'present',
+			dateStr: '',
 		} );
 	}
 

--- a/projects/plugins/jetpack/extensions/shared/memberships/test/subscribers-affirmation-test.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/test/subscribers-affirmation-test.js
@@ -3,6 +3,7 @@ import { META_NAME_FOR_POST_TIER_ID_SETTINGS, accessOptions } from '../constants
 import {
 	getFormattedCategories,
 	getAccessLevelLabel,
+	getAccessLabelForCopy,
 	getCurrentTierName,
 	shouldShowWontResendMessage,
 	getSentCopyLine,
@@ -91,6 +92,39 @@ describe( 'getAccessLevelLabel', () => {
 		expect( getAccessLevelLabel( 'paid_subscribers', 'Premium' ) ).toBe(
 			'paid subscribers (Premium)'
 		);
+	} );
+} );
+
+describe( 'getAccessLabelForCopy', () => {
+	test( 'paid_subscribers with paywall returns "all subscribers"', () => {
+		expect( getAccessLabelForCopy( 'paid_subscribers', null, true ) ).toBe( 'all subscribers' );
+	} );
+
+	test( 'paid_subscribers with paywall ignores tierName', () => {
+		expect( getAccessLabelForCopy( 'paid_subscribers', 'Premium', true ) ).toBe(
+			'all subscribers'
+		);
+	} );
+
+	test( 'paid_subscribers without paywall returns "paid subscribers"', () => {
+		expect( getAccessLabelForCopy( 'paid_subscribers', null, false ) ).toBe( 'paid subscribers' );
+	} );
+
+	test( 'paid_subscribers without paywall with tierName returns "paid subscribers (Premium)"', () => {
+		expect( getAccessLabelForCopy( 'paid_subscribers', 'Premium', false ) ).toBe(
+			'paid subscribers (Premium)'
+		);
+	} );
+
+	test( 'subscribers with paywall returns "all subscribers"', () => {
+		expect( getAccessLabelForCopy( 'subscribers', null, true ) ).toBe( 'all subscribers' );
+	} );
+
+	test( 'paid_subscribers with falsy postHasPaywallBlock defaults to paid label', () => {
+		expect( getAccessLabelForCopy( 'paid_subscribers', null, undefined ) ).toBe(
+			'paid subscribers'
+		);
+		expect( getAccessLabelForCopy( 'paid_subscribers', null ) ).toBe( 'paid subscribers' );
 	} );
 } );
 

--- a/projects/plugins/jetpack/extensions/shared/memberships/test/subscribers-affirmation-test.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/test/subscribers-affirmation-test.js
@@ -2,8 +2,6 @@ import { getAdminUrl } from '@automattic/jetpack-script-data';
 import { META_NAME_FOR_POST_TIER_ID_SETTINGS, accessOptions } from '../constants';
 import {
 	getFormattedCategories,
-	getCopyForSubscribers,
-	getCopyForCategorySubscribers,
 	getAccessLevelLabel,
 	getCurrentTierName,
 	shouldShowWontResendMessage,
@@ -66,118 +64,6 @@ describe( 'getFormattedCategories', () => {
 
 	test( 'handles undefined postCategories with optional chaining when fallback is false', () => {
 		expect( getFormattedCategories( undefined, newsletterCategories, false ) ).toBe( '' );
-	} );
-} );
-
-describe( 'getCopyForSubscribers', () => {
-	test( 'future tense returns "will be sent" copy', () => {
-		const result = getCopyForSubscribers( {
-			futureTense: true,
-			isPaidPost: false,
-			postHasPaywallBlock: false,
-			reachCount: 5,
-		} );
-		expect( result ).toContain( 'will be sent' );
-		expect( result ).toContain( '5' );
-	} );
-
-	test( 'past tense returns "was sent" copy', () => {
-		const result = getCopyForSubscribers( {
-			futureTense: false,
-			isPaidPost: false,
-			postHasPaywallBlock: false,
-			reachCount: 10,
-		} );
-		expect( result ).toContain( 'was sent' );
-		expect( result ).toContain( '10' );
-	} );
-
-	test( 'paid post without paywall shows paid subscriber copy', () => {
-		const result = getCopyForSubscribers( {
-			futureTense: true,
-			isPaidPost: true,
-			postHasPaywallBlock: false,
-			reachCount: 3,
-		} );
-		expect( result ).toContain( 'paid subscriber' );
-	} );
-
-	test( 'pluralizes subscriber correctly', () => {
-		const singular = getCopyForSubscribers( {
-			futureTense: true,
-			isPaidPost: false,
-			postHasPaywallBlock: false,
-			reachCount: 1,
-		} );
-		const plural = getCopyForSubscribers( {
-			futureTense: true,
-			isPaidPost: false,
-			postHasPaywallBlock: false,
-			reachCount: 2,
-		} );
-		expect( singular ).toContain( 'subscriber' );
-		expect( singular ).not.toContain( 'subscribers' );
-		expect( plural ).toContain( 'subscribers' );
-	} );
-} );
-
-const newsletterCategories = [
-	{ id: 1, name: 'Uncategorized' },
-	{ id: 2, name: 'Tech' },
-	{ id: 3, name: 'News' },
-];
-
-describe( 'getCopyForCategorySubscribers', () => {
-	test( 'future tense returns "will be sent to everyone subscribed to" copy', () => {
-		const result = getCopyForCategorySubscribers( {
-			futureTense: true,
-			newsletterCategories,
-			postCategories: [ 2 ],
-			reachCount: 5,
-		} );
-		expect( result ).toContain( 'will be sent' );
-		expect( result ).toContain( 'Tech' );
-		expect( result ).toContain( '5' );
-	} );
-
-	test( 'past tense returns "was sent to everyone subscribed to" with link placeholder', () => {
-		const result = getCopyForCategorySubscribers( {
-			futureTense: false,
-			newsletterCategories,
-			postCategories: [ 2 ],
-			reachCount: 10,
-		} );
-		expect( result ).toContain( 'was sent' );
-		expect( result ).toContain( '<link>' );
-		expect( result ).toContain( 'Tech' );
-	} );
-
-	test( 'reachCount undefined uses "0"', () => {
-		const result = getCopyForCategorySubscribers( {
-			futureTense: true,
-			newsletterCategories,
-			postCategories: [ 2 ],
-			reachCount: undefined,
-		} );
-		expect( result ).toContain( '0' );
-	} );
-
-	test( 'pluralizes subscriber correctly', () => {
-		const singular = getCopyForCategorySubscribers( {
-			futureTense: true,
-			newsletterCategories,
-			postCategories: [ 2 ],
-			reachCount: 1,
-		} );
-		const plural = getCopyForCategorySubscribers( {
-			futureTense: true,
-			newsletterCategories,
-			postCategories: [ 2 ],
-			reachCount: 2,
-		} );
-		expect( singular ).toContain( 'subscriber' );
-		expect( singular ).not.toContain( 'subscribers' );
-		expect( plural ).toContain( 'subscribers' );
 	} );
 } );
 
@@ -326,11 +212,11 @@ describe( 'shouldShowWontResendMessage', () => {
 } );
 
 describe( 'getSentCopyLine', () => {
-	test( 'pastTense with dateStr and no accessLabel returns date-only format', () => {
+	test( 'tense past with dateStr and no accessLabel returns date-only format', () => {
 		const result = getSentCopyLine( {
 			accessLabel: '',
 			categoryNames: '',
-			pastTense: true,
+			tense: 'past',
 			dateStr: 'Jan 15, 2024',
 		} );
 		expect( result ).toContain( 'emailed on' );
@@ -338,11 +224,11 @@ describe( 'getSentCopyLine', () => {
 		expect( result ).toContain( 'delivery details' );
 	} );
 
-	test( 'pastTense with categoryNames and dateStr returns "was emailed to X of Y on Z"', () => {
+	test( 'tense past with categoryNames and dateStr returns "was emailed to X of Y on Z"', () => {
 		const result = getSentCopyLine( {
 			accessLabel: 'all subscribers',
 			categoryNames: 'Tech',
-			pastTense: true,
+			tense: 'past',
 			dateStr: 'Jan 15, 2024',
 		} );
 		expect( result ).toContain( 'was emailed to' );
@@ -351,11 +237,11 @@ describe( 'getSentCopyLine', () => {
 		expect( result ).toContain( 'Jan 15, 2024' );
 	} );
 
-	test( 'pastTense with categoryNames, no dateStr returns "was emailed to X of Y"', () => {
+	test( 'tense past with categoryNames, no dateStr returns "was emailed to X of Y"', () => {
 		const result = getSentCopyLine( {
 			accessLabel: 'all subscribers',
 			categoryNames: 'Tech',
-			pastTense: true,
+			tense: 'past',
 			dateStr: '',
 		} );
 		expect( result ).toContain( 'was emailed to' );
@@ -363,11 +249,11 @@ describe( 'getSentCopyLine', () => {
 		expect( result ).toContain( 'Tech' );
 	} );
 
-	test( 'future tense with categoryNames returns "is being emailed to X of Y"', () => {
+	test( 'tense present with categoryNames returns "is being emailed to X of Y"', () => {
 		const result = getSentCopyLine( {
 			accessLabel: 'all subscribers',
 			categoryNames: 'Tech',
-			pastTense: false,
+			tense: 'present',
 			dateStr: '',
 		} );
 		expect( result ).toContain( 'is being emailed' );
@@ -375,11 +261,23 @@ describe( 'getSentCopyLine', () => {
 		expect( result ).toContain( 'Tech' );
 	} );
 
-	test( 'pastTense with accessLabel and dateStr returns "was emailed to X on Y"', () => {
+	test( 'tense future with categoryNames returns "will be emailed to X of Y"', () => {
+		const result = getSentCopyLine( {
+			accessLabel: 'all subscribers',
+			categoryNames: 'Tech',
+			tense: 'future',
+			dateStr: '',
+		} );
+		expect( result ).toContain( 'will be emailed' );
+		expect( result ).toContain( 'all subscribers' );
+		expect( result ).toContain( 'Tech' );
+	} );
+
+	test( 'tense past with accessLabel and dateStr returns "was emailed to X on Y"', () => {
 		const result = getSentCopyLine( {
 			accessLabel: 'all subscribers',
 			categoryNames: '',
-			pastTense: true,
+			tense: 'past',
 			dateStr: 'Jan 15, 2024',
 		} );
 		expect( result ).toContain( 'was emailed to' );
@@ -387,11 +285,11 @@ describe( 'getSentCopyLine', () => {
 		expect( result ).toContain( 'Jan 15, 2024' );
 	} );
 
-	test( 'pastTense with accessLabel only returns "was emailed to X"', () => {
+	test( 'tense past with accessLabel only returns "was emailed to X"', () => {
 		const result = getSentCopyLine( {
 			accessLabel: 'all subscribers',
 			categoryNames: '',
-			pastTense: true,
+			tense: 'past',
 			dateStr: '',
 		} );
 		expect( result ).toContain( 'was emailed to' );
@@ -399,14 +297,25 @@ describe( 'getSentCopyLine', () => {
 		expect( result ).toContain( 'delivery details' );
 	} );
 
-	test( 'future tense with accessLabel returns "is being emailed to X"', () => {
+	test( 'tense present with accessLabel returns "is being emailed to X"', () => {
 		const result = getSentCopyLine( {
 			accessLabel: 'all subscribers',
 			categoryNames: '',
-			pastTense: false,
+			tense: 'present',
 			dateStr: '',
 		} );
 		expect( result ).toContain( 'is being emailed' );
+		expect( result ).toContain( 'all subscribers' );
+	} );
+
+	test( 'tense future with accessLabel returns "will be emailed to X"', () => {
+		const result = getSentCopyLine( {
+			accessLabel: 'all subscribers',
+			categoryNames: '',
+			tense: 'future',
+			dateStr: '',
+		} );
+		expect( result ).toContain( 'will be emailed' );
 		expect( result ).toContain( 'all subscribers' );
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/store/membership-products/actions.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/actions.js
@@ -120,12 +120,6 @@ export const setNewsletterCategories = newsletterCategories => ( {
 	newsletterCategories,
 } );
 
-export const setNewsletterCategoriesSubscriptionsCount =
-	newsletterCategoriesSubscriptionsCount => ( {
-		type: 'SET_NEWSLETTER_CATEGORIES_SUBSCRIPTIONS_COUNT',
-		newsletterCategoriesSubscriptionsCount,
-	} );
-
 export const setPostEmailSentState = ( postId, { email_sent_at, stats_on_send } ) => ( {
 	type: 'SET_POST_EMAIL_SENT_STATE',
 	postId,

--- a/projects/plugins/jetpack/extensions/store/membership-products/reducer.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/reducer.js
@@ -51,11 +51,6 @@ export default function reducer( state = DEFAULT_STATE, action ) {
 				...state,
 				newsletterCategories: action.newsletterCategories,
 			};
-		case 'SET_NEWSLETTER_CATEGORIES_SUBSCRIPTIONS_COUNT':
-			return {
-				...state,
-				newsletterCategoriesSubscriptionsCount: action.newsletterCategoriesSubscriptionsCount,
-			};
 		case 'SET_POST_EMAIL_SENT_STATE':
 			return {
 				...state,

--- a/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
@@ -15,7 +15,6 @@ import {
 	setConnectedAccountDefaultCurrency,
 	setSubscriberCounts,
 	setNewsletterCategories,
-	setNewsletterCategoriesSubscriptionsCount,
 	setTotalEmailsSentCount,
 	setPostEmailSentState,
 } from './actions';
@@ -28,8 +27,6 @@ const TOTAL_EMAILS_SENT_COUNT_EXECUTION_KEY =
 	'membership-products-resolver-getTotalEmailsSentCount';
 const GET_NEWSLETTER_CATEGORIES_EXECUTION_KEY =
 	'membership-products-resolver-getNewsletterCategories';
-const GET_NEWSLETTER_CATEGORIES_SUBSCRIPTIONS_COUNT_EXECUTION_KEY =
-	'membership-products-resolver-getNewsletterCategoriesSubscriptionsCount';
 const GET_POST_EMAIL_SENT_STATE_EXECUTION_KEY =
 	'membership-products-resolver-getPostEmailSentState';
 let hydratedFromAPI = false;
@@ -137,32 +134,6 @@ const fetchTotalEmailsSentCount = async ( blogId, postId ) => {
 const fetchNewsletterCategories = async () => {
 	const response = await apiFetch( {
 		path: '/wpcom/v2/newsletter-categories',
-	} );
-
-	if ( ! response || typeof response !== 'object' ) {
-		throw new Error( 'Unexpected API response' );
-	}
-
-	/**
-	 * WP_Error returns a list of errors with custom names:
-	 * `errors: { foo: [ 'message' ], bar: [ 'message' ] }`
-	 * Since we don't know their names, to get the message, we transform the object
-	 * into an array, and just pick the first message of the first error.
-	 *
-	 * @see https://developer.wordpress.org/reference/classes/wp_error/
-	 */
-	const wpError = response?.errors && Object.values( response.errors )?.[ 0 ]?.[ 0 ];
-	if ( wpError ) {
-		throw new Error( wpError );
-	}
-
-	return response;
-};
-
-export const fetchNewsletterCategoriesSubscriptionsCount = async termIds => {
-	const response = await apiFetch( {
-		path: `/wpcom/v2/newsletter-categories/count?term_ids=${ termIds.join( ',' ) }`,
-		method: 'GET',
 	} );
 
 	if ( ! response || typeof response !== 'object' ) {
@@ -345,28 +316,6 @@ export const getNewsletterCategories =
 					categories: response.newsletter_categories,
 				} )
 			);
-		} catch ( error ) {
-			dispatch( setApiState( API_STATE_NOTCONNECTED ) );
-			onError( error.message, registry );
-		} finally {
-			executionLock.release( lock );
-		}
-	};
-
-export const getNewsletterCategoriesSubscriptionsCount =
-	( termIds = [] ) =>
-	async ( { dispatch, registry } ) => {
-		await executionLock.blockExecution(
-			GET_NEWSLETTER_CATEGORIES_SUBSCRIPTIONS_COUNT_EXECUTION_KEY
-		);
-
-		const lock = executionLock.acquire(
-			GET_NEWSLETTER_CATEGORIES_SUBSCRIPTIONS_COUNT_EXECUTION_KEY
-		);
-
-		try {
-			const response = await fetchNewsletterCategoriesSubscriptionsCount( termIds );
-			dispatch( setNewsletterCategoriesSubscriptionsCount( response.subscriptions_count ) );
 		} catch ( error ) {
 			dispatch( setApiState( API_STATE_NOTCONNECTED ) );
 			onError( error.message, registry );

--- a/projects/plugins/jetpack/extensions/store/membership-products/selectors.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/selectors.js
@@ -36,9 +36,6 @@ export const getNewsletterCategories = state => state.newsletterCategories.categ
 
 export const getNewsletterCategoriesEnabled = state => state.newsletterCategories.enabled;
 
-export const getNewsletterCategoriesSubscriptionsCount = state =>
-	state.newsletterCategoriesSubscriptionsCount;
-
 const DEFAULT_POST_EMAIL_SENT_STATE = { email_sent_at: null, stats_on_send: null };
 export const getPostEmailSentState = ( state, postId ) => {
 	if ( ! postId ) {

--- a/projects/plugins/jetpack/extensions/store/membership-products/test/actions-test.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/test/actions-test.js
@@ -10,7 +10,6 @@ import {
 	setSiteSlug,
 	setConnectedAccountDefaultCurrency,
 	setNewsletterCategories,
-	setNewsletterCategoriesSubscriptionsCount,
 	setPostEmailSentState,
 	setTotalEmailsSentCount,
 	setAlreadySentPostModifiedInSession,
@@ -319,20 +318,6 @@ describe( 'Membership Products Actions', () => {
 
 		// Then
 		expect( result ).toStrictEqual( anyValidNewsletterCategoriesWithType );
-	} );
-
-	test( 'Set newsletter categories subscriptions count works as expected', () => {
-		// Given
-		const anyValidNewsletterCategoriesSubscriptionsCountWithType = {
-			type: 'SET_NEWSLETTER_CATEGORIES_SUBSCRIPTIONS_COUNT',
-			newsletterCategoriesSubscriptionsCount: ANY_VALID_DATA,
-		};
-
-		// When
-		const result = setNewsletterCategoriesSubscriptionsCount( ANY_VALID_DATA );
-
-		// Then
-		expect( result ).toStrictEqual( anyValidNewsletterCategoriesSubscriptionsCountWithType );
 	} );
 
 	test( 'Set total emails sent count works as expected', () => {

--- a/projects/plugins/jetpack/extensions/store/membership-products/test/reducer-test.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/test/reducer-test.js
@@ -128,27 +128,6 @@ describe( 'Membership products reducer testing', () => {
 		} );
 	} );
 
-	test( 'set newsletter categories subscriptions count action type adds the newsletter categories subscriptions count to the returned state.', () => {
-		// Given
-		const anyNewsletterCategoriesSubscriptionsCount = 1;
-		const anySetNewsletterCategoriesSubscriptionsCountAction = {
-			type: 'SET_NEWSLETTER_CATEGORIES_SUBSCRIPTIONS_COUNT',
-			newsletterCategoriesSubscriptionsCount: anyNewsletterCategoriesSubscriptionsCount,
-		};
-
-		// When
-		const returnedState = reducer(
-			DEFAULT_STATE,
-			anySetNewsletterCategoriesSubscriptionsCountAction
-		);
-
-		// Then
-		expect( returnedState ).toStrictEqual( {
-			...DEFAULT_STATE,
-			newsletterCategoriesSubscriptionsCount: anyNewsletterCategoriesSubscriptionsCount,
-		} );
-	} );
-
 	test( 'SET_TOTAL_EMAILS_SENT_COUNT action adds the total emails sent count to the returned state.', () => {
 		const anyTotalEmailsSentCount = 10;
 		const anySetTotalEmailsSentCountAction = {

--- a/projects/plugins/jetpack/extensions/store/membership-products/test/selectors-test.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/test/selectors-test.js
@@ -2,7 +2,6 @@ import {
 	getNewsletterCategories,
 	getNewsletterCategoriesEnabled,
 	getNewsletterTierProducts,
-	getNewsletterCategoriesSubscriptionsCount,
 	getPostEmailSentState,
 	getProducts,
 	getTotalEmailsSentCount,
@@ -48,16 +47,6 @@ describe( 'Membership Products Selectors', () => {
 		);
 		expect( getNewsletterCategoriesEnabled( state ) ).toStrictEqual(
 			state.newsletterCategories.enabled
-		);
-	} );
-
-	test( 'getNewsletterCategoriesSubscriptionsCount works as expected', () => {
-		const state = {
-			newsletterCategoriesSubscriptionsCount: 1,
-		};
-
-		expect( getNewsletterCategoriesSubscriptionsCount( state ) ).toStrictEqual(
-			state.newsletterCategoriesSubscriptionsCount
 		);
 	} );
 


### PR DESCRIPTION
Fixes # https://linear.app/a8c/issue/NL-450/newsletter-editor-panel-make-will-send-to-subscriber-numbers-accurate
 
## Proposed changes
<!--- Explain what functional changes your PR includes -->

Updates the "will send to" copies to
* always include details about both access levels (including paid tiers) AND newsletter categories, for who will receive the emails.
    * removes old separate copy helpers for categories and paid posts, and moves these copies into the helper we use for sent emails. 
* removes misrepresentative counts from the copies.
    * removes the store and fetch related to unused counts.  

<img width="267" height="199" alt="Screenshot 2026-03-16 at 2 16 50 PM" src="https://github.com/user-attachments/assets/2bae26b2-ba26-4849-b9cd-b4ad36a653bb" />
<img width="284" height="250" alt="Screenshot 2026-03-16 at 2 19 55 PM" src="https://github.com/user-attachments/assets/6ef36225-f6ae-477d-8912-3d7094822284" />
<img width="302" height="239" alt="Screenshot 2026-03-16 at 2 20 16 PM" src="https://github.com/user-attachments/assets/146f3c96-decf-45c9-aaf0-7313e93716f0" />
<img width="286" height="239" alt="Screenshot 2026-03-16 at 2 20 38 PM" src="https://github.com/user-attachments/assets/392abef8-b082-4394-b893-053a917577de" />



### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Apply this build to a newsletter test site with paid tiers and w/ and w/o newsletter categories.
* Go to the editor and test the newsletter panel pre-publish/pre-email message.
* Verify the new message is shown: it will have no numbers, and will accurately say the access level and categories that are set. Try this for variations of number of categories and paid settings and verify everything looks accurate.
* Add a paywal block to the page and set the paywall access to paid subscribers only, the newsletter message should say it is being emailed to "all subscribers". (This is previous behavior as well, paywalled posts are emailed more broadly than the access setting since the access setting is for the content behind the paywall block.)
