### PR TITLE
Blocks: Remove redundant Jetpack block collection from the block inserter

### DIFF
--- a/projects/packages/forms/changelog/fix-dont-list-form-blocks-twice
+++ b/projects/packages/forms/changelog/fix-dont-list-form-blocks-twice
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Remove reduntant de-registration of Jetpack collection in forms editor.

--- a/projects/packages/forms/src/form-editor/class-form-editor.php
+++ b/projects/packages/forms/src/form-editor/class-form-editor.php
@@ -32,7 +32,6 @@ class Form_Editor {
 		add_filter( 'block_editor_settings_all', array( __CLASS__, 'block_editor_settings_all' ), 10, 2 );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_admin_scripts' ) );
 		add_action( 'current_screen', array( __CLASS__, 'disable_block_directory' ) );
-		add_action( 'current_screen', array( __CLASS__, 'disable_block_collection' ) );
 	}
 
 	/**
@@ -155,26 +154,6 @@ class Form_Editor {
 		}
 		if ( Contact_Form::POST_TYPE === $screen->post_type ) {
 			remove_action( 'enqueue_block_editor_assets', 'wp_enqueue_editor_block_directory_assets' );
-		}
-	}
-
-	/**
-	 * Disable the Jetpack block collection in the form editor.
-	 *
-	 * Filters `jetpack_register_block_collection` to prevent the "Jetpack"
-	 * collection label from appearing in the block inserter, since form field
-	 * blocks are organized into their own granular categories.
-	 *
-	 * @since 7.12.0
-	 *
-	 * @param \WP_Screen $screen The current screen object.
-	 */
-	public static function disable_block_collection( $screen ) {
-		if ( ! isset( $screen->post_type ) ) {
-			return;
-		}
-		if ( Contact_Form::POST_TYPE === $screen->post_type ) {
-			add_filter( 'jetpack_register_block_collection', '__return_false' );
 		}
 	}
 

--- a/projects/plugins/jetpack/changelog/fix-dont-list-form-blocks-twice
+++ b/projects/plugins/jetpack/changelog/fix-dont-list-form-blocks-twice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Remove duplicate display of form blocks under the "Jetpack" block inserter section; form blocks now only appear under the "Forms" category.

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -781,10 +781,10 @@ class Jetpack_Gutenberg {
 
 		$jetpack_plan  = Jetpack_Plan::get();
 		$initial_state = array(
-			'available_blocks'        => self::get_availability(),
-			'blocks_variation'        => $blocks_variation,
-			'modules'                 => $modules,
-			'jetpack'                 => array(
+			'available_blocks' => self::get_availability(),
+			'blocks_variation' => $blocks_variation,
+			'modules'          => $modules,
+			'jetpack'          => array(
 				'is_active'                     => Jetpack::is_connection_ready(),
 				'is_current_user_connected'     => $is_current_user_connected,
 				/** This filter is documented in class.jetpack-gutenberg.php */
@@ -811,22 +811,14 @@ class Jetpack_Gutenberg {
 				 */
 				'republicize_enabled'           => apply_filters( 'jetpack_block_editor_republicize_feature', true ),
 			),
-			'siteFragment'            => $status->get_site_suffix(),
-			'adminUrl'                => esc_url( admin_url() ),
-			'tracksUserData'          => $user_data,
-			'wpcomBlogId'             => $blog_id,
-			'allowedMimeTypes'        => wp_get_mime_types(),
-			'siteLocale'              => str_replace( '_', '-', get_locale() ),
-			'ai-assistant'            => $ai_assistant_state,
-			'screenBase'              => $screen_base,
-			/**
-			 * Should all blocks get registered the Jetpack block collection in addition to their own categories?
-			 *
-			 * @since 15.3
-			 *
-			 * @param boolean true Enable Jetpack block collection in block categories. Defaults to true.
-			 */
-			'registerBlockCollection' => apply_filters( 'jetpack_register_block_collection', true ),
+			'siteFragment'     => $status->get_site_suffix(),
+			'adminUrl'         => esc_url( admin_url() ),
+			'tracksUserData'   => $user_data,
+			'wpcomBlogId'      => $blog_id,
+			'allowedMimeTypes' => wp_get_mime_types(),
+			'siteLocale'       => str_replace( '_', '-', get_locale() ),
+			'ai-assistant'     => $ai_assistant_state,
+			'screenBase'       => $screen_base,
 			/**
 			 * Add your own feature flags to the block editor.
 			 *
@@ -836,8 +828,8 @@ class Jetpack_Gutenberg {
 			 *
 			 * @param array true Enable the RePublicize UI in the block editor context. Defaults to true.
 			 */
-			'feature_flags'           => apply_filters( 'jetpack_block_editor_feature_flags', array() ),
-			'pluginBasePath'          => plugins_url( '', Constants::get_constant( 'JETPACK__PLUGIN_FILE' ) ),
+			'feature_flags'    => apply_filters( 'jetpack_block_editor_feature_flags', array() ),
+			'pluginBasePath'   => plugins_url( '', Constants::get_constant( 'JETPACK__PLUGIN_FILE' ) ),
 		);
 
 		wp_localize_script(

--- a/projects/plugins/jetpack/extensions/shared/block-category.js
+++ b/projects/plugins/jetpack/extensions/shared/block-category.js
@@ -1,13 +1,6 @@
 import { JetpackLogo } from '@automattic/jetpack-shared-extension-utils/icons';
-import { getCategories, setCategories, registerBlockCollection } from '@wordpress/blocks';
+import { getCategories, setCategories } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
-
-if ( window?.Jetpack_Editor_Initial_State?.registerBlockCollection ) {
-	registerBlockCollection( 'jetpack', {
-		title: 'Jetpack',
-		icon: <JetpackLogo />,
-	} );
-}
 
 // We're moving Form specific blocks to a new 'Forms' category
 // that should appear before the 'monetize' and 'grow' categories


### PR DESCRIPTION
Fixes JETPACK-1418

## Proposed changes

* Removes the `registerBlockCollection('jetpack', ...)` call from `block-category.js`. Every Jetpack block already has a specific category assigned (`contact-form`, `monetize`, `grow`, `text`, `media`, `embed`, `widgets`), so the "Jetpack" collection was entirely redundant — it duplicated every Jetpack block under an extra "Jetpack" panel alongside their proper categories.
* Removes the now-unused `registerBlockCollection` PHP flag from `Jetpack_Editor_Initial_State` in `class.jetpack-gutenberg.php`.

The `registerBlockCollection` API groups blocks purely by namespace prefix with no per-block opt-out, so it cannot be scoped to a subset of blocks. Since all Jetpack blocks are already discoverable through their own categories, the collection adds no value and only creates clutter.

https://www.loom.com/share/cba360a20d5b4c4c9f4a4c2d3da9c308

### On `registerBlockCollection` and intentional duplication

The [Block Collections API](https://make.wordpress.org/core/2020/02/27/block-collections/) (introduced in WordPress 5.4) was designed to provide **vendor visibility** — letting plugin authors add a branded panel in the inserter so users can discover all of a plugin's blocks in one place, even when those blocks span multiple semantic categories. The duplication is intentional by design.

However, the WordPress core team itself acknowledged the feature was "in its infancy" and that "vendor" was simply the easiest criterion to experiment with. One common criticism at the time: *"No one is clicking the block inserter thinking 'I don't really care what block I use as long as it's a coblocks one.'"*

The "vendor panel" rationale is especially weak for Jetpack because our blocks span many unrelated functional categories (Forms, Monetize, Grow, Text, Embed, etc.) rather than forming a coherent bundle users would naturally browse together. Removing the collection follows the standard WordPress best practice: each block belongs to **one** semantic category.

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links

peKye1-1418-p2

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Activate Jetpack on a WordPress site.
2. Open the block editor on any post or page.
3. Open the block inserter ("+" button) and click "Browse all".
4. Verify there is **no** "Jetpack" section in the block inserter.
5. Verify all Jetpack blocks are still accessible under their proper categories:
   - Forms blocks (Form, Text input, Number, Radio, etc.) → **Forms**
   - Donations, WordAds, Payments → **Monetize**
   - Subscriptions, Mailchimp, Business Hours → **Grow**
   - Markdown, AI Chat, Blogging Prompt → **Text**
   - Map, Eventbrite, Google Calendar → **Embed**