### PR TITLE
Renovate: Bump abandonmentThreshold to two years

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,5 +1,6 @@
 {
 	extends: [ 'config:recommended', 'abandonments:recommended', 'group:definitelyTyped' ],
+	abandonmentThreshold: '2 years',
 	labels: [ 'Task', '[Status] Needs Review' ],
 	reviewers: [ 'team:jetpack-monorepo' ],
 	prHourlyLimit: 1,


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
Currently Renovate considers dependencies abandoned if there have been no updates in one year. That's a bit aggressive, so this bumps it to an also-arbitrary-but-more-forgiving two years.

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* p1773694053673749-slack-C05Q5HSS013
* Docs: https://docs.renovatebot.com/configuration-options/#abandonmentthreshold

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

🦐