### PR TITLE
Fix AI Assistant modal shaking when content streams in

### DIFF
--- a/projects/js-packages/ai-client/changelog/pr-47616
+++ b/projects/js-packages/ai-client/changelog/pr-47616
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AI Assistant: Fix modal shaking when content streams in by correcting header margins and making the header sticky.

--- a/projects/js-packages/ai-client/src/components/modal/index.tsx
+++ b/projects/js-packages/ai-client/src/components/modal/index.tsx
@@ -57,7 +57,6 @@ export default function AiAssistantModal( {
 		>
 			<div className="ai-assistant-modal__content" style={ { maxWidth } }>
 				<ModalHeader requestingState={ requestingState } onClose={ handleClose } title={ title } />
-				<hr className="ai-assistant-modal__divider" />
 				{ children }
 			</div>
 		</Modal>

--- a/projects/js-packages/ai-client/src/components/modal/style.scss
+++ b/projects/js-packages/ai-client/src/components/modal/style.scss
@@ -16,16 +16,14 @@
 	&__header {
 		display: flex;
 		justify-content: space-between;
-		margin-right: -32px;
-		margin-left: -32px;
-		margin-top: -32px;
+		margin-right: -24px;
+		margin-left: -24px;
+		margin-top: -24px;
 		padding: 8px 12px;
-	}
-
-	&__divider {
-		background: #dcdcde;
-		margin: 0 -32px;
-		height: 1px;
+		position: sticky;
+		top: -24px;
+		background: #fff;
+		border-bottom: 1px solid #dcdcde;
 	}
 
 	&__title-wrapper {

--- a/projects/plugins/jetpack/changelog/pr-47616
+++ b/projects/plugins/jetpack/changelog/pr-47616
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Assistant: Fix modal shaking when content streams in by correcting header margins and making the header sticky.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/feedback/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/feedback/style.scss
@@ -1,8 +1,8 @@
 .ai-assistant-post-feedback {
 
 	&__suggestion {
-		padding: 18px 0;
-		margin-bottom: -32px;
+		padding: 8px 0;
+		margin-bottom: -16px;
 
 		ul,
 		ol {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/title-optimization/style.scss
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/title-optimization/style.scss
@@ -26,11 +26,11 @@
 	&__footer {
 		display: flex;
 		justify-content: flex-start;
-		margin-right: -32px;
-		margin-left: -32px;
-		margin-top: 32px;
-		margin-bottom: -32px;
-		padding: 20px 32px;
+		margin-right: -24px;
+		margin-left: -24px;
+		margin-top: 24px;
+		margin-bottom: -24px;
+		padding: 20px 24px;
 		border-top: solid 1px #dcdcde;
 		height: 60px;
 	}


### PR DESCRIPTION
Part of JPAI-95

Fixes a visual issue where the AI Assistant modal would shake/jitter as content streamed in.

## Proposed changes

* **Fix modal header spacing** (`ai-client`): The header used `-32px` negative margins that didn't match the WordPress Modal component's actual `24px` content padding, causing layout instability as content changed. Corrected to `-24px`.
* **Make header sticky** (`ai-client`): Replace the separate `<hr>` divider element with a `border-bottom` on the header and add `position: sticky` so the header stays in place when content scrolls, reducing visual jumpiness.
* **Align consumer components** (`plugins/jetpack`): Update the feedback suggestion and title optimization footer components to use matching `-24px` margins/padding.


https://github.com/user-attachments/assets/5b87d0d4-c53e-4080-b31f-005c80dc3d84



### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
p1773669718127489-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. Open a post in the block editor
2. Open the AI Assistant from the Jetpack sidebar
3. Use "Optimize title" or request feedback on the post
4. Observe the modal as text streams in — it should no longer shake or jitter
5. If the modal content is long enough to scroll, verify the header stays pinned at the top