### PR TITLE
Charts: Move tooltip portal containerRef off ChartLayout in pie charts

### DIFF
--- a/projects/js-packages/charts/changelog/charts-186-pie-chart-tooltip-containerref
+++ b/projects/js-packages/charts/changelog/charts-186-pie-chart-tooltip-containerref
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Move tooltip portal containerRef off ChartLayout to inner svg-wrapper in pie charts.

--- a/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
@@ -298,7 +298,6 @@ const PieChartInternal = ( {
 	return (
 		<SingleChartContext.Provider value={ { chartId } }>
 			<ChartLayout
-				ref={ containerRef }
 				legendPosition={ legendPosition }
 				legendElement={ legendElement }
 				legendChildren={ legendChildren }
@@ -348,7 +347,12 @@ const PieChartInternal = ( {
 						: 0;
 
 					return (
-						<Stack align="center" justify="center" className={ styles[ 'pie-chart__centering' ] }>
+						<Stack
+							ref={ containerRef }
+							align="center"
+							justify="center"
+							className={ styles[ 'pie-chart__centering' ] }
+						>
 							<svg
 								viewBox={ `0 0 ${ width } ${ height }` }
 								preserveAspectRatio="xMidYMid meet"

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -342,7 +342,6 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 	return (
 		<SingleChartContext.Provider value={ { chartId } }>
 			<ChartLayout
-				ref={ containerRef }
 				legendPosition={ legendPosition }
 				legendElement={ legendElement }
 				legendChildren={ legendChildren }
@@ -387,6 +386,7 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 
 					return (
 						<Stack
+							ref={ containerRef }
 							align="center"
 							justify="center"
 							className={ styles[ 'pie-semi-circle-chart__centering' ] }

--- a/projects/js-packages/charts/src/charts/private/chart-layout/chart-layout.tsx
+++ b/projects/js-packages/charts/src/charts/private/chart-layout/chart-layout.tsx
@@ -1,5 +1,5 @@
 import { Stack } from '@wordpress/ui';
-import { forwardRef, useEffect } from 'react';
+import { useEffect } from 'react';
 import { useElementSize } from '../../../hooks';
 import { renderLegendSlot } from '../chart-composition';
 import styles from './chart-layout.module.scss';
@@ -45,70 +45,62 @@ export interface ChartLayoutProps {
 	'data-chart-id'?: string;
 }
 
-export const ChartLayout = forwardRef< HTMLDivElement, ChartLayoutProps >(
-	(
-		{
-			legendPosition,
-			legendElement,
-			legendChildren,
-			children,
-			trailingContent,
-			onContentHeightChange,
-			gap,
-			className,
-			style,
-			'data-testid': dataTestId,
-			'data-chart-id': dataChartId,
-		},
-		ref
-	) => {
-		const [ contentRef, contentWidth, contentHeight ] = useElementSize< HTMLDivElement >();
-		const isRenderProp = typeof children === 'function';
-		const isMeasured = contentHeight > 0;
+export const ChartLayout = ( {
+	legendPosition,
+	legendElement,
+	legendChildren,
+	children,
+	trailingContent,
+	onContentHeightChange,
+	gap,
+	className,
+	style,
+	'data-testid': dataTestId,
+	'data-chart-id': dataChartId,
+}: ChartLayoutProps ) => {
+	const [ contentRef, contentWidth, contentHeight ] = useElementSize< HTMLDivElement >();
+	const isRenderProp = typeof children === 'function';
+	const isMeasured = contentHeight > 0;
 
-		// When using render-prop children, hide the layout until measurement is available
-		// to prevent layout shift. Plain ReactNode children don't need this since they
-		// don't depend on measured dimensions.
-		const visibilityStyle: { visibility?: 'hidden' | 'visible' } =
-			isRenderProp && ! isMeasured ? { visibility: 'hidden' } : {};
+	// When using render-prop children, hide the layout until measurement is available
+	// to prevent layout shift. Plain ReactNode children don't need this since they
+	// don't depend on measured dimensions.
+	const visibilityStyle: { visibility?: 'hidden' | 'visible' } =
+		isRenderProp && ! isMeasured ? { visibility: 'hidden' } : {};
 
-		useEffect( () => {
-			if ( isRenderProp && onContentHeightChange && isMeasured ) {
-				onContentHeightChange( contentHeight );
-			}
-		}, [ isRenderProp, contentHeight, isMeasured, onContentHeightChange ] );
-		const renderedChildren = isRenderProp
-			? children( { contentWidth, contentHeight, isMeasured } )
-			: children;
+	useEffect( () => {
+		if ( isRenderProp && onContentHeightChange && isMeasured ) {
+			onContentHeightChange( contentHeight );
+		}
+	}, [ isRenderProp, contentHeight, isMeasured, onContentHeightChange ] );
+	const renderedChildren = isRenderProp
+		? children( { contentWidth, contentHeight, isMeasured } )
+		: children;
 
-		return (
-			<Stack
-				ref={ ref }
-				direction="column"
-				gap={ gap }
-				className={ className }
-				style={ { ...style, ...visibilityStyle } }
-				data-testid={ dataTestId }
-				data-chart-id={ dataChartId }
-			>
-				{ legendPosition === 'top' && legendElement }
-				{ renderLegendSlot( legendChildren, 'top' ) }
+	return (
+		<Stack
+			direction="column"
+			gap={ gap }
+			className={ className }
+			style={ { ...style, ...visibilityStyle } }
+			data-testid={ dataTestId }
+			data-chart-id={ dataChartId }
+		>
+			{ legendPosition === 'top' && legendElement }
+			{ renderLegendSlot( legendChildren, 'top' ) }
 
-				{ isRenderProp ? (
-					<div ref={ contentRef } className={ styles[ 'chart-layout__content' ] }>
-						{ renderedChildren }
-					</div>
-				) : (
-					renderedChildren
-				) }
+			{ isRenderProp ? (
+				<div ref={ contentRef } className={ styles[ 'chart-layout__content' ] }>
+					{ renderedChildren }
+				</div>
+			) : (
+				renderedChildren
+			) }
 
-				{ legendPosition === 'bottom' && legendElement }
-				{ renderLegendSlot( legendChildren, 'bottom' ) }
+			{ legendPosition === 'bottom' && legendElement }
+			{ renderLegendSlot( legendChildren, 'bottom' ) }
 
-				{ trailingContent }
-			</Stack>
-		);
-	}
-);
-
-ChartLayout.displayName = 'ChartLayout';
+			{ trailingContent }
+		</Stack>
+	);
+};

--- a/projects/js-packages/charts/src/charts/private/chart-layout/test/chart-layout.test.tsx
+++ b/projects/js-packages/charts/src/charts/private/chart-layout/test/chart-layout.test.tsx
@@ -128,16 +128,6 @@ describe( 'ChartLayout', () => {
 		expect( screen.getByTestId( 'layout' ) ).toBeInTheDocument();
 	} );
 
-	it( 'forwards ref to Stack', () => {
-		const ref = jest.fn();
-		render(
-			<ChartLayout ref={ ref } legendPosition="bottom" legendChildren={ [] }>
-				<div>Chart</div>
-			</ChartLayout>
-		);
-		expect( ref ).toHaveBeenCalledWith( expect.any( HTMLElement ) );
-	} );
-
 	it( 'calls function-as-children with measurement props', () => {
 		const childFn = jest.fn().mockReturnValue( <div data-testid="chart-content">Chart</div> );
 


### PR DESCRIPTION
Fixes CHARTS-186

## Proposed changes

* Move `containerRef` (from `useTooltipInPortal`) off the `ChartLayout` component and onto the centering `Stack` element (svg-wrapper) inside each pie chart's render prop.
* This aligns `PieChart` and `PieSemiCircleChart` with `LineChart`/`BarChart`/`LeaderboardChart`, which do not pass a ref to `ChartLayout`.
* Remove the now-unused `forwardRef` wrapper from `ChartLayout`, simplifying it to a plain function component.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* Follow-up from CHARTS-181 (ChartLayout extraction)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. Open Storybook and navigate to **Pie Chart > Tooltips > Default**
2. In the Controls panel, enable **showOffsetTestButtons** (under the "Testing" category)
3. Hover over pie segments — tooltips should appear near the cursor with correct data (e.g., "Linux: 22K", "MacOS: 30K", "Windows: 80K")
4. Click **Right →** or **Down ↓** to shift the container via direct DOM manipulation (no React re-render)
5. Hover over segments again — **tooltip should still follow the cursor correctly**
6. Repeat steps 2–5 for **Pie Semi Circle Chart > Tooltips**
7. Run `jp test js js-packages/charts` — all tests pass

### Why this works

The tooltip position math already cancels out `containerBounds`:

```
tooltipLeft = clientX - containerBounds.left + offset
TooltipInPortal applies: tooltipLeft + containerBounds.left + scrollX
Result: clientX + offset + scrollX (containerBounds cancel out)
```

So moving `containerRef` to a child element does not affect tooltip positioning.

Linear Issue: [CHARTS-186](https://linear.app/a8c/issue/CHARTS-186/move-tooltip-portal-containerref-off-chartlayout-in-pie-charts)
