### PR TITLE
Forms: Distinguish permission denied from not found for form blocks

### DIFF
--- a/projects/packages/forms/changelog/fix-author-form-block-permission-error
+++ b/projects/packages/forms/changelog/fix-author-form-block-permission-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Show distinct error message when user lacks permission to edit a form block vs when the form does not exist.

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -29,7 +29,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useRef, useEffect, useCallback, lazy, Suspense, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import clsx from 'clsx';
 /*
  * Internal dependencies
@@ -1027,7 +1027,7 @@ function JetpackContactFormEdit( {
 		const errorMessage =
 			syncedFormErrorType === 'permission_denied'
 				? __( "You don't have permission to edit this form.", 'jetpack-forms' )
-				: __( 'The referenced form could not be found.', 'jetpack-forms', 0 );
+				: _x( 'The referenced form could not be found.', 'synced form error', 'jetpack-forms' );
 		elt = (
 			<Notice status="warning" isDismissible={ false }>
 				{ errorMessage }

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -222,6 +222,7 @@ function JetpackContactFormEdit( {
 		isLoading: isResolvingSyncedForm,
 		syncedAttributes: syncedFormAttributes,
 		syncedInnerBlocks: syncedFormBlocks,
+		errorType: syncedFormErrorType,
 	} = useSyncedForm( ref );
 
 	// Backward compatibility for the deprecated customThankyou attribute.
@@ -1019,11 +1020,13 @@ function JetpackContactFormEdit( {
 			</div>
 		);
 	}
-	// Show error if referenced form not found
+	// Show error if referenced form not found or not accessible
 	else if ( ref && ! syncedForm && ! isResolvingSyncedForm ) {
 		elt = (
 			<Notice status="warning" isDismissible={ false }>
-				{ __( 'The referenced form could not be found.', 'jetpack-forms' ) }
+				{ syncedFormErrorType === 'permission_denied'
+					? __( "You don't have permission to edit this form.", 'jetpack-forms' )
+					: __( 'The referenced form could not be found.', 'jetpack-forms' ) }
 			</Notice>
 		);
 	}

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -1022,11 +1022,15 @@ function JetpackContactFormEdit( {
 	}
 	// Show error if referenced form not found or not accessible
 	else if ( ref && ! syncedForm && ! isResolvingSyncedForm ) {
+		// Note: The two __() calls must remain dissimilar to prevent Terser from
+		// compacting them into a single call with a ternary argument, which breaks i18n.
+		const errorMessage =
+			syncedFormErrorType === 'permission_denied'
+				? __( "You don't have permission to edit this form.", 'jetpack-forms' )
+				: __( 'The referenced form could not be found.', 'jetpack-forms', 0 );
 		elt = (
 			<Notice status="warning" isDismissible={ false }>
-				{ syncedFormErrorType === 'permission_denied'
-					? __( "You don't have permission to edit this form.", 'jetpack-forms' )
-					: __( 'The referenced form could not be found.', 'jetpack-forms' ) }
+				{ errorMessage }
 			</Notice>
 		);
 	}

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form.ts
@@ -22,6 +22,7 @@ interface UseSyncedFormResult {
 	syncedAttributes: Record< string, unknown > | null;
 	syncedInnerBlocks: ParsedBlock[] | null;
 	syncedForm: JetpackForm | null;
+	errorType: 'permission_denied' | 'not_found' | null;
 }
 
 const EMPTY_FORM = { syncedAttributes: null, syncedInnerBlocks: null };
@@ -42,6 +43,24 @@ export function useSyncedForm( ref: number | undefined ): UseSyncedFormResult {
 		{
 			enabled: !! ref,
 		}
+	);
+
+	// Check for resolution errors to distinguish permission denied from not found
+	const resolutionError = useSelect(
+		select => {
+			if ( ! ref ) {
+				return null;
+			}
+			const store = select( coreStore ) as Record< string, ( ...args: unknown[] ) => unknown >;
+			if ( typeof store.getResolutionError !== 'function' ) {
+				return null;
+			}
+			return store.getResolutionError( 'getEntityRecord', [ 'postType', FORM_POST_TYPE, ref ] ) as {
+				status?: number;
+				data?: { status?: number };
+			} | null;
+		},
+		[ ref ]
 	);
 
 	// Get the actual pending edits object to see exactly what's being changed
@@ -134,12 +153,26 @@ export function useSyncedForm( ref: number | undefined ): UseSyncedFormResult {
 		};
 	}, [ pendingBlocks, record, ref ] );
 
+	// Derive error type from resolution error
+	let errorType: UseSyncedFormResult[ 'errorType' ] = null;
+	if ( ref && ! record && ! isResolving && status !== 'IDLE' ) {
+		const httpStatus =
+			( resolutionError as { status?: number } )?.status ??
+			( resolutionError as { data?: { status?: number } } )?.data?.status;
+		if ( httpStatus === 403 ) {
+			errorType = 'permission_denied';
+		} else {
+			errorType = 'not_found';
+		}
+	}
+
 	if ( ! ref ) {
 		return {
 			isLoading: false,
 			syncedAttributes: null,
 			syncedInnerBlocks: null,
 			syncedForm: null,
+			errorType: null,
 		};
 	}
 
@@ -150,6 +183,7 @@ export function useSyncedForm( ref: number | undefined ): UseSyncedFormResult {
 			syncedAttributes,
 			syncedInnerBlocks,
 			syncedForm: record,
+			errorType,
 		};
 	}
 
@@ -158,5 +192,6 @@ export function useSyncedForm( ref: number | undefined ): UseSyncedFormResult {
 		syncedAttributes,
 		syncedInnerBlocks,
 		syncedForm: record,
+		errorType,
 	};
 }

--- a/projects/packages/forms/tests/js/contact-form/use-synced-form.test.js
+++ b/projects/packages/forms/tests/js/contact-form/use-synced-form.test.js
@@ -31,14 +31,36 @@ const { useSyncedForm } = await import(
 );
 
 describe( 'useSyncedForm', () => {
+	/**
+	 * useSelect is called twice in useSyncedForm:
+	 * 1st call returns resolutionError, 2nd call returns pendingEdits.
+	 * Use mockReturnValueOnce to control each call independently.
+	 *
+	 * @param {object}  root0                 - Mock configuration.
+	 * @param {object}  root0.record          - Entity record to return.
+	 * @param {boolean} root0.isResolving     - Whether the entity is resolving.
+	 * @param {boolean} root0.hasEdits        - Whether the entity has pending edits.
+	 * @param {string}  root0.status          - Resolution status.
+	 * @param {object}  root0.resolutionError - Resolution error object.
+	 * @param {object}  root0.pendingEdits    - Pending edits object.
+	 */
+	const setupMocks = ( {
+		record = null,
+		isResolving = false,
+		hasEdits = false,
+		status = 'SUCCESS',
+		resolutionError = null,
+		pendingEdits = null,
+	} = {} ) => {
+		mockUseEntityRecord.mockReset();
+		mockUseSelect.mockReset();
+		mockUseEntityRecord.mockReturnValue( { record, isResolving, hasEdits, status } );
+		mockUseSelect.mockReturnValueOnce( resolutionError ).mockReturnValueOnce( pendingEdits );
+	};
+
 	beforeEach( () => {
 		jest.clearAllMocks();
-		mockUseEntityRecord.mockReturnValue( {
-			record: null,
-			isResolving: false,
-			hasEdits: false,
-		} );
-		mockUseSelect.mockReturnValue( null );
+		setupMocks();
 	} );
 
 	it( 'returns null values when ref is undefined', () => {
@@ -48,14 +70,11 @@ describe( 'useSyncedForm', () => {
 		expect( result.syncedAttributes ).toBeNull();
 		expect( result.syncedInnerBlocks ).toBeNull();
 		expect( result.syncedForm ).toBeNull();
+		expect( result.errorType ).toBeNull();
 	} );
 
 	it( 'returns loading state when resolving', () => {
-		mockUseEntityRecord.mockReturnValue( {
-			record: null,
-			isResolving: true,
-			hasEdits: false,
-		} );
+		setupMocks( { isResolving: true } );
 
 		const result = useSyncedForm( 123 );
 
@@ -71,12 +90,11 @@ describe( 'useSyncedForm', () => {
 			},
 		];
 
-		mockUseEntityRecord.mockReturnValue( {
+		setupMocks( {
 			record: { content: { raw: '<!-- old content -->' } },
-			isResolving: false,
 			hasEdits: true,
+			pendingEdits: { blocks: pendingBlocks },
 		} );
-		mockUseSelect.mockReturnValue( { blocks: pendingBlocks } );
 
 		const result = useSyncedForm( 123 );
 
@@ -96,12 +114,11 @@ describe( 'useSyncedForm', () => {
 			},
 		];
 
-		mockUseEntityRecord.mockReturnValue( {
+		setupMocks( {
 			record: { content: { raw: '<!-- saved content -->' } },
-			isResolving: false,
 			hasEdits: true,
+			pendingEdits: { content: '<!-- pending content -->' },
 		} );
-		mockUseSelect.mockReturnValue( { content: '<!-- pending content -->' } );
 		mockParse.mockReturnValue( parsedBlocks );
 
 		const result = useSyncedForm( 456 );
@@ -122,12 +139,9 @@ describe( 'useSyncedForm', () => {
 			},
 		];
 
-		mockUseEntityRecord.mockReturnValue( {
+		setupMocks( {
 			record: { content: { raw: '<!-- saved form -->' } },
-			isResolving: false,
-			hasEdits: false,
 		} );
-		mockUseSelect.mockReturnValue( null );
 		mockParse.mockReturnValue( savedBlocks );
 
 		const result = useSyncedForm( 789 );
@@ -148,12 +162,11 @@ describe( 'useSyncedForm', () => {
 			},
 		];
 
-		mockUseEntityRecord.mockReturnValue( {
+		setupMocks( {
 			record: { content: { raw: '...' } },
-			isResolving: false,
 			hasEdits: true,
+			pendingEdits: { blocks: blocksWithLock },
 		} );
-		mockUseSelect.mockReturnValue( { blocks: blocksWithLock } );
 
 		const result = useSyncedForm( 123 );
 
@@ -170,16 +183,80 @@ describe( 'useSyncedForm', () => {
 			},
 		];
 
-		mockUseEntityRecord.mockReturnValue( {
+		setupMocks( {
 			record: { content: { raw: '...' } },
-			isResolving: false,
 			hasEdits: true,
+			pendingEdits: { blocks: wrongBlock },
 		} );
-		mockUseSelect.mockReturnValue( { blocks: wrongBlock } );
 
 		const result = useSyncedForm( 123 );
 
 		expect( result.syncedAttributes ).toBeNull();
 		expect( result.syncedInnerBlocks ).toBeNull();
+	} );
+
+	describe( 'errorType', () => {
+		it( 'returns permission_denied when resolution error has status 403', () => {
+			setupMocks( {
+				resolutionError: { status: 403 },
+			} );
+
+			const result = useSyncedForm( 123 );
+
+			expect( result.errorType ).toBe( 'permission_denied' );
+			expect( result.syncedForm ).toBeNull();
+		} );
+
+		it( 'returns not_found when resolution error has status 404', () => {
+			setupMocks( {
+				resolutionError: { status: 404 },
+			} );
+
+			const result = useSyncedForm( 123 );
+
+			expect( result.errorType ).toBe( 'not_found' );
+			expect( result.syncedForm ).toBeNull();
+		} );
+
+		it( 'returns not_found when record is null with no resolution error', () => {
+			setupMocks();
+
+			const result = useSyncedForm( 123 );
+
+			expect( result.errorType ).toBe( 'not_found' );
+		} );
+
+		it( 'returns null errorType when record exists', () => {
+			const savedBlocks = [
+				{
+					name: 'jetpack/contact-form',
+					attributes: { to: 'test@example.com' },
+					innerBlocks: [],
+				},
+			];
+
+			setupMocks( {
+				record: { content: { raw: '<!-- form -->' } },
+			} );
+			mockParse.mockReturnValue( savedBlocks );
+
+			const result = useSyncedForm( 123 );
+
+			expect( result.errorType ).toBeNull();
+		} );
+
+		it( 'returns null errorType when ref is undefined', () => {
+			const result = useSyncedForm( undefined );
+
+			expect( result.errorType ).toBeNull();
+		} );
+
+		it( 'returns null errorType while still resolving', () => {
+			setupMocks( { isResolving: true } );
+
+			const result = useSyncedForm( 123 );
+
+			expect( result.errorType ).toBeNull();
+		} );
 	} );
 } );


### PR DESCRIPTION
Before:
<img width="840" height="291" alt="Screenshot 2026-03-16 at 11 40 17 PM" src="https://github.com/user-attachments/assets/b7114c8f-eb8f-4b0e-ba2c-28371852f0c5" />

After: 

<img width="844" height="344" alt="Screenshot 2026-03-16 at 11 46 24 PM" src="https://github.com/user-attachments/assets/4db25c6f-13dc-4f3d-a565-548c2f8ac9a7" />

## Proposed changes

* When an author user views a form block created by another user, the editor now shows "You don't have permission to edit this form" instead of the misleading "The referenced form could not be found" message.
* Added `errorType` field to the `useSyncedForm` hook that distinguishes between permission denied (HTTP 403) and not found (HTTP 404) errors using `getResolutionError` from `@wordpress/data`.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Log in as an **author** user
* Create a post and add a Jetpack Form block — this creates a `jetpack_form` post owned by another user (e.g., an admin)
* As the author, open a different post that contains a form block referencing a form you did **not** create
* Verify you see: **"You don't have permission to edit this form."**
* Now change the form block's `ref` attribute to a non-existent post ID
* Verify you see: **"The referenced form could not be found."**
* Run JS tests: `cd projects/packages/forms && pnpm test` — all 640 tests should pass
