### PR TITLE
Newsletter: Update settings max width to 660px

### DIFF
--- a/projects/packages/newsletter/changelog/newsletter-settings-width
+++ b/projects/packages/newsletter/changelog/newsletter-settings-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update newsletter settings max width to 660px to match MSD and future settings pages

--- a/projects/packages/newsletter/src/settings/style.scss
+++ b/projects/packages/newsletter/src/settings/style.scss
@@ -11,7 +11,7 @@
 }
 
 .newsletter-settings {
-	max-width: 1200px;
+	max-width: 660px; /* MSD and future JP settings pages are 660px wide */
 	margin-inline: auto;
 
 	.components-notice {


### PR DESCRIPTION
Fixes #

## Proposed changes
* Update the newsletter settings page max width from 1200px to 660px to align with MSD and other Jetpack settings pages.

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
pdtkmj-4rt-p2#comment-8688

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Go to the Newsletter settings page in wp-admin (Jetpack → Newsletter).
* Verify the settings container is 660px wide (instead of 1200px).
* Resize the browser window to confirm the layout remains correct at smaller viewports.


Before | After
-------|------
<img width="2630" height="6488" alt="Screen Shot 2026-03-17 at 14 17 06-fullpage" src="https://github.com/user-attachments/assets/59177781-2346-44af-a261-7b7bc2f46c6e" /> | <img width="2630" height="6638" alt="Screen Shot 2026-03-17 at 14 14 29-fullpage" src="https://github.com/user-attachments/assets/1cc30fe0-58a4-4c46-827e-717af8ecb435" />


