### PR TITLE
Disabled pingbacks for staging sites

### DIFF
--- a/projects/plugins/wpcomsh/changelog/pr-47625
+++ b/projects/plugins/wpcomsh/changelog/pr-47625
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Disable outgoing and incoming pingbacks for staging sites.

--- a/projects/plugins/wpcomsh/feature-plugins/staging-sites.php
+++ b/projects/plugins/wpcomsh/feature-plugins/staging-sites.php
@@ -25,3 +25,44 @@ function wpcomsh_is_staging_site_get_atomic_persistent_data( $wpcom_is_staging_s
 // need to hook to default_option_* too because if this option doesn't exist, the hook wouldn't run.
 add_filter( 'default_option_wpcom_is_staging_site', 'wpcomsh_is_staging_site_get_atomic_persistent_data' );
 add_filter( 'option_wpcom_is_staging_site', 'wpcomsh_is_staging_site_get_atomic_persistent_data' );
+
+/**
+ * Disables outgoing pingbacks/trackbacks in staging environments.
+ *
+ * Prevents the dispatch of pingbacks when the environment type is 'staging'.
+ * This can be removed once WordPress core addresses the issue.
+ *
+ * @see https://core.trac.wordpress.org/ticket/64837
+ *
+ * @param bool $send Whether to send the pingback. Default true.
+ * @return bool False to prevent sending in staging environments, otherwise the original value.
+ */
+function wpcomsh_disable_outgoing_pings_in_non_production_envs( $send ) {
+	if ( 'staging' === wp_get_environment_type() ) {
+		return false;
+	}
+
+	return $send;
+}
+add_filter( 'pre_pingback_send', 'wpcomsh_disable_outgoing_pings_in_non_production_envs' );
+
+/**
+ * Disables incoming pingbacks in staging environments by removing
+ * the 'pingback.ping' XML-RPC method.
+ *
+ * Prevents WordPress from processing incoming pingbacks when the environment
+ * type is 'staging'. This can be removed once WordPress core addresses the issue.
+ *
+ * @see https://core.trac.wordpress.org/ticket/64837
+ *
+ * @param array<string, callable> $methods Associative array of XML-RPC methods.
+ * @return array<string, callable> Modified associative array of XML-RPC methods.
+ */
+function wpcomsh_disable_incoming_pings_in_non_production_envs( $methods ) {
+	if ( 'staging' === wp_get_environment_type() ) {
+		unset( $methods['pingback.ping'] );
+	}
+
+	return $methods;
+}
+add_filter( 'xmlrpc_methods', 'wpcomsh_disable_incoming_pings_in_non_production_envs' );

--- a/projects/plugins/wpcomsh/tests/StagingSitePingsTest.php
+++ b/projects/plugins/wpcomsh/tests/StagingSitePingsTest.php
@@ -7,6 +7,12 @@
 
 /**
  * Class StagingSitePingsTest.
+ *
+ * Each test runs in a separate process because wp_get_environment_type()
+ * caches its result in a static variable that cannot be reset between tests.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
  */
 class StagingSitePingsTest extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
@@ -17,25 +23,6 @@ class StagingSitePingsTest extends WP_UnitTestCase {
 	public function test_outgoing_pings_disabled_in_staging() {
 		putenv( 'WP_ENVIRONMENT_TYPE=staging' );
 		$this->assertFalse( wpcomsh_disable_outgoing_pings_in_non_production_envs( true ) );
-		putenv( 'WP_ENVIRONMENT_TYPE' );
-	}
-
-	/**
-	 * Test that outgoing pings are allowed in development environment.
-	 */
-	public function test_outgoing_pings_allowed_in_development() {
-		putenv( 'WP_ENVIRONMENT_TYPE=development' );
-		$this->assertTrue( wpcomsh_disable_outgoing_pings_in_non_production_envs( true ) );
-		putenv( 'WP_ENVIRONMENT_TYPE' );
-	}
-
-	/**
-	 * Test that outgoing pings are allowed in local environment.
-	 */
-	public function test_outgoing_pings_allowed_in_local() {
-		putenv( 'WP_ENVIRONMENT_TYPE=local' );
-		$this->assertTrue( wpcomsh_disable_outgoing_pings_in_non_production_envs( true ) );
-		putenv( 'WP_ENVIRONMENT_TYPE' );
 	}
 
 	/**
@@ -44,7 +31,6 @@ class StagingSitePingsTest extends WP_UnitTestCase {
 	public function test_outgoing_pings_allowed_in_production() {
 		putenv( 'WP_ENVIRONMENT_TYPE=production' );
 		$this->assertTrue( wpcomsh_disable_outgoing_pings_in_non_production_envs( true ) );
-		putenv( 'WP_ENVIRONMENT_TYPE' );
 	}
 
 	/**
@@ -61,41 +47,6 @@ class StagingSitePingsTest extends WP_UnitTestCase {
 
 		$this->assertArrayNotHasKey( 'pingback.ping', $result );
 		$this->assertArrayHasKey( 'wp.getPosts', $result );
-		putenv( 'WP_ENVIRONMENT_TYPE' );
-	}
-
-	/**
-	 * Test that incoming pingback.ping method is kept in development environment.
-	 */
-	public function test_incoming_pings_allowed_in_development() {
-		putenv( 'WP_ENVIRONMENT_TYPE=development' );
-		$methods = array(
-			'pingback.ping' => 'some_callback',
-			'wp.getPosts'   => 'some_callback',
-		);
-
-		$result = wpcomsh_disable_incoming_pings_in_non_production_envs( $methods );
-
-		$this->assertArrayHasKey( 'pingback.ping', $result );
-		$this->assertArrayHasKey( 'wp.getPosts', $result );
-		putenv( 'WP_ENVIRONMENT_TYPE' );
-	}
-
-	/**
-	 * Test that incoming pingback.ping method is kept in local environment.
-	 */
-	public function test_incoming_pings_allowed_in_local() {
-		putenv( 'WP_ENVIRONMENT_TYPE=local' );
-		$methods = array(
-			'pingback.ping' => 'some_callback',
-			'wp.getPosts'   => 'some_callback',
-		);
-
-		$result = wpcomsh_disable_incoming_pings_in_non_production_envs( $methods );
-
-		$this->assertArrayHasKey( 'pingback.ping', $result );
-		$this->assertArrayHasKey( 'wp.getPosts', $result );
-		putenv( 'WP_ENVIRONMENT_TYPE' );
 	}
 
 	/**
@@ -112,21 +63,5 @@ class StagingSitePingsTest extends WP_UnitTestCase {
 
 		$this->assertArrayHasKey( 'pingback.ping', $result );
 		$this->assertArrayHasKey( 'wp.getPosts', $result );
-		putenv( 'WP_ENVIRONMENT_TYPE' );
-	}
-
-	/**
-	 * Test that incoming pings filter handles missing pingback.ping gracefully.
-	 */
-	public function test_incoming_pings_handles_missing_pingback_method() {
-		putenv( 'WP_ENVIRONMENT_TYPE=staging' );
-		$methods = array(
-			'wp.getPosts' => 'some_callback',
-		);
-
-		$result = wpcomsh_disable_incoming_pings_in_non_production_envs( $methods );
-
-		$this->assertArrayHasKey( 'wp.getPosts', $result );
-		putenv( 'WP_ENVIRONMENT_TYPE' );
 	}
 }

--- a/projects/plugins/wpcomsh/tests/StagingSitePingsTest.php
+++ b/projects/plugins/wpcomsh/tests/StagingSitePingsTest.php
@@ -7,15 +7,28 @@
 
 /**
  * Class StagingSitePingsTest.
- *
- * Each test runs in a separate process because wp_get_environment_type()
- * caches its result in a static variable that cannot be reset between tests.
- *
- * @runTestsInSeparateProcesses
- * @preserveGlobalState disabled
  */
 class StagingSitePingsTest extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Define WP_RUN_CORE_TESTS so wp_get_environment_type() bypasses
+	 * its static cache and re-reads the env var on every call.
+	 */
+	public function set_up() {
+		parent::set_up();
+		if ( ! defined( 'WP_RUN_CORE_TESTS' ) ) {
+			define( 'WP_RUN_CORE_TESTS', true );
+		}
+	}
+
+	/**
+	 * Reset the environment type after each test.
+	 */
+	public function tear_down() {
+		putenv( 'WP_ENVIRONMENT_TYPE' );
+		parent::tear_down();
+	}
 
 	/**
 	 * Test that outgoing pings are disabled in staging environment.

--- a/projects/plugins/wpcomsh/tests/StagingSitePingsTest.php
+++ b/projects/plugins/wpcomsh/tests/StagingSitePingsTest.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Staging Site Pings Test file.
+ *
+ * @package wpcomsh
+ */
+
+/**
+ * Class StagingSitePingsTest.
+ */
+class StagingSitePingsTest extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Test that outgoing pings are disabled in staging environment.
+	 */
+	public function test_outgoing_pings_disabled_in_staging() {
+		putenv( 'WP_ENVIRONMENT_TYPE=staging' );
+		$this->assertFalse( wpcomsh_disable_outgoing_pings_in_non_production_envs( true ) );
+		putenv( 'WP_ENVIRONMENT_TYPE' );
+	}
+
+	/**
+	 * Test that outgoing pings are allowed in development environment.
+	 */
+	public function test_outgoing_pings_allowed_in_development() {
+		putenv( 'WP_ENVIRONMENT_TYPE=development' );
+		$this->assertTrue( wpcomsh_disable_outgoing_pings_in_non_production_envs( true ) );
+		putenv( 'WP_ENVIRONMENT_TYPE' );
+	}
+
+	/**
+	 * Test that outgoing pings are allowed in local environment.
+	 */
+	public function test_outgoing_pings_allowed_in_local() {
+		putenv( 'WP_ENVIRONMENT_TYPE=local' );
+		$this->assertTrue( wpcomsh_disable_outgoing_pings_in_non_production_envs( true ) );
+		putenv( 'WP_ENVIRONMENT_TYPE' );
+	}
+
+	/**
+	 * Test that outgoing pings are not disabled in production environment.
+	 */
+	public function test_outgoing_pings_allowed_in_production() {
+		putenv( 'WP_ENVIRONMENT_TYPE=production' );
+		$this->assertTrue( wpcomsh_disable_outgoing_pings_in_non_production_envs( true ) );
+		putenv( 'WP_ENVIRONMENT_TYPE' );
+	}
+
+	/**
+	 * Test that incoming pingback.ping method is removed in staging environment.
+	 */
+	public function test_incoming_pings_disabled_in_staging() {
+		putenv( 'WP_ENVIRONMENT_TYPE=staging' );
+		$methods = array(
+			'pingback.ping' => 'some_callback',
+			'wp.getPosts'   => 'some_callback',
+		);
+
+		$result = wpcomsh_disable_incoming_pings_in_non_production_envs( $methods );
+
+		$this->assertArrayNotHasKey( 'pingback.ping', $result );
+		$this->assertArrayHasKey( 'wp.getPosts', $result );
+		putenv( 'WP_ENVIRONMENT_TYPE' );
+	}
+
+	/**
+	 * Test that incoming pingback.ping method is kept in development environment.
+	 */
+	public function test_incoming_pings_allowed_in_development() {
+		putenv( 'WP_ENVIRONMENT_TYPE=development' );
+		$methods = array(
+			'pingback.ping' => 'some_callback',
+			'wp.getPosts'   => 'some_callback',
+		);
+
+		$result = wpcomsh_disable_incoming_pings_in_non_production_envs( $methods );
+
+		$this->assertArrayHasKey( 'pingback.ping', $result );
+		$this->assertArrayHasKey( 'wp.getPosts', $result );
+		putenv( 'WP_ENVIRONMENT_TYPE' );
+	}
+
+	/**
+	 * Test that incoming pingback.ping method is kept in local environment.
+	 */
+	public function test_incoming_pings_allowed_in_local() {
+		putenv( 'WP_ENVIRONMENT_TYPE=local' );
+		$methods = array(
+			'pingback.ping' => 'some_callback',
+			'wp.getPosts'   => 'some_callback',
+		);
+
+		$result = wpcomsh_disable_incoming_pings_in_non_production_envs( $methods );
+
+		$this->assertArrayHasKey( 'pingback.ping', $result );
+		$this->assertArrayHasKey( 'wp.getPosts', $result );
+		putenv( 'WP_ENVIRONMENT_TYPE' );
+	}
+
+	/**
+	 * Test that incoming pingback.ping method is kept in production environment.
+	 */
+	public function test_incoming_pings_allowed_in_production() {
+		putenv( 'WP_ENVIRONMENT_TYPE=production' );
+		$methods = array(
+			'pingback.ping' => 'some_callback',
+			'wp.getPosts'   => 'some_callback',
+		);
+
+		$result = wpcomsh_disable_incoming_pings_in_non_production_envs( $methods );
+
+		$this->assertArrayHasKey( 'pingback.ping', $result );
+		$this->assertArrayHasKey( 'wp.getPosts', $result );
+		putenv( 'WP_ENVIRONMENT_TYPE' );
+	}
+
+	/**
+	 * Test that incoming pings filter handles missing pingback.ping gracefully.
+	 */
+	public function test_incoming_pings_handles_missing_pingback_method() {
+		putenv( 'WP_ENVIRONMENT_TYPE=staging' );
+		$methods = array(
+			'wp.getPosts' => 'some_callback',
+		);
+
+		$result = wpcomsh_disable_incoming_pings_in_non_production_envs( $methods );
+
+		$this->assertArrayHasKey( 'wp.getPosts', $result );
+		putenv( 'WP_ENVIRONMENT_TYPE' );
+	}
+}


### PR DESCRIPTION
Fixes DOTDEV-401

## Proposed changes
With this PR we are disabling pingbacks for staging sites. This feature will be added to the core (https://core.trac.wordpress.org/ticket/64837#ticket) later, so we are fixing it here as a temporary solution. The solution in this PR follows the solution in https://core.trac.wordpress.org/ticket/64837.

## Related product discussion/links
DOTDEV-401

## Testing instructions
Strictly follow the steps, since I had issues when I created the staging site earlier or missed the "Add dev blog" action, etc.
1. Create a free site
2. Open PCYsg-Osp-p2 and click on the link "WoW Developer Blog Manager" (sorry, Tanpermonkey doesn't work for this link to provide it here directly)
3. Provide blog id and click "Add dev blog"
4. Upgrade to Business plan
5. Activate hosting features to allow installing plugins
6. Download beta plugin here - https://jetpack.com/download-jetpack-beta/
7. Install it on your website and activate
8. Launch your site (you can skip domain purchase)
9. Open `Jetpack -> Beta tester`
10. Click on `Manage` button for "WordPress.com Site Helper"
11. In the search field write `fix/disablepingBacksForStagignSites`
12. Click `Activate` button
13. Create staging site
14. Open staging site and find the link to default "Hello world" post, e.g. `https://staging-6e32-nightnei356.wpcomstaging.com/2026/03/17/hello-world/` and copy it
15. Open your prod site and create a post with pasting `https://staging-6e32-nightnei356.wpcomstaging.com/2026/03/17/hello-world/` and create a post
16. Open wp-admin of your staging site and select "Comments" in left sidebar
17. Assert that you so nothing: <br /><img width="1324" height="234" alt="Screenshot 2026-03-17 at 18 04 14" src="https://github.com/user-attachments/assets/c4394d47-571a-4e7a-8235-fccff695e13c" />