### PR TITLE
SSO: broker URLs served from mu plugin

### DIFF
--- a/projects/packages/connection/changelog/add-sso-broker-redirect-mu-urls
+++ b/projects/packages/connection/changelog/add-sso-broker-redirect-mu-urls
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added broker URL feature for SSO that enables specific wpcom sites to use different URLs for SSO auth redirects.

--- a/projects/packages/connection/changelog/add-sso-broker-redirect-mu-urls
+++ b/projects/packages/connection/changelog/add-sso-broker-redirect-mu-urls
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Added broker URL feature for SSO that enables specific wpcom sites to use different URLs for SSO auth redirects.
+Add SSO broker URLs so specific WordPress.com sites can use different URLs for SSO auth redirects.

--- a/projects/packages/connection/changelog/add-sso-broker-redirect-mu-urls
+++ b/projects/packages/connection/changelog/add-sso-broker-redirect-mu-urls
@@ -1,4 +1,4 @@
 Significance: minor
-Type: added
+Type: changed
 
-Add SSO broker URLs so specific WordPress.com sites can use different URLs for SSO auth redirects.
+Replace transient-based SSO broker URL storage with a constant-based approach gated by a WordPress.com authorization signal, and fall back to WordPress.com SSO when the referrer is a WordPress.com domain.

--- a/projects/packages/connection/src/sso/class-helpers.php
+++ b/projects/packages/connection/src/sso/class-helpers.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Connection\SSO;
 
+use Automattic\Jetpack\Connection\SSO;
 use Automattic\Jetpack\Constants;
 use Jetpack_IXR_Client;
 
@@ -208,6 +209,15 @@ class Helpers {
 			$base_url_parts = wp_parse_url( esc_url_raw( $api_base ) );
 			if ( $base_url_parts && ! empty( $base_url_parts['host'] ) ) {
 				$hosts[] = $base_url_parts['host'];
+			}
+		}
+
+		foreach ( array( SSO::get_broker_url(), SSO::get_broker_auth_url() ) as $broker_url ) {
+			if ( $broker_url ) {
+				$broker_parts = wp_parse_url( $broker_url );
+				if ( $broker_parts && ! empty( $broker_parts['host'] ) ) {
+					$hosts[] = $broker_parts['host'];
+				}
 			}
 		}
 

--- a/projects/packages/connection/src/sso/class-sso.php
+++ b/projects/packages/connection/src/sso/class-sso.php
@@ -584,6 +584,9 @@ class SSO {
 		if ( self::is_live_referrer_wpcom() ) {
 			setcookie( 'jetpack_sso_wpcom_referrer', '1', time() + ( 10 * MINUTE_IN_SECONDS ), COOKIEPATH, COOKIE_DOMAIN, is_ssl(), true );
 			$_COOKIE['jetpack_sso_wpcom_referrer'] = '1';
+		} elseif ( ! empty( $_COOKIE['jetpack_sso_wpcom_referrer'] ) ) {
+			setcookie( 'jetpack_sso_wpcom_referrer', ' ', time() - YEAR_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN, is_ssl(), true );
+			unset( $_COOKIE['jetpack_sso_wpcom_referrer'] );
 		}
 
 		if ( ! empty( $_GET['redirect_to'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended

--- a/projects/packages/connection/src/sso/class-sso.php
+++ b/projects/packages/connection/src/sso/class-sso.php
@@ -814,6 +814,8 @@ class SSO {
 				is_ssl(),
 				true
 			);
+			// Ensure this request can use the nonce immediately after setcookie().
+			$_COOKIE['jetpack_sso_nonce'] = $nonce;
 
 			if ( $use_broker ) {
 				setcookie(
@@ -825,8 +827,11 @@ class SSO {
 					is_ssl(),
 					true
 				);
+				// Mirror the broker signal in-memory for this request.
+				$_COOKIE[ self::BROKER_COOKIE ] = $nonce;
 			} else {
 				setcookie( self::BROKER_COOKIE, ' ', time() - YEAR_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN, is_ssl(), true );
+				unset( $_COOKIE[ self::BROKER_COOKIE ] );
 			}
 		}
 
@@ -1323,7 +1328,9 @@ class SSO {
 	}
 
 	/**
-	 * Build WordPress.com SSO URL with appropriate query parameters.
+	 * Build SSO URL with appropriate query parameters.
+	 *
+	 * The base URL can be WordPress.com or an authorized broker URL.
 	 *
 	 * @param array $args Optional query parameters.
 	 * @return string|WP_Error Redirect URL for SSO authentication.

--- a/projects/packages/connection/src/sso/class-sso.php
+++ b/projects/packages/connection/src/sso/class-sso.php
@@ -13,6 +13,7 @@ use Automattic\Jetpack\Connection\SSO\Helpers;
 use Automattic\Jetpack\Connection\SSO\Notices;
 use Automattic\Jetpack\Connection\SSO\User_Admin;
 use Automattic\Jetpack\Connection\Webhooks\Authorize_Redirect;
+use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Roles;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
@@ -732,6 +733,18 @@ class SSO {
 				true
 			);
 		}
+
+		if ( isset( $_COOKIE[ self::BROKER_COOKIE ] ) ) {
+			setcookie(
+				self::BROKER_COOKIE,
+				' ',
+				time() - YEAR_IN_SECONDS,
+				COOKIEPATH,
+				COOKIE_DOMAIN,
+				is_ssl(),
+				true
+			);
+		}
 	}
 
 	/**
@@ -744,6 +757,16 @@ class SSO {
 			Helpers::delete_connection_for_user( get_current_user_id() );
 		}
 	}
+
+	/**
+	 * Cookie name for the SSO broker authorization signal.
+	 *
+	 * Set when WP.com signals that a broker should be used for SSO. The cookie
+	 * value is the SSO nonce, tying the signal to a specific authentication flow.
+	 *
+	 * @var string
+	 */
+	const BROKER_COOKIE = 'jetpack_sso_broker';
 
 	/**
 	 * Retrieves nonce used for SSO form.
@@ -763,20 +786,151 @@ class SSO {
 				return new WP_Error( $xml->getErrorCode(), $xml->getErrorMessage() );
 			}
 
-			$nonce = sanitize_key( $xml->getResponse() );
+			$response = $xml->getResponse();
+
+			// The response may be a plain nonce string (default) or an associative
+			// array containing 'nonce' and a 'use_sso_broker' signal for sites that
+			// use an external SSO broker (e.g. CIAB stores via the MSD).
+			if ( is_array( $response ) ) {
+				if ( empty( $response['nonce'] ) ) {
+					return new WP_Error( 'invalid_response', __( 'Invalid nonce response from WordPress.com.', 'jetpack-connection' ) );
+				}
+
+				$nonce      = sanitize_key( $response['nonce'] );
+				$use_broker = ! empty( $response['use_sso_broker'] );
+			} else {
+				$nonce      = sanitize_key( $response );
+				$use_broker = false;
+			}
+
+			$cookie_expiry = time() + ( 10 * MINUTE_IN_SECONDS );
 
 			setcookie(
 				'jetpack_sso_nonce',
 				$nonce,
-				time() + ( 10 * MINUTE_IN_SECONDS ),
+				$cookie_expiry,
 				COOKIEPATH,
 				COOKIE_DOMAIN,
 				is_ssl(),
 				true
 			);
+
+			if ( $use_broker ) {
+				setcookie(
+					self::BROKER_COOKIE,
+					$nonce,
+					$cookie_expiry,
+					COOKIEPATH,
+					COOKIE_DOMAIN,
+					is_ssl(),
+					true
+				);
+			} else {
+				setcookie( self::BROKER_COOKIE, ' ', time() - YEAR_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN, is_ssl(), true );
+			}
 		}
 
 		return $nonce;
+	}
+
+	/**
+	 * Validates a broker URL string.
+	 *
+	 * @param string $url The URL to validate.
+	 * @return string|false The URL if valid HTTPS with a host, or false.
+	 */
+	private static function validate_broker_url( $url ) {
+		if ( empty( $url ) || ! is_string( $url ) ) {
+			return false;
+		}
+
+		$sanitized = esc_url_raw( $url );
+		$url_parts = wp_parse_url( $sanitized );
+
+		if ( $url_parts && 'https' === ( $url_parts['scheme'] ?? '' ) && ! empty( $url_parts['host'] ) ) {
+			return $sanitized;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Checks whether WP.com has authorized broker mode for the current SSO flow.
+	 *
+	 * The broker cookie is set during the nonce request when WP.com signals
+	 * that broker SSO should be used. Its value matches the SSO nonce to tie
+	 * the authorization to a specific flow.
+	 *
+	 * @return bool True if WP.com authorized broker mode for this nonce.
+	 */
+	private static function is_broker_authorized() {
+		$broker_signal = ! empty( $_COOKIE[ self::BROKER_COOKIE ] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			? sanitize_key( wp_unslash( $_COOKIE[ self::BROKER_COOKIE ] ) ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			: false;
+		$current_nonce = ! empty( $_COOKIE['jetpack_sso_nonce'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			? sanitize_key( wp_unslash( $_COOKIE['jetpack_sso_nonce'] ) ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			: false;
+
+		return $broker_signal && $current_nonce && $broker_signal === $current_nonce;
+	}
+
+	/**
+	 * Checks whether the current request's referrer is a WordPress.com domain.
+	 *
+	 * Used to skip the broker URL when the user navigated from Calypso or
+	 * another WordPress.com interface, so they stay within the expected
+	 * wordpress.com SSO flow.
+	 *
+	 * @return bool True if the referrer is a WordPress.com domain.
+	 */
+	private static function is_referrer_wpcom() {
+		$referer = wp_get_raw_referer();
+		if ( ! $referer ) {
+			return false;
+		}
+
+		$wpcom_hosts = array(
+			'wordpress.com',
+			'horizon.wordpress.com',
+			'wpcalypso.wordpress.com',
+		);
+
+		$referer_host = wp_parse_url( $referer, PHP_URL_HOST );
+		return $referer_host && in_array( $referer_host, $wpcom_hosts, true );
+	}
+
+	/**
+	 * Retrieves the SSO broker URL if authorized by WP.com and defined by the MU plugin.
+	 *
+	 * The broker URL is read from the JETPACK_SSO_BROKER_URL constant, which
+	 * is expected to be defined by a garden MU plugin (e.g. for CIAB stores).
+	 * It is only used when WP.com has signaled broker mode via the nonce response.
+	 *
+	 * @return string|false The broker URL, or false if not available.
+	 */
+	public static function get_broker_url() {
+		if ( ! self::is_broker_authorized() ) {
+			return false;
+		}
+		$url = Constants::get_constant( 'JETPACK_SSO_BROKER_URL' );
+		return $url ? self::validate_broker_url( $url ) : false;
+	}
+
+	/**
+	 * Retrieves the SSO broker authorization URL if authorized by WP.com.
+	 *
+	 * For broker sites, this URL replaces the Jetpack authorization endpoint
+	 * for establishing user connections. Read from the JETPACK_SSO_BROKER_AUTH_URL
+	 * constant defined by the garden MU plugin.
+	 *
+	 * @return string|false The broker authorization URL, or false if not available.
+	 */
+	public static function get_broker_auth_url() {
+		if ( ! self::is_broker_authorized() ) {
+			return false;
+		}
+		$url = Constants::get_constant( 'JETPACK_SSO_BROKER_AUTH_URL' );
+		return $url ? self::validate_broker_url( $url ) : false;
 	}
 
 	/**
@@ -1007,6 +1161,22 @@ class SSO {
 				$authorize_json_api->store_json_api_authorization_token( $user->user_login, $user );
 
 			} elseif ( ! $is_user_connected ) {
+				$broker_auth_url = self::get_broker_auth_url();
+				if ( $broker_auth_url ) {
+					add_filter( 'allowed_redirect_hosts', array( Helpers::class, 'allowed_redirect_hosts' ) );
+					wp_safe_redirect(
+						add_query_arg(
+							array(
+								'action'                   => 'jetpack-sso',
+								'site_id'                  => Manager::get_site_id( true ),
+								'broker-sso-auth-redirect' => '1',
+							),
+							$broker_auth_url
+						)
+					);
+					exit( 0 );
+				}
+
 				wp_safe_redirect(
 					add_query_arg(
 						array(
@@ -1135,10 +1305,28 @@ class SSO {
 	}
 
 	/**
+	 * Returns the base URL for SSO authentication.
+	 *
+	 * If a broker URL is available (authorized by WP.com and defined by the
+	 * garden MU plugin), that URL is used unless the user navigated from a
+	 * WordPress.com domain. Otherwise falls back to the default WordPress.com
+	 * login URL.
+	 *
+	 * @return string The base SSO URL.
+	 */
+	public static function get_sso_base_url() {
+		$broker_url = self::get_broker_url();
+		if ( $broker_url && ! self::is_referrer_wpcom() ) {
+			return $broker_url;
+		}
+		return 'https://wordpress.com/wp-login.php';
+	}
+
+	/**
 	 * Build WordPress.com SSO URL with appropriate query parameters.
 	 *
 	 * @param array $args Optional query parameters.
-	 * @return string|WP_Error WordPress.com SSO URL
+	 * @return string|WP_Error Redirect URL for SSO authentication.
 	 */
 	public function build_sso_url( $args = array() ) {
 		$sso_nonce = ! empty( $args['sso_nonce'] ) ? $args['sso_nonce'] : self::request_initial_nonce();
@@ -1155,16 +1343,15 @@ class SSO {
 			return $sso_nonce;
 		}
 
-		return add_query_arg( $args, 'https://wordpress.com/wp-login.php' );
+		return add_query_arg( $args, self::get_sso_base_url() );
 	}
 
 	/**
-	 * Build WordPress.com SSO URL with appropriate query parameters,
-	 * including the parameters necessary to force the user to reauthenticate
-	 * on WordPress.com.
+	 * Build SSO URL with appropriate query parameters, including the
+	 * parameters necessary to force the user to reauthenticate.
 	 *
 	 * @param array $args Optional query parameters.
-	 * @return string|WP_Error WordPress.com SSO URL
+	 * @return string|WP_Error Redirect URL for SSO authentication.
 	 */
 	public function build_reauth_and_sso_url( $args = array() ) {
 		$sso_nonce = ! empty( $args['sso_nonce'] ) ? $args['sso_nonce'] : self::request_initial_nonce();
@@ -1194,7 +1381,7 @@ class SSO {
 			return $args['sso_nonce'];
 		}
 
-		return add_query_arg( $args, 'https://wordpress.com/wp-login.php' );
+		return add_query_arg( $args, self::get_sso_base_url() );
 	}
 
 	/**

--- a/projects/packages/connection/src/sso/class-sso.php
+++ b/projects/packages/connection/src/sso/class-sso.php
@@ -50,6 +50,16 @@ class SSO {
 	private static $sso_user_for_2fa = null;
 
 	/**
+	 * Cookie name for the SSO broker authorization signal.
+	 *
+	 * Set when WP.com signals that a broker should be used for SSO. The cookie
+	 * value is the SSO nonce, tying the signal to a specific authentication flow.
+	 *
+	 * @var string
+	 */
+	const BROKER_COOKIE = 'jetpack_sso_broker';
+
+	/**
 	 * Automattic\Jetpack\Connection\SSO constructor.
 	 */
 	private function __construct() {
@@ -759,16 +769,6 @@ class SSO {
 	}
 
 	/**
-	 * Cookie name for the SSO broker authorization signal.
-	 *
-	 * Set when WP.com signals that a broker should be used for SSO. The cookie
-	 * value is the SSO nonce, tying the signal to a specific authentication flow.
-	 *
-	 * @var string
-	 */
-	const BROKER_COOKIE = 'jetpack_sso_broker';
-
-	/**
 	 * Retrieves nonce used for SSO form.
 	 *
 	 * @return string|WP_Error
@@ -1135,16 +1135,6 @@ class SSO {
 
 			wp_set_current_user( $user->ID );
 
-			$_request_redirect_to = isset( $_REQUEST['redirect_to'] ) ? esc_url_raw( wp_unslash( $_REQUEST['redirect_to'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$redirect_to          = user_can( $user, 'edit_posts' ) ? admin_url() : self::profile_page_url();
-
-			// If we have a saved redirect to request in a cookie.
-			if ( ! empty( $_COOKIE['jetpack_sso_redirect_to'] ) ) {
-				// Set that as the requested redirect to.
-				$redirect_to          = esc_url_raw( wp_unslash( $_COOKIE['jetpack_sso_redirect_to'] ) );
-				$_request_redirect_to = $redirect_to;
-			}
-
 			$json_api_auth_environment = Helpers::get_json_api_auth_environment();
 
 			$is_json_api_auth  = ! empty( $json_api_auth_environment );
@@ -1159,6 +1149,16 @@ class SSO {
 					'is_json_api_auth' => $is_json_api_auth,
 				)
 			);
+
+			$_request_redirect_to = isset( $_REQUEST['redirect_to'] ) ? esc_url_raw( wp_unslash( $_REQUEST['redirect_to'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$redirect_to          = user_can( $user, 'edit_posts' ) ? admin_url() : self::profile_page_url();
+
+			// If we have a saved redirect to request in a cookie.
+			if ( ! empty( $_COOKIE['jetpack_sso_redirect_to'] ) ) {
+				// Set that as the requested redirect to.
+				$redirect_to          = esc_url_raw( wp_unslash( $_COOKIE['jetpack_sso_redirect_to'] ) );
+				$_request_redirect_to = $redirect_to;
+			}
 
 			if ( $is_json_api_auth ) {
 				$authorize_json_api = new Authorize_Json_Api();

--- a/projects/packages/connection/src/sso/class-sso.php
+++ b/projects/packages/connection/src/sso/class-sso.php
@@ -578,6 +578,13 @@ class SSO {
 			true
 		);
 
+		// Persist the WordPress.com referrer signal so it survives the SSO button
+		// click, which changes the HTTP Referer to the site's own login page.
+		if ( self::is_referrer_wpcom() ) {
+			setcookie( 'jetpack_sso_wpcom_referrer', '1', time() + ( 10 * MINUTE_IN_SECONDS ), COOKIEPATH, COOKIE_DOMAIN, is_ssl(), true );
+			$_COOKIE['jetpack_sso_wpcom_referrer'] = '1';
+		}
+
 		if ( ! empty( $_GET['redirect_to'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			// If we have something to redirect to.
 			$url = esc_url_raw( wp_unslash( $_GET['redirect_to'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -755,6 +762,18 @@ class SSO {
 				true
 			);
 		}
+
+		if ( isset( $_COOKIE['jetpack_sso_wpcom_referrer'] ) ) {
+			setcookie(
+				'jetpack_sso_wpcom_referrer',
+				' ',
+				time() - YEAR_IN_SECONDS,
+				COOKIEPATH,
+				COOKIE_DOMAIN,
+				is_ssl(),
+				true
+			);
+		}
 	}
 
 	/**
@@ -889,6 +908,13 @@ class SSO {
 	 * @return bool True if the referrer is a WordPress.com domain.
 	 */
 	private static function is_referrer_wpcom() {
+		// Check the cookie persisted by save_cookies() on the initial login page
+		// load. The live HTTP Referer changes to the site's own wp-login.php when
+		// the user clicks the SSO button, so the cookie carries the original signal.
+		if ( ! empty( $_COOKIE['jetpack_sso_wpcom_referrer'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return true;
+		}
+
 		$referer = wp_get_raw_referer();
 		if ( ! $referer ) {
 			return false;

--- a/projects/packages/connection/src/sso/class-sso.php
+++ b/projects/packages/connection/src/sso/class-sso.php
@@ -580,7 +580,8 @@ class SSO {
 
 		// Persist the WordPress.com referrer signal so it survives the SSO button
 		// click, which changes the HTTP Referer to the site's own login page.
-		if ( self::is_referrer_wpcom() ) {
+		// Uses the live-only check to avoid a self-reinforcing cookie loop.
+		if ( self::is_live_referrer_wpcom() ) {
 			setcookie( 'jetpack_sso_wpcom_referrer', '1', time() + ( 10 * MINUTE_IN_SECONDS ), COOKIEPATH, COOKIE_DOMAIN, is_ssl(), true );
 			$_COOKIE['jetpack_sso_wpcom_referrer'] = '1';
 		}
@@ -915,6 +916,19 @@ class SSO {
 			return true;
 		}
 
+		return self::is_live_referrer_wpcom();
+	}
+
+	/**
+	 * Checks the live HTTP Referer header against WordPress.com domains.
+	 *
+	 * Unlike is_referrer_wpcom(), this does NOT consult the persisted cookie,
+	 * so it is safe to call from save_cookies() without creating a
+	 * self-reinforcing loop.
+	 *
+	 * @return bool True if the live referrer is a WordPress.com domain.
+	 */
+	private static function is_live_referrer_wpcom() {
 		$referer = wp_get_raw_referer();
 		if ( ! $referer ) {
 			return false;

--- a/projects/packages/connection/src/sso/class-sso.php
+++ b/projects/packages/connection/src/sso/class-sso.php
@@ -1174,6 +1174,8 @@ class SSO {
 							array(
 								'action'                   => 'jetpack-sso',
 								'site_id'                  => Manager::get_site_id( true ),
+								'redirect_to'              => $redirect_to,
+								'request_redirect_to'      => $_request_redirect_to,
 								'broker-sso-auth-redirect' => '1',
 							),
 							$broker_auth_url

--- a/projects/packages/connection/tests/php/sso/Helpers_Test.php
+++ b/projects/packages/connection/tests/php/sso/Helpers_Test.php
@@ -9,6 +9,7 @@
 
 namespace Automattic\Jetpack\Connection\SSO;
 
+use Automattic\Jetpack\Connection\SSO;
 use Automattic\Jetpack\Connection\Utils;
 use Automattic\Jetpack\Constants;
 use WorDBless\BaseTestCase;
@@ -354,6 +355,77 @@ class Helpers_Test extends BaseTestCase {
 			),
 			$environment
 		);
+	}
+
+	/**
+	 * Test "show_sso_login_returns_true_when_login_form_hidden".
+	 */
+	public function test_show_sso_login_returns_true_when_login_form_hidden() {
+		add_filter( 'jetpack_remove_login_form', '__return_true' );
+		$this->assertTrue( Helpers::show_sso_login() );
+		remove_filter( 'jetpack_remove_login_form', '__return_true' );
+	}
+
+	/**
+	 * Test "show_sso_login_returns_true_by_default".
+	 */
+	public function test_show_sso_login_returns_true_by_default() {
+		$this->assertTrue( Helpers::show_sso_login() );
+	}
+
+	/**
+	 * Test "show_sso_login_returns_false_with_filter".
+	 */
+	public function test_show_sso_login_returns_false_with_filter() {
+		add_filter( 'jetpack_sso_default_to_sso_login', '__return_false' );
+		$this->assertFalse( Helpers::show_sso_login() );
+		remove_filter( 'jetpack_sso_default_to_sso_login', '__return_false' );
+	}
+
+	/**
+	 * Test "allowed_redirect_hosts_includes_broker_hosts_when_set".
+	 */
+	public function test_allowed_redirect_hosts_includes_broker_hosts_when_set() {
+		$nonce                         = 'test_nonce_123';
+		$_COOKIE[ SSO::BROKER_COOKIE ] = $nonce;
+		$_COOKIE['jetpack_sso_nonce']  = $nonce;
+
+		Constants::set_constant( 'JETPACK_SSO_BROKER_URL', 'https://broker.example.com/sso' );
+		Constants::set_constant( 'JETPACK_SSO_BROKER_AUTH_URL', 'https://broker-auth.example.com/auth' );
+		Constants::set_constant( 'JETPACK__API_BASE', 'https://jetpack.wordpress.com/jetpack.' );
+
+		$hosts = Helpers::allowed_redirect_hosts( array() );
+		$this->assertContains( 'broker.example.com', $hosts );
+		$this->assertContains( 'broker-auth.example.com', $hosts );
+
+		unset( $_COOKIE[ SSO::BROKER_COOKIE ], $_COOKIE['jetpack_sso_nonce'] );
+	}
+
+	/**
+	 * Test "allowed_redirect_hosts_does_not_include_broker_when_not_authorized".
+	 */
+	public function test_allowed_redirect_hosts_does_not_include_broker_when_not_authorized() {
+		Constants::set_constant( 'JETPACK_SSO_BROKER_URL', 'https://broker.example.com/sso' );
+		Constants::set_constant( 'JETPACK__API_BASE', 'https://jetpack.wordpress.com/jetpack.' );
+
+		$hosts = Helpers::allowed_redirect_hosts( array() );
+		$this->assertNotContains( 'broker.example.com', $hosts );
+	}
+
+	/**
+	 * Test "match_by_email_defaults_to_true_from_option".
+	 */
+	public function test_match_by_email_defaults_to_true_from_option() {
+		$this->assertTrue( Helpers::match_by_email() );
+	}
+
+	/**
+	 * Test "match_by_email_option_zero_returns_false".
+	 */
+	public function test_match_by_email_option_zero_returns_false() {
+		update_option( 'jetpack_sso_match_by_email', 0 );
+		$this->assertFalse( Helpers::match_by_email() );
+		delete_option( 'jetpack_sso_match_by_email' );
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/sso/SSO_Test.php
+++ b/projects/packages/connection/tests/php/sso/SSO_Test.php
@@ -1,0 +1,571 @@
+<?php
+/**
+ * Testing functions in the Automattic\Jetpack\Connection\SSO class.
+ *
+ * @package automattic/jetpack-connection
+ */
+
+namespace Automattic\Jetpack\Connection;
+
+use Automattic\Jetpack\Connection\SSO\Helpers;
+use Automattic\Jetpack\Constants;
+use WorDBless\BaseTestCase;
+use WP_Error;
+
+/**
+ * SSO class test suite.
+ */
+class SSO_Test extends BaseTestCase {
+
+	/**
+	 * SSO instance.
+	 *
+	 * @var SSO
+	 */
+	private $sso;
+
+	/**
+	 * Set up.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->reset_sso_instance();
+		$this->sso = SSO::get_instance();
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down() {
+		$this->reset_sso_instance();
+		Constants::clear_constants();
+		unset(
+			$_COOKIE[ SSO::BROKER_COOKIE ],
+			$_COOKIE['jetpack_sso_nonce'],
+			$_GET['redirect_to'],
+			$_SERVER['HTTP_REFERER']
+		);
+		parent::tear_down();
+	}
+
+	/**
+	 * Reset the SSO singleton so each test starts fresh.
+	 */
+	private function reset_sso_instance() {
+		SSO::$instance = null;
+		$this->sso     = null;
+	}
+
+	// ──────────────────────────────────────────────
+	// Singleton
+	// ──────────────────────────────────────────────
+
+	/**
+	 * Test get_instance returns an SSO object.
+	 */
+	public function test_get_instance_returns_sso_object() {
+		$this->assertInstanceOf( SSO::class, $this->sso );
+	}
+
+	/**
+	 * Test get_instance returns the same object on subsequent calls.
+	 */
+	public function test_get_instance_returns_same_instance() {
+		$instance_a = SSO::get_instance();
+		$instance_b = SSO::get_instance();
+		$this->assertSame( $instance_a, $instance_b );
+	}
+
+	// ──────────────────────────────────────────────
+	// sync_sso_callables
+	// ──────────────────────────────────────────────
+
+	/**
+	 * Test that sync_sso_callables merges SSO callables.
+	 */
+	public function test_sync_sso_callables_merges_sso_callables() {
+		$existing  = array( 'existing_callable' => 'some_function' );
+		$callables = $this->sso->sync_sso_callables( $existing );
+
+		$this->assertArrayHasKey( 'existing_callable', $callables );
+		$this->assertArrayHasKey( 'sso_is_two_step_required', $callables );
+		$this->assertArrayHasKey( 'sso_should_hide_login_form', $callables );
+		$this->assertArrayHasKey( 'sso_match_by_email', $callables );
+		$this->assertArrayHasKey( 'sso_new_user_override', $callables );
+		$this->assertArrayHasKey( 'sso_bypass_default_login_form', $callables );
+	}
+
+	/**
+	 * Test that sync_sso_callables points to the correct Helpers methods.
+	 */
+	public function test_sync_sso_callables_references_helpers_methods() {
+		$callables = $this->sso->sync_sso_callables( array() );
+
+		$this->assertSame( array( Helpers::class, 'is_two_step_required' ), $callables['sso_is_two_step_required'] );
+		$this->assertSame( array( Helpers::class, 'should_hide_login_form' ), $callables['sso_should_hide_login_form'] );
+		$this->assertSame( array( Helpers::class, 'match_by_email' ), $callables['sso_match_by_email'] );
+		$this->assertSame( array( Helpers::class, 'new_user_override' ), $callables['sso_new_user_override'] );
+		$this->assertSame( array( Helpers::class, 'bypass_login_forward_wpcom' ), $callables['sso_bypass_default_login_form'] );
+	}
+
+	// ──────────────────────────────────────────────
+	// sso_reminder_logout_wpcom
+	// ──────────────────────────────────────────────
+
+	/**
+	 * Test that the logout reminder is added when the user logs out.
+	 */
+	public function test_sso_reminder_logout_wpcom_adds_message_on_loggedout() {
+		$errors = new WP_Error( 'loggedout', 'You are now logged out.' );
+		$result = $this->sso->sso_reminder_logout_wpcom( $errors );
+
+		$this->assertNotEmpty( $result->get_error_messages( 'jetpack-sso-show-logout' ) );
+		$this->assertStringContainsString( 'wordpress.com/me', $result->get_error_messages( 'jetpack-sso-show-logout' )[0] );
+	}
+
+	/**
+	 * Test that no reminder is added when no loggedout error exists.
+	 */
+	public function test_sso_reminder_logout_wpcom_no_message_without_loggedout() {
+		$errors = new WP_Error( 'invalid_username', 'Invalid username.' );
+		$result = $this->sso->sso_reminder_logout_wpcom( $errors );
+
+		$this->assertEmpty( $result->get_error_messages( 'jetpack-sso-show-logout' ) );
+	}
+
+	/**
+	 * Test that an empty WP_Error is returned unchanged.
+	 */
+	public function test_sso_reminder_logout_wpcom_returns_empty_errors_unchanged() {
+		$errors = new WP_Error();
+		$result = $this->sso->sso_reminder_logout_wpcom( $errors );
+
+		$this->assertEmpty( $result->get_error_codes() );
+	}
+
+	// ──────────────────────────────────────────────
+	// xmlrpc_methods
+	// ──────────────────────────────────────────────
+
+	/**
+	 * Test that xmlrpc_methods adds jetpack.userDisconnect.
+	 */
+	public function test_xmlrpc_methods_adds_user_disconnect() {
+		$methods = $this->sso->xmlrpc_methods( array() );
+		$this->assertArrayHasKey( 'jetpack.userDisconnect', $methods );
+	}
+
+	/**
+	 * Test that xmlrpc_methods preserves existing methods.
+	 */
+	public function test_xmlrpc_methods_preserves_existing() {
+		$methods = $this->sso->xmlrpc_methods( array( 'existing.method' => 'callback' ) );
+		$this->assertArrayHasKey( 'existing.method', $methods );
+		$this->assertArrayHasKey( 'jetpack.userDisconnect', $methods );
+	}
+
+	// ──────────────────────────────────────────────
+	// Validation methods
+	// ──────────────────────────────────────────────
+
+	/**
+	 * Test validate_jetpack_sso_require_two_step returns 1 for truthy value.
+	 */
+	public function test_validate_require_two_step_truthy() {
+		$this->assertSame( 1, $this->sso->validate_jetpack_sso_require_two_step( '1' ) );
+		$this->assertSame( 1, $this->sso->validate_jetpack_sso_require_two_step( 'yes' ) );
+		$this->assertSame( 1, $this->sso->validate_jetpack_sso_require_two_step( true ) );
+	}
+
+	/**
+	 * Test validate_jetpack_sso_require_two_step returns 0 for falsy value.
+	 */
+	public function test_validate_require_two_step_falsy() {
+		$this->assertSame( 0, $this->sso->validate_jetpack_sso_require_two_step( '' ) );
+		$this->assertSame( 0, $this->sso->validate_jetpack_sso_require_two_step( false ) );
+		$this->assertSame( 0, $this->sso->validate_jetpack_sso_require_two_step( null ) );
+		$this->assertSame( 0, $this->sso->validate_jetpack_sso_require_two_step( 0 ) );
+	}
+
+	/**
+	 * Test validate_jetpack_sso_match_by_email returns 1 for truthy value.
+	 */
+	public function test_validate_match_by_email_truthy() {
+		$this->assertSame( 1, $this->sso->validate_jetpack_sso_match_by_email( '1' ) );
+		$this->assertSame( 1, $this->sso->validate_jetpack_sso_match_by_email( 'yes' ) );
+		$this->assertSame( 1, $this->sso->validate_jetpack_sso_match_by_email( true ) );
+	}
+
+	/**
+	 * Test validate_jetpack_sso_match_by_email returns 0 for falsy value.
+	 */
+	public function test_validate_match_by_email_falsy() {
+		$this->assertSame( 0, $this->sso->validate_jetpack_sso_match_by_email( '' ) );
+		$this->assertSame( 0, $this->sso->validate_jetpack_sso_match_by_email( false ) );
+		$this->assertSame( 0, $this->sso->validate_jetpack_sso_match_by_email( null ) );
+		$this->assertSame( 0, $this->sso->validate_jetpack_sso_match_by_email( 0 ) );
+	}
+
+	// ──────────────────────────────────────────────
+	// login_body_class
+	// ──────────────────────────────────────────────
+
+	/**
+	 * Test that login_body_class leaves classes unchanged for non-SSO actions.
+	 */
+	public function test_login_body_class_unchanged_for_non_sso_action() {
+		global $action;
+		$action  = 'postpass';
+		$classes = $this->sso->login_body_class( array( 'existing' ) );
+
+		$this->assertSame( array( 'existing' ), $classes );
+	}
+
+	/**
+	 * Test that login_body_class adds jetpack-sso for login action.
+	 */
+	public function test_login_body_class_adds_jetpack_sso_for_login_action() {
+		global $action;
+		$action  = 'login';
+		$classes = $this->sso->login_body_class( array() );
+
+		$this->assertContains( 'jetpack-sso', $classes );
+	}
+
+	/**
+	 * Test that login_body_class adds jetpack-sso-form-display when SSO login is shown.
+	 */
+	public function test_login_body_class_adds_form_display_when_sso_shown() {
+		global $action;
+		$action  = 'login';
+		$classes = $this->sso->login_body_class( array() );
+
+		$this->assertContains( 'jetpack-sso', $classes );
+		$this->assertContains( 'jetpack-sso-form-display', $classes );
+	}
+
+	/**
+	 * Test that login_body_class does not add form-display when show-default-form param is set.
+	 */
+	public function test_login_body_class_no_form_display_when_default_form_requested() {
+		global $action;
+		$action                                = 'login';
+		$_GET['jetpack-sso-show-default-form'] = '1';
+		$classes                               = $this->sso->login_body_class( array() );
+
+		$this->assertContains( 'jetpack-sso', $classes );
+		$this->assertNotContains( 'jetpack-sso-form-display', $classes );
+
+		unset( $_GET['jetpack-sso-show-default-form'] );
+	}
+
+	// ──────────────────────────────────────────────
+	// profile_page_url
+	// ──────────────────────────────────────────────
+
+	/**
+	 * Test that profile_page_url returns the admin profile URL.
+	 */
+	public function test_profile_page_url() {
+		$url = SSO::profile_page_url();
+		$this->assertStringContainsString( 'profile.php', $url );
+	}
+
+	// ──────────────────────────────────────────────
+	// get_user_by_wpcom_id
+	// ──────────────────────────────────────────────
+
+	/**
+	 * Test get_user_by_wpcom_id returns null when no user found.
+	 */
+	public function test_get_user_by_wpcom_id_returns_null_when_not_found() {
+		$this->assertNull( SSO::get_user_by_wpcom_id( 99999 ) );
+	}
+
+	// ──────────────────────────────────────────────
+	// get_user_data / is_user_connected
+	// ──────────────────────────────────────────────
+
+	/**
+	 * Test get_user_data returns stored meta.
+	 */
+	public function test_get_user_data_returns_stored_meta() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'connected_user',
+				'user_email' => 'connected@example.com',
+				'user_pass'  => 'password123',
+			)
+		);
+
+		$wpcom_data = (object) array(
+			'ID'           => 999,
+			'display_name' => 'Connected User',
+			'email'        => 'connected@example.com',
+		);
+		update_user_meta( $user_id, 'wpcom_user_data', $wpcom_data );
+
+		$data = $this->sso->get_user_data( $user_id );
+		$this->assertEquals( $wpcom_data, $data );
+
+		wp_delete_user( $user_id );
+	}
+
+	/**
+	 * Test is_user_connected returns falsy when no data.
+	 */
+	public function test_is_user_connected_returns_falsy_when_no_data() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'disconnected_user',
+				'user_email' => 'disconnected@example.com',
+				'user_pass'  => 'password123',
+			)
+		);
+
+		$this->assertEmpty( $this->sso->is_user_connected( $user_id ) );
+
+		wp_delete_user( $user_id );
+	}
+
+	/**
+	 * Test is_user_connected returns truthy when data exists.
+	 */
+	public function test_is_user_connected_returns_truthy_when_data_exists() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'user_with_data',
+				'user_email' => 'withdata@example.com',
+				'user_pass'  => 'password123',
+			)
+		);
+
+		update_user_meta(
+			$user_id,
+			'wpcom_user_data',
+			(object) array(
+				'ID'    => 888,
+				'email' => 'withdata@example.com',
+			)
+		);
+
+		$this->assertNotEmpty( $this->sso->is_user_connected( $user_id ) );
+
+		wp_delete_user( $user_id );
+	}
+
+	// ──────────────────────────────────────────────
+	// build_sso_button_url
+	// ──────────────────────────────────────────────
+
+	/**
+	 * Test build_sso_button_url includes jetpack-sso action by default.
+	 */
+	public function test_build_sso_button_url_includes_action() {
+		$url = $this->sso->build_sso_button_url();
+		$this->assertStringContainsString( 'action=jetpack-sso', $url );
+	}
+
+	/**
+	 * Test build_sso_button_url includes custom arguments.
+	 */
+	public function test_build_sso_button_url_includes_custom_args() {
+		$url = $this->sso->build_sso_button_url( array( 'force_reauth' => '1' ) );
+		$this->assertStringContainsString( 'force_reauth=1', $url );
+		$this->assertStringContainsString( 'action=jetpack-sso', $url );
+	}
+
+	/**
+	 * Test build_sso_button_url includes redirect_to from GET param.
+	 */
+	public function test_build_sso_button_url_includes_redirect_to() {
+		$_GET['redirect_to'] = 'http://example.org/wp-admin/';
+		$url                 = $this->sso->build_sso_button_url();
+		$this->assertStringContainsString( 'redirect_to=', $url );
+	}
+
+	// ──────────────────────────────────────────────
+	// build_sso_button
+	// ──────────────────────────────────────────────
+
+	/**
+	 * Test build_sso_button returns HTML with a link.
+	 */
+	public function test_build_sso_button_returns_html_link() {
+		$button = $this->sso->build_sso_button();
+		$this->assertStringContainsString( '<a ', $button );
+		$this->assertStringContainsString( 'jetpack-sso', $button );
+		$this->assertStringContainsString( 'button', $button );
+	}
+
+	/**
+	 * Test build_sso_button with primary class.
+	 */
+	public function test_build_sso_button_primary_class() {
+		$button = $this->sso->build_sso_button( array(), true );
+		$this->assertStringContainsString( 'button-primary', $button );
+	}
+
+	/**
+	 * Test build_sso_button without primary class.
+	 */
+	public function test_build_sso_button_no_primary_class() {
+		$button = $this->sso->build_sso_button( array(), false );
+		$this->assertStringNotContainsString( 'button-primary', $button );
+	}
+
+	// ──────────────────────────────────────────────
+	// get_sso_base_url
+	// ──────────────────────────────────────────────
+
+	/**
+	 * Test get_sso_base_url returns WordPress.com by default.
+	 */
+	public function test_get_sso_base_url_returns_wpcom_by_default() {
+		$this->assertSame( 'https://wordpress.com/wp-login.php', SSO::get_sso_base_url() );
+	}
+
+	/**
+	 * Test get_sso_base_url returns broker URL when authorized.
+	 */
+	public function test_get_sso_base_url_returns_broker_url_when_authorized() {
+		$nonce                         = 'test_nonce_base';
+		$_COOKIE[ SSO::BROKER_COOKIE ] = $nonce;
+		$_COOKIE['jetpack_sso_nonce']  = $nonce;
+		Constants::set_constant( 'JETPACK_SSO_BROKER_URL', 'https://broker.example.com/sso' );
+
+		$this->assertSame( 'https://broker.example.com/sso', SSO::get_sso_base_url() );
+	}
+
+	/**
+	 * Test get_sso_base_url falls back to WordPress.com when referrer is WordPress.com.
+	 */
+	public function test_get_sso_base_url_falls_back_when_referrer_is_wpcom() {
+		$nonce                         = 'test_nonce_ref';
+		$_COOKIE[ SSO::BROKER_COOKIE ] = $nonce;
+		$_COOKIE['jetpack_sso_nonce']  = $nonce;
+		Constants::set_constant( 'JETPACK_SSO_BROKER_URL', 'https://broker.example.com/sso' );
+		$_SERVER['HTTP_REFERER'] = 'https://wordpress.com/sites/example.com';
+
+		$this->assertSame( 'https://wordpress.com/wp-login.php', SSO::get_sso_base_url() );
+	}
+
+	// ──────────────────────────────────────────────
+	// get_broker_url / get_broker_auth_url
+	// ──────────────────────────────────────────────
+
+	/**
+	 * Test get_broker_url returns false when not authorized.
+	 */
+	public function test_get_broker_url_returns_false_when_not_authorized() {
+		Constants::set_constant( 'JETPACK_SSO_BROKER_URL', 'https://broker.example.com/sso' );
+		$this->assertFalse( SSO::get_broker_url() );
+	}
+
+	/**
+	 * Test get_broker_url returns URL when authorized.
+	 */
+	public function test_get_broker_url_returns_url_when_authorized() {
+		$nonce                         = 'broker_nonce_1';
+		$_COOKIE[ SSO::BROKER_COOKIE ] = $nonce;
+		$_COOKIE['jetpack_sso_nonce']  = $nonce;
+		Constants::set_constant( 'JETPACK_SSO_BROKER_URL', 'https://broker.example.com/sso' );
+
+		$this->assertSame( 'https://broker.example.com/sso', SSO::get_broker_url() );
+	}
+
+	/**
+	 * Test get_broker_url returns false when cookies don't match.
+	 */
+	public function test_get_broker_url_returns_false_when_cookies_mismatch() {
+		$_COOKIE[ SSO::BROKER_COOKIE ] = 'nonce_a';
+		$_COOKIE['jetpack_sso_nonce']  = 'nonce_b';
+		Constants::set_constant( 'JETPACK_SSO_BROKER_URL', 'https://broker.example.com/sso' );
+
+		$this->assertFalse( SSO::get_broker_url() );
+	}
+
+	/**
+	 * Test get_broker_url returns false when constant is not set.
+	 */
+	public function test_get_broker_url_returns_false_when_no_constant() {
+		$nonce                         = 'broker_nonce_2';
+		$_COOKIE[ SSO::BROKER_COOKIE ] = $nonce;
+		$_COOKIE['jetpack_sso_nonce']  = $nonce;
+
+		$this->assertFalse( SSO::get_broker_url() );
+	}
+
+	/**
+	 * Test get_broker_auth_url returns false when not authorized.
+	 */
+	public function test_get_broker_auth_url_returns_false_when_not_authorized() {
+		Constants::set_constant( 'JETPACK_SSO_BROKER_AUTH_URL', 'https://broker-auth.example.com/auth' );
+		$this->assertFalse( SSO::get_broker_auth_url() );
+	}
+
+	/**
+	 * Test get_broker_auth_url returns URL when authorized.
+	 */
+	public function test_get_broker_auth_url_returns_url_when_authorized() {
+		$nonce                         = 'auth_nonce_1';
+		$_COOKIE[ SSO::BROKER_COOKIE ] = $nonce;
+		$_COOKIE['jetpack_sso_nonce']  = $nonce;
+		Constants::set_constant( 'JETPACK_SSO_BROKER_AUTH_URL', 'https://broker-auth.example.com/auth' );
+
+		$this->assertSame( 'https://broker-auth.example.com/auth', SSO::get_broker_auth_url() );
+	}
+
+	// ──────────────────────────────────────────────
+	// validate_broker_url (via public methods)
+	// ──────────────────────────────────────────────
+
+	/**
+	 * Test that broker URL validation rejects HTTP URLs.
+	 */
+	public function test_broker_url_rejects_http() {
+		$nonce                         = 'validate_nonce_1';
+		$_COOKIE[ SSO::BROKER_COOKIE ] = $nonce;
+		$_COOKIE['jetpack_sso_nonce']  = $nonce;
+		Constants::set_constant( 'JETPACK_SSO_BROKER_URL', 'http://insecure.example.com/sso' );
+
+		$this->assertFalse( SSO::get_broker_url() );
+	}
+
+	/**
+	 * Test that broker URL validation rejects empty strings.
+	 */
+	public function test_broker_url_rejects_empty_string() {
+		$nonce                         = 'validate_nonce_2';
+		$_COOKIE[ SSO::BROKER_COOKIE ] = $nonce;
+		$_COOKIE['jetpack_sso_nonce']  = $nonce;
+		Constants::set_constant( 'JETPACK_SSO_BROKER_URL', '' );
+
+		$this->assertFalse( SSO::get_broker_url() );
+	}
+
+	/**
+	 * Test that broker URL validation accepts valid HTTPS URLs.
+	 */
+	public function test_broker_url_accepts_valid_https() {
+		$nonce                         = 'validate_nonce_3';
+		$_COOKIE[ SSO::BROKER_COOKIE ] = $nonce;
+		$_COOKIE['jetpack_sso_nonce']  = $nonce;
+		Constants::set_constant( 'JETPACK_SSO_BROKER_URL', 'https://valid.example.com/path?query=1' );
+
+		$result = SSO::get_broker_url();
+		$this->assertNotFalse( $result );
+		$this->assertStringStartsWith( 'https://', $result );
+	}
+
+	// ──────────────────────────────────────────────
+	// BROKER_COOKIE constant
+	// ──────────────────────────────────────────────
+
+	/**
+	 * Test that BROKER_COOKIE constant is defined.
+	 */
+	public function test_broker_cookie_constant_defined() {
+		$this->assertSame( 'jetpack_sso_broker', SSO::BROKER_COOKIE );
+	}
+}

--- a/projects/packages/connection/tests/php/sso/SSO_Test.php
+++ b/projects/packages/connection/tests/php/sso/SSO_Test.php
@@ -41,6 +41,7 @@ class SSO_Test extends BaseTestCase {
 			$_COOKIE[ SSO::BROKER_COOKIE ],
 			$_COOKIE['jetpack_sso_nonce'],
 			$_GET['redirect_to'],
+			$_GET['jetpack-sso-show-default-form'],
 			$_SERVER['HTTP_REFERER'],
 			$GLOBALS['action']
 		);
@@ -236,8 +237,6 @@ class SSO_Test extends BaseTestCase {
 
 		$this->assertContains( 'jetpack-sso', $classes );
 		$this->assertNotContains( 'jetpack-sso-form-display', $classes );
-
-		unset( $_GET['jetpack-sso-show-default-form'] );
 	}
 
 	// ──────────────────────────────────────────────

--- a/projects/packages/connection/tests/php/sso/SSO_Test.php
+++ b/projects/packages/connection/tests/php/sso/SSO_Test.php
@@ -41,7 +41,8 @@ class SSO_Test extends BaseTestCase {
 			$_COOKIE[ SSO::BROKER_COOKIE ],
 			$_COOKIE['jetpack_sso_nonce'],
 			$_GET['redirect_to'],
-			$_SERVER['HTTP_REFERER']
+			$_SERVER['HTTP_REFERER'],
+			$GLOBALS['action']
 		);
 		parent::tear_down();
 	}

--- a/projects/packages/connection/tests/php/sso/SSO_Test.php
+++ b/projects/packages/connection/tests/php/sso/SSO_Test.php
@@ -29,7 +29,6 @@ class SSO_Test extends BaseTestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
-		$this->reset_sso_instance();
 		$this->sso = SSO::get_instance();
 	}
 
@@ -37,7 +36,6 @@ class SSO_Test extends BaseTestCase {
 	 * Tear down.
 	 */
 	public function tear_down() {
-		$this->reset_sso_instance();
 		Constants::clear_constants();
 		unset(
 			$_COOKIE[ SSO::BROKER_COOKIE ],
@@ -46,14 +44,6 @@ class SSO_Test extends BaseTestCase {
 			$_SERVER['HTTP_REFERER']
 		);
 		parent::tear_down();
-	}
-
-	/**
-	 * Reset the SSO singleton so each test starts fresh.
-	 */
-	private function reset_sso_instance() {
-		SSO::$instance = null;
-		$this->sso     = null;
 	}
 
 	// ──────────────────────────────────────────────
@@ -172,8 +162,6 @@ class SSO_Test extends BaseTestCase {
 	 * Test validate_jetpack_sso_require_two_step returns 1 for truthy value.
 	 */
 	public function test_validate_require_two_step_truthy() {
-		$this->assertSame( 1, $this->sso->validate_jetpack_sso_require_two_step( '1' ) );
-		$this->assertSame( 1, $this->sso->validate_jetpack_sso_require_two_step( 'yes' ) );
 		$this->assertSame( 1, $this->sso->validate_jetpack_sso_require_two_step( true ) );
 	}
 
@@ -181,18 +169,13 @@ class SSO_Test extends BaseTestCase {
 	 * Test validate_jetpack_sso_require_two_step returns 0 for falsy value.
 	 */
 	public function test_validate_require_two_step_falsy() {
-		$this->assertSame( 0, $this->sso->validate_jetpack_sso_require_two_step( '' ) );
 		$this->assertSame( 0, $this->sso->validate_jetpack_sso_require_two_step( false ) );
-		$this->assertSame( 0, $this->sso->validate_jetpack_sso_require_two_step( null ) );
-		$this->assertSame( 0, $this->sso->validate_jetpack_sso_require_two_step( 0 ) );
 	}
 
 	/**
 	 * Test validate_jetpack_sso_match_by_email returns 1 for truthy value.
 	 */
 	public function test_validate_match_by_email_truthy() {
-		$this->assertSame( 1, $this->sso->validate_jetpack_sso_match_by_email( '1' ) );
-		$this->assertSame( 1, $this->sso->validate_jetpack_sso_match_by_email( 'yes' ) );
 		$this->assertSame( 1, $this->sso->validate_jetpack_sso_match_by_email( true ) );
 	}
 
@@ -200,10 +183,7 @@ class SSO_Test extends BaseTestCase {
 	 * Test validate_jetpack_sso_match_by_email returns 0 for falsy value.
 	 */
 	public function test_validate_match_by_email_falsy() {
-		$this->assertSame( 0, $this->sso->validate_jetpack_sso_match_by_email( '' ) );
 		$this->assertSame( 0, $this->sso->validate_jetpack_sso_match_by_email( false ) );
-		$this->assertSame( 0, $this->sso->validate_jetpack_sso_match_by_email( null ) );
-		$this->assertSame( 0, $this->sso->validate_jetpack_sso_match_by_email( 0 ) );
 	}
 
 	// ──────────────────────────────────────────────

--- a/projects/packages/connection/tests/php/sso/SSO_Test.php
+++ b/projects/packages/connection/tests/php/sso/SSO_Test.php
@@ -40,6 +40,7 @@ class SSO_Test extends BaseTestCase {
 		unset(
 			$_COOKIE[ SSO::BROKER_COOKIE ],
 			$_COOKIE['jetpack_sso_nonce'],
+			$_COOKIE['jetpack_sso_wpcom_referrer'],
 			$_GET['redirect_to'],
 			$_GET['jetpack-sso-show-default-form'],
 			$_SERVER['HTTP_REFERER'],
@@ -418,7 +419,7 @@ class SSO_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test get_sso_base_url falls back to WordPress.com when referrer is WordPress.com.
+	 * Test get_sso_base_url falls back to WordPress.com when live referrer is WordPress.com.
 	 */
 	public function test_get_sso_base_url_falls_back_when_referrer_is_wpcom() {
 		$nonce                         = 'test_nonce_ref';
@@ -426,6 +427,19 @@ class SSO_Test extends BaseTestCase {
 		$_COOKIE['jetpack_sso_nonce']  = $nonce;
 		Constants::set_constant( 'JETPACK_SSO_BROKER_URL', 'https://broker.example.com/sso' );
 		$_SERVER['HTTP_REFERER'] = 'https://wordpress.com/sites/example.com';
+
+		$this->assertSame( 'https://wordpress.com/wp-login.php', SSO::get_sso_base_url() );
+	}
+
+	/**
+	 * Test get_sso_base_url falls back to WordPress.com when the referrer cookie is set.
+	 */
+	public function test_get_sso_base_url_falls_back_when_referrer_cookie_set() {
+		$nonce                                 = 'test_nonce_cookie_ref';
+		$_COOKIE[ SSO::BROKER_COOKIE ]         = $nonce;
+		$_COOKIE['jetpack_sso_nonce']          = $nonce;
+		$_COOKIE['jetpack_sso_wpcom_referrer'] = '1';
+		Constants::set_constant( 'JETPACK_SSO_BROKER_URL', 'https://broker.example.com/sso' );
 
 		$this->assertSame( 'https://wordpress.com/wp-login.php', SSO::get_sso_base_url() );
 	}


### PR DESCRIPTION
## Proposed changes

* Add support for external SSO broker URLs, allowing CIAB (Commerce in a Box) stores to route SSO authentication through a garden-specific broker (e.g., `my.woo.ai`) instead of directly to `wordpress.com/wp-login.php`.
* Broker URL resolution uses a two-part authorization model: WP.com signals broker mode via `use_sso_broker` in the `jetpack.sso.requestNonce` XML-RPC response (stored as a cookie tied to the nonce), and the actual URLs come from PHP constants (`JETPACK_SSO_BROKER_URL`, `JETPACK_SSO_BROKER_AUTH_URL`) defined by the garden MU plugin.
* Add a referrer-based check that falls back to the default `wordpress.com` SSO when the user navigated from a Calypso/WordPress.com domain, following the pattern established by `wpcomsh_bypass_jetpack_sso_login()`.
* For unconnected users who log in via broker SSO, redirect to the broker authorization URL (`JETPACK_SSO_BROKER_AUTH_URL`) instead of the default Jetpack authorization flow.
* Broker hosts are automatically added to `allowed_redirect_hosts` so `wp_safe_redirect()` permits the redirect.

### How it works

1. `request_initial_nonce()` calls the `jetpack.sso.requestNonce` XML-RPC endpoint. If WP.com returns `use_sso_broker: true`, a `jetpack_sso_broker` cookie is set with the nonce value.
2. `get_broker_url()` / `get_broker_auth_url()` check both the cookie signal and the MU plugin constant. Both must be present for broker mode to activate.
3. `get_sso_base_url()` uses the broker URL unless the HTTP referrer is a WordPress.com domain (in which case it falls back to `wordpress.com/wp-login.php`).

Related to CONNECT-191

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Load this PR on a test site and make sure regular SSO flow works as before.
* Actual garden site is hard to test at this point so that part requires only code review. Related to 206862-ghe-Automattic/wpcom