### PR TITLE
Forms: Remove temporary script deregistering on wp-build dashboard

### DIFF
--- a/projects/packages/forms/changelog/update-forms-wp-build-remove-default-scripts-re-add
+++ b/projects/packages/forms/changelog/update-forms-wp-build-remove-default-scripts-re-add
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Removed a temporary fix that was never in production
+
+

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -54,15 +54,6 @@ class Dashboard {
 
 			if ( file_exists( $wp_build_index ) ) {
 				require_once $wp_build_index;
-
-				// Re-add core's registration only when Gutenberg isn't providing it
-				if ( ! defined( 'IS_GUTENBERG_PLUGIN' ) || ! IS_GUTENBERG_PLUGIN ) {
-					// `wp-build` currently removes `wp_default_script_modules` from `wp_default_scripts`.
-					// Re-add the core hook so script modules work in vanilla wp-admin (no Gutenberg plugin).
-					if ( function_exists( 'wp_default_script_modules' ) ) {
-						add_action( 'wp_default_scripts', 'wp_default_script_modules', 0 );
-					}
-				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #

## Proposed changes
<!--- Explain what functional changes your PR includes -->
Removes temporary workaround to wp-build deregistering core's scripts without checking if Gutenberg was activated or not, as it was solved upstream: https://github.com/WordPress/gutenberg/pull/75909

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Go to the wp-build dashboard with Gutenberg deactivated
* Check that the dashboard loads as expected
