### PR TITLE
Try hacking around a possible PHP 8.4.19 bug in CI

### DIFF
--- a/.github/files/generate-ci-matrix.php
+++ b/.github/files/generate-ci-matrix.php
@@ -115,6 +115,13 @@ $matrix[] = array(
 	'timeout' => 40, // 2025-11-06: Successful runs seem to take ~15 minutes.
 );
 
+// Hack around a possible PHP 8.4.19 bug.
+foreach ( $matrix as $k => $v ) {
+	if ( $v['php'] === '8.4' ) {
+		$matrix[ $k ]['php'] = '8.4.18';
+	}
+}
+
 // END matrix definitions.
 // Now, validation.
 


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
CRM's codeception tests have been intermittently failing in the PHP 8.4 runs for a few days. This aligns with when CI started running with 8.4.19. Let's see if forcing 8.4.18 makes it go away?

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p1773764782485639/1773618372.849869-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
None

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* CI happy?