### PR TITLE
docs: Update PHP_CodeSniffer repository link

### DIFF
--- a/projects/packages/phpcs-filter/README.md
+++ b/projects/packages/phpcs-filter/README.md
@@ -117,4 +117,4 @@ This is applied before the filter runs, and so has no effect on a per-directory 
 This should be avoided, as it takes effect globally rather than being scoped to the directory.
 
 
-[PHP CodeSniffer]: https://github.com/squizlabs/PHP_CodeSniffer
+[PHP CodeSniffer]: https://github.com/PHPCSStandards/PHP_CodeSniffer

--- a/projects/packages/phpcs-filter/changelog/pr-47635
+++ b/projects/packages/phpcs-filter/changelog/pr-47635
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+Comment: README link update only, no user-facing changes.
+


### PR DESCRIPTION
## Proposed changes

Update PHP_CodeSniffer repository link as the PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is archived, and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Open `projects/packages/phpcs-filter/README.md`.
* Verify that the `[PHP CodeSniffer]` link at the bottom of the file points to `https://github.com/PHPCSStandards/PHP_CodeSniffer`.