### PR TITLE
AI Client: fix markdown-to-HTML paragraph renderer

### DIFF
--- a/projects/js-packages/ai-client/changelog/fix-redos-markdown-to-html
+++ b/projects/js-packages/ai-client/changelog/fix-redos-markdown-to-html
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Fix polynomial ReDoS vulnerability in markdown-to-HTML paragraph renderer.

--- a/projects/js-packages/ai-client/src/libs/markdown/markdown-to-html.ts
+++ b/projects/js-packages/ai-client/src/libs/markdown/markdown-to-html.ts
@@ -62,8 +62,16 @@ export const fixes: Fixes = {
 			return content;
 		}
 
-		// Fix encoding of <br /> tags
-		return content.replaceAll( '&lt;br /&gt;', '<br />' );
+		// Fix encoding of <br /> tags and trim surrounding whitespace.
+		// Uses split/join instead of regex to avoid polynomial ReDoS on long whitespace runs.
+		return content
+			.split( '&lt;br /&gt;' )
+			.map( ( s, i, arr ) => {
+				if ( i < arr.length - 1 ) s = s.trimEnd();
+				if ( i > 0 ) s = s.trimStart();
+				return s;
+			} )
+			.join( '<br />' );
 	},
 	table: ( content: string, extension = false, { hasFixedLayout = false } ) => {
 		if ( ! extension ) {

--- a/projects/js-packages/ai-client/src/libs/markdown/markdown-to-html.ts
+++ b/projects/js-packages/ai-client/src/libs/markdown/markdown-to-html.ts
@@ -63,7 +63,7 @@ export const fixes: Fixes = {
 		}
 
 		// Fix encoding of <br /> tags
-		return content.replaceAll( /\s*&lt;br \/&gt;\s*/g, '<br />' );
+		return content.replaceAll( '&lt;br /&gt;', '<br />' );
 	},
 	table: ( content: string, extension = false, { hasFixedLayout = false } ) => {
 		if ( ! extension ) {


### PR DESCRIPTION
## Proposed changes

* Replace the vulnerable regex `/\s*&lt;br \/&gt;\s*/g` with a plain `String.replaceAll()` call in the markdown-to-HTML paragraph renderer.
* This eliminates a polynomial ReDoS (Regular Expression Denial of Service) vulnerability flagged by CodeQL (CWE-1333, CWE-400).

### Other information
- [ ] Generate changelog entries for this PR (using AI).

The original regex had `\s*LITERAL\s*` structure which causes O(n²) backtracking on long whitespace inputs. A plain string replacement achieves the same HTML entity decoding without any regex engine involvement. The whitespace trimming the regex also performed is unnecessary since HTML rendering collapses whitespace.

## Related product discussion/links
p1773778370518299-slack-C052XEUUBL4

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* This is a security fix to a regex pattern. The functional behavior is preserved — `&lt;br /&gt;` is still decoded to `<br />` in AI-generated markdown content.
* Verify the AI assistant's paragraph rendering still correctly displays line breaks.