### PR TITLE
Site Launch Button: Add wp-admin ref parameter for redirecting back from Calypso

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/datsci-1163-redirect-users-back-to-wp-admin-after-completing-the-launch
+++ b/projects/packages/jetpack-mu-wpcom/changelog/datsci-1163-redirect-users-back-to-wp-admin-after-completing-the-launch
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Site Launch Button: Add wp-admin ref parameter for redirecting back from Calypso

--- a/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
@@ -62,7 +62,13 @@ function wpcom_add_launch_button_to_admin_bar( WP_Admin_Bar $admin_bar ) {
 			'parent' => null,
 			'group'  => null,
 			'title'  => '<span class="ab-icon">' . $icon . '</span><span class="ab-label">' . __( 'Launch site', 'jetpack-mu-wpcom' ) . '</span>',
-			'href'   => 'https://wordpress.com/start/launch-site?siteSlug=' . $blog_domain,
+			'href'   => add_query_arg(
+				array(
+					'siteSlug' => $blog_domain,
+					'ref'      => 'wp-admin',
+				),
+				'https://wordpress.com/start/launch-site'
+			),
 			'meta'   => array(
 				// Use `admin-color-modern` to keep the button always in blueberry (modern scheme).
 				'class' => 'launch-site admin-color-modern',


### PR DESCRIPTION
Part of DATSCI-1163.

## Proposed changes

Adds a ref parameter so Calypso knows to send the user back to WP Admin after launching the site.

## Related product discussion/links

See the linked issue's project overview.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Follow the instructions from https://github.com/Automattic/wp-calypso/pull/109340.