### PR TITLE
VideoPress: Migrate edit-video-details to unified header with breadcrumbs

### DIFF
--- a/projects/packages/videopress/changelog/update-normalize-videopress-edit-details-header
+++ b/projects/packages/videopress/changelog/update-normalize-videopress-edit-details-header
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Unify admin dashboard page header with admin-ui components

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
@@ -1,26 +1,25 @@
 import {
 	Text,
-	Button,
 	AdminPage,
 	AdminSection,
 	Container,
 	Col,
-	useBreakpointMatch,
-	JetpackVideoPressLogo,
+	JetpackLogo,
 	LoadingPlaceholder,
 } from '@automattic/jetpack-components';
 import { shouldUseInternalLinks } from '@automattic/jetpack-shared-extension-utils';
-import { SelectControl, RadioControl, CheckboxControl } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
 import {
-	Icon,
-	chevronRightSmall,
-	arrowLeft,
-	globe as siteDefaultPrivacyIcon,
-} from '@wordpress/icons';
+	Button,
+	SelectControl,
+	RadioControl,
+	CheckboxControl,
+	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Icon, globe as siteDefaultPrivacyIcon } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useEffect } from 'react';
-import { useNavigate, Link } from 'react-router';
+import { useNavigate } from 'react-router';
 import ChaptersLearnMoreHelper from '../../../components/chapters-learn-more-helper';
 import privatePrivacyIcon from '../../../components/icons/crossed-eye-icon';
 import publicPrivacyIcon from '../../../components/icons/uncrossed-eye-icon';
@@ -49,61 +48,6 @@ import type { JSX } from 'react';
 
 const noop = () => {
 	// noop
-};
-
-const Header = ( {
-	saveDisabled = true,
-	disabled = false,
-	onSaveChanges,
-	onDelete,
-	videoId,
-}: {
-	saveDisabled?: boolean;
-	disabled?: boolean;
-	onSaveChanges: () => void;
-	onDelete: () => void;
-	videoId: string | number;
-} ) => {
-	const [ isSm ] = useBreakpointMatch( 'sm' );
-	const navigate = useNavigate();
-
-	return (
-		<div className={ clsx( styles[ 'header-wrapper' ], { [ styles.small ]: isSm } ) }>
-			<button onClick={ () => navigate( '/' ) } className={ styles[ 'logo-button' ] }>
-				<JetpackVideoPressLogo />
-			</button>
-			<div className={ styles[ 'header-content' ] }>
-				<div className={ styles.breadcrumb }>
-					{ ! isSm && <Icon icon={ chevronRightSmall } /> }
-					<Text>{ __( 'Edit video details', 'jetpack-videopress-pkg' ) }</Text>
-				</div>
-				<div className={ styles.buttons }>
-					<Button
-						disabled={ saveDisabled || disabled }
-						onClick={ onSaveChanges }
-						isLoading={ disabled }
-					>
-						{ __( 'Save changes', 'jetpack-videopress-pkg' ) }
-					</Button>
-					<VideoDetailsActions videoId={ videoId } disabled={ disabled } onDelete={ onDelete } />
-				</div>
-			</div>
-		</div>
-	);
-};
-
-const GoBackLink = () => {
-	const { page } = useVideosQuery();
-	const to = page > 1 ? `/?page=${ page }` : '/';
-
-	return (
-		<div className={ styles[ 'back-link' ] }>
-			<Link to={ to } className={ styles.link }>
-				<Icon icon={ arrowLeft } className={ styles.icon } />
-				{ __( 'Go back', 'jetpack-videopress-pkg' ) }
-			</Link>
-		</div>
-	);
 };
 
 const Infos = ( {
@@ -265,6 +209,51 @@ const EditVideoDetails = () => {
 		height ? ` h=${ height }` : ''
 	}]`;
 
+	const backUrl = page > 1 ? `#/?page=${ page }` : '#/';
+
+	const breadcrumbs = (
+		<nav
+			aria-label={ __( 'Breadcrumbs', 'jetpack-videopress-pkg' ) }
+			className={ styles.breadcrumbs }
+		>
+			<HStack
+				as="ul"
+				className="admin-ui-breadcrumbs__list"
+				spacing={ 0 }
+				justify="flex-start"
+				alignment="center"
+			>
+				<li>
+					<a href={ backUrl } className={ styles[ 'breadcrumb-link' ] }>
+						<JetpackLogo showText={ false } height={ 20 } />
+						{ 'VideoPress' /** "VideoPress" is a product name, do not translate. */ }
+					</a>
+				</li>
+				<li>
+					<h1 className={ styles[ 'breadcrumb-current' ] }>
+						{ __( 'Edit video details', 'jetpack-videopress-pkg' ) }
+					</h1>
+				</li>
+			</HStack>
+		</nav>
+	);
+
+	const headerActions = [
+		<Button
+			variant="primary"
+			disabled={ ! hasChanges || isBusy || isFetchingData }
+			onClick={ handleSaveChanges }
+			isLoading={ isBusy || isFetchingData }
+		>
+			{ __( 'Save changes', 'jetpack-videopress-pkg' ) }
+		</Button>,
+		<VideoDetailsActions
+			videoId={ id }
+			disabled={ isBusy || isFetchingData }
+			onDelete={ handleDelete }
+		/>,
+	];
+
 	return (
 		<>
 			{ frameSelectorIsOpen && (
@@ -278,21 +267,16 @@ const EditVideoDetails = () => {
 			) }
 
 			<AdminPage
-				header={
-					<>
-						<div id="jp-admin-notices" className={ styles[ 'jetpack-videopress-jitm-card' ] } />
-						<GoBackLink />
-						<Header
-							onSaveChanges={ handleSaveChanges }
-							onDelete={ handleDelete }
-							saveDisabled={ ! hasChanges }
-							disabled={ isBusy || isFetchingData }
-							videoId={ id }
-						/>
-					</>
-				}
+				breadcrumbs={ breadcrumbs }
+				subTitle={ __( 'Professional quality, ad-free video hosting.', 'jetpack-videopress-pkg' ) }
+				actions={ headerActions }
 				useInternalLinks={ shouldUseInternalLinks() }
 			>
+				<Container horizontalSpacing={ 0 }>
+					<Col>
+						<div id="jp-admin-notices" className={ styles[ 'jetpack-videopress-jitm-card' ] } />
+					</Col>
+				</Container>
 				<AdminSection>
 					<Container horizontalSpacing={ 6 } horizontalGap={ 10 }>
 						<Col sm={ 4 } md={ 8 } lg={ 7 }>

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
@@ -243,6 +243,7 @@ const EditVideoDetails = () => {
 
 	const headerActions = [
 		<VideoDetailsActions
+			key="video-details-actions"
 			videoId={ id }
 			disabled={ isBusy || isFetchingData }
 			onDelete={ handleDelete }
@@ -287,7 +288,7 @@ const EditVideoDetails = () => {
 										variant="primary"
 										disabled={ ! hasChanges || isBusy || isFetchingData }
 										onClick={ handleSaveChanges }
-										isLoading={ isBusy || isFetchingData }
+										isBusy={ isBusy || isFetchingData }
 									>
 										{ __( 'Save changes', 'jetpack-videopress-pkg' ) }
 									</Button>

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
@@ -57,6 +57,7 @@ const Infos = ( {
 	onChangeDescription,
 	loading = false,
 	disabled = false,
+	actions,
 }: {
 	title: string;
 	onChangeTitle: ( value: string ) => void;
@@ -64,6 +65,7 @@ const Infos = ( {
 	onChangeDescription: ( value: string ) => void;
 	loading: boolean;
 	disabled: boolean;
+	actions?: React.ReactNode | React.ReactNode[];
 } ) => {
 	const { hasIncompleteChapters } = useChaptersLiveParsing( description );
 
@@ -109,6 +111,7 @@ const Infos = ( {
 					</div>
 				</>
 			) }
+			{ ! loading && actions && <div className={ styles.actions }>{ actions }</div> }
 		</>
 	);
 };
@@ -231,7 +234,7 @@ const EditVideoDetails = () => {
 				</li>
 				<li>
 					<h1 className={ styles[ 'breadcrumb-current' ] }>
-						{ __( 'Edit video details', 'jetpack-videopress-pkg' ) }
+						{ __( 'Edit', 'jetpack-videopress-pkg' ) }
 					</h1>
 				</li>
 			</HStack>
@@ -239,14 +242,6 @@ const EditVideoDetails = () => {
 	);
 
 	const headerActions = [
-		<Button
-			variant="primary"
-			disabled={ ! hasChanges || isBusy || isFetchingData }
-			onClick={ handleSaveChanges }
-			isLoading={ isBusy || isFetchingData }
-		>
-			{ __( 'Save changes', 'jetpack-videopress-pkg' ) }
-		</Button>,
 		<VideoDetailsActions
 			videoId={ id }
 			disabled={ isBusy || isFetchingData }
@@ -287,6 +282,16 @@ const EditVideoDetails = () => {
 								onChangeDescription={ setDescription }
 								loading={ isFetchingData }
 								disabled={ isBusy }
+								actions={
+									<Button
+										variant="primary"
+										disabled={ ! hasChanges || isBusy || isFetchingData }
+										onClick={ handleSaveChanges }
+										isLoading={ isBusy || isFetchingData }
+									>
+										{ __( 'Save changes', 'jetpack-videopress-pkg' ) }
+									</Button>
+								}
 							/>
 						</Col>
 						<Col sm={ 4 } md={ 8 } lg={ { start: 9, end: 12 } }>

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/style.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/style.module.scss
@@ -1,58 +1,39 @@
 
-.header-wrapper {
+.breadcrumbs :global(.admin-ui-breadcrumbs__list) {
+	min-height: auto;
 
-	&:not(.small) {
+	li {
 		display: flex;
 		align-items: center;
+		margin-bottom: 0;
 	}
+}
 
-	&.small .header-content {
-		align-items: flex-end;
-	}
+.breadcrumb-current {
+	display: inline;
+	font-size: inherit;
+	font-weight: inherit;
+	line-height: inherit;
+	margin: 0;
+}
 
-	.logo-button {
-		all: unset;
-		cursor: pointer;
-	}
+.breadcrumb-link {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	color: inherit;
+	text-decoration: none;
 
-	.header-content {
-		display: flex;
-		justify-content: space-between;
-		flex-grow: 1;
-	}
-
-	.breadcrumb {
-		display: flex;
-		gap: var(--spacing-base);
-		align-items: center;
-		color: var(--jp-gray-40);
-
-		&:not(.small) {
-			margin-left: var(--spacing-base);
-		}
+	&:hover,
+	&:focus,
+	&:active {
+		color: inherit;
+		text-decoration: underline;
 	}
 }
 
 .input {
 	margin-top: calc(var(--spacing-base) * 3); // 24px
-}
-
-.back-link {
-	display: flex;
-
-	.icon {
-		width: 16px;
-		margin-right: 4px;
-	}
-
-	.link {
-		margin-bottom: calc(var(--spacing-base) * 3);
-		font-size: 14px;
-		color: var(--jp-gray-70);
-		display: flex;
-		text-decoration: none;
-		align-items: center;
-	}
 }
 
 .side-fields {
@@ -128,14 +109,6 @@
 	}
 }
 
-.buttons {
-	display: flex;
-
-	> * + * {
-		margin-left: calc(var(--spacing-base) * 2); // 16px
-	}
-}
-
 // JITM
 :global {
 
@@ -146,9 +119,6 @@
 		}
 	}
 
-	#jetpack-videopress-root .jp-admin-page-header {
-		display: block;
-	}
 }
 
 .jetpack-videopress-jitm-card {

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/style.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/style.module.scss
@@ -50,6 +50,10 @@
 	margin-left: var(--spacing-base); // 8px
 }
 
+.actions {
+	margin-top: calc(var(--spacing-base) * 3); // 24px
+}
+
 .rating {
 
 	:global {

--- a/projects/packages/videopress/src/client/admin/components/video-details-actions/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-details-actions/index.tsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import { Button, ThemeProvider } from '@automattic/jetpack-components';
-import { Dropdown } from '@wordpress/components';
+import { ThemeProvider } from '@automattic/jetpack-components';
+import { Button, Dropdown } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { moreVertical, media, trash, download } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';

--- a/projects/packages/videopress/src/client/admin/components/video-details-actions/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-details-actions/index.tsx
@@ -60,8 +60,6 @@ const VideoDetailsActions = ( {
 					<ThemeProvider>
 						<div className={ styles.dropdown }>
 							<Button
-								weight="regular"
-								fullWidth
 								variant="tertiary"
 								icon={ media }
 								href={ newPostURL }
@@ -72,8 +70,6 @@ const VideoDetailsActions = ( {
 								{ __( 'Add to new post', 'jetpack-videopress-pkg' ) }
 							</Button>
 							<Button
-								weight="regular"
-								fullWidth
 								variant="tertiary"
 								icon={ download }
 								href={ url }
@@ -85,8 +81,6 @@ const VideoDetailsActions = ( {
 							</Button>
 							<hr className={ styles.separator } />
 							<Button
-								weight="regular"
-								fullWidth
 								variant="tertiary"
 								icon={ trash }
 								className={ styles.delete }

--- a/projects/packages/videopress/src/client/admin/components/video-details-actions/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-details-actions/index.tsx
@@ -48,6 +48,7 @@ const VideoDetailsActions = ( {
 				placement="bottom center"
 				renderToggle={ ( { isOpen, onToggle } ) => (
 					<Button
+						size="compact"
 						variant="tertiary"
 						disabled={ disabled }
 						icon={ moreVertical }

--- a/projects/packages/videopress/src/client/admin/components/video-details-actions/style.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/video-details-actions/style.module.scss
@@ -1,5 +1,11 @@
 .dropdown {
 
+	button,
+	a {
+		width: 100%;
+		justify-content: flex-start;
+	}
+
 	.separator {
 		margin: var(--spacing-base) 0;
 	}


### PR DESCRIPTION
## Proposed changes

Migrates the VideoPress **edit-video-details** page to the unified admin header pattern, replacing the custom `Header` and `GoBackLink` components with standard `AdminPage` breadcrumbs + actions.

This is a continuation of the admin page header normalization effort (#47313) and follows the same breadcrumbs pattern established in Boost's cache debug log page.

Before:
<img width="1120" height="303" alt="image" src="https://github.com/user-attachments/assets/df96f5d3-b255-4583-a48c-43c6c24a9640" />


After:
<img width="967" height="724" alt="image" src="https://github.com/user-attachments/assets/18bebb93-424a-4205-a62e-a2eb3f597cbd" />

<img width="367" height="714" alt="image" src="https://github.com/user-attachments/assets/fb54f7e8-e59f-435f-876c-697a418e160b" />




### Changes

* **Breadcrumbs navigation**: Replace custom `Header` (VideoPress wordmark logo + chevron + text) and `GoBackLink` (arrow + "Go back") with admin-ui breadcrumbs: Jetpack bolt icon + "VideoPress" link → "Edit" heading (shortened from "Edit video details" for better mobile fit)
* **Save button in content area**: Move the primary "Save changes" button from the header into the content area below the description fields, keeping only the kebab actions menu in the header
* **Compact action buttons**: Use `size="compact"` on the kebab menu button, consistent with #47679
* **Button consistency**: Switch `Button` from `@automattic/jetpack-components` to `@wordpress/components` (with `variant="primary"`) for consistent styling across admin pages — also applied to `VideoDetailsActions`
* **Subtitle**: Add the same "Professional quality, ad-free video hosting." tagline shown on the main VideoPress dashboard page
* **JITM placement**: Move `#jp-admin-notices` slot from above `AdminPage` into the page content area (inside `Container`/`Col`), following the pattern from #47558 by @vianasw
* **CSS cleanup**: Remove stale `.header-wrapper`, `.logo-button`, `.header-content`, `.breadcrumb`, `.back-link`, `.buttons` styles and the `.jp-admin-page-header` override

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* Part of the Jetpack admin page header normalization initiative
* Main PR: #47313
* JITM fix pattern: #47558
* Compact action buttons: #47679

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. Go to **Jetpack → VideoPress** (`wp-admin/admin.php?page=jetpack-videopress`)
2. Click **"Edit video details"** on any video
3. Verify the header shows:
   - Jetpack bolt icon + "VideoPress" (as a clickable breadcrumb link) / "Edit"
   - Subtitle: "Professional quality, ad-free video hosting."
   - Kebab (⋮) actions menu on the right (compact size)
4. Verify the "Save changes" button appears below the description field in the content area
5. Click the "VideoPress" breadcrumb link — should navigate back to the main dashboard (preserving pagination if applicable)
6. Verify the main VideoPress dashboard page still renders correctly with its unified header

### JITM testing (optional)
Add a fake JITM via mu-plugin (see #47558 for the snippet) and verify it renders below the header, not inside it.
