### PR TITLE
Charts: Remove redundant box-sizing from SvgEmptyState styles

### DIFF
--- a/projects/js-packages/charts/changelog/pr-47643
+++ b/projects/js-packages/charts/changelog/pr-47643
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Remove no-op CSS property. No user-facing change.
+
+

--- a/projects/js-packages/charts/src/charts/private/svg-empty-state/svg-empty-state.module.scss
+++ b/projects/js-packages/charts/src/charts/private/svg-empty-state/svg-empty-state.module.scss
@@ -4,5 +4,4 @@
 	height: 100%;
 	font-size: var(--wpds-font-size-md, 13px);
 	color: var(--wpds-color-fg-content-neutral-weak, #6d6d6d);
-	box-sizing: border-box;
 }


### PR DESCRIPTION
Fixes [CHARTS-188: Wrap empty-state text when all legends are hidden](https://linear.app/a8c/issue/CHARTS-188/wrap-empty-state-text-when-all-legends-are-hidden)

## Proposed changes

One commit was missing from the [previous PR](https://github.com/Automattic/jetpack/pull/47620):

* Remove `box-sizing: border-box` from `SvgEmptyState` styles — without padding on the element it has no effect. The padding was removed in a prior commit, leaving this as a no-op.

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* Linear: CHARTS-188

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* No visual change expected — this is a CSS no-op cleanup.
* Verify Storybook still renders the empty-state message correctly by navigating to **Pie Chart > With Legend**, enabling `legendInteractive`, and hiding all segments.

