### PR TITLE
Forms: Fix header spacing for wp-build dashboard on mobile viewport

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4181,8 +4181,8 @@ importers:
         specifier: ^1.9.0
         version: 1.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/boot':
-        specifier: ^0.7.1
-        version: 0.7.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1)
+        specifier: ^0.8.0
+        version: 0.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1)
       '@wordpress/icons':
         specifier: ^11.7.0
         version: 11.8.0(react@18.3.1)
@@ -10494,13 +10494,6 @@ packages:
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18.0.0
-
-  '@wordpress/boot@0.7.1':
-    resolution: {integrity: sha512-rfoPJiDYCt4odZBmc3CL2C8wL+uH6L9Jfg+udTBk6sLx81MSgRJlhAmcH6T8LO1vemrdsChk8Z84VBO428glAA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
 
   '@wordpress/boot@0.8.0':
     resolution: {integrity: sha512-vyjmPZXWC0FgoU27JO/8KVZVNLwELKgiSB6FO/DATy22zQBmOuqIBbGKhsf2MazPYpkwe+l5ozBp2hGgIX/ofg==}
@@ -24008,40 +24001,6 @@ snapshots:
       simple-html-tokenizer: 0.5.11
       uuid: 9.0.1(patch_hash=87a713b75995ed86c0ecd0cadfd1b9f85092ca16fdff7132ff98b62fc3cf2db0)
 
-  '@wordpress/boot@0.7.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1)':
-    dependencies:
-      '@wordpress/a11y': 4.41.0
-      '@wordpress/admin-ui': 1.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/base-styles': 6.17.0
-      '@wordpress/commands': 1.41.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/components': 32.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.41.0(react@18.3.1)
-      '@wordpress/core-data': 7.41.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1)
-      '@wordpress/data': 10.41.0(react@18.3.1)
-      '@wordpress/editor': 14.41.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1)
-      '@wordpress/element': 6.41.0
-      '@wordpress/html-entities': 4.41.0
-      '@wordpress/i18n': 6.14.0
-      '@wordpress/icons': 11.8.0(react@18.3.1)
-      '@wordpress/keyboard-shortcuts': 5.41.0(react@18.3.1)
-      '@wordpress/keycodes': 4.41.0
-      '@wordpress/lazy-editor': 1.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1)
-      '@wordpress/notices': 5.41.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/primitives': 4.41.0(react@18.3.1)
-      '@wordpress/private-apis': 1.41.0
-      '@wordpress/route': 0.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/theme': 0.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1)
-      '@wordpress/url': 4.41.0
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    transitivePeerDependencies:
-      - '@emotion/is-prop-valid'
-      - '@types/react'
-      - '@types/react-dom'
-      - stylelint
-      - supports-color
-
   '@wordpress/boot@0.8.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1)':
     dependencies:
       '@wordpress/a11y': 4.41.0
@@ -24060,6 +24019,40 @@ snapshots:
       '@wordpress/keyboard-shortcuts': 5.41.0(react@18.3.1)
       '@wordpress/keycodes': 4.41.0
       '@wordpress/lazy-editor': 1.7.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1)
+      '@wordpress/notices': 5.41.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/primitives': 4.41.0(react@18.3.1)
+      '@wordpress/private-apis': 1.41.0
+      '@wordpress/route': 0.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/theme': 0.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1)
+      '@wordpress/url': 4.41.0
+      clsx: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - stylelint
+      - supports-color
+
+  '@wordpress/boot@0.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1)':
+    dependencies:
+      '@wordpress/a11y': 4.41.0
+      '@wordpress/admin-ui': 1.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/base-styles': 6.17.0
+      '@wordpress/commands': 1.41.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/components': 32.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.41.0(react@18.3.1)
+      '@wordpress/core-data': 7.41.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1)
+      '@wordpress/data': 10.41.0(react@18.3.1)
+      '@wordpress/editor': 14.41.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1)
+      '@wordpress/element': 6.41.0
+      '@wordpress/html-entities': 4.41.0
+      '@wordpress/i18n': 6.14.0
+      '@wordpress/icons': 11.8.0(react@18.3.1)
+      '@wordpress/keyboard-shortcuts': 5.41.0(react@18.3.1)
+      '@wordpress/keycodes': 4.41.0
+      '@wordpress/lazy-editor': 1.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1)
       '@wordpress/notices': 5.41.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/primitives': 4.41.0(react@18.3.1)
       '@wordpress/private-apis': 1.41.0

--- a/projects/packages/forms/changelog/fix-forms-wp-build-header-spacing
+++ b/projects/packages/forms/changelog/fix-forms-wp-build-header-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix header spacing for wp-build dashboard on mobile viewport

--- a/projects/packages/forms/routes/shared.scss
+++ b/projects/packages/forms/routes/shared.scss
@@ -1,17 +1,6 @@
 @use "sass:meta";
 @include meta.load-css("@wordpress/dataviews/build-style/style.css");
 
-// Fix for sticky header on mobile in wp-admin
-// The entire page needs to account for the wp-admin bar
-// (46px on mobile, 32px on tablet+)
-.admin-ui-page {
-
-	@media (max-width: 782px) {
-		// On mobile, the admin bar is fixed, so the page needs to be below it
-		top: 46px;
-	}
-}
-
 .jp-forms-dataviews__view-actions {
 	// On small screens, switch to column-reverse stacking
 	@container (width < 500px) {

--- a/projects/packages/forms/src/dashboard/components/page/style.scss
+++ b/projects/packages/forms/src/dashboard/components/page/style.scss
@@ -35,12 +35,6 @@
 	flex-shrink: 0;
 	z-index: 10;
 	border-bottom: none;
-
-	@container (max-width: 430px) {
-		padding: variables.$grid-unit-15 variables.$grid-unit-30;
-		// Account for wp-admin bar on mobile (46px)
-		top: var(--wp-admin--admin-bar--height, 0);
-	}
 }
 
 .admin-ui-page__header-subtitle {

--- a/projects/packages/wp-build-polyfills/changelog/fix-forms-wp-build-header-spacing
+++ b/projects/packages/wp-build-polyfills/changelog/fix-forms-wp-build-header-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update @wordpress/boot version

--- a/projects/packages/wp-build-polyfills/package.json
+++ b/projects/packages/wp-build-polyfills/package.json
@@ -23,7 +23,7 @@
 		"@automattic/jetpack-webpack-config": "workspace:*",
 		"@wordpress/a11y": "^4.40.0",
 		"@wordpress/admin-ui": "^1.9.0",
-		"@wordpress/boot": "^0.7.1",
+		"@wordpress/boot": "^0.8.0",
 		"@wordpress/icons": "^11.7.0",
 		"@wordpress/lazy-editor": "^1.6.1",
 		"@wordpress/notices": "^5.40.0",


### PR DESCRIPTION
Part of FORMS-625

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Updates `@wordpress/boot` on the polyfills package to get the upstream fix when Gutenberg is not installed
* Removes local workarounds that were necessary before the upstream fix

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Activate Gutenberg
* Go to the forms dashboard
* Change the viewport to mobile
* Check that the header spacing is right
* Open a response modal
* Check that you can see the close button 
* Deactivate Gutenberg
* Repeat the tests

| Before | After |
| - | - |
| <img width="435" height="461" alt="image" src="https://github.com/user-attachments/assets/c9236361-f461-4390-867b-be653d9ab931" /> | <img width="435" height="461" alt="Screenshot from 2026-03-17 22-46-17" src="https://github.com/user-attachments/assets/ec769e67-d95e-4e61-a48c-ff43a9c39b4c" /> |