### PR TITLE
Forms Dashboard: Add tracking events for form-level actions

### DIFF
--- a/projects/packages/forms/changelog/add-form-dashboard-analytics
+++ b/projects/packages/forms/changelog/add-form-dashboard-analytics
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Forms Dashboard: Add tracking events for form-level actions (preview, copy embed, copy shortcode, duplicate, trash, restore, delete, rename, publish/unpublish, edit, view responses)

--- a/projects/packages/forms/routes/forms/package.json
+++ b/projects/packages/forms/routes/forms/package.json
@@ -3,6 +3,7 @@
 	"version": "1.0.0",
 	"private": true,
 	"dependencies": {
+		"@automattic/jetpack-analytics": "workspace:*",
 		"@automattic/jetpack-components": "workspace:*",
 		"@automattic/number-formatters": "workspace:*",
 		"@types/react": "18.3.28",

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { formatNumber } from '@automattic/number-formatters';
 import { Page } from '@wordpress/admin-ui';
 import {
@@ -327,6 +328,9 @@ function StageInner() {
 				label: __( 'Responses', 'jetpack-forms' ),
 				supportsBulk: false,
 				callback( items: FormListItem[] ) {
+					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_form_view_responses_click', {
+						source: 'forms_list',
+					} );
 					const [ item ] = items;
 					if ( ! item ) {
 						return;
@@ -343,6 +347,10 @@ function StageInner() {
 				label: __( 'Restore', 'jetpack-forms' ),
 				supportsBulk: true,
 				async callback( items: FormListItem[] ) {
+					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_form_restore_click', {
+						source: 'forms_list',
+						multiple: items.length > 1,
+					} );
 					if ( isDeleting ) {
 						return;
 					}
@@ -359,6 +367,10 @@ function StageInner() {
 				label: __( 'Delete permanently', 'jetpack-forms' ),
 				supportsBulk: true,
 				async callback( items: FormListItem[] ) {
+					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_form_delete_permanently_click', {
+						source: 'forms_list',
+						multiple: items.length > 1,
+					} );
 					if ( isDeleting ) {
 						return;
 					}
@@ -377,6 +389,9 @@ function StageInner() {
 			label: __( 'Edit', 'jetpack-forms' ),
 			supportsBulk: false,
 			async callback( items: FormListItem[] ) {
+				jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_form_edit_form_click', {
+					source: 'forms_list',
+				} );
 				const [ item ] = items;
 				if ( ! item ) {
 					return;
@@ -392,6 +407,9 @@ function StageInner() {
 			label: __( 'Preview', 'jetpack-forms' ),
 			supportsBulk: false,
 			async callback( items: FormListItem[] ) {
+				jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_form_preview_click', {
+					source: 'forms_list',
+				} );
 				const [ item ] = items;
 				if ( item ) {
 					await previewForm( item );
@@ -406,6 +424,9 @@ function StageInner() {
 				label: __( 'Copy embed', 'jetpack-forms' ),
 				supportsBulk: false,
 				async callback( items: FormListItem[] ) {
+					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_form_copy_embed_click', {
+						source: 'forms_list',
+					} );
 					const [ item ] = items;
 					if ( item ) {
 						await copyEmbed( item );
@@ -419,6 +440,9 @@ function StageInner() {
 				label: __( 'Copy shortcode', 'jetpack-forms' ),
 				supportsBulk: false,
 				async callback( items: FormListItem[] ) {
+					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_form_copy_shortcode_click', {
+						source: 'forms_list',
+					} );
 					const [ item ] = items;
 					if ( item ) {
 						await copyShortcode( item );
@@ -441,6 +465,10 @@ function StageInner() {
 			isEligible: ( item: FormListItem ) => item.status !== 'publish',
 			supportsBulk: true,
 			async callback( items: FormListItem[] ) {
+				jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_form_publish_click', {
+					source: 'forms_list',
+					multiple: items.length > 1,
+				} );
 				if ( isDeleting || isUpdatingStatus ) {
 					return;
 				}
@@ -463,6 +491,10 @@ function StageInner() {
 			isEligible: ( item: FormListItem ) => item.status === 'publish',
 			supportsBulk: true,
 			async callback( items: FormListItem[] ) {
+				jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_form_unpublish_click', {
+					source: 'forms_list',
+					multiple: items.length > 1,
+				} );
 				if ( isDeleting || isUpdatingStatus ) {
 					return;
 				}
@@ -484,6 +516,9 @@ function StageInner() {
 			label: __( 'Rename', 'jetpack-forms' ),
 			supportsBulk: false,
 			callback( items: FormListItem[] ) {
+				jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_form_rename_click', {
+					source: 'forms_list',
+				} );
 				const [ item ] = items;
 				if ( ! item ) {
 					return;
@@ -498,6 +533,9 @@ function StageInner() {
 			label: __( 'Duplicate', 'jetpack-forms' ),
 			supportsBulk: false,
 			async callback( items: FormListItem[] ) {
+				jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_form_duplicate_click', {
+					source: 'forms_list',
+				} );
 				const [ item ] = items;
 				if ( item ) {
 					await duplicateForm( item );
@@ -511,6 +549,10 @@ function StageInner() {
 			label: __( 'Trash', 'jetpack-forms' ),
 			supportsBulk: true,
 			async callback( items: FormListItem[] ) {
+				jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_form_trash_click', {
+					source: 'forms_list',
+					multiple: items.length > 1,
+				} );
 				if ( isDeleting ) {
 					return;
 				}

--- a/projects/packages/forms/src/dashboard/components/edit-form-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/edit-form-button/index.tsx
@@ -12,21 +12,27 @@ import { getFormEditUrl } from '../../utils.ts';
 
 type EditFormButtonProps = {
 	formId: number;
+	onClick?: () => void;
 };
 
 /**
  * Button that navigates to edit the given `jetpack_form`.
  *
- * @param props        - Props.
- * @param props.formId - Form (post) ID.
+ * @param props         - Props.
+ * @param props.formId  - Form (post) ID.
+ * @param props.onClick - Optional callback fired before navigation.
  * @return JSX element.
  */
-export default function EditFormButton( { formId }: EditFormButtonProps ): JSX.Element {
+export default function EditFormButton( {
+	formId,
+	onClick: onClickProp,
+}: EditFormButtonProps ): JSX.Element {
 	const adminUrl = ( useConfigValue( 'adminUrl' ) as string ) || '';
 
 	const onClick = useCallback( () => {
+		onClickProp?.();
 		window.location.href = getFormEditUrl( formId, adminUrl );
-	}, [ adminUrl, formId ] );
+	}, [ adminUrl, formId, onClickProp ] );
 
 	return (
 		<Button size="compact" variant="secondary" onClick={ onClick }>

--- a/projects/packages/forms/src/dashboard/components/export-responses/button.tsx
+++ b/projects/packages/forms/src/dashboard/components/export-responses/button.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { Button } from '@wordpress/components';
+import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { download } from '@wordpress/icons';
 /**
@@ -16,9 +17,11 @@ import './style.scss';
 const ExportResponsesButton = ( {
 	isPrimary = false,
 	showIcon = true,
+	onClick: onClickProp,
 }: {
 	isPrimary?: boolean;
 	showIcon?: boolean;
+	onClick?: () => void;
 } ) => {
 	const {
 		showExportModal,
@@ -34,6 +37,11 @@ const ExportResponsesButton = ( {
 	const isEmpty = isLoadingData || totalItems === 0;
 	const isDisabled = isEmpty || userCanExport === false;
 
+	const handleClick = useCallback( () => {
+		onClickProp?.();
+		openModal();
+	}, [ onClickProp, openModal ] );
+
 	if ( userCanExport === false ) {
 		return null;
 	}
@@ -44,7 +52,7 @@ const ExportResponsesButton = ( {
 				size="compact"
 				variant={ isPrimary ? 'primary' : 'secondary' }
 				icon={ showIcon ? download : undefined }
-				onClick={ openModal }
+				onClick={ handleClick }
 				accessibleWhenDisabled
 				disabled={ isDisabled }
 				label={ isEmpty ? __( 'Nothing to export.', 'jetpack-forms' ) : '' }

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { JetpackLogo } from '@automattic/jetpack-components';
 import apiFetch from '@wordpress/api-fetch';
 import {
@@ -225,9 +224,6 @@ export default function FormsDashboardForms(): JSX.Element | null {
 				label: __( 'View responses', 'jetpack-forms' ),
 				supportsBulk: false,
 				callback( items: FormListItem[] ) {
-					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_form_view_responses_click', {
-						source: 'forms_list',
-					} );
 					const [ item ] = items;
 					if ( ! item ) {
 						return;
@@ -241,9 +237,6 @@ export default function FormsDashboardForms(): JSX.Element | null {
 				label: __( 'Edit', 'jetpack-forms' ),
 				supportsBulk: false,
 				async callback( items: FormListItem[] ) {
-					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_form_edit_form_click', {
-						source: 'forms_list',
-					} );
 					const [ item ] = items;
 					if ( ! item ) {
 						return;
@@ -258,9 +251,6 @@ export default function FormsDashboardForms(): JSX.Element | null {
 				label: __( 'Preview', 'jetpack-forms' ),
 				supportsBulk: false,
 				async callback( items: FormListItem[] ) {
-					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_form_preview_click', {
-						source: 'forms_list',
-					} );
 					const [ item ] = items;
 					if ( ! item ) {
 						return;
@@ -287,9 +277,6 @@ export default function FormsDashboardForms(): JSX.Element | null {
 				label: __( 'Copy embed', 'jetpack-forms' ),
 				supportsBulk: false,
 				async callback( items: FormListItem[] ) {
-					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_form_copy_embed_click', {
-						source: 'forms_list',
-					} );
 					const [ item ] = items;
 					if ( ! item ) {
 						return;
@@ -315,9 +302,6 @@ export default function FormsDashboardForms(): JSX.Element | null {
 				label: __( 'Copy shortcode', 'jetpack-forms' ),
 				supportsBulk: false,
 				async callback( items: FormListItem[] ) {
-					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_form_copy_shortcode_click', {
-						source: 'forms_list',
-					} );
 					const [ item ] = items;
 					if ( ! item ) {
 						return;
@@ -346,10 +330,6 @@ export default function FormsDashboardForms(): JSX.Element | null {
 				label: __( 'Restore', 'jetpack-forms' ),
 				supportsBulk: true,
 				async callback( items: FormListItem[] ) {
-					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_form_restore_click', {
-						source: 'forms_list',
-						multiple: items.length > 1,
-					} );
 					if ( isDeleting ) {
 						return;
 					}
@@ -366,10 +346,6 @@ export default function FormsDashboardForms(): JSX.Element | null {
 				label: __( 'Delete permanently', 'jetpack-forms' ),
 				supportsBulk: true,
 				async callback( items: FormListItem[] ) {
-					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_form_delete_permanently_click', {
-						source: 'forms_list',
-						multiple: items.length > 1,
-					} );
 					if ( isDeleting ) {
 						return;
 					}
@@ -388,10 +364,6 @@ export default function FormsDashboardForms(): JSX.Element | null {
 			label: __( 'Trash', 'jetpack-forms' ),
 			supportsBulk: true,
 			async callback( items: FormListItem[] ) {
-				jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_form_trash_click', {
-					source: 'forms_list',
-					multiple: items.length > 1,
-				} );
 				if ( isDeleting ) {
 					return;
 				}

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { JetpackLogo } from '@automattic/jetpack-components';
 import apiFetch from '@wordpress/api-fetch';
 import {
@@ -224,6 +225,9 @@ export default function FormsDashboardForms(): JSX.Element | null {
 				label: __( 'View responses', 'jetpack-forms' ),
 				supportsBulk: false,
 				callback( items: FormListItem[] ) {
+					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_action_view_responses_click', {
+						source: 'forms_list',
+					} );
 					const [ item ] = items;
 					if ( ! item ) {
 						return;
@@ -237,6 +241,9 @@ export default function FormsDashboardForms(): JSX.Element | null {
 				label: __( 'Edit', 'jetpack-forms' ),
 				supportsBulk: false,
 				async callback( items: FormListItem[] ) {
+					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_action_edit_form_click', {
+						source: 'forms_list',
+					} );
 					const [ item ] = items;
 					if ( ! item ) {
 						return;
@@ -251,6 +258,9 @@ export default function FormsDashboardForms(): JSX.Element | null {
 				label: __( 'Preview', 'jetpack-forms' ),
 				supportsBulk: false,
 				async callback( items: FormListItem[] ) {
+					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_action_preview_click', {
+						source: 'forms_list',
+					} );
 					const [ item ] = items;
 					if ( ! item ) {
 						return;
@@ -277,6 +287,9 @@ export default function FormsDashboardForms(): JSX.Element | null {
 				label: __( 'Copy embed', 'jetpack-forms' ),
 				supportsBulk: false,
 				async callback( items: FormListItem[] ) {
+					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_action_copy_embed_click', {
+						source: 'forms_list',
+					} );
 					const [ item ] = items;
 					if ( ! item ) {
 						return;
@@ -302,6 +315,9 @@ export default function FormsDashboardForms(): JSX.Element | null {
 				label: __( 'Copy shortcode', 'jetpack-forms' ),
 				supportsBulk: false,
 				async callback( items: FormListItem[] ) {
+					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_action_copy_shortcode_click', {
+						source: 'forms_list',
+					} );
 					const [ item ] = items;
 					if ( ! item ) {
 						return;
@@ -330,6 +346,10 @@ export default function FormsDashboardForms(): JSX.Element | null {
 				label: __( 'Restore', 'jetpack-forms' ),
 				supportsBulk: true,
 				async callback( items: FormListItem[] ) {
+					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_action_restore_click', {
+						source: 'forms_list',
+						multiple: items.length > 1,
+					} );
 					if ( isDeleting ) {
 						return;
 					}
@@ -346,6 +366,10 @@ export default function FormsDashboardForms(): JSX.Element | null {
 				label: __( 'Delete permanently', 'jetpack-forms' ),
 				supportsBulk: true,
 				async callback( items: FormListItem[] ) {
+					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_action_delete_permanently_click', {
+						source: 'forms_list',
+						multiple: items.length > 1,
+					} );
 					if ( isDeleting ) {
 						return;
 					}
@@ -364,6 +388,10 @@ export default function FormsDashboardForms(): JSX.Element | null {
 			label: __( 'Trash', 'jetpack-forms' ),
 			supportsBulk: true,
 			async callback( items: FormListItem[] ) {
+				jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_action_trash_click', {
+					source: 'forms_list',
+					multiple: items.length > 1,
+				} );
 				if ( isDeleting ) {
 					return;
 				}

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -225,7 +225,7 @@ export default function FormsDashboardForms(): JSX.Element | null {
 				label: __( 'View responses', 'jetpack-forms' ),
 				supportsBulk: false,
 				callback( items: FormListItem[] ) {
-					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_action_view_responses_click', {
+					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_form_view_responses_click', {
 						source: 'forms_list',
 					} );
 					const [ item ] = items;
@@ -241,7 +241,7 @@ export default function FormsDashboardForms(): JSX.Element | null {
 				label: __( 'Edit', 'jetpack-forms' ),
 				supportsBulk: false,
 				async callback( items: FormListItem[] ) {
-					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_action_edit_form_click', {
+					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_form_edit_form_click', {
 						source: 'forms_list',
 					} );
 					const [ item ] = items;
@@ -258,7 +258,7 @@ export default function FormsDashboardForms(): JSX.Element | null {
 				label: __( 'Preview', 'jetpack-forms' ),
 				supportsBulk: false,
 				async callback( items: FormListItem[] ) {
-					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_action_preview_click', {
+					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_form_preview_click', {
 						source: 'forms_list',
 					} );
 					const [ item ] = items;
@@ -287,7 +287,7 @@ export default function FormsDashboardForms(): JSX.Element | null {
 				label: __( 'Copy embed', 'jetpack-forms' ),
 				supportsBulk: false,
 				async callback( items: FormListItem[] ) {
-					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_action_copy_embed_click', {
+					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_form_copy_embed_click', {
 						source: 'forms_list',
 					} );
 					const [ item ] = items;
@@ -315,7 +315,7 @@ export default function FormsDashboardForms(): JSX.Element | null {
 				label: __( 'Copy shortcode', 'jetpack-forms' ),
 				supportsBulk: false,
 				async callback( items: FormListItem[] ) {
-					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_action_copy_shortcode_click', {
+					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_form_copy_shortcode_click', {
 						source: 'forms_list',
 					} );
 					const [ item ] = items;
@@ -346,7 +346,7 @@ export default function FormsDashboardForms(): JSX.Element | null {
 				label: __( 'Restore', 'jetpack-forms' ),
 				supportsBulk: true,
 				async callback( items: FormListItem[] ) {
-					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_action_restore_click', {
+					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_form_restore_click', {
 						source: 'forms_list',
 						multiple: items.length > 1,
 					} );
@@ -366,7 +366,7 @@ export default function FormsDashboardForms(): JSX.Element | null {
 				label: __( 'Delete permanently', 'jetpack-forms' ),
 				supportsBulk: true,
 				async callback( items: FormListItem[] ) {
-					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_action_delete_permanently_click', {
+					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_form_delete_permanently_click', {
 						source: 'forms_list',
 						multiple: items.length > 1,
 					} );
@@ -388,7 +388,7 @@ export default function FormsDashboardForms(): JSX.Element | null {
 			label: __( 'Trash', 'jetpack-forms' ),
 			supportsBulk: true,
 			async callback( items: FormListItem[] ) {
-				jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_action_trash_click', {
+				jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_form_trash_click', {
 					source: 'forms_list',
 					multiple: items.length > 1,
 				} );

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { useBreakpointMatch } from '@automattic/jetpack-components';
 import JetpackLogo from '@automattic/jetpack-components/jetpack-logo';
 import { Breadcrumbs } from '@wordpress/admin-ui';
@@ -388,15 +389,27 @@ export default function usePageHeaderDetails(
 
 		const formItem = { id: sourceIdNumber, title: formTitle };
 
+		const trackAction = ( eventName: string ) => {
+			jetpackAnalytics.tracks.recordEvent( eventName, {
+				source: 'form_header',
+			} );
+		};
+
 		if ( formRecord?.status === 'trash' ) {
 			return [
 				{
 					title: __( 'Restore', 'jetpack-forms' ),
-					onClick: () => restoreForm( formItem ),
+					onClick: () => {
+						trackAction( 'jetpack_forms_action_restore_click' );
+						restoreForm( formItem );
+					},
 				},
 				{
 					title: __( 'Delete permanently', 'jetpack-forms' ),
-					onClick: () => openPermanentDeleteConfirm( formItem ),
+					onClick: () => {
+						trackAction( 'jetpack_forms_action_delete_permanently_click' );
+						openPermanentDeleteConfirm( formItem );
+					},
 				},
 			];
 		}
@@ -404,7 +417,10 @@ export default function usePageHeaderDetails(
 		const controls: Array< { title: string; onClick: () => void } > = [
 			{
 				title: __( 'Preview', 'jetpack-forms' ),
-				onClick: () => previewForm( formItem ),
+				onClick: () => {
+					trackAction( 'jetpack_forms_action_preview_click' );
+					previewForm( formItem );
+				},
 			},
 		];
 
@@ -412,11 +428,17 @@ export default function usePageHeaderDetails(
 			controls.push(
 				{
 					title: __( 'Copy embed', 'jetpack-forms' ),
-					onClick: () => copyEmbed( formItem ),
+					onClick: () => {
+						trackAction( 'jetpack_forms_action_copy_embed_click' );
+						copyEmbed( formItem );
+					},
 				},
 				{
 					title: __( 'Copy shortcode', 'jetpack-forms' ),
-					onClick: () => copyShortcode( formItem ),
+					onClick: () => {
+						trackAction( 'jetpack_forms_action_copy_shortcode_click' );
+						copyShortcode( formItem );
+					},
 				}
 			);
 		}
@@ -426,6 +448,7 @@ export default function usePageHeaderDetails(
 				title: __( 'Unpublish', 'jetpack-forms' ),
 				onClick: () => {
 					if ( ! isUpdatingStatus ) {
+						trackAction( 'jetpack_forms_action_unpublish_click' );
 						setFormsToDraft( [ formItem ] );
 					}
 				},
@@ -435,6 +458,7 @@ export default function usePageHeaderDetails(
 				title: __( 'Publish', 'jetpack-forms' ),
 				onClick: () => {
 					if ( ! isUpdatingStatus ) {
+						trackAction( 'jetpack_forms_action_publish_click' );
 						publishForms( [ formItem ] );
 					}
 				},
@@ -444,15 +468,24 @@ export default function usePageHeaderDetails(
 		controls.push(
 			{
 				title: __( 'Rename', 'jetpack-forms' ),
-				onClick: () => setRenameFormItem( formItem ),
+				onClick: () => {
+					trackAction( 'jetpack_forms_action_rename_click' );
+					setRenameFormItem( formItem );
+				},
 			},
 			{
 				title: __( 'Duplicate', 'jetpack-forms' ),
-				onClick: () => duplicateForm( formItem ),
+				onClick: () => {
+					trackAction( 'jetpack_forms_action_duplicate_click' );
+					duplicateForm( formItem );
+				},
 			},
 			{
 				title: __( 'Trash', 'jetpack-forms' ),
-				onClick: () => trashForm( formItem ),
+				onClick: () => {
+					trackAction( 'jetpack_forms_action_trash_click' );
+					trashForm( formItem );
+				},
 			}
 		);
 

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -382,18 +382,18 @@ export default function usePageHeaderDetails(
 		isUpdatingStatus,
 	} = useFormItemActions();
 
+	const trackAction = useCallback( ( eventName: string ) => {
+		jetpackAnalytics.tracks.recordEvent( eventName, {
+			source: 'form_header',
+		} );
+	}, [] );
+
 	const formItemControls = useMemo( () => {
 		if ( ! sourceIdNumber ) {
 			return [];
 		}
 
 		const formItem = { id: sourceIdNumber, title: formTitle };
-
-		const trackAction = ( eventName: string ) => {
-			jetpackAnalytics.tracks.recordEvent( eventName, {
-				source: 'form_header',
-			} );
-		};
 
 		if ( formRecord?.status === 'trash' ) {
 			return [
@@ -504,6 +504,7 @@ export default function usePageHeaderDetails(
 		previewForm,
 		setFormsToDraft,
 		sourceIdNumber,
+		trackAction,
 	] );
 
 	const WrapWithJetpackLogo = ( { children }: { children: ReactNode } ) => (
@@ -905,6 +906,7 @@ export default function usePageHeaderDetails(
 		closePermanentDeleteConfirm,
 		confirmPermanentDelete,
 		formStatus,
+		trackAction,
 	] );
 
 	return { ariaLabel, breadcrumbs, title, badges, subtitle, actions };

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -400,14 +400,14 @@ export default function usePageHeaderDetails(
 				{
 					title: __( 'Restore', 'jetpack-forms' ),
 					onClick: () => {
-						trackAction( 'jetpack_forms_action_restore_click' );
+						trackAction( 'jetpack_forms_form_restore_click' );
 						restoreForm( formItem );
 					},
 				},
 				{
 					title: __( 'Delete permanently', 'jetpack-forms' ),
 					onClick: () => {
-						trackAction( 'jetpack_forms_action_delete_permanently_click' );
+						trackAction( 'jetpack_forms_form_delete_permanently_click' );
 						openPermanentDeleteConfirm( formItem );
 					},
 				},
@@ -418,7 +418,7 @@ export default function usePageHeaderDetails(
 			{
 				title: __( 'Preview', 'jetpack-forms' ),
 				onClick: () => {
-					trackAction( 'jetpack_forms_action_preview_click' );
+					trackAction( 'jetpack_forms_form_preview_click' );
 					previewForm( formItem );
 				},
 			},
@@ -429,14 +429,14 @@ export default function usePageHeaderDetails(
 				{
 					title: __( 'Copy embed', 'jetpack-forms' ),
 					onClick: () => {
-						trackAction( 'jetpack_forms_action_copy_embed_click' );
+						trackAction( 'jetpack_forms_form_copy_embed_click' );
 						copyEmbed( formItem );
 					},
 				},
 				{
 					title: __( 'Copy shortcode', 'jetpack-forms' ),
 					onClick: () => {
-						trackAction( 'jetpack_forms_action_copy_shortcode_click' );
+						trackAction( 'jetpack_forms_form_copy_shortcode_click' );
 						copyShortcode( formItem );
 					},
 				}
@@ -448,7 +448,7 @@ export default function usePageHeaderDetails(
 				title: __( 'Unpublish', 'jetpack-forms' ),
 				onClick: () => {
 					if ( ! isUpdatingStatus ) {
-						trackAction( 'jetpack_forms_action_unpublish_click' );
+						trackAction( 'jetpack_forms_form_unpublish_click' );
 						setFormsToDraft( [ formItem ] );
 					}
 				},
@@ -458,7 +458,7 @@ export default function usePageHeaderDetails(
 				title: __( 'Publish', 'jetpack-forms' ),
 				onClick: () => {
 					if ( ! isUpdatingStatus ) {
-						trackAction( 'jetpack_forms_action_publish_click' );
+						trackAction( 'jetpack_forms_form_publish_click' );
 						publishForms( [ formItem ] );
 					}
 				},
@@ -469,21 +469,21 @@ export default function usePageHeaderDetails(
 			{
 				title: __( 'Rename', 'jetpack-forms' ),
 				onClick: () => {
-					trackAction( 'jetpack_forms_action_rename_click' );
+					trackAction( 'jetpack_forms_form_rename_click' );
 					setRenameFormItem( formItem );
 				},
 			},
 			{
 				title: __( 'Duplicate', 'jetpack-forms' ),
 				onClick: () => {
-					trackAction( 'jetpack_forms_action_duplicate_click' );
+					trackAction( 'jetpack_forms_form_duplicate_click' );
 					duplicateForm( formItem );
 				},
 			},
 			{
 				title: __( 'Trash', 'jetpack-forms' ),
 				onClick: () => {
-					trackAction( 'jetpack_forms_action_trash_click' );
+					trackAction( 'jetpack_forms_form_trash_click' );
 					trashForm( formItem );
 				},
 			}

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -382,9 +382,9 @@ export default function usePageHeaderDetails(
 		isUpdatingStatus,
 	} = useFormItemActions();
 
-	const trackAction = useCallback( ( eventName: string ) => {
+	const trackAction = useCallback( ( eventName: string, source = 'form_header' ) => {
 		jetpackAnalytics.tracks.recordEvent( eventName, {
-			source: 'form_header',
+			source,
 		} );
 	}, [] );
 
@@ -578,6 +578,19 @@ export default function usePageHeaderDetails(
 		return __( 'View and manage all your form responses in one place.', 'jetpack-forms' );
 	}, [ formTitle, isFormsScreen, isSingleFormScreen, onOpenFormsHelp, hasClassicForms ] );
 
+	const trackEditFormClick = useCallback(
+		() => trackAction( 'jetpack_forms_form_edit_form_click' ),
+		[ trackAction ]
+	);
+	const trackExportClick = useCallback(
+		() => trackAction( 'jetpack_forms_form_export_click' ),
+		[ trackAction ]
+	);
+	const trackExportClickResponsesList = useCallback(
+		() => trackAction( 'jetpack_forms_form_export_click', 'responses_list' ),
+		[ trackAction ]
+	);
+
 	const actions = useMemo( () => {
 		// Mobile: show dropdown menu with actions
 		if ( isSm ) {
@@ -651,7 +664,7 @@ export default function usePageHeaderDetails(
 
 				dropdownControls.push( {
 					onClick: () => {
-						trackAction( 'jetpack_forms_form_export_click' );
+						trackAction( 'jetpack_forms_form_export_click', 'responses_list' );
 						openExportModal();
 					},
 					title: exportLabel,
@@ -783,12 +796,19 @@ export default function usePageHeaderDetails(
 		if ( isSingleFormScreen ) {
 			return [
 				...( sourceIdNumber && formStatus !== 'trash'
-					? [ <EditFormButton key="edit-form" formId={ sourceIdNumber } /> ]
+					? [
+							<EditFormButton
+								key="edit-form"
+								formId={ sourceIdNumber }
+								onClick={ trackEditFormClick }
+							/>,
+					  ]
 					: [] ),
 				<ExportResponsesButton
 					key="export"
 					isPrimary={ statusView === 'inbox' }
 					showIcon={ false }
+					onClick={ trackExportClick }
 				/>,
 				...( statusView === 'trash' ? [ <EmptyTrashButton key="empty-trash" /> ] : [] ),
 				...( statusView === 'spam' ? [ <EmptySpamButton key="empty-spam" /> ] : [] ),
@@ -857,6 +877,7 @@ export default function usePageHeaderDetails(
 				key="export"
 				isPrimary={ statusView === 'inbox' }
 				showIcon={ false }
+				onClick={ trackExportClickResponsesList }
 			/>,
 			...( statusView === 'trash' ? [ <EmptyTrashButton key="empty-trash" /> ] : [] ),
 			...( statusView === 'spam' ? [ <EmptySpamButton key="empty-spam" /> ] : [] ),
@@ -907,6 +928,9 @@ export default function usePageHeaderDetails(
 		confirmPermanentDelete,
 		formStatus,
 		trackAction,
+		trackEditFormClick,
+		trackExportClick,
+		trackExportClickResponsesList,
 	] );
 
 	return { ariaLabel, breadcrumbs, title, badges, subtitle, actions };

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -600,13 +600,17 @@ export default function usePageHeaderDetails(
 				if ( statusView === 'inbox' && sourceIdNumber ) {
 					dropdownControls.push( {
 						onClick: () => {
+							trackAction( 'jetpack_forms_form_edit_form_click' );
 							window.location.href = getFormEditUrl( sourceIdNumber, adminUrl );
 						},
 						title: __( 'Edit form', 'jetpack-forms' ),
 					} );
 				}
 				dropdownControls.push( {
-					onClick: openExportModal,
+					onClick: () => {
+						trackAction( 'jetpack_forms_form_export_click' );
+						openExportModal();
+					},
 					title: exportLabel,
 					isDisabled: ! hasResponses,
 				} );
@@ -645,7 +649,10 @@ export default function usePageHeaderDetails(
 				}
 
 				dropdownControls.push( {
-					onClick: openExportModal,
+					onClick: () => {
+						trackAction( 'jetpack_forms_form_export_click' );
+						openExportModal();
+					},
 					title: exportLabel,
 					isDisabled: ! hasResponses,
 				} );


### PR DESCRIPTION
Fixes FORMS-634


## Proposed changes

* Add unique analytics tracking events for all form-level actions in the Forms dashboard
* Track actions from both the DataViews forms list (`routes/forms/stage.tsx`) and the header dropdown (`use-page-header-details.tsx`)
* Each event uses a distinct, searchable name following the pattern `jetpack_forms_form_{action}_click`
* The `form` prefix distinguishes these from future response-level action events
* All events include a `source` property (`forms_list` or `form_header`) to distinguish where the action was triggered
* Bulk-capable actions include a `multiple` property

### Events added

| Event Name | Sources |
|---|---|
| `jetpack_forms_form_view_responses_click` | forms_list |
| `jetpack_forms_form_edit_form_click` | forms_list, form_header |
| `jetpack_forms_form_preview_click` | forms_list, form_header |
| `jetpack_forms_form_copy_embed_click` | forms_list, form_header |
| `jetpack_forms_form_copy_shortcode_click` | forms_list, form_header |
| `jetpack_forms_form_export_click` | form_header |
| `jetpack_forms_form_publish_click` | forms_list, form_header |
| `jetpack_forms_form_unpublish_click` | forms_list, form_header |
| `jetpack_forms_form_rename_click` | forms_list, form_header |
| `jetpack_forms_form_duplicate_click` | forms_list, form_header |
| `jetpack_forms_form_trash_click` | forms_list, form_header |
| `jetpack_forms_form_restore_click` | forms_list, form_header |
| `jetpack_forms_form_delete_permanently_click` | forms_list, form_header |

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
Yes — this PR adds new Tracks analytics events for form-level actions in the dashboard. These events track which action the user performed and where it was triggered (forms list vs. form header dropdown). No PII is collected; only action names and source context are recorded.

## Testing instructions

* Go to the Jetpack Forms dashboard (wp-admin → Jetpack → Forms)
* Open browser dev tools, go to the Network tab, and filter by "tracks" or "pixel"
* **Forms list (DataViews):**
  1. Click the actions menu on any form row
  2. Test each action: View responses, Edit, Preview, Copy embed, Copy shortcode, Publish/Unpublish, Rename, Duplicate, Trash
  3. Verify each fires its corresponding `jetpack_forms_form_*_click` event with `source: forms_list`
  4. Select multiple forms and use bulk Trash — verify `multiple: true`
  5. Switch to Trash view and test Restore and Delete permanently
* **Single form header dropdown:**
  1. Navigate to a form's responses view
  2. Click the "..." dropdown menu in the header
  3. Test each action: Edit form, Preview, Copy embed, Copy shortcode, Export, Publish/Unpublish, Rename, Duplicate, Trash
  4. Verify each fires its corresponding event with `source: form_header`