### PR TITLE
Forms: Add tracking events for form editor interactions

### DIFF
--- a/projects/packages/forms/changelog/add-form-editor-events
+++ b/projects/packages/forms/changelog/add-form-editor-events
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add tracking event for form conversion to synced (toolbar, AI generation, field auto-wrap)

--- a/projects/packages/forms/src/blocks/contact-form/components/convert-form-toolbar.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/convert-form-toolbar.tsx
@@ -3,6 +3,7 @@
  * Provides toolbar buttons to convert forms to synced mode and edit synced forms
  */
 
+import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { ToolbarGroup, ToolbarButton } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -98,6 +99,11 @@ export function ConvertFormToolbar( {
 				formTitle,
 				currentPostId
 			);
+
+			jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_convert_to_synced', {
+				source: 'toolbar',
+				editor_context: editorContext,
+			} );
 
 			// Clear block and set ref to the new form
 			replaceInnerBlocks( clientId, [], false );

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -1,6 +1,7 @@
 /*
  * External dependencies
  */
+import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { ThemeProvider } from '@automattic/jetpack-components';
 import { useModuleStatus, hasFeatureFlag } from '@automattic/jetpack-shared-extension-utils';
 import {
@@ -849,6 +850,8 @@ function JetpackContactFormEdit( {
 			setActiveStep( clientId, stepContainer.innerBlocks[ 0 ].clientId );
 		}
 
+		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_convert_to_multistep' );
+
 		// Ensure we are marked as multistep – this records the undo level.
 		if ( variationName !== 'multistep' ) {
 			setAttributes( { variationName: 'multistep' } );
@@ -953,6 +956,7 @@ function JetpackContactFormEdit( {
 			setAttributes( { variationName: 'default-empty' } );
 		}
 
+		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_convert_to_standard' );
 		formTransitionStateRef.current = FormTransitionState.IS_FORM;
 	}, [
 		variationName,

--- a/projects/packages/forms/src/blocks/contact-form/plugins/ai-form-generation.ts
+++ b/projects/packages/forms/src/blocks/contact-form/plugins/ai-form-generation.ts
@@ -14,6 +14,7 @@
  * - The hook callback only runs when AI actually generates content
  */
 
+import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { select, dispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
@@ -81,6 +82,11 @@ export async function handleAiGenerationComplete(
 		if ( ! updatedBlock || updatedBlock.attributes?.ref ) {
 			return;
 		}
+
+		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_convert_to_synced', {
+			source: 'ai_generation',
+			editor_context: 'post',
+		} );
 
 		// Set the ref attribute to link to the synced form.
 		dispatch( blockEditorStore ).updateBlockAttributes( clientId, { ref: formId } );

--- a/projects/packages/forms/src/blocks/contact-form/variation-picker.js
+++ b/projects/packages/forms/src/blocks/contact-form/variation-picker.js
@@ -1,3 +1,4 @@
+import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { hasFeatureFlag } from '@automattic/jetpack-shared-extension-utils';
 import {
 	__experimentalBlockVariationPicker as BlockVariationPicker, // eslint-disable-line @wordpress/no-unsafe-wp-apis
@@ -128,6 +129,10 @@ export default function VariationPicker( { blockName, setAttributes, clientId, c
 				instructions={ getInstructions() }
 				variations={ variations.filter( v => ! v.hiddenFromPicker ) }
 				onSelect={ async ( nextVariation = defaultVariation ) => {
+					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_variation_selected', {
+						variation: nextVariation.name,
+					} );
+
 					// If we're editing a jetpack-form post directly, or central form management
 					// is disabled, use the "old" behavior: apply the variation directly to this
 					// block by setting attributes and inner blocks, without creating a synced

--- a/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
+++ b/projects/packages/forms/src/blocks/shared/hooks/use-form-wrapper.js
@@ -1,3 +1,4 @@
+import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { createBlock, getBlockType } from '@wordpress/blocks';
 import { store as coreStore } from '@wordpress/core-data';
@@ -7,6 +8,7 @@ import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import useConfigValue from '../../../hooks/use-config-value.ts';
 import { createSyncedForm } from '../../contact-form/util/create-synced-form.ts';
+import { getEditorContext } from '../../contact-form/util/get-editor-context.ts';
 import { FORM_BLOCK_NAME, FORM_POST_TYPE, VERTICAL_LAYOUT } from '../util/constants.js';
 
 /**
@@ -60,6 +62,11 @@ export async function convertFormToSynced(
 		formTitle,
 		currentPostId
 	);
+
+	jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_convert_to_synced', {
+		source: 'field_auto_wrap',
+		editor_context: getEditorContext(),
+	} );
 
 	// Preload the entity record into the cache BEFORE setting ref.
 	// This ensures the form component won't show a loading skeleton

--- a/projects/packages/forms/src/dashboard/hooks/use-delete-form.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-delete-form.ts
@@ -1,3 +1,4 @@
+import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { useDispatch } from '@wordpress/data';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
@@ -114,6 +115,12 @@ export default function useDeleteForm( {
 			const failedCount = promises.length - restoredCount;
 
 			if ( restoredCount ) {
+				items.slice( 0, restoredCount ).forEach( () => {
+					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_form_status_change', {
+						new_status: 'draft',
+						action: 'restore',
+					} );
+				} );
 				const successMessage =
 					restoredCount === 1
 						? __( 'Form restored as draft.', 'jetpack-forms' )
@@ -267,6 +274,12 @@ export default function useDeleteForm( {
 				const failedCount = items.length - trashedCount;
 
 				if ( trashedCount ) {
+					trashedItems.forEach( () => {
+						jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_form_status_change', {
+							new_status: 'trash',
+							action: 'trash',
+						} );
+					} );
 					const successMessage =
 						trashedCount === 1
 							? __( 'Form moved to trash.', 'jetpack-forms' )
@@ -384,6 +397,12 @@ export default function useDeleteForm( {
 			const failedCount = promises.length - deletedCount;
 
 			if ( deletedCount ) {
+				permanentDeleteItems.slice( 0, deletedCount ).forEach( () => {
+					jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_form_status_change', {
+						new_status: 'trash',
+						action: 'delete_permanently',
+					} );
+				} );
 				const successMessage =
 					deletedCount === 1
 						? __( 'Form deleted permanently.', 'jetpack-forms' )

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-duplicate-form.ts
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-duplicate-form.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { resolveSelect, useDispatch } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
@@ -108,6 +109,8 @@ export default function useDuplicateForm(): UseDuplicateFormReturn {
 					} );
 					return;
 				}
+
+				jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_form_duplicated' );
 
 				createSuccessNotice( __( 'Form duplicated.', 'jetpack-forms' ), {
 					type: 'snackbar',

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-form-item-actions.ts
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-form-item-actions.ts
@@ -1,3 +1,4 @@
+import jetpackAnalytics from '@automattic/jetpack-analytics';
 /**
  * WordPress dependencies
  */
@@ -76,6 +77,9 @@ export default function useFormItemActions(): UseFormItemActionsReturn {
 			const embedCode = `<!-- wp:jetpack/contact-form {"ref":${ item.id }} /-->`;
 			try {
 				await navigator.clipboard.writeText( embedCode );
+				jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_copy_embed', {
+					type: 'embed',
+				} );
 				createSuccessNotice( __( 'Embed code copied to clipboard.', 'jetpack-forms' ), {
 					type: 'snackbar',
 				} );
@@ -93,6 +97,9 @@ export default function useFormItemActions(): UseFormItemActionsReturn {
 			const shortcode = `[contact-form ref="${ item.id }"]`;
 			try {
 				await navigator.clipboard.writeText( shortcode );
+				jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_copy_embed', {
+					type: 'shortcode',
+				} );
 				createSuccessNotice( __( 'Shortcode copied to clipboard.', 'jetpack-forms' ), {
 					type: 'snackbar',
 				} );
@@ -147,6 +154,14 @@ export default function useFormItemActions(): UseFormItemActionsReturn {
 				const failedCount = promises.length - updatedCount;
 
 				if ( updatedCount ) {
+					items.forEach( ( item, index ) => {
+						if ( promises[ index ]?.status === 'fulfilled' ) {
+							jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_form_status_change', {
+								new_status: nextStatus,
+								action: nextStatus === 'publish' ? 'publish' : 'unpublish',
+							} );
+						}
+					} );
 					const message =
 						nextStatus === 'publish'
 							? sprintf(


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add `jetpack_forms_convert_to_synced` tracking event when a form is converted from inline to synced mode (toolbar, AI generation, field auto-wrap)
* Add `jetpack_forms_variation_selected` tracking event when a form variation is selected from the picker
* Add `jetpack_forms_convert_to_multistep` and `jetpack_forms_convert_to_standard` tracking events for multi-step form conversions
* Add `jetpack_forms_form_duplicated` tracking event when a form is duplicated from the dashboard
* Add `jetpack_forms_form_status_change` tracking event for publish, unpublish, trash, restore, and permanent delete actions
* Add `jetpack_forms_copy_embed` tracking event when embed code or shortcode is copied from the dashboard

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
Yes — this PR adds several new Tracks events for form editor interactions:

| Event | Properties |
|-------|-----------|
| `jetpack_forms_convert_to_synced` | `source` (`toolbar`/`ai_generation`/`field_auto_wrap`), `editor_context` (`post`/`site`/`widget`) |
| `jetpack_forms_variation_selected` | `variation` (slug) |
| `jetpack_forms_convert_to_multistep` | — |
| `jetpack_forms_convert_to_standard` | — |
| `jetpack_forms_form_duplicated` | — |
| `jetpack_forms_form_status_change` | `new_status` (`publish`/`draft`/`trash`), `action` (`publish`/`unpublish`/`trash`/`restore`/`delete_permanently`) |
| `jetpack_forms_copy_embed` | `type` (`embed`/`shortcode`) |

## Testing instructions

### Form conversion (toolbar)
1. Open a post with an inline form block, click "Edit Form" toolbar button
2. Verify `jetpack_forms_convert_to_synced` fires with `source: 'toolbar'`

### Form conversion (AI)
1. Use AI Assistant to generate a form
2. Verify event fires with `source: 'ai_generation'`

### Form conversion (field auto-wrap)
1. Insert a standalone field block (e.g., Name field) into a post
2. Verify event fires with `source: 'field_auto_wrap'`

### Variation selection
1. Insert a new Contact Form block → variation picker appears
2. Select any variation → verify `jetpack_forms_variation_selected` fires with correct `variation` value

### Multi-step conversion
1. Create a form, convert to multi-step → verify `jetpack_forms_convert_to_multistep` fires
2. Convert back to standard → verify `jetpack_forms_convert_to_standard` fires

### Form duplication
1. Go to Forms dashboard, duplicate a form → verify `jetpack_forms_form_duplicated` fires

### Status changes
1. Publish a draft form → verify `jetpack_forms_form_status_change` fires with `action: 'publish'`
2. Unpublish → `action: 'unpublish'`
3. Trash → `action: 'trash'`
4. Restore from trash → `action: 'restore'`
5. Permanently delete → `action: 'delete_permanently'`

### Embed/shortcode copy
1. From Forms dashboard, use "Copy embed code" → verify `jetpack_forms_copy_embed` fires with `type: 'embed'`
2. Use "Copy shortcode" → verify with `type: 'shortcode'`
