### PR TITLE
Forms: Fix default wp-build dashboard URL leading to 404

### DIFF
--- a/projects/packages/forms/changelog/fix-form-view-responses-link
+++ b/projects/packages/forms/changelog/fix-form-view-responses-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix default wp-build dashboard URL to point to /responses/inbox instead of / which caused a 404

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -534,7 +534,7 @@ class Dashboard {
 			return '/responses/inbox?responseIds=["' . $post_id . '"]';
 		}
 
-		return '/';
+		return '/responses/inbox';
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
+++ b/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
@@ -109,7 +109,7 @@ class Dashboard_Test extends BaseTestCase {
 	 */
 	public function test_get_forms_admin_url_wp_build_without_tab() {
 		add_filter( 'jetpack_forms_alpha', '__return_true' );
-		$expected = get_admin_url() . 'admin.php?page=' . Dashboard::FORMS_WPBUILD_ADMIN_SLUG . '&p=%2F';
+		$expected = get_admin_url() . 'admin.php?page=' . Dashboard::FORMS_WPBUILD_ADMIN_SLUG . '&p=' . rawurlencode( '/responses/inbox' );
 		$this->assertEquals( $expected, Dashboard::get_forms_admin_url() );
 		remove_filter( 'jetpack_forms_alpha', '__return_true' );
 	}


### PR DESCRIPTION
Fixes the issue where the links to the form responses would take the user to a 404 page. Route not found. 

## Proposed changes

* Fix the default wp-build dashboard URL path from `/` to `/responses/inbox`
* The previous default produced `p=%2F` in the URL, which leads to a 404 page
* This affects all callers of `get_forms_admin_url()` without a tab argument, including the admin bar "Form Responses" link and the Google Drive integration "View form responses" link

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. Enable the wp-build forms dashboard (`jetpack_forms_alpha` filter returning true)
2. Navigate to any page with a Jetpack form
3. Click the "Form Responses" link in the admin bar (masterbar)
4. Verify it navigates to the responses inbox page instead of a 404
5. Also verify the Google Drive integration "View form responses" link works correctly from the block editor integrations modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)
