### PR TITLE
Forms: Remove greeting text from email notifications

### DIFF
--- a/projects/packages/forms/changelog/remove-email-greeting-text
+++ b/projects/packages/forms/changelog/remove-email-greeting-text
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove greeting text from form response notification emails.

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -114,9 +114,9 @@ class Feedback_Email_Renderer {
 		 *
 		 * @param string the title of the email
 		 */
-		$default_email_title = '';
-		$title               = (string) apply_filters( 'jetpack_forms_response_email_title', $default_email_title );
-		$message             = self::get_compiled_form_for_email( $post_id, $form );
+		$title   = (string) apply_filters( 'jetpack_forms_response_email_title', '' );
+		$title   = ! empty( $title ) ? sprintf( '<h1 class="email-header">%s</h1>', $title ) : '';
+		$message = self::get_compiled_form_for_email( $post_id, $form );
 
 		if ( is_user_logged_in() ) {
 			$sent_by_text = sprintf(

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -105,17 +105,17 @@ class Feedback_Email_Renderer {
 		$is_spam              = $context_data['is_spam'];
 		$feedback_status      = $context_data['feedback_status'];
 
-		/**
-		 * Filter the title used in the response email.
-		 *
-		 * @module contact-form
-		 *
-		 * @since 0.18.0
-		 *
-		 * @param string the title of the email
-		 */
-		$default_email_title = __( 'Hey, a new form response just came in!', 'jetpack-forms' );
-		$title               = (string) apply_filters( 'jetpack_forms_response_email_title', $default_email_title );
+	/**
+	 * Filter the title used in the response email.
+	 *
+	 * @module contact-form
+	 *
+	 * @since 0.18.0
+	 *
+	 * @param string the title of the email
+	 */
+	$default_email_title = '';
+	$title               = (string) apply_filters( 'jetpack_forms_response_email_title', $default_email_title );
 		$message             = self::get_compiled_form_for_email( $post_id, $form );
 
 		if ( is_user_logged_in() ) {

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -115,7 +115,7 @@ class Feedback_Email_Renderer {
 		 * @param string the title of the email
 		 */
 		$title   = (string) apply_filters( 'jetpack_forms_response_email_title', '' );
-		$title   = ! empty( $title ) ? sprintf( '<h1 class="email-header">%s</h1>', $title ) : '';
+		$title   = ! empty( $title ) ? sprintf( '<h1 class="email-header">%s</h1>', esc_html( $title ) ) : '';
 		$message = self::get_compiled_form_for_email( $post_id, $form );
 
 		if ( is_user_logged_in() ) {
@@ -616,7 +616,7 @@ class Feedback_Email_Renderer {
 				'',
 				$template
 			),
-			esc_html( $title ),
+			$title,
 			$body,
 			'',
 			'',

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -105,17 +105,17 @@ class Feedback_Email_Renderer {
 		$is_spam              = $context_data['is_spam'];
 		$feedback_status      = $context_data['feedback_status'];
 
-	/**
-	 * Filter the title used in the response email.
-	 *
-	 * @module contact-form
-	 *
-	 * @since 0.18.0
-	 *
-	 * @param string the title of the email
-	 */
-	$default_email_title = '';
-	$title               = (string) apply_filters( 'jetpack_forms_response_email_title', $default_email_title );
+		/**
+		 * Filter the title used in the response email.
+		 *
+		 * @module contact-form
+		 *
+		 * @since 0.18.0
+		 *
+		 * @param string the title of the email
+		 */
+		$default_email_title = '';
+		$title               = (string) apply_filters( 'jetpack_forms_response_email_title', $default_email_title );
 		$message             = self::get_compiled_form_for_email( $post_id, $form );
 
 		if ( is_user_logged_in() ) {

--- a/projects/packages/forms/src/contact-form/templates/email-response.php
+++ b/projects/packages/forms/src/contact-form/templates/email-response.php
@@ -3,7 +3,7 @@
  * Jetpack Forms Email Response Template
  *
  * The template contains several placeholders:
- * %1$s is the hero text to display above the response (e.g., "Hey, a new form response just came in!")
+ * %1$s is the hero text to display above the response (can be empty or filtered)
  * %2$s is the response itself (form fields HTML).
  * %3$s was a link to the response page in wp-admin (left empty for backwards compatibility)
  * %4$s was a link to the embedded form to allow the site owner to edit it to change their email address (left empty for backwards compatibility)
@@ -63,9 +63,6 @@ $template = '
 					<table role="presentation" border="0" cellpadding="0" cellspacing="0" class="main">
 						<tr>
 							<td class="wrapper">
-								<!-- Header -->
-								<h1 class="email-header">%1$s</h1>
-
 								<!-- Respondent Info -->
 								%10$s
 
@@ -181,15 +178,6 @@ $style = '<style media="all" type="text/css">
 		width: 0;
 	}
 
-	/* Header */
-	.email-header {
-		font-size: 20px;
-		font-weight: 600;
-		color: ' . $text_color . ';
-		margin: 0 0 24px 0;
-		padding: 0;
-	}
-
 	.respondent-name {
 		font-size: 16px;
 		font-weight: 500;
@@ -264,11 +252,6 @@ $style = '<style media="all" type="text/css">
 		padding: 16px 0;
 	}
 
-	h1 {
-		font-size: 20px;
-		font-weight: 600;
-	}
-
 	p {
 		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 		font-size: 14px;
@@ -330,10 +313,6 @@ $style = '<style media="all" type="text/css">
 
 		.collapse {
 			display: none;
-		}
-
-		h1 {
-			padding: 0 16px;
 		}
 
 		.powered-by {

--- a/projects/packages/forms/src/contact-form/templates/email-response.php
+++ b/projects/packages/forms/src/contact-form/templates/email-response.php
@@ -64,7 +64,7 @@ $template = '
 						<tr>
 							<td class="wrapper">
 								<!-- Header -->
-								<h1 class="email-header">%1$s</h1>
+								%1$s
 
 								<!-- Respondent Info -->
 								%10$s

--- a/projects/packages/forms/src/contact-form/templates/email-response.php
+++ b/projects/packages/forms/src/contact-form/templates/email-response.php
@@ -63,6 +63,9 @@ $template = '
 					<table role="presentation" border="0" cellpadding="0" cellspacing="0" class="main">
 						<tr>
 							<td class="wrapper">
+								<!-- Header -->
+								<h1 class="email-header">%1$s</h1>
+
 								<!-- Respondent Info -->
 								%10$s
 
@@ -178,6 +181,15 @@ $style = '<style media="all" type="text/css">
 		width: 0;
 	}
 
+	/* Header */
+	.email-header {
+		font-size: 20px;
+		font-weight: 600;
+		color: ' . $text_color . ';
+		margin: 0 0 24px 0;
+		padding: 0;
+	}
+
 	.respondent-name {
 		font-size: 16px;
 		font-weight: 500;
@@ -252,6 +264,11 @@ $style = '<style media="all" type="text/css">
 		padding: 16px 0;
 	}
 
+	h1 {
+		font-size: 20px;
+		font-weight: 600;
+	}
+
 	p {
 		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 		font-size: 14px;
@@ -313,6 +330,10 @@ $style = '<style media="all" type="text/css">
 
 		.collapse {
 			display: none;
+		}
+
+		h1 {
+			padding: 0 16px;
 		}
 
 		.powered-by {

--- a/projects/packages/forms/src/contact-form/templates/email-response.php
+++ b/projects/packages/forms/src/contact-form/templates/email-response.php
@@ -63,7 +63,7 @@ $template = '
 					<table role="presentation" border="0" cellpadding="0" cellspacing="0" class="main">
 						<tr>
 							<td class="wrapper">
-								<!-- Header -->
+								<!-- Header title -->
 								%1$s
 
 								<!-- Respondent Info -->

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Email_Renderer_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Email_Renderer_Test.php
@@ -520,6 +520,77 @@ class Feedback_Email_Renderer_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test build_email_content with empty title does not render h1 tag.
+	 */
+	public function test_build_email_content_empty_title() {
+		$post_id = Utility::create_legacy_feedback(
+			array(
+				'Name'  => 'Test User',
+				'Email' => 'test@example.com',
+			),
+			'Test message',
+			'Test User'
+		);
+
+		$form     = new Contact_Form( array(), '' );
+		$response = Feedback::get( $post_id );
+
+		$context_data = array(
+			'time'                 => current_time( 'mysql' ),
+			'url'                  => 'https://example.com',
+			'comment_author'       => 'Test User',
+			'comment_author_email' => 'test@example.com',
+			'comment_author_ip'    => '127.0.0.1',
+			'is_spam'              => false,
+			'feedback_status'      => 'publish',
+		);
+
+		add_filter( 'jetpack_forms_response_email_title', '__return_empty_string' );
+		$result = Feedback_Email_Renderer::build_email_content( $post_id, $form, $response, $context_data );
+		remove_filter( 'jetpack_forms_response_email_title', '__return_empty_string' );
+
+		$this->assertStringNotContainsString( '<h1 class="email-header">', $result['message'] );
+	}
+
+	/**
+	 * Test build_email_content with non-empty title renders h1 tag.
+	 */
+	public function test_build_email_content_with_title() {
+		$post_id = Utility::create_legacy_feedback(
+			array(
+				'Name'  => 'Test User',
+				'Email' => 'test@example.com',
+			),
+			'Test message',
+			'Test User'
+		);
+
+		$form     = new Contact_Form( array(), '' );
+		$response = Feedback::get( $post_id );
+
+		$context_data = array(
+			'time'                 => current_time( 'mysql' ),
+			'url'                  => 'https://example.com',
+			'comment_author'       => 'Test User',
+			'comment_author_email' => 'test@example.com',
+			'comment_author_ip'    => '127.0.0.1',
+			'is_spam'              => false,
+			'feedback_status'      => 'publish',
+		);
+
+		add_filter(
+			'jetpack_forms_response_email_title',
+			function () {
+				return 'Custom Email Title';
+			}
+		);
+		$result = Feedback_Email_Renderer::build_email_content( $post_id, $form, $response, $context_data );
+		remove_all_filters( 'jetpack_forms_response_email_title' );
+
+		$this->assertStringContainsString( '<h1 class="email-header">Custom Email Title</h1>', $result['message'] );
+	}
+
+	/**
 	 * Invoke a private static method on Feedback_Field via reflection.
 	 *
 	 * @param string $method_name The method name.


### PR DESCRIPTION
Part of FORMS-624
Part of FORMS-615

## Changes proposed in this Pull Request

- Updates the default email title to an empty string in form response notification emails, effectively removing the default "Hey, a new form response just came in!" greeting text.

Before
<img width="1062" height="333" alt="image" src="https://github.com/user-attachments/assets/9369e1fc-359f-4680-9b5d-a43e1a985eff" />

After
<img width="887" height="268" alt="Screenshot 2026-03-18 at 12 27 24" src="https://github.com/user-attachments/assets/5fb49383-1b54-4344-ae09-7a986fa0aa37" />

With a custom title added via filter
<img width="894" height="345" alt="Screenshot 2026-03-18 at 12 50 18" src="https://github.com/user-attachments/assets/dcff8d96-fbcb-4fda-b197-d0853dea82a1" />




## Why are these changes being made?

The greeting text adds unnecessary casual tone to what should be a professional notification. Removing it creates a cleaner, more direct email that focuses on the form response content itself.

## Testing instructions

- Submit a form on a WordPress site with Jetpack Forms installed
- Check the email notification that is sent via localhost:1080
- Verify that the "Hey, a new form response just came in!" text no longer appears
- Verify that adding custom title works, which can help e.g. adding hints that help email filters:

```php
add_filter( 'jetpack_forms_response_email_title', function( $title ) {
	return 'Test';
} );
```

## Changelog entry

- [x] Changelog entry added