### PR TITLE
Donations Block: Add fallback plan resolution for stale plan IDs

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-donations-fallback-plan-resolution
+++ b/projects/plugins/jetpack/changelog/fix-donations-fallback-plan-resolution
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Donations Block: Add fallback plan resolution when saved plan ID is stale.

--- a/projects/plugins/jetpack/extensions/blocks/donations/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/donations/block.json
@@ -44,7 +44,6 @@
 			"type": "object",
 			"default": {
 				"show": true,
-				"planId": null,
 				"amounts": [ 5, 15, 100 ]
 			}
 		},
@@ -52,7 +51,6 @@
 			"type": "object",
 			"default": {
 				"show": true,
-				"planId": null,
 				"amounts": [ 5, 15, 100 ]
 			}
 		},
@@ -60,7 +58,6 @@
 			"type": "object",
 			"default": {
 				"show": true,
-				"planId": null,
 				"amounts": [ 5, 15, 100 ]
 			}
 		},

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -19,8 +19,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Resolve a donation plan post, trying the saved plan ID first then falling
- * back to a query by type, interval, and currency.
+ * Resolve a donation plan post for the given interval and currency.
+ *
+ * When duplicates exist (same interval+currency), the products cache from
+ * /memberships/status is used to pick the correct one by product_id.
  *
  * @param int    $plan_id  The saved plan post ID (may be 0 or stale).
  * @param string $interval The donation interval (one-time, 1 month, 1 year).
@@ -29,27 +31,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function resolve_donation_plan( $plan_id, $interval, $currency ) {
 	$post_type = \Jetpack_Memberships::$post_type_plan;
-	$site_id   = \Jetpack_Memberships::get_blog_id();
 
-	// Try the saved plan ID first.
-	if ( $plan_id ) {
-		$plan = get_post( $plan_id );
-		$meta = $plan ? get_post_meta( $plan->ID ) : array();
-		if ( $plan && ! is_wp_error( $plan )
-			&& $plan->post_type === $post_type
-			&& ( $meta['jetpack_memberships_type'][0] ?? '' ) === 'donation'
-			&& (int) ( $meta['jetpack_memberships_site_id'][0] ?? 0 ) === $site_id
-			&& ( $meta['jetpack_memberships_interval'][0] ?? '' ) === $interval
-			&& ( $meta['jetpack_memberships_currency'][0] ?? '' ) === $currency
-		) {
-			return $plan;
-		}
-	}
-
-	// Fallback: query by type + interval + currency.
-	$plans = get_posts(
+	// Query all local plans for this interval + currency.
+	$candidates = get_posts(
 		array(
-			'posts_per_page' => 1,
+			'posts_per_page' => -1,
 			'post_type'      => $post_type,
 			'meta_query'     => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 				array(
@@ -68,14 +54,120 @@ function resolve_donation_plan( $plan_id, $interval, $currency ) {
 					'key'     => 'jetpack_memberships_is_deleted',
 					'compare' => 'NOT EXISTS',
 				),
-				array(
-					'key'   => 'jetpack_memberships_site_id',
-					'value' => $site_id,
-				),
 			),
 		)
 	);
-	return ! empty( $plans ) ? $plans[0] : null;
+
+	if ( empty( $candidates ) ) {
+		return null;
+	}
+
+	// Single candidate — no ambiguity.
+	if ( count( $candidates ) === 1 ) {
+		return $candidates[0];
+	}
+
+	// Multiple candidates — use remote products to pick the right one.
+	$products = get_donation_products( $currency );
+	if ( ! empty( $products ) ) {
+		foreach ( $candidates as $candidate ) {
+			$pid = get_post_meta( $candidate->ID, 'jetpack_memberships_product_id', true );
+			if ( $pid && isset( $products[ (int) $pid ] ) ) {
+				return $candidate;
+			}
+		}
+	}
+
+	// Fall back to the saved plan ID if it's among the candidates.
+	if ( $plan_id ) {
+		foreach ( $candidates as $candidate ) {
+			if ( $candidate->ID === $plan_id ) {
+				return $candidate;
+			}
+		}
+	}
+
+	// No products cache and no saved ID match — return first candidate.
+	return $candidates[0];
+}
+
+/**
+ * Get donation products for a currency, keyed by product_id.
+ *
+ * Returns cached data when available. Otherwise fetches from
+ * /memberships/status (GET, read-only) and caches the result.
+ *
+ * @param string $currency The currency code.
+ * @return array Map of product_id => product data, or empty array.
+ */
+function get_donation_products( $currency ) {
+	$cache_key = 'jetpack_donation_products_' . strtolower( $currency );
+	$neg_key   = $cache_key . '_empty';
+
+	// Return cached products if available.
+	$cached = get_transient( $cache_key );
+	if ( is_array( $cached ) ) {
+		return $cached;
+	}
+
+	// Negative cache — no products exist for this currency.
+	if ( false !== get_transient( $neg_key ) ) {
+		return array();
+	}
+
+	// Fetch from remote.
+	$status = null;
+
+	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+		require_lib( 'memberships' );
+		\Memberships_Store_Sandbox::get_instance()->init( true );
+		$result = get_memberships_settings_for_site( get_current_blog_id(), 'donation', false, 'server' );
+		if ( ! is_wp_error( $result ) ) {
+			$status = (array) $result;
+		}
+	} else {
+		$blog_id = \Jetpack_Options::get_option( 'id' );
+		if ( $blog_id ) {
+			$response = \Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_blog(
+				sprintf( '/sites/%d/memberships/status?type=donation&is_editable=0', $blog_id ),
+				'2',
+				array( 'method' => 'GET' )
+			);
+			if ( ! is_wp_error( $response ) && 200 === wp_remote_retrieve_response_code( $response ) ) {
+				$body = json_decode( wp_remote_retrieve_body( $response ), true );
+				if ( is_array( $body ) ) {
+					$status = $body;
+				}
+			}
+		}
+	}
+
+	if ( ! is_array( $status ) || empty( $status['products'] ) ) {
+		set_transient( $neg_key, 1, HOUR_IN_SECONDS );
+		return array();
+	}
+
+	// Build product_id => product map for the requested currency.
+	$upper_curr     = strtoupper( $currency );
+	$products_by_id = array();
+	foreach ( $status['products'] as $product ) {
+		if ( strtoupper( $product['currency'] ?? '' ) !== $upper_curr ) {
+			continue;
+		}
+		$product_id = (int) ( $product['product_id'] ?? ( $product['id'] ?? 0 ) );
+		if ( $product_id ) {
+			$products_by_id[ $product_id ] = $product;
+		}
+	}
+
+	if ( empty( $products_by_id ) ) {
+		set_transient( $neg_key, 1, HOUR_IN_SECONDS );
+		return array();
+	}
+
+	set_transient( $cache_key, $products_by_id, DAY_IN_SECONDS );
+
+	return $products_by_id;
 }
 
 /**
@@ -193,8 +285,16 @@ function render_block( $attr, $content ) {
 	$amounts            = '';
 	$extra_text         = '';
 	$buttons            = '';
+
+	// Resolve donation plans. When duplicates exist, resolve_donation_plan()
+	// fetches the products cache from /memberships/status to disambiguate.
+	$resolved_plans = array();
 	foreach ( $donations as $interval => $donation ) {
-		$plan = resolve_donation_plan( (int) $donation['planId'], $interval, $currency );
+		$resolved_plans[ $interval ] = resolve_donation_plan( (int) $donation['planId'], $interval, $currency );
+	}
+
+	foreach ( $donations as $interval => $donation ) {
+		$plan = $resolved_plans[ $interval ];
 		if ( ! $plan ) {
 			continue;
 		}

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -29,11 +29,18 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function resolve_donation_plan( $plan_id, $interval, $currency ) {
 	$post_type = \Jetpack_Memberships::$post_type_plan;
+	$site_id   = \Jetpack_Memberships::get_blog_id();
 
 	// Try the saved plan ID first.
 	if ( $plan_id ) {
 		$plan = get_post( $plan_id );
-		if ( $plan && ! is_wp_error( $plan ) && $plan->post_type === $post_type ) {
+		if ( $plan && ! is_wp_error( $plan )
+			&& $plan->post_type === $post_type
+			&& (int) get_post_meta( $plan->ID, 'jetpack_memberships_site_id', true ) === $site_id
+			&& get_post_meta( $plan->ID, 'jetpack_memberships_type', true ) === 'donation'
+			&& get_post_meta( $plan->ID, 'jetpack_memberships_interval', true ) === $interval
+			&& get_post_meta( $plan->ID, 'jetpack_memberships_currency', true ) === $currency
+		) {
 			return $plan;
 		}
 	}
@@ -59,6 +66,10 @@ function resolve_donation_plan( $plan_id, $interval, $currency ) {
 				array(
 					'key'     => 'jetpack_memberships_is_deleted',
 					'compare' => 'NOT EXISTS',
+				),
+				array(
+					'key'   => 'jetpack_memberships_site_id',
+					'value' => $site_id,
 				),
 			),
 		)

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -35,7 +35,6 @@ function resolve_donation_plan_id( $interval, $currency ) {
 			'fields'         => 'ids',
 			'post_type'      => \Jetpack_Memberships::$post_type_plan,
 			'meta_query'     => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-				'relation' => 'AND',
 				array(
 					'key'   => 'jetpack_memberships_type',
 					'value' => 'donation',
@@ -179,8 +178,11 @@ function render_block( $attr, $content ) {
 
 		// Fallback: resolve by type + interval + currency if saved planId is stale.
 		if ( ! $plan || is_wp_error( $plan ) ) {
-			$plan_id = resolve_donation_plan_id( $interval, $currency );
-			$plan    = $plan_id ? get_post( $plan_id ) : null;
+			$resolved_id = resolve_donation_plan_id( $interval, $currency );
+			if ( $resolved_id ) {
+				$plan_id = $resolved_id;
+				$plan    = get_post( $plan_id );
+			}
 		}
 
 		if ( ! $plan || is_wp_error( $plan ) ) {

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -19,6 +19,46 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Resolve a donation plan ID by querying for a matching jp_mem_plan post.
+ *
+ * Used as a fallback when the saved planId in block attributes is stale
+ * (e.g. the product was deleted and recreated).
+ *
+ * @param string $interval The donation interval (one-time, 1 month, 1 year).
+ * @param string $currency The currency code.
+ * @return int|null The plan post ID, or null if not found.
+ */
+function resolve_donation_plan_id( $interval, $currency ) {
+	$plans = get_posts(
+		array(
+			'posts_per_page' => 1,
+			'fields'         => 'ids',
+			'post_type'      => \Jetpack_Memberships::$post_type_plan,
+			'meta_query'     => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				'relation' => 'AND',
+				array(
+					'key'   => 'jetpack_memberships_type',
+					'value' => 'donation',
+				),
+				array(
+					'key'   => 'jetpack_memberships_interval',
+					'value' => $interval,
+				),
+				array(
+					'key'   => 'jetpack_memberships_currency',
+					'value' => $currency,
+				),
+				array(
+					'key'     => 'jetpack_memberships_is_deleted',
+					'compare' => 'NOT EXISTS',
+				),
+			),
+		)
+	);
+	return ! empty( $plans ) ? $plans[0] : null;
+}
+
+/**
  * Registers the block for use in Gutenberg
  * This is done via an action so that we can disable
  * registration if we need to.
@@ -135,7 +175,14 @@ function render_block( $attr, $content ) {
 	$buttons            = '';
 	foreach ( $donations as $interval => $donation ) {
 		$plan_id = (int) $donation['planId'];
-		$plan    = get_post( $plan_id );
+		$plan    = $plan_id ? get_post( $plan_id ) : null;
+
+		// Fallback: resolve by type + interval + currency if saved planId is stale.
+		if ( ! $plan || is_wp_error( $plan ) ) {
+			$plan_id = resolve_donation_plan_id( $interval, $currency );
+			$plan    = $plan_id ? get_post( $plan_id ) : null;
+		}
+
 		if ( ! $plan || is_wp_error( $plan ) ) {
 			continue;
 		}

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -71,8 +71,7 @@ function resolve_donation_plan( $plan_id, $interval, $currency ) {
 	$products = get_donation_products( $currency );
 	if ( ! empty( $products ) ) {
 		foreach ( $candidates as $candidate ) {
-			$pid = get_post_meta( $candidate->ID, 'jetpack_memberships_product_id', true );
-			if ( $pid && isset( $products[ (int) $pid ] ) ) {
+			if ( isset( $products[ $candidate->ID ] ) ) {
 				return $candidate;
 			}
 		}
@@ -87,8 +86,8 @@ function resolve_donation_plan( $plan_id, $interval, $currency ) {
 		}
 	}
 
-	// No products cache and no saved ID match — return first candidate.
-	return $candidates[0];
+	// No products cache and no saved ID match.
+	return null;
 }
 
 /**
@@ -115,19 +114,18 @@ function get_donation_products( $currency ) {
 		return array();
 	}
 
-	// Fetch via internal REST request to /wpcom/v2/memberships/status.
-	$request = new \WP_REST_Request( 'GET', '/wpcom/v2/memberships/status' );
+	// Fetch via internal REST request.
+	$request = new \WP_REST_Request( 'GET', '/wpcom/v2/memberships/products' );
 	$request->set_param( 'type', 'donation' );
 	$request->set_param( 'is_editable', false );
-
 	$response = rest_do_request( $request );
-	$status   = null;
+	$data     = null;
 
 	if ( ! $response->is_error() && 200 === $response->get_status() ) {
-		$status = $response->get_data();
+		$data = $response->get_data();
 	}
 
-	if ( ! is_array( $status ) || empty( $status['products'] ) ) {
+	if ( ! is_array( $data ) || empty( $data['products'] ) ) {
 		set_transient( $neg_key, 1, HOUR_IN_SECONDS );
 		return array();
 	}
@@ -135,7 +133,7 @@ function get_donation_products( $currency ) {
 	// Build product_id => product map for the requested currency.
 	$upper_curr     = strtoupper( $currency );
 	$products_by_id = array();
-	foreach ( $status['products'] as $product ) {
+	foreach ( $data['products'] as $product ) {
 		if ( strtoupper( $product['currency'] ?? '' ) !== $upper_curr ) {
 			continue;
 		}

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -131,13 +131,13 @@ function get_donation_products( $currency ) {
 	}
 
 	// Build product_id => product map for the requested currency.
-	$upper_curr     = strtoupper( $currency );
 	$products_by_id = array();
 	foreach ( $data['products'] as $product ) {
-		if ( strtoupper( $product['currency'] ?? '' ) !== $upper_curr ) {
+		if ( strtoupper( $product['currency'] ) !== strtoupper( $currency ) ) {
 			continue;
 		}
-		$product_id = (int) $product['id'] ?? 0;
+
+		$product_id = $product['id'];
 		if ( $product_id ) {
 			$products_by_id[ $product_id ] = $product;
 		}

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -19,21 +19,30 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Resolve a donation plan ID by querying for a matching jp_mem_plan post.
+ * Resolve a donation plan post, trying the saved plan ID first then falling
+ * back to a query by type, interval, and currency.
  *
- * Used as a fallback when the saved planId in block attributes is stale
- * (e.g. the product was deleted and recreated).
- *
+ * @param int    $plan_id  The saved plan post ID (may be 0 or stale).
  * @param string $interval The donation interval (one-time, 1 month, 1 year).
  * @param string $currency The currency code.
- * @return int|null The plan post ID, or null if not found.
+ * @return WP_Post|null The plan post, or null if not found.
  */
-function resolve_donation_plan_id( $interval, $currency ) {
+function resolve_donation_plan( $plan_id, $interval, $currency ) {
+	$post_type = \Jetpack_Memberships::$post_type_plan;
+
+	// Try the saved plan ID first.
+	if ( $plan_id ) {
+		$plan = get_post( $plan_id );
+		if ( $plan && ! is_wp_error( $plan ) && $plan->post_type === $post_type ) {
+			return $plan;
+		}
+	}
+
+	// Fallback: query by type + interval + currency.
 	$plans = get_posts(
 		array(
 			'posts_per_page' => 1,
-			'fields'         => 'ids',
-			'post_type'      => \Jetpack_Memberships::$post_type_plan,
+			'post_type'      => $post_type,
 			'meta_query'     => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 				array(
 					'key'   => 'jetpack_memberships_type',
@@ -173,19 +182,8 @@ function render_block( $attr, $content ) {
 	$extra_text         = '';
 	$buttons            = '';
 	foreach ( $donations as $interval => $donation ) {
-		$plan_id = (int) $donation['planId'];
-		$plan    = $plan_id ? get_post( $plan_id ) : null;
-
-		// Fallback: resolve by type + interval + currency if saved planId is stale.
-		if ( ! $plan || is_wp_error( $plan ) ) {
-			$resolved_id = resolve_donation_plan_id( $interval, $currency );
-			if ( $resolved_id ) {
-				$plan_id = $resolved_id;
-				$plan    = get_post( $plan_id );
-			}
-		}
-
-		if ( ! $plan || is_wp_error( $plan ) ) {
+		$plan = resolve_donation_plan( (int) $donation['planId'], $interval, $currency );
+		if ( ! $plan ) {
 			continue;
 		}
 
@@ -224,7 +222,7 @@ function render_block( $attr, $content ) {
 		$buttons    .= sprintf(
 			'<a class="wp-block-button__link donations__donate-button %1$s" href="%2$s">%3$s</a>',
 			esc_attr( $donation['class'] ),
-			esc_url( \Jetpack_Memberships::get_instance()->get_subscription_url( $plan_id ) ),
+			esc_url( \Jetpack_Memberships::get_instance()->get_subscription_url( $plan->ID ) ),
 			wp_kses_post( $donation['buttonText'] )
 		);
 	}

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -24,12 +24,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  * When duplicates exist (same interval+currency), the products cache from
  * /memberships/status is used to pick the correct one by product_id.
  *
- * @param int    $plan_id  The saved plan post ID (may be 0 or stale).
  * @param string $interval The donation interval (one-time, 1 month, 1 year).
  * @param string $currency The currency code.
  * @return WP_Post|null The plan post, or null if not found.
  */
-function resolve_donation_plan( $plan_id, $interval, $currency ) {
+function resolve_donation_plan( $interval, $currency ) {
 	$post_type = \Jetpack_Memberships::$post_type_plan;
 
 	// Query all local plans for this interval + currency.
@@ -77,16 +76,7 @@ function resolve_donation_plan( $plan_id, $interval, $currency ) {
 		}
 	}
 
-	// Fall back to the saved plan ID if it's among the candidates.
-	if ( $plan_id ) {
-		foreach ( $candidates as $candidate ) {
-			if ( $candidate->ID === $plan_id ) {
-				return $candidate;
-			}
-		}
-	}
-
-	// No products cache and no saved ID match.
+	// No products cache match.
 	return null;
 }
 
@@ -226,7 +216,6 @@ function render_block( $attr, $content ) {
 	$donations = array(
 		'one-time' => array_merge(
 			array(
-				'planId'     => null,
 				'title'      => __( 'One-Time', 'jetpack' ),
 				'class'      => 'donations__one-time-item',
 				'heading'    => $default_texts['oneTimeDonation']['heading'],
@@ -238,7 +227,6 @@ function render_block( $attr, $content ) {
 	if ( $attr['monthlyDonation']['show'] ) {
 		$donations['1 month'] = array_merge(
 			array(
-				'planId'     => null,
 				'title'      => __( 'Monthly', 'jetpack' ),
 				'class'      => 'donations__monthly-item',
 				'heading'    => $default_texts['monthlyDonation']['heading'],
@@ -250,7 +238,6 @@ function render_block( $attr, $content ) {
 	if ( $attr['annualDonation']['show'] ) {
 		$donations['1 year'] = array_merge(
 			array(
-				'planId'     => null,
 				'title'      => __( 'Yearly', 'jetpack' ),
 				'class'      => 'donations__annual-item',
 				'heading'    => $default_texts['annualDonation']['heading'],
@@ -273,7 +260,7 @@ function render_block( $attr, $content ) {
 	// fetches the products cache from /memberships/status to disambiguate.
 	$resolved_plans = array();
 	foreach ( $donations as $interval => $donation ) {
-		$resolved_plans[ $interval ] = resolve_donation_plan( (int) $donation['planId'], $interval, $currency );
+		$resolved_plans[ $interval ] = resolve_donation_plan( $interval, $currency );
 	}
 
 	foreach ( $donations as $interval => $donation ) {

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -115,31 +115,16 @@ function get_donation_products( $currency ) {
 		return array();
 	}
 
-	// Fetch from remote.
-	$status = null;
+	// Fetch via internal REST request to /wpcom/v2/memberships/status.
+	$request = new \WP_REST_Request( 'GET', '/wpcom/v2/memberships/status' );
+	$request->set_param( 'type', 'donation' );
+	$request->set_param( 'is_editable', false );
 
-	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-		require_lib( 'memberships' );
-		\Memberships_Store_Sandbox::get_instance()->init( true );
-		$result = get_memberships_settings_for_site( get_current_blog_id(), 'donation', false, 'server' );
-		if ( ! is_wp_error( $result ) ) {
-			$status = (array) $result;
-		}
-	} else {
-		$blog_id = \Jetpack_Options::get_option( 'id' );
-		if ( $blog_id ) {
-			$response = \Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_blog(
-				sprintf( '/sites/%d/memberships/status?type=donation&is_editable=0', $blog_id ),
-				'2',
-				array( 'method' => 'GET' )
-			);
-			if ( ! is_wp_error( $response ) && 200 === wp_remote_retrieve_response_code( $response ) ) {
-				$body = json_decode( wp_remote_retrieve_body( $response ), true );
-				if ( is_array( $body ) ) {
-					$status = $body;
-				}
-			}
-		}
+	$response = rest_do_request( $request );
+	$status   = null;
+
+	if ( ! $response->is_error() && 200 === $response->get_status() ) {
+		$status = $response->get_data();
 	}
 
 	if ( ! is_array( $status ) || empty( $status['products'] ) ) {
@@ -154,7 +139,7 @@ function get_donation_products( $currency ) {
 		if ( strtoupper( $product['currency'] ?? '' ) !== $upper_curr ) {
 			continue;
 		}
-		$product_id = (int) ( $product['product_id'] ?? ( $product['id'] ?? 0 ) );
+		$product_id = (int) $product['id'] ?? 0;
 		if ( $product_id ) {
 			$products_by_id[ $product_id ] = $product;
 		}

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -34,12 +34,13 @@ function resolve_donation_plan( $plan_id, $interval, $currency ) {
 	// Try the saved plan ID first.
 	if ( $plan_id ) {
 		$plan = get_post( $plan_id );
+		$meta = $plan ? get_post_meta( $plan->ID ) : array();
 		if ( $plan && ! is_wp_error( $plan )
 			&& $plan->post_type === $post_type
-			&& (int) get_post_meta( $plan->ID, 'jetpack_memberships_site_id', true ) === $site_id
-			&& get_post_meta( $plan->ID, 'jetpack_memberships_type', true ) === 'donation'
-			&& get_post_meta( $plan->ID, 'jetpack_memberships_interval', true ) === $interval
-			&& get_post_meta( $plan->ID, 'jetpack_memberships_currency', true ) === $currency
+			&& ( $meta['jetpack_memberships_type'][0] ?? '' ) === 'donation'
+			&& (int) ( $meta['jetpack_memberships_site_id'][0] ?? 0 ) === $site_id
+			&& ( $meta['jetpack_memberships_interval'][0] ?? '' ) === $interval
+			&& ( $meta['jetpack_memberships_currency'][0] ?? '' ) === $currency
 		) {
 			return $plan;
 		}

--- a/projects/plugins/jetpack/extensions/blocks/donations/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/edit.js
@@ -23,7 +23,6 @@ const Edit = props => {
 
 	const blockProps = useBlockProps();
 	const [ loadingError, setLoadingError ] = useState( '' );
-	const [ products, setProducts ] = useState( [] );
 	const [ showFirstTimeModal, setShowFirstTimeModal ] = useState( false );
 	const isUserConnected = useIsUserConnected();
 
@@ -128,26 +127,19 @@ const Edit = props => {
 			const filteredProducts = filterProducts( result.products );
 
 			if ( hasRequiredProducts( filteredProducts ) ) {
-				setProducts( filteredProducts );
 				unlockPostSaving( 'donations' );
 				return;
 			}
 
 			// Set fake products when there is no connection to Stripe so users can still try the block in the editor.
 			if ( result.connect_url ) {
-				setProducts( {
-					'one-time': -1,
-					'1 month': -1,
-					'1 year': -1,
-				} );
 				unlockPostSaving( 'donations' );
 				return;
 			}
 
 			if ( currency ) {
 				// Only create products if we have the correct plan and stripe connection.
-				fetchDefaultProducts( currency ).then( defaultProducts => {
-					setProducts( filterProducts( defaultProducts ) );
+				fetchDefaultProducts( currency ).then( () => {
 					unlockPostSaving( 'donations' );
 				}, apiError );
 			}
@@ -181,7 +173,7 @@ const Edit = props => {
 		// Memberships settings are still loading
 		content = <Spinner />;
 	} else {
-		content = <Tabs { ...props } products={ products } />;
+		content = <Tabs { ...props } />;
 	}
 
 	// When the first time modal is closed, update the user meta to mark the donation warning as dismissed

--- a/projects/plugins/jetpack/extensions/blocks/donations/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/save.js
@@ -6,12 +6,7 @@ const DEFAULT_TEXTS = getDefaultTexts();
 const Save = ( { attributes } ) => {
 	const { fallbackLinkUrl, oneTimeDonation, monthlyDonation, annualDonation } = attributes;
 
-	if (
-		! oneTimeDonation ||
-		! oneTimeDonation.show ||
-		! oneTimeDonation.planId ||
-		oneTimeDonation.planId === -1
-	) {
+	if ( ! oneTimeDonation || ! oneTimeDonation.show ) {
 		return null;
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/donations/tabs.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/tabs.js
@@ -5,8 +5,8 @@ import Controls from './controls';
 import Tab from './tab';
 
 const Tabs = props => {
-	const { attributes, products, setAttributes } = props;
-	const { oneTimeDonation, monthlyDonation, annualDonation } = attributes;
+	const { attributes, setAttributes } = props;
+	const { monthlyDonation, annualDonation } = attributes;
 	const [ activeTab, setActiveTab ] = useState( 'one-time' );
 
 	const isTabActive = useCallback( tab => activeTab === tab, [ activeTab ] );
@@ -16,29 +16,6 @@ const Tabs = props => {
 		...( monthlyDonation.show && { '1 month': { title: __( 'Monthly', 'jetpack' ) } } ),
 		...( annualDonation.show && { '1 year': { title: __( 'Yearly', 'jetpack' ) } } ),
 	};
-
-	// Updates plans.
-	useEffect( () => {
-		if (
-			oneTimeDonation.planId === products[ 'one-time' ] &&
-			monthlyDonation.planId === products[ '1 month' ] &&
-			annualDonation.planId === products[ '1 year' ]
-		) {
-			return;
-		}
-
-		setAttributes( {
-			...( products[ 'one-time' ] && {
-				oneTimeDonation: { ...oneTimeDonation, planId: products[ 'one-time' ] },
-			} ),
-			...( products[ '1 month' ] && {
-				monthlyDonation: { ...monthlyDonation, planId: products[ '1 month' ] },
-			} ),
-			...( products[ '1 year' ] && {
-				annualDonation: { ...annualDonation, planId: products[ '1 year' ] },
-			} ),
-		} );
-	}, [ oneTimeDonation, monthlyDonation, annualDonation, setAttributes, products ] );
 
 	// Activates the one-time tab if the interval of the current active tab is disabled.
 	useEffect( () => {

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -226,6 +226,9 @@ class Jetpack_Memberships {
 			'interval'        => array(
 				'meta' => $meta_prefix . 'interval',
 			),
+			'site_id'         => array(
+				'meta' => $meta_prefix . 'site_id',
+			),
 			'tier'            => array(
 				'meta' => $meta_prefix . 'tier',
 			),

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -220,6 +220,12 @@ class Jetpack_Memberships {
 			'product_id'      => array(
 				'meta' => $meta_prefix . 'product_id',
 			),
+			'type'            => array(
+				'meta' => $meta_prefix . 'type',
+			),
+			'interval'        => array(
+				'meta' => $meta_prefix . 'interval',
+			),
 			'tier'            => array(
 				'meta' => $meta_prefix . 'tier',
 			),

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -226,9 +226,6 @@ class Jetpack_Memberships {
 			'interval'        => array(
 				'meta' => $meta_prefix . 'interval',
 			),
-			'site_id'         => array(
-				'meta' => $meta_prefix . 'site_id',
-			),
 			'tier'            => array(
 				'meta' => $meta_prefix . 'tier',
 			),


### PR DESCRIPTION
Fixes DOTEV-282

## Proposed changes

The saved `planId` in block attributes can become stale, causing the donation tab to silently disappear or render incorrectly on the frontend when:
* A donation product is deleted and recreated
* A post containing the donation block is synced from a staging site (creating duplicate local `jp_mem_plan` posts with the same interval+currency)

### Approach

Remove `planId` from block attributes entirely and resolve donation plans server-side using interval + currency + the remote products cache:

1. **Query all local candidates** matching `type=donation` + `interval` + `currency` (not deleted)
2. **Single candidate** → return it directly
3. **Multiple candidates** → fetch canonical products from `GET /wpcom/v2/memberships/products` via internal REST request (`rest_do_request`), match candidates by post ID against the products map
4. **No match** → return null (tab is skipped)

### Key changes

- **`block.json`**: Remove `planId` from `oneTimeDonation`, `monthlyDonation`, and `annualDonation` attribute defaults
- **`donations.php`**:
  - Add `resolve_donation_plan($interval, $currency)` to query all candidates and disambiguate duplicates using a products cache keyed by post ID
  - Add `get_donation_products()` which fetches from `/wpcom/v2/memberships/products` via `rest_do_request()` and caches results in a transient (with negative caching)
  - Remove `planId` from the `$donations` array defaults
  - Resolve all plans upfront in `render_block()` before rendering
- **`save.js`**: Remove `planId` guard — block renders when `oneTimeDonation.show` is true
- **`tabs.js`**: Remove `useEffect` that synced `planId` from fetched products into block attributes
- **`edit.js`**: Remove `products` state and prop passing to `Tabs` (no longer needed)

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Go to a site with the Donations block active
2. Verify the donations block renders correctly on the frontend
3. In the editor, verify the block loads without errors
4. Save the post, verify no `planId` is stored in the block attributes

**Duplicate plan scenario**

1. Create a staging site, and push to production site
2. Go to frontend of your site
3. Check the Donations block renders correctly and links point to the right plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)