### PR TITLE
Forms: show logged in user info

### DIFF
--- a/projects/packages/forms/changelog/pr-47652
+++ b/projects/packages/forms/changelog/pr-47652
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add logged-in user display name and ID to form submission emails and response sidebar.

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -630,6 +630,29 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'readonly'    => true,
 		);
 
+		$schema['properties']['logged_in_user'] = array(
+			'description' => __( 'The logged-in user who submitted the form, if any.', 'jetpack-forms' ),
+			'type'        => array( 'object', 'null' ),
+			'context'     => array( 'view', 'edit', 'embed' ),
+			'properties'  => array(
+				'display_name' => array(
+					'type'        => 'string',
+					'description' => __( 'The display name of the logged-in user.', 'jetpack-forms' ),
+					'arg_options' => array(
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+				'id'           => array(
+					'type'        => 'integer',
+					'description' => __( 'The ID of the logged-in user.', 'jetpack-forms' ),
+					'arg_options' => array(
+						'sanitize_callback' => 'absint',
+					),
+				),
+			),
+			'readonly'    => true,
+		);
+
 		$schema['properties']['entry_title'] = array(
 			'description' => __( 'The title of the page or post where the form was submitted.', 'jetpack-forms' ),
 			'type'        => 'string',
@@ -894,6 +917,10 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 
 		if ( rest_is_field_included( 'browser', $fields ) ) {
 			$data['browser'] = $feedback_response->get_browser();
+		}
+
+		if ( rest_is_field_included( 'logged_in_user', $fields ) ) {
+			$data['logged_in_user'] = $feedback_response->get_logged_in_user();
 		}
 
 		if ( rest_is_field_included( 'entry_title', $fields ) ) {

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -642,6 +642,13 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 						'sanitize_callback' => 'sanitize_text_field',
 					),
 				),
+				'username'     => array(
+					'type'        => 'string',
+					'description' => __( 'The username of the logged-in user.', 'jetpack-forms' ),
+					'arg_options' => array(
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
 				'id'           => array(
 					'type'        => 'integer',
 					'description' => __( 'The ID of the logged-in user.', 'jetpack-forms' ),

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -750,10 +750,11 @@ class Feedback_Email_Renderer {
 		}
 
 		// Logged in user row.
-		if ( ! empty( $metadata['logged_in_user'] ) ) {
-			$user_value = '#' . $metadata['logged_in_user']['id'];
+		if ( ! empty( $metadata['logged_in_user'] ) && isset( $metadata['logged_in_user']['id'] ) ) {
+			$user_id    = $metadata['logged_in_user']['id'];
+			$user_value = '#' . $user_id;
 			if ( ! empty( $metadata['logged_in_user']['display_name'] ) ) {
-				$user_value = $metadata['logged_in_user']['display_name'] . ' (#' . $metadata['logged_in_user']['id'] . ')';
+				$user_value = $metadata['logged_in_user']['display_name'] . ' (#' . $user_id . ')';
 			}
 			$rows[] = self::generate_metadata_row( __( 'Logged-in user', 'jetpack-forms' ), esc_html( $user_value ) );
 		}

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -528,7 +528,7 @@ class Feedback_Email_Renderer {
 	 * @param string $footer - the footer containing meta information.
 	 * @param string $actions - HTML for actions displayed in the email.
 	 * @param array  $respondent_info - Optional. Respondent information array with 'name', 'email', 'avatar'.
-	 * @param array  $metadata - Optional. Metadata array with 'date', 'source', 'source_url', 'device', 'ip', 'ip_flag', 'logged_in_user'.
+	 * @param array  $metadata - Optional. Metadata array with 'date', 'source', 'source_url', 'device', 'ip', 'ip_flag', 'logged_in_user' (with display_name, username, id).
 	 *
 	 * @return string
 	 */
@@ -710,7 +710,7 @@ class Feedback_Email_Renderer {
 	/**
 	 * Generate HTML for metadata section in email.
 	 *
-	 * @param array $metadata Array with 'date', 'source', 'source_url', 'device', 'ip', 'ip_flag', 'logged_in_user' keys.
+	 * @param array $metadata Array with 'date', 'source', 'source_url', 'device', 'ip', 'ip_flag', 'logged_in_user' (with display_name, username, id) keys.
 	 * @return string HTML for metadata section.
 	 */
 	private static function generate_metadata_html( $metadata ) {
@@ -755,6 +755,8 @@ class Feedback_Email_Renderer {
 			$user_value = '#' . $user_id;
 			if ( ! empty( $metadata['logged_in_user']['display_name'] ) ) {
 				$user_value = $metadata['logged_in_user']['display_name'] . ' (#' . $user_id . ')';
+			} elseif ( ! empty( $metadata['logged_in_user']['username'] ) ) {
+				$user_value = $metadata['logged_in_user']['username'] . ' (#' . $user_id . ')';
 			}
 			$rows[] = self::generate_metadata_row( __( 'Logged-in user', 'jetpack-forms' ), esc_html( $user_value ) );
 		}

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -241,14 +241,20 @@ class Feedback_Email_Renderer {
 			$form_title = Contact_Form::get_post_property( $form->current_post, 'post_title' );
 		}
 
+		$current_user = is_user_logged_in() ? wp_get_current_user() : null;
+
 		// Build metadata for the new email template.
 		$metadata = array(
-			'date'       => $time,
-			'source'     => $form_title,
-			'source_url' => $url,
-			'device'     => $response->get_browser(),
-			'ip'         => $comment_author_ip,
-			'ip_flag'    => $response->get_country_flag(),
+			'date'         => $time,
+			'source'       => $form_title,
+			'source_url'   => $url,
+			'device'       => $response->get_browser(),
+			'ip'           => $comment_author_ip,
+			'ip_flag'      => $response->get_country_flag(),
+			'current_user' => $current_user ? array(
+				'display_name' => $current_user->display_name,
+				'id'           => $current_user->ID,
+			) : null,
 		);
 
 		/**
@@ -746,6 +752,15 @@ class Feedback_Email_Renderer {
 			}
 			$ip_value .= esc_html( $metadata['ip'] );
 			$rows[]    = self::generate_metadata_row( __( 'IP address', 'jetpack-forms' ), $ip_value );
+		}
+
+		// Logged in user row.
+		if ( ! empty( $metadata['current_user'] ) ) {
+			$user_value = '#' . $metadata['current_user']['id'];
+			if ( ! empty( $metadata['current_user']['display_name'] ) ) {
+				$user_value = $metadata['current_user']['display_name'] . ' (#' . $metadata['current_user']['id'] . ')';
+			}
+			$rows[] = self::generate_metadata_row( __( 'Logged-in user', 'jetpack-forms' ), esc_html( $user_value ) );
 		}
 
 		if ( empty( $rows ) ) {

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -241,20 +241,15 @@ class Feedback_Email_Renderer {
 			$form_title = Contact_Form::get_post_property( $form->current_post, 'post_title' );
 		}
 
-		$current_user = is_user_logged_in() ? wp_get_current_user() : null;
-
 		// Build metadata for the new email template.
 		$metadata = array(
-			'date'         => $time,
-			'source'       => $form_title,
-			'source_url'   => $url,
-			'device'       => $response->get_browser(),
-			'ip'           => $comment_author_ip,
-			'ip_flag'      => $response->get_country_flag(),
-			'current_user' => $current_user ? array(
-				'display_name' => $current_user->display_name,
-				'id'           => $current_user->ID,
-			) : null,
+			'date'           => $time,
+			'source'         => $form_title,
+			'source_url'     => $url,
+			'device'         => $response->get_browser(),
+			'ip'             => $comment_author_ip,
+			'ip_flag'        => $response->get_country_flag(),
+			'logged_in_user' => $response->get_logged_in_user(),
 		);
 
 		/**
@@ -533,7 +528,7 @@ class Feedback_Email_Renderer {
 	 * @param string $footer - the footer containing meta information.
 	 * @param string $actions - HTML for actions displayed in the email.
 	 * @param array  $respondent_info - Optional. Respondent information array with 'name', 'email', 'avatar'.
-	 * @param array  $metadata - Optional. Metadata array with 'date', 'source', 'source_url', 'device', 'ip', 'ip_flag'.
+	 * @param array  $metadata - Optional. Metadata array with 'date', 'source', 'source_url', 'device', 'ip', 'ip_flag', 'logged_in_user'.
 	 *
 	 * @return string
 	 */
@@ -715,7 +710,7 @@ class Feedback_Email_Renderer {
 	/**
 	 * Generate HTML for metadata section in email.
 	 *
-	 * @param array $metadata Array with 'date', 'source', 'source_url', 'device', 'ip', 'ip_flag' keys.
+	 * @param array $metadata Array with 'date', 'source', 'source_url', 'device', 'ip', 'ip_flag', 'logged_in_user' keys.
 	 * @return string HTML for metadata section.
 	 */
 	private static function generate_metadata_html( $metadata ) {
@@ -755,10 +750,10 @@ class Feedback_Email_Renderer {
 		}
 
 		// Logged in user row.
-		if ( ! empty( $metadata['current_user'] ) ) {
-			$user_value = '#' . $metadata['current_user']['id'];
-			if ( ! empty( $metadata['current_user']['display_name'] ) ) {
-				$user_value = $metadata['current_user']['display_name'] . ' (#' . $metadata['current_user']['id'] . ')';
+		if ( ! empty( $metadata['logged_in_user'] ) ) {
+			$user_value = '#' . $metadata['logged_in_user']['id'];
+			if ( ! empty( $metadata['logged_in_user']['display_name'] ) ) {
+				$user_value = $metadata['logged_in_user']['display_name'] . ' (#' . $metadata['logged_in_user']['id'] . ')';
 			}
 			$rows[] = self::generate_metadata_row( __( 'Logged-in user', 'jetpack-forms' ), esc_html( $user_value ) );
 		}

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -356,6 +356,7 @@ class Feedback {
 			$current_user         = wp_get_current_user();
 			$this->logged_in_user = array(
 				'display_name' => $current_user->display_name,
+				'username'     => $current_user->user_login,
 				'id'           => $current_user->ID,
 			);
 		}

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -185,6 +185,13 @@ class Feedback {
 	protected $form_id = null;
 
 	/**
+	 * The logged-in user who submitted the feedback, if any.
+	 *
+	 * @var array|null Array with 'display_name' and 'id' keys, or null if not logged in.
+	 */
+	protected $logged_in_user = null;
+
+	/**
 	 * Create a response object from a feedback post ID.
 	 *
 	 * @param int $feedback_post_id The ID of the feedback post.
@@ -269,6 +276,7 @@ class Feedback {
 		$this->subject      = $parsed_content['subject'] ?? $this->get_first_field_of_type( 'subject' );
 
 		$this->notification_recipients = $parsed_content['notification_recipients'] ?? array();
+		$this->logged_in_user          = $parsed_content['logged_in_user'] ?? null;
 
 		$this->author_data = new Feedback_Author(
 			$this->get_first_field_of_type( 'name', 'pre_comment_author_name' ),
@@ -342,6 +350,15 @@ class Feedback {
 		$this->feedback_time         = current_time( 'mysql' );
 		$this->legacy_feedback_title = "{$this->get_author()} - {$this->feedback_time}";
 		$this->legacy_feedback_id    = md5( $this->legacy_feedback_title );
+
+		// Capture logged-in user info at submission time.
+		if ( is_user_logged_in() ) {
+			$current_user         = wp_get_current_user();
+			$this->logged_in_user = array(
+				'display_name' => $current_user->display_name,
+				'id'           => $current_user->ID,
+			);
+		}
 	}
 
 	/**
@@ -1079,6 +1096,15 @@ class Feedback {
 	}
 
 	/**
+	 * Get the logged-in user information who submitted the feedback.
+	 *
+	 * @return array|null Array with 'display_name' and 'id' keys, or null if not logged in.
+	 */
+	public function get_logged_in_user() {
+		return $this->logged_in_user;
+	}
+
+	/**
 	 * Get the email subject.
 	 *
 	 * @return string
@@ -1342,6 +1368,7 @@ class Feedback {
 				'country_code'            => $this->country_code,
 				'user_agent'              => $this->user_agent,
 				'notification_recipients' => $this->notification_recipients,
+				'logged_in_user'          => $this->logged_in_user,
 			),
 			$this->source->serialize()
 		);

--- a/projects/packages/forms/src/dashboard/components/inspector/response-meta/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-meta/index.tsx
@@ -126,7 +126,7 @@ const ResponseMeta = ( { response }: ResponseMetaProps ): import('react').JSX.El
 							<td>{ response.browser }</td>
 						</tr>
 					) }
-					{ response.logged_in_user && (
+					{ response.logged_in_user && response.logged_in_user.id && (
 						<tr>
 							<th>{ __( 'Logged-in user:', 'jetpack-forms' ) }&nbsp;</th>
 							<td>

--- a/projects/packages/forms/src/dashboard/components/inspector/response-meta/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-meta/index.tsx
@@ -47,6 +47,16 @@ const ResponseMeta = ( { response }: ResponseMetaProps ): import('react').JSX.El
 
 	const dateSettings = getDateSettings();
 
+	// Logged-in user row content: either shows display name and ID, username and ID, or just the ID.
+	const loggedInUser = response?.logged_in_user?.id ? response.logged_in_user : null;
+	const loggedInUserName = loggedInUser?.display_name || loggedInUser?.username || null;
+	let loggedInUserDisplay = null;
+	if ( loggedInUser ) {
+		loggedInUserDisplay = loggedInUserName
+			? `${ loggedInUserName } (#${ loggedInUser.id })`
+			: `#${ loggedInUser.id }`;
+	}
+
 	return (
 		<div className="jp-forms__inbox-response-meta">
 			<HStack alignment="topLeft" spacing="3" wrap={ false }>
@@ -126,14 +136,10 @@ const ResponseMeta = ( { response }: ResponseMetaProps ): import('react').JSX.El
 							<td>{ response.browser }</td>
 						</tr>
 					) }
-					{ response.logged_in_user && response.logged_in_user.id && (
+					{ loggedInUserDisplay && (
 						<tr>
 							<th>{ __( 'Logged-in user:', 'jetpack-forms' ) }&nbsp;</th>
-							<td>
-								{ response.logged_in_user.display_name
-									? `${ response.logged_in_user.display_name } (#${ response.logged_in_user.id })`
-									: `#${ response.logged_in_user.id }` }
-							</td>
+							<td>{ loggedInUserDisplay }</td>
 						</tr>
 					) }
 				</tbody>

--- a/projects/packages/forms/src/dashboard/components/inspector/response-meta/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-meta/index.tsx
@@ -126,6 +126,16 @@ const ResponseMeta = ( { response }: ResponseMetaProps ): import('react').JSX.El
 							<td>{ response.browser }</td>
 						</tr>
 					) }
+					{ response.logged_in_user && (
+						<tr>
+							<th>{ __( 'Logged-in user:', 'jetpack-forms' ) }&nbsp;</th>
+							<td>
+								{ response.logged_in_user.display_name
+									? `${ response.logged_in_user.display_name } (#${ response.logged_in_user.id })`
+									: `#${ response.logged_in_user.id }` }
+							</td>
+						</tr>
+					) }
 				</tbody>
 			</table>
 		</div>

--- a/projects/packages/forms/src/types/index.ts
+++ b/projects/packages/forms/src/types/index.ts
@@ -139,6 +139,7 @@ export interface FormResponse {
 	/** The logged-in user who submitted the form, if any. */
 	logged_in_user?: {
 		display_name: string;
+		username: string;
 		id: number;
 	} | null;
 	/** The title of the form that the response was submitted to. */

--- a/projects/packages/forms/src/types/index.ts
+++ b/projects/packages/forms/src/types/index.ts
@@ -136,6 +136,11 @@ export interface FormResponse {
 	country_code: string;
 	/** The browser and platform used to submit the form. */
 	browser?: string;
+	/** The logged-in user who submitted the form, if any. */
+	logged_in_user?: {
+		display_name: string;
+		id: number;
+	} | null;
 	/** The title of the form that the response was submitted to. */
 	entry_title: string;
 	/** The permalink of the form that the response was submitted to. */

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -184,6 +184,7 @@ class Contact_Form_Endpoint_Test extends TestCase {
 		$this->assertContains( 'null', $logged_in_user_schema['type'] );
 		$this->assertArrayHasKey( 'properties', $logged_in_user_schema );
 		$this->assertArrayHasKey( 'display_name', $logged_in_user_schema['properties'] );
+		$this->assertArrayHasKey( 'username', $logged_in_user_schema['properties'] );
 		$this->assertArrayHasKey( 'id', $logged_in_user_schema['properties'] );
 
 		// Also make sure that we don't have fields that are not relevant to feedback.
@@ -1204,6 +1205,7 @@ JSON_DATA{"1_name":"Test Author","2_email":"author@example.com","3_file":{"field
 				'entry_page'     => 123,
 				'logged_in_user' => array(
 					'display_name' => 'Test Display Name',
+					'username'     => 'testuser',
 					'id'           => $user_id,
 				),
 				'fields'         => array(
@@ -1236,8 +1238,10 @@ JSON_DATA{"1_name":"Test Author","2_email":"author@example.com","3_file":{"field
 		$this->assertArrayHasKey( 'logged_in_user', $data );
 		$this->assertIsArray( $data['logged_in_user'] );
 		$this->assertArrayHasKey( 'display_name', $data['logged_in_user'] );
+		$this->assertArrayHasKey( 'username', $data['logged_in_user'] );
 		$this->assertArrayHasKey( 'id', $data['logged_in_user'] );
 		$this->assertEquals( 'Test Display Name', $data['logged_in_user']['display_name'] );
+		$this->assertEquals( 'testuser', $data['logged_in_user']['username'] );
 		$this->assertEquals( $user_id, $data['logged_in_user']['id'] );
 
 		wp_delete_user( $user_id );

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -168,11 +168,23 @@ class Contact_Form_Endpoint_Test extends TestCase {
 		$this->assertArrayHasKey( 'author_avatar', $schema_properties );
 		$this->assertArrayHasKey( 'email_marketing_consent', $schema_properties );
 		$this->assertArrayHasKey( 'ip', $schema_properties );
+		$this->assertArrayHasKey( 'country_code', $schema_properties );
+		$this->assertArrayHasKey( 'browser', $schema_properties );
+		$this->assertArrayHasKey( 'logged_in_user', $schema_properties );
 		$this->assertArrayHasKey( 'entry_title', $schema_properties );
 		$this->assertArrayHasKey( 'entry_permalink', $schema_properties );
 		$this->assertArrayHasKey( 'subject', $schema_properties );
 		$this->assertArrayHasKey( 'fields', $schema_properties );
 		$this->assertArrayHasKey( 'is_unread', $schema_properties );
+
+		// Verify logged_in_user schema structure
+		$logged_in_user_schema = $schema_properties['logged_in_user'];
+		$this->assertArrayHasKey( 'type', $logged_in_user_schema );
+		$this->assertContains( 'object', $logged_in_user_schema['type'] );
+		$this->assertContains( 'null', $logged_in_user_schema['type'] );
+		$this->assertArrayHasKey( 'properties', $logged_in_user_schema );
+		$this->assertArrayHasKey( 'display_name', $logged_in_user_schema['properties'] );
+		$this->assertArrayHasKey( 'id', $logged_in_user_schema['properties'] );
 
 		// Also make sure that we don't have fields that are not relevant to feedback.
 		$this->assertArrayNotHasKey( 'link', $schema_properties );
@@ -1168,5 +1180,110 @@ JSON_DATA{"1_name":"Test Author","2_email":"author@example.com","3_file":{"field
 		$response = $this->server->dispatch( $request );
 
 		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test prepare_item_for_response includes logged_in_user when user is logged in.
+	 */
+	public function test_prepare_item_for_response_with_logged_in_user() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login'   => 'testuser',
+				'user_pass'    => 'testpass',
+				'display_name' => 'Test Display Name',
+			)
+		);
+
+		$feedback_time = current_time( 'mysql' );
+		$content       = wp_json_encode(
+			array(
+				'subject'        => 'Test Subject',
+				'ip'             => '127.0.0.1',
+				'country_code'   => 'US',
+				'entry_title'    => 'Test Form',
+				'entry_page'     => 123,
+				'logged_in_user' => array(
+					'display_name' => 'Test Display Name',
+					'id'           => $user_id,
+				),
+				'fields'         => array(
+					array(
+						'id'    => '1',
+						'label' => 'Name',
+						'value' => 'Submitter Name',
+					),
+				),
+			),
+			JSON_UNESCAPED_SLASHES
+		);
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'      => 'feedback',
+				'post_status'    => 'publish',
+				'post_title'     => 'Test Feedback - ' . $feedback_time,
+				'post_content'   => $content,
+				'post_mime_type' => 'v2',
+			)
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/feedback/' . $post_id );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+
+		$this->assertArrayHasKey( 'logged_in_user', $data );
+		$this->assertIsArray( $data['logged_in_user'] );
+		$this->assertArrayHasKey( 'display_name', $data['logged_in_user'] );
+		$this->assertArrayHasKey( 'id', $data['logged_in_user'] );
+		$this->assertEquals( 'Test Display Name', $data['logged_in_user']['display_name'] );
+		$this->assertEquals( $user_id, $data['logged_in_user']['id'] );
+
+		wp_delete_user( $user_id );
+	}
+
+	/**
+	 * Test prepare_item_for_response returns null for logged_in_user when not logged in.
+	 */
+	public function test_prepare_item_for_response_without_logged_in_user() {
+		$feedback_time = current_time( 'mysql' );
+		$content       = wp_json_encode(
+			array(
+				'subject'        => 'Test Subject',
+				'ip'             => '127.0.0.1',
+				'country_code'   => 'US',
+				'entry_title'    => 'Test Form',
+				'entry_page'     => 123,
+				'logged_in_user' => null,
+				'fields'         => array(
+					array(
+						'id'    => '1',
+						'label' => 'Name',
+						'value' => 'Submitter Name',
+					),
+				),
+			),
+			JSON_UNESCAPED_SLASHES
+		);
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'      => 'feedback',
+				'post_status'    => 'publish',
+				'post_title'     => 'Test Feedback - ' . $feedback_time,
+				'post_content'   => $content,
+				'post_mime_type' => 'v2',
+			)
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/feedback/' . $post_id );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+
+		$this->assertArrayHasKey( 'logged_in_user', $data );
+		$this->assertNull( $data['logged_in_user'] );
 	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Email_Renderer_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Email_Renderer_Test.php
@@ -211,7 +211,7 @@ class Feedback_Email_Renderer_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test generate_metadata_html with logged-in user renders user info.
+	 * Test generate_metadata_html with logged-in user renders user info with display name.
 	 */
 	public function test_generate_metadata_html_logged_in_user() {
 		$result = self::invoke_static_method(
@@ -219,6 +219,7 @@ class Feedback_Email_Renderer_Test extends BaseTestCase {
 			array(
 				'logged_in_user' => array(
 					'display_name' => 'John Smith',
+					'username'     => 'jsmith',
 					'id'           => 42,
 				),
 			)
@@ -226,17 +227,56 @@ class Feedback_Email_Renderer_Test extends BaseTestCase {
 
 		$this->assertStringContainsString( 'Logged-in user', $result );
 		$this->assertStringContainsString( 'John Smith (#42)', $result );
+		$this->assertStringNotContainsString( 'jsmith', $result );
 	}
 
 	/**
-	 * Test generate_metadata_html with logged-in user without display name shows ID only.
+	 * Test generate_metadata_html with logged-in user uses username as fallback when no display name.
 	 */
-	public function test_generate_metadata_html_logged_in_user_no_display_name() {
+	public function test_generate_metadata_html_logged_in_user_username_fallback() {
 		$result = self::invoke_static_method(
 			'generate_metadata_html',
 			array(
 				'logged_in_user' => array(
 					'display_name' => '',
+					'username'     => 'jsmith',
+					'id'           => 123,
+				),
+			)
+		);
+
+		$this->assertStringContainsString( 'Logged-in user', $result );
+		$this->assertStringContainsString( 'jsmith (#123)', $result );
+	}
+
+	/**
+	 * Test generate_metadata_html with logged-in user uses username as fallback when display name is null.
+	 */
+	public function test_generate_metadata_html_logged_in_user_username_fallback_null_display_name() {
+		$result = self::invoke_static_method(
+			'generate_metadata_html',
+			array(
+				'logged_in_user' => array(
+					'username' => 'fallbackuser',
+					'id'       => 456,
+				),
+			)
+		);
+
+		$this->assertStringContainsString( 'Logged-in user', $result );
+		$this->assertStringContainsString( 'fallbackuser (#456)', $result );
+	}
+
+	/**
+	 * Test generate_metadata_html with logged-in user shows ID only when both display name and username are empty.
+	 */
+	public function test_generate_metadata_html_logged_in_user_id_only() {
+		$result = self::invoke_static_method(
+			'generate_metadata_html',
+			array(
+				'logged_in_user' => array(
+					'display_name' => '',
+					'username'     => '',
 					'id'           => 123,
 				),
 			)

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Email_Renderer_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Email_Renderer_Test.php
@@ -211,6 +211,58 @@ class Feedback_Email_Renderer_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test generate_metadata_html with logged-in user renders user info.
+	 */
+	public function test_generate_metadata_html_logged_in_user() {
+		$result = self::invoke_static_method(
+			'generate_metadata_html',
+			array(
+				'logged_in_user' => array(
+					'display_name' => 'John Smith',
+					'id'           => 42,
+				),
+			)
+		);
+
+		$this->assertStringContainsString( 'Logged-in user', $result );
+		$this->assertStringContainsString( 'John Smith (#42)', $result );
+	}
+
+	/**
+	 * Test generate_metadata_html with logged-in user without display name shows ID only.
+	 */
+	public function test_generate_metadata_html_logged_in_user_no_display_name() {
+		$result = self::invoke_static_method(
+			'generate_metadata_html',
+			array(
+				'logged_in_user' => array(
+					'display_name' => '',
+					'id'           => 123,
+				),
+			)
+		);
+
+		$this->assertStringContainsString( 'Logged-in user', $result );
+		$this->assertStringContainsString( '#123', $result );
+		$this->assertStringNotContainsString( '(#123)', $result );
+	}
+
+	/**
+	 * Test generate_metadata_html without logged-in user omits the row.
+	 */
+	public function test_generate_metadata_html_no_logged_in_user() {
+		$result = self::invoke_static_method(
+			'generate_metadata_html',
+			array(
+				'date'   => 'January 1, 2025',
+				'device' => 'Desktop',
+			)
+		);
+
+		$this->assertStringNotContainsString( 'Logged-in user', $result );
+	}
+
+	/**
 	 * Test format_field_for_email with label renders label, value, and field icon.
 	 */
 	public function test_format_field_for_email_with_label() {

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Entry_Metadata_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Entry_Metadata_Test.php
@@ -351,8 +351,10 @@ class Feedback_Entry_Metadata_Test extends BaseTestCase {
 		$logged_in_user = $response->get_logged_in_user();
 		$this->assertIsArray( $logged_in_user, 'Logged-in user should be an array' );
 		$this->assertArrayHasKey( 'display_name', $logged_in_user, 'Logged-in user should have display_name key' );
+		$this->assertArrayHasKey( 'username', $logged_in_user, 'Logged-in user should have username key' );
 		$this->assertArrayHasKey( 'id', $logged_in_user, 'Logged-in user should have id key' );
 		$this->assertEquals( 'Test Submitter', $logged_in_user['display_name'], 'Display name should match' );
+		$this->assertEquals( 'testsubmitter', $logged_in_user['username'], 'Username should match' );
 		$this->assertEquals( $user_id, $logged_in_user['id'], 'User ID should match' );
 
 		// Check saved response has the same data
@@ -437,5 +439,43 @@ class Feedback_Entry_Metadata_Test extends BaseTestCase {
 		$saved_response = Feedback::get( $post_id );
 		$this->assertNotNull( $saved_response->get_logged_in_user(), 'Logged-in user should not be null for legacy feedback' );
 		$this->assertEquals( $logged_in_user, $saved_response->get_logged_in_user(), 'Logged-in user should match legacy data' );
+	}
+
+	/**
+	 * Test that username is captured alongside display_name and id.
+	 */
+	public function test_logged_in_user_includes_username() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login'   => 'usernametest',
+				'user_email'   => 'username@example.com',
+				'user_pass'    => 'password123',
+				'display_name' => 'Display Name Test',
+				'role'         => 'subscriber',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		$form_id    = Utility::get_form_id();
+		$_post_data = Utility::get_post_request(
+			array(
+				'name'  => 'Test Name',
+				'email' => 'test@example.com',
+			),
+			'g' . $form_id
+		);
+
+		$form     = new Contact_Form( array(), '' );
+		$response = Feedback::from_submission( $_post_data, $form );
+
+		$logged_in_user = $response->get_logged_in_user();
+		$this->assertIsArray( $logged_in_user );
+		$this->assertArrayHasKey( 'username', $logged_in_user );
+		$this->assertEquals( 'usernametest', $logged_in_user['username'] );
+		$this->assertEquals( 'Display Name Test', $logged_in_user['display_name'] );
+		$this->assertEquals( $user_id, $logged_in_user['id'] );
+
+		wp_delete_user( $user_id );
+		wp_set_current_user( 0 );
 	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Entry_Metadata_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Entry_Metadata_Test.php
@@ -304,4 +304,138 @@ class Feedback_Entry_Metadata_Test extends BaseTestCase {
 		$this->assertStringContainsString( $post->post_date, $response->get_time(), 'Feedback submitted time should match the form submission' );
 		$this->assertStringContainsString( $post->post_date, $saved_response->get_time(), 'Feedback submitted time should match the saved form submission' );
 	}
+
+	/**
+	 * Test that logged-in user info is captured and persists after save/load.
+	 */
+	public function test_logged_in_user_captured_during_submission() {
+		// Create a test user and log them in
+		$user_id = wp_insert_user(
+			array(
+				'user_login'   => 'testsubmitter',
+				'user_email'   => 'submitter@example.com',
+				'user_pass'    => 'password123',
+				'display_name' => 'Test Submitter',
+				'role'         => 'subscriber',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		$form_id    = Utility::get_form_id();
+		$_post_data = Utility::get_post_request(
+			array(
+				'name'    => 'John Doe',
+				'email'   => 'john@example.com',
+				'message' => 'Test message from logged-in user',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		$response         = Feedback::from_submission( $_post_data, $form );
+		$feedback_post_id = $response->save();
+		$saved_response   = Feedback::get( $feedback_post_id );
+
+		// The logged-in user info should be present
+		$this->assertNotEmpty( $response->get_logged_in_user(), 'Logged-in user should not be empty for submission' );
+		$this->assertNotEmpty( $saved_response->get_logged_in_user(), 'Logged-in user should not be empty after save/load' );
+
+		// Check the structure and values
+		$logged_in_user = $response->get_logged_in_user();
+		$this->assertIsArray( $logged_in_user, 'Logged-in user should be an array' );
+		$this->assertArrayHasKey( 'display_name', $logged_in_user, 'Logged-in user should have display_name key' );
+		$this->assertArrayHasKey( 'id', $logged_in_user, 'Logged-in user should have id key' );
+		$this->assertEquals( 'Test Submitter', $logged_in_user['display_name'], 'Display name should match' );
+		$this->assertEquals( $user_id, $logged_in_user['id'], 'User ID should match' );
+
+		// Check saved response has the same data
+		$saved_logged_in_user = $saved_response->get_logged_in_user();
+		$this->assertEquals( $logged_in_user, $saved_logged_in_user, 'Logged-in user info should match after save/load' );
+
+		// Clean up
+		wp_delete_user( $user_id );
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * Test that logged-in user is null when no user is logged in.
+	 */
+	public function test_logged_in_user_null_when_not_logged_in() {
+		// Ensure no user is logged in
+		wp_set_current_user( 0 );
+
+		$form_id    = Utility::get_form_id();
+		$_post_data = Utility::get_post_request(
+			array(
+				'name'    => 'Anonymous User',
+				'email'   => 'anon@example.com',
+				'message' => 'Test message from anonymous user',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		$response         = Feedback::from_submission( $_post_data, $form );
+		$feedback_post_id = $response->save();
+		$saved_response   = Feedback::get( $feedback_post_id );
+
+		// The logged-in user should be null
+		$this->assertNull( $response->get_logged_in_user(), 'Logged-in user should be null when not logged in' );
+		$this->assertNull( $saved_response->get_logged_in_user(), 'Logged-in user should be null after save/load when not logged in' );
+	}
+
+	/**
+	 * Test that logged-in user persists through serialization for legacy feedback.
+	 */
+	public function test_logged_in_user_in_legacy_feedback() {
+		$logged_in_user = array(
+			'display_name' => 'Legacy User',
+			'id'           => 42,
+		);
+
+		// Create a v3 feedback post with logged_in_user data
+		$content = wp_json_encode(
+			array(
+				'subject'        => 'Test Subject',
+				'ip'             => '127.0.0.1',
+				'country_code'   => 'US',
+				'user_agent'     => 'Mozilla/5.0',
+				'logged_in_user' => $logged_in_user,
+				'entry_title'    => 'Test Page',
+				'entry_page'     => 1,
+				'source_type'    => 'single',
+				'request_url'    => 'https://example.com',
+				'fields'         => array(),
+			),
+			JSON_UNESCAPED_SLASHES
+		);
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'      => Feedback::POST_TYPE,
+				'post_title'     => 'Legacy Feedback with User',
+				'post_content'   => addslashes( $content ),
+				'post_status'    => 'publish',
+				'post_mime_type' => 'v3',
+			)
+		);
+
+		$saved_response = Feedback::get( $post_id );
+		$this->assertNotNull( $saved_response->get_logged_in_user(), 'Logged-in user should not be null for legacy feedback' );
+		$this->assertEquals( $logged_in_user, $saved_response->get_logged_in_user(), 'Logged-in user should match legacy data' );
+	}
 }

--- a/projects/plugins/jetpack/changelog/pr-47652
+++ b/projects/plugins/jetpack/changelog/pr-47652
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Add logged-in user display name and ID to form submission emails and response sidebar.


### PR DESCRIPTION


## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Adds info (display name & ID) about logged in user in emails and response sidebar

We used to have this info in the email footers, but with the template redesign  in https://github.com/Automattic/jetpack/pull/47117, that info went missing. So I'm adding it back and also adding it to the wp admin sidebar.

#### Before, and when user isn't logged in

Sidebar
<img width="410" height="300" alt="Screenshot 2026-03-18 at 11 17 12" src="https://github.com/user-attachments/assets/8b6ae67f-1d8c-4377-af26-dc8332ac8502" />
Email
<img width="891" height="324" alt="Screenshot 2026-03-18 at 11 00 42" src="https://github.com/user-attachments/assets/adfa0e69-03ff-475a-a454-f5ae922b5ea8" />

#### After, when user is logged in
Sidebar
<img width="481" height="242" alt="Screenshot 2026-03-18 at 10 22 32" src="https://github.com/user-attachments/assets/8be38342-f5a5-491d-b627-61af359ad60f" />
Email
<img width="401" height="302" alt="image" src="https://github.com/user-attachments/assets/bedaaaaf-c75b-4a9f-8729-a481c0d915c8" />


### Other information
<!-- Check the box below to generate a changelog entry. -->
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Be logged in in wordpress and submit a form
* Do the same while not being logged in
* See email via localhost:1080 and the response in sidebar
* Check that old responses without this info also work