### PR TITLE
CRM: Disable PHP tests on PHP 8.4.19

### DIFF
--- a/projects/plugins/crm/changelog/update-crm-disable_tests_on_PHP_8.4.19
+++ b/projects/plugins/crm/changelog/update-crm-disable_tests_on_PHP_8.4.19
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Disable tests on PHP 8.4.19.
+
+

--- a/projects/plugins/crm/tests/action-skip-test-php.sh
+++ b/projects/plugins/crm/tests/action-skip-test-php.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 
+# Skip tests on PHP 8.4.19 due to inconsistent Codeception timeouts on that version.
+# @todo: remove this when PHP 8.4 has a higher patch version: p1773618372849869-slack-C034JEXD1RD
+if php -r 'exit(PHP_VERSION === "8.4.19" ? 0 : 1);'; then
+	echo "Skipping Codeception tests on PHP 8.4.19 (current: $(php -r 'echo PHP_VERSION;'))"
+	exit 3
+fi
+
 # Skip tests on PHP 8.5+ due to dependency constraints (dompdf v2)
 if php -r 'exit(PHP_VERSION_ID >= 80500 ? 0 : 1);'; then
 	echo "Skipping tests on PHP 8.5+ (current: $(php -r 'echo PHP_VERSION;'))"
 	exit 3
 fi
-
-# Uncomment the below snippet to disable tests on WP trunk
-# if [[ "$WP_BRANCH" == 'trunk' ]]; then
-# 	echo "Codeception tests against WP trunk are temporarily disabled."
-# 	exit 3
-# fi


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
It seems PHP 8.4.19 has inconsistent timeouts when running CRM Codeception tests. It's not something we've been able to reproduce outside of CI, and there's no easy way to force a lower version (see attempt in #47632) in CI, so for now let's disable them for that specific version.

Once PHP 8.4.20 is available, tests should again run and we can check if things are better.

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* p1773618372849869-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

CRM tests should be skipped in PHP 8.4.19 runs.