### PR TITLE
ci: post-build: fix artifact "poisoning"

### DIFF
--- a/.github/workflows/post-build.yml
+++ b/.github/workflows/post-build.yml
@@ -287,10 +287,11 @@ jobs:
           name: ${{ needs.find_artifact.outputs.artifact_name }}
           github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
+          path: ${{ runner.temp }}/artifact/
 
       - name: Extract build artifact
         env:
-          ARTIFACT_FILENAME: ${{ needs.find_artifact.outputs.artifact_filename }}
+          ARTIFACT_FILENAME: ${{ runner.temp }}/artifact/${{ needs.find_artifact.outputs.artifact_filename }}
         shell: bash
         run: tar --xz -xvvf "$ARTIFACT_FILENAME" build/plugins.tsv
 
@@ -354,10 +355,11 @@ jobs:
           name: ${{ needs.find_artifact.outputs.artifact_name }}
           github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
+          path: ${{ runner.temp }}/artifact/
 
       - name: Extract build artifact
         env:
-          ARTIFACT_FILENAME: ${{ needs.find_artifact.outputs.artifact_filename }}
+          ARTIFACT_FILENAME: ${{ runner.temp }}/artifact/${{ needs.find_artifact.outputs.artifact_filename }}
         shell: bash
         run: tar --xz -xvvf "$ARTIFACT_FILENAME" build
 
@@ -442,10 +444,11 @@ jobs:
           name: ${{ needs.find_artifact.outputs.artifact_name }}
           github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
+          path: ${{ runner.temp }}/artifact/
 
       - name: Extract build artifact
         env:
-          ARTIFACT_FILENAME: ${{ needs.find_artifact.outputs.artifact_filename }}
+          ARTIFACT_FILENAME: ${{ runner.temp }}/artifact/${{ needs.find_artifact.outputs.artifact_filename }}
         shell: bash
         run: tar --xz -xvvf "$ARTIFACT_FILENAME" build
 


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
GitHub's code scanning raised a new alert about a potential artifact "poisoning" after we switched to actions/download-artifact in post-build, presumably on the chance that someone might somehow have the artifact contain extra files that would overwrite important things.

I don't know why it didn't complain about the other two places in the same workflow that do the same thing. May as well do the same fix to all three.

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
https://github.com/Automattic/jetpack/security/code-scanning/560

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* CI happy? The relevant bits of Post-Build actually ran?