### PR TITLE
Settings: modernize UI with @wordpress/components Card

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/settings-card/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-card/index.jsx
@@ -1,5 +1,6 @@
 import { getUserConnectionUrl } from '@automattic/jetpack-connection';
 import { getSiteFragment } from '@automattic/jetpack-shared-extension-utils';
+import { Card, CardHeader, CardBody } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import PropTypes from 'prop-types';
@@ -7,7 +8,6 @@ import { connect } from 'react-redux';
 import Button from 'components/button';
 import JetpackBanner from 'components/jetpack-banner';
 import ModuleOverridenBanner from 'components/module-overridden-banner';
-import SectionHeader from 'components/section-header';
 import analytics from 'lib/analytics';
 import {
 	FEATURE_SECURITY_SCANNING_JETPACK,
@@ -578,41 +578,47 @@ export const SettingsCard = inprops => {
 
 	return (
 		getGoogleAnalyticsOverridenBanner() || (
-			<form
-				{ ...( moduleId ? { id: moduleId } : null ) }
-				className={ `jp-form-settings-card` }
-				onSubmit={ ! isDisabled && ! isSaving ? props.onSubmit : undefined }
-			>
-				<SectionHeader label={ header }>
-					{ ! props.hideButton && (
-						<Button
-							primary
-							rna
-							compact
-							type="submit"
-							disabled={ isDisabled || isSaving || ! props.isDirty() }
-						>
-							{ isSaving
-								? _x( 'Saving…', 'Button caption', 'jetpack' )
-								: _x(
-										'Save settings',
-										'Button caption',
-										'jetpack',
-										/* dummy arg to avoid bad minification */ 0
-								  ) }
-						</Button>
-					) }
-					{ props.action && (
-						<ProStatus
-							proFeature={ props.action }
-							siteAdminUrl={ props.siteAdminUrl }
-							isCompact={ false }
-						/>
-					) }
-				</SectionHeader>
-				{ children }
-				{ banner }
-			</form>
+			<Card className="jp-form-settings-card">
+				<form
+					{ ...( moduleId ? { id: moduleId } : null ) }
+					onSubmit={ ! isDisabled && ! isSaving ? props.onSubmit : undefined }
+				>
+					<CardHeader className="jp-form-settings-card__header">
+						<span className="jp-form-settings-card__header-label">{ header }</span>
+						<div className="jp-form-settings-card__header-actions">
+							{ ! props.hideButton && (
+								<Button
+									primary
+									rna
+									compact
+									type="submit"
+									disabled={ isDisabled || isSaving || ! props.isDirty() }
+								>
+									{ isSaving
+										? _x( 'Saving…', 'Button caption', 'jetpack' )
+										: _x(
+												'Save settings',
+												'Button caption',
+												'jetpack',
+												/* dummy arg to avoid bad minification */ 0
+										  ) }
+								</Button>
+							) }
+							{ props.action && (
+								<ProStatus
+									proFeature={ props.action }
+									siteAdminUrl={ props.siteAdminUrl }
+									isCompact={ false }
+								/>
+							) }
+						</div>
+					</CardHeader>
+					<CardBody size="none">
+						{ children }
+						{ banner }
+					</CardBody>
+				</form>
+			</Card>
 		)
 	);
 };

--- a/projects/plugins/jetpack/_inc/client/components/settings-card/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/settings-card/style.scss
@@ -4,21 +4,24 @@
 .jp-form-settings-card {
 	margin-bottom: rem.convert(24px);
 	font-size: rem.convert(14px);
-	box-shadow: 0 0 40px rgba(0, 0, 0, 0.08);
-	border-radius: rem.convert(4px);
 
-	+ .jp-at-a-glance__stats-card {
-		margin-bottom: rem.convert(24px);
+	.jp-form-settings-card__header {
+		font-size: rem.convert(20px);
+		font-weight: 500;
+		min-height: unset;
 	}
 
-	> :first-child {
-		border-top-left-radius: rem.convert(4px);
-		border-top-right-radius: rem.convert(4px);
+	.jp-form-settings-card__header-label {
+		flex-grow: 1;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
 	}
 
-	> :last-child {
-		border-bottom-left-radius: rem.convert(4px);
-		border-bottom-right-radius: rem.convert(4px);
+	.jp-form-settings-card__header-actions {
+		display: flex;
+		align-items: center;
+		flex-shrink: 0;
 	}
 
 	.jp-settings-card__configure-link {
@@ -32,7 +35,9 @@
 
 	.dops-card {
 		box-shadow: none;
+		margin: 0;
 		padding: rem.convert(16px) rem.convert(24px);
+		background: transparent;
 
 		&::after {
 			display: none;

--- a/projects/plugins/jetpack/_inc/client/components/settings-card/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/components/settings-card/test/component.js
@@ -69,8 +69,11 @@ describe( 'SettingsCard', () => {
 				<Child />
 			</SettingsCard>
 		);
-		// eslint-disable-next-line testing-library/no-node-access
-		expect( screen.getByText( 'Comments' ).closest( '.dops-section-header' ) ).toBeInTheDocument();
+
+		const header = screen.getByText( 'Comments' );
+		expect( header ).toBeInTheDocument();
+		// Verify it's inside the card header
+		expect( header.closest( '.jp-form-settings-card__header' ) ).not.toBeNull(); // eslint-disable-line testing-library/no-node-access
 	} );
 
 	it( "when not saving and has settings to save, it's enabled", () => {
@@ -97,11 +100,11 @@ describe( 'SettingsCard', () => {
 			);
 			expect(
 				// eslint-disable-next-line testing-library/no-node-access
-				screen.getByText( 'A custom header' ).closest( '.dops-section-header' )
+				screen.getByText( 'A custom header' ).closest( '.jp-form-settings-card__header' )
 			).toBeInTheDocument();
 			expect(
 				// eslint-disable-next-line testing-library/no-node-access
-				screen.queryByText( 'Comments' )?.closest( '.dops-section-header' ) || null
+				screen.queryByText( 'Comments' )?.closest( '.jp-form-settings-card__header' ) || null
 			).not.toBeInTheDocument();
 		} );
 	} );

--- a/projects/plugins/jetpack/_inc/client/components/settings-group/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-group/index.jsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import Card from 'components/card';
 import SupportInfo from 'components/support-info';
 import {
 	isOfflineMode,
@@ -54,17 +53,15 @@ export const SettingsGroup = inprops => {
 	}
 
 	return (
-		<div className={ clsx( 'jp-form-settings-group', props.className ) }>
-			<Card
-				className={ clsx( {
-					'jp-form-has-child': props.hasChild,
-					'jp-form-settings-disable': disableInOfflineMode || disableInSiteConnectionMode,
-				} ) }
-			>
-				{ displayFadeBlock && <div className="jp-form-block-fade" /> }
-				{ props.support.link && <SupportInfo module={ module } { ...props.support } /> }
-				{ props.children }
-			</Card>
+		<div
+			className={ clsx( 'jp-form-settings-group', props.className, {
+				'jp-form-has-child': props.hasChild,
+				'jp-form-settings-disable': disableInOfflineMode || disableInSiteConnectionMode,
+			} ) }
+		>
+			{ displayFadeBlock && <div className="jp-form-block-fade" /> }
+			{ props.support.link && <SupportInfo module={ module } { ...props.support } /> }
+			{ props.children }
 		</div>
 	);
 };

--- a/projects/plugins/jetpack/_inc/client/components/settings-group/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/settings-group/style.scss
@@ -5,6 +5,8 @@
 .jp-form-settings-group {
 	position: relative;
 	margin-bottom: 0;
+	padding: rem.convert(16px) rem.convert(24px);
+	padding-right: rem.convert(72px);
 
 	p {
 		font-size: typography.$font-body-small;
@@ -38,10 +40,6 @@
 		font-weight: 400;
 		overflow-wrap: break-word;
 
-		+ .dops-card {
-			margin-top: rem.convert(16px);
-		}
-
 		&.is-warning {
 			color: colors.$alert-red;
 		}
@@ -49,15 +47,6 @@
 		a {
 			text-decoration: underline;
 		}
-	}
-
-	.dops-foldable-card & {
-
-		/* padding-bottom: 16px; */
-	}
-
-	.dops-card {
-		padding-right: rem.convert(72px);
 	}
 
 	.jp-support-info {
@@ -77,19 +66,6 @@
 	.form-toggle__switch {
 		float: left;
 		margin-top: 2px;
-	}
-
-	> .dops-card:first-child {
-		margin-bottom: 0;
-	}
-
-	.dops-foldable-card & .dops-card {
-		padding: 0;
-		box-shadow: none;
-	}
-
-	&.foldable-wrapper > .dops-card {
-		padding: 0;
 	}
 
 	.email-settings__title {

--- a/projects/plugins/jetpack/_inc/client/components/settings-group/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/components/settings-group/test/component.js
@@ -54,7 +54,9 @@ describe( 'SettingsGroup', () => {
 	it( 'outputs a special CSS class when it has the hasChild property', () => {
 		const { container } = render( <SettingsGroup support={ testProps.info } hasChild /> );
 		// eslint-disable-next-line testing-library/no-container
-		expect( container.querySelector( '.dops-card' ) ).toHaveClass( 'jp-form-has-child' );
+		expect( container.querySelector( '.jp-form-settings-group' ) ).toHaveClass(
+			'jp-form-has-child'
+		);
 	} );
 
 	it( 'the support info icon has an informational tooltip', () => {

--- a/projects/plugins/jetpack/_inc/client/newsletter/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/newsletter/test/component.js
@@ -113,7 +113,7 @@ describe( 'Newsletter', () => {
 		it( 'renders header and manage subscribers link', () => {
 			render( <Newsletter { ...defaultProps } />, { initialState } );
 			expect(
-				screen.getByText( 'Newsletter' ).closest( '.dops-section-header' )
+				screen.getByText( 'Newsletter' ).closest( '.jp-form-settings-card__header' )
 			).toBeInTheDocument();
 			expect( screen.getByRole( 'link', { name: 'Manage all subscribers' } ) ).toBeInTheDocument();
 		} );

--- a/projects/plugins/jetpack/_inc/client/settings/style.scss
+++ b/projects/plugins/jetpack/_inc/client/settings/style.scss
@@ -1,6 +1,16 @@
 @use "../scss/mixins/breakpoints";
 @use "../scss/functions/rem";
 
+.jp-settings-admin-page .admin-ui-page {
+	background-color: #fcfcfc;
+}
+
+.jp-settings-admin-page .jp-lower {
+	max-width: 660px;
+	margin-left: auto;
+	margin-right: auto;
+}
+
 .jp-settings-container {
 
 	a,
@@ -31,6 +41,10 @@
 
 	.dops-banner.dops-card {
 		border-left: none;
+		border-top: none;
+	}
+
+	.jp-form-settings-group + .dops-banner.dops-card {
 		border-top: 1px solid var(--jp-gray);
 	}
 
@@ -89,7 +103,7 @@
 	}
 
 	.jp-form-settings-group + .jp-form-settings-group {
-		border-top: 1px solid var(--jp-gray);
+		border-top: none;
 	}
 
 	.dops-search__input[type="search"] {

--- a/projects/plugins/jetpack/changelog/update-jetpack-settings-cards
+++ b/projects/plugins/jetpack/changelog/update-jetpack-settings-cards
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Settings: modernize settings page UI using @wordpress/components Card and constrain content to 660px max-width.


### PR DESCRIPTION
## Proposed changes
  * Modernize the Jetpack Settings page UI by wrapping each settings section in `@wordpress/components` Card
  components (Card, CardHeader, CardBody), replacing the legacy DOPS SectionHeader and Card wrappers.
  * Constrain the settings content area to a max-width of 660px, centered on the page.
  * Remove the inner DOPS Card wrapper from SettingsGroup, simplifying the component hierarchy.
  * Clean up separator lines between settings groups and fix double-border issues with upgrade banners.

### Screenshots

Before | After
--|--
<img width="1321" height="982" alt="image" src="https://github.com/user-attachments/assets/74d88eb7-f490-4372-8338-08fc6e0a2892" /> | <img width="1311" height="1113" alt="image" src="https://github.com/user-attachments/assets/7b949beb-3f83-463d-85e6-0eb8f804477b" />


### Other information
N/A

## Related product discussion/links
N/A

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

  * Go to `/wp-admin/admin.php?page=jetpack#/settings`
  * Verify each settings tab (Security, Performance, Writing, Sharing, Discussion, etc.) renders cards with rounded
  corners and proper spacing.
  * Verify the content area is centered with a max-width of 660px.
  * Verify the page background color is visible around the cards.
  * Verify dropdowns (e.g., Carousel color scheme on Writing > Media) open fully without being clipped.
  * Verify Save settings buttons and toggle controls work as expected.
  * Verify upgrade banners display without double borders.
