### PR TITLE
Forms: fix phone field initialization failure (FORMS-629)

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-phone-field-dependency-loading
+++ b/projects/packages/forms/changelog/fix-forms-phone-field-dependency-loading
@@ -2,4 +2,4 @@ Significance: patch
 Type: fixed
 Comment: Fixes FORMS-629
 
-Fix phone field initialization failure when script module loads after DOMContentLoaded
+Fix phone field initialization failure when script module loads after DOMContentLoaded.

--- a/projects/packages/forms/changelog/fix-forms-phone-field-dependency-loading
+++ b/projects/packages/forms/changelog/fix-forms-phone-field-dependency-loading
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fixes FORMS-629
+
+Fix phone field initialization failure when script module loads after DOMContentLoaded

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -3375,7 +3375,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		\wp_enqueue_script_module(
 			'jetpack-form-phone-field',
 			plugins_url( '../../dist/modules/field-phone/view.js', __FILE__ ),
-			array( '@wordpress/interactivity' ),
+			array( '@wordpress/interactivity', 'jp-forms-view' ),
 			$version
 		);
 	}

--- a/projects/packages/forms/src/modules/field-phone/view.js
+++ b/projects/packages/forms/src/modules/field-phone/view.js
@@ -4,7 +4,6 @@ import {
 	getConfig,
 	getElement,
 	withSyncEvent as originalWithSyncEvent,
-	withScope,
 } from '@wordpress/interactivity';
 import parsePhoneNumber, { AsYouType } from 'libphonenumber-js';
 import { countries } from '../../blocks/field-telephone/country-list.js';
@@ -21,6 +20,65 @@ const asYouTypes = {};
 const phoneInputRefs = {};
 const searchInputRefs = {};
 const optionsListRefs = {};
+
+/**
+ * Ensures the phone field is fully initialized. Serves as both the primary
+ * initialization path (called from data-wp-init) and a safety net for event
+ * handlers in case the init callback was missed — which can happen when the
+ * module loads after DOMContentLoaded and the Interactivity API has already
+ * processed the DOM.
+ *
+ * @param {string} fieldId - The field ID to initialize.
+ * @return {boolean} Whether the field is initialized and ready.
+ */
+const ensureInitialized = fieldId => {
+	if ( asYouTypes[ fieldId ] ) {
+		return true;
+	}
+
+	const context = getContext();
+	if ( ! context.showCountrySelector ) {
+		return true;
+	}
+
+	// Resolve refs via DOM query if register callbacks haven't fired.
+	const { ref } = getElement();
+	const wrapper = ref.closest( '.jetpack-field__input-phone-wrapper' );
+	if ( ! wrapper ) {
+		return false;
+	}
+
+	if ( ! phoneInputRefs[ fieldId ] ) {
+		phoneInputRefs[ fieldId ] = wrapper.querySelector( '.jetpack-field__input-element' );
+	}
+	if ( ! searchInputRefs[ fieldId ] ) {
+		searchInputRefs[ fieldId ] = wrapper.querySelector( '.jetpack-combobox-search' );
+	}
+	if ( ! optionsListRefs[ fieldId ] ) {
+		optionsListRefs[ fieldId ] = wrapper.querySelector( '.jetpack-combobox-options' );
+	}
+
+	if (
+		! phoneInputRefs[ fieldId ] ||
+		! searchInputRefs[ fieldId ] ||
+		! optionsListRefs[ fieldId ]
+	) {
+		return false;
+	}
+
+	const config = getConfig( 'jetpack/field-phone' );
+	context.allCountries = countries.map( country => ( {
+		...country,
+		country: config?.i18n?.countryNames?.[ country.code ] || '',
+		selected: country.code === context.defaultCountry,
+	} ) );
+	context.filteredCountries = [ ...context.allCountries ];
+	context.selectedCountry = context.filteredCountries.find(
+		country => country.code === context.defaultCountry
+	);
+	asYouTypes[ fieldId ] = new AsYouType( context.defaultCountry );
+	return true;
+};
 
 /**
  * Sets flag text on an element by modifying existing text node data instead of
@@ -54,7 +112,7 @@ const updateSelection = selectedCountry => {
 	} ) );
 };
 
-const { actions, callbacks } = store( NAMESPACE, {
+const { actions } = store( NAMESPACE, {
 	state: {
 		validators: {
 			phone: ( value, isRequired ) => {
@@ -106,6 +164,9 @@ const { actions, callbacks } = store( NAMESPACE, {
 				context.phoneNumber = context.fullPhoneNumber = value;
 				return;
 			}
+			if ( ! ensureInitialized( fieldId ) ) {
+				return;
+			}
 			const groomedValue = value.indexOf( '00' ) === 0 ? '+' + value.slice( 2 ) : value;
 
 			asYouTypes[ fieldId ].reset();
@@ -125,6 +186,9 @@ const { actions, callbacks } = store( NAMESPACE, {
 		},
 		phoneCountryChangeHandler() {
 			const context = getContext();
+			if ( ! ensureInitialized( context.fieldId ) ) {
+				return;
+			}
 			// this context.filtered is from the template iterator
 			context.selectedCountry = { ...context.filtered };
 			updateSelection( context.selectedCountry );
@@ -133,6 +197,9 @@ const { actions, callbacks } = store( NAMESPACE, {
 		},
 		phoneComboboxInputHandler( event ) {
 			const context = getContext();
+			if ( ! ensureInitialized( context.fieldId ) ) {
+				return;
+			}
 			const searchTerm = event.target.value.toLowerCase();
 			context.filteredCountries = context.allCountries.filter(
 				country =>
@@ -144,6 +211,9 @@ const { actions, callbacks } = store( NAMESPACE, {
 		},
 		phoneComboboxKeydownHandler: withSyncEvent( event => {
 			const context = getContext();
+			if ( ! ensureInitialized( context.fieldId ) ) {
+				return;
+			}
 			if ( event.key === 'Escape' ) {
 				context.comboboxOpen = false;
 			} else if ( event.key === 'Enter' ) {
@@ -213,6 +283,9 @@ const { actions, callbacks } = store( NAMESPACE, {
 		},
 		phoneComboboxToggle() {
 			const context = getContext();
+			if ( ! ensureInitialized( context.fieldId ) ) {
+				return;
+			}
 			context.comboboxOpen = ! context.comboboxOpen;
 			if ( context.comboboxOpen ) {
 				setTimeout( () => {
@@ -265,44 +338,7 @@ const { actions, callbacks } = store( NAMESPACE, {
 		},
 		initializePhoneFieldCustomComboBox() {
 			const context = getContext();
-			if ( ! context.showCountrySelector ) {
-				return;
-			}
-
-			if (
-				! phoneInputRefs[ context.fieldId ] ||
-				! searchInputRefs[ context.fieldId ] ||
-				! optionsListRefs[ context.fieldId ]
-			) {
-				const { ref } = getElement();
-				// delay execution with a timeout and scoping withScope and return.
-				setTimeout(
-					withScope( function () {
-						const context2 = getContext();
-						phoneInputRefs[ context2.fieldId ] = ref;
-						searchInputRefs[ context2.fieldId ] = ref.parentElement.querySelector(
-							'.jetpack-combobox-search'
-						);
-						optionsListRefs[ context2.fieldId ] = ref.parentElement.querySelector(
-							'.jetpack-combobox-options'
-						);
-						callbacks.initializePhoneFieldCustomComboBox();
-					} ),
-					100
-				);
-				return;
-			}
-			const config = getConfig( 'jetpack/field-phone' );
-			context.allCountries = countries.map( country => ( {
-				...country,
-				country: config?.i18n?.countryNames?.[ country.code ] || '',
-				selected: country.code === context.defaultCountry,
-			} ) );
-			context.filteredCountries = [ ...context.allCountries ];
-			context.selectedCountry = context.filteredCountries.find(
-				country => country.code === context.defaultCountry
-			);
-			asYouTypes[ context.fieldId ] = new AsYouType( context.defaultCountry );
+			ensureInitialized( context.fieldId );
 		},
 	},
 } );

--- a/projects/packages/forms/src/modules/field-phone/view.js
+++ b/projects/packages/forms/src/modules/field-phone/view.js
@@ -69,7 +69,7 @@ const ensureInitialized = fieldId => {
 	const config = getConfig( 'jetpack/field-phone' );
 	context.allCountries = countries.map( country => ( {
 		...country,
-		country: config?.i18n?.countryNames?.[ country.code ] || '',
+		country: config?.i18n?.countryNames?.[ country.code ] || country.country,
 		selected: country.code === context.defaultCountry,
 	} ) );
 	context.filteredCountries = [ ...context.allCountries ];

--- a/projects/packages/forms/tests/js/modules/field-phone/view.test.js
+++ b/projects/packages/forms/tests/js/modules/field-phone/view.test.js
@@ -6,7 +6,6 @@ const mockGetContext = jest.fn();
 const mockGetConfig = jest.fn();
 const mockGetElement = jest.fn();
 const mockWithSyncEvent = jest.fn( callback => callback );
-const mockWithScope = jest.fn( callback => callback );
 
 await jest.unstable_mockModule( '@wordpress/interactivity', () => ( {
 	store: mockStore,
@@ -14,7 +13,6 @@ await jest.unstable_mockModule( '@wordpress/interactivity', () => ( {
 	getConfig: mockGetConfig,
 	getElement: mockGetElement,
 	withSyncEvent: mockWithSyncEvent,
-	withScope: mockWithScope,
 } ) );
 
 // Mock libphonenumber-js
@@ -254,7 +252,7 @@ describe( 'Phone Field View', () => {
 			expect( mockContext.fullPhoneNumber ).toBe( '555-123-4567' );
 		} );
 
-		test( 'calls actions correctly with country selector enabled', () => {
+		test( 'self-heals initialization when called with country selector enabled', () => {
 			mockContext.showCountrySelector = true;
 			mockContext.fieldId = 'test-phone';
 
@@ -266,11 +264,12 @@ describe( 'Phone Field View', () => {
 			const mockUpdateField = jest.fn();
 			storeConfig.actions.updateField = mockUpdateField;
 
-			// This will throw because internal refs aren't set up, but that's expected behavior
-			// In real usage, the callback would have been called first
-			expect( () => {
-				storeConfig.actions.phoneNumberInputHandler( mockEvent );
-			} ).toThrow();
+			// With ensureInitialized, the handler should self-heal by querying
+			// the DOM for refs and initializing, rather than throwing.
+			storeConfig.actions.phoneNumberInputHandler( mockEvent );
+
+			expect( mockAsYouType ).toHaveBeenCalledWith( 'US' );
+			expect( mockUpdateField ).toHaveBeenCalledWith( 'test-phone', '555-123-4567' );
 		} );
 	} );
 
@@ -488,111 +487,51 @@ describe( 'Phone Field View', () => {
 			expect( mockGetConfig ).not.toHaveBeenCalled();
 		} );
 
-		test( 'initializes phone field with country selector', () => {
+		test( 'initializes phone field with country selector via DOM query', () => {
 			mockContext.showCountrySelector = true;
+			mockContext.fieldId = 'init-test-phone';
 
-			// Mock the element querySelector methods
-			const mockParentElement = {
-				querySelector: jest
-					.fn()
-					.mockReturnValueOnce( document.querySelector( '.jetpack-combobox-search' ) )
-					.mockReturnValueOnce( document.querySelector( '.jetpack-combobox-options' ) ),
-			};
-
-			const mockPhoneInput = {
-				parentElement: mockParentElement,
-			};
-
-			mockGetElement.mockReturnValue( { ref: mockPhoneInput } );
+			// Point getElement to the tel input inside the DOM structure
+			const phoneInput = document.querySelector( '.jetpack-field__input-element' );
+			mockGetElement.mockReturnValue( { ref: phoneInput } );
 
 			storeConfig.callbacks.initializePhoneFieldCustomComboBox();
 
 			expect( mockGetConfig ).toHaveBeenCalledWith( 'jetpack/field-phone' );
+			expect( mockAsYouType ).toHaveBeenCalledWith( 'US' );
+			expect( mockContext.allCountries ).toHaveLength( 3 );
+			expect( mockContext.selectedCountry.code ).toBe( 'US' );
 		} );
 
-		test( 'uses delayed initialization when internal refs are not set up', () => {
-			// Use a fresh fieldId that hasn't been initialized yet
+		test( 'skips initialization if wrapper is not found', () => {
 			mockContext.showCountrySelector = true;
-			mockContext.fieldId = 'fresh-phone-field';
+			mockContext.fieldId = 'orphan-field';
 
-			// Mock setTimeout to capture the delayed callback
-			const originalSetTimeout = global.setTimeout;
-			const mockSetTimeout = jest.fn();
-			global.setTimeout = mockSetTimeout;
+			// Element not inside the expected wrapper
+			const orphanElement = document.createElement( 'input' );
+			document.body.appendChild( orphanElement );
+			mockGetElement.mockReturnValue( { ref: orphanElement } );
 
-			// Mock element for delayed initialization
-			const mockPhoneInput = document.querySelector( '.jetpack-field__input-element' );
-			const mockParentElement = {
-				querySelector: jest
-					.fn()
-					.mockReturnValueOnce( document.querySelector( '.jetpack-combobox-search' ) )
-					.mockReturnValueOnce( document.querySelector( '.jetpack-combobox-options' ) ),
-			};
-
-			// Mock a proper element structure
-			Object.defineProperty( mockPhoneInput, 'parentElement', {
-				value: mockParentElement,
-				writable: true,
-			} );
-
-			mockGetElement.mockReturnValue( { ref: mockPhoneInput } );
-
-			// First call - should trigger delayed initialization since refs aren't set up
 			storeConfig.callbacks.initializePhoneFieldCustomComboBox();
 
-			// Verify setTimeout was called with 100ms delay
-			expect( mockSetTimeout ).toHaveBeenCalledWith( expect.any( Function ), 100 );
-
-			// Verify mockWithScope was called (for scoping the delayed callback)
-			expect( mockWithScope ).toHaveBeenCalled();
-
-			// Should not have called getConfig yet since it's delayed
 			expect( mockGetConfig ).not.toHaveBeenCalled();
-
-			// Restore original setTimeout to execute the delayed callback
-			global.setTimeout = originalSetTimeout;
-
-			// Now simulate the delayed execution by calling the setTimeout callback
-			const delayedCallback = mockSetTimeout.mock.calls[ 0 ][ 0 ];
-			delayedCallback();
-
-			// Now it should have called getConfig
-			expect( mockGetConfig ).toHaveBeenCalledWith( 'jetpack/field-phone' );
+			expect( mockAsYouType ).not.toHaveBeenCalled();
 		} );
 
-		test( 'handles recursive delayed initialization pattern', () => {
-			// Use a different fresh fieldId
+		test( 'does not re-initialize if already initialized', () => {
 			mockContext.showCountrySelector = true;
-			mockContext.fieldId = 'another-fresh-field';
+			mockContext.fieldId = 'reinit-test-phone';
 
-			// Mock setTimeout to capture multiple delayed callbacks
-			const mockSetTimeout = jest.fn();
-			global.setTimeout = mockSetTimeout;
+			const phoneInput = document.querySelector( '.jetpack-field__input-element' );
+			mockGetElement.mockReturnValue( { ref: phoneInput } );
 
-			// Mock element structure
-			const mockPhoneInput = document.querySelector( '.jetpack-field__input-element' );
-			const mockParentElement = {
-				querySelector: jest
-					.fn()
-					.mockReturnValue( document.querySelector( '.jetpack-combobox-search' ) ),
-			};
-
-			Object.defineProperty( mockPhoneInput, 'parentElement', {
-				value: mockParentElement,
-				writable: true,
-			} );
-
-			mockGetElement.mockReturnValue( { ref: mockPhoneInput } );
-
-			// First call - should trigger delayed initialization
+			// First initialization
 			storeConfig.callbacks.initializePhoneFieldCustomComboBox();
+			expect( mockAsYouType ).toHaveBeenCalledTimes( 1 );
 
-			expect( mockSetTimeout ).toHaveBeenCalledTimes( 1 );
-
-			// Verify the delayed pattern is set up correctly
-			expect( mockSetTimeout ).toHaveBeenCalledWith( expect.any( Function ), 100 );
-
-			// Should not have called getConfig yet since it's delayed
+			// Second call should be a no-op (fast path)
+			mockGetConfig.mockClear();
+			storeConfig.callbacks.initializePhoneFieldCustomComboBox();
 			expect( mockGetConfig ).not.toHaveBeenCalled();
 		} );
 	} );


### PR DESCRIPTION
Part of FORMS-629

## Proposed changes

The phone field (`jetpack/field-telephone`) with country selector intermittently fails to initialize — no flag, no country prefix, TypeErrors on interaction. This PR fixes the root cause and adds a safety net.

### Root cause

The WordPress Interactivity API (v6.41.0) silently skips `data-wp-init` callbacks that are not registered in the store at hydration time. From `@wordpress/interactivity/src/directives.tsx`:

```ts
let result = evaluate(entry);  // lookup callback in store
if (typeof result === 'function') { result = result(); }
// If undefined -> silently does nothing. No error, no retry, no re-fire.
```

The phone field view module is 472KB (bundles `libphonenumber-js`). When this module loads after `DOMContentLoaded` — due to CDN delays, caching, or hosting optimizations — all four `data-wp-init` callbacks are missed. The store eventually receives the callbacks (which is why event handlers work on interaction), but `data-wp-init` has already fired and will not re-fire, leaving refs unset, countries unloaded, and `AsYouType` formatters uninitialized.

### What this PR does

**1. Self-healing initialization (view.js)**

Extracts the initialization logic into a reusable `ensureInitialized(fieldId)` helper that:
- Fast-returns if already initialized (checks `asYouTypes[fieldId]`)
- Resolves element refs via DOM queries (`ref.closest()` + `querySelector`)
- Initializes countries, selected country, and AsYouType formatter
- Returns a boolean indicating success

Every event handler that depends on initialized state calls `ensureInitialized()` as a guard. On the happy path (init ran normally), this is a single boolean check. When init was missed, the first interaction triggers full recovery.

Also removes the previous infinite `setTimeout` retry loop that could spin forever if DOM elements were not found.

**2. Module dependency declaration (PHP)**

Adds `jp-forms-view` to `jetpack-form-phone-field` `wp_enqueue_script_module` dependencies. The phone module extends the `jetpack/form` store and uses shared actions — this ensures WordPress enforces proper loading order.

### What this PR does NOT do

- Does not change `libphonenumber-js` import — the default build already uses `min` metadata (smallest available)
- Does not move phone store into the form module — would bloat the form bundle for all pages
- Does not switch to `data-wp-watch` — suffers the same silent-skip issue as `data-wp-init`

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* https://linear.app/a8c/issue/FORMS-629/forms-phone-number-field-fails-to-load

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

### 1. Normal behavior (verify no regression)

1. Create a post with a `jetpack/field-telephone` block (country selector enabled, any default country)
2. View the post on the frontend
3. Verify:
   - Flag emoji and country prefix (+1, +44, etc.) appear on load
   - Clicking the dropdown shows searchable country list with translated names
   - Selecting a country updates the flag and prefix
   - Typing a phone number works (as-you-type formatting with country selector)
   - No console errors

### 2. Simulating the race condition (verify the fix)

This simulates exactly what happens when the module loads after `DOMContentLoaded` and the Interactivity API skips all `data-wp-init` callbacks:

1. In `projects/packages/forms/src/modules/field-phone/view.js`, temporarily change these four callbacks to no-ops:
   ```js
   registerPhoneInput() { return; },
   registerPhoneComboboxSearchInput() { return; },
   registerPhoneComboboxOptionsList() { return; },
   initializePhoneFieldCustomComboBox() { return; },
   ```
2. Rebuild: `pnpm jetpack build packages/forms`
3. Load the page with the phone field — observe: **no flag, no prefix** (the broken state from FORMS-629)
4. Click the dropdown trigger — observe: **flag appears, countries load, dropdown opens normally, 0 console errors** (self-healing via `ensureInitialized()` in `phoneComboboxToggle`)
5. Select a country, type a number — everything works
6. **Revert the temporary changes** and rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)
