### PR TITLE
Brute Force Protection: Update error when module can't be activated.

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/jetpack-notices/state-notices.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-notices/state-notices.jsx
@@ -218,7 +218,7 @@ class JetpackStateNotices extends Component {
 				break;
 			case 'protect_misconfigured_ip':
 				message = __(
-					'Your server is misconfigured, which means that Jetpack Protect is unable to effectively protect your site.',
+					'Your server is misconfigured, which means that Jetpack Brute Force Protection is unable to effectively protect your site.',
 					'jetpack'
 				);
 				status = 'is-info';

--- a/projects/plugins/jetpack/changelog/update-brute-force-protect-error
+++ b/projects/plugins/jetpack/changelog/update-brute-force-protect-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Brute Force Protection: Update error when module can't be activated.


### PR DESCRIPTION
Addresses JETPACK-1436

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Updates error message to indicate that "Brute Force Protection" can't be activated instead of "Protect".
* The name of the module has been changed and this message wasn't updated.

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).


## Does this pull request change what data or activity we track or use?

No

## Testing instructions

- This is a minor text change to the error message. The functionality of what triggers the error remains the same.
