### PR TITLE
Help Center: Fix Help Center not loading on the block editor on support sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/DOTCOM-16404-support-editor-help-cente-not-showing
+++ b/projects/packages/jetpack-mu-wpcom/changelog/DOTCOM-16404-support-editor-help-cente-not-showing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Help Center now loads in the editor of /support

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -652,20 +652,20 @@ class Help_Center {
 			}
 		}
 
+		$suffix = $this->is_jetpack_disconnected() ? '-disconnected' : '';
+
 		if ( $is_next_admin ) {
-			$variant = 'ciab-admin' . ( $this->is_jetpack_disconnected() ? '-disconnected' : '' );
+			$variant = 'ciab-admin' . $suffix;
 		} elseif ( $this->is_support_site ) {
 			if ( ! is_user_logged_in() ) {
 				$variant = 'logged-out';
 			} else {
-				$variant = 'wp-admin' . ( $this->is_jetpack_disconnected() ? '-disconnected' : '' );
+				$variant = ( $this->is_block_editor() ? 'gutenberg' : 'wp-admin' ) . $suffix;
 			}
 		} elseif ( $this->is_loading_on_frontend() ) {
 			$variant = 'wp-admin-disconnected';
-		} elseif ( $this->is_block_editor() ) {
-			$variant = 'gutenberg' . ( $this->is_jetpack_disconnected() ? '-disconnected' : '' );
 		} else {
-			$variant = 'wp-admin' . ( $this->is_jetpack_disconnected() ? '-disconnected' : '' );
+			$variant = ( $this->is_block_editor() ? 'gutenberg' : 'wp-admin' ) . $suffix;
 		}
 
 		$cache_key  = 'help-center-asset-' . $variant . '.asset.json';


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-16404/support-editor-help-cente-not-showing

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* On support sites (/support, /forums), the Help Center variant selection always used wp-admin for logged-in users, even when the block editor was active. The is_block_editor() check was in a
  later elseif branch that was unreachable because is_support_site was checked first.

  This moves the block editor detection inside both the is_support_site branch and the default branch, so the correct gutenberg variant is loaded when appropriate. Also extracts the disconnected suffix computation to reduce duplication.


### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Sync the mu plugin
* Go to https://en.support.wordpress.com/wp-admin/post-new.php
* Sandbox the support website
* The Help Center should be there
