### PR TITLE
CRM: Ensure proper flags are used with wp_json_encode()

### DIFF
--- a/projects/plugins/crm/.phpcs.dir.xml
+++ b/projects/plugins/crm/.phpcs.dir.xml
@@ -68,9 +68,4 @@
 			</property>
 		</properties>
 	</rule>
-
-	<!-- Pending https://github.com/Automattic/jetpack/pull/46111 -->
-	<rule ref="Jetpack.Functions.JsonEncodeFlags">
-		<exclude name="Jetpack.Functions.JsonEncodeFlags.Missing"/>
-	</rule>
 </ruleset>

--- a/projects/plugins/crm/admin/activation/wizard.ajax.php
+++ b/projects/plugins/crm/admin/activation/wizard.ajax.php
@@ -10,216 +10,217 @@ function zbs_wizard_fin() {
 	check_ajax_referer( 'zbswf-ajax-nonce', 'security' );
 	// only admin can do this too (extra security layer)
 
-	$r = array();
-
-	if ( current_user_can( 'manage_options' ) ) {
-
-		global $zbs;
-
-		// Retrieve post
-		$crm_name       = sanitize_text_field( $_POST['zbs_crm_name'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-		$crm_curr       = sanitize_text_field( $_POST['zbs_crm_curr'] );  // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-		$crm_type       = sanitize_text_field( $_POST['zbs_crm_type'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-		$crm_other      = sanitize_text_field( $_POST['zbs_crm_other'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-		$crm_menu_style = (int) sanitize_text_field( $_POST['zbs_crm_menu_style'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-		$crm_share      = empty( $_POST['zbs_crm_share_essentials'] ) ? 0 : 1;
-
-		$crm_enable_quotes     = empty( $_POST['zbs_quotes'] ) ? 0 : 1;
-		$crm_enable_invoices   = empty( $_POST['zbs_invoicing'] ) ? 0 : 1;
-		$crm_enable_woo_module = empty( $_POST['jpcrm_woo_module'] ) ? 0 : 1;
-
-		$bn      = sanitize_text_field( $_POST['zbs_crm_subblogname'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-		$fn      = sanitize_text_field( $_POST['zbs_crm_first_name'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-		$ln      = sanitize_text_field( $_POST['zbs_crm_last_name'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-		$em      = sanitize_text_field( $_POST['zbs_crm_email'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-		$emv     = zeroBSCRM_validateEmail( $em );
-		$crm_sub = empty( $_POST['zbs_crm_subscribed'] ) ? 0 : 1;
-
-		// Just to pass for smm:
-		$crm_enable_forms = 1;
-		$crm_override     = 0;
-		$crm_url          = '';
-
-		// Save down initial options as option bk
-		$init_options = array(
-			'share' => $crm_share,
-			'bn'    => $bn,
-			'fn'    => $fn,
-			'ln'    => $ln,
-			'em'    => $em,
-			'emv'   => $emv,
-			'smm'   => time(),
-			'n'     => $crm_name,
-			'u'     => $crm_url,
-			'o'     => $crm_other,
-			's'     => $crm_sub,
-			't'     => $crm_type,
-			'ov'    => $crm_override,
-			'eq'    => $crm_enable_quotes,
-			'ei'    => $crm_enable_invoices,
-			'ef'    => $crm_enable_forms,
-			'ew'    => $crm_enable_woo_module,
-			'ems'   => $crm_menu_style,
-			'v'     => $zbs::VERSION,
-			'cu'    => $crm_curr,
+	if ( ! current_user_can( 'manage_options' ) ) {
+		$r = array(
+			'message' => 'Unauthorised.',
+			'success' => 0,
 		);
-		update_option( 'zbs_initopts_' . time(), $init_options, false );
-
-		// Note: this only shares if "share essentials" has been ticked...
-		// ... or email subscribe (where upon our server ignores customer data except email sub details)
-		if ( is_callable( 'curl_init' ) && ( $crm_share === 1 || $crm_sub === 1 ) ) {
-
-			$crm_url = home_url();
-
-			// pass whether we are sharing essentials
-			$m = $init_options;
-
-			wp_remote_post(
-				$zbs->urls['smm'],
-				array(
-					'method'      => 'POST',
-					'timeout'     => 45,
-					'redirection' => 5,
-					'httpversion' => '1.0',
-					'blocking'    => true,
-					'headers'     => array(),
-					'body'        => $m,
-					'cookies'     => array(),
-				)
-			);
-
-		}
-
-		// Header text
-		$zbs->settings->update( 'customheadertext', $crm_name );
-
-		// load currency list
-		global $whwpCurrencyList; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-		if ( ! isset( $whwpCurrencyList ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-			require_once ZEROBSCRM_INCLUDE_PATH . 'wh.currency.lib.php';
-		}
-
-		// Currency (Grim but will work for now)
-		$curr_setting = array(
-			'chr'    => '$',
-			'strval' => 'USD',
-		);
-		if ( ! empty( $crm_curr ) ) {
-			foreach ( $whwpCurrencyList as $currency_obj ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-				if ( $currency_obj[1] === $crm_curr ) {
-					$curr_setting['chr']    = $currency_obj[0];
-					$curr_setting['strval'] = $currency_obj[1];
-					break;
-				}
-			}
-		}
-
-		// Save currency
-		$zbs->settings->update( 'currency', $curr_setting );
-
-		// Save Share Essentials
-		$zbs->settings->update( 'shareessentials', $crm_share );
-
-		// Menu style
-		switch ( $crm_menu_style ) {
-
-			case 1:
-				// full (normal) wp
-				$zbs->settings->update( 'menulayout', 1 );
-				break;
-
-			case 2:
-				// slimline
-				$zbs->settings->update( 'menulayout', 2 );
-				break;
-
-			case 3:
-				// CRM only
-				$zbs->settings->update( 'menulayout', 3 );
-				break;
-
-		}
-
-		// Enable/disable extensions
-		if ( $crm_enable_quotes === 1 ) {
-			zeroBSCRM_extension_install_quotebuilder();
-		} else {
-			zeroBSCRM_extension_uninstall_quotebuilder();
-		}
-
-		if ( $crm_enable_invoices === 1 ) {
-
-			zeroBSCRM_extension_install_invbuilder();
-			// This assumes they want pdf inv too ;)
-			zeroBSCRM_extension_install_pdfinv();
-
-		} else {
-
-			zeroBSCRM_extension_uninstall_invbuilder();
-
-		}
-
-		if ( $crm_enable_forms === 1 ) {
-			zeroBSCRM_extension_install_forms();
-		} else {
-			zeroBSCRM_extension_uninstall_forms();
-		}
-
-		if ( $crm_enable_woo_module === 1 ) {
-			zeroBSCRM_extension_install_woo_sync();
-		} else {
-			zeroBSCRM_extension_uninstall_woo_sync();
-		}
-
-		// Tax tables, defaults
-		// added basic in v3.0, this would be great to expand if we get operational country (assume by ip?)
-		// based on currency, not ideal.
-		$current_tax_tables = zeroBSCRM_taxRates_getTaxTableArr();
-		if ( is_array( $current_tax_tables ) && count( $current_tax_tables ) === 0 && is_array( $curr_setting ) && isset( $curr_setting['strval'] ) ) {
-
-			$rates_to_add = array();
-
-			// this can be factored out into a single 'setup packs' file ++
-			switch ( $curr_setting['strval'] ) {
-
-				case 'USD':
-					// state based, MEH. leave for v3.1+
-					break;
-
-				case 'GBP':
-					$rates_to_add[] = array(
-						'name' => 'VAT',
-						'rate' => 20.0,
-					);
-					break;
-
-			}
-
-			// add any
-			if ( count( $rates_to_add ) > 0 ) {
-				foreach ( $rates_to_add as $rate ) {
-
-					zeroBSCRM_taxRates_addUpdateTaxRate(
-						array(
-							// fields (directly)
-							'data' => $rate,
-						)
-					);
-				}
-			}
-		}
-
-		// log successful wizard completion
-		update_option( 'jpcrm_wizard_completed', 1 );
-
-		$r['message'] = 'success';
-		$r['success'] = 1;
-		wp_send_json( $r );
-	} else {
-		$r['message'] = 'Unauthorised to do this...';
-		$r['success'] = 0;
-		wp_send_json( $r );
+		wp_send_json( $r, 403, JSON_UNESCAPED_SLASHES );
 	}
+
+	global $zbs;
+
+	// Retrieve post
+	$crm_name       = sanitize_text_field( $_POST['zbs_crm_name'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+	$crm_curr       = sanitize_text_field( $_POST['zbs_crm_curr'] );  // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+	$crm_type       = sanitize_text_field( $_POST['zbs_crm_type'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+	$crm_other      = sanitize_text_field( $_POST['zbs_crm_other'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+	$crm_menu_style = (int) sanitize_text_field( $_POST['zbs_crm_menu_style'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+	$crm_share      = empty( $_POST['zbs_crm_share_essentials'] ) ? 0 : 1;
+
+	$crm_enable_quotes     = empty( $_POST['zbs_quotes'] ) ? 0 : 1;
+	$crm_enable_invoices   = empty( $_POST['zbs_invoicing'] ) ? 0 : 1;
+	$crm_enable_woo_module = empty( $_POST['jpcrm_woo_module'] ) ? 0 : 1;
+
+	$bn      = sanitize_text_field( $_POST['zbs_crm_subblogname'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+	$fn      = sanitize_text_field( $_POST['zbs_crm_first_name'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+	$ln      = sanitize_text_field( $_POST['zbs_crm_last_name'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+	$em      = sanitize_text_field( $_POST['zbs_crm_email'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+	$emv     = zeroBSCRM_validateEmail( $em );
+	$crm_sub = empty( $_POST['zbs_crm_subscribed'] ) ? 0 : 1;
+
+	// Just to pass for smm:
+	$crm_enable_forms = 1;
+	$crm_override     = 0;
+	$crm_url          = '';
+
+	// Save down initial options as option bk
+	$init_options = array(
+		'share' => $crm_share,
+		'bn'    => $bn,
+		'fn'    => $fn,
+		'ln'    => $ln,
+		'em'    => $em,
+		'emv'   => $emv,
+		'smm'   => time(),
+		'n'     => $crm_name,
+		'u'     => $crm_url,
+		'o'     => $crm_other,
+		's'     => $crm_sub,
+		't'     => $crm_type,
+		'ov'    => $crm_override,
+		'eq'    => $crm_enable_quotes,
+		'ei'    => $crm_enable_invoices,
+		'ef'    => $crm_enable_forms,
+		'ew'    => $crm_enable_woo_module,
+		'ems'   => $crm_menu_style,
+		'v'     => $zbs::VERSION,
+		'cu'    => $crm_curr,
+	);
+	update_option( 'zbs_initopts_' . time(), $init_options, false );
+
+	// Note: this only shares if "share essentials" has been ticked...
+	// ... or email subscribe (where upon our server ignores customer data except email sub details)
+	if ( is_callable( 'curl_init' ) && ( $crm_share === 1 || $crm_sub === 1 ) ) {
+
+		$crm_url = home_url();
+
+		// pass whether we are sharing essentials
+		$m = $init_options;
+
+		wp_remote_post(
+			$zbs->urls['smm'],
+			array(
+				'method'      => 'POST',
+				'timeout'     => 45,
+				'redirection' => 5,
+				'httpversion' => '1.0',
+				'blocking'    => true,
+				'headers'     => array(),
+				'body'        => $m,
+				'cookies'     => array(),
+			)
+		);
+
+	}
+
+	// Header text
+	$zbs->settings->update( 'customheadertext', $crm_name );
+
+	// load currency list
+	global $whwpCurrencyList; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	if ( ! isset( $whwpCurrencyList ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		require_once ZEROBSCRM_INCLUDE_PATH . 'wh.currency.lib.php';
+	}
+
+	// Currency (Grim but will work for now)
+	$curr_setting = array(
+		'chr'    => '$',
+		'strval' => 'USD',
+	);
+	if ( ! empty( $crm_curr ) ) {
+		foreach ( $whwpCurrencyList as $currency_obj ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			if ( $currency_obj[1] === $crm_curr ) {
+				$curr_setting['chr']    = $currency_obj[0];
+				$curr_setting['strval'] = $currency_obj[1];
+				break;
+			}
+		}
+	}
+
+	// Save currency
+	$zbs->settings->update( 'currency', $curr_setting );
+
+	// Save Share Essentials
+	$zbs->settings->update( 'shareessentials', $crm_share );
+
+	// Menu style
+	switch ( $crm_menu_style ) {
+
+		case 1:
+			// full (normal) wp
+			$zbs->settings->update( 'menulayout', 1 );
+			break;
+
+		case 2:
+			// slimline
+			$zbs->settings->update( 'menulayout', 2 );
+			break;
+
+		case 3:
+			// CRM only
+			$zbs->settings->update( 'menulayout', 3 );
+			break;
+
+	}
+
+	// Enable/disable extensions
+	if ( $crm_enable_quotes === 1 ) {
+		zeroBSCRM_extension_install_quotebuilder();
+	} else {
+		zeroBSCRM_extension_uninstall_quotebuilder();
+	}
+
+	if ( $crm_enable_invoices === 1 ) {
+
+		zeroBSCRM_extension_install_invbuilder();
+		// This assumes they want pdf inv too ;)
+		zeroBSCRM_extension_install_pdfinv();
+
+	} else {
+
+		zeroBSCRM_extension_uninstall_invbuilder();
+
+	}
+
+	if ( $crm_enable_forms === 1 ) {
+		zeroBSCRM_extension_install_forms();
+	} else {
+		zeroBSCRM_extension_uninstall_forms();
+	}
+
+	if ( $crm_enable_woo_module === 1 ) {
+		zeroBSCRM_extension_install_woo_sync();
+	} else {
+		zeroBSCRM_extension_uninstall_woo_sync();
+	}
+
+	// Tax tables, defaults
+	// added basic in v3.0, this would be great to expand if we get operational country (assume by ip?)
+	// based on currency, not ideal.
+	$current_tax_tables = zeroBSCRM_taxRates_getTaxTableArr();
+	if ( is_array( $current_tax_tables ) && count( $current_tax_tables ) === 0 && is_array( $curr_setting ) && isset( $curr_setting['strval'] ) ) {
+
+		$rates_to_add = array();
+
+		// this can be factored out into a single 'setup packs' file ++
+		switch ( $curr_setting['strval'] ) {
+
+			case 'USD':
+				// state based, MEH. leave for v3.1+
+				break;
+
+			case 'GBP':
+				$rates_to_add[] = array(
+					'name' => 'VAT',
+					'rate' => 20.0,
+				);
+				break;
+
+		}
+
+		// add any
+		if ( count( $rates_to_add ) > 0 ) {
+			foreach ( $rates_to_add as $rate ) {
+
+				zeroBSCRM_taxRates_addUpdateTaxRate(
+					array(
+						// fields (directly)
+						'data' => $rate,
+					)
+				);
+			}
+		}
+	}
+
+	// log successful wizard completion
+	update_option( 'jpcrm_wizard_completed', 1 );
+
+	$r = array(
+		'message' => 'Success.',
+		'success' => 1,
+	);
+	wp_send_json( $r, 200, JSON_UNESCAPED_SLASHES );
 }
 add_action( 'wp_ajax_nopriv_zbs_wizard_fin', 'zbs_wizard_fin' );
 add_action( 'wp_ajax_zbs_wizard_fin', 'zbs_wizard_fin' );

--- a/projects/plugins/crm/admin/contact/contact.ajax.php
+++ b/projects/plugins/crm/admin/contact/contact.ajax.php
@@ -9,12 +9,12 @@ function jpcrm_update_meta_ajax() {
 
 	// check perms
 	if ( ! zeroBSCRM_permsCustomers() ) {
-		wp_send_json_error( null, null, JSON_UNESCAPED_SLASHES );
+		wp_send_json_error( null, 403, JSON_UNESCAPED_SLASHES );
 	}
 
 	// check for params; note that we may want an empty value
 	if ( empty( $_POST['contact_id'] ) || empty( $_POST['meta_key'] ) ) {
-		wp_send_json_error( null, null, JSON_UNESCAPED_SLASHES );
+		wp_send_json_error( null, 200, JSON_UNESCAPED_SLASHES );
 	}
 
 	$valid_meta_keys = array( 'do-not-email' );
@@ -23,7 +23,7 @@ function jpcrm_update_meta_ajax() {
 
 	// check for valid meta key
 	if ( ! in_array( $meta_key, $valid_meta_keys, true ) ) {
-		wp_send_json_error( null, null, JSON_UNESCAPED_SLASHES );
+		wp_send_json_error( null, 200, JSON_UNESCAPED_SLASHES );
 	}
 
 	global $zbs;
@@ -41,9 +41,9 @@ function jpcrm_update_meta_ajax() {
 
 	}
 	if ( $success ) {
-		wp_send_json_success( null, null, JSON_UNESCAPED_SLASHES );
+		wp_send_json_success( null, 200, JSON_UNESCAPED_SLASHES );
 	} else {
-		wp_send_json_error( null, null, JSON_UNESCAPED_SLASHES );
+		wp_send_json_error( null, 200, JSON_UNESCAPED_SLASHES );
 	}
 }
 add_action( 'wp_ajax_jpcrm_update_meta', 'jpcrm_update_meta_ajax' );
@@ -106,7 +106,7 @@ function zeroBSCRM_generateClientPortalUser() { // phpcs:ignore WordPress.Naming
 			$m['message'] = 'WordPress User Created';
 			$m['success'] = true;
 			$m['user_id'] = $created;
-			wp_send_json( $m, null, JSON_UNESCAPED_SLASHES );
+			wp_send_json( $m, 200, JSON_UNESCAPED_SLASHES );
 		} else {
 
 			// if has wp id, & contact ID is set
@@ -120,7 +120,7 @@ function zeroBSCRM_generateClientPortalUser() { // phpcs:ignore WordPress.Naming
 			$m['message'] = __( 'User already exists or invalid email!', 'zero-bs-crm' );
 			$m['success'] = false;
 			$m['email']   = $email;
-			wp_send_json( $m, null, JSON_UNESCAPED_SLASHES );
+			wp_send_json( $m, 200, JSON_UNESCAPED_SLASHES );
 		}
 	}
 }
@@ -149,7 +149,7 @@ function zeroBSCRM_AJAX_zbsPortalAction() { // phpcs:ignore WordPress.NamingConv
 					zeroBSCRM_customerPortalDisableEnable( $contact_id, 'enable' );
 
 					// send success
-					wp_send_json( array( 'success' => 1 ), null, JSON_UNESCAPED_SLASHES );
+					wp_send_json( array( 'success' => 1 ), 200, JSON_UNESCAPED_SLASHES );
 
 					break;
 				// disable
@@ -158,7 +158,7 @@ function zeroBSCRM_AJAX_zbsPortalAction() { // phpcs:ignore WordPress.NamingConv
 					zeroBSCRM_customerPortalDisableEnable( $contact_id, 'disable' );
 
 					// send success
-					wp_send_json( array( 'success' => 1 ), null, JSON_UNESCAPED_SLASHES );
+					wp_send_json( array( 'success' => 1 ), 200, JSON_UNESCAPED_SLASHES );
 
 					break;
 				// Reset client portal password
@@ -172,7 +172,7 @@ function zeroBSCRM_AJAX_zbsPortalAction() { // phpcs:ignore WordPress.NamingConv
 							'success' => 1,
 							'pw'      => $newpw,
 						),
-						null,
+						200,
 						JSON_UNESCAPED_SLASHES
 					);
 

--- a/projects/plugins/crm/admin/contact/contact.ajax.php
+++ b/projects/plugins/crm/admin/contact/contact.ajax.php
@@ -9,12 +9,12 @@ function jpcrm_update_meta_ajax() {
 
 	// check perms
 	if ( ! zeroBSCRM_permsCustomers() ) {
-		wp_send_json_error();
+		wp_send_json_error( null, null, JSON_UNESCAPED_SLASHES );
 	}
 
 	// check for params; note that we may want an empty value
 	if ( empty( $_POST['contact_id'] ) || empty( $_POST['meta_key'] ) ) {
-		wp_send_json_error();
+		wp_send_json_error( null, null, JSON_UNESCAPED_SLASHES );
 	}
 
 	$valid_meta_keys = array( 'do-not-email' );
@@ -23,7 +23,7 @@ function jpcrm_update_meta_ajax() {
 
 	// check for valid meta key
 	if ( ! in_array( $meta_key, $valid_meta_keys, true ) ) {
-		wp_send_json_error();
+		wp_send_json_error( null, null, JSON_UNESCAPED_SLASHES );
 	}
 
 	global $zbs;
@@ -41,9 +41,9 @@ function jpcrm_update_meta_ajax() {
 
 	}
 	if ( $success ) {
-		wp_send_json_success();
+		wp_send_json_success( null, null, JSON_UNESCAPED_SLASHES );
 	} else {
-		wp_send_json_error();
+		wp_send_json_error( null, null, JSON_UNESCAPED_SLASHES );
 	}
 }
 add_action( 'wp_ajax_jpcrm_update_meta', 'jpcrm_update_meta_ajax' );
@@ -106,7 +106,7 @@ function zeroBSCRM_generateClientPortalUser() { // phpcs:ignore WordPress.Naming
 			$m['message'] = 'WordPress User Created';
 			$m['success'] = true;
 			$m['user_id'] = $created;
-			wp_send_json( $m );
+			wp_send_json( $m, null, JSON_UNESCAPED_SLASHES );
 		} else {
 
 			// if has wp id, & contact ID is set
@@ -120,7 +120,7 @@ function zeroBSCRM_generateClientPortalUser() { // phpcs:ignore WordPress.Naming
 			$m['message'] = __( 'User already exists or invalid email!', 'zero-bs-crm' );
 			$m['success'] = false;
 			$m['email']   = $email;
-			wp_send_json( $m );
+			wp_send_json( $m, null, JSON_UNESCAPED_SLASHES );
 		}
 	}
 }
@@ -149,7 +149,7 @@ function zeroBSCRM_AJAX_zbsPortalAction() { // phpcs:ignore WordPress.NamingConv
 					zeroBSCRM_customerPortalDisableEnable( $contact_id, 'enable' );
 
 					// send success
-					wp_send_json( array( 'success' => 1 ) );
+					wp_send_json( array( 'success' => 1 ), null, JSON_UNESCAPED_SLASHES );
 
 					break;
 				// disable
@@ -158,7 +158,7 @@ function zeroBSCRM_AJAX_zbsPortalAction() { // phpcs:ignore WordPress.NamingConv
 					zeroBSCRM_customerPortalDisableEnable( $contact_id, 'disable' );
 
 					// send success
-					wp_send_json( array( 'success' => 1 ) );
+					wp_send_json( array( 'success' => 1 ), null, JSON_UNESCAPED_SLASHES );
 
 					break;
 				// Reset client portal password
@@ -171,7 +171,9 @@ function zeroBSCRM_AJAX_zbsPortalAction() { // phpcs:ignore WordPress.NamingConv
 						array(
 							'success' => 1,
 							'pw'      => $newpw,
-						)
+						),
+						null,
+						JSON_UNESCAPED_SLASHES
 					);
 
 					break;
@@ -180,7 +182,7 @@ function zeroBSCRM_AJAX_zbsPortalAction() { // phpcs:ignore WordPress.NamingConv
 		}
 	}
 
-	wp_send_json_error( array( 'no-action-or-rights' => 1 ), 500 );
+	wp_send_json_error( array( 'no-action-or-rights' => 1 ), 500, JSON_UNESCAPED_SLASHES );
 }
 add_action( 'wp_ajax_zbsPortalAction', 'zeroBSCRM_AJAX_zbsPortalAction' );
 

--- a/projects/plugins/crm/admin/dashboard/dashboard.ajax.php
+++ b/projects/plugins/crm/admin/dashboard/dashboard.ajax.php
@@ -140,7 +140,7 @@ function jetpackcrm_dash_refresh() {
 		'chart'   => $chart,
 	);
 
-	wp_send_json( $r, null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( $r, 200, JSON_UNESCAPED_SLASHES );
 }
 add_action( 'wp_ajax_jetpackcrm_dash_refresh', 'jetpackcrm_dash_refresh' );
 
@@ -169,7 +169,7 @@ function jpcrm_dash_setting() {
 			update_user_meta( $current_user_id, $setting_key, $is_checked );
 
 			// No rights or failed key match
-			wp_send_json( array( 'fini' => 1 ), null, JSON_UNESCAPED_SLASHES );
+			wp_send_json( array( 'fini' => 1 ), 200, JSON_UNESCAPED_SLASHES );
 		}
 	}
 

--- a/projects/plugins/crm/admin/dashboard/dashboard.ajax.php
+++ b/projects/plugins/crm/admin/dashboard/dashboard.ajax.php
@@ -140,7 +140,7 @@ function jetpackcrm_dash_refresh() {
 		'chart'   => $chart,
 	);
 
-	wp_send_json( $r );
+	wp_send_json( $r, null, JSON_UNESCAPED_SLASHES );
 }
 add_action( 'wp_ajax_jetpackcrm_dash_refresh', 'jetpackcrm_dash_refresh' );
 
@@ -169,11 +169,11 @@ function jpcrm_dash_setting() {
 			update_user_meta( $current_user_id, $setting_key, $is_checked );
 
 			// No rights or failed key match
-			wp_send_json( array( 'fini' => 1 ) );
+			wp_send_json( array( 'fini' => 1 ), null, JSON_UNESCAPED_SLASHES );
 		}
 	}
 
 	// No rights or failed key match
-	wp_send_json_error( array( 'no-action-or-rights' => 1 ), 500 );
+	wp_send_json_error( array( 'no-action-or-rights' => 1 ), 500, JSON_UNESCAPED_SLASHES );
 }
 add_action( 'wp_ajax_zbs_dash_setting', 'jpcrm_dash_setting' );

--- a/projects/plugins/crm/admin/dashboard/main.page.php
+++ b/projects/plugins/crm/admin/dashboard/main.page.php
@@ -407,12 +407,13 @@ function jpcrm_render_dashboard_page() {
 		}
 	}
 
-	$jpcrm_dash_data  = 'const jpcrm_funnel_data = ' . wp_json_encode( $funnel_data ) . ';';
+	$jpcrm_dash_data  = 'const jpcrm_funnel_data = ' . wp_json_encode( $funnel_data, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . ';';
 	$jpcrm_dash_data .= 'const jpcrm_revenue_chart_data = ' . wp_json_encode(
 		array(
 			'labels' => $labels,
 			'data'   => $chartdata,
-		)
+		),
+		JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 	);
 	wp_add_inline_script( 'jpcrm-dash', $jpcrm_dash_data, 'before' );
 }

--- a/projects/plugins/crm/admin/dashboard/partials/first-use-dashboard-woo.block.php
+++ b/projects/plugins/crm/admin/dashboard/partials/first-use-dashboard-woo.block.php
@@ -101,7 +101,7 @@ $learn_from_mike_videos = array(
 	</div>
 </div>
 <?php // PHPCS:Ignore WordPress.Security.NonceVerification.Recommended ?>
-<script>var jpcrm_show_first_use_dash = <?php echo wp_json_encode( ! isset( $_GET['zbs-welcome-tour'] ) ); ?>;</script>
+<script>var jpcrm_show_first_use_dash = <?php echo isset( $_GET['zbs-welcome-tour'] ) ? 'false' : 'true'; ?>;</script>
 <?php
 
 ##/WLREMOVE

--- a/projects/plugins/crm/admin/dashboard/partials/first-use-dashboard.block.php
+++ b/projects/plugins/crm/admin/dashboard/partials/first-use-dashboard.block.php
@@ -122,7 +122,7 @@ $learn_from_mike_videos = array(
 	</div>
 </div>
 <?php // PHPCS:Ignore WordPress.Security.NonceVerification.Recommended ?>
-<script>var jpcrm_show_first_use_dash = <?php echo wp_json_encode( ! isset( $_GET['zbs-welcome-tour'] ) ); ?>;</script>
+<script>var jpcrm_show_first_use_dash = <?php echo isset( $_GET['zbs-welcome-tour'] ) ? 'false' : 'true'; ?>;</script>
 <?php
 
 ##/WLREMOVE

--- a/projects/plugins/crm/admin/email/email.ajax.php
+++ b/projects/plugins/crm/admin/email/email.ajax.php
@@ -20,7 +20,7 @@ function zeroBSCRM_star_email_thread() {
 	check_ajax_referer( 'zbscrmjs-glob-ajax-nonce', 'sec' );
 
 	if ( ! zeroBSCRM_permsSendEmailContacts() ) {
-		wp_send_json( array( 'processed' => -1 ) );
+		wp_send_json( array( 'processed' => -1 ), null, JSON_UNESCAPED_SLASHES );
 	}
 
 	global $wpdb, $ZBSCRM_t; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
@@ -28,7 +28,7 @@ function zeroBSCRM_star_email_thread() {
 	$sql        = $wpdb->prepare( 'UPDATE ' . $ZBSCRM_t['system_mail_hist'] . ' SET zbsmail_starred = 1 WHERE zbsmail_sender_thread = %d', $the_thread ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	$wpdb->query( $sql );
 	$m = array( 'message' => 'success' );
-	wp_send_json( $m );
+	wp_send_json( $m, null, JSON_UNESCAPED_SLASHES );
 }
 add_action( 'wp_ajax_zbs_email_star_thread', 'zeroBSCRM_star_email_thread' );
 
@@ -41,7 +41,7 @@ function zeroBSCRM_unstar_email_thread() {
 	check_ajax_referer( 'zbscrmjs-glob-ajax-nonce', 'sec' );
 
 	if ( ! zeroBSCRM_permsSendEmailContacts() ) {
-		wp_send_json( array( 'processed' => -1 ) );
+		wp_send_json( array( 'processed' => -1 ), null, JSON_UNESCAPED_SLASHES );
 	}
 
 	global $wpdb, $ZBSCRM_t; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
@@ -49,7 +49,7 @@ function zeroBSCRM_unstar_email_thread() {
 	$sql        = $wpdb->prepare( 'UPDATE ' . $ZBSCRM_t['system_mail_hist'] . ' SET zbsmail_starred = 0 WHERE zbsmail_sender_thread = %d', $the_thread ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	$wpdb->query( $sql );
 	$m = array( 'message' => 'success' );
-	wp_send_json( $m );
+	wp_send_json( $m, null, JSON_UNESCAPED_SLASHES );
 }
 add_action( 'wp_ajax_zbs_email_unstar_thread', 'zeroBSCRM_unstar_email_thread' );
 
@@ -61,7 +61,7 @@ function zeroBSCRM_delete_email_thread() {
 	check_ajax_referer( 'zbscrmjs-glob-ajax-nonce', 'sec' );
 
 	if ( ! zeroBSCRM_permsSendEmailContacts() ) {
-		wp_send_json( array( 'processed' => -1 ) );
+		wp_send_json( array( 'processed' => -1 ), null, JSON_UNESCAPED_SLASHES );
 	}
 
 	global $wpdb, $ZBSCRM_t; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
@@ -69,7 +69,7 @@ function zeroBSCRM_delete_email_thread() {
 	$sql        = $wpdb->prepare( 'DELETE FROM ' . $ZBSCRM_t['system_mail_hist'] . ' WHERE zbsmail_sender_thread = %d', $the_thread ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	$wpdb->query( $sql );
 	$m = array( 'message' => 'success' );
-	wp_send_json( $m );
+	wp_send_json( $m, null, JSON_UNESCAPED_SLASHES );
 }
 add_action( 'wp_ajax_zbs_delete_email_thread', 'zeroBSCRM_delete_email_thread' );
 
@@ -83,7 +83,7 @@ function zeroBSCRM_send_email_thread_ajax() {
 
 	// check permissions
 	if ( ! zeroBSCRM_permsSendEmailContacts() ) {
-		wp_send_json( array( 'processed' => -1 ) );
+		wp_send_json( array( 'processed' => -1 ), null, JSON_UNESCAPED_SLASHES );
 	}
 
 	global $wpdb, $ZBSCRM_t; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
@@ -123,7 +123,7 @@ function zeroBSCRM_emails_customer_panel() {
 	check_ajax_referer( 'zbscrmjs-glob-ajax-nonce', 'sec' );
 
 	if ( ! zeroBSCRM_permsSendEmailContacts() ) {
-		wp_send_json( array( 'processed' => -1 ) );
+		wp_send_json( array( 'processed' => -1 ), null, JSON_UNESCAPED_SLASHES );
 	}
 
 	$contact_id = ( empty( $_POST['cid'] ) ? -1 : (int) $_POST['cid'] );
@@ -171,7 +171,7 @@ function zeroBSCRM_emails_customer_panel() {
 
 	$ret['email'] = $email_ret;
 
-	wp_send_json( $ret, true );
+	wp_send_json( $ret, null, JSON_UNESCAPED_SLASHES );
 }
 add_action( 'wp_ajax_zbs_email_customer_panel', 'zeroBSCRM_emails_customer_panel' );
 
@@ -204,7 +204,7 @@ function jpcrm_send_single_email_from_box( $send_to_email = '', $thread_id = -1,
 	// check permissions
 	if ( ! zeroBSCRM_permsSendEmailContacts() ) {
 		if ( $exit_json ) {
-			wp_send_json( array( 'processed' => -1 ) );
+			wp_send_json( array( 'processed' => -1 ), null, JSON_UNESCAPED_SLASHES );
 		} else {
 			exit( 0 );
 		}
@@ -353,7 +353,7 @@ function jpcrm_send_single_email_from_box( $send_to_email = '', $thread_id = -1,
 
 	if ( $exit_json ) {
 
-		wp_send_json( $m );
+		wp_send_json( $m, null, JSON_UNESCAPED_SLASHES );
 
 	}
 	return $result;

--- a/projects/plugins/crm/admin/email/email.ajax.php
+++ b/projects/plugins/crm/admin/email/email.ajax.php
@@ -20,7 +20,7 @@ function zeroBSCRM_star_email_thread() {
 	check_ajax_referer( 'zbscrmjs-glob-ajax-nonce', 'sec' );
 
 	if ( ! zeroBSCRM_permsSendEmailContacts() ) {
-		wp_send_json( array( 'processed' => -1 ), null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( array( 'processed' => -1 ), 403, JSON_UNESCAPED_SLASHES );
 	}
 
 	global $wpdb, $ZBSCRM_t; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
@@ -28,7 +28,7 @@ function zeroBSCRM_star_email_thread() {
 	$sql        = $wpdb->prepare( 'UPDATE ' . $ZBSCRM_t['system_mail_hist'] . ' SET zbsmail_starred = 1 WHERE zbsmail_sender_thread = %d', $the_thread ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	$wpdb->query( $sql );
 	$m = array( 'message' => 'success' );
-	wp_send_json( $m, null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( $m, 200, JSON_UNESCAPED_SLASHES );
 }
 add_action( 'wp_ajax_zbs_email_star_thread', 'zeroBSCRM_star_email_thread' );
 
@@ -41,7 +41,7 @@ function zeroBSCRM_unstar_email_thread() {
 	check_ajax_referer( 'zbscrmjs-glob-ajax-nonce', 'sec' );
 
 	if ( ! zeroBSCRM_permsSendEmailContacts() ) {
-		wp_send_json( array( 'processed' => -1 ), null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( array( 'processed' => -1 ), 403, JSON_UNESCAPED_SLASHES );
 	}
 
 	global $wpdb, $ZBSCRM_t; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
@@ -49,7 +49,7 @@ function zeroBSCRM_unstar_email_thread() {
 	$sql        = $wpdb->prepare( 'UPDATE ' . $ZBSCRM_t['system_mail_hist'] . ' SET zbsmail_starred = 0 WHERE zbsmail_sender_thread = %d', $the_thread ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	$wpdb->query( $sql );
 	$m = array( 'message' => 'success' );
-	wp_send_json( $m, null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( $m, 200, JSON_UNESCAPED_SLASHES );
 }
 add_action( 'wp_ajax_zbs_email_unstar_thread', 'zeroBSCRM_unstar_email_thread' );
 
@@ -61,7 +61,7 @@ function zeroBSCRM_delete_email_thread() {
 	check_ajax_referer( 'zbscrmjs-glob-ajax-nonce', 'sec' );
 
 	if ( ! zeroBSCRM_permsSendEmailContacts() ) {
-		wp_send_json( array( 'processed' => -1 ), null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( array( 'processed' => -1 ), 403, JSON_UNESCAPED_SLASHES );
 	}
 
 	global $wpdb, $ZBSCRM_t; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
@@ -69,7 +69,7 @@ function zeroBSCRM_delete_email_thread() {
 	$sql        = $wpdb->prepare( 'DELETE FROM ' . $ZBSCRM_t['system_mail_hist'] . ' WHERE zbsmail_sender_thread = %d', $the_thread ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	$wpdb->query( $sql );
 	$m = array( 'message' => 'success' );
-	wp_send_json( $m, null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( $m, 200, JSON_UNESCAPED_SLASHES );
 }
 add_action( 'wp_ajax_zbs_delete_email_thread', 'zeroBSCRM_delete_email_thread' );
 
@@ -83,7 +83,7 @@ function zeroBSCRM_send_email_thread_ajax() {
 
 	// check permissions
 	if ( ! zeroBSCRM_permsSendEmailContacts() ) {
-		wp_send_json( array( 'processed' => -1 ), null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( array( 'processed' => -1 ), 403, JSON_UNESCAPED_SLASHES );
 	}
 
 	global $wpdb, $ZBSCRM_t; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
@@ -123,7 +123,7 @@ function zeroBSCRM_emails_customer_panel() {
 	check_ajax_referer( 'zbscrmjs-glob-ajax-nonce', 'sec' );
 
 	if ( ! zeroBSCRM_permsSendEmailContacts() ) {
-		wp_send_json( array( 'processed' => -1 ), null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( array( 'processed' => -1 ), 403, JSON_UNESCAPED_SLASHES );
 	}
 
 	$contact_id = ( empty( $_POST['cid'] ) ? -1 : (int) $_POST['cid'] );
@@ -171,7 +171,7 @@ function zeroBSCRM_emails_customer_panel() {
 
 	$ret['email'] = $email_ret;
 
-	wp_send_json( $ret, null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( $ret, 200, JSON_UNESCAPED_SLASHES );
 }
 add_action( 'wp_ajax_zbs_email_customer_panel', 'zeroBSCRM_emails_customer_panel' );
 
@@ -204,7 +204,7 @@ function jpcrm_send_single_email_from_box( $send_to_email = '', $thread_id = -1,
 	// check permissions
 	if ( ! zeroBSCRM_permsSendEmailContacts() ) {
 		if ( $exit_json ) {
-			wp_send_json( array( 'processed' => -1 ), null, JSON_UNESCAPED_SLASHES );
+			wp_send_json( array( 'processed' => -1 ), 403, JSON_UNESCAPED_SLASHES );
 		} else {
 			exit( 0 );
 		}
@@ -353,7 +353,7 @@ function jpcrm_send_single_email_from_box( $send_to_email = '', $thread_id = -1,
 
 	if ( $exit_json ) {
 
-		wp_send_json( $m, null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( $m, 200, JSON_UNESCAPED_SLASHES );
 
 	}
 	return $result;

--- a/projects/plugins/crm/admin/settings/custom-fields.page.php
+++ b/projects/plugins/crm/admin/settings/custom-fields.page.php
@@ -465,8 +465,8 @@ if ( $sbupdated ) {
 
 		// all custom js moved to admin.settings.js 12/3/19 :)
 
-		var wpzbscrmCustomFields = <?php echo json_encode( $current_custom_fields ); ?>;
-		var wpzbscrmAcceptableTypes = <?php echo json_encode( $acceptableCFTypes ); ?>;
+		var wpzbscrmCustomFields = <?php echo wp_json_encode( $current_custom_fields, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
+		var wpzbscrmAcceptableTypes = <?php echo wp_json_encode( $acceptableCFTypes, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
 		var wpzbscrm_settings_page = 'customfields'; // this fires init js in admin.settings.min.js
 		var wpzbscrm_settings_lang = {
 

--- a/projects/plugins/crm/admin/settings/mail-delivery.ajax.php
+++ b/projects/plugins/crm/admin/settings/mail-delivery.ajax.php
@@ -226,7 +226,7 @@ function zeroBSCRM_AJAX_mailDelivery_validateWPMail() {
 
 	// } Perms?
 	if ( ! zeroBSCRM_permsMailCampaigns() ) {
-		wp_send_json( array( 'permserror' => 1 ), null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( array( 'permserror' => 1 ), 403, JSON_UNESCAPED_SLASHES );
 	}
 
 	// } Retrieve...
@@ -301,7 +301,7 @@ function zeroBSCRM_AJAX_mailDelivery_validateWPMail() {
 					if ( ! isset( $existing_mail_delivery_methods[ $settingsKey ] ) ) {
 						$existing_mail_delivery_methods[ $settingsKey ] = $settingsArr;
 					} else {
-						wp_send_json( array( 'keyerror' => 1 ), null, JSON_UNESCAPED_SLASHES );
+						wp_send_json( array( 'keyerror' => 1 ), 200, JSON_UNESCAPED_SLASHES );
 					}
 
 					// } Update
@@ -334,7 +334,7 @@ function zeroBSCRM_AJAX_mailDelivery_validateWPMail() {
 
 	}
 
-	wp_send_json( $res, null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( $res, 200, JSON_UNESCAPED_SLASHES );
 }
 
 // } Attempts to validate mail delivery SMTP settings, send test email, & save's if validated
@@ -439,7 +439,7 @@ function zeroBSCRM_AJAX_mailDelivery_validateSMTP() {
 										),
 									),
 								),
-								null,
+								200,
 								JSON_UNESCAPED_SLASHES
 							);
 						}
@@ -488,7 +488,7 @@ function zeroBSCRM_AJAX_mailDelivery_validateSMTP() {
 
 	}
 
-	wp_send_json( $res, null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( $res, 200, JSON_UNESCAPED_SLASHES );
 }
 
 // } quickly checks if ports are open (pre smtp check)
@@ -556,7 +556,7 @@ function zeroBSCRM_AJAX_mailDelivery_validateSMTPPorts() {
 	}
 
 	$res['open'] = $okay;
-	wp_send_json( $res, null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( $res, 200, JSON_UNESCAPED_SLASHES );
 }
 
 /*
@@ -572,7 +572,7 @@ function jpcrm_ajax_mail_delivery_validate_api_oauth() {
 
 	// Permission check
 	if ( ! zeroBSCRM_permsMailCampaigns() ) {
-		wp_send_json( array( 'permserror' => 1 ), null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( array( 'permserror' => 1 ), 403, JSON_UNESCAPED_SLASHES );
 	}
 
 	// return
@@ -708,7 +708,7 @@ function jpcrm_ajax_mail_delivery_validate_api_oauth() {
 	}
 
 	// return
-	wp_send_json( $return, null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( $return, 200, JSON_UNESCAPED_SLASHES );
 }
 
 // } Attempts to send a test email from a stored mail delivery method
@@ -739,7 +739,7 @@ function zeroBSCRM_AJAX_mailDelivery_testEmail() {
 	// validate the email
 	if ( ! zeroBSCRM_validateEmail( $sendToEmail ) ) {
 		$res['message'] = 'Not a valid email';
-		wp_send_json( $res, null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( $res, 200, JSON_UNESCAPED_SLASHES );
 	}
 
 	// } Check id + perms + em
@@ -778,7 +778,7 @@ function zeroBSCRM_AJAX_mailDelivery_testEmail() {
 	$sent = zeroBSCRM_mailDelivery_sendMessage( $mailDeliveryIndxKey, $mailArray );
 	if ( is_array( $sent ) && $sent[0] ) {
 		// fini
-		wp_send_json( $res, null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( $res, 200, JSON_UNESCAPED_SLASHES );
 	}
 
 	// error
@@ -864,7 +864,7 @@ function zeroBSCRM_AJAX_mailDelivery_removeMailDelivery() {
 
 	}
 
-	wp_send_json( $res, null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( $res, 200, JSON_UNESCAPED_SLASHES );
 }
 
 // } Attempts to set a delivery route default

--- a/projects/plugins/crm/admin/settings/mail-delivery.ajax.php
+++ b/projects/plugins/crm/admin/settings/mail-delivery.ajax.php
@@ -898,5 +898,5 @@ function zeroBSCRM_AJAX_mailDelivery_setMailDeliveryAsDefault() {
 	// fini - lazy nocheck
 	$res['success'] = 1;
 
-	echo wp_json_encode( $res );
+	echo wp_json_encode( $res, JSON_UNESCAPED_SLASHES );
 }

--- a/projects/plugins/crm/admin/settings/mail-delivery.ajax.php
+++ b/projects/plugins/crm/admin/settings/mail-delivery.ajax.php
@@ -900,5 +900,5 @@ function zeroBSCRM_AJAX_mailDelivery_setMailDeliveryAsDefault() {
 	// fini - lazy nocheck
 	$res['success'] = 1;
 
-	echo wp_json_encode( $res, JSON_UNESCAPED_SLASHES );
+	wp_send_json( $res, 200, JSON_UNESCAPED_SLASHES );
 }

--- a/projects/plugins/crm/admin/settings/mail-delivery.ajax.php
+++ b/projects/plugins/crm/admin/settings/mail-delivery.ajax.php
@@ -226,7 +226,7 @@ function zeroBSCRM_AJAX_mailDelivery_validateWPMail() {
 
 	// } Perms?
 	if ( ! zeroBSCRM_permsMailCampaigns() ) {
-		wp_send_json( array( 'permserror' => 1 ) );
+		wp_send_json( array( 'permserror' => 1 ), null, JSON_UNESCAPED_SLASHES );
 	}
 
 	// } Retrieve...
@@ -301,7 +301,7 @@ function zeroBSCRM_AJAX_mailDelivery_validateWPMail() {
 					if ( ! isset( $existing_mail_delivery_methods[ $settingsKey ] ) ) {
 						$existing_mail_delivery_methods[ $settingsKey ] = $settingsArr;
 					} else {
-						wp_send_json( array( 'keyerror' => 1 ) );
+						wp_send_json( array( 'keyerror' => 1 ), null, JSON_UNESCAPED_SLASHES );
 					}
 
 					// } Update
@@ -334,7 +334,7 @@ function zeroBSCRM_AJAX_mailDelivery_validateWPMail() {
 
 	}
 
-	wp_send_json( $res );
+	wp_send_json( $res, null, JSON_UNESCAPED_SLASHES );
 }
 
 // } Attempts to validate mail delivery SMTP settings, send test email, & save's if validated
@@ -438,7 +438,9 @@ function zeroBSCRM_AJAX_mailDelivery_validateSMTP() {
 											'keyerrors' => 1,
 										),
 									),
-								)
+								),
+								null,
+								JSON_UNESCAPED_SLASHES
 							);
 						}
 
@@ -486,7 +488,7 @@ function zeroBSCRM_AJAX_mailDelivery_validateSMTP() {
 
 	}
 
-	wp_send_json( $res, JSON_UNESCAPED_UNICODE );
+	wp_send_json( $res, null, JSON_UNESCAPED_SLASHES );
 }
 
 // } quickly checks if ports are open (pre smtp check)
@@ -554,7 +556,7 @@ function zeroBSCRM_AJAX_mailDelivery_validateSMTPPorts() {
 	}
 
 	$res['open'] = $okay;
-	wp_send_json( $res, JSON_UNESCAPED_UNICODE );
+	wp_send_json( $res, null, JSON_UNESCAPED_SLASHES );
 }
 
 /*
@@ -570,7 +572,7 @@ function jpcrm_ajax_mail_delivery_validate_api_oauth() {
 
 	// Permission check
 	if ( ! zeroBSCRM_permsMailCampaigns() ) {
-		wp_send_json( array( 'permserror' => 1 ) );
+		wp_send_json( array( 'permserror' => 1 ), null, JSON_UNESCAPED_SLASHES );
 	}
 
 	// return
@@ -706,7 +708,7 @@ function jpcrm_ajax_mail_delivery_validate_api_oauth() {
 	}
 
 	// return
-	wp_send_json( $return );
+	wp_send_json( $return, null, JSON_UNESCAPED_SLASHES );
 }
 
 // } Attempts to send a test email from a stored mail delivery method
@@ -737,7 +739,7 @@ function zeroBSCRM_AJAX_mailDelivery_testEmail() {
 	// validate the email
 	if ( ! zeroBSCRM_validateEmail( $sendToEmail ) ) {
 		$res['message'] = 'Not a valid email';
-		wp_send_json( $res );
+		wp_send_json( $res, null, JSON_UNESCAPED_SLASHES );
 	}
 
 	// } Check id + perms + em
@@ -776,12 +778,12 @@ function zeroBSCRM_AJAX_mailDelivery_testEmail() {
 	$sent = zeroBSCRM_mailDelivery_sendMessage( $mailDeliveryIndxKey, $mailArray );
 	if ( is_array( $sent ) && $sent[0] ) {
 		// fini
-		wp_send_json( $res );
+		wp_send_json( $res, null, JSON_UNESCAPED_SLASHES );
 	}
 
 	// error
 	$res['errors'] = array( 'sendfail' => 1 );
-	wp_send_json_error( $res, 500 );
+	wp_send_json_error( $res, 500, JSON_UNESCAPED_SLASHES );
 }
 
 // } Attempts to remove a delivery route
@@ -862,7 +864,7 @@ function zeroBSCRM_AJAX_mailDelivery_removeMailDelivery() {
 
 	}
 
-	wp_send_json( $res );
+	wp_send_json( $res, null, JSON_UNESCAPED_SLASHES );
 }
 
 // } Attempts to set a delivery route default

--- a/projects/plugins/crm/admin/settings/tax.page.php
+++ b/projects/plugins/crm/admin/settings/tax.page.php
@@ -219,7 +219,7 @@ if ( ! empty( $tax_errors ) ) {
 
 	<script type="text/javascript">
 
-		var zeroBSCRMJS_taxTable = <?php echo json_encode( $taxTables ); ?>;
+		var zeroBSCRMJS_taxTable = <?php echo wp_json_encode( $taxTables, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
 		var zeroBSCRMJS_taxTableLang = {
 
 			defaultTaxName: '<?php echo esc_html( zeroBSCRM_slashOut( __( 'Tax Rate Name', 'zero-bs-crm' ) ) ); ?>',

--- a/projects/plugins/crm/admin/support/main.page.php
+++ b/projects/plugins/crm/admin/support/main.page.php
@@ -101,7 +101,7 @@ if ( $has_license ) {
 		if ( $result === true ) {
 			$result = 'yes';
 		} elseif ( is_array( $result ) ) {
-			$result = wp_json_encode( $result );
+			$result = wp_json_encode( $result, JSON_UNESCAPED_SLASHES );
 		}
 
 		$site_data['Server Info'][] = "$env_name: $result";
@@ -192,7 +192,7 @@ if ( $has_license ) {
 		<form id="support-form">
 			<input type="hidden" name="license" value="<?php echo esc_attr( $license_key ); ?>">
 			<input type="hidden" name="site_url" value="<?php echo esc_attr( $site_url ); ?>">
-			<input type="hidden" name="site_data" value='<?php echo wp_json_encode( $site_data ); ?>'>
+			<input type="hidden" name="site_data" value='<?php echo esc_attr( wp_json_encode( $site_data, JSON_HEX_AMP | JSON_UNESCAPED_SLASHES ) ); ?>'>
 			<div class="form-group">
 				<label for="subject"><?php echo esc_html__( 'Subject', 'zero-bs-crm' ); ?>:</label>
 				<input type="text" class="form-control" id="subject" name="subject">
@@ -207,7 +207,7 @@ if ( $has_license ) {
 			<div class="data-shared">
 				<b>Site URL:</b> <?php echo esc_html( $site_url ); ?><br>
 				<b>License:</b> <?php echo esc_html( $license_key ); ?><br>
-				<b>Site data:</b><?php echo wp_json_encode( $site_data ); ?><br>
+				<b>Site data:</b><?php echo esc_html( wp_json_encode( $site_data, JSON_UNESCAPED_SLASHES | JSON_HEX_AMP ) ); ?><br>
 			</div>
 			<div class="text-center">
 				<button type="submit" class="btn btn-primary"><?php echo esc_html__( 'Submit', 'zero-bs-crm' ); ?></button>

--- a/projects/plugins/crm/api/companies.php
+++ b/projects/plugins/crm/api/companies.php
@@ -71,4 +71,4 @@ $args = array(
 global $zbs;
 $companies = $zbs->DAL->companies->getCompanies( $args ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable,WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
-wp_send_json( $companies, null, JSON_UNESCAPED_SLASHES );
+wp_send_json( $companies, 200, JSON_UNESCAPED_SLASHES );

--- a/projects/plugins/crm/api/companies.php
+++ b/projects/plugins/crm/api/companies.php
@@ -71,4 +71,4 @@ $args = array(
 global $zbs;
 $companies = $zbs->DAL->companies->getCompanies( $args ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable,WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
-wp_send_json( $companies );
+wp_send_json( $companies, null, JSON_UNESCAPED_SLASHES );

--- a/projects/plugins/crm/api/create_company.php
+++ b/projects/plugins/crm/api/create_company.php
@@ -199,9 +199,6 @@ if (
 		zeroBS_setOwner( $new_company_id, $assign, ZBS_TYPE_COMPANY );
 	}
 
-	// old way just returned what was sent...
-	// wp_send_json($json_params); //sends back to Zapier the customer that's been sent to it.
-
 	// thorough much? lol.
 	if ( ! empty( $new_company_id ) && $new_company_id !== -1 ) {
 
@@ -215,12 +212,12 @@ if (
 		}
 
 		// return
-		wp_send_json( $return_params );
+		wp_send_json( $return_params, null, JSON_UNESCAPED_SLASHES );
 
 	} else {
 
 		// fail.
-		wp_send_json( array( 'error' => 100 ) );
+		wp_send_json( array( 'error' => 100 ), null, JSON_UNESCAPED_SLASHES );
 
 	}
 }

--- a/projects/plugins/crm/api/create_company.php
+++ b/projects/plugins/crm/api/create_company.php
@@ -212,12 +212,12 @@ if (
 		}
 
 		// return
-		wp_send_json( $return_params, null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( $return_params, 200, JSON_UNESCAPED_SLASHES );
 
 	} else {
 
 		// fail.
-		wp_send_json( array( 'error' => 100 ), null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( array( 'error' => 100 ), 200, JSON_UNESCAPED_SLASHES );
 
 	}
 }

--- a/projects/plugins/crm/api/create_customer.php
+++ b/projects/plugins/crm/api/create_customer.php
@@ -22,7 +22,7 @@ if ( ! is_array( $new_customer ) ) {
 			'error'   => true,
 			'message' => 'Invalid JSON data',
 		),
-		null,
+		200,
 		JSON_UNESCAPED_SLASHES
 	);
 }
@@ -253,14 +253,14 @@ if (
 		}
 
 		// return
-		wp_send_json( $return_params, null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( $return_params, 200, JSON_UNESCAPED_SLASHES );
 
 	} else {
 
 		// fail.
-		wp_send_json( array( 'error' => 100 ), null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( array( 'error' => 100 ), 200, JSON_UNESCAPED_SLASHES );
 
 	}
 }
 
-wp_send_json( array( 'errors' => 1 ), null, JSON_UNESCAPED_SLASHES );
+wp_send_json( array( 'errors' => 1 ), 200, JSON_UNESCAPED_SLASHES );

--- a/projects/plugins/crm/api/create_customer.php
+++ b/projects/plugins/crm/api/create_customer.php
@@ -21,7 +21,9 @@ if ( ! is_array( $new_customer ) ) {
 		array(
 			'error'   => true,
 			'message' => 'Invalid JSON data',
-		)
+		),
+		null,
+		JSON_UNESCAPED_SLASHES
 	);
 }
 
@@ -238,9 +240,6 @@ if (
 		zeroBS_setOwner( $new_contact, $assign, ZBS_TYPE_CONTACT );
 	}
 
-	// old way just returned what was sent...
-	// wp_send_json($json_params); //sends back to Zapier the customer that's been sent to it.
-
 	// thorough much? lol.
 	if ( ! empty( $new_contact ) && $new_contact !== -1 ) {
 
@@ -254,14 +253,14 @@ if (
 		}
 
 		// return
-		wp_send_json( $return_params );
+		wp_send_json( $return_params, null, JSON_UNESCAPED_SLASHES );
 
 	} else {
 
 		// fail.
-		wp_send_json( array( 'error' => 100 ) );
+		wp_send_json( array( 'error' => 100 ), null, JSON_UNESCAPED_SLASHES );
 
 	}
 }
 
-wp_send_json( array( 'errors' => 1 ) );
+wp_send_json( array( 'errors' => 1 ), null, JSON_UNESCAPED_SLASHES );

--- a/projects/plugins/crm/api/create_event.php
+++ b/projects/plugins/crm/api/create_event.php
@@ -108,11 +108,11 @@ if ( ! empty( $task_result ) && $task_result !== -1 ) {
 	}
 
 	// return
-	wp_send_json( $return_params );
+	wp_send_json( $return_params, null, JSON_UNESCAPED_SLASHES );
 
 } else {
 
 	// fail.
-	wp_send_json( array( 'error' => 100 ) );
+	wp_send_json( array( 'error' => 100 ), null, JSON_UNESCAPED_SLASHES );
 
 }

--- a/projects/plugins/crm/api/create_event.php
+++ b/projects/plugins/crm/api/create_event.php
@@ -108,11 +108,11 @@ if ( ! empty( $task_result ) && $task_result !== -1 ) {
 	}
 
 	// return
-	wp_send_json( $return_params, null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( $return_params, 200, JSON_UNESCAPED_SLASHES );
 
 } else {
 
 	// fail.
-	wp_send_json( array( 'error' => 100 ), null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( array( 'error' => 100 ), 200, JSON_UNESCAPED_SLASHES );
 
 }

--- a/projects/plugins/crm/api/create_transaction.php
+++ b/projects/plugins/crm/api/create_transaction.php
@@ -34,7 +34,9 @@ foreach ( $required_fields as $field ) {
 			array(
 				'error'   => 400,
 				'message' => 'Missing required field: ' . $field,
-			)
+			),
+			null,
+			JSON_UNESCAPED_SLASHES
 		);
 		exit( 0 );
 	}
@@ -216,9 +218,6 @@ if ( ! empty( $orderid ) ) {
 			);
 	// ^^ this'll be either: ID if added, no of rows if updated, or FALSE if failed to insert/update
 
-	// old way just returned what was sent...
-	// wp_send_json($json_params);
-
 	// thorough much? lol.
 	if ( ! empty( $trans ) && $trans !== -1 ) {
 
@@ -232,12 +231,12 @@ if ( ! empty( $orderid ) ) {
 		}
 
 		// return
-		wp_send_json( $return_params );
+		wp_send_json( $return_params, null, JSON_UNESCAPED_SLASHES );
 
 	} else {
 
 		// fail.
-		wp_send_json( array( 'error' => 100 ) );
+		wp_send_json( array( 'error' => 100 ), null, JSON_UNESCAPED_SLASHES );
 
 	}
 }

--- a/projects/plugins/crm/api/create_transaction.php
+++ b/projects/plugins/crm/api/create_transaction.php
@@ -35,7 +35,7 @@ foreach ( $required_fields as $field ) {
 				'error'   => 400,
 				'message' => 'Missing required field: ' . $field,
 			),
-			null,
+			200,
 			JSON_UNESCAPED_SLASHES
 		);
 		exit( 0 );
@@ -231,12 +231,12 @@ if ( ! empty( $orderid ) ) {
 		}
 
 		// return
-		wp_send_json( $return_params, null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( $return_params, 200, JSON_UNESCAPED_SLASHES );
 
 	} else {
 
 		// fail.
-		wp_send_json( array( 'error' => 100 ), null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( array( 'error' => 100 ), 200, JSON_UNESCAPED_SLASHES );
 
 	}
 }

--- a/projects/plugins/crm/api/customer_search.php
+++ b/projects/plugins/crm/api/customer_search.php
@@ -53,7 +53,7 @@ if ( isset( $_GET['email'] ) ) {
 
 	// Send an empty array if no matches.
 	if ( ! $customer_matches ) {
-		wp_send_json( array() );
+		wp_send_json( array(), null, JSON_UNESCAPED_SLASHES );
 	}
 } else {
 	// could be more matches (don't return financial data - unperformant)
@@ -61,7 +61,7 @@ if ( isset( $_GET['email'] ) ) {
 }
 
 if ( $replace_hyphens_in_response === 1 ) {
-	wp_send_json( jpcrm_api_replace_hyphens_in_json_keys_with_underscores( $customer_matches ) );
+	wp_send_json( jpcrm_api_replace_hyphens_in_json_keys_with_underscores( $customer_matches ), null, JSON_UNESCAPED_SLASHES );
 }
 
-wp_send_json( $customer_matches );
+wp_send_json( $customer_matches, null, JSON_UNESCAPED_SLASHES );

--- a/projects/plugins/crm/api/customer_search.php
+++ b/projects/plugins/crm/api/customer_search.php
@@ -53,7 +53,7 @@ if ( isset( $_GET['email'] ) ) {
 
 	// Send an empty array if no matches.
 	if ( ! $customer_matches ) {
-		wp_send_json( array(), null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( array(), 200, JSON_UNESCAPED_SLASHES );
 	}
 } else {
 	// could be more matches (don't return financial data - unperformant)
@@ -61,7 +61,7 @@ if ( isset( $_GET['email'] ) ) {
 }
 
 if ( $replace_hyphens_in_response === 1 ) {
-	wp_send_json( jpcrm_api_replace_hyphens_in_json_keys_with_underscores( $customer_matches ), null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( jpcrm_api_replace_hyphens_in_json_keys_with_underscores( $customer_matches ), 200, JSON_UNESCAPED_SLASHES );
 }
 
-wp_send_json( $customer_matches, null, JSON_UNESCAPED_SLASHES );
+wp_send_json( $customer_matches, 200, JSON_UNESCAPED_SLASHES );

--- a/projects/plugins/crm/api/customers.php
+++ b/projects/plugins/crm/api/customers.php
@@ -95,7 +95,7 @@ $args = array(
 
 $customers = $zbs->DAL->contacts->getContacts( $args );
 
-wp_send_json( $customers, null, JSON_UNESCAPED_SLASHES );
+wp_send_json( $customers, 200, JSON_UNESCAPED_SLASHES );
 
 // phpcs:enabled WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 

--- a/projects/plugins/crm/api/customers.php
+++ b/projects/plugins/crm/api/customers.php
@@ -95,7 +95,7 @@ $args = array(
 
 $customers = $zbs->DAL->contacts->getContacts( $args );
 
-wp_send_json( $customers );
+wp_send_json( $customers, null, JSON_UNESCAPED_SLASHES );
 
 // phpcs:enabled WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 

--- a/projects/plugins/crm/api/events.php
+++ b/projects/plugins/crm/api/events.php
@@ -53,4 +53,4 @@ $args = array(
 global $zbs;
 $tasks = $zbs->DAL->events->getEvents( $args ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
-wp_send_json( $tasks, null, JSON_UNESCAPED_SLASHES );
+wp_send_json( $tasks, 200, JSON_UNESCAPED_SLASHES );

--- a/projects/plugins/crm/api/events.php
+++ b/projects/plugins/crm/api/events.php
@@ -53,4 +53,4 @@ $args = array(
 global $zbs;
 $tasks = $zbs->DAL->events->getEvents( $args ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
-wp_send_json( $tasks );
+wp_send_json( $tasks, null, JSON_UNESCAPED_SLASHES );

--- a/projects/plugins/crm/api/invoices.php
+++ b/projects/plugins/crm/api/invoices.php
@@ -37,4 +37,4 @@ global $zbs;
 $invoices = $zbs->DAL->invoices->getInvoices( $args ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 
-wp_send_json( $invoices );
+wp_send_json( $invoices, null, JSON_UNESCAPED_SLASHES );

--- a/projects/plugins/crm/api/invoices.php
+++ b/projects/plugins/crm/api/invoices.php
@@ -37,4 +37,4 @@ global $zbs;
 $invoices = $zbs->DAL->invoices->getInvoices( $args ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 
-wp_send_json( $invoices, null, JSON_UNESCAPED_SLASHES );
+wp_send_json( $invoices, 200, JSON_UNESCAPED_SLASHES );

--- a/projects/plugins/crm/api/quotes.php
+++ b/projects/plugins/crm/api/quotes.php
@@ -46,4 +46,4 @@ $args = array(
 
 $quotes = $zbs->DAL->quotes->getQuotes( $args );
 
-wp_send_json( $quotes, null, JSON_UNESCAPED_SLASHES );
+wp_send_json( $quotes, 200, JSON_UNESCAPED_SLASHES );

--- a/projects/plugins/crm/api/quotes.php
+++ b/projects/plugins/crm/api/quotes.php
@@ -46,4 +46,4 @@ $args = array(
 
 $quotes = $zbs->DAL->quotes->getQuotes( $args );
 
-wp_send_json( $quotes );
+wp_send_json( $quotes, null, JSON_UNESCAPED_SLASHES );

--- a/projects/plugins/crm/api/status.php
+++ b/projects/plugins/crm/api/status.php
@@ -35,4 +35,4 @@ if ( isset( $_GET['full'] ) ) {
 	$reply['extensions'] = $active_extensions_and_ver;
 }
 
-wp_send_json_success( $reply, null, JSON_UNESCAPED_SLASHES );
+wp_send_json_success( $reply, 200, JSON_UNESCAPED_SLASHES );

--- a/projects/plugins/crm/api/status.php
+++ b/projects/plugins/crm/api/status.php
@@ -35,4 +35,4 @@ if ( isset( $_GET['full'] ) ) {
 	$reply['extensions'] = $active_extensions_and_ver;
 }
 
-wp_send_json_success( $reply );
+wp_send_json_success( $reply, null, JSON_UNESCAPED_SLASHES );

--- a/projects/plugins/crm/api/transactions.php
+++ b/projects/plugins/crm/api/transactions.php
@@ -37,4 +37,4 @@ $args       = array(
 global $zbs;
 $transactions = $zbs->DAL->transactions->getTransactions( $args ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
-wp_send_json( $transactions, null, JSON_UNESCAPED_SLASHES );
+wp_send_json( $transactions, 200, JSON_UNESCAPED_SLASHES );

--- a/projects/plugins/crm/api/transactions.php
+++ b/projects/plugins/crm/api/transactions.php
@@ -37,4 +37,4 @@ $args       = array(
 global $zbs;
 $transactions = $zbs->DAL->transactions->getTransactions( $args ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
-wp_send_json( $transactions );
+wp_send_json( $transactions, null, JSON_UNESCAPED_SLASHES );

--- a/projects/plugins/crm/api/webhook.php
+++ b/projects/plugins/crm/api/webhook.php
@@ -71,4 +71,4 @@ if ( ! in_array( $webhook_action, $valid_webhook_actions ) ) {
 do_action( 'jpcrm_webhook_' . $webhook_action, $webhook_data );
 
 // by default, send success, but the action can override this
-wp_send_json_success( null, null, JSON_UNESCAPED_SLASHES );
+wp_send_json_success( null, 200, JSON_UNESCAPED_SLASHES );

--- a/projects/plugins/crm/api/webhook.php
+++ b/projects/plugins/crm/api/webhook.php
@@ -26,7 +26,7 @@ function jpcrm_api_invalid_webhook() {
 		'status'  => __( 'Invalid webhook request', 'zero-bs-crm' ),
 		'message' => __( 'Please ensure you are using the proper webhook action name and that the webhook is enabled in the CRM.', 'zero-bs-crm' ),
 	);
-	wp_send_json_error( $reply, 400 );
+	wp_send_json_error( $reply, 400, JSON_UNESCAPED_SLASHES );
 }
 
 // Check the method
@@ -71,4 +71,4 @@ if ( ! in_array( $webhook_action, $valid_webhook_actions ) ) {
 do_action( 'jpcrm_webhook_' . $webhook_action, $webhook_data );
 
 // by default, send success, but the action can override this
-wp_send_json_success();
+wp_send_json_success( null, null, JSON_UNESCAPED_SLASHES );

--- a/projects/plugins/crm/changelog/fix-crm-audit_json_encode_flags_part_deux
+++ b/projects/plugins/crm/changelog/fix-crm-audit_json_encode_flags_part_deux
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Ensure proper flags are used with `json_encode()`.

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -31,7 +31,7 @@ if ( ! defined( 'ZEROBSCRM_PATH' ) ) {
 function jpcrm_hide_woo_promo() {
 	if ( current_user_can( 'activate_plugins' ) ) {
 		$option = update_option( 'jpcrm_hide_woo_promo', 'hide', false );
-		wp_send_json_success();
+		wp_send_json_success( null, null, JSON_UNESCAPED_SLASHES );
 	}
 }
 
@@ -39,7 +39,7 @@ function jpcrm_hide_woo_promo() {
 function jpcrm_hide_track_notice() {
 	if ( current_user_can( 'activate_plugins' ) ) {
 		$option = update_option( 'jpcrm_hide_track_notice', 'hide', false );
-		wp_send_json_success();
+		wp_send_json_success( null, null, JSON_UNESCAPED_SLASHES );
 	}
 }
 
@@ -48,7 +48,7 @@ function jpcrm_hide_feature_alert() {
 	if ( current_user_can( 'activate_plugins' ) && isset( $_POST['feature_alert'] ) ) {
 		$option = 'jpcrm_hide_' . sanitize_text_field( $_POST['feature_alert'] );
 		update_option( $option, true, false );
-		wp_send_json_success();
+		wp_send_json_success( null, null, JSON_UNESCAPED_SLASHES );
 	}
 }
 
@@ -65,7 +65,7 @@ function zbs_create_email_templates() {
 	} else {
 		$m['message'] = 'no permissions';
 	}
-	wp_send_json( $m );
+	wp_send_json( $m, null, JSON_UNESCAPED_SLASHES );
 }
 
 	// save email template
@@ -153,7 +153,7 @@ function zbs_save_email_status() {
 		$m['message'] = 'no perms';
 	}
 
-	wp_send_json( $m );
+	wp_send_json( $m, null, JSON_UNESCAPED_SLASHES );
 	// nonce field is zbs-save-email_active
 }
 
@@ -180,7 +180,7 @@ function zeroBSCRM_AJAX_logClose() {
 		update_option( 'zbs_closers_' . $potentialKey, time(), false );
 	}
 
-	wp_send_json( array( 'fini' => 1 ) );
+	wp_send_json( array( 'fini' => 1 ), null, JSON_UNESCAPED_SLASHES );
 }
 
 	/*
@@ -231,7 +231,7 @@ function jpcrm_set_jpcrm_transient() {
 		}
 	}
 
-	wp_send_json( array( 'fini' => 1 ) );
+	wp_send_json( array( 'fini' => 1 ), null, JSON_UNESCAPED_SLASHES );
 }
 
 	// } Feedback
@@ -245,7 +245,7 @@ function zeroBSCRM_AJAX_markFeedback() {
 		}
 		update_option( 'zbsfeedback', $feedbackVal, false );
 	}
-	wp_send_json( array( 'fini' => 1 ) );
+	wp_send_json( array( 'fini' => 1 ), null, JSON_UNESCAPED_SLASHES );
 }
 
 	// } Retrieve list of invoice deets for customer ID
@@ -274,7 +274,7 @@ function zeroBSCRM_AJAX_getCustInvs() {
 		}
 	}
 
-	wp_send_json( $ret );
+	wp_send_json( $ret, null, JSON_UNESCAPED_SLASHES );
 }
 
 	// } Remove file
@@ -333,7 +333,9 @@ function zeroBSCRM_removeFile() {
 		array(
 			'res'    => $res,
 			'errors' => $errors,
-		)
+		),
+		null,
+		JSON_UNESCAPED_SLASHES
 	);
 }
 
@@ -348,7 +350,7 @@ function zeroBSCRM_AJAX_filterCustomers() {
 	check_ajax_referer( 'zbscrmjs-ajax-nonce', 'sec' );
 
 	if ( ! zeroBSCRM_permsCustomers() ) {
-		wp_send_json( array( 'processed' => -1 ) );
+		wp_send_json( array( 'processed' => -1 ), null, JSON_UNESCAPED_SLASHES );
 	}
 
 	// } Running this auto-pulls POSTED filters + finds customers
@@ -361,7 +363,7 @@ function zeroBSCRM_AJAX_filterCustomers() {
 		$res                      = zeroBS__customerFiltersRetrieveCustomerCountAndTopCustomers();
 		$res['filters_in_effect'] = $zbsCustomerFiltersInEffect;
 
-	wp_send_json( $res );
+	wp_send_json( $res, null, JSON_UNESCAPED_SLASHES );
 }
 
 	// Add log
@@ -375,7 +377,7 @@ function zeroBSCRM_AJAX_addLog() {
 
 	// brutal
 	if ( ! zeroBSCRM_permsCustomers() ) {
-		wp_send_json( array( 'processed' => -1 ) );
+		wp_send_json( array( 'processed' => -1 ), null, JSON_UNESCAPED_SLASHES );
 	}
 
 	global $zbs;
@@ -439,7 +441,7 @@ function zeroBSCRM_AJAX_addLog() {
 
 	}
 
-	wp_send_json( array( 'processed' => $res ) );
+	wp_send_json( array( 'processed' => $res ), null, JSON_UNESCAPED_SLASHES );
 }
 
 	// Update log
@@ -453,7 +455,7 @@ function zeroBSCRM_AJAX_updateLog() {
 
 	// brutal
 	if ( ! zeroBSCRM_permsLogsAddEdit() ) {
-		wp_send_json( array( 'processed' => -1 ) );
+		wp_send_json( array( 'processed' => -1 ), null, JSON_UNESCAPED_SLASHES );
 	}
 
 	global $zbs;
@@ -530,7 +532,7 @@ function zeroBSCRM_AJAX_updateLog() {
 		}
 	}
 
-	wp_send_json( array( 'processed' => $res ) );
+	wp_send_json( array( 'processed' => $res ), null, JSON_UNESCAPED_SLASHES );
 }
 
 	// } Del log
@@ -546,7 +548,7 @@ function zeroBSCRM_AJAX_deleteLog() {
 	// from 2.94.2 uses sub perms
 	// if (!zeroBSCRM_permsCustomers()) exit('{processed:-1}');
 	if ( ! zeroBSCRM_permsLogsDelete() ) {
-		wp_send_json( array( 'processed' => -1 ) );
+		wp_send_json( array( 'processed' => -1 ), null, JSON_UNESCAPED_SLASHES );
 	}
 	// if (!current_user_can('edit_page', $post_id)) return;
 
@@ -567,7 +569,7 @@ function zeroBSCRM_AJAX_deleteLog() {
 		$res = $zbs->DAL->logs->deleteLog( array( 'id' => $zbsNoteID ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase,WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	}
 
-	wp_send_json( array( 'processed' => $res ) );
+	wp_send_json( array( 'processed' => $res ), null, JSON_UNESCAPED_SLASHES );
 }
 
 	// Pin log
@@ -581,7 +583,7 @@ function jpcrm_ajax_pin_log() {
 	check_ajax_referer( 'zbscrmjs-ajax-nonce-logs', 'sec' );
 
 	if ( ! zeroBSCRM_permsLogsDelete() ) {
-		wp_send_json( array( processed => false ) );
+		wp_send_json( array( processed => false ), null, JSON_UNESCAPED_SLASHES );
 	}
 
 	// Retrieve vars - this allows notes against ALL post types (just by id)
@@ -602,7 +604,7 @@ function jpcrm_ajax_pin_log() {
 
 	}
 
-	wp_send_json( array( 'processed' => $res ) );
+	wp_send_json( array( 'processed' => $res ), null, JSON_UNESCAPED_SLASHES );
 }
 
 	// Un-Pin log
@@ -616,7 +618,7 @@ function jpcrm_ajax_unpin_log() {
 	check_ajax_referer( 'zbscrmjs-ajax-nonce-logs', 'sec' );
 
 	if ( ! zeroBSCRM_permsLogsDelete() ) {
-		wp_send_json( array( processed => false ) );
+		wp_send_json( array( processed => false ), null, JSON_UNESCAPED_SLASHES );
 	}
 
 	// Retrieve vars - this allows notes against ALL post types (just by id)
@@ -637,7 +639,7 @@ function jpcrm_ajax_unpin_log() {
 
 	}
 
-	wp_send_json( array( 'processed' => $res ) );
+	wp_send_json( array( 'processed' => $res ), null, JSON_UNESCAPED_SLASHES );
 }
 
 /*
@@ -663,10 +665,10 @@ function ZeroBSCRM_get_quote_template() {
 
 	// } brutal
 	if ( ! zeroBSCRM_permsCustomers() ) {
-		wp_send_json( array( 'processed' => -1 ) );
+		wp_send_json( array( 'processed' => -1 ), null, JSON_UNESCAPED_SLASHES );
 	}
 	if ( ! zeroBSCRM_permsQuotes() ) {
-		wp_send_json( array( 'processed' => -1 ) );
+		wp_send_json( array( 'processed' => -1 ), null, JSON_UNESCAPED_SLASHES );
 	}
 
 	// } Retrive deets
@@ -834,13 +836,13 @@ function ZeroBSCRM_get_quote_template() {
 			$content['template_notes'] = $quote_template['notes'];
 
 			// } return
-			wp_send_json( $content );
+			wp_send_json( $content, null, JSON_UNESCAPED_SLASHES );
 
 		} // / if content
 
 	} // / if vars
 
-	wp_send_json( array( 'error' => 1 ) );
+	wp_send_json( array( 'error' => 1 ), null, JSON_UNESCAPED_SLASHES );
 }
 
 // Send a quote via email
@@ -852,10 +854,10 @@ function jpcrm_ajax_quote_send_email() {
 
 	// Check Permissions
 	if ( ! zeroBSCRM_permsCustomers() ) {
-		wp_send_json( array( 'processed' => -1 ) );
+		wp_send_json( array( 'processed' => -1 ), null, JSON_UNESCAPED_SLASHES );
 	}
 	if ( ! zeroBSCRM_permsQuotes() ) {
-		wp_send_json( array( 'processed' => -1 ) );
+		wp_send_json( array( 'processed' => -1 ), null, JSON_UNESCAPED_SLASHES );
 	}
 
 	// Retrive details
@@ -886,12 +888,12 @@ function jpcrm_ajax_quote_send_email() {
 
 	// validate the email
 	if ( ! zeroBSCRM_validateEmail( $target_email ) || empty( $target_email ) ) {
-		wp_send_json_error( array( 'message' => __( 'Invalid email', 'zero-bs-crm' ) ), 400 );
+		wp_send_json_error( array( 'message' => __( 'Invalid email', 'zero-bs-crm' ) ), 400, JSON_UNESCAPED_SLASHES );
 	}
 
 	// Check id
 	if ( $quoteID == -1 ) {
-		wp_send_json_error( array( 'message' => __( 'Invalid parameters', 'zero-bs-crm' ) ), 400 );
+		wp_send_json_error( array( 'message' => __( 'Invalid parameters', 'zero-bs-crm' ) ), 400, JSON_UNESCAPED_SLASHES );
 	}
 
 	global $zbs;
@@ -1030,11 +1032,11 @@ function jpcrm_ajax_quote_send_email() {
 		if ( $sent ) {
 
 			// send result
-			wp_send_json( array( 'message' => 'sent' ) );
+			wp_send_json( array( 'message' => 'sent' ), null, JSON_UNESCAPED_SLASHES );
 
 		}
 		// send err
-		wp_send_json_error( array( 'message' => __( 'not sent', 'zero-bs-crm' ) ), 500 );
+		wp_send_json_error( array( 'message' => __( 'not sent', 'zero-bs-crm' ) ), 500, JSON_UNESCAPED_SLASHES );
 }
 
 /**
@@ -1052,7 +1054,7 @@ function ZeroBSCRM_accept_quote() {
 
 	// } Got quote ID?
 	if ( empty( $quoteID ) || $quoteID < 0 ) {
-		wp_send_json_error( array( 'noparams' => 1 ), 400 );
+		wp_send_json_error( array( 'noparams' => 1 ), 400, JSON_UNESCAPED_SLASHES );
 	} // / posted data
 
 	// If nonced & has quote id, verify user can 'accept'
@@ -1075,20 +1077,20 @@ function ZeroBSCRM_accept_quote() {
 		if ( ! $can ) {
 			// Require login
 			if ( ! is_user_logged_in() ) {
-				wp_send_json_error( array( 'access' => 1 ), 403 );
+				wp_send_json_error( array( 'access' => 1 ), 403, JSON_UNESCAPED_SLASHES );
 			}
 			// Resolve IDs safely
 			$customer_id      = (int) zeroBS_getCustomerIDWithEmail( $uinfo->user_email );
 			$quote_contact_id = (int) $zbs->DAL->quotes->getQuoteContactID( $quoteID ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase,WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 			// Both IDs must exist and match
 			if ( $customer_id <= 0 || $quote_contact_id <= 0 || $customer_id !== $quote_contact_id ) {
-				wp_send_json_error( array( 'access' => 1 ), 403 );
+				wp_send_json_error( array( 'access' => 1 ), 403, JSON_UNESCAPED_SLASHES );
 			}
 		}
 	} else {
 		$quote_from_hash = zeroBSCRM_quotes_getFromHash( $quoteHash );
 		if ( ! $quote_from_hash['success'] || $quoteID !== (int) $quote_from_hash['data']['ID'] ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-			wp_send_json_error( array( 'hash' => 1 ), 403 );
+			wp_send_json_error( array( 'hash' => 1 ), 403, JSON_UNESCAPED_SLASHES );
 		}
 	}
 
@@ -1111,7 +1113,7 @@ function ZeroBSCRM_accept_quote() {
 	} // / if email notification active
 
 	// success
-	wp_send_json( array( 'success' => 1 ) );
+	wp_send_json( array( 'success' => 1 ), null, JSON_UNESCAPED_SLASHES );
 }
 
 /*
@@ -1187,7 +1189,7 @@ function zbs_lead_form_views() {
 	$form_id    = (int) sanitize_text_field( $_POST['id'] );
 	$form_views = $zbs->DAL->forms->add_form_view( $form_id );
 
-	wp_send_json( array( 'view_logged' => 'true' ) );
+	wp_send_json( array( 'view_logged' => 'true' ), null, JSON_UNESCAPED_SLASHES );
 }
 	add_action( 'wp_ajax_nopriv_zbs_lead_form_views', 'zbs_lead_form_views' );
 	add_action( 'wp_ajax_zbs_lead_form_views', 'zbs_lead_form_views' );
@@ -1256,7 +1258,7 @@ function zbs_lead_form_capture() {
 			// } AXE IT
 			$r['message'] = 'Nope.';
 			$r['code']    = 'recaptcha';
-			wp_send_json( $r );
+			wp_send_json( $r, null, JSON_UNESCAPED_SLASHES );
 
 		}
 	}
@@ -1273,7 +1275,7 @@ function zbs_lead_form_capture() {
 		// } AXE IT
 		$r['message'] = 'Nope.';
 		$r['code']    = 'form';
-		wp_send_json( $r );
+		wp_send_json( $r, null, JSON_UNESCAPED_SLASHES );
 
 	}
 
@@ -1283,7 +1285,7 @@ function zbs_lead_form_capture() {
 		// then this is likely a spambot who has filled in the form since its hidden from humans
 		$r['message'] = 'This is a honeypot.. something has gone wrong can alert the member on response';
 		$r['code']    = 'honey';
-		wp_send_json( $r );
+		wp_send_json( $r, null, JSON_UNESCAPED_SLASHES );
 	} else {
 
 		// } Added here: REQUIRE email...
@@ -1297,7 +1299,7 @@ function zbs_lead_form_capture() {
 			// } AXE IT
 			$r['message'] = 'Email Required.';
 			$r['code']    = 'emailfail';
-			wp_send_json( $r );
+			wp_send_json( $r, null, JSON_UNESCAPED_SLASHES );
 
 		}
 
@@ -1571,7 +1573,7 @@ function zbs_lead_form_capture() {
 			// return
 			$r['message'] = 'Contact received.';
 			$r['code']    = 'success';
-			wp_send_json( $r );
+			wp_send_json( $r, null, JSON_UNESCAPED_SLASHES );
 
 	}
 }
@@ -1605,7 +1607,7 @@ function zeroBSCRM_AJAX_addAlias() {
 
 	// } Check perms
 	if ( ! zeroBSCRM_permsCustomers() ) {
-		wp_send_json( array( 'err' => 1 ) );
+		wp_send_json( array( 'err' => 1 ), null, JSON_UNESCAPED_SLASHES );
 	}
 
 	// } Proceed :)
@@ -1639,12 +1641,12 @@ function zeroBSCRM_AJAX_addAlias() {
 		}
 
 		// } Return
-		wp_send_json( $passback );
+		wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 	}
 
 		// err really :o
-		wp_send_json( array() );
+		wp_send_json( array(), null, JSON_UNESCAPED_SLASHES );
 }
 	add_action( 'wp_ajax_removeAlias', 'zeroBSCRM_AJAX_removeAlias' );
 function zeroBSCRM_AJAX_removeAlias() {
@@ -1654,7 +1656,7 @@ function zeroBSCRM_AJAX_removeAlias() {
 
 	// } Check perms
 	if ( ! zeroBSCRM_permsCustomers() ) {
-		wp_send_json( array( 'err' => 1 ) );
+		wp_send_json( array( 'err' => 1 ), null, JSON_UNESCAPED_SLASHES );
 	}
 
 	// } Proceed :)
@@ -1679,12 +1681,12 @@ function zeroBSCRM_AJAX_removeAlias() {
 		// } For now, no checks :)
 
 			// } Return
-			wp_send_json( $passback );
+			wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 	}
 
 		// err really :o
-		wp_send_json( array() );
+		wp_send_json( array(), null, JSON_UNESCAPED_SLASHES );
 }
 
 /*
@@ -1708,7 +1710,7 @@ function zeroBSCRM_AJAX_updateListViewColumns() {
 
 	// } Check perms
 	if ( ! zeroBSCRM_isZBSAdminOrAdmin() ) {
-		wp_send_json( array( 'err' => 1 ) );
+		wp_send_json( array( 'err' => 1 ), null, JSON_UNESCAPED_SLASHES );
 	}
 
 		global $zbs;
@@ -1751,7 +1753,7 @@ function zeroBSCRM_AJAX_updateListViewColumns() {
 			$zbs->settings->update( 'customviews2', $newCustomViews );
 
 			// } Return
-			wp_send_json( $passback );
+			wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 			break;
 
@@ -1778,7 +1780,7 @@ function zeroBSCRM_AJAX_updateListViewColumns() {
 			$zbs->settings->update( 'customviews2', $newCustomViews );
 
 			// } Return
-			wp_send_json( $passback );
+			wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 			break;
 
@@ -1805,7 +1807,7 @@ function zeroBSCRM_AJAX_updateListViewColumns() {
 			$zbs->settings->update( 'customviews2', $newCustomViews );
 
 			// } Return
-			wp_send_json( $passback );
+			wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 			break;
 
@@ -1832,7 +1834,7 @@ function zeroBSCRM_AJAX_updateListViewColumns() {
 			$zbs->settings->update( 'customviews2', $newCustomViews );
 
 			// } Return
-			wp_send_json( $passback );
+			wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 			break;
 
@@ -1859,7 +1861,7 @@ function zeroBSCRM_AJAX_updateListViewColumns() {
 			$zbs->settings->update( 'customviews2', $newCustomViews );
 
 			// } Return
-			wp_send_json( $passback );
+			wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 			break;
 
@@ -1886,7 +1888,7 @@ function zeroBSCRM_AJAX_updateListViewColumns() {
 			$zbs->settings->update( 'customviews2', $newCustomViews );
 
 			// } Return
-			wp_send_json( $passback );
+			wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 			break;
 
@@ -1913,7 +1915,7 @@ function zeroBSCRM_AJAX_updateListViewColumns() {
 			$zbs->settings->update( 'customviews2', $newCustomViews );
 
 			// } Return
-			wp_send_json( $passback );
+			wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 			break;
 
@@ -1938,13 +1940,13 @@ function zeroBSCRM_AJAX_updateListViewColumns() {
 			$zbs->settings->update( 'customviews2', $newCustomViews );
 
 			// } Return
-			wp_send_json( $passback );
+			wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 			break;
 
 		default:
 			// err really :o
-			wp_send_json( array() );
+			wp_send_json( array(), null, JSON_UNESCAPED_SLASHES );
 
 			break;
 
@@ -2078,25 +2080,25 @@ function zeroBSCRM_AJAX_listViewRetrieveData() {
 
 		// } check perms first
 		if ( $listViewParams['listtype'] == 'customer' && ! zeroBSCRM_permsViewCustomers() ) {
-			wp_send_json_error( array( 'no-action-or-rights' => 1 ), 500 );
+			wp_send_json_error( array( 'no-action-or-rights' => 1 ), 500, JSON_UNESCAPED_SLASHES );
 		}
 		if ( $listViewParams['listtype'] == 'company' && ! zeroBSCRM_permsViewCustomers() ) {
-			wp_send_json_error( array( 'no-action-or-rights' => 1 ), 500 );
+			wp_send_json_error( array( 'no-action-or-rights' => 1 ), 500, JSON_UNESCAPED_SLASHES );
 		}
 		if ( $listViewParams['listtype'] == 'segment' && ! zeroBSCRM_permsViewCustomers() ) {
-			wp_send_json_error( array( 'no-action-or-rights' => 1 ), 500 );
+			wp_send_json_error( array( 'no-action-or-rights' => 1 ), 500, JSON_UNESCAPED_SLASHES );
 		}
 		if ( $listViewParams['listtype'] == 'quote' && ! zeroBSCRM_permsViewQuotes() ) {
-			wp_send_json_error( array( 'no-action-or-rights' => 1 ), 500 );
+			wp_send_json_error( array( 'no-action-or-rights' => 1 ), 500, JSON_UNESCAPED_SLASHES );
 		}
 		if ( $listViewParams['listtype'] == 'quotetemplate' && ! zeroBSCRM_permsViewQuotes() ) {
-			wp_send_json_error( array( 'no-action-or-rights' => 1 ), 500 );
+			wp_send_json_error( array( 'no-action-or-rights' => 1 ), 500, JSON_UNESCAPED_SLASHES );
 		}
 		if ( $listViewParams['listtype'] == 'invoice' && ! zeroBSCRM_permsViewInvoices() ) {
-			wp_send_json_error( array( 'no-action-or-rights' => 1 ), 500 );
+			wp_send_json_error( array( 'no-action-or-rights' => 1 ), 500, JSON_UNESCAPED_SLASHES );
 		}
 		if ( $listViewParams['listtype'] == 'transaction' && ! zeroBSCRM_permsViewTransactions() ) {
-			wp_send_json_error( array( 'no-action-or-rights' => 1 ), 500 );
+			wp_send_json_error( array( 'no-action-or-rights' => 1 ), 500, JSON_UNESCAPED_SLASHES );
 		}
 
 		// } Check for screen options (perpage)
@@ -3621,7 +3623,7 @@ function zeroBSCRM_AJAX_listViewRetrieveData() {
 
 		// debug $res = array(isset($listViewParams),gettype($listViewParams) == 'array',isset($listViewParams['listtype']));
 
-		wp_send_json( $res );
+		wp_send_json( $res, null, JSON_UNESCAPED_SLASHES );
 }
 
 	// } Enact some bulk action :)
@@ -3643,7 +3645,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 			'status'  => __( 'Forbidden', 'zero-bs-crm' ),
 			'message' => __( 'You do not have permission to access this resource.', 'zero-bs-crm' ),
 		);
-		wp_send_json_error( $reply, 403 );
+		wp_send_json_error( $reply, 403, JSON_UNESCAPED_SLASHES );
 	}
 
 	// ret
@@ -3700,7 +3702,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 							$passback['deleted'] = $deleted;
 
 							// } Return
-							wp_send_json( $passback );
+							wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 							break;
 
@@ -3729,7 +3731,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 							$passback['accepted'] = $accepted;
 
 							// } Return
-							wp_send_json( $passback );
+							wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 							break;
 
@@ -3773,14 +3775,14 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 							}
 
 							// } Return
-							wp_send_json( $passback );
+							wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 							break;
 
 					}
 
 						// } Return - will be an error if here
-						wp_send_json( $passback );
+						wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 					break;
 
@@ -3825,7 +3827,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 								$passback['deleted'] = $deleted;
 
 								// } Return
-								wp_send_json( $passback );
+								wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 								break;
 
@@ -3849,7 +3851,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 					}
 
 					// } Return - will be an error if here
-					wp_send_json( $passback );
+					wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 					break;
 
@@ -3891,7 +3893,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 								$passback['deleted'] = $deleted;
 
 								// } Return
-								wp_send_json( $passback );
+								wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 								break;
 
@@ -3911,7 +3913,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 								$passback['accepted'] = $accepted;
 
 								// } Return
-								wp_send_json( $passback );
+								wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 								break;
 
@@ -3931,7 +3933,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 								$passback['unaccepted'] = $unaccepted;
 
 								// } Return
-								wp_send_json( $passback );
+								wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 								break;
 
@@ -3955,7 +3957,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 					}
 
 					// } Return - will be an error if here
-					wp_send_json( $passback );
+					wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 					break;
 
@@ -3996,7 +3998,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 								$passback['deleted'] = $deleted;
 
 								// } Return
-								wp_send_json( $passback );
+								wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 								break;
 
@@ -4022,7 +4024,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 								$passback['accepted'] = $accepted;
 
 								// } Return
-								wp_send_json( $passback );
+								wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 								break;
 
@@ -4046,7 +4048,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 					}
 
 					// } Return - will be an error if here
-					wp_send_json( $passback );
+					wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 					break;
 
@@ -4088,7 +4090,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 								$passback['deleted'] = $deleted;
 
 								// } Return
-								wp_send_json( $passback );
+								wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 								break;
 
@@ -4112,7 +4114,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 					}
 
 					// } Return - will be an error if here
-					wp_send_json( $passback );
+					wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 					break;
 
@@ -4154,7 +4156,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 								$passback['deleted'] = $deleted;
 
 								// } Return
-								wp_send_json( $passback );
+								wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 								break;
 
@@ -4166,7 +4168,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 					}
 
 					// } Return - will be an error if here
-					wp_send_json( $passback );
+					wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 					break;
 
@@ -4202,7 +4204,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 								$passback['deleted'] = $deleted;
 
 								// } Return
-								wp_send_json( $passback );
+								wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 								break;
 
@@ -4214,7 +4216,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 					}
 
 					// } Return - will be an error if here, really!?!?
-					wp_send_json( $passback );
+					wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 					break;
 
@@ -4250,7 +4252,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 								$passback['deleted'] = $deleted;
 
 								// } Return
-								wp_send_json( $passback );
+								wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 								break;
 
@@ -4262,7 +4264,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 					}
 
 					// } Return - will be an error if here, really!?!? should be passsing headers as such.
-					wp_send_json( $passback );
+					wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 					break;
 
@@ -4304,7 +4306,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 								$passback['deleted'] = $deleted;
 
 								// } Return
-								wp_send_json( $passback );
+								wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 								break;
 
@@ -4336,7 +4338,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 								$passback['completed'] = $completed;
 
 								// } Return
-								wp_send_json( $passback );
+								wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 								break;
 
@@ -4356,7 +4358,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 								$passback['incompleted'] = $incompleted;
 
 								// } Return
-								wp_send_json( $passback );
+								wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 								break;
 
@@ -4368,13 +4370,13 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 					}
 
 					// } Return - will be an error if here, really!?!? should be passsing headers as such.
-					wp_send_json( $passback );
+					wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
 
 					break;
 
 				default:
 					// err really :o
-					wp_send_json( array() );
+					wp_send_json( array(), null, JSON_UNESCAPED_SLASHES );
 
 					break;
 
@@ -4443,7 +4445,7 @@ function zeroBSCRM_bulkAction_enact_addTags( $obj_ids = array(), $obj_type_id = 
 			$passback['tagged'] = $tagged;
 
 			// This function outputs JSON and exits.
-			wp_send_json( $passback ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 	} else {
 
@@ -4452,7 +4454,7 @@ function zeroBSCRM_bulkAction_enact_addTags( $obj_ids = array(), $obj_type_id = 
 	}
 
 		// err
-		wp_send_json_error( -1, 500 );
+		wp_send_json_error( -1, 500, JSON_UNESCAPED_SLASHES );
 }
 
 	/**
@@ -4510,7 +4512,7 @@ function zeroBSCRM_bulkAction_enact_removeTags( $obj_ids = array(), $obj_type_id
 			$passback['untagged'] = $untagged;
 
 			// This function outputs JSON and exits.
-			wp_send_json( $passback ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 	} else {
 
@@ -4519,7 +4521,7 @@ function zeroBSCRM_bulkAction_enact_removeTags( $obj_ids = array(), $obj_type_id
 	}
 
 		// err
-		wp_send_json_error( -1, 500 );
+		wp_send_json_error( -1, 500, JSON_UNESCAPED_SLASHES );
 }
 
 /*
@@ -4598,7 +4600,8 @@ function zeroBSCRM_AJAX_previewSegment() {
 					'count' => 0,
 					'error' => $error_string,
 				),
-				$status
+				$status,
+				JSON_UNESCAPED_SLASHES
 			);
 
 		}
@@ -4606,13 +4609,13 @@ function zeroBSCRM_AJAX_previewSegment() {
 		if ( is_array( $ret ) && isset( $ret['count'] ) ) {
 
 			// return id / fail
-			wp_send_json( $ret );
+			wp_send_json( $ret, null, JSON_UNESCAPED_SLASHES );
 
 		}
 	}
 
 	// empty handed
-	wp_send_json( array( 'count' => 0 ) );
+	wp_send_json( array( 'count' => 0 ), null, JSON_UNESCAPED_SLASHES );
 }
 // } Save a segment down (update or add)
 add_action( 'wp_ajax_zbs_segment_savesegment', 'zeroBSCRM_AJAX_saveSegment' );
@@ -4652,7 +4655,7 @@ function zeroBSCRM_AJAX_saveSegment() {
 		if ( ! empty( $segmentID ) ) {
 
 			// return id / fail
-			wp_send_json( array( 'id' => $segmentID ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			wp_send_json( array( 'id' => $segmentID ), null, JSON_UNESCAPED_SLASHES ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 		}
 	}
@@ -4718,7 +4721,7 @@ function zeroBSCRM_AJAX_addTag() {
 		}
 
 		if ( empty( $objType ) ) {
-			wp_send_json_error( array( 'notag' => 1 ), 500 );
+			wp_send_json_error( array( 'notag' => 1 ), 500, JSON_UNESCAPED_SLASHES );
 			exit( 0 );
 		}
 
@@ -4762,14 +4765,16 @@ function zeroBSCRM_AJAX_addTag() {
 					array(
 						'id'   => $tagID,
 						'slug' => $slug,
-					)
+					),
+					null,
+					JSON_UNESCAPED_SLASHES
 				);
 			}
 		} // if objtype match
 
 	}
 
-	wp_send_json_error( array( 'dataerr' => 1 ), 500 );
+	wp_send_json_error( array( 'dataerr' => 1 ), 500, JSON_UNESCAPED_SLASHES );
 }
 
 add_action( 'wp_ajax_zbs_delete_tag', 'zeroBSCRM_AJAX_deleteTag' );
@@ -4789,7 +4794,7 @@ function zeroBSCRM_AJAX_deleteTag() {
 		}
 
 		if ( empty( $objTagID ) ) {
-			wp_send_json_error( array( 'notag' => 1 ), 500 );
+			wp_send_json_error( array( 'notag' => 1 ), 500, JSON_UNESCAPED_SLASHES );
 		}
 
 		global $zbs;
@@ -4806,13 +4811,13 @@ function zeroBSCRM_AJAX_deleteTag() {
 				)
 			);
 
-			wp_send_json( array( 'res' => $res ) );
+			wp_send_json( array( 'res' => $res ), null, JSON_UNESCAPED_SLASHES );
 
 		} // if objtype match
 
 	}
 
-	wp_send_json_error( array( 'dataerr' => 1 ), 500 );
+	wp_send_json_error( array( 'dataerr' => 1 ), 500, JSON_UNESCAPED_SLASHES );
 }
 
 // } Preview a tagged group
@@ -4867,13 +4872,13 @@ function zeroBSCRM_AJAX_previewTagged() {
 		if ( is_array( $ret ) && isset( $ret['count'] ) ) {
 
 			// return id / fail
-			wp_send_json( $ret );
+			wp_send_json( $ret, null, JSON_UNESCAPED_SLASHES );
 
 		}
 	}
 
 	// empty handed
-	wp_send_json( array( 'count' => 0 ) );
+	wp_send_json( array( 'count' => 0 ), null, JSON_UNESCAPED_SLASHES );
 }
 
 /*
@@ -4897,7 +4902,7 @@ function zeroBSCRM_AJAX_saveScreenOptions() {
 
 	// } Check is logged in legit user
 	if ( ! zeroBS_canUpdateScreenOptions() ) {
-		wp_send_json_error( array( 'err' => 'rights' ), 500 );
+		wp_send_json_error( array( 'err' => 'rights' ), 500, JSON_UNESCAPED_SLASHES );
 	}
 
 	global $zbs;
@@ -4983,11 +4988,11 @@ function zeroBSCRM_AJAX_saveScreenOptions() {
 		// } Brutally update
 		$zbs->DAL->updateSetting( 'screenopts_' . $pageKey, $screenOpts ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase,WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
-		wp_send_json( array( 'fini' => 1 ) );
+		wp_send_json( array( 'fini' => 1 ), null, JSON_UNESCAPED_SLASHES );
 
 	}
 
-	wp_send_json_error( array( 'err' => 'pagekey' ), 500 );
+	wp_send_json_error( array( 'err' => 'pagekey' ), 500, JSON_UNESCAPED_SLASHES );
 }
 
 /*
@@ -5022,7 +5027,7 @@ function zeroBSCRM_AJAX_listViewInlineEdit_save() {
 		case 'customer':
 			// } Perms
 			if ( ! zeroBSCRM_permsCustomers() ) {
-				wp_send_json_error( array( 'no-action-or-rights' => 1 ), 500 );
+				wp_send_json_error( array( 'no-action-or-rights' => 1 ), 500, JSON_UNESCAPED_SLASHES );
 			}
 
 			// } check deets
@@ -5041,7 +5046,7 @@ function zeroBSCRM_AJAX_listViewInlineEdit_save() {
 				}
 
 				if ( $success ) {
-					wp_send_json( array( 'success' => 1 ) );
+					wp_send_json( array( 'success' => 1 ), null, JSON_UNESCAPED_SLASHES );
 				}
 			}
 
@@ -5049,7 +5054,7 @@ function zeroBSCRM_AJAX_listViewInlineEdit_save() {
 
 	}
 
-	wp_send_json_error( array( 'no-action-or-rights' => 1 ), 500 );
+	wp_send_json_error( array( 'no-action-or-rights' => 1 ), 500, JSON_UNESCAPED_SLASHES );
 }
 
 /*
@@ -5094,12 +5099,12 @@ function zbs_invoice_send_invoice() {
 
 	// validate the email
 	if ( ! zeroBSCRM_validateEmail( $em ) ) {
-		wp_send_json_error( array( 'message' => __( 'Not valid', 'zero-bs-crm' ) ), 500 );
+		wp_send_json_error( array( 'message' => __( 'Not valid', 'zero-bs-crm' ) ), 500, JSON_UNESCAPED_SLASHES );
 	}
 
 	// } Check id + perms + em
 	if ( $zbs_invID <= 0 || empty( $em ) || ! zeroBSCRM_permsInvoices() ) {
-		wp_send_json_error( array( 'message' => __( 'Not valid', 'zero-bs-crm' ) ), 500 );
+		wp_send_json_error( array( 'message' => __( 'Not valid', 'zero-bs-crm' ) ), 500, JSON_UNESCAPED_SLASHES );
 	}
 
 	$sent = zeroBSCRM_AJAX_sendInvoiceEmail_v3( $em, $zbs_invID, $attachAssignedDocs, $attachAsPDF );
@@ -5107,12 +5112,12 @@ function zbs_invoice_send_invoice() {
 	if ( $sent ) {
 
 		// send result
-		wp_send_json( array( 'message' => 'sent' ) );
+		wp_send_json( array( 'message' => 'sent' ), null, JSON_UNESCAPED_SLASHES );
 
 	}
 
 	// send err
-	wp_send_json_error( array( 'message' => __( 'not sent', 'zero-bs-crm' ) ), 500 );
+	wp_send_json_error( array( 'message' => __( 'not sent', 'zero-bs-crm' ) ), 500, JSON_UNESCAPED_SLASHES );
 }
 
 // v3.0+ send email for an invoice
@@ -5307,7 +5312,7 @@ function zeroBSCRM_AJAX_sendStatement() {
 	if ( ! zeroBSCRM_validateEmail( $em ) ) {
 
 		$r['error'] = __( 'Not a valid email', 'zero-bs-crm' );
-		wp_send_json_error( $r, 500 );
+		wp_send_json_error( $r, 500, JSON_UNESCAPED_SLASHES );
 
 	} else {
 		$email = $em;
@@ -5317,7 +5322,7 @@ function zeroBSCRM_AJAX_sendStatement() {
 	if ( $cID <= 0 || empty( $email ) || ! zeroBSCRM_permsInvoices() ) {
 
 		$r['error'] = '';
-		wp_send_json_error( $r, 500 );
+		wp_send_json_error( $r, 500, JSON_UNESCAPED_SLASHES );
 
 	}
 
@@ -5330,7 +5335,7 @@ function zeroBSCRM_AJAX_sendStatement() {
 	if ( ! file_exists( $statementPDFfilepath ) ) {
 
 		$r['error'] = '';
-		wp_send_json_error( $r, 500 );
+		wp_send_json_error( $r, 500, JSON_UNESCAPED_SLASHES );
 
 	}
 
@@ -5389,7 +5394,7 @@ function zeroBSCRM_AJAX_sendStatement() {
 		unlink( $statementPDFfilepath );
 
 		$r['success'] = __( 'Sent', 'zero-bs-crm' );
-		wp_send_json( $r );
+		wp_send_json( $r, null, JSON_UNESCAPED_SLASHES );
 }
 
 add_action( 'wp_ajax_zbs_invoice_mark_paid', 'zbs_invoice_mark_paid' );
@@ -5417,7 +5422,7 @@ function zbs_invoice_mark_paid() {
 
 	// all OK ....
 	$r = array( 'message' => 'All done OK' );
-	wp_send_json( $r );
+	wp_send_json( $r, null, JSON_UNESCAPED_SLASHES );
 }
 
 // } and send test so they can test before actually sending the invoice
@@ -5443,7 +5448,7 @@ function zbs_invoice_send_test_invoice() {
 	// validate the email
 	if ( ! zeroBSCRM_validateEmail( $em ) ) {
 		$r['message'] = 'Not a valid email';
-		wp_send_json( $r );
+		wp_send_json( $r, null, JSON_UNESCAPED_SLASHES );
 	} else {
 		$email = $em;
 	}
@@ -5533,7 +5538,7 @@ function zbs_invoice_send_test_invoice() {
 
 	// sends the invoice via wp_mail (for now)...
 	$r['message'] = 'All done OK';
-	wp_send_json( $r );
+	wp_send_json( $r, null, JSON_UNESCAPED_SLASHES );
 }
 
 /*
@@ -5574,7 +5579,7 @@ function zeroBSCRM_AJAX_getInvoice() {
 
 	// check perms
 	if ( ! zeroBSCRM_permsIsZBSUser() ) {
-		wp_send_json_error( null, 500 );
+		wp_send_json_error( null, 500, JSON_UNESCAPED_SLASHES );
 	}
 
 		// build + return
@@ -5592,7 +5597,7 @@ function zeroBSCRM_AJAX_getInvoice() {
 		$data = zeroBSCRM_invoicing_getInvoiceData( $invID );
 
 		// pass back in json
-		wp_send_json( $data );
+		wp_send_json( $data, null, JSON_UNESCAPED_SLASHES );
 
 	} else {
 
@@ -5612,12 +5617,12 @@ function zeroBSCRM_AJAX_getInvoice() {
 		$data['tax_linesObj'] = zeroBSCRM_taxRates_getTaxTableArr();
 
 		// pass back in json
-		wp_send_json( $data );
+		wp_send_json( $data, null, JSON_UNESCAPED_SLASHES );
 
 	}
 
 		// exit json
-		wp_send_json_error( array( 'here' ), 500 );
+		wp_send_json_error( array( 'here' ), 500, JSON_UNESCAPED_SLASHES );
 }
 
 /*
@@ -5637,7 +5642,7 @@ function zeroBSCRM_ajax_mark_task_complete() {
 	check_ajax_referer( 'zbscrmjs-glob-ajax-nonce', 'sec' );
 
 	if ( ! zeroBSCRM_perms_tasks() ) {
-		wp_send_json_error( array( 'permission_error' => 1 ), 403 );
+		wp_send_json_error( array( 'permission_error' => 1 ), 403, JSON_UNESCAPED_SLASHES );
 	}
 
 	global $zbs;
@@ -5653,12 +5658,14 @@ function zeroBSCRM_ajax_mark_task_complete() {
 				array(
 					'task_id' => $task_id,
 					'status'  => $status,
-				)
+				),
+				null,
+				JSON_UNESCAPED_SLASHES
 			);
 		}
 	}
 
-	wp_send_json_error( array( 'params_error' => 1 ), 400 );
+	wp_send_json_error( array( 'params_error' => 1 ), 400, JSON_UNESCAPED_SLASHES );
 }
 
 /*

--- a/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AJAX.php
@@ -31,7 +31,7 @@ if ( ! defined( 'ZEROBSCRM_PATH' ) ) {
 function jpcrm_hide_woo_promo() {
 	if ( current_user_can( 'activate_plugins' ) ) {
 		$option = update_option( 'jpcrm_hide_woo_promo', 'hide', false );
-		wp_send_json_success( null, null, JSON_UNESCAPED_SLASHES );
+		wp_send_json_success( null, 200, JSON_UNESCAPED_SLASHES );
 	}
 }
 
@@ -39,7 +39,7 @@ function jpcrm_hide_woo_promo() {
 function jpcrm_hide_track_notice() {
 	if ( current_user_can( 'activate_plugins' ) ) {
 		$option = update_option( 'jpcrm_hide_track_notice', 'hide', false );
-		wp_send_json_success( null, null, JSON_UNESCAPED_SLASHES );
+		wp_send_json_success( null, 200, JSON_UNESCAPED_SLASHES );
 	}
 }
 
@@ -48,7 +48,7 @@ function jpcrm_hide_feature_alert() {
 	if ( current_user_can( 'activate_plugins' ) && isset( $_POST['feature_alert'] ) ) {
 		$option = 'jpcrm_hide_' . sanitize_text_field( $_POST['feature_alert'] );
 		update_option( $option, true, false );
-		wp_send_json_success( null, null, JSON_UNESCAPED_SLASHES );
+		wp_send_json_success( null, 200, JSON_UNESCAPED_SLASHES );
 	}
 }
 
@@ -65,7 +65,7 @@ function zbs_create_email_templates() {
 	} else {
 		$m['message'] = 'no permissions';
 	}
-	wp_send_json( $m, null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( $m, 200, JSON_UNESCAPED_SLASHES );
 }
 
 	// save email template
@@ -153,7 +153,7 @@ function zbs_save_email_status() {
 		$m['message'] = 'no perms';
 	}
 
-	wp_send_json( $m, null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( $m, 200, JSON_UNESCAPED_SLASHES );
 	// nonce field is zbs-save-email_active
 }
 
@@ -180,7 +180,7 @@ function zeroBSCRM_AJAX_logClose() {
 		update_option( 'zbs_closers_' . $potentialKey, time(), false );
 	}
 
-	wp_send_json( array( 'fini' => 1 ), null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( array( 'fini' => 1 ), 200, JSON_UNESCAPED_SLASHES );
 }
 
 	/*
@@ -231,7 +231,7 @@ function jpcrm_set_jpcrm_transient() {
 		}
 	}
 
-	wp_send_json( array( 'fini' => 1 ), null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( array( 'fini' => 1 ), 200, JSON_UNESCAPED_SLASHES );
 }
 
 	// } Feedback
@@ -245,7 +245,7 @@ function zeroBSCRM_AJAX_markFeedback() {
 		}
 		update_option( 'zbsfeedback', $feedbackVal, false );
 	}
-	wp_send_json( array( 'fini' => 1 ), null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( array( 'fini' => 1 ), 200, JSON_UNESCAPED_SLASHES );
 }
 
 	// } Retrieve list of invoice deets for customer ID
@@ -274,7 +274,7 @@ function zeroBSCRM_AJAX_getCustInvs() {
 		}
 	}
 
-	wp_send_json( $ret, null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( $ret, 200, JSON_UNESCAPED_SLASHES );
 }
 
 	// } Remove file
@@ -334,7 +334,7 @@ function zeroBSCRM_removeFile() {
 			'res'    => $res,
 			'errors' => $errors,
 		),
-		null,
+		200,
 		JSON_UNESCAPED_SLASHES
 	);
 }
@@ -350,7 +350,7 @@ function zeroBSCRM_AJAX_filterCustomers() {
 	check_ajax_referer( 'zbscrmjs-ajax-nonce', 'sec' );
 
 	if ( ! zeroBSCRM_permsCustomers() ) {
-		wp_send_json( array( 'processed' => -1 ), null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( array( 'processed' => -1 ), 200, JSON_UNESCAPED_SLASHES );
 	}
 
 	// } Running this auto-pulls POSTED filters + finds customers
@@ -363,7 +363,7 @@ function zeroBSCRM_AJAX_filterCustomers() {
 		$res                      = zeroBS__customerFiltersRetrieveCustomerCountAndTopCustomers();
 		$res['filters_in_effect'] = $zbsCustomerFiltersInEffect;
 
-	wp_send_json( $res, null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( $res, 200, JSON_UNESCAPED_SLASHES );
 }
 
 	// Add log
@@ -377,7 +377,7 @@ function zeroBSCRM_AJAX_addLog() {
 
 	// brutal
 	if ( ! zeroBSCRM_permsCustomers() ) {
-		wp_send_json( array( 'processed' => -1 ), null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( array( 'processed' => -1 ), 403, JSON_UNESCAPED_SLASHES );
 	}
 
 	global $zbs;
@@ -441,7 +441,7 @@ function zeroBSCRM_AJAX_addLog() {
 
 	}
 
-	wp_send_json( array( 'processed' => $res ), null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( array( 'processed' => $res ), 200, JSON_UNESCAPED_SLASHES );
 }
 
 	// Update log
@@ -455,7 +455,7 @@ function zeroBSCRM_AJAX_updateLog() {
 
 	// brutal
 	if ( ! zeroBSCRM_permsLogsAddEdit() ) {
-		wp_send_json( array( 'processed' => -1 ), null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( array( 'processed' => -1 ), 403, JSON_UNESCAPED_SLASHES );
 	}
 
 	global $zbs;
@@ -532,7 +532,7 @@ function zeroBSCRM_AJAX_updateLog() {
 		}
 	}
 
-	wp_send_json( array( 'processed' => $res ), null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( array( 'processed' => $res ), 200, JSON_UNESCAPED_SLASHES );
 }
 
 	// } Del log
@@ -544,11 +544,8 @@ function zeroBSCRM_AJAX_deleteLog() {
 	// } Check nonce
 	check_ajax_referer( 'zbscrmjs-ajax-nonce-logs', 'sec' );
 
-	// } brutal
-	// from 2.94.2 uses sub perms
-	// if (!zeroBSCRM_permsCustomers()) exit('{processed:-1}');
 	if ( ! zeroBSCRM_permsLogsDelete() ) {
-		wp_send_json( array( 'processed' => -1 ), null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( array( 'processed' => -1 ), 403, JSON_UNESCAPED_SLASHES );
 	}
 	// if (!current_user_can('edit_page', $post_id)) return;
 
@@ -569,7 +566,7 @@ function zeroBSCRM_AJAX_deleteLog() {
 		$res = $zbs->DAL->logs->deleteLog( array( 'id' => $zbsNoteID ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase,WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	}
 
-	wp_send_json( array( 'processed' => $res ), null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( array( 'processed' => $res ), 200, JSON_UNESCAPED_SLASHES );
 }
 
 	// Pin log
@@ -583,7 +580,7 @@ function jpcrm_ajax_pin_log() {
 	check_ajax_referer( 'zbscrmjs-ajax-nonce-logs', 'sec' );
 
 	if ( ! zeroBSCRM_permsLogsDelete() ) {
-		wp_send_json( array( processed => false ), null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( array( processed => false ), 403, JSON_UNESCAPED_SLASHES );
 	}
 
 	// Retrieve vars - this allows notes against ALL post types (just by id)
@@ -604,7 +601,7 @@ function jpcrm_ajax_pin_log() {
 
 	}
 
-	wp_send_json( array( 'processed' => $res ), null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( array( 'processed' => $res ), 200, JSON_UNESCAPED_SLASHES );
 }
 
 	// Un-Pin log
@@ -618,7 +615,7 @@ function jpcrm_ajax_unpin_log() {
 	check_ajax_referer( 'zbscrmjs-ajax-nonce-logs', 'sec' );
 
 	if ( ! zeroBSCRM_permsLogsDelete() ) {
-		wp_send_json( array( processed => false ), null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( array( processed => false ), 403, JSON_UNESCAPED_SLASHES );
 	}
 
 	// Retrieve vars - this allows notes against ALL post types (just by id)
@@ -639,7 +636,7 @@ function jpcrm_ajax_unpin_log() {
 
 	}
 
-	wp_send_json( array( 'processed' => $res ), null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( array( 'processed' => $res ), 200, JSON_UNESCAPED_SLASHES );
 }
 
 /*
@@ -664,14 +661,11 @@ function ZeroBSCRM_get_quote_template() {
 	check_ajax_referer( 'quo-ajax-nonce', 'security' );  // nonce..
 
 	// } brutal
-	if ( ! zeroBSCRM_permsCustomers() ) {
-		wp_send_json( array( 'processed' => -1 ), null, JSON_UNESCAPED_SLASHES );
-	}
-	if ( ! zeroBSCRM_permsQuotes() ) {
-		wp_send_json( array( 'processed' => -1 ), null, JSON_UNESCAPED_SLASHES );
+	if ( ! zeroBSCRM_permsCustomers() || ! zeroBSCRM_permsQuotes() ) {
+		wp_send_json( array( 'processed' => -1 ), 403, JSON_UNESCAPED_SLASHES );
 	}
 
-	// } Retrive deets
+	// Retrieve deets
 	$customer_ID = -1;
 	if ( isset( $_POST['cust_id'] ) ) {
 		$customer_ID = (int) $_POST['cust_id']; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
@@ -836,13 +830,13 @@ function ZeroBSCRM_get_quote_template() {
 			$content['template_notes'] = $quote_template['notes'];
 
 			// } return
-			wp_send_json( $content, null, JSON_UNESCAPED_SLASHES );
+			wp_send_json( $content, 200, JSON_UNESCAPED_SLASHES );
 
 		} // / if content
 
 	} // / if vars
 
-	wp_send_json( array( 'error' => 1 ), null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( array( 'error' => 1 ), 200, JSON_UNESCAPED_SLASHES );
 }
 
 // Send a quote via email
@@ -853,11 +847,8 @@ function jpcrm_ajax_quote_send_email() {
 	check_ajax_referer( 'edit-nonce-quote', 'sec' );
 
 	// Check Permissions
-	if ( ! zeroBSCRM_permsCustomers() ) {
-		wp_send_json( array( 'processed' => -1 ), null, JSON_UNESCAPED_SLASHES );
-	}
-	if ( ! zeroBSCRM_permsQuotes() ) {
-		wp_send_json( array( 'processed' => -1 ), null, JSON_UNESCAPED_SLASHES );
+	if ( ! zeroBSCRM_permsCustomers() || ! zeroBSCRM_permsQuotes() ) {
+		wp_send_json( array( 'processed' => -1 ), 403, JSON_UNESCAPED_SLASHES );
 	}
 
 	// Retrive details
@@ -1032,7 +1023,7 @@ function jpcrm_ajax_quote_send_email() {
 		if ( $sent ) {
 
 			// send result
-			wp_send_json( array( 'message' => 'sent' ), null, JSON_UNESCAPED_SLASHES );
+			wp_send_json( array( 'message' => 'sent' ), 200, JSON_UNESCAPED_SLASHES );
 
 		}
 		// send err
@@ -1113,7 +1104,7 @@ function ZeroBSCRM_accept_quote() {
 	} // / if email notification active
 
 	// success
-	wp_send_json( array( 'success' => 1 ), null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( array( 'success' => 1 ), 200, JSON_UNESCAPED_SLASHES );
 }
 
 /*
@@ -1189,7 +1180,7 @@ function zbs_lead_form_views() {
 	$form_id    = (int) sanitize_text_field( $_POST['id'] );
 	$form_views = $zbs->DAL->forms->add_form_view( $form_id );
 
-	wp_send_json( array( 'view_logged' => 'true' ), null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( array( 'view_logged' => 'true' ), 200, JSON_UNESCAPED_SLASHES );
 }
 	add_action( 'wp_ajax_nopriv_zbs_lead_form_views', 'zbs_lead_form_views' );
 	add_action( 'wp_ajax_zbs_lead_form_views', 'zbs_lead_form_views' );
@@ -1258,7 +1249,7 @@ function zbs_lead_form_capture() {
 			// } AXE IT
 			$r['message'] = 'Nope.';
 			$r['code']    = 'recaptcha';
-			wp_send_json( $r, null, JSON_UNESCAPED_SLASHES );
+			wp_send_json( $r, 200, JSON_UNESCAPED_SLASHES );
 
 		}
 	}
@@ -1275,7 +1266,7 @@ function zbs_lead_form_capture() {
 		// } AXE IT
 		$r['message'] = 'Nope.';
 		$r['code']    = 'form';
-		wp_send_json( $r, null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( $r, 200, JSON_UNESCAPED_SLASHES );
 
 	}
 
@@ -1285,7 +1276,7 @@ function zbs_lead_form_capture() {
 		// then this is likely a spambot who has filled in the form since its hidden from humans
 		$r['message'] = 'This is a honeypot.. something has gone wrong can alert the member on response';
 		$r['code']    = 'honey';
-		wp_send_json( $r, null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( $r, 200, JSON_UNESCAPED_SLASHES );
 	} else {
 
 		// } Added here: REQUIRE email...
@@ -1299,7 +1290,7 @@ function zbs_lead_form_capture() {
 			// } AXE IT
 			$r['message'] = 'Email Required.';
 			$r['code']    = 'emailfail';
-			wp_send_json( $r, null, JSON_UNESCAPED_SLASHES );
+			wp_send_json( $r, 200, JSON_UNESCAPED_SLASHES );
 
 		}
 
@@ -1573,7 +1564,7 @@ function zbs_lead_form_capture() {
 			// return
 			$r['message'] = 'Contact received.';
 			$r['code']    = 'success';
-			wp_send_json( $r, null, JSON_UNESCAPED_SLASHES );
+			wp_send_json( $r, 200, JSON_UNESCAPED_SLASHES );
 
 	}
 }
@@ -1607,7 +1598,7 @@ function zeroBSCRM_AJAX_addAlias() {
 
 	// } Check perms
 	if ( ! zeroBSCRM_permsCustomers() ) {
-		wp_send_json( array( 'err' => 1 ), null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( array( 'err' => 1 ), 403, JSON_UNESCAPED_SLASHES );
 	}
 
 	// } Proceed :)
@@ -1641,12 +1632,12 @@ function zeroBSCRM_AJAX_addAlias() {
 		}
 
 		// } Return
-		wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 	}
 
 		// err really :o
-		wp_send_json( array(), null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( array(), 200, JSON_UNESCAPED_SLASHES );
 }
 	add_action( 'wp_ajax_removeAlias', 'zeroBSCRM_AJAX_removeAlias' );
 function zeroBSCRM_AJAX_removeAlias() {
@@ -1656,7 +1647,7 @@ function zeroBSCRM_AJAX_removeAlias() {
 
 	// } Check perms
 	if ( ! zeroBSCRM_permsCustomers() ) {
-		wp_send_json( array( 'err' => 1 ), null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( array( 'err' => 1 ), 200, JSON_UNESCAPED_SLASHES );
 	}
 
 	// } Proceed :)
@@ -1681,12 +1672,12 @@ function zeroBSCRM_AJAX_removeAlias() {
 		// } For now, no checks :)
 
 			// } Return
-			wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+			wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 	}
 
 		// err really :o
-		wp_send_json( array(), null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( array(), 200, JSON_UNESCAPED_SLASHES );
 }
 
 /*
@@ -1710,7 +1701,7 @@ function zeroBSCRM_AJAX_updateListViewColumns() {
 
 	// } Check perms
 	if ( ! zeroBSCRM_isZBSAdminOrAdmin() ) {
-		wp_send_json( array( 'err' => 1 ), null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( array( 'err' => 1 ), 403, JSON_UNESCAPED_SLASHES );
 	}
 
 		global $zbs;
@@ -1753,7 +1744,7 @@ function zeroBSCRM_AJAX_updateListViewColumns() {
 			$zbs->settings->update( 'customviews2', $newCustomViews );
 
 			// } Return
-			wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+			wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 			break;
 
@@ -1780,7 +1771,7 @@ function zeroBSCRM_AJAX_updateListViewColumns() {
 			$zbs->settings->update( 'customviews2', $newCustomViews );
 
 			// } Return
-			wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+			wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 			break;
 
@@ -1807,7 +1798,7 @@ function zeroBSCRM_AJAX_updateListViewColumns() {
 			$zbs->settings->update( 'customviews2', $newCustomViews );
 
 			// } Return
-			wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+			wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 			break;
 
@@ -1834,7 +1825,7 @@ function zeroBSCRM_AJAX_updateListViewColumns() {
 			$zbs->settings->update( 'customviews2', $newCustomViews );
 
 			// } Return
-			wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+			wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 			break;
 
@@ -1861,7 +1852,7 @@ function zeroBSCRM_AJAX_updateListViewColumns() {
 			$zbs->settings->update( 'customviews2', $newCustomViews );
 
 			// } Return
-			wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+			wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 			break;
 
@@ -1888,7 +1879,7 @@ function zeroBSCRM_AJAX_updateListViewColumns() {
 			$zbs->settings->update( 'customviews2', $newCustomViews );
 
 			// } Return
-			wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+			wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 			break;
 
@@ -1915,7 +1906,7 @@ function zeroBSCRM_AJAX_updateListViewColumns() {
 			$zbs->settings->update( 'customviews2', $newCustomViews );
 
 			// } Return
-			wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+			wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 			break;
 
@@ -1940,13 +1931,13 @@ function zeroBSCRM_AJAX_updateListViewColumns() {
 			$zbs->settings->update( 'customviews2', $newCustomViews );
 
 			// } Return
-			wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+			wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 			break;
 
 		default:
 			// err really :o
-			wp_send_json( array(), null, JSON_UNESCAPED_SLASHES );
+			wp_send_json( array(), 200, JSON_UNESCAPED_SLASHES );
 
 			break;
 
@@ -3620,10 +3611,7 @@ function zeroBSCRM_AJAX_listViewRetrieveData() {
 
 		}
 	}
-
-		// debug $res = array(isset($listViewParams),gettype($listViewParams) == 'array',isset($listViewParams['listtype']));
-
-		wp_send_json( $res, null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( $res, 200, JSON_UNESCAPED_SLASHES );
 }
 
 	// } Enact some bulk action :)
@@ -3702,7 +3690,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 							$passback['deleted'] = $deleted;
 
 							// } Return
-							wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+							wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 							break;
 
@@ -3731,7 +3719,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 							$passback['accepted'] = $accepted;
 
 							// } Return
-							wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+							wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 							break;
 
@@ -3775,14 +3763,14 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 							}
 
 							// } Return
-							wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+							wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 							break;
 
 					}
 
 						// } Return - will be an error if here
-						wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+						wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 					break;
 
@@ -3827,7 +3815,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 								$passback['deleted'] = $deleted;
 
 								// } Return
-								wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+								wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 								break;
 
@@ -3851,7 +3839,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 					}
 
 					// } Return - will be an error if here
-					wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+					wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 					break;
 
@@ -3893,7 +3881,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 								$passback['deleted'] = $deleted;
 
 								// } Return
-								wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+								wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 								break;
 
@@ -3913,7 +3901,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 								$passback['accepted'] = $accepted;
 
 								// } Return
-								wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+								wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 								break;
 
@@ -3933,7 +3921,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 								$passback['unaccepted'] = $unaccepted;
 
 								// } Return
-								wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+								wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 								break;
 
@@ -3957,7 +3945,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 					}
 
 					// } Return - will be an error if here
-					wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+					wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 					break;
 
@@ -3998,7 +3986,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 								$passback['deleted'] = $deleted;
 
 								// } Return
-								wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+								wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 								break;
 
@@ -4024,7 +4012,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 								$passback['accepted'] = $accepted;
 
 								// } Return
-								wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+								wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 								break;
 
@@ -4048,7 +4036,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 					}
 
 					// } Return - will be an error if here
-					wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+					wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 					break;
 
@@ -4090,7 +4078,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 								$passback['deleted'] = $deleted;
 
 								// } Return
-								wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+								wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 								break;
 
@@ -4114,7 +4102,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 					}
 
 					// } Return - will be an error if here
-					wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+					wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 					break;
 
@@ -4156,7 +4144,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 								$passback['deleted'] = $deleted;
 
 								// } Return
-								wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+								wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 								break;
 
@@ -4168,7 +4156,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 					}
 
 					// } Return - will be an error if here
-					wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+					wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 					break;
 
@@ -4204,7 +4192,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 								$passback['deleted'] = $deleted;
 
 								// } Return
-								wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+								wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 								break;
 
@@ -4216,7 +4204,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 					}
 
 					// } Return - will be an error if here, really!?!?
-					wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+					wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 					break;
 
@@ -4252,7 +4240,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 								$passback['deleted'] = $deleted;
 
 								// } Return
-								wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+								wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 								break;
 
@@ -4264,7 +4252,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 					}
 
 					// } Return - will be an error if here, really!?!? should be passsing headers as such.
-					wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+					wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 					break;
 
@@ -4306,7 +4294,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 								$passback['deleted'] = $deleted;
 
 								// } Return
-								wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+								wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 								break;
 
@@ -4338,7 +4326,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 								$passback['completed'] = $completed;
 
 								// } Return
-								wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+								wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 								break;
 
@@ -4358,7 +4346,7 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 								$passback['incompleted'] = $incompleted;
 
 								// } Return
-								wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+								wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 								break;
 
@@ -4370,13 +4358,13 @@ function zeroBSCRM_AJAX_enactListViewBulkAction() {
 					}
 
 					// } Return - will be an error if here, really!?!? should be passsing headers as such.
-					wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES );
+					wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES );
 
 					break;
 
 				default:
 					// err really :o
-					wp_send_json( array(), null, JSON_UNESCAPED_SLASHES );
+					wp_send_json( array(), 200, JSON_UNESCAPED_SLASHES );
 
 					break;
 
@@ -4445,7 +4433,7 @@ function zeroBSCRM_bulkAction_enact_addTags( $obj_ids = array(), $obj_type_id = 
 			$passback['tagged'] = $tagged;
 
 			// This function outputs JSON and exits.
-			wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 	} else {
 
@@ -4512,7 +4500,7 @@ function zeroBSCRM_bulkAction_enact_removeTags( $obj_ids = array(), $obj_type_id
 			$passback['untagged'] = $untagged;
 
 			// This function outputs JSON and exits.
-			wp_send_json( $passback, null, JSON_UNESCAPED_SLASHES ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			wp_send_json( $passback, 200, JSON_UNESCAPED_SLASHES ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 	} else {
 
@@ -4609,13 +4597,13 @@ function zeroBSCRM_AJAX_previewSegment() {
 		if ( is_array( $ret ) && isset( $ret['count'] ) ) {
 
 			// return id / fail
-			wp_send_json( $ret, null, JSON_UNESCAPED_SLASHES );
+			wp_send_json( $ret, 200, JSON_UNESCAPED_SLASHES );
 
 		}
 	}
 
 	// empty handed
-	wp_send_json( array( 'count' => 0 ), null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( array( 'count' => 0 ), 200, JSON_UNESCAPED_SLASHES );
 }
 // } Save a segment down (update or add)
 add_action( 'wp_ajax_zbs_segment_savesegment', 'zeroBSCRM_AJAX_saveSegment' );
@@ -4655,7 +4643,7 @@ function zeroBSCRM_AJAX_saveSegment() {
 		if ( ! empty( $segmentID ) ) {
 
 			// return id / fail
-			wp_send_json( array( 'id' => $segmentID ), null, JSON_UNESCAPED_SLASHES ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			wp_send_json( array( 'id' => $segmentID ), 200, JSON_UNESCAPED_SLASHES ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 		}
 	}
@@ -4766,7 +4754,7 @@ function zeroBSCRM_AJAX_addTag() {
 						'id'   => $tagID,
 						'slug' => $slug,
 					),
-					null,
+					200,
 					JSON_UNESCAPED_SLASHES
 				);
 			}
@@ -4811,7 +4799,7 @@ function zeroBSCRM_AJAX_deleteTag() {
 				)
 			);
 
-			wp_send_json( array( 'res' => $res ), null, JSON_UNESCAPED_SLASHES );
+			wp_send_json( array( 'res' => $res ), 200, JSON_UNESCAPED_SLASHES );
 
 		} // if objtype match
 
@@ -4872,13 +4860,13 @@ function zeroBSCRM_AJAX_previewTagged() {
 		if ( is_array( $ret ) && isset( $ret['count'] ) ) {
 
 			// return id / fail
-			wp_send_json( $ret, null, JSON_UNESCAPED_SLASHES );
+			wp_send_json( $ret, 200, JSON_UNESCAPED_SLASHES );
 
 		}
 	}
 
 	// empty handed
-	wp_send_json( array( 'count' => 0 ), null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( array( 'count' => 0 ), 200, JSON_UNESCAPED_SLASHES );
 }
 
 /*
@@ -4988,7 +4976,7 @@ function zeroBSCRM_AJAX_saveScreenOptions() {
 		// } Brutally update
 		$zbs->DAL->updateSetting( 'screenopts_' . $pageKey, $screenOpts ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase,WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
-		wp_send_json( array( 'fini' => 1 ), null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( array( 'fini' => 1 ), 200, JSON_UNESCAPED_SLASHES );
 
 	}
 
@@ -5046,7 +5034,7 @@ function zeroBSCRM_AJAX_listViewInlineEdit_save() {
 				}
 
 				if ( $success ) {
-					wp_send_json( array( 'success' => 1 ), null, JSON_UNESCAPED_SLASHES );
+					wp_send_json( array( 'success' => 1 ), 200, JSON_UNESCAPED_SLASHES );
 				}
 			}
 
@@ -5112,7 +5100,7 @@ function zbs_invoice_send_invoice() {
 	if ( $sent ) {
 
 		// send result
-		wp_send_json( array( 'message' => 'sent' ), null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( array( 'message' => 'sent' ), 200, JSON_UNESCAPED_SLASHES );
 
 	}
 
@@ -5394,7 +5382,7 @@ function zeroBSCRM_AJAX_sendStatement() {
 		unlink( $statementPDFfilepath );
 
 		$r['success'] = __( 'Sent', 'zero-bs-crm' );
-		wp_send_json( $r, null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( $r, 200, JSON_UNESCAPED_SLASHES );
 }
 
 add_action( 'wp_ajax_zbs_invoice_mark_paid', 'zbs_invoice_mark_paid' );
@@ -5422,7 +5410,7 @@ function zbs_invoice_mark_paid() {
 
 	// all OK ....
 	$r = array( 'message' => 'All done OK' );
-	wp_send_json( $r, null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( $r, 200, JSON_UNESCAPED_SLASHES );
 }
 
 // } and send test so they can test before actually sending the invoice
@@ -5448,7 +5436,7 @@ function zbs_invoice_send_test_invoice() {
 	// validate the email
 	if ( ! zeroBSCRM_validateEmail( $em ) ) {
 		$r['message'] = 'Not a valid email';
-		wp_send_json( $r, null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( $r, 200, JSON_UNESCAPED_SLASHES );
 	} else {
 		$email = $em;
 	}
@@ -5538,7 +5526,7 @@ function zbs_invoice_send_test_invoice() {
 
 	// sends the invoice via wp_mail (for now)...
 	$r['message'] = 'All done OK';
-	wp_send_json( $r, null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( $r, 200, JSON_UNESCAPED_SLASHES );
 }
 
 /*
@@ -5597,7 +5585,7 @@ function zeroBSCRM_AJAX_getInvoice() {
 		$data = zeroBSCRM_invoicing_getInvoiceData( $invID );
 
 		// pass back in json
-		wp_send_json( $data, null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( $data, 200, JSON_UNESCAPED_SLASHES );
 
 	} else {
 
@@ -5617,7 +5605,7 @@ function zeroBSCRM_AJAX_getInvoice() {
 		$data['tax_linesObj'] = zeroBSCRM_taxRates_getTaxTableArr();
 
 		// pass back in json
-		wp_send_json( $data, null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( $data, 200, JSON_UNESCAPED_SLASHES );
 
 	}
 
@@ -5659,7 +5647,7 @@ function zeroBSCRM_ajax_mark_task_complete() {
 					'task_id' => $task_id,
 					'status'  => $status,
 				),
-				null,
+				200,
 				JSON_UNESCAPED_SLASHES
 			);
 		}

--- a/projects/plugins/crm/includes/ZeroBSCRM.API.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.API.php
@@ -84,7 +84,7 @@ function jpcrm_api_invalid_request() {
 		'status'  => __( 'Bad request', 'zero-bs-crm' ),
 		'message' => __( 'The API request was invalid.', 'zero-bs-crm' ),
 	);
-	wp_send_json_error( $reply, 400 );
+	wp_send_json_error( $reply, 400, JSON_UNESCAPED_SLASHES );
 }
 
 /**
@@ -95,7 +95,7 @@ function jpcrm_api_unauthorised_request() {
 		'status'  => __( 'Unauthorized', 'zero-bs-crm' ),
 		'message' => __( 'Please ensure your Jetpack CRM API key and secret are correctly configured.', 'zero-bs-crm' ),
 	);
-	wp_send_json_error( $reply, 401 );
+	wp_send_json_error( $reply, 401, JSON_UNESCAPED_SLASHES );
 }
 
 /**
@@ -106,7 +106,7 @@ function jpcrm_api_forbidden_request() {
 		'status'  => __( 'Forbidden', 'zero-bs-crm' ),
 		'message' => __( 'You do not have permission to access this resource.', 'zero-bs-crm' ),
 	);
-	wp_send_json_error( $reply, 403 );
+	wp_send_json_error( $reply, 403, JSON_UNESCAPED_SLASHES );
 }
 
 /**
@@ -117,7 +117,7 @@ function jpcrm_api_invalid_method() {
 		'status'  => __( 'Method not allowed', 'zero-bs-crm' ),
 		'message' => __( 'Please ensure you are using the proper method (e.g. POST or GET).', 'zero-bs-crm' ),
 	);
-	wp_send_json_error( $reply, 405 );
+	wp_send_json_error( $reply, 405, JSON_UNESCAPED_SLASHES );
 }
 
 /**
@@ -128,7 +128,7 @@ function jpcrm_api_teapot() {
 		'status'  => 'I\'m a teapot',
 		'message' => 'As per RFC 2324 (section 2.3.2), this response is short and stout.',
 	);
-	wp_send_json_error( $reply, 418 );
+	wp_send_json_error( $reply, 418, JSON_UNESCAPED_SLASHES );
 }
 
 /**
@@ -173,7 +173,7 @@ function zeroBSCRM_API_error( $errorMsg = 'Error', $header_code = 400 ) {
 
 	// } 400 = general error
 	// } 403 = perms
-	wp_send_json( array( 'error' => $errorMsg ), $header_code );
+	wp_send_json( array( 'error' => $errorMsg ), $header_code, JSON_UNESCAPED_SLASHES );
 }
 
 // now to locate the templates...

--- a/projects/plugins/crm/includes/ZeroBSCRM.AdminStyling.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.AdminStyling.php
@@ -239,7 +239,7 @@ function zbs_color_grabber() {
 	// } Information here to get the colors
 	global $_wp_admin_css_colors, $zbsadmincolors;
 	$current_color = get_user_option( 'admin_color' );
-	echo '<script type="text/javascript">var zbsJS_admcolours = ' . json_encode( $_wp_admin_css_colors[ $current_color ] ) . ';</script>';
+	echo '<script type="text/javascript">var zbsJS_admcolours = ' . wp_json_encode( $_wp_admin_css_colors[ $current_color ], JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . ';</script>';
 	echo '<script type="text/javascript">var zbsJS_unpaid = "' . esc_html__( 'unpaid', 'zero-bs-crm' ) . '";</script>';
 	$zbsadmincolors = $_wp_admin_css_colors[ $current_color ]->colors;
 	?>

--- a/projects/plugins/crm/includes/ZeroBSCRM.CustomerFilters.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.CustomerFilters.php
@@ -127,7 +127,7 @@ function zeroBSCRM_cjson() {
 		$ret = zeroBS_getCustomers( true, 10000, 0, false, false, '', false, false, false );
 	}
 
-	wp_send_json( $ret );
+	wp_send_json( $ret, null, JSON_UNESCAPED_SLASHES );
 }
 
 	// WH NOTE: WHY is this getting ALL of them and not s? param
@@ -152,7 +152,7 @@ function zeroBSCRM_cojson() {
 
 	}
 
-	wp_send_json( $ret );
+	wp_send_json( $ret, null, JSON_UNESCAPED_SLASHES );
 }
 
 /*

--- a/projects/plugins/crm/includes/ZeroBSCRM.CustomerFilters.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.CustomerFilters.php
@@ -127,7 +127,7 @@ function zeroBSCRM_cjson() {
 		$ret = zeroBS_getCustomers( true, 10000, 0, false, false, '', false, false, false );
 	}
 
-	wp_send_json( $ret, null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( $ret, 200, JSON_UNESCAPED_SLASHES );
 }
 
 	// WH NOTE: WHY is this getting ALL of them and not s? param
@@ -152,7 +152,7 @@ function zeroBSCRM_cojson() {
 
 	}
 
-	wp_send_json( $ret, null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( $ret, 200, JSON_UNESCAPED_SLASHES );
 }
 
 /*

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Helpers.php
@@ -1659,18 +1659,6 @@ function zeroBSCRM_mergeCustomers( $dominantID = -1, $slaveID = -1 ) {
 				$slaveLogs = zeroBSCRM_getContactLogs( $slaveID, true, 10000, 0 ); // id created name meta
 				if ( is_array( $slaveLogs ) && count( $slaveLogs ) > 0 ) {
 
-					/*
-					in fact, just save as json encode :D - rough but quicker
-					// brutal str builder.
-					$logStr = '';
-
-					foreach ( $slaveLogs as $log){
-
-						if ( !empty( $logStr)) $logStr .= "\r\n";
-
-					} */
-
-					// update_post_meta($dominantID, 'zbs_merged_customer_log_bk_'.time(), json_encode($slaveLogs));
 					// no $change here, as this is kinda secret, kthx
 					$zbs->DAL->updateMeta( ZBS_TYPE_CONTACT, $dominantID, 'merged_customer_log_bk_' . time(), $slaveLogs );
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.php
@@ -2479,7 +2479,7 @@ class zbsDAL {
 			// WH note: it was necessary to add JSON_UNESCAPED_SLASHES to properly save down without issue
 			// combined with a more complex zeroBSCRM_stripSlashes recurrsive
 			// https://stackoverflow.com/questions/7282755/how-to-remove-backslash-on-json-encode-function
-			$data['val'] = json_encode( $data['val'], JSON_UNESCAPED_SLASHES );
+			$data['val'] = wp_json_encode( $data['val'], JSON_UNESCAPED_SLASHES ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 
 		}
 
@@ -3162,7 +3162,7 @@ class zbsDAL {
 		#} Var up any val (json_encode)
 		if ( in_array( gettype( $data['val'] ), array( 'object', 'array' ) ) ) {
 
-			$data['val'] = json_encode( $data['val'] );
+			$data['val'] = wp_json_encode( $data['val'], JSON_UNESCAPED_SLASHES ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 
 		}
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.Edit.Segment.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Edit.Segment.php
@@ -216,9 +216,9 @@ function zeroBSCRM_html_addEditSegment( $potentialID = -1 ) {
 				var jpcrm_available_contact_tags = <?php echo wp_json_encode( $available_tags_contacts, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
 				var jpcrm_available_transaction_tags = <?php echo wp_json_encode( $available_tags_transactions, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
 				var zbsAvailableStatuses = <?php echo wp_json_encode( $availableStatuses, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
-				var zbsSegmentStemURL = '<?php echo jpcrm_esc_link( 'edit', -1, 'segment', true ); ?>';
-				var jpcrm_contact_stem_URL = '<?php echo jpcrm_esc_link( 'view', -1, 'contact', true ); ?>';
-				var zbsSegmentListURL = '<?php echo jpcrm_esc_link( $zbs->slugs['segments'] ); ?>';
+				var zbsSegmentStemURL = <?php echo wp_json_encode( jpcrm_esc_link( 'edit', -1, 'segment', true ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
+				var jpcrm_contact_stem_URL = <?php echo wp_json_encode( jpcrm_esc_link( 'view', -1, 'contact', true ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
+				var zbsSegmentListURL = <?php echo wp_json_encode( jpcrm_esc_link( $zbs->slugs['segments'] ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
 				var zbsSegmentSEC = <?php echo wp_json_encode( wp_create_nonce( 'zbs-ajax-nonce' ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
 				var zbsSegmentLang = {
 					generalerrortitle: '<?php esc_html_e( 'General Error', 'zero-bs-crm' ); ?>',

--- a/projects/plugins/crm/includes/ZeroBSCRM.Edit.Segment.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Edit.Segment.php
@@ -164,49 +164,7 @@ function zeroBSCRM_html_addEditSegment( $potentialID = -1 ) {
 				</div>
 			</div>
 
-			<?php // ajax + lang bits ?><script type="text/javascript">
-			var zbsSegment = <?php echo json_encode( $segment ); ?>;
-			var jpcrm_available_conditions = <?php echo json_encode( $available_conditions ); ?>;
-			var jpcrm_available_conditions_by_category = <?php echo json_encode( $available_conditions_by_category ); ?>;
-			var zbsAvailableConditionOperators = <?php echo json_encode( $available_condition_operators ); ?>;
-			var jpcrm_available_contact_tags = <?php echo json_encode( $available_tags_contacts ); ?>;
-			var jpcrm_available_transaction_tags = <?php echo json_encode( $available_tags_transactions ); ?>;
-			var zbsAvailableStatuses = <?php echo json_encode( $availableStatuses ); ?>;
-			var zbsSegmentStemURL = '<?php echo jpcrm_esc_link( 'edit', -1, 'segment', true ); ?>';
-			var jpcrm_contact_stem_URL = '<?php echo jpcrm_esc_link( 'view', -1, 'contact', true ); ?>';
-			var zbsSegmentListURL = '<?php echo jpcrm_esc_link( $zbs->slugs['segments'] ); ?>';
-			var zbsSegmentSEC = '<?php echo esc_js( wp_create_nonce( 'zbs-ajax-nonce' ) ); ?>';
-			var zbsSegmentLang = {
-
-				generalerrortitle: '<?php esc_html_e( 'General Error', 'zero-bs-crm' ); ?>',
-				generalerror: '<?php esc_html_e( 'There was a general error.', 'zero-bs-crm' ); ?>',
-
-				currentlyInSegment: '<?php esc_html_e( 'Contacts currently match these conditions.', 'zero-bs-crm' ); ?>',
-				previewTitle: '<?php esc_html_e( 'Contacts Preview (randomised)', 'zero-bs-crm' ); ?>',
-
-				noName: '<?php esc_html_e( 'Unnamed Contact', 'zero-bs-crm' ); ?>',
-				noEmail: '<?php esc_html_e( 'No Email', 'zero-bs-crm' ); ?>',
-
-				notags: '<?php esc_html_e( 'No Tags Found', 'zero-bs-crm' ); ?>',
-				nostatuses: '<?php esc_html_e( 'No Statuses Found', 'zero-bs-crm' ); ?>',
-				noextsources: '<?php esc_html_e( 'No External Sources Found', 'zero-bs-crm' ); ?>',
-				no_mailpoet_statuses: '<?php esc_html_e( 'No MailPoet Statuses Found', 'zero-bs-crm' ); ?>',
-				nosegmentid: '<?php esc_html_e( 'No Segment ID Found.', 'zero-bs-crm' ); ?>',
-
-				to: '<?php esc_html_e( 'to', 'zero-bs-crm' ); ?>',
-				eg: '<?php esc_html_e( 'e.g.', 'zero-bs-crm' ); ?>',
-
-				saveSegment: '<?php echo esc_html( zeroBSCRM_slashOut( 'Save Segment', true ) ) . ' <i class="save icon">'; ?>',
-				savedSegment: '<?php echo esc_html( zeroBSCRM_slashOut( 'Segment Saved', true ) ) . ' <i class="check circle outline icon">'; ?>',
-
-				contactfields: '=== <?php esc_html_e( 'Contact Fields', 'zero-bs-crm' ); ?> ===',
-
-				default_description: '<?php echo esc_html( zeroBSCRM_slashOut( 'Condition which selects contacts based on given value', true ) ); ?>',
-
-			};
-			var jpcrm_external_source_list = 
 			<?php
-
 			// simplify our external sources array
 			$external_source_array = array();
 			foreach ( $zbs->external_sources as $external_source_key => $external_source_info ) {
@@ -224,42 +182,80 @@ function zeroBSCRM_html_addEditSegment( $potentialID = -1 ) {
 				}
 			);
 
-											echo json_encode( $external_source_array );
-
-											// any extra js? e.g. MailPoet Export functionality
-											do_action( 'segment_edit_extra_js' );
-
+			// phpcs:disable WordPress.WP.I18n.TextDomainMismatch -- this is intentionally using the `mailpoet` text domain
+			$jpcrm_mailpoet_status_list = array(
+				array(
+					'key'  => 'subscribed',
+					'name' => __( 'Subscribed', 'mailpoet' ),
+				),
+				array(
+					'key'  => 'unconfirmed',
+					'name' => __( 'Unconfirmed', 'mailpoet' ),
+				),
+				array(
+					'key'  => 'unsubscribed',
+					'name' => __( 'Unsubscribed', 'mailpoet' ),
+				),
+				array(
+					'key'  => 'inactive',
+					'name' => __( 'Inactive', 'mailpoet' ),
+				),
+				array(
+					'key'  => 'bounced',
+					'name' => __( 'Bounced', 'mailpoet' ),
+				),
+			);
+			// phpcs:enable WordPress.WP.I18n.TextDomainMismatch
 			?>
-			;
-			var jpcrm_mailpoet_status_list = 
-			<?php
-				$jpcrm_mailpoet_status_list = array(
-					array(
-						'key'  => 'subscribed',
-						'name' => __( 'Subscribed', 'mailpoet' ),
-					),
-					array(
-						'key'  => 'unconfirmed',
-						'name' => __( 'Unconfirmed', 'mailpoet' ),
-					),
-					array(
-						'key'  => 'unsubscribed',
-						'name' => __( 'Unsubscribed', 'mailpoet' ),
-					),
-					array(
-						'key'  => 'inactive',
-						'name' => __( 'Inactive', 'mailpoet' ),
-					),
-					array(
-						'key'  => 'bounced',
-						'name' => __( 'Bounced', 'mailpoet' ),
-					),
-				);
-				echo json_encode( $jpcrm_mailpoet_status_list );
-				?>
-			</script>
 
-	</div>
+			<script type="text/javascript">
+				var zbsSegment = <?php echo wp_json_encode( $segment, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
+				var jpcrm_available_conditions = <?php echo wp_json_encode( $available_conditions, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
+				var jpcrm_available_conditions_by_category = <?php echo wp_json_encode( $available_conditions_by_category, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
+				var zbsAvailableConditionOperators = <?php echo wp_json_encode( $available_condition_operators, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
+				var jpcrm_available_contact_tags = <?php echo wp_json_encode( $available_tags_contacts, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
+				var jpcrm_available_transaction_tags = <?php echo wp_json_encode( $available_tags_transactions, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
+				var zbsAvailableStatuses = <?php echo wp_json_encode( $availableStatuses, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
+				var zbsSegmentStemURL = '<?php echo jpcrm_esc_link( 'edit', -1, 'segment', true ); ?>';
+				var jpcrm_contact_stem_URL = '<?php echo jpcrm_esc_link( 'view', -1, 'contact', true ); ?>';
+				var zbsSegmentListURL = '<?php echo jpcrm_esc_link( $zbs->slugs['segments'] ); ?>';
+				var zbsSegmentSEC = <?php echo wp_json_encode( wp_create_nonce( 'zbs-ajax-nonce' ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
+				var zbsSegmentLang = {
+					generalerrortitle: '<?php esc_html_e( 'General Error', 'zero-bs-crm' ); ?>',
+					generalerror: '<?php esc_html_e( 'There was a general error.', 'zero-bs-crm' ); ?>',
+
+					currentlyInSegment: '<?php esc_html_e( 'Contacts currently match these conditions.', 'zero-bs-crm' ); ?>',
+					previewTitle: '<?php esc_html_e( 'Contacts Preview (randomised)', 'zero-bs-crm' ); ?>',
+
+					noName: '<?php esc_html_e( 'Unnamed Contact', 'zero-bs-crm' ); ?>',
+					noEmail: '<?php esc_html_e( 'No Email', 'zero-bs-crm' ); ?>',
+
+					notags: '<?php esc_html_e( 'No Tags Found', 'zero-bs-crm' ); ?>',
+					nostatuses: '<?php esc_html_e( 'No Statuses Found', 'zero-bs-crm' ); ?>',
+					noextsources: '<?php esc_html_e( 'No External Sources Found', 'zero-bs-crm' ); ?>',
+					no_mailpoet_statuses: '<?php esc_html_e( 'No MailPoet Statuses Found', 'zero-bs-crm' ); ?>',
+					nosegmentid: '<?php esc_html_e( 'No Segment ID Found.', 'zero-bs-crm' ); ?>',
+
+					to: '<?php esc_html_e( 'to', 'zero-bs-crm' ); ?>',
+					eg: '<?php esc_html_e( 'e.g.', 'zero-bs-crm' ); ?>',
+
+					saveSegment: '<?php echo esc_html( zeroBSCRM_slashOut( 'Save Segment', true ) ) . ' <i class="save icon">'; ?>',
+					savedSegment: '<?php echo esc_html( zeroBSCRM_slashOut( 'Segment Saved', true ) ) . ' <i class="check circle outline icon">'; ?>',
+
+					contactfields: '=== <?php esc_html_e( 'Contact Fields', 'zero-bs-crm' ); ?> ===',
+
+					default_description: '<?php echo esc_html( zeroBSCRM_slashOut( 'Condition which selects contacts based on given value', true ) ); ?>',
+				};
+				var jpcrm_external_source_list = <?php echo wp_json_encode( $external_source_array, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
+
+				<?php
+				// any extra js? e.g. MailPoet Export functionality
+				do_action( 'segment_edit_extra_js' );
+				?>
+
+				var jpcrm_mailpoet_status_list = <?php echo wp_json_encode( $jpcrm_mailpoet_status_list, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>
+			</script>
+			</div>
 	<?php
 }
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.Edit.Segment.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Edit.Segment.php
@@ -239,12 +239,12 @@ function zeroBSCRM_html_addEditSegment( $potentialID = -1 ) {
 					to: '<?php esc_html_e( 'to', 'zero-bs-crm' ); ?>',
 					eg: '<?php esc_html_e( 'e.g.', 'zero-bs-crm' ); ?>',
 
-					saveSegment: '<?php echo esc_html( zeroBSCRM_slashOut( 'Save Segment', true ) ) . ' <i class="save icon">'; ?>',
-					savedSegment: '<?php echo esc_html( zeroBSCRM_slashOut( 'Segment Saved', true ) ) . ' <i class="check circle outline icon">'; ?>',
+					saveSegment: '<?php esc_html_e( 'Save Segment', 'zero-bs-crm' ); ?> <i class="save icon">',
+					savedSegment: '<?php esc_html_e( 'Segment Saved', 'zero-bs-crm' ); ?> <i class="check circle outline icon">',
 
 					contactfields: '=== <?php esc_html_e( 'Contact Fields', 'zero-bs-crm' ); ?> ===',
 
-					default_description: '<?php echo esc_html( zeroBSCRM_slashOut( 'Condition which selects contacts based on given value', true ) ); ?>',
+					default_description: '<?php esc_html_e( 'Condition which selects contacts based on given value', 'zero-bs-crm' ); ?>',
 				};
 				var jpcrm_external_source_list = <?php echo wp_json_encode( $external_source_array, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
@@ -199,7 +199,7 @@ function zeroBSCRM_generateHash( $length = 20 ) {
 function jpcrm_generate_hash_of_obj( $obj ) {
 
 	// note this will return different if sort order different
-	return md5( json_encode( $obj ) );
+	return md5( wp_json_encode( $obj, JSON_UNESCAPED_SLASHES ) );
 }
 
 function zeroBSCRM_loadCountryList() {

--- a/projects/plugins/crm/includes/ZeroBSCRM.InternalAutomator.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.InternalAutomator.php
@@ -50,8 +50,7 @@ function zeroBSCRM_FireInternalAutomator( $actionStr = '', $obj = array() ) {
 	if ( in_array( $actionStr, $zeroBSCRM_IA_Dupeblocks ) ) {
 
 		if ( gettype( $obj ) != 'string' && gettype( $obj ) != 'String' ) {
-			#$objStr = implode('.',$obj);
-			$objStr     = json_encode( $obj );
+			$objStr     = wp_json_encode( $obj, JSON_UNESCAPED_SLASHES );
 			$objStr     = md5( $objStr );
 			$actionHash = $actionStr . $objStr;
 		} else {

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.Tasks.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.Tasks.php
@@ -111,7 +111,8 @@ function zeroBSCRM_render_tasks_calendar_page() { // phpcs:ignore WordPress.Nami
 					'locale'   => $fullcalendar_locale,
 					'events'   => $calendar_events,
 					'firstDay' => (int) get_option( 'start_of_week', 0 ),
-				)
+				),
+				JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 			);
 			?>
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.Views.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.Views.php
@@ -29,7 +29,7 @@ function zeroBSCRM_render_customerslist_page() { // phpcs:ignore WordPress.Namin
 	// extra_js:
 	$status_array = $zbs->settings->get( 'customisedfields' )['customers']['status'];
 	$statuses     = is_array( $status_array ) && isset( $status_array[1] ) ? explode( ',', $status_array[1] ) : array();
-	$extra_js     = 'var zbsStatusesForBulkActions = ' . wp_json_encode( $statuses ) . ';';
+	$extra_js     = 'var zbsStatusesForBulkActions = ' . wp_json_encode( $statuses, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . ';';
 
 	// phpcs:ignore Squiz.PHP.CommentedOutCode.Found
 	// Messages:

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.php
@@ -419,10 +419,12 @@ class zeroBSCRM_list {
 
 			?>
 
-		<?php // phpcs:disable Generic.WhiteSpace.ScopeIndent.IncorrectExact, Generic.Formatting.DisallowMultipleStatements.SameLine, Squiz.PHP.EmbeddedPhp -- mixed PHP/JS context ?>
+		<?php // phpcs:disable Generic.WhiteSpace.ScopeIndent.IncorrectExact, Generic.Formatting.DisallowMultipleStatements.SameLine, Squiz.PHP.EmbeddedPhp -- mixed PHP/JS context
+		global $zeroBSCRM_logTypes;
+		?>
 		<script type="text/javascript">
 			// expose log types (For columns)
-			var zbsLogTypes = <?php global $zeroBSCRM_logTypes; echo json_encode( $zeroBSCRM_logTypes ); ?>;
+			var zbsLogTypes = <?php echo wp_json_encode( $zeroBSCRM_logTypes, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
 
 			<?php
 
@@ -495,10 +497,10 @@ class zeroBSCRM_list {
 			?>
 
 			// General options for listview
-			var zbsListViewSettings = <?php echo wp_json_encode( $list_view_settings ); ?>;
+			var zbsListViewSettings = <?php echo wp_json_encode( $list_view_settings, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
 
 			// Vars for zbs list view drawer
-			var zbsListViewParams = <?php echo wp_json_encode( $list_view_parameters ); ?>;
+			var zbsListViewParams = <?php echo wp_json_encode( $list_view_parameters, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
 
 			var zbsSortables = [
 			<?php
@@ -617,7 +619,7 @@ class zeroBSCRM_list {
 
 			}
 			?>
-			var zbsListViewLangLabels = <?php echo wp_json_encode( $jpcrm_listview_lang_labels ); ?>;
+			var zbsListViewLangLabels = <?php echo wp_json_encode( $jpcrm_listview_lang_labels, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
 			var zbsTagsForBulkActions = 
 			<?php
 				$tags = $zbs->DAL->getTagsForObjType( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
@@ -641,7 +643,7 @@ class zeroBSCRM_list {
 					}
 				}
 
-				$zbs_tags_for_bulk_actions = wp_json_encode( $simple_tags );
+				$zbs_tags_for_bulk_actions = wp_json_encode( $simple_tags, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
 				echo ( $zbs_tags_for_bulk_actions ? $zbs_tags_for_bulk_actions : '[]' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 			?>;
@@ -657,7 +659,7 @@ class zeroBSCRM_list {
 							// phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 							global $zbsCustomerFields;
 							if ( is_array( $zbsCustomerFields['status'][3] ) ) {
-								echo wp_json_encode( $zbsCustomerFields['status'][3] );
+								echo wp_json_encode( $zbsCustomerFields['status'][3], JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
 							} else {
 								echo '[]';
 							}
@@ -671,10 +673,10 @@ class zeroBSCRM_list {
 						// hardcoded customer perms atm
 						$possible_owners = zeroBS_getPossibleOwners( array( 'zerobs_admin', 'zerobs_customermgr' ), true );
 						if ( ! is_array( $possible_owners ) ) {
-							echo wp_json_encode( array() );
-						} else {
-							echo wp_json_encode( $possible_owners );
-						}
+						echo wp_json_encode( array(), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
+					} else {
+						echo wp_json_encode( $possible_owners, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
+					}
 
 					?>
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.Mail.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Mail.php
@@ -1071,7 +1071,7 @@ function zeroBSCRM_mailDelivery_checkSMTPDetails( $sendFromName = '', $sendFromE
 
 						#} add to debug list + log tried
 						$emailDebugs[]        = $emailDebug;
-						$emailSettingsTried[] = json_encode( $smtpSettings );
+						$emailSettingsTried[] = wp_json_encode( $smtpSettings, JSON_UNESCAPED_SLASHES );
 
 						#} Analysis of send
 
@@ -1175,7 +1175,7 @@ function zeroBSCRM_mailDelivery_checkSMTPDetails( $sendFromName = '', $sendFromE
 							}
 
 							#} If not already tried, try that!
-							if ( ! in_array( json_encode( $smtpSettings ), $emailSettingsTried ) ) {
+							if ( ! in_array( wp_json_encode( $smtpSettings, JSON_UNESCAPED_SLASHES ), $emailSettingsTried, true ) ) {
 
 									// Re-test
 									$emailDebug = zeroBSCRM_mailDelivery_sendViaSMTP(
@@ -1203,7 +1203,7 @@ function zeroBSCRM_mailDelivery_checkSMTPDetails( $sendFromName = '', $sendFromE
 
 									#} add to debug list + save tried settings
 									$emailDebugs[]        = $emailDebug;
-									$emailSettingsTried[] = json_encode( $smtpSettings );
+									$emailSettingsTried[] = wp_json_encode( $smtpSettings, JSON_UNESCAPED_SLASHES );
 
 									#} Analysis of send - THIS ISN'T DRY!
 									#success: or error:
@@ -1270,7 +1270,7 @@ function zeroBSCRM_mailDelivery_checkSMTPDetails( $sendFromName = '', $sendFromE
 						}
 
 						#} If not already tried, try that!
-						if ( ! in_array( json_encode( $smtpSettings ), $emailSettingsTried ) ) {
+						if ( ! in_array( wp_json_encode( $smtpSettings, JSON_UNESCAPED_SLASHES ), $emailSettingsTried, true ) ) {
 
 								// Re-test
 								$emailDebug = zeroBSCRM_mailDelivery_sendViaSMTP(
@@ -1298,7 +1298,7 @@ function zeroBSCRM_mailDelivery_checkSMTPDetails( $sendFromName = '', $sendFromE
 
 								#} add to debug list + save tried settings
 								$emailDebugs[]        = $emailDebug;
-								$emailSettingsTried[] = json_encode( $smtpSettings );
+								$emailSettingsTried[] = wp_json_encode( $smtpSettings, JSON_UNESCAPED_SLASHES );
 
 								#} Analysis of send - THIS ISN'T DRY
 								#success: or error:
@@ -1343,7 +1343,7 @@ function zeroBSCRM_mailDelivery_checkSMTPDetails( $sendFromName = '', $sendFromE
 						}
 
 						#} If not already tried, try that!
-						if ( ! in_array( json_encode( $smtpSettings ), $emailSettingsTried ) ) {
+						if ( ! in_array( wp_json_encode( $smtpSettings, JSON_UNESCAPED_SLASHES ), $emailSettingsTried, true ) ) {
 
 								// Re-test
 								$emailDebug = zeroBSCRM_mailDelivery_sendViaSMTP(
@@ -1371,7 +1371,7 @@ function zeroBSCRM_mailDelivery_checkSMTPDetails( $sendFromName = '', $sendFromE
 
 								#} add to debug list + save tried settings
 								$emailDebugs[]        = $emailDebug;
-								$emailSettingsTried[] = json_encode( $smtpSettings );
+								$emailSettingsTried[] = wp_json_encode( $smtpSettings, JSON_UNESCAPED_SLASHES );
 
 								#} Analysis of send - THIS ISN'T DRY
 								#success: or error:

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Logs.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Logs.php
@@ -496,14 +496,15 @@ class zeroBS__Metabox_LogsV2 extends zeroBS__Metabox {
 
 				var zbsLogPerms = 
 				<?php
-				echo json_encode(
+				echo wp_json_encode(
 					array(
 						'addedit' => zeroBSCRM_permsLogsAddEdit(),
 						'delete'  => zeroBSCRM_permsLogsDelete(),
-					)
+					),
+					JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 				);
 				?>
-									;
+;
 
 				var zbsLogAgainstID = <?php echo esc_html( $objid ); ?>; var zbsLogProcessingBlocker = false;
 
@@ -527,7 +528,7 @@ class zeroBS__Metabox_LogsV2 extends zeroBS__Metabox {
 						}
 					}
 				}
-				echo 'var zbsLogsLocked = ' . json_encode( $lockedLogs ) . ';';
+				echo 'var zbsLogsLocked = ' . wp_json_encode( $lockedLogs, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . ';';
 
 				/*
 				var zbsLogsLocked = {
@@ -541,7 +542,7 @@ class zeroBS__Metabox_LogsV2 extends zeroBS__Metabox {
 
 				if ( isset( $zeroBSCRM_logTypes[ $this->postType ] ) && count( $zeroBSCRM_logTypes[ $this->postType ] ) > 0 ) {
 
-					echo 'var zbsLogTypes = ' . json_encode( $zeroBSCRM_logTypes[ $this->postType ] ) . ';';
+					echo 'var zbsLogTypes = ' . wp_json_encode( $zeroBSCRM_logTypes[ $this->postType ], JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . ';';
 
 				}
 				?>
@@ -564,9 +565,9 @@ class zeroBS__Metabox_LogsV2 extends zeroBS__Metabox {
 
 					}
 
-					echo json_encode( $zbsLogsExpose );
+					echo wp_json_encode( $zbsLogsExpose, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
 				} else {
-					echo json_encode( array() );
+					echo wp_json_encode( array(), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
 				}
 				?>
 				;

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.QuoteTemplates.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.QuoteTemplates.php
@@ -88,7 +88,7 @@ class zeroBS__Metabox_QuoteTemplate extends zeroBS__Metabox {
 		// pass specific placeholder list for WYSIWYG inserter
 		$placeholder_templating = $zbs->get_templating();
 		$placeholder_list       = $placeholder_templating->get_placeholders_for_tooling( array( 'quote', 'contact', 'global' ), false, false );
-		echo '<script>var jpcrm_placeholder_list = ' . wp_json_encode( $placeholder_templating->simplify_placeholders_for_wysiwyg( $placeholder_list ) ) . ';</script>';
+		echo '<script>var jpcrm_placeholder_list = ' . wp_json_encode( $placeholder_templating->simplify_placeholders_for_wysiwyg( $placeholder_list ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . ';</script>';
 
 		// for mvp v3.0 we now just hard-type these, as there a lesser obj rarely used.
 		$fields = array(

--- a/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Tags.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.MetaBoxes3.Tags.php
@@ -178,7 +178,7 @@ class zeroBS__Metabox_Tags extends zeroBS__Metabox {
 					</div>
 					<script type="text/javascript">
 
-						var zbsCRMJS_currentTags = <?php echo json_encode( $tags ); ?>;
+						var zbsCRMJS_currentTags = <?php echo wp_json_encode( $tags, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
 
 					</script>
 			<?php

--- a/projects/plugins/crm/includes/ZeroBSCRM.Migrations.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Migrations.php
@@ -1040,7 +1040,7 @@ function zeroBSCRM_migration_560_move_file_array( $meta_row ) { // phpcs:ignore 
 	$update_result = $wpdb->update( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$ZBSCRM_t['meta'], // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 		array(
-			'zbsm_val'         => wp_json_encode( $new_file_array ),
+			'zbsm_val'         => wp_json_encode( $new_file_array, JSON_UNESCAPED_SLASHES ),
 			'zbsm_lastupdated' => time(),
 		),
 		array( 'ID' => $meta_row->ID ),

--- a/projects/plugins/crm/includes/ZeroBSCRM.NotifyMe.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.NotifyMe.php
@@ -470,5 +470,5 @@ function zeroBSCRM_notifyme_get_notifications_ajax() {
 		$res['notifybody']  = 'This is the body';
 		$res['count']       = count( $res['notifications'] );
 	}
-	wp_send_json( $res, null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( $res, 200, JSON_UNESCAPED_SLASHES );
 }

--- a/projects/plugins/crm/includes/ZeroBSCRM.NotifyMe.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.NotifyMe.php
@@ -470,5 +470,5 @@ function zeroBSCRM_notifyme_get_notifications_ajax() {
 		$res['notifybody']  = 'This is the body';
 		$res['count']       = count( $res['notifications'] );
 	}
-	wp_send_json( $res );
+	wp_send_json( $res, null, JSON_UNESCAPED_SLASHES );
 }

--- a/projects/plugins/crm/includes/ZeroBSCRM.PerformanceTesting.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.PerformanceTesting.php
@@ -137,7 +137,7 @@ function zeroBSCRM_performanceTest_debugOut() {
 			echo '<p>' . $sTime . $sTimeExtra . ' seconds</p>';
 			$retArr         = $v;
 			$retArr['took'] = $sTime;
-			$scriptVer     .= 'console.log("' . $k . ': ' . $sTime . $sTimeExtra . '",' . json_encode( $retArr ) . ');';
+			$scriptVer     .= 'console.log("' . $k . ': ' . $sTime . $sTimeExtra . '",' . wp_json_encode( $retArr, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . ');';
 
 	}
 	echo '</div>';

--- a/projects/plugins/crm/includes/ZeroBSCRM.ScreenOptions.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.ScreenOptions.php
@@ -234,7 +234,10 @@ function zeroBS_outputScreenOptions() {
 	$screenOpts = $zbs->global_screen_options(); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 	?>
-	<script type="text/javascript">var zbsPageKey = '<?php echo esc_html( $zbs->pageKey ); ?>';var zbsScreenOptions = <?php echo json_encode( $screenOpts ); ?>;</script>
+	<script type="text/javascript">
+		var zbsPageKey = <?php echo wp_json_encode( $zbs->pageKey, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
+		var zbsScreenOptions = <?php echo wp_json_encode( $screenOpts, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
+	</script>
 	<?php
 }
 

--- a/projects/plugins/crm/includes/ZeroBSCRM.ScriptsStyles.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.ScriptsStyles.php
@@ -659,7 +659,7 @@ function zeroBSCRM_mailTemplatesEnqueue() {
 		'code-editor',
 		sprintf(
 			'jQuery( function() { wp.codeEditor.initialize( "zbstemplatehtml", %s ); } );',
-			wp_json_encode( $settings )
+			wp_json_encode( $settings, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP )
 		)
 	);
 }

--- a/projects/plugins/crm/includes/ZeroBSCRM.TagManager.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.TagManager.php
@@ -287,7 +287,7 @@ class zeroBSCRM_TagManager {
 			var zbsCustomTagInitFunc = 'zbsJS_bindTagManagerInit';
 			var zbsDontDrawTags = true; // don't draw em in edit box
 			// and this OVERRIDES the tag metabox list:
-			var zbsCRMJS_currentTags = <?php echo json_encode( $tags ); ?>;
+			var zbsCRMJS_currentTags = <?php echo wp_json_encode( $tags, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
 
 			jQuery(function($){
 				console.log("======= TAG MANAGER VIEW UI =========");

--- a/projects/plugins/crm/includes/ZeroBSCRM.WYSIWYGButtons.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.WYSIWYGButtons.php
@@ -70,7 +70,8 @@ function zeroBSCRM_exposeFormListJS() {
 		}
 	}
 
-	?><script type="text/javascript">var zbsCRMFormList = <?php echo json_encode( $ret ); ?>;</script>
+	?>
+	<script type="text/javascript">var zbsCRMFormList = <?php echo wp_json_encode( $ret, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;</script>
 	<?php
 }
 

--- a/projects/plugins/crm/includes/jpcrm-usage-tracking.php
+++ b/projects/plugins/crm/includes/jpcrm-usage-tracking.php
@@ -73,7 +73,7 @@ class jpcrm_usage_tracking {
 
 		}
 
-		wp_send_json( $res );
+		wp_send_json( $res, null, JSON_UNESCAPED_SLASHES );
 	}
 
 	/**

--- a/projects/plugins/crm/includes/jpcrm-usage-tracking.php
+++ b/projects/plugins/crm/includes/jpcrm-usage-tracking.php
@@ -73,7 +73,7 @@ class jpcrm_usage_tracking {
 
 		}
 
-		wp_send_json( $res, null, JSON_UNESCAPED_SLASHES );
+		wp_send_json( $res, 200, JSON_UNESCAPED_SLASHES );
 	}
 
 	/**

--- a/projects/plugins/crm/modules/automations/admin/admin-page-init.php
+++ b/projects/plugins/crm/modules/automations/admin/admin-page-init.php
@@ -84,5 +84,5 @@ function render_initial_state() {
 		)
 	);
 
-	return 'var jpcrmAutomationsInitialState=JSON.parse(decodeURIComponent( "' . rawurlencode( wp_json_encode( $initial_state ) ) . '" ) );';
+	return 'var jpcrmAutomationsInitialState=' . wp_json_encode( $initial_state, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . ';';
 }

--- a/projects/plugins/crm/modules/mailpoet/admin/mailpoet-hub/main.page.ajax.php
+++ b/projects/plugins/crm/modules/mailpoet/admin/mailpoet-hub/main.page.ajax.php
@@ -15,7 +15,7 @@ function jpcrm_mailpoet_ajax_import_subscribers() {
 
 	// if something's returned, output via AJAX
 	// (Mostly `background_sync->sync_subscribers()` will do this automatically)
-	wp_send_json( $return, null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( $return, 200, JSON_UNESCAPED_SLASHES );
 }
 
 // import subscribers AJAX

--- a/projects/plugins/crm/modules/mailpoet/admin/mailpoet-hub/main.page.ajax.php
+++ b/projects/plugins/crm/modules/mailpoet/admin/mailpoet-hub/main.page.ajax.php
@@ -15,7 +15,7 @@ function jpcrm_mailpoet_ajax_import_subscribers() {
 
 	// if something's returned, output via AJAX
 	// (Mostly `background_sync->sync_subscribers()` will do this automatically)
-	wp_send_json( $return );
+	wp_send_json( $return, null, JSON_UNESCAPED_SLASHES );
 }
 
 // import subscribers AJAX

--- a/projects/plugins/crm/modules/mailpoet/admin/mailpoet-hub/main.page.php
+++ b/projects/plugins/crm/modules/mailpoet/admin/mailpoet-hub/main.page.php
@@ -238,7 +238,7 @@ function jpcrm_mailpoet_output_language_labels( $additional_labels = array() ) {
 	);
 
 	?>
-	<script>var jpcrm_mailpoet_language_labels = <?php echo json_encode( $language_labels ); ?></script>
+	<script>var jpcrm_mailpoet_language_labels = <?php echo wp_json_encode( $language_labels, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?></script>
 	<?php
 }
 

--- a/projects/plugins/crm/modules/mailpoet/includes/class-mailpoet-background-sync.php
+++ b/projects/plugins/crm/modules/mailpoet/includes/class-mailpoet-background-sync.php
@@ -274,7 +274,7 @@ class Mailpoet_Background_Sync {
 				'total_crm_contacts_from_mailpoet' => $this->mailpoet()->get_crm_mailpoet_contact_count(),
 			);
 			$mailpoet_latest_stats     = $this->mailpoet()->get_jpcrm_mailpoet_latest_stats();
-			wp_send_json( array_merge( $mailpoet_latest_stats, $mailpoetsync_status_array ) );
+			wp_send_json( array_merge( $mailpoet_latest_stats, $mailpoetsync_status_array ), null, JSON_UNESCAPED_SLASHES );
 		}
 	}
 

--- a/projects/plugins/crm/modules/mailpoet/includes/class-mailpoet-background-sync.php
+++ b/projects/plugins/crm/modules/mailpoet/includes/class-mailpoet-background-sync.php
@@ -274,7 +274,7 @@ class Mailpoet_Background_Sync {
 				'total_crm_contacts_from_mailpoet' => $this->mailpoet()->get_crm_mailpoet_contact_count(),
 			);
 			$mailpoet_latest_stats     = $this->mailpoet()->get_jpcrm_mailpoet_latest_stats();
-			wp_send_json( array_merge( $mailpoet_latest_stats, $mailpoetsync_status_array ), null, JSON_UNESCAPED_SLASHES );
+			wp_send_json( array_merge( $mailpoet_latest_stats, $mailpoetsync_status_array ), 200, JSON_UNESCAPED_SLASHES );
 		}
 	}
 

--- a/projects/plugins/crm/modules/mailpoet/includes/class-mailpoet-export-segment-to-mailpoet.php
+++ b/projects/plugins/crm/modules/mailpoet/includes/class-mailpoet-export-segment-to-mailpoet.php
@@ -181,7 +181,9 @@ class Mailpoet_Export_Segment_To_MailPoet {
 											'export_finished_long' => __( 'The export process is now complete. Click the button below to view the list of subscribers.', 'zero-bs-crm' ),
 											'go_to_mailpoet_list' => __( 'Go to MailPoet', 'zero-bs-crm' ),
 										),
-									)
+									),
+									null,
+									JSON_UNESCAPED_SLASHES
 								);
 							}
 						}
@@ -193,7 +195,9 @@ class Mailpoet_Export_Segment_To_MailPoet {
 									'error_title'   => __( 'Something went wrong', 'zero-bs-crm' ),
 									'error_message' => $th->getMessage(),
 								),
-							)
+							),
+							null,
+							JSON_UNESCAPED_SLASHES
 						);
 					}
 				}
@@ -207,7 +211,9 @@ class Mailpoet_Export_Segment_To_MailPoet {
 							'error_title'   => __( 'Something went wrong', 'zero-bs-crm' ),
 							'error_message' => __( 'The segment could not be exported to MailPoet', 'zero-bs-crm' ),
 						),
-					)
+					),
+					null,
+					JSON_UNESCAPED_SLASHES
 				);
 			}
 		);
@@ -256,7 +262,9 @@ class Mailpoet_Export_Segment_To_MailPoet {
 								'segmentID'     => $segment_id,
 								'current_page'  => $page,
 								'is_last_batch' => $is_last_batch,
-							)
+							),
+							null,
+							JSON_UNESCAPED_SLASHES
 						);
 
 					} else {
@@ -270,7 +278,9 @@ class Mailpoet_Export_Segment_To_MailPoet {
 									'error_title'   => __( 'Something went wrong', 'zero-bs-crm' ),
 									'error_message' => __( 'The segment could not be exported to MailPoet', 'zero-bs-crm' ),
 								),
-							)
+							),
+							null,
+							JSON_UNESCAPED_SLASHES
 						);
 
 					}
@@ -285,7 +295,9 @@ class Mailpoet_Export_Segment_To_MailPoet {
 											'error_title' => __( 'Something went wrong', 'zero-bs-crm' ),
 											'error_message' => __( 'The segment could not be exported to MailPoet', 'zero-bs-crm' ),
 										),
-									)
+									),
+									null,
+									JSON_UNESCAPED_SLASHES
 								);
 
 				}
@@ -327,13 +339,13 @@ class Mailpoet_Export_Segment_To_MailPoet {
 
 					if ( ! is_array( $list_details ) ) {
 						// nope
-						wp_send_json( false );
+						wp_send_json( false, null, JSON_UNESCAPED_SLASHES );
 					} else {
 						// success
-						wp_send_json( $list_details );
+						wp_send_json( $list_details, null, JSON_UNESCAPED_SLASHES );
 					}
 				} catch ( \Throwable $th ) {
-					wp_send_json_error( array( 'fail' => 1 ), 500 );
+					wp_send_json_error( array( 'fail' => 1 ), 500, JSON_UNESCAPED_SLASHES );
 				}
 			}
 		);

--- a/projects/plugins/crm/modules/mailpoet/includes/class-mailpoet-export-segment-to-mailpoet.php
+++ b/projects/plugins/crm/modules/mailpoet/includes/class-mailpoet-export-segment-to-mailpoet.php
@@ -182,7 +182,7 @@ class Mailpoet_Export_Segment_To_MailPoet {
 											'go_to_mailpoet_list' => __( 'Go to MailPoet', 'zero-bs-crm' ),
 										),
 									),
-									null,
+									200,
 									JSON_UNESCAPED_SLASHES
 								);
 							}
@@ -196,7 +196,7 @@ class Mailpoet_Export_Segment_To_MailPoet {
 									'error_message' => $th->getMessage(),
 								),
 							),
-							null,
+							200,
 							JSON_UNESCAPED_SLASHES
 						);
 					}
@@ -212,7 +212,7 @@ class Mailpoet_Export_Segment_To_MailPoet {
 							'error_message' => __( 'The segment could not be exported to MailPoet', 'zero-bs-crm' ),
 						),
 					),
-					null,
+					200,
 					JSON_UNESCAPED_SLASHES
 				);
 			}
@@ -263,7 +263,7 @@ class Mailpoet_Export_Segment_To_MailPoet {
 								'current_page'  => $page,
 								'is_last_batch' => $is_last_batch,
 							),
-							null,
+							200,
 							JSON_UNESCAPED_SLASHES
 						);
 
@@ -279,7 +279,7 @@ class Mailpoet_Export_Segment_To_MailPoet {
 									'error_message' => __( 'The segment could not be exported to MailPoet', 'zero-bs-crm' ),
 								),
 							),
-							null,
+							200,
 							JSON_UNESCAPED_SLASHES
 						);
 
@@ -296,7 +296,7 @@ class Mailpoet_Export_Segment_To_MailPoet {
 											'error_message' => __( 'The segment could not be exported to MailPoet', 'zero-bs-crm' ),
 										),
 									),
-									null,
+									200,
 									JSON_UNESCAPED_SLASHES
 								);
 
@@ -339,10 +339,10 @@ class Mailpoet_Export_Segment_To_MailPoet {
 
 					if ( ! is_array( $list_details ) ) {
 						// nope
-						wp_send_json( false, null, JSON_UNESCAPED_SLASHES );
+						wp_send_json( false, 200, JSON_UNESCAPED_SLASHES );
 					} else {
 						// success
-						wp_send_json( $list_details, null, JSON_UNESCAPED_SLASHES );
+						wp_send_json( $list_details, 200, JSON_UNESCAPED_SLASHES );
 					}
 				} catch ( \Throwable $th ) {
 					wp_send_json_error( array( 'fail' => 1 ), 500, JSON_UNESCAPED_SLASHES );

--- a/projects/plugins/crm/modules/woo-sync/admin/settings/connections.page.ajax.php
+++ b/projects/plugins/crm/modules/woo-sync/admin/settings/connections.page.ajax.php
@@ -68,7 +68,7 @@ function jpcrm_woosync_ajax_get_auth_url() {
 
 	// Check perms
 	if ( ! zeroBSCRM_isZBSAdminOrAdmin() ) {
-		wp_send_json_error( array(), 500 );
+		wp_send_json_error( array(), 500, JSON_UNESCAPED_SLASHES );
 	}
 
 	// retrieve params
@@ -83,11 +83,13 @@ function jpcrm_woosync_ajax_get_auth_url() {
 			wp_send_json(
 				array(
 					'target_url' => $zbs->modules->woosync->get_external_woo_url_for_oauth( $site_url ),
-				)
+				),
+				null,
+				JSON_UNESCAPED_SLASHES
 			);
 		}
 	}
 
-	wp_send_json_error( array(), 500 );
+	wp_send_json_error( array(), 500, JSON_UNESCAPED_SLASHES );
 }
 add_action( 'wp_ajax_jpcrm_woosync_get_auth_url', 'jpcrm_woosync_ajax_get_auth_url' );

--- a/projects/plugins/crm/modules/woo-sync/admin/settings/connections.page.ajax.php
+++ b/projects/plugins/crm/modules/woo-sync/admin/settings/connections.page.ajax.php
@@ -84,7 +84,7 @@ function jpcrm_woosync_ajax_get_auth_url() {
 				array(
 					'target_url' => $zbs->modules->woosync->get_external_woo_url_for_oauth( $site_url ),
 				),
-				null,
+				200,
 				JSON_UNESCAPED_SLASHES
 			);
 		}

--- a/projects/plugins/crm/modules/woo-sync/admin/woo-sync-hub/main.page.ajax.php
+++ b/projects/plugins/crm/modules/woo-sync/admin/woo-sync-hub/main.page.ajax.php
@@ -15,7 +15,7 @@ function jpcrm_woosync_ajax_import_orders() {
 
 	// if something's returned, output via AJAX
 	// (Mostly `background_sync->sync_orders()` will do this automatically)
-	wp_send_json( $return );
+	wp_send_json( $return, null, JSON_UNESCAPED_SLASHES );
 }
 
 // import orders AJAX

--- a/projects/plugins/crm/modules/woo-sync/admin/woo-sync-hub/main.page.ajax.php
+++ b/projects/plugins/crm/modules/woo-sync/admin/woo-sync-hub/main.page.ajax.php
@@ -15,7 +15,7 @@ function jpcrm_woosync_ajax_import_orders() {
 
 	// if something's returned, output via AJAX
 	// (Mostly `background_sync->sync_orders()` will do this automatically)
-	wp_send_json( $return, null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( $return, 200, JSON_UNESCAPED_SLASHES );
 }
 
 // import orders AJAX

--- a/projects/plugins/crm/modules/woo-sync/admin/woo-sync-hub/main.page.php
+++ b/projects/plugins/crm/modules/woo-sync/admin/woo-sync-hub/main.page.php
@@ -440,7 +440,7 @@ function jpcrm_woosync_output_language_labels( $additional_labels = array() ) {
 	);
 
 	?>
-	<script>var jpcrm_woosync_language_labels = <?php echo json_encode( $language_labels ); ?></script>
+	<script>var jpcrm_woosync_language_labels = <?php echo wp_json_encode( $language_labels, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?></script>
 	<?php
 }
 

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
@@ -878,14 +878,14 @@ class Woo_Sync_Background_Sync_Job {
 
 				} else {
 
-						$this->debug( 'Company import failed: <code>' . json_encode( $crm_object_data['company'] ) . '</code>' );
+						$this->debug( 'Company import failed: <code>' . wp_json_encode( $crm_object_data['company'], JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . '</code>' );
 
 				}
 			}
 		} else {
 
 			// failed to add contact?
-			$this->debug( 'Contact import failed, or there was no contact to import. Contact Data: <code>' . json_encode( $crm_object_data['contact'] ) . '</code>' );
+			$this->debug( 'Contact import failed, or there was no contact to import. Contact Data: <code>' . wp_json_encode( $crm_object_data['contact'], JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . '</code>' );
 
 		}
 
@@ -926,7 +926,7 @@ class Woo_Sync_Background_Sync_Job {
 
 			} else {
 
-				$this->debug( 'invoice import failed: <code>' . json_encode( $crm_object_data['invoice'] ) . '</code>' );
+				$this->debug( 'invoice import failed: <code>' . wp_json_encode( $crm_object_data['invoice'], JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . '</code>' );
 
 			}
 		}
@@ -973,7 +973,7 @@ class Woo_Sync_Background_Sync_Job {
 			}
 		} else {
 
-			$this->debug( 'Transaction import failed: <code>' . json_encode( $crm_object_data['transaction'] ) . '</code>' );
+			$this->debug( 'Transaction import failed: <code>' . wp_json_encode( $crm_object_data['transaction'], JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . '</code>' );
 
 		}
 

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
@@ -515,7 +515,7 @@ class Woo_Sync_Background_Sync_Job {
 						'orders_imported'      => 0,
 						'percentage_completed' => 0,
 					),
-					null,
+					200,
 					JSON_UNESCAPED_SLASHES
 				);
 			}

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
@@ -880,14 +880,14 @@ class Woo_Sync_Background_Sync_Job {
 
 				} else {
 
-						$this->debug( 'Company import failed: <code>' . wp_json_encode( $crm_object_data['company'], JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . '</code>' );
+						$this->debug( 'Company import failed: <code>' . htmlspecialchars( wp_json_encode( $crm_object_data['company'], JSON_UNESCAPED_SLASHES ) ) . '</code>' );
 
 				}
 			}
 		} else {
 
 			// failed to add contact?
-			$this->debug( 'Contact import failed, or there was no contact to import. Contact Data: <code>' . wp_json_encode( $crm_object_data['contact'], JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . '</code>' );
+			$this->debug( 'Contact import failed, or there was no contact to import. Contact Data: <code>' . htmlspecialchars( wp_json_encode( $crm_object_data['contact'], JSON_UNESCAPED_SLASHES ) ) . '</code>' );
 
 		}
 
@@ -928,7 +928,7 @@ class Woo_Sync_Background_Sync_Job {
 
 			} else {
 
-				$this->debug( 'invoice import failed: <code>' . wp_json_encode( $crm_object_data['invoice'], JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . '</code>' );
+				$this->debug( 'invoice import failed: <code>' . htmlspecialchars( wp_json_encode( $crm_object_data['invoice'], JSON_UNESCAPED_SLASHES ) ) . '</code>' );
 
 			}
 		}
@@ -975,7 +975,7 @@ class Woo_Sync_Background_Sync_Job {
 			}
 		} else {
 
-			$this->debug( 'Transaction import failed: <code>' . wp_json_encode( $crm_object_data['transaction'], JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . '</code>' );
+			$this->debug( 'Transaction import failed: <code>' . htmlspecialchars( wp_json_encode( $crm_object_data['transaction'], JSON_UNESCAPED_SLASHES ) ) . '</code>' );
 
 		}
 

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
@@ -514,7 +514,9 @@ class Woo_Sync_Background_Sync_Job {
 						'page_no'              => $page_no,
 						'orders_imported'      => 0,
 						'percentage_completed' => 0,
-					)
+					),
+					null,
+					JSON_UNESCAPED_SLASHES
 				);
 			}
 

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
@@ -880,14 +880,14 @@ class Woo_Sync_Background_Sync_Job {
 
 				} else {
 
-						$this->debug( 'Company import failed: <code>' . htmlspecialchars( wp_json_encode( $crm_object_data['company'], JSON_UNESCAPED_SLASHES ) ) . '</code>' );
+						$this->debug( 'Company import failed: <code>' . htmlspecialchars( wp_json_encode( $crm_object_data['company'], JSON_UNESCAPED_SLASHES ), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ) . '</code>' );
 
 				}
 			}
 		} else {
 
 			// failed to add contact?
-			$this->debug( 'Contact import failed, or there was no contact to import. Contact Data: <code>' . htmlspecialchars( wp_json_encode( $crm_object_data['contact'], JSON_UNESCAPED_SLASHES ) ) . '</code>' );
+			$this->debug( 'Contact import failed, or there was no contact to import. Contact Data: <code>' . htmlspecialchars( wp_json_encode( $crm_object_data['contact'], JSON_UNESCAPED_SLASHES ), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ) . '</code>' );
 
 		}
 
@@ -928,7 +928,7 @@ class Woo_Sync_Background_Sync_Job {
 
 			} else {
 
-				$this->debug( 'invoice import failed: <code>' . htmlspecialchars( wp_json_encode( $crm_object_data['invoice'], JSON_UNESCAPED_SLASHES ) ) . '</code>' );
+				$this->debug( 'invoice import failed: <code>' . htmlspecialchars( wp_json_encode( $crm_object_data['invoice'], JSON_UNESCAPED_SLASHES ), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ) . '</code>' );
 
 			}
 		}
@@ -975,7 +975,7 @@ class Woo_Sync_Background_Sync_Job {
 			}
 		} else {
 
-			$this->debug( 'Transaction import failed: <code>' . htmlspecialchars( wp_json_encode( $crm_object_data['transaction'], JSON_UNESCAPED_SLASHES ) ) . '</code>' );
+			$this->debug( 'Transaction import failed: <code>' . htmlspecialchars( wp_json_encode( $crm_object_data['transaction'], JSON_UNESCAPED_SLASHES ), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ) . '</code>' );
 
 		}
 

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync.php
@@ -396,7 +396,7 @@ class Woo_Sync_Background_Sync {
 				'percentage_completed' => $overall_percentage,
 			);
 			$woosync_latest_stats = $this->woosync()->get_jpcrm_woo_latest_stats();
-			wp_send_json( array_merge( $woosync_latest_stats, $woosync_status_array ), null, JSON_UNESCAPED_SLASHES );
+			wp_send_json( array_merge( $woosync_latest_stats, $woosync_status_array ), 200, JSON_UNESCAPED_SLASHES );
 
 		}
 	}

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync.php
@@ -396,7 +396,7 @@ class Woo_Sync_Background_Sync {
 				'percentage_completed' => $overall_percentage,
 			);
 			$woosync_latest_stats = $this->woosync()->get_jpcrm_woo_latest_stats();
-			wp_send_json( array_merge( $woosync_latest_stats, $woosync_status_array ) );
+			wp_send_json( array_merge( $woosync_latest_stats, $woosync_status_array ), null, JSON_UNESCAPED_SLASHES );
 
 		}
 	}

--- a/projects/plugins/crm/src/automation/workflow/class-workflow-repository.php
+++ b/projects/plugins/crm/src/automation/workflow/class-workflow-repository.php
@@ -180,8 +180,8 @@ class Workflow_Repository {
 	protected function prepare_data_to_persist( Automation_Workflow $workflow ): array {
 		$data = $workflow->to_array();
 
-		$data['triggers'] = wp_json_encode( $data['triggers'] );
-		$data['steps']    = wp_json_encode( $data['steps'] );
+		$data['triggers'] = wp_json_encode( $data['triggers'], JSON_UNESCAPED_SLASHES );
+		$data['steps']    = wp_json_encode( $data['steps'], JSON_UNESCAPED_SLASHES );
 
 		return $data;
 	}


### PR DESCRIPTION
Closes MONOREP-264. Supersedes #46111.

## Proposed changes
<!--- Explain what functional changes your PR includes -->
This adds appropriate flags to `wp_json_encode()` and like functions in Jetpack CRM.

Phan doesn't like `null` as a status code for the `wp_json_send()` variants, so I've set most to 200 (the default that PHP would send). Any clearly perm-related ones I changed to 403. I believe in most if not all cases, the status code isn't even looked at, but I hesitate to change much more without deeper testing.

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* See MONOREP-129
* p1763997995289799-slack-C05Q5HSS013


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Check the code.