### PR TITLE
Charts: Fix broken story references in Storybook docs

### DIFF
--- a/projects/js-packages/charts/changelog/charts-189-fix-broken-story-references-in-storybook-docs
+++ b/projects/js-packages/charts/changelog/charts-189-fix-broken-story-references-in-storybook-docs
@@ -1,4 +1,4 @@
 Significance: patch
-Type: fixed
+Type: changed
 
-Charts: Fix broken story references in Storybook docs.
+Charts: Fix broken story references and simplify legend sections in Storybook docs.

--- a/projects/js-packages/charts/changelog/charts-189-fix-broken-story-references-in-storybook-docs
+++ b/projects/js-packages/charts/changelog/charts-189-fix-broken-story-references-in-storybook-docs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Charts: Fix broken story references in Storybook docs.

--- a/projects/js-packages/charts/docs/ai-documentation-guide.md
+++ b/projects/js-packages/charts/docs/ai-documentation-guide.md
@@ -166,12 +166,9 @@ See the `feature-documentation.mdx.template` for the complete section structure.
 
 Only include this section if the chart supports legends. Remove this section entirely if the chart has no legend capabilities.
 
-Document legend features including:
+Show a single basic example using the composition API (`<[Component].Legend />`), then link to the Legend component docs for full configuration (positioning, orientation, shapes, interactivity, etc.). Do not duplicate legend configuration details in each chart's docs — the Legend component docs are the single source of truth.
 
-- **Basic Legend**: How to enable with `showLegend`, orientation, alignment, and position props
-- **Custom Legend Shapes**: Shape options and custom glyphs if supported
-- **Composition API**: Using `<[Component].Legend />` as a child component for flexible positioning, if supported
-- **Interactive Legends**: Toggling series visibility with `legendInteractive`, requirements (`GlobalChartsProvider`, `chartId`), keyboard support, and visual feedback
+If the chart has a chart-specific legend prop not covered by the Legend component (e.g. `legendLabels` on LeaderboardChart), include a brief example for that prop.
 
 See the `feature-documentation.mdx.template` for the complete section structure.
 

--- a/projects/js-packages/charts/docs/feature-documentation.mdx.template
+++ b/projects/js-packages/charts/docs/feature-documentation.mdx.template
@@ -128,38 +128,18 @@ Charts are fully keyboard accessible:
 
 [Only include this section if the chart supports legends. Remove this section entirely if the chart has no legend capabilities.]
 
-### Basic Legend
+[Brief description of the legend for this chart type]:
 
-[Description of how to display a legend with automatic color matching]:
-
-<Source
-	language="tsx"
-	code={ `<[Component]
-		data={ data }
-		showLegend={ true }
-		legendOrientation="horizontal"
-		legendAlignment="center"
-		legendPosition="bottom"
-	/>` }
-/>
-
-### Interactive Legends
-
-[If supported, show how to enable interactive legends that toggle series visibility]:
+<Canvas of={ [FeatureName]Stories.WithCompositionLegend } />
 
 <Source
 	language="tsx"
-	code={ `import { GlobalChartsProvider, [Component] } from '@automattic/charts';
-
-	<GlobalChartsProvider>
-		<[Component]
-			data={ data }
-			chartId="[unique-chart-id]"
-			showLegend={ true }
-			legendInteractive={ true }
-		/>
-	</GlobalChartsProvider>` }
+	code={ `<[Component] data={ data }>
+		<[Component].Legend />
+	</[Component]>` }
 />
+
+For full legend configuration options — positioning, orientation, shapes, interactivity, and the composition API — see the [Legend component docs](./?path=/docs/js-packages-charts-library-components-legend--docs).
 
 ## Styling and Customization
 

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
@@ -299,108 +299,18 @@ Charts are fully keyboard accessible:
 
 ## Legends
 
-### Basic Legend
-
-Display series information with automatic color and pattern matching:
-
-<Canvas of={ BarChartStories.WithLegend } />
-
-<Source
-	language="jsx"
-	code={ `<BarChart
-		data={data}
-		showLegend={true}
-	/>` }
-/>
-
-### Vertical Legend
-
-Display legends vertically for charts with many series:
-
-<Source
-	language="jsx"
-	code={ `<BarChart
-		data={data}
-		showLegend={true}
-		legend={{
-			orientation: 'vertical',
-		}}
-	/>` }
-/>
-
-### Composition API
-
-For more flexible legend positioning and future extensibility, use the composition API with `<BarChart.Legend />` as a child component:
+Use the composition API to add a legend by placing `<BarChart.Legend />` as a child:
 
 <Canvas of={ BarChartStories.WithCompositionLegend } />
 
 <Source
 	language="jsx"
-	code={ `<BarChart
-		data={data}
-		withTooltips={true}
-		gridVisibility="x"
-		showLegend={false}
-	>
+	code={ `<BarChart data={data}>
 		<BarChart.Legend />
 	</BarChart>` }
 />
 
-**Benefits of the composition API:**
-- **Flexible positioning**: Place legends anywhere within the chart container
-- **Future extensibility**: Enables additional chart components like annotations
-- **Consistent API**: Same pattern as LineChart for a unified developer experience
-- **Backward compatibility**: Existing `showLegend` prop continues to work
-
-**Usage patterns:**
-
-<Source
-	language="jsx"
-	code={ `// Composition API (recommended for new code)
-	<BarChart data={data}>
-		<BarChart.Legend orientation="vertical" alignment="end" />
-	</BarChart>
-
-	// Traditional prop-based approach (still supported)
-	<BarChart
-		data={data}
-		showLegend={true}
-		legend={{
-			orientation: 'vertical',
-			alignment: 'end',
-		}}
-	/>` }
-/>
-
-### Interactive Legend
-
-Enable interactive legend items that users can click to toggle series visibility. This feature requires a `chartId` and wrapping your chart in a `GlobalChartsProvider`:
-
-<Source
-	language="jsx"
-	code={ `import { BarChart, GlobalChartsProvider } from '@automattic/charts';
-
-	<GlobalChartsProvider>
-		<BarChart
-			data={data}
-			chartId="my-chart"
-			showLegend={true}
-			legend={{ interactive: true }}
-		/>
-	</GlobalChartsProvider>` }
-/>
-
-**Interactive legend features:**
-- **Click to toggle**: Click legend items to show/hide series
-- **Visual feedback**: Legend items visually indicate their active/inactive state
-- **Accessibility**: Full keyboard support with proper ARIA attributes
-- **Empty state**: When all series are hidden, a message prompts users to re-enable series
-- **State management**: Visibility state is managed through the global charts provider
-
-**Requirements:**
-- Set `legend={{ interactive: true }}` to enable the feature
-- Provide a unique `chartId` prop for state tracking
-- Wrap the chart in a `<GlobalChartsProvider>` component
+For full legend configuration options — positioning, orientation, shapes, interactivity, and the composition API — see the [Legend component docs](./?path=/docs/js-packages-charts-library-components-legend--docs).
 
 ## Theming Integration
 

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
@@ -310,20 +310,12 @@ Display series information with automatic color and pattern matching:
 	code={ `<BarChart
 		data={data}
 		showLegend={true}
-		legend={{
-			orientation: 'horizontal',
-			alignment: 'center',
-			position: 'bottom',
-			shape: 'rect',
-		}}
 	/>` }
 />
 
 ### Vertical Legend
 
 Display legends vertically for charts with many series:
-
-<Canvas of={ BarChartStories.WithLegend } />
 
 <Source
 	language="jsx"
@@ -332,8 +324,6 @@ Display legends vertically for charts with many series:
 		showLegend={true}
 		legend={{
 			orientation: 'vertical',
-			alignment: 'start',
-			position: 'top',
 		}}
 	/>` }
 />
@@ -350,12 +340,9 @@ For more flexible legend positioning and future extensibility, use the compositi
 		data={data}
 		withTooltips={true}
 		gridVisibility="x"
+		showLegend={false}
 	>
-		<BarChart.Legend
-			orientation="horizontal"
-			alignment="center"
-			position="bottom"
-		/>
+		<BarChart.Legend />
 	</BarChart>` }
 />
 
@@ -388,8 +375,6 @@ For more flexible legend positioning and future extensibility, use the compositi
 ### Interactive Legend
 
 Enable interactive legend items that users can click to toggle series visibility. This feature requires a `chartId` and wrapping your chart in a `GlobalChartsProvider`:
-
-<Canvas of={ BarChartStories.WithLegend } />
 
 <Source
 	language="jsx"

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
@@ -303,7 +303,7 @@ Charts are fully keyboard accessible:
 
 Display series information with automatic color and pattern matching:
 
-<Canvas of={ BarChartStories.WithInteractiveLegend } />
+<Canvas of={ BarChartStories.WithLegend } />
 
 <Source
 	language="jsx"
@@ -323,7 +323,7 @@ Display series information with automatic color and pattern matching:
 
 Display legends vertically for charts with many series:
 
-<Canvas of={ BarChartStories.CustomLegendPositioning } />
+<Canvas of={ BarChartStories.WithLegend } />
 
 <Source
 	language="jsx"
@@ -389,7 +389,7 @@ For more flexible legend positioning and future extensibility, use the compositi
 
 Enable interactive legend items that users can click to toggle series visibility. This feature requires a `chartId` and wrapping your chart in a `GlobalChartsProvider`:
 
-<Canvas of={ BarChartStories.WithInteractiveLegend } />
+<Canvas of={ BarChartStories.WithLegend } />
 
 <Source
 	language="jsx"

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.docs.mdx
@@ -335,7 +335,7 @@ Display a legend to help users understand the data visualization:
 
 Customize legend labels with specific date ranges or descriptive text:
 
-<Canvas of={ LeaderboardChartStories.CustomLegendLabels } />
+<Canvas of={ LeaderboardChartStories.WithCompositionLegend } />
 
 <Source
 	language="tsx"
@@ -360,7 +360,7 @@ Use the composition API for explicit legend placement:
 
 Enable interactive legend items to toggle visibility of current and comparison series:
 
-<Canvas of={ LeaderboardChartStories.InteractiveLegend } />
+<Canvas of={ LeaderboardChartStories.WithLegend } />
 
 **Legend Configuration Options:**
 - Control legend positioning, alignment, and visual appearance

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.docs.mdx
@@ -316,24 +316,18 @@ Calculate the `currentShare` and `previousShare` values to determine bar widths:
 
 ## Legends
 
-### Basic Legend
+Use the composition API to add a legend by placing `<LeaderboardChart.Legend />` as a child:
 
-Display a legend to help users understand the data visualization:
-
-<Canvas of={ LeaderboardChartStories.WithLegend } />
+<Canvas of={ LeaderboardChartStories.WithCompositionLegend } />
 
 <Source
 	language="tsx"
-	code={ `<LeaderboardChart
-		data={data}
-		withComparison={true}
-		showLegend={true}
-	/>` }
+	code={ `<LeaderboardChart data={data} withComparison={true}>
+		<LeaderboardChart.Legend />
+	</LeaderboardChart>` }
 />
 
-### Custom Legend Labels
-
-Customize legend labels with specific date ranges or descriptive text:
+Use `legendLabels` to show descriptive labels (e.g. date ranges) for the primary and comparison series:
 
 <Canvas of={ LeaderboardChartStories.WithLegendLabels } />
 
@@ -344,50 +338,13 @@ Customize legend labels with specific date ranges or descriptive text:
 		withComparison={true}
 		showLegend={true}
 		legendLabels={{
-			primary: 'Aug 11-Sep 9, 2025',
-			comparison: 'Jul 11-Aug 11, 2025',
+			primary: 'Aug 11–Sep 9, 2025',
+			comparison: 'Jul 11–Aug 11, 2025',
 		}}
 	/>` }
 />
 
-### Composition API Legend
-
-Use the composition API for explicit legend placement:
-
-<Source
-	language="tsx"
-	code={ `<LeaderboardChart
-		data={data}
-		withComparison={true}
-		showLegend={false}
-	>
-		<LeaderboardChart.Legend />
-	>` }
-/>
-
-### Interactive Legends
-
-Enable interactive legend items to toggle visibility of current and comparison series:
-
-<Source
-	language="tsx"
-	code={ `<LeaderboardChart
-		data={data}
-		withComparison={true}
-		showLegend={true}
-		legend={{
-			interactive: true,
-		}}
-	/>` }
-/>
-
-**Legend Configuration Options:**
-- Control legend positioning, alignment, and visual appearance
-- Customize legend shapes and sizes
-- Add custom labels for different time periods or data series
-- Control legend/content spacing with the chart-level `gap` prop
-
-See the [API Reference](./?path=/docs/js-packages-charts-library-charts-leaderboard-chart-api-reference--docs) for detailed prop information.
+For full legend configuration options — positioning, orientation, shapes, interactivity, and the composition API — see the [Legend component docs](./?path=/docs/js-packages-charts-library-components-legend--docs).
 
 ## Styling and Customization
 

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.docs.mdx
@@ -335,7 +335,7 @@ Display a legend to help users understand the data visualization:
 
 Customize legend labels with specific date ranges or descriptive text:
 
-<Canvas of={ LeaderboardChartStories.WithCompositionLegend } />
+<Canvas of={ LeaderboardChartStories.WithLegendLabels } />
 
 <Source
 	language="tsx"
@@ -354,13 +354,32 @@ Customize legend labels with specific date ranges or descriptive text:
 
 Use the composition API for explicit legend placement:
 
-<Canvas of={ LeaderboardChartStories.WithCompositionLegend } />
+<Source
+	language="tsx"
+	code={ `<LeaderboardChart
+		data={data}
+		withComparison={true}
+		showLegend={false}
+	>
+		<LeaderboardChart.Legend />
+	>` }
+/>
 
 ### Interactive Legends
 
 Enable interactive legend items to toggle visibility of current and comparison series:
 
-<Canvas of={ LeaderboardChartStories.WithLegend } />
+<Source
+	language="tsx"
+	code={ `<LeaderboardChart
+		data={data}
+		withComparison={true}
+		showLegend={true}
+		legend={{
+			interactive: true,
+		}}
+	/>` }
+/>
 
 **Legend Configuration Options:**
 - Control legend positioning, alignment, and visual appearance

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.docs.mdx
@@ -338,8 +338,8 @@ Use `legendLabels` to show descriptive labels (e.g. date ranges) for the primary
 		withComparison={true}
 		showLegend={true}
 		legendLabels={{
-			primary: 'Aug 11–Sep 9, 2025',
-			comparison: 'Jul 11–Aug 11, 2025',
+			primary: 'Aug 11-Sep 9, 2025',
+			comparison: 'Jul 11-Aug 11, 2025',
 		}}
 	/>` }
 />

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.stories.tsx
@@ -409,7 +409,7 @@ export const WithLegendLabels: Story = {
 		docs: {
 			description: {
 				story:
-					'Props-based legend using `showLegend` and the `legend` config object. Use Storybook controls to adjust legend position, alignment, orientation, shape, and interactivity.',
+					'Props-based legend using `showLegend`, the `legend` config object, and the `legendLabels` prop to customize primary and comparison labels. Other legend options (position, alignment, orientation, shape, interactivity) can be adjusted via Storybook controls.',
 			},
 		},
 	},

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.stories.tsx
@@ -394,6 +394,27 @@ export const WithLegend: Story = {
 	},
 };
 
+export const WithLegendLabels: Story = {
+	args: {
+		data: sampleData,
+		withComparison: true,
+		loading: false,
+		showLegend: true,
+		legendLabels: {
+			primary: 'Aug 11-Sep 9, 2025',
+			comparison: 'Jul 11-Aug 11, 2025',
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Props-based legend using `showLegend` and the `legend` config object. Use Storybook controls to adjust legend position, alignment, orientation, shape, and interactivity.',
+			},
+		},
+	},
+};
+
 export const WithCompositionLegend: Story = {
 	render: args => {
 		const legend = extractLegendConfig( args );
@@ -414,10 +435,6 @@ export const WithCompositionLegend: Story = {
 		data: sampleData,
 		withComparison: true,
 		loading: false,
-		legendLabels: {
-			primary: 'Aug 11-Sep 9, 2025',
-			comparison: 'Jul 11-Aug 11, 2025',
-		},
 	},
 	parameters: {
 		docs: {

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
@@ -512,7 +512,7 @@ Charts are fully keyboard accessible with Tab navigation and arrow key data poin
 
 Display series information with automatic color matching:
 
-<Canvas of={ LineChartStories.CustomLegendPositioning } />
+<Canvas of={ LineChartStories.WithLegend } />
 
 <Source
 	language="jsx"

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
@@ -519,11 +519,6 @@ Display series information with automatic color matching:
 	code={ `<LineChart
 		data={data}
 		showLegend={true}
-		legend={{
-			orientation: 'horizontal',
-			alignment: 'center',
-			position: 'bottom',
-		}}
 	/>` }
 />
 
@@ -536,31 +531,22 @@ Use different shapes and custom glyphs in legends:
 	code={ `<LineChart
 		data={data}
 		showLegend={true}
-		legend={{
-			alignment: 'end',
-			position: 'top',
-			shape: 'circle',
-		}}
 		withLegendGlyph={true}
 	/>` }
 />
 
 ### Interactive Legends
 
-Enable interactive legends that allow users to toggle series visibility by clicking or using keyboard navigation. This feature requires wrapping your chart in `GlobalChartsProvider` and providing a unique `chartId`:
+Enable interactive legends that allow users to toggle series visibility by clicking or using keyboard navigation:
 
 <Source
 	language="jsx"
-	code={ `import { GlobalChartsProvider, LineChart } from '@automattic/charts';
-
-	<GlobalChartsProvider>
-		<LineChart
-			data={data}
-			chartId="sales-chart"
-			showLegend={true}
-			legend={{ interactive: true }}
-		/>
-	</GlobalChartsProvider>` }
+	code={ `<LineChart
+	data={data}
+	chartId="sales-chart"
+	showLegend={true}
+	legend={{ interactive: true }}
+/>` }
 />
 
 **Interactive Legend Features:**
@@ -571,11 +557,8 @@ Enable interactive legends that allow users to toggle series visibility by click
 - **Color Stability**: Series colors remain consistent when toggling visibility
 
 **Requirements:**
-- Must be wrapped in `GlobalChartsProvider`
-- Must provide a unique `chartId` prop
+- Provide a unique `chartId` prop
 - Set `legend={{ interactive: true }}` and `showLegend={true}`
-
-**Note:** Interactive legends are currently supported for both LineChart and BarChart. Support for additional chart types will be added in future releases.
 
 ## Theming Integration
 

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
@@ -508,70 +508,18 @@ Charts are fully keyboard accessible with Tab navigation and arrow key data poin
 
 ## Legends
 
-### Basic Legend
+Use the composition API to add a legend by placing `<LineChart.Legend />` as a child:
 
-Display series information with automatic color matching:
-
-<Canvas of={ LineChartStories.WithLegend } />
+<Canvas of={ LineChartStories.WithCompositionLegend } />
 
 <Source
 	language="jsx"
-	code={ `<LineChart
-		data={data}
-		showLegend={true}
-	/>` }
+	code={ `<LineChart data={data}>
+		<LineChart.Legend />
+	</LineChart>` }
 />
 
-### Legend Shape
-
-Control the shape of the legend glyph using the `legend.shape` prop. Available values are `'line'` (default), `'rect'`, and `'circle'`:
-
-<Source
-	language="jsx"
-	code={ `<LineChart
-		data={data}
-		showLegend={true}
-		legend={{ shape: 'circle' }}
-	/>` }
-/>
-
-### Legend Glyphs
-
-Show a data-point glyph on the legend line marker using `withLegendGlyph`:
-
-<Source
-	language="jsx"
-	code={ `<LineChart
-		data={data}
-		showLegend={true}
-		withLegendGlyph={true}
-	/>` }
-/>
-
-### Interactive Legends
-
-Enable interactive legends that allow users to toggle series visibility by clicking or using keyboard navigation:
-
-<Source
-	language="jsx"
-	code={ `<LineChart
-		data={data}
-		chartId="sales-chart"
-		showLegend={true}
-		legend={{ interactive: true }}
-	/>` }
-/>
-
-**Interactive Legend Features:**
-- **Click or Tap**: Toggle series visibility by clicking on legend items
-- **Keyboard Navigation**: Use Tab to focus legend items, then Enter or Space to toggle
-- **Accessibility**: Full ARIA support with screen reader announcements
-- **Visual Feedback**: Hidden series appear with reduced opacity and strikethrough text
-- **Color Stability**: Series colors remain consistent when toggling visibility
-
-**Requirements:**
-- Provide a unique `chartId` prop
-- Set `legend={{ interactive: true }}` and `showLegend={true}`
+For full legend configuration options — positioning, orientation, shapes, interactivity, and the composition API — see the [Legend component docs](./?path=/docs/js-packages-charts-library-components-legend--docs).
 
 ## Theming Integration
 

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
@@ -522,9 +522,22 @@ Display series information with automatic color matching:
 	/>` }
 />
 
-### Custom Legend Shapes
+### Legend Shape
 
-Use different shapes and custom glyphs in legends:
+Control the shape of the legend glyph using the `legend.shape` prop. Available values are `'line'` (default), `'rect'`, and `'circle'`:
+
+<Source
+	language="jsx"
+	code={ `<LineChart
+		data={data}
+		showLegend={true}
+		legend={{ shape: 'circle' }}
+	/>` }
+/>
+
+### Legend Glyphs
+
+Show a data-point glyph on the legend line marker using `withLegendGlyph`:
 
 <Source
 	language="jsx"
@@ -542,11 +555,11 @@ Enable interactive legends that allow users to toggle series visibility by click
 <Source
 	language="jsx"
 	code={ `<LineChart
-	data={data}
-	chartId="sales-chart"
-	showLegend={true}
-	legend={{ interactive: true }}
-/>` }
+		data={data}
+		chartId="sales-chart"
+		showLegend={true}
+		legend={{ interactive: true }}
+	/>` }
 />
 
 **Interactive Legend Features:**

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/donut.docs.mdx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/donut.docs.mdx
@@ -179,7 +179,21 @@ Use the composition API to add a legend by placing `<PieChart.Legend />` as a ch
 
 <Source
 	language="jsx"
-	code={ `<PieChart data={ data } thickness={ 0.5 }>
+	code={ `<PieChart
+		data={ data }
+		thickness={ 0.5 }
+		gapScale={ 0.03 }
+		cornerScale={ 0.03 }
+		withTooltips={ true }
+	>
+		<Group>
+			<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 24 } y={ -16 }>
+				User Activity
+			</Text>
+			<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 18 } y={ 16 }>
+				Total: 100K Users
+			</Text>
+		</Group>
 		<PieChart.Legend />
 	</PieChart>` }
 />

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/donut.docs.mdx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/donut.docs.mdx
@@ -173,32 +173,18 @@ Tooltips work seamlessly with donut charts:
 
 ## Legends
 
-### Donut with Legend
+Use the composition API to add a legend by placing `<PieChart.Legend />` as a child:
 
-Combine legends with donut charts for comprehensive data presentation:
-
-<Canvas of={ DonutStories.WithLegend } />
+<Canvas of={ DonutStories.WithCompositionLegend } />
 
 <Source
 	language="jsx"
-	code={ `<PieChart
-		thickness={ 0.5 }
-		gapScale={ 0.03 }
-		cornerScale={ 0.03 }
-		withTooltips={ true }
-		showLegend={ true }
-		data={ data }
-	>
-		<Group>
-			<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 24 } y={ -16 }>
-				User Activity
-			</Text>
-			<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 18 } y={ 16 }>
-				Total: 100K Users
-			</Text>
-		</Group>
+	code={ `<PieChart data={ data } thickness={ 0.5 }>
+		<PieChart.Legend />
 	</PieChart>` }
 />
+
+For full legend configuration options — positioning, orientation, shapes, interactivity, and the composition API — see the [Legend component docs](./?path=/docs/js-packages-charts-library-components-legend--docs).
 
 ### Data Validation and Error Handling
 

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/donut.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/donut.stories.tsx
@@ -232,26 +232,17 @@ export const WithCompositionLegend: Story = {
 		return (
 			<PieChart
 				{ ...args }
-				size={ 300 }
-				thickness={ 0.5 }
 				legend={ { interactive: legend?.interactive } }
 				chartId="composition-donut-chart"
 			>
-				<Group>
-					<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 16 } y={ -8 }>
-						User Stats
-					</Text>
-					<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 14 } y={ 12 } fill="#666">
-						100K Total
-					</Text>
-				</Group>
+				{ args.children }
 				<PieChart.Legend { ...legend } />
 			</PieChart>
 		);
 	},
 	args: {
-		data,
-		thickness: 0.5,
+		...Default.args,
+		containerHeight: '500px',
 	},
 	parameters: {
 		docs: {

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/index.docs.mdx
@@ -142,42 +142,18 @@ The chart validates:
 
 ## Legends
 
-### Legend Positioning
+Use the composition API to add a legend by placing `<PieChart.Legend />` as a child:
 
-Control legend alignment and positioning:
-
-<Canvas of={ PieChartStories.WithLegend } />
+<Canvas of={ PieChartStories.WithCompositionLegend } />
 
 <Source
 	language="jsx"
-	code={ `<PieChart
-		size={ 400 }
-		data={ data }
-		showLegend={ true }
-		legend={{
-			alignment: 'end',
-			position: 'top',
-		}}
-	/>` }
+	code={ `<PieChart size={ 400 } data={ data }>
+		<PieChart.Legend />
+	</PieChart>` }
 />
 
-### Vertical Legend
-
-Use vertical orientation for space-efficient legend placement:
-
-<Source
-	language="jsx"
-	code={ `<PieChart
-		size={ 400 }
-		data={ data }
-		showLegend={ true }
-		legend={{
-			orientation: 'vertical',
-			alignment: 'end',
-			position: 'top',
-		}}
-	/>` }
-/>
+For full legend configuration options — positioning, orientation, shapes, interactivity, and the composition API — see the [Legend component docs](./?path=/docs/js-packages-charts-library-components-legend--docs).
 
 ## Styling and Customization
 

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/index.docs.mdx
@@ -146,7 +146,7 @@ The chart validates:
 
 Control legend alignment and positioning:
 
-<Canvas of={ PieChartStories.CustomLegendPositioning } />
+<Canvas of={ PieChartStories.WithLegend } />
 
 <Source
 	language="jsx"

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/index.docs.mdx
@@ -172,47 +172,20 @@ The chart gracefully handles single data points, rendering a complete semi-circl
 	/>` }
 />
 
-## Legend Integration
+## Legends
 
-### Legend Positioning
+Use the composition API to add a legend by placing `<PieSemiCircleChart.Legend />` as a child:
 
-Control legend placement using alignment properties:
-
-<Source
-	language="jsx"
-	code={ `// Legend at top-right
-	<PieSemiCircleChart
-		data={ data }
-		showLegend={ true }
-		legend={{
-			alignment: 'end',
-			position: 'top',
-		}}
-	/>
-
-	// Vertical legend on the right
-	<PieSemiCircleChart
-		data={ data }
-		showLegend={ true }
-		legend={{
-			orientation: 'vertical',
-			alignment: 'end',
-		}}
-	/>` }
-/>
-
-### Legend Shape Options
-
-Customize legend indicators with different shapes:
+<Canvas of={ PieSemiCircleChartStories.WithCompositionLegend } />
 
 <Source
 	language="jsx"
-	code={ `<PieSemiCircleChart
-	data={ data }
-	showLegend={ true }
-	legend={{ shape: 'rect' }} // Options: 'rect', 'circle', 'line'
-/>` }
+	code={ `<PieSemiCircleChart data={ data }>
+		<PieSemiCircleChart.Legend />
+	</PieSemiCircleChart>` }
 />
+
+For full legend configuration options — positioning, orientation, shapes, interactivity, and the composition API — see the [Legend component docs](./?path=/docs/js-packages-charts-library-components-legend--docs).
 
 ## Styling and Customization
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHARTS-189

## Proposed changes

* Fix 7 broken CSF story export references in `.docs.mdx` Canvas blocks across 4 chart docs files (bar, line, pie, leaderboard)
* Simplify legend sections in all 5 chart docs (bar, line, pie, pie-semi-circle, leaderboard) to a single composition API example + link to the Legend component docs — eliminates duplicated configuration details that drifted out of sync
* Add a dedicated `WithLegendLabels` story for the leaderboard chart to properly demonstrate the `legendLabels` prop
* Update the AI documentation guide and feature template to match the new pattern: basic composition API example + link, no duplication

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links

* https://linear.app/a8c/issue/CHARTS-189/fix-broken-story-references-in-storybook-docs

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run Storybook locally: `pnpm --filter @automattic/charts run storybook`
* Navigate to each chart's docs page and verify all Canvas blocks render without errors:
  * **Bar Chart** → Legends section shows the `WithCompositionLegend` story
  * **Line Chart** → Legends section shows the `WithCompositionLegend` story
  * **Pie Chart** → Legends section shows the `WithCompositionLegend` story
  * **Pie Semi Circle Chart** → Legends section shows the `WithCompositionLegend` story
  * **Leaderboard Chart** → Legends section shows `WithCompositionLegend` and `WithLegendLabels` stories
* Verify each legend section links to the Legend component docs page
* Open the browser console on each docs page and confirm no Storybook errors about missing story exports

