### PR TITLE
Fix translations for the Name profile section title

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-profile-name-setting-translation
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-profile-name-setting-translation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Translate the title of the Name profile section

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.php
@@ -33,8 +33,9 @@ function wpcom_profile_settings_add_links_to_wpcom() {
 				'text' => __( 'Manage on WP.com ↗', 'jetpack-mu-wpcom' ),
 			),
 			'name'          => array(
-				'link' => esc_url( 'https://wordpress.com/me' ),
-				'text' => __( 'Manage on WP.com ↗', 'jetpack-mu-wpcom' ),
+				'link'  => esc_url( 'https://wordpress.com/me' ),
+				'text'  => __( 'Manage on WP.com ↗', 'jetpack-mu-wpcom' ),
+				'title' => __( 'Name', 'jetpack-mu-wpcom' ),
 			),
 			'website'       => array(
 				'link' => esc_url( 'https://wordpress.com/me' ),

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.ts
@@ -21,9 +21,10 @@ const wpcom_profile_settings_modify_name_section = () => {
 
 	const settingsLink = window.wpcomProfileSettingsLinkToWpcom?.name?.link;
 	const settingsLinkText = window.wpcomProfileSettingsLinkToWpcom?.name?.text;
-	if ( table && settingsLink && settingsLinkText ) {
+	const settingsLinkTitle = window.wpcomProfileSettingsLinkToWpcom?.name?.title;
+	if ( table && settingsLink && settingsLinkText && settingsLinkTitle ) {
 		const h2 = document.createElement( 'h2' );
-		h2.innerHTML = 'Name';
+		h2.textContent = settingsLinkTitle;
 		h2.style = 'font-size: 1.2em';
 		th.appendChild( h2 );
 


### PR DESCRIPTION
Related to TRA-13

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Add translations for the "Name" section title, which was previously hardcoded to be in English.

Before:
<img width="881" height="219" alt="Screenshot 2026-03-19 at 00 47 04" src="https://github.com/user-attachments/assets/7b377f08-313d-4312-a025-c6f86701b511" />

After:
<img width="881" height="222" alt="Screenshot 2026-03-19 at 00 43 24" src="https://github.com/user-attachments/assets/d56ac64d-ce4d-4040-b385-f40e27dd1d3d" />


### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Switch to a popular non-English language and go to /wp-admin/profile.php, confirm that "Name" appears untranslated.
* Checkout the PR / install it and re-test to confirm that the label is translated now.
