### PR TITLE
Forms: Fix blocks disappearing after navigating back from form editor

### DIFF
--- a/projects/packages/forms/changelog/fix-form-disapering-
+++ b/projects/packages/forms/changelog/fix-form-disapering-
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix blocks disappearing after navigating back from form editor when page has multiple form blocks

--- a/projects/packages/forms/changelog/fix-form-disapering-
+++ b/projects/packages/forms/changelog/fix-form-disapering-
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix blocks disappearing after navigating back from form editor when page has multiple form blocks
+Fix blocks disappearing after navigating back from form editor when page has multiple form blocks.

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -121,6 +121,7 @@ const state = {
 	lastSelectedBlockId: null as string | null | undefined,
 	isFormBlockLocked: false,
 	formBlockStable: false,
+	previousTickFormBlockClientId: null as string | null,
 	hasOpenedInserter: false,
 };
 
@@ -361,7 +362,6 @@ const setupFormEditorSubscription = () => {
 		try {
 			const { getCurrentPostType } = select( 'core/editor' );
 			const isFormEditor = getCurrentPostType() === FORM_POST_TYPE;
-
 			// 1. Handle form editor enter/leave transitions
 			// Detect if we are in the form editor and detect when this state changes across ticks.
 			if ( isFormEditor !== state.isFormEditor ) {
@@ -415,6 +415,7 @@ const setupFormEditorSubscription = () => {
 					state.lastSelectedBlockId = null;
 					state.isFormBlockLocked = false;
 					state.formBlockStable = false;
+					state.previousTickFormBlockClientId = null;
 					state.hasOpenedInserter = false;
 				}
 			}
@@ -424,6 +425,15 @@ const setupFormEditorSubscription = () => {
 				// We are not in the form editor, nothing more to do.
 				return;
 			}
+
+			// Compute form block stability per tick. The form block is "stable" when
+			// its clientId hasn't changed since the previous tick. This allows
+			// enforceBlockNesting and lockFormBlock to run once the editor settles,
+			// while skipping them during transitions (navigation, block re-parse)
+			// where the clientId bounces through null/different values.
+			state.formBlockStable =
+				!! state.formBlockClientId &&
+				state.formBlockClientId === state.previousTickFormBlockClientId;
 
 			// 3. One-time category setup, block directory disable, and collection removal
 			if ( ! state.categoriesSetUp ) {
@@ -448,8 +458,13 @@ const setupFormEditorSubscription = () => {
 				const formBlock = findFormBlock( rootBlocks );
 				state.formBlockClientId = formBlock ? formBlock.clientId : null;
 
-				if ( state.formBlockClientId && state.formBlockClientId !== previousFormBlockClientId ) {
-					state.isFormBlockLocked = false;
+				// When the clientId changes (including through null), the per-tick
+				// stability from the top of this tick is stale — override it.
+				if ( state.formBlockClientId !== previousFormBlockClientId ) {
+					state.formBlockStable = false;
+					if ( state.formBlockClientId ) {
+						state.isFormBlockLocked = false;
+					}
 				}
 
 				// When the form block first appears, defer restrictAllowedBlocks to break
@@ -476,14 +491,7 @@ const setupFormEditorSubscription = () => {
 					enforceBlockSelection();
 				}
 
-				// Only run enforceBlockNesting when the form block is stable (same clientId
-				// as before). When the formBlockClientId changes, we're in a transition
-				// (initial load, block re-parse, or navigating back to page) and nesting
-				// would incorrectly move page/transition blocks inside the form.
-				const formBlockIsStable =
-					!! state.formBlockClientId && state.formBlockClientId === previousFormBlockClientId;
-				state.formBlockStable = formBlockIsStable;
-				if ( formBlockIsStable ) {
+				if ( state.formBlockStable ) {
 					enforceBlockNesting();
 				}
 			}
@@ -540,6 +548,9 @@ const setupFormEditorSubscription = () => {
 					state.isFormBlockLocked = true;
 				}
 			}
+			// Track the form block clientId from this tick so the next tick can
+			// determine whether it has stabilized.
+			state.previousTickFormBlockClientId = state.formBlockClientId;
 		} finally {
 			isProcessing = false;
 		}

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -431,6 +431,15 @@ const setupFormEditorSubscription = () => {
 				return;
 			}
 
+			// 2b. Early return if entered via entity navigation (e.g. "Edit Form" from a page).
+			// All form-editor-specific block manipulations below (category setup, block nesting,
+			// block locking, selection enforcement, etc.) should only run when the form editor
+			// is loaded directly. During entity navigation transitions, the block store briefly
+			// contains page blocks while isFormEditor is still true, which causes race conditions.
+			if ( state.enteredViaNavigation ) {
+				return;
+			}
+
 			// 3. One-time category setup, block directory disable, and collection removal
 			if ( ! state.categoriesSetUp ) {
 				state.categoriesSetUp = true;
@@ -482,9 +491,7 @@ const setupFormEditorSubscription = () => {
 					enforceBlockSelection();
 				}
 
-				if ( ! state.enteredViaNavigation ) {
-					enforceBlockNesting();
-				}
+				enforceBlockNesting();
 			}
 
 			// 5. Auto-open the block inserter (once) after blocks are ready

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -121,6 +121,7 @@ const state = {
 	lastSelectedBlockId: null as string | null | undefined,
 	isFormBlockLocked: false,
 	hasOpenedInserter: false,
+	enteredViaNavigation: false,
 };
 
 const BLOCK_DIRECTORY_PLUGIN_NAME = 'block-directory';
@@ -257,14 +258,6 @@ const enforceBlockNesting = () => {
 		return;
 	}
 
-	// In the form editor, there should be exactly one jetpack/contact-form at root.
-	// If there are multiple, we're seeing page/post blocks during an entity transition
-	// (e.g. navigating back from the form editor). Skip nesting to avoid corrupting page content.
-	const formBlockCount = rootBlocks.filter( b => b.name === 'jetpack/contact-form' ).length;
-	if ( formBlockCount > 1 ) {
-		return;
-	}
-
 	// Find any blocks that aren't the form block
 	const blocksToMove = getBlocksToMove( rootBlocks, state.formBlockClientId );
 
@@ -372,9 +365,15 @@ const setupFormEditorSubscription = () => {
 			// 1. Handle form editor enter/leave transitions
 			// Detect if we are in the form editor and detect when this state changes across ticks.
 			if ( isFormEditor !== state.isFormEditor ) {
-				state.isFormEditor = isFormEditor; // Store the current isFormEditor in the state object for future reference.
+				const previousIsFormEditor = state.isFormEditor;
+				state.isFormEditor = isFormEditor;
 
 				if ( isFormEditor ) {
+					// Track how we entered: false → true = entity navigation, null → true = direct load.
+					// When entered via entity navigation (e.g. "Edit Form" from a page), skip
+					// enforceBlockNesting to avoid corrupting page blocks during the transition.
+					state.enteredViaNavigation = previousIsFormEditor === false;
+
 					// We just entered the form editor.
 					document.body.classList.add( 'post-type-jetpack_form' );
 
@@ -422,6 +421,7 @@ const setupFormEditorSubscription = () => {
 					state.lastSelectedBlockId = null;
 					state.isFormBlockLocked = false;
 					state.hasOpenedInserter = false;
+					state.enteredViaNavigation = false;
 				}
 			}
 
@@ -482,7 +482,9 @@ const setupFormEditorSubscription = () => {
 					enforceBlockSelection();
 				}
 
-				enforceBlockNesting();
+				if ( ! state.enteredViaNavigation ) {
+					enforceBlockNesting();
+				}
 			}
 
 			// 5. Auto-open the block inserter (once) after blocks are ready

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -120,8 +120,8 @@ const state = {
 	lastRootBlockIds: '',
 	lastSelectedBlockId: null as string | null | undefined,
 	isFormBlockLocked: false,
+	formBlockStable: false,
 	hasOpenedInserter: false,
-	enteredViaNavigation: false,
 };
 
 const BLOCK_DIRECTORY_PLUGIN_NAME = 'block-directory';
@@ -365,15 +365,9 @@ const setupFormEditorSubscription = () => {
 			// 1. Handle form editor enter/leave transitions
 			// Detect if we are in the form editor and detect when this state changes across ticks.
 			if ( isFormEditor !== state.isFormEditor ) {
-				const previousIsFormEditor = state.isFormEditor;
 				state.isFormEditor = isFormEditor;
 
 				if ( isFormEditor ) {
-					// Track how we entered: false → true = entity navigation, null → true = direct load.
-					// When entered via entity navigation (e.g. "Edit Form" from a page), skip
-					// enforceBlockNesting to avoid corrupting page blocks during the transition.
-					state.enteredViaNavigation = previousIsFormEditor === false;
-
 					// We just entered the form editor.
 					document.body.classList.add( 'post-type-jetpack_form' );
 
@@ -420,23 +414,14 @@ const setupFormEditorSubscription = () => {
 					state.lastRootBlockIds = '';
 					state.lastSelectedBlockId = null;
 					state.isFormBlockLocked = false;
+					state.formBlockStable = false;
 					state.hasOpenedInserter = false;
-					state.enteredViaNavigation = false;
 				}
 			}
 
 			// 2. Early return if not in form editor
 			if ( ! isFormEditor ) {
 				// We are not in the form editor, nothing more to do.
-				return;
-			}
-
-			// 2b. Early return if entered via entity navigation (e.g. "Edit Form" from a page).
-			// All form-editor-specific block manipulations below (category setup, block nesting,
-			// block locking, selection enforcement, etc.) should only run when the form editor
-			// is loaded directly. During entity navigation transitions, the block store briefly
-			// contains page blocks while isFormEditor is still true, which causes race conditions.
-			if ( state.enteredViaNavigation ) {
 				return;
 			}
 
@@ -491,7 +476,16 @@ const setupFormEditorSubscription = () => {
 					enforceBlockSelection();
 				}
 
-				enforceBlockNesting();
+				// Only run enforceBlockNesting when the form block is stable (same clientId
+				// as before). When the formBlockClientId changes, we're in a transition
+				// (initial load, block re-parse, or navigating back to page) and nesting
+				// would incorrectly move page/transition blocks inside the form.
+				const formBlockIsStable =
+					!! state.formBlockClientId && state.formBlockClientId === previousFormBlockClientId;
+				state.formBlockStable = formBlockIsStable;
+				if ( formBlockIsStable ) {
+					enforceBlockNesting();
+				}
 			}
 
 			// 5. Auto-open the block inserter (once) after blocks are ready
@@ -535,8 +529,9 @@ const setupFormEditorSubscription = () => {
 				enforceBlockSelection();
 			}
 
-			// 7. Ensure form block is locked
-			if ( ! state.isFormBlockLocked && state.formBlockClientId ) {
+			// 7. Ensure form block is locked (only when form block is stable —
+			// skip during transitions to avoid locking page blocks).
+			if ( ! state.isFormBlockLocked && state.formBlockClientId && state.formBlockStable ) {
 				lockFormBlock();
 				const { getBlock } = select( 'core/block-editor' );
 				const formBlock = getBlock( state.formBlockClientId );

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -257,6 +257,14 @@ const enforceBlockNesting = () => {
 		return;
 	}
 
+	// In the form editor, there should be exactly one jetpack/contact-form at root.
+	// If there are multiple, we're seeing page/post blocks during an entity transition
+	// (e.g. navigating back from the form editor). Skip nesting to avoid corrupting page content.
+	const formBlockCount = rootBlocks.filter( b => b.name === 'jetpack/contact-form' ).length;
+	if ( formBlockCount > 1 ) {
+		return;
+	}
+
 	// Find any blocks that aren't the form block
 	const blocksToMove = getBlocksToMove( rootBlocks, state.formBlockClientId );
 


### PR DESCRIPTION
Fixes #

## Proposed changes

* Fix blocks disappearing and form block getting locked after navigating back from the form editor when a page has multiple form blocks.
* The form editor's `subscribe()` callback runs operations like `enforceBlockNesting`, `lockFormBlock`, and `enforceBlockSelection` that assume root blocks belong to the form editor. When navigating back from the form editor via `onNavigateToEntityRecord`, the block store briefly loads page blocks while `isFormEditor` is still `true`, causing these operations to corrupt page content.
* Add a `formBlockStable` flag computed per subscription tick by comparing the current `formBlockClientId` against the previous tick's value. Operations like `enforceBlockNesting` and `lockFormBlock` are gated behind this flag so they only run once the editor has settled — skipping the transient ticks where the block store re-parses content (bouncing through `null → id → null → id`) or where page blocks are briefly visible during navigation transitions.
* The root-block-change handler overrides `formBlockStable` to `false` when the clientId changes mid-tick, preventing stale per-tick stability from allowing block manipulation on page blocks during the transition back from the form editor.

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

### Test 1: Blocks no longer disappear
1. Create a new page
2. Add a paragraph block, then two separate Jetpack Form blocks, then another paragraph block (4 blocks total)
3. Save/publish the page
4. Click "Edit Form" on one of the form blocks to enter the form editor
5. Navigate back to the page editor (click the back arrow or breadcrumb)
6. **Expected:** All 4 blocks are preserved when returning to the page editor

### Test 2: Form block is not locked after returning
1. Using the same page from Test 1, after navigating back from the form editor
2. Click on the first form block
3. **Expected:** The form block toolbar shows move handles and the block can be moved/removed normally (it is NOT locked)

### Test 3: Direct form editor still works
1. Navigate directly to a `jetpack_form` post (e.g. via wp-admin → Forms → edit a form)
2. The form block should be locked (cannot be moved or removed) — this is expected in the form editor
3. Try adding a block at the root level (e.g. via the top-level inserter) — it should be automatically nested inside the form block
4. The block inserter should auto-open on wide viewports