### PR TITLE
Pie Charts: Remove percentage from interface, calculate from value

### DIFF
--- a/projects/js-packages/charts/changelog/fix-charts-pie-legend-percentage-stability
+++ b/projects/js-packages/charts/changelog/fix-charts-pie-legend-percentage-stability
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Charts: Make `percentage` optional in DataPointPercentage. Percentages are now calculated from `value`, aligning with industry-standard charting libraries (Chart.js, Recharts, D3).
+Charts: Remove `percentage` from DataPointPercentage interface. Percentages are now calculated automatically from `value`, aligning with industry-standard charting libraries (Chart.js, Recharts, D3).

--- a/projects/js-packages/charts/changelog/fix-charts-pie-legend-percentage-stability
+++ b/projects/js-packages/charts/changelog/fix-charts-pie-legend-percentage-stability
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Charts: Remove `percentage` from DataPointPercentage interface. Percentages are now calculated automatically from `value`, aligning with industry-standard charting libraries (Chart.js, Recharts, D3).
+Remove `percentage` from DataPointPercentage interface.

--- a/projects/js-packages/charts/changelog/fix-charts-pie-legend-percentage-stability
+++ b/projects/js-packages/charts/changelog/fix-charts-pie-legend-percentage-stability
@@ -1,4 +1,4 @@
-Significance: patch
-Type: fixed
+Significance: minor
+Type: changed
 
 Charts: Remove `percentage` from DataPointPercentage interface. Percentages are now calculated automatically from `value`, aligning with industry-standard charting libraries (Chart.js, Recharts, D3).

--- a/projects/js-packages/charts/changelog/fix-charts-pie-legend-percentage-stability
+++ b/projects/js-packages/charts/changelog/fix-charts-pie-legend-percentage-stability
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Charts: Make `percentage` optional in DataPointPercentage. Percentages are now calculated from `value`, aligning with industry-standard charting libraries (Chart.js, Recharts, D3).

--- a/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
@@ -7,7 +7,11 @@ import clsx from 'clsx';
 import { useCallback, useContext, useMemo } from 'react';
 import { Legend, useChartLegendItems } from '../../components/legend';
 import { BaseTooltip } from '../../components/tooltip';
-import { useInteractiveLegendData, usePrefersReducedMotion } from '../../hooks';
+import {
+	useDataWithPercentages,
+	useInteractiveLegendData,
+	usePrefersReducedMotion,
+} from '../../hooks';
 import {
 	GlobalChartsProvider,
 	useChartId,
@@ -206,13 +210,7 @@ const PieChartInternal = ( {
 	const { getElementStyles, isSeriesVisible } = useGlobalChartsContext();
 
 	// Calculate percentages from values (single source of truth)
-	const dataWithPercentages = useMemo( () => {
-		const totalValue = data.reduce( ( sum, segment ) => sum + segment.value, 0 );
-		return data.map( segment => ( {
-			...segment,
-			percentage: totalValue > 0 ? ( segment.value / totalValue ) * 100 : 0,
-		} ) );
-	}, [ data ] );
+	const dataWithPercentages = useDataWithPercentages( data );
 
 	// Filter and recalculate data for interactive legends
 	const { visibleData, allSegmentsHidden, legendData } = useInteractiveLegendData( {

--- a/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
@@ -273,8 +273,7 @@ const PieChartInternal = ( {
 	} );
 
 	const accessors = {
-		// Use value for slice sizing - percentages are calculated from values
-		pieValue: ( d: DataPointPercentage ) => d.value,
+		value: ( d: DataPointPercentage ) => d.value,
 		fill: ( d: DataPointPercentage & { index: number } ) => {
 			return getElementStyles( { data: d, index: d.index } ).color;
 		},
@@ -384,7 +383,7 @@ const PieChartInternal = ( {
 									) : (
 										<Pie< DataPointPercentage & { index: number } >
 											data={ dataWithIndex }
-											pieValue={ accessors.pieValue }
+											pieValue={ accessors.value }
 											outerRadius={ outerRadius }
 											innerRadius={ innerRadius }
 											padAngle={ padAngle }

--- a/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
@@ -205,9 +205,18 @@ const PieChartInternal = ( {
 
 	const { getElementStyles, isSeriesVisible } = useGlobalChartsContext();
 
+	// Calculate percentages from values (single source of truth)
+	const dataWithPercentages = useMemo( () => {
+		const totalValue = data.reduce( ( sum, segment ) => sum + segment.value, 0 );
+		return data.map( segment => ( {
+			...segment,
+			percentage: totalValue > 0 ? ( segment.value / totalValue ) * 100 : 0,
+		} ) );
+	}, [ data ] );
+
 	// Filter and recalculate data for interactive legends
 	const { visibleData, allSegmentsHidden, legendData } = useInteractiveLegendData( {
-		data,
+		data: dataWithPercentages,
 		chartId,
 		legendInteractive,
 		isSeriesVisible,

--- a/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
@@ -137,16 +137,15 @@ const validateData = ( data: DataPointPercentage[] ) => {
 	}
 
 	// Check for negative values
-	const hasNegativeValues = data.some( item => item.percentage < 0 || item.value < 0 );
+	const hasNegativeValues = data.some( item => item.value < 0 );
 	if ( hasNegativeValues ) {
 		return { isValid: false, message: 'Invalid data: Negative values are not allowed' };
 	}
 
-	// Validate total percentage
-	const totalPercentage = data.reduce( ( sum, item ) => sum + item.percentage, 0 );
-	if ( Math.abs( totalPercentage - 100 ) > 0.01 ) {
-		// Using small epsilon for floating point comparison
-		return { isValid: false, message: 'Invalid percentage total: Must equal 100' };
+	// Validate total value is greater than 0
+	const totalValue = data.reduce( ( sum, item ) => sum + item.value, 0 );
+	if ( totalValue <= 0 ) {
+		return { isValid: false, message: 'Invalid data: Total value must be greater than 0' };
 	}
 
 	return { isValid: true, message: '' };
@@ -274,7 +273,8 @@ const PieChartInternal = ( {
 	} );
 
 	const accessors = {
-		value: ( d: DataPointPercentage ) => d.value,
+		// Use value for slice sizing - percentages are calculated from values
+		pieValue: ( d: DataPointPercentage ) => d.value,
 		fill: ( d: DataPointPercentage & { index: number } ) => {
 			return getElementStyles( { data: d, index: d.index } ).color;
 		},
@@ -384,7 +384,7 @@ const PieChartInternal = ( {
 									) : (
 										<Pie< DataPointPercentage & { index: number } >
 											data={ dataWithIndex }
-											pieValue={ accessors.value }
+											pieValue={ accessors.pieValue }
 											outerRadius={ outerRadius }
 											innerRadius={ innerRadius }
 											padAngle={ padAngle }

--- a/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
@@ -30,7 +30,12 @@ import { SvgEmptyState } from '../private/svg-empty-state';
 import { withResponsive, ResponsiveConfig } from '../private/with-responsive';
 import styles from './pie-chart.module.scss';
 import type { LegendValueDisplay } from '../../components/legend';
-import type { BaseChartProps, DataPointPercentage, Optional } from '../../types';
+import type {
+	BaseChartProps,
+	DataPointPercentage,
+	DataPointPercentageCalculated,
+	Optional,
+} from '../../types';
 import type { ChartComponentWithComposition } from '../private/chart-composition';
 import type { SVGProps, MouseEvent, ReactNode, FC } from 'react';
 
@@ -39,9 +44,9 @@ import type { SVGProps, MouseEvent, ReactNode, FC } from 'react';
  */
 export type PieChartRenderTooltipParams = {
 	/**
-	 * The data point being hovered, including label, value, and percentage.
+	 * The data point being hovered, including label, value, and calculated percentage.
 	 */
-	tooltipData: DataPointPercentage;
+	tooltipData: DataPointPercentageCalculated;
 };
 
 /**
@@ -190,7 +195,7 @@ const PieChartInternal = ( {
 	const providerTheme = useGlobalChartsTheme();
 	const chartId = useChartId( providedChartId );
 	const { tooltipOpen, tooltipLeft, tooltipTop, tooltipData, hideTooltip, showTooltip } =
-		useTooltip< DataPointPercentage >();
+		useTooltip< DataPointPercentageCalculated >();
 
 	// Set up portal tooltip for better z-index handling
 	// We get containerBounds to cancel out stale offsets in the position calculation
@@ -280,8 +285,8 @@ const PieChartInternal = ( {
 	} );
 
 	const accessors = {
-		value: ( d: DataPointPercentage ) => d.value,
-		fill: ( d: DataPointPercentage & { index: number } ) => {
+		value: ( d: DataPointPercentageCalculated ) => d.value,
+		fill: ( d: DataPointPercentageCalculated & { index: number } ) => {
 			return getElementStyles( { data: d, index: d.index } ).color;
 		},
 	};
@@ -388,7 +393,7 @@ const PieChartInternal = ( {
 											) }
 										</SvgEmptyState>
 									) : (
-										<Pie< DataPointPercentage & { index: number } >
+										<Pie< DataPointPercentageCalculated & { index: number } >
 											data={ dataWithIndex }
 											pieValue={ accessors.value }
 											outerRadius={ outerRadius }

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/donut.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/donut.stories.tsx
@@ -27,13 +27,11 @@ const data = [
 		label: 'Active Users',
 		value: 65000,
 		valueDisplay: '65K',
-		percentage: 65,
 	},
 	{
 		label: 'Inactive Users',
 		value: 35000,
 		valueDisplay: '35K',
-		percentage: 35,
 	},
 ];
 
@@ -156,11 +154,7 @@ export const ErrorStates: Story = {
 			</div>
 			<div>
 				<h3>Single Value</h3>
-				<PieChart
-					height={ 300 }
-					thickness={ 0.6 }
-					data={ [ { label: 'Single', value: 100, percentage: 100 } ] }
-				/>
+				<PieChart height={ 300 } thickness={ 0.6 } data={ [ { label: 'Single', value: 100 } ] } />
 			</div>
 		</div>
 	),

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/index.stories.tsx
@@ -219,9 +219,9 @@ export const WithCompositionLegend: Story = {
 export const CompositionAPI: Story = {
 	render: args => {
 		const chartData = args.data || [
-			{ label: 'Desktop', value: 45, percentage: 45 },
-			{ label: 'Mobile', value: 30, percentage: 30 },
-			{ label: 'Tablet', value: 25, percentage: 25 },
+			{ label: 'Desktop', value: 45 },
+			{ label: 'Mobile', value: 30 },
+			{ label: 'Tablet', value: 25 },
 		];
 
 		return (
@@ -311,21 +311,18 @@ export const CustomLabelColors: Story = {
 				label: 'Desktop',
 				value: 45000,
 				valueDisplay: '45K',
-				percentage: 45,
 				color: '#FF6B6B', // Light red segment
 			},
 			{
 				label: 'Mobile',
 				value: 35000,
 				valueDisplay: '35K',
-				percentage: 35,
 				color: '#4ECDC4', // Light teal segment
 			},
 			{
 				label: 'Tablet',
 				value: 20000,
 				valueDisplay: '20K',
-				percentage: 20,
 				color: '#45B7D1', // Light blue segment
 			},
 		],
@@ -357,26 +354,26 @@ export const ErrorStates: Story = {
 				<PieChart data={ [] } />
 			</div>
 			<div>
-				<h3>Invalid Percentage Total</h3>
+				<h3>Partial Values</h3>
 				<PieChart
 					data={ [
-						{ label: 'A', value: 30, percentage: 30 },
-						{ label: 'B', value: 40, percentage: 40 },
-					] } // Only adds up to 70%
+						{ label: 'A', value: 30 },
+						{ label: 'B', value: 40 },
+					] }
 				/>
 			</div>
 			<div>
 				<h3>Negative Values</h3>
 				<PieChart
 					data={ [
-						{ label: 'A', value: -30, percentage: -30 },
-						{ label: 'B', value: 130, percentage: 130 },
+						{ label: 'A', value: -30 },
+						{ label: 'B', value: 130 },
 					] }
 				/>
 			</div>
 			<div>
 				<h3>Single Data Point</h3>
-				<PieChart height={ 300 } data={ [ { label: 'A', value: 100, percentage: 100 } ] } />
+				<PieChart height={ 300 } data={ [ { label: 'A', value: 100 } ] } />
 			</div>
 		</div>
 	),

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/index.stories.tsx
@@ -351,11 +351,12 @@ export const ErrorStatesAndEdgeCases: Story = {
 		<div style={ { display: 'grid', gap: '2rem', gridTemplateColumns: 'repeat(2, 1fr)' } }>
 			<div>
 				<h3>Empty Data</h3>
-				<PieChart data={ [] } />
+				<PieChart height={ 300 } data={ [] } />
 			</div>
 			<div>
 				<h3>Negative Values</h3>
 				<PieChart
+					height={ 300 }
 					data={ [
 						{ label: 'A', value: -30 },
 						{ label: 'B', value: 130 },

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/index.stories.tsx
@@ -346,7 +346,7 @@ Use the Storybook controls to experiment with different combinations. Try settin
 	},
 };
 
-export const ErrorStatesAndEdgeCases: Story = {
+export const ErrorStates: Story = {
 	render: () => (
 		<div style={ { display: 'grid', gap: '2rem', gridTemplateColumns: 'repeat(2, 1fr)' } }>
 			<div>

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/index.stories.tsx
@@ -346,7 +346,7 @@ Use the Storybook controls to experiment with different combinations. Try settin
 	},
 };
 
-export const ErrorStates: Story = {
+export const ErrorStatesAndEdgeCases: Story = {
 	render: () => (
 		<div style={ { display: 'grid', gap: '2rem', gridTemplateColumns: 'repeat(2, 1fr)' } }>
 			<div>

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/index.stories.tsx
@@ -354,15 +354,6 @@ export const ErrorStatesAndEdgeCases: Story = {
 				<PieChart data={ [] } />
 			</div>
 			<div>
-				<h3>Partial Values</h3>
-				<PieChart
-					data={ [
-						{ label: 'A', value: 30 },
-						{ label: 'B', value: 40 },
-					] }
-				/>
-			</div>
-			<div>
 				<h3>Negative Values</h3>
 				<PieChart
 					data={ [

--- a/projects/js-packages/charts/src/charts/pie-chart/test/composition-api.test.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/test/composition-api.test.tsx
@@ -6,9 +6,9 @@ import { PieChartUnresponsive as PieChart } from '../index';
 
 describe( 'PieChart Composition API', () => {
 	const mockData = [
-		{ label: 'A', value: 30, percentage: 30 },
-		{ label: 'B', value: 40, percentage: 40 },
-		{ label: 'C', value: 30, percentage: 30 },
+		{ label: 'A', value: 30 },
+		{ label: 'B', value: 40 },
+		{ label: 'C', value: 30 },
 	];
 
 	const renderWithChildren = ( props = {}, children = undefined ) => {

--- a/projects/js-packages/charts/src/charts/pie-chart/test/pie-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/test/pie-chart.test.tsx
@@ -7,8 +7,8 @@ describe( 'PieChart', () => {
 	const defaultProps = {
 		size: 500,
 		data: [
-			{ label: 'A', percentage: 50, value: 50 },
-			{ label: 'B', percentage: 50, value: 50 },
+			{ label: 'A', value: 50 },
+			{ label: 'B', value: 50 },
 		],
 	};
 
@@ -21,21 +21,21 @@ describe( 'PieChart', () => {
 	};
 
 	describe( 'Data Validation', () => {
-		test( 'validates total percentage equals 100', () => {
+		test( 'validates total value is greater than 0', () => {
 			renderWithTheme( {
 				data: [
-					{ label: 'A', percentage: 60, value: 60 },
-					{ label: 'B', percentage: 50, value: 50 },
+					{ label: 'A', value: 0 },
+					{ label: 'B', value: 0 },
 				],
 			} );
-			expect( screen.getByText( /invalid percentage total/i ) ).toBeInTheDocument();
+			expect( screen.getByText( /invalid data/i ) ).toBeInTheDocument();
 		} );
 
 		test( 'handles negative values', () => {
 			renderWithTheme( {
 				data: [
-					{ label: 'A', percentage: -30, value: -30 },
-					{ label: 'B', percentage: 130, value: 130 },
+					{ label: 'A', value: -30 },
+					{ label: 'B', value: 130 },
 				],
 			} );
 			expect( screen.getByText( /invalid data/i ) ).toBeInTheDocument();
@@ -48,7 +48,7 @@ describe( 'PieChart', () => {
 
 		test( 'handles single data point', () => {
 			renderWithTheme( {
-				data: [ { label: 'A', percentage: 100, value: 100 } ],
+				data: [ { label: 'A', value: 100 } ],
 			} );
 			// Use getAllByText since 'A' appears in both chart and legend
 			const labels = screen.getAllByText( 'A' );
@@ -157,10 +157,11 @@ describe( 'PieChart', () => {
 	} );
 
 	describe( 'Legend Value Display', () => {
+		// Values that give clean percentages: 60/100=60%, 23/100=23%, 17/100=17%
 		const testData = [
-			{ label: 'Windows', value: 80000, valueDisplay: '80K', percentage: 60 },
-			{ label: 'MacOS', value: 30000, valueDisplay: '30K', percentage: 23 },
-			{ label: 'Linux', value: 22000, valueDisplay: '22K', percentage: 17 },
+			{ label: 'Windows', value: 60, valueDisplay: '60' },
+			{ label: 'MacOS', value: 23, valueDisplay: '23' },
+			{ label: 'Linux', value: 17, valueDisplay: '17' },
 		];
 
 		test( 'shows percentage values by default when showLegend and showValues are enabled', () => {
@@ -170,7 +171,7 @@ describe( 'PieChart', () => {
 				// legendValueDisplay defaults to 'percentage'
 			} );
 
-			// Should display percentage values (using formatPercentage which shows "60%", "23%", "17%")
+			// Should display calculated percentages from values
 			expect( screen.getByText( '60%' ) ).toBeInTheDocument();
 			expect( screen.getByText( '23%' ) ).toBeInTheDocument();
 			expect( screen.getByText( '17%' ) ).toBeInTheDocument();
@@ -184,9 +185,9 @@ describe( 'PieChart', () => {
 			} );
 
 			// Should display localized numeric values
-			expect( screen.getByText( '80,000' ) ).toBeInTheDocument();
-			expect( screen.getByText( '30,000' ) ).toBeInTheDocument();
-			expect( screen.getByText( '22,000' ) ).toBeInTheDocument();
+			expect( screen.getByText( '60' ) ).toBeInTheDocument();
+			expect( screen.getByText( '23' ) ).toBeInTheDocument();
+			expect( screen.getByText( '17' ) ).toBeInTheDocument();
 		} );
 
 		test( 'shows formatted values when legendValueDisplay is set to "valueDisplay"', () => {
@@ -197,9 +198,9 @@ describe( 'PieChart', () => {
 			} );
 
 			// Should display formatted values (valueDisplay field)
-			expect( screen.getByText( '80K' ) ).toBeInTheDocument();
-			expect( screen.getByText( '30K' ) ).toBeInTheDocument();
-			expect( screen.getByText( '22K' ) ).toBeInTheDocument();
+			expect( screen.getByText( '60' ) ).toBeInTheDocument();
+			expect( screen.getByText( '23' ) ).toBeInTheDocument();
+			expect( screen.getByText( '17' ) ).toBeInTheDocument();
 		} );
 
 		test( 'shows no values when legendValueDisplay is set to "none"', () => {
@@ -222,9 +223,12 @@ describe( 'PieChart', () => {
 	} );
 
 	describe( 'Tooltip Functionality', () => {
+		// Values: 80000 + 30000 = 110000
+		// Windows: 80000/110000 = 72.727...%
+		// MacOS: 30000/110000 = 27.272...%
 		const testData = [
-			{ label: 'Windows', value: 80000, valueDisplay: '80K', percentage: 70 },
-			{ label: 'MacOS', value: 30000, valueDisplay: '30K', percentage: 30 },
+			{ label: 'Windows', value: 80000, valueDisplay: '80K' },
+			{ label: 'MacOS', value: 30000, valueDisplay: '30K' },
 		];
 
 		test( 'does not show tooltip when withTooltips is false', async () => {
@@ -314,7 +318,7 @@ describe( 'PieChart', () => {
 
 		test( 'tooltip shows valueDisplay when available, falls back to value', async () => {
 			const user = userEvent.setup();
-			const dataWithoutValueDisplay = [ { label: 'Test', value: 42, percentage: 100 } ];
+			const dataWithoutValueDisplay = [ { label: 'Test', value: 42 } ];
 
 			renderWithTheme( {
 				data: dataWithoutValueDisplay,
@@ -356,15 +360,18 @@ describe( 'PieChart', () => {
 			expect( customTooltipRenderer ).toHaveBeenCalled();
 
 			// Verify the renderer received correct parameters
+			// Percentage is calculated from values: 80000 / (80000 + 30000) = 72.727...%
 			expect( customTooltipRenderer ).toHaveBeenCalledWith(
 				expect.objectContaining( {
 					tooltipData: expect.objectContaining( {
 						label: 'Windows',
 						value: 80000,
-						percentage: 70,
 					} ),
 				} )
 			);
+			// Verify percentage is calculated (approximately 72.73%)
+			const callArgs = customTooltipRenderer.mock.calls[ 0 ][ 0 ];
+			expect( callArgs.tooltipData.percentage ).toBeCloseTo( 72.73, 1 );
 		} );
 	} );
 
@@ -372,8 +379,8 @@ describe( 'PieChart', () => {
 		test( 'filters segments when interactive legend is enabled and segment is toggled', async () => {
 			const user = userEvent.setup();
 			const testData = [
-				{ label: 'Segment A', value: 50, percentage: 50 },
-				{ label: 'Segment B', value: 50, percentage: 50 },
+				{ label: 'Segment A', value: 50 },
+				{ label: 'Segment B', value: 50 },
 			];
 
 			renderWithTheme( {
@@ -404,8 +411,8 @@ describe( 'PieChart', () => {
 		test( 'shows empty state when all segments are hidden', async () => {
 			const user = userEvent.setup();
 			const testData = [
-				{ label: 'Segment A', value: 50, percentage: 50 },
-				{ label: 'Segment B', value: 50, percentage: 50 },
+				{ label: 'Segment A', value: 50 },
+				{ label: 'Segment B', value: 50 },
 			];
 
 			renderWithTheme( {
@@ -443,8 +450,8 @@ describe( 'PieChart', () => {
 
 		test( 'does not filter segments when legendInteractive is false', () => {
 			const testData = [
-				{ label: 'Segment A', value: 50, percentage: 50 },
-				{ label: 'Segment B', value: 50, percentage: 50 },
+				{ label: 'Segment A', value: 50 },
+				{ label: 'Segment B', value: 50 },
 			];
 
 			renderWithTheme( {
@@ -466,9 +473,9 @@ describe( 'PieChart', () => {
 		test( 'maintains consistent colors when segments are hidden', async () => {
 			const user = userEvent.setup();
 			const testData = [
-				{ label: 'Segment A', value: 30, percentage: 30 },
-				{ label: 'Segment B', value: 40, percentage: 40 },
-				{ label: 'Segment C', value: 30, percentage: 30 },
+				{ label: 'Segment A', value: 30 },
+				{ label: 'Segment B', value: 40 },
+				{ label: 'Segment C', value: 30 },
 			];
 
 			renderWithTheme( {
@@ -498,9 +505,9 @@ describe( 'PieChart', () => {
 		test( 'recalculates legend percentages when segments are hidden', async () => {
 			const user = userEvent.setup();
 			const testData = [
-				{ label: 'Segment A', value: 25, percentage: 25 },
-				{ label: 'Segment B', value: 50, percentage: 50 },
-				{ label: 'Segment C', value: 25, percentage: 25 },
+				{ label: 'Segment A', value: 25 },
+				{ label: 'Segment B', value: 50 },
+				{ label: 'Segment C', value: 25 },
 			];
 
 			renderWithTheme( {

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -8,7 +8,11 @@ import clsx from 'clsx';
 import { useCallback, useContext, useMemo } from 'react';
 import { Legend, useChartLegendItems } from '../../components/legend';
 import { BaseTooltip } from '../../components/tooltip';
-import { useInteractiveLegendData, usePrefersReducedMotion } from '../../hooks';
+import {
+	useDataWithPercentages,
+	useInteractiveLegendData,
+	usePrefersReducedMotion,
+} from '../../hooks';
 import {
 	GlobalChartsProvider,
 	useChartId,
@@ -235,13 +239,7 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 	const { getElementStyles, isSeriesVisible } = useGlobalChartsContext();
 
 	// Calculate percentages from values (single source of truth)
-	const dataWithPercentages = useMemo( () => {
-		const totalValue = data.reduce( ( sum, segment ) => sum + segment.value, 0 );
-		return data.map( segment => ( {
-			...segment,
-			percentage: totalValue > 0 ? ( segment.value / totalValue ) * 100 : 0,
-		} ) );
-	}, [ data ] );
+	const dataWithPercentages = useDataWithPercentages( data );
 
 	// Filter and recalculate data for interactive legends
 	const { visibleData, allSegmentsHidden, legendData } = useInteractiveLegendData( {

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -139,15 +139,15 @@ const validateData = ( data: DataPointPercentage[] ) => {
 	}
 
 	// Check for negative values
-	const hasNegativeValues = data.some( item => item.percentage < 0 || item.value < 0 );
+	const hasNegativeValues = data.some( item => item.value < 0 );
 	if ( hasNegativeValues ) {
 		return { isValid: false, message: 'Invalid data: Negative values are not allowed' };
 	}
 
-	// Validate total percentage is greater than 0
-	const totalPercentage = data.reduce( ( sum, item ) => sum + item.percentage, 0 );
-	if ( totalPercentage <= 0 ) {
-		return { isValid: false, message: 'Invalid percentage total: Must be greater than 0' };
+	// Validate total value is greater than 0
+	const totalValue = data.reduce( ( sum, item ) => sum + item.value, 0 );
+	if ( totalValue <= 0 ) {
+		return { isValid: false, message: 'Invalid data: Total value must be greater than 0' };
 	}
 
 	return { isValid: true, message: '' };
@@ -245,7 +245,8 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 	// Define accessors with useMemo to avoid changing dependencies
 	const accessors = useMemo(
 		() => ( {
-			value: ( d: DataPointPercentage ) => d.value,
+			// Use value for slice sizing - percentages are calculated from values
+			pieValue: ( d: DataPointPercentage ) => d.value,
 			sort: (
 				a: DataPointPercentage & { index: number },
 				b: DataPointPercentage & { index: number }
@@ -427,7 +428,7 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 											{ /* Pie chart */ }
 											<Pie< DataPointPercentage & { index: number } >
 												data={ dataWithIndex }
-												pieValue={ accessors.value }
+												pieValue={ accessors.pieValue }
 												outerRadius={ radius }
 												innerRadius={ innerRadius }
 												cornerRadius={ 3 }

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -234,9 +234,18 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 
 	const { getElementStyles, isSeriesVisible } = useGlobalChartsContext();
 
+	// Calculate percentages from values (single source of truth)
+	const dataWithPercentages = useMemo( () => {
+		const totalValue = data.reduce( ( sum, segment ) => sum + segment.value, 0 );
+		return data.map( segment => ( {
+			...segment,
+			percentage: totalValue > 0 ? ( segment.value / totalValue ) * 100 : 0,
+		} ) );
+	}, [ data ] );
+
 	// Filter and recalculate data for interactive legends
 	const { visibleData, allSegmentsHidden, legendData } = useInteractiveLegendData( {
-		data,
+		data: dataWithPercentages,
 		chartId,
 		legendInteractive,
 		isSeriesVisible,

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -29,7 +29,12 @@ import { SvgEmptyState } from '../private/svg-empty-state';
 import { withResponsive } from '../private/with-responsive';
 import styles from './pie-semi-circle-chart.module.scss';
 import type { LegendValueDisplay } from '../../components/legend';
-import type { BaseChartProps, DataPointPercentage, Optional } from '../../types';
+import type {
+	BaseChartProps,
+	DataPointPercentage,
+	DataPointPercentageCalculated,
+	Optional,
+} from '../../types';
 import type { ChartComponentWithComposition } from '../private/chart-composition';
 import type { ResponsiveConfig } from '../private/with-responsive';
 import type { PieArcDatum } from '@visx/shape/lib/shapes/Pie';
@@ -40,9 +45,9 @@ import type { FC, MouseEvent, ReactNode } from 'react';
  */
 export type PieSemiCircleChartRenderTooltipParams = {
 	/**
-	 * The data point being hovered, including label, value, and percentage.
+	 * The data point being hovered, including label, value, and calculated percentage.
 	 */
-	tooltipData: DataPointPercentage;
+	tooltipData: DataPointPercentageCalculated;
 };
 
 /**
@@ -130,7 +135,7 @@ type PieSemiCircleChartResponsiveComponent = ChartComponentWithComposition<
 	PieSemiCircleChartBaseProps & ResponsiveConfig
 >;
 
-export type ArcData = PieArcDatum< DataPointPercentage >;
+export type ArcData = PieArcDatum< DataPointPercentageCalculated >;
 
 /**
  * Validates the semi-circle pie chart data
@@ -183,7 +188,7 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 
 	const chartId = useChartId( providedChartId );
 	const { tooltipOpen, tooltipLeft, tooltipTop, tooltipData, hideTooltip, showTooltip } =
-		useTooltip< DataPointPercentage >();
+		useTooltip< DataPointPercentageCalculated >();
 
 	// Set up portal tooltip for better z-index handling
 	// We get containerBounds to cancel out stale offsets in the position calculation
@@ -252,12 +257,12 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 	// Define accessors with useMemo to avoid changing dependencies
 	const accessors = useMemo(
 		() => ( {
-			value: ( d: DataPointPercentage ) => d.value,
+			value: ( d: DataPointPercentageCalculated ) => d.value,
 			sort: (
-				a: DataPointPercentage & { index: number },
-				b: DataPointPercentage & { index: number }
+				a: DataPointPercentageCalculated & { index: number },
+				b: DataPointPercentageCalculated & { index: number }
 			) => b.value - a.value,
-			fill: ( d: DataPointPercentage & { index: number } ) =>
+			fill: ( d: DataPointPercentageCalculated & { index: number } ) =>
 				getElementStyles( { data: d, index: d.index } ).color,
 		} ),
 		[ getElementStyles ]
@@ -432,7 +437,7 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 									) : (
 										<>
 											{ /* Pie chart */ }
-											<Pie< DataPointPercentage & { index: number } >
+											<Pie< DataPointPercentageCalculated & { index: number } >
 												data={ dataWithIndex }
 												pieValue={ accessors.value }
 												outerRadius={ radius }

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -245,8 +245,7 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 	// Define accessors with useMemo to avoid changing dependencies
 	const accessors = useMemo(
 		() => ( {
-			// Use value for slice sizing - percentages are calculated from values
-			pieValue: ( d: DataPointPercentage ) => d.value,
+			value: ( d: DataPointPercentage ) => d.value,
 			sort: (
 				a: DataPointPercentage & { index: number },
 				b: DataPointPercentage & { index: number }
@@ -428,7 +427,7 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 											{ /* Pie chart */ }
 											<Pie< DataPointPercentage & { index: number } >
 												data={ dataWithIndex }
-												pieValue={ accessors.pieValue }
+												pieValue={ accessors.value }
 												outerRadius={ radius }
 												innerRadius={ innerRadius }
 												cornerRadius={ 3 }

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/index.stories.tsx
@@ -186,12 +186,12 @@ export const ErrorStates: Story = {
 			</div>
 
 			<div>
-				<h3>Zero Total Percentage</h3>
+				<h3>Zero Total Value</h3>
 				<PieSemiCircleChart
 					width={ 300 }
 					data={ [
-						{ label: 'A', value: 0, percentage: 0 },
-						{ label: 'B', value: 0, percentage: 0 },
+						{ label: 'A', value: 0 },
+						{ label: 'B', value: 0 },
 					] }
 				/>
 			</div>
@@ -201,18 +201,15 @@ export const ErrorStates: Story = {
 				<PieSemiCircleChart
 					width={ 300 }
 					data={ [
-						{ label: 'A', value: -30, percentage: -30 },
-						{ label: 'B', value: 130, percentage: 130 },
+						{ label: 'A', value: -30 },
+						{ label: 'B', value: 130 },
 					] }
 				/>
 			</div>
 
 			<div>
 				<h3>Single Data Point</h3>
-				<PieSemiCircleChart
-					height={ 300 }
-					data={ [ { label: 'Single Point', value: 100, percentage: 100 } ] }
-				/>
+				<PieSemiCircleChart height={ 300 } data={ [ { label: 'Single Point', value: 100 } ] } />
 			</div>
 		</div>
 	),

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/test/pie-semi-circle-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/test/pie-semi-circle-chart.test.tsx
@@ -18,13 +18,11 @@ const mockData = [
 		label: 'Category A',
 		value: 30,
 		valueDisplay: '30%',
-		percentage: 30,
 	},
 	{
 		label: 'Category B',
 		value: 70,
 		valueDisplay: '70%',
-		percentage: 70,
 	},
 ];
 
@@ -64,9 +62,9 @@ describe( 'PieSemiCircleChart', () => {
 	it( 'shows tooltip on segment hover when withTooltips is true', async () => {
 		const user = userEvent.setup();
 		const testData = [
-			{ label: 'MacOS', value: 30000, valueDisplay: '30K', percentage: 5 },
-			{ label: 'Linux', value: 22000, valueDisplay: '22K', percentage: 1 },
-			{ label: 'Windows', value: 80000, valueDisplay: '80K', percentage: 2 },
+			{ label: 'MacOS', value: 30000, valueDisplay: '30K' },
+			{ label: 'Linux', value: 22000, valueDisplay: '22K' },
+			{ label: 'Windows', value: 80000, valueDisplay: '80K' },
 		];
 
 		renderPieChart( { data: testData, withTooltips: true, width: 400 } );
@@ -86,9 +84,9 @@ describe( 'PieSemiCircleChart', () => {
 	it( 'hides tooltip on mouse leave', async () => {
 		const user = userEvent.setup();
 		const testData = [
-			{ label: 'MacOS', value: 30000, valueDisplay: '30K', percentage: 5 },
-			{ label: 'Linux', value: 22000, valueDisplay: '22K', percentage: 1 },
-			{ label: 'Windows', value: 80000, valueDisplay: '80K', percentage: 2 },
+			{ label: 'MacOS', value: 30000, valueDisplay: '30K' },
+			{ label: 'Linux', value: 22000, valueDisplay: '22K' },
+			{ label: 'Windows', value: 80000, valueDisplay: '80K' },
 		];
 
 		renderPieChart( { data: testData, withTooltips: true, width: 400 } );
@@ -113,9 +111,9 @@ describe( 'PieSemiCircleChart', () => {
 	it( 'renders custom tooltip when renderTooltip prop is provided', async () => {
 		const user = userEvent.setup();
 		const testData = [
-			{ label: 'MacOS', value: 30000, valueDisplay: '30K', percentage: 5 },
-			{ label: 'Linux', value: 22000, valueDisplay: '22K', percentage: 1 },
-			{ label: 'Windows', value: 80000, valueDisplay: '80K', percentage: 2 },
+			{ label: 'MacOS', value: 30000, valueDisplay: '30K' },
+			{ label: 'Linux', value: 22000, valueDisplay: '22K' },
+			{ label: 'Windows', value: 80000, valueDisplay: '80K' },
 		];
 
 		const customTooltipRenderer = jest.fn( ( { tooltipData } ) => (
@@ -148,10 +146,12 @@ describe( 'PieSemiCircleChart', () => {
 				tooltipData: expect.objectContaining( {
 					label: 'MacOS',
 					value: 30000,
-					percentage: 5,
 				} ),
 			} )
 		);
+		// Verify percentage is calculated (approximately 22.73%)
+		const callArgs = customTooltipRenderer.mock.calls[ 0 ][ 0 ];
+		expect( callArgs.tooltipData.percentage ).toBeCloseTo( 22.73, 1 );
 	} );
 
 	it( 'applies custom className', () => {
@@ -193,21 +193,21 @@ describe( 'PieSemiCircleChart', () => {
 			expect( screen.getByText( 'No data available' ) ).toBeInTheDocument();
 		} );
 
-		test( 'handles zero total percentage', () => {
+		test( 'handles zero total value', () => {
 			renderPieChart( {
 				data: [
-					{ label: 'A', value: 0, percentage: 0 },
-					{ label: 'B', value: 0, percentage: 0 },
+					{ label: 'A', value: 0 },
+					{ label: 'B', value: 0 },
 				],
 			} );
 			expect(
-				screen.getByText( 'Invalid percentage total: Must be greater than 0' )
+				screen.getByText( 'Invalid data: Total value must be greater than 0' )
 			).toBeInTheDocument();
 		} );
 
 		test( 'handles single data point', () => {
 			renderPieChart( {
-				data: [ { label: 'Single', value: 100, percentage: 50 } ],
+				data: [ { label: 'Single', value: 100 } ],
 			} );
 			expect( screen.getByTestId( 'pie-segment' ) ).toBeInTheDocument();
 		} );
@@ -215,8 +215,8 @@ describe( 'PieSemiCircleChart', () => {
 		test( 'handles negative values', () => {
 			renderPieChart( {
 				data: [
-					{ label: 'A', value: -30, percentage: -30 },
-					{ label: 'B', value: 130, percentage: 130 },
+					{ label: 'A', value: -30 },
+					{ label: 'B', value: 130 },
 				],
 			} );
 			expect(
@@ -288,8 +288,8 @@ describe( 'PieSemiCircleChart', () => {
 		test( 'filters segments when interactive legend is enabled and segment is toggled', async () => {
 			const user = userEvent.setup();
 			const testData = [
-				{ label: 'Segment A', value: 50, percentage: 50 },
-				{ label: 'Segment B', value: 50, percentage: 50 },
+				{ label: 'Segment A', value: 50 },
+				{ label: 'Segment B', value: 50 },
 			];
 
 			renderPieChart( {
@@ -320,8 +320,8 @@ describe( 'PieSemiCircleChart', () => {
 		test( 'shows empty state when all segments are hidden', async () => {
 			const user = userEvent.setup();
 			const testData = [
-				{ label: 'Segment A', value: 50, percentage: 50 },
-				{ label: 'Segment B', value: 50, percentage: 50 },
+				{ label: 'Segment A', value: 50 },
+				{ label: 'Segment B', value: 50 },
 			];
 
 			renderPieChart( {
@@ -347,8 +347,8 @@ describe( 'PieSemiCircleChart', () => {
 
 		test( 'does not filter segments when legendInteractive is false', () => {
 			const testData = [
-				{ label: 'Segment A', value: 50, percentage: 50 },
-				{ label: 'Segment B', value: 50, percentage: 50 },
+				{ label: 'Segment A', value: 50 },
+				{ label: 'Segment B', value: 50 },
 			];
 
 			renderPieChart( {

--- a/projects/js-packages/charts/src/components/legend/hooks/test/use-chart-legend-items.test.tsx
+++ b/projects/js-packages/charts/src/components/legend/hooks/test/use-chart-legend-items.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react';
 import { GlobalChartsProvider } from '../../../../providers';
 import { useChartLegendItems } from '../use-chart-legend-items';
-import type { DataPointPercentage, DataPointDate, SeriesData } from '../../../../types';
+import type { DataPointPercentageCalculated, DataPointDate, SeriesData } from '../../../../types';
 import type { ReactNode } from 'react';
 
 // Wrapper component to provide GlobalChartsProvider context
@@ -11,8 +11,8 @@ const wrapper = ( { children }: { children: ReactNode } ) => (
 
 describe( 'useChartLegendItems', () => {
 	describe( 'Number Formatting (i18n)', () => {
-		describe( 'DataPointPercentage', () => {
-			const percentageData: DataPointPercentage[] = [
+		describe( 'DataPointPercentageCalculated', () => {
+			const percentageData: DataPointPercentageCalculated[] = [
 				{ label: 'Item 1', value: 80000, percentage: 60.6 },
 				{ label: 'Item 2', value: 30000, percentage: 22.7 },
 				{ label: 'Item 3', value: 22000, percentage: 16.7 },
@@ -50,7 +50,7 @@ describe( 'useChartLegendItems', () => {
 			} );
 
 			test( 'uses valueDisplay when provided, falling back to formatted value', () => {
-				const dataWithDisplay: DataPointPercentage[] = [
+				const dataWithDisplay: DataPointPercentageCalculated[] = [
 					{ label: 'Item 1', value: 80000, percentage: 60, valueDisplay: 'Custom 80K' },
 					{ label: 'Item 2', value: 30000, percentage: 30 },
 				];
@@ -194,7 +194,9 @@ describe( 'useChartLegendItems', () => {
 		} );
 
 		test( 'handles data with zero values', () => {
-			const zeroData: DataPointPercentage[] = [ { label: 'Zero Value', value: 0, percentage: 0 } ];
+			const zeroData: DataPointPercentageCalculated[] = [
+				{ label: 'Zero Value', value: 0, percentage: 0 },
+			];
 
 			const { result } = renderHook(
 				() =>
@@ -209,7 +211,7 @@ describe( 'useChartLegendItems', () => {
 		} );
 
 		test( 'handles very large numbers', () => {
-			const largeData: DataPointPercentage[] = [
+			const largeData: DataPointPercentageCalculated[] = [
 				{ label: 'Large', value: 1234567890, percentage: 100 },
 			];
 
@@ -227,7 +229,7 @@ describe( 'useChartLegendItems', () => {
 		} );
 
 		test( 'handles decimal values', () => {
-			const decimalData: DataPointPercentage[] = [
+			const decimalData: DataPointPercentageCalculated[] = [
 				{ label: 'Decimal', value: 1234.5678, percentage: 100 },
 			];
 
@@ -247,7 +249,9 @@ describe( 'useChartLegendItems', () => {
 
 	describe( 'Label and Color', () => {
 		test( 'preserves label and color from data', () => {
-			const data: DataPointPercentage[] = [ { label: 'Test Label', value: 100, percentage: 100 } ];
+			const data: DataPointPercentageCalculated[] = [
+				{ label: 'Test Label', value: 100, percentage: 100 },
+			];
 
 			const { result } = renderHook(
 				() =>

--- a/projects/js-packages/charts/src/components/legend/hooks/use-chart-legend-items.ts
+++ b/projects/js-packages/charts/src/components/legend/hooks/use-chart-legend-items.ts
@@ -40,11 +40,13 @@ function formatPointValue(
 	}
 
 	// Handle DataPointPercentage (pie chart data)
-	if ( 'percentage' in point ) {
+	// Note: percentage is now optional, but the hook calculates it from value
+	if ( 'value' in point && ! ( 'date' in point ) && ! ( 'dateString' in point ) ) {
 		const percentagePoint = point as DataPointPercentage;
 		switch ( legendValueDisplay ) {
 			case 'percentage':
-				return formatPercentage( percentagePoint.percentage );
+				// Percentage should be calculated by the hook, fall back to 0
+				return formatPercentage( percentagePoint.percentage ?? 0 );
 			case 'value':
 				return formatNumber( percentagePoint.value );
 			case 'valueDisplay':

--- a/projects/js-packages/charts/src/components/legend/hooks/use-chart-legend-items.ts
+++ b/projects/js-packages/charts/src/components/legend/hooks/use-chart-legend-items.ts
@@ -6,7 +6,7 @@ import {
 	type ElementStyles,
 } from '../../../providers';
 import { formatPercentage } from '../../../utils';
-import type { SeriesData, DataPointDate, DataPointPercentage } from '../../../types';
+import type { SeriesData, DataPointDate, DataPointPercentageCalculated } from '../../../types';
 import type { BaseLegendItem } from '../types';
 import type { LegendShape } from '@visx/legend/lib/types';
 import type { GlyphProps } from '@visx/xychart';
@@ -31,7 +31,7 @@ export interface ChartLegendOptions {
  * @return Formatted value string
  */
 function formatPointValue(
-	point: DataPointDate | DataPointPercentage,
+	point: DataPointDate | DataPointPercentageCalculated,
 	showValues: boolean,
 	legendValueDisplay: LegendValueDisplay = 'percentage'
 ): string {
@@ -39,18 +39,15 @@ function formatPointValue(
 		return '';
 	}
 
-	// Handle DataPointPercentage (pie chart data)
-	// Note: percentage is now optional, but the hook calculates it from value
-	if ( 'value' in point && ! ( 'date' in point ) && ! ( 'dateString' in point ) ) {
-		const percentagePoint = point as DataPointPercentage;
+	// Handle DataPointPercentageCalculated (pie chart data with calculated percentage)
+	if ( 'percentage' in point ) {
 		switch ( legendValueDisplay ) {
 			case 'percentage':
-				// Percentage should be calculated by the hook, fall back to 0
-				return formatPercentage( percentagePoint.percentage ?? 0 );
+				return formatPercentage( point.percentage );
 			case 'value':
-				return formatNumber( percentagePoint.value );
+				return formatNumber( point.value );
 			case 'valueDisplay':
-				return percentagePoint.valueDisplay || formatNumber( percentagePoint.value );
+				return point.valueDisplay || formatNumber( point.value );
 			default:
 				return '';
 		}
@@ -147,7 +144,7 @@ function processSeriesData(
  * @return Array of processed legend items
  */
 function processPointData(
-	pointData: ( DataPointDate | DataPointPercentage )[],
+	pointData: ( DataPointDate | DataPointPercentageCalculated )[],
 	getElementStyles: ( params: GetElementStylesParams ) => ElementStyles,
 	showValues: boolean,
 	legendValueDisplay: LegendValueDisplay,
@@ -156,9 +153,9 @@ function processPointData(
 	renderGlyph?: < Datum extends object >( props: GlyphProps< Datum > ) => ReactNode,
 	legendShape?: LegendShape< SeriesData[], number >
 ): BaseLegendItem[] {
-	const mapper = ( point: DataPointDate | DataPointPercentage, index: number ) => {
+	const mapper = ( point: DataPointDate | DataPointPercentageCalculated, index: number ) => {
 		const { color, glyph, shapeStyles } = getElementStyles( {
-			data: point as DataPointPercentage,
+			data: point as DataPointPercentageCalculated,
 			index,
 			legendShape,
 		} );
@@ -184,7 +181,7 @@ function processPointData(
  * @return Array of legend items ready for display
  */
 export function useChartLegendItems<
-	T extends SeriesData[] | DataPointDate[] | DataPointPercentage[],
+	T extends SeriesData[] | DataPointDate[] | DataPointPercentageCalculated[],
 >(
 	data: T,
 	options: ChartLegendOptions = {},
@@ -217,9 +214,9 @@ export function useChartLegendItems<
 			);
 		}
 
-		// Handle DataPointDate or DataPointPercentage (single data points)
+		// Handle DataPointDate or DataPointPercentageCalculated (single data points)
 		return processPointData(
-			data as ( DataPointDate | DataPointPercentage )[],
+			data as ( DataPointDate | DataPointPercentageCalculated )[],
 			getElementStyles,
 			showValues,
 			legendValueDisplay,

--- a/projects/js-packages/charts/src/components/legend/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/components/legend/stories/index.stories.tsx
@@ -68,8 +68,8 @@ const barChartData: SeriesData[] = [
 ];
 
 const pieChartData: DataPointPercentage[] = [
-	{ label: 'Desktop', value: 65, percentage: 65 },
-	{ label: 'Mobile', value: 35, percentage: 35 },
+	{ label: 'Desktop', value: 65 },
+	{ label: 'Mobile', value: 35 },
 ];
 
 // Basic standalone legends

--- a/projects/js-packages/charts/src/components/tooltip/base-tooltip.tsx
+++ b/projects/js-packages/charts/src/components/tooltip/base-tooltip.tsx
@@ -6,7 +6,6 @@ type TooltipData = {
 	label: string;
 	value: number;
 	valueDisplay?: string;
-	percentage?: number;
 };
 
 type TooltipComponentProps = {

--- a/projects/js-packages/charts/src/components/tooltip/base-tooltip.tsx
+++ b/projects/js-packages/charts/src/components/tooltip/base-tooltip.tsx
@@ -41,16 +41,11 @@ type CustomTooltip = {
 
 type BaseTooltipProps = TooltipCommonProps & ( DefaultDataTooltip | CustomTooltip );
 
-const DefaultTooltipContent = ( { data }: TooltipComponentProps ) => {
-	// Display value in order of preference: valueDisplay > value
-	const displayValue = data?.valueDisplay || formatNumber( data?.value );
-
-	return (
-		<>
-			{ data?.label }: { displayValue }
-		</>
-	);
-};
+const DefaultTooltipContent = ( { data }: TooltipComponentProps ) => (
+	<>
+		{ data?.label }: { data?.valueDisplay || formatNumber( data?.value ) }
+	</>
+);
 
 export const BaseTooltip = ( {
 	data,

--- a/projects/js-packages/charts/src/components/tooltip/base-tooltip.tsx
+++ b/projects/js-packages/charts/src/components/tooltip/base-tooltip.tsx
@@ -6,6 +6,7 @@ type TooltipData = {
 	label: string;
 	value: number;
 	valueDisplay?: string;
+	percentage?: number;
 };
 
 type TooltipComponentProps = {
@@ -40,11 +41,16 @@ type CustomTooltip = {
 
 type BaseTooltipProps = TooltipCommonProps & ( DefaultDataTooltip | CustomTooltip );
 
-const DefaultTooltipContent = ( { data }: TooltipComponentProps ) => (
-	<>
-		{ data?.label }: { data?.valueDisplay || formatNumber( data?.value ) }
-	</>
-);
+const DefaultTooltipContent = ( { data }: TooltipComponentProps ) => {
+	// Display value in order of preference: valueDisplay > value
+	const displayValue = data?.valueDisplay || formatNumber( data?.value );
+
+	return (
+		<>
+			{ data?.label }: { displayValue }
+		</>
+	);
+};
 
 export const BaseTooltip = ( {
 	data,

--- a/projects/js-packages/charts/src/hooks/index.ts
+++ b/projects/js-packages/charts/src/hooks/index.ts
@@ -6,6 +6,7 @@ export { useChartMargin } from './use-chart-margin';
 export { useElementSize } from './use-element-size';
 export { useTextTruncation } from './use-text-truncation';
 export { useZeroValueDisplay } from './use-zero-value-display';
+export { useDataWithPercentages } from './use-data-with-percentages';
 export { useInteractiveLegendData } from './use-interactive-legend-data';
 export { usePrefersReducedMotion } from './use-prefers-reduced-motion';
 export { useTooltipPortalRelocator } from './use-tooltip-portal-relocator';

--- a/projects/js-packages/charts/src/hooks/use-data-with-percentages.ts
+++ b/projects/js-packages/charts/src/hooks/use-data-with-percentages.ts
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+
+interface DataPointWithValue {
+	value: number;
+}
+
+/**
+ * Hook to calculate percentages from values for chart data.
+ * Ensures percentages are always derived from values (single source of truth).
+ *
+ * @param data - Array of data points with values
+ * @return Data with calculated percentages
+ */
+export const useDataWithPercentages = < T extends DataPointWithValue >(
+	data: T[]
+): ( T & { percentage: number } )[] => {
+	return useMemo( () => {
+		const totalValue = data.reduce( ( sum, segment ) => sum + segment.value, 0 );
+		return data.map( segment => ( {
+			...segment,
+			percentage: totalValue > 0 ? ( segment.value / totalValue ) * 100 : 0,
+		} ) );
+	}, [ data ] );
+};

--- a/projects/js-packages/charts/src/hooks/use-interactive-legend-data.ts
+++ b/projects/js-packages/charts/src/hooks/use-interactive-legend-data.ts
@@ -2,12 +2,13 @@ import { useMemo } from 'react';
 
 /**
  * Data point interface for charts with interactive legends.
- * Requires label for series identification, value for calculations, and percentage for display.
+ * Requires label for series identification and value for calculations.
+ * Percentage is optional - if not provided, it's calculated from value.
  */
 interface DataPointWithPercentage {
 	label: string;
 	value: number;
-	percentage: number;
+	percentage?: number;
 }
 
 /**
@@ -33,9 +34,9 @@ interface UseInteractiveLegendDataResult< T extends DataPointWithPercentage > {
 	/** Boolean indicating if all segments are hidden */
 	allSegmentsHidden: boolean;
 	/**
-	 * Legend data with recalculated percentages for visible items.
-	 * Uses original data for hidden items, but shows recalculated percentages for visible ones.
-	 * This ensures the legend displays accurate percentages while maintaining all entries.
+	 * Legend data with stable percentage formatting.
+	 * Hidden items keep their original percentage.
+	 * Visible items show recalculated percentages that total 100%.
 	 */
 	legendData: T[];
 }
@@ -84,47 +85,55 @@ export const useInteractiveLegendData = < T extends DataPointWithPercentage >( {
 	legendInteractive,
 	isSeriesVisible,
 }: UseInteractiveLegendDataParams< T > ): UseInteractiveLegendDataResult< T > => {
+	// Calculate baseline percentages from values (for all items)
+	const baselineData = useMemo( () => {
+		const totalValue = data.reduce( ( sum, segment ) => sum + segment.value, 0 );
+		return data.map( segment => ( {
+			...segment,
+			percentage: totalValue > 0 ? ( segment.value / totalValue ) * 100 : 0,
+		} ) );
+	}, [ data ] );
+
 	// Filter and recalculate data for interactive legends
 	const visibleData = useMemo( () => {
-		// If interactive mode is disabled or no chartId, return all data unchanged
+		// If interactive mode is disabled or no chartId, return baseline data
 		if ( ! chartId || ! legendInteractive ) {
-			return data;
+			return baselineData;
 		}
 
 		// Filter to only visible segments based on legend state
-		const filtered = data.filter( segment => isSeriesVisible( chartId, segment.label ) );
+		const filtered = baselineData.filter( segment => isSeriesVisible( chartId, segment.label ) );
 
 		// If no segments are visible, return empty array
 		if ( filtered.length === 0 ) {
 			return [];
 		}
 
-		// Recalculate percentages so visible segments total 100%
+		// Recalculate percentages from values so visible segments total 100%
 		const totalValue = filtered.reduce( ( sum, segment ) => sum + segment.value, 0 );
-
 		return filtered.map( segment => ( {
 			...segment,
 			percentage: totalValue > 0 ? ( segment.value / totalValue ) * 100 : 0,
 		} ) );
-	}, [ data, chartId, isSeriesVisible, legendInteractive ] );
+	}, [ baselineData, chartId, isSeriesVisible, legendInteractive ] );
 
 	// Check if all segments are hidden (only relevant in interactive mode)
 	const allSegmentsHidden = useMemo( () => {
 		return legendInteractive && visibleData.length === 0;
 	}, [ legendInteractive, visibleData ] );
 
-	// Prepare legend data with recalculated percentages for visible items
-	// This maintains all legend entries but shows updated percentages for visible segments
+	// Prepare legend data with calculated percentages
+	// Hidden items keep their baseline percentage (calculated from all values)
+	// Visible items show recalculated percentages (totaling 100%)
 	const legendData = useMemo( () => {
 		if ( ! legendInteractive || ! chartId ) {
-			return data;
+			return baselineData;
 		}
 
-		// Map original data to show recalculated percentages for visible items
-		return data.map( segment => {
+		return baselineData.map( segment => {
 			const isVisible = isSeriesVisible( chartId, segment.label );
 			if ( ! isVisible ) {
-				// Return original data for hidden items
+				// Hidden items keep baseline percentage
 				return segment;
 			}
 
@@ -132,7 +141,7 @@ export const useInteractiveLegendData = < T extends DataPointWithPercentage >( {
 			const recalculated = visibleData.find( d => d.label === segment.label );
 			return recalculated || segment;
 		} );
-	}, [ data, visibleData, legendInteractive, chartId, isSeriesVisible ] );
+	}, [ baselineData, visibleData, legendInteractive, chartId, isSeriesVisible ] );
 
 	return { visibleData, allSegmentsHidden, legendData };
 };

--- a/projects/js-packages/charts/src/hooks/use-interactive-legend-data.ts
+++ b/projects/js-packages/charts/src/hooks/use-interactive-legend-data.ts
@@ -122,6 +122,9 @@ export const useInteractiveLegendData = < T extends DataPointWithPercentage >( {
 			return data;
 		}
 
+		// Build a Map for O(1) lookups instead of O(n) find() calls
+		const visibleDataMap = new Map( visibleData.map( d => [ d.label, d ] ) );
+
 		return data.map( segment => {
 			const isVisible = isSeriesVisible( chartId, segment.label );
 			if ( ! isVisible ) {
@@ -129,9 +132,8 @@ export const useInteractiveLegendData = < T extends DataPointWithPercentage >( {
 				return segment;
 			}
 
-			// For visible items, find the recalculated percentage from visibleData
-			const recalculated = visibleData.find( d => d.label === segment.label );
-			return recalculated || segment;
+			// For visible items, get the recalculated percentage from visibleData
+			return visibleDataMap.get( segment.label ) || segment;
 		} );
 	}, [ data, visibleData, legendInteractive, chartId, isSeriesVisible ] );
 

--- a/projects/js-packages/charts/src/hooks/use-interactive-legend-data.ts
+++ b/projects/js-packages/charts/src/hooks/use-interactive-legend-data.ts
@@ -2,20 +2,20 @@ import { useMemo } from 'react';
 
 /**
  * Data point interface for charts with interactive legends.
- * Requires label for series identification and value for calculations.
- * Percentage is optional - if not provided, it's calculated from value.
+ * Requires label for series identification, value for calculations,
+ * and percentage (should be pre-calculated by the chart component).
  */
 interface DataPointWithPercentage {
 	label: string;
 	value: number;
-	percentage?: number;
+	percentage: number;
 }
 
 /**
  * Parameters for the useInteractiveLegendData hook.
  */
 interface UseInteractiveLegendDataParams< T extends DataPointWithPercentage > {
-	/** The chart data to filter based on legend visibility */
+	/** The chart data with pre-calculated percentages */
 	data: T[];
 	/** Unique chart identifier, required for interactive legends */
 	chartId: string | undefined;
@@ -85,24 +85,16 @@ export const useInteractiveLegendData = < T extends DataPointWithPercentage >( {
 	legendInteractive,
 	isSeriesVisible,
 }: UseInteractiveLegendDataParams< T > ): UseInteractiveLegendDataResult< T > => {
-	// Calculate baseline percentages from values (for all items)
-	const baselineData = useMemo( () => {
-		const totalValue = data.reduce( ( sum, segment ) => sum + segment.value, 0 );
-		return data.map( segment => ( {
-			...segment,
-			percentage: totalValue > 0 ? ( segment.value / totalValue ) * 100 : 0,
-		} ) );
-	}, [ data ] );
-
 	// Filter and recalculate data for interactive legends
+	// Note: data should already have percentages calculated by the chart component
 	const visibleData = useMemo( () => {
-		// If interactive mode is disabled or no chartId, return baseline data
+		// If interactive mode is disabled or no chartId, return data as-is
 		if ( ! chartId || ! legendInteractive ) {
-			return baselineData;
+			return data;
 		}
 
 		// Filter to only visible segments based on legend state
-		const filtered = baselineData.filter( segment => isSeriesVisible( chartId, segment.label ) );
+		const filtered = data.filter( segment => isSeriesVisible( chartId, segment.label ) );
 
 		// If no segments are visible, return empty array
 		if ( filtered.length === 0 ) {
@@ -115,25 +107,25 @@ export const useInteractiveLegendData = < T extends DataPointWithPercentage >( {
 			...segment,
 			percentage: totalValue > 0 ? ( segment.value / totalValue ) * 100 : 0,
 		} ) );
-	}, [ baselineData, chartId, isSeriesVisible, legendInteractive ] );
+	}, [ data, chartId, isSeriesVisible, legendInteractive ] );
 
 	// Check if all segments are hidden (only relevant in interactive mode)
 	const allSegmentsHidden = useMemo( () => {
 		return legendInteractive && visibleData.length === 0;
 	}, [ legendInteractive, visibleData ] );
 
-	// Prepare legend data with calculated percentages
-	// Hidden items keep their baseline percentage (calculated from all values)
+	// Prepare legend data with percentages
+	// Hidden items keep their original percentage (calculated from all values)
 	// Visible items show recalculated percentages (totaling 100%)
 	const legendData = useMemo( () => {
 		if ( ! legendInteractive || ! chartId ) {
-			return baselineData;
+			return data;
 		}
 
-		return baselineData.map( segment => {
+		return data.map( segment => {
 			const isVisible = isSeriesVisible( chartId, segment.label );
 			if ( ! isVisible ) {
-				// Hidden items keep baseline percentage
+				// Hidden items keep original percentage
 				return segment;
 			}
 
@@ -141,7 +133,7 @@ export const useInteractiveLegendData = < T extends DataPointWithPercentage >( {
 			const recalculated = visibleData.find( d => d.label === segment.label );
 			return recalculated || segment;
 		} );
-	}, [ baselineData, visibleData, legendInteractive, chartId, isSeriesVisible ] );
+	}, [ data, visibleData, legendInteractive, chartId, isSeriesVisible ] );
 
 	return { visibleData, allSegmentsHidden, legendData };
 };

--- a/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
@@ -200,7 +200,13 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( {
 	const getElementStyles = useCallback< GlobalChartsContextValue[ 'getElementStyles' ] >(
 		( { data, index, overrideColor, legendShape } ) => {
 			const isSeriesData = data && typeof data === 'object' && 'data' in data && 'options' in data;
-			const isPointPercentageData = data && typeof data === 'object' && 'percentage' in data;
+			// DataPointPercentage has a numeric 'value' directly, unlike SeriesData which has 'data' array
+			const isPointPercentageData =
+				data &&
+				typeof data === 'object' &&
+				'value' in data &&
+				typeof data.value === 'number' &&
+				! ( 'data' in data );
 
 			return {
 				color: resolveColor( {

--- a/projects/js-packages/charts/src/stories/sample-data/index.ts
+++ b/projects/js-packages/charts/src/stories/sample-data/index.ts
@@ -750,19 +750,16 @@ export const osUsageData: DataPointPercentage[] = [
 		label: 'MacOS',
 		value: 30000,
 		valueDisplay: '30K',
-		percentage: 23,
 	},
 	{
 		label: 'Linux',
 		value: 22000,
 		valueDisplay: '22K',
-		percentage: 17,
 	},
 	{
 		label: 'Windows',
 		value: 80000,
 		valueDisplay: '80K',
-		percentage: 60,
 	},
 ];
 
@@ -779,19 +776,16 @@ export const partialOsUsageData: DataPointPercentage[] = [
 		label: 'MacOS',
 		value: 30000,
 		valueDisplay: '30K',
-		percentage: 5,
 	},
 	{
 		label: 'Linux',
 		value: 22000,
 		valueDisplay: '22K',
-		percentage: 1,
 	},
 	{
 		label: 'Windows',
 		value: 80000,
 		valueDisplay: '80K',
-		percentage: 2,
 	},
 ];
 
@@ -897,13 +891,11 @@ export const customerRevenueData: DataPointPercentage[] = [
 		label: 'New',
 		value: 302331.27,
 		valueDisplay: '$302.33K',
-		percentage: 66.97,
 	},
 	{
 		label: 'Returning',
 		value: 149111.41,
 		valueDisplay: '$149.11K',
-		percentage: 33.03,
 	},
 ];
 

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -163,17 +163,20 @@ export type DataPointPercentage = {
 	 */
 	label: string;
 	/**
-	 * Numerical value
+	 * Numerical value used for slice sizing.
+	 * Percentages are calculated automatically from values.
 	 */
 	value: number;
 	/**
-	 * Formatted value for display
+	 * Formatted value for display (e.g., "30K" instead of 30000)
 	 */
 	valueDisplay?: string;
 	/**
-	 * Percentage value
+	 * Pre-calculated percentage for display purposes (optional).
+	 * If not provided, percentage is calculated from value.
+	 * Note: This is for display only - slice sizing always uses value.
 	 */
-	percentage: number;
+	percentage?: number;
 	/**
 	 * Color code for the segment, by default colours are taken from the theme but this property can overrides it
 	 */

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -159,7 +159,7 @@ export type MultipleDataPointsDate = {
 
 /**
  * Input data point for percentage-based charts (pie, donut, semi-circle).
- * Provide values and percentages will be calculated automatically.
+ * Provide values; percentages will be calculated automatically.
  */
 export type DataPointPercentage = {
 	/**

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -157,6 +157,10 @@ export type MultipleDataPointsDate = {
 	data: DataPointDate[];
 };
 
+/**
+ * Input data point for percentage-based charts (pie, donut, semi-circle).
+ * Provide values and percentages will be calculated automatically.
+ */
 export type DataPointPercentage = {
 	/**
 	 * Label for the data point
@@ -172,12 +176,6 @@ export type DataPointPercentage = {
 	 */
 	valueDisplay?: string;
 	/**
-	 * Pre-calculated percentage for display purposes (optional).
-	 * If not provided, percentage is calculated from value.
-	 * Note: This is for display only - slice sizing always uses value.
-	 */
-	percentage?: number;
-	/**
 	 * Color code for the segment, by default colours are taken from the theme but this property can overrides it
 	 */
 	color?: string;
@@ -185,6 +183,17 @@ export type DataPointPercentage = {
 	 * Group for the data point, used to match color with groups on other charts
 	 */
 	group?: string;
+};
+
+/**
+ * Internal type with calculated percentage.
+ * Used internally after percentage calculation from values.
+ */
+export type DataPointPercentageCalculated = DataPointPercentage & {
+	/**
+	 * Calculated percentage (0-100) based on value relative to total
+	 */
+	percentage: number;
 };
 
 /**


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHARTS-190

## Proposed changes

* Remove `percentage` from `DataPointPercentage` public API — users only provide `value`, percentages are calculated automatically
* Add `DataPointPercentageCalculated` internal type for data after percentage calculation
* Add `useDataWithPercentages` hook to calculate percentages from values (shared between pie charts)
* Fix legend percentage "jumping" when toggling interactive legend items
* Simplify validation to check `totalValue > 0` instead of `percentage === 100`
* Align with industry-standard charting libraries (Chart.js, Recharts, D3)

**Problem**: The old API required both `value` and `percentage`, which could be inconsistent. For example, `{ value: 30000, percentage: 23 }` when the actual calculated percentage is 22.73%. When toggling legend items, recalculated percentages didn't match provided ones, causing visual "jumps".

**Solution**: Single source of truth — `value` drives both slice sizing AND percentage display. Percentages are always calculated from values, never provided by users.

**TypeScript changes**:
- `DataPointPercentage` (public input): `{ label, value, valueDisplay?, color?, group? }` — no percentage
- `DataPointPercentageCalculated` (internal): extends with `{ percentage: number }`
- All internal code (tooltips, legends, rendering) uses the calculated type

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* https://linear.app/a8c/issue/CHARTS-190

## Does this pull request change what data or activity we track or use?
No

## Testing instructions

### 1. Verify pie charts render correctly
* Run Storybook: `pnpm --filter=@automattic/charts storybook`
* Go to **Charts > PieChart > Docs**
* Verify pie charts render with correct proportions

### 2. Verify legend percentages are calculated
* Go to **Charts > PieChart > Legend Value Display**
* Observe legend shows percentage values (e.g., "60%", "23%", "17%")
* These should add up to 100%

### 3. Test interactive legend (the main fix)
* Go to **Charts > PieChart > Interactive Legend**
* Click a legend item to hide a segment
* **Before this PR**: Percentages would "jump" (e.g., 60% → 59.8%) because provided percentages didn't match recalculated ones
* **After this PR**: Percentages recalculate smoothly to total 100% for visible segments
* Toggle segments on/off — percentages should always be stable and consistent

### 4. Verify semi-circle chart
* Go to **Charts > PieSemiCircleChart > Interactive Legend**
* Repeat step 3 — same behavior expected

### 5. Run tests
```bash
pnpm --filter=@automattic/charts test
```
All 791 tests should pass.

### 6. Verify TypeScript types (for API consumers)
```typescript
// Before: users had to provide percentage (confusing, could be inconsistent)
const data = [
  { label: 'A', value: 60, percentage: 60 },
  { label: 'B', value: 40, percentage: 40 },
];

// After: users only provide value (cleaner API)
const data = [
  { label: 'A', value: 60 },
  { label: 'B', value: 40 },
];
// Percentages are calculated automatically
```


| Before | After |
|--------|------|
| <video src="https://github.com/user-attachments/assets/de4651a3-b44f-4ac8-95ce-32081c953108" /> | <video src="https://github.com/user-attachments/assets/c96e3223-fd09-4123-b030-968447ad331c" /> |








