### PR TITLE
Forms: Insert blocks into active step in multistep form editor

### DIFF
--- a/projects/packages/forms/changelog/fix-muiltistep-from-form-editior
+++ b/projects/packages/forms/changelog/fix-muiltistep-from-form-editior
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Form Editor: Insert new blocks into the active step in multistep forms instead of the form root

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -27,7 +27,14 @@ import {
 	restoreJetpackBlockCollection,
 } from './utils/block-collection';
 import { determineBlockNestingAction } from './utils/block-nesting-logic';
-import { BlockLock, findFormBlock, shouldLockBlock, getBlocksToMove } from './utils/block-utils';
+import {
+	BlockLock,
+	findActiveStepBlock,
+	findFormBlock,
+	isMultistepForm,
+	shouldLockBlock,
+	getBlocksToMove,
+} from './utils/block-utils';
 import {
 	moveContactFormCategoryToFront as moveCategoryToFront,
 	moveContactFormCategoryToBack as moveCategoryToBack,
@@ -272,8 +279,24 @@ const enforceBlockNesting = () => {
 		return;
 	}
 
-	// Determine what action to take based on form state and blocks to move
-	const action = determineBlockNestingAction( formBlock, blocksToMove );
+	// For multistep forms, target the active step instead of the form block directly
+	let targetBlock = formBlock;
+	let targetClientId = state.formBlockClientId;
+
+	if ( isMultistepForm( formBlock ) ) {
+		const { getActiveStepId } = select( 'jetpack/forms/single-step' ) as {
+			getActiveStepId: ( formClientId: string ) => string | null;
+		};
+		const activeStepId = getActiveStepId( state.formBlockClientId );
+		const activeStep = findActiveStepBlock( formBlock, activeStepId );
+		if ( activeStep ) {
+			targetBlock = activeStep;
+			targetClientId = activeStep.clientId;
+		}
+	}
+
+	// Determine what action to take based on target block state and blocks to move
+	const action = determineBlockNestingAction( targetBlock, blocksToMove );
 
 	const { replaceInnerBlocks, removeBlocks, __unstableMarkNextChangeAsNotPersistent } = dispatch(
 		'core/block-editor'
@@ -299,14 +322,14 @@ const enforceBlockNesting = () => {
 		return;
 	}
 
-	// Handle move-blocks case: clone blocks and insert them into the form
+	// Handle move-blocks case: clone blocks and insert them into the target
 	const clonedBlocks = blocksToMove.map( block => cloneBlock( block ) );
 
 	// Build the new inner blocks array
 	let newInnerBlocks: ReturnType< typeof createBlock >[];
 
-	if ( action.addSubmitButton ) {
-		// Form was empty, add a submit button after the moved blocks
+	if ( action.addSubmitButton && targetBlock === formBlock ) {
+		// Form was empty (non-multistep), add a submit button after the moved blocks
 		const submitButton = createBlock( 'core/button', {
 			tagName: 'button',
 			type: 'submit',
@@ -315,9 +338,13 @@ const enforceBlockNesting = () => {
 		} );
 
 		newInnerBlocks = [ ...clonedBlocks, submitButton ];
+	} else if ( action.addSubmitButton ) {
+		// Multistep step was empty — just add the blocks without a submit button
+		// (multistep forms use form-step-navigation for submission)
+		newInnerBlocks = [ ...clonedBlocks ];
 	} else {
-		// Form already has blocks, insert new blocks at the target index
-		const existingBlocks = [ ...formBlock.innerBlocks ];
+		// Target already has blocks, insert new blocks at the target index
+		const existingBlocks = [ ...targetBlock.innerBlocks ];
 		existingBlocks.splice( action.insertionIndex!, 0, ...clonedBlocks );
 		newInnerBlocks = existingBlocks;
 	}
@@ -327,10 +354,10 @@ const enforceBlockNesting = () => {
 	__unstableMarkNextChangeAsNotPersistent();
 	removeBlocks( clientIdsToRemove );
 
-	// Then use replaceInnerBlocks to set the form's inner blocks
+	// Then use replaceInnerBlocks to set the target's inner blocks
 	__unstableMarkNextChangeAsNotPersistent();
 	replaceInnerBlocks(
-		state.formBlockClientId,
+		targetClientId,
 		newInnerBlocks,
 		false // Don't update selection
 	);

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -285,10 +285,10 @@ const enforceBlockNesting = () => {
 
 	const stepContainer = findStepContainer( formBlock );
 	if ( stepContainer ) {
-		const { getActiveStepId } = select( 'jetpack/forms/single-step' ) as {
-			getActiveStepId: ( formClientId: string ) => string | null;
+		const store = select( 'jetpack/forms/single-step' ) as {
+			getActiveStepId?: ( formClientId: string ) => string | null;
 		};
-		const activeStepId = getActiveStepId( state.formBlockClientId );
+		const activeStepId = store?.getActiveStepId?.( state.formBlockClientId ) ?? null;
 		const activeStep = findActiveStepInContainer( stepContainer, activeStepId );
 		if ( activeStep ) {
 			targetBlock = activeStep;
@@ -329,7 +329,7 @@ const enforceBlockNesting = () => {
 	// Build the new inner blocks array
 	let newInnerBlocks: ReturnType< typeof createBlock >[];
 
-	if ( action.addSubmitButton && targetBlock === formBlock ) {
+	if ( action.targetWasEmpty && targetBlock === formBlock ) {
 		// Form was empty (non-multistep), add a submit button after the moved blocks
 		const submitButton = createBlock( 'core/button', {
 			tagName: 'button',
@@ -339,7 +339,7 @@ const enforceBlockNesting = () => {
 		} );
 
 		newInnerBlocks = [ ...clonedBlocks, submitButton ];
-	} else if ( action.addSubmitButton ) {
+	} else if ( action.targetWasEmpty ) {
 		// Multistep step was empty — just add the blocks without a submit button
 		// (multistep forms use form-step-navigation for submission)
 		newInnerBlocks = clonedBlocks;

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -29,9 +29,9 @@ import {
 import { determineBlockNestingAction } from './utils/block-nesting-logic';
 import {
 	BlockLock,
-	findActiveStepBlock,
+	findActiveStepInContainer,
 	findFormBlock,
-	isMultistepForm,
+	findStepContainer,
 	shouldLockBlock,
 	getBlocksToMove,
 } from './utils/block-utils';
@@ -283,12 +283,13 @@ const enforceBlockNesting = () => {
 	let targetBlock = formBlock;
 	let targetClientId = state.formBlockClientId;
 
-	if ( isMultistepForm( formBlock ) ) {
+	const stepContainer = findStepContainer( formBlock );
+	if ( stepContainer ) {
 		const { getActiveStepId } = select( 'jetpack/forms/single-step' ) as {
 			getActiveStepId: ( formClientId: string ) => string | null;
 		};
 		const activeStepId = getActiveStepId( state.formBlockClientId );
-		const activeStep = findActiveStepBlock( formBlock, activeStepId );
+		const activeStep = findActiveStepInContainer( stepContainer, activeStepId );
 		if ( activeStep ) {
 			targetBlock = activeStep;
 			targetClientId = activeStep.clientId;
@@ -341,7 +342,7 @@ const enforceBlockNesting = () => {
 	} else if ( action.addSubmitButton ) {
 		// Multistep step was empty — just add the blocks without a submit button
 		// (multistep forms use form-step-navigation for submission)
-		newInnerBlocks = [ ...clonedBlocks ];
+		newInnerBlocks = clonedBlocks;
 	} else {
 		// Target already has blocks, insert new blocks at the target index
 		const existingBlocks = [ ...targetBlock.innerBlocks ];

--- a/projects/packages/forms/src/form-editor/utils/block-nesting-logic.ts
+++ b/projects/packages/forms/src/form-editor/utils/block-nesting-logic.ts
@@ -23,9 +23,9 @@ export interface BlockNestingAction {
 	 */
 	insertionIndex?: number;
 	/**
-	 * Whether to add a submit button after the moved blocks (for move-blocks action)
+	 * Whether the target block was empty before insertion (for move-blocks action)
 	 */
-	addSubmitButton?: boolean;
+	targetWasEmpty?: boolean;
 	/**
 	 * The clientId of the existing empty paragraph to select (for dedupe-empty-paragraph action)
 	 */
@@ -40,22 +40,22 @@ export interface BlockNestingAction {
  * 2. Detecting when to add a submit button (when the form was empty/placeholder state)
  * 3. Calculating the correct insertion index (before the submit button if one exists)
  *
- * @param formBlock    - The form block that will receive the moved blocks
- * @param blocksToMove - The blocks that need to be moved into the form
+ * @param targetBlock  - The block that will receive the moved blocks (form block or step block)
+ * @param blocksToMove - The blocks that need to be moved into the target
  * @return Action object describing what to do
  */
 export function determineBlockNestingAction(
-	formBlock: Block,
+	targetBlock: Block,
 	blocksToMove: Block[]
 ): BlockNestingAction {
-	const wasEmpty = formBlock.innerBlocks.length === 0;
+	const wasEmpty = targetBlock.innerBlocks.length === 0;
 
 	// Check for dedupe-empty-paragraph case:
-	// If the only block to move is an empty paragraph and the form already has an empty
+	// If the only block to move is an empty paragraph and the target already has an empty
 	// paragraph at the end (before the submit button), just select the existing one
 	if ( ! wasEmpty && blocksToMove.length === 1 && isEmptyParagraph( blocksToMove[ 0 ] ) ) {
-		// Find the last non-button block in the form
-		const lastNonButtonBlock = [ ...formBlock.innerBlocks ]
+		// Find the last non-button block in the target
+		const lastNonButtonBlock = [ ...targetBlock.innerBlocks ]
 			.reverse()
 			.find( b => b.name !== 'jetpack/button' && b.name !== 'core/button' );
 
@@ -69,18 +69,18 @@ export function determineBlockNestingAction(
 
 	// Move blocks case
 	if ( wasEmpty ) {
-		// Form was empty (placeholder state), add a submit button after the moved blocks
+		// Form was empty (placeholder state)
 		return {
 			type: 'move-blocks',
 			insertionIndex: 0,
-			addSubmitButton: true,
+			targetWasEmpty: true,
 		};
 	}
 
 	// Form already has blocks, insert new blocks at the target index (before submit button if exists)
 	return {
 		type: 'move-blocks',
-		insertionIndex: getInsertionIndex( formBlock ),
-		addSubmitButton: false,
+		insertionIndex: getInsertionIndex( targetBlock ),
+		targetWasEmpty: false,
 	};
 }

--- a/projects/packages/forms/src/form-editor/utils/block-utils.ts
+++ b/projects/packages/forms/src/form-editor/utils/block-utils.ts
@@ -74,13 +74,23 @@ export function getBlocksToMove( blocks: Block[], formBlockClientId: string ): B
 }
 
 /**
- * Finds the step container block inside a form block.
+ * Finds the step container block inside a form block, searching recursively
+ * through nested inner blocks.
  *
  * @param formBlock - The form block to search
  * @return The step container block or null if not found
  */
 export function findStepContainer( formBlock: Block ): Block | null {
-	return formBlock.innerBlocks.find( b => b.name === 'jetpack/form-step-container' ) || null;
+	for ( const block of formBlock.innerBlocks ) {
+		if ( block.name === 'jetpack/form-step-container' ) {
+			return block;
+		}
+		const found = findStepContainer( block );
+		if ( found ) {
+			return found;
+		}
+	}
+	return null;
 }
 
 /**

--- a/projects/packages/forms/src/form-editor/utils/block-utils.ts
+++ b/projects/packages/forms/src/form-editor/utils/block-utils.ts
@@ -74,6 +74,53 @@ export function getBlocksToMove( blocks: Block[], formBlockClientId: string ): B
 }
 
 /**
+ * Finds the step container block inside a form block.
+ *
+ * @param formBlock - The form block to search
+ * @return The step container block or null if not found
+ */
+export function findStepContainer( formBlock: Block ): Block | null {
+	return formBlock.innerBlocks.find( b => b.name === 'jetpack/form-step-container' ) || null;
+}
+
+/**
+ * Checks if a form block is a multistep form (has a step container).
+ *
+ * @param formBlock - The form block to check
+ * @return True if the form contains a step container
+ */
+export function isMultistepForm( formBlock: Block ): boolean {
+	return findStepContainer( formBlock ) !== null;
+}
+
+/**
+ * Finds the active step block inside a multistep form.
+ *
+ * Traverses form → step-container → steps to find the step matching activeStepId.
+ * Falls back to the first step if no matching step is found.
+ *
+ * @param formBlock    - The form block containing the step container
+ * @param activeStepId - The client ID of the active step (from the store)
+ * @return The active step block, the first step as fallback, or null if no steps exist
+ */
+export function findActiveStepBlock( formBlock: Block, activeStepId: string | null ): Block | null {
+	const stepContainer = findStepContainer( formBlock );
+	if ( ! stepContainer || stepContainer.innerBlocks.length === 0 ) {
+		return null;
+	}
+
+	if ( activeStepId ) {
+		const activeStep = stepContainer.innerBlocks.find( b => b.clientId === activeStepId );
+		if ( activeStep ) {
+			return activeStep;
+		}
+	}
+
+	// Fall back to the first step
+	return stepContainer.innerBlocks[ 0 ];
+}
+
+/**
  * Checks if a block is an empty paragraph.
  *
  * Handles various content types: undefined, null, empty string, empty object {},

--- a/projects/packages/forms/src/form-editor/utils/block-utils.ts
+++ b/projects/packages/forms/src/form-editor/utils/block-utils.ts
@@ -84,28 +84,20 @@ export function findStepContainer( formBlock: Block ): Block | null {
 }
 
 /**
- * Checks if a form block is a multistep form (has a step container).
+ * Finds the active step block inside a step container.
  *
- * @param formBlock - The form block to check
- * @return True if the form contains a step container
- */
-export function isMultistepForm( formBlock: Block ): boolean {
-	return findStepContainer( formBlock ) !== null;
-}
-
-/**
- * Finds the active step block inside a multistep form.
- *
- * Traverses form → step-container → steps to find the step matching activeStepId.
+ * Looks for the step matching activeStepId within the container's inner blocks.
  * Falls back to the first step if no matching step is found.
  *
- * @param formBlock    - The form block containing the step container
- * @param activeStepId - The client ID of the active step (from the store)
+ * @param stepContainer - The step container block
+ * @param activeStepId  - The client ID of the active step (from the store)
  * @return The active step block, the first step as fallback, or null if no steps exist
  */
-export function findActiveStepBlock( formBlock: Block, activeStepId: string | null ): Block | null {
-	const stepContainer = findStepContainer( formBlock );
-	if ( ! stepContainer || stepContainer.innerBlocks.length === 0 ) {
+export function findActiveStepInContainer(
+	stepContainer: Block,
+	activeStepId: string | null
+): Block | null {
+	if ( stepContainer.innerBlocks.length === 0 ) {
 		return null;
 	}
 

--- a/projects/packages/forms/tests/js/form-editor/utils/block-nesting-logic.test.js
+++ b/projects/packages/forms/tests/js/form-editor/utils/block-nesting-logic.test.js
@@ -29,7 +29,7 @@ describe( 'block-nesting-logic', () => {
 				expect( result ).toEqual( {
 					type: 'move-blocks',
 					insertionIndex: 0,
-					addSubmitButton: true,
+					targetWasEmpty: true,
 				} );
 			} );
 
@@ -51,7 +51,7 @@ describe( 'block-nesting-logic', () => {
 				expect( result ).toEqual( {
 					type: 'move-blocks',
 					insertionIndex: 0,
-					addSubmitButton: true,
+					targetWasEmpty: true,
 				} );
 			} );
 
@@ -76,7 +76,7 @@ describe( 'block-nesting-logic', () => {
 				expect( result ).toEqual( {
 					type: 'move-blocks',
 					insertionIndex: 0,
-					addSubmitButton: true,
+					targetWasEmpty: true,
 				} );
 			} );
 		} );
@@ -358,7 +358,7 @@ describe( 'block-nesting-logic', () => {
 				expect( result ).toEqual( {
 					type: 'move-blocks',
 					insertionIndex: 2, // Before button at index 2
-					addSubmitButton: false,
+					targetWasEmpty: false,
 				} );
 			} );
 
@@ -381,7 +381,7 @@ describe( 'block-nesting-logic', () => {
 				expect( result ).toEqual( {
 					type: 'move-blocks',
 					insertionIndex: 1, // Before button at index 1
-					addSubmitButton: false,
+					targetWasEmpty: false,
 				} );
 			} );
 
@@ -404,7 +404,7 @@ describe( 'block-nesting-logic', () => {
 				expect( result ).toEqual( {
 					type: 'move-blocks',
 					insertionIndex: 2, // At the end
-					addSubmitButton: false,
+					targetWasEmpty: false,
 				} );
 			} );
 
@@ -428,7 +428,7 @@ describe( 'block-nesting-logic', () => {
 				expect( result ).toEqual( {
 					type: 'move-blocks',
 					insertionIndex: 1, // Before first button
-					addSubmitButton: false,
+					targetWasEmpty: false,
 				} );
 			} );
 
@@ -451,7 +451,7 @@ describe( 'block-nesting-logic', () => {
 				expect( result ).toEqual( {
 					type: 'move-blocks',
 					insertionIndex: 0, // Before button at beginning
-					addSubmitButton: false,
+					targetWasEmpty: false,
 				} );
 			} );
 		} );

--- a/projects/packages/forms/tests/js/form-editor/utils/block-utils.test.js
+++ b/projects/packages/forms/tests/js/form-editor/utils/block-utils.test.js
@@ -7,8 +7,7 @@
 import {
 	findFormBlock,
 	findStepContainer,
-	isMultistepForm,
-	findActiveStepBlock,
+	findActiveStepInContainer,
 	getInsertionIndex,
 	shouldLockBlock,
 	getBlocksToMove,
@@ -151,90 +150,40 @@ describe( 'block-utils', () => {
 		} );
 	} );
 
-	describe( 'isMultistepForm', () => {
-		test( 'returns true when form has step container', () => {
-			const formBlock = {
-				name: 'jetpack/contact-form',
-				clientId: 'form-1',
-				innerBlocks: [
-					{
-						name: 'jetpack/form-step-container',
-						clientId: 'container-1',
-						innerBlocks: [],
-					},
-				],
-			};
-
-			expect( isMultistepForm( formBlock ) ).toBe( true );
-		} );
-
-		test( 'returns false for regular form', () => {
-			const formBlock = {
-				name: 'jetpack/contact-form',
-				clientId: 'form-1',
-				innerBlocks: [ { name: 'jetpack/field-text', clientId: 'field-1', innerBlocks: [] } ],
-			};
-
-			expect( isMultistepForm( formBlock ) ).toBe( false );
-		} );
-	} );
-
-	describe( 'findActiveStepBlock', () => {
-		const formBlock = {
-			name: 'jetpack/contact-form',
-			clientId: 'form-1',
+	describe( 'findActiveStepInContainer', () => {
+		const stepContainer = {
+			name: 'jetpack/form-step-container',
+			clientId: 'container-1',
 			innerBlocks: [
-				{
-					name: 'jetpack/form-step-container',
-					clientId: 'container-1',
-					innerBlocks: [
-						{ name: 'jetpack/form-step', clientId: 'step-1', innerBlocks: [] },
-						{ name: 'jetpack/form-step', clientId: 'step-2', innerBlocks: [] },
-						{ name: 'jetpack/form-step', clientId: 'step-3', innerBlocks: [] },
-					],
-				},
+				{ name: 'jetpack/form-step', clientId: 'step-1', innerBlocks: [] },
+				{ name: 'jetpack/form-step', clientId: 'step-2', innerBlocks: [] },
+				{ name: 'jetpack/form-step', clientId: 'step-3', innerBlocks: [] },
 			],
 		};
 
 		test( 'finds the active step by ID', () => {
-			const result = findActiveStepBlock( formBlock, 'step-2' );
+			const result = findActiveStepInContainer( stepContainer, 'step-2' );
 			expect( result?.clientId ).toBe( 'step-2' );
 		} );
 
 		test( 'falls back to first step when activeStepId is null', () => {
-			const result = findActiveStepBlock( formBlock, null );
+			const result = findActiveStepInContainer( stepContainer, null );
 			expect( result?.clientId ).toBe( 'step-1' );
 		} );
 
 		test( 'falls back to first step when activeStepId not found', () => {
-			const result = findActiveStepBlock( formBlock, 'nonexistent' );
+			const result = findActiveStepInContainer( stepContainer, 'nonexistent' );
 			expect( result?.clientId ).toBe( 'step-1' );
 		} );
 
-		test( 'returns null when no step container exists', () => {
-			const regularForm = {
-				name: 'jetpack/contact-form',
-				clientId: 'form-1',
-				innerBlocks: [ { name: 'jetpack/field-text', clientId: 'field-1', innerBlocks: [] } ],
-			};
-
-			expect( findActiveStepBlock( regularForm, 'step-1' ) ).toBeNull();
-		} );
-
 		test( 'returns null when step container has no steps', () => {
-			const emptyMultistep = {
-				name: 'jetpack/contact-form',
-				clientId: 'form-1',
-				innerBlocks: [
-					{
-						name: 'jetpack/form-step-container',
-						clientId: 'container-1',
-						innerBlocks: [],
-					},
-				],
+			const emptyContainer = {
+				name: 'jetpack/form-step-container',
+				clientId: 'container-1',
+				innerBlocks: [],
 			};
 
-			expect( findActiveStepBlock( emptyMultistep, null ) ).toBeNull();
+			expect( findActiveStepInContainer( emptyContainer, null ) ).toBeNull();
 		} );
 	} );
 

--- a/projects/packages/forms/tests/js/form-editor/utils/block-utils.test.js
+++ b/projects/packages/forms/tests/js/form-editor/utils/block-utils.test.js
@@ -6,6 +6,9 @@
 
 import {
 	findFormBlock,
+	findStepContainer,
+	isMultistepForm,
+	findActiveStepBlock,
 	getInsertionIndex,
 	shouldLockBlock,
 	getBlocksToMove,
@@ -101,6 +104,137 @@ describe( 'block-utils', () => {
 				attributes: { formId: 123 },
 				customProp: 'value',
 			} );
+		} );
+	} );
+
+	describe( 'findStepContainer', () => {
+		test( 'finds step container in form block', () => {
+			const formBlock = {
+				name: 'jetpack/contact-form',
+				clientId: 'form-1',
+				innerBlocks: [
+					{ name: 'jetpack/form-progress-indicator', clientId: 'prog-1', innerBlocks: [] },
+					{
+						name: 'jetpack/form-step-container',
+						clientId: 'container-1',
+						innerBlocks: [ { name: 'jetpack/form-step', clientId: 'step-1', innerBlocks: [] } ],
+					},
+					{ name: 'jetpack/form-step-navigation', clientId: 'nav-1', innerBlocks: [] },
+				],
+			};
+
+			const result = findStepContainer( formBlock );
+			expect( result?.clientId ).toBe( 'container-1' );
+		} );
+
+		test( 'returns null when no step container exists', () => {
+			const formBlock = {
+				name: 'jetpack/contact-form',
+				clientId: 'form-1',
+				innerBlocks: [
+					{ name: 'jetpack/field-text', clientId: 'field-1', innerBlocks: [] },
+					{ name: 'core/button', clientId: 'btn-1', innerBlocks: [] },
+				],
+			};
+
+			expect( findStepContainer( formBlock ) ).toBeNull();
+		} );
+
+		test( 'returns null for empty form', () => {
+			const formBlock = {
+				name: 'jetpack/contact-form',
+				clientId: 'form-1',
+				innerBlocks: [],
+			};
+
+			expect( findStepContainer( formBlock ) ).toBeNull();
+		} );
+	} );
+
+	describe( 'isMultistepForm', () => {
+		test( 'returns true when form has step container', () => {
+			const formBlock = {
+				name: 'jetpack/contact-form',
+				clientId: 'form-1',
+				innerBlocks: [
+					{
+						name: 'jetpack/form-step-container',
+						clientId: 'container-1',
+						innerBlocks: [],
+					},
+				],
+			};
+
+			expect( isMultistepForm( formBlock ) ).toBe( true );
+		} );
+
+		test( 'returns false for regular form', () => {
+			const formBlock = {
+				name: 'jetpack/contact-form',
+				clientId: 'form-1',
+				innerBlocks: [ { name: 'jetpack/field-text', clientId: 'field-1', innerBlocks: [] } ],
+			};
+
+			expect( isMultistepForm( formBlock ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'findActiveStepBlock', () => {
+		const formBlock = {
+			name: 'jetpack/contact-form',
+			clientId: 'form-1',
+			innerBlocks: [
+				{
+					name: 'jetpack/form-step-container',
+					clientId: 'container-1',
+					innerBlocks: [
+						{ name: 'jetpack/form-step', clientId: 'step-1', innerBlocks: [] },
+						{ name: 'jetpack/form-step', clientId: 'step-2', innerBlocks: [] },
+						{ name: 'jetpack/form-step', clientId: 'step-3', innerBlocks: [] },
+					],
+				},
+			],
+		};
+
+		test( 'finds the active step by ID', () => {
+			const result = findActiveStepBlock( formBlock, 'step-2' );
+			expect( result?.clientId ).toBe( 'step-2' );
+		} );
+
+		test( 'falls back to first step when activeStepId is null', () => {
+			const result = findActiveStepBlock( formBlock, null );
+			expect( result?.clientId ).toBe( 'step-1' );
+		} );
+
+		test( 'falls back to first step when activeStepId not found', () => {
+			const result = findActiveStepBlock( formBlock, 'nonexistent' );
+			expect( result?.clientId ).toBe( 'step-1' );
+		} );
+
+		test( 'returns null when no step container exists', () => {
+			const regularForm = {
+				name: 'jetpack/contact-form',
+				clientId: 'form-1',
+				innerBlocks: [ { name: 'jetpack/field-text', clientId: 'field-1', innerBlocks: [] } ],
+			};
+
+			expect( findActiveStepBlock( regularForm, 'step-1' ) ).toBeNull();
+		} );
+
+		test( 'returns null when step container has no steps', () => {
+			const emptyMultistep = {
+				name: 'jetpack/contact-form',
+				clientId: 'form-1',
+				innerBlocks: [
+					{
+						name: 'jetpack/form-step-container',
+						clientId: 'container-1',
+						innerBlocks: [],
+					},
+				],
+			};
+
+			expect( findActiveStepBlock( emptyMultistep, null ) ).toBeNull();
 		} );
 	} );
 

--- a/projects/packages/forms/tests/js/form-editor/utils/block-utils.test.js
+++ b/projects/packages/forms/tests/js/form-editor/utils/block-utils.test.js
@@ -148,6 +148,29 @@ describe( 'block-utils', () => {
 
 			expect( findStepContainer( formBlock ) ).toBeNull();
 		} );
+
+		test( 'finds step container nested inside a child block', () => {
+			const formBlock = {
+				name: 'jetpack/contact-form',
+				clientId: 'form-1',
+				innerBlocks: [
+					{
+						name: 'core/group',
+						clientId: 'group-1',
+						innerBlocks: [
+							{
+								name: 'jetpack/form-step-container',
+								clientId: 'container-1',
+								innerBlocks: [ { name: 'jetpack/form-step', clientId: 'step-1', innerBlocks: [] } ],
+							},
+						],
+					},
+				],
+			};
+
+			const result = findStepContainer( formBlock );
+			expect( result?.clientId ).toBe( 'container-1' );
+		} );
 	} );
 
 	describe( 'findActiveStepInContainer', () => {


### PR DESCRIPTION
Fixes #

## Proposed changes

* In the form editor, when a user adds a block to a multistep form, it now gets inserted into the currently active step block instead of the form root.
* Added helper functions (`findStepContainer`, `findActiveStepInContainer`) to detect multistep forms and locate the active step. `findStepContainer` searches recursively through nested inner blocks.
* Renamed the `addSubmitButton` flag to `targetWasEmpty` in `BlockNestingAction` for clearer semantics, and renamed the `formBlock` parameter to `targetBlock` in `determineBlockNestingAction` since it now accepts either a form block or a step block.
* Added a defensive check for the `jetpack/forms/single-step` store in case it isn't registered.
* When inserting into an empty step, skip adding a submit button since multistep forms use `form-step-navigation` for submission.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. Create a new multistep form in the form editor
2. Switch to a specific step (e.g., Step 2)
3. Add a new block (e.g., a text field) from the inserter
4. Verify the block is added inside the active step, not at the form root level
5. Switch to a different step and add another block — verify it goes into that step
6. Test with a regular (non-multistep) form to confirm blocks still insert before the submit button as before