### PR TITLE
Forms: Hide tabs in wp-build dashboard when CFM is disabled

### DIFF
--- a/projects/packages/forms/changelog/update-forms-wp-build-cfm-disabled-tabs
+++ b/projects/packages/forms/changelog/update-forms-wp-build-cfm-disabled-tabs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Removes tabs from the wp-build dashboard when CFM is disabled

--- a/projects/packages/forms/routes/forms/route.tsx
+++ b/projects/packages/forms/routes/forms/route.tsx
@@ -1,9 +1,26 @@
 /**
+ * WordPress dependencies
+ */
+import { resolveSelect } from '@wordpress/data';
+import { redirect } from '@wordpress/route';
+/**
  * Internal dependencies
  */
 import { preloadGlobalTabCounts } from '../../src/dashboard/wp-build/utils/preload';
+import { CONFIG_STORE } from '../../src/store/config/index.ts';
 
 export const route = {
+	/**
+	 * Redirect to responses when Central Form Management is disabled.
+	 */
+	beforeLoad: async () => {
+		const config = await resolveSelect( CONFIG_STORE ).getConfig();
+
+		if ( ! config?.isCentralFormManagementEnabled ) {
+			throw redirect( { href: '/responses/inbox' } );
+		}
+	},
+
 	/**
 	 * Preload data before the route renders.
 	 */

--- a/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/index.tsx
@@ -11,6 +11,7 @@ import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useNavigate } from '@wordpress/route';
 import { Badge, Stack, Tabs } from '@wordpress/ui';
+import useConfigValue from '../../../../hooks/use-config-value.ts';
 import useFormStatusCounts from '../../../hooks/use-form-status-counts.ts';
 import { store as dashboardStore } from '../../../store/index.js';
 import InboxStatusToggle from '../inbox-status-toggle';
@@ -29,10 +30,13 @@ type DataViewsHeaderRowProps = {
 
 /**
  * Shared wp-build DataViews header row:
- * - Left: Forms | Responses tabs (CFM-on behavior; wp-build assumes CFM is always on)
+ * - Left: Forms | Responses tabs (only when Central Form Management is enabled)
  * - Single-form special case: show Inbox/Spam/Trash tabs instead
  * - Right: DataViews controls (Search + ViewConfig)
  * - Below: DataViews filter pills row (collapses when empty)
+ *
+ * When Central Form Management is disabled, the Forms tab is hidden and
+ * no tab bar is rendered — only the DataViews controls are shown.
  *
  * @param props                  - Props.
  * @param props.activeTab        - Which top tab is active.
@@ -50,6 +54,7 @@ export default function DataViewsHeaderRow( {
 	onStatusChange,
 }: DataViewsHeaderRowProps ): JSX.Element {
 	const navigate = useNavigate();
+	const isCFMEnabled = useConfigValue( 'isCentralFormManagementEnabled' );
 	const { all: formsCount } = useFormStatusCounts();
 
 	const responsesInboxCount = useSelect( select => {
@@ -89,26 +94,28 @@ export default function DataViewsHeaderRow( {
 							onChange={ onStatusChange ?? ( () => {} ) }
 						/>
 					) : (
-						<Tabs.Root value={ activeTab } onValueChange={ onTabChange }>
-							<Tabs.List variant="minimal">
-								<Tabs.Tab value="forms">
-									<span>
-										{ __( 'Forms', 'jetpack-forms' ) }
-										<Badge intent="draft" className="jp-forms-tabs-count">
-											{ formatNumberCompact( formsCount || 0 ) }
-										</Badge>
-									</span>
-								</Tabs.Tab>
-								<Tabs.Tab value="responses">
-									<span>
-										{ __( 'Responses', 'jetpack-forms' ) }
-										<Badge intent="draft" className="jp-forms-tabs-count">
-											{ formatNumberCompact( responsesInboxCount || 0 ) }
-										</Badge>
-									</span>
-								</Tabs.Tab>
-							</Tabs.List>
-						</Tabs.Root>
+						isCFMEnabled && (
+							<Tabs.Root value={ activeTab } onValueChange={ onTabChange }>
+								<Tabs.List variant="minimal">
+									<Tabs.Tab value="forms">
+										<span>
+											{ __( 'Forms', 'jetpack-forms' ) }
+											<Badge intent="draft" className="jp-forms-tabs-count">
+												{ formatNumberCompact( formsCount || 0 ) }
+											</Badge>
+										</span>
+									</Tabs.Tab>
+									<Tabs.Tab value="responses">
+										<span>
+											{ __( 'Responses', 'jetpack-forms' ) }
+											<Badge intent="draft" className="jp-forms-tabs-count">
+												{ formatNumberCompact( responsesInboxCount || 0 ) }
+											</Badge>
+										</span>
+									</Tabs.Tab>
+								</Tabs.List>
+							</Tabs.Root>
+						)
 					) }
 				</Stack>
 				<Stack align="center" gap="sm">


### PR DESCRIPTION
Fixes #

## Proposed changes

* When the `central-form-management` feature flag is disabled, the wp-build dashboard now hides the Forms/Responses tab bar entirely instead of showing a Forms tab with 0 entries.
* The `/forms` route redirects to `/responses/inbox` via a `beforeLoad` guard when CFM is off, preventing direct URL access to the empty Forms view.
* The Responses view loads as the default with no tab navigation when CFM is disabled.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. Enable the wp-build Forms dashboard by ensuring the `jetpack_forms_alpha` filter returns `true`.
2. **With CFM disabled** (ensure `central-form-management` is NOT in the `jetpack_block_editor_feature_flags` filter):
   - Navigate to the Forms dashboard — verify you land on the Responses view with no Forms/Responses tabs visible.
   - Try navigating directly to the `/forms` route (e.g. by editing the URL `&p=/forms`) — verify you are redirected to `/responses/inbox`.
   - Verify the DataViews controls (Search, View Config) still appear in the header.
3. **With CFM enabled** (add `central-form-management` to the `jetpack_block_editor_feature_flags` filter):
   - Navigate to the Forms dashboard — verify the Forms/Responses tabs appear as before.
   - Verify you can switch between Forms and Responses tabs normally.
   - Verify clicking a form navigates to the single-form responses view with Inbox/Spam/Trash tabs.
