### PR TITLE
Charts: Derive default legend shape from chart type in composition API

### DIFF
--- a/projects/js-packages/charts/changelog/cursor-CHARTS-192-line-chart-legend-shape-c306
+++ b/projects/js-packages/charts/changelog/cursor-CHARTS-192-line-chart-legend-shape-c306
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Derive default legend shape from chart type in composition API.

--- a/projects/js-packages/charts/src/components/legend/legend.tsx
+++ b/projects/js-packages/charts/src/components/legend/legend.tsx
@@ -5,9 +5,8 @@ import { BaseLegend } from './private';
 import type { LegendProps } from './types';
 import type { LegendShape } from '@visx/legend/lib/types';
 
-const defaultShapeByChartType: Record<
-	string,
-	Extract< LegendShape< unknown, unknown >, string >
+const defaultShapeByChartType: Partial<
+	Record< string, Extract< LegendShape< unknown, unknown >, string > >
 > = {
 	line: 'line',
 	bar: 'rect',

--- a/projects/js-packages/charts/src/components/legend/legend.tsx
+++ b/projects/js-packages/charts/src/components/legend/legend.tsx
@@ -4,8 +4,16 @@ import { GlobalChartsContext } from '../../providers';
 import { BaseLegend } from './private';
 import type { LegendProps } from './types';
 
+const defaultShapeByChartType: Record< string, 'rect' | 'circle' | 'line' > = {
+	line: 'line',
+	bar: 'rect',
+	pie: 'circle',
+	'pie-semi-circle': 'circle',
+	leaderboard: 'circle',
+};
+
 export const Legend = forwardRef< HTMLDivElement, LegendProps >(
-	( { chartId, items, ...props }, ref ) => {
+	( { chartId, items, shape, ...props }, ref ) => {
 		// Get context but don't throw if it doesn't exist
 		const context = useContext( GlobalChartsContext );
 		const singleChartContext = useContext( SingleChartContext );
@@ -14,12 +22,18 @@ export const Legend = forwardRef< HTMLDivElement, LegendProps >(
 		// When chartId is not provided, we use the context's chartId, meaning it is in a single chart context
 		const contextChartId = chartId ?? singleChartContext?.chartId;
 
-		// Use useMemo to ensure re-rendering when context changes
-		const contextItems = useMemo( () => {
+		const chartData = useMemo( () => {
 			return contextChartId && context
-				? context.getChartData( contextChartId )?.legendItems
+				? context.getChartData( contextChartId )
 				: undefined;
 		}, [ contextChartId, context ] );
+
+		const contextItems = chartData?.legendItems;
+
+		// Derive the default legend shape from the chart type when no explicit shape is provided
+		const resolvedShape = shape ?? ( chartData?.chartType
+			? defaultShapeByChartType[ chartData.chartType ]
+			: undefined );
 
 		// Provided items take precedence over context items
 		const legendItems = ( items || contextItems ) as typeof items;
@@ -28,6 +42,14 @@ export const Legend = forwardRef< HTMLDivElement, LegendProps >(
 			return null;
 		}
 
-		return <BaseLegend ref={ ref } items={ legendItems } { ...props } chartId={ contextChartId } />;
+		return (
+			<BaseLegend
+				ref={ ref }
+				items={ legendItems }
+				shape={ resolvedShape }
+				{ ...props }
+				chartId={ contextChartId }
+			/>
+		);
 	}
 );

--- a/projects/js-packages/charts/src/components/legend/legend.tsx
+++ b/projects/js-packages/charts/src/components/legend/legend.tsx
@@ -22,18 +22,17 @@ export const Legend = forwardRef< HTMLDivElement, LegendProps >(
 		// When chartId is not provided, we use the context's chartId, meaning it is in a single chart context
 		const contextChartId = chartId ?? singleChartContext?.chartId;
 
-		const chartData = useMemo( () => {
-			return contextChartId && context
-				? context.getChartData( contextChartId )
-				: undefined;
-		}, [ contextChartId, context ] );
+		const chartData = useMemo(
+			() => ( contextChartId && context ? context.getChartData( contextChartId ) : undefined ),
+			[ contextChartId, context ]
+		);
 
 		const contextItems = chartData?.legendItems;
 
 		// Derive the default legend shape from the chart type when no explicit shape is provided
-		const resolvedShape = shape ?? ( chartData?.chartType
-			? defaultShapeByChartType[ chartData.chartType ]
-			: undefined );
+		const resolvedShape =
+			shape ??
+			( chartData?.chartType ? defaultShapeByChartType[ chartData.chartType ] : undefined );
 
 		// Provided items take precedence over context items
 		const legendItems = ( items || contextItems ) as typeof items;

--- a/projects/js-packages/charts/src/components/legend/legend.tsx
+++ b/projects/js-packages/charts/src/components/legend/legend.tsx
@@ -3,10 +3,11 @@ import { SingleChartContext } from '../../charts/private/single-chart-context';
 import { GlobalChartsContext } from '../../providers';
 import { BaseLegend } from './private';
 import type { LegendProps } from './types';
+import type { ChartType } from '../../types';
 import type { LegendShape } from '@visx/legend/lib/types';
 
 const defaultShapeByChartType: Partial<
-	Record< string, Extract< LegendShape< unknown, unknown >, string > >
+	Record< ChartType, Extract< LegendShape< unknown, unknown >, string > >
 > = {
 	line: 'line',
 	bar: 'rect',

--- a/projects/js-packages/charts/src/components/legend/legend.tsx
+++ b/projects/js-packages/charts/src/components/legend/legend.tsx
@@ -3,8 +3,12 @@ import { SingleChartContext } from '../../charts/private/single-chart-context';
 import { GlobalChartsContext } from '../../providers';
 import { BaseLegend } from './private';
 import type { LegendProps } from './types';
+import type { LegendShape } from '@visx/legend/lib/types';
 
-const defaultShapeByChartType: Record< string, 'rect' | 'circle' | 'line' > = {
+const defaultShapeByChartType: Record<
+	string,
+	Extract< LegendShape< unknown, unknown >, string >
+> = {
 	line: 'line',
 	bar: 'rect',
 	pie: 'circle',

--- a/projects/js-packages/charts/src/components/legend/test/legend.test.tsx
+++ b/projects/js-packages/charts/src/components/legend/test/legend.test.tsx
@@ -481,6 +481,7 @@ describe( 'BaseLegend', () => {
 			expect( screen.getByRole( 'list' ) ).toBeInTheDocument();
 
 			const html = document.body.innerHTML;
+			expect( html ).toContain( 'background:' );
 			expect( html ).not.toContain( '<line' );
 			expect( html ).not.toContain( '<circle' );
 		} );

--- a/projects/js-packages/charts/src/components/legend/test/legend.test.tsx
+++ b/projects/js-packages/charts/src/components/legend/test/legend.test.tsx
@@ -6,6 +6,7 @@ import { SingleChartContext } from '../../../charts/private/single-chart-context
 import { GlobalChartsProvider, useChartId, useChartRegistration } from '../../../providers';
 import { Legend } from '../legend';
 import { BaseLegend } from '../private/base-legend';
+import type { ChartType } from '../../../types';
 import type { LegendProps } from '../types';
 
 const TestShape: LegendProps[ 'shape' ] = props => {
@@ -438,7 +439,13 @@ describe( 'BaseLegend', () => {
 			<span data-testid="custom-shape" style={ { color: props.fill as string } } />
 		);
 
-		const ChartRegistrar = ( { chartType, chartId }: { chartType: string; chartId: string } ) => {
+		const ChartRegistrar = ( {
+			chartType,
+			chartId,
+		}: {
+			chartType: ChartType;
+			chartId: string;
+		} ) => {
 			const resolvedId = useChartId( chartId );
 			const metadata = useMemo( () => ( {} ), [] );
 			useChartRegistration( {
@@ -452,7 +459,7 @@ describe( 'BaseLegend', () => {
 		};
 
 		const renderLegendWithChartType = (
-			chartType: string,
+			chartType: ChartType,
 			explicitShape?: LegendProps[ 'shape' ]
 		) => {
 			const chartId = `test-${ chartType }`;

--- a/projects/js-packages/charts/src/components/legend/test/legend.test.tsx
+++ b/projects/js-packages/charts/src/components/legend/test/legend.test.tsx
@@ -487,10 +487,15 @@ describe( 'BaseLegend', () => {
 			renderLegendWithChartType( 'bar' );
 			expect( screen.getByRole( 'list' ) ).toBeInTheDocument();
 
-			const html = document.body.innerHTML;
-			expect( html ).toContain( 'background:' );
-			expect( html ).not.toContain( '<line' );
-			expect( html ).not.toContain( '<circle' );
+			// visx ShapeRect renders a <div> with inline background style inside
+			// .visx-legend-shape. No testids or roles on these elements, so direct
+			// node access is necessary.
+			// eslint-disable-next-line testing-library/no-node-access
+			const shapes = document.querySelectorAll( '.visx-legend-shape > div' );
+			expect( shapes ).toHaveLength( 2 );
+			shapes.forEach( shape => {
+				expect( ( shape as HTMLElement ).style.background ).toBeTruthy();
+			} );
 		} );
 
 		it( 'uses circle shape for pie chart type', () => {

--- a/projects/js-packages/charts/src/components/legend/test/legend.test.tsx
+++ b/projects/js-packages/charts/src/components/legend/test/legend.test.tsx
@@ -6,7 +6,7 @@ import { SingleChartContext } from '../../../charts/private/single-chart-context
 import { GlobalChartsProvider, useChartId, useChartRegistration } from '../../../providers';
 import { Legend } from '../legend';
 import { BaseLegend } from '../private/base-legend';
-import { LegendProps } from '../types';
+import type { LegendProps } from '../types';
 
 const TestShape: LegendProps[ 'shape' ] = props => {
 	return (

--- a/projects/js-packages/charts/src/components/legend/test/legend.test.tsx
+++ b/projects/js-packages/charts/src/components/legend/test/legend.test.tsx
@@ -3,11 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useMemo } from 'react';
 import { SingleChartContext } from '../../../charts/private/single-chart-context';
-import {
-	GlobalChartsProvider,
-	useChartId,
-	useChartRegistration,
-} from '../../../providers';
+import { GlobalChartsProvider, useChartId, useChartRegistration } from '../../../providers';
 import { Legend } from '../legend';
 import { BaseLegend } from '../private/base-legend';
 import { LegendProps } from '../types';
@@ -438,13 +434,11 @@ describe( 'BaseLegend', () => {
 			{ label: 'Series 2', color: '#00ff00' },
 		];
 
-		const ChartRegistrar = ( {
-			chartType,
-			chartId,
-		}: {
-			chartType: string;
-			chartId: string;
-		} ) => {
+		const CustomShape: LegendProps[ 'shape' ] = props => (
+			<span data-testid="custom-shape" style={ { color: props.fill as string } } />
+		);
+
+		const ChartRegistrar = ( { chartType, chartId }: { chartType: string; chartId: string } ) => {
 			const resolvedId = useChartId( chartId );
 			const metadata = useMemo( () => ( {} ), [] );
 			useChartRegistration( {
@@ -457,16 +451,17 @@ describe( 'BaseLegend', () => {
 			return null;
 		};
 
-		const renderLegendWithChartType = ( chartType: string, explicitShape?: LegendProps[ 'shape' ] ) => {
+		const renderLegendWithChartType = (
+			chartType: string,
+			explicitShape?: LegendProps[ 'shape' ]
+		) => {
 			const chartId = `test-${ chartType }`;
 
 			return render(
 				<GlobalChartsProvider>
 					<ChartRegistrar chartType={ chartType } chartId={ chartId } />
-					<SingleChartContext.Provider
-						value={ { chartId } }
-					>
-						<Legend shape={ explicitShape } data-testid="composition-legend" />
+					<SingleChartContext.Provider value={ { chartId } }>
+						<Legend shape={ explicitShape } />
 					</SingleChartContext.Provider>
 				</GlobalChartsProvider>
 			);
@@ -474,50 +469,38 @@ describe( 'BaseLegend', () => {
 
 		it( 'uses line shape for line chart type', () => {
 			renderLegendWithChartType( 'line' );
-			const legendEl = screen.getByRole( 'list' );
-			expect( legendEl ).toBeInTheDocument();
+			expect( screen.getByRole( 'list' ) ).toBeInTheDocument();
+			expect( screen.getAllByTestId( 'legend-item' ) ).toHaveLength( 2 );
 
-			const svgs = legendEl.querySelectorAll( 'svg' );
-			const hasLineSvg = Array.from( svgs ).some( svg => {
-				return svg.querySelector( 'line' ) !== null;
-			} );
-			expect( hasLineSvg ).toBe( true );
+			const html = document.body.innerHTML;
+			expect( html ).toContain( '<line' );
 		} );
 
 		it( 'uses rect shape for bar chart type', () => {
 			renderLegendWithChartType( 'bar' );
-			const legendEl = screen.getByRole( 'list' );
-			expect( legendEl ).toBeInTheDocument();
+			expect( screen.getByRole( 'list' ) ).toBeInTheDocument();
 
-			const svgs = legendEl.querySelectorAll( 'svg' );
-			const hasLineSvg = Array.from( svgs ).some( svg => {
-				return svg.querySelector( 'line' ) !== null;
-			} );
-			expect( hasLineSvg ).toBe( false );
+			const html = document.body.innerHTML;
+			expect( html ).not.toContain( '<line' );
+			expect( html ).not.toContain( '<circle' );
 		} );
 
 		it( 'uses circle shape for pie chart type', () => {
 			renderLegendWithChartType( 'pie' );
-			const legendEl = screen.getByRole( 'list' );
-			expect( legendEl ).toBeInTheDocument();
+			expect( screen.getByRole( 'list' ) ).toBeInTheDocument();
 
-			const svgs = legendEl.querySelectorAll( 'svg' );
-			const hasLineSvg = Array.from( svgs ).some( svg => {
-				return svg.querySelector( 'line' ) !== null;
-			} );
-			expect( hasLineSvg ).toBe( false );
+			const html = document.body.innerHTML;
+			expect( html ).toContain( '<circle' );
+			expect( html ).not.toContain( '<line' );
 		} );
 
 		it( 'allows explicit shape to override chart type default', () => {
-			renderLegendWithChartType( 'line', 'circle' );
-			const legendEl = screen.getByRole( 'list' );
+			renderLegendWithChartType( 'line', CustomShape );
+			expect( screen.getByRole( 'list' ) ).toBeInTheDocument();
+			expect( screen.getAllByTestId( 'custom-shape' ) ).toHaveLength( 2 );
 
-			const svgs = legendEl.querySelectorAll( 'svg' );
-			const hasLineSvg = Array.from( svgs ).some( svg => {
-				return svg.querySelector( 'line' ) !== null;
-			} );
-
-			expect( hasLineSvg ).toBe( false );
+			const html = document.body.innerHTML;
+			expect( html ).not.toContain( '<line' );
 		} );
 	} );
 

--- a/projects/js-packages/charts/src/components/legend/test/legend.test.tsx
+++ b/projects/js-packages/charts/src/components/legend/test/legend.test.tsx
@@ -1,9 +1,16 @@
 /* eslint-disable react/jsx-no-bind */
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { GlobalChartsProvider } from '../../../providers';
+import { useMemo } from 'react';
+import { SingleChartContext } from '../../../charts/private/single-chart-context';
+import {
+	GlobalChartsProvider,
+	useChartId,
+	useChartRegistration,
+} from '../../../providers';
+import { Legend } from '../legend';
 import { BaseLegend } from '../private/base-legend';
-import type { LegendProps } from '../types';
+import { LegendProps } from '../types';
 
 const TestShape: LegendProps[ 'shape' ] = props => {
 	return (
@@ -422,6 +429,95 @@ describe( 'BaseLegend', () => {
 
 			expect( screen.getByTestId( 'custom-legend' ) ).toBeInTheDocument();
 			expect( screen.queryByTestId( 'legend-vertical' ) ).not.toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'Legend shape defaults from chart type', () => {
+		const legendItems = [
+			{ label: 'Series 1', color: '#ff0000' },
+			{ label: 'Series 2', color: '#00ff00' },
+		];
+
+		const ChartRegistrar = ( {
+			chartType,
+			chartId,
+		}: {
+			chartType: string;
+			chartId: string;
+		} ) => {
+			const resolvedId = useChartId( chartId );
+			const metadata = useMemo( () => ( {} ), [] );
+			useChartRegistration( {
+				chartId: resolvedId,
+				legendItems,
+				chartType,
+				isDataValid: true,
+				metadata,
+			} );
+			return null;
+		};
+
+		const renderLegendWithChartType = ( chartType: string, explicitShape?: LegendProps[ 'shape' ] ) => {
+			const chartId = `test-${ chartType }`;
+
+			return render(
+				<GlobalChartsProvider>
+					<ChartRegistrar chartType={ chartType } chartId={ chartId } />
+					<SingleChartContext.Provider
+						value={ { chartId } }
+					>
+						<Legend shape={ explicitShape } data-testid="composition-legend" />
+					</SingleChartContext.Provider>
+				</GlobalChartsProvider>
+			);
+		};
+
+		it( 'uses line shape for line chart type', () => {
+			renderLegendWithChartType( 'line' );
+			const legendEl = screen.getByRole( 'list' );
+			expect( legendEl ).toBeInTheDocument();
+
+			const svgs = legendEl.querySelectorAll( 'svg' );
+			const hasLineSvg = Array.from( svgs ).some( svg => {
+				return svg.querySelector( 'line' ) !== null;
+			} );
+			expect( hasLineSvg ).toBe( true );
+		} );
+
+		it( 'uses rect shape for bar chart type', () => {
+			renderLegendWithChartType( 'bar' );
+			const legendEl = screen.getByRole( 'list' );
+			expect( legendEl ).toBeInTheDocument();
+
+			const svgs = legendEl.querySelectorAll( 'svg' );
+			const hasLineSvg = Array.from( svgs ).some( svg => {
+				return svg.querySelector( 'line' ) !== null;
+			} );
+			expect( hasLineSvg ).toBe( false );
+		} );
+
+		it( 'uses circle shape for pie chart type', () => {
+			renderLegendWithChartType( 'pie' );
+			const legendEl = screen.getByRole( 'list' );
+			expect( legendEl ).toBeInTheDocument();
+
+			const svgs = legendEl.querySelectorAll( 'svg' );
+			const hasLineSvg = Array.from( svgs ).some( svg => {
+				return svg.querySelector( 'line' ) !== null;
+			} );
+			expect( hasLineSvg ).toBe( false );
+		} );
+
+		it( 'allows explicit shape to override chart type default', () => {
+			renderLegendWithChartType( 'line', 'circle' );
+			const legendEl = screen.getByRole( 'list' );
+
+			const svgs = legendEl.querySelectorAll( 'svg' );
+			const hasLineSvg = Array.from( svgs ).some( svg => {
+				return svg.querySelector( 'line' ) !== null;
+			} );
+
+			expect( hasLineSvg ).toBe( false );
 		} );
 	} );
 

--- a/projects/js-packages/charts/src/providers/chart-context/hooks/use-chart-registration.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/hooks/use-chart-registration.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo } from 'react';
 import { useDeepMemo } from '../../../hooks';
 import { useGlobalChartsContext } from './use-global-charts-context';
 import type { BaseLegendItem } from '../../../components/legend';
+import type { ChartType } from '../../../types';
 
 export const useChartRegistration = ( {
 	chartId,
@@ -12,7 +13,7 @@ export const useChartRegistration = ( {
 }: {
 	chartId: string;
 	legendItems: BaseLegendItem[];
-	chartType: string;
+	chartType: ChartType;
 	isDataValid: boolean;
 	metadata?: Record< string, unknown >;
 } ): void => {

--- a/projects/js-packages/charts/src/providers/chart-context/types.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/types.ts
@@ -1,12 +1,12 @@
 import { CSSProperties, ReactNode } from 'react';
 import type { BaseLegendItem } from '../../components/legend';
-import type { CompleteChartTheme, DataPointPercentage, SeriesData } from '../../types';
+import type { ChartType, CompleteChartTheme, DataPointPercentage, SeriesData } from '../../types';
 import type { LegendShape } from '@visx/legend/lib/types';
 import type { GlyphProps, LineStyles } from '@visx/xychart';
 
 export interface ChartRegistration {
 	legendItems: BaseLegendItem[];
-	chartType: string;
+	chartType: ChartType;
 	metadata?: Record< string, unknown >;
 }
 

--- a/projects/js-packages/charts/src/stories/legend-config.tsx
+++ b/projects/js-packages/charts/src/stories/legend-config.tsx
@@ -33,7 +33,7 @@ export const legendArgTypes = {
 	},
 	legendShape: {
 		control: { type: 'select' as const },
-		options: [ 'circle', 'rect' ],
+		options: [ 'circle', 'line', 'rect' ],
 		description: 'Shape of the legend marker icon',
 		table: { category: 'Legend' },
 	},

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -15,6 +15,14 @@ type ValueOf< T > = T[ keyof T ];
 
 export type Optional< T, K extends keyof T > = Pick< Partial< T >, K > & Omit< T, K >;
 
+export type ChartType =
+	| 'bar'
+	| 'conversion-funnel'
+	| 'leaderboard'
+	| 'line'
+	| 'pie'
+	| 'pie-semi-circle';
+
 export type OrientationType = ValueOf< typeof Orientation >;
 
 export type AnnotationStyles = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes CHARTS-192

## Proposed changes

When using the composition API (`<LineChart.Legend />`), the Legend component now automatically derives the default shape from the registered chart type. Previously, it always fell back to `'rect'` (BaseLegend default), ignoring the chart type — resulting in square legend markers for line charts instead of line-shaped ones.

* The `Legend` component now looks up the chart's `chartType` from the `GlobalChartsContext` and maps it to the appropriate default shape:
  - `line` → `'line'`
  - `bar` → `'rect'`
  - `pie` / `pie-semi-circle` / `leaderboard` → `'circle'`
* An explicit `shape` prop still overrides the derived default.
* Added focused behavioral tests verifying the shape defaulting logic.
* Added `'line'` to the `legendShape` Storybook control options — it was previously missing, so the line shape couldn't be selected via controls.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* CHARTS-192

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. Run `pnpm storybook` in `projects/js-packages/charts`.
2. Navigate to **Line Chart → With Composition Legend** — the legend markers should be horizontal line shapes, matching the **With Legend** story.
3. Navigate to **Bar Chart → With Composition Legend** — the legend markers should remain as rectangles/squares.
4. Verify that passing an explicit `shape` prop to `<LineChart.Legend shape="circle" />` overrides the default.
5. In the Storybook controls panel, verify the **Legend Shape** dropdown includes `line`, `circle`, and `rect`.

**Before (bug):** Composition API line chart legend shows square markers.
**After (fix):** Composition API line chart legend shows line-shaped markers, matching `showLegend` behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CHARTS-192](https://linear.app/a8c/issue/CHARTS-192/line-chart-legend-defaults-to-square-in-composition-api)