### PR TITLE
Forms: Fix DataViews filters missing in Responses tab due to duplicate module

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-wp-build-responses-filters
+++ b/projects/packages/forms/changelog/fix-forms-wp-build-responses-filters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix DataViews filters missing in wp-build Responses tab due to duplicate module instance from pnpm peer dependency resolution

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -10,7 +10,6 @@ import {
 } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { DataViews } from '@wordpress/dataviews';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useEffect, useMemo, useState, useCallback, useRef } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
@@ -38,6 +37,7 @@ import WpRouteDashboardSearchParamsProvider from '../../src/dashboard/router/wp-
 import { getFormEditUrl } from '../../src/dashboard/utils.ts';
 import DataViewsHeaderRow from '../../src/dashboard/wp-build/components/dataviews-header-row';
 import FormsHelpModal from '../../src/dashboard/wp-build/components/forms-help-modal';
+import { DataViews } from '../../src/dashboard/wp-build/dataviews';
 import useFormItemActions from '../../src/dashboard/wp-build/hooks/use-form-item-actions';
 import usePageHeaderDetails from '../../src/dashboard/wp-build/hooks/use-page-header-details';
 import '../../src/dashboard/wp-build/style.scss';
@@ -48,7 +48,7 @@ import './style.scss';
  * Types
  */
 import type { FormListItem } from '../../src/dashboard/hooks/use-forms-data.ts';
-import type { Action, Operator, View } from '@wordpress/dataviews';
+import type { Action, Operator, View } from '../../src/dashboard/wp-build/dataviews';
 
 /**
  * Default DataViews config for the Forms list.

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -11,7 +11,6 @@ import {
 	ExternalLink,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { DataViews } from '@wordpress/dataviews';
 import { dateI18n } from '@wordpress/date';
 import { useMemo, useState, useCallback, useEffect } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -29,6 +28,7 @@ import TextWithFlag from '../../src/dashboard/components/text-with-flag/index.ts
 import useInboxData from '../../src/dashboard/hooks/use-inbox-data.ts';
 import WpRouteDashboardSearchParamsProvider from '../../src/dashboard/router/wp-route-dashboard-search-params-provider.tsx';
 import DataViewsHeaderRow from '../../src/dashboard/wp-build/components/dataviews-header-row';
+import { DataViews } from '../../src/dashboard/wp-build/dataviews';
 import usePageHeaderDetails from '../../src/dashboard/wp-build/hooks/use-page-header-details';
 import useConfigValue from '../../src/hooks/use-config-value';
 import { INTEGRATIONS_STORE, IntegrationsSelectors } from '../../src/store/integrations';
@@ -38,8 +38,8 @@ import './style.scss';
 /**
  * Types
  */
+import type { View, Field, Action, Operator } from '../../src/dashboard/wp-build/dataviews';
 import type { FormResponse } from '../../src/types/index.ts';
-import type { View, Field, Action, Operator } from '@wordpress/dataviews';
 
 type FeedbackFilterDate = {
 	month: number;

--- a/projects/packages/forms/src/dashboard/wp-build/dataviews.ts
+++ b/projects/packages/forms/src/dashboard/wp-build/dataviews.ts
@@ -1,0 +1,14 @@
+/**
+ * Re-export `@wordpress/dataviews` from a single location.
+ *
+ * In a pnpm monorepo, route packages and the parent forms package may resolve
+ * `@wordpress/dataviews` to different physical directories (due to differing peer
+ * dependency contexts). When esbuild bundles both copies, each creates its own
+ * React context, causing DataViews sub-components (e.g. FiltersToggled) to read
+ * from the wrong context.
+ *
+ * By re-exporting here (inside `src/`), all imports resolve through the forms
+ * package's node_modules — collapsing to a single module instance.
+ */
+export { DataViews } from '@wordpress/dataviews';
+export type { View, Field, Action, Operator } from '@wordpress/dataviews';


### PR DESCRIPTION
Fixes #

## Proposed changes

* **Fix DataViews filters missing in Responses tab**: The `DataViews.FiltersToggled` container (`.jp-forms-dataviews-filters__container`) was completely absent from the DOM in the Responses tab on some environments due to a duplicate module instance bug.
  - **Root cause**: pnpm resolved `@wordpress/dataviews@11.3.0` to two different physical directories due to differing peer dependency contexts. esbuild bundled both copies, creating two separate `DataViewsContext` instances. The `<DataViews>` provider set `isShowingFilter: true` in one context, but `<DataViews.FiltersToggled>` read from the other (default `false`).
  - **Fix**: Created a re-export barrel (`src/dashboard/wp-build/dataviews.ts`) so all route imports resolve through the forms package's `node_modules/`, collapsing to a single module instance.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

To enable the flags necessary to view the test page, add the following snippet to your site:
```
add_filter( 'jetpack_forms_alpha', '__return_true' ); // Enable the wp-build dashboard

// Enable CFM
add_filter( 'jetpack_block_editor_feature_flags', 'eb_register_feature' );
function eb_register_feature( $flags ) {
    $flags['central-form-management'] = true;
    return $flags;
}
```

1. Enable the wp-build dashboard (`jetpack_forms_alpha` filter returning `true`) and the `central-form-management` feature flag.
2. Navigate to the **Responses** tab.
3. Verify the filter pills row (`.jp-forms-dataviews-filters__container`) is present in the DOM with the Folder filter (Inbox/Spam/Trash).
4. Navigate to the **Forms** tab — verify filters (Status) are also present.
5. Check both tabs render DataViews controls (Search, ViewConfig) correctly.

| Before | After |
| - | - |
| <img width="508" height="276" alt="Screenshot from 2026-03-18 22-50-37" src="https://github.com/user-attachments/assets/55362350-9711-42a8-a2b9-65aeec90a119" /> | <img width="508" height="276" alt="Screenshot from 2026-03-18 22-50-44" src="https://github.com/user-attachments/assets/f4e1a1b7-846a-49a5-ba64-a3eb808e5ae8" /> |
