### PR TITLE
Charts: Remove individual chart entry point exports for v1

### DIFF
--- a/projects/js-packages/charts/README.md
+++ b/projects/js-packages/charts/README.md
@@ -36,8 +36,6 @@ Modern bundlers handle tree-shaking automatically, so only the components you us
 
 For utilities and auxiliary components, separate entry points are available:
 
-- `@automattic/charts/legend` - Legend component
-- `@automattic/charts/tooltip` - Tooltip component
 - `@automattic/charts/trend-indicator` - Trend Indicator component
 - `@automattic/charts/hooks` - React hooks
 - `@automattic/charts/providers` - Context providers
@@ -49,8 +47,6 @@ For utilities and auxiliary components, separate entry points are available:
 #### Available Style Imports
 
 - `@automattic/charts/style.css` - All chart styles
-- `@automattic/charts/legend/style.css`
-- `@automattic/charts/tooltip/style.css`
 - `@automattic/charts/trend-indicator/style.css`
 
 ### Basic Usage Example

--- a/projects/js-packages/charts/README.md
+++ b/projects/js-packages/charts/README.md
@@ -23,51 +23,20 @@ yarn add @automattic/charts
 
 ### Importing Components
 
-You can import charts from the package in several ways depending on your needs:
-
-#### Option 1: Import everything from the main entry (includes all styles)
+Import chart components from the main entry point:
 
 ```javascript
 import { LineChart, BarChart, PieChart } from '@automattic/charts';
-import '@automattic/charts/style.css'; // Import all styles
+import '@automattic/charts/style.css';
 ```
 
-#### Option 2: Import individual components (tree-shaking friendly)
+Modern bundlers handle tree-shaking automatically, so only the components you use will be included in your bundle.
 
-For better bundle optimization, you can import components individually:
+#### Additional Entry Points
 
-```javascript
-// Import individual components
-import { LineChart } from '@automattic/charts/line-chart';
-import { BarChart } from '@automattic/charts/bar-chart';
-import { PieChart } from '@automattic/charts/pie-chart';
-import { GeoChart } from '@automattic/charts/geo-chart';
-import { Sparkline } from '@automattic/charts/sparkline';
+For utilities and auxiliary components, separate entry points are available:
 
-// Import individual component styles
-import '@automattic/charts/line-chart/style.css';
-import '@automattic/charts/bar-chart/style.css';
-import '@automattic/charts/pie-chart/style.css';
-import '@automattic/charts/geo-chart/style.css';
-import '@automattic/charts/sparkline/style.css';
-```
-
-Individual entry exports also provide easier access to chart-specific types and helpers when available. This makes it simpler to find and leverage TypeScript types, utility functions, and other chart-specific tools that are exported alongside the main component.
-
-#### Available Components and Entry Points
-
-The following components can be imported individually:
-
-- `@automattic/charts/bar-chart` - Bar Chart component
-- `@automattic/charts/bar-list-chart` - Bar List Chart component
-- `@automattic/charts/conversion-funnel-chart` - Conversion Funnel Chart component
-- `@automattic/charts/geo-chart` - Geo Chart component
-- `@automattic/charts/leaderboard-chart` - Leaderboard Chart component
 - `@automattic/charts/legend` - Legend component
-- `@automattic/charts/line-chart` - Line Chart component
-- `@automattic/charts/pie-chart` - Pie Chart component
-- `@automattic/charts/pie-semi-circle-chart` - Pie Semi-Circle Chart component
-- `@automattic/charts/sparkline` - Sparkline component
 - `@automattic/charts/tooltip` - Tooltip component
 - `@automattic/charts/trend-indicator` - Trend Indicator component
 - `@automattic/charts/hooks` - React hooks
@@ -79,18 +48,8 @@ The following components can be imported individually:
 
 #### Available Style Imports
 
-Each component has its own CSS file that can be imported individually:
-
-- `@automattic/charts/bar-chart/style.css`
-- `@automattic/charts/bar-list-chart/style.css`
-- `@automattic/charts/conversion-funnel-chart/style.css`
-- `@automattic/charts/geo-chart/style.css`
-- `@automattic/charts/leaderboard-chart/style.css`
+- `@automattic/charts/style.css` - All chart styles
 - `@automattic/charts/legend/style.css`
-- `@automattic/charts/line-chart/style.css`
-- `@automattic/charts/pie-chart/style.css`
-- `@automattic/charts/pie-semi-circle-chart/style.css`
-- `@automattic/charts/sparkline/style.css`
 - `@automattic/charts/tooltip/style.css`
 - `@automattic/charts/trend-indicator/style.css`
 
@@ -99,7 +58,7 @@ Each component has its own CSS file that can be imported individually:
 ```javascript
 import React from 'react';
 import { LineChart } from '@automattic/charts';
-import '@automattic/charts/line-chart/style.css';
+import '@automattic/charts/style.css';
 
 const data = [
 	{ date: new Date( '2024-01-01' ), value: 10 },

--- a/projects/js-packages/charts/README.md
+++ b/projects/js-packages/charts/README.md
@@ -36,7 +36,6 @@ Modern bundlers handle tree-shaking automatically, so only the components you us
 
 For utilities and auxiliary components, separate entry points are available:
 
-- `@automattic/charts/trend-indicator` - Trend Indicator component
 - `@automattic/charts/hooks` - React hooks
 - `@automattic/charts/providers` - Context providers
 - `@automattic/charts/utils` - Shared chart utility functions
@@ -47,7 +46,6 @@ For utilities and auxiliary components, separate entry points are available:
 #### Available Style Imports
 
 - `@automattic/charts/style.css` - All chart styles
-- `@automattic/charts/trend-indicator/style.css`
 
 ### Basic Usage Example
 

--- a/projects/js-packages/charts/README.md
+++ b/projects/js-packages/charts/README.md
@@ -30,7 +30,7 @@ import { LineChart, BarChart, PieChart } from '@automattic/charts';
 import '@automattic/charts/style.css';
 ```
 
-Modern bundlers handle tree-shaking automatically, so only the components you use will be included in your bundle.
+Modern bundlers tree-shake unused JavaScript automatically, so only the chart components you import are included in your bundle. Note that `style.css` includes styles for all charts.
 
 #### Additional Entry Points
 

--- a/projects/js-packages/charts/changelog/update-charts-remove-individual-exports
+++ b/projects/js-packages/charts/changelog/update-charts-remove-individual-exports
@@ -1,4 +1,4 @@
 Significance: major
 Type: removed
 
-Charts: Remove individual chart entry point exports in favor of main package export for v1.
+Charts: Remove individual chart entry point exports in favor of the main package entry point for v1.

--- a/projects/js-packages/charts/changelog/update-charts-remove-individual-exports
+++ b/projects/js-packages/charts/changelog/update-charts-remove-individual-exports
@@ -1,4 +1,4 @@
 Significance: major
 Type: removed
 
-Charts: Remove individual chart entry point exports in favor of the main package entry point for v1.
+Remove individual chart entry point exports in favor of the main package entry point for v1.

--- a/projects/js-packages/charts/changelog/update-charts-remove-individual-exports
+++ b/projects/js-packages/charts/changelog/update-charts-remove-individual-exports
@@ -1,0 +1,4 @@
+Significance: major
+Type: removed
+
+Charts: Remove individual chart entry point exports in favor of main package export for v1.

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -28,24 +28,12 @@
 			"import": "./dist/hooks/index.js",
 			"require": "./dist/hooks/index.cjs"
 		},
-		"./legend": {
-			"jetpack:src": "./src/components/legend/index.ts",
-			"import": "./dist/components/legend/index.js",
-			"require": "./dist/components/legend/index.cjs"
-		},
-		"./legend/style.css": "./dist/components/legend/index.css",
 		"./providers": {
 			"jetpack:src": "./src/providers/index.ts",
 			"import": "./dist/providers/index.js",
 			"require": "./dist/providers/index.cjs"
 		},
 		"./style.css": "./dist/index.css",
-		"./tooltip": {
-			"jetpack:src": "./src/components/tooltip/index.ts",
-			"import": "./dist/components/tooltip/index.js",
-			"require": "./dist/components/tooltip/index.cjs"
-		},
-		"./tooltip/style.css": "./dist/components/tooltip/index.css",
 		"./trend-indicator": {
 			"jetpack:src": "./src/components/trend-indicator/index.ts",
 			"import": "./dist/components/trend-indicator/index.js",
@@ -83,14 +71,8 @@
 			"hooks": [
 				"./dist/hooks/index.d.ts"
 			],
-			"legend": [
-				"./dist/components/legend/index.d.ts"
-			],
 			"providers": [
 				"./dist/providers/index.d.ts"
-			],
-			"tooltip": [
-				"./dist/components/tooltip/index.d.ts"
 			],
 			"trend-indicator": [
 				"./dist/components/trend-indicator/index.d.ts"

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -23,76 +23,22 @@
 			"import": "./dist/index.js",
 			"require": "./dist/index.cjs"
 		},
-		"./bar-chart": {
-			"jetpack:src": "./src/charts/bar-chart/index.ts",
-			"import": "./dist/charts/bar-chart/index.js",
-			"require": "./dist/charts/bar-chart/index.cjs"
-		},
-		"./bar-chart/style.css": "./dist/charts/bar-chart/index.css",
-		"./bar-list-chart": {
-			"jetpack:src": "./src/charts/bar-list-chart/index.ts",
-			"import": "./dist/charts/bar-list-chart/index.js",
-			"require": "./dist/charts/bar-list-chart/index.cjs"
-		},
-		"./bar-list-chart/style.css": "./dist/charts/bar-list-chart/index.css",
-		"./conversion-funnel-chart": {
-			"jetpack:src": "./src/charts/conversion-funnel-chart/index.ts",
-			"import": "./dist/charts/conversion-funnel-chart/index.js",
-			"require": "./dist/charts/conversion-funnel-chart/index.cjs"
-		},
-		"./conversion-funnel-chart/style.css": "./dist/charts/conversion-funnel-chart/index.css",
-		"./geo-chart": {
-			"jetpack:src": "./src/charts/geo-chart/index.ts",
-			"import": "./dist/charts/geo-chart/index.js",
-			"require": "./dist/charts/geo-chart/index.cjs"
-		},
-		"./geo-chart/style.css": "./dist/charts/geo-chart/index.css",
 		"./hooks": {
 			"jetpack:src": "./src/hooks/index.ts",
 			"import": "./dist/hooks/index.js",
 			"require": "./dist/hooks/index.cjs"
 		},
-		"./leaderboard-chart": {
-			"jetpack:src": "./src/charts/leaderboard-chart/index.ts",
-			"import": "./dist/charts/leaderboard-chart/index.js",
-			"require": "./dist/charts/leaderboard-chart/index.cjs"
-		},
-		"./leaderboard-chart/style.css": "./dist/charts/leaderboard-chart/index.css",
 		"./legend": {
 			"jetpack:src": "./src/components/legend/index.ts",
 			"import": "./dist/components/legend/index.js",
 			"require": "./dist/components/legend/index.cjs"
 		},
 		"./legend/style.css": "./dist/components/legend/index.css",
-		"./line-chart": {
-			"jetpack:src": "./src/charts/line-chart/index.ts",
-			"import": "./dist/charts/line-chart/index.js",
-			"require": "./dist/charts/line-chart/index.cjs"
-		},
-		"./line-chart/style.css": "./dist/charts/line-chart/index.css",
-		"./pie-chart": {
-			"jetpack:src": "./src/charts/pie-chart/index.ts",
-			"import": "./dist/charts/pie-chart/index.js",
-			"require": "./dist/charts/pie-chart/index.cjs"
-		},
-		"./pie-chart/style.css": "./dist/charts/pie-chart/index.css",
-		"./pie-semi-circle-chart": {
-			"jetpack:src": "./src/charts/pie-semi-circle-chart/index.ts",
-			"import": "./dist/charts/pie-semi-circle-chart/index.js",
-			"require": "./dist/charts/pie-semi-circle-chart/index.cjs"
-		},
-		"./pie-semi-circle-chart/style.css": "./dist/charts/pie-semi-circle-chart/index.css",
 		"./providers": {
 			"jetpack:src": "./src/providers/index.ts",
 			"import": "./dist/providers/index.js",
 			"require": "./dist/providers/index.cjs"
 		},
-		"./sparkline": {
-			"jetpack:src": "./src/charts/sparkline/index.ts",
-			"import": "./dist/charts/sparkline/index.js",
-			"require": "./dist/charts/sparkline/index.cjs"
-		},
-		"./sparkline/style.css": "./dist/charts/sparkline/index.css",
 		"./style.css": "./dist/index.css",
 		"./tooltip": {
 			"jetpack:src": "./src/components/tooltip/index.ts",
@@ -134,38 +80,11 @@
 			".": [
 				"./dist/index.d.ts"
 			],
-			"bar-chart": [
-				"./dist/charts/bar-chart/index.d.ts"
-			],
-			"bar-list-chart": [
-				"./dist/charts/bar-list-chart/index.d.ts"
-			],
-			"conversion-funnel-chart": [
-				"./dist/charts/conversion-funnel-chart/index.d.ts"
-			],
-			"geo-chart": [
-				"./dist/charts/geo-chart/index.d.ts"
-			],
 			"hooks": [
 				"./dist/hooks/index.d.ts"
 			],
-			"leaderboard-chart": [
-				"./dist/charts/leaderboard-chart/index.d.ts"
-			],
 			"legend": [
 				"./dist/components/legend/index.d.ts"
-			],
-			"line-chart": [
-				"./dist/charts/line-chart/index.d.ts"
-			],
-			"pie-chart": [
-				"./dist/charts/pie-chart/index.d.ts"
-			],
-			"pie-semi-circle-chart": [
-				"./dist/charts/pie-semi-circle-chart/index.d.ts"
-			],
-			"sparkline": [
-				"./dist/charts/sparkline/index.d.ts"
 			],
 			"providers": [
 				"./dist/providers/index.d.ts"

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -34,12 +34,6 @@
 			"require": "./dist/providers/index.cjs"
 		},
 		"./style.css": "./dist/index.css",
-		"./trend-indicator": {
-			"jetpack:src": "./src/components/trend-indicator/index.ts",
-			"import": "./dist/components/trend-indicator/index.js",
-			"require": "./dist/components/trend-indicator/index.cjs"
-		},
-		"./trend-indicator/style.css": "./dist/components/trend-indicator/index.css",
 		"./utils": {
 			"jetpack:src": "./src/utils/index.ts",
 			"import": "./dist/utils/index.js",
@@ -73,9 +67,6 @@
 			],
 			"providers": [
 				"./dist/providers/index.d.ts"
-			],
-			"trend-indicator": [
-				"./dist/components/trend-indicator/index.d.ts"
 			],
 			"utils": [
 				"./dist/utils/index.d.ts"

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -23,22 +23,7 @@
 			"import": "./dist/index.js",
 			"require": "./dist/index.cjs"
 		},
-		"./hooks": {
-			"jetpack:src": "./src/hooks/index.ts",
-			"import": "./dist/hooks/index.js",
-			"require": "./dist/hooks/index.cjs"
-		},
-		"./providers": {
-			"jetpack:src": "./src/providers/index.ts",
-			"import": "./dist/providers/index.js",
-			"require": "./dist/providers/index.cjs"
-		},
 		"./style.css": "./dist/index.css",
-		"./utils": {
-			"jetpack:src": "./src/utils/index.ts",
-			"import": "./dist/utils/index.js",
-			"require": "./dist/utils/index.cjs"
-		},
 		"./visx/group": {
 			"jetpack:src": "./src/visx/group/index.ts",
 			"import": "./dist/visx/group/index.js",
@@ -61,15 +46,6 @@
 		"*": {
 			".": [
 				"./dist/index.d.ts"
-			],
-			"hooks": [
-				"./dist/hooks/index.d.ts"
-			],
-			"providers": [
-				"./dist/providers/index.d.ts"
-			],
-			"utils": [
-				"./dist/utils/index.d.ts"
 			],
 			"visx/group": [
 				"./dist/visx/group/index.d.ts"

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
@@ -16,6 +16,7 @@ The Bar Chart component provides a flexible, accessible, and highly customizable
 <Source
 	language="jsx"
 	code={ `import { BarChart } from '@automattic/charts';
+import '@automattic/charts/style.css';
 
 	<BarChart
 		data={ data }

--- a/projects/js-packages/charts/src/charts/bar-list-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/bar-list-chart/stories/index.docs.mdx
@@ -16,6 +16,7 @@ The BarListChart component extends the BarChart component to create a list-style
 <Source
 	language="jsx"
 	code={ `import { BarListChart } from '@automattic/charts';
+import '@automattic/charts/style.css';
 
 	const data = [
 		{

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/stories/index.docs.mdx
@@ -25,6 +25,7 @@ The ConversionFunnelChart component provides a specialized visualization for tra
 <Source
 	language="tsx"
 	code={ `import { ConversionFunnelChart } from '@automattic/charts';
+import '@automattic/charts/style.css';
 
 	const funnelData = [
 		{ id: 'sessions', label: 'Sessions', rate: 100, count: 10000 },

--- a/projects/js-packages/charts/src/charts/geo-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/geo-chart/stories/index.docs.mdx
@@ -17,6 +17,7 @@ The Geo Chart component provides a clean, accessible solution for displaying cou
 <Source
 	language="tsx"
 	code={ `import { GeoChart } from '@automattic/charts';
+import '@automattic/charts/style.css';
 
 	<GeoChart
 		data={ ordersByCountry }

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.docs.mdx
@@ -16,6 +16,7 @@ The Leaderboard Chart component provides a clean, responsive visualization for d
 <Source
 	language="tsx"
 	code={ `import { LeaderboardChart } from '@automattic/charts';
+import '@automattic/charts/style.css';
 
 	<LeaderboardChart
 		data={data}

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
@@ -17,6 +17,7 @@ The Line Chart component provides a flexible, accessible, and highly customizabl
 <Source
 	language="jsx"
 	code={ `import { LineChart } from '@automattic/charts';
+import '@automattic/charts/style.css';
 
 	<LineChart data={ data }>
 		{/* Optional child components for advanced features */}

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/index.docs.mdx
@@ -17,6 +17,7 @@ The Pie Chart component provides a flexible, accessible, and highly customizable
 <Source
 	language="jsx"
 	code={ `import { PieChart } from '@automattic/charts';
+import '@automattic/charts/style.css';
 
     <PieChart
     	data={ data }

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/stories/index.docs.mdx
@@ -16,6 +16,7 @@ The PieSemiCircleChart component renders data as segments in a semi-circular arc
 <Source
 	language="jsx"
 	code={ `import { PieSemiCircleChart } from '@automattic/charts';
+import '@automattic/charts/style.css';
 
 	const data = [
 		{

--- a/projects/js-packages/charts/src/charts/sparkline/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/sparkline/stories/index.api.mdx
@@ -104,7 +104,7 @@ The default export is the **responsive variant** that automatically adjusts to c
 ### Named Exports
 
 ```typescript
-import { SparklineUnresponsive } from '@automattic/charts/sparkline';
+import { SparklineUnresponsive } from '@automattic/charts';
 ```
 
 **SparklineUnresponsive**: Fixed-size variant without responsive behavior. Use this when you want explicit width/height control without automatic resizing.
@@ -193,7 +193,7 @@ import type {
 	SparklineProps,
 	GradientConfig,
 	SparklineDataPoint
-} from '@automattic/charts/sparkline';
+} from '@automattic/charts';
 
 const config: GradientConfig = {
 	from: '#4CAF50',

--- a/projects/js-packages/charts/src/charts/sparkline/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/sparkline/stories/index.docs.mdx
@@ -24,6 +24,7 @@ For full control over axes, tooltips, and other features, use LineChart directly
 <Source
 	language="jsx"
 	code={ `import { Sparkline } from '@automattic/charts';
+	import '@automattic/charts/style.css';
 
 	<Sparkline
 		data={ [10, 15, 12, 18, 22, 25, 23, 28] }

--- a/projects/js-packages/charts/src/charts/sparkline/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/sparkline/stories/index.docs.mdx
@@ -24,7 +24,7 @@ For full control over axes, tooltips, and other features, use LineChart directly
 <Source
 	language="jsx"
 	code={ `import { Sparkline } from '@automattic/charts';
-	import '@automattic/charts/sparkline/style.css';
+	import '@automattic/charts/style.css';
 
 	<Sparkline
 		data={ [10, 15, 12, 18, 22, 25, 23, 28] }

--- a/projects/js-packages/charts/src/charts/sparkline/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/sparkline/stories/index.docs.mdx
@@ -24,7 +24,6 @@ For full control over axes, tooltips, and other features, use LineChart directly
 <Source
 	language="jsx"
 	code={ `import { Sparkline } from '@automattic/charts';
-	import '@automattic/charts/style.css';
 
 	<Sparkline
 		data={ [10, 15, 12, 18, 22, 25, 23, 28] }

--- a/projects/js-packages/charts/src/index.ts
+++ b/projects/js-packages/charts/src/index.ts
@@ -31,12 +31,35 @@ export {
 // Types
 export type * from './types';
 export type * from './visx/types';
+export type { BarChartProps } from './charts/bar-chart';
+export type {
+	BarListChartProps,
+	RenderLabelProps,
+	RenderValueProps,
+} from './charts/bar-list-chart';
+export type {
+	ConversionFunnelChartProps,
+	FunnelStep,
+	StepLabelRenderProps,
+	StepRateRenderProps,
+	MainMetricRenderProps,
+	TooltipRenderProps,
+} from './charts/conversion-funnel-chart';
+export type { GeoChartProps, GeoRegion, GeoResolution } from './charts/geo-chart';
+export type { LeaderboardChartProps } from './charts/leaderboard-chart';
+export type {
+	LineChartProps,
+	LineChartAnnotationProps,
+	RenderLineGlyphProps,
+	TooltipDatum,
+	CurveType,
+} from './charts/line-chart';
 export type { PieChartProps, PieChartRenderTooltipParams } from './charts/pie-chart';
 export type {
 	PieSemiCircleChartProps,
 	PieSemiCircleChartRenderTooltipParams,
 } from './charts/pie-semi-circle-chart';
-export type { GeoChartProps, GeoRegion, GeoResolution } from './charts/geo-chart';
+export type { SparklineProps, GradientConfig, SparklineDataPoint } from './charts/sparkline';
 export type {
 	LegendProps,
 	BaseLegendProps,
@@ -44,9 +67,8 @@ export type {
 	ChartLegendOptions,
 	LegendValueDisplay,
 } from './components/legend';
-export type { TrendIndicatorProps, TrendDirection } from './components/trend-indicator';
 export type { BaseTooltipProps, TooltipData, TooltipProps } from './components/tooltip';
-export type { SparklineProps, GradientConfig, SparklineDataPoint } from './charts/sparkline';
+export type { TrendIndicatorProps, TrendDirection } from './components/trend-indicator';
 export type { LineStyles, GridStyles, EventHandlerParams } from '@visx/xychart';
 export type {
 	GoogleDataTableColumn,

--- a/projects/js-packages/charts/src/index.ts
+++ b/projects/js-packages/charts/src/index.ts
@@ -10,7 +10,7 @@ export { PieSemiCircleChart, PieSemiCircleChartUnresponsive } from './charts/pie
 export { Sparkline, SparklineUnresponsive } from './charts/sparkline';
 
 // Components
-export { BaseTooltip } from './components/tooltip';
+export { BaseTooltip, AccessibleTooltip, useKeyboardNavigation } from './components/tooltip';
 export { Legend, useChartLegendItems } from './components/legend';
 export { TrendIndicator } from './components/trend-indicator';
 
@@ -37,8 +37,15 @@ export type {
 	PieSemiCircleChartRenderTooltipParams,
 } from './charts/pie-semi-circle-chart';
 export type { GeoChartProps, GeoRegion, GeoResolution } from './charts/geo-chart';
-export type { LegendValueDisplay, BaseLegendItem } from './components/legend';
+export type {
+	LegendProps,
+	BaseLegendProps,
+	BaseLegendItem,
+	ChartLegendOptions,
+	LegendValueDisplay,
+} from './components/legend';
 export type { TrendIndicatorProps, TrendDirection } from './components/trend-indicator';
+export type { BaseTooltipProps, TooltipData, TooltipProps } from './components/tooltip';
 export type { SparklineProps, GradientConfig, SparklineDataPoint } from './charts/sparkline';
 export type { LineStyles, GridStyles, EventHandlerParams } from '@visx/xychart';
 export type {

--- a/projects/js-packages/charts/src/index.ts
+++ b/projects/js-packages/charts/src/index.ts
@@ -13,6 +13,7 @@ export { Sparkline, SparklineUnresponsive } from './charts/sparkline';
 export { BaseTooltip } from './components/tooltip';
 export { Legend, useChartLegendItems } from './components/legend';
 export { TrendIndicator } from './components/trend-indicator';
+export { useLeaderboardLegendItems } from './charts/leaderboard-chart/hooks';
 
 // Compositions
 

--- a/projects/js-packages/charts/src/index.ts
+++ b/projects/js-packages/charts/src/index.ts
@@ -10,7 +10,7 @@ export { PieSemiCircleChart, PieSemiCircleChartUnresponsive } from './charts/pie
 export { Sparkline, SparklineUnresponsive } from './charts/sparkline';
 
 // Components
-export { BaseTooltip, AccessibleTooltip, useKeyboardNavigation } from './components/tooltip';
+export { BaseTooltip } from './components/tooltip';
 export { Legend, useChartLegendItems } from './components/legend';
 export { TrendIndicator } from './components/trend-indicator';
 
@@ -31,6 +31,28 @@ export {
 // Types
 export type * from './types';
 export type * from './visx/types';
+export type { PieChartProps, PieChartRenderTooltipParams } from './charts/pie-chart';
+export type {
+	PieSemiCircleChartProps,
+	PieSemiCircleChartRenderTooltipParams,
+} from './charts/pie-semi-circle-chart';
+export type { GeoChartProps, GeoRegion, GeoResolution } from './charts/geo-chart';
+export type { LegendValueDisplay, BaseLegendItem } from './components/legend';
+export type { TrendIndicatorProps, TrendDirection } from './components/trend-indicator';
+export type { LineStyles, GridStyles, EventHandlerParams } from '@visx/xychart';
+export type {
+	GoogleDataTableColumn,
+	GoogleDataTableRow,
+	GoogleDataTableColumnRoleType,
+} from 'react-google-charts';
+
+// Re-exports from removed individual entry points
+// Previously available via '@automattic/charts/tooltip', '@automattic/charts/legend'
+export { AccessibleTooltip, useKeyboardNavigation } from './components/tooltip';
+export type { BaseTooltipProps, TooltipData, TooltipProps } from './components/tooltip';
+export type { LegendProps, BaseLegendProps, ChartLegendOptions } from './components/legend';
+
+// Previously available via '@automattic/charts/bar-chart', '@automattic/charts/line-chart', etc.
 export type { BarChartProps } from './charts/bar-chart';
 export type {
 	BarListChartProps,
@@ -45,7 +67,6 @@ export type {
 	MainMetricRenderProps,
 	TooltipRenderProps,
 } from './charts/conversion-funnel-chart';
-export type { GeoChartProps, GeoRegion, GeoResolution } from './charts/geo-chart';
 export type { LeaderboardChartProps } from './charts/leaderboard-chart';
 export type {
 	LineChartProps,
@@ -54,25 +75,37 @@ export type {
 	TooltipDatum,
 	CurveType,
 } from './charts/line-chart';
-export type { PieChartProps, PieChartRenderTooltipParams } from './charts/pie-chart';
-export type {
-	PieSemiCircleChartProps,
-	PieSemiCircleChartRenderTooltipParams,
-	ArcData,
-} from './charts/pie-semi-circle-chart';
+export type { ArcData } from './charts/pie-semi-circle-chart';
 export type { SparklineProps, GradientConfig, SparklineDataPoint } from './charts/sparkline';
-export type {
-	LegendProps,
-	BaseLegendProps,
-	BaseLegendItem,
-	ChartLegendOptions,
-	LegendValueDisplay,
-} from './components/legend';
-export type { BaseTooltipProps, TooltipData, TooltipProps } from './components/tooltip';
-export type { TrendIndicatorProps, TrendDirection } from './components/trend-indicator';
-export type { LineStyles, GridStyles, EventHandlerParams } from '@visx/xychart';
-export type {
-	GoogleDataTableColumn,
-	GoogleDataTableRow,
-	GoogleDataTableColumnRoleType,
-} from 'react-google-charts';
+
+// Previously available via '@automattic/charts/hooks'
+export {
+	useDeepMemo,
+	useChartMouseHandler,
+	useXYChartTheme,
+	useChartDataTransform,
+	useChartMargin,
+	useElementSize,
+	useTextTruncation,
+	useZeroValueDisplay,
+	useInteractiveLegendData,
+	usePrefersReducedMotion,
+	useTooltipPortalRelocator,
+} from './hooks';
+
+// Previously available via '@automattic/charts/utils'
+export {
+	attachSubComponents,
+	parseAsLocalDate,
+	formatMetricValue,
+	formatPercentage,
+	getLongestTickWidth,
+	getSeriesLineStyles,
+	getSeriesStroke,
+	getItemShapeStyles,
+	isSafari,
+	mergeThemes,
+	resolveCssVariable,
+} from './utils';
+export * from './utils/color-utils';
+export type { MetricValueType } from './utils';

--- a/projects/js-packages/charts/src/index.ts
+++ b/projects/js-packages/charts/src/index.ts
@@ -39,6 +39,7 @@ export type {
 export type { GeoChartProps, GeoRegion, GeoResolution } from './charts/geo-chart';
 export type { LegendValueDisplay, BaseLegendItem } from './components/legend';
 export type { TrendIndicatorProps, TrendDirection } from './components/trend-indicator';
+export type { SparklineProps, GradientConfig, SparklineDataPoint } from './charts/sparkline';
 export type { LineStyles, GridStyles, EventHandlerParams } from '@visx/xychart';
 export type {
 	GoogleDataTableColumn,

--- a/projects/js-packages/charts/src/index.ts
+++ b/projects/js-packages/charts/src/index.ts
@@ -58,6 +58,7 @@ export type { PieChartProps, PieChartRenderTooltipParams } from './charts/pie-ch
 export type {
 	PieSemiCircleChartProps,
 	PieSemiCircleChartRenderTooltipParams,
+	ArcData,
 } from './charts/pie-semi-circle-chart';
 export type { SparklineProps, GradientConfig, SparklineDataPoint } from './charts/sparkline';
 export type {

--- a/projects/js-packages/charts/src/index.ts
+++ b/projects/js-packages/charts/src/index.ts
@@ -13,7 +13,6 @@ export { Sparkline, SparklineUnresponsive } from './charts/sparkline';
 export { BaseTooltip } from './components/tooltip';
 export { Legend, useChartLegendItems } from './components/legend';
 export { TrendIndicator } from './components/trend-indicator';
-export { useLeaderboardLegendItems } from './charts/leaderboard-chart/hooks';
 
 // Compositions
 
@@ -48,6 +47,8 @@ export type {
 } from 'react-google-charts';
 
 // Re-exports from removed individual entry points
+export { useLeaderboardLegendItems } from './charts/leaderboard-chart/hooks';
+
 // Previously available via '@automattic/charts/tooltip', '@automattic/charts/legend'
 export { AccessibleTooltip, useKeyboardNavigation } from './components/tooltip';
 export type { BaseTooltipProps, TooltipData, TooltipProps } from './components/tooltip';


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHARTS-191/remove-individual-chart-exports-for-v1

## Proposed changes

Remove individual entry point exports to simplify the package API and reduce maintenance overhead for v1:

* Remove individual chart entry points (bar-chart, line-chart, pie-chart, geo-chart, sparkline, etc.)
* Remove component entry points (legend, tooltip, trend-indicator)
* Remove utility entry points (hooks, providers, utils)
* Keep only: main entry (`.`), `./style.css`, and `./visx/*` exports
* Update documentation to reflect the simplified import pattern
* Add `style.css` import to all chart docs for consistency
* Export all chart types, component types, hooks, and utils from main entry to maintain API

### Breaking Changes

| Removed Export | Migration |
|----------------|-----------|
| `@automattic/charts/bar-chart` | `import { BarChart } from '@automattic/charts'` |
| `@automattic/charts/bar-list-chart` | `import { BarListChart } from '@automattic/charts'` |
| `@automattic/charts/conversion-funnel-chart` | `import { ConversionFunnelChart } from '@automattic/charts'` |
| `@automattic/charts/geo-chart` | `import { GeoChart } from '@automattic/charts'` |
| `@automattic/charts/leaderboard-chart` | `import { LeaderboardChart, useLeaderboardLegendItems } from '@automattic/charts'` |
| `@automattic/charts/legend` | `import { Legend } from '@automattic/charts'` |
| `@automattic/charts/line-chart` | `import { LineChart } from '@automattic/charts'` |
| `@automattic/charts/pie-chart` | `import { PieChart } from '@automattic/charts'` |
| `@automattic/charts/pie-semi-circle-chart` | `import { PieSemiCircleChart } from '@automattic/charts'` |
| `@automattic/charts/sparkline` | `import { Sparkline } from '@automattic/charts'` |
| `@automattic/charts/tooltip` | `import { BaseTooltip } from '@automattic/charts'` |
| `@automattic/charts/trend-indicator` | `import { TrendIndicator } from '@automattic/charts'` |
| `@automattic/charts/hooks` | `import { useDeepMemo, ... } from '@automattic/charts'` |
| `@automattic/charts/providers` | `import { GlobalChartsProvider, ... } from '@automattic/charts'` |
| `@automattic/charts/utils` | `import { formatMetricValue, formatPercentage, ... } from '@automattic/charts'` |

**Note:** `formatMetricValue` and `MetricValueType` were also exported from `@automattic/charts/leaderboard-chart` — these now import from the main entry point.

### Remaining Exports

| Export | Purpose |
|--------|---------|
| `.` | Main entry point with all charts, components, hooks, utils, and types |
| `./style.css` | Required stylesheet for chart styling |
| `./visx/group` | Re-export of @visx/group |
| `./visx/legend` | Re-export of @visx/legend |
| `./visx/text` | Re-export of @visx/text |

Modern bundlers tree-shake unused JavaScript effectively, so individual exports are no longer necessary. This also prevents duplicate modules/styles for consumers using multiple chart types.

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* https://linear.app/a8c/issue/CHARTS-191/remove-individual-chart-exports-for-v1

## Does this pull request change what data or activity we track or use?
No

## Testing instructions
* Build the package: `pnpm run build` in `projects/js-packages/charts`
* Run tests: `pnpm run test`
* Verify imports work from main entry: `import { LineChart, BarChart, Sparkline, useDeepMemo, formatMetricValue } from '@automattic/charts'`
* Verify visx imports still work: `import { Group } from '@automattic/charts/visx/group'`