### PR TITLE
Image Studio: Enqueue assets on `next_admin_init`

### DIFF
--- a/projects/plugins/jetpack/changelog/image-studio-ciab-opt-in-support
+++ b/projects/plugins/jetpack/changelog/image-studio-ciab-opt-in-support
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Image Studio: Add CIAB/Next Admin support via opt-in filter and next_admin_init hook.

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -35,13 +35,7 @@ const ASSET_TRANSIENT        = 'jetpack_image_studio_asset';
  * @return bool
  */
 function is_image_studio_enabled() {
-	if ( is_big_sky_enabled() ) {
-		$enabled = true;
-	} elseif ( ! has_jetpack_ai_features() ) {
-		$enabled = false;
-	} else {
-		$enabled = true;
-	}
+	$enabled = is_big_sky_enabled() || has_jetpack_ai_features();
 
 	/**
 	 * Filter whether Image Studio is available.

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -28,21 +28,32 @@ const ASSET_TRANSIENT        = 'jetpack_image_studio_asset';
 /**
  * Check if Image Studio is enabled.
  *
- * Enabled when AI features are available and either the request is from an
- * Automattician or the Big Sky plugin is active and enabled.
+ * Enabled by default when Big Sky is active or Jetpack AI features are
+ * available. The result is passed through the {@see 'jetpack_image_studio_available'}
+ * filter so consumers (e.g. CIAB / Next Admin) can opt in or out.
  *
  * @return bool
  */
 function is_image_studio_enabled() {
-	if ( is_ciab_environment() || is_big_sky_enabled() ) {
-		return true;
+	if ( is_big_sky_enabled() ) {
+		$enabled = true;
+	} elseif ( ! has_jetpack_ai_features() ) {
+		$enabled = false;
+	} else {
+		$enabled = true;
 	}
 
-	if ( ! has_jetpack_ai_features() ) {
-		return false;
-	}
-
-	return true;
+	/**
+	 * Filter whether Image Studio is available.
+	 *
+	 * Allows consumers (e.g. CIAB / Next Admin) to enable or disable
+	 * Image Studio independently of the default environment checks.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param bool $enabled Whether Image Studio is currently enabled.
+	 */
+	return (bool) apply_filters( 'jetpack_image_studio_available', $enabled );
 }
 
 /**
@@ -263,6 +274,9 @@ function do_enqueue_assets() {
 		return;
 	}
 
+	// Signal to Big Sky that Jetpack is handling Image Studio, so it skips its own loading.
+	add_filter( 'jetpack_image_studio_enabled', '__return_true', 5 );
+
 	$asset_data = get_asset_data();
 	if ( ! $asset_data ) {
 		return;
@@ -294,8 +308,9 @@ function do_enqueue_assets() {
 	);
 
 	$image_studio_data = array(
-		'enabled' => true,
-		'version' => '1.0',
+		'enabled'     => true,
+		'version'     => '1.0',
+		'environment' => is_ciab_environment() ? 'ciab-admin' : 'wp-admin',
 	);
 
 	wp_add_inline_script(
@@ -311,6 +326,18 @@ function do_enqueue_assets() {
 		$version
 	);
 }
+
+/*
+ * CIAB / Next Admin SPA context.
+ *
+ * In the CIAB SPA, admin_enqueue_scripts never fires and there is no
+ * current_screen. Assets are enqueued on next_admin_init (after the
+ * SPA's script dequeue sweep). The CIAB consumer must opt in via the
+ * jetpack_image_studio_available filter before this priority fires.
+ *
+ * Follows the same pattern as Help Center and Agents Manager.
+ */
+add_action( 'next_admin_init', __NAMESPACE__ . '\do_enqueue_assets', 1000 );
 
 /**
  * Enqueue Image Studio assets in the block editor.

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -62,12 +62,21 @@ function is_big_sky_enabled() {
 /**
  * Check if current environment is CIAB (Commerce in a Box) / Next Admin.
  *
- * Uses the same detection method as Help Center and Agents Manager
+ * On CIAB sites the entire admin is the CIAB SPA — every request runs in
+ * CIAB context — so the presence of the CIAB plugin marker constant is a
+ * sufficient signal.
+ *
+ * Note: Help Center and Agents Manager use `did_action( 'next_admin_init' )`
+ * for the same check. We can't reuse that signal because we also need to
+ * detect CIAB during REST requests (the CIAB editor calls a REST endpoint
+ * that fires `enqueue_block_editor_assets` to collect editor assets), and
+ * `next_admin_init` only fires during the CIAB SPA page render — not during
+ * REST requests.
  *
  * @return bool True if CIAB/Next Admin environment.
  */
 function is_ciab_environment() {
-	return (bool) did_action( 'next_admin_init' );
+	return defined( 'NEXT_ADMIN_PLUGIN_DIR' );
 }
 
 /**
@@ -324,10 +333,11 @@ function do_enqueue_assets() {
 /*
  * CIAB / Next Admin SPA context.
  *
- * In the CIAB SPA, admin_enqueue_scripts never fires and there is no
- * current_screen. Assets are enqueued on next_admin_init (after the
- * SPA's script dequeue sweep). The CIAB consumer must opt in via the
- * jetpack_image_studio_available filter before this priority fires.
+ * In the CIAB SPA, assets enqueued during admin_enqueue_scripts are
+ * dequeued before the SPA renders. Assets are re-enqueued on
+ * next_admin_init (after the dequeue sweep). The CIAB consumer must
+ * opt in via the jetpack_image_studio_available filter before this
+ * priority fires.
  *
  * Follows the same pattern as Help Center and Agents Manager.
  */
@@ -339,7 +349,7 @@ add_action( 'next_admin_init', __NAMESPACE__ . '\do_enqueue_assets', 1000 );
  * @return void
  */
 function enqueue_image_studio() {
-	if ( ! is_block_editor() ) {
+	if ( is_ciab_environment() || ! is_block_editor() ) {
 		return;
 	}
 
@@ -353,7 +363,7 @@ add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_image_studi
  * @return void
  */
 function enqueue_image_studio_admin() {
-	if ( ! is_media_library() ) {
+	if ( is_ciab_environment() || ! is_media_library() ) {
 		return;
 	}
 

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -7,6 +7,8 @@
 
 use Automattic\Jetpack\Extensions\ImageStudio;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 require_once JETPACK__PLUGIN_DIR . '/extensions/plugins/image-studio/image-studio.php';
 require_once JETPACK__PLUGIN_DIR . '/extensions/plugins/ai-assistant-plugin/ai-assistant-plugin.php';
@@ -287,25 +289,11 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * NOT auto-enabled in CIAB when AI features are unavailable (opt-in required).
-	 *
-	 * Disables AI features to isolate the CIAB path — without this, the
-	 * function returns true via the AI-features branch regardless of CIAB.
+	 * Enabled when opted in via the jetpack_image_studio_available filter,
+	 * even when AI features and Big Sky are unavailable.
 	 */
-	public function test_is_not_enabled_in_ciab_by_default() {
+	public function test_is_enabled_when_opted_in_via_filter() {
 		$this->disable_ai_features();
-		do_action( 'next_admin_init' );
-		$this->assertTrue( ImageStudio\is_ciab_environment() );
-		$this->assertFalse( ImageStudio\is_image_studio_enabled() );
-	}
-
-	/**
-	 * Enabled in CIAB when opted in via jetpack_image_studio_available filter,
-	 * even when AI features are unavailable.
-	 */
-	public function test_is_enabled_in_ciab_when_opted_in_via_filter() {
-		$this->disable_ai_features();
-		do_action( 'next_admin_init' );
 		add_filter( 'jetpack_image_studio_available', '__return_true' );
 		$this->assertTrue( ImageStudio\is_image_studio_enabled() );
 	}
@@ -318,6 +306,36 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 		$this->enable_big_sky();
 		add_filter( 'jetpack_image_studio_available', '__return_false' );
 		$this->assertFalse( ImageStudio\is_image_studio_enabled() );
+	}
+
+	// -------------------------------------------------------------------------
+	// is_ciab_environment() tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Default state: CIAB plugin marker constant is not defined.
+	 */
+	public function test_is_ciab_environment_false_when_constant_not_defined() {
+		$this->assertFalse( defined( 'NEXT_ADMIN_PLUGIN_DIR' ) );
+		$this->assertFalse( ImageStudio\is_ciab_environment() );
+	}
+
+	/**
+	 * CIAB detected when the plugin marker constant is defined.
+	 *
+	 * Runs in a separate process so the `define()` does not leak into other
+	 * tests — PHP constants persist for the rest of the process once set,
+	 * which would otherwise force every subsequent test into CIAB mode.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_is_ciab_environment_true_when_constant_defined() {
+		require_once JETPACK__PLUGIN_DIR . '/extensions/plugins/image-studio/image-studio.php';
+		define( 'NEXT_ADMIN_PLUGIN_DIR', '/fake/ciab/plugin' );
+		$this->assertTrue( ImageStudio\is_ciab_environment() );
 	}
 
 	// -------------------------------------------------------------------------
@@ -599,9 +617,20 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 
 	/**
 	 * Test inline script includes ciab-admin environment in CIAB context.
+	 *
+	 * Runs in a separate process so defining `NEXT_ADMIN_PLUGIN_DIR` does
+	 * not leak into other tests (see is_ciab_environment tests above).
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
 	public function test_inline_script_includes_ciab_environment() {
-		do_action( 'next_admin_init' );
+		require_once JETPACK__PLUGIN_DIR . '/extensions/plugins/image-studio/image-studio.php';
+		define( 'NEXT_ADMIN_PLUGIN_DIR', '/fake/ciab/plugin' );
+
+		$GLOBALS['wp_scripts'] = new WP_Scripts();
 		add_filter( 'jetpack_image_studio_available', '__return_true' );
 		set_transient(
 			ImageStudio\ASSET_TRANSIENT,
@@ -617,7 +646,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 		$inline = $GLOBALS['wp_scripts']->get_data( ImageStudio\FEATURE_NAME, 'before' );
 
 		$found = false;
-		foreach ( $inline as $line ) {
+		foreach ( (array) $inline as $line ) {
 			if ( is_string( $line ) && strpos( $line, 'imageStudioData' ) !== false ) {
 				$found = true;
 				$this->assertStringContainsString( '"environment":"ciab-admin"', $line );

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -73,6 +73,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	public function tear_down() {
 		delete_transient( ImageStudio\ASSET_TRANSIENT );
 		remove_all_filters( 'jetpack_image_studio_enabled' );
+		remove_all_filters( 'jetpack_image_studio_available' );
 		remove_all_filters( 'pre_http_request' );
 		remove_all_filters( 'locale' );
 		remove_all_filters( 'jetpack_ai_enabled' );
@@ -277,6 +278,48 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 		$this->assertFalse( ImageStudio\is_image_studio_enabled() );
 	}
 
+	/**
+	 * Enabled when Big Sky is active.
+	 */
+	public function test_is_enabled_via_big_sky() {
+		$this->enable_big_sky();
+		$this->assertTrue( ImageStudio\is_image_studio_enabled() );
+	}
+
+	/**
+	 * NOT auto-enabled in CIAB when AI features are unavailable (opt-in required).
+	 *
+	 * Disables AI features to isolate the CIAB path — without this, the
+	 * function returns true via the AI-features branch regardless of CIAB.
+	 */
+	public function test_is_not_enabled_in_ciab_by_default() {
+		$this->disable_ai_features();
+		do_action( 'next_admin_init' );
+		$this->assertTrue( ImageStudio\is_ciab_environment() );
+		$this->assertFalse( ImageStudio\is_image_studio_enabled() );
+	}
+
+	/**
+	 * Enabled in CIAB when opted in via jetpack_image_studio_available filter,
+	 * even when AI features are unavailable.
+	 */
+	public function test_is_enabled_in_ciab_when_opted_in_via_filter() {
+		$this->disable_ai_features();
+		do_action( 'next_admin_init' );
+		add_filter( 'jetpack_image_studio_available', '__return_true' );
+		$this->assertTrue( ImageStudio\is_image_studio_enabled() );
+	}
+
+	/**
+	 * Not enabled when filter jetpack_image_studio_available returns false,
+	 * even when other conditions (Big Sky) are met.
+	 */
+	public function test_is_not_enabled_when_filter_returns_false() {
+		$this->enable_big_sky();
+		add_filter( 'jetpack_image_studio_available', '__return_false' );
+		$this->assertFalse( ImageStudio\is_image_studio_enabled() );
+	}
+
 	// -------------------------------------------------------------------------
 	// signal_image_studio_active() tests
 	// -------------------------------------------------------------------------
@@ -297,6 +340,38 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 		$this->disable_ai_features();
 		ImageStudio\signal_image_studio_active();
 		$this->assertFalse( apply_filters( 'jetpack_image_studio_enabled', false ) );
+	}
+
+	/**
+	 * Test do_enqueue_assets also sets the Big Sky signal filter.
+	 */
+	public function test_do_enqueue_assets_sets_big_sky_signal() {
+		$this->enable_big_sky();
+		set_transient(
+			ImageStudio\ASSET_TRANSIENT,
+			array(
+				'version'      => '1.0.0',
+				'dependencies' => array(),
+			),
+			HOUR_IN_SECONDS
+		);
+
+		// Clear any signal from init hook.
+		remove_all_filters( 'jetpack_image_studio_enabled' );
+
+		ImageStudio\do_enqueue_assets();
+		$this->assertTrue( apply_filters( 'jetpack_image_studio_enabled', false ) );
+	}
+
+	/**
+	 * Test do_enqueue_assets is hooked to next_admin_init at priority 1000.
+	 */
+	public function test_do_enqueue_assets_hooked_to_next_admin_init() {
+		$priority = has_action(
+			'next_admin_init',
+			'Automattic\Jetpack\Extensions\ImageStudio\do_enqueue_assets'
+		);
+		$this->assertSame( 1000, $priority );
 	}
 
 	// -------------------------------------------------------------------------
@@ -499,6 +574,53 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 			if ( is_string( $line ) && strpos( $line, 'imageStudioData' ) !== false ) {
 				$found = true;
 				$this->assertStringContainsString( '"enabled":true', $line );
+			}
+		}
+		$this->assertTrue( $found, 'Inline script with imageStudioData not found.' );
+	}
+
+	/**
+	 * Test inline script includes wp-admin environment by default.
+	 */
+	public function test_inline_script_includes_wp_admin_environment() {
+		$this->enable_and_enqueue_block_editor();
+
+		$inline = $GLOBALS['wp_scripts']->get_data( ImageStudio\FEATURE_NAME, 'before' );
+
+		$found = false;
+		foreach ( $inline as $line ) {
+			if ( is_string( $line ) && strpos( $line, 'imageStudioData' ) !== false ) {
+				$found = true;
+				$this->assertStringContainsString( '"environment":"wp-admin"', $line );
+			}
+		}
+		$this->assertTrue( $found, 'Inline script with imageStudioData not found.' );
+	}
+
+	/**
+	 * Test inline script includes ciab-admin environment in CIAB context.
+	 */
+	public function test_inline_script_includes_ciab_environment() {
+		do_action( 'next_admin_init' );
+		add_filter( 'jetpack_image_studio_available', '__return_true' );
+		set_transient(
+			ImageStudio\ASSET_TRANSIENT,
+			array(
+				'version'      => '1.0.0',
+				'dependencies' => array(),
+			),
+			HOUR_IN_SECONDS
+		);
+
+		ImageStudio\do_enqueue_assets();
+
+		$inline = $GLOBALS['wp_scripts']->get_data( ImageStudio\FEATURE_NAME, 'before' );
+
+		$found = false;
+		foreach ( $inline as $line ) {
+			if ( is_string( $line ) && strpos( $line, 'imageStudioData' ) !== false ) {
+				$found = true;
+				$this->assertStringContainsString( '"environment":"ciab-admin"', $line );
 			}
 		}
 		$this->assertTrue( $found, 'Inline script with imageStudioData not found.' );


### PR DESCRIPTION
Part of FORNO-250

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Enqueue Image Studio assets on `next_admin_init` hook to support user in CIAB.
* Introduce a `jetpack_image_studio_available` filter to enable consumers to disable Image Studio even if the conditions to enable it are met.

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* FORNO-250

## Does this pull request change what data or activity we track or use?
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Check for regression:

* `bin/jetpack-downloader test jetpack forno-250/image-studio-ciab-support` on your sandbox
* Sandbox a simple site without Big Sky enabled
* Verify Image Studio is enabled
* Install Jetpack Beta plugin on an atomic site and select this branch
* Verify Image Studio is enabled

CIAB integration:

* Follow testing steps in `ciab-admin` PR 3814
