### PR TITLE
wpcomsh: Add function_exists() guard for wpcom_is_automattic_p2_site

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-wpcom-features-p2-function-exists-check
+++ b/projects/plugins/wpcomsh/changelog/add-wpcom-features-p2-function-exists-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add function_exists() check for wpcom_is_automattic_p2_site to prevent fatal errors when the function is undefined.

--- a/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
@@ -70,7 +70,7 @@ function wpcom_site_has_feature( $feature, $blog_id = 0 ) {
 	/*
 	 * A8C override for internal P2s
 	 */
-	if ( $feature === WPCOM_Features::AI_ASSISTANT && wpcom_is_automattic_p2_site( $blog_id ) ) {
+	if ( $feature === WPCOM_Features::AI_ASSISTANT && ( function_exists( 'wpcom_is_automattic_p2_site' ) && wpcom_is_automattic_p2_site( $blog_id ) ) ) {
 		return true;
 	}
 


### PR DESCRIPTION
Fixes #

## Proposed changes

* Add a `function_exists()` guard around the call to `wpcom_is_automattic_p2_site()` in `wpcom_site_has_feature()` to prevent fatal errors when the function is not defined.
* This matches the existing defensive pattern already used for `wpcom_is_wporg_jp_index()` on the line immediately below.

### Other information

- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Verify that the `wpcom_is_automattic_p2_site` check on line 73 of `projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php` now includes a `function_exists()` guard grouped in parentheses, matching the pattern used for `wpcom_is_wporg_jp_index` on line 80.
* Confirm the AI_ASSISTANT feature override still works correctly when `wpcom_is_automattic_p2_site()` is defined and returns true.
