### PR TITLE
Social: Add notices for X usage in the connections modal

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3556,6 +3556,12 @@ importers:
       '@wordpress/preferences':
         specifier: 4.42.0
         version: 4.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/theme':
+        specifier: 0.9.0
+        version: 0.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1)
+      '@wordpress/ui':
+        specifier: 0.9.0
+        version: 0.9.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1)
       '@wordpress/url':
         specifier: 4.42.0
         version: 4.42.0

--- a/projects/packages/publicize/_inc/components/connection-management/connection-info.tsx
+++ b/projects/packages/publicize/_inc/components/connection-management/connection-info.tsx
@@ -6,6 +6,7 @@ import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
 import { useReducer } from 'react';
 import { store as socialStore } from '../../social-store';
 import ConnectionIcon from '../connection-icon';
+import { XNotice } from '../services/x-notice';
 import { ConnectionName } from './connection-name';
 import { ConnectionStatus, ConnectionStatusProps } from './connection-status';
 import { Disconnect } from './disconnect';
@@ -79,6 +80,7 @@ export function ConnectionInfo( { connection, service, canMarkAsShared }: Connec
 							{ __( 'This connection is added by a site administrator.', 'jetpack-publicize-pkg' ) }
 						</Text>
 					) }
+					{ service?.id === 'x' && <XNotice /> }
 				</PanelBody>
 			</Panel>
 		</>

--- a/projects/packages/publicize/_inc/components/services/constants.ts
+++ b/projects/packages/publicize/_inc/components/services/constants.ts
@@ -1,0 +1,2 @@
+export const X_FREE_SHARES = 5;
+export const X_PAID_SHARES_PER_MONTH = 100;

--- a/projects/packages/publicize/_inc/components/services/service-item-notice.tsx
+++ b/projects/packages/publicize/_inc/components/services/service-item-notice.tsx
@@ -1,0 +1,25 @@
+import { Connection } from '../../social-store/types';
+import { SupportedService } from './types';
+import { XNotice } from './x-notice';
+
+export type ServicesItemNoticeProps = {
+	service: SupportedService;
+	serviceConnections: Array< Connection >;
+};
+
+/**
+ * Service item notice component
+ *
+ * @param {ServicesItemNoticeProps} props - Component props
+ *
+ * @return Service item notice component
+ */
+export function ServiceItemNotice( { service, serviceConnections }: ServicesItemNoticeProps ) {
+	switch ( service.id ) {
+		case 'x':
+			return serviceConnections.length > 0 ? <XNotice /> : null;
+
+		default:
+			return null;
+	}
+}

--- a/projects/packages/publicize/_inc/components/services/service-item.tsx
+++ b/projects/packages/publicize/_inc/components/services/service-item.tsx
@@ -7,6 +7,7 @@ import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
 import { store as socialStore } from '../../social-store';
 import { ConnectForm } from './connect-form';
 import { ServiceItemDetails, ServicesItemDetailsProps } from './service-item-details';
+import { ServiceItemNotice } from './service-item-notice';
 import { ServiceStatus } from './service-status';
 import styles from './style.module.scss';
 
@@ -118,6 +119,7 @@ export function ServiceItem( {
 			<Panel className={ styles[ 'service-panel' ] } ref={ panelRef }>
 				<PanelBody opened={ isPanelOpen } onToggle={ togglePanel }>
 					<ServiceItemDetails service={ service } serviceConnections={ serviceConnections } />
+					<ServiceItemNotice service={ service } serviceConnections={ serviceConnections } />
 					{
 						// Connect form for services that need custom inputs
 						// should be shown only if there are no broken connections

--- a/projects/packages/publicize/_inc/components/services/utils.tsx
+++ b/projects/packages/publicize/_inc/components/services/utils.tsx
@@ -12,6 +12,7 @@ import connectionsThreads from '../../assets/connections-threads.webp';
 import connectionsTumblr from '../../assets/connections-tumblr.webp';
 import { ConnectionService } from '../../types';
 import { ServiceUiDetails } from './types';
+import { XNotice } from './x-notice';
 
 /**
  * Get the UI details for a given service.
@@ -240,14 +241,15 @@ export function getServiceUiDetails( id: ConnectionService[ 'id' ] ): ServiceUiD
 			return {
 				icon: props => <SocialServiceIcon serviceName="x" { ...props } />,
 				badges: [ badgeNew ],
-				description: __( 'Share posts to X.', 'jetpack-publicize-pkg' ),
+				description: __( 'Share with your X network.', 'jetpack-publicize-pkg' ),
 				examples: [
 					() => (
 						<>
 							{ __(
-								'Reach your audience by automatically sharing your posts to X when you publish.',
+								'You asked, we listened. You can share to X directly from your Jetpack site again.',
 								'jetpack-publicize-pkg'
 							) }
+							<XNotice />
 						</>
 					),
 				],

--- a/projects/packages/publicize/_inc/components/services/x-notice.module.scss
+++ b/projects/packages/publicize/_inc/components/services/x-notice.module.scss
@@ -1,0 +1,5 @@
+@use "@wordpress/theme/design-tokens.css";
+
+.x-notice-root {
+	margin-block-start: 1rem;
+}

--- a/projects/packages/publicize/_inc/components/services/x-notice.tsx
+++ b/projects/packages/publicize/_inc/components/services/x-notice.tsx
@@ -1,0 +1,54 @@
+import '@automattic/ui/style.css';
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import { getSiteFragment } from '@automattic/jetpack-shared-extension-utils';
+import { __, sprintf } from '@wordpress/i18n';
+import { Notice } from '@wordpress/ui';
+import { hasSocialPaidFeatures } from '../../utils';
+import { X_FREE_SHARES, X_PAID_SHARES_PER_MONTH } from './constants';
+import styles from './x-notice.module.scss';
+
+/**
+ * Notice component for X service, showing different messages based on whether the user has paid features or not.
+ *
+ * @return The XNotice component.
+ */
+export function XNotice() {
+	const redirectUrl = getRedirectUrl( 'jetpack-social-basic-plan-block-editor', {
+		site: getSiteFragment() || '',
+		query: 'redirect_to=' + encodeURIComponent( window.location.href ),
+	} );
+
+	return (
+		<Notice.Root intent="info" className={ styles[ 'x-notice-root' ] }>
+			<Notice.Title>
+				{ hasSocialPaidFeatures()
+					? sprintf(
+							/* translators: %d: Number of shares included in the paid plan. */
+							__( 'Your plan includes %d shares to X per month', 'jetpack-publicize-pkg' ),
+							X_PAID_SHARES_PER_MONTH
+					  )
+					: sprintf(
+							/* translators: %d: Number of shares included in the free plan. */
+							__( 'Your free plan includes %d shares to X.', 'jetpack-publicize-pkg' ),
+							X_FREE_SHARES
+					  ) }
+			</Notice.Title>
+			<Notice.Description>
+				{ hasSocialPaidFeatures()
+					? __( 'Sharing quota resets on the 1st of each month', 'jetpack-publicize-pkg' )
+					: sprintf(
+							/* translators: %d: Number of shares included in the free plan. */
+							__( 'Need more? Paid plan includes %d shares per month.', 'jetpack-publicize-pkg' ),
+							X_PAID_SHARES_PER_MONTH
+					  ) }
+			</Notice.Description>
+			{ ! hasSocialPaidFeatures() && (
+				<Notice.Actions>
+					<Notice.ActionLink openInNewTab href={ redirectUrl }>
+						{ __( 'Compare plans', 'jetpack-publicize-pkg' ) }
+					</Notice.ActionLink>
+				</Notice.Actions>
+			) }
+		</Notice.Root>
+	);
+}

--- a/projects/packages/publicize/changelog/add-social-x-usage-notices
+++ b/projects/packages/publicize/changelog/add-social-x-usage-notices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add notices for X usage in the connections modal.

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -68,6 +68,8 @@
 		"@wordpress/notices": "5.42.0",
 		"@wordpress/plugins": "7.42.0",
 		"@wordpress/preferences": "4.42.0",
+		"@wordpress/theme": "0.9.0",
+		"@wordpress/ui": "0.9.0",
 		"@wordpress/url": "4.42.0",
 		"clsx": "2.1.1",
 		"jquery": "3.7.1",

--- a/projects/packages/publicize/webpack.config.js
+++ b/projects/packages/publicize/webpack.config.js
@@ -31,7 +31,7 @@ const socialWebpackConfig = {
 
 			// Add textdomains (but no other optimizations) for @wordpress/dataviews and its dependencies.
 			jetpackWebpackConfig.TranspileRule( {
-				includeNodeModules: [ '@wordpress/dataviews/' ],
+				includeNodeModules: [ '@wordpress/dataviews/', '@wordpress/ui' ],
 				babelOpts: {
 					configFile: false,
 					plugins: [


### PR DESCRIPTION
Completes SOCIAL-393

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Add notices for X usage in the social connections management modal and the connections list on the Social admin page.

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Ensure that your site has the required blog sticker - `add_blog_sticker( 'jetpack-social-x-connection', null, null, $blog_id );`
* Ensure that your sandbox has the credentials as mentioned in 206884-ghe-Automattic/wpcom
* Point your site to your sandbox
* Go Jetpack > Social
* Click on "Connect an account" to open the connections modal
* Expand X
* Confirm that you see the notice as per the site plan - free/paid
* Add an X account
* Confirm that you still see the notice under the connected account
* For the free plan, confirm that the Compare plan link goes to Jetpack social pricing page
* Close the modal
* Expand the X connection
* Confirm that you see the notice under the account

<table>
    <tbody>
        <tr>
            <th>Free plan</th>
            <th>Paid plan</th>
        </tr>
        <tr>
            <th colspan="2">Account not connected</th>
        </tr>
        <tr>
            <td>
<img width="1048" height="433" alt="Screenshot 2026-03-19 at 2 21 17 PM" src="https://github.com/user-attachments/assets/f0e37a70-3fac-4710-8fac-a6a13748f896" />
</td>
            <td>
<img width="1047" height="402" alt="Screenshot 2026-03-19 at 2 21 35 PM" src="https://github.com/user-attachments/assets/790aff9a-4900-4b7e-aedf-763fbce0d3b3" />
</td>
        </tr>
        <tr>
            <th colspan="2">Account connected</th>
        </tr>
        <tr>
            <td>
<img width="1048" height="465" alt="Screenshot 2026-03-19 at 2 34 06 PM" src="https://github.com/user-attachments/assets/1b47e36c-b744-4831-902d-8c03f775f99f" />
</td>
            <td>
<img width="1047" height="439" alt="Screenshot 2026-03-19 at 2 34 26 PM" src="https://github.com/user-attachments/assets/da789158-98bd-4043-86da-f2492b9bce5c" />
</td>
        </tr>
    </tbody>
</table>

Social admin page
<img width="1028" height="345" alt="image" src="https://github.com/user-attachments/assets/ed06aaae-e270-41b9-9747-745e845d65c8" />
