### PR TITLE
Update AdminPage header action buttons to use compact size

### DIFF
--- a/projects/packages/backup/changelog/update-admin-page-button-size-compact
+++ b/projects/packages/backup/changelog/update-admin-page-button-size-compact
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Backup: Update header action buttons to use compact size for consistent UI.

--- a/projects/packages/backup/src/js/components/Admin/index.js
+++ b/projects/packages/backup/src/js/components/Admin/index.js
@@ -73,7 +73,12 @@ const Admin = () => {
 
 		if ( showActivateLicenseLink ) {
 			buttons.push(
-				<Button key="activate-license" variant="secondary" href={ activateLicenseUrl }>
+				<Button
+					key="activate-license"
+					size="compact"
+					variant="secondary"
+					href={ activateLicenseUrl }
+				>
 					{ __( 'Use license key', 'jetpack-backup-pkg' ) }
 				</Button>
 			);

--- a/projects/packages/backup/src/js/components/back-up-now/index.jsx
+++ b/projects/packages/backup/src/js/components/back-up-now/index.jsx
@@ -83,6 +83,7 @@ export const BackupNowButton = ( { children, tooltipText, tracksEventName, onCli
 	const button = (
 		<div>
 			<Button
+				size="compact"
 				accessibleWhenDisabled
 				disabled={ disabled }
 				isBusy={ isEnqueuing || backupCurrentlyInProgress }

--- a/projects/packages/publicize/_inc/components/admin-page/index.tsx
+++ b/projects/packages/publicize/_inc/components/admin-page/index.tsx
@@ -84,7 +84,7 @@ export const SocialAdminPage = () => {
 	const subTitle = __( 'Publish once. Share everywhere.', 'jetpack-publicize-pkg' );
 
 	const licenseAction = ! hasSocialPaidFeatures() && isJetpackSite && (
-		<Button variant="secondary" href={ getMyJetpackUrl( '#/add-license' ) }>
+		<Button size="compact" variant="secondary" href={ getMyJetpackUrl( '#/add-license' ) }>
 			{ __( 'Use license key', 'jetpack-publicize-pkg' ) }
 		</Button>
 	);

--- a/projects/packages/publicize/changelog/update-admin-page-button-size-compact
+++ b/projects/packages/publicize/changelog/update-admin-page-button-size-compact
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Publicize: Update header action buttons to use compact size for consistent UI.

--- a/projects/packages/search/changelog/update-admin-page-button-size-compact
+++ b/projects/packages/search/changelog/update-admin-page-button-size-compact
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search: Update header action buttons to use compact size for consistent UI.

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -118,7 +118,7 @@ export default function DashboardPage( { isLoading = false } ) {
 						) }
 						actions={
 							( ( isNewPricing && isFreePlan ) || ! supportsInstantSearch ) && (
-								<Button variant="link" onClick={ sendPaidPlanToCart }>
+								<Button size="compact" variant="link" onClick={ sendPaidPlanToCart }>
 									{ __( 'Upgrade Jetpack Search', 'jetpack-search-pkg' ) }
 								</Button>
 							)

--- a/projects/packages/search/src/dashboard/components/pages/upsell-page/index.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/upsell-page/index.jsx
@@ -105,7 +105,7 @@ export default function UpsellPage( { isLoading = false } ) {
 					) }
 					actions={
 						! isWpcom && (
-							<Button variant="secondary" href={ activateLicenseUrl }>
+							<Button size="compact" variant="secondary" href={ activateLicenseUrl }>
 								{ __( 'Use license key', 'jetpack-search-pkg' ) }
 							</Button>
 						)

--- a/projects/plugins/boost/app/assets/src/js/layout/boost-admin-page/boost-admin-page.tsx
+++ b/projects/plugins/boost/app/assets/src/js/layout/boost-admin-page/boost-admin-page.tsx
@@ -22,7 +22,7 @@ const BoostAdminPage = ( {
 
 	const licenseAction =
 		showActivateLicense && ! isWoaHosting() && ! hasPlan ? (
-			<Button variant="secondary" href={ activateLicenseUrl }>
+			<Button size="compact" variant="secondary" href={ activateLicenseUrl }>
 				{ __( 'Use license key', 'jetpack-boost' ) }
 			</Button>
 		) : undefined;

--- a/projects/plugins/boost/changelog/update-admin-page-button-size-compact
+++ b/projects/plugins/boost/changelog/update-admin-page-button-size-compact
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update header button size to compact.


### PR DESCRIPTION
Sets `size="compact"` on all Button ([docs](https://wordpress.github.io/gutenberg/?path=/docs/components-button--docs)) components passed to AdminPage actions prop for consistent UI styling across Backup, Publicize, Search, and Boost admin pages.

Resolves JETPACK-1480

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Update all buttons used in header actions to be "compact" size.

Before
<img width="882" height="105" alt="Screenshot 2026-03-19 at 13 19 37" src="https://github.com/user-attachments/assets/d8ac6d9c-04a7-479c-9b34-3c098297c9aa" />


After
<img width="880" height="107" alt="Screenshot 2026-03-19 at 13 19 30" src="https://github.com/user-attachments/assets/b2dbee60-f165-457d-87c4-4595c76e5fa0" />

Slight difference in spacing between title/subheading is covered with ticket JETPACK-1482


### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Just see header buttons continue work across Social, Boost, Backup, Search
