### PR TITLE
VideoPress: Add capability check to upload token AJAX handlers

### DIFF
--- a/projects/packages/videopress/changelog/vidp-230-videopress-uploader-skips-per-user-connection-check
+++ b/projects/packages/videopress/changelog/vidp-230-videopress-uploader-skips-per-user-connection-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Add upload_files capability check to VideoPress upload token AJAX handlers.

--- a/projects/packages/videopress/changelog/vidp-230-videopress-uploader-skips-per-user-connection-check
+++ b/projects/packages/videopress/changelog/vidp-230-videopress-uploader-skips-per-user-connection-check
@@ -1,4 +1,4 @@
 Significance: patch
 Type: security
 
-Add upload_files capability check to VideoPress upload token AJAX handlers.
+Ensure only users who can upload media can request VideoPress upload tokens via AJAX.

--- a/projects/packages/videopress/src/class-ajax.php
+++ b/projects/packages/videopress/src/class-ajax.php
@@ -173,6 +173,12 @@ class AJAX {
 	 * @return void
 	 */
 	public function wp_ajax_videopress_get_upload_jwt() {
+		if ( ! current_user_can( 'upload_files' ) ) {
+			// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- It takes null, but its phpdoc only says int.
+			wp_send_json_error( array( 'message' => __( 'You do not have permission to upload files.', 'jetpack-videopress-pkg' ) ), null, JSON_UNESCAPED_SLASHES );
+			return;
+		}
+
 		$video_blog_id = $this->get_videopress_blog_id();
 		$args          = array(
 			'method' => 'POST',
@@ -206,6 +212,12 @@ class AJAX {
 	 * @return void
 	 */
 	public function wp_ajax_videopress_get_upload_token() {
+		if ( ! current_user_can( 'upload_files' ) ) {
+			// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- It takes null, but its phpdoc only says int.
+			wp_send_json_error( array( 'message' => __( 'You do not have permission to upload files.', 'jetpack-videopress-pkg' ) ), null, JSON_UNESCAPED_SLASHES );
+			return;
+		}
+
 		$video_blog_id = $this->get_videopress_blog_id();
 
 		$args = array(

--- a/projects/packages/videopress/tests/php/AJAX_Test.php
+++ b/projects/packages/videopress/tests/php/AJAX_Test.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Tests for Automattic\Jetpack\VideoPress\AJAX
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+namespace Automattic\Jetpack\VideoPress;
+
+use Automattic\Jetpack\Constants;
+use WorDBless\BaseTestCase;
+
+/**
+ * AJAX capability check test suite.
+ */
+class AJAX_Test extends BaseTestCase {
+
+	/**
+	 * The AJAX instance.
+	 *
+	 * @var AJAX
+	 */
+	private $ajax;
+
+	/**
+	 * Set up before each test.
+	 */
+	protected function set_up() {
+		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
+		// Mock connection.
+		\Jetpack_Options::update_option( 'blog_token', 'asdasd.123123' );
+		\Jetpack_Options::update_option( 'id', 1234 );
+
+		$this->ajax = AJAX::init();
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	protected function tear_down() {
+		wp_set_current_user( 0 );
+		Constants::clear_constants();
+	}
+
+	/**
+	 * Test that subscribers cannot get upload JWTs.
+	 */
+	public function test_get_upload_jwt_rejected_for_subscriber() {
+		$this->set_current_user_role( 'subscriber' );
+
+		$response = $this->call_ajax_method( 'wp_ajax_videopress_get_upload_jwt' );
+
+		$this->assertFalse( $response['success'] );
+		$this->assertSame( 'You do not have permission to upload files.', $response['data']['message'] );
+	}
+
+	/**
+	 * Test that contributors cannot get upload JWTs.
+	 */
+	public function test_get_upload_jwt_rejected_for_contributor() {
+		$this->set_current_user_role( 'contributor' );
+
+		$response = $this->call_ajax_method( 'wp_ajax_videopress_get_upload_jwt' );
+
+		$this->assertFalse( $response['success'] );
+		$this->assertSame( 'You do not have permission to upload files.', $response['data']['message'] );
+	}
+
+	/**
+	 * Test that authors can get upload JWTs.
+	 */
+	public function test_get_upload_jwt_allowed_for_author() {
+		$this->set_current_user_role( 'author' );
+
+		$valid_response = array( $this, 'return_valid_upload_response' );
+		add_filter( 'pre_http_request', $valid_response );
+		$response = $this->call_ajax_method( 'wp_ajax_videopress_get_upload_jwt' );
+		remove_filter( 'pre_http_request', $valid_response );
+
+		$this->assertTrue( $response['success'] );
+	}
+
+	/**
+	 * Test that subscribers cannot get upload tokens.
+	 */
+	public function test_get_upload_token_rejected_for_subscriber() {
+		$this->set_current_user_role( 'subscriber' );
+
+		$response = $this->call_ajax_method( 'wp_ajax_videopress_get_upload_token' );
+
+		$this->assertFalse( $response['success'] );
+		$this->assertSame( 'You do not have permission to upload files.', $response['data']['message'] );
+	}
+
+	/**
+	 * Test that authors can get upload tokens.
+	 */
+	public function test_get_upload_token_allowed_for_author() {
+		$this->set_current_user_role( 'author' );
+
+		$valid_response = array( $this, 'return_valid_upload_response' );
+		add_filter( 'pre_http_request', $valid_response );
+		$response = $this->call_ajax_method( 'wp_ajax_videopress_get_upload_token' );
+		remove_filter( 'pre_http_request', $valid_response );
+
+		$this->assertTrue( $response['success'] );
+	}
+
+	/**
+	 * Helper to call an AJAX method and return the decoded JSON response.
+	 *
+	 * @param string $method The AJAX method name.
+	 * @return array The decoded JSON response.
+	 */
+	private function call_ajax_method( $method ) {
+		add_filter( 'wp_doing_ajax', '__return_true' );
+
+		ob_start();
+		$this->ajax->$method();
+		$output = ob_get_clean();
+
+		remove_filter( 'wp_doing_ajax', '__return_true' );
+
+		$response = json_decode( $output, true );
+		$this->assertNotNull( $response, "AJAX method '$method' did not return valid JSON. Output: " . substr( $output, 0, 200 ) );
+
+		return $response;
+	}
+
+	/**
+	 * Create a user with the given role and set as current user.
+	 *
+	 * @param string $role The user role.
+	 */
+	private function set_current_user_role( $role ) {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => $role . '_user',
+				'user_pass'  => 'pass',
+				'user_email' => $role . '@test.com',
+				'role'       => $role,
+			)
+		);
+		wp_set_current_user( $user_id );
+	}
+
+	/**
+	 * Returns a mock HTTP response with a valid upload token.
+	 *
+	 * @return array
+	 */
+	public function return_valid_upload_response() {
+		return array( 'body' => wp_json_encode( array( 'upload_token' => 'test-token' ), JSON_UNESCAPED_SLASHES ) );
+	}
+}

--- a/projects/packages/videopress/tests/php/AJAX_Test.php
+++ b/projects/packages/videopress/tests/php/AJAX_Test.php
@@ -115,10 +115,17 @@ class AJAX_Test extends BaseTestCase {
 	private function call_ajax_method( $method ) {
 		add_filter( 'wp_doing_ajax', '__return_true' );
 
+		// Override WorDBless's wp_die handler to avoid a current_filter() bug on PHP < 8.
+		$noop_die_handler = static function () {
+			return '__return_empty_string';
+		};
+		add_filter( 'wp_die_ajax_handler', $noop_die_handler, 20 );
+
 		ob_start();
 		$this->ajax->$method();
 		$output = ob_get_clean();
 
+		remove_filter( 'wp_die_ajax_handler', $noop_die_handler, 20 );
 		remove_filter( 'wp_doing_ajax', '__return_true' );
 
 		$response = json_decode( $output, true );


### PR DESCRIPTION
Fixes VIDP-230

## Proposed changes

* Add `current_user_can( 'upload_files' )` capability check to both `wp_ajax_videopress_get_upload_jwt` and `wp_ajax_videopress_get_upload_token` AJAX handlers.
* After ac712ed1 replaced the per-user Jetpack connection check with a site-level check, any logged-in user (including subscribers) could obtain upload tokens. This restores proper authorization by gating on the WordPress `upload_files` capability.

### Other information

- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links

* VIDP-230

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Set up a Jetpack-connected site with VideoPress active.
* Log in as a subscriber (a role without `upload_files` capability).
* Trigger the `videopress-get-upload-jwt` or `videopress-get-upload-token` AJAX actions.
* Verify the request is rejected with a "You do not have permission to upload files." error.
* Log in as an author or administrator and verify the upload token is returned successfully.
