### PR TITLE
Jetpack Sync: Add page_condition taxonomy to sync safelist

### DIFF
--- a/projects/packages/sync/changelog/add-sync-page_condition-taxonomy
+++ b/projects/packages/sync/changelog/add-sync-page_condition-taxonomy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Jetpack Sync: Add page_condition taxonomy to approved sync list.

--- a/projects/packages/sync/src/modules/class-search.php
+++ b/projects/packages/sync/src/modules/class-search.php
@@ -1332,6 +1332,7 @@ class Search extends Module {
 		'organization',
 		'our_team_category',
 		'page_category',
+		'page_condition',
 		'parisrestaurant',
 		'parissauna',
 		'partner_category',


### PR DESCRIPTION
## Proposed changes:

Add `page_condition` to the approved sync list.

### Other information:

Related to 208558-ghe-Automattic/wpcom

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

Code Review