### PR TITLE
WAF: Fix stale MATCHED_VAR cache bypass in chained rules

### DIFF
--- a/projects/packages/waf/changelog/waf-fix-rule-bypass
+++ b/projects/packages/waf/changelog/waf-fix-rule-bypass
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+WAF: Fix issue that potentially allowed bypassing WAF rules.

--- a/projects/packages/waf/src/class-waf-runtime.php
+++ b/projects/packages/waf/src/class-waf-runtime.php
@@ -715,6 +715,12 @@ class Waf_Runtime {
 			$this->matched_vars_names = array();
 			$this->matched_var        = '';
 			$this->matched_var_name   = '';
+			unset(
+				$this->metadata['matched_var'],
+				$this->metadata['matched_vars'],
+				$this->metadata['matched_vars_names'],
+				$this->metadata['matched_var_name']
+			);
 	}
 
 	/**

--- a/projects/packages/waf/tests/php/unit/WafRuntimeTest.php
+++ b/projects/packages/waf/tests/php/unit/WafRuntimeTest.php
@@ -305,4 +305,66 @@ final class WafRuntimeTest extends PHPUnit\Framework\TestCase {
 		$this->assertEmpty( $this->runtime->matched_var );
 		$this->assertEmpty( $this->runtime->matched_var_name );
 	}
+
+	/**
+	 * Test that reset_matched_vars() invalidates the metadata cache.
+	 *
+	 * If the cache is not cleared, meta() returns stale matched-variable data
+	 * after a reset, potentially allowing a WAF bypass.
+	 */
+	public function testResetMatchedVarsInvalidatesMetadataCache() {
+		// Step 1: Simulate Rule A matching on a benign value.
+		$this->runtime->matched_var        = 'safe-string';
+		$this->runtime->matched_var_name   = 'ARGS:safe_param';
+		$this->runtime->matched_vars       = array( 'safe-string' );
+		$this->runtime->matched_vars_names = array( 'ARGS:safe_param' );
+
+		// Populate the metadata cache by reading matched_var values.
+		$cached_var        = $this->runtime->meta( 'matched_var' );
+		$cached_vars       = $this->runtime->meta( 'matched_vars' );
+		$cached_var_name   = $this->runtime->meta( 'matched_var_name' );
+		$cached_vars_names = $this->runtime->meta( 'matched_vars_names' );
+
+		// Sanity check: cache has the initial values.
+		$this->assertSame( array( 'ARGS:safe_param' => 'safe-string' ), $cached_var );
+		$this->assertSame( array( 'ARGS:safe_param' => 'safe-string' ), $cached_vars );
+		$this->assertSame( array( 'ARGS:safe_param' ), $cached_var_name );
+		$this->assertSame( array( 'ARGS:safe_param' ), $cached_vars_names );
+
+		// Step 2: Reset matched vars (e.g. between rule chains).
+		$this->runtime->reset_matched_vars();
+
+		// Step 3: Simulate Rule B matching on a malicious value.
+		$this->runtime->matched_var        = '<script>alert(1)</script>';
+		$this->runtime->matched_var_name   = 'ARGS:evil_param';
+		$this->runtime->matched_vars       = array( '<script>alert(1)</script>' );
+		$this->runtime->matched_vars_names = array( 'ARGS:evil_param' );
+
+		// Step 4: meta() must return the NEW values, not the stale cached ones.
+		$new_var        = $this->runtime->meta( 'matched_var' );
+		$new_vars       = $this->runtime->meta( 'matched_vars' );
+		$new_var_name   = $this->runtime->meta( 'matched_var_name' );
+		$new_vars_names = $this->runtime->meta( 'matched_vars_names' );
+
+		$this->assertSame(
+			array( 'ARGS:evil_param' => '<script>alert(1)</script>' ),
+			$new_var,
+			'meta("matched_var") returned stale cached data after reset_matched_vars()'
+		);
+		$this->assertSame(
+			array( 'ARGS:evil_param' => '<script>alert(1)</script>' ),
+			$new_vars,
+			'meta("matched_vars") returned stale cached data after reset_matched_vars()'
+		);
+		$this->assertSame(
+			array( 'ARGS:evil_param' ),
+			$new_var_name,
+			'meta("matched_var_name") returned stale cached data after reset_matched_vars()'
+		);
+		$this->assertSame(
+			array( 'ARGS:evil_param' ),
+			$new_vars_names,
+			'meta("matched_vars_names") returned stale cached data after reset_matched_vars()'
+		);
+	}
 }

--- a/projects/plugins/jetpack/changelog/waf-fix-rule-bypass
+++ b/projects/plugins/jetpack/changelog/waf-fix-rule-bypass
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+ WAF: Fix issue that potentially allowed bypassing WAF rules.

--- a/projects/plugins/protect/changelog/waf-fix-rule-bypass
+++ b/projects/plugins/protect/changelog/waf-fix-rule-bypass
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+ WAF: Fix issue that potentially allowed bypassing WAF rules.


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/PROTECT-156

Since it was an unused feature we can just have a PR here. See p1773941497772489/1773940753.911989-slack-C08LSARAWCV 

## Proposed changes

  * Fix WAF matched variable metadata cache not being invalidated when `reset_matched_vars()` is called. The `meta()` method caches `matched_var`, `matched_vars`, `matched_var_name`, and `matched_vars_names` on
   first access, but `reset_matched_vars()` only cleared the underlying properties without unsetting the cached entries. This allowed stale match data to persist across rule chains, potentially enabling a WAF
  bypass.
  * Add a unit test that verifies the metadata cache is properly invalidated after a reset.


  ## Related product discussion/links

  * https://linear.app/a8c/issue/PROTECT-156

  ## Does this pull request change what data or activity we track or use?

  No.

  ## Testing instructions

  ### Automated

  * Run the WAF unit tests: `cd projects/packages/waf && composer test-php-unit`
  * All 226 tests should pass, including the new `testResetMatchedVarsInvalidatesMetadataCache` test.

  ### Manual

  * Run a Jetpack site on this branch.
  * Activate "Automatic firewall protection".
  * Replace the content of `wp-content/jetpack-waf/rules/automatic-rules.php` with:

  ```php
  <?php
  $rule = (object) array( 'id' => 1337, 'reason' => 'stale-cache-bypass', 'tags' => array() );
  try {
  if($waf->match_targets(array (
    0 => 'lowercase',
  ),array (
    'args' =>
    array (
      'only' =>
      array (
        0 => 'safe_param',
      ),
    ),
  ),'contains','safe',false,false)) {
  $waf->meta('matched_var');
  $waf->reset_matched_vars();
  if($waf->match_targets(array (
    0 => 'lowercase',
  ),array (
    'args' =>
    array (
      'only' =>
      array (
        0 => 'evil_param',
      ),
    ),
  ),'contains','malicious',false,false)) {
  if($waf->match_targets(array (
  ),array (
    'matched_var' =>
    array (
    ),
  ),'contains','malicious',false,false)) {
  return $waf->block('block',$rule->id,$rule->reason,403);
  }
  }
  }
  } catch ( \Throwable $t ) {
  error_log( 'Rule ' . $rule->id . ' failed: ' . $t );
  }
```

  - Visit https://your-site.tld/?safe_param=safe&evil_param=malicious
    - Before fix: Site loads normally (WAF bypass — stale cache returns "safe" instead of "malicious").
    - After fix: WAF blocks with rule 1337.
  - Visit https://your-site.tld/?safe_param=safe — site should load normally (no match on evil_param).