### PR TITLE
Components: fix AdminPage heading size

### DIFF
--- a/projects/js-packages/components/changelog/update-admin-ui-1.10-heading-fix
+++ b/projects/js-packages/components/changelog/update-admin-ui-1.10-heading-fix
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Bump @wordpress/admin-ui to 1.10.0 and remove double heading wrapper from AdminPage title, fixing header title sizing across all Jetpack admin pages.

--- a/projects/js-packages/components/changelog/update-admin-ui-1.10-heading-fix
+++ b/projects/js-packages/components/changelog/update-admin-ui-1.10-heading-fix
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Bump @wordpress/admin-ui to 1.10.0 and remove double heading wrapper from AdminPage title, fixing header title sizing across all Jetpack admin pages.
+Remove double heading wrapper from AdminPage title, fixing header title sizing across all Jetpack admin pages.

--- a/projects/js-packages/components/components/admin-page/index.tsx
+++ b/projects/js-packages/components/components/admin-page/index.tsx
@@ -2,7 +2,6 @@ import restApi from '@automattic/jetpack-api';
 import { Page } from '@wordpress/admin-ui';
 import '@wordpress/admin-ui/build-style/style.css';
 import {
-	__experimentalHeading as Heading, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
@@ -75,17 +74,11 @@ const AdminPage: FC< AdminPageProps > = ( {
 	}, [] );
 
 	// Compose the title with logo for the admin-ui Page header.
-	// Note: The inner Heading causes a double h2 wrapping because Page's Header
-	// also wraps title in a Heading. This is a known issue — the inner Heading is
-	// needed until https://github.com/WordPress/gutenberg/pull/75899 fixes
-	// non-string title rendering in admin-ui. Once that lands, remove the Heading
-	// here and pass the plain HStack with a string child.
+	// Page's Header wraps this in an <h2> tag, so we just pass the content directly.
 	const composedTitle = title ? (
 		<HStack spacing={ 2 } justify="left">
 			{ logo || <JetpackLogo showText={ false } height={ 20 } /> }
-			<Heading as="h2" level={ 3 } weight={ 500 } truncate>
-				{ title }
-			</Heading>
+			<span>{ title }</span>
 		</HStack>
 	) : undefined;
 


### PR DESCRIPTION
## Proposed changes

* ~**Bump `@wordpress/admin-ui` from 1.9.0 to 1.10.0** in `js-packages/components`. This version includes [gutenberg#75899](https://github.com/WordPress/gutenberg/pull/75899) which renders the Page header title as a plain `<h2>` tag instead of a `Heading` component, properly supporting non-string title content.~ done in https://github.com/Automattic/jetpack/pull/47684
* **Fix double heading wrapping in AdminPage**: Remove the inner `<Heading as="h2" level={3}>` wrapper from `composedTitle` that was causing a nested `h2 > h2` structure. The title text is now passed directly in a `<span>`, letting admin-ui's native heading styling control the size. This fixes the title size across **all Jetpack admin pages** using the unified header (VideoPress, Social, Backup, Search, Newsletter, Boost, etc.).


<img width="1916" height="104" alt="cg5 jurassic tube_wp-admin_admin php_page=my-jetpack (2)" src="https://github.com/user-attachments/assets/40b6fa15-de2b-44eb-9110-b3389004e9f8" />
<img width="1916" height="162" alt="cg5 jurassic tube_wp-admin_admin php_page=jetpack-boost (2)" src="https://github.com/user-attachments/assets/40733d74-6c0b-49d3-bb09-8b0dfbde96e9" />
<img width="1916" height="162" alt="cg5 jurassic tube_wp-admin_admin php_page=jetpack-boost (1)" src="https://github.com/user-attachments/assets/ddb7e309-7b73-44bb-b4ee-2f67968611f3" />
<img width="1916" height="162" alt="cg5 jurassic tube_wp-admin_admin php_page=jetpack-videopress (1)" src="https://github.com/user-attachments/assets/bd3fee70-7868-457d-996a-b5194a4fc71a" />
<img width="1916" height="170" alt="cg5 jurassic tube_wp-admin_admin php_page=jetpack-videopress" src="https://github.com/user-attachments/assets/a766ec58-7ea7-44d5-8a0b-a18b82a70647" />
<img width="1916" height="162" alt="cg5 jurassic tube_wp-admin_admin php_page=jetpack-social (1)" src="https://github.com/user-attachments/assets/4b5a8716-f46a-41b3-a8ca-6f8dcc3d2c67" />
<img width="1916" height="160" alt="cg5 jurassic tube_wp-admin_admin php_page=jetpack-protect (1)" src="https://github.com/user-attachments/assets/2294aada-37c8-4620-89d1-86c6c2108a14" />
<img width="1916" height="170" alt="cg5 jurassic tube_wp-admin_admin php_page=jetpack-backup (1)" src="https://github.com/user-attachments/assets/c22e5cbe-3113-4f71-85e8-b3586f972dcc" />
<img width="1916" height="162" alt="cg5 jurassic tube_wp-admin_admin php_page=jetpack-search (1)" src="https://github.com/user-attachments/assets/475e5e74-3b8e-422f-96e1-f26864b72e24" />
<img width="1916" height="104" alt="cg5 jurassic tube_wp-admin_admin php_page=jetpack" src="https://github.com/user-attachments/assets/87c8a615-5f0b-495e-ba50-8dd3f64e32e5" />



### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* Part of the Jetpack admin page header normalization initiative (#47313)
* Gutenberg PR that enables this fix: [WordPress/gutenberg#75899](https://github.com/WordPress/gutenberg/pull/75899)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. Go to any Jetpack admin page that uses the unified header (e.g. **VideoPress**, **Social**, **Backup**, **Search**, **Newsletter**)
2. Verify the page title (e.g. "VideoPress", "Social") renders at the correct heading size — matching the admin-ui storybook's "Page / With Subtitle" story
3. Verify the title is not oversized compared to the subtitle text below it
4. Verify the Jetpack bolt logo still appears next to the title
5. Check that breadcrumb pages (e.g. VideoPress edit details, Boost cache debug log) still render correctly
