### PR TITLE
Backup: fix progress animation overlapping the page header

### DIFF
--- a/projects/js-packages/components/changelog/fix-backup-animation-overlaps-header
+++ b/projects/js-packages/components/changelog/fix-backup-animation-overlaps-header
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add overflow hidden to AdminSectionHero and z-index to AdminPage header to prevent content from overlapping the page header.

--- a/projects/js-packages/components/components/admin-page/style.module.scss
+++ b/projects/js-packages/components/components/admin-page/style.module.scss
@@ -21,6 +21,7 @@
 	// JETPACK-1386
 	:global(.admin-ui-page__header) {
 		position: relative;
+		z-index: 1;
 	}
 
 	// Normalize admin headers: implementation of admin-ui needs to

--- a/projects/js-packages/components/components/admin-section/hero/style.module.scss
+++ b/projects/js-packages/components/components/admin-section/hero/style.module.scss
@@ -1,4 +1,5 @@
 .section-hero {
 	padding-top: 1px; // prevent margin collapse for interior sections
 	background: var(--jp-white-off);
+	overflow: hidden;
 }

--- a/projects/packages/backup/changelog/fix-backup-progress-overlaps-header
+++ b/projects/packages/backup/changelog/fix-backup-progress-overlaps-header
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix progress animation overlapping the page header by clipping animation overflow.

--- a/projects/packages/backup/src/js/components/backups-style.scss
+++ b/projects/packages/backup/src/js/components/backups-style.scss
@@ -149,7 +149,6 @@
 
 .backup__animation {
 	position: relative;
-	overflow: hidden;
 
 	@include calypso-mixins.responsive( full-width ) {
 		display: none;

--- a/projects/packages/backup/src/js/components/backups-style.scss
+++ b/projects/packages/backup/src/js/components/backups-style.scss
@@ -149,6 +149,7 @@
 
 .backup__animation {
 	position: relative;
+	overflow: hidden;
 
 	@include calypso-mixins.responsive( full-width ) {
 		display: none;
@@ -160,7 +161,6 @@
 .backup__animation-el-3 {
 	opacity: 0;
 	position: absolute;
-	z-index: 4;
 	animation: animation-el-3 4s ease-in-out 0.8s infinite normal forwards;
 }
 


### PR DESCRIPTION
Fixes JETPACK-1393

## Proposed changes

* Remove unnecessary `z-index: 4` from the Backup in-progress animation elements (`.backup__animation-el-1/2/3`). This z-index served no purpose within its grid column and caused animation images to paint above the AdminPage header when animating upward.
* Add `overflow: hidden` to `AdminSectionHero` (`.section-hero`) so any content that escapes the hero section boundary is clipped cleanly at the gray section edge.
* Add `z-index: 1` to the AdminPage header (`.admin-ui-page__header`) to ensure it always paints above page content.

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* JETPACK-1393

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. Install and activate the **Jetpack Backup** plugin on a test site connected to WordPress.com with an active Backup plan.
2. Trigger a backup (or wait for one to start) so the "Backing up [site]" in-progress screen is displayed.
3. Observe the floating animation elements (blue rectangle, yellow rectangle, card with pink circle) on the right side of the hero section.
4. **Before this fix**: The animation elements would visually overlap the page header ("Backup" title area) as they floated upward.
5. **After this fix**: The animation elements clip cleanly at the top edge of the gray hero section and do not overlap the header.
6. Verify the header always renders above content on other AdminPage-based pages (My Jetpack, Boost, Social, Protect) — no visual regressions.
