### PR TITLE
Forms: Improve dashboard copy and labels

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-cfm-copy-polish
+++ b/projects/packages/forms/changelog/fix-forms-cfm-copy-polish
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Improve dashboard copy: replace 'shared form pattern' with 'form', rename 'Folder' filter to 'Status', and use 'Form name' label in create modal.

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -632,7 +632,7 @@ function StageInner() {
 						<EmptyWrapper
 							heading={ __( "You're set up. No forms yet.", 'jetpack-forms' ) }
 							body={ __(
-								'Create a shared form pattern to manage and reuse it across your site.',
+								'Create a form to manage and reuse it across your site.',
 								'jetpack-forms'
 							) }
 							actions={

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -338,7 +338,7 @@ function StageInner() {
 				: [
 						{
 							id: 'folder',
-							label: __( 'Folder', 'jetpack-forms' ),
+							label: __( 'Status', 'jetpack-forms' ),
 							elements: [
 								{
 									label: sprintf(

--- a/projects/packages/forms/src/dashboard/components/form-name-modal/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/form-name-modal/index.tsx
@@ -62,7 +62,7 @@ export type FormNameModalProps = {
 
 	/**
 	 * Label for the input field.
-	 * @default "Name"
+	 * @default "Form name"
 	 */
 	inputLabel?: string;
 
@@ -151,7 +151,7 @@ export function FormNameModal( {
 		<Modal title={ title } onRequestClose={ handleClose } size="medium">
 			<form onSubmit={ onSubmitForm }>
 				<TextControl
-					label={ inputLabel || __( 'Name', 'jetpack-forms' ) }
+					label={ inputLabel || __( 'Form name', 'jetpack-forms' ) }
 					value={ name }
 					onChange={ setName }
 					__next40pxDefaultSize

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -445,7 +445,7 @@ export default function FormsDashboardForms(): JSX.Element | null {
 						<EmptyWrapper
 							heading={ __( "You're set up. No forms yet.", 'jetpack-forms' ) }
 							body={ __(
-								'Create a shared form pattern to manage and reuse it across your site.',
+								'Create a form to manage and reuse it across your site.',
 								'jetpack-forms'
 							) }
 							actions={

--- a/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
@@ -21,7 +21,7 @@ import type { FormResponse, ResponseField, ResponseFields } from '../../types/in
  * This is the only way to filter the data by `status`.
  *
  * Note: When Central Form Management (CFM) is enabled, the UI can expose a
- * "Folder" DataViews filter that syncs its value to the URL `status` param.
+ * "Status" DataViews filter that syncs its value to the URL `status` param.
  *
  * @param {string} urlStatus - The current status from the URL.
  * @return {string} The status filter to apply.

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -327,7 +327,7 @@ export default function InboxView( { parentId, pageTitle, pageSubtitle } = {} ) 
 				? [
 						{
 							id: 'folder',
-							label: __( 'Folder', 'jetpack-forms' ),
+							label: __( 'Status', 'jetpack-forms' ),
 							elements: [
 								{ label: __( 'Inbox', 'jetpack-forms' ), value: 'inbox' },
 								{ label: __( 'Spam', 'jetpack-forms' ), value: 'spam' },


### PR DESCRIPTION
Fixes #

## Proposed changes

Improve copy and labels in the Jetpack Forms dashboard based on UX review findings:

* Replace "shared form pattern" with "form" in the empty state body text — the word "pattern" is confusing in a WordPress context where "block patterns" already exist.
* Rename the "Folder" filter label to "Status" in the responses view — "Folder" was borrowed from email semantics and doesn't fit a forms context. The filter values (Inbox, Spam, Trash) are status categories.
* Change the "Name" label to "Form name" in the create/rename modal — the single word "Name" is ambiguous and, when styled as uppercase ("NAME"), feels aggressive for a form field.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* Internal UX expert review of the Central Forms Management flow

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. Go to the Forms dashboard (with Central Form Management enabled)
2. Verify the empty state says "Create a form to manage and reuse it across your site." (not "shared form pattern")
3. Click "Create a new form" — verify the modal label says "Form name" (not "Name")
4. Create a form and go to Responses tab
5. Verify the filter label says "Status" (not "Folder")
