### PR TITLE
Boost: Fix JITM rendering above header on cache debug log page

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/pages/cache-debug-log/cache-debug-log.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/cache-debug-log/cache-debug-log.tsx
@@ -51,6 +51,9 @@ const CacheDebugLog = () => {
 	return (
 		<BoostAdminPage breadcrumbs={ breadcrumbs }>
 			<div id="jb-dashboard" className="jb-dashboard jb-dashboard--main">
+				<div className="jb-container">
+					<div id="jp-admin-notices" className="jetpack-boost-jitm-card" />
+				</div>
 				<div className={ clsx( 'jb-section jb-section--main', styles.section ) }>
 					<div className="jb-container">
 						<header className={ styles.header }>

--- a/projects/plugins/boost/app/assets/src/js/pages/cache-debug-log/cache-debug-log.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/cache-debug-log/cache-debug-log.tsx
@@ -51,11 +51,9 @@ const CacheDebugLog = () => {
 	return (
 		<BoostAdminPage breadcrumbs={ breadcrumbs }>
 			<div id="jb-dashboard" className="jb-dashboard jb-dashboard--main">
-				<div className="jb-container">
-					<div id="jp-admin-notices" className="jetpack-boost-jitm-card" />
-				</div>
 				<div className={ clsx( 'jb-section jb-section--main', styles.section ) }>
 					<div className="jb-container">
+						<div id="jp-admin-notices" className="jetpack-boost-jitm-card" />
 						<header className={ styles.header }>
 							<h3>{ __( 'Jetpack Boost Cache Log Viewer', 'jetpack-boost' ) }</h3>
 							<CopyToClipboard

--- a/projects/plugins/boost/changelog/fix-cache-debug-log-jitm-placement
+++ b/projects/plugins/boost/changelog/fix-cache-debug-log-jitm-placement
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add JITM notices slot to cache debug log page so notices render below the header instead of above it.


### PR DESCRIPTION
## Proposed changes

* Add `#jp-admin-notices` JITM slot to the Boost **cache debug log** page, inside `jb-dashboard > jb-container`, matching the same structure used on the main Boost page (`speed-score.tsx`).
* Without this, JITMs injected by the JITM JS render above the page header (in `#wpbody-content`) instead of below it.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* Follows the JITM placement pattern from #47558 (Social, My Jetpack, Search)
* Part of the admin page header normalization initiative (#47313)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

### Setup: Fake JITM
Add the following snippet to a mu-plugin (e.g. `wp-content/mu-plugins/fake-jitm.php`) — see #47558 for the full snippet.

### Test
1. Go to **Jetpack > Boost** (`wp-admin/admin.php?page=jetpack-boost`)
2. Navigate to the **Cache debug log** page (`#/cache-debug-log`)
3. Verify the JITM appears **below the breadcrumb header**, not above it
4. Compare with the main Boost page — JITM placement should be consistent
