### PR TITLE
Forms Dashboard: Show form name modal on all Create Form buttons

### DIFF
--- a/projects/packages/forms/changelog/fix-create-form-button
+++ b/projects/packages/forms/changelog/fix-create-form-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms Dashboard: Show name modal when creating a new form instead of navigating directly to the editor.

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -632,7 +632,7 @@ function StageInner() {
 						<EmptyWrapper
 							heading={ __( "You're set up. No forms yet.", 'jetpack-forms' ) }
 							body={ __(
-								'Create a shared form pattern to manage and reuse it across your site.',
+								'Create a form to manage and reuse it across your site.',
 								'jetpack-forms'
 							) }
 							actions={
@@ -640,7 +640,7 @@ function StageInner() {
 									<CreateFormButton
 										label={ __( 'Create a new form', 'jetpack-forms' ) }
 										variant="primary"
-										showIcon={ false }
+										showNameModal
 									/>
 									{ hasClassicForms && (
 										<Button size="compact" variant="secondary" onClick={ openFormsHelpModal }>

--- a/projects/packages/forms/src/dashboard/components/empty-responses/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/empty-responses/index.tsx
@@ -255,6 +255,7 @@ const EmptyResponses = ( {
 					<CreateFormButton
 						label={ __( 'Create a new form', 'jetpack-forms' ) }
 						variant="primary"
+						showNameModal
 					/>
 				)
 			}

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -398,7 +398,7 @@ export default function FormsDashboardForms(): JSX.Element | null {
 
 	const onChangeView = useCallback( newView => setView( newView ), [ setView ] );
 
-	const headerActions = useMemo( () => [ <CreateFormButton key="create" /> ], [] );
+	const headerActions = useMemo( () => [ <CreateFormButton key="create" showNameModal /> ], [] );
 	const getItemId = useCallback( ( item: FormListItem ) => String( item.id ), [] );
 	const onClickItem = useCallback(
 		( item: FormListItem ) => {
@@ -446,7 +446,7 @@ export default function FormsDashboardForms(): JSX.Element | null {
 						<EmptyWrapper
 							heading={ __( "You're set up. No forms yet.", 'jetpack-forms' ) }
 							body={ __(
-								'Create a shared form pattern to manage and reuse it across your site.',
+								'Create a form to manage and reuse it across your site.',
 								'jetpack-forms'
 							) }
 							actions={
@@ -454,6 +454,7 @@ export default function FormsDashboardForms(): JSX.Element | null {
 									<CreateFormButton
 										label={ __( 'Create a new form', 'jetpack-forms' ) }
 										variant="primary"
+										showNameModal
 									/>
 									{ hasClassicForms && (
 										<Button size="compact" variant="secondary" onClick={ openFormsHelpModal }>


### PR DESCRIPTION
Fixes #

## Proposed changes
* Show the form name modal on all "Create a form" / "Create a new form" buttons across the Forms Dashboard, instead of navigating directly to the editor.
* Update empty state copy from "Create a shared form pattern to manage and reuse it across your site." to "Create a form to manage and reuse it across your site."
* Re-enable the `+` icon on the Create Form button in the stage route empty state.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Go to the Jetpack Forms Dashboard (with Central Form Management enabled).
* Verify the "Create a form" button in the header shows a name modal when clicked.
* When no forms exist, verify the "Create a new form" empty state button also shows the name modal.
* Go to the Responses tab with no responses — verify the "Create a new form" button shows the name modal.
* Verify the empty state description reads "Create a form to manage and reuse it across your site."
