### PR TITLE
Charts: Remove internal hooks and utilities from public exports

### DIFF
--- a/projects/js-packages/charts/changelog/update-charts-remove-internal-exports
+++ b/projects/js-packages/charts/changelog/update-charts-remove-internal-exports
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Remove internal hooks and utilities from public exports to reduce API surface.
+Remove internal hooks, utilities, and types from public exports to reduce API surface.

--- a/projects/js-packages/charts/changelog/update-charts-remove-internal-exports
+++ b/projects/js-packages/charts/changelog/update-charts-remove-internal-exports
@@ -1,4 +1,4 @@
-Significance: patch
+Significance: minor
 Type: changed
 
 Remove internal hooks and utilities from public exports to reduce API surface.

--- a/projects/js-packages/charts/changelog/update-charts-remove-internal-exports
+++ b/projects/js-packages/charts/changelog/update-charts-remove-internal-exports
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove internal hooks and utilities from public exports to reduce API surface.

--- a/projects/js-packages/charts/src/index.ts
+++ b/projects/js-packages/charts/src/index.ts
@@ -50,7 +50,7 @@ export type {
 export { useLeaderboardLegendItems } from './charts/leaderboard-chart/hooks';
 
 // Previously available via '@automattic/charts/tooltip', '@automattic/charts/legend'
-export { AccessibleTooltip, useKeyboardNavigation } from './components/tooltip';
+export { AccessibleTooltip } from './components/tooltip';
 export type { BaseTooltipProps, TooltipData, TooltipProps } from './components/tooltip';
 export type { LegendProps, BaseLegendProps, ChartLegendOptions } from './components/legend';
 
@@ -80,34 +80,7 @@ export type {
 export type { ArcData } from './charts/pie-semi-circle-chart';
 export type { SparklineProps, GradientConfig, SparklineDataPoint } from './charts/sparkline';
 
-// Previously available via '@automattic/charts/hooks'
-export {
-	useDeepMemo,
-	useChartMouseHandler,
-	useXYChartTheme,
-	useChartDataTransform,
-	useChartMargin,
-	useElementSize,
-	useTextTruncation,
-	useZeroValueDisplay,
-	useInteractiveLegendData,
-	usePrefersReducedMotion,
-	useTooltipPortalRelocator,
-} from './hooks';
-
-// Previously available via '@automattic/charts/utils'
-export {
-	attachSubComponents,
-	parseAsLocalDate,
-	formatMetricValue,
-	formatPercentage,
-	getLongestTickWidth,
-	getSeriesLineStyles,
-	getSeriesStroke,
-	getItemShapeStyles,
-	isSafari,
-	mergeThemes,
-	resolveCssVariable,
-} from './utils';
+// Utilities
+export { parseAsLocalDate, formatMetricValue, formatPercentage, mergeThemes } from './utils';
 export * from './utils/color-utils';
 export type { MetricValueType } from './utils';

--- a/projects/js-packages/charts/src/index.ts
+++ b/projects/js-packages/charts/src/index.ts
@@ -54,7 +54,7 @@ export type {
 	BaseChartProps,
 	GridProps,
 } from './types';
-export type { RenderTooltipParams } from './visx/types';
+export type * from './visx/types';
 export type { PieChartProps, PieChartRenderTooltipParams } from './charts/pie-chart';
 export type {
 	PieSemiCircleChartProps,

--- a/projects/js-packages/charts/src/index.ts
+++ b/projects/js-packages/charts/src/index.ts
@@ -28,9 +28,33 @@ export {
 	defaultTheme,
 } from './providers';
 
-// Types
-export type * from './types';
-export type * from './visx/types';
+// Types - explicit exports (excludes internal types like DataPointPercentageCalculated)
+export type {
+	Optional,
+	OrientationType,
+	AnnotationStyles,
+	DataPoint,
+	GeoData,
+	DataPointDate,
+	LeaderboardEntry,
+	GradientStop,
+	SeriesDataOptions,
+	SeriesData,
+	MultipleDataPointsDate,
+	DataPointPercentage,
+	ChartTheme,
+	CompleteChartTheme,
+	AxisOptions,
+	ScaleOptions,
+	LegendItemStyles,
+	LegendLabelStyles,
+	LegendShapeStyles,
+	LegendPosition,
+	ChartLegendConfig,
+	BaseChartProps,
+	GridProps,
+} from './types';
+export type { RenderTooltipParams } from './visx/types';
 export type { PieChartProps, PieChartRenderTooltipParams } from './charts/pie-chart';
 export type {
 	PieSemiCircleChartProps,

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -308,7 +308,7 @@ export type CompleteChartTheme = Required< ChartTheme > & {
 	};
 };
 
-declare type AxisOptions = {
+export type AxisOptions = {
 	orientation?: OrientationType;
 	numTicks?: number;
 	axisClassName?: string;


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHARTS-194/add-namespaced-exports-to-improve-discoverability

## Proposed changes

Remove internal implementation details from the public API surface to maintain a stable, focused API.

### Removed exports

**Internal hooks:**
- `useDeepMemo`, `useChartMouseHandler`, `useXYChartTheme`, `useChartDataTransform`, `useChartMargin`, `useElementSize`, `useTextTruncation`, `useZeroValueDisplay`, `useInteractiveLegendData`, `usePrefersReducedMotion`, `useTooltipPortalRelocator`, `useKeyboardNavigation`

**Internal utils:**
- `attachSubComponents`, `getLongestTickWidth`, `getSeriesLineStyles`, `getSeriesStroke`, `getItemShapeStyles`, `isSafari`, `resolveCssVariable`

### Kept public utilities
- `parseAsLocalDate`, `formatMetricValue`, `formatPercentage`, `mergeThemes`
- All color utilities (`hexToRgba`, `lightenHexColor`, etc.)

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links

* https://linear.app/a8c/issue/CHARTS-194/add-namespaced-exports-to-improve-discoverability

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Run `pnpm typecheck` - should pass
2. Run `pnpm test` - all 791 tests should pass
3. Build the package with `pnpm build` - should succeed

### Upgrade path for woocommerce-analytics

The following import needs to be updated:

```diff
- import { hexToRgba } from '@automattic/charts/utils';
+ import { hexToRgba } from '@automattic/charts';
```

File: `next-woocommerce-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-chart.tsx`

All other imports remain compatible.