### PR TITLE
Stats Admin: Hide stats column for non-public post types

### DIFF
--- a/projects/packages/stats-admin/changelog/fix-stats-admin-hide-column-for-non-public-post-types
+++ b/projects/packages/stats-admin/changelog/fix-stats-admin-hide-column-for-non-public-post-types
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Hide stats column for non-public post types in the WP Admin post list.

--- a/projects/packages/stats-admin/src/class-admin-post-list-column.php
+++ b/projects/packages/stats-admin/src/class-admin-post-list-column.php
@@ -166,12 +166,14 @@ class Admin_Post_List_Column {
 	 * @return mixed
 	 */
 	public function add_stats_post_table( $columns ) {
-		// Skip stats column for non-public post types.
-		$screen = get_current_screen();
-		if ( $screen && $screen->post_type ) {
-			$post_type_object = get_post_type_object( $screen->post_type );
-			if ( $post_type_object && ! $post_type_object->public ) {
-				return $columns;
+		// Skip stats column for non-public post types when screen info is available.
+		if ( function_exists( 'get_current_screen' ) ) {
+			$screen = get_current_screen();
+			if ( $screen && $screen->post_type ) {
+				$post_type_object = get_post_type_object( $screen->post_type );
+				if ( $post_type_object && ! $post_type_object->public ) {
+					return $columns;
+				}
 			}
 		}
 

--- a/projects/packages/stats-admin/src/class-admin-post-list-column.php
+++ b/projects/packages/stats-admin/src/class-admin-post-list-column.php
@@ -166,6 +166,15 @@ class Admin_Post_List_Column {
 	 * @return mixed
 	 */
 	public function add_stats_post_table( $columns ) {
+		// Skip stats column for non-public post types.
+		$screen = get_current_screen();
+		if ( $screen && $screen->post_type ) {
+			$post_type_object = get_post_type_object( $screen->post_type );
+			if ( $post_type_object && ! $post_type_object->public ) {
+				return $columns;
+			}
+		}
+
 		/**
 		 * The manage_options capability is a fallback for Simple.
 		 * This should be updated with a proper fix. Implemented based on this PR: https://github.com/Automattic/jetpack/pull/41549.


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack-roadmap/issues/2697

## Proposed changes
* Hide the stats column in the WP Admin post list for non-public post types (e.g., `p2_pattern`)
* Instead of hardcoding specific post types to exclude, this checks `post_type_object->public` to determine if the stats column should be shown

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* Linear: https://linear.app/a8c/issue/STATS-139/p2-p2-patterns-stats-column-width-issue

## Does this pull request change what data or activity we track or use?
No

## Testing instructions
1. Apply this PR to your sandbox
2. Go to a P2 site (e.g., yourp2.wordpress.com)
3. Navigate to `/wp-admin/edit.php?post_type=p2_pattern`
4. Verify the Stats column is **no longer displayed**
5. Navigate to `/wp-admin/edit.php` (regular posts)
6. Verify the Stats column is **still displayed** for public post types