### PR TITLE
Form Editor: Add padding to visual editor area

### DIFF
--- a/projects/packages/forms/changelog/add-form-editor-padding
+++ b/projects/packages/forms/changelog/add-form-editor-padding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add padding to the form editor visual editor area

--- a/projects/packages/forms/src/form-editor/style.scss
+++ b/projects/packages/forms/src/form-editor/style.scss
@@ -12,3 +12,7 @@
 .post-type-jetpack_form .editor-post-content-information {
 	display: none;
 }
+
+.post-type-jetpack_form .editor-visual-editor {
+	padding: 24px 24px 0;
+}


### PR DESCRIPTION
Before:
<img width="1677" height="1047" alt="Screenshot 2026-03-19 at 7 18 44 PM" src="https://github.com/user-attachments/assets/af8c8c40-e191-49b9-a5fb-b585d2ef559e" />

After:

<img width="1686" height="869" alt="Screenshot 2026-03-19 at 7 17 17 PM" src="https://github.com/user-attachments/assets/078f5dea-af65-42fe-bb33-4a96ca0375fc" />


## Proposed changes
* Add padding (24px horizontal, 24px top) to the form editor's visual editor area so that the form editor is a bit different from the page/post editor. 

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Go to wp-admin and create or edit a Jetpack Form (post type `jetpack_form`).
* Verify the visual editor area now has 24px of padding on the left, right, and top.
* Confirm the content no longer touches the edges of the editor canvas.
