### PR TITLE
Disable batched analytics requests when SOCKS proxy is configured

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/claude-slack-fix-cookie-consent-settings-6Azqt
+++ b/projects/packages/woocommerce-analytics/changelog/claude-slack-fix-cookie-consent-settings-6Azqt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Disable batched analytics requests when a SOCKS proxy is configured, falling back to wp_remote_get() which respects WP_PROXY_* settings.

--- a/projects/packages/woocommerce-analytics/src/class-pixel-builder.php
+++ b/projects/packages/woocommerce-analytics/src/class-pixel-builder.php
@@ -226,9 +226,18 @@ class Pixel_Builder {
 			return false;
 		}
 
-		$proxy_host = strtolower( WP_PROXY_HOST );
+		return self::is_socks_proxy_host( WP_PROXY_HOST );
+	}
 
-		// Check if the proxy host indicates a SOCKS proxy.
+	/**
+	 * Check if a proxy host string indicates a SOCKS proxy.
+	 *
+	 * @param string $proxy_host The proxy host value.
+	 * @return bool True if the host indicates a SOCKS proxy.
+	 */
+	public static function is_socks_proxy_host( $proxy_host ) {
+		$proxy_host = strtolower( $proxy_host );
+
 		return 0 === strpos( $proxy_host, 'socks5://' )
 			|| 0 === strpos( $proxy_host, 'socks4://' )
 			|| 0 === strpos( $proxy_host, 'socks://' );

--- a/projects/packages/woocommerce-analytics/src/class-pixel-builder.php
+++ b/projects/packages/woocommerce-analytics/src/class-pixel-builder.php
@@ -214,6 +214,27 @@ class Pixel_Builder {
 	}
 
 	/**
+	 * Check if a SOCKS proxy is configured.
+	 *
+	 * The Requests library doesn't support SOCKS proxies, so we need to fall back
+	 * to wp_remote_get() which respects WordPress proxy settings.
+	 *
+	 * @return bool True if a SOCKS proxy is configured.
+	 */
+	private static function is_socks_proxy_configured() {
+		if ( ! defined( 'WP_PROXY_HOST' ) || empty( WP_PROXY_HOST ) ) {
+			return false;
+		}
+
+		$proxy_host = strtolower( WP_PROXY_HOST );
+
+		// Check if the proxy host indicates a SOCKS proxy.
+		return str_starts_with( $proxy_host, 'socks5://' )
+			|| str_starts_with( $proxy_host, 'socks4://' )
+			|| str_starts_with( $proxy_host, 'socks://' );
+	}
+
+	/**
 	 * Send pixel requests using batched non-blocking HTTP calls.
 	 *
 	 * Uses Requests library's request_multiple() for parallel execution via curl_multi.
@@ -227,8 +248,11 @@ class Pixel_Builder {
 		}
 
 		// Check if batching is supported.
+		// Note: WpOrg\Requests\Requests doesn't support SOCKS proxies, so we fall back
+		// to individual wp_remote_get() requests which respect WP_PROXY_* settings.
 		$can_batch = ( class_exists( 'WpOrg\Requests\Requests' ) && method_exists( 'WpOrg\Requests\Requests', 'request_multiple' ) )
 			|| ( class_exists( 'Requests' ) && method_exists( 'Requests', 'request_multiple' ) );
+		$can_batch = $can_batch && ! self::is_socks_proxy_configured();
 
 		if ( ! $can_batch ) {
 			// Fallback to individual requests.

--- a/projects/packages/woocommerce-analytics/src/class-pixel-builder.php
+++ b/projects/packages/woocommerce-analytics/src/class-pixel-builder.php
@@ -226,7 +226,7 @@ class Pixel_Builder {
 			return false;
 		}
 
-		return self::is_socks_proxy_host( WP_PROXY_HOST );
+		return self::is_socks_proxy_host( (string) WP_PROXY_HOST );
 	}
 
 	/**

--- a/projects/packages/woocommerce-analytics/src/class-pixel-builder.php
+++ b/projects/packages/woocommerce-analytics/src/class-pixel-builder.php
@@ -222,16 +222,16 @@ class Pixel_Builder {
 	 * @return bool True if a SOCKS proxy is configured.
 	 */
 	private static function is_socks_proxy_configured() {
-		if ( ! defined( 'WP_PROXY_HOST' ) || empty( WP_PROXY_HOST ) ) {
+		if ( ! defined( 'WP_PROXY_HOST' ) || ! is_string( WP_PROXY_HOST ) || '' === WP_PROXY_HOST ) {
 			return false;
 		}
 
 		$proxy_host = strtolower( WP_PROXY_HOST );
 
 		// Check if the proxy host indicates a SOCKS proxy.
-		return str_starts_with( $proxy_host, 'socks5://' )
-			|| str_starts_with( $proxy_host, 'socks4://' )
-			|| str_starts_with( $proxy_host, 'socks://' );
+		return 0 === strpos( $proxy_host, 'socks5://' )
+			|| 0 === strpos( $proxy_host, 'socks4://' )
+			|| 0 === strpos( $proxy_host, 'socks://' );
 	}
 
 	/**

--- a/projects/packages/woocommerce-analytics/tests/php/Pixel_Builder_Socks_Proxy_Test.php
+++ b/projects/packages/woocommerce-analytics/tests/php/Pixel_Builder_Socks_Proxy_Test.php
@@ -75,7 +75,9 @@ class Pixel_Builder_Socks_Proxy_Test extends BaseTestCase {
 
 		$reflection = new \ReflectionClass( Pixel_Builder::class );
 		$method     = $reflection->getMethod( 'is_socks_proxy_configured' );
-		$method->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
 
 		$this->assertFalse( $method->invoke( null ) );
 	}

--- a/projects/packages/woocommerce-analytics/tests/php/Pixel_Builder_Socks_Proxy_Test.php
+++ b/projects/packages/woocommerce-analytics/tests/php/Pixel_Builder_Socks_Proxy_Test.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Tests for Pixel_Builder SOCKS proxy detection.
+ *
+ * Uses plain TestCase (not WorDBless) to allow @runInSeparateProcess,
+ * which is needed to define the WP_PROXY_HOST constant per test.
+ *
+ * @package automattic/woocommerce-analytics
+ */
+
+namespace Automattic\Woocommerce_Analytics;
+
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for Pixel_Builder SOCKS proxy detection.
+ */
+class Pixel_Builder_Socks_Proxy_Test extends TestCase {
+
+	/**
+	 * Helper to invoke the private is_socks_proxy_configured method.
+	 *
+	 * @return bool
+	 */
+	private static function invoke_is_socks_proxy_configured() {
+		$reflection = new \ReflectionClass( Pixel_Builder::class );
+		$method     = $reflection->getMethod( 'is_socks_proxy_configured' );
+		$method->setAccessible( true );
+
+		return $method->invoke( null );
+	}
+
+	/**
+	 * Test is_socks_proxy_configured returns false when WP_PROXY_HOST is not defined.
+	 */
+	public function test_returns_false_when_proxy_not_defined(): void {
+		if ( defined( 'WP_PROXY_HOST' ) ) {
+			$this->markTestSkipped( 'WP_PROXY_HOST is already defined in the environment.' );
+		}
+
+		$this->assertFalse( self::invoke_is_socks_proxy_configured() );
+	}
+
+	/**
+	 * Test is_socks_proxy_configured returns true for socks5 proxy.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_returns_true_for_socks5_proxy(): void {
+		if ( ! defined( 'WP_PROXY_HOST' ) ) {
+			define( 'WP_PROXY_HOST', 'socks5://127.0.0.1' );
+		}
+
+		$this->assertTrue( self::invoke_is_socks_proxy_configured() );
+	}
+
+	/**
+	 * Test is_socks_proxy_configured returns true for socks4 proxy.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_returns_true_for_socks4_proxy(): void {
+		if ( ! defined( 'WP_PROXY_HOST' ) ) {
+			define( 'WP_PROXY_HOST', 'socks4://127.0.0.1' );
+		}
+
+		$this->assertTrue( self::invoke_is_socks_proxy_configured() );
+	}
+
+	/**
+	 * Test is_socks_proxy_configured returns false for HTTP proxy.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_returns_false_for_http_proxy(): void {
+		if ( ! defined( 'WP_PROXY_HOST' ) ) {
+			define( 'WP_PROXY_HOST', 'proxy.example.com' );
+		}
+
+		$this->assertFalse( self::invoke_is_socks_proxy_configured() );
+	}
+}

--- a/projects/packages/woocommerce-analytics/tests/php/Pixel_Builder_Socks_Proxy_Test.php
+++ b/projects/packages/woocommerce-analytics/tests/php/Pixel_Builder_Socks_Proxy_Test.php
@@ -2,92 +2,81 @@
 /**
  * Tests for Pixel_Builder SOCKS proxy detection.
  *
- * Uses plain TestCase (not WorDBless) to allow @runInSeparateProcess,
- * which is needed to define the WP_PROXY_HOST constant per test.
- *
  * @package automattic/woocommerce-analytics
  */
 
 namespace Automattic\Woocommerce_Analytics;
 
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use WorDBless\BaseTestCase;
 
 /**
  * Tests for Pixel_Builder SOCKS proxy detection.
  */
-class Pixel_Builder_Socks_Proxy_Test extends TestCase {
+class Pixel_Builder_Socks_Proxy_Test extends BaseTestCase {
 
 	/**
-	 * Helper to invoke the private is_socks_proxy_configured method.
+	 * Test is_socks_proxy_host returns true for SOCKS proxy hosts.
 	 *
-	 * @return bool
+	 * @dataProvider socks_proxy_hosts_provider
+	 * @param string $host The proxy host value.
 	 */
-	private static function invoke_is_socks_proxy_configured() {
-		$reflection = new \ReflectionClass( Pixel_Builder::class );
-		$method     = $reflection->getMethod( 'is_socks_proxy_configured' );
-		$method->setAccessible( true );
+	#[DataProvider( 'socks_proxy_hosts_provider' )]
+	public function test_is_socks_proxy_host_returns_true( string $host ): void {
+		$this->assertTrue( Pixel_Builder::is_socks_proxy_host( $host ) );
+	}
 
-		return $method->invoke( null );
+	/**
+	 * Data provider for SOCKS proxy hosts.
+	 *
+	 * @return array
+	 */
+	public static function socks_proxy_hosts_provider(): array {
+		return array(
+			'socks5'           => array( 'socks5://127.0.0.1' ),
+			'socks4'           => array( 'socks4://127.0.0.1' ),
+			'socks generic'    => array( 'socks://127.0.0.1' ),
+			'socks5 uppercase' => array( 'SOCKS5://127.0.0.1' ),
+			'socks5 with port' => array( 'socks5://127.0.0.1:1080' ),
+		);
+	}
+
+	/**
+	 * Test is_socks_proxy_host returns false for non-SOCKS proxy hosts.
+	 *
+	 * @dataProvider non_socks_proxy_hosts_provider
+	 * @param string $host The proxy host value.
+	 */
+	#[DataProvider( 'non_socks_proxy_hosts_provider' )]
+	public function test_is_socks_proxy_host_returns_false( string $host ): void {
+		$this->assertFalse( Pixel_Builder::is_socks_proxy_host( $host ) );
+	}
+
+	/**
+	 * Data provider for non-SOCKS proxy hosts.
+	 *
+	 * @return array
+	 */
+	public static function non_socks_proxy_hosts_provider(): array {
+		return array(
+			'plain hostname' => array( 'proxy.example.com' ),
+			'http proxy'     => array( 'http://proxy.example.com' ),
+			'ip address'     => array( '192.168.1.1' ),
+		);
 	}
 
 	/**
 	 * Test is_socks_proxy_configured returns false when WP_PROXY_HOST is not defined.
 	 */
-	public function test_returns_false_when_proxy_not_defined(): void {
+	public function test_is_socks_proxy_configured_returns_false_when_not_defined(): void {
 		if ( defined( 'WP_PROXY_HOST' ) ) {
 			$this->markTestSkipped( 'WP_PROXY_HOST is already defined in the environment.' );
 		}
 
-		$this->assertFalse( self::invoke_is_socks_proxy_configured() );
-	}
+		$reflection = new \ReflectionClass( Pixel_Builder::class );
+		$method     = $reflection->getMethod( 'is_socks_proxy_configured' );
+		$method->setAccessible( true );
 
-	/**
-	 * Test is_socks_proxy_configured returns true for socks5 proxy.
-	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	#[RunInSeparateProcess]
-	#[PreserveGlobalState( false )]
-	public function test_returns_true_for_socks5_proxy(): void {
-		if ( ! defined( 'WP_PROXY_HOST' ) ) {
-			define( 'WP_PROXY_HOST', 'socks5://127.0.0.1' );
-		}
-
-		$this->assertTrue( self::invoke_is_socks_proxy_configured() );
-	}
-
-	/**
-	 * Test is_socks_proxy_configured returns true for socks4 proxy.
-	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	#[RunInSeparateProcess]
-	#[PreserveGlobalState( false )]
-	public function test_returns_true_for_socks4_proxy(): void {
-		if ( ! defined( 'WP_PROXY_HOST' ) ) {
-			define( 'WP_PROXY_HOST', 'socks4://127.0.0.1' );
-		}
-
-		$this->assertTrue( self::invoke_is_socks_proxy_configured() );
-	}
-
-	/**
-	 * Test is_socks_proxy_configured returns false for HTTP proxy.
-	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	#[RunInSeparateProcess]
-	#[PreserveGlobalState( false )]
-	public function test_returns_false_for_http_proxy(): void {
-		if ( ! defined( 'WP_PROXY_HOST' ) ) {
-			define( 'WP_PROXY_HOST', 'proxy.example.com' );
-		}
-
-		$this->assertFalse( self::invoke_is_socks_proxy_configured() );
+		$this->assertFalse( $method->invoke( null ) );
 	}
 }

--- a/projects/packages/woocommerce-analytics/tests/php/Pixel_Builder_Test.php
+++ b/projects/packages/woocommerce-analytics/tests/php/Pixel_Builder_Test.php
@@ -9,7 +9,6 @@ namespace Automattic\Woocommerce_Analytics;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use WorDBless\BaseTestCase;
 use WP_Error;
 
@@ -426,64 +425,5 @@ class Pixel_Builder_Test extends BaseTestCase {
 		$method->setAccessible( true );
 
 		$this->assertFalse( $method->invoke( null ) );
-	}
-
-	/**
-	 * Test is_socks_proxy_configured returns true when a SOCKS5 proxy is configured.
-	 *
-	 * @runInSeparateProcess
-	 */
-	#[RunInSeparateProcess]
-	public function test_is_socks_proxy_configured_returns_true_for_socks5(): void {
-		if ( ! defined( 'WP_PROXY_HOST' ) ) {
-			define( 'WP_PROXY_HOST', 'socks5://127.0.0.1' );
-		}
-
-		$reflection = new \ReflectionClass( Pixel_Builder::class );
-		$method     = $reflection->getMethod( 'is_socks_proxy_configured' );
-		$method->setAccessible( true );
-
-		$this->assertTrue( $method->invoke( null ) );
-	}
-
-	/**
-	 * Test is_socks_proxy_configured returns false for a non-SOCKS proxy.
-	 *
-	 * @runInSeparateProcess
-	 */
-	#[RunInSeparateProcess]
-	public function test_is_socks_proxy_configured_returns_false_for_http_proxy(): void {
-		if ( ! defined( 'WP_PROXY_HOST' ) ) {
-			define( 'WP_PROXY_HOST', 'proxy.example.com' );
-		}
-
-		$reflection = new \ReflectionClass( Pixel_Builder::class );
-		$method     = $reflection->getMethod( 'is_socks_proxy_configured' );
-		$method->setAccessible( true );
-
-		$this->assertFalse( $method->invoke( null ) );
-	}
-
-	/**
-	 * Test send_pixels_batched falls back to individual requests when SOCKS proxy is configured.
-	 *
-	 * @runInSeparateProcess
-	 */
-	#[RunInSeparateProcess]
-	#[IgnoreDeprecations]
-	public function test_send_pixels_batched_falls_back_when_socks_proxy(): void {
-		if ( ! defined( 'WP_PROXY_HOST' ) ) {
-			define( 'WP_PROXY_HOST', 'socks5://127.0.0.1' );
-		}
-
-		$pixels = array(
-			Pixel_Builder::TRACKS_PIXEL_URL . '?_en=woocommerceanalytics_test1',
-			Pixel_Builder::TRACKS_PIXEL_URL . '?_en=woocommerceanalytics_test2',
-		);
-
-		// Should still succeed, using the wp_remote_get fallback path.
-		$result = Pixel_Builder::send_pixels_batched( $pixels );
-
-		$this->assertTrue( $result );
 	}
 }

--- a/projects/packages/woocommerce-analytics/tests/php/Pixel_Builder_Test.php
+++ b/projects/packages/woocommerce-analytics/tests/php/Pixel_Builder_Test.php
@@ -9,6 +9,7 @@ namespace Automattic\Woocommerce_Analytics;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use WorDBless\BaseTestCase;
 use WP_Error;
 
@@ -416,14 +417,73 @@ class Pixel_Builder_Test extends BaseTestCase {
 	 * Test is_socks_proxy_configured returns false when WP_PROXY_HOST is not defined.
 	 */
 	public function test_is_socks_proxy_configured_returns_false_when_not_defined(): void {
-		// Use reflection to access private method.
+		if ( defined( 'WP_PROXY_HOST' ) ) {
+			$this->markTestSkipped( 'WP_PROXY_HOST is already defined in the environment.' );
+		}
+
 		$reflection = new \ReflectionClass( Pixel_Builder::class );
 		$method     = $reflection->getMethod( 'is_socks_proxy_configured' );
 		$method->setAccessible( true );
 
-		// When WP_PROXY_HOST is not defined (default), should return false.
-		$result = $method->invoke( null );
+		$this->assertFalse( $method->invoke( null ) );
+	}
 
-		$this->assertFalse( $result );
+	/**
+	 * Test is_socks_proxy_configured returns true when a SOCKS5 proxy is configured.
+	 *
+	 * @runInSeparateProcess
+	 */
+	#[RunInSeparateProcess]
+	public function test_is_socks_proxy_configured_returns_true_for_socks5(): void {
+		if ( ! defined( 'WP_PROXY_HOST' ) ) {
+			define( 'WP_PROXY_HOST', 'socks5://127.0.0.1' );
+		}
+
+		$reflection = new \ReflectionClass( Pixel_Builder::class );
+		$method     = $reflection->getMethod( 'is_socks_proxy_configured' );
+		$method->setAccessible( true );
+
+		$this->assertTrue( $method->invoke( null ) );
+	}
+
+	/**
+	 * Test is_socks_proxy_configured returns false for a non-SOCKS proxy.
+	 *
+	 * @runInSeparateProcess
+	 */
+	#[RunInSeparateProcess]
+	public function test_is_socks_proxy_configured_returns_false_for_http_proxy(): void {
+		if ( ! defined( 'WP_PROXY_HOST' ) ) {
+			define( 'WP_PROXY_HOST', 'proxy.example.com' );
+		}
+
+		$reflection = new \ReflectionClass( Pixel_Builder::class );
+		$method     = $reflection->getMethod( 'is_socks_proxy_configured' );
+		$method->setAccessible( true );
+
+		$this->assertFalse( $method->invoke( null ) );
+	}
+
+	/**
+	 * Test send_pixels_batched falls back to individual requests when SOCKS proxy is configured.
+	 *
+	 * @runInSeparateProcess
+	 */
+	#[RunInSeparateProcess]
+	#[IgnoreDeprecations]
+	public function test_send_pixels_batched_falls_back_when_socks_proxy(): void {
+		if ( ! defined( 'WP_PROXY_HOST' ) ) {
+			define( 'WP_PROXY_HOST', 'socks5://127.0.0.1' );
+		}
+
+		$pixels = array(
+			Pixel_Builder::TRACKS_PIXEL_URL . '?_en=woocommerceanalytics_test1',
+			Pixel_Builder::TRACKS_PIXEL_URL . '?_en=woocommerceanalytics_test2',
+		);
+
+		// Should still succeed, using the wp_remote_get fallback path.
+		$result = Pixel_Builder::send_pixels_batched( $pixels );
+
+		$this->assertTrue( $result );
 	}
 }

--- a/projects/packages/woocommerce-analytics/tests/php/Pixel_Builder_Test.php
+++ b/projects/packages/woocommerce-analytics/tests/php/Pixel_Builder_Test.php
@@ -411,19 +411,4 @@ class Pixel_Builder_Test extends BaseTestCase {
 
 		$this->assertTrue( $result );
 	}
-
-	/**
-	 * Test is_socks_proxy_configured returns false when WP_PROXY_HOST is not defined.
-	 */
-	public function test_is_socks_proxy_configured_returns_false_when_not_defined(): void {
-		if ( defined( 'WP_PROXY_HOST' ) ) {
-			$this->markTestSkipped( 'WP_PROXY_HOST is already defined in the environment.' );
-		}
-
-		$reflection = new \ReflectionClass( Pixel_Builder::class );
-		$method     = $reflection->getMethod( 'is_socks_proxy_configured' );
-		$method->setAccessible( true );
-
-		$this->assertFalse( $method->invoke( null ) );
-	}
 }

--- a/projects/packages/woocommerce-analytics/tests/php/Pixel_Builder_Test.php
+++ b/projects/packages/woocommerce-analytics/tests/php/Pixel_Builder_Test.php
@@ -411,4 +411,19 @@ class Pixel_Builder_Test extends BaseTestCase {
 
 		$this->assertTrue( $result );
 	}
+
+	/**
+	 * Test is_socks_proxy_configured returns false when WP_PROXY_HOST is not defined.
+	 */
+	public function test_is_socks_proxy_configured_returns_false_when_not_defined(): void {
+		// Use reflection to access private method.
+		$reflection = new \ReflectionClass( Pixel_Builder::class );
+		$method     = $reflection->getMethod( 'is_socks_proxy_configured' );
+		$method->setAccessible( true );
+
+		// When WP_PROXY_HOST is not defined (default), should return false.
+		$result = $method->invoke( null );
+
+		$this->assertFalse( $result );
+	}
 }


### PR DESCRIPTION
Fixes WOOA7S-1146

## Proposed changes

* Added `is_socks_proxy_configured()` method to detect when a SOCKS proxy (`socks5://`, `socks4://`, `socks://`) is configured via `WP_PROXY_HOST`
* Modified `send_pixels_batched()` to fall back to individual `wp_remote_get()` requests when a SOCKS proxy is detected, since the `WpOrg\Requests\Requests` library doesn't support SOCKS proxies or respect WordPress proxy settings
* Added unit test for the SOCKS proxy detection

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* p1773972582207959/1773936166.674629-slack-C06FSDTSN82


## Does this pull request change what data or activity we track or use?
No — this only changes the transport mechanism (batched vs individual requests) under certain proxy configurations. No tracking data changes.

## Testing instructions

1. Set up a WordPress environment with a SOCKS proxy by adding to `wp-config.php` such as:
   ```php
   define( 'WP_PROXY_HOST', 'socks5://127.0.0.1' );
   define( 'WP_PROXY_PORT', '1080' );
   ```
2. Trigger WooCommerce analytics events that use server-side pixel tracking (e.g., via the `/track` endpoint)
3. Verify that pixel requests are sent successfully via `wp_remote_get()` (the fallback path) instead of the batched `Requests::request_multiple()` path
4. Without a SOCKS proxy configured, verify that batched requests still work as before