### PR TITLE
Forms Dashboard: Add tracking for Create Form button clicks

### DIFF
--- a/projects/packages/forms/changelog/add-track-create-form-button
+++ b/projects/packages/forms/changelog/add-track-create-form-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Add tracking events for Create Form button clicks, modal close, and modal create actions

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -641,6 +641,7 @@ function StageInner() {
 										label={ __( 'Create a new form', 'jetpack-forms' ) }
 										variant="primary"
 										showNameModal
+										source="forms_empty_state"
 									/>
 									{ hasClassicForms && (
 										<Button size="compact" variant="secondary" onClick={ openFormsHelpModal }>

--- a/projects/packages/forms/src/dashboard/components/actions-dropdown-menu/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/actions-dropdown-menu/index.tsx
@@ -34,6 +34,9 @@ const ActionsDropdownMenu = ( { exportData }: ActionsDropdownMenuProps ) => {
 	}, [] );
 
 	const onCreateFormClick = useCallback( () => {
+		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_create_form_click', {
+			source: 'actions_menu',
+		} );
 		openNewForm( {
 			analyticsEvent,
 		} );

--- a/projects/packages/forms/src/dashboard/components/create-form-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/create-form-button/index.tsx
@@ -18,6 +18,7 @@ type CreateFormButtonProps = {
 	variant?: 'primary' | 'secondary';
 	showIcon?: boolean;
 	showNameModal?: boolean;
+	source?: 'forms_header' | 'forms_empty_state' | 'responses_header' | 'responses_empty_state';
 };
 
 /**
@@ -29,6 +30,7 @@ type CreateFormButtonProps = {
  * @param {string}  props.variant       - The button variant (primary or secondary).
  * @param {boolean} props.showIcon      - Whether to show the plus icon.
  * @param {boolean} props.showNameModal - Whether to show a modal asking for the form name before creating.
+ * @param {string}  props.source        - The source identifier for tracking where the button was clicked.
  * @return {JSX.Element}                  The button to create a new form.
  */
 export default function CreateFormButton( {
@@ -37,11 +39,15 @@ export default function CreateFormButton( {
 	variant = 'secondary',
 	showIcon = true,
 	showNameModal = false,
+	source,
 }: CreateFormButtonProps ): JSX.Element {
 	const { openNewForm } = useCreateForm();
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 
 	const onButtonClickHandler = useCallback( () => {
+		if ( source ) {
+			jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_create_form_click', { source } );
+		}
 		if ( showNameModal ) {
 			setIsModalOpen( true );
 			return;
@@ -54,14 +60,20 @@ export default function CreateFormButton( {
 				} );
 			},
 		} );
-	}, [ showNameModal, openNewForm, showPatterns ] );
+	}, [ showNameModal, openNewForm, showPatterns, source ] );
 
 	const handleModalClose = useCallback( () => {
+		if ( source ) {
+			jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_create_form_modal_close', { source } );
+		}
 		setIsModalOpen( false );
-	}, [] );
+	}, [ source ] );
 
 	const handleModalSave = useCallback(
 		async ( formTitle: string ) => {
+			if ( source ) {
+				jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_create_form_modal_create', { source } );
+			}
 			await openNewForm( {
 				showPatterns,
 				formTitle,
@@ -72,7 +84,7 @@ export default function CreateFormButton( {
 				},
 			} );
 		},
-		[ openNewForm, showPatterns ]
+		[ openNewForm, showPatterns, source ]
 	);
 
 	return (

--- a/projects/packages/forms/src/dashboard/components/empty-responses/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/empty-responses/index.tsx
@@ -256,6 +256,7 @@ const EmptyResponses = ( {
 						label={ __( 'Create a new form', 'jetpack-forms' ) }
 						variant="primary"
 						showNameModal
+						source="responses_empty_state"
 					/>
 				)
 			}

--- a/projects/packages/forms/src/dashboard/forms/index.tsx
+++ b/projects/packages/forms/src/dashboard/forms/index.tsx
@@ -398,7 +398,10 @@ export default function FormsDashboardForms(): JSX.Element | null {
 
 	const onChangeView = useCallback( newView => setView( newView ), [ setView ] );
 
-	const headerActions = useMemo( () => [ <CreateFormButton key="create" showNameModal /> ], [] );
+	const headerActions = useMemo(
+		() => [ <CreateFormButton key="create" showNameModal source="forms_header" /> ],
+		[]
+	);
 	const getItemId = useCallback( ( item: FormListItem ) => String( item.id ), [] );
 	const onClickItem = useCallback(
 		( item: FormListItem ) => {
@@ -455,6 +458,7 @@ export default function FormsDashboardForms(): JSX.Element | null {
 										label={ __( 'Create a new form', 'jetpack-forms' ) }
 										variant="primary"
 										showNameModal
+										source="forms_empty_state"
 									/>
 									{ hasClassicForms && (
 										<Button size="compact" variant="secondary" onClick={ openFormsHelpModal }>

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { useBreakpointMatch } from '@automattic/jetpack-components';
 import JetpackLogo from '@automattic/jetpack-components/jetpack-logo';
 import { Breadcrumbs } from '@wordpress/admin-ui';
@@ -106,15 +107,31 @@ export default function usePageHeaderDetails(
 	// Hooks for mobile dropdown menu actions
 	const { openNewForm } = useCreateForm();
 	const [ isCreateFormModalOpen, setIsCreateFormModalOpen ] = useState( false );
-	const handleCreateFormClick = useCallback( () => {
+	const [ createFormSource, setCreateFormSource ] = useState< string | null >( null );
+	const handleCreateFormClick = useCallback( ( source: string ) => {
+		setCreateFormSource( source );
 		setIsCreateFormModalOpen( true );
 	}, [] );
-	const closeCreateFormModal = useCallback( () => setIsCreateFormModalOpen( false ), [] );
+	const closeCreateFormModal = useCallback( () => {
+		if ( createFormSource ) {
+			jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_create_form_modal_close', {
+				source: createFormSource,
+			} );
+		}
+		setCreateFormSource( null );
+		setIsCreateFormModalOpen( false );
+	}, [ createFormSource ] );
 	const handleCreateFormSave = useCallback(
 		async ( formName: string ) => {
+			if ( createFormSource ) {
+				jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_create_form_modal_create', {
+					source: createFormSource,
+				} );
+			}
+			setCreateFormSource( null );
 			await openNewForm( { formTitle: formName } );
 		},
-		[ openNewForm ]
+		[ openNewForm, createFormSource ]
 	);
 	const {
 		showExportModal,
@@ -559,7 +576,12 @@ export default function usePageHeaderDetails(
 				}
 
 				dropdownControls.push( {
-					onClick: handleCreateFormClick,
+					onClick: () => {
+						jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_create_form_click', {
+							source: 'forms_header_mobile',
+						} );
+						handleCreateFormClick( 'forms_header_mobile' );
+					},
 					title: __( 'Create a form', 'jetpack-forms' ),
 				} );
 			} else if ( isSingleFormScreen ) {
@@ -606,7 +628,12 @@ export default function usePageHeaderDetails(
 
 				if ( statusView === 'inbox' ) {
 					dropdownControls.push( {
-						onClick: handleCreateFormClick,
+						onClick: () => {
+							jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_create_form_click', {
+								source: 'responses_header_mobile',
+							} );
+							handleCreateFormClick( 'responses_header_mobile' );
+						},
 						title: __( 'Create a form', 'jetpack-forms' ),
 					} );
 				}
@@ -735,7 +762,13 @@ export default function usePageHeaderDetails(
 				...( isIntegrationsEnabled && showDashboardIntegrations
 					? [ <ManageIntegrationsButton key="integrations" onClick={ onOpenIntegrations } /> ]
 					: [] ),
-				<CreateFormButton key="create" variant="primary" showIcon={ false } showNameModal />,
+				<CreateFormButton
+					key="create"
+					variant="primary"
+					showIcon={ false }
+					showNameModal
+					source="forms_header"
+				/>,
 			];
 		}
 
@@ -809,6 +842,7 @@ export default function usePageHeaderDetails(
 							showPatterns={ false }
 							showIcon={ false }
 							showNameModal
+							source="responses_header"
 						/>,
 				  ]
 				: [] ),


### PR DESCRIPTION
Part to FORMS-634

## Proposed changes
* Add `jetpack_forms_create_form_click` tracking event with a `source` property to all "Create a form" button locations across the dashboard
* Add `jetpack_forms_create_form_modal_close` event when the form name modal is cancelled
* Add `jetpack_forms_create_form_modal_create` event when the "Create" button is clicked in the modal
* All events include a `source` property to identify where the action originated:
  - `forms_header` — Forms page header button
  - `forms_empty_state` — Forms page empty state CTA
  - `responses_header` — Responses page header button
  - `responses_empty_state` — Responses page empty state CTA
  - `forms_header_mobile` — Forms page mobile dropdown
  - `responses_header_mobile` — Responses page mobile dropdown
  - `actions_menu` — Actions dropdown menu

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
Yes — this adds three new Tracks events (`jetpack_forms_create_form_click`, `jetpack_forms_create_form_modal_close`, `jetpack_forms_create_form_modal_create`) to measure form creation engagement across the dashboard. Each event includes a `source` string property.

## Testing instructions
* Go to the Jetpack Forms dashboard (wp-admin → Jetpack → Forms)
* Open browser dev tools and filter the Network tab for `tracks` or monitor `window._tkq`
* Click the "Create a form" button in the page header → verify `jetpack_forms_create_form_click` fires with `source: forms_header`
* In the form name modal, click Cancel → verify `jetpack_forms_create_form_modal_close` fires
* Click "Create a form" again, enter a name, click Create → verify `jetpack_forms_create_form_modal_create` fires
* Delete all forms to see the empty state, click the CTA → verify the event fires with `source: forms_empty_state`
* Navigate to the Responses page and repeat for the header button (`source: responses_header`)
* Resize the browser to mobile width and test the dropdown menu items (`source: forms_header_mobile` / `responses_header_mobile`)
