### PR TITLE
Fix AI assistant banner dismiss and respect AI Tips unsub

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-ai-assistant-banner-mu-wpcom
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-ai-assistant-banner-mu-wpcom
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add AI assistant banner to the WordPress.com dashboard for Business/Commerce sites

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -342,6 +342,7 @@ class Jetpack_Mu_Wpcom {
 		if ( ! class_exists( 'A8C\FSE\Survicate' ) ) {
 			require_once __DIR__ . '/features/survicate/class-survicate.php';
 		}
+		require_once __DIR__ . '/features/ai-assistant-banner/ai-assistant-banner.php';
 		require_once __DIR__ . '/features/html-block-restricted-tags/html-block-restricted-tags.php';
 		require_once __DIR__ . '/features/marketing/marketing.php';
 		require_once __DIR__ . '/features/pages/pages.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/ai-assistant-banner.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/ai-assistant-banner.php
@@ -35,9 +35,18 @@ function wpcom_should_show_ai_assistant_banner() {
 		return false;
 	}
 
-	// Don't show if user has opted out of AI features.
-	if ( function_exists( 'get_user_attribute' ) && '1' === get_user_attribute( get_current_user_id(), 'ai_features_opted_out' ) ) {
-		return false;
+	if ( function_exists( 'get_user_attribute' ) ) {
+		$user_id = get_current_user_id();
+
+		// Don't show if user has opted out of AI features.
+		if ( '1' === get_user_attribute( $user_id, 'ai_features_opted_out' ) ) {
+			return false;
+		}
+
+		// Don't show if user has unsubscribed from AI Tips emails.
+		if ( '1' === get_user_attribute( $user_id, 'notifications_wpcom_email_ai_tips' ) ) {
+			return false;
+		}
 	}
 
 	return true;
@@ -51,7 +60,7 @@ function wpcom_render_ai_assistant_banner() {
 	$cta_url   = wpcom_get_calypso_origin() . '/sites/' . $site_slug . '/settings/ai-tools';
 	$nonce     = wp_create_nonce( 'dismiss_ai_assistant_banner' );
 	?>
-	<div id="wpcom-ai-assistant-banner" class="notice is-dismissible" style="border-left-color: #3858E9;" data-nonce="<?php echo esc_attr( $nonce ); ?>">
+	<div id="wpcom-ai-assistant-banner" class="notice" style="border-left-color: #3858E9;" data-nonce="<?php echo esc_attr( $nonce ); ?>">
 		<div style="display: flex; align-items: center; gap: 16px; padding: 4px 0;">
 			<svg width="24" height="24" viewBox="0 0 400 400" fill="none" xmlns="http://www.w3.org/2000/svg">
 				<path d="M391.528 188.061L309.455 159.75C276.997 148.597 251.403 123.003 240.25 90.5451L211.939 8.47185C208.079 -2.82395 191.921 -2.82395 188.061 8.47185L159.75 90.5451C148.597 123.003 123.003 148.597 90.5451 159.75L8.47185 188.061C-2.82395 191.921 -2.82395 208.079 8.47185 211.939L90.5451 240.25C123.003 251.403 148.597 276.997 159.75 309.455L188.061 391.528C191.921 402.824 208.079 402.824 211.939 391.528L240.25 309.455C251.403 276.997 276.997 251.403 309.455 240.25L391.528 211.939C402.824 208.079 402.824 191.921 391.528 188.061ZM295.728 206.077L254.692 220.232C238.391 225.809 225.666 238.677 220.089 254.835L205.934 295.871C203.932 301.591 195.925 301.591 193.923 295.871L179.768 254.835C174.191 238.534 161.323 225.809 145.165 220.232L104.129 206.077C98.4093 204.075 98.4093 196.068 104.129 194.066L145.165 179.911C161.466 174.334 174.191 161.466 179.768 145.308L193.923 104.272C195.925 98.5523 203.932 98.5523 205.934 104.272L220.089 145.308C225.666 161.609 238.534 174.334 254.692 179.911L295.728 194.066C301.448 196.068 301.448 204.075 295.728 206.077Z" fill="#3858E9"/>
@@ -63,6 +72,7 @@ function wpcom_render_ai_assistant_banner() {
 			<a href="<?php echo esc_url( $cta_url ); ?>" class="button-secondary">
 				<?php esc_html_e( 'Enable AI assistant', 'jetpack-mu-wpcom' ); ?>
 			</a>
+			<button type="button" class="notice-dismiss"><span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.', 'jetpack-mu-wpcom' ); ?></span></button>
 		</div>
 	</div>
 	<style>

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/ai-assistant-banner.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/ai-assistant-banner.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * AI Assistant Banner for the WordPress.com dashboard.
+ *
+ * Displays a banner prompting Business/Commerce admins to enable the AI assistant.
+ * Works on both Simple and Atomic sites via cross-platform utilities.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Determines whether the AI assistant banner should be shown to the current user.
+ *
+ * @return bool
+ */
+function wpcom_should_show_ai_assistant_banner() {
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return false;
+	}
+
+	if ( ! wpcom_site_has_feature( 'ai-assistant' ) ) {
+		return false;
+	}
+
+	// Don't show on Big Sky sites.
+	if ( get_option( 'site_intent' ) === 'ai-assembler' ) {
+		return false;
+	}
+	if ( wpcom_has_blog_sticker( 'big-sky-enabled', get_wpcom_blog_id() ) ) {
+		return false;
+	}
+
+	// Don't show if already dismissed.
+	if ( get_user_meta( get_current_user_id(), 'wpcom_ai_assistant_banner_dismissed', true ) ) {
+		return false;
+	}
+
+	// Don't show if user has opted out of AI features (Simple sites only).
+	if ( function_exists( 'get_user_attribute' ) && '1' === get_user_attribute( get_current_user_id(), 'ai_features_opted_out' ) ) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Renders the AI assistant banner markup.
+ */
+function wpcom_render_ai_assistant_banner() {
+	$site_slug = wp_parse_url( home_url(), PHP_URL_HOST );
+	$cta_url   = 'https://wordpress.com/sites/' . $site_slug . '/settings/ai-tools';
+	$nonce     = wp_create_nonce( 'dismiss_ai_assistant_banner' );
+	?>
+	<div id="wpcom-ai-assistant-banner" class="notice wpcom-ai-assistant-banner" data-nonce="<?php echo esc_attr( $nonce ); ?>">
+		<div class="wpcom-ai-assistant-banner__content">
+			<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class="wpcom-ai-assistant-banner__icon">
+				<path d="M12 2L14.09 8.26L20 9.27L15.55 13.97L16.91 20L12 16.9L7.09 20L8.45 13.97L4 9.27L9.91 8.26L12 2Z" fill="#E65054"/>
+			</svg>
+			<div class="wpcom-ai-assistant-banner__text">
+				<strong><?php esc_html_e( 'Bring AI to your site.', 'jetpack-mu-wpcom' ); ?></strong>
+				<span><?php esc_html_e( 'Enable the AI assistant to help you create content, optimize your site, and more.', 'jetpack-mu-wpcom' ); ?></span>
+			</div>
+			<a href="<?php echo esc_url( $cta_url ); ?>" class="button button-primary wpcom-ai-assistant-banner__cta">
+				<?php esc_html_e( 'Enable AI', 'jetpack-mu-wpcom' ); ?>
+			</a>
+		</div>
+		<button type="button" class="notice-dismiss wpcom-ai-assistant-banner__dismiss">
+			<span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.', 'jetpack-mu-wpcom' ); ?></span>
+		</button>
+	</div>
+	<style>
+		.wpcom-ai-assistant-banner {
+			display: flex;
+			align-items: center;
+			padding: 12px 16px;
+			border-left-color: #E65054;
+			position: relative;
+		}
+		.wpcom-ai-assistant-banner__content {
+			display: flex;
+			align-items: center;
+			gap: 12px;
+			flex: 1;
+		}
+		.wpcom-ai-assistant-banner__icon {
+			flex-shrink: 0;
+		}
+		.wpcom-ai-assistant-banner__text {
+			display: flex;
+			flex-direction: column;
+			gap: 2px;
+		}
+		.wpcom-ai-assistant-banner__dismiss {
+			position: static;
+			flex-shrink: 0;
+			margin-left: 8px;
+		}
+	</style>
+	<?php
+}
+
+/**
+ * Conditionally adds the AI assistant banner on the dashboard screen.
+ */
+function wpcom_maybe_add_ai_assistant_banner() {
+	$screen = get_current_screen();
+	if ( ! $screen || 'dashboard' !== $screen->id ) {
+		return;
+	}
+
+	if ( ! wpcom_should_show_ai_assistant_banner() ) {
+		return;
+	}
+
+	add_action( 'admin_notices', 'wpcom_render_ai_assistant_banner' );
+
+	wp_register_script_module(
+		'wpcom-tracks-module',
+		plugin_dir_url( __FILE__ ) . '../../common/tracks.js',
+		array(),
+		'20250604'
+	);
+
+	wp_enqueue_script_module(
+		'wpcom-ai-assistant-banner',
+		plugin_dir_url( __FILE__ ) . 'js/ai-assistant-banner.js',
+		array( 'wpcom-tracks-module', 'jquery' ),
+		'20250604'
+	);
+}
+add_action( 'current_screen', 'wpcom_maybe_add_ai_assistant_banner' );
+
+/**
+ * AJAX handler to dismiss the AI assistant banner.
+ */
+function wpcom_dismiss_ai_assistant_banner() {
+	check_ajax_referer( 'dismiss_ai_assistant_banner', 'nonce' );
+	update_user_meta( get_current_user_id(), 'wpcom_ai_assistant_banner_dismissed', '1' );
+	wp_send_json_success( null, 200, JSON_UNESCAPED_SLASHES );
+}
+add_action( 'wp_ajax_dismiss_ai_assistant_banner', 'wpcom_dismiss_ai_assistant_banner' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/ai-assistant-banner.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/ai-assistant-banner.php
@@ -97,7 +97,7 @@ function wpcom_maybe_add_ai_assistant_banner() {
 
 	wp_enqueue_script(
 		'wpcom-ai-assistant-banner',
-		plugin_dir_url( __FILE__ ) . 'js/wpcom-ai-assistant-banner.js',
+		plugin_dir_url( __FILE__ ) . 'js/ai-assistant-banner.js',
 		array( 'jquery' ),
 		'20250604',
 		true

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/ai-assistant-banner.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/ai-assistant-banner.php
@@ -60,7 +60,7 @@ function wpcom_render_ai_assistant_banner() {
 				<strong><?php esc_html_e( 'Bring AI to your site.', 'jetpack-mu-wpcom' ); ?></strong>
 				<span><?php esc_html_e( 'Opt-in to get site-aware assistance where you write and design.', 'jetpack-mu-wpcom' ); ?></span>
 			</div>
-			<a href="<?php echo esc_url( $cta_url ); ?>" class="button button-primary wpcom-ai-assistant-banner__cta">
+			<a href="<?php echo esc_url( $cta_url ); ?>" class="button wpcom-ai-assistant-banner__cta">
 				<?php esc_html_e( 'Enable AI assistant', 'jetpack-mu-wpcom' ); ?>
 			</a>
 		</div>
@@ -74,7 +74,6 @@ function wpcom_render_ai_assistant_banner() {
 			align-items: center;
 			padding: 12px 16px;
 			border-left-color: #3858E9;
-			position: relative;
 		}
 		.wpcom-ai-assistant-banner__content {
 			display: flex;
@@ -86,14 +85,16 @@ function wpcom_render_ai_assistant_banner() {
 			flex-shrink: 0;
 		}
 		.wpcom-ai-assistant-banner__text {
-			display: flex;
-			flex-direction: column;
-			gap: 2px;
+			flex: 1;
 		}
-		.wpcom-ai-assistant-banner__dismiss {
+		.wpcom-ai-assistant-banner__cta {
+			flex-shrink: 0;
+			white-space: nowrap;
+		}
+		.wpcom-ai-assistant-banner .notice-dismiss {
 			position: static;
 			flex-shrink: 0;
-			margin-left: 8px;
+			padding: 0 0 0 12px;
 		}
 	</style>
 	<?php
@@ -112,7 +113,7 @@ function wpcom_maybe_add_ai_assistant_banner() {
 		return;
 	}
 
-	add_action( 'admin_notices', 'wpcom_render_ai_assistant_banner' );
+	add_action( 'admin_notices', 'wpcom_render_ai_assistant_banner', 1 );
 
 	wp_register_script_module(
 		'wpcom-tracks-module',

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/ai-assistant-banner.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/ai-assistant-banner.php
@@ -53,15 +53,15 @@ function wpcom_render_ai_assistant_banner() {
 	?>
 	<div id="wpcom-ai-assistant-banner" class="notice wpcom-ai-assistant-banner" data-nonce="<?php echo esc_attr( $nonce ); ?>">
 		<div class="wpcom-ai-assistant-banner__content">
-			<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class="wpcom-ai-assistant-banner__icon">
-				<path d="M12 2L14.09 8.26L20 9.27L15.55 13.97L16.91 20L12 16.9L7.09 20L8.45 13.97L4 9.27L9.91 8.26L12 2Z" fill="#E65054"/>
+			<svg width="24" height="24" viewBox="0 0 400 400" fill="none" xmlns="http://www.w3.org/2000/svg" class="wpcom-ai-assistant-banner__icon">
+				<path d="M391.528 188.061L309.455 159.75C276.997 148.597 251.403 123.003 240.25 90.5451L211.939 8.47185C208.079 -2.82395 191.921 -2.82395 188.061 8.47185L159.75 90.5451C148.597 123.003 123.003 148.597 90.5451 159.75L8.47185 188.061C-2.82395 191.921 -2.82395 208.079 8.47185 211.939L90.5451 240.25C123.003 251.403 148.597 276.997 159.75 309.455L188.061 391.528C191.921 402.824 208.079 402.824 211.939 391.528L240.25 309.455C251.403 276.997 276.997 251.403 309.455 240.25L391.528 211.939C402.824 208.079 402.824 191.921 391.528 188.061ZM295.728 206.077L254.692 220.232C238.391 225.809 225.666 238.677 220.089 254.835L205.934 295.871C203.932 301.591 195.925 301.591 193.923 295.871L179.768 254.835C174.191 238.534 161.323 225.809 145.165 220.232L104.129 206.077C98.4093 204.075 98.4093 196.068 104.129 194.066L145.165 179.911C161.466 174.334 174.191 161.466 179.768 145.308L193.923 104.272C195.925 98.5523 203.932 98.5523 205.934 104.272L220.089 145.308C225.666 161.609 238.534 174.334 254.692 179.911L295.728 194.066C301.448 196.068 301.448 204.075 295.728 206.077Z" fill="#3858E9"/>
 			</svg>
 			<div class="wpcom-ai-assistant-banner__text">
 				<strong><?php esc_html_e( 'Bring AI to your site.', 'jetpack-mu-wpcom' ); ?></strong>
-				<span><?php esc_html_e( 'Enable the AI assistant to help you create content, optimize your site, and more.', 'jetpack-mu-wpcom' ); ?></span>
+				<span><?php esc_html_e( 'Opt-in to get site-aware assistance where you write and design.', 'jetpack-mu-wpcom' ); ?></span>
 			</div>
 			<a href="<?php echo esc_url( $cta_url ); ?>" class="button button-primary wpcom-ai-assistant-banner__cta">
-				<?php esc_html_e( 'Enable AI', 'jetpack-mu-wpcom' ); ?>
+				<?php esc_html_e( 'Enable AI assistant', 'jetpack-mu-wpcom' ); ?>
 			</a>
 		</div>
 		<button type="button" class="notice-dismiss wpcom-ai-assistant-banner__dismiss">
@@ -73,7 +73,7 @@ function wpcom_render_ai_assistant_banner() {
 			display: flex;
 			align-items: center;
 			padding: 12px 16px;
-			border-left-color: #E65054;
+			border-left-color: #3858E9;
 			position: relative;
 		}
 		.wpcom-ai-assistant-banner__content {

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/ai-assistant-banner.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/ai-assistant-banner.php
@@ -51,52 +51,20 @@ function wpcom_render_ai_assistant_banner() {
 	$cta_url   = 'https://wordpress.com/sites/' . $site_slug . '/settings/ai-tools';
 	$nonce     = wp_create_nonce( 'dismiss_ai_assistant_banner' );
 	?>
-	<div id="wpcom-ai-assistant-banner" class="notice wpcom-ai-assistant-banner" data-nonce="<?php echo esc_attr( $nonce ); ?>">
-		<div class="wpcom-ai-assistant-banner__content">
-			<svg width="24" height="24" viewBox="0 0 400 400" fill="none" xmlns="http://www.w3.org/2000/svg" class="wpcom-ai-assistant-banner__icon">
+	<div id="wpcom-ai-assistant-banner" class="notice is-dismissible" data-nonce="<?php echo esc_attr( $nonce ); ?>">
+		<div style="display: flex; align-items: center; gap: 16px; padding: 4px 0;">
+			<svg width="24" height="24" viewBox="0 0 400 400" fill="none" xmlns="http://www.w3.org/2000/svg">
 				<path d="M391.528 188.061L309.455 159.75C276.997 148.597 251.403 123.003 240.25 90.5451L211.939 8.47185C208.079 -2.82395 191.921 -2.82395 188.061 8.47185L159.75 90.5451C148.597 123.003 123.003 148.597 90.5451 159.75L8.47185 188.061C-2.82395 191.921 -2.82395 208.079 8.47185 211.939L90.5451 240.25C123.003 251.403 148.597 276.997 159.75 309.455L188.061 391.528C191.921 402.824 208.079 402.824 211.939 391.528L240.25 309.455C251.403 276.997 276.997 251.403 309.455 240.25L391.528 211.939C402.824 208.079 402.824 191.921 391.528 188.061ZM295.728 206.077L254.692 220.232C238.391 225.809 225.666 238.677 220.089 254.835L205.934 295.871C203.932 301.591 195.925 301.591 193.923 295.871L179.768 254.835C174.191 238.534 161.323 225.809 145.165 220.232L104.129 206.077C98.4093 204.075 98.4093 196.068 104.129 194.066L145.165 179.911C161.466 174.334 174.191 161.466 179.768 145.308L193.923 104.272C195.925 98.5523 203.932 98.5523 205.934 104.272L220.089 145.308C225.666 161.609 238.534 174.334 254.692 179.911L295.728 194.066C301.448 196.068 301.448 204.075 295.728 206.077Z" fill="#3858E9"/>
 			</svg>
-			<div class="wpcom-ai-assistant-banner__text">
-				<strong><?php esc_html_e( 'Bring AI to your site.', 'jetpack-mu-wpcom' ); ?></strong>
-				<span><?php esc_html_e( 'Opt-in to get site-aware assistance where you write and design.', 'jetpack-mu-wpcom' ); ?></span>
+			<div style="flex: 1;">
+				<strong><?php esc_html_e( 'Bring AI to your site.', 'jetpack-mu-wpcom' ); ?></strong><br>
+				<?php esc_html_e( 'Opt-in to get site-aware assistance where you write and design.', 'jetpack-mu-wpcom' ); ?>
 			</div>
-			<a href="<?php echo esc_url( $cta_url ); ?>" class="button wpcom-ai-assistant-banner__cta">
+			<a href="<?php echo esc_url( $cta_url ); ?>" class="button-secondary" style="margin-right: 16px;">
 				<?php esc_html_e( 'Enable AI assistant', 'jetpack-mu-wpcom' ); ?>
 			</a>
 		</div>
-		<button type="button" class="notice-dismiss wpcom-ai-assistant-banner__dismiss">
-			<span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.', 'jetpack-mu-wpcom' ); ?></span>
-		</button>
 	</div>
-	<style>
-		.wpcom-ai-assistant-banner {
-			display: flex;
-			align-items: center;
-			padding: 12px 16px;
-			border-left-color: #3858E9;
-		}
-		.wpcom-ai-assistant-banner__content {
-			display: flex;
-			align-items: center;
-			gap: 12px;
-			flex: 1;
-		}
-		.wpcom-ai-assistant-banner__icon {
-			flex-shrink: 0;
-		}
-		.wpcom-ai-assistant-banner__text {
-			flex: 1;
-		}
-		.wpcom-ai-assistant-banner__cta {
-			flex-shrink: 0;
-			white-space: nowrap;
-		}
-		.wpcom-ai-assistant-banner .notice-dismiss {
-			position: static;
-			flex-shrink: 0;
-			padding: 0 0 0 12px;
-		}
-	</style>
 	<?php
 }
 
@@ -115,18 +83,12 @@ function wpcom_maybe_add_ai_assistant_banner() {
 
 	add_action( 'admin_notices', 'wpcom_render_ai_assistant_banner', 1 );
 
-	wp_register_script_module(
-		'wpcom-tracks-module',
-		plugin_dir_url( __FILE__ ) . '../../common/tracks.js',
-		array(),
-		'20250604'
-	);
-
-	wp_enqueue_script_module(
+	wp_enqueue_script(
 		'wpcom-ai-assistant-banner',
 		plugin_dir_url( __FILE__ ) . 'js/ai-assistant-banner.js',
-		array( 'wpcom-tracks-module', 'jquery' ),
-		'20250604'
+		array( 'jquery' ),
+		'20250604',
+		true
 	);
 }
 add_action( 'current_screen', 'wpcom_maybe_add_ai_assistant_banner' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/ai-assistant-banner.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/ai-assistant-banner.php
@@ -23,7 +23,7 @@ function wpcom_should_show_ai_assistant_banner() {
 		return false;
 	}
 
-	if ( ! function_exists( 'wpcom_site_has_feature' ) || ! wpcom_site_has_feature( WPCOM_Features::AI_ASSISTANT ) ) {
+	if ( ! function_exists( 'wpcom_site_has_feature' ) || ! wpcom_site_has_feature( 'big-sky' ) ) {
 		return false;
 	}
 
@@ -48,7 +48,7 @@ function wpcom_should_show_ai_assistant_banner() {
  */
 function wpcom_render_ai_assistant_banner() {
 	$site_slug = wpcom_get_site_slug();
-	$cta_url   = 'https://wordpress.com/sites/' . $site_slug . '/settings/ai-tools';
+	$cta_url   = wpcom_get_calypso_origin() . '/sites/' . $site_slug . '/settings/ai-tools';
 	$nonce     = wp_create_nonce( 'dismiss_ai_assistant_banner' );
 	?>
 	<div id="wpcom-ai-assistant-banner" class="notice is-dismissible" style="border-left-color: #3858E9;" data-nonce="<?php echo esc_attr( $nonce ); ?>">
@@ -95,13 +95,7 @@ function wpcom_maybe_add_ai_assistant_banner() {
 
 	add_action( 'admin_notices', 'wpcom_render_ai_assistant_banner', 1 );
 
-	wp_enqueue_script(
-		'wpcom-ai-assistant-banner',
-		plugin_dir_url( __FILE__ ) . 'js/ai-assistant-banner.js',
-		array( 'jquery' ),
-		'20250604',
-		true
-	);
+	jetpack_mu_wpcom_enqueue_assets( 'ai-assistant-banner', array( 'js' ) );
 }
 add_action( 'current_screen', 'wpcom_maybe_add_ai_assistant_banner' );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/ai-assistant-banner.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/ai-assistant-banner.php
@@ -23,7 +23,7 @@ function wpcom_should_show_ai_assistant_banner() {
 		return false;
 	}
 
-	if ( ! wpcom_site_has_feature( 'ai-assistant' ) ) {
+	if ( ! function_exists( 'wpcom_site_has_feature' ) || ! wpcom_site_has_feature( 'ai-assistant' ) ) {
 		return false;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/ai-assistant-banner.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/ai-assistant-banner.php
@@ -35,7 +35,7 @@ function wpcom_should_show_ai_assistant_banner() {
 		return false;
 	}
 
-	// Don't show if user has opted out of AI features (Simple sites only).
+	// Don't show if user has opted out of AI features.
 	if ( function_exists( 'get_user_attribute' ) && '1' === get_user_attribute( get_current_user_id(), 'ai_features_opted_out' ) ) {
 		return false;
 	}
@@ -51,7 +51,7 @@ function wpcom_render_ai_assistant_banner() {
 	$cta_url   = 'https://wordpress.com/sites/' . $site_slug . '/settings/ai-tools';
 	$nonce     = wp_create_nonce( 'dismiss_ai_assistant_banner' );
 	?>
-	<div id="ai-assistant-banner" class="notice is-dismissible" style="border-left-color: #3858E9;" data-nonce="<?php echo esc_attr( $nonce ); ?>">
+	<div id="wpcom-ai-assistant-banner" class="notice is-dismissible" style="border-left-color: #3858E9;" data-nonce="<?php echo esc_attr( $nonce ); ?>">
 		<div style="display: flex; align-items: center; gap: 16px; padding: 4px 0;">
 			<svg width="24" height="24" viewBox="0 0 400 400" fill="none" xmlns="http://www.w3.org/2000/svg">
 				<path d="M391.528 188.061L309.455 159.75C276.997 148.597 251.403 123.003 240.25 90.5451L211.939 8.47185C208.079 -2.82395 191.921 -2.82395 188.061 8.47185L159.75 90.5451C148.597 123.003 123.003 148.597 90.5451 159.75L8.47185 188.061C-2.82395 191.921 -2.82395 208.079 8.47185 211.939L90.5451 240.25C123.003 251.403 148.597 276.997 159.75 309.455L188.061 391.528C191.921 402.824 208.079 402.824 211.939 391.528L240.25 309.455C251.403 276.997 276.997 251.403 309.455 240.25L391.528 211.939C402.824 208.079 402.824 191.921 391.528 188.061ZM295.728 206.077L254.692 220.232C238.391 225.809 225.666 238.677 220.089 254.835L205.934 295.871C203.932 301.591 195.925 301.591 193.923 295.871L179.768 254.835C174.191 238.534 161.323 225.809 145.165 220.232L104.129 206.077C98.4093 204.075 98.4093 196.068 104.129 194.066L145.165 179.911C161.466 174.334 174.191 161.466 179.768 145.308L193.923 104.272C195.925 98.5523 203.932 98.5523 205.934 104.272L220.089 145.308C225.666 161.609 238.534 174.334 254.692 179.911L295.728 194.066C301.448 196.068 301.448 204.075 295.728 206.077Z" fill="#3858E9"/>
@@ -66,11 +66,11 @@ function wpcom_render_ai_assistant_banner() {
 		</div>
 	</div>
 	<style>
-		#ai-assistant-banner .notice-dismiss {
+		#wpcom-ai-assistant-banner .notice-dismiss {
 			top: 50%;
 			transform: translateY(-50%);
 		}
-		#ai-assistant-banner .notice-dismiss:before {
+		#wpcom-ai-assistant-banner .notice-dismiss:before {
 			content: "\2715";
 			font-family: inherit;
 			color: #787c82;
@@ -96,8 +96,8 @@ function wpcom_maybe_add_ai_assistant_banner() {
 	add_action( 'admin_notices', 'wpcom_render_ai_assistant_banner', 1 );
 
 	wp_enqueue_script(
-		'ai-assistant-banner',
-		plugin_dir_url( __FILE__ ) . 'js/ai-assistant-banner.js',
+		'wpcom-ai-assistant-banner',
+		plugin_dir_url( __FILE__ ) . 'js/wpcom-ai-assistant-banner.js',
 		array( 'jquery' ),
 		'20250604',
 		true

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/ai-assistant-banner.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/ai-assistant-banner.php
@@ -23,7 +23,7 @@ function wpcom_should_show_ai_assistant_banner() {
 		return false;
 	}
 
-	if ( ! function_exists( 'wpcom_site_has_feature' ) || ! wpcom_site_has_feature( 'ai-assistant' ) ) {
+	if ( ! function_exists( 'wpcom_site_has_feature' ) || ! wpcom_site_has_feature( WPCOM_Features::AI_ASSISTANT ) ) {
 		return false;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/ai-assistant-banner.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/ai-assistant-banner.php
@@ -18,6 +18,11 @@ function wpcom_should_show_ai_assistant_banner() {
 		return false;
 	}
 
+	// Check dismissal early — most users will have dismissed over time.
+	if ( get_user_meta( get_current_user_id(), 'wpcom_ai_assistant_banner_dismissed', true ) ) {
+		return false;
+	}
+
 	if ( ! wpcom_site_has_feature( 'ai-assistant' ) ) {
 		return false;
 	}
@@ -27,11 +32,6 @@ function wpcom_should_show_ai_assistant_banner() {
 		return false;
 	}
 	if ( wpcom_has_blog_sticker( 'big-sky-enabled', get_wpcom_blog_id() ) ) {
-		return false;
-	}
-
-	// Don't show if already dismissed.
-	if ( get_user_meta( get_current_user_id(), 'wpcom_ai_assistant_banner_dismissed', true ) ) {
 		return false;
 	}
 
@@ -47,11 +47,11 @@ function wpcom_should_show_ai_assistant_banner() {
  * Renders the AI assistant banner markup.
  */
 function wpcom_render_ai_assistant_banner() {
-	$site_slug = wp_parse_url( home_url(), PHP_URL_HOST );
+	$site_slug = wpcom_get_site_slug();
 	$cta_url   = 'https://wordpress.com/sites/' . $site_slug . '/settings/ai-tools';
 	$nonce     = wp_create_nonce( 'dismiss_ai_assistant_banner' );
 	?>
-	<div id="wpcom-ai-assistant-banner" class="notice is-dismissible" data-nonce="<?php echo esc_attr( $nonce ); ?>">
+	<div id="ai-assistant-banner" class="notice is-dismissible" style="border-left-color: #3858E9;" data-nonce="<?php echo esc_attr( $nonce ); ?>">
 		<div style="display: flex; align-items: center; gap: 16px; padding: 4px 0;">
 			<svg width="24" height="24" viewBox="0 0 400 400" fill="none" xmlns="http://www.w3.org/2000/svg">
 				<path d="M391.528 188.061L309.455 159.75C276.997 148.597 251.403 123.003 240.25 90.5451L211.939 8.47185C208.079 -2.82395 191.921 -2.82395 188.061 8.47185L159.75 90.5451C148.597 123.003 123.003 148.597 90.5451 159.75L8.47185 188.061C-2.82395 191.921 -2.82395 208.079 8.47185 211.939L90.5451 240.25C123.003 251.403 148.597 276.997 159.75 309.455L188.061 391.528C191.921 402.824 208.079 402.824 211.939 391.528L240.25 309.455C251.403 276.997 276.997 251.403 309.455 240.25L391.528 211.939C402.824 208.079 402.824 191.921 391.528 188.061ZM295.728 206.077L254.692 220.232C238.391 225.809 225.666 238.677 220.089 254.835L205.934 295.871C203.932 301.591 195.925 301.591 193.923 295.871L179.768 254.835C174.191 238.534 161.323 225.809 145.165 220.232L104.129 206.077C98.4093 204.075 98.4093 196.068 104.129 194.066L145.165 179.911C161.466 174.334 174.191 161.466 179.768 145.308L193.923 104.272C195.925 98.5523 203.932 98.5523 205.934 104.272L220.089 145.308C225.666 161.609 238.534 174.334 254.692 179.911L295.728 194.066C301.448 196.068 301.448 204.075 295.728 206.077Z" fill="#3858E9"/>
@@ -60,11 +60,23 @@ function wpcom_render_ai_assistant_banner() {
 				<strong><?php esc_html_e( 'Bring AI to your site.', 'jetpack-mu-wpcom' ); ?></strong><br>
 				<?php esc_html_e( 'Opt-in to get site-aware assistance where you write and design.', 'jetpack-mu-wpcom' ); ?>
 			</div>
-			<a href="<?php echo esc_url( $cta_url ); ?>" class="button-secondary" style="margin-right: 16px;">
+			<a href="<?php echo esc_url( $cta_url ); ?>" class="button-secondary">
 				<?php esc_html_e( 'Enable AI assistant', 'jetpack-mu-wpcom' ); ?>
 			</a>
 		</div>
 	</div>
+	<style>
+		#ai-assistant-banner .notice-dismiss {
+			top: 50%;
+			transform: translateY(-50%);
+		}
+		#ai-assistant-banner .notice-dismiss:before {
+			content: "\2715";
+			font-family: inherit;
+			color: #787c82;
+			background: none;
+		}
+	</style>
 	<?php
 }
 
@@ -84,7 +96,7 @@ function wpcom_maybe_add_ai_assistant_banner() {
 	add_action( 'admin_notices', 'wpcom_render_ai_assistant_banner', 1 );
 
 	wp_enqueue_script(
-		'wpcom-ai-assistant-banner',
+		'ai-assistant-banner',
 		plugin_dir_url( __FILE__ ) . 'js/ai-assistant-banner.js',
 		array( 'jquery' ),
 		'20250604',

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/js/ai-assistant-banner.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/js/ai-assistant-banner.js
@@ -1,13 +1,15 @@
-import { wpcomTrackEvent } from '../../../common/tracks';
-
-/**
- * JavaScript for the AI Assistant banner event tracking and dismiss handling.
- *
- * @param {object} $ - The jQuery object
- */
-
 /* global jQuery */
 ( function ( $ ) {
+	/**
+	 * Record a Tracks event via the _tkq global.
+	 *
+	 * @param {string} eventName - The event name to record.
+	 */
+	function trackEvent( eventName ) {
+		window._tkq = window._tkq || [];
+		window._tkq.push( [ 'recordEvent', eventName ] );
+	}
+
 	$( document ).ready( function () {
 		const banner = document.getElementById( 'wpcom-ai-assistant-banner' );
 
@@ -15,16 +17,16 @@ import { wpcomTrackEvent } from '../../../common/tracks';
 			return;
 		}
 
-		wpcomTrackEvent( 'jetpack_ai_assistant_banner_impression' );
+		trackEvent( 'jetpack_ai_assistant_banner_impression' );
 
-		const ctaBtn = banner.querySelector( '.wpcom-ai-assistant-banner__cta' );
+		const ctaBtn = banner.querySelector( '.button-secondary' );
 		ctaBtn?.addEventListener( 'click', function () {
-			wpcomTrackEvent( 'jetpack_ai_assistant_banner_cta_click' );
+			trackEvent( 'jetpack_ai_assistant_banner_cta_click' );
 		} );
 
-		const dismissBtn = banner.querySelector( '.wpcom-ai-assistant-banner__dismiss' );
+		const dismissBtn = banner.querySelector( '.notice-dismiss' );
 		dismissBtn?.addEventListener( 'click', function () {
-			wpcomTrackEvent( 'jetpack_ai_assistant_banner_dismiss' );
+			trackEvent( 'jetpack_ai_assistant_banner_dismiss' );
 
 			$.post( window.ajaxurl, {
 				action: 'dismiss_ai_assistant_banner',

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/js/ai-assistant-banner.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/js/ai-assistant-banner.js
@@ -15,16 +15,16 @@ import { wpcomTrackEvent } from '../../../common/tracks';
 			return;
 		}
 
-		wpcomTrackEvent( 'wpcom_tip_ai_assistant_banner_impression' );
+		wpcomTrackEvent( 'jetpack_ai_assistant_banner_impression' );
 
 		const ctaBtn = banner.querySelector( '.wpcom-ai-assistant-banner__cta' );
 		ctaBtn?.addEventListener( 'click', function () {
-			wpcomTrackEvent( 'wpcom_tip_ai_assistant_banner_cta_click' );
+			wpcomTrackEvent( 'jetpack_ai_assistant_banner_cta_click' );
 		} );
 
 		const dismissBtn = banner.querySelector( '.wpcom-ai-assistant-banner__dismiss' );
 		dismissBtn?.addEventListener( 'click', function () {
-			wpcomTrackEvent( 'wpcom_tip_ai_assistant_banner_dismiss' );
+			wpcomTrackEvent( 'jetpack_ai_assistant_banner_dismiss' );
 
 			$.post( window.ajaxurl, {
 				action: 'dismiss_ai_assistant_banner',

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/js/ai-assistant-banner.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/js/ai-assistant-banner.js
@@ -1,31 +1,28 @@
-/* global jQuery */
 import { wpcomTrackEvent } from '../../../common/tracks';
 
-( function ( $ ) {
-	$( document ).ready( function () {
-		const banner = document.getElementById( 'wpcom-ai-assistant-banner' );
+document.addEventListener( 'DOMContentLoaded', () => {
+	const banner = document.getElementById( 'wpcom-ai-assistant-banner' );
 
-		if ( ! banner ) {
-			return;
-		}
+	if ( ! banner ) {
+		return;
+	}
 
-		wpcomTrackEvent( 'jetpack_ai_assistant_banner_impression' );
+	wpcomTrackEvent( 'jetpack_ai_assistant_banner_impression' );
 
-		const ctaBtn = banner.querySelector( '.button-secondary' );
-		ctaBtn?.addEventListener( 'click', function () {
-			wpcomTrackEvent( 'jetpack_ai_assistant_banner_cta_click' );
-		} );
-
-		const dismissBtn = banner.querySelector( '.notice-dismiss' );
-		dismissBtn?.addEventListener( 'click', function () {
-			wpcomTrackEvent( 'jetpack_ai_assistant_banner_dismiss' );
-
-			$.post( window.ajaxurl, {
-				action: 'dismiss_ai_assistant_banner',
-				nonce: banner.dataset.nonce,
-			} );
-
-			banner.style.display = 'none';
-		} );
+	const ctaBtn = banner.querySelector( '.button-secondary' );
+	ctaBtn?.addEventListener( 'click', () => {
+		wpcomTrackEvent( 'jetpack_ai_assistant_banner_cta_click' );
 	} );
-} )( jQuery );
+
+	const dismissBtn = banner.querySelector( '.notice-dismiss' );
+	dismissBtn?.addEventListener( 'click', () => {
+		wpcomTrackEvent( 'jetpack_ai_assistant_banner_dismiss' );
+
+		const body = new FormData();
+		body.append( 'action', 'dismiss_ai_assistant_banner' );
+		body.append( 'nonce', banner.dataset.nonce );
+		fetch( window.ajaxurl, { method: 'POST', body } );
+
+		banner.style.display = 'none';
+	} );
+} );

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/js/ai-assistant-banner.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/js/ai-assistant-banner.js
@@ -11,7 +11,7 @@
 	}
 
 	$( document ).ready( function () {
-		const banner = document.getElementById( 'wpcom-ai-assistant-banner' );
+		const banner = document.getElementById( 'ai-assistant-banner' );
 
 		if ( ! banner ) {
 			return;

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/js/ai-assistant-banner.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/js/ai-assistant-banner.js
@@ -11,7 +11,7 @@
 	}
 
 	$( document ).ready( function () {
-		const banner = document.getElementById( 'ai-assistant-banner' );
+		const banner = document.getElementById( 'wpcom-ai-assistant-banner' );
 
 		if ( ! banner ) {
 			return;

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/js/ai-assistant-banner.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/js/ai-assistant-banner.js
@@ -1,15 +1,7 @@
 /* global jQuery */
-( function ( $ ) {
-	/**
-	 * Record a Tracks event via the _tkq global.
-	 *
-	 * @param {string} eventName - The event name to record.
-	 */
-	function trackEvent( eventName ) {
-		window._tkq = window._tkq || [];
-		window._tkq.push( [ 'recordEvent', eventName ] );
-	}
+import { wpcomTrackEvent } from '../../../common/tracks';
 
+( function ( $ ) {
 	$( document ).ready( function () {
 		const banner = document.getElementById( 'wpcom-ai-assistant-banner' );
 
@@ -17,16 +9,16 @@
 			return;
 		}
 
-		trackEvent( 'jetpack_ai_assistant_banner_impression' );
+		wpcomTrackEvent( 'jetpack_ai_assistant_banner_impression' );
 
 		const ctaBtn = banner.querySelector( '.button-secondary' );
 		ctaBtn?.addEventListener( 'click', function () {
-			trackEvent( 'jetpack_ai_assistant_banner_cta_click' );
+			wpcomTrackEvent( 'jetpack_ai_assistant_banner_cta_click' );
 		} );
 
 		const dismissBtn = banner.querySelector( '.notice-dismiss' );
 		dismissBtn?.addEventListener( 'click', function () {
-			trackEvent( 'jetpack_ai_assistant_banner_dismiss' );
+			wpcomTrackEvent( 'jetpack_ai_assistant_banner_dismiss' );
 
 			$.post( window.ajaxurl, {
 				action: 'dismiss_ai_assistant_banner',

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/js/ai-assistant-banner.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/js/ai-assistant-banner.js
@@ -1,0 +1,37 @@
+import { wpcomTrackEvent } from '../../../common/tracks';
+
+/**
+ * JavaScript for the AI Assistant banner event tracking and dismiss handling.
+ *
+ * @param {object} $ - The jQuery object
+ */
+
+/* global jQuery */
+( function ( $ ) {
+	$( document ).ready( function () {
+		const banner = document.getElementById( 'wpcom-ai-assistant-banner' );
+
+		if ( ! banner ) {
+			return;
+		}
+
+		wpcomTrackEvent( 'wpcom_tip_ai_assistant_banner_impression' );
+
+		const ctaBtn = banner.querySelector( '.wpcom-ai-assistant-banner__cta' );
+		ctaBtn?.addEventListener( 'click', function () {
+			wpcomTrackEvent( 'wpcom_tip_ai_assistant_banner_cta_click' );
+		} );
+
+		const dismissBtn = banner.querySelector( '.wpcom-ai-assistant-banner__dismiss' );
+		dismissBtn?.addEventListener( 'click', function () {
+			wpcomTrackEvent( 'wpcom_tip_ai_assistant_banner_dismiss' );
+
+			$.post( window.ajaxurl, {
+				action: 'dismiss_ai_assistant_banner',
+				nonce: banner.dataset.nonce,
+			} );
+
+			banner.style.display = 'none';
+		} );
+	} );
+} )( jQuery );

--- a/projects/packages/jetpack-mu-wpcom/webpack.config.js
+++ b/projects/packages/jetpack-mu-wpcom/webpack.config.js
@@ -10,6 +10,8 @@ module.exports = async () => {
 		moduleConfig,
 		{
 			entry: {
+				'ai-assistant-banner':
+					'./src/features/ai-assistant-banner/js/ai-assistant-banner.js',
 				'a8c-posts-list': './src/features/wpcom-blocks/a8c-posts-list/blocks/posts-list/index.js',
 				'block-inserter-modifications': './src/features/block-inserter-modifications/index.js',
 				'core-customizer-css':

--- a/projects/packages/jetpack-mu-wpcom/webpack.config.js
+++ b/projects/packages/jetpack-mu-wpcom/webpack.config.js
@@ -10,8 +10,7 @@ module.exports = async () => {
 		moduleConfig,
 		{
 			entry: {
-				'ai-assistant-banner':
-					'./src/features/ai-assistant-banner/js/ai-assistant-banner.js',
+				'ai-assistant-banner': './src/features/ai-assistant-banner/js/ai-assistant-banner.js',
 				'a8c-posts-list': './src/features/wpcom-blocks/a8c-posts-list/blocks/posts-list/index.js',
 				'block-inserter-modifications': './src/features/block-inserter-modifications/index.js',
 				'core-customizer-css':


### PR DESCRIPTION
## Proposed changes

- **Fix dismiss button**: The `is-dismissible` class caused WordPress core to inject the dismiss button dynamically via JS, racing with our `DOMContentLoaded` listener. The button often didn't exist when we attached click handlers, so neither the AJAX persistence call nor the `jetpack_ai_assistant_banner_dismiss` tracks event fired. Now we render the button directly in PHP markup.
- **Respect AI Tips unsubscription**: Hide the banner for users who unsubscribed from the AI Tips mailing list (`notifications_wpcom_email_ai_tips` = `"1"`).

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Does this pull request change what data or activity we track or use?
No new tracking. This fixes the existing `jetpack_ai_assistant_banner_dismiss` tracks event that was not firing due to the race condition.

## Testing instructions

1. Visit the WP Admin dashboard on a Business/Commerce site with the `big-sky` feature enabled
2. Verify the dismiss button (×) is visible on the AI assistant banner
3. Click the dismiss button and confirm:
   - The banner disappears
   - The `jetpack_ai_assistant_banner_dismiss` tracks event fires (check browser network tab for the tracks request)
4. Reload the page — the banner should not reappear (persistence via `wpcom_ai_assistant_banner_dismissed` user meta)
5. For a user with `notifications_wpcom_email_ai_tips` = `"1"` (unsubscribed from AI Tips), verify the banner does not appear
6. For a subscribed user (attribute absent or not `"1"`), verify the banner still appears