### PR TITLE
Newsletter: Move admin notices and JITMs below page header

### DIFF
--- a/projects/packages/newsletter/changelog/fix-newsletter-admin-notices-below-header
+++ b/projects/packages/newsletter/changelog/fix-newsletter-admin-notices-below-header
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Move admin notices and JITMs below the page header instead of rendering inside it

--- a/projects/packages/newsletter/src/settings/index.tsx
+++ b/projects/packages/newsletter/src/settings/index.tsx
@@ -388,6 +388,12 @@ function NewsletterSettingsApp(): JSX.Element | null {
 				'jetpack-newsletter'
 			) }
 		>
+			<GlobalNotices />
+			<Container horizontalSpacing={ 0 }>
+				<Col>
+					<div id="jp-admin-notices" className="newsletter-jitm-card" />
+				</Col>
+			</Container>
 			<Container horizontalSpacing={ 3 }>
 				<Col>
 					<Stack gap="md" direction="column" className="newsletter-settings">
@@ -456,8 +462,6 @@ function NewsletterSettingsApp(): JSX.Element | null {
 							</Stack>
 						</Disabled>
 					</Stack>
-
-					<GlobalNotices />
 				</Col>
 			</Container>
 		</AdminPage>

--- a/projects/packages/newsletter/src/settings/style.scss
+++ b/projects/packages/newsletter/src/settings/style.scss
@@ -10,6 +10,15 @@
 	text-align: right;
 }
 
+.newsletter-jitm-card {
+
+	.jitm-card {
+		margin-right: 0;
+		margin-bottom: 1.5rem;
+		margin-top: 1.5rem;
+	}
+}
+
 .newsletter-settings {
 	max-width: 660px; /* MSD and future JP settings pages are 660px wide */
 	margin-inline: auto;

--- a/projects/packages/newsletter/src/settings/style.scss
+++ b/projects/packages/newsletter/src/settings/style.scss
@@ -13,9 +13,8 @@
 .newsletter-jitm-card {
 
 	.jitm-card {
-		margin-right: 0;
-		margin-bottom: 1.5rem;
-		margin-top: 1.5rem;
+		margin-inline-end: 0;
+		margin-block: 1.5rem;
 	}
 }
 


### PR DESCRIPTION
Fixes JETPACK-1484

## Proposed changes

* Move `GlobalNotices` to render immediately after the `<AdminPage>` open tag, before the form content (was previously at the bottom after all sections)
* Add a `#jp-admin-notices` container for JITM injection, positioned below the header in its own zero-spacing `Container`/`Col` pair
* Use CSS logical properties (`margin-inline-end`, `margin-block`) for RTL-safe JITM card styling

This follows the same pattern established in #47558 for My Jetpack, Social, and Search — the Newsletter page was missed in that PR.

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* Follow-up to #47558

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. Enable the Newsletter settings page feature flag by adding this to a mu-plugin:
   ```php
   add_filter( 'jetpack_wp_admin_newsletter_settings_enabled', '__return_true' );
   ```
2. Navigate to **Jetpack → Newsletter** in wp-admin
3. Trigger a notice (e.g., save a setting) — verify it appears **below the header**, not inside it
4. Optionally inject a fake JITM via the `jetpack_jitm_received_envelopes` filter to verify JITM placement below the header
