### PR TITLE
Fix: add memberships_gift_is_sandboxed to sync post meta whitelist

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-memberships-gift-sandbox-meta
+++ b/projects/plugins/jetpack/changelog/fix-memberships-gift-sandbox-meta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Add memberships_gift_is_sandboxed to the Jetpack sync post meta whitelist so gifting works on self-hosted Jetpack sites

--- a/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
+++ b/projects/plugins/jetpack/modules/memberships/class-jetpack-memberships.php
@@ -395,6 +395,7 @@ class Jetpack_Memberships {
 			$meta_gifts_prefix . 'user_id',
 			$meta_gifts_prefix . 'plan_id',
 			$meta_gifts_prefix . 'is_deleted',
+			$meta_gifts_prefix . 'is_sandboxed',
 		);
 		return array_merge(
 			$post_meta,


### PR DESCRIPTION
## Proposed changes
* Add `memberships_gift_is_sandboxed` to the `allow_sync_post_meta` whitelist in `class-jetpack-memberships.php`
* The `is_sandboxed` meta key was already included for coupons but was omitted for gifts. Without this key in the whitelist, the Jetpack REST API never returns it, but `internal_list()` always filters on it via `add_sandbox_meta()`, causing all gifts to be silently discarded on self-hosted Jetpack sites.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* Related to NL-501

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a self-hosted Jetpack site, create a membership gift
* Verify `memberships_gift_is_sandboxed` appears in the Jetpack REST API response for `memberships_gift` posts
* Confirm gifting works end-to-end on the self-hosted site
* Verify existing coupon sync behavior is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)