### PR TITLE
Generated post excerpts - fix word glue on stripping br tags.

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-post-excerpt-br-stripping-without-spaces
+++ b/projects/plugins/jetpack/changelog/fix-post-excerpt-br-stripping-without-spaces
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+adds a filter to ensure generated excerpts have spaces between words when br's are stripped

--- a/projects/plugins/jetpack/functions.excerpt-compat.php
+++ b/projects/plugins/jetpack/functions.excerpt-compat.php
@@ -1,0 +1,29 @@
+<?php // phpcs:ignore WordPress.Files.FileName.NotHyphenatedLowercase
+/**
+ * Compatibility helpers for post excerpts.
+ *
+ * Auto-generated excerpts run post content through `the_content`, then `wp_trim_words()`
+ * calls `wp_strip_all_tags()`. PHP `strip_tags()` removes `<br>` without inserting a
+ * word boundary, so text like "This is<br/>an example" becomes "This isan example".
+ *
+ * @package automattic/jetpack
+ */
+
+/**
+ * Replace `<br>` tags with spaces in post content when building an auto excerpt.
+ *
+ * Runs late on `the_content` so wpautop and other filters have already run, but before
+ * `wp_trim_excerpt()` passes the string to `wp_trim_words()` / `wp_strip_all_tags()`.
+ *
+ * @param string $content Filtered post content HTML.
+ * @return string
+ */
+function jetpack_excerpt_br_tags_to_spaces_in_the_content( $content ) {
+	if ( ! doing_filter( 'get_the_excerpt' ) ) {
+		return $content;
+	}
+
+	return preg_replace( '/<br\b[^>]*\/?>/i', ' ', $content );
+}
+
+add_filter( 'the_content', 'jetpack_excerpt_br_tags_to_spaces_in_the_content', PHP_INT_MAX - 10 );

--- a/projects/plugins/jetpack/load-jetpack.php
+++ b/projects/plugins/jetpack/load-jetpack.php
@@ -37,6 +37,7 @@ require_once JETPACK__PLUGIN_DIR . 'class.photon.php';
 require_once JETPACK__PLUGIN_DIR . 'functions.photon.php';
 require_once JETPACK__PLUGIN_DIR . 'functions.global.php';
 require_once JETPACK__PLUGIN_DIR . 'functions.compat.php';
+require_once JETPACK__PLUGIN_DIR . 'functions.excerpt-compat.php';
 require_once JETPACK__PLUGIN_DIR . 'class-jetpack-gallery-settings.php';
 require_once JETPACK__PLUGIN_DIR . 'functions.cookies.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-autoupdate.php';

--- a/projects/plugins/jetpack/tests/php/general/Excerpt_Compat_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Excerpt_Compat_Test.php
@@ -1,0 +1,54 @@
+<?php
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+
+/**
+ * @covers ::jetpack_excerpt_br_tags_to_spaces_in_the_content
+ */
+#[CoversFunction( 'jetpack_excerpt_br_tags_to_spaces_in_the_content' )]
+class Excerpt_Compat_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Auto excerpts should keep a word boundary where `<br>` was stripped.
+	 */
+	public function test_auto_excerpt_inserts_space_where_br_was_between_words() {
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_content' => 'This is<br/>an example phrase for excerpt testing.',
+				'post_excerpt' => '',
+			)
+		);
+
+		$excerpt = get_the_excerpt( $post );
+
+		$this->assertStringContainsString( 'is an', $excerpt );
+		$this->assertStringNotContainsString( 'isan', $excerpt );
+	}
+
+	/**
+	 * `<br>` with attributes should also become a word boundary.
+	 */
+	public function test_auto_excerpt_br_with_attributes() {
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_content' => 'Line one<br class="x" />line two here.',
+				'post_excerpt' => '',
+			)
+		);
+
+		$excerpt = get_the_excerpt( $post );
+
+		$this->assertStringContainsString( 'one line', $excerpt );
+		$this->assertStringNotContainsString( 'oneline', $excerpt );
+	}
+
+	/**
+	 * `the_content` should not be altered by this callback outside `get_the_excerpt`.
+	 */
+	public function test_the_content_br_preserved_when_not_building_excerpt() {
+		$filtered = apply_filters( 'the_content', 'Hello<br/>World' );
+
+		$this->assertStringContainsString( '<br', $filtered );
+	}
+}


### PR DESCRIPTION
Fixes #

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* 

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

(this doesn't seem to work currently)
* On a test site, enable excerpts in reading and newsletter settings (this actually may be unnecessary for testing via the endpoint).
* Publish a post without adding a custom excerpt. Ensure you write in a paragraph block and go to new lines in the same paragraph block using "shft+enter" - this adds <br/>s in the paragraph block content contrary to standard "enter" creating a new paragraph block.
* Retrieve the post from the site posts endpoint. For simple, I have an example staged here: https://public-api.wordpress.com/rest/v1.1/sites/245723124/posts/22 
    * Without this patched to wpcom, you should see word glue in the excerpt field:  `"this is allone paragraphusing shft+enter between lineswhich..."`
    * With this patched to wpcom and sandboxing the public-api, you should see the added spaces: `"this is all one paragraph using shft+enter between lines which..."`
