### PR TITLE
VideoPress: Fix poster image not saving when selected during upload

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-poster-not-saving-during-upload
+++ b/projects/packages/videopress/changelog/fix-videopress-poster-not-saving-during-upload
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix poster image not saving when selected during video upload

--- a/projects/packages/videopress/changelog/fix-videopress-poster-not-saving-during-upload
+++ b/projects/packages/videopress/changelog/fix-videopress-poster-not-saving-during-upload
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix poster image not saving when selected during video upload
+Fix poster image not saving when selected during video upload.

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/test/uploader-progress.test.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/test/uploader-progress.test.js
@@ -371,6 +371,47 @@ describe( 'usePosterAndTitleUpdate', () => {
 		expect( onDone ).toHaveBeenCalledWith( videoData );
 	} );
 
+	it( 'does not send poster update when guid is missing', async () => {
+		const posterUrl = 'https://example.com/poster.jpg';
+		mockUploadPoster.mockResolvedValue( { data: { poster: posterUrl } } );
+
+		const videoDataWithoutGuid = { id: 1 };
+		const { result, rerender } = renderHook(
+			( { vData } ) =>
+				usePosterAndTitleUpdate( {
+					setAttributes,
+					videoData: vData,
+					onDone,
+				} ),
+			{ initialProps: { vData: videoDataWithoutGuid } }
+		);
+
+		act( () => {
+			getHookValues( result ).handleSelectPoster( { id: 42 } );
+		} );
+
+		// Attempt Done while guid is still missing — should be a no-op.
+		await act( async () => {
+			getHookValues( result ).handleDoneUpload();
+		} );
+
+		expect( mockUploadPoster ).not.toHaveBeenCalled();
+		expect( onDone ).not.toHaveBeenCalled();
+
+		// Simulate guid arriving (upload success).
+		rerender( { vData: videoData } );
+
+		await act( async () => {
+			getHookValues( result ).handleDoneUpload();
+		} );
+
+		expect( mockUploadPoster ).toHaveBeenCalledWith( { poster_attachment_id: 42 } );
+		expect( onDone ).toHaveBeenCalledWith( {
+			...videoData,
+			poster: posterUrl,
+		} );
+	} );
+
 	it( 'reports hasPosterEdits when poster image is selected', () => {
 		const { result } = renderTestHook();
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/test/uploader-progress.test.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/test/uploader-progress.test.js
@@ -117,26 +117,38 @@ describe( 'usePosterAndTitleUpdate', () => {
 		} );
 	} );
 
-	it( 'sends server-side poster update for video frame selection', async () => {
+	it( 'awaits server poster URL for video frame selection', async () => {
+		const posterUrl = 'https://example.com/frame-poster.jpg';
+		mockUploadPoster.mockResolvedValue( { data: { poster: posterUrl } } );
+
 		const { result } = renderTestHook();
 
 		act( () => {
 			getHookValues( result ).handleVideoFrameSelected( 5000 );
 		} );
 
+		// The debounced useEffect fires immediately (mock), then
+		// handleDoneUpload reuses that promise instead of duplicating.
 		await act( async () => {
 			getHookValues( result ).handleDoneUpload();
 		} );
 
+		// Only one POST should have been made (from the useEffect).
+		expect( mockUploadPoster ).toHaveBeenCalledTimes( 1 );
 		expect( mockUploadPoster ).toHaveBeenCalledWith( {
 			at_time: 5000,
 			is_millisec: true,
 		} );
-		// No client-side URL for frame selection, so onDone has no poster.
-		expect( onDone ).toHaveBeenCalledWith( videoData );
+		expect( onDone ).toHaveBeenCalledWith( {
+			...videoData,
+			poster: posterUrl,
+		} );
 	} );
 
 	it( 'handles video frame selected at 0ms', async () => {
+		const posterUrl = 'https://example.com/zero-frame.jpg';
+		mockUploadPoster.mockResolvedValue( { data: { poster: posterUrl } } );
+
 		const { result } = renderTestHook();
 
 		act( () => {
@@ -151,7 +163,10 @@ describe( 'usePosterAndTitleUpdate', () => {
 			at_time: 0,
 			is_millisec: true,
 		} );
-		expect( onDone ).toHaveBeenCalledWith( videoData );
+		expect( onDone ).toHaveBeenCalledWith( {
+			...videoData,
+			poster: posterUrl,
+		} );
 	} );
 
 	it( 'sets poster attribute via setAttributes when debounced update resolves', async () => {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/test/uploader-progress.test.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/test/uploader-progress.test.js
@@ -214,6 +214,35 @@ describe( 'usePosterAndTitleUpdate', () => {
 		jest.useRealTimers();
 	} );
 
+	it( 'resolves with null when polling fails during poster generation', async () => {
+		jest.useFakeTimers();
+
+		// Upload returns generating, but polling rejects.
+		mockUploadPoster.mockResolvedValue( { data: { generating: true } } );
+		mockGetPoster.mockRejectedValue( new Error( 'polling failed' ) );
+		mockApiFetch.mockRejectedValue( new Error( 'fallback failed' ) );
+
+		const { result } = renderTestHook();
+
+		act( () => {
+			getHookValues( result ).handleSelectPoster( { id: 10 } );
+		} );
+
+		await act( async () => {
+			getHookValues( result ).handleDoneUpload();
+		} );
+
+		await act( async () => {
+			jest.advanceTimersByTime( 2000 );
+			await Promise.resolve();
+		} );
+
+		// onDone should still be called (without poster) rather than hanging.
+		expect( onDone ).toHaveBeenCalledWith( videoData );
+
+		jest.useRealTimers();
+	} );
+
 	it( 'falls back to apiFetch when poster upload hook rejects', async () => {
 		const posterUrl = 'https://example.com/fallback-poster.jpg';
 		mockUploadPoster.mockRejectedValue( new Error( 'hook failed' ) );
@@ -255,9 +284,13 @@ describe( 'usePosterAndTitleUpdate', () => {
 			await Promise.resolve();
 		} );
 
-		// Now set up both paths to reject for handleDoneUpload's direct call.
-		mockUploadPoster.mockRejectedValue( new Error( 'hook failed' ) );
-		mockApiFetch.mockRejectedValue( new Error( 'fallback failed' ) );
+		// Reject once for handleDoneUpload's direct call, then restore
+		// resolved defaults so the useEffect re-run after isFinishingUpdate
+		// resets doesn't trigger unhandled rejections.
+		mockUploadPoster
+			.mockRejectedValueOnce( new Error( 'hook failed' ) )
+			.mockResolvedValue( { data: {} } );
+		mockApiFetch.mockRejectedValueOnce( new Error( 'fallback failed' ) ).mockResolvedValue( {} );
 
 		await act( async () => {
 			getHookValues( result ).handleDoneUpload();

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/test/uploader-progress.test.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/test/uploader-progress.test.js
@@ -48,6 +48,7 @@ describe( 'usePosterAndTitleUpdate', () => {
 		setAttributes = jest.fn();
 		onDone = jest.fn();
 		mockUpdateMeta.mockResolvedValue( {} );
+		mockUploadPoster.mockResolvedValue( { data: {} } );
 	} );
 
 	const renderTestHook = ( overrides = {} ) => {
@@ -93,10 +94,7 @@ describe( 'usePosterAndTitleUpdate', () => {
 		expect( onDone ).toHaveBeenCalledWith( videoData );
 	} );
 
-	it( 'includes poster URL in onDone data when a poster image is selected', async () => {
-		const posterUrl = 'https://example.com/custom-poster.jpg';
-		mockUploadPoster.mockResolvedValue( { data: { poster: posterUrl } } );
-
+	it( 'includes client-side poster URL in onDone when a poster image is selected', async () => {
 		const { result } = renderTestHook();
 
 		act( () => {
@@ -110,17 +108,16 @@ describe( 'usePosterAndTitleUpdate', () => {
 			getHookValues( result ).handleDoneUpload();
 		} );
 
+		// Server-side poster update fires in background.
 		expect( mockUploadPoster ).toHaveBeenCalledWith( { poster_attachment_id: 42 } );
+		// onDone uses the client-side URL immediately.
 		expect( onDone ).toHaveBeenCalledWith( {
 			...videoData,
-			poster: posterUrl,
+			poster: 'https://example.com/image.jpg',
 		} );
 	} );
 
-	it( 'includes poster URL in onDone data when a video frame is selected', async () => {
-		const posterUrl = 'https://example.com/frame-poster.jpg';
-		mockUploadPoster.mockResolvedValue( { data: { poster: posterUrl } } );
-
+	it( 'sends server-side poster update for video frame selection', async () => {
 		const { result } = renderTestHook();
 
 		act( () => {
@@ -135,16 +132,11 @@ describe( 'usePosterAndTitleUpdate', () => {
 			at_time: 5000,
 			is_millisec: true,
 		} );
-		expect( onDone ).toHaveBeenCalledWith( {
-			...videoData,
-			poster: posterUrl,
-		} );
+		// No client-side URL for frame selection, so onDone has no poster.
+		expect( onDone ).toHaveBeenCalledWith( videoData );
 	} );
 
 	it( 'handles video frame selected at 0ms', async () => {
-		const posterUrl = 'https://example.com/zero-frame.jpg';
-		mockUploadPoster.mockResolvedValue( { data: { poster: posterUrl } } );
-
 		const { result } = renderTestHook();
 
 		act( () => {
@@ -159,13 +151,10 @@ describe( 'usePosterAndTitleUpdate', () => {
 			at_time: 0,
 			is_millisec: true,
 		} );
-		expect( onDone ).toHaveBeenCalledWith( {
-			...videoData,
-			poster: posterUrl,
-		} );
+		expect( onDone ).toHaveBeenCalledWith( videoData );
 	} );
 
-	it( 'sets poster attribute via setAttributes when poster resolves', async () => {
+	it( 'sets poster attribute via setAttributes when debounced update resolves', async () => {
 		const posterUrl = 'https://example.com/poster.jpg';
 		mockUploadPoster.mockResolvedValue( { data: { poster: posterUrl } } );
 
@@ -175,8 +164,9 @@ describe( 'usePosterAndTitleUpdate', () => {
 			getHookValues( result ).handleSelectPoster( { id: 10 } );
 		} );
 
+		// The debounced useEffect fires sendUpdatePoster immediately (debounce is mocked).
 		await act( async () => {
-			getHookValues( result ).handleDoneUpload();
+			await Promise.resolve();
 		} );
 
 		expect( setAttributes ).toHaveBeenCalledWith( { poster: posterUrl } );
@@ -198,8 +188,9 @@ describe( 'usePosterAndTitleUpdate', () => {
 			getHookValues( result ).handleSelectPoster( { id: 10 } );
 		} );
 
+		// Flush the debounced useEffect call.
 		await act( async () => {
-			getHookValues( result ).handleDoneUpload();
+			await Promise.resolve();
 		} );
 
 		// Advance past the polling setTimeout and flush resolved promises.
@@ -227,8 +218,9 @@ describe( 'usePosterAndTitleUpdate', () => {
 			getHookValues( result ).handleSelectPoster( { id: 10 } );
 		} );
 
+		// Flush the debounced useEffect call.
 		await act( async () => {
-			getHookValues( result ).handleDoneUpload();
+			await Promise.resolve();
 		} );
 
 		// Advance through all 10 retries (10 × 2000ms).
@@ -239,8 +231,11 @@ describe( 'usePosterAndTitleUpdate', () => {
 			} );
 		}
 
-		// onDone should be called without poster after retries are exhausted.
-		expect( onDone ).toHaveBeenCalledWith( videoData );
+		// After exhausting retries, setAttributes should not have been
+		// called with a poster (generating never resolved to a URL).
+		expect( setAttributes ).not.toHaveBeenCalledWith(
+			expect.objectContaining( { poster: expect.any( String ) } )
+		);
 
 		jest.useRealTimers();
 	} );
@@ -259,8 +254,9 @@ describe( 'usePosterAndTitleUpdate', () => {
 			getHookValues( result ).handleSelectPoster( { id: 10 } );
 		} );
 
+		// Flush the debounced useEffect call.
 		await act( async () => {
-			getHookValues( result ).handleDoneUpload();
+			await Promise.resolve();
 		} );
 
 		await act( async () => {
@@ -268,8 +264,10 @@ describe( 'usePosterAndTitleUpdate', () => {
 			await Promise.resolve();
 		} );
 
-		// onDone should still be called (without poster) rather than hanging.
-		expect( onDone ).toHaveBeenCalledWith( videoData );
+		// Poster should not have been set via setAttributes.
+		expect( setAttributes ).not.toHaveBeenCalledWith(
+			expect.objectContaining( { poster: expect.any( String ) } )
+		);
 
 		jest.useRealTimers();
 	} );
@@ -285,8 +283,10 @@ describe( 'usePosterAndTitleUpdate', () => {
 			getHookValues( result ).handleSelectPoster( { id: 10 } );
 		} );
 
+		// Flush the debounced useEffect call and its fallback.
 		await act( async () => {
-			getHookValues( result ).handleDoneUpload();
+			await Promise.resolve();
+			await Promise.resolve();
 		} );
 
 		expect( mockApiFetch ).toHaveBeenCalledWith(
@@ -298,97 +298,14 @@ describe( 'usePosterAndTitleUpdate', () => {
 		expect( setAttributes ).toHaveBeenCalledWith( { poster: posterUrl } );
 	} );
 
-	it( 'calls onDone without poster when both upload paths reject', async () => {
-		// Let the useEffect's debounced call succeed first, then set up rejections.
-		mockUploadPoster.mockResolvedValueOnce( {
-			data: { poster: 'https://example.com/poster.jpg' },
-		} );
-
-		const { result } = renderTestHook();
-
-		act( () => {
-			getHookValues( result ).handleSelectPoster( { id: 10 } );
-		} );
-
-		// Flush the useEffect's debounced call.
-		await act( async () => {
-			await Promise.resolve();
-		} );
-
-		// Reject once for handleDoneUpload's direct call, then restore
-		// resolved defaults so the useEffect re-run after isFinishingUpdate
-		// resets doesn't trigger unhandled rejections.
-		mockUploadPoster
-			.mockRejectedValueOnce( new Error( 'hook failed' ) )
-			.mockResolvedValue( { data: {} } );
-		mockApiFetch.mockRejectedValueOnce( new Error( 'fallback failed' ) ).mockResolvedValue( {} );
-
-		await act( async () => {
-			getHookValues( result ).handleDoneUpload();
-		} );
-
-		expect( onDone ).toHaveBeenCalledWith( videoData );
-	} );
-
-	it( 'waits for title update alongside poster update', async () => {
-		const posterUrl = 'https://example.com/poster.jpg';
-		mockUploadPoster.mockResolvedValue( { data: { poster: posterUrl } } );
-
-		let resolveMetaUpdate;
-		mockUpdateMeta.mockReturnValue(
-			new Promise( resolve => {
-				resolveMetaUpdate = resolve;
-			} )
-		);
-
-		const { result } = renderTestHook( {
-			videoData: { ...videoData, title: 'My Video' },
-		} );
-
-		act( () => {
-			getHookValues( result ).handleSelectPoster( { id: 10 } );
-		} );
-
-		await act( async () => {
-			getHookValues( result ).handleDoneUpload();
-		} );
-
-		// onDone should not have been called yet — title update is pending.
-		expect( onDone ).not.toHaveBeenCalled();
-
-		// Resolve the title update.
-		await act( async () => {
-			resolveMetaUpdate();
-		} );
-
-		expect( onDone ).toHaveBeenCalledWith( {
-			...videoData,
-			title: 'My Video',
-			poster: posterUrl,
-		} );
-	} );
-
-	it( 'does not include poster in onDone when poster update resolves with null', async () => {
-		mockUploadPoster.mockResolvedValue( { data: {} } );
-
-		const { result } = renderTestHook();
-
-		act( () => {
-			getHookValues( result ).handleSelectPoster( { id: 10 } );
-		} );
-
-		await act( async () => {
-			getHookValues( result ).handleDoneUpload();
-		} );
-
-		expect( onDone ).toHaveBeenCalledWith( videoData );
-	} );
-
 	it( 'calls onDone without poster after handleRemovePoster', async () => {
 		const { result } = renderTestHook();
 
 		act( () => {
-			getHookValues( result ).handleSelectPoster( { id: 10 } );
+			getHookValues( result ).handleSelectPoster( {
+				id: 10,
+				url: 'https://example.com/image.jpg',
+			} );
 		} );
 
 		act( () => {
@@ -403,9 +320,6 @@ describe( 'usePosterAndTitleUpdate', () => {
 	} );
 
 	it( 'does not send poster update when guid is missing', async () => {
-		const posterUrl = 'https://example.com/poster.jpg';
-		mockUploadPoster.mockResolvedValue( { data: { poster: posterUrl } } );
-
 		const videoDataWithoutGuid = { id: 1 };
 		const { result, rerender } = renderHook(
 			( { vData } ) =>
@@ -418,7 +332,10 @@ describe( 'usePosterAndTitleUpdate', () => {
 		);
 
 		act( () => {
-			getHookValues( result ).handleSelectPoster( { id: 42 } );
+			getHookValues( result ).handleSelectPoster( {
+				id: 42,
+				url: 'https://example.com/image.jpg',
+			} );
 		} );
 
 		// Attempt Done while guid is still missing — should be a no-op.
@@ -439,7 +356,7 @@ describe( 'usePosterAndTitleUpdate', () => {
 		expect( mockUploadPoster ).toHaveBeenCalledWith( { poster_attachment_id: 42 } );
 		expect( onDone ).toHaveBeenCalledWith( {
 			...videoData,
-			poster: posterUrl,
+			poster: 'https://example.com/image.jpg',
 		} );
 	} );
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/test/uploader-progress.test.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/test/uploader-progress.test.js
@@ -1,0 +1,378 @@
+import { renderHook, act } from '@testing-library/react';
+import { usePosterAndTitleUpdate } from '../uploader-progress.js';
+
+const mockUploadPoster = jest.fn();
+const mockGetPoster = jest.fn();
+const mockUpdateMeta = jest.fn();
+jest.mock( '../../../../../../hooks/use-poster-upload.js', () => () => mockUploadPoster );
+jest.mock( '../../../../../../hooks/use-poster-image.js', () => () => mockGetPoster );
+jest.mock( '../../../../../../hooks/use-meta-update.js', () => () => mockUpdateMeta );
+jest.mock(
+	'@wordpress/api-fetch',
+	() =>
+		( ...args ) =>
+			mockApiFetch( ...args )
+);
+
+// Declared after jest.mock calls because @wordpress/api-fetch mock needs a lazy reference.
+const mockApiFetch = jest.fn();
+jest.mock( '@wordpress/compose', () => ( {
+	useDebounce: fn => fn,
+	createHigherOrderComponent: () => c => c,
+} ) );
+jest.mock( '@wordpress/components', () => ( {
+	Button: () => null,
+	TextControl: () => null,
+} ) );
+jest.mock( '@wordpress/escape-html', () => ( {
+	escapeHTML: s => s,
+} ) );
+jest.mock( '@wordpress/i18n', () => ( {
+	__: s => s,
+	sprintf: ( ...args ) => args.join( '' ),
+} ) );
+jest.mock( 'debug', () => () => () => {} );
+jest.mock( 'filesize', () => ( { filesize: () => '0 B' } ) );
+jest.mock( '../uploader-editor.js', () => () => null );
+jest.mock( '../../../edit', () => ( {
+	PlaceholderWrapper: () => null,
+} ) );
+
+describe( 'usePosterAndTitleUpdate', () => {
+	let setAttributes;
+	let onDone;
+	const videoData = { id: 1, guid: 'abc123', src: 'https://example.com/video.mp4' };
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		setAttributes = jest.fn();
+		onDone = jest.fn();
+		mockUpdateMeta.mockResolvedValue( {} );
+	} );
+
+	const renderTestHook = ( overrides = {} ) => {
+		return renderHook( () =>
+			usePosterAndTitleUpdate( {
+				setAttributes,
+				videoData,
+				onDone,
+				...overrides,
+			} )
+		);
+	};
+
+	const getHookValues = result => {
+		const [
+			handleVideoFrameSelected,
+			handleSelectPoster,
+			handleRemovePoster,
+			handleDoneUpload,
+			videoPosterImageData,
+			isFinishingUpdate,
+			hasPosterEdits,
+		] = result.current;
+
+		return {
+			handleVideoFrameSelected,
+			handleSelectPoster,
+			handleRemovePoster,
+			handleDoneUpload,
+			videoPosterImageData,
+			isFinishingUpdate,
+			hasPosterEdits,
+		};
+	};
+
+	it( 'calls onDone with videoData when no poster edits are made', async () => {
+		const { result } = renderTestHook();
+
+		await act( async () => {
+			getHookValues( result ).handleDoneUpload();
+		} );
+
+		expect( onDone ).toHaveBeenCalledWith( videoData );
+	} );
+
+	it( 'includes poster URL in onDone data when a poster image is selected', async () => {
+		const posterUrl = 'https://example.com/custom-poster.jpg';
+		mockUploadPoster.mockResolvedValue( { data: { poster: posterUrl } } );
+
+		const { result } = renderTestHook();
+
+		act( () => {
+			getHookValues( result ).handleSelectPoster( {
+				id: 42,
+				url: 'https://example.com/image.jpg',
+			} );
+		} );
+
+		await act( async () => {
+			getHookValues( result ).handleDoneUpload();
+		} );
+
+		expect( mockUploadPoster ).toHaveBeenCalledWith( { poster_attachment_id: 42 } );
+		expect( onDone ).toHaveBeenCalledWith( {
+			...videoData,
+			poster: posterUrl,
+		} );
+	} );
+
+	it( 'includes poster URL in onDone data when a video frame is selected', async () => {
+		const posterUrl = 'https://example.com/frame-poster.jpg';
+		mockUploadPoster.mockResolvedValue( { data: { poster: posterUrl } } );
+
+		const { result } = renderTestHook();
+
+		act( () => {
+			getHookValues( result ).handleVideoFrameSelected( 5000 );
+		} );
+
+		await act( async () => {
+			getHookValues( result ).handleDoneUpload();
+		} );
+
+		expect( mockUploadPoster ).toHaveBeenCalledWith( {
+			at_time: 5000,
+			is_millisec: true,
+		} );
+		expect( onDone ).toHaveBeenCalledWith( {
+			...videoData,
+			poster: posterUrl,
+		} );
+	} );
+
+	it( 'handles video frame selected at 0ms', async () => {
+		const posterUrl = 'https://example.com/zero-frame.jpg';
+		mockUploadPoster.mockResolvedValue( { data: { poster: posterUrl } } );
+
+		const { result } = renderTestHook();
+
+		act( () => {
+			getHookValues( result ).handleVideoFrameSelected( 0 );
+		} );
+
+		await act( async () => {
+			getHookValues( result ).handleDoneUpload();
+		} );
+
+		expect( mockUploadPoster ).toHaveBeenCalledWith( {
+			at_time: 0,
+			is_millisec: true,
+		} );
+		expect( onDone ).toHaveBeenCalledWith( {
+			...videoData,
+			poster: posterUrl,
+		} );
+	} );
+
+	it( 'sets poster attribute via setAttributes when poster resolves', async () => {
+		const posterUrl = 'https://example.com/poster.jpg';
+		mockUploadPoster.mockResolvedValue( { data: { poster: posterUrl } } );
+
+		const { result } = renderTestHook();
+
+		act( () => {
+			getHookValues( result ).handleSelectPoster( { id: 10 } );
+		} );
+
+		await act( async () => {
+			getHookValues( result ).handleDoneUpload();
+		} );
+
+		expect( setAttributes ).toHaveBeenCalledWith( { poster: posterUrl } );
+	} );
+
+	it( 'polls until poster generation completes', async () => {
+		jest.useFakeTimers();
+
+		const posterUrl = 'https://example.com/generated-poster.jpg';
+
+		// First upload call returns generating state.
+		mockUploadPoster.mockResolvedValue( { data: { generating: true } } );
+		// Polling via getPosterImage returns the final poster.
+		mockGetPoster.mockResolvedValue( { data: { poster: posterUrl } } );
+
+		const { result } = renderTestHook();
+
+		act( () => {
+			getHookValues( result ).handleSelectPoster( { id: 10 } );
+		} );
+
+		await act( async () => {
+			getHookValues( result ).handleDoneUpload();
+		} );
+
+		// Advance past the polling setTimeout and flush resolved promises.
+		await act( async () => {
+			jest.advanceTimersByTime( 2000 );
+			await Promise.resolve();
+		} );
+
+		expect( mockGetPoster ).toHaveBeenCalled();
+		expect( setAttributes ).toHaveBeenCalledWith( { poster: posterUrl } );
+
+		jest.useRealTimers();
+	} );
+
+	it( 'falls back to apiFetch when poster upload hook rejects', async () => {
+		const posterUrl = 'https://example.com/fallback-poster.jpg';
+		mockUploadPoster.mockRejectedValue( new Error( 'hook failed' ) );
+		mockApiFetch.mockResolvedValue( { poster: posterUrl } );
+
+		const { result } = renderTestHook();
+
+		act( () => {
+			getHookValues( result ).handleSelectPoster( { id: 10 } );
+		} );
+
+		await act( async () => {
+			getHookValues( result ).handleDoneUpload();
+		} );
+
+		expect( mockApiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				method: 'POST',
+				data: { poster_attachment_id: 10 },
+			} )
+		);
+		expect( setAttributes ).toHaveBeenCalledWith( { poster: posterUrl } );
+	} );
+
+	it( 'calls onDone without poster when both upload paths reject', async () => {
+		// Let the useEffect's debounced call succeed first, then set up rejections.
+		mockUploadPoster.mockResolvedValueOnce( {
+			data: { poster: 'https://example.com/poster.jpg' },
+		} );
+
+		const { result } = renderTestHook();
+
+		act( () => {
+			getHookValues( result ).handleSelectPoster( { id: 10 } );
+		} );
+
+		// Flush the useEffect's debounced call.
+		await act( async () => {
+			await Promise.resolve();
+		} );
+
+		// Now set up both paths to reject for handleDoneUpload's direct call.
+		mockUploadPoster.mockRejectedValue( new Error( 'hook failed' ) );
+		mockApiFetch.mockRejectedValue( new Error( 'fallback failed' ) );
+
+		await act( async () => {
+			getHookValues( result ).handleDoneUpload();
+		} );
+
+		expect( onDone ).toHaveBeenCalledWith( videoData );
+	} );
+
+	it( 'waits for title update alongside poster update', async () => {
+		const posterUrl = 'https://example.com/poster.jpg';
+		mockUploadPoster.mockResolvedValue( { data: { poster: posterUrl } } );
+
+		let resolveMetaUpdate;
+		mockUpdateMeta.mockReturnValue(
+			new Promise( resolve => {
+				resolveMetaUpdate = resolve;
+			} )
+		);
+
+		const { result } = renderTestHook( {
+			videoData: { ...videoData, title: 'My Video' },
+		} );
+
+		act( () => {
+			getHookValues( result ).handleSelectPoster( { id: 10 } );
+		} );
+
+		await act( async () => {
+			getHookValues( result ).handleDoneUpload();
+		} );
+
+		// onDone should not have been called yet — title update is pending.
+		expect( onDone ).not.toHaveBeenCalled();
+
+		// Resolve the title update.
+		await act( async () => {
+			resolveMetaUpdate();
+		} );
+
+		expect( onDone ).toHaveBeenCalledWith( {
+			...videoData,
+			title: 'My Video',
+			poster: posterUrl,
+		} );
+	} );
+
+	it( 'does not include poster in onDone when poster update resolves with null', async () => {
+		mockUploadPoster.mockResolvedValue( { data: {} } );
+
+		const { result } = renderTestHook();
+
+		act( () => {
+			getHookValues( result ).handleSelectPoster( { id: 10 } );
+		} );
+
+		await act( async () => {
+			getHookValues( result ).handleDoneUpload();
+		} );
+
+		expect( onDone ).toHaveBeenCalledWith( videoData );
+	} );
+
+	it( 'calls onDone without poster after handleRemovePoster', async () => {
+		const { result } = renderTestHook();
+
+		act( () => {
+			getHookValues( result ).handleSelectPoster( { id: 10 } );
+		} );
+
+		act( () => {
+			getHookValues( result ).handleRemovePoster();
+		} );
+
+		await act( async () => {
+			getHookValues( result ).handleDoneUpload();
+		} );
+
+		expect( onDone ).toHaveBeenCalledWith( videoData );
+	} );
+
+	it( 'reports hasPosterEdits when poster image is selected', () => {
+		const { result } = renderTestHook();
+
+		expect( getHookValues( result ).hasPosterEdits ).toBe( false );
+
+		act( () => {
+			getHookValues( result ).handleSelectPoster( { id: 10 } );
+		} );
+
+		expect( getHookValues( result ).hasPosterEdits ).toBe( true );
+	} );
+
+	it( 'reports hasPosterEdits when video frame is selected', () => {
+		const { result } = renderTestHook();
+
+		act( () => {
+			getHookValues( result ).handleVideoFrameSelected( 3000 );
+		} );
+
+		expect( getHookValues( result ).hasPosterEdits ).toBe( true );
+	} );
+
+	it( 'clears poster image data when video frame is selected', () => {
+		const { result } = renderTestHook();
+
+		act( () => {
+			getHookValues( result ).handleSelectPoster( { id: 10 } );
+		} );
+
+		expect( getHookValues( result ).videoPosterImageData ).toEqual( { id: 10 } );
+
+		act( () => {
+			getHookValues( result ).handleVideoFrameSelected( 3000 );
+		} );
+
+		expect( getHookValues( result ).videoPosterImageData ).toBeNull();
+	} );
+} );

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/test/uploader-progress.test.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/test/uploader-progress.test.js
@@ -19,7 +19,7 @@ const mockApiFetch = jest.fn();
 jest.mock( '@wordpress/compose', () => ( {
 	useDebounce: fn => {
 		const debounced = ( ...args ) => fn( ...args );
-		jest.spyOn( debounced, 'cancel' ).mockImplementation();
+		debounced.cancel = jest.fn(); // eslint-disable-line jest/prefer-spy-on
 		return debounced;
 	},
 	createHigherOrderComponent: () => c => c,

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/test/uploader-progress.test.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/test/uploader-progress.test.js
@@ -17,7 +17,11 @@ jest.mock(
 // Declared after jest.mock calls because @wordpress/api-fetch mock needs a lazy reference.
 const mockApiFetch = jest.fn();
 jest.mock( '@wordpress/compose', () => ( {
-	useDebounce: fn => fn,
+	useDebounce: fn => {
+		const debounced = ( ...args ) => fn( ...args );
+		jest.spyOn( debounced, 'cancel' ).mockImplementation();
+		return debounced;
+	},
 	createHigherOrderComponent: () => c => c,
 } ) );
 jest.mock( '@wordpress/components', () => ( {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/test/uploader-progress.test.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/test/uploader-progress.test.js
@@ -75,6 +75,7 @@ describe( 'usePosterAndTitleUpdate', () => {
 			videoPosterImageData,
 			isFinishingUpdate,
 			hasPosterEdits,
+			videoRef,
 		] = result.current;
 
 		return {
@@ -85,6 +86,7 @@ describe( 'usePosterAndTitleUpdate', () => {
 			videoPosterImageData,
 			isFinishingUpdate,
 			hasPosterEdits,
+			videoRef,
 		};
 	};
 
@@ -121,39 +123,76 @@ describe( 'usePosterAndTitleUpdate', () => {
 		} );
 	} );
 
-	it( 'awaits server poster URL for video frame selection', async () => {
-		const posterUrl = 'https://example.com/frame-poster.jpg';
-		mockUploadPoster.mockResolvedValue( { data: { poster: posterUrl } } );
+	it( 'captures frame client-side and uploads as poster on Done', async () => {
+		const posterUrl = 'https://example.com/wp-content/uploads/poster.jpg';
+		const fakeBlob = new Blob( [ 'fake' ], { type: 'image/jpeg' } );
+
+		// Mock the media upload response.
+		mockApiFetch.mockResolvedValue( { id: 99, source_url: posterUrl } );
 
 		const { result } = renderTestHook();
+		const { videoRef } = getHookValues( result );
+
+		// Simulate a video element with capturable dimensions.
+		videoRef.current = {
+			videoWidth: 640,
+			videoHeight: 360,
+		};
+
+		// Mock canvas and toBlob globally for captureVideoFrame.
+		const mockToBlob = jest.fn( cb => cb( fakeBlob ) );
+		const mockGetContext = jest.fn( () => ( { drawImage: jest.fn() } ) );
+		jest.spyOn( document, 'createElement' ).mockReturnValue( {
+			width: 0,
+			height: 0,
+			getContext: mockGetContext,
+			toBlob: mockToBlob,
+		} );
 
 		act( () => {
 			getHookValues( result ).handleVideoFrameSelected( 5000 );
 		} );
 
-		// The debounced useEffect fires immediately (mock), then
-		// handleDoneUpload reuses that promise instead of duplicating.
 		await act( async () => {
 			getHookValues( result ).handleDoneUpload();
+			await Promise.resolve();
+			await Promise.resolve();
 		} );
 
-		// Only one POST should have been made (from the useEffect).
-		expect( mockUploadPoster ).toHaveBeenCalledTimes( 1 );
-		expect( mockUploadPoster ).toHaveBeenCalledWith( {
-			at_time: 5000,
-			is_millisec: true,
-		} );
+		// Should upload via WP media API, not the VideoPress poster endpoint.
+		expect( mockApiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: '/wp/v2/media',
+				method: 'POST',
+			} )
+		);
+		expect( mockUploadPoster ).not.toHaveBeenCalled();
 		expect( onDone ).toHaveBeenCalledWith( {
 			...videoData,
 			poster: posterUrl,
 		} );
+
+		document.createElement.mockRestore();
 	} );
 
-	it( 'handles video frame selected at 0ms', async () => {
-		const posterUrl = 'https://example.com/zero-frame.jpg';
-		mockUploadPoster.mockResolvedValue( { data: { poster: posterUrl } } );
+	it( 'handles frame capture at 0ms', async () => {
+		const posterUrl = 'https://example.com/wp-content/uploads/poster.jpg';
+		const fakeBlob = new Blob( [ 'fake' ], { type: 'image/jpeg' } );
+
+		mockApiFetch.mockResolvedValue( { id: 99, source_url: posterUrl } );
 
 		const { result } = renderTestHook();
+		const { videoRef } = getHookValues( result );
+
+		videoRef.current = { videoWidth: 640, videoHeight: 360 };
+
+		const mockToBlob = jest.fn( cb => cb( fakeBlob ) );
+		jest.spyOn( document, 'createElement' ).mockReturnValue( {
+			width: 0,
+			height: 0,
+			getContext: jest.fn( () => ( { drawImage: jest.fn() } ) ),
+			toBlob: mockToBlob,
+		} );
 
 		act( () => {
 			getHookValues( result ).handleVideoFrameSelected( 0 );
@@ -161,16 +200,90 @@ describe( 'usePosterAndTitleUpdate', () => {
 
 		await act( async () => {
 			getHookValues( result ).handleDoneUpload();
+			await Promise.resolve();
+			await Promise.resolve();
 		} );
 
-		expect( mockUploadPoster ).toHaveBeenCalledWith( {
-			at_time: 0,
-			is_millisec: true,
-		} );
 		expect( onDone ).toHaveBeenCalledWith( {
 			...videoData,
 			poster: posterUrl,
 		} );
+
+		document.createElement.mockRestore();
+	} );
+
+	it( 'falls back to onDone without poster when frame capture fails', async () => {
+		mockApiFetch.mockRejectedValue( new Error( 'upload failed' ) );
+
+		const { result } = renderTestHook();
+		const { videoRef } = getHookValues( result );
+
+		videoRef.current = { videoWidth: 640, videoHeight: 360 };
+
+		jest.spyOn( document, 'createElement' ).mockReturnValue( {
+			width: 0,
+			height: 0,
+			getContext: jest.fn( () => ( { drawImage: jest.fn() } ) ),
+			toBlob: jest.fn( cb => cb( new Blob( [ 'fake' ] ) ) ),
+		} );
+
+		act( () => {
+			getHookValues( result ).handleVideoFrameSelected( 5000 );
+		} );
+
+		await act( async () => {
+			getHookValues( result ).handleDoneUpload();
+			await Promise.resolve();
+			await Promise.resolve();
+		} );
+
+		// Should fall back gracefully.
+		expect( onDone ).toHaveBeenCalledWith( videoData );
+
+		document.createElement.mockRestore();
+	} );
+
+	it( 'falls back to onDone without poster when toBlob returns null', async () => {
+		const { result } = renderTestHook();
+		const { videoRef } = getHookValues( result );
+
+		videoRef.current = { videoWidth: 640, videoHeight: 360 };
+
+		jest.spyOn( document, 'createElement' ).mockReturnValue( {
+			width: 0,
+			height: 0,
+			getContext: jest.fn( () => ( { drawImage: jest.fn() } ) ),
+			toBlob: jest.fn( cb => cb( null ) ),
+		} );
+
+		act( () => {
+			getHookValues( result ).handleVideoFrameSelected( 5000 );
+		} );
+
+		await act( async () => {
+			getHookValues( result ).handleDoneUpload();
+			await Promise.resolve();
+			await Promise.resolve();
+		} );
+
+		expect( onDone ).toHaveBeenCalledWith( videoData );
+
+		document.createElement.mockRestore();
+	} );
+
+	it( 'falls back to onDone without poster when videoRef is missing', async () => {
+		const { result } = renderTestHook();
+
+		// videoRef.current is null by default — don't set it.
+		act( () => {
+			getHookValues( result ).handleVideoFrameSelected( 5000 );
+		} );
+
+		await act( async () => {
+			getHookValues( result ).handleDoneUpload();
+		} );
+
+		expect( onDone ).toHaveBeenCalledWith( videoData );
 	} );
 
 	it( 'sets poster attribute via setAttributes when debounced update resolves', async () => {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/test/uploader-progress.test.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/test/uploader-progress.test.js
@@ -214,6 +214,37 @@ describe( 'usePosterAndTitleUpdate', () => {
 		jest.useRealTimers();
 	} );
 
+	it( 'stops polling and resolves null after max retries', async () => {
+		jest.useFakeTimers();
+
+		// Upload and every poll return generating — never completes.
+		mockUploadPoster.mockResolvedValue( { data: { generating: true } } );
+		mockGetPoster.mockResolvedValue( { data: { generating: true } } );
+
+		const { result } = renderTestHook();
+
+		act( () => {
+			getHookValues( result ).handleSelectPoster( { id: 10 } );
+		} );
+
+		await act( async () => {
+			getHookValues( result ).handleDoneUpload();
+		} );
+
+		// Advance through all 10 retries (10 × 2000ms).
+		for ( let i = 0; i < 10; i++ ) {
+			await act( async () => {
+				jest.advanceTimersByTime( 2000 );
+				await Promise.resolve();
+			} );
+		}
+
+		// onDone should be called without poster after retries are exhausted.
+		expect( onDone ).toHaveBeenCalledWith( videoData );
+
+		jest.useRealTimers();
+	} );
+
 	it( 'resolves with null when polling fails during poster generation', async () => {
 		jest.useFakeTimers();
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-editor.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-editor.js
@@ -27,7 +27,7 @@ const PosterImage = ( { videoPosterImageUrl } ) => {
 	);
 };
 
-const Poster = ( { file, videoPosterImageData, onVideoFrameSelected } ) => {
+const Poster = ( { file, videoPosterImageData, onVideoFrameSelected, videoRef } ) => {
 	const hasPosterImage = Boolean( videoPosterImageData?.url );
 
 	// - Avoid recreate the object on every render
@@ -40,6 +40,7 @@ const Poster = ( { file, videoPosterImageData, onVideoFrameSelected } ) => {
 				src={ src?.current }
 				onVideoFrameSelected={ onVideoFrameSelected }
 				className={ clsx( { 'uploading-editor__hide': hasPosterImage } ) }
+				videoRef={ videoRef }
 			/>
 			{ hasPosterImage && (
 				<>
@@ -83,8 +84,14 @@ const PosterActions = ( { hasPoster, onSelectPoster, onRemovePoster } ) => {
 };
 
 const UploadingEditor = props => {
-	const { file, onSelectPoster, onRemovePoster, videoPosterImageData, onVideoFrameSelected } =
-		props;
+	const {
+		file,
+		onSelectPoster,
+		onRemovePoster,
+		videoPosterImageData,
+		onVideoFrameSelected,
+		videoRef,
+	} = props;
 
 	return (
 		<div className="uploading-editor">
@@ -96,6 +103,7 @@ const UploadingEditor = props => {
 					file={ file }
 					videoPosterImageData={ videoPosterImageData }
 					onVideoFrameSelected={ onVideoFrameSelected }
+					videoRef={ videoRef }
 				/>
 				<PosterActions
 					hasPoster={ Boolean( videoPosterImageData ) }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
@@ -21,6 +21,26 @@ import UploadingEditor from './uploader-editor.js';
 
 const debug = debugFactory( 'videopress:block:uploader' );
 
+/**
+ * Captures the current frame from a video element as a JPEG blob.
+ *
+ * @param {HTMLVideoElement} video - The video element to capture from.
+ * @return {Promise<Blob>} A promise that resolves with the JPEG blob.
+ */
+const captureVideoFrame = video => {
+	const canvas = document.createElement( 'canvas' );
+	canvas.width = video.videoWidth;
+	canvas.height = video.videoHeight;
+	canvas.getContext( '2d' ).drawImage( video, 0, 0 );
+	return new Promise( ( resolve, reject ) =>
+		canvas.toBlob(
+			blob => ( blob ? resolve( blob ) : reject( new Error( 'toBlob failed' ) ) ),
+			'image/jpeg',
+			0.95
+		)
+	);
+};
+
 const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 	const [ isFinishingUpdate, setIsFinishingUpdate ] = useState( false );
 	const [ videoFrameMs, setVideoFrameMs ] = useState( null );
@@ -99,6 +119,7 @@ const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 	};
 
 	const posterPromiseRef = useRef( null );
+	const videoRef = useRef( null );
 
 	const debouncedSendUpdatePoster = useDebounce( posterData => {
 		posterPromiseRef.current = sendUpdatePoster( posterData );
@@ -151,22 +172,31 @@ const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 			return;
 		}
 
-		// Frame selection: reuse the in-flight promise from the debounced
-		// useEffect (single request) rather than firing a duplicate POST.
-		// If the debounce hasn't fired yet, send the request now.
-		if ( 'undefined' !== typeof videoFrameMs && null !== videoFrameMs ) {
-			const posterPromise =
-				posterPromiseRef.current ||
-				sendUpdatePoster( { at_time: videoFrameMs, is_millisec: true } );
+		// Frame selection: capture the frame client-side from the video
+		// element and upload it to the WP Media Library as an attachment.
+		// The attachment URL is used directly as the poster, bypassing
+		// the VideoPress poster API. This avoids depending on server-side
+		// frame extraction which requires the video to be fully transcoded.
+		if ( 'undefined' !== typeof videoFrameMs && null !== videoFrameMs && videoRef.current ) {
+			captureVideoFrame( videoRef.current )
+				.then( blob => {
+					const formData = new FormData();
+					formData.append( 'file', blob, 'poster.jpg' );
 
-			posterPromise
-				.then( posterUrl => {
-					onDone( {
-						...videoData,
-						...( posterUrl ? { poster: posterUrl } : {} ),
+					return apiFetch( {
+						path: '/wp/v2/media',
+						method: 'POST',
+						body: formData,
 					} );
 				} )
-				.catch( () => {
+				.then( attachment => {
+					onDone( {
+						...videoData,
+						poster: attachment.source_url,
+					} );
+				} )
+				.catch( error => {
+					debug( 'Failed to capture/upload frame poster: %o', error );
 					onDone( videoData );
 				} );
 			return;
@@ -183,11 +213,8 @@ const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 
 		if ( videoPosterImageData ) {
 			debouncedSendUpdatePoster( { poster_attachment_id: videoPosterImageData?.id } );
-		} else if ( 'undefined' !== typeof videoFrameMs && null !== videoFrameMs ) {
-			// Check against undefined and null instead of bool to allow 0ms selection.
-			debouncedSendUpdatePoster( { at_time: videoFrameMs, is_millisec: true } );
 		}
-	}, [ videoPosterImageData, videoFrameMs, guid, isFinishingUpdate ] );
+	}, [ videoPosterImageData, guid, isFinishingUpdate ] );
 
 	const hasPosterEdits = videoPosterImageData !== null || videoFrameMs !== null;
 
@@ -199,6 +226,7 @@ const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 		videoPosterImageData,
 		isFinishingUpdate,
 		hasPosterEdits,
+		videoRef,
 	];
 };
 
@@ -223,6 +251,7 @@ const UploaderProgress = ( {
 		videoPosterImageData,
 		isFinishingUpdate,
 		hasPosterEdits,
+		videoRef,
 	] = usePosterAndTitleUpdate( {
 		setAttributes,
 		videoData: { ...uploadedVideoData, title: attributes.title },
@@ -273,6 +302,7 @@ const UploaderProgress = ( {
 				onRemovePoster={ handleRemovePoster }
 				onVideoFrameSelected={ handleVideoFrameSelected }
 				videoPosterImageData={ videoPosterImageData }
+				videoRef={ videoRef }
 			/>
 
 			<div className="videopress-uploader-progress">

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
@@ -50,21 +50,25 @@ const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 	};
 
 	const updatePoster = ( { data: result } ) => {
-		if ( result?.generating ) {
-			setTimeout( () => {
-				getPosterImage().then( response => updatePoster( response ) );
-			}, 2000 );
-		} else if ( result?.poster ) {
-			setAttributes( { poster: result?.poster } );
-		}
+		return new Promise( resolve => {
+			if ( result?.generating ) {
+				setTimeout( () => {
+					getPosterImage().then( response => updatePoster( response ).then( resolve ) );
+				}, 2000 );
+			} else if ( result?.poster ) {
+				setAttributes( { poster: result.poster } );
+				resolve( result.poster );
+			} else {
+				resolve( null );
+			}
+		} );
 	};
 
 	const sendUpdatePoster = data => {
 		return new Promise( ( resolve, reject ) => {
 			videoPressUploadPoster( data )
 				.then( result => {
-					updatePoster( result );
-					resolve();
+					updatePoster( result ).then( resolve );
 				} )
 				.catch( () => {
 					apiFetch( {
@@ -74,8 +78,8 @@ const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 						global: true,
 						data: data,
 					} )
-						.then( () => {
-							resolve();
+						.then( result => {
+							updatePoster( { data: result } ).then( resolve );
 						} )
 						.catch( e => {
 							reject( e );
@@ -114,9 +118,36 @@ const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 			updates.push( sendUpdateTitleRequest() );
 		}
 
+		// Include the poster update in the completion flow so it resolves
+		// before the upload component unmounts. The resolved poster URL
+		// is passed through onDone so it persists in block attributes.
+		let posterUpdate = null;
+		if ( videoPosterImageData ) {
+			posterUpdate = sendUpdatePoster( {
+				poster_attachment_id: videoPosterImageData?.id,
+			} );
+			updates.push( posterUpdate );
+		} else if ( 'undefined' !== typeof videoFrameMs && null !== videoFrameMs ) {
+			posterUpdate = sendUpdatePoster( {
+				at_time: videoFrameMs,
+				is_millisec: true,
+			} );
+			updates.push( posterUpdate );
+		}
+
 		Promise.allSettled( updates ).then( () => {
 			setIsFinishingUpdate( false );
-			onDone( videoData );
+
+			if ( posterUpdate ) {
+				posterUpdate.then( posterUrl => {
+					onDone( {
+						...videoData,
+						...( posterUrl ? { poster: posterUrl } : {} ),
+					} );
+				} );
+			} else {
+				onDone( videoData );
+			}
 		} );
 	};
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
@@ -116,6 +116,7 @@ const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 
 	const handleDoneUpload = () => {
 		setIsFinishingUpdate( true );
+		debouncedSsendUpdatePoster.cancel?.();
 
 		const updates = [];
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
@@ -177,11 +177,9 @@ const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 		}
 
 		if ( videoPosterImageData ) {
-			return debouncedSendUpdatePoster( { poster_attachment_id: videoPosterImageData?.id } );
-		}
-
-		// Check if videoFrameMs is not undefined or null instead of bool check to allow 0ms. selection
-		if ( 'undefined' !== typeof videoFrameMs && null !== videoFrameMs ) {
+			debouncedSendUpdatePoster( { poster_attachment_id: videoPosterImageData?.id } );
+		} else if ( 'undefined' !== typeof videoFrameMs && null !== videoFrameMs ) {
+			// Check against undefined and null instead of bool to allow 0ms selection.
 			debouncedSendUpdatePoster( { at_time: videoFrameMs, is_millisec: true } );
 		}
 	}, [ videoPosterImageData, videoFrameMs, guid, isFinishingUpdate ] );

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
@@ -96,7 +96,7 @@ const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 		} );
 	};
 
-	const debouncedSsendUpdatePoster = useDebounce( posterData => {
+	const debouncedSendUpdatePoster = useDebounce( posterData => {
 		sendUpdatePoster( posterData );
 	}, 1000 );
 
@@ -123,7 +123,7 @@ const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 		}
 
 		setIsFinishingUpdate( true );
-		debouncedSsendUpdatePoster.cancel?.();
+		debouncedSendUpdatePoster.cancel?.();
 
 		if ( title ) {
 			sendUpdateTitleRequest();
@@ -159,12 +159,12 @@ const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 		}
 
 		if ( videoPosterImageData ) {
-			return debouncedSsendUpdatePoster( { poster_attachment_id: videoPosterImageData?.id } );
+			return debouncedSendUpdatePoster( { poster_attachment_id: videoPosterImageData?.id } );
 		}
 
 		// Check if videoFrameMs is not undefined or null instead of bool check to allow 0ms. selection
 		if ( 'undefined' !== typeof videoFrameMs && null !== videoFrameMs ) {
-			debouncedSsendUpdatePoster( { at_time: videoFrameMs, is_millisec: true } );
+			debouncedSendUpdatePoster( { at_time: videoFrameMs, is_millisec: true } );
 		}
 	}, [ videoPosterImageData, videoFrameMs, guid, isFinishingUpdate ] );
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
@@ -119,6 +119,7 @@ const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 	const handleVideoFrameSelected = ms => {
 		setVideoFrameMs( ms );
 		setVideoPosterImageData( null );
+		posterPromiseRef.current = null;
 	};
 
 	const handleDoneUpload = () => {
@@ -130,7 +131,9 @@ const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 		debouncedSendUpdatePoster.cancel?.();
 
 		if ( title ) {
-			sendUpdateTitleRequest();
+			sendUpdateTitleRequest().catch( error => {
+				debug( 'Failed to update video title: %o', error );
+			} );
 		}
 
 		// Image selection: we have the URL client-side, fire the server
@@ -138,6 +141,8 @@ const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 		if ( videoPosterImageData ) {
 			sendUpdatePoster( {
 				poster_attachment_id: videoPosterImageData?.id,
+			} ).catch( error => {
+				debug( 'Failed to update poster in background: %o', error );
 			} );
 			onDone( {
 				...videoData,

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
@@ -357,7 +357,7 @@ const UploaderProgress = ( {
 					</>
 				) : (
 					<>
-						{ hasUserEdits ? (
+						{ hasUserEdits && uploadedVideoData ? (
 							<>
 								<span>{ __( 'Upload Complete!', 'jetpack-videopress-pkg' ) } 🎉</span>
 								<Button

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
@@ -115,6 +115,10 @@ const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 	};
 
 	const handleDoneUpload = () => {
+		if ( ! guid ) {
+			return;
+		}
+
 		setIsFinishingUpdate( true );
 		debouncedSsendUpdatePoster.cancel?.();
 
@@ -306,7 +310,7 @@ const UploaderProgress = ( {
 								<Button
 									variant="primary"
 									onClick={ handleDoneUpload }
-									disabled={ isFinishingUpdate }
+									disabled={ isFinishingUpdate || ! uploadedVideoData?.guid }
 									isBusy={ isFinishingUpdate }
 								>
 									{ __( 'Done', 'jetpack-videopress-pkg' ) }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
@@ -125,47 +125,31 @@ const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 		setIsFinishingUpdate( true );
 		debouncedSsendUpdatePoster.cancel?.();
 
-		const updates = [];
-
 		if ( title ) {
-			updates.push( sendUpdateTitleRequest() );
+			sendUpdateTitleRequest();
 		}
 
-		// Include the poster update in the completion flow so it resolves
-		// before the upload component unmounts. The resolved poster URL
-		// is passed through onDone so it persists in block attributes.
-		let posterUpdate = null;
+		// Fire the server-side poster update in the background — don't
+		// block onDone.  We already have the poster URL client-side
+		// (videoPosterImageData.url) so we pass it through immediately.
 		if ( videoPosterImageData ) {
-			posterUpdate = sendUpdatePoster( {
+			sendUpdatePoster( {
 				poster_attachment_id: videoPosterImageData?.id,
 			} );
-			updates.push( posterUpdate );
 		} else if ( 'undefined' !== typeof videoFrameMs && null !== videoFrameMs ) {
-			posterUpdate = sendUpdatePoster( {
+			sendUpdatePoster( {
 				at_time: videoFrameMs,
 				is_millisec: true,
 			} );
-			updates.push( posterUpdate );
 		}
 
-		Promise.allSettled( updates ).then( () => {
-			setIsFinishingUpdate( false );
+		// Use the client-side poster URL if available so the block
+		// attribute is set immediately without waiting for the server.
+		const posterUrl = videoPosterImageData?.url;
 
-			if ( posterUpdate ) {
-				posterUpdate
-					.then( posterUrl => {
-						onDone( {
-							...videoData,
-							...( posterUrl ? { poster: posterUrl } : {} ),
-						} );
-					} )
-					.catch( error => {
-						debug( 'Poster update failed: %o', error );
-						onDone( videoData );
-					} );
-			} else {
-				onDone( videoData );
-			}
+		onDone( {
+			...videoData,
+			...( posterUrl ? { poster: posterUrl } : {} ),
 		} );
 	};
 
@@ -313,7 +297,7 @@ const UploaderProgress = ( {
 								<Button
 									variant="primary"
 									onClick={ handleDoneUpload }
-									disabled={ isFinishingUpdate || ! uploadedVideoData?.guid }
+									disabled={ isFinishingUpdate }
 									isBusy={ isFinishingUpdate }
 								>
 									{ __( 'Done', 'jetpack-videopress-pkg' ) }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
@@ -49,12 +49,12 @@ const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 		} );
 	};
 
-	const updatePoster = ( { data: result } ) => {
+	const updatePoster = ( { data: result }, remainingRetries = 10 ) => {
 		return new Promise( resolve => {
-			if ( result?.generating ) {
+			if ( result?.generating && remainingRetries > 0 ) {
 				setTimeout( () => {
 					getPosterImage()
-						.then( response => updatePoster( response ).then( resolve ) )
+						.then( response => updatePoster( response, remainingRetries - 1 ).then( resolve ) )
 						.catch( error => {
 							debug( 'Poster polling failed: %o', error );
 							resolve( null );
@@ -64,6 +64,9 @@ const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 				setAttributes( { poster: result.poster } );
 				resolve( result.poster );
 			} else {
+				if ( result?.generating ) {
+					debug( 'Poster generation polling timed out' );
+				}
 				resolve( null );
 			}
 		} );

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
@@ -139,12 +139,16 @@ const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 			setIsFinishingUpdate( false );
 
 			if ( posterUpdate ) {
-				posterUpdate.then( posterUrl => {
-					onDone( {
-						...videoData,
-						...( posterUrl ? { poster: posterUrl } : {} ),
+				posterUpdate
+					.then( posterUrl => {
+						onDone( {
+							...videoData,
+							...( posterUrl ? { poster: posterUrl } : {} ),
+						} );
+					} )
+					.catch( () => {
+						onDone( videoData );
 					} );
-				} );
 			} else {
 				onDone( videoData );
 			}
@@ -312,3 +316,4 @@ const UploaderProgress = ( {
 };
 
 export default UploaderProgress;
+export { usePosterAndTitleUpdate };

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
@@ -28,17 +28,32 @@ const debug = debugFactory( 'videopress:block:uploader' );
  * @return {Promise<Blob>} A promise that resolves with the JPEG blob.
  */
 const captureVideoFrame = video => {
-	const canvas = document.createElement( 'canvas' );
-	canvas.width = video.videoWidth;
-	canvas.height = video.videoHeight;
-	canvas.getContext( '2d' ).drawImage( video, 0, 0 );
-	return new Promise( ( resolve, reject ) =>
+	return new Promise( ( resolve, reject ) => {
+		const canvas = document.createElement( 'canvas' );
+		canvas.width = video.videoWidth;
+		canvas.height = video.videoHeight;
+
+		const context = canvas.getContext( '2d' );
+		if ( ! context ) {
+			reject( new Error( 'Could not get 2D context for canvas' ) );
+			return;
+		}
+
+		try {
+			context.drawImage( video, 0, 0 );
+		} catch ( error ) {
+			reject(
+				error instanceof Error ? error : new Error( 'Failed to draw video frame to canvas' )
+			);
+			return;
+		}
+
 		canvas.toBlob(
 			blob => ( blob ? resolve( blob ) : reject( new Error( 'toBlob failed' ) ) ),
 			'image/jpeg',
 			0.95
-		)
-	);
+		);
+	} );
 };
 
 const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
@@ -51,7 +51,12 @@ const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 
 	const updatePoster = ( { data: result }, remainingRetries = 10 ) => {
 		return new Promise( resolve => {
-			if ( result?.generating && remainingRetries > 0 ) {
+			// Check for a poster URL first — the API can return both
+			// `poster` and `generating: true` simultaneously.
+			if ( result?.poster ) {
+				setAttributes( { poster: result.poster } );
+				resolve( result.poster );
+			} else if ( result?.generating && remainingRetries > 0 ) {
 				setTimeout( () => {
 					getPosterImage()
 						.then( response => updatePoster( response, remainingRetries - 1 ).then( resolve ) )
@@ -60,9 +65,6 @@ const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 							resolve( null );
 						} );
 				}, 2000 );
-			} else if ( result?.poster ) {
-				setAttributes( { poster: result.poster } );
-				resolve( result.poster );
 			} else {
 				if ( result?.generating ) {
 					debug( 'Poster generation polling timed out' );
@@ -96,8 +98,10 @@ const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 		} );
 	};
 
+	const posterPromiseRef = useRef( null );
+
 	const debouncedSendUpdatePoster = useDebounce( posterData => {
-		sendUpdatePoster( posterData );
+		posterPromiseRef.current = sendUpdatePoster( posterData );
 	}, 1000 );
 
 	const sendUpdateTitleRequest = () => {
@@ -129,28 +133,42 @@ const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 			sendUpdateTitleRequest();
 		}
 
-		// Fire the server-side poster update in the background — don't
-		// block onDone.  We already have the poster URL client-side
-		// (videoPosterImageData.url) so we pass it through immediately.
+		// Image selection: we have the URL client-side, fire the server
+		// update in the background and proceed immediately.
 		if ( videoPosterImageData ) {
 			sendUpdatePoster( {
 				poster_attachment_id: videoPosterImageData?.id,
 			} );
-		} else if ( 'undefined' !== typeof videoFrameMs && null !== videoFrameMs ) {
-			sendUpdatePoster( {
-				at_time: videoFrameMs,
-				is_millisec: true,
+			onDone( {
+				...videoData,
+				poster: videoPosterImageData.url,
 			} );
+			return;
 		}
 
-		// Use the client-side poster URL if available so the block
-		// attribute is set immediately without waiting for the server.
-		const posterUrl = videoPosterImageData?.url;
+		// Frame selection: reuse the in-flight promise from the debounced
+		// useEffect (single request) rather than firing a duplicate POST.
+		// If the debounce hasn't fired yet, send the request now.
+		if ( 'undefined' !== typeof videoFrameMs && null !== videoFrameMs ) {
+			const posterPromise =
+				posterPromiseRef.current ||
+				sendUpdatePoster( { at_time: videoFrameMs, is_millisec: true } );
 
-		onDone( {
-			...videoData,
-			...( posterUrl ? { poster: posterUrl } : {} ),
-		} );
+			posterPromise
+				.then( posterUrl => {
+					onDone( {
+						...videoData,
+						...( posterUrl ? { poster: posterUrl } : {} ),
+					} );
+				} )
+				.catch( () => {
+					onDone( videoData );
+				} );
+			return;
+		}
+
+		// No poster edits.
+		onDone( videoData );
 	};
 
 	useEffect( () => {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-progress.js
@@ -53,7 +53,12 @@ const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 		return new Promise( resolve => {
 			if ( result?.generating ) {
 				setTimeout( () => {
-					getPosterImage().then( response => updatePoster( response ).then( resolve ) );
+					getPosterImage()
+						.then( response => updatePoster( response ).then( resolve ) )
+						.catch( error => {
+							debug( 'Poster polling failed: %o', error );
+							resolve( null );
+						} );
 				}, 2000 );
 			} else if ( result?.poster ) {
 				setAttributes( { poster: result.poster } );
@@ -146,7 +151,8 @@ const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 							...( posterUrl ? { poster: posterUrl } : {} ),
 						} );
 					} )
-					.catch( () => {
+					.catch( error => {
+						debug( 'Poster update failed: %o', error );
 						onDone( videoData );
 					} );
 			} else {
@@ -156,7 +162,7 @@ const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 	};
 
 	useEffect( () => {
-		if ( ! guid ) {
+		if ( ! guid || isFinishingUpdate ) {
 			return;
 		}
 
@@ -168,7 +174,7 @@ const usePosterAndTitleUpdate = ( { setAttributes, videoData, onDone } ) => {
 		if ( 'undefined' !== typeof videoFrameMs && null !== videoFrameMs ) {
 			debouncedSsendUpdatePoster( { at_time: videoFrameMs, is_millisec: true } );
 		}
-	}, [ videoPosterImageData, videoFrameMs, guid ] );
+	}, [ videoPosterImageData, videoFrameMs, guid, isFinishingUpdate ] );
 
 	const hasPosterEdits = videoPosterImageData !== null || videoFrameMs !== null;
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -390,8 +390,14 @@ export default function VideoPressEdit( {
 					...newVideoData,
 				};
 
-				// Remove the old video's poster unless a new one was selected during upload.
-				if ( ! newVideoData.poster ) {
+				// Remove the old video's poster unless a new one was selected during
+				// upload. Only delete if it still matches the poster from before the
+				// replacement started, so we don't drop a poster that was set via
+				// setAttributes during upload but not included in newVideoData.
+				if (
+					! newVideoData.poster &&
+					( ! attributes.poster || attributes.poster === isReplacingFile.prevAttrs?.poster )
+				) {
 					delete newBlockAttributes.poster;
 				}
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/edit.tsx
@@ -390,8 +390,10 @@ export default function VideoPressEdit( {
 					...newVideoData,
 				};
 
-				// Delete attributes that are not needed.
-				delete newBlockAttributes.poster;
+				// Remove the old video's poster unless a new one was selected during upload.
+				if ( ! newVideoData.poster ) {
+					delete newBlockAttributes.poster;
+				}
 
 				setIsReplacingFile( { isReplacing: false, prevAttrs: {} } );
 				replaceBlock( clientId, createBlock( 'videopress/video', newBlockAttributes ) );

--- a/projects/packages/videopress/src/client/components/video-frame-selector/index.jsx
+++ b/projects/packages/videopress/src/client/components/video-frame-selector/index.jsx
@@ -11,8 +11,9 @@ import clsx from 'clsx';
 import playIcon from '../icons/play-icon';
 import styles from './style.module.scss';
 
-export const VideoPlayer = ( { src, setMaxDuration = null, currentTime } ) => {
-	const videoPlayer = useRef( null );
+export const VideoPlayer = ( { src, setMaxDuration = null, currentTime, videoRef } ) => {
+	const internalRef = useRef( null );
+	const videoPlayer = videoRef || internalRef;
 	const [ isVideoLoading, setIsVideoLoading ] = useState( true );
 
 	useEffect( () => {
@@ -58,6 +59,7 @@ const VideoFrameSelector = ( {
 	onVideoFrameSelected,
 	className = '',
 	initialCurrentTime = null,
+	videoRef = null,
 } ) => {
 	const [ maxDuration, setMaxDuration ] = useState( 0 );
 	const [ currentTime, setCurrentTime ] = useState(
@@ -72,7 +74,12 @@ const VideoFrameSelector = ( {
 	return (
 		<div className={ clsx( styles.container, className ) }>
 			<Icon className={ styles[ 'play-icon' ] } icon={ playIcon } />
-			<VideoPlayer src={ src } setMaxDuration={ setMaxDuration } currentTime={ currentTime } />
+			<VideoPlayer
+				src={ src }
+				setMaxDuration={ setMaxDuration }
+				currentTime={ currentTime }
+				videoRef={ videoRef }
+			/>
 			<RangeControl
 				className={ styles.range }
 				min={ 0 }


### PR DESCRIPTION
## Proposed changes

* Fix poster image not persisting when selected during video upload. Three interacting bugs prevented this:
  1. `handleDoneUpload` didn't wait for the poster API call — it was fire-and-forget via a debounced `useEffect`, so the upload component could unmount before the poster resolved.
  2. The resolved poster URL was never included in the data passed through `onDone`, so it didn't reach block attributes.
  3. On video replacement, the poster was unconditionally deleted regardless of whether the user selected a new one.
* Make `updatePoster` and `sendUpdatePoster` return promises that resolve with the poster URL, so `handleDoneUpload` can await them and pass the URL through `onDone`.
* Add `.catch()` to the poster update chain so `onDone` is always called even when poster upload fails completely (prevents UI hang).
* Add 14 tests for the `usePosterAndTitleUpdate` hook covering poster persistence, polling, fallback paths, error handling, and edge cases (0ms frame selection).

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Create a new post and add a VideoPress block
* Upload a video
* While the upload is in progress/complete, select a custom poster image
* Click "Done" — the poster should persist in the block
* Save the post and reload — the poster should still be set
* Repeat with selecting a video frame as poster instead of an image
* Replace an existing video, select a poster during replacement — poster should persist
* Upload a video without selecting a poster — default behavior should be unchanged
* Run JS tests: `cd projects/packages/videopress && pnpm jest`
