### PR TITLE
Fix blank page caused by missing @wordpress/ui in wp-build-polyfills

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4247,6 +4247,9 @@ importers:
       '@wordpress/theme':
         specifier: ^0.9.0
         version: 0.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1)
+      '@wordpress/ui':
+        specifier: ^0.9.0
+        version: 0.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1)
       webpack:
         specifier: ^5.104.1
         version: 5.105.2(webpack-cli@6.0.1)

--- a/projects/packages/wp-build-polyfills/bin/validate-boot-asset-lib.js
+++ b/projects/packages/wp-build-polyfills/bin/validate-boot-asset-lib.js
@@ -1,0 +1,141 @@
+/* global __dirname */
+/**
+ * Shared validation logic for the boot module asset file.
+ *
+ * Used by both the post-build CLI script and the test suite.
+ */
+
+const { readFileSync, existsSync } = require( 'fs' );
+const path = require( 'path' );
+
+// Script handles registered by WordPress Core (wp_default_scripts).
+// This list should be kept in sync with Core's wp-includes/script-loader.php.
+const CORE_SCRIPT_HANDLES = new Set( [
+	'react',
+	'react-dom',
+	'react-jsx-runtime',
+	'wp-a11y',
+	'wp-api-fetch',
+	'wp-blob',
+	'wp-block-directory',
+	'wp-block-editor',
+	'wp-block-library',
+	'wp-block-serialization-default-parser',
+	'wp-blocks',
+	'wp-commands',
+	'wp-components',
+	'wp-compose',
+	'wp-core-data',
+	'wp-customize-widgets',
+	'wp-data',
+	'wp-data-controls',
+	'wp-date',
+	'wp-deprecated',
+	'wp-dom',
+	'wp-dom-ready',
+	'wp-edit-post',
+	'wp-edit-site',
+	'wp-edit-widgets',
+	'wp-editor',
+	'wp-element',
+	'wp-escape-html',
+	'wp-format-library',
+	'wp-hooks',
+	'wp-html-entities',
+	'wp-i18n',
+	'wp-is-shallow-equal',
+	'wp-keyboard-shortcuts',
+	'wp-keycodes',
+	'wp-list-reusable-blocks',
+	'wp-media-utils',
+	'wp-notices',
+	'wp-nux',
+	'wp-plugins',
+	'wp-preferences',
+	'wp-preferences-persistence',
+	'wp-primitives',
+	'wp-priority-queue',
+	'wp-private-apis',
+	'wp-redux-routine',
+	'wp-reusable-blocks',
+	'wp-rich-text',
+	'wp-server-side-render',
+	'wp-shortcode',
+	'wp-style-engine',
+	'wp-token-list',
+	'wp-url',
+	'wp-viewport',
+	'wp-warning',
+	'wp-widgets',
+	'wp-wordcount',
+] );
+
+// Handles polyfilled by this package.
+const POLYFILL_HANDLES = new Set( [ 'wp-notices', 'wp-private-apis', 'wp-theme' ] );
+
+/**
+ * Parse dependency handles from a PHP asset file's content.
+ *
+ * @param {string} content - The PHP file content.
+ * @return {string[]} Array of handle strings, or empty array if parsing fails.
+ */
+function parseHandles( content ) {
+	const depsMatch = content.match( /dependencies.*?array\(([^)]*)\)/ );
+	if ( ! depsMatch ) {
+		return [];
+	}
+	return depsMatch[ 1 ].match( /'([^']+)'/g )?.map( s => s.replace( /'/g, '' ) ) ?? [];
+}
+
+/**
+ * Validate the boot module's asset file.
+ *
+ * @param {string} [assetFilePath] - Optional path to the asset file. Defaults to the build output.
+ * @return {{ ok: boolean, error?: string, unknownHandles?: string[], handles?: string[] }} Validation result.
+ */
+function validateBootAsset( assetFilePath ) {
+	const assetFile =
+		assetFilePath || path.join( __dirname, '..', 'build', 'modules', 'boot', 'index.asset.php' );
+
+	if ( ! existsSync( assetFile ) ) {
+		return {
+			ok: false,
+			error: `Boot asset file not found at ${ assetFile }`,
+		};
+	}
+
+	const content = readFileSync( assetFile, 'utf8' );
+	const handles = parseHandles( content );
+
+	if ( handles.length === 0 ) {
+		return {
+			ok: false,
+			error: 'Could not parse dependencies from asset file.',
+		};
+	}
+
+	const unknownHandles = handles.filter(
+		h => ! CORE_SCRIPT_HANDLES.has( h ) && ! POLYFILL_HANDLES.has( h )
+	);
+
+	if ( unknownHandles.length > 0 ) {
+		return {
+			ok: false,
+			handles,
+			unknownHandles,
+			error:
+				'Boot module asset file contains script handles not registered by ' +
+				'WordPress Core or this polyfill package:\n' +
+				unknownHandles.map( h => `   - ${ h }` ).join( '\n' ) +
+				'\n\n' +
+				'This will cause a silent failure at runtime (blank page, no errors).\n' +
+				'Fix: Add the corresponding @wordpress/* package to devDependencies in\n' +
+				'projects/packages/wp-build-polyfills/package.json so webpack can\n' +
+				'resolve it and bundle it instead of externalizing it.',
+		};
+	}
+
+	return { ok: true, handles };
+}
+
+module.exports = { validateBootAsset, parseHandles, CORE_SCRIPT_HANDLES, POLYFILL_HANDLES };

--- a/projects/packages/wp-build-polyfills/bin/validate-boot-asset.js
+++ b/projects/packages/wp-build-polyfills/bin/validate-boot-asset.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+/**
+ * Validate the boot module's asset file to catch unregistered script handles.
+ *
+ * The boot module polyfill lists classic script handles as dependencies in its
+ * .asset.php file. WordPress silently skips printing scripts when a dependency
+ * handle isn't registered, causing a blank page with no errors.
+ *
+ * This script checks that every handle in the asset file is either:
+ * - A well-known WordPress Core script handle
+ * - A handle polyfilled by this package (SCRIPT_HANDLES in class-wp-build-polyfills.php)
+ * - A vendor handle (react, react-dom, etc.)
+ *
+ * Run this after the build to catch issues before they reach production.
+ */
+
+const { validateBootAsset } = require( './validate-boot-asset-lib.js' );
+
+const result = validateBootAsset();
+
+if ( ! result.ok ) {
+	throw new Error( result.error );
+}

--- a/projects/packages/wp-build-polyfills/changelog/fix-add-wp-ui-to-polyfill
+++ b/projects/packages/wp-build-polyfills/changelog/fix-add-wp-ui-to-polyfill
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add @wordpress/ui to devDependencies so the boot module bundles it instead of externalizing it as an unregistered wp-ui script handle, which caused a blank page at runtime.

--- a/projects/packages/wp-build-polyfills/package.json
+++ b/projects/packages/wp-build-polyfills/package.json
@@ -15,9 +15,10 @@
 		"provide-boot-asset-file": "bin/provide-boot-asset-file.js"
 	},
 	"scripts": {
-		"build": "pnpm run clean && webpack",
+		"build": "pnpm run clean && webpack && node bin/validate-boot-asset.js",
 		"build-production": "NODE_ENV=production BABEL_ENV=production pnpm run build",
-		"clean": "rm -rf build/"
+		"clean": "rm -rf build/",
+		"test": "node --test 'tests/js/**/*.test.js'"
 	},
 	"devDependencies": {
 		"@automattic/jetpack-webpack-config": "workspace:*",
@@ -30,6 +31,7 @@
 		"@wordpress/private-apis": "^1.40.0",
 		"@wordpress/route": "^0.8.0",
 		"@wordpress/theme": "^0.9.0",
+		"@wordpress/ui": "^0.9.0",
 		"webpack": "^5.104.1",
 		"webpack-cli": "^6.0.1"
 	},

--- a/projects/packages/wp-build-polyfills/tests/js/validate-boot-asset.test.js
+++ b/projects/packages/wp-build-polyfills/tests/js/validate-boot-asset.test.js
@@ -1,0 +1,113 @@
+const { existsSync, writeFileSync, mkdirSync, rmSync } = require( 'fs' );
+const assert = require( 'node:assert/strict' );
+const { describe, it } = require( 'node:test' );
+const path = require( 'path' );
+const {
+	validateBootAsset,
+	parseHandles,
+	CORE_SCRIPT_HANDLES,
+	POLYFILL_HANDLES,
+} = require( '../../bin/validate-boot-asset-lib.js' );
+
+describe( 'validate-boot-asset', () => {
+	describe( 'parseHandles', () => {
+		it( 'should parse handles from a PHP asset file', () => {
+			const content =
+				"<?php return array('dependencies' => array('react', 'wp-data', 'wp-element'), 'version' => 'abc');";
+			const handles = parseHandles( content );
+			assert.deepEqual( handles, [ 'react', 'wp-data', 'wp-element' ] );
+		} );
+
+		it( 'should return empty array for unparseable content', () => {
+			assert.deepEqual( parseHandles( 'not a php file' ), [] );
+		} );
+
+		it( 'should return empty array for empty dependencies', () => {
+			const content = "<?php return array('dependencies' => array(), 'version' => 'abc');";
+			assert.deepEqual( parseHandles( content ), [] );
+		} );
+	} );
+
+	describe( 'validateBootAsset', () => {
+		it( 'should return error for missing file', () => {
+			const result = validateBootAsset( '/nonexistent/path/asset.php' );
+			assert.equal( result.ok, false );
+			assert.match( result.error, /not found/ );
+		} );
+
+		it( 'should pass for a file with only known handles', () => {
+			const tmpDir = path.join( __dirname, '.tmp-test-valid' );
+			const tmpFile = path.join( tmpDir, 'index.asset.php' );
+			try {
+				mkdirSync( tmpDir, { recursive: true } );
+				writeFileSync(
+					tmpFile,
+					"<?php return array('dependencies' => array('react', 'wp-data', 'wp-element', 'wp-theme'), 'version' => 'abc');\n"
+				);
+				const result = validateBootAsset( tmpFile );
+				assert.equal( result.ok, true );
+			} finally {
+				rmSync( tmpDir, { recursive: true, force: true } );
+			}
+		} );
+
+		it( 'should fail for a file with unknown handles', () => {
+			const tmpDir = path.join( __dirname, '.tmp-test-unknown' );
+			const tmpFile = path.join( tmpDir, 'index.asset.php' );
+			try {
+				mkdirSync( tmpDir, { recursive: true } );
+				writeFileSync(
+					tmpFile,
+					"<?php return array('dependencies' => array('react', 'wp-data', 'wp-ui', 'wp-nonexistent'), 'version' => 'abc');\n"
+				);
+				const result = validateBootAsset( tmpFile );
+				assert.equal( result.ok, false );
+				assert.deepEqual( result.unknownHandles, [ 'wp-ui', 'wp-nonexistent' ] );
+				assert.match( result.error, /wp-ui/ );
+				assert.match( result.error, /wp-nonexistent/ );
+			} finally {
+				rmSync( tmpDir, { recursive: true, force: true } );
+			}
+		} );
+
+		it( 'should validate the actual built asset file has no unknown handles', () => {
+			const assetFile = path.join(
+				__dirname,
+				'..',
+				'..',
+				'build',
+				'modules',
+				'boot',
+				'index.asset.php'
+			);
+
+			if ( ! existsSync( assetFile ) ) {
+				// Skip if not built — the PHP test and build step cover this too.
+				return;
+			}
+
+			const result = validateBootAsset( assetFile );
+			assert.equal(
+				result.ok,
+				true,
+				result.error || 'Built asset file should not contain unknown handles'
+			);
+		} );
+	} );
+
+	describe( 'known handles lists', () => {
+		it( 'CORE_SCRIPT_HANDLES should include common WordPress handles', () => {
+			assert.ok( CORE_SCRIPT_HANDLES.has( 'wp-data' ) );
+			assert.ok( CORE_SCRIPT_HANDLES.has( 'wp-element' ) );
+			assert.ok( CORE_SCRIPT_HANDLES.has( 'wp-components' ) );
+			assert.ok( CORE_SCRIPT_HANDLES.has( 'react' ) );
+		} );
+
+		it( 'POLYFILL_HANDLES should match the PHP class constants', () => {
+			assert.ok( POLYFILL_HANDLES.has( 'wp-notices' ) );
+			assert.ok( POLYFILL_HANDLES.has( 'wp-private-apis' ) );
+			assert.ok( POLYFILL_HANDLES.has( 'wp-theme' ) );
+			assert.equal( POLYFILL_HANDLES.size, 3 );
+		} );
+	} );
+} );

--- a/projects/packages/wp-build-polyfills/tests/php/WP_Build_Polyfills_Test.php
+++ b/projects/packages/wp-build-polyfills/tests/php/WP_Build_Polyfills_Test.php
@@ -580,15 +580,17 @@ class WP_Build_Polyfills_Test extends BaseTestCase {
 		$known_handles = array_merge( $core_handles, $polyfill_handles );
 
 		$unknown = array_diff( $asset['dependencies'], $known_handles );
-		$this->assertEmpty(
-			$unknown,
-			sprintf(
-				"Boot module asset file contains unregistered script handle(s): %s.\n" .
-				"This will cause a silent failure at runtime (blank page, no errors).\n" .
-				'Add the corresponding @wordpress/* package to devDependencies so webpack bundles it.',
-				implode( ', ', $unknown )
-			)
-		);
+		if ( ! empty( $unknown ) ) {
+			$this->fail(
+				sprintf(
+					"Boot module asset file contains unregistered script handle(s): %s.\n" .
+					"This will cause a silent failure at runtime (blank page, no errors).\n" .
+					'Add the corresponding @wordpress/* package to devDependencies in ' .
+					'projects/packages/wp-build-polyfills/package.json so webpack bundles it.',
+					implode( ', ', $unknown )
+				)
+			);
+		}
 	}
 
 	/**

--- a/projects/packages/wp-build-polyfills/tests/php/WP_Build_Polyfills_Test.php
+++ b/projects/packages/wp-build-polyfills/tests/php/WP_Build_Polyfills_Test.php
@@ -496,6 +496,102 @@ class WP_Build_Polyfills_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test that the built boot module asset file only contains script handles
+	 * that are registered by WordPress Core or polyfilled by this package.
+	 *
+	 * This prevents silent runtime failures where WordPress skips printing
+	 * the entire prerequisites script because a dependency handle is missing.
+	 */
+	public function test_boot_asset_has_no_unregistered_handles() {
+		$asset_file = dirname( __DIR__, 2 ) . '/build/modules/boot/index.asset.php';
+
+		if ( ! file_exists( $asset_file ) ) {
+			$this->markTestSkipped( 'Boot asset file not found — run `pnpm run build` first.' );
+		}
+
+		$asset = require $asset_file;
+		$this->assertIsArray( $asset, 'Asset file should return an array.' );
+		$this->assertArrayHasKey( 'dependencies', $asset, 'Asset file should have a dependencies key.' );
+
+		// Script handles registered by WordPress Core (wp_default_scripts).
+		$core_handles = array(
+			'react',
+			'react-dom',
+			'react-jsx-runtime',
+			'wp-a11y',
+			'wp-api-fetch',
+			'wp-blob',
+			'wp-block-directory',
+			'wp-block-editor',
+			'wp-block-library',
+			'wp-block-serialization-default-parser',
+			'wp-blocks',
+			'wp-commands',
+			'wp-components',
+			'wp-compose',
+			'wp-core-data',
+			'wp-customize-widgets',
+			'wp-data',
+			'wp-data-controls',
+			'wp-date',
+			'wp-deprecated',
+			'wp-dom',
+			'wp-dom-ready',
+			'wp-edit-post',
+			'wp-edit-site',
+			'wp-edit-widgets',
+			'wp-editor',
+			'wp-element',
+			'wp-escape-html',
+			'wp-format-library',
+			'wp-hooks',
+			'wp-html-entities',
+			'wp-i18n',
+			'wp-is-shallow-equal',
+			'wp-keyboard-shortcuts',
+			'wp-keycodes',
+			'wp-list-reusable-blocks',
+			'wp-media-utils',
+			'wp-notices',
+			'wp-nux',
+			'wp-plugins',
+			'wp-preferences',
+			'wp-preferences-persistence',
+			'wp-primitives',
+			'wp-priority-queue',
+			'wp-private-apis',
+			'wp-redux-routine',
+			'wp-reusable-blocks',
+			'wp-rich-text',
+			'wp-server-side-render',
+			'wp-shortcode',
+			'wp-style-engine',
+			'wp-token-list',
+			'wp-url',
+			'wp-viewport',
+			'wp-warning',
+			'wp-widgets',
+			'wp-wordcount',
+		);
+
+		// Handles polyfilled by this package.
+		$polyfill_handles = WP_Build_Polyfills::SCRIPT_HANDLES;
+
+		$known_handles = array_merge( $core_handles, $polyfill_handles );
+
+		$unknown = array_diff( $asset['dependencies'], $known_handles );
+		$this->assertEmpty(
+			$unknown,
+			sprintf(
+				"Boot module asset file contains unregistered script handle(s): %s.\n" .
+				"This will cause a silent failure at runtime (blank page, no errors).\n" .
+				'Add the corresponding @wordpress/* package to devDependencies so webpack bundles it.',
+				implode( ', ', $unknown )
+			)
+		);
+	}
+
+	/**
 	 * Test that only requested polyfills are registered.
 	 */
 	public function test_register_scripts_only_registers_requested_handles() {


### PR DESCRIPTION
Fixes #

## Proposed changes

* Add `@wordpress/ui` to `devDependencies` in `wp-build-polyfills` so the boot module's webpack build can resolve it and bundle it, instead of silently externalizing it as a classic script handle (`wp-ui`) that doesn't exist at runtime.
* Add a post-build validation script (`bin/validate-boot-asset.js`) that checks all dependency handles in the boot asset file are known WordPress Core handles or polyfilled handles. This fails the build immediately if an unknown handle appears.
* Add a PHP test (`test_boot_asset_has_no_unregistered_handles`) and JS tests (9 tests using Node's built-in test runner) to catch this class of bug in CI.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Verify the build passes: `cd projects/packages/wp-build-polyfills && pnpm run build`
  - Should see no errors and the validation step should pass
* Verify JS tests pass: `pnpm test`
  - 9 tests, all passing
* Verify PHP tests pass: `composer run test-php`
  - 16 tests (15 existing + 1 new), all passing
* To verify the validation catches bad handles, temporarily remove `@wordpress/ui` from `devDependencies`, rebuild, and confirm the build fails with a clear error message about `wp-ui`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
