### PR TITLE
fix: include WP REST nonce in analytics track endpoint for logged-in users

### DIFF
--- a/projects/packages/woocommerce-analytics/changelog/fix-store-admin-nonce-rest-api
+++ b/projects/packages/woocommerce-analytics/changelog/fix-store-admin-nonce-rest-api
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fixed store_admin property always reporting 0 for admin users in REST API tracking requests
+Fixed store_admin property always reporting 0 for admin users in REST API tracking requests.

--- a/projects/packages/woocommerce-analytics/changelog/fix-store-admin-nonce-rest-api
+++ b/projects/packages/woocommerce-analytics/changelog/fix-store-admin-nonce-rest-api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed store_admin property always reporting 0 for admin users in REST API tracking requests

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -93,7 +93,7 @@ class Universal {
 					$track_endpoint = add_query_arg( '_wpnonce', wp_create_nonce( 'wp_rest' ), $track_endpoint );
 				}
 				?>
-				wcAnalytics.trackEndpoint = '<?php echo esc_url( $track_endpoint ); ?>';
+				wcAnalytics.trackEndpoint = <?php echo wp_json_encode( esc_url_raw( $track_endpoint ) ); ?>;
 
 				// Set common properties for all events.
 				wcAnalytics.commonProps = <?php echo wp_json_encode( $common_properties, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -96,7 +96,7 @@ class Universal {
 					$track_endpoint = add_query_arg( '_wpnonce', wp_create_nonce( 'wp_rest' ), $track_endpoint );
 				}
 				?>
-				wcAnalytics.trackEndpoint = <?php echo wp_json_encode( esc_url_raw( $track_endpoint ) ); ?>;
+				wcAnalytics.trackEndpoint = <?php echo wp_json_encode( esc_url_raw( $track_endpoint ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
 
 				// Set common properties for all events.
 				wcAnalytics.commonProps = <?php echo wp_json_encode( $common_properties, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -87,7 +87,13 @@ class Universal {
 				wcAnalytics.assets_url = '<?php echo esc_url( plugins_url( '../build/', __DIR__ . '/class-woocommerce-analytics.php' ) ); ?>';
 
 				// Set the REST API tracking endpoint URL.
-				wcAnalytics.trackEndpoint = '<?php echo esc_url( rest_url( 'woocommerce-analytics/v1/track' ) ); ?>';
+				<?php
+				$track_endpoint = rest_url( 'woocommerce-analytics/v1/track' );
+				if ( is_user_logged_in() ) {
+					$track_endpoint = add_query_arg( '_wpnonce', wp_create_nonce( 'wp_rest' ), $track_endpoint );
+				}
+				?>
+				wcAnalytics.trackEndpoint = '<?php echo esc_url( $track_endpoint ); ?>';
 
 				// Set common properties for all events.
 				wcAnalytics.commonProps = <?php echo wp_json_encode( $common_properties, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;

--- a/projects/packages/woocommerce-analytics/src/class-universal.php
+++ b/projects/packages/woocommerce-analytics/src/class-universal.php
@@ -89,6 +89,9 @@ class Universal {
 				// Set the REST API tracking endpoint URL.
 				<?php
 				$track_endpoint = rest_url( 'woocommerce-analytics/v1/track' );
+				// Include the WP REST nonce for logged-in users so WordPress can identify
+				// the current user via cookie auth. This is needed for the store_admin
+				// property detection, not for endpoint authorization.
 				if ( is_user_logged_in() ) {
 					$track_endpoint = add_query_arg( '_wpnonce', wp_create_nonce( 'wp_rest' ), $track_endpoint );
 				}


### PR DESCRIPTION
Fixes WOOA7S-1150

## Proposed changes

* Include `_wpnonce` query parameter in the REST API tracking endpoint URL for logged-in users
* WordPress REST API resets the authenticated user to 0 when cookies are present but no nonce is sent (`rest_cookie_check_errors()` calls `wp_set_current_user(0)`). The analytics `sendBeacon()`/`fetch()` calls send cookies but never included a nonce, causing `store_admin` to always be `0` for admin users.
* Uses `add_query_arg()` which handles both pretty-permalink and `?rest_route=` URL formats. Only adds nonce for logged-in users (guests are unaffected).

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links

p1773997827271959-slack-C06FSDTSN82

## Does this pull request change what data or activity we track or use?
No. This fixes an existing tracked property (`store_admin`) that was always incorrectly reporting `0` for admin users.

## Testing instructions

* Deactivate woocommerce-analytics plugin if active
* Deactivate `woocommerce-analytics-proxy-speed` module. For CIAB environments, you may need to manually comment out the relevant lines.
* Add the following code snippet:

```php
<?php

add_filter( 'woocommerce_analytics_clickhouse_enabled', '__return_true' );
add_filter( 'woocommerce_analytics_experimental_proxy_tracking_enabled', '__return_true' );
add_filter(
	'jetpack_woocommerce_analytics_event_props',
	function ( $properties ) {
		error_log( 'WooCommerce Analytics get_properties: ' . print_r( $properties, true ) );
		return $properties;
	},
	10,
	2
);
```

* Log in as admin → view storefront 
* Verify `woocommerce-analytics/v1/track` request contains `_wpnonce` query parameter in browser dev tools
* Open an incognito/private window and verify `woocommerce-analytics/v1/track` request does NOT contain `_wpnonce=`
* Verify `store_admin` is set to 1 in debug log

<img width="1276" height="607" alt="Screenshot 2026-03-23 at 14 58 36" src="https://github.com/user-attachments/assets/ee28e10c-d773-4907-afec-e93526588c13" />
<img width="1099" height="544" alt="Screenshot 2026-03-23 at 14 58 56" src="https://github.com/user-attachments/assets/1330d684-c34f-40b8-81e9-8e28075710d2" />