### PR TITLE
Newsletter: Enable wp-admin newsletter settings by default

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-newsletter-settings-default-true
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-newsletter-settings-default-true
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Enable wp-admin newsletter settings on Simple sites instead of gating behind the newsletter-package-202603 sticker. WoA/WoW sites will activate after the next Jetpack plugin release.

--- a/projects/packages/jetpack-mu-wpcom/src/utils.php
+++ b/projects/packages/jetpack-mu-wpcom/src/utils.php
@@ -215,18 +215,31 @@ function wpcom_has_blog_sticker( $blog_sticker, $blog_id ) {
 }
 
 /**
- * Enable the newsletter settings package for sites with the newsletter-package-202603 sticker.
+ * Enable the newsletter settings package on Simple sites.
  *
- * This allows opt-in testing of the newsletter settings package on wpcom infrastructure.
+ * On Simple sites, jetpack-mu-wpcom controls the full stack so we can enable
+ * immediately. On WoA/WoW sites, we explicitly return false because the
+ * autoloader may load the newer newsletter package (with default true) from
+ * jetpack-mu-wpcom before the Jetpack plugin's copy, causing the new settings
+ * to activate before the admin menu integration is ready.
+ *
+ * Phase 2 (after the Jetpack plugin ships with the new defaults) will update
+ * this callback and the wpcom-admin-menu.php filter defaults to enable the
+ * new settings on WoA/WoW sites.
  *
  * @param bool $enabled Whether the newsletter settings are enabled.
  * @return bool
  */
-function wpcom_maybe_enable_newsletter_settings( $enabled ) {
-	if ( $enabled ) {
+function wpcom_maybe_enable_newsletter_settings( $enabled ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	if ( ! class_exists( '\Automattic\Jetpack\Status\Host' ) ) {
 		return $enabled;
 	}
-
-	// Stickered sites (will always be simple, as we don't sync this sticker. WoW sites can just add their own mu-plugin/snippet)
-	return function_exists( 'has_blog_sticker' ) && has_blog_sticker( 'newsletter-package-202603' );
+	$host = new \Automattic\Jetpack\Status\Host();
+	if ( $host->is_wpcom_simple() ) {
+		return true;
+	}
+	if ( $host->is_woa_site() ) {
+		return false;
+	}
+	return true;
 }

--- a/projects/packages/my-jetpack/changelog/update-newsletter-settings-default-true
+++ b/projects/packages/my-jetpack/changelog/update-newsletter-settings-default-true
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update Newsletter manage URL to default to new wp-admin settings page.

--- a/projects/packages/my-jetpack/src/products/class-newsletter.php
+++ b/projects/packages/my-jetpack/src/products/class-newsletter.php
@@ -177,7 +177,7 @@ class Newsletter extends Module_Product {
 	 * @return ?string
 	 */
 	public static function get_manage_url() {
-		if ( apply_filters( 'jetpack_wp_admin_newsletter_settings_enabled', false ) ) {
+		if ( apply_filters( 'jetpack_wp_admin_newsletter_settings_enabled', true ) ) {
 			return admin_url( 'admin.php?page=jetpack-newsletter' );
 		}
 		return admin_url( 'admin.php?page=jetpack#/newsletter' );

--- a/projects/packages/newsletter/README.md
+++ b/projects/packages/newsletter/README.md
@@ -22,16 +22,16 @@ Reader_Link::init();
 
 ## Settings page
 
-The settings page is gated behind the `jetpack_wp_admin_newsletter_settings_enabled` filter (defaults to `false`). When enabled, it registers a `Jetpack > Newsletter` submenu page in wp-admin with a React-based settings UI.
+The settings page is controlled by the `jetpack_wp_admin_newsletter_settings_enabled` filter (defaults to `true`). It registers a `Jetpack > Newsletter` submenu page in wp-admin with a React-based settings UI.
 
 ### Filters
 
 #### `jetpack_wp_admin_newsletter_settings_enabled`
 
-A temporary filter used during development of this package. When `true`, the new wp-admin newsletter settings page is used. When `false` (default), the existing settings pages are used instead (Calypso on WoA/Simple sites, the Jetpack Settings `#/newsletter` tab on standalone Jetpack sites). This filter will be removed once the new settings page is ready for general use.
+Controls whether the new wp-admin newsletter settings page is used. Defaults to `true`. When `false`, the existing settings pages are used instead (Calypso on WoA/Simple sites, the Jetpack Settings `#/newsletter` tab on standalone Jetpack sites). This filter will be removed in a future release.
 
 ```php
-add_filter( 'jetpack_wp_admin_newsletter_settings_enabled', '__return_true' );
+add_filter( 'jetpack_wp_admin_newsletter_settings_enabled', '__return_false' );
 ```
 
 #### `jetpack_show_newsletter_menu_item`

--- a/projects/packages/newsletter/changelog/update-newsletter-settings-default-true
+++ b/projects/packages/newsletter/changelog/update-newsletter-settings-default-true
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Enable wp-admin newsletter settings by default by changing the jetpack_wp_admin_newsletter_settings_enabled filter default to true. Defer the expose_to_users() check in init_hooks() to avoid timing issues with late-registered filters.

--- a/projects/packages/newsletter/src/class-settings.php
+++ b/projects/packages/newsletter/src/class-settings.php
@@ -50,9 +50,9 @@ class Settings {
 		 *
 		 * @since 15.3.0
 		 *
-		 * @param bool $enabled Whether to enable the new newsletter settings UI. Default false.
+		 * @param bool $enabled Whether to enable the new newsletter settings UI. Default true.
 		 */
-		return apply_filters( 'jetpack_wp_admin_newsletter_settings_enabled', false );
+		return apply_filters( 'jetpack_wp_admin_newsletter_settings_enabled', true );
 	}
 
 	/**
@@ -94,15 +94,16 @@ class Settings {
 			add_action( 'admin_init', array( $this, 'add_reading_page_notice' ) );
 		}
 
-		if ( ! $this->expose_to_users() ) {
-			return;
-		}
-
 		// Hijack the config URLs to point to our settings page.
 		// Priority 20 to override the default URL set in subscriptions.php.
+		// Check expose_to_users() lazily in the callback so filters registered
+		// after init() (e.g. by jetpack-mu-wpcom) are available.
 		add_filter(
 			'jetpack_module_configuration_url_subscriptions',
-			function () {
+			function ( $url ) {
+				if ( ! $this->expose_to_users() ) {
+					return $url;
+				}
 				return Urls::get_newsletter_settings_url( ( new Status() )->get_site_suffix() );
 			},
 			20
@@ -118,6 +119,8 @@ class Settings {
 		}
 
 		// Add admin menu item.
+		// The expose_to_users() check is deferred to add_wp_admin_menu() so that
+		// filters registered after init() are available when admin_menu fires.
 		// Use priority 999 to ensure menu items are queued BEFORE Admin_Menu::admin_menu_hook_callback
 		// runs at priority 1000 to process all queued items.
 		add_action( 'admin_menu', array( $this, 'add_wp_admin_menu' ), 999 );

--- a/projects/packages/newsletter/src/class-urls.php
+++ b/projects/packages/newsletter/src/class-urls.php
@@ -35,9 +35,9 @@ class Urls {
 		 *
 		 * @since 0.6.0
 		 *
-		 * @param bool $enabled Whether the new settings UI is enabled. Default false.
+		 * @param bool $enabled Whether the new settings UI is enabled. Default true.
 		 */
-		if ( apply_filters( 'jetpack_wp_admin_newsletter_settings_enabled', false ) ) {
+		if ( apply_filters( 'jetpack_wp_admin_newsletter_settings_enabled', true ) ) {
 			return admin_url( 'admin.php?page=jetpack-newsletter' );
 		}
 

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
@@ -249,7 +249,7 @@ class Jetpack_Redux_State_Helper {
 			/* This filter is already documented in jetpack/modules/subscriptions.php */
 			'isWpAdminSubscriberManagementEnabled' => apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', false ),
 			/* This filter is documented in projects/packages/newsletter/src/class-settings.php */
-			'isWpAdminNewsletterSettingsEnabled'   => apply_filters( 'jetpack_wp_admin_newsletter_settings_enabled', false ),
+			'isWpAdminNewsletterSettingsEnabled'   => apply_filters( 'jetpack_wp_admin_newsletter_settings_enabled', true ),
 		);
 	}
 

--- a/projects/plugins/jetpack/changelog/update-newsletter-settings-default-true
+++ b/projects/plugins/jetpack/changelog/update-newsletter-settings-default-true
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Newsletter: Default the jetpack_wp_admin_newsletter_settings_enabled filter to true.


### PR DESCRIPTION
Fixes DOTCOM-16250

## Proposed changes

* Change the `jetpack_wp_admin_newsletter_settings_enabled` filter default from `false` to `true` in the newsletter package, my-jetpack, and Jetpack plugin.
* Defer the `expose_to_users()` check in `Settings::init_hooks()` so that filters registered after `init()` (e.g. by jetpack-mu-wpcom) are evaluated at the right time.
* Update `wpcom_maybe_enable_newsletter_settings()` in jetpack-mu-wpcom: return `true` on Simple, explicitly `false` on WoA/WoW (because the autoloader may load the newer package from jetpack-mu-wpcom before the admin menu integration is ready).
* Update the newsletter package README to reflect the new default.

### Rollout strategy

This is a phased rollout to account for different deploy cadences:

**Phase 1 (this PR):**
- **Simple sites**: Activate immediately — jetpack-mu-wpcom controls the full stack, so the filter callback returns `true`.
- **WoA/WoW sites**: No change yet — the filter callback explicitly returns `false` to prevent the new settings from activating before the wpcom-admin-menu integration is updated. The old Calypso-based settings continue to work.
- **Self-hosted sites**: Will activate when they update the Jetpack plugin (package defaults flip to `true`).

**Phase 2 (after this PR is deployed):**
- Update jetpack-mu-wpcom: remove the explicit `false` for WoA/WoW and update the `wpcom-admin-menu.php` filter defaults to `true`.

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

**Simple sites:**
* Navigate to **Jetpack > Newsletter** in wp-admin.
* Verify the new newsletter settings page loads without needing any sticker.
* Verify the Reading settings page notice links to the new newsletter settings URL.

**WoA/WoW sites (with trunk Jetpack):**
* Verify the old Calypso-based Newsletter menu item still works.
* Verify the Jetpack Settings > Newsletter tab is not broken.
* Navigate to **Jetpack > My Jetpack**, find the Newsletter card, and verify the "Manage" link points to the old settings (not the new wp-admin page).

**Self-hosted / standalone Jetpack:**
* Verify the new settings page loads at **Jetpack > Newsletter**.
* Navigate to **Jetpack > My Jetpack**, find the Newsletter card, and verify the "Manage" link points to `admin.php?page=jetpack-newsletter`.
