### PR TITLE
Live Branches: Fix "merged" detection with old-style UI

### DIFF
--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Jetpack Live Branches
 // @namespace    https://wordpress.com/
-// @version      1.37
+// @version      1.38
 // @description  Adds links to PRs pointing to Jurassic Ninja sites for live-testing a changeset
 // @grant        GM_xmlhttpRequest
 // @connect      betadownload.jetpack.me
@@ -150,7 +150,7 @@
 
 		const repo = determineRepo();
 
-		if ( branchStatus === 'MERGED' ) {
+		if ( branchStatus.toUpperCase() === 'MERGED' ) {
 			const contents = `
 				<p><strong>This branch is already merged.</strong></p>
 				<p><a target="_blank" rel="nofollow noopener" href="${ getLink()[ 0 ] }">


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
Old-style UI will return "Merged" rather than "MERGED". Handle both possibilities.

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
Fixes MONOREP-398

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Install from https://github.com/Automattic/jetpack/raw/refs/heads/fix/live-branches-merged-detection/tools/jetpack-live-branches/jetpack-live-branches.user.js and see if it works. Bonus if you're still on the old-style UI somehow.