### PR TITLE
jp: Improve security of rsync proxy

### DIFF
--- a/projects/js-packages/jetpack-cli/bin/jp.js
+++ b/projects/js-packages/jetpack-cli/bin/jp.js
@@ -330,6 +330,7 @@ const runRsyncWithProxy = async ( monorepoRoot, args ) => {
 		os.tmpdir(),
 		'jp-rsync-' + Math.floor( Math.random() * 2821109907456 ).toString( 36 )
 	);
+	const secret = crypto.randomUUID();
 
 	/**
 	 * Clean up the proxy server and socket file.
@@ -389,8 +390,9 @@ const runRsyncWithProxy = async ( monorepoRoot, args ) => {
 				// Validate that this is an SSH command (security check)
 				if (
 					! Array.isArray( parsedArgs ) ||
-					parsedArgs.length === 0 ||
-					parsedArgs[ 0 ] !== 'ssh'
+					parsedArgs.length < 2 ||
+					parsedArgs[ 0 ] !== secret ||
+					parsedArgs[ 1 ] !== 'ssh'
 				) {
 					console.error( chalk.red( 'Invalid command received: expected ssh command' ) );
 					socket.destroy();
@@ -398,7 +400,7 @@ const runRsyncWithProxy = async ( monorepoRoot, args ) => {
 				}
 
 				// Spawn SSH with parsed arguments
-				const sshProcess = spawn( 'ssh', parsedArgs.slice( 1 ), {
+				const sshProcess = spawn( 'ssh', parsedArgs.slice( 2 ), {
 					stdio: [ 'pipe', 'pipe', 'inherit' ],
 				} );
 
@@ -460,7 +462,9 @@ const runRsyncWithProxy = async ( monorepoRoot, args ) => {
 				rejectListening( err );
 			} );
 
+			const oldumask = process.umask( 0o077 );
 			proxyServer.listen( { path: socketPath }, () => {
+				process.umask( oldumask );
 				resolveListening();
 			} );
 		} );
@@ -476,6 +480,7 @@ const runRsyncWithProxy = async ( monorepoRoot, args ) => {
 					env: {
 						...process.env,
 						RSYNC_PROXY_SOCKET: socketPath,
+						RSYNC_PROXY_SECRET: secret,
 					},
 				}
 			);

--- a/projects/js-packages/jetpack-cli/bin/jp.js
+++ b/projects/js-packages/jetpack-cli/bin/jp.js
@@ -381,19 +381,36 @@ const runRsyncWithProxy = async ( monorepoRoot, args ) => {
 				let parsedArgs;
 				try {
 					parsedArgs = JSON.parse( commandLine );
+					if ( ! Array.isArray( parsedArgs ) || parsedArgs.length === 0 ) {
+						throw new Error( 'parsedArgs is not a non-empty array' );
+					}
 				} catch {
 					console.error( chalk.red( 'Invalid JSON received from proxy' ) );
 					socket.destroy();
 					return;
 				}
 
+				// Validate the shared secret (security check)
+				if ( parsedArgs[ 0 ] !== secret ) {
+					if ( parsedArgs[ 0 ] === 'ssh' ) {
+						console.error(
+							chalk.red(
+								'The container did not send the shared secret. Update your git checkout with the latest trunk.'
+							)
+						);
+					} else {
+						console.error(
+							chalk.red(
+								'Incorrect shared secret received. Possible unauthorized access or misconfiguration.'
+							)
+						);
+					}
+					socket.destroy();
+					return;
+				}
+
 				// Validate that this is an SSH command (security check)
-				if (
-					! Array.isArray( parsedArgs ) ||
-					parsedArgs.length < 2 ||
-					parsedArgs[ 0 ] !== secret ||
-					parsedArgs[ 1 ] !== 'ssh'
-				) {
+				if ( parsedArgs.length < 2 || parsedArgs[ 1 ] !== 'ssh' ) {
 					console.error( chalk.red( 'Invalid command received: expected ssh command' ) );
 					socket.destroy();
 					return;
@@ -458,11 +475,13 @@ const runRsyncWithProxy = async ( monorepoRoot, args ) => {
 		await new Promise( ( resolveListening, rejectListening ) => {
 			proxyServer = net.createServer( handleConnection );
 
+			const oldumask = process.umask( 0o077 );
+
 			proxyServer.on( 'error', err => {
+				process.umask( oldumask );
 				rejectListening( err );
 			} );
 
-			const oldumask = process.umask( 0o077 );
 			proxyServer.listen( { path: socketPath }, () => {
 				process.umask( oldumask );
 				resolveListening();

--- a/projects/js-packages/jetpack-cli/changelog/fix-jp-rsync-proxy-security
+++ b/projects/js-packages/jetpack-cli/changelog/fix-jp-rsync-proxy-security
@@ -1,0 +1,4 @@
+Significance: major
+Type: security
+
+Rsync: Make it harder for a host-system attacker to attack the rsync proxy.

--- a/tools/docker/bin/monorepo
+++ b/tools/docker/bin/monorepo
@@ -112,9 +112,10 @@ fi
   # Mount rsync proxy socket if set (for SSH proxy via Unix domain socket)
   RSYNC_ENV=()
   if [[ -n "${RSYNC_PROXY_SOCKET:-}" ]]; then
-      RSYNC_ENV=( -v "$RSYNC_PROXY_SOCKET:/var/run/jp-rsync-socket" -e RSYNC_PROXY_SOCKET=/var/run/jp-rsync-socket )
-      if [[ -n "${RSYNC_PROXY_SECRET:-}" ]]; then
-          RSYNC_ENV+=( -e RSYNC_PROXY_SECRET )
+      RSYNC_ENV=( -v "$RSYNC_PROXY_SOCKET:/var/run/jp-rsync-socket" -e RSYNC_PROXY_SOCKET=/var/run/jp-rsync-socket -e RSYNC_PROXY_SECRET )
+      if [[ -z "${RSYNC_PROXY_SECRET:-}" ]]; then
+          echo "RSYNC_PROXY_SECRET is not set. Update your copy of @automattic/jetpack-cli." >&2
+          exit 1
       fi
   fi
 

--- a/tools/docker/bin/monorepo
+++ b/tools/docker/bin/monorepo
@@ -113,6 +113,9 @@ fi
   RSYNC_ENV=()
   if [[ -n "${RSYNC_PROXY_SOCKET:-}" ]]; then
       RSYNC_ENV=( -v "$RSYNC_PROXY_SOCKET:/var/run/jp-rsync-socket" -e RSYNC_PROXY_SOCKET=/var/run/jp-rsync-socket )
+      if [[ -n "${RSYNC_PROXY_SECRET:-}" ]]; then
+          RSYNC_ENV+=( -e RSYNC_PROXY_SECRET )
+      fi
   fi
 
   # Worktree-specific Docker args

--- a/tools/docker/bin/rsync-rsh-proxy.sh
+++ b/tools/docker/bin/rsync-rsh-proxy.sh
@@ -18,8 +18,12 @@ if [[ -z "${RSYNC_PROXY_SOCKET:-}" ]]; then
     echo "Error: RSYNC_PROXY_SOCKET not set" >&2
     exit 1
 fi
+if [[ -z "${RSYNC_PROXY_SECRET:-}" ]]; then
+    echo "Error: RSYNC_PROXY_SECRET not set" >&2
+    exit 1
+fi
 
 exec socat STDIO "UNIX-CONNECT:$RSYNC_PROXY_SOCKET" < <(
-    jq -nc '$ARGS.positional' --args -- ssh "$@"
+    jq -nc '$ARGS.positional' --args -- "$RSYNC_PROXY_SECRET" ssh "$@"
     cat
 )


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
Make it harder for something on the host system to activate the proxy.

* Set umask 0077 when creating the socket.
* Pass a secret value to the container, which must be passed back.

Note this isn't bulletproof security: if an attacker can read the environment from Docker and access files as the host system user, this would be fairly easy to get around. But if they can do all that, they can probably do worse things already.

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
Fixes MONOREP-397

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Try it out, ideally without using a saved destination. A `jp rsync` should work, and while it's waiting at the "No saved entries for XXX. Create one for easier use later?" prompt you can examine the filesystem to see that the socket file (probably `/tmp/jp-rsync-XXX`) is mode 0700, and the process list to verify that the secret value isn't included in the command line to `docker run`.