### PR TITLE
Repo Gardening: Add option to disable Slack notification on Customer Report label

### DIFF
--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -83,3 +83,4 @@ jobs:
           triage_projects_token: ${{ secrets.PROJECT_AUTOMATION_TOKEN }}
           project_board_url: ${{ vars.PROJECT_BOARD_URL }}
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          slack_notify_on_customer_report: 'false'

--- a/projects/github-actions/repo-gardening/README.md
+++ b/projects/github-actions/repo-gardening/README.md
@@ -84,6 +84,7 @@ The action relies on the following parameters.
 - (Optional) `slack_quality_channel` is the Slack public channel ID where issues needing extra triage / escalation will be sent. The value should be stored in a variable.
 - (Optional) `slack_product_ambassadors_channel` is the Slack public channel ID where messages about PRs needing docs review will be sent. The value should be stored in a variable.
 - (Optional) `reply_to_customers_threshold`. It is optional, and defaults to 10. It is the minimum number of support references needed to trigger an alert that we need to reply to customers.
+- (Optional) `slack_notify_on_customer_report` is a boolean value that controls whether a Slack notification is sent when the "Customer Report" label is added to an issue. Defaults to `true`.
 - (Optional) `triage_projects_token` is a [personal access token](https://github.com/settings/tokens/new) with `repo` and `project` scopes. The token should be stored in a secret. This is required if you want to use the `triageIssues` task.
 - (Optional) `project_board_url` is the URL of a GitHub Project Board. We'll automate some of the work on that board in the `triageIssues` task.
 - (Optional) `labels_team_assignments` is a list of features you can provide, with matching team names, as specified in the "Team" field of your GitHub Project Board used for the `triageIssues` task, and lists of labels in use in your repository.

--- a/projects/github-actions/repo-gardening/action.yml
+++ b/projects/github-actions/repo-gardening/action.yml
@@ -76,6 +76,10 @@ inputs:
     description: 'Linear Team ID for the team handling documentation-related issues.'
     required: false
     default: ''
+  slack_notify_on_customer_report:
+    description: 'Send a Slack notification when a "Customer Report" label is added to an issue. Default to true.'
+    required: false
+    default: 'true'
 runs:
   using: node24
   main: "dist/index.js"

--- a/projects/github-actions/repo-gardening/changelog/2026-03-23-15-14-06-487355
+++ b/projects/github-actions/repo-gardening/changelog/2026-03-23-15-14-06-487355
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Gather support references: Add a new slack_notify_on_customer_report input to allow disabling Slack notifications when the Customer Report label is added to an issue.

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.ts
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.ts
@@ -465,12 +465,11 @@ async function addHappinessLabel(
 		labels: [ happinessLabel ],
 	} );
 
-	// Send Slack notification, if we have the necessary tokens.
-	// No Slack tokens, we won't be able to escalate. Bail.
-	// If the issue is already closed, do not send any Slack reminder.
+	// Send Slack notification, if we have the necessary tokens and the feature is enabled.
+	const slackNotifyOnCustomerReport = getInput( 'slack_notify_on_customer_report' ) !== 'false';
 	const slackToken = getInput( 'slack_token' );
 	const channel = getInput( 'slack_quality_channel' );
-	if ( ! slackToken || ! channel || state === 'closed' ) {
+	if ( ! slackNotifyOnCustomerReport || ! slackToken || ! channel || state === 'closed' ) {
 		return;
 	}
 

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/readme.md
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/readme.md
@@ -2,7 +2,7 @@
 
 Happiness Engineers can comment on issues to add references to support interactions with customers that would like to be updated whenever the problem is solved.
 
-This task creates a new comment that lists all support references found in all comments on the issue. If it finds a support reference, it will also add a label to the issue, "Customer Report". When that label is added, we warn the triage team in Slack.
+This task creates a new comment that lists all support references found in all comments on the issue. If it finds a support reference, it will also add a label to the issue, "Customer Report". When that label is added, we warn the triage team in Slack (this notification can be disabled by setting the `slack_notify_on_customer_report` input to `false`).
 
 The tasks also monitors the number of support references it has gathered:
 


### PR DESCRIPTION
Fixes QAO-356

## Proposed changes

* Add a new `slack_notify_on_customer_report` input to the repo-gardening action that allows disabling the Slack notification sent when the "Customer Report" label is added to an issue. Defaults to `true` to preserve existing behavior.
* Disable this notification in the Jetpack monorepo's gardening workflow.
* Update documentation (README and task readme) to reflect the new option.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* QAO-356

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Verify that when `slack_notify_on_customer_report` is not set, the action still sends Slack notifications on "Customer Report" label (default `true` behavior).
* Verify that when `slack_notify_on_customer_report` is set to `'false'`, no Slack notification is sent when the label is added.
* Verify that the "Customer Report" label is still added to the issue regardless of the notification setting.