### PR TITLE
Social: Fix useSelect warning for notesConfig on Social admin page

### DIFF
--- a/projects/packages/publicize/_inc/components/admin-page/toggles/social-notes-toggle/index.tsx
+++ b/projects/packages/publicize/_inc/components/admin-page/toggles/social-notes-toggle/index.tsx
@@ -8,6 +8,7 @@ import { useState } from 'react';
 import { store as socialStore } from '../../../../social-store';
 import ToggleSection from '../toggle-section';
 import styles from './styles.module.scss';
+import type { SocialNotesConfig } from '../../../../social-store/types';
 import type { Dispatch, FC, SetStateAction } from 'react';
 
 type SocialNotesToggleProps = {
@@ -32,12 +33,15 @@ const handleStateUpdating = async (
 };
 
 const SocialNotesToggle: FC< SocialNotesToggleProps > = ( { disabled } ) => {
-	const { isEnabled, notesConfig, isUpdating } = useSelect( select => {
+	const { isEnabled, isUpdating, appendLink, linkFormat } = useSelect( select => {
 		const store = select( socialStore );
 
+		const { socialNotes } = store.getSocialSettings();
+
 		return {
-			isEnabled: store.getSocialSettings().socialNotes.enabled,
-			notesConfig: store.getSocialSettings().socialNotes.config,
+			isEnabled: socialNotes.enabled,
+			appendLink: socialNotes.config.append_link ?? true,
+			linkFormat: socialNotes.config.link_format,
 			isUpdating: store.isSavingSiteSettings(),
 		};
 	}, [] );
@@ -60,13 +64,12 @@ const SocialNotesToggle: FC< SocialNotesToggleProps > = ( { disabled } ) => {
 			handleStateUpdating(
 				() =>
 					updateSocialNotesConfig( {
-						...notesConfig,
 						append_link,
 					} ),
 				setIsAppendLinkToggleUpdating
 			);
 		},
-		[ notesConfig, updateSocialNotesConfig ]
+		[ updateSocialNotesConfig ]
 	);
 
 	const onChangeLinkFormat = useCallback(
@@ -74,16 +77,13 @@ const SocialNotesToggle: FC< SocialNotesToggleProps > = ( { disabled } ) => {
 			handleStateUpdating(
 				() =>
 					updateSocialNotesConfig( {
-						...notesConfig,
-						link_format: link_format as ( typeof notesConfig )[ 'link_format' ],
+						link_format: link_format as SocialNotesConfig[ 'link_format' ],
 					} ),
 				setIsLinkFormatUpdating
 			);
 		},
-		[ notesConfig, updateSocialNotesConfig ]
+		[ updateSocialNotesConfig ]
 	);
-
-	const appendLink = notesConfig.append_link ?? true;
 
 	return (
 		<ToggleSection
@@ -131,7 +131,7 @@ const SocialNotesToggle: FC< SocialNotesToggleProps > = ( { disabled } ) => {
 					{ appendLink ? (
 						<SelectControl
 							label={ __( 'Link format', 'jetpack-publicize-pkg' ) }
-							value={ notesConfig.link_format ?? 'full_url' }
+							value={ linkFormat ?? 'full_url' }
 							onChange={ onChangeLinkFormat }
 							disabled={ isLinkFormatUpdating || isUpdating || isAppendLinkToggleUpdating }
 							options={ [

--- a/projects/packages/publicize/_inc/social-store/actions/social-notes.ts
+++ b/projects/packages/publicize/_inc/social-store/actions/social-notes.ts
@@ -1,6 +1,8 @@
 import { store as coreStore } from '@wordpress/core-data';
 import { SOCIAL_NOTES_CONFIG_KEY, SOCIAL_NOTES_ENABLED_KEY } from '../constants';
 import { SocialNotesConfig } from '../types';
+import type { store } from '../index';
+import type { ThunkArgs } from '@wordpress/data';
 
 /**
  * Sets the Social Notes enabled status.
@@ -25,9 +27,11 @@ export function toggleSocialNotes( isEnabled: boolean ) {
  * @return {Function} A thunk.
  */
 export function updateSocialNotesConfig( data: Partial< SocialNotesConfig > ) {
-	return async function ( { registry } ) {
+	return async function ( { registry, select }: ThunkArgs< typeof store > ) {
+		const prevConfig = select.getSocialSettings().socialNotes.config;
+
 		const { saveSite } = registry.dispatch( coreStore );
 
-		await saveSite( { [ SOCIAL_NOTES_CONFIG_KEY ]: data } );
+		await saveSite( { [ SOCIAL_NOTES_CONFIG_KEY ]: { ...prevConfig, ...data } } );
 	};
 }

--- a/projects/packages/publicize/changelog/fix-social-notes-config-use-select-warning
+++ b/projects/packages/publicize/changelog/fix-social-notes-config-use-select-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix useSelect warning for notesConfig on Social admin page.

--- a/projects/plugins/social/changelog/fix-social-notes-config-use-select-warning
+++ b/projects/plugins/social/changelog/fix-social-notes-config-use-select-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix useSelect warning for notesConfig on Social admin page.


### PR DESCRIPTION
When we open the Social admin page, with the Social plugin active, we have a warning 

```
The `useSelect` hook returns different values when called with the same state and parameters.
This can lead to unnecessary re-renders and performance issues if not fixed.

Non-equal value keys: notesConfig
```

<img width="569" height="129" alt="Screenshot 2026-03-23 at 12 59 02 PM" src="https://github.com/user-attachments/assets/8d84f577-982c-4f82-9ab4-73fe935ba647" />


## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Update the notes config settings usage on the Social admin page to fix the `useSelect` warning. The approach is to use return the scalar values from useSelect instead of an object. Thus, the PR changes the `useSelect` usage to return individual setttings. It also changes the notes save settings action to accept the partial data, so that we don't have to pass it from the consumer component.

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Activate Social plugin
* Go to Jetpack > Social
* Confirm that the above warning is gone
* Toggle the Social notes feature ON/OFF
* Confirm that it works fine
* Reload the page and confirm the settings are preserved
* Do the same for notes config like "Append post link" and the options under it
* Confirm that they work fine and preserve after page reload.