### PR TITLE
Jetpack_Widgets: Fix fatal error when adding new widgets on PHP 8.4

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/widgets.php
+++ b/projects/plugins/jetpack/_inc/lib/widgets.php
@@ -383,7 +383,7 @@ class Jetpack_Widgets {
 		$widget_option_name = self::get_widget_option_name( $widget_id );
 		$widget_settings    = get_option( $widget_option_name );
 		$instance_key       = self::get_widget_instance_key( $widget_id );
-		$old_settings       = $widget_settings[ $instance_key ];
+		$old_settings       = $widget_settings[ $instance_key ] ?? array();
 		$settings           = self::sanitize_widget_settings( $widget_id, $settings, $old_settings );
 
 		if ( ! $settings ) {

--- a/projects/plugins/jetpack/changelog/fix-jetpack-widgets
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-widgets
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Fixes a fatal error when adding a new widget if $widget_settings[ $instance_key ] is not defined.
+
+


### PR DESCRIPTION
Fixes #

## Proposed changes

AI Description:

*    Jetpack_Widgets::set_widget_settings() passes null as $old_settings when creating a new widget instance, since the instance key doesn't exist in the option yet. PHP 8.4 promotes the resulting null argument to array_merge() from a deprecation warning to a TypeError. Fix by defaulting to an empty array with ?? array().


### Other information
<!-- Check the box below to generate a changelog entry. -->
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Go to '..'
*
