### PR TITLE
Publicize: Add standard.site protocol support for Bluesky

### DIFF
--- a/projects/packages/publicize/changelog/add-bluesky-standard-site-integration
+++ b/projects/packages/publicize/changelog/add-bluesky-standard-site-integration
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added standard.site protocol support for Bluesky connections: publication URI storage, well-known endpoint, document URI post meta, and link tag injection.

--- a/projects/packages/publicize/src/class-connections.php
+++ b/projects/packages/publicize/src/class-connections.php
@@ -17,7 +17,8 @@ use WP_REST_Request;
  */
 class Connections {
 
-	const CONNECTIONS_TRANSIENT = 'jetpack_social_connections_list';
+	const CONNECTIONS_TRANSIENT          = 'jetpack_social_connections_list';
+	const BLUESKY_PUBLICATION_URI_OPTION = 'bluesky_standard_site_publication_uri';
 
 	/**
 	 * Get all connections.
@@ -141,6 +142,8 @@ class Connections {
 
 				set_transient( self::CONNECTIONS_TRANSIENT, $connections, HOUR_IN_SECONDS * 4 );
 			}
+
+			self::maybe_store_bluesky_publication_uri_from( $connections );
 		}
 
 		return $connections;
@@ -375,5 +378,35 @@ class Connections {
 	 */
 	public static function clear_cache() {
 		delete_transient( self::CONNECTIONS_TRANSIENT );
+	}
+
+	/**
+	 * Extract and store the standard.site publication URI from Bluesky connections.
+	 *
+	 * When a Bluesky connection includes a standard_site_publication_uri, store it
+	 * as a site option for the well-known endpoint. Clean up when disconnected.
+	 *
+	 * @param array $connections The connections data from the API.
+	 */
+	public static function maybe_store_bluesky_publication_uri_from( $connections ) {
+		$publication_uri = null;
+		$has_bluesky     = false;
+
+		foreach ( $connections as $connection ) {
+			if ( isset( $connection['service_name'] ) && 'bluesky' === $connection['service_name'] ) {
+				$has_bluesky = true;
+				if ( ! empty( $connection['standard_site_publication_uri'] ) ) {
+					$publication_uri = $connection['standard_site_publication_uri'];
+					break;
+				}
+			}
+		}
+
+		if ( $publication_uri ) {
+			update_option( self::BLUESKY_PUBLICATION_URI_OPTION, $publication_uri );
+		} elseif ( ! $has_bluesky ) {
+			// Clean up when no Bluesky connections exist (disconnected).
+			delete_option( self::BLUESKY_PUBLICATION_URI_OPTION );
+		}
 	}
 }

--- a/projects/packages/publicize/src/class-connections.php
+++ b/projects/packages/publicize/src/class-connections.php
@@ -386,6 +386,14 @@ class Connections {
 	 * When a Bluesky connection includes a standard_site_publication_uri, store it
 	 * as a site option for the well-known endpoint. Clean up when disconnected.
 	 *
+	 * Multiple Bluesky connections: the standard.site well-known endpoint is a
+	 * site-wide singleton (one publication record per site), but Publicize allows
+	 * N Bluesky connections per site. First-found-with-URI wins — we take the URI
+	 * from the first Bluesky connection in the API response that carries one. The
+	 * stored URI is only cleared when all Bluesky connections are gone, so if the
+	 * connection that contributed the URI is removed while others remain, the
+	 * option keeps its (now stale) value until the next refresh picks a new one.
+	 *
 	 * @param array $connections The connections data from the API.
 	 */
 	public static function maybe_store_bluesky_publication_uri_from( $connections ) {

--- a/projects/packages/publicize/src/class-publicize-setup.php
+++ b/projects/packages/publicize/src/class-publicize-setup.php
@@ -160,6 +160,11 @@ class Publicize_Setup {
 		// Things that should not happen on WPCOM.
 		if ( ! $is_wpcom_simple ) {
 			add_action( 'rest_api_init', array( new REST_Controller(), 'register_rest_routes' ) );
+
+			// standard.site well-known endpoint and link tag for Bluesky.
+			add_action( 'init', array( self::class, 'register_standard_site_rewrite' ) );
+			add_action( 'template_redirect', array( self::class, 'serve_standard_site_publication' ) );
+			add_action( 'wp_head', array( self::class, 'inject_standard_site_link_tag' ) );
 		}
 	}
 
@@ -239,5 +244,73 @@ class Publicize_Setup {
 	 */
 	public static function get_blog_id() {
 		return defined( 'IS_WPCOM' ) && IS_WPCOM ? get_current_blog_id() : \Jetpack_Options::get_option( 'id' );
+	}
+
+	/**
+	 * Register the rewrite rule for /.well-known/site.standard.publication.
+	 */
+	public static function register_standard_site_rewrite() {
+		add_rewrite_rule(
+			'^\.well-known/site\.standard\.publication$',
+			'index.php?standard_site_publication=1',
+			'top'
+		);
+
+		add_rewrite_tag( '%standard_site_publication%', '([^&]+)' );
+	}
+
+	/**
+	 * Serve the /.well-known/site.standard.publication endpoint.
+	 *
+	 * Redirects to the stored AT URI for the site's standard.site publication record.
+	 */
+	public static function serve_standard_site_publication() {
+		if ( ! get_query_var( 'standard_site_publication' ) ) {
+			return;
+		}
+
+		$publication_uri = get_option( Connections::BLUESKY_PUBLICATION_URI_OPTION );
+
+		if ( ! $publication_uri ) {
+			status_header( 404 );
+			exit;
+		}
+
+		wp_redirect( $publication_uri, 302 ); // phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect -- AT URI (at://) is not an HTTP URL, wp_safe_redirect would reject it.
+		exit;
+	}
+
+	/**
+	 * Inject a <link> tag for the standard.site document URI on singular posts.
+	 */
+	public static function inject_standard_site_link_tag() {
+		if ( ! is_singular() ) {
+			return;
+		}
+
+		$uri = get_post_meta( get_the_ID(), Share_Status::BLUESKY_DOCUMENT_URI_META_KEY, true );
+
+		if ( $uri ) {
+			printf( '<link rel="alternate" type="application/json" href="%s" />' . "\n", esc_attr( $uri ) );
+		}
+	}
+
+	/**
+	 * Store the standard.site document URI from Bluesky share status data.
+	 *
+	 * @param int   $post_id The post ID.
+	 * @param array $shares  The shares data.
+	 */
+	public static function store_bluesky_document_uri( $post_id, array $shares ) {
+		foreach ( $shares as $share ) {
+			if (
+				isset( $share['service'] ) &&
+				'bluesky' === $share['service'] &&
+				! empty( $share['standard_site_document_uri'] )
+			) {
+				update_post_meta( $post_id, Share_Status::BLUESKY_DOCUMENT_URI_META_KEY, $share['standard_site_document_uri'] );
+				break;
+			}
+		}
 	}
 }

--- a/projects/packages/publicize/src/class-publicize-setup.php
+++ b/projects/packages/publicize/src/class-publicize-setup.php
@@ -161,10 +161,7 @@ class Publicize_Setup {
 		if ( ! $is_wpcom_simple ) {
 			add_action( 'rest_api_init', array( new REST_Controller(), 'register_rest_routes' ) );
 
-			// standard.site well-known endpoint and link tag for Bluesky.
-			add_action( 'init', array( self::class, 'register_standard_site_rewrite' ) );
-			add_action( 'template_redirect', array( self::class, 'serve_standard_site_publication' ) );
-			add_action( 'wp_head', array( self::class, 'inject_standard_site_link_tag' ) );
+			Standard_Site_Integration::init();
 		}
 	}
 
@@ -244,73 +241,5 @@ class Publicize_Setup {
 	 */
 	public static function get_blog_id() {
 		return defined( 'IS_WPCOM' ) && IS_WPCOM ? get_current_blog_id() : \Jetpack_Options::get_option( 'id' );
-	}
-
-	/**
-	 * Register the rewrite rule for /.well-known/site.standard.publication.
-	 */
-	public static function register_standard_site_rewrite() {
-		add_rewrite_rule(
-			'^\.well-known/site\.standard\.publication$',
-			'index.php?standard_site_publication=1',
-			'top'
-		);
-
-		add_rewrite_tag( '%standard_site_publication%', '([^&]+)' );
-	}
-
-	/**
-	 * Serve the /.well-known/site.standard.publication endpoint.
-	 *
-	 * Redirects to the stored AT URI for the site's standard.site publication record.
-	 */
-	public static function serve_standard_site_publication() {
-		if ( ! get_query_var( 'standard_site_publication' ) ) {
-			return;
-		}
-
-		$publication_uri = get_option( Connections::BLUESKY_PUBLICATION_URI_OPTION );
-
-		if ( ! $publication_uri ) {
-			status_header( 404 );
-			exit;
-		}
-
-		wp_redirect( $publication_uri, 302 ); // phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect -- AT URI (at://) is not an HTTP URL, wp_safe_redirect would reject it.
-		exit;
-	}
-
-	/**
-	 * Inject a <link> tag for the standard.site document URI on singular posts.
-	 */
-	public static function inject_standard_site_link_tag() {
-		if ( ! is_singular() ) {
-			return;
-		}
-
-		$uri = get_post_meta( get_the_ID(), Share_Status::BLUESKY_DOCUMENT_URI_META_KEY, true );
-
-		if ( $uri ) {
-			printf( '<link rel="alternate" type="application/json" href="%s" />' . "\n", esc_attr( $uri ) );
-		}
-	}
-
-	/**
-	 * Store the standard.site document URI from Bluesky share status data.
-	 *
-	 * @param int   $post_id The post ID.
-	 * @param array $shares  The shares data.
-	 */
-	public static function store_bluesky_document_uri( $post_id, array $shares ) {
-		foreach ( $shares as $share ) {
-			if (
-				isset( $share['service'] ) &&
-				'bluesky' === $share['service'] &&
-				! empty( $share['standard_site_document_uri'] )
-			) {
-				update_post_meta( $post_id, Share_Status::BLUESKY_DOCUMENT_URI_META_KEY, $share['standard_site_document_uri'] );
-				break;
-			}
-		}
 	}
 }

--- a/projects/packages/publicize/src/class-share-status.php
+++ b/projects/packages/publicize/src/class-share-status.php
@@ -11,7 +11,8 @@ namespace Automattic\Jetpack\Publicize;
  * Publicize Services class.
  */
 class Share_Status {
-	const SHARES_META_KEY = '_publicize_shares';
+	const SHARES_META_KEY               = '_publicize_shares';
+	const BLUESKY_DOCUMENT_URI_META_KEY = '_bluesky_standard_site_document_uri';
 
 	/**
 	 * Gets the share status for a post.

--- a/projects/packages/publicize/src/class-share-status.php
+++ b/projects/packages/publicize/src/class-share-status.php
@@ -11,8 +11,7 @@ namespace Automattic\Jetpack\Publicize;
  * Publicize Services class.
  */
 class Share_Status {
-	const SHARES_META_KEY               = '_publicize_shares';
-	const BLUESKY_DOCUMENT_URI_META_KEY = '_bluesky_standard_site_document_uri';
+	const SHARES_META_KEY = '_publicize_shares';
 
 	/**
 	 * Gets the share status for a post.

--- a/projects/packages/publicize/src/class-standard-site-integration.php
+++ b/projects/packages/publicize/src/class-standard-site-integration.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * standard.site protocol integration for Bluesky.
+ *
+ * @package automattic/jetpack-publicize
+ */
+
+namespace Automattic\Jetpack\Publicize;
+
+/**
+ * Wires up the standard.site well-known endpoint, the per-post document
+ * URI link tag, and the persistence of the document URI from share status.
+ *
+ * @see https://standard.site/
+ */
+class Standard_Site_Integration {
+
+	const DOCUMENT_URI_META_KEY = '_bluesky_standard_site_document_uri';
+
+	/**
+	 * Register hooks for the integration.
+	 */
+	public static function init() {
+		add_action( 'init', array( self::class, 'register_rewrite' ) );
+		add_action( 'template_redirect', array( self::class, 'serve_publication' ) );
+		add_action( 'wp_head', array( self::class, 'inject_link_tag' ) );
+	}
+
+	/**
+	 * Register the rewrite rule for /.well-known/site.standard.publication.
+	 */
+	public static function register_rewrite() {
+		add_rewrite_rule(
+			'^\.well-known/site\.standard\.publication$',
+			'index.php?standard_site_publication=1',
+			'top'
+		);
+
+		add_rewrite_tag( '%standard_site_publication%', '([^&]+)' );
+	}
+
+	/**
+	 * Serve the /.well-known/site.standard.publication endpoint.
+	 *
+	 * Redirects to the stored AT URI for the site's standard.site publication record.
+	 */
+	public static function serve_publication() {
+		if ( ! get_query_var( 'standard_site_publication' ) ) {
+			return;
+		}
+
+		$publication_uri = get_option( Connections::BLUESKY_PUBLICATION_URI_OPTION );
+
+		if ( ! $publication_uri ) {
+			status_header( 404 );
+			exit;
+		}
+
+		wp_redirect( $publication_uri, 302 ); // phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect -- AT URI (at://) is not an HTTP URL, wp_safe_redirect would reject it.
+		exit;
+	}
+
+	/**
+	 * Inject a <link> tag for the standard.site document URI on singular posts.
+	 */
+	public static function inject_link_tag() {
+		if ( ! is_singular() ) {
+			return;
+		}
+
+		$uri = get_post_meta( get_the_ID(), self::DOCUMENT_URI_META_KEY, true );
+
+		if ( $uri ) {
+			printf( '<link rel="alternate" type="application/json" href="%s" />' . "\n", esc_attr( $uri ) );
+		}
+	}
+
+	/**
+	 * Store the standard.site document URI from Bluesky share status data.
+	 *
+	 * @param int   $post_id The post ID.
+	 * @param array $shares  The shares data.
+	 */
+	public static function store_document_uri( $post_id, array $shares ) {
+		foreach ( $shares as $share ) {
+			if (
+				isset( $share['service'] ) &&
+				'bluesky' === $share['service'] &&
+				! empty( $share['standard_site_document_uri'] )
+			) {
+				update_post_meta( $post_id, self::DOCUMENT_URI_META_KEY, $share['standard_site_document_uri'] );
+				break;
+			}
+		}
+	}
+}

--- a/projects/packages/publicize/src/class-standard-site-integration.php
+++ b/projects/packages/publicize/src/class-standard-site-integration.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * standard.site protocol integration for Bluesky.
+ * Integration for the standard.site protocol (used by Bluesky).
  *
  * @package automattic/jetpack-publicize
  */

--- a/projects/packages/publicize/src/rest-api/class-connections-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-connections-controller.php
@@ -187,43 +187,43 @@ class Connections_Controller extends Base_Controller {
 	 */
 	public static function get_the_item_schema() {
 		return array(
-			'connection_id'   => array(
+			'connection_id'                 => array(
 				'type'        => 'string',
 				'description' => __( 'Connection ID of the connected account.', 'jetpack-publicize-pkg' ),
 			),
-			'display_name'    => array(
+			'display_name'                  => array(
 				'type'        => 'string',
 				'description' => __( 'Display name of the connected account.', 'jetpack-publicize-pkg' ),
 			),
-			'external_handle' => array(
+			'external_handle'               => array(
 				'type'        => array( 'string', 'null' ),
 				'description' => __( 'The external handle or username of the connected account.', 'jetpack-publicize-pkg' ),
 			),
-			'external_id'     => array(
+			'external_id'                   => array(
 				'type'        => 'string',
 				'description' => __( 'The external ID of the connected account.', 'jetpack-publicize-pkg' ),
 			),
-			'profile_link'    => array(
+			'profile_link'                  => array(
 				'type'        => 'string',
 				'description' => __( 'Profile link of the connected account.', 'jetpack-publicize-pkg' ),
 			),
-			'profile_picture' => array(
+			'profile_picture'               => array(
 				'type'        => 'string',
 				'description' => __( 'URL of the profile picture of the connected account.', 'jetpack-publicize-pkg' ),
 			),
-			'service_label'   => array(
+			'service_label'                 => array(
 				'type'        => 'string',
 				'description' => __( 'Human-readable label for the Jetpack Social service.', 'jetpack-publicize-pkg' ),
 			),
-			'service_name'    => array(
+			'service_name'                  => array(
 				'type'        => 'string',
 				'description' => __( 'Alphanumeric identifier for the Jetpack Social service.', 'jetpack-publicize-pkg' ),
 			),
-			'shared'          => array(
+			'shared'                        => array(
 				'type'        => 'boolean',
 				'description' => __( 'Whether the connection is shared with other users.', 'jetpack-publicize-pkg' ),
 			),
-			'status'          => array(
+			'status'                        => array(
 				'type'        => array( 'string', 'null' ),
 				'description' => __( 'The connection status.', 'jetpack-publicize-pkg' ),
 				'enum'        => array(
@@ -233,9 +233,13 @@ class Connections_Controller extends Base_Controller {
 					null,
 				),
 			),
-			'wpcom_user_id'   => array(
+			'wpcom_user_id'                 => array(
 				'type'        => 'integer',
 				'description' => __( 'wordpress.com ID of the user the connection belongs to.', 'jetpack-publicize-pkg' ),
+			),
+			'standard_site_publication_uri' => array(
+				'type'        => array( 'string', 'null' ),
+				'description' => __( 'AT URI of the standard.site publication record for this connection.', 'jetpack-publicize-pkg' ),
 			),
 		);
 	}

--- a/projects/packages/publicize/src/rest-api/class-share-status-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-share-status-controller.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Publicize\REST_API;
 
 use Automattic\Jetpack\Connection\Rest_Authentication;
 use Automattic\Jetpack\Connection\Traits\WPCOM_REST_API_Proxy_Request;
+use Automattic\Jetpack\Publicize\Publicize_Setup;
 use Automattic\Jetpack\Publicize\Share_Status;
 use WP_Error;
 use WP_REST_Request;
@@ -142,45 +143,49 @@ class Share_Status_Controller extends Base_Controller {
 	 */
 	public function get_share_item_schema() {
 		return array(
-			'status'          => array(
+			'status'                     => array(
 				'description' => __( 'Status of the share.', 'jetpack-publicize-pkg' ),
 				'type'        => 'string',
 			),
-			'message'         => array(
+			'message'                    => array(
 				'description' => __( 'Share message or link.', 'jetpack-publicize-pkg' ),
 				'type'        => 'string',
 			),
-			'timestamp'       => array(
+			'timestamp'                  => array(
 				'description' => __( 'Timestamp of the share.', 'jetpack-publicize-pkg' ),
 				'type'        => 'integer',
 			),
-			'service'         => array(
+			'service'                    => array(
 				'description' => __( 'The service to which it was shared.', 'jetpack-publicize-pkg' ),
 				'type'        => 'string',
 			),
-			'connection_id'   => array(
+			'connection_id'              => array(
 				'description' => __( 'Connection ID for the share.', 'jetpack-publicize-pkg' ),
 				'type'        => 'integer',
 			),
-			'external_id'     => array(
+			'external_id'                => array(
 				'description' => __( 'External ID of the shared post.', 'jetpack-publicize-pkg' ),
 				'type'        => 'string',
 			),
-			'external_name'   => array(
+			'external_name'              => array(
 				'description' => __( 'External name of the shared post.', 'jetpack-publicize-pkg' ),
 				'type'        => 'string',
 			),
-			'profile_picture' => array(
+			'profile_picture'            => array(
 				'description' => __( 'Profile picture URL of the account sharing.', 'jetpack-publicize-pkg' ),
 				'type'        => 'string',
 			),
-			'profile_link'    => array(
+			'profile_link'               => array(
 				'description' => __( 'Profile link of the sharing account.', 'jetpack-publicize-pkg' ),
 				'type'        => 'string',
 			),
-			'wpcom_user_id'   => array(
+			'wpcom_user_id'              => array(
 				'type'        => 'integer',
 				'description' => __( 'wordpress.com ID of the user the connection belongs to.', 'jetpack-publicize-pkg' ),
+			),
+			'standard_site_document_uri' => array(
+				'type'        => 'string',
+				'description' => __( 'AT URI of the standard.site document record.', 'jetpack-publicize-pkg' ),
 			),
 		);
 	}
@@ -253,6 +258,8 @@ class Share_Status_Controller extends Base_Controller {
 		}
 
 		update_post_meta( $post_id, Share_Status::SHARES_META_KEY, $shares );
+
+		Publicize_Setup::store_bluesky_document_uri( $post_id, $shares );
 
 		$urls = array();
 

--- a/projects/packages/publicize/src/rest-api/class-share-status-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-share-status-controller.php
@@ -9,8 +9,8 @@ namespace Automattic\Jetpack\Publicize\REST_API;
 
 use Automattic\Jetpack\Connection\Rest_Authentication;
 use Automattic\Jetpack\Connection\Traits\WPCOM_REST_API_Proxy_Request;
-use Automattic\Jetpack\Publicize\Publicize_Setup;
 use Automattic\Jetpack\Publicize\Share_Status;
+use Automattic\Jetpack\Publicize\Standard_Site_Integration;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -259,7 +259,7 @@ class Share_Status_Controller extends Base_Controller {
 
 		update_post_meta( $post_id, Share_Status::SHARES_META_KEY, $shares );
 
-		Publicize_Setup::store_bluesky_document_uri( $post_id, $shares );
+		Standard_Site_Integration::store_document_uri( $post_id, $shares );
 
 		$urls = array();
 

--- a/projects/packages/publicize/tests/php/Standard_Site_Test.php
+++ b/projects/packages/publicize/tests/php/Standard_Site_Test.php
@@ -1,0 +1,323 @@
+<?php // phpcs:disable WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Tests for standard.site protocol integration (Bluesky).
+ */
+
+namespace Automattic\Jetpack\Publicize;
+
+use PHPUnit\Framework\TestCase;
+use WorDBless\Options as WorDBless_Options;
+use WorDBless\PostMeta as WorDBless_PostMeta;
+use WorDBless\Posts as WorDBless_Posts;
+use WorDBless\Users as WorDBless_Users;
+
+/**
+ * Class Standard_Site_Test
+ */
+class Standard_Site_Test extends TestCase {
+
+	/**
+	 * The admin user ID.
+	 *
+	 * @var int
+	 */
+	private static $admin_id = 0;
+
+	/**
+	 * The post ID.
+	 *
+	 * @var int
+	 */
+	private static $post_id = 0;
+
+	/**
+	 * Setting up the test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		static::$admin_id = wp_insert_user(
+			array(
+				'user_login' => 'dummy_admin',
+				'user_pass'  => 'dummy_pass',
+				'role'       => 'administrator',
+			)
+		);
+
+		static::$post_id = wp_insert_post(
+			array(
+				'post_author'  => static::$admin_id,
+				'post_title'   => 'Test Post',
+				'post_excerpt' => 'Test excerpt',
+				'post_status'  => 'publish',
+				'post_type'    => 'post',
+			)
+		);
+
+		wp_set_current_user( static::$admin_id );
+	}
+
+	/**
+	 * Returning the environment into its initial state.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		wp_set_current_user( 0 );
+
+		WorDBless_Options::init()->clear_options();
+		WorDBless_Posts::init()->clear_all_posts();
+		WorDBless_Users::init()->clear_all_users();
+		WorDBless_PostMeta::init()->clear_all_meta();
+
+		delete_transient( Connections::CONNECTIONS_TRANSIENT );
+	}
+
+	/**
+	 * Test that publication URI is stored when Bluesky connection has it.
+	 */
+	public function test_store_publication_uri_from_bluesky_connection() {
+		$connections = array(
+			array(
+				'connection_id' => '111',
+				'service_name'  => 'tumblr',
+				'shared'        => true,
+				'wpcom_user_id' => 0,
+			),
+			array(
+				'connection_id'                 => '222',
+				'service_name'                  => 'bluesky',
+				'shared'                        => true,
+				'wpcom_user_id'                 => 0,
+				'standard_site_publication_uri' => 'at://did:plc:abc123/site.standard.publication/self',
+			),
+		);
+
+		Connections::maybe_store_bluesky_publication_uri_from( $connections );
+
+		$this->assertEquals(
+			'at://did:plc:abc123/site.standard.publication/self',
+			get_option( Connections::BLUESKY_PUBLICATION_URI_OPTION )
+		);
+	}
+
+	/**
+	 * Test that publication URI is not stored when Bluesky connection lacks it.
+	 */
+	public function test_no_publication_uri_when_bluesky_lacks_it() {
+		$connections = array(
+			array(
+				'connection_id' => '222',
+				'service_name'  => 'bluesky',
+				'shared'        => true,
+				'wpcom_user_id' => 0,
+			),
+		);
+
+		Connections::maybe_store_bluesky_publication_uri_from( $connections );
+
+		$this->assertFalse( get_option( Connections::BLUESKY_PUBLICATION_URI_OPTION ) );
+	}
+
+	/**
+	 * Test that publication URI is cleaned up when no Bluesky connections exist.
+	 */
+	public function test_publication_uri_cleaned_up_on_disconnect() {
+		update_option( Connections::BLUESKY_PUBLICATION_URI_OPTION, 'at://did:plc:abc123/site.standard.publication/self' );
+
+		$connections = array(
+			array(
+				'connection_id' => '111',
+				'service_name'  => 'tumblr',
+				'shared'        => true,
+				'wpcom_user_id' => 0,
+			),
+		);
+
+		Connections::maybe_store_bluesky_publication_uri_from( $connections );
+
+		$this->assertFalse( get_option( Connections::BLUESKY_PUBLICATION_URI_OPTION ) );
+	}
+
+	/**
+	 * Test that publication URI is NOT cleaned up when Bluesky connection exists but lacks URI.
+	 */
+	public function test_publication_uri_kept_when_bluesky_exists_without_uri() {
+		$existing_uri = 'at://did:plc:abc123/site.standard.publication/self';
+		update_option( Connections::BLUESKY_PUBLICATION_URI_OPTION, $existing_uri );
+
+		$connections = array(
+			array(
+				'connection_id' => '222',
+				'service_name'  => 'bluesky',
+				'shared'        => true,
+				'wpcom_user_id' => 0,
+			),
+		);
+
+		Connections::maybe_store_bluesky_publication_uri_from( $connections );
+
+		$this->assertEquals( $existing_uri, get_option( Connections::BLUESKY_PUBLICATION_URI_OPTION ) );
+	}
+
+	/**
+	 * Test that document URI is stored from Bluesky share status.
+	 */
+	public function test_store_document_uri_from_share_status() {
+		$shares = array(
+			array(
+				'connection_id' => '111',
+				'service'       => 'tumblr',
+				'timestamp'     => 1234567890,
+				'status'        => 'success',
+			),
+			array(
+				'connection_id'              => '222',
+				'service'                    => 'bluesky',
+				'timestamp'                  => 1234567890,
+				'status'                     => 'success',
+				'standard_site_document_uri' => 'at://did:plc:abc123/site.standard.document/tid123',
+			),
+		);
+
+		Publicize_Setup::store_bluesky_document_uri( static::$post_id, $shares );
+
+		$this->assertEquals(
+			'at://did:plc:abc123/site.standard.document/tid123',
+			get_post_meta( static::$post_id, Share_Status::BLUESKY_DOCUMENT_URI_META_KEY, true )
+		);
+	}
+
+	/**
+	 * Test that document URI is not stored when no Bluesky share has it.
+	 */
+	public function test_no_document_uri_when_bluesky_lacks_it() {
+		$shares = array(
+			array(
+				'connection_id' => '222',
+				'service'       => 'bluesky',
+				'timestamp'     => 1234567890,
+				'status'        => 'success',
+			),
+		);
+
+		Publicize_Setup::store_bluesky_document_uri( static::$post_id, $shares );
+
+		$this->assertEmpty(
+			get_post_meta( static::$post_id, Share_Status::BLUESKY_DOCUMENT_URI_META_KEY, true )
+		);
+	}
+
+	/**
+	 * Test that link tag is injected for posts with document URI.
+	 */
+	/**
+	 * Test that link tag is injected for posts with document URI.
+	 */
+	public function test_inject_link_tag_with_document_uri() {
+		$uri = 'at://did:plc:abc123/site.standard.document/tid123';
+		update_post_meta( static::$post_id, Share_Status::BLUESKY_DOCUMENT_URI_META_KEY, $uri );
+
+		// Simulate a singular post context.
+		$GLOBALS['wp_query']              = new \WP_Query();
+		$GLOBALS['wp_query']->is_singular = true;
+		$GLOBALS['wp_query']->post        = get_post( static::$post_id );
+		$GLOBALS['wp_query']->posts       = array( $GLOBALS['wp_query']->post );
+		$GLOBALS['post']                  = $GLOBALS['wp_query']->post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		ob_start();
+		Publicize_Setup::inject_standard_site_link_tag();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '<link rel="alternate" type="application/json"', $output );
+		$this->assertStringContainsString( $uri, $output );
+	}
+
+	/**
+	 * Test that link tag is not injected for posts without document URI.
+	 */
+	public function test_no_link_tag_without_document_uri() {
+		// Simulate a singular post context.
+		$GLOBALS['wp_query']              = new \WP_Query();
+		$GLOBALS['wp_query']->is_singular = true;
+		$GLOBALS['wp_query']->post        = get_post( static::$post_id );
+		$GLOBALS['wp_query']->posts       = array( $GLOBALS['wp_query']->post );
+		$GLOBALS['post']                  = $GLOBALS['wp_query']->post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		ob_start();
+		Publicize_Setup::inject_standard_site_link_tag();
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output );
+	}
+
+	/**
+	 * Test that well-known endpoint returns 404 when no publication URI is stored.
+	 */
+	public function test_wellknown_404_without_publication_uri() {
+		delete_option( Connections::BLUESKY_PUBLICATION_URI_OPTION );
+
+		// We can't easily test exit/redirect, but we can verify the option check.
+		$this->assertFalse( get_option( Connections::BLUESKY_PUBLICATION_URI_OPTION ) );
+	}
+
+	/**
+	 * Test that serve_standard_site_publication returns early when query var is not set.
+	 */
+	public function test_serve_wellknown_returns_early_without_query_var() {
+		// No query var set — method should return without calling exit.
+		Publicize_Setup::serve_standard_site_publication();
+
+		// If we reach here, it returned early as expected.
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Test that inject_standard_site_link_tag returns early on non-singular pages.
+	 */
+	public function test_no_link_tag_on_non_singular() {
+		$uri = 'at://did:plc:abc123/site.standard.document/tid123';
+		update_post_meta( static::$post_id, Share_Status::BLUESKY_DOCUMENT_URI_META_KEY, $uri );
+
+		// Default wp_query is not singular.
+		$GLOBALS['wp_query'] = new \WP_Query();
+
+		ob_start();
+		Publicize_Setup::inject_standard_site_link_tag();
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output );
+	}
+
+	/**
+	 * Test that store_bluesky_document_uri skips non-bluesky shares.
+	 */
+	public function test_store_document_uri_skips_non_bluesky() {
+		$shares = array(
+			array(
+				'connection_id'              => '111',
+				'service'                    => 'tumblr',
+				'timestamp'                  => 1234567890,
+				'status'                     => 'success',
+				'standard_site_document_uri' => 'at://should/not/be/stored',
+			),
+		);
+
+		Publicize_Setup::store_bluesky_document_uri( static::$post_id, $shares );
+
+		$this->assertEmpty(
+			get_post_meta( static::$post_id, Share_Status::BLUESKY_DOCUMENT_URI_META_KEY, true )
+		);
+	}
+
+	/**
+	 * Test that register_standard_site_rewrite registers the rewrite rule and tag.
+	 */
+	public function test_register_standard_site_rewrite() {
+		global $wp_rewrite;
+
+		Publicize_Setup::register_standard_site_rewrite();
+
+		$this->assertNotEmpty( $wp_rewrite->extra_rules_top );
+		$this->assertArrayHasKey( '^\.well-known/site\.standard\.publication$', $wp_rewrite->extra_rules_top );
+	}
+}

--- a/projects/packages/publicize/tests/php/Standard_Site_Test.php
+++ b/projects/packages/publicize/tests/php/Standard_Site_Test.php
@@ -179,11 +179,11 @@ class Standard_Site_Test extends TestCase {
 			),
 		);
 
-		Publicize_Setup::store_bluesky_document_uri( static::$post_id, $shares );
+		Standard_Site_Integration::store_document_uri( static::$post_id, $shares );
 
 		$this->assertEquals(
 			'at://did:plc:abc123/site.standard.document/tid123',
-			get_post_meta( static::$post_id, Share_Status::BLUESKY_DOCUMENT_URI_META_KEY, true )
+			get_post_meta( static::$post_id, Standard_Site_Integration::DOCUMENT_URI_META_KEY, true )
 		);
 	}
 
@@ -200,10 +200,10 @@ class Standard_Site_Test extends TestCase {
 			),
 		);
 
-		Publicize_Setup::store_bluesky_document_uri( static::$post_id, $shares );
+		Standard_Site_Integration::store_document_uri( static::$post_id, $shares );
 
 		$this->assertEmpty(
-			get_post_meta( static::$post_id, Share_Status::BLUESKY_DOCUMENT_URI_META_KEY, true )
+			get_post_meta( static::$post_id, Standard_Site_Integration::DOCUMENT_URI_META_KEY, true )
 		);
 	}
 
@@ -215,7 +215,7 @@ class Standard_Site_Test extends TestCase {
 	 */
 	public function test_inject_link_tag_with_document_uri() {
 		$uri = 'at://did:plc:abc123/site.standard.document/tid123';
-		update_post_meta( static::$post_id, Share_Status::BLUESKY_DOCUMENT_URI_META_KEY, $uri );
+		update_post_meta( static::$post_id, Standard_Site_Integration::DOCUMENT_URI_META_KEY, $uri );
 
 		// Simulate a singular post context.
 		$GLOBALS['wp_query']              = new \WP_Query();
@@ -225,7 +225,7 @@ class Standard_Site_Test extends TestCase {
 		$GLOBALS['post']                  = $GLOBALS['wp_query']->post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 		ob_start();
-		Publicize_Setup::inject_standard_site_link_tag();
+		Standard_Site_Integration::inject_link_tag();
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( '<link rel="alternate" type="application/json"', $output );
@@ -244,7 +244,7 @@ class Standard_Site_Test extends TestCase {
 		$GLOBALS['post']                  = $GLOBALS['wp_query']->post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 		ob_start();
-		Publicize_Setup::inject_standard_site_link_tag();
+		Standard_Site_Integration::inject_link_tag();
 		$output = ob_get_clean();
 
 		$this->assertEmpty( $output );
@@ -261,35 +261,35 @@ class Standard_Site_Test extends TestCase {
 	}
 
 	/**
-	 * Test that serve_standard_site_publication returns early when query var is not set.
+	 * Test that serve_publication returns early when query var is not set.
 	 */
 	public function test_serve_wellknown_returns_early_without_query_var() {
 		// No query var set — method should return without calling exit.
-		Publicize_Setup::serve_standard_site_publication();
+		Standard_Site_Integration::serve_publication();
 
 		// If we reach here, it returned early as expected.
 		$this->assertTrue( true );
 	}
 
 	/**
-	 * Test that inject_standard_site_link_tag returns early on non-singular pages.
+	 * Test that inject_link_tag returns early on non-singular pages.
 	 */
 	public function test_no_link_tag_on_non_singular() {
 		$uri = 'at://did:plc:abc123/site.standard.document/tid123';
-		update_post_meta( static::$post_id, Share_Status::BLUESKY_DOCUMENT_URI_META_KEY, $uri );
+		update_post_meta( static::$post_id, Standard_Site_Integration::DOCUMENT_URI_META_KEY, $uri );
 
 		// Default wp_query is not singular.
 		$GLOBALS['wp_query'] = new \WP_Query();
 
 		ob_start();
-		Publicize_Setup::inject_standard_site_link_tag();
+		Standard_Site_Integration::inject_link_tag();
 		$output = ob_get_clean();
 
 		$this->assertEmpty( $output );
 	}
 
 	/**
-	 * Test that store_bluesky_document_uri skips non-bluesky shares.
+	 * Test that store_document_uri skips non-bluesky shares.
 	 */
 	public function test_store_document_uri_skips_non_bluesky() {
 		$shares = array(
@@ -302,20 +302,20 @@ class Standard_Site_Test extends TestCase {
 			),
 		);
 
-		Publicize_Setup::store_bluesky_document_uri( static::$post_id, $shares );
+		Standard_Site_Integration::store_document_uri( static::$post_id, $shares );
 
 		$this->assertEmpty(
-			get_post_meta( static::$post_id, Share_Status::BLUESKY_DOCUMENT_URI_META_KEY, true )
+			get_post_meta( static::$post_id, Standard_Site_Integration::DOCUMENT_URI_META_KEY, true )
 		);
 	}
 
 	/**
-	 * Test that register_standard_site_rewrite registers the rewrite rule and tag.
+	 * Test that register_rewrite registers the rewrite rule and tag.
 	 */
 	public function test_register_standard_site_rewrite() {
 		global $wp_rewrite;
 
-		Publicize_Setup::register_standard_site_rewrite();
+		Standard_Site_Integration::register_rewrite();
 
 		$this->assertNotEmpty( $wp_rewrite->extra_rules_top );
 		$this->assertArrayHasKey( '^\.well-known/site\.standard\.publication$', $wp_rewrite->extra_rules_top );


### PR DESCRIPTION
Fixes #

## Proposed changes

Adds [standard.site](https://standard.site) open-web protocol support for Bluesky connections in the Publicize package. This enables self-hosted Jetpack sites to participate in the AT Protocol's long-form content ecosystem.

* **Stores the publication URI on connect** — When connections are fetched from the API, extracts `standard_site_publication_uri` from Bluesky connections and stores it as the `bluesky_standard_site_publication_uri` site option. Cleans up on disconnect.
* **Serves `/.well-known/site.standard.publication`** — Registers a rewrite rule that 302-redirects to the stored AT URI, enabling discovery of the site's publication record.
* **Stores the document URI after publishing** — When share status is synced back, extracts `standard_site_document_uri` from Bluesky share items and stores it as `_bluesky_standard_site_document_uri` post meta.
* **Injects `<link>` tag in post HTML heads** — Outputs `<link rel="alternate" type="application/json" href="at://..." />` on singular posts that have a stored document URI.
* **Declares REST schema** — Adds `standard_site_publication_uri` to the connections schema and `standard_site_document_uri` to the share status schema.

### Other information

- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links

* https://standard.site

## Does this pull request change what data or activity we track or use?

This PR stores two new pieces of data locally:
- **Site option** `bluesky_standard_site_publication_uri`: the AT URI of the site's standard.site publication record on the user's AT Protocol PDS. Stored on connect, deleted on disconnect.
- **Post meta** `_bluesky_standard_site_document_uri`: the AT URI of the standard.site document record created when a post is shared to Bluesky. Stored per-post after publishing.

Both values are AT Protocol URIs that are already public on the user's PDS. No new data is sent to external services — this only stores data already returned by existing API responses.

## Testing instructions

* Connect a Bluesky account via Jetpack Social
* Verify the `bluesky_standard_site_publication_uri` option is stored (`wp option get bluesky_standard_site_publication_uri`)
* Verify the connections REST response (`/wpcom/v2/publicize/connections`) includes `standard_site_publication_uri` for the Bluesky connection
* Visit `/.well-known/site.standard.publication` and confirm it 302-redirects to the AT URI
* Publish a post with Bluesky selected and verify `_bluesky_standard_site_document_uri` post meta is set
* Confirm the `<link rel="alternate" type="application/json">` tag appears in the published post's HTML `<head>`
* Disconnect Bluesky and verify the publication URI option is cleaned up
* Confirm the well-known endpoint returns 404 when no publication URI is stored