### PR TITLE
Newsletter: Enable wp-admin newsletter settings by default

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/enable-new-newsletter-settings
+++ b/projects/packages/jetpack-mu-wpcom/changelog/enable-new-newsletter-settings
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Enable wp-admin newsletter settings for all wpcom sites instead of gating behind the newsletter-package-202603 sticker.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -352,7 +352,7 @@ function wpcom_add_jetpack_submenu() {
 		// by the newsletter package's Settings::add_wp_admin_menu() for Atomic sites.
 		// Otherwise, link to Calypso for atomic Personal/Premium sites.
 		/** This filter is documented in projects/packages/newsletter/src/class-settings.php */
-		if ( ! apply_filters( 'jetpack_wp_admin_newsletter_settings_enabled', false ) ) {
+		if ( ! apply_filters( 'jetpack_wp_admin_newsletter_settings_enabled', true ) ) {
 			add_submenu_page(
 				'jetpack',
 				esc_attr__( 'Newsletter', 'jetpack-mu-wpcom' ),
@@ -429,7 +429,7 @@ function wpcom_add_jetpack_submenu() {
 	if ( $is_simple_site ) {
 		// Jetpack > Newsletter.
 		/** This filter is documented in projects/packages/newsletter/src/class-settings.php */
-		if ( apply_filters( 'jetpack_wp_admin_newsletter_settings_enabled', false ) ) {
+		if ( apply_filters( 'jetpack_wp_admin_newsletter_settings_enabled', true ) ) {
 			// Register the in-admin Newsletter settings page (with its own render callback
 			// and admin hooks). This must be done here (at priority 999999) because the
 			// Jetpack menu is created by this function and doesn't exist at earlier priorities.

--- a/projects/packages/jetpack-mu-wpcom/src/utils.php
+++ b/projects/packages/jetpack-mu-wpcom/src/utils.php
@@ -215,18 +215,15 @@ function wpcom_has_blog_sticker( $blog_sticker, $blog_id ) {
 }
 
 /**
- * Enable the newsletter settings package for sites with the newsletter-package-202603 sticker.
+ * Enable the newsletter settings package for all wpcom sites.
  *
- * This allows opt-in testing of the newsletter settings package on wpcom infrastructure.
+ * Previously gated by the newsletter-package-202603 sticker for opt-in testing.
+ * Now enabled unconditionally. This function and its add_filter hook can be
+ * removed once the filter itself is cleaned up.
  *
  * @param bool $enabled Whether the newsletter settings are enabled.
  * @return bool
  */
-function wpcom_maybe_enable_newsletter_settings( $enabled ) {
-	if ( $enabled ) {
-		return $enabled;
-	}
-
-	// Stickered sites (will always be simple, as we don't sync this sticker. WoW sites can just add their own mu-plugin/snippet)
-	return function_exists( 'has_blog_sticker' ) && has_blog_sticker( 'newsletter-package-202603' );
+function wpcom_maybe_enable_newsletter_settings( $enabled ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	return true;
 }

--- a/projects/packages/my-jetpack/changelog/enable-newsletter-settings-by-default
+++ b/projects/packages/my-jetpack/changelog/enable-newsletter-settings-by-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update Newsletter manage URL to default to new wp-admin settings page.

--- a/projects/packages/my-jetpack/src/products/class-newsletter.php
+++ b/projects/packages/my-jetpack/src/products/class-newsletter.php
@@ -177,7 +177,7 @@ class Newsletter extends Module_Product {
 	 * @return ?string
 	 */
 	public static function get_manage_url() {
-		if ( apply_filters( 'jetpack_wp_admin_newsletter_settings_enabled', false ) ) {
+		if ( apply_filters( 'jetpack_wp_admin_newsletter_settings_enabled', true ) ) {
 			return admin_url( 'admin.php?page=jetpack-newsletter' );
 		}
 		return admin_url( 'admin.php?page=jetpack#/newsletter' );

--- a/projects/packages/newsletter/README.md
+++ b/projects/packages/newsletter/README.md
@@ -22,16 +22,16 @@ Reader_Link::init();
 
 ## Settings page
 
-The settings page is gated behind the `jetpack_wp_admin_newsletter_settings_enabled` filter (defaults to `false`). When enabled, it registers a `Jetpack > Newsletter` submenu page in wp-admin with a React-based settings UI.
+The settings page is controlled by the `jetpack_wp_admin_newsletter_settings_enabled` filter (defaults to `true`). It registers a `Jetpack > Newsletter` submenu page in wp-admin with a React-based settings UI.
 
 ### Filters
 
 #### `jetpack_wp_admin_newsletter_settings_enabled`
 
-A temporary filter used during development of this package. When `true`, the new wp-admin newsletter settings page is used. When `false` (default), the existing settings pages are used instead (Calypso on WoA/Simple sites, the Jetpack Settings `#/newsletter` tab on standalone Jetpack sites). This filter will be removed once the new settings page is ready for general use.
+Controls whether the new wp-admin newsletter settings page is used. Defaults to `true`. When `false`, the existing settings pages are used instead (Calypso on WoA/Simple sites, the Jetpack Settings `#/newsletter` tab on standalone Jetpack sites). This filter will be removed in a future release.
 
 ```php
-add_filter( 'jetpack_wp_admin_newsletter_settings_enabled', '__return_true' );
+add_filter( 'jetpack_wp_admin_newsletter_settings_enabled', '__return_false' );
 ```
 
 #### `jetpack_show_newsletter_menu_item`

--- a/projects/packages/newsletter/changelog/enable-newsletter-settings-by-default
+++ b/projects/packages/newsletter/changelog/enable-newsletter-settings-by-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Enable wp-admin newsletter settings by default by changing the jetpack_wp_admin_newsletter_settings_enabled filter default to true. Defer the expose_to_users() check in init_hooks() to avoid timing issues with late-registered filters.

--- a/projects/packages/newsletter/src/class-settings.php
+++ b/projects/packages/newsletter/src/class-settings.php
@@ -50,9 +50,9 @@ class Settings {
 		 *
 		 * @since 15.3.0
 		 *
-		 * @param bool $enabled Whether to enable the new newsletter settings UI. Default false.
+		 * @param bool $enabled Whether to enable the new newsletter settings UI. Default true.
 		 */
-		return apply_filters( 'jetpack_wp_admin_newsletter_settings_enabled', false );
+		return apply_filters( 'jetpack_wp_admin_newsletter_settings_enabled', true );
 	}
 
 	/**
@@ -94,15 +94,16 @@ class Settings {
 			add_action( 'admin_init', array( $this, 'add_reading_page_notice' ) );
 		}
 
-		if ( ! $this->expose_to_users() ) {
-			return;
-		}
-
 		// Hijack the config URLs to point to our settings page.
 		// Priority 20 to override the default URL set in subscriptions.php.
+		// Check expose_to_users() lazily in the callback so filters registered
+		// after init() (e.g. by jetpack-mu-wpcom) are available.
 		add_filter(
 			'jetpack_module_configuration_url_subscriptions',
-			function () {
+			function ( $url ) {
+				if ( ! $this->expose_to_users() ) {
+					return $url;
+				}
 				return Urls::get_newsletter_settings_url( ( new Status() )->get_site_suffix() );
 			},
 			20
@@ -118,6 +119,8 @@ class Settings {
 		}
 
 		// Add admin menu item.
+		// The expose_to_users() check is deferred to add_wp_admin_menu() so that
+		// filters registered after init() are available when admin_menu fires.
 		// Use priority 999 to ensure menu items are queued BEFORE Admin_Menu::admin_menu_hook_callback
 		// runs at priority 1000 to process all queued items.
 		add_action( 'admin_menu', array( $this, 'add_wp_admin_menu' ), 999 );

--- a/projects/packages/newsletter/src/class-urls.php
+++ b/projects/packages/newsletter/src/class-urls.php
@@ -35,9 +35,9 @@ class Urls {
 		 *
 		 * @since 0.6.0
 		 *
-		 * @param bool $enabled Whether the new settings UI is enabled. Default false.
+		 * @param bool $enabled Whether the new settings UI is enabled. Default true.
 		 */
-		if ( apply_filters( 'jetpack_wp_admin_newsletter_settings_enabled', false ) ) {
+		if ( apply_filters( 'jetpack_wp_admin_newsletter_settings_enabled', true ) ) {
 			return admin_url( 'admin.php?page=jetpack-newsletter' );
 		}
 

--- a/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/index.jsx
@@ -11,6 +11,7 @@ import {
 	userCanManageModules as _userCanManageModules,
 	userIsSubscriber as _userIsSubscriber,
 	userCanPublish,
+	isWpAdminNewsletterSettingsEnabled as _isWpAdminNewsletterSettingsEnabled,
 } from 'state/initial-state';
 import {
 	hasAnyOfTheseModules,
@@ -65,6 +66,7 @@ const SettingsNavTabs = props => {
 		hasPerformanceFeature,
 		hasModules,
 		isModuleActive,
+		isWpAdminNewsletterSettingsEnabled,
 		searchTerm,
 		searchForTerm,
 	} = props;
@@ -156,7 +158,7 @@ const SettingsNavTabs = props => {
 						onClick={ () => trackNavClick( 'traffic' ) }
 					/>
 				) }
-				{ hasModules( [ 'subscriptions' ] ) && (
+				{ hasModules( [ 'subscriptions' ] ) && ! isWpAdminNewsletterSettingsEnabled && (
 					<Tab
 						to="/newsletter"
 						label={ TAB_LABELS[ '/newsletter' ] }
@@ -267,6 +269,7 @@ export default connect(
 		hasPerformanceFeature: hasAnyPerformanceFeature( state ),
 		hasModules: modules => hasAnyOfTheseModules( state, modules ),
 		isModuleActive: module => isModuleActivated( state, module ),
+		isWpAdminNewsletterSettingsEnabled: _isWpAdminNewsletterSettingsEnabled( state ),
 		searchTerm: getSearchTerm( state ),
 	} ),
 	dispatch => ( {

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
@@ -249,7 +249,7 @@ class Jetpack_Redux_State_Helper {
 			/* This filter is already documented in jetpack/modules/subscriptions.php */
 			'isWpAdminSubscriberManagementEnabled' => apply_filters( 'jetpack_wp_admin_subscriber_management_enabled', false ),
 			/* This filter is documented in projects/packages/newsletter/src/class-settings.php */
-			'isWpAdminNewsletterSettingsEnabled'   => apply_filters( 'jetpack_wp_admin_newsletter_settings_enabled', false ),
+			'isWpAdminNewsletterSettingsEnabled'   => apply_filters( 'jetpack_wp_admin_newsletter_settings_enabled', true ),
 		);
 	}
 

--- a/projects/plugins/jetpack/changelog/enable-newsletter-settings-by-default
+++ b/projects/plugins/jetpack/changelog/enable-newsletter-settings-by-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Newsletter: Default the jetpack_wp_admin_newsletter_settings_enabled filter to true and hide the old settings tab when the new settings page is active.


### PR DESCRIPTION
Fixes DOTCOM-16250

## Proposed changes

* Change the `jetpack_wp_admin_newsletter_settings_enabled` filter default from `false` to `true` across all packages (newsletter, my-jetpack, Jetpack plugin, jetpack-mu-wpcom).
* Make `wpcom_maybe_enable_newsletter_settings()` in jetpack-mu-wpcom return `true` unconditionally, replacing the sticker-based gating (`newsletter-package-202603`).
* Defer the `expose_to_users()` check in `Settings::init_hooks()` so that filters registered after `init()` (e.g. by jetpack-mu-wpcom) are evaluated at the right time.
* Hide the Newsletter tab in the Jetpack Settings navigation when the new settings page is enabled (the recently added `SettingsNavTabs` component was missing this check).
* Update the newsletter package README to reflect the new default.

### How this works on WoA/WoW

The Jetpack autoloader loads the newest version of each package across all plugins. Since mu-plugins (including jetpack-mu-wpcom) load before regular plugins, the autoloader picks up jetpack-mu-wpcom's copy of the newsletter package. This means the deferred `init_hooks()` and `true` defaults from this PR take effect on WoA/WoW immediately, regardless of which Jetpack plugin version is deployed.

### Rollback plan

- **wpcom (Simple/WoA/WoW)**: Change `wpcom_maybe_enable_newsletter_settings()` in `jetpack-mu-wpcom/src/utils.php` to `return false;`. This overrides the `true` default in every `apply_filters` call and restores the old settings screens.
- **Self-hosted**: Site admins can add `add_filter( 'jetpack_wp_admin_newsletter_settings_enabled', '__return_false' );` to a mu-plugin, or roll back the Jetpack plugin update.

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

**Simple sites:**
* Navigate to **Jetpack > Newsletter** in wp-admin.
* Verify the new newsletter settings page loads without needing any sticker.
* Verify the Reading settings page notice links to the new newsletter settings URL.

**WoA/WoW sites (with all changes deployed):**
* Navigate to **Jetpack > Newsletter** in wp-admin.
* Verify the new newsletter settings page loads.
* Navigate to **Jetpack > Settings** and verify the Newsletter tab is **not** shown in the settings navigation.

**WoA/WoW sites (with updated wpcomsh but current/trunk Jetpack plugin):**
* Navigate to **Jetpack > Newsletter** in wp-admin.
* Verify the new newsletter settings page loads.
* Navigate to **Jetpack > Settings** — the Newsletter tab will still be visible (the tab-hiding JS change has not shipped yet), but clicking it should redirect to the new settings page.

**Self-hosted / standalone Jetpack:**
* Verify the new settings page loads at **Jetpack > Newsletter**.
* Navigate to **Jetpack > My Jetpack**, find the Newsletter card, and verify the "Manage" link points to `admin.php?page=jetpack-newsletter`.
* Navigate to **Jetpack > Settings** and verify the Newsletter tab is **not** shown in the settings navigation.
