### PR TITLE
Fix disabling outgoing pingbacks from staging sites

### DIFF
--- a/projects/plugins/wpcomsh/changelog/pr-47752
+++ b/projects/plugins/wpcomsh/changelog/pr-47752
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Fix disabling of outgoing pingbacks from staging sites.

--- a/projects/plugins/wpcomsh/feature-plugins/staging-sites.php
+++ b/projects/plugins/wpcomsh/feature-plugins/staging-sites.php
@@ -29,22 +29,22 @@ add_filter( 'option_wpcom_is_staging_site', 'wpcomsh_is_staging_site_get_atomic_
 /**
  * Disables outgoing pingbacks/trackbacks in staging environments.
  *
- * Prevents the dispatch of pingbacks when the environment type is 'staging'.
+ * Prevents the dispatch of pingbacks when the environment type is 'staging'
+ * by clearing the list of URLs to ping. The `pre_ping` action passes
+ * `$post_links` by reference, so emptying it prevents all outgoing pings.
+ *
  * This can be removed once WordPress core addresses the issue.
  *
  * @see https://core.trac.wordpress.org/ticket/64837
  *
- * @param bool $send Whether to send the pingback. Default true.
- * @return bool False to prevent sending in staging environments, otherwise the original value.
+ * @param string[] $post_links Array of URLs to ping (passed by reference).
  */
-function wpcomsh_disable_outgoing_pings_in_non_production_envs( $send ) {
+function wpcomsh_disable_outgoing_pings_in_non_production_envs( &$post_links ) {
 	if ( 'staging' === wp_get_environment_type() ) {
-		return false;
+		$post_links = array();
 	}
-
-	return $send;
 }
-add_filter( 'pre_pingback_send', 'wpcomsh_disable_outgoing_pings_in_non_production_envs' );
+add_action( 'pre_ping', 'wpcomsh_disable_outgoing_pings_in_non_production_envs' );
 
 /**
  * Disables incoming pingbacks in staging environments by removing

--- a/projects/plugins/wpcomsh/tests/StagingSitePingsTest.php
+++ b/projects/plugins/wpcomsh/tests/StagingSitePingsTest.php
@@ -35,7 +35,9 @@ class StagingSitePingsTest extends WP_UnitTestCase {
 	 */
 	public function test_outgoing_pings_disabled_in_staging() {
 		putenv( 'WP_ENVIRONMENT_TYPE=staging' );
-		$this->assertFalse( wpcomsh_disable_outgoing_pings_in_non_production_envs( true ) );
+		$post_links = array( 'https://example.com/post-1', 'https://example.com/post-2' );
+		wpcomsh_disable_outgoing_pings_in_non_production_envs( $post_links );
+		$this->assertEmpty( $post_links );
 	}
 
 	/**
@@ -43,7 +45,9 @@ class StagingSitePingsTest extends WP_UnitTestCase {
 	 */
 	public function test_outgoing_pings_allowed_in_production() {
 		putenv( 'WP_ENVIRONMENT_TYPE=production' );
-		$this->assertTrue( wpcomsh_disable_outgoing_pings_in_non_production_envs( true ) );
+		$post_links = array( 'https://example.com/post-1', 'https://example.com/post-2' );
+		wpcomsh_disable_outgoing_pings_in_non_production_envs( $post_links );
+		$this->assertCount( 2, $post_links );
 	}
 
 	/**


### PR DESCRIPTION


## Proposed changes
Follow-up to https://github.com/Automattic/jetpack/pull/47628
Notifications TO staging were fixed with the previous PR, but notifications to prod appear. It wan't reproducable before, but I reproduced it today. My bad.

## Testing instructions
Strictly follow the steps, since I had issues when I created the staging site earlier or missed the "Add dev blog" action, etc.
1. Create a free site
2. Open PCYsg-Osp-p2 and click on the link "WoW Developer Blog Manager" (sorry, Tanpermonkey doesn't work for this link to provide it here directly)
3. Provide blog id and click "Add dev blog"
4. Upgrade to Business plan
5. Activate hosting features to allow installing plugins
6. Launch your site (you can skip domain purchase)
7. Create staging site
8. Create a post on prod site e.g. "I am post on prod" (Jot down the link)
9. Create a post on staging site e.g. "I am post on staging" (Jot down the link)
10. Create a post on prod with pasting the link from staging (9-th step into the body)
11. Open "wp-admin -> Comments" on staging site and assert that you see nothing what means that we don't have a regression ([this use case was handled in the previous PR](https://github.com/Automattic/jetpack/pull/47628))
12. Create a post on staging with pasting the link from prod (8-th step into the body)
13. Open "wp-admin -> Comments" on staging site and assert that you SEE the comment, what means that this way wasn't handled with [the previous PR](https://github.com/Automattic/jetpack/pull/47628), and it's exectly what is fixed with this PR, let's test it<br /><img width="1434" height="141" alt="Screenshot 2026-03-24 at 17 44 48" src="https://github.com/user-attachments/assets/b0c08df0-a611-40b2-ad42-b7d8e40830a4" />
  13.1 Download beta plugin here - https://jetpack.com/download-jetpack-beta/
  13.2 Install it on both stagign and production and activate
  13.3 Apply to both prod and staging sites: open `Jetpack -> Beta tester` -> click on `Manage` button for "WordPress.com Site Helper" -> in the search field write `fix/disableOutgoingPingbacksForStagingSites` -> click `Activate` button
  14.4 Repeat steps 10-13 and assert that now you don't see comments on staging and also on prod site<br /><img width="1324" height="234" alt="Screenshot 2026-03-17 at 18 04 14" src="https://github.com/user-attachments/assets/c4394d47-571a-4e7a-8235-fccff695e13c" />
