### PR TITLE
Jetpack Sync: Fix user role sync when role update happens from WP REST

### DIFF
--- a/projects/packages/sync/changelog/fix-user-role-sync
+++ b/projects/packages/sync/changelog/fix-user-role-sync
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Users: Use the effective role when the role-change payload is empty, and avoid syncing empty roles.

--- a/projects/packages/sync/src/class-users.php
+++ b/projects/packages/sync/src/class-users.php
@@ -54,12 +54,8 @@ class Users {
 	public static function user_role_change( $user_id ) {
 		$connection = new Jetpack_Connection();
 		if ( $connection->is_user_connected( $user_id ) ) {
-			unset( self::$user_roles[ $user_id ] );
-			$effective_role = self::get_role( $user_id );
-
-			if ( ! empty( $effective_role ) ) {
-				self::update_role_on_com( $user_id );
-			}
+			self::get_role( $user_id );
+			self::update_role_on_com( $user_id );
 
 			// Try to choose a new master if we're demoting the current one.
 			self::maybe_demote_master_user( $user_id );
@@ -72,11 +68,12 @@ class Users {
 	 * @access public
 	 * @static
 	 *
-	 * @param int $user_id ID of the user.
+	 * @param int  $user_id ID of the user.
+	 * @param bool $reload Forces reading the role from the database.
 	 * @return string Role of the user.
 	 */
-	public static function get_role( $user_id ) {
-		if ( isset( self::$user_roles[ $user_id ] ) ) {
+	public static function get_role( $user_id, $reload = false ) {
+		if ( ! $reload && isset( self::$user_roles[ $user_id ] ) ) {
 			return self::$user_roles[ $user_id ];
 		}
 

--- a/projects/packages/sync/src/class-users.php
+++ b/projects/packages/sync/src/class-users.php
@@ -54,7 +54,13 @@ class Users {
 	public static function user_role_change( $user_id ) {
 		$connection = new Jetpack_Connection();
 		if ( $connection->is_user_connected( $user_id ) ) {
-			self::update_role_on_com( $user_id );
+			unset( self::$user_roles[ $user_id ] );
+			$effective_role = self::get_role( $user_id );
+
+			if ( ! empty( $effective_role ) ) {
+				self::update_role_on_com( $user_id );
+			}
+
 			// Try to choose a new master if we're demoting the current one.
 			self::maybe_demote_master_user( $user_id );
 		}

--- a/projects/plugins/jetpack/changelog/fix-user-role-sync
+++ b/projects/plugins/jetpack/changelog/fix-user-role-sync
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update Sync user-role tests for package behavior changes.
+
+

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Users_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Users_Test.php
@@ -301,7 +301,7 @@ class Jetpack_Sync_Users_Test extends Jetpack_Sync_TestBase {
 		$this->assertContains( 'jetpack.updateRole', $method_names );
 	}
 
-	public function test_user_role_change_does_not_send_empty_effective_role() {
+	public function test_user_role_change_with_empty_effective_role_sends_update() {
 		$user = get_user_by( 'id', $this->user_id );
 		$user->remove_role( 'subscriber' );
 
@@ -325,7 +325,7 @@ class Jetpack_Sync_Users_Test extends Jetpack_Sync_TestBase {
 			}
 		}
 
-		$this->assertNotContains( 'jetpack.updateRole', $method_names );
+		$this->assertContains( 'jetpack.updateRole', $method_names );
 	}
 
 	public function test_user_remove_role_is_synced() {

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Users_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Users_Test.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Connection\Utils;
+use Automattic\Jetpack\Connection\XMLRPC_Async_Call;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Users;
@@ -274,6 +275,57 @@ class Jetpack_Sync_Users_Test extends Jetpack_Sync_TestBase {
 		$this->assertTrue( $events[0]->args[1]['role_changed'] );
 		$this->assertEquals( array( 'subscriber' ), $events[0]->args[1]['previous_role'] );
 		$this->assertCount( 1, $events );
+	}
+
+	public function test_user_role_change_with_empty_set_user_role_value_uses_effective_role() {
+		Jetpack_Options::update_option(
+			'user_tokens',
+			array(
+				$this->user_id => 'apple.a.' . $this->user_id,
+			)
+		);
+
+		XMLRPC_Async_Call::$clients = array();
+
+		Users::user_role_change( $this->user_id, '', array( 'subscriber' ) );
+
+		$method_names = array();
+		foreach ( XMLRPC_Async_Call::$clients as $blog_clients ) {
+			foreach ( $blog_clients as $client ) {
+				foreach ( $client->calls as $call ) {
+					$method_names[] = $call['methodName'];
+				}
+			}
+		}
+
+		$this->assertContains( 'jetpack.updateRole', $method_names );
+	}
+
+	public function test_user_role_change_does_not_send_empty_effective_role() {
+		$user = get_user_by( 'id', $this->user_id );
+		$user->remove_role( 'subscriber' );
+
+		Jetpack_Options::update_option(
+			'user_tokens',
+			array(
+				$this->user_id => 'apple.a.' . $this->user_id,
+			)
+		);
+
+		XMLRPC_Async_Call::$clients = array();
+
+		Users::user_role_change( $this->user_id, '', array( 'subscriber' ) );
+
+		$method_names = array();
+		foreach ( XMLRPC_Async_Call::$clients as $blog_clients ) {
+			foreach ( $blog_clients as $client ) {
+				foreach ( $client->calls as $call ) {
+					$method_names[] = $call['methodName'];
+				}
+			}
+		}
+
+		$this->assertNotContains( 'jetpack.updateRole', $method_names );
 	}
 
 	public function test_user_remove_role_is_synced() {

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Users_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Users_Test.php
@@ -287,7 +287,7 @@ class Jetpack_Sync_Users_Test extends Jetpack_Sync_TestBase {
 
 		XMLRPC_Async_Call::$clients = array();
 
-		Users::user_role_change( $this->user_id, '', array( 'subscriber' ) );
+		Users::user_role_change( $this->user_id );
 
 		$method_names = array();
 		foreach ( XMLRPC_Async_Call::$clients as $blog_clients ) {
@@ -314,7 +314,7 @@ class Jetpack_Sync_Users_Test extends Jetpack_Sync_TestBase {
 
 		XMLRPC_Async_Call::$clients = array();
 
-		Users::user_role_change( $this->user_id, '', array( 'subscriber' ) );
+		Users::user_role_change( $this->user_id );
 
 		$method_names = array();
 		foreach ( XMLRPC_Async_Call::$clients as $blog_clients ) {


### PR DESCRIPTION
## Proposed changes
* Refresh cached role data before handling role-change events.
* Use the effective user role.
* Add regression coverage for both fallback and empty-role cases.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Run: `jp test php packages/sync`
* Run: `jp test php plugins/jetpack -- --filter Jetpack_Sync_Users_Test`
 
### Manual test: verify role update via WP REST does sync correctly to WP.com
1. **Set up**
   - Use a Jetpack-connected test site with Sync enabled.
   - Create a connected test user (not your primary admin/master user).
   - Create a temporary logger (mu-plugin or snippet) to capture outgoing requests and flag any body containing `jetpack.updateRole`.
2. **Add temporary request logger**
   - Add this snippet temporarily:
   ```php
   add_filter(
   	'pre_http_request',
   	function ( $pre, $args, $url ) {
   		if ( false !== strpos( $url, 'xmlrpc.php' ) && isset( $args['body'] ) ) {
   			$body = is_string( $args['body'] ) ? $args['body'] : wp_json_encode( $args['body'] );
   			if ( false !== strpos( $body, 'jetpack.updateRole' ) ) {
   				error_log( 'SYNC TEST: jetpack.updateRole detected' );
   			}
   		}
   		return $pre;
   	},
   	10,
   	3
   );

> Instead of a request logger, one can use the Blog RC audit log

3.
   - Update the user role via WP REST to a valid role (e.g. editor):
   - POST /wp-json/wp/v2/users/<USER_ID> with body:
          { roles: ["administrator"] }
        - Confirm triggers sync twice, first for empty role ( transient ) and then for effective role.
        - Confirm logs show SYNC TEST: jetpack.updateRole detected at least once.
4. 
   - Update the same user via WP REST to no effective role (empty roles):
   - POST /wp-json/wp/v2/users/<USER_ID> with body:
          { roles: [] }
        - Trigger sync normally (or wait for scheduled sync/send).
   - Confirm new SYNC TEST: jetpack.updateRole detected log appears for this update.

5.
   - Set role back to a valid role again (e.g. editor) via WP REST:
          { roles: ["editor"] }
        - Confirm jetpack.updateRole is detected again.