### PR TITLE
jetpack-mu-wpcom: Add Central Forms Management feature flags for Simple + Atomic

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-forms-central-management-flags
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-forms-central-management-flags
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add Central Forms Management feature flags for percentage-based rollout on both Simple and Atomic sites.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -392,6 +392,7 @@ class Jetpack_Mu_Wpcom {
 		}
 
 		require_once __DIR__ . '/features/gutenberg-rtc/gutenberg-rtc.php';
+		require_once __DIR__ . '/features/wpcom-contact-form-flags/wpcom-contact-form-flags.php';
 
 		/**
 		 * Load features for the editor and the frontend pages.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-contact-form-flags/wpcom-contact-form-flags.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-contact-form-flags/wpcom-contact-form-flags.php
@@ -78,6 +78,3 @@ function wpcom_contact_form_set_editor_feature_flags( $flags ) {
 	return $flags;
 }
 add_filter( 'jetpack_block_editor_feature_flags', 'wpcom_contact_form_set_editor_feature_flags', 1000 );
-
-// Disable the integrations tab on all WordPress.com sites.
-add_filter( 'jetpack_forms_enable_integrations_tab', '__return_false' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-contact-form-flags/wpcom-contact-form-flags.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-contact-form-flags/wpcom-contact-form-flags.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * WordPress.com Contact Form feature flags.
+ *
+ * Controls the Central Forms Management rollout and disables the integrations
+ * tab on WordPress.com sites. Works on both Simple and Atomic infrastructure.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Check if a site has the 'central-forms-management' blog sticker.
+ *
+ * Uses the appropriate sticker API depending on whether the site is
+ * Simple (has_blog_sticker) or Atomic (wpcomsh_is_site_sticker_active).
+ *
+ * @param int $blog_id The blog ID to check.
+ * @return bool
+ */
+function wpcom_has_central_forms_management_sticker( $blog_id ) {
+	$sticker = 'central-forms-management';
+
+	if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC && function_exists( 'wpcomsh_is_site_sticker_active' ) ) {
+		return (bool) wpcomsh_is_site_sticker_active( $sticker );
+	} elseif ( function_exists( 'has_blog_sticker' ) ) {
+		return (bool) has_blog_sticker( $sticker, $blog_id );
+	}
+
+	return false;
+}
+
+/**
+ * Check if Central Forms Management is enabled for a given blog.
+ *
+ * Enabled when the blog falls within the percentage-based rollout
+ * (blog_id % 100 < 10, i.e. 10%) or has the 'central-forms-management'
+ * blog sticker.
+ *
+ * @param int|null $blog_id Blog ID. Defaults to the current WP.com blog ID.
+ * @return bool
+ */
+function wpcom_is_central_forms_management_enabled( $blog_id = null ) {
+	if ( null === $blog_id ) {
+		$blog_id = function_exists( 'get_wpcom_blog_id' ) ? get_wpcom_blog_id() : get_current_blog_id();
+	}
+
+	// Percentage-based rollout: 10% of sites.
+	if ( ( $blog_id % 100 ) < 10 ) {
+		return true;
+	}
+
+	return wpcom_has_central_forms_management_sticker( $blog_id );
+}
+
+/**
+ * Enable the Central Forms Management alpha features when the rollout
+ * criteria are met. Called immediately on file load since this file is
+ * required during plugins_loaded (priority 10) inside load_wpcom_sites_features(),
+ * which is after the priority 1 that the wpcom mu-plugin uses.
+ */
+function wpcom_maybe_enable_central_forms_management() {
+	if ( ! wpcom_is_central_forms_management_enabled() ) {
+		return;
+	}
+
+	add_filter( 'jetpack_forms_alpha', '__return_true', 999 );
+}
+wpcom_maybe_enable_central_forms_management();
+
+/**
+ * Set the 'central-form-management' block editor feature flag.
+ *
+ * @param array $flags Existing feature flags.
+ * @return array Modified feature flags.
+ */
+function wpcom_contact_form_set_editor_feature_flags( $flags ) {
+	$flags['central-form-management'] = wpcom_is_central_forms_management_enabled();
+	return $flags;
+}
+add_filter( 'jetpack_block_editor_feature_flags', 'wpcom_contact_form_set_editor_feature_flags', 1000 );
+
+// Disable the integrations tab on all WordPress.com sites.
+add_filter( 'jetpack_forms_enable_integrations_tab', '__return_false' );


### PR DESCRIPTION
Part of FORMS-536

## Proposed changes

* Move the Central Forms Management (CFM) rollout logic from the wpcom repo's `wpcom-contact-form.php` into `jetpack-mu-wpcom` so it works on **both Simple and Atomic** infrastructure.
* Define `wpcom_is_central_forms_management_enabled()` with dual Simple/Atomic blog sticker support and a 10% percentage-based rollout (`blog_id % 100 < 10`).
* Hook `jetpack_block_editor_feature_flags` at priority 1000 to set the `central-form-management` editor flag (runs after the existing wpcom hook at 999).
* Hook `jetpack_forms_alpha` to enable the alpha dashboard when the rollout criteria are met.
* Follow the established sticker-check pattern from `gutenberg-rtc.php` (`IS_ATOMIC` + `wpcomsh_is_site_sticker_active` for Atomic, `has_blog_sticker` for Simple).

### Why

Previously the feature flags lived only in `wpcom-contact-form.php`, which only runs on Simple sites. If a site created forms under CFM and later moved to Atomic (e.g. by installing a plugin), the feature would silently disappear and forms would be lost. Moving the logic into `jetpack-mu-wpcom` — which runs on both Simple and Atomic — prevents this.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links

* CFT post: pdtkmj-4pt-p2

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This change controls feature flag evaluation only — no UI changes in this PR.

1. **Verify percentage rollout logic**:
   - For a site where `blog_id % 100 < 10`, confirm `wpcom_is_central_forms_management_enabled()` returns `true`.
   - For a site where `blog_id % 100 >= 10` and no sticker, confirm it returns `false`.

2. **Verify sticker override**:
   - Add the `central-forms-management` blog sticker to a site outside the 10% bucket.
   - Confirm `wpcom_is_central_forms_management_enabled()` returns `true` for that site.

3. **Verify Atomic support**:
   - On an Atomic site, confirm the sticker check uses `wpcomsh_is_site_sticker_active()` (not `has_blog_sticker()`).

4. **Verify editor feature flag**:
   - On an enabled site, confirm `jetpack_block_editor_feature_flags` includes `'central-form-management' => true`.

5. **Verify coexistence with wpcom code**:
   - On a Simple site, both the wpcom hook (priority 999) and this hook (priority 1000) will run. Confirm the priority 1000 value wins.

**Note**: A companion wpcom PR will slim down `wpcom-contact-form.php` to only handle the `PUBLIC_API_BLOG_ID` edge case at priority 1001.