### PR TITLE
PayPal Payments Button: fix escaping issue for stacked payments buttons

### DIFF
--- a/projects/packages/paypal-payments/changelog/fix-escaping-issues-in-paypal-buttons
+++ b/projects/packages/paypal-payments/changelog/fix-escaping-issues-in-paypal-buttons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+PayPal Payments Button: fix escaping issue for stacked payments buttons

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-payment-buttons.php
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-payment-buttons.php
@@ -69,7 +69,8 @@ class PayPal_Payment_Buttons {
 			$sanitized_url .= $parsed_url['path'];
 		}
 		if ( isset( $parsed_url['query'] ) ) {
-			$sanitized_url .= '?' . $parsed_url['query'];
+			// If we have escaped ampersands in the query string, we need to unescape them.
+			$sanitized_url .= '?' . str_replace( '&amp;', '&', $parsed_url['query'] );
 		}
 
 		return $sanitized_url;
@@ -124,9 +125,8 @@ class PayPal_Payment_Buttons {
 				return;
 			}
 
-			$script_url = esc_url( $sanitized_url );
 			// We can't include the version number here. If we do, it is appended to the URL and causes a 400 response.
-			wp_enqueue_script( 'paypal-payment-buttons-block-head', $script_url, array(), null, false ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+			wp_enqueue_script( 'paypal-payment-buttons-block-head', $sanitized_url, array(), null, false ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 			add_filter(
 				'script_loader_tag',
 				function ( $tag, $handle, $src ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable

--- a/projects/packages/paypal-payments/tests/php/Paypal_Payment_Buttons_Test.php
+++ b/projects/packages/paypal-payments/tests/php/Paypal_Payment_Buttons_Test.php
@@ -57,12 +57,13 @@ class Paypal_Payment_Buttons_Test extends TestCase {
 	 */
 	public static function valid_paypal_urls_provider() {
 		return array(
-			'paypal.com'                    => array( 'https://www.paypal.com/sdk/js' ),
-			'paypal.com subdomain'          => array( 'https://www.paypal.com/sdk/js?client-id=test' ),
-			'sandbox.paypal.com'            => array( 'https://www.sandbox.paypal.com/sdk/js' ),
-			'sandbox.paypal.com with query' => array( 'https://www.sandbox.paypal.com/sdk/js?client-id=test&currency=USD' ),
-			'www.paypal.com'                => array( 'https://www.paypal.com/webapps/xoplatform' ),
-			'www.sandbox.paypal.com'        => array( 'https://www.sandbox.paypal.com/webapps/xoplatform' ),
+			'paypal.com'                              => array( 'https://www.paypal.com/sdk/js' ),
+			'paypal.com subdomain'                    => array( 'https://www.paypal.com/sdk/js?client-id=test' ),
+			'paypal.com subdomain with escaped query' => array( 'https://www.paypal.com/sdk/js?client-id=test&amp;currency=USD' ),
+			'sandbox.paypal.com'                      => array( 'https://www.sandbox.paypal.com/sdk/js' ),
+			'sandbox.paypal.com with query'           => array( 'https://www.sandbox.paypal.com/sdk/js?client-id=test&currency=USD' ),
+			'www.paypal.com'                          => array( 'https://www.paypal.com/webapps/xoplatform' ),
+			'www.sandbox.paypal.com'                  => array( 'https://www.sandbox.paypal.com/webapps/xoplatform' ),
 		);
 	}
 
@@ -116,11 +117,11 @@ class Paypal_Payment_Buttons_Test extends TestCase {
 	 */
 	public function test_query_parameters_are_preserved() {
 		// Valid PayPal URL with query params
-		$valid_url = 'https://www.paypal.com/sdk/js?client-id=test&currency=USD&locale=en_US';
+		$valid_url = 'https://www.paypal.com/sdk/js?client-id=test&currency=USD&locale=en_US&amp;foo=bar';
 		$result    = PayPal_Payment_Buttons::sanitize_paypal_script_url( $valid_url );
 
 		$result_parsed = wp_parse_url( $result );
-		$this->assertEquals( 'client-id=test&currency=USD&locale=en_US', $result_parsed['query'] );
+		$this->assertEquals( 'client-id=test&currency=USD&locale=en_US&foo=bar', $result_parsed['query'] );
 	}
 
 	/**
@@ -141,14 +142,14 @@ class Paypal_Payment_Buttons_Test extends TestCase {
 	 */
 	public function test_all_url_components_together() {
 		// Valid PayPal URL with all components (fragment and port are stripped)
-		$valid_url = 'https://www.paypal.com:443/sdk/js?client-id=test&currency=USD#init';
+		$valid_url = 'https://www.paypal.com:443/sdk/js?client-id=test&currency=USD&amp;foo=bar#init';
 		$result    = PayPal_Payment_Buttons::sanitize_paypal_script_url( $valid_url );
 
 		$result_parsed = wp_parse_url( $result );
 		$this->assertEquals( 'www.paypal.com', $result_parsed['host'] );
 		$this->assertEquals( 'https', $result_parsed['scheme'] );
 		$this->assertEquals( '/sdk/js', $result_parsed['path'] );
-		$this->assertEquals( 'client-id=test&currency=USD', $result_parsed['query'] );
+		$this->assertEquals( 'client-id=test&currency=USD&foo=bar', $result_parsed['query'] );
 		$this->assertArrayNotHasKey( 'fragment', $result_parsed, 'Fragment should be stripped' );
 	}
 

--- a/projects/plugins/jetpack/changelog/fix-escaping-issues-in-paypal-buttons
+++ b/projects/plugins/jetpack/changelog/fix-escaping-issues-in-paypal-buttons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+PayPal Payments Button: fix escaping issue for stacked payments buttons

--- a/projects/plugins/paypal-payment-buttons/changelog/fix-escaping-issues-in-paypal-buttons
+++ b/projects/plugins/paypal-payment-buttons/changelog/fix-escaping-issues-in-paypal-buttons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+PayPal Payments Button: fix escaping issue for stacked payments buttons


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/PAYPAL-159/

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* This PR attempts to address two issues with the PayPal script URLs that we generate for the default stacked mode
   - In situations where the serialised URL has already had the `&` characters escaped to `&amp;`, we restore the values to `&` in the query string
   - In the code that enqueues the script via `wp_enqueue_script()`, we no longer call `esc_url()` on the URL value, as `wp_enqueue_script()` is expecting to escape the URL as needed, and the code in `add_query_arg()` is mangling the escaped URL. (I still need to work out whether that's a bug in core.)

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* PAYPAL-159

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No changes to tracking.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Find or create a new PayPal Payment Buttons block in a post, and ensure that the URL you paste in already includes `&amp;` characters
* Publish the post
* Verify that the published post renders the correct PayPal Buttons
