### PR TITLE
Add AGENTS.md and CLAUDE.md for Agents Manager backend

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-agents-manager-claude-md
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-agents-manager-claude-md
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Add AGENTS.md and CLAUDE.md for Agents Manager feature.

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/AGENTS.md
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/AGENTS.md
@@ -1,0 +1,116 @@
+# Agents Manager (Jetpack Backend)
+
+## Overview
+
+The Agents Manager backend in `jetpack-mu-wpcom` is responsible for loading the Agents Manager frontend bundles on WordPress.com sites and providing REST API endpoints for persisting UI state.
+
+The frontend code lives in the Calypso repository (`packages/agents-manager/` and `apps/agents-manager/`). This feature only handles enqueueing and backend concerns.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `agents-manager.php` | Entry point, requires the main class |
+| `class-agents-manager.php` | Core class: script enqueueing, variant selection, admin bar, feature gating |
+| `class-wp-rest-agents-manager-persisted-open-state.php` | REST controller for UI state persistence |
+
+## Script Loading
+
+### Variant Selection
+
+The `get_variant()` method selects which bundle to load based on the current environment:
+
+| Variant | Context |
+|---------|---------|
+| `gutenberg` | Block editor, connected to Jetpack |
+| `gutenberg-disconnected` | Block editor, disconnected |
+| `wp-admin` | Classic wp-admin, connected |
+| `wp-admin-disconnected` | Classic wp-admin, disconnected |
+| `ciab` | CIAB / Next Admin, connected |
+| `ciab-disconnected` | CIAB / Next Admin, disconnected |
+
+### Bundle Sources
+
+All JS/CSS bundles are loaded from `widgets.wp.com/agents-manager/`:
+- JavaScript: `agents-manager-{variant}.min.js`
+- CSS: `agents-manager-{variant}.css` (with `.rtl.css` for RTL languages)
+- Asset metadata: `agents-manager-{variant}.asset.json` (cached in transient for 1 hour)
+
+### Enqueue Hooks
+
+Scripts are enqueued via three hooks (all at priority 101, after Help Center at 100):
+- `admin_enqueue_scripts` — wp-admin pages
+- `wp_enqueue_scripts` — frontend pages (eligible editors only)
+- `next_admin_init` (priority 1001) — CIAB / Next Admin
+
+### Inline Data
+
+The PHP injects `agentsManagerData` as inline script data containing:
+- `agentProviders` — from `agents_manager_agent_providers` filter
+- `useUnifiedExperience` — from `agents_manager_use_unified_experience` filter
+- `isDevMode` — development environment detection
+- `sectionName` — the variant name
+- `currentUser` — user ID, username, display name, avatar, email
+- `site` — site ID and domain
+- `helpCenterUrl` — fallback URL for disconnected variants
+
+## REST API
+
+**Namespace:** `agents-manager`
+**Route:** `/open-state`
+
+### GET `/wp-json/agents-manager/open-state`
+
+Retrieves the Agents Manager UI state from user preferences.
+
+**Permission:** `is_user_logged_in`
+
+**Response fields:**
+- `agents_manager_open` (bool, default: false)
+- `agents_manager_docked` (bool, default: false)
+- `agents_manager_floating_position` (string, default: 'right')
+- `agents_manager_router_history` (object|null, default: null)
+
+### POST `/wp-json/agents-manager/open-state`
+
+Updates the Agents Manager UI state. All parameters are optional; only provided parameters are updated.
+
+**Permission:** `is_user_logged_in`
+
+Both endpoints proxy to `/agents-manager/state` on wpcom via `Jetpack\Connection\Client::wpcom_json_api_request_as_user()`.
+
+## Filters
+
+| Filter | Purpose | Default |
+|--------|---------|---------|
+| `agents_manager_use_unified_experience` | Enable unified experience UI | `false` |
+| `agents_manager_enabled_in_ciab` | Enable/disable in CIAB | `true` |
+| `agents_manager_enabled_in_block_editor` | Enable/disable in block editor | `false` |
+| `agents_manager_agent_providers` | Register extension provider module URLs | `[]` |
+
+## Feature Gating
+
+The `is_enabled()` method implements multi-level feature gates:
+1. CIAB: always enabled (controllable via `agents_manager_enabled_in_ciab`)
+2. Unified experience: enabled if `agents_manager_use_unified_experience` is true
+3. Block editor only: if `agents_manager_enabled_in_block_editor` is true
+4. Default: disabled
+
+## Help Center Interaction
+
+On Gutenberg pages, the Agents Manager dequeues Help Center scripts and styles to prevent duplicate UI. In classic wp-admin, it replaces the Help Center admin bar node with its own.
+
+## Router History Cleanup
+
+The `calypso_preferences_update` filter limits router history entries to 50. When exceeded, it keeps the last 49 entries and prepends a root entry to ensure the back button works.
+
+## Development
+
+This feature is loaded for WordPress.com-connected users via `Jetpack_Mu_Wpcom`. To develop:
+
+1. Follow the standard [`jetpack-mu-wpcom` development process](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/jetpack-mu-wpcom/README.md).
+2. For frontend-only changes, work in the Calypso repo instead (`packages/agents-manager/` or `apps/agents-manager/`).
+
+## Deployment
+
+After changes to the PHP files, deploy `jetpack-mu-wpcom`. Releases happen twice daily.

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/AGENTS.md
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/AGENTS.md
@@ -1,112 +1,32 @@
 # Agents Manager (Jetpack Backend)
 
-## Overview
+Backend for the Agents Manager in `jetpack-mu-wpcom`. Handles script enqueueing, feature gating, and UI state persistence.
 
-The Agents Manager backend in `jetpack-mu-wpcom` is responsible for loading the Agents Manager frontend bundles on WordPress.com sites and providing REST API endpoints for persisting UI state.
+The frontend code lives in the Calypso repo (`packages/agents-manager/` and `apps/agents-manager/`). This feature only handles loading those bundles and backend concerns.
 
-The frontend code lives in the Calypso repository (`packages/agents-manager/` and `apps/agents-manager/`). This feature only handles enqueueing and backend concerns.
+## Cross-Repo Relationship
 
-## Files
+- All JS/CSS bundles are fetched from `widgets.wp.com/agents-manager/`, built by the Calypso `apps/agents-manager/` app.
+- Asset metadata (`.asset.json`) is fetched via HTTP on Atomic sites or read from disk on Simple sites, then cached in a transient for 1 hour.
+- The REST endpoint proxies to `/agents-manager/state` on wpcom via `Jetpack\Connection\Client::wpcom_json_api_request_as_user()`.
 
-| File | Purpose |
-|------|---------|
-| `agents-manager.php` | Entry point, requires the main class |
-| `class-agents-manager.php` | Core class: script enqueueing, variant selection, admin bar, feature gating |
-| `class-wp-rest-agents-manager-persisted-open-state.php` | REST controller for UI state persistence |
+## Key Filters
 
-## Script Loading
-
-### Variant Selection
-
-The `get_variant()` method selects which bundle to load based on the current environment:
-
-| Variant | Context |
-|---------|---------|
-| `gutenberg` | Block editor, connected to Jetpack |
-| `gutenberg-disconnected` | Block editor, disconnected |
-| `wp-admin` | Classic wp-admin, connected |
-| `wp-admin-disconnected` | Classic wp-admin, disconnected |
-| `ciab` | CIAB / Next Admin, connected |
-| `ciab-disconnected` | CIAB / Next Admin, disconnected |
-
-### Bundle Sources
-
-All JS/CSS bundles are loaded from `widgets.wp.com/agents-manager/`:
-- JavaScript: `agents-manager-{variant}.min.js`
-- CSS: `agents-manager-{variant}.css` (with `.rtl.css` for RTL languages)
-- Asset metadata: `agents-manager-{variant}.asset.json` (cached in transient for 1 hour)
-
-### Enqueue Hooks
-
-Scripts are enqueued via three hooks (all at priority 101, after Help Center at 100):
-- `admin_enqueue_scripts` — wp-admin pages
-- `wp_enqueue_scripts` — frontend pages (eligible editors only)
-- `next_admin_init` (priority 1001) — CIAB / Next Admin
-
-### Inline Data
-
-The PHP injects `agentsManagerData` as inline script data containing:
-- `agentProviders` — from `agents_manager_agent_providers` filter
-- `useUnifiedExperience` — from `agents_manager_use_unified_experience` filter
-- `isDevMode` — development environment detection
-- `sectionName` — the variant name
-- `currentUser` — user ID, username, display name, avatar, email
-- `site` — site ID and domain
-- `helpCenterUrl` — fallback URL for disconnected variants
-
-## REST API
-
-**Namespace:** `agents-manager`
-**Route:** `/open-state`
-
-### GET `/wp-json/agents-manager/open-state`
-
-Retrieves the Agents Manager UI state from user preferences.
-
-**Permission:** `is_user_logged_in`
-
-**Response fields:**
-- `agents_manager_open` (bool, default: false)
-- `agents_manager_docked` (bool, default: false)
-- `agents_manager_floating_position` (string, default: 'right')
-- `agents_manager_router_history` (object|null, default: null)
-
-### POST `/wp-json/agents-manager/open-state`
-
-Updates the Agents Manager UI state. All parameters are optional; only provided parameters are updated.
-
-**Permission:** `is_user_logged_in`
-
-Both endpoints proxy to `/agents-manager/state` on wpcom via `Jetpack\Connection\Client::wpcom_json_api_request_as_user()`.
-
-## Filters
+These filters control behavior and are used by other plugins (like Big Sky) to integrate:
 
 | Filter | Purpose | Default |
 |--------|---------|---------|
+| `agents_manager_agent_providers` | Register extension provider module URLs | `[]` |
 | `agents_manager_use_unified_experience` | Enable unified experience UI | `false` |
 | `agents_manager_enabled_in_ciab` | Enable/disable in CIAB | `true` |
 | `agents_manager_enabled_in_block_editor` | Enable/disable in block editor | `false` |
-| `agents_manager_agent_providers` | Register extension provider module URLs | `[]` |
 
-## Feature Gating
+## Pitfalls
 
-The `is_enabled()` method implements multi-level feature gates:
-1. CIAB: always enabled (controllable via `agents_manager_enabled_in_ciab`)
-2. Unified experience: enabled if `agents_manager_use_unified_experience` is true
-3. Block editor only: if `agents_manager_enabled_in_block_editor` is true
-4. Default: disabled
-
-## Help Center Interaction
-
-On Gutenberg pages, the Agents Manager dequeues Help Center scripts and styles to prevent duplicate UI. In classic wp-admin, it replaces the Help Center admin bar node with its own.
-
-## Router History Cleanup
-
-The `calypso_preferences_update` filter limits router history entries to 50. When exceeded, it keeps the last 49 entries and prepends a root entry to ensure the back button works.
+- **Enqueue priority matters**: Scripts enqueue at priority 101 (after Help Center at 100) so the Agents Manager can dequeue Help Center. Changing priority breaks this.
+- **Feature gating is multi-layered**: `is_enabled()` checks CIAB, unified experience, and block editor filters in order. The first match wins. This is not a simple on/off.
+- **Router history cleanup**: The `calypso_preferences_update` filter silently limits history to 50 entries. If debugging missing history state, check this.
 
 ## Development
 
-This feature is loaded for WordPress.com-connected users via `Jetpack_Mu_Wpcom`. To develop:
-
-1. Follow the standard [`jetpack-mu-wpcom` development process](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/jetpack-mu-wpcom/README.md).
-2. For frontend-only changes, work in the Calypso repo instead (`packages/agents-manager/` or `apps/agents-manager/`).
+Follow the standard [`jetpack-mu-wpcom` development process](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/jetpack-mu-wpcom/README.md). For frontend-only changes, work in the Calypso repo instead.

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/AGENTS.md
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/AGENTS.md
@@ -110,7 +110,3 @@ This feature is loaded for WordPress.com-connected users via `Jetpack_Mu_Wpcom`.
 
 1. Follow the standard [`jetpack-mu-wpcom` development process](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/jetpack-mu-wpcom/README.md).
 2. For frontend-only changes, work in the Calypso repo instead (`packages/agents-manager/` or `apps/agents-manager/`).
-
-## Deployment
-
-After changes to the PHP files, deploy `jetpack-mu-wpcom`. Releases happen twice daily.

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/CLAUDE.md
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` and `CLAUDE.md` to `jetpack-mu-wpcom/src/features/agents-manager/`
- Documents cross-repo relationships, key filters, and non-obvious pitfalls for AI coding agents

## Testing instructions

This is a docs-only change (Markdown files + changelog). No functional changes.

1. Verify the new files exist at `projects/packages/jetpack-mu-wpcom/src/features/agents-manager/AGENTS.md` and `CLAUDE.md`.
2. Confirm no PHP, JS, or CSS files were modified.

## Does this pull request change what data or activity we track or use?

No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)