### PR TITLE
WPCOM: Bump 'react', 'react-dom', 'react-jsx-runtime' version number HotFix.

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-react-version-bump-hotfix
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-react-version-bump-hotfix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add cache breaking mechanism to fix React cache error.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-hotfixes/wpcom-hotfixes.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-hotfixes/wpcom-hotfixes.php
@@ -4,3 +4,11 @@
  *
  * @package automattic/jetpack-mu-wpcom
  */
+
+add_action( 'wp_default_scripts', function( $scripts ) {
+	foreach ( [ 'react', 'react-dom', 'react-jsx-runtime' ] as $handle ) {
+		if ( isset( $scripts->registered[ $handle ] ) ) {
+			$scripts->registered[ $handle ]->ver = '18.3.1';
+		}
+	}
+}, 20 ); // priority 20 runs after Gutenberg's priority 10

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-hotfixes/wpcom-hotfixes.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-hotfixes/wpcom-hotfixes.php
@@ -5,10 +5,14 @@
  * @package automattic/jetpack-mu-wpcom
  */
 
-add_action( 'wp_default_scripts', function( $scripts ) {
-	foreach ( [ 'react', 'react-dom', 'react-jsx-runtime' ] as $handle ) {
-		if ( isset( $scripts->registered[ $handle ] ) ) {
-			$scripts->registered[ $handle ]->ver = '18.3.1';
+add_action(
+	'wp_default_scripts',
+	function ( $scripts ) {
+		foreach ( [ 'react', 'react-dom', 'react-jsx-runtime' ] as $handle ) {
+			if ( isset( $scripts->registered[ $handle ] ) ) {
+				$scripts->registered[ $handle ]->ver = '18.3.1';
+			}
 		}
-	}
-}, 20 ); // priority 20 runs after Gutenberg's priority 10
+	},
+	20 // priority 20 runs after Gutenberg's priority 10
+);

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-hotfixes/wpcom-hotfixes.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-hotfixes/wpcom-hotfixes.php
@@ -8,7 +8,7 @@
 add_action(
 	'wp_default_scripts',
 	function ( $scripts ) {
-		foreach ( [ 'react', 'react-dom', 'react-jsx-runtime' ] as $handle ) {
+		foreach ( array( 'react', 'react-dom', 'react-jsx-runtime' ) as $handle ) {
 			if ( isset( $scripts->registered[ $handle ] ) ) {
 				$scripts->registered[ $handle ]->ver = '18.3.1';
 			}


### PR DESCRIPTION
Fixes #

## Proposed changes

In Gutenberg v22.6.0, the contents of `react-dom.min.js` changed but the `?ver=` parameter stayed at "18". The CDN served the stale v22.5.3 file to sites running v22.7.0, causing JS errors `(Uncaught TypeError: 0.$createRoot is not a function)` and blank/white-screen pages.

Adds a `wp_default_scripts` action at priority 20 (after Gutenberg's priority 10) to `wpcom-hotfixes.php` that normalizes react, react-dom, and `react-jsx-runtime` version strings to the full `semver (18.3.1),` causing the CDN to treat them as new resources and fetch updated files.

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* See https://github.com/Automattic/jetpack/pull/47766#issuecomment-4122644022
* When you load the editor on a WoA or simple site, you should see the network request for `react-dom.min.js` includes a `?ver=18.3.1` query parameter.
