### PR TITLE
Akismet: allow Akismet to register its own menu even if Jetpack is installed

### DIFF
--- a/projects/packages/admin-ui/changelog/update-keep-settings-akismet-on-jetpack
+++ b/projects/packages/admin-ui/changelog/update-keep-settings-akismet-on-jetpack
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Akismet: allow Akismet to register its own menu even if Jetpack is installed

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -44,19 +44,16 @@ class Admin_Menu {
 	}
 
 	/**
-	 * Handles the Akismet menu item when used alongside other stand-alone plugins
+	 * Handles the Akismet menu item when used alongside other stand-alone plugins.
 	 *
-	 * When Jetpack plugin is present, Akismet menu item is moved under the Jetpack top level menu, but if Akismet is active alongside other stand-alone plugins,
-	 * we use this method to move the menu item.
+	 * When Jetpack plugin is present, an Akismet menu item is added under the Jetpack top level menu, but if Akismet is active alongside other stand-alone plugins,
+	 * we use this method to add the menu item.
 	 */
 	private static function handle_akismet_menu() {
 		if ( class_exists( 'Akismet_Admin' ) ) {
 			add_action(
 				'admin_menu',
 				function () {
-					// Prevent Akismet from adding a menu item.
-					remove_action( 'admin_menu', array( 'Akismet_Admin', 'admin_menu' ), 5 );
-
 					// Add an Anti-spam menu item for Jetpack.
 					self::add_menu( __( 'Akismet Anti-spam', 'jetpack-admin-ui' ), __( 'Akismet Anti-spam', 'jetpack-admin-ui' ), 'manage_options', 'akismet-key-config', array( 'Akismet_Admin', 'display_page' ), 6 );
 				},

--- a/projects/plugins/jetpack/changelog/update-keep-settings-akismet-on-jetpack
+++ b/projects/plugins/jetpack/changelog/update-keep-settings-akismet-on-jetpack
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Akismet: allow Akismet to register its own menu even if Jetpack is installed

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -79,23 +79,8 @@ class Jetpack_Admin {
 		add_action( 'jetpack_unrecognized_action', array( $this, 'handle_unrecognized_action' ) );
 
 		if ( class_exists( 'Akismet_Admin' ) ) {
-			// If the site has Jetpack Anti-spam, change the Akismet menu label and logo accordingly.
-			$site_products         = array_column( Jetpack_Plan::get_products(), 'product_slug' );
-			$has_anti_spam_product = count( array_intersect( array( 'jetpack_anti_spam', 'jetpack_anti_spam_monthly' ), $site_products ) ) > 0;
-
-			if ( Jetpack_Plan::supports( 'akismet' ) || Jetpack_Plan::supports( 'antispam' ) || $has_anti_spam_product ) {
-				// Prevent Akismet from adding a menu item.
-				add_action(
-					'admin_menu',
-					function () {
-						remove_action( 'admin_menu', array( 'Akismet_Admin', 'admin_menu' ), 5 );
-					},
-					4
-				);
-
-				// Add an Anti-spam menu item for Jetpack. This is handled automatically by the Admin_Menu as long as it has been initialized.
-				Admin_Menu::init();
-			}
+			// Add an Akismet Anti-spam menu item for Jetpack. This is handled automatically by the Admin_Menu as long as it has been initialized.
+			Admin_Menu::init();
 		}
 
 		// Ensure an Additional CSS menu item is added to the Appearance menu whenever Jetpack is connected.


### PR DESCRIPTION
## Proposed changes:
* Previously, when Jetpack was active alongside Akismet, Jetpack would suppress Akismet's own menu registration and conditionally add its own Anti-spam menu item — but only if the site had an anti-spam plan/product. This meant the menu item was missing for sites without that plan.
* This change removes the plan/product check and the suppression of Akismet's native menu registration, so the Akismet Anti-spam menu item always appears when both Jetpack and Akismet are active.

Fixes NOSPAM-607.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

* Install both Jetpack and Akismet on a WordPress site
* Verify the Akismet Anti-spam menu item appears under the Jetpack top-level menu regardless of whether the site has an anti-spam plan