### PR TITLE
RTC Notices: Fix image URLs on Simple sites by importing public-path

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-16486-validate-that-the-modals-work-on-simple-sites
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-16486-validate-that-the-modals-work-on-simple-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+RTC Notices: Fix image URLs on Simple sites by importing public-path to set webpack publicPath correctly

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/index.tsx
@@ -1,3 +1,6 @@
+/*** THIS MUST BE THE FIRST THING EVALUATED IN THIS SCRIPT *****/
+import '../../common/public-path';
+
 /**
  * Gutenberg RTC Notices & Limits
  *


### PR DESCRIPTION
 ## Summary

  The `gutenberg-rtc-notices` entry point was missing the `public-path` import that other features (`wpcom-block-editor-nux`,
  `wpcom-dashboard-widgets`) already include. Without it, webpack's automatic `publicPath` detection generates a broken relative
  path (`/_static/../images/...`) for image assets on WordPress.com Simple sites where JS concatenation rewrites script URLs.

  The fix adds `import '../../common/public-path'` as the first import, which sets `__webpack_public_path__` from
  `JETPACK_MU_WPCOM_SETTINGS.assetsUrl` — the same mechanism used by other features in the package.

  ## Testing instructions

  1. Enable RTC on a WordPress.com Simple site (requires the `REAL_TIME_COLLABORATION` feature, `wpcom-features-edge` sticker, and
  Gutenberg >= 22.7.0).
  2. Open the block editor on a post.
  3. Trigger the welcome modal (reset dismissal if needed by deleting the `wpcom_rtc_welcome_notice_dismissed` user option).
  4. Verify the hero image (`rtc-hero.png`) in the welcome modal loads correctly — before this fix, the image URL resolves to a
  broken `/_static/../images/...` path resulting in a 404.
  5. Verify the connection error modal and room-limit modals also display their images correctly.

  ## Does this pull request change what data or activity we track or use?

  No.
