### PR TITLE
RTC: Add RTC-specific pixel beacons for Grafana dashboarding

### DIFF
--- a/projects/packages/rtc/changelog/dotcom-16504-add-missing-metrics-for-rtc-ws-flow
+++ b/projects/packages/rtc/changelog/dotcom-16504-add-missing-metrics-for-rtc-ws-flow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Add RTC-specific pixel beacons (`pinghub.rtc.*`) alongside existing shared beacons for dedicated RTC dashboarding, and add new beacons for JWT fetch latency/errors and send drops.

--- a/projects/packages/rtc/src/js/providers/pinghub/pinghub-bridge.ts
+++ b/projects/packages/rtc/src/js/providers/pinghub/pinghub-bridge.ts
@@ -160,7 +160,7 @@ function detectBrowser(): string {
  * @param value - Metric value.
  * @param unit  - Unit indicator ('ms' for milliseconds, 'c' for counter).
  */
-function pixel( key: string, value: string | number, unit: string ): void {
+export function pixel( key: string, value: string | number, unit: string ): void {
 	new Image().src =
 		'https://pixel.wp.com/boom.gif?' +
 		'v=0.9&u=https://public-api.wordpress.com/pinghub&' +

--- a/projects/packages/rtc/src/js/providers/pinghub/pinghub-bridge.ts
+++ b/projects/packages/rtc/src/js/providers/pinghub/pinghub-bridge.ts
@@ -328,6 +328,7 @@ export class PingHubBridge {
 		if ( this.cachedJwt && Date.now() - this.cachedJwtTimestamp < JWT_CACHE_TTL_MS ) {
 			return this.cachedJwt;
 		}
+		const start = Date.now();
 		try {
 			const response = await apiFetch< { token: string } >( {
 				path: '/wpcom/v2/rtc/pinghub-token',
@@ -335,8 +336,10 @@ export class PingHubBridge {
 			} );
 			this.cachedJwt = response?.token ?? null;
 			this.cachedJwtTimestamp = Date.now();
+			pixel( 'pinghub.rtc.jwt_fetch', Date.now() - start, 'ms' );
 			return this.cachedJwt;
 		} catch {
+			pixel( 'pinghub.rtc.jwt_fetch_error', Date.now() - start, 'ms' );
 			return null;
 		}
 	}
@@ -386,6 +389,7 @@ export class PingHubBridge {
 
 		ws.addEventListener( 'open', () => {
 			pixel( 'pinghub.conn_open', Date.now() - start, 'ms' );
+			pixel( 'pinghub.rtc.conn_open', Date.now() - start, 'ms' );
 			this.connectingWaiters.delete( room );
 			waiters.splice( 0 ).forEach( ( { resolve } ) => resolve() );
 			this.openHandlers.get( room )?.forEach( h => h() );
@@ -393,6 +397,7 @@ export class PingHubBridge {
 
 		ws.addEventListener( 'close', event => {
 			pixel( 'pinghub.conn_close_code.' + event.code, Date.now() - start, 'ms' );
+			pixel( 'pinghub.rtc.conn_close_code.' + event.code, Date.now() - start, 'ms' );
 			this.sockets.delete( room );
 			if ( this.connectingWaiters.has( room ) ) {
 				this.connectingWaiters.delete( room );
@@ -404,6 +409,7 @@ export class PingHubBridge {
 
 		ws.addEventListener( 'error', () => {
 			pixel( 'pinghub.conn_err', Date.now() - start, 'ms' );
+			pixel( 'pinghub.rtc.conn_err', Date.now() - start, 'ms' );
 		} );
 
 		ws.addEventListener( 'message', event => {
@@ -459,6 +465,7 @@ export class PingHubBridge {
 	send( room: string, data: Uint8Array ): void {
 		const ws = this.sockets.get( room );
 		if ( ! ws || ws.readyState !== WebSocket.OPEN ) {
+			pixel( 'pinghub.rtc.send_drop', 1, 'c' );
 			return;
 		}
 

--- a/projects/packages/rtc/src/js/providers/pinghub/pinghub-manager.ts
+++ b/projects/packages/rtc/src/js/providers/pinghub/pinghub-manager.ts
@@ -2,7 +2,7 @@ import * as decoding from 'lib0/decoding';
 import * as encoding from 'lib0/encoding';
 import * as awarenessProtocol from 'y-protocols/awareness';
 import * as syncProtocol from 'y-protocols/sync';
-import { PingHubBridge } from './pinghub-bridge';
+import { PingHubBridge, pixel } from './pinghub-bridge';
 import type { Awareness, ConnectionStatus } from '@wordpress/sync';
 import type * as Y from 'yjs';
 
@@ -313,6 +313,9 @@ class PingHubConnection {
 	} ): void => {
 		if ( ! this.connected ) {
 			return;
+		}
+		if ( added.length > 0 ) {
+			pixel( 'pinghub.rtc.room_peers', this.awareness.getStates().size, 'ms' );
 		}
 		const changed = added.concat( updated ).concat( removed );
 		const update = awarenessProtocol.encodeAwarenessUpdate( this.awareness, changed );

--- a/projects/packages/rtc/src/js/providers/pinghub/pinghub-manager.ts
+++ b/projects/packages/rtc/src/js/providers/pinghub/pinghub-manager.ts
@@ -204,6 +204,8 @@ class PingHubConnection {
 			const update = awarenessProtocol.encodeAwarenessUpdate( this.awareness, [ this.clientId ] );
 			this.broadcastAwareness( update );
 		}
+
+		pixel( 'pinghub.rtc.room_peers', this.awareness.getStates().size, 'ms' );
 	};
 
 	/**


### PR DESCRIPTION
Fixes DOTCOM-16504

## Proposed changes
- Add `pinghub.rtc.*` pixel beacons alongside existing shared `pinghub.*` beacons so RTC WebSocket metrics can be distinguished from other PingHub consumers (e.g. notification rest-proxy) in Grafana
- Add new beacons for peers per room (`pinghub.rtc.room_peers`), JWT fetch latency/errors (`pinghub.rtc.jwt_fetch`, `pinghub.rtc.jwt_fetch_error`) and message send drops (`pinghub.rtc.send_drop`)
- Shared beacons (`pinghub.conn_open`, `pinghub.conn_close_code.*`, `pinghub.conn_err`) are preserved so the existing aggregate PingHub dashboard continues to work


## Related product discussion/links

N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- Apply these changes to your WP.com sandbox
- Sandbox a paid simple site
- Make sure the site has the `wpcom-features-edge` sticker
- Open the post editor
- Check the Ajax grafana dashboard (link in Linear issue)
- Make sure stats are updated in the dashboard

