### PR TITLE
Paid Content block: add grace period to prevent renewal lockout

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-premium-content-stale-jwt-renewal
+++ b/projects/plugins/jetpack/changelog/fix-premium-content-stale-jwt-renewal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Paid Content block: add 1-day grace period to subscription expiry check to prevent access lockout during renewal processing.

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
@@ -428,8 +428,8 @@ abstract class Abstract_Token_Subscription_Service implements Subscription_Servi
 		foreach ( $user_abbreviated_subscriptions as $subscription_plan_id => $details ) {
 			$details = (array) $details;
 			$end     = is_int( $details['end_date'] ) ? $details['end_date'] : strtotime( $details['end_date'] );
-			if ( $end < time() ) {
-				// subscription not active anymore
+			if ( $end + DAY_IN_SECONDS < time() ) {
+				// subscription not active anymore (with grace period for renewal processing)
 				continue;
 			}
 
@@ -623,7 +623,7 @@ abstract class Abstract_Token_Subscription_Service implements Subscription_Servi
 		foreach ( $token_subscriptions as $product_id => $token_subscription ) {
 			if ( in_array( intval( $product_id ), $product_ids, true ) ) {
 				$end = is_int( $token_subscription->end_date ) ? $token_subscription->end_date : strtotime( $token_subscription->end_date );
-				if ( $end > time() ) {
+				if ( $end + DAY_IN_SECONDS > time() ) {
 					return true;
 				}
 			}

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Jetpack_Premium_Content_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Jetpack_Premium_Content_Test.php
@@ -195,4 +195,41 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 		$this->assertTrue( current_visitor_can_access( array( 'selectedPlanIds' => array( $plan_id ) ), array() ) );
 		$this->assertTrue( current_visitor_can_access( array(), (object) array( 'context' => array( 'premium-content/planIds' => array( $plan_id ) ) ) ) );
 	}
+
+	/**
+	 * Test that a recently expired subscription is still accessible within the grace period.
+	 * This covers the renewal lockout bug where the JWT cookie contains a stale end_date.
+	 *
+	 * @return void
+	 */
+	public function test_access_granted_within_grace_period_after_expiry() {
+		$users_plans        = $this->set_up_users_and_plans();
+		$paid_subscriber_id = $users_plans[2];
+		$plan_id            = $users_plans[3];
+		$selected_plan_ids  = array( $plan_id );
+
+		// Subscription expired 1 hour ago — within the 1-day grace period.
+		wp_set_current_user( $paid_subscriber_id );
+		$payload = $this->get_payload( true, true, time() - HOUR_IN_SECONDS );
+		$this->set_returned_token( $payload );
+		$this->assertTrue( current_visitor_can_access( array( 'selectedPlanIds' => $selected_plan_ids ), array() ) );
+	}
+
+	/**
+	 * Test that a subscription expired beyond the grace period is denied access.
+	 *
+	 * @return void
+	 */
+	public function test_access_denied_beyond_grace_period() {
+		$users_plans        = $this->set_up_users_and_plans();
+		$paid_subscriber_id = $users_plans[2];
+		$plan_id            = $users_plans[3];
+		$selected_plan_ids  = array( $plan_id );
+
+		// Subscription expired 2 days ago — beyond the 1-day grace period.
+		wp_set_current_user( $paid_subscriber_id );
+		$payload = $this->get_payload( true, true, time() - 2 * DAY_IN_SECONDS );
+		$this->set_returned_token( $payload );
+		$this->assertFalse( current_visitor_can_access( array( 'selectedPlanIds' => $selected_plan_ids ), array() ) );
+	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
@@ -242,7 +242,8 @@ class Jetpack_Subscriptions_Test extends WP_UnitTestCase {
 	}
 
 	public static function matrix_access() {
-		$time_outdated = time() - HOUR_IN_SECONDS;
+		$time_outdated     = time() - 2 * DAY_IN_SECONDS;
+		$time_grace_period = time() - HOUR_IN_SECONDS;
 
 		return array(
 			// The follow use cases are mainly yot be thourough and probably duplicates some former use cases
@@ -315,8 +316,8 @@ class Jetpack_Subscriptions_Test extends WP_UnitTestCase {
 			static::access_use_case( 'paid_subscriber_id', false, true, 'subscribers', true, true ),
 			static::access_use_case( 'paid_subscriber_id', false, true, 'paid_subscribers', true, true ),
 
-			// Outdated paid subscription --  only matters for 'paid_subscribers' post - they are treated as normal "subscribers"
-				// loggued
+			// Outdated paid subscription (beyond grace period) -- only matters for 'paid_subscribers' post - they are treated as normal "subscribers"
+				// logged
 			static::access_use_case( 'paid_subscriber_id', true, false, '', true, true, $time_outdated ),
 			static::access_use_case( 'paid_subscriber_id', true, false, 'everybody', true, true, $time_outdated ),
 			static::access_use_case( 'paid_subscriber_id', true, false, 'subscribers', true, true, $time_outdated ),
@@ -326,6 +327,10 @@ class Jetpack_Subscriptions_Test extends WP_UnitTestCase {
 			static::access_use_case( 'paid_subscriber_id', false, true, 'everybody', true, true, $time_outdated ),
 			static::access_use_case( 'paid_subscriber_id', false, true, 'subscribers', true, true, $time_outdated ),
 			static::access_use_case( 'paid_subscriber_id', false, true, 'paid_subscribers', false, false, $time_outdated ),
+
+			// Recently expired paid subscription (within grace period) -- still granted access for renewal processing
+			static::access_use_case( 'paid_subscriber_id', true, false, 'paid_subscribers', true, true, $time_grace_period ),
+			static::access_use_case( 'paid_subscriber_id', false, true, 'paid_subscribers', true, true, $time_grace_period ),
 
 			// inactive subscription status
 			static::access_use_case( 'paid_subscriber_id', true, false, 'paid_subscribers', false, false, null, 'inactive' ),
@@ -759,11 +764,17 @@ class Jetpack_Subscriptions_Test extends WP_UnitTestCase {
 		);
 		$this->assertTrue( $subscription_service->visitor_can_view_content( Jetpack_Memberships::get_all_newsletter_plan_ids(), $post_access_level ) );
 
-		// Let's make sure date is taken into account
+		// Let's make sure date is taken into account (beyond grace period)
+		$subscription_service = $this->set_returned_token(
+			$this->get_payload( true, true, time() - 2 * DAY_IN_SECONDS, null, $gold_tier_annual_plan_id )
+		);
+		$this->assertFalse( $subscription_service->visitor_can_view_content( Jetpack_Memberships::get_all_newsletter_plan_ids(), $post_access_level ) );
+
+		// Within grace period, access should still be granted
 		$subscription_service = $this->set_returned_token(
 			$this->get_payload( true, true, time() - HOUR_IN_SECONDS, null, $gold_tier_annual_plan_id )
 		);
-		$this->assertFalse( $subscription_service->visitor_can_view_content( Jetpack_Memberships::get_all_newsletter_plan_ids(), $post_access_level ) );
+		$this->assertTrue( $subscription_service->visitor_can_view_content( Jetpack_Memberships::get_all_newsletter_plan_ids(), $post_access_level ) );
 
 		// This was removed because subscriptions in JWT_token does not provide the subscription status
 		// See https://github.com/Automattic/jetpack/pull/32710/commits/7e874089416d4d0f6b27d03420055f4b55d3c1e2


### PR DESCRIPTION
Fixes NL-546

## Proposed changes

* Add a 1-day (`DAY_IN_SECONDS`) grace period to the subscription expiry check in `validate_subscriptions()` so that a JWT token with a recently-passed `end_date` still grants access during the renewal processing window.
* Apply the same grace period in `maybe_gate_access_for_user_if_tier()` for tier-based content gating.
* Add tests verifying access is granted within the grace period and denied beyond it.

Access granted | Access denied
---- | ----
<img width="622" height="439" alt="Screenshot 2026-03-25 at 11 46 45 AM" src="https://github.com/user-attachments/assets/f9c0c91a-248d-4eed-859e-e2b15ff071b0" /> | <img width="624" height="422" alt="Screenshot 2026-03-25 at 11 46 37 AM" src="https://github.com/user-attachments/assets/bc0c26f6-829b-42be-9c32-81a1ac0a03a8" />

### Other information

This is a known issue dating back to DOTCOM-11076 (Oct 2020). A grace period fix was coded in PR #22757 but closed without merging in March 2023. This PR revives that approach and applies it to both code paths that check subscription expiry.

**Root cause:** When a paid subscriber's subscription renews, Billingdaddy records the new `end_date`, but the JWT cookie still contains the old snapshot. `validate_subscriptions()` checks `end_date > time()` against the stale cookie value and denies access. The subscriber sees a "subscribe again" prompt but is told they're already subscribed.

**Tradeoff:** A subscriber whose subscription genuinely lapses (cancelled/payment failed) retains access for up to 24 hours. This is acceptable given the current bug locks out legitimate paying subscribers entirely. The billing system's own retry window is ~8 days, so a 1-day grace period is well within that range.

## Related product discussion/links

* https://linear.app/a8c/issue/NL-546
* https://linear.app/a8c/issue/MON-67
* https://linear.app/a8c/issue/MON-6
* Jetpack PR #22757 (original grace period fix, closed without merge)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

### Setup

1. Use a WoA or Jetpack-connected site with the Paid Content block and a recurring subscription product.
2. Get the site's JWT signing key via WP-CLI:
   ```
   wp eval "echo (new Automattic\Jetpack\Connection\Tokens())->get_access_token()->secret;"
   ```
3. Note the `product_id` for the subscription plan (from the memberships/status endpoint or post meta).

### Test 1: Access granted within grace period (expired 1 hour ago)

Generate a token with an `end_date` 1 hour in the past:

```
wp eval "
require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/class-jwt.php';
use Automattic\Jetpack\Extensions\Premium_Content\JWT;

\$key = (new Automattic\Jetpack\Connection\Tokens())->get_access_token()->secret;
\$payload = [
    'blog_sub' => 'active',
    'subscriptions' => [
        YOUR_PRODUCT_ID => [
            'status' => 'active',
            'end_date' => time() - 3600,
            'product_id' => YOUR_PRODUCT_ID,
        ],
    ],
];
echo JWT::encode(\$payload, \$key);
"
```

Visit `https://your-site.com/premium-post/?token=<output>`.

**Expected:** Premium content is visible (within 1-day grace period).

### Test 2: Access denied beyond grace period (expired 2+ days ago)

Generate a token with an `end_date` ~2.3 days in the past:

```
wp eval "
require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/class-jwt.php';
use Automattic\Jetpack\Extensions\Premium_Content\JWT;

\$key = (new Automattic\Jetpack\Connection\Tokens())->get_access_token()->secret;
\$payload = [
    'blog_sub' => 'active',
    'subscriptions' => [
        YOUR_PRODUCT_ID => [
            'status' => 'active',
            'end_date' => time() - 200000,
            'product_id' => YOUR_PRODUCT_ID,
        ],
    ],
];
echo JWT::encode(\$payload, \$key);
"
```

Visit `https://your-site.com/premium-post/?token=<output>`.

**Expected:** Premium content is hidden / subscribe prompt shown (beyond grace period).

### Test 3: Active subscription still works

Generate a token with an `end_date` in the future:

```
wp eval "
require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/class-jwt.php';
use Automattic\Jetpack\Extensions\Premium_Content\JWT;

\$key = (new Automattic\Jetpack\Connection\Tokens())->get_access_token()->secret;
\$payload = [
    'blog_sub' => 'active',
    'subscriptions' => [
        YOUR_PRODUCT_ID => [
            'status' => 'active',
            'end_date' => time() + 3600,
            'product_id' => YOUR_PRODUCT_ID,
        ],
    ],
];
echo JWT::encode(\$payload, \$key);
"
```

Visit `https://your-site.com/premium-post/?token=<output>`.

**Expected:** Premium content is visible (active subscription, no change in behavior).
