### PR TITLE
Remove RTC is enabled check before registering the notices endpoint

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-16486-validate-that-the-modals-work-on-simple-sites-remove-check
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-16486-validate-that-the-modals-work-on-simple-sites-remove-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Removed the RTC enabled check before loading the notices endpoint

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/gutenberg-rtc-notices.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/gutenberg-rtc-notices.php
@@ -13,9 +13,6 @@ require_once __DIR__ . '/../../utils.php';
 add_action(
 	'rest_api_init',
 	function () {
-		if ( ! \Automattic\Jetpack\RTC::is_enabled() ) {
-			return;
-		}
 		require_once __DIR__ . '/class-wp-rest-rtc-notices.php';
 		( new WP_REST_RTC_Notices() )->register_routes();
 	},


### PR DESCRIPTION
Fixes:
- https://linear.app/a8c/issue/DOTCOM-16486/validate-that-the-modals-work-on-simple-sites

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Remove the RTC enabled check so that the endpoint can be registered on Simple sites.

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* No

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Apply to your sandbox.
* Make sure you have Gutenberg edge and wpcom feature stickers.
* Go to the editor with RTC enabled.
* Dismissing the welcome notice should work as expected.
