### PR TITLE
Social: Add quota enforcement selectors and disable X toggle when limit reached

### DIFF
--- a/projects/packages/publicize/_inc/components/connections-toggle-list/index.tsx
+++ b/projects/packages/publicize/_inc/components/connections-toggle-list/index.tsx
@@ -82,9 +82,9 @@ export function ConnectionsToggleList( {
 									{ connection.display_name }
 								</div>
 								{ disabledReason === 'quota_exceeded' && (
-									<div className={ styles[ 'disabled-reason' ] }>
-										{ __( 'X sharing limit reached', 'jetpack-publicize-pkg' ) }
-									</div>
+									<span className="description">
+										{ __( 'Sharing limit reached', 'jetpack-publicize-pkg' ) }
+									</span>
 								) }
 							</div>
 						</div>

--- a/projects/packages/publicize/_inc/components/connections-toggle-list/index.tsx
+++ b/projects/packages/publicize/_inc/components/connections-toggle-list/index.tsx
@@ -1,4 +1,4 @@
-import { Button, FormToggle, Tooltip } from '@wordpress/components';
+import { Button, FormToggle } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useCallback } from 'react';
@@ -50,7 +50,12 @@ export function ConnectionsToggleList( {
 
 				const ariaLabel = getA11yLabelForConnectionToggle( connection );
 
-				const toggleButton = (
+				const titleText =
+					disabledReason === 'quota_exceeded'
+						? __( 'Sharing limit reached', 'jetpack-publicize-pkg' )
+						: connection.display_name;
+
+				return (
 					<Button
 						key={ connection.connection_id }
 						role="switch"
@@ -67,6 +72,7 @@ export function ConnectionsToggleList( {
 						onClick={ onClickConnection( connection ) }
 						aria-label={ ariaLabel }
 						aria-checked={ isSelected }
+						title={ titleText }
 						className={ clsx( styles.item, getItemClassName?.( connection ) ) }
 					>
 						<div className={ styles[ 'connection-info' ] }>
@@ -77,22 +83,11 @@ export function ConnectionsToggleList( {
 								disabled={ isDisabled }
 								aria-label={ ariaLabel }
 							/>
-							<div className={ styles[ 'display-name' ] } title={ connection.display_name }>
+							<div className={ styles[ 'display-name' ] } title={ titleText }>
 								{ connection.display_name }
 							</div>
 						</div>
 					</Button>
-				);
-
-				return disabledReason === 'quota_exceeded' ? (
-					<Tooltip
-						key={ connection.connection_id }
-						text={ __( 'Sharing limit reached', 'jetpack-publicize-pkg' ) }
-					>
-						{ toggleButton }
-					</Tooltip>
-				) : (
-					toggleButton
 				);
 			} ) }
 		</div>

--- a/projects/packages/publicize/_inc/components/connections-toggle-list/index.tsx
+++ b/projects/packages/publicize/_inc/components/connections-toggle-list/index.tsx
@@ -1,4 +1,4 @@
-import { Button, FormToggle } from '@wordpress/components';
+import { Button, FormToggle, Tooltip } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useCallback } from 'react';
@@ -50,7 +50,7 @@ export function ConnectionsToggleList( {
 
 				const ariaLabel = getA11yLabelForConnectionToggle( connection );
 
-				return (
+				const toggleButton = (
 					<Button
 						key={ connection.connection_id }
 						role="switch"
@@ -77,18 +77,22 @@ export function ConnectionsToggleList( {
 								disabled={ isDisabled }
 								aria-label={ ariaLabel }
 							/>
-							<div>
-								<div className={ styles[ 'display-name' ] } title={ connection.display_name }>
-									{ connection.display_name }
-								</div>
-								{ disabledReason === 'quota_exceeded' && (
-									<span className="description">
-										{ __( 'Sharing limit reached', 'jetpack-publicize-pkg' ) }
-									</span>
-								) }
+							<div className={ styles[ 'display-name' ] } title={ connection.display_name }>
+								{ connection.display_name }
 							</div>
 						</div>
 					</Button>
+				);
+
+				return disabledReason === 'quota_exceeded' ? (
+					<Tooltip
+						key={ connection.connection_id }
+						text={ __( 'Sharing limit reached', 'jetpack-publicize-pkg' ) }
+					>
+						{ toggleButton }
+					</Tooltip>
+				) : (
+					toggleButton
 				);
 			} ) }
 		</div>

--- a/projects/packages/publicize/_inc/components/connections-toggle-list/index.tsx
+++ b/projects/packages/publicize/_inc/components/connections-toggle-list/index.tsx
@@ -26,7 +26,7 @@ export function ConnectionsToggleList( {
 	onClickItem,
 	getItemClassName,
 }: ConnectionsToggleListProps ) {
-	const { canBeTurnedOn, shouldBeDisabled } = useConnectionState();
+	const { canBeTurnedOn, shouldBeDisabled, getDisabledReason } = useConnectionState();
 	const { connections } = useSocialMediaConnections();
 
 	const onClickConnection = useCallback(
@@ -46,6 +46,7 @@ export function ConnectionsToggleList( {
 				const isSelected = Boolean( canBeTurnedOn( connection ) && connection.enabled );
 
 				const isDisabled = shouldBeDisabled( connection );
+				const disabledReason = getDisabledReason( connection );
 
 				const ariaLabel = getA11yLabelForConnectionToggle( connection );
 
@@ -76,8 +77,15 @@ export function ConnectionsToggleList( {
 								disabled={ isDisabled }
 								aria-label={ ariaLabel }
 							/>
-							<div className={ styles[ 'display-name' ] } title={ connection.display_name }>
-								{ connection.display_name }
+							<div>
+								<div className={ styles[ 'display-name' ] } title={ connection.display_name }>
+									{ connection.display_name }
+								</div>
+								{ disabledReason === 'quota_exceeded' && (
+									<div className={ styles[ 'disabled-reason' ] }>
+										{ __( 'X sharing limit reached', 'jetpack-publicize-pkg' ) }
+									</div>
+								) }
 							</div>
 						</div>
 					</Button>

--- a/projects/packages/publicize/_inc/components/connections-toggle-list/index.tsx
+++ b/projects/packages/publicize/_inc/components/connections-toggle-list/index.tsx
@@ -49,10 +49,12 @@ export function ConnectionsToggleList( {
 				const isQuotaBlocked = getDisabledReason( connection ) === 'quota_exceeded';
 
 				const ariaLabel = getA11yLabelForConnectionToggle( connection );
+				const quotaReachedLabel = __( 'Sharing limit reached', 'jetpack-publicize-pkg' );
 
 				const quotaTooltipProps = isQuotaBlocked
 					? {
-							description: __( 'Sharing limit reached', 'jetpack-publicize-pkg' ),
+							label: quotaReachedLabel,
+							description: quotaReachedLabel,
 							showTooltip: true,
 							accessibleWhenDisabled: true,
 					  }

--- a/projects/packages/publicize/_inc/components/connections-toggle-list/index.tsx
+++ b/projects/packages/publicize/_inc/components/connections-toggle-list/index.tsx
@@ -46,14 +46,17 @@ export function ConnectionsToggleList( {
 				const isSelected = Boolean( canBeTurnedOn( connection ) && connection.enabled );
 
 				const isDisabled = shouldBeDisabled( connection );
-				const disabledReason = getDisabledReason( connection );
+				const isQuotaBlocked = getDisabledReason( connection ) === 'quota_exceeded';
 
 				const ariaLabel = getA11yLabelForConnectionToggle( connection );
 
-				const titleText =
-					disabledReason === 'quota_exceeded'
-						? __( 'Sharing limit reached', 'jetpack-publicize-pkg' )
-						: connection.display_name;
+				const quotaTooltipProps = isQuotaBlocked
+					? {
+							description: __( 'Sharing limit reached', 'jetpack-publicize-pkg' ),
+							showTooltip: true,
+							accessibleWhenDisabled: true,
+					  }
+					: {};
 
 				return (
 					<Button
@@ -72,8 +75,8 @@ export function ConnectionsToggleList( {
 						onClick={ onClickConnection( connection ) }
 						aria-label={ ariaLabel }
 						aria-checked={ isSelected }
-						title={ titleText }
 						className={ clsx( styles.item, getItemClassName?.( connection ) ) }
+						{ ...quotaTooltipProps }
 					>
 						<div className={ styles[ 'connection-info' ] }>
 							<FormToggle
@@ -83,9 +86,7 @@ export function ConnectionsToggleList( {
 								disabled={ isDisabled }
 								aria-label={ ariaLabel }
 							/>
-							<div className={ styles[ 'display-name' ] } title={ titleText }>
-								{ connection.display_name }
-							</div>
+							<div className={ styles[ 'display-name' ] }>{ connection.display_name }</div>
 						</div>
 					</Button>
 				);

--- a/projects/packages/publicize/_inc/components/connections-toggle-list/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/connections-toggle-list/styles.module.scss
@@ -28,9 +28,4 @@
 		text-align: start;
 	}
 
-	.disabled-reason {
-		font-size: 0.75rem;
-		color: gb.$alert-red;
-		text-align: start;
-	}
 }

--- a/projects/packages/publicize/_inc/components/connections-toggle-list/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/connections-toggle-list/styles.module.scss
@@ -27,4 +27,10 @@
 		white-space: nowrap;
 		text-align: start;
 	}
+
+	.disabled-reason {
+		font-size: 0.75rem;
+		color: gb.$alert-red;
+		text-align: start;
+	}
 }

--- a/projects/packages/publicize/_inc/components/connections-toggle-list/test/index.test.tsx
+++ b/projects/packages/publicize/_inc/components/connections-toggle-list/test/index.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react';
+import { ConnectionsToggleList } from '..';
+import useSocialMediaConnections from '../../../hooks/use-social-media-connections';
+import { useConnectionState } from '../../form/use-connection-state';
+
+jest.mock( '../../../hooks/use-social-media-connections', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+jest.mock( '../../form/use-connection-state', () => ( {
+	useConnectionState: jest.fn(),
+} ) );
+
+const baseConnections = [
+	{
+		connection_id: 'x-1',
+		service_name: 'x',
+		display_name: 'X account',
+		profile_picture: '',
+		enabled: true,
+	},
+	{
+		connection_id: 'tumblr-1',
+		service_name: 'tumblr',
+		display_name: 'Tumblr account',
+		profile_picture: '',
+		enabled: true,
+	},
+];
+
+describe( 'ConnectionsToggleList', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		( useSocialMediaConnections as jest.Mock ).mockReturnValue( {
+			connections: baseConnections,
+		} );
+	} );
+
+	it( 'shows quota-reached accessible text and blocks checked state for quota-blocked X', () => {
+		( useConnectionState as jest.Mock ).mockReturnValue( {
+			canBeTurnedOn: ( connection: { service_name: string } ) => connection.service_name !== 'x',
+			shouldBeDisabled: ( connection: { service_name: string } ) => connection.service_name === 'x',
+			getDisabledReason: ( connection: { service_name: string } ) =>
+				connection.service_name === 'x' ? 'quota_exceeded' : undefined,
+		} );
+
+		render( <ConnectionsToggleList onClickItem={ jest.fn() } /> );
+
+		expect( screen.getByText( 'Sharing limit reached' ) ).toBeInTheDocument();
+
+		const [ xToggle ] = screen.getAllByRole( 'switch' );
+		expect( xToggle ).not.toBeChecked();
+		expect( xToggle ).toHaveAttribute( 'aria-disabled', 'true' );
+	} );
+
+	it( 'does not show quota-reached text when no connection is quota blocked', () => {
+		( useConnectionState as jest.Mock ).mockReturnValue( {
+			canBeTurnedOn: () => true,
+			shouldBeDisabled: () => false,
+			getDisabledReason: () => undefined,
+		} );
+
+		render( <ConnectionsToggleList onClickItem={ jest.fn() } /> );
+
+		expect( screen.queryByText( 'Sharing limit reached' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/publicize/_inc/components/form/test/use-connection-state.test.ts
+++ b/projects/packages/publicize/_inc/components/form/test/use-connection-state.test.ts
@@ -1,0 +1,127 @@
+jest.mock( '@wordpress/data', () => {
+	const actual = jest.requireActual( '@wordpress/data' );
+	const mocks = {
+		useSelect: jest.fn(),
+	};
+
+	return new Proxy( actual, {
+		get( target, property ) {
+			return mocks[ property as keyof typeof mocks ] ?? target[ property as keyof typeof target ];
+		},
+	} );
+} );
+
+import { renderHook } from '@testing-library/react';
+import { useSelect } from '@wordpress/data';
+import useAttachedMedia from '../../../hooks/use-attached-media';
+import useFeaturedImage from '../../../hooks/use-featured-image';
+import useMediaDetails from '../../../hooks/use-media-details';
+import useMediaRestrictions from '../../../hooks/use-media-restrictions';
+import usePublicizeConfig from '../../../hooks/use-publicize-config';
+import useSocialMediaConnections from '../../../hooks/use-social-media-connections';
+import { useConnectionState } from '../use-connection-state';
+import type { Connection } from '../../../social-store/types';
+
+jest.mock( '../../../hooks/use-social-media-connections', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+jest.mock( '../../../hooks/use-publicize-config', () => jest.fn() );
+jest.mock( '../../../hooks/use-attached-media', () => jest.fn() );
+jest.mock( '../../../hooks/use-featured-image', () => jest.fn() );
+jest.mock( '../../../hooks/use-media-details', () => jest.fn() );
+jest.mock( '../../../hooks/use-media-restrictions', () => jest.fn() );
+
+const mockUseSelect = useSelect as jest.Mock;
+
+const mockXConnection: Connection = {
+	connection_id: 'x-1',
+	display_name: 'X Account',
+	external_handle: '@x-user',
+	external_id: 'x-external',
+	profile_link: 'https://example.com/x',
+	profile_picture: '',
+	service_label: 'X',
+	service_name: 'x',
+	shared: false,
+	status: 'ok',
+	wpcom_user_id: 1,
+	enabled: true,
+};
+
+const mockTumblrConnection: Connection = {
+	connection_id: 'tumblr-1',
+	display_name: 'Tumblr Account',
+	external_handle: '@tumblr-user',
+	external_id: 'tumblr-external',
+	profile_link: 'https://example.com/tumblr',
+	profile_picture: '',
+	service_label: 'Tumblr',
+	service_name: 'tumblr',
+	shared: false,
+	status: 'ok',
+	wpcom_user_id: 1,
+	enabled: true,
+};
+
+describe( 'useConnectionState', () => {
+	let xQuotaExceeded = false;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		( useSocialMediaConnections as jest.Mock ).mockReturnValue( {
+			connections: [ mockXConnection, mockTumblrConnection ],
+		} );
+
+		( usePublicizeConfig as jest.Mock ).mockReturnValue( {
+			isPublicizeEnabled: true,
+			isPublicizeDisabledBySitePlan: false,
+		} );
+
+		( useAttachedMedia as jest.Mock ).mockReturnValue( { attachedMedia: [] } );
+		( useFeaturedImage as jest.Mock ).mockReturnValue( null );
+		( useMediaDetails as jest.Mock ).mockReturnValue( [ null ] );
+		( useMediaRestrictions as jest.Mock ).mockReturnValue( {
+			validationErrors: {},
+			isConvertible: true,
+		} );
+
+		mockUseSelect.mockImplementation( selector => {
+			return selector( () => ( {
+				isXQuotaExceeded: () => xQuotaExceeded,
+			} ) );
+		} );
+	} );
+
+	it( 'blocks X connections when quota is exceeded', () => {
+		xQuotaExceeded = true;
+
+		const { result } = renderHook( () => useConnectionState() );
+
+		expect( result.current.shouldBeDisabled( mockXConnection ) ).toBe( true );
+		expect( result.current.canBeTurnedOn( mockXConnection ) ).toBe( false );
+		expect( result.current.getDisabledReason( mockXConnection ) ).toBe( 'quota_exceeded' );
+	} );
+
+	it( 'does not block non-X connections when X quota is exceeded', () => {
+		xQuotaExceeded = true;
+
+		const { result } = renderHook( () => useConnectionState() );
+
+		expect( result.current.shouldBeDisabled( mockTumblrConnection ) ).toBe( false );
+		expect( result.current.canBeTurnedOn( mockTumblrConnection ) ).toBe( true );
+		expect( result.current.getDisabledReason( mockTumblrConnection ) ).toBeUndefined();
+	} );
+
+	it( 'does not block X connections when quota is available', () => {
+		xQuotaExceeded = false;
+
+		const { result } = renderHook( () => useConnectionState() );
+
+		expect( result.current.shouldBeDisabled( mockXConnection ) ).toBe( false );
+		expect( result.current.canBeTurnedOn( mockXConnection ) ).toBe( true );
+		expect( result.current.getDisabledReason( mockXConnection ) ).toBeUndefined();
+	} );
+} );

--- a/projects/packages/publicize/_inc/components/form/use-connection-state.ts
+++ b/projects/packages/publicize/_inc/components/form/use-connection-state.ts
@@ -100,7 +100,7 @@ export const useConnectionState = () => {
 	const getDisabledReason = useCallback(
 		( connection: Connection ) => {
 			if ( connection.service_name === 'x' && xQuotaExceeded ) {
-				return 'quota_exceeded' as const;
+				return 'quota_exceeded';
 			}
 			return undefined;
 		},

--- a/projects/packages/publicize/_inc/components/form/use-connection-state.ts
+++ b/projects/packages/publicize/_inc/components/form/use-connection-state.ts
@@ -1,3 +1,4 @@
+import { useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { useMemo } from 'react';
 import useAttachedMedia from '../../hooks/use-attached-media';
@@ -7,6 +8,7 @@ import useMediaRestrictions from '../../hooks/use-media-restrictions';
 import { NO_MEDIA_ERROR } from '../../hooks/use-media-restrictions/constants';
 import usePublicizeConfig from '../../hooks/use-publicize-config';
 import useSocialMediaConnections from '../../hooks/use-social-media-connections';
+import { store as socialStore } from '../../social-store';
 import { Connection } from '../../social-store/types';
 
 export const useConnectionState = () => {
@@ -20,6 +22,8 @@ export const useConnectionState = () => {
 		connections,
 		useMediaDetails( mediaId )[ 0 ]
 	);
+
+	const xQuotaExceeded = useSelect( select => select( socialStore ).isXQuotaExceeded(), [] );
 
 	/**
 	 * Returns whether a connection is in good shape.
@@ -62,10 +66,12 @@ export const useConnectionState = () => {
 				// Publicize is disabled
 				! isPublicizeEnabled ||
 				// or the connection is not in good shape
-				! isInGoodShape( connection )
+				! isInGoodShape( connection ) ||
+				// or X quota is exceeded for X connections
+				( connection.service_name === 'x' && xQuotaExceeded )
 			);
 		},
-		[ isInGoodShape, isPublicizeEnabled ]
+		[ isInGoodShape, isPublicizeEnabled, xQuotaExceeded ]
 	);
 
 	/**
@@ -83,17 +89,30 @@ export const useConnectionState = () => {
 				// Publicize is not disabled due to the current site plan
 				! isPublicizeDisabledBySitePlan &&
 				// and the connection is in good shape
-				isInGoodShape( connection )
+				isInGoodShape( connection ) &&
+				// and X quota is not exceeded for X connections
+				! ( connection.service_name === 'x' && xQuotaExceeded )
 			);
 		},
-		[ isInGoodShape, isPublicizeDisabledBySitePlan ]
+		[ isInGoodShape, isPublicizeDisabledBySitePlan, xQuotaExceeded ]
+	);
+
+	const getDisabledReason = useCallback(
+		( connection: Connection ) => {
+			if ( connection.service_name === 'x' && xQuotaExceeded ) {
+				return 'quota_exceeded' as const;
+			}
+			return undefined;
+		},
+		[ xQuotaExceeded ]
 	);
 
 	return useMemo(
 		() => ( {
 			shouldBeDisabled,
 			canBeTurnedOn,
+			getDisabledReason,
 		} ),
-		[ shouldBeDisabled, canBeTurnedOn ]
+		[ shouldBeDisabled, canBeTurnedOn, getDisabledReason ]
 	);
 };

--- a/projects/packages/publicize/_inc/components/form/use-connection-state.ts
+++ b/projects/packages/publicize/_inc/components/form/use-connection-state.ts
@@ -26,6 +26,14 @@ export const useConnectionState = () => {
 	const xQuotaExceeded = useSelect( select => select( socialStore ).isXQuotaExceeded(), [] );
 
 	/**
+	 * Returns whether the connection is blocked by the X sharing quota.
+	 */
+	const isXQuotaBlocked = useCallback(
+		( connection: Connection ) => connection.service_name === 'x' && xQuotaExceeded,
+		[ xQuotaExceeded ]
+	);
+
+	/**
 	 * Returns whether a connection is in good shape.
 	 *
 	 * A connection is in good shape if:
@@ -59,6 +67,7 @@ export const useConnectionState = () => {
 	 * - Publicize is disabled
 	 * - There are no more connections available
 	 * - The connection is not in good shape
+	 * - The connection is an X connection blocked by the sharing quota
 	 */
 	const shouldBeDisabled = useCallback(
 		( connection: Connection ) => {
@@ -68,10 +77,10 @@ export const useConnectionState = () => {
 				// or the connection is not in good shape
 				! isInGoodShape( connection ) ||
 				// or X quota is exceeded for X connections
-				( connection.service_name === 'x' && xQuotaExceeded )
+				isXQuotaBlocked( connection )
 			);
 		},
-		[ isInGoodShape, isPublicizeEnabled, xQuotaExceeded ]
+		[ isInGoodShape, isPublicizeEnabled, isXQuotaBlocked ]
 	);
 
 	/**
@@ -81,6 +90,7 @@ export const useConnectionState = () => {
 	 * A connection can be enabled if:
 	 * - Publicize is not disabled due to the current site plan
 	 * - The connection is in good shape
+	 * - The connection is not an X connection blocked by the sharing quota
 	 */
 	const canBeTurnedOn = useCallback(
 		( connection: Connection ) => {
@@ -91,20 +101,20 @@ export const useConnectionState = () => {
 				// and the connection is in good shape
 				isInGoodShape( connection ) &&
 				// and X quota is not exceeded for X connections
-				! ( connection.service_name === 'x' && xQuotaExceeded )
+				! isXQuotaBlocked( connection )
 			);
 		},
-		[ isInGoodShape, isPublicizeDisabledBySitePlan, xQuotaExceeded ]
+		[ isInGoodShape, isPublicizeDisabledBySitePlan, isXQuotaBlocked ]
 	);
 
 	const getDisabledReason = useCallback(
 		( connection: Connection ) => {
-			if ( connection.service_name === 'x' && xQuotaExceeded ) {
+			if ( isXQuotaBlocked( connection ) ) {
 				return 'quota_exceeded';
 			}
 			return undefined;
 		},
-		[ xQuotaExceeded ]
+		[ isXQuotaBlocked ]
 	);
 
 	return useMemo(

--- a/projects/packages/publicize/_inc/components/panel/description.tsx
+++ b/projects/packages/publicize/_inc/components/panel/description.tsx
@@ -13,7 +13,7 @@ import styles from './styles.module.scss';
  * @return The description component.
  */
 export function Description() {
-	const { hasEnabledConnections } = useSelectSocialMediaConnections();
+	const { hasConnectionsReadyToShare } = useSelectSocialMediaConnections();
 	const isPostPublished = useSelect( select => select( editorStore ).isCurrentPostPublished(), [] );
 
 	const { isPublicizeEnabled } = usePublicizeConfig();
@@ -29,7 +29,7 @@ export function Description() {
 						);
 					}
 
-					return isPublicizeEnabled && hasEnabledConnections
+					return isPublicizeEnabled && hasConnectionsReadyToShare
 						? __(
 								'When the post is published, it will be shared automatically on:',
 								'jetpack-publicize-pkg'

--- a/projects/packages/publicize/_inc/components/panel/test/description.test.tsx
+++ b/projects/packages/publicize/_inc/components/panel/test/description.test.tsx
@@ -1,0 +1,86 @@
+jest.mock( '@wordpress/data', () => {
+	const actual = jest.requireActual( '@wordpress/data' );
+	const mocks = {
+		useSelect: jest.fn(),
+	};
+
+	return new Proxy( actual, {
+		get( target, property ) {
+			return mocks[ property as keyof typeof mocks ] ?? target[ property as keyof typeof target ];
+		},
+	} );
+} );
+
+import { render, screen } from '@testing-library/react';
+import { useSelect } from '@wordpress/data';
+import usePublicizeConfig from '../../../hooks/use-publicize-config';
+import useSocialMediaConnections from '../../../hooks/use-social-media-connections';
+import { Description } from '../description';
+
+jest.mock( '../../../hooks/use-publicize-config', () => jest.fn() );
+jest.mock( '../../../hooks/use-social-media-connections', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+const mockUseSelect = useSelect as jest.Mock;
+
+describe( 'Description', () => {
+	let isPostPublished = false;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		mockUseSelect.mockImplementation( selector => {
+			return selector( () => ( {
+				isCurrentPostPublished: () => isPostPublished,
+			} ) );
+		} );
+
+		( usePublicizeConfig as jest.Mock ).mockReturnValue( {
+			isPublicizeEnabled: true,
+		} );
+
+		( useSocialMediaConnections as jest.Mock ).mockReturnValue( {
+			hasConnectionsReadyToShare: false,
+		} );
+	} );
+
+	it( 'shows automatic-sharing copy only when there are connections ready to share', () => {
+		( useSocialMediaConnections as jest.Mock ).mockReturnValue( {
+			hasConnectionsReadyToShare: true,
+		} );
+
+		render( <Description /> );
+
+		expect(
+			screen.getByText( 'When the post is published, it will be shared automatically on:' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'shows fallback copy when there are no connections ready to share', () => {
+		( useSocialMediaConnections as jest.Mock ).mockReturnValue( {
+			hasConnectionsReadyToShare: false,
+		} );
+
+		render( <Description /> );
+
+		expect(
+			screen.getByText(
+				'After the post is published, you can preview, and manually share or schedule it.'
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'shows post-published instructions when the post is published', () => {
+		isPostPublished = true;
+
+		render( <Description /> );
+
+		expect(
+			screen.getByText(
+				'Enable the social media accounts where you want to re-share your post, then click on the "Preview and Share" button below.'
+			)
+		).toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/publicize/_inc/components/post-publish-share-status/index.tsx
+++ b/projects/packages/publicize/_inc/components/post-publish-share-status/index.tsx
@@ -26,11 +26,12 @@ export function PostPublishShareStatus() {
 
 	const isSharingPossible = usePostPrePublishValue( useIsSharingPossible() );
 
-	const enabledConnections = usePostPrePublishValue(
-		useSelect( select => select( socialStore ).getEnabledConnections(), [] )
+	const connectionsReadyToShare = usePostPrePublishValue(
+		useSelect( select => select( socialStore ).getConnectionsReadyToShare(), [] )
 	);
 
-	const willPostBeShared = isPublicizeEnabled && enabledConnections.length > 0 && isSharingPossible;
+	const willPostBeShared =
+		isPublicizeEnabled && connectionsReadyToShare.length > 0 && isSharingPossible;
 
 	const showStatus = willPostBeShared && isPostPublished;
 

--- a/projects/packages/publicize/_inc/components/post-publish-share-status/test/index.test.tsx
+++ b/projects/packages/publicize/_inc/components/post-publish-share-status/test/index.test.tsx
@@ -1,0 +1,96 @@
+jest.mock( '@wordpress/data', () => {
+	const actual = jest.requireActual( '@wordpress/data' );
+	const mocks = {
+		useDispatch: jest.fn(),
+		useSelect: jest.fn(),
+	};
+
+	return new Proxy( actual, {
+		get( target, property ) {
+			return mocks[ property as keyof typeof mocks ] ?? target[ property as keyof typeof target ];
+		},
+	} );
+} );
+
+import { render, screen } from '@testing-library/react';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useIsSharingPossible } from '../../../hooks/use-is-sharing-possible';
+import { usePostMeta } from '../../../hooks/use-post-meta';
+import { usePostPrePublishValue } from '../../../hooks/use-post-pre-publish-value';
+import { usePostJustPublished } from '../../../hooks/use-saving-post';
+import { PostPublishShareStatus } from '../index';
+
+jest.mock( '../../../social-store', () => ( {
+	store: 'jetpack-social',
+} ) );
+
+jest.mock( '@wordpress/editor', () => ( {
+	store: 'core/editor',
+	PluginPostPublishPanel: ( { children } ) => (
+		<div data-testid="post-publish-panel">{ children }</div>
+	),
+} ) );
+
+jest.mock( '../../../hooks/use-is-sharing-possible', () => ( {
+	useIsSharingPossible: jest.fn(),
+} ) );
+
+jest.mock( '../../../hooks/use-post-meta', () => ( {
+	usePostMeta: jest.fn(),
+} ) );
+
+jest.mock( '../../../hooks/use-post-pre-publish-value', () => ( {
+	usePostPrePublishValue: jest.fn( value => value ),
+} ) );
+
+jest.mock( '../../../hooks/use-saving-post', () => ( {
+	usePostJustPublished: jest.fn(),
+} ) );
+
+jest.mock( '../share-status', () => ( {
+	ShareStatus: () => <div>Share status</div>,
+} ) );
+
+const mockUseDispatch = useDispatch as jest.Mock;
+const mockUseSelect = useSelect as jest.Mock;
+
+describe( 'PostPublishShareStatus', () => {
+	const isPostPublished = true;
+	let connectionsReadyToShare = [ { connection_id: '1' } ];
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		mockUseDispatch.mockReturnValue( {
+			pollForPostShareStatus: jest.fn(),
+		} );
+
+		mockUseSelect.mockImplementation( selector => {
+			return selector( () => ( {
+				isCurrentPostPublished: () => isPostPublished,
+				getConnectionsReadyToShare: () => connectionsReadyToShare,
+			} ) );
+		} );
+
+		( useIsSharingPossible as jest.Mock ).mockReturnValue( true );
+		( usePostMeta as jest.Mock ).mockReturnValue( { isPublicizeEnabled: true } );
+		( usePostPrePublishValue as jest.Mock ).mockImplementation( value => value );
+		( usePostJustPublished as jest.Mock ).mockImplementation( () => {} );
+	} );
+
+	it( 'renders share status when a post is published and connections are ready to share', () => {
+		render( <PostPublishShareStatus /> );
+
+		expect( screen.getByTestId( 'post-publish-panel' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Share status' ) ).toBeInTheDocument();
+	} );
+
+	it( 'does not render when no connections are ready to share', () => {
+		connectionsReadyToShare = [];
+
+		render( <PostPublishShareStatus /> );
+
+		expect( screen.queryByTestId( 'post-publish-panel' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Share status' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/publicize/_inc/components/unified-modal/social-post-preview/footer-content.tsx
+++ b/projects/packages/publicize/_inc/components/unified-modal/social-post-preview/footer-content.tsx
@@ -42,7 +42,7 @@ function ScheduledPostsNav() {
  * @return Footer info element.
  */
 function FooterInfo() {
-	const { enabledConnections } = useSocialMediaConnections();
+	const { connectionsReadyToShare } = useSocialMediaConnections();
 	const isCurrentPostPublished = useSelect(
 		select => select( editorStore ).isCurrentPostPublished(),
 		[]
@@ -50,17 +50,17 @@ function FooterInfo() {
 
 	return (
 		<>
-			{ enabledConnections.length ? (
+			{ connectionsReadyToShare.length ? (
 				<span>
 					{ sprintf(
-						/* translators: %d: Number of enabled connections. */
+						/* translators: %d: Number of connections ready to share to. */
 						_n(
 							'Ready to share to %d account.',
 							'Ready to share to %d accounts.',
-							enabledConnections.length,
+							connectionsReadyToShare.length,
 							'jetpack-publicize-pkg'
 						),
-						enabledConnections.length
+						connectionsReadyToShare.length
 					) }
 					&nbsp;
 				</span>

--- a/projects/packages/publicize/_inc/components/unified-modal/social-post-preview/test/footer-content.test.tsx
+++ b/projects/packages/publicize/_inc/components/unified-modal/social-post-preview/test/footer-content.test.tsx
@@ -1,0 +1,72 @@
+jest.mock( '@wordpress/data', () => {
+	const actual = jest.requireActual( '@wordpress/data' );
+	const mocks = {
+		useSelect: jest.fn(),
+	};
+
+	return new Proxy( actual, {
+		get( target, property ) {
+			return mocks[ property as keyof typeof mocks ] ?? target[ property as keyof typeof target ];
+		},
+	} );
+} );
+
+import { render, screen } from '@testing-library/react';
+import { useSelect } from '@wordpress/data';
+import useSocialMediaConnections from '../../../../hooks/use-social-media-connections';
+import { FooterContent } from '../footer-content';
+
+jest.mock( '../../../../social-store', () => ( {
+	store: 'jetpack-social',
+} ) );
+
+jest.mock( '@wordpress/editor', () => ( {
+	store: 'core/editor',
+} ) );
+
+jest.mock( '../../../../hooks/use-social-media-connections', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+jest.mock( '../confirmation-config', () => ( {
+	ConfirmationConfig: () => <div>Confirmation config</div>,
+} ) );
+
+const mockUseSelect = useSelect as jest.Mock;
+
+describe( 'FooterContent', () => {
+	const isCurrentPostPublished = false;
+	const isPublishSidebarOpened = false;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		mockUseSelect.mockImplementation( selector => {
+			return selector( () => ( {
+				isCurrentPostPublished: () => isCurrentPostPublished,
+				isPublishSidebarOpened: () => isPublishSidebarOpened,
+			} ) );
+		} );
+	} );
+
+	it( 'shows ready-to-share account count based on connectionsReadyToShare', () => {
+		( useSocialMediaConnections as jest.Mock ).mockReturnValue( {
+			connectionsReadyToShare: [ { connection_id: '1' }, { connection_id: '2' } ],
+		} );
+
+		render( <FooterContent /> );
+
+		expect( screen.getByText( 'Ready to share to 2 accounts.' ) ).toBeInTheDocument();
+	} );
+
+	it( 'does not show ready-to-share copy when no connections are ready', () => {
+		( useSocialMediaConnections as jest.Mock ).mockReturnValue( {
+			connectionsReadyToShare: [],
+		} );
+
+		render( <FooterContent /> );
+
+		expect( screen.queryByText( /Ready to share to/i ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/publicize/_inc/components/x-usage/constants.ts
+++ b/projects/packages/publicize/_inc/components/x-usage/constants.ts
@@ -1,3 +1,2 @@
-export const FREE_PLAN_LIMIT = 5;
-export const PAID_PLAN_LIMIT = 100;
+export { FREE_PLAN_LIMIT, PAID_PLAN_LIMIT } from '../../social-store/constants';
 export const WARNING_THRESHOLD = 0.8;

--- a/projects/packages/publicize/_inc/hooks/use-is-sharing-possible/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-is-sharing-possible/index.ts
@@ -10,18 +10,18 @@ import { store as socialStore } from '../../social-store';
 /**
  * Returns whether sharing is possible based on the current media and connections.
  *
- * Returns true if at least one of the enabled connections is valid for sharing, false otherwise.
+ * Returns true if at least one ready-to-share connection is valid for sharing, false otherwise.
  *
  * @return {boolean} Whether sharing is possible.
  */
 export function useIsSharingPossible() {
-	const { enabledConnections } = useSocialMediaConnections();
+	const { connectionsReadyToShare } = useSocialMediaConnections();
 	const { attachedMedia } = useAttachedMedia();
 	const featuredImageId = useFeaturedImage();
 
 	const mediaId = attachedMedia[ 0 ]?.id || featuredImageId;
 	const { validationErrors, isConvertible } = useMediaRestrictions(
-		enabledConnections,
+		connectionsReadyToShare,
 		useMediaDetails( mediaId )[ 0 ]
 	);
 
@@ -31,8 +31,11 @@ export function useIsSharingPossible() {
 			.map( c => c.connection_id );
 	}, [] );
 
-	// Sharing will be possible if any of the enabled connections are valid for sharing.
-	return enabledConnections.some( function isValidForSharing( { connection_id, service_name } ) {
+	// Sharing will be possible if any ready-to-share connections are valid for sharing.
+	return connectionsReadyToShare.some( function isValidForSharing( {
+		connection_id,
+		service_name,
+	} ) {
 		// Return early if the connection is broken
 		if ( brokenConnectionIds.includes( connection_id ) ) {
 			return false;

--- a/projects/packages/publicize/_inc/hooks/use-schedule-post/index.tsx
+++ b/projects/packages/publicize/_inc/hooks/use-schedule-post/index.tsx
@@ -21,7 +21,7 @@ type SchedulePostOptions = {
 export function useSchedulePost() {
 	const { scheduleShares, openUnifiedModal } = useDispatch( socialStore );
 	const { message } = useSocialMediaMessage();
-	const { enabledConnections } = useSocialMediaConnections();
+	const { connectionsReadyToShare } = useSocialMediaConnections();
 	const navigator = useNavigator();
 
 	const openSharingActivity = useCallback( () => {
@@ -37,7 +37,7 @@ export function useSchedulePost() {
 
 	return useCallback(
 		async ( { timestamp }: SchedulePostOptions ) => {
-			const connectionIds = enabledConnections.map( connection =>
+			const connectionIds = connectionsReadyToShare.map( connection =>
 				Number( connection.connection_id )
 			);
 
@@ -61,6 +61,6 @@ export function useSchedulePost() {
 
 			return await scheduleShares( { connectionIds, message, timestamp }, { savePost, actions } );
 		},
-		[ enabledConnections, message, openSharingActivity, scheduleShares ]
+		[ connectionsReadyToShare, message, openSharingActivity, scheduleShares ]
 	);
 }

--- a/projects/packages/publicize/_inc/hooks/use-social-media-connections/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-social-media-connections/index.ts
@@ -15,9 +15,11 @@ export default function useSocialMediaConnections() {
 		const connections = store.getConnections();
 		const enabledConnections = store.getEnabledConnections();
 		const disabledConnections = store.getDisabledConnections();
+		const connectionsReadyToShare = store.getConnectionsReadyToShare();
 
 		const hasConnections = connections.length > 0;
 		const hasEnabledConnections = enabledConnections.length > 0;
+		const hasConnectionsReadyToShare = connectionsReadyToShare.length > 0;
 
 		return {
 			connections,
@@ -25,6 +27,8 @@ export default function useSocialMediaConnections() {
 			hasEnabledConnections,
 			disabledConnections,
 			enabledConnections,
+			connectionsReadyToShare,
+			hasConnectionsReadyToShare,
 		};
 	}, [] );
 

--- a/projects/packages/publicize/_inc/hooks/use-social-media-connections/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-social-media-connections/index.ts
@@ -32,10 +32,15 @@ export default function useSocialMediaConnections() {
 		};
 	}, [] );
 
-	const skippedConnections = useMemo(
-		() => connectionsData.disabledConnections.map( connection => connection.connection_id ),
-		[ connectionsData.disabledConnections ]
-	);
+	const skippedConnections = useMemo( () => {
+		const readyConnectionIds = connectionsData.connectionsReadyToShare.map(
+			connection => connection.connection_id
+		);
+
+		return connectionsData.connections
+			.filter( connection => ! readyConnectionIds.includes( connection.connection_id ) )
+			.map( connection => connection.connection_id );
+	}, [ connectionsData.connections, connectionsData.connectionsReadyToShare ] );
 
 	return useMemo(
 		() => ( {

--- a/projects/packages/publicize/_inc/social-store/constants.ts
+++ b/projects/packages/publicize/_inc/social-store/constants.ts
@@ -7,6 +7,10 @@ export const SHOW_PRICING_PAGE_KEY = 'jetpack-social_show_pricing_page';
 
 export const CUSTOMIZE_PER_NETWORK_KEY = '_wpas_customize_per_network';
 
+// X usage quota limits
+export const FREE_PLAN_LIMIT = 5;
+export const PAID_PLAN_LIMIT = 100;
+
 /**
  * This is to avoid creating a new empty array each time.
  *

--- a/projects/packages/publicize/_inc/social-store/selectors/connection-data.ts
+++ b/projects/packages/publicize/_inc/social-store/selectors/connection-data.ts
@@ -3,6 +3,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { createRegistrySelector, createSelector } from '@wordpress/data';
 import { REQUEST_TYPE_DEFAULT } from '../actions/constants';
 import { EMPTY_ARRAY } from '../constants';
+import { canShareToX } from './x-usage';
 import type { Connection, ConnectionData, SocialStoreState } from '../types';
 
 /**
@@ -115,6 +116,28 @@ export const getEnabledConnections = createSelector(
 	},
 	( state: SocialStoreState ) => [ state.connectionData?.connections ]
 );
+
+/**
+ * Returns the connections that are both enabled and allowed to be shared to.
+ *
+ * This excludes connections that the user has toggled on but cannot actually
+ * be used for sharing — currently, X connections when the sharing quota is
+ * exceeded. Use this for "will be shared" UI surfaces; use
+ * `getEnabledConnections` for user-intent state (e.g. post meta sync).
+ *
+ * @param state - State object.
+ *
+ * @return List of connections ready to share.
+ */
+export function getConnectionsReadyToShare( state: SocialStoreState ): Array< Connection > {
+	const enabled = getEnabledConnections( state );
+
+	if ( canShareToX( state ) ) {
+		return enabled;
+	}
+
+	return enabled.filter( connection => connection.service_name !== 'x' );
+}
 
 /**
  * Returns the Publicize connections that are disabled.

--- a/projects/packages/publicize/_inc/social-store/selectors/test/connection-data.test.js
+++ b/projects/packages/publicize/_inc/social-store/selectors/test/connection-data.test.js
@@ -1,3 +1,8 @@
+let mockCanShareToX = true;
+jest.mock( '../x-usage', () => ( {
+	canShareToX: () => mockCanShareToX,
+} ) );
+
 import {
 	getConnections,
 	hasConnections,
@@ -5,6 +10,7 @@ import {
 	getMustReauthConnections,
 	getEnabledConnections,
 	getDisabledConnections,
+	getConnectionsReadyToShare,
 } from '../connection-data';
 
 const state = {
@@ -115,6 +121,90 @@ describe( 'Social store selectors: connectionData', () => {
 			expect( disabledConnections ).toEqual( [
 				state.connectionData.connections[ 0 ],
 				state.connectionData.connections[ 2 ],
+			] );
+		} );
+	} );
+
+	describe( 'getConnectionsReadyToShare', () => {
+		const readyState = {
+			connectionData: {
+				connections: [
+					{
+						service_name: 'x',
+						display_name: 'X account',
+						profile_picture: '',
+						external_handle: 'handle',
+						enabled: true,
+						connection_id: 'x-1',
+						status: 'ok',
+					},
+					{
+						service_name: 'tumblr',
+						display_name: 'Tumblr account',
+						profile_picture: '',
+						external_handle: 'handle',
+						enabled: true,
+						connection_id: 'tumblr-1',
+						status: 'ok',
+					},
+					{
+						service_name: 'mastodon',
+						display_name: 'Mastodon account',
+						profile_picture: '',
+						external_handle: '@handle@mastodon.social',
+						enabled: false,
+						connection_id: 'mastodon-1',
+						status: 'ok',
+					},
+				],
+			},
+		};
+
+		afterEach( () => {
+			mockCanShareToX = true;
+		} );
+
+		it( 'should return empty array if no connections', () => {
+			expect( getConnectionsReadyToShare( {} ) ).toEqual( [] );
+		} );
+
+		it( 'should return all enabled connections when X quota is available', () => {
+			mockCanShareToX = true;
+			const ready = getConnectionsReadyToShare( readyState );
+			expect( ready ).toEqual( [
+				readyState.connectionData.connections[ 0 ],
+				readyState.connectionData.connections[ 1 ],
+			] );
+		} );
+
+		it( 'should exclude X connections when X quota is exceeded', () => {
+			mockCanShareToX = false;
+			const ready = getConnectionsReadyToShare( readyState );
+			expect( ready ).toEqual( [ readyState.connectionData.connections[ 1 ] ] );
+		} );
+
+		it( 'should return an empty array when only X is enabled and quota is exceeded', () => {
+			mockCanShareToX = false;
+			const onlyXState = {
+				connectionData: {
+					connections: [ readyState.connectionData.connections[ 0 ] ],
+				},
+			};
+			expect( getConnectionsReadyToShare( onlyXState ) ).toEqual( [] );
+		} );
+
+		it( 'should not affect non-X connections when X quota is exceeded', () => {
+			mockCanShareToX = false;
+			const noXState = {
+				connectionData: {
+					connections: [
+						readyState.connectionData.connections[ 1 ],
+						readyState.connectionData.connections[ 2 ],
+					],
+				},
+			};
+			expect( getConnectionsReadyToShare( noXState ) ).toEqual( [
+				readyState.connectionData.connections[ 1 ],
 			] );
 		} );
 	} );

--- a/projects/packages/publicize/_inc/social-store/selectors/test/x-usage.test.ts
+++ b/projects/packages/publicize/_inc/social-store/selectors/test/x-usage.test.ts
@@ -1,0 +1,172 @@
+// Mock hasSocialPaidFeatures
+let mockHasPaidFeatures = false;
+jest.mock( '../../../utils/script-data', () => ( {
+	hasSocialPaidFeatures: () => mockHasPaidFeatures,
+} ) );
+
+// Mock getCurrentPeriod
+jest.mock( '../../../components/x-usage/utils', () => ( {
+	getCurrentPeriod: () => '2026-03',
+} ) );
+
+// Mock the registry selectors — getXUsage returns configurable data
+let mockUsageData: Array< { period: string; used: number; pending: number; total: number } > = [];
+jest.mock( '@wordpress/core-data', () => ( {} ) );
+jest.mock( '@wordpress/data', () => ( {
+	createRegistrySelector: () => () => mockUsageData,
+} ) );
+
+import { isXQuotaExceeded, canShareToX, getXQuotaRemaining, getXUsageFor } from '../x-usage';
+
+describe( 'Social store selectors: x-usage enforcement', () => {
+	beforeEach( () => {
+		mockHasPaidFeatures = false;
+		mockUsageData = [];
+	} );
+
+	describe( 'isXQuotaExceeded', () => {
+		describe( 'free plan', () => {
+			it( 'should return true when at limit (5)', () => {
+				mockUsageData = [ { period: 'free', used: 4, pending: 1, total: 5 } ];
+				expect( isXQuotaExceeded( {} ) ).toBe( true );
+			} );
+
+			it( 'should return true when over limit (6)', () => {
+				mockUsageData = [ { period: 'free', used: 5, pending: 1, total: 6 } ];
+				expect( isXQuotaExceeded( {} ) ).toBe( true );
+			} );
+
+			it( 'should return false when under limit (3)', () => {
+				mockUsageData = [ { period: 'free', used: 2, pending: 1, total: 3 } ];
+				expect( isXQuotaExceeded( {} ) ).toBe( false );
+			} );
+
+			it( 'should return false when no data', () => {
+				expect( isXQuotaExceeded( {} ) ).toBe( false );
+			} );
+
+			it( 'should use "free" period by default', () => {
+				mockUsageData = [
+					{ period: 'free', used: 4, pending: 1, total: 5 },
+					{ period: '2026-03', used: 0, pending: 0, total: 0 },
+				];
+				expect( isXQuotaExceeded( {} ) ).toBe( true );
+			} );
+		} );
+
+		describe( 'paid plan', () => {
+			beforeEach( () => {
+				mockHasPaidFeatures = true;
+			} );
+
+			it( 'should return true when at limit (100)', () => {
+				mockUsageData = [ { period: '2026-03', used: 90, pending: 10, total: 100 } ];
+				expect( isXQuotaExceeded( {} ) ).toBe( true );
+			} );
+
+			it( 'should return true when over limit', () => {
+				mockUsageData = [ { period: '2026-03', used: 100, pending: 5, total: 105 } ];
+				expect( isXQuotaExceeded( {} ) ).toBe( true );
+			} );
+
+			it( 'should return false when under limit', () => {
+				mockUsageData = [ { period: '2026-03', used: 40, pending: 10, total: 50 } ];
+				expect( isXQuotaExceeded( {} ) ).toBe( false );
+			} );
+
+			it( 'should return false when no data', () => {
+				expect( isXQuotaExceeded( {} ) ).toBe( false );
+			} );
+
+			it( 'should use current period by default', () => {
+				mockUsageData = [
+					{ period: 'free', used: 4, pending: 1, total: 5 },
+					{ period: '2026-03', used: 90, pending: 10, total: 100 },
+				];
+				expect( isXQuotaExceeded( {} ) ).toBe( true );
+			} );
+		} );
+
+		it( 'should accept an explicit period parameter', () => {
+			mockUsageData = [
+				{ period: '2026-01', used: 4, pending: 1, total: 5 },
+				{ period: '2026-02', used: 1, pending: 0, total: 1 },
+			];
+			expect( isXQuotaExceeded( {}, '2026-01' ) ).toBe( true );
+			expect( isXQuotaExceeded( {}, '2026-02' ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'canShareToX', () => {
+		it( 'should return true when under limit', () => {
+			mockUsageData = [ { period: 'free', used: 2, pending: 1, total: 3 } ];
+			expect( canShareToX( {} ) ).toBe( true );
+		} );
+
+		it( 'should return false when at limit', () => {
+			mockUsageData = [ { period: 'free', used: 4, pending: 1, total: 5 } ];
+			expect( canShareToX( {} ) ).toBe( false );
+		} );
+
+		it( 'should return false when over limit', () => {
+			mockUsageData = [ { period: 'free', used: 5, pending: 1, total: 6 } ];
+			expect( canShareToX( {} ) ).toBe( false );
+		} );
+
+		it( 'should return true when data is missing (defaults to allowing)', () => {
+			expect( canShareToX( {} ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'getXQuotaRemaining', () => {
+		it( 'should return correct remaining for free plan', () => {
+			mockUsageData = [ { period: 'free', used: 2, pending: 1, total: 3 } ];
+			expect( getXQuotaRemaining( {} ) ).toBe( 2 );
+		} );
+
+		it( 'should return correct remaining for paid plan', () => {
+			mockHasPaidFeatures = true;
+			mockUsageData = [ { period: '2026-03', used: 40, pending: 10, total: 50 } ];
+			expect( getXQuotaRemaining( {} ) ).toBe( 50 );
+		} );
+
+		it( 'should never return negative', () => {
+			mockUsageData = [ { period: 'free', used: 5, pending: 1, total: 6 } ];
+			expect( getXQuotaRemaining( {} ) ).toBe( 0 );
+		} );
+
+		it( 'should return full limit when no data (free plan)', () => {
+			expect( getXQuotaRemaining( {} ) ).toBe( 5 );
+		} );
+
+		it( 'should return full limit when no data (paid plan)', () => {
+			mockHasPaidFeatures = true;
+			expect( getXQuotaRemaining( {} ) ).toBe( 100 );
+		} );
+
+		it( 'should accept an explicit period parameter', () => {
+			mockUsageData = [ { period: '2026-01', used: 3, pending: 0, total: 3 } ];
+			expect( getXQuotaRemaining( {}, '2026-01' ) ).toBe( 2 );
+		} );
+	} );
+
+	describe( 'getXUsageFor', () => {
+		it( 'should return the usage item for the given period', () => {
+			mockUsageData = [
+				{ period: 'free', used: 3, pending: 0, total: 3 },
+				{ period: '2026-03', used: 10, pending: 5, total: 15 },
+			];
+			expect( getXUsageFor( {}, 'free' ) ).toEqual( {
+				period: 'free',
+				used: 3,
+				pending: 0,
+				total: 3,
+			} );
+		} );
+
+		it( 'should return undefined when no matching period', () => {
+			mockUsageData = [ { period: 'free', used: 3, pending: 0, total: 3 } ];
+			expect( getXUsageFor( {}, 'nonexistent' ) ).toBeUndefined();
+		} );
+	} );
+} );

--- a/projects/packages/publicize/_inc/social-store/selectors/x-usage.ts
+++ b/projects/packages/publicize/_inc/social-store/selectors/x-usage.ts
@@ -1,6 +1,8 @@
 import { store as coreStore } from '@wordpress/core-data';
 import { createRegistrySelector } from '@wordpress/data';
-import { EMPTY_ARRAY } from '../constants';
+import { getCurrentPeriod } from '../../components/x-usage/utils';
+import { hasSocialPaidFeatures } from '../../utils/script-data';
+import { EMPTY_ARRAY, FREE_PLAN_LIMIT, PAID_PLAN_LIMIT } from '../constants';
 
 export type XUsageItem = {
 	period: string;
@@ -43,3 +45,66 @@ export const isFetchingXUsage = createRegistrySelector( select => (): boolean =>
 
 	return isResolving( 'getEntityRecords', [ 'wpcom/v2', 'publicize/x-usage' ] );
 } );
+
+/**
+ * Returns the quota limit for the current plan.
+ *
+ * @return The quota limit.
+ */
+function getQuotaLimit() {
+	return hasSocialPaidFeatures() ? PAID_PLAN_LIMIT : FREE_PLAN_LIMIT;
+}
+
+/**
+ * Returns the default period based on plan type.
+ *
+ * @return The default period identifier.
+ */
+function getDefaultPeriod() {
+	return hasSocialPaidFeatures() ? getCurrentPeriod() : 'free';
+}
+
+/**
+ * Returns whether the X sharing quota has been exceeded.
+ *
+ * @param state  - State object.
+ * @param period - The period identifier. Defaults based on plan type.
+ *
+ * @return Whether the quota is exceeded. Defaults to false when data is missing.
+ */
+export function isXQuotaExceeded( state: object, period?: string ): boolean {
+	const resolvedPeriod = period ?? getDefaultPeriod();
+	const usageItem = getXUsageFor( state, resolvedPeriod );
+
+	if ( ! usageItem ) {
+		return false;
+	}
+
+	return usageItem.total >= getQuotaLimit();
+}
+
+/**
+ * Returns whether the user can share to X.
+ *
+ * @param state - State object.
+ *
+ * @return Whether sharing to X is allowed. Defaults to true when data is missing.
+ */
+export function canShareToX( state: object ): boolean {
+	return ! isXQuotaExceeded( state );
+}
+
+/**
+ * Returns the number of remaining X shares for the current period.
+ *
+ * @param state  - State object.
+ * @param period - The period identifier. Defaults based on plan type.
+ *
+ * @return The number of remaining shares, never negative.
+ */
+export function getXQuotaRemaining( state: object, period?: string ): number {
+	const resolvedPeriod = period ?? getDefaultPeriod();
+	const usageItem = getXUsageFor( state, resolvedPeriod );
+
+	return Math.max( 0, getQuotaLimit() - ( usageItem?.total ?? 0 ) );
+}

--- a/projects/packages/publicize/changelog/social-418-add-quota-enforcement-selectors-to-social-store
+++ b/projects/packages/publicize/changelog/social-418-add-quota-enforcement-selectors-to-social-store
@@ -1,4 +1,5 @@
-Significance: minor
-Type: added
+Significance: patch
+Type: changed
+Comment: Add quota enforcement selectors to the social store and disable X toggle when sharing limit is reached.
 
-Social: Add quota enforcement selectors and disable X toggle when sharing limit is reached.
+

--- a/projects/packages/publicize/changelog/social-418-add-quota-enforcement-selectors-to-social-store
+++ b/projects/packages/publicize/changelog/social-418-add-quota-enforcement-selectors-to-social-store
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Social: Add quota enforcement selectors and disable X toggle when sharing limit is reached.


### PR DESCRIPTION
Fixes SOCIAL-418
Fixes SOCIAL-416

## Proposed changes

* Add three quota enforcement selectors to the social store: `isXQuotaExceeded`, `canShareToX`, and `getXQuotaRemaining` — enabling any component to make quota-aware decisions without duplicating logic.
* Move `FREE_PLAN_LIMIT` and `PAID_PLAN_LIMIT` constants from the component level to the social store, re-exporting from the original location for backward compatibility.
* Update `useConnectionState()` hook to disable X connection toggles and prevent them from being turned on when the sharing quota is exceeded.
* Show inline "X sharing limit reached" text below disabled X toggles in the `ConnectionsToggleList` component.
* Add comprehensive unit tests for all new selectors covering free/paid plans, at/over/under limits, missing data defaults, and explicit period parameters.

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
None

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Open a WordPress site with the Social plugin or Jetpack plugin active and an X connection configured.
* Create or edit a post and open the editor sidebar — verify the X connection toggle appears.
* **Under quota**: Confirm the X toggle works normally (can be toggled on/off).
* **At/over quota** ([see how to simulate in the docs](https://linear.app/a8c/document/development-and-testing-233742b93b35)): Confirm the X toggle is disabled and shows "X sharing limit reached" text below the connection name.
* Verify non-X connections (e.g., Tumblr, Mastodon) are unaffected by the quota check.

<img width="284" height="200" alt="image" src="https://github.com/user-attachments/assets/e8f70bc4-c04d-444c-bbe7-eeddcc9344d3" />

