### PR TITLE
Newsletter settings - fix fatal on disconnected jetpack

### DIFF
--- a/projects/packages/newsletter/changelog/fix-newsletter-fatal-on-disconnected-jetpack
+++ b/projects/packages/newsletter/changelog/fix-newsletter-fatal-on-disconnected-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+avoid fatals from newsletter settings for disconnected jetpack errors

--- a/projects/packages/newsletter/src/class-settings.php
+++ b/projects/packages/newsletter/src/class-settings.php
@@ -300,8 +300,8 @@ class Settings {
 		}
 
 		// For Jetpack sites, use the jetpack.com redirect URL.
-		$site_id = $blog_id ? (int) $blog_id : Connection_Manager::get_site_id();
-		$args    = ( ! is_wp_error( $site_id ) && ! empty( $site_id ) )
+		$site_id = $blog_id ? (int) $blog_id : Connection_Manager::get_site_id( true );
+		$args    = ( ! empty( $site_id ) )
 			? array( 'site' => $site_id )
 			: array();
 

--- a/projects/packages/newsletter/src/class-settings.php
+++ b/projects/packages/newsletter/src/class-settings.php
@@ -300,10 +300,14 @@ class Settings {
 		}
 
 		// For Jetpack sites, use the jetpack.com redirect URL.
-		$site_id = $blog_id ? $blog_id : Connection_Manager::get_site_id();
+		$site_id = $blog_id ? (int) $blog_id : Connection_Manager::get_site_id();
+		$args    = ( ! is_wp_error( $site_id ) && ! empty( $site_id ) )
+			? array( 'site' => $site_id )
+			: array();
+
 		return Redirect::get_url(
 			'jetpack-settings-jetpack-manage-subscribers',
-			array( 'site' => $site_id )
+			$args
 		);
 	}
 


### PR DESCRIPTION
Fixes # https://linear.app/a8c/issue/NL-550/find-27-newsletter-settings-fatal-error-on-disconnected-jetpack-sites

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Prevents a fatal error by preventing passing WP_Error as an arg in the get_url call here. Previously with broken connections, this page would fatal due to this.

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

To Repro existing issue:
* Run local jetpack docker setup with `add_filter( 'jetpack_wp_admin_newsletter_settings_enabled', '__return_true' );` added in a mu-plugin (such as debug.php).
* visit `/wp-admin/admin.php?page=jetpack-newsletter` and ensure it loads (Proof of concept message).
* go to plugins, enable debug plugin, enabled broken tokens module
* under broken tokens section, near the bottom, click "clear blog id"
* after the success message for breaking jetpack, revisit `/wp-admin/admin.php?page=jetpack-newsletter` and confirm there is the fatal error displayed.

Test this fix:
* Apply the build from this diff.
* Visit the `/wp-admin/admin.php?page=jetpack-newsletter` page and verify the error is gone. (assuming you did the above in "repro" instructions, if not be sure to use the debug plugin to break the clear the blog id as described)
