### PR TITLE
Forms: Bundle admin-ui base CSS in wp-build output

### DIFF
--- a/projects/packages/forms/changelog/add-forms-admin-ui-css
+++ b/projects/packages/forms/changelog/add-forms-admin-ui-css
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Bundle admin-ui base CSS in wp-build output so host applications don't need to load it separately.

--- a/projects/packages/forms/routes/shared.scss
+++ b/projects/packages/forms/routes/shared.scss
@@ -1,4 +1,5 @@
 @use "sass:meta";
+@include meta.load-css("@wordpress/admin-ui/build-style/style.css");
 @include meta.load-css("@wordpress/dataviews/build-style/style.css");
 
 .jp-forms-dataviews__view-actions {


### PR DESCRIPTION
## Summary

The Forms dashboard routes use `Page` and `Breadcrumbs` components from `@wordpress/admin-ui`, but the base layout CSS (flexbox column layout, sticky header, content overflow, breadcrumb list styles) was not included in the wp-build output.

This meant host applications embedding the Forms wp-build dashboard had to load `@wordpress/admin-ui/build-style/style.css` separately, which risks version mismatch between the JS components (bundled) and CSS (loaded externally).

**Fix:** Add the admin-ui CSS import to `shared.scss` alongside the existing DataViews CSS import, so wp-build bundles it into the content modules — same pattern already used for `@wordpress/dataviews`.

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

1. Build the Forms wp-build: `pnpm run -C projects/packages/forms build:wp-build`
2. Check that `build/routes/forms/content.js` includes admin-ui page layout styles (search for `flex-flow:column` or `.admin-ui-page`)
3. Verify the Forms dashboard renders correctly with proper page layout

🤖 Generated with [Claude Code](https://claude.ai/code)