### PR TITLE
phpunit-select-config: add passthru support for auto_prepend_file

### DIFF
--- a/projects/packages/phpunit-select-config/bin/phpunit-select-config.php
+++ b/projects/packages/phpunit-select-config/bin/phpunit-select-config.php
@@ -47,6 +47,12 @@ foreach ( array( 'pcov', 'xdebug' ) as $ext ) {
 	}
 }
 
+// Pass through auto_prepend_file if set
+$prepend = ini_get( 'auto_prepend_file' );
+if ( $prepend ) {
+	array_unshift( $argv, '-dauto_prepend_file=' . $prepend );
+}
+
 // Assume phpdbg is being run with -qrr.
 if ( 'phpdbg' === php_sapi_name() ) {
 	array_unshift( $argv, '-qrr' );

--- a/projects/packages/phpunit-select-config/changelog/add-phpunit-select-config-support_prepend
+++ b/projects/packages/phpunit-select-config/changelog/add-phpunit-select-config-support_prepend
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add passthru support for auto_prepend_file.

--- a/projects/packages/phpunit-select-config/tests/BinTest.php
+++ b/projects/packages/phpunit-select-config/tests/BinTest.php
@@ -245,7 +245,13 @@ class BinTest extends TestCase {
 	}
 
 	public function testPrependFileRun() {
-		\Patchwork\redefine( 'ini_get', \Patchwork\always( '/path/to/prepend.php' ) );
+		\Patchwork\redefine(
+			'ini_get',
+			function ( $option ) {
+				$this->assertSame( 'auto_prepend_file', $option );
+				return '/path/to/prepend.php';
+			}
+		);
 
 		$this->doSuccessfulRun(
 			array( 'xxx', 'test#.xml' ),

--- a/projects/packages/phpunit-select-config/tests/BinTest.php
+++ b/projects/packages/phpunit-select-config/tests/BinTest.php
@@ -244,6 +244,33 @@ class BinTest extends TestCase {
 		);
 	}
 
+	public function testPrependFileRun() {
+		\Patchwork\redefine( 'ini_get', \Patchwork\always( '/path/to/prepend.php' ) );
+
+		$this->doSuccessfulRun(
+			array( 'xxx', 'test#.xml' ),
+			array(
+				'-dauto_prepend_file=/path/to/prepend.php',
+				__DIR__ . '/../vendor/bin/phpunit',
+				'--configuration',
+				'test' . explode( '.', \PHPUnit\Runner\Version::id() )[0] . '.xml',
+			)
+		);
+	}
+
+	public function testNoPrependFileRun() {
+		\Patchwork\redefine( 'ini_get', \Patchwork\always( false ) );
+
+		$this->doSuccessfulRun(
+			array( 'xxx', 'test#.xml' ),
+			array(
+				__DIR__ . '/../vendor/bin/phpunit',
+				'--configuration',
+				'test' . explode( '.', \PHPUnit\Runner\Version::id() )[0] . '.xml',
+			)
+		);
+	}
+
 	public function testFailedExec() {
 		$GLOBALS['_composer_autoload_path'] = __DIR__ . '/../vendor/autoload.php';
 		$GLOBALS['_composer_bin_dir']       = __DIR__ . '/../vendor/bin';

--- a/projects/packages/phpunit-select-config/tests/BinTest.php
+++ b/projects/packages/phpunit-select-config/tests/BinTest.php
@@ -258,19 +258,6 @@ class BinTest extends TestCase {
 		);
 	}
 
-	public function testNoPrependFileRun() {
-		\Patchwork\redefine( 'ini_get', \Patchwork\always( false ) );
-
-		$this->doSuccessfulRun(
-			array( 'xxx', 'test#.xml' ),
-			array(
-				__DIR__ . '/../vendor/bin/phpunit',
-				'--configuration',
-				'test' . explode( '.', \PHPUnit\Runner\Version::id() )[0] . '.xml',
-			)
-		);
-	}
-
 	public function testFailedExec() {
 		$GLOBALS['_composer_autoload_path'] = __DIR__ . '/../vendor/autoload.php';
 		$GLOBALS['_composer_bin_dir']       = __DIR__ . '/../vendor/bin';

--- a/projects/packages/phpunit-select-config/tests/patchwork.json
+++ b/projects/packages/phpunit-select-config/tests/patchwork.json
@@ -4,6 +4,7 @@
 		"exit",
 		"extension_loaded",
 		"fprintf",
+		"ini_get",
 		"ini_get_all",
 		"pcntl_exec",
 		"php_sapi_name"


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
Sometimes we need to run things (e.g. to suppress errors) prior to running PHPUnit. This allows us to specify an `auto_prepend_file` in the initial PHP invocation and pass it through to the second invocation done by the wrapper.

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

1. `echo '<?php echo 123;' > asdf.php`
2. `php -dauto_prepend_file=asdf.php vendor/bin/phpunit-select-config phpunit.#.xml.dist`

This runs the `asdf.php` file prior to running phpunit via the wrapper.