### PR TITLE
jetpack-mu-wpcom: Increase Central Forms Management rollout to 50%

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-forms-cfm-rollout-50-percent
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-forms-cfm-rollout-50-percent
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Increase Central Forms Management rollout to 50% of WordPress.com sites.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-contact-form-flags/wpcom-contact-form-flags.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-contact-form-flags/wpcom-contact-form-flags.php
@@ -33,7 +33,7 @@ function wpcom_has_central_forms_management_sticker( $blog_id ) {
  * Check if Central Forms Management is enabled for a given blog.
  *
  * Enabled when the blog falls within the percentage-based rollout
- * (blog_id % 100 < 10, i.e. 10%) or has the 'central-forms-management'
+ * (blog_id % 100 < 50, i.e. 50%) or has the 'central-forms-management'
  * blog sticker.
  *
  * @param int|null $blog_id Blog ID. Defaults to the current WP.com blog ID.
@@ -44,8 +44,8 @@ function wpcom_is_central_forms_management_enabled( $blog_id = null ) {
 		$blog_id = function_exists( 'get_wpcom_blog_id' ) ? get_wpcom_blog_id() : get_current_blog_id();
 	}
 
-	// Percentage-based rollout: 10% of sites.
-	if ( ( $blog_id % 100 ) < 10 ) {
+	// Percentage-based rollout: 50% of sites.
+	if ( ( $blog_id % 100 ) < 50 ) {
 		return true;
 	}
 


### PR DESCRIPTION
Part of FORMS-536

## Proposed changes

* Increase the Central Forms Management percentage-based rollout from 10% to 50% of WordPress.com sites (`blog_id % 100 < 50`).

This is step 2 of the phased rollout. See #47757 for the initial 10% rollout PR.

## Other information
- [x] Generate changelog entries for this PR (using AI).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Confirm `wpcom_is_central_forms_management_enabled()` returns `true` for a site where `blog_id % 100` is between 10 and 49 (previously excluded).
2. Confirm sites with `blog_id % 100 >= 50` and no sticker still return `false`.
