### PR TITLE
Forms: Fix ref attribute during synced form conversion

### DIFF
--- a/projects/packages/forms/changelog/fix-conversion-ref-attribute
+++ b/projects/packages/forms/changelog/fix-conversion-ref-attribute
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed ref attribute being cleared instead of set during synced form conversion.

--- a/projects/packages/forms/src/blocks/contact-form/components/convert-form-toolbar.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/convert-form-toolbar.tsx
@@ -102,7 +102,12 @@ export function ConvertFormToolbar( {
 			// Clear block and set ref to the new form
 			replaceInnerBlocks( clientId, [], false );
 			const clearedAttributes = Object.keys( attributes ).reduce(
-				( acc, key ) => ( { ...acc, [ key ]: undefined } ),
+				( acc, key ) => {
+					if ( key === 'ref' ) {
+						return acc;
+					}
+					return { ...acc, [ key ]: undefined };
+				},
 				{ ref: formId }
 			);
 			updateBlockAttributes( clientId, clearedAttributes );


### PR DESCRIPTION
Fixes FORMS-659

## Proposed changes

* Fix a bug where converting an inline form to a synced form via the toolbar button would clear the `ref` attribute instead of setting it to the new form's ID.
* **Root cause**: The `Object.keys(attributes).reduce()` in `convertToSynced` starts with `{ ref: formId }` as the accumulator, but `ref` is a registered block attribute, so the reducer iterates over it and overwrites `formId` with `undefined`.
* **Fix**: Skip the `ref` key in the reducer so the `formId` value survives into the final `updateBlockAttributes` call.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Insert an inline Jetpack Form block in a post (not a synced/reusable form).
2. Click **Edit Form** in the block toolbar to convert it to a synced form.
3. Verify the form converts successfully — the block should now reference the newly created form post.
4. Save the post and reload. Verify the synced form loads correctly (not blank or broken).
5. Click **Edit Form** again and verify it navigates to the form editor for the correct form.

