### PR TITLE
Forms: Improve form submission ref validation

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-ref-spoofing
+++ b/projects/packages/forms/changelog/fix-forms-ref-spoofing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Improved form submission validation.

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -329,9 +329,9 @@ class Feedback {
 
 		$this->source = Feedback_Source::from_submission( $current_post, $current_page_number );
 
-		// Extract and validate form ID from POST data or ref attribute
-		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verification happens in process_form_submission()
-		$form_id_attribute = $post_data['contact-form-ref'] ?? $form->get_attribute( 'ref' );
+		// Use the form's ref attribute as the authoritative form ID.
+		// The ref is set server-side (from the JWT or shortcode attributes) and cannot be tampered with.
+		$form_id_attribute = $form->get_attribute( 'ref' );
 		$form_id_attribute = is_numeric( $form_id_attribute ) ? absint( $form_id_attribute ) : 0;
 		$this->form_id     = $form_id_attribute > 0 ? $form_id_attribute : null;
 


### PR DESCRIPTION
Fixes FORMS-664

## Proposed changes

* Use the form's server-side `ref` attribute as the authoritative form ID instead of client-provided POST data.
* The `ref` attribute is set from the JWT or shortcode attributes, ensuring it cannot be tampered with via crafted POST requests.
* No hidden input named `contact-form-ref` is ever rendered in form HTML, so removing it has zero impact on legitimate submissions.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. **Synced form submissions**: Create a synced form (via Jetpack > Forms), add it to a page, publish, and submit. Verify the feedback entry appears under the correct form in the dashboard.
2. **Classic form submissions**: Insert an inline (non-synced) Jetpack Form block on a page, publish, and submit. Verify the submission is recorded correctly (no ref expected, `form_id` remains null).
3. **Dashboard check**: Verify feedback entries appear under the correct form in the Forms dashboard responses tab.

