### PR TITLE
Forms: Fix rename modal closing on save error

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-rename-modal-error
+++ b/projects/packages/forms/changelog/fix-forms-rename-modal-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed form rename modal closing even when save fails, so users can retry without losing their input

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -9,13 +9,11 @@ import {
 	__experimentalConfirmDialog as ConfirmDialog, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
-import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useEffect, useMemo, useState, useCallback } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 import { useSearch, useNavigate } from '@wordpress/route';
 import { Badge } from '@wordpress/ui';
 import * as React from 'react';
@@ -23,7 +21,6 @@ import * as React from 'react';
  * Internal dependencies
  */
 import IntegrationsModal from '../../src/blocks/contact-form/components/jetpack-integrations-modal';
-import { FORM_POST_TYPE } from '../../src/blocks/shared/util/constants.js';
 import CreateFormButton from '../../src/dashboard/components/create-form-button/index.tsx';
 import { EmptyWrapper, NoResults } from '../../src/dashboard/components/empty-responses/index.tsx';
 import { FormNameModal } from '../../src/dashboard/components/form-name-modal';
@@ -41,6 +38,7 @@ import DataViewsHeaderRow from '../../src/dashboard/wp-build/components/dataview
 import FormsHelpModal from '../../src/dashboard/wp-build/components/forms-help-modal';
 import useFormItemActions from '../../src/dashboard/wp-build/hooks/use-form-item-actions';
 import usePageHeaderDetails from '../../src/dashboard/wp-build/hooks/use-page-header-details';
+import { useRenameForm } from '../../src/dashboard/wp-build/hooks/use-rename-form';
 import '../../src/dashboard/wp-build/style.scss';
 import useConfigValue from '../../src/hooks/use-config-value';
 import { INTEGRATIONS_STORE, IntegrationsSelectors } from '../../src/store/integrations';
@@ -171,11 +169,8 @@ function StageInner() {
 	const [ selection, setSelection ] = useState< string[] >( [] );
 	const [ pendingPermanentDeleteCount, setPendingPermanentDeleteCount ] = useState( 0 );
 
-	// Rename modal state
-	const [ renameFormItem, setRenameFormItem ] = useState< FormListItem | null >( null );
-
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-	const { saveEntityRecord } = useDispatch( coreStore );
+	// Rename form
+	const { renameFormItem, openRenameModal, closeRenameModal, handleRename } = useRenameForm();
 
 	// Selection is local state. Clear it whenever the view changes (page/perPage/search/filters).
 	useEffect( () => {
@@ -203,43 +198,6 @@ function StageInner() {
 			setSelection( [] );
 		}
 	}, [ confirmPermanentDelete ] );
-
-	const openRenameModal = useCallback( ( item: FormListItem ) => {
-		setRenameFormItem( item );
-	}, [] );
-
-	const closeRenameModal = useCallback( () => {
-		setRenameFormItem( null );
-	}, [] );
-
-	const handleRename = useCallback(
-		async ( newTitle: string ) => {
-			if ( ! renameFormItem ) {
-				return;
-			}
-			try {
-				await saveEntityRecord(
-					'postType',
-					FORM_POST_TYPE,
-					{
-						id: renameFormItem.id,
-						title: newTitle,
-					},
-					{ throwOnError: true }
-				);
-
-				createSuccessNotice( __( 'Form renamed.', 'jetpack-forms' ), { type: 'snackbar' } );
-			} catch ( error ) {
-				createErrorNotice( __( 'Failed to rename form.', 'jetpack-forms' ), {
-					type: 'snackbar',
-				} );
-				// eslint-disable-next-line no-console
-				console.error( 'Failed to rename form:', error );
-				throw error;
-			}
-		},
-		[ renameFormItem, saveEntityRecord, createSuccessNotice, createErrorNotice ]
-	);
 
 	const fields = useMemo(
 		() => [

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -13,7 +13,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
-import { useEffect, useMemo, useState, useCallback, useRef } from '@wordpress/element';
+import { useEffect, useMemo, useState, useCallback } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useSearch, useNavigate } from '@wordpress/route';
@@ -173,7 +173,6 @@ function StageInner() {
 
 	// Rename modal state
 	const [ renameFormItem, setRenameFormItem ] = useState< FormListItem | null >( null );
-	const renameRetryRef = useRef< { item: FormListItem; title: string } | null >( null );
 
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { saveEntityRecord } = useDispatch( coreStore );
@@ -211,7 +210,6 @@ function StageInner() {
 
 	const closeRenameModal = useCallback( () => {
 		setRenameFormItem( null );
-		renameRetryRef.current = null;
 	}, [] );
 
 	const handleRename = useCallback(
@@ -231,27 +229,13 @@ function StageInner() {
 				);
 
 				createSuccessNotice( __( 'Form renamed.', 'jetpack-forms' ), { type: 'snackbar' } );
-				renameRetryRef.current = null;
 			} catch ( error ) {
-				// Store retry data in case the user closes the modal manually.
-				// The modal stays open on error, but if they close it, they can retry via the snackbar.
-				const retryItem = renameFormItem;
-				const retryTitle = newTitle;
-
 				createErrorNotice( __( 'Failed to rename form.', 'jetpack-forms' ), {
 					type: 'snackbar',
-					actions: [
-						{
-							label: __( 'Retry', 'jetpack-forms' ),
-							onClick: () => {
-								renameRetryRef.current = { item: retryItem, title: retryTitle };
-								setRenameFormItem( retryItem );
-							},
-						},
-					],
 				} );
 				// eslint-disable-next-line no-console
 				console.error( 'Failed to rename form:', error );
+				throw error;
 			}
 		},
 		[ renameFormItem, saveEntityRecord, createSuccessNotice, createErrorNotice ]
@@ -736,7 +720,7 @@ function StageInner() {
 				onClose={ closeRenameModal }
 				onSave={ handleRename }
 				title={ __( 'Rename form', 'jetpack-forms' ) }
-				initialValue={ renameRetryRef.current?.title || renameFormItem?.title || '' }
+				initialValue={ renameFormItem?.title || '' }
 			/>
 			<IntegrationsModal
 				isOpen={ isIntegrationsModalOpen }

--- a/projects/packages/forms/src/dashboard/components/form-name-modal/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/form-name-modal/index.tsx
@@ -127,11 +127,11 @@ export function FormNameModal( {
 
 		try {
 			await onSave( finalName );
+			onClose();
 		} catch {
-			// Error handling is left to the caller via onSave
+			// onSave threw — keep the modal open so the user can retry.
 		} finally {
 			setIsSaving( false );
-			onClose();
 		}
 	}, [ name, fallbackName, isSaving, onSave, onClose ] );
 

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -140,9 +140,6 @@ export default function usePageHeaderDetails(
 	const [ renameFormItem, setRenameFormItem ] = useState< { id: number; title: string } | null >(
 		null
 	);
-	const renameRetryRef = useRef< { item: { id: number; title: string }; title: string } | null >(
-		null
-	);
 	const { saveEntityRecord, deleteEntityRecord } = useDispatch( coreDataStore ) as {
 		saveEntityRecord: (
 			kind: string,
@@ -183,7 +180,6 @@ export default function usePageHeaderDetails(
 
 	const closeRenameModal = useCallback( () => {
 		setRenameFormItem( null );
-		renameRetryRef.current = null;
 	}, [] );
 
 	const handleRename = useCallback(
@@ -203,25 +199,13 @@ export default function usePageHeaderDetails(
 				);
 
 				createSuccessNotice( __( 'Form renamed.', 'jetpack-forms' ), { type: 'snackbar' } );
-				renameRetryRef.current = null;
 			} catch ( error ) {
-				const retryItem = renameFormItem;
-				const retryTitle = newTitle;
-
 				createErrorNotice( __( 'Failed to rename form.', 'jetpack-forms' ), {
 					type: 'snackbar',
-					actions: [
-						{
-							label: __( 'Retry', 'jetpack-forms' ),
-							onClick: () => {
-								renameRetryRef.current = { item: retryItem, title: retryTitle };
-								setRenameFormItem( retryItem );
-							},
-						},
-					],
 				} );
 				// eslint-disable-next-line no-console
 				console.error( 'Failed to rename form:', error );
+				throw error;
 			}
 		},
 		[ renameFormItem, saveEntityRecord, createSuccessNotice, createErrorNotice ]
@@ -757,7 +741,7 @@ export default function usePageHeaderDetails(
 								onClose={ closeRenameModal }
 								onSave={ handleRename }
 								title={ __( 'Rename form', 'jetpack-forms' ) }
-								initialValue={ renameRetryRef.current?.title || renameFormItem?.title || '' }
+								initialValue={ renameFormItem?.title || '' }
 							/>,
 					  ]
 					: [] ),
@@ -831,7 +815,7 @@ export default function usePageHeaderDetails(
 								onClose={ closeRenameModal }
 								onSave={ handleRename }
 								title={ __( 'Rename form', 'jetpack-forms' ) }
-								initialValue={ renameRetryRef.current?.title || renameFormItem?.title || '' }
+								initialValue={ renameFormItem?.title || '' }
 							/>,
 					  ]
 					: [] ),

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -43,6 +43,7 @@ import { store as dashboardStore } from '../../store/index.js';
 import { getFormEditUrl } from '../../utils.ts';
 import ManageIntegrationsButton from '../components/manage-integrations-button';
 import useFormItemActions from './use-form-item-actions';
+import { useRenameForm } from './use-rename-form';
 import type { ReactNode } from 'react';
 
 type ResponsesStatusView = 'inbox' | 'spam' | 'trash';
@@ -136,10 +137,8 @@ export default function usePageHeaderDetails(
 	const [ isPermanentDeleteConfirmOpen, setIsPermanentDeleteConfirmOpen ] = useState( false );
 	const permanentDeleteItemRef = useRef< { id: number } | null >( null );
 
-	// Rename form state
-	const [ renameFormItem, setRenameFormItem ] = useState< { id: number; title: string } | null >(
-		null
-	);
+	// Rename form
+	const { renameFormItem, openRenameModal, closeRenameModal, handleRename } = useRenameForm();
 	const { saveEntityRecord, deleteEntityRecord } = useDispatch( coreDataStore ) as {
 		saveEntityRecord: (
 			kind: string,
@@ -177,39 +176,6 @@ export default function usePageHeaderDetails(
 		const rendered = formRecord?.title?.rendered || '';
 		return decodeEntities( rendered );
 	}, [ formRecord?.title?.rendered ] );
-
-	const closeRenameModal = useCallback( () => {
-		setRenameFormItem( null );
-	}, [] );
-
-	const handleRename = useCallback(
-		async ( newTitle: string ) => {
-			if ( ! renameFormItem ) {
-				return;
-			}
-			try {
-				await saveEntityRecord(
-					'postType',
-					FORM_POST_TYPE,
-					{
-						id: renameFormItem.id,
-						title: newTitle,
-					},
-					{ throwOnError: true }
-				);
-
-				createSuccessNotice( __( 'Form renamed.', 'jetpack-forms' ), { type: 'snackbar' } );
-			} catch ( error ) {
-				createErrorNotice( __( 'Failed to rename form.', 'jetpack-forms' ), {
-					type: 'snackbar',
-				} );
-				// eslint-disable-next-line no-console
-				console.error( 'Failed to rename form:', error );
-				throw error;
-			}
-		},
-		[ renameFormItem, saveEntityRecord, createSuccessNotice, createErrorNotice ]
-	);
 
 	const trashForm = useCallback(
 		async ( item: { id: number } ) => {
@@ -454,7 +420,7 @@ export default function usePageHeaderDetails(
 				title: __( 'Rename', 'jetpack-forms' ),
 				onClick: () => {
 					trackAction( 'jetpack_forms_form_rename_click' );
-					setRenameFormItem( formItem );
+					openRenameModal( formItem );
 				},
 			},
 			{
@@ -488,6 +454,7 @@ export default function usePageHeaderDetails(
 		previewForm,
 		setFormsToDraft,
 		sourceIdNumber,
+		openRenameModal,
 		trackAction,
 	] );
 

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-rename-form.ts
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-rename-form.ts
@@ -1,0 +1,96 @@
+/**
+ * Hook to manage the rename form modal state and save logic.
+ *
+ * Shared between the page header (use-page-header-details) and
+ * the DataViews row actions (routes/forms/stage.tsx) so the rename
+ * behavior stays consistent in one place.
+ */
+
+import { store as coreDataStore } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+import { useCallback, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { FORM_POST_TYPE } from '../../../blocks/shared/util/constants.js';
+
+export interface RenameFormItem {
+	id: number;
+	title: string;
+}
+
+interface UseRenameFormReturn {
+	/** The item currently being renamed, or null if the modal is closed. */
+	renameFormItem: RenameFormItem | null;
+	/** Open the rename modal for a given item. */
+	openRenameModal: ( item: RenameFormItem ) => void;
+	/** Close the rename modal. */
+	closeRenameModal: () => void;
+	/**
+	 * Save handler for the FormNameModal.
+	 * Resolves on success, throws on error (so the modal stays open).
+	 */
+	handleRename: ( newTitle: string ) => Promise< void >;
+}
+
+/**
+ * Hook to manage the rename form modal state and save logic.
+ *
+ * @return {UseRenameFormReturn} Rename modal state and handlers.
+ */
+export function useRenameForm(): UseRenameFormReturn {
+	const [ renameFormItem, setRenameFormItem ] = useState< RenameFormItem | null >( null );
+
+	const { saveEntityRecord } = useDispatch( coreDataStore ) as {
+		saveEntityRecord: (
+			kind: string,
+			name: string,
+			record: Record< string, unknown >,
+			options?: { throwOnError?: boolean }
+		) => Promise< unknown >;
+	};
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+
+	const openRenameModal = useCallback( ( item: RenameFormItem ) => {
+		setRenameFormItem( item );
+	}, [] );
+
+	const closeRenameModal = useCallback( () => {
+		setRenameFormItem( null );
+	}, [] );
+
+	const handleRename = useCallback(
+		async ( newTitle: string ) => {
+			if ( ! renameFormItem ) {
+				return;
+			}
+			try {
+				await saveEntityRecord(
+					'postType',
+					FORM_POST_TYPE,
+					{
+						id: renameFormItem.id,
+						title: newTitle,
+					},
+					{ throwOnError: true }
+				);
+
+				createSuccessNotice( __( 'Form renamed.', 'jetpack-forms' ), { type: 'snackbar' } );
+			} catch ( error ) {
+				createErrorNotice( __( 'Failed to rename form.', 'jetpack-forms' ), {
+					type: 'snackbar',
+				} );
+				// eslint-disable-next-line no-console
+				console.error( 'Failed to rename form:', error );
+				throw error;
+			}
+		},
+		[ renameFormItem, saveEntityRecord, createSuccessNotice, createErrorNotice ]
+	);
+
+	return {
+		renameFormItem,
+		openRenameModal,
+		closeRenameModal,
+		handleRename,
+	};
+}


### PR DESCRIPTION
Fixes FORMS-657

## Proposed changes

* Fix the `FormNameModal` component unconditionally closing in its `finally` block, even when the save operation failed.
* The modal now stays open on error so the user can retry without losing their input.
* Remove the now-unnecessary `renameRetryRef` retry mechanism — it was a workaround for the modal-closing bug. Since the modal stays open on error, retry is built-in.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. **Rename success**: In the Forms dashboard, open the actions menu for a form and click **Rename**. Enter a new name and save. Verify the modal closes and a success snackbar appears.
2. **Rename error**: Disconnect your network (or throttle to offline in DevTools), then try to rename a form. Verify the modal stays open with your input preserved and an error snackbar appears.
3. **Reconnect and retry**: Re-enable the network and click Save again in the still-open modal. Verify it succeeds and the modal closes.
4. **Create form**: Click **Create Form** in the dashboard header. Verify the create modal still works correctly (closes on success, stays open on error).

