### PR TITLE
Disable RTC on the WordPress.com desktop app

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/2026-03-26-11-14-25-163939
+++ b/projects/packages/jetpack-mu-wpcom/changelog/2026-03-26-11-14-25-163939
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Disable Real-Time Collaboration on the WordPress.com desktop app to prevent editing issues caused by an incompatibility.

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
@@ -41,11 +41,28 @@ function wpcom_should_enforce_http_polling() {
 }
 
 /**
+ * Determine whether the current request is from the WordPress.com desktop app.
+ *
+ * @return bool
+ */
+function wpcom_rtc_is_desktop_app() {
+	if ( ! isset( $_SERVER['HTTP_USER_AGENT'] ) ) {
+		return false;
+	}
+	$user_agent = sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) );
+	return false !== strpos( $user_agent, 'WordPressDesktop' );
+}
+
+/**
  * Determine whether RTC should be enabled based on the site's features.
  *
  * @return bool
  */
 function wpcom_enable_rtc() {
+	// Disable RTC on the desktop app due to an incompatibility.
+	if ( wpcom_rtc_is_desktop_app() ) {
+		return false;
+	}
 	$has_rtc_feature = false;
 	if ( function_exists( 'wpcom_site_has_feature' ) && class_exists( 'WPCOM_Features' ) && defined( 'WPCOM_Features::REAL_TIME_COLLABORATION' ) ) {
 		$blog_id         = get_wpcom_blog_id();

--- a/projects/packages/jetpack-mu-wpcom/tests/lib/class-wpcom-features.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/lib/class-wpcom-features.php
@@ -13,5 +13,6 @@ if ( class_exists( 'WPCOM_Features' ) ) {
  * Class WPCOM_Features.
  */
 class WPCOM_Features {
-	const GLOBAL_STYLES = 'global-styles';
+	const GLOBAL_STYLES           = 'global-styles';
+	const REAL_TIME_COLLABORATION = 'real-time-collaboration';
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc/Gutenberg_RTC_Test.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Gutenberg RTC Tests.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+declare( strict_types = 1 );
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+use PHPUnit\Framework\Attributes\CoversFunction;
+
+// phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/gutenberg-rtc/gutenberg-rtc.php';
+
+/**
+ * Tests for the gutenberg-rtc.php feature gating functions.
+ *
+ * @covers ::wpcom_rtc_is_desktop_app
+ * @covers ::wpcom_enable_rtc
+ * @covers ::wpcom_should_enforce_http_polling
+ * @covers ::wpcom_rtc_providers
+ * @covers ::wpcom_has_features_edge_sticker
+ */
+#[CoversFunction( 'wpcom_rtc_is_desktop_app' )]
+#[CoversFunction( 'wpcom_enable_rtc' )]
+#[CoversFunction( 'wpcom_should_enforce_http_polling' )]
+#[CoversFunction( 'wpcom_rtc_providers' )]
+#[CoversFunction( 'wpcom_has_features_edge_sticker' )]
+class Gutenberg_RTC_Test extends \WorDBless\BaseTestCase {
+
+	/**
+	 * Original $_SERVER['HTTP_USER_AGENT'] value.
+	 *
+	 * @var string|null
+	 */
+	private $original_user_agent;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		$this->original_user_agent = $_SERVER['HTTP_USER_AGENT'] ?? null;
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down(): void {
+		// Restore original user agent.
+		if ( null === $this->original_user_agent ) {
+			unset( $_SERVER['HTTP_USER_AGENT'] );
+		} else {
+			$_SERVER['HTTP_USER_AGENT'] = $this->original_user_agent;
+		}
+
+		remove_all_filters( 'jetpack_rtc_enabled' );
+		remove_all_filters( 'jetpack_rtc_providers' );
+
+		parent::tear_down();
+	}
+
+	// ─── wpcom_rtc_is_desktop_app ────────────────────────────────────
+
+	/**
+	 * Tests that the desktop app is detected via user agent.
+	 */
+	public function test_is_desktop_app_with_desktop_user_agent() {
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 WordPressDesktop/8.5.0';
+		$this->assertTrue( wpcom_rtc_is_desktop_app() );
+	}
+
+	/**
+	 * Tests that a regular browser is not detected as desktop app.
+	 */
+	public function test_is_desktop_app_with_regular_browser() {
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0';
+		$this->assertFalse( wpcom_rtc_is_desktop_app() );
+	}
+
+	/**
+	 * Tests that missing user agent returns false.
+	 */
+	public function test_is_desktop_app_without_user_agent() {
+		unset( $_SERVER['HTTP_USER_AGENT'] );
+		$this->assertFalse( wpcom_rtc_is_desktop_app() );
+	}
+
+	/**
+	 * Tests that an empty user agent returns false.
+	 */
+	public function test_is_desktop_app_with_empty_user_agent() {
+		$_SERVER['HTTP_USER_AGENT'] = '';
+		$this->assertFalse( wpcom_rtc_is_desktop_app() );
+	}
+
+	/**
+	 * Tests that mobile app user agents are not detected as desktop.
+	 */
+	public function test_is_desktop_app_with_mobile_app_user_agent() {
+		$_SERVER['HTTP_USER_AGENT'] = 'wp-iphone/24.0';
+		$this->assertFalse( wpcom_rtc_is_desktop_app() );
+	}
+
+	// ─── wpcom_enable_rtc ────────────────────────────────────────────
+
+	/**
+	 * Tests that RTC is disabled on the desktop app.
+	 */
+	public function test_enable_rtc_returns_false_on_desktop_app() {
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 WordPressDesktop/8.5.0';
+		$this->assertFalse( wpcom_enable_rtc() );
+	}
+
+	/**
+	 * Tests that RTC is disabled when the site lacks the RTC feature.
+	 *
+	 * Without `wpcom_site_has_feature` available, `wpcom_enable_rtc` should
+	 * return false because the feature cannot be verified.
+	 */
+	public function test_enable_rtc_returns_false_without_rtc_feature() {
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 Chrome/120.0.0.0';
+		$this->assertFalse( wpcom_enable_rtc() );
+	}
+
+	// ─── wpcom_should_enforce_http_polling ───────────────────────────
+
+	/**
+	 * Tests that HTTP polling is not enforced when IS_ATOMIC is not defined.
+	 */
+	public function test_enforce_http_polling_returns_false_when_not_atomic() {
+		// IS_ATOMIC is not defined in the test environment.
+		$this->assertFalse( wpcom_should_enforce_http_polling() );
+	}
+
+	// ─── wpcom_has_features_edge_sticker ─────────────────────────────
+
+	/**
+	 * Tests that features edge sticker returns false without wpcom functions.
+	 *
+	 * Neither `wpcomsh_is_site_sticker_active` nor `has_blog_sticker` exist
+	 * in the test environment.
+	 */
+	public function test_features_edge_sticker_returns_false_without_wpcom_functions() {
+		$this->assertFalse( wpcom_has_features_edge_sticker() );
+	}
+
+	// ─── wpcom_rtc_providers ─────────────────────────────────────────
+
+	/**
+	 * Tests that providers pass through when HTTP polling is not enforced.
+	 */
+	public function test_rtc_providers_passes_through_when_not_enforcing_http_polling() {
+		$providers = array( 'pinghub' );
+		$this->assertSame( $providers, wpcom_rtc_providers( $providers ) );
+	}
+}


### PR DESCRIPTION
Fixes DOTCOM-16517

## Proposed changes

* Disable the Real-Time Collaboration (RTC) feature when the request comes from the WordPress.com desktop app.
* Add a `wpcom_rtc_is_desktop_app()` helper that detects the desktop app via the `WordPressDesktop` user agent string.
* Return `false` early from `wpcom_enable_rtc()` when on the desktop app, preventing RTC from being initialized.

This is a mitigation step — RTC is causing editing issues on the desktop app (users cannot edit posts). Disabling it there restores normal editing while the root cause is investigated.

## Related product discussion/links
N/A

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Apply these changes to a WoW sites where RTC has been gradually rolled out.
* Open the WordPress.com desktop app.
* Switch to your WoW site.
* Go to Posts → Add New.
* Verify that the editor loads normally and the post is editable (RTC should not be active).
* Open the same site in a regular browser and verify that RTC still works as expected.
