### PR TITLE
Forms: Fix undo restoring wrong form status in dashboard

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-undo-status
+++ b/projects/packages/forms/changelog/fix-forms-undo-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed undo restoring wrong form status for non-standard statuses in dashboard header actions

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -393,7 +393,7 @@ export default function usePageHeaderDetails(
 			return [];
 		}
 
-		const formItem = { id: sourceIdNumber, title: formTitle };
+		const formItem = { id: sourceIdNumber, title: formTitle, status: formRecord?.status };
 
 		if ( formRecord?.status === 'trash' ) {
 			return [


### PR DESCRIPTION
Fixes FORMS-662

## Proposed changes

* Fix a bug where undo after publish/unpublish in the dashboard header would restore the wrong form status for forms with non-standard statuses (`pending`, `private`, `future`).
* The `formItem` object passed to `publishForms`/`setFormsToDraft` was missing the `status` property, causing the undo handler to fall back to the binary opposite (`draft`/`publish`) instead of the original status.
* One-line fix: include `status: formRecord?.status` in the formItem construction.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Create a form and set it to `pending` or `private` status (via Quick Edit or the REST API).
2. Navigate to the Forms dashboard and open the single-form view for that form.
3. Click **Publish** in the header.
4. Click **Undo** in the snackbar notification.
5. Verify the form status is restored to the original (`pending`/`private`), not `draft`.
6. Repeat with a `publish` → **Unpublish** → **Undo** flow and verify the status restores to `publish`, not `draft`.

