### PR TITLE
jetpack-mu-wpcom: Exclude e2e test sites from Central Forms Management rollout

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-forms-cfm-exclude-e2e-sites
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-forms-cfm-exclude-e2e-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Exclude e2e test sites from Central Forms Management rollout.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-contact-form-flags/wpcom-contact-form-flags.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-contact-form-flags/wpcom-contact-form-flags.php
@@ -44,6 +44,11 @@ function wpcom_is_central_forms_management_enabled( $blog_id = null ) {
 		$blog_id = function_exists( 'get_wpcom_blog_id' ) ? get_wpcom_blog_id() : get_current_blog_id();
 	}
 
+	// Exclude e2e test sites — their tests aren't ready for CFM yet.
+	if ( function_exists( 'has_blog_sticker' ) && has_blog_sticker( 'a8c-e2e-test-blog', $blog_id ) ) {
+		return false;
+	}
+
 	// Percentage-based rollout: 50% of sites.
 	if ( ( $blog_id % 100 ) < 50 ) {
 		return true;


### PR DESCRIPTION
Related to FORMS-649

Fixes e2e tests failing in the CI pipeline

## Proposed changes

* Exclude sites with the `a8c-e2e-test-blog` blog sticker from the Central Forms Management rollout.
* The check runs early in `wpcom_is_central_forms_management_enabled()`, before the percentage or sticker checks, so e2e sites are never opted in regardless of their blog ID.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links

* Initial rollout PR: #47757
* 50% rollout PR: #47793

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. On a site with the `a8c-e2e-test-blog` sticker and a `blog_id` in the rollout bucket (`blog_id % 100 < 50`), confirm `wpcom_is_central_forms_management_enabled()` returns `false`.
2. On a regular site in the rollout bucket (no e2e sticker), confirm it still returns `true`.
3. On a site with both the `a8c-e2e-test-blog` and `central-forms-management` stickers, confirm it returns `false` (e2e exclusion takes priority).
