### PR TITLE
Fix monorepo E2E builds

### DIFF
--- a/projects/plugins/automattic-for-agencies-client/changelog/fix-monorepo-e2es
+++ b/projects/plugins/automattic-for-agencies-client/changelog/fix-monorepo-e2es
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix E2E builds: Jetpack now requires Social-Logos to have been built.
+
+

--- a/projects/plugins/automattic-for-agencies-client/tests/e2e/package.json
+++ b/projects/plugins/automattic-for-agencies-client/tests/e2e/package.json
@@ -2,7 +2,7 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
-		"build": "pnpm jetpack build plugins/automattic-for-agencies-client plugins/jetpack -v --no-pnpm-install --production",
+		"build": "pnpm jetpack build js-packages/social-logos plugins/automattic-for-agencies-client plugins/jetpack -v --no-pnpm-install --production",
 		"clean": "rm -rf output",
 		"config:decrypt": "openssl enc -md sha1 -aes-256-cbc -pbkdf2 -iter 100000 -d -pass env:CONFIG_KEY -in ./node_modules/_jetpack-e2e-commons/config/encrypted.enc -out ./config/local.cjs",
 		"distclean": "rm -rf node_modules",

--- a/projects/plugins/boost/changelog/fix-monorepo-e2es
+++ b/projects/plugins/boost/changelog/fix-monorepo-e2es
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix E2E builds: Jetpack now requires Social-Logos to have been built.
+
+

--- a/projects/plugins/boost/tests/e2e/package.json
+++ b/projects/plugins/boost/tests/e2e/package.json
@@ -3,7 +3,7 @@
 	"type": "module",
 	"scripts": {
 		"allure-report": "allure generate --clean --output ./output/allure-report ./output/allure-results && allure open ./output/allure-report",
-		"build": "pnpm jetpack build plugins/jetpack plugins/boost js-packages/image-guide js-packages/critical-css-gen packages/plugin-deactivation packages/connection packages/jitm packages/my-jetpack packages/assets -v --no-pnpm-install --production",
+		"build": "pnpm jetpack build plugins/jetpack plugins/boost js-packages/image-guide js-packages/critical-css-gen js-packages/social-logos packages/plugin-deactivation packages/connection packages/jitm packages/my-jetpack packages/assets -v --no-pnpm-install --production",
 		"clean": "rm -rf output",
 		"config:decrypt": "openssl enc -md sha1 -aes-256-cbc -pbkdf2 -iter 100000 -d -pass env:CONFIG_KEY -in ./node_modules/_jetpack-e2e-commons/config/encrypted.enc -out ./config/local.cjs",
 		"distclean": "rm -rf node_modules",

--- a/projects/plugins/classic-theme-helper-plugin/changelog/fix-monorepo-e2es
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/fix-monorepo-e2es
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix E2E builds: Jetpack now requires Social-Logos to have been built.
+
+

--- a/projects/plugins/classic-theme-helper-plugin/tests/e2e/package.json
+++ b/projects/plugins/classic-theme-helper-plugin/tests/e2e/package.json
@@ -2,7 +2,7 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
-		"build": "pnpm jetpack build plugins/classic-theme-helper-plugin plugins/jetpack -v --no-pnpm-install --production",
+		"build": "pnpm jetpack build js-packages/social-logos plugins/classic-theme-helper-plugin plugins/jetpack -v --no-pnpm-install --production",
 		"clean": "rm -rf output",
 		"config:decrypt": "openssl enc -md sha1 -aes-256-cbc -pbkdf2 -iter 100000 -d -pass env:CONFIG_KEY -in ./node_modules/_jetpack-e2e-commons/config/encrypted.enc -out ./config/local.cjs",
 		"distclean": "rm -rf node_modules",

--- a/projects/plugins/protect/changelog/fix-monorepo-e2es
+++ b/projects/plugins/protect/changelog/fix-monorepo-e2es
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix E2E builds: Jetpack now requires Social-Logos to have been built.
+
+

--- a/projects/plugins/protect/tests/e2e/package.json
+++ b/projects/plugins/protect/tests/e2e/package.json
@@ -3,7 +3,7 @@
 	"type": "module",
 	"scripts": {
 		"allure-report": "allure generate --clean --output ./output/allure-report ./output/allure-results && allure open ./output/allure-report",
-		"build": "pnpm jetpack build packages/assets packages/connection plugins/protect plugins/jetpack -v --no-pnpm-install --production",
+		"build": "pnpm jetpack build js-packages/social-logos packages/assets packages/connection plugins/protect plugins/jetpack -v --no-pnpm-install --production",
 		"clean": "rm -rf output",
 		"config:decrypt": "openssl enc -md sha1 -aes-256-cbc -pbkdf2 -iter 100000 -d -pass env:CONFIG_KEY -in ./node_modules/_jetpack-e2e-commons/config/encrypted.enc -out ./config/local.cjs",
 		"distclean": "rm -rf node_modules",

--- a/projects/plugins/search/changelog/fix-monorepo-e2es
+++ b/projects/plugins/search/changelog/fix-monorepo-e2es
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix E2E builds: Jetpack now requires Social-Logos to have been built.
+
+

--- a/projects/plugins/search/tests/e2e/package.json
+++ b/projects/plugins/search/tests/e2e/package.json
@@ -2,7 +2,7 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
-		"build": "pnpm jetpack build packages/assets packages/search packages/connection plugins/jetpack -v --no-pnpm-install --production",
+		"build": "pnpm jetpack build js-packages/social-logos packages/assets packages/search packages/connection plugins/jetpack -v --no-pnpm-install --production",
 		"clean": "rm -rf output",
 		"config:decrypt": "openssl enc -md sha1 -aes-256-cbc -pbkdf2 -iter 100000 -d -pass env:CONFIG_KEY -in ./node_modules/_jetpack-e2e-commons/config/encrypted.enc -out ./config/local.cjs",
 		"distclean": "rm -rf node_modules",

--- a/projects/plugins/social/changelog/fix-monorepo-e2es
+++ b/projects/plugins/social/changelog/fix-monorepo-e2es
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix E2E builds: Jetpack now requires Social-Logos to have been built.
+
+

--- a/projects/plugins/social/tests/e2e/package.json
+++ b/projects/plugins/social/tests/e2e/package.json
@@ -3,7 +3,7 @@
 	"type": "module",
 	"scripts": {
 		"allure-report": "allure generate --clean --output ./output/allure-report ./output/allure-results && allure open ./output/allure-report",
-		"build": "pnpm jetpack build packages/assets packages/connection packages/publicize plugins/social plugins/jetpack -v --no-pnpm-install --production",
+		"build": "pnpm jetpack build js-packages/social-logos packages/assets packages/connection packages/publicize plugins/social plugins/jetpack -v --no-pnpm-install --production",
 		"clean": "rm -rf output",
 		"config:decrypt": "openssl enc -md sha1 -aes-256-cbc -pbkdf2 -iter 100000 -d -pass env:CONFIG_KEY -in ./node_modules/_jetpack-e2e-commons/config/encrypted.enc -out ./config/local.cjs",
 		"distclean": "rm -rf node_modules",

--- a/projects/plugins/starter-plugin/changelog/fix-monorepo-e2es
+++ b/projects/plugins/starter-plugin/changelog/fix-monorepo-e2es
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix E2E builds: Jetpack now requires Social-Logos to have been built.
+
+

--- a/projects/plugins/starter-plugin/tests/e2e/package.json
+++ b/projects/plugins/starter-plugin/tests/e2e/package.json
@@ -3,7 +3,7 @@
 	"type": "module",
 	"scripts": {
 		"allure-report": "allure generate --clean --output ./output/allure-report ./output/allure-results && allure open ./output/allure-report",
-		"build": "pnpm jetpack build plugins/starter-plugin plugins/jetpack -v --no-pnpm-install --production",
+		"build": "pnpm jetpack build js-packages/social-logos plugins/starter-plugin plugins/jetpack -v --no-pnpm-install --production",
 		"clean": "rm -rf output",
 		"config:decrypt": "openssl enc -md sha1 -aes-256-cbc -pbkdf2 -iter 100000 -d -pass env:CONFIG_KEY -in ./node_modules/_jetpack-e2e-commons/config/encrypted.enc -out ./config/local.cjs",
 		"distclean": "rm -rf node_modules",

--- a/projects/plugins/videopress/changelog/fix-monorepo-e2es
+++ b/projects/plugins/videopress/changelog/fix-monorepo-e2es
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix E2E builds: Jetpack now requires Social-Logos to have been built.
+
+

--- a/projects/plugins/videopress/tests/e2e/package.json
+++ b/projects/plugins/videopress/tests/e2e/package.json
@@ -3,7 +3,7 @@
 	"type": "module",
 	"scripts": {
 		"allure-report": "allure generate --clean --output ./output/allure-report ./output/allure-results && allure open ./output/allure-report",
-		"build": "pnpm jetpack build plugins/videopress plugins/jetpack -v --no-pnpm-install --production",
+		"build": "pnpm jetpack build js-packages/social-logos plugins/videopress plugins/jetpack -v --no-pnpm-install --production",
 		"clean": "rm -rf output",
 		"config:decrypt": "openssl enc -md sha1 -aes-256-cbc -pbkdf2 -iter 100000 -d -pass env:CONFIG_KEY -in ./node_modules/_jetpack-e2e-commons/config/encrypted.enc -out ./config/local.cjs",
 		"distclean": "rm -rf node_modules",


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
The E2E builds try to build only what they need, instead of building all dependencies, to try to get things started faster.

PR #47753 made Jetpack's build require that js-packages/social-logos is built. So we need to add that to the list for all the E2E builds that build Jetpack.

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* E2Es happy now?
