### PR TITLE
SEO Tools: Prevent warnings when filtered type is not iterable

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-warnings_in_seo_module
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-warnings_in_seo_module
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+SEO Tools: Prevent PHP warnings when handling malformed data.

--- a/projects/plugins/jetpack/modules/seo-tools/class-jetpack-seo.php
+++ b/projects/plugins/jetpack/modules/seo-tools/class-jetpack-seo.php
@@ -281,6 +281,10 @@ class Jetpack_SEO {
 		 */
 		$meta = apply_filters( 'jetpack_seo_meta_tags', $meta );
 
+		if ( ! is_array( $meta ) ) {
+			return;
+		}
+
 		// Output them.
 		foreach ( $meta as $name => $content ) {
 			if ( ! empty( $content ) ) {


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
We try to iterate on filtered content without verifying it's iterable. This PR returns early if the type is not an array.

This should prevent about 1/3 of Jetpack-attributed warnings on WP Cloud (50K/month).

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Look at the code.