### PR TITLE
Sharing: Prevent warnings when button is missing the service attribute

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-warnings_in_sharing_button_block
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-warnings_in_sharing_button_block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Sharing: Prevent warning when handling malformed data.

--- a/projects/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php
+++ b/projects/plugins/jetpack/extensions/blocks/sharing-button/sharing-button.php
@@ -54,6 +54,11 @@ add_action( 'init', __NAMESPACE__ . '\register_block' );
  * @return string
  */
 function render_block( $attr, $content, $block ) {
+	$services = get_services();
+	if ( ! isset( $attr['service'] ) || ! array_key_exists( $attr['service'], $services ) ) {
+		return $content;
+	}
+
 	$service_name = $attr['service'];
 	$title        = $attr['label'] ?? $service_name;
 	$icon         = get_social_logo( $service_name );
@@ -64,11 +69,6 @@ function render_block( $attr, $content, $block ) {
 		$service_name,
 		$post_id
 	);
-
-	$services = get_services();
-	if ( ! array_key_exists( $service_name, $services ) ) {
-		return $content;
-	}
 
 	$service      = new $services[ $service_name ]( $service_name, array() );
 	$link_props   = $service->get_link(


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
This PR moves the early return earlier in the function and adds a condition to verify the `service` attribute is set.

This is the warning in question:
```
PHP Warning: Undefined array key "service" in /wordpress/plugins/jetpack/15.7-a.5/extensions/blocks/sharing-button/sharing-button.php on line 57
```

Recently it's been generating about 1000 log entries (many of which are combined multi-warnings).

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

The code should return early either way, but now with no warning and less work done before the return.