### PR TITLE
CRM: Skip WooSync tag insertion if there are no tags to insert

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-warnings_in_woosync_background_job
+++ b/projects/plugins/crm/changelog/fix-crm-warnings_in_woosync_background_job
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+WooSync: Skip tag insertion if there are no tags to insert.

--- a/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
+++ b/projects/plugins/crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php
@@ -789,13 +789,15 @@ class Woo_Sync_Background_Sync_Job {
 
 			$this->debug( 'Contact added/updated #' . $contact_id );
 
-			$zbs->DAL->contacts->addUpdateContactTags( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-				array(
-					'id'        => $contact_id,
-					'tag_input' => $crm_object_data['contact']['tags'],
-					'mode'      => 'append',
-				)
-			);
+			if ( ! empty( $crm_object_data['contact']['tags'] ) ) {
+				$zbs->DAL->contacts->addUpdateContactTags( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+					array(
+						'id'        => $contact_id,
+						'tag_input' => $crm_object_data['contact']['tags'],
+						'mode'      => 'append',
+					)
+				);
+			}
 
 			// contact logs
 			if ( is_array( $crm_object_data['contact_logs'] ) ) {


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
This PR prevents WooSync from trying to add tags to a contact when there are no tags provided for adding.

This addresses about 180K warnings per month attributed to Jetpack CRM on WP Cloud:
```
PHP Warning: Undefined array key "tags" in /srv/htdocs/wp-content/plugins/zero-bs-crm/modules/woo-sync/includes/class-woo-sync-background-sync-job.php on line 812
```

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

The code should be pretty clear.