### PR TITLE
Forms: Show email prefix initials instead of mystery person avatar

### DIFF
--- a/projects/packages/forms/changelog/fix-gravatar-email-initials
+++ b/projects/packages/forms/changelog/fix-gravatar-email-initials
@@ -1,4 +1,4 @@
 Significance: patch
-Type: enhancement
+Type: changed
 
 Gravatar: Show initials derived from email prefix instead of mystery person avatar when no name is provided.

--- a/projects/packages/forms/changelog/fix-gravatar-email-initials
+++ b/projects/packages/forms/changelog/fix-gravatar-email-initials
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Gravatar: Show initials derived from email prefix instead of mystery person avatar when no name is provided.

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -383,7 +383,10 @@ function StageInner() {
 					);
 					const showEmail =
 						item.author_email && displayName !== decodeEntities( item.author_email );
-					const defaultImage = item.author_name ? 'initials' : 'mp';
+					const gravatarName = item.author_name
+						? decodeEntities( item.author_name )
+						: item.author_email?.split( '@' )[ 0 ];
+					const defaultImage = gravatarName ? 'initials' : 'mp';
 
 					return (
 						<Stack align="center" gap="sm">
@@ -403,7 +406,7 @@ function StageInner() {
 							<Gravatar
 								email={ item.author_email || item.ip } // With IP we still return placeholder image
 								defaultImage={ defaultImage }
-								displayName={ item.author_name ? decodeEntities( item.author_name ) : undefined }
+								displayName={ gravatarName }
 								size={ 32 }
 								useHovercard={ false }
 							/>

--- a/projects/packages/forms/src/contact-form/class-feedback-author.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-author.php
@@ -149,11 +149,12 @@ class Feedback_Author {
 		$hash = md5( strtolower( trim( $this->email ) ) );
 		$name = $this->get_name();
 
-		if ( ! empty( $name ) ) {
-			return "https://gravatar.com/avatar/{$hash}?d=initials&name=" . rawurlencode( $name ) . '&s=96';
+		if ( empty( $name ) ) {
+			// Use the email prefix as a fallback for initials.
+			$name = strstr( $this->email, '@', true );
 		}
 
-		return "https://gravatar.com/avatar/{$hash}?d=mp&s=96";
+		return "https://gravatar.com/avatar/{$hash}?d=initials&name=" . rawurlencode( $name ) . '&s=96';
 	}
 
 	/**

--- a/projects/packages/forms/src/dashboard/components/inspector/response-meta/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-meta/index.tsx
@@ -43,8 +43,8 @@ const ResponseMeta = ( { response }: ResponseMetaProps ): import('react').JSX.El
 	const gravatarEmail = response.author_email || response.ip;
 	const gravatarDisplayName = response.author_name
 		? decodeEntities( response.author_name )
-		: undefined;
-	const defaultImage = response.author_name ? 'initials' : 'mp';
+		: response.author_email?.split( '@' )[ 0 ];
+	const defaultImage = gravatarDisplayName ? 'initials' : 'mp';
 
 	const responseAuthorEmailParts = response.author_email?.split( '@' ) ?? [];
 

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -378,7 +378,10 @@ export default function InboxView( { parentId, pageTitle, pageSubtitle } = {} ) 
 					const authorInfo = decodeEntities(
 						item.author_name || item.author_email || item.author_url || item.ip
 					);
-					const defaultImage = item.author_name ? 'initials' : 'mp';
+					const gravatarName = item.author_name
+						? decodeEntities( item.author_name )
+						: item.author_email?.split( '@' )[ 0 ];
+					const defaultImage = gravatarName ? 'initials' : 'mp';
 					const secondaryInfo =
 						item.author_email && authorInfo !== decodeEntities( item.author_email ) ? (
 							<span className="jp-forms__inbox__author-field__email">
@@ -412,7 +415,7 @@ export default function InboxView( { parentId, pageTitle, pageSubtitle } = {} ) 
 							<Gravatar
 								email={ item.author_email || item.ip } // With IP we still return placeholder image
 								defaultImage={ defaultImage }
-								displayName={ item.author_name ? decodeEntities( item.author_name ) : undefined }
+								displayName={ gravatarName }
 								key={ item.id }
 								size={ 32 }
 								useHovercard={ false }

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Author_Metadata_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Author_Metadata_Test.php
@@ -210,8 +210,8 @@ class Feedback_Author_Metadata_Test extends BaseTestCase {
 		$this->assertEquals( $email, $saved_response->get_author_email(), 'Author email should match the legacy feedback post author email' );
 		$avatar_url = $saved_response->get_author_avatar();
 		$this->assertStringContainsString( 'gravatar.com/avatar/', $avatar_url, 'Author avatar should be a Gravatar URL' );
-		$this->assertStringContainsString( 'd=mp', $avatar_url, 'Author avatar should use mystery person default when no name is set' );
-		$this->assertStringNotContainsString( 'name=', $avatar_url, 'Author avatar should not include name parameter when no name is set' );
+		$this->assertStringContainsString( 'd=initials', $avatar_url, 'Author avatar should use initials default with email prefix when no name is set' );
+		$this->assertStringContainsString( 'name=', $avatar_url, 'Author avatar should include name parameter derived from email prefix' );
 	}
 
 	public function test_computed_email() {


### PR DESCRIPTION
Fixes JETPACK-1456

## Proposed changes

* When a form response has an email but no name, use the email prefix (e.g. "test" from test@example.com) for Gravatar initials instead of falling back to the mystery person avatar.
* Only IP-only responses (no email, no name) still show the mystery person.
* This is a follow-up to #47779 which removed PII from Gravatar URLs but degraded the UI by showing mystery person for all responses without a name.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* See JETPACK-1456

## Does this pull request change what data or activity we track or use?

No. The email prefix is derived client-side and server-side from data already present in the response. No new data is sent to Gravatar -- the `name` parameter only affects the fallback initials image and does not contain the email address or any PII.

## Testing instructions

* Set up a Jetpack Forms contact form on a test site.
* Submit several responses with different combinations:
  1. Name + email (e.g. "Jane" / jane@example.com) -- should show Gravatar or "J" initials as before.
  2. Email only, no name (e.g. test@example.com) -- should now show "T" initials (from the email prefix) instead of mystery person.
  3. No name, no email (IP only) -- should still show mystery person.
* Check the responses in all three views:
  * Data Views table (`/wp-admin/admin.php?page=jetpack-forms&view=responses`)
  * Legacy Inbox view (`/wp-admin/admin.php?page=jetpack-forms&view=inbox`)
  * Response detail inspector (click a response to open the side panel)
* Verify the avatar URL in the `<img>` src does NOT contain the raw email address -- only a hash and the email prefix in the `name=` parameter.
