### PR TITLE
Social: Make X quota enforcement date-aware for sidebar toggle

### DIFF
--- a/projects/packages/publicize/_inc/components/connections-toggle-list/index.tsx
+++ b/projects/packages/publicize/_inc/components/connections-toggle-list/index.tsx
@@ -82,9 +82,9 @@ export function ConnectionsToggleList( {
 									{ connection.display_name }
 								</div>
 								{ disabledReason === 'quota_exceeded' && (
-									<div className={ styles[ 'disabled-reason' ] }>
-										{ __( 'X sharing limit reached', 'jetpack-publicize-pkg' ) }
-									</div>
+									<span className="description">
+										{ __( 'Sharing limit reached', 'jetpack-publicize-pkg' ) }
+									</span>
 								) }
 							</div>
 						</div>

--- a/projects/packages/publicize/_inc/components/connections-toggle-list/index.tsx
+++ b/projects/packages/publicize/_inc/components/connections-toggle-list/index.tsx
@@ -1,4 +1,4 @@
-import { Button, FormToggle, Tooltip } from '@wordpress/components';
+import { Button, FormToggle } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useCallback } from 'react';
@@ -50,7 +50,12 @@ export function ConnectionsToggleList( {
 
 				const ariaLabel = getA11yLabelForConnectionToggle( connection );
 
-				const toggleButton = (
+				const titleText =
+					disabledReason === 'quota_exceeded'
+						? __( 'Sharing limit reached', 'jetpack-publicize-pkg' )
+						: connection.display_name;
+
+				return (
 					<Button
 						key={ connection.connection_id }
 						role="switch"
@@ -67,6 +72,7 @@ export function ConnectionsToggleList( {
 						onClick={ onClickConnection( connection ) }
 						aria-label={ ariaLabel }
 						aria-checked={ isSelected }
+						title={ titleText }
 						className={ clsx( styles.item, getItemClassName?.( connection ) ) }
 					>
 						<div className={ styles[ 'connection-info' ] }>
@@ -77,22 +83,11 @@ export function ConnectionsToggleList( {
 								disabled={ isDisabled }
 								aria-label={ ariaLabel }
 							/>
-							<div className={ styles[ 'display-name' ] } title={ connection.display_name }>
+							<div className={ styles[ 'display-name' ] } title={ titleText }>
 								{ connection.display_name }
 							</div>
 						</div>
 					</Button>
-				);
-
-				return disabledReason === 'quota_exceeded' ? (
-					<Tooltip
-						key={ connection.connection_id }
-						text={ __( 'Sharing limit reached', 'jetpack-publicize-pkg' ) }
-					>
-						{ toggleButton }
-					</Tooltip>
-				) : (
-					toggleButton
 				);
 			} ) }
 		</div>

--- a/projects/packages/publicize/_inc/components/connections-toggle-list/index.tsx
+++ b/projects/packages/publicize/_inc/components/connections-toggle-list/index.tsx
@@ -1,4 +1,4 @@
-import { Button, FormToggle } from '@wordpress/components';
+import { Button, FormToggle, Tooltip } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useCallback } from 'react';
@@ -50,7 +50,7 @@ export function ConnectionsToggleList( {
 
 				const ariaLabel = getA11yLabelForConnectionToggle( connection );
 
-				return (
+				const toggleButton = (
 					<Button
 						key={ connection.connection_id }
 						role="switch"
@@ -77,18 +77,22 @@ export function ConnectionsToggleList( {
 								disabled={ isDisabled }
 								aria-label={ ariaLabel }
 							/>
-							<div>
-								<div className={ styles[ 'display-name' ] } title={ connection.display_name }>
-									{ connection.display_name }
-								</div>
-								{ disabledReason === 'quota_exceeded' && (
-									<span className="description">
-										{ __( 'Sharing limit reached', 'jetpack-publicize-pkg' ) }
-									</span>
-								) }
+							<div className={ styles[ 'display-name' ] } title={ connection.display_name }>
+								{ connection.display_name }
 							</div>
 						</div>
 					</Button>
+				);
+
+				return disabledReason === 'quota_exceeded' ? (
+					<Tooltip
+						key={ connection.connection_id }
+						text={ __( 'Sharing limit reached', 'jetpack-publicize-pkg' ) }
+					>
+						{ toggleButton }
+					</Tooltip>
+				) : (
+					toggleButton
 				);
 			} ) }
 		</div>

--- a/projects/packages/publicize/_inc/components/connections-toggle-list/index.tsx
+++ b/projects/packages/publicize/_inc/components/connections-toggle-list/index.tsx
@@ -26,7 +26,7 @@ export function ConnectionsToggleList( {
 	onClickItem,
 	getItemClassName,
 }: ConnectionsToggleListProps ) {
-	const { canBeTurnedOn, shouldBeDisabled } = useConnectionState();
+	const { canBeTurnedOn, shouldBeDisabled, getDisabledReason } = useConnectionState();
 	const { connections } = useSocialMediaConnections();
 
 	const onClickConnection = useCallback(
@@ -46,6 +46,7 @@ export function ConnectionsToggleList( {
 				const isSelected = Boolean( canBeTurnedOn( connection ) && connection.enabled );
 
 				const isDisabled = shouldBeDisabled( connection );
+				const disabledReason = getDisabledReason( connection );
 
 				const ariaLabel = getA11yLabelForConnectionToggle( connection );
 
@@ -76,8 +77,15 @@ export function ConnectionsToggleList( {
 								disabled={ isDisabled }
 								aria-label={ ariaLabel }
 							/>
-							<div className={ styles[ 'display-name' ] } title={ connection.display_name }>
-								{ connection.display_name }
+							<div>
+								<div className={ styles[ 'display-name' ] } title={ connection.display_name }>
+									{ connection.display_name }
+								</div>
+								{ disabledReason === 'quota_exceeded' && (
+									<div className={ styles[ 'disabled-reason' ] }>
+										{ __( 'X sharing limit reached', 'jetpack-publicize-pkg' ) }
+									</div>
+								) }
 							</div>
 						</div>
 					</Button>

--- a/projects/packages/publicize/_inc/components/connections-toggle-list/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/connections-toggle-list/styles.module.scss
@@ -28,9 +28,4 @@
 		text-align: start;
 	}
 
-	.disabled-reason {
-		font-size: 0.75rem;
-		color: gb.$alert-red;
-		text-align: start;
-	}
 }

--- a/projects/packages/publicize/_inc/components/connections-toggle-list/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/connections-toggle-list/styles.module.scss
@@ -27,4 +27,10 @@
 		white-space: nowrap;
 		text-align: start;
 	}
+
+	.disabled-reason {
+		font-size: 0.75rem;
+		color: gb.$alert-red;
+		text-align: start;
+	}
 }

--- a/projects/packages/publicize/_inc/components/customize-and-preview/connection-toggle/index.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/connection-toggle/index.tsx
@@ -20,7 +20,7 @@ export type ConnectionToggleProps = {
 export function ConnectionToggle( { connection }: ConnectionToggleProps ) {
 	const { toggleById } = useSocialMediaConnections();
 	const { recordEvent } = useAnalytics();
-	const { canBeTurnedOn, shouldBeDisabled } = useConnectionState();
+	const { canSchedule, getWarningReason } = useConnectionState();
 
 	const onClickConnectionToggle = useCallback( () => {
 		toggleById( connection.connection_id );
@@ -38,21 +38,35 @@ export function ConnectionToggle( { connection }: ConnectionToggleProps ) {
 		toggleById,
 	] );
 
-	const isEnabled = Boolean( canBeTurnedOn( connection ) && connection.enabled );
-	const isDisabled = shouldBeDisabled( connection );
+	const warningReason = getWarningReason( connection );
+	const hasScheduleHint = warningReason === 'quota_exceeded_schedule_hint';
+
+	const canScheduleConnection = canSchedule( connection );
+	const isEnabled = Boolean( canScheduleConnection && connection.enabled );
+	const isDisabled = ! canScheduleConnection;
 
 	return (
-		<ToggleControl
-			__nextHasNoMarginBottom
-			label={ sprintf(
-				/* translators: %s: social media account title */
-				__( 'Share to %s', 'jetpack-publicize-pkg' ),
-				connection.display_name
+		<div>
+			<ToggleControl
+				__nextHasNoMarginBottom
+				label={ sprintf(
+					/* translators: %s: social media account title */
+					__( 'Share to %s', 'jetpack-publicize-pkg' ),
+					connection.display_name
+				) }
+				className={ styles[ 'connection-toggle' ] }
+				checked={ isEnabled }
+				onChange={ onClickConnectionToggle }
+				disabled={ isDisabled }
+			/>
+			{ hasScheduleHint && (
+				<p className={ styles.description }>
+					{ __(
+						'Current month limit reached. Schedule for a future month.',
+						'jetpack-publicize-pkg'
+					) }
+				</p>
 			) }
-			className={ styles[ 'connection-toggle' ] }
-			checked={ isEnabled }
-			onChange={ onClickConnectionToggle }
-			disabled={ isDisabled }
-		/>
+		</div>
 	);
 }

--- a/projects/packages/publicize/_inc/components/customize-and-preview/connection-toggle/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/connection-toggle/styles.module.scss
@@ -8,3 +8,9 @@
 		white-space: nowrap;
 	}
 }
+
+.description {
+	color: var(--wp-components-color-gray-600, #757575);
+	font-size: 12px;
+	margin-block-start: 0;
+}

--- a/projects/packages/publicize/_inc/components/form/use-connection-state.ts
+++ b/projects/packages/publicize/_inc/components/form/use-connection-state.ts
@@ -1,4 +1,6 @@
 import { useSelect } from '@wordpress/data';
+import { date } from '@wordpress/date';
+import { store as editorStore } from '@wordpress/editor';
 import { useCallback } from '@wordpress/element';
 import { useMemo } from 'react';
 import useAttachedMedia from '../../hooks/use-attached-media';
@@ -23,7 +25,20 @@ export const useConnectionState = () => {
 		useMediaDetails( mediaId )[ 0 ]
 	);
 
-	const xQuotaExceeded = useSelect( select => select( socialStore ).isXQuotaExceeded(), [] );
+	const postDate = useSelect(
+		select => select( editorStore ).getEditedPostAttribute( 'date' ) as string | undefined,
+		[]
+	);
+
+	// Derive the period from the post date so quota checks apply to the correct month.
+	const postPeriod = postDate ? date( 'Y-m', postDate ) : null;
+
+	const canShareNow = useSelect( select => select( socialStore ).canShareToXNow(), [] );
+
+	const canScheduleFor = useSelect(
+		select => select( socialStore ).canScheduleXShareFor( postPeriod ),
+		[ postPeriod ]
+	);
 
 	/**
 	 * Returns whether a connection is in good shape.
@@ -59,6 +74,7 @@ export const useConnectionState = () => {
 	 * - Publicize is disabled
 	 * - There are no more connections available
 	 * - The connection is not in good shape
+	 * - X quota is exceeded for the post's target month
 	 */
 	const shouldBeDisabled = useCallback(
 		( connection: Connection ) => {
@@ -67,11 +83,11 @@ export const useConnectionState = () => {
 				! isPublicizeEnabled ||
 				// or the connection is not in good shape
 				! isInGoodShape( connection ) ||
-				// or X quota is exceeded for X connections
-				( connection.service_name === 'x' && xQuotaExceeded )
+				// or X quota is exceeded for the post's target month
+				( connection.service_name === 'x' && ! canScheduleFor )
 			);
 		},
-		[ isInGoodShape, isPublicizeEnabled, xQuotaExceeded ]
+		[ isInGoodShape, isPublicizeEnabled, canScheduleFor ]
 	);
 
 	/**
@@ -81,38 +97,68 @@ export const useConnectionState = () => {
 	 * A connection can be enabled if:
 	 * - Publicize is not disabled due to the current site plan
 	 * - The connection is in good shape
+	 * - X quota allows sharing for the post's target month
 	 */
 	const canBeTurnedOn = useCallback(
 		( connection: Connection ) => {
-			// A connection toggle can be turned ON if
 			return (
 				// Publicize is not disabled due to the current site plan
 				! isPublicizeDisabledBySitePlan &&
 				// and the connection is in good shape
 				isInGoodShape( connection ) &&
-				// and X quota is not exceeded for X connections
-				! ( connection.service_name === 'x' && xQuotaExceeded )
+				// and X quota allows sharing for the post's target month
+				! ( connection.service_name === 'x' && ! canScheduleFor )
 			);
 		},
-		[ isInGoodShape, isPublicizeDisabledBySitePlan, xQuotaExceeded ]
+		[ isInGoodShape, isPublicizeDisabledBySitePlan, canScheduleFor ]
+	);
+
+	/**
+	 * Returns whether a connection can be used for scheduling a share.
+	 */
+	const canSchedule = useCallback(
+		( connection: Connection ) => {
+			return (
+				isPublicizeEnabled &&
+				! isPublicizeDisabledBySitePlan &&
+				isInGoodShape( connection ) &&
+				! ( connection.service_name === 'x' && ! canScheduleFor )
+			);
+		},
+		[ isInGoodShape, isPublicizeEnabled, isPublicizeDisabledBySitePlan, canScheduleFor ]
 	);
 
 	const getDisabledReason = useCallback(
 		( connection: Connection ) => {
-			if ( connection.service_name === 'x' && xQuotaExceeded ) {
+			if ( connection.service_name === 'x' && ! canScheduleFor ) {
 				return 'quota_exceeded';
 			}
 			return undefined;
 		},
-		[ xQuotaExceeded ]
+		[ canScheduleFor ]
+	);
+
+	const getWarningReason = useCallback(
+		( connection: Connection ) => {
+			// Show the "schedule for a future month" hint only when the current month is
+			// exceeded and no specific post date is set yet. If the post already targets
+			// a future month with available quota, the hint is redundant.
+			if ( connection.service_name === 'x' && ! canShareNow && ! postPeriod ) {
+				return 'quota_exceeded_schedule_hint';
+			}
+			return undefined;
+		},
+		[ canShareNow, postPeriod ]
 	);
 
 	return useMemo(
 		() => ( {
 			shouldBeDisabled,
 			canBeTurnedOn,
+			canSchedule,
 			getDisabledReason,
+			getWarningReason,
 		} ),
-		[ shouldBeDisabled, canBeTurnedOn, getDisabledReason ]
+		[ shouldBeDisabled, canBeTurnedOn, canSchedule, getDisabledReason, getWarningReason ]
 	);
 };

--- a/projects/packages/publicize/_inc/components/form/use-connection-state.ts
+++ b/projects/packages/publicize/_inc/components/form/use-connection-state.ts
@@ -100,7 +100,7 @@ export const useConnectionState = () => {
 	const getDisabledReason = useCallback(
 		( connection: Connection ) => {
 			if ( connection.service_name === 'x' && xQuotaExceeded ) {
-				return 'quota_exceeded' as const;
+				return 'quota_exceeded';
 			}
 			return undefined;
 		},

--- a/projects/packages/publicize/_inc/components/form/use-connection-state.ts
+++ b/projects/packages/publicize/_inc/components/form/use-connection-state.ts
@@ -1,3 +1,4 @@
+import { useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { useMemo } from 'react';
 import useAttachedMedia from '../../hooks/use-attached-media';
@@ -7,6 +8,7 @@ import useMediaRestrictions from '../../hooks/use-media-restrictions';
 import { NO_MEDIA_ERROR } from '../../hooks/use-media-restrictions/constants';
 import usePublicizeConfig from '../../hooks/use-publicize-config';
 import useSocialMediaConnections from '../../hooks/use-social-media-connections';
+import { store as socialStore } from '../../social-store';
 import { Connection } from '../../social-store/types';
 
 export const useConnectionState = () => {
@@ -20,6 +22,8 @@ export const useConnectionState = () => {
 		connections,
 		useMediaDetails( mediaId )[ 0 ]
 	);
+
+	const xQuotaExceeded = useSelect( select => select( socialStore ).isXQuotaExceeded(), [] );
 
 	/**
 	 * Returns whether a connection is in good shape.
@@ -62,10 +66,12 @@ export const useConnectionState = () => {
 				// Publicize is disabled
 				! isPublicizeEnabled ||
 				// or the connection is not in good shape
-				! isInGoodShape( connection )
+				! isInGoodShape( connection ) ||
+				// or X quota is exceeded for X connections
+				( connection.service_name === 'x' && xQuotaExceeded )
 			);
 		},
-		[ isInGoodShape, isPublicizeEnabled ]
+		[ isInGoodShape, isPublicizeEnabled, xQuotaExceeded ]
 	);
 
 	/**
@@ -83,17 +89,30 @@ export const useConnectionState = () => {
 				// Publicize is not disabled due to the current site plan
 				! isPublicizeDisabledBySitePlan &&
 				// and the connection is in good shape
-				isInGoodShape( connection )
+				isInGoodShape( connection ) &&
+				// and X quota is not exceeded for X connections
+				! ( connection.service_name === 'x' && xQuotaExceeded )
 			);
 		},
-		[ isInGoodShape, isPublicizeDisabledBySitePlan ]
+		[ isInGoodShape, isPublicizeDisabledBySitePlan, xQuotaExceeded ]
+	);
+
+	const getDisabledReason = useCallback(
+		( connection: Connection ) => {
+			if ( connection.service_name === 'x' && xQuotaExceeded ) {
+				return 'quota_exceeded' as const;
+			}
+			return undefined;
+		},
+		[ xQuotaExceeded ]
 	);
 
 	return useMemo(
 		() => ( {
 			shouldBeDisabled,
 			canBeTurnedOn,
+			getDisabledReason,
 		} ),
-		[ shouldBeDisabled, canBeTurnedOn ]
+		[ shouldBeDisabled, canBeTurnedOn, getDisabledReason ]
 	);
 };

--- a/projects/packages/publicize/_inc/components/x-usage/constants.ts
+++ b/projects/packages/publicize/_inc/components/x-usage/constants.ts
@@ -1,3 +1,2 @@
-export const FREE_PLAN_LIMIT = 5;
-export const PAID_PLAN_LIMIT = 100;
+export { FREE_PLAN_LIMIT, PAID_PLAN_LIMIT } from '../../social-store/constants';
 export const WARNING_THRESHOLD = 0.8;

--- a/projects/packages/publicize/_inc/components/x-usage/utils.ts
+++ b/projects/packages/publicize/_inc/components/x-usage/utils.ts
@@ -2,6 +2,7 @@ import { getRedirectUrl } from '@automattic/jetpack-components';
 import { getSiteFragment } from '@automattic/jetpack-shared-extension-utils';
 import { date, getDate, humanTimeDiff } from '@wordpress/date';
 import { __, sprintf } from '@wordpress/i18n';
+import { hasSocialPaidFeatures } from '../../utils/script-data';
 import styles from './styles.module.scss';
 
 /**
@@ -40,6 +41,16 @@ export function getUpgradeUrl() {
  */
 export function getCurrentPeriod() {
 	return date( 'Y-m' );
+}
+
+/**
+ * Get the period identifier for a given unix timestamp.
+ *
+ * @param {number} timestamp - Unix timestamp in seconds.
+ * @return The period string ('yyyy-mm' for paid plans, 'free' for free plans).
+ */
+export function getPeriodForTimestamp( timestamp: number ): string {
+	return hasSocialPaidFeatures() ? date( 'Y-m', new Date( timestamp * 1000 ) ) : 'free';
 }
 
 /**

--- a/projects/packages/publicize/_inc/social-store/actions/scheduled-shares.ts
+++ b/projects/packages/publicize/_inc/social-store/actions/scheduled-shares.ts
@@ -2,6 +2,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
+import { getPeriodForTimestamp } from '../../components/x-usage/utils';
 import { ScheduledShare } from '../types';
 import { SET_IS_SCHEDULING_SHARES } from './constants';
 
@@ -116,7 +117,7 @@ export function scheduleShares(
 	{ message, connectionIds, timestamp }: ScheduledSharesParams,
 	{ savePost = true, actions = [] }: ScheduledSharesConfig
 ) {
-	return async function ( { dispatch, registry } ): Promise< boolean > {
+	return async function ( { dispatch, select, registry } ): Promise< boolean > {
 		if ( ! connectionIds.length || ! timestamp ) {
 			return false;
 		}
@@ -124,7 +125,47 @@ export function scheduleShares(
 		const { isCurrentPostPublished, isEditedPostDirty, isEditedPostAutosaveable } =
 			registry.select( editorStore );
 
-		const { createErrorNotice, createSuccessNotice } = registry.dispatch( noticesStore );
+		const { createErrorNotice, createSuccessNotice, createWarningNotice } =
+			registry.dispatch( noticesStore );
+
+		// Check if X quota is exceeded for the target month.
+		let effectiveConnectionIds = connectionIds;
+		const targetPeriod = getPeriodForTimestamp( timestamp );
+
+		if ( select.isXQuotaExceeded( targetPeriod ) ) {
+			const connections = select.getConnections();
+			const xConnectionIds = new Set(
+				connections
+					.filter( connection => connection.service_name === 'x' )
+					.map( connection => Number( connection.connection_id ) )
+			);
+
+			effectiveConnectionIds = connectionIds.filter( id => ! xConnectionIds.has( id ) );
+
+			if ( ! effectiveConnectionIds.length ) {
+				createErrorNotice(
+					__(
+						'X sharing quota reached for the scheduled month. Please choose a different month or remove X from your sharing selections.',
+						'jetpack-publicize-pkg'
+					),
+					{
+						id: SCHEDULE_SHARE_NOTICE_ID,
+					}
+				);
+				return false;
+			}
+
+			createWarningNotice(
+				__(
+					'X sharing limit reached for the scheduled month. The post will be shared to your other connections only.',
+					'jetpack-publicize-pkg'
+				),
+				{
+					type: 'snackbar',
+					id: SCHEDULE_SHARE_NOTICE_ID,
+				}
+			);
+		}
 
 		if ( ! isCurrentPostPublished() ) {
 			createErrorNotice(
@@ -146,7 +187,7 @@ export function scheduleShares(
 		const post_id = registry.select( editorStore ).getCurrentPostId();
 
 		const result = await Promise.all(
-			connectionIds.map( connection_id => {
+			effectiveConnectionIds.map( connection_id => {
 				return dispatch(
 					createScheduledShare( {
 						post_id,

--- a/projects/packages/publicize/_inc/social-store/constants.ts
+++ b/projects/packages/publicize/_inc/social-store/constants.ts
@@ -7,6 +7,10 @@ export const SHOW_PRICING_PAGE_KEY = 'jetpack-social_show_pricing_page';
 
 export const CUSTOMIZE_PER_NETWORK_KEY = '_wpas_customize_per_network';
 
+// X usage quota limits
+export const FREE_PLAN_LIMIT = 5;
+export const PAID_PLAN_LIMIT = 100;
+
 /**
  * This is to avoid creating a new empty array each time.
  *

--- a/projects/packages/publicize/_inc/social-store/selectors/test/x-usage.test.ts
+++ b/projects/packages/publicize/_inc/social-store/selectors/test/x-usage.test.ts
@@ -16,7 +16,13 @@ jest.mock( '@wordpress/data', () => ( {
 	createRegistrySelector: () => () => mockUsageData,
 } ) );
 
-import { isXQuotaExceeded, canShareToX, getXQuotaRemaining, getXUsageFor } from '../x-usage';
+import {
+	isXQuotaExceeded,
+	canShareToXNow,
+	canScheduleXShareFor,
+	getXQuotaRemaining,
+	getXUsageFor,
+} from '../x-usage';
 
 describe( 'Social store selectors: x-usage enforcement', () => {
 	beforeEach( () => {
@@ -97,24 +103,74 @@ describe( 'Social store selectors: x-usage enforcement', () => {
 		} );
 	} );
 
-	describe( 'canShareToX', () => {
+	describe( 'canShareToXNow', () => {
 		it( 'should return true when under limit', () => {
 			mockUsageData = [ { period: 'free', used: 2, pending: 1, total: 3 } ];
-			expect( canShareToX( {} ) ).toBe( true );
+			expect( canShareToXNow( {} ) ).toBe( true );
 		} );
 
 		it( 'should return false when at limit', () => {
 			mockUsageData = [ { period: 'free', used: 4, pending: 1, total: 5 } ];
-			expect( canShareToX( {} ) ).toBe( false );
+			expect( canShareToXNow( {} ) ).toBe( false );
 		} );
 
 		it( 'should return false when over limit', () => {
 			mockUsageData = [ { period: 'free', used: 5, pending: 1, total: 6 } ];
-			expect( canShareToX( {} ) ).toBe( false );
+			expect( canShareToXNow( {} ) ).toBe( false );
 		} );
 
 		it( 'should return true when data is missing (defaults to allowing)', () => {
-			expect( canShareToX( {} ) ).toBe( true );
+			expect( canShareToXNow( {} ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'canScheduleXShareFor', () => {
+		describe( 'free plan', () => {
+			it( 'should return false when quota exhausted (no period)', () => {
+				mockUsageData = [ { period: 'free', used: 4, pending: 1, total: 5 } ];
+				expect( canScheduleXShareFor( {} ) ).toBe( false );
+			} );
+
+			it( 'should return true when under limit (no period)', () => {
+				mockUsageData = [ { period: 'free', used: 2, pending: 1, total: 3 } ];
+				expect( canScheduleXShareFor( {} ) ).toBe( true );
+			} );
+
+			it( 'should ignore period argument and check lifetime quota', () => {
+				mockUsageData = [ { period: 'free', used: 4, pending: 1, total: 5 } ];
+				expect( canScheduleXShareFor( {}, '2026-04' ) ).toBe( false );
+			} );
+		} );
+
+		describe( 'paid plan', () => {
+			beforeEach( () => {
+				mockHasPaidFeatures = true;
+			} );
+
+			it( 'should return true when no period specified (user can pick future month)', () => {
+				mockUsageData = [ { period: '2026-03', used: 90, pending: 10, total: 100 } ];
+				expect( canScheduleXShareFor( {} ) ).toBe( true );
+			} );
+
+			it( 'should return true with null period', () => {
+				mockUsageData = [ { period: '2026-03', used: 90, pending: 10, total: 100 } ];
+				expect( canScheduleXShareFor( {}, null ) ).toBe( true );
+			} );
+
+			it( 'should return false when specific period quota is exhausted', () => {
+				mockUsageData = [ { period: '2026-04', used: 90, pending: 10, total: 100 } ];
+				expect( canScheduleXShareFor( {}, '2026-04' ) ).toBe( false );
+			} );
+
+			it( 'should return true when specific period has remaining quota', () => {
+				mockUsageData = [ { period: '2026-04', used: 40, pending: 10, total: 50 } ];
+				expect( canScheduleXShareFor( {}, '2026-04' ) ).toBe( true );
+			} );
+
+			it( 'should return true for a future period with no usage data', () => {
+				mockUsageData = [ { period: '2026-03', used: 90, pending: 10, total: 100 } ];
+				expect( canScheduleXShareFor( {}, '2026-04' ) ).toBe( true );
+			} );
 		} );
 	} );
 

--- a/projects/packages/publicize/_inc/social-store/selectors/test/x-usage.test.ts
+++ b/projects/packages/publicize/_inc/social-store/selectors/test/x-usage.test.ts
@@ -1,0 +1,172 @@
+// Mock hasSocialPaidFeatures
+let mockHasPaidFeatures = false;
+jest.mock( '../../../utils/script-data', () => ( {
+	hasSocialPaidFeatures: () => mockHasPaidFeatures,
+} ) );
+
+// Mock getCurrentPeriod
+jest.mock( '../../../components/x-usage/utils', () => ( {
+	getCurrentPeriod: () => '2026-03',
+} ) );
+
+// Mock the registry selectors — getXUsage returns configurable data
+let mockUsageData: Array< { period: string; used: number; pending: number; total: number } > = [];
+jest.mock( '@wordpress/core-data', () => ( {} ) );
+jest.mock( '@wordpress/data', () => ( {
+	createRegistrySelector: () => () => mockUsageData,
+} ) );
+
+import { isXQuotaExceeded, canShareToX, getXQuotaRemaining, getXUsageFor } from '../x-usage';
+
+describe( 'Social store selectors: x-usage enforcement', () => {
+	beforeEach( () => {
+		mockHasPaidFeatures = false;
+		mockUsageData = [];
+	} );
+
+	describe( 'isXQuotaExceeded', () => {
+		describe( 'free plan', () => {
+			it( 'should return true when at limit (5)', () => {
+				mockUsageData = [ { period: 'free', used: 4, pending: 1, total: 5 } ];
+				expect( isXQuotaExceeded( {} ) ).toBe( true );
+			} );
+
+			it( 'should return true when over limit (6)', () => {
+				mockUsageData = [ { period: 'free', used: 5, pending: 1, total: 6 } ];
+				expect( isXQuotaExceeded( {} ) ).toBe( true );
+			} );
+
+			it( 'should return false when under limit (3)', () => {
+				mockUsageData = [ { period: 'free', used: 2, pending: 1, total: 3 } ];
+				expect( isXQuotaExceeded( {} ) ).toBe( false );
+			} );
+
+			it( 'should return false when no data', () => {
+				expect( isXQuotaExceeded( {} ) ).toBe( false );
+			} );
+
+			it( 'should use "free" period by default', () => {
+				mockUsageData = [
+					{ period: 'free', used: 4, pending: 1, total: 5 },
+					{ period: '2026-03', used: 0, pending: 0, total: 0 },
+				];
+				expect( isXQuotaExceeded( {} ) ).toBe( true );
+			} );
+		} );
+
+		describe( 'paid plan', () => {
+			beforeEach( () => {
+				mockHasPaidFeatures = true;
+			} );
+
+			it( 'should return true when at limit (100)', () => {
+				mockUsageData = [ { period: '2026-03', used: 90, pending: 10, total: 100 } ];
+				expect( isXQuotaExceeded( {} ) ).toBe( true );
+			} );
+
+			it( 'should return true when over limit', () => {
+				mockUsageData = [ { period: '2026-03', used: 100, pending: 5, total: 105 } ];
+				expect( isXQuotaExceeded( {} ) ).toBe( true );
+			} );
+
+			it( 'should return false when under limit', () => {
+				mockUsageData = [ { period: '2026-03', used: 40, pending: 10, total: 50 } ];
+				expect( isXQuotaExceeded( {} ) ).toBe( false );
+			} );
+
+			it( 'should return false when no data', () => {
+				expect( isXQuotaExceeded( {} ) ).toBe( false );
+			} );
+
+			it( 'should use current period by default', () => {
+				mockUsageData = [
+					{ period: 'free', used: 4, pending: 1, total: 5 },
+					{ period: '2026-03', used: 90, pending: 10, total: 100 },
+				];
+				expect( isXQuotaExceeded( {} ) ).toBe( true );
+			} );
+		} );
+
+		it( 'should accept an explicit period parameter', () => {
+			mockUsageData = [
+				{ period: '2026-01', used: 4, pending: 1, total: 5 },
+				{ period: '2026-02', used: 1, pending: 0, total: 1 },
+			];
+			expect( isXQuotaExceeded( {}, '2026-01' ) ).toBe( true );
+			expect( isXQuotaExceeded( {}, '2026-02' ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'canShareToX', () => {
+		it( 'should return true when under limit', () => {
+			mockUsageData = [ { period: 'free', used: 2, pending: 1, total: 3 } ];
+			expect( canShareToX( {} ) ).toBe( true );
+		} );
+
+		it( 'should return false when at limit', () => {
+			mockUsageData = [ { period: 'free', used: 4, pending: 1, total: 5 } ];
+			expect( canShareToX( {} ) ).toBe( false );
+		} );
+
+		it( 'should return false when over limit', () => {
+			mockUsageData = [ { period: 'free', used: 5, pending: 1, total: 6 } ];
+			expect( canShareToX( {} ) ).toBe( false );
+		} );
+
+		it( 'should return true when data is missing (defaults to allowing)', () => {
+			expect( canShareToX( {} ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'getXQuotaRemaining', () => {
+		it( 'should return correct remaining for free plan', () => {
+			mockUsageData = [ { period: 'free', used: 2, pending: 1, total: 3 } ];
+			expect( getXQuotaRemaining( {} ) ).toBe( 2 );
+		} );
+
+		it( 'should return correct remaining for paid plan', () => {
+			mockHasPaidFeatures = true;
+			mockUsageData = [ { period: '2026-03', used: 40, pending: 10, total: 50 } ];
+			expect( getXQuotaRemaining( {} ) ).toBe( 50 );
+		} );
+
+		it( 'should never return negative', () => {
+			mockUsageData = [ { period: 'free', used: 5, pending: 1, total: 6 } ];
+			expect( getXQuotaRemaining( {} ) ).toBe( 0 );
+		} );
+
+		it( 'should return full limit when no data (free plan)', () => {
+			expect( getXQuotaRemaining( {} ) ).toBe( 5 );
+		} );
+
+		it( 'should return full limit when no data (paid plan)', () => {
+			mockHasPaidFeatures = true;
+			expect( getXQuotaRemaining( {} ) ).toBe( 100 );
+		} );
+
+		it( 'should accept an explicit period parameter', () => {
+			mockUsageData = [ { period: '2026-01', used: 3, pending: 0, total: 3 } ];
+			expect( getXQuotaRemaining( {}, '2026-01' ) ).toBe( 2 );
+		} );
+	} );
+
+	describe( 'getXUsageFor', () => {
+		it( 'should return the usage item for the given period', () => {
+			mockUsageData = [
+				{ period: 'free', used: 3, pending: 0, total: 3 },
+				{ period: '2026-03', used: 10, pending: 5, total: 15 },
+			];
+			expect( getXUsageFor( {}, 'free' ) ).toEqual( {
+				period: 'free',
+				used: 3,
+				pending: 0,
+				total: 3,
+			} );
+		} );
+
+		it( 'should return undefined when no matching period', () => {
+			mockUsageData = [ { period: 'free', used: 3, pending: 0, total: 3 } ];
+			expect( getXUsageFor( {}, 'nonexistent' ) ).toBeUndefined();
+		} );
+	} );
+} );

--- a/projects/packages/publicize/_inc/social-store/selectors/x-usage.ts
+++ b/projects/packages/publicize/_inc/social-store/selectors/x-usage.ts
@@ -84,14 +84,43 @@ export function isXQuotaExceeded( state: object, period?: string ): boolean {
 }
 
 /**
- * Returns whether the user can share to X.
+ * Returns whether the user can share to X right now (current period).
  *
  * @param state - State object.
  *
- * @return Whether sharing to X is allowed. Defaults to true when data is missing.
+ * @return Whether sharing to X is allowed now. Defaults to true when data is missing.
  */
-export function canShareToX( state: object ): boolean {
+export function canShareToXNow( state: object ): boolean {
 	return ! isXQuotaExceeded( state );
+}
+
+/**
+ * Returns whether the user can schedule an X share.
+ *
+ * Behavior:
+ * - Free plan, quota exhausted → false (lifetime limit)
+ * - Paid plan, no period specified → true (user can pick a future month)
+ * - Paid plan, period specified → checks that period's usage against quota
+ *
+ * @param state  - State object.
+ * @param period - Optional period to check (e.g. 'yyyy-mm'). When omitted,
+ *               paid plans always return true; free plans check lifetime quota.
+ *
+ * @return Whether scheduling an X share is allowed.
+ */
+export function canScheduleXShareFor( state: object, period?: string | null ): boolean {
+	// Free plan: always check the lifetime 'free' period.
+	if ( ! hasSocialPaidFeatures() ) {
+		return ! isXQuotaExceeded( state );
+	}
+
+	// Paid plan without a specific period: allow scheduling (user can pick a future month).
+	if ( ! period ) {
+		return true;
+	}
+
+	// Paid plan with a specific period: check that period's quota.
+	return ! isXQuotaExceeded( state, period );
 }
 
 /**

--- a/projects/packages/publicize/_inc/social-store/selectors/x-usage.ts
+++ b/projects/packages/publicize/_inc/social-store/selectors/x-usage.ts
@@ -1,6 +1,8 @@
 import { store as coreStore } from '@wordpress/core-data';
 import { createRegistrySelector } from '@wordpress/data';
-import { EMPTY_ARRAY } from '../constants';
+import { getCurrentPeriod } from '../../components/x-usage/utils';
+import { hasSocialPaidFeatures } from '../../utils/script-data';
+import { EMPTY_ARRAY, FREE_PLAN_LIMIT, PAID_PLAN_LIMIT } from '../constants';
 
 export type XUsageItem = {
 	period: string;
@@ -43,3 +45,66 @@ export const isFetchingXUsage = createRegistrySelector( select => (): boolean =>
 
 	return isResolving( 'getEntityRecords', [ 'wpcom/v2', 'publicize/x-usage' ] );
 } );
+
+/**
+ * Returns the quota limit for the current plan.
+ *
+ * @return The quota limit.
+ */
+function getQuotaLimit() {
+	return hasSocialPaidFeatures() ? PAID_PLAN_LIMIT : FREE_PLAN_LIMIT;
+}
+
+/**
+ * Returns the default period based on plan type.
+ *
+ * @return The default period identifier.
+ */
+function getDefaultPeriod() {
+	return hasSocialPaidFeatures() ? getCurrentPeriod() : 'free';
+}
+
+/**
+ * Returns whether the X sharing quota has been exceeded.
+ *
+ * @param state  - State object.
+ * @param period - The period identifier. Defaults based on plan type.
+ *
+ * @return Whether the quota is exceeded. Defaults to false when data is missing.
+ */
+export function isXQuotaExceeded( state: object, period?: string ): boolean {
+	const resolvedPeriod = period ?? getDefaultPeriod();
+	const usageItem = getXUsageFor( state, resolvedPeriod );
+
+	if ( ! usageItem ) {
+		return false;
+	}
+
+	return usageItem.total >= getQuotaLimit();
+}
+
+/**
+ * Returns whether the user can share to X.
+ *
+ * @param state - State object.
+ *
+ * @return Whether sharing to X is allowed. Defaults to true when data is missing.
+ */
+export function canShareToX( state: object ): boolean {
+	return ! isXQuotaExceeded( state );
+}
+
+/**
+ * Returns the number of remaining X shares for the current period.
+ *
+ * @param state  - State object.
+ * @param period - The period identifier. Defaults based on plan type.
+ *
+ * @return The number of remaining shares, never negative.
+ */
+export function getXQuotaRemaining( state: object, period?: string ): number {
+	const resolvedPeriod = period ?? getDefaultPeriod();
+	const usageItem = getXUsageFor( state, resolvedPeriod );
+
+	return Math.max( 0, getQuotaLimit() - ( usageItem?.total ?? 0 ) );
+}

--- a/projects/packages/publicize/changelog/social-418-add-quota-enforcement-selectors-to-social-store
+++ b/projects/packages/publicize/changelog/social-418-add-quota-enforcement-selectors-to-social-store
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Social: Add quota enforcement selectors and disable X toggle when sharing limit is reached.


### PR DESCRIPTION
Fixes SOCIAL-417

**Note:** Merge this after #47775

## Proposed changes
* Make the sidebar X connection toggle date-aware: it now checks quota for the post's scheduled month instead of always using the current month. A post scheduled for a future month with available quota will have the X toggle enabled, even if the current month is exhausted.
* Add `canScheduleXShareFor` selector that checks quota for a specific period (paid plans) or lifetime usage (free plans), and rename `canShareToX` to `canShareToXNow` for clarity.
* Add server-side quota enforcement in `scheduleShares` action — filters out X connections when the target month's quota is exceeded and shows appropriate error/warning notices.
* Only show the "Schedule for a future month" hint when no post date is set; suppress it when the post already targets a future month with available quota.
<img width="382" height="125" alt="Google Chrome 2026-03-26 18 42 00" src="https://github.com/user-attachments/assets/bb6cade8-1be9-46ac-8760-9f71e1af918e" />

* Add `getPeriodForTimestamp` utility and update connection toggle component to use the new `canSchedule` and `getWarningReason` hooks.

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
None

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
[Use the docs](https://linear.app/a8c/document/development-and-testing-233742b93b35) for useful testing snippets.

* Set up a site with X connected and the current month's X sharing quota exhausted
* Create a new post and verify the X toggle in the sidebar is **disabled** (current month exceeded)
* Change the post's publish date to a future month → the X toggle should become **enabled**
* With no publish date set and current month exceeded, verify the "Current month limit reached. Schedule for a future month." hint appears below the X toggle
* Set a future publish date → verify the hint disappears
* Test scheduling shares for a future month with exceeded current month quota → shares should go through for non-exceeded months
* Test scheduling shares for an exceeded month → X connections should be filtered out with appropriate notice