### PR TITLE
jetpack-mu-wpcom: Increase CFM rollout to 100%

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-forms-cfm-rollout-100-percent
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-forms-cfm-rollout-100-percent
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Increase Central Forms Management rollout to 100% of WordPress.com sites.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-contact-form-flags/wpcom-contact-form-flags.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-contact-form-flags/wpcom-contact-form-flags.php
@@ -32,9 +32,7 @@ function wpcom_has_central_forms_management_sticker( $blog_id ) {
 /**
  * Check if Central Forms Management is enabled for a given blog.
  *
- * Enabled when the blog falls within the percentage-based rollout
- * (blog_id % 100 < 50, i.e. 50%) or has the 'central-forms-management'
- * blog sticker.
+ * Enabled for all WordPress.com sites except e2e test sites.
  *
  * @param int|null $blog_id Blog ID. Defaults to the current WP.com blog ID.
  * @return bool
@@ -49,12 +47,7 @@ function wpcom_is_central_forms_management_enabled( $blog_id = null ) {
 		return false;
 	}
 
-	// Percentage-based rollout: 50% of sites.
-	if ( ( $blog_id % 100 ) < 50 ) {
-		return true;
-	}
-
-	return wpcom_has_central_forms_management_sticker( $blog_id );
+	return true;
 }
 
 /**


### PR DESCRIPTION
## Proposed changes

* Increase the Central Forms Management percentage-based rollout from 50% to 100% of WordPress.com sites.
* The e2e test site exclusion (`a8c-e2e-test-blog` sticker check) remains in place so automated tests are unaffected.

This is the final step in the gradual rollout:
- #47757 — 10% rollout
- #47793 — 50% rollout
- #47801 — e2e test site exclusion

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* Previous rollout PRs: #47757, #47793, #47801

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. Verify that `wpcom_is_central_forms_management_enabled()` returns `true` for any non-e2e blog ID (since `blog_id % 100` is always `< 100`).
2. Verify that e2e test sites (those with the `a8c-e2e-test-blog` sticker) still return `false` and are excluded from the rollout.
3. Confirm the `jetpack_forms_alpha` filter is set to `true` and the `central-form-management` editor feature flag is enabled for regular sites.
