### PR TITLE
RTC Notices: Fix modal display and clean up per-tab limit logic

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-rtc-too-many-editors-modal
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-rtc-too-many-editors-modal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+RTC Notices: Restore Gutenberg's native "Too many editors connected" modal on sites where branded limit notices are disabled.

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-rtc-too-many-editors-modal
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-rtc-too-many-editors-modal
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-RTC Notices: Restore Gutenberg's native "Too many editors connected" modal on sites where branded limit notices are disabled.
+RTC Notices: Restore Gutenberg's native "Too many editors connected" modal on sites where branded limit notices are disabled. Fix room limit enforcement for PingHub provider by using awareness join timestamps instead of unpopulated collaboratorInfo.

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-rtc-too-many-editors-modal
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-rtc-too-many-editors-modal
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-RTC Notices: Restore Gutenberg's native "Too many editors connected" modal on sites where branded limit notices are disabled. Fix room limit enforcement for PingHub provider by using awareness join timestamps instead of unpopulated collaboratorInfo.
+RTC Notices: Restore Gutenberg's native "Too many editors connected" modal on sites where branded limit notices are disabled.

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/gutenberg-rtc-notices.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/gutenberg-rtc-notices.php
@@ -29,15 +29,6 @@ function wpcom_get_rtc_max_peers_per_room() {
 }
 
 /**
- * Get the maximum number of clients (tabs) allowed per user in a room.
- *
- * @return int Max clients per user.
- */
-function wpcom_get_rtc_max_clients_per_user() {
-	return (int) apply_filters( 'wpcom_rtc_max_clients_per_user', 2 );
-}
-
-/**
  * Check if the current user is the plan owner for this site.
  * Works on Simple sites (via wpcom_get_blog_owner) and Atomic sites
  * (via Jetpack connection master_user). Returns false on self-hosted
@@ -127,7 +118,6 @@ function wpcom_enqueue_rtc_notices_assets() {
 			'postsListUrl'       => admin_url( 'edit.php' ),
 			'siteSlug'           => wpcom_get_site_slug(),
 			'maxPeersPerRoom'    => wpcom_get_rtc_max_peers_per_room(),
-			'maxClientsPerUser'  => wpcom_get_rtc_max_clients_per_user(),
 			'enableLimitNotices' => apply_filters( 'wpcom_rtc_enable_limit_notices', false ),
 		),
 		JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/images.d.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/images.d.ts
@@ -13,7 +13,6 @@ interface WpcomRtcNoticesConfig {
 	postsListUrl: string;
 	siteSlug: string;
 	maxPeersPerRoom?: number;
-	maxClientsPerUser?: number;
 	enableLimitNotices?: boolean;
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/index.tsx
@@ -41,16 +41,11 @@ function registerRoomLimitFilter(): void {
 		20
 	);
 
-	// Disable Gutenberg's built-in connection limit check only when our branded
-	// replacement modal is active. Otherwise, Gutenberg's native "Too many editors
-	// connected" modal should be allowed to show.
-	if ( enableLimitNotices ) {
-		addFilter(
-			'sync.pollingProvider.maxClientsPerRoom',
-			'wpcom/rtc-disable-builtin-limit',
-			() => Number.MAX_SAFE_INTEGER
-		);
-	}
+	addFilter(
+		'sync.pollingProvider.maxClientsPerRoom',
+		'wpcom/rtc-disable-builtin-limit',
+		() => Number.MAX_SAFE_INTEGER
+	);
 }
 
 // Room-limit enforcement always runs (it stops polling, sends join requests).

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/index.tsx
@@ -28,7 +28,7 @@ const enableLimitNotices = window.wpcomRtcNotices?.enableLimitNotices ?? false;
  */
 function registerRoomLimitFilter(): void {
 	const config = window.wpcomRtcNotices;
-	if ( ! config?.maxPeersPerRoom && ! config?.maxClientsPerUser ) {
+	if ( ! config?.maxPeersPerRoom ) {
 		return;
 	}
 
@@ -36,20 +36,21 @@ function registerRoomLimitFilter(): void {
 		'sync.providers',
 		'wpcom/rtc-room-limits',
 		( providers: ProviderCreator[] ) => {
-			return providers.map( creator =>
-				withRoomLimit( creator, config.maxPeersPerRoom, config.maxClientsPerUser )
-			);
+			return providers.map( creator => withRoomLimit( creator, config.maxPeersPerRoom ) );
 		},
 		20
 	);
 
-	// Disable Gutenberg's built-in connection limit check so our
-	// room-limit.ts handles it with branded notices instead.
-	addFilter(
-		'sync.pollingProvider.maxClientsPerRoom',
-		'wpcom/rtc-disable-builtin-limit',
-		() => Number.MAX_SAFE_INTEGER
-	);
+	// Disable Gutenberg's built-in connection limit check only when our branded
+	// replacement modal is active. Otherwise, Gutenberg's native "Too many editors
+	// connected" modal should be allowed to show.
+	if ( enableLimitNotices ) {
+		addFilter(
+			'sync.pollingProvider.maxClientsPerRoom',
+			'wpcom/rtc-disable-builtin-limit',
+			() => Number.MAX_SAFE_INTEGER
+		);
+	}
 }
 
 // Room-limit enforcement always runs (it stops polling, sends join requests).

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/notices/rtc-welcome-notice.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/notices/rtc-welcome-notice.tsx
@@ -38,13 +38,21 @@ const RtcWelcomeNotice = () => {
 
 	// Don't show the welcome notice if the sync connection is lost (e.g. room
 	// limit reached). The limit-reached modal should take priority.
-	const isDisconnected = useSelect( select => {
+	// Also detect when Gutenberg's own "Welcome to the editor" guide is visible —
+	// that means the user has never opened the editor before, so the RTC notice
+	// is irrelevant (it announces a feature to returning users).
+	const { isDisconnected, isWelcomeGuideVisible } = useSelect( select => {
 		const coreStore = select( 'core' ) as {
 			getSyncConnectionStatus?: () => SyncConnectionStatus | undefined;
 		};
-		return (
-			coreStore.getSyncConnectionStatus?.()?.status === 'disconnected' || isRoomLimitBreached()
-		);
+		const prefs = select( 'core/preferences' ) as
+			| { get: ( scope: string, key: string ) => unknown }
+			| undefined;
+		return {
+			isDisconnected:
+				coreStore.getSyncConnectionStatus?.()?.status === 'disconnected' || isRoomLimitBreached(),
+			isWelcomeGuideVisible: !! prefs?.get( 'core/edit-post', 'welcomeGuide' ),
+		};
 	}, [] );
 
 	const dismissNotice = useCallback( () => {
@@ -56,6 +64,14 @@ const RtcWelcomeNotice = () => {
 			// Silently fail - the notice will show again next time if the API call fails.
 		} );
 	}, [] );
+
+	// Auto-dismiss the RTC welcome notice for first-time editor users so it
+	// won't appear after they close Gutenberg's own "Welcome to the editor" guide.
+	useEffect( () => {
+		if ( isWelcomeGuideVisible && ! isDismissed ) {
+			dismissNotice();
+		}
+	}, [ isWelcomeGuideVisible, isDismissed, dismissNotice ] );
 
 	if ( ! config || isDismissed || ! isReady || isDisconnected ) {
 		return null;

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/room-limit.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/room-limit.ts
@@ -8,7 +8,7 @@ import type { Awareness } from 'y-protocols/awareness';
  * HTTP request for every registered room. To fully stop polling when the
  * room limit is reached we must destroy *all* wrapped providers — entity
  * rooms AND collection rooms — in one shot. We only trigger that global
- * teardown when the current client is in the overflow set (newest by joinedAt).
+ * teardown when the current client is in the overflow set (newest by enteredAt).
  */
 let breached = false;
 
@@ -30,17 +30,53 @@ const NOOP_RESULT: ProviderCreatorResult = {
 };
 
 /**
- * Wraps a provider creator to enforce a per-room connection limit.
+ * Build a sorted list of unique collaborators (by WordPress user ID), ordered
+ * by the time they entered the room.
  *
- * When the wrapped provider initializes it stamps a join timestamp into the
- * local awareness state (`__wpcomRtcJoinedAt`). On every awareness change,
- * connections are sorted by that timestamp. When the total number of
- * connections exceeds the allowed maximum, only the current client is
- * considered "overflow" if it is among the newest (by joinedAt). In that
- * case all wrapped providers in this window are destroyed.
+ * The earliest `enteredAt` value for each user is used so that multiple tabs
+ * for the same user share a single, stable "join time".
+ *
+ * @param awareness - The Yjs awareness instance.
+ * @return Array of user descriptors sorted by enter time.
+ */
+function getSortedCollaborators(
+	awareness: Awareness
+): Array< { id: number; enteredAt: number } > {
+	const byId = new Map< number, number >();
+
+	for ( const [ , state ] of awareness.getStates() ) {
+		const info = state?.collaboratorInfo as { id?: unknown; enteredAt?: unknown } | undefined;
+		const id = info?.id;
+		const enteredAt = info?.enteredAt;
+		if ( typeof id !== 'number' || typeof enteredAt !== 'number' ) {
+			continue;
+		}
+		const prev = byId.get( id );
+		if ( prev === undefined || enteredAt < prev ) {
+			byId.set( id, enteredAt );
+		}
+	}
+
+	return Array.from( byId.entries() )
+		.map( ( [ id, enteredAt ] ) => ( { id, enteredAt } ) )
+		.sort( ( a, b ) => {
+			if ( a.enteredAt !== b.enteredAt ) {
+				return a.enteredAt - b.enteredAt;
+			}
+			return a.id - b.id;
+		} );
+}
+
+/**
+ * Wraps a provider creator to enforce a per-room user limit.
+ *
+ * Collaborators are ordered by `enteredAt`. When the total number of unique
+ * users exceeds the allowed maximum, only the current client is considered
+ * "overflow" if it is among the newest (by enteredAt). In that case all
+ * wrapped providers in this window are destroyed.
  *
  * @param creator         - The provider creator to wrap.
- * @param maxPeersPerRoom - Max connections allowed per room. Undefined or <= 0 disables enforcement.
+ * @param maxPeersPerRoom - Max other unique users allowed. Undefined or <= 0 disables peer enforcement.
  * @return Wrapped provider creator.
  */
 export function withRoomLimit(
@@ -102,32 +138,24 @@ export function withRoomLimit(
 				return;
 			}
 
-			const states = awareness.getStates();
-			if ( states.size <= maxPeersPerRoom ) {
+			const localUserId = awareness.getLocalState()?.collaboratorInfo?.id;
+			if ( typeof localUserId !== 'number' ) {
 				return;
 			}
 
-			// Sort connections by join time (oldest first). Use clientID as a
-			// tiebreaker so the ordering is deterministic across all peers.
-			const sorted = Array.from( states.entries() )
-				.map( ( [ clientId, state ] ) => ( {
-					clientId,
-					joinedAt: ( state?.__wpcomRtcJoinedAt as number ) ?? 0,
-				} ) )
-				.sort( ( a, b ) => a.joinedAt - b.joinedAt || a.clientId - b.clientId );
-
-			const overflow = sorted.slice( maxPeersPerRoom );
-			if ( overflow.some( c => c.clientId === awareness.clientID ) ) {
-				destroyAll();
+			// Peer limit: too many unique users; only newest users (by enteredAt) are overflow.
+			const collaborators = getSortedCollaborators( awareness );
+			if ( collaborators.length > maxPeersPerRoom ) {
+				const overflow = collaborators.slice( maxPeersPerRoom );
+				if ( overflow.some( user => user.id === localUserId ) ) {
+					destroyAll();
+				}
 			}
 		}
 
 		teardowns.push( destroy );
 
 		if ( awareness ) {
-			// Stamp our join time into the awareness state so that all peers
-			// can sort connections by join order and agree on who is overflow.
-			( awareness as Awareness ).setLocalStateField( '__wpcomRtcJoinedAt', Date.now() );
 			awareness.on( 'change', onAwarenessChange );
 			onAwarenessChange();
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/room-limit.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/room-limit.ts
@@ -68,62 +68,22 @@ function getSortedCollaborators(
 }
 
 /**
- * Build a sorted list of clients (tabs) for the local WordPress user, ordered
- * by when they entered the room (earliest enteredAt per clientId).
- *
- * @param awareness   - The Yjs awareness instance.
- * @param localUserId - The WordPress user ID to filter by.
- * @return Array of client descriptors sorted by enter time.
- */
-function getSortedClientsForLocalUser(
-	awareness: Awareness,
-	localUserId: number
-): Array< { clientId: number; enteredAt: number } > {
-	const byClientId = new Map< number, number >();
-
-	for ( const [ clientId, state ] of awareness.getStates() ) {
-		const info = state?.collaboratorInfo as { id?: unknown; enteredAt?: unknown } | undefined;
-		if ( info?.id !== localUserId || typeof info?.enteredAt !== 'number' ) {
-			continue;
-		}
-		const enteredAt = info.enteredAt as number;
-		const prev = byClientId.get( clientId );
-		if ( prev === undefined || enteredAt < prev ) {
-			byClientId.set( clientId, enteredAt );
-		}
-	}
-
-	return Array.from( byClientId.entries() )
-		.map( ( [ clientId, enteredAt ] ) => ( { clientId, enteredAt } ) )
-		.sort( ( a, b ) => {
-			if ( a.enteredAt !== b.enteredAt ) {
-				return a.enteredAt - b.enteredAt;
-			}
-			return a.clientId - b.clientId;
-		} );
-}
-
-/**
  * Wraps a provider creator to enforce a per-room user limit.
  *
  * Collaborators are ordered by `enteredAt`. When the total number of unique
- * users (or clients for the same user) exceeds the allowed maximum, only the
- * current client is considered "overflow" if it is among the newest (by enteredAt).
- * In that case all wrapped providers in this window are destroyed.
+ * users exceeds the allowed maximum, only the current client is considered
+ * "overflow" if it is among the newest (by enteredAt). In that case all
+ * wrapped providers in this window are destroyed.
  *
- * @param creator           - The provider creator to wrap.
- * @param maxPeersPerRoom   - Max other unique users allowed. Undefined or <= 0 disables peer enforcement.
- * @param maxClientsPerUser - Max additional clients (tabs) for the same user. Undefined or <= 0 disables per-user enforcement.
+ * @param creator         - The provider creator to wrap.
+ * @param maxPeersPerRoom - Max other unique users allowed. Undefined or <= 0 disables peer enforcement.
  * @return Wrapped provider creator.
  */
 export function withRoomLimit(
 	creator: ProviderCreator,
-	maxPeersPerRoom?: number,
-	maxClientsPerUser?: number
+	maxPeersPerRoom?: number
 ): ProviderCreator {
-	const hasPeerLimit = Boolean( maxPeersPerRoom && maxPeersPerRoom > 0 );
-	const hasClientLimit = Boolean( maxClientsPerUser && maxClientsPerUser > 0 );
-	if ( ! hasPeerLimit && ! hasClientLimit ) {
+	if ( ! maxPeersPerRoom || maxPeersPerRoom <= 0 ) {
 		return creator;
 	}
 
@@ -184,29 +144,11 @@ export function withRoomLimit(
 			}
 
 			// Peer limit: too many unique users; only newest users (by enteredAt) are overflow.
-			if ( hasPeerLimit ) {
-				const collaborators = getSortedCollaborators( awareness );
-				if ( collaborators.length > maxPeersPerRoom! ) {
-					const overflow = collaborators.slice( maxPeersPerRoom );
-					if ( overflow.some( user => user.id === localUserId ) ) {
-						destroyAll();
-						return;
-					}
-				}
-			}
-
-			// Client limit: too many tabs for this user; only newest clients (by enteredAt) are overflow.
-			if ( hasClientLimit ) {
-				const localClientId = ( awareness as Awareness & { clientID?: unknown } ).clientID;
-				if ( typeof localClientId !== 'number' ) {
-					return;
-				}
-				const clientsForUser = getSortedClientsForLocalUser( awareness, localUserId );
-				if ( clientsForUser.length > maxClientsPerUser! ) {
-					const overflow = clientsForUser.slice( maxClientsPerUser );
-					if ( overflow.some( c => c.clientId === localClientId ) ) {
-						destroyAll();
-					}
+			const collaborators = getSortedCollaborators( awareness );
+			if ( collaborators.length > maxPeersPerRoom ) {
+				const overflow = collaborators.slice( maxPeersPerRoom );
+				if ( overflow.some( user => user.id === localUserId ) ) {
+					destroyAll();
 				}
 			}
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/room-limit.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/room-limit.ts
@@ -95,6 +95,7 @@ export function withRoomLimit(
 		const { awareness } = options;
 		const innerProvider = await creator( options );
 		let destroyed = false;
+		const statusListeners: Array< ( status: unknown ) => void > = [];
 
 		/** Trigger a global teardown for all wrapped providers in this window. */
 		function destroyAll(): void {
@@ -120,6 +121,20 @@ export function withRoomLimit(
 				fn();
 			}
 			teardowns.length = 0;
+		}
+
+		/**
+		 * Called by destroyAll: emits the connection-limit-exceeded status so
+		 * Gutenberg shows the "Too many editors connected" modal, then tears down.
+		 */
+		function destroyWithLimitError(): void {
+			for ( const listener of statusListeners ) {
+				listener( {
+					status: 'disconnected',
+					error: { code: 'connection-limit-exceeded' },
+				} );
+			}
+			destroy();
 		}
 
 		/** Tear down this single provider and detach the awareness listener. */
@@ -153,7 +168,7 @@ export function withRoomLimit(
 			}
 		}
 
-		teardowns.push( destroy );
+		teardowns.push( destroyWithLimitError );
 
 		if ( awareness ) {
 			awareness.on( 'change', onAwarenessChange );
@@ -162,13 +177,18 @@ export function withRoomLimit(
 
 		return {
 			destroy: () => {
-				const idx = teardowns.indexOf( destroy );
+				const idx = teardowns.indexOf( destroyWithLimitError );
 				if ( idx >= 0 ) {
 					teardowns.splice( idx, 1 );
 				}
 				destroy();
 			},
-			on: innerProvider.on.bind( innerProvider ),
+			on: ( event: string, callback: ( ...args: unknown[] ) => void ) => {
+				if ( event === 'status' ) {
+					statusListeners.push( callback );
+				}
+				innerProvider.on( event, callback );
+			},
 		};
 	};
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/room-limit.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/room-limit.ts
@@ -8,7 +8,7 @@ import type { Awareness } from 'y-protocols/awareness';
  * HTTP request for every registered room. To fully stop polling when the
  * room limit is reached we must destroy *all* wrapped providers — entity
  * rooms AND collection rooms — in one shot. We only trigger that global
- * teardown when the current client is in the overflow set (newest by joinedAt).
+ * teardown when the current client is in the overflow set (newest by enteredAt).
  */
 let breached = false;
 
@@ -30,17 +30,53 @@ const NOOP_RESULT: ProviderCreatorResult = {
 };
 
 /**
- * Wraps a provider creator to enforce a per-room connection limit.
+ * Build a sorted list of unique collaborators (by WordPress user ID), ordered
+ * by the time they entered the room.
  *
- * When the wrapped provider initializes it stamps a join timestamp into the
- * local awareness state (`__wpcomRtcJoinedAt`). On every awareness change,
- * connections are sorted by that timestamp. When the total number of
- * connections exceeds the allowed maximum, only the current client is
- * considered "overflow" if it is among the newest (by joinedAt). In that
- * case all wrapped providers in this window are destroyed.
+ * The earliest `enteredAt` value for each user is used so that multiple tabs
+ * for the same user share a single, stable "join time".
+ *
+ * @param awareness - The Yjs awareness instance.
+ * @return Array of user descriptors sorted by enter time.
+ */
+function getSortedCollaborators(
+	awareness: Awareness
+): Array< { id: number; enteredAt: number } > {
+	const byId = new Map< number, number >();
+
+	for ( const [ , state ] of awareness.getStates() ) {
+		const info = state?.collaboratorInfo as { id?: unknown; enteredAt?: unknown } | undefined;
+		const id = info?.id;
+		const enteredAt = info?.enteredAt;
+		if ( typeof id !== 'number' || typeof enteredAt !== 'number' ) {
+			continue;
+		}
+		const prev = byId.get( id );
+		if ( prev === undefined || enteredAt < prev ) {
+			byId.set( id, enteredAt );
+		}
+	}
+
+	return Array.from( byId.entries() )
+		.map( ( [ id, enteredAt ] ) => ( { id, enteredAt } ) )
+		.sort( ( a, b ) => {
+			if ( a.enteredAt !== b.enteredAt ) {
+				return a.enteredAt - b.enteredAt;
+			}
+			return a.id - b.id;
+		} );
+}
+
+/**
+ * Wraps a provider creator to enforce a per-room user limit.
+ *
+ * Collaborators are ordered by `enteredAt`. When the total number of unique
+ * users exceeds the allowed maximum, only the current client is considered
+ * "overflow" if it is among the newest (by enteredAt). In that case all
+ * wrapped providers in this window are destroyed.
  *
  * @param creator         - The provider creator to wrap.
- * @param maxPeersPerRoom - Max connections allowed per room. Undefined or <= 0 disables enforcement.
+ * @param maxPeersPerRoom - Max other unique users allowed. Undefined or <= 0 disables peer enforcement.
  * @return Wrapped provider creator.
  */
 export function withRoomLimit(
@@ -117,32 +153,24 @@ export function withRoomLimit(
 				return;
 			}
 
-			const states = awareness.getStates();
-			if ( states.size <= maxPeersPerRoom ) {
+			const localUserId = awareness.getLocalState()?.collaboratorInfo?.id;
+			if ( typeof localUserId !== 'number' ) {
 				return;
 			}
 
-			// Sort connections by join time (oldest first). Use clientID as a
-			// tiebreaker so the ordering is deterministic across all peers.
-			const sorted = Array.from( states.entries() )
-				.map( ( [ clientId, state ] ) => ( {
-					clientId,
-					joinedAt: ( state?.__wpcomRtcJoinedAt as number ) ?? 0,
-				} ) )
-				.sort( ( a, b ) => a.joinedAt - b.joinedAt || a.clientId - b.clientId );
-
-			const overflow = sorted.slice( maxPeersPerRoom );
-			if ( overflow.some( c => c.clientId === awareness.clientID ) ) {
-				destroyAll();
+			// Peer limit: too many unique users; only newest users (by enteredAt) are overflow.
+			const collaborators = getSortedCollaborators( awareness );
+			if ( collaborators.length > maxPeersPerRoom ) {
+				const overflow = collaborators.slice( maxPeersPerRoom );
+				if ( overflow.some( user => user.id === localUserId ) ) {
+					destroyAll();
+				}
 			}
 		}
 
 		teardowns.push( destroyWithLimitError );
 
 		if ( awareness ) {
-			// Stamp our join time into the awareness state so that all peers
-			// can sort connections by join order and agree on who is overflow.
-			( awareness as Awareness ).setLocalStateField( '__wpcomRtcJoinedAt', Date.now() );
 			awareness.on( 'change', onAwarenessChange );
 			onAwarenessChange();
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/room-limit.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/room-limit.ts
@@ -1,5 +1,4 @@
 import type { ProviderCreator, ProviderCreatorResult } from '@wordpress/sync';
-import type { Awareness } from 'y-protocols/awareness';
 
 /*
  * Module-level state shared across all `withRoomLimit` wrappers.
@@ -8,7 +7,7 @@ import type { Awareness } from 'y-protocols/awareness';
  * HTTP request for every registered room. To fully stop polling when the
  * room limit is reached we must destroy *all* wrapped providers — entity
  * rooms AND collection rooms — in one shot. We only trigger that global
- * teardown when the current client is in the overflow set (newest by enteredAt).
+ * teardown when the current client is in the overflow set (newest by enteredAt / clientID).
  */
 let breached = false;
 
@@ -30,53 +29,16 @@ const NOOP_RESULT: ProviderCreatorResult = {
 };
 
 /**
- * Build a sorted list of unique collaborators (by WordPress user ID), ordered
- * by the time they entered the room.
+ * Wraps a provider creator to enforce a per-room connection limit.
  *
- * The earliest `enteredAt` value for each user is used so that multiple tabs
- * for the same user share a single, stable "join time".
- *
- * @param awareness - The Yjs awareness instance.
- * @return Array of user descriptors sorted by enter time.
- */
-function getSortedCollaborators(
-	awareness: Awareness
-): Array< { id: number; enteredAt: number } > {
-	const byId = new Map< number, number >();
-
-	for ( const [ , state ] of awareness.getStates() ) {
-		const info = state?.collaboratorInfo as { id?: unknown; enteredAt?: unknown } | undefined;
-		const id = info?.id;
-		const enteredAt = info?.enteredAt;
-		if ( typeof id !== 'number' || typeof enteredAt !== 'number' ) {
-			continue;
-		}
-		const prev = byId.get( id );
-		if ( prev === undefined || enteredAt < prev ) {
-			byId.set( id, enteredAt );
-		}
-	}
-
-	return Array.from( byId.entries() )
-		.map( ( [ id, enteredAt ] ) => ( { id, enteredAt } ) )
-		.sort( ( a, b ) => {
-			if ( a.enteredAt !== b.enteredAt ) {
-				return a.enteredAt - b.enteredAt;
-			}
-			return a.id - b.id;
-		} );
-}
-
-/**
- * Wraps a provider creator to enforce a per-room user limit.
- *
- * Collaborators are ordered by `enteredAt`. When the total number of unique
- * users exceeds the allowed maximum, only the current client is considered
- * "overflow" if it is among the newest (by enteredAt). In that case all
- * wrapped providers in this window are destroyed.
+ * All awareness states (connections) are sorted by `collaboratorInfo.enteredAt`
+ * with the Yjs `clientID` as a deterministic tiebreaker. When the total number
+ * of connections exceeds the allowed maximum, only the current client is
+ * considered "overflow" if it is among the newest. In that case all wrapped
+ * providers in this window are destroyed.
  *
  * @param creator         - The provider creator to wrap.
- * @param maxPeersPerRoom - Max other unique users allowed. Undefined or <= 0 disables peer enforcement.
+ * @param maxPeersPerRoom - Max total connections allowed. Undefined or <= 0 disables enforcement.
  * @return Wrapped provider creator.
  */
 export function withRoomLimit(
@@ -153,18 +115,32 @@ export function withRoomLimit(
 				return;
 			}
 
-			const localUserId = awareness.getLocalState()?.collaboratorInfo?.id;
-			if ( typeof localUserId !== 'number' ) {
+			const states = awareness.getStates();
+			if ( states.size <= maxPeersPerRoom ) {
 				return;
 			}
 
-			// Peer limit: too many unique users; only newest users (by enteredAt) are overflow.
-			const collaborators = getSortedCollaborators( awareness );
-			if ( collaborators.length > maxPeersPerRoom ) {
-				const overflow = collaborators.slice( maxPeersPerRoom );
-				if ( overflow.some( user => user.id === localUserId ) ) {
-					destroyAll();
-				}
+			// Sort all connections by enteredAt (from collaboratorInfo) so that
+			// earlier editors stay in the room. Use clientID as a tiebreaker so
+			// every client independently reaches the same ordering without
+			// needing to write any new field to the awareness state.
+			const sorted = Array.from( states.entries() )
+				.map( ( [ clientId, state ] ) => ( {
+					clientId,
+					enteredAt: ( state?.collaboratorInfo as { enteredAt?: unknown } | undefined )?.enteredAt,
+				} ) )
+				.sort( ( a, b ) => {
+					const aTime = typeof a.enteredAt === 'number' ? a.enteredAt : Infinity;
+					const bTime = typeof b.enteredAt === 'number' ? b.enteredAt : Infinity;
+					if ( aTime !== bTime ) {
+						return aTime - bTime;
+					}
+					return a.clientId - b.clientId;
+				} );
+
+			const overflow = sorted.slice( maxPeersPerRoom );
+			if ( overflow.some( c => c.clientId === awareness.clientID ) ) {
+				destroyAll();
 			}
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/room-limit.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/room-limit.ts
@@ -162,8 +162,19 @@ export function withRoomLimit(
 			on: ( event: string, callback: ( ...args: unknown[] ) => void ) => {
 				if ( event === 'status' ) {
 					statusListeners.push( callback );
+					// Forward inner-provider status events only while the limit
+					// has not been breached. Once breached, destroyWithLimitError
+					// emits connection-limit-exceeded directly; subsequent events
+					// from the inner provider (e.g. PingHub's own disconnect)
+					// must not overwrite that with a generic "Connection lost".
+					innerProvider.on( event, ( ...args: unknown[] ) => {
+						if ( ! breached ) {
+							callback( ...args );
+						}
+					} );
+				} else {
+					innerProvider.on( event, callback );
 				}
-				innerProvider.on( event, callback );
 			},
 		};
 	};

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/room-limit.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/room-limit.ts
@@ -8,7 +8,7 @@ import type { Awareness } from 'y-protocols/awareness';
  * HTTP request for every registered room. To fully stop polling when the
  * room limit is reached we must destroy *all* wrapped providers — entity
  * rooms AND collection rooms — in one shot. We only trigger that global
- * teardown when the current client is in the overflow set (newest by enteredAt).
+ * teardown when the current client is in the overflow set (newest by joinedAt).
  */
 let breached = false;
 
@@ -30,53 +30,17 @@ const NOOP_RESULT: ProviderCreatorResult = {
 };
 
 /**
- * Build a sorted list of unique collaborators (by WordPress user ID), ordered
- * by the time they entered the room.
+ * Wraps a provider creator to enforce a per-room connection limit.
  *
- * The earliest `enteredAt` value for each user is used so that multiple tabs
- * for the same user share a single, stable "join time".
- *
- * @param awareness - The Yjs awareness instance.
- * @return Array of user descriptors sorted by enter time.
- */
-function getSortedCollaborators(
-	awareness: Awareness
-): Array< { id: number; enteredAt: number } > {
-	const byId = new Map< number, number >();
-
-	for ( const [ , state ] of awareness.getStates() ) {
-		const info = state?.collaboratorInfo as { id?: unknown; enteredAt?: unknown } | undefined;
-		const id = info?.id;
-		const enteredAt = info?.enteredAt;
-		if ( typeof id !== 'number' || typeof enteredAt !== 'number' ) {
-			continue;
-		}
-		const prev = byId.get( id );
-		if ( prev === undefined || enteredAt < prev ) {
-			byId.set( id, enteredAt );
-		}
-	}
-
-	return Array.from( byId.entries() )
-		.map( ( [ id, enteredAt ] ) => ( { id, enteredAt } ) )
-		.sort( ( a, b ) => {
-			if ( a.enteredAt !== b.enteredAt ) {
-				return a.enteredAt - b.enteredAt;
-			}
-			return a.id - b.id;
-		} );
-}
-
-/**
- * Wraps a provider creator to enforce a per-room user limit.
- *
- * Collaborators are ordered by `enteredAt`. When the total number of unique
- * users exceeds the allowed maximum, only the current client is considered
- * "overflow" if it is among the newest (by enteredAt). In that case all
- * wrapped providers in this window are destroyed.
+ * When the wrapped provider initializes it stamps a join timestamp into the
+ * local awareness state (`__wpcomRtcJoinedAt`). On every awareness change,
+ * connections are sorted by that timestamp. When the total number of
+ * connections exceeds the allowed maximum, only the current client is
+ * considered "overflow" if it is among the newest (by joinedAt). In that
+ * case all wrapped providers in this window are destroyed.
  *
  * @param creator         - The provider creator to wrap.
- * @param maxPeersPerRoom - Max other unique users allowed. Undefined or <= 0 disables peer enforcement.
+ * @param maxPeersPerRoom - Max connections allowed per room. Undefined or <= 0 disables enforcement.
  * @return Wrapped provider creator.
  */
 export function withRoomLimit(
@@ -153,24 +117,32 @@ export function withRoomLimit(
 				return;
 			}
 
-			const localUserId = awareness.getLocalState()?.collaboratorInfo?.id;
-			if ( typeof localUserId !== 'number' ) {
+			const states = awareness.getStates();
+			if ( states.size <= maxPeersPerRoom ) {
 				return;
 			}
 
-			// Peer limit: too many unique users; only newest users (by enteredAt) are overflow.
-			const collaborators = getSortedCollaborators( awareness );
-			if ( collaborators.length > maxPeersPerRoom ) {
-				const overflow = collaborators.slice( maxPeersPerRoom );
-				if ( overflow.some( user => user.id === localUserId ) ) {
-					destroyAll();
-				}
+			// Sort connections by join time (oldest first). Use clientID as a
+			// tiebreaker so the ordering is deterministic across all peers.
+			const sorted = Array.from( states.entries() )
+				.map( ( [ clientId, state ] ) => ( {
+					clientId,
+					joinedAt: ( state?.__wpcomRtcJoinedAt as number ) ?? 0,
+				} ) )
+				.sort( ( a, b ) => a.joinedAt - b.joinedAt || a.clientId - b.clientId );
+
+			const overflow = sorted.slice( maxPeersPerRoom );
+			if ( overflow.some( c => c.clientId === awareness.clientID ) ) {
+				destroyAll();
 			}
 		}
 
 		teardowns.push( destroyWithLimitError );
 
 		if ( awareness ) {
+			// Stamp our join time into the awareness state so that all peers
+			// can sort connections by join order and agree on who is overflow.
+			( awareness as Awareness ).setLocalStateField( '__wpcomRtcJoinedAt', Date.now() );
 			awareness.on( 'change', onAwarenessChange );
 			onAwarenessChange();
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/room-limit.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/room-limit.ts
@@ -8,7 +8,7 @@ import type { Awareness } from 'y-protocols/awareness';
  * HTTP request for every registered room. To fully stop polling when the
  * room limit is reached we must destroy *all* wrapped providers — entity
  * rooms AND collection rooms — in one shot. We only trigger that global
- * teardown when the current client is in the overflow set (newest by enteredAt).
+ * teardown when the current client is in the overflow set (newest by joinedAt).
  */
 let breached = false;
 
@@ -30,53 +30,17 @@ const NOOP_RESULT: ProviderCreatorResult = {
 };
 
 /**
- * Build a sorted list of unique collaborators (by WordPress user ID), ordered
- * by the time they entered the room.
+ * Wraps a provider creator to enforce a per-room connection limit.
  *
- * The earliest `enteredAt` value for each user is used so that multiple tabs
- * for the same user share a single, stable "join time".
- *
- * @param awareness - The Yjs awareness instance.
- * @return Array of user descriptors sorted by enter time.
- */
-function getSortedCollaborators(
-	awareness: Awareness
-): Array< { id: number; enteredAt: number } > {
-	const byId = new Map< number, number >();
-
-	for ( const [ , state ] of awareness.getStates() ) {
-		const info = state?.collaboratorInfo as { id?: unknown; enteredAt?: unknown } | undefined;
-		const id = info?.id;
-		const enteredAt = info?.enteredAt;
-		if ( typeof id !== 'number' || typeof enteredAt !== 'number' ) {
-			continue;
-		}
-		const prev = byId.get( id );
-		if ( prev === undefined || enteredAt < prev ) {
-			byId.set( id, enteredAt );
-		}
-	}
-
-	return Array.from( byId.entries() )
-		.map( ( [ id, enteredAt ] ) => ( { id, enteredAt } ) )
-		.sort( ( a, b ) => {
-			if ( a.enteredAt !== b.enteredAt ) {
-				return a.enteredAt - b.enteredAt;
-			}
-			return a.id - b.id;
-		} );
-}
-
-/**
- * Wraps a provider creator to enforce a per-room user limit.
- *
- * Collaborators are ordered by `enteredAt`. When the total number of unique
- * users exceeds the allowed maximum, only the current client is considered
- * "overflow" if it is among the newest (by enteredAt). In that case all
- * wrapped providers in this window are destroyed.
+ * When the wrapped provider initializes it stamps a join timestamp into the
+ * local awareness state (`__wpcomRtcJoinedAt`). On every awareness change,
+ * connections are sorted by that timestamp. When the total number of
+ * connections exceeds the allowed maximum, only the current client is
+ * considered "overflow" if it is among the newest (by joinedAt). In that
+ * case all wrapped providers in this window are destroyed.
  *
  * @param creator         - The provider creator to wrap.
- * @param maxPeersPerRoom - Max other unique users allowed. Undefined or <= 0 disables peer enforcement.
+ * @param maxPeersPerRoom - Max connections allowed per room. Undefined or <= 0 disables enforcement.
  * @return Wrapped provider creator.
  */
 export function withRoomLimit(
@@ -138,24 +102,32 @@ export function withRoomLimit(
 				return;
 			}
 
-			const localUserId = awareness.getLocalState()?.collaboratorInfo?.id;
-			if ( typeof localUserId !== 'number' ) {
+			const states = awareness.getStates();
+			if ( states.size <= maxPeersPerRoom ) {
 				return;
 			}
 
-			// Peer limit: too many unique users; only newest users (by enteredAt) are overflow.
-			const collaborators = getSortedCollaborators( awareness );
-			if ( collaborators.length > maxPeersPerRoom ) {
-				const overflow = collaborators.slice( maxPeersPerRoom );
-				if ( overflow.some( user => user.id === localUserId ) ) {
-					destroyAll();
-				}
+			// Sort connections by join time (oldest first). Use clientID as a
+			// tiebreaker so the ordering is deterministic across all peers.
+			const sorted = Array.from( states.entries() )
+				.map( ( [ clientId, state ] ) => ( {
+					clientId,
+					joinedAt: ( state?.__wpcomRtcJoinedAt as number ) ?? 0,
+				} ) )
+				.sort( ( a, b ) => a.joinedAt - b.joinedAt || a.clientId - b.clientId );
+
+			const overflow = sorted.slice( maxPeersPerRoom );
+			if ( overflow.some( c => c.clientId === awareness.clientID ) ) {
+				destroyAll();
 			}
 		}
 
 		teardowns.push( destroy );
 
 		if ( awareness ) {
+			// Stamp our join time into the awareness state so that all peers
+			// can sort connections by join order and agree on who is overflow.
+			( awareness as Awareness ).setLocalStateField( '__wpcomRtcJoinedAt', Date.now() );
 			awareness.on( 'change', onAwarenessChange );
 			onAwarenessChange();
 		}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc-notices/RTC_Notices_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/gutenberg-rtc-notices/RTC_Notices_Test.php
@@ -21,13 +21,11 @@ use PHPUnit\Framework\Attributes\CoversFunction;
  * Tests for RTC Notices feature.
  *
  * @covers ::wpcom_get_rtc_max_peers_per_room
- * @covers ::wpcom_get_rtc_max_clients_per_user
  * @covers ::wpcom_rtc_is_plan_owner
  * @covers ::wpcom_enqueue_rtc_notices_assets
  * @covers WP_REST_RTC_Notices
  */
 #[CoversFunction( 'wpcom_get_rtc_max_peers_per_room' )]
-#[CoversFunction( 'wpcom_get_rtc_max_clients_per_user' )]
 #[CoversFunction( 'wpcom_rtc_is_plan_owner' )]
 #[CoversFunction( 'wpcom_enqueue_rtc_notices_assets' )]
 #[CoversClass( WP_REST_RTC_Notices::class )]
@@ -108,7 +106,6 @@ class RTC_Notices_Test extends \WorDBless\BaseTestCase {
 		wp_delete_user( $this->second_user_id );
 
 		remove_all_filters( 'wpcom_rtc_max_peers_per_room' );
-		remove_all_filters( 'wpcom_rtc_max_clients_per_user' );
 		remove_all_filters( 'jetpack_rtc_enabled' );
 		remove_all_filters( 'wpcom_rtc_enable_limit_notices' );
 		remove_all_filters( 'users_pre_query' );
@@ -147,27 +144,6 @@ class RTC_Notices_Test extends \WorDBless\BaseTestCase {
 		);
 
 		$this->assertSame( 5, wpcom_get_rtc_max_peers_per_room() );
-	}
-
-	/**
-	 * Tests that default max clients per user is 2.
-	 */
-	public function test_default_max_clients_per_user() {
-		$this->assertSame( 2, wpcom_get_rtc_max_clients_per_user() );
-	}
-
-	/**
-	 * Tests that max clients per user is filterable.
-	 */
-	public function test_filterable_max_clients_per_user() {
-		add_filter(
-			'wpcom_rtc_max_clients_per_user',
-			function () {
-				return 3;
-			}
-		);
-
-		$this->assertSame( 3, wpcom_get_rtc_max_clients_per_user() );
 	}
 
 	/**
@@ -496,7 +472,6 @@ class RTC_Notices_Test extends \WorDBless\BaseTestCase {
 		$this->assertStringContainsString( '"isAdmin"', $inline );
 		$this->assertStringContainsString( '"welcomeDismissed"', $inline );
 		$this->assertStringContainsString( '"maxPeersPerRoom"', $inline );
-		$this->assertStringContainsString( '"maxClientsPerUser"', $inline );
 		$this->assertStringContainsString( '"siteSlug"', $inline );
 	}
 


### PR DESCRIPTION
Fixes DOTCOM-16522

## Proposed changes

- **Fix "Connection lost" modal on WP.com**: Gutenberg's native "Too many editors connected" modal was not being used by our room limit logic.

Before | After
--- | ---
<img width="2644" height="1292" alt="image" src="https://github.com/user-attachments/assets/52f35df2-28ee-444a-b74d-ca3db8f169f1" /> | <img width="1290" height="849" alt="Screenshot 2026-03-27 at 11 47 02" src="https://github.com/user-attachments/assets/4c4054ad-3bcf-4c0e-a7d3-4b47f75d1779" />

- **Skip RTC welcome notice for first-time editor users**: The welcome notice now checks the `welcomeGuide` preference (`core/edit-post`) from `@wordpress/preferences`. If the Gutenberg "Welcome to the editor" guide is visible (first-time user), the RTC notice is auto-dismissed via the API so it won't appear after the guide is closed.

Before | After
--- | ---
<img width="1434" height="882" alt="Screenshot 2026-03-27 at 11 32 28" src="https://github.com/user-attachments/assets/b7a97769-3d42-4d28-9d41-0c66fb041be2" /> | <img width="1433" height="881" alt="Screenshot 2026-03-27 at 11 41 54" src="https://github.com/user-attachments/assets/2ff2fd54-0562-4854-b460-4b2b2840496e" />


- **Remove per-user tab limit** (`maxClientsPerUser`): Gutenberg doesn't enforce a per-tab limit natively, making this custom logic unnecessary and inconsistent with core behaviour. Removed from `room-limit.ts`, `gutenberg-rtc-notices.php`, `images.d.ts`, and `index.tsx`.


## Related product discussion/links
N/A

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

- [ ] Open a post in the editor with 4+ users connected — confirm the "Too many editors connected" modal appears (not "Connection lost") on a WP.com site.
- [ ] Add `add_filter( 'wpcom_rtc_enable_limit_notices', '__return_true', 100) and confirm the branded WP.com limit modal still appears instead of Gutenberg's native one
- [ ] Open the editor as a brand-new user (with the "Welcome to the editor" guide visible) — confirm the RTC welcome notice does NOT appear, and that after closing the guide it still doesn't appear
- [ ] Open the editor as a returning user (welcome guide already dismissed) — confirm the RTC welcome notice still appears normally if it has not been dismissed before
