### PR TITLE
RTC: Increase HTTP polling rollout to 50% of WoW sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-16482-increase-rollout-to-50-of-wow-sites
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-16482-increase-rollout-to-50-of-wow-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+RTC: Increase HTTP polling rollout to 50% of WoW sites

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
@@ -32,7 +32,7 @@ function wpcom_should_enforce_http_polling() {
 
 	if (
 		defined( 'IS_ATOMIC' ) && IS_ATOMIC &&
-		( $blog_id % 100 < 25 ) &&
+		( $blog_id % 100 < 50 ) &&
 		! wpcom_has_features_edge_sticker() // Sites with the sticker should use WS.
 	) {
 		return true;


### PR DESCRIPTION
Fixes DOTCOM-16482

## Proposed changes

* Increase the RTC HTTP polling rollout from ~25% (`blog_id % 100 < 25`) to ~50% (`blog_id % 100 < 50`) of non-edge Atomic (WoW) sites.


## Related product discussion/links

N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Verify that the condition in `wpcom_should_enforce_http_polling()` now uses `$blog_id % 100 < 50` instead of `$blog_id % 100 < 25`.
* Confirm that Atomic sites with `blog_id` values where `blog_id % 100` is 0–49 (and without the `wpcom-features-edge` sticker) will now use HTTP polling.
* Confirm that sites with the `wpcom-features-edge` sticker are still excluded from HTTP polling (they use WebSockets).
