### PR TITLE
jetpack-mu-wpcom: Fix e2e test site exclusion from CFM on Atomic

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-forms-cfm-e2e-exclusion-atomic
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-forms-cfm-e2e-exclusion-atomic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix e2e test site exclusion from Central Forms Management on Atomic sites.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-contact-form-flags/wpcom-contact-form-flags.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-contact-form-flags/wpcom-contact-form-flags.php
@@ -9,17 +9,16 @@
  */
 
 /**
- * Check if a site has the 'central-forms-management' blog sticker.
+ * Check if a site has a given blog sticker.
  *
  * Uses the appropriate sticker API depending on whether the site is
  * Simple (has_blog_sticker) or Atomic (wpcomsh_is_site_sticker_active).
  *
- * @param int $blog_id The blog ID to check.
+ * @param string $sticker The sticker name to check.
+ * @param int    $blog_id The blog ID to check.
  * @return bool
  */
-function wpcom_has_central_forms_management_sticker( $blog_id ) {
-	$sticker = 'central-forms-management';
-
+function wpcom_forms_has_blog_sticker( $sticker, $blog_id ) {
 	if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC && function_exists( 'wpcomsh_is_site_sticker_active' ) ) {
 		return (bool) wpcomsh_is_site_sticker_active( $sticker );
 	} elseif ( function_exists( 'has_blog_sticker' ) ) {
@@ -43,7 +42,7 @@ function wpcom_is_central_forms_management_enabled( $blog_id = null ) {
 	}
 
 	// Exclude e2e test sites — their tests aren't ready for CFM yet.
-	if ( function_exists( 'has_blog_sticker' ) && has_blog_sticker( 'a8c-e2e-test-blog', $blog_id ) ) {
+	if ( wpcom_forms_has_blog_sticker( 'a8c-e2e-test-blog', $blog_id ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
Fixes failing e2e tests.

## Proposed changes

* Fix the e2e test site exclusion from Central Forms Management so it works on **both Simple and Atomic** sites.
* The previous exclusion used `has_blog_sticker()` directly, which only exists on Simple. On Atomic, the function doesn't exist, so the check was silently skipped — e2e test sites on Atomic got CFM enabled, breaking their form submission tests.
* Generalize the sticker helper into `wpcom_forms_has_blog_sticker()` that accepts any sticker name and uses the dual Simple/Atomic pattern (`has_blog_sticker` vs `wpcomsh_is_site_sticker_active`).

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links

* Initial rollout: #47757
* E2e exclusion (Simple only): #47801
* 100% rollout: #47811

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. On an **Atomic** e2e test site (has `a8c-e2e-test-blog` sticker), confirm `wpcom_is_central_forms_management_enabled()` returns `false`.
2. On a **Simple** e2e test site, confirm the same — `false`.
3. On a regular Atomic or Simple site (no e2e sticker), confirm it returns `true`.
