### PR TITLE
Fix disabling pingbacks in wp-admin UI for staging sites

### DIFF
--- a/projects/plugins/wpcomsh/changelog/2026-03-27-14-16-38-465663
+++ b/projects/plugins/wpcomsh/changelog/2026-03-27-14-16-38-465663
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Make Discussion Settings UI reflect that pingbacks are disabled on staging sites.

--- a/projects/plugins/wpcomsh/changelog/pr-47817
+++ b/projects/plugins/wpcomsh/changelog/pr-47817
@@ -1,4 +1,4 @@
 Significance: patch
-Type: changed
+Type: fixed
 
 Make Discussion Settings UI reflect that pingbacks are disabled on staging sites.

--- a/projects/plugins/wpcomsh/feature-plugins/staging-sites.php
+++ b/projects/plugins/wpcomsh/feature-plugins/staging-sites.php
@@ -71,7 +71,7 @@ add_filter( 'xmlrpc_methods', 'wpcomsh_disable_incoming_pings_in_non_production_
  * Forces the default_pingback_flag option to '0' on staging sites so the
  * Discussion Settings UI reflects that outgoing pingbacks are disabled.
  *
- * @return string '0' on staging sites, allowing normal behavior otherwise.
+ * @return string|false '0' on staging sites, false to allow normal behavior otherwise.
  */
 function wpcomsh_force_pingback_flag_off_on_staging() {
 	if ( 'staging' === wp_get_environment_type() ) {
@@ -86,7 +86,7 @@ add_filter( 'pre_option_default_pingback_flag', 'wpcomsh_force_pingback_flag_off
  * Forces the default_ping_status option to 'closed' on staging sites so the
  * Discussion Settings UI reflects that incoming pingbacks are disabled.
  *
- * @return string 'closed' on staging sites, allowing normal behavior otherwise.
+ * @return string|false 'closed' on staging sites, false to allow normal behavior otherwise.
  */
 function wpcomsh_force_ping_status_closed_on_staging() {
 	if ( 'staging' === wp_get_environment_type() ) {

--- a/projects/plugins/wpcomsh/feature-plugins/staging-sites.php
+++ b/projects/plugins/wpcomsh/feature-plugins/staging-sites.php
@@ -66,3 +66,66 @@ function wpcomsh_disable_incoming_pings_in_non_production_envs( $methods ) {
 	return $methods;
 }
 add_filter( 'xmlrpc_methods', 'wpcomsh_disable_incoming_pings_in_non_production_envs' );
+
+/**
+ * Forces the default_pingback_flag option to '0' on staging sites so the
+ * Discussion Settings UI reflects that outgoing pingbacks are disabled.
+ *
+ * @return string '0' on staging sites, allowing normal behavior otherwise.
+ */
+function wpcomsh_force_pingback_flag_off_on_staging() {
+	if ( 'staging' === wp_get_environment_type() ) {
+		return '0';
+	}
+
+	return false;
+}
+add_filter( 'pre_option_default_pingback_flag', 'wpcomsh_force_pingback_flag_off_on_staging' );
+
+/**
+ * Forces the default_ping_status option to 'closed' on staging sites so the
+ * Discussion Settings UI reflects that incoming pingbacks are disabled.
+ *
+ * @return string 'closed' on staging sites, allowing normal behavior otherwise.
+ */
+function wpcomsh_force_ping_status_closed_on_staging() {
+	if ( 'staging' === wp_get_environment_type() ) {
+		return 'closed';
+	}
+
+	return false;
+}
+add_filter( 'pre_option_default_ping_status', 'wpcomsh_force_ping_status_closed_on_staging' );
+
+/**
+ * Disables pingback checkboxes and adds an explanation on the Discussion
+ * Settings page for staging sites.
+ */
+function wpcomsh_disable_pingback_ui_on_staging() {
+	if ( 'staging' !== wp_get_environment_type() ) {
+		return;
+	}
+
+	$screen = get_current_screen();
+	if ( ! $screen || 'options-discussion' !== $screen->id ) {
+		return;
+	}
+
+	?>
+	<script>
+	( function() {
+		var ids = [ 'default_pingback_flag', 'default_ping_status' ];
+		ids.forEach( function( id ) {
+			var checkbox = document.getElementById( id );
+			if ( checkbox ) {
+				checkbox.disabled = true;
+				var note = document.createElement( 'em' );
+				note.textContent = ' — Pingbacks are disabled on staging sites to prevent unintended outbound requests.';
+				checkbox.parentNode.appendChild( note );
+			}
+		} );
+	} )();
+	</script>
+	<?php
+}
+add_action( 'admin_print_footer_scripts', 'wpcomsh_disable_pingback_ui_on_staging' );

--- a/projects/plugins/wpcomsh/feature-plugins/staging-sites.php
+++ b/projects/plugins/wpcomsh/feature-plugins/staging-sites.php
@@ -111,12 +111,11 @@ function wpcomsh_disable_pingback_ui_on_staging() {
 		return;
 	}
 
-	$message = esc_js( __( 'Pingbacks are disabled on staging sites to prevent unintended outbound requests.', 'wpcomsh' ) );
 	?>
 	<script>
 	( function() {
 		var ids = [ 'default_pingback_flag', 'default_ping_status' ];
-		var message = ' — <?php echo $message; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped above with esc_js. ?>';
+		var message = ' — ' + <?php echo wp_json_encode( __( 'Pingbacks are disabled on staging sites to prevent unintended outbound requests.', 'wpcomsh' ) ); ?>;
 		ids.forEach( function( id ) {
 			var checkbox = document.getElementById( id );
 			if ( checkbox ) {

--- a/projects/plugins/wpcomsh/feature-plugins/staging-sites.php
+++ b/projects/plugins/wpcomsh/feature-plugins/staging-sites.php
@@ -115,7 +115,7 @@ function wpcomsh_disable_pingback_ui_on_staging() {
 	<script>
 	( function() {
 		var ids = [ 'default_pingback_flag', 'default_ping_status' ];
-		var message = ' — ' + <?php echo wp_json_encode( __( 'Pingbacks are disabled on staging sites to prevent unintended outbound requests.', 'wpcomsh' ) ); ?>;
+		var message = ' — ' + <?php echo wp_json_encode( __( 'Pingbacks are disabled on staging sites to prevent unintended outbound requests.', 'wpcomsh' ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
 		ids.forEach( function( id ) {
 			var checkbox = document.getElementById( id );
 			if ( checkbox ) {

--- a/projects/plugins/wpcomsh/feature-plugins/staging-sites.php
+++ b/projects/plugins/wpcomsh/feature-plugins/staging-sites.php
@@ -111,16 +111,18 @@ function wpcomsh_disable_pingback_ui_on_staging() {
 		return;
 	}
 
+	$message = esc_js( __( 'Pingbacks are disabled on staging sites to prevent unintended outbound requests.', 'wpcomsh' ) );
 	?>
 	<script>
 	( function() {
 		var ids = [ 'default_pingback_flag', 'default_ping_status' ];
+		var message = ' — <?php echo $message; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped above with esc_js. ?>';
 		ids.forEach( function( id ) {
 			var checkbox = document.getElementById( id );
 			if ( checkbox ) {
 				checkbox.disabled = true;
 				var note = document.createElement( 'em' );
-				note.textContent = ' — Pingbacks are disabled on staging sites to prevent unintended outbound requests.';
+				note.textContent = message;
 				checkbox.parentNode.appendChild( note );
 			}
 		} );

--- a/projects/plugins/wpcomsh/tests/StagingSitePingsTest.php
+++ b/projects/plugins/wpcomsh/tests/StagingSitePingsTest.php
@@ -144,7 +144,7 @@ class StagingSitePingsTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'default_pingback_flag', $output );
 		$this->assertStringContainsString( 'default_ping_status', $output );
 		$this->assertStringContainsString( 'checkbox.disabled = true', $output );
-		$this->assertStringContainsString( 'Pingbacks are disabled on staging sites', $output );
+		$this->assertStringContainsString( 'Pingbacks are disabled on staging sites to prevent unintended outbound requests.', $output );
 
 		set_current_screen( 'front' );
 	}

--- a/projects/plugins/wpcomsh/tests/StagingSitePingsTest.php
+++ b/projects/plugins/wpcomsh/tests/StagingSitePingsTest.php
@@ -81,4 +81,36 @@ class StagingSitePingsTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'pingback.ping', $result );
 		$this->assertArrayHasKey( 'wp.getPosts', $result );
 	}
+
+	/**
+	 * Test that default_pingback_flag option is forced to '0' on staging.
+	 */
+	public function test_pingback_flag_forced_off_on_staging() {
+		putenv( 'WP_ENVIRONMENT_TYPE=staging' );
+		$this->assertSame( '0', wpcomsh_force_pingback_flag_off_on_staging() );
+	}
+
+	/**
+	 * Test that default_pingback_flag option is not overridden in production.
+	 */
+	public function test_pingback_flag_not_overridden_in_production() {
+		putenv( 'WP_ENVIRONMENT_TYPE=production' );
+		$this->assertFalse( wpcomsh_force_pingback_flag_off_on_staging() );
+	}
+
+	/**
+	 * Test that default_ping_status option is forced to 'closed' on staging.
+	 */
+	public function test_ping_status_forced_closed_on_staging() {
+		putenv( 'WP_ENVIRONMENT_TYPE=staging' );
+		$this->assertSame( 'closed', wpcomsh_force_ping_status_closed_on_staging() );
+	}
+
+	/**
+	 * Test that default_ping_status option is not overridden in production.
+	 */
+	public function test_ping_status_not_overridden_in_production() {
+		putenv( 'WP_ENVIRONMENT_TYPE=production' );
+		$this->assertFalse( wpcomsh_force_ping_status_closed_on_staging() );
+	}
 }

--- a/projects/plugins/wpcomsh/tests/StagingSitePingsTest.php
+++ b/projects/plugins/wpcomsh/tests/StagingSitePingsTest.php
@@ -113,4 +113,55 @@ class StagingSitePingsTest extends WP_UnitTestCase {
 		putenv( 'WP_ENVIRONMENT_TYPE=production' );
 		$this->assertFalse( wpcomsh_force_ping_status_closed_on_staging() );
 	}
+
+	/**
+	 * Test that the pingback UI script is not output in production.
+	 */
+	public function test_pingback_ui_not_modified_in_production() {
+		putenv( 'WP_ENVIRONMENT_TYPE=production' );
+		set_current_screen( 'options-discussion' );
+
+		ob_start();
+		wpcomsh_disable_pingback_ui_on_staging();
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output );
+
+		set_current_screen( 'front' );
+	}
+
+	/**
+	 * Test that the pingback UI script is output on the Discussion Settings page in staging.
+	 */
+	public function test_pingback_ui_disabled_on_staging_discussion_page() {
+		putenv( 'WP_ENVIRONMENT_TYPE=staging' );
+		set_current_screen( 'options-discussion' );
+
+		ob_start();
+		wpcomsh_disable_pingback_ui_on_staging();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'default_pingback_flag', $output );
+		$this->assertStringContainsString( 'default_ping_status', $output );
+		$this->assertStringContainsString( 'checkbox.disabled = true', $output );
+		$this->assertStringContainsString( 'Pingbacks are disabled on staging sites', $output );
+
+		set_current_screen( 'front' );
+	}
+
+	/**
+	 * Test that the pingback UI script is not output on non-Discussion admin pages in staging.
+	 */
+	public function test_pingback_ui_not_modified_on_other_admin_pages() {
+		putenv( 'WP_ENVIRONMENT_TYPE=staging' );
+		set_current_screen( 'dashboard' );
+
+		ob_start();
+		wpcomsh_disable_pingback_ui_on_staging();
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output );
+
+		set_current_screen( 'front' );
+	}
 }


### PR DESCRIPTION
Fixes DOTDEV-401

## Proposed changes
Follow up to https://github.com/Automattic/jetpack/pull/47752
With this PR we are disabling checkboxes in wp-admin and printing the reason
<img width="1370" height="70" alt="Screenshot 2026-03-27 at 15 23 32" src="https://github.com/user-attachments/assets/f4768c2f-87b4-41fa-99a2-4db4c2ac27a1" />

## Testing instructions
Strictly follow the steps, since I had issues when I created the staging site earlier or missed the "Add dev blog" action, etc.
1. Create a free site
2. Open PCYsg-Osp-p2 and click on the link "WoW Developer Blog Manager" (sorry, Tanpermonkey doesn't work for this link to provide it here directly)
3. Provide blog id and click "Add dev blog"
4. Upgrade to Business plan
5. Activate hosting features to allow installing plugins
6. Launch your site (you can skip domain purchase)
7. Create staging site
8. Download beta plugin here - https://jetpack.com/download-jetpack-beta/
9. Install it on both staging and production and activate
10. Apply to both prod and staging sites: open `Jetpack -> Beta tester` -> click on `Manage` button for "WordPress.com Site Helper" -> in the search field write `fix/disablePingbacksInUiForStaging` -> click `Activate` button
11. Open "wp-admin -> Settings Discussions" on staging site
12. Assert that you see unchecked and disabled checkboxes and the explanations of why thy are disabled<br /><img width="1370" height="70" alt="Screenshot 2026-03-27 at 15 23 32" src="https://github.com/user-attachments/assets/f4768c2f-87b4-41fa-99a2-4db4c2ac27a1" />
13. Repeat 11 and 12 for prod site and assert that no regression there - they are enabled<br /><img width="837" height="68" alt="Screenshot 2026-03-27 at 15 27 34" src="https://github.com/user-attachments/assets/a0d322fc-d3f8-47d3-9e7a-d4e810e147a2" />
