### PR TITLE
Forms: Exclude blueprints directory from production builds

### DIFF
--- a/projects/packages/forms/.gitattributes
+++ b/projects/packages/forms/.gitattributes
@@ -27,3 +27,4 @@ tools/**                 production-exclude
 tsconfig.json            production-exclude
 declarations.d.ts        production-exclude
 global.d.ts              production-exclude
+blueprints/**            production-exclude

--- a/projects/packages/forms/changelog/remove-blueprints-production-exclude
+++ b/projects/packages/forms/changelog/remove-blueprints-production-exclude
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Exclude blueprints directory from production builds


### PR DESCRIPTION
This is a follow UP PR to - This is a follow up to https://github.com/Automattic/jetpack/pull/47758 

## Proposed changes
* Exclude the `blueprints/` directory from production builds of the Forms package by adding it to the production-exclude list in `.gitattributes`.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Verify that `blueprints/**` is listed under the production-exclude section in `projects/packages/forms/.gitattributes`.
* No functional changes — this only affects what gets included in the mirror repo.
