### PR TITLE
jetpack-mu-wpcom: Add blog sticker to disable CFM for individual sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-forms-cfm-disable-sticker
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-forms-cfm-disable-sticker
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add disable-central-forms-management blog sticker to opt out individual sites from CFM.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-contact-form-flags/wpcom-contact-form-flags.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-contact-form-flags/wpcom-contact-form-flags.php
@@ -46,6 +46,11 @@ function wpcom_is_central_forms_management_enabled( $blog_id = null ) {
 		return false;
 	}
 
+	// Allow disabling CFM for individual sites via blog sticker.
+	if ( wpcom_forms_has_blog_sticker( 'disable-central-forms-management', $blog_id ) ) {
+		return false;
+	}
+
 	return true;
 }
 


### PR DESCRIPTION
Fixes #

## Proposed changes

* Add a `disable-central-forms-management` blog sticker that allows opting individual sites out of CFM.
* Uses the existing `wpcom_forms_has_blog_sticker()` helper so it works on both Simple and Atomic.
* Checked before `return true`, after the e2e exclusion — so it takes priority over the 100% rollout.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links

* CFM rollout PRs: #47757, #47793, #47801, #47811, #47815

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Add the `disable-central-forms-management` blog sticker to a site.
2. Confirm `wpcom_is_central_forms_management_enabled()` returns `false` for that site.
3. Confirm the Forms dashboard shows the old responses view (no Forms/Responses tabs).
4. Remove the sticker and confirm CFM is re-enabled.
