### PR TITLE
Forms: Fix boot script timing with third-party plugins that use script modules

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-boot-importmap-compat
+++ b/projects/packages/forms/changelog/fix-forms-boot-importmap-compat
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Forms dashboard black screen when The Events Calendar is active by replacing fragile import() in inline script with a proper script module.

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -60,6 +60,66 @@ class Dashboard {
 	}
 
 	/**
+	 * Fix import map ordering for the wp-build boot script.
+	 *
+	 * In wp-admin, _wp_footer_scripts (classic scripts) and print_import_map
+	 * both hook into admin_print_footer_scripts at priority 10, but
+	 * _wp_footer_scripts is registered first. This causes the inline
+	 * import("@wordpress/boot") to execute before the import map exists.
+	 *
+	 * This fix moves the import() call from the classic inline script to a
+	 * <script type="module"> printed at priority 20 (after the import map).
+	 *
+	 * @todo Remove once @wordpress/build ships with the loader.js fix upstream
+	 *       (WordPress/gutenberg#76870) and Jetpack updates the dependency.
+	 */
+	public static function fix_boot_import_map_ordering() {
+		$handle = self::FORMS_WPBUILD_ADMIN_SLUG . '-prerequisites';
+
+		add_action(
+			'admin_enqueue_scripts',
+			static function () use ( $handle ) {
+				if ( ! Dashboard::is_jetpack_forms_admin_page() ) {
+					return;
+				}
+
+				$data = wp_scripts()->get_data( $handle, 'after' );
+				if ( empty( $data ) ) {
+					return;
+				}
+
+				// Find and extract the import("@wordpress/boot") inline script.
+				$boot_script = null;
+				$remaining   = array();
+				foreach ( $data as $line ) {
+					if ( strpos( $line, '@wordpress/boot' ) !== false ) {
+						$boot_script = $line;
+					} else {
+						$remaining[] = $line;
+					}
+				}
+
+				if ( $boot_script === null ) {
+					return;
+				}
+
+				// Remove from the classic script handle.
+				wp_scripts()->add_data( $handle, 'after', $remaining );
+
+				// Re-emit as a module script after the import map.
+				add_action(
+					'admin_print_footer_scripts',
+					static function () use ( $boot_script ) {
+						wp_print_inline_script_tag( $boot_script, array( 'type' => 'module' ) );
+					},
+					20
+				);
+			},
+			PHP_INT_MAX
+		);
+	}
+
+	/**
 	 * Script handle for the JS file we enqueue in the Feedback admin page.
 	 *
 	 * @var string
@@ -97,6 +157,7 @@ class Dashboard {
 
 		if ( $is_wp_build_enabled ) {
 			self::load_wp_build();
+			self::fix_boot_import_map_ordering();
 		}
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'load_admin_scripts' ) );


### PR DESCRIPTION
Resolves FORMS-667

Note upstream fix https://github.com/WordPress/gutenberg/pull/76870

## Description

The wp-build generated `page-wp-admin.php` attaches an `import("@wordpress/boot")` call to a classic inline script via `wp_add_inline_script`. In `admin_print_footer_scripts`, both `_wp_footer_scripts` (classic scripts) and `print_import_map` run at priority 10, but `_wp_footer_scripts` is registered first — so the inline `import()` executes before the import map is in the DOM.

This is a latent bug: bare specifier resolution requires the import map to already exist. It happens to work in most environments because browser microtask scheduling defers the actual resolution. But when a third-party plugin (e.g. The Events Calendar, via StellarWP) converts classic scripts to `type="module"` using `script_loader_tag`, the timing changes and `@wordpress/boot` fails to resolve — resulting in a blank Forms dashboard.

## Fix

Move the `import("@wordpress/boot")` inline code from the classic script handle to a `<script type="module">` printed at `admin_print_footer_scripts` priority 20, well after the import map (priority 10). Module scripts resolve bare specifiers using whatever import map is in the DOM at execution time, so the ordering is guaranteed.

The fix extracts the existing inline script verbatim — it doesn't reconstruct the boot config or depend on any `@wordpress/boot` internals.

The upstream fix is https://github.com/WordPress/gutenberg/pull/76870.

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

1. Install and activate [The Events Calendar](https://wordpress.org/plugins/the-events-calendar/)
2. Navigate to Jetpack → Forms
3. **Before**: blank/dark page, console shows `TypeError: Failed to resolve module specifier '@wordpress/boot'`
4. **After**: dashboard loads normally
5. Deactivate The Events Calendar — Forms dashboard still works