### PR TITLE
Forms: Fix import map ordering for wp-build boot script

### DIFF
--- a/projects/packages/forms/changelog/fix-event-calendar-cfm
+++ b/projects/packages/forms/changelog/fix-event-calendar-cfm
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix import map ordering for wp-build boot script in wp-admin, preventing 'Failed to resolve module specifier' errors.

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -79,12 +79,7 @@ class Dashboard {
 			'admin_enqueue_scripts',
 			function () use ( $handle ) {
 				// Only run on the Forms admin page.
-				$current_screen = get_current_screen();
-				$is_forms_page  = (
-					( isset( $_GET['page'] ) && self::FORMS_WPBUILD_ADMIN_SLUG === $_GET['page'] ) || // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-					( $current_screen && 'jetpack-forms-responses' === $current_screen->id )
-				);
-				if ( ! $is_forms_page ) {
+				if ( ! self::is_jetpack_forms_admin_page() ) {
 					return;
 				}
 

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -60,6 +60,61 @@ class Dashboard {
 	}
 
 	/**
+	 * Fix import map ordering for the wp-build boot script.
+	 *
+	 * In wp-admin, _wp_footer_scripts (classic scripts) and print_import_map
+	 * both hook into admin_print_footer_scripts at priority 10, but
+	 * _wp_footer_scripts is registered first. This causes the inline
+	 * import("@wordpress/boot") to execute before the import map exists.
+	 *
+	 * This fix moves the import() call from the classic inline script to a
+	 * <script type="module"> printed at priority 11 (after the import map).
+	 *
+	 * Public for testability. Should not be called directly outside of this class.
+	 */
+	public static function fix_boot_import_map_ordering() {
+		$handle = self::FORMS_WPBUILD_ADMIN_SLUG . '-prerequisites';
+
+		add_action(
+			'admin_enqueue_scripts',
+			function () use ( $handle ) {
+				$data = wp_scripts()->get_data( $handle, 'after' );
+				if ( empty( $data ) ) {
+					return;
+				}
+
+				// Find and extract the import("@wordpress/boot") inline script.
+				$init_script = null;
+				$remaining   = array();
+				foreach ( $data as $line ) {
+					if ( strpos( $line, '@wordpress/boot' ) !== false ) {
+						$init_script = $line;
+					} else {
+						$remaining[] = $line;
+					}
+				}
+
+				if ( $init_script === null ) {
+					return;
+				}
+
+				// Remove the original inline script from the classic script handle.
+				wp_scripts()->add_data( $handle, 'after', $remaining );
+
+				// Re-emit it as a module script after the import map (priority 11).
+				add_action(
+					'admin_print_footer_scripts',
+					function () use ( $init_script ) {
+						echo '<script type="module">' . $init_script . "</script>\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Generated JS with JSON-encoded data from wp_json_encode.
+					},
+					11
+				);
+			},
+			PHP_INT_MAX // Run after the page's own enqueue hook.
+		);
+	}
+
+	/**
 	 * Script handle for the JS file we enqueue in the Feedback admin page.
 	 *
 	 * @var string
@@ -97,6 +152,7 @@ class Dashboard {
 
 		if ( $is_wp_build_enabled ) {
 			self::load_wp_build();
+			self::fix_boot_import_map_ordering();
 		}
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'load_admin_scripts' ) );

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -78,6 +78,16 @@ class Dashboard {
 		add_action(
 			'admin_enqueue_scripts',
 			function () use ( $handle ) {
+				// Only run on the Forms admin page.
+				$current_screen = get_current_screen();
+				$is_forms_page  = (
+					( isset( $_GET['page'] ) && self::FORMS_WPBUILD_ADMIN_SLUG === $_GET['page'] ) || // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+					( $current_screen && 'jetpack-forms-responses' === $current_screen->id )
+				);
+				if ( ! $is_forms_page ) {
+					return;
+				}
+
 				$data = wp_scripts()->get_data( $handle, 'after' );
 				if ( empty( $data ) ) {
 					return;
@@ -105,7 +115,7 @@ class Dashboard {
 				add_action(
 					'admin_print_footer_scripts',
 					function () use ( $init_script ) {
-						echo '<script type="module">' . $init_script . "</script>\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Generated JS with JSON-encoded data from wp_json_encode.
+						wp_print_inline_script_tag( $init_script, array( 'type' => 'module' ) );
 					},
 					11
 				);

--- a/projects/packages/forms/tests/php/dashboard/Dashboard_Boot_Import_Map_Test.php
+++ b/projects/packages/forms/tests/php/dashboard/Dashboard_Boot_Import_Map_Test.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Tests for the boot import map ordering fix.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\Dashboard;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+
+/**
+ * Verifies that fix_boot_import_map_ordering moves the import("@wordpress/boot")
+ * inline script from a classic script handle to a <script type="module"> printed
+ * after the import map.
+ *
+ * @covers Automattic\Jetpack\Forms\Dashboard\Dashboard
+ */
+#[CoversClass( Dashboard::class )]
+class Dashboard_Boot_Import_Map_Test extends BaseTestCase {
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		// Reset the script queue.
+		$GLOBALS['wp_scripts'] = null;
+		remove_all_actions( 'admin_print_footer_scripts' );
+		remove_all_actions( 'admin_enqueue_scripts' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Simulate what the generated page-wp-admin.php does: register a classic
+	 * script with an inline import("@wordpress/boot") call, then verify the
+	 * fix moves it to a module script on admin_print_footer_scripts at priority 11.
+	 */
+	public function test_fix_moves_boot_import_to_module_script() {
+		$handle = Dashboard::FORMS_WPBUILD_ADMIN_SLUG . '-prerequisites';
+
+		// Simulate the generated page-wp-admin.php: register script + inline import().
+		wp_register_script( $handle, '', array(), '1.0', true );
+		wp_add_inline_script(
+			$handle,
+			'import("@wordpress/boot").then(mod => mod.initSinglePage({mountId: "app", routes: []}));'
+		);
+
+		// Verify the inline script is attached before the fix.
+		$before = wp_scripts()->get_data( $handle, 'after' );
+		$this->assertNotEmpty( $before, 'Inline script should be attached before fix runs.' );
+		$this->assertTrue(
+			$this->array_contains_string( $before, '@wordpress/boot' ),
+			'Inline script should contain @wordpress/boot before fix.'
+		);
+
+		Dashboard::fix_boot_import_map_ordering();
+
+		// Fire admin_enqueue_scripts to trigger the fix's callback.
+		do_action( 'admin_enqueue_scripts', '' );
+
+		// The inline script should have been removed from the classic handle.
+		$after = wp_scripts()->get_data( $handle, 'after' );
+		$this->assertFalse(
+			$this->array_contains_string( is_array( $after ) ? $after : array(), '@wordpress/boot' ),
+			'import("@wordpress/boot") should be removed from the classic script handle.'
+		);
+
+		// A callback should be registered on admin_print_footer_scripts at priority 11.
+		$this->assertGreaterThan(
+			0,
+			has_action( 'admin_print_footer_scripts' ),
+			'A callback should be hooked to admin_print_footer_scripts.'
+		);
+
+		// Capture its output and verify it's a <script type="module">.
+		ob_start();
+		do_action( 'admin_print_footer_scripts' );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '<script type="module">', $output );
+		$this->assertStringContainsString( '@wordpress/boot', $output );
+		$this->assertStringContainsString( 'initSinglePage', $output );
+	}
+
+	/**
+	 * Verify the fix is a no-op when there is no inline script on the handle.
+	 */
+	public function test_fix_is_noop_without_inline_script() {
+		$handle = Dashboard::FORMS_WPBUILD_ADMIN_SLUG . '-prerequisites';
+
+		wp_register_script( $handle, '', array(), '1.0', true );
+		// No wp_add_inline_script — the handle has no 'after' data.
+
+		Dashboard::fix_boot_import_map_ordering();
+
+		do_action( 'admin_enqueue_scripts', '' );
+
+		// Nothing should be hooked at priority 11.
+		ob_start();
+		do_action( 'admin_print_footer_scripts' );
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( '<script type="module">', $output );
+	}
+
+	/**
+	 * Helper: check if any string in the array contains the given substring.
+	 *
+	 * @param array  $arr    Array of strings.
+	 * @param string $needle Substring to search for.
+	 * @return bool
+	 */
+	private function array_contains_string( array $arr, string $needle ): bool {
+		foreach ( $arr as $item ) {
+			if ( is_string( $item ) && strpos( $item, $needle ) !== false ) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/projects/packages/forms/tests/php/dashboard/Dashboard_Boot_Import_Map_Test.php
+++ b/projects/packages/forms/tests/php/dashboard/Dashboard_Boot_Import_Map_Test.php
@@ -21,13 +21,24 @@ use WorDBless\BaseTestCase;
 class Dashboard_Boot_Import_Map_Test extends BaseTestCase {
 
 	/**
-	 * Clean up after each test.
+	 * Set up before each test.
 	 */
-	public function tear_down() {
-		// Reset the script queue.
+	public function set_up() {
+		parent::set_up();
 		$GLOBALS['wp_scripts'] = null;
 		remove_all_actions( 'admin_print_footer_scripts' );
 		remove_all_actions( 'admin_enqueue_scripts' );
+		unset( $_GET['page'] );
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		$GLOBALS['wp_scripts'] = null;
+		remove_all_actions( 'admin_print_footer_scripts' );
+		remove_all_actions( 'admin_enqueue_scripts' );
+		unset( $_GET['page'] );
 		parent::tear_down();
 	}
 
@@ -37,6 +48,9 @@ class Dashboard_Boot_Import_Map_Test extends BaseTestCase {
 	 * fix moves it to a module script on admin_print_footer_scripts at priority 11.
 	 */
 	public function test_fix_moves_boot_import_to_module_script() {
+		// Simulate being on the Forms admin page.
+		$_GET['page'] = Dashboard::FORMS_WPBUILD_ADMIN_SLUG;
+
 		$handle = Dashboard::FORMS_WPBUILD_ADMIN_SLUG . '-prerequisites';
 
 		// Simulate the generated page-wp-admin.php: register script + inline import().
@@ -78,30 +92,62 @@ class Dashboard_Boot_Import_Map_Test extends BaseTestCase {
 		do_action( 'admin_print_footer_scripts' );
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( '<script type="module">', $output );
+		$this->assertMatchesRegularExpression( '/<script\b[^>]*type=["\']module["\'][^>]*>/', $output );
 		$this->assertStringContainsString( '@wordpress/boot', $output );
 		$this->assertStringContainsString( 'initSinglePage', $output );
+	}
+
+	/**
+	 * Verify the fix does not run on non-Forms admin pages.
+	 */
+	public function test_fix_does_not_run_on_other_pages() {
+		$_GET['page'] = 'some-other-page';
+
+		$handle = Dashboard::FORMS_WPBUILD_ADMIN_SLUG . '-prerequisites';
+
+		wp_register_script( $handle, '', array(), '1.0', true );
+		wp_add_inline_script(
+			$handle,
+			'import("@wordpress/boot").then(mod => mod.initSinglePage({mountId: "app", routes: []}));'
+		);
+
+		Dashboard::fix_boot_import_map_ordering();
+		do_action( 'admin_enqueue_scripts', '' );
+
+		// The inline script should still be on the classic handle.
+		$after = wp_scripts()->get_data( $handle, 'after' );
+		$this->assertTrue(
+			$this->array_contains_string( is_array( $after ) ? $after : array(), '@wordpress/boot' ),
+			'import("@wordpress/boot") should remain on the classic script handle on other pages.'
+		);
+
+		// Nothing should be hooked to admin_print_footer_scripts.
+		ob_start();
+		do_action( 'admin_print_footer_scripts' );
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'type="module"', $output );
 	}
 
 	/**
 	 * Verify the fix is a no-op when there is no inline script on the handle.
 	 */
 	public function test_fix_is_noop_without_inline_script() {
+		$_GET['page'] = Dashboard::FORMS_WPBUILD_ADMIN_SLUG;
+
 		$handle = Dashboard::FORMS_WPBUILD_ADMIN_SLUG . '-prerequisites';
 
 		wp_register_script( $handle, '', array(), '1.0', true );
 		// No wp_add_inline_script — the handle has no 'after' data.
 
 		Dashboard::fix_boot_import_map_ordering();
-
 		do_action( 'admin_enqueue_scripts', '' );
 
-		// Nothing should be hooked at priority 11.
 		ob_start();
 		do_action( 'admin_print_footer_scripts' );
 		$output = ob_get_clean();
 
-		$this->assertStringNotContainsString( '<script type="module">', $output );
+		$this->assertStringNotContainsString( 'type="module"', $output );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/dashboard/Dashboard_Boot_Import_Map_Test.php
+++ b/projects/packages/forms/tests/php/dashboard/Dashboard_Boot_Import_Map_Test.php
@@ -28,7 +28,6 @@ class Dashboard_Boot_Import_Map_Test extends BaseTestCase {
 		$GLOBALS['wp_scripts'] = null;
 		remove_all_actions( 'admin_print_footer_scripts' );
 		remove_all_actions( 'admin_enqueue_scripts' );
-		unset( $_GET['page'] );
 	}
 
 	/**
@@ -38,7 +37,7 @@ class Dashboard_Boot_Import_Map_Test extends BaseTestCase {
 		$GLOBALS['wp_scripts'] = null;
 		remove_all_actions( 'admin_print_footer_scripts' );
 		remove_all_actions( 'admin_enqueue_scripts' );
-		unset( $_GET['page'] );
+		set_current_screen( 'front' );
 		parent::tear_down();
 	}
 
@@ -48,8 +47,7 @@ class Dashboard_Boot_Import_Map_Test extends BaseTestCase {
 	 * fix moves it to a module script on admin_print_footer_scripts at priority 11.
 	 */
 	public function test_fix_moves_boot_import_to_module_script() {
-		// Simulate being on the Forms admin page.
-		$_GET['page'] = Dashboard::FORMS_WPBUILD_ADMIN_SLUG;
+		$this->set_forms_admin_screen();
 
 		$handle = Dashboard::FORMS_WPBUILD_ADMIN_SLUG . '-prerequisites';
 
@@ -101,7 +99,7 @@ class Dashboard_Boot_Import_Map_Test extends BaseTestCase {
 	 * Verify the fix does not run on non-Forms admin pages.
 	 */
 	public function test_fix_does_not_run_on_other_pages() {
-		$_GET['page'] = 'some-other-page';
+		set_current_screen( 'dashboard' );
 
 		$handle = Dashboard::FORMS_WPBUILD_ADMIN_SLUG . '-prerequisites';
 
@@ -130,10 +128,39 @@ class Dashboard_Boot_Import_Map_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Verify the fix preserves other inline scripts on the same handle.
+	 */
+	public function test_fix_preserves_other_inline_scripts() {
+		$this->set_forms_admin_screen();
+
+		$handle = Dashboard::FORMS_WPBUILD_ADMIN_SLUG . '-prerequisites';
+
+		wp_register_script( $handle, '', array(), '1.0', true );
+		wp_add_inline_script( $handle, 'console.log("other script");' );
+		wp_add_inline_script(
+			$handle,
+			'import("@wordpress/boot").then(mod => mod.initSinglePage({mountId: "app", routes: []}));'
+		);
+
+		Dashboard::fix_boot_import_map_ordering();
+		do_action( 'admin_enqueue_scripts', '' );
+
+		$after = wp_scripts()->get_data( $handle, 'after' );
+		$this->assertTrue(
+			$this->array_contains_string( is_array( $after ) ? $after : array(), 'other script' ),
+			'Non-boot inline scripts should be preserved on the classic handle.'
+		);
+		$this->assertFalse(
+			$this->array_contains_string( is_array( $after ) ? $after : array(), '@wordpress/boot' ),
+			'Boot import should be removed from the classic handle.'
+		);
+	}
+
+	/**
 	 * Verify the fix is a no-op when there is no inline script on the handle.
 	 */
 	public function test_fix_is_noop_without_inline_script() {
-		$_GET['page'] = Dashboard::FORMS_WPBUILD_ADMIN_SLUG;
+		$this->set_forms_admin_screen();
 
 		$handle = Dashboard::FORMS_WPBUILD_ADMIN_SLUG . '-prerequisites';
 
@@ -148,6 +175,13 @@ class Dashboard_Boot_Import_Map_Test extends BaseTestCase {
 		$output = ob_get_clean();
 
 		$this->assertStringNotContainsString( 'type="module"', $output );
+	}
+
+	/**
+	 * Set the current screen to the Forms wp-build admin page.
+	 */
+	private function set_forms_admin_screen() {
+		set_current_screen( 'jetpack_page_' . Dashboard::FORMS_WPBUILD_ADMIN_SLUG );
 	}
 
 	/**


### PR DESCRIPTION
Fixes FORMS-667

See also potential upstream fix:
- https://github.com/WordPress/gutenberg/pull/76870

## Proposed changes

* Fix `TypeError: Failed to resolve module specifier '@wordpress/boot'` on the Jetpack Forms wp-build admin page.
* In wp-admin, `_wp_footer_scripts` (classic scripts) and `print_import_map` (script modules) both hook into `admin_print_footer_scripts` at priority 10, but `_wp_footer_scripts` is registered first. The inline `import("@wordpress/boot")` call — attached to a classic script via `wp_add_inline_script` — executes before the import map is printed, so the browser cannot resolve the bare specifier.
* The fix intercepts the inline script at `admin_enqueue_scripts` time, removes it from the classic script handle, and re-emits it as a `<script type="module">` at `admin_print_footer_scripts` priority 11 (after the import map).

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* This issue was surfaced when The Events Calendar plugin was active, but the root cause is a WordPress core hook ordering issue that affects all sites using wp-build pages in wp-admin.
See p1774633136941859-slack-C086RGTJT1D

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. Install and activate [The Events Calendar](https://wordpress.org/plugins/the-events-calendar/) plugin (or any plugin that enqueues scripts globally in wp-admin).
2. Enable the wp-build forms dashboard (`jetpack_forms_alpha` filter must return `true`).
3. Go to **Jetpack → Forms** in wp-admin.
4. **Before this fix:** The page shows a blank content area with `TypeError: Failed to resolve module specifier '@wordpress/boot'` in the browser console.
5. **After this fix:** The Forms page renders correctly with the full table of forms, tabs, search, and pagination.