### PR TITLE
feat: Editor assets endpoint allows the VideoPress block

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-block-editor-assets.php
@@ -112,6 +112,7 @@ class WPCOM_REST_API_V2_Endpoint_Block_Editor_Assets extends WP_REST_Controller 
 		'premium-content/logged-out-view',
 		'premium-content/login-button',
 		'premium-content/subscriber-view',
+		'videopress/video',
 	);
 
 	/**

--- a/projects/plugins/jetpack/changelog/feat-editor-assets-endpoint-allows-videopress
+++ b/projects/plugins/jetpack/changelog/feat-editor-assets-endpoint-allows-videopress
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Editor assets endpoint: allow the VideoPress block type.


### PR DESCRIPTION
Ref CMM-713. 

Replaces #45255, which was erroneously closed.

## Proposed changes:
Allow the `videopress/video` block type for the GutenbergKit mobile app editor. 

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
pbArwn-7AD-p2

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:

1. Apply these Jetpack changes to your site (see [comment](https://github.com/Automattic/jetpack/pull/45255#issuecomment-3313588564)). 
1. Make a request to the `/wpcom/v2/sites/<site_id>/editor-assets` endpoint for the WPCOM site—via [API Console](https://developer.wordpress.com/docs/api/console/), `curl`, etc. 
1. Verify the 200 response includes the `videopress/video` block type within the `allow_block_types`.