### PR TITLE
Newsletter: Fix spacing for manage subscribers link

### DIFF
--- a/projects/packages/newsletter/changelog/fix-subscriber-toggle-spacing
+++ b/projects/packages/newsletter/changelog/fix-subscriber-toggle-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix spacing between the send-default toggle description and the Manage all subscribers link in the Newsletter settings card.

--- a/projects/packages/newsletter/src/settings/sections/newsletter-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-section.tsx
@@ -131,7 +131,7 @@ export function NewsletterSection( { data, onChange }: NewsletterSectionProps ):
 					onChange={ handleChange }
 				/>
 				{ data.subscriptions && newsletterScriptData && (
-					<div>
+					<div className="newsletter-manage-subscribers">
 						<ExternalLink
 							href={ newsletterScriptData.subscriberManagementUrl }
 							onClick={ handleManageSubscribersClick }

--- a/projects/packages/newsletter/src/settings/sections/newsletter-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-section.tsx
@@ -130,18 +130,16 @@ export function NewsletterSection( { data, onChange }: NewsletterSectionProps ):
 					} }
 					onChange={ handleChange }
 				/>
-				{ data.subscriptions && newsletterScriptData && (
-					<div className="newsletter-manage-subscribers">
-						<ExternalLink
-							href={ newsletterScriptData.subscriberManagementUrl }
-							onClick={ handleManageSubscribersClick }
-						>
-							{ __( 'Manage all subscribers', 'jetpack-newsletter' ) }
-						</ExternalLink>
-					</div>
-				) }
 			</CardBody>
-			<CardFooter>
+			<CardFooter className="newsletter-card-footer">
+				{ data.subscriptions && newsletterScriptData && (
+					<ExternalLink
+						href={ newsletterScriptData.subscriberManagementUrl }
+						onClick={ handleManageSubscribersClick }
+					>
+						{ __( 'Manage all subscribers', 'jetpack-newsletter' ) }
+					</ExternalLink>
+				) }
 				<ExternalLink
 					href={ getRedirectUrl( 'jetpack-support-subscriptions', { anchor: 'privacy' } ) }
 				>

--- a/projects/packages/newsletter/src/settings/sections/newsletter-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-section.tsx
@@ -132,6 +132,11 @@ export function NewsletterSection( { data, onChange }: NewsletterSectionProps ):
 				/>
 			</CardBody>
 			<CardFooter className="newsletter-card-footer">
+				<ExternalLink
+					href={ getRedirectUrl( 'jetpack-support-subscriptions', { anchor: 'privacy' } ) }
+				>
+					{ __( 'Privacy information', 'jetpack-newsletter' ) }
+				</ExternalLink>
 				{ data.subscriptions && newsletterScriptData && (
 					<ExternalLink
 						href={ newsletterScriptData.subscriberManagementUrl }
@@ -140,11 +145,6 @@ export function NewsletterSection( { data, onChange }: NewsletterSectionProps ):
 						{ __( 'Manage all subscribers', 'jetpack-newsletter' ) }
 					</ExternalLink>
 				) }
-				<ExternalLink
-					href={ getRedirectUrl( 'jetpack-support-subscriptions', { anchor: 'privacy' } ) }
-				>
-					{ __( 'Privacy information', 'jetpack-newsletter' ) }
-				</ExternalLink>
 			</CardFooter>
 		</Card>
 	);

--- a/projects/packages/newsletter/src/settings/style.scss
+++ b/projects/packages/newsletter/src/settings/style.scss
@@ -30,4 +30,8 @@
 	.components-card__body > p:first-child {
 		margin-top: 0;
 	}
+
+	.newsletter-manage-subscribers {
+		margin-top: 16px;
+	}
 }

--- a/projects/packages/newsletter/src/settings/style.scss
+++ b/projects/packages/newsletter/src/settings/style.scss
@@ -31,7 +31,10 @@
 		margin-top: 0;
 	}
 
-	.newsletter-manage-subscribers {
-		margin-block-start: 16px;
+	.newsletter-card-footer {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: space-between;
+		gap: 8px;
 	}
 }

--- a/projects/packages/newsletter/src/settings/style.scss
+++ b/projects/packages/newsletter/src/settings/style.scss
@@ -32,6 +32,6 @@
 	}
 
 	.newsletter-manage-subscribers {
-		margin-top: 16px;
+		margin-block-start: 16px;
 	}
 }


### PR DESCRIPTION
## Summary

The link for "Manage all subscribers" was not looking great at the bottom of the options. It was a little too close to the text above and generally looked awkward between the option and link in the CardFooter. I tested a few options like extra margin or a divider to match the link below. In the end the best fix was to move this to the footer alongside the "Privacy information" link.

<table>
<tr>
 <td>
 <td>Simple
 <td>Jetpack
<tr>
 <td>Before
 <td><img width="685" height="237" alt="Screen Shot 2026-03-29 at 17 49 03" src="https://github.com/user-attachments/assets/c54442c6-8fd7-4564-86fc-3dadf24b954e" />
 <td><img width="682" height="297" alt="Screen Shot 2026-03-29 at 17 48 38" src="https://github.com/user-attachments/assets/e1a103d7-8d53-4220-aa59-0cd034678d07" />
<tr>
 <td>After
 <td><img width="684" height="216" alt="Screen Shot 2026-03-29 at 17 38 37" src="https://github.com/user-attachments/assets/6e8f5716-071b-457e-8639-3e2d823611a4" />
 <td><img width="698" height="285" alt="Screen Shot 2026-03-29 at 17 47 34" src="https://github.com/user-attachments/assets/7ede4204-4bca-4577-bb0c-d2efac57725b" />
</table>

Follows up on #47565.

## Testing instructions

- Go to wp-admin/admin.php?page=jetpack-newsletter
- Enable the subscriptions toggle
- Verify the "Manage all subscribers" looks good
- Toggle subscriptions off — verify the link disappears cleanly with no layout shift

## Does this pull request change what data or activity we track or use?
No