### PR TITLE
RTC: Fix notes not syncing in real time over WebSockets

### DIFF
--- a/projects/packages/rtc/changelog/dotcom-16519-all-notes-section-does-not-sync-in-real-time-over-ws
+++ b/projects/packages/rtc/changelog/dotcom-16519-all-notes-section-does-not-sync-in-real-time-over-ws
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+PingHub: support root/comment entity type so collaborative notes sync in real time over WebSockets

--- a/projects/packages/rtc/src/js/providers/pinghub/pinghub-provider.ts
+++ b/projects/packages/rtc/src/js/providers/pinghub/pinghub-provider.ts
@@ -136,10 +136,15 @@ function getRoom( objectType: string, objectId: string | null ): string {
 export function createPingHubProvider(): ProviderCreator {
 	return async ( { awareness, objectType, objectId, ydoc } ): Promise< ProviderCreatorResult > => {
 		/**
-		 * Only post-like entities with a concrete ID are supported now.
+		 * The sync manager only invokes provider creators for entity types that
+		 * have a syncConfig, so no explicit allowlist is needed here.
+		 *
+		 * Collection-level sync (objectId is null, from loadCollection) is only
+		 * meaningful for root/ entities such as root/comment (notes). Post-type
+		 * and taxonomy entities are always synced per-record, so skip them when
+		 * no concrete ID is present.
 		 */
-		const SUPPORTED_OBJECT_TYPES = new Set( [ 'postType/post', 'postType/page' ] );
-		if ( ! SUPPORTED_OBJECT_TYPES.has( objectType ) || ! objectId ) {
+		if ( ! objectId && ! objectType.startsWith( 'root/' ) ) {
 			return {
 				destroy: () => {},
 				on: () => {},


### PR DESCRIPTION
Fixes DOTCOM-16519

## Proposed changes

Two issues prevented notes from syncing in real time over WebSockets:

1. **Notes are synced at the collection level, not per-record.** The collab sidebar fetches notes via `getEntityRecords('root', 'comment', { per_page: -1, type: 'note' })`, which triggers `loadCollection()` in the sync manager with `objectId = null`. The old `! objectId` guard in the PingHub provider was blocking this call.

2. **The hardcoded `SUPPORTED_OBJECT_TYPES` allowlist was too narrow.** Only `postType/post` and `postType/page` were listed — `root/comment` was missing.

Rather than patching the allowlist, the fix removes it entirely. The sync manager already guarantees it only calls provider creators for entity types that have a `syncConfig` assigned (in Gutenberg's `entities.js`), so maintaining a second manual gate here was redundant. The only guard that remains is: skip collection-level calls (`objectId = null`) for non-`root/` entities, since `postType/*` and `taxonomy/*` are always synced per-record.

This means the provider now automatically supports any entity type that Gutenberg adds `syncConfig` to in the future, without requiring changes here.

## Related product discussion/links

N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Apply these changes to your sandbox.
* Apply the `wpcom-features-edge` blog sticker to a Simple site with a paid plan.
* Sandbox that site.
* Enable RTC in **Options → Writing**.
* Open a post for editing in two separate browser sessions (two different logged-in users).
* With one user, open the **Notes** (collab sidebar) panel and add a note.
* Observe that the note appears in real time in the other user's editor without a page refresh.
* Verify that regular post edits (blocks, title) still sync in real time as before.

