### PR TITLE
SSO: Fall back to main broker URL for auth when no separate auth URL is defined

### DIFF
--- a/projects/packages/connection/changelog/add-broker-auth-fallback-sso
+++ b/projects/packages/connection/changelog/add-broker-auth-fallback-sso
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+SSO: Fall back to the main broker URL for authorization when no separate broker auth URL is defined.

--- a/projects/packages/connection/src/sso/class-sso.php
+++ b/projects/packages/connection/src/sso/class-sso.php
@@ -969,7 +969,8 @@ class SSO {
 	 *
 	 * For broker sites, this URL replaces the Jetpack authorization endpoint
 	 * for establishing user connections. Read from the JETPACK_SSO_BROKER_AUTH_URL
-	 * constant defined by the garden MU plugin.
+	 * constant defined by the garden MU plugin, falling back to the main broker
+	 * URL (JETPACK_SSO_BROKER_URL) when no separate auth URL is defined.
 	 *
 	 * @return string|false The broker authorization URL, or false if not available.
 	 */
@@ -978,7 +979,10 @@ class SSO {
 			return false;
 		}
 		$url = Constants::get_constant( 'JETPACK_SSO_BROKER_AUTH_URL' );
-		return $url ? self::validate_broker_url( $url ) : false;
+		if ( $url ) {
+			return self::validate_broker_url( $url );
+		}
+		return self::get_broker_url();
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/sso/SSO_Test.php
+++ b/projects/packages/connection/tests/php/sso/SSO_Test.php
@@ -510,6 +510,29 @@ class SSO_Test extends BaseTestCase {
 		$this->assertSame( 'https://broker-auth.example.com/auth', SSO::get_broker_auth_url() );
 	}
 
+	/**
+	 * Test get_broker_auth_url falls back to broker URL when auth URL is not defined.
+	 */
+	public function test_get_broker_auth_url_falls_back_to_broker_url() {
+		$nonce                         = 'auth_fallback_1';
+		$_COOKIE[ SSO::BROKER_COOKIE ] = $nonce;
+		$_COOKIE['jetpack_sso_nonce']  = $nonce;
+		Constants::set_constant( 'JETPACK_SSO_BROKER_URL', 'https://broker.example.com/sso' );
+
+		$this->assertSame( 'https://broker.example.com/sso', SSO::get_broker_auth_url() );
+	}
+
+	/**
+	 * Test get_broker_auth_url returns false when neither auth URL nor broker URL is defined.
+	 */
+	public function test_get_broker_auth_url_returns_false_when_no_urls_defined() {
+		$nonce                         = 'auth_fallback_2';
+		$_COOKIE[ SSO::BROKER_COOKIE ] = $nonce;
+		$_COOKIE['jetpack_sso_nonce']  = $nonce;
+
+		$this->assertFalse( SSO::get_broker_auth_url() );
+	}
+
 	// ──────────────────────────────────────────────
 	// validate_broker_url (via public methods)
 	// ──────────────────────────────────────────────


### PR DESCRIPTION
Related to CONNECT-201

## Proposed changes

* Make `get_broker_auth_url()` fall back to the main broker URL (`JETPACK_SSO_BROKER_URL`) when `JETPACK_SSO_BROKER_AUTH_URL` is not defined, instead of returning `false`.
* This allows MU plugins to define a single `JETPACK_SSO_BROKER_URL` constant and have it used for both the SSO login redirect and the user-connection authorization redirect — the broker can distinguish the two request types via query parameters (`broker-sso-auth-redirect=1`).
* Deployments that need separate endpoints can still define `JETPACK_SSO_BROKER_AUTH_URL` to override the fallback.

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. **Fallback behavior (no auth URL defined):** Set only `JETPACK_SSO_BROKER_URL` to a valid HTTPS URL. Trigger the SSO flow for an unconnected user — verify the auth redirect goes to the broker URL with `broker-sso-auth-redirect=1`.
2. **Explicit auth URL still wins:** Set both `JETPACK_SSO_BROKER_URL` and `JETPACK_SSO_BROKER_AUTH_URL` to different valid HTTPS URLs. Verify the auth redirect uses the auth-specific URL.
3. **Neither defined:** Remove both constants. Verify `get_broker_auth_url()` returns `false` and the normal Jetpack authorization flow is used.
4. **Run unit tests:** `jp test php packages/connection` — two new tests cover the fallback and the "neither defined" case.