### PR TITLE
Footer update

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -584,6 +584,12 @@ importers:
       '@wordpress/notices':
         specifier: 5.42.0
         version: 5.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/theme':
+        specifier: 0.9.0
+        version: 0.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
+      '@wordpress/ui':
+        specifier: 0.9.0
+        version: 0.9.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
       clsx:
         specifier: 2.1.1
         version: 2.1.1

--- a/projects/js-packages/components/changelog/pr-47840
+++ b/projects/js-packages/components/changelog/pr-47840
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+JetpackFooter: Update footer design with Products and Help navigation links, removing About, Privacy, and Terms links and related props.

--- a/projects/js-packages/components/components/admin-page/index.tsx
+++ b/projects/js-packages/components/components/admin-page/index.tsx
@@ -79,14 +79,6 @@ const AdminPage: FC< AdminPageProps > = ( {
 		</HStack>
 	) : undefined;
 
-	const footer = showFooter && (
-		<Container className={ styles[ 'admin-page-footer' ] } horizontalSpacing={ 5 }>
-			<Col>
-				<JetpackFooter menu={ optionalMenuItems } />
-			</Col>
-		</Container>
-	);
-
 	// When title or breadcrumbs are provided, use admin-ui Page for the full page layout.
 	if ( showHeader && ( composedTitle || breadcrumbs ) ) {
 		return (
@@ -103,7 +95,7 @@ const AdminPage: FC< AdminPageProps > = ( {
 					<Container fluid horizontalSpacing={ 0 }>
 						<Col>{ children }</Col>
 					</Container>
-					{ footer }
+					{ showFooter && <JetpackFooter menu={ optionalMenuItems } /> }
 				</Page>
 			</div>
 		);
@@ -135,7 +127,7 @@ const AdminPage: FC< AdminPageProps > = ( {
 			<Container fluid horizontalSpacing={ 0 }>
 				<Col>{ children }</Col>
 			</Container>
-			{ footer }
+			{ showFooter && <JetpackFooter menu={ optionalMenuItems } /> }
 		</div>
 	);
 };

--- a/projects/js-packages/components/components/admin-page/index.tsx
+++ b/projects/js-packages/components/components/admin-page/index.tsx
@@ -28,7 +28,6 @@ const AdminPage: FC< AdminPageProps > = ( {
 	className,
 	showHeader = true,
 	showFooter = true,
-	useInternalLinks = false,
 	showBackground = true,
 	sandboxedDomain = '',
 	apiRoot = '',
@@ -83,7 +82,7 @@ const AdminPage: FC< AdminPageProps > = ( {
 	const footer = showFooter && (
 		<Container className={ styles[ 'admin-page-footer' ] } horizontalSpacing={ 5 }>
 			<Col>
-				<JetpackFooter menu={ optionalMenuItems } useInternalLinks={ useInternalLinks } />
+				<JetpackFooter menu={ optionalMenuItems } />
 			</Col>
 		</Container>
 	);

--- a/projects/js-packages/components/components/admin-page/index.tsx
+++ b/projects/js-packages/components/components/admin-page/index.tsx
@@ -26,8 +26,6 @@ import type { FC, ReactNode } from 'react';
 const AdminPage: FC< AdminPageProps > = ( {
 	children,
 	className,
-	moduleName = 'Jetpack' /** "Jetpack" is a product name, do not translate. */,
-	moduleNameHref,
 	showHeader = true,
 	showFooter = true,
 	useInternalLinks = false,
@@ -85,12 +83,7 @@ const AdminPage: FC< AdminPageProps > = ( {
 	const footer = showFooter && (
 		<Container className={ styles[ 'admin-page-footer' ] } horizontalSpacing={ 5 }>
 			<Col>
-				<JetpackFooter
-					moduleName={ moduleName }
-					moduleNameHref={ moduleNameHref }
-					menu={ optionalMenuItems }
-					useInternalLinks={ useInternalLinks }
-				/>
+				<JetpackFooter menu={ optionalMenuItems } useInternalLinks={ useInternalLinks } />
 			</Col>
 		</Container>
 	);

--- a/projects/js-packages/components/components/admin-page/stories/index.stories.tsx
+++ b/projects/js-packages/components/components/admin-page/stories/index.stories.tsx
@@ -8,7 +8,6 @@ const meta: Meta< typeof AdminPage > = {
 	title: 'JS Packages/Components/Admin Page',
 	component: AdminPage,
 	argTypes: {
-		moduleName: { control: 'text', defaultValue: 'Jetpack' },
 		showHeader: { control: 'boolean', defaultValue: true },
 		showFooter: { control: 'boolean', defaultValue: true },
 		showBackground: { control: 'boolean', defaultValue: true },

--- a/projects/js-packages/components/components/admin-page/types.ts
+++ b/projects/js-packages/components/components/admin-page/types.ts
@@ -55,11 +55,6 @@ export type AdminPageProps = {
 	showFooter?: boolean;
 
 	/**
-	 * Whether or not to link to Jetpack plugin admin pages.
-	 */
-	useInternalLinks?: boolean;
-
-	/**
 	 * Whether or not to display the Background Color
 	 */
 	showBackground?: boolean;

--- a/projects/js-packages/components/components/admin-page/types.ts
+++ b/projects/js-packages/components/components/admin-page/types.ts
@@ -8,11 +8,6 @@ export type AdminPageProps = {
 	children: ReactNode;
 
 	/**
-	 * Name of the module, e.g. 'Jetpack Search' that will be displayed in the footer.
-	 */
-	moduleName?: string;
-
-	/**
 	 * Whether or not to display the Header
 	 */
 	showHeader?: boolean;
@@ -63,11 +58,6 @@ export type AdminPageProps = {
 	 * Whether or not to link to Jetpack plugin admin pages.
 	 */
 	useInternalLinks?: boolean;
-
-	/**
-	 * Link that the Footer Module name will link to (optional).
-	 */
-	moduleNameHref?: string;
 
 	/**
 	 * Whether or not to display the Background Color

--- a/projects/js-packages/components/components/jetpack-footer/README.md
+++ b/projects/js-packages/components/components/jetpack-footer/README.md
@@ -1,19 +1,16 @@
 # Jetpack Admin Footer
 
 Component that renders Jetpack Admin Footer.
-It takes moduleName and URL to show in the footer.
 
 ## How to use:
 
 ```js
-<JetpackFooter moduleName="Jetpack Search" className="jp-dashboard-footer" />
+<JetpackFooter className="jp-dashboard-footer" />
 ```
 
 ## Props
 
 - `className`: String - (default: `jp-dashboard-footer`) the additional class name set on the element.
-- `moduleName`: String - (default: `Jetpack`) set the name of the Module, e.g. `Jetpack Search`.
-- `moduleNameHref`: String - (default: `https://jetpack.com`) link that the Module name will link to.
 - `menu`: JetpackFooterMenuItem[] - (default: `undefined`) set the menu items to be rendered in the footer.
 - `onAboutClick`: () => void - (default: `undefined`) function called when the About link is clicked.
 - `onPrivacyClick`: () => void - (default: `undefined`) function called when the Privacy link is clicked.

--- a/projects/js-packages/components/components/jetpack-footer/README.md
+++ b/projects/js-packages/components/components/jetpack-footer/README.md
@@ -12,5 +12,3 @@ Component that renders Jetpack Admin Footer.
 
 - `className`: String - (default: `jp-dashboard-footer`) the additional class name set on the element.
 - `menu`: JetpackFooterMenuItem[] - (default: `undefined`) set the menu items to be rendered in the footer.
-- `onPrivacyClick`: () => void - (default: `undefined`) function called when the Privacy link is clicked.
-- `onTermsClick`: () => void - (default: `undefined`) function called when the Terms link is clicked.

--- a/projects/js-packages/components/components/jetpack-footer/README.md
+++ b/projects/js-packages/components/components/jetpack-footer/README.md
@@ -11,4 +11,4 @@ Component that renders Jetpack Admin Footer.
 ## Props
 
 - `className`: String - (default: `jp-dashboard-footer`) the additional class name set on the element.
-- `menu`: JetpackFooterMenuItem[] - (default: `undefined`) set the menu items to be rendered in the footer.
+- `menu`: JetpackFooterMenuItem[] - (default: `undefined`) set additional menu items to be rendered in the footer.

--- a/projects/js-packages/components/components/jetpack-footer/README.md
+++ b/projects/js-packages/components/components/jetpack-footer/README.md
@@ -2,7 +2,7 @@
 
 Component that renders Jetpack Admin Footer.
 
-## How to use:
+## How to use
 
 ```js
 <JetpackFooter className="jp-dashboard-footer" />
@@ -12,6 +12,5 @@ Component that renders Jetpack Admin Footer.
 
 - `className`: String - (default: `jp-dashboard-footer`) the additional class name set on the element.
 - `menu`: JetpackFooterMenuItem[] - (default: `undefined`) set the menu items to be rendered in the footer.
-- `onAboutClick`: () => void - (default: `undefined`) function called when the About link is clicked.
 - `onPrivacyClick`: () => void - (default: `undefined`) function called when the Privacy link is clicked.
 - `onTermsClick`: () => void - (default: `undefined`) function called when the Terms link is clicked.

--- a/projects/js-packages/components/components/jetpack-footer/README.md
+++ b/projects/js-packages/components/components/jetpack-footer/README.md
@@ -4,11 +4,30 @@ Component that renders Jetpack Admin Footer.
 
 ## How to use
 
+Note that most of the time you would just use `admin-page` component, which includes the footer. If you must use footer independently, basic usage is:
+
 ```js
-<JetpackFooter className="jp-dashboard-footer" />
+<JetpackFooter />
+```
+
+In special occasions you might want to use custom className or additional menu links:
+
+```js
+const menu = [
+  {
+    label: "Support",
+    href="https://wordpress.com/support/",
+  },
+  {
+    label: "Chat",
+    onClick: () => {},
+  }
+];
+
+<JetpackFooter menu={ menu } className="my-footer" />
 ```
 
 ## Props
 
-- `className`: String - (default: `jp-dashboard-footer`) the additional class name set on the element.
+- `className`: String - (default: `jetpack-footer`) the additional class name set on the element.
 - `menu`: JetpackFooterMenuItem[] - (default: `undefined`) set additional menu items to be rendered in the footer.

--- a/projects/js-packages/components/components/jetpack-footer/index.tsx
+++ b/projects/js-packages/components/components/jetpack-footer/index.tsx
@@ -1,24 +1,24 @@
 import { isWpcomPlatformSite } from '@automattic/jetpack-script-data';
+import {
+	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Icon, external } from '@wordpress/icons';
 import clsx from 'clsx';
 import { getRedirectUrl } from '../../index.ts';
 import getSiteAdminUrl from '../../tools/get-site-admin-url/index.ts';
 import AutomatticBylineLogo from '../automattic-byline-logo/index.tsx';
 import './style.scss';
 import JetpackLogo from '../jetpack-logo/index.tsx';
-import useBreakpointMatch from '../layout/use-breakpoint-match/index.ts';
 import type { JetpackFooterProps, JetpackFooterMenuItem } from './types.ts';
 import type { FC, ReactNode } from 'react';
-
-const JetpackIcon: FC = () => (
-	<JetpackLogo logoColor="#000" showText={ false } height={ 16 } aria-hidden="true" />
-);
+import '@wordpress/admin-ui/build-style/style.css';
 
 const ExternalIcon: FC = () => (
 	<>
-		<Icon icon={ external } size={ 16 } />
-		<span className="jp-dashboard-footer__accessible-external-link">
+		{ ' ' }
+		<span aria-hidden="true">↗</span>
+		<span className="jetpack-footer__accessible-external-link">
 			{
 				/* translators: accessibility text */
 				__( '(opens in a new tab)', 'jetpack-components' )
@@ -34,10 +34,6 @@ const ExternalIcon: FC = () => (
  * @return {ReactNode} JetpackFooter component.
  */
 const JetpackFooter: FC< JetpackFooterProps > = ( { className, menu, ...otherProps } ) => {
-	const [ isSm ] = useBreakpointMatch( 'sm', '<=' );
-	const [ isMd ] = useBreakpointMatch( 'md', '<=' );
-	const [ isLg ] = useBreakpointMatch( 'lg', '>' );
-
 	const siteAdminUrl = getSiteAdminUrl();
 
 	let items: JetpackFooterMenuItem[] = [];
@@ -63,62 +59,58 @@ const JetpackFooter: FC< JetpackFooterProps > = ( { className, menu, ...otherPro
 	}
 
 	return (
-		<footer
-			className={ clsx(
-				'jp-dashboard-footer',
-				{
-					'is-sm': isSm,
-					'is-md': isMd,
-					'is-lg': isLg,
-				},
-				className
-			) }
+		<HStack
+			as="footer"
+			className={ clsx( 'jetpack-footer', className ) }
 			aria-label={ __( 'Jetpack', 'jetpack-components' ) }
 			role="contentinfo"
+			justify="start"
+			direction="row"
 			{ ...otherProps }
 		>
-			<ul>
-				<li className="jp-dashboard-footer__jp-item">
-					<JetpackIcon />
-					{ 'Jetpack' /* "Jetpack" is a product name, do not translate. */ }
-				</li>
+			<HStack className="jetpack-footer-footer__logo">
+				<JetpackLogo logoColor="#000" showText={ false } height={ 16 } aria-hidden="true" />
+				Jetpack
+			</HStack>
+			<HStack as="ul" direction="row" spacing={ 2 }>
 				{ items.map( item => {
 					const isButton = item.role === 'button';
 					const isExternalLink = ! isButton && item.target === '_blank';
 
 					return (
 						<li key={ item.label }>
-							<a
-								href={ item.href }
-								title={ item.title }
-								target={ item.target }
-								onClick={ item.onClick }
-								onKeyDown={ item.onKeyDown }
-								className={ clsx( 'jp-dashboard-footer__menu-item', {
+							<Text
+								as={ isButton ? 'span' : 'a' }
+								href={ item.href || '' }
+								title={ item.title || '' }
+								target={ item.target || '' }
+								onClick={ item.onClick || undefined }
+								onKeyDown={ item.onKeyDown || undefined }
+								className={ clsx( 'jetpack-footer__menu-item', {
 									'is-external': isExternalLink,
 								} ) }
 								role={ item.role }
 								rel={ isExternalLink ? 'noopener noreferrer' : undefined }
 								tabIndex={ isButton ? 0 : undefined }
+								variant="muted"
 							>
 								{ item.label }
-								{ isExternalLink && <ExternalIcon /> }
-							</a>
+							</Text>
+							{ isExternalLink && <ExternalIcon /> }
 						</li>
 					);
 				} ) }
-				<li className="jp-dashboard-footer__a8c-item">
-					<a
-						href={ getRedirectUrl( 'a8c-about' ) }
-						target="_blank"
-						rel="noopener noreferrer"
-						aria-label={ __( 'An Automattic Airline', 'jetpack-components' ) }
-					>
-						<AutomatticBylineLogo aria-hidden="true" />
-					</a>
-				</li>
-			</ul>
-		</footer>
+			</HStack>
+			<a
+				aria-label={ __( 'An Automattic Airline', 'jetpack-components' ) }
+				className="jetpack-footer__a8c"
+				href={ getRedirectUrl( 'a8c-about' ) }
+				rel="noopener noreferrer"
+				target="_blank"
+			>
+				<AutomatticBylineLogo aria-hidden="true" />
+			</a>
+		</HStack>
 	);
 };
 

--- a/projects/js-packages/components/components/jetpack-footer/index.tsx
+++ b/projects/js-packages/components/components/jetpack-footer/index.tsx
@@ -1,9 +1,6 @@
 import { isWpcomPlatformSite } from '@automattic/jetpack-script-data';
-import {
-	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { Stack, Text, Link } from '@wordpress/ui';
 import clsx from 'clsx';
 import { getRedirectUrl } from '../../index.ts';
 import getSiteAdminUrl from '../../tools/get-site-admin-url/index.ts';
@@ -11,21 +8,7 @@ import AutomatticBylineLogo from '../automattic-byline-logo/index.tsx';
 import './style.scss';
 import JetpackLogo from '../jetpack-logo/index.tsx';
 import type { JetpackFooterProps, JetpackFooterMenuItem } from './types.ts';
-import type { FC, ReactNode } from 'react';
-import '@wordpress/admin-ui/build-style/style.css';
-
-const ExternalIcon: FC = () => (
-	<>
-		{ ' ' }
-		<span aria-hidden="true">↗</span>
-		<span className="jetpack-footer__accessible-external-link">
-			{
-				/* translators: accessibility text */
-				__( '(opens in a new tab)', 'jetpack-components' )
-			}
-		</span>
-	</>
-);
+import type { FC } from 'react';
 
 /**
  * JetpackFooter component displays a tiny Jetpack logo with the product name on the left and the Automattic Airline "by line" on the right.
@@ -38,7 +21,7 @@ const JetpackFooter: FC< JetpackFooterProps > = ( { className, menu, ...otherPro
 
 	let items: JetpackFooterMenuItem[] = [];
 
-	if ( isWpcomPlatformSite() ) {
+	if ( ! isWpcomPlatformSite() ) {
 		items = [
 			{
 				label: __( 'Products', 'jetpack-components' ),
@@ -59,58 +42,79 @@ const JetpackFooter: FC< JetpackFooterProps > = ( { className, menu, ...otherPro
 	}
 
 	return (
-		<HStack
-			as="footer"
+		<Stack
+			render={ <footer /> }
 			className={ clsx( 'jetpack-footer', className ) }
 			aria-label={ __( 'Jetpack', 'jetpack-components' ) }
 			role="contentinfo"
-			justify="start"
 			direction="row"
+			justify="flex-start"
+			align="center"
+			wrap="wrap"
+			gap="xl"
 			{ ...otherProps }
 		>
-			<HStack className="jetpack-footer-footer__logo">
-				<JetpackLogo logoColor="#000" showText={ false } height={ 16 } aria-hidden="true" />
-				Jetpack
-			</HStack>
-			<HStack as="ul" direction="row" spacing={ 2 }>
+			<Stack className="jetpack-footer__logo" direction="row" gap="sm" align="center">
+				<JetpackLogo showText={ false } height={ 16 } aria-hidden="true" />
+				<Text variant="body-md" className="jetpack-footer__logo-text">
+					Jetpack
+				</Text>
+			</Stack>
+			<Stack render={ <ul /> } direction="row" gap="lg" wrap="wrap">
 				{ items.map( item => {
 					const isButton = item.role === 'button';
 					const isExternalLink = ! isButton && item.target === '_blank';
 
+					const menuItemClassName = clsx( 'jetpack-footer__menu-item', {
+						'is-external': isExternalLink,
+					} );
+
 					return (
 						<li key={ item.label }>
 							<Text
-								as={ isButton ? 'span' : 'a' }
-								href={ item.href || '' }
-								title={ item.title || '' }
-								target={ item.target || '' }
-								onClick={ item.onClick || undefined }
-								onKeyDown={ item.onKeyDown || undefined }
-								className={ clsx( 'jetpack-footer__menu-item', {
-									'is-external': isExternalLink,
-								} ) }
-								role={ item.role }
-								rel={ isExternalLink ? 'noopener noreferrer' : undefined }
-								tabIndex={ isButton ? 0 : undefined }
-								variant="muted"
+								variant="body-sm"
+								className={ menuItemClassName }
+								render={
+									isButton ? (
+										<Link
+											render={ <Text variant="body-md" render={ <span /> } /> }
+											tone="neutral"
+											variant="default"
+											role={ item.role }
+											tabIndex={ 0 }
+											onClick={ item.onClick || undefined }
+											onKeyDown={ item.onKeyDown || undefined }
+										/>
+									) : (
+										<Link
+											render={ <Text variant="body-md" render={ <a /> } /> }
+											tone="neutral"
+											variant="default"
+											href={ item.href || '' }
+											title={ item.title || '' }
+											openInNewTab={ isExternalLink }
+											role={ item.role }
+											onClick={ item.onClick || undefined }
+											onKeyDown={ item.onKeyDown || undefined }
+										/>
+									)
+								}
 							>
 								{ item.label }
 							</Text>
-							{ isExternalLink && <ExternalIcon /> }
 						</li>
 					);
 				} ) }
-			</HStack>
+			</Stack>
 			<a
-				aria-label={ __( 'An Automattic Airline', 'jetpack-components' ) }
 				className="jetpack-footer__a8c"
 				href={ getRedirectUrl( 'a8c-about' ) }
 				rel="noopener noreferrer"
 				target="_blank"
 			>
-				<AutomatticBylineLogo aria-hidden="true" />
+				<AutomatticBylineLogo height={ 8 } />
 			</a>
-		</HStack>
+		</Stack>
 	);
 };
 

--- a/projects/js-packages/components/components/jetpack-footer/index.tsx
+++ b/projects/js-packages/components/components/jetpack-footer/index.tsx
@@ -36,7 +36,6 @@ const JetpackFooter: FC< JetpackFooterProps > = ( {
 	className,
 	menu,
 	useInternalLinks,
-	onAboutClick,
 	onPrivacyClick,
 	onTermsClick,
 	...otherProps
@@ -48,15 +47,6 @@ const JetpackFooter: FC< JetpackFooterProps > = ( {
 	const siteAdminUrl = getSiteAdminUrl();
 
 	let items: JetpackFooterMenuItem[] = [
-		{
-			label: _x( 'About', 'Link to learn more about Jetpack.', 'jetpack-components' ),
-			title: __( 'About Jetpack', 'jetpack-components' ),
-			href: useInternalLinks
-				? new URL( 'admin.php?page=jetpack_about', siteAdminUrl ).href
-				: getRedirectUrl( 'jetpack-about' ),
-			target: useInternalLinks ? '_self' : '_blank',
-			onClick: onAboutClick,
-		},
 		{
 			label: _x( 'Privacy', 'Shorthand for Privacy Policy.', 'jetpack-components' ),
 			title: __( "Automattic's Privacy Policy", 'jetpack-components' ),
@@ -126,11 +116,9 @@ const JetpackFooter: FC< JetpackFooterProps > = ( {
 				} ) }
 				<li className="jp-dashboard-footer__a8c-item">
 					<a
-						href={
-							useInternalLinks
-								? new URL( 'admin.php?page=jetpack_about', siteAdminUrl ).href
-								: getRedirectUrl( 'a8c-about' )
-						}
+						href={ getRedirectUrl( 'a8c-about' ) }
+						target="_blank"
+						rel="noopener noreferrer"
 						aria-label={ __( 'An Automattic Airline', 'jetpack-components' ) }
 					>
 						<AutomatticBylineLogo aria-hidden="true" />

--- a/projects/js-packages/components/components/jetpack-footer/index.tsx
+++ b/projects/js-packages/components/components/jetpack-footer/index.tsx
@@ -1,3 +1,4 @@
+import { isWpcomPlatformSite } from '@automattic/jetpack-script-data';
 import { __, _x } from '@wordpress/i18n';
 import { Icon, external } from '@wordpress/icons';
 import clsx from 'clsx';
@@ -64,6 +65,17 @@ const JetpackFooter: FC< JetpackFooterProps > = ( {
 			onClick: onTermsClick,
 		},
 	];
+
+	if ( isWpcomPlatformSite() ) {
+		items = [
+			{
+				label: __( 'Products', 'jetpack-components' ),
+				title: __( 'Jetpack products', 'jetpack-components' ),
+				href: new URL( 'admin.php?page=my-jetpack#/products', siteAdminUrl ).href,
+			},
+			...items,
+		];
+	}
 
 	if ( menu ) {
 		items = [ ...items, ...menu ];

--- a/projects/js-packages/components/components/jetpack-footer/index.tsx
+++ b/projects/js-packages/components/components/jetpack-footer/index.tsx
@@ -33,9 +33,7 @@ const ExternalIcon: FC = () => (
  * @return {ReactNode} JetpackFooter component.
  */
 const JetpackFooter: FC< JetpackFooterProps > = ( {
-	moduleName = 'Jetpack' /** "Jetpack" is a product name, do not translate. */,
 	className,
-	moduleNameHref = 'https://jetpack.com',
 	menu,
 	useInternalLinks,
 	onAboutClick,
@@ -81,13 +79,6 @@ const JetpackFooter: FC< JetpackFooterProps > = ( {
 		items = [ ...items, ...menu ];
 	}
 
-	const jetpackItemContent = (
-		<>
-			<JetpackIcon />
-			{ moduleName }
-		</>
-	);
-
 	return (
 		<footer
 			className={ clsx(
@@ -105,11 +96,8 @@ const JetpackFooter: FC< JetpackFooterProps > = ( {
 		>
 			<ul>
 				<li className="jp-dashboard-footer__jp-item">
-					{ moduleNameHref ? (
-						<a href={ moduleNameHref }>{ jetpackItemContent }</a>
-					) : (
-						jetpackItemContent
-					) }
+					<JetpackIcon />
+					{ 'Jetpack' /* "Jetpack" is a product name, do not translate. */ }
 				</li>
 				{ items.map( item => {
 					const isButton = item.role === 'button';

--- a/projects/js-packages/components/components/jetpack-footer/index.tsx
+++ b/projects/js-packages/components/components/jetpack-footer/index.tsx
@@ -56,9 +56,7 @@ const JetpackFooter: FC< JetpackFooterProps > = ( { className, menu, ...otherPro
 		>
 			<Stack className="jetpack-footer__logo" direction="row" gap="sm" align="center">
 				<JetpackLogo showText={ false } height={ 16 } aria-hidden="true" />
-				<Text variant="body-md" className="jetpack-footer__logo-text">
-					Jetpack
-				</Text>
+				<Text variant="body-md">Jetpack</Text>
 			</Stack>
 			<Stack render={ <ul /> } direction="row" gap="lg" wrap="wrap">
 				{ items.map( item => {

--- a/projects/js-packages/components/components/jetpack-footer/index.tsx
+++ b/projects/js-packages/components/components/jetpack-footer/index.tsx
@@ -1,5 +1,5 @@
 import { isWpcomPlatformSite } from '@automattic/jetpack-script-data';
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { Icon, external } from '@wordpress/icons';
 import clsx from 'clsx';
 import { getRedirectUrl } from '../../index.ts';
@@ -33,38 +33,14 @@ const ExternalIcon: FC = () => (
  * @param {JetpackFooterProps} props - Component properties.
  * @return {ReactNode} JetpackFooter component.
  */
-const JetpackFooter: FC< JetpackFooterProps > = ( {
-	className,
-	menu,
-	useInternalLinks,
-	onPrivacyClick,
-	onTermsClick,
-	...otherProps
-} ) => {
+const JetpackFooter: FC< JetpackFooterProps > = ( { className, menu, ...otherProps } ) => {
 	const [ isSm ] = useBreakpointMatch( 'sm', '<=' );
 	const [ isMd ] = useBreakpointMatch( 'md', '<=' );
 	const [ isLg ] = useBreakpointMatch( 'lg', '>' );
 
 	const siteAdminUrl = getSiteAdminUrl();
 
-	let items: JetpackFooterMenuItem[] = [
-		{
-			label: _x( 'Privacy', 'Shorthand for Privacy Policy.', 'jetpack-components' ),
-			title: __( "Automattic's Privacy Policy", 'jetpack-components' ),
-			href: useInternalLinks
-				? new URL( 'admin.php?page=jetpack#/privacy', siteAdminUrl ).href
-				: getRedirectUrl( 'a8c-privacy' ),
-			target: useInternalLinks ? '_self' : '_blank',
-			onClick: onPrivacyClick,
-		},
-		{
-			label: _x( 'Terms', 'Shorthand for Terms of Service.', 'jetpack-components' ),
-			title: __( 'WordPress.com Terms of Service', 'jetpack-components' ),
-			href: getRedirectUrl( 'wpcom-tos' ),
-			target: '_blank',
-			onClick: onTermsClick,
-		},
-	];
+	let items: JetpackFooterMenuItem[] = [];
 
 	if ( isWpcomPlatformSite() ) {
 		items = [

--- a/projects/js-packages/components/components/jetpack-footer/index.tsx
+++ b/projects/js-packages/components/components/jetpack-footer/index.tsx
@@ -73,6 +73,11 @@ const JetpackFooter: FC< JetpackFooterProps > = ( {
 				title: __( 'Jetpack products', 'jetpack-components' ),
 				href: new URL( 'admin.php?page=my-jetpack#/products', siteAdminUrl ).href,
 			},
+			{
+				label: __( 'Help', 'jetpack-components' ),
+				title: '',
+				href: new URL( 'admin.php?page=my-jetpack#/help', siteAdminUrl ).href,
+			},
 			...items,
 		];
 	}

--- a/projects/js-packages/components/components/jetpack-footer/index.tsx
+++ b/projects/js-packages/components/components/jetpack-footer/index.tsx
@@ -1,9 +1,8 @@
-import { isWpcomPlatformSite } from '@automattic/jetpack-script-data';
+import { isWpcomPlatformSite, getAdminUrl } from '@automattic/jetpack-script-data';
 import { __ } from '@wordpress/i18n';
 import { Stack, Text, Link } from '@wordpress/ui';
 import clsx from 'clsx';
 import { getRedirectUrl } from '../../index.ts';
-import getSiteAdminUrl from '../../tools/get-site-admin-url/index.ts';
 import AutomatticBylineLogo from '../automattic-byline-logo/index.tsx';
 import './style.scss';
 import JetpackLogo from '../jetpack-logo/index.tsx';
@@ -17,8 +16,6 @@ import type { FC } from 'react';
  * @return {ReactNode} JetpackFooter component.
  */
 const JetpackFooter: FC< JetpackFooterProps > = ( { className, menu, ...otherProps } ) => {
-	const siteAdminUrl = getSiteAdminUrl();
-
 	let items: JetpackFooterMenuItem[] = [];
 
 	if ( ! isWpcomPlatformSite() ) {
@@ -26,12 +23,12 @@ const JetpackFooter: FC< JetpackFooterProps > = ( { className, menu, ...otherPro
 			{
 				label: __( 'Products', 'jetpack-components' ),
 				title: __( 'Jetpack products', 'jetpack-components' ),
-				href: new URL( 'admin.php?page=my-jetpack#/products', siteAdminUrl ).href,
+				href: getAdminUrl( 'admin.php?page=my-jetpack#/products' ),
 			},
 			{
 				label: __( 'Help', 'jetpack-components' ),
 				title: '',
-				href: new URL( 'admin.php?page=my-jetpack#/help', siteAdminUrl ).href,
+				href: getAdminUrl( 'admin.php?page=my-jetpack#/help' ),
 			},
 			...items,
 		];

--- a/projects/js-packages/components/components/jetpack-footer/index.tsx
+++ b/projects/js-packages/components/components/jetpack-footer/index.tsx
@@ -22,12 +22,10 @@ const JetpackFooter: FC< JetpackFooterProps > = ( { className, menu, ...otherPro
 		items = [
 			{
 				label: __( 'Products', 'jetpack-components' ),
-				title: __( 'Jetpack products', 'jetpack-components' ),
 				href: getAdminUrl( 'admin.php?page=my-jetpack#/products' ),
 			},
 			{
 				label: __( 'Help', 'jetpack-components' ),
-				title: '',
 				href: getAdminUrl( 'admin.php?page=my-jetpack#/help' ),
 			},
 			...items,
@@ -58,17 +56,12 @@ const JetpackFooter: FC< JetpackFooterProps > = ( { className, menu, ...otherPro
 			<Stack render={ <ul /> } direction="row" gap="lg" wrap="wrap">
 				{ items.map( item => {
 					const isButton = item.role === 'button';
-					const isExternalLink = ! isButton && item.target === '_blank';
-
-					const menuItemClassName = clsx( 'jetpack-footer__menu-item', {
-						'is-external': isExternalLink,
-					} );
 
 					return (
 						<li key={ item.label }>
 							<Text
 								variant="body-sm"
-								className={ menuItemClassName }
+								className="jetpack-footer__menu-item"
 								render={
 									isButton ? (
 										<Link
@@ -87,7 +80,6 @@ const JetpackFooter: FC< JetpackFooterProps > = ( { className, menu, ...otherPro
 											variant="default"
 											href={ item.href || '' }
 											title={ item.title || '' }
-											openInNewTab={ isExternalLink }
 											role={ item.role }
 											onClick={ item.onClick || undefined }
 											onKeyDown={ item.onKeyDown || undefined }

--- a/projects/js-packages/components/components/jetpack-footer/stories/index.stories.tsx
+++ b/projects/js-packages/components/components/jetpack-footer/stories/index.stories.tsx
@@ -11,9 +11,7 @@ export default meta;
 const Template: StoryFn< typeof JetpackFooter > = args => <JetpackFooter { ...args } />;
 
 const DefaultArgs = {
-	moduleName: 'Jetpack',
 	className: '',
-	moduleNameHref: 'https://jetpack.com',
 };
 
 export const _default = Template.bind( {} );

--- a/projects/js-packages/components/components/jetpack-footer/style.scss
+++ b/projects/js-packages/components/components/jetpack-footer/style.scss
@@ -1,26 +1,27 @@
-.jetpack-footer {
-	align-items: center;
-	border-top: var(--wpds-border-width-xs, 1px) solid var(--wpds-color-stroke-surface-neutral-weak, #e0e0e0);
-	display: flex;
-	flex-wrap: wrap;
-	font-size: var(--font-body-extra-small);
-	padding: var(--wpds-dimension-padding-2xl, 24px);
-	width: 100%;
-	line-height: 1.333;
+@use "sass:meta";
+@include meta.load-css("pkg:@wordpress/theme/design-tokens.css");
+@include meta.load-css("pkg:@wordpress/admin-ui/build-style/style.css");
 
-	a {
-		text-decoration: none;
+.jetpack-footer {
+	border-top: var(--wpds-border-width-xs, 1px) solid var(--wpds-color-stroke-surface-neutral-weak, #e0e0e0);
+	box-sizing: border-box;
+	padding: var(--wpds-dimension-padding-xl) var(--wpds-dimension-padding-2xl);
+	width: 100%;
+
+	.jetpack-footer__menu-item {
 
 		&:any-link,
 		&[role="button"] {
-			color: inherit;
+			color: var(--wpds-color-fg-interactive-neutral-weak);
+			cursor: pointer;
+			text-decoration: none;
 		}
 
 		&:hover {
 			text-decoration: underline;
-			text-decoration-thickness: 1.5px;
 		}
 
+		/*
 		&:focus {
 			box-shadow: none;
 			outline-width: 0;
@@ -32,6 +33,7 @@
 			outline: 1.5px solid currentColor;
 			outline-offset: 3px;
 		}
+		*/
 	}
 
 	> ul {
@@ -40,32 +42,25 @@
 		padding: 0;
 
 		> li {
-			margin-bottom: 0;
-
-			> a {
-				display: flex;
-				align-items: center;
-				gap: 0.25rem;
-
-				min-height: 44px; // Minimum target area size
-			}
+			margin: 0;
 		}
 	}
 }
 
-a.jetpack-footer__a8c {
-	text-decoration: none;
-	margin-inline-start: auto;
+.jetpack-footer__logo {
+	flex-shrink: 0;
 }
 
-.jetpack-footer__accessible-external-link {
-	border: 0;
-	clip-path: inset(50%);
-	height: 1px;
-	margin: -1px;
-	overflow: hidden;
-	padding: 0;
-	position: absolute;
-	width: 1px;
-	overflow-wrap: normal;
+.jetpack-footer__logo-text {
+	font-weight: var(--wpds-font-weight-regular);
+}
+
+a.jetpack-footer__a8c {
+	flex-shrink: 0;
+	margin-inline-start: auto;
+	text-decoration: none;
+
+	svg {
+		fill: var(--wpds-color-fg-interactive-neutral-weak);
+	}
 }

--- a/projects/js-packages/components/components/jetpack-footer/style.scss
+++ b/projects/js-packages/components/components/jetpack-footer/style.scss
@@ -1,14 +1,11 @@
-.jp-dashboard-footer {
+.jetpack-footer {
+	align-items: center;
+	border-top: var(--wpds-border-width-xs, 1px) solid var(--wpds-color-stroke-surface-neutral-weak, #e0e0e0);
 	display: flex;
 	flex-wrap: wrap;
-	align-items: center;
-
-	max-width: 1128px;
-	width: 100%;
-
-	color: var(--jp-black);
-
 	font-size: var(--font-body-extra-small);
+	padding: var(--wpds-dimension-padding-2xl, 24px);
+	width: 100%;
 	line-height: 1.333;
 
 	a {
@@ -37,31 +34,10 @@
 		}
 	}
 
-	&.is-sm {
-
-		> ul {
-			flex-direction: column;
-			align-items: flex-start;
-			gap: 0.125rem;
-		}
-	}
-
-	&.is-md {
-		flex-direction: column;
-		align-items: flex-start;
-	}
-
 	> ul {
-		display: flex;
-		flex-wrap: wrap;
-		align-items: center;
-		gap: 1rem;
-
-		width: 100%;
+		list-style: none;
 		margin: 0;
 		padding: 0;
-
-		list-style: none;
 
 		> li {
 			margin-bottom: 0;
@@ -77,7 +53,12 @@
 	}
 }
 
-.jp-dashboard-footer__accessible-external-link {
+a.jetpack-footer__a8c {
+	text-decoration: none;
+	margin-inline-start: auto;
+}
+
+.jetpack-footer__accessible-external-link {
 	border: 0;
 	clip-path: inset(50%);
 	height: 1px;
@@ -87,33 +68,4 @@
 	position: absolute;
 	width: 1px;
 	overflow-wrap: normal;
-}
-
-.jp-dashboard-footer__jp-item {
-	padding-inline-end: 1rem;
-
-	font-weight: 600;
-
-	.jp-dashboard-footer.is-sm & {
-		padding-bottom: 1rem;
-	}
-}
-
-.jp-dashboard-footer__a8c-item {
-
-	.jp-dashboard-footer.is-lg & {
-		margin-inline-start: auto;
-	}
-
-	.jp-dashboard-footer.is-sm & {
-		padding-top: 1rem;
-	}
-}
-
-.jp-dashboard-footer__jp-item,
-.jp-dashboard-footer__a8c-item {
-
-	> a {
-		text-decoration: none; // Logos typically have no hover effect
-	}
 }

--- a/projects/js-packages/components/components/jetpack-footer/style.scss
+++ b/projects/js-packages/components/components/jetpack-footer/style.scss
@@ -51,14 +51,11 @@
 	flex-shrink: 0;
 }
 
-.jetpack-footer__logo-text {
-	font-weight: var(--wpds-font-weight-regular);
-}
-
 a.jetpack-footer__a8c {
-	flex-shrink: 0;
-	margin-inline-start: auto;
-	text-decoration: none;
+
+	@media (min-width: 480px) {
+		margin-inline-start: auto;
+	}
 
 	svg {
 		fill: var(--wpds-color-fg-interactive-neutral-weak);

--- a/projects/js-packages/components/components/jetpack-footer/style.scss
+++ b/projects/js-packages/components/components/jetpack-footer/style.scss
@@ -1,6 +1,5 @@
 @use "sass:meta";
 @include meta.load-css("pkg:@wordpress/theme/design-tokens.css");
-@include meta.load-css("pkg:@wordpress/admin-ui/build-style/style.css");
 
 .jetpack-footer {
 	border-top: var(--wpds-border-width-xs, 1px) solid var(--wpds-color-stroke-surface-neutral-weak, #e0e0e0);

--- a/projects/js-packages/components/components/jetpack-footer/style.scss
+++ b/projects/js-packages/components/components/jetpack-footer/style.scss
@@ -20,20 +20,6 @@
 		&:hover {
 			text-decoration: underline;
 		}
-
-		/*
-		&:focus {
-			box-shadow: none;
-			outline-width: 0;
-		}
-
-		&:focus-visible {
-			border-radius: 2px;
-			box-shadow: none;
-			outline: 1.5px solid currentColor;
-			outline-offset: 3px;
-		}
-		*/
 	}
 
 	> ul {

--- a/projects/js-packages/components/components/jetpack-footer/test/__snapshots__/component.tsx.snap
+++ b/projects/js-packages/components/components/jetpack-footer/test/__snapshots__/component.tsx.snap
@@ -11,32 +11,28 @@ exports[`JetpackFooter Render the component should match the snapshot: all props
       <li
         class="jp-dashboard-footer__jp-item"
       >
-        <a
-          href="https://jetpack.com/path/to-some-page"
+        <svg
+          aria-hidden="true"
+          aria-labelledby="jetpack-logo-title"
+          class="jetpack-logo"
+          height="16"
+          role="img"
+          viewBox="0 0 32 32"
+          x="0px"
+          xmlns="http://www.w3.org/2000/svg"
+          y="0px"
         >
-          <svg
-            aria-hidden="true"
-            aria-labelledby="jetpack-logo-title"
-            class="jetpack-logo"
-            height="16"
-            role="img"
-            viewBox="0 0 32 32"
-            x="0px"
-            xmlns="http://www.w3.org/2000/svg"
-            y="0px"
+          <title
+            id="jetpack-logo-title"
           >
-            <title
-              id="jetpack-logo-title"
-            >
-              Jetpack Logo
-            </title>
-            <path
-              d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z M15,19H7l8-16V19z M17,29V13h8L17,29z"
-              fill="#000"
-            />
-          </svg>
-          Test module
-        </a>
+            Jetpack Logo
+          </title>
+          <path
+            d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z M15,19H7l8-16V19z M17,29V13h8L17,29z"
+            fill="#000"
+          />
+        </svg>
+        Jetpack
       </li>
       <li>
         <a

--- a/projects/js-packages/components/components/jetpack-footer/test/__snapshots__/component.tsx.snap
+++ b/projects/js-packages/components/components/jetpack-footer/test/__snapshots__/component.tsx.snap
@@ -37,34 +37,6 @@ exports[`JetpackFooter Render the component should match the snapshot: all props
       <li>
         <a
           class="jp-dashboard-footer__menu-item is-external"
-          href="https://jetpack.com/redirect/?source=jetpack-about"
-          rel="noopener noreferrer"
-          target="_blank"
-          title="About Jetpack"
-        >
-          About
-          <svg
-            aria-hidden="true"
-            focusable="false"
-            height="16"
-            viewBox="0 0 24 24"
-            width="16"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M19.5 4.5h-7V6h4.44l-5.97 5.97 1.06 1.06L18 7.06v4.44h1.5v-7Zm-13 1a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-3H17v3a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h3V5.5h-3Z"
-            />
-          </svg>
-          <span
-            class="jp-dashboard-footer__accessible-external-link"
-          >
-            (opens in a new tab)
-          </span>
-        </a>
-      </li>
-      <li>
-        <a
-          class="jp-dashboard-footer__menu-item is-external"
           href="https://jetpack.com/redirect/?source=a8c-privacy"
           rel="noopener noreferrer"
           target="_blank"

--- a/projects/js-packages/components/components/jetpack-footer/test/__snapshots__/component.tsx.snap
+++ b/projects/js-packages/components/components/jetpack-footer/test/__snapshots__/component.tsx.snap
@@ -4,173 +4,114 @@ exports[`JetpackFooter Render the component should match the snapshot: all props
 <div>
   <footer
     aria-label="Jetpack"
-    class="jp-dashboard-footer sample-classname"
+    class="_19ce0419607e1896__stack jetpack-footer sample-classname"
     role="contentinfo"
+    style="gap: var(--wpds-dimension-gap-xl, 24px); align-items: center; justify-content: flex-start; flex-direction: row; flex-wrap: wrap;"
   >
-    <ul>
-      <li
-        class="jp-dashboard-footer__jp-item"
+    <div
+      class="_19ce0419607e1896__stack jetpack-footer__logo"
+      style="gap: var(--wpds-dimension-gap-sm, 8px); align-items: center; flex-direction: row;"
+    >
+      <svg
+        aria-hidden="true"
+        aria-labelledby="jetpack-logo-title"
+        class="jetpack-logo"
+        height="16"
+        role="img"
+        viewBox="0 0 32 32"
+        x="0px"
+        xmlns="http://www.w3.org/2000/svg"
+        y="0px"
       >
-        <svg
-          aria-hidden="true"
-          aria-labelledby="jetpack-logo-title"
-          class="jetpack-logo"
-          height="16"
-          role="img"
-          viewBox="0 0 32 32"
-          x="0px"
-          xmlns="http://www.w3.org/2000/svg"
-          y="0px"
+        <title
+          id="jetpack-logo-title"
         >
-          <title
-            id="jetpack-logo-title"
-          >
-            Jetpack Logo
-          </title>
-          <path
-            d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z M15,19H7l8-16V19z M17,29V13h8L17,29z"
-            fill="#000"
-          />
-        </svg>
+          Jetpack Logo
+        </title>
+        <path
+          d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z M15,19H7l8-16V19z M17,29V13h8L17,29z"
+          fill="#069e08"
+        />
+      </svg>
+      <span
+        class="_131101940be12424__body-md"
+      >
         Jetpack
-      </li>
+      </span>
+    </div>
+    <ul
+      class="_19ce0419607e1896__stack"
+      style="gap: var(--wpds-dimension-gap-lg, 16px); flex-direction: row; flex-wrap: wrap;"
+    >
       <li>
         <a
-          class="jp-dashboard-footer__menu-item is-external"
-          href="https://jetpack.com/redirect/?source=a8c-privacy"
-          rel="noopener noreferrer"
-          target="_blank"
-          title="Automattic's Privacy Policy"
+          class="_131101940be12424__body-md _336cd3e4e743482f__box-sizing _08e8a2e44959f892__outset-ring--focus d4250949359b05ce__link _92e0dfcaeee15b88__is-neutral _0e8d87a42c1f75fa__body-sm jetpack-footer__menu-item"
+          href="undefinedadmin.php?page=my-jetpack#/products"
+          title=""
         >
-          Privacy
-          <svg
-            aria-hidden="true"
-            focusable="false"
-            height="16"
-            viewBox="0 0 24 24"
-            width="16"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M19.5 4.5h-7V6h4.44l-5.97 5.97 1.06 1.06L18 7.06v4.44h1.5v-7Zm-13 1a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-3H17v3a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h3V5.5h-3Z"
-            />
-          </svg>
-          <span
-            class="jp-dashboard-footer__accessible-external-link"
-          >
-            (opens in a new tab)
-          </span>
+          Products
         </a>
       </li>
       <li>
         <a
-          class="jp-dashboard-footer__menu-item is-external"
-          href="https://jetpack.com/redirect/?source=wpcom-tos"
-          rel="noopener noreferrer"
-          target="_blank"
-          title="WordPress.com Terms of Service"
+          class="_131101940be12424__body-md _336cd3e4e743482f__box-sizing _08e8a2e44959f892__outset-ring--focus d4250949359b05ce__link _92e0dfcaeee15b88__is-neutral _0e8d87a42c1f75fa__body-sm jetpack-footer__menu-item"
+          href="undefinedadmin.php?page=my-jetpack#/help"
+          title=""
         >
-          Terms
-          <svg
-            aria-hidden="true"
-            focusable="false"
-            height="16"
-            viewBox="0 0 24 24"
-            width="16"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M19.5 4.5h-7V6h4.44l-5.97 5.97 1.06 1.06L18 7.06v4.44h1.5v-7Zm-13 1a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-3H17v3a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h3V5.5h-3Z"
-            />
-          </svg>
-          <span
-            class="jp-dashboard-footer__accessible-external-link"
-          >
-            (opens in a new tab)
-          </span>
+          Help
         </a>
       </li>
       <li>
         <a
-          class="jp-dashboard-footer__menu-item"
+          class="_131101940be12424__body-md _336cd3e4e743482f__box-sizing _08e8a2e44959f892__outset-ring--focus d4250949359b05ce__link _92e0dfcaeee15b88__is-neutral _0e8d87a42c1f75fa__body-sm jetpack-footer__menu-item"
           href="/"
+          title=""
         >
           Link
         </a>
       </li>
       <li>
-        <a
-          class="jp-dashboard-footer__menu-item is-external"
-          href="/"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          External link
-          <svg
-            aria-hidden="true"
-            focusable="false"
-            height="16"
-            viewBox="0 0 24 24"
-            width="16"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M19.5 4.5h-7V6h4.44l-5.97 5.97 1.06 1.06L18 7.06v4.44h1.5v-7Zm-13 1a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-3H17v3a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h3V5.5h-3Z"
-            />
-          </svg>
-          <span
-            class="jp-dashboard-footer__accessible-external-link"
-          >
-            (opens in a new tab)
-          </span>
-        </a>
-      </li>
-      <li>
-        <a
-          class="jp-dashboard-footer__menu-item"
-          href="/"
+        <span
+          class="_131101940be12424__body-md _336cd3e4e743482f__box-sizing _08e8a2e44959f892__outset-ring--focus d4250949359b05ce__link _92e0dfcaeee15b88__is-neutral _0e8d87a42c1f75fa__body-sm jetpack-footer__menu-item"
           role="button"
           tabindex="0"
         >
           Button link
-        </a>
-      </li>
-      <li
-        class="jp-dashboard-footer__a8c-item"
-      >
-        <a
-          aria-label="An Automattic Airline"
-          href="https://jetpack.com/redirect/?source=a8c-about"
-        >
-          <svg
-            aria-hidden="true"
-            aria-labelledby="jp-automattic-byline-logo-title"
-            class="jp-automattic-byline-logo"
-            enable-background="new 0 0 935 38.2"
-            height="7"
-            role="img"
-            viewBox="0 0 935 38.2"
-            x="0"
-            y="0"
-          >
-            <desc
-              id="jp-automattic-byline-logo-title"
-            >
-              An Automattic Airline
-            </desc>
-            <path
-              d="M317.1 38.2c-12.6 0-20.7-9.1-20.7-18.5v-1.2c0-9.6 8.2-18.5 20.7-18.5 12.6 0 20.8 8.9 20.8 18.5v1.2C337.9 29.1 329.7 38.2 317.1 38.2zM331.2 18.6c0-6.9-5-13-14.1-13s-14 6.1-14 13v0.9c0 6.9 5 13.1 14 13.1s14.1-6.2 14.1-13.1V18.6zM175 36.8l-4.7-8.8h-20.9l-4.5 8.8h-7L157 1.3h5.5L182 36.8H175zM159.7 8.2L152 23.1h15.7L159.7 8.2zM212.4 38.2c-12.7 0-18.7-6.9-18.7-16.2V1.3h6.6v20.9c0 6.6 4.3 10.5 12.5 10.5 8.4 0 11.9-3.9 11.9-10.5V1.3h6.7V22C231.4 30.8 225.8 38.2 212.4 38.2zM268.6 6.8v30h-6.7v-30h-15.5V1.3h37.7v5.5H268.6zM397.3 36.8V8.7l-1.8 3.1 -14.9 25h-3.3l-14.7-25 -1.8-3.1v28.1h-6.5V1.3h9.2l14 24.4 1.7 3 1.7-3 13.9-24.4h9.1v35.5H397.3zM454.4 36.8l-4.7-8.8h-20.9l-4.5 8.8h-7l19.2-35.5h5.5l19.5 35.5H454.4zM439.1 8.2l-7.7 14.9h15.7L439.1 8.2zM488.4 6.8v30h-6.7v-30h-15.5V1.3h37.7v5.5H488.4zM537.3 6.8v30h-6.7v-30h-15.5V1.3h37.7v5.5H537.3zM569.3 36.8V4.6c2.7 0 3.7-1.4 3.7-3.4h2.8v35.5L569.3 36.8 569.3 36.8zM628 11.3c-3.2-2.9-7.9-5.7-14.2-5.7 -9.5 0-14.8 6.5-14.8 13.3v0.7c0 6.7 5.4 13 15.3 13 5.9 0 10.8-2.8 13.9-5.7l4 4.2c-3.9 3.8-10.5 7.1-18.3 7.1 -13.4 0-21.6-8.7-21.6-18.3v-1.2c0-9.6 8.9-18.7 21.9-18.7 7.5 0 14.3 3.1 18 7.1L628 11.3zM321.5 12.4c1.2 0.8 1.5 2.4 0.8 3.6l-6.1 9.4c-0.8 1.2-2.4 1.6-3.6 0.8l0 0c-1.2-0.8-1.5-2.4-0.8-3.6l6.1-9.4C318.7 11.9 320.3 11.6 321.5 12.4L321.5 12.4z"
-            />
-            <path
-              d="M37.5 36.7l-4.7-8.9H11.7l-4.6 8.9H0L19.4 0.8H25l19.7 35.9H37.5zM22 7.8l-7.8 15.1h15.9L22 7.8zM82.8 36.7l-23.3-24 -2.3-2.5v26.6h-6.7v-36H57l22.6 24 2.3 2.6V0.8h6.7v35.9H82.8z"
-            />
-            <path
-              d="M719.9 37l-4.8-8.9H694l-4.6 8.9h-7.1l19.5-36h5.6l19.8 36H719.9zM704.4 8l-7.8 15.1h15.9L704.4 8zM733 37V1h6.8v36H733zM781 37c-1.8 0-2.6-2.5-2.9-5.8l-0.2-3.7c-0.2-3.6-1.7-5.1-8.4-5.1h-12.8V37H750V1h19.6c10.8 0 15.7 4.3 15.7 9.9 0 3.9-2 7.7-9 9 7 0.5 8.5 3.7 8.6 7.9l0.1 3c0.1 2.5 0.5 4.3 2.2 6.1V37H781zM778.5 11.8c0-2.6-2.1-5.1-7.9-5.1h-13.8v10.8h14.4c5 0 7.3-2.4 7.3-5.2V11.8zM794.8 37V1h6.8v30.4h28.2V37H794.8zM836.7 37V1h6.8v36H836.7zM886.2 37l-23.4-24.1 -2.3-2.5V37h-6.8V1h6.5l22.7 24.1 2.3 2.6V1h6.8v36H886.2zM902.3 37V1H935v5.6h-26v9.2h20v5.5h-20v10.1h26V37H902.3z"
-            />
-          </svg>
-        </a>
+        </span>
       </li>
     </ul>
+    <a
+      class="jetpack-footer__a8c"
+      href="https://jetpack.com/redirect/?source=a8c-about"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      <svg
+        aria-labelledby="jp-automattic-byline-logo-title"
+        class="jp-automattic-byline-logo"
+        enable-background="new 0 0 935 38.2"
+        height="8"
+        role="img"
+        viewBox="0 0 935 38.2"
+        x="0"
+        y="0"
+      >
+        <desc
+          id="jp-automattic-byline-logo-title"
+        >
+          An Automattic Airline
+        </desc>
+        <path
+          d="M317.1 38.2c-12.6 0-20.7-9.1-20.7-18.5v-1.2c0-9.6 8.2-18.5 20.7-18.5 12.6 0 20.8 8.9 20.8 18.5v1.2C337.9 29.1 329.7 38.2 317.1 38.2zM331.2 18.6c0-6.9-5-13-14.1-13s-14 6.1-14 13v0.9c0 6.9 5 13.1 14 13.1s14.1-6.2 14.1-13.1V18.6zM175 36.8l-4.7-8.8h-20.9l-4.5 8.8h-7L157 1.3h5.5L182 36.8H175zM159.7 8.2L152 23.1h15.7L159.7 8.2zM212.4 38.2c-12.7 0-18.7-6.9-18.7-16.2V1.3h6.6v20.9c0 6.6 4.3 10.5 12.5 10.5 8.4 0 11.9-3.9 11.9-10.5V1.3h6.7V22C231.4 30.8 225.8 38.2 212.4 38.2zM268.6 6.8v30h-6.7v-30h-15.5V1.3h37.7v5.5H268.6zM397.3 36.8V8.7l-1.8 3.1 -14.9 25h-3.3l-14.7-25 -1.8-3.1v28.1h-6.5V1.3h9.2l14 24.4 1.7 3 1.7-3 13.9-24.4h9.1v35.5H397.3zM454.4 36.8l-4.7-8.8h-20.9l-4.5 8.8h-7l19.2-35.5h5.5l19.5 35.5H454.4zM439.1 8.2l-7.7 14.9h15.7L439.1 8.2zM488.4 6.8v30h-6.7v-30h-15.5V1.3h37.7v5.5H488.4zM537.3 6.8v30h-6.7v-30h-15.5V1.3h37.7v5.5H537.3zM569.3 36.8V4.6c2.7 0 3.7-1.4 3.7-3.4h2.8v35.5L569.3 36.8 569.3 36.8zM628 11.3c-3.2-2.9-7.9-5.7-14.2-5.7 -9.5 0-14.8 6.5-14.8 13.3v0.7c0 6.7 5.4 13 15.3 13 5.9 0 10.8-2.8 13.9-5.7l4 4.2c-3.9 3.8-10.5 7.1-18.3 7.1 -13.4 0-21.6-8.7-21.6-18.3v-1.2c0-9.6 8.9-18.7 21.9-18.7 7.5 0 14.3 3.1 18 7.1L628 11.3zM321.5 12.4c1.2 0.8 1.5 2.4 0.8 3.6l-6.1 9.4c-0.8 1.2-2.4 1.6-3.6 0.8l0 0c-1.2-0.8-1.5-2.4-0.8-3.6l6.1-9.4C318.7 11.9 320.3 11.6 321.5 12.4L321.5 12.4z"
+        />
+        <path
+          d="M37.5 36.7l-4.7-8.9H11.7l-4.6 8.9H0L19.4 0.8H25l19.7 35.9H37.5zM22 7.8l-7.8 15.1h15.9L22 7.8zM82.8 36.7l-23.3-24 -2.3-2.5v26.6h-6.7v-36H57l22.6 24 2.3 2.6V0.8h6.7v35.9H82.8z"
+        />
+        <path
+          d="M719.9 37l-4.8-8.9H694l-4.6 8.9h-7.1l19.5-36h5.6l19.8 36H719.9zM704.4 8l-7.8 15.1h15.9L704.4 8zM733 37V1h6.8v36H733zM781 37c-1.8 0-2.6-2.5-2.9-5.8l-0.2-3.7c-0.2-3.6-1.7-5.1-8.4-5.1h-12.8V37H750V1h19.6c10.8 0 15.7 4.3 15.7 9.9 0 3.9-2 7.7-9 9 7 0.5 8.5 3.7 8.6 7.9l0.1 3c0.1 2.5 0.5 4.3 2.2 6.1V37H781zM778.5 11.8c0-2.6-2.1-5.1-7.9-5.1h-13.8v10.8h14.4c5 0 7.3-2.4 7.3-5.2V11.8zM794.8 37V1h6.8v30.4h28.2V37H794.8zM836.7 37V1h6.8v36H836.7zM886.2 37l-23.4-24.1 -2.3-2.5V37h-6.8V1h6.5l22.7 24.1 2.3 2.6V1h6.8v36H886.2zM902.3 37V1H935v5.6h-26v9.2h20v5.5h-20v10.1h26V37H902.3z"
+        />
+      </svg>
+    </a>
   </footer>
 </div>
 `;

--- a/projects/js-packages/components/components/jetpack-footer/test/component.tsx
+++ b/projects/js-packages/components/components/jetpack-footer/test/component.tsx
@@ -13,13 +13,8 @@ describe( 'JetpackFooter', () => {
 				href: '/',
 			},
 			{
-				label: 'External link',
-				href: '/',
-				target: '_blank',
-			},
-			{
 				label: 'Button link',
-				href: '/',
+				onClick: () => {},
 				role: 'button',
 			},
 		];
@@ -60,36 +55,20 @@ describe( 'JetpackFooter', () => {
 		it( 'should render the Automattic logo', () => {
 			render( <JetpackFooter /> );
 
-			const element = screen.getByLabelText( 'An Automattic Airline', { selector: 'a' } );
+			const element = screen.getByText( 'An Automattic Airline', {
+				selector: '#jp-automattic-byline-logo-title',
+			} );
 
 			expect( element ).toBeInTheDocument();
-		} );
-
-		it( 'should render a list', () => {
-			render( <JetpackFooter menu={ menu } /> );
-
-			const element = screen.getByRole( 'list' );
-
-			expect( element ).toBeInTheDocument();
-			// eslint-disable-next-line testing-library/no-node-access
-			expect( element.children ).toHaveLength( 2 + menu.length ); // 2 logos
 		} );
 
 		it( 'should render the links', () => {
 			render( <JetpackFooter menu={ menu } /> );
-			const externalLinkLabel = menu[ 1 ].label + '(opens in a new tab)';
 
 			const link = screen.getByRole( 'link', { name: menu[ 0 ].label } );
-			const externalLink = screen.getByRole( 'link', { name: externalLinkLabel } );
-			const button = screen.getByRole( 'button', { name: menu[ 2 ].label } );
+			const button = screen.getByRole( 'button', { name: menu[ 1 ].label } );
 
 			expect( link ).toBeInTheDocument();
-
-			expect( externalLink ).toBeInTheDocument();
-			expect( externalLink ).toHaveAttribute( 'target', '_blank' );
-			expect( externalLink ).toHaveAttribute( 'rel', 'noopener noreferrer' );
-			expect( externalLink ).toContainHTML( 'svg' );
-
 			expect( button ).toBeInTheDocument();
 			expect( button ).toHaveAttribute( 'tabindex', '0' );
 		} );

--- a/projects/js-packages/components/components/jetpack-footer/test/component.tsx
+++ b/projects/js-packages/components/components/jetpack-footer/test/component.tsx
@@ -5,8 +5,6 @@ import JetpackFooter from '../index.tsx';
 
 describe( 'JetpackFooter', () => {
 	const className = 'sample-classname';
-	const moduleName = 'Test module';
-	const moduleNameHref = 'https://jetpack.com/path/to-some-page';
 
 	describe( 'Render the component', () => {
 		const menu = [
@@ -50,20 +48,10 @@ describe( 'JetpackFooter', () => {
 			expect( element ).toBeInTheDocument();
 		} );
 
-		it( 'should render the module name as a link', () => {
-			render( <JetpackFooter moduleName={ moduleName } moduleNameHref={ moduleNameHref } /> );
+		it( 'should render Jetpack as regular text', () => {
+			render( <JetpackFooter /> );
 
-			const element = screen.getByText( moduleName );
-
-			expect( element ).toBeInTheDocument();
-			expect( element ).toBeInstanceOf( HTMLAnchorElement );
-			expect( element ).toHaveAttribute( 'href', moduleNameHref );
-		} );
-
-		it( 'should render the module name as regular text', () => {
-			render( <JetpackFooter moduleName={ moduleName } moduleNameHref={ null } /> );
-
-			const element = screen.getByText( moduleName );
+			const element = screen.getByText( 'Jetpack' );
 
 			expect( element ).toBeInTheDocument();
 			expect( element ).not.toBeInstanceOf( HTMLAnchorElement );
@@ -107,14 +95,7 @@ describe( 'JetpackFooter', () => {
 		} );
 
 		it( 'should match the snapshot', () => {
-			const { container } = render(
-				<JetpackFooter
-					className={ className }
-					moduleName={ moduleName }
-					moduleNameHref={ moduleNameHref }
-					menu={ menu }
-				/>
-			);
+			const { container } = render( <JetpackFooter className={ className } menu={ menu } /> );
 			expect( container ).toMatchSnapshot( 'all props' );
 		} );
 	} );

--- a/projects/js-packages/components/components/jetpack-footer/test/component.tsx
+++ b/projects/js-packages/components/components/jetpack-footer/test/component.tsx
@@ -72,7 +72,7 @@ describe( 'JetpackFooter', () => {
 
 			expect( element ).toBeInTheDocument();
 			// eslint-disable-next-line testing-library/no-node-access
-			expect( element.children ).toHaveLength( 2 + 2 + menu.length ); // 2 logos, 2 generic links
+			expect( element.children ).toHaveLength( 2 + menu.length ); // 2 logos
 		} );
 
 		it( 'should render the links', () => {

--- a/projects/js-packages/components/components/jetpack-footer/test/component.tsx
+++ b/projects/js-packages/components/components/jetpack-footer/test/component.tsx
@@ -72,7 +72,7 @@ describe( 'JetpackFooter', () => {
 
 			expect( element ).toBeInTheDocument();
 			// eslint-disable-next-line testing-library/no-node-access
-			expect( element.children ).toHaveLength( 2 + 3 + menu.length ); // 2 logos, 3 generic links
+			expect( element.children ).toHaveLength( 2 + 2 + menu.length ); // 2 logos, 2 generic links
 		} );
 
 		it( 'should render the links', () => {

--- a/projects/js-packages/components/components/jetpack-footer/types.ts
+++ b/projects/js-packages/components/components/jetpack-footer/types.ts
@@ -30,11 +30,6 @@ export type JetpackFooterProps = {
 	siteAdminUrl?: string;
 
 	/**
-	 * Function called when the About link is clicked.
-	 */
-	onAboutClick?: () => void;
-
-	/**
 	 * Function called when the Privacy link is clicked.
 	 */
 	onPrivacyClick?: () => void;

--- a/projects/js-packages/components/components/jetpack-footer/types.ts
+++ b/projects/js-packages/components/components/jetpack-footer/types.ts
@@ -1,9 +1,8 @@
 export type JetpackFooterMenuItem = {
-	href: string;
+	href?: string;
 	label: string;
 	onClick?: () => void;
 	onKeyDown?: () => void;
-	target?: string;
 	title?: string;
 	role?: string;
 };
@@ -15,7 +14,7 @@ export type JetpackFooterProps = {
 	className?: string;
 
 	/**
-	 * Navigation menu to display in the footer.
+	 * Additional links to display in the footer.
 	 */
 	menu?: JetpackFooterMenuItem[];
 };

--- a/projects/js-packages/components/components/jetpack-footer/types.ts
+++ b/projects/js-packages/components/components/jetpack-footer/types.ts
@@ -10,19 +10,9 @@ export type JetpackFooterMenuItem = {
 
 export type JetpackFooterProps = {
 	/**
-	 * Name of the module, e.g. 'Jetpack Search'.
-	 */
-	moduleName?: string;
-
-	/**
 	 * additional className of the wrapper, `jp-dashboard-footer` always included.
 	 */
 	className?: string;
-
-	/**
-	 * Link that the Module name will link to (optional).
-	 */
-	moduleNameHref?: string;
 
 	/**
 	 * Navigation menu to display in the footer.

--- a/projects/js-packages/components/components/jetpack-footer/types.ts
+++ b/projects/js-packages/components/components/jetpack-footer/types.ts
@@ -20,22 +20,7 @@ export type JetpackFooterProps = {
 	menu?: JetpackFooterMenuItem[];
 
 	/**
-	 * Whether to enable Jetpack admin links.
-	 */
-	useInternalLinks?: boolean;
-
-	/**
 	 * URL of the site WP Admin.
 	 */
 	siteAdminUrl?: string;
-
-	/**
-	 * Function called when the Privacy link is clicked.
-	 */
-	onPrivacyClick?: () => void;
-
-	/**
-	 * Function called when the Terms link is clicked.
-	 */
-	onTermsClick?: () => void;
 };

--- a/projects/js-packages/components/components/jetpack-footer/types.ts
+++ b/projects/js-packages/components/components/jetpack-footer/types.ts
@@ -10,7 +10,7 @@ export type JetpackFooterMenuItem = {
 
 export type JetpackFooterProps = {
 	/**
-	 * additional className of the wrapper, `jp-dashboard-footer` always included.
+	 * Additional className of the wrapper, `jetpack-footer` always included.
 	 */
 	className?: string;
 
@@ -18,9 +18,4 @@ export type JetpackFooterProps = {
 	 * Navigation menu to display in the footer.
 	 */
 	menu?: JetpackFooterMenuItem[];
-
-	/**
-	 * URL of the site WP Admin.
-	 */
-	siteAdminUrl?: string;
 };

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -63,6 +63,8 @@
 		"@wordpress/i18n": "6.15.0",
 		"@wordpress/icons": "12.0.0",
 		"@wordpress/notices": "5.42.0",
+		"@wordpress/theme": "0.9.0",
+		"@wordpress/ui": "0.9.0",
 		"clsx": "2.1.1",
 		"prop-types": "^15.7.2",
 		"qrcode.react": "4.2.0",

--- a/projects/js-packages/storybook/changelog/pr-47840
+++ b/projects/js-packages/storybook/changelog/pr-47840
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add NodePackageImporter to Vite SCSS config to support pkg: imports.

--- a/projects/js-packages/storybook/storybook/main.js
+++ b/projects/js-packages/storybook/storybook/main.js
@@ -6,6 +6,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'url';
 import react from '@vitejs/plugin-react';
 import remarkGfm from 'remark-gfm';
+import { NodePackageImporter } from 'sass-embedded';
 import jetpackConfig from './jetpackConfig.js';
 import { projects } from './projects.js';
 
@@ -119,6 +120,7 @@ const sbconfig = {
 						],
 						// Boost-specific alias. Needs separate configuration from the below, sigh.
 						importers: [
+							new NodePackageImporter(),
 							{
 								findFileUrl( url ) {
 									if ( url.startsWith( '$css/' ) ) {

--- a/projects/js-packages/webpack-config/README.md
+++ b/projects/js-packages/webpack-config/README.md
@@ -45,6 +45,9 @@ module.exports = {
 				includeNodeModules: [ '@automattic/jetpack-' ],
 			} ),
 
+			// Workarounds for non-extracted `@wordpress/*` packages.
+			...jetpackWebpackConfig.BundledWpPkgsTranspileRules(),
+
 			// Handle CSS.
 			jetpackWebpackConfig.CssRule(),
 
@@ -268,7 +271,7 @@ Requires WordPress's `wp-react-refresh-runtime` script to be enqueued.
 
 #### Module rules and loaders
 
-Note all rule sets are provided as factory functions returning a single rule.
+Note all rule sets (except `BundledWpPkgsTranspileRules`) are provided as factory functions returning a single rule.
 
 ##### `TranspileRule( options )`
 
@@ -284,6 +287,15 @@ Options are:
   - `cacheDirectory`: `path.resolve( '.cache/babel` )`.
   - `cacheCompression`: `true`.
   - If `path.resolve( 'babel.config.js' )` exists, `configFile` will default to that. Otherwise, `presets` will default to set some appropriate defaults (which will require the peer dependencies on [@babel/core](https://www.npmjs.com/package/@babel/core) and [@babel/runtime](https://www.npmjs.com/package/@babel/runtime)).
+
+##### `BundledWpPkgsTranspileRules( options )`
+
+This provides two instances of `TranspileRule` configured to handle known `@wordpress/*` packages that aren't extracted by `@wordpress/dependency-extraction-webpack-plugin`.
+
+If you're not using the relevant packages, there's no need to use this.
+
+Options are:
+- `textdomain`: Text domain for [@automattic/babel-plugin-replace-textdomain](https://www.npmjs.com/package/@automattic/babel-plugin-replace-textdomain). Defaults to reading the domain from `composer.json`.
 
 ##### `CssRule( options )`
 

--- a/projects/js-packages/webpack-config/changelog/update-footer
+++ b/projects/js-packages/webpack-config/changelog/update-footer
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add `BundledWpPkgsTranspileRules` to centralize the hacks needed for non-extracted `@wordpress/*` packages.

--- a/projects/js-packages/webpack-config/src/webpack.js
+++ b/projects/js-packages/webpack-config/src/webpack.js
@@ -17,7 +17,7 @@ const FileRule = require( './webpack/file-rule' );
 const MiniCSSWithRTLWebpackPlugin = require( './webpack/mini-css-with-rtl' );
 const PnpmDeterministicModuleIdsWebpackPlugin = require( './webpack/pnpm-deterministic-ids.js' );
 const TerserPlugin = require( './webpack/terser' );
-const TranspileRule = require( './webpack/transpile-rule' );
+const BaseTranspileRule = require( './webpack/transpile-rule' );
 
 const CssMinimizerPlugin = options => new CssMinimizerWebpackPlugin( options );
 
@@ -60,6 +60,21 @@ const i18nFilterFunction = file => {
 	const i = file.lastIndexOf( '/node_modules/' ) + 14;
 	return i < 14 || file.startsWith( '@automattic/', i );
 };
+
+/**
+ * Generate i18n function variants for replace-textdomain plugin compatibility.
+ *
+ * @param {string} baseFn - Base function name (e.g., '__', '_x', '_n').
+ * @param {number} value  - Textdomain argument position (1-based index).
+ * @return {object} Object mapping function names to textdomain positions.
+ */
+const generateI18nVariants = ( baseFn, value ) =>
+	Object.fromEntries(
+		Array.from( { length: 100 }, ( _, i ) => [
+			`${ baseFn }${ i || '' }`, // empty suffix for 0
+			value,
+		] )
+	);
 
 const getUniqueName = () => {
 	let dir = process.cwd(),
@@ -250,6 +265,39 @@ const PnpmDeterministicModuleIdsPlugin = options => [
 ];
 
 const WebpackRtlPlugin = options => [ new WebpackRTLWebpackPlugin( options ) ];
+
+const TranspileRule = ( options = {} ) => {
+	const includeNodeModules = options.includeNodeModules || [];
+	const shouldRewriteWordPressUi = includeNodeModules.some(
+		module => module === '@wordpress/ui' || module.startsWith( '@wordpress/ui/' )
+	);
+
+	if ( ! shouldRewriteWordPressUi ) {
+		return BaseTranspileRule( options );
+	}
+
+	const textdomainPlugin = [
+		require.resolve( '@automattic/babel-plugin-replace-textdomain' ),
+		{
+			textdomain: loadTextDomainFromComposerJson(),
+			functions: {
+				...generateI18nVariants( '__', 1 ),
+				...generateI18nVariants( '_x', 2 ),
+				...generateI18nVariants( '_n', 3 ),
+			},
+		},
+	];
+
+	const existingPlugins = options.babelOpts?.plugins || [];
+
+	return BaseTranspileRule( {
+		...options,
+		babelOpts: {
+			...options.babelOpts,
+			plugins: [ ...existingPlugins, textdomainPlugin ],
+		},
+	} );
+};
 
 const StandardPlugins = ( options = {} ) => {
 	if ( typeof options.ForkTSCheckerPlugin === 'undefined' ) {

--- a/projects/js-packages/webpack-config/src/webpack.js
+++ b/projects/js-packages/webpack-config/src/webpack.js
@@ -11,47 +11,19 @@ const CssMinimizerWebpackPlugin = require( 'css-minimizer-webpack-plugin' );
 const ForkTSCheckerWebpackPlugin = require( 'fork-ts-checker-webpack-plugin' );
 const MiniCssExtractWebpackPlugin = require( 'mini-css-extract-plugin' );
 const webpack = require( 'webpack' );
+const BundledWpPkgsTranspileRules = require( './webpack/bundled-wp-pkgs-transpile-rules' );
 const CssRule = require( './webpack/css-rule' );
 const DevServer = require( './webpack/dev-server' );
 const FileRule = require( './webpack/file-rule' );
+const loadTextDomainFromComposerJson = require( './webpack/load-textdomain-from-composer-json.js' );
 const MiniCSSWithRTLWebpackPlugin = require( './webpack/mini-css-with-rtl' );
 const PnpmDeterministicModuleIdsWebpackPlugin = require( './webpack/pnpm-deterministic-ids.js' );
 const TerserPlugin = require( './webpack/terser' );
-const BaseTranspileRule = require( './webpack/transpile-rule' );
+const TranspileRule = require( './webpack/transpile-rule' );
 
 const CssMinimizerPlugin = options => new CssMinimizerWebpackPlugin( options );
 
 /****** Functions ******/
-
-let loadTextDomainFromComposerJson = () => {
-	let dir = process.cwd(),
-		olddir,
-		ret;
-	do {
-		const file = path.join( dir, 'composer.json' );
-		if ( fs.existsSync( file ) ) {
-			const cfg = JSON.parse( fs.readFileSync( file, { encoding: 'utf8' } ) );
-			if ( cfg.extra ) {
-				if ( cfg.extra.textdomain ) {
-					ret = cfg.extra.textdomain;
-				} else if ( cfg.extra[ 'wp-plugin-slug' ] ) {
-					ret = cfg.extra[ 'wp-plugin-slug' ];
-				} else if ( cfg.extra[ 'beta-plugin-slug' ] ) {
-					ret = cfg.extra[ 'beta-plugin-slug' ];
-				}
-			}
-			break;
-		}
-
-		olddir = dir;
-		dir = path.dirname( dir );
-	} while ( dir !== olddir );
-
-	// thunk it
-	loadTextDomainFromComposerJson = () => ret;
-
-	return ret;
-};
 
 const i18nFilterFunction = file => {
 	if ( ! /\.(?:jsx?|tsx?|cjs|mjs|svelte)$/.test( file ) ) {
@@ -60,21 +32,6 @@ const i18nFilterFunction = file => {
 	const i = file.lastIndexOf( '/node_modules/' ) + 14;
 	return i < 14 || file.startsWith( '@automattic/', i );
 };
-
-/**
- * Generate i18n function variants for replace-textdomain plugin compatibility.
- *
- * @param {string} baseFn - Base function name (e.g., '__', '_x', '_n').
- * @param {number} value  - Textdomain argument position (1-based index).
- * @return {object} Object mapping function names to textdomain positions.
- */
-const generateI18nVariants = ( baseFn, value ) =>
-	Object.fromEntries(
-		Array.from( { length: 100 }, ( _, i ) => [
-			`${ baseFn }${ i || '' }`, // empty suffix for 0
-			value,
-		] )
-	);
 
 const getUniqueName = () => {
 	let dir = process.cwd(),
@@ -266,39 +223,6 @@ const PnpmDeterministicModuleIdsPlugin = options => [
 
 const WebpackRtlPlugin = options => [ new WebpackRTLWebpackPlugin( options ) ];
 
-const TranspileRule = ( options = {} ) => {
-	const includeNodeModules = options.includeNodeModules || [];
-	const shouldRewriteWordPressUi = includeNodeModules.some(
-		module => module === '@wordpress/ui' || module.startsWith( '@wordpress/ui/' )
-	);
-
-	if ( ! shouldRewriteWordPressUi ) {
-		return BaseTranspileRule( options );
-	}
-
-	const textdomainPlugin = [
-		require.resolve( '@automattic/babel-plugin-replace-textdomain' ),
-		{
-			textdomain: loadTextDomainFromComposerJson(),
-			functions: {
-				...generateI18nVariants( '__', 1 ),
-				...generateI18nVariants( '_x', 2 ),
-				...generateI18nVariants( '_n', 3 ),
-			},
-		},
-	];
-
-	const existingPlugins = options.babelOpts?.plugins || [];
-
-	return BaseTranspileRule( {
-		...options,
-		babelOpts: {
-			...options.babelOpts,
-			plugins: [ ...existingPlugins, textdomainPlugin ],
-		},
-	} );
-};
-
 const StandardPlugins = ( options = {} ) => {
 	if ( typeof options.ForkTSCheckerPlugin === 'undefined' ) {
 		options.ForkTSCheckerPlugin = false;
@@ -386,6 +310,7 @@ module.exports = {
 	ReactRefreshWebpackPlugin,
 	// Module rules and loaders.
 	TranspileRule,
+	BundledWpPkgsTranspileRules,
 	CssRule,
 	FileRule,
 };

--- a/projects/js-packages/webpack-config/src/webpack/bundled-wp-pkgs-transpile-rules.js
+++ b/projects/js-packages/webpack-config/src/webpack/bundled-wp-pkgs-transpile-rules.js
@@ -1,0 +1,89 @@
+const loadTextDomainFromComposerJson = require( './load-textdomain-from-composer-json.js' );
+const TranspileRule = require( './transpile-rule.js' );
+
+/**
+ * Generate i18n function variants for `@automattic/babel-plugin-replace-textdomain`.
+ *
+ * The `@wordpress/dataviews` currently uses the i18n functions under a variety of aliases,
+ * which makes it a pain to add the proper textdomain. This function generates an object
+ * with the base function and 99 more variants as keys.
+ *
+ * @param {string} baseFn - Base function name (e.g., '__', '_x', '_n')
+ * @param {number} value  - Textdomain argument position (1-based index)
+ * @return {object} Object mapping function names to textdomain positions
+ */
+const generateI18nVariants = ( baseFn, value ) =>
+	Object.fromEntries(
+		Array.from( { length: 100 }, ( _, i ) => [
+			`${ baseFn }${ i || '' }`, // empty suffix for 0
+			value,
+		] )
+	);
+
+/**
+ * Provide transpile rules for bundled `@wordpress/*` packages.
+ *
+ * If bundled packages contain `@wordpress/i18n` calls, the i18n doesn't actually work due to
+ * mismatched text domains. Our `@automattic/babel-plugin-replace-textdomain` plugin fixes that,
+ * but it needs to be applied. This supplies the needed rules to do so for `@wordpress/*` packages
+ * that aren't extracted by `@wordpress/dependency-extraction-webpack-plugin`.
+ *
+ * This also provides a rule that works around the totally broken i18n calls in the `@wordpress/dataviews/wp`
+ * entry point.
+ *
+ * @see https://developer.wordpress.com/2022/01/06/wordpress-plugin-i18n-webpack-and-composer/
+ * @see https://github.com/Automattic/jetpack/issues/39907
+ *
+ * @param {object} [options]            - Options.
+ * @param {string} [options.textdomain] - Text domain for `@automattic/babel-plugin-replace-textdomain`.
+ * @return {object[]} Transpilation rules.
+ */
+const BundledWpPkgsTranspileRules = ( options = {} ) => {
+	const textdomain = options.textdomain ?? loadTextDomainFromComposerJson();
+
+	/**
+	 * Transpile `@wordpress/dataviews` in node_modules too.
+	 *
+	 * Uses configFile: false to avoid inheriting babel.config.js, and
+	 * manually applies textdomain replacement with i18n function variants
+	 * to handle the aliased function names (e.g. __1, _x2) in the
+	 * dataviews build-wp bundle.
+	 *
+	 * @see https://github.com/Automattic/jetpack/issues/39907
+	 */
+	const dataviewsWp = TranspileRule( {
+		includeNodeModules: [ '@wordpress/dataviews/build-wp/' ],
+		babelOpts: {
+			configFile: false,
+			plugins: [
+				[
+					require.resolve( '@automattic/babel-plugin-replace-textdomain' ),
+					{
+						textdomain,
+						functions: {
+							...generateI18nVariants( '__', 1 ),
+							...generateI18nVariants( '_x', 2 ),
+							...generateI18nVariants( '_n', 3 ),
+						},
+					},
+				],
+			],
+		},
+	} );
+
+	// Add textdomains (but no other optimizations) for @wordpress/dataviews and @wordpress/ui.
+	const textdomainsOnly = TranspileRule( {
+		includeNodeModules: [ '@wordpress/dataviews/', '@wordpress/ui/' ],
+		exclude: dataviewsWp.include,
+		babelOpts: {
+			configFile: false,
+			plugins: [
+				[ require.resolve( '@automattic/babel-plugin-replace-textdomain' ), { textdomain } ],
+			],
+		},
+	} );
+
+	return [ dataviewsWp, textdomainsOnly ];
+};
+
+module.exports = BundledWpPkgsTranspileRules;

--- a/projects/js-packages/webpack-config/src/webpack/load-textdomain-from-composer-json.js
+++ b/projects/js-packages/webpack-config/src/webpack/load-textdomain-from-composer-json.js
@@ -1,0 +1,38 @@
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+let cachedDomain;
+const loadTextDomainFromComposerJson = () => {
+	if ( cachedDomain !== undefined ) {
+		return cachedDomain;
+	}
+
+	let dir = process.cwd(),
+		olddir,
+		ret;
+	do {
+		const file = path.join( dir, 'composer.json' );
+		if ( fs.existsSync( file ) ) {
+			const cfg = JSON.parse( fs.readFileSync( file, { encoding: 'utf8' } ) );
+			if ( cfg.extra ) {
+				if ( cfg.extra.textdomain ) {
+					ret = cfg.extra.textdomain;
+				} else if ( cfg.extra[ 'wp-plugin-slug' ] ) {
+					ret = cfg.extra[ 'wp-plugin-slug' ];
+				} else if ( cfg.extra[ 'beta-plugin-slug' ] ) {
+					ret = cfg.extra[ 'beta-plugin-slug' ];
+				}
+			}
+			break;
+		}
+
+		olddir = dir;
+		dir = path.dirname( dir );
+	} while ( dir !== olddir );
+
+	cachedDomain = ret;
+
+	return ret;
+};
+
+module.exports = loadTextDomainFromComposerJson;

--- a/projects/packages/backup/changelog/pr-47840
+++ b/projects/packages/backup/changelog/pr-47840
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update admin page footer design.

--- a/projects/packages/backup/src/js/components/Admin/index.js
+++ b/projects/packages/backup/src/js/components/Admin/index.js
@@ -8,7 +8,6 @@ import {
 	LoadingPlaceholder,
 } from '@automattic/jetpack-components';
 import { useConnectionErrorNotice, ConnectionError } from '@automattic/jetpack-connection';
-import { shouldUseInternalLinks } from '@automattic/jetpack-shared-extension-utils';
 import apiFetch from '@wordpress/api-fetch';
 import { Button, ExternalLink } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
@@ -124,7 +123,6 @@ const Admin = () => {
 				'jetpack-backup-pkg'
 			) }
 			actions={ headerActions }
-			useInternalLinks={ shouldUseInternalLinks() }
 		>
 			<div id="jetpack-backup-admin-container" className="jp-content">
 				<div className="content">

--- a/projects/packages/backup/src/js/components/Admin/style.scss
+++ b/projects/packages/backup/src/js/components/Admin/style.scss
@@ -150,9 +150,6 @@
 	}
 }
 
-.jp-dashboard-footer {
-	padding: 40px 0;
-}
 
 .jp-connection-status-card--status {
 	margin: 30px 0;

--- a/projects/packages/backup/webpack.config.js
+++ b/projects/packages/backup/webpack.config.js
@@ -33,6 +33,9 @@ module.exports = [
 					includeNodeModules: [ '@automattic/jetpack-' ],
 				} ),
 
+				// Workarounds for non-extracted `@wordpress/*` packages.
+				...jetpackWebpackConfig.BundledWpPkgsTranspileRules(),
+
 				// Handle CSS.
 				jetpackWebpackConfig.CssRule( {
 					extensions: [ 'css', 'sass', 'scss' ],

--- a/projects/packages/forms/changelog/update-footer
+++ b/projects/packages/forms/changelog/update-footer
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use new `BundledWpPkgsTranspileRules` from webpack-config to centralize the hacks needed for non-extracted `@wordpress/*` packages.
+
+

--- a/projects/packages/forms/tools/webpack.config.dashboard.js
+++ b/projects/packages/forms/tools/webpack.config.dashboard.js
@@ -2,32 +2,11 @@
  * Builds the forms dashboard JS bundle.
  */
 
-import { createRequire } from 'module';
 import path from 'path';
 import jetpackWebpackConfig from '@automattic/jetpack-webpack-config/webpack';
 import { NodePackageImporter } from 'sass-embedded';
 
 const __dirname = import.meta.dirname;
-const require = createRequire( import.meta.url );
-
-/**
- * Generate i18n function variants for `@automattic/babel-plugin-replace-textdomain`.
- *
- * The `@wordpress/dataviews` currently uses the i18n functions under a variety of aliases,
- * which makes it a pain to add the proper textdomain. This function generates an object
- * with the base function and 99 more variants as keys.
- *
- * @param {string} baseFn - Base function name (e.g., '__', '_x', '_n')
- * @param {number} value  - Textdomain argument position (1-based index)
- * @return {object} Object mapping function names to textdomain positions
- */
-const generateI18nVariants = ( baseFn, value ) =>
-	Object.fromEntries(
-		Array.from( { length: 100 }, ( _, i ) => [
-			`${ baseFn }${ i || '' }`, // empty suffix for 0
-			value,
-		] )
-	);
 
 export default {
 	mode: jetpackWebpackConfig.mode,
@@ -76,30 +55,8 @@ export default {
 				includeNodeModules: [ '@automattic/', 'debug/' ],
 			} ),
 
-			/**
-			 * Transpile `@wordpress/dataviews` in node_modules too.
-			 *
-			 * @see https://github.com/Automattic/jetpack/issues/39907
-			 */
-			jetpackWebpackConfig.TranspileRule( {
-				includeNodeModules: [ '@wordpress/dataviews/build-wp/' ],
-				babelOpts: {
-					configFile: false,
-					plugins: [
-						[
-							require.resolve( '@automattic/babel-plugin-replace-textdomain' ),
-							{
-								textdomain: 'jetpack-forms',
-								functions: {
-									...generateI18nVariants( '__', 1 ),
-									...generateI18nVariants( '_x', 2 ),
-									...generateI18nVariants( '_n', 3 ),
-								},
-							},
-						],
-					],
-				},
-			} ),
+			// Workarounds for non-extracted `@wordpress/*` packages.
+			...jetpackWebpackConfig.BundledWpPkgsTranspileRules(),
 
 			// Handle CSS.
 			jetpackWebpackConfig.CssRule( {

--- a/projects/packages/my-jetpack/_inc/components/add-license-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/add-license-screen/index.jsx
@@ -3,7 +3,6 @@
  */
 import { AdminPage, Container, Col } from '@automattic/jetpack-components';
 import { ActivationScreen } from '@automattic/jetpack-licensing';
-import { shouldUseInternalLinks } from '@automattic/jetpack-shared-extension-utils';
 import { useCallback, useState, useMemo } from 'react';
 /*
  * Internal dependencies
@@ -54,11 +53,7 @@ export default function AddLicenseScreen() {
 	const { siteSuffix = '', adminUrl = '' } = getMyJetpackWindowInitialState();
 
 	return (
-		<AdminPage
-			showHeader={ false }
-			showBackground={ false }
-			useInternalLinks={ shouldUseInternalLinks() }
-		>
+		<AdminPage showHeader={ false } showBackground={ false }>
 			<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
 				<Col>
 					<GoBackLink onClick={ onClickGoBack } reload={ hasActivatedLicense } />

--- a/projects/packages/my-jetpack/_inc/components/connection-screen/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-screen/index.tsx
@@ -1,5 +1,4 @@
 import { Container, Col, AdminPage } from '@automattic/jetpack-components';
-import { shouldUseInternalLinks } from '@automattic/jetpack-shared-extension-utils';
 import { __ } from '@wordpress/i18n';
 import { useSearchParams } from 'react-router';
 import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
@@ -16,11 +15,7 @@ const ConnectionScreen: FC = () => {
 	const returnToPage = useMyJetpackReturnToPage();
 	const { apiRoot, apiNonce, registrationNonce } = useMyJetpackConnection();
 	return (
-		<AdminPage
-			showHeader={ false }
-			showBackground={ false }
-			useInternalLinks={ shouldUseInternalLinks() }
-		>
+		<AdminPage showHeader={ false } showBackground={ false }>
 			<Container horizontalSpacing={ 8 } horizontalGap={ 0 }>
 				<Col className={ styles[ 'relative-col' ] }>
 					<CloseLink

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -10,7 +10,6 @@ import {
 	Notice,
 	useBreakpointMatch,
 } from '@automattic/jetpack-components';
-import { shouldUseInternalLinks } from '@automattic/jetpack-shared-extension-utils';
 import { __, _x } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useContext, useEffect, useLayoutEffect, useRef, useState } from 'react';
@@ -182,7 +181,6 @@ export default function MyJetpackScreen() {
 			apiNonce={ apiNonce }
 			title="Jetpack"
 			optionalMenuItems={ isDevVersion && userIsAdmin ? [ resetOptionsMenuItem ] : [] }
-			useInternalLinks={ shouldUseInternalLinks() }
 			className={ styles[ 'my-jetpack-screen' ] }
 			showBottomBorder={ false }
 		>

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -10,7 +10,7 @@ import {
 	Notice,
 	useBreakpointMatch,
 } from '@automattic/jetpack-components';
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useContext, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router';
@@ -162,12 +162,7 @@ export default function MyJetpackScreen() {
 	}
 
 	const resetOptionsMenuItem = {
-		label: _x(
-			'Reset Options (dev only)',
-			'Button for option to reset Jetpack Options',
-			'jetpack-my-jetpack'
-		),
-		title: __( 'Reset Options', 'jetpack-my-jetpack' ),
+		label: 'Reset options (devs)',
 		role: 'button',
 		onClick: () => resetJetpackOptions(),
 		onKeyDown: e => onKeyDownCallback( e, () => resetJetpackOptions() ),

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/more-requests.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/more-requests.jsx
@@ -10,7 +10,6 @@ import {
 	H3,
 	getRedirectUrl,
 } from '@automattic/jetpack-components';
-import { shouldUseInternalLinks } from '@automattic/jetpack-shared-extension-utils';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useCallback } from 'react';
@@ -43,11 +42,7 @@ export function JetpackAIInterstitialMoreRequests( { onClickGoBack = () => {} } 
 	}, [ recordEvent ] );
 
 	return (
-		<AdminPage
-			showHeader={ false }
-			showBackground={ false }
-			useInternalLinks={ shouldUseInternalLinks() }
-		>
+		<AdminPage showHeader={ false } showBackground={ false }>
 			<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
 				<Col className={ styles[ 'product-interstitial__header' ] }>
 					<GoBackLink onClick={ onClickGoBack } reload={ false } />

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -10,7 +10,6 @@ import {
 	getRedirectUrl,
 	Notice,
 } from '@automattic/jetpack-components';
-import { shouldUseInternalLinks } from '@automattic/jetpack-shared-extension-utils';
 import { Button, Card, ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
@@ -211,11 +210,7 @@ export default function () {
 	);
 
 	return (
-		<AdminPage
-			showHeader={ false }
-			showBackground={ true }
-			useInternalLinks={ shouldUseInternalLinks() }
-		>
+		<AdminPage showHeader={ false } showBackground={ true }>
 			<Container fluid horizontalSpacing={ 3 } horizontalGap={ 2 }>
 				<Col className={ clsx( styles[ 'product-interstitial__section' ] ) }>
 					<div className={ styles[ 'product-interstitial__section-wrapper-wide' ] }>

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/pricing-interstitial.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/pricing-interstitial.jsx
@@ -15,7 +15,6 @@ import {
 } from '@automattic/jetpack-components';
 import { useProductCheckoutWorkflow } from '@automattic/jetpack-connection';
 import { getScriptData, getMyJetpackUrl } from '@automattic/jetpack-script-data';
-import { shouldUseInternalLinks } from '@automattic/jetpack-shared-extension-utils';
 import { Spinner } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -381,11 +380,7 @@ export default function PricingInterstitial( { slug } ) {
 	const currencyCode = productPricing?.currencyCode || bundlePricing?.currencyCode || 'USD';
 
 	return (
-		<AdminPage
-			showHeader={ false }
-			showBackground={ false }
-			useInternalLinks={ shouldUseInternalLinks() }
-		>
+		<AdminPage showHeader={ false } showBackground={ false }>
 			<Container
 				className={ styles.interstitialContainer }
 				horizontalSpacing={ 3 }

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/product-interstitial.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/product-interstitial.jsx
@@ -10,7 +10,6 @@ import {
 	TermsOfService,
 } from '@automattic/jetpack-components';
 import { getMyJetpackUrl } from '@automattic/jetpack-script-data';
-import { shouldUseInternalLinks } from '@automattic/jetpack-shared-extension-utils';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import clsx from 'clsx';
@@ -202,11 +201,7 @@ export default function ProductInterstitial( {
 	);
 
 	return (
-		<AdminPage
-			showHeader={ false }
-			showBackground={ false }
-			useInternalLinks={ shouldUseInternalLinks() }
-		>
+		<AdminPage showHeader={ false } showBackground={ false }>
 			<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
 				<Col className={ styles[ 'product-interstitial__header' ] }>
 					<GoBackLink onClick={ onClickGoBack } />

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/protect/product-page.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/protect/product-page.tsx
@@ -8,7 +8,6 @@ import {
 	JetpackLogo,
 	getRedirectUrl,
 } from '@automattic/jetpack-components';
-import { shouldUseInternalLinks } from '@automattic/jetpack-shared-extension-utils';
 import { formatNumberCompact } from '@automattic/number-formatters';
 import { Button, Card, ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -88,11 +87,7 @@ export default function ProtectProductPage() {
 	const securityFeaturesUrl = getRedirectUrl( 'jetpack-security' );
 
 	return (
-		<AdminPage
-			showHeader={ false }
-			showBackground={ true }
-			useInternalLinks={ shouldUseInternalLinks() }
-		>
+		<AdminPage showHeader={ false } showBackground={ true }>
 			<Container fluid horizontalSpacing={ 3 } horizontalGap={ 2 }>
 				{ /* Header Section */ }
 				<Col className={ clsx( styles[ 'product-interstitial__section' ] ) }>

--- a/projects/packages/my-jetpack/_inc/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/style.module.scss
@@ -17,10 +17,6 @@
 		--wp-admin-theme-color-darker-20: var(--jp-black-80);
 		height: 100%;
 
-		.jp-dashboard-footer__jetpack-symbol {
-			height: 16px;
-		}
-
 		&:has(.my-jetpack-deprecate-notice-title) {
 
 			.jetpack-deprecation-notice-link {

--- a/projects/packages/my-jetpack/changelog/pr-47840
+++ b/projects/packages/my-jetpack/changelog/pr-47840
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update admin page footer design.

--- a/projects/packages/my-jetpack/webpack.config.js
+++ b/projects/packages/my-jetpack/webpack.config.js
@@ -34,19 +34,8 @@ module.exports = [
 					includeNodeModules: [ '@automattic/jetpack-' ],
 				} ),
 
-				// Add textdomains (but no other optimizations) for @wordpress/dataviews.
-				jetpackWebpackConfig.TranspileRule( {
-					includeNodeModules: [ '@wordpress/dataviews/' ],
-					babelOpts: {
-						configFile: false,
-						plugins: [
-							[
-								require.resolve( '@automattic/babel-plugin-replace-textdomain' ),
-								{ textdomain: 'jetpack-my-jetpack' },
-							],
-						],
-					},
-				} ),
+				// Workarounds for non-extracted `@wordpress/*` packages.
+				...jetpackWebpackConfig.BundledWpPkgsTranspileRules(),
 
 				// Handle CSS.
 				jetpackWebpackConfig.CssRule( {

--- a/projects/packages/my-jetpack/webpack.config.js
+++ b/projects/packages/my-jetpack/webpack.config.js
@@ -34,9 +34,9 @@ module.exports = [
 					includeNodeModules: [ '@automattic/jetpack-' ],
 				} ),
 
-				// Add textdomains (but no other optimizations) for @wordpress/dataviews and @wordpress/ui.
+				// Add textdomains (but no other optimizations) for @wordpress/dataviews.
 				jetpackWebpackConfig.TranspileRule( {
-					includeNodeModules: [ '@wordpress/dataviews/', '@wordpress/ui' ],
+					includeNodeModules: [ '@wordpress/dataviews/' ],
 					babelOpts: {
 						configFile: false,
 						plugins: [

--- a/projects/packages/my-jetpack/webpack.config.js
+++ b/projects/packages/my-jetpack/webpack.config.js
@@ -34,9 +34,9 @@ module.exports = [
 					includeNodeModules: [ '@automattic/jetpack-' ],
 				} ),
 
-				// Add textdomains (but no other optimizations) for @wordpress/dataviews.
+				// Add textdomains (but no other optimizations) for @wordpress/dataviews and @wordpress/ui.
 				jetpackWebpackConfig.TranspileRule( {
-					includeNodeModules: [ '@wordpress/dataviews/' ],
+					includeNodeModules: [ '@wordpress/dataviews/', '@wordpress/ui' ],
 					babelOpts: {
 						configFile: false,
 						plugins: [

--- a/projects/packages/newsletter/changelog/update-footer
+++ b/projects/packages/newsletter/changelog/update-footer
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use new `BundledWpPkgsTranspileRules` from webpack-config to centralize the hacks needed for non-extracted `@wordpress/*` packages.
+
+

--- a/projects/packages/newsletter/webpack.config.js
+++ b/projects/packages/newsletter/webpack.config.js
@@ -2,31 +2,10 @@
  * Builds the newsletter JS bundle.
  */
 
-import { createRequire } from 'module';
 import path from 'path';
 import jetpackWebpackConfig from '@automattic/jetpack-webpack-config/webpack';
 
 const __dirname = import.meta.dirname;
-const require = createRequire( import.meta.url );
-
-/**
- * Generate i18n function variants for `@automattic/babel-plugin-replace-textdomain`.
- *
- * The `@wordpress/dataviews` currently uses the i18n functions under a variety of aliases,
- * which makes it a pain to add the proper textdomain. This function generates an object
- * with the base function and 99 more variants as keys.
- *
- * @param {string} baseFn - Base function name (e.g., '__', '_x', '_n')
- * @param {number} value  - Textdomain argument position (1-based index)
- * @return {object} Object mapping function names to textdomain positions
- */
-const generateI18nVariants = ( baseFn, value ) =>
-	Object.fromEntries(
-		Array.from( { length: 100 }, ( _, i ) => [
-			`${ baseFn }${ i || '' }`, // empty suffix for 0
-			value,
-		] )
-	);
 
 export default {
 	mode: jetpackWebpackConfig.mode,
@@ -67,35 +46,8 @@ export default {
 				includeNodeModules: [ '@automattic/', 'debug/' ],
 			} ),
 
-			/**
-			 * Transpile `@wordpress/dataviews` in node_modules too.
-			 *
-			 * Uses configFile: false to avoid inheriting babel.config.js, and
-			 * manually applies textdomain replacement with i18n function variants
-			 * to handle the aliased function names (e.g. __1, _x2) in the
-			 * dataviews build-wp bundle.
-			 *
-			 * @see https://github.com/Automattic/jetpack/issues/39907
-			 */
-			jetpackWebpackConfig.TranspileRule( {
-				includeNodeModules: [ '@wordpress/dataviews/build-wp/' ],
-				babelOpts: {
-					configFile: false,
-					plugins: [
-						[
-							require.resolve( '@automattic/babel-plugin-replace-textdomain' ),
-							{
-								textdomain: 'jetpack-newsletter',
-								functions: {
-									...generateI18nVariants( '__', 1 ),
-									...generateI18nVariants( '_x', 2 ),
-									...generateI18nVariants( '_n', 3 ),
-								},
-							},
-						],
-					],
-				},
-			} ),
+			// Workarounds for non-extracted `@wordpress/*` packages.
+			...jetpackWebpackConfig.BundledWpPkgsTranspileRules(),
 
 			// Handle CSS.
 			jetpackWebpackConfig.CssRule( {

--- a/projects/packages/publicize/_inc/components/admin-page/index.tsx
+++ b/projects/packages/publicize/_inc/components/admin-page/index.tsx
@@ -60,18 +60,13 @@ export const SocialAdminPage = () => {
 		};
 	}, [] );
 
-	const { social, jetpack } = getSocialScriptData().plugin_info;
-
-	const moduleName = social.version
-		? `Jetpack Social ${ social.version }`
-		: `Jetpack ${ jetpack.version }`;
+	const { social } = getSocialScriptData().plugin_info;
 
 	const canManageOptions = currentUserCan( 'manage_options' );
 
 	if ( showConnectionCard ) {
 		return (
 			<AdminPage
-				moduleName={ moduleName }
 				title={ 'Social' /** "Social" is a product name, do not translate. */ }
 				subTitle={ __( 'Publish once. Share everywhere.', 'jetpack-publicize-pkg' ) }
 				showBackground={ false }
@@ -96,7 +91,6 @@ export const SocialAdminPage = () => {
 
 	return (
 		<AdminPage
-			moduleName={ moduleName }
 			title={ 'Social' /** "Social" is a product name, do not translate. */ }
 			subTitle={ subTitle }
 			actions={ licenseAction }

--- a/projects/packages/publicize/_inc/components/admin-page/index.tsx
+++ b/projects/packages/publicize/_inc/components/admin-page/index.tsx
@@ -18,7 +18,6 @@ import {
 	siteHasFeature,
 	currentUserCan,
 } from '@automattic/jetpack-script-data';
-import { shouldUseInternalLinks } from '@automattic/jetpack-shared-extension-utils';
 import { Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useState, useCallback } from '@wordpress/element';
@@ -70,7 +69,6 @@ export const SocialAdminPage = () => {
 				title={ 'Social' /** "Social" is a product name, do not translate. */ }
 				subTitle={ __( 'Publish once. Share everywhere.', 'jetpack-publicize-pkg' ) }
 				showBackground={ false }
-				useInternalLinks={ shouldUseInternalLinks() }
 			>
 				<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
 					<Col>
@@ -95,7 +93,6 @@ export const SocialAdminPage = () => {
 			subTitle={ subTitle }
 			actions={ licenseAction }
 			showFooter={ isJetpackSite }
-			useInternalLinks={ shouldUseInternalLinks() }
 		>
 			<GlobalNotices />
 			{ isJetpackSite && ! hasSocialPaidFeatures() && showPricingPage && ! pricingPageDismissed ? (

--- a/projects/packages/publicize/_inc/components/admin-page/test/index.test.jsx
+++ b/projects/packages/publicize/_inc/components/admin-page/test/index.test.jsx
@@ -3,14 +3,12 @@ import { clearMockedScriptData, mockScriptData } from '../../../utils/test-utils
 import { SocialAdminPage } from '../index';
 
 describe( 'load the app', () => {
-	const version = '99.9';
-
 	beforeEach( () => {
 		mockScriptData( {
 			social: {
 				plugin_info: {
 					social: {
-						version,
+						version: '99.9',
 					},
 				},
 			},
@@ -23,6 +21,6 @@ describe( 'load the app', () => {
 
 	test( 'container renders', () => {
 		render( <SocialAdminPage /> );
-		expect( screen.getByText( `Jetpack Social ${ version }` ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Jetpack' ) ).toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/publicize/changelog/pr-47840
+++ b/projects/packages/publicize/changelog/pr-47840
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update admin page footer design.

--- a/projects/packages/publicize/webpack.config.js
+++ b/projects/packages/publicize/webpack.config.js
@@ -29,19 +29,8 @@ const socialWebpackConfig = {
 				includeNodeModules: [ '@automattic/jetpack-' ],
 			} ),
 
-			// Add textdomains (but no other optimizations) for @wordpress/dataviews and its dependencies.
-			jetpackWebpackConfig.TranspileRule( {
-				includeNodeModules: [ '@wordpress/dataviews/', '@wordpress/ui' ],
-				babelOpts: {
-					configFile: false,
-					plugins: [
-						[
-							require.resolve( '@automattic/babel-plugin-replace-textdomain' ),
-							{ textdomain: 'jetpack-publicize-pkg' },
-						],
-					],
-				},
-			} ),
+			// Workarounds for non-extracted `@wordpress/*` packages.
+			...jetpackWebpackConfig.BundledWpPkgsTranspileRules(),
 
 			// Handle CSS.
 			jetpackWebpackConfig.CssRule( {

--- a/projects/packages/search/changelog/pr-47840
+++ b/projects/packages/search/changelog/pr-47840
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update admin page footer design.

--- a/projects/packages/search/src/dashboard/components/dashboard/wrapped-dashboard.jsx
+++ b/projects/packages/search/src/dashboard/components/dashboard/wrapped-dashboard.jsx
@@ -1,6 +1,5 @@
 import analytics from '@automattic/jetpack-analytics';
 import restApi from '@automattic/jetpack-api';
-import { shouldUseInternalLinks } from '@automattic/jetpack-shared-extension-utils';
 import { useSelect, select as syncSelect } from '@wordpress/data';
 import { useMemo } from 'react';
 import SearchConnectionPage from 'components/pages/connection-page';
@@ -84,12 +83,7 @@ function AfterConnectionPage() {
 
 	return (
 		<>
-			{ supportsSearch && (
-				<SearchDashboardPage
-					isLoading={ isPageLoading }
-					useInternalLinks={ shouldUseInternalLinks() }
-				/>
-			) }
+			{ supportsSearch && <SearchDashboardPage isLoading={ isPageLoading } /> }
 			{ ! supportsSearch && <UpsellPage isLoading={ isPageLoading } /> }
 		</>
 	);

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -7,7 +7,6 @@ import {
 	getProductCheckoutUrl,
 } from '@automattic/jetpack-components';
 import { useConnectionErrorNotice, ConnectionError } from '@automattic/jetpack-connection';
-import { shouldUseInternalLinks } from '@automattic/jetpack-shared-extension-utils';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import NoticesList from 'components/global-notices';
@@ -265,10 +264,7 @@ const Footer = () => {
 	return (
 		<div className="jp-search-dashboard-footer jp-search-dashboard-wrap">
 			<div className="jp-search-dashboard-row">
-				<JetpackFooter
-					className="lg-col-span-12 md-col-span-8 sm-col-span-4"
-					useInternalLinks={ shouldUseInternalLinks() }
-				/>
+				<JetpackFooter className="lg-col-span-12 md-col-span-8 sm-col-span-4" />
 			</div>
 		</div>
 	);

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -186,7 +186,7 @@ export default function DashboardPage( { isLoading = false } ) {
 								isTogglingInstantSearch={ isTogglingInstantSearch }
 							/>
 						</div>
-						<Footer />
+						<JetpackFooter />
 						<NoticesList
 							notices={ notices }
 							handleLocalNoticeDismissClick={ handleLocalNoticeDismissClick }
@@ -257,15 +257,5 @@ const MockedSearchContent = ( { supportsInstantSearch, supportsOnlyClassicSearch
 				</div>
 			</div>
 		</>
-	);
-};
-
-const Footer = () => {
-	return (
-		<div className="jp-search-dashboard-footer jp-search-dashboard-wrap">
-			<div className="jp-search-dashboard-row">
-				<JetpackFooter className="lg-col-span-12 md-col-span-8 sm-col-span-4" />
-			</div>
-		</div>
 	);
 };

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.scss
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.scss
@@ -53,12 +53,7 @@
 
 	.jp-search-dashboard-bottom {
 		background-color: variables.$white;
-	}
-
-	.jp-search-dashboard-footer {
-		padding: 2.5em 0;
-
-		background-color: variables.$white;
+		padding-bottom: 2.5em;
 	}
 }
 

--- a/projects/packages/search/src/dashboard/components/pages/upsell-page/index.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/upsell-page/index.jsx
@@ -16,7 +16,6 @@ import {
 	ThemeProvider,
 } from '@automattic/jetpack-components';
 import { ConnectionError, useConnectionErrorNotice } from '@automattic/jetpack-connection';
-import { shouldUseInternalLinks } from '@automattic/jetpack-shared-extension-utils';
 import { formatNumberCompact } from '@automattic/number-formatters';
 import { Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -108,7 +107,6 @@ export default function UpsellPage( { isLoading = false } ) {
 							</Button>
 						)
 					}
-					useInternalLinks={ shouldUseInternalLinks() }
 				>
 					<AdminSectionHero>
 						{ isNewPricing ? (

--- a/projects/packages/search/src/dashboard/components/pages/upsell-page/index.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/upsell-page/index.jsx
@@ -31,8 +31,6 @@ import { STORE_ID } from 'store';
 
 import './styles.scss';
 
-const JETPACK_SEARCH__LINK = 'https://jetpack.com/upgrade/search';
-
 /**
  * defines UpsellPage.
  *
@@ -110,7 +108,6 @@ export default function UpsellPage( { isLoading = false } ) {
 							</Button>
 						)
 					}
-					moduleNameHref={ JETPACK_SEARCH__LINK }
 					useInternalLinks={ shouldUseInternalLinks() }
 				>
 					<AdminSectionHero>

--- a/projects/packages/search/tools/webpack.dashboard.config.js
+++ b/projects/packages/search/tools/webpack.dashboard.config.js
@@ -57,6 +57,9 @@ module.exports = {
 				includeNodeModules: [ '@automattic/jetpack-' ],
 			} ),
 
+			// Workarounds for non-extracted `@wordpress/*` packages.
+			...jetpackWebpackConfig.BundledWpPkgsTranspileRules(),
+
 			// Handle CSS.
 			jetpackWebpackConfig.CssRule( {
 				extensions: [ 'css', 'sass', 'scss' ],

--- a/projects/packages/subscribers-dashboard/changelog/update-footer
+++ b/projects/packages/subscribers-dashboard/changelog/update-footer
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use new `BundledWpPkgsTranspileRules` from webpack-config to centralize the hacks needed for non-extracted `@wordpress/*` packages.
+
+

--- a/projects/packages/subscribers-dashboard/webpack.config.js
+++ b/projects/packages/subscribers-dashboard/webpack.config.js
@@ -31,33 +31,8 @@ module.exports = [
 					includeNodeModules: [ '@automattic/' ],
 				} ),
 
-				// Add textdomains (but no other optimizations) for @wordpress/dataviews.
-				jetpackWebpackConfig.TranspileRule( {
-					includeNodeModules: [ '@wordpress/dataviews/' ],
-					babelOpts: {
-						configFile: false,
-						plugins: [
-							[
-								require.resolve( '@automattic/babel-plugin-replace-textdomain' ),
-								{ textdomain: 'jetpack-subscribers-dashboard' },
-							],
-						],
-					},
-				} ),
-
-				// Add textdomains (but no other optimizations) for @wordpress/dataviews.
-				jetpackWebpackConfig.TranspileRule( {
-					includeNodeModules: [ '@wordpress/dataviews/build-wp/' ],
-					babelOpts: {
-						configFile: false,
-						plugins: [
-							[
-								require.resolve( '@automattic/babel-plugin-replace-textdomain' ),
-								{ textdomain: 'jetpack-subscribers-dashboard' },
-							],
-						],
-					},
-				} ),
+				// Workarounds for non-extracted `@wordpress/*` packages.
+				...jetpackWebpackConfig.BundledWpPkgsTranspileRules(),
 
 				// Handle CSS.
 				jetpackWebpackConfig.CssRule( {

--- a/projects/packages/videopress/changelog/pr-47840
+++ b/projects/packages/videopress/changelog/pr-47840
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update admin page footer design.

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -17,7 +17,6 @@ import {
 	useConnectionErrorNotice,
 	ConnectionError,
 } from '@automattic/jetpack-connection';
-import { shouldUseInternalLinks } from '@automattic/jetpack-shared-extension-utils';
 import { FormFileUpload } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -194,7 +193,6 @@ const Admin = () => {
 		<AdminPage
 			title={ 'VideoPress' /** "VideoPress" is a product name, do not translate. */ }
 			subTitle={ __( 'Professional quality, ad-free video hosting.', 'jetpack-videopress-pkg' ) }
-			useInternalLinks={ shouldUseInternalLinks() }
 		>
 			<div
 				className={ clsx( styles[ 'files-overlay' ], {

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
@@ -7,7 +7,6 @@ import {
 	JetpackLogo,
 	LoadingPlaceholder,
 } from '@automattic/jetpack-components';
-import { shouldUseInternalLinks } from '@automattic/jetpack-shared-extension-utils';
 import {
 	Button,
 	SelectControl,
@@ -266,7 +265,6 @@ const EditVideoDetails = () => {
 				breadcrumbs={ breadcrumbs }
 				subTitle={ __( 'Professional quality, ad-free video hosting.', 'jetpack-videopress-pkg' ) }
 				actions={ headerActions }
-				useInternalLinks={ shouldUseInternalLinks() }
 			>
 				<Container horizontalSpacing={ 0 }>
 					<Col>

--- a/projects/packages/videopress/webpack.config.js
+++ b/projects/packages/videopress/webpack.config.js
@@ -64,6 +64,9 @@ module.exports = [
 					includeNodeModules: [ '@automattic/jetpack-' ],
 				} ),
 
+				// Workarounds for non-extracted `@wordpress/*` packages.
+				...jetpackWebpackConfig.BundledWpPkgsTranspileRules(),
+
 				// Handle CSS.
 				jetpackWebpackConfig.CssRule( {
 					extensions: [ 'css', 'sass', 'scss' ],

--- a/projects/plugins/boost/changelog/update-footer
+++ b/projects/plugins/boost/changelog/update-footer
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Use new `BundledWpPkgsTranspileRules` from webpack-config to centralize the hacks needed for non-extracted `@wordpress/*` packages.
+
+

--- a/projects/plugins/boost/webpack.config.js
+++ b/projects/plugins/boost/webpack.config.js
@@ -96,6 +96,9 @@ module.exports = [
 					includeNodeModules: [ '@automattic/jetpack-' ],
 				} ),
 
+				// Workarounds for non-extracted `@wordpress/*` packages.
+				...jetpackWebpackConfig.BundledWpPkgsTranspileRules(),
+
 				// Handle CSS.
 				jetpackWebpackConfig.CssRule( {
 					extensions: [ 'css', 'sass', 'scss' ],

--- a/projects/plugins/classic-theme-helper-plugin/changelog/pr-47840
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/pr-47840
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update admin page footer design.

--- a/projects/plugins/classic-theme-helper-plugin/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/classic-theme-helper-plugin/src/js/components/admin-page/index.jsx
@@ -7,7 +7,6 @@ import {
 } from '@automattic/jetpack-components';
 import { ConnectScreenRequiredPlan } from '@automattic/jetpack-connection';
 import { getScriptData } from '@automattic/jetpack-script-data';
-import { shouldUseInternalLinks } from '@automattic/jetpack-shared-extension-utils';
 import { __ } from '@wordpress/i18n';
 import styles from './styles.module.scss';
 
@@ -16,7 +15,7 @@ const Admin = () => {
 	const { isUserConnected, isRegistered } = connectionStatus;
 	const showConnectionCard = ! isRegistered || ! isUserConnected;
 	return (
-		<AdminPage useInternalLinks={ shouldUseInternalLinks() }>
+		<AdminPage>
 			<AdminSectionHero>
 				{ showConnectionCard ? (
 					<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>

--- a/projects/plugins/classic-theme-helper-plugin/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/classic-theme-helper-plugin/src/js/components/admin-page/index.jsx
@@ -16,10 +16,7 @@ const Admin = () => {
 	const { isUserConnected, isRegistered } = connectionStatus;
 	const showConnectionCard = ! isRegistered || ! isUserConnected;
 	return (
-		<AdminPage
-			moduleName={ __( 'Jetpack Classic Theme Helper Plugin', 'classic-theme-helper-plugin' ) }
-			useInternalLinks={ shouldUseInternalLinks() }
-		>
+		<AdminPage useInternalLinks={ shouldUseInternalLinks() }>
 			<AdminSectionHero>
 				{ showConnectionCard ? (
 					<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>

--- a/projects/plugins/classic-theme-helper-plugin/webpack.config.js
+++ b/projects/plugins/classic-theme-helper-plugin/webpack.config.js
@@ -33,6 +33,9 @@ module.exports = [
 					includeNodeModules: [ '@automattic/jetpack-' ],
 				} ),
 
+				// Workarounds for non-extracted `@wordpress/*` packages.
+				...jetpackWebpackConfig.BundledWpPkgsTranspileRules(),
+
 				// Handle CSS.
 				jetpackWebpackConfig.CssRule( {
 					extensions: [ 'css', 'sass', 'scss' ],

--- a/projects/plugins/crm/changelog/update-footer
+++ b/projects/plugins/crm/changelog/update-footer
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use new `BundledWpPkgsTranspileRules` from webpack-config to centralize the hacks needed for non-extracted `@wordpress/*` packages.
+
+

--- a/projects/plugins/crm/webpack.config.js
+++ b/projects/plugins/crm/webpack.config.js
@@ -281,6 +281,9 @@ module.exports = [
 			rules: [
 				...crmWebpackConfig.module.rules,
 
+				// Workarounds for non-extracted `@wordpress/*` packages.
+				...jetpackWebpackConfig.BundledWpPkgsTranspileRules(),
+
 				// Handle CSS.
 				jetpackWebpackConfig.CssRule( {
 					extensions: [ 'css', 'sass', 'scss' ],

--- a/projects/plugins/jetpack/_inc/client/components/footer/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/footer/index.jsx
@@ -145,7 +145,6 @@ export class Footer extends Component {
 					<div className="jp-footer__container">
 						<JetpackFooter
 							menu={ menu }
-							moduleNameHref={ getRedirectUrl( 'jetpack' ) }
 							onAboutClick={ this.trackAboutClick }
 							onPrivacyClick={ this.trackPrivacyClick }
 							onTermsClick={ this.trackTermsClick }

--- a/projects/plugins/jetpack/_inc/client/components/footer/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/footer/index.jsx
@@ -15,14 +15,6 @@ import {
 } from 'state/initial-state';
 import onKeyDownCallback from 'utils/onkeydown-callback';
 
-const smoothScroll = () => {
-	const jpContentY = document.getElementById( 'jp-navigation' ).offsetTop;
-	window.scrollTo( 0, window.scrollY - jpContentY / 1.5 );
-	if ( window.scrollY > jpContentY ) {
-		window.requestAnimationFrame( smoothScroll );
-	}
-};
-
 export class Footer extends Component {
 	static displayName = 'Footer';
 
@@ -37,21 +29,6 @@ export class Footer extends Component {
 		analytics.tracks.recordJetpackClick( {
 			target: 'footer_link',
 			link: 'version',
-		} );
-	};
-
-	trackTermsClick = () => {
-		analytics.tracks.recordJetpackClick( {
-			target: 'footer_link',
-			link: 'terms',
-		} );
-	};
-
-	trackPrivacyClick = () => {
-		window.requestAnimationFrame( smoothScroll );
-		analytics.tracks.recordJetpackClick( {
-			target: 'footer_link',
-			link: 'privacy',
 		} );
 	};
 
@@ -136,12 +113,7 @@ export class Footer extends Component {
 			<ThemeProvider>
 				<div className={ clsx( 'jp-footer', classes ) }>
 					<div className="jp-footer__container">
-						<JetpackFooter
-							menu={ menu }
-							onPrivacyClick={ this.trackPrivacyClick }
-							onTermsClick={ this.trackTermsClick }
-							useInternalLinks={ this.props.siteConnectionStatus }
-						/>
+						<JetpackFooter menu={ menu } />
 					</div>
 					{ this.props.isDevVersion && this.props.displayDevCard && <DevCard /> }
 				</div>

--- a/projects/plugins/jetpack/_inc/client/components/footer/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/footer/index.jsx
@@ -47,13 +47,6 @@ export class Footer extends Component {
 		} );
 	};
 
-	trackAboutClick = () => {
-		analytics.tracks.recordJetpackClick( {
-			target: 'footer_link',
-			link: 'about',
-		} );
-	};
-
 	trackPrivacyClick = () => {
 		window.requestAnimationFrame( smoothScroll );
 		analytics.tracks.recordJetpackClick( {
@@ -145,7 +138,6 @@ export class Footer extends Component {
 					<div className="jp-footer__container">
 						<JetpackFooter
 							menu={ menu }
-							onAboutClick={ this.trackAboutClick }
 							onPrivacyClick={ this.trackPrivacyClick }
 							onTermsClick={ this.trackTermsClick }
 							useInternalLinks={ this.props.siteConnectionStatus }

--- a/projects/plugins/jetpack/_inc/client/components/settings-admin-page/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-admin-page/index.jsx
@@ -105,16 +105,7 @@ function buildFooterMenuItems( props ) {
 }
 
 const SettingsAdminPage = props => {
-	const {
-		apiRoot,
-		apiNonce,
-		isDevVersion,
-		displayDevCard,
-		siteConnectionStatus,
-		location,
-		tabs,
-		children,
-	} = props;
+	const { apiRoot, apiNonce, isDevVersion, displayDevCard, location, tabs, children } = props;
 
 	const footerMenuItems = buildFooterMenuItems( props );
 
@@ -128,7 +119,6 @@ const SettingsAdminPage = props => {
 				showBackground={ true }
 				tabs={ tabs }
 				optionalMenuItems={ footerMenuItems }
-				useInternalLinks={ !! siteConnectionStatus }
 				actions={ isWoASite() && <HeaderNav location={ location } /> }
 			>
 				{ children }

--- a/projects/plugins/jetpack/_inc/client/components/settings-admin-page/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-admin-page/index.jsx
@@ -1,10 +1,8 @@
-import { AdminPage, getRedirectUrl } from '@automattic/jetpack-components';
-import { isJetpackSelfHostedSite, isWoASite } from '@automattic/jetpack-script-data';
-import { __, _x, sprintf } from '@wordpress/i18n';
+import { AdminPage } from '@automattic/jetpack-components';
+import { isWoASite } from '@automattic/jetpack-script-data';
+import { __ } from '@wordpress/i18n';
 import { connect } from 'react-redux';
 import DevCard from 'components/dev-card';
-import analytics from 'lib/analytics';
-import { getSiteConnectionStatus } from 'state/connection';
 import { canDisplayDevCard, enableDevCard, resetOptions } from 'state/dev-version';
 import {
 	isDevVersion as _isDevVersion,
@@ -24,68 +22,13 @@ import { HeaderNav } from '../masthead/header-nav';
  * @return {Array} Footer menu items.
  */
 function buildFooterMenuItems( props ) {
-	const { currentVersion, isDevVersion, siteAdminUrl, siteConnectionStatus, canManageOptions } =
-		props;
+	const { isDevVersion, canManageOptions } = props;
 
 	const menu = [];
 
-	if ( isJetpackSelfHostedSite() ) {
-		menu.push( {
-			label: sprintf(
-				/* Translators: %s: a version number. */
-				__( 'Version %s', 'jetpack' ),
-				currentVersion
-			),
-			href: getRedirectUrl( 'jetpack' ),
-			target: '_blank',
-			onClick: () => {
-				analytics.tracks.recordJetpackClick( {
-					target: 'footer_link',
-					link: 'version',
-				} );
-			},
-		} );
-	}
-
-	if ( siteConnectionStatus && canManageOptions ) {
-		menu.push( {
-			label: _x(
-				'Modules',
-				'Navigation item. Noun. Links to a list of modules for Jetpack.',
-				'jetpack'
-			),
-			title: __( 'Access the full list of Jetpack modules available on your site.', 'jetpack' ),
-			href: siteAdminUrl + 'admin.php?page=jetpack_modules',
-			onClick: () => {
-				analytics.tracks.recordJetpackClick( {
-					target: 'footer_link',
-					link: 'modules',
-				} );
-			},
-		} );
-	}
-
-	if ( canManageOptions ) {
-		menu.push( {
-			label: _x(
-				'Debug',
-				'Navigation item. Noun. Links to a debugger tool for Jetpack.',
-				'jetpack'
-			),
-			title: __( "Test your site's compatibility with Jetpack.", 'jetpack' ),
-			href: siteAdminUrl + 'admin.php?page=jetpack-debugger',
-			onClick: () => {
-				analytics.tracks.recordJetpackClick( {
-					target: 'footer_link',
-					link: 'debug',
-				} );
-			},
-		} );
-	}
-
 	if ( isDevVersion && canManageOptions ) {
 		menu.push( {
-			label: _x( 'Reset Options (dev only)', 'Navigation item.', 'jetpack' ),
+			label: 'Reset options (devs)',
 			role: 'button',
 			onKeyDown: onKeyDownCallback( props.doResetOptions ),
 			onClick: props.doResetOptions,
@@ -94,7 +37,7 @@ function buildFooterMenuItems( props ) {
 
 	if ( isDevVersion ) {
 		menu.push( {
-			label: _x( 'Dev Tools', 'Navigation item.', 'jetpack' ),
+			label: 'Tools (devs)',
 			role: 'button',
 			onKeyDown: onKeyDownCallback( props.doEnableDevCard ),
 			onClick: props.doEnableDevCard,
@@ -137,7 +80,6 @@ export default connect(
 		displayDevCard: canDisplayDevCard( state ),
 		canManageOptions: userCanManageOptions( state ),
 		siteAdminUrl: getSiteAdminUrl( state ),
-		siteConnectionStatus: getSiteConnectionStatus( state ),
 	} ),
 	dispatch => ( {
 		doResetOptions: () => {

--- a/projects/plugins/jetpack/_inc/client/components/settings-admin-page/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-admin-page/index.jsx
@@ -128,7 +128,6 @@ const SettingsAdminPage = props => {
 				showBackground={ true }
 				tabs={ tabs }
 				optionalMenuItems={ footerMenuItems }
-				moduleNameHref={ getRedirectUrl( 'jetpack' ) }
 				useInternalLinks={ !! siteConnectionStatus }
 				actions={ isWoASite() && <HeaderNav location={ location } /> }
 			>

--- a/projects/plugins/jetpack/changelog/pr-47840
+++ b/projects/plugins/jetpack/changelog/pr-47840
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Update admin page footer with Products and Help navigation links, replacing About, Privacy, and Terms links.

--- a/projects/plugins/jetpack/tools/webpack.config.js
+++ b/projects/plugins/jetpack/tools/webpack.config.js
@@ -48,6 +48,9 @@ const sharedWebpackConfig = {
 				includeNodeModules: [ '@automattic/', 'debug/' ],
 			} ),
 
+			// Workarounds for non-extracted `@wordpress/*` packages.
+			...jetpackWebpackConfig.BundledWpPkgsTranspileRules(),
+
 			// Handle CSS.
 			jetpackWebpackConfig.CssRule( {
 				extensions: [ 'css', 'sass', 'scss' ],

--- a/projects/plugins/protect/changelog/update-footer
+++ b/projects/plugins/protect/changelog/update-footer
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Use new `BundledWpPkgsTranspileRules` from webpack-config to centralize the hacks needed for non-extracted `@wordpress/*` packages.
+
+

--- a/projects/plugins/protect/webpack.config.js
+++ b/projects/plugins/protect/webpack.config.js
@@ -33,6 +33,9 @@ module.exports = [
 					includeNodeModules: [ '@automattic/jetpack-' ],
 				} ),
 
+				// Workarounds for non-extracted `@wordpress/*` packages.
+				...jetpackWebpackConfig.BundledWpPkgsTranspileRules(),
+
 				// Handle CSS.
 				jetpackWebpackConfig.CssRule( {
 					extensions: [ 'css', 'sass', 'scss' ],

--- a/projects/plugins/search/changelog/pr-47840
+++ b/projects/plugins/search/changelog/pr-47840
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Update e2e test selector for renamed footer CSS class.

--- a/projects/plugins/search/tests/e2e/specs/search-dashboard.test.ts
+++ b/projects/plugins/search/tests/e2e/specs/search-dashboard.test.ts
@@ -64,10 +64,7 @@ test.describe( 'Search Dashboard', () => {
 				'Jetpack header logo should be visible'
 			).toBeVisible();
 
-			await expect(
-				page.locator( '.jp-dashboard-footer' ),
-				'Footer should be visible'
-			).toBeVisible();
+			await expect( page.locator( '.jetpack-footer' ), 'Footer should be visible' ).toBeVisible();
 
 			await expect( customizeButton, 'Customize button should be visible' ).toBeVisible();
 

--- a/projects/plugins/starter-plugin/changelog/pr-47840
+++ b/projects/plugins/starter-plugin/changelog/pr-47840
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update admin page footer design.

--- a/projects/plugins/starter-plugin/changelog/update-footer
+++ b/projects/plugins/starter-plugin/changelog/update-footer
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use new `BundledWpPkgsTranspileRules` from webpack-config to centralize the hacks needed for non-extracted `@wordpress/*` packages.
+
+

--- a/projects/plugins/starter-plugin/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/starter-plugin/src/js/components/admin-page/index.jsx
@@ -19,10 +19,7 @@ const Admin = () => {
 	const showConnectionCard = ! isRegistered || ! isUserConnected;
 
 	return (
-		<AdminPage
-			moduleName={ __( 'Jetpack Starter Plugin', 'jetpack-starter-plugin' ) }
-			useInternalLinks={ shouldUseInternalLinks() }
-		>
+		<AdminPage useInternalLinks={ shouldUseInternalLinks() }>
 			<AdminSectionHero>
 				{ showConnectionCard ? (
 					<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>

--- a/projects/plugins/starter-plugin/src/js/components/admin-page/index.jsx
+++ b/projects/plugins/starter-plugin/src/js/components/admin-page/index.jsx
@@ -6,7 +6,6 @@ import {
 	PricingCard,
 } from '@automattic/jetpack-components';
 import { ConnectScreenRequiredPlan, CONNECTION_STORE_ID } from '@automattic/jetpack-connection';
-import { shouldUseInternalLinks } from '@automattic/jetpack-shared-extension-utils';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import styles from './styles.module.scss';
@@ -19,7 +18,7 @@ const Admin = () => {
 	const showConnectionCard = ! isRegistered || ! isUserConnected;
 
 	return (
-		<AdminPage useInternalLinks={ shouldUseInternalLinks() }>
+		<AdminPage>
 			<AdminSectionHero>
 				{ showConnectionCard ? (
 					<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>

--- a/projects/plugins/starter-plugin/src/js/components/admin-page/test/index.test.js
+++ b/projects/plugins/starter-plugin/src/js/components/admin-page/test/index.test.js
@@ -22,8 +22,8 @@ describe( 'Admin', () => {
 			.mockReturnValue( { isRegistered: false, isUserConnected: false } );
 
 		render( <Admin /> );
-		// Look for the link in the footer.
-		expect( screen.getByRole( 'link', { name: 'Jetpack Starter Plugin' } ) ).toBeInTheDocument();
+		// Look for the Jetpack text in the footer.
+		expect( screen.getByText( 'Jetpack' ) ).toBeInTheDocument();
 		expect(
 			screen.getByRole( 'heading', { name: 'Connection screen title' } )
 		).toBeInTheDocument();

--- a/projects/plugins/starter-plugin/webpack.config.js
+++ b/projects/plugins/starter-plugin/webpack.config.js
@@ -33,6 +33,9 @@ module.exports = [
 					includeNodeModules: [ '@automattic/jetpack-' ],
 				} ),
 
+				// Workarounds for non-extracted `@wordpress/*` packages.
+				...jetpackWebpackConfig.BundledWpPkgsTranspileRules(),
+
 				// Handle CSS.
 				jetpackWebpackConfig.CssRule( {
 					extensions: [ 'css', 'sass', 'scss' ],


### PR DESCRIPTION
Part of JETPACK-1391
Resolves JETPACK-1503

Design internal ref p1HpG7-xRc-p2

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Update Footer visually across most pages
  * Boost still uses [custom component](https://github.com/Automattic/jetpack/blob/0b469ee67d829a4e2e30becdf7e2127a556e3638/projects/plugins/boost/app/assets/src/js/layout/footer/footer.tsx); handled in a follow-up
  * Akismet, CRM, Stats, Blaze and WP.com Calypso pages such as Subscribers and Monetize are still separately handled as well.
* Update footer contents to be: Products & Help
   * Note: My Jetpack & Settings add a few dev-only links.
   * Settings had "Modules" and "Debug" links, which are now removed from footer but still available via "Help":
        <img width="170" height="136" alt="Screenshot 2026-03-30 at 16 58 28" src="https://github.com/user-attachments/assets/8f6fd560-f311-4eaa-853c-c96ead183684" />
* Removes About, TOS, and Privacy links and related props (`useInternalLinks`, `onAboutClick`, `onPrivacyClick`, `onTermsClick`) and their usage around Jetpack.
* Use new [components](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-introduction--docs) from `@wordpress/ui` and design tokens, which we bundle, so everything is backwards compatible with older WP versions.
* Does not show Products & Help links at WP.com sites since those pages are not yet available at WP.com.

### Before

#### Newsletter
<img width="1463" height="272" alt="image" src="https://github.com/user-attachments/assets/c443a9a5-baa6-418d-851a-91d7e55e6f3f" />

#### Social
<img width="1457" height="165" alt="image" src="https://github.com/user-attachments/assets/781045c6-fcc1-45cb-ae86-2bef46c4099f" />

#### Settings
<img width="1255" height="131" alt="image" src="https://github.com/user-attachments/assets/bf255bdc-2352-49a0-ba0d-995e5a149d39" />

#### My Jetpack
<img width="1256" height="121" alt="image" src="https://github.com/user-attachments/assets/a710e1c8-7200-4555-a4df-34e89c132a38" />

### Mobile
<img width="411" height="372" alt="image" src="https://github.com/user-attachments/assets/bcde1cc2-6d31-492a-8039-6bafdcb5a0e0" />


### After

#### Newsletter
<img width="1468" height="193" alt="image" src="https://github.com/user-attachments/assets/fb869264-9114-4d08-965a-b4694bae27db" />

#### Social
<img width="1459" height="99" alt="image" src="https://github.com/user-attachments/assets/7e908165-b36f-4c0a-b702-9195612c6a69" />

#### Settings
<img width="999" height="67" alt="image" src="https://github.com/user-attachments/assets/0385f867-f1e0-48d6-8098-649399c538e8" />

#### My Jetpack
<img width="1290" height="68" alt="image" src="https://github.com/user-attachments/assets/cd43068e-d95f-4af8-aaba-a342587c2af0" />

### Mobile
<img width="423" height="141" alt="image" src="https://github.com/user-attachments/assets/7f7cc590-0789-4c37-91a6-3e347c8e0a31" />

### Focus rings

<img width="284" height="60" alt="image" src="https://github.com/user-attachments/assets/4dea279a-7bf6-407b-8ed1-5cd94939d90b" />

<img width="243" height="70" alt="image" src="https://github.com/user-attachments/assets/908bf285-3219-4e91-94bb-553bfcf2027a" />



### Other information
<!-- Check the box below to generate a changelog entry. -->
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Click around different Jetpack pages and check the footer
* Test different media widths
* Test keyboard navigation
