### PR TITLE
Fix module name casing in module list

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-module-name-casing
+++ b/projects/plugins/jetpack/changelog/fix-module-name-casing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Modules list:  ensure capitalization is consistent.

--- a/projects/plugins/jetpack/changelog/fix-module-name-casing
+++ b/projects/plugins/jetpack/changelog/fix-module-name-casing
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Modules list:  ensure capitalization is consistent.
+Module list: Ensure capitalization is consistent.

--- a/projects/plugins/jetpack/modules/account-protection.php
+++ b/projects/plugins/jetpack/modules/account-protection.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Module Name: Account protection
+ * Module Name: Account Protection
  * Module Description: Shield your login page with rate‑limiting and secure authentication safeguards.
  * Sort Order: 4
  * First Introduced: 14.5

--- a/projects/plugins/jetpack/modules/custom-content-types.php
+++ b/projects/plugins/jetpack/modules/custom-content-types.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Module Name: Custom content types
+ * Module Name: Custom Content Types
  * Module Description: Display different types of content on your site with custom content types.
  * First Introduced: 3.1
  * Requires Connection: No

--- a/projects/plugins/jetpack/modules/post-by-email.php
+++ b/projects/plugins/jetpack/modules/post-by-email.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Module Name: Post by email
+ * Module Name: Post by Email
  * Module Description: Publish blog posts simply by sending an email to a custom address.
  * First Introduced: 2.0
  * Sort Order: 14

--- a/projects/plugins/jetpack/modules/protect.php
+++ b/projects/plugins/jetpack/modules/protect.php
@@ -1,6 +1,6 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 /**
- * Module Name: Brute force protection
+ * Module Name: Brute Force Protection
  * Module Description: Block malicious login attempts automatically and keep hackers out.
  * Sort Order: 1
  * Recommendation Order: 4

--- a/projects/plugins/jetpack/modules/related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts.php
@@ -1,6 +1,6 @@
 <?php //phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 /**
- * Module Name: Related posts
+ * Module Name: Related Posts
  * Module Description: Automatically display related articles to keep visitors reading longer.
  * First Introduced: 2.9
  * Sort Order: 29

--- a/projects/plugins/jetpack/modules/verification-tools.php
+++ b/projects/plugins/jetpack/modules/verification-tools.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Module Name: Site verification
+ * Module Name: Site Verification
  * Module Description: Verify your site with search engines and social platforms in a couple of clicks.
  * First Introduced: 3.0
  * Sort Order: 33

--- a/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_REST_API_Authentication_Test.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_REST_API_Authentication_Test.php
@@ -190,7 +190,7 @@ class Jetpack_REST_API_Authentication_Test extends Jetpack_REST_TestCase {
 		$response          = $this->server->dispatch( $this->request );
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data();
-		$this->assertEquals( 'Brute force protection', $data['name'] );
+		$this->assertEquals( 'Brute Force Protection', $data['name'] );
 		$this->assertEquals( self::$admin_id, get_current_user_id() );
 	}
 


### PR DESCRIPTION
Fixes MONOREP-401

## Proposed changes

* Applies consistent casing to module names, fixing an issue where some modules are formatted like "Beautiful Math" and others are "Account protection" and "Brute Force Protection". This ensures all follow the same labeling.

## Does this pull request change what data or activity we track or use?

No.


## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

1. Go to https://example.com/wp-admin/admin.php?page=jetpack_modules
2. See that module names don't follow consistent capitalization
3. Apply the PR and see that capitalization is consistent

**Before**:

<img width="1450" height="1047" alt="image" src="https://github.com/user-attachments/assets/efaf9b78-5171-48d2-b07f-b3fb247452f7" />

**After**:

<img width="1549" height="1165" alt="image" src="https://github.com/user-attachments/assets/d1fb6fe3-c0af-4e57-8023-5e816741b542" />


