### PR TITLE
Document PHP version test matrix in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,7 @@ jp test coverage <project>      # Generate coverage report (optional)
 ### PHP Testing
 
 - `jp test php` works for most projects. A few plugins that require a full WordPress copy (`plugins/jetpack`, `plugins/crm`, `plugins/wpcomsh`) use `jp docker phpunit` instead.
+- **PHP version matrix**: CI runs PHP tests against every supported version from 7.2 to 8.5 (see `.github/versions.sh` for current values). When fixing an issue on one PHP version, ensure the fix is compatible with all supported versions — don't use syntax or functions unavailable in PHP 7.2 unless the project's `composer.json` requires a higher minimum.
 - `jp test php` does not support passthrough options like `--filter`. To filter tests in Docker-based projects, use: `jp docker phpunit jetpack -- --filter=Jetpack_Sync_Post_Test` or `jp docker phpunit jetpack -- --group jetpack-sync`
 - PHP testing approaches vary by project:
   - Some packages use basic PHPUnit with `yoast/phpunit-polyfills` (no WordPress-specific testing)


### PR DESCRIPTION
## Proposed changes

* Add a bullet point to the PHP Testing section of AGENTS.md documenting the PHP version test matrix (7.2–8.5), pointing to `.github/versions.sh` as the source of truth, and reminding agents that fixes must be compatible across all supported versions.

### Other information

This is a documentation-only change to AGENTS.md. No changelog entry needed since AGENTS.md is outside `/projects`.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Review the added bullet point in the PHP Testing section of AGENTS.md for accuracy.
* Confirm the PHP version range (7.2–8.5) matches `.github/versions.sh`.