### PR TITLE
AGENTS.md: Fix outdated @wordpress/element import convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,7 @@ The `$$next-version$$` placeholder is automatically replaced with the correct ve
 ### JavaScript & React Standards
 
 - Write modern ES6+ code following WordPress JS standards
-- Use `@wordpress/element` instead of importing React directly
+- Importing from `react` directly is fine. `@wordpress/element` also works but is no longer required — follow the convention used in the package you're working in
 - Use WordPress data stores (`@wordpress/data`) for state management
 - Use `@wordpress/i18n` for translations with an appropriate unique text domain
 - Follow WordPress component lifecycle patterns and accessibility guidelines


### PR DESCRIPTION
## Proposed changes

* Update the React import guideline in AGENTS.md to reflect the current convention. The previous instruction to "Use `@wordpress/element` instead of importing React directly" is stale since October 2023, when the Gutenberg team resolved [WordPress/gutenberg#54074](https://github.com/WordPress/gutenberg/issues/54074) and updated the docs and wp-scripts to allow importing from `react` directly.
* The Jetpack codebase already imports from `react` extensively (e.g. `projects/packages/my-jetpack/_inc/**`). This was flagged by Copilot during the original AGENTS.md consolidation PR (#47190) but was not addressed.
* The new wording tells agents to import from `react` directly and follow whatever convention the package they're working in already uses.

### Other information
- [ ] Generate changelog entries for this PR
- [ ] peGwbA-4S1-p2

## Related product discussion/links
* WordPress/gutenberg#54074
* #47190 (Copilot review comment)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Docs only change to AGENTS.md. No code affected.
* Verify the diff updates line 91 to replace the `@wordpress/element` requirement with guidance to follow the existing convention in whatever package you're working in.