### PR TITLE
Fix conversion funnel chart color flickers on load

### DIFF
--- a/projects/js-packages/charts/changelog/charts-168-conversion-funnel-chart-color-flickers-on-story-load
+++ b/projects/js-packages/charts/changelog/charts-168-conversion-funnel-chart-color-flickers-on-story-load
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix conversion funnel chart color flicker on initial render by deferring CSS transitions until the color palette is resolved.

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
@@ -53,7 +53,10 @@
 	display: flex;
 	flex-direction: column;
 	height: 100%;
-	transition: all 0.3s ease;
+
+	&__animated {
+		transition: all 0.3s ease;
+	}
 
 	&.blurred {
 		opacity: 0.3;
@@ -95,8 +98,10 @@
 	border-radius: 4px;
 	position: relative;
 	cursor: pointer;
-	transition: all 0.2s ease;
 
+	&__animated {
+		transition: all 0.2s ease;
+	}
 
 	&.disabled {
 		cursor: pointer;
@@ -107,14 +112,17 @@
 	width: 100%;
 	min-height: 4px;
 	border-radius: 4px 4px 0 0;
-	transition: all 0.3s ease;
+
+	&__animated {
+		transition: all 0.3s ease;
+	}
 
 	&.selected {
 		box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
 		filter: brightness(1.1);
 	}
 
-	&--animated {
+	&__animated-entry {
 		transform-origin: bottom;
 		transform-box: fill-box;
 		transform: scaleY(0);

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
@@ -1,9 +1,18 @@
-.conversionFunnelChart {
+.conversion-funnel-chart {
 	font-family: var(--funnel-font-family, "SF Pro Text");
 
 	&.loading {
 		opacity: 0.6;
 		pointer-events: none;
+	}
+
+	&.animated {
+
+		.funnel-step,
+		.bar-container,
+		.funnel-bar {
+			transition: all 0.2s ease;
+		}
 	}
 }
 
@@ -54,9 +63,6 @@
 	flex-direction: column;
 	height: 100%;
 
-	&__animated {
-		transition: all 0.3s ease;
-	}
 
 	&.blurred {
 		opacity: 0.3;
@@ -99,9 +105,6 @@
 	position: relative;
 	cursor: pointer;
 
-	&__animated {
-		transition: all 0.2s ease;
-	}
 
 	&.disabled {
 		cursor: pointer;
@@ -113,9 +116,6 @@
 	min-height: 4px;
 	border-radius: 4px 4px 0 0;
 
-	&__animated {
-		transition: all 0.3s ease;
-	}
 
 	&.selected {
 		box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
@@ -6,14 +6,6 @@
 		pointer-events: none;
 	}
 
-	&.animated {
-
-		.funnel-step,
-		.bar-container,
-		.funnel-bar {
-			transition: all 0.2s ease;
-		}
-	}
 }
 
 .main-metric {
@@ -63,6 +55,9 @@
 	flex-direction: column;
 	height: 100%;
 
+	&--animated {
+		transition: all 0.2s ease;
+	}
 
 	&.blurred {
 		opacity: 0.3;
@@ -105,7 +100,6 @@
 	position: relative;
 	cursor: pointer;
 
-
 	&.disabled {
 		cursor: pointer;
 	}
@@ -116,13 +110,12 @@
 	min-height: 4px;
 	border-radius: 4px 4px 0 0;
 
-
 	&.selected {
 		box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
 		filter: brightness(1.1);
 	}
 
-	&__animated-entry {
+	&--animated-entry {
 		transform-origin: bottom;
 		transform-box: fill-box;
 		transform: scaleY(0);

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
@@ -5,7 +5,6 @@
 		opacity: 0.6;
 		pointer-events: none;
 	}
-
 }
 
 .main-metric {

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
@@ -55,7 +55,7 @@
 	height: 100%;
 
 	&--animated {
-		transition: all 0.3s ease;
+		transition: opacity 0.3s ease;
 	}
 
 	&.blurred {

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
@@ -114,7 +114,7 @@
 		filter: brightness(1.1);
 	}
 
-	&--animated-entry {
+	&--animated {
 		transform-origin: bottom;
 		transform-box: fill-box;
 		transform: scaleY(0);

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
@@ -55,7 +55,7 @@
 	height: 100%;
 
 	&--animated {
-		transition: all 0.2s ease;
+		transition: all 0.3s ease;
 	}
 
 	&.blurred {

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.tsx
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.tsx
@@ -52,7 +52,7 @@ const ConversionFunnelChartInternal: FC< ConversionFunnelChartProps > = ( {
 } ) => {
 	const chartId = useChartId( providedChartId );
 	const { conversionFunnelChart: conversionFunnelChartSettings } = useGlobalChartsTheme();
-	const { getElementStyles } = useGlobalChartsContext();
+	const { getElementStyles, isColorPaletteResolved } = useGlobalChartsContext();
 	const chartRef = useRef< HTMLDivElement >( null );
 	const selectedBarRef = useRef< HTMLDivElement | null >( null );
 
@@ -348,7 +348,11 @@ const ConversionFunnelChartInternal: FC< ConversionFunnelChartProps > = ( {
 						return (
 							<div
 								key={ step.id }
-								className={ clsx( styles[ 'funnel-step' ], isBlurred && styles.blurred ) }
+								className={ clsx(
+									styles[ 'funnel-step' ],
+									isColorPaletteResolved && styles[ 'funnel-step__animated' ],
+									isBlurred && styles.blurred
+								) }
 							>
 								{ /* Step Label and Rate */ }
 								<div className={ styles[ 'step-header' ] }>
@@ -376,7 +380,11 @@ const ConversionFunnelChartInternal: FC< ConversionFunnelChartProps > = ( {
 
 								{ /* Funnel Bar */ }
 								<div
-									className={ clsx( styles[ 'bar-container' ], isBlurred && styles.disabled ) }
+									className={ clsx(
+										styles[ 'bar-container' ],
+										isColorPaletteResolved && styles[ 'bar-container__animated' ],
+										isBlurred && styles.disabled
+									) }
 									onClick={ stepHandlers.get( step.id )?.onClick }
 									onKeyDown={ stepHandlers.get( step.id )?.onKeyDown }
 									role="button"
@@ -385,10 +393,14 @@ const ConversionFunnelChartInternal: FC< ConversionFunnelChartProps > = ( {
 									style={ { backgroundColor: barBackgroundColor } }
 								>
 									<div
-										className={ clsx( styles[ 'funnel-bar' ], {
-											[ styles[ 'funnel-bar--animated' ] ]:
-												animation && ! loading && ! prefersReducedMotion,
-										} ) }
+										className={ clsx(
+											styles[ 'funnel-bar' ],
+											isColorPaletteResolved && styles[ 'funnel-bar__animated' ],
+											{
+												[ styles[ 'funnel-bar__animated-entry' ] ]:
+													animation && ! loading && ! prefersReducedMotion,
+											}
+										) }
 										style={ {
 											height: `${ barHeight }%`,
 											backgroundColor: barColor,

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.tsx
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.tsx
@@ -331,7 +331,6 @@ const ConversionFunnelChartInternal: FC< ConversionFunnelChartProps > = ( {
 				className={ clsx(
 					styles[ 'conversion-funnel-chart' ],
 					loading && styles.loading,
-					isColorPaletteResolved && styles.animated,
 					className
 				) }
 				style={ { ...style, height: resolvedHeight } }
@@ -357,7 +356,11 @@ const ConversionFunnelChartInternal: FC< ConversionFunnelChartProps > = ( {
 						return (
 							<div
 								key={ step.id }
-								className={ clsx( styles[ 'funnel-step' ], isBlurred && styles.blurred ) }
+								className={ clsx(
+									styles[ 'funnel-step' ],
+									isColorPaletteResolved && styles[ 'funnel-step--animated' ],
+									isBlurred && styles.blurred
+								) }
 							>
 								{ /* Step Label and Rate */ }
 								<div className={ styles[ 'step-header' ] }>
@@ -395,7 +398,7 @@ const ConversionFunnelChartInternal: FC< ConversionFunnelChartProps > = ( {
 								>
 									<div
 										className={ clsx( styles[ 'funnel-bar' ], {
-											[ styles[ 'funnel-bar__animated-entry' ] ]:
+											[ styles[ 'funnel-bar--animated-entry' ] ]:
 												animation && ! loading && ! prefersReducedMotion,
 										} ) }
 										style={ {

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.tsx
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.tsx
@@ -301,7 +301,11 @@ const ConversionFunnelChartInternal: FC< ConversionFunnelChartProps > = ( {
 			<Stack
 				direction="column"
 				data-testid="conversion-funnel-chart"
-				className={ clsx( styles.conversionFunnelChart, loading && styles.loading, className ) }
+				className={ clsx(
+					styles[ 'conversion-funnel-chart' ],
+					loading && styles.loading,
+					className
+				) }
 				style={ { ...style, height: resolvedHeight } }
 			>
 				<div className={ styles[ 'empty-state' ] }>
@@ -324,7 +328,12 @@ const ConversionFunnelChartInternal: FC< ConversionFunnelChartProps > = ( {
 					portalContainerRef( node );
 					chartRef.current = node;
 				} }
-				className={ clsx( styles.conversionFunnelChart, loading && styles.loading, className ) }
+				className={ clsx(
+					styles[ 'conversion-funnel-chart' ],
+					loading && styles.loading,
+					isColorPaletteResolved && styles.animated,
+					className
+				) }
 				style={ { ...style, height: resolvedHeight } }
 			>
 				{ /* Main Metric */ }
@@ -348,11 +357,7 @@ const ConversionFunnelChartInternal: FC< ConversionFunnelChartProps > = ( {
 						return (
 							<div
 								key={ step.id }
-								className={ clsx(
-									styles[ 'funnel-step' ],
-									isColorPaletteResolved && styles[ 'funnel-step__animated' ],
-									isBlurred && styles.blurred
-								) }
+								className={ clsx( styles[ 'funnel-step' ], isBlurred && styles.blurred ) }
 							>
 								{ /* Step Label and Rate */ }
 								<div className={ styles[ 'step-header' ] }>
@@ -380,11 +385,7 @@ const ConversionFunnelChartInternal: FC< ConversionFunnelChartProps > = ( {
 
 								{ /* Funnel Bar */ }
 								<div
-									className={ clsx(
-										styles[ 'bar-container' ],
-										isColorPaletteResolved && styles[ 'bar-container__animated' ],
-										isBlurred && styles.disabled
-									) }
+									className={ clsx( styles[ 'bar-container' ], isBlurred && styles.disabled ) }
 									onClick={ stepHandlers.get( step.id )?.onClick }
 									onKeyDown={ stepHandlers.get( step.id )?.onKeyDown }
 									role="button"
@@ -393,14 +394,10 @@ const ConversionFunnelChartInternal: FC< ConversionFunnelChartProps > = ( {
 									style={ { backgroundColor: barBackgroundColor } }
 								>
 									<div
-										className={ clsx(
-											styles[ 'funnel-bar' ],
-											isColorPaletteResolved && styles[ 'funnel-bar__animated' ],
-											{
-												[ styles[ 'funnel-bar__animated-entry' ] ]:
-													animation && ! loading && ! prefersReducedMotion,
-											}
-										) }
+										className={ clsx( styles[ 'funnel-bar' ], {
+											[ styles[ 'funnel-bar__animated-entry' ] ]:
+												animation && ! loading && ! prefersReducedMotion,
+										} ) }
 										style={ {
 											height: `${ barHeight }%`,
 											backgroundColor: barColor,

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.tsx
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.tsx
@@ -399,7 +399,7 @@ const ConversionFunnelChartInternal: FC< ConversionFunnelChartProps > = ( {
 								>
 									<div
 										className={ clsx( styles[ 'funnel-bar' ], {
-											[ styles[ 'funnel-bar--animated-entry' ] ]:
+											[ styles[ 'funnel-bar--animated' ] ]:
 												animation && ! loading && ! prefersReducedMotion,
 										} ) }
 										style={ {

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.tsx
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.tsx
@@ -356,6 +356,7 @@ const ConversionFunnelChartInternal: FC< ConversionFunnelChartProps > = ( {
 						return (
 							<div
 								key={ step.id }
+								data-testid="funnel-step"
 								className={ clsx(
 									styles[ 'funnel-step' ],
 									isColorPaletteResolved && styles[ 'funnel-step--animated' ],

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/test/conversion-funnel-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/test/conversion-funnel-chart.test.tsx
@@ -467,9 +467,9 @@ describe( 'ConversionFunnelChart', () => {
 			render( <ConversionFunnelChart { ...defaultProps } /> );
 
 			// After render, effects have run (via useEffect in GlobalChartsProvider),
-			// so the palette is resolved and the __animated classes are applied to funnel bars
-			const bars = screen.getAllByRole( 'button' );
-			expect( bars[ 0 ] ).toHaveClass( 'bar-container__animated' );
+			// so the palette is resolved and the animated class is applied to the root
+			const chart = screen.getByTestId( 'conversion-funnel-chart' );
+			expect( chart ).toHaveClass( 'animated' );
 		} );
 	} );
 } );

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/test/conversion-funnel-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/test/conversion-funnel-chart.test.tsx
@@ -466,8 +466,8 @@ describe( 'ConversionFunnelChart', () => {
 		it( 'enables transitions once color palette is resolved', () => {
 			render( <ConversionFunnelChart { ...defaultProps } /> );
 
-			// After render, layout effects have run so palette is resolved
-			// and the __animated classes should be applied to funnel bars
+			// After render, effects have run (via useEffect in GlobalChartsProvider),
+			// so the palette is resolved and the __animated classes are applied to funnel bars
 			const bars = screen.getAllByRole( 'button' );
 			expect( bars[ 0 ] ).toHaveClass( 'bar-container__animated' );
 		} );

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/test/conversion-funnel-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/test/conversion-funnel-chart.test.tsx
@@ -461,4 +461,15 @@ describe( 'ConversionFunnelChart', () => {
 			expect( customRenderMainMetric ).toHaveBeenCalled();
 		} );
 	} );
+
+	describe( 'Color palette readiness', () => {
+		it( 'enables transitions once color palette is resolved', () => {
+			render( <ConversionFunnelChart { ...defaultProps } /> );
+
+			// After render, layout effects have run so palette is resolved
+			// and the __animated classes should be applied to funnel bars
+			const bars = screen.getAllByRole( 'button' );
+			expect( bars[ 0 ] ).toHaveClass( 'bar-container__animated' );
+		} );
+	} );
 } );

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/test/conversion-funnel-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/test/conversion-funnel-chart.test.tsx
@@ -468,9 +468,7 @@ describe( 'ConversionFunnelChart', () => {
 
 			// After render, effects have run (via useEffect in GlobalChartsProvider),
 			// so the palette is resolved and the animated class is applied to funnel steps
-			const chart = screen.getByTestId( 'conversion-funnel-chart' );
-			// eslint-disable-next-line testing-library/no-node-access -- verifying CSS class on non-interactive wrapper
-			const funnelStep = chart.querySelector( '[class*="funnel-step"]' );
+			const funnelStep = screen.getAllByTestId( 'funnel-step' )[ 0 ];
 			expect( funnelStep ).toHaveClass( 'funnel-step--animated' );
 		} );
 	} );

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/test/conversion-funnel-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/test/conversion-funnel-chart.test.tsx
@@ -467,9 +467,11 @@ describe( 'ConversionFunnelChart', () => {
 			render( <ConversionFunnelChart { ...defaultProps } /> );
 
 			// After render, effects have run (via useEffect in GlobalChartsProvider),
-			// so the palette is resolved and the animated class is applied to the root
+			// so the palette is resolved and the animated class is applied to funnel steps
 			const chart = screen.getByTestId( 'conversion-funnel-chart' );
-			expect( chart ).toHaveClass( 'animated' );
+			// eslint-disable-next-line testing-library/no-node-access -- verifying CSS class on non-interactive wrapper
+			const funnelStep = chart.querySelector( '[class*="funnel-step"]' );
+			expect( funnelStep ).toHaveClass( 'funnel-step--animated' );
 		} );
 	} );
 } );

--- a/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
@@ -70,6 +70,8 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( {
 		maxHue: 0,
 	} ) );
 
+	// Track if the color palette has been resolved from the DOM
+	// Useful for animations that should only run after the color palette is resolved
 	const [ isColorPaletteResolved, setIsColorPaletteResolved ] = useState( false );
 
 	// Compute color cache after DOM is updated (so CSS variables are available)
@@ -127,8 +129,6 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( {
 		} );
 	}, [ providerTheme ] );
 
-	// Set after paint (useEffect, not useLayoutEffect) so consumers see
-	// one render with resolved colors before this flag flips to true.
 	useEffect( () => {
 		if ( colorCache.colors.length > 0 ) {
 			setIsColorPaletteResolved( true );

--- a/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
@@ -125,8 +125,15 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( {
 			minHue,
 			maxHue,
 		} );
-		setIsColorPaletteResolved( true );
 	}, [ providerTheme ] );
+
+	// Set after paint (useEffect, not useLayoutEffect) so consumers see
+	// one render with resolved colors before this flag flips to true.
+	useEffect( () => {
+		if ( colorCache.colors.length > 0 ) {
+			setIsColorPaletteResolved( true );
+		}
+	}, [ colorCache ] );
 
 	const [ groupToColorMap, setGroupToColorMap ] = useState< Map< string, string > >(
 		() => new Map()

--- a/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
@@ -70,6 +70,8 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( {
 		maxHue: 0,
 	} ) );
 
+	const [ isColorPaletteResolved, setIsColorPaletteResolved ] = useState( false );
+
 	// Compute color cache after DOM is updated (so CSS variables are available)
 	// Resolves CSS variables from the wrapper element's scope to handle scoped variables
 	// Note: Only re-runs when providerTheme changes, not when wrapper element changes.
@@ -123,6 +125,7 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( {
 			minHue,
 			maxHue,
 		} );
+		setIsColorPaletteResolved( true );
 	}, [ providerTheme ] );
 
 	const [ groupToColorMap, setGroupToColorMap ] = useState< Map< string, string > >(
@@ -271,6 +274,7 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( {
 			toggleSeriesVisibility,
 			isSeriesVisible,
 			getHiddenSeries,
+			isColorPaletteResolved,
 		} ),
 		[
 			charts,
@@ -282,6 +286,7 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( {
 			toggleSeriesVisibility,
 			isSeriesVisible,
 			getHiddenSeries,
+			isColorPaletteResolved,
 		]
 	);
 

--- a/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
@@ -79,6 +79,7 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( {
 	// Note: Only re-runs when providerTheme changes, not when wrapper element changes.
 	// This is intentional, as wrapperRef is expected to be stable for the lifetime of the provider.
 	useLayoutEffect( () => {
+		setIsColorPaletteResolved( false );
 		const { colors } = providerTheme;
 		const resolvedColors: string[] = [];
 		const hues: number[] = [];

--- a/projects/js-packages/charts/src/providers/chart-context/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/providers/chart-context/stories/index.api.mdx
@@ -16,6 +16,7 @@ The main provider component that enables chart context functionality.
 | ---- | ---- | ------- | ----------- |
 | `theme` | `Partial<ChartTheme>` | `defaultTheme` | Custom theme object that gets merged with the default theme |
 | `children` | `ReactNode` | - | **Required.** Chart components and other React elements |
+| `portalContainer` | `React.RefObject<HTMLElement \| null>` | - | Optional ref to an element that chart tooltip portals should be relocated into. When provided, visx tooltip portals (normally appended to `document.body`) will be moved into this container so they participate in the same CSS stacking context. |
 
 ## GlobalChartsContextValue
 
@@ -50,7 +51,7 @@ interface GlobalChartsContextValue {
 ```typescript
 interface ChartRegistration {
 	legendItems: BaseLegendItem[];
-	chartType: string;
+	chartType: ChartType;
 	metadata?: Record<string, unknown>;
 }
 ```
@@ -58,10 +59,10 @@ interface ChartRegistration {
 ## ElementStyles Type
 
 ```typescript
-interface ElementStyles {
+type ElementStyles = {
 	color: string;
-	lineStyles: CSSProperties & LineStyles;
-	glyph?: (props: GlyphProps) => ReactNode;
+	lineStyles: LineStyles;
+	glyph: <Datum extends object>(props: GlyphProps<Datum>) => ReactNode;
 	shapeStyles: CSSProperties & LineStyles;
-}
+};
 ```

--- a/projects/js-packages/charts/src/providers/chart-context/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/providers/chart-context/stories/index.api.mdx
@@ -1,0 +1,67 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="JS Packages/Charts Library/Global Context/API Reference" />
+
+# Chart Context API Reference
+
+This document provides comprehensive API documentation for the Global Charts Context system.
+
+## GlobalChartsProvider
+
+The main provider component that enables chart context functionality.
+
+**Props:**
+
+| Prop | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `theme` | `Partial<ChartTheme>` | `defaultTheme` | Custom theme object that gets merged with the default theme |
+| `children` | `ReactNode` | - | **Required.** Chart components and other React elements |
+
+## GlobalChartsContextValue
+
+The context value shape provided by `useGlobalChartsContext`:
+
+```typescript
+interface GlobalChartsContextValue {
+	// Chart registry
+	charts: Map<string, ChartRegistration>;
+	registerChart: (id: string, data: ChartRegistration) => void;
+	unregisterChart: (id: string) => void;
+	getChartData: (id: string) => ChartRegistration | undefined;
+
+	// Theme and styling
+	theme: CompleteChartTheme;
+	getElementStyles: (params: GetElementStylesParams) => ElementStyles;
+
+	// Series visibility management for interactive legends
+	toggleSeriesVisibility: (chartId: string, seriesLabel: string) => void;
+	isSeriesVisible: (chartId: string, seriesLabel: string) => boolean;
+	getHiddenSeries: (chartId: string) => Set<string>;
+
+	// Color palette resolution state
+	isColorPaletteResolved: boolean;
+}
+```
+
+`isColorPaletteResolved` is `false` until the provider's color cache has been resolved from the DOM and painted. Chart components can use this to defer CSS transitions or animations that would otherwise interpolate from a fallback color to the resolved theme color on initial render.
+
+## ChartRegistration Type
+
+```typescript
+interface ChartRegistration {
+	legendItems: BaseLegendItem[];
+	chartType: string;
+	metadata?: Record<string, unknown>;
+}
+```
+
+## ElementStyles Type
+
+```typescript
+interface ElementStyles {
+	color: string;
+	lineStyles: CSSProperties & LineStyles;
+	glyph?: (props: GlyphProps) => ReactNode;
+	shapeStyles: CSSProperties & LineStyles;
+}
+```

--- a/projects/js-packages/charts/src/providers/chart-context/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/providers/chart-context/stories/index.api.mdx
@@ -2,7 +2,7 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 <Meta title="JS Packages/Charts Library/Global Context/API Reference" />
 
-# Chart Context API Reference
+# Global Charts Context API Reference
 
 This document provides comprehensive API documentation for the Global Charts Context system.
 

--- a/projects/js-packages/charts/src/providers/chart-context/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/providers/chart-context/stories/index.docs.mdx
@@ -399,8 +399,18 @@ interface GlobalChartsContextValue {
 	// Theme and styling
 	theme: CompleteChartTheme;
 	getElementStyles: (params: GetElementStylesParams) => ElementStyles;
+
+	// Series visibility management for interactive legends
+	toggleSeriesVisibility: (chartId: string, seriesLabel: string) => void;
+	isSeriesVisible: (chartId: string, seriesLabel: string) => boolean;
+	getHiddenSeries: (chartId: string) => Set<string>;
+
+	// Color palette resolution state
+	isColorPaletteResolved: boolean;
 }
 ```
+
+`isColorPaletteResolved` is `false` until the provider's color cache has been resolved from the DOM and painted. Chart components can use this to defer CSS transitions or animations that would otherwise interpolate from a fallback color to the resolved theme color on initial render.
 
 ### ChartRegistration Type
 

--- a/projects/js-packages/charts/src/providers/chart-context/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/providers/chart-context/stories/index.docs.mdx
@@ -17,6 +17,10 @@ The Global Charts Context system consists of three main parts:
 2. **GlobalChartsContext** - The underlying React context that manages shared state
 3. **Context hooks** - Utilities for accessing theme and registration functionality
 
+## API Reference
+
+For detailed information about provider props, context values, and type definitions, see the [API Reference](?path=/docs/js-packages-charts-library-global-context-api-reference--docs).
+
 ## Basic Usage
 
 ### Setting Up the Provider
@@ -370,68 +374,6 @@ When charts register with a `chartId`, their legend data becomes available to st
 - **Flexible Layouts** - Create complex dashboard designs with legends positioned anywhere
 - **Automatic Updates** - Legend data updates automatically when chart data changes
 - **No Prop Drilling** - No need to pass legend data through component hierarchies
-
-## API Reference
-
-### GlobalChartsProvider
-
-The main provider component that enables chart context functionality.
-
-**Props:**
-
-| Prop | Type | Default | Description |
-| ---- | ---- | ------- | ----------- |
-| `theme` | `Partial<ChartTheme>` | `defaultTheme` | Custom theme object that gets merged with the default theme |
-| `children` | `ReactNode` | - | **Required.** Chart components and other React elements |
-
-### GlobalChartsContextValue
-
-The context value shape provided by `useGlobalChartsContext`:
-
-```typescript
-interface GlobalChartsContextValue {
-	// Chart registry
-	charts: Map<string, ChartRegistration>;
-	registerChart: (id: string, data: ChartRegistration) => void;
-	unregisterChart: (id: string) => void;
-	getChartData: (id: string) => ChartRegistration | undefined;
-
-	// Theme and styling
-	theme: CompleteChartTheme;
-	getElementStyles: (params: GetElementStylesParams) => ElementStyles;
-
-	// Series visibility management for interactive legends
-	toggleSeriesVisibility: (chartId: string, seriesLabel: string) => void;
-	isSeriesVisible: (chartId: string, seriesLabel: string) => boolean;
-	getHiddenSeries: (chartId: string) => Set<string>;
-
-	// Color palette resolution state
-	isColorPaletteResolved: boolean;
-}
-```
-
-`isColorPaletteResolved` is `false` until the provider's color cache has been resolved from the DOM and painted. Chart components can use this to defer CSS transitions or animations that would otherwise interpolate from a fallback color to the resolved theme color on initial render.
-
-### ChartRegistration Type
-
-```typescript
-interface ChartRegistration {
-	legendItems: BaseLegendItem[];
-	chartType: string;
-	metadata?: Record<string, unknown>;
-}
-```
-
-### ElementStyles Type
-
-```typescript
-interface ElementStyles {
-	color: string;
-	lineStyles: CSSProperties & LineStyles;
-	glyph?: (props: GlyphProps) => ReactNode;
-	shapeStyles: CSSProperties & LineStyles;
-}
-```
 
 ## Accessibility
 

--- a/projects/js-packages/charts/src/providers/chart-context/test/chart-context.test.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/test/chart-context.test.tsx
@@ -61,7 +61,7 @@ describe( 'ChartContext', () => {
 				</GlobalChartsProvider>
 			);
 
-			// After render + layout effects, isColorPaletteResolved should be true
+			// After render and effects, isColorPaletteResolved should be true
 			expect( contextValue.isColorPaletteResolved ).toBe( true );
 		} );
 

--- a/projects/js-packages/charts/src/providers/chart-context/test/chart-context.test.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/test/chart-context.test.tsx
@@ -47,6 +47,24 @@ describe( 'ChartContext', () => {
 			expect( contextValue.charts ).toBeInstanceOf( Map );
 		} );
 
+		it( 'exposes isColorPaletteResolved as true after render', () => {
+			let contextValue: GlobalChartsContextValue;
+
+			const TestComponent = () => {
+				contextValue = useGlobalChartsContext();
+				return <div>Test</div>;
+			};
+
+			render(
+				<GlobalChartsProvider>
+					<TestComponent />
+				</GlobalChartsProvider>
+			);
+
+			// After render + layout effects, isColorPaletteResolved should be true
+			expect( contextValue.isColorPaletteResolved ).toBe( true );
+		} );
+
 		it( 'throws error when useGlobalChartsContext is used outside provider', () => {
 			const TestComponent = () => {
 				useGlobalChartsContext();

--- a/projects/js-packages/charts/src/providers/chart-context/test/chart-context.test.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/test/chart-context.test.tsx
@@ -65,6 +65,39 @@ describe( 'ChartContext', () => {
 			expect( contextValue.isColorPaletteResolved ).toBe( true );
 		} );
 
+		it( 'resolves palette again after theme change', () => {
+			let contextValue: GlobalChartsContextValue;
+
+			const TestComponent = () => {
+				contextValue = useGlobalChartsContext();
+				return <div>Test</div>;
+			};
+
+			const theme1: Partial< ChartTheme > = {
+				colors: [ '#006DAB', '#1F9828' ],
+			};
+			const theme2: Partial< ChartTheme > = {
+				colors: [ '#FF0000', '#00FF00' ],
+			};
+
+			const { rerender } = render(
+				<GlobalChartsProvider theme={ theme1 }>
+					<TestComponent />
+				</GlobalChartsProvider>
+			);
+
+			expect( contextValue.isColorPaletteResolved ).toBe( true );
+
+			rerender(
+				<GlobalChartsProvider theme={ theme2 }>
+					<TestComponent />
+				</GlobalChartsProvider>
+			);
+
+			// After theme change, palette should re-resolve to true
+			expect( contextValue.isColorPaletteResolved ).toBe( true );
+		} );
+
 		it( 'throws error when useGlobalChartsContext is used outside provider', () => {
 			const TestComponent = () => {
 				useGlobalChartsContext();

--- a/projects/js-packages/charts/src/providers/chart-context/types.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/types.ts
@@ -35,4 +35,5 @@ export interface GlobalChartsContextValue {
 	toggleSeriesVisibility: ( chartId: string, seriesLabel: string ) => void;
 	isSeriesVisible: ( chartId: string, seriesLabel: string ) => boolean;
 	getHiddenSeries: ( chartId: string ) => Set< string >;
+	isColorPaletteResolved: boolean;
 }


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHARTS-168

## Proposed changes

* Add `isColorPaletteResolved` boolean to `GlobalChartsProvider` context, set via `useEffect` after the color cache is populated and painted
* Suppress CSS transitions on conversion funnel chart elements until the color palette is resolved, preventing the color flicker on initial render
* Apply `--animated` BEM modifier on `funnel-step` once palette is resolved to enable the blur/opacity transition on bar selection
* Rename entry animation modifier to `funnel-bar--animated` for consistent BEM naming
* Fix root class reference after linter kebab-case rename (`.conversionFunnelChart` → `.conversion-funnel-chart`)
* Extract Global Context API reference into a separate `.api.mdx` document

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* https://linear.app/a8c/issue/CHARTS-168/conversion-funnel-chart-color-flickers-on-story-load

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Go to Storybook: `JS Packages / Charts / Library / Conversion Funnel Chart`
* Hard-reload the default story several times — the bars should appear with the correct color immediately, with no flash of a different color
* Click on a bar — other bars should smoothly fade (opacity transition) and the clicked bar should remain highlighted
* Click outside to deselect — bars should smoothly return to normal
* Check other conversion funnel stories (with change indicator, loading state) for correct behavior
* Spot-check other chart types (bar chart, line chart) to confirm they are unaffected
* Verify the Global Context API Reference page renders in Storybook under `JS Packages / Charts Library / Global Context / API Reference`
