### PR TITLE
Disable handling issues in repo gardening workflow

### DIFF
--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -2,10 +2,6 @@ name: Gardening
 on:
   pull_request_target: # When a PR is opened, edited, updated, closed, or a label is added.
     types: [opened, reopened, synchronize, edited, labeled, closed ]
-  issues: # For auto-triage of issues.
-    types: [opened, reopened, labeled, edited, closed]
-  issue_comment: # To gather support references in issue comments.
-    types: [created]
   push:
     branches:
       - trunk # Every time a PR is merged to trunk.
@@ -62,12 +58,8 @@ jobs:
 
       - name: Wait for prior instances of the workflow to finish
         uses: ./.github/actions/turnstile
-        with:
-          # Split issues and issue_comment triggers from the rest. Otherwise a lot of issue work can result in pushes to trunk timing out.
-          events:        ${{ case( github.event_name == 'issues' || github.event_name == 'issue_comment', 'issues issue_comment', '' ) }}
-          ignore-events: ${{ case( github.event_name == 'issues' || github.event_name == 'issue_comment', '', 'issues issue_comment' ) }}
 
-      - name: "Run the action (assign, manage milestones, for issues and PRs)"
+      - name: "Run the action (assign, manage milestones, for PRs)"
         uses: ./projects/github-actions/repo-gardening
         env:
           PR_WORKSPACE: ${{ github.workspace }}${{ case( github.event_name == 'pull_request_target', '/pr-checkout', '' ) }}

--- a/projects/github-actions/repo-gardening/changelog/disable-issue-triage-labels
+++ b/projects/github-actions/repo-gardening/changelog/disable-issue-triage-labels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove issue and issue_comment triggers from the gardening workflow, since issue triage now happens in Linear.

--- a/projects/github-actions/repo-gardening/changelog/disable-issue-triage-labels
+++ b/projects/github-actions/repo-gardening/changelog/disable-issue-triage-labels
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Remove issue and issue_comment triggers from the gardening workflow, since issue triage now happens in Linear.


### PR DESCRIPTION
## Summary

- Remove `issues:` and `issue_comment:` triggers from the repo gardening workflow
- Issue triage now happens in Linear, so the GitHub issue automations (`triageIssues`, `gatherSupportReferences`, `replyToCustomersReminder`) add conflicting labels (e.g. `[Pri] Low`) and duplicate work that's moved to Zendesk-to-Linear linking
- All PR automation is preserved unchanged
- Also removes the turnstile issue/PR event splitting (no longer needed with only PR and push triggers)

Context: discussion in Slack and [QAO-346](https://linear.app/a8c/issue/QAO-346). Customer-reported issue lifecycle has moved to direct Zendesk-to-Linear linking per p7DVsv-oVD-p2.

## Test plan

- [ ] Verify the workflow still runs on PR events (open a test PR or check CI on this PR)
- [ ] Verify new GitHub issues no longer trigger the gardening workflow at all
- [ ] Confirm PR labeling (`addLabels`, `checkDescription`, etc.) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)