### PR TITLE
Try: Feature gate Block Notes behind paid Jetpack AI plan

### DIFF
--- a/projects/plugins/jetpack/changelog/try-block-notes-paid-plan-gate
+++ b/projects/plugins/jetpack/changelog/try-block-notes-paid-plan-gate
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Block Notes: Gate feature behind a paid Jetpack AI plan instead of allowing free-tier access.

--- a/projects/plugins/jetpack/extensions/plugins/block-notes/block-notes.php
+++ b/projects/plugins/jetpack/extensions/plugins/block-notes/block-notes.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Extensions\BlockNotes;
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\My_Jetpack\Products\Jetpack_Ai;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
 
@@ -26,8 +27,8 @@ const HEADLESS_AGENT_PROVIDER = 'block-notes/headless-agent-provider';
 /**
  * Check if Block Notes is enabled.
  *
- * Enabled when the Big Sky plugin is active, or when Jetpack AI
- * features are not disabled.
+ * Enabled when the Big Sky plugin is active, or when the site has
+ * a paid Jetpack AI plan and AI features are not disabled.
  *
  * @return bool
  */
@@ -40,7 +41,35 @@ function is_block_notes_enabled() {
 		return false;
 	}
 
+	if ( ! has_paid_ai_plan() ) {
+		return false;
+	}
+
 	return true;
+}
+
+/**
+ * Check if the site has a paid Jetpack AI plan.
+ *
+ * Uses the Jetpack AI product class to verify the site has an active
+ * paid AI subscription (yearly, monthly, or bi-yearly) or a bundle
+ * plan that includes the ai-assistant feature.
+ *
+ * @return bool
+ */
+function has_paid_ai_plan() {
+	if ( ! class_exists( Jetpack_Ai::class ) ) {
+		return false;
+	}
+
+	/**
+	 * Filter whether the site has a paid AI plan.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param bool $has_paid_plan Whether the site has a paid AI plan.
+	 */
+	return apply_filters( 'jetpack_block_notes_has_paid_ai_plan', Jetpack_Ai::has_paid_plan_for_product() );
 }
 
 /**

--- a/projects/plugins/jetpack/extensions/plugins/block-notes/block-notes.php
+++ b/projects/plugins/jetpack/extensions/plugins/block-notes/block-notes.php
@@ -51,15 +51,19 @@ function is_block_notes_enabled() {
 /**
  * Check if the site has a paid Jetpack AI plan.
  *
- * Uses the Jetpack AI product class to verify the site has an active
- * paid AI subscription (yearly, monthly, or bi-yearly) or a bundle
- * plan that includes the ai-assistant feature.
+ * Tries the My Jetpack product class first, then falls back to the
+ * Jetpack AI Helper which lives in the Jetpack plugin itself.
  *
  * @return bool
  */
 function has_paid_ai_plan() {
-	if ( ! class_exists( Jetpack_Ai::class ) ) {
-		return false;
+	$has_paid_plan = false;
+
+	if ( class_exists( Jetpack_Ai::class ) ) {
+		$has_paid_plan = Jetpack_Ai::has_paid_plan_for_product();
+	} elseif ( class_exists( 'Jetpack_AI_Helper' ) ) {
+		$feature_data  = \Jetpack_AI_Helper::get_ai_assistance_feature();
+		$has_paid_plan = ! is_wp_error( $feature_data ) && ! empty( $feature_data['has-feature'] );
 	}
 
 	/**
@@ -69,7 +73,7 @@ function has_paid_ai_plan() {
 	 *
 	 * @param bool $has_paid_plan Whether the site has a paid AI plan.
 	 */
-	return apply_filters( 'jetpack_block_notes_has_paid_ai_plan', Jetpack_Ai::has_paid_plan_for_product() );
+	return apply_filters( 'jetpack_block_notes_has_paid_ai_plan', $has_paid_plan );
 }
 
 /**

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/block-notes/Block_Notes_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/block-notes/Block_Notes_Test.php
@@ -39,6 +39,7 @@ class Block_Notes_Test extends \WP_UnitTestCase {
 		$GLOBALS['wp_scripts']  = new WP_Scripts();
 		$this->reset_availability();
 		$this->simulate_connected_owner();
+		$this->simulate_paid_ai_plan();
 		// Ensure Big Sky is disabled by default so tests aren't affected by the
 		// Big_Sky class persisting across tests once simulate_big_sky_class() runs.
 		update_option( 'big_sky_enable', '0' );
@@ -54,6 +55,7 @@ class Block_Notes_Test extends \WP_UnitTestCase {
 		remove_all_filters( 'agents_manager_agent_providers' );
 		remove_all_filters( 'pre_http_request' );
 		remove_all_filters( 'jetpack_ai_enabled' );
+		remove_all_filters( 'jetpack_block_notes_has_paid_ai_plan' );
 		remove_filter( 'get_avatar_data', 'Automattic\Jetpack\Extensions\BlockNotes\customize_ai_avatar', 10 );
 		unregister_meta_key( 'comment', 'bigsky_ai_processed_date' );
 		( new \Automattic\Jetpack\Connection\Manager( 'jetpack' ) )->reset_connection_status();
@@ -91,6 +93,20 @@ class Block_Notes_Test extends \WP_UnitTestCase {
 	 */
 	private function disable_ai_features() {
 		add_filter( 'jetpack_ai_enabled', '__return_false' );
+	}
+
+	/**
+	 * Simulate having a paid AI plan via the jetpack_block_notes_has_paid_ai_plan filter.
+	 */
+	private function simulate_paid_ai_plan() {
+		add_filter( 'jetpack_block_notes_has_paid_ai_plan', '__return_true' );
+	}
+
+	/**
+	 * Simulate not having a paid AI plan via the jetpack_block_notes_has_paid_ai_plan filter.
+	 */
+	private function simulate_no_paid_ai_plan() {
+		add_filter( 'jetpack_block_notes_has_paid_ai_plan', '__return_false' );
 	}
 
 	/**
@@ -254,6 +270,23 @@ class Block_Notes_Test extends \WP_UnitTestCase {
 		$this->simulate_big_sky_class();
 		update_option( 'big_sky_enable', '' );
 		$this->assertFalse( BlockNotes\is_block_notes_enabled() );
+	}
+
+	/**
+	 * Not enabled when AI features are available but no paid AI plan.
+	 */
+	public function test_is_not_enabled_without_paid_ai_plan() {
+		$this->simulate_no_paid_ai_plan();
+		$this->assertFalse( BlockNotes\is_block_notes_enabled() );
+	}
+
+	/**
+	 * Enabled via Big Sky even without a paid AI plan.
+	 */
+	public function test_is_enabled_via_big_sky_without_paid_plan() {
+		$this->simulate_no_paid_ai_plan();
+		$this->enable_big_sky();
+		$this->assertTrue( BlockNotes\is_block_notes_enabled() );
 	}
 
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Gate Block Notes behind a paid Jetpack AI plan (AI Assistant or Jetpack Complete) so that free-tier users can no longer access the feature without their usage being tracked.
- Add a `has_paid_ai_plan()` check using `Jetpack_Ai::has_paid_plan_for_product()` which verifies the site has an active AI subscription or a bundle plan that includes the `ai-assistant` feature.
- Big Sky users continue to bypass the plan check (existing behavior).
- Add unit tests for the new paid plan gating logic.

## Does this pull request change what data or activity we track or use?

No. This PR only adds a plan-level gate to an existing feature. No new data is collected, stored, or transmitted.

## Testing instructions

### Setup

1. Spin up a Jurassic Ninja site with the Jetpack Beta plugin and this branch pre-installed:
   [Launch JN site with this branch](https://jurassic.ninja/create?jetpack-beta&branch=try/block-notes-jp-paid)
2. Once the site is ready, go to **Jetpack > Jetpack Beta** in wp-admin and confirm the `try/block-notes-jp-paid` branch is active.
3. Connect a Jetpack account to the site.

### Verify Block Notes is disabled on a free plan

4. Navigate to **Posts > Add New** to open the post editor.
5. Add a block note to the draft post.
6. Type `@ai hello` in the block note prompt.
7. Confirm that AI does **not** respond -- the feature should be inactive on a free plan.

### Verify Block Notes is enabled on a paid plan

8. Upgrade the site to **Jetpack AI Assistant** or **Jetpack Complete**.
9. Repeat steps 4-6 (navigate to a draft post, add a block note, type `@ai hello`).
10. Confirm that AI **does** respond with a reply to the prompt.

## Other information

- [x] Generate changelog entries for this PR (using AI).