### PR TITLE
Use lightweight wpcom_site_has_feature() on WPCOM instead of heavy AI…

### DIFF
--- a/projects/plugins/jetpack/extensions/plugins/block-notes/block-notes.php
+++ b/projects/plugins/jetpack/extensions/plugins/block-notes/block-notes.php
@@ -51,19 +51,19 @@ function is_block_notes_enabled() {
 /**
  * Check if the site has a paid Jetpack AI plan.
  *
- * Tries the My Jetpack product class first, then falls back to the
- * Jetpack AI Helper which lives in the Jetpack plugin itself.
+ * On WordPress.com, uses the lightweight wpcom_site_has_feature() lookup.
+ * On self-hosted sites, tries the My Jetpack product class first, then
+ * falls back to the Jetpack AI Helper.
  *
  * @return bool
  */
 function has_paid_ai_plan() {
 	$has_paid_plan = false;
 
-	if ( class_exists( Jetpack_Ai::class ) ) {
+	if ( defined( 'IS_WPCOM' ) && IS_WPCOM && function_exists( 'wpcom_site_has_feature' ) ) {
+		$has_paid_plan = wpcom_site_has_feature( 'ai-assistant', get_current_blog_id() );
+	} elseif ( class_exists( Jetpack_Ai::class ) ) {
 		$has_paid_plan = Jetpack_Ai::has_paid_plan_for_product();
-	} elseif ( class_exists( 'Jetpack_AI_Helper' ) ) {
-		$feature_data  = \Jetpack_AI_Helper::get_ai_assistance_feature();
-		$has_paid_plan = ! is_wp_error( $feature_data ) && ! empty( $feature_data['has-feature'] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/extensions/plugins/block-notes/block-notes.php
+++ b/projects/plugins/jetpack/extensions/plugins/block-notes/block-notes.php
@@ -52,8 +52,7 @@ function is_block_notes_enabled() {
  * Check if the site has a paid Jetpack AI plan.
  *
  * On WordPress.com, uses the lightweight wpcom_site_has_feature() lookup.
- * On self-hosted sites, tries the My Jetpack product class first, then
- * falls back to the Jetpack AI Helper.
+ * On self-hosted and Atomic sites, uses the My Jetpack product class.
  *
  * @return bool
  */


### PR DESCRIPTION
… helper

On WPCOM Simple, has_paid_ai_plan() was falling through to Jetpack_AI_Helper::get_ai_assistance_feature() which triggers 12 heavy DB operations against billing/metered-usage tables when we only need a boolean. This caused side effects that interfered with unrelated WPCOM test suites (woo-billing, Happytools-Scheduler).

Replace with wpcom_site_has_feature('ai-assistant') on WPCOM — a simple feature lookup without billing side effects. Self-hosted and Atomic environments continue using Jetpack_Ai::has_paid_plan_for_product().

Fixes #

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* 

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Go to '..'
*
