### PR TITLE
Subscriptions: include "Jetpack" in the Newsletter panel title

### DIFF
--- a/projects/plugins/jetpack/changelog/update-newsletter-panel-title
+++ b/projects/plugins/jetpack/changelog/update-newsletter-panel-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions: update panel name to include "jetpack"

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
@@ -39,7 +39,7 @@ const NewsletterMenu = ( { openPreviewModal } ) => {
 	return (
 		<PluginSidebar
 			name="jetpack-newsletter-settings-sidebar"
-			title={ __( 'Newsletter', 'jetpack' ) }
+			title={ __( 'Jetpack Newsletter', 'jetpack' ) }
 			icon={ <SendIcon /> }
 			className="jetpack-newsletter-settings-sidebar"
 		>


### PR DESCRIPTION
Fixes NL-556

## Proposed changes

Let's make it clearer that the Newsletter panel is provided by Jetpack.

**Before**

<img width="310" height="180" alt="Screenshot 2026-03-31 at 10 24 47" src="https://github.com/user-attachments/assets/372b1604-c294-43a2-9b42-5edb9ca2ab83" />

**After**

<img width="310" height="178" alt="image" src="https://github.com/user-attachments/assets/f4fc8cb9-3eca-4103-a9d6-d83d60db4f38" />

<img width="328" height="212" alt="image" src="https://github.com/user-attachments/assets/01f8f29a-d8c9-4afe-a720-7b84b5655743" />


### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links

See p1HpG7-xUC-p2

## Does this pull request change what data or activity we track or use?

No

## Testing instructions

* Go to Jetpack > Newsletter
* Enable the Newsletter feature
* Go to Posts > Add New
* Check the plugin sidebar titles (see screenshots above)

