### PR TITLE
Reapply: Rename Advertising to Blaze Ads, add context-aware menu and campaign promotion

### DIFF
--- a/projects/packages/blaze/changelog/add-blaze-ads-menu-revisions
+++ b/projects/packages/blaze/changelog/add-blaze-ads-menu-revisions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Rename "Advertising" to "Blaze Ads", add context-aware menu placement and campaign-based top-level promotion.

--- a/projects/packages/blaze/changelog/fix-blaze-menu-race-condition
+++ b/projects/packages/blaze/changelog/fix-blaze-menu-race-condition
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Blaze Ads menu generating broken URL on Simple Sites by using Admin_Menu to avoid race condition with Jetpack top-level menu creation.

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -137,27 +137,12 @@ class Blaze {
 		 */
 		$css_prefix = apply_filters( 'jetpack_blaze_dashboard_css_prefix', 'jp-blaze' );
 
-		$parent_slug = self::get_menu_parent();
+		$parent_slug     = self::get_menu_parent();
+		$is_simple_site  = defined( 'IS_WPCOM' ) && IS_WPCOM;
+		$admin_page      = $is_simple_site ? 'tools.php' : 'admin.php';
+		$blaze_dashboard = new Blaze_Dashboard( $admin_page, $menu_slug, $css_prefix );
 
-		$is_simple_site      = defined( 'IS_WPCOM' ) && IS_WPCOM;
-		$admin_page          = $is_simple_site ? 'tools.php' : 'admin.php';
-		$blaze_dashboard     = new Blaze_Dashboard( $admin_page, $menu_slug, $css_prefix );
-		$dashboard_enabled   = self::is_dashboard_enabled();
-		$has_campaigns       = self::has_site_campaigns();
-		$wpcom_admin_iface   = get_option( 'wpcom_admin_interface', '(not set)' );
-
-		// DEBUG — remove before merging.
-		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-		error_log( sprintf(
-			'[BLAZE-DEBUG] enable_blaze_menu: parent_slug=%s, is_simple=%s, dashboard_enabled=%s, has_campaigns=%s, wpcom_admin_interface=%s',
-			$parent_slug,
-			$is_simple_site ? 'yes' : 'no',
-			$dashboard_enabled ? 'yes' : 'no',
-			$has_campaigns ? 'yes' : 'no',
-			$wpcom_admin_iface
-		) );
-
-		if ( $dashboard_enabled ) {
+		if ( self::is_dashboard_enabled() ) {
 			if ( $has_campaigns ) {
 				$page_suffix = add_menu_page(
 					esc_attr( $menu_label ),
@@ -500,8 +485,8 @@ class Blaze {
 			$menu_slug = apply_filters( 'jetpack_blaze_menu_slug', 'advertising' );
 			// Simple Sites use tools.php; all other installations use admin.php.
 			$admin_page = ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ? 'tools.php' : 'admin.php';
-			$admin_url  = admin_url( $admin_page . '?page=' . $menu_slug );
-			$hostname   = wp_parse_url( get_site_url(), PHP_URL_HOST );
+			$admin_url = admin_url( $admin_page . '?page=' . $menu_slug );
+			$hostname  = wp_parse_url( get_site_url(), PHP_URL_HOST );
 			$blaze_url = sprintf(
 				'%1$s#!/advertising/posts/promote/post-%2$s/%3$s',
 				$admin_url,

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -138,80 +138,29 @@ class Blaze {
 		$css_prefix = apply_filters( 'jetpack_blaze_dashboard_css_prefix', 'jp-blaze' );
 
 		$parent_slug     = self::get_menu_parent();
-		$is_simple_site  = defined( 'IS_WPCOM' ) && IS_WPCOM;
-		$admin_page      = $is_simple_site ? 'tools.php' : 'admin.php';
-		$blaze_dashboard = new Blaze_Dashboard( $admin_page, $menu_slug, $css_prefix );
+		$blaze_dashboard = new Blaze_Dashboard( 'admin.php', $menu_slug, $css_prefix );
 
 		if ( self::is_dashboard_enabled() ) {
 			if ( self::has_site_campaigns() ) {
-				if ( $is_simple_site ) {
-					// On Simple Sites, add_menu_page with a slug produces
-					// admin.php?page=slug which the WPCOM bridge cannot route.
-					// Register the page under tools.php (routable) and add a
-					// visible top-level menu pointing to it.
-					$page_suffix = add_submenu_page(
-						'tools.php',
-						esc_attr( $menu_label ),
-						$menu_label,
-						'manage_options',
-						$menu_slug,
-						array( $blaze_dashboard, 'render' ),
-						1
-					);
-					remove_submenu_page( 'tools.php', $menu_slug );
-					add_menu_page(
-						esc_attr( $menu_label ),
-						$menu_label,
-						'manage_options',
-						admin_url( 'tools.php?page=' . $menu_slug ),
-						null, // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
-						'dashicons-megaphone',
-						30
-					);
-				} else {
-					$page_suffix = add_menu_page(
-						esc_attr( $menu_label ),
-						$menu_label,
-						'manage_options',
-						$menu_slug,
-						array( $blaze_dashboard, 'render' ),
-						'dashicons-megaphone',
-						30
-					);
-				}
+				$page_suffix = add_menu_page(
+					esc_attr( $menu_label ),
+					$menu_label,
+					'manage_options',
+					$menu_slug,
+					array( $blaze_dashboard, 'render' ),
+					'dashicons-megaphone',
+					30
+				);
 			} else {
-				if ( $is_simple_site ) {
-					// Same approach: register routable page, link from Jetpack.
-					$page_suffix = add_submenu_page(
-						'tools.php',
-						esc_attr( $menu_label ),
-						$menu_label,
-						'manage_options',
-						$menu_slug,
-						array( $blaze_dashboard, 'render' ),
-						1
-					);
-					remove_submenu_page( 'tools.php', $menu_slug );
-					add_submenu_page(
-						$parent_slug,
-						esc_attr( $menu_label ),
-						$menu_label,
-						'manage_options',
-						admin_url( 'tools.php?page=' . $menu_slug ),
-						null, // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
-						1
-					);
-				} else {
-					$page_suffix = add_submenu_page(
-						$parent_slug,
-						esc_attr( $menu_label ),
-						$menu_label,
-						'manage_options',
-						$menu_slug,
-						array( $blaze_dashboard, 'render' ),
-						1
-					);
-				}
+				$page_suffix = add_submenu_page(
+					$parent_slug,
+					esc_attr( $menu_label ),
+					$menu_label,
+					'manage_options',
+					$menu_slug,
+					array( $blaze_dashboard, 'render' ),
+					1
+				);
 			}
 			add_action( 'load-' . $page_suffix, array( $blaze_dashboard, 'admin_init' ) );
 		} elseif ( ( new Host() )->is_wpcom_platform() ) {
@@ -353,12 +302,6 @@ class Blaze {
 			&& isset( $_GET['page'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			&& 'advertising' === $_GET['page'] // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		) {
-			// On Simple Sites the dashboard still uses tools.php as its base,
-			// so there is nothing to redirect — the URL is already correct.
-			if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-				return;
-			}
-
 			/** This filter is documented in Blaze::enable_blaze_menu() */
 			$menu_slug = apply_filters( 'jetpack_blaze_menu_slug', 'advertising' );
 			wp_safe_redirect( admin_url( 'admin.php?page=' . $menu_slug ), 302 );
@@ -532,9 +475,7 @@ class Blaze {
 		if ( self::is_dashboard_enabled() ) {
 			/** This filter is documented in Blaze::enable_blaze_menu() */
 			$menu_slug = apply_filters( 'jetpack_blaze_menu_slug', 'advertising' );
-			// Simple Sites use tools.php; all other installations use admin.php.
-			$admin_page = ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ? 'tools.php' : 'admin.php';
-			$admin_url  = admin_url( $admin_page . '?page=' . $menu_slug );
+			$admin_url = admin_url( 'admin.php?page=' . $menu_slug );
 			$hostname   = wp_parse_url( get_site_url(), PHP_URL_HOST );
 			$blaze_url  = sprintf(
 				'%1$s#!/advertising/posts/promote/post-%2$s/%3$s',

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -137,18 +137,17 @@ class Blaze {
 		 */
 		$css_prefix = apply_filters( 'jetpack_blaze_dashboard_css_prefix', 'jp-blaze' );
 
-		$parent_slug     = self::get_menu_parent();
-		$is_simple_site  = defined( 'IS_WPCOM' ) && IS_WPCOM;
-		$blaze_dashboard = new Blaze_Dashboard( 'admin.php', $menu_slug, $css_prefix );
+		$parent_slug = self::get_menu_parent();
 
-		// On Simple Sites the embedded wp-admin dashboard does not work under a
-		// plugin parent menu (admin.php?page=advertising is not routed by the
-		// WPCOM admin bridge and falls back to /home/).  Use the external
-		// Calypso URL instead, which is the same approach every other Jetpack
-		// submenu item takes on Simple Sites.
-		$use_embedded_dashboard = self::is_dashboard_enabled() && ! $is_simple_site;
+		// On Simple Sites the WPCOM admin bridge only routes tools.php?page=…
+		// URLs.  admin.php?page=… under a plugin parent falls back to /home/.
+		// Keep tools.php as the dashboard base so the embedded dashboard keeps
+		// working on Simple Sites.
+		$is_simple_site = defined( 'IS_WPCOM' ) && IS_WPCOM;
+		$admin_page     = $is_simple_site ? 'tools.php' : 'admin.php';
+		$blaze_dashboard = new Blaze_Dashboard( $admin_page, $menu_slug, $css_prefix );
 
-		if ( $use_embedded_dashboard ) {
+		if ( self::is_dashboard_enabled() ) {
 			if ( self::has_site_campaigns() ) {
 				$page_suffix = add_menu_page(
 					esc_attr( $menu_label ),
@@ -303,12 +302,6 @@ class Blaze {
 	 * @return void
 	 */
 	public static function redirect_legacy_advertising_url() {
-		// On Simple Sites the menu is not registered under admin.php, so
-		// redirecting tools.php → admin.php would land on an unroutable URL.
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			return;
-		}
-
 		global $pagenow;
 
 		if (
@@ -316,6 +309,12 @@ class Blaze {
 			&& isset( $_GET['page'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			&& 'advertising' === $_GET['page'] // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		) {
+			// On Simple Sites the dashboard still uses tools.php as its base,
+			// so there is nothing to redirect — the URL is already correct.
+			if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+				return;
+			}
+
 			/** This filter is documented in Blaze::enable_blaze_menu() */
 			$menu_slug = apply_filters( 'jetpack_blaze_menu_slug', 'advertising' );
 			wp_safe_redirect( admin_url( 'admin.php?page=' . $menu_slug ), 302 );
@@ -486,15 +485,12 @@ class Blaze {
 	 * @return array An array with the link, and whether this is a Calypso or a wp-admin link.
 	 */
 	public static function get_campaign_management_url( $post_id ) {
-		$is_simple_site = defined( 'IS_WPCOM' ) && IS_WPCOM;
-
-		// Use the embedded dashboard URL on non-Simple sites with the dashboard enabled.
-		// Simple Sites cannot route admin.php?page=* under plugin parent menus,
-		// so they fall through to the Calypso URL below.
-		if ( self::is_dashboard_enabled() && ! $is_simple_site ) {
+		if ( self::is_dashboard_enabled() ) {
 			/** This filter is documented in Blaze::enable_blaze_menu() */
 			$menu_slug = apply_filters( 'jetpack_blaze_menu_slug', 'advertising' );
-			$admin_url = admin_url( 'admin.php?page=' . $menu_slug );
+			// Simple Sites use tools.php; all other installations use admin.php.
+			$admin_page = ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ? 'tools.php' : 'admin.php';
+			$admin_url  = admin_url( $admin_page . '?page=' . $menu_slug );
 			$hostname  = wp_parse_url( get_site_url(), PHP_URL_HOST );
 			$blaze_url = sprintf(
 				'%1$s#!/advertising/posts/promote/post-%2$s/%3$s',

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -138,9 +138,17 @@ class Blaze {
 		$css_prefix = apply_filters( 'jetpack_blaze_dashboard_css_prefix', 'jp-blaze' );
 
 		$parent_slug     = self::get_menu_parent();
+		$is_simple_site  = defined( 'IS_WPCOM' ) && IS_WPCOM;
 		$blaze_dashboard = new Blaze_Dashboard( 'admin.php', $menu_slug, $css_prefix );
 
-		if ( self::is_dashboard_enabled() ) {
+		// On Simple Sites the embedded wp-admin dashboard does not work under a
+		// plugin parent menu (admin.php?page=advertising is not routed by the
+		// WPCOM admin bridge and falls back to /home/).  Use the external
+		// Calypso URL instead, which is the same approach every other Jetpack
+		// submenu item takes on Simple Sites.
+		$use_embedded_dashboard = self::is_dashboard_enabled() && ! $is_simple_site;
+
+		if ( $use_embedded_dashboard ) {
 			if ( self::has_site_campaigns() ) {
 				$page_suffix = add_menu_page(
 					esc_attr( $menu_label ),
@@ -262,8 +270,12 @@ class Blaze {
 
 		// Use the site-specific stats endpoint so we count all campaigns
 		// belonging to this site regardless of status (including those in moderation).
+		// We use request_as_blog (not request_as_user) because on Simple Sites
+		// request_as_user relies on Jetpack Signature which is unavailable.
+		// request_as_blog uses WPCOM_API_Direct on Simple Sites, making the call
+		// without an HTTP round-trip.
 		$url      = sprintf( '/sites/%d/wordads/dsp/api/v1/campaigns/site/%d/stats', $site_id, $site_id );
-		$response = Client::wpcom_json_api_request_as_user(
+		$response = Client::wpcom_json_api_request_as_blog(
 			$url,
 			'2',
 			array( 'method' => 'GET' ),
@@ -291,6 +303,12 @@ class Blaze {
 	 * @return void
 	 */
 	public static function redirect_legacy_advertising_url() {
+		// On Simple Sites the menu is not registered under admin.php, so
+		// redirecting tools.php → admin.php would land on an unroutable URL.
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			return;
+		}
+
 		global $pagenow;
 
 		if (
@@ -468,7 +486,12 @@ class Blaze {
 	 * @return array An array with the link, and whether this is a Calypso or a wp-admin link.
 	 */
 	public static function get_campaign_management_url( $post_id ) {
-		if ( self::is_dashboard_enabled() ) {
+		$is_simple_site = defined( 'IS_WPCOM' ) && IS_WPCOM;
+
+		// Use the embedded dashboard URL on non-Simple sites with the dashboard enabled.
+		// Simple Sites cannot route admin.php?page=* under plugin parent menus,
+		// so they fall through to the Calypso URL below.
+		if ( self::is_dashboard_enabled() && ! $is_simple_site ) {
 			/** This filter is documented in Blaze::enable_blaze_menu() */
 			$menu_slug = apply_filters( 'jetpack_blaze_menu_slug', 'advertising' );
 			$admin_url = admin_url( 'admin.php?page=' . $menu_slug );

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -143,8 +143,8 @@ class Blaze {
 		// URLs.  admin.php?page=… under a plugin parent falls back to /home/.
 		// Keep tools.php as the dashboard base so the embedded dashboard keeps
 		// working on Simple Sites.
-		$is_simple_site = defined( 'IS_WPCOM' ) && IS_WPCOM;
-		$admin_page     = $is_simple_site ? 'tools.php' : 'admin.php';
+		$is_simple_site  = defined( 'IS_WPCOM' ) && IS_WPCOM;
+		$admin_page      = $is_simple_site ? 'tools.php' : 'admin.php';
 		$blaze_dashboard = new Blaze_Dashboard( $admin_page, $menu_slug, $css_prefix );
 
 		if ( self::is_dashboard_enabled() ) {
@@ -491,7 +491,7 @@ class Blaze {
 			// Simple Sites use tools.php; all other installations use admin.php.
 			$admin_page = ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ? 'tools.php' : 'admin.php';
 			$admin_url  = admin_url( $admin_page . '?page=' . $menu_slug );
-			$hostname  = wp_parse_url( get_site_url(), PHP_URL_HOST );
+			$hostname   = wp_parse_url( get_site_url(), PHP_URL_HOST );
 			$blaze_url = sprintf(
 				'%1$s#!/advertising/posts/promote/post-%2$s/%3$s',
 				$admin_url,

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -139,16 +139,26 @@ class Blaze {
 
 		$parent_slug = self::get_menu_parent();
 
-		// On Simple Sites the WPCOM admin bridge only routes tools.php?page=…
-		// URLs.  admin.php?page=… under a plugin parent falls back to /home/.
-		// Keep tools.php as the dashboard base so the embedded dashboard keeps
-		// working on Simple Sites.
-		$is_simple_site  = defined( 'IS_WPCOM' ) && IS_WPCOM;
-		$admin_page      = $is_simple_site ? 'tools.php' : 'admin.php';
-		$blaze_dashboard = new Blaze_Dashboard( $admin_page, $menu_slug, $css_prefix );
+		$is_simple_site      = defined( 'IS_WPCOM' ) && IS_WPCOM;
+		$admin_page          = $is_simple_site ? 'tools.php' : 'admin.php';
+		$blaze_dashboard     = new Blaze_Dashboard( $admin_page, $menu_slug, $css_prefix );
+		$dashboard_enabled   = self::is_dashboard_enabled();
+		$has_campaigns       = self::has_site_campaigns();
+		$wpcom_admin_iface   = get_option( 'wpcom_admin_interface', '(not set)' );
 
-		if ( self::is_dashboard_enabled() ) {
-			if ( self::has_site_campaigns() ) {
+		// DEBUG — remove before merging.
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		error_log( sprintf(
+			'[BLAZE-DEBUG] enable_blaze_menu: parent_slug=%s, is_simple=%s, dashboard_enabled=%s, has_campaigns=%s, wpcom_admin_interface=%s',
+			$parent_slug,
+			$is_simple_site ? 'yes' : 'no',
+			$dashboard_enabled ? 'yes' : 'no',
+			$has_campaigns ? 'yes' : 'no',
+			$wpcom_admin_iface
+		) );
+
+		if ( $dashboard_enabled ) {
+			if ( $has_campaigns ) {
 				$page_suffix = add_menu_page(
 					esc_attr( $menu_label ),
 					$menu_label,

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -476,8 +476,8 @@ class Blaze {
 			/** This filter is documented in Blaze::enable_blaze_menu() */
 			$menu_slug = apply_filters( 'jetpack_blaze_menu_slug', 'advertising' );
 			$admin_url = admin_url( 'admin.php?page=' . $menu_slug );
-			$hostname   = wp_parse_url( get_site_url(), PHP_URL_HOST );
-			$blaze_url  = sprintf(
+			$hostname  = wp_parse_url( get_site_url(), PHP_URL_HOST );
+			$blaze_url = sprintf(
 				'%1$s#!/advertising/posts/promote/post-%2$s/%3$s',
 				$admin_url,
 				esc_attr( $post_id ),

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -143,7 +143,7 @@ class Blaze {
 		$blaze_dashboard = new Blaze_Dashboard( $admin_page, $menu_slug, $css_prefix );
 
 		if ( self::is_dashboard_enabled() ) {
-			if ( $has_campaigns ) {
+			if ( self::has_site_campaigns() ) {
 				$page_suffix = add_menu_page(
 					esc_attr( $menu_label ),
 					$menu_label,
@@ -485,9 +485,9 @@ class Blaze {
 			$menu_slug = apply_filters( 'jetpack_blaze_menu_slug', 'advertising' );
 			// Simple Sites use tools.php; all other installations use admin.php.
 			$admin_page = ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ? 'tools.php' : 'admin.php';
-			$admin_url = admin_url( $admin_page . '?page=' . $menu_slug );
-			$hostname  = wp_parse_url( get_site_url(), PHP_URL_HOST );
-			$blaze_url = sprintf(
+			$admin_url  = admin_url( $admin_page . '?page=' . $menu_slug );
+			$hostname   = wp_parse_url( get_site_url(), PHP_URL_HOST );
+			$blaze_url  = sprintf(
 				'%1$s#!/advertising/posts/promote/post-%2$s/%3$s',
 				$admin_url,
 				esc_attr( $post_id ),

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack;
 
+use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Blaze\Dashboard as Blaze_Dashboard;
 use Automattic\Jetpack\Blaze\Dashboard_REST_Controller as Blaze_Dashboard_REST_Controller;
 use Automattic\Jetpack\Blaze\REST_Controller;
@@ -125,7 +126,7 @@ class Blaze {
 		 *
 		 * @param string $menu_label The menu label. Default 'Blaze Ads'.
 		 */
-		$menu_label = apply_filters( 'jetpack_blaze_menu_label', __( 'Blaze Ads', 'jetpack-blaze' ) );
+		$menu_label = apply_filters( 'jetpack_blaze_menu_label', __( 'Blaze Ads Test 2', 'jetpack-blaze' ) );
 
 		/**
 		 * Filter the CSS class prefix for the Blaze dashboard.
@@ -139,8 +140,9 @@ class Blaze {
 		$parent_slug     = self::get_menu_parent();
 		$blaze_dashboard = new Blaze_Dashboard( 'admin.php', $menu_slug, $css_prefix );
 
-		if ( self::is_dashboard_enabled() ) {
+		if ( self::is_dashboard_enabled() || ( new Host() )->is_wpcom_platform() ) {
 			if ( self::has_site_campaigns() ) {
+				// Top-level menu when the site has campaigns — no parent dependency.
 				$page_suffix = add_menu_page(
 					esc_attr( $menu_label ),
 					$menu_label,
@@ -150,9 +152,13 @@ class Blaze {
 					'dashicons-megaphone',
 					30
 				);
-			} else {
-				$page_suffix = add_submenu_page(
-					$parent_slug,
+			} elseif ( 'jetpack' === $parent_slug ) {
+				// Use Admin_Menu to register under Jetpack. This avoids a race
+				// condition on Simple Sites where the Jetpack top-level menu is
+				// created at priority 1000, but this code runs at 999. Registering
+				// via add_submenu_page before the parent exists causes WordPress to
+				// compute the wrong page hookname, resulting in a broken menu URL.
+				$page_suffix = Admin_Menu::add_menu(
 					esc_attr( $menu_label ),
 					$menu_label,
 					'manage_options',
@@ -160,20 +166,9 @@ class Blaze {
 					array( $blaze_dashboard, 'render' ),
 					1
 				);
-			}
-			add_action( 'load-' . $page_suffix, array( $blaze_dashboard, 'admin_init' ) );
-		} elseif ( ( new Host() )->is_wpcom_platform() ) {
-			if ( self::has_site_campaigns() ) {
-				$page_suffix = add_menu_page(
-					esc_attr( $menu_label ),
-					$menu_label,
-					'manage_options',
-					$menu_slug,
-					array( $blaze_dashboard, 'render' ),
-					'dashicons-megaphone',
-					30
-				);
 			} else {
+				// For other parents (tools.php, woocommerce-marketing) that are
+				// guaranteed to exist at this priority, use add_submenu_page directly.
 				$page_suffix = add_submenu_page(
 					$parent_slug,
 					esc_attr( $menu_label ),

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -126,7 +126,7 @@ class Blaze {
 		 *
 		 * @param string $menu_label The menu label. Default 'Blaze Ads'.
 		 */
-		$menu_label = apply_filters( 'jetpack_blaze_menu_label', __( 'Blaze Ads Test 2', 'jetpack-blaze' ) );
+		$menu_label = apply_filters( 'jetpack_blaze_menu_label', __( 'Blaze Ads', 'jetpack-blaze' ) );
 
 		/**
 		 * Filter the CSS class prefix for the Blaze dashboard.

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -55,6 +55,9 @@ class Blaze {
 		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_block_editor_assets' ) );
 		// Add a Blaze Menu.
 		add_action( 'admin_menu', array( __CLASS__, 'enable_blaze_menu' ), 999 );
+		// Redirect old tools.php URL to the canonical admin.php URL.
+		// Hooked early on admin_menu so it runs before WordPress validates the page parameter.
+		add_action( 'admin_menu', array( __CLASS__, 'redirect_legacy_advertising_url' ), 1 );
 		// Add Blaze dashboard app REST API endpoints.
 		add_action( 'rest_api_init', array( new Blaze_Dashboard_REST_Controller(), 'register_rest_routes' ) );
 		// Add general Blaze REST API endpoints.
@@ -107,31 +110,198 @@ class Blaze {
 			return;
 		}
 
-		$blaze_dashboard = new Blaze_Dashboard();
+		/**
+		 * Filter the menu page slug used for the Blaze dashboard.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param string $menu_slug The menu page slug. Default 'advertising'.
+		 */
+		$menu_slug = apply_filters( 'jetpack_blaze_menu_slug', 'advertising' );
+
+		/**
+		 * Filter the menu label for the Blaze dashboard menu item.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param string $menu_label The menu label. Default 'Blaze Ads'.
+		 */
+		$menu_label = apply_filters( 'jetpack_blaze_menu_label', __( 'Blaze Ads', 'jetpack-blaze' ) );
+
+		/**
+		 * Filter the CSS class prefix for the Blaze dashboard.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param string $css_prefix The CSS class prefix. Default 'jp-blaze'.
+		 */
+		$css_prefix = apply_filters( 'jetpack_blaze_dashboard_css_prefix', 'jp-blaze' );
+
+		$parent_slug     = self::get_menu_parent();
+		$blaze_dashboard = new Blaze_Dashboard( 'admin.php', $menu_slug, $css_prefix );
 
 		if ( self::is_dashboard_enabled() ) {
-			$page_suffix = add_submenu_page(
-				'tools.php',
-				esc_attr__( 'Advertising', 'jetpack-blaze' ),
-				__( 'Advertising', 'jetpack-blaze' ),
-				'manage_options',
-				'advertising',
-				array( $blaze_dashboard, 'render' ),
-				1
-			);
+			if ( self::has_site_campaigns() ) {
+				$page_suffix = add_menu_page(
+					esc_attr( $menu_label ),
+					$menu_label,
+					'manage_options',
+					$menu_slug,
+					array( $blaze_dashboard, 'render' ),
+					'dashicons-megaphone',
+					30
+				);
+			} else {
+				$page_suffix = add_submenu_page(
+					$parent_slug,
+					esc_attr( $menu_label ),
+					$menu_label,
+					'manage_options',
+					$menu_slug,
+					array( $blaze_dashboard, 'render' ),
+					1
+				);
+			}
 			add_action( 'load-' . $page_suffix, array( $blaze_dashboard, 'admin_init' ) );
 		} elseif ( ( new Host() )->is_wpcom_platform() ) {
-			$domain      = ( new Jetpack_Status() )->get_site_suffix();
-			$page_suffix = add_submenu_page(
-				'tools.php',
-				esc_attr__( 'Advertising', 'jetpack-blaze' ),
-				__( 'Advertising', 'jetpack-blaze' ),
-				'manage_options',
-				'https://wordpress.com/advertising/' . $domain,
-				null, // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539
-				1
-			);
+			$domain = ( new Jetpack_Status() )->get_site_suffix();
+			$url    = 'https://wordpress.com/advertising/' . $domain;
+
+			if ( self::has_site_campaigns() ) {
+				$page_suffix = add_menu_page(
+					esc_attr( $menu_label ),
+					$menu_label,
+					'manage_options',
+					$url,
+					null, // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539
+					'dashicons-megaphone',
+					30
+				);
+			} else {
+				$page_suffix = add_submenu_page(
+					$parent_slug,
+					esc_attr( $menu_label ),
+					$menu_label,
+					'manage_options',
+					$url,
+					null, // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539
+					1
+				);
+			}
 			add_action( 'load-' . $page_suffix, array( $blaze_dashboard, 'admin_init' ) );
+		}
+	}
+
+	/**
+	 * Determine the appropriate parent menu slug based on the installation context.
+	 *
+	 * - WooCommerce active: parent is 'woocommerce-marketing'
+	 * - WPCOM platform or Jetpack connected: parent is 'jetpack'
+	 * - Otherwise: parent is 'tools.php'
+	 *
+	 * @return string The parent menu slug.
+	 */
+	public static function get_menu_parent() {
+		if ( class_exists( 'WooCommerce' ) ) {
+			// Only use woocommerce-marketing if the menu is actually registered.
+			global $menu;
+			foreach ( (array) $menu as $item ) {
+				if ( isset( $item[2] ) && 'woocommerce-marketing' === $item[2] ) {
+					$parent = 'woocommerce-marketing';
+
+					/**
+					 * Filter the parent menu slug for the Blaze dashboard submenu item.
+					 *
+					 * @since $$next-version$$
+					 *
+					 * @param string $parent The parent menu slug.
+					 */
+					return apply_filters( 'jetpack_blaze_menu_parent', $parent );
+				}
+			}
+		}
+
+		if ( ( new Host() )->is_wpcom_platform() ) {
+			/** This filter is documented above. */
+			return apply_filters( 'jetpack_blaze_menu_parent', 'jetpack' );
+		}
+
+		// should_initialize() already checks Jetpack connection, so if we reach
+		// enable_blaze_menu() on a self-hosted site, the site is connected.
+		$connection = new Jetpack_Connection();
+		if ( $connection->is_connected() ) {
+			/** This filter is documented above. */
+			return apply_filters( 'jetpack_blaze_menu_parent', 'jetpack' );
+		}
+
+		/** This filter is documented above. */
+		return apply_filters( 'jetpack_blaze_menu_parent', 'tools.php' );
+	}
+
+	/**
+	 * Check whether the site has any Blaze campaigns.
+	 *
+	 * Results are cached in a transient for one hour. On error the method
+	 * returns false so the menu falls back to a submenu entry.
+	 *
+	 * @return bool
+	 */
+	public static function has_site_campaigns() {
+		$site_id = Jetpack_Connection::get_site_id();
+
+		if ( is_wp_error( $site_id ) || ! is_numeric( $site_id ) ) {
+			return false;
+		}
+
+		$transient_name = 'jetpack_blaze_has_site_campaigns_' . $site_id;
+		$cached_result  = get_transient( $transient_name );
+
+		if ( false !== $cached_result ) {
+			return 'yes' === $cached_result;
+		}
+
+		// Use the site-specific stats endpoint so we count all campaigns
+		// belonging to this site regardless of status (including those in moderation).
+		$url      = sprintf( '/sites/%d/wordads/dsp/api/v1/campaigns/site/%d/stats', $site_id, $site_id );
+		$response = Client::wpcom_json_api_request_as_user(
+			$url,
+			'2',
+			array( 'method' => 'GET' ),
+			null,
+			'wpcom'
+		);
+
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			set_transient( $transient_name, 'no', HOUR_IN_SECONDS );
+			return false;
+		}
+
+		$result      = json_decode( wp_remote_retrieve_body( $response ), true );
+		$has_active  = is_array( $result ) && ! empty( $result['total'] );
+		$cache_value = $has_active ? 'yes' : 'no';
+
+		set_transient( $transient_name, $cache_value, HOUR_IN_SECONDS );
+
+		return $has_active;
+	}
+
+	/**
+	 * Redirect the legacy tools.php?page=advertising URL to admin.php?page=advertising.
+	 *
+	 * @return void
+	 */
+	public static function redirect_legacy_advertising_url() {
+		global $pagenow;
+
+		if (
+			'tools.php' === $pagenow
+			&& isset( $_GET['page'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			&& 'advertising' === $_GET['page'] // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		) {
+			/** This filter is documented in Blaze::enable_blaze_menu() */
+			$menu_slug = apply_filters( 'jetpack_blaze_menu_slug', 'advertising' );
+			wp_safe_redirect( admin_url( 'admin.php?page=' . $menu_slug ), 302 );
+			exit;
 		}
 	}
 
@@ -299,7 +469,9 @@ class Blaze {
 	 */
 	public static function get_campaign_management_url( $post_id ) {
 		if ( self::is_dashboard_enabled() ) {
-			$admin_url = admin_url( 'tools.php?page=advertising' );
+			/** This filter is documented in Blaze::enable_blaze_menu() */
+			$menu_slug = apply_filters( 'jetpack_blaze_menu_slug', 'advertising' );
+			$admin_url = admin_url( 'admin.php?page=' . $menu_slug );
 			$hostname  = wp_parse_url( get_site_url(), PHP_URL_HOST );
 			$blaze_url = sprintf(
 				'%1$s#!/advertising/posts/promote/post-%2$s/%3$s',

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -144,25 +144,74 @@ class Blaze {
 
 		if ( self::is_dashboard_enabled() ) {
 			if ( self::has_site_campaigns() ) {
-				$page_suffix = add_menu_page(
-					esc_attr( $menu_label ),
-					$menu_label,
-					'manage_options',
-					$menu_slug,
-					array( $blaze_dashboard, 'render' ),
-					'dashicons-megaphone',
-					30
-				);
+				if ( $is_simple_site ) {
+					// On Simple Sites, add_menu_page with a slug produces
+					// admin.php?page=slug which the WPCOM bridge cannot route.
+					// Register the page under tools.php (routable) and add a
+					// visible top-level menu pointing to it.
+					$page_suffix = add_submenu_page(
+						'tools.php',
+						esc_attr( $menu_label ),
+						$menu_label,
+						'manage_options',
+						$menu_slug,
+						array( $blaze_dashboard, 'render' ),
+						1
+					);
+					remove_submenu_page( 'tools.php', $menu_slug );
+					add_menu_page(
+						esc_attr( $menu_label ),
+						$menu_label,
+						'manage_options',
+						admin_url( 'tools.php?page=' . $menu_slug ),
+						null, // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
+						'dashicons-megaphone',
+						30
+					);
+				} else {
+					$page_suffix = add_menu_page(
+						esc_attr( $menu_label ),
+						$menu_label,
+						'manage_options',
+						$menu_slug,
+						array( $blaze_dashboard, 'render' ),
+						'dashicons-megaphone',
+						30
+					);
+				}
 			} else {
-				$page_suffix = add_submenu_page(
-					$parent_slug,
-					esc_attr( $menu_label ),
-					$menu_label,
-					'manage_options',
-					$menu_slug,
-					array( $blaze_dashboard, 'render' ),
-					1
-				);
+				if ( $is_simple_site ) {
+					// Same approach: register routable page, link from Jetpack.
+					$page_suffix = add_submenu_page(
+						'tools.php',
+						esc_attr( $menu_label ),
+						$menu_label,
+						'manage_options',
+						$menu_slug,
+						array( $blaze_dashboard, 'render' ),
+						1
+					);
+					remove_submenu_page( 'tools.php', $menu_slug );
+					add_submenu_page(
+						$parent_slug,
+						esc_attr( $menu_label ),
+						$menu_label,
+						'manage_options',
+						admin_url( 'tools.php?page=' . $menu_slug ),
+						null, // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal
+						1
+					);
+				} else {
+					$page_suffix = add_submenu_page(
+						$parent_slug,
+						esc_attr( $menu_label ),
+						$menu_label,
+						'manage_options',
+						$menu_slug,
+						array( $blaze_dashboard, 'render' ),
+						1
+					);
+				}
 			}
 			add_action( 'load-' . $page_suffix, array( $blaze_dashboard, 'admin_init' ) );
 		} elseif ( ( new Host() )->is_wpcom_platform() ) {

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -13,7 +13,6 @@ use Automattic\Jetpack\Blaze\REST_Controller;
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
-use Automattic\Jetpack\Status as Jetpack_Status;
 use Automattic\Jetpack\Status\Host;
 use Automattic\Jetpack\Sync\Settings as Sync_Settings;
 use WP_Post;
@@ -164,16 +163,13 @@ class Blaze {
 			}
 			add_action( 'load-' . $page_suffix, array( $blaze_dashboard, 'admin_init' ) );
 		} elseif ( ( new Host() )->is_wpcom_platform() ) {
-			$domain = ( new Jetpack_Status() )->get_site_suffix();
-			$url    = 'https://wordpress.com/advertising/' . $domain;
-
 			if ( self::has_site_campaigns() ) {
 				$page_suffix = add_menu_page(
 					esc_attr( $menu_label ),
 					$menu_label,
 					'manage_options',
-					$url,
-					null, // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539
+					$menu_slug,
+					array( $blaze_dashboard, 'render' ),
 					'dashicons-megaphone',
 					30
 				);
@@ -183,8 +179,8 @@ class Blaze {
 					esc_attr( $menu_label ),
 					$menu_label,
 					'manage_options',
-					$url,
-					null, // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- Core should ideally document null for no-callback arg. https://core.trac.wordpress.org/ticket/52539
+					$menu_slug,
+					array( $blaze_dashboard, 'render' ),
 					1
 				);
 			}

--- a/projects/packages/blaze/src/class-dashboard-config-data.php
+++ b/projects/packages/blaze/src/class-dashboard-config-data.php
@@ -19,7 +19,7 @@ use Jetpack_Options;
 class Dashboard_Config_Data {
 
 	/**
-	 * Blaze dashboard admin page. Default is tools.php.
+	 * Blaze dashboard admin page. Default is admin.php.
 	 *
 	 * @var string
 	 */
@@ -35,10 +35,10 @@ class Dashboard_Config_Data {
 	/**
 	 * Dashboard config constructor.
 	 *
-	 * @param string $admin_page Dashboard admin page. Default is tools.php.
+	 * @param string $admin_page Dashboard admin page. Default is admin.php.
 	 * @param string $menu_slug Dashboard menu slug. Default is 'advertising'.
 	 */
-	public function __construct( $admin_page = 'tools.php', $menu_slug = 'advertising' ) {
+	public function __construct( $admin_page = 'admin.php', $menu_slug = 'advertising' ) {
 		$this->admin_page = $admin_page;
 		$this->menu_slug  = $menu_slug;
 	}

--- a/projects/packages/blaze/src/class-dashboard-rest-controller.php
+++ b/projects/packages/blaze/src/class-dashboard-rest-controller.php
@@ -1235,6 +1235,12 @@ class Dashboard_REST_Controller {
 
 		if ( ! is_wp_error( $response ) && is_array( $response ) ) {
 			$response['sync_ready'] = $sync_ready;
+
+			// Invalidate the cached campaign check so the menu updates immediately.
+			$site_id = $this->get_site_id();
+			if ( ! is_wp_error( $site_id ) ) {
+				delete_transient( 'jetpack_blaze_has_site_campaigns_' . $site_id );
+			}
 		}
 
 		return $response;

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -59,7 +59,7 @@ class Dashboard {
 	const BLAZEDASH_CACHE_BUSTER_CACHE_KEY = 'jetpack_blaze_admin_asset_cache_buster';
 
 	/**
-	 * Blaze dashboard admin page. Default is tools.php.
+	 * Blaze dashboard admin page. Default is admin.php.
 	 *
 	 * @var string
 	 */
@@ -82,11 +82,11 @@ class Dashboard {
 	/**
 	 * Dashboard constructor.
 	 *
-	 * @param string $admin_page Dashboard admin page. Default is tools.php.
+	 * @param string $admin_page Dashboard admin page. Default is admin.php.
 	 * @param string $menu_slug Dashboard menu slug. Default is 'advertising'.
 	 * @param string $css_prefix Dashboard css prefix. Default is 'jp-blaze'.
 	 */
-	public function __construct( $admin_page = 'tools.php', $menu_slug = 'advertising', $css_prefix = 'jp-blaze' ) {
+	public function __construct( $admin_page = 'admin.php', $menu_slug = 'advertising', $css_prefix = 'jp-blaze' ) {
 		$this->admin_page = $admin_page;
 		$this->menu_slug  = $menu_slug;
 		$this->css_prefix = $css_prefix;

--- a/projects/packages/blaze/tests/php/Blaze_Test.php
+++ b/projects/packages/blaze/tests/php/Blaze_Test.php
@@ -37,6 +37,13 @@ class Blaze_Test extends BaseTestCase {
 	 * Set up before each test.
 	 */
 	public function set_up() {
+		// Reset admin menu globals to avoid state leakage between tests.
+		global $menu, $submenu, $_parent_pages, $_registered_pages;
+		$menu              = array();
+		$submenu           = array();
+		$_parent_pages     = array();
+		$_registered_pages = array();
+
 		$this->admin_id = wp_insert_user(
 			array(
 				'user_login' => 'dummy_user',
@@ -149,6 +156,375 @@ class Blaze_Test extends BaseTestCase {
 		$this->assertNotEmpty( menu_page_url( 'advertising', false ) );
 
 		add_filter( 'jetpack_blaze_enabled', '__return_false' );
+	}
+
+	/**
+	 * Test that the menu label is "Blaze Ads" (not "Advertising").
+	 */
+	public function test_admin_menu_label_is_blaze_ads() {
+		global $submenu;
+
+		wp_set_current_user( $this->admin_id );
+		add_filter( 'jetpack_blaze_enabled', '__return_true' );
+
+		Blaze::enable_blaze_menu();
+
+		// Find the "advertising" submenu entry and verify its label.
+		$parent_slug = Blaze::get_menu_parent();
+		$found_label = null;
+		if ( isset( $submenu[ $parent_slug ] ) ) {
+			foreach ( $submenu[ $parent_slug ] as $item ) {
+				if ( 'advertising' === $item[2] ) {
+					$found_label = $item[0];
+					break;
+				}
+			}
+		}
+
+		$this->assertSame( 'Blaze Ads', $found_label );
+
+		add_filter( 'jetpack_blaze_enabled', '__return_false' );
+	}
+
+	/**
+	 * Test that get_menu_parent() returns 'tools.php' when neither WooCommerce
+	 * nor Jetpack connection is present.
+	 */
+	public function test_get_menu_parent_fallback() {
+		// In the test environment, WooCommerce class does not exist and
+		// the site is not WPCOM or Jetpack-connected, so we should get tools.php.
+		$this->assertSame( 'tools.php', Blaze::get_menu_parent() );
+	}
+
+	/**
+	 * Test that has_site_campaigns() returns false when there is no site ID
+	 * (the typical test-environment scenario).
+	 */
+	public function test_has_site_campaigns_returns_false_without_site_id() {
+		$this->assertFalse( Blaze::has_site_campaigns() );
+	}
+
+	/**
+	 * Test that has_site_campaigns() reads the cached transient.
+	 */
+	public function test_has_site_campaigns_cached_yes() {
+		// Seed the site ID in the compact jetpack_options array (where
+		// Jetpack_Options::get_option( 'id' ) actually reads it).
+		update_option( 'jetpack_options', array( 'id' => 12345 ) );
+		set_transient( 'jetpack_blaze_has_site_campaigns_12345', 'yes', HOUR_IN_SECONDS );
+
+		$this->assertTrue( Blaze::has_site_campaigns() );
+
+		delete_transient( 'jetpack_blaze_has_site_campaigns_12345' );
+		delete_option( 'jetpack_options' );
+	}
+
+	/**
+	 * Test that has_site_campaigns() reads cached "no" transient.
+	 */
+	public function test_has_site_campaigns_cached_no() {
+		update_option( 'jetpack_options', array( 'id' => 12345 ) );
+		set_transient( 'jetpack_blaze_has_site_campaigns_12345', 'no', HOUR_IN_SECONDS );
+
+		$this->assertFalse( Blaze::has_site_campaigns() );
+
+		delete_transient( 'jetpack_blaze_has_site_campaigns_12345' );
+		delete_option( 'jetpack_options' );
+	}
+
+	/**
+	 * Test that enable_blaze_menu() registers a top-level menu when the site
+	 * has active campaigns (transient cached as 'yes').
+	 */
+	public function test_top_level_menu_when_active_campaigns() {
+		global $menu;
+
+		wp_set_current_user( $this->admin_id );
+		add_filter( 'jetpack_blaze_enabled', '__return_true' );
+
+		// Seed the site ID and campaign transient.
+		update_option( 'jetpack_options', array( 'id' => 12345 ) );
+		set_transient( 'jetpack_blaze_has_site_campaigns_12345', 'yes', HOUR_IN_SECONDS );
+
+		Blaze::enable_blaze_menu();
+
+		// Verify a top-level menu entry exists for 'advertising'.
+		$found_top_level = false;
+		foreach ( (array) $menu as $item ) {
+			if ( isset( $item[2] ) && 'advertising' === $item[2] ) {
+				$found_top_level = true;
+				break;
+			}
+		}
+
+		$this->assertTrue( $found_top_level, 'Expected a top-level menu entry for advertising when active campaigns exist.' );
+
+		delete_transient( 'jetpack_blaze_has_site_campaigns_12345' );
+		delete_option( 'jetpack_options' );
+		add_filter( 'jetpack_blaze_enabled', '__return_false' );
+	}
+
+	/**
+	 * Test that enable_blaze_menu() registers a submenu (not top-level)
+	 * when the site has no active campaigns.
+	 */
+	public function test_submenu_when_no_active_campaigns() {
+		global $menu, $submenu;
+
+		wp_set_current_user( $this->admin_id );
+		add_filter( 'jetpack_blaze_enabled', '__return_true' );
+
+		Blaze::enable_blaze_menu();
+
+		// Verify 'advertising' is NOT in the top-level menu.
+		$found_top_level = false;
+		foreach ( (array) $menu as $item ) {
+			if ( isset( $item[2] ) && 'advertising' === $item[2] ) {
+				$found_top_level = true;
+				break;
+			}
+		}
+		$this->assertFalse( $found_top_level, 'Did not expect a top-level menu entry when no active campaigns.' );
+
+		// Verify it exists as a submenu instead.
+		$parent_slug   = Blaze::get_menu_parent();
+		$found_submenu = false;
+		if ( isset( $submenu[ $parent_slug ] ) ) {
+			foreach ( $submenu[ $parent_slug ] as $item ) {
+				if ( 'advertising' === $item[2] ) {
+					$found_submenu = true;
+					break;
+				}
+			}
+		}
+		$this->assertTrue( $found_submenu, 'Expected a submenu entry for advertising under ' . $parent_slug );
+
+		add_filter( 'jetpack_blaze_enabled', '__return_false' );
+	}
+
+	/**
+	 * Test that get_menu_parent() returns 'woocommerce-marketing' when WooCommerce
+	 * is active and the marketing menu is registered.
+	 */
+	public function test_get_menu_parent_woocommerce() {
+		global $menu;
+
+		// In CI the WooCommerce stubs are already loaded, so class_exists
+		// returns true. Skip the test when the class is not available.
+		if ( ! class_exists( 'WooCommerce' ) ) {
+			$this->markTestSkipped( 'WooCommerce class not available.' );
+		}
+
+		// Simulate WooCommerce marketing menu being registered.
+		$menu[] = array( 'Marketing', 'manage_options', 'woocommerce-marketing', '', '', '', '' );
+
+		$this->assertSame( 'woocommerce-marketing', Blaze::get_menu_parent() );
+	}
+
+	/**
+	 * Test that has_site_campaigns() returns true when the API returns campaigns.
+	 */
+	public function test_has_site_campaigns_api_returns_campaigns() {
+		update_option( 'jetpack_options', array( 'id' => 99999 ) );
+		// Ensure no cached transient.
+		delete_transient( 'jetpack_blaze_has_site_campaigns_99999' );
+
+		Constants::$set_constants['JETPACK__WPCOM_JSON_API_BASE'] = 'https://public-api.wordpress.com';
+		update_option( 'jetpack_private_options', array( 'blog_token' => 'blog.token' ) );
+
+		add_filter(
+			'pre_http_request',
+			function () {
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => wp_json_encode(
+						array(
+							'total'   => 1,
+							'results' => array( array( 'campaign_id' => 1 ) ),
+						),
+						JSON_UNESCAPED_SLASHES
+					),
+				);
+			}
+		);
+
+		$this->assertTrue( Blaze::has_site_campaigns() );
+
+		delete_transient( 'jetpack_blaze_has_site_campaigns_99999' );
+		delete_option( 'jetpack_options' );
+		delete_option( 'jetpack_private_options' );
+	}
+
+	/**
+	 * Test that has_site_campaigns() returns false when the API returns empty campaigns.
+	 */
+	public function test_has_site_campaigns_api_returns_empty() {
+		update_option( 'jetpack_options', array( 'id' => 99999 ) );
+		delete_transient( 'jetpack_blaze_has_site_campaigns_99999' );
+
+		Constants::$set_constants['JETPACK__WPCOM_JSON_API_BASE'] = 'https://public-api.wordpress.com';
+		update_option( 'jetpack_private_options', array( 'blog_token' => 'blog.token' ) );
+
+		add_filter(
+			'pre_http_request',
+			function () {
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => wp_json_encode(
+						array(
+							'total'   => 0,
+							'results' => array(),
+						),
+						JSON_UNESCAPED_SLASHES
+					),
+				);
+			}
+		);
+
+		$this->assertFalse( Blaze::has_site_campaigns() );
+
+		delete_transient( 'jetpack_blaze_has_site_campaigns_99999' );
+		delete_option( 'jetpack_options' );
+		delete_option( 'jetpack_private_options' );
+	}
+
+	/**
+	 * Test that has_site_campaigns() returns false when the API returns an error.
+	 */
+	public function test_has_site_campaigns_api_error() {
+		update_option( 'jetpack_options', array( 'id' => 99999 ) );
+		delete_transient( 'jetpack_blaze_has_site_campaigns_99999' );
+
+		Constants::$set_constants['JETPACK__WPCOM_JSON_API_BASE'] = 'https://public-api.wordpress.com';
+		update_option( 'jetpack_private_options', array( 'blog_token' => 'blog.token' ) );
+
+		add_filter(
+			'pre_http_request',
+			function () {
+				return array(
+					'response' => array( 'code' => 403 ),
+					'body'     => '',
+				);
+			}
+		);
+
+		$this->assertFalse( Blaze::has_site_campaigns() );
+
+		delete_transient( 'jetpack_blaze_has_site_campaigns_99999' );
+		delete_option( 'jetpack_options' );
+		delete_option( 'jetpack_private_options' );
+	}
+
+	/**
+	 * Test that enable_blaze_menu() registers a top-level menu on WPCOM
+	 * when the dashboard is disabled and the site has active campaigns.
+	 */
+	public function test_wpcom_non_dashboard_top_level_menu_with_campaigns() {
+		global $menu;
+
+		wp_set_current_user( $this->admin_id );
+		add_filter( 'jetpack_blaze_enabled', '__return_true' );
+		add_filter( 'jetpack_blaze_dashboard_enable', '__return_false' );
+
+		// Simulate WPCOM platform.
+		Constants::set_constant( 'IS_WPCOM', true );
+
+		// Seed campaigns.
+		update_option( 'jetpack_options', array( 'id' => 12345 ) );
+		set_transient( 'jetpack_blaze_has_site_campaigns_12345', 'yes', HOUR_IN_SECONDS );
+
+		Blaze::enable_blaze_menu();
+
+		$found_top_level = false;
+		foreach ( (array) $menu as $item ) {
+			if ( isset( $item[2] ) && str_contains( $item[2], 'advertising' ) ) {
+				$found_top_level = true;
+				break;
+			}
+		}
+
+		$this->assertTrue( $found_top_level, 'Expected top-level menu on WPCOM non-dashboard with active campaigns.' );
+
+		delete_transient( 'jetpack_blaze_has_site_campaigns_12345' );
+		delete_option( 'jetpack_options' );
+		Constants::clear_single_constant( 'IS_WPCOM' );
+		add_filter( 'jetpack_blaze_enabled', '__return_false' );
+		remove_all_filters( 'jetpack_blaze_dashboard_enable' );
+	}
+
+	/**
+	 * Test that enable_blaze_menu() registers a submenu on WPCOM
+	 * when the dashboard is disabled and there are no active campaigns.
+	 */
+	public function test_wpcom_non_dashboard_submenu_without_campaigns() {
+		global $submenu;
+
+		wp_set_current_user( $this->admin_id );
+		add_filter( 'jetpack_blaze_enabled', '__return_true' );
+		add_filter( 'jetpack_blaze_dashboard_enable', '__return_false' );
+
+		Constants::set_constant( 'IS_WPCOM', true );
+
+		Blaze::enable_blaze_menu();
+
+		// Should be a submenu, not top-level.
+		$found_submenu = false;
+		foreach ( (array) $submenu as $items ) {
+			foreach ( $items as $item ) {
+				if ( isset( $item[2] ) && str_contains( $item[2], 'advertising' ) ) {
+					$found_submenu = true;
+					break 2;
+				}
+			}
+		}
+
+		$this->assertTrue( $found_submenu, 'Expected submenu on WPCOM non-dashboard without campaigns.' );
+
+		Constants::clear_single_constant( 'IS_WPCOM' );
+		add_filter( 'jetpack_blaze_enabled', '__return_false' );
+		remove_all_filters( 'jetpack_blaze_dashboard_enable' );
+	}
+
+	/**
+	 * Test that get_menu_parent() returns 'jetpack' on WPCOM platform.
+	 */
+	public function test_get_menu_parent_wpcom_platform() {
+		Constants::set_constant( 'IS_WPCOM', true );
+
+		$this->assertSame( 'jetpack', Blaze::get_menu_parent() );
+
+		Constants::clear_single_constant( 'IS_WPCOM' );
+	}
+
+	/**
+	 * Test that redirect_legacy_advertising_url does not redirect when not on tools.php.
+	 */
+	public function test_redirect_legacy_url_no_redirect_on_other_pages() {
+		global $pagenow;
+		$pagenow = 'edit.php';
+
+		// Should not redirect (no exit), just return.
+		Blaze::redirect_legacy_advertising_url();
+
+		// If we get here, no redirect happened.
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Test that get_campaign_management_url() uses admin.php (not tools.php).
+	 */
+	public function test_campaign_management_url_uses_admin_php() {
+		$url_data = Blaze::get_campaign_management_url( 42 );
+		$this->assertStringContainsString( 'admin.php?page=advertising', $url_data['link'] );
+		$this->assertStringNotContainsString( 'tools.php', $url_data['link'] );
+	}
+
+	/**
+	 * Test that redirect_legacy_advertising_url is hooked on admin_init.
+	 */
+	public function test_redirect_legacy_url_is_hooked() {
+		Blaze::init();
+		$this->assertIsInt( has_action( 'admin_menu', array( Blaze::class, 'redirect_legacy_advertising_url' ) ) );
 	}
 
 	/**
@@ -334,5 +710,119 @@ class Blaze_Test extends BaseTestCase {
 				false,
 			),
 		);
+	}
+
+	/**
+	 * Test that the jetpack_blaze_menu_slug filter changes the registered menu slug.
+	 */
+	public function test_menu_slug_filter() {
+		global $submenu;
+
+		wp_set_current_user( $this->admin_id );
+		add_filter( 'jetpack_blaze_enabled', '__return_true' );
+		add_filter(
+			'jetpack_blaze_menu_slug',
+			function () {
+				return 'wp-blaze';
+			}
+		);
+
+		Blaze::enable_blaze_menu();
+
+		$parent_slug   = Blaze::get_menu_parent();
+		$found_submenu = false;
+		if ( isset( $submenu[ $parent_slug ] ) ) {
+			foreach ( $submenu[ $parent_slug ] as $item ) {
+				if ( 'wp-blaze' === $item[2] ) {
+					$found_submenu = true;
+					break;
+				}
+			}
+		}
+		$this->assertTrue( $found_submenu, 'Expected a submenu entry with slug wp-blaze when filter is applied.' );
+
+		// Verify the default slug is not registered.
+		$found_default = false;
+		if ( isset( $submenu[ $parent_slug ] ) ) {
+			foreach ( $submenu[ $parent_slug ] as $item ) {
+				if ( 'advertising' === $item[2] ) {
+					$found_default = true;
+					break;
+				}
+			}
+		}
+		$this->assertFalse( $found_default, 'Default slug "advertising" should not be registered when filter overrides it.' );
+
+		remove_all_filters( 'jetpack_blaze_menu_slug' );
+		add_filter( 'jetpack_blaze_enabled', '__return_false' );
+	}
+
+	/**
+	 * Test that the jetpack_blaze_menu_label filter changes the menu label.
+	 */
+	public function test_menu_label_filter() {
+		global $submenu;
+
+		wp_set_current_user( $this->admin_id );
+		add_filter( 'jetpack_blaze_enabled', '__return_true' );
+		add_filter(
+			'jetpack_blaze_menu_label',
+			function () {
+				return 'Custom Ads';
+			}
+		);
+
+		Blaze::enable_blaze_menu();
+
+		$parent_slug = Blaze::get_menu_parent();
+		$found_label = null;
+		if ( isset( $submenu[ $parent_slug ] ) ) {
+			foreach ( $submenu[ $parent_slug ] as $item ) {
+				if ( 'advertising' === $item[2] ) {
+					$found_label = $item[0];
+					break;
+				}
+			}
+		}
+
+		$this->assertSame( 'Custom Ads', $found_label );
+
+		remove_all_filters( 'jetpack_blaze_menu_label' );
+		add_filter( 'jetpack_blaze_enabled', '__return_false' );
+	}
+
+	/**
+	 * Test that get_campaign_management_url() uses the filtered slug.
+	 */
+	public function test_campaign_management_url_uses_filtered_slug() {
+		add_filter(
+			'jetpack_blaze_menu_slug',
+			function () {
+				return 'wp-blaze';
+			}
+		);
+
+		$url_data = Blaze::get_campaign_management_url( 42 );
+		$this->assertStringContainsString( 'admin.php?page=wp-blaze', $url_data['link'] );
+		$this->assertStringNotContainsString( 'page=advertising', $url_data['link'] );
+
+		remove_all_filters( 'jetpack_blaze_menu_slug' );
+	}
+
+	/**
+	 * Test that the jetpack_blaze_menu_parent filter can override the parent slug.
+	 */
+	public function test_menu_parent_filter() {
+		add_filter(
+			'jetpack_blaze_menu_parent',
+			function () {
+				return 'custom-parent';
+			}
+		);
+
+		$parent = Blaze::get_menu_parent();
+		$this->assertSame( 'custom-parent', $parent );
+
+		remove_all_filters( 'jetpack_blaze_menu_parent' );
 	}
 }

--- a/projects/packages/blaze/tests/php/Blaze_Test.php
+++ b/projects/packages/blaze/tests/php/Blaze_Test.php
@@ -8,6 +8,7 @@
 
 namespace Automattic\Jetpack;
 
+use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use WorDBless\BaseTestCase;
@@ -466,6 +467,10 @@ class Blaze_Test extends BaseTestCase {
 		Constants::set_constant( 'IS_WPCOM', true );
 
 		Blaze::enable_blaze_menu();
+
+		// On WPCOM the parent is 'jetpack', so the item is queued via
+		// Admin_Menu::add_menu(). Flush the queue to populate $submenu.
+		Admin_Menu::admin_menu_hook_callback();
 
 		// Should be a submenu, not top-level.
 		$found_submenu = false;

--- a/projects/packages/blaze/tests/php/Dashboard_Test.php
+++ b/projects/packages/blaze/tests/php/Dashboard_Test.php
@@ -31,7 +31,7 @@ class Dashboard_Test extends BaseTestCase {
 	 */
 	public function test_render_with_overridden_class() {
 		$this->expectOutputRegex( '/<div id="wpcom" class="custom-class-dashboard".*>/i' );
-		( new Dashboard( 'tools.php', 'advertising', 'custom-class' ) )->render();
+		( new Dashboard( 'admin.php', 'advertising', 'custom-class' ) )->render();
 	}
 
 	/**
@@ -50,12 +50,50 @@ class Dashboard_Test extends BaseTestCase {
 		$style_handle  = $script_handle . '-style';
 
 		// Scripts and style should not be enqueued on the main dashboard.
-		( new Dashboard( 'tools.php', 'custom-menu' ) )->load_admin_scripts( 'index.php' );
+		( new Dashboard( 'admin.php', 'custom-menu' ) )->load_admin_scripts( 'index.php' );
 		$this->assertFalse( wp_script_is( $script_handle, 'enqueued' ) );
 		$this->assertFalse( wp_style_is( $style_handle, 'enqueued' ) );
 
 		// They should, however, be enqueued on the Advertising page.
-		( new Dashboard( 'tools.php', 'custom-menu' ) )->load_admin_scripts( 'tools_page_custom-menu' );
+		( new Dashboard( 'admin.php', 'custom-menu' ) )->load_admin_scripts( 'toplevel_page_custom-menu' );
+		$this->assertTrue( wp_script_is( $script_handle, 'enqueued' ) );
+		$this->assertTrue( wp_style_is( $style_handle, 'enqueued' ) );
+	}
+
+	/**
+	 * Ensure the script is enqueued for submenu pages under Jetpack parent.
+	 */
+	public function test_load_admin_scripts_jetpack_parent() {
+		$script_handle = Dashboard::SCRIPT_HANDLE;
+		$style_handle  = $script_handle . '-style';
+
+		// Reset enqueued state.
+		wp_dequeue_script( $script_handle );
+		wp_deregister_script( $script_handle );
+		wp_dequeue_style( $style_handle );
+		wp_deregister_style( $style_handle );
+
+		// The hook suffix for submenu pages under Jetpack uses "jetpack_page_".
+		( new Dashboard( 'admin.php', 'advertising' ) )->load_admin_scripts( 'jetpack_page_advertising' );
+		$this->assertTrue( wp_script_is( $script_handle, 'enqueued' ) );
+		$this->assertTrue( wp_style_is( $style_handle, 'enqueued' ) );
+	}
+
+	/**
+	 * Ensure the script is enqueued for top-level menu pages.
+	 */
+	public function test_load_admin_scripts_toplevel() {
+		$script_handle = Dashboard::SCRIPT_HANDLE;
+		$style_handle  = $script_handle . '-style';
+
+		// Reset enqueued state.
+		wp_dequeue_script( $script_handle );
+		wp_deregister_script( $script_handle );
+		wp_dequeue_style( $style_handle );
+		wp_deregister_style( $style_handle );
+
+		// The hook suffix for top-level menu pages uses "toplevel_page_".
+		( new Dashboard( 'admin.php', 'advertising' ) )->load_admin_scripts( 'toplevel_page_advertising' );
 		$this->assertTrue( wp_script_is( $script_handle, 'enqueued' ) );
 		$this->assertTrue( wp_style_is( $style_handle, 'enqueued' ) );
 	}

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-blaze-ads-menu-revisions
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-blaze-ads-menu-revisions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Move Blaze Ads from Tools submenu reorder to Jetpack submenu reorder.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -475,6 +475,7 @@ function wpcom_add_jetpack_submenu() {
 		array(
 			'my-jetpack',
 			'stats',
+			'advertising',
 			'boost',
 			'social',
 			'akismet-key-config',
@@ -711,7 +712,6 @@ function wpcom_add_tools_menu() {
 		'tools.php',
 		array(
 			'tools.php',
-			'advertising',
 			'marketing',
 			'monetize',
 			'import',

--- a/projects/plugins/jetpack/_inc/client/traffic/blaze.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/blaze.jsx
@@ -51,7 +51,7 @@ function Blaze( props ) {
 				className="jp-settings-card__configure-link"
 				href={
 					blazeDashboardEnabled
-						? siteAdminUrl + 'tools.php?page=advertising'
+						? siteAdminUrl + 'admin.php?page=advertising'
 						: getRedirectUrl( 'jetpack-blaze' )
 				}
 				onClick={ trackDashboardClick }

--- a/projects/plugins/jetpack/changelog/add-blaze-ads-menu-revisions
+++ b/projects/plugins/jetpack/changelog/add-blaze-ads-menu-revisions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Blaze: rename Advertising menu to Blaze Ads and move it under Jetpack submenu.


### PR DESCRIPTION
> ⚠️ **Reproduction branch** — this reapplies the original #47582 changes (reverted in #47856) without fixes, to reproduce and debug the Simple Sites menu regression.

## Proposed changes:

Renames the "Advertising" menu item to "Blaze Ads" and makes the menu placement context-aware across all installation types. When a site has active campaigns, the menu is promoted to a top-level entry for better visibility.

### Changes in `jetpack-blaze` package:
* Rename all user-facing "Advertising" labels to "Blaze Ads"
* Add `get_menu_parent()` for context-aware parent menu selection: WooCommerce Marketing (with menu existence guard) > Jetpack > Tools fallback
* Add `has_active_campaigns()` with 1-hour transient cache for campaign detection via WPCOM DSP API
* Promote to top-level `add_menu_page()` when active campaigns exist (both dashboard-enabled and WPCOM non-dashboard paths)
* Update `Dashboard` and `Dashboard_Config_Data` constructor defaults from `tools.php` to `admin.php`
* Update `get_campaign_management_url()` to use `admin.php?page=advertising`
* Add `redirect_legacy_advertising_url()` (302 redirect from `tools.php?page=advertising`)

### Changes in `jetpack-mu-wpcom` package:
* Remove `advertising` from Tools submenu reorder array
* Add `advertising` to Jetpack submenu reorder array

### Changes in Jetpack plugin:
* Fix stale `tools.php?page=advertising` URL in `blaze.jsx` settings panel

### Other information:

- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links

## Does this pull request change what data or activity we track or use?

No. The campaign detection API call uses the existing WPCOM DSP proxy and results are cached in a transient. No new tracking is introduced.

## Testing instructions:

### Context-aware menu placement (no campaigns):
1. On a WPCOM/Jetpack site: verify "Blaze Ads" appears under Jetpack menu
2. On a WooCommerce + Jetpack site: verify "Blaze Ads" appears under Marketing menu
3. On a self-hosted + Jetpack site (no Woo): verify "Blaze Ads" appears under Jetpack menu

### Top-level promotion (with campaigns):
1. On any site with active Blaze campaigns: verify "Blaze Ads" appears as a top-level menu item with megaphone icon
2. Flush the transient (`delete_transient('jetpack_blaze_has_active_campaigns_{blog_id}')`) to verify state transitions

### Legacy URL redirect:
1. Navigate to `tools.php?page=advertising` and verify it 302-redirects to `admin.php?page=advertising`

### Dashboard functionality:
1. Verify the Blaze dashboard loads and hash-based routing works in all menu positions
2. Verify "Promote with Blaze" row action on posts list still works

---

## 🤖 Jurassic Ninja Test Results (2026-04-01)

### Test matrix

| # | Environment | Campaigns | Expected Menu Location | Actual Menu Location | Dashboard Loads | Legacy Redirect | Result |
|---|---|---|---|---|---|---|---|
| 1 | JN + Jetpack (no Woo) | No | Jetpack → Blaze Ads | Jetpack → Blaze Ads | ✅ | ✅ `tools.php` → `admin.php` | ✅ PASS |
| 2 | JN + Jetpack (no Woo) | Yes (transient) | Top-level Blaze Ads | Top-level Blaze Ads | ✅ | ✅ | ✅ PASS |
| 3 | JN + Jetpack + WooCommerce | No | Marketing → Blaze Ads | Marketing → Blaze Ads | ✅ | ✅ `tools.php` → `admin.php` | ✅ PASS |
| 4 | JN + Jetpack + WooCommerce | Yes (transient) | Top-level Blaze Ads | Top-level Blaze Ads | ✅ | ✅ | ✅ PASS |

### Test sites used
- **No WooCommerce:** `registered-haddock-lemur.jurassic.ninja`
- **With WooCommerce:** `bird-of-rabbits.jurassic.ninja`

### Notes
- Branch: `javiolmo89/ads-796-blaze-ads-menu-repro` installed via Jetpack Beta Tester
- Campaign detection tested by setting transient `jetpack_blaze_has_site_campaigns_{blog_id}` to `yes` (the DSP API does not immediately return campaigns in moderation as active, so transient simulation was used)
- Campaign creation flow tested end-to-end on site 1 (campaign submitted successfully, appears in Campaigns tab as "In moderation")
- Legacy URL redirect (`tools.php?page=advertising` → `admin.php?page=advertising`) verified on both sites
- Blaze dashboard loads correctly in all menu positions with hash-based routing working