### PR TITLE
Agents Manager: Add agents_manager_agent_id filter

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/agents-manager-agent-id-filter
+++ b/projects/packages/jetpack-mu-wpcom/changelog/agents-manager-agent-id-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Agents Manager: Add agents_manager_agent_id filter to allow host applications to specify a custom workflow agent.

--- a/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php
@@ -248,20 +248,37 @@ class Agents_Manager {
 		 */
 		$use_unified_experience = apply_filters( 'agents_manager_use_unified_experience', false );
 
+		/**
+		 * Filter the default agent ID for the Agents Manager.
+		 *
+		 * Allows host applications (e.g., CIAB, WooCommerce AI) to specify a custom
+		 * workflow agent instead of the default orchestrator. The value is passed to
+		 * the frontend as `agentsManagerData.agentId` and consumed by `useAgentConfig()`.
+		 *
+		 * @param string|null $agent_id The agent ID to use, or null for default behavior.
+		 */
+		$agent_id = apply_filters( 'agents_manager_agent_id', null );
+
 		$this->enqueue_script( $variant );
+
+		$inline_data = array(
+			'agentProviders'       => $agent_providers,
+			'useUnifiedExperience' => $use_unified_experience,
+			'isDevMode'            => self::is_dev_mode(),
+			'sectionName'          => $variant,
+			'currentUser'          => $this->get_current_user_data(),
+			'site'                 => $this->get_current_site(),
+			'helpCenterUrl'        => self::HELP_CENTER_URL,
+		);
+
+		if ( $agent_id ) {
+			$inline_data['agentId'] = $agent_id;
+		}
 
 		wp_add_inline_script(
 			'agents-manager',
 			'const agentsManagerData = ' . wp_json_encode(
-				array(
-					'agentProviders'       => $agent_providers,
-					'useUnifiedExperience' => $use_unified_experience,
-					'isDevMode'            => self::is_dev_mode(),
-					'sectionName'          => $variant,
-					'currentUser'          => $this->get_current_user_data(),
-					'site'                 => $this->get_current_site(),
-					'helpCenterUrl'        => self::HELP_CENTER_URL,
-				),
+				$inline_data,
 				JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 			) . ';',
 			'before'


### PR DESCRIPTION
Part of WOOAI-445

## Proposed changes

Add a new `agents_manager_agent_id` WordPress filter that allows host applications (CIAB, WooCommerce AI, etc.) to specify a custom workflow agent ID. The value is included in the `agentsManagerData` inline script and consumed by `useAgentConfig()` on the frontend.

This follows the same pattern as the existing `agents_manager_agent_providers` filter:
- Default is `null` (no agent ID sent, preserving current behavior)
- When a host hooks the filter, `agentId` is conditionally included in the inline data
- The frontend priority chain in `useAgentConfig()` already reads `agentsManagerData.agentId`

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links

Enables CIAB to route AI requests through `ciab-workflow-unified_chat` via:
```php
add_filter( 'agents_manager_agent_id', fn() => 'ciab-workflow-unified_chat' );
```

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Verify default behavior is unchanged: without any filter hook, `agentsManagerData` should not contain an `agentId` key.
* Add a filter in a mu-plugin:
  ```php
  add_filter( 'agents_manager_agent_id', fn() => 'test-workflow-agent' );
  ```
* Verify `agentsManagerData.agentId` is `"test-workflow-agent"` in the inline script output (view page source or check the Network tab).
* Verify the Agents Manager UI loads the specified agent (check network requests to the orchestrator endpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)