### PR TITLE
Connection: Prevent disconnect on WoA and VIP sites in Connectors card

### DIFF
--- a/projects/packages/connection/changelog/add-wow-connection-controls
+++ b/projects/packages/connection/changelog/add-wow-connection-controls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Connector card: Prevent site disconnection and owner account unlinking on WoA and VIP sites.

--- a/projects/packages/connection/src/connectors/class-wpcom-connector.php
+++ b/projects/packages/connection/src/connectors/class-wpcom-connector.php
@@ -11,6 +11,8 @@
 
 namespace Automattic\Jetpack\Connection;
 
+use Automattic\Jetpack\Status\Host;
+
 /**
  * WordPress.com connector card handler.
  *
@@ -148,6 +150,10 @@ class Wpcom_Connector {
 			$data['currentUser']     = static::get_current_user_data( $manager );
 			$data['connectionOwner'] = static::get_connection_owner_data( $manager );
 		}
+
+		$host              = new Host();
+		$data['isWoaSite'] = $host->is_woa_site();
+		$data['isVipSite'] = $host->is_vip_site();
 
 		return $data;
 	}

--- a/projects/packages/connection/src/connectors/js/connectors-card.js
+++ b/projects/packages/connection/src/connectors/js/connectors-card.js
@@ -43,6 +43,9 @@ const currentUser = data.currentUser || null;
 const connectionOwner = data.connectionOwner || null;
 const connectedPlugins = data.connectedPlugins || [];
 const siteDetails = data.siteDetails || null;
+const isWoaSite = Boolean( data.isWoaSite );
+const isVipSite = Boolean( data.isVipSite );
+const isManagedPlatformSite = isWoaSite || isVipSite;
 const CONNECTOR_LOGO = data.connectorLogoUrl
 	? createElement( 'img', { src: data.connectorLogoUrl, alt: '', width: 36, height: 36 } )
 	: null;
@@ -469,18 +472,21 @@ function ExpandedDetails( { isConnecting = false, onConnect = null } ) {
 						? __( 'Connected as owner', 'jetpack-connection' )
 						: __( 'Connected as', 'jetpack-connection' ),
 					user: currentUser,
-					actionSlot: createElement(
-						Button,
-						{
-							variant: 'link',
-							isDestructive: true,
-							isBusy: isUnlinking,
-							disabled: isUnlinking || isDisconnecting,
-							onClick: handleUnlinkUser,
-							className: 'wpcom-connector__inline-action',
-						},
-						__( 'Disconnect account', 'jetpack-connection' )
-					),
+					actionSlot:
+						isManagedPlatformSite && currentUser.isOwner
+							? null
+							: createElement(
+									Button,
+									{
+										variant: 'link',
+										isDestructive: true,
+										isBusy: isUnlinking,
+										disabled: isUnlinking || isDisconnecting,
+										onClick: handleUnlinkUser,
+										className: 'wpcom-connector__inline-action',
+									},
+									__( 'Disconnect account', 'jetpack-connection' )
+							  ),
 			  } )
 			: null,
 
@@ -529,19 +535,21 @@ function ExpandedDetails( { isConnecting = false, onConnect = null } ) {
 						__( 'Connection details', 'jetpack-connection' )
 				  )
 				: null,
-			createElement(
-				Button,
-				{
-					variant: 'secondary',
-					isDestructive: true,
-					size: 'compact',
-					isBusy: isDisconnecting,
-					disabled: isDisconnecting || isUnlinking,
-					onClick: handleDisconnect,
-					className: 'wpcom-connector__disconnect-site',
-				},
-				__( 'Disconnect site', 'jetpack-connection' )
-			)
+			isManagedPlatformSite
+				? null
+				: createElement(
+						Button,
+						{
+							variant: 'secondary',
+							isDestructive: true,
+							size: 'compact',
+							isBusy: isDisconnecting,
+							disabled: isDisconnecting || isUnlinking,
+							onClick: handleDisconnect,
+							className: 'wpcom-connector__disconnect-site',
+						},
+						__( 'Disconnect site', 'jetpack-connection' )
+				  )
 		),
 
 		// Modals (rendered but visually hidden until triggered).


### PR DESCRIPTION
## Proposed changes

* Prevent site disconnection on WoA (WordPress.com on Atomic) and VIP sites from the WP 7.0+ Settings > Connectors card.
* Prevent connection owners from unlinking their account on these managed platforms, matching the existing behavior in My Jetpack's connection card and the `ManageConnectionDialog` component.

### How it works

**PHP (`class-wpcom-connector.php`):** Passes `isWoaSite` and `isVipSite` boolean flags from `Automattic\Jetpack\Status\Host` into the script module data.

**JS (`connectors-card.js`):** Reads the flags and derives a combined `isManagedPlatformSite` boolean. On managed platform sites:
- The "Disconnect site" button in the card footer is hidden entirely.
- The "Disconnect account" link is hidden for the connection owner (non-owner admins can still disconnect their own accounts).

This mirrors the pattern already established in:
- `ManageConnectionDialog` — hides "Disconnect Jetpack" on WoA sites (`!isWoASite()` guard on line 208)
- My Jetpack `ConnectionStatusCard` — prevents connection owners from opening the manage dialog on WoA sites (`shouldPreventDialog` logic)

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. Set up a WoA dev site and create a staging site of it. Flip the staging site to WP 7 in settings.
2. Go to Settings > Connectors
3. Click **Details** on the WordPress.com connector card.
4. Verify:
   - The **"Disconnect site"** button is **not shown** in the card footer.
   - If you are the connection owner, the **"Disconnect account"** link is **not shown** next to your user info.
   - If you are a non-owner admin, the "Disconnect account" link **is still shown**.
5. On a regular self-hosted site (non-WoA, non-VIP), verify both disconnect actions still appear and function normally.