### PR TITLE
My Jetpack: update to "Dashboard"

### DIFF
--- a/projects/packages/jitm/tests/php/Jetpack_JITM_Test.php
+++ b/projects/packages/jitm/tests/php/Jetpack_JITM_Test.php
@@ -152,7 +152,7 @@ class Jetpack_JITM_Test extends TestCase {
 		return array(
 			'Jetpack main dashboard'         => array( 'toplevel_page_jetpack', true ),
 			'Jetpack about page'             => array( 'admin_page_jetpack_about', true ),
-			'My Jetpack'                     => array( 'jetpack_page_my-jetpack', true ),
+			'Dashboard'                      => array( 'jetpack_page_my-jetpack', true ),
 			'Posts List'                     => array( 'edit-post', false ),
 			'Main dashboard'                 => array( 'dashboard', false ),
 			'WooCommerce admin page'         => array( 'woocommerce_page_wc-admin', true ),

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -186,7 +186,7 @@ export default function MyJetpackScreen() {
 			className={ styles[ 'my-jetpack-screen' ] }
 			showBottomBorder={ false }
 		>
-			<h1 className="screen-reader-text">{ __( 'My Jetpack', 'jetpack-my-jetpack' ) }</h1>
+			<h1 className="screen-reader-text">{ __( 'Dashboard', 'jetpack-my-jetpack' ) }</h1>
 
 			<IDCModal />
 			{ isSectionVisible && userIsAdmin && <EvaluationRecommendations /> }

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -158,8 +158,8 @@ class Initializer {
 	 */
 	public static function add_my_jetpack_menu_item() {
 		$page_suffix = Admin_Menu::add_menu(
-			__( 'My Jetpack', 'jetpack-my-jetpack' ),
-			__( 'My Jetpack', 'jetpack-my-jetpack' ),
+			__( 'Dashboard', 'jetpack-my-jetpack' ),
+			__( 'Dashboard', 'jetpack-my-jetpack' ),
 			'edit_posts',
 			'my-jetpack',
 			array( __CLASS__, 'admin_page' ),

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -1027,8 +1027,8 @@ abstract class Product {
 			'jetpack-home' => sprintf(
 				'<a href="%1$s" title="%3$s">%2$s</a>',
 				admin_url( 'admin.php?page=my-jetpack' ),
-				__( 'My Jetpack', 'jetpack-my-jetpack' ),
-				__( 'My Jetpack dashboard', 'jetpack-my-jetpack' )
+				__( 'Dashboard', 'jetpack-my-jetpack' ),
+				__( 'Dashboard', 'jetpack-my-jetpack' )
 			),
 		);
 

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Functions_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Functions_Test.php
@@ -919,7 +919,7 @@ class Jetpack_Sync_Functions_Test extends Jetpack_Sync_TestBase {
 		);
 
 		if ( ! defined( 'IS_ATOMIC' ) || ! IS_ATOMIC ) {
-			$expected_array['jetpack/jetpack.php']['My Jetpack'] = admin_url( 'admin.php?page=my-jetpack' );
+			$expected_array['jetpack/jetpack.php']['Dashboard'] = admin_url( 'admin.php?page=my-jetpack' );
 		}
 
 		$this->assertEquals( $expected_array, $this->extract_plugins_we_are_testing( $plugins_action_links ) );


### PR DESCRIPTION
Fixes #

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Update "My Jetpack" from the sidebar to just "Dashboard"

Before
<img width="440" height="150" alt="Screenshot 2026-03-31 at 16 20 43" src="https://github.com/user-attachments/assets/cb89af85-4e8f-4d4f-8795-2cd5277cd546" />


After
<img width="492" height="152" alt="Screenshot 2026-03-31 at 16 20 06" src="https://github.com/user-attachments/assets/004f5ad7-2fbc-4340-88fa-425f8f2bf987" />

Doesn't update different code comments and other non-user-facing things.

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* All UI references to My Jetpack are Dashboard
