### PR TITLE
RTC: Avoid endless reconnection loop on persistent errors

### DIFF
--- a/projects/packages/rtc/changelog/dotcom-16555-avoid-endless-connection-auth-when-there-is-an-error
+++ b/projects/packages/rtc/changelog/dotcom-16555-avoid-endless-connection-auth-when-there-is-an-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid endless PingHub reconnection loop on persistent WebSocket or JWT fetch errors

--- a/projects/packages/rtc/src/js/providers/pinghub/pinghub-bridge.ts
+++ b/projects/packages/rtc/src/js/providers/pinghub/pinghub-bridge.ts
@@ -328,6 +328,18 @@ export class PingHubBridge {
 	}
 
 	/**
+	 * Reset JWT backoff state so the next fetch attempt is not suppressed.
+	 *
+	 * Called by the manager when reconnect state is reset (e.g. on tab
+	 * visibility change or successful connection).
+	 */
+	resetJwtState(): void {
+		this.jwtFetchFailures = 0;
+		this.jwtBackoffDelay = JWT_BACKOFF_BASE_MS;
+		this.jwtBackoffUntil = 0;
+	}
+
+	/**
 	 * Fetch a short-lived JWT for PingHub authentication via the REST endpoint.
 	 * Caches the token for 1 minute to avoid redundant requests on reconnects.
 	 *
@@ -351,9 +363,7 @@ export class PingHubBridge {
 			} );
 			this.cachedJwt = response?.token ?? null;
 			this.cachedJwtTimestamp = Date.now();
-			this.jwtFetchFailures = 0;
-			this.jwtBackoffDelay = JWT_BACKOFF_BASE_MS;
-			this.jwtBackoffUntil = 0;
+			this.resetJwtState();
 			pixel( 'pinghub.rtc.jwt_fetch', Date.now() - start, 'ms' );
 			return this.cachedJwt;
 		} catch {
@@ -400,7 +410,7 @@ export class PingHubBridge {
 			this.connectingWaiters.delete( room );
 			const err = new Error( 'PingHub JWT fetch failed' );
 			waiters.splice( 0 ).forEach( ( { reject } ) => reject( err ) );
-			return;
+			return Promise.reject( err );
 		}
 
 		const wsUrl = this.fullPath( room ) + '?jwt=' + encodeURIComponent( jwt );

--- a/projects/packages/rtc/src/js/providers/pinghub/pinghub-bridge.ts
+++ b/projects/packages/rtc/src/js/providers/pinghub/pinghub-bridge.ts
@@ -122,6 +122,9 @@ function getBlogId(): number | null {
 }
 
 const JWT_CACHE_TTL_MS = 60 * 1000; // 1 minute
+const MAX_JWT_FETCH_FAILURES = 5;
+const JWT_BACKOFF_BASE_MS = 1000;
+const JWT_BACKOFF_MAX_MS = 30 * 1000;
 
 let detectedBrowser: string | null = null;
 
@@ -191,6 +194,12 @@ export class PingHubBridge {
 	/** Cached JWT for PingHub authentication. */
 	private cachedJwt: string | null = null;
 	private cachedJwtTimestamp = 0;
+	/** Consecutive JWT fetch failure count. */
+	private jwtFetchFailures = 0;
+	/** Exponential backoff delay for JWT fetch retries. */
+	private jwtBackoffDelay = JWT_BACKOFF_BASE_MS;
+	/** Timestamp before which JWT fetches are suppressed. */
+	private jwtBackoffUntil = 0;
 	/** Reassembly buffer: key = room + ':' + msgId, value = { totalChunks, chunks } */
 	private chunkBuffers = new Map<
 		string,
@@ -328,6 +337,12 @@ export class PingHubBridge {
 		if ( this.cachedJwt && Date.now() - this.cachedJwtTimestamp < JWT_CACHE_TTL_MS ) {
 			return this.cachedJwt;
 		}
+		if ( this.jwtFetchFailures >= MAX_JWT_FETCH_FAILURES ) {
+			return null;
+		}
+		if ( Date.now() < this.jwtBackoffUntil ) {
+			return null;
+		}
 		const start = Date.now();
 		try {
 			const response = await apiFetch< { token: string } >( {
@@ -336,9 +351,15 @@ export class PingHubBridge {
 			} );
 			this.cachedJwt = response?.token ?? null;
 			this.cachedJwtTimestamp = Date.now();
+			this.jwtFetchFailures = 0;
+			this.jwtBackoffDelay = JWT_BACKOFF_BASE_MS;
+			this.jwtBackoffUntil = 0;
 			pixel( 'pinghub.rtc.jwt_fetch', Date.now() - start, 'ms' );
 			return this.cachedJwt;
 		} catch {
+			this.jwtFetchFailures++;
+			this.jwtBackoffUntil = Date.now() + this.jwtBackoffDelay;
+			this.jwtBackoffDelay = Math.min( this.jwtBackoffDelay * 2, JWT_BACKOFF_MAX_MS );
 			pixel( 'pinghub.rtc.jwt_fetch_error', Date.now() - start, 'ms' );
 			return null;
 		}
@@ -372,15 +393,17 @@ export class PingHubBridge {
 		const waiters: Array< { resolve: () => void; reject: ( err: Error ) => void } > = [];
 		this.connectingWaiters.set( room, waiters );
 
-		// Fetch a short-lived JWT so the connection authenticates even when
-		// WPCOM cookies are absent (third-party cookie blocking on
-		// custom-domain Jetpack/Atomic sites).
-		let wsUrl = this.fullPath( room );
+		// Fetch a short-lived JWT for authentication. Without it the
+		// connection cannot authenticate, so bail out early.
 		const jwt = await this.fetchPinghubJwt();
-		if ( jwt ) {
-			wsUrl += '?jwt=' + encodeURIComponent( jwt );
+		if ( ! jwt ) {
+			this.connectingWaiters.delete( room );
+			const err = new Error( 'PingHub JWT fetch failed' );
+			waiters.splice( 0 ).forEach( ( { reject } ) => reject( err ) );
+			return;
 		}
 
+		const wsUrl = this.fullPath( room ) + '?jwt=' + encodeURIComponent( jwt );
 		const ws = new WebSocket( wsUrl );
 		ws.binaryType = 'arraybuffer';
 		this.sockets.set( room, ws );

--- a/projects/packages/rtc/src/js/providers/pinghub/pinghub-manager.ts
+++ b/projects/packages/rtc/src/js/providers/pinghub/pinghub-manager.ts
@@ -10,6 +10,7 @@ const MSG_SYNC = 0x00;
 const MSG_AWARENESS = 0x01;
 const RECONNECT_BASE_DELAY_MS = 1000;
 const RECONNECT_MAX_DELAY_MS = 30 * 1000;
+const MAX_RECONNECT_ATTEMPTS = 5;
 const PINGHUB_MANAGER_ORIGIN = 'pinghub-manager';
 
 interface RegisterRoomOptions {
@@ -44,6 +45,7 @@ class PingHubConnection {
 	private syncStep1RepliedTo = new Set< number >();
 	public reconnectTimer: ReturnType< typeof setTimeout > | null = null;
 	public reconnectDelay = RECONNECT_BASE_DELAY_MS;
+	public reconnectAttempts = 0;
 
 	public constructor( options: RegisterRoomOptions ) {
 		this.room = options.room;
@@ -174,6 +176,11 @@ class PingHubConnection {
 		if ( this.reconnectTimer !== null ) {
 			return;
 		}
+		if ( this.reconnectAttempts >= MAX_RECONNECT_ATTEMPTS ) {
+			this.onStatusChange( { status: 'disconnected' } );
+			return;
+		}
+		this.reconnectAttempts++;
 		this.reconnectTimer = setTimeout( () => {
 			this.reconnectTimer = null;
 			if ( rooms.has( this.room ) ) {
@@ -193,6 +200,7 @@ class PingHubConnection {
 		this.connected = true;
 		this.syncStep1RepliedTo.clear();
 		this.reconnectDelay = RECONNECT_BASE_DELAY_MS;
+		this.reconnectAttempts = 0;
 		this.onStatusChange( { status: 'connected' } );
 
 		this.sendSyncStep1();
@@ -385,6 +393,7 @@ function handleVisibilityChange(): void {
 			connection.reconnectTimer = null;
 		}
 		connection.reconnectDelay = RECONNECT_BASE_DELAY_MS;
+		connection.reconnectAttempts = 0;
 		connection.connect();
 	}
 }

--- a/projects/packages/rtc/src/js/providers/pinghub/pinghub-manager.ts
+++ b/projects/packages/rtc/src/js/providers/pinghub/pinghub-manager.ts
@@ -201,6 +201,7 @@ class PingHubConnection {
 		this.syncStep1RepliedTo.clear();
 		this.reconnectDelay = RECONNECT_BASE_DELAY_MS;
 		this.reconnectAttempts = 0;
+		bridge?.resetJwtState();
 		this.onStatusChange( { status: 'connected' } );
 
 		this.sendSyncStep1();
@@ -384,6 +385,7 @@ function handleVisibilityChange(): void {
 		return;
 	}
 	isUnloadPending = false;
+	bridge?.resetJwtState();
 	for ( const [ , connection ] of rooms ) {
 		if ( connection.connected ) {
 			continue;


### PR DESCRIPTION
Fixes DOTCOM-16555

## Proposed changes

* Add a max reconnect attempt limit (5) with exponential backoff to the PingHub manager, preventing infinite retry loops when the WebSocket endpoint returns persistent errors (e.g. 500). Resets on successful connection or tab visibility change.
* Add a max JWT fetch failure limit (5) with its own exponential backoff, so the `/wpcom/v2/rtc/pinghub-token` endpoint is not hammered on repeated failures.
* Skip the WebSocket connection attempt entirely when JWT is unavailable, since the connection cannot authenticate without it.

## Related product discussion/links
N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions

* Apply these changes to your sandbox
* Sandbox a site with RTC over WS enabled (requires the `wpcom-features-edge` sticker)
* On your sandbox, edit the `REST_Pinghub_Token` class to simulate a 500 error on the `pinghub-token` REST endpoint:

```
public function create_item( $request ) {
	return new WP_Error(
		'rest_pinghub_token_error',
		__( 'Test error', 'jetpack-rtc' ),
		array( 'status' => 500 )
	);
}
```

* Open the editor on your sandbox site
* Make sure that there are only 5 requests to the `pinghub-token` REST endpoint.
* You should see a "Connection lost" modal afterwards and no more requests
* Revert the `REST_Pinghub_Token` class changes on your sandbox
* Now, temporary revert 209884-ghe-Automattic/wpcom in your sandbox
* Add a "Comments" block to a post, save it, publish a comment, and reload the editor
* Make sure that there are only 5 attempts to establish a connection via WS to `wss://public-api.wordpress.com/pinghub/wpcom/rtc/<SITE_ID>/root-comment-<COMMENT_ID>`
* You should see a "Connection lost" modal afterwards and no more requests
* Restore 209884-ghe-Automattic/wpcom now
* Reload the editor
* Verify that RTC works as expected