### PR TITLE
Connection: Add error handling to WordPress.com Connectors card

### DIFF
--- a/projects/packages/connection/changelog/add-connector-error-flow
+++ b/projects/packages/connection/changelog/add-connector-error-flow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Connection: Display inline error notices for site registration, authorization, and disconnect failures in the WordPress.com Connectors card.

--- a/projects/packages/connection/src/connectors/class-wpcom-connector.php
+++ b/projects/packages/connection/src/connectors/class-wpcom-connector.php
@@ -313,6 +313,8 @@ class Wpcom_Connector {
 	 * the auth webhook fails. The transient is read on the next
 	 * Connectors page load so the JS card can display the error.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @param \WP_Error $error Authorization error.
 	 */
 	public static function store_auth_error( $error ) {

--- a/projects/packages/connection/src/connectors/class-wpcom-connector.php
+++ b/projects/packages/connection/src/connectors/class-wpcom-connector.php
@@ -45,6 +45,7 @@ class Wpcom_Connector {
 
 		add_action( 'wp_connectors_init', array( static::class, 'register_connector' ), 20 );
 		add_action( 'admin_enqueue_scripts', array( static::class, 'enqueue_script_module' ) );
+		add_action( 'jetpack_client_authorize_error', array( static::class, 'store_auth_error' ) );
 	}
 
 	/**
@@ -154,6 +155,11 @@ class Wpcom_Connector {
 		$host              = new Host();
 		$data['isWoaSite'] = $host->is_woa_site();
 		$data['isVipSite'] = $host->is_vip_site();
+
+		$auth_error = static::consume_auth_error();
+		if ( $auth_error ) {
+			$data['authError'] = $auth_error;
+		}
 
 		return $data;
 	}
@@ -298,6 +304,48 @@ class Wpcom_Connector {
 		}
 
 		return 'options-connectors.php';
+	}
+
+	/**
+	 * Store an authorization error in a short-lived transient.
+	 *
+	 * Hooked to `jetpack_client_authorize_error` which fires when
+	 * the auth webhook fails. The transient is read on the next
+	 * Connectors page load so the JS card can display the error.
+	 *
+	 * @param \WP_Error $error Authorization error.
+	 */
+	public static function store_auth_error( $error ) {
+		if ( is_wp_error( $error ) ) {
+			$user_id = get_current_user_id();
+			if ( $user_id ) {
+				set_transient(
+					'wpcom_connector_auth_error_' . $user_id,
+					$error->get_error_message(),
+					60
+				);
+			}
+		}
+	}
+
+	/**
+	 * Read and delete a stored authorization error for the current user.
+	 *
+	 * @return string|false Error message or false if none.
+	 */
+	private static function consume_auth_error() {
+		$user_id = get_current_user_id();
+		if ( ! $user_id ) {
+			return false;
+		}
+
+		$key   = 'wpcom_connector_auth_error_' . $user_id;
+		$error = get_transient( $key );
+		if ( false !== $error ) {
+			delete_transient( $key );
+		}
+
+		return $error;
 	}
 
 	/**

--- a/projects/packages/connection/src/connectors/css/connectors-card.css
+++ b/projects/packages/connection/src/connectors/css/connectors-card.css
@@ -117,4 +117,15 @@
 	color: #cc1818;
 	font-size: 13px;
 	margin-block-start: 8px;
+	padding-block: 8px;
+	padding-inline: 12px;
+	border-inline-start: 4px solid #cc1818;
+	background-color: #fcecec;
+	border-radius: 2px;
+	align-items: center;
+}
+
+.wpcom-connector__error .components-button {
+	color: #cc1818;
+	flex-shrink: 0;
 }

--- a/projects/packages/connection/src/connectors/js/connectors-card.js
+++ b/projects/packages/connection/src/connectors/js/connectors-card.js
@@ -72,7 +72,10 @@ async function startConnectionFlow( siteRegistered ) {
 			{ headers: { 'X-WP-Nonce': apiNonce } }
 		);
 		if ( ! authRes.ok ) {
-			throw new Error( 'Failed to retrieve authorization URL' );
+			const errBody = await authRes.json().catch( () => null );
+			throw new Error(
+				errBody?.message || __( 'Failed to retrieve authorization URL.', 'jetpack-connection' )
+			);
 		}
 		const authData = await authRes.json();
 		const authorizeUrl = authData?.authorizeUrl || authData;
@@ -98,7 +101,8 @@ async function startConnectionFlow( siteRegistered ) {
 	} );
 
 	if ( ! response.ok ) {
-		throw new Error( 'Registration failed' );
+		const errBody = await response.json().catch( () => null );
+		throw new Error( errBody?.message || __( 'Site registration failed.', 'jetpack-connection' ) );
 	}
 
 	const result = await response.json();
@@ -132,6 +136,34 @@ function addSkipPricing( url ) {
 }
 
 /* ── Small presentational components ────────────────────────────── */
+
+/**
+ * Inline error notice with an optional dismiss button.
+ *
+ * @param {object}        props           - Component props.
+ * @param {string}        props.message   - Error message text.
+ * @param {Function|null} props.onDismiss - Callback to clear the error; omit for non-dismissible.
+ * @return {object} React element.
+ */
+function ErrorNotice( { message, onDismiss = null } ) {
+	return createElement(
+		HStack,
+		{ spacing: 2, className: 'wpcom-connector__error', role: 'alert' },
+		createElement( Text, { size: 13 }, message ),
+		onDismiss
+			? createElement(
+					Button,
+					{
+						variant: 'link',
+						size: 'small',
+						onClick: onDismiss,
+						'aria-label': __( 'Dismiss error', 'jetpack-connection' ),
+					},
+					__( 'Dismiss', 'jetpack-connection' )
+			  )
+			: null
+	);
+}
 
 /**
  * Status badge with a BEM modifier for different connection states.
@@ -385,10 +417,12 @@ function ExpandedDetails( { isConnecting = false, onConnect = null } ) {
 	const [ isUnlinking, setIsUnlinking ] = useState( false );
 	const [ showDetailsModal, setShowDetailsModal ] = useState( false );
 	const [ pendingConfirm, setPendingConfirm ] = useState( null );
+	const [ actionError, setActionError ] = useState( null );
 
 	const executeDisconnect = async () => {
 		setPendingConfirm( null );
 		setIsDisconnecting( true );
+		setActionError( null );
 
 		try {
 			const response = await window.fetch( apiRoot + 'jetpack/v4/connection', {
@@ -402,7 +436,18 @@ function ExpandedDetails( { isConnecting = false, onConnect = null } ) {
 
 			if ( response.ok ) {
 				window.location.reload();
+				return;
 			}
+
+			const errBody = await response.json().catch( () => null );
+			setActionError(
+				errBody?.message ||
+					__( 'Failed to disconnect the site. Please try again.', 'jetpack-connection' )
+			);
+		} catch {
+			setActionError(
+				__( 'Failed to disconnect the site. Please try again.', 'jetpack-connection' )
+			);
 		} finally {
 			setIsDisconnecting( false );
 		}
@@ -422,6 +467,7 @@ function ExpandedDetails( { isConnecting = false, onConnect = null } ) {
 	const executeUnlinkUser = async () => {
 		setPendingConfirm( null );
 		setIsUnlinking( true );
+		setActionError( null );
 
 		try {
 			const body = { linked: false, force: true };
@@ -440,7 +486,18 @@ function ExpandedDetails( { isConnecting = false, onConnect = null } ) {
 
 			if ( response.ok ) {
 				window.location.reload();
+				return;
 			}
+
+			const errBody = await response.json().catch( () => null );
+			setActionError(
+				errBody?.message ||
+					__( 'Failed to disconnect the account. Please try again.', 'jetpack-connection' )
+			);
+		} catch {
+			setActionError(
+				__( 'Failed to disconnect the account. Please try again.', 'jetpack-connection' )
+			);
 		} finally {
 			setIsUnlinking( false );
 		}
@@ -518,6 +575,13 @@ function ExpandedDetails( { isConnecting = false, onConnect = null } ) {
 
 		createElement( ConnectedPluginsSection ),
 
+		actionError
+			? createElement( ErrorNotice, {
+					message: actionError,
+					onDismiss: () => setActionError( null ),
+			  } )
+			: null,
+
 		// Footer: connection details link + disconnect site button.
 		createElement( 'hr', { className: 'wpcom-connector__divider' } ),
 		createElement(
@@ -592,7 +656,7 @@ function WpcomConnectorCard( { name, label, description, logo, icon } ) {
 	const isConnected = initialIsConnected;
 	const isSiteRegistered = initialIsRegistered;
 	const [ isConnecting, setIsConnecting ] = useState( false );
-	const [ connectError, setConnectError ] = useState( null );
+	const [ connectError, setConnectError ] = useState( data.authError || null );
 
 	const handleConnect = async () => {
 		setIsConnecting( true );
@@ -682,14 +746,10 @@ function WpcomConnectorCard( { name, label, description, logo, icon } ) {
 		},
 		expandedContent,
 		connectError
-			? createElement(
-					'p',
-					{
-						className: 'wpcom-connector__error',
-						role: 'alert',
-					},
-					connectError
-			  )
+			? createElement( ErrorNotice, {
+					message: connectError,
+					onDismiss: () => setConnectError( null ),
+			  } )
 			: null
 	);
 }

--- a/projects/packages/connection/tests/php/Wpcom_Connector_Test.php
+++ b/projects/packages/connection/tests/php/Wpcom_Connector_Test.php
@@ -456,7 +456,7 @@ class Wpcom_Connector_Test extends TestCase {
 	 * Test that store_auth_error ignores non-WP_Error values.
 	 */
 	public function test_store_auth_error_ignores_non_wp_error() {
-		Wpcom_Connector::store_auth_error( 'not an error' );
+		Wpcom_Connector::store_auth_error( 'not an error' ); // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- intentionally passing wrong type to test the guard.
 
 		$this->assertFalse( get_transient( 'wpcom_connector_auth_error_' . $this->admin_id ) );
 	}

--- a/projects/packages/connection/tests/php/Wpcom_Connector_Test.php
+++ b/projects/packages/connection/tests/php/Wpcom_Connector_Test.php
@@ -64,6 +64,10 @@ class Wpcom_Connector_Test extends TestCase {
 		// Remove hooks that init() may have registered.
 		remove_all_actions( 'wp_connectors_init' );
 		remove_all_actions( 'admin_enqueue_scripts' );
+		remove_all_actions( 'jetpack_client_authorize_error' );
+
+		// Clean up any auth error transients left by tests.
+		delete_transient( 'wpcom_connector_auth_error_' . $this->admin_id );
 
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Users::init()->clear_all_users();
@@ -80,6 +84,7 @@ class Wpcom_Connector_Test extends TestCase {
 
 		$this->assertIsInt( has_action( 'wp_connectors_init', array( Wpcom_Connector::class, 'register_connector' ) ) );
 		$this->assertIsInt( has_action( 'admin_enqueue_scripts', array( Wpcom_Connector::class, 'enqueue_script_module' ) ) );
+		$this->assertIsInt( has_action( 'jetpack_client_authorize_error', array( Wpcom_Connector::class, 'store_auth_error' ) ) );
 	}
 
 	/**
@@ -431,6 +436,126 @@ class Wpcom_Connector_Test extends TestCase {
 		$this->assertSame( 'options-connectors.php', $method->invoke( null ) );
 
 		unset( $_SERVER['SCRIPT_NAME'] );
+	}
+
+	/* ── store_auth_error() / consume_auth_error() ───────────── */
+
+	/**
+	 * Test that store_auth_error stores a transient for a WP_Error.
+	 */
+	public function test_store_auth_error_saves_transient() {
+		$error = new \WP_Error( 'auth_denied', 'Authorization was denied.' );
+
+		Wpcom_Connector::store_auth_error( $error );
+
+		$stored = get_transient( 'wpcom_connector_auth_error_' . $this->admin_id );
+		$this->assertSame( 'Authorization was denied.', $stored );
+	}
+
+	/**
+	 * Test that store_auth_error ignores non-WP_Error values.
+	 */
+	public function test_store_auth_error_ignores_non_wp_error() {
+		Wpcom_Connector::store_auth_error( 'not an error' );
+
+		$this->assertFalse( get_transient( 'wpcom_connector_auth_error_' . $this->admin_id ) );
+	}
+
+	/**
+	 * Test that store_auth_error does nothing when no user is logged in.
+	 */
+	public function test_store_auth_error_no_user() {
+		wp_set_current_user( 0 );
+
+		Wpcom_Connector::store_auth_error( new \WP_Error( 'fail', 'Failure.' ) );
+
+		$this->assertFalse( get_transient( 'wpcom_connector_auth_error_0' ) );
+	}
+
+	/**
+	 * Test that consume_auth_error reads and deletes the transient.
+	 */
+	public function test_consume_auth_error_reads_and_deletes() {
+		set_transient( 'wpcom_connector_auth_error_' . $this->admin_id, 'Token expired.', 60 );
+
+		$method = new \ReflectionMethod( Wpcom_Connector::class, 'consume_auth_error' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$result = $method->invoke( null );
+		$this->assertSame( 'Token expired.', $result );
+
+		// Transient should be deleted after consumption.
+		$this->assertFalse( get_transient( 'wpcom_connector_auth_error_' . $this->admin_id ) );
+	}
+
+	/**
+	 * Test that consume_auth_error deletes the transient even when value is an empty string.
+	 */
+	public function test_consume_auth_error_deletes_empty_string_transient() {
+		set_transient( 'wpcom_connector_auth_error_' . $this->admin_id, '', 60 );
+
+		$method = new \ReflectionMethod( Wpcom_Connector::class, 'consume_auth_error' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$result = $method->invoke( null );
+		$this->assertSame( '', $result );
+
+		// Transient must be deleted even though the value was falsy.
+		$this->assertFalse( get_transient( 'wpcom_connector_auth_error_' . $this->admin_id ) );
+	}
+
+	/**
+	 * Test that consume_auth_error returns false when no transient exists.
+	 */
+	public function test_consume_auth_error_returns_false_when_empty() {
+		$method = new \ReflectionMethod( Wpcom_Connector::class, 'consume_auth_error' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$this->assertFalse( $method->invoke( null ) );
+	}
+
+	/**
+	 * Test that consume_auth_error returns false for logged-out users.
+	 */
+	public function test_consume_auth_error_returns_false_no_user() {
+		wp_set_current_user( 0 );
+
+		$method = new \ReflectionMethod( Wpcom_Connector::class, 'consume_auth_error' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$this->assertFalse( $method->invoke( null ) );
+	}
+
+	/**
+	 * Test that get_connector_data includes authError when transient is set.
+	 */
+	public function test_get_connector_data_includes_auth_error() {
+		set_transient( 'wpcom_connector_auth_error_' . $this->admin_id, 'Auth failed.', 60 );
+
+		$data = Wpcom_Connector::get_connector_data( array() );
+
+		$this->assertArrayHasKey( 'authError', $data );
+		$this->assertSame( 'Auth failed.', $data['authError'] );
+
+		// Transient should be consumed (deleted).
+		$this->assertFalse( get_transient( 'wpcom_connector_auth_error_' . $this->admin_id ) );
+	}
+
+	/**
+	 * Test that get_connector_data omits authError when no transient exists.
+	 */
+	public function test_get_connector_data_omits_auth_error_when_none() {
+		$data = Wpcom_Connector::get_connector_data( array() );
+
+		$this->assertArrayNotHasKey( 'authError', $data );
 	}
 
 	/* ── Helpers ───────────────────────────────────────────────── */


### PR DESCRIPTION
## Proposed changes

* Parse REST API response bodies during site registration and authorization URL retrieval to surface specific server error messages instead of generic failures.
* Add inline error notices (with dismiss support) for disconnect and unlink operations in the expanded card, catching both HTTP error responses and network failures.
* Hook into `jetpack_client_authorize_error` on the PHP side to store post-redirect authorization errors in a per-user transient, consumed on the next Connectors page load so the JS card can display them.
* Introduce a reusable `ErrorNotice` component with `role="alert"` for consistent, accessible error presentation across the card.
* Update `.wpcom-connector__error` CSS with notice-style visual treatment (left border, background, dismiss button alignment).
* Add PHPUnit tests covering `store_auth_error()`, `consume_auth_error()`, and their integration through `get_connector_data()`.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

### Connection errors (JS — site registration & authorization)
1. Go to **Settings → Connectors** on a disconnected site.
2. Click "Connect account". Simulate a registration failure (e.g., block `jetpack/v4/connection/register` via a filter or disconnect the network). Verify an inline error notice appears with the API error message and a "Dismiss" link.
3. Dismiss the error and confirm it disappears.

### Authorization redirect errors (PHP → JS)
1. Force a `jetpack_client_authorize_error` action to fire (e.g., by returning a `WP_Error` from the `jetpack_client_authorize` filter).
2. Navigate to the Connectors page. The error message from the WP_Error should appear as an inline notice. Refreshing the page should not show it again (transient is consumed).

### Disconnect / unlink errors
1. Connect a site and user account.
2. Click "Disconnect account" or "Disconnect site". Simulate an API failure (e.g., block `jetpack/v4/connection` or `jetpack/v4/connection/user`). Confirm an error notice appears inside the expanded card.
3. Dismiss the error and retry.

### PHPUnit
```bash
jetpack test php packages/connection -- --filter=Wpcom_Connector_Test
```