### PR TITLE
Subscriptions: do not translate newsletter panel title

### DIFF
--- a/projects/plugins/jetpack/changelog/update-newsletter-panel-title-no-i18n
+++ b/projects/plugins/jetpack/changelog/update-newsletter-panel-title-no-i18n
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Subscriptions: do not translate newsletter panel title.
+
+

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/menu.js
@@ -39,7 +39,7 @@ const NewsletterMenu = ( { openPreviewModal } ) => {
 	return (
 		<PluginSidebar
 			name="jetpack-newsletter-settings-sidebar"
-			title={ __( 'Jetpack Newsletter', 'jetpack' ) }
+			title={ 'Jetpack Newsletter' }
 			icon={ <SendIcon /> }
 			className="jetpack-newsletter-settings-sidebar"
 		>


### PR DESCRIPTION
## Proposed changes

Follow-up to #47857
We do not need to translate brands.

See https://github.com/Automattic/jetpack/pull/47857#discussion_r3015697102

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links

* n/a

## Does this pull request change what data or activity we track or use?

* No

## Testing instructions


* Go to Jetpack > Newsletter
* Enable the Newsletter feature
* Go to Posts > Add New
* Check the plugin sidebar titles (see screenshots above)

