### PR TITLE
RTC: Disable for super admins who are not blog members

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-16563-disable-rtc-for-non-member-super-admins
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-16563-disable-rtc-for-non-member-super-admins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+RTC notices: Remove duplicated site editor and option checks, rely on RTC::is_enabled() instead.

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/gutenberg-rtc-notices.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/gutenberg-rtc-notices.php
@@ -60,25 +60,7 @@ function wpcom_rtc_is_plan_owner() {
  * Enqueue block editor assets for RTC notices and limits.
  */
 function wpcom_enqueue_rtc_notices_assets() {
-	global $pagenow;
-
 	if ( ! \Automattic\Jetpack\RTC::is_enabled() ) {
-		return;
-	}
-
-	// Real-time collaboration is not enabled in the site editor.
-	if (
-		'site-editor.php' === $pagenow ||
-		( 'admin.php' === $pagenow && isset( $_GET['page'] ) && 'site-editor-v2' === sanitize_text_field( wp_unslash( $_GET['page'] ) ) ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	) {
-		return;
-	}
-
-	// Don't show notices if the user has turned off RTC in Writing Settings.
-	// Both the old and new option names must be false to consider it disabled.
-	$old_option = get_option( 'wp_enable_real_time_collaboration', false );
-	$new_option = get_option( 'wp_collaboration_enabled', false );
-	if ( ! $old_option && ! $new_option ) {
 		return;
 	}
 

--- a/projects/packages/rtc/changelog/dotcom-16563-disable-rtc-for-non-member-super-admins
+++ b/projects/packages/rtc/changelog/dotcom-16563-disable-rtc-for-non-member-super-admins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Disable RTC for super admins who are not members of the blog to prevent exposing their presence during support sessions.

--- a/projects/packages/rtc/src/class-rtc.php
+++ b/projects/packages/rtc/src/class-rtc.php
@@ -54,24 +54,41 @@ class RTC {
 		foreach ( array( self::OPTION_OLD, self::OPTION_NEW ) as $option ) {
 			add_filter( 'option_' . $option, array( __CLASS__, 'filter_rtc_option' ), 10 );
 			add_filter( 'default_option_' . $option, array( __CLASS__, 'default_rtc_option' ), 20, 2 );
+			add_filter( 'pre_option_' . $option, array( __CLASS__, 'pre_rtc_option' ) );
 		}
+	}
+
+	/**
+	 * Determine whether RTC is allowed.
+	 *
+	 * @return bool
+	 */
+	public static function is_allowed() {
+		/**
+		 * Filter whether RTC can be enabled.
+		 *
+		 * @param bool $is_enabled Whether RTC can be enabled.
+		 */
+		return apply_filters( 'jetpack_rtc_enabled', false );
 	}
 
 	/**
 	 * Determine whether RTC is enabled.
 	 *
-	 * Disabled by default until the PingHub provider is ready
-	 * and we are confident in proceeding with the rollout.
-	 *
 	 * @return bool
 	 */
 	public static function is_enabled() {
-		/**
-		 * Filter whether RTC is enabled.
-		 *
-		 * @param bool $is_enabled Whether RTC is enabled.
-		 */
-		return apply_filters( 'jetpack_rtc_enabled', false );
+		global $pagenow;
+
+		// Real-time collaboration is not enabled in the site editor.
+		if (
+			'site-editor.php' === $pagenow ||
+			( 'admin.php' === $pagenow && isset( $_GET['page'] ) && 'site-editor-v2' === sanitize_text_field( wp_unslash( $_GET['page'] ) ) ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		) {
+			return false;
+		}
+
+		return self::is_allowed() && (bool) get_option( 'wp_collaboration_enabled' );
 	}
 
 	/**
@@ -121,13 +138,7 @@ class RTC {
 	 * @return void
 	 */
 	public static function enqueue_assets() {
-		global $pagenow;
-
-		// Real-time collaboration is not enabled in the site editor.
-		if (
-			'site-editor.php' === $pagenow ||
-			( 'admin.php' === $pagenow && isset( $_GET['page'] ) && 'site-editor-v2' === sanitize_text_field( wp_unslash( $_GET['page'] ) ) ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		) {
+		if ( ! self::is_enabled() ) {
 			return;
 		}
 
@@ -168,13 +179,12 @@ class RTC {
 	}
 
 	/**
-	 * Unregister the RTC setting field on the Writing page.
+	 * Unregister the RTC setting field on the Writing page if RTC is not allowed.
 	 *
 	 * @return void
 	 */
 	public static function unregister_rtc_setting() {
-		$providers = self::get_providers();
-		if ( count( $providers ) > 0 ) {
+		if ( self::is_allowed() ) {
 			return;
 		}
 
@@ -188,34 +198,24 @@ class RTC {
 	}
 
 	/**
-	 * When there are no providers, always force the option off.
-	 * When there are providers, respect the stored option value.
+	 * When RTC is not allowed, always force the option off.
+	 * When RTC is allowed, respect the stored option value.
 	 *
 	 * @param mixed $value  The value of the option.
 	 * @return mixed
 	 */
 	public static function filter_rtc_option( $value ) {
-		global $pagenow;
-
-		$providers = self::get_providers();
-		// No providers: force the option off, regardless of what's in the DB.
-		if ( count( $providers ) === 0 ) {
+		// RTC not allowed: force the option off, regardless of what's in the DB.
+		if ( ! self::is_allowed() ) {
 			return '0';
 		}
 
-		// Disable RTC for super admins that are not members of the blog to avoid
-		// accidentally exposing their presence to site owners (e.g. during support).
-		// Skip this on the Writing settings page so they can still toggle the option.
-		if ( 'options-writing.php' !== $pagenow && is_super_admin() && ! is_user_member_of_blog() ) {
-			return '0';
-		}
-
-		// Providers exist: respect whatever is stored.
+		// RTC allowed: respect whatever is stored.
 		return $value;
 	}
 
 	/**
-	 * When there ARE providers and the option is NOT stored yet,
+	 * When RTC is allowed and the option is NOT stored yet,
 	 * default the option to enabled (1), unless the old option
 	 * has a stored value to migrate from.
 	 *
@@ -228,18 +228,35 @@ class RTC {
 	 * @return mixed
 	 */
 	public static function default_rtc_option( $default = '', $option = '' ) {
-		$providers = self::get_providers();
-		// No providers: keep default disabled.
-		if ( count( $providers ) === 0 ) {
+		// RTC not allowed: keep default disabled.
+		if ( ! self::is_allowed() ) {
 			return '0';
 		}
-		// Providers exist and option is not stored yet
+		// RTC allowed and option is not stored yet
 		if ( $option === self::OPTION_NEW ) {
 			// If the old option is set, use that.
 			return get_option( self::OPTION_OLD );
 		}
 		// Default to enabled.
 		return '1';
+	}
+
+	/**
+	 * Disable RTC for super admins that are not members of the blog to avoid
+	 * accidentally exposing their presence to site users (e.g. during support).
+	 * Skip this on the Writing settings page so they can still toggle the option.
+	 *
+	 * @return mixed
+	 */
+	public static function pre_rtc_option() {
+		global $pagenow;
+
+		if ( 'options-writing.php' !== $pagenow && is_super_admin() && ! is_user_member_of_blog() ) {
+			return '0';
+		}
+
+		// Returning false to let `get_option` proceed normally.
+		return false;
 	}
 
 	/**
@@ -250,8 +267,11 @@ class RTC {
 	public static function override_rtc_setting_default() {
 		global $wp_registered_settings;
 
-		$providers = self::get_providers();
-		$default   = count( $providers ) > 0;
+		// No need to override the setting when RTC is not allowed, since we unregister it
+		// in `unregister_rtc_setting`.
+		if ( ! self::is_allowed() ) {
+			return;
+		}
 
 		foreach ( array( self::OPTION_OLD, self::OPTION_NEW ) as $option ) {
 			// Only re-register the option if Gutenberg already registered it.
@@ -268,8 +288,7 @@ class RTC {
 					'type'              => 'boolean',
 					'description'       => __( 'Enable Real-Time Collaboration', 'jetpack-rtc' ),
 					'sanitize_callback' => 'rest_sanitize_boolean',
-					// Dynamic default: true when providers exist, false otherwise.
-					'default'           => $default,
+					'default'           => true,
 					'show_in_rest'      => true,
 				)
 			);

--- a/projects/packages/rtc/src/class-rtc.php
+++ b/projects/packages/rtc/src/class-rtc.php
@@ -195,11 +195,21 @@ class RTC {
 	 * @return mixed
 	 */
 	public static function filter_rtc_option( $value ) {
+		global $pagenow;
+
 		$providers = self::get_providers();
 		// No providers: force the option off, regardless of what's in the DB.
 		if ( count( $providers ) === 0 ) {
 			return '0';
 		}
+
+		// Disable RTC for super admins that are not members of the blog to avoid
+		// accidentally exposing their presence to site owners (e.g. during support).
+		// Skip this on the Writing settings page so they can still toggle the option.
+		if ( 'options-writing.php' !== $pagenow && is_super_admin() && ! is_user_member_of_blog() ) {
+			return '0';
+		}
+
 		// Providers exist: respect whatever is stored.
 		return $value;
 	}

--- a/projects/packages/rtc/tests/php/RTC_Test.php
+++ b/projects/packages/rtc/tests/php/RTC_Test.php
@@ -40,30 +40,40 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	private $original_wp_styles;
 
 	/**
+	 * Original $pagenow value to restore after each test.
+	 *
+	 * @var string|null
+	 */
+	private $original_pagenow;
+
+	/**
 	 * Save global state before each test.
 	 */
 	public function set_up(): void {
 		parent::set_up();
-		global $wp_settings_fields, $wp_scripts, $wp_styles;
+		global $wp_settings_fields, $wp_scripts, $wp_styles, $pagenow;
 		$this->original_wp_settings_fields = $wp_settings_fields;
 		$this->original_wp_scripts         = $wp_scripts;
 		$this->original_wp_styles          = $wp_styles;
+		$this->original_pagenow            = $pagenow;
 	}
 
 	/**
 	 * Clean up filters and restore global state after each test.
 	 */
 	public function tear_down(): void {
-		global $wp_settings_fields, $wp_scripts, $wp_styles;
+		global $wp_settings_fields, $wp_scripts, $wp_styles, $pagenow;
 		$wp_settings_fields = $this->original_wp_settings_fields; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$wp_scripts         = $this->original_wp_scripts; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$wp_styles          = $this->original_wp_styles; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$pagenow            = $this->original_pagenow; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		remove_all_filters( 'jetpack_rtc_enabled' );
 		remove_all_filters( 'jetpack_rtc_providers' );
-		remove_all_filters( 'option_' . RTC::OPTION_OLD );
-		remove_all_filters( 'default_option_' . RTC::OPTION_OLD );
-		remove_all_filters( 'option_' . RTC::OPTION_NEW );
-		remove_all_filters( 'default_option_' . RTC::OPTION_NEW );
+		foreach ( array( RTC::OPTION_OLD, RTC::OPTION_NEW ) as $option ) {
+			remove_all_filters( 'option_' . $option );
+			remove_all_filters( 'default_option_' . $option );
+			remove_all_filters( 'pre_option_' . $option );
+		}
 
 		// Reset the static $initialized flag so hooks are re-registered in the next test.
 		$reflection = new \ReflectionProperty( RTC::class, 'initialized' );
@@ -129,23 +139,75 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 		$this->assertSame( 20, has_filter( 'default_option_' . RTC::OPTION_NEW, array( RTC::class, 'default_rtc_option' ) ) );
 	}
 
+	/**
+	 * Tests that init hooks pre_rtc_option on both old and new pre option filters.
+	 */
+	public function test_init_hooks_pre_rtc_option() {
+		RTC::init();
+		$this->assertSame( 10, has_filter( 'pre_option_' . RTC::OPTION_OLD, array( RTC::class, 'pre_rtc_option' ) ) );
+		$this->assertSame( 10, has_filter( 'pre_option_' . RTC::OPTION_NEW, array( RTC::class, 'pre_rtc_option' ) ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// is_allowed tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Tests that RTC is not allowed by default.
+	 */
+	public function test_is_allowed_default() {
+		$this->assertFalse( RTC::is_allowed() );
+	}
+
+	/**
+	 * Tests that RTC can be allowed via filter.
+	 */
+	public function test_is_allowed_via_filter() {
+		add_filter( 'jetpack_rtc_enabled', '__return_true' );
+		$this->assertTrue( RTC::is_allowed() );
+	}
+
 	// -------------------------------------------------------------------------
 	// is_enabled tests
 	// -------------------------------------------------------------------------
 
 	/**
-	 * Tests that RTC is disabled by default.
+	 * Tests that RTC is disabled when not allowed.
 	 */
-	public function test_is_enabled_default() {
+	public function test_is_enabled_returns_false_when_not_allowed() {
+		update_option( RTC::OPTION_NEW, '1' );
 		$this->assertFalse( RTC::is_enabled() );
 	}
 
 	/**
-	 * Tests that RTC can be enabled via filter.
+	 * Tests that RTC is enabled when allowed and the option is on.
 	 */
-	public function test_is_enabled_via_filter() {
+	public function test_is_enabled_returns_true_when_allowed_and_option_enabled() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
+		RTC::init();
 		$this->assertTrue( RTC::is_enabled() );
+	}
+
+	/**
+	 * Tests that RTC is disabled when allowed but the option is off.
+	 */
+	public function test_is_enabled_returns_false_when_allowed_but_option_disabled() {
+		add_filter( 'jetpack_rtc_enabled', '__return_true' );
+		update_option( RTC::OPTION_NEW, '0' );
+		$this->assertFalse( RTC::is_enabled() );
+	}
+
+	/**
+	 * Tests that RTC is disabled in the site editor.
+	 */
+	public function test_is_enabled_returns_false_in_site_editor() {
+		global $pagenow;
+
+		add_filter( 'jetpack_rtc_enabled', '__return_true' );
+		RTC::init();
+
+		$pagenow = 'site-editor.php'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$this->assertFalse( RTC::is_enabled() );
 	}
 
 	// -------------------------------------------------------------------------
@@ -178,6 +240,7 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_get_providers_returns_providers_when_enabled() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
+		RTC::init();
 		add_filter(
 			'jetpack_rtc_providers',
 			function () {
@@ -193,6 +256,7 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_get_providers_filters_unknown_providers() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
+		RTC::init();
 		add_filter(
 			'jetpack_rtc_providers',
 			function () {
@@ -208,6 +272,7 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_get_providers_handles_non_array_filter() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
+		RTC::init();
 		add_filter(
 			'jetpack_rtc_providers',
 			function () {
@@ -223,6 +288,7 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_get_providers_reindexes_after_filtering() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
+		RTC::init();
 		add_filter(
 			'jetpack_rtc_providers',
 			function () {
@@ -241,6 +307,7 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_get_providers_handles_empty_filter() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
+		RTC::init();
 		add_filter(
 			'jetpack_rtc_providers',
 			function () {
@@ -256,6 +323,7 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_get_providers_default_passes_allowlist() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
+		RTC::init();
 
 		$this->assertSame( array( 'pinghub' ), RTC::get_providers() );
 	}
@@ -269,6 +337,7 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_enqueue_assets_skips_http_polling_only() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
+		RTC::init();
 		add_filter(
 			'jetpack_rtc_providers',
 			function () {
@@ -286,6 +355,7 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_enqueue_assets_enqueues_when_pinghub() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
+		RTC::init();
 		add_filter(
 			'jetpack_rtc_providers',
 			function () {
@@ -303,6 +373,7 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_enqueue_assets_enqueues_with_multiple_providers() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
+		RTC::init();
 		add_filter(
 			'jetpack_rtc_providers',
 			function () {
@@ -320,6 +391,7 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_enqueue_assets_does_not_include_jwt_token() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
+		RTC::init();
 		add_filter(
 			'jetpack_rtc_providers',
 			function () {
@@ -338,12 +410,16 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that enqueue still registers the script when no providers are available.
+	 * Tests that enqueue skips when RTC is not enabled.
 	 */
-	public function test_enqueue_assets_enqueues_when_no_providers() {
+	public function test_enqueue_assets_skips_when_not_enabled() {
+		// Reset scripts to ensure clean state.
+		global $wp_scripts;
+		$wp_scripts = new \WP_Scripts(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
 		RTC::enqueue_assets();
 
-		$this->assertTrue( wp_script_is( 'jetpack-rtc', 'enqueued' ) );
+		$this->assertFalse( wp_script_is( 'jetpack-rtc', 'enqueued' ) );
 	}
 
 	// -------------------------------------------------------------------------
@@ -351,9 +427,9 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * Tests that unregister_rtc_setting removes both old and new fields when no providers exist.
+	 * Tests that unregister_rtc_setting removes both old and new fields when RTC is not allowed.
 	 */
-	public function test_unregister_rtc_setting_removes_field_when_no_providers() {
+	public function test_unregister_rtc_setting_removes_field_when_not_allowed() {
 		global $wp_settings_fields;
 
 		$wp_settings_fields['writing']['default'][ RTC::OPTION_OLD ] = array( 'id' => RTC::OPTION_OLD ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
@@ -366,9 +442,9 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that unregister_rtc_setting keeps both fields when providers exist.
+	 * Tests that unregister_rtc_setting keeps both fields when RTC is allowed.
 	 */
-	public function test_unregister_rtc_setting_keeps_field_when_providers_exist() {
+	public function test_unregister_rtc_setting_keeps_field_when_allowed() {
 		global $wp_settings_fields;
 
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
@@ -400,16 +476,16 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * Tests that filter_rtc_option forces '0' when no providers exist.
+	 * Tests that filter_rtc_option forces '0' when RTC is not allowed.
 	 */
-	public function test_filter_rtc_option_returns_0_when_no_providers() {
+	public function test_filter_rtc_option_returns_0_when_not_allowed() {
 		$this->assertSame( '0', RTC::filter_rtc_option( '1' ) );
 	}
 
 	/**
-	 * Tests that filter_rtc_option passes through the value when providers exist.
+	 * Tests that filter_rtc_option passes through the value when RTC is allowed.
 	 */
-	public function test_filter_rtc_option_passes_through_when_providers_exist() {
+	public function test_filter_rtc_option_passes_through_when_allowed() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
 
 		$this->assertSame( '1', RTC::filter_rtc_option( '1' ) );
@@ -421,16 +497,16 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * Tests that default_rtc_option returns '0' when no providers exist.
+	 * Tests that default_rtc_option returns '0' when RTC is not allowed.
 	 */
-	public function test_default_rtc_option_returns_0_when_no_providers() {
+	public function test_default_rtc_option_returns_0_when_not_allowed() {
 		$this->assertSame( '0', RTC::default_rtc_option() );
 	}
 
 	/**
-	 * Tests that default_rtc_option returns '1' when providers exist and no option is stored.
+	 * Tests that default_rtc_option returns '1' when RTC is allowed and no option is stored.
 	 */
-	public function test_default_rtc_option_returns_1_when_providers_exist() {
+	public function test_default_rtc_option_returns_1_when_allowed() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
 
 		$this->assertSame( '1', RTC::default_rtc_option( '', RTC::OPTION_OLD ) );
@@ -444,5 +520,47 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 		update_option( RTC::OPTION_OLD, '0' );
 
 		$this->assertSame( '0', RTC::default_rtc_option( '', RTC::OPTION_NEW ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// pre_rtc_option tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Tests that pre_rtc_option passes through (returns false) when no user is logged in.
+	 */
+	public function test_pre_rtc_option_passes_through_when_logged_out() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( RTC::pre_rtc_option() );
+	}
+
+	/**
+	 * Tests that pre_rtc_option passes through for a blog member.
+	 *
+	 * In single-site, is_user_member_of_blog() is always true for existing users,
+	 * so the super admin non-member condition is never met.
+	 */
+	public function test_pre_rtc_option_passes_through_for_blog_member() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'admin_member',
+				'user_pass'  => 'password',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		$this->assertFalse( RTC::pre_rtc_option() );
+	}
+
+	/**
+	 * Tests that pre_rtc_option passes through on the Writing settings page
+	 * regardless of user role, so super admins can still toggle the setting.
+	 */
+	public function test_pre_rtc_option_passes_through_on_writing_settings_page() {
+		global $pagenow;
+		$pagenow = 'options-writing.php'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$this->assertFalse( RTC::pre_rtc_option() );
 	}
 }


### PR DESCRIPTION
Fixes DOTCOM-16563

## Proposed changes

* Disable RTC for super admins who are not explicit members of the blog, preventing their presence from being exposed to site owners (e.g. during support sessions). This also fixes the 403 error on the PingHub JWT endpoint for blogs where super admins are not blog members (e.g. blog ID 1).
* Use a `pre_option_` filter (`pre_rtc_option`) to force the collaboration option to `'0'` for non-member super admins. This short-circuits `get_option` before both `option_` and `default_option_` filters, avoiding duplicated logic. The override is skipped on the Writing settings page so super admins can still toggle the setting.
* Refactor `is_enabled()` → `is_allowed()` (whether RTC can be enabled at all) and introduce a new `is_enabled()` that combines `is_allowed()`, the stored option value, and the site editor exclusion — centralizing the "is RTC active" check.
* Simplify `enqueue_assets`, `unregister_rtc_setting`, and `override_rtc_setting_default` to use the new `is_enabled`/`is_allowed` methods.
* Remove duplicated site editor and option checks from `wpcom_enqueue_rtc_notices_assets()` in `jetpack-mu-wpcom`, since `RTC::is_enabled()` now handles them.
* Update tests to match the refactored API and add coverage for `is_enabled`, `is_allowed`, `pre_rtc_option`, and site editor exclusion.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* N/A

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* As a super admin who is **not** a member of a blog, open the post editor — RTC should be fully disabled (no collaborators, no HTTP polling).
* As a super admin who is **not** a member of a blog, go to Settings > Writing — the RTC toggle should still be visible and functional.
* As a super admin who **is** a member of a blog, open the post editor — RTC should work normally.
* As a regular blog member, open the post editor — RTC should work normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)