### PR TITLE
CRM: Align header with unified Jetpack admin page pattern

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4783,6 +4783,9 @@ importers:
       '@wordpress/icons':
         specifier: 12.0.0
         version: 12.0.0(react@18.3.1)
+      '@wordpress/theme':
+        specifier: 0.9.0
+        version: 0.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
       clsx:
         specifier: 2.1.1
         version: 2.1.1

--- a/projects/plugins/crm/changelog/update-crm-unified-header
+++ b/projects/plugins/crm/changelog/update-crm-unified-header
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: CRM unified header
+
+Replace header logo with Jetpack bolt icon and "CRM" text to match the unified admin page header pattern. Adjust spacing, add border below tabs, and preserve fullscreen toggle and white-label support.

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.Top.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.Top.php
@@ -275,12 +275,19 @@ function zeroBSCRM_admin_top_menu( $branding = 'zero-bs-crm', $page = 'dash' ) {
 		<!---  // mobile only menu -->
 	<div id="jpcrm-top-menu">
 		<div class="logo-cube <?php echo esc_attr( $admin_menu_state ); ?>">
-			<div class="cube-side side1">
-				<img alt="Jetpack CRM logo" src="<?php echo esc_url( jpcrm_get_logo( false ) ); ?>">
-			</div>
-			<div class="cube-side side2">
-				<i class="expand icon fa-flip-horizontal"></i>
-			</div>
+			<?php
+			$header_icon = '<img alt="" src="' . esc_url( plugins_url( '/i/icon-32.png', ZBS_ROOTFILE ) ) . '" width="20" height="20" class="jpcrm-header-logo__icon" />';
+			##WLREMOVE
+			$header_icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="20" height="20" class="jpcrm-header-logo__icon" aria-hidden="true" focusable="false">'
+				. '<path fill="#069e08" d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z M15,19H7l8-16V19z M17,29V13h8L17,29z"/>'
+				. '</svg>';
+			##/WLREMOVE
+			echo $header_icon; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Hardcoded HTML with pre-escaped attributes.
+			##WLREMOVE
+			?>
+			<span class="jpcrm-header-logo__text"><?php esc_html_e( 'CRM', 'zero-bs-crm' ); ?></span>
+			<?php ##/WLREMOVE ?>
+			<i class="expand icon jpcrm-fullscreen-toggle" title="<?php esc_attr_e( 'Toggle full screen', 'zero-bs-crm' ); ?>"></i>
 		</div>
 
 		<menu-bar>

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.Top.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.Top.php
@@ -275,19 +275,22 @@ function zeroBSCRM_admin_top_menu( $branding = 'zero-bs-crm', $page = 'dash' ) {
 		<!---  // mobile only menu -->
 	<div id="jpcrm-top-menu">
 		<div class="logo-cube <?php echo esc_attr( $admin_menu_state ); ?>">
-			<?php
-			$header_icon = '<img alt="" src="' . esc_url( jpcrm_get_logo( false ) ) . '" width="20" height="20" class="jpcrm-header-logo__icon" />';
-			##WLREMOVE
-			$header_icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="20" height="20" class="jpcrm-header-logo__icon" aria-hidden="true" focusable="false">'
-				. '<path fill="#069e08" d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z M15,19H7l8-16V19z M17,29V13h8L17,29z"/>'
-				. '</svg>';
-			##/WLREMOVE
-			echo $header_icon; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Hardcoded HTML with pre-escaped attributes.
-			##WLREMOVE
-			?>
-			<span class="jpcrm-header-logo__text">CRM</span>
-			<?php ##/WLREMOVE ?>
-			<i class="expand icon jpcrm-fullscreen-toggle" title="<?php esc_attr_e( 'Toggle full screen', 'zero-bs-crm' ); ?>"></i>
+			<div class="cube-side side1">
+				<?php
+				$header_icon = '<img alt="" src="' . esc_url( jpcrm_get_logo( false ) ) . '" width="20" height="20" class="jpcrm-header-logo__icon" />';
+				##WLREMOVE
+				// Jetpack logo
+				$header_icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="20" height="20" class="jpcrm-header-logo__icon" aria-hidden="true" focusable="false"><path fill="#069e08" d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z M15,19H7l8-16V19z M17,29V13h8L17,29z"/></svg>';
+				##/WLREMOVE
+				echo $header_icon; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Hardcoded HTML with pre-escaped attributes.
+				?>
+				<?php ##WLREMOVE ?>
+				<span class="jpcrm-header-logo__text">CRM</span>
+				<?php ##/WLREMOVE ?>
+			</div>
+			<div class="cube-side side2">
+				<i class="expand icon jpcrm-fullscreen-toggle" title="<?php esc_attr_e( 'Toggle full screen', 'zero-bs-crm' ); ?>"></i>
+			</div>
 		</div>
 
 		<menu-bar>

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.Top.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.Top.php
@@ -285,7 +285,7 @@ function zeroBSCRM_admin_top_menu( $branding = 'zero-bs-crm', $page = 'dash' ) {
 			echo $header_icon; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Hardcoded HTML with pre-escaped attributes.
 			##WLREMOVE
 			?>
-			<span class="jpcrm-header-logo__text"><?php esc_html_e( 'CRM', 'zero-bs-crm' ); ?></span>
+			<span class="jpcrm-header-logo__text">CRM</span>
 			<?php ##/WLREMOVE ?>
 			<i class="expand icon jpcrm-fullscreen-toggle" title="<?php esc_attr_e( 'Toggle full screen', 'zero-bs-crm' ); ?>"></i>
 		</div>

--- a/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.Top.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.Core.Menus.Top.php
@@ -276,7 +276,7 @@ function zeroBSCRM_admin_top_menu( $branding = 'zero-bs-crm', $page = 'dash' ) {
 	<div id="jpcrm-top-menu">
 		<div class="logo-cube <?php echo esc_attr( $admin_menu_state ); ?>">
 			<?php
-			$header_icon = '<img alt="" src="' . esc_url( plugins_url( '/i/icon-32.png', ZBS_ROOTFILE ) ) . '" width="20" height="20" class="jpcrm-header-logo__icon" />';
+			$header_icon = '<img alt="" src="' . esc_url( jpcrm_get_logo( false ) ) . '" width="20" height="20" class="jpcrm-header-logo__icon" />';
 			##WLREMOVE
 			$header_icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="20" height="20" class="jpcrm-header-logo__icon" aria-hidden="true" focusable="false">'
 				. '<path fill="#069e08" d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z M15,19H7l8-16V19z M17,29V13h8L17,29z"/>'

--- a/projects/plugins/crm/includes/ZeroBSCRM.List.Views.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.List.Views.php
@@ -304,7 +304,7 @@ function zeroBSCRM_render_formslist_page() { // phpcs:ignore WordPress.NamingCon
 		##WLREMOVE
 		// first build upsell box html
 		$upsell_box_html  = '<!-- Forms PRO box --><div class="">';
-		$upsell_box_html .= '<h4>' . esc_html__( 'Need More Complex Forms?', 'zero-bs-crm' ) . '</h4>';
+		$upsell_box_html .= '<h4 style="padding: 0 8px;">' . esc_html__( 'Need More Complex Forms?', 'zero-bs-crm' ) . '</h4>';
 
 		$up_title  = esc_html__( 'Fully Flexible Forms', 'zero-bs-crm' );
 		$up_desc   = esc_html__( 'Jetpack CRM forms cover simple use contact and subscription forms, but if you need more we suggest using a form plugin like Contact Form 7 or Gravity Forms:', 'zero-bs-crm' );
@@ -372,7 +372,7 @@ function zeroBSCRM_render_segmentslist_page() { // phpcs:ignore WordPress.Naming
 
 		// first build upsell box html
 		$upsell_box_html  = '<div class="">';
-		$upsell_box_html .= '<h4>' . esc_html__( 'Using Segments?', 'zero-bs-crm' ) . '</h4>';
+		$upsell_box_html .= '<h4 style="padding: 0 8px;">' . esc_html__( 'Using Segments?', 'zero-bs-crm' ) . '</h4>';
 
 		$up_title  = esc_html__( 'Segment like a PRO', 'zero-bs-crm' );
 		$up_desc   = esc_html__( 'Did you know that we\'ve made segments more advanced?', 'zero-bs-crm' );

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.global.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.global.js
@@ -199,8 +199,9 @@ function zbscrm_JS_adminMenuDropdown() {
 
 		// if calypso, loading on an embed page, already full screen, need to run this to re-adjust/hide:
 		setTimeout( function () {
-			if ( ! jQuery( '#jpcrm-top-menu .logo-cube' ).hasClass( 'menu-open' ) ) {
-				zbscrm_JS_fullscreenModeOn( jQuery( '#jpcrm-top-menu .logo-cube' ) );
+			const $logoCube = jQuery( '#jpcrm-top-menu .logo-cube' );
+			if ( $logoCube.length && ! $logoCube.hasClass( 'menu-open' ) ) {
+				zbscrm_JS_fullscreenModeOn( $logoCube );
 			}
 		}, 0 );
 	}

--- a/projects/plugins/crm/package.json
+++ b/projects/plugins/crm/package.json
@@ -31,6 +31,7 @@
 		"@wordpress/element": "6.43.0",
 		"@wordpress/i18n": "6.16.0",
 		"@wordpress/icons": "12.0.0",
+		"@wordpress/theme": "0.9.0",
 		"clsx": "2.1.1",
 		"prop-types": "15.8.1",
 		"react": "18.3.1",

--- a/projects/plugins/crm/sass/emerald/_jpcrm_top_menu.scss
+++ b/projects/plugins/crm/sass/emerald/_jpcrm_top_menu.scss
@@ -1,13 +1,12 @@
 #jpcrm-top-menu {
-	padding: 16px 24px 0;
+	padding: var(--wpds-dimension-padding-xl, 16px) var(--wpds-dimension-padding-2xl, 24px) 0;
 	display: block;
 	background-color: #fff;
 
-	/* logo area — keeps .logo-cube class for backward compatibility */
 	.logo-cube {
 		display: flex;
 		align-items: center;
-		gap: 8px;
+		gap: var(--wpds-dimension-gap-sm, 8px);
 		height: 24px;
 		cursor: pointer;
 
@@ -39,13 +38,13 @@
 	}
 
 	menu-bar {
-		margin-top: 8px;
+		margin-top: var(--wpds-dimension-gap-sm, 8px);
 		margin-left: -1em;
 		padding-bottom: 0;
 		display: flex;
 		justify-content: space-between;
 		align-items: end;
-		border-bottom: 1px solid #dcdcde;
+		border-bottom: var(--wpds-border-width-xs, 1px) solid var(--wpds-color-stroke-surface-neutral-weak, #dcdcde);
 
 		menu-section {
 
@@ -60,7 +59,7 @@
 				line-height: 1;
 
 				&.current_menu_item {
-					border-bottom: 2px solid var(--jp-black);
+					border-bottom: 2px solid var(--wpds-color-stroke-interactive-neutral-strong, #6c6c6c);
 				}
 			}
 

--- a/projects/plugins/crm/sass/emerald/_jpcrm_top_menu.scss
+++ b/projects/plugins/crm/sass/emerald/_jpcrm_top_menu.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/theme/design-tokens.css";
+
 #jpcrm-top-menu {
 	padding: var(--wpds-dimension-padding-xl, 16px) var(--wpds-dimension-padding-2xl, 24px) 0;
 	display: block;
@@ -18,10 +20,10 @@
 
 		.jpcrm-header-logo__text {
 			font-family: -apple-system, system-ui, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-			font-size: 15px;
+			font-size: var(--wpds-font-size-lg, 15px);
 			font-weight: 499;
-			line-height: 28px;
-			color: #1d2327;
+			line-height: var(--wpds-font-line-height-lg, 28px);
+			color: var(--wpds-color-fg-content-neutral, #1d2327);
 		}
 
 		.jpcrm-fullscreen-toggle {

--- a/projects/plugins/crm/sass/emerald/_jpcrm_top_menu.scss
+++ b/projects/plugins/crm/sass/emerald/_jpcrm_top_menu.scss
@@ -3,7 +3,7 @@
 #jpcrm-top-menu {
 	padding: var(--wpds-dimension-padding-xl, 16px) var(--wpds-dimension-padding-2xl, 24px) 0;
 	display: block;
-	background-color: #fff;
+	background-color: var(--wpds-color-bg-surface-neutral-strong, #fff);
 
 	.logo-cube {
 		display: flex;
@@ -29,7 +29,7 @@
 		.jpcrm-fullscreen-toggle {
 			opacity: 0;
 			font-size: 17px;
-			color: rgba(0, 0, 0, 0.4);
+			color: var(--wpds-color-fg-content-neutral-weak, #6d6d6d);
 			transition: opacity 0.2s;
 			margin: 0;
 		}
@@ -49,14 +49,11 @@
 		border-bottom: var(--wpds-border-width-xs, 1px) solid var(--wpds-color-stroke-surface-neutral-weak, #dcdcde);
 
 		menu-section {
-
-			font-size: 14px;
-			font-family: Lato, "Helvetica Neue", Arial, Helvetica, sans-serif;
 			display: flex;
 			align-items: center;
 
 			.item {
-				color: var(--jp-black) !important;
+				color: var(--wpds-color-fg-content-neutral, #1e1e1e) !important;
 				padding: 1em;
 				line-height: 1;
 
@@ -91,14 +88,14 @@
 
 					i {
 						margin-right: 10px;
-						color: rgba(0, 0, 0, 0.4);
+						color: var(--wpds-color-fg-content-neutral-weak, #6d6d6d);
 					}
 				}
 
 				&:hover {
 
 					.item i {
-						color: rgba(0, 0, 0, 0.87);
+						color: var(--wpds-color-fg-content-neutral, #1e1e1e);
 					}
 				}
 			}

--- a/projects/plugins/crm/sass/emerald/_jpcrm_top_menu.scss
+++ b/projects/plugins/crm/sass/emerald/_jpcrm_top_menu.scss
@@ -6,36 +6,49 @@
 	background-color: var(--wpds-color-bg-surface-neutral-strong, #fff);
 
 	.logo-cube {
-		display: flex;
-		align-items: center;
-		gap: var(--wpds-dimension-gap-sm, 8px);
-		height: 24px;
 		cursor: pointer;
+		width: fit-content;
+		height: 24px;
+		line-height: 1;
+		transition: transform 0.33s;
+		transform-style: preserve-3d;
 
-		.jpcrm-header-logo__icon {
-			height: 20px;
-			width: 20px;
-			flex-shrink: 0;
+		&:hover {
+			transform: rotateX(90deg);
 		}
 
-		.jpcrm-header-logo__text {
-			font-family: -apple-system, system-ui, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-			font-size: var(--wpds-font-size-lg, 15px);
-			font-weight: 499;
-			line-height: var(--wpds-font-line-height-lg, 28px);
-			color: var(--wpds-color-fg-content-neutral, #1d2327);
-		}
+		.cube-side {
+			height: 24px;
 
-		.jpcrm-fullscreen-toggle {
-			opacity: 0;
-			font-size: 17px;
-			color: var(--wpds-color-fg-content-neutral-weak, #6d6d6d);
-			transition: opacity 0.2s;
-			margin: 0;
-		}
+			&.side1 {
+				display: flex;
+				align-items: center;
+				gap: var(--wpds-dimension-gap-sm, 8px);
+				transform: translateZ(12px);
 
-		&:hover .jpcrm-fullscreen-toggle {
-			opacity: 1;
+				.jpcrm-header-logo__icon {
+					flex-shrink: 0;
+				}
+
+				.jpcrm-header-logo__text {
+					font-family: -apple-system, system-ui, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+					font-size: var(--wpds-font-size-lg, 15px);
+					font-weight: 499;
+					line-height: var(--wpds-font-line-height-lg, 28px);
+					color: var(--wpds-color-fg-content-neutral, #1d2327);
+				}
+			}
+
+			&.side2 {
+				font-size: 24px;
+				text-align: center;
+				transform: rotateX(-90deg) translateZ(-12px);
+
+				.jpcrm-fullscreen-toggle {
+					color: var(--wpds-color-fg-content-neutral-weak, #6d6d6d);
+					margin: 0;
+				}
+			}
 		}
 	}
 

--- a/projects/plugins/crm/sass/emerald/_jpcrm_top_menu.scss
+++ b/projects/plugins/crm/sass/emerald/_jpcrm_top_menu.scss
@@ -1,47 +1,51 @@
 #jpcrm-top-menu {
-	padding: 20px 20px 0 20px;
+	padding: 16px 24px 0;
 	display: block;
 	background-color: #fff;
 
-	/* handle top menu logo cube */
+	/* logo area — keeps .logo-cube class for backward compatibility */
 	.logo-cube {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		height: 24px;
 		cursor: pointer;
-		height: 40px;
-		width: 200px;
-		line-height: 1;
-		transition: transform 0.33s;
-		transform-style: preserve-3d;
 
-		&:hover {
-			transform: rotateX(90deg); /* Text bleed at 90º */
+		.jpcrm-header-logo__icon {
+			height: 20px;
+			width: 20px;
+			flex-shrink: 0;
 		}
 
-		.cube-side {
-			height: 40px;
-			background-color: #fff;
-			text-align: center;
+		.jpcrm-header-logo__text {
+			font-family: -apple-system, system-ui, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+			font-size: 15px;
+			font-weight: 499;
+			line-height: 28px;
+			color: #1d2327;
+		}
 
-			&.side1 {
-				transform: translateZ(20px);
+		.jpcrm-fullscreen-toggle {
+			opacity: 0;
+			font-size: 17px;
+			color: rgba(0, 0, 0, 0.4);
+			transition: opacity 0.2s;
+			margin: 0;
+		}
 
-				img {
-					max-width: 100%;
-					max-height: 40px;
-				}
-			}
-
-			&.side2 {
-				font-size: 40px;
-				transform: rotateX(-90deg) translateZ(-20px);
-			}
+		&:hover .jpcrm-fullscreen-toggle {
+			opacity: 1;
 		}
 	}
 
 	menu-bar {
-		margin-top: 10px;
+		margin-top: 8px;
+		margin-left: -1em;
+		padding-bottom: 0;
 		display: flex;
 		justify-content: space-between;
 		align-items: end;
+		border-bottom: 1px solid #dcdcde;
 
 		menu-section {
 


### PR DESCRIPTION
Resolves JETPACK-1357

## Proposed changes

Replaces the Jetpack CRM top menu header with the unified Jetpack header pattern, aligning it visually with other Jetpack admin pages (Social, Backup, VideoPress, etc.).

This is a **pure PHP/CSS change** — CRM has no React build for its admin pages, so we modify the server-rendered header directly.

Before:
<img width="2050" height="236" alt="zerobscrm-before" src="https://github.com/user-attachments/assets/6e1d3d9e-2e51-4417-a88a-cc71ecaea42f" />

After:
<img width="2050" height="194" alt="zerobscrm-after" src="https://github.com/user-attachments/assets/00bfb76c-29ff-4bbf-a4fc-2e961347735f" />


NOTE: Calypso side of things needs checking/testing

### What changed

* **Logo**: The 3D logo-cube (horizontal "Jetpack CRM" PNG wordmark with flip animation) is replaced with an inline Jetpack bolt SVG + "CRM" DOM text, matching the `@wordpress/admin-ui` Page header pattern. The `.logo-cube` class is preserved for backward compatibility.
* **Styling**: Header padding adjusted to 16px/24px, border-bottom added below the tab row, tab links aligned with the logo via negative margin. Title text matches `.admin-ui-page__header-title` styles (15px, weight 499, system font stack).
* **Fullscreen mode**: The old 3D cube flip revealed an expand icon on hover. Now a small expand icon fades in on hover of the logo area instead. All fullscreen PHP/JS logic is fully preserved — only the Calypso auto-fullscreen init is guarded with an element existence check to prevent a false trigger.
* **White-label**: Uses the existing `##WLREMOVE` pattern. Branded builds get bolt SVG + "CRM" text; white-label builds fall back to `jpcrm_get_logo()` (icon-32.png) with no text. **Note**: we don't have a render path to test white-label builds — the `##WLREMOVE` stripping is done by an external build process. We've simulated it by manually commenting out the tagged blocks and confirmed the fallback renders correctly, but a proper WL build test would be ideal if anyone knows how to trigger one.
* **Upsell headings**: Added horizontal padding to "Using Segments?" and "Need More Complex Forms?" headings that were flush against the page border.

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links

* Slack thread: p1774966393824219-slack-C052XEUUBL4
* Part of the p1HpG7-xCB-p2 effort

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. Activate Jetpack CRM plugin
2. Go to any CRM page (Dashboard, Contacts, Settings, etc.)
3. Verify the header shows Jetpack bolt icon + "CRM" text with a bottom border below the tabs
4. Hover over the logo area — an expand icon should fade in
5. Click the logo area — fullscreen mode should toggle (hides WP admin bar and sidebar)
6. Navigate between CRM pages — header should be consistent, dropdown menus should work
7. Check the Segments list view — "Using Segments?" heading should be aligned with content
8. Check the Forms list view — "Need More Complex Forms?" heading should be aligned with content

### Before / After

| Before | After |
|--------|-------|
| Horizontal "Jetpack CRM" PNG wordmark | Jetpack bolt icon + "CRM" text |
| 3D cube flip animation on hover | Subtle expand icon fade-in on hover |
| No border below tabs | 1px border separating header from content |
| 20px padding | 16px/24px padding matching other Jetpack pages |

cc @haqadn @tbradsha — would appreciate a visual review. If either of you knows how to trigger a white-label build for CRM, it would be great to verify the `##WLREMOVE` fallback path renders correctly in that context.