### PR TITLE
Subscriptions: Make default capability dynamic based on post type

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscriptions-capability-check
+++ b/projects/plugins/jetpack/changelog/fix-subscriptions-capability-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscriptions: Make default capability dynamic based on post type

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -979,7 +979,11 @@ class Jetpack_Subscriptions {
 	 *
 	 * @return bool
 	 */
-	public function first_published_status_meta_auth_callback() {
+	public function first_published_status_meta_auth_callback( $allowed, $meta_key, $object_id ) {
+		$post_type        = get_post_type( $object_id );
+		$post_type_object = $post_type ? get_post_type_object( $post_type ) : null;
+		$default_cap      = $post_type_object ? $post_type_object->cap->publish_posts : 'publish_posts';
+
 		/**
 		 * Filter the capability to view if a post was ever published in the Subscription Module.
 		 *
@@ -987,9 +991,10 @@ class Jetpack_Subscriptions {
 		 *
 		 * @since 13.4
 		 *
-		 * @param string $capability User capability needed to view if a post was ever published. Default to publish_posts.
+		 * @param string $capability User capability needed to view if a post was ever published.
+		 *                           Default to publish_posts, or the equivalent capability for the post type.
 		 */
-		$capability = apply_filters( 'jetpack_subscriptions_post_was_ever_published_capability', 'publish_posts' );
+		$capability = apply_filters( 'jetpack_subscriptions_post_was_ever_published_capability', $default_cap );
 		if ( current_user_can( $capability ) ) {
 			return true;
 		}

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -977,14 +977,9 @@ class Jetpack_Subscriptions {
 	/**
 	 * Checks if the current user can publish posts.
 	 *
-	 * @return bool
-	 */
-/**
-	 * Checks if the current user can publish posts.
-	 *
-	 * @param bool     $allowed   Whether the user can add the object meta. Default false.
-	 * @param string   $meta_key  The meta key.
-	 * @param int      $object_id Object ID.
+	 * @param bool   $allowed   Whether the user can add the object meta. Default false.
+	 * @param string $meta_key  The meta key.
+	 * @param int    $object_id Object ID.
 	 * @return bool
 	 */
 	public function first_published_status_meta_auth_callback( $allowed, $meta_key, $object_id ) {

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -979,6 +979,14 @@ class Jetpack_Subscriptions {
 	 *
 	 * @return bool
 	 */
+/**
+	 * Checks if the current user can publish posts.
+	 *
+	 * @param bool     $allowed   Whether the user can add the object meta. Default false.
+	 * @param string   $meta_key  The meta key.
+	 * @param int      $object_id Object ID.
+	 * @return bool
+	 */
 	public function first_published_status_meta_auth_callback( $allowed, $meta_key, $object_id ) {
 		$post_type        = get_post_type( $object_id );
 		$post_type_object = $post_type ? get_post_type_object( $post_type ) : null;


### PR DESCRIPTION
## Proposed changes

The `first_published_status_meta_auth_callback` method, which controls access to the `jetpack_post_was_ever_published` post meta via the REST API, hardcodes `publish_posts` as the default capability. This causes the auth check to always use the built-in post capability regardless of the actual post type being accessed.

This PR makes the default capability dynamic by resolving it from the post type object.

## Related product discussion/links

- A reported issue on the Pattern Directory repo: https://github.com/WordPress/pattern-directory/issues/737#issuecomment-4160401639
- Disucussuion on `#meta` channel: See https://wordpress.slack.com/archives/C02QB8GMM/p1774601970308729

## Does this pull request change what data or activity we track or use?

No

## Testing instructions

I didn't have the bandwidth to set up a local Jetpack environment, but if my hypothesis is correct, you should be able to test this PR with the following steps.

1. Enable the Subscriptions module.
2. Register a custom post type with a custom capability type, e.g.:

    ```php
    add_action( 'init', function() {
    	register_post_type( 'book', array(
    		'capability_type' => array( 'book', 'books' ),
    		'map_meta_cap'    => true,
    		'show_in_rest'    => true,
    	) );
    	$role = get_role( 'contributor' );
    	$role->add_cap( 'publish_books' );
    } );
    ```

3. Create a user with the `contributor` role and then log in as that user.

4. Create a new "book" post and publish it.

   - Before this fix: access would be denied  
   - After this fix: access should be granted

