### PR TITLE
Subscriptions: limit post meta to the post post type

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscriptions-post-type-restriction
+++ b/projects/plugins/jetpack/changelog/fix-subscriptions-post-type-restriction
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscriptions: avoid conflicts in the block editor when editing custom post types.

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -968,6 +968,11 @@ class Jetpack_Subscriptions {
 	 * @param object $post obj The post object.
 	 */
 	public function maybe_set_first_published_status( $new_status, $old_status, $post ) {
+		// Subscriptions are only available for posts so far.
+		if ( ! $post instanceof \WP_Post || 'post' !== $post->post_type ) {
+			return;
+		}
+
 		$was_post_ever_published = get_post_meta( $post->ID, '_jetpack_post_was_ever_published', true );
 		if ( ! $was_post_ever_published && 'publish' === $old_status && 'draft' === $new_status ) {
 			update_post_meta( $post->ID, '_jetpack_post_was_ever_published', true );
@@ -1001,14 +1006,15 @@ class Jetpack_Subscriptions {
 	 */
 	public function register_post_meta() {
 		$jetpack_post_was_ever_published = array(
-			'type'          => 'boolean',
-			'description'   => __( 'Whether the post was ever published.', 'jetpack' ),
-			'single'        => true,
-			'default'       => false,
-			'show_in_rest'  => array(
+			'type'           => 'boolean',
+			'description'    => __( 'Whether the post was ever published.', 'jetpack' ),
+			'single'         => true,
+			'default'        => false,
+			'show_in_rest'   => array(
 				'name' => 'jetpack_post_was_ever_published',
 			),
-			'auth_callback' => array( $this, 'first_published_status_meta_auth_callback' ),
+			'auth_callback'  => array( $this, 'first_published_status_meta_auth_callback' ),
+			'object_subtype' => 'post', // Subscriptions are only for the post post type so far, so we can limit this meta to posts only.
 		);
 
 		register_meta( 'post', '_jetpack_post_was_ever_published', $jetpack_post_was_ever_published );


### PR DESCRIPTION
Fixes NL-576

Alternative to #47875.

## Proposed changes

Subscriptions only support the `post` post type, so there's no reason to register the `_jetpack_post_was_ever_published` meta or track first-published status for custom post types. This PR:

* Adds `object_subtype => 'post'` to the meta registration, so it only applies to posts.
* Adds an early return in `maybe_set_first_published_status` for non-post types.

This avoids capability conflicts in the block editor when editing custom post types (e.g. missing `publish_posts` cap on types that use different capabilities).

### Other information

- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links

* #47875

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Start with a site that's connected to WordPress.com
* Go to Jetpack > Newsletter and enable the Newsletter feature
* Open the block editor for a custom post type (e.g. one registered by a plugin).
* Publish that CPT.
* Verify no errors related to `publish_posts` capability.
* Create a new post, publish it, then revert to draft. Verify `_jetpack_post_was_ever_published` meta is still set correctly.
* Confirm the subscription email flow still works normally for regular posts.