### PR TITLE
Social: Make link preview icons clickable to open preview modal

### DIFF
--- a/projects/packages/publicize/_inc/components/link-preview-panel/index.tsx
+++ b/projects/packages/publicize/_inc/components/link-preview-panel/index.tsx
@@ -4,10 +4,48 @@
  * Shows available services and allows opening up the preview modal.
  */
 
-import { PanelBody } from '@wordpress/components';
-import { __, _x } from '@wordpress/i18n';
-import { LinkPreviewModalWithTrigger, usePreviewTabs } from '../../exports/link-preview';
+import { Button, PanelBody } from '@wordpress/components';
+import { __, _x, sprintf } from '@wordpress/i18n';
+import { useCallback, useState } from 'react';
+import { LinkPreviewModal, usePreviewTabs } from '../../exports/link-preview';
+import { LinkPreviewPlatform } from '../../exports/link-preview/types';
+import { PreviewTab } from '../../exports/link-preview/use-preview-tabs';
 import styles from './styles.module.scss';
+
+/**
+ * A single social service icon button that opens the preview modal for that service.
+ *
+ * @param {object}   props         - Component props.
+ * @param {object}   props.tab     - The preview tab definition.
+ * @param {Function} props.onClick - Callback when the button is clicked, receives the tab name.
+ * @return The service icon button component.
+ */
+function ServiceIconButton( {
+	tab,
+	onClick,
+}: {
+	tab: PreviewTab;
+	onClick: ( name: LinkPreviewPlatform ) => void;
+} ) {
+	const handleClick = useCallback( () => {
+		onClick( tab.name );
+	}, [ onClick, tab.name ] );
+
+	return (
+		<Button
+			className={ styles[ 'social-icon-button' ] }
+			label={ sprintf(
+				/* translators: %s is the name of a social media service, e.g. "Facebook" */
+				__( 'Preview on %s', 'jetpack-publicize-pkg' ),
+				tab.title
+			) }
+			showTooltip
+			onClick={ handleClick }
+		>
+			{ typeof tab.icon === 'function' ? <tab.icon /> : tab.icon }
+		</Button>
+	);
+}
 
 /**
  * Display the link previews panel, showing available services and a trigger to open the preview modal.
@@ -16,6 +54,21 @@ import styles from './styles.module.scss';
  */
 export function LinkPreviewPanel() {
 	const previewTabs = usePreviewTabs();
+	const [ initialTab, setInitialTab ] = useState< LinkPreviewPlatform | undefined >();
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
+
+	const openModal = useCallback( ( tabName?: LinkPreviewPlatform ) => {
+		setInitialTab( tabName );
+		setIsModalOpen( true );
+	}, [] );
+
+	const openModalDefault = useCallback( () => {
+		openModal();
+	}, [ openModal ] );
+
+	const closeModal = useCallback( () => {
+		setIsModalOpen( false );
+	}, [] );
 
 	return (
 		<PanelBody title={ __( 'Link preview', 'jetpack-publicize-pkg' ) }>
@@ -28,21 +81,28 @@ export function LinkPreviewPanel() {
 
 			<ul className={ styles[ 'social-icons-list' ] }>
 				{ previewTabs.map( tab => (
-					<li key={ tab.name }>{ typeof tab.icon === 'function' ? <tab.icon /> : tab.icon }</li>
+					<li key={ tab.name }>
+						<ServiceIconButton tab={ tab } onClick={ openModal } />
+					</li>
 				) ) }
 			</ul>
 
-			<LinkPreviewModalWithTrigger
-				triggerButtonProps={ {
-					size: 'default',
-					'aria-label': __( 'Open link preview', 'jetpack-publicize-pkg' ),
-					children: _x(
-						'Preview',
-						'Button label that opens the SEO link previews modal',
-						'jetpack-publicize-pkg'
-					),
-				} }
-			/>
+			<Button
+				variant="secondary"
+				size="default"
+				aria-label={ __( 'Open link preview', 'jetpack-publicize-pkg' ) }
+				onClick={ openModalDefault }
+			>
+				{ _x(
+					'Preview',
+					'Button label that opens the SEO link previews modal',
+					'jetpack-publicize-pkg'
+				) }
+			</Button>
+
+			{ isModalOpen && (
+				<LinkPreviewModal initialTabName={ initialTab } onRequestClose={ closeModal } />
+			) }
 		</PanelBody>
 	);
 }

--- a/projects/packages/publicize/_inc/components/link-preview-panel/index.tsx
+++ b/projects/packages/publicize/_inc/components/link-preview-panel/index.tsx
@@ -5,47 +5,12 @@
  */
 
 import { Button, PanelBody } from '@wordpress/components';
-import { __, _x, sprintf } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { useCallback, useState } from 'react';
 import { LinkPreviewModal, usePreviewTabs } from '../../exports/link-preview';
 import { LinkPreviewPlatform } from '../../exports/link-preview/types';
-import { PreviewTab } from '../../exports/link-preview/use-preview-tabs';
+import { ServiceIconButton } from './service-icon-button';
 import styles from './styles.module.scss';
-
-/**
- * A single social service icon button that opens the preview modal for that service.
- *
- * @param {object}   props         - Component props.
- * @param {object}   props.tab     - The preview tab definition.
- * @param {Function} props.onClick - Callback when the button is clicked, receives the tab name.
- * @return The service icon button component.
- */
-function ServiceIconButton( {
-	tab,
-	onClick,
-}: {
-	tab: PreviewTab;
-	onClick: ( name: LinkPreviewPlatform ) => void;
-} ) {
-	const handleClick = useCallback( () => {
-		onClick( tab.name );
-	}, [ onClick, tab.name ] );
-
-	return (
-		<Button
-			className={ styles[ 'social-icon-button' ] }
-			label={ sprintf(
-				/* translators: %s is the name of a social media service, e.g. "Facebook" */
-				__( 'Preview on %s', 'jetpack-publicize-pkg' ),
-				tab.title
-			) }
-			showTooltip
-			onClick={ handleClick }
-		>
-			{ typeof tab.icon === 'function' ? <tab.icon /> : tab.icon }
-		</Button>
-	);
-}
 
 /**
  * Display the link previews panel, showing available services and a trigger to open the preview modal.

--- a/projects/packages/publicize/_inc/components/link-preview-panel/service-icon-button.tsx
+++ b/projects/packages/publicize/_inc/components/link-preview-panel/service-icon-button.tsx
@@ -1,0 +1,50 @@
+/**
+ * A single social service icon button that opens the preview modal for that service.
+ */
+
+import { Button } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { useCallback } from 'react';
+import { LinkPreviewPlatform } from '../../exports/link-preview/types';
+import { PreviewTab } from '../../exports/link-preview/use-preview-tabs';
+import styles from './styles.module.scss';
+
+type ServiceIconButtonProps = {
+	/**
+	 * The preview tab definition.
+	 */
+	tab: PreviewTab;
+
+	/**
+	 * Callback when the button is clicked, receives the tab name.
+	 */
+	onClick: ( name: LinkPreviewPlatform ) => void;
+};
+
+/**
+ * A single social service icon button that opens the preview modal for that service.
+ *
+ * @param {ServiceIconButtonProps} props - Component props.
+ *
+ * @return The service icon button component.
+ */
+export function ServiceIconButton( { tab, onClick }: ServiceIconButtonProps ) {
+	const handleClick = useCallback( () => {
+		onClick( tab.name );
+	}, [ onClick, tab.name ] );
+
+	return (
+		<Button
+			className={ styles[ 'social-icon-button' ] }
+			label={ sprintf(
+				/* translators: %s is the name of a social media service, e.g. "Facebook" */
+				__( 'Preview for %s', 'jetpack-publicize-pkg' ),
+				tab.title
+			) }
+			showTooltip
+			onClick={ handleClick }
+		>
+			{ typeof tab.icon === 'function' ? <tab.icon /> : tab.icon }
+		</Button>
+	);
+}

--- a/projects/packages/publicize/_inc/components/link-preview-panel/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/link-preview-panel/styles.module.scss
@@ -5,3 +5,8 @@
 	gap: 0.5rem;
 	flex-wrap: wrap;
 }
+
+.social-icon-button {
+	padding: 0;
+	height: auto;
+}

--- a/projects/packages/publicize/_inc/exports/link-preview/modal.tsx
+++ b/projects/packages/publicize/_inc/exports/link-preview/modal.tsx
@@ -5,13 +5,18 @@ import { useReducer } from 'react';
 import { useLinkPreviewPostData } from '../../hooks/use-link-preview-post-data';
 import styles from './styles.module.scss';
 import { LinkPreviewTabs } from './tabs';
-import { LinkPreviewData } from './types';
+import { LinkPreviewData, LinkPreviewPlatform } from './types';
 
 export type LinkPreviewModalProps = Omit< React.ComponentProps< typeof Modal >, 'children' > & {
 	/**
 	 * The data to show in the link preview modal.
 	 */
 	previewData?: Partial< LinkPreviewData >;
+
+	/**
+	 * The initial tab to show when the modal opens.
+	 */
+	initialTabName?: LinkPreviewPlatform;
 };
 
 /**
@@ -21,6 +26,7 @@ export type LinkPreviewModalProps = Omit< React.ComponentProps< typeof Modal >, 
  */
 export function LinkPreviewModal( {
 	previewData,
+	initialTabName,
 	title,
 	className,
 	...modalProps
@@ -34,7 +40,11 @@ export function LinkPreviewModal( {
 			className={ clsx( styles[ 'link-preview-modal' ], className ) }
 			{ ...modalProps }
 		>
-			<LinkPreviewTabs { ...linkPreviewData } { ...previewData } />
+			<LinkPreviewTabs
+				initialTabName={ initialTabName }
+				{ ...linkPreviewData }
+				{ ...previewData }
+			/>
 		</Modal>
 	);
 }

--- a/projects/packages/publicize/changelog/social-426-make-button-at-link-preview-interactable
+++ b/projects/packages/publicize/changelog/social-426-make-button-at-link-preview-interactable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Make social service icons clickable to open the preview modal with that service selected.

--- a/projects/packages/publicize/changelog/social-426-make-button-at-link-preview-interactable
+++ b/projects/packages/publicize/changelog/social-426-make-button-at-link-preview-interactable
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Make social service icons clickable to open the preview modal with that service selected.
+Make link preview icons clickable to open the clicked service tab by default.


### PR DESCRIPTION
Fixes SOCIAL-426

## Proposed changes

* Make each social service icon in the Link Preview panel a clickable button
* Clicking an icon opens the preview modal with that service's tab pre-selected
* Add `initialTabName` prop to `LinkPreviewModal` to support opening on a specific tab
* Add tooltip to each icon button showing "Preview on {service name}"

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links

* Found in the latest Product Call with Matt

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Open a post in the block editor
2. Open the Jetpack Social sidebar → Link Preview panel
3. Verify the social icons have a hover state and tooltip (e.g. "Preview on Facebook")
4. Click a social icon → the preview modal should open with that service's tab selected
5. Close the modal, click the "Preview" button → modal should open on the first tab (Google Search)
6. Verify keyboard navigation works (Tab to icons, Enter/Space to activate)



https://github.com/user-attachments/assets/100ecfcf-628a-4d68-8425-f0f73556d438

