### PR TITLE
Carousel: Remove unused medium image file handling

### DIFF
--- a/projects/plugins/jetpack/changelog/carousel-remove-medium
+++ b/projects/plugins/jetpack/changelog/carousel-remove-medium
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Carousel: Remove unused medium image file handling
+
+

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -1,6 +1,7 @@
 /* global wpcom, jetpackCarouselStrings, DocumentTouch */
 /* eslint-disable no-shadow */
 
+alert( 'jp carousel' );
 ( function () {
 	'use strict';
 	var swiper;
@@ -905,19 +906,23 @@
 		}
 
 		function selectBestImageUrl( args ) {
+			console.log( 'selectBestImageUrl', args );
 			if ( typeof args !== 'object' ) {
 				args = {};
 			}
 
 			if ( typeof args.origFile === 'undefined' ) {
+				console.log( ' exit 1' );
 				return '';
 			}
 
 			if ( typeof args.origWidth === 'undefined' || typeof args.maxWidth === 'undefined' ) {
+				console.log( ' exit 2' );
 				return args.origFile;
 			}
 
 			if ( typeof args.mediumFile === 'undefined' || typeof args.largeFile === 'undefined' ) {
+				console.log( ' exit 3' );
 				return args.origFile;
 			}
 
@@ -943,6 +948,8 @@
 			}
 
 			if ( largeWidth >= args.maxWidth || largeHeight >= args.maxHeight ) {
+				console.log( { args, mediumWidth, largeWidth } );
+				console.log( ' pick large' );
 				return args.largeFile;
 			}
 
@@ -951,13 +958,17 @@
 			var mediumHeight = parseInt( mediumSizeParts[ 1 ], 10 );
 
 			if ( mediumWidth >= args.maxWidth || mediumHeight >= args.maxHeight ) {
+				console.log( { args, mediumWidth, largeWidth } );
+				console.log( ' pick medium' );
 				return args.mediumFile;
 			}
+			console.log( { args, mediumWidth, largeWidth } );
 
 			if ( isPhotonUrl ) {
 				// args.origFile doesn't point to a Photon url, so in this case we use args.largeFile
 				// to return the photon url of the original image.
 				if ( args.largeFile.lastIndexOf( '?' ) === -1 ) {
+					console.log( ' exit 4' );
 					return args.largeFile;
 				}
 
@@ -975,9 +986,11 @@
 				}
 
 				// Return a Photon URL image that's better fitted for the viewport.
+				console.log( ' exit 5' );
 				return sanitizedUrl.toString();
 			}
 
+			console.log( ' exit 6' );
 			return args.origFile;
 		}
 

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -906,23 +906,19 @@ alert( 'jp carousel2' );
 		}
 
 		function selectBestImageUrl( args ) {
-			console.log( 'selectBestImageUrl', args );
 			if ( typeof args !== 'object' ) {
 				args = {};
 			}
 
 			if ( typeof args.origFile === 'undefined' ) {
-				console.log( ' exit 1' );
 				return '';
 			}
 
 			if ( typeof args.origWidth === 'undefined' || typeof args.maxWidth === 'undefined' ) {
-				console.log( ' exit 2' );
 				return args.origFile;
 			}
 
 			if ( typeof args.largeFile === 'undefined' ) {
-				console.log( ' exit 3' );
 				return args.origFile;
 			}
 
@@ -948,8 +944,6 @@ alert( 'jp carousel2' );
 			}
 
 			if ( largeWidth >= args.maxWidth || largeHeight >= args.maxHeight ) {
-				console.log( { args, largeWidth } );
-				console.log( ' pick large' );
 				return args.largeFile;
 			}
 
@@ -957,7 +951,6 @@ alert( 'jp carousel2' );
 				// args.origFile doesn't point to a Photon url, so in this case we use args.largeFile
 				// to return the photon url of the original image.
 				if ( args.largeFile.lastIndexOf( '?' ) === -1 ) {
-					console.log( ' exit 4' );
 					return args.largeFile;
 				}
 
@@ -975,11 +968,9 @@ alert( 'jp carousel2' );
 				}
 
 				// Return a Photon URL image that's better fitted for the viewport.
-				console.log( ' exit 5' );
 				return sanitizedUrl.toString();
 			}
 
-			console.log( ' exit 6' );
 			return args.origFile;
 		}
 

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -1,7 +1,6 @@
 /* global wpcom, jetpackCarouselStrings, DocumentTouch */
 /* eslint-disable no-shadow */
 
-alert( 'jp carousel2' );
 ( function () {
 	'use strict';
 	var swiper;

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -1,7 +1,7 @@
 /* global wpcom, jetpackCarouselStrings, DocumentTouch */
 /* eslint-disable no-shadow */
 
-alert( 'jp carousel' );
+alert( 'jp carousel2' );
 ( function () {
 	'use strict';
 	var swiper;

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -921,7 +921,7 @@ alert( 'jp carousel' );
 				return args.origFile;
 			}
 
-			if ( typeof args.mediumFile === 'undefined' || typeof args.largeFile === 'undefined' ) {
+			if ( typeof args.largeFile === 'undefined' ) {
 				console.log( ' exit 3' );
 				return args.origFile;
 			}
@@ -948,21 +948,10 @@ alert( 'jp carousel' );
 			}
 
 			if ( largeWidth >= args.maxWidth || largeHeight >= args.maxHeight ) {
-				console.log( { args, mediumWidth, largeWidth } );
+				console.log( { args, largeWidth } );
 				console.log( ' pick large' );
 				return args.largeFile;
 			}
-
-			var mediumSizeParts = getImageSizeParts( args.mediumFile, args.origWidth, isPhotonUrl );
-			var mediumWidth = parseInt( mediumSizeParts[ 0 ], 10 );
-			var mediumHeight = parseInt( mediumSizeParts[ 1 ], 10 );
-
-			if ( mediumWidth >= args.maxWidth || mediumHeight >= args.maxHeight ) {
-				console.log( { args, mediumWidth, largeWidth } );
-				console.log( ' pick medium' );
-				return args.mediumFile;
-			}
-			console.log( { args, mediumWidth, largeWidth } );
 
 			if ( isPhotonUrl ) {
 				// args.origFile doesn't point to a Photon url, so in this case we use args.largeFile
@@ -1445,7 +1434,6 @@ alert( 'jp carousel' );
 					imageMeta: domUtil.getJSONAttribute( item, 'data-image-meta' ) || {},
 					title: item.getAttribute( 'data-image-title' ) || '',
 					desc: item.getAttribute( 'data-image-description' ) || '',
-					mediumFile: item.getAttribute( 'data-medium-file' ) || '',
 					largeFile: item.getAttribute( 'data-large-file' ) || '',
 					origFile: origFile || '',
 					thumbSize: { width: item.naturalWidth, height: item.naturalHeight },
@@ -1476,7 +1464,6 @@ alert( 'jp carousel' );
 						origHeight: attrs.origHeight,
 						maxWidth: max.width,
 						maxHeight: max.height,
-						mediumFile: attrs.mediumFile,
 						largeFile: attrs.largeFile,
 					} );
 				}

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -963,9 +963,6 @@ class Jetpack_Carousel {
 		 * array(4) { [0]=> string(82) "http://vanillawpinstall.blah/wp-content/uploads/2012/06/IMG_3534-1024x764.jpg" [1]=> int(640) [2]=> int(477) [3]=> bool(true) }
 		 */
 
-		$medium_file_info = wp_get_attachment_image_src( $attachment_id, 'medium' );
-		$medium_file      = isset( $medium_file_info[0] ) ? $medium_file_info[0] : '';
-
 		$large_file_info = wp_get_attachment_image_src( $attachment_id, 'large' );
 		$large_file      = isset( $large_file_info[0] ) ? $large_file_info[0] : '';
 
@@ -990,7 +987,6 @@ class Jetpack_Carousel {
 		$attr['data-image-title']       = esc_attr( htmlspecialchars( $attachment_title, ENT_COMPAT ) );
 		$attr['data-image-description'] = esc_attr( htmlspecialchars( $attachment_desc, ENT_COMPAT ) );
 		$attr['data-image-caption']     = esc_attr( htmlspecialchars( $attachment_caption, ENT_COMPAT ) );
-		$attr['data-medium-file']       = esc_attr( $medium_file );
 		$attr['data-large-file']        = esc_attr( $large_file );
 		return $attr;
 	}


### PR DESCRIPTION
## Proposed changes

The `selectBestImageUrl` function checks image sizes in order: large, then medium, then falls back to the original. However, since WordPress's large size is by definition larger than medium, if the large file isn't big enough to satisfy the viewport, the medium file can't be either. The medium check is unreachable under any standard WordPress configuration.
This removes the medium file from the entire pipeline:

* Drops the `wp_get_attachment_image_src( $attachment_id, 'medium' )` call in PHP, eliminating a potential db call carousel image
* Removes the `data-medium-file` attribute from image markup
* Removes the medium file parsing and comparison in the JS image selection logic

The only scenario where medium could have been selected is if an admin configured their medium size to be larger than their large size, which is a misconfiguration. In that case, the carousel will now select the original file instead - the same behavior every correctly configured site already has.
 
See extra analysis at p1775122736693869/1774995576.642459-slack-C4GAQ900P

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?

## Testing instructions

* Turn on carousel
* Create a new post, add a gallery and a few images
* Make sure the carousel still looks correct on the front-end
* Double check the logic used to determine medium is never used on a well configured site - can use something like b4ea8461095daaf176273953d91abe35139174e8 to trace the paths