### PR TITLE
Charts: Replace __experimentalText with @wordpress/ui Text

### DIFF
--- a/projects/js-packages/charts/changelog/text-component-migration
+++ b/projects/js-packages/charts/changelog/text-component-migration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Replace __experimentalText from @wordpress/components with stable Text from @wordpress/ui.

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
@@ -1,8 +1,8 @@
 /* eslint-disable @wordpress/no-unsafe-wp-apis */
-import { __experimentalGrid as Grid, __experimentalText as Text } from '@wordpress/components';
+import { __experimentalGrid as Grid } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Stack } from '@wordpress/ui';
+import { Stack, Text } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useContext, useMemo, type FC } from 'react';
 import { Legend } from '../../components/legend';

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/donut.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/donut.stories.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @wordpress/no-unsafe-wp-apis */
 import { __experimentalHStack as HStack } from '@wordpress/components';
-import { Text as WPText } from '@wordpress/ui';
+import { Text } from '@wordpress/ui';
 import { Fragment } from 'react';
 import { BaseLegendItem } from '../../../components/legend/types';
 import {
@@ -14,7 +14,7 @@ import {
 } from '../../../stories';
 import { customerRevenueData, customerRevenueLegendData } from '../../../stories/sample-data';
 import { Group } from '../../../visx/group';
-import { Text } from '../../../visx/text';
+import { Text as SvgText } from '../../../visx/text';
 import { PieChart, PieChartUnresponsive } from '../../pie-chart';
 import type { Meta, StoryObj } from '@storybook/react';
 
@@ -106,12 +106,12 @@ export const Default: Story = {
 		data,
 		children: (
 			<Group>
-				<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 24 } y={ -16 }>
+				<SvgText textAnchor="middle" verticalAnchor="middle" fontSize={ 24 } y={ -16 }>
 					User Activity
-				</Text>
-				<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 18 } y={ 16 }>
+				</SvgText>
+				<SvgText textAnchor="middle" verticalAnchor="middle" fontSize={ 18 } y={ 16 }>
 					Total: 100K Users
-				</Text>
+				</SvgText>
 			</Group>
 		),
 	},
@@ -125,12 +125,12 @@ export const WithSize: Story = {
 		showLabels: false,
 		children: (
 			<Group>
-				<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 18 } y={ -16 }>
+				<SvgText textAnchor="middle" verticalAnchor="middle" fontSize={ 18 } y={ -16 }>
 					User Activity
-				</Text>
-				<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 14 } y={ 16 }>
+				</SvgText>
+				<SvgText textAnchor="middle" verticalAnchor="middle" fontSize={ 14 } y={ 16 }>
 					Total: 100K Users
-				</Text>
+				</SvgText>
 			</Group>
 		),
 	},
@@ -166,12 +166,12 @@ export const Thin: Story = {
 		showLabels: false,
 		children: (
 			<Group>
-				<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 24 } y={ -16 }>
+				<SvgText textAnchor="middle" verticalAnchor="middle" fontSize={ 24 } y={ -16 }>
 					Thin Donut
-				</Text>
-				<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 18 } y={ 16 }>
+				</SvgText>
+				<SvgText textAnchor="middle" verticalAnchor="middle" fontSize={ 18 } y={ 16 }>
 					Thickness: 20%
-				</Text>
+				</SvgText>
 			</Group>
 		),
 	},
@@ -191,12 +191,12 @@ export const WithTooltips: Story = {
 		withTooltips: true,
 		children: (
 			<Group>
-				<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 14 } y={ -10 }>
+				<SvgText textAnchor="middle" verticalAnchor="middle" fontSize={ 14 } y={ -10 }>
 					Hover over segments
-				</Text>
-				<Text textAnchor="middle" verticalAnchor="middle" fontSize={ 14 } y={ 10 }>
+				</SvgText>
+				<SvgText textAnchor="middle" verticalAnchor="middle" fontSize={ 14 } y={ 10 }>
 					to see tooltips
-				</Text>
+				</SvgText>
 			</Group>
 		),
 	},
@@ -277,14 +277,14 @@ const CustomPieLegend = ( {
 								backgroundColor: color,
 							} }
 						/>
-						<WPText variant="body-sm">{ item.label }</WPText>
+						<Text variant="body-sm">{ item.label }</Text>
 					</HStack>
-					<WPText variant="body-sm" style={ { fontWeight: 600, textAlign: 'right' } }>
+					<Text variant="body-sm" style={ { fontWeight: 600, textAlign: 'right' } }>
 						{ item.formattedValue }
-					</WPText>
-					<WPText variant="body-sm" style={ { textAlign: 'right', color: '#008a20' } }>
+					</Text>
+					<Text variant="body-sm" style={ { textAlign: 'right', color: '#008a20' } }>
 						{ withComparison && item.comparison }
-					</WPText>
+					</Text>
 				</Fragment>
 			);
 		} ) }

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/donut.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/donut.stories.tsx
@@ -1,8 +1,6 @@
 /* eslint-disable @wordpress/no-unsafe-wp-apis */
-import {
-	__experimentalText as WPText,
-	__experimentalHStack as HStack,
-} from '@wordpress/components';
+import { __experimentalHStack as HStack } from '@wordpress/components';
+import { Text as WPText } from '@wordpress/ui';
 import { Fragment } from 'react';
 import { BaseLegendItem } from '../../../components/legend/types';
 import {
@@ -279,12 +277,12 @@ const CustomPieLegend = ( {
 								backgroundColor: color,
 							} }
 						/>
-						<WPText size="small">{ item.label }</WPText>
+						<WPText variant="body-sm">{ item.label }</WPText>
 					</HStack>
-					<WPText size="small" weight={ 600 } style={ { textAlign: 'right' } }>
+					<WPText variant="body-sm" style={ { fontWeight: 600, textAlign: 'right' } }>
 						{ item.formattedValue }
 					</WPText>
-					<WPText size="small" style={ { textAlign: 'right', color: '#008a20' } }>
+					<WPText variant="body-sm" style={ { textAlign: 'right', color: '#008a20' } }>
 						{ withComparison && item.comparison }
 					</WPText>
 				</Fragment>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Proposed changes

Migrate the `Text` component usage from the experimental `__experimentalText` export in `@wordpress/components` to the stable `Text` component from `@wordpress/ui`.

* **`leaderboard-chart.tsx` (production):** Import `Text` from `@wordpress/ui` alongside the existing `Stack` import, removing it from the `@wordpress/components` import (which still imports `__experimentalGrid`)
* **`donut.stories.tsx` (stories):** Import `Text` from `@wordpress/ui`, renaming the visx SVG text import to `SvgText` to avoid collision. Props adapted from the `@wordpress/components` API to `@wordpress/ui`:
  * `size="small"` → `variant="body-sm"`
  * `weight={600}` → `style={{ fontWeight: 600 }}`

### Other information
- `@wordpress/ui` v0.9.0 is already a production dependency of `@automattic/charts`
- `@wordpress/components` remains as a devDependency for other experimental components (`__experimentalGrid`, `__experimentalHStack`) — those migrations are tracked separately (e.g., CHARTS-175 for HStack)
- The `eslint-disable @wordpress/no-unsafe-wp-apis` comment is preserved in both files since other experimental imports remain

## Related product discussion/links
* Linear: CHARTS-206

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. Run typecheck: `cd projects/js-packages/charts && pnpm run typecheck` — should pass with no errors
2. Run tests: `cd projects/js-packages/charts && pnpm run test` — all 841 tests should pass
3. Run build: `cd projects/js-packages/charts && pnpm run build` — should build successfully
4. Verify in Storybook that the Leaderboard Chart and Donut Chart stories render correctly (text elements should appear with proper styling)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CHARTS-206](https://linear.app/a8c/issue/CHARTS-206/replace-experimentaltext-with-wordpressui-text)

<div><a href="https://cursor.com/agents/bc-de4b7a71-0fc4-4f69-be8c-c7471262a0d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de4b7a71-0fc4-4f69-be8c-c7471262a0d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

