### PR TITLE
Social: Include platform name in social preview identifiers

### DIFF
--- a/projects/packages/publicize/_inc/components/customize-and-preview/connection-toggle/index.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/connection-toggle/index.tsx
@@ -45,9 +45,10 @@ export function ConnectionToggle( { connection }: ConnectionToggleProps ) {
 		<ToggleControl
 			__nextHasNoMarginBottom
 			label={ sprintf(
-				/* translators: %s: social media account title */
-				__( 'Share to %s', 'jetpack-publicize-pkg' ),
-				connection.display_name
+				/* translators: %1$s: social media account name, %2$s: social media platform name (e.g. Facebook, LinkedIn) */
+				__( 'Share to %1$s on %2$s', 'jetpack-publicize-pkg' ),
+				connection.display_name,
+				connection.service_label
 			) }
 			className={ styles[ 'connection-toggle' ] }
 			checked={ isEnabled }

--- a/projects/packages/publicize/_inc/components/customize-and-preview/tab-panels/use-connection-tabs.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/tab-panels/use-connection-tabs.tsx
@@ -18,7 +18,7 @@ export function useConnectionTabs() {
 			return {
 				connectionId: connection.connection_id,
 				name: connection.connection_id,
-				title: connection.display_name,
+				title: `${ connection.display_name } (${ connection.service_label })`,
 				icon: (
 					<ConnectionIcon
 						serviceName={ connection.service_name }

--- a/projects/packages/publicize/changelog/pr-47895
+++ b/projects/packages/publicize/changelog/pr-47895
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Include platform name in social preview toggle labels and tab titles for clearer identification.


### PR DESCRIPTION
Fixes SOCIAL-428

## Proposed changes

* Update the share toggle label from "Share to \<name\>" to "Share to \<name\> on \<platform\>" (e.g., "Share to Devin Walker on Facebook")
* Append the service label to tab titles so each preview tab is clearly identified (e.g., "Devin Walker (Facebook)")

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* https://linear.app/a8c/issue/SOCIAL-428/social-preview-is-not-clearly-identified

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. Connect multiple social media accounts
2. Create or edit a post and open the Social preview modal
3. Verify that each tab now shows "Display Name (Platform)" instead of just "Display Name"
4. Verify that the toggle label reads "Share to Display Name on Platform" instead of "Share to Display Name"


https://github.com/user-attachments/assets/99df33df-f11e-44e4-a64b-2345ecdc802b

