### PR TITLE
Fix SIG template not saving on back/close navigation

### DIFF
--- a/projects/js-packages/components/changelog/fix-social-429-sig-template-save-on-back
+++ b/projects/js-packages/components/changelog/fix-social-429-sig-template-save-on-back
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added onBack and onClose callback props to NavigatorModal Screen and Header components

--- a/projects/js-packages/components/changelog/fix-social-429-sig-template-save-on-back
+++ b/projects/js-packages/components/changelog/fix-social-429-sig-template-save-on-back
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Added onBack and onClose callback props to NavigatorModal Screen and Header components
+Added onGoBack and onClose callback props to NavigatorModal Screen and Header components

--- a/projects/js-packages/components/components/navigator-modal/header.tsx
+++ b/projects/js-packages/components/components/navigator-modal/header.tsx
@@ -20,7 +20,7 @@ export type HeaderProps = {
 	/**
 	 * Optional callback to run before navigating back.
 	 */
-	onBack?: VoidFunction;
+	onGoBack?: VoidFunction;
 	/**
 	 * Optional callback to run before closing the modal.
 	 */
@@ -37,16 +37,16 @@ export function Header( {
 	icon,
 	title,
 	isScreenLocked,
-	onBack,
+	onGoBack: onGoBackProp,
 	onClose: onCloseProp,
 }: HeaderProps ) {
 	const context = useContext( NavigatorModalContext );
 	const navigator = useNavigator();
 
 	const onGoBack = useCallback( () => {
-		onBack?.();
+		onGoBackProp?.();
 		navigator.goBack();
-	}, [ navigator, onBack ] );
+	}, [ navigator, onGoBackProp ] );
 
 	const onCloseModal = useCallback( () => {
 		onCloseProp?.();

--- a/projects/js-packages/components/components/navigator-modal/header.tsx
+++ b/projects/js-packages/components/components/navigator-modal/header.tsx
@@ -17,6 +17,14 @@ export type HeaderProps = {
 	 * Optional icon to display in the header.
 	 */
 	icon?: React.ReactNode;
+	/**
+	 * Optional callback to run before navigating back.
+	 */
+	onBack?: VoidFunction;
+	/**
+	 * Optional callback to run before closing the modal.
+	 */
+	onClose?: VoidFunction;
 };
 
 /**
@@ -25,13 +33,25 @@ export type HeaderProps = {
  *
  * @return component
  */
-export function Header( { icon, title, isScreenLocked }: HeaderProps ) {
+export function Header( {
+	icon,
+	title,
+	isScreenLocked,
+	onBack,
+	onClose: onCloseProp,
+}: HeaderProps ) {
 	const context = useContext( NavigatorModalContext );
 	const navigator = useNavigator();
 
 	const onGoBack = useCallback( () => {
+		onBack?.();
 		navigator.goBack();
-	}, [ navigator ] );
+	}, [ navigator, onBack ] );
+
+	const onCloseModal = useCallback( () => {
+		onCloseProp?.();
+		context.onClose?.();
+	}, [ onCloseProp, context ] );
 
 	return (
 		<div className="jp-navigator-modal__header">
@@ -51,7 +71,7 @@ export function Header( { icon, title, isScreenLocked }: HeaderProps ) {
 			{ context.isDismissible ? (
 				<Button
 					size="compact"
-					onClick={ context.onClose }
+					onClick={ onCloseModal }
 					icon={ close }
 					label={ __( 'Close', 'jetpack-components' ) }
 					variant="tertiary"

--- a/projects/js-packages/components/components/navigator-modal/screen.tsx
+++ b/projects/js-packages/components/components/navigator-modal/screen.tsx
@@ -1,71 +1,51 @@
 import { Flex, Navigator } from '@wordpress/components';
 import clsx from 'clsx';
 import { Footer, FooterProps } from './footer.tsx';
-import { Header } from './header.tsx';
+import { Header, HeaderProps } from './header.tsx';
 
 export type ScreenProps = Omit<
 	React.ComponentProps< typeof Navigator.Screen >,
 	'content' | 'children'
-> & {
-	/**
-	 * The title of the screen.
-	 */
-	title?: string;
+> &
+	Omit< HeaderProps, 'icon' > & {
+		/**
+		 * Optional icon to display in the header.
+		 */
+		headerIcon?: React.ReactNode;
 
-	/**
-	 * Optional icon to display in the header.
-	 */
-	headerIcon?: React.ReactNode;
+		/**
+		 * The path of the screen.
+		 */
+		path: string;
+		/**
+		 * The sidebar content
+		 */
+		sidebar?: React.ReactNode;
+		/**
+		 * The footer content
+		 */
+		footerContent?: React.ReactNode;
 
-	/**
-	 * The path of the screen.
-	 */
-	path: string;
-	/**
-	 * The sidebar content
-	 */
-	sidebar?: React.ReactNode;
-	/**
-	 * Whether the screen is locked or has a parent screen.
-	 *
-	 * When it's locked, it means there will be no navigation back to a previous screen.
-	 */
-	isScreenLocked?: boolean;
-	/**
-	 * The footer content
-	 */
-	footerContent?: React.ReactNode;
+		/**
+		 * The footer actions
+		 */
+		footerActions?: FooterProps[ 'actions' ];
 
-	/**
-	 * The footer actions
-	 */
-	footerActions?: FooterProps[ 'actions' ];
+		/**
+		 * className to be applied to the modal.
+		 */
+		className?: string;
 
-	/**
-	 * Optional callback to run before navigating back.
-	 */
-	onBack?: VoidFunction;
+		/**
+		 * The content of the screen.
+		 */
+		content?: React.ReactNode;
 
-	/**
-	 * Optional callback to run before closing the modal.
-	 */
-	onClose?: VoidFunction;
-
-	/**
-	 * className to be applied to the modal.
-	 */
-	className?: string;
-
-	/**
-	 * The content of the screen.
-	 */
-	content?: React.ReactNode;
-
-	/**
-	 * The children of the screen. Alternative to `content`.
-	 */
-	children?: React.ReactNode;
-};
+		/**
+		 * The children of the screen. Alternative to `content`.
+		 */
+		children?: React.ReactNode;
+	};
 
 /**
  * Renders a screen.
@@ -81,7 +61,7 @@ export function Screen( {
 	sidebar,
 	headerIcon,
 	isScreenLocked,
-	onBack,
+	onGoBack,
 	onClose,
 	footerContent,
 	footerActions,
@@ -102,7 +82,7 @@ export function Screen( {
 					title={ title }
 					isScreenLocked={ isScreenLocked }
 					icon={ headerIcon }
-					onBack={ onBack }
+					onGoBack={ onGoBack }
 					onClose={ onClose }
 				/>
 

--- a/projects/js-packages/components/components/navigator-modal/screen.tsx
+++ b/projects/js-packages/components/components/navigator-modal/screen.tsx
@@ -42,6 +42,16 @@ export type ScreenProps = Omit<
 	footerActions?: FooterProps[ 'actions' ];
 
 	/**
+	 * Optional callback to run before navigating back.
+	 */
+	onBack?: VoidFunction;
+
+	/**
+	 * Optional callback to run before closing the modal.
+	 */
+	onClose?: VoidFunction;
+
+	/**
 	 * className to be applied to the modal.
 	 */
 	className?: string;
@@ -71,6 +81,8 @@ export function Screen( {
 	sidebar,
 	headerIcon,
 	isScreenLocked,
+	onBack,
+	onClose,
 	footerContent,
 	footerActions,
 	children,
@@ -86,7 +98,13 @@ export function Screen( {
 			{ ...props }
 		>
 			<Flex direction="column" gap={ 0 }>
-				<Header title={ title } isScreenLocked={ isScreenLocked } icon={ headerIcon } />
+				<Header
+					title={ title }
+					isScreenLocked={ isScreenLocked }
+					icon={ headerIcon }
+					onBack={ onBack }
+					onClose={ onClose }
+				/>
 
 				<Flex gap={ 0 } align="start" className="jp-navigator-modal__body">
 					{ sidebar ? <div className="jp-navigator-modal__sidebar">{ sidebar }</div> : null }

--- a/projects/js-packages/components/components/navigator-modal/test/component.tsx
+++ b/projects/js-packages/components/components/navigator-modal/test/component.tsx
@@ -4,6 +4,8 @@ import { jest } from '@jest/globals';
 import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 
+const mockGoBack = jest.fn();
+
 // ESM-compatible mock - must be before dynamic import
 jest.unstable_mockModule( '@wordpress/components', () => ( {
 	Modal: ( {
@@ -23,20 +25,39 @@ jest.unstable_mockModule( '@wordpress/components', () => ( {
 			{ children }
 		</div>
 	),
-	Navigator: ( { children }: { children: React.ReactNode } ) => (
-		<div data-testid="mock-navigator">{ children }</div>
+	Navigator: Object.assign(
+		( { children }: { children: React.ReactNode } ) => (
+			<div data-testid="mock-navigator">{ children }</div>
+		),
+		{
+			Screen: ( { children }: { children: React.ReactNode } ) => (
+				<div data-testid="mock-navigator-screen">{ children }</div>
+			),
+		}
 	),
-	Button: ( { children, onClick }: { children: React.ReactNode; onClick?: () => void } ) => (
-		<button onClick={ onClick }>{ children }</button>
+	Button: ( {
+		children,
+		onClick,
+		label,
+	}: {
+		children: React.ReactNode;
+		onClick?: () => void;
+		label?: string;
+	} ) => (
+		<button onClick={ onClick } aria-label={ label }>
+			{ children }
+		</button>
 	),
 	Flex: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
 	FlexBlock: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
 	FlexItem: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
-	useNavigator: () => ( { goBack: jest.fn(), goTo: jest.fn(), location: { path: '/' } } ),
+	useNavigator: () => ( { goBack: mockGoBack, goTo: jest.fn(), location: { path: '/' } } ),
 } ) );
 
 // Dynamic import after mock setup
 const { NavigatorModal } = await import( '../index.tsx' );
+const { Screen } = await import( '../screen.tsx' );
+const { NavigatorModalContext } = await import( '../context.ts' );
 
 describe( 'NavigatorModal', () => {
 	it( 'renders children within the modal', () => {
@@ -95,5 +116,56 @@ describe( 'NavigatorModal', () => {
 
 			expect( screen.getByTestId( 'mock-modal' ) ).toBeInTheDocument();
 		} );
+	} );
+} );
+
+describe( 'Screen', () => {
+	beforeEach( () => {
+		mockGoBack.mockClear();
+	} );
+
+	it( 'calls onBack before navigating back when back button is clicked', async () => {
+		const user = userEvent.setup();
+		const onBack = jest.fn();
+
+		render( <Screen path="/test" title="Test" onBack={ onBack } /> );
+
+		await user.click( screen.getByLabelText( 'Go back' ) );
+
+		expect( onBack ).toHaveBeenCalledTimes( 1 );
+		expect( mockGoBack ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'navigates back without calling onBack when onBack is not provided', async () => {
+		const user = userEvent.setup();
+
+		render( <Screen path="/test" title="Test" /> );
+
+		await user.click( screen.getByLabelText( 'Go back' ) );
+
+		expect( mockGoBack ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'does not show back button when screen is locked', () => {
+		render( <Screen path="/test" title="Test" isScreenLocked onBack={ jest.fn() } /> );
+
+		expect( screen.queryByLabelText( 'Go back' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'calls onClose before closing the modal when close button is clicked', async () => {
+		const user = userEvent.setup();
+		const onClose = jest.fn();
+		const contextOnClose = jest.fn();
+
+		render(
+			<NavigatorModalContext.Provider value={ { isDismissible: true, onClose: contextOnClose } }>
+				<Screen path="/test" title="Test" onClose={ onClose } />
+			</NavigatorModalContext.Provider>
+		);
+
+		await user.click( screen.getByLabelText( 'Close' ) );
+
+		expect( onClose ).toHaveBeenCalledTimes( 1 );
+		expect( contextOnClose ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/projects/js-packages/components/components/navigator-modal/test/component.tsx
+++ b/projects/js-packages/components/components/navigator-modal/test/component.tsx
@@ -124,19 +124,19 @@ describe( 'Screen', () => {
 		mockGoBack.mockClear();
 	} );
 
-	it( 'calls onBack before navigating back when back button is clicked', async () => {
+	it( 'calls onGoBack before navigating back when back button is clicked', async () => {
 		const user = userEvent.setup();
-		const onBack = jest.fn();
+		const onGoBack = jest.fn();
 
-		render( <Screen path="/test" title="Test" onBack={ onBack } /> );
+		render( <Screen path="/test" title="Test" onGoBack={ onGoBack } /> );
 
 		await user.click( screen.getByLabelText( 'Go back' ) );
 
-		expect( onBack ).toHaveBeenCalledTimes( 1 );
+		expect( onGoBack ).toHaveBeenCalledTimes( 1 );
 		expect( mockGoBack ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'navigates back without calling onBack when onBack is not provided', async () => {
+	it( 'navigates back without calling onGoBack when onGoBack is not provided', async () => {
 		const user = userEvent.setup();
 
 		render( <Screen path="/test" title="Test" /> );
@@ -147,7 +147,7 @@ describe( 'Screen', () => {
 	} );
 
 	it( 'does not show back button when screen is locked', () => {
-		render( <Screen path="/test" title="Test" isScreenLocked onBack={ jest.fn() } /> );
+		render( <Screen path="/test" title="Test" isScreenLocked onGoBack={ jest.fn() } /> );
 
 		expect( screen.queryByLabelText( 'Go back' ) ).not.toBeInTheDocument();
 	} );

--- a/projects/packages/publicize/_inc/components/unified-modal/edit-template/use-modal-screen.tsx
+++ b/projects/packages/publicize/_inc/components/unified-modal/edit-template/use-modal-screen.tsx
@@ -47,6 +47,8 @@ export function useModalScreen() {
 			path: '/edit-template',
 			title: __( 'Edit social image template', 'jetpack-publicize-pkg' ),
 			isScreenLocked,
+			onBack: handleSave,
+			onClose: handleSave,
 			sidebar: (
 				<Sidebar
 					localState={ localState }

--- a/projects/packages/publicize/_inc/components/unified-modal/edit-template/use-modal-screen.tsx
+++ b/projects/packages/publicize/_inc/components/unified-modal/edit-template/use-modal-screen.tsx
@@ -47,7 +47,7 @@ export function useModalScreen() {
 			path: '/edit-template',
 			title: __( 'Edit social image template', 'jetpack-publicize-pkg' ),
 			isScreenLocked,
-			onBack: handleSave,
+			onGoBack: handleSave,
 			onClose: handleSave,
 			sidebar: (
 				<Sidebar

--- a/projects/packages/publicize/changelog/fix-social-429-sig-template-save-on-back
+++ b/projects/packages/publicize/changelog/fix-social-429-sig-template-save-on-back
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed SIG template changes not saving when using the back arrow or close button

--- a/projects/packages/publicize/changelog/fix-social-429-sig-template-save-on-back
+++ b/projects/packages/publicize/changelog/fix-social-429-sig-template-save-on-back
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fixed SIG template changes not saving when using the back arrow or close button
+Fix edit template changes not saving when using the back arrow or close button.


### PR DESCRIPTION
Fixes SOCIAL-429

## Proposed changes

* Add `onBack` and `onClose` callback props to `NavigatorModal.Screen` and `Header` components, allowing screens to run logic (e.g. save) before back navigation or modal close.
* Wire `handleSave` to both `onBack` and `onClose` in the SIG edit-template screen so changes persist regardless of how the user exits the screen.

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* https://linear.app/a8c/issue/SOCIAL-429

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. Open a post in the block editor with Jetpack Social enabled and having the Social Plan.
2. Open the Social post preview modal, then navigate to "Edit social image template"
3. Make changes to the template (e.g. change the font or custom text)
4. Click the **back arrow** — verify the changes are saved (not reverted)
5. Open the template editor again from the sidebar (locked mode) — make changes and click the **X close button** — verify changes are saved
6. Verify clicking "Done"/"Close" still saves as before (no regression)


https://github.com/user-attachments/assets/facdef26-e974-4b9e-8a35-90590db12beb

