### PR TITLE
Renovate: separate bundled WP dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -93,17 +93,30 @@
 			matchPackageNames: [ 'docker/**' ],
 		},
 
-		// Separate this from 'monorepo:wordpress' while it's still considered unstable.
+		// Bundled, WordPress dependencies are separated from 'monorepo:wordpress' while
+		// they're still considered unstable and can have significant breaking changes.
+		// Since they're not externalized to WP, they have higher chance of impacting functionality.
 		{
-			groupName: '@wordpress/dataviews',
-			matchPackageNames: [ '@wordpress/dataviews' ],
+			groupName: 'Bundled @wordpress/* monorepo',
+			// See the list at https://github.com/WordPress/gutenberg/blob/580d8bd24b9d1647a66fecc3115edf9b7dce64b1/packages/dependency-extraction-webpack-plugin/lib/util.js#L2
+			matchPackageNames: [
+				'@wordpress/admin-ui',
+				'@wordpress/dataviews',
+				'@wordpress/dataviews/wp',
+				'@wordpress/icons',
+				'@wordpress/interface',
+				'@wordpress/undo-manager',
+				'@wordpress/fields',
+				'@wordpress/views',
+				'@wordpress/ui',
+			],
 			separateMajorMinor: false,
-			// Teams using DataViews in their projects
+			// Teams that can help vet the update
 			additionalReviewers: [
-				'team:triforce', // Publicize, My Jetpack
-				'team:loop', // Newsletter subscriber management
+				'team:triforce', // Monorepo overall, Publicize, My Jetpack
+				'team:loop', // Newsletter dashboard & subscriber management
 				'team:bastion', // Scan
-				'team:zap', // Forms
+				'team:zap', // Forms, much of the recent componentry work.
 			],
 		},
 

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -102,7 +102,6 @@
 			matchPackageNames: [
 				'@wordpress/admin-ui',
 				'@wordpress/dataviews',
-				'@wordpress/dataviews/wp',
 				'@wordpress/icons',
 				'@wordpress/interface',
 				'@wordpress/undo-manager',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -111,7 +111,7 @@
 				'@wordpress/ui',
 			],
 			separateMajorMinor: false,
-			// Teams that can help vet the update
+			// Teams that can help test the update
 			additionalReviewers: [
 				'team:triforce', // Monorepo overall, Publicize, My Jetpack
 				'team:loop', // Newsletter dashboard & subscriber management


### PR DESCRIPTION

## Proposed changes
<!--- Explain what functional changes your PR includes -->
Earlier, we split `@wordpress/dataviews` into a separately tested/reviewed, since it was bundled and not externalised to WP.

This includes the rest of the bundled packages, too. Full list taken [from the dep extraction plugin](https://github.com/WordPress/gutenberg/blob/580d8bd24b9d1647a66fecc3115edf9b7dce64b1/packages/dependency-extraction-webpack-plugin/lib/util.js#L2-L12).

Particularly important are:
- `@wordpress/ui` - components such as Badges, Buttons, etc.
- `@wordpress/admin-ui` - components for admin pages, including headers across Jetpack

Since bundled packages are likely to have significant breaking changes, it's important to test them separately from other WP dependency updates, which we don't have as much control over when they're externalised to WordPress & Gutenberg.

For earlier convo on who reviews DataViews changes, see https://github.com/Automattic/jetpack/pull/42851

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
-

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
-

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* N/A