### PR TITLE
Forms: allow lazy-load gravatars

### DIFF
--- a/projects/packages/forms/changelog/update-forms-gravatar-lazy
+++ b/projects/packages/forms/changelog/update-forms-gravatar-lazy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Forms: allow browsers to lazy-load avatars in responses.

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -152,13 +152,6 @@ class Dashboard {
 		add_action( 'admin_menu', array( $this, 'add_admin_submenu' ), self::MENU_PRIORITY );
 		add_action( 'admin_menu', array( __CLASS__, 'redirect_dashboard_url_cross_variant' ), 1 );
 
-		Assets::add_resource_hint(
-			array(
-				'//secure.gravatar.com',
-			),
-			'dns-prefetch'
-		);
-
 		// Flag to enable the wp-build-based dashboard.
 		$is_wp_build_enabled = apply_filters( 'jetpack_forms_alpha', false );
 

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -152,6 +152,13 @@ class Dashboard {
 		add_action( 'admin_menu', array( $this, 'add_admin_submenu' ), self::MENU_PRIORITY );
 		add_action( 'admin_menu', array( __CLASS__, 'redirect_dashboard_url_cross_variant' ), 1 );
 
+		Assets::add_resource_hint(
+			array(
+				'//secure.gravatar.com',
+			),
+			'dns-prefetch'
+		);
+
 		// Flag to enable the wp-build-based dashboard.
 		$is_wp_build_enabled = apply_filters( 'jetpack_forms_alpha', false );
 

--- a/projects/packages/forms/src/dashboard/components/gravatar/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/gravatar/index.tsx
@@ -86,7 +86,7 @@ export default function Gravatar( {
 			alt={ displayName || '' }
 			className="jp-forms__gravatar"
 			ref={ profileImageRef }
-			src={ `https://0.gravatar.com/avatar/${ hashedEmail }?d=${ defaultImage }${
+			src={ `https://secure.gravatar.com/avatar/${ hashedEmail }?d=${ defaultImage }${
 				displayName ? `&name=${ encodeURIComponent( displayName ) }` : ''
 			}` }
 			width={ size }

--- a/projects/packages/forms/src/dashboard/components/gravatar/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/gravatar/index.tsx
@@ -91,6 +91,7 @@ export default function Gravatar( {
 			}` }
 			width={ size }
 			height={ size }
+			loading="lazy"
 		/>
 	);
 }


### PR DESCRIPTION

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Allow lazy-load Gravatar images in the responses views. Basically lets browser delay loading images until they're in/closer to the viewport, helping with performance particularly on mobile/small screens.

> The [loading](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#loading) attribute [...] can be used to instruct the browser to defer loading of linked resources when elements are off-screen until the user scrolls near them. This allows non-critical resources to load only if needed, potentially speeding up initial page loads and reducing network usage.

— [via](https://developer.mozilla.org/en-US/docs/Web/Performance/Guides/Lazy_loading)

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Forms dashboard respones gravatars still load just fine
