### PR TITLE
RTC: Defer backoff reset until connection is stable

### DIFF
--- a/projects/packages/rtc/changelog/dotcom-16597-defer-backoff-reset-until-connection-is-stable
+++ b/projects/packages/rtc/changelog/dotcom-16597-defer-backoff-reset-until-connection-is-stable
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Defer reconnect backoff reset until WebSocket connection has been stable for 30 seconds

--- a/projects/packages/rtc/src/class-rtc.php
+++ b/projects/packages/rtc/src/class-rtc.php
@@ -10,6 +10,7 @@
 
 namespace Automattic\Jetpack;
 
+use Automattic\Jetpack\RTC\REST_Connection_Log;
 use Automattic\Jetpack\RTC\REST_Pinghub_Token;
 
 /**
@@ -130,6 +131,10 @@ class RTC {
 	 */
 	public static function register_rest_routes() {
 		( new REST_Pinghub_Token() )->register_routes();
+
+		if ( function_exists( 'log2logstash' ) ) {
+			( new REST_Connection_Log() )->register_routes();
+		}
 	}
 
 	/**
@@ -166,7 +171,8 @@ class RTC {
 
 		$data = wp_json_encode(
 			array(
-				'providers' => $providers,
+				'providers'         => $providers,
+				'connectionLogging' => function_exists( 'log2logstash' ),
 			),
 			JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 		);

--- a/projects/packages/rtc/src/js/providers/pinghub/pinghub-bridge.ts
+++ b/projects/packages/rtc/src/js/providers/pinghub/pinghub-bridge.ts
@@ -178,6 +178,33 @@ export function pixel( key: string, value: string | number, unit: string ): void
 		'"]}';
 }
 
+/**
+ * Log a PingHub connection lifecycle event to the server for Logstash.
+ * Fire-and-forget: errors are silently swallowed.
+ *
+ * @param event      - Event name: 'connected', 'disconnected', or 'jwt_fetch_error'.
+ * @param properties - Event properties (close_code, connection_lifetime_ms, etc.).
+ */
+export function logConnectionEvent(
+	event: string,
+	properties: Record< string, unknown > = {}
+): void {
+	if ( ! window.jetpackRTC?.connectionLogging ) {
+		return;
+	}
+	apiFetch( {
+		path: '/wpcom/v2/rtc/connection-log',
+		method: 'POST',
+		data: {
+			event,
+			properties: {
+				browser: detectBrowser(),
+				...properties,
+			},
+		},
+	} ).catch( () => {} );
+}
+
 export class PingHubBridge {
 	private openHandlers = new Map< string, Set< () => void > >();
 	private closeHandlers = new Map< string, Set< ( code: number, reason: string ) => void > >();
@@ -370,7 +397,12 @@ export class PingHubBridge {
 			this.jwtFetchFailures++;
 			this.jwtBackoffUntil = Date.now() + this.jwtBackoffDelay;
 			this.jwtBackoffDelay = Math.min( this.jwtBackoffDelay * 2, JWT_BACKOFF_MAX_MS );
-			pixel( 'pinghub.rtc.jwt_fetch_error', Date.now() - start, 'ms' );
+			const elapsed = Date.now() - start;
+			pixel( 'pinghub.rtc.jwt_fetch_error', elapsed, 'ms' );
+			logConnectionEvent( 'jwt_fetch_error', {
+				duration_ms: elapsed,
+				failure_count: this.jwtFetchFailures,
+			} );
 			return null;
 		}
 	}
@@ -421,16 +453,28 @@ export class PingHubBridge {
 		const start = Date.now();
 
 		ws.addEventListener( 'open', () => {
-			pixel( 'pinghub.conn_open', Date.now() - start, 'ms' );
-			pixel( 'pinghub.rtc.conn_open', Date.now() - start, 'ms' );
+			const elapsed = Date.now() - start;
+			pixel( 'pinghub.conn_open', elapsed, 'ms' );
+			pixel( 'pinghub.rtc.conn_open', elapsed, 'ms' );
+			logConnectionEvent( 'connected', {
+				room,
+				time_to_connect_ms: elapsed,
+			} );
 			this.connectingWaiters.delete( room );
 			waiters.splice( 0 ).forEach( ( { resolve } ) => resolve() );
 			this.openHandlers.get( room )?.forEach( h => h() );
 		} );
 
 		ws.addEventListener( 'close', event => {
-			pixel( 'pinghub.conn_close_code.' + event.code, Date.now() - start, 'ms' );
-			pixel( 'pinghub.rtc.conn_close_code.' + event.code, Date.now() - start, 'ms' );
+			const elapsed = Date.now() - start;
+			pixel( 'pinghub.conn_close_code.' + event.code, elapsed, 'ms' );
+			pixel( 'pinghub.rtc.conn_close_code.' + event.code, elapsed, 'ms' );
+			logConnectionEvent( 'disconnected', {
+				room,
+				close_code: event.code,
+				close_reason: event.reason,
+				connection_lifetime_ms: elapsed,
+			} );
 			this.sockets.delete( room );
 			if ( this.connectingWaiters.has( room ) ) {
 				this.connectingWaiters.delete( room );

--- a/projects/packages/rtc/src/js/providers/pinghub/pinghub-manager.ts
+++ b/projects/packages/rtc/src/js/providers/pinghub/pinghub-manager.ts
@@ -11,6 +11,7 @@ const MSG_AWARENESS = 0x01;
 const RECONNECT_BASE_DELAY_MS = 1000;
 const RECONNECT_MAX_DELAY_MS = 30 * 1000;
 const MAX_RECONNECT_ATTEMPTS = 5;
+const STABLE_CONNECTION_MS = 30 * 1000;
 const PINGHUB_MANAGER_ORIGIN = 'pinghub-manager';
 
 interface RegisterRoomOptions {
@@ -46,6 +47,7 @@ class PingHubConnection {
 	public reconnectTimer: ReturnType< typeof setTimeout > | null = null;
 	public reconnectDelay = RECONNECT_BASE_DELAY_MS;
 	public reconnectAttempts = 0;
+	private stableConnectionTimer: ReturnType< typeof setTimeout > | null = null;
 
 	public constructor( options: RegisterRoomOptions ) {
 		this.room = options.room;
@@ -70,6 +72,11 @@ class PingHubConnection {
 	public destroy(): void {
 		if ( this.connected ) {
 			this.removeAwareness( 'provider-destroy' );
+		}
+
+		if ( this.stableConnectionTimer !== null ) {
+			clearTimeout( this.stableConnectionTimer );
+			this.stableConnectionTimer = null;
 		}
 
 		if ( this.reconnectTimer !== null ) {
@@ -199,10 +206,21 @@ class PingHubConnection {
 		}
 		this.connected = true;
 		this.syncStep1RepliedTo.clear();
-		this.reconnectDelay = RECONNECT_BASE_DELAY_MS;
-		this.reconnectAttempts = 0;
-		bridge?.resetJwtState();
 		this.onStatusChange( { status: 'connected' } );
+
+		// Reset backoff state only after the connection has been stable for
+		// a while. If the connection closes immediately (e.g. server rejects
+		// after auth), the counters are preserved so MAX_RECONNECT_ATTEMPTS
+		// is respected and we don't loop forever.
+		if ( this.stableConnectionTimer !== null ) {
+			clearTimeout( this.stableConnectionTimer );
+		}
+		this.stableConnectionTimer = setTimeout( () => {
+			this.stableConnectionTimer = null;
+			this.reconnectDelay = RECONNECT_BASE_DELAY_MS;
+			this.reconnectAttempts = 0;
+			bridge?.resetJwtState();
+		}, STABLE_CONNECTION_MS );
 
 		this.sendSyncStep1();
 
@@ -222,6 +240,10 @@ class PingHubConnection {
 	 */
 	private handleWsClose = (): void => {
 		this.connected = false;
+		if ( this.stableConnectionTimer !== null ) {
+			clearTimeout( this.stableConnectionTimer );
+			this.stableConnectionTimer = null;
+		}
 		if ( ! rooms.has( this.room ) ) {
 			return;
 		}

--- a/projects/packages/rtc/src/rest-api/class-rest-connection-log.php
+++ b/projects/packages/rtc/src/rest-api/class-rest-connection-log.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * REST API endpoint for logging PingHub connection events to Logstash.
+ *
+ * Only registered on Simple sites where log2logstash() is available.
+ *
+ * @package automattic/jetpack-rtc
+ */
+
+namespace Automattic\Jetpack\RTC;
+
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * REST controller that receives PingHub connection lifecycle events from
+ * the browser and forwards them to Logstash for debugging.
+ */
+class REST_Connection_Log extends WP_REST_Controller {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'wpcom/v2';
+		$this->rest_base = 'rtc/connection-log';
+	}
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_item' ),
+					'permission_callback' => array( $this, 'create_item_permissions_check' ),
+					'args'                => array(
+						'event'      => array(
+							'required' => true,
+							'type'     => 'string',
+							'enum'     => array( 'connected', 'disconnected', 'jwt_fetch_error' ),
+						),
+						'properties' => array(
+							'required' => false,
+							'type'     => 'object',
+							'default'  => array(),
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Permission check: current user must be a member of the blog.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error
+	 */
+	public function create_item_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( ! is_user_member_of_blog() ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'You are not allowed to access this endpoint.', 'jetpack-rtc' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Log a PingHub connection event to Logstash.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response
+	 */
+	public function create_item( $request ) {
+		$event      = $request['event'];
+		$properties = $request['properties'];
+
+		// Sanitize properties to scalar values only.
+		$sanitized = array();
+		if ( is_array( $properties ) ) {
+			foreach ( $properties as $key => $value ) {
+				if ( is_scalar( $value ) ) {
+					$sanitized[ sanitize_key( $key ) ] = $value;
+				}
+			}
+		}
+
+		log2logstash(
+			array(
+				'feature' => 'rtc',
+				'message' => 'pinghub_' . $event,
+				'blog_id' => get_current_blog_id(),
+				'user_id' => get_current_user_id(),
+				'extra'   => wp_json_encode( $sanitized, JSON_UNESCAPED_SLASHES ),
+			)
+		);
+
+		return rest_ensure_response( array( 'success' => true ) );
+	}
+}


### PR DESCRIPTION
Fixes DOTCOM-16597

## Proposed changes

### 1. Defer backoff reset until connection is stable

Previously, `handleWsOpen` immediately reset `reconnectAttempts`, `reconnectDelay`, and JWT backoff state whenever the WebSocket opened. This meant that a connect→open→close loop would restart the reconnect cycle from scratch every time, completely bypassing `MAX_RECONNECT_ATTEMPTS` (added in #47864) and causing unbounded request loops to the `pinghub-token` endpoint (~1 request/minute/session due to 60s JWT cache TTL).

* Defer the backoff reset to a 30-second stable-connection timer. If the connection stays open for 30s, the counters reset (so future disconnects get a fresh retry budget). If the connection closes before 30s, the timer is cancelled and the counters are preserved — `MAX_RECONNECT_ATTEMPTS` is enforced as intended.
* Clean up the timer in `handleWsClose` and `destroy()`.

### 2. Add connection lifecycle logging to Logstash (Simple sites only)

The existing pixel events (`boom.gif` beacons) don't support filtering by site, making it impossible to debug connection issues for specific blogs. Add a lightweight REST endpoint (`POST /wpcom/v2/rtc/connection-log`) that receives connection events from the JS client and logs them to Logstash via `log2logstash()`. Only registered on Simple sites where `log2logstash()` is available.

Events logged:
* `pinghub_connected` — WS opened (`room`, `time_to_connect_ms`)
* `pinghub_disconnected` — WS closed (`room`, `close_code`, `close_reason`, `connection_lifetime_ms`)
* `pinghub_jwt_fetch_error` — JWT fetch failed (`duration_ms`, `failure_count`)

All events include `blog_id`, `user_id`, and `browser` for per-site investigation.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
N/A

## Does this pull request change what data or activity we track or use?
Yes — adds connection lifecycle events to Logstash (feature: `rtc`) on Simple sites only. Properties include `blog_id`, `user_id`, `browser`, connection timing, and WebSocket close codes. No PII is collected beyond existing user/blog IDs.

## Testing instructions

### Backoff reset fix
1. Open a post in the block editor on a site with RTC enabled via WebSocket (pinghub provider)
2. Verify that the WebSocket connection establishes and real-time collaboration works normally
3. Simulate an unstable connection (e.g. throttle network, or temporarily block the WebSocket URL in devtools) — after 5 reconnect attempts with connections that close within 30s, the client should stop retrying
4. Verify that a genuinely stable connection (open for 30s+) properly resets the retry budget, so a later disconnect gets a fresh set of retries

### Connection logging
1. On a Simple site with RTC enabled, open a post in the block editor
2. Verify `window.jetpackRTC.connectionLogging` is `true` in the browser console
3. Open devtools Network tab and filter by `connection-log` — you should see a POST request on connection open
4. Close the WebSocket (e.g. kill network in devtools) and verify another POST fires with `close_code`
5. On an Atomic site, verify `window.jetpackRTC.connectionLogging` is `false` and no `connection-log` requests are made

🤖 Generated with [Claude Code](https://claude.com/claude-code)