### PR TITLE
Connector: improve connection and disconnection flows

### DIFF
--- a/projects/packages/connection/changelog/fix-connector-connection-flow-and-modal-display
+++ b/projects/packages/connection/changelog/fix-connector-connection-flow-and-modal-display
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix connection flow in connector card when using Gutenberg, and ensuring modals always show on disconnection.
+Fix connection flow in connector card when using Gutenberg and ensure modals always show on disconnection.

--- a/projects/packages/connection/changelog/fix-connector-connection-flow-and-modal-display
+++ b/projects/packages/connection/changelog/fix-connector-connection-flow-and-modal-display
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix connection flow in connector card when using Gutenberg, and ensuring modals always show on disconnection.

--- a/projects/packages/connection/src/connectors/class-wpcom-connector.php
+++ b/projects/packages/connection/src/connectors/class-wpcom-connector.php
@@ -43,6 +43,13 @@ class Wpcom_Connector {
 	const GUTENBERG_CONNECTORS_SCREEN_ID = 'settings_page_options-connectors-wp-admin';
 
 	/**
+	 * Page slug registered by the Gutenberg plugin for the connectors submenu page.
+	 *
+	 * @var string
+	 */
+	const GUTENBERG_CONNECTORS_PAGE_SLUG = 'options-connectors-wp-admin';
+
+	/**
 	 * Initialize the connector.
 	 */
 	public static function init() {
@@ -317,7 +324,7 @@ class Wpcom_Connector {
 		// Gutenberg plugin registers the page under options-general.php.
 		$screen = get_current_screen();
 		if ( $screen && static::GUTENBERG_CONNECTORS_SCREEN_ID === $screen->id ) {
-			return 'options-general.php?page=options-connectors-wp-admin';
+			return 'options-general.php?page=' . static::GUTENBERG_CONNECTORS_PAGE_SLUG;
 		}
 
 		return 'options-connectors.php';

--- a/projects/packages/connection/src/connectors/class-wpcom-connector.php
+++ b/projects/packages/connection/src/connectors/class-wpcom-connector.php
@@ -36,6 +36,13 @@ class Wpcom_Connector {
 	const MODULE_ID = '@automattic/jetpack-connection-connectors';
 
 	/**
+	 * Screen ID assigned by WordPress to the Gutenberg plugin's connectors submenu page.
+	 *
+	 * @var string
+	 */
+	const GUTENBERG_CONNECTORS_SCREEN_ID = 'settings_page_options-connectors-wp-admin';
+
+	/**
 	 * Initialize the connector.
 	 */
 	public static function init() {
@@ -277,7 +284,7 @@ class Wpcom_Connector {
 	 */
 	private static function is_connectors_screen( $screen ) {
 		return 'options-connectors' === $screen->id
-			|| 'settings_page_options-connectors-wp-admin' === $screen->id;
+			|| static::GUTENBERG_CONNECTORS_SCREEN_ID === $screen->id;
 	}
 
 	/**
@@ -288,6 +295,11 @@ class Wpcom_Connector {
 	 * with slug `options-connectors-wp-admin`. Both set parent_file to
 	 * `options-general.php` for menu highlighting, so we distinguish them by
 	 * checking the actual script filename being served.
+	 *
+	 * Note: for the Gutenberg case we use the registered page slug directly,
+	 * not `$screen->id`. WordPress auto-prefixes screen IDs for submenu pages
+	 * (e.g. `settings_page_options-connectors-wp-admin`), so using `$screen->id`
+	 * as the `page=` parameter produces an invalid URL.
 	 *
 	 * The result is suitable for the `redirect_uri` parameter accepted by the
 	 * `jetpack/v4/connection/register` REST endpoint (which wraps it in `admin_url()`).
@@ -304,8 +316,8 @@ class Wpcom_Connector {
 
 		// Gutenberg plugin registers the page under options-general.php.
 		$screen = get_current_screen();
-		if ( $screen ) {
-			return 'options-general.php?page=' . rawurlencode( $screen->id );
+		if ( $screen && static::GUTENBERG_CONNECTORS_SCREEN_ID === $screen->id ) {
+			return 'options-general.php?page=options-connectors-wp-admin';
 		}
 
 		return 'options-connectors.php';

--- a/projects/packages/connection/src/connectors/js/connectors-card.js
+++ b/projects/packages/connection/src/connectors/js/connectors-card.js
@@ -519,18 +519,22 @@ function ExpandedDetails( { isConnecting = false, onConnect = null } ) {
 	};
 
 	const handleUnlinkUser = () => {
-		if ( currentUser?.isOwner && currentUser?.hasOtherConnectedUsers ) {
-			setPendingConfirm( {
-				title: __( 'Disconnect user account', 'jetpack-connection' ),
-				message: __(
-					'Disconnecting the owner account will remove the WordPress.com account connection for all users on this site. The site will remain connected to WordPress.com.',
-					'jetpack-connection'
-				),
-				onConfirm: executeUnlinkUser,
-			} );
-		} else {
-			executeUnlinkUser();
-		}
+		const message =
+			currentUser?.isOwner && currentUser?.hasOtherConnectedUsers
+				? __(
+						'Disconnecting the owner account will remove the WordPress.com account connection for all users on this site. The site will remain connected to WordPress.com.',
+						'jetpack-connection'
+				  )
+				: __(
+						'Are you sure you want to disconnect your WordPress.com account? The site will remain connected to WordPress.com.',
+						'jetpack-connection'
+				  );
+
+		setPendingConfirm( {
+			title: __( 'Disconnect user account', 'jetpack-connection' ),
+			message,
+			onConfirm: executeUnlinkUser,
+		} );
 	};
 
 	return createElement(

--- a/projects/packages/connection/tests/php/Wpcom_Connector_Test.php
+++ b/projects/packages/connection/tests/php/Wpcom_Connector_Test.php
@@ -506,6 +506,31 @@ class Wpcom_Connector_Test extends TestCase {
 		unset( $_SERVER['SCRIPT_NAME'] );
 	}
 
+	/**
+	 * Test that the Gutenberg plugin screen returns the correct page slug, not the screen ID.
+	 *
+	 * WordPress auto-prefixes submenu screen IDs (e.g. settings_page_<slug>), so using
+	 * $screen->id directly as the page= parameter would produce an invalid URL.
+	 */
+	public function test_connectors_page_path_gutenberg() {
+		$_SERVER['SCRIPT_NAME'] = '/wp-admin/options-general.php';
+
+		$screen                    = new \stdClass();
+		$screen->id                = 'settings_page_options-connectors-wp-admin';
+		$GLOBALS['current_screen'] = $screen;
+
+		$method = new \ReflectionMethod( Wpcom_Connector::class, 'get_connectors_page_path' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$result = $method->invoke( null );
+
+		unset( $GLOBALS['current_screen'], $_SERVER['SCRIPT_NAME'] );
+
+		$this->assertSame( 'options-general.php?page=options-connectors-wp-admin', $result );
+	}
+
 	/* ── store_auth_error() / consume_auth_error() ───────────── */
 
 	/**

--- a/projects/packages/connection/tests/php/Wpcom_Connector_Test.php
+++ b/projects/packages/connection/tests/php/Wpcom_Connector_Test.php
@@ -516,7 +516,7 @@ class Wpcom_Connector_Test extends TestCase {
 		$_SERVER['SCRIPT_NAME'] = '/wp-admin/options-general.php';
 
 		$screen                    = new \stdClass();
-		$screen->id                = 'settings_page_options-connectors-wp-admin';
+		$screen->id                = Wpcom_Connector::GUTENBERG_CONNECTORS_SCREEN_ID;
 		$GLOBALS['current_screen'] = $screen;
 
 		$method = new \ReflectionMethod( Wpcom_Connector::class, 'get_connectors_page_path' );
@@ -528,7 +528,7 @@ class Wpcom_Connector_Test extends TestCase {
 
 		unset( $GLOBALS['current_screen'], $_SERVER['SCRIPT_NAME'] );
 
-		$this->assertSame( 'options-general.php?page=options-connectors-wp-admin', $result );
+		$this->assertSame( 'options-general.php?page=' . Wpcom_Connector::GUTENBERG_CONNECTORS_PAGE_SLUG, $result );
 	}
 
 	/* ── store_auth_error() / consume_auth_error() ───────────── */


### PR DESCRIPTION
Fixes CONNECT-218

## Proposed changes

* This PR ensures that clicking 'Disconnect account' from the WordPress.com connectors card in any scenario will open a modal confirming disconnection, before disconnecting. Prior to this, the modal only displayed if you were both connected via the owner account, and there are other connected users. 
  * A similar modal now displays in all other cases, with more generic wording.
* This PR also fixes an issue with the page redirection after connection, if you attempt connection via the new connectors card, and have both core at 7.0 and the Gutenberg plugin active.
  * With both core at 7.0 and the Gutenberg plugin active, Gutenberg takes priority. As such, when disconnecting and reconnecting from the connectors page itself, the page you are redirected to after connecting (`/wp-admin/options-general.php?page=settings_page_options-connectors-wp-admin`) leads to an error: 'sorry you are not allowed to access this page'. This PR sends you back to the correct page.

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

To test, add the WordPress Beta Tester plugin to a test site with Jetpack installed and active as well. With the Beta Tester, enable release candidates, and ensure the latest RC is active on the site.

Gutenberg compatibility:
* On bleeding edge (Jetpack), for the Gutenberg compatibility test, install and active Gutenberg on your site.
* Visit the connectors page via Settings > Connectors (ensure you do this rather than refreshing an existing tab with the connectors page open, as the URL will be slightly different).
* On the connectors card, disconnect your user account. Then via the connectors card, connect your account. The connection flow will take you to to a page showing 'sorry you are not allowed to access this page'.
* If you follow the same flow with this PR applied via the Jetpack Beta tester plugin (or applied locally), you should be redirected back to the correct page.
* Ensure the connection flows act as expected without the Gutenberg plugin active as well.

Disconnection modal:
* On bleeding edge (Jetpack), ensure you have only one connected user on your site and visit the connectors page. Click on 'disconnect account', and it should immediately disconnect you.
* Follow the same flow with this PR applied, and you should now see a modal confirming if you want to disconnect.
* Ensure the owner / other user connect modal flow shows as expected as well in that scenario.

New modal text:

<img width="424" height="227" alt="Screenshot 2026-04-02 at 13 46 21" src="https://github.com/user-attachments/assets/6be22c04-7319-472d-b05f-f97b2dbb6efe" />
