### PR TITLE
Fix sidebar free upsell color on problematic admin color schemes

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1822,7 +1822,26 @@ importers:
 
   projects/packages/account-protection: {}
 
-  projects/packages/admin-ui: {}
+  projects/packages/admin-ui:
+    devDependencies:
+      '@automattic/jetpack-webpack-config':
+        specifier: workspace:*
+        version: link:../../js-packages/webpack-config
+      '@wordpress/browserslist-config':
+        specifier: 6.42.0
+        version: 6.42.0
+      sass-embedded:
+        specifier: 1.97.3
+        version: 1.97.3
+      sass-loader:
+        specifier: 16.0.5
+        version: 16.0.5(sass-embedded@1.97.3)(webpack@5.105.2)
+      webpack:
+        specifier: 5.105.2
+        version: 5.105.2(webpack-cli@6.0.1)
+      webpack-cli:
+        specifier: 6.0.1
+        version: 6.0.1(webpack@5.105.2)
 
   projects/packages/assets:
     dependencies:

--- a/projects/packages/admin-ui/.gitattributes
+++ b/projects/packages/admin-ui/.gitattributes
@@ -6,6 +6,7 @@ package.json      export-ignore
 # Files to include in the mirror repo, but excluded via gitignore
 # Remember to end all directories with `/**` to properly tag every file.
 # /src/js/example.min.js  production-include
+build/**          production-include
 
 # Files to exclude from the mirror repo, but included in the monorepo.
 # Remember to end all directories with `/**` to properly tag every file.
@@ -13,3 +14,5 @@ package.json      export-ignore
 .phpcs.dir.xml    production-exclude
 changelog/**      production-exclude
 tests/**          production-exclude
+webpack.config.js production-exclude
+src/**.scss       production-exclude

--- a/projects/packages/admin-ui/.gitignore
+++ b/projects/packages/admin-ui/.gitignore
@@ -1,3 +1,4 @@
+build/
 vendor/
 node_modules/
 wordpress

--- a/projects/packages/admin-ui/changelog/fix-sidebar-free-upsell-color
+++ b/projects/packages/admin-ui/changelog/fix-sidebar-free-upsell-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix upgrade menu item color on problematic admin color schemes and add build pipeline for CSS assets.

--- a/projects/packages/admin-ui/composer.json
+++ b/projects/packages/admin-ui/composer.json
@@ -24,6 +24,12 @@
 		]
 	},
 	"scripts": {
+		"build-development": [
+			"pnpm run build"
+		],
+		"build-production": [
+			"pnpm run build-production"
+		],
 		"phpunit": [
 			"phpunit-select-config phpunit.#.xml.dist --colors=always"
 		],

--- a/projects/packages/admin-ui/package.json
+++ b/projects/packages/admin-ui/package.json
@@ -15,9 +15,21 @@
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic",
 	"scripts": {
-		"build": "echo 'Not implemented.'",
-		"build-js": "echo 'Not implemented.'",
-		"build-production": "echo 'Not implemented.'",
-		"build-production-js": "echo 'Not implemented.'"
+		"build": "pnpm run clean && webpack --config webpack.config.js",
+		"build-production": "pnpm run clean && NODE_ENV=production BABEL_ENV=production webpack --config webpack.config.js && pnpm run validate",
+		"clean": "rm -rf build/",
+		"validate": "pnpm exec validate-es build/",
+		"watch": "pnpm run build && pnpm webpack watch"
+	},
+	"browserslist": [
+		"extends @wordpress/browserslist-config"
+	],
+	"devDependencies": {
+		"@automattic/jetpack-webpack-config": "workspace:*",
+		"@wordpress/browserslist-config": "6.42.0",
+		"sass-embedded": "1.97.3",
+		"sass-loader": "16.0.5",
+		"webpack": "5.105.2",
+		"webpack-cli": "6.0.1"
 	}
 }

--- a/projects/packages/admin-ui/src/admin-menu-style.scss
+++ b/projects/packages/admin-ui/src/admin-menu-style.scss
@@ -1,0 +1,42 @@
+$upgrade-menu-slug: jetpack-wpadmin-sidebar-free-plan-upsell-menu-item;
+$upgrade-menu-default-color: #069e08;
+$upgrade-menu-safe-color-schemes: fresh, light, modern;
+$upgrade-menu-special-color-schemes: (
+	coffee: #9ea476,
+	ectoplasm: #a3b745,
+	midnight: #e14d43,
+);
+
+@mixin upgrade-menu-item-link-selector {
+	#adminmenu li.#{$upgrade-menu-slug} > a,
+	#adminmenu li.#{$upgrade-menu-slug} > a:hover {
+		@content;
+	}
+}
+
+@mixin upgrade-menu-item-theme-selector($theme) {
+	body.admin-color-#{$theme} #adminmenu li.#{$upgrade-menu-slug} > a,
+	body.admin-color-#{$theme} #adminmenu li.#{$upgrade-menu-slug} > a:hover {
+		@content;
+	}
+}
+
+@include upgrade-menu-item-link-selector {
+	font-weight: 600;
+}
+
+
+@each $theme in $upgrade-menu-safe-color-schemes {
+
+	@include upgrade-menu-item-theme-selector($theme) {
+		color: $upgrade-menu-default-color !important;
+	}
+}
+
+
+@each $theme, $color in $upgrade-menu-special-color-schemes {
+
+	@include upgrade-menu-item-theme-selector($theme) {
+		color: $color !important;
+	}
+}

--- a/projects/packages/admin-ui/src/admin-ui-upgrade-menu.scss
+++ b/projects/packages/admin-ui/src/admin-ui-upgrade-menu.scss
@@ -1,6 +1,7 @@
+// Keep the slug in sync with `UPGRADE_MENU_SLUG` at class-admin-menu.php
 $upgrade-menu-slug: jetpack-wpadmin-sidebar-free-plan-upsell-menu-item;
 $upgrade-menu-default-color: #069e08;
-$upgrade-menu-safe-color-schemes: fresh, light, modern;
+$upgrade-menu-default-color-schemes: fresh, light, modern;
 $upgrade-menu-special-color-schemes: (
 	coffee: #9ea476,
 	ectoplasm: #a3b745,
@@ -25,14 +26,12 @@ $upgrade-menu-special-color-schemes: (
 	font-weight: 600;
 }
 
-
-@each $theme in $upgrade-menu-safe-color-schemes {
+@each $theme in $upgrade-menu-default-color-schemes {
 
 	@include upgrade-menu-item-theme-selector($theme) {
 		color: $upgrade-menu-default-color !important;
 	}
 }
-
 
 @each $theme, $color in $upgrade-menu-special-color-schemes {
 

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -54,7 +54,7 @@ class Admin_Menu {
 			self::handle_akismet_menu();
 			add_action( 'admin_menu', array( __CLASS__, 'admin_menu_hook_callback' ), 1000 ); // Jetpack uses 998.
 			add_action( 'network_admin_menu', array( __CLASS__, 'admin_menu_hook_callback' ), 1000 ); // Jetpack uses 998.
-			add_action( 'admin_head', array( __CLASS__, 'add_upgrade_menu_item_styles' ) );
+			add_action( 'admin_enqueue_scripts', array( __CLASS__, 'add_upgrade_menu_item_styles' ) );
 		}
 	}
 
@@ -345,10 +345,10 @@ class Admin_Menu {
 	}
 
 	/**
-	 * Outputs inline CSS to style the "Upgrade Jetpack" menu item in Jetpack green.
+	 * Enqueues admin styles for the "Upgrade Jetpack" menu item.
 	 *
-	 * The sidebar menu is visible on every admin page, so styles must load globally.
-	 * Only outputs for free-plan sites on self-hosted installs.
+	 * The sidebar menu is visible on every admin page, so styles load globally.
+	 * Only enqueues for free-plan sites on self-hosted installs.
 	 *
 	 * @return void
 	 */
@@ -357,42 +357,16 @@ class Admin_Menu {
 			return;
 		}
 
-		// All color schemes have bold upsell text
-		$styles_template =
-			'#adminmenu li.%slug% > a,' .
-			'#adminmenu li.%slug% > a:hover { ' .
-			'font-weight: 600; }';
+		$asset_file = dirname( __DIR__ ) . '/build/admin-menu-style.asset.php';
+		if ( file_exists( $asset_file ) ) {
+			$asset = require $asset_file;
 
-		// Safe admin color schemes have Jetpack Green as the highlight color.
-		$safe_color_schemes = array( 'fresh', 'light', 'modern', 'coffee', 'midnight' );
-		$color_selectors    = array();
-		foreach ( $safe_color_schemes as $color_scheme ) {
-			$color_selectors[] = '.admin-color-' . $color_scheme . ' #adminmenu li.%slug% > a';
-			$color_selectors[] = '.admin-color-' . $color_scheme . ' #adminmenu li.%slug% > a:hover';
+			wp_enqueue_style(
+				'jetpack-admin-ui-upgrade-menu',
+				plugins_url( '../build/admin-menu-style.css', __FILE__ ),
+				$asset['dependencies'] ?? array(),
+				$asset['version'] ?? self::PACKAGE_VERSION
+			);
 		}
-
-		$styles_template .= implode( ',', $color_selectors ) . '{color: #069e08 !important;}';
-
-		// Special color schemes have a different highlight color suitable to the scheme to stay readable.
-		$special_color_schemes = array(
-			'coffee'    => '#9ea476',
-			'ectoplasm' => '#a3b745',
-			'midnight'  => '#e14d43',
-		);
-
-		foreach ( $special_color_schemes as $color_scheme => $color ) {
-			$styles_template .= '.admin-color-' . $color_scheme . ' #adminmenu li.%slug% > a,';
-			$styles_template .= '.admin-color-' . $color_scheme . ' #adminmenu li.%slug% > a:hover {color: ' . $color . ' !important;}';
-		}
-
-		$styles = str_replace( '%slug%', esc_attr( self::UPGRADE_MENU_SLUG ), $styles_template );
-
-		?>
-		<style>
-			<?php echo $styles; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output is a CSS string generated from trusted selectors and an escaped slug. ?>
-		</style>
-		<?php
 	}
 }
-
-

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -16,18 +16,11 @@ class Admin_Menu {
 	const PACKAGE_VERSION = '0.6.0';
 
 	/**
-	 * Redirect source slug used as the upgrade URL identifier.
+	 * Slug used for the upgrade menu item and redirect URL.
 	 *
 	 * @var string
 	 */
-	const UPGRADE_REDIRECT_SLUG = 'jetpack-wpadmin-sidebar-free-plan-upsell-menu-item';
-
-	/**
-	 * Menu item CSS class.
-	 *
-	 * @var string
-	 */
-	const UPGRADE_MENU_SLUG = 'jp-sidebar-upsell-menu-item';
+	const UPGRADE_MENU_SLUG = 'jetpack-wpadmin-sidebar-free-plan-upsell-menu-item';
 
 	/**
 	 * Fallback upgrade URL when the Redirect class is unavailable.
@@ -322,7 +315,7 @@ class Admin_Menu {
 		}
 
 		$upgrade_url = class_exists( '\Automattic\Jetpack\Redirect' )
-			? \Automattic\Jetpack\Redirect::get_url( self::UPGRADE_REDIRECT_SLUG )
+			? \Automattic\Jetpack\Redirect::get_url( self::UPGRADE_MENU_SLUG )
 			: self::UPGRADE_MENU_FALLBACK_URL;
 
 		$menu_title = esc_html__( 'Upgrade Jetpack', 'jetpack-admin-ui' )

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -363,7 +363,7 @@ class Admin_Menu {
 			'#adminmenu li.%slug% > a:hover { ' .
 			'font-weight: 600; }';
 
-		// Safe admin color schemes for the highlight color while being readable.
+		// Safe admin color schemes have Jetpack Green as the highlight color.
 		$safe_color_schemes = array( 'fresh', 'light', 'modern', 'coffee', 'midnight' );
 		$color_selectors    = array();
 		foreach ( $safe_color_schemes as $color_scheme ) {
@@ -372,6 +372,18 @@ class Admin_Menu {
 		}
 
 		$styles_template .= implode( ',', $color_selectors ) . '{color: #069e08 !important;}';
+
+		// Special color schemes have a different highlight color suitable to the scheme to stay readable.
+		$special_color_schemes = array(
+			'coffee'    => '#9ea476',
+			'ectoplasm' => '#a3b745',
+			'midnight'  => '#e14d43',
+		);
+
+		foreach ( $special_color_schemes as $color_scheme => $color ) {
+			$styles_template .= '.admin-color-' . $color_scheme . ' #adminmenu li.%slug% > a,';
+			$styles_template .= '.admin-color-' . $color_scheme . ' #adminmenu li.%slug% > a:hover {color: ' . $color . ' !important;}';
+		}
 
 		$styles = str_replace( '%slug%', esc_attr( self::UPGRADE_MENU_SLUG ), $styles_template );
 

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -360,15 +360,13 @@ class Admin_Menu {
 		}
 
 		$asset_file = dirname( __DIR__ ) . '/build/admin-ui-upgrade-menu.asset.php';
-		if ( file_exists( $asset_file ) ) {
-			$asset = require $asset_file;
+		$asset      = file_exists( $asset_file ) ? require $asset_file : array();
 
-			wp_enqueue_style(
-				'jetpack-admin-ui-upgrade-menu',
-				plugins_url( '../build/admin-ui-upgrade-menu.css', __FILE__ ),
-				$asset['dependencies'] ?? array(),
-				$asset['version'] ?? self::PACKAGE_VERSION
-			);
-		}
+		wp_enqueue_style(
+			'jetpack-admin-ui-upgrade-menu',
+			plugins_url( '../build/admin-ui-upgrade-menu.css', __FILE__ ),
+			$asset['dependencies'] ?? array(),
+			$asset['version'] ?? self::PACKAGE_VERSION
+		);
 	}
 }

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -18,6 +18,8 @@ class Admin_Menu {
 	/**
 	 * Slug used for the upgrade menu item and redirect URL.
 	 *
+	 * Keep the slug in sync with `$upgrade-menu-slug` at admin-ui-upgrade-menu.scss
+	 *
 	 * @var string
 	 */
 	const UPGRADE_MENU_SLUG = 'jetpack-wpadmin-sidebar-free-plan-upsell-menu-item';
@@ -357,13 +359,13 @@ class Admin_Menu {
 			return;
 		}
 
-		$asset_file = dirname( __DIR__ ) . '/build/admin-menu-style.asset.php';
+		$asset_file = dirname( __DIR__ ) . '/build/admin-ui-upgrade-menu.asset.php';
 		if ( file_exists( $asset_file ) ) {
 			$asset = require $asset_file;
 
 			wp_enqueue_style(
 				'jetpack-admin-ui-upgrade-menu',
-				plugins_url( '../build/admin-menu-style.css', __FILE__ ),
+				plugins_url( '../build/admin-ui-upgrade-menu.css', __FILE__ ),
 				$asset['dependencies'] ?? array(),
 				$asset['version'] ?? self::PACKAGE_VERSION
 			);

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -16,11 +16,18 @@ class Admin_Menu {
 	const PACKAGE_VERSION = '0.6.0';
 
 	/**
-	 * Redirect source slug used as the upgrade URL identifier and CSS class.
+	 * Redirect source slug used as the upgrade URL identifier.
 	 *
 	 * @var string
 	 */
-	const UPGRADE_MENU_SLUG = 'jetpack-wpadmin-sidebar-free-plan-upsell-menu-item';
+	const UPGRADE_REDIRECT_SLUG = 'jetpack-wpadmin-sidebar-free-plan-upsell-menu-item';
+
+	/**
+	 * Menu item CSS class.
+	 *
+	 * @var string
+	 */
+	const UPGRADE_MENU_SLUG = 'jp-sidebar-upsell-menu-item';
 
 	/**
 	 * Fallback upgrade URL when the Redirect class is unavailable.
@@ -315,7 +322,7 @@ class Admin_Menu {
 		}
 
 		$upgrade_url = class_exists( '\Automattic\Jetpack\Redirect' )
-			? \Automattic\Jetpack\Redirect::get_url( self::UPGRADE_MENU_SLUG )
+			? \Automattic\Jetpack\Redirect::get_url( self::UPGRADE_REDIRECT_SLUG )
 			: self::UPGRADE_MENU_FALLBACK_URL;
 
 		$menu_title = esc_html__( 'Upgrade Jetpack', 'jetpack-admin-ui' )
@@ -356,14 +363,31 @@ class Admin_Menu {
 		if ( ! self::should_show_upgrade_menu() ) {
 			return;
 		}
+
+		// All color schemes have bold upsell text
+		$styles_template =
+			'#adminmenu li.%slug% > a,' .
+			'#adminmenu li.%slug% > a:hover { ' .
+			'font-weight: 600; }';
+
+		// Safe admin color schemes for the highlight color while being readable.
+		$safe_color_schemes = array( 'fresh', 'light', 'modern', 'coffee', 'midnight' );
+		$color_selectors    = array();
+		foreach ( $safe_color_schemes as $color_scheme ) {
+			$color_selectors[] = '.admin-color-' . $color_scheme . ' #adminmenu li.%slug% > a';
+			$color_selectors[] = '.admin-color-' . $color_scheme . ' #adminmenu li.%slug% > a:hover';
+		}
+
+		$styles_template .= implode( ',', $color_selectors ) . '{color: #069e08 !important;}';
+
+		$styles = str_replace( '%slug%', esc_attr( self::UPGRADE_MENU_SLUG ), $styles_template );
+
 		?>
 		<style>
-			#adminmenu li.<?php echo esc_attr( self::UPGRADE_MENU_SLUG ); ?> > a,
-			#adminmenu li.<?php echo esc_attr( self::UPGRADE_MENU_SLUG ); ?> > a:hover {
-				color: #069e08 !important;
-				font-weight: 600;
-			}
+			<?php echo $styles; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output is a CSS string generated from trusted selectors and an escaped slug. ?>
 		</style>
 		<?php
 	}
 }
+
+

--- a/projects/packages/admin-ui/tests/php/Admin_Menu_Test.php
+++ b/projects/packages/admin-ui/tests/php/Admin_Menu_Test.php
@@ -91,6 +91,8 @@ class Admin_Menu_Test extends TestCase {
 		$submenu = array();
 		delete_option( 'jetpack_active_plan' );
 		delete_option( 'jetpack_site_products' );
+		wp_dequeue_style( 'jetpack-admin-ui-upgrade-menu' );
+		wp_deregister_style( 'jetpack-admin-ui-upgrade-menu' );
 
 		$reflection = new \ReflectionClass( Admin_Menu::class );
 
@@ -362,29 +364,26 @@ class Admin_Menu_Test extends TestCase {
 	}
 
 	/**
-	 * CSS styles are output for a free-plan site on any admin screen.
+	 * Upgrade menu stylesheet is enqueued for a free-plan site.
 	 *
 	 * The sidebar is visible everywhere in wp-admin, so styles must load globally.
 	 *
 	 * @return void
 	 */
-	public function test_upgrade_menu_item_styles_output_for_free_plan() {
+	public function test_upgrade_menu_item_styles_enqueued_for_free_plan() {
 		wp_set_current_user( self::$admin_user_id );
 
-		ob_start();
 		Admin_Menu::add_upgrade_menu_item_styles();
-		$output = ob_get_clean();
 
-		$this->assertStringContainsString( Admin_Menu::UPGRADE_MENU_SLUG, $output );
-		$this->assertStringContainsString( '#069e08', $output );
+		$this->assertTrue( wp_style_is( 'jetpack-admin-ui-upgrade-menu', 'enqueued' ) );
 	}
 
 	/**
-	 * No CSS output when the site has a paid plan.
+	 * No stylesheet enqueue when the site has a paid plan.
 	 *
 	 * @return void
 	 */
-	public function test_upgrade_menu_item_styles_no_output_for_paid_plan() {
+	public function test_upgrade_menu_item_styles_not_enqueued_for_paid_plan() {
 		wp_set_current_user( self::$admin_user_id );
 		update_option(
 			'jetpack_active_plan',
@@ -394,19 +393,17 @@ class Admin_Menu_Test extends TestCase {
 			)
 		);
 
-		ob_start();
 		Admin_Menu::add_upgrade_menu_item_styles();
-		$output = ob_get_clean();
 
-		$this->assertSame( '', $output );
+		$this->assertFalse( wp_style_is( 'jetpack-admin-ui-upgrade-menu', 'enqueued' ) );
 	}
 
 	/**
-	 * No CSS output when is_free is false.
+	 * No stylesheet enqueue when is_free is false.
 	 *
 	 * @return void
 	 */
-	public function test_upgrade_menu_item_styles_no_output_when_is_free_false() {
+	public function test_upgrade_menu_item_styles_not_enqueued_when_is_free_false() {
 		wp_set_current_user( self::$admin_user_id );
 		update_option(
 			'jetpack_active_plan',
@@ -416,19 +413,17 @@ class Admin_Menu_Test extends TestCase {
 			)
 		);
 
-		ob_start();
 		Admin_Menu::add_upgrade_menu_item_styles();
-		$output = ob_get_clean();
 
-		$this->assertSame( '', $output );
+		$this->assertFalse( wp_style_is( 'jetpack-admin-ui-upgrade-menu', 'enqueued' ) );
 	}
 
 	/**
-	 * No CSS output when site has products.
+	 * No stylesheet enqueue when site has products.
 	 *
 	 * @return void
 	 */
-	public function test_upgrade_menu_item_styles_no_output_when_site_has_products() {
+	public function test_upgrade_menu_item_styles_not_enqueued_when_site_has_products() {
 		wp_set_current_user( self::$admin_user_id );
 		update_option(
 			'jetpack_site_products',
@@ -439,11 +434,9 @@ class Admin_Menu_Test extends TestCase {
 			)
 		);
 
-		ob_start();
 		Admin_Menu::add_upgrade_menu_item_styles();
-		$output = ob_get_clean();
 
-		$this->assertSame( '', $output );
+		$this->assertFalse( wp_style_is( 'jetpack-admin-ui-upgrade-menu', 'enqueued' ) );
 	}
 
 	/**

--- a/projects/packages/admin-ui/webpack.config.js
+++ b/projects/packages/admin-ui/webpack.config.js
@@ -4,7 +4,7 @@ const jetpackWebpackConfig = require( '@automattic/jetpack-webpack-config/webpac
 module.exports = [
 	{
 		entry: {
-			'admin-menu-style': './src/admin-menu-style.scss',
+			'admin-ui-upgrade-menu': './src/admin-ui-upgrade-menu.scss',
 		},
 		mode: jetpackWebpackConfig.mode,
 		devtool: jetpackWebpackConfig.devtool,

--- a/projects/packages/admin-ui/webpack.config.js
+++ b/projects/packages/admin-ui/webpack.config.js
@@ -1,0 +1,24 @@
+const path = require( 'path' );
+const jetpackWebpackConfig = require( '@automattic/jetpack-webpack-config/webpack' );
+
+module.exports = [
+	{
+		entry: {
+			'admin-menu-style': './src/admin-menu-style.scss',
+		},
+		mode: jetpackWebpackConfig.mode,
+		devtool: jetpackWebpackConfig.devtool,
+		output: {
+			path: path.resolve( './build' ),
+		},
+		plugins: [ ...jetpackWebpackConfig.StandardPlugins() ],
+		module: {
+			rules: [
+				jetpackWebpackConfig.CssRule( {
+					extensions: [ 'css', 'sass', 'scss' ],
+					extraLoaders: [ { loader: 'sass-loader', options: { api: 'modern-compiler' } } ],
+				} ),
+			],
+		},
+	},
+];

--- a/projects/plugins/automattic-for-agencies-client/changelog/fix-sidebar-free-upsell-color
+++ b/projects/plugins/automattic-for-agencies-client/changelog/fix-sidebar-free-upsell-color
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
+Comment: Update composer lockfile.
 
-Update composer lockfile.

--- a/projects/plugins/automattic-for-agencies-client/changelog/fix-sidebar-free-upsell-color
+++ b/projects/plugins/automattic-for-agencies-client/changelog/fix-sidebar-free-upsell-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update composer lockfile.

--- a/projects/plugins/automattic-for-agencies-client/composer.lock
+++ b/projects/plugins/automattic-for-agencies-client/composer.lock
@@ -66,7 +66,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "827d689e815ae1112f6823ed45a51739d78bac4f"
+                "reference": "d71575c86c7f4cec8c3354e21c15db817b966515"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -104,6 +104,12 @@
                 ]
             },
             "scripts": {
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "pnpm run build-production"
+                ],
                 "phpunit": [
                     "phpunit-select-config phpunit.#.xml.dist --colors=always"
                 ],

--- a/projects/plugins/backup/changelog/fix-sidebar-free-upsell-color
+++ b/projects/plugins/backup/changelog/fix-sidebar-free-upsell-color
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
+Comment: Update composer lockfile.
 
-Update composer lockfile.

--- a/projects/plugins/backup/changelog/fix-sidebar-free-upsell-color
+++ b/projects/plugins/backup/changelog/fix-sidebar-free-upsell-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update composer lockfile.

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -66,7 +66,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "827d689e815ae1112f6823ed45a51739d78bac4f"
+                "reference": "d71575c86c7f4cec8c3354e21c15db817b966515"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -104,6 +104,12 @@
                 ]
             },
             "scripts": {
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "pnpm run build-production"
+                ],
                 "phpunit": [
                     "phpunit-select-config phpunit.#.xml.dist --colors=always"
                 ],

--- a/projects/plugins/beta/changelog/fix-sidebar-free-upsell-color
+++ b/projects/plugins/beta/changelog/fix-sidebar-free-upsell-color
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
+Comment: Update composer lockfile.
 
-Update composer lockfile.

--- a/projects/plugins/beta/changelog/fix-sidebar-free-upsell-color
+++ b/projects/plugins/beta/changelog/fix-sidebar-free-upsell-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update composer lockfile.

--- a/projects/plugins/beta/composer.lock
+++ b/projects/plugins/beta/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "827d689e815ae1112f6823ed45a51739d78bac4f"
+                "reference": "d71575c86c7f4cec8c3354e21c15db817b966515"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -50,6 +50,12 @@
                 ]
             },
             "scripts": {
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "pnpm run build-production"
+                ],
                 "phpunit": [
                     "phpunit-select-config phpunit.#.xml.dist --colors=always"
                 ],

--- a/projects/plugins/boost/changelog/fix-sidebar-free-upsell-color
+++ b/projects/plugins/boost/changelog/fix-sidebar-free-upsell-color
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
+Comment: Update composer lockfile.
 
-Update composer lockfile.

--- a/projects/plugins/boost/changelog/fix-sidebar-free-upsell-color
+++ b/projects/plugins/boost/changelog/fix-sidebar-free-upsell-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update composer lockfile.

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -66,7 +66,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "827d689e815ae1112f6823ed45a51739d78bac4f"
+                "reference": "d71575c86c7f4cec8c3354e21c15db817b966515"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -104,6 +104,12 @@
                 ]
             },
             "scripts": {
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "pnpm run build-production"
+                ],
                 "phpunit": [
                     "phpunit-select-config phpunit.#.xml.dist --colors=always"
                 ],

--- a/projects/plugins/classic-theme-helper-plugin/changelog/fix-sidebar-free-upsell-color
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/fix-sidebar-free-upsell-color
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
+Comment: Update composer lockfile.
 
-Update composer lockfile.

--- a/projects/plugins/classic-theme-helper-plugin/changelog/fix-sidebar-free-upsell-color
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/fix-sidebar-free-upsell-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update composer lockfile.

--- a/projects/plugins/classic-theme-helper-plugin/composer.lock
+++ b/projects/plugins/classic-theme-helper-plugin/composer.lock
@@ -130,7 +130,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "827d689e815ae1112f6823ed45a51739d78bac4f"
+                "reference": "d71575c86c7f4cec8c3354e21c15db817b966515"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -168,6 +168,12 @@
                 ]
             },
             "scripts": {
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "pnpm run build-production"
+                ],
                 "phpunit": [
                     "phpunit-select-config phpunit.#.xml.dist --colors=always"
                 ],

--- a/projects/plugins/inspect/changelog/fix-sidebar-free-upsell-color
+++ b/projects/plugins/inspect/changelog/fix-sidebar-free-upsell-color
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
+Comment: Update composer lockfile.
 
-Update composer lockfile.

--- a/projects/plugins/inspect/changelog/fix-sidebar-free-upsell-color
+++ b/projects/plugins/inspect/changelog/fix-sidebar-free-upsell-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update composer lockfile.

--- a/projects/plugins/inspect/composer.lock
+++ b/projects/plugins/inspect/composer.lock
@@ -66,7 +66,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "827d689e815ae1112f6823ed45a51739d78bac4f"
+                "reference": "d71575c86c7f4cec8c3354e21c15db817b966515"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -104,6 +104,12 @@
                 ]
             },
             "scripts": {
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "pnpm run build-production"
+                ],
                 "phpunit": [
                     "phpunit-select-config phpunit.#.xml.dist --colors=always"
                 ],

--- a/projects/plugins/jetpack/changelog/fix-sidebar-free-upsell-color
+++ b/projects/plugins/jetpack/changelog/fix-sidebar-free-upsell-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Fix upgrade menu item color on problematic admin color schemes.

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -199,7 +199,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "827d689e815ae1112f6823ed45a51739d78bac4f"
+                "reference": "d71575c86c7f4cec8c3354e21c15db817b966515"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -237,6 +237,12 @@
                 ]
             },
             "scripts": {
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "pnpm run build-production"
+                ],
                 "phpunit": [
                     "phpunit-select-config phpunit.#.xml.dist --colors=always"
                 ],

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-sidebar-free-upsell-color
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-sidebar-free-upsell-color
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
+Comment: Update composer lockfile.
 
-Update composer lockfile.

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-sidebar-free-upsell-color
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-sidebar-free-upsell-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update composer lockfile.

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -130,7 +130,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "827d689e815ae1112f6823ed45a51739d78bac4f"
+                "reference": "d71575c86c7f4cec8c3354e21c15db817b966515"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -168,6 +168,12 @@
                 ]
             },
             "scripts": {
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "pnpm run build-production"
+                ],
                 "phpunit": [
                     "phpunit-select-config phpunit.#.xml.dist --colors=always"
                 ],

--- a/projects/plugins/paypal-payment-buttons/changelog/fix-sidebar-free-upsell-color
+++ b/projects/plugins/paypal-payment-buttons/changelog/fix-sidebar-free-upsell-color
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
+Comment: Update composer lockfile.
 
-Update composer lockfile.

--- a/projects/plugins/paypal-payment-buttons/changelog/fix-sidebar-free-upsell-color
+++ b/projects/plugins/paypal-payment-buttons/changelog/fix-sidebar-free-upsell-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update composer lockfile.

--- a/projects/plugins/paypal-payment-buttons/composer.lock
+++ b/projects/plugins/paypal-payment-buttons/composer.lock
@@ -66,7 +66,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "827d689e815ae1112f6823ed45a51739d78bac4f"
+                "reference": "d71575c86c7f4cec8c3354e21c15db817b966515"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -104,6 +104,12 @@
                 ]
             },
             "scripts": {
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "pnpm run build-production"
+                ],
                 "phpunit": [
                     "phpunit-select-config phpunit.#.xml.dist --colors=always"
                 ],

--- a/projects/plugins/protect/changelog/fix-sidebar-free-upsell-color
+++ b/projects/plugins/protect/changelog/fix-sidebar-free-upsell-color
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
+Comment: Update composer lockfile.
 
-Update composer lockfile.

--- a/projects/plugins/protect/changelog/fix-sidebar-free-upsell-color
+++ b/projects/plugins/protect/changelog/fix-sidebar-free-upsell-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update composer lockfile.

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -135,7 +135,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "827d689e815ae1112f6823ed45a51739d78bac4f"
+                "reference": "d71575c86c7f4cec8c3354e21c15db817b966515"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -173,6 +173,12 @@
                 ]
             },
             "scripts": {
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "pnpm run build-production"
+                ],
                 "phpunit": [
                     "phpunit-select-config phpunit.#.xml.dist --colors=always"
                 ],

--- a/projects/plugins/search/changelog/fix-sidebar-free-upsell-color
+++ b/projects/plugins/search/changelog/fix-sidebar-free-upsell-color
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
+Comment: Update composer lockfile.
 
-Update composer lockfile.

--- a/projects/plugins/search/changelog/fix-sidebar-free-upsell-color
+++ b/projects/plugins/search/changelog/fix-sidebar-free-upsell-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update composer lockfile.

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -66,7 +66,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "827d689e815ae1112f6823ed45a51739d78bac4f"
+                "reference": "d71575c86c7f4cec8c3354e21c15db817b966515"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -104,6 +104,12 @@
                 ]
             },
             "scripts": {
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "pnpm run build-production"
+                ],
                 "phpunit": [
                     "phpunit-select-config phpunit.#.xml.dist --colors=always"
                 ],

--- a/projects/plugins/social/changelog/fix-sidebar-free-upsell-color
+++ b/projects/plugins/social/changelog/fix-sidebar-free-upsell-color
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
+Comment: Update composer lockfile.
 
-Update composer lockfile.

--- a/projects/plugins/social/changelog/fix-sidebar-free-upsell-color
+++ b/projects/plugins/social/changelog/fix-sidebar-free-upsell-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update composer lockfile.

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -130,7 +130,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "827d689e815ae1112f6823ed45a51739d78bac4f"
+                "reference": "d71575c86c7f4cec8c3354e21c15db817b966515"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -168,6 +168,12 @@
                 ]
             },
             "scripts": {
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "pnpm run build-production"
+                ],
                 "phpunit": [
                     "phpunit-select-config phpunit.#.xml.dist --colors=always"
                 ],

--- a/projects/plugins/starter-plugin/changelog/fix-sidebar-free-upsell-color
+++ b/projects/plugins/starter-plugin/changelog/fix-sidebar-free-upsell-color
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
+Comment: Update composer lockfile.
 
-Update composer lockfile.

--- a/projects/plugins/starter-plugin/changelog/fix-sidebar-free-upsell-color
+++ b/projects/plugins/starter-plugin/changelog/fix-sidebar-free-upsell-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update composer lockfile.

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -66,7 +66,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "827d689e815ae1112f6823ed45a51739d78bac4f"
+                "reference": "d71575c86c7f4cec8c3354e21c15db817b966515"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -104,6 +104,12 @@
                 ]
             },
             "scripts": {
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "pnpm run build-production"
+                ],
                 "phpunit": [
                     "phpunit-select-config phpunit.#.xml.dist --colors=always"
                 ],

--- a/projects/plugins/videopress/changelog/fix-sidebar-free-upsell-color
+++ b/projects/plugins/videopress/changelog/fix-sidebar-free-upsell-color
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
+Comment: Update composer lockfile.
 
-Update composer lockfile.

--- a/projects/plugins/videopress/changelog/fix-sidebar-free-upsell-color
+++ b/projects/plugins/videopress/changelog/fix-sidebar-free-upsell-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update composer lockfile.

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -66,7 +66,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "827d689e815ae1112f6823ed45a51739d78bac4f"
+                "reference": "d71575c86c7f4cec8c3354e21c15db817b966515"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -104,6 +104,12 @@
                 ]
             },
             "scripts": {
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "pnpm run build-production"
+                ],
                 "phpunit": [
                     "phpunit-select-config phpunit.#.xml.dist --colors=always"
                 ],

--- a/projects/plugins/wpcloud-sso/changelog/fix-sidebar-free-upsell-color
+++ b/projects/plugins/wpcloud-sso/changelog/fix-sidebar-free-upsell-color
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
+Comment: Update composer lockfile.
 
-Update composer lockfile.

--- a/projects/plugins/wpcloud-sso/changelog/fix-sidebar-free-upsell-color
+++ b/projects/plugins/wpcloud-sso/changelog/fix-sidebar-free-upsell-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update composer lockfile.

--- a/projects/plugins/wpcloud-sso/composer.lock
+++ b/projects/plugins/wpcloud-sso/composer.lock
@@ -66,7 +66,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "827d689e815ae1112f6823ed45a51739d78bac4f"
+                "reference": "d71575c86c7f4cec8c3354e21c15db817b966515"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -104,6 +104,12 @@
                 ]
             },
             "scripts": {
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "pnpm run build-production"
+                ],
                 "phpunit": [
                     "phpunit-select-config phpunit.#.xml.dist --colors=always"
                 ],

--- a/projects/plugins/wpcomsh/changelog/fix-sidebar-free-upsell-color
+++ b/projects/plugins/wpcomsh/changelog/fix-sidebar-free-upsell-color
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
+Comment: Update composer lockfile.
 
-Update composer lockfile.

--- a/projects/plugins/wpcomsh/changelog/fix-sidebar-free-upsell-color
+++ b/projects/plugins/wpcomsh/changelog/fix-sidebar-free-upsell-color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update composer lockfile.

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -198,7 +198,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "827d689e815ae1112f6823ed45a51739d78bac4f"
+                "reference": "d71575c86c7f4cec8c3354e21c15db817b966515"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -236,6 +236,12 @@
                 ]
             },
             "scripts": {
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "pnpm run build-production"
+                ],
                 "phpunit": [
                     "phpunit-select-config phpunit.#.xml.dist --colors=always"
                 ],


### PR DESCRIPTION


Follow-up to https://github.com/Automattic/jetpack/pull/47418

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Moves styles (that were slightly larger) to a CSS file, which then gets cached across admin page loads instead of being inlined. The logic of CSS building from variables is a bit easier to reason about in SASS rather than PHP ([which I tested](https://github.com/Automattic/jetpack/blob/b65cf690ce3f1bc93b354c3a83fb79ddc93157b5/projects/packages/admin-ui/src/class-admin-menu.php#L347-L396)).
* Continues to apply Jetpack green color to admin color schemes: fresh, light, modern
* Applies custom color on following color schemes: coffee, ectoplasm, midnight
* All other color schemes (sunrise, ocean, blue and any custom ones) continue get their regular menu color, but the item is still set to font-weight 600.

Alternatively, we could pull the colour scheme user-option and output styles _only_ for active colour scheme, but then switching from one colour scheme to another wouldn't work, logic would all be in PHP, etc. And now the CSS gets cached anyway.

## Before

Some color schemes had issues like these:

<img width="173" height="126" alt="image" src="https://github.com/user-attachments/assets/e316b2bd-b7c0-4f8a-9dd1-525e51af77aa" />


## After

### Jetpack green : fresh, light, modern

<img width="1331" height="647" alt="Screenshot 2026-04-02 at 15 33 30" src="https://github.com/user-attachments/assets/be2532ac-b239-4707-b31c-04ae9c527776" />
<img width="1328" height="641" alt="Screenshot 2026-04-02 at 15 33 45" src="https://github.com/user-attachments/assets/348db181-31d9-48d7-ba50-3d813abba25c" />
<img width="1330" height="643" alt="Screenshot 2026-04-02 at 15 33 38" src="https://github.com/user-attachments/assets/c4a1d1b1-5f7e-448f-98ad-72cf220499ac" />

### Custom color: coffee, ectoplasm, midnight

<img width="1325" height="636" alt="Screenshot 2026-04-02 at 15 34 15" src="https://github.com/user-attachments/assets/0040f136-ede0-4ba7-a80f-0764fe22d25c" />
<img width="1323" height="646" alt="Screenshot 2026-04-02 at 15 34 07" src="https://github.com/user-attachments/assets/3c1b91e3-c577-4a6c-9e99-be04225c10dc" />
<img width="1334" height="642" alt="Screenshot 2026-04-02 at 15 33 59" src="https://github.com/user-attachments/assets/88757249-d086-42f3-b031-c4dc73aa2935" />

### Other color schemes: sunrise, ocean, blue
<img width="1332" height="640" alt="Screenshot 2026-04-02 at 15 34 30" src="https://github.com/user-attachments/assets/61c9b038-dfc3-41b1-9054-fa76d5ee1bda" />
<img width="1334" height="646" alt="Screenshot 2026-04-02 at 15 34 22" src="https://github.com/user-attachments/assets/7aa0f9bd-c2be-4a7c-b449-b7ffba96b320" />
<img width="1333" height="645" alt="Screenshot 2026-04-02 at 15 33 52" src="https://github.com/user-attachments/assets/4a89daad-1b94-46e7-8fb7-e5c19c70e986" />


### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Test site with plan and without plan; you can see the menu and CSS stylesheet load only when on the free plan. 
* Go to _Users → Profile_: test all color schemes and see the Jetpack menu.
* Save one of the color schemes and see how color continues to apply across different pages.

