### PR TITLE
Forms: add missing margin prop to SelectControl

### DIFF
--- a/projects/packages/forms/changelog/fix-select-control-margin
+++ b/projects/packages/forms/changelog/fix-select-control-margin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix missing margin prop in SelectControl component.

--- a/projects/packages/forms/src/blocks/contact-form/variation-picker.js
+++ b/projects/packages/forms/src/blocks/contact-form/variation-picker.js
@@ -210,6 +210,7 @@ export default function VariationPicker( { blockName, setAttributes, clientId, c
 				<div className="form-placeholder__shell">
 					<SelectControl
 						__next40pxDefaultSize
+						__nextHasNoMarginBottom
 						label={ __( 'Or select an existing form', 'jetpack-forms' ) }
 						options={ [
 							{ label: __( 'Select a form…', 'jetpack-forms' ), value: '' },


### PR DESCRIPTION
Fixes:

<img width="676" height="696" alt="image" src="https://github.com/user-attachments/assets/b85069e7-1728-489f-b5c6-e85880217a98" />


## Proposed changes
<!--- Explain what functional changes your PR includes -->
*  Adds missing margin prop to get rid of warning and prepare for WP7.0

### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Test forms placeholder in editor
<img width="669" height="340" alt="image" src="https://github.com/user-attachments/assets/0ac87207-8917-4e3a-80d2-1c69d5a297fe" />
