### PR TITLE
Forms: polyfill WP Views and update private-apis version

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4198,6 +4198,10 @@ importers:
         version: 6.0.1(webpack@5.105.2)
 
   projects/packages/wp-build-polyfills:
+    dependencies:
+      '@wordpress/views':
+        specifier: ~1.10.0
+        version: 1.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
     devDependencies:
       '@automattic/jetpack-webpack-config':
         specifier: workspace:*
@@ -7013,8 +7017,29 @@ packages:
       '@types/react':
         optional: true
 
+  '@base-ui/react@1.3.0':
+    resolution: {integrity: sha512-FwpKqZbPz14AITp1CVgf4AjhKPe1OeeVKSBMdgD10zbFlj3QSWelmtCMLi2+/PFZZcIm3l87G7rwtCZJwHyXWA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@base-ui/utils@0.2.5':
     resolution: {integrity: sha512-oYC7w0gp76RI5MxprlGLV0wze0SErZaRl3AAkeP3OnNB/UBMb6RqNf6ZSIlxOc9Qp68Ab3C2VOcJQyRs7Xc7Vw==}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@base-ui/utils@0.2.6':
+    resolution: {integrity: sha512-yQ+qeuqohwhsNpoYDqqXaLllYAkPCP4vYdDrVo8FQXaAPfHWm1pG/Vm+jmGTA5JFS0BAIjookyapuJFY8F9PIw==}
     peerDependencies:
       '@types/react': ^17 || ^18 || ^19
       react: ^17 || ^18 || ^19
@@ -10274,6 +10299,10 @@ packages:
     resolution: {integrity: sha512-7NdHXJt3XDBXujkhoZkuBzZJIY+LrG0r2aPSJVujoHwioBR3V+HgdcGa1xydAnKtdiNnYa8fEdlWqk49EEQ0MA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/a11y@4.43.0':
+    resolution: {integrity: sha512-AWNmSi+Cjx5m03JhG/XjDqgRufqCFcIpYddWw7/0vR6rMk/DK5O+Jx6yJcJOwgmz2KFSgjMnjFfqbh3EtX8rRg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/admin-ui@1.10.0':
     resolution: {integrity: sha512-Fn/vNDKLQuUSv0feb40Rmbl0TIndOPGtPon3gYiBMBLxgYebT/ET4RS0vktn8IEcP9frPG1wVZ5dM8dT3d/cHw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -10290,12 +10319,20 @@ packages:
     resolution: {integrity: sha512-Y6WI4ZovoKNaSz6TTtZwc80RrgIoGc8lxDLi/KCHAr4Nyxu6YaSfLPtHsaqDmrggdZuce7KHx0T/oyHKtDu0Aw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/api-fetch@7.43.0':
+    resolution: {integrity: sha512-1Tetm4VIEKDIwrCsvDY0KjjrHvkEaSa2Qvld5gguY2ofcIszL3mR0tGezFaaaB14FHd7Zl0MpfpQY3KeQ+BatQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/asset-loader@1.8.0':
     resolution: {integrity: sha512-9qMiFVfwlS/yUOlgHgIry9HWXkDSwKI74HImSiCan4AC3LwsKTXn3slJ4v6FYlr8Q10croCnnmUXWcLgny929w==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/autop@4.42.0':
     resolution: {integrity: sha512-cda5C9P15fUUQZmdYUnOxKTbZqoCX9oeo0UHaSmSsJcuoj3jFvGr5NxjTHKPxwS/2p/mIdfb3VDS4klBx9uraw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/autop@4.43.0':
+    resolution: {integrity: sha512-ODEGv8CZmL12DRKyYCCUXwTHS8aI2/K1C4WuVLeQ5uhPmFk0QHAHQ2sGga509K9F0Nj/DY7fgkD0YlE9T1stbA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/babel-plugin-import-jsx-pragma@5.42.0':
@@ -10312,12 +10349,27 @@ packages:
     resolution: {integrity: sha512-c9C8gE49uFsR6S8zmfhH8xFR8FrrkpO289sscv5jRABHeH21irwP/yGuEbkJiUqIqV9Rm2+HbQay4+F5M8DYfA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/base-styles@6.19.0':
+    resolution: {integrity: sha512-SAZA6dhfC5X00s9PRrL9diY59WegiF0MuAWupkoKnYk3a2IAQbRUUTrh3j3wRyr08ljqefmifX5GR3hz/VwQaw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/blob@4.42.0':
     resolution: {integrity: sha512-UwUUrdmjEJTgvelFdVg7c7s/240Siv6bFIurv0o9XY4Bu46z4NHJI96nUiziKRNTRm0lcvzS6CZxeRTT/m1Fig==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/blob@4.43.0':
+    resolution: {integrity: sha512-wNYpE1DMabI9wDIVBcwsakbnVnvskAj0eJ+7A1njEdmJFYEQ0wc6kTqJ6ma4pLYYPrgw2svWl8vI3HIIB50qhg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/block-editor@15.15.0':
     resolution: {integrity: sha512-2IBkb17gOWW0mvZQewzB/0g+ANTrg00/U7AnAYmx/ldU6EP9dEINcfRCiTBRA4Z7d4oaQW9cpFdKVI255U1Syg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
+  '@wordpress/block-editor@15.16.0':
+    resolution: {integrity: sha512-gTTsrN3F1uWKmzOldi4t+IbbSbF/oEd/mxyhjZvvZ0mJV6cQM2q8q3FuWEx9mlqh1jsnh+ycuc//L556KXdIHA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18.0.0
@@ -10334,8 +10386,18 @@ packages:
     resolution: {integrity: sha512-XcX6gOeQOuG0RrUqJV1dadPBUi77uhLhpGfQH/s8vmAEGSWqgJAbjWwUKD8RP6wCGY+IE3Gayd5zu48aVRlB4A==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/block-serialization-default-parser@5.43.0':
+    resolution: {integrity: sha512-1P2eujRuY9VmhFT8Kp7hghxbxbw6dIcHWGLlo/V3YVaHor1WZ3P5p6k+ELQRJTyrbWYV+qu/zYWGYCGGDtEvsA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/blocks@15.15.0':
     resolution: {integrity: sha512-xUlxCqIV8UuH5MjtPQBnxEwvhe2CCrZ+WqGJ+ffLxQQGHbe513zXl8sr79FdE2noec4Bj8VdOp1oH8zlESQEUA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
+  '@wordpress/blocks@15.16.0':
+    resolution: {integrity: sha512-vyr87vwJvDErB19jVsBscpTC/x4+VhNGXGel4zawY3CdbyfBIHZrrdiOTjwwUnijLVspkv0nWkiUtYIxWP/SMQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18.0.0
@@ -10377,8 +10439,22 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
+  '@wordpress/commands@1.43.0':
+    resolution: {integrity: sha512-oD2uurR7HYgQ3lXhukcWX0/mc+PHEFEfB2lu/mi5IvX8xYMV8e/l/uoP6BJ+Krm7EqtOkSwoaoGi6KcYoR4sMw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
   '@wordpress/components@32.4.0':
     resolution: {integrity: sha512-aGXtHZbrvA2upy/Qwti1lFjt0BPqezoYx2Le5x/0P841Ss4O/9XtAvJGg99hityIugbzEdDzkWKcdoBRwa2FBQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
+  '@wordpress/components@32.5.0':
+    resolution: {integrity: sha512-UEBNEqxHfOvTVbVepoLPS2wSzIjcZoCHMv6P2iN0om819x3aLIKAZqpxjNF8x0nz2z/gnj5Bj9GpXTW0+Bvfcw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18.0.0
@@ -10390,8 +10466,21 @@ packages:
     peerDependencies:
       react: ^18.0.0
 
+  '@wordpress/compose@7.43.0':
+    resolution: {integrity: sha512-soLT1qavMSyIP/n8Bd+nWRvhZpQVf5YqqjB/ibTGHU8782oaV6Qw2fd6SVXL0kx6/3YzC9FHTPy69v5gxuM6XQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
   '@wordpress/core-data@7.42.0':
     resolution: {integrity: sha512-QAg/EPYUN/CJkO7DGxdldeRMHHnwWWSVUc/0cLYxOPRLbjqdKKSmg7Wiu+62yfl/GO6gpMaGr3QrORMNlMAXVg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
+  '@wordpress/core-data@7.43.0':
+    resolution: {integrity: sha512-18YOgbce1nwWN5FFXZ/qMdKlejAAYJI7gyp6EdIbo+ivnrfHL1YT41C3rzbQWw4QsjDF/Zvludb8M81OpA/mUQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18.0.0
@@ -10409,14 +10498,30 @@ packages:
     peerDependencies:
       react: ^18.0.0
 
+  '@wordpress/data@10.43.0':
+    resolution: {integrity: sha512-LKjxBrub1qkMm8Oyj6ynHAGix5eJcJqN9Pq0aX9UYLPjc1T/zkhhAopFL7It2S4muKMNcAHizR+e1eZNA3k4fQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
   '@wordpress/dataviews@13.1.0':
     resolution: {integrity: sha512-nZQux6jhcgKQhkD+eBwC9YojA2xWerutShUvPWyBu6mLhArGWUSYniuX1An8rhSMkm6nwju7Omgui7BdvqJhhw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18.0.0
 
+  '@wordpress/dataviews@14.0.0':
+    resolution: {integrity: sha512-DTfJiwNL+Yt60P4BmLvYLjpd/QeOmJJry/DRdMqcPyt6w98rRFwr32hcbn0FwVkADJXmW8l2Y2vczf01StnZJw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
   '@wordpress/date@5.42.0':
     resolution: {integrity: sha512-iTzp5vkJm3lX2V2vRdu1PK/Z9LNREWGSic5yYNKTxmOXd7FUu93hCb4hfxYReJHRqSq8lQORbvxxF/b3JeM3yA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/date@5.43.0':
+    resolution: {integrity: sha512-8DiFlE7YzP7F/P59Hr6h5fWJxJlvt6eZgU1C7huM9XhANh8Y3dZfepsySL6K7h1yE66SQDSq07cEefFQgJW31g==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/dependency-extraction-webpack-plugin@6.42.0':
@@ -10429,12 +10534,24 @@ packages:
     resolution: {integrity: sha512-p0MjfkaworM9gYrab7JYwikGnQw88PaISdxVI3TiSyloRdlYU1p8UXSGHwn0vk55ty32YhSsPqtr0xMTgtW1xw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/deprecated@4.43.0':
+    resolution: {integrity: sha512-Pxn+nUmCVAaKBiZun2tEVweVdevMvWFWyCRqIqsAKdWCLsD8Uk6o27EwXc1u8BlO65VmK8D2zF9uWKGKfdZbCw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/dom-ready@4.42.0':
     resolution: {integrity: sha512-ujShJCmo9Y6yqX9tD7100M7MwiEPiDsaN2OQzX1vA+2lp099muq73376zv9ISBkK0C8uUbMZzw2B+JTmBiyGtw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/dom-ready@4.43.0':
+    resolution: {integrity: sha512-Y3oNeAdVzw9tACCgL7HuimhpSlhdU5RfRGtLp2kgewWHl5I6tzfi7XypG7FdBmS+dI+j2SaYYdTNPen/kFsZlA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/dom@4.42.0':
     resolution: {integrity: sha512-LRyfQEkAcDyVvFt7pMO9jOVE1X32N9Kef/WBUFfdT0NjPPLHG/iYIDmiyXNrvpxcLrBPxWZqr0jvuFEudlrwXw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/dom@4.43.0':
+    resolution: {integrity: sha512-OxPYbiwW3sCXmImkDjV7TMkoSG3wCB8mA5FQ4cBcXx1ZYjfHn3ZUSSJ7wwb52kJ6dNJ5p8dFNroy7dk8PVtwKQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/e2e-test-utils-playwright@1.42.0':
@@ -10462,8 +10579,16 @@ packages:
     resolution: {integrity: sha512-aSuifJL9MF0xrAynWSWxIuhgagJcVwSWrqIpLwX0DZasQ0LKsJe08SmuDe/z3sgOymGG6cOd/GHv0fLwQe8VFQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/element@6.43.0':
+    resolution: {integrity: sha512-eUWSBXnwO2y6ejg0RsZUnAk0E+tnuuCbCReZsZAgGJZykqek1Rt2hqxtvLZXPyuqzOR2XcR7k4hSf5l5BAJbhA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/escape-html@3.42.0':
     resolution: {integrity: sha512-dykrMeKAxhwfEImrXfTqKREYGJP2qVIU8q3daUNyNLzrOdwhulAlBzUWXH9zYyY5qEQWrWsnjq4M9f77dO0p4w==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/escape-html@3.43.0':
+    resolution: {integrity: sha512-Mo6b0y1vEnj/x7MVp+pe5IYYLs2X5ke5spuncrReO2Qb+iXw/d7694kpMGHyIVzBPj3ekwxEYezirW5OQrppOw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/eslint-plugin@24.4.0':
@@ -10508,6 +10633,10 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
+  '@wordpress/global-styles-engine@1.10.0':
+    resolution: {integrity: sha512-vlvboNnpCZwA5rWC5ptGqY/IzkQ8Hm3xpKtpdKsOXrIhVyXMpQudtW8H6cB7zIK4eTX84pq6yfhGyo6lJUdUSQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/global-styles-engine@1.9.0':
     resolution: {integrity: sha512-dYg1XYyaDQDzFnmlGUUqStdb672VsjfHfi0JZrkuTfSVQ7GjgV2MTmft2S4ZaUx+fIyKzbDWXn8HNVi4apGgcA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -10523,12 +10652,25 @@ packages:
     resolution: {integrity: sha512-isdznPKo+LEAGrP/o6SnWjxKYKn4KNzb5dmpnYPTbLh13gE/p8KctpLyzMsgR2GBXF8soAL+hpXMxxKoTQSabA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/hooks@4.43.0':
+    resolution: {integrity: sha512-BY7GPjEwhOlgkavVak40E3RtA8Z9ehydqTZckRoesMRjXYfxKSzr1C1FT4wAPS5uXM1pNlWivfofMaJjVNQu5w==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/html-entities@4.42.0':
     resolution: {integrity: sha512-uI1vF5+KCdxQiPY4rzkaM1oZY5SX1lvSB+Uxndv2WCmc3lvTwabYos7wfXVYySxHRMOrG6KsqOWDzaK7h/b3NQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/html-entities@4.43.0':
+    resolution: {integrity: sha512-z7C782VfH3E5dWYO4VOtN8EEhzfID2kiJmGTINiVPD8kywxp5BsBU2KJSSPvkUjqOCMNJ2XhkYPgADKi9O1U7A==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/i18n@6.15.0':
     resolution: {integrity: sha512-ZkGJbZIRhtcQmynb1jb+rRXrw9+SSV0y6KE2R4eex6MzFN0PoNKJcjlOtMLiyMsXd5KFYzfzVj14EGsx5XgG/w==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    hasBin: true
+
+  '@wordpress/i18n@6.16.0':
+    resolution: {integrity: sha512-D8yiDLzOrs9Aa4Cc1nm7m2OMilZeG9Qd7zHauMIDQujwHOe9xrOyH9ppDDko6AAWb+GeUYsf5zf2Efu5saLq0w==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     hasBin: true
 
@@ -10544,8 +10686,21 @@ packages:
     peerDependencies:
       react: ^18.0.0
 
+  '@wordpress/icons@12.1.0':
+    resolution: {integrity: sha512-JOEVd94kZQsGYyLhjq1edfaMOTPON/7qUDuzT74uSwSCJ6OiHf3yJHfxMlLOMoh12dQshWPciLVLagkYLCldag==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
   '@wordpress/image-cropper@1.6.0':
     resolution: {integrity: sha512-3ZzJ77kNscc92jLoCd6w9xjgp54CJNkdb/vzobiH5GUfC8H1MXM9yNK18uJhZpCDAtgTC/Oo6HPMP7VDVN2Huw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
+  '@wordpress/image-cropper@1.7.0':
+    resolution: {integrity: sha512-yVY8+V39Jv15HDIAFOLP7wjUeacX5Ws6Tu7bIijak92i0nYfi190u93PS1bIjBWqwLZMh+jwdNu0qS0LHwylBQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18.0.0
@@ -10559,6 +10714,10 @@ packages:
     resolution: {integrity: sha512-Vj7jtNHM4GDHYA07GrL46u0bYF2CARRTOtWK5RRRO7+c2IVTgDEkhZRUmjYNRoBsDw59iwKjDI9h9Kg/nR1cSw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/interactivity@6.43.0':
+    resolution: {integrity: sha512-v+7isar/S6XECBF3NbRr3+PW8lSGo+c8nt80NHqb+LIPQmG6/0xZ7GourL7OZLkY1cRSSqvSokV6zwQ2kfmRhg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/interface@9.27.0':
     resolution: {integrity: sha512-nKjrAi2grZM7of3HP68orGrQJB2nreWrtuxcJ8A1rWzpskQNzInPzRTbH0XcfN0ifmaLeI84h+kZaHrW4z6Bnw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -10568,6 +10727,10 @@ packages:
 
   '@wordpress/is-shallow-equal@5.42.0':
     resolution: {integrity: sha512-o2nEnBeUvGv5vT6uV2ed/7UcFWlSMFmRRtcDqQomPledVOHpAZfrRWawuSFEC61PMFqclp7kGfNLSHfhoG1J+A==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/is-shallow-equal@5.43.0':
+    resolution: {integrity: sha512-KHm4AXUXz+a30RR/bb7gQjwUU7XL5m068BAo3MC2idQXPmYVvq4zooaiVogRvX95R/kOd7m+Au+HLftXPxu77w==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/jest-console@8.42.0':
@@ -10582,8 +10745,18 @@ packages:
     peerDependencies:
       react: ^18.0.0
 
+  '@wordpress/keyboard-shortcuts@5.43.0':
+    resolution: {integrity: sha512-JJThUTTiJZgzzOIYHgK5CHPHwD6plK1O45e/0RpsOEe4vLCuLH0RoVAWoy/9Z4jIxXLGbwE5WdJIQkTStf+KMQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
   '@wordpress/keycodes@4.42.0':
     resolution: {integrity: sha512-QV82RsOYL3qWXxVTU7T6zk5LU1ad4YP6DDH4czQR8mJECoDsblf2gSjYcGDHkPUK30SXJ7/x/ZOnhGkyJSVaKw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/keycodes@4.43.0':
+    resolution: {integrity: sha512-1F0BS9qGwYFGgMgzXFSSoBdVGqpU1mCA9UVQ1wJxi/qTMIH+sQcvD8KGoSMJLvTDjbiFc4axLilYOL7DJ0EG/A==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/latex-to-mathml@1.10.0':
@@ -10618,6 +10791,12 @@ packages:
     peerDependencies:
       react: ^18.0.0
 
+  '@wordpress/notices@5.43.0':
+    resolution: {integrity: sha512-EvYerIJQ9wc5tT/ibfKhqP3Ja75JJpcSUc11zaQECdTpG3leXGIsUBgl9GDFbd70GpDj1ZCU7NmVcTYl+y0b7w==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
   '@wordpress/patterns@2.42.0':
     resolution: {integrity: sha512-OUhnwyD3PkxILegMgbO1OiD8mHRFGO50JywOGjVLTgDDQXjtjLTLfnPo6b2gPy6EMFrraunKoy79g1+TWrEpHw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -10639,6 +10818,13 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
+  '@wordpress/preferences@4.43.0':
+    resolution: {integrity: sha512-di93xiAo2IT0lnAzV6J+3d+HB1vkOKs3eAfo500STGx10akGN1NgOqSmu6O+tdzlViLzz8q1mkIZ0j3KraKkPA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
   '@wordpress/prettier-config@4.42.0':
     resolution: {integrity: sha512-YoOlVxDMZ02+Eg8N9OVItikOLnpLd6C4mi/QwJvlKS7b9sKAQe+ekBugj6y/9w1PkODhMM+Dvxj+dGWq/8TTyA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -10651,12 +10837,26 @@ packages:
     peerDependencies:
       react: ^18.0.0
 
+  '@wordpress/primitives@4.43.0':
+    resolution: {integrity: sha512-lU1vBSDyRkAYFEfbLyzjophDvIVCeQ7uuEXv5dBAbxkSLSsCcX6oLbWSwjkCEHp1R+9UtukLvbmXDdAbDYiEOA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
   '@wordpress/priority-queue@3.42.0':
     resolution: {integrity: sha512-XNi5PWOCz6Y8YSNl7PDNx+CPoADxzRvYhfxCdzJbX4Za5HZi7/qfrIIUI6GIETRPRvWSCI9TZmctRFjBg1mq3Q==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/priority-queue@3.43.0':
+    resolution: {integrity: sha512-sWQ3ibq7/I/Ta4oLDORKLfROcc01CYSUU1t35kxcMUna4I9u5O3gpVp6dAfKAllNPmd2Wn/yVnpFCG4Pu/Q7Ug==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/private-apis@1.42.0':
     resolution: {integrity: sha512-IDpyCszdnBECvkejn2vyGPHn4aWtROFq0yFaVGPAvYCadnlpWsQC0oJodppBOE7sftYiIDnTw6/rnv+mp29/Kg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/private-apis@1.43.0':
+    resolution: {integrity: sha512-ADZB20UjyQgdL43uFkFE9tm49URMRphydi+ngaxbAJnT/3n5x7WSzfXMBqrdQOuBpdy44O9yHz7JtzLXRapkjQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/react-i18n@4.41.0':
@@ -10665,6 +10865,12 @@ packages:
 
   '@wordpress/redux-routine@5.42.0':
     resolution: {integrity: sha512-rT81HPHH8USZHUYb6slGawmhZN71iBB6ACSDK+hWc3PxApTPlOYcc7MzfTEiOzYPGolWfm+NamBNgks9YISEhg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      redux: '>=4'
+
+  '@wordpress/redux-routine@5.43.0':
+    resolution: {integrity: sha512-3QIt7jBhhwhE1AybMeYfeo5Vj7Rn+7l7QBYiqXiWHWBYGEJtI0VXiEjcC34ctTZKdVGBPvYJZUhBbNHOjLtgMw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       redux: '>=4'
@@ -10678,6 +10884,12 @@ packages:
 
   '@wordpress/rich-text@7.42.0':
     resolution: {integrity: sha512-BmX2JZd5a53/FdAjuHJDswQD1YEmHrx8fhf921K8YbP/h043qwfjTPp1FVBxAmXP02QWGrgE2iSZEZWzbG+ACw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
+  '@wordpress/rich-text@7.43.0':
+    resolution: {integrity: sha512-qoCnzUFZVfWLg7iuaqVifPO+y92gRWX+yz3ILKFxxduTHc1Avy9woNsy3nLaS6xgQhxYIUjEgb8jFShb3eR3OQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18.0.0
@@ -10705,8 +10917,16 @@ packages:
     resolution: {integrity: sha512-vaXEGjis5IqvPtSMYZgrT2zg5HwjePrs5fgWCwYfX5r/uiizfkeOSedpTBSH/FLpQQTMMeFsr22DLcuF0qdyeA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/shortcode@4.43.0':
+    resolution: {integrity: sha512-mSpGnX6Wlzd8wx5GED2D188Mxvtc2FrflDPI39Tlysz4OW+9PNAKueRzvcQ7QLwZhIzaDQ8pvonyal5i8PryIQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/style-engine@2.42.0':
     resolution: {integrity: sha512-mrqmz7Ldp5d150oIQdoMvMRFtWXHZbkoeOYKpxPOeo2EwNldkU5zQSkU196/Z7nFvMNKr9yMt+OgnpWTIZvpcg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/style-engine@2.43.0':
+    resolution: {integrity: sha512-pP+HHwq8Rbv2vfXBO3aMcybxQnjX7nKqELGMzHDT3s3oRH8cyFzuuVbvkDTlfAF//MJx+Jg+zUzBFQu1mQfbeQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/stylelint-config@23.34.0':
@@ -10719,6 +10939,21 @@ packages:
   '@wordpress/sync@1.42.0':
     resolution: {integrity: sha512-xCbWUEBvtWEELMtcI1YL5gdncwf//cQsu/9D7zQZJUGvckHXPkCjeO7VEbj22kNfyRu633F0iDO8H8uwaf0Tug==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/sync@1.43.0':
+    resolution: {integrity: sha512-AbN6qS4OTP9zYwN6n/YLtuaq+o5rfGG8c8aXH+3LwBsGrQC1MyLmohMTGD17ptwTrXvHbrOpVhDMhneg1JMOYw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/theme@0.10.0':
+    resolution: {integrity: sha512-U8CaRvGzeQtFfGQFsKarcbzPEH+jfXJmpOlIpt4bq2goW9CgeWFlDC29p0oyzoMn1Ga9hX+c8ay3nUgSbhmSSA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+      stylelint: '>=16.8.2'
+    peerDependenciesMeta:
+      stylelint:
+        optional: true
 
   '@wordpress/theme@0.9.0':
     resolution: {integrity: sha512-jxskNZVvWHIswQvWvswaNIAkBpXwdFcocBYxTWQnYgvb0QAEYsKsnqYMulZPrz/Dk4c+GF7ptwdLxb3rry9tcg==}
@@ -10735,6 +10970,17 @@ packages:
     resolution: {integrity: sha512-s7fdwYf+1CRQfBHWzpb56wGWEMjF/EQW/c7k7imuPURhjXfOHDD7R7zESiLt0q6hovOJPFialZJcrKXi/KNLJw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/token-list@3.43.0':
+    resolution: {integrity: sha512-hNbN9Mrt2F14BguLVxQ2AtoO1gTTZtOuKJJ7D4c/fHCNh7QiSV03A/Zc629WIPIfgfIt4diASMVQpJ3hvKaUbw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/ui@0.10.0':
+    resolution: {integrity: sha512-HnS8/yCxcgpoVOw0ssiKjFa0WfGbC3BDYeDaitE9iLPOUtk1YxuuljKcXt21T6BZvtV1f/8SKhIUOqTwDMWo2Q==}
+    engines: {node: '>=20.10.0', npm: '>=10.2.3'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
   '@wordpress/ui@0.9.0':
     resolution: {integrity: sha512-PXx0CU5ngJOaC69ylhyyS33Ac4njVudGMkrPjXuRd6cXZeizD3q6KO0ws1ECtm4FYlrWv5YvYyNhT5salP9hTg==}
     engines: {node: '>=20.10.0', npm: '>=10.2.3'}
@@ -10746,8 +10992,19 @@ packages:
     resolution: {integrity: sha512-FczZFHqFY0R5z2PyYEa/Dsc7mR2PhWAX05at274m0Z/wlPeOx2VnZn0L5Vs4mDEOlF13r17Mn+7VRLtjm5lxTQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/undo-manager@1.43.0':
+    resolution: {integrity: sha512-G1hP30a1iV6QaUQ+oouUgFN2VetBVcMPmL+zD04TO1Gs0Dq+4Dgego7/GFuOPBZWO2qiuXTMJUUmi1wO6FSh9A==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/upload-media@0.27.0':
     resolution: {integrity: sha512-p14rxOwpr5URUpqKPDhg+lIPhEek9d0XjvXOL8PPEAB0RcaBF6utBrmMtdxTdRfOqbQ4KBoIM5NrkLrBT6h0og==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
+  '@wordpress/upload-media@0.28.0':
+    resolution: {integrity: sha512-t4iGWFVEObjkozYvRQ/y0j/BKpQCo3kqv2TUHkhq0vd26rse3vuFQPCxhgfJJfA1YIM8Wl726WApnhcvvj7/5Q==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18.0.0
@@ -10757,18 +11014,34 @@ packages:
     resolution: {integrity: sha512-Y1aeKxfTBOt6yvu5ZbqBAyYm6vgxVcjWpLrqiLGg7qpbZuti+Ixcmlj2p67glodfHMx1/eA/BOpfRas3Y/huzA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/url@4.43.0':
+    resolution: {integrity: sha512-FFq/KZUlhAszI9y232BpQ83+58CtRV5M0SFuv7pQq+DxNDuWNHp8gjdX9WOnHkO/MrKAyVTI0jX9YoWF2RNEZw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/viewport@6.42.0':
     resolution: {integrity: sha512-HvKOUx5ZWLV85TNG4VupvssqcTB5uj1oCLxnpXO+kxUJIYXUADozAlqpNbZlPkp1DqT/ApVnvDtX2ysTpx9GYQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18.0.0
 
+  '@wordpress/views@1.10.0':
+    resolution: {integrity: sha512-YDnZqL/Hh7qwyLRvjKH5ZnOz1O8lt2/MNQMloLAfizHHsEQO4LeWyzRqHFvfw104FEqFyvsgqgVoMtAEAeYdrA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/vips@1.2.0':
     resolution: {integrity: sha512-7yYYPdSUqeuewfY7VEshC3h3sJ2cd8ZSfHWQdmwXlUcYJrewxNNpzcQCGF9Wd/XVv8l6F9enfegV4NzQqqC6jQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/vips@1.3.0':
+    resolution: {integrity: sha512-ECQ8iFLRRsMI71+wkBW41+5MRUfCl8AWWOSQ4iskTAqzW2G0LpldNj0J6noX8lrq7MZkCpCRWUMPE626m9odPA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/warning@3.42.0':
     resolution: {integrity: sha512-LMsbWI57IkVRoco+HTQezSzf3FW97AJH3QllwQdk+Ge5y2mJ2jkfIgwZP7uDeMozA1HVUAW+TgmybLloS9xHzg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/warning@3.43.0':
+    resolution: {integrity: sha512-hZn++Njsops73oG2DHpjgriUkHTgk1ykvZtHEDllPSNx5Zf6S8KJ00kcToHjIj/4p1iiDjag2zSX5Yi9ySJHvg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/widgets@4.42.0':
@@ -10782,8 +11055,16 @@ packages:
     resolution: {integrity: sha512-H27okPtQPwgvuLNijYBRjFTbPx9ogSCKvly1/Ps/FFJ8xv1YCL/fPcSFwQ5limXikX0gr4o5DN9PbF22jvUe8A==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/wordcount@4.43.0':
+    resolution: {integrity: sha512-kz1qrK57bkyoPYKFVkHln09HCUH2D4YRxMrMT02VHypwdjUQBN23R/bkzxhIy/Vl5k1yLjeYTRB2pWSYyWle/A==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/worker-threads@1.2.0':
     resolution: {integrity: sha512-o2fsT5aphF5yzrLVLnzo/pG8DHHAayBi19+nhnsWoMthWTF4L1apTsc6ezDTL0d5Th3PF2WmVbLugdkPTPYCqA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/worker-threads@1.3.0':
+    resolution: {integrity: sha512-V0LEupaw1AqO3BX6FtFBpVs/UYYjBkbc2u3ODl6syHT+ojRhfHahE7S+JX9z131wDwXqMFX36c/d+YS3PkMsyw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@xmldom/xmldom@0.9.9':
@@ -14281,6 +14562,9 @@ packages:
 
   lodash.uniqby@4.5.0:
     resolution: {integrity: sha512-IRt7cfTtHy6f1aRVA5n7kT8rgN3N1nH6MOWLcHfpWG2SH19E3JksLK38MktLxZDhlAjCP9jpIXkOnRXlu6oByQ==}
+
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
@@ -19112,6 +19396,17 @@ snapshots:
       tabbable: 6.4.0
       use-sync-external-store: 1.6.0(react@18.3.1)
 
+  '@base-ui/react@1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@base-ui/utils': 0.2.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/react-dom': 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/utils': 0.2.11
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tabbable: 6.4.0
+      use-sync-external-store: 1.6.0(react@18.3.1)
+
   '@base-ui/utils@0.2.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.6
@@ -19124,6 +19419,15 @@ snapshots:
       '@types/react': 18.3.28
 
   '@base-ui/utils@0.2.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@floating-ui/utils': 0.2.11
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      reselect: 5.1.1
+      use-sync-external-store: 1.6.0(react@18.3.1)
+
+  '@base-ui/utils@0.2.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@floating-ui/utils': 0.2.11
@@ -22809,7 +23113,7 @@ snapshots:
     dependencies:
       '@types/lodash': 4.17.20
       '@types/react': 18.3.28
-      lodash: 4.18.1
+      lodash: 4.17.23
       prop-types: 15.8.1
       react: 18.3.1
 
@@ -22829,7 +23133,7 @@ snapshots:
       classnames: 2.5.1
       d3-path: 1.0.9
       d3-shape: 1.3.7
-      lodash: 4.18.1
+      lodash: 4.17.23
       prop-types: 15.8.1
       react: 18.3.1
 
@@ -22838,7 +23142,7 @@ snapshots:
       '@types/lodash': 4.17.20
       '@types/react': 18.3.28
       classnames: 2.5.1
-      lodash: 4.18.1
+      lodash: 4.17.23
       prop-types: 15.8.1
       react: 18.3.1
       reduce-css-calc: 1.3.0
@@ -22905,7 +23209,7 @@ snapshots:
       classnames: 2.5.1
       d3-interpolate-path: 2.2.1
       d3-shape: 2.1.0
-      lodash: 4.18.1
+      lodash: 4.17.23
       mitt: 2.1.0
       prop-types: 15.8.1
       react: 18.3.1
@@ -23113,6 +23417,11 @@ snapshots:
       '@wordpress/dom-ready': 4.42.0
       '@wordpress/i18n': 6.15.0
 
+  '@wordpress/a11y@4.43.0':
+    dependencies:
+      '@wordpress/dom-ready': 4.43.0
+      '@wordpress/i18n': 6.16.0
+
   '@wordpress/admin-ui@1.10.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)':
     dependencies:
       '@wordpress/base-styles': 6.18.0
@@ -23163,9 +23472,16 @@ snapshots:
       '@wordpress/i18n': 6.15.0
       '@wordpress/url': 4.42.0
 
+  '@wordpress/api-fetch@7.43.0':
+    dependencies:
+      '@wordpress/i18n': 6.16.0
+      '@wordpress/url': 4.43.0
+
   '@wordpress/asset-loader@1.8.0': {}
 
   '@wordpress/autop@4.42.0': {}
+
+  '@wordpress/autop@4.43.0': {}
 
   '@wordpress/babel-plugin-import-jsx-pragma@5.42.0(@babel/core@7.29.0)':
     dependencies:
@@ -23189,7 +23505,11 @@ snapshots:
 
   '@wordpress/base-styles@6.18.0': {}
 
+  '@wordpress/base-styles@6.19.0': {}
+
   '@wordpress/blob@4.42.0': {}
+
+  '@wordpress/blob@4.43.0': {}
 
   '@wordpress/block-editor@15.15.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)':
     dependencies:
@@ -23357,6 +23677,69 @@ snapshots:
       '@wordpress/url': 4.42.0
       '@wordpress/warning': 3.42.0
       '@wordpress/wordcount': 4.42.0
+      change-case: 4.1.2
+      clsx: 2.1.1
+      colord: 2.9.3
+      deepmerge: 4.3.1
+      diff: 4.0.4
+      fast-deep-equal: 3.1.3
+      memize: 2.1.1
+      parsel-js: 1.2.2
+      postcss: 8.5.6
+      postcss-prefix-selector: 1.16.1(postcss@8.5.6)
+      postcss-urlrebase: 1.4.0(postcss@8.5.6)
+      react: 18.3.1
+      react-autosize-textarea: 7.1.0(patch_hash=5c09e1dee59caaaba3871f9d722f93e56b41169db486b059597e8f8c788aa464)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      react-easy-crop: 5.5.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      remove-accents: 0.5.0
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - stylelint
+      - supports-color
+
+  '@wordpress/block-editor@15.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)':
+    dependencies:
+      '@react-spring/web': 9.7.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/a11y': 4.43.0
+      '@wordpress/api-fetch': 7.43.0
+      '@wordpress/base-styles': 6.19.0
+      '@wordpress/blob': 4.43.0
+      '@wordpress/block-serialization-default-parser': 5.43.0
+      '@wordpress/blocks': 15.16.0(react@18.3.1)
+      '@wordpress/commands': 1.43.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/components': 32.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.43.0(react@18.3.1)
+      '@wordpress/data': 10.43.0(react@18.3.1)
+      '@wordpress/dataviews': 14.0.0(react@18.3.1)(stylelint@17.5.0)
+      '@wordpress/date': 5.43.0
+      '@wordpress/deprecated': 4.43.0
+      '@wordpress/dom': 4.43.0
+      '@wordpress/element': 6.43.0
+      '@wordpress/escape-html': 3.43.0
+      '@wordpress/global-styles-engine': 1.10.0(react@18.3.1)
+      '@wordpress/hooks': 4.43.0
+      '@wordpress/html-entities': 4.43.0
+      '@wordpress/i18n': 6.16.0
+      '@wordpress/icons': 12.1.0(react@18.3.1)
+      '@wordpress/image-cropper': 1.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/interactivity': 6.43.0
+      '@wordpress/is-shallow-equal': 5.43.0
+      '@wordpress/keyboard-shortcuts': 5.43.0(react@18.3.1)
+      '@wordpress/keycodes': 4.43.0
+      '@wordpress/notices': 5.43.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/preferences': 4.43.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/priority-queue': 3.43.0
+      '@wordpress/private-apis': 1.43.0
+      '@wordpress/rich-text': 7.43.0(react@18.3.1)
+      '@wordpress/style-engine': 2.43.0
+      '@wordpress/token-list': 3.43.0
+      '@wordpress/upload-media': 0.28.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/url': 4.43.0
+      '@wordpress/warning': 3.43.0
+      '@wordpress/wordcount': 4.43.0
       change-case: 4.1.2
       clsx: 2.1.1
       colord: 2.9.3
@@ -23553,6 +23936,8 @@ snapshots:
 
   '@wordpress/block-serialization-default-parser@5.42.0': {}
 
+  '@wordpress/block-serialization-default-parser@5.43.0': {}
+
   '@wordpress/blocks@15.15.0(react@18.3.1)':
     dependencies:
       '@wordpress/autop': 4.42.0
@@ -23570,6 +23955,36 @@ snapshots:
       '@wordpress/rich-text': 7.42.0(react@18.3.1)
       '@wordpress/shortcode': 4.42.0
       '@wordpress/warning': 3.42.0
+      change-case: 4.1.2
+      colord: 2.9.3
+      fast-deep-equal: 3.1.3
+      hpq: 1.4.0
+      is-plain-object: 5.0.0
+      memize: 2.1.1
+      react: 18.3.1
+      react-is: 18.3.1
+      remove-accents: 0.5.0
+      showdown: 1.9.1
+      simple-html-tokenizer: 0.5.11
+      uuid: 9.0.1(patch_hash=87a713b75995ed86c0ecd0cadfd1b9f85092ca16fdff7132ff98b62fc3cf2db0)
+
+  '@wordpress/blocks@15.16.0(react@18.3.1)':
+    dependencies:
+      '@wordpress/autop': 4.43.0
+      '@wordpress/blob': 4.43.0
+      '@wordpress/block-serialization-default-parser': 5.43.0
+      '@wordpress/data': 10.43.0(react@18.3.1)
+      '@wordpress/deprecated': 4.43.0
+      '@wordpress/dom': 4.43.0
+      '@wordpress/element': 6.43.0
+      '@wordpress/hooks': 4.43.0
+      '@wordpress/html-entities': 4.43.0
+      '@wordpress/i18n': 6.16.0
+      '@wordpress/is-shallow-equal': 5.43.0
+      '@wordpress/private-apis': 1.43.0
+      '@wordpress/rich-text': 7.43.0(react@18.3.1)
+      '@wordpress/shortcode': 4.43.0
+      '@wordpress/warning': 3.43.0
       change-case: 4.1.2
       colord: 2.9.3
       fast-deep-equal: 3.1.3
@@ -23742,6 +24157,28 @@ snapshots:
       - '@types/react-dom'
       - supports-color
 
+  '@wordpress/commands@1.43.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/base-styles': 6.19.0
+      '@wordpress/components': 32.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/data': 10.43.0(react@18.3.1)
+      '@wordpress/element': 6.43.0
+      '@wordpress/i18n': 6.16.0
+      '@wordpress/icons': 12.1.0(react@18.3.1)
+      '@wordpress/keyboard-shortcuts': 5.43.0(react@18.3.1)
+      '@wordpress/preferences': 4.43.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/private-apis': 1.43.0
+      '@wordpress/warning': 3.43.0
+      clsx: 2.1.1
+      cmdk: 1.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - supports-color
+
   '@wordpress/components@32.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@ariakit/react': 0.4.22(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -23799,6 +24236,63 @@ snapshots:
       - '@emotion/is-prop-valid'
       - supports-color
 
+  '@wordpress/components@32.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@ariakit/react': 0.4.22(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@date-fns/utc': 2.1.1
+      '@emotion/cache': 11.14.0
+      '@emotion/css': 11.13.5
+      '@emotion/react': 11.14.0(@types/react@18.3.28)(react@18.3.1)
+      '@emotion/serialize': 1.3.3
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)
+      '@emotion/utils': 1.4.2
+      '@floating-ui/react-dom': 2.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/gradient-parser': 1.1.0
+      '@types/highlight-words-core': 1.2.1
+      '@types/react': 18.3.28
+      '@use-gesture/react': 10.3.1(react@18.3.1)
+      '@wordpress/a11y': 4.43.0
+      '@wordpress/base-styles': 6.19.0
+      '@wordpress/compose': 7.43.0(react@18.3.1)
+      '@wordpress/date': 5.43.0
+      '@wordpress/deprecated': 4.43.0
+      '@wordpress/dom': 4.43.0
+      '@wordpress/element': 6.43.0
+      '@wordpress/escape-html': 3.43.0
+      '@wordpress/hooks': 4.43.0
+      '@wordpress/html-entities': 4.43.0
+      '@wordpress/i18n': 6.16.0
+      '@wordpress/icons': 12.1.0(react@18.3.1)
+      '@wordpress/is-shallow-equal': 5.43.0
+      '@wordpress/keycodes': 4.43.0
+      '@wordpress/primitives': 4.43.0(react@18.3.1)
+      '@wordpress/private-apis': 1.43.0
+      '@wordpress/rich-text': 7.43.0(react@18.3.1)
+      '@wordpress/warning': 3.43.0
+      change-case: 4.1.2
+      clsx: 2.1.1
+      colord: 2.9.3
+      csstype: 3.2.3
+      date-fns: 3.6.0
+      deepmerge: 4.3.1
+      fast-deep-equal: 3.1.3
+      framer-motion: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      gradient-parser: 1.1.1
+      highlight-words-core: 1.2.3
+      is-plain-object: 5.0.0
+      memize: 2.1.1
+      path-to-regexp: 6.3.0
+      re-resizable: 6.11.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-colorful: 5.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-day-picker: 9.14.0(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      remove-accents: 0.5.0
+      uuid: 9.0.1(patch_hash=87a713b75995ed86c0ecd0cadfd1b9f85092ca16fdff7132ff98b62fc3cf2db0)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - supports-color
+
   '@wordpress/compose@7.42.0(react@18.3.1)':
     dependencies:
       '@types/mousetrap': 1.6.15
@@ -23809,6 +24303,21 @@ snapshots:
       '@wordpress/keycodes': 4.42.0
       '@wordpress/priority-queue': 3.42.0
       '@wordpress/undo-manager': 1.42.0
+      change-case: 4.1.2
+      mousetrap: 1.6.5
+      react: 18.3.1
+      use-memo-one: 1.1.3(react@18.3.1)
+
+  '@wordpress/compose@7.43.0(react@18.3.1)':
+    dependencies:
+      '@types/mousetrap': 1.6.15
+      '@wordpress/deprecated': 4.43.0
+      '@wordpress/dom': 4.43.0
+      '@wordpress/element': 6.43.0
+      '@wordpress/is-shallow-equal': 5.43.0
+      '@wordpress/keycodes': 4.43.0
+      '@wordpress/priority-queue': 3.43.0
+      '@wordpress/undo-manager': 1.43.0
       change-case: 4.1.2
       mousetrap: 1.6.5
       react: 18.3.1
@@ -23910,6 +24419,38 @@ snapshots:
       - stylelint
       - supports-color
 
+  '@wordpress/core-data@7.43.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)':
+    dependencies:
+      '@wordpress/api-fetch': 7.43.0
+      '@wordpress/block-editor': 15.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
+      '@wordpress/blocks': 15.16.0(react@18.3.1)
+      '@wordpress/compose': 7.43.0(react@18.3.1)
+      '@wordpress/data': 10.43.0(react@18.3.1)
+      '@wordpress/deprecated': 4.43.0
+      '@wordpress/element': 6.43.0
+      '@wordpress/html-entities': 4.43.0
+      '@wordpress/i18n': 6.16.0
+      '@wordpress/is-shallow-equal': 5.43.0
+      '@wordpress/private-apis': 1.43.0
+      '@wordpress/rich-text': 7.43.0(react@18.3.1)
+      '@wordpress/sync': 1.43.0
+      '@wordpress/undo-manager': 1.43.0
+      '@wordpress/url': 4.43.0
+      '@wordpress/warning': 3.43.0
+      change-case: 4.1.2
+      equivalent-key-map: 0.2.2
+      fast-deep-equal: 3.1.3
+      memize: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      uuid: 9.0.1(patch_hash=87a713b75995ed86c0ecd0cadfd1b9f85092ca16fdff7132ff98b62fc3cf2db0)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - stylelint
+      - supports-color
+
   '@wordpress/data-controls@4.42.0(react@18.3.1)':
     dependencies:
       '@wordpress/api-fetch': 7.42.0
@@ -23926,6 +24467,24 @@ snapshots:
       '@wordpress/priority-queue': 3.42.0
       '@wordpress/private-apis': 1.42.0
       '@wordpress/redux-routine': 5.42.0(redux@5.0.1)
+      deepmerge: 4.3.1
+      equivalent-key-map: 0.2.2
+      is-plain-object: 5.0.0
+      is-promise: 4.0.0
+      react: 18.3.1
+      redux: 5.0.1
+      rememo: 4.0.2
+      use-memo-one: 1.1.3(react@18.3.1)
+
+  '@wordpress/data@10.43.0(react@18.3.1)':
+    dependencies:
+      '@wordpress/compose': 7.43.0(react@18.3.1)
+      '@wordpress/deprecated': 4.43.0
+      '@wordpress/element': 6.43.0
+      '@wordpress/is-shallow-equal': 5.43.0
+      '@wordpress/priority-queue': 3.43.0
+      '@wordpress/private-apis': 1.43.0
+      '@wordpress/redux-routine': 5.43.0(redux@5.0.1)
       deepmerge: 4.3.1
       equivalent-key-map: 0.2.2
       is-plain-object: 5.0.0
@@ -24035,9 +24594,65 @@ snapshots:
       - stylelint
       - supports-color
 
+  '@wordpress/dataviews@14.0.0(react@18.3.1)(stylelint@17.5.0)':
+    dependencies:
+      '@ariakit/react': 0.4.22(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/base-styles': 6.19.0
+      '@wordpress/components': 32.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.43.0(react@18.3.1)
+      '@wordpress/data': 10.43.0(react@18.3.1)
+      '@wordpress/deprecated': 4.43.0
+      '@wordpress/element': 6.43.0
+      '@wordpress/i18n': 6.16.0
+      '@wordpress/icons': 12.1.0(react@18.3.1)
+      '@wordpress/keycodes': 4.43.0
+      '@wordpress/primitives': 4.43.0(react@18.3.1)
+      '@wordpress/private-apis': 1.43.0
+      '@wordpress/ui': 0.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
+      '@wordpress/warning': 3.43.0
+      clsx: 2.1.1
+      react: 18.3.1
+      remove-accents: 0.5.0
+    optionalDependencies:
+      '@base-ui/react': 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@emotion/cache': 11.14.0
+      '@emotion/css': 11.13.5
+      '@emotion/react': 11.14.0(react@18.3.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(react@18.3.1))(react@18.3.1)
+      '@emotion/utils': 1.4.2
+      '@floating-ui/react-dom': 2.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@use-gesture/react': 10.3.1(react@18.3.1)
+      '@wordpress/date': 5.43.0
+      '@wordpress/hooks': 4.43.0
+      change-case: 4.1.2
+      colord: 2.9.3
+      date-fns: 4.1.0
+      deepmerge: 4.3.1
+      fast-deep-equal: 3.1.3
+      framer-motion: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      highlight-words-core: 1.2.3
+      is-plain-object: 5.0.0
+      memize: 2.1.1
+      react-colorful: 5.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-day-picker: 9.14.0(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      use-memo-one: 1.1.3(react@18.3.1)
+      uuid: 9.0.1(patch_hash=87a713b75995ed86c0ecd0cadfd1b9f85092ca16fdff7132ff98b62fc3cf2db0)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - stylelint
+      - supports-color
+
   '@wordpress/date@5.42.0':
     dependencies:
       '@wordpress/deprecated': 4.42.0
+      moment: 2.30.1
+      moment-timezone: 0.5.48
+
+  '@wordpress/date@5.43.0':
+    dependencies:
+      '@wordpress/deprecated': 4.43.0
       moment: 2.30.1
       moment-timezone: 0.5.48
 
@@ -24050,11 +24665,21 @@ snapshots:
     dependencies:
       '@wordpress/hooks': 4.42.0
 
+  '@wordpress/deprecated@4.43.0':
+    dependencies:
+      '@wordpress/hooks': 4.43.0
+
   '@wordpress/dom-ready@4.42.0': {}
+
+  '@wordpress/dom-ready@4.43.0': {}
 
   '@wordpress/dom@4.42.0':
     dependencies:
       '@wordpress/deprecated': 4.42.0
+
+  '@wordpress/dom@4.43.0':
+    dependencies:
+      '@wordpress/deprecated': 4.43.0
 
   '@wordpress/e2e-test-utils-playwright@1.42.0(@playwright/test@1.58.2)(@types/node@24.12.0)':
     dependencies:
@@ -24410,7 +25035,19 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@wordpress/element@6.43.0':
+    dependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+      '@wordpress/escape-html': 3.43.0
+      change-case: 4.1.2
+      is-plain-object: 5.0.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@wordpress/escape-html@3.42.0': {}
+
+  '@wordpress/escape-html@3.43.0': {}
 
   '@wordpress/eslint-plugin@24.4.0(@babel/core@7.29.0)(eslint-config-prettier@10.1.8(eslint@9.39.4))(eslint-plugin-import@2.32.0)(eslint-plugin-jest@29.15.0(eslint@9.39.4)(jest@30.3.0)(typescript@5.9.3))(eslint-plugin-jsdoc@62.8.0(eslint@9.39.4))(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.4))(eslint-plugin-playwright@2.10.0(eslint@9.39.4))(eslint-plugin-prettier@5.5.5(eslint-config-prettier@10.1.8(eslint@9.39.4))(eslint@9.39.4)(wp-prettier@3.0.3))(eslint-plugin-react-hooks@7.0.1(eslint@9.39.4))(eslint-plugin-react@7.37.5(eslint@9.39.4))(eslint@9.39.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0(typescript@5.9.3))(typescript@5.9.3)(wp-prettier@3.0.3)':
     dependencies:
@@ -24588,6 +25225,20 @@ snapshots:
       - stylelint
       - supports-color
 
+  '@wordpress/global-styles-engine@1.10.0(react@18.3.1)':
+    dependencies:
+      '@wordpress/blocks': 15.16.0(react@18.3.1)
+      '@wordpress/data': 10.43.0(react@18.3.1)
+      '@wordpress/i18n': 6.16.0
+      '@wordpress/style-engine': 2.43.0
+      colord: 2.9.3
+      deepmerge: 4.3.1
+      fast-deep-equal: 3.1.3
+      is-plain-object: 5.0.0
+      memize: 2.1.1
+    transitivePeerDependencies:
+      - react
+
   '@wordpress/global-styles-engine@1.9.0(react@18.3.1)':
     dependencies:
       '@wordpress/blocks': 15.15.0(react@18.3.1)
@@ -24694,12 +25345,24 @@ snapshots:
 
   '@wordpress/hooks@4.42.0': {}
 
+  '@wordpress/hooks@4.43.0': {}
+
   '@wordpress/html-entities@4.42.0': {}
+
+  '@wordpress/html-entities@4.43.0': {}
 
   '@wordpress/i18n@6.15.0':
     dependencies:
       '@tannin/sprintf': 1.3.3
       '@wordpress/hooks': 4.42.0
+      gettext-parser: 1.4.0
+      memize: 2.1.1
+      tannin: 1.2.0
+
+  '@wordpress/i18n@6.16.0':
+    dependencies:
+      '@tannin/sprintf': 1.3.3
+      '@wordpress/hooks': 4.43.0
       gettext-parser: 1.4.0
       memize: 2.1.1
       tannin: 1.2.0
@@ -24718,11 +25381,32 @@ snapshots:
       change-case: 4.1.2
       react: 18.3.1
 
+  '@wordpress/icons@12.1.0(react@18.3.1)':
+    dependencies:
+      '@wordpress/element': 6.43.0
+      '@wordpress/primitives': 4.43.0(react@18.3.1)
+      change-case: 4.1.2
+      react: 18.3.1
+
   '@wordpress/image-cropper@1.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/components': 32.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/element': 6.42.0
       '@wordpress/i18n': 6.15.0
+      clsx: 2.1.1
+      dequal: 2.0.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-easy-crop: 5.5.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - supports-color
+
+  '@wordpress/image-cropper@1.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/components': 32.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/element': 6.43.0
+      '@wordpress/i18n': 6.16.0
       clsx: 2.1.1
       dequal: 2.0.3
       react: 18.3.1
@@ -24739,6 +25423,11 @@ snapshots:
       es-module-lexer: 1.7.0
 
   '@wordpress/interactivity@6.42.0':
+    dependencies:
+      '@preact/signals': 1.3.4(preact@10.28.2)
+      preact: 10.28.2
+
+  '@wordpress/interactivity@6.43.0':
     dependencies:
       '@preact/signals': 1.3.4(preact@10.28.2)
       preact: 10.28.2
@@ -24793,6 +25482,8 @@ snapshots:
 
   '@wordpress/is-shallow-equal@5.42.0': {}
 
+  '@wordpress/is-shallow-equal@5.43.0': {}
+
   '@wordpress/jest-console@8.42.0(jest@30.3.0)':
     dependencies:
       jest: 30.3.0
@@ -24806,9 +25497,20 @@ snapshots:
       '@wordpress/keycodes': 4.42.0
       react: 18.3.1
 
+  '@wordpress/keyboard-shortcuts@5.43.0(react@18.3.1)':
+    dependencies:
+      '@wordpress/data': 10.43.0(react@18.3.1)
+      '@wordpress/element': 6.43.0
+      '@wordpress/keycodes': 4.43.0
+      react: 18.3.1
+
   '@wordpress/keycodes@4.42.0':
     dependencies:
       '@wordpress/i18n': 6.15.0
+
+  '@wordpress/keycodes@4.43.0':
+    dependencies:
+      '@wordpress/i18n': 6.16.0
 
   '@wordpress/latex-to-mathml@1.10.0':
     dependencies:
@@ -25052,6 +25754,18 @@ snapshots:
       - react-dom
       - supports-color
 
+  '@wordpress/notices@5.43.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/a11y': 4.43.0
+      '@wordpress/components': 32.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/data': 10.43.0(react@18.3.1)
+      clsx: 2.1.1
+      react: 18.3.1
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - react-dom
+      - supports-color
+
   '@wordpress/patterns@2.42.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)':
     dependencies:
       '@wordpress/a11y': 4.42.0
@@ -25165,6 +25879,25 @@ snapshots:
       - '@emotion/is-prop-valid'
       - supports-color
 
+  '@wordpress/preferences@4.43.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/a11y': 4.43.0
+      '@wordpress/base-styles': 6.19.0
+      '@wordpress/components': 32.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.43.0(react@18.3.1)
+      '@wordpress/data': 10.43.0(react@18.3.1)
+      '@wordpress/deprecated': 4.43.0
+      '@wordpress/element': 6.43.0
+      '@wordpress/i18n': 6.16.0
+      '@wordpress/icons': 12.1.0(react@18.3.1)
+      '@wordpress/private-apis': 1.43.0
+      clsx: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - supports-color
+
   '@wordpress/prettier-config@4.42.0(wp-prettier@3.0.3)':
     dependencies:
       prettier: wp-prettier@3.0.3
@@ -25175,11 +25908,23 @@ snapshots:
       clsx: 2.1.1
       react: 18.3.1
 
+  '@wordpress/primitives@4.43.0(react@18.3.1)':
+    dependencies:
+      '@wordpress/element': 6.43.0
+      clsx: 2.1.1
+      react: 18.3.1
+
   '@wordpress/priority-queue@3.42.0':
     dependencies:
       requestidlecallback: 0.3.0
 
+  '@wordpress/priority-queue@3.43.0':
+    dependencies:
+      requestidlecallback: 0.3.0
+
   '@wordpress/private-apis@1.42.0': {}
+
+  '@wordpress/private-apis@1.43.0': {}
 
   '@wordpress/react-i18n@4.41.0':
     dependencies:
@@ -25188,6 +25933,13 @@ snapshots:
       utility-types: 3.11.0
 
   '@wordpress/redux-routine@5.42.0(redux@5.0.1)':
+    dependencies:
+      is-plain-object: 5.0.0
+      is-promise: 4.0.0
+      redux: 5.0.1
+      rungen: 0.3.2
+
+  '@wordpress/redux-routine@5.43.0(redux@5.0.1)':
     dependencies:
       is-plain-object: 5.0.0
       is-promise: 4.0.0
@@ -25279,6 +26031,22 @@ snapshots:
       memize: 2.1.1
       react: 18.3.1
 
+  '@wordpress/rich-text@7.43.0(react@18.3.1)':
+    dependencies:
+      '@wordpress/a11y': 4.43.0
+      '@wordpress/compose': 7.43.0(react@18.3.1)
+      '@wordpress/data': 10.43.0(react@18.3.1)
+      '@wordpress/deprecated': 4.43.0
+      '@wordpress/dom': 4.43.0
+      '@wordpress/element': 6.43.0
+      '@wordpress/escape-html': 3.43.0
+      '@wordpress/i18n': 6.16.0
+      '@wordpress/keycodes': 4.43.0
+      '@wordpress/private-apis': 1.43.0
+      colord: 2.9.3
+      memize: 2.1.1
+      react: 18.3.1
+
   '@wordpress/route@0.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@tanstack/history': 1.161.4
@@ -25319,7 +26087,15 @@ snapshots:
     dependencies:
       memize: 2.1.1
 
+  '@wordpress/shortcode@4.43.0':
+    dependencies:
+      memize: 2.1.1
+
   '@wordpress/style-engine@2.42.0':
+    dependencies:
+      change-case: 4.1.2
+
+  '@wordpress/style-engine@2.43.0':
     dependencies:
       change-case: 4.1.2
 
@@ -25348,6 +26124,29 @@ snapshots:
       y-protocols: 1.0.7(yjs@13.6.29)
       yjs: 13.6.29
 
+  '@wordpress/sync@1.43.0':
+    dependencies:
+      '@wordpress/api-fetch': 7.43.0
+      '@wordpress/hooks': 4.43.0
+      '@wordpress/private-apis': 1.43.0
+      '@wordpress/undo-manager': 1.43.0
+      diff: 8.0.3
+      fast-deep-equal: 3.1.3
+      lib0: 0.2.99
+      y-protocols: 1.0.7(yjs@13.6.29)
+      yjs: 13.6.29
+
+  '@wordpress/theme@0.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)':
+    dependencies:
+      '@wordpress/element': 6.43.0
+      '@wordpress/private-apis': 1.43.0
+      colorjs.io: 0.6.1
+      memize: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      stylelint: 17.5.0
+
   '@wordpress/theme@0.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0(typescript@5.9.3))':
     dependencies:
       '@wordpress/element': 6.42.0
@@ -25371,6 +26170,28 @@ snapshots:
       stylelint: 17.5.0
 
   '@wordpress/token-list@3.42.0': {}
+
+  '@wordpress/token-list@3.43.0': {}
+
+  '@wordpress/ui@0.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)':
+    dependencies:
+      '@base-ui/react': 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/a11y': 4.43.0
+      '@wordpress/compose': 7.43.0(react@18.3.1)
+      '@wordpress/element': 6.43.0
+      '@wordpress/i18n': 6.16.0
+      '@wordpress/icons': 12.1.0(react@18.3.1)
+      '@wordpress/keycodes': 4.43.0
+      '@wordpress/primitives': 4.43.0(react@18.3.1)
+      '@wordpress/private-apis': 1.43.0
+      '@wordpress/theme': 0.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
+      clsx: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tabbable: 6.4.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - stylelint
 
   '@wordpress/ui@0.9.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)':
     dependencies:
@@ -25414,6 +26235,10 @@ snapshots:
     dependencies:
       '@wordpress/is-shallow-equal': 5.42.0
 
+  '@wordpress/undo-manager@1.43.0':
+    dependencies:
+      '@wordpress/is-shallow-equal': 5.43.0
+
   '@wordpress/upload-media@0.27.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/blob': 4.42.0
@@ -25432,7 +26257,29 @@ snapshots:
       - '@emotion/is-prop-valid'
       - supports-color
 
+  '@wordpress/upload-media@0.28.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/blob': 4.43.0
+      '@wordpress/compose': 7.43.0(react@18.3.1)
+      '@wordpress/data': 10.43.0(react@18.3.1)
+      '@wordpress/element': 6.43.0
+      '@wordpress/i18n': 6.16.0
+      '@wordpress/preferences': 4.43.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/private-apis': 1.43.0
+      '@wordpress/url': 4.43.0
+      '@wordpress/vips': 1.3.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      uuid: 9.0.1(patch_hash=87a713b75995ed86c0ecd0cadfd1b9f85092ca16fdff7132ff98b62fc3cf2db0)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - supports-color
+
   '@wordpress/url@4.42.0':
+    dependencies:
+      remove-accents: 0.5.0
+
+  '@wordpress/url@4.43.0':
     dependencies:
       remove-accents: 0.5.0
 
@@ -25443,12 +26290,37 @@ snapshots:
       '@wordpress/element': 6.42.0
       react: 18.3.1
 
+  '@wordpress/views@1.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)':
+    dependencies:
+      '@wordpress/core-data': 7.43.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
+      '@wordpress/data': 10.43.0(react@18.3.1)
+      '@wordpress/dataviews': 14.0.0(react@18.3.1)(stylelint@17.5.0)
+      '@wordpress/element': 6.43.0
+      '@wordpress/preferences': 4.43.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/private-apis': 1.43.0
+      dequal: 2.0.3
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+      - stylelint
+      - supports-color
+
   '@wordpress/vips@1.2.0':
     dependencies:
       '@wordpress/worker-threads': 1.2.0
       wasm-vips: 0.0.16
 
+  '@wordpress/vips@1.3.0':
+    dependencies:
+      '@wordpress/worker-threads': 1.3.0
+      wasm-vips: 0.0.16
+
   '@wordpress/warning@3.42.0': {}
+
+  '@wordpress/warning@3.43.0': {}
 
   '@wordpress/widgets@4.42.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)':
     dependencies:
@@ -25524,7 +26396,13 @@ snapshots:
 
   '@wordpress/wordcount@4.42.0': {}
 
+  '@wordpress/wordcount@4.43.0': {}
+
   '@wordpress/worker-threads@1.2.0':
+    dependencies:
+      comctx: 1.6.1
+
+  '@wordpress/worker-threads@1.3.0':
     dependencies:
       comctx: 1.6.1
 
@@ -29618,6 +30496,8 @@ snapshots:
       lodash._baseiteratee: 4.7.0
       lodash._baseuniq: 4.6.0
 
+  lodash@4.17.23: {}
+
   lodash@4.18.1: {}
 
   log-symbols@1.0.2:
@@ -32631,7 +33511,7 @@ snapshots:
       '@xmldom/xmldom': 0.9.9
       argparse: 2.0.1
       cubic2quad: 1.2.1
-      lodash: 4.18.1
+      lodash: 4.17.23
       microbuffer: 1.0.0
       svgpath: 2.6.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4225,8 +4225,8 @@ importers:
         specifier: ^5.40.0
         version: 5.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/private-apis':
-        specifier: ^1.40.0
-        version: 1.42.0
+        specifier: ^1.43.0
+        version: 1.43.0
       '@wordpress/route':
         specifier: ^0.8.0
         version: 0.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -23428,7 +23428,7 @@ snapshots:
       '@wordpress/components': 32.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/element': 6.42.0
       '@wordpress/i18n': 6.15.0
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/route': 0.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/ui': 0.9.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
       clsx: 2.1.1
@@ -23446,7 +23446,7 @@ snapshots:
       '@wordpress/components': 32.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/element': 6.42.0
       '@wordpress/i18n': 6.15.0
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/route': 0.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/ui': 0.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
       clsx: 2.1.1
@@ -23543,7 +23543,7 @@ snapshots:
       '@wordpress/notices': 5.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/preferences': 4.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/priority-queue': 3.42.0
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/rich-text': 7.42.0(react@18.3.1)
       '@wordpress/style-engine': 2.42.0
       '@wordpress/token-list': 3.42.0
@@ -23606,7 +23606,7 @@ snapshots:
       '@wordpress/notices': 5.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/preferences': 4.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/priority-queue': 3.42.0
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/rich-text': 7.42.0(react@18.3.1)
       '@wordpress/style-engine': 2.42.0
       '@wordpress/token-list': 3.42.0
@@ -23669,7 +23669,7 @@ snapshots:
       '@wordpress/notices': 5.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/preferences': 4.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/priority-queue': 3.42.0
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/rich-text': 7.42.0(react@18.3.1)
       '@wordpress/style-engine': 2.42.0
       '@wordpress/token-list': 3.42.0
@@ -23794,7 +23794,7 @@ snapshots:
       '@wordpress/notices': 5.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/patterns': 2.42.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
       '@wordpress/primitives': 4.42.0(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/reusable-blocks': 5.42.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
       '@wordpress/rich-text': 7.42.0(react@18.3.1)
       '@wordpress/server-side-render': 6.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -23851,7 +23851,7 @@ snapshots:
       '@wordpress/notices': 5.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/patterns': 2.42.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
       '@wordpress/primitives': 4.42.0(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/reusable-blocks': 5.42.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
       '@wordpress/rich-text': 7.42.0(react@18.3.1)
       '@wordpress/server-side-render': 6.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -23908,7 +23908,7 @@ snapshots:
       '@wordpress/notices': 5.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/patterns': 2.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
       '@wordpress/primitives': 4.42.0(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/reusable-blocks': 5.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
       '@wordpress/rich-text': 7.42.0(react@18.3.1)
       '@wordpress/server-side-render': 6.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -23951,7 +23951,7 @@ snapshots:
       '@wordpress/html-entities': 4.42.0
       '@wordpress/i18n': 6.15.0
       '@wordpress/is-shallow-equal': 5.42.0
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/rich-text': 7.42.0(react@18.3.1)
       '@wordpress/shortcode': 4.42.0
       '@wordpress/warning': 3.42.0
@@ -24018,7 +24018,7 @@ snapshots:
       '@wordpress/lazy-editor': 1.8.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
       '@wordpress/notices': 5.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/primitives': 4.42.0(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/route': 0.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/theme': 0.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
       '@wordpress/url': 4.42.0
@@ -24052,7 +24052,7 @@ snapshots:
       '@wordpress/lazy-editor': 1.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
       '@wordpress/notices': 5.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/primitives': 4.42.0(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/route': 0.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/theme': 0.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
       '@wordpress/url': 4.42.0
@@ -24103,7 +24103,7 @@ snapshots:
       '@wordpress/i18n': 6.15.0
       '@wordpress/icons': 12.0.0(react@18.3.1)
       '@wordpress/keyboard-shortcuts': 5.42.0(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/warning': 3.42.0
       clsx: 2.1.1
       cmdk: 1.1.1(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -24124,7 +24124,7 @@ snapshots:
       '@wordpress/i18n': 6.15.0
       '@wordpress/icons': 12.0.0(react@18.3.1)
       '@wordpress/keyboard-shortcuts': 5.42.0(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/warning': 3.42.0
       clsx: 2.1.1
       cmdk: 1.1.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -24145,7 +24145,7 @@ snapshots:
       '@wordpress/i18n': 6.15.0
       '@wordpress/icons': 12.0.0(react@18.3.1)
       '@wordpress/keyboard-shortcuts': 5.42.0(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/warning': 3.42.0
       clsx: 2.1.1
       cmdk: 1.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -24209,7 +24209,7 @@ snapshots:
       '@wordpress/is-shallow-equal': 5.42.0
       '@wordpress/keycodes': 4.42.0
       '@wordpress/primitives': 4.42.0(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/rich-text': 7.42.0(react@18.3.1)
       '@wordpress/warning': 3.42.0
       change-case: 4.1.2
@@ -24335,7 +24335,7 @@ snapshots:
       '@wordpress/html-entities': 4.42.0
       '@wordpress/i18n': 6.15.0
       '@wordpress/is-shallow-equal': 5.42.0
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/rich-text': 7.42.0(react@18.3.1)
       '@wordpress/sync': 1.42.0
       '@wordpress/undo-manager': 1.42.0
@@ -24367,7 +24367,7 @@ snapshots:
       '@wordpress/html-entities': 4.42.0
       '@wordpress/i18n': 6.15.0
       '@wordpress/is-shallow-equal': 5.42.0
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/rich-text': 7.42.0(react@18.3.1)
       '@wordpress/sync': 1.42.0
       '@wordpress/undo-manager': 1.42.0
@@ -24399,7 +24399,7 @@ snapshots:
       '@wordpress/html-entities': 4.42.0
       '@wordpress/i18n': 6.15.0
       '@wordpress/is-shallow-equal': 5.42.0
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/rich-text': 7.42.0(react@18.3.1)
       '@wordpress/sync': 1.42.0
       '@wordpress/undo-manager': 1.42.0
@@ -24465,7 +24465,7 @@ snapshots:
       '@wordpress/element': 6.42.0
       '@wordpress/is-shallow-equal': 5.42.0
       '@wordpress/priority-queue': 3.42.0
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/redux-routine': 5.42.0(redux@5.0.1)
       deepmerge: 4.3.1
       equivalent-key-map: 0.2.2
@@ -24507,7 +24507,7 @@ snapshots:
       '@wordpress/icons': 12.0.0(react@18.3.1)
       '@wordpress/keycodes': 4.42.0
       '@wordpress/primitives': 4.42.0(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/ui': 0.9.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
       '@wordpress/warning': 3.42.0
       clsx: 2.1.1
@@ -24557,7 +24557,7 @@ snapshots:
       '@wordpress/icons': 12.0.0(react@18.3.1)
       '@wordpress/keycodes': 4.42.0
       '@wordpress/primitives': 4.42.0(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/ui': 0.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
       '@wordpress/warning': 3.42.0
       clsx: 2.1.1
@@ -24726,7 +24726,7 @@ snapshots:
       '@wordpress/notices': 5.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/plugins': 7.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/preferences': 4.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/url': 4.42.0
       '@wordpress/viewport': 6.42.0(react@18.3.1)
       '@wordpress/warning': 3.42.0
@@ -24770,7 +24770,7 @@ snapshots:
       '@wordpress/notices': 5.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/plugins': 7.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/preferences': 4.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/url': 4.42.0
       '@wordpress/viewport': 6.42.0(react@18.3.1)
       '@wordpress/warning': 3.42.0
@@ -24814,7 +24814,7 @@ snapshots:
       '@wordpress/notices': 5.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/plugins': 7.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/preferences': 4.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/url': 4.42.0
       '@wordpress/viewport': 6.42.0(react@18.3.1)
       '@wordpress/warning': 3.42.0
@@ -24867,7 +24867,7 @@ snapshots:
       '@wordpress/patterns': 2.42.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
       '@wordpress/plugins': 7.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/preferences': 4.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/reusable-blocks': 5.42.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
       '@wordpress/rich-text': 7.42.0(react@18.3.1)
       '@wordpress/server-side-render': 6.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -24932,7 +24932,7 @@ snapshots:
       '@wordpress/patterns': 2.42.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
       '@wordpress/plugins': 7.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/preferences': 4.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/reusable-blocks': 5.42.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
       '@wordpress/rich-text': 7.42.0(react@18.3.1)
       '@wordpress/server-side-render': 6.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -24997,7 +24997,7 @@ snapshots:
       '@wordpress/patterns': 2.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
       '@wordpress/plugins': 7.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/preferences': 4.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/reusable-blocks': 5.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
       '@wordpress/rich-text': 7.42.0(react@18.3.1)
       '@wordpress/server-side-render': 6.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -25102,7 +25102,7 @@ snapshots:
       '@wordpress/notices': 5.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/patterns': 2.42.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
       '@wordpress/primitives': 4.42.0(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/router': 1.42.0(react@18.3.1)
       '@wordpress/url': 4.42.0
       '@wordpress/warning': 3.42.0
@@ -25142,7 +25142,7 @@ snapshots:
       '@wordpress/notices': 5.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/patterns': 2.42.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
       '@wordpress/primitives': 4.42.0(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/router': 1.42.0(react@18.3.1)
       '@wordpress/url': 4.42.0
       '@wordpress/warning': 3.42.0
@@ -25182,7 +25182,7 @@ snapshots:
       '@wordpress/notices': 5.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/patterns': 2.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
       '@wordpress/primitives': 4.42.0(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/router': 1.42.0(react@18.3.1)
       '@wordpress/url': 4.42.0
       '@wordpress/warning': 3.42.0
@@ -25213,7 +25213,7 @@ snapshots:
       '@wordpress/i18n': 6.15.0
       '@wordpress/icons': 12.0.0(react@18.3.1)
       '@wordpress/latex-to-mathml': 1.10.0
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/rich-text': 7.42.0(react@18.3.1)
       '@wordpress/url': 4.42.0
       react: 18.3.1
@@ -25270,7 +25270,7 @@ snapshots:
       '@wordpress/i18n': 6.15.0
       '@wordpress/icons': 12.0.0(react@18.3.1)
       '@wordpress/keycodes': 4.42.0
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       change-case: 4.1.2
       clsx: 2.1.1
       colord: 2.9.3
@@ -25300,7 +25300,7 @@ snapshots:
       '@wordpress/i18n': 6.15.0
       '@wordpress/icons': 12.0.0(react@18.3.1)
       '@wordpress/keycodes': 4.42.0
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       change-case: 4.1.2
       clsx: 2.1.1
       colord: 2.9.3
@@ -25330,7 +25330,7 @@ snapshots:
       '@wordpress/i18n': 6.15.0
       '@wordpress/icons': 12.0.0(react@18.3.1)
       '@wordpress/keycodes': 4.42.0
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       change-case: 4.1.2
       clsx: 2.1.1
       colord: 2.9.3
@@ -25529,7 +25529,7 @@ snapshots:
       '@wordpress/element': 6.42.0
       '@wordpress/global-styles-engine': 1.9.0(react@18.3.1)
       '@wordpress/i18n': 6.15.0
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - '@types/react'
@@ -25552,7 +25552,7 @@ snapshots:
       '@wordpress/element': 6.42.0
       '@wordpress/global-styles-engine': 1.9.0(react@18.3.1)
       '@wordpress/i18n': 6.15.0
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - '@types/react'
@@ -25678,7 +25678,7 @@ snapshots:
       '@wordpress/icons': 12.0.0(react@18.3.1)
       '@wordpress/media-fields': 0.7.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
       '@wordpress/notices': 5.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/ui': 0.9.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
       clsx: 2.1.1
       react: 18.3.1
@@ -25704,7 +25704,7 @@ snapshots:
       '@wordpress/icons': 12.0.0(react@18.3.1)
       '@wordpress/media-fields': 0.7.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
       '@wordpress/notices': 5.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/ui': 0.9.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
       clsx: 2.1.1
       react: 18.3.1
@@ -25730,7 +25730,7 @@ snapshots:
       '@wordpress/icons': 12.0.0(react@18.3.1)
       '@wordpress/media-fields': 0.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
       '@wordpress/notices': 5.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/ui': 0.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
       clsx: 2.1.1
       react: 18.3.1
@@ -25781,7 +25781,7 @@ snapshots:
       '@wordpress/i18n': 6.15.0
       '@wordpress/icons': 12.0.0(react@18.3.1)
       '@wordpress/notices': 5.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/url': 4.42.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -25807,7 +25807,7 @@ snapshots:
       '@wordpress/i18n': 6.15.0
       '@wordpress/icons': 12.0.0(react@18.3.1)
       '@wordpress/notices': 5.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/url': 4.42.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -25833,7 +25833,7 @@ snapshots:
       '@wordpress/i18n': 6.15.0
       '@wordpress/icons': 12.0.0(react@18.3.1)
       '@wordpress/notices': 5.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/url': 4.42.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -25871,7 +25871,7 @@ snapshots:
       '@wordpress/element': 6.42.0
       '@wordpress/i18n': 6.15.0
       '@wordpress/icons': 12.0.0(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -25958,7 +25958,7 @@ snapshots:
       '@wordpress/i18n': 6.15.0
       '@wordpress/icons': 12.0.0(react@18.3.1)
       '@wordpress/notices': 5.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/url': 4.42.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -25981,7 +25981,7 @@ snapshots:
       '@wordpress/i18n': 6.15.0
       '@wordpress/icons': 12.0.0(react@18.3.1)
       '@wordpress/notices': 5.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/url': 4.42.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -26004,7 +26004,7 @@ snapshots:
       '@wordpress/i18n': 6.15.0
       '@wordpress/icons': 12.0.0(react@18.3.1)
       '@wordpress/notices': 5.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/url': 4.42.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -26026,7 +26026,7 @@ snapshots:
       '@wordpress/escape-html': 3.42.0
       '@wordpress/i18n': 6.15.0
       '@wordpress/keycodes': 4.42.0
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       colord: 2.9.3
       memize: 2.1.1
       react: 18.3.1
@@ -26051,7 +26051,7 @@ snapshots:
     dependencies:
       '@tanstack/history': 1.161.4
       '@tanstack/react-router': 1.166.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       react: 18.3.1
     transitivePeerDependencies:
       - react-dom
@@ -26060,7 +26060,7 @@ snapshots:
     dependencies:
       '@wordpress/compose': 7.42.0(react@18.3.1)
       '@wordpress/element': 6.42.0
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/url': 4.42.0
       history: 5.3.0
       react: 18.3.1
@@ -26116,7 +26116,7 @@ snapshots:
     dependencies:
       '@wordpress/api-fetch': 7.42.0
       '@wordpress/hooks': 4.42.0
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/undo-manager': 1.42.0
       diff: 8.0.3
       fast-deep-equal: 3.1.3
@@ -26150,7 +26150,7 @@ snapshots:
   '@wordpress/theme@0.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0(typescript@5.9.3))':
     dependencies:
       '@wordpress/element': 6.42.0
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       colorjs.io: 0.6.1
       memize: 2.1.1
       react: 18.3.1
@@ -26161,7 +26161,7 @@ snapshots:
   '@wordpress/theme@0.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)':
     dependencies:
       '@wordpress/element': 6.42.0
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       colorjs.io: 0.6.1
       memize: 2.1.1
       react: 18.3.1
@@ -26203,7 +26203,7 @@ snapshots:
       '@wordpress/icons': 12.0.0(react@18.3.1)
       '@wordpress/keycodes': 4.42.0
       '@wordpress/primitives': 4.42.0(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/theme': 0.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
       clsx: 2.1.1
       react: 18.3.1
@@ -26222,7 +26222,7 @@ snapshots:
       '@wordpress/icons': 12.0.0(react@18.3.1)
       '@wordpress/keycodes': 4.42.0
       '@wordpress/primitives': 4.42.0(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/theme': 0.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)
       clsx: 2.1.1
       react: 18.3.1
@@ -26247,7 +26247,7 @@ snapshots:
       '@wordpress/element': 6.42.0
       '@wordpress/i18n': 6.15.0
       '@wordpress/preferences': 4.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.42.0
+      '@wordpress/private-apis': 1.43.0
       '@wordpress/url': 4.42.0
       '@wordpress/vips': 1.2.0
       react: 18.3.1

--- a/projects/packages/wp-build-polyfills/README.md
+++ b/projects/packages/wp-build-polyfills/README.md
@@ -20,6 +20,7 @@ This package provides those missing packages so that plugins using `@wordpress/b
 | `wp-notices`      | `@wordpress/notices`    | Yes — missing component exports |
 | `wp-private-apis` | `@wordpress/private-apis` | Yes — incomplete allowlist |
 | `wp-theme`        | `@wordpress/theme`      | No — only registered if absent |
+| `wp-views`        | `@wordpress/views`      | No — only registered if absent |
 
 ### Script modules (ESM)
 

--- a/projects/packages/wp-build-polyfills/changelog/update-forms-wp-views-polyfill
+++ b/projects/packages/wp-build-polyfills/changelog/update-forms-wp-views-polyfill
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Update @wordpress/private-apis to v1.43.0 to include @wordpress/views in the core modules allowlist, fixing a crash with latest Gutenberg trunk.

--- a/projects/packages/wp-build-polyfills/package.json
+++ b/projects/packages/wp-build-polyfills/package.json
@@ -38,5 +38,8 @@
 	"optionalDependencies": {
 		"react": "18.3.1",
 		"react-dom": "18.3.1"
+	},
+	"dependencies": {
+		"@wordpress/views": "~1.10.0"
 	}
 }

--- a/projects/packages/wp-build-polyfills/package.json
+++ b/projects/packages/wp-build-polyfills/package.json
@@ -28,7 +28,7 @@
 		"@wordpress/icons": "^12.0.0",
 		"@wordpress/lazy-editor": "^1.6.1",
 		"@wordpress/notices": "^5.40.0",
-		"@wordpress/private-apis": "^1.40.0",
+		"@wordpress/private-apis": "^1.43.0",
 		"@wordpress/route": "^0.8.0",
 		"@wordpress/theme": "^0.9.0",
 		"@wordpress/ui": "^0.9.0",

--- a/projects/packages/wp-build-polyfills/src/class-wp-build-polyfills.php
+++ b/projects/packages/wp-build-polyfills/src/class-wp-build-polyfills.php
@@ -19,7 +19,7 @@ class WP_Build_Polyfills {
 	/**
 	 * Available polyfill handles for classic scripts.
 	 */
-	const SCRIPT_HANDLES = array( 'wp-notices', 'wp-private-apis', 'wp-theme' );
+	const SCRIPT_HANDLES = array( 'wp-notices', 'wp-private-apis', 'wp-theme', 'wp-views' );
 
 	/**
 	 * Available polyfill module IDs.
@@ -140,6 +140,9 @@ class WP_Build_Polyfills {
 			),
 			'wp-theme'        => array(
 				'path' => 'theme',
+			),
+			'wp-views'        => array(
+				'path' => 'views',
 			),
 		);
 

--- a/projects/packages/wp-build-polyfills/webpack.config.js
+++ b/projects/packages/wp-build-polyfills/webpack.config.js
@@ -143,6 +143,11 @@ const classicPolyfills = [
 		packageName: '@wordpress/theme',
 		library: [ 'wp', 'theme' ],
 	},
+	{
+		name: 'views',
+		packageName: '@wordpress/views',
+		library: [ 'wp', 'views' ],
+	},
 ];
 
 const modulePolyfills = [


### PR DESCRIPTION
Resolves FORMS-673

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Adds `@wordpress/views` to polyfills after adding them to DataViews in https://github.com/WordPress/gutenberg/pull/76953/changes
* Bump @wordpress/private-apis to ^1.43.0 to fix allowlist
   * v1.43.0 adds @wordpress/views to the core modules allowlist. Without this, the polyfill force-replaces Gutenberg's wp-private-apis with a version that rejects @wordpress/views, crashing the page.


Fixes:
<img width="4280" height="2456" alt="image" src="https://github.com/user-attachments/assets/8d08e339-727e-422a-8161-5934e5ad363b" />


### Other information
<!-- Check the box below to generate a changelog entry. -->
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Gutenberg `trunk` enabled (just needs [this PR](https://github.com/WordPress/gutenberg/pull/76953/changes))
* Open forms; before it fails, with this PR it opens