### PR TITLE
Hide upgrade menu item on multisite installs

### DIFF
--- a/projects/packages/admin-ui/changelog/fix-hide-upgrade-menu-multisite
+++ b/projects/packages/admin-ui/changelog/fix-hide-upgrade-menu-multisite
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Hide "Upgrade Jetpack" sidebar menu item on multisite installations.

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -252,8 +252,12 @@ class Admin_Menu {
 	 * @return bool True if the upgrade menu should be shown.
 	 */
 	private static function should_show_upgrade_menu() {
-		// Only show to administrators.
+		// Only show to administrators on single-site installs.
 		if ( ! current_user_can( 'manage_options' ) ) {
+			return false;
+		}
+
+		if ( is_multisite() ) {
 			return false;
 		}
 


### PR DESCRIPTION
## Proposed changes

* Hide the "Upgrade Jetpack" sidebar menu item on multisite installations. The upsell is not relevant in multisite environments where plan management is handled at the network level.

### Discussion
p1775143980027909-slack-CDLH4C1UZ

### Other information
- [x] Generate changelog entries for this PR (using AI).

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Set up a multisite environment
* Verify the "Upgrade Jetpack" menu item does not appear in the sidebar
* On a single-site install with a free plan, verify the menu item still appears as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)