### PR TITLE
Sidebar upsell nudge: update visually

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1824,6 +1824,9 @@ importers:
 
   projects/packages/admin-ui:
     devDependencies:
+      '@automattic/jetpack-base-styles':
+        specifier: workspace:*
+        version: link:../../js-packages/base-styles
       '@automattic/jetpack-webpack-config':
         specifier: workspace:*
         version: link:../../js-packages/webpack-config

--- a/projects/packages/admin-ui/changelog/update-sidebar-upsell-visual-update
+++ b/projects/packages/admin-ui/changelog/update-sidebar-upsell-visual-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update design of the sidebar upsell.

--- a/projects/packages/admin-ui/composer.json
+++ b/projects/packages/admin-ui/composer.json
@@ -38,6 +38,10 @@
 		],
 		"test-php": [
 			"@composer phpunit"
+		],
+		"watch": [
+			"Composer\\Config::disableProcessTimeout",
+			"pnpm run watch"
 		]
 	},
 	"repositories": [

--- a/projects/packages/admin-ui/package.json
+++ b/projects/packages/admin-ui/package.json
@@ -25,6 +25,7 @@
 		"extends @wordpress/browserslist-config"
 	],
 	"devDependencies": {
+		"@automattic/jetpack-base-styles": "workspace:*",
 		"@automattic/jetpack-webpack-config": "workspace:*",
 		"@wordpress/browserslist-config": "6.42.0",
 		"sass-embedded": "1.97.3",

--- a/projects/packages/admin-ui/src/admin-ui-upgrade-menu.scss
+++ b/projects/packages/admin-ui/src/admin-ui-upgrade-menu.scss
@@ -12,6 +12,7 @@
 		margin: 2px 4px;
 		max-width: 250px;
 		overflow: hidden;
+		text-align: center;
 		text-overflow: ellipsis;
 		white-space: nowrap;
 	}

--- a/projects/packages/admin-ui/src/admin-ui-upgrade-menu.scss
+++ b/projects/packages/admin-ui/src/admin-ui-upgrade-menu.scss
@@ -10,11 +10,8 @@
 		box-shadow: none !important;
 		color: var(--jp-white) !important;
 		margin: 2px 4px;
-		max-width: 250px;
-		overflow: hidden;
 		text-align: center;
-		text-overflow: ellipsis;
-		white-space: nowrap;
+		text-wrap: pretty;
 	}
 
 	&:hover {

--- a/projects/packages/admin-ui/src/admin-ui-upgrade-menu.scss
+++ b/projects/packages/admin-ui/src/admin-ui-upgrade-menu.scss
@@ -3,19 +3,23 @@
 // Keep the slug in sync with `UPGRADE_MENU_SLUG` at class-admin-menu.php
 $upgrade-menu-slug: jetpack-wpadmin-sidebar-free-plan-upsell-menu-item;
 
-#adminmenu li.#{$upgrade-menu-slug} > a,
-#adminmenu li.#{$upgrade-menu-slug} > a:hover {
-	background: var(--jp-green-40) !important;
-	border-radius: var(--jp-border-radius) !important;
-	box-shadow: none !important;
-	color: var(--jp-white) !important;
-	margin: 2px 4px;
-	max-width: 250px;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
+#adminmenu li.#{$upgrade-menu-slug} > a {
 
-#adminmenu li.#{$upgrade-menu-slug} > a:hover {
-	background: var(--jp-green-30) !important;
+	&,
+	&:hover {
+		background: var(--jp-green-40) !important;
+		border-radius: var(--jp-border-radius) !important;
+		box-shadow: none !important;
+		color: var(--jp-white) !important;
+		margin: 2px 4px;
+		max-width: 250px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	&:hover {
+		background: var(--jp-green-30) !important;
+	}
+
 }

--- a/projects/packages/admin-ui/src/admin-ui-upgrade-menu.scss
+++ b/projects/packages/admin-ui/src/admin-ui-upgrade-menu.scss
@@ -11,7 +11,7 @@
 		color: var(--jp-white) !important;
 		margin: 2px 4px;
 		text-align: center;
-		text-wrap: pretty;
+		text-wrap: balance;
 	}
 
 	&:hover {

--- a/projects/packages/admin-ui/src/admin-ui-upgrade-menu.scss
+++ b/projects/packages/admin-ui/src/admin-ui-upgrade-menu.scss
@@ -9,9 +9,11 @@ $upgrade-menu-slug: jetpack-wpadmin-sidebar-free-plan-upsell-menu-item;
 	border-radius: var(--jp-border-radius) !important;
 	box-shadow: none !important;
 	color: var(--jp-white) !important;
-	font-weight: 600;
-	margin-left: 5px;
-	margin-right: 5px;
+	margin: 2px 4px;
+	max-width: 250px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 #adminmenu li.#{$upgrade-menu-slug} > a:hover {

--- a/projects/packages/admin-ui/src/admin-ui-upgrade-menu.scss
+++ b/projects/packages/admin-ui/src/admin-ui-upgrade-menu.scss
@@ -1,41 +1,19 @@
+@use "@automattic/jetpack-base-styles/root-variables";
+
 // Keep the slug in sync with `UPGRADE_MENU_SLUG` at class-admin-menu.php
 $upgrade-menu-slug: jetpack-wpadmin-sidebar-free-plan-upsell-menu-item;
-$upgrade-menu-default-color: #069e08;
-$upgrade-menu-default-color-schemes: fresh, light, modern;
-$upgrade-menu-special-color-schemes: (
-	coffee: #9ea476,
-	ectoplasm: #a3b745,
-	midnight: #e14d43,
-);
 
-@mixin upgrade-menu-item-link-selector {
-	#adminmenu li.#{$upgrade-menu-slug} > a,
-	#adminmenu li.#{$upgrade-menu-slug} > a:hover {
-		@content;
-	}
-}
-
-@mixin upgrade-menu-item-theme-selector($theme) {
-	body.admin-color-#{$theme} #adminmenu li.#{$upgrade-menu-slug} > a,
-	body.admin-color-#{$theme} #adminmenu li.#{$upgrade-menu-slug} > a:hover {
-		@content;
-	}
-}
-
-@include upgrade-menu-item-link-selector {
+#adminmenu li.#{$upgrade-menu-slug} > a,
+#adminmenu li.#{$upgrade-menu-slug} > a:hover {
+	background: var(--jp-green-40) !important;
+	border-radius: var(--jp-border-radius) !important;
+	box-shadow: none !important;
+	color: var(--jp-white) !important;
 	font-weight: 600;
+	margin-left: 5px;
+	margin-right: 5px;
 }
 
-@each $theme in $upgrade-menu-default-color-schemes {
-
-	@include upgrade-menu-item-theme-selector($theme) {
-		color: $upgrade-menu-default-color !important;
-	}
-}
-
-@each $theme, $color in $upgrade-menu-special-color-schemes {
-
-	@include upgrade-menu-item-theme-selector($theme) {
-		color: $color !important;
-	}
+#adminmenu li.#{$upgrade-menu-slug} > a:hover {
+	background: var(--jp-green-30) !important;
 }

--- a/projects/packages/admin-ui/src/admin-ui-upgrade-menu.scss
+++ b/projects/packages/admin-ui/src/admin-ui-upgrade-menu.scss
@@ -1,9 +1,7 @@
 @use "@automattic/jetpack-base-styles/root-variables";
 
 // Keep the slug in sync with `UPGRADE_MENU_SLUG` at class-admin-menu.php
-$upgrade-menu-slug: jetpack-wpadmin-sidebar-free-plan-upsell-menu-item;
-
-#adminmenu li.#{$upgrade-menu-slug} > a {
+#adminmenu li.jetpack-wpadmin-sidebar-free-plan-upsell-menu-item > a {
 
 	&,
 	&:hover {

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -320,12 +320,11 @@ class Admin_Menu {
 			? \Automattic\Jetpack\Redirect::get_url( self::UPGRADE_MENU_SLUG )
 			: self::UPGRADE_MENU_FALLBACK_URL;
 
-		$menu_title = esc_html__( 'Upgrade Jetpack', 'jetpack-admin-ui' )
-			. ' <span aria-hidden="true">↗</span>';
+		$menu_title = esc_html__( 'Upgrade Jetpack', 'jetpack-admin-ui' );
 
 		add_submenu_page(
 			'jetpack',
-			__( 'Upgrade Jetpack', 'jetpack-admin-ui' ),
+			$menu_title,
 			$menu_title,
 			'manage_options',
 			esc_url( $upgrade_url ),

--- a/projects/plugins/automattic-for-agencies-client/changelog/update-sidebar-upsell-visual-update
+++ b/projects/plugins/automattic-for-agencies-client/changelog/update-sidebar-upsell-visual-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update design of the sidebar upsell.

--- a/projects/plugins/automattic-for-agencies-client/composer.lock
+++ b/projects/plugins/automattic-for-agencies-client/composer.lock
@@ -66,7 +66,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "d71575c86c7f4cec8c3354e21c15db817b966515"
+                "reference": "b85d3fbbc9298316d8cd1d3e35f50a6e0b17c07c"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -118,6 +118,10 @@
                 ],
                 "test-php": [
                     "@composer phpunit"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
                 ]
             },
             "license": [

--- a/projects/plugins/backup/changelog/update-sidebar-upsell-visual-update
+++ b/projects/plugins/backup/changelog/update-sidebar-upsell-visual-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update design of the sidebar upsell.

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -66,7 +66,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "d71575c86c7f4cec8c3354e21c15db817b966515"
+                "reference": "b85d3fbbc9298316d8cd1d3e35f50a6e0b17c07c"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -118,6 +118,10 @@
                 ],
                 "test-php": [
                     "@composer phpunit"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
                 ]
             },
             "license": [

--- a/projects/plugins/beta/changelog/update-sidebar-upsell-visual-update
+++ b/projects/plugins/beta/changelog/update-sidebar-upsell-visual-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update design of the sidebar upsell.

--- a/projects/plugins/beta/composer.lock
+++ b/projects/plugins/beta/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "d71575c86c7f4cec8c3354e21c15db817b966515"
+                "reference": "b85d3fbbc9298316d8cd1d3e35f50a6e0b17c07c"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -64,6 +64,10 @@
                 ],
                 "test-php": [
                     "@composer phpunit"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
                 ]
             },
             "license": [

--- a/projects/plugins/boost/changelog/update-sidebar-upsell-visual-update
+++ b/projects/plugins/boost/changelog/update-sidebar-upsell-visual-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update design of the sidebar upsell.

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -66,7 +66,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "d71575c86c7f4cec8c3354e21c15db817b966515"
+                "reference": "b85d3fbbc9298316d8cd1d3e35f50a6e0b17c07c"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -118,6 +118,10 @@
                 ],
                 "test-php": [
                     "@composer phpunit"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
                 ]
             },
             "license": [

--- a/projects/plugins/classic-theme-helper-plugin/changelog/update-sidebar-upsell-visual-update
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/update-sidebar-upsell-visual-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update design of the sidebar upsell.

--- a/projects/plugins/classic-theme-helper-plugin/composer.lock
+++ b/projects/plugins/classic-theme-helper-plugin/composer.lock
@@ -130,7 +130,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "d71575c86c7f4cec8c3354e21c15db817b966515"
+                "reference": "b85d3fbbc9298316d8cd1d3e35f50a6e0b17c07c"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -182,6 +182,10 @@
                 ],
                 "test-php": [
                     "@composer phpunit"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
                 ]
             },
             "license": [

--- a/projects/plugins/inspect/changelog/update-sidebar-upsell-visual-update
+++ b/projects/plugins/inspect/changelog/update-sidebar-upsell-visual-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update design of the sidebar upsell.

--- a/projects/plugins/inspect/composer.lock
+++ b/projects/plugins/inspect/composer.lock
@@ -66,7 +66,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "d71575c86c7f4cec8c3354e21c15db817b966515"
+                "reference": "b85d3fbbc9298316d8cd1d3e35f50a6e0b17c07c"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -118,6 +118,10 @@
                 ],
                 "test-php": [
                     "@composer phpunit"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
                 ]
             },
             "license": [

--- a/projects/plugins/jetpack/changelog/update-sidebar-upsell-visual-update
+++ b/projects/plugins/jetpack/changelog/update-sidebar-upsell-visual-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+ Update design of the sidebar upsell.

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -199,7 +199,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "d71575c86c7f4cec8c3354e21c15db817b966515"
+                "reference": "b85d3fbbc9298316d8cd1d3e35f50a6e0b17c07c"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -251,6 +251,10 @@
                 ],
                 "test-php": [
                     "@composer phpunit"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
                 ]
             },
             "license": [

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-sidebar-upsell-visual-update
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-sidebar-upsell-visual-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update design of the sidebar upsell.

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -130,7 +130,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "d71575c86c7f4cec8c3354e21c15db817b966515"
+                "reference": "b85d3fbbc9298316d8cd1d3e35f50a6e0b17c07c"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -182,6 +182,10 @@
                 ],
                 "test-php": [
                     "@composer phpunit"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
                 ]
             },
             "license": [

--- a/projects/plugins/paypal-payment-buttons/changelog/update-sidebar-upsell-visual-update
+++ b/projects/plugins/paypal-payment-buttons/changelog/update-sidebar-upsell-visual-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update design of the sidebar upsell.

--- a/projects/plugins/paypal-payment-buttons/composer.lock
+++ b/projects/plugins/paypal-payment-buttons/composer.lock
@@ -66,7 +66,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "d71575c86c7f4cec8c3354e21c15db817b966515"
+                "reference": "b85d3fbbc9298316d8cd1d3e35f50a6e0b17c07c"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -118,6 +118,10 @@
                 ],
                 "test-php": [
                     "@composer phpunit"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
                 ]
             },
             "license": [

--- a/projects/plugins/protect/changelog/update-sidebar-upsell-visual-update
+++ b/projects/plugins/protect/changelog/update-sidebar-upsell-visual-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update design of the sidebar upsell.

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -135,7 +135,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "d71575c86c7f4cec8c3354e21c15db817b966515"
+                "reference": "b85d3fbbc9298316d8cd1d3e35f50a6e0b17c07c"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -187,6 +187,10 @@
                 ],
                 "test-php": [
                     "@composer phpunit"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
                 ]
             },
             "license": [

--- a/projects/plugins/search/changelog/update-sidebar-upsell-visual-update
+++ b/projects/plugins/search/changelog/update-sidebar-upsell-visual-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update design of the sidebar upsell.

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -66,7 +66,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "d71575c86c7f4cec8c3354e21c15db817b966515"
+                "reference": "b85d3fbbc9298316d8cd1d3e35f50a6e0b17c07c"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -118,6 +118,10 @@
                 ],
                 "test-php": [
                     "@composer phpunit"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
                 ]
             },
             "license": [

--- a/projects/plugins/social/changelog/update-sidebar-upsell-visual-update
+++ b/projects/plugins/social/changelog/update-sidebar-upsell-visual-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update design of the sidebar upsell.

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -130,7 +130,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "d71575c86c7f4cec8c3354e21c15db817b966515"
+                "reference": "b85d3fbbc9298316d8cd1d3e35f50a6e0b17c07c"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -182,6 +182,10 @@
                 ],
                 "test-php": [
                     "@composer phpunit"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
                 ]
             },
             "license": [

--- a/projects/plugins/starter-plugin/changelog/update-sidebar-upsell-visual-update
+++ b/projects/plugins/starter-plugin/changelog/update-sidebar-upsell-visual-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update design of the sidebar upsell.

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -66,7 +66,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "d71575c86c7f4cec8c3354e21c15db817b966515"
+                "reference": "b85d3fbbc9298316d8cd1d3e35f50a6e0b17c07c"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -118,6 +118,10 @@
                 ],
                 "test-php": [
                     "@composer phpunit"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
                 ]
             },
             "license": [

--- a/projects/plugins/videopress/changelog/update-sidebar-upsell-visual-update
+++ b/projects/plugins/videopress/changelog/update-sidebar-upsell-visual-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update design of the sidebar upsell.

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -66,7 +66,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "d71575c86c7f4cec8c3354e21c15db817b966515"
+                "reference": "b85d3fbbc9298316d8cd1d3e35f50a6e0b17c07c"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -118,6 +118,10 @@
                 ],
                 "test-php": [
                     "@composer phpunit"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
                 ]
             },
             "license": [

--- a/projects/plugins/wpcloud-sso/changelog/update-sidebar-upsell-visual-update
+++ b/projects/plugins/wpcloud-sso/changelog/update-sidebar-upsell-visual-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update design of the sidebar upsell.

--- a/projects/plugins/wpcloud-sso/composer.lock
+++ b/projects/plugins/wpcloud-sso/composer.lock
@@ -66,7 +66,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "d71575c86c7f4cec8c3354e21c15db817b966515"
+                "reference": "b85d3fbbc9298316d8cd1d3e35f50a6e0b17c07c"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -118,6 +118,10 @@
                 ],
                 "test-php": [
                     "@composer phpunit"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
                 ]
             },
             "license": [

--- a/projects/plugins/wpcomsh/changelog/update-sidebar-upsell-visual-update
+++ b/projects/plugins/wpcomsh/changelog/update-sidebar-upsell-visual-update
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Update design of the sidebar upsell.

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -198,7 +198,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "d71575c86c7f4cec8c3354e21c15db817b966515"
+                "reference": "b85d3fbbc9298316d8cd1d3e35f50a6e0b17c07c"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -250,6 +250,10 @@
                 ],
                 "test-php": [
                     "@composer phpunit"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
                 ]
             },
             "license": [


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/jetpack/pull/47903

### Desktop
<img width="185" height="325" alt="image" src="https://github.com/user-attachments/assets/5966bcbd-6fe3-4d40-a541-d36d58febd91" />

### Mobile
<img width="422" height="691" alt="image" src="https://github.com/user-attachments/assets/33129a6d-7b18-45b2-ae38-97eccee9be08" />


## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Update design for the upsell nudge in the sidebar.

### Before
Desktop
<img width="177" height="477" alt="image" src="https://github.com/user-attachments/assets/1986465b-ef8f-4f29-b5f2-02feea6d4b16" />


Mobile
<img width="409" height="691" alt="image" src="https://github.com/user-attachments/assets/aa4757fd-7bde-433a-b179-61a1add2fcb3" />



### Other information
<!-- Check the box below to generate a changelog entry. -->
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* `jetpack build packages/admin-ui` or `jetpack watch packages/admin-ui` if you wanna tweak CSS.
* Site without a plan, or in `should_show_upgrade_menu()` just `return true` and don't commit ;-)
* See the sidebar; test the heck out of it in different screen sizes, admin color schemes, etc
* You can swap color schemes from _Users -> Profile_