### PR TITLE
Network Admin: Migrate to unified AdminPage header

### DIFF
--- a/projects/js-packages/components/changelog/update-network-admin-settings-visually
+++ b/projects/js-packages/components/changelog/update-network-admin-settings-visually
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update network admin settings visually.

--- a/projects/js-packages/components/components/jetpack-footer/index.tsx
+++ b/projects/js-packages/components/components/jetpack-footer/index.tsx
@@ -9,6 +9,12 @@ import JetpackLogo from '../jetpack-logo/index.tsx';
 import type { JetpackFooterProps, JetpackFooterMenuItem } from './types.ts';
 import type { FC } from 'react';
 
+declare global {
+	interface Window {
+		JetpackNetworkAdminData;
+	}
+}
+
 /**
  * JetpackFooter component displays a tiny Jetpack logo with the product name on the left and the Automattic Airline "by line" on the right.
  *
@@ -18,7 +24,7 @@ import type { FC } from 'react';
 const JetpackFooter: FC< JetpackFooterProps > = ( { className, menu, ...otherProps } ) => {
 	let items: JetpackFooterMenuItem[] = [];
 
-	if ( ! isWpcomPlatformSite() ) {
+	if ( ! isWpcomPlatformSite() && ! window?.JetpackNetworkAdminData ) {
 		items = [
 			{
 				label: __( 'Products', 'jetpack-components' ),

--- a/projects/js-packages/components/components/jetpack-footer/index.tsx
+++ b/projects/js-packages/components/components/jetpack-footer/index.tsx
@@ -11,7 +11,10 @@ import type { FC } from 'react';
 
 declare global {
 	interface Window {
-		JetpackNetworkAdminData;
+		JetpackNetworkAdminData?: {
+			sitesUrl: string;
+			settingsUrl: string;
+		};
 	}
 }
 

--- a/projects/js-packages/components/components/jetpack-footer/test/component.tsx
+++ b/projects/js-packages/components/components/jetpack-footer/test/component.tsx
@@ -78,7 +78,10 @@ describe( 'JetpackFooter', () => {
 		} );
 
 		it( 'should hide default links when JetpackNetworkAdminData is present', () => {
-			window.JetpackNetworkAdminData = {};
+			window.JetpackNetworkAdminData = {
+				sitesUrl: '/',
+				settingsUrl: '/',
+			};
 
 			render( <JetpackFooter /> );
 

--- a/projects/js-packages/components/components/jetpack-footer/test/component.tsx
+++ b/projects/js-packages/components/components/jetpack-footer/test/component.tsx
@@ -6,6 +6,10 @@ import JetpackFooter from '../index.tsx';
 describe( 'JetpackFooter', () => {
 	const className = 'sample-classname';
 
+	afterEach( () => {
+		delete window.JetpackNetworkAdminData;
+	} );
+
 	describe( 'Render the component', () => {
 		const menu = [
 			{
@@ -71,6 +75,15 @@ describe( 'JetpackFooter', () => {
 			expect( link ).toBeInTheDocument();
 			expect( button ).toBeInTheDocument();
 			expect( button ).toHaveAttribute( 'tabindex', '0' );
+		} );
+
+		it( 'should hide default links when JetpackNetworkAdminData is present', () => {
+			window.JetpackNetworkAdminData = {};
+
+			render( <JetpackFooter /> );
+
+			expect( screen.queryByRole( 'link', { name: 'Products' } ) ).not.toBeInTheDocument();
+			expect( screen.queryByRole( 'link', { name: 'Help' } ) ).not.toBeInTheDocument();
 		} );
 
 		it( 'should match the snapshot', () => {

--- a/projects/plugins/jetpack/_inc/client/network-admin.tsx
+++ b/projects/plugins/jetpack/_inc/client/network-admin.tsx
@@ -1,4 +1,10 @@
-import { AdminPage, ThemeProvider, Container, Col } from '@automattic/jetpack-components';
+import {
+	AdminPage,
+	ThemeProvider,
+	Container,
+	Col,
+	getRedirectUrl,
+} from '@automattic/jetpack-components';
 import { Button } from '@wordpress/components';
 import { createRoot } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
@@ -84,6 +90,12 @@ function NetworkAdminApp( { pageType }: { pageType: PageType } ) {
 			title={ config.title }
 			subTitle={ config.subTitle }
 			actions={ <HeaderActions pageType={ pageType } /> }
+			optionalMenuItems={ [
+				{
+					label: __( 'Support', 'jetpack' ),
+					href: getRedirectUrl( 'jetpack-support' ),
+				},
+			] }
 		>
 			<Container horizontalSpacing={ 5 } horizontalGap={ 0 }>
 				<Col>

--- a/projects/plugins/jetpack/_inc/client/network-admin.tsx
+++ b/projects/plugins/jetpack/_inc/client/network-admin.tsx
@@ -1,0 +1,106 @@
+import { AdminPage, ThemeProvider, Container, Col } from '@automattic/jetpack-components';
+import { Button } from '@wordpress/components';
+import { createRoot } from '@wordpress/element';
+import { __, _x } from '@wordpress/i18n';
+import { useEffect, useRef } from 'react';
+
+type PageType = 'sites' | 'settings';
+
+declare global {
+	interface Window {
+		JetpackNetworkAdminData?: {
+			sitesUrl: string;
+			settingsUrl: string;
+		};
+	}
+}
+
+const PAGE_CONFIG: Record< PageType, { title: string; subTitle: string } > = {
+	sites: {
+		title: __( 'Network Sites', 'jetpack' ),
+		subTitle: __( 'Manage Jetpack connections across your network.', 'jetpack' ),
+	},
+	settings: {
+		title: __( 'Network Settings', 'jetpack' ),
+		subTitle: __( 'Configure Jetpack settings for your entire network.', 'jetpack' ),
+	},
+};
+
+/**
+ * Navigation buttons for the header actions slot.
+ *
+ * @param {object}   props          - Component props.
+ * @param {PageType} props.pageType - The current page type.
+ * @return {import('react').ReactNode} Header action buttons.
+ */
+function HeaderActions( { pageType }: { pageType: PageType } ) {
+	const data = window.JetpackNetworkAdminData;
+	if ( ! data ) {
+		return null;
+	}
+
+	return (
+		<>
+			<Button
+				size="compact"
+				variant={ pageType === 'sites' ? 'primary' : 'secondary' }
+				href={ data.sitesUrl }
+			>
+				{ _x( 'Sites', 'Navigation item', 'jetpack' ) }
+			</Button>
+			<Button
+				size="compact"
+				variant={ pageType === 'settings' ? 'primary' : 'secondary' }
+				href={ data.settingsUrl }
+			>
+				{ _x( 'Network Settings', 'Navigation item', 'jetpack' ) }
+			</Button>
+		</>
+	);
+}
+
+/**
+ * Wraps the server-rendered network admin page content with the unified
+ * Jetpack AdminPage header and footer.
+ *
+ * @param {object}   props          - Component props.
+ * @param {PageType} props.pageType - The current page type.
+ * @return {import('react').ReactNode} The network admin page.
+ */
+function NetworkAdminApp( { pageType }: { pageType: PageType } ) {
+	const config = PAGE_CONFIG[ pageType ];
+	const contentRef = useRef< HTMLDivElement >( null );
+
+	useEffect( () => {
+		const phpContent = document.getElementById( 'jp-network-admin-content' );
+		if ( contentRef.current && phpContent ) {
+			phpContent.style.display = '';
+			contentRef.current.appendChild( phpContent );
+		}
+	}, [] );
+
+	return (
+		<AdminPage
+			title={ config.title }
+			subTitle={ config.subTitle }
+			actions={ <HeaderActions pageType={ pageType } /> }
+		>
+			<Container horizontalSpacing={ 5 } horizontalGap={ 0 }>
+				<Col>
+					<div ref={ contentRef } />
+				</Col>
+			</Container>
+		</AdminPage>
+	);
+}
+
+const container = document.getElementById( 'jp-network-admin-root' );
+if ( container ) {
+	const pageType = ( container.dataset.page as PageType ) || 'sites';
+	const root = createRoot( container );
+	root.render(
+		<ThemeProvider targetDom={ document.body }>
+			<NetworkAdminApp pageType={ pageType } />
+		</ThemeProvider>
+	);
+}

--- a/projects/plugins/jetpack/_inc/client/network-admin.tsx
+++ b/projects/plugins/jetpack/_inc/client/network-admin.tsx
@@ -17,11 +17,11 @@ declare global {
 
 const PAGE_CONFIG: Record< PageType, { title: string; subTitle: string } > = {
 	sites: {
-		title: __( 'Network Sites', 'jetpack' ),
+		title: __( 'Network sites', 'jetpack' ),
 		subTitle: __( 'Manage Jetpack connections across your network.', 'jetpack' ),
 	},
 	settings: {
-		title: __( 'Network Settings', 'jetpack' ),
+		title: __( 'Network settings', 'jetpack' ),
 		subTitle: __( 'Configure Jetpack settings for your entire network.', 'jetpack' ),
 	},
 };

--- a/projects/plugins/jetpack/_inc/client/network-admin.tsx
+++ b/projects/plugins/jetpack/_inc/client/network-admin.tsx
@@ -5,9 +5,8 @@ import {
 	Col,
 	getRedirectUrl,
 } from '@automattic/jetpack-components';
-import { Button } from '@wordpress/components';
 import { createRoot } from '@wordpress/element';
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useEffect, useRef } from 'react';
 
 type PageType = 'sites' | 'settings';
@@ -33,39 +32,6 @@ const PAGE_CONFIG: Record< PageType, { title: string; subTitle: string } > = {
 };
 
 /**
- * Navigation buttons for the header actions slot.
- *
- * @param {object}   props          - Component props.
- * @param {PageType} props.pageType - The current page type.
- * @return {import('react').ReactNode} Header action buttons.
- */
-function HeaderActions( { pageType }: { pageType: PageType } ) {
-	const data = window.JetpackNetworkAdminData;
-	if ( ! data ) {
-		return null;
-	}
-
-	return (
-		<>
-			<Button
-				size="compact"
-				variant={ pageType === 'sites' ? 'primary' : 'secondary' }
-				href={ data.sitesUrl }
-			>
-				{ _x( 'Sites', 'Navigation item', 'jetpack' ) }
-			</Button>
-			<Button
-				size="compact"
-				variant={ pageType === 'settings' ? 'primary' : 'secondary' }
-				href={ data.settingsUrl }
-			>
-				{ _x( 'Network Settings', 'Navigation item', 'jetpack' ) }
-			</Button>
-		</>
-	);
-}
-
-/**
  * Wraps the server-rendered network admin page content with the unified
  * Jetpack AdminPage header and footer.
  *
@@ -89,7 +55,6 @@ function NetworkAdminApp( { pageType }: { pageType: PageType } ) {
 		<AdminPage
 			title={ config.title }
 			subTitle={ config.subTitle }
-			actions={ <HeaderActions pageType={ pageType } /> }
 			optionalMenuItems={ [
 				{
 					label: __( 'Support', 'jetpack' ),

--- a/projects/plugins/jetpack/changelog/update-network-admin-settings-visually
+++ b/projects/plugins/jetpack/changelog/update-network-admin-settings-visually
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Update network admin settings visually.

--- a/projects/plugins/jetpack/changelog/update-network-admin-unified-header
+++ b/projects/plugins/jetpack/changelog/update-network-admin-unified-header
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Network Admin: Replace legacy PHP masthead on Network Sites and Network Settings pages with the unified AdminPage header from @automattic/jetpack-components.

--- a/projects/plugins/jetpack/class.jetpack-network.php
+++ b/projects/plugins/jetpack/class.jetpack-network.php
@@ -520,28 +520,28 @@ class Jetpack_Network {
 	 * @since $$next-version$$
 	 */
 	public function enqueue_network_admin_scripts() {
-		$build_dir        = JETPACK__PLUGIN_DIR . '_inc/build/';
-		$script_deps_path = $build_dir . 'network-admin.asset.php';
+		$build_dir         = JETPACK__PLUGIN_DIR . '_inc/build/';
+		$script_asset_path = $build_dir . 'network-admin.asset.php';
 
-		if ( ! file_exists( $script_deps_path ) ) {
+		if ( ! file_exists( $script_asset_path ) ) {
 			return;
 		}
 
-		$script_deps = require $script_deps_path;
+		$script_asset = require $script_asset_path;
 
 		wp_enqueue_script(
 			'jetpack-network-admin',
 			plugins_url( '_inc/build/network-admin.js', JETPACK__PLUGIN_FILE ),
-			$script_deps['dependencies'],
-			$script_deps['version'],
+			$script_asset['dependencies'],
+			$script_asset['version'],
 			true
 		);
 
 		wp_enqueue_style(
 			'jetpack-network-admin',
 			plugins_url( '_inc/build/network-admin.css', JETPACK__PLUGIN_FILE ),
-			array( 'wp-components' ),
-			$script_deps['version']
+			array(),
+			$script_asset['version']
 		);
 
 		wp_set_script_translations( 'jetpack-network-admin', 'jetpack' );

--- a/projects/plugins/jetpack/class.jetpack-network.php
+++ b/projects/plugins/jetpack/class.jetpack-network.php
@@ -285,15 +285,8 @@ class Jetpack_Network {
 		add_menu_page( 'Jetpack', 'Jetpack', 'jetpack_network_admin_page', 'jetpack', array( $this, 'wrap_network_admin_page' ), $icon, 3 );
 		$jetpack_sites_page_hook    = add_submenu_page( 'jetpack', __( 'Jetpack Sites', 'jetpack' ), __( 'Sites', 'jetpack' ), 'jetpack_network_sites_page', 'jetpack', array( $this, 'wrap_network_admin_page' ) );
 		$jetpack_settings_page_hook = add_submenu_page( 'jetpack', __( 'Settings', 'jetpack' ), __( 'Settings', 'jetpack' ), 'jetpack_network_settings_page', 'jetpack-settings', array( $this, 'wrap_render_network_admin_settings_page' ) );
-		add_action( "admin_print_styles-$jetpack_sites_page_hook", array( 'Jetpack_Admin_Page', 'load_wrapper_styles' ) );
-		add_action( "admin_print_styles-$jetpack_settings_page_hook", array( 'Jetpack_Admin_Page', 'load_wrapper_styles' ) );
-		/**
-		 * As jetpack_register_genericons is by default fired off a hook,
-		 * the hook may have already fired by this point.
-		 * So, let's just trigger it manually.
-		 */
-		require_once JETPACK__PLUGIN_DIR . '_inc/genericons.php';
-		jetpack_register_genericons();
+		add_action( "load-$jetpack_sites_page_hook", array( $this, 'admin_init_network_page' ) );
+		add_action( "load-$jetpack_settings_page_hook", array( $this, 'admin_init_network_page' ) );
 	}
 
 	/**
@@ -513,10 +506,64 @@ class Jetpack_Network {
 	}
 
 	/**
-	 * A hook handler for adding admin pages and subpages.
+	 * Initializes assets for network admin pages.
+	 *
+	 * @since $$next-version$$
+	 */
+	public function admin_init_network_page() {
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_network_admin_scripts' ) );
+	}
+
+	/**
+	 * Enqueues the JS and CSS for the unified network admin header.
+	 *
+	 * @since $$next-version$$
+	 */
+	public function enqueue_network_admin_scripts() {
+		$build_dir        = JETPACK__PLUGIN_DIR . '_inc/build/';
+		$script_deps_path = $build_dir . 'network-admin.asset.php';
+
+		if ( ! file_exists( $script_deps_path ) ) {
+			return;
+		}
+
+		$script_deps = require $script_deps_path;
+
+		wp_enqueue_script(
+			'jetpack-network-admin',
+			plugins_url( '_inc/build/network-admin.js', JETPACK__PLUGIN_FILE ),
+			$script_deps['dependencies'],
+			$script_deps['version'],
+			true
+		);
+
+		wp_enqueue_style(
+			'jetpack-network-admin',
+			plugins_url( '_inc/build/network-admin.css', JETPACK__PLUGIN_FILE ),
+			array( 'wp-components' ),
+			$script_deps['version']
+		);
+
+		wp_set_script_translations( 'jetpack-network-admin', 'jetpack' );
+
+		wp_localize_script(
+			'jetpack-network-admin',
+			'JetpackNetworkAdminData',
+			array(
+				'sitesUrl'    => network_admin_url( 'admin.php?page=jetpack' ),
+				'settingsUrl' => network_admin_url( 'admin.php?page=jetpack-settings' ),
+			)
+		);
+	}
+
+	/**
+	 * Renders the Network Sites page with the unified admin header.
 	 */
 	public function wrap_network_admin_page() {
-		Jetpack_Admin_Page::wrap_ui( array( $this, 'network_admin_page' ) );
+		echo '<div id="jp-network-admin-root" data-page="sites"></div>';
+		echo '<div id="jp-network-admin-content" style="display:none">';
+		$this->network_admin_page();
+		echo '</div>';
 	}
 
 	/**
@@ -528,7 +575,6 @@ class Jetpack_Network {
 	 */
 	public function network_admin_page() {
 		global $current_site;
-		$this->network_admin_page_header();
 
 		$jp = Jetpack::init();
 
@@ -650,17 +696,19 @@ class Jetpack_Network {
 	}
 
 	/**
-	 * A hook handler for adding admin pages and subpages.
+	 * Renders the Network Settings page with the unified admin header.
 	 */
 	public function wrap_render_network_admin_settings_page() {
-		Jetpack_Admin_Page::wrap_ui( array( $this, 'render_network_admin_settings_page' ) );
+		echo '<div id="jp-network-admin-root" data-page="settings"></div>';
+		echo '<div id="jp-network-admin-content" style="display:none">';
+		$this->render_network_admin_settings_page();
+		echo '</div>';
 	}
 
 	/**
 	 * A hook rendering the admin settings page.
 	 */
 	public function render_network_admin_settings_page() {
-		$this->network_admin_page_header();
 		$options = wp_parse_args( get_site_option( $this->settings_name ), $this->setting_defaults );
 
 		$modules      = array();

--- a/projects/plugins/jetpack/tools/webpack.config.js
+++ b/projects/plugins/jetpack/tools/webpack.config.js
@@ -157,6 +157,7 @@ module.exports = [
 				},
 			},
 			'plugins-page': path.join( __dirname, '../_inc/client', 'plugins-entry.js' ),
+			'network-admin': path.join( __dirname, '../_inc/client', 'network-admin.tsx' ),
 		},
 		plugins: [
 			...sharedWebpackConfig.plugins,

--- a/projects/plugins/jetpack/views/admin/network-settings.php
+++ b/projects/plugins/jetpack/views/admin/network-settings.php
@@ -26,10 +26,7 @@ if ( isset( $_GET['error'] ) && 'jetpack_protect_whitelist' === $_GET['error'] )
 <?php endif; ?>
 
 <div class="wrap">
-	<h2><?php esc_html_e( 'Network Settings', 'jetpack' ); ?></h2>
 	<form action="edit.php?action=jetpack-network-settings" method="POST">
-		<h3><?php echo esc_html_x( 'Global', 'Affects all sites in a Multisite network.', 'jetpack' ); ?></h3>
-		<p><?php esc_html_e( 'These settings affect all sites on the network.', 'jetpack' ); ?></p>
 		<?php wp_nonce_field( 'jetpack-network-settings' ); ?>
 		<table class="form-table">
 			<tr valign="top">


### PR DESCRIPTION
Resolves JETPACK-1514
Part of JETPACK-1391

## Proposed changes

Replace the legacy PHP masthead (`Jetpack_Admin_Page::wrap_ui()`) on the multisite **Network Sites** and **Network Settings** pages with the unified `AdminPage` header from `@automattic/jetpack-components`, matching the pattern already used by Social, Settings, VideoPress, Newsletter, and other Jetpack admin pages.

* Add a `network-admin.tsx` React entry point that mounts the `AdminPage` component (Jetpack bolt icon + title + subtitle + footer) around the existing server-rendered PHP content.
* Add Sites/Network Settings navigation buttons in the header `actions` slot, with primary/secondary variants to indicate the current page.
* PHP content (sites list table, settings form) is preserved as-is — rendered in a hidden div and relocated into the React tree at mount time.
* Remove old wrapper style hooks (`dops-css`, `genericons`) and the legacy `network_admin_page_header()` calls.


<img width="940" height="335" alt="image" src="https://github.com/user-attachments/assets/0e011b8e-1403-42ac-8f92-ac4426f4775a" />


<img width="943" height="669" alt="image" src="https://github.com/user-attachments/assets/187bd5eb-102d-4d1b-b812-124033d44734" />



### Other information
- [x] Generate changelog entries for this PR (using AI).

## Related product discussion/links
* Linear: JETPACK-1514
* Slack: p1775159306637099-slack-C052XEUUBL4

### Nice-to-have / follow-up
The Sites/Settings header buttons currently act as a toggle with primary highlighting the "current" page. This is slightly ambiguous UX (primary = navigation target vs. primary = you-are-here). Worth revisiting in a follow-up — options include hiding the current-page button entirely, or inverting the variant logic.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

These pages only appear on **WordPress multisite** network admin. To test locally:

1. Convert your Docker environment to multisite:
   ```sh
   jetpack docker multisite-convert
   ```
2. Build the Jetpack plugin:
   ```sh
   jetpack build plugins/jetpack
   ```
3. Navigate to **Network Admin → Jetpack → Sites** and **Network Admin → Jetpack → Settings**.
4. Verify:
   - The header shows the Jetpack bolt icon + "Network Sites" / "Network Settings" title and subtitle.
   - Sites and Network Settings buttons appear in the top-right and navigate between the two pages.
   - The content area has proper horizontal padding (not edge-to-edge).
   - The standard Jetpack footer renders at the bottom.
   - The settings form (sub-site override, IP allowlist) still functions correctly.

### Before
![Old masthead with green circle logo and dops buttons](https://github.com/user-attachments/assets/placeholder-before)

### After
![New unified header with bolt icon, title, subtitle, and nav buttons](https://github.com/user-attachments/assets/placeholder-after)