### PR TITLE
Disable Write Brief (Breve) proofreading feature by default

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -58,8 +58,6 @@ export default function () {
 	const videoTitleForms = __( 'Build forms using prompts', 'jetpack-my-jetpack' );
 	const videoTitleContentFeedback = __( 'Get feedback on posts', 'jetpack-my-jetpack' );
 
-	const videoTitleBreve = __( 'Make your writing easy to read', 'jetpack-my-jetpack' );
-
 	debug( aiAssistantFeature );
 	const {
 		requestsCount: allTimeRequests = 0,
@@ -87,8 +85,6 @@ export default function () {
 	const videoLinkContentFeedback = getRedirectUrl(
 		'jetpack-ai-product-page-content-feedback-link'
 	);
-
-	const videoLinkBreve = getRedirectUrl( 'jetpack-ai-product-page-breve' );
 
 	// isRegistered works as a flag to know if the page can link to a post creation or not
 	const ctaURL = isRegistered
@@ -202,12 +198,6 @@ export default function () {
 	useEffect( () => {
 		setShowNotice( showRenewalNotice || showUpgradeNotice );
 	}, [ showRenewalNotice, showUpgradeNotice ] );
-
-	const newBadge = (
-		<span className={ styles[ 'product-interstitial__new-badge' ] }>
-			{ __( 'New', 'jetpack-my-jetpack' ) }{ ' ' }
-		</span>
-	);
 
 	return (
 		<AdminPage showHeader={ false } showBackground={ true }>
@@ -353,40 +343,6 @@ export default function () {
 							{ __( 'Discover all the Jetpack features powered by AI', 'jetpack-my-jetpack' ) }
 						</p>
 						<div className={ styles[ 'product-interstitial__usage-videos' ] }>
-							<div className={ styles[ 'product-interstitial__usage-videos-item' ] }>
-								<div className={ styles[ 'product-interstitial__usage-videos-video' ] }>
-									<iframe
-										width="280"
-										height="157"
-										src="https://videopress.com/embed/2OU6GCMs?posterUrl=https%3A%2F%2Fjetpackme.files.wordpress.com%2F2024%2F07%2Fjetpack-ai-breve-poster.png%3Fw%3D560"
-										allowFullScreen
-										allow="clipboard-write"
-										title={ videoTitleBreve }
-									></iframe>
-									<script src="https://videopress.com/videopress-iframe.js"></script>
-								</div>
-								<div className={ styles[ 'product-interstitial__usage-videos-content' ] }>
-									<div className={ styles[ 'product-interstitial__usage-videos-heading' ] }>
-										{ videoTitleBreve }
-										{ newBadge }
-									</div>
-									<div className={ styles[ 'product-interstitial__usage-videos-text' ] }>
-										{ __(
-											'Simplify your writing with AI suggestions to fix long sentences and complex words and sound more confident. As you type, check your Reading grade score to make sure it suits your audience.',
-											'jetpack-my-jetpack'
-										) }
-									</div>
-									<Button
-										className={ styles[ 'product-interstitial__usage-videos-link' ] }
-										icon={ help }
-										target="_blank"
-										href={ videoLinkBreve }
-									>
-										{ __( 'Learn more', 'jetpack-my-jetpack' ) }
-									</Button>
-								</div>
-							</div>
-
 							<div className={ styles[ 'product-interstitial__usage-videos-item' ] }>
 								<div className={ styles[ 'product-interstitial__usage-videos-video' ] }>
 									<iframe

--- a/projects/packages/my-jetpack/changelog/disable-breve-via-filter
+++ b/projects/packages/my-jetpack/changelog/disable-breve-via-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI product page: Remove Write Brief (Breve) video showcase section since the feature is now disabled by default.

--- a/projects/plugins/jetpack/changelog/disable-breve-via-filter
+++ b/projects/plugins/jetpack/changelog/disable-breve-via-filter
@@ -1,5 +1,4 @@
 Significance: minor
 Type: major
-Comment: Disable the Write Brief (Breve) proofreading feature by default. It can be re-enabled via the 'breve_enabled' filter.
 
-AI Assistant: Disable the Write Brief (Breve) proofreading feature by default.
+AI Assistant: Disable the Write Brief (Breve) proofreading feature by default. It can be re-enabled via the 'breve_enabled' filter.

--- a/projects/plugins/jetpack/changelog/disable-breve-via-filter
+++ b/projects/plugins/jetpack/changelog/disable-breve-via-filter
@@ -1,0 +1,5 @@
+Significance: minor
+Type: major
+Comment: Disable the Write Brief (Breve) proofreading feature by default. It can be re-enabled via the 'breve_enabled' filter.
+
+AI Assistant: Disable the Write Brief (Breve) proofreading feature by default.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -79,8 +79,9 @@ add_action(
 			Jetpack_Gutenberg::set_extension_available( 'ai-assistant-image-extension' );
 
 			$site_locale = get_locale();
-			// Only enable Write Brief for sites with an English locale
-			if ( str_starts_with( $site_locale, 'en' ) && apply_filters( 'breve_enabled', true ) ) {
+			// Only enable Write Brief for sites with an English locale.
+			// Disabled by default; set the 'breve_enabled' filter to true to re-enable.
+			if ( str_starts_with( $site_locale, 'en' ) && apply_filters( 'breve_enabled', false ) ) {
 				Jetpack_Gutenberg::set_extension_available( 'ai-proofread-breve' );
 			}
 


### PR DESCRIPTION
## Summary

- Flip the `breve_enabled` filter default from `true` to `false` in the AI Assistant PHP registration
- This hides the Write Brief (Breve) proofreading feature for all users without removing any code
- Remove the Breve video card from the My Jetpack AI product page since the feature is now disabled
- The feature can be re-enabled per-site by hooking into the filter: `add_filter( 'breve_enabled', '__return_true' );`

### More Context

- pgLAn3-iK-p2
- p1HpG7-xUC-p2

## Testing instructions:

1. Build the Jetpack plugin (\`pnpm jetpack build plugins/jetpack\`)
2. Open the WordPress block editor (create or edit a post)
3. Open the **Jetpack AI Assistant** sidebar panel (in the right sidebar)
4. Verify the **"Write Brief"** section is **not visible** in the sidebar
5. Type some content in a paragraph block — verify there are **no Breve highlights** (colored underlines for spelling, complex words, long sentences)
6. Navigate to **My Jetpack → AI** (\`wp-admin/admin.php?page=my-jetpack#/jetpack-ai\`)
7. Scroll down to the **"AI Features"** video showcase section
8. Verify the **"Make your writing easy to read"** (Breve) video card is **not shown**
9. Verify all other video cards (Content Generation, Featured Images, Title Optimization, Forms, Content Feedback) are still present
10. Add \`add_filter( 'breve_enabled', '__return_true' );\` to your theme's \`functions.php\`
11. Reload the editor and verify the **"Write Brief"** toggle reappears in the AI Assistant sidebar
12. Verify Breve highlights work when enabled
13. Verify other AI features (title optimization, featured image, feedback) still work normally

## Does this pull request change what data or activity we track or use?

No. This PR only changes the default value of an existing filter. No new data collection, tracking, or privacy-related changes are introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)