### PR TITLE
AI Assistant Banner: Hide banner when big_sky_enable is set

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-ai-banner-big-sky-enable-check
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-ai-banner-big-sky-enable-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AI Assistant Banner: Hide banner when the AI assistant is already enabled via big_sky_enable option.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/ai-assistant-banner.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/ai-assistant-banner.php
@@ -32,6 +32,11 @@ function wpcom_should_show_ai_assistant_banner() {
 		return false;
 	}
 
+	// Don't show if AI assistant is already enabled.
+	if ( get_option( 'big_sky_enable' ) ) {
+		return false;
+	}
+
 	if ( function_exists( 'get_user_attribute' ) ) {
 		$user_id = get_current_user_id();
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/ai-assistant-banner.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/ai-assistant-banner.php
@@ -33,7 +33,7 @@ function wpcom_should_show_ai_assistant_banner() {
 	}
 
 	// Don't show if AI assistant is already enabled.
-	if ( get_option( 'big_sky_enable' ) ) {
+	if ( class_exists( 'Big_Sky' ) && get_option( 'big_sky_enable', '1' ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
Fixes #

## Proposed changes
* Hide the AI assistant banner on sites where the AI assistant is already enabled via the `big_sky_enable` option.
* Previously, the banner could still appear on sites that had already opted in, which was unnecessary.

### Other information

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Go to a WordPress.com site dashboard (Business/Commerce plan) where the `big_sky_enable` option is **not** set.
* Verify the AI assistant banner appears on the dashboard.
* Set the `big_sky_enable` option to a truthy value (e.g., `update_option( 'big_sky_enable', true )`).
* Reload the dashboard and verify the banner no longer appears.
