### PR TITLE
RTC: Skip attachment entities in PingHub provider

### DIFF
--- a/projects/packages/rtc/changelog/dotcom-16597-skip-attachment-pinghub-rooms
+++ b/projects/packages/rtc/changelog/dotcom-16597-skip-attachment-pinghub-rooms
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Skip attachment entities in PingHub provider to avoid excessive WebSocket connections on media-heavy sites

--- a/projects/packages/rtc/src/js/providers/pinghub/pinghub-provider.ts
+++ b/projects/packages/rtc/src/js/providers/pinghub/pinghub-provider.ts
@@ -135,6 +135,11 @@ function getRoom( objectType: string, objectId: string | null ): string {
  */
 export function createPingHubProvider(): ProviderCreator {
 	return async ( { awareness, objectType, objectId, ydoc } ): Promise< ProviderCreatorResult > => {
+		const noopProvider = {
+			destroy: () => {},
+			on: () => {},
+		};
+
 		/**
 		 * The sync manager only invokes provider creators for entity types that
 		 * have a syncConfig, so no explicit allowlist is needed here.
@@ -145,10 +150,14 @@ export function createPingHubProvider(): ProviderCreator {
 		 * no concrete ID is present.
 		 */
 		if ( ! objectId && ! objectType.startsWith( 'root/' ) ) {
-			return {
-				destroy: () => {},
-				on: () => {},
-			};
+			return noopProvider;
+		}
+
+		// Skip attachments: real-time collaboration on attachment metadata has
+		// minimal value, and media-heavy sites can trigger hundreds of
+		// simultaneous WebSocket connections (one per attachment entity).
+		if ( objectType === 'postType/attachment' ) {
+			return noopProvider;
 		}
 
 		const room = getRoom( objectType, objectId );


### PR DESCRIPTION
Fixes DOTCOM-16597

## Proposed changes

Gutenberg assigns a `syncConfig` to every post type (including `attachment`), so the sync manager creates a provider for each attachment entity resolved through the data store. With the PingHub provider, this means **one WebSocket room per attachment**.

On media-heavy sites, this can result in hundreds of simultaneous WebSocket connections from a single browser tab. Analysis of site 194531900 showed **181 concurrent `postType-attachment-*` rooms**, causing:
- Median connect time of **14.5s** (should be <1s) due to connection queuing
- Mass disconnects (all 181 connections dropping simultaneously with close code 1006 — pong timeout)
- Excessive `pinghub-token` endpoint requests from reconnection attempts

Real-time collaboration on attachment metadata has minimal value, so return a no-op provider for `postType/attachment`. These entities fall back to Gutenberg's default HTTP polling transport instead.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links
N/A

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. Open a post in the block editor on a site with RTC enabled via WebSocket (pinghub provider)
2. Add several image blocks with uploaded images
3. Open devtools Network tab and filter by `pinghub` WebSocket connections
4. Verify that no WebSocket rooms are created for `postType-attachment-*` entities
5. Verify that WebSocket rooms ARE still created for the post itself (`postType-post-*`)
6. Verify that real-time collaboration (cursors, edits) still works normally for the post content, including the images

🤖 Generated with [Claude Code](https://claude.com/claude-code)