### PR TITLE
HOG-522: Exclude Image Guide from JS concatenation

### DIFF
--- a/projects/plugins/boost/changelog/hog-522-fix-concatenate-image-guide
+++ b/projects/plugins/boost/changelog/hog-522-fix-concatenate-image-guide
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Image Guide: Exclude from JS concatenation on Atomic/WoW sites to prevent script errors.

--- a/projects/plugins/boost/changelog/hog-522-fix-concatenate-image-guide
+++ b/projects/plugins/boost/changelog/hog-522-fix-concatenate-image-guide
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Image Guide: Exclude from JS concatenation on Atomic/WoW sites to prevent script errors.
+Image Guide: Fix script errors when JavaScript concatenation is enabled.

--- a/projects/plugins/boost/compatibility/js-concatenate.php
+++ b/projects/plugins/boost/compatibility/js-concatenate.php
@@ -18,6 +18,9 @@ function maybe_do_not_concat( $do_concat, $handle ) {
 		'wc-bookings-booking-form',
 		// WooCommerce Analytics
 		'woocommerce-analytics-client',
+		// Boost Image Guide — webpack IIFE bundle with wp_localize_script data
+		// that produces a malformed concatenated bundle on Atomic/WoW sites.
+		'jetpack-boost-guide',
 	);
 
 	if ( in_array( $handle, $excluded_handles, true ) ) {

--- a/projects/plugins/boost/compatibility/js-concatenate.php
+++ b/projects/plugins/boost/compatibility/js-concatenate.php
@@ -18,8 +18,7 @@ function maybe_do_not_concat( $do_concat, $handle ) {
 		'wc-bookings-booking-form',
 		// WooCommerce Analytics
 		'woocommerce-analytics-client',
-		// Boost Image Guide — webpack IIFE bundle with wp_localize_script data
-		// that produces a malformed concatenated bundle on Atomic/WoW sites.
+		// Boost Image Guide — ES6 webpack bundle corrupted by _jb_static re-minification (HOG-522)
 		'jetpack-boost-guide',
 	);
 


### PR DESCRIPTION
Fixes [HOG-522](https://linear.app/a8c/issue/HOG-522/jetpack-boost-image-guide-disappears-with-concatenate-js-enabled-on)

## Proposed changes

When Boost has both **Concatenate JS** and **Image Guide** enabled, the Image Guide overlays can silently disappear. This was discovered on Atomic/WoW sites but affects any site using Boost's concatenation module.

**Root cause:** `guide.js` is a webpack/Terser production bundle containing ES6 template literals. When it ends up in a multi-script `_jb_static/??` concatenation group, the serving code re-minifies it through MatthiasMullie — a PHP regex-based minifier designed for ES5. MatthiasMullie can't parse the template literals, truncating 85% of the file (78KB down to 11KB) and producing a `SyntaxError`.

**Why it doesn't always manifest:** If all scripts adjacent to `guide.js` in the footer queue are individually excluded from concatenation (external URLs, strict mode, inline content), `guide.js` ends up solo and gets served directly — no `_jb_static` serving, no re-minification. The bug only triggers when another non-excluded local script shares the group.

**Fix:** Add `'jetpack-boost-guide'` to the `$excluded_handles` array in `compatibility/js-concatenate.php`, preventing it from ever joining a multi-script concatenation group.

**Follow-up:** The systemic MatthiasMullie ES6 corruption issue is tracked in [HOG-534](https://linear.app/a8c/issue/HOG-534/matthiasmullie-js-minifier-corrupts-es6-scripts-in-jb-static).

### Other information

* The exclusion applies globally (not just Atomic/WoW) since `js-concatenate.php` is loaded unconditionally. This is intentional — the concatenation incompatibility isn't platform-specific.

## Related product discussion/links

* [HOG-522](https://linear.app/a8c/issue/HOG-522/jetpack-boost-image-guide-disappears-with-concatenate-js-enabled-on)
* [HOG-534](https://linear.app/a8c/issue/HOG-534/matthiasmullie-js-minifier-corrupts-es6-scripts-in-jb-static) (systemic follow-up)

## Does this pull request change what data or activity we track or use?

No. Only affects which JS files are excluded from concatenation.

## Testing instructions

### Prerequisites
Atomic/WoA site with Boost 4.5.8+, Concatenate JS enabled, Image Guide enabled.

### Before the fix — verify the bug

**Quick verification (no setup needed):**

* Go to `https://your-site.com/_jb_static/??/wp-content/plugins/jetpack-boost/app/modules/image-guide/dist/guide.js,/wp-includes/js/wp-util.min.js`
* Open browser DevTools Console and run:
```js
fetch(window.location.href).then(r=>r.text()).then(t=>{try{new Function(t);console.log('VALID JS')}catch(e){console.error('BROKEN:',e.message,'\nSize:',t.length,'bytes')}})
```
* Expected: `BROKEN: Unexpected end of input` or `BROKEN: missing ) after argument list`, size ~13KB (guide.js corrupted from ~78KB to ~11KB).

**End-to-end verification with snippet:**

* Add this PHP snippet via Code Snippets plugin or mu-plugin (frontend only):
```php
add_action( 'wp_enqueue_scripts', function () {
    if ( ! is_user_logged_in() ) {
        return;
    }
    wp_dequeue_script( 'grofiles-cards' );
    wp_dequeue_script( 'wpgroho' );
}, 999 );

add_filter( 'js_do_concat', function ( $do_concat, $handle ) {
    if ( 'sourcebuster-js' === $handle ) {
        return true;
    }
    return $do_concat;
}, 20, 2 );
```
* Visit any frontend page as a logged-in admin.
* Observe that Image Guide overlays are **missing** (only admin bar "Jetpack Boost" item remains). DevTools Console shows a SyntaxError in the `_jb_static/??` bundle containing `jetpack-boost-guide`.
* Disable Concatenate JS in Boost settings — overlays reappear.

### After the fix — verify the fix works

* With the reproduction snippet still active, apply the fix.
* Visit any frontend page as a logged-in admin.
* Confirm Image Guide overlays appear correctly (green/red on images).
* Confirm `guide.js` is served as a standalone `<script>` tag, NOT inside a `_jb_static/??` bundle (check via DevTools Network tab or view source).
* Confirm no console errors related to `_jb_static` bundles.
* Deactivate the reproduction snippet — Image Guide should continue working normally.