### PR TITLE
RTC: Enforce peer limit per post instead of globally

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-16554-rtc-limit-should-be-enforced-per-room-ws
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-16554-rtc-limit-should-be-enforced-per-room-ws
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+RTC: Enforce peer limit per post instead of globally across all posts

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/room-limit.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc-notices/room-limit.ts
@@ -146,7 +146,14 @@ export function withRoomLimit(
 
 		teardowns.push( destroyWithLimitError );
 
-		if ( awareness ) {
+		// Only enforce the peer limit on entity rooms (objectId !== null).
+		// Collection rooms (objectId === null) are shared across posts, so
+		// their awareness aggregates all editors site-wide — not just those
+		// on the same post. Monitoring them would cause the limit to behave
+		// as a global cap instead of a per-post cap.
+		const isEntityRoom = options.objectId !== null;
+
+		if ( awareness && isEntityRoom ) {
 			awareness.on( 'change', onAwarenessChange );
 			onAwarenessChange();
 		}


### PR DESCRIPTION
Fixes DOTCOM-16554

## Proposed changes

* Fix `withRoomLimit` to only enforce the peer limit on entity rooms (`objectId !== null`), skipping collection rooms (`objectId === null`).
* Collection rooms (e.g. `root-comment-collection`) are shared across all posts being edited on a site. Their awareness state aggregates all editors site-wide, causing the limit to act as a global cap instead of per-post.
* Entity rooms are scoped per post, so monitoring only those rooms enforces the limit correctly.
* Collection room providers are still registered in the `teardowns` array, so they are properly cleaned up when an entity room breach triggers `destroyAll()`.

### Other information

This mirrors [the `isPrimaryRoom` concept](https://github.com/WordPress/gutenberg/blob/582f52bfb97ade38b6535265c481604f79c5e2d0/packages/sync/src/providers/http-polling/polling-manager.ts#L275) already used by Gutenberg's built-in `checkConnectionLimit` in the polling manager, but uses `objectId` for a more precise distinction instead of relying on room registration order.

## Related product discussion/links

N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Open a site with RTC enabled.
* Have 3 users open **Post A** in the editor — the 3rd user should be at the limit.
* Have a 4th user open **Post B** in the editor.
* **Before this fix**: the 4th user (or one of the others) would get disconnected with a "Too many editors connected" modal, because the shared collection room aggregated all 4 users.
* **After this fix**: the 4th user can edit Post B normally, since the limit is enforced per entity room (per post). Only if a 4th user opens Post A would the limit kick in.
