### PR TITLE
codeowners: Unassign plugin composer.lock, changelogs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,7 +38,11 @@
 /projects/packages/phpunit-select-config @Automattic/jetpack-monorepo
 /projects/packages/stub-generator @Automattic/jetpack-monorepo
 /projects/plugins/beta @Automattic/jetpack-monorepo
+/projects/plugins/beta/composer.lock # No owner - too noisy
+/projects/plugins/beta/changelog # No owner - to go with the above
 /projects/plugins/starter-plugin @Automattic/jetpack-monorepo
+/projects/plugins/starter-plugin/composer.lock # No owner - too noisy
+/projects/plugins/starter-plugin/changelog # No owner - to go with the above
 /stylelint.config.mjs @Automattic/jetpack-monorepo
 /tools @Automattic/jetpack-monorepo
 /tools/e2e-commons # No owner assigned


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
We don't need to be pinged for review if the only thing changing in the plugin is composer.lock and a corresponding changelog entry.

### Other information

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* 🤷