### PR TITLE
RTC: Enable when WordPress 7.0+ is detected without Gutenberg

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-16598-rtc-test-with-wp-70
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-16598-rtc-test-with-wp-70
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+RTC: Enable when WordPress 7.0+ is detected without the Gutenberg plugin

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
@@ -88,7 +88,13 @@ function wpcom_enable_rtc() {
 	}
 
 	$has_needed_gutenberg_version = defined( 'GUTENBERG_VERSION' ) && is_string( GUTENBERG_VERSION ) && version_compare( (string) GUTENBERG_VERSION, '22.7.0', '>=' );
-	if ( ! $has_needed_gutenberg_version ) {
+
+	// WordPress 7.0+ includes RTC support in core.
+	// strtok strips beta/RC suffixes (e.g. "7.0-beta1" → "7.0") so pre-release versions match.
+	global $wp_version;
+	$has_needed_wp_version = version_compare( strtok( $wp_version, '-' ), '7.0', '>=' );
+
+	if ( ! $has_needed_gutenberg_version && ! $has_needed_wp_version ) {
 		return false;
 	}
 


### PR DESCRIPTION
Fixes DOTCOM-16598

## Proposed changes

* Enable RTC on sites running WordPress 7.0+ even when the Gutenberg plugin is not installed, since WP 7.0 includes RTC support in core.
* Uses `strtok` to strip beta/RC suffixes from `$wp_version` so pre-release versions (e.g. `7.0-beta1`, `7.0-RC1`) also match.

## Related product discussion/links

N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a site running WordPress 7.0-beta (or RC) **without** the Gutenberg plugin installed, verify that RTC is enabled (the `wp_collaboration_enabled` option defaults to on).
* On a site running WordPress 7.0+ **with** Gutenberg >= 22.7.0, verify RTC still works as before.
* On a site running WordPress < 7.0 without Gutenberg, verify RTC remains disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)