### PR TITLE
Build: Add separate job for wpcom deploy mirrors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,6 +119,17 @@ jobs:
             mkdir "$BUILD_BASE"
             touch "$BUILD_BASE/mirrors.txt"
           else
+            # On trunk pushes, exclude wpcom deploy projects (plugins/jetpack, plugins/mu-wpcom-plugin)
+            # which are built by the parallel build_wpcom job. This cuts the general build from ~13 min to ~3.5 min.
+            if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/trunk" ]]; then
+              GENERAL=()
+              for P in "${PROJECTS[@]}"; do
+                if [[ "$P" != "plugins/jetpack" && "$P" != "plugins/mu-wpcom-plugin" ]]; then
+                  GENERAL+=("$P")
+                fi
+              done
+              PROJECTS=("${GENERAL[@]}")
+            fi
             pnpm jetpack build -v --no-pnpm-install --for-mirrors="$BUILD_BASE" "${PROJECTS[@]}"
           fi
 
@@ -191,6 +202,110 @@ jobs:
           script: |
             const { checkTestReminderComment } = require('.github/files/build-reminder-comment/check-test-reminder-comment.js')
             await checkTestReminderComment( github, context, core );
+
+  build_wpcom:
+    name: Build wpcom deploy projects
+    runs-on: ubuntu-latest
+    timeout-minutes: 25  # Should take ~10 min, but turnstile may add wait time.
+    permissions:
+      # .github/actions/turnstile
+      actions: read
+      # actions/checkout
+      contents: read
+      # push-to-mirrors uses secrets.API_TOKEN_GITHUB, so no need for permissions
+
+    # Only run on pushes to trunk. Other branches and PRs don't need the wpcom build lane.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/trunk' && github.repository == 'Automattic/jetpack'
+
+    env:
+      BUILD_BASE: /tmp/jetpack-build-wpcom
+
+    steps:
+      - uses: actions/checkout@v6
+        timeout-minutes: 1
+
+      - name: Setup tools
+        uses: ./.github/actions/tool-setup
+        timeout-minutes: 2
+
+      - name: Pnpm install
+        run: pnpm install
+        timeout-minutes: 3
+
+      # Same as the general build's "Deepen tree for packages" step, but scoped to the wpcom projects.
+      - name: Deepen tree for packages
+        run: |
+          WPCOM_PROJECTS=(plugins/jetpack plugins/mu-wpcom-plugin)
+          depth=$( git rev-list --count --first-parent HEAD )
+          [[ "$depth" -lt 1000 ]] && depth=1000
+          BASE=$PWD
+          REF=$(git rev-parse HEAD)
+          for SLUG in $(pnpm jetpack dependencies list --add-dependencies --extra="build" --ignore-root "${WPCOM_PROJECTS[@]}"); do
+            cd "$BASE/projects/$SLUG/"
+            if [[ "$SLUG" == packages/* ]]; then
+              SUBDIR=.
+              # Only deepen if it'll be a -alpha, i.e. it has changelog entries
+              CHANGES_DIR="$(jq -r '.extra.changelogger["changes-dir"] // "changelog"' composer.json)"
+              [[ -d "$CHANGES_DIR" && -n "$(ls -- "$CHANGES_DIR")" ]] || continue
+            elif [[ "$SLUG" == js-packages/social-logos ]]; then
+              SUBDIR=./src/svg
+            else
+              continue
+            fi
+            echo "Checking depth for $SLUG"
+            while git log --format='%h, %D,' -1 "$SUBDIR" | grep ', grafted,'; do
+              depth=$((depth * 2))
+              echo "::group::Deepen to $depth"
+              echo "/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=$depth --filter=blob:none origin $REF"
+              /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=$depth --filter=blob:none origin "$REF"
+              echo "::endgroup::"
+            done
+          done
+        timeout-minutes: 2
+
+      - name: Build wpcom projects
+        run: pnpm jetpack build -v --no-pnpm-install --for-mirrors="$BUILD_BASE" plugins/jetpack plugins/mu-wpcom-plugin
+        timeout-minutes: 15
+
+      - name: Filter mirrors to wpcom repos
+        id: filter
+        run: |
+          WPCOM_MIRRORS=("Automattic/jetpack-production" "Automattic/jetpack-mu-wpcom-plugin")
+          if [[ ! -s "$BUILD_BASE/mirrors.txt" ]]; then
+            echo "No mirrors were built."
+            echo "any=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          FILTERED=""
+          for MIRROR in "${WPCOM_MIRRORS[@]}"; do
+            if grep -q --fixed-strings --line-regexp "$MIRROR" "$BUILD_BASE/mirrors.txt"; then
+              FILTERED+="$MIRROR"$'\n'
+            fi
+          done
+          if [[ -z "$FILTERED" ]]; then
+            echo "wpcom mirrors not found in build output."
+            echo "any=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          printf '%s' "$FILTERED" > "$BUILD_BASE/mirrors.txt"
+          echo "wpcom mirrors to push:"
+          cat "$BUILD_BASE/mirrors.txt"
+          echo "any=true" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for prior instances of the workflow to finish
+        if: steps.filter.outputs.any == 'true'
+        uses: ./.github/actions/turnstile
+
+      - name: Push wpcom mirrors
+        if: steps.filter.outputs.any == 'true'
+        uses: ./projects/github-actions/push-to-mirrors
+        with:
+          source-directory: ${{ github.workspace }}
+          token: ${{ secrets.API_TOKEN_GITHUB }}
+          upstream-ref-since: '2024-04-10'
+          username: matticbot
+          working-directory: ${{ env.BUILD_BASE }}
+        timeout-minutes: 5
 
   jetpack_beta:
     name: Create artifact for Jetpack Beta plugin
@@ -281,7 +396,7 @@ jobs:
           compression-level: 0
 
   update_mirrors:
-    name: Push to mirror repos
+    name: Push general mirror repos
     runs-on: ubuntu-latest
     needs: build
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,7 +191,7 @@ jobs:
           tar --owner=0 --group=0 --xz -cvvf "$FILENAME" -C "$BUILD_BASE" --transform 's,^\.,build,' .
 
           # In case the "Push wpcom projects" below runs, it'll want a modified mirrors.txt
-          printf '%s\n' plugins/jetpack plugins/mu-wpcom-plugin > "$BUILD_BASE/mirrors.txt"
+          printf '%s\n' Automattic/jetpack-production Automattic/jetpack-mu-wpcom-plugin > "$BUILD_BASE/mirrors.txt"
 
       - name: Store build as artifact
         uses: actions/upload-artifact@v7
@@ -301,7 +301,7 @@ jobs:
           ln jetpack-build.tar.xz build.tar.xz
 
       - name: Prepare plugin zips
-        if: steps.plugins.outputs.any
+        if: steps.plugins.outputs.any == 'true'
         id: plugin-zips
         env:
           SHA: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,25 +18,23 @@ permissions:
 
 env:
   COMPOSER_ROOT_VERSION: "dev-trunk"
+  # This string is used as a unique identifier of test reminder comments on PRs.
+  TEST_COMMENT_INDICATOR: "<!-- wpcom-reminder-comment -->"
 
 jobs:
-  build:
-    name: Build all projects
+  prepare:
+    name: Prepare build matrix
     runs-on: ubuntu-latest
-    timeout-minutes: 30  # 2025-11-06: Build times have crept up to ~15–20 minutes as we've added more projects, bump to 30.
+    timeout-minutes: 5  # 2026-04-07: Should take about a minute.
     permissions:
-      # actions/checkout, actions/upload-artifact
+      # actions/checkout
       contents: read
       # Comment posting
       pull-requests: write
-    env:
-      # Hard-code a specific directory to avoid paths in vendor/composer/installed.json changing every build.
-      BUILD_BASE: /tmp/jetpack-build
-      # This string is used as a unique identifier of test reminder comments on PRs.
-      TEST_COMMENT_INDICATOR: "<!-- wpcom-reminder-comment -->"
     outputs:
-      any_plugins: ${{ steps.plugins.outputs.any }}
       changed_projects: ${{ steps.changed.outputs.projects }}
+      build_matrix: ${{ steps.changed.outputs.build-matrix }}
+      comment_id: ${{ steps.check-test-reminder-comment.outputs.result }}
 
     steps:
       - uses: actions/checkout@v6
@@ -55,11 +53,45 @@ jobs:
       - name: Pnpm install
         run: pnpm install
 
+      # For trunk merges, we build everything but split into two jobs: 'wpcom' and 'non-wpcom'. The 'wpcom' job pushes certain plugins to mirrors.
+      # For everything else, we do a single build job.
       - name: Detect changed projects
         id: changed
         run: |
-          CHANGED="$(EXTRA=build .github/files/list-changed-projects.sh)"
-          echo "projects=${CHANGED}" >> "$GITHUB_OUTPUT"
+          if [[ "$GITHUB_EVENT_NAME" == 'push' && "$GITHUB_REF" == 'refs/heads/trunk' ]]; then
+            pnpm jetpack dependencies list --extra=build --ignore-root | sort > all.txt
+            pnpm jetpack dependencies list --extra=build --ignore-root --add-dependencies plugins/jetpack plugins/mu-wpcom-plugin | sort > wpcom.txt
+            comm -23 all.txt wpcom.txt > non-wpcom.txt
+
+            CHANGED=$( jq -ncR 'reduce inputs as $i ({}; .[$i] |= true)' all.txt )
+            echo "projects=${CHANGED}" >> "$GITHUB_OUTPUT"
+
+            WPCOM=$( jq -ncR 'reduce inputs as $i ({}; .[$i] |= true)' wpcom.txt )
+            NONWPCOM=$( jq -ncR 'reduce inputs as $i ({}; .[$i] |= true)' non-wpcom.txt )
+
+            MATRIX=$( jq -nc --arg WPCOM "$WPCOM" --arg NONWPCOM "$NONWPCOM" '[
+              {
+                what: "wpcom",
+                changed: $WPCOM,
+              },
+              {
+                what: "non-wpcom",
+                changed: $NONWPCOM,
+              }
+            ]' )
+            echo "build-matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          else
+            CHANGED="$(EXTRA=build .github/files/list-changed-projects.sh)"
+            echo "projects=${CHANGED}" >> "$GITHUB_OUTPUT"
+
+            MATRIX=$( jq -nc --arg CHANGED "$CHANGED" '[
+              {
+                what: "all",
+                changed: $CHANGED,
+              }
+            ]' )
+            echo "build-matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Check if a WordPress.com test reminder comment is needed.
         id: check-test-reminder-comment
@@ -73,11 +105,44 @@ jobs:
             const data = await checkTestPendingComment( github, context, core );
             return data;
 
+  build:
+    name: Build ${{ matrix.what }} projects
+    runs-on: ubuntu-latest
+    needs: prepare
+    env:
+      FILENAME: partial-build-${{ matrix.what }}.tar.xz
+      CHANGED: ${{ matrix.changed }}
+      # Hard-code a specific directory to avoid paths in vendor/composer/installed.json changing every build.
+      BUILD_BASE: /tmp/jetpack-build
+    permissions:
+      # .github/actions/turnstile
+      actions: read
+      # actions/checkout, actions/upload-artifact
+      contents: read
+      # push-to-mirrors uses secrets.API_TOKEN_GITHUB, so no need for permissions
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson( needs.prepare.outputs.build_matrix ) }}
+
+    # We don't set a job-level timeout because the turnstyle step may take arbitrarily long.
+
+    steps:
+      - uses: actions/checkout@v6
+        timeout-minutes: 1  # 2026-04-07: Successful runs seem to take a few seconds
+
+      - name: Setup tools
+        uses: ./.github/actions/tool-setup
+        timeout-minutes: 3  # 2026-04-07: Successful runs seem to take ~30 seconds
+
+      - name: Pnpm install
+        timeout-minutes: 5  # 2025-11-20: The pnpm install may take a few minutes on cache miss.
+        run: pnpm install
+
       # We need the tree (but not the blob) for packages that will have -alpha version numbers so the timestamp appending works right.
       # We also need the tree for js-packages/social-logos/src/svg so the font build will work right.
       - name: Deepen tree for packages
-        env:
-          CHANGED: ${{ steps.changed.outputs.projects }}
+        timeout-minutes: 1  # 2026-04-07: Successful runs seem to take a few seconds
         run: |
           mapfile -t PROJECTS < <(jq -r 'to_entries[] | select( .value ) | .key' <<<"$CHANGED")
           if [[ ${#PROJECTS[@]} -gt 0 ]]; then
@@ -109,9 +174,7 @@ jobs:
           fi
 
       - name: Build changed projects
-        id: build
-        env:
-          CHANGED: ${{ steps.changed.outputs.projects }}
+        timeout-minutes: 25  # 2026-04-07: Successful runs seem to take ~15 minutes.
         run: |
           mapfile -t PROJECTS < <(jq -r 'to_entries[] | select( .value ) | .key' <<<"$CHANGED")
           if [[ ${#PROJECTS[@]} -eq 0 ]]; then
@@ -119,214 +182,127 @@ jobs:
             mkdir "$BUILD_BASE"
             touch "$BUILD_BASE/mirrors.txt"
           else
-            # On trunk pushes, exclude wpcom deploy projects (plugins/jetpack, plugins/mu-wpcom-plugin)
-            # which are built by the parallel build_wpcom job. This cuts the general build from ~13 min to ~3.5 min.
-            if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/trunk" ]]; then
-              GENERAL=()
-              for P in "${PROJECTS[@]}"; do
-                if [[ "$P" != "plugins/jetpack" && "$P" != "plugins/mu-wpcom-plugin" ]]; then
-                  GENERAL+=("$P")
-                fi
-              done
-              PROJECTS=("${GENERAL[@]}")
-            fi
             pnpm jetpack build -v --no-pnpm-install --for-mirrors="$BUILD_BASE" "${PROJECTS[@]}"
           fi
 
+      - name: Create archive
+        timeout-minutes: 5  # 2026-04-07: Takes a minute or two.
+        run: |
+          tar --owner=0 --group=0 --xz -cvvf "$FILENAME" -C "$BUILD_BASE" --transform 's,^\.,build,' .
+
+          # In case the "Push wpcom projects" below runs, it'll want a modified mirrors.txt
+          printf '%s\n' plugins/jetpack plugins/mu-wpcom-plugin > "$BUILD_BASE/mirrors.txt"
+
+      - name: Store build as artifact
+        uses: actions/upload-artifact@v7
+        timeout-minutes: 5  # 2026-04-07: Should take just a few seconds.
+        with:
+          path: ${{ env.FILENAME }}
+          retention-days: 1
+          # Already compressed.
+          compression-level: 0
+          archive: false
+
+      - name: Wait for prior instances of the workflow to finish
+        if: github.event_name == 'push' && github.repository == 'Automattic/jetpack' && matrix.what == 'wpcom'
+        uses: ./.github/actions/turnstile
+
+      - name: Push wpcom projects
+        if: github.event_name == 'push' && github.repository == 'Automattic/jetpack' && matrix.what == 'wpcom'
+        uses: ./projects/github-actions/push-to-mirrors
+        with:
+          source-directory: ${{ github.workspace }}
+          token: ${{ secrets.API_TOKEN_GITHUB }}
+          upstream-ref-since: '2024-04-10' # No point in checking 12 years of earlier commits from before we started adding "Upstream-Ref".
+          username: matticbot
+          working-directory: ${{ env.BUILD_BASE }}
+        timeout-minutes: 10  # 2025-11-06: Successful runs seem to take a minute or two.
+
+  merge_artifacts:
+    name: Merge build artifacts
+    runs-on: ubuntu-latest
+    timeout-minutes: 10  # 2026-04-07: Should take a minute or two.
+    needs: [ prepare, build ]
+    permissions:
+      # actions/checkout, actions/upload-artifact, actions/download-artifact
+      contents: read
+      # Comment posting
+      pull-requests: write
+    env:
+      BUILD_BASE: ${{ github.workspace }}/build
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          path: monorepo
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: partial-build-*.tar.xz
+          merge-multiple: true
+      - name: Extract and merge build archives
+        run: |
+          mkdir merged
+          touch merged.mirrors.txt
+          for ARCHIVE in partial-build-*.tar.xz; do
+            echo "::group::Extracting $ARCHIVE"
+            tar --xz -xvvf "$ARCHIVE" build
+            echo "::endgroup::"
+            for MIRROR in $(< build/mirrors.txt ); do
+              if [[ ! -d "merged/$MIRROR" ]]; then
+                echo "Copying $MIRROR from $ARCHIVE"
+                mkdir -p "$( dirname "merged/$MIRROR" )"
+                mv "build/$MIRROR" "merged/$MIRROR"
+                echo "$MIRROR" >> merged/mirrors.txt
+              elif [[ "$MIRROR" == 'Automattic/storybook' || "$MIRROR" == 'Automattic/charts' ]]; then
+                # Known unstable builds
+                echo "Ignoring $MIRROR from $ARCHIVE, already copied"
+              elif diff -ur "build/$MIRROR" "merged/$MIRROR" > diff.txt; then
+                echo "Skipping $MIRROR from $ARCHIVE, matches earlier copied build"
+              else
+                echo "::warning::Multiple builds for $MIRROR differ!"
+                echo "::group::Diff for $MIRROR builds"
+                cat diff.txt
+                echo "::endgroup::"
+              fi
+            done
+            rm -rf build
+          done
+          mv merged build
+
       - name: Filter mirror list for release branch
         if: github.ref == 'refs/heads/prerelease' || contains( github.ref, '/branch-' )
+        working-directory: ./monorepo
         run: .github/files/filter-mirrors-for-release-branch.sh
 
       - name: Determine plugins to publish
         id: plugins
+        working-directory: ./monorepo
         run: |
           jq -r 'if .extra["mirror-repo"] and ( .extra["beta-plugin-slug"] // .extra["wp-plugin-slug"] ) then [ ( input_filename | sub( "/composer\\.json$"; "" ) ), .extra["mirror-repo"], .extra["beta-plugin-slug"] // .extra["wp-plugin-slug"] ] else empty end | @tsv' projects/plugins/*/composer.json | while IFS=$'\t' read -r SRC MIRROR SLUG; do
             if [[ -e "$BUILD_BASE/$MIRROR" ]] && grep -q --fixed-strings --line-regexp "$MIRROR" "$BUILD_BASE/mirrors.txt"; then
               printf '%s\t%s\t%s\n' "$SRC" "$MIRROR" "$SLUG"
             fi
           done > "$BUILD_BASE/plugins.tsv"
-          if [[ -s "$BUILD_BASE/plugins.tsv" ]]; then
-            cat "$BUILD_BASE/plugins.tsv"
-            echo "any=true" >> "$GITHUB_OUTPUT"
-          else
+          if [[ ! -s "$BUILD_BASE/plugins.tsv" ]]; then
             echo "No plugins were built"
             echo "any=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
-      # GitHub's artifact stuff doesn't preserve permissions or file case. Sigh.
-      # This is the official workaround: https://github.com/actions/upload-artifact#maintaining-file-permissions-and-case-sensitive-files
-      # It'll also make it faster to upload and download though, so maybe it's a win anyway.
-      - name: Create archive
+          cat "$BUILD_BASE/plugins.tsv"
+          echo "any=true" >> "$GITHUB_OUTPUT"
+
+      - name: Create merged archive
         run: |
           tar --owner=0 --group=0 --xz -cvvf jetpack-build.tar.xz -C "$BUILD_BASE" --transform 's,^\.,build,' .
           # For Store build as artifact (old)
           ln jetpack-build.tar.xz build.tar.xz
 
-      # 2026-03-02: Temporarily upload the artifact twice, under both old and new names, as we update things using the old name.
-      - name: Store build as artifact (old)
-        uses: actions/upload-artifact@v7
-        with:
-          name: jetpack-build
-          path: build.tar.xz
-          # Retain trunk builds for 7 days so we can manually download for branch comparisons. Branch builds only need one day so the beta builder can slurp it up to distribute.
-          retention-days: ${{ case( github.ref == 'refs/heads/trunk', 7, 1 ) }}
-          # Already compressed.
-          compression-level: 0
-      - name: Store build as artifact (new)
-        uses: actions/upload-artifact@v7
-        with:
-          path: jetpack-build.tar.xz
-          # Retain trunk builds for 7 days so we can manually download for branch comparisons. Branch builds only need one day so the beta builder can slurp it up to distribute.
-          retention-days: ${{ case( github.ref == 'refs/heads/trunk', 7, 1 ) }}
-          # Already compressed.
-          compression-level: 0
-          archive: false
-
-      - name: Store plugins.tsv as artifact
-        if: steps.plugins.outputs.any == 'true'
-        uses: actions/upload-artifact@v7
-        with:
-          path: ${{ env.BUILD_BASE }}/plugins.tsv
-          # We don't really care about this artifact, its presence is a flag to the post-build job.
-          retention-days: 1
-          archive: false
-
-      - name: Update reminder with testing instructions
-        id: update-reminder-comment
-        uses: actions/github-script@v8
-        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name && fromJSON(steps.check-test-reminder-comment.outputs.result)['commentId'] != 0 }}
-        env:
-          BRANCH_NAME: ${{ github.head_ref }}
-          DATA: ${{ steps.check-test-reminder-comment.outputs.result }}
-        with:
-          script: |
-            const { checkTestReminderComment } = require('.github/files/build-reminder-comment/check-test-reminder-comment.js')
-            await checkTestReminderComment( github, context, core );
-
-  build_wpcom:
-    name: Build wpcom deploy projects
-    runs-on: ubuntu-latest
-    timeout-minutes: 25  # Should take ~10 min, but turnstile may add wait time.
-    permissions:
-      # .github/actions/turnstile
-      actions: read
-      # actions/checkout
-      contents: read
-      # push-to-mirrors uses secrets.API_TOKEN_GITHUB, so no need for permissions
-
-    # Only run on pushes to trunk. Other branches and PRs don't need the wpcom build lane.
-    if: github.event_name == 'push' && github.ref == 'refs/heads/trunk' && github.repository == 'Automattic/jetpack'
-
-    env:
-      BUILD_BASE: /tmp/jetpack-build-wpcom
-
-    steps:
-      - uses: actions/checkout@v6
-        timeout-minutes: 1
-
-      - name: Setup tools
-        uses: ./.github/actions/tool-setup
-        timeout-minutes: 2
-
-      - name: Pnpm install
-        run: pnpm install
-        timeout-minutes: 3
-
-      # Same as the general build's "Deepen tree for packages" step, but scoped to the wpcom projects.
-      - name: Deepen tree for packages
-        run: |
-          WPCOM_PROJECTS=(plugins/jetpack plugins/mu-wpcom-plugin)
-          depth=$( git rev-list --count --first-parent HEAD )
-          [[ "$depth" -lt 1000 ]] && depth=1000
-          BASE=$PWD
-          REF=$(git rev-parse HEAD)
-          for SLUG in $(pnpm jetpack dependencies list --add-dependencies --extra="build" --ignore-root "${WPCOM_PROJECTS[@]}"); do
-            cd "$BASE/projects/$SLUG/"
-            if [[ "$SLUG" == packages/* ]]; then
-              SUBDIR=.
-              # Only deepen if it'll be a -alpha, i.e. it has changelog entries
-              CHANGES_DIR="$(jq -r '.extra.changelogger["changes-dir"] // "changelog"' composer.json)"
-              [[ -d "$CHANGES_DIR" && -n "$(ls -- "$CHANGES_DIR")" ]] || continue
-            elif [[ "$SLUG" == js-packages/social-logos ]]; then
-              SUBDIR=./src/svg
-            else
-              continue
-            fi
-            echo "Checking depth for $SLUG"
-            while git log --format='%h, %D,' -1 "$SUBDIR" | grep ', grafted,'; do
-              depth=$((depth * 2))
-              echo "::group::Deepen to $depth"
-              echo "/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=$depth --filter=blob:none origin $REF"
-              /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=$depth --filter=blob:none origin "$REF"
-              echo "::endgroup::"
-            done
-          done
-        timeout-minutes: 2
-
-      - name: Build wpcom projects
-        run: pnpm jetpack build -v --no-pnpm-install --for-mirrors="$BUILD_BASE" plugins/jetpack plugins/mu-wpcom-plugin
-        timeout-minutes: 15
-
-      - name: Filter mirrors to wpcom repos
-        id: filter
-        run: |
-          WPCOM_MIRRORS=("Automattic/jetpack-production" "Automattic/jetpack-mu-wpcom-plugin")
-          if [[ ! -s "$BUILD_BASE/mirrors.txt" ]]; then
-            echo "No mirrors were built."
-            echo "any=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          FILTERED=""
-          for MIRROR in "${WPCOM_MIRRORS[@]}"; do
-            if grep -q --fixed-strings --line-regexp "$MIRROR" "$BUILD_BASE/mirrors.txt"; then
-              FILTERED+="$MIRROR"$'\n'
-            fi
-          done
-          if [[ -z "$FILTERED" ]]; then
-            echo "wpcom mirrors not found in build output."
-            echo "any=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          printf '%s' "$FILTERED" > "$BUILD_BASE/mirrors.txt"
-          echo "wpcom mirrors to push:"
-          cat "$BUILD_BASE/mirrors.txt"
-          echo "any=true" >> "$GITHUB_OUTPUT"
-
-      - name: Wait for prior instances of the workflow to finish
-        if: steps.filter.outputs.any == 'true'
-        uses: ./.github/actions/turnstile
-
-      - name: Push wpcom mirrors
-        if: steps.filter.outputs.any == 'true'
-        uses: ./projects/github-actions/push-to-mirrors
-        with:
-          source-directory: ${{ github.workspace }}
-          token: ${{ secrets.API_TOKEN_GITHUB }}
-          upstream-ref-since: '2024-04-10'
-          username: matticbot
-          working-directory: ${{ env.BUILD_BASE }}
-        timeout-minutes: 5
-
-  jetpack_beta:
-    name: Create artifact for Jetpack Beta plugin
-    runs-on: ubuntu-latest
-    needs: build
-    if: needs.build.outputs.any_plugins == 'true'
-    timeout-minutes: 10  # 2025-11-06: Successful runs should take about 30 seconds. But sometimes the upload is slow.
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          path: monorepo
-
-      - name: Download build artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: jetpack-build.tar.xz
-      - name: Extract build archive
-        run: tar --xz -xvvf jetpack-build.tar.xz build
-
       - name: Prepare plugin zips
-        id: prepare
+        if: steps.plugins.outputs.any
+        id: plugin-zips
         env:
           SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
@@ -384,9 +360,38 @@ jobs:
           fi
           echo "any-built=$ANY_BUILT" >> "$GITHUB_OUTPUT"
 
+      # 2026-03-02: Temporarily upload the artifact twice, under both old and new names, as we update things using the old name.
+      - name: Store build as artifact (old)
+        uses: actions/upload-artifact@v7
+        with:
+          name: jetpack-build
+          path: build.tar.xz
+          # Retain trunk builds for 7 days so we can manually download for branch comparisons. Branch builds only need one day so the beta builder can slurp it up to distribute.
+          retention-days: ${{ case( github.ref == 'refs/heads/trunk', 7, 1 ) }}
+          # Already compressed.
+          compression-level: 0
+      - name: Store build as artifact (new)
+        uses: actions/upload-artifact@v7
+        with:
+          path: jetpack-build.tar.xz
+          # Retain trunk builds for 7 days so we can manually download for branch comparisons. Branch builds only need one day so the beta builder can slurp it up to distribute.
+          retention-days: ${{ case( github.ref == 'refs/heads/trunk', 7, 1 ) }}
+          # Already compressed.
+          compression-level: 0
+          archive: false
+
+      - name: Store plugins.tsv as artifact
+        if: steps.plugins.outputs.any == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          path: ${{ env.BUILD_BASE }}/plugins.tsv
+          # We don't really care about this artifact, its presence is a flag to the post-build job.
+          retention-days: 1
+          archive: false
+
       - name: Create plugins artifact
         uses: actions/upload-artifact@v7
-        if: steps.prepare.outputs.any-built == 'true'
+        if: steps.plugin-zips.outputs.any-built == 'true'
         with:
           name: plugins
           path: zips
@@ -395,10 +400,22 @@ jobs:
           # Already compressed.
           compression-level: 0
 
+      - name: Update reminder with testing instructions
+        id: update-reminder-comment
+        uses: actions/github-script@v8
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name && fromJSON(needs.prepare.outputs.comment_id)['commentId'] != 0 }}
+        env:
+          BRANCH_NAME: ${{ github.head_ref }}
+          DATA: ${{ needs.prepare.outputs.comment_id }}
+        with:
+          script: |
+            const { checkTestReminderComment } = require('./monorepo/.github/files/build-reminder-comment/check-test-reminder-comment.js')
+            await checkTestReminderComment( github, context, core );
+
   update_mirrors:
-    name: Push general mirror repos
+    name: Push to mirror repos
     runs-on: ubuntu-latest
-    needs: build
+    needs: merge_artifacts
     permissions:
       # .github/actions/turnstile
       actions: read


### PR DESCRIPTION
Fixes MONOREP-403

## Proposed changes

* Split the trunk build into two parallel lanes:
  * **`build_wpcom`**: builds `plugins/jetpack` + `plugins/mu-wpcom-plugin` (and their dependencies), then pushes their mirrors (`jetpack-production`, `jetpack-mu-wpcom-plugin`) immediately. This is the lane that unblocks the wpcom deploy notification.
  * **`build` (general)**: builds everything else, excluding the two wpcom plugins. This cuts the general build from ~13 min to ~3.5 min since `plugins/jetpack` (the heaviest webpack build) is no longer in its critical path.
* Each lane pushes its own non-overlapping set of mirrors — no duplicate pushes or race conditions
* On PRs and non-trunk branches, the build job continues to work as before (building all changed projects)

### Other information

Timeline analysis of [PR #47919](https://github.com/Automattic/jetpack/pull/47919) showed:
- The `Build all projects` step takes ~13 min building all projects on every trunk push
- `plugins/jetpack` with its heavy webpack is the long pole at ~2 min
- `mu-wpcom-plugin` itself takes only 21.5s but doesn't start until 10+ min into the build
- The archive/artifact transfer adds ~2 min overhead that the wpcom lane eliminates entirely

Prior art: MONOREP-177 optimized mirror push order (saving ~1-2 min). This tackles the larger bottleneck: the build step itself.

## Related product discussion/links

* Linear: MONOREP-403
* Prior discussion: p1762272271170879-slack-C05Q5HSS013
* Announcement: pdWQjU-1xQ-p2

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This change only affects CI workflows on trunk pushes. To verify:

* Merge this PR to trunk
* Observe the Build workflow run — there should be a new `Build wpcom deploy projects` job running in parallel with `Build all projects`
* The wpcom lane should complete and push its mirrors before the general build finishes
* The `Push general mirror repos` job should NOT contain `jetpack-production` or `jetpack-mu-wpcom-plugin` in its mirrors list (since the general build excludes those plugins)
* The Slack deploy notification should arrive earlier than usual (~8-10 min instead of ~16 min)