### PR TITLE
Forms: Add PHP foundation for custom field extensibility

### DIFF
--- a/projects/packages/forms/changelog/add-form-fields-php-foundation
+++ b/projects/packages/forms/changelog/add-form-fields-php-foundation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Add PHP foundation for custom field extensibility with filter hooks and unified field registry.

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -519,6 +519,37 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				}
 				break;
 			default:
+				/**
+				 * Filter to allow custom validation for form fields.
+				 *
+				 * This filter enables external developers to add validation logic for custom field types.
+				 * Return a string error message to indicate validation failure, true for success,
+				 * or null to fall through to the default validation.
+				 *
+				 * @since $$next-version$$
+				 *
+				 * @param mixed                $result      The validation result. Return string for error, true for success, null for default.
+				 * @param string               $field_type  The type of the field being validated.
+				 * @param mixed                $field_value The submitted value of the field.
+				 * @param string               $field_label The label of the field.
+				 * @param Contact_Form_Field   $field       The field instance.
+				 */
+				$custom_validation = apply_filters(
+					'jetpack_forms_validate_field',
+					null,
+					$field_type,
+					$field_value,
+					$field_label,
+					$this
+				);
+
+				if ( $custom_validation !== null ) {
+					if ( is_string( $custom_validation ) ) {
+						$this->add_error( $custom_validation );
+					}
+					return;
+				}
+
 				// Just check for presence of any text
 				if ( ! is_string( $field_value ) || ! strlen( trim( $field_value ) ) ) {
 					/* translators: %s is the name of a form field */
@@ -718,6 +749,49 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			if ( null !== $maxlabel && '' !== $maxlabel ) {
 				$extra_attrs['maxLabel'] = $maxlabel;
 			}
+		}
+
+		/**
+		 * Filter to allow custom rendering for form fields.
+		 *
+		 * This filter enables external developers to provide custom HTML rendering for their field types.
+		 * Return a string with the HTML to render, or null to fall through to the default rendering.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param string|null        $custom_render    The custom HTML to render, or null for default.
+		 * @param string             $field_type       The type of the field.
+		 * @param array              $field_data       Array containing field data (id, label, value, required, placeholder, field instance).
+		 */
+		$custom_render = apply_filters(
+			'jetpack_forms_render_field',
+			null,
+			$field_type,
+			array(
+				'id'          => $field_id,
+				'label'       => $field_label,
+				'value'       => $field_value,
+				'required'    => $field_required,
+				'placeholder' => $field_placeholder,
+				'class'       => $field_class,
+				'extra_attrs' => $extra_attrs,
+				'field'       => $this,
+			)
+		);
+
+		if ( $custom_render !== null ) {
+			/**
+			 * Filter the HTML of the Contact Form.
+			 *
+			 * @module contact-form
+			 *
+			 * @since 2.6.0
+			 *
+			 * @param string $rendered_field Contact Form HTML output.
+			 * @param string $field_label Field label.
+			 * @param int|null $id Post ID.
+			 */
+			return apply_filters( 'grunion_contact_form_field_html', $custom_render, $field_label, ( in_the_loop() ? get_the_ID() : null ) );
 		}
 
 		$rendered_field = $this->render_field( $field_type, $field_id, $field_label, $field_value, $field_class, $field_placeholder, $field_required, $field_required_text, $extra_attrs, $field_required_indicator );
@@ -3418,5 +3492,53 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		}
 
 		return array_slice( $options, 0, $last_valid_index + 1 );
+	}
+
+	/**
+	 * Get the list of registered field types.
+	 *
+	 * This method returns all known field types, including custom ones registered via filter.
+	 * External developers can use the 'jetpack_forms_field_types' filter to register
+	 * their custom field types.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return array List of registered field type strings.
+	 */
+	public static function get_registered_field_types() {
+		$core_field_types = array(
+			'text',
+			'email',
+			'url',
+			'telephone',
+			'textarea',
+			'checkbox',
+			'checkbox-multiple',
+			'radio',
+			'select',
+			'date',
+			'time',
+			'number',
+			'file',
+			'rating',
+			'consent',
+			'hidden',
+			'name',
+			'image-select',
+			'slider',
+		);
+
+		/**
+		 * Filter to register custom field types.
+		 *
+		 * This filter allows external developers to register their custom field types.
+		 * Custom field types should also implement validation via 'jetpack_forms_validate_field'
+		 * and rendering via 'jetpack_forms_render_field'.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param array $field_types List of field type strings.
+		 */
+		return apply_filters( 'jetpack_forms_field_types', $core_field_types );
 	}
 }

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -34,6 +34,10 @@ require_once __DIR__ . '/class-form-submission-error.php';
 // Load the Form_Preview class.
 require_once __DIR__ . '/class-form-preview.php';
 
+// Load the Form_Field_Registry class and global functions.
+require_once __DIR__ . '/class-form-field-registry.php';
+require_once __DIR__ . '/form-field-functions.php';
+
 /**
  * Sets up various actions, filters, post types, post statuses, shortcodes.
  */

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1243,14 +1243,30 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$version = $asset['version'];
 		}
 
+		$core_error_types = array(
+			'is_required'        => __( 'This field is required.', 'jetpack-forms' ),
+			'invalid_form_empty' => __( 'The form you are trying to submit is empty.', 'jetpack-forms' ),
+			'invalid_form'       => __( 'Please fill out the form correctly.', 'jetpack-forms' ),
+			'network_error'      => __( 'Connection issue while submitting the form. Check that you are connected to the Internet and try again.', 'jetpack-forms' ),
+			'preview_mode'       => __( 'Form submissions are disabled in preview mode.', 'jetpack-forms' ),
+		);
+
+		/**
+		 * Filter to register custom error types for form validation.
+		 *
+		 * This filter allows external developers to add custom error messages
+		 * that will be displayed when their custom field validators return
+		 * specific error keys. Error keys follow the pattern 'invalid_{field_type}'
+		 * or custom keys as needed.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param array $error_types Associative array of error keys to error messages.
+		 */
+		$error_types = apply_filters( 'jetpack_forms_error_types', $core_error_types );
+
 		$config = array(
-			'error_types'    => array(
-				'is_required'        => __( 'This field is required.', 'jetpack-forms' ),
-				'invalid_form_empty' => __( 'The form you are trying to submit is empty.', 'jetpack-forms' ),
-				'invalid_form'       => __( 'Please fill out the form correctly.', 'jetpack-forms' ),
-				'network_error'      => __( 'Connection issue while submitting the form. Check that you are connected to the Internet and try again.', 'jetpack-forms' ),
-				'preview_mode'       => __( 'Form submissions are disabled in preview mode.', 'jetpack-forms' ),
-			),
+			'error_types'    => $error_types,
 			'admin_ajax_url' => admin_url( 'admin-ajax.php' ),
 		);
 		wp_interactivity_config( 'jetpack/form', $config );

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -147,6 +147,34 @@ class Feedback_Field {
 	 * @return string
 	 */
 	public function get_render_value( $context = 'default' ) {
+		/**
+		 * Filter to allow custom rendering of field values in different contexts.
+		 *
+		 * This filter enables external developers to provide custom value rendering
+		 * for their field types in various contexts (email, web, api, csv, etc.).
+		 * Return a non-null value to override the default rendering.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param mixed          $custom_render The custom rendered value, or null for default rendering.
+		 * @param string         $context       The rendering context (email, web, api, csv, submit, ajax, default).
+		 * @param string         $field_type    The type of the field.
+		 * @param mixed          $field_value   The raw value of the field.
+		 * @param Feedback_Field $field         The field instance.
+		 */
+		$custom_render = apply_filters(
+			'jetpack_forms_render_field_value',
+			null,
+			$context,
+			$this->type,
+			$this->value,
+			$this
+		);
+
+		if ( $custom_render !== null ) {
+			return $custom_render;
+		}
+
 		switch ( $context ) {
 			case 'submit':
 				return $this->get_render_submit_value();

--- a/projects/packages/forms/src/contact-form/class-form-field-registry.php
+++ b/projects/packages/forms/src/contact-form/class-form-field-registry.php
@@ -1,0 +1,467 @@
+<?php
+/**
+ * Form Field Registry
+ *
+ * Provides a unified API for registering custom form field types.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+/**
+ * Registry for custom form field types.
+ *
+ * Similar to WordPress's register_post_type(), this provides a single function
+ * to register all aspects of a custom form field: block registration, validation,
+ * rendering, and dashboard integration.
+ */
+class Form_Field_Registry {
+
+	/**
+	 * Registered field types.
+	 *
+	 * @var array
+	 */
+	private static $registered_fields = array();
+
+	/**
+	 * Whether the hooks have been initialized.
+	 *
+	 * @var bool
+	 */
+	private static $hooks_initialized = false;
+
+	/**
+	 * Register a custom form field type.
+	 *
+	 * This function provides a unified API for registering custom form fields,
+	 * similar to WordPress's register_post_type(). It handles:
+	 * - Block registration (both PHP and asset enqueueing)
+	 * - Field type registration
+	 * - Validation callbacks
+	 * - Frontend rendering
+	 * - Response value rendering (email, CSV, API, dashboard)
+	 * - Error messages
+	 * - Dashboard script registration
+	 *
+	 * @param string $field_type The field type identifier (e.g., 'color', 'rating').
+	 * @param array  $args       {
+	 *     Configuration arguments for the field type.
+	 *
+	 *     @type string   $block_name           Block name. Defaults to 'jetpack/field-{$field_type}'.
+	 *     @type array    $block_attributes     Block attributes definition.
+	 *     @type callable $render_callback      Block render callback. Receives ($atts, $content, $block).
+	 *                                          If not provided, uses default that calls Contact_Form::parse_contact_field().
+	 *     @type callable $validate_callback    Validation callback. Receives ($value, $label, $field).
+	 *                                          Return true for valid, string error message for invalid.
+	 *     @type callable $render_field         Frontend field render callback. Receives ($data).
+	 *                                          Return HTML string or null for default rendering.
+	 *     @type callable $render_value         Value render callback. Receives ($context, $value, $field).
+	 *                                          Context is 'email', 'web', 'ajax', 'csv', 'api'.
+	 *                                          Return rendered value or null for default.
+	 *     @type array    $error_messages       Associative array of error_key => message.
+	 *     @type string   $editor_script        URL to the editor script.
+	 *     @type array    $editor_script_deps   Editor script dependencies.
+	 *     @type string   $editor_script_ver    Editor script version.
+	 *     @type string   $dashboard_script     URL to the dashboard script.
+	 *     @type array    $dashboard_script_deps Dashboard script dependencies.
+	 *     @type string   $dashboard_script_ver Dashboard script version.
+	 * }
+	 * @return bool True on success, false on failure.
+	 */
+	public static function register( $field_type, $args = array() ) {
+		if ( empty( $field_type ) || ! is_string( $field_type ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				esc_html__( 'Field type must be a non-empty string.', 'jetpack-forms' ),
+				'1.0.0'
+			);
+			return false;
+		}
+
+		// Sanitize field type to lowercase alphanumeric with hyphens.
+		$field_type = sanitize_key( $field_type );
+
+		if ( isset( self::$registered_fields[ $field_type ] ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				sprintf(
+					/* translators: %s: field type */
+					esc_html__( 'Field type "%s" is already registered.', 'jetpack-forms' ),
+					esc_html( $field_type )
+				),
+				'1.0.0'
+			);
+			return false;
+		}
+
+		$defaults = array(
+			'block_name'            => 'jetpack/field-' . $field_type,
+			'block_attributes'      => array(),
+			'render_callback'       => null,
+			'validate_callback'     => null,
+			'render_field'          => null,
+			'render_value'          => null,
+			'error_messages'        => array(),
+			'editor_script'         => '',
+			'editor_script_deps'    => array( 'wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-i18n' ),
+			'editor_script_ver'     => '1.0.0',
+			'dashboard_script'      => '',
+			'dashboard_script_deps' => array( 'wp-hooks', 'wp-element', 'jp-forms-dashboard' ),
+			'dashboard_script_ver'  => '1.0.0',
+		);
+
+		$args = wp_parse_args( $args, $defaults );
+
+		// Store the field configuration.
+		self::$registered_fields[ $field_type ] = $args;
+
+		// Initialize hooks if not already done.
+		self::init_hooks();
+
+		// Register the block if Jetpack Forms is active.
+		if ( did_action( 'init' ) ) {
+			self::register_block( $field_type, $args );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get a registered field type configuration.
+	 *
+	 * @param string $field_type The field type identifier.
+	 * @return array|null The field configuration or null if not registered.
+	 */
+	public static function get( $field_type ) {
+		return self::$registered_fields[ $field_type ] ?? null;
+	}
+
+	/**
+	 * Get all registered field types.
+	 *
+	 * @return array Array of registered field types.
+	 */
+	public static function get_all() {
+		return self::$registered_fields;
+	}
+
+	/**
+	 * Check if a field type is registered.
+	 *
+	 * @param string $field_type The field type identifier.
+	 * @return bool True if registered, false otherwise.
+	 */
+	public static function is_registered( $field_type ) {
+		return isset( self::$registered_fields[ $field_type ] );
+	}
+
+	/**
+	 * Get all registered block names.
+	 *
+	 * @return array Array of block names (e.g., 'jetpack/field-color').
+	 */
+	public static function get_registered_block_names() {
+		$block_names = array();
+		foreach ( self::$registered_fields as $args ) {
+			$block_names[] = $args['block_name'];
+		}
+		return $block_names;
+	}
+
+	/**
+	 * Initialize the filter hooks.
+	 */
+	private static function init_hooks() {
+		if ( self::$hooks_initialized ) {
+			return;
+		}
+
+		self::$hooks_initialized = true;
+
+		// Register field types.
+		add_filter( 'jetpack_forms_field_types', array( __CLASS__, 'filter_field_types' ) );
+
+		// Validation.
+		add_filter( 'jetpack_forms_validate_field', array( __CLASS__, 'filter_validate_field' ), 10, 5 );
+
+		// Frontend field rendering.
+		add_filter( 'jetpack_forms_render_field', array( __CLASS__, 'filter_render_field' ), 10, 3 );
+
+		// Value rendering.
+		add_filter( 'jetpack_forms_render_field_value', array( __CLASS__, 'filter_render_value' ), 10, 5 );
+
+		// Error messages.
+		add_filter( 'jetpack_forms_error_types', array( __CLASS__, 'filter_error_types' ) );
+
+		// Block registration on init (for fields registered before init).
+		add_action( 'init', array( __CLASS__, 'register_blocks' ), 20 );
+
+		// Editor scripts.
+		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_editor_assets' ) );
+
+		// Dashboard scripts.
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_dashboard_assets' ), 20 );
+	}
+
+	/**
+	 * Register blocks for all registered field types.
+	 *
+	 * Hooked to 'init' action.
+	 */
+	public static function register_blocks() {
+		foreach ( self::$registered_fields as $field_type => $args ) {
+			self::register_block( $field_type, $args );
+		}
+	}
+
+	/**
+	 * Register a single block for a field type.
+	 *
+	 * @param string $field_type The field type identifier.
+	 * @param array  $args       The field configuration.
+	 */
+	private static function register_block( $field_type, $args ) {
+		// Only register if Jetpack Forms is active.
+		if ( ! class_exists( 'Automattic\Jetpack\Forms\ContactForm\Contact_Form' ) ) {
+			return;
+		}
+
+		$block_name = $args['block_name'];
+
+		// Check if block is already registered.
+		if ( \WP_Block_Type_Registry::get_instance()->is_registered( $block_name ) ) {
+			return;
+		}
+
+		// Determine the render callback.
+		$render_callback = $args['render_callback'];
+		if ( ! is_callable( $render_callback ) ) {
+			// Use default render callback that integrates with the forms system.
+			$render_callback = function ( $atts, $content, $block ) use ( $field_type ) {
+				return self::default_render_callback( $atts, $content, $block, $field_type );
+			};
+		}
+
+		// Default block attributes.
+		$default_attributes = array(
+			'label'             => array(
+				'type'    => 'string',
+				'default' => ucfirst( $field_type ),
+			),
+			'required'          => array(
+				'type'    => 'boolean',
+				'default' => false,
+			),
+			'requiredText'      => array(
+				'type'    => 'string',
+				'default' => '(required)',
+			),
+			'requiredIndicator' => array(
+				'type'    => 'boolean',
+				'default' => true,
+			),
+			'width'             => array(
+				'type'    => 'number',
+				'default' => 100,
+			),
+			'id'                => array(
+				'type' => 'string',
+			),
+		);
+
+		$block_attributes = array_merge( $default_attributes, $args['block_attributes'] );
+
+		register_block_type(
+			$block_name,
+			array(
+				'api_version'     => 3,
+				'render_callback' => $render_callback,
+				'attributes'      => $block_attributes,
+			)
+		);
+	}
+
+	/**
+	 * Default render callback for custom field blocks.
+	 *
+	 * Integrates with the Jetpack Forms system by calling Contact_Form::parse_contact_field().
+	 *
+	 * @param array     $atts       Block attributes.
+	 * @param string    $content    Block content.
+	 * @param \WP_Block $block      Block instance.
+	 * @param string    $field_type The field type.
+	 * @return string HTML output.
+	 */
+	private static function default_render_callback( $atts, $content, $block, $field_type ) {
+		// Set the field type.
+		$atts['type'] = $field_type;
+
+		// Convert block attribute names to shortcode format.
+		if ( isset( $atts['defaultValue'] ) ) {
+			$atts['default'] = $atts['defaultValue'];
+			unset( $atts['defaultValue'] );
+		}
+
+		if ( isset( $atts['className'] ) ) {
+			$atts['class'] = $atts['className'];
+			unset( $atts['className'] );
+		}
+
+		// Call the forms system to parse and render the field.
+		return Contact_Form::parse_contact_field( $atts, $content, $block );
+	}
+
+	/**
+	 * Filter: Add registered field types to the list.
+	 *
+	 * @param array $types Existing field types.
+	 * @return array Modified field types.
+	 */
+	public static function filter_field_types( $types ) {
+		foreach ( self::$registered_fields as $field_type => $args ) {
+			if ( ! in_array( $field_type, $types, true ) ) {
+				$types[] = $field_type;
+			}
+		}
+		return $types;
+	}
+
+	/**
+	 * Filter: Validate custom field types.
+	 *
+	 * @param mixed              $result Current validation result.
+	 * @param string             $type   Field type.
+	 * @param mixed              $value  Field value.
+	 * @param string             $label  Field label.
+	 * @param Contact_Form_Field $field  Field instance.
+	 * @return mixed Validation result.
+	 */
+	public static function filter_validate_field( $result, $type, $value, $label, $field ) {
+		if ( ! isset( self::$registered_fields[ $type ] ) ) {
+			return $result;
+		}
+
+		$args = self::$registered_fields[ $type ];
+
+		if ( ! is_callable( $args['validate_callback'] ) ) {
+			return $result;
+		}
+
+		return call_user_func( $args['validate_callback'], $value, $label, $field );
+	}
+
+	/**
+	 * Filter: Render custom field HTML.
+	 *
+	 * @param string|null $html Field HTML.
+	 * @param string      $type Field type.
+	 * @param array       $data Field data.
+	 * @return string|null Rendered HTML.
+	 */
+	public static function filter_render_field( $html, $type, $data ) {
+		if ( ! isset( self::$registered_fields[ $type ] ) ) {
+			return $html;
+		}
+
+		$args = self::$registered_fields[ $type ];
+
+		if ( ! is_callable( $args['render_field'] ) ) {
+			return $html;
+		}
+
+		return call_user_func( $args['render_field'], $data );
+	}
+
+	/**
+	 * Filter: Render field value for different contexts.
+	 *
+	 * @param mixed          $rendered Rendered value.
+	 * @param string         $context  Render context (email, web, ajax, csv, api).
+	 * @param string         $type     Field type.
+	 * @param mixed          $value    Raw field value.
+	 * @param Feedback_Field $field    Field instance.
+	 * @return mixed Rendered value.
+	 */
+	public static function filter_render_value( $rendered, $context, $type, $value, $field ) {
+		if ( ! isset( self::$registered_fields[ $type ] ) ) {
+			return $rendered;
+		}
+
+		$args = self::$registered_fields[ $type ];
+
+		if ( ! is_callable( $args['render_value'] ) ) {
+			return $rendered;
+		}
+
+		return call_user_func( $args['render_value'], $context, $value, $field );
+	}
+
+	/**
+	 * Filter: Add custom error messages.
+	 *
+	 * @param array $error_types Existing error types.
+	 * @return array Modified error types.
+	 */
+	public static function filter_error_types( $error_types ) {
+		foreach ( self::$registered_fields as $args ) {
+			if ( ! empty( $args['error_messages'] ) && is_array( $args['error_messages'] ) ) {
+				$error_types = array_merge( $error_types, $args['error_messages'] );
+			}
+		}
+		return $error_types;
+	}
+
+	/**
+	 * Enqueue editor scripts for registered fields.
+	 */
+	public static function enqueue_editor_assets() {
+		// Only load if Jetpack Forms is active.
+		if ( ! class_exists( 'Automattic\Jetpack\Forms\ContactForm\Contact_Form' ) ) {
+			return;
+		}
+
+		foreach ( self::$registered_fields as $field_type => $args ) {
+			if ( empty( $args['editor_script'] ) ) {
+				continue;
+			}
+
+			$handle = 'jetpack-forms-field-' . $field_type . '-editor';
+
+			wp_enqueue_script(
+				$handle,
+				$args['editor_script'],
+				$args['editor_script_deps'],
+				$args['editor_script_ver'],
+				true
+			);
+		}
+	}
+
+	/**
+	 * Enqueue dashboard scripts for registered fields.
+	 */
+	public static function enqueue_dashboard_assets() {
+		// Only load if the Jetpack Forms dashboard script is registered.
+		if ( ! wp_script_is( 'jp-forms-dashboard', 'registered' ) && ! wp_script_is( 'jp-forms-dashboard', 'enqueued' ) ) {
+			return;
+		}
+
+		foreach ( self::$registered_fields as $field_type => $args ) {
+			if ( empty( $args['dashboard_script'] ) ) {
+				continue;
+			}
+
+			$handle = 'jetpack-forms-field-' . $field_type . '-dashboard';
+
+			wp_enqueue_script(
+				$handle,
+				$args['dashboard_script'],
+				$args['dashboard_script_deps'],
+				$args['dashboard_script_ver'],
+				true
+			);
+		}
+	}
+}

--- a/projects/packages/forms/src/contact-form/form-field-functions.php
+++ b/projects/packages/forms/src/contact-form/form-field-functions.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Global functions for Jetpack Forms field registration.
+ *
+ * These functions provide a WordPress-style API for registering custom form fields,
+ * similar to register_post_type() and register_taxonomy().
+ *
+ * @package automattic/jetpack-forms
+ */
+
+use Automattic\Jetpack\Forms\ContactForm\Form_Field_Registry;
+
+/**
+ * Register a custom Jetpack form field type.
+ *
+ * This function provides a unified API for registering custom form fields,
+ * similar to WordPress's register_post_type(). It handles block registration,
+ * validation, frontend rendering, response value rendering, error messages,
+ * and dashboard script registration.
+ *
+ * @since $$next-version$$
+ *
+ * @param string $field_type The field type identifier (e.g., 'color', 'rating').
+ * @param array  $args       {
+ *     Configuration arguments for the field type.
+ *
+ *     @type string   $block_name           Block name. Defaults to 'jetpack/field-{$field_type}'.
+ *     @type array    $block_attributes     Block attributes definition.
+ *     @type callable $render_callback      Block render callback. Receives ($atts, $content, $block).
+ *                                          If not provided, uses default that calls Contact_Form::parse_contact_field().
+ *     @type callable $validate_callback    Validation callback. Receives ($value, $label, $field).
+ *                                          Return true for valid, string error message for invalid.
+ *     @type callable $render_field         Frontend field render callback. Receives ($data).
+ *                                          Return HTML string or null for default rendering.
+ *     @type callable $render_value         Value render callback. Receives ($context, $value, $field).
+ *                                          Context is 'email', 'web', 'ajax', 'csv', 'api'.
+ *                                          Return rendered value or null for default.
+ *     @type array    $error_messages       Associative array of error_key => message.
+ *     @type string   $editor_script        URL to the editor script.
+ *     @type array    $editor_script_deps   Editor script dependencies.
+ *     @type string   $editor_script_ver    Editor script version.
+ *     @type string   $dashboard_script     URL to the dashboard script.
+ *     @type array    $dashboard_script_deps Dashboard script dependencies.
+ *     @type string   $dashboard_script_ver Dashboard script version.
+ * }
+ * @return bool True on success, false on failure.
+ */
+function register_jetpack_form_field( $field_type, $args = array() ) {
+	return Form_Field_Registry::register( $field_type, $args );
+}
+
+/**
+ * Get a registered Jetpack form field type.
+ *
+ * @since $$next-version$$
+ *
+ * @param string $field_type The field type identifier.
+ * @return array|null The field configuration or null if not registered.
+ */
+function get_jetpack_form_field( $field_type ) {
+	return Form_Field_Registry::get( $field_type );
+}
+
+/**
+ * Check if a Jetpack form field type is registered.
+ *
+ * @since $$next-version$$
+ *
+ * @param string $field_type The field type identifier.
+ * @return bool True if registered, false otherwise.
+ */
+function jetpack_form_field_exists( $field_type ) {
+	return Form_Field_Registry::is_registered( $field_type );
+}

--- a/projects/packages/forms/src/form-editor/class-form-editor.php
+++ b/projects/packages/forms/src/form-editor/class-form-editor.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Forms\Editor;
 
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Forms\ContactForm\Contact_Form;
+use Automattic\Jetpack\Forms\ContactForm\Form_Field_Registry;
 
 /**
  * Class Form_Editor
@@ -52,7 +53,7 @@ class Form_Editor {
 
 		// Allow only field blocks, button, and core blocks.
 		// Visual wrapping is handled by JavaScript DOM manipulation.
-		return array(
+		$allowed_blocks = array(
 			// Field blocks.
 			'jetpack/field-name',
 			'jetpack/field-email',
@@ -118,6 +119,21 @@ class Form_Editor {
 			'core/subhead',
 			'core/video',
 		);
+
+		// Add custom registered field blocks.
+		$custom_field_blocks = Form_Field_Registry::get_registered_block_names();
+		$allowed_blocks      = array_merge( $allowed_blocks, $custom_field_blocks );
+
+		/**
+		 * Filter the allowed blocks in the Jetpack Form editor.
+		 *
+		 * Allows plugins to add additional blocks to the form editor.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param array $allowed_blocks Array of allowed block names.
+		 */
+		return apply_filters( 'jetpack_form_editor_allowed_blocks', $allowed_blocks );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Field_Extensibility_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Field_Extensibility_Test.php
@@ -1,0 +1,645 @@
+<?php
+/**
+ * Unit Tests for Jetpack Forms Field Extensibility API.
+ *
+ * Tests the filter-based extensibility system for custom form fields,
+ * including integration with the Form_Field_Registry unified registration API.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use ReflectionClass;
+use WorDBless\BaseTestCase;
+
+/**
+ * Test class for the Field Extensibility API.
+ *
+ * @covers \Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
+ * @covers \Automattic\Jetpack\Forms\ContactForm\Feedback_Field
+ * @covers \Automattic\Jetpack\Forms\ContactForm\Form_Field_Registry
+ */
+#[CoversClass( Contact_Form_Field::class )]
+#[CoversClass( Feedback_Field::class )]
+#[CoversClass( Form_Field_Registry::class )]
+class Field_Extensibility_Test extends BaseTestCase {
+
+	/**
+	 * Store original registered fields to restore after tests.
+	 *
+	 * @var array
+	 */
+	private static $original_fields = array();
+
+	/**
+	 * Set up before all tests.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		// Load the global functions file.
+		require_once __DIR__ . '/../../../src/contact-form/form-field-functions.php';
+
+		self::$original_fields = Form_Field_Registry::get_all();
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	protected function tearDown(): void {
+		parent::tearDown();
+
+		// Reset the registry using reflection.
+		$reflection = new ReflectionClass( Form_Field_Registry::class );
+
+		$fields_property = $reflection->getProperty( 'registered_fields' );
+		$fields_property->setAccessible( true );
+		$fields_property->setValue( null, self::$original_fields );
+
+		// Reset hooks_initialized flag so hooks can be re-added.
+		$hooks_property = $reflection->getProperty( 'hooks_initialized' );
+		$hooks_property->setAccessible( true );
+		$hooks_property->setValue( null, false );
+
+		// Remove test filters.
+		remove_all_filters( 'jetpack_forms_field_types' );
+		remove_all_filters( 'jetpack_forms_validate_field' );
+		remove_all_filters( 'jetpack_forms_render_field' );
+		remove_all_filters( 'jetpack_forms_render_field_value' );
+		remove_all_filters( 'jetpack_forms_error_types' );
+	}
+
+	/**
+	 * Test that jetpack_forms_field_types filter returns core field types.
+	 */
+	public function test_get_registered_field_types_returns_core_types() {
+		$types = Contact_Form_Field::get_registered_field_types();
+
+		$this->assertIsArray( $types );
+		$this->assertContains( 'text', $types );
+		$this->assertContains( 'email', $types );
+		$this->assertContains( 'url', $types );
+		$this->assertContains( 'telephone', $types );
+		$this->assertContains( 'textarea', $types );
+		$this->assertContains( 'checkbox', $types );
+		$this->assertContains( 'radio', $types );
+		$this->assertContains( 'select', $types );
+		$this->assertContains( 'date', $types );
+		$this->assertContains( 'file', $types );
+		$this->assertContains( 'rating', $types );
+	}
+
+	/**
+	 * Test that jetpack_forms_field_types filter allows adding custom types.
+	 */
+	public function test_get_registered_field_types_allows_custom_types() {
+		add_filter(
+			'jetpack_forms_field_types',
+			function ( $types ) {
+				$types[] = 'color';
+				$types[] = 'custom-field';
+				return $types;
+			}
+		);
+
+		$types = Contact_Form_Field::get_registered_field_types();
+
+		$this->assertContains( 'color', $types );
+		$this->assertContains( 'custom-field', $types );
+
+		// Clean up
+		remove_all_filters( 'jetpack_forms_field_types' );
+	}
+
+	/**
+	 * Test that jetpack_forms_render_field_value filter is called.
+	 */
+	public function test_render_field_value_filter_is_called() {
+		$filter_called = false;
+		$filter_params = array();
+
+		add_filter(
+			'jetpack_forms_render_field_value',
+			function ( $html, $context, $type, $value, $field ) use ( &$filter_called, &$filter_params ) {
+				$filter_called = true;
+				$filter_params = array(
+					'html'    => $html,
+					'context' => $context,
+					'type'    => $type,
+					'value'   => $value,
+					'field'   => $field,
+				);
+				return $html;
+			},
+			10,
+			5
+		);
+
+		$field = new Feedback_Field( 'test_key', 'Test Label', 'test_value', 'custom-type' );
+		$field->get_render_value( 'web' );
+
+		$this->assertTrue( $filter_called );
+		$this->assertNull( $filter_params['html'] );
+		$this->assertEquals( 'web', $filter_params['context'] );
+		$this->assertEquals( 'custom-type', $filter_params['type'] );
+		$this->assertEquals( 'test_value', $filter_params['value'] );
+		$this->assertInstanceOf( Feedback_Field::class, $filter_params['field'] );
+
+		// Clean up
+		remove_all_filters( 'jetpack_forms_render_field_value' );
+	}
+
+	/**
+	 * Test that custom render value overrides default rendering.
+	 */
+	public function test_custom_render_value_overrides_default() {
+		add_filter(
+			'jetpack_forms_render_field_value',
+			function ( $html, $context, $type, $value, $field ) {
+				if ( $type === 'color' ) {
+					return '<span style="color:' . esc_attr( $value ) . '">' . esc_html( $value ) . '</span>';
+				}
+				return $html;
+			},
+			10,
+			5
+		);
+
+		$field  = new Feedback_Field( 'color_key', 'Color', '#FF0000', 'color' );
+		$result = $field->get_render_value( 'email' );
+
+		$this->assertEquals( '<span style="color:#FF0000">#FF0000</span>', $result );
+
+		// Clean up
+		remove_all_filters( 'jetpack_forms_render_field_value' );
+	}
+
+	/**
+	 * Test that non-matching custom render filter falls through to default.
+	 */
+	public function test_non_matching_render_filter_falls_through() {
+		add_filter(
+			'jetpack_forms_render_field_value',
+			function ( $html, $context, $type, $value, $field ) {
+				if ( $type === 'color' ) {
+					return 'custom render';
+				}
+				return $html; // Return null to fall through
+			},
+			10,
+			5
+		);
+
+		// Test with a non-color field type
+		$field  = new Feedback_Field( 'text_key', 'Text', 'hello world', 'text' );
+		$result = $field->get_render_value( 'default' );
+
+		// Should fall through to default rendering
+		$this->assertEquals( 'hello world', $result );
+
+		// Clean up
+		remove_all_filters( 'jetpack_forms_render_field_value' );
+	}
+
+	/**
+	 * Test that custom render value works with different contexts.
+	 */
+	public function test_custom_render_value_with_different_contexts() {
+		add_filter(
+			'jetpack_forms_render_field_value',
+			function ( $html, $context, $type, $value, $field ) {
+				if ( $type !== 'color' ) {
+					return $html;
+				}
+
+				switch ( $context ) {
+					case 'email':
+						return '<span style="background-color:' . esc_attr( $value ) . '">' . esc_html( $value ) . '</span>';
+					case 'csv':
+						return $value;
+					case 'web':
+						return array(
+							'type'  => 'color',
+							'value' => $value,
+						);
+					default:
+						return $value;
+				}
+			},
+			10,
+			5
+		);
+
+		$field = new Feedback_Field( 'color_key', 'Color', '#00FF00', 'color' );
+
+		// Test email context
+		$email_result = $field->get_render_value( 'email' );
+		$this->assertStringContainsString( 'background-color:#00FF00', $email_result );
+
+		// Test csv context
+		$csv_result = $field->get_render_value( 'csv' );
+		$this->assertEquals( '#00FF00', $csv_result );
+
+		// Test web context
+		$web_result = $field->get_render_value( 'web' );
+		$this->assertIsArray( $web_result );
+		$this->assertEquals( 'color', $web_result['type'] );
+		$this->assertEquals( '#00FF00', $web_result['value'] );
+
+		// Clean up
+		remove_all_filters( 'jetpack_forms_render_field_value' );
+	}
+
+	/**
+	 * Test error types filter returns core error types.
+	 */
+	public function test_error_types_filter_returns_core_types() {
+		// We can't easily test the Contact_Form filter directly since it requires
+		// the full rendering context. Instead, we test that our filter pattern works.
+		$core_error_types = array(
+			'is_required'        => 'This field is required.',
+			'invalid_form_empty' => 'The form you are trying to submit is empty.',
+			'invalid_form'       => 'Please fill out the form correctly.',
+			'network_error'      => 'Connection issue while submitting the form.',
+			'preview_mode'       => 'Form submissions are disabled in preview mode.',
+		);
+
+		$error_types = apply_filters( 'jetpack_forms_error_types', $core_error_types );
+
+		$this->assertArrayHasKey( 'is_required', $error_types );
+		$this->assertArrayHasKey( 'invalid_form_empty', $error_types );
+	}
+
+	/**
+	 * Test error types filter allows adding custom error types.
+	 */
+	public function test_error_types_filter_allows_custom_types() {
+		add_filter(
+			'jetpack_forms_error_types',
+			function ( $error_types ) {
+				$error_types['invalid_color']        = 'Please enter a valid hex color.';
+				$error_types['color_not_in_palette'] = 'This color is not in the allowed palette.';
+				return $error_types;
+			}
+		);
+
+		$core_error_types = array(
+			'is_required' => 'This field is required.',
+		);
+
+		$error_types = apply_filters( 'jetpack_forms_error_types', $core_error_types );
+
+		$this->assertArrayHasKey( 'invalid_color', $error_types );
+		$this->assertEquals( 'Please enter a valid hex color.', $error_types['invalid_color'] );
+		$this->assertArrayHasKey( 'color_not_in_palette', $error_types );
+
+		// Clean up
+		remove_all_filters( 'jetpack_forms_error_types' );
+	}
+
+	/**
+	 * Test that field types can be filtered correctly.
+	 */
+	public function test_field_types_filter_preserves_core_types() {
+		// Add a filter that appends custom types
+		add_filter(
+			'jetpack_forms_field_types',
+			function ( $types ) {
+				// Add custom type without removing any
+				$types[] = 'signature';
+				return $types;
+			}
+		);
+
+		$types = Contact_Form_Field::get_registered_field_types();
+
+		// Core types should still be present
+		$this->assertContains( 'text', $types );
+		$this->assertContains( 'email', $types );
+
+		// Custom type should also be present
+		$this->assertContains( 'signature', $types );
+
+		// Clean up
+		remove_all_filters( 'jetpack_forms_field_types' );
+	}
+
+	// =========================================================================
+	// Form_Field_Registry Integration Tests
+	// =========================================================================
+
+	/**
+	 * Test that register_jetpack_form_field adds field type to registered types.
+	 */
+	public function test_registry_adds_field_to_registered_types() {
+		register_jetpack_form_field( 'color', array() );
+
+		$types = Contact_Form_Field::get_registered_field_types();
+
+		$this->assertContains( 'color', $types );
+	}
+
+	/**
+	 * Test that registry validation callback integrates with validate filter.
+	 */
+	public function test_registry_validation_integrates_with_filter() {
+		register_jetpack_form_field(
+			'color',
+			array(
+				'validate_callback' => function ( $value, $label, $field ) {
+					if ( empty( $value ) ) {
+						return sprintf( '%s is required.', $label );
+					}
+					if ( ! preg_match( '/^#[0-9A-Fa-f]{6}$/', $value ) ) {
+						return sprintf( '%s must be a valid hex color.', $label );
+					}
+					return true;
+				},
+			)
+		);
+
+		// Simulate the filter being called (as Contact_Form_Field::validate() would do).
+		$result = apply_filters(
+			'jetpack_forms_validate_field',
+			null,
+			'color',
+			'invalid-color',
+			'Favorite Color',
+			$this->createMock( Contact_Form_Field::class )
+		);
+
+		$this->assertEquals( 'Favorite Color must be a valid hex color.', $result );
+	}
+
+	/**
+	 * Test that registry validation returns true for valid values.
+	 */
+	public function test_registry_validation_returns_true_for_valid() {
+		register_jetpack_form_field(
+			'color',
+			array(
+				'validate_callback' => function ( $value, $label, $field ) {
+					if ( ! preg_match( '/^#[0-9A-Fa-f]{6}$/', $value ) ) {
+						return 'Invalid color.';
+					}
+					return true;
+				},
+			)
+		);
+
+		$result = apply_filters(
+			'jetpack_forms_validate_field',
+			null,
+			'color',
+			'#FF0000',
+			'Color',
+			$this->createMock( Contact_Form_Field::class )
+		);
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test that registry render_field callback integrates with filter.
+	 */
+	public function test_registry_render_field_integrates_with_filter() {
+		register_jetpack_form_field(
+			'color',
+			array(
+				'render_field' => function ( $data ) {
+					return sprintf(
+						'<input type="color" id="%s" name="%s" value="%s" />',
+						esc_attr( $data['id'] ),
+						esc_attr( $data['id'] ),
+						esc_attr( $data['value'] ?? '#000000' )
+					);
+				},
+			)
+		);
+
+		$result = apply_filters(
+			'jetpack_forms_render_field',
+			null,
+			'color',
+			array(
+				'id'    => 'my-color',
+				'value' => '#FF0000',
+			)
+		);
+
+		$this->assertStringContainsString( 'type="color"', $result );
+		$this->assertStringContainsString( 'id="my-color"', $result );
+		$this->assertStringContainsString( 'value="#FF0000"', $result );
+	}
+
+	/**
+	 * Test that registry render_value callback integrates with Feedback_Field.
+	 */
+	public function test_registry_render_value_integrates_with_feedback_field() {
+		register_jetpack_form_field(
+			'color',
+			array(
+				'render_value' => function ( $context, $value, $field ) {
+					if ( $context === 'email' ) {
+						return sprintf(
+							'<span style="background-color:%s">%s</span>',
+							esc_attr( $value ),
+							esc_html( $value )
+						);
+					}
+					return $value;
+				},
+			)
+		);
+
+		$field  = new Feedback_Field( 'color_key', 'Favorite Color', '#00FF00', 'color' );
+		$result = $field->get_render_value( 'email' );
+
+		$this->assertStringContainsString( 'background-color:#00FF00', $result );
+		$this->assertStringContainsString( '#00FF00', $result );
+	}
+
+	/**
+	 * Test that registry error_messages integrate with error_types filter.
+	 */
+	public function test_registry_error_messages_integrate_with_filter() {
+		register_jetpack_form_field(
+			'color',
+			array(
+				'error_messages' => array(
+					'invalid_color'  => 'Please enter a valid hex color (e.g., #FF0000).',
+					'color_too_dark' => 'The selected color is too dark.',
+				),
+			)
+		);
+
+		$error_types = apply_filters( 'jetpack_forms_error_types', array() );
+
+		$this->assertArrayHasKey( 'invalid_color', $error_types );
+		$this->assertArrayHasKey( 'color_too_dark', $error_types );
+		$this->assertEquals( 'Please enter a valid hex color (e.g., #FF0000).', $error_types['invalid_color'] );
+	}
+
+	/**
+	 * Test complete field registration workflow.
+	 */
+	public function test_complete_registration_workflow() {
+		// Register a complete custom field.
+		register_jetpack_form_field(
+			'rating',
+			array(
+				'block_attributes'  => array(
+					'maxRating' => array(
+						'type'    => 'number',
+						'default' => 5,
+					),
+				),
+				'validate_callback' => function ( $value, $label, $field ) {
+					if ( empty( $value ) && $field->get_attribute( 'required' ) ) {
+						return sprintf( '%s is required.', $label );
+					}
+					$value = intval( $value );
+					if ( $value < 1 || $value > 5 ) {
+						return sprintf( '%s must be between 1 and 5.', $label );
+					}
+					return true;
+				},
+				'render_value'      => function ( $context, $value, $field ) {
+					$stars = str_repeat( '★', intval( $value ) ) . str_repeat( '☆', 5 - intval( $value ) );
+					if ( $context === 'email' ) {
+						return $stars . " ($value/5)";
+					}
+					return $value;
+				},
+				'error_messages'    => array(
+					'invalid_rating' => 'Please select a valid rating.',
+				),
+			)
+		);
+
+		// Verify field type is registered.
+		$this->assertTrue( jetpack_form_field_exists( 'rating' ) );
+		$this->assertContains( 'rating', Contact_Form_Field::get_registered_field_types() );
+
+		// Verify configuration is retrievable.
+		$config = get_jetpack_form_field( 'rating' );
+		$this->assertArrayHasKey( 'maxRating', $config['block_attributes'] );
+
+		// Verify validation works.
+		$mock_field = $this->createMock( Contact_Form_Field::class );
+		$mock_field->method( 'get_attribute' )->willReturn( false );
+
+		$valid_result = apply_filters( 'jetpack_forms_validate_field', null, 'rating', '4', 'Rating', $mock_field );
+		$this->assertTrue( $valid_result );
+
+		$invalid_result = apply_filters( 'jetpack_forms_validate_field', null, 'rating', '10', 'Rating', $mock_field );
+		$this->assertStringContainsString( 'must be between 1 and 5', $invalid_result );
+
+		// Verify rendering works.
+		$feedback_field = new Feedback_Field( 'rating_key', 'Rating', '4', 'rating' );
+		$email_render   = $feedback_field->get_render_value( 'email' );
+		$this->assertStringContainsString( '★★★★☆', $email_render );
+		$this->assertStringContainsString( '(4/5)', $email_render );
+
+		// Verify error messages are registered.
+		$error_types = apply_filters( 'jetpack_forms_error_types', array() );
+		$this->assertArrayHasKey( 'invalid_rating', $error_types );
+	}
+
+	/**
+	 * Test that multiple custom fields can be registered independently.
+	 */
+	public function test_multiple_custom_fields_independent() {
+		register_jetpack_form_field(
+			'color',
+			array(
+				'validate_callback' => function ( $value, $label, $field ) {
+					return 'color validation';
+				},
+			)
+		);
+
+		register_jetpack_form_field(
+			'signature',
+			array(
+				'validate_callback' => function ( $value, $label, $field ) {
+					return 'signature validation';
+				},
+			)
+		);
+
+		$mock_field = $this->createMock( Contact_Form_Field::class );
+
+		$color_result     = apply_filters( 'jetpack_forms_validate_field', null, 'color', 'val', 'Label', $mock_field );
+		$signature_result = apply_filters( 'jetpack_forms_validate_field', null, 'signature', 'val', 'Label', $mock_field );
+
+		$this->assertEquals( 'color validation', $color_result );
+		$this->assertEquals( 'signature validation', $signature_result );
+	}
+
+	/**
+	 * Test that unregistered field types pass through to default handling.
+	 */
+	public function test_unregistered_types_use_default_handling() {
+		register_jetpack_form_field(
+			'color',
+			array(
+				'validate_callback' => function () {
+					return 'custom validation';
+				},
+			)
+		);
+
+		$mock_field = $this->createMock( Contact_Form_Field::class );
+
+		// 'text' is a core type, not registered via Form_Field_Registry.
+		// The filter should pass through the original result.
+		$result = apply_filters( 'jetpack_forms_validate_field', 'default-result', 'text', 'val', 'Label', $mock_field );
+
+		$this->assertEquals( 'default-result', $result );
+	}
+
+	/**
+	 * Test Feedback_Field renders custom field values correctly for different contexts.
+	 */
+	public function test_feedback_field_renders_custom_values_for_contexts() {
+		register_jetpack_form_field(
+			'color',
+			array(
+				'render_value' => function ( $context, $value, $field ) {
+					switch ( $context ) {
+						case 'email':
+							return "<div style='background:$value'>$value</div>";
+						case 'csv':
+							return $value; // Raw value for CSV.
+						case 'api':
+							return array(
+								'hex'  => $value,
+								'type' => 'color',
+							);
+						default:
+							return $value;
+					}
+				},
+			)
+		);
+
+		$field = new Feedback_Field( 'color_key', 'Color', '#123456', 'color' );
+
+		// Test email context.
+		$email = $field->get_render_value( 'email' );
+		$this->assertStringContainsString( 'background:#123456', $email );
+
+		// Test CSV context.
+		$csv = $field->get_render_value( 'csv' );
+		$this->assertEquals( '#123456', $csv );
+
+		// Test API context.
+		$api = $field->get_render_value( 'api' );
+		$this->assertIsArray( $api );
+		$this->assertEquals( '#123456', $api['hex'] );
+		$this->assertEquals( 'color', $api['type'] );
+	}
+}

--- a/projects/packages/forms/tests/php/contact-form/Form_Field_Registry_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Form_Field_Registry_Test.php
@@ -1,0 +1,718 @@
+<?php
+/**
+ * Unit Tests for Jetpack Forms Field Registry.
+ *
+ * Tests the unified registration API for custom form fields.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use ReflectionClass;
+use WorDBless\BaseTestCase;
+
+/**
+ * Test class for the Form Field Registry.
+ *
+ * @covers \Automattic\Jetpack\Forms\ContactForm\Form_Field_Registry
+ */
+#[CoversClass( Form_Field_Registry::class )]
+class Form_Field_Registry_Test extends BaseTestCase {
+
+	/**
+	 * Store original registered fields to restore after tests.
+	 *
+	 * @var array
+	 */
+	private static $original_fields = array();
+
+	/**
+	 * Set up before all tests.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		// Load the global functions file.
+		require_once __DIR__ . '/../../../src/contact-form/form-field-functions.php';
+
+		// Store original state before any tests run.
+		self::$original_fields = Form_Field_Registry::get_all();
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	protected function tearDown(): void {
+		parent::tearDown();
+
+		// Reset the registry to original state using reflection.
+		$reflection = new ReflectionClass( Form_Field_Registry::class );
+
+		$fields_property = $reflection->getProperty( 'registered_fields' );
+		$fields_property->setAccessible( true );
+		$fields_property->setValue( null, self::$original_fields );
+
+		// Reset hooks_initialized flag so hooks can be re-added.
+		$hooks_property = $reflection->getProperty( 'hooks_initialized' );
+		$hooks_property->setAccessible( true );
+		$hooks_property->setValue( null, false );
+
+		// Remove any test filters.
+		remove_all_filters( 'jetpack_forms_field_types' );
+		remove_all_filters( 'jetpack_forms_validate_field' );
+		remove_all_filters( 'jetpack_forms_render_field' );
+		remove_all_filters( 'jetpack_forms_render_field_value' );
+		remove_all_filters( 'jetpack_forms_error_types' );
+	}
+
+	/**
+	 * Test that the global registration function exists.
+	 */
+	public function test_register_jetpack_form_field_function_exists() {
+		$this->assertTrue( function_exists( 'register_jetpack_form_field' ) );
+	}
+
+	/**
+	 * Test that the global get function exists.
+	 */
+	public function test_get_jetpack_form_field_function_exists() {
+		$this->assertTrue( function_exists( 'get_jetpack_form_field' ) );
+	}
+
+	/**
+	 * Test that the global exists function exists.
+	 */
+	public function test_jetpack_form_field_exists_function_exists() {
+		$this->assertTrue( function_exists( 'jetpack_form_field_exists' ) );
+	}
+
+	/**
+	 * Test basic field registration.
+	 */
+	public function test_register_field_type_succeeds() {
+		$result = Form_Field_Registry::register( 'test-color', array() );
+
+		$this->assertTrue( $result );
+		$this->assertTrue( Form_Field_Registry::is_registered( 'test-color' ) );
+	}
+
+	/**
+	 * Test registration with full configuration.
+	 */
+	public function test_register_field_with_full_config() {
+		$config = array(
+			'block_name'        => 'custom/color-picker',
+			'block_attributes'  => array(
+				'defaultColor' => array(
+					'type'    => 'string',
+					'default' => '#000000',
+				),
+			),
+			'validate_callback' => function ( $value, $label, $field ) {
+				return true;
+			},
+			'render_field'      => function ( $data ) {
+				return '<input type="color" />';
+			},
+			'render_value'      => function ( $context, $value, $field ) {
+				return $value;
+			},
+			'error_messages'    => array(
+				'invalid_color' => 'Invalid color format.',
+			),
+			'editor_script'     => 'https://example.com/editor.js',
+			'dashboard_script'  => 'https://example.com/dashboard.js',
+		);
+
+		$result = Form_Field_Registry::register( 'custom-color', $config );
+
+		$this->assertTrue( $result );
+
+		$registered = Form_Field_Registry::get( 'custom-color' );
+		$this->assertEquals( 'custom/color-picker', $registered['block_name'] );
+		$this->assertArrayHasKey( 'defaultColor', $registered['block_attributes'] );
+		$this->assertIsCallable( $registered['validate_callback'] );
+		$this->assertIsCallable( $registered['render_field'] );
+		$this->assertIsCallable( $registered['render_value'] );
+		$this->assertArrayHasKey( 'invalid_color', $registered['error_messages'] );
+	}
+
+	/**
+	 * Test that field type is sanitized.
+	 */
+	public function test_field_type_is_sanitized() {
+		// sanitize_key converts to lowercase and removes non-alphanumeric chars (except - and _).
+		Form_Field_Registry::register( 'MY-CUSTOM_field', array() );
+
+		// Field type should be sanitized to lowercase.
+		$this->assertTrue( Form_Field_Registry::is_registered( 'my-custom_field' ) );
+		$this->assertFalse( Form_Field_Registry::is_registered( 'MY-CUSTOM_field' ) );
+	}
+
+	/**
+	 * Test registration fails with empty field type.
+	 */
+	public function test_register_fails_with_empty_field_type() {
+		$result = Form_Field_Registry::register( '', array() );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test registration fails with non-string field type.
+	 */
+	public function test_register_fails_with_non_string_field_type() {
+		$result = Form_Field_Registry::register( 123, array() );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test registration fails when type is already registered.
+	 */
+	public function test_register_fails_when_already_registered() {
+		Form_Field_Registry::register( 'duplicate-test', array() );
+		$result = Form_Field_Registry::register( 'duplicate-test', array() );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test default block name is generated correctly.
+	 */
+	public function test_default_block_name_generation() {
+		Form_Field_Registry::register( 'my-custom-type', array() );
+
+		$registered = Form_Field_Registry::get( 'my-custom-type' );
+		$this->assertEquals( 'jetpack/field-my-custom-type', $registered['block_name'] );
+	}
+
+	/**
+	 * Test custom block name overrides default.
+	 */
+	public function test_custom_block_name_overrides_default() {
+		Form_Field_Registry::register(
+			'override-test',
+			array(
+				'block_name' => 'myplugin/custom-block',
+			)
+		);
+
+		$registered = Form_Field_Registry::get( 'override-test' );
+		$this->assertEquals( 'myplugin/custom-block', $registered['block_name'] );
+	}
+
+	/**
+	 * Test get_registered_block_names returns all block names.
+	 */
+	public function test_get_registered_block_names() {
+		Form_Field_Registry::register( 'block-test-1', array() );
+		Form_Field_Registry::register(
+			'block-test-2',
+			array(
+				'block_name' => 'custom/block-two',
+			)
+		);
+
+		$block_names = Form_Field_Registry::get_registered_block_names();
+
+		$this->assertContains( 'jetpack/field-block-test-1', $block_names );
+		$this->assertContains( 'custom/block-two', $block_names );
+	}
+
+	/**
+	 * Test is_registered returns correct boolean.
+	 */
+	public function test_is_registered_returns_correct_boolean() {
+		Form_Field_Registry::register( 'exists-test', array() );
+
+		$this->assertTrue( Form_Field_Registry::is_registered( 'exists-test' ) );
+		$this->assertFalse( Form_Field_Registry::is_registered( 'does-not-exist' ) );
+	}
+
+	/**
+	 * Test get returns null for unregistered field type.
+	 */
+	public function test_get_returns_null_for_unregistered() {
+		$result = Form_Field_Registry::get( 'unregistered-type' );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test get_all returns all registered fields.
+	 */
+	public function test_get_all_returns_all_fields() {
+		$initial_count = count( Form_Field_Registry::get_all() );
+
+		Form_Field_Registry::register( 'all-test-1', array() );
+		Form_Field_Registry::register( 'all-test-2', array() );
+
+		$all = Form_Field_Registry::get_all();
+
+		$this->assertCount( $initial_count + 2, $all );
+		$this->assertArrayHasKey( 'all-test-1', $all );
+		$this->assertArrayHasKey( 'all-test-2', $all );
+	}
+
+	/**
+	 * Test filter_field_types adds custom types.
+	 */
+	public function test_filter_field_types_adds_custom_types() {
+		Form_Field_Registry::register( 'filter-type-test', array() );
+
+		$types = Form_Field_Registry::filter_field_types( array( 'text', 'email' ) );
+
+		$this->assertContains( 'text', $types );
+		$this->assertContains( 'email', $types );
+		$this->assertContains( 'filter-type-test', $types );
+	}
+
+	/**
+	 * Test filter_field_types doesn't add duplicates.
+	 */
+	public function test_filter_field_types_no_duplicates() {
+		Form_Field_Registry::register( 'text', array() ); // Try to register existing type name.
+
+		$types = Form_Field_Registry::filter_field_types( array( 'text', 'email' ) );
+
+		// Should only have one 'text' entry.
+		$text_count = array_count_values( $types )['text'] ?? 0;
+		$this->assertSame( 1, $text_count );
+	}
+
+	/**
+	 * Test filter_validate_field calls validation callback for registered type.
+	 */
+	public function test_filter_validate_field_calls_callback() {
+		$callback_called = false;
+		$received_params = array();
+
+		Form_Field_Registry::register(
+			'validate-test',
+			array(
+				'validate_callback' => function ( $value, $label, $field ) use ( &$callback_called, &$received_params ) {
+					$callback_called   = true;
+					$received_params   = array(
+						'value' => $value,
+						'label' => $label,
+						'field' => $field,
+					);
+					return true;
+				},
+			)
+		);
+
+		$mock_field = $this->createMock( Contact_Form_Field::class );
+
+		$result = Form_Field_Registry::filter_validate_field(
+			null,
+			'validate-test',
+			'test-value',
+			'Test Label',
+			$mock_field
+		);
+
+		$this->assertTrue( $callback_called );
+		$this->assertEquals( 'test-value', $received_params['value'] );
+		$this->assertEquals( 'Test Label', $received_params['label'] );
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test filter_validate_field returns error message.
+	 */
+	public function test_filter_validate_field_returns_error() {
+		Form_Field_Registry::register(
+			'validate-error-test',
+			array(
+				'validate_callback' => function ( $value, $label, $field ) {
+					return 'This field is invalid.';
+				},
+			)
+		);
+
+		$mock_field = $this->createMock( Contact_Form_Field::class );
+
+		$result = Form_Field_Registry::filter_validate_field(
+			null,
+			'validate-error-test',
+			'bad-value',
+			'Test Label',
+			$mock_field
+		);
+
+		$this->assertEquals( 'This field is invalid.', $result );
+	}
+
+	/**
+	 * Test filter_validate_field passes through for unregistered type.
+	 */
+	public function test_filter_validate_field_passes_through_unregistered() {
+		$mock_field = $this->createMock( Contact_Form_Field::class );
+
+		$result = Form_Field_Registry::filter_validate_field(
+			'original-result',
+			'unregistered-type',
+			'value',
+			'Label',
+			$mock_field
+		);
+
+		$this->assertEquals( 'original-result', $result );
+	}
+
+	/**
+	 * Test filter_validate_field passes through when no callback.
+	 */
+	public function test_filter_validate_field_passes_through_no_callback() {
+		Form_Field_Registry::register( 'no-validate-callback', array() );
+
+		$mock_field = $this->createMock( Contact_Form_Field::class );
+
+		$result = Form_Field_Registry::filter_validate_field(
+			'original-result',
+			'no-validate-callback',
+			'value',
+			'Label',
+			$mock_field
+		);
+
+		$this->assertEquals( 'original-result', $result );
+	}
+
+	/**
+	 * Test filter_render_field calls render callback.
+	 */
+	public function test_filter_render_field_calls_callback() {
+		$received_data = array();
+
+		Form_Field_Registry::register(
+			'render-field-test',
+			array(
+				'render_field' => function ( $data ) use ( &$received_data ) {
+					$received_data = $data;
+					return '<input type="custom" />';
+				},
+			)
+		);
+
+		$data   = array(
+			'id'       => 'test-id',
+			'label'    => 'Test Label',
+			'required' => true,
+		);
+		$result = Form_Field_Registry::filter_render_field( null, 'render-field-test', $data );
+
+		$this->assertEquals( '<input type="custom" />', $result );
+		$this->assertEquals( $data, $received_data );
+	}
+
+	/**
+	 * Test filter_render_field passes through for unregistered type.
+	 */
+	public function test_filter_render_field_passes_through_unregistered() {
+		$result = Form_Field_Registry::filter_render_field(
+			'<original />',
+			'unregistered-type',
+			array()
+		);
+
+		$this->assertEquals( '<original />', $result );
+	}
+
+	/**
+	 * Test filter_render_value calls render callback.
+	 */
+	public function test_filter_render_value_calls_callback() {
+		Form_Field_Registry::register(
+			'render-value-test',
+			array(
+				'render_value' => function ( $context, $value, $field ) {
+					return "[$context] $value";
+				},
+			)
+		);
+
+		$mock_field = $this->createMock( Feedback_Field::class );
+
+		$result = Form_Field_Registry::filter_render_value(
+			null,
+			'email',
+			'render-value-test',
+			'#FF0000',
+			$mock_field
+		);
+
+		$this->assertEquals( '[email] #FF0000', $result );
+	}
+
+	/**
+	 * Test filter_render_value with different contexts.
+	 */
+	public function test_filter_render_value_different_contexts() {
+		Form_Field_Registry::register(
+			'context-test',
+			array(
+				'render_value' => function ( $context, $value, $field ) {
+					switch ( $context ) {
+						case 'email':
+							return "<b>$value</b>";
+						case 'csv':
+							return $value;
+						case 'api':
+							return array( 'value' => $value );
+						default:
+							return $value;
+					}
+				},
+			)
+		);
+
+		$mock_field = $this->createMock( Feedback_Field::class );
+
+		$email_result = Form_Field_Registry::filter_render_value( null, 'email', 'context-test', 'test', $mock_field );
+		$this->assertEquals( '<b>test</b>', $email_result );
+
+		$csv_result = Form_Field_Registry::filter_render_value( null, 'csv', 'context-test', 'test', $mock_field );
+		$this->assertEquals( 'test', $csv_result );
+
+		$api_result = Form_Field_Registry::filter_render_value( null, 'api', 'context-test', 'test', $mock_field );
+		$this->assertIsArray( $api_result );
+		$this->assertEquals( 'test', $api_result['value'] );
+	}
+
+	/**
+	 * Test filter_error_types adds custom error messages.
+	 */
+	public function test_filter_error_types_adds_custom_messages() {
+		Form_Field_Registry::register(
+			'error-types-test',
+			array(
+				'error_messages' => array(
+					'invalid_format' => 'The format is invalid.',
+					'out_of_range'   => 'The value is out of range.',
+				),
+			)
+		);
+
+		$error_types = Form_Field_Registry::filter_error_types(
+			array(
+				'is_required' => 'This field is required.',
+			)
+		);
+
+		$this->assertArrayHasKey( 'is_required', $error_types );
+		$this->assertArrayHasKey( 'invalid_format', $error_types );
+		$this->assertArrayHasKey( 'out_of_range', $error_types );
+		$this->assertEquals( 'The format is invalid.', $error_types['invalid_format'] );
+	}
+
+	/**
+	 * Test filter_error_types merges from multiple registered fields.
+	 */
+	public function test_filter_error_types_merges_multiple_fields() {
+		Form_Field_Registry::register(
+			'error-test-1',
+			array(
+				'error_messages' => array(
+					'error_one' => 'Error one.',
+				),
+			)
+		);
+		Form_Field_Registry::register(
+			'error-test-2',
+			array(
+				'error_messages' => array(
+					'error_two' => 'Error two.',
+				),
+			)
+		);
+
+		$error_types = Form_Field_Registry::filter_error_types( array() );
+
+		$this->assertArrayHasKey( 'error_one', $error_types );
+		$this->assertArrayHasKey( 'error_two', $error_types );
+	}
+
+	/**
+	 * Test default attributes are merged with custom attributes.
+	 */
+	public function test_default_attributes_merged() {
+		Form_Field_Registry::register(
+			'attr-test',
+			array(
+				'block_attributes' => array(
+					'customAttr' => array(
+						'type'    => 'string',
+						'default' => 'custom',
+					),
+				),
+			)
+		);
+
+		$registered = Form_Field_Registry::get( 'attr-test' );
+
+		// Should have custom attribute.
+		$this->assertArrayHasKey( 'customAttr', $registered['block_attributes'] );
+		// Default label attribute should NOT be in block_attributes - it's added during block registration.
+		// The block_attributes in the registry only stores the custom ones passed during registration.
+		$this->assertEquals( 'custom', $registered['block_attributes']['customAttr']['default'] );
+	}
+
+	/**
+	 * Test global function register_jetpack_form_field works.
+	 */
+	public function test_global_register_function() {
+		$result = register_jetpack_form_field( 'global-test', array() );
+
+		$this->assertTrue( $result );
+		$this->assertTrue( jetpack_form_field_exists( 'global-test' ) );
+	}
+
+	/**
+	 * Test global function get_jetpack_form_field works.
+	 */
+	public function test_global_get_function() {
+		register_jetpack_form_field(
+			'global-get-test',
+			array(
+				'error_messages' => array( 'test' => 'Test message' ),
+			)
+		);
+
+		$config = get_jetpack_form_field( 'global-get-test' );
+
+		$this->assertIsArray( $config );
+		$this->assertArrayHasKey( 'test', $config['error_messages'] );
+	}
+
+	/**
+	 * Test global function get_jetpack_form_field returns null for unregistered.
+	 */
+	public function test_global_get_function_returns_null() {
+		$result = get_jetpack_form_field( 'nonexistent' );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test global function jetpack_form_field_exists works.
+	 */
+	public function test_global_exists_function() {
+		register_jetpack_form_field( 'exists-global-test', array() );
+
+		$this->assertTrue( jetpack_form_field_exists( 'exists-global-test' ) );
+		$this->assertFalse( jetpack_form_field_exists( 'does-not-exist-global' ) );
+	}
+
+	/**
+	 * Test default script dependencies are set.
+	 */
+	public function test_default_script_dependencies() {
+		Form_Field_Registry::register( 'deps-test', array() );
+
+		$registered = Form_Field_Registry::get( 'deps-test' );
+
+		$this->assertContains( 'wp-blocks', $registered['editor_script_deps'] );
+		$this->assertContains( 'wp-element', $registered['editor_script_deps'] );
+		$this->assertContains( 'wp-hooks', $registered['dashboard_script_deps'] );
+	}
+
+	/**
+	 * Test custom script dependencies override defaults.
+	 */
+	public function test_custom_script_dependencies() {
+		Form_Field_Registry::register(
+			'custom-deps-test',
+			array(
+				'editor_script_deps' => array( 'custom-dep' ),
+			)
+		);
+
+		$registered = Form_Field_Registry::get( 'custom-deps-test' );
+
+		$this->assertEquals( array( 'custom-dep' ), $registered['editor_script_deps'] );
+	}
+
+	/**
+	 * Data provider for validation callback test cases.
+	 *
+	 * @return array Test cases.
+	 */
+	public static function validation_callback_data_provider(): array {
+		return array(
+			'valid value returns true'     => array(
+				'value'    => '#FF0000',
+				'expected' => true,
+			),
+			'empty required returns error' => array(
+				'value'    => '',
+				'expected' => 'Color is required.',
+			),
+			'invalid format returns error' => array(
+				'value'    => 'not-a-color',
+				'expected' => 'Invalid hex color format.',
+			),
+		);
+	}
+
+	/**
+	 * Test validation callback with various inputs.
+	 *
+	 * @dataProvider validation_callback_data_provider
+	 *
+	 * @param string $value    The value to validate.
+	 * @param mixed  $expected The expected result.
+	 */
+	#[DataProvider( 'validation_callback_data_provider' )]
+	public function test_validation_callback_various_inputs( $value, $expected ) {
+		Form_Field_Registry::register(
+			'validation-data-test',
+			array(
+				'validate_callback' => function ( $val, $label, $field ) {
+					if ( empty( $val ) ) {
+						return 'Color is required.';
+					}
+					if ( ! preg_match( '/^#[0-9A-Fa-f]{6}$/', $val ) ) {
+						return 'Invalid hex color format.';
+					}
+					return true;
+				},
+			)
+		);
+
+		$mock_field = $this->createMock( Contact_Form_Field::class );
+
+		$result = Form_Field_Registry::filter_validate_field(
+			null,
+			'validation-data-test',
+			$value,
+			'Color',
+			$mock_field
+		);
+
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Test that hooks are only initialized once.
+	 */
+	public function test_hooks_initialized_only_once() {
+		// Register multiple fields - hooks should only be added once.
+		Form_Field_Registry::register( 'hooks-test-1', array() );
+		Form_Field_Registry::register( 'hooks-test-2', array() );
+		Form_Field_Registry::register( 'hooks-test-3', array() );
+
+		// Check that the filter is added by checking filter priority.
+		// has_filter returns the priority (int) if found, false if not.
+		$filter_priority = has_filter( 'jetpack_forms_field_types', array( Form_Field_Registry::class, 'filter_field_types' ) );
+
+		// The filter should exist and have a valid priority (10 is default).
+		$this->assertIsInt( $filter_priority );
+		$this->assertEquals( 10, $filter_priority );
+	}
+}


### PR DESCRIPTION
Fixes #

## Proposed changes

* Add PHP filter hooks to `Contact_Form_Field` for custom field validation (`jetpack_forms_validate_field`), rendering (`jetpack_forms_render_field`), and field type registration (`jetpack_forms_field_types`)
* Add `jetpack_forms_render_field_value` filter to `Feedback_Field` for custom value rendering across contexts (email, CSV, API, dashboard)
* Add `jetpack_forms_error_types` filter to `Contact_Form` for custom validation error messages
* Add `Form_Field_Registry` class providing a unified `register()` API (similar to `register_post_type()`) that handles block registration, validation, rendering, error messages, and asset enqueueing in one call
* Add convenience wrapper functions in `form-field-functions.php`: `register_jetpack_form_field()`, `unregister_jetpack_form_field()`, `get_jetpack_form_field()`
* Integrate registered custom field blocks into the Form Editor's allowed block list automatically
* Add comprehensive PHPUnit tests for both the registry (`Form_Field_Registry_Test`) and the filter-based extensibility (`Field_Extensibility_Test`)

### Other information

This is PR 1/5 in the stacked custom field extensibility API series:

1. **#47931** (this PR) — PHP foundation: filter hooks and `Form_Field_Registry`
2. **#47932** — JS/Editor API: block editor integration for custom fields
3. **#47933** — Label, dashboard, and Interactivity API support
4. **#47930** — Asset pipeline and style support
5. **#47929** — Documentation and changelog

- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links

* Part of the Jetpack Forms custom field extensibility initiative

## Does this pull request change what data or activity we track or use?

No changes to tracked data or activity.

## Testing instructions

1. Check out this branch and ensure the Jetpack Forms package is active
2. Run the PHPUnit tests to verify the registry and extensibility hooks:
   ```
   cd projects/packages/forms && composer phpunit -- --filter="Form_Field_Registry_Test|Field_Extensibility_Test"
   ```
3. Test manual field registration by adding the following to a plugin or theme's `functions.php`:
   ```php
   add_action( 'init', function() {
       if ( function_exists( 'register_jetpack_form_field' ) ) {
           register_jetpack_form_field( 'color', array(
               'validate_callback' => function( $value, $label ) {
                   if ( ! preg_match( '/^#[0-9a-f]{6}$/i', $value ) ) {
                       return sprintf( '%s must be a valid hex color.', $label );
                   }
                   return true;
               },
               'render_field' => function( $data ) {
                   return sprintf(
                       '<input type="color" name="%s" id="%s" value="%s" class="grunion-field" />',
                       esc_attr( $data['id'] ),
                       esc_attr( $data['id'] ),
                       esc_attr( $data['value'] )
                   );
               },
           ) );
       }
   } );
   ```
4. Verify the custom field type appears in `Contact_Form_Field::get_registered_field_types()`
5. Verify existing form functionality is not broken — submit a standard form and confirm it still works as expected