### PR TITLE
Forms: Add JavaScript Field API for editor integration

### DIFF
--- a/projects/packages/forms/changelog/add-form-fields-js-editor
+++ b/projects/packages/forms/changelog/add-form-fields-js-editor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Add JavaScript Field API for registering custom form field blocks in the editor.

--- a/projects/packages/forms/docs/custom-fields.md
+++ b/projects/packages/forms/docs/custom-fields.md
@@ -1,0 +1,594 @@
+# Custom Form Fields Developer Guide
+
+This guide explains how to extend Jetpack Forms with custom field types. The extensibility system allows external developers to register new form fields that integrate seamlessly with the Jetpack Forms editor, validation system, response handling, and dashboard.
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Getting Started](#getting-started)
+3. [PHP API Reference](#php-api-reference)
+4. [JavaScript Block Registration](#javascript-block-registration)
+5. [Dashboard Integration](#dashboard-integration)
+6. [Complete Example: Color Picker Field](#complete-example-color-picker-field)
+7. [Testing Your Custom Fields](#testing-your-custom-fields)
+
+## Overview
+
+The Jetpack Forms extensibility system provides a unified API similar to WordPress's `register_post_type()`. With a single function call, you can register:
+
+- Block type for the editor
+- Server-side validation
+- Frontend field rendering
+- Response value rendering (email, CSV, API, dashboard)
+- Error messages
+- Editor and dashboard scripts
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                  register_jetpack_form_field()                   │
+│                                                                  │
+│  Single function call that handles:                              │
+│  ┌─────────────────────────────────────────────────────────────┐│
+│  │ • Block registration (register_block_type)                  ││
+│  │ • Field type registration (jetpack_forms_field_types)       ││
+│  │ • Validation (jetpack_forms_validate_field)                 ││
+│  │ • Field rendering (jetpack_forms_render_field)              ││
+│  │ • Value rendering (jetpack_forms_render_field_value)        ││
+│  │ • Error messages (jetpack_forms_error_types)                ││
+│  │ • Script enqueueing (editor + dashboard)                    ││
+│  └─────────────────────────────────────────────────────────────┘│
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Getting Started
+
+### Prerequisites
+
+- WordPress 6.0+
+- Jetpack Forms plugin active
+- Basic knowledge of WordPress block development
+
+### Quick Start
+
+1. **Create a WordPress plugin** to contain your custom field
+2. **Register the field** using `register_jetpack_form_field()` on the `init` hook
+3. **Create the editor block** in JavaScript
+4. **Create the dashboard script** for custom value rendering (optional)
+
+### Minimal Example
+
+```php
+add_action( 'init', function() {
+    if ( ! function_exists( 'register_jetpack_form_field' ) ) {
+        return;
+    }
+
+    register_jetpack_form_field( 'color', array(
+        'validate_callback' => function( $value, $label, $field ) {
+            if ( empty( $value ) && $field->get_attribute( 'required' ) ) {
+                return sprintf( '%s is required.', $label );
+            }
+            return true;
+        },
+        'editor_script' => plugin_dir_url( __FILE__ ) . 'build/index.js',
+    ) );
+} );
+```
+
+## PHP API Reference
+
+### register_jetpack_form_field()
+
+The main function for registering a custom form field type.
+
+```php
+register_jetpack_form_field( string $field_type, array $args = array() );
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `$field_type` | string | Unique identifier for the field (e.g., 'color', 'rating'). |
+| `$args` | array | Configuration arguments (see below). |
+
+**Configuration Arguments:**
+
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `block_name` | string | `'jetpack/field-{type}'` | WordPress block name. |
+| `block_attributes` | array | `[]` | Additional block attributes. |
+| `render_callback` | callable | Auto-generated | Block render callback. |
+| `validate_callback` | callable | `null` | Validation callback. |
+| `render_field` | callable | `null` | Frontend field HTML render callback. |
+| `render_value` | callable | `null` | Value render callback for contexts. |
+| `error_messages` | array | `[]` | Error key => message pairs. |
+| `editor_script` | string | `''` | URL to the editor script. |
+| `editor_script_deps` | array | `['wp-blocks', ...]` | Editor script dependencies. |
+| `editor_script_ver` | string | `'1.0.0'` | Editor script version. |
+| `dashboard_script` | string | `''` | URL to the dashboard script. |
+| `dashboard_script_deps` | array | `['wp-hooks', ...]` | Dashboard script dependencies. |
+| `dashboard_script_ver` | string | `'1.0.0'` | Dashboard script version. |
+
+### Callback Signatures
+
+#### validate_callback
+
+```php
+/**
+ * @param mixed              $value The submitted field value.
+ * @param string             $label The field label.
+ * @param Contact_Form_Field $field The field instance.
+ * @return bool|string True if valid, error message string if invalid.
+ */
+function( $value, $label, $field ) {
+    if ( empty( $value ) && $field->get_attribute( 'required' ) ) {
+        return sprintf( '%s is required.', $label );
+    }
+    return true;
+}
+```
+
+#### render_field
+
+```php
+/**
+ * @param array $data Field data with keys: id, label, value, required, placeholder, class, field.
+ * @return string HTML to render.
+ */
+function( $data ) {
+    return sprintf(
+        '<div class="grunion-field-wrap">
+            <label for="%s">%s</label>
+            <input type="color" id="%s" name="%s" value="%s" />
+        </div>',
+        esc_attr( $data['id'] ),
+        esc_html( $data['label'] ),
+        esc_attr( $data['id'] ),
+        esc_attr( $data['id'] ),
+        esc_attr( $data['value'] ?? '#000000' )
+    );
+}
+```
+
+#### render_value
+
+```php
+/**
+ * @param string         $context The render context: 'email', 'web', 'ajax', 'csv', 'api'.
+ * @param mixed          $value   The raw field value.
+ * @param Feedback_Field $field   The field instance.
+ * @return mixed Rendered value.
+ */
+function( $context, $value, $field ) {
+    if ( $context === 'email' ) {
+        return sprintf( '<span style="color: %s">%s</span>', esc_attr( $value ), esc_html( $value ) );
+    }
+    return $value;
+}
+```
+
+### Helper Functions
+
+```php
+// Check if a field type is registered
+if ( jetpack_form_field_exists( 'color' ) ) {
+    // Field is registered
+}
+
+// Get field configuration
+$config = get_jetpack_form_field( 'color' );
+```
+
+## JavaScript Block Registration
+
+Even with `register_jetpack_form_field()`, you still need to create a JavaScript file that registers the block in the editor using `registerBlockType()`.
+
+### Basic Editor Block
+
+```javascript
+( function() {
+    'use strict';
+
+    const { registerBlockType } = wp.blocks;
+    const { useBlockProps, InspectorControls } = wp.blockEditor;
+    const { PanelBody, ToggleControl, TextControl } = wp.components;
+    const { createElement: el, Fragment } = wp.element;
+    const { __ } = wp.i18n;
+
+    // Custom icon for your field
+    const fieldIcon = el(
+        'svg',
+        { viewBox: '0 0 24 24', xmlns: 'http://www.w3.org/2000/svg' },
+        el( 'path', { d: 'M12 2C6.49 2 2 6.49 2 12s4.49 10 10 10...' } )
+    );
+
+    registerBlockType( 'jetpack/field-color', {
+        apiVersion: 3,
+        title: __( 'Color Picker', 'my-plugin' ),
+        description: __( 'Add a color picker field to your form.', 'my-plugin' ),
+        icon: fieldIcon,
+        category: 'contact-form',
+        parent: [ 'jetpack/contact-form' ],
+        attributes: {
+            label: {
+                type: 'string',
+                default: 'Favorite Color',
+            },
+            required: {
+                type: 'boolean',
+                default: false,
+            },
+            requiredText: {
+                type: 'string',
+                default: '(required)',
+            },
+            requiredIndicator: {
+                type: 'boolean',
+                default: true,
+            },
+            defaultValue: {
+                type: 'string',
+                default: '#000000',
+            },
+            width: {
+                type: 'number',
+                default: 100,
+            },
+            id: {
+                type: 'string',
+            },
+            shareFieldAttributes: {
+                type: 'boolean',
+                default: true,
+            },
+        },
+        supports: {
+            reusable: false,
+            html: false,
+        },
+
+        edit: function( props ) {
+            const { attributes, setAttributes, clientId } = props;
+            const { label, required, requiredText, requiredIndicator, defaultValue, width } = attributes;
+
+            // Generate field ID if not set
+            if ( ! attributes.id ) {
+                setAttributes( { id: 'color-' + clientId.substring( 0, 8 ) } );
+            }
+
+            const blockProps = useBlockProps( {
+                className: 'jetpack-field jetpack-field-color grunion-field-width-' + width,
+            } );
+
+            return el(
+                Fragment,
+                null,
+                el(
+                    InspectorControls,
+                    null,
+                    el(
+                        PanelBody,
+                        { title: __( 'Field Settings', 'my-plugin' ) },
+                        el( TextControl, {
+                            label: __( 'Label', 'my-plugin' ),
+                            value: label,
+                            onChange: ( value ) => setAttributes( { label: value } ),
+                        } ),
+                        el( ToggleControl, {
+                            label: __( 'Required', 'my-plugin' ),
+                            checked: required,
+                            onChange: ( value ) => setAttributes( { required: value } ),
+                        } )
+                    )
+                ),
+                el(
+                    'div',
+                    blockProps,
+                    el(
+                        'label',
+                        { className: 'grunion-field-label' },
+                        label,
+                        required && requiredIndicator && el( 'span', { className: 'required' }, requiredText )
+                    ),
+                    el( 'input', {
+                        type: 'color',
+                        value: defaultValue,
+                        onChange: ( e ) => setAttributes( { defaultValue: e.target.value } ),
+                    } )
+                )
+            );
+        },
+
+        save: function() {
+            return null; // Server-side rendered
+        },
+    } );
+} )();
+```
+
+**Important:** The block name in JavaScript must match the `block_name` in your PHP registration (defaults to `'jetpack/field-{type}'`).
+
+## Dashboard Integration
+
+The Jetpack Forms dashboard uses React to display form responses. Custom fields can provide custom rendering using WordPress hooks.
+
+### Available Hooks
+
+#### jetpack.forms.dashboard.fieldValue
+
+Customize how field values are displayed in the response viewer.
+
+```javascript
+wp.hooks.addFilter(
+    'jetpack.forms.dashboard.fieldValue',
+    'my-plugin/field-value',
+    function( element, fieldType, value, field ) {
+        if ( fieldType !== 'color' ) {
+            return element;
+        }
+
+        if ( ! value || typeof value !== 'string' ) {
+            return '-';
+        }
+
+        return wp.element.createElement(
+            'span',
+            { style: { display: 'inline-flex', alignItems: 'center', gap: '8px' } },
+            wp.element.createElement( 'span', {
+                style: {
+                    display: 'inline-block',
+                    width: '20px',
+                    height: '20px',
+                    backgroundColor: value,
+                    border: '1px solid #ccc',
+                    borderRadius: '3px',
+                },
+            } ),
+            wp.element.createElement( 'span', {
+                style: { fontFamily: 'monospace', fontSize: '13px' },
+            }, value )
+        );
+    }
+);
+```
+
+#### jetpack.forms.dashboard.fieldIcon
+
+Provide a custom icon for your field type.
+
+```javascript
+wp.hooks.addFilter(
+    'jetpack.forms.dashboard.fieldIcon',
+    'my-plugin/field-icon',
+    function( icon, fieldType ) {
+        if ( fieldType !== 'color' ) {
+            return icon;
+        }
+
+        return wp.element.createElement(
+            'svg',
+            { viewBox: '0 0 24 24', width: 24, height: 24 },
+            wp.element.createElement( 'path', {
+                d: 'M12 2C6.49 2 2 6.49 2 12s4.49 10 10 10...',
+                fill: 'currentColor',
+            } )
+        );
+    }
+);
+```
+
+## Complete Example: Color Picker Field
+
+Here's a complete working plugin using the unified registration API.
+
+### Plugin Structure
+
+```
+jetpack-forms-color-field/
+├── jetpack-forms-color-field.php    # Main plugin file
+├── src/
+│   ├── index.js                     # Editor block (source)
+│   └── dashboard.js                 # Dashboard integration
+└── build/
+    ├── index.js                     # Compiled editor block
+    └── index.asset.php              # Asset dependencies
+```
+
+### Main Plugin File (PHP)
+
+```php
+<?php
+/**
+ * Plugin Name: Jetpack Forms Color Field
+ * Description: Adds a color picker field to Jetpack Forms.
+ * Version: 1.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+add_action( 'init', function() {
+    if ( ! function_exists( 'register_jetpack_form_field' ) ) {
+        return;
+    }
+
+    register_jetpack_form_field( 'color', array(
+        // Block attributes specific to this field type
+        'block_attributes' => array(
+            'label' => array(
+                'type'    => 'string',
+                'default' => 'Favorite Color',
+            ),
+            'defaultValue' => array(
+                'type'    => 'string',
+                'default' => '#000000',
+            ),
+        ),
+
+        // Validation callback
+        'validate_callback' => function( $value, $label, $field ) {
+            if ( empty( $value ) && $field->get_attribute( 'required' ) ) {
+                return sprintf( __( '%s is required.', 'my-plugin' ), $label );
+            }
+
+            if ( empty( $value ) ) {
+                return true;
+            }
+
+            if ( ! preg_match( '/^#[0-9A-Fa-f]{6}$/', $value ) ) {
+                return sprintf( __( '%s must be a valid hex color.', 'my-plugin' ), $label );
+            }
+
+            return true;
+        },
+
+        // Frontend field rendering
+        'render_field' => function( $data ) {
+            $id       = esc_attr( $data['id'] );
+            $label    = esc_html( $data['label'] );
+            $value    = esc_attr( $data['value'] ?? '#000000' );
+            $required = $data['required'] ? 'required aria-required="true"' : '';
+
+            return sprintf(
+                '<div class="grunion-field-wrap">
+                    <label class="grunion-field-label color" for="%s">%s</label>
+                    <input type="color" id="%s" name="%s" value="%s" data-type="color" %s />
+                </div>',
+                $id, $label, $id, $id, $value, $required
+            );
+        },
+
+        // Value rendering for different contexts
+        'render_value' => function( $context, $value, $field ) {
+            if ( empty( $value ) ) {
+                return '';
+            }
+
+            if ( $context === 'email' ) {
+                return sprintf(
+                    '<span style="display:inline-block;width:16px;height:16px;background-color:%s;border:1px solid #ccc;margin-right:8px;"></span>%s',
+                    esc_attr( $value ),
+                    esc_html( $value )
+                );
+            }
+
+            return $value;
+        },
+
+        // Custom error messages
+        'error_messages' => array(
+            'invalid_color' => __( 'Please enter a valid hex color.', 'my-plugin' ),
+        ),
+
+        // Scripts
+        'editor_script'    => plugin_dir_url( __FILE__ ) . 'build/index.js',
+        'dashboard_script' => plugin_dir_url( __FILE__ ) . 'src/dashboard.js',
+    ) );
+} );
+```
+
+### Dashboard Integration (JavaScript)
+
+```javascript
+// src/dashboard.js
+( function() {
+    'use strict';
+
+    const { addFilter } = wp.hooks;
+    const { createElement: el } = wp.element;
+
+    function ColorSwatch( { value } ) {
+        return el(
+            'span',
+            { style: { display: 'inline-flex', alignItems: 'center', gap: '8px' } },
+            el( 'span', {
+                style: {
+                    display: 'inline-block',
+                    width: '20px',
+                    height: '20px',
+                    backgroundColor: value,
+                    border: '1px solid #ccc',
+                    borderRadius: '3px',
+                },
+            } ),
+            el( 'span', { style: { fontFamily: 'monospace' } }, value )
+        );
+    }
+
+    addFilter(
+        'jetpack.forms.dashboard.fieldValue',
+        'my-plugin/field-value',
+        function( element, fieldType, value ) {
+            if ( fieldType !== 'color' ) return element;
+            if ( ! value ) return '-';
+            return el( ColorSwatch, { value } );
+        }
+    );
+} )();
+```
+
+## Testing Your Custom Fields
+
+### Manual Testing Checklist
+
+1. **Block Registration**
+   - [ ] Field appears in block inserter under "Contact Form" category
+   - [ ] Field can only be inserted within a form block
+   - [ ] Field settings panel shows expected controls
+
+2. **Frontend Rendering**
+   - [ ] Field renders correctly on the frontend
+   - [ ] Field respects required attribute
+   - [ ] Default value is pre-filled
+
+3. **Form Submission**
+   - [ ] Field value is submitted correctly
+   - [ ] Server-side validation works
+   - [ ] Invalid submissions show appropriate errors
+
+4. **Response Handling**
+   - [ ] Email notifications display field value correctly
+   - [ ] Dashboard response viewer shows custom rendering
+   - [ ] CSV export includes field value
+   - [ ] API responses include field value
+
+## Troubleshooting
+
+### Common Issues
+
+**Field doesn't appear in inserter:**
+- Ensure `parent: ['jetpack/contact-form']` is set in your JavaScript block
+- Check browser console for JavaScript errors
+- Verify Jetpack Forms plugin is active
+
+**Field value not saved on submission:**
+- Ensure the input `name` attribute matches the field ID
+- Check that `data-type` attribute is set on the input
+
+**Validation not working:**
+- Verify `validate_callback` returns `true` for valid, string for invalid
+- Check the field type matches in your callback
+
+**Custom rendering not showing in dashboard:**
+- Verify `dashboard_script` URL is correct
+- Check that the script uses the correct filter hook name
+- Ensure `jp-forms-dashboard` is listed in dependencies
+
+### Debug Tips
+
+```php
+// Check if your field is registered
+if ( jetpack_form_field_exists( 'color' ) ) {
+    $config = get_jetpack_form_field( 'color' );
+    error_log( print_r( $config, true ) );
+}
+```
+
+```javascript
+// Debug dashboard hooks
+console.log( 'Registered filters:', wp.hooks.filters );
+```

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -15,6 +15,10 @@
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic",
 	"type": "module",
+	"exports": {
+		".": "./src/api/index.js",
+		"./field-api": "./dist/blocks/field-api.js"
+	},
 	"scripts": {
 		"build": "pnpm run clean && pnpm run build:blocks && pnpm run build:contact-form && pnpm run build:dashboard && pnpm run build:wp-build && pnpm run build:boot-asset && pnpm run build:form-editor && pnpm run module:build",
 		"build:blocks": "webpack --config ./tools/webpack.config.blocks.js",

--- a/projects/packages/forms/src/api/components.js
+++ b/projects/packages/forms/src/api/components.js
@@ -1,0 +1,28 @@
+/**
+ * Shared components for Jetpack Forms field extensibility.
+ *
+ * This module exports the reusable components that custom field implementations can use
+ * to maintain consistent styling and behavior with built-in Jetpack Forms fields.
+ */
+
+// Core field components
+export { default as JetpackField } from '../blocks/shared/components/jetpack-field.js';
+export { default as JetpackFieldControls } from '../blocks/shared/components/jetpack-field-controls.js';
+export { default as JetpackFieldWidth } from '../blocks/shared/components/jetpack-field-width.js';
+export { default as JetpackFieldId } from '../blocks/shared/components/jetpack-field-id-control.js';
+export { default as ToolbarRequiredGroup } from '../blocks/shared/components/toolbar-required-group.js';
+
+// Default settings for field blocks
+export { default as defaultSettings } from '../blocks/shared/settings/index.js';
+
+// Hooks for field behavior
+export { default as useFormWrapper } from '../blocks/shared/hooks/use-form-wrapper.js';
+export { default as useFieldSelected } from '../blocks/shared/hooks/use-field-selected.js';
+export { default as useJetpackFieldStyles } from '../blocks/shared/hooks/use-jetpack-field-styles.js';
+export { default as useFormStyle } from '../blocks/shared/hooks/use-form-style.js';
+export { default as useSyncRequiredIndicator } from '../blocks/shared/hooks/use-sync-required-indicator.js';
+export { default as useParentFormClientId } from '../blocks/shared/hooks/use-parent-form-client-id.js';
+
+// Utility functions
+export { generateUniqueFormFieldId } from '../blocks/shared/util/generate-unique-id.js';
+export { FORM_BLOCK_NAME, ALLOWED_INNER_BLOCKS } from '../blocks/shared/util/constants.js';

--- a/projects/packages/forms/src/api/index.js
+++ b/projects/packages/forms/src/api/index.js
@@ -1,0 +1,64 @@
+/**
+ * Jetpack Forms Field Extensibility API
+ *
+ * This module provides the public API for extending Jetpack Forms with custom field types.
+ * External developers can use this API to register new form fields that integrate
+ * seamlessly with Jetpack Forms, including validation, rendering, and response handling.
+ *
+ * @example
+ * // Import the API in your plugin
+ * import {
+ *     registerJetpackFormField,
+ *     JetpackField,
+ *     useFormWrapper,
+ * } from '@automattic/jetpack-forms/field-api';
+ *
+ * // Register a custom color picker field
+ * registerJetpackFormField({
+ *     name: 'field-color',
+ *     title: 'Color Picker',
+ *     icon: 'color-picker',
+ *     edit: ColorPickerEdit,
+ *     validation: {
+ *         frontend: (value, isRequired) => {
+ *             if (isRequired && !value) return 'is_required';
+ *             if (value && !/^#[0-9A-Fa-f]{6}$/.test(value)) return 'invalid_color';
+ *             return 'yes';
+ *         },
+ *     },
+ *     phpType: 'color',
+ * });
+ *
+ * @module @automattic/jetpack-forms/field-api
+ */
+
+// Field registration
+export { registerJetpackFormField, getRegisteredFields } from './register-field.js';
+
+// Validation utilities
+export {
+	registerFieldValidator,
+	validateField,
+	validateDate,
+	isEmptyValue,
+	getCustomValidators,
+} from './validation.js';
+
+// Shared components
+export {
+	JetpackField,
+	JetpackFieldControls,
+	JetpackFieldWidth,
+	JetpackFieldId,
+	ToolbarRequiredGroup,
+	defaultSettings,
+	useFormWrapper,
+	useFieldSelected,
+	useJetpackFieldStyles,
+	useFormStyle,
+	useSyncRequiredIndicator,
+	useParentFormClientId,
+	generateUniqueFormFieldId,
+	FORM_BLOCK_NAME,
+	ALLOWED_INNER_BLOCKS,
+} from './components.js';

--- a/projects/packages/forms/src/api/register-field.js
+++ b/projects/packages/forms/src/api/register-field.js
@@ -1,0 +1,173 @@
+/**
+ * Field registration API for Jetpack Forms extensibility.
+ *
+ * This module provides the main API for registering custom form fields.
+ * External developers can use registerJetpackFormField() to add new field types
+ * that integrate seamlessly with Jetpack Forms.
+ */
+
+import { registerBlockType } from '@wordpress/blocks';
+import { defaultSettings } from './components.js';
+import { registerFieldValidator } from './validation.js';
+
+/**
+ * Registry of all registered custom fields.
+ *
+ * @type {Array<{name: string, blockName: string, fieldType: string}>}
+ */
+const registeredFields = [];
+
+/**
+ * Default attributes that all Jetpack form fields share.
+ *
+ * @type {object}
+ */
+const defaultFieldAttributes = {
+	label: {
+		type: 'string',
+		default: '',
+	},
+	required: {
+		type: 'boolean',
+		default: false,
+	},
+	requiredText: {
+		type: 'string',
+		default: '',
+	},
+	requiredIndicator: {
+		type: 'boolean',
+		default: true,
+	},
+	placeholder: {
+		type: 'string',
+		default: '',
+	},
+	width: {
+		enum: [ 25, 33, 50, 75, 100, 'auto' ],
+		default: 100,
+	},
+	id: {
+		type: 'string',
+	},
+	shareFieldAttributes: {
+		type: 'boolean',
+		default: true,
+	},
+};
+
+/**
+ * Register a custom Jetpack Form field.
+ *
+ * This function registers a new block type that will appear as a field option
+ * in the Jetpack Forms editor, and optionally registers frontend validation.
+ *
+ * @param {object}        config                       - Configuration object for the custom field.
+ * @param {string}        config.name                  - Block name without 'jetpack/' prefix (e.g., 'field-color').
+ * @param {string}        config.title                 - Human-readable field title (e.g., 'Color Picker').
+ * @param {string|object} config.icon                  - Block icon (dashicon name or SVG element).
+ * @param {Function}      config.edit                  - Edit component for the block editor.
+ * @param {Function}      [config.save]                - Save function (defaults to returning null for dynamic blocks).
+ * @param {string}        [config.description]         - Field description shown in the inserter.
+ * @param {object}        [config.attributes]          - Additional block attributes beyond the defaults.
+ * @param {object}        [config.validation]          - Validation configuration.
+ * @param {Function}      [config.validation.frontend] - Frontend validator: (value, isRequired, extra) => 'yes' | errorKey
+ * @param {string}        [config.phpType]             - The PHP field type (defaults to name without 'field-' prefix).
+ * @param {object}        [config.supports]            - Block supports configuration.
+ * @param {boolean}       [config.isPrivate]           - If true, block won't appear in inserter (for internal use).
+ * @return {object|undefined} The registered block type, or undefined if registration failed.
+ *
+ * @example
+ * // Register a simple color picker field
+ * registerJetpackFormField({
+ *     name: 'field-color',
+ *     title: 'Color Picker',
+ *     icon: 'color-picker',
+ *     edit: ColorPickerEdit,
+ *     validation: {
+ *         frontend: (value, isRequired) => {
+ *             if (isRequired && !value) return 'is_required';
+ *             if (value && !/^#[0-9A-Fa-f]{6}$/.test(value)) return 'invalid_color';
+ *             return 'yes';
+ *         },
+ *     },
+ *     phpType: 'color',
+ * });
+ */
+export function registerJetpackFormField( config ) {
+	const {
+		name,
+		title,
+		icon,
+		edit,
+		save = () => null,
+		description = '',
+		attributes = {},
+		validation = null,
+		phpType = null,
+		supports = {},
+		isPrivate = false,
+	} = config;
+
+	if ( ! name || ! title || ! edit ) {
+		// eslint-disable-next-line no-console
+		console.error(
+			'Jetpack Forms: registerJetpackFormField requires name, title, and edit properties.'
+		);
+		return undefined;
+	}
+
+	const blockName = name.startsWith( 'jetpack/' ) ? name : `jetpack/${ name }`;
+	const fieldType = phpType || name.replace( /^(jetpack\/)?field-/, '' );
+
+	// Merge default attributes with custom attributes
+	const mergedAttributes = {
+		...defaultFieldAttributes,
+		...attributes,
+	};
+
+	// Register the block
+	const blockConfig = {
+		...defaultSettings,
+		title,
+		icon,
+		description,
+		category: 'contact-form',
+		parent: [ 'jetpack/contact-form' ],
+		attributes: mergedAttributes,
+		edit,
+		save,
+		supports: {
+			...defaultSettings.supports,
+			...supports,
+			inserter: ! isPrivate,
+		},
+	};
+
+	const result = registerBlockType( blockName, blockConfig );
+
+	// Register frontend validation if provided
+	if ( validation?.frontend && typeof validation.frontend === 'function' ) {
+		registerFieldValidator( fieldType, validation.frontend );
+	}
+
+	// Store registration info for later reference
+	registeredFields.push( {
+		name,
+		blockName,
+		fieldType,
+	} );
+
+	return result;
+}
+
+/**
+ * Get all registered custom fields.
+ *
+ * @return {Array<{name: string, blockName: string, fieldType: string}>} List of registered fields.
+ */
+export function getRegisteredFields() {
+	return [ ...registeredFields ];
+}
+
+export default registerJetpackFormField;

--- a/projects/packages/forms/src/api/validation.js
+++ b/projects/packages/forms/src/api/validation.js
@@ -1,0 +1,13 @@
+/**
+ * Validation utilities for Jetpack Forms field extensibility.
+ *
+ * This module provides validation functions that can be used by custom field implementations.
+ */
+
+export {
+	registerFieldValidator,
+	validateField,
+	validateDate,
+	isEmptyValue,
+	getCustomValidators,
+} from '../contact-form/js/validate-helper.js';

--- a/projects/packages/forms/src/blocks/contact-form/child-blocks.js
+++ b/projects/packages/forms/src/blocks/contact-form/child-blocks.js
@@ -1,4 +1,5 @@
 import { hasFeatureFlag } from '@automattic/jetpack-shared-extension-utils';
+import { applyFilters } from '@wordpress/hooks';
 import DeprecatedOptionCheckbox from '../deprecated/field-option-checkbox/index.js';
 import DeprecatedOptionRadio from '../deprecated/field-option-radio/index.js';
 import JetpackDropzone from '../dropzone/index.js';
@@ -36,7 +37,11 @@ import JetpackLabel from '../label/index.js';
 import JetpackOption from '../option/index.js';
 import JetpackOptions from '../options/index.js';
 
-export const childBlocks = [
+/**
+ * Core child blocks for Jetpack Forms.
+ * These are the built-in field types provided by Jetpack Forms.
+ */
+const coreChildBlocks = [
 	JetpackLabel,
 	JetpackDropzone,
 	JetpackInput,
@@ -82,3 +87,23 @@ export const childBlocks = [
 		  ]
 		: [] ),
 ];
+
+/**
+ * Filter to allow external plugins to add custom field blocks to Jetpack Forms.
+ *
+ * External developers can use this filter to register their custom field block
+ * configurations alongside the core Jetpack Forms fields.
+ *
+ * @param {Array} childBlocks - Array of block configuration objects.
+ *
+ * @example
+ * // Add a custom color picker field
+ * import { addFilter } from '@wordpress/hooks';
+ *
+ * addFilter(
+ *     'jetpack.forms.childBlocks',
+ *     'my-plugin/custom-fields',
+ *     (blocks) => [...blocks, MyColorPickerField]
+ * );
+ */
+export const childBlocks = applyFilters( 'jetpack.forms.childBlocks', coreChildBlocks );

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -14,7 +14,7 @@ import {
 	BlockControls,
 	BlockContextProvider,
 } from '@wordpress/block-editor';
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, getBlockTypes } from '@wordpress/blocks';
 import {
 	ExternalLink,
 	Notice,
@@ -29,6 +29,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useRef, useEffect, useCallback, lazy, Suspense, useState } from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
 import { __, _x } from '@wordpress/i18n';
 import clsx from 'clsx';
 /*
@@ -87,7 +88,44 @@ const validFields = childBlocks.filter( childBlock => {
 	);
 } );
 
-const ALLOWED_BLOCKS = [ ...validFields.map( block => `jetpack/${ block.name }` ) ];
+const CORE_ALLOWED_BLOCKS = [ ...validFields.map( block => `jetpack/${ block.name }` ) ];
+
+/**
+ * Get all allowed blocks for the form, including externally registered blocks.
+ * This function checks all registered blocks to find ones that declare
+ * jetpack/contact-form as their parent.
+ *
+ * @return {string[]} Array of allowed block names.
+ */
+function getAllowedFormBlocks(): string[] {
+	const allBlocks = getBlockTypes();
+	const externalFormBlocks = allBlocks
+		.filter( block => {
+			// Skip blocks already in our core list
+			if ( CORE_ALLOWED_BLOCKS.includes( block.name ) ) {
+				return false;
+			}
+			// Check if this block declares contact-form as parent
+			const parent = block.parent as string | string[] | undefined;
+			return (
+				parent === 'jetpack/contact-form' ||
+				( Array.isArray( parent ) && parent.includes( 'jetpack/contact-form' ) )
+			);
+		} )
+		.map( block => block.name );
+
+	const allAllowedBlocks = [ ...CORE_ALLOWED_BLOCKS, ...externalFormBlocks ];
+
+	/**
+	 * Filter the list of allowed blocks in a Jetpack Form.
+	 *
+	 * This filter allows external plugins to add their custom field blocks
+	 * to the list of blocks that can be inserted into a Jetpack Form.
+	 *
+	 * @param {string[]} allowedBlocks - Array of block names allowed in the form.
+	 */
+	return applyFilters( 'jetpack.forms.allowedBlocks', allAllowedBlocks ) as string[];
+}
 
 // At the top level of a multistep form we allow navigation, progress indicator
 // and the step-container itself (users may add it manually before steps are
@@ -105,9 +143,17 @@ const REMOVE_FIELDS_FROM_FORM = [
 	'jetpack/form-step-container',
 ];
 
-const ALLOWED_FORM_BLOCKS = ALLOWED_BLOCKS.concat( CORE_BLOCKS ).filter(
-	block => ! REMOVE_FIELDS_FROM_FORM.includes( block )
-);
+/**
+ * Get the allowed blocks for a standard (non-multistep) form.
+ * This is computed dynamically to include externally registered blocks.
+ *
+ * @return {string[]} Array of allowed block names for non-multistep forms.
+ */
+function getAllowedFormBlocksFiltered(): string[] {
+	return getAllowedFormBlocks()
+		.concat( CORE_BLOCKS )
+		.filter( block => ! REMOVE_FIELDS_FROM_FORM.includes( block ) );
+}
 
 const PRIORITIZED_INSERTER_BLOCKS = [ ...validFields.map( block => `jetpack/${ block.name }` ) ];
 
@@ -386,7 +432,7 @@ function JetpackContactFormEdit( {
 		},
 		{
 			allowedBlocks:
-				variationName === 'multistep' ? ALLOWED_MULTI_STEP_BLOCKS : ALLOWED_FORM_BLOCKS,
+				variationName === 'multistep' ? ALLOWED_MULTI_STEP_BLOCKS : getAllowedFormBlocksFiltered(),
 			prioritizedInserterBlocks: PRIORITIZED_INSERTER_BLOCKS,
 			templateInsertUpdatesSelection: false,
 		}

--- a/projects/packages/forms/src/contact-form/js/validate-helper.js
+++ b/projects/packages/forms/src/contact-form/js/validate-helper.js
@@ -1,4 +1,37 @@
 /**
+ * Registry for custom field validators.
+ *
+ * External developers can register custom validators using registerFieldValidator().
+ * Validators are functions that receive (value, isRequired, extra) and return
+ * 'yes' for valid, or an error key string for invalid (e.g., 'is_required', 'invalid_color').
+ *
+ * @type {Object.<string, Function>}
+ */
+const customValidators = {};
+
+/**
+ * Register a custom field validator for a specific field type.
+ *
+ * @param {string}   type      The field type to validate (e.g., 'color', 'custom-field').
+ * @param {Function} validator Validation function: (value, isRequired, extra) => 'yes' | errorKey
+ */
+export const registerFieldValidator = ( type, validator ) => {
+	if ( typeof validator !== 'function' ) {
+		// eslint-disable-next-line no-console
+		console.error( `Jetpack Forms: Validator for type "${ type }" must be a function.` );
+		return;
+	}
+	customValidators[ type ] = validator;
+};
+
+/**
+ * Get all registered custom validators.
+ *
+ * @returns {Object.<string, Function>} The custom validators registry.
+ */
+export const getCustomValidators = () => ( { ...customValidators } );
+
+/**
  * Validate the date Value based on the format of the date field.
  *
  * @param {string} value  Date value
@@ -97,15 +130,24 @@ export const isEmptyValue = value => {
 };
 
 /**
- * return true or the field error.
- * @param  type
- * @param  value
- * @param  isRequired
- * @param  extra
+ * Validate a form field value.
  *
- * @returns {string}
+ * Returns 'yes' for valid fields, or an error key string for invalid fields.
+ * Error keys can be used to look up localized error messages.
+ *
+ * @param {string}  type       The field type (e.g., 'email', 'url', 'text', 'color').
+ * @param {*}       value      The field value to validate.
+ * @param {boolean} isRequired Whether the field is required.
+ * @param {*}       extra      Extra validation context (e.g., date format, min/max for numbers).
+ *
+ * @returns {string} 'yes' if valid, or an error key string (e.g., 'is_required', 'invalid_email').
  */
 export const validateField = ( type, value, isRequired, extra = null ) => {
+	// Check if there's a custom validator registered for this type
+	if ( customValidators[ type ] ) {
+		return customValidators[ type ]( value, isRequired, extra );
+	}
+
 	if ( isEmptyValue( value ) && isRequired ) {
 		return 'is_required';
 	}

--- a/projects/packages/forms/tests/js/api/register-field.test.js
+++ b/projects/packages/forms/tests/js/api/register-field.test.js
@@ -1,0 +1,220 @@
+/**
+ * Tests for the Jetpack Forms field registration API.
+ */
+
+// Mock WordPress dependencies
+jest.mock( '@wordpress/blocks', () => ( {
+	registerBlockType: jest.fn( ( name, config ) => ( { name, ...config } ) ),
+} ) );
+
+jest.mock( '../../../src/api/validation', () => ( {
+	registerFieldValidator: jest.fn(),
+} ) );
+
+jest.mock( '../../../src/api/components', () => ( {
+	defaultSettings: {
+		apiVersion: 3,
+		category: 'contact-form',
+		supports: {
+			reusable: false,
+			html: false,
+		},
+		save: () => null,
+	},
+} ) );
+
+import { registerBlockType } from '@wordpress/blocks';
+import { registerJetpackFormField, getRegisteredFields } from '../../../src/api/register-field';
+import { registerFieldValidator } from '../../../src/api/validation';
+
+describe( 'registerJetpackFormField', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'registers a block with the correct name', () => {
+		const MockEdit = () => null;
+
+		registerJetpackFormField( {
+			name: 'field-color',
+			title: 'Color Picker',
+			icon: 'color-picker',
+			edit: MockEdit,
+		} );
+
+		expect( registerBlockType ).toHaveBeenCalledWith(
+			'jetpack/field-color',
+			expect.objectContaining( {
+				title: 'Color Picker',
+				icon: 'color-picker',
+				edit: MockEdit,
+			} )
+		);
+	} );
+
+	test( 'handles names that already include jetpack/ prefix', () => {
+		const MockEdit = () => null;
+
+		registerJetpackFormField( {
+			name: 'jetpack/field-custom',
+			title: 'Custom Field',
+			edit: MockEdit,
+		} );
+
+		expect( registerBlockType ).toHaveBeenCalledWith( 'jetpack/field-custom', expect.anything() );
+	} );
+
+	test( 'merges default attributes with custom attributes', () => {
+		const MockEdit = () => null;
+
+		registerJetpackFormField( {
+			name: 'field-test',
+			title: 'Test Field',
+			edit: MockEdit,
+			attributes: {
+				customAttr: {
+					type: 'string',
+					default: 'custom value',
+				},
+			},
+		} );
+
+		expect( registerBlockType ).toHaveBeenCalledWith(
+			'jetpack/field-test',
+			expect.objectContaining( {
+				attributes: expect.objectContaining( {
+					// Default attributes
+					label: expect.anything(),
+					required: expect.anything(),
+					width: expect.anything(),
+					// Custom attribute
+					customAttr: {
+						type: 'string',
+						default: 'custom value',
+					},
+				} ),
+			} )
+		);
+	} );
+
+	test( 'sets parent to contact-form', () => {
+		const MockEdit = () => null;
+
+		registerJetpackFormField( {
+			name: 'field-test',
+			title: 'Test Field',
+			edit: MockEdit,
+		} );
+
+		expect( registerBlockType ).toHaveBeenCalledWith(
+			'jetpack/field-test',
+			expect.objectContaining( {
+				parent: [ 'jetpack/contact-form' ],
+			} )
+		);
+	} );
+
+	test( 'registers frontend validation when provided', () => {
+		const MockEdit = () => null;
+		const mockValidator = jest.fn();
+
+		registerJetpackFormField( {
+			name: 'field-validated',
+			title: 'Validated Field',
+			edit: MockEdit,
+			validation: {
+				frontend: mockValidator,
+			},
+		} );
+
+		expect( registerFieldValidator ).toHaveBeenCalledWith( 'validated', mockValidator );
+	} );
+
+	test( 'uses phpType when specified for validation', () => {
+		const MockEdit = () => null;
+		const mockValidator = jest.fn();
+
+		registerJetpackFormField( {
+			name: 'field-color',
+			title: 'Color Picker',
+			edit: MockEdit,
+			phpType: 'custom-color',
+			validation: {
+				frontend: mockValidator,
+			},
+		} );
+
+		expect( registerFieldValidator ).toHaveBeenCalledWith( 'custom-color', mockValidator );
+	} );
+
+	test( 'does not register validation when not provided', () => {
+		const MockEdit = () => null;
+
+		registerJetpackFormField( {
+			name: 'field-no-validation',
+			title: 'No Validation Field',
+			edit: MockEdit,
+		} );
+
+		expect( registerFieldValidator ).not.toHaveBeenCalled();
+	} );
+
+	test( 'returns undefined and logs error when required props are missing', () => {
+		const consoleSpy = jest.spyOn( console, 'error' ).mockImplementation();
+
+		const result = registerJetpackFormField( {
+			name: 'field-incomplete',
+			// Missing title and edit
+		} );
+
+		expect( result ).toBeUndefined();
+		expect( consoleSpy ).toHaveBeenCalled();
+
+		consoleSpy.mockRestore();
+	} );
+
+	test( 'tracks registered fields', () => {
+		const MockEdit = () => null;
+
+		registerJetpackFormField( {
+			name: 'field-tracked',
+			title: 'Tracked Field',
+			edit: MockEdit,
+		} );
+
+		const registeredFields = getRegisteredFields();
+		const trackedField = registeredFields.find( f => f.name === 'field-tracked' );
+
+		expect( trackedField ).toBeDefined();
+		expect( trackedField.blockName ).toBe( 'jetpack/field-tracked' );
+		expect( trackedField.fieldType ).toBe( 'tracked' );
+	} );
+
+	test( 'getRegisteredFields returns a copy of the registry', () => {
+		const fields1 = getRegisteredFields();
+		const fields2 = getRegisteredFields();
+
+		expect( fields1 ).toEqual( fields2 );
+		expect( fields1 ).not.toBe( fields2 );
+	} );
+
+	test( 'sets inserter to false when isPrivate is true', () => {
+		const MockEdit = () => null;
+
+		registerJetpackFormField( {
+			name: 'field-private',
+			title: 'Private Field',
+			edit: MockEdit,
+			isPrivate: true,
+		} );
+
+		expect( registerBlockType ).toHaveBeenCalledWith(
+			'jetpack/field-private',
+			expect.objectContaining( {
+				supports: expect.objectContaining( {
+					inserter: false,
+				} ),
+			} )
+		);
+	} );
+} );

--- a/projects/packages/forms/tests/js/contact-form/validate-helper.test.js
+++ b/projects/packages/forms/tests/js/contact-form/validate-helper.test.js
@@ -3,6 +3,8 @@ import {
 	validateField,
 	validateDate,
 	isEmptyValue,
+	registerFieldValidator,
+	getCustomValidators,
 } from '../../../src/contact-form/js/validate-helper';
 
 // To run these test:
@@ -294,6 +296,76 @@ describe( 'validateField', () => {
 		test( 'returns false for functions', () => {
 			expect( isEmptyValue( function () {} ) ).toBe( false );
 			expect( isEmptyValue( () => {} ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'custom validator registration', () => {
+		test( 'registerFieldValidator adds a custom validator', () => {
+			const colorValidator = ( value, isRequired ) => {
+				if ( isRequired && ! value ) {
+					return 'is_required';
+				}
+				if ( value && ! /^#[0-9A-Fa-f]{6}$/.test( value ) ) {
+					return 'invalid_color';
+				}
+				return 'yes';
+			};
+
+			registerFieldValidator( 'color', colorValidator );
+
+			const validators = getCustomValidators();
+			expect( validators.color ).toBe( colorValidator );
+		} );
+
+		test( 'custom validators are called during validateField', () => {
+			const customValidator = jest.fn( () => 'yes' );
+			registerFieldValidator( 'custom-test', customValidator );
+
+			validateField( 'custom-test', 'test value', true, { extra: 'data' } );
+
+			expect( customValidator ).toHaveBeenCalledWith( 'test value', true, { extra: 'data' } );
+		} );
+
+		test( 'custom validator validates required fields correctly', () => {
+			registerFieldValidator( 'color', ( value, isRequired ) => {
+				if ( isRequired && ! value ) {
+					return 'is_required';
+				}
+				if ( value && ! /^#[0-9A-Fa-f]{6}$/.test( value ) ) {
+					return 'invalid_color';
+				}
+				return 'yes';
+			} );
+
+			expect( validateField( 'color', '', true ) ).toBe( 'is_required' );
+			expect( validateField( 'color', '', false ) ).toBe( 'yes' );
+		} );
+
+		test( 'custom validator validates format correctly', () => {
+			registerFieldValidator( 'color', ( value, isRequired ) => {
+				if ( isRequired && ! value ) {
+					return 'is_required';
+				}
+				if ( value && ! /^#[0-9A-Fa-f]{6}$/.test( value ) ) {
+					return 'invalid_color';
+				}
+				return 'yes';
+			} );
+
+			expect( validateField( 'color', '#FF0000', false ) ).toBe( 'yes' );
+			expect( validateField( 'color', '#ff0000', false ) ).toBe( 'yes' );
+			expect( validateField( 'color', 'red', false ) ).toBe( 'invalid_color' );
+			expect( validateField( 'color', '#FFF', false ) ).toBe( 'invalid_color' );
+			expect( validateField( 'color', 'invalid', true ) ).toBe( 'invalid_color' );
+		} );
+
+		test( 'getCustomValidators returns a copy of the registry', () => {
+			const validators = getCustomValidators();
+			const validators2 = getCustomValidators();
+
+			// Should be equal in content but not the same object
+			expect( validators ).toEqual( validators2 );
+			expect( validators ).not.toBe( validators2 );
 		} );
 	} );
 } );

--- a/projects/packages/forms/tools/webpack.config.blocks.js
+++ b/projects/packages/forms/tools/webpack.config.blocks.js
@@ -27,6 +27,7 @@ const sharedWebpackConfig = {
 		'field-rating/style': './src/blocks/field-rating/style.scss',
 		'field-image-select/style': './src/blocks/field-image-select/style.scss',
 		'input-range/style': './src/blocks/input-range/style.scss',
+		'field-api': './src/api/index.js',
 	},
 	output: {
 		...jetpackWebpackConfig.output,


### PR DESCRIPTION
Fixes #

## Proposed changes

This PR adds the JavaScript Field API that enables third-party developers to register custom form field blocks in the Jetpack Forms editor. It builds on the PHP foundation from #47931.

* Add `registerJetpackFormField()` JS API in `src/api/register-field.js` for registering custom field blocks with the editor, including automatic block type registration, attribute merging, and parent block assignment
* Add `registerFieldValidator()` in `src/api/validation.js` for registering client-side field validators that integrate with the existing `validate-helper.js` system
* Add `field-api` webpack entry point in `tools/webpack.config.blocks.js` to expose the JS API as a standalone script
* Update `child-blocks.js` with `getAllowedFormBlocks()` to dynamically discover registered custom field blocks alongside built-in form blocks
* Update `edit.tsx` to use `getAllowedFormBlocks()` for the contact form's `allowedBlocks` list
* Add shared component re-exports in `src/api/components.js` (JetpackFieldLabel, JetpackFieldControls, etc.) so custom fields can reuse existing form field UI components
* Extend `validate-helper.js` to support pluggable validators via `registerFieldValidator` alongside the existing built-in validation
* Add initial developer documentation in `docs/custom-fields.md` covering PHP API, JS block registration, dashboard integration, and a complete color picker example
* Add Jest tests for `registerJetpackFormField` (register-field.test.js) and validator integration (validate-helper.test.js)

### Other information

This is **PR 2 of 5** in a stacked PR series for the Forms custom fields extensibility system. It is stacked on #47931.

**Full stack:**
1. #47931 -- PHP foundation (field registry, validation, rendering)
2. #47932 -- JS/Editor API (this PR)
3. #47933 -- Label, dashboard, Interactivity API
4. #47930 -- Asset pipeline & styles
5. #47929 -- Documentation & changelog

- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links

* Part of the Jetpack Forms extensibility initiative to allow third-party custom field types

## Does this pull request change what data or activity we track or use?

No changes to tracked data or activity.

## Testing instructions

1. **Verify JS API registration works in the editor:**
   - Check out this branch (ensure #47931 base branch is also present)
   - Run `pnpm build` in `projects/packages/forms`
   - Create a new post with a Jetpack Form block
   - Confirm that the built-in form field child blocks still appear correctly in the block inserter within the form

2. **Run the Jest tests:**
   ```
   cd projects/packages/forms && pnpm test
   ```
   - Confirm `register-field.test.js` passes (tests for `registerJetpackFormField`, attribute merging, parent block assignment, error handling)
   - Confirm `validate-helper.test.js` passes (tests for `registerFieldValidator` integration with the validation system)

3. **Verify the webpack entry point:**
   - After building, confirm `build/field-api.js` is generated
   - Verify it exports `registerJetpackFormField`, `registerFieldValidator`, and shared components

4. **Verify `getAllowedFormBlocks()`:**
   - In the editor, add a Jetpack Form block
   - Open the block inserter inside the form and confirm all standard field blocks are listed
   - The allowed blocks list should now be dynamically generated rather than hardcoded