### PR TITLE
Forms: Add label support, dashboard hooks, and Interactivity API

### DIFF
--- a/projects/packages/forms/changelog/add-form-fields-label-dashboard
+++ b/projects/packages/forms/changelog/add-form-fields-label-dashboard
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: Add label block support, dashboard extensibility hooks, and Interactivity API context for custom fields.

--- a/projects/packages/forms/docs/custom-fields.md
+++ b/projects/packages/forms/docs/custom-fields.md
@@ -8,9 +8,10 @@ This guide explains how to extend Jetpack Forms with custom field types. The ext
 2. [Getting Started](#getting-started)
 3. [PHP API Reference](#php-api-reference)
 4. [JavaScript Block Registration](#javascript-block-registration)
-5. [Dashboard Integration](#dashboard-integration)
-6. [Complete Example: Color Picker Field](#complete-example-color-picker-field)
-7. [Testing Your Custom Fields](#testing-your-custom-fields)
+5. [Frontend Interactivity](#frontend-interactivity)
+6. [Dashboard Integration](#dashboard-integration)
+7. [Complete Example: Color Picker Field](#complete-example-color-picker-field)
+8. [Testing Your Custom Fields](#testing-your-custom-fields)
 
 ## Overview
 
@@ -18,10 +19,12 @@ The Jetpack Forms extensibility system provides a unified API similar to WordPre
 
 - Block type for the editor
 - Server-side validation
-- Frontend field rendering
+- Frontend field rendering with Interactivity API support
 - Response value rendering (email, CSV, API, dashboard)
 - Error messages
-- Editor and dashboard scripts
+- Editor, view, and dashboard scripts
+- Automatic Name/ID control in the Advanced panel
+- Label support with the `jetpack/label` block
 
 ### Architecture
 
@@ -37,7 +40,9 @@ The Jetpack Forms extensibility system provides a unified API similar to WordPre
 │  │ • Field rendering (jetpack_forms_render_field)              ││
 │  │ • Value rendering (jetpack_forms_render_field_value)        ││
 │  │ • Error messages (jetpack_forms_error_types)                ││
-│  │ • Script enqueueing (editor + dashboard)                    ││
+│  │ • Script enqueueing (editor, view, dashboard)               ││
+│  │ • Automatic Name/ID control injection                       ││
+│  │ • Label block parent registration (with supports.label)     ││
 │  └─────────────────────────────────────────────────────────────┘│
 └─────────────────────────────────────────────────────────────────┘
 ```
@@ -46,7 +51,7 @@ The Jetpack Forms extensibility system provides a unified API similar to WordPre
 
 ### Prerequisites
 
-- WordPress 6.0+
+- WordPress 6.5+ (for Interactivity API support)
 - Jetpack Forms plugin active
 - Basic knowledge of WordPress block development
 
@@ -54,8 +59,9 @@ The Jetpack Forms extensibility system provides a unified API similar to WordPre
 
 1. **Create a WordPress plugin** to contain your custom field
 2. **Register the field** using `register_jetpack_form_field()` on the `init` hook
-3. **Create the editor block** in JavaScript
-4. **Create the dashboard script** for custom value rendering (optional)
+3. **Create the editor block** in JavaScript using `registerBlockType()`
+4. **Create the view script** for frontend interactivity (optional)
+5. **Create the dashboard script** for custom value rendering (optional)
 
 ### Minimal Example
 
@@ -66,6 +72,9 @@ add_action( 'init', function() {
     }
 
     register_jetpack_form_field( 'color', array(
+        'supports' => array(
+            'label' => true, // Enable jetpack/label as inner block
+        ),
         'validate_callback' => function( $value, $label, $field ) {
             if ( empty( $value ) && $field->get_attribute( 'required' ) ) {
                 return sprintf( '%s is required.', $label );
@@ -100,21 +109,33 @@ register_jetpack_form_field( string $field_type, array $args = array() );
 |----------|------|---------|-------------|
 | `block_name` | string | `'jetpack/field-{type}'` | WordPress block name. |
 | `block_attributes` | array | `[]` | Additional block attributes. |
+| `supports` | array | `[]` | Feature support flags (see below). |
 | `render_callback` | callable | Auto-generated | Block render callback. |
-| `validate_callback` | callable | `null` | Validation callback. |
+| `validate_callback` | callable | `null` | Server-side validation callback. |
 | `render_field` | callable | `null` | Frontend field HTML render callback. |
 | `render_value` | callable | `null` | Value render callback for contexts. |
-| `error_messages` | array | `[]` | Error key => message pairs. |
+| `error_messages` | array | `[]` | Error key => message pairs for frontend validation. |
 | `editor_script` | string | `''` | URL to the editor script. |
-| `editor_script_deps` | array | `['wp-blocks', ...]` | Editor script dependencies. |
+| `editor_script_deps` | array | `['wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-i18n']` | Editor script dependencies. |
 | `editor_script_ver` | string | `'1.0.0'` | Editor script version. |
+| `view_script` | string | `''` | URL to the frontend view script (ES module). |
+| `view_script_deps` | array | `['@wordpress/interactivity', 'jp-forms-view']` | View script module dependencies. |
+| `view_script_ver` | string | `'1.0.0'` | View script version. |
 | `dashboard_script` | string | `''` | URL to the dashboard script. |
-| `dashboard_script_deps` | array | `['wp-hooks', ...]` | Dashboard script dependencies. |
+| `dashboard_script_deps` | array | `['wp-hooks', 'wp-element', 'jp-forms-dashboard']` | Dashboard script dependencies. |
 | `dashboard_script_ver` | string | `'1.0.0'` | Dashboard script version. |
+
+**Supports Flags:**
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `label` | bool | Enable `jetpack/label` as inner block. Provides pre-rendered `label_html` in render_field data. |
 
 ### Callback Signatures
 
 #### validate_callback
+
+Server-side validation that runs when the form is submitted.
 
 ```php
 /**
@@ -127,33 +148,52 @@ function( $value, $label, $field ) {
     if ( empty( $value ) && $field->get_attribute( 'required' ) ) {
         return sprintf( '%s is required.', $label );
     }
+    if ( $value && ! preg_match( '/^#[0-9A-Fa-f]{6}$/', $value ) ) {
+        return sprintf( '%s must be a valid hex color.', $label );
+    }
     return true;
 }
 ```
 
 #### render_field
 
+Renders the field HTML on the frontend. When `supports.label` is enabled, you receive pre-rendered label and error HTML.
+
 ```php
 /**
- * @param array $data Field data with keys: id, label, value, required, placeholder, class, field.
+ * @param array $data Field data with keys:
+ *   - id: Field ID
+ *   - label: Field label text
+ *   - value: Current/default value
+ *   - required: Whether field is required
+ *   - placeholder: Placeholder text
+ *   - class: CSS classes
+ *   - field: Contact_Form_Field instance
+ *   - wrapper_attrs: Interactivity API attributes for wrapper div
+ *   - label_html: Pre-rendered label HTML (when supports.label is true)
+ *   - error_html: Pre-rendered error HTML for validation messages
  * @return string HTML to render.
  */
 function( $data ) {
     return sprintf(
-        '<div class="grunion-field-wrap">
-            <label for="%s">%s</label>
-            <input type="color" id="%s" name="%s" value="%s" />
+        '<div class="grunion-field-wrap" %s>
+            %s
+            <input type="color" id="%s" name="%s" value="%s" data-type="color" />
+            %s
         </div>',
+        $data['wrapper_attrs'],
+        $data['label_html'],
         esc_attr( $data['id'] ),
-        esc_html( $data['label'] ),
         esc_attr( $data['id'] ),
-        esc_attr( $data['id'] ),
-        esc_attr( $data['value'] ?? '#000000' )
+        esc_attr( $data['value'] ?? '' ),
+        $data['error_html']
     );
 }
 ```
 
 #### render_value
+
+Renders the field value in different contexts (email notifications, dashboard, CSV export, API).
 
 ```php
 /**
@@ -163,10 +203,19 @@ function( $data ) {
  * @return mixed Rendered value.
  */
 function( $context, $value, $field ) {
-    if ( $context === 'email' ) {
-        return sprintf( '<span style="color: %s">%s</span>', esc_attr( $value ), esc_html( $value ) );
+    if ( empty( $value ) ) {
+        return '';
     }
-    return $value;
+
+    if ( $context === 'email' ) {
+        return sprintf(
+            '<span style="display:inline-block;width:16px;height:16px;background-color:%s;border:1px solid #ccc;margin-right:8px;"></span>%s',
+            esc_attr( $value ),
+            esc_html( $value )
+        );
+    }
+
+    return $value; // Raw value for csv, api, web, ajax
 }
 ```
 
@@ -184,220 +233,395 @@ $config = get_jetpack_form_field( 'color' );
 
 ## JavaScript Block Registration
 
-Even with `register_jetpack_form_field()`, you still need to create a JavaScript file that registers the block in the editor using `registerBlockType()`.
+Create a JavaScript file that registers the block in the editor using `registerBlockType()`.
 
-### Basic Editor Block
+### Key Points
+
+1. **Block name must match** the `block_name` in PHP (defaults to `'jetpack/field-{type}'`)
+2. **Use `parent: ['jetpack/contact-form']`** to restrict the field to forms
+3. **Include an `id` attribute** - the Name/ID control is automatically injected
+4. **Don't auto-generate IDs** - leave `id` empty and the server will generate unique IDs based on the label
+
+### Modern Block with Label Support
+
+When `supports.label` is enabled, use `jetpack/label` as an inner block for the label:
 
 ```javascript
-( function() {
-    'use strict';
+import { registerBlockType } from '@wordpress/blocks';
+import { useBlockProps, useInnerBlocksProps, InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, ToggleControl, ColorPicker } from '@wordpress/components';
+import { useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
-    const { registerBlockType } = wp.blocks;
-    const { useBlockProps, InspectorControls } = wp.blockEditor;
-    const { PanelBody, ToggleControl, TextControl } = wp.components;
-    const { createElement: el, Fragment } = wp.element;
-    const { __ } = wp.i18n;
+const ALLOWED_INNER_BLOCKS = [ 'jetpack/label' ];
 
-    // Custom icon for your field
-    const fieldIcon = el(
-        'svg',
-        { viewBox: '0 0 24 24', xmlns: 'http://www.w3.org/2000/svg' },
-        el( 'path', { d: 'M12 2C6.49 2 2 6.49 2 12s4.49 10 10 10...' } )
-    );
-
-    registerBlockType( 'jetpack/field-color', {
-        apiVersion: 3,
-        title: __( 'Color Picker', 'my-plugin' ),
-        description: __( 'Add a color picker field to your form.', 'my-plugin' ),
-        icon: fieldIcon,
-        category: 'contact-form',
-        parent: [ 'jetpack/contact-form' ],
-        attributes: {
-            label: {
-                type: 'string',
-                default: 'Favorite Color',
-            },
-            required: {
-                type: 'boolean',
-                default: false,
-            },
-            requiredText: {
-                type: 'string',
-                default: '(required)',
-            },
-            requiredIndicator: {
-                type: 'boolean',
-                default: true,
-            },
-            defaultValue: {
-                type: 'string',
-                default: '#000000',
-            },
-            width: {
-                type: 'number',
-                default: 100,
-            },
-            id: {
-                type: 'string',
-            },
-            shareFieldAttributes: {
-                type: 'boolean',
-                default: true,
-            },
+registerBlockType( 'jetpack/field-color', {
+    apiVersion: 3,
+    title: __( 'Color Picker', 'my-plugin' ),
+    icon: 'color-picker',
+    category: 'contact-form',
+    parent: [ 'jetpack/contact-form' ],
+    attributes: {
+        required: {
+            type: 'boolean',
+            default: false,
         },
-        supports: {
-            reusable: false,
-            html: false,
+        requiredIndicator: {
+            type: 'boolean',
+            default: true,
         },
-
-        edit: function( props ) {
-            const { attributes, setAttributes, clientId } = props;
-            const { label, required, requiredText, requiredIndicator, defaultValue, width } = attributes;
-
-            // Generate field ID if not set
-            if ( ! attributes.id ) {
-                setAttributes( { id: 'color-' + clientId.substring( 0, 8 ) } );
-            }
-
-            const blockProps = useBlockProps( {
-                className: 'jetpack-field jetpack-field-color grunion-field-width-' + width,
-            } );
-
-            return el(
-                Fragment,
-                null,
-                el(
-                    InspectorControls,
-                    null,
-                    el(
-                        PanelBody,
-                        { title: __( 'Field Settings', 'my-plugin' ) },
-                        el( TextControl, {
-                            label: __( 'Label', 'my-plugin' ),
-                            value: label,
-                            onChange: ( value ) => setAttributes( { label: value } ),
-                        } ),
-                        el( ToggleControl, {
-                            label: __( 'Required', 'my-plugin' ),
-                            checked: required,
-                            onChange: ( value ) => setAttributes( { required: value } ),
-                        } )
-                    )
-                ),
-                el(
-                    'div',
-                    blockProps,
-                    el(
-                        'label',
-                        { className: 'grunion-field-label' },
-                        label,
-                        required && requiredIndicator && el( 'span', { className: 'required' }, requiredText )
-                    ),
-                    el( 'input', {
-                        type: 'color',
-                        value: defaultValue,
-                        onChange: ( e ) => setAttributes( { defaultValue: e.target.value } ),
-                    } )
-                )
-            );
+        defaultValue: {
+            type: 'string',
+            default: '',
         },
-
-        save: function() {
-            return null; // Server-side rendered
+        width: {
+            enum: [ 25, 33, 50, 75, 100, 'auto' ],
+            default: 100,
         },
-    } );
-} )();
+        // Optional custom ID - leave empty for auto-generation
+        id: {
+            type: 'string',
+        },
+        shareFieldAttributes: {
+            type: 'boolean',
+            default: true,
+        },
+    },
+    // Provide context to jetpack/label
+    providesContext: {
+        'jetpack/field-required': 'required',
+        'jetpack/field-share-attributes': 'shareFieldAttributes',
+    },
+    supports: {
+        reusable: false,
+        html: false,
+        __experimentalExposeControlsToChildren: true,
+    },
+
+    edit: function( { attributes, setAttributes } ) {
+        const { required, requiredIndicator, defaultValue, width, shareFieldAttributes } = attributes;
+
+        const blockProps = useBlockProps( {
+            className: `jetpack-field jetpack-field-color jetpack-field__width-${ width }`,
+        } );
+
+        const template = useMemo( () => [
+            [ 'jetpack/label', {
+                label: __( 'Favorite Color', 'my-plugin' ),
+                required,
+            } ],
+        ], [ required ] );
+
+        const innerBlocksProps = useInnerBlocksProps( {}, {
+            allowedBlocks: ALLOWED_INNER_BLOCKS,
+            template,
+            templateLock: 'all',
+        } );
+
+        return (
+            <>
+                <InspectorControls>
+                    <PanelBody title={ __( 'Field Settings', 'my-plugin' ) }>
+                        <ToggleControl
+                            label={ __( 'Field is required', 'my-plugin' ) }
+                            checked={ required }
+                            onChange={ ( value ) => setAttributes( { required: value } ) }
+                        />
+                        { required && (
+                            <ToggleControl
+                                label={ __( 'Show required text', 'my-plugin' ) }
+                                checked={ requiredIndicator }
+                                onChange={ ( value ) => setAttributes( { requiredIndicator: value } ) }
+                            />
+                        ) }
+                        <ToggleControl
+                            label={ __( 'Sync fields style', 'my-plugin' ) }
+                            checked={ shareFieldAttributes }
+                            onChange={ ( value ) => setAttributes( { shareFieldAttributes: value } ) }
+                        />
+                    </PanelBody>
+                    <PanelBody title={ __( 'Default Value', 'my-plugin' ) } initialOpen={ false }>
+                        <ColorPicker
+                            color={ defaultValue }
+                            onChange={ ( value ) => setAttributes( { defaultValue: value } ) }
+                            enableAlpha={ false }
+                        />
+                    </PanelBody>
+                </InspectorControls>
+
+                <div { ...blockProps }>
+                    <div { ...innerBlocksProps } />
+                    { /* Your field preview UI here */ }
+                </div>
+            </>
+        );
+    },
+
+    save: () => {
+        const innerBlocksProps = useInnerBlocksProps.save();
+        return <div { ...innerBlocksProps } />;
+    },
+} );
 ```
 
-**Important:** The block name in JavaScript must match the `block_name` in your PHP registration (defaults to `'jetpack/field-{type}'`).
+### Automatic Name/ID Control
+
+The Name/ID control is automatically injected into the Advanced panel for all custom fields. Users can:
+- Leave it empty (recommended) - a unique ID is auto-generated from the label
+- Set a custom ID for specific use cases
+
+You don't need to add any code for this - just include the `id` attribute in your block registration.
+
+## Frontend Interactivity
+
+For dynamic frontend behavior, create a view script that extends the `jetpack/form` Interactivity API store.
+
+### View Script Structure
+
+```javascript
+// src/view.js
+import { store, getContext } from '@wordpress/interactivity';
+
+const NAMESPACE = 'jetpack/form';
+
+// Get reference to the form's actions for validation integration
+const { actions: formActions } = store( NAMESPACE );
+
+store( NAMESPACE, {
+    state: {
+        // Register your validator so the form can use it
+        validators: {
+            color: ( value, isRequired ) => {
+                if ( isRequired && ! value ) {
+                    return 'is_required';
+                }
+                if ( value && ! /^#[0-9A-Fa-f]{6}$/i.test( value ) ) {
+                    return 'invalid_color';
+                }
+                return 'yes';
+            },
+        },
+
+        // Custom state getters for your field
+        get getColorValue() {
+            const context = getContext();
+            return context.fieldValue || '';
+        },
+
+        get hasColorValue() {
+            const context = getContext();
+            return !! context.fieldValue;
+        },
+    },
+
+    actions: {
+        // Handle value changes - update both local state and form registry
+        onColorChange( event ) {
+            const context = getContext();
+            const value = event.target.value;
+
+            // Update local fieldValue for UI reactivity
+            context.fieldValue = value;
+
+            // Update form's field registry for validation
+            if ( formActions.updateField ) {
+                formActions.updateField( context.fieldId, value );
+            }
+        },
+
+        // Handle blur to show validation errors
+        onColorBlur( event ) {
+            const context = getContext();
+            const value = event.target.value;
+
+            // Pass true to show field errors
+            if ( formActions.updateField ) {
+                formActions.updateField( context.fieldId, value, true );
+            }
+        },
+    },
+} );
+```
+
+### Webpack Configuration for View Scripts
+
+View scripts must be built as ES modules:
+
+```javascript
+// webpack.config.js
+const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
+const path = require( 'path' );
+
+// Editor script (standard)
+const editorConfig = {
+    ...defaultConfig,
+    entry: { index: './src/index.js' },
+    output: {
+        ...defaultConfig.output,
+        path: path.resolve( __dirname, 'build' ),
+    },
+};
+
+// View script (ES module for Interactivity API)
+const viewConfig = {
+    mode: defaultConfig.mode,
+    entry: { view: './src/view.js' },
+    output: {
+        path: path.resolve( __dirname, 'build' ),
+        filename: '[name].js',
+        module: true,
+        chunkFormat: 'module',
+        library: { type: 'module' },
+    },
+    experiments: { outputModule: true },
+    externalsType: 'module',
+    externals: {
+        '@wordpress/interactivity': '@wordpress/interactivity',
+    },
+    module: {
+        rules: [
+            {
+                test: /\.js$/,
+                exclude: /node_modules/,
+                use: {
+                    loader: 'babel-loader',
+                    options: {
+                        presets: [ '@babel/preset-env' ],
+                    },
+                },
+            },
+        ],
+    },
+};
+
+module.exports = [ editorConfig, viewConfig ];
+```
+
+### Using Interactivity Directives in PHP
+
+In your `render_field` callback, use Interactivity API directives:
+
+```php
+'render_field' => function( $data ) {
+    return sprintf(
+        '<div class="grunion-field-wrap" %s>
+            %s
+            <input
+                type="color"
+                id="%s"
+                name="%s"
+                value="%s"
+                data-type="color"
+                data-wp-bind--value="state.getColorValue"
+                data-wp-on--input="actions.onColorChange"
+                data-wp-on--change="actions.onColorBlur"
+            />
+            %s
+        </div>',
+        $data['wrapper_attrs'], // Contains interactivity context
+        $data['label_html'],
+        esc_attr( $data['id'] ),
+        esc_attr( $data['id'] ),
+        esc_attr( $data['value'] ?? '' ),
+        $data['error_html']
+    );
+},
+```
+
+The `wrapper_attrs` includes:
+- `data-wp-interactive="jetpack/form"`
+- `data-wp-context` with field data (fieldId, fieldValue, fieldType, fieldIsRequired, etc.)
+- `data-wp-init="callbacks.initializeField"` to register the field
+- `data-wp-on--jetpack-form-reset="callbacks.initializeField"` for form reset handling
 
 ## Dashboard Integration
 
 The Jetpack Forms dashboard uses React to display form responses. Custom fields can provide custom rendering using WordPress hooks.
 
-### Available Hooks
-
-#### jetpack.forms.dashboard.fieldValue
-
-Customize how field values are displayed in the response viewer.
+### Dashboard Script
 
 ```javascript
-wp.hooks.addFilter(
-    'jetpack.forms.dashboard.fieldValue',
-    'my-plugin/field-value',
-    function( element, fieldType, value, field ) {
-        if ( fieldType !== 'color' ) {
-            return element;
+// src/dashboard.js
+( function() {
+    const { addFilter } = wp.hooks;
+    const { createElement: el } = wp.element;
+
+    // Custom field value rendering
+    addFilter(
+        'jetpack.forms.dashboard.fieldValue',
+        'my-plugin/color-field-value',
+        function( element, fieldType, value ) {
+            if ( fieldType !== 'color' ) {
+                return element;
+            }
+
+            if ( ! value ) {
+                return '-';
+            }
+
+            return el(
+                'span',
+                { style: { display: 'inline-flex', alignItems: 'center', gap: '8px' } },
+                el( 'span', {
+                    style: {
+                        display: 'inline-block',
+                        width: '20px',
+                        height: '20px',
+                        backgroundColor: value,
+                        border: '1px solid #ccc',
+                        borderRadius: '3px',
+                    },
+                } ),
+                el( 'span', { style: { fontFamily: 'monospace' } }, value )
+            );
         }
+    );
 
-        if ( ! value || typeof value !== 'string' ) {
-            return '-';
+    // Custom field icon
+    addFilter(
+        'jetpack.forms.dashboard.fieldIcon',
+        'my-plugin/color-field-icon',
+        function( icon, fieldType ) {
+            if ( fieldType !== 'color' ) {
+                return icon;
+            }
+
+            return el(
+                'svg',
+                { viewBox: '0 0 24 24', width: 24, height: 24 },
+                el( 'path', {
+                    d: 'M12 2C6.49 2 2 6.49 2 12s4.49 10 10 10c1.38 0 2.5-1.12 2.5-2.5 0-.61-.23-1.2-.64-1.67-.08-.1-.13-.21-.13-.33 0-.28.22-.5.5-.5H16c3.31 0 6-2.69 6-6 0-4.96-4.49-9-10-9z',
+                    fill: 'currentColor',
+                } )
+            );
         }
-
-        return wp.element.createElement(
-            'span',
-            { style: { display: 'inline-flex', alignItems: 'center', gap: '8px' } },
-            wp.element.createElement( 'span', {
-                style: {
-                    display: 'inline-block',
-                    width: '20px',
-                    height: '20px',
-                    backgroundColor: value,
-                    border: '1px solid #ccc',
-                    borderRadius: '3px',
-                },
-            } ),
-            wp.element.createElement( 'span', {
-                style: { fontFamily: 'monospace', fontSize: '13px' },
-            }, value )
-        );
-    }
-);
-```
-
-#### jetpack.forms.dashboard.fieldIcon
-
-Provide a custom icon for your field type.
-
-```javascript
-wp.hooks.addFilter(
-    'jetpack.forms.dashboard.fieldIcon',
-    'my-plugin/field-icon',
-    function( icon, fieldType ) {
-        if ( fieldType !== 'color' ) {
-            return icon;
-        }
-
-        return wp.element.createElement(
-            'svg',
-            { viewBox: '0 0 24 24', width: 24, height: 24 },
-            wp.element.createElement( 'path', {
-                d: 'M12 2C6.49 2 2 6.49 2 12s4.49 10 10 10...',
-                fill: 'currentColor',
-            } )
-        );
-    }
-);
+    );
+} )();
 ```
 
 ## Complete Example: Color Picker Field
 
-Here's a complete working plugin using the unified registration API.
+Here's the complete plugin structure for a color picker field:
 
 ### Plugin Structure
 
 ```
 jetpack-forms-color-field/
 ├── jetpack-forms-color-field.php    # Main plugin file
+├── package.json                      # Build configuration
+├── webpack.config.js                 # Webpack config for both scripts
 ├── src/
-│   ├── index.js                     # Editor block (source)
-│   └── dashboard.js                 # Dashboard integration
+│   ├── index.js                      # Editor block
+│   ├── view.js                       # Frontend interactivity
+│   └── dashboard.js                  # Dashboard integration
 └── build/
-    ├── index.js                     # Compiled editor block
-    └── index.asset.php              # Asset dependencies
+    ├── index.js                      # Compiled editor
+    ├── index.asset.php
+    ├── view.js                       # Compiled view module
+    └── view.asset.php
 ```
 
-### Main Plugin File (PHP)
+### Main Plugin File
 
 ```php
 <?php
@@ -417,57 +641,51 @@ add_action( 'init', function() {
     }
 
     register_jetpack_form_field( 'color', array(
-        // Block attributes specific to this field type
+        'supports' => array(
+            'label' => true,
+        ),
+
         'block_attributes' => array(
-            'label' => array(
-                'type'    => 'string',
-                'default' => 'Favorite Color',
-            ),
             'defaultValue' => array(
                 'type'    => 'string',
-                'default' => '#000000',
+                'default' => '',
             ),
         ),
 
-        // Validation callback
         'validate_callback' => function( $value, $label, $field ) {
             if ( empty( $value ) && $field->get_attribute( 'required' ) ) {
                 return sprintf( __( '%s is required.', 'my-plugin' ), $label );
             }
-
-            if ( empty( $value ) ) {
-                return true;
-            }
-
-            if ( ! preg_match( '/^#[0-9A-Fa-f]{6}$/', $value ) ) {
+            if ( $value && ! preg_match( '/^#[0-9A-Fa-f]{6}$/', $value ) ) {
                 return sprintf( __( '%s must be a valid hex color.', 'my-plugin' ), $label );
             }
-
             return true;
         },
 
-        // Frontend field rendering
         'render_field' => function( $data ) {
-            $id       = esc_attr( $data['id'] );
-            $label    = esc_html( $data['label'] );
-            $value    = esc_attr( $data['value'] ?? '#000000' );
-            $required = $data['required'] ? 'required aria-required="true"' : '';
-
             return sprintf(
-                '<div class="grunion-field-wrap">
-                    <label class="grunion-field-label color" for="%s">%s</label>
-                    <input type="color" id="%s" name="%s" value="%s" data-type="color" %s />
+                '<div class="grunion-field-wrap" %s>
+                    %s
+                    <input type="color" id="%s" name="%s" value="%s" data-type="color"
+                        data-wp-bind--value="state.getColorValue"
+                        data-wp-on--input="actions.onColorChange"
+                        data-wp-on--change="actions.onColorBlur"
+                    />
+                    %s
                 </div>',
-                $id, $label, $id, $id, $value, $required
+                $data['wrapper_attrs'],
+                $data['label_html'],
+                esc_attr( $data['id'] ),
+                esc_attr( $data['id'] ),
+                esc_attr( $data['value'] ?? '' ),
+                $data['error_html']
             );
         },
 
-        // Value rendering for different contexts
         'render_value' => function( $context, $value, $field ) {
             if ( empty( $value ) ) {
                 return '';
             }
-
             if ( $context === 'email' ) {
                 return sprintf(
                     '<span style="display:inline-block;width:16px;height:16px;background-color:%s;border:1px solid #ccc;margin-right:8px;"></span>%s',
@@ -475,60 +693,18 @@ add_action( 'init', function() {
                     esc_html( $value )
                 );
             }
-
             return $value;
         },
 
-        // Custom error messages
         'error_messages' => array(
-            'invalid_color' => __( 'Please enter a valid hex color.', 'my-plugin' ),
+            'invalid_color' => __( 'Please enter a valid hex color (e.g., #FF0000).', 'my-plugin' ),
         ),
 
-        // Scripts
-        'editor_script'    => plugin_dir_url( __FILE__ ) . 'build/index.js',
+        'editor_script' => plugin_dir_url( __FILE__ ) . 'build/index.js',
+        'view_script'   => plugin_dir_url( __FILE__ ) . 'build/view.js',
         'dashboard_script' => plugin_dir_url( __FILE__ ) . 'src/dashboard.js',
     ) );
 } );
-```
-
-### Dashboard Integration (JavaScript)
-
-```javascript
-// src/dashboard.js
-( function() {
-    'use strict';
-
-    const { addFilter } = wp.hooks;
-    const { createElement: el } = wp.element;
-
-    function ColorSwatch( { value } ) {
-        return el(
-            'span',
-            { style: { display: 'inline-flex', alignItems: 'center', gap: '8px' } },
-            el( 'span', {
-                style: {
-                    display: 'inline-block',
-                    width: '20px',
-                    height: '20px',
-                    backgroundColor: value,
-                    border: '1px solid #ccc',
-                    borderRadius: '3px',
-                },
-            } ),
-            el( 'span', { style: { fontFamily: 'monospace' } }, value )
-        );
-    }
-
-    addFilter(
-        'jetpack.forms.dashboard.fieldValue',
-        'my-plugin/field-value',
-        function( element, fieldType, value ) {
-            if ( fieldType !== 'color' ) return element;
-            if ( ! value ) return '-';
-            return el( ColorSwatch, { value } );
-        }
-    );
-} )();
 ```
 
 ## Testing Your Custom Fields
@@ -539,44 +715,50 @@ add_action( 'init', function() {
    - [ ] Field appears in block inserter under "Contact Form" category
    - [ ] Field can only be inserted within a form block
    - [ ] Field settings panel shows expected controls
+   - [ ] Name/ID control appears in Advanced panel
 
 2. **Frontend Rendering**
    - [ ] Field renders correctly on the frontend
-   - [ ] Field respects required attribute
+   - [ ] Label displays with proper styles
    - [ ] Default value is pre-filled
+   - [ ] Multiple instances work independently
 
-3. **Form Submission**
+3. **Validation**
+   - [ ] Required field shows error when empty
+   - [ ] Custom validation (e.g., format) works
+   - [ ] Error messages display correctly
+   - [ ] Server-side validation catches invalid submissions
+
+4. **Form Submission**
    - [ ] Field value is submitted correctly
-   - [ ] Server-side validation works
-   - [ ] Invalid submissions show appropriate errors
-
-4. **Response Handling**
-   - [ ] Email notifications display field value correctly
+   - [ ] Email notifications display field value
    - [ ] Dashboard response viewer shows custom rendering
    - [ ] CSV export includes field value
-   - [ ] API responses include field value
 
 ## Troubleshooting
 
 ### Common Issues
 
 **Field doesn't appear in inserter:**
-- Ensure `parent: ['jetpack/contact-form']` is set in your JavaScript block
+- Ensure `parent: ['jetpack/contact-form']` is set in JavaScript
 - Check browser console for JavaScript errors
 - Verify Jetpack Forms plugin is active
 
-**Field value not saved on submission:**
-- Ensure the input `name` attribute matches the field ID
-- Check that `data-type` attribute is set on the input
+**Validation errors not showing:**
+- Ensure `view_script` is registered
+- Check that validators are registered in `state.validators`
+- Verify `wrapper_attrs` is included in render output
+- Check that `error_html` is included in render output
 
-**Validation not working:**
-- Verify `validate_callback` returns `true` for valid, string for invalid
-- Check the field type matches in your callback
+**Multiple fields share the same value:**
+- Don't auto-generate IDs in the editor
+- Use `context.fieldValue` (field-level) not `context.fields` (form-level)
+- Delete and re-add fields after fixing ID issues
 
-**Custom rendering not showing in dashboard:**
-- Verify `dashboard_script` URL is correct
-- Check that the script uses the correct filter hook name
-- Ensure `jp-forms-dashboard` is listed in dependencies
+**View script not loading:**
+- Check that `view_script` URL is correct
+- Verify the script is built as an ES module
+- Check browser console for module loading errors
 
 ### Debug Tips
 
@@ -589,6 +771,9 @@ if ( jetpack_form_field_exists( 'color' ) ) {
 ```
 
 ```javascript
+// Debug in view script
+console.log( '[MyField] Context:', getContext() );
+
 // Debug dashboard hooks
 console.log( 'Registered filters:', wp.hooks.filters );
 ```

--- a/projects/packages/forms/src/blocks/label/index.js
+++ b/projects/packages/forms/src/blocks/label/index.js
@@ -1,8 +1,49 @@
 import { Path } from '@wordpress/components';
+import { applyFilters } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import renderMaterialIcon from '../shared/components/render-material-icon.jsx';
 import edit from './edit.js';
 import save from './save.js';
+
+/**
+ * Core parent blocks for the label block.
+ * Do not include 'jetpack/field-file' since it prevents the label from being duplicated.
+ */
+const coreParentBlocks = [
+	'jetpack/field-date',
+	'jetpack/field-email',
+	'jetpack/field-multiple-choice',
+	'jetpack/field-name',
+	'jetpack/field-number',
+	'jetpack/field-rating',
+	'jetpack/field-select',
+	'jetpack/field-single-choice',
+	'jetpack/field-telephone',
+	'jetpack/field-text',
+	'jetpack/field-textarea',
+	'jetpack/field-time',
+	'jetpack/field-image-select',
+	'jetpack/field-slider',
+];
+
+/**
+ * Filter to allow custom field blocks to be valid parents for the label block.
+ *
+ * External developers can use this filter to register their custom field block
+ * as a valid parent for the jetpack/label block.
+ *
+ * @param {string[]} parentBlocks - Array of parent block names.
+ *
+ * @example
+ * import { addFilter } from '@wordpress/hooks';
+ *
+ * addFilter(
+ *     'jetpack.forms.label.parentBlocks',
+ *     'my-plugin/color-field',
+ *     (parents) => [...parents, 'jetpack/field-color']
+ * );
+ */
+const parentBlocks = applyFilters( 'jetpack.forms.label.parentBlocks', coreParentBlocks );
 
 const name = 'label';
 const settings = {
@@ -15,22 +56,7 @@ const settings = {
 			<Path d="M12.9 6H10.9L6.90002 17H8.80002L9.90002 14H14.1L15.2 17H17.1L12.9 6ZM10.4 12.5L11.9 7.6L13.6 12.5H10.4Z" />
 		),
 	},
-	parent: [
-		'jetpack/field-date',
-		'jetpack/field-email',
-		'jetpack/field-multiple-choice',
-		'jetpack/field-name',
-		'jetpack/field-number',
-		'jetpack/field-rating',
-		'jetpack/field-select',
-		'jetpack/field-single-choice',
-		'jetpack/field-telephone',
-		'jetpack/field-text',
-		'jetpack/field-textarea',
-		'jetpack/field-time',
-		'jetpack/field-image-select',
-		// Do not include 'jetpack/field-file' since it prevents the label from being duplicated.
-	],
+	parent: parentBlocks,
 	supports: {
 		reusable: false,
 		html: false,

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -751,6 +751,24 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			}
 		}
 
+		// Build interactivity context for custom fields.
+		$interactivity_context = array(
+			'fieldId'           => $field_id,
+			'fieldType'         => $field_type,
+			'fieldLabel'        => $field_label,
+			'fieldValue'        => $field_value,
+			'fieldPlaceholder'  => $field_placeholder,
+			'fieldIsRequired'   => $field_required,
+			'fieldErrorMessage' => '',
+			'fieldExtra'        => $this->get_field_extra( $field_type, $extra_attrs ),
+			'formHash'          => $this->form->hash,
+		);
+
+		$wrapper_attrs = sprintf(
+			'data-wp-interactive="jetpack/form" %s data-wp-init="callbacks.initializeField" data-wp-on--jetpack-form-reset="callbacks.initializeField"',
+			wp_interactivity_data_wp_context( $interactivity_context )
+		);
+
 		/**
 		 * Filter to allow custom rendering for form fields.
 		 *
@@ -761,21 +779,22 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		 *
 		 * @param string|null        $custom_render    The custom HTML to render, or null for default.
 		 * @param string             $field_type       The type of the field.
-		 * @param array              $field_data       Array containing field data (id, label, value, required, placeholder, field instance).
+		 * @param array              $field_data       Array containing field data (id, label, value, required, placeholder, field instance, wrapper_attrs).
 		 */
 		$custom_render = apply_filters(
 			'jetpack_forms_render_field',
 			null,
 			$field_type,
 			array(
-				'id'          => $field_id,
-				'label'       => $field_label,
-				'value'       => $field_value,
-				'required'    => $field_required,
-				'placeholder' => $field_placeholder,
-				'class'       => $field_class,
-				'extra_attrs' => $extra_attrs,
-				'field'       => $this,
+				'id'            => $field_id,
+				'label'         => $field_label,
+				'value'         => $field_value,
+				'required'      => $field_required,
+				'placeholder'   => $field_placeholder,
+				'class'         => $field_class,
+				'extra_attrs'   => $extra_attrs,
+				'field'         => $this,
+				'wrapper_attrs' => $wrapper_attrs,
 			)
 		);
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -450,6 +450,20 @@ class Contact_Form_Plugin {
 	}
 
 	/**
+	 * Get block support classes and styles for the jetpack/label block.
+	 *
+	 * This is a public helper method for the Form_Field_Registry to use
+	 * when extracting label styles from inner blocks.
+	 *
+	 * @param array $attrs - the label block attributes.
+	 *
+	 * @return array Array with 'class' and 'style' keys.
+	 */
+	public static function get_label_block_support_classes_and_styles( $attrs ) {
+		return self::get_block_support_classes_and_styles( 'jetpack/label', $attrs );
+	}
+
+	/**
 	 * Generate block support CSS classes and inline styles for block supports
 	 * via the style engine.
 	 *

--- a/projects/packages/forms/src/contact-form/class-form-field-registry.php
+++ b/projects/packages/forms/src/contact-form/class-form-field-registry.php
@@ -309,6 +309,24 @@ class Form_Field_Registry {
 			unset( $atts['className'] );
 		}
 
+		// Extract attributes from inner blocks (label, input, etc.).
+		if ( $block && ! empty( $block->parsed_block['innerBlocks'] ) ) {
+			foreach ( $block->parsed_block['innerBlocks'] as $inner_block ) {
+				$block_name = $inner_block['blockName'] ?? '';
+
+				// Extract label from jetpack/label inner block.
+				if ( 'jetpack/label' === $block_name ) {
+					$atts['label']        = $inner_block['attrs']['label'] ?? $inner_block['attrs']['defaultLabel'] ?? '';
+					$atts['requiredText'] = $inner_block['attrs']['requiredText'] ?? null;
+
+					// Check if required indicator should be shown.
+					if ( isset( $inner_block['attrs']['requiredIndicator'] ) ) {
+						$atts['requiredIndicator'] = $inner_block['attrs']['requiredIndicator'];
+					}
+				}
+			}
+		}
+
 		// Call the forms system to parse and render the field.
 		return Contact_Form::parse_contact_field( $atts, $content, $block );
 	}

--- a/projects/packages/forms/src/contact-form/class-form-field-registry.php
+++ b/projects/packages/forms/src/contact-form/class-form-field-registry.php
@@ -51,12 +51,24 @@ class Form_Field_Registry {
 	 *
 	 *     @type string   $block_name           Block name. Defaults to 'jetpack/field-{$field_type}'.
 	 *     @type array    $block_attributes     Block attributes definition.
+	 *     @type array    $supports             Feature support flags. {
+	 *         @type bool $label                Enable label support with automatic syncing. Default false.
+	 *                                          When true, automatically:
+	 *                                          - Adds jetpack/label as valid inner block
+	 *                                          - Sets up context for label syncing
+	 *                                          - Handles label rendering with styles on frontend
+	 *     }
 	 *     @type callable $render_callback      Block render callback. Receives ($atts, $content, $block).
 	 *                                          If not provided, uses default that calls Contact_Form::parse_contact_field().
 	 *     @type callable $validate_callback    Validation callback. Receives ($value, $label, $field).
 	 *                                          Return true for valid, string error message for invalid.
 	 *     @type callable $render_field         Frontend field render callback. Receives ($data).
 	 *                                          Return HTML string or null for default rendering.
+	 *                                          $data always includes 'wrapper_attrs' with interactivity attributes
+	 *                                          that should be added to the field's wrapper div for validation errors.
+	 *                                          $data includes 'error_html' with pre-rendered error message container.
+	 *                                          When supports.label is true, $data includes 'label_html' with
+	 *                                          pre-rendered label markup including styles.
 	 *     @type callable $render_value         Value render callback. Receives ($context, $value, $field).
 	 *                                          Context is 'email', 'web', 'ajax', 'csv', 'api'.
 	 *                                          Return rendered value or null for default.
@@ -67,6 +79,9 @@ class Form_Field_Registry {
 	 *     @type string   $dashboard_script     URL to the dashboard script.
 	 *     @type array    $dashboard_script_deps Dashboard script dependencies.
 	 *     @type string   $dashboard_script_ver Dashboard script version.
+	 *     @type string   $view_script          URL to the frontend view script (ES module for Interactivity API).
+	 *     @type array    $view_script_deps     View script module dependencies.
+	 *     @type string   $view_script_ver      View script version.
 	 * }
 	 * @return bool True on success, false on failure.
 	 */
@@ -99,6 +114,7 @@ class Form_Field_Registry {
 		$defaults = array(
 			'block_name'            => 'jetpack/field-' . $field_type,
 			'block_attributes'      => array(),
+			'supports'              => array(),
 			'render_callback'       => null,
 			'validate_callback'     => null,
 			'render_field'          => null,
@@ -110,9 +126,18 @@ class Form_Field_Registry {
 			'dashboard_script'      => '',
 			'dashboard_script_deps' => array( 'wp-hooks', 'wp-element', 'jp-forms-dashboard' ),
 			'dashboard_script_ver'  => '1.0.0',
+			'view_script'           => '',
+			'view_script_deps'      => array( '@wordpress/interactivity', 'jp-forms-view' ),
+			'view_script_ver'       => '1.0.0',
 		);
 
 		$args = wp_parse_args( $args, $defaults );
+
+		// Parse supports with defaults.
+		$supports_defaults = array(
+			'label' => false,
+		);
+		$args['supports']  = wp_parse_args( $args['supports'], $supports_defaults );
 
 		// Store the field configuration.
 		self::$registered_fields[ $field_type ] = $args;
@@ -203,6 +228,24 @@ class Form_Field_Registry {
 
 		// Dashboard scripts.
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_dashboard_assets' ), 20 );
+
+		// Add label parent blocks filter for fields with label support.
+		add_filter( 'jetpack.forms.label.parentBlocks', array( __CLASS__, 'filter_label_parent_blocks' ) );
+	}
+
+	/**
+	 * Filter: Add custom field blocks as valid parents for the label block.
+	 *
+	 * @param array $parents Existing parent blocks.
+	 * @return array Modified parent blocks.
+	 */
+	public static function filter_label_parent_blocks( $parents ) {
+		foreach ( self::$registered_fields as $args ) {
+			if ( ! empty( $args['supports']['label'] ) ) {
+				$parents[] = $args['block_name'];
+			}
+		}
+		return $parents;
 	}
 
 	/**
@@ -271,16 +314,37 @@ class Form_Field_Registry {
 			),
 		);
 
+		// Add label support attributes if enabled.
+		if ( ! empty( $args['supports']['label'] ) ) {
+			$default_attributes['shareFieldAttributes'] = array(
+				'type'    => 'boolean',
+				'default' => true,
+			);
+		}
+
 		$block_attributes = array_merge( $default_attributes, $args['block_attributes'] );
 
-		register_block_type(
-			$block_name,
-			array(
-				'api_version'     => 3,
-				'render_callback' => $render_callback,
-				'attributes'      => $block_attributes,
-			)
+		// Build block registration args.
+		$block_args = array(
+			'api_version'     => 3,
+			'render_callback' => $render_callback,
+			'attributes'      => $block_attributes,
 		);
+
+		// Add label support configuration.
+		if ( ! empty( $args['supports']['label'] ) ) {
+			$block_args['provides_context'] = array(
+				'jetpack/field-required'         => 'required',
+				'jetpack/field-share-attributes' => 'shareFieldAttributes',
+			);
+			$block_args['supports']         = array(
+				'reusable'                               => false,
+				'html'                                   => false,
+				'__experimentalExposeControlsToChildren' => true,
+			);
+		}
+
+		register_block_type( $block_name, $block_args );
 	}
 
 	/**
@@ -322,6 +386,16 @@ class Form_Field_Registry {
 					// Check if required indicator should be shown.
 					if ( isset( $inner_block['attrs']['requiredIndicator'] ) ) {
 						$atts['requiredIndicator'] = $inner_block['attrs']['requiredIndicator'];
+					}
+
+					// Extract label style attributes using WordPress block support functions.
+					$label_attrs          = Contact_Form_Plugin::get_label_block_support_classes_and_styles( $inner_block['attrs'] );
+					$atts['labelclasses'] = 'wp-block-jetpack-label';
+					if ( ! empty( $label_attrs['class'] ) ) {
+						$atts['labelclasses'] .= ' ' . $label_attrs['class'];
+					}
+					if ( ! empty( $label_attrs['style'] ) ) {
+						$atts['labelstyles'] = $label_attrs['style'];
 					}
 				}
 			}
@@ -385,11 +459,112 @@ class Form_Field_Registry {
 
 		$args = self::$registered_fields[ $type ];
 
+		// Enqueue the view script if provided (ES module for Interactivity API).
+		if ( ! empty( $args['view_script'] ) ) {
+			wp_enqueue_script_module(
+				'jetpack-forms-field-' . $type . '-view',
+				$args['view_script'],
+				$args['view_script_deps'],
+				$args['view_script_ver']
+			);
+		}
+
+		// Add error state first (needed for label rendering).
+		if ( isset( $data['field'] ) ) {
+			$data['is_error']   = $data['field']->is_error();
+			$data['error_html'] = self::render_error_html( $data, $type );
+		}
+
+		// If label support is enabled, add pre-rendered label HTML to data.
+		if ( ! empty( $args['supports']['label'] ) && isset( $data['field'] ) ) {
+			$data['label_html'] = self::render_label_html( $data );
+		}
+
 		if ( ! is_callable( $args['render_field'] ) ) {
 			return $html;
 		}
 
 		return call_user_func( $args['render_field'], $data );
+	}
+
+	/**
+	 * Render error HTML for validation errors.
+	 *
+	 * This generates the error message container that displays validation errors.
+	 * Uses the WordPress Interactivity API for dynamic error state.
+	 *
+	 * @param array  $data       Field data including 'field' instance.
+	 * @param string $field_type The field type.
+	 * @return string Rendered error HTML.
+	 */
+	private static function render_error_html( $data, $field_type ) {
+		$id = esc_attr( $data['id'] );
+
+		return '
+			<div id="' . $id . '-' . esc_attr( $field_type ) . '-error" class="contact-form__input-error" data-wp-class--has-errors="state.fieldHasErrors">
+				<span class="contact-form__warning-icon" aria-hidden="true">
+					<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+						<path d="M8.50015 11.6402H7.50015V10.6402H8.50015V11.6402Z" />
+						<path d="M7.50015 9.64018H8.50015V6.30684H7.50015V9.64018Z" />
+						<path fill-rule="evenodd" clip-rule="evenodd" d="M6.98331 3.0947C7.42933 2.30177 8.57096 2.30177 9.01698 3.09469L13.8771 11.7349C14.3145 12.5126 13.7525 13.4735 12.8602 13.4735H3.14004C2.24774 13.4735 1.68575 12.5126 2.12321 11.7349L6.98331 3.0947ZM8.14541 3.58496C8.08169 3.47168 7.9186 3.47168 7.85488 3.58496L2.99478 12.2251C2.93229 12.3362 3.01257 12.4735 3.14004 12.4735H12.8602C12.9877 12.4735 13.068 12.3362 13.0055 12.2251L8.14541 3.58496Z" />
+					</svg>
+				</span>
+				<span data-wp-text="state.errorMessage" id="' . $id . '-' . esc_attr( $field_type ) . '-error-message"></span>
+			</div>';
+	}
+
+	/**
+	 * Render label HTML with proper classes and styles.
+	 *
+	 * This generates the label HTML including all styling from the inner jetpack/label block.
+	 * Developers using supports.label can use $data['label_html'] in their render_field callback.
+	 *
+	 * @param array $data Field data including 'field' instance.
+	 * @return string Rendered label HTML.
+	 */
+	private static function render_label_html( $data ) {
+		$field_instance = $data['field'];
+		$label          = esc_html( $data['label'] );
+		$id             = esc_attr( $data['id'] );
+		$required       = $data['required'];
+		$is_error       = ! empty( $data['is_error'] );
+
+		// Build label classes.
+		$label_classes = 'grunion-field-label';
+		if ( $is_error ) {
+			$label_classes .= ' form-error';
+		}
+		if ( ! empty( $field_instance->label_classes ) ) {
+			$label_classes .= ' ' . esc_attr( $field_instance->label_classes );
+		}
+
+		// Build label styles.
+		$label_style_attr = '';
+		if ( ! empty( $field_instance->label_styles ) ) {
+			$label_style_attr = ' style="' . esc_attr( $field_instance->label_styles ) . '"';
+		}
+
+		// Build required indicator.
+		$required_markup = '';
+		if ( $required ) {
+			$required_text = $field_instance->get_attribute( 'requiredtext' );
+			if ( empty( $required_text ) ) {
+				$required_text = __( '(required)', 'jetpack-forms' );
+			}
+			$show_required_text = $field_instance->get_attribute( 'requiredindicator' );
+			if ( $show_required_text ) {
+				$required_markup = '<span class="required">' . esc_html( $required_text ) . '</span>';
+			}
+		}
+
+		return sprintf(
+			'<label class="%s" for="%s"%s>%s%s</label>',
+			esc_attr( $label_classes ),
+			$id,
+			$label_style_attr,
+			$label,
+			$required_markup
+		);
 	}
 
 	/**
@@ -440,7 +615,19 @@ class Form_Field_Registry {
 			return;
 		}
 
+		// Collect blocks with label support and all custom field blocks.
+		$label_support_blocks = array();
+		$custom_field_blocks  = array();
+
 		foreach ( self::$registered_fields as $field_type => $args ) {
+			// Track all custom field blocks for ID control injection.
+			$custom_field_blocks[] = $args['block_name'];
+
+			// Track blocks with label support.
+			if ( ! empty( $args['supports']['label'] ) ) {
+				$label_support_blocks[] = $args['block_name'];
+			}
+
 			if ( empty( $args['editor_script'] ) ) {
 				continue;
 			}
@@ -455,6 +642,135 @@ class Form_Field_Registry {
 				true
 			);
 		}
+
+		// Add inline script to register label parent blocks filter.
+		if ( ! empty( $label_support_blocks ) ) {
+			self::enqueue_label_support_script( $label_support_blocks );
+		}
+
+		// Add inline script to inject ID control for custom field blocks.
+		if ( ! empty( $custom_field_blocks ) ) {
+			self::enqueue_field_id_control_script( $custom_field_blocks );
+		}
+	}
+
+	/**
+	 * Enqueue inline script to add label parent blocks filter.
+	 *
+	 * @param array $block_names Array of block names with label support.
+	 */
+	private static function enqueue_label_support_script( $block_names ) {
+		// We need to add this filter before the label block is registered.
+		// Use wp-hooks as dependency since we need addFilter.
+		$script = sprintf(
+			'(function() {
+				var blocks = %s;
+				if (window.wp && window.wp.hooks && window.wp.hooks.addFilter) {
+					window.wp.hooks.addFilter(
+						"jetpack.forms.label.parentBlocks",
+						"jetpack-forms-field-registry/label-parents",
+						function(parents) {
+							return parents.concat(blocks);
+						}
+					);
+				}
+			})();',
+			wp_json_encode( $block_names, JSON_UNESCAPED_SLASHES )
+		);
+
+		wp_add_inline_script( 'wp-hooks', $script, 'after' );
+	}
+
+	/**
+	 * Enqueue inline script to add ID control to custom field blocks.
+	 *
+	 * This automatically injects the Name/ID field in the Advanced panel
+	 * for all custom form fields registered via register_jetpack_form_field().
+	 *
+	 * @param array $block_names Array of block names to add ID control to.
+	 */
+	private static function enqueue_field_id_control_script( $block_names ) {
+		$script = sprintf(
+			'(function() {
+				var customFieldBlocks = %s;
+				var reservedAttributes = ["accept","action","autocomplete","enctype","method","name","novalidate","target","type","value"];
+				var wp = window.wp;
+
+				if (!wp || !wp.hooks || !wp.element || !wp.blockEditor || !wp.components || !wp.i18n) {
+					return;
+				}
+
+				var addFilter = wp.hooks.addFilter;
+				var createElement = wp.element.createElement;
+				var Fragment = wp.element.Fragment;
+				var useState = wp.element.useState;
+				var useCallback = wp.element.useCallback;
+				var InspectorAdvancedControls = wp.blockEditor.InspectorAdvancedControls;
+				var TextControl = wp.components.TextControl;
+				var __ = wp.i18n.__;
+
+				// Higher Order Component to add ID control
+				var withFieldIdControl = function(BlockEdit) {
+					return function(props) {
+						if (customFieldBlocks.indexOf(props.name) === -1) {
+							return createElement(BlockEdit, props);
+						}
+
+						var id = props.attributes.id || "";
+						var setAttributes = props.setAttributes;
+
+						var errorState = useState("");
+						var idError = errorState[0];
+						var setIdError = errorState[1];
+
+						var setId = useCallback(function(value) {
+							var newValue = value.replace(/[^a-zA-Z0-9_-]/g, "");
+
+							// Check for reserved attribute names
+							var isReserved = reservedAttributes.some(function(attr) {
+								return attr.toLowerCase() === newValue.toLowerCase();
+							});
+
+							if (isReserved) {
+								setIdError(__("This is a reserved word. Please use a different name.", "jetpack-forms"));
+								return;
+							}
+
+							setIdError("");
+							setAttributes({ id: newValue });
+						}, [setAttributes]);
+
+						return createElement(
+							Fragment,
+							null,
+							createElement(BlockEdit, props),
+							createElement(
+								InspectorAdvancedControls,
+								null,
+								createElement(TextControl, {
+									label: __("Name/ID", "jetpack-forms"),
+									value: id,
+									onChange: setId,
+									help: idError || __("Customize the input\'s name/ID. Only alphanumeric, dash and underscore characters are allowed", "jetpack-forms"),
+									className: idError ? "jetpack-forms-field-controls__input-error" : "",
+									__nextHasNoMarginBottom: true,
+									__next40pxDefaultSize: true
+								})
+							)
+						);
+					};
+				};
+
+				addFilter(
+					"editor.BlockEdit",
+					"jetpack-forms-field-registry/field-id-control",
+					withFieldIdControl
+				);
+			})();',
+			wp_json_encode( $block_names, JSON_UNESCAPED_SLASHES )
+		);
+
+		wp_add_inline_script( 'wp-hooks', $script, 'after' );
 	}
 
 	/**

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/index.tsx
@@ -8,6 +8,7 @@ import {
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
+import { applyFilters } from '@wordpress/hooks';
 import { Badge } from '@wordpress/ui';
 /**
  * Internal dependencies
@@ -23,7 +24,24 @@ import type { ResponseField, FieldType, FileItem } from '../../../../../types/in
 import './style.scss';
 
 const getFieldIcon = ( fieldType: FieldType ): React.ReactNode => {
-	return <Icon icon={ fieldIcons[ fieldType ] ?? fieldIcons.text } />;
+	/**
+	 * Filter to allow custom field icons.
+	 *
+	 * @param {JSX.Element|null} icon      - The icon element, or null for default.
+	 * @param {string}           fieldType - The field type.
+	 * @return {JSX.Element|null} The icon element or null.
+	 */
+	const customIcon = applyFilters(
+		'jetpack.forms.dashboard.fieldIcon',
+		null,
+		fieldType
+	) as JSX.Element | null;
+
+	if ( customIcon ) {
+		return customIcon;
+	}
+
+	return <Icon icon={ fieldIcons[ fieldType as keyof typeof fieldIcons ] ?? fieldIcons.text } />;
 };
 
 const BADGED_VALUE_FIELDS: FieldType[] = [ 'consent', 'checkbox', 'radio', 'select' ];
@@ -42,6 +60,31 @@ const FieldPreview = ( { field, onFilePreview }: FieldPreviewProps ) => {
 	const typeClassName = `is-field-type-${ fieldType }`;
 
 	const renderFieldValue = () => {
+		/**
+		 * Filter to allow custom field value rendering.
+		 *
+		 * External plugins can use this filter to provide custom rendering
+		 * for their field types. Return a React element to override the default rendering,
+		 * or null/undefined to use the default.
+		 *
+		 * @param {React.ReactNode|null} element   - The custom element, or null for default.
+		 * @param {string}               fieldType - The field type.
+		 * @param {unknown}              value     - The field value.
+		 * @param {ResponseField}        field     - The full field object.
+		 * @return {React.ReactNode|null} The custom element or null.
+		 */
+		const customRender = applyFilters(
+			'jetpack.forms.dashboard.fieldValue',
+			null,
+			fieldType,
+			value,
+			field
+		) as React.ReactNode | null;
+
+		if ( customRender !== null && customRender !== undefined ) {
+			return customRender;
+		}
+
 		// Image select fields
 		if ( fieldType === 'image-select' ) {
 			const choices = ( value as { choices?: unknown[] } )?.choices;


### PR DESCRIPTION
Fixes #

## Proposed changes

This PR adds label block support, dashboard extensibility hooks, and Interactivity API integration to the custom form fields system.

* Add `supports.label` flag to field registry, enabling `jetpack/label` as an inner block for custom fields with pre-rendered `label_html` and `error_html` in render data
* Add `jetpack.forms.label.parentBlocks` JavaScript filter so custom field blocks can register as valid parents for `jetpack/label`
* Add dashboard extensibility hooks (`jetpack.forms.dashboard.fieldValue`, `jetpack.forms.dashboard.fieldIcon`) for custom field rendering in the response viewer
* Add Interactivity API context via `wrapper_attrs` in `render_field` data — provides `data-wp-interactive`, `data-wp-context`, and field initialization directives
* Enhance field registry with `view_script` / `view_script_deps` / `view_script_ver` for frontend ES module scripts and automatic Name/ID control injection
* Update `class-contact-form-field.php` to output Interactivity API wrapper attributes and label/error HTML for fields with label support
* Update `class-contact-form-plugin.php` with view script module enqueue support
* Rewrite and expand `custom-fields.md` documentation with label support examples, Interactivity API usage, view script webpack config, and updated complete example

### Other information

This is **PR 3 of 5** in a stacked PR series for the Forms custom fields extensibility API. It builds on the JS/Editor API from PR 2.

**Full stack:**
- PR 1: #47931 — PHP foundation (field registry, validation, rendering)
- PR 2: #47932 — JS/Editor API (block registration, editor scripts)
- **PR 3: #47933 (this PR)** — Label block, dashboard hooks, Interactivity API
- PR 4: #47930 — Asset pipeline & styles
- PR 5: #47929 — Documentation & changelog

- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links

* Part of the Jetpack Forms custom field extensibility initiative

## Does this pull request change what data or activity we track or use?

No changes to tracked data or activity.

## Testing instructions

1. **Label block support**
   - Register a custom field with `'supports' => array( 'label' => true )` in PHP
   - In the editor, insert the custom field block inside a form — verify `jetpack/label` appears as an inner block
   - On the frontend, verify the label renders with proper HTML and required indicator

2. **Dashboard hooks**
   - Register `jetpack.forms.dashboard.fieldValue` and `jetpack.forms.dashboard.fieldIcon` filters via a dashboard script
   - Submit a form with the custom field, then view the response in the Jetpack Forms dashboard
   - Verify the custom icon and value rendering appear correctly

3. **Interactivity API context**
   - Register a custom field with a `view_script` and `render_field` callback that uses `$data['wrapper_attrs']`
   - On the frontend, inspect the field wrapper div — verify it contains `data-wp-interactive="jetpack/form"` and `data-wp-context` with field data
   - Verify frontend validation works via the Interactivity API store

4. **Label parentBlocks filter**
   - Use `addFilter('jetpack.forms.label.parentBlocks', ...)` in an editor script to add a custom block name
   - Verify `jetpack/label` can be inserted inside that custom block in the editor

5. **Name/ID control**
   - Insert a custom field in the editor and open the Advanced panel
   - Verify the Name/ID control is present and defaults to auto-generated from label
   - Set a custom ID and verify it persists on save