### PR TITLE
RTC: Bump WebSocket gradual rollout to 20% on Simple sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-16603-rtc-bump-ws-rollout-20-percent
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-16603-rtc-bump-ws-rollout-20-percent
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+RTC: Bump WebSocket gradual rollout to 20% on Simple sites

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
@@ -47,7 +47,7 @@ function wpcom_is_rtc_websocket_rollout() {
 
 	if (
 		defined( 'IS_WPCOM' ) && IS_WPCOM &&
-		( $blog_id % 100 < 5 )
+		( $blog_id % 100 < 20 )
 	) {
 		return true;
 	}


### PR DESCRIPTION
Fixes DOTCOM-16603

## Proposed changes
* Increase the RTC WebSocket rollout threshold from 5% to 20% of Simple sites (`$blog_id % 100 < 20`).

### Other information

## Related product discussion/links
N/A

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Verify that `wpcom_is_rtc_websocket_rollout()` returns `true` for blog IDs where `$blog_id % 100 < 20` on Simple sites (`IS_WPCOM`).
* Verify it still returns `false` for blog IDs where `$blog_id % 100 >= 20`.