### PR TITLE
CLI: Add --password flag to jetpack rsync and Jurassic Ninja testing skill

### DIFF
--- a/.claude/skills/jetpack-test-jurassic-ninja/SKILL.md
+++ b/.claude/skills/jetpack-test-jurassic-ninja/SKILL.md
@@ -85,8 +85,10 @@ If the build fails, stop and report the error to the user — do not proceed to 
 
 ### 4. Run the rsync
 
+Derive the SSH host from the site's `ssh_command` field (e.g. `ssh foo.jurassic.ninja@sftp.wp.com` → host is `sftp.wp.com`). Do not hardcode the SSH host — it may change.
+
 ```bash
-jetpack rsync {plugin} {domain}@ssh.atomicsites.net:/srv/htdocs/wp-content/plugins/{plugin-slug} --non-interactive --password='{JN_PASSWORD}'
+jetpack rsync {plugin} {domain}@{ssh_host}:/srv/htdocs/wp-content/plugins/{plugin-slug} --non-interactive --password='{JN_PASSWORD}'
 ```
 
 The `--password` flag passes the SSH password automatically via `SSH_ASKPASS`.

--- a/.claude/skills/jetpack-test-jurassic-ninja/SKILL.md
+++ b/.claude/skills/jetpack-test-jurassic-ninja/SKILL.md
@@ -36,7 +36,7 @@ If missing: tell user to run `pnpm install` in the monorepo root, or `pnpm jetpa
 ### Check 3: Dependencies installed
 
 ```bash
-test -d node_modules && echo "pnpm deps OK" || echo "MISSING"
+test -d "$(git rev-parse --show-toplevel)/node_modules" && echo "pnpm deps OK" || echo "MISSING"
 ```
 
 If missing: run `jetpack install -r` to install pnpm and composer dependencies.
@@ -80,6 +80,8 @@ jetpack build plugins/{plugin}
 ```
 
 Required — without it the remote site gets broken symlinks and fatal errors like `Class not found`.
+
+If the build fails, stop and report the error to the user — do not proceed to rsync.
 
 ### 4. Run the rsync
 

--- a/.claude/skills/jetpack-test-jurassic-ninja/SKILL.md
+++ b/.claude/skills/jetpack-test-jurassic-ninja/SKILL.md
@@ -19,24 +19,24 @@ Run these checks in order. Stop at the first failure and help the user fix it.
 ### Check 1: rsync installed
 
 ```bash
-which rsync && rsync --version | head -1
+rsync --version
 ```
 
-- If missing: tell user to `brew install rsync`
+- If the command fails: tell user to `brew install rsync`
 - If output contains `openrsync` on macOS: warn that `brew install rsync` is recommended for proper symlink handling
 
 ### Check 2: jetpack CLI available
 
 ```bash
-which jetpack
+pnpm jetpack --help
 ```
 
-If missing: tell user to run `pnpm install` in the monorepo root, or `pnpm jetpack` to verify.
+If missing: tell user to run `pnpm install` in the monorepo root.
 
 ### Check 3: Dependencies installed
 
 ```bash
-test -d "$(git rev-parse --show-toplevel)/node_modules" && echo "pnpm deps OK" || echo "MISSING"
+ls node_modules/.package-lock.json
 ```
 
 If missing: run `jetpack install -r` to install pnpm and composer dependencies.

--- a/.claude/skills/jetpack-test-jurassic-ninja/SKILL.md
+++ b/.claude/skills/jetpack-test-jurassic-ninja/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: jetpack-test-jurassic-ninja
+description: >
+  Rsync a Jetpack monorepo plugin to a Jurassic Ninja test site for live testing.
+  Use when the user wants to push/deploy/sync/test code on a Jurassic Ninja site,
+  mentions "jurassic ninja", "JN site", "test live", "rsync to JN", or says
+  "/jetpack-test-jurassic-ninja". Handles site discovery, password retrieval, and
+  the jetpack rsync command automatically with no user interaction needed.
+---
+
+# Jetpack Test on Jurassic Ninja
+
+Push a plugin from the Jetpack monorepo to a Jurassic Ninja ephemeral site. Fully automated — no user interaction required after pre-flight checks pass.
+
+## Pre-flight Checks (run all before starting)
+
+Run these checks in order. Stop at the first failure and help the user fix it.
+
+### Check 1: rsync installed
+
+```bash
+which rsync && rsync --version | head -1
+```
+
+- If missing: tell user to `brew install rsync`
+- If output contains `openrsync` on macOS: warn that `brew install rsync` is recommended for proper symlink handling
+
+### Check 2: jetpack CLI available
+
+```bash
+which jetpack
+```
+
+If missing: tell user to run `pnpm install` in the monorepo root, or `pnpm jetpack` to verify.
+
+### Check 3: Dependencies installed
+
+```bash
+test -d node_modules && echo "pnpm deps OK" || echo "MISSING"
+```
+
+If missing: run `jetpack install -r` to install pnpm and composer dependencies.
+
+### Check 4: Jurassic Ninja MCP provider
+
+Try to load the `jurassic-ninja` MCP provider:
+
+```
+load-provider: jurassic-ninja
+```
+
+If it fails, tell the user:
+
+> The `context-a8c` MCP server is not configured. Visit **mc.a8c.com/ai/context-a8c** to set it up, then restart Claude Code.
+
+### Check 5: User has Jurassic Ninja sites
+
+```
+execute-tool: jurassic-ninja / list-sites (include_passwords: true)
+```
+
+If the sites list is empty, tell the user:
+
+> You don't have any Jurassic Ninja sites. Create one at **https://jurassic.ninja/create**, wait for it to be ready, then try again.
+
+## Workflow
+
+### 1. Determine which plugin to sync
+
+Default: `jetpack`. Use a different plugin only if the user specifies one.
+
+### 2. Pick the target site
+
+Use the **first** site from the list (most recently created) unless the user specifies a different one.
+
+### 3. Build the plugin
+
+```bash
+jetpack build plugins/{plugin}
+```
+
+Required — without it the remote site gets broken symlinks and fatal errors like `Class not found`.
+
+### 4. Run the rsync
+
+```bash
+jetpack rsync {plugin} {domain}@ssh.atomicsites.net:/srv/htdocs/wp-content/plugins/{plugin-slug} --non-interactive --password='{JN_PASSWORD}'
+```
+
+The `--password` flag passes the SSH password automatically via `SSH_ASKPASS`.
+
+### 5. Report results
+
+After sync completes, show:
+- The admin login URL: `https://{domain}/?auto_login`
+- Reminder: set `define('JETPACK_AUTOLOAD_DEV', true);` in a mu-plugin on the remote site

--- a/.claude/skills/jetpack-test-jurassic-ninja/SKILL.md
+++ b/.claude/skills/jetpack-test-jurassic-ninja/SKILL.md
@@ -63,6 +63,33 @@ If the sites list is empty, tell the user:
 
 > You don't have any Jurassic Ninja sites. Create one at **https://jurassic.ninja/create**, wait for it to be ready, then try again.
 
+### Check 6: SSH access to Jurassic Ninja
+
+Test whether the user has SSH key-based access configured for the JN SFTP host:
+
+```bash
+ssh -o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=no {domain}@ssh.atomicsites.net exit 2>&1
+```
+
+Where `{domain}` is the domain of the target site (e.g. `foo.jurassic.ninja`).
+
+**If the command succeeds (exit code 0):** SSH keys are configured — skip password entirely. Set `SSH_OK=true`.
+
+**If the command fails:** SSH key auth is not configured. Tell the user:
+
+> SSH key authentication to `ssh.atomicsites.net` is not configured. You can fix this by adding the following to your `~/.ssh/config`:
+>
+> ```
+> Host ssh.atomicsites.net
+>     HostName ssh.atomicsites.net
+>     Include ~/.ssh/a8c-key.config
+>     ProxyJump proxy.automattic.com
+> ```
+>
+> For now, I'll use the site password instead.
+
+Then set `SSH_OK=false` and retrieve the password from the site data to use as a fallback.
+
 ## Workflow
 
 ### 1. Determine which plugin to sync
@@ -85,10 +112,20 @@ If the build fails, stop and report the error to the user — do not proceed to 
 
 ### 4. Run the rsync
 
-Derive the SSH host from the site's `ssh_command` field (e.g. `ssh foo.jurassic.ninja@sftp.wp.com` → host is `sftp.wp.com`). Do not hardcode the SSH host — it may change.
+The SSH host is always `ssh.atomicsites.net`.
+
+**If SSH_OK is true** (key-based auth works):
 
 ```bash
-jetpack rsync {plugin} {domain}@{ssh_host}:/srv/htdocs/wp-content/plugins/{plugin-slug} --non-interactive --password='{JN_PASSWORD}'
+jetpack rsync {plugin} {domain}@ssh.atomicsites.net:/srv/htdocs/wp-content/plugins/{plugin-slug} --non-interactive
+```
+
+No `--password` flag needed — SSH keys handle authentication.
+
+**If SSH_OK is false** (falling back to password):
+
+```bash
+jetpack rsync {plugin} {domain}@ssh.atomicsites.net:/srv/htdocs/wp-content/plugins/{plugin-slug} --non-interactive --password='{JN_PASSWORD}'
 ```
 
 The `--password` flag passes the SSH password automatically via `SSH_ASKPASS`.
@@ -98,3 +135,4 @@ The `--password` flag passes the SSH password automatically via `SSH_ASKPASS`.
 After sync completes, show:
 - The admin login URL: `https://{domain}/?auto_login`
 - Reminder: set `define('JETPACK_AUTOLOAD_DEV', true);` in a mu-plugin on the remote site
+- If SSH_OK was false: remind the user to set up SSH keys for a smoother experience next time

--- a/.claude/skills/jetpack-test-jurassic-ninja/SKILL.md
+++ b/.claude/skills/jetpack-test-jurassic-ninja/SKILL.md
@@ -39,7 +39,7 @@ If missing: tell user to run `pnpm install` in the monorepo root.
 ls node_modules/.package-lock.json
 ```
 
-If missing: run `jetpack install -r` to install pnpm and composer dependencies.
+If missing: run `pnpm jetpack install -r` to install pnpm and composer dependencies.
 
 ### Check 4: Jurassic Ninja MCP provider
 
@@ -77,7 +77,7 @@ Where `{domain}` is the domain of the target site (e.g. `foo.jurassic.ninja`).
 
 **If the command fails:** SSH key auth is not configured. Tell the user:
 
-> SSH key authentication to `ssh.atomicsites.net` is not configured. You can fix this by adding the following to your `~/.ssh/config`:
+> SSH key authentication to `ssh.atomicsites.net` is not configured. If you are an Automattician, you can fix this by adding the following to your `~/.ssh/config`:
 >
 > ```
 > Host ssh.atomicsites.net
@@ -100,13 +100,26 @@ Default: `jetpack`. Use a different plugin only if the user specifies one.
 
 Use the **first** site from the list (most recently created) unless the user specifies a different one.
 
-### 3. Build the plugin
+### 3. Build the plugin (only if needed)
+
+Check whether the plugin's build output already exists. Most plugins use `build/` as the output directory, but Jetpack uses `_inc/build/`.
 
 ```bash
-jetpack build plugins/{plugin}
+# For plugins/jetpack:
+ls projects/plugins/jetpack/_inc/build/ 2>/dev/null
+# For other plugins:
+ls projects/plugins/{plugin}/build/ 2>/dev/null
 ```
 
-Required — without it the remote site gets broken symlinks and fatal errors like `Class not found`.
+**If build output exists:** Skip the build — it's already been done. Tell the user you're skipping the build since output exists.
+
+**If build output is missing:** Build the plugin. Use `--deps` to also build any monorepo dependencies the plugin needs (e.g. packages it depends on). Without `--deps`, builds can fail if dependency packages haven't been built yet.
+
+```bash
+pnpm jetpack build --deps plugins/{plugin}
+```
+
+Note: `--deps` can take a while for plugins with many dependencies (like Jetpack). If the build is slow and the user wants to iterate quickly, they can pre-build once with `--deps` and then subsequent syncs will skip the build entirely.
 
 If the build fails, stop and report the error to the user — do not proceed to rsync.
 
@@ -117,7 +130,7 @@ The SSH host is always `ssh.atomicsites.net`.
 **If SSH_OK is true** (key-based auth works):
 
 ```bash
-jetpack rsync {plugin} {domain}@ssh.atomicsites.net:/srv/htdocs/wp-content/plugins/{plugin-slug} --non-interactive
+pnpm jetpack rsync {plugin} {domain}@ssh.atomicsites.net:/srv/htdocs/wp-content/plugins/{plugin-slug} --non-interactive
 ```
 
 No `--password` flag needed — SSH keys handle authentication.
@@ -125,7 +138,7 @@ No `--password` flag needed — SSH keys handle authentication.
 **If SSH_OK is false** (falling back to password):
 
 ```bash
-jetpack rsync {plugin} {domain}@ssh.atomicsites.net:/srv/htdocs/wp-content/plugins/{plugin-slug} --non-interactive --password='{JN_PASSWORD}'
+pnpm jetpack rsync {plugin} {domain}@ssh.atomicsites.net:/srv/htdocs/wp-content/plugins/{plugin-slug} --non-interactive --password='{JN_PASSWORD}'
 ```
 
 The `--password` flag passes the SSH password automatically via `SSH_ASKPASS`.

--- a/tools/cli/commands/rsync.js
+++ b/tools/cli/commands/rsync.js
@@ -142,6 +142,8 @@ export async function rsyncInit( argv ) {
 		}
 	}
 
+	const password = argv.password || null;
+
 	if ( argv.watch ) {
 		await tracks( 'rsync_watch' );
 		let watcher;
@@ -150,7 +152,7 @@ export async function rsyncInit( argv ) {
 				console.debug( `rsync due to event ${ event } for ${ eventfile }` );
 			}
 
-			const paths = await rsyncToDest( sourcePluginPath, finalDest );
+			const paths = await rsyncToDest( sourcePluginPath, finalDest, password );
 
 			// Warn but don't fail if file was intentionally not synced. We still want to sync
 			// if a change event occurs, as other change events could have been debounced.
@@ -237,7 +239,7 @@ export async function rsyncInit( argv ) {
 		};
 		await rsyncAndUpdateWatches( 'startup', 'jetpack rsync --watch' );
 	} else {
-		await rsyncToDest( sourcePluginPath, finalDest );
+		await rsyncToDest( sourcePluginPath, finalDest, password );
 
 		console.log( '\n' );
 		console.log(
@@ -562,13 +564,15 @@ async function getUntrackedFiles( pluginPath ) {
 /**
  * Function that does the actual work of rsync.
  *
- * @param {string} source - Source path.
- * @param {string} dest   - Final destination path, including plugin slug.
+ * @param {string}      source   - Source path.
+ * @param {string}      dest     - Final destination path, including plugin slug.
+ * @param {string|null} password - SSH password for the remote host, or null for interactive prompt.
  * @return {Promise<Set>} Synced path set.
  */
-async function rsyncToDest( source, dest ) {
+async function rsyncToDest( source, dest, password = null ) {
 	const paths = await collectPaths( source );
 	const tmpFile = await createFilterFile( paths );
+	let askpassFile = null;
 
 	try {
 		// Some versions of openrsync partially work with --copy-unsafe-links, so do that for them.
@@ -593,12 +597,35 @@ async function rsyncToDest( source, dest ) {
 
 		rsyncArgs.push( source, dest );
 
-		await runCommand( 'rsync', rsyncArgs );
+		// When a password is provided, use SSH_ASKPASS to feed it to SSH automatically.
+		const runOpts = { stdio: 'inherit' };
+		if ( password ) {
+			askpassFile = tmp.fileSync( { mode: 0o700, postfix: '.sh' } );
+			await fs.writeFile(
+				askpassFile.name,
+				`#!/bin/sh\necho '${ password.replace( /'/g, "'\\''" ) }'\n`
+			);
+			runOpts.env = {
+				...process.env,
+				SSH_ASKPASS: askpassFile.name,
+				SSH_ASKPASS_REQUIRE: 'force',
+			};
+			// Pipe stdin so SSH doesn't try to read the password from the terminal.
+			runOpts.stdio = [ 'pipe', 'inherit', 'inherit' ];
+		}
+
+		await runCommand( 'rsync', rsyncArgs, runOpts );
 		tmpFile.removeCallback();
+		if ( askpassFile ) {
+			askpassFile.removeCallback();
+		}
 	} catch ( e ) {
 		console.log( e );
 		console.error( chalk.red( 'Uh oh! ' + e.message ) );
 		tmpFile.removeCallback();
+		if ( askpassFile ) {
+			askpassFile.removeCallback();
+		}
 		process.exit( 1 );
 	}
 
@@ -791,6 +818,10 @@ export function rsyncDefine( yargs ) {
 				.option( 'non-interactive', {
 					describe: 'Do not use interactive prompts. Ideal for CI runs.',
 					type: 'boolean',
+				} )
+				.option( 'password', {
+					describe: 'SSH password for the remote host. Passed via SSH_ASKPASS.',
+					type: 'string',
 				} );
 		},
 		async argv => {

--- a/tools/cli/commands/rsync.js
+++ b/tools/cli/commands/rsync.js
@@ -807,7 +807,7 @@ export function rsyncDefine( yargs ) {
 				} )
 				.option( 'watch', {
 					describe:
-						'Watch the plugin for changes and rsync on change. Note this will probably not be useful if rsync prompts for a password.',
+						'Watch the plugin for changes and rsync on change. Note this will probably not be useful if rsync prompts for a password, unless --password is also provided.',
 					type: 'boolean',
 				} )
 				.option( 'non-interactive', {

--- a/tools/cli/commands/rsync.js
+++ b/tools/cli/commands/rsync.js
@@ -601,32 +601,27 @@ async function rsyncToDest( source, dest, password = null ) {
 		const runOpts = { stdio: 'inherit' };
 		if ( password ) {
 			askpassFile = tmp.fileSync( { mode: 0o700, postfix: '.sh' } );
-			await fs.writeFile(
-				askpassFile.name,
-				`#!/bin/sh\necho '${ password.replace( /'/g, "'\\''" ) }'\n`
-			);
+			await fs.writeFile( askpassFile.name, '#!/bin/sh\nprintf \'%s\\n\' "$ASKPASS_PASSWORD"\n' );
 			runOpts.env = {
 				...process.env,
 				SSH_ASKPASS: askpassFile.name,
 				SSH_ASKPASS_REQUIRE: 'force',
+				ASKPASS_PASSWORD: password,
 			};
 			// Pipe stdin so SSH doesn't try to read the password from the terminal.
 			runOpts.stdio = [ 'pipe', 'inherit', 'inherit' ];
 		}
 
 		await runCommand( 'rsync', rsyncArgs, runOpts );
-		tmpFile.removeCallback();
-		if ( askpassFile ) {
-			askpassFile.removeCallback();
-		}
 	} catch ( e ) {
 		console.log( e );
 		console.error( chalk.red( 'Uh oh! ' + e.message ) );
+		process.exit( 1 );
+	} finally {
 		tmpFile.removeCallback();
 		if ( askpassFile ) {
 			askpassFile.removeCallback();
 		}
-		process.exit( 1 );
 	}
 
 	return paths;
@@ -820,7 +815,8 @@ export function rsyncDefine( yargs ) {
 					type: 'boolean',
 				} )
 				.option( 'password', {
-					describe: 'SSH password for the remote host. Passed via SSH_ASKPASS.',
+					describe:
+						'SSH password for the remote host. Passed via SSH_ASKPASS. Note: the password may be visible in process listings.',
 					type: 'string',
 				} );
 		},

--- a/tools/cli/commands/rsync.js
+++ b/tools/cli/commands/rsync.js
@@ -600,7 +600,7 @@ async function rsyncToDest( source, dest, password = null ) {
 		// When a password is provided, use SSH_ASKPASS to feed it to SSH automatically.
 		const runOpts = { stdio: 'inherit' };
 		if ( password ) {
-			askpassFile = tmp.fileSync( { mode: 0o700, postfix: '.sh' } );
+			askpassFile = tmp.fileSync( { discardDescriptor: true, mode: 0o700, postfix: '.sh' } );
 			await fs.writeFile( askpassFile.name, '#!/bin/sh\nprintf \'%s\\n\' "$ASKPASS_PASSWORD"\n' );
 			runOpts.env = {
 				...process.env,


### PR DESCRIPTION
Fixes #

## Proposed changes

* Add a `--password` option to `jetpack rsync` that passes SSH passwords automatically via `SSH_ASKPASS`, removing the need for `sshpass` or interactive password entry
* When `--password` is provided, a temporary askpass script is created, `SSH_ASKPASS_REQUIRE=force` is set, and stdin is piped so SSH uses the script instead of prompting on the terminal
* The temp askpass script is cleaned up after rsync completes (both success and error paths)
* Add a `/jetpack-test-jurassic-ninja` Claude Code skill that automates pushing a Jetpack plugin to a Jurassic Ninja ephemeral site — discovers sites via the `context-a8c` MCP provider, builds the plugin, and rsyncs with zero user interaction
* The skill includes pre-flight checks for rsync, jetpack CLI, dependencies, MCP provider availability, and existing JN sites with actionable setup instructions for each

### Other information

* The `--password` flag works with both `--non-interactive` and `--watch` modes
* Without `--password`, behavior is unchanged — SSH prompts for the password interactively as before
* The skill lives in `.claude/skills/` so it's available to all Jetpack contributors using Claude Code

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run `jetpack rsync jetpack <user>@<host>:/path/to/plugins/jetpack --non-interactive --password='<password>'` against a Jurassic Ninja site and verify it connects and syncs without prompting for a password
* Run `jetpack rsync jetpack <user>@<host>:/path/to/plugins/jetpack --non-interactive` (no `--password`) and verify it still prompts for the password interactively as before
* Invoke `/jetpack-test-jurassic-ninja` in Claude Code with the `context-a8c` MCP configured and verify it discovers a JN site, builds the plugin, and rsyncs automatically
* Verify the synced plugin loads on the JN site (no critical errors, HTTP 200)
