### PR TITLE
SAL: expose has_password field in post API response

### DIFF
--- a/projects/plugins/jetpack/changelog/update-fix-466-add-has-password-field
+++ b/projects/plugins/jetpack/changelog/update-fix-466-add-has-password-field
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+SAL: Add has_password field to post API response

--- a/projects/plugins/jetpack/changelog/update-fix-466-add-has-password-field
+++ b/projects/plugins/jetpack/changelog/update-fix-466-add-has-password-field
@@ -1,4 +1,4 @@
 Significance: minor
 Type: other
 
-SAL: Add has_password field to post API response
+SAL: Add has_password field to post API response.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-post-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-post-v1-1-endpoint.php
@@ -38,6 +38,7 @@ abstract class WPCOM_JSON_API_Post_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint
 		),
 		'sticky'           => '(bool) Is the post sticky?',
 		'password'         => '(string) The plaintext password protecting the post, or, more likely, the empty string if the post is not password protected.',
+		'has_password'     => '(bool) Whether the post is password protected, regardless of whether the current user can access it.',
 		'parent'           => "(object>post_reference|false) A reference to the post's parent, if it has one.",
 		'type'             => "(string) The post's post_type. Post types besides post, page and revision need to be whitelisted using the <code>rest_api_allowed_post_types</code> filter.",
 		'discussion'       => '(object) Hash of discussion options for the post',
@@ -218,6 +219,9 @@ abstract class WPCOM_JSON_API_Post_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint
 					break;
 				case 'password':
 					$response[ $key ] = $post->get_password();
+					break;
+				case 'has_password':
+					$response[ $key ] = $post->get_has_password();
 					break;
 				/** (object|false) */
 				case 'parent':

--- a/projects/plugins/jetpack/sal/class.json-api-post-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-post-base.php
@@ -683,6 +683,15 @@ abstract class SAL_Post {
 	}
 
 	/**
+	 * Returns true if the post is password protected, regardless of user permissions.
+	 *
+	 * @return bool
+	 */
+	public function get_has_password(): bool {
+		return strlen( (string) $this->post->post_password ) > 0;
+	}
+
+	/**
 	 * Returns an object representing a post's parent, and false if it doesn't have one.
 	 *
 	 * @return object|bool

--- a/projects/plugins/jetpack/sal/class.json-api-post-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-post-base.php
@@ -683,7 +683,7 @@ abstract class SAL_Post {
 	}
 
 	/**
-	 * Returns true if the post is password protected, regardless of user permissions.
+	 * Returns true if the post has a password set, regardless of whether the current user can view or receive the password value.
 	 *
 	 * @return bool
 	 */

--- a/projects/plugins/jetpack/tests/php/json-api/SalPostsTest.php
+++ b/projects/plugins/jetpack/tests/php/json-api/SalPostsTest.php
@@ -43,4 +43,37 @@ class SalPostsTest extends WP_UnitTestCase {
 
 		$this->assertEquals( $post->post_type, $wrapped_post->get_type() );
 	}
+
+	public function test_get_has_password_returns_true_when_post_has_password() {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'    => 'Password Protected Post',
+				'post_content'  => 'Secret content.',
+				'post_status'   => 'publish',
+				'post_password' => 'secret123',
+				'post_author'   => get_current_user_id(),
+			)
+		);
+
+		$post         = get_post( $post_id );
+		$wrapped_post = self::$site->wrap_post( $post, 'display' );
+
+		$this->assertTrue( $wrapped_post->get_has_password() );
+	}
+
+	public function test_get_has_password_returns_false_when_post_has_no_password() {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Public Post',
+				'post_content' => 'Public content.',
+				'post_status'  => 'publish',
+				'post_author'  => get_current_user_id(),
+			)
+		);
+
+		$post         = get_post( $post_id );
+		$wrapped_post = self::$site->wrap_post( $post, 'display' );
+
+		$this->assertFalse( $wrapped_post->get_has_password() );
+	}
 }

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Get_Post_v1_1_Endpoint_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Get_Post_v1_1_Endpoint_Test.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * WPCOM_JSON_API_Get_Post_v1_1_Endpoint unit tests.
+ *
+ * Run this test with command: jetpack docker phpunit jetpack -- --filter=WPCOM_JSON_API_Get_Post_v1_1_Endpoint_Test
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
+require_once JETPACK__PLUGIN_DIR . 'class.json-api-endpoints.php';
+require_once JETPACK__PLUGIN_DIR . 'json-endpoints/class.wpcom-json-api-get-post-v1-1-endpoint.php';
+
+/**
+ * Tests for the /sites/%s/posts/%d v1.1 get post endpoint.
+ *
+ * @covers \WPCOM_JSON_API_Get_Post_v1_1_Endpoint
+ */
+#[CoversClass( WPCOM_JSON_API_Get_Post_v1_1_Endpoint::class )]
+class WPCOM_JSON_API_Get_Post_v1_1_Endpoint_Test extends WP_UnitTestCase {
+	use WP_UnitTestCase_Fix;
+
+	/**
+	 * An admin user ID.
+	 *
+	 * @var int
+	 */
+	private static $admin_user_id;
+
+	/**
+	 * The current blog ID.
+	 *
+	 * @var int
+	 */
+	private static $blog_id;
+
+	/**
+	 * Saved $_SERVER superglobal.
+	 *
+	 * @var array
+	 */
+	private $pre_globals;
+
+	/**
+	 * Inserts globals needed to initialize the endpoint.
+	 */
+	private function set_globals() {
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$_SERVER['HTTP_HOST']      = '127.0.0.1';
+		$_SERVER['REQUEST_URI']    = '/';
+	}
+
+	/**
+	 * Create fixtures once, before any tests in the class have run.
+	 *
+	 * @param WP_UnitTest_Factory $factory A factory object.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_user_id = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$blog_id       = $GLOBALS['blog_id'];
+	}
+
+	/**
+	 * Prepare the environment for each test.
+	 */
+	public function set_up() {
+		if ( ! defined( 'WPCOM_JSON_API__BASE' ) ) {
+			define( 'WPCOM_JSON_API__BASE', 'public-api.wordpress.com/rest/v1' );
+		}
+
+		parent::set_up();
+
+		$this->pre_globals = $_SERVER;
+		$this->set_globals();
+
+		WPCOM_JSON_API::init()->token_details = array( 'blog_id' => self::$blog_id );
+		wp_set_current_user( self::$admin_user_id );
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		parent::tear_down();
+
+		$_SERVER = $this->pre_globals;
+
+		WPCOM_JSON_API::init()->token_details = array();
+		WPCOM_JSON_API::init()->query         = array();
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * Retrieve the registered v1.1 get-post endpoint instance.
+	 *
+	 * @return WPCOM_JSON_API_Get_Post_v1_1_Endpoint
+	 *
+	 * @phan-suppress PhanTypeArraySuspicious
+	 */
+	private function get_endpoint() {
+		$api = WPCOM_JSON_API::init();
+		foreach ( $api->endpoints as $endpoints_by_method ) {
+			if (
+				isset( $endpoints_by_method['GET'] )
+				&& get_class( $endpoints_by_method['GET'] ) === 'WPCOM_JSON_API_Get_Post_v1_1_Endpoint'
+				&& '1.1' === $endpoints_by_method['GET']->max_version
+			) {
+				return $endpoints_by_method['GET'];
+			}
+		}
+		$this->fail( 'WPCOM_JSON_API_Get_Post_v1_1_Endpoint (v1.1) not found in registered endpoints.' );
+	}
+
+	/**
+	 * Helper to create a published post.
+	 *
+	 * @param array $args Optional overrides for wp_insert_post.
+	 * @return int Post ID.
+	 */
+	private function create_post( $args = array() ) {
+		return wp_insert_post(
+			array_merge(
+				array(
+					'post_title'   => 'Test Post',
+					'post_content' => 'Test content.',
+					'post_status'  => 'publish',
+					'post_type'    => 'post',
+					'post_author'  => self::$admin_user_id,
+				),
+				$args
+			)
+		);
+	}
+
+	/**
+	 * Test that has_password is true for a password-protected post.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_has_password_is_true_for_password_protected_post() {
+		$post_id = $this->create_post( array( 'post_password' => 'secret123' ) );
+
+		$response = $this->get_endpoint()->callback(
+			'/sites/' . self::$blog_id . '/posts/' . $post_id,
+			self::$blog_id,
+			$post_id
+		);
+
+		$this->assertIsArray( $response );
+		$this->assertArrayHasKey( 'has_password', $response );
+		$this->assertTrue( $response['has_password'] );
+	}
+
+	/**
+	 * Test that has_password is false for a post without a password.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_has_password_is_false_for_post_without_password() {
+		$post_id = $this->create_post();
+
+		$response = $this->get_endpoint()->callback(
+			'/sites/' . self::$blog_id . '/posts/' . $post_id,
+			self::$blog_id,
+			$post_id
+		);
+
+		$this->assertIsArray( $response );
+		$this->assertArrayHasKey( 'has_password', $response );
+		$this->assertFalse( $response['has_password'] );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Get_Post_v1_1_Endpoint_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Get_Post_v1_1_Endpoint_Test.php
@@ -20,7 +20,7 @@ require_once JETPACK__PLUGIN_DIR . 'json-endpoints/class.wpcom-json-api-get-post
  * @covers \WPCOM_JSON_API_Get_Post_v1_1_Endpoint
  */
 #[CoversClass( WPCOM_JSON_API_Get_Post_v1_1_Endpoint::class )]
-class WPCOM_JSON_API_Get_Post_v1_1_Endpoint_Test extends WP_UnitTestCase {
+class WPCOM_JSON_API_Get_Post_v1_1_Endpoint_Test extends WP_UnitTestCase { // phpcs:ignore PEAR.NamingConventions.ValidClassName.Invalid, Generic.Classes.OpeningBraceSameLine.ContentAfterBrace -- matches source class naming.
 	use WP_UnitTestCase_Fix;
 
 	/**


### PR DESCRIPTION
Part of READ-446

Expose has_password field to permit reader show better information about how the user can see the post. 



## Summary

- Add `has_password` boolean field to `$post_object_format` in `WPCOM_JSON_API_Post_v1_1_Endpoint`
- Add `case 'has_password':` in `render_response_keys()` calling `$post->get_has_password()`
- Add `get_has_password()` method to `SAL_Post` — returns `true` if `post_password` is non-empty, regardless of whether the current user can view the password value
- Add PHPUnit tests: `SalPostsTest` covers `get_has_password()` directly on the SAL wrapper; `WPCOM_JSON_API_Get_Post_v1_1_Endpoint_Test` covers the `has_password` field in the v1.1 API response


## Does this pull request change what data or activity we track or use?
N/A


## Why

When a site owner (user with `edit_post` capability) requests a password-protected post via the WordPress.com Reader, `can_access_post()` bypasses the `WP_Error` path. The existing `password` field is filtered out before reaching the Reader endpoint. A dedicated boolean field allows the Reader to reliably detect password-protected posts and show the standard placeholder, regardless of whether the current user can view the password value.

Companion change to wpcom PR wpcom/pull/210471 (READ-446).

## Testing instructions:
- Automated tests covering this change https://github.com/Automattic/jetpack/pull/47938/changes#diff-f615eec43602f698170bf558ed8b6da5c6e27b66de55c39fcccfbf32d3ec80b0R46-R78
- For manual testing, check the wpcom PR ( wpcom/pull/210471 )


