### PR TITLE
Settings: Replace custom tabs with @wordpress/ui Tabs component

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5065,6 +5065,9 @@ importers:
       '@wordpress/rich-text':
         specifier: 7.43.0
         version: 7.43.0(react@18.3.1)
+      '@wordpress/ui':
+        specifier: 0.10.0
+        version: 0.10.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.7.0)
       '@wordpress/url':
         specifier: 4.43.0
         version: 4.43.0

--- a/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/index.jsx
@@ -1,9 +1,9 @@
 import { isWoASite as _isWoASite } from '@automattic/jetpack-script-data';
 import { __, _x } from '@wordpress/i18n';
-import clsx from 'clsx';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Tabs } from '@wordpress/ui';
+import { useCallback, useEffect, useMemo } from 'react';
 import { connect } from 'react-redux';
-import { NavLink, useLocation } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import QuerySitePlugins from 'components/data/query-site-plugins';
 import Search from 'components/search';
 import analytics from 'lib/analytics';
@@ -20,9 +20,9 @@ import {
 	isModuleActivated,
 } from 'state/modules';
 import { filterSearch, getSearchTerm } from 'state/search';
+import './style.scss';
 
 // Map route paths to their translated tab labels.
-// Used both for rendering tabs and for the mobile dropdown header text.
 const TAB_LABELS = {
 	'/security': _x( 'Security', 'Navigation item.', 'jetpack' ),
 	'/performance': _x( 'Performance', 'Navigation item.', 'jetpack' ),
@@ -35,27 +35,17 @@ const TAB_LABELS = {
 	'/earn': _x( 'Monetize', 'Navigation item.', 'jetpack' ),
 };
 
-const Tab = ( { to, label, onClick, alsoActiveFor } ) => {
-	const { pathname } = useLocation();
-	const extraActive = alsoActiveFor?.includes( pathname );
-
-	return (
-		<NavLink
-			to={ to }
-			// NavLink's className API requires a function — not a bind issue.
-			// eslint-disable-next-line react/jsx-no-bind
-			className={ ( { isActive } ) =>
-				clsx( 'jp-settings-nav__tab', {
-					'jp-settings-nav__tab--active': isActive || extraActive,
-				} )
-			}
-			onClick={ onClick }
-		>
-			{ label }
-		</NavLink>
-	);
+// Routes that should highlight a different tab (e.g. /settings → /security).
+const ROUTE_ALIASES = {
+	'/settings': '/security',
 };
 
+/**
+ * Settings page tab navigation using `@wordpress/ui` Tabs.
+ *
+ * @param {object} props - Component props from Redux.
+ * @return {import('react').ReactNode} The settings navigation tabs.
+ */
 const SettingsNavTabs = props => {
 	const {
 		userCanManageModules,
@@ -72,14 +62,10 @@ const SettingsNavTabs = props => {
 	} = props;
 
 	const location = useLocation();
-	const [ mobileOpen, setMobileOpen ] = useState( false );
+	const navigate = useNavigate();
 
-	const selectedTabText = TAB_LABELS[ location.pathname ] || __( 'Settings', 'jetpack' );
-
-	// Close the mobile dropdown when navigating to a new tab.
-	useEffect( () => {
-		setMobileOpen( false );
-	}, [ location.pathname ] );
+	// Resolve the active tab value from the current route.
+	const activeTab = ROUTE_ALIASES[ location.pathname ] || location.pathname;
 
 	const trackNavClick = target => {
 		analytics.tracks.recordJetpackClick( {
@@ -87,6 +73,14 @@ const SettingsNavTabs = props => {
 			path: target,
 		} );
 	};
+
+	const handleTabChange = useCallback(
+		value => {
+			trackNavClick( value.slice( 1 ) );
+			navigate( value );
+		},
+		[ navigate ]
+	);
 
 	const doSearch = useCallback(
 		keywords => {
@@ -101,147 +95,95 @@ const SettingsNavTabs = props => {
 		[ searchForTerm ]
 	);
 
-	let tabs;
-
-	/* eslint-disable react/jsx-no-bind -- Arrow callbacks for analytics tracking. */
-	if ( userCanManageModules ) {
-		tabs = (
-			<>
-				{ hasSecurityFeature && (
-					<Tab
-						to="/security"
-						label={ TAB_LABELS[ '/security' ] }
-						onClick={ () => trackNavClick( 'security' ) }
-						alsoActiveFor={ [ '/settings' ] }
-					/>
-				) }
-				{ hasPerformanceFeature && (
-					<Tab
-						to="/performance"
-						label={ TAB_LABELS[ '/performance' ] }
-						onClick={ () => trackNavClick( 'performance' ) }
-					/>
-				) }
-				{ ( hasModules( [ 'markdown', 'post-by-email', 'infinite-scroll', 'copy-post' ] ) ||
-					window.CUSTOM_CONTENT_TYPE__INITIAL_STATE?.active ) && (
-					<Tab
-						to="/writing"
-						label={ TAB_LABELS[ '/writing' ] }
-						onClick={ () => trackNavClick( 'writing' ) }
-					/>
-				) }
-				{ hasModules( [ 'publicize', 'sharedaddy', 'likes' ] ) && (
-					<Tab
-						to="/sharing"
-						label={ TAB_LABELS[ '/sharing' ] }
-						onClick={ () => trackNavClick( 'sharing' ) }
-					/>
-				) }
-				{ hasModules( [ 'comments', 'gravatar-hovercards', 'markdown' ] ) && (
-					<Tab
-						to="/discussion"
-						label={ TAB_LABELS[ '/discussion' ] }
-						onClick={ () => trackNavClick( 'discussion' ) }
-					/>
-				) }
-				{ hasModules( [
-					'seo-tools',
-					'stats',
-					'related-posts',
-					'verification-tools',
-					'sitemaps',
-					'google-analytics',
-				] ) && (
-					<Tab
-						to="/traffic"
-						label={ TAB_LABELS[ '/traffic' ] }
-						onClick={ () => trackNavClick( 'traffic' ) }
-					/>
-				) }
-				{ hasModules( [ 'subscriptions' ] ) && ! isWpAdminNewsletterSettingsEnabled && (
-					<Tab
-						to="/newsletter"
-						label={ TAB_LABELS[ '/newsletter' ] }
-						onClick={ () => trackNavClick( 'newsletter' ) }
-					/>
-				) }
-				{ hasModules( [ 'wpcom-reader' ] ) && ! isWoASite && (
-					<Tab
-						to="/reader"
-						label={ TAB_LABELS[ '/reader' ] }
-						onClick={ () => trackNavClick( 'reader' ) }
-					/>
-				) }
-				{ hasModules( [ 'wordads' ] ) && (
-					<Tab
-						to="/earn"
-						label={ TAB_LABELS[ '/earn' ] }
-						onClick={ () => trackNavClick( 'earn' ) }
-					/>
-				) }
-			</>
-		);
-	} else if ( isSubscriber ) {
-		tabs = null;
-	} else {
-		tabs = (
-			<>
-				{ isModuleActive( 'post-by-email' ) &&
-					userCanPublishPosts &&
-					hasModules( [ 'post-by-email' ] ) && (
-						<Tab
-							to="/writing"
-							label={ TAB_LABELS[ '/writing' ] }
-							onClick={ () => trackNavClick( 'writing' ) }
-						/>
-					) }
-				{ isModuleActive( 'publicize' ) && userCanPublishPosts && hasModules( [ 'publicize' ] ) && (
-					<Tab
-						to="/sharing"
-						label={ TAB_LABELS[ '/sharing' ] }
-						onClick={ () => trackNavClick( 'sharing' ) }
-						alsoActiveFor={ [ '/settings' ] }
-					/>
-				) }
-			</>
-		);
-	}
-	/* eslint-enable react/jsx-no-bind */
-
 	const searchFromUrl = useMemo(
 		() => new URLSearchParams( location.search ).get( 'term' ) || '',
 		[ location.search ]
 	);
 
-	// Sync URL search term to Redux on mount and route changes,
-	// matching the old NavigationSettings.onRouteChange behavior.
+	// Sync URL search term to Redux on mount and route changes.
 	useEffect( () => {
 		searchForTerm( searchFromUrl );
 	}, [ searchFromUrl, searchForTerm ] );
 
-	/* eslint-disable react/jsx-no-bind -- Trivial toggle callback. */
+	// Build the list of visible tabs based on permissions and modules.
+	const visibleTabs = [];
+
+	if ( userCanManageModules ) {
+		if ( hasSecurityFeature ) {
+			visibleTabs.push( '/security' );
+		}
+		if ( hasPerformanceFeature ) {
+			visibleTabs.push( '/performance' );
+		}
+		if (
+			hasModules( [ 'markdown', 'post-by-email', 'infinite-scroll', 'copy-post' ] ) ||
+			window.CUSTOM_CONTENT_TYPE__INITIAL_STATE?.active
+		) {
+			visibleTabs.push( '/writing' );
+		}
+		if ( hasModules( [ 'publicize', 'sharedaddy', 'likes' ] ) ) {
+			visibleTabs.push( '/sharing' );
+		}
+		if ( hasModules( [ 'comments', 'gravatar-hovercards', 'markdown' ] ) ) {
+			visibleTabs.push( '/discussion' );
+		}
+		if (
+			hasModules( [
+				'seo-tools',
+				'stats',
+				'related-posts',
+				'verification-tools',
+				'sitemaps',
+				'google-analytics',
+			] )
+		) {
+			visibleTabs.push( '/traffic' );
+		}
+		if ( hasModules( [ 'subscriptions' ] ) && ! isWpAdminNewsletterSettingsEnabled ) {
+			visibleTabs.push( '/newsletter' );
+		}
+		if ( hasModules( [ 'wpcom-reader' ] ) && ! isWoASite ) {
+			visibleTabs.push( '/reader' );
+		}
+		if ( hasModules( [ 'wordads' ] ) ) {
+			visibleTabs.push( '/earn' );
+		}
+	} else if ( ! isSubscriber ) {
+		if (
+			isModuleActive( 'post-by-email' ) &&
+			userCanPublishPosts &&
+			hasModules( [ 'post-by-email' ] )
+		) {
+			visibleTabs.push( '/writing' );
+		}
+		if ( isModuleActive( 'publicize' ) && userCanPublishPosts && hasModules( [ 'publicize' ] ) ) {
+			visibleTabs.push( '/sharing' );
+		}
+	}
+
+	if ( visibleTabs.length === 0 ) {
+		return null;
+	}
+
 	return (
-		<div className={ clsx( 'jp-settings-nav', { 'is-open': mobileOpen } ) }>
+		<div className="jp-settings-nav">
 			<QuerySitePlugins />
-			<button
-				className={ clsx( 'jp-settings-nav__mobile-header', { 'is-open': mobileOpen } ) }
-				onClick={ () => setMobileOpen( ! mobileOpen ) }
-				aria-expanded={ mobileOpen }
+			<Tabs.Root
+				value={ activeTab }
+				onValueChange={ handleTabChange }
+				className="jp-settings-nav__tabs-root"
 			>
-				<span>{ selectedTabText }</span>
-				<span
-					className={ clsx( 'dashicons', 'jp-settings-nav__mobile-chevron', {
-						'dashicons-arrow-up-alt2': mobileOpen,
-						'dashicons-arrow-down-alt2': ! mobileOpen,
-					} ) }
-				/>
-			</button>
-			<nav
-				className="jp-settings-nav__tabs"
-				aria-label={ __( 'Jetpack settings sections', 'jetpack' ) }
-			>
-				{ tabs }
-			</nav>
+				<Tabs.List
+					className="jp-settings-nav__tabs"
+					aria-label={ __( 'Jetpack settings sections', 'jetpack' ) }
+				>
+					{ visibleTabs.map( path => (
+						<Tabs.Tab key={ path } value={ path } className="jp-settings-nav__tab">
+							{ TAB_LABELS[ path ] }
+						</Tabs.Tab>
+					) ) }
+				</Tabs.List>
+			</Tabs.Root>
 			{ userCanManageModules && (
 				<Search
 					pinned={ true }
@@ -256,7 +198,6 @@ const SettingsNavTabs = props => {
 			) }
 		</div>
 	);
-	/* eslint-enable react/jsx-no-bind */
 };
 
 export default connect(

--- a/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/style.scss
@@ -21,35 +21,26 @@ $spacing-base: var(--spacing-base, 8px);
 	}
 }
 
+// Outer container: flex row with tabs + search side by side.
 .jp-settings-nav {
 	display: flex;
 	align-items: center;
 	position: relative;
 	border-bottom: 1px solid gb.$gray-100;
 	padding-inline: calc(#{$spacing-base} * 3); // 24px — matches admin-ui header
-	background-color: #fff; // Match search component background; prevents beige bleed-through
+	background-color: #fff;
 
-	@media (max-width: 660px) {
-		flex-wrap: wrap;
-		padding-inline: calc(#{$spacing-base} * 2); // tighter padding on mobile
-		border-bottom: none;
-		box-shadow: 0 0 0 1px gb.$gray-100, 0 1px 1px 1px rgba(0, 0, 0, 0.04);
-		margin: calc(#{$spacing-base} * 1.5) calc(#{$spacing-base} * 2);
-		border-radius: 2px;
-
-		&.is-open {
-			box-shadow: 0 0 0 1px gb.$gray-300, 0 2px 4px rgba(0, 0, 0, 0.1);
-		}
-	}
-
-	// The Search component uses position: absolute with fitsContainer, which
-	// positions relative to the padding edge (ignoring padding). Offset it to
-	// stay within the padded content area.
+	// Search: position absolutely so it doesn't shrink the tab area.
+	// On mobile this prevents the search icon from stealing tab scroll space.
 	.dops-search.is-expanded-to-container {
+		position: absolute;
 		inset-inline-end: calc(#{$spacing-base} * 3);
+		inset-block: 0;
+		display: flex;
+		align-items: center;
 
 		@media (max-width: 660px) {
-			inset-inline-end: 0;
+			inset-inline-end: calc(#{$spacing-base} * 2);
 		}
 
 		&.is-open {
@@ -57,119 +48,30 @@ $spacing-base: var(--spacing-base, 8px);
 			width: auto;
 
 			@media (max-width: 660px) {
-				// Slide over the entire dropdown box (header + tabs).
-				// Don't set inset-inline-start — keep the element right-anchored
-				// so the width transition creates a smooth leftward slide.
-				// (auto → 0 isn't animatable and would cause an instant snap.)
-				inset-inline-start: auto;
-				inset-block: 0;
 				z-index: 1;
 				background-color: #fff;
-				// Concrete value enables CSS width transition.
-				// (auto is not interpolatable, so it snaps instead of animating.)
-				width: 100%;
-				border-radius: 2px;
 			}
 		}
 	}
 }
 
-// Mobile dropdown header — hidden on desktop, visible at <=660px.
-.jp-settings-nav__mobile-header {
-	display: none;
-
-	@media (max-width: 660px) {
-		display: flex;
-		align-items: center;
-		width: 100%;
-		gap: calc(#{$spacing-base} / 2);
-		padding: calc(#{$spacing-base} * 1.5) 0;
-		background: none;
-		border: none;
-		cursor: pointer;
-		font-size: var(--font-body);
-		font-weight: 400;
-		color: var(--jp-black);
-		font-family: inherit;
-
-		&:focus,
-		&:focus-visible {
-			outline-color: gb.$gray-100;
-		}
-
-		.jp-settings-nav__mobile-chevron {
-			font-size: 16px;
-			width: 16px;
-			height: 16px;
-			flex-shrink: 0;
-			color: gb.$gray-700;
-		}
-	}
+// Tabs.Root: fills the available flex space and clips the TabList so the
+// component's built-in overflow detection (scrollWidth > clientWidth) works.
+.jp-settings-nav__tabs-root {
+	// let there be scroll
+	overflow: hidden;
+	// Reserve space for the absolutely-positioned search icon.
+	padding-inline-end: 50px;
 }
 
-.jp-settings-nav__tabs {
-	display: flex;
-	flex: 1;
-	overflow-x: auto;
-	-webkit-overflow-scrolling: touch;
-
-	// Hide the scrollbar but keep scroll functionality.
-	scrollbar-width: none; // Firefox
-	&::-webkit-scrollbar {
-		display: none; // Chrome, Safari, Edge
-	}
-
-	// On mobile, tabs are hidden by default and shown as a vertical dropdown.
-	@media (max-width: 660px) {
-		display: none;
-		flex-direction: column;
-		width: 100%;
-		overflow-x: visible;
-
-		.is-open > & {
-			display: flex;
-			border-top: 1px solid gb.$gray-100;
-			padding-top: calc(#{$spacing-base} / 2);
-		}
-	}
+// TabList: override the component's fit-content default to fill the parent,
+// enabling its built-in overflow detection (scrollWidth > clientWidth) and
+// horizontal scroll with gradient fade indicators.
+.jp-settings-nav__tabs[role="tablist"][data-orientation="horizontal"] {
+	width: 100%;
 }
 
+// Tabs: size to content instead of stretching to fill the row.
 .jp-settings-nav__tab {
-	color: var(--wpds-color-fg-interactive-neutral, #1e1e1e);
-	font-size: var(--wpds-font-size-md, 13px);
-	line-height: 1.2;
-	text-decoration: none;
-	padding: #{$spacing-base} 0;
-	margin-inline-end: calc(#{$spacing-base} * 4);
-	white-space: nowrap;
-
-	@media (max-width: 660px) {
-		margin-inline-end: 0;
-		padding: calc(#{$spacing-base} * 1.5) calc(#{$spacing-base} * 2);
-		border-inline-start: 3px solid transparent;
-	}
-
-	&:last-child {
-		margin-inline-end: 0;
-	}
-
-	&:hover,
-	&:focus {
-		box-shadow: none;
-		color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
-	}
-
-	&:focus-visible {
-		outline-color: gb.$gray-100;
-	}
-
-	&--active {
-		border-bottom: var(--jp-underline-thickness) solid var(--jp-black);
-
-		@media (max-width: 660px) {
-			border-bottom: none;
-			border-inline-start-color: var(--jp-black);
-			font-weight: 600;
-		}
-	}
+	flex: 0 0 auto;
 }

--- a/projects/plugins/jetpack/_inc/client/settings/style.scss
+++ b/projects/plugins/jetpack/_inc/client/settings/style.scss
@@ -142,6 +142,10 @@
 		color: #23282d;
 		margin-top: rem.convert(48px);
 		margin-bottom: rem.convert(24px);
+
+		@include breakpoints.breakpoint( "<480px" ) {
+			padding-inline: rem.convert(24px);
+		}
 	}
 
 	.dops-info-popover-button,

--- a/projects/plugins/jetpack/changelog/update-settings-tabs-wordpress-ui
+++ b/projects/plugins/jetpack/changelog/update-settings-tabs-wordpress-ui
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Settings: Replace custom tab navigation with @wordpress/ui Tabs component for proper ARIA semantics, built-in overflow handling, and animated indicator.

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -87,6 +87,7 @@
 		"@wordpress/plugins": "7.43.0",
 		"@wordpress/primitives": "4.43.0",
 		"@wordpress/rich-text": "7.43.0",
+		"@wordpress/ui": "0.10.0",
 		"@wordpress/url": "4.43.0",
 		"@wordpress/viewport": "6.43.0",
 		"@wordpress/widgets": "4.43.0",


### PR DESCRIPTION
## Proposed changes

Replace the custom ad-hoc `SettingsNavTabs` component with the `@wordpress/ui` Tabs component for the Jetpack Settings admin page.

* Rewrite tab navigation to use `Tabs.Root` / `Tabs.List` / `Tabs.Tab` from `@wordpress/ui` in controlled mode, synced with React Router.
* Get proper WAI-ARIA `tablist`/`tab` semantics, animated active indicator, and built-in horizontal scroll with gradient fade on overflow — all from the component.
* Reduce custom SCSS from ~178 lines to ~75 lines by removing the custom mobile dropdown, scrollbar hiding, and active-state styling that the component handles natively.
* Preserve all existing behavior: Redux-driven conditional tab visibility, Jetpack Tracks analytics, search integration, and `/settings` → `/security` route alias.

### Other information

* Adds `@wordpress/ui` 0.10.0 as a direct dependency. It's already in the webpack `BUNDLED_PACKAGES` list (not externalized to `window.wp`).
* `Tabs.Panel` is intentionally not used — tab content is route-managed via React Router, so only the tab bar is replaced.
* The component's `width: fit-content` default on TabList prevents its overflow detection from working. We override it with `width: 100%` using a `[data-orientation="horizontal"]` selector for specificity.

## Related product discussion/links

* Part of the ongoing Jetpack admin UI modernization effort.

## Does this pull request change what data or activity we track or use?

No. Analytics tracking is preserved — `recordJetpackClick` fires on tab changes with the same `nav_item` target and path payload.

## Testing instructions

1. `jetpack build plugins/jetpack`
2. Navigate to **Jetpack → Settings** (`wp-admin/admin.php?page=jetpack#/settings`)

**Desktop:**
* Verify all tabs render (Security, Performance, Writing, Sharing, Discussion, Traffic, Reader, Monetize — exact set depends on active modules)
* Click each tab — URL should update (`#/security`, `#/writing`, etc.) and content should change
* The animated underline indicator should follow the active tab
* Search icon (magnifying glass) should appear on the right and expand when clicked

**Mobile (≤ 660px):**
* Tabs should scroll horizontally with a gradient fade hinting at more content
* Swipe/scroll to reach hidden tabs — they should be tappable
* Search icon should remain accessible and not overlap tabs

**Keyboard:**
* Focus the tab bar and use arrow keys to navigate between tabs
* Enter/Space should activate the focused tab

### Before
<img width="903" height="256" alt="image" src="https://github.com/user-attachments/assets/733b92cc-504e-4f88-a122-88eff3ce3110" />

<img width="356" height="264" alt="image" src="https://github.com/user-attachments/assets/81bfc079-c9aa-4ac7-8ff4-b696ae4dab4e" />
<img width="349" height="476" alt="image" src="https://github.com/user-attachments/assets/88af5b98-1a8d-4564-86d3-3c41695dca6c" />


### After
<img width="919" height="426" alt="image" src="https://github.com/user-attachments/assets/afe938e2-3684-4586-953c-a1d397ce5dfc" />

<img width="346" height="280" alt="image" src="https://github.com/user-attachments/assets/5a679ebb-cc19-4ffc-abd7-3d62443b34fc" />

<img width="356" height="407" alt="image" src="https://github.com/user-attachments/assets/aeb4d5a6-3402-4557-8b1b-31a38cd3b308" />

