### PR TITLE
Forms: fix 'Don't show this again' checkbox only dismissing on Got it click

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-missing-forms-checkbox-dismiss
+++ b/projects/packages/forms/changelog/fix-forms-missing-forms-checkbox-dismiss
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Fix 'Don't show this again' checkbox in the help modal so it only dismisses permanently when clicking 'Got it', not when closing via the X button or Escape key.

--- a/projects/packages/forms/changelog/fix-forms-missing-forms-checkbox-dissmiss
+++ b/projects/packages/forms/changelog/fix-forms-missing-forms-checkbox-dissmiss
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fixed 'Don't show this again' checkbox in Forms help modal dismissing permanently when closing via X button or Escape key instead of only when clicking 'Got it'

--- a/projects/packages/forms/changelog/fix-forms-missing-forms-checkbox-dissmiss
+++ b/projects/packages/forms/changelog/fix-forms-missing-forms-checkbox-dissmiss
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed 'Don't show this again' checkbox in Forms help modal dismissing permanently when closing via X button or Escape key instead of only when clicking 'Got it'

--- a/projects/packages/forms/src/dashboard/wp-build/components/forms-help-modal/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/forms-help-modal/index.tsx
@@ -37,7 +37,7 @@ export default function FormsHelpModal( { isOpen, onClose }: Props ) {
 	const [ dontShowAgain, setDontShowAgain ] = useState( false );
 	const { receiveConfigValue } = useDispatch( CONFIG_STORE );
 
-	const handleClose = useCallback( () => {
+	const handleSubmit = useCallback( () => {
 		if ( dontShowAgain ) {
 			receiveConfigValue( 'hasClassicForms', false );
 			apiFetch( {
@@ -53,10 +53,7 @@ export default function FormsHelpModal( { isOpen, onClose }: Props ) {
 	}
 
 	return (
-		<Modal
-			title={ __( 'Not seeing all your forms?', 'jetpack-forms' ) }
-			onRequestClose={ handleClose }
-		>
+		<Modal title={ __( 'Not seeing all your forms?', 'jetpack-forms' ) } onRequestClose={ onClose }>
 			<VStack spacing="4">
 				<Text>
 					{ __( 'The Forms list shows reusable forms, not simple form blocks.', 'jetpack-forms' ) }
@@ -83,7 +80,7 @@ export default function FormsHelpModal( { isOpen, onClose }: Props ) {
 						checked={ dontShowAgain }
 						onChange={ setDontShowAgain }
 					/>
-					<Button variant="primary" onClick={ handleClose }>
+					<Button variant="primary" onClick={ handleSubmit }>
 						{ __( 'Got it', 'jetpack-forms' ) }
 					</Button>
 				</HStack>

--- a/projects/packages/forms/src/dashboard/wp-build/components/forms-help-modal/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/forms-help-modal/index.tsx
@@ -58,7 +58,10 @@ export default function FormsHelpModal( { isOpen, onClose }: Props ) {
 	}
 
 	return (
-		<Modal title={ __( 'Not seeing all your forms?', 'jetpack-forms' ) } onRequestClose={ handleClose }>
+		<Modal
+			title={ __( 'Not seeing all your forms?', 'jetpack-forms' ) }
+			onRequestClose={ handleClose }
+		>
 			<VStack spacing="4">
 				<Text>
 					{ __( 'The Forms list shows reusable forms, not simple form blocks.', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/dashboard/wp-build/components/forms-help-modal/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/forms-help-modal/index.tsx
@@ -37,6 +37,11 @@ export default function FormsHelpModal( { isOpen, onClose }: Props ) {
 	const [ dontShowAgain, setDontShowAgain ] = useState( false );
 	const { receiveConfigValue } = useDispatch( CONFIG_STORE );
 
+	const handleClose = useCallback( () => {
+		setDontShowAgain( false );
+		onClose();
+	}, [ onClose ] );
+
 	const handleSubmit = useCallback( () => {
 		if ( dontShowAgain ) {
 			receiveConfigValue( 'hasClassicForms', false );
@@ -45,15 +50,15 @@ export default function FormsHelpModal( { isOpen, onClose }: Props ) {
 				method: 'POST',
 			} );
 		}
-		onClose();
-	}, [ dontShowAgain, onClose, receiveConfigValue ] );
+		handleClose();
+	}, [ dontShowAgain, handleClose, receiveConfigValue ] );
 
 	if ( ! isOpen ) {
 		return null;
 	}
 
 	return (
-		<Modal title={ __( 'Not seeing all your forms?', 'jetpack-forms' ) } onRequestClose={ onClose }>
+		<Modal title={ __( 'Not seeing all your forms?', 'jetpack-forms' ) } onRequestClose={ handleClose }>
 			<VStack spacing="4">
 				<Text>
 					{ __( 'The Forms list shows reusable forms, not simple form blocks.', 'jetpack-forms' ) }


### PR DESCRIPTION
## Proposed changes

* Fix the "Don't show this again" checkbox in the Forms help modal ("Not seeing all your forms?") so that the permanent dismiss only fires when the user explicitly clicks "Got it", not when closing via the X button or Escape key.
* Previously, `onRequestClose` (X / Escape) shared the same handler as the "Got it" button, so checking the checkbox and then closing via X would permanently dismiss the modal with no way to undo.
* Now, closing via X or Escape simply closes the modal without side effects, allowing the user to change their mind.

### Other information

The fix separates the modal's `onRequestClose` handler (which now just calls `onClose`) from the "Got it" button handler (renamed to `handleSubmit`), which checks the checkbox state before calling the dismiss API.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions
Make sure that the option "jetpack_forms_classic_state" is set to "classic". This will make the button that shows the modal appear. You can do this in `/wp-admin/options.php` 


1. Go to the Jetpack Forms dashboard on a site that has classic (non-managed) forms so the "Not seeing all your forms?" link appears.
2. Click the "Not seeing all your forms?" link to open the help modal.
3. Check the "Don't show this again" checkbox.
4. Close the modal by clicking the X button or pressing Escape.
5. Re-open the modal — it should still appear (the dismiss was NOT triggered).
6. Check the "Don't show this again" checkbox again.
7. Click the "Got it" button.
8. Verify the modal no longer appears — the dismiss was triggered only via "Got it".
