### PR TITLE
Social: Fix SIG edit template modal not preselecting Default Image

### DIFF
--- a/projects/packages/publicize/_inc/components/unified-modal/edit-template/use-modal-screen.tsx
+++ b/projects/packages/publicize/_inc/components/unified-modal/edit-template/use-modal-screen.tsx
@@ -26,7 +26,8 @@ export function useModalScreen() {
 
 	const [ localState, setLocalState ] = useState< LocalState >( () => ( {
 		imageId: imageId ?? null,
-		imageType: ( imageType ?? 'featured' ) as LocalState[ 'imageType' ],
+		imageType: ( imageType ??
+			( defaultImageId ? 'default' : 'featured' ) ) as LocalState[ 'imageType' ],
 		customText: customText ?? '',
 		template: template ?? null,
 		font: font ?? '',

--- a/projects/packages/publicize/changelog/fix-social-sig-default-image-preselect
+++ b/projects/packages/publicize/changelog/fix-social-sig-default-image-preselect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix edit template modal not preselecting Default Image when a default image is configured


### PR DESCRIPTION
Fixes SOCIAL-431

## Proposed changes

* When a default SIG image is configured and the user opens the "Edit social image template" modal, the background image dropdown now correctly preselects "Default Image" instead of always defaulting to "Featured Image".

### Other information

The root cause was in `use-modal-screen.tsx` where `imageType` defaulted to `'featured'` when not explicitly set in post meta, ignoring the presence of a configured default image.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Go to Jetpack > Settings > Social and set a default SIG image
2. Create a new post
3. Open the Social sidebar and click "Edit social image template"
4. Verify the background image dropdown shows "Default Image" selected (not "Featured Image")
5. Verify the preview shows the default image

### Before
<img width="2594" height="1800" alt="CleanShot 2026-04-06 at 13 59 27@2x" src="https://github.com/user-attachments/assets/37389caa-1218-43a4-8a09-eaf4c4a56d62" />


### After
<img width="2656" height="1844" alt="CleanShot 2026-04-06 at 14 08 27@2x" src="https://github.com/user-attachments/assets/5b6cf604-c088-41a2-895e-b5e7fad9a74d" />
