### PR TITLE
Adding documentation_category to jetpack sync taxonomy allowlist

### DIFF
--- a/projects/packages/sync/changelog/SEARCH-128-add-woocommerce-documentation-category
+++ b/projects/packages/sync/changelog/SEARCH-128-add-woocommerce-documentation-category
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Sync: add documentation_category to taxonomy allowlist

--- a/projects/packages/sync/src/modules/class-search.php
+++ b/projects/packages/sync/src/modules/class-search.php
@@ -772,6 +772,7 @@ class Search extends Module {
 		'translation_priority',
 
 		// woocommerce.
+		'documentation_category',
 		'pa_accessory-type',
 		'pa_actor',
 		'pa_age',


### PR DESCRIPTION
woocommerce.com uses the `documentation_category` taxonomy, which we want to sync in order to provide better search of the documentation in order to improve customer support.

## Related product discussion/links
Addresses Linear Issue SEARCH-128

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
After woocommerce.com has been updated to a Jetpack release including this change, run a full sync of the terms. 
