### PR TITLE
Sidebar upsell: add "seen" event

### DIFF
--- a/projects/packages/admin-ui/src/admin-ui-upgrade-menu-tracking.js
+++ b/projects/packages/admin-ui/src/admin-ui-upgrade-menu-tracking.js
@@ -23,6 +23,33 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		window.analytics.initialize( config.tracksUserData?.userid, config.tracksUserData?.username );
 	}
 
+	const parentTopLevelMenu = item.closest(
+		'#toplevel_page_jetpack, #toplevel_page_jetpack-network'
+	);
+
+	const isParentMenuOpen =
+		parentTopLevelMenu &&
+		parentTopLevelMenu.classList.contains( 'wp-menu-open' ) &&
+		parentTopLevelMenu.classList.contains( 'wp-has-current-submenu' );
+
+	if ( isParentMenuOpen ) {
+		// Only record the "seen" event if the parent menu is open.
+		window.analytics?.tracks?.recordEvent(
+			'jetpack_sidebar_free_upgrade_seen',
+			config.tracksEventData
+		);
+	} else {
+		// Only record the "seen" event if the parent menu was opened, and record it once only.
+		const onHover = function () {
+			window.analytics?.tracks?.recordEvent(
+				'jetpack_sidebar_free_upgrade_seen',
+				config.tracksEventData
+			);
+			parentTopLevelMenu.removeEventListener( 'hover', onHover );
+		};
+		parentTopLevelMenu.addEventListener( 'hover', onHover );
+	}
+
 	item.addEventListener( 'click', function () {
 		window.analytics?.tracks?.recordEvent(
 			'jetpack_sidebar_free_upgrade_click',


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/jetpack/pull/47937

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Adds "seen" event alongside "click" event

### Other information

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Go to '..'
*
