### PR TITLE
Sidebar upsell: make event prop names lowercase

### DIFF
--- a/projects/packages/admin-ui/changelog/update-sidebar-tracks-event-props
+++ b/projects/packages/admin-ui/changelog/update-sidebar-tracks-event-props
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Comment: update Tracks event prop names to be lowercase.

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -409,9 +409,9 @@ class Admin_Menu {
 				'menuItemClass'   => self::UPGRADE_MENU_SLUG,
 				'tracksUserData'  => $tracks_user_data,
 				'tracksEventData' => array(
-					'isAdmin'       => $is_admin,
-					'currentScreen' => $current_screen ? $current_screen->id : false,
-					'blogID'        => $site_id,
+					'is_admin'       => $is_admin,
+					'current_screen' => $current_screen ? $current_screen->id : false,
+					'blog_id'        => $site_id,
 				),
 			)
 		);


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/jetpack/pull/47937

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Rename props to be lowercase to avoid rejections:

> eventname or eventprops failed "^[a-z_][a-z0-9_]*$" pattern

### Other information

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Event continues to work as before but with lowercase props
