### PR TITLE
wp-build-polyfills: Skip force-replace when Gutenberg is active

### DIFF
--- a/projects/packages/wp-build-polyfills/changelog/fix-forms-wp-build-gutenberg-active
+++ b/projects/packages/wp-build-polyfills/changelog/fix-forms-wp-build-gutenberg-active
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Skip force-replacing polyfill scripts when the Gutenberg plugin is active, preventing crashes from allowlist mismatches (e.g. @wordpress/views).

--- a/projects/packages/wp-build-polyfills/src/class-wp-build-polyfills.php
+++ b/projects/packages/wp-build-polyfills/src/class-wp-build-polyfills.php
@@ -120,21 +120,28 @@ class WP_Build_Polyfills {
 	 * @param string      $wp_version_threshold  WP version below which force-replacements apply.
 	 */
 	private static function register_scripts( $scripts, $build_dir, $base_file, $wp_version_threshold ) {
-		$force_replace = version_compare( $GLOBALS['wp_version'] ?? '0', $wp_version_threshold, '<' );
+		// Force-replace only when Core's bundled scripts are incomplete (WP < 7.0)
+		// AND Gutenberg is not active. When Gutenberg is present, its script
+		// registrations (priority 10) are always self-consistent — replacing them
+		// with our polyfills can break packages that Gutenberg ships but our
+		// polyfill's allowlist doesn't cover yet (e.g. @wordpress/views).
+		$gutenberg_active = defined( 'GUTENBERG_VERSION' );
+		$force_replace    = ! $gutenberg_active
+			&& version_compare( $GLOBALS['wp_version'] ?? '0', $wp_version_threshold, '<' );
 
 		$polyfills = array(
 			'wp-notices'      => array(
 				'path'  => 'notices',
-				// Only force-replace on older WP: older Core versions ship
-				// notices without SnackbarNotices and InlineNotices component
-				// exports that @wordpress/boot depends on.
+				// Only force-replace on older WP without Gutenberg: older Core
+				// versions ship notices without SnackbarNotices and InlineNotices
+				// component exports that @wordpress/boot depends on.
 				'force' => $force_replace,
 			),
 			'wp-private-apis' => array(
 				'path'  => 'private-apis',
-				// Only force-replace on older WP: older Core versions ship
-				// private-apis with an incomplete allowlist that rejects
-				// @wordpress/theme and @wordpress/route.
+				// Only force-replace on older WP without Gutenberg: older Core
+				// versions ship private-apis with an incomplete allowlist that
+				// rejects @wordpress/theme and @wordpress/route.
 				// Our version is a strict superset (same API, larger allowlist).
 				'force' => $force_replace,
 			),

--- a/projects/packages/wp-build-polyfills/src/class-wp-build-polyfills.php
+++ b/projects/packages/wp-build-polyfills/src/class-wp-build-polyfills.php
@@ -123,8 +123,8 @@ class WP_Build_Polyfills {
 		// Force-replace only when Core's bundled scripts are incomplete (WP < 7.0)
 		// AND Gutenberg is not active. When Gutenberg is present, its script
 		// registrations (priority 10) are always self-consistent — replacing them
-		// with our polyfills can break packages that Gutenberg ships but our
-		// polyfill's allowlist doesn't cover yet (e.g. @wordpress/views).
+		// with our polyfills can break packages that Gutenberg adds in the future while
+		// our polyfill's allowlist doesn't cover them yet.
 		$gutenberg_active = defined( 'GUTENBERG_VERSION' );
 		$force_replace    = ! $gutenberg_active
 			&& version_compare( $GLOBALS['wp_version'] ?? '0', $wp_version_threshold, '<' );


### PR DESCRIPTION

## Proposed changes

* Skip force-replacing `wp-notices` and `wp-private-apis` polyfill scripts when the Gutenberg plugin is active (`defined('GUTENBERG_VERSION')`).
* The force-replace mechanism was designed to fix incomplete scripts in WordPress Core < 7.0, but it also overwrites Gutenberg's self-consistent registrations. This can cause crashes when Gutenberg ships packages (e.g. `@wordpress/views`) that the polyfill's allowlist doesn't cover.
* Polyfills still register missing scripts via first-wins semantics when they aren't provided by either Core or Gutenberg.

### Other information

This is a complementary fix to #47905, which bumped `@wordpress/private-apis` to `^1.43.0`. That PR fixed the specific allowlist gap; this PR prevents the class of bug entirely by not overriding Gutenberg's own script registrations.

## Related product discussion/links
* Related PR: #47905
* Linear: FORMS-673

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Undo the changes of #47905 or apply the changes of this PR to the commit right before that PR, as that PR fixes the immediate issue.

1. Install and activate the Gutenberg plugin (trunk) on a WordPress < 7.0 site with Jetpack Forms.
2. Enable the wp-build Forms dashboard (`jetpack_forms_alpha` filter).
3. Navigate to the Forms dashboard in wp-admin.
4. **Before this change**: The dashboard crashes with "can't access property 'name', storeNameOrDescriptor is undefined" because the polyfill's `wp-private-apis` replaces Gutenberg's version with an incomplete allowlist.
5. **After this change**: The dashboard loads correctly — Gutenberg's `wp-private-apis` is preserved, and the polyfill only fills gaps for scripts not provided by Core or Gutenberg.
6. Also verify the dashboard works correctly **without** Gutenberg installed (polyfill should still force-replace Core's incomplete scripts on WP < 7.0).
