### PR TITLE
Garden Sites: Add garden_purge_eligible_at field to site endpoint 

### DIFF
--- a/projects/plugins/jetpack/changelog/add-garden-purge-eligible-at-field
+++ b/projects/plugins/jetpack/changelog/add-garden-purge-eligible-at-field
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Add garden_purge_eligible_at field to the site API endpoint.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -99,6 +99,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'garden_name'                 => '(string) The name of the Garden site.',
 		'garden_partner'              => '(string) The partner of the Garden site.',
 		'garden_is_provisioned'       => '(bool) If the Garden site is provisioned.',
+		'garden_purge_eligible_at'    => '(string) UTC datetime when the Garden site becomes eligible for purging.',
 		'is_wpcom_flex'               => '(bool) If the site is a Flex site',
 		'big_sky_enabled'             => '(bool) Whether the Big Sky AI assistant is enabled for this site.',
 	);
@@ -261,6 +262,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'garden_name',
 		'garden_partner',
 		'garden_is_provisioned',
+		'garden_purge_eligible_at',
 		'is_wpcom_flex',
 		'big_sky_enabled',
 	);
@@ -662,6 +664,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				break;
 			case 'garden_is_provisioned':
 				$response[ $key ] = $this->site->garden_is_provisioned();
+				break;
+			case 'garden_purge_eligible_at':
+				$response[ $key ] = $this->site->garden_purge_eligible_at();
 				break;
 			case 'is_wpcom_flex':
 				$response[ $key ] = $this->site->is_wpcom_flex();

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1746,6 +1746,15 @@ abstract class SAL_Site {
 	}
 
 	/**
+	 * Get the UTC datetime when the Garden site becomes eligible for purging.
+	 *
+	 * @return string|null
+	 */
+	public function garden_purge_eligible_at() {
+		return null;
+	}
+
+	/**
 	 * Detect whether the site is a Flex site.
 	 *
 	 * @return bool


### PR DESCRIPTION
## Proposed changes

* Add a new `garden_purge_eligible_at` field to the site endpoint, exposing the UTC datetime when a Garden site becomes eligible for purging.
* This field is used by the CIAB (Commerce in a Box) dashboard to show site owners when their site will be purged after plan expiry.
* Returns `null` for non-garden sites or when no purge countdown is active.

### Other information

This is the Jetpack-side counterpart to the wpcom changes. The actual value is stored as `garden_purge_eligible_at` blog meta on WordPress.com and read by the shadow SAL class in wpcom.
 
## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Apply this PR to your sandbox
* Call the site endpoint for a Garden site with `garden_purge_eligible_at` in the `fields` parameter: 
```
GET /rest/v1.1/sites/$site?fields=garden_purge_eligible_at
```
* For a Garden site with no purge countdown, the field should return `null`.
* For a non-garden site, the field should return `null`.
* For a Garden site with the `garden_purge_eligible_at` blog meta set, it should return the UTC datetime string.