### PR TITLE
Add full-stack E2E test infrastructure for Boost Cloud pipeline

### DIFF
--- a/projects/plugins/boost/.phan/baseline.php
+++ b/projects/plugins/boost/.phan/baseline.php
@@ -12,8 +12,8 @@ return [
     // PhanTypeArraySuspiciousNullable : 15+ occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 10+ occurrences
     // PhanTypeArraySuspicious : 9 occurrences
-    // PhanTypeMismatchArgument : 6 occurrences
     // PhanUndeclaredConstant : 5 occurrences
+    // PhanTypeMismatchArgument : 4 occurrences
     // PhanTypeMismatchReturnProbablyReal : 4 occurrences
     // PhanUndeclaredClassConstant : 4 occurrences
     // PhanUndeclaredFunction : 4 occurrences
@@ -32,7 +32,7 @@ return [
         'app/admin/class-config.php' => ['PhanTypeMismatchArgument'],
         'app/data-sync/class-minify-excludes-state-entry.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'app/data-sync/class-performance-history-entry.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspicious'],
-        'app/lib/class-cli.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument'],
+        'app/lib/class-cli.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'app/lib/critical-css/class-critical-css-state.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeArraySuspiciousNullable'],
         'app/lib/minify/class-concatenate-css.php' => ['PhanPluginUseReturnValueInternalKnown', 'PhanTypeMismatchArgument'],
         'app/lib/minify/class-concatenate-js.php' => ['PhanPluginUseReturnValueInternalKnown', 'PhanTypeMismatchArgument'],

--- a/projects/plugins/boost/app/lib/class-cli.php
+++ b/projects/plugins/boost/app/lib/class-cli.php
@@ -28,7 +28,7 @@ class CLI {
 	 */
 	private $jetpack_boost;
 
-	const MAKE_E2E_TESTS_WORK_MODULES = array( 'critical_css', 'speculation_rules', 'render_blocking_js', 'page_cache', 'lcp', 'minify_js', 'minify_css', 'image_cdn', 'image_guide' );
+	const MAKE_E2E_TESTS_WORK_MODULES = array( 'critical_css', 'cloud_css', 'speculation_rules', 'render_blocking_js', 'page_cache', 'lcp', 'minify_js', 'minify_css', 'image_cdn', 'image_guide' );
 
 	/**
 	 * CLI constructor.
@@ -123,6 +123,10 @@ class CLI {
 		}
 
 		$module->update( $status );
+
+		// Fire the same action that the DataSync REST path fires (Modules_State_Entry::set),
+		// so CLI activation triggers module hooks like Cloud_CSS::activate() → Regenerate::start().
+		do_action( 'jetpack_boost_module_status_updated', $module_slug, $status );
 
 		if ( $module_slug === 'page_cache' && $status ) {
 			$setup_result = Page_Cache_Setup::run_setup();

--- a/projects/plugins/boost/app/lib/class-cli.php
+++ b/projects/plugins/boost/app/lib/class-cli.php
@@ -110,7 +110,7 @@ class CLI {
 	 * Set a module status.
 	 *
 	 * @param string $module_slug Module slug.
-	 * @param string $status      Module status.
+	 * @param bool   $status      Module status.
 	 */
 	private function set_module_status( $module_slug, $status ) {
 		$modules = ( new Modules_Setup() )->get_available_modules_and_submodules();

--- a/projects/plugins/boost/app/lib/class-cli.php
+++ b/projects/plugins/boost/app/lib/class-cli.php
@@ -122,11 +122,14 @@ class CLI {
 			);
 		}
 
-		$module->update( $status );
+		$updated = $module->update( $status );
 
 		// Fire the same action that the DataSync REST path fires (Modules_State_Entry::set),
 		// so CLI activation triggers module hooks like Cloud_CSS::activate() → Regenerate::start().
-		do_action( 'jetpack_boost_module_status_updated', $module_slug, $status );
+		// Only fire when the status actually changed, matching the DataSync guard.
+		if ( $updated ) {
+			do_action( 'jetpack_boost_module_status_updated', $module_slug, $status );
+		}
 
 		if ( $module_slug === 'page_cache' && $status ) {
 			$setup_result = Page_Cache_Setup::run_setup();

--- a/projects/plugins/boost/app/lib/class-cli.php
+++ b/projects/plugins/boost/app/lib/class-cli.php
@@ -149,10 +149,17 @@ class CLI {
 
 		$status_label = $status ? __( 'activated', 'jetpack-boost' ) : __( 'deactivated', 'jetpack-boost' );
 
-		/* translators: The %1$s refers to the module slug, %2$s refers to the module state (either activated or deactivated)*/
-		\WP_CLI::success(
-			sprintf( __( "'%1\$s' has been %2\$s.", 'jetpack-boost' ), $module_slug, $status_label )
-		);
+		if ( $updated ) {
+			/* translators: The %1$s refers to the module slug, %2$s refers to the module state (either activated or deactivated)*/
+			\WP_CLI::success(
+				sprintf( __( "'%1\$s' has been %2\$s.", 'jetpack-boost' ), $module_slug, $status_label )
+			);
+		} else {
+			/* translators: The %1$s refers to the module slug, %2$s refers to the module state (either activated or deactivated)*/
+			\WP_CLI::warning(
+				sprintf( __( "'%1\$s' was already %2\$s.", 'jetpack-boost' ), $module_slug, $status_label )
+			);
+		}
 	}
 
 	/**

--- a/projects/plugins/boost/changelog/add-boost-full-stack-e2e-infrastructure
+++ b/projects/plugins/boost/changelog/add-boost-full-stack-e2e-infrastructure
@@ -1,3 +1,3 @@
 Significance: patch
 Type: added
-Comment: Add full-stack E2E test infrastructure for the Boost Cloud pipeline.
+Comment: Add full-stack E2E test infrastructure for the Boost Cloud pipeline. Fix WP-CLI module activation not triggering side-effect hooks (e.g., Cloud CSS regeneration).

--- a/projects/plugins/boost/changelog/add-boost-full-stack-e2e-infrastructure
+++ b/projects/plugins/boost/changelog/add-boost-full-stack-e2e-infrastructure
@@ -1,0 +1,3 @@
+Significance: patch
+Type: added
+Comment: Add full-stack E2E test infrastructure for the Boost Cloud pipeline.

--- a/projects/plugins/boost/changelog/add-boost-full-stack-e2e-infrastructure
+++ b/projects/plugins/boost/changelog/add-boost-full-stack-e2e-infrastructure
@@ -1,3 +1,4 @@
 Significance: patch
-Type: added
-Comment: Add full-stack E2E test infrastructure for the Boost Cloud pipeline. Fix WP-CLI module activation not triggering side-effect hooks (e.g., Cloud CSS regeneration).
+Type: fixed
+
+Fix WP-CLI module activation not triggering side-effect hooks (e.g., Cloud CSS regeneration). Add full-stack E2E test infrastructure for the Boost Cloud pipeline.

--- a/projects/plugins/boost/tests/e2e/.gitignore
+++ b/projects/plugins/boost/tests/e2e/.gitignore
@@ -6,4 +6,5 @@ plan-data.txt
 e2e_tunnels.txt
 jetpack-private-options.txt
 /allure-results
+/.state
 storage.json

--- a/projects/plugins/boost/tests/e2e/lib/fixtures/full-stack-test.ts
+++ b/projects/plugins/boost/tests/e2e/lib/fixtures/full-stack-test.ts
@@ -12,11 +12,7 @@
 
 import { test as baseTest, expect } from '_jetpack-e2e-commons/fixtures/base-test';
 import JetpackBoostPage from '../pages/jetpack-boost-page';
-import {
-	FullStackUtils,
-	activateBoostModuleDev,
-	deactivateBoostModuleDev,
-} from '../utils/full-stack-utils';
+import { FullStackUtils } from '../utils/full-stack-utils';
 
 const test = baseTest.extend<
 	{ jetpackBoostPage: JetpackBoostPage },
@@ -51,4 +47,4 @@ test.afterEach( async ( { fullStackUtils }, testInfo ) => {
 	}
 } );
 
-export { test, expect, activateBoostModuleDev, deactivateBoostModuleDev };
+export { test, expect };

--- a/projects/plugins/boost/tests/e2e/lib/fixtures/full-stack-test.ts
+++ b/projects/plugins/boost/tests/e2e/lib/fixtures/full-stack-test.ts
@@ -19,6 +19,8 @@ const test = baseTest.extend<
 	{ fullStackUtils: FullStackUtils }
 >( {
 	jetpackBoostPage: async ( { page }, use ) => {
+		// Log uncaught page errors — base-test.ts provides this via its extended page fixture,
+		// but we add it explicitly since full-stack tests may not always extend base-test.
 		page.on( 'pageerror', exception => {
 			console.error( `Page error: "${ exception }"` );
 		} );

--- a/projects/plugins/boost/tests/e2e/lib/fixtures/full-stack-test.ts
+++ b/projects/plugins/boost/tests/e2e/lib/fixtures/full-stack-test.ts
@@ -21,6 +21,9 @@ const test = baseTest.extend<
 	jetpackBoostPage: async ( { page }, use ) => {
 		await use( new JetpackBoostPage( page ) );
 	},
+	// Worker-scoped: one instance shared across all tests in a worker.
+	// Full-stack specs must use test.describe.serial because the shared Docker
+	// environment (dev WordPress, Redis, boost-cloud) cannot handle concurrent tests.
 	fullStackUtils: [
 		async ( {}, use ) => {
 			await use( new FullStackUtils() );

--- a/projects/plugins/boost/tests/e2e/lib/fixtures/full-stack-test.ts
+++ b/projects/plugins/boost/tests/e2e/lib/fixtures/full-stack-test.ts
@@ -1,0 +1,54 @@
+/**
+ * Playwright fixture for full-stack Boost E2E tests.
+ *
+ * Extends base-test from e2e-commons. The inherited beforeEach/afterEach hooks
+ * (WPCOM request counting) target the e2e container — harmless overhead when
+ * that container is running, which it typically is during local dev.
+ *
+ * Provides:
+ * - fullStackUtils (worker-scoped): Docker, Redis, WP-CLI operations against dev container
+ * - jetpackBoostPage (test-scoped): Boost admin page object
+ */
+
+import { test as baseTest, expect } from '_jetpack-e2e-commons/fixtures/base-test';
+import JetpackBoostPage from '../pages/jetpack-boost-page';
+import {
+	FullStackUtils,
+	activateBoostModuleDev,
+	deactivateBoostModuleDev,
+} from '../utils/full-stack-utils';
+
+const test = baseTest.extend<
+	{ jetpackBoostPage: JetpackBoostPage },
+	{ fullStackUtils: FullStackUtils }
+>( {
+	jetpackBoostPage: async ( { page }, use ) => {
+		page.on( 'pageerror', exception => {
+			console.error( `Page error: "${ exception }"` );
+		} );
+		await use( new JetpackBoostPage( page ) );
+	},
+	fullStackUtils: [
+		async ( {}, use ) => {
+			await use( new FullStackUtils() );
+		},
+		{ scope: 'worker' },
+	],
+} );
+
+// Capture Docker logs on test failure for post-mortem debugging in the Playwright HTML report.
+test.afterEach( async ( { fullStackUtils }, testInfo ) => {
+	if ( testInfo.status !== testInfo.expectedStatus ) {
+		try {
+			const logs = await fullStackUtils.captureDockerLogs();
+			await testInfo.attach( 'docker-logs', {
+				body: logs,
+				contentType: 'text/plain',
+			} );
+		} catch {
+			// Don't mask the real test failure
+		}
+	}
+} );
+
+export { test, expect, activateBoostModuleDev, deactivateBoostModuleDev };

--- a/projects/plugins/boost/tests/e2e/lib/fixtures/full-stack-test.ts
+++ b/projects/plugins/boost/tests/e2e/lib/fixtures/full-stack-test.ts
@@ -19,11 +19,6 @@ const test = baseTest.extend<
 	{ fullStackUtils: FullStackUtils }
 >( {
 	jetpackBoostPage: async ( { page }, use ) => {
-		// Log uncaught page errors — base-test.ts provides this via its extended page fixture,
-		// but we add it explicitly since full-stack tests may not always extend base-test.
-		page.on( 'pageerror', exception => {
-			console.error( `Page error: "${ exception }"` );
-		} );
 		await use( new JetpackBoostPage( page ) );
 	},
 	fullStackUtils: [

--- a/projects/plugins/boost/tests/e2e/lib/full-stack-global-setup.ts
+++ b/projects/plugins/boost/tests/e2e/lib/full-stack-global-setup.ts
@@ -10,7 +10,7 @@
 
 import { execFile } from 'child_process';
 import { mkdirSync, existsSync } from 'fs';
-import { dirname } from 'path';
+import { dirname, join } from 'path';
 import { promisify } from 'util';
 import { test as setup, expect } from '@playwright/test';
 import { getDevDomain, executeDevWpCommand } from './utils/full-stack-utils';
@@ -28,6 +28,7 @@ async function execDocker( args: string[] ): Promise< string > {
 	return stdout + stderr;
 }
 
+// Keep in sync with storageState path in playwright.config.ts fullStackProjects.
 const STORAGE_STATE_PATH = join(
 	dirname( new URL( import.meta.url ).pathname ),
 	'..',
@@ -182,5 +183,3 @@ setup( 'full-stack environment health check', async ( { request } ) => {
 		await request.storageState( { path: STORAGE_STATE_PATH } );
 	} );
 } );
-
-export { STORAGE_STATE_PATH };

--- a/projects/plugins/boost/tests/e2e/lib/full-stack-global-setup.ts
+++ b/projects/plugins/boost/tests/e2e/lib/full-stack-global-setup.ts
@@ -1,0 +1,216 @@
+/**
+ * Full-stack E2E test setup project.
+ *
+ * Performs health-check gates to verify the full-stack environment is ready,
+ * then authenticates against the dev WordPress and saves storage state.
+ *
+ * This file is referenced as a Playwright setup project in playwright.config.ts
+ * and runs before any full-stack test specs.
+ */
+
+import { execFile } from 'child_process';
+import { readFileSync, mkdirSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { promisify } from 'util';
+import { test as setup, expect } from '@playwright/test';
+import { executeCommand } from '_jetpack-e2e-commons/utils/cli';
+
+const execFileAsync = promisify( execFile );
+
+/**
+ * Read DEV_DOMAIN from the boost-cloud .env file.
+ *
+ * @return {string} The dev domain, or 'jetpack-boost.test' as fallback.
+ */
+function getDevDomain(): string {
+	const dir = process.env.BOOST_CLOUD_DIR!;
+	try {
+		const envContent = readFileSync( join( dir, '.env' ), 'utf8' );
+		const match = envContent.match( /^DEV_DOMAIN=(.+)$/m );
+		return match?.[ 1 ] ?? 'jetpack-boost.test';
+	} catch {
+		return 'jetpack-boost.test';
+	}
+}
+
+/**
+ * Execute a WP-CLI command against the dev WordPress container.
+ *
+ * @param  command - WP-CLI command string or argument array.
+ * @return {Promise<string>} Command stdout.
+ */
+async function executeDevWpCommand( command: string | string[] ): Promise< string > {
+	const devDomain = getDevDomain();
+	const base = [ 'pnpm', 'jetpack', 'docker', 'wp', '--', `--url=http://${ devDomain }` ];
+	if ( Array.isArray( command ) ) {
+		return executeCommand( [ ...base, ...command ] );
+	}
+	return executeCommand( [ ...base, ...command.trim().split( /\s+/ ) ] );
+}
+
+/**
+ * Execute a Docker CLI command via child_process.execFile.
+ *
+ * @param  args - Arguments passed to the docker CLI.
+ * @return {Promise<string>} Combined stdout and stderr.
+ */
+async function execDocker( args: string[] ): Promise< string > {
+	const { stdout, stderr } = await execFileAsync( 'docker', args, { timeout: 30_000 } );
+	return stdout + stderr;
+}
+
+const STORAGE_STATE_PATH = join(
+	dirname( new URL( import.meta.url ).pathname ),
+	'..',
+	'.state',
+	'full-stack-storage-state.json'
+);
+
+setup( 'full-stack environment health check', async ( { request } ) => {
+	const boostCloudDir = process.env.BOOST_CLOUD_DIR!;
+	const devDomain = getDevDomain();
+
+	// Gate 1: BOOST_CLOUD_DIR is valid
+	await setup.step( 'BOOST_CLOUD_DIR has docker-compose.yml', () => {
+		expect(
+			existsSync( join( boostCloudDir, 'docker-compose.yml' ) ),
+			`docker-compose.yml not found at ${ boostCloudDir }`
+		).toBe( true );
+	} );
+
+	// Gate 2: WordPress is alive
+	await setup.step( 'WordPress is reachable', async () => {
+		const response = await request.get( `http://${ devDomain }/`, {
+			maxRedirects: 0,
+			failOnStatusCode: false,
+		} );
+		expect(
+			[ 200, 301, 302 ],
+			`WordPress at http://${ devDomain }/ returned ${ response.status() }`
+		).toContain( response.status() );
+	} );
+
+	// Gate 3: Shield API is healthy
+	await setup.step( 'Shield API is healthy', async () => {
+		let healthy = false;
+		for ( let attempt = 0; attempt < 6; attempt++ ) {
+			try {
+				const response = await fetch( 'http://localhost:1982/v2/health' );
+				const body = ( await response.json() ) as { status: string };
+				// eslint-disable-next-line playwright/no-conditional-in-test
+				if ( body.status === 'ok' ) {
+					healthy = true;
+					break;
+				}
+			} catch {
+				// Shield may be starting up
+			}
+			await new Promise( resolve => setTimeout( resolve, 5_000 ) );
+		}
+		expect( healthy, 'Shield health check at localhost:1982/v2/health did not return ok' ).toBe(
+			true
+		);
+	} );
+
+	// Gate 4: Redis is reachable
+	await setup.step( 'Redis is reachable', async () => {
+		const output = await execDocker( [
+			'compose',
+			'-f',
+			`${ boostCloudDir }/docker-compose.yml`,
+			'exec',
+			'-T',
+			'redis',
+			'redis-cli',
+			'ping',
+		] );
+		expect( output, 'Redis did not respond with PONG' ).toContain( 'PONG' );
+	} );
+
+	// Gate 5: Hydra can reach WordPress
+	await setup.step( 'Hydra can reach WordPress', async () => {
+		const output = await execDocker( [
+			'compose',
+			'-f',
+			`${ boostCloudDir }/docker-compose.yml`,
+			'exec',
+			'-T',
+			'boost-hydra-css',
+			'curl',
+			'-s',
+			'-o',
+			'/dev/null',
+			'-w',
+			'%{http_code}',
+			`http://${ devDomain }/`,
+		] );
+		const httpCode = parseInt( output.trim(), 10 );
+		expect(
+			[ 200, 301, 302 ],
+			`Hydra got HTTP ${ httpCode } reaching http://${ devDomain }/`
+		).toContain( httpCode );
+	} );
+
+	// Gate 6: boost-developer plugin is active
+	await setup.step( 'boost-developer plugin is active', async () => {
+		const output = await executeDevWpCommand( 'plugin list --status=active --format=json' );
+		const plugins = JSON.parse( output.trim() ) as Array< { name: string } >;
+		const names = plugins.map( p => p.name );
+		expect( names, 'boost-developer plugin is not active' ).toContain( 'boost-developer' );
+	} );
+
+	// Gate 7: No debug-critical-css-providers.php mu-plugin
+	await setup.step( 'debug-critical-css-providers mu-plugin is not present', async () => {
+		const output = await executeDevWpCommand(
+			"eval \"echo file_exists(WPMU_PLUGIN_DIR . '/debug-critical-css-providers.php') ? 'EXISTS' : 'NOT_FOUND';\""
+		);
+		expect(
+			output.trim(),
+			'debug-critical-css-providers.php is present in mu-plugins. ' +
+				'This file hardcodes external CSS provider URLs (wincityvoices.org), ' +
+				'causing Hydra to generate CSS for the wrong site. ' +
+				'Remove it: rm tools/docker/mu-plugins/debug-critical-css-providers.php'
+		).toContain( 'NOT_FOUND' );
+	} );
+
+	// Gate 8: Flush Redis to clear stale BullMQ jobs from interrupted prior runs
+	await setup.step( 'Flush Redis', async () => {
+		await execDocker( [
+			'compose',
+			'-f',
+			`${ boostCloudDir }/docker-compose.yml`,
+			'exec',
+			'-T',
+			'redis',
+			'redis-cli',
+			'FLUSHALL',
+		] );
+	} );
+
+	// Gate 9: Authenticate against dev WordPress and save storage state
+	await setup.step( 'Authenticate against dev WordPress', async () => {
+		const loginResponse = await request.post( `http://${ devDomain }/wp-login.php`, {
+			form: {
+				log: 'jp_docker_acct',
+				pwd: 'jp_docker_pass',
+				rememberme: 'forever',
+				'wp-submit': 'Log In',
+				redirect_to: `http://${ devDomain }/wp-admin/`,
+			},
+		} );
+		expect(
+			loginResponse.ok() || loginResponse.status() === 302,
+			`Login failed with status ${ loginResponse.status() }`
+		).toBe( true );
+
+		// Save storage state for the full-stack test project
+		const stateDir = dirname( STORAGE_STATE_PATH );
+		// eslint-disable-next-line playwright/no-conditional-in-test
+		if ( ! existsSync( stateDir ) ) {
+			mkdirSync( stateDir, { recursive: true } );
+		}
+		await request.storageState( { path: STORAGE_STATE_PATH } );
+	} );
+} );
+
+export { STORAGE_STATE_PATH };

--- a/projects/plugins/boost/tests/e2e/lib/full-stack-global-setup.ts
+++ b/projects/plugins/boost/tests/e2e/lib/full-stack-global-setup.ts
@@ -65,7 +65,9 @@ setup( 'full-stack environment health check', async ( { request } ) => {
 		let healthy = false;
 		for ( let attempt = 0; attempt < 6; attempt++ ) {
 			try {
-				const response = await fetch( 'http://localhost:1982/v2/health' );
+				const response = await fetch( 'http://localhost:1982/v2/health', {
+					signal: AbortSignal.timeout( 5_000 ),
+				} );
 				const body = ( await response.json() ) as { status: string };
 				// eslint-disable-next-line playwright/no-conditional-in-test
 				if ( body.status === 'ok' ) {

--- a/projects/plugins/boost/tests/e2e/lib/full-stack-global-setup.ts
+++ b/projects/plugins/boost/tests/e2e/lib/full-stack-global-setup.ts
@@ -10,6 +10,7 @@
 
 import { mkdirSync, existsSync } from 'fs';
 import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
 import { test as setup, expect } from '@playwright/test';
 import {
 	getDevDomain,
@@ -20,7 +21,7 @@ import {
 
 // Keep in sync with storageState path in playwright.config.ts fullStackProjects.
 const STORAGE_STATE_PATH = join(
-	dirname( new URL( import.meta.url ).pathname ),
+	dirname( fileURLToPath( import.meta.url ) ),
 	'..',
 	'.state',
 	'full-stack-storage-state.json'
@@ -165,6 +166,14 @@ setup( 'full-stack environment health check', async ( { request } ) => {
 			loginResponse.ok() || loginResponse.status() === 302,
 			`Login failed with status ${ loginResponse.status() }`
 		).toBe( true );
+
+		// Verify authentication by requesting an admin page — a 200 with the login
+		// form would be a false positive from the POST above.
+		const adminResponse = await request.get( `http://${ devDomain }/wp-admin/profile.php` );
+		expect(
+			adminResponse.url(),
+			'Authentication failed: admin request was redirected to the login page'
+		).not.toContain( 'wp-login.php' );
 
 		// Save storage state for the full-stack test project
 		const stateDir = dirname( STORAGE_STATE_PATH );

--- a/projects/plugins/boost/tests/e2e/lib/full-stack-global-setup.ts
+++ b/projects/plugins/boost/tests/e2e/lib/full-stack-global-setup.ts
@@ -8,25 +8,15 @@
  * and runs before any full-stack test specs.
  */
 
-import { execFile } from 'child_process';
 import { mkdirSync, existsSync } from 'fs';
 import { dirname, join } from 'path';
-import { promisify } from 'util';
 import { test as setup, expect } from '@playwright/test';
-import { getDevDomain, executeDevWpCommand } from './utils/full-stack-utils';
-
-const execFileAsync = promisify( execFile );
-
-/**
- * Execute a Docker CLI command via child_process.execFile.
- *
- * @param  args - Arguments passed to the docker CLI.
- * @return {Promise<string>} Combined stdout and stderr.
- */
-async function execDocker( args: string[] ): Promise< string > {
-	const { stdout, stderr } = await execFileAsync( 'docker', args, { timeout: 30_000 } );
-	return stdout + stderr;
-}
+import {
+	getDevDomain,
+	executeDevWpCommand,
+	execDocker,
+	flushRedis,
+} from './utils/full-stack-utils';
 
 // Keep in sync with storageState path in playwright.config.ts fullStackProjects.
 const STORAGE_STATE_PATH = join(
@@ -146,16 +136,7 @@ setup( 'full-stack environment health check', async ( { request } ) => {
 
 	// Gate 8: Flush Redis to clear stale BullMQ jobs from interrupted prior runs
 	await setup.step( 'Flush Redis', async () => {
-		await execDocker( [
-			'compose',
-			'-f',
-			`${ boostCloudDir }/docker-compose.yml`,
-			'exec',
-			'-T',
-			'redis',
-			'redis-cli',
-			'FLUSHALL',
-		] );
+		await flushRedis( boostCloudDir );
 	} );
 
 	// Gate 9: Authenticate against dev WordPress and save storage state

--- a/projects/plugins/boost/tests/e2e/lib/full-stack-global-setup.ts
+++ b/projects/plugins/boost/tests/e2e/lib/full-stack-global-setup.ts
@@ -57,7 +57,9 @@ setup( 'full-stack environment health check', async ( { request } ) => {
 		).toContain( response.status() );
 	} );
 
-	// Gate 3: Shield API is healthy
+	// Gate 3: Shield API is healthy.
+	// Uses localhost:1982 (host-side port mapping) — not boost-shield:1982 (Docker-internal).
+	// BOOST_DEV_DEFAULTS.shield_url uses the Docker hostname for container-to-container routing.
 	await setup.step( 'Shield API is healthy', async () => {
 		let healthy = false;
 		for ( let attempt = 0; attempt < 6; attempt++ ) {
@@ -111,8 +113,9 @@ setup( 'full-stack environment health check', async ( { request } ) => {
 			'%{http_code}',
 			`http://${ devDomain }/`,
 		] );
-		// Parse last line only — Docker Compose may emit stderr warnings before stdout.
-		const httpCode = parseInt( output.trim().split( '\n' ).pop() ?? '', 10 );
+		// Extract 3-digit HTTP status code — execDocker concatenates stdout+stderr,
+		// so Docker Compose warnings may surround curl's status code output.
+		const httpCode = parseInt( output.match( /\b[1-5]\d{2}\b/ )?.[ 0 ] ?? '', 10 );
 		expect(
 			[ 200, 301, 302 ],
 			`Hydra got HTTP ${ httpCode } reaching http://${ devDomain }/`

--- a/projects/plugins/boost/tests/e2e/lib/full-stack-global-setup.ts
+++ b/projects/plugins/boost/tests/e2e/lib/full-stack-global-setup.ts
@@ -9,44 +9,13 @@
  */
 
 import { execFile } from 'child_process';
-import { readFileSync, mkdirSync, existsSync } from 'fs';
-import { join, dirname } from 'path';
+import { mkdirSync, existsSync } from 'fs';
+import { dirname } from 'path';
 import { promisify } from 'util';
 import { test as setup, expect } from '@playwright/test';
-import { executeCommand } from '_jetpack-e2e-commons/utils/cli';
+import { getDevDomain, executeDevWpCommand } from './utils/full-stack-utils';
 
 const execFileAsync = promisify( execFile );
-
-/**
- * Read DEV_DOMAIN from the boost-cloud .env file.
- *
- * @return {string} The dev domain, or 'jetpack-boost.test' as fallback.
- */
-function getDevDomain(): string {
-	const dir = process.env.BOOST_CLOUD_DIR!;
-	try {
-		const envContent = readFileSync( join( dir, '.env' ), 'utf8' );
-		const match = envContent.match( /^DEV_DOMAIN=(.+)$/m );
-		return match?.[ 1 ] ?? 'jetpack-boost.test';
-	} catch {
-		return 'jetpack-boost.test';
-	}
-}
-
-/**
- * Execute a WP-CLI command against the dev WordPress container.
- *
- * @param  command - WP-CLI command string or argument array.
- * @return {Promise<string>} Command stdout.
- */
-async function executeDevWpCommand( command: string | string[] ): Promise< string > {
-	const devDomain = getDevDomain();
-	const base = [ 'pnpm', 'jetpack', 'docker', 'wp', '--', `--url=http://${ devDomain }` ];
-	if ( Array.isArray( command ) ) {
-		return executeCommand( [ ...base, ...command ] );
-	}
-	return executeCommand( [ ...base, ...command.trim().split( /\s+/ ) ] );
-}
 
 /**
  * Execute a Docker CLI command via child_process.execFile.
@@ -161,9 +130,10 @@ setup( 'full-stack environment health check', async ( { request } ) => {
 
 	// Gate 7: No debug-critical-css-providers.php mu-plugin
 	await setup.step( 'debug-critical-css-providers mu-plugin is not present', async () => {
-		const output = await executeDevWpCommand(
-			"eval \"echo file_exists(WPMU_PLUGIN_DIR . '/debug-critical-css-providers.php') ? 'EXISTS' : 'NOT_FOUND';\""
-		);
+		const output = await executeDevWpCommand( [
+			'eval',
+			"echo file_exists(WPMU_PLUGIN_DIR . '/debug-critical-css-providers.php') ? 'EXISTS' : 'NOT_FOUND';",
+		] );
 		expect(
 			output.trim(),
 			'debug-critical-css-providers.php is present in mu-plugins. ' +

--- a/projects/plugins/boost/tests/e2e/lib/full-stack-global-setup.ts
+++ b/projects/plugins/boost/tests/e2e/lib/full-stack-global-setup.ts
@@ -118,7 +118,12 @@ setup( 'full-stack environment health check', async ( { request } ) => {
 		] );
 		// Extract 3-digit HTTP status code — execDocker concatenates stdout+stderr,
 		// so Docker Compose warnings may surround curl's status code output.
-		const httpCode = parseInt( output.match( /\b[1-5]\d{2}\b/ )?.[ 0 ] ?? '', 10 );
+		const match = output.match( /\b[1-5]\d{2}\b/ );
+		expect(
+			match,
+			`No HTTP status code found in Docker output: ${ output.slice( 0, 200 ) }`
+		).not.toBeNull();
+		const httpCode = parseInt( match![ 0 ], 10 );
 		expect(
 			[ 200, 301, 302 ],
 			`Hydra got HTTP ${ httpCode } reaching http://${ devDomain }/`

--- a/projects/plugins/boost/tests/e2e/lib/full-stack-global-setup.ts
+++ b/projects/plugins/boost/tests/e2e/lib/full-stack-global-setup.ts
@@ -27,7 +27,14 @@ const STORAGE_STATE_PATH = join(
 );
 
 setup( 'full-stack environment health check', async ( { request } ) => {
-	const boostCloudDir = process.env.BOOST_CLOUD_DIR!;
+	const boostCloudDir = process.env.BOOST_CLOUD_DIR;
+	// eslint-disable-next-line playwright/no-conditional-in-test
+	if ( ! boostCloudDir ) {
+		throw new Error(
+			'BOOST_CLOUD_DIR environment variable is required. ' +
+				'Set it to the path of your boost-cloud repository.'
+		);
+	}
 	const devDomain = getDevDomain();
 
 	// Gate 1: BOOST_CLOUD_DIR is valid
@@ -104,7 +111,8 @@ setup( 'full-stack environment health check', async ( { request } ) => {
 			'%{http_code}',
 			`http://${ devDomain }/`,
 		] );
-		const httpCode = parseInt( output.trim(), 10 );
+		// Parse last line only — Docker Compose may emit stderr warnings before stdout.
+		const httpCode = parseInt( output.trim().split( '\n' ).pop() ?? '', 10 );
 		expect(
 			[ 200, 301, 302 ],
 			`Hydra got HTTP ${ httpCode } reaching http://${ devDomain }/`

--- a/projects/plugins/boost/tests/e2e/lib/utils/full-stack-utils.ts
+++ b/projects/plugins/boost/tests/e2e/lib/utils/full-stack-utils.ts
@@ -70,7 +70,9 @@ export function getDevDomain(): string {
  * Passes --url to ensure home_url() returns the correct domain instead of http://localhost
  * (wp-config.php:99 sets WP_HOME='http://localhost' when HTTP_HOST is empty in Docker).
  *
- * Always uses array form to preserve JSON arguments containing spaces.
+ * **Use array form for commands with spaces in arguments** (JSON values, `wp eval` code, etc.).
+ * The string form splits on whitespace, matching the e2e-commons `executeCommand` convention,
+ * but will break quoted/space-containing args.
  *
  * @param  command - WP-CLI command string or argument array.
  * @return {Promise<string>} Command stdout.

--- a/projects/plugins/boost/tests/e2e/lib/utils/full-stack-utils.ts
+++ b/projects/plugins/boost/tests/e2e/lib/utils/full-stack-utils.ts
@@ -57,7 +57,7 @@ export function getDevDomain(): string {
 	try {
 		const envContent = readFileSync( join( dir, '.env' ), 'utf8' );
 		const match = envContent.match( /^DEV_DOMAIN=(.+)$/m );
-		return match?.[ 1 ] ?? 'jetpack-boost.test';
+		return match?.[ 1 ]?.trim() ?? 'jetpack-boost.test';
 	} catch {
 		return 'jetpack-boost.test';
 	}
@@ -226,16 +226,6 @@ export class FullStackUtils {
 				`Last state: ${ lastState }. ` +
 				`Docker logs:\n${ logs.slice( 0, 2000 ) }`
 		);
-	}
-
-	/**
-	 * Check Shield API health.
-	 *
-	 * @return {Promise<{status: string}>} Health response object.
-	 */
-	async getShieldHealth(): Promise< { status: string } > {
-		const response = await fetch( 'http://localhost:1982/v2/health' );
-		return ( await response.json() ) as { status: string };
 	}
 
 	/**

--- a/projects/plugins/boost/tests/e2e/lib/utils/full-stack-utils.ts
+++ b/projects/plugins/boost/tests/e2e/lib/utils/full-stack-utils.ts
@@ -188,8 +188,9 @@ export class FullStackUtils {
 			await executeDevWpCommand(
 				'plugin deactivate e2e-mock-boost-connection e2e-mock-speed-score-api e2e-mock-premium-features'
 			);
-		} catch {
-			// Ignore errors if plugins are not installed
+		} catch ( error ) {
+			// Expected when mock plugins are not installed; log other errors for debugging.
+			console.debug( 'Mock plugin deactivation (non-fatal):', String( error ) );
 		}
 
 		// Write all 19 boost_dev keys with correct defaults

--- a/projects/plugins/boost/tests/e2e/lib/utils/full-stack-utils.ts
+++ b/projects/plugins/boost/tests/e2e/lib/utils/full-stack-utils.ts
@@ -57,7 +57,7 @@ export function getDevDomain(): string {
 	try {
 		const envContent = readFileSync( join( dir, '.env' ), 'utf8' );
 		const match = envContent.match( /^DEV_DOMAIN=(.+)$/m );
-		return match?.[ 1 ]?.trim() ?? 'jetpack-boost.test';
+		return match?.[ 1 ]?.trim().replace( /^["']|["']$/g, '' ) ?? 'jetpack-boost.test';
 	} catch {
 		return 'jetpack-boost.test';
 	}
@@ -97,6 +97,54 @@ export async function executeDevJetpackBoostCommand(
 		return executeDevWpCommand( [ 'jetpack-boost', ...command ] );
 	}
 	return executeDevWpCommand( `jetpack-boost ${ command }` );
+}
+
+/**
+ * Execute a Docker CLI command via child_process.execFile.
+ * Uses execFile directly because the e2e-commons executeCommand allowlist
+ * (wp, pnpm, sh) does not include docker. execFile is safe against
+ * shell injection (no shell expansion).
+ *
+ * @param  args - Arguments passed to the docker CLI.
+ * @return {Promise<string>} Combined stdout and stderr.
+ */
+export async function execDocker( args: string[] ): Promise< string > {
+	try {
+		const { stdout, stderr } = await execFileAsync( 'docker', args, {
+			timeout: 30_000,
+		} );
+		return stdout + stderr;
+	} catch ( error ) {
+		const msg = String( error );
+		if ( msg.includes( 'ENOENT' ) ) {
+			throw new Error( 'Docker not found. Is Docker installed and in your PATH?' );
+		}
+		if ( msg.includes( 'Cannot connect' ) || msg.includes( 'connect ECONNREFUSED' ) ) {
+			throw new Error(
+				'Docker daemon is not running. Start Docker Desktop or the Docker service.'
+			);
+		}
+		throw error;
+	}
+}
+
+/**
+ * Flush all Redis data in the boost-cloud Docker stack.
+ * Clears BullMQ job queues and dedup locks.
+ *
+ * @param boostCloudDir - Path to the boost-cloud repository.
+ */
+export async function flushRedis( boostCloudDir: string ): Promise< void > {
+	await execDocker( [
+		'compose',
+		'-f',
+		`${ boostCloudDir }/docker-compose.yml`,
+		'exec',
+		'-T',
+		'redis',
+		'redis-cli',
+		'FLUSHALL',
+	] );
 }
 
 /**
@@ -159,19 +207,9 @@ export class FullStackUtils {
 
 	/**
 	 * Flush all Redis data. Clears BullMQ job queues and dedup locks.
-	 * Uses -T flag to disable pseudo-TTY allocation (avoids TTY bug from cloud.sh).
 	 */
 	async flushRedis(): Promise< void > {
-		await this.execDocker( [
-			'compose',
-			'-f',
-			`${ this.boostCloudDir }/docker-compose.yml`,
-			'exec',
-			'-T',
-			'redis',
-			'redis-cli',
-			'FLUSHALL',
-		] );
+		await flushRedis( this.boostCloudDir );
 	}
 
 	/**
@@ -254,7 +292,7 @@ export class FullStackUtils {
 	 * @return {Promise<string>} Combined stdout and stderr from the log tail.
 	 */
 	async captureDockerLogs(): Promise< string > {
-		return this.execDocker( [
+		return execDocker( [
 			'compose',
 			'-f',
 			`${ this.boostCloudDir }/docker-compose.yml`,
@@ -286,40 +324,6 @@ export class FullStackUtils {
 		const moduleArray = Array.isArray( modules ) ? modules : [ modules ];
 		for ( const mod of moduleArray ) {
 			await executeDevJetpackBoostCommand( `module deactivate ${ mod }` );
-		}
-	}
-
-	/**
-	 * Single point for all Docker command execution.
-	 * Uses child_process.execFile directly because the e2e-commons executeCommand
-	 * allowlist (wp, pnpm, sh) does not include docker.
-	 * execFile is safe against shell injection (no shell expansion).
-	 *
-	 * @param  args - Arguments passed to the docker CLI.
-	 * @return {Promise<string>} Combined stdout and stderr.
-	 */
-	private async execDocker( args: string[] ): Promise< string > {
-		try {
-			const { stdout, stderr } = await execFileAsync( 'docker', args, {
-				timeout: 30_000,
-			} );
-			return stdout + stderr;
-		} catch ( error ) {
-			const msg = String( error );
-			if ( msg.includes( 'ENOENT' ) ) {
-				throw new Error( 'Docker not found. Is Docker installed and in your PATH?' );
-			}
-			if ( msg.includes( 'Cannot connect' ) || msg.includes( 'connect ECONNREFUSED' ) ) {
-				throw new Error(
-					'Docker daemon is not running. Start Docker Desktop or the Docker service.'
-				);
-			}
-			if ( msg.includes( 'is not running' ) ) {
-				throw new Error(
-					`boost-cloud Docker is not running. Start it with: cd ${ this.boostCloudDir } && docker compose up -d`
-				);
-			}
-			throw error;
 		}
 	}
 }

--- a/projects/plugins/boost/tests/e2e/lib/utils/full-stack-utils.ts
+++ b/projects/plugins/boost/tests/e2e/lib/utils/full-stack-utils.ts
@@ -100,30 +100,6 @@ export async function executeDevJetpackBoostCommand(
 }
 
 /**
- * Activate one or more Boost modules on the dev WordPress container.
- *
- * @param modules - Module slug(s) to activate.
- */
-export async function activateBoostModuleDev( modules: string | string[] ): Promise< void > {
-	const moduleArray = Array.isArray( modules ) ? modules : [ modules ];
-	for ( const mod of moduleArray ) {
-		await executeDevJetpackBoostCommand( `module activate ${ mod }` );
-	}
-}
-
-/**
- * Deactivate one or more Boost modules on the dev WordPress container.
- *
- * @param modules - Module slug(s) to deactivate.
- */
-export async function deactivateBoostModuleDev( modules: string | string[] ): Promise< void > {
-	const moduleArray = Array.isArray( modules ) ? modules : [ modules ];
-	for ( const mod of moduleArray ) {
-		await executeDevJetpackBoostCommand( `module deactivate ${ mod }` );
-	}
-}
-
-/**
  * Full-stack test utilities class.
  * Worker-scoped in the Playwright fixture (one instance per worker).
  */
@@ -297,6 +273,30 @@ export class FullStackUtils {
 			'boost-shield',
 			'boost-hydra-css',
 		] );
+	}
+
+	/**
+	 * Activate one or more Boost modules on the dev WordPress container.
+	 *
+	 * @param modules - Module slug(s) to activate.
+	 */
+	async activateModule( modules: string | string[] ): Promise< void > {
+		const moduleArray = Array.isArray( modules ) ? modules : [ modules ];
+		for ( const mod of moduleArray ) {
+			await executeDevJetpackBoostCommand( `module activate ${ mod }` );
+		}
+	}
+
+	/**
+	 * Deactivate one or more Boost modules on the dev WordPress container.
+	 *
+	 * @param modules - Module slug(s) to deactivate.
+	 */
+	async deactivateModule( modules: string | string[] ): Promise< void > {
+		const moduleArray = Array.isArray( modules ) ? modules : [ modules ];
+		for ( const mod of moduleArray ) {
+			await executeDevJetpackBoostCommand( `module deactivate ${ mod }` );
+		}
 	}
 
 	/**

--- a/projects/plugins/boost/tests/e2e/lib/utils/full-stack-utils.ts
+++ b/projects/plugins/boost/tests/e2e/lib/utils/full-stack-utils.ts
@@ -1,0 +1,335 @@
+/**
+ * Full-stack test utilities for Jetpack Boost.
+ *
+ * Provides Docker-aware operations, WP-CLI polling, and Redis management
+ * for full-stack E2E tests that exercise the complete cloud pipeline
+ * (WordPress → Shield → Redis → Hydra → callback).
+ *
+ * Targets the dev WordPress container (not e2e) because boost-cloud services
+ * run on the jetpack_dev_default Docker network.
+ */
+
+import { execFile } from 'child_process';
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { promisify } from 'util';
+import { executeCommand } from '_jetpack-e2e-commons/utils/cli';
+
+const execFileAsync = promisify( execFile );
+
+/**
+ * All 19 keys from boost-developer.php:50-69.
+ * boost_dev_get() sets any missing key to `false` (not the default) when the option exists,
+ * so ALL keys must be present. Missing `local_shield` = false breaks Shield routing.
+ */
+export const BOOST_DEV_DEFAULTS: Record< string, string | number | boolean > = {
+	cornerstone_pages_plan: 'default',
+	css_mode: 'default',
+	local_shield: 'on',
+	shield_url: 'http://boost-shield:1982',
+	client_id: 'boost-plugin',
+	client_secret: 'plugin-secret',
+	skip_check: false,
+	force_error: 'none',
+	docker_urls: false,
+	mobile_score: 80,
+	desktop_score: 90,
+	fake_speed_score: 'off',
+	datasync_debug: 'off',
+	site_url: '',
+	custom_site_url: '',
+	wpcom_token: '',
+	proxy_host: '',
+	proxy_port: '',
+	lcp_element: '',
+};
+
+/**
+ * Read DEV_DOMAIN from the boost-cloud .env file.
+ *
+ * @return {string} The dev domain, or 'jetpack-boost.test' as fallback.
+ */
+export function getDevDomain(): string {
+	const dir = process.env.BOOST_CLOUD_DIR;
+	if ( ! dir ) {
+		return 'jetpack-boost.test';
+	}
+	try {
+		const envContent = readFileSync( join( dir, '.env' ), 'utf8' );
+		const match = envContent.match( /^DEV_DOMAIN=(.+)$/m );
+		return match?.[ 1 ] ?? 'jetpack-boost.test';
+	} catch {
+		return 'jetpack-boost.test';
+	}
+}
+
+/**
+ * Execute a WP-CLI command against the dev WordPress container.
+ *
+ * Uses `pnpm jetpack docker wp --` (no --type e2e --name t1) to target the dev container.
+ * Passes --url to ensure home_url() returns the correct domain instead of http://localhost
+ * (wp-config.php:99 sets WP_HOME='http://localhost' when HTTP_HOST is empty in Docker).
+ *
+ * Always uses array form to preserve JSON arguments containing spaces.
+ *
+ * @param  command - WP-CLI command string or argument array.
+ * @return {Promise<string>} Command stdout.
+ */
+export async function executeDevWpCommand( command: string | string[] ): Promise< string > {
+	const devDomain = getDevDomain();
+	const base = [ 'pnpm', 'jetpack', 'docker', 'wp', '--', `--url=http://${ devDomain }` ];
+	if ( Array.isArray( command ) ) {
+		return executeCommand( [ ...base, ...command ] );
+	}
+	return executeCommand( [ ...base, ...command.trim().split( /\s+/ ) ] );
+}
+
+/**
+ * Execute a Jetpack Boost CLI command against the dev WordPress container.
+ *
+ * @param  command - Boost CLI subcommand string or argument array.
+ * @return {Promise<string>} Command stdout.
+ */
+export async function executeDevJetpackBoostCommand(
+	command: string | string[]
+): Promise< string > {
+	if ( Array.isArray( command ) ) {
+		return executeDevWpCommand( [ 'jetpack-boost', ...command ] );
+	}
+	return executeDevWpCommand( `jetpack-boost ${ command }` );
+}
+
+/**
+ * Activate one or more Boost modules on the dev WordPress container.
+ *
+ * @param modules - Module slug(s) to activate.
+ */
+export async function activateBoostModuleDev( modules: string | string[] ): Promise< void > {
+	const moduleArray = Array.isArray( modules ) ? modules : [ modules ];
+	for ( const mod of moduleArray ) {
+		await executeDevJetpackBoostCommand( `module activate ${ mod }` );
+	}
+}
+
+/**
+ * Deactivate one or more Boost modules on the dev WordPress container.
+ *
+ * @param modules - Module slug(s) to deactivate.
+ */
+export async function deactivateBoostModuleDev( modules: string | string[] ): Promise< void > {
+	const moduleArray = Array.isArray( modules ) ? modules : [ modules ];
+	for ( const mod of moduleArray ) {
+		await executeDevJetpackBoostCommand( `module deactivate ${ mod }` );
+	}
+}
+
+/**
+ * Full-stack test utilities class.
+ * Worker-scoped in the Playwright fixture (one instance per worker).
+ */
+export class FullStackUtils {
+	private boostCloudDir: string;
+
+	constructor() {
+		const dir = process.env.BOOST_CLOUD_DIR;
+		if ( ! dir ) {
+			throw new Error(
+				'BOOST_CLOUD_DIR environment variable is required. ' +
+					'Set it to the path of your boost-cloud repository.'
+			);
+		}
+		if ( ! existsSync( join( dir, 'docker-compose.yml' ) ) ) {
+			throw new Error(
+				`BOOST_CLOUD_DIR is set to '${ dir }' but docker-compose.yml was not found there.`
+			);
+		}
+		this.boostCloudDir = dir;
+	}
+
+	/**
+	 * Reset the full-stack environment to a clean state.
+	 *
+	 * wp jetpack-boost reset is a FULL UNINSTALL: deletes all jetpack_boost_% options via SQL,
+	 * clears CSS storage posts, and removes transients. boost_dev survives (no jetpack_boost_ prefix).
+	 */
+	async resetFullStackEnvironment(): Promise< void > {
+		// Full reset (uninstall + deactivate)
+		await executeDevWpCommand( 'jetpack-boost reset' );
+
+		// Ensure both plugins are active
+		await executeDevWpCommand( 'plugin activate jetpack-boost boost-developer' );
+
+		// Deactivate mock plugins that may be left from prior e2e test runs
+		try {
+			await executeDevWpCommand(
+				'plugin deactivate e2e-mock-boost-connection e2e-mock-speed-score-api e2e-mock-premium-features'
+			);
+		} catch {
+			// Ignore errors if plugins are not installed
+		}
+
+		// Write all 19 boost_dev keys with correct defaults
+		await executeDevWpCommand( [
+			'option',
+			'update',
+			'boost_dev',
+			JSON.stringify( BOOST_DEV_DEFAULTS ),
+			'--format=json',
+		] );
+
+		// Clear Redis to prevent BullMQ dedup hangs from stale jobs
+		await this.flushRedis();
+	}
+
+	/**
+	 * Flush all Redis data. Clears BullMQ job queues and dedup locks.
+	 * Uses -T flag to disable pseudo-TTY allocation (avoids TTY bug from cloud.sh).
+	 */
+	async flushRedis(): Promise< void > {
+		await this.execDocker( [
+			'compose',
+			'-f',
+			`${ this.boostCloudDir }/docker-compose.yml`,
+			'exec',
+			'-T',
+			'redis',
+			'redis-cli',
+			'FLUSHALL',
+		] );
+	}
+
+	/**
+	 * Poll WP-CLI for Critical CSS generation completion.
+	 *
+	 * Option: jetpack_boost_ds_critical_css_state (wp-js-data-sync.php:17 + class-critical-css.php:92)
+	 * States: not_generated → pending → generated | error (class-critical-css-state.php:9-14)
+	 *
+	 * @param timeout - Maximum wait time in milliseconds.
+	 */
+	async waitForCssGeneration( timeout = 120_000 ): Promise< void > {
+		const pollInterval = 5_000;
+		const start = Date.now();
+		let lastState = 'unknown';
+
+		while ( Date.now() - start < timeout ) {
+			try {
+				const output = await executeDevWpCommand(
+					'option get jetpack_boost_ds_critical_css_state --format=json'
+				);
+				const state = JSON.parse( output.trim() );
+				lastState = JSON.stringify( state );
+
+				if ( state?.status === 'generated' ) {
+					return;
+				}
+
+				if ( state?.status === 'error' ) {
+					const errorMsg = state?.status_error ?? 'Unknown error';
+					throw new Error( `CSS generation failed: ${ errorMsg }` );
+				}
+			} catch ( error ) {
+				if ( error instanceof Error && error.message.startsWith( 'CSS generation failed' ) ) {
+					throw error;
+				}
+				// Option may not exist yet, keep polling
+			}
+
+			await new Promise( resolve => setTimeout( resolve, pollInterval ) );
+		}
+
+		// Timeout — capture diagnostics
+		let logs = '';
+		try {
+			logs = await this.captureDockerLogs();
+		} catch {
+			// Best effort
+		}
+
+		throw new Error(
+			`CSS generation timed out after ${ timeout / 1000 }s. ` +
+				`Last state: ${ lastState }. ` +
+				`Docker logs:\n${ logs.slice( 0, 2000 ) }`
+		);
+	}
+
+	/**
+	 * Check Shield API health.
+	 *
+	 * @return {Promise<{status: string}>} Health response object.
+	 */
+	async getShieldHealth(): Promise< { status: string } > {
+		const response = await fetch( 'http://localhost:1982/v2/health' );
+		return ( await response.json() ) as { status: string };
+	}
+
+	/**
+	 * Update a single key in the boost_dev WordPress option.
+	 *
+	 * @param key   - Option key within the boost_dev object.
+	 * @param value - New value for the key.
+	 */
+	async setBoostDevOption( key: string, value: unknown ): Promise< void > {
+		const output = await executeDevWpCommand( 'option get boost_dev --format=json' );
+		const current = JSON.parse( output.trim() );
+		current[ key ] = value;
+		await executeDevWpCommand( [
+			'option',
+			'update',
+			'boost_dev',
+			JSON.stringify( current ),
+			'--format=json',
+		] );
+	}
+
+	/**
+	 * Capture recent Docker logs from Shield and Hydra CSS services.
+	 * Wrapped in error handling to avoid masking real test failures.
+	 *
+	 * @return {Promise<string>} Combined stdout and stderr from the log tail.
+	 */
+	async captureDockerLogs(): Promise< string > {
+		return this.execDocker( [
+			'compose',
+			'-f',
+			`${ this.boostCloudDir }/docker-compose.yml`,
+			'logs',
+			'--tail=200',
+			'boost-shield',
+			'boost-hydra-css',
+		] );
+	}
+
+	/**
+	 * Single point for all Docker command execution.
+	 * Uses child_process.execFile directly because the e2e-commons executeCommand
+	 * allowlist (wp, pnpm, sh) does not include docker.
+	 * execFile is safe against shell injection (no shell expansion).
+	 *
+	 * @param  args - Arguments passed to the docker CLI.
+	 * @return {Promise<string>} Combined stdout and stderr.
+	 */
+	private async execDocker( args: string[] ): Promise< string > {
+		try {
+			const { stdout, stderr } = await execFileAsync( 'docker', args, {
+				timeout: 30_000,
+			} );
+			return stdout + stderr;
+		} catch ( error ) {
+			const msg = String( error );
+			if ( msg.includes( 'ENOENT' ) ) {
+				throw new Error( 'Docker not found. Is Docker installed and in your PATH?' );
+			}
+			if ( msg.includes( 'Cannot connect' ) || msg.includes( 'connect ECONNREFUSED' ) ) {
+				throw new Error(
+					'Docker daemon is not running. Start Docker Desktop or the Docker service.'
+				);
+			}
+			if ( msg.includes( 'is not running' ) ) {
+				throw new Error(
+					`boost-cloud Docker is not running. Start it with: cd ${ this.boostCloudDir } && docker compose up -d`
+				);
+			}
+			throw error;
+		}
+	}
+}

--- a/projects/plugins/boost/tests/e2e/playwright.config.ts
+++ b/projects/plugins/boost/tests/e2e/playwright.config.ts
@@ -5,6 +5,9 @@ import baseConfig, { setupProjects } from '_jetpack-e2e-commons/playwright.confi
  * Read DEV_DOMAIN from the boost-cloud .env file for full-stack test baseURL.
  * Falls back to 'jetpack-boost.test' if BOOST_CLOUD_DIR is not set or .env is unreadable.
  *
+ * Intentionally duplicated from lib/utils/full-stack-utils.ts to avoid pulling
+ * test utility imports into config evaluation.
+ *
  * @return {string} The dev domain, or 'jetpack-boost.test' as fallback.
  */
 function getDevDomain(): string {
@@ -14,7 +17,7 @@ function getDevDomain(): string {
 	}
 	try {
 		const env = readFileSync( `${ dir }/.env`, 'utf8' );
-		return env.match( /^DEV_DOMAIN=(.+)$/m )?.[ 1 ] ?? 'jetpack-boost.test';
+		return env.match( /^DEV_DOMAIN=(.+)$/m )?.[ 1 ]?.trim() ?? 'jetpack-boost.test';
 	} catch {
 		return 'jetpack-boost.test';
 	}
@@ -38,6 +41,7 @@ const fullStackProjects = process.env.BOOST_CLOUD_DIR
 				dependencies: [ 'full-stack setup' ],
 				use: {
 					baseURL: `http://${ getDevDomain() }`,
+					// Keep in sync with STORAGE_STATE_PATH in lib/full-stack-global-setup.ts.
 					storageState: '.state/full-stack-storage-state.json',
 				},
 			},

--- a/projects/plugins/boost/tests/e2e/playwright.config.ts
+++ b/projects/plugins/boost/tests/e2e/playwright.config.ts
@@ -1,4 +1,48 @@
+import { readFileSync } from 'fs';
 import baseConfig, { setupProjects } from '_jetpack-e2e-commons/playwright.config.default';
+
+/**
+ * Read DEV_DOMAIN from the boost-cloud .env file for full-stack test baseURL.
+ * Falls back to 'jetpack-boost.test' if BOOST_CLOUD_DIR is not set or .env is unreadable.
+ *
+ * @return {string} The dev domain, or 'jetpack-boost.test' as fallback.
+ */
+function getDevDomain(): string {
+	const dir = process.env.BOOST_CLOUD_DIR;
+	if ( ! dir ) {
+		return 'jetpack-boost.test';
+	}
+	try {
+		const env = readFileSync( `${ dir }/.env`, 'utf8' );
+		return env.match( /^DEV_DOMAIN=(.+)$/m )?.[ 1 ] ?? 'jetpack-boost.test';
+	} catch {
+		return 'jetpack-boost.test';
+	}
+}
+
+// Full-stack projects are only registered when BOOST_CLOUD_DIR is set.
+// Playwright treats skipped setup projects as successful, so dependent projects
+// would still run and fail — conditional registration is the only safe approach.
+const fullStackProjects = process.env.BOOST_CLOUD_DIR
+	? [
+			{
+				name: 'full-stack setup',
+				testDir: './lib',
+				testMatch: 'full-stack-global-setup.ts',
+				dependencies: [ 'environment check' ],
+				storageState: undefined as undefined,
+			},
+			{
+				name: 'full-stack',
+				testMatch: '**/specs/full-stack/**',
+				dependencies: [ 'full-stack setup' ],
+				use: {
+					baseURL: `http://${ getDevDomain() }`,
+					storageState: '.state/full-stack-storage-state.json',
+				},
+			},
+	  ]
+	: [];
 
 export default {
 	...baseConfig,
@@ -11,7 +55,9 @@ export default {
 		{
 			name: 'jetpack boost e2e',
 			testMatch: '**/specs/**',
+			testIgnore: '**/specs/full-stack/**',
 			dependencies: [ 'global authentication' ],
 		},
+		...fullStackProjects,
 	],
 };

--- a/projects/plugins/boost/tests/e2e/playwright.config.ts
+++ b/projects/plugins/boost/tests/e2e/playwright.config.ts
@@ -17,7 +17,12 @@ function getDevDomain(): string {
 	}
 	try {
 		const env = readFileSync( `${ dir }/.env`, 'utf8' );
-		return env.match( /^DEV_DOMAIN=(.+)$/m )?.[ 1 ]?.trim() ?? 'jetpack-boost.test';
+		return (
+			env
+				.match( /^DEV_DOMAIN=(.+)$/m )?.[ 1 ]
+				?.trim()
+				.replace( /^["']|["']$/g, '' ) ?? 'jetpack-boost.test'
+		);
 	} catch {
 		return 'jetpack-boost.test';
 	}

--- a/projects/plugins/boost/tests/e2e/playwright.config.ts
+++ b/projects/plugins/boost/tests/e2e/playwright.config.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs';
+import { join } from 'path';
 import baseConfig, { setupProjects } from '_jetpack-e2e-commons/playwright.config.default';
 
 /**
@@ -16,7 +17,7 @@ function getDevDomain(): string {
 		return 'jetpack-boost.test';
 	}
 	try {
-		const env = readFileSync( `${ dir }/.env`, 'utf8' );
+		const env = readFileSync( join( dir, '.env' ), 'utf8' );
 		return (
 			env
 				.match( /^DEV_DOMAIN=(.+)$/m )?.[ 1 ]
@@ -44,6 +45,9 @@ const fullStackProjects = process.env.BOOST_CLOUD_DIR
 				name: 'full-stack',
 				testMatch: '**/specs/full-stack/**',
 				dependencies: [ 'full-stack setup' ],
+				// Force single worker — full-stack tests mutate shared state
+				// (dev WordPress, boost-cloud Redis) and cannot run in parallel.
+				workers: 1,
 				use: {
 					baseURL: `http://${ getDevDomain() }`,
 					// Keep in sync with STORAGE_STATE_PATH in lib/full-stack-global-setup.ts.

--- a/projects/plugins/boost/tests/e2e/specs/full-stack/critical-css.test.ts
+++ b/projects/plugins/boost/tests/e2e/specs/full-stack/critical-css.test.ts
@@ -7,7 +7,7 @@
  * Requires: Jetpack dev Docker + boost-cloud Docker + boost-developer plugin
  */
 
-import { test, expect, activateBoostModuleDev } from '../../lib/fixtures/full-stack-test';
+import { test, expect } from '../../lib/fixtures/full-stack-test';
 
 test.describe.serial( 'Full-stack Critical CSS generation', () => {
 	test.beforeAll( async ( { fullStackUtils } ) => {
@@ -18,9 +18,9 @@ test.describe.serial( 'Full-stack Critical CSS generation', () => {
 		await fullStackUtils.setBoostDevOption( 'css_mode', 'cloud' );
 
 		// Activating cloud_css triggers Cloud_CSS::activate() → Regenerate::start()
-		// via the jetpack_boost_module_status_updated action (added in Step 0b).
+		// via the jetpack_boost_module_status_updated action in the CLI.
 		// This sends a CSS generation request to Shield immediately.
-		await activateBoostModuleDev( 'cloud_css' );
+		await fullStackUtils.activateModule( 'cloud_css' );
 	} );
 
 	test( 'generates Critical CSS via Shield and Hydra', async ( {

--- a/projects/plugins/boost/tests/e2e/specs/full-stack/critical-css.test.ts
+++ b/projects/plugins/boost/tests/e2e/specs/full-stack/critical-css.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Full-stack Critical CSS generation test.
+ *
+ * Exercises the complete cloud pipeline:
+ * WordPress → Shield → Redis → Hydra (Chromium) → callback → WordPress
+ *
+ * Requires: Jetpack dev Docker + boost-cloud Docker + boost-developer plugin
+ */
+
+import { test, expect, activateBoostModuleDev } from '../../lib/fixtures/full-stack-test';
+
+test.describe.serial( 'Full-stack Critical CSS generation', () => {
+	test.beforeAll( async ( { fullStackUtils } ) => {
+		await fullStackUtils.resetFullStackEnvironment();
+
+		// Set cloud CSS mode so boost-developer enables the cloud-critical-css feature
+		// (Actions.php adds jetpack_boost_has_feature_cloud-critical-css filter when css_mode === 'cloud')
+		await fullStackUtils.setBoostDevOption( 'css_mode', 'cloud' );
+
+		// Activating cloud_css triggers Cloud_CSS::activate() → Regenerate::start()
+		// via the jetpack_boost_module_status_updated action (added in Step 0b).
+		// This sends a CSS generation request to Shield immediately.
+		await activateBoostModuleDev( 'cloud_css' );
+	} );
+
+	test( 'generates Critical CSS via Shield and Hydra', async ( {
+		fullStackUtils,
+		jetpackBoostPage,
+		page,
+	} ) => {
+		// Poll WP-CLI for CSS generation completion.
+		// Option: jetpack_boost_ds_critical_css_state (wp-js-data-sync.php:17 + class-critical-css.php:92)
+		// States: not_generated → pending → generated | error (class-critical-css-state.php:9-14)
+		await fullStackUtils.waitForCssGeneration( 120_000 );
+
+		// Verify the admin UI shows generation metadata.
+		// Test ID: data-testid="critical-css-meta" (status/status.tsx:59)
+		await jetpackBoostPage.visit();
+		await expect( page.getByTestId( 'critical-css-meta' ) ).toBeVisible( {
+			timeout: 30_000,
+		} );
+	} );
+
+	test( 'Critical CSS is present on the frontend', async ( { page } ) => {
+		await page.goto( '/' );
+
+		// Selector: <style id="jetpack-boost-critical-css"> (class-display-critical-css.php:108)
+		const styles = page.locator( '#jetpack-boost-critical-css' );
+		await expect( styles ).toBeAttached();
+
+		// textContent() preferred over innerText() for <style> elements (no layout reflow)
+		const content = await styles.textContent();
+		expect( content?.length ?? 0 ).toBeGreaterThan( 50 );
+	} );
+} );


### PR DESCRIPTION
Fixes AIE-95

## Proposed changes

* Add Playwright full-stack test infrastructure that exercises the complete Boost Cloud pipeline (WordPress → Shield → Redis → Hydra → callback) against the local dev Docker environment
* Create `FullStackUtils` class with Docker-aware helpers: `executeDevWpCommand` (targets dev container with `--url` flag), `flushRedis`, `waitForCssGeneration` (WP-CLI polling), `captureDockerLogs` (attached to Playwright report on failure)
* Create `full-stack-test.ts` fixture extending `base-test` from e2e-commons
* Create `full-stack-global-setup.ts` setup project with 9 gates: config validation, WordPress/Shield/Redis/Hydra health checks, boost-developer verification, debug mu-plugin guard,  Redis flush, and dev WordPress authentication
* Modify `playwright.config.ts`: add `testIgnore` for full-stack specs on existing project, conditionally register `full-stack setup` and `full-stack` projects when `BOOST_CLOUD_DIR` is set, per-project `baseURL` read from boost-cloud `.env`
* Add Critical CSS smoke test (`specs/full-stack/critical-css.test.ts`) that validates CSS generation through Shield+Hydra and checks frontend output
* Add `cloud_css` to CLI module allowlist in `class-cli.php`
* Fire `jetpack_boost_module_status_updated` action in CLI `set_module_status()` so CLI module activation triggers the same hooks as the DataSync REST path (e.g., `Cloud_CSS::activate()` → `Regenerate::start()`)

### Other information

* Full-stack tests target the **dev WordPress container** (not e2e) because boost-cloud services run on `jetpack_dev_default` Docker network — the e2e container is on a separate network where `boost-shield:1982` DNS does not resolve
* All WP-CLI commands pass `--url=http://${DEV_DOMAIN}` because inside Docker `$_SERVER["HTTP_HOST"]` is empty and `wp-config.php` defaults `WP_HOME` to `http://localhost`, which Hydra containers cannot reach
* The `do_action` addition in `class-cli.php` is a behavioral change: previously CLI `module activate` only wrote the option, now it also fires the module status hook. This aligns CLI behavior with the DataSync REST path and is required for Cloud CSS generation to trigger via CLI

## Related product discussion/links

* [Linear Solver project](https://linear.app/a8c/project/linear-solver-cf0046867fa0)
* [AIE-95](https://linear.app/a8c/issue/AIE-95/add-full-stack-e2e-test-infrastructure-for-the-boost-cloud-pipeline)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

### Prerequisites
All three local environments must be running:
1. Jetpack dev Docker: `pnpm jetpack docker up -d` (from monorepo root)
2. boost-cloud Docker: `docker compose up -d` (from boost-cloud repo)
3. boost-developer plugin installed and active in dev WordPress (via `setup-boost-local`)

### Run full-stack tests
* `cd projects/plugins/boost/tests/e2e`
* `BOOST_CLOUD_DIR=/path/to/boost-cloud npx playwright test --project=full-stack`
* Verify the Playwright HTML report shows:
  * `full-stack setup` project: all 9 gates pass (health checks + auth)
  * `full-stack` project: both Critical CSS tests pass (generation + frontend check)

### Verify existing tests are unaffected
* `npx playwright test --project="jetpack boost e2e"` (without `BOOST_CLOUD_DIR`)
* Existing mock-based tests should pass normally — `testIgnore` prevents them from picking up `specs/full-stack/`

### Verify CLI `do_action` change
* `pnpm jetpack docker wp -- jetpack-boost module activate cloud_css --url=http://jetpack-boost.test` (with boost-developer `css_mode: cloud`)
* Verify CSS generation starts (check `wp option get jetpack_boost_ds_critical_css_state --format=json` shows `pending` → `generated`)