### PR TITLE
Forms: Validate field type format in get_field_type_icon

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-icon-field-type-validation
+++ b/projects/packages/forms/changelog/fix-forms-icon-field-type-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Validate the field type before resolving the block icon path.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1743,6 +1743,13 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @return string The SVG icon HTML.
 	 */
 	private static function get_field_type_icon( $field_type ) {
+		// Reject field types that don't fit the expected 'field-{type}' naming
+		// convention. Valid types are non-empty strings of lowercase letters,
+		// digits, and hyphens starting with a letter.
+		if ( ! is_string( $field_type ) || ! preg_match( '/^[a-z][a-z0-9-]*$/', $field_type ) ) {
+			return '';
+		}
+
 		// Map field types that don't follow the 'field-{type}' naming convention.
 		static $type_exceptions = array(
 			'phone'             => 'field-telephone',

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -4096,4 +4096,135 @@ class Contact_Form_Test extends BaseTestCase {
 		$this->assertContains( 'jetpack-contact-form-container', $classes_array );
 		$this->assertContains( 'alignwide', $classes_array );
 	}
+
+	/**
+	 * Test that get_field_type_icon rejects field types that don't match the
+	 * required format (lowercase letter prefix, then lowercase letters, digits,
+	 * or hyphens).
+	 *
+	 * @dataProvider data_provider_get_field_type_icon_invalid
+	 *
+	 * @param mixed  $field_type  The field type to test.
+	 * @param string $description Human-readable description of the case.
+	 */
+	#[DataProvider( 'data_provider_get_field_type_icon_invalid' )]
+	public function test_get_field_type_icon_rejects_invalid_field_type_format( $field_type, $description ) {
+		$reflection = new \ReflectionClass( Contact_Form::class );
+		$method     = $reflection->getMethod( 'get_field_type_icon' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$result = $method->invoke( null, $field_type );
+
+		$this->assertSame( '', $result, $description );
+	}
+
+	/**
+	 * Data provider for invalid field type format cases.
+	 *
+	 * @return array[]
+	 */
+	public static function data_provider_get_field_type_icon_invalid() {
+		return array(
+			'contains parent directory segment' => array(
+				'../../../../etc/passwd',
+				'Field type containing ../ should be rejected',
+			),
+			'contains url-encoded path segment' => array(
+				'..%2F..%2Fetc%2Fpasswd',
+				'Field type with url-encoded path segment should be rejected',
+			),
+			'contains backslash path segment'   => array(
+				'..\\..\\windows\\system32',
+				'Field type with backslash path segment should be rejected',
+			),
+			'leading slash'                     => array(
+				'/etc/passwd',
+				'Field type beginning with a forward slash should be rejected',
+			),
+			'contains null byte'                => array(
+				"text\0.svg",
+				'Field type with embedded null byte should be rejected',
+			),
+			'uppercase letters'                 => array(
+				'TEXT',
+				'Uppercase field type should be rejected (strict format)',
+			),
+			'starts with digit'                 => array(
+				'1text',
+				'Field type starting with digit should be rejected',
+			),
+			'starts with hyphen'                => array(
+				'-text',
+				'Field type starting with hyphen should be rejected',
+			),
+			'contains space'                    => array(
+				'text field',
+				'Field type with space should be rejected',
+			),
+			'non-string array'                  => array(
+				array( 'text' ),
+				'Array field type should be rejected',
+			),
+			'non-string integer'                => array(
+				123,
+				'Integer field type should be rejected',
+			),
+			'non-string null'                   => array(
+				null,
+				'Null field type should be rejected',
+			),
+			'empty string'                      => array(
+				'',
+				'Empty field type should be rejected',
+			),
+		);
+	}
+
+	/**
+	 * Test that get_field_type_icon returns valid SVG markup for known field types.
+	 *
+	 * Companion to test_get_field_type_icon_rejects_invalid_field_type_format —
+	 * ensures the format check does not break legitimate field types.
+	 *
+	 * @dataProvider data_provider_get_field_type_icon_valid
+	 *
+	 * @param string $field_type The valid field type to test.
+	 */
+	#[DataProvider( 'data_provider_get_field_type_icon_valid' )]
+	public function test_get_field_type_icon_accepts_valid_types( $field_type ) {
+		$reflection = new \ReflectionClass( Contact_Form::class );
+		$method     = $reflection->getMethod( 'get_field_type_icon' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$result = $method->invoke( null, $field_type );
+
+		// Valid field types either return SVG markup (when the icon file exists)
+		// or an empty string (when the block directory exists but has no icon.svg yet).
+		$this->assertIsString( $result, "Field type '$field_type' should return a string" );
+		if ( $result !== '' ) {
+			$this->assertStringContainsString( '<svg', $result, "Field type '$field_type' should return SVG markup" );
+		}
+	}
+
+	/**
+	 * Data provider for valid field type acceptance test cases.
+	 *
+	 * @return array[]
+	 */
+	public static function data_provider_get_field_type_icon_valid() {
+		return array(
+			'text'                           => array( 'text' ),
+			'email'                          => array( 'email' ),
+			'textarea'                       => array( 'textarea' ),
+			'phone (via exception map)'      => array( 'phone' ),
+			'telephone (via exception map)'  => array( 'telephone' ),
+			'radio (via exception map)'      => array( 'radio' ),
+			'checkbox-multiple (hyphenated)' => array( 'checkbox-multiple' ),
+			'image-select (hyphenated)'      => array( 'image-select' ),
+		);
+	}
 }


### PR DESCRIPTION
Fixes FORMS-656

## Proposed changes

`Contact_Form::get_field_type_icon()` builds a filesystem path from the `$field_type` value before reading the corresponding `icon.svg` file. The helper trusted whatever the caller passed in, so a non-conforming `$field_type` could yield an unexpected file lookup. While the existing `/icon.svg` suffix on the path significantly limits any practical impact (only files literally named `icon.svg` can ever be read, and the standard set of those in WordPress are public block/plugin icons), the absence of input validation on a value that drives a filesystem call is still worth tightening as a hardening / code-quality improvement.

The fix is a strict format check at the top of the helper:

```php
if ( ! is_string( $field_type ) || ! preg_match( '/^[a-z][a-z0-9-]*$/', $field_type ) ) {
    return '';
}
```

Valid types are non-empty strings of lowercase letters, digits, and hyphens, starting with a letter. Anything else returns the same empty string the helper already returns when an icon file is missing, so caller flow is unchanged for legitimate types.

Why a regex format check vs. a hardcoded allowlist:
- No filesystem I/O (vs. globbing `blocks/field-*` to build a runtime list)
- No maintenance burden (vs. a hardcoded list that needs updating every time a new field type is added)
- Catches the value at the boundary where it enters typed code, which is the right place to enforce a format invariant

### Other information

- [x] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable?

## Related product discussion/links

* N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Apply this branch and build the forms package.
2. Run the new tests:
   ```
   cd projects/packages/forms
   vendor/bin/phpunit -c phpunit.11.xml.dist tests/php/contact-form/Contact_Form_Test.php --filter='get_field_type_icon'
   ```
   Expect 21 passing tests covering both rejected formats (parent-path tokens, percent-encoded segments, backslashes, leading slash, null bytes, uppercase letters, leading digit, leading hyphen, whitespace, non-string types, empty string) and accepted formats (text, email, textarea, phone, telephone, radio, checkbox-multiple, image-select).
3. Manual sanity check: in a Forms-enabled WP install, edit a form block in the editor and verify icon rendering still works for the standard field types in the inserter and the success-summary view. The standard field types and their hyphenated exception-map entries (`phone`, `telephone`, `radio`, `checkbox-multiple`) should all render their icons identically to before.
