### PR TITLE
Forms: Guard phone field rendering against non-string values

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-phone-field-input-validation
+++ b/projects/packages/forms/changelog/fix-forms-phone-field-input-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Handle non-string values in the phone field rendering pipeline.

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -264,6 +264,12 @@ class Feedback_Field {
 	 * @return string Phone number with country flag prefix.
 	 */
 	private function get_phone_value_with_flag() {
+		// Field values arrive as `mixed` (per the constructor); short-circuit
+		// to an empty string for non-string values.
+		if ( ! is_string( $this->value ) ) {
+			return '';
+		}
+
 		if ( empty( $this->value ) ) {
 			return $this->value;
 		}
@@ -523,11 +529,13 @@ class Feedback_Field {
 	 * @return string HTML with tel: link.
 	 */
 	private function render_email_phone() {
-		if ( empty( $this->value ) ) {
+		// Guard against non-string values for the same reason as
+		// get_phone_value_with_flag().
+		if ( ! is_string( $this->value ) || empty( $this->value ) ) {
 			return $this->render_empty_value_html();
 		}
 
-		$raw_phone    = preg_replace( '/[^\d+]/', '', (string) $this->value );
+		$raw_phone    = preg_replace( '/[^\d+]/', '', $this->value );
 		$country_code = $this->get_country_code_from_phone( $this->value );
 		$flag_prefix  = '';
 

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Field_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Field_Test.php
@@ -478,6 +478,54 @@ class Feedback_Field_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test phone field with non-string array input renders safely in web context.
+	 */
+	public function test_phone_field_with_array_value_renders_safely_in_web_context() {
+		$field = new Feedback_Field( 'phone_key', 'Phone', array( '+44 7911', '+1 555' ), 'phone' );
+
+		$value = $field->get_render_value( 'web' );
+
+		$this->assertIsString( $value );
+		$this->assertSame( '', $value );
+	}
+
+	/**
+	 * Test phone field with non-string array input renders safely in email context.
+	 */
+	public function test_phone_field_with_array_value_renders_safely_in_email_context() {
+		$field = new Feedback_Field( 'phone_key', 'Phone', array( '+44', '+1' ), 'phone' );
+
+		$value = $field->get_render_value( 'email' );
+
+		$this->assertIsString( $value );
+		$this->assertSame( '', $value );
+	}
+
+	/**
+	 * Test phone field with non-string array input renders safely in email_html context.
+	 */
+	public function test_phone_field_with_array_value_renders_safely_in_email_html_context() {
+		$field = new Feedback_Field( 'phone_key', 'Phone', array( '+44', '+1' ), 'phone' );
+
+		$value = $field->get_render_value( 'email_html' );
+
+		$this->assertIsString( $value );
+		$this->assertStringContainsString( '&mdash;', $value );
+		$this->assertStringNotContainsString( 'tel:', $value );
+	}
+
+	/**
+	 * Test telephone alias also handles non-string array input safely.
+	 */
+	public function test_telephone_field_with_array_value_renders_safely() {
+		$field = new Feedback_Field( 'phone_key', 'Phone', array( '+44' ), 'telephone' );
+
+		$this->assertSame( '', $field->get_render_value( 'web' ) );
+		$this->assertSame( '', $field->get_render_value( 'email' ) );
+		$this->assertStringContainsString( '&mdash;', $field->get_render_value( 'email_html' ) );
+	}
+
+	/**
 	 * Test rating field returns structured array for web context.
 	 */
 	public function test_rating_field_returns_structured_array_for_web() {


### PR DESCRIPTION
Fixes FORMS-658

## Proposed changes

`Feedback_Field::$value` is typed as `mixed` in the constructor, but the phone field rendering pipeline (`get_phone_value_with_flag()` and `render_email_phone()`) hands the value straight to `get_country_code_from_phone()`, which calls `strpos()` on it. Under PHP 8 a non-string argument here causes a fatal error, which means the rendering pipeline can't gracefully handle anything other than a string in `$this->value`.

The fix adds an `is_string()` check at each rendering boundary so non-string values short-circuit to a safe default — empty string for the web/structured-email paths, the em-dash empty-value placeholder for the HTML email path — before any downstream string-only helpers run. This matches the existing defensive `is_string()` pattern already used in the constructor for `$label`.

Also drops the now-redundant `(string)` cast in `render_email_phone()` since the early return guarantees a string by that point.

### Other information

- [x] Have you written new tests for your changes, if applicable? — 4 new tests covering all three render contexts (web, email, email_html) plus the telephone alias.
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable?

## Related product discussion/links

* N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Apply this branch and build the forms package.
2. Run the new tests:
   ```
   cd projects/packages/forms
   vendor/bin/phpunit -c phpunit.11.xml.dist tests/php/contact-form/Feedback_Field_Test.php
   ```
   Expect 57 passing tests. The 4 new ones are:
   - `test_phone_field_with_array_value_renders_safely_in_web_context`
   - `test_phone_field_with_array_value_renders_safely_in_email_context`
   - `test_phone_field_with_array_value_renders_safely_in_email_html_context`
   - `test_telephone_field_with_array_value_renders_safely`
3. Manual sanity check: in a Forms-enabled WP install, submit a form with a normal phone value (e.g. `+44 7911 123456`) and verify the success summary, structured email, and HTML email all render the phone with the country flag prefix correctly.
