### PR TITLE
Forms: Guard rating field rendering against non-string values

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-rating-field-input-validation
+++ b/projects/packages/forms/changelog/fix-forms-rating-field-input-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Handle non-string values in the rating field rendering pipeline.

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -317,6 +317,12 @@ class Feedback_Field {
 	 * @return array|string Structured rating data or original value if parsing fails.
 	 */
 	private function get_rating_value() {
+		// Field values arrive as `mixed` (per the constructor); short-circuit
+		// to an empty string for non-string values.
+		if ( ! is_string( $this->value ) ) {
+			return '';
+		}
+
 		if ( empty( $this->value ) ) {
 			return $this->value;
 		}

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Field_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Field_Test.php
@@ -587,6 +587,43 @@ class Feedback_Field_Test extends BaseTestCase {
 		$this->assertEquals( 5, $value['maxRating'] );
 	}
 
+	/**
+	 * Test rating field with non-string array input renders safely in web context.
+	 */
+	public function test_rating_field_with_array_value_renders_safely_in_web_context() {
+		$field = new Feedback_Field( 'rating_key', 'Rating', array( '1/5', '2/5' ), 'rating' );
+
+		$value = $field->get_render_value( 'web' );
+
+		$this->assertIsString( $value );
+		$this->assertSame( '', $value );
+	}
+
+	/**
+	 * Test rating field with non-string array input renders safely in email context.
+	 */
+	public function test_rating_field_with_array_value_renders_safely_in_email_context() {
+		$field = new Feedback_Field( 'rating_key', 'Rating', array( '3/5' ), 'rating' );
+
+		$value = $field->get_render_value( 'email' );
+
+		$this->assertIsString( $value );
+		$this->assertSame( '', $value );
+	}
+
+	/**
+	 * Regression pin for the email_html rating path. render_email_rating() already
+	 * guards non-string input; this test exists to keep that safe path safe.
+	 */
+	public function test_rating_field_with_array_value_renders_safely_in_email_html_context() {
+		$field = new Feedback_Field( 'rating_key', 'Rating', array( '3/5' ), 'rating' );
+
+		$value = $field->get_render_value( 'email_html' );
+
+		$this->assertIsString( $value );
+		$this->assertStringNotContainsString( '&#9733;', $value );
+	}
+
 	// ─── Email HTML rendering tests ───
 
 	/**


### PR DESCRIPTION
Fixes FORMS-660

## Proposed changes

`Feedback_Field::$value` is typed as `mixed` in the constructor, but `get_rating_value()` calls `explode( '/', $this->value )` directly without guarding against non-string input. Under PHP 8 a non-string argument to `explode()` causes a fatal error, which means the rendering pipeline can't gracefully handle anything other than a string in `$this->value` for rating fields.

The fix adds an `is_string()` check at the top of `get_rating_value()` so non-string values short-circuit to an empty string before the parser runs. This matches the existing defensive `is_string()` pattern already used in the sibling `render_email_rating()` (for the email_html context, which is why that path was already safe) and in `get_phone_value_with_flag()` (the parallel phone field helper).

### Other information

- [x] Have you written new tests for your changes, if applicable? — 3 new tests covering the web and email rendering contexts (which both route through `get_rating_value()`) plus a regression pin for the email_html context (which routes through the already-guarded `render_email_rating()` helper).
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable?

## Related product discussion/links

* N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Apply this branch and build the forms package.
2. Run the new tests:
   ```
   cd projects/packages/forms
   vendor/bin/phpunit -c phpunit.11.xml.dist tests/php/contact-form/Feedback_Field_Test.php
   ```
   Expect 56 passing tests. The 3 new ones are:
   - `test_rating_field_with_array_value_renders_safely_in_web_context`
   - `test_rating_field_with_array_value_renders_safely_in_email_context`
   - `test_rating_field_with_array_value_renders_safely_in_email_html_context`
3. Manual sanity check: in a Forms-enabled WP install, submit a form with a normal rating value (e.g. `3/5`) and verify the success summary, structured email, and HTML email all render the rating correctly (web context shows star/heart structured data, HTML email shows the gold/grey star characters).
