### PR TITLE
RTC: Bump WebSocket gradual rollout to 50% on simple sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-16627-rtc-bump-ws-rollout-50-percent
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-16627-rtc-bump-ws-rollout-50-percent
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+RTC: Bump WebSocket gradual rollout to 50% on simple sites.

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
@@ -47,7 +47,7 @@ function wpcom_is_rtc_websocket_rollout() {
 
 	if (
 		defined( 'IS_WPCOM' ) && IS_WPCOM &&
-		( $blog_id % 100 < 20 )
+		( $blog_id % 100 < 50 )
 	) {
 		return true;
 	}


### PR DESCRIPTION
Fixes DOTCOM-16627

## Proposed changes

* Bump the RTC WebSocket gradual rollout threshold from 20% to 50% on simple sites (`$blog_id % 100 < 50`).

### Other information

Previous rollout steps: 1% → 5% → 20% → **50%** (this PR).

## Related product discussion/links

* DOTCOM-16627

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Verify that `wpcom_is_rtc_websocket_rollout()` returns `true` for sites where `blog_id % 100 < 50` and `false` otherwise (on simple sites with `IS_WPCOM` defined).