### PR TITLE
FORNO-300: Skip premature enabling of AM via Block Notes

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-skip-premature-am-enable-block-notes
+++ b/projects/plugins/jetpack/changelog/fix-skip-premature-am-enable-block-notes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Block Notes: Stop force-enabling Agents Manager site-wide via the unified experience filter.

--- a/projects/plugins/jetpack/extensions/plugins/block-notes/block-notes.php
+++ b/projects/plugins/jetpack/extensions/plugins/block-notes/block-notes.php
@@ -289,25 +289,6 @@ function enqueue_block_notes() {
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_block_notes' );
 
 /**
- * Enable the agents manager unified experience on self-hosted sites
- * when Block Notes is enabled.
- *
- * This ensures the agents manager loads and can host the headless agent
- * even when the unified chat experience is not otherwise enabled.
- *
- * @param bool $use_unified_experience Current value of the filter.
- * @return bool
- */
-function enable_agents_manager_for_block_notes( $use_unified_experience ) {
-	if ( $use_unified_experience ) {
-		return true;
-	}
-
-	return is_block_notes_enabled();
-}
-add_filter( 'agents_manager_use_unified_experience', __NAMESPACE__ . '\enable_agents_manager_for_block_notes' );
-
-/**
  * Register the Block Notes headless agent provider with the agents manager.
  *
  * When Block Notes is enabled, adds the Block Notes headless

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/block-notes/Block_Notes_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/block-notes/Block_Notes_Test.php
@@ -51,7 +51,6 @@ class Block_Notes_Test extends \WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		delete_transient( BlockNotes\ASSET_TRANSIENT );
-		remove_all_filters( 'agents_manager_use_unified_experience' );
 		remove_all_filters( 'agents_manager_agent_providers' );
 		remove_all_filters( 'pre_http_request' );
 		remove_all_filters( 'jetpack_ai_enabled' );
@@ -957,52 +956,6 @@ class Block_Notes_Test extends \WP_UnitTestCase {
 		$result = BlockNotes\get_asset_data_from_remote();
 
 		$this->assertFalse( $result );
-	}
-
-	// -------------------------------------------------------------------------
-	// enable_agents_manager_for_block_notes() tests
-	// -------------------------------------------------------------------------
-
-	/**
-	 * Test that enable_agents_manager_for_block_notes returns true
-	 * when AI features are available.
-	 */
-	public function test_enable_agents_manager_returns_true_when_block_notes_enabled() {
-		$result = BlockNotes\enable_agents_manager_for_block_notes( false );
-
-		$this->assertTrue( $result );
-	}
-
-	/**
-	 * Test that enable_agents_manager_for_block_notes returns false
-	 * when AI features are disabled and input is false.
-	 */
-	public function test_enable_agents_manager_returns_false_when_block_notes_disabled() {
-		$this->disable_ai_features();
-
-		$result = BlockNotes\enable_agents_manager_for_block_notes( false );
-
-		$this->assertFalse( $result );
-	}
-
-	/**
-	 * Test that enable_agents_manager_for_block_notes does not override
-	 * when agents_manager_use_unified_experience is already true.
-	 */
-	public function test_enable_agents_manager_preserves_existing_true() {
-		$result = BlockNotes\enable_agents_manager_for_block_notes( true );
-
-		$this->assertTrue( $result );
-	}
-
-	/**
-	 * Test that enable_agents_manager_for_block_notes preserves true
-	 * when input is already true and block notes is also enabled.
-	 */
-	public function test_enable_agents_manager_no_double_registration() {
-		$result = BlockNotes\enable_agents_manager_for_block_notes( true );
-
-		$this->assertTrue( $result );
 	}
 
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #

## Proposed changes
<!--- Explain what functional changes your PR includes -->
Block Notes was hooking into the `agents_manager_use_unified_experience` filter to force-enable Agents Manager whenever Block Notes was active causing Agents Manager to load site-wide.

  * Remove the `enable_agents_manager_for_block_notes()` function and its
    `agents_manager_use_unified_experience` filter hook
  * Remove associated tests

Block Notes JS (`block-notes.min.js`) is self-contained and works independently of Agents Manager, consistent with how Image Studio operates.

### Other information

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Regression test Block Notes:
1. Sandbox a site and install plugin: `bin/jetpack-downloader test jetpack fix/skip-premature-am-enable-block-notes`
2. Goto draft post and add a block
3. Create a note and prompt AI
4. It should respond correctly.

