### PR TITLE
Hotfix: Temporarily disable Block Notes

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-disable-block-notes
+++ b/projects/plugins/jetpack/changelog/fix-disable-block-notes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Block Notes: Temporarily disable feature to prevent expensive API calls on every Gutenberg page load and premature Agents Manager activation.

--- a/projects/plugins/jetpack/changelog/fix-disable-block-notes
+++ b/projects/plugins/jetpack/changelog/fix-disable-block-notes
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Block Notes: Temporarily disable feature to prevent expensive API calls on every Gutenberg page load and premature Agents Manager activation.
+Block Notes: Temporarily disable feature to prevent expensive API calls on every Gutenberg page load.

--- a/projects/plugins/jetpack/extensions/plugins/block-notes/block-notes.php
+++ b/projects/plugins/jetpack/extensions/plugins/block-notes/block-notes.php
@@ -33,12 +33,32 @@ const HEADLESS_AGENT_PROVIDER = 'block-notes/headless-agent-provider';
  * @return bool
  */
 function is_block_notes_enabled() {
-	/*
+	/**
 	 * Temporarily disabled while we investigate expensive API calls
 	 * triggered by has_paid_ai_plan() on every Gutenberg page load for
-	 * self-hosted sites.
+	 * self-hosted sites. Filter allows tests and development to re-enable.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param bool $enabled Whether Block Notes is force-enabled. Default false.
 	 */
-	return false;
+	if ( ! apply_filters( 'jetpack_block_notes_enabled', false ) ) {
+		return false;
+	}
+
+	if ( is_big_sky_enabled() ) {
+		return true;
+	}
+
+	if ( ! has_jetpack_ai_features() ) {
+		return false;
+	}
+
+	if ( ! has_paid_ai_plan() ) {
+		return false;
+	}
+
+	return true;
 }
 
 /**

--- a/projects/plugins/jetpack/extensions/plugins/block-notes/block-notes.php
+++ b/projects/plugins/jetpack/extensions/plugins/block-notes/block-notes.php
@@ -36,8 +36,7 @@ function is_block_notes_enabled() {
 	/*
 	 * Temporarily disabled while we investigate expensive API calls
 	 * triggered by has_paid_ai_plan() on every Gutenberg page load for
-	 * self-hosted sites, and premature Agents Manager activation via
-	 * the unified experience filter.
+	 * self-hosted sites.
 	 */
 	return false;
 }

--- a/projects/plugins/jetpack/extensions/plugins/block-notes/block-notes.php
+++ b/projects/plugins/jetpack/extensions/plugins/block-notes/block-notes.php
@@ -33,19 +33,13 @@ const HEADLESS_AGENT_PROVIDER = 'block-notes/headless-agent-provider';
  * @return bool
  */
 function is_block_notes_enabled() {
-	if ( is_big_sky_enabled() ) {
-		return true;
-	}
-
-	if ( ! has_jetpack_ai_features() ) {
-		return false;
-	}
-
-	if ( ! has_paid_ai_plan() ) {
-		return false;
-	}
-
-	return true;
+	/*
+	 * Temporarily disabled while we investigate expensive API calls
+	 * triggered by has_paid_ai_plan() on every Gutenberg page load for
+	 * self-hosted sites, and premature Agents Manager activation via
+	 * the unified experience filter.
+	 */
+	return false;
 }
 
 /**

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/block-notes/Block_Notes_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/block-notes/Block_Notes_Test.php
@@ -40,6 +40,9 @@ class Block_Notes_Test extends \WP_UnitTestCase {
 		$this->reset_availability();
 		$this->simulate_connected_owner();
 		$this->simulate_paid_ai_plan();
+		// Re-enable Block Notes for tests (production is temporarily disabled via the
+		// jetpack_block_notes_enabled filter defaulting to false).
+		add_filter( 'jetpack_block_notes_enabled', '__return_true' );
 		// Ensure Big Sky is disabled by default so tests aren't affected by the
 		// Big_Sky class persisting across tests once simulate_big_sky_class() runs.
 		update_option( 'big_sky_enable', '0' );
@@ -51,6 +54,7 @@ class Block_Notes_Test extends \WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		delete_transient( BlockNotes\ASSET_TRANSIENT );
+		remove_all_filters( 'jetpack_block_notes_enabled' );
 		remove_all_filters( 'agents_manager_use_unified_experience' );
 		remove_all_filters( 'agents_manager_agent_providers' );
 		remove_all_filters( 'pre_http_request' );


### PR DESCRIPTION
 
Fixes #

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Temporarily disables Block Notes by short-circuiting `is_block_notes_enabled()` to return `false`.
* `has_paid_ai_plan()` triggers expensive WPCOM API calls (`/rest/v1.1/sites/$site/purchases`) on every Gutenberg page load for self-hosted Jetpack sites, causing a sustained spike in billing DB queries after the 15.7-beta rollout.
* All code paths are gated by `is_block_notes_enabled()`, so returning `false` prevents any API calls or side effects. Will be re-enabled once the plan check is optimized.

### Other information

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Simple site
1. Sandbox a site and install jetpack plugin from this branch
2. goto draft post and add a note
3. No placeholder in note input - block notes should not be active

Simple/atomic site with big sky enabled
1. Goto  site with big sky enabled
2. goto draft post and add note
3. AI should respond because Block notes activated from big sky as fallback

JN site
1. Use JP beta plugin to install this branch version of plugin
4. goto draft post and add a note
5. No placeholder in note input -block notes should not be active
