### PR TITLE
Jetpack Beta: Move menu item to bottom position

### DIFF
--- a/projects/plugins/beta/changelog/fix-beta-move_to_bottom_menu_position
+++ b/projects/plugins/beta/changelog/fix-beta-move_to_bottom_menu_position
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Move menu position to bottom.

--- a/projects/plugins/beta/src/class-admin.php
+++ b/projects/plugins/beta/src/class-admin.php
@@ -42,7 +42,7 @@ class Admin {
 			'update_plugins',
 			'jetpack-beta',
 			array( self::class, 'render' ),
-			16
+			999
 		);
 
 		if ( false !== self::$hookname ) {

--- a/projects/plugins/beta/src/class-admin.php
+++ b/projects/plugins/beta/src/class-admin.php
@@ -42,7 +42,7 @@ class Admin {
 			'update_plugins',
 			'jetpack-beta',
 			array( self::class, 'render' ),
-			999
+			998
 		);
 
 		if ( false !== self::$hookname ) {


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
In #47418, menu order and positions were adjusted. This resulted in situations where Jetpack Beta ends up in a weird position like this:

<img width="338" height="1030" alt="image" src="https://github.com/user-attachments/assets/7bb901b6-2545-4354-bad0-3e5b379a610b" />

After this PR, it bumps to the bottom:
<img width="402" height="932" alt="image" src="https://github.com/user-attachments/assets/f70d7ccf-52fd-4ce3-a415-e0543a8b4789" />

Note that 999 is also the "Upgrade Jetpack" button position, which remains at the very bottom of the menu.

### Other information

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

I'm not sure the best way to test this other than spinning up a site, adding a backup/scan plan, then looking at the menu to verify Jetpack Beta is at the bottom.