### PR TITLE
Fix JS linting errors in Super Cache and remove .eslintignore #40571

### DIFF
--- a/projects/plugins/super-cache/.eslintignore
+++ b/projects/plugins/super-cache/.eslintignore
@@ -1,6 +1,0 @@
-# Our standard eslint config reads .gitignore and .eslintignore to determine what to ignore.
-
-# @todo: Files below ignored as part of Automattic/jetpack/pull/25449
-# They can be removed here as lint errors are addressed.
-/inc/delete-cache-button.js
-/inc/preload-notification.js

--- a/projects/plugins/super-cache/changelog/fix-supercache-eslint-cleanup
+++ b/projects/plugins/super-cache/changelog/fix-supercache-eslint-cleanup
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Removed .eslintignore and fixed JS linting errors in delete-cache-button.js.
+Remove `.eslintignore` and fix JS linting errors in `delete-cache-button.js`.

--- a/projects/plugins/super-cache/changelog/fix-supercache-eslint-cleanup
+++ b/projects/plugins/super-cache/changelog/fix-supercache-eslint-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Removed .eslintignore and fixed JS linting errors in delete-cache-button.js.

--- a/projects/plugins/super-cache/inc/delete-cache-button.js
+++ b/projects/plugins/super-cache/inc/delete-cache-button.js
@@ -1,3 +1,4 @@
+/* global wpsc_ajax */
 ( function ( $ ) {
 	$( document ).ready( function () {
 		$( '#wp-admin-bar-delete-cache' ).on( 'click', function () {
@@ -16,12 +17,17 @@
 					// send the nonce along with the request
 					nonce: wpsc_ajax.nonce,
 				},
-				success: function ( msg ) {
-					wpsc_ajax.admin == 1 && console.log( 'Deleted entire cache' );
-					wpsc_ajax.admin == 0 && console.log( 'Deleted cache for this page and reloading' );
+				success: function () {
+					if ( wpsc_ajax.admin === 1 ) {
+						// eslint-disable-next-line no-console
+						console.log( 'Deleted entire cache' );
+					} else {
+						// eslint-disable-next-line no-console
+						console.log( 'Deleted cache for this page and reloading' );
+					}
 					window.location.reload();
 				},
-				complete: function ( msg ) {
+				complete: function () {
 					$( '#wp-admin-bar-delete-cache' ).fadeIn( 'slow' );
 				},
 			} );

--- a/projects/plugins/super-cache/inc/delete-cache-button.js
+++ b/projects/plugins/super-cache/inc/delete-cache-button.js
@@ -18,7 +18,7 @@
 					nonce: wpsc_ajax.nonce,
 				},
 				success: function () {
-					if ( wpsc_ajax.admin === 1 ) {
+					if ( wpsc_ajax.admin === '1' ) {
 						// eslint-disable-next-line no-console
 						console.log( 'Deleted entire cache' );
 					} else {


### PR DESCRIPTION
Fixes #40571

## Proposed changes

* Removed `.eslintignore` from `projects/plugins/super-cache/` — it excluded two files (`delete-cache-button.js` and `preload-notification.js`), but `preload-notification.js` no longer exists.
* Fixed all ESLint errors in `inc/delete-cache-button.js`:
  * Added `/* global wpsc_ajax */` declaration to resolve `no-undef` errors
  * Replaced `==` with `===` for strict equality (`eqeqeq`)
  * Removed unused `msg` parameters from callback functions (`no-unused-vars`)
  * Refactored short-circuit `&&` expressions into `if/else` blocks for clarity
  * Added `eslint-disable-next-line no-console` comments for intentional `console.log` usage

### Other information

This addresses the `@todo` left in [#25449](https://github.com/Automattic/jetpack/pull/25449) to fix lint errors and remove the ignore file.

## Related product discussion/links

* https://github.com/Automattic/jetpack/issues/40571

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run `npx eslint projects/plugins/super-cache/inc/delete-cache-button.js` from the repo root — should pass with zero errors/warnings.
* Verify `.eslintignore` is deleted under `projects/plugins/super-cache/`.
* Optionally: activate Super Cache on a test site, confirm the "Delete Cache" button in the admin bar still works (the JS logic is unchanged, only linting fixes).