### PR TITLE
wpcomsh: only load on specific clients

### DIFF
--- a/projects/plugins/wpcomsh/README.md
+++ b/projects/plugins/wpcomsh/README.md
@@ -24,11 +24,8 @@ $ pnpm jetpack rsync wpcomsh USER@HOST:/path/to/wordpress/wp-content/mu-plugins
 $ cd wp-content/mu-plugins
 $ ln -s wpcomsh/wpcomsh-loader.php ./ # or copy the loader to mu-plugins
 
-# define 'IS_ATOMIC', 'ATOMIC_SITE_ID' and 'ATOMIC_CLIENT_ID' as true so the loader will require wpcomsh
-
-define( 'IS_ATOMIC', true );
-define( 'ATOMIC_SITE_ID', true );
-define( 'ATOMIC_CLIENT_ID', true );
+# Force-load wpcomsh regardless of WP Cloud client ID.
+define( 'WPCOMSH_FORCE_LOAD', true );
 ```
 
 To work on wpcomsh, you need a WP.org site and ideally the Jetpack plugin installed and connected to WP.com.

--- a/projects/plugins/wpcomsh/changelog/fix-wpcomsh-selectively_load
+++ b/projects/plugins/wpcomsh/changelog/fix-wpcomsh-selectively_load
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Load only when desired.

--- a/projects/plugins/wpcomsh/wpcomsh-loader.php
+++ b/projects/plugins/wpcomsh/wpcomsh-loader.php
@@ -5,6 +5,27 @@
  * @package wpcomsh
  */
 
-if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
+// List of WP Cloud clients that will always load wpcomsh.
+$wpcloud_client_ids = array(
+	2, // wpcom
+	10, // e2e
+	32, // jurassicninja
+);
+
+/**
+ * Filters whether wpcomsh should be loaded.
+ *
+ * Only mu-plugins loaded before this file can hook into this filter.
+ *
+ * @param bool Whether wpcomsh should be loaded.
+ */
+$should_load_wpcomsh = (bool) apply_filters( 'wpcomsh_force_load', false );
+
+// Load if any of these conditions are true.
+$should_load_wpcomsh = $should_load_wpcomsh
+	|| ( defined( 'WPCOMSH_FORCE_LOAD' ) && WPCOMSH_FORCE_LOAD )
+	|| ( defined( 'ATOMIC_CLIENT_ID' ) && in_array( (int) ATOMIC_CLIENT_ID, $wpcloud_client_ids, true ) );
+
+if ( $should_load_wpcomsh ) {
 	require_once WPMU_PLUGIN_DIR . '/wpcomsh/wpcomsh.php';
 }


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
Right now we load wpcomsh if `IS_ATOMIC` is true. This PR changes it to load if any of these are true:

1. The `wpcomsh_force_load` filter returns `true`
2. The `WPCOMSH_FORCE_LOAD` constant is `true`
3. The `ATOMIC_CLIENT_ID` constant is one of the predefined client IDs that should load `wpcomsh`

### Other information

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* p1774878419588439-slack-C7YPW6K40

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Go to '..'
*