### PR TITLE
Charts: Use Stack for layout

### DIFF
--- a/projects/js-packages/charts/changelog/charts-175-use-stack-for-layout
+++ b/projects/js-packages/charts/changelog/charts-175-use-stack-for-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Charts: Replace ad-hoc flexbox layouts with @wordpress/ui Stack across legend, conversion funnel, line chart, geo chart, and donut story.

--- a/projects/js-packages/charts/changelog/charts-175-use-stack-for-layout
+++ b/projects/js-packages/charts/changelog/charts-175-use-stack-for-layout
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Charts: Replace ad-hoc flexbox layouts with @wordpress/ui Stack across legend, conversion funnel, line chart, geo chart, and donut story.
+Charts: Replace ad-hoc flexbox layouts with @wordpress/ui Stack across legend, conversion funnel, line chart, geo chart, conversion funnel tooltip, and donut story.

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
@@ -52,10 +52,6 @@
 	}
 }
 
-.step-header {
-	margin-bottom: 24px;
-}
-
 .step-label {
 	color: #757575;
 	font-size: var(--wpds-font-size-sm, 12px);
@@ -80,8 +76,6 @@
 
 .bar-container {
 	flex: 1;
-	display: flex;
-	align-items: flex-end;
 	border-radius: 4px;
 	position: relative;
 	cursor: pointer;

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
@@ -7,7 +7,6 @@
 }
 
 .main-metric {
-	margin-bottom: 24px;
 	height: 20px;
 }
 

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
@@ -7,9 +7,6 @@
 }
 
 .main-metric {
-	display: flex;
-	align-items: baseline;
-	gap: 8px;
 	margin-bottom: 24px;
 	height: 20px;
 }
@@ -36,9 +33,6 @@
 }
 
 .funnel-container {
-	display: flex;
-	gap: 16px;
-	align-items: flex-end;
 	flex: 1;
 	min-height: 200px;
 	width: 100%;
@@ -47,8 +41,6 @@
 .funnel-step {
 	flex: 1 1 0;
 	min-width: 0;
-	display: flex;
-	flex-direction: column;
 	height: 100%;
 
 	&--animated {

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
@@ -108,12 +108,6 @@
 }
 
 .tooltip-wrapper {
-	display: inline-flex;
-	flex-direction: column;
-	justify-content: center;
-	align-items: flex-start;
-	gap: 4px;
-
 	border-bottom: 1px solid var(--Gray-Gray-5, #dcdcde);
 	background: var(--black-white-white, #fff);
 

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.tsx
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.tsx
@@ -322,6 +322,7 @@ const ConversionFunnelChartInternal: FC< ConversionFunnelChartProps > = ( {
 		<>
 			<Stack
 				direction="column"
+				gap="xl"
 				data-testid="conversion-funnel-chart"
 				ref={ node => {
 					// Set containerRef for @visx coordinate system

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.tsx
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.tsx
@@ -263,13 +263,13 @@ const ConversionFunnelChartInternal: FC< ConversionFunnelChartProps > = ( {
 
 	// Default tooltip rendering function
 	const renderDefaultTooltip = ( step: FunnelStep ) => (
-		<>
+		<Stack direction="column" align="flex-start" gap="xs">
 			<div className={ styles[ 'tooltip-title' ] }>{ step.label }</div>
 			<div className={ styles[ 'tooltip-content' ] }>
 				{ formatPercentage( step.rate ) }
 				{ ` • ${ step.count ?? 'no' } items` }
 			</div>
-		</>
+		</Stack>
 	);
 
 	// Validate data

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.tsx
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.tsx
@@ -344,18 +344,21 @@ const ConversionFunnelChartInternal: FC< ConversionFunnelChartProps > = ( {
 						changeColor,
 					} )
 				) : (
-					<div className={ styles[ 'main-metric' ] }>{ renderDefaultMainMetric() }</div>
+					<Stack direction="row" align="baseline" gap="sm" className={ styles[ 'main-metric' ] }>
+						{ renderDefaultMainMetric() }
+					</Stack>
 				) }
 
 				{ /* Funnel Steps */ }
-				<div className={ styles[ 'funnel-container' ] }>
+				<Stack direction="row" align="flex-end" gap="lg" className={ styles[ 'funnel-container' ] }>
 					{ steps.map( ( step, index ) => {
 						const barHeight = ( step.rate / maxRate ) * 100;
 						const { isBlurred } = getStepState( step.id );
 
 						return (
-							<div
+							<Stack
 								key={ step.id }
+								direction="column"
 								data-testid="funnel-step"
 								className={ clsx(
 									styles[ 'funnel-step' ],
@@ -408,10 +411,10 @@ const ConversionFunnelChartInternal: FC< ConversionFunnelChartProps > = ( {
 										} }
 									/>
 								</div>
-							</div>
+							</Stack>
 						);
 					} ) }
-				</div>
+				</Stack>
 			</Stack>
 
 			{ /* Tooltip Portal */ }

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.tsx
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.tsx
@@ -365,9 +365,10 @@ const ConversionFunnelChartInternal: FC< ConversionFunnelChartProps > = ( {
 									isColorPaletteResolved && styles[ 'funnel-step--animated' ],
 									isBlurred && styles[ 'funnel-step--blurred' ]
 								) }
+								gap="xl"
 							>
 								{ /* Step Label and Rate */ }
-								<div className={ styles[ 'step-header' ] }>
+								<div>
 									{ renderStepLabel ? (
 										renderStepLabel( {
 											step,
@@ -391,7 +392,9 @@ const ConversionFunnelChartInternal: FC< ConversionFunnelChartProps > = ( {
 								</div>
 
 								{ /* Funnel Bar */ }
-								<div
+								<Stack
+									direction="column"
+									justify="flex-end"
 									className={ styles[ 'bar-container' ] }
 									onClick={ stepHandlers.get( step.id )?.onClick }
 									onKeyDown={ stepHandlers.get( step.id )?.onKeyDown }
@@ -410,7 +413,7 @@ const ConversionFunnelChartInternal: FC< ConversionFunnelChartProps > = ( {
 											backgroundColor: barColor,
 										} }
 									/>
-								</div>
+								</Stack>
 							</Stack>
 						);
 					} ) }

--- a/projects/js-packages/charts/src/charts/geo-chart/geo-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/geo-chart/geo-chart.module.scss
@@ -1,6 +1,3 @@
 .container {
 	position: relative;
-	display: flex;
-	justify-content: center;
-	align-items: center;
 }

--- a/projects/js-packages/charts/src/charts/geo-chart/geo-chart.tsx
+++ b/projects/js-packages/charts/src/charts/geo-chart/geo-chart.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Stack } from '@wordpress/ui';
 import clsx from 'clsx';
 import { FC, useContext, useMemo } from 'react';
 import { Chart, type GoogleChartOptions } from 'react-google-charts';
@@ -57,13 +58,15 @@ const GeoChartInternal: FC< GeoChartProps > = ( {
 
 	// Render loading placeholder
 	const loadingPlaceholder = (
-		<div
+		<Stack
+			align="center"
+			justify="center"
 			className={ clsx( 'geo-chart', styles.container, className ) }
 			data-testid="geo-chart-loading"
 			style={ { width, height } }
 		>
 			{ renderPlaceholder ? renderPlaceholder() : __( 'Loading map', 'jetpack-charts' ) }
-		</div>
+		</Stack>
 	);
 
 	// Google charts doesn't accept CSS variables, so we need to convert them to hex colors
@@ -144,7 +147,9 @@ const GeoChartInternal: FC< GeoChartProps > = ( {
 	);
 
 	return (
-		<div
+		<Stack
+			align="center"
+			justify="center"
 			className={ clsx( 'geo-chart', styles.container, className ) }
 			data-testid="geo-chart"
 			style={ { width, height, backgroundColor } }
@@ -157,7 +162,7 @@ const GeoChartInternal: FC< GeoChartProps > = ( {
 				options={ options }
 				loader={ loadingPlaceholder }
 			/>
-		</div>
+		</Stack>
 	);
 };
 

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.module.scss
@@ -26,10 +26,7 @@
 	}
 
 	&__tooltip-row {
-		display: flex;
-		align-items: center;
 		padding: 4px 0;
-		justify-content: space-between;
 	}
 
 	&__tooltip-label {
@@ -79,13 +76,6 @@
 			position: initial;
 			margin: auto;
 		}
-	}
-
-	&__annotation-label-popover-header {
-		display: flex;
-		flex-direction: row;
-		justify-content: space-between;
-		align-items: start;
 	}
 
 	&__annotation-label-popover-content {

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
@@ -4,6 +4,7 @@ import { LinearGradient } from '@visx/gradient';
 import { scaleTime } from '@visx/scale';
 import { XYChart, AreaSeries, Grid, Axis, DataContext } from '@visx/xychart';
 import { __ } from '@wordpress/i18n';
+import { Stack } from '@wordpress/ui';
 import clsx from 'clsx';
 import { differenceInHours, differenceInYears } from 'date-fns';
 import {
@@ -103,12 +104,18 @@ const renderDefaultTooltip = ( params: RenderTooltipParams< DataPointDate > ) =>
 				{ nearestDatum.date?.toLocaleDateString() }
 			</div>
 			{ tooltipPoints.map( point => (
-				<div key={ point.key } className={ styles[ 'line-chart__tooltip-row' ] }>
+				<Stack
+					key={ point.key }
+					direction="row"
+					align="center"
+					justify="space-between"
+					className={ styles[ 'line-chart__tooltip-row' ] }
+				>
 					<span className={ styles[ 'line-chart__tooltip-label' ] }>{ point.key }:</span>
 					<span className={ styles[ 'line-chart__tooltip-value' ] }>
 						{ formatNumber( point.value ) }
 					</span>
-				</div>
+				</Stack>
 			) ) }
 		</div>
 	);

--- a/projects/js-packages/charts/src/charts/line-chart/private/line-chart-annotation-label-popover.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/private/line-chart-annotation-label-popover.tsx
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { Icon, close } from '@wordpress/icons';
+import { Stack } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useEffect, useId, useRef, useState } from 'react';
 import { isSafari } from '../../../utils';
@@ -88,7 +89,12 @@ const LineChartAnnotationLabelWithPopover: FC< LineChartAnnotationLabelWithPopov
 				) }
 				data-testid="line-chart-annotation-label-popover"
 			>
-				<div className={ styles[ 'line-chart__annotation-label-popover-header' ] }>
+				<Stack
+					direction="row"
+					align="flex-start"
+					justify="space-between"
+					className={ styles[ 'line-chart__annotation-label-popover-header' ] }
+				>
 					<div className={ styles[ 'line-chart__annotation-label-popover-content' ] }>
 						{ renderLabelPopover( { title, subtitle } ) }
 					</div>
@@ -102,7 +108,7 @@ const LineChartAnnotationLabelWithPopover: FC< LineChartAnnotationLabelWithPopov
 					>
 						<Icon icon={ close } size={ 16 } />
 					</button>
-				</div>
+				</Stack>
 			</div>
 		</div>
 	);

--- a/projects/js-packages/charts/src/charts/line-chart/private/line-chart-annotation-label-popover.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/private/line-chart-annotation-label-popover.tsx
@@ -89,12 +89,7 @@ const LineChartAnnotationLabelWithPopover: FC< LineChartAnnotationLabelWithPopov
 				) }
 				data-testid="line-chart-annotation-label-popover"
 			>
-				<Stack
-					direction="row"
-					align="flex-start"
-					justify="space-between"
-					className={ styles[ 'line-chart__annotation-label-popover-header' ] }
-				>
+				<Stack direction="row" align="flex-start" justify="space-between">
 					<div className={ styles[ 'line-chart__annotation-label-popover-content' ] }>
 						{ renderLabelPopover( { title, subtitle } ) }
 					</div>

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/donut.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/donut.stories.tsx
@@ -265,7 +265,7 @@ const CustomPieLegend = ( {
 
 			return (
 				<Fragment key={ index }>
-					<Stack direction="row" justify="flex-start" gap="sm">
+					<Stack direction="row" justify="flex-start" align="center" gap="sm">
 						<div
 							style={ {
 								width: '8px',

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/donut.stories.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/donut.stories.tsx
@@ -1,6 +1,4 @@
-/* eslint-disable @wordpress/no-unsafe-wp-apis */
-import { __experimentalHStack as HStack } from '@wordpress/components';
-import { Text } from '@wordpress/ui';
+import { Stack, Text } from '@wordpress/ui';
 import { Fragment } from 'react';
 import { BaseLegendItem } from '../../../components/legend/types';
 import {
@@ -267,7 +265,7 @@ const CustomPieLegend = ( {
 
 			return (
 				<Fragment key={ index }>
-					<HStack direction="row" justify="flex-start" spacing={ 2 }>
+					<Stack direction="row" justify="flex-start" gap="sm">
 						<div
 							style={ {
 								width: '8px',
@@ -278,7 +276,7 @@ const CustomPieLegend = ( {
 							} }
 						/>
 						<Text variant="body-sm">{ item.label }</Text>
-					</HStack>
+					</Stack>
 					<Text variant="body-sm" style={ { fontWeight: 600, textAlign: 'right' } }>
 						{ item.formattedValue }
 					</Text>

--- a/projects/js-packages/charts/src/components/legend/private/base-legend.module.scss
+++ b/projects/js-packages/charts/src/components/legend/private/base-legend.module.scss
@@ -3,8 +3,6 @@
 }
 
 .legend-item {
-	display: flex;
-	align-items: center;
 	font-size: var(--wpds-font-size-md, 13px);
 
 	&--interactive {

--- a/projects/js-packages/charts/src/components/legend/private/base-legend.module.scss
+++ b/projects/js-packages/charts/src/components/legend/private/base-legend.module.scss
@@ -1,44 +1,5 @@
 .legend {
 	align-self: stretch;
-
-	&--horizontal {
-		display: flex;
-		flex-direction: row;
-		flex-wrap: wrap;
-		gap: 16px;
-	}
-
-	&--vertical {
-		display: flex;
-		flex-direction: column;
-		gap: 8px;
-	}
-
-	&--alignment-start {
-		justify-content: flex-start;
-	}
-
-	&--alignment-center {
-		justify-content: center;
-	}
-
-	&--alignment-end {
-		justify-content: flex-end;
-	}
-
-	// Vertical legends align on the cross-axis instead
-	&--vertical.legend--alignment-start {
-		align-items: flex-start;
-	}
-
-	&--vertical.legend--alignment-center {
-		align-items: center;
-	}
-
-	&--vertical.legend--alignment-end {
-		align-items: flex-end;
-	}
-
 }
 
 .legend-item {

--- a/projects/js-packages/charts/src/components/legend/private/base-legend.module.scss
+++ b/projects/js-packages/charts/src/components/legend/private/base-legend.module.scss
@@ -36,14 +36,6 @@
 	}
 }
 
-.legend-item-label {
-	display: flex;
-	align-items: center;
-	gap: 0.5rem;
-
-	/* Text wrapping is handled at the text level, not the label container */
-}
-
 .legend-item-text {
 
 	&--wrap {

--- a/projects/js-packages/charts/src/components/legend/private/base-legend.tsx
+++ b/projects/js-packages/charts/src/components/legend/private/base-legend.tsx
@@ -17,6 +17,12 @@ import { valueOrIdentity, valueOrIdentityString, labelTransformFactory } from '.
 import styles from './base-legend.module.scss';
 import type { BaseLegendProps } from '../types';
 
+const ALIGNMENT_TO_FLEX = {
+	start: 'flex-start',
+	center: 'center',
+	end: 'flex-end',
+} as const;
+
 // Component for legend text with truncation detection
 // Moved outside BaseLegend to prevent recreation on every render
 const LegendText = ( {
@@ -155,12 +161,7 @@ export const BaseLegend: ForwardRefExoticComponent<
 			[ interactive, handleLegendClick ]
 		);
 
-		const alignmentToFlex = {
-			start: 'flex-start',
-			center: 'center',
-			end: 'flex-end',
-		} as const;
-		const flexAlignment = alignmentToFlex[ alignment ] ?? 'center';
+		const flexAlignment = ALIGNMENT_TO_FLEX[ alignment ] ?? 'center';
 
 		return render ? (
 			render( items )

--- a/projects/js-packages/charts/src/components/legend/private/base-legend.tsx
+++ b/projects/js-packages/charts/src/components/legend/private/base-legend.tsx
@@ -257,23 +257,24 @@ export const BaseLegend: ForwardRefExoticComponent<
 											labelClassName
 										) }
 										style={ {
-											justifyContent: labelJustifyContent,
 											flex: labelFlex,
 											margin: labelMargin,
 											...theme.legend?.labelStyles,
 										} }
 									>
-										<LegendText
-											text={ label.text }
-											textOverflow={ textOverflow }
-											maxWidth={ maxWidth }
-										/>
-										{ matchedItem?.value != null && matchedItem.value !== '' && (
-											<span className={ styles[ 'legend-item-value' ] }>
-												{ '\u00A0' }
-												{ matchedItem.value }
-											</span>
-										) }
+										<Stack align="center" gap="sm" justify={ labelJustifyContent }>
+											<LegendText
+												text={ label.text }
+												textOverflow={ textOverflow }
+												maxWidth={ maxWidth }
+											/>
+											{ matchedItem?.value != null && matchedItem.value !== '' && (
+												<span className={ styles[ 'legend-item-value' ] }>
+													{ '\u00A0' }
+													{ matchedItem.value }
+												</span>
+											) }
+										</Stack>
 									</LegendLabel>
 								</LegendItem>
 							);

--- a/projects/js-packages/charts/src/components/legend/private/base-legend.tsx
+++ b/projects/js-packages/charts/src/components/legend/private/base-legend.tsx
@@ -1,6 +1,7 @@
 import { Group } from '@visx/group';
 import { LegendItem, LegendLabel, LegendOrdinal, LegendShape } from '@visx/legend';
 import { scaleOrdinal } from '@visx/scale';
+import { Stack } from '@wordpress/ui';
 import clsx from 'clsx';
 import {
 	type RefAttributes,
@@ -15,11 +16,6 @@ import { GlobalChartsContext, useGlobalChartsTheme } from '../../../providers';
 import { valueOrIdentity, valueOrIdentityString, labelTransformFactory } from '../utils';
 import styles from './base-legend.module.scss';
 import type { BaseLegendProps } from '../types';
-
-const orientationToFlexDirection = {
-	horizontal: 'row' as const,
-	vertical: 'column' as const,
-};
 
 // Component for legend text with truncation detection
 // Moved outside BaseLegend to prevent recreation on every render
@@ -159,6 +155,13 @@ export const BaseLegend: ForwardRefExoticComponent<
 			[ interactive, handleLegendClick ]
 		);
 
+		const alignmentToFlex = {
+			start: 'flex-start',
+			center: 'center',
+			end: 'flex-end',
+		} as const;
+		const flexAlignment = alignmentToFlex[ alignment ] ?? 'center';
+
 		return render ? (
 			render( items )
 		) : (
@@ -168,20 +171,17 @@ export const BaseLegend: ForwardRefExoticComponent<
 				labelTransform={ labelTransform }
 			>
 				{ labels => (
-					<div
+					<Stack
 						ref={ ref }
+						direction={ orientation === 'vertical' ? 'column' : 'row' }
+						gap={ orientation === 'vertical' ? 'sm' : 'lg' }
+						align={ orientation === 'vertical' ? flexAlignment : undefined }
+						justify={ orientation === 'horizontal' ? flexAlignment : undefined }
+						wrap={ orientation === 'horizontal' ? 'wrap' : undefined }
 						role="list"
 						data-testid={ `legend-${ orientation }` }
-						className={ clsx(
-							styles.legend,
-							styles[ `legend--${ orientation }` ],
-							styles[ `legend--alignment-${ alignment }` ],
-							className
-						) }
-						style={ {
-							flexDirection: orientationToFlexDirection[ orientation ],
-							...theme.legend?.containerStyles,
-						} }
+						className={ clsx( styles.legend, className ) }
+						style={ theme.legend?.containerStyles }
 					>
 						{ labels.map( ( label, i ) => {
 							const visible = isSeriesVisible( label.text );
@@ -278,7 +278,7 @@ export const BaseLegend: ForwardRefExoticComponent<
 								</LegendItem>
 							);
 						} ) }
-					</div>
+					</Stack>
 				) }
 			</LegendOrdinal>
 		);


### PR DESCRIPTION
Fixes [CHARTS-175](https://linear.app/a8c/issue/CHARTS-175/use-stack-for-layout)

## Proposed changes

* Migrate the legend container from a `<div>` with BEM modifier classes (`.legend--horizontal`, `.legend--vertical`, `.legend--alignment-*`) to a `<Stack>` from `@wordpress/ui`. The root `.legend` class is preserved as an identifying selector hook; layout-only modifier classes are dropped.
* Migrate the legend item label inner layout (`LegendText` + value span) to a `<Stack gap="sm">`, replacing the `display: flex; align-items: center; gap: 0.5rem` SCSS rule. Drop the redundant `display: flex; align-items: center` rules from `.legend-item` — visx's `LegendItem` applies those as inline styles by default, so the SCSS was dead code.
* Migrate conversion funnel layout wrappers (`.main-metric`, `.funnel-container`, `.funnel-step`, `.bar-container`) to `<Stack>`. The `.bar-container` keeps its button semantics (onClick/onKeyDown/role/tabIndex/aria-label) on the Stack wrapper.
* Lift two ad-hoc margin-as-gap rules onto parent Stacks: `.main-metric { margin-bottom: 24px }` becomes `gap="xl"` on the outer funnel Stack, and `.step-header { margin-bottom: 24px }` (deleted entirely) becomes `gap="xl"` on the funnel-step Stack.
* Migrate the conversion funnel default tooltip to `<Stack>`. The `.tooltip-wrapper` class now carries only visual chrome (border, padding, box-shadow); its layout properties move onto a `<Stack>` wrapping the tooltip children inside `TooltipInPortal`. Custom `renderTooltip` callers are responsible for their own layout.
* Migrate line-chart tooltip row and annotation popover header to `<Stack>`. Button-internal icon centering (`.annotation-label-trigger-button`, `.annotation-label-popover-close-button`) stays as SCSS — it's single-icon button centering, not layout.
* Migrate the geo-chart container (both the loading placeholder and the main render) to `<Stack>` with centered alignment. `position: relative` stays in SCSS because Google Charts' GeoChart relies on it for tooltip positioning.
* Replace `__experimentalHStack` from `@wordpress/components` with `Stack` from `@wordpress/ui` in the donut story's `CustomPieLegend` example.
* Gap values move from hardcoded px to design-system tokens: `4px → xs`, `8px → sm`, `16px → lg`, `24px → xl`. This contributes to [CHARTS-199](https://linear.app/a8c/issue/CHARTS-199/spacingborder-tokenization) (spacing/border tokenization).

### Other information

Two deviations from the original issue scope, both documented in the commit messages:

* **Trend-indicator skipped.** `TrendIndicator` is a publicly exported component rendered as `<span display: inline-flex>`. `Stack` from `@wordpress/ui` only renders `<div>`, which would change the element from inline to block — a backward-compat regression risk for consumers using it in flowing text. A follow-up is trivial if/when `Stack` gains an `as` prop.
* **One 2px sibling margin left in place.** `.step-label { margin: 0 0 2px 0 }` couldn't be lifted to a Stack `gap` because `@wordpress/ui` Stack only accepts design-system tokens (`xs=4px` is the smallest), not raw pixel values. Migrating would have rounded 2px → 4px, so the margin stays as-is.

## Related product discussion/links

* [CHARTS-175: Use Stack for layout](<https://linear.app/a8c/issue/CHARTS-175/use-stack-for-layout>)
* [CHARTS-199: Spacing/border tokenization](<https://linear.app/a8c/issue/CHARTS-199/spacingborder-tokenization>) (this PR contributes)
* pgvZfX-yD-p2

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This is a refactor with no intended behavior changes. Verification is existing tests + visual parity in Storybook.

* From the monorepo root: `pnpm --filter @automattic/charts test` — expect 841 passing tests across 43 suites.
* From the monorepo root: `pnpm --filter @automattic/charts typecheck` — expect clean.
* Start Storybook: `cd projects/js-packages/storybook && pnpm run storybook:dev` and navigate to each migrated surface. Layout should be visually identical to trunk:
  * Legend: `JS Packages / Charts Library / Components / Legend → Default` (horizontal, items side-by-side with 16px gap) and `Vertical` (items stacked with 8px gap, center-aligned). Items with values should show 8px gap between label text and value.
  * Conversion funnel: `JS Packages / Charts Library / Charts / Conversion Funnel Chart → Default`. Main metric (`10.3% +2%`) should be baseline-aligned with 8px between values, and 24px below the funnel. Four steps (Sessions/Cart/Checkout/Purchase) should have 16px gap, bars bottom-aligned, and 24px between each step's label/rate header and its bar. Click a funnel bar — the default tooltip should show title + rate/items with 4px gap between them.
  * Line chart tooltip: `JS Packages / Charts Library / Charts / Line Chart → Default`. Hover the chart — tooltip rows should have label left, value right, space-between layout.
  * Line chart annotations: `JS Packages / Charts Library / Charts / Line Chart / Annotations → Default`. Three annotation labels should render with title/subtitle column layout.
  * Geo chart: `JS Packages / Charts Library / Charts / Geo Chart → Default`. World map should be centered in the container; tooltips on country hover should still position correctly.
  * Donut custom legend: `JS Packages / Charts Library / Charts / Donut Chart → Custom Legend`. Legend rows should show color dot + label (8px gap) + right-aligned values and comparison percentages.

### Note

This unrelated issue was discovered while testing: [CHARTS-208](https://linear.app/a8c/issue/CHARTS-208)