### PR TITLE
CI: Skip some E2E jobs run from forks

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -326,7 +326,7 @@ jobs:
   test-report:
     name: "Test report"
     runs-on: ubuntu-latest
-    if: ${{ always() && needs.e2e-tests.result != 'cancelled' }}
+    if: ${{ always() && needs.e2e-tests.result != 'cancelled' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
     needs: [e2e-tests]
 
     steps:
@@ -382,7 +382,7 @@ jobs:
       actions: read
       # actions/checkout, actions/download-artifact
       contents: read
-    if: ${{ always() && needs.e2e-tests.result != 'cancelled' }}
+    if: ${{ always() && needs.e2e-tests.result != 'cancelled' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
     needs: [e2e-tests]
 
     steps:


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
Some jobs will fail when run on a PR from a fork. This gates against such failures by skipping the job.

### Other information

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* p1775593103376089-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Try from a fork.

* Example without this change: https://github.com/Automattic/jetpack/actions/runs/24103867477
* Example with this change: https://github.com/Automattic/jetpack/actions/runs/24106069227