### PR TITLE
Launch Site Masterbar Button: Reload page if launching from WP Admin

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/masterbar-launch-button-reload-after-launching
+++ b/projects/packages/jetpack-mu-wpcom/changelog/masterbar-launch-button-reload-after-launching
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Launch Site Masterbar Button: Reload page if launching from WP Admin

--- a/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.js
@@ -4,6 +4,9 @@ import { LaunchButton } from './launch-button';
 
 const queryClient = new QueryClient();
 
+const launchButtonDataAdmin =
+	typeof window === 'object' ? window.JETPACK_LAUNCH_BUTTON_DATA_ADMIN : false;
+
 /**
  * Renders the launch button.
  * @return {Promise<void>}
@@ -19,6 +22,12 @@ async function renderLaunchButton() {
 		<QueryClientProvider client={ queryClient }>
 			<LaunchButton
 				onCelebrationModalClose={ () => {
+					if ( launchButtonDataAdmin ) {
+						// If we're in wp-admin, reload the page so the new site status is reflected.
+						window.location.reload();
+						return;
+					}
+
 					root.unmount();
 					launchButton.remove();
 				} }

--- a/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
@@ -143,6 +143,24 @@ function wpcom_enqueue_launch_button_assets() {
 	Common\wpcom_enqueue_tracking_scripts( 'adminbar-launch-button' );
 }
 
+/**
+ * Enqueue a wp-admin only script that flags the launch button as being in wp-admin.
+ *
+ * This is used to determine whether to reload the page when the celebration modal is closed.
+ */
+function wpcom_enqueue_admin_launch_button_assets() {
+	if ( ! wpcom_should_show_launch_button() ) {
+		return;
+	}
+
+	wp_add_inline_script(
+		'adminbar-launch-button',
+		'var JETPACK_LAUNCH_BUTTON_DATA_ADMIN = true;',
+		'before'
+	);
+}
+
 add_action( 'admin_bar_menu', 'wpcom_add_launch_button_to_admin_bar', 500 );
 add_action( 'wp_enqueue_scripts', 'wpcom_enqueue_launch_button_assets' );
 add_action( 'admin_enqueue_scripts', 'wpcom_enqueue_launch_button_assets' );
+add_action( 'admin_enqueue_scripts', 'wpcom_enqueue_admin_launch_button_assets' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launch-button/launch-button.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launch-button/launch-button.js
@@ -36,9 +36,11 @@ export function LaunchButton( { onCelebrationModalClose } ) {
 	const [ , data ] = useExperimentWithAuth( 'calypso_standardized_site_launch_gating' );
 	const [ showCelebrateLaunchModal, setShowCelebrateLaunchModal ] = useState( false );
 
-	const { mutate: launchSite, isPending } = useLaunchSiteMutation( launchButtonData.blogId, () =>
-		setShowCelebrateLaunchModal( true )
-	);
+	const {
+		mutate: launchSite,
+		isPending,
+		isSuccess,
+	} = useLaunchSiteMutation( launchButtonData.blogId, () => setShowCelebrateLaunchModal( true ) );
 
 	// Default experience. Markup should match what's coming from the back-end.
 	if ( ! data || data.variationName !== 'ungated_site_launch' ) {
@@ -69,17 +71,25 @@ export function LaunchButton( { onCelebrationModalClose } ) {
 
 	return (
 		<>
-			<a
-				className={ `ab-item${ isPending ? ' is-busy' : '' }` }
-				role="menuitem"
-				href="#"
-				onClick={ handleLaunchClick }
-				aria-disabled={ isPending }
-			>
-				<Content />
-			</a>
+			{ ! isSuccess && (
+				<a
+					className={ `ab-item${ isPending ? ' is-busy' : '' }` }
+					role="menuitem"
+					href="#"
+					onClick={ handleLaunchClick }
+					aria-disabled={ isPending }
+				>
+					<Content />
+				</a>
+			) }
 			{ showCelebrateLaunchModal && (
-				<CelebrateLaunchModal { ...launchButtonData } onRequestClose={ onCelebrationModalClose } />
+				<CelebrateLaunchModal
+					{ ...launchButtonData }
+					onRequestClose={ () => {
+						setShowCelebrateLaunchModal( false );
+						onCelebrationModalClose();
+					} }
+				/>
 			) }
 		</>
 	);


### PR DESCRIPTION
Part of DATSCI-1168.

## Proposed changes

Improves the UX of the Launch button in the masterbar:

1. In the front-end, hides the button after launching
2. In WP Admin, reloads the page so the user sees the latest status

## Related product discussion/links

DATSCI-1168.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Assign yourself to the `ungated_site_launch` variant
2. Launch a site from the front-end, and verify the launch button disappears but the user stays on the page.
3. Launch a site from the WP Admin, and verify the launch button disappears AND the page reloads after dismissing the modal.