### PR TITLE
AI Site Logo: fix static edit-post import breaking no-post-editor bundle on P2

### DIFF
--- a/projects/plugins/jetpack/changelog/claude-fervent-jepsen
+++ b/projects/plugins/jetpack/changelog/claude-fervent-jepsen
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Site Logo extension: fix static import of @wordpress/edit-post that caused the no-post-editor bundle to list wp-edit-post as a dependency, breaking the P2 frontend block inserter.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/lib/can-ai-assistant-be-enabled.ts
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/lib/can-ai-assistant-be-enabled.ts
@@ -4,7 +4,6 @@
 import { isUserConnected } from '@automattic/jetpack-shared-extension-utils';
 import { getBlockType } from '@wordpress/blocks';
 import { select } from '@wordpress/data';
-import { store as editPostStore } from '@wordpress/edit-post';
 /*
  * Internal dependencies
  */
@@ -39,11 +38,14 @@ export function canAIAssistantBeEnabled(): boolean {
 	}
 
 	/*
-	 * Do not enable if the AI Assistant block is hidden
-	 * ToDo: the `editPostStore` is undefined for P2 sites.
-	 * Let's find a way to check if the block is hidden.
+	 * Do not enable if the AI Assistant block is hidden.
+	 * Note: `select( 'core/edit-post' )` returns null on P2 sites (no post editor),
+	 * so we fall back to an empty array, which allows the AI Assistant to be enabled.
 	 */
-	const hiddenBlocks = select( editPostStore ).getHiddenBlockTypes?.() ?? [];
+	const hiddenBlocks =
+		(
+			select( 'core/edit-post' ) as null | { getHiddenBlockTypes?: () => string[] }
+		 )?.getHiddenBlockTypes?.() ?? [];
 
 	if ( hiddenBlocks.includes( 'jetpack/ai-assistant' ) ) {
 		return false;

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/index.tsx
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/index.tsx
@@ -184,8 +184,10 @@ function canExtendBlock( name: string ): boolean {
 	 * Note: `select( 'core/edit-post' )` returns null on P2 sites (no post editor),
 	 * so we fall back to an empty array, which allows the extension to load.
 	 */
-	const { getHiddenBlockTypes } = select( 'core/edit-post' ) || {};
-	const hiddenBlocks = getHiddenBlockTypes?.() || [];
+	const hiddenBlocks =
+		(
+			select( 'core/edit-post' ) as null | { getHiddenBlockTypes?: () => string[] }
+		 )?.getHiddenBlockTypes?.() ?? [];
 
 	if ( hiddenBlocks.includes( 'jetpack/ai-assistant' ) ) {
 		return false;

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/index.tsx
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-site-logo/index.tsx
@@ -6,7 +6,6 @@ import { BlockControls } from '@wordpress/block-editor';
 import { getBlockType } from '@wordpress/blocks';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useDispatch, useSelect, select } from '@wordpress/data';
-import { store as editPostStore } from '@wordpress/edit-post';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { addFilter } from '@wordpress/hooks';
 /*
@@ -182,10 +181,11 @@ function canExtendBlock( name: string ): boolean {
 	/*
 	 * Do not extend if the AI Assistant block is hidden,
 	 * as a way for the user to hide the extension.
-	 * TODO: the `editPostStore` is undefined for P2 sites.
-	 * Let's find a way to check if the block is hidden there.
+	 * Note: `select( 'core/edit-post' )` returns null on P2 sites (no post editor),
+	 * so we fall back to an empty array, which allows the extension to load.
 	 */
-	const hiddenBlocks = select( editPostStore ).getHiddenBlockTypes?.() ?? [];
+	const { getHiddenBlockTypes } = select( 'core/edit-post' ) || {};
+	const hiddenBlocks = getHiddenBlockTypes?.() || [];
 
 	if ( hiddenBlocks.includes( 'jetpack/ai-assistant' ) ) {
 		return false;

--- a/projects/plugins/jetpack/tools/check-block-assets.php
+++ b/projects/plugins/jetpack/tools/check-block-assets.php
@@ -84,7 +84,7 @@ $allowed = array(
 chdir( dirname( __DIR__ ) );
 $base   = 'projects/plugins/jetpack/';
 $script = 'projects/plugins/jetpack/tools/check-block-assets.php';
-$issues = array( $script => array() );
+$issues = array();
 
 $tmp = $bad_deps;
 sort( $bad_deps );
@@ -141,9 +141,16 @@ if ( ! empty( $allowed ) ) {
 	}
 }
 
-if ( empty( $issues[ $script ] ) ) {
-	unset( $issues[ $script ] );
+// Additionally, check the editor-no-post-editor bundle to make sure it really lacks a dependency on wp-edit-post.
+if ( file_exists( '_inc/blocks/editor-no-post-editor.asset.php' ) ) {
+	$data = require __DIR__ . '/../_inc/blocks/editor-no-post-editor.asset.php';
+	if ( in_array( 'wp-edit-post', $data['dependencies'], true ) ) {
+		$issues[ $base . '_inc/blocks/editor-no-post-editor.asset.php' ][] = 'The editor-no-post-editor.js bundle depends on wp-edit-post. It must not.';
+	}
+} else {
+	$issues[ $script ][] = 'Cannot check _inc/blocks/editor-no-post-editor.asset.php, asset file not found.';
 }
+
 if ( ! empty( $issues ) ) {
 	echo "\n\n\e[1mBlock view script dependency check detected issues!\e[0m\n";
 	foreach ( $issues as $file => $msgs ) {


### PR DESCRIPTION
Fixes MONOREP-404

## Proposed changes

* Revert the static `import { store as editPostStore } from 'wordpress/edit-post'` introduced by the March 20 monorepo bump (03439481ce) in two files:
  * `extended-blocks/core-site-logo/index.tsx`
  * `blocks/ai-assistant/extensions/lib/can-ai-assistant-be-enabled.ts`

Both static imports caused `dependency-extraction-webpack-plugin` to add `wp-edit-post` as a hard dependency in `editor-no-post-editor.asset.php`. On P2 sites the post editor is never loaded, so WordPress refused to enqueue the script — breaking the P2 frontend block inserter.

The fix uses a dynamic `select( 'core/edit-post' )` call with a null guard (`as null | { getHiddenBlockTypes?: () => string[] }`) in place of the static import. This removes `wp-edit-post` from the asset file while preserving the hidden-blocks check on standard post editor sites.

### Other information

* Root cause confirmed by tracing the import chain: `editor.js` (editorSetup) → `core-site-logo/index.tsx` + `ai-assistant` block → static imports from `wordpress/edit-post` → `wp-edit-post` added to asset.php dependencies.
* Both files had an existing TODO comment acknowledging the store is unavailable on P2 — updated to document the behavior.
* Tested on a WP.com P2: `wp-edit-post` no longer appears in `editor-no-post-editor.asset.php` and the frontend block inserter loads correctly.

## Related product discussion/links

* MONOREP-404

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Go to a P2 site with the Jetpack editor extensions loaded.
* Open the block inserter — it should load without errors (previously it would fail because `wp-edit-post` was listed as a required dependency but not enqueued).
* Verify the AI Site Logo extension and AI Assistant block still work correctly on a standard post editor (the `getHiddenBlockTypes` check should still respect hidden blocks via the dynamic store selection).