### PR TITLE
Charts: Fix Line Chart Annotations Custom story error in Storybook

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -403,6 +403,9 @@ importers:
       '@wordpress/i18n':
         specifier: ^6.0.0
         version: 6.16.0
+      '@wordpress/icons':
+        specifier: ^12.0.0
+        version: 12.0.0(react@18.3.1)
       '@wordpress/theme':
         specifier: 0.10.0
         version: 0.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.5.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -424,9 +424,6 @@ importers:
       fast-deep-equal:
         specifier: 3.1.3
         version: 3.1.3
-      gridicons:
-        specifier: 3.4.2
-        version: 3.4.2(react@18.3.1)
       react-google-charts:
         specifier: ^5.2.1
         version: 5.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/projects/js-packages/charts/changelog/fix-annotation-popover-gridicon
+++ b/projects/js-packages/charts/changelog/fix-annotation-popover-gridicon
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix Line Chart Annotations Custom story error in Storybook by replacing CJS-only gridicons dependency with inline SVG.
+Fix Line Chart Annotations Custom story error in Storybook by replacing CJS-only gridicons dependency with @wordpress/icons.

--- a/projects/js-packages/charts/changelog/fix-annotation-popover-gridicon
+++ b/projects/js-packages/charts/changelog/fix-annotation-popover-gridicon
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix Line Chart Annotations Custom story error in Storybook by replacing CJS-only gridicons dependency with @wordpress/icons.
+Fix Line Chart Annotations Custom and Alert story errors in Storybook by replacing the CJS-only gridicons dependency with @wordpress/icons.

--- a/projects/js-packages/charts/changelog/fix-annotation-popover-gridicon
+++ b/projects/js-packages/charts/changelog/fix-annotation-popover-gridicon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Line Chart Annotations Custom story error in Storybook by replacing CJS-only gridicons dependency with inline SVG.

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -94,7 +94,6 @@
 		"deepmerge": "4.3.1",
 		"dompurify": "^3.3.3",
 		"fast-deep-equal": "3.1.3",
-		"gridicons": "3.4.2",
 		"react-google-charts": "^5.2.1",
 		"tslib": "2.8.1"
 	},

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -87,6 +87,7 @@
 		"@visx/vendor": "^3.12.0",
 		"@visx/xychart": "^3.12.0",
 		"@wordpress/i18n": "^6.0.0",
+		"@wordpress/icons": "^12.0.0",
 		"@wordpress/theme": "0.10.0",
 		"@wordpress/ui": "0.9.0",
 		"clsx": "2.1.1",

--- a/projects/js-packages/charts/src/charts/line-chart/private/line-chart-annotation-label-popover.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/private/line-chart-annotation-label-popover.tsx
@@ -1,11 +1,16 @@
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
-import Gridicon from 'gridicons';
 import { useEffect, useId, useRef, useState } from 'react';
 import { isSafari } from '../../../utils';
 import styles from '../line-chart.module.scss';
 import type { ButtonWithPopover, PopoverElement, ToggleEvent } from '../../../types';
-import type { FC } from 'react';
+import type { FC, SVGProps } from 'react';
+
+const CloseIcon: FC< SVGProps< SVGSVGElement > > = props => (
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" { ...props }>
+		<path d="M18.36 19.78L12 13.41l-6.36 6.37-1.42-1.42L10.59 12 4.22 5.64l1.42-1.42L12 10.59l6.36-6.36 1.41 1.41L13.41 12l6.36 6.36z" />
+	</svg>
+);
 
 export const POPOVER_BUTTON_SIZE = 44;
 
@@ -100,7 +105,7 @@ const LineChartAnnotationLabelWithPopover: FC< LineChartAnnotationLabelWithPopov
 						className={ styles[ 'line-chart__annotation-label-popover-close-button' ] }
 						aria-label={ __( 'Close', 'jetpack-charts' ) }
 					>
-						<Gridicon icon="cross" size={ 16 } />
+						<CloseIcon width={ 16 } height={ 16 } />
 					</button>
 				</div>
 			</div>

--- a/projects/js-packages/charts/src/charts/line-chart/private/line-chart-annotation-label-popover.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/private/line-chart-annotation-label-popover.tsx
@@ -1,16 +1,11 @@
 import { __ } from '@wordpress/i18n';
+import { Icon, close } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useEffect, useId, useRef, useState } from 'react';
 import { isSafari } from '../../../utils';
 import styles from '../line-chart.module.scss';
 import type { ButtonWithPopover, PopoverElement, ToggleEvent } from '../../../types';
-import type { FC, SVGProps } from 'react';
-
-const CloseIcon: FC< SVGProps< SVGSVGElement > > = props => (
-	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" { ...props }>
-		<path d="M18.36 19.78L12 13.41l-6.36 6.37-1.42-1.42L10.59 12 4.22 5.64l1.42-1.42L12 10.59l6.36-6.36 1.41 1.41L13.41 12l6.36 6.36z" />
-	</svg>
-);
+import type { FC } from 'react';
 
 export const POPOVER_BUTTON_SIZE = 44;
 
@@ -105,7 +100,7 @@ const LineChartAnnotationLabelWithPopover: FC< LineChartAnnotationLabelWithPopov
 						className={ styles[ 'line-chart__annotation-label-popover-close-button' ] }
 						aria-label={ __( 'Close', 'jetpack-charts' ) }
 					>
-						<CloseIcon width={ 16 } height={ 16 } />
+						<Icon icon={ close } size={ 16 } />
 					</button>
 				</div>
 			</div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes CHARTS-208

## Proposed changes

The Line Chart Annotations **Custom** story (and **Alert** story) throw `Element type is invalid: expected a string or a class/function but got: object. Check the render method of LineChartAnnotationLabelWithPopover` in Storybook.

**Root cause:** The `gridicons` package is CJS-only (`"use strict"; Object.defineProperty(exports, "__esModule", {value: !0})`). Storybook uses Vite, which can fail to properly resolve the CJS default export during its CJS-to-ESM interop — the `Gridicon` import ends up as an object `{ default: ... }` instead of the actual React component.

**Fix:** Replace the `gridicons` import (used only for a close/cross icon in the popover close button) with `@wordpress/icons`, which is an ESM package already widely used across the monorepo. This eliminates the CJS interop issue and aligns with WordPress ecosystem conventions.

* Replace `import Gridicon from 'gridicons'` with `import { Icon, close } from '@wordpress/icons'`
* Add `@wordpress/icons` as a dependency
* Remove `gridicons` from dependencies
* Update `pnpm-lock.yaml`

### Screenshot (new close icon)

![Screenshot 2026-04-09 at 9 20 59 AM](https://github.com/user-attachments/assets/fd65352b-3781-4bc7-9dde-a8b96454bb8c)

### Other information

Unit tests (75/75 line chart tests) continue to pass. The fix was verified end-to-end in Storybook — both the Custom and Alert annotation stories render correctly.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Run `pnpm storybook:dev` from `projects/js-packages/storybook`
2. Navigate to **JS Packages > Charts Library > Charts > Line Chart > Annotations > Custom**
3. Verify the story renders correctly with custom annotation icons (no error)
4. Navigate to the **Alert** story
5. Verify it also renders correctly with the alert annotation icon

### Before (on trunk)

The Custom story throws: `Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object. Check the render method of LineChartAnnotationLabelWithPopover.`

### After

Both Custom and Alert stories render correctly:

![Custom story rendering correctly](https://cursor.com/artifacts/c/art-4de0774f-470a-4624-993c-2e2d3130bfe7)

![Alert story rendering correctly](https://cursor.com/artifacts/c/art-a1503c0d-a91b-4f0f-a16b-233bd71d86f1)

<a href="https://cursor.com/agents/bc-e9bc88ad-77b6-44f6-ac0c-5e5820ff9f27/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_annotation_stories_with_wordpress_icons.mp4"><img src="https://cursor.com/artifacts/c/art-809be394-eb81-4b7b-8abe-7245a2331ebb" alt="demo_annotation_stories_with_wordpress_icons.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CHARTS-208](https://linear.app/a8c/issue/CHARTS-208/line-chart-annotations-custom-story-throws)

<div><a href="https://cursor.com/agents/bc-e9bc88ad-77b6-44f6-ac0c-5e5820ff9f27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9bc88ad-77b6-44f6-ac0c-5e5820ff9f27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

