### PR TITLE
Fix view_stats capability check for users with multiple roles

### DIFF
--- a/projects/packages/stats/changelog/fix-stats-view-multi-role
+++ b/projects/packages/stats/changelog/fix-stats-view-multi-role
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix view_stats capability check for users with multiple roles by checking all roles instead of only the first.

--- a/projects/packages/stats/src/class-main.php
+++ b/projects/packages/stats/src/class-main.php
@@ -127,12 +127,11 @@ class Main {
 			$user = new WP_User( $user_id );
 			// WordPress 6.9 introduced lazy-loading of some WP_User properties, including `roles`.
 			// It also made said properties protected, so we can't modify keys directly.
-			$user_roles  = $user->roles;
-			$user_role   = array_shift( $user_roles ); // Work with the copy
+			$user_roles  = (array) $user->roles;
 			$stats_roles = Options::get_option( 'roles' );
 
-			// Is the users role in the available stats roles?
-			if ( is_array( $stats_roles ) && in_array( $user_role, $stats_roles, true ) ) {
+			// Is any of the user's roles in the available stats roles?
+			if ( is_array( $stats_roles ) && ! empty( array_intersect( $user_roles, $stats_roles ) ) ) {
 				$caps = array( 'read' );
 			}
 		}

--- a/projects/packages/stats/tests/php/Main_Test.php
+++ b/projects/packages/stats/tests/php/Main_Test.php
@@ -179,6 +179,25 @@ class Main_Test extends StatsBaseTestCase {
 	}
 
 	/**
+	 * Test Main::map_meta_caps with multi-role user where admin is not the first role.
+	 */
+	public function test_view_stats_meta_mapping_multi_role() {
+		$dummy_user_id = wp_insert_user(
+			array(
+				'user_login' => 'dummy_multirole',
+				'user_pass'  => 'password',
+				'role'       => 'subscriber',
+			)
+		);
+
+		// Add administrator as a second role.
+		$user = new \WP_User( $dummy_user_id );
+		$user->add_role( 'administrator' );
+
+		$this->assertTrue( user_can( $dummy_user_id, 'view_stats' ) );
+	}
+
+	/**
 	 * Test Main::should_track
 	 */
 	public function test_should_track_will_return_false_without_connection() {


### PR DESCRIPTION
Fixes #47258

## Proposed changes

* Fixed `view_stats` meta-capability mapping to check **all** user roles instead of only the first one.
* Replaced `array_shift()` + `in_array()` with `array_intersect()` so multi-role users (e.g. `customer` + `administrator`) are correctly granted stats access.
* Added a test for multi-role users where `administrator` is not the first role.

### Other information

The bug occurs because `array_shift($user_roles)` only returns the first role in the array. For users who were assigned a non-admin role before being promoted to administrator, the first role (e.g. `customer`) isn't in the stats allowlist, so they're denied access.

## Related product discussion/links

* https://github.com/Automattic/jetpack/issues/47258

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Create a test user with `subscriber` role
* Add `administrator` as a second role: `$user->add_role('administrator')`
* Verify `user_can($user_id, 'view_stats')` returns `true`
* Previously this would return `false` because only the first role (`subscriber`) was checked