### PR TITLE
Admin page component: add isolation style for wp-ui popovers

### DIFF
--- a/projects/js-packages/components/changelog/update-page-isolation-styles
+++ b/projects/js-packages/components/changelog/update-page-isolation-styles
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Admin page: add isolation styles for wp-ui popovers.

--- a/projects/js-packages/components/components/admin-page/style.module.scss
+++ b/projects/js-packages/components/components/admin-page/style.module.scss
@@ -1,4 +1,7 @@
 .admin-page {
+	// Ensures portaled popovers from `@wordpress/ui` appear correctly.
+	// See https://github.com/WordPress/gutenberg/blob/trunk/packages/ui/README.md#setup
+	isolation: isolate;
 	margin-left: -20px; // to neutralize the padding of #wpcontent.
 
 	@media (max-width: 782px) {


### PR DESCRIPTION

Now that we're using `@wordpress/ui` in all headers of Admin UI as well as in other places of Jetpack UI, let's set up popovers properly as instructed in the package readme.

## Proposed changes
<!--- Explain what functional changes your PR includes -->
*  Adds isolation styles to help portaled popovers from `@wordpress/ui` to appear correctly.

See https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/isolation

See [setup](https://github.com/WordPress/gutenberg/blob/trunk/packages/ui/README.md#setup):

> Also, to ensure that portaled popovers appear correctly, add these isolation styles to your application's layout root element:
>
> ```css
> .root {
>  isolation: isolate;
> }
> ```

No before/after since we're not using popovers yet from `@wordpress/ui`, but it's easy to miss this setup rule for anyone later adding them.

### Other information

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Jetpack pages continue to work
