### PR TITLE
RTC: Multiplex all rooms over a single PingHub WebSocket

### DIFF
--- a/projects/packages/rtc/changelog/dotcom-16641-many-ws-connections-when-post-editor-is-configured-as-site
+++ b/projects/packages/rtc/changelog/dotcom-16641-many-ws-connections-when-post-editor-is-configured-as-site
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+Multiplex all PingHub rooms over a single WebSocket connection per editing session, reducing connection count from N to 1.

--- a/projects/packages/rtc/src/class-rtc.php
+++ b/projects/packages/rtc/src/class-rtc.php
@@ -176,6 +176,8 @@ class RTC {
 			array(
 				'providers'         => $providers,
 				'connectionLogging' => function_exists( 'log2logstash' ),
+				'currentPostType'   => get_post_type() ? get_post_type() : null,
+				'currentPostId'     => get_the_ID() ? get_the_ID() : null,
 			),
 			JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 		);

--- a/projects/packages/rtc/src/js/providers/pinghub/pinghub-bridge.ts
+++ b/projects/packages/rtc/src/js/providers/pinghub/pinghub-bridge.ts
@@ -11,6 +11,12 @@ const CHUNK_HEADER_LEN = 5; // magic(1) + msgId(2) + totalChunks(1) + chunkIndex
 const MAX_PAYLOAD_BEFORE_CHUNK = 1024;
 const MAX_CHUNK_BUFFERS = 256;
 
+/** Null byte used to separate the room tag from the payload. */
+const ROOM_TAG_SEPARATOR = 0x00;
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
 /**
  * Decode a base64 string back into a Uint8Array.
  *
@@ -121,6 +127,39 @@ function getBlogId(): number | null {
 	return null;
 }
 
+/**
+ * Prepend the room name (UTF-8) and a null separator to the payload.
+ *
+ * @param room - Room name.
+ * @param data - Original payload bytes.
+ * @return Tagged payload: [roomBytes, 0x00, ...data].
+ */
+function tagPayload( room: string, data: Uint8Array ): Uint8Array {
+	const roomBytes = textEncoder.encode( room );
+	const out = new Uint8Array( roomBytes.length + 1 + data.length );
+	out.set( roomBytes, 0 );
+	out[ roomBytes.length ] = ROOM_TAG_SEPARATOR;
+	out.set( data, roomBytes.length + 1 );
+	return out;
+}
+
+/**
+ * Extract the room name and payload from a tagged message.
+ *
+ * @param data - Tagged payload bytes.
+ * @return Room and payload, or null if no separator found.
+ */
+function untagPayload( data: Uint8Array ): { room: string; payload: Uint8Array } | null {
+	const idx = data.indexOf( ROOM_TAG_SEPARATOR );
+	if ( idx === -1 ) {
+		return null;
+	}
+	return {
+		room: textDecoder.decode( data.subarray( 0, idx ) ),
+		payload: data.subarray( idx + 1 ),
+	};
+}
+
 const JWT_CACHE_TTL_MS = 60 * 1000; // 1 minute
 const MAX_JWT_FETCH_FAILURES = 5;
 const JWT_BACKOFF_BASE_MS = 1000;
@@ -205,19 +244,27 @@ export function logConnectionEvent(
 	} ).catch( () => {} );
 }
 
+/**
+ * PingHub bridge that multiplexes all rooms over a single WebSocket.
+ *
+ * All rooms share one PingHub channel scoped to the post being edited.
+ * Messages are tagged with the room name inside the binary payload so
+ * the bridge can demultiplex incoming messages to the correct handlers.
+ */
 export class PingHubBridge {
 	private openHandlers = new Map< string, Set< () => void > >();
 	private closeHandlers = new Map< string, Set< ( code: number, reason: string ) => void > >();
 	private messageHandlers = new Map< string, Set< ( data: Uint8Array ) => void > >();
-	/** Active WebSocket per room. */
-	private sockets = new Map< string, WebSocket >();
-	/** Waiters for an in-flight connect per room. */
-	private connectingWaiters = new Map<
-		string,
-		Array< { resolve: () => void; reject: ( err: Error ) => void } >
-	>();
-	/** Per-room message ID for chunked sends. */
-	private chunkMsgIdByRoom = new Map< string, number >();
+	/** The single shared WebSocket connection. */
+	private ws: WebSocket | null = null;
+	/** State of the shared connection. */
+	private wsState: 'idle' | 'connecting' | 'open' = 'idle';
+	/** Rooms currently registered on this bridge. */
+	private registeredRooms = new Set< string >();
+	/** Waiters for the shared WebSocket to open. */
+	private connectingWaiters: Array< { resolve: () => void; reject: ( err: Error ) => void } > = [];
+	/** Global message ID counter for chunked sends. */
+	private chunkMsgId = 0;
 	/** Cached JWT for PingHub authentication. */
 	private cachedJwt: string | null = null;
 	private cachedJwtTimestamp = 0;
@@ -232,19 +279,25 @@ export class PingHubBridge {
 		string,
 		{ totalChunks: number; chunks: Map< number, Uint8Array > }
 	>();
+	/** Timestamp when the shared WebSocket started connecting. */
+	private wsConnectStart = 0;
 
 	/**
-	 * Build the full PingHub path for a room name.
+	 * Build the shared PingHub channel path for this editing session.
 	 *
-	 * @param room - Short room identifier (e.g. "postType-post-42").
-	 * @return Full PingHub channel path.
+	 * @return Full WebSocket URL for the shared channel.
 	 */
-	private fullPath( room: string ): string {
+	private channelPath(): string {
 		const blogId = getBlogId();
 		if ( ! blogId ) {
 			throw new Error( 'Cannot determine blog ID for PingHub bridge' );
 		}
-		return `wss://public-api.wordpress.com/pinghub/wpcom/rtc/${ blogId }/${ room }`;
+		const postType = window.jetpackRTC?.currentPostType;
+		const postId = window.jetpackRTC?.currentPostId;
+		if ( ! postType || ! postId ) {
+			throw new Error( 'Cannot determine current post for PingHub bridge' );
+		}
+		return `wss://public-api.wordpress.com/pinghub/wpcom/rtc/${ blogId }/editor/${ postType }/${ postId }`;
 	}
 
 	/**
@@ -271,12 +324,15 @@ export class PingHubBridge {
 	/**
 	 * Buffer incoming chunks and dispatch the reassembled message when all chunks have arrived.
 	 *
-	 * @param room               - Room name.
-	 * @param parsed             - Parsed chunk header and payload.
+	 * Each chunk's payload already contains the room tag. The room is extracted from the first
+	 * chunk and used as part of the reassembly buffer key.
+	 *
+	 * @param room               - Room name (extracted from the chunk's tagged payload).
+	 * @param parsed             - Parsed chunk header and stripped payload (without room tag).
 	 * @param parsed.msgId       - Message identifier shared across all chunks of one message.
 	 * @param parsed.totalChunks - Total number of chunks expected.
 	 * @param parsed.chunkIndex  - Zero-based index of this chunk.
-	 * @param parsed.payload     - Payload bytes for this chunk.
+	 * @param parsed.payload     - Payload bytes for this chunk (room tag already stripped).
 	 */
 	private reassembleChunk(
 		room: string,
@@ -408,85 +464,68 @@ export class PingHubBridge {
 	}
 
 	/**
-	 * Open a direct WebSocket connection to PingHub for the given room.
-	 *
-	 * Fetches a short-lived JWT from the REST endpoint and appends it as
-	 * ?jwt=<token> so pinghub-auth.php can authenticate the connection when
-	 * WPCOM cookies are absent (third-party cookie blocking on custom-domain
-	 * Jetpack/Atomic sites).
-	 *
-	 * @param room - Room name.
-	 * @return Promise
+	 * Open the shared WebSocket if it isn't already open or connecting.
 	 */
-	async connect( room: string ): Promise< void > {
-		// Already open: fire open handlers and return.
-		const existing = this.sockets.get( room );
-		if ( existing?.readyState === WebSocket.OPEN ) {
-			this.openHandlers.get( room )?.forEach( h => h() );
-			return Promise.resolve();
+	private async openSharedSocket(): Promise< void > {
+		if ( this.wsState !== 'idle' ) {
+			return;
 		}
+		this.wsState = 'connecting';
 
-		// Connect already in flight: wait for it instead of opening another socket.
-		const existingWaiters = this.connectingWaiters.get( room );
-		if ( existingWaiters ) {
-			return new Promise( ( resolve, reject ) => existingWaiters.push( { resolve, reject } ) );
-		}
-
-		const waiters: Array< { resolve: () => void; reject: ( err: Error ) => void } > = [];
-		this.connectingWaiters.set( room, waiters );
-
-		// Fetch a short-lived JWT for authentication. Without it the
-		// connection cannot authenticate, so bail out early.
 		const jwt = await this.fetchPinghubJwt();
 		if ( ! jwt ) {
-			this.connectingWaiters.delete( room );
+			this.wsState = 'idle';
 			const err = new Error( 'PingHub JWT fetch failed' );
-			waiters.splice( 0 ).forEach( ( { reject } ) => reject( err ) );
-			return Promise.reject( err );
+			this.connectingWaiters.splice( 0 ).forEach( ( { reject } ) => reject( err ) );
+			return;
 		}
 
-		const wsUrl = this.fullPath( room ) + '?jwt=' + encodeURIComponent( jwt );
+		const wsUrl = this.channelPath() + '?jwt=' + encodeURIComponent( jwt );
 		const ws = new WebSocket( wsUrl );
 		ws.binaryType = 'arraybuffer';
-		this.sockets.set( room, ws );
-
-		const start = Date.now();
+		this.ws = ws;
+		this.wsConnectStart = Date.now();
 
 		ws.addEventListener( 'open', () => {
-			const elapsed = Date.now() - start;
+			const elapsed = Date.now() - this.wsConnectStart;
+			this.wsState = 'open';
 			pixel( 'pinghub.conn_open', elapsed, 'ms' );
 			pixel( 'pinghub.rtc.conn_open', elapsed, 'ms' );
 			logConnectionEvent( 'connected', {
-				room,
 				time_to_connect_ms: elapsed,
+				active_rooms: this.registeredRooms.size,
 			} );
-			this.connectingWaiters.delete( room );
-			waiters.splice( 0 ).forEach( ( { resolve } ) => resolve() );
-			this.openHandlers.get( room )?.forEach( h => h() );
+			this.connectingWaiters.splice( 0 ).forEach( ( { resolve } ) => resolve() );
+			for ( const room of this.registeredRooms ) {
+				this.openHandlers.get( room )?.forEach( h => h() );
+			}
 		} );
 
 		ws.addEventListener( 'close', event => {
-			const elapsed = Date.now() - start;
+			const elapsed = Date.now() - this.wsConnectStart;
 			pixel( 'pinghub.conn_close_code.' + event.code, elapsed, 'ms' );
 			pixel( 'pinghub.rtc.conn_close_code.' + event.code, elapsed, 'ms' );
 			logConnectionEvent( 'disconnected', {
-				room,
 				close_code: event.code,
 				close_reason: event.reason,
 				connection_lifetime_ms: elapsed,
+				active_rooms: this.registeredRooms.size,
 			} );
-			this.sockets.delete( room );
-			if ( this.connectingWaiters.has( room ) ) {
-				this.connectingWaiters.delete( room );
+			const wasConnecting = this.wsState === 'connecting';
+			this.ws = null;
+			this.wsState = 'idle';
+			if ( wasConnecting ) {
 				const err = new Error( 'PingHub connect failed' );
-				waiters.splice( 0 ).forEach( ( { reject } ) => reject( err ) );
+				this.connectingWaiters.splice( 0 ).forEach( ( { reject } ) => reject( err ) );
 			}
-			this.closeHandlers.get( room )?.forEach( h => h( event.code, event.reason ) );
+			for ( const room of this.registeredRooms ) {
+				this.closeHandlers.get( room )?.forEach( h => h( event.code, event.reason ) );
+			}
 		} );
 
 		ws.addEventListener( 'error', () => {
-			pixel( 'pinghub.conn_err', Date.now() - start, 'ms' );
-			pixel( 'pinghub.rtc.conn_err', Date.now() - start, 'ms' );
+			pixel( 'pinghub.conn_err', Date.now() - this.wsConnectStart, 'ms' );
+			pixel( 'pinghub.rtc.conn_err', Date.now() - this.wsConnectStart, 'ms' );
 		} );
 
 		ws.addEventListener( 'message', event => {
@@ -503,64 +542,113 @@ export class PingHubBridge {
 			} else {
 				return;
 			}
+
 			const parsed = parseChunkHeader( u8 );
 			if ( parsed ) {
-				this.reassembleChunk( room, parsed );
+				// Each chunk's payload is room-tagged. Extract the room,
+				// strip the tag, and reassemble with clean payloads.
+				const tagged = untagPayload( parsed.payload );
+				if ( ! tagged || ! this.registeredRooms.has( tagged.room ) ) {
+					return;
+				}
+				this.reassembleChunk( tagged.room, {
+					msgId: parsed.msgId,
+					totalChunks: parsed.totalChunks,
+					chunkIndex: parsed.chunkIndex,
+					payload: tagged.payload,
+				} );
 			} else {
-				this.messageHandlers.get( room )?.forEach( h => h( u8 ) );
+				const tagged = untagPayload( u8 );
+				if ( ! tagged || ! this.registeredRooms.has( tagged.room ) ) {
+					return;
+				}
+				this.messageHandlers.get( tagged.room )?.forEach( h => h( tagged.payload ) );
 			}
-		} );
-
-		return new Promise( ( resolve, reject ) => {
-			waiters.push( { resolve, reject } );
 		} );
 	}
 
 	/**
-	 * Close the WebSocket for the given room.
+	 * Register a room on the shared WebSocket connection.
+	 *
+	 * If the WebSocket is already open, the room's open handlers fire
+	 * immediately. If it is not yet open, it is opened (or the room
+	 * waits for the in-flight connection to complete).
+	 *
+	 * @param room - Room name.
+	 * @return Promise that resolves when the connection is open.
+	 */
+	async connect( room: string ): Promise< void > {
+		this.registeredRooms.add( room );
+
+		if ( this.wsState === 'open' ) {
+			this.openHandlers.get( room )?.forEach( h => h() );
+			return;
+		}
+
+		const promise = new Promise< void >( ( resolve, reject ) => {
+			this.connectingWaiters.push( { resolve, reject } );
+		} );
+
+		this.openSharedSocket();
+
+		return promise;
+	}
+
+	/**
+	 * Unregister a room. If no rooms remain, close the shared WebSocket.
 	 *
 	 * @param room - Room name.
 	 */
 	async disconnect( room: string ): Promise< void > {
-		const ws = this.sockets.get( room );
-		this.sockets.delete( room );
-		this.connectingWaiters.delete( room );
-		if ( ws && ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING ) {
-			ws.close( 1000, 'disconnect' );
+		this.registeredRooms.delete( room );
+
+		// Clean up chunk buffers for this room.
+		for ( const key of this.chunkBuffers.keys() ) {
+			if ( key.startsWith( room + ':' ) ) {
+				this.chunkBuffers.delete( key );
+			}
+		}
+
+		if ( this.registeredRooms.size === 0 && this.ws ) {
+			if ( this.ws.readyState !== WebSocket.CLOSED && this.ws.readyState !== WebSocket.CLOSING ) {
+				this.ws.close( 1000, 'disconnect' );
+			}
+			this.ws = null;
+			this.wsState = 'idle';
 		}
 	}
 
 	/**
 	 * Send binary data to peers in the given room.
 	 *
-	 * Messages larger than MAX_PAYLOAD_BEFORE_CHUNK bytes are split into chunks
-	 * so all peers (regardless of transport) can reassemble them.
+	 * The payload is tagged with the room name before chunking and sending,
+	 * so all peers on the shared channel can demultiplex by room.
 	 *
 	 * @param room - Room name.
 	 * @param data - Payload to send.
 	 */
 	send( room: string, data: Uint8Array ): void {
-		const ws = this.sockets.get( room );
-		if ( ! ws || ws.readyState !== WebSocket.OPEN ) {
+		if ( ! this.ws || this.ws.readyState !== WebSocket.OPEN ) {
 			pixel( 'pinghub.rtc.send_drop', 1, 'c' );
 			return;
 		}
 
-		const sendOne = ( payload: Uint8Array ) => ws.send( uint8ArrayToBase64( payload ) );
+		const tagged = tagPayload( room, data );
+		const sendOne = ( payload: Uint8Array ) => this.ws!.send( uint8ArrayToBase64( payload ) );
 
-		if ( data.length <= MAX_PAYLOAD_BEFORE_CHUNK ) {
-			sendOne( data );
+		if ( tagged.length <= MAX_PAYLOAD_BEFORE_CHUNK ) {
+			sendOne( tagged );
 			return;
 		}
 
 		// eslint-disable-next-line no-bitwise
-		const msgId = ( this.chunkMsgIdByRoom.get( room ) ?? 0 ) & 0xffff;
-		this.chunkMsgIdByRoom.set( room, msgId + 1 );
+		const msgId = this.chunkMsgId & 0xffff;
+		this.chunkMsgId++;
 		const chunkSize = MAX_PAYLOAD_BEFORE_CHUNK - CHUNK_HEADER_LEN;
-		const totalChunks = Math.ceil( data.length / chunkSize );
+		const totalChunks = Math.ceil( tagged.length / chunkSize );
 		for ( let i = 0; i < totalChunks; i++ ) {
 			const start = i * chunkSize;
-			const payload = data.subarray( start, Math.min( start + chunkSize, data.length ) );
+			const payload = tagged.subarray( start, Math.min( start + chunkSize, tagged.length ) );
 			sendOne( buildChunk( msgId, totalChunks, i, payload ) );
 		}
 	}


### PR DESCRIPTION
Fixes DOTCOM-16641
Requires 210947-ghe-Automattic/wpcom

## Proposed changes

* Rewrite `PingHubBridge` to multiplex all rooms over a single shared WebSocket connection per editing session, instead of opening one WebSocket per entity.
* The shared channel is scoped to the post being edited: `/wpcom/rtc/{blogId}/editor/{postType}/{postId}`.
* Messages are tagged with the room name inside the binary payload (room bytes + `0x00` separator + Yjs data) so peers can demultiplex incoming messages to the correct Yjs document.
* Pass `currentPostType` and `currentPostId` from PHP via `window.jetpackRTC` so the bridge can build the channel path.

### Other information

When the post editor has "Show template" enabled, Gutenberg syncs every entity the template references (navigation menus, pages, taxonomy terms, etc.), which can trigger many simultaneous WebSocket connections. Each connection requires a separate auth subrequest through the PingHub proxy, causing progressive time-to-connect degradation.

This change reduces the connection count from N to 1. The bridge's public API (`connect`/`disconnect`/`send`/`on`/`off`) remains room-based, so the manager and provider need no changes. No changes to the PingHub Go server are needed — it just sees one channel with tagged messages.

## Related product discussion/links

* DOTCOM-16641

## Does this pull request change what data or activity we track or use?

The `pinghub_connected` and `pinghub_disconnected` Logstash events now fire once per editing session (for the shared connection) instead of once per entity room. The `active_rooms` property is included to indicate how many rooms are multiplexed.

## Testing instructions

* Apply 210947-ghe-Automattic/wpcom to your sandbox
* Apply these changes too
* Open a site with RTC enabled that uses a block theme
* Edit a post and enable "Show template" via the Template panel dropdown in the sidebar
* Open DevTools → Network → WS tab
* Verify there is only **one** WebSocket connection to `/pinghub/wpcom/rtc/{blogId}/editor/{postType}/{postId}` instead of multiple individual connections
* Verify real-time sync works:
  * Open the same post in two browser windows and confirm edits propagate
  * Verify notes are synced too

🤖 Generated with [Claude Code](https://claude.com/claude-code)