### PR TITLE
CI: Fix broken tests that surfaced after PHPUnit 12.5.17 update

### DIFF
--- a/projects/packages/boost-speed-score/changelog/fix-ci-repair_broken_tests
+++ b/projects/packages/boost-speed-score/changelog/fix-ci-repair_broken_tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Prevent tests from exiting early.
+
+

--- a/projects/packages/boost-speed-score/tests/bootstrap.php
+++ b/projects/packages/boost-speed-score/tests/bootstrap.php
@@ -5,6 +5,10 @@
  * @package automattic/
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
 // Include the composer autoloader.
 require_once __DIR__ . '/../vendor/autoload.php';
 

--- a/projects/packages/error/changelog/fix-ci-repair_broken_tests
+++ b/projects/packages/error/changelog/fix-ci-repair_broken_tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Prevent tests from exiting early.
+
+

--- a/projects/packages/error/tests/php/bootstrap.php
+++ b/projects/packages/error/tests/php/bootstrap.php
@@ -5,6 +5,10 @@
  * @package automattic/jetpack-error
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
 /**
  * Load Composer autoloader.
  */

--- a/projects/packages/jitm/changelog/fix-ci-repair_broken_tests
+++ b/projects/packages/jitm/changelog/fix-ci-repair_broken_tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Prevent tests from exiting early.
+
+

--- a/projects/packages/jitm/tests/php/Rest_Api_Endpoints_Test.php
+++ b/projects/packages/jitm/tests/php/Rest_Api_Endpoints_Test.php
@@ -5,11 +5,22 @@ namespace Automattic\Jetpack;
 use Automattic\Jetpack\JITMS\JITM;
 use Automattic\Jetpack\JITMS\Rest_Api_Endpoints;
 use Brain\Monkey;
+use Brain\Monkey\Functions;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @runTestsInSeparateProcesses
+ */
+#[RunTestsInSeparateProcesses]
 class Rest_Api_Endpoints_Test extends TestCase {
 	use MockeryPHPUnitIntegration;
+
+	/**
+	 * @var \Mockery\MockInterface
+	 */
+	private $mock_jitm;
 
 	/**
 	 * Set up.
@@ -17,6 +28,9 @@ class Rest_Api_Endpoints_Test extends TestCase {
 	public function setUp(): void {
 		parent::setUp();
 		Monkey\setUp();
+		Functions\when( 'urldecode_deep' )->returnArg( 1 );
+		$this->mock_jitm = \Mockery::mock( 'overload:' . JITM::class );
+		$this->mock_jitm->shouldReceive( 'get_instance' )->andReturnSelf();
 	}
 
 	/**
@@ -31,10 +45,8 @@ class Rest_Api_Endpoints_Test extends TestCase {
 	 * Test that get_jitm_message returns empty array when JITMs are disabled.
 	 */
 	public function test_get_jitm_message_returns_empty_when_disabled() {
-		$mock_jitm = \Mockery::mock( 'overload:' . JITM::class );
-		$mock_jitm->shouldReceive( 'get_instance' )->andReturnSelf();
-		$mock_jitm->shouldReceive( 'jitms_enabled' )->once()->andReturn( false );
-		$mock_jitm->shouldNotReceive( 'get_messages' );
+		$this->mock_jitm->shouldReceive( 'jitms_enabled' )->once()->andReturn( false );
+		$this->mock_jitm->shouldNotReceive( 'get_messages' );
 
 		$request = $this->create_mock_request( 'test_path', '' );
 
@@ -47,10 +59,8 @@ class Rest_Api_Endpoints_Test extends TestCase {
 	 * Test that get_jitm_message passes empty array when query is empty.
 	 */
 	public function test_get_jitm_message_with_empty_query() {
-		$mock_jitm = \Mockery::mock( 'overload:' . JITM::class );
-		$mock_jitm->shouldReceive( 'get_instance' )->andReturnSelf();
-		$mock_jitm->shouldReceive( 'jitms_enabled' )->once()->andReturn( true );
-		$mock_jitm->shouldReceive( 'get_messages' )
+		$this->mock_jitm->shouldReceive( 'jitms_enabled' )->once()->andReturn( true );
+		$this->mock_jitm->shouldReceive( 'get_messages' )
 			->once()
 			->with( 'test_path', array(), false )
 			->andReturn( array( 'test_message' ) );
@@ -66,10 +76,8 @@ class Rest_Api_Endpoints_Test extends TestCase {
 	 * Test that get_jitm_message correctly parses query string into array.
 	 */
 	public function test_get_jitm_message_parses_query_string() {
-		$mock_jitm = \Mockery::mock( 'overload:' . JITM::class );
-		$mock_jitm->shouldReceive( 'get_instance' )->andReturnSelf();
-		$mock_jitm->shouldReceive( 'jitms_enabled' )->once()->andReturn( true );
-		$mock_jitm->shouldReceive( 'get_messages' )
+		$this->mock_jitm->shouldReceive( 'jitms_enabled' )->once()->andReturn( true );
+		$this->mock_jitm->shouldReceive( 'get_messages' )
 			->once()
 			->with(
 				'woomobile:my_store:admin_notices',
@@ -96,10 +104,8 @@ class Rest_Api_Endpoints_Test extends TestCase {
 	 * Test that get_jitm_message handles URL-encoded query strings.
 	 */
 	public function test_get_jitm_message_handles_url_encoded_query() {
-		$mock_jitm = \Mockery::mock( 'overload:' . JITM::class );
-		$mock_jitm->shouldReceive( 'get_instance' )->andReturnSelf();
-		$mock_jitm->shouldReceive( 'jitms_enabled' )->once()->andReturn( true );
-		$mock_jitm->shouldReceive( 'get_messages' )
+		$this->mock_jitm->shouldReceive( 'jitms_enabled' )->once()->andReturn( true );
+		$this->mock_jitm->shouldReceive( 'get_messages' )
 			->once()
 			->with(
 				'test_path',
@@ -121,10 +127,8 @@ class Rest_Api_Endpoints_Test extends TestCase {
 	 * Test that full_jp_logo_exists parameter is correctly passed.
 	 */
 	public function test_get_jitm_message_passes_logo_exists_param() {
-		$mock_jitm = \Mockery::mock( 'overload:' . JITM::class );
-		$mock_jitm->shouldReceive( 'get_instance' )->andReturnSelf();
-		$mock_jitm->shouldReceive( 'jitms_enabled' )->once()->andReturn( true );
-		$mock_jitm->shouldReceive( 'get_messages' )
+		$this->mock_jitm->shouldReceive( 'jitms_enabled' )->once()->andReturn( true );
+		$this->mock_jitm->shouldReceive( 'get_messages' )
 			->once()
 			->with( 'test_path', array(), true )
 			->andReturn( array() );
@@ -143,7 +147,7 @@ class Rest_Api_Endpoints_Test extends TestCase {
 	 * @return \WP_REST_Request Mock request object.
 	 */
 	private function create_mock_request( $message_path, $query, $full_jp_logo_exists = 'false' ) {
-		$request = \Mockery::mock( 'WP_REST_Request' );
+		$request = \Mockery::mock( 'WP_REST_Request, ArrayAccess' );
 		$request->shouldReceive( 'offsetGet' )->with( 'message_path' )->andReturn( $message_path );
 		$request->shouldReceive( 'offsetGet' )->with( 'query' )->andReturn( $query );
 		$request->shouldReceive( 'offsetGet' )->with( 'full_jp_logo_exists' )->andReturn( $full_jp_logo_exists );

--- a/projects/packages/jitm/tests/php/Rest_Api_Endpoints_Test.php
+++ b/projects/packages/jitm/tests/php/Rest_Api_Endpoints_Test.php
@@ -7,13 +7,16 @@ use Automattic\Jetpack\JITMS\Rest_Api_Endpoints;
 use Brain\Monkey;
 use Brain\Monkey\Functions;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
  */
 #[RunTestsInSeparateProcesses]
+#[PreserveGlobalState( false )]
 class Rest_Api_Endpoints_Test extends TestCase {
 	use MockeryPHPUnitIntegration;
 

--- a/projects/packages/jitm/tests/php/bootstrap.php
+++ b/projects/packages/jitm/tests/php/bootstrap.php
@@ -5,6 +5,10 @@
  * @package automattic/jetpack-jitm
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
 /**
  * Include the composer autoloader.
  */

--- a/projects/packages/jitm/tests/php/bootstrap.php
+++ b/projects/packages/jitm/tests/php/bootstrap.php
@@ -9,6 +9,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', __DIR__ . '/' );
 }
 
+if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
+	define( 'MINUTE_IN_SECONDS', 60 );
+}
+
 /**
  * Include the composer autoloader.
  */


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
This ensures `ABSPATH` is set before running `boost-speed-score`, `error`, and `jitm` package tests. It also cleans up/fixes some issues in the JITM tests:
* `MINUTE_IN_SECONDS` wasn't defined
* classes were being redeclared
* `urldecode_deep` wasn't defined
* `WP_REST_Request` needed `ArrayAccess`

### Other information
In #44832 I guarded against direct access to various files. This made some tests exit early due to `ABSPATH` not being defined. However, PHPUnit didn't at that time flag test exits as failures, so the tests "quietly" failed.

There actually was this message, but no one caught it: `Fatal error: Premature end of PHP process when running ***`

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* p1775636086954439-slack-C034JEXD1RD
* sebastianbergmann/phpunit#4793

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

PHPUnit tests in PHP 8.3, 8.4, and 8.5 should now pass.