### PR TITLE
Forms: Load build.php unconditionally to support external host applications

### DIFF
--- a/projects/packages/forms/changelog/update-forms-wp-build-load
+++ b/projects/packages/forms/changelog/update-forms-wp-build-load
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Load build.php unconditionally when alpha is enabled, so host applications can integrate Forms routes without manual file loading.

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -28,35 +28,42 @@ class Dashboard {
 	 * This is for the new DataViews-based responses list.
 	 */
 	public static function load_wp_build() {
-		if ( self::get_admin_query_page() === self::FORMS_WPBUILD_ADMIN_SLUG ) {
-			// When no route path is specified, redirect to the default view
-			// so the client-side router doesn't need a catch-all root route.
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			if ( ! isset( $_GET['p'] ) ) {
-				$default_tab = Contact_Form_Plugin::has_editor_feature_flag( 'central-form-management' )
-					? 'forms'
-					: 'inbox';
+		// Load build.php unconditionally so that script/module/route registration
+		// hooks are available to any host application (standalone Forms page, CIAB, etc.).
+		// The actual route init action (jetpack-forms-responses-wp-admin_init) is fired
+		// by each host's own enqueue handler — not here — to avoid double-firing.
+		$wp_build_index = dirname( __DIR__, 2 ) . '/build/build.php';
 
-				wp_safe_redirect( self::get_forms_admin_url( $default_tab ) );
-
-				exit;
-			}
-
-			// Register polyfills for WP < 7.0 (must run before build.php).
-			WP_Build_Polyfills::register(
-				'jetpack-forms',
-				array_merge(
-					WP_Build_Polyfills::SCRIPT_HANDLES,
-					WP_Build_Polyfills::MODULE_IDS
-				)
-			);
-
-			$wp_build_index = dirname( __DIR__, 2 ) . '/build/build.php';
-
-			if ( file_exists( $wp_build_index ) ) {
-				require_once $wp_build_index;
-			}
+		if ( file_exists( $wp_build_index ) ) {
+			require_once $wp_build_index;
 		}
+
+		// The remaining setup only applies to the standalone Forms page.
+		if ( self::get_admin_query_page() !== self::FORMS_WPBUILD_ADMIN_SLUG ) {
+			return;
+		}
+
+		// When no route path is specified, redirect to the default view
+		// so the client-side router doesn't need a catch-all root route.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! isset( $_GET['p'] ) ) {
+			$default_tab = Contact_Form_Plugin::has_editor_feature_flag( 'central-form-management' )
+				? 'forms'
+				: 'inbox';
+
+			wp_safe_redirect( self::get_forms_admin_url( $default_tab ) );
+
+			exit;
+		}
+
+		// Register polyfills for WP < 7.0 (must run before enqueue).
+		WP_Build_Polyfills::register(
+			'jetpack-forms',
+			array_merge(
+				WP_Build_Polyfills::SCRIPT_HANDLES,
+				WP_Build_Polyfills::MODULE_IDS
+			)
+		);
 	}
 
 	/**

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -28,10 +28,21 @@ class Dashboard {
 	 * This is for the new DataViews-based responses list.
 	 */
 	public static function load_wp_build() {
-		// Load build.php unconditionally so that script/module/route registration
-		// hooks are available to any host application (standalone Forms page, CIAB, etc.).
-		// The actual route init action (jetpack-forms-responses-wp-admin_init) is fired
-		// by each host's own enqueue handler — not here — to avoid double-firing.
+		// Always load for the standalone Forms page.
+		$should_load = self::get_admin_query_page() === self::FORMS_WPBUILD_ADMIN_SLUG;
+
+		/**
+		 * Filter whether to load the wp-build asset registrations.
+		 * Host applications (e.g., CIAB) can return true to opt in.
+		 *
+		 * @param bool $should_load Whether build.php should be loaded.
+		 */
+		$should_load = apply_filters( 'jetpack_forms_load_wp_build', $should_load );
+
+		if ( ! $should_load ) {
+			return;
+		}
+
 		$wp_build_index = dirname( __DIR__, 2 ) . '/build/build.php';
 
 		if ( file_exists( $wp_build_index ) ) {


### PR DESCRIPTION
Fixes #

## Proposed changes

* Move `require_once build.php` outside the page slug guard in `Dashboard::load_wp_build()` so it runs unconditionally when `jetpack_forms_alpha` is enabled
* Remove the unconditional `do_action('jetpack-forms-responses-wp-admin_init')` that was added in #47784 — each host application (standalone Forms page, CIAB) fires this action in its own enqueue handler, so firing it here caused duplicate route registration and a `tiny-invariant` "Duplicate routes" error
* Keep the redirect logic and polyfill registration gated behind the standalone Forms page check

### Other information

This is a follow-up to #47784 which bundled the admin-ui CSS change with a `load_wp_build()` restructure. The CSS change was merged separately; this PR contains only the `load_wp_build()` changes with the double-firing bug fixed.

The `_init` action is already fired by:
- `page-wp-admin.php` (auto-generated by wp-build) during `admin_enqueue_scripts` for the standalone Forms page
- `ciab-next.php` during `next_admin_init` for the CIAB SPA

## Related product discussion/links

* PR #47784

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Ensure `jetpack_forms_alpha` filter returns `true`
* Go to the standalone Forms admin page (Jetpack > Forms) — verify it loads without console errors
* Navigate between tabs (Inbox, Spam, Trash, Forms) — verify no "Duplicate routes" errors
* Verify other wp-admin pages still work correctly (no script interference)