### PR TITLE
RTC: Send bell notification to plan owner when non-admin is blocked by collaborator limit

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-16367-rtc-bell-notification
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-16367-rtc-bell-notification
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add lib/ with reusable site owner and bell notification helpers

--- a/projects/packages/jetpack-mu-wpcom/phpunit.11.xml.dist
+++ b/projects/packages/jetpack-mu-wpcom/phpunit.11.xml.dist
@@ -25,6 +25,9 @@
 		<testsuite name="common">
 			<directory suffix="Test.php">tests/php/common</directory>
 		</testsuite>
+		<testsuite name="lib">
+			<directory suffix="Test.php">tests/php/lib</directory>
+		</testsuite>
 	</testsuites>
 
 	<source>

--- a/projects/packages/jetpack-mu-wpcom/phpunit.9.xml.dist
+++ b/projects/packages/jetpack-mu-wpcom/phpunit.9.xml.dist
@@ -16,5 +16,8 @@
 		<testsuite name="common">
 			<directory suffix="Test.php">tests/php/common</directory>
 		</testsuite>
+		<testsuite name="lib">
+			<directory suffix="Test.php">tests/php/lib</directory>
+		</testsuite>
 	</testsuites>
 </phpunit>

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -30,6 +30,7 @@ class Jetpack_Mu_Wpcom {
 		// Shared code for src/features.
 		require_once self::PKG_DIR . 'src/common/index.php'; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
 		require_once __DIR__ . '/utils.php';
+		require_once __DIR__ . '/lib/load.php';
 
 		// Load features that don't need any special loading considerations.
 		add_action( 'plugins_loaded', array( __CLASS__, 'load_features' ) );

--- a/projects/packages/jetpack-mu-wpcom/src/lib/AGENTS.md
+++ b/projects/packages/jetpack-mu-wpcom/src/lib/AGENTS.md
@@ -1,0 +1,66 @@
+# WPCom Lib — Reusable Operations
+
+Generic helper functions that work on both Simple and Atomic/WoW WordPress.com sites. Use these instead of reimplementing platform-specific logic.
+
+## Available Operations
+
+### Site Owner (`lib/site-owner.php`)
+
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `wpcom_get_site_owner_id()` | `int` | Plan/site owner user ID. Returns `0` on self-hosted. |
+| `wpcom_is_site_owner()` | `bool` | Whether the current user is the site owner. |
+
+**Environment behavior:**
+- **Simple:** uses `wpcom_get_blog_owner()`
+- **Atomic:** uses Jetpack `master_user` option
+- **Self-hosted:** returns `0` / `false`
+
+**Example:**
+```php
+$owner_id = wpcom_get_site_owner_id();
+if ( $owner_id ) {
+    $owner = get_userdata( $owner_id );
+    // send notification to $owner
+}
+```
+
+### Admin Notifications (`lib/admin-notifications.php`)
+
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `wpcom_send_bell_notification( $recipient_id, $type, $data, $dedup_key )` | `void` | Send a WP.com bell notification. No-ops if unavailable. |
+
+**`wpcom_send_bell_notification` parameters:**
+- `$recipient_id` (int) — User ID to notify
+- `$type` (string) — Notification type identifier (e.g. `'rtc_collaborator_blocked'`)
+- `$data` (array) — Payload attached to the notification
+- `$dedup_key` (string) — Deduplication key; repeat calls update the existing note
+
+**Example:**
+```php
+$owner_id = wpcom_get_site_owner_id();
+
+wpcom_send_bell_notification(
+    $owner_id,
+    'my_feature_event',
+    array( 'blog_id' => get_current_blog_id(), 'post_id' => $post_id ),
+    sprintf( 'my-feature-%d-%d', get_current_blog_id(), $post_id )
+);
+```
+
+## Testing
+
+Tests are in `tests/php/lib/`. Run with:
+```bash
+cd projects/packages/jetpack-mu-wpcom
+composer phpunit -- --testsuite=lib
+```
+
+## Adding New Operations
+
+1. Create a new file in `src/lib/` (one file per domain)
+2. Use the `wpcom_` function prefix
+3. Add a `require_once` in `src/lib/load.php`
+4. Add tests in `tests/php/lib/`
+5. Document the function in this AGENTS.md file

--- a/projects/packages/jetpack-mu-wpcom/src/lib/AGENTS.md
+++ b/projects/packages/jetpack-mu-wpcom/src/lib/AGENTS.md
@@ -49,6 +49,25 @@ wpcom_send_bell_notification(
 );
 ```
 
+### Blog Transients (`lib/transients.php`)
+
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `wpcom_set_blog_transient( $key, $value, $expiration )` | `bool` | Set a blog-scoped transient. |
+| `wpcom_get_blog_transient( $key )` | `mixed` | Get a blog-scoped transient. Returns `false` if not set. |
+| `wpcom_delete_blog_transient( $key )` | `bool` | Delete a blog-scoped transient. |
+
+**Why use these instead of `set_transient()` directly?** Intent clarity. These wrappers make it explicit that the data is per-blog. On Simple sites (multisite), `set_transient()` already stores per-blog in each blog's `wp_options` table. On Atomic (single-site), there is only one blog. The wrappers add no runtime logic.
+
+**Example:**
+```php
+// Rate-limit an action to once per day per blog.
+if ( ! wpcom_get_blog_transient( 'my_feature_throttle' ) ) {
+    wpcom_set_blog_transient( 'my_feature_throttle', 1, DAY_IN_SECONDS );
+    // Do the thing...
+}
+```
+
 ## Testing
 
 Tests are in `tests/php/lib/`. Run with:

--- a/projects/packages/jetpack-mu-wpcom/src/lib/admin-notifications.php
+++ b/projects/packages/jetpack-mu-wpcom/src/lib/admin-notifications.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Admin notification helpers.
+ *
+ * Generic functions for sending notifications to WordPress.com users.
+ * Works on Simple and Atomic/WoW sites; gracefully no-ops when
+ * platform APIs are unavailable.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Send a WordPress.com bell notification.
+ *
+ * Wraps notes_send_callback (available on Simple sites). Gracefully
+ * no-ops when the function is unavailable (Atomic / self-hosted).
+ *
+ * @param int    $recipient_id The user ID to notify.
+ * @param string $type         Notification type identifier (e.g. 'rtc_collaborator_blocked').
+ * @param array  $data         Arbitrary payload attached to the notification.
+ * @param string $dedup_key    Deduplication key — repeat calls with the same key update the existing note.
+ */
+function wpcom_send_bell_notification( $recipient_id, $type, $data, $dedup_key ) {
+	if ( ! function_exists( 'notes_send_callback' ) ) {
+		return;
+	}
+
+	notes_send_callback(
+		$recipient_id,
+		$type,
+		$data,
+		$dedup_key,
+		1,     // Mark as unread.
+		false  // Allow updating existing note.
+	);
+}

--- a/projects/packages/jetpack-mu-wpcom/src/lib/admin-notifications.php
+++ b/projects/packages/jetpack-mu-wpcom/src/lib/admin-notifications.php
@@ -12,8 +12,9 @@
 /**
  * Send a WordPress.com bell notification.
  *
- * Wraps notes_send_callback (available on Simple sites). Gracefully
- * no-ops when the function is unavailable (Atomic / self-hosted).
+ * On Simple sites calls notes_send_callback directly.
+ * On WoW/Atomic sites calls the wpcom/v2/site-notifications REST endpoint.
+ * Gracefully no-ops when neither path is available.
  *
  * @param int    $recipient_id The user ID to notify.
  * @param string $type         Notification type identifier (e.g. 'rtc_collaborator_blocked').
@@ -21,16 +22,45 @@
  * @param string $dedup_key    Deduplication key — repeat calls with the same key update the existing note.
  */
 function wpcom_send_bell_notification( $recipient_id, $type, $data, $dedup_key ) {
-	if ( ! function_exists( 'notes_send_callback' ) ) {
+	// Simple sites: call directly.
+	if ( function_exists( 'notes_send_callback' ) ) {
+		notes_send_callback(
+			$recipient_id,
+			$type,
+			$data,
+			$dedup_key,
+			1,     // Mark as unread.
+			false  // Allow updating existing note.
+		);
 		return;
 	}
 
-	notes_send_callback(
-		$recipient_id,
-		$type,
-		$data,
-		$dedup_key,
-		1,     // Mark as unread.
-		false  // Allow updating existing note.
+	// WoW/Atomic sites: call the wpcom REST endpoint.
+	if ( ! class_exists( '\Automattic\Jetpack\Connection\Client' ) ) {
+		return;
+	}
+
+	$blog_id = \Jetpack_Options::get_option( 'id' );
+	if ( ! $blog_id ) {
+		return;
+	}
+
+	\Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(
+		sprintf( '/sites/%d/site-notifications', $blog_id ),
+		'2',
+		array(
+			'method'  => 'POST',
+			'headers' => array( 'content-type' => 'application/json' ),
+		),
+		wp_json_encode(
+			array(
+				'recipient_id' => $recipient_id,
+				'type'         => $type,
+				'data'         => $data,
+				'dedup_key'    => $dedup_key,
+			),
+			JSON_UNESCAPED_SLASHES
+		),
+		'wpcom'
 	);
 }

--- a/projects/packages/jetpack-mu-wpcom/src/lib/admin-notifications.php
+++ b/projects/packages/jetpack-mu-wpcom/src/lib/admin-notifications.php
@@ -36,17 +36,17 @@ function wpcom_send_bell_notification( $recipient_id, $type, $data, $dedup_key )
 	}
 
 	// WoW/Atomic sites: call the wpcom REST endpoint.
+	// Uses blog token auth — the endpoint extracts the blog_id from the token.
 	if ( ! class_exists( '\Automattic\Jetpack\Connection\Client' ) ) {
 		return;
 	}
 
-	$blog_id = \Jetpack_Options::get_option( 'id' );
-	if ( ! $blog_id ) {
+	if ( ! \Jetpack_Options::get_option( 'id' ) ) {
 		return;
 	}
 
-	\Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(
-		sprintf( '/sites/%d/site-notifications', $blog_id ),
+	\Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_blog(
+		'site-notifications',
 		'2',
 		array(
 			'method'  => 'POST',

--- a/projects/packages/jetpack-mu-wpcom/src/lib/load.php
+++ b/projects/packages/jetpack-mu-wpcom/src/lib/load.php
@@ -10,3 +10,4 @@
 
 require_once __DIR__ . '/site-owner.php';
 require_once __DIR__ . '/admin-notifications.php';
+require_once __DIR__ . '/transients.php';

--- a/projects/packages/jetpack-mu-wpcom/src/lib/load.php
+++ b/projects/packages/jetpack-mu-wpcom/src/lib/load.php
@@ -1,0 +1,12 @@
+<?php // phpcs:ignore Squiz.Commenting.FileComment.Missing
+/**
+ * Load all lib files.
+ *
+ * This file is the entrypoint for the lib/ directory. It requires
+ * every lib file so the functions are available to all features.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+require_once __DIR__ . '/site-owner.php';
+require_once __DIR__ . '/admin-notifications.php';

--- a/projects/packages/jetpack-mu-wpcom/src/lib/site-owner.php
+++ b/projects/packages/jetpack-mu-wpcom/src/lib/site-owner.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Site owner resolution helpers.
+ *
+ * Works on Simple sites (via wpcom_get_blog_owner), Atomic/WoW sites
+ * (via Jetpack connection master_user), and gracefully returns defaults
+ * on self-hosted.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Get the site/plan owner's user ID.
+ *
+ * - Simple sites: delegates to wpcom_get_blog_owner().
+ * - Atomic sites: reads the Jetpack connection master_user option.
+ * - Self-hosted: returns 0.
+ *
+ * @return int Owner user ID, or 0 if unavailable.
+ */
+function wpcom_get_site_owner_id() {
+	// Simple sites: wpcom_get_blog_owner is the canonical source.
+	if ( function_exists( 'wpcom_get_blog_owner' ) ) {
+		return (int) wpcom_get_blog_owner( get_wpcom_blog_id() );
+	}
+
+	// Atomic sites: the Jetpack connection master_user is the plan owner.
+	if ( class_exists( 'Jetpack_Options' ) ) {
+		$master_user = \Jetpack_Options::get_option( 'master_user' );
+		if ( $master_user ) {
+			return (int) $master_user;
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * Check if the current user is the site/plan owner.
+ *
+ * @return bool True if the current user is the owner, false otherwise.
+ */
+function wpcom_is_site_owner() {
+	$owner_id = wpcom_get_site_owner_id();
+	if ( ! $owner_id ) {
+		return false;
+	}
+	return get_current_user_id() === $owner_id;
+}

--- a/projects/packages/jetpack-mu-wpcom/src/lib/transients.php
+++ b/projects/packages/jetpack-mu-wpcom/src/lib/transients.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Blog-scoped transient helpers.
+ *
+ * Thin wrappers around WordPress transient functions that make
+ * per-blog storage intent explicit. On Simple sites (multisite),
+ * set_transient() already stores per-blog in each blog's wp_options
+ * table. On Atomic (single-site), there is only one blog.
+ *
+ * These wrappers add no runtime logic — they exist to make the
+ * intent self-documenting for developers and AI agents.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Set a blog-scoped transient.
+ *
+ * Stores data that is specific to the current blog. On multisite
+ * (Simple), this is isolated per blog automatically. On single-site
+ * (Atomic), there is only one blog.
+ *
+ * @param string $key        Transient name. Must be 172 characters or fewer.
+ * @param mixed  $value      Transient value.
+ * @param int    $expiration Time until expiration in seconds. Default 0 (no expiration).
+ * @return bool True if the value was set, false otherwise.
+ */
+function wpcom_set_blog_transient( $key, $value, $expiration = 0 ) {
+	return set_transient( $key, $value, $expiration );
+}
+
+/**
+ * Get a blog-scoped transient.
+ *
+ * @param string $key Transient name.
+ * @return mixed Transient value or false if not set / expired.
+ */
+function wpcom_get_blog_transient( $key ) {
+	return get_transient( $key );
+}
+
+/**
+ * Delete a blog-scoped transient.
+ *
+ * @param string $key Transient name.
+ * @return bool True if the transient was deleted, false otherwise.
+ */
+function wpcom_delete_blog_transient( $key ) {
+	return delete_transient( $key );
+}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/lib/Admin_Notifications_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/lib/Admin_Notifications_Test.php
@@ -7,18 +7,84 @@
 
 declare( strict_types = 1 );
 
+use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Constants;
+
 /**
  * Tests for admin notification lib functions.
  */
 class Admin_Notifications_Test extends \WorDBless\BaseTestCase {
 
 	/**
-	 * Tests that bell notification no-ops when notes_send_callback is unavailable.
+	 * Tests that bell notification no-ops when notes_send_callback is unavailable
+	 * and no Jetpack site ID is set.
 	 */
-	public function test_bell_notification_noop_without_notes_function() {
-		// notes_send_callback does not exist in this test environment.
+	public function test_bell_notification_noop_without_notes_function_or_site_id() {
+		// notes_send_callback does not exist in this test environment,
+		// and no Jetpack site ID is configured.
 		// Should not throw — gracefully skips.
+		\Jetpack_Options::delete_option( 'id' );
 		wpcom_send_bell_notification( 1, 'test_type', array( 'key' => 'value' ), 'dedup-1' );
 		$this->assertTrue( true );
+	}
+
+	/**
+	 * Tests that bell notification calls the wpcom API when notes_send_callback
+	 * is unavailable but a Jetpack site ID is set (WoW/Atomic path).
+	 */
+	public function test_bell_notification_calls_wpcom_api_on_wow() {
+		if ( ! class_exists( Client::class ) ) {
+			$this->markTestSkipped( 'Jetpack Connection Client not available' );
+		}
+
+		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
+
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'bell_test_user',
+				'user_pass'  => 'password',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		\Jetpack_Options::update_option( 'user_tokens', array( $user_id => 'test.token.' . $user_id ) );
+		\Jetpack_Options::update_option( 'id', 12345 );
+
+		// Hook into pre_http_request to capture the outgoing request.
+		$captured = null;
+		$filter   = function ( $preempt, $args, $url ) use ( &$captured ) {
+			$captured = array(
+				'url'  => $url,
+				'args' => $args,
+			);
+			// Short-circuit the HTTP request.
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => '{"success":true}',
+			);
+		};
+		add_filter( 'pre_http_request', $filter, 10, 3 );
+
+		wpcom_send_bell_notification(
+			42,
+			'rtc_collaborator_blocked',
+			array( 'post_id' => 99 ),
+			'dedup-key-1'
+		);
+
+		remove_filter( 'pre_http_request', $filter );
+		\Jetpack_Options::delete_option( 'id' );
+		\Jetpack_Options::delete_option( 'user_tokens' );
+		Constants::clear_single_constant( 'JETPACK__WPCOM_JSON_API_BASE' );
+
+		$this->assertNotNull( $captured, 'Expected an HTTP request to be made' );
+		$this->assertStringContainsString( '/sites/12345/site-notifications', $captured['url'] );
+
+		$body = json_decode( $captured['args']['body'], true );
+		$this->assertSame( 42, $body['recipient_id'] );
+		$this->assertSame( 'rtc_collaborator_blocked', $body['type'] );
+		$this->assertSame( array( 'post_id' => 99 ), $body['data'] );
+		$this->assertSame( 'dedup-key-1', $body['dedup_key'] );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/lib/Admin_Notifications_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/lib/Admin_Notifications_Test.php
@@ -48,7 +48,7 @@ class Admin_Notifications_Test extends \WorDBless\BaseTestCase {
 		);
 		wp_set_current_user( $user_id );
 
-		\Jetpack_Options::update_option( 'user_tokens', array( $user_id => 'test.token.' . $user_id ) );
+		\Jetpack_Options::update_option( 'blog_token', 'test.blogtoken' );
 		\Jetpack_Options::update_option( 'id', 12345 );
 
 		// Hook into pre_http_request to capture the outgoing request.
@@ -75,11 +75,12 @@ class Admin_Notifications_Test extends \WorDBless\BaseTestCase {
 
 		remove_filter( 'pre_http_request', $filter );
 		\Jetpack_Options::delete_option( 'id' );
-		\Jetpack_Options::delete_option( 'user_tokens' );
+		\Jetpack_Options::delete_option( 'blog_token' );
 		Constants::clear_single_constant( 'JETPACK__WPCOM_JSON_API_BASE' );
 
 		$this->assertNotNull( $captured, 'Expected an HTTP request to be made' );
-		$this->assertStringContainsString( '/sites/12345/site-notifications', $captured['url'] );
+		$this->assertStringContainsString( '/site-notifications', $captured['url'] );
+		$this->assertStringNotContainsString( '/sites/', $captured['url'] );
 
 		$body = json_decode( $captured['args']['body'], true );
 		$this->assertSame( 42, $body['recipient_id'] );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/lib/Admin_Notifications_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/lib/Admin_Notifications_Test.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Admin Notifications Lib Tests.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+declare( strict_types = 1 );
+
+/**
+ * Tests for admin notification lib functions.
+ */
+class Admin_Notifications_Test extends \WorDBless\BaseTestCase {
+
+	/**
+	 * Tests that bell notification no-ops when notes_send_callback is unavailable.
+	 */
+	public function test_bell_notification_noop_without_notes_function() {
+		// notes_send_callback does not exist in this test environment.
+		// Should not throw — gracefully skips.
+		wpcom_send_bell_notification( 1, 'test_type', array( 'key' => 'value' ), 'dedup-1' );
+		$this->assertTrue( true );
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/lib/Site_Owner_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/lib/Site_Owner_Test.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Site Owner Lib Tests.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+declare( strict_types = 1 );
+
+/**
+ * Tests for site owner lib functions.
+ */
+class Site_Owner_Test extends \WorDBless\BaseTestCase {
+
+	/**
+	 * Test user ID.
+	 *
+	 * @var int
+	 */
+	private $user_id;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		$this->user_id = wp_insert_user(
+			array(
+				'user_login' => 'site_owner_test_user',
+				'user_pass'  => 'password',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $this->user_id );
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down(): void {
+		wp_set_current_user( 0 );
+		wp_delete_user( $this->user_id );
+		parent::tear_down();
+	}
+
+	/**
+	 * Tests that get_site_owner_id returns 0 when no owner detection is available.
+	 */
+	public function test_get_site_owner_id_returns_zero_without_detection() {
+		$this->assertSame( 0, wpcom_get_site_owner_id() );
+	}
+
+	/**
+	 * Tests that is_site_owner returns false when no owner detection is available.
+	 */
+	public function test_is_site_owner_returns_false_without_detection() {
+		$this->assertFalse( wpcom_is_site_owner() );
+	}
+
+	/**
+	 * Tests that get_site_owner_id returns master_user via Jetpack_Options.
+	 */
+	public function test_get_site_owner_id_via_jetpack_master_user() {
+		if ( ! class_exists( 'Jetpack_Options' ) ) {
+			$this->markTestSkipped( 'Jetpack_Options not available' );
+		}
+
+		\Jetpack_Options::update_option( 'master_user', $this->user_id );
+		$this->assertSame( $this->user_id, wpcom_get_site_owner_id() );
+
+		\Jetpack_Options::delete_option( 'master_user' );
+	}
+
+	/**
+	 * Tests that is_site_owner returns true when current user is the master_user.
+	 */
+	public function test_is_site_owner_via_jetpack_master_user() {
+		if ( ! class_exists( 'Jetpack_Options' ) ) {
+			$this->markTestSkipped( 'Jetpack_Options not available' );
+		}
+
+		\Jetpack_Options::update_option( 'master_user', $this->user_id );
+		$this->assertTrue( wpcom_is_site_owner() );
+
+		\Jetpack_Options::update_option( 'master_user', 999999 );
+		$this->assertFalse( wpcom_is_site_owner() );
+
+		\Jetpack_Options::delete_option( 'master_user' );
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/lib/Transients_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/lib/Transients_Test.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Blog Transient Lib Tests.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+declare( strict_types = 1 );
+
+/**
+ * Tests for blog-scoped transient lib functions.
+ */
+class Transients_Test extends \WorDBless\BaseTestCase {
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down(): void {
+		wpcom_delete_blog_transient( 'test_transient' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Tests that set and get work together.
+	 */
+	public function test_set_and_get_blog_transient() {
+		wpcom_set_blog_transient( 'test_transient', 'hello', 60 );
+		$this->assertSame( 'hello', wpcom_get_blog_transient( 'test_transient' ) );
+	}
+
+	/**
+	 * Tests that get returns false when transient is not set.
+	 */
+	public function test_get_returns_false_when_not_set() {
+		$this->assertFalse( wpcom_get_blog_transient( 'nonexistent_transient' ) );
+	}
+
+	/**
+	 * Tests that delete removes the transient.
+	 */
+	public function test_delete_blog_transient() {
+		wpcom_set_blog_transient( 'test_transient', 'value', 60 );
+		wpcom_delete_blog_transient( 'test_transient' );
+		$this->assertFalse( wpcom_get_blog_transient( 'test_transient' ) );
+	}
+}

--- a/projects/packages/rtc/.phan/config.php
+++ b/projects/packages/rtc/.phan/config.php
@@ -15,8 +15,11 @@ return make_phan_config(
 	array(
 		'+stubs'          => array( 'wpcom' ),
 		'parse_file_list' => array(
-			// get_wpcom_blog_id() is defined in the jetpack-mu-wpcom package.
+			// Functions defined in the jetpack-mu-wpcom package.
 			__DIR__ . '/../../../packages/jetpack-mu-wpcom/src/utils.php',
+			__DIR__ . '/../../../packages/jetpack-mu-wpcom/src/lib/transients.php',
+			__DIR__ . '/../../../packages/jetpack-mu-wpcom/src/lib/admin-notifications.php',
+			__DIR__ . '/../../../packages/jetpack-mu-wpcom/src/lib/site-owner.php',
 		),
 	)
 );

--- a/projects/packages/rtc/changelog/dotcom-16367-rtc-bell-notification
+++ b/projects/packages/rtc/changelog/dotcom-16367-rtc-bell-notification
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Send bell notification to plan owner when a non-admin is blocked by the collaborator limit

--- a/projects/packages/rtc/src/class-rtc.php
+++ b/projects/packages/rtc/src/class-rtc.php
@@ -50,6 +50,7 @@ class RTC {
 		add_action( 'rest_api_init', array( __CLASS__, 'register_rest_routes' ) );
 		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'register_providers' ) );
 		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'load_notices' ) );
+		add_action( 'jetpack_rtc_collaborator_blocked', array( RTC\REST_RTC_Notices::class, 'on_collaborator_blocked' ), 10, 3 );
 		add_action( 'load-options-writing.php', array( __CLASS__, 'unregister_rtc_setting' ) );
 		add_action( 'load-options-writing.php', array( __CLASS__, 'override_rtc_setting_default' ) );
 

--- a/projects/packages/rtc/src/class-rtc.php
+++ b/projects/packages/rtc/src/class-rtc.php
@@ -322,23 +322,19 @@ class RTC {
 	 * @return bool
 	 */
 	public static function is_plan_owner() {
-		$current_user_id = get_current_user_id();
+		return wpcom_is_site_owner();
+	}
 
-		// Simple sites: wpcom_get_blog_owner is the canonical source.
-		if ( function_exists( 'wpcom_get_blog_owner' ) ) {
-			$owner_id = wpcom_get_blog_owner( get_wpcom_blog_id() );
-			return (int) $current_user_id === (int) $owner_id;
-		}
-
-		// Atomic sites: the Jetpack connection master_user is the plan owner.
-		if ( class_exists( 'Jetpack_Options' ) ) {
-			$master_user = \Jetpack_Options::get_option( 'master_user' );
-			if ( $master_user ) {
-				return (int) $current_user_id === (int) $master_user;
-			}
-		}
-
-		return false;
+	/**
+	 * Get the plan owner's user ID for this site.
+	 * Works on Simple sites (via wpcom_get_blog_owner) and Atomic sites
+	 * (via Jetpack connection master_user). Returns 0 on self-hosted
+	 * since there is no WP.com plan to upgrade.
+	 *
+	 * @return int Plan owner user ID, or 0 if unavailable.
+	 */
+	public static function get_plan_owner_id() {
+		return wpcom_get_site_owner_id();
 	}
 
 	/**

--- a/projects/packages/rtc/src/rest-api/class-rest-rtc-notices.php
+++ b/projects/packages/rtc/src/rest-api/class-rest-rtc-notices.php
@@ -201,7 +201,69 @@ class REST_RTC_Notices extends WP_REST_Controller {
 		// Expire after 2 minutes.
 		set_transient( $key, $requests, 2 * MINUTE_IN_SECONDS );
 
+		// Send async bell notification to the plan owner so
+		// they see it even when they are not in the editor.
+		self::send_async_admin_notifications( $post_id, $user );
+
 		return rest_ensure_response( array( 'success' => true ) );
+	}
+
+	/**
+	 * Send async notifications (bell) to the plan owner when a
+	 * non-admin is blocked by the collaborator limit.
+	 *
+	 * Rate-limited: only fires once per configurable interval (default 24 h)
+	 * per (blog, post, blocked user) combination.
+	 *
+	 * @param int      $post_id The post the user was trying to join.
+	 * @param \WP_User $user    The blocked user.
+	 */
+	public static function send_async_admin_notifications( $post_id, $user ) {
+		// Only send when limit notices are enabled.
+		if ( ! apply_filters( 'jetpack_rtc_enable_limit_notices', false ) ) {
+			return;
+		}
+
+		$owner_id = \Automattic\Jetpack\RTC::get_plan_owner_id();
+		if ( ! $owner_id ) {
+			return;
+		}
+
+		// Rate-limit: one notification set per (blog, post, user) per interval.
+		$blog_id          = get_current_blog_id();
+		$throttle_key     = sprintf( 'rtc_notif_sent_%d_%d_%d', $blog_id, $post_id, $user->ID );
+		$throttle_seconds = (int) apply_filters( 'jetpack_rtc_async_notification_interval', DAY_IN_SECONDS );
+
+		if ( get_transient( $throttle_key ) ) {
+			return;
+		}
+
+		// Set the throttle *before* sending so concurrent requests don't
+		// race past the check.
+		set_transient( $throttle_key, 1, $throttle_seconds );
+
+		self::send_admin_bell_notification( $blog_id, $post_id, $user, $owner_id );
+	}
+
+	/**
+	 * Send a WordPress.com bell notification to the plan owner.
+	 *
+	 * @param int      $blog_id  The blog ID.
+	 * @param int      $post_id  The post the user was trying to join.
+	 * @param \WP_User $user     The blocked user.
+	 * @param int      $owner_id The plan owner's user ID.
+	 */
+	public static function send_admin_bell_notification( $blog_id, $post_id, $user, $owner_id ) {
+		wpcom_send_bell_notification(
+			$owner_id,
+			'rtc_collaborator_blocked',
+			array(
+				'blog_id' => $blog_id,
+				'post_id' => $post_id,
+				'user_id' => $user->ID,
+			),
+			sprintf( 'rtc-blocked-%d-%d-%d', $blog_id, $post_id, $user->ID )
+		);
 	}
 
 	/**

--- a/projects/packages/rtc/src/rest-api/class-rest-rtc-notices.php
+++ b/projects/packages/rtc/src/rest-api/class-rest-rtc-notices.php
@@ -201,26 +201,30 @@ class REST_RTC_Notices extends WP_REST_Controller {
 		// Expire after 2 minutes.
 		set_transient( $key, $requests, 2 * MINUTE_IN_SECONDS );
 
-		// Send async bell notification to the plan owner so
-		// they see it even when they are not in the editor.
-		self::send_async_admin_notifications( $post_id, $user );
+		// Fire rate-limited action so listeners (bell, email, etc.)
+		// can notify the plan owner.
+		self::maybe_fire_collaborator_blocked( $post_id, $user );
 
 		return rest_ensure_response( array( 'success' => true ) );
 	}
 
 	/**
-	 * Send async notifications (bell) to the plan owner when a
-	 * non-admin is blocked by the collaborator limit.
+	 * Fire the jetpack_rtc_collaborator_blocked action if not throttled.
 	 *
-	 * Rate-limited: only fires once per configurable interval (default 24 h)
-	 * per (blog, post, blocked user) combination.
+	 * Rate-limited to once per day per blog. Listeners hook into the
+	 * action to send notifications (bell, email, etc.).
 	 *
 	 * @param int      $post_id The post the user was trying to join.
 	 * @param \WP_User $user    The blocked user.
 	 */
-	public static function send_async_admin_notifications( $post_id, $user ) {
-		// Only send when limit notices are enabled.
+	public static function maybe_fire_collaborator_blocked( $post_id, $user ) {
+		// Only fire when limit notices are enabled.
 		if ( ! apply_filters( 'jetpack_rtc_enable_limit_notices', false ) ) {
+			return;
+		}
+
+		// Check rate limit — once per day per blog.
+		if ( wpcom_get_blog_transient( 'rtc_collaborator_blocked_fired' ) ) {
 			return;
 		}
 
@@ -229,40 +233,40 @@ class REST_RTC_Notices extends WP_REST_Controller {
 			return;
 		}
 
-		// Rate-limit: one notification set per (blog, post, user) per interval.
-		$blog_id          = get_current_blog_id();
-		$throttle_key     = sprintf( 'rtc_notif_sent_%d_%d_%d', $blog_id, $post_id, $user->ID );
-		$throttle_seconds = (int) apply_filters( 'jetpack_rtc_async_notification_interval', DAY_IN_SECONDS );
-
-		if ( get_transient( $throttle_key ) ) {
-			return;
-		}
-
-		// Set the throttle *before* sending so concurrent requests don't
+		// Set the throttle *before* firing so concurrent requests don't
 		// race past the check.
-		set_transient( $throttle_key, 1, $throttle_seconds );
+		wpcom_set_blog_transient( 'rtc_collaborator_blocked_fired', 1, DAY_IN_SECONDS );
 
-		self::send_admin_bell_notification( $blog_id, $post_id, $user, $owner_id );
+		/**
+		 * Fires when a non-admin user is blocked by the collaborator limit.
+		 *
+		 * Rate-limited to once per day per blog. Hook into this action
+		 * to add notification strategies (bell, email, Slack, etc.).
+		 *
+		 * @param int      $post_id  The post the user was trying to join.
+		 * @param \WP_User $user     The blocked user.
+		 * @param int      $owner_id The plan owner's user ID.
+		 */
+		do_action( 'jetpack_rtc_collaborator_blocked', $post_id, $user, $owner_id );
 	}
 
 	/**
-	 * Send a WordPress.com bell notification to the plan owner.
+	 * Bell notification listener for the collaborator blocked action.
 	 *
-	 * @param int      $blog_id  The blog ID.
 	 * @param int      $post_id  The post the user was trying to join.
 	 * @param \WP_User $user     The blocked user.
 	 * @param int      $owner_id The plan owner's user ID.
 	 */
-	public static function send_admin_bell_notification( $blog_id, $post_id, $user, $owner_id ) {
+	public static function on_collaborator_blocked( $post_id, $user, $owner_id ) {
 		wpcom_send_bell_notification(
 			$owner_id,
 			'rtc_collaborator_blocked',
 			array(
-				'blog_id' => $blog_id,
+				'blog_id' => get_current_blog_id(),
 				'post_id' => $post_id,
 				'user_id' => $user->ID,
 			),
-			sprintf( 'rtc-blocked-%d-%d-%d', $blog_id, $post_id, $user->ID )
+			sprintf( 'rtc-blocked-%d-%d-%d', get_current_blog_id(), $post_id, $user->ID )
 		);
 	}
 

--- a/projects/packages/rtc/tests/php/RTC_Notices_Test.php
+++ b/projects/packages/rtc/tests/php/RTC_Notices_Test.php
@@ -110,9 +110,7 @@ class RTC_Notices_Test extends \WorDBless\BaseTestCase {
 		delete_transient( REST_RTC_Notices::JOIN_REQUEST_OPTION . '_' . 999999 );
 
 		// Clean up rate-limit transients that may have been set by tests.
-		global $wpdb;
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE '%rtc_notif_sent_%'" );
+		wpcom_delete_blog_transient( 'rtc_collaborator_blocked_fired' );
 
 		// Reset the REST server so stale route registrations don't leak
 		// into other test classes.
@@ -537,9 +535,9 @@ class RTC_Notices_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that async notifications are rate-limited by transient.
+	 * Tests that the collaborator blocked action is rate-limited by transient.
 	 */
-	public function test_async_notifications_rate_limited() {
+	public function test_collaborator_blocked_action_is_rate_limited() {
 		if ( ! class_exists( 'Jetpack_Options' ) ) {
 			$this->markTestSkipped( 'Jetpack_Options not available' );
 		}
@@ -555,21 +553,41 @@ class RTC_Notices_Test extends \WorDBless\BaseTestCase {
 		\Jetpack_Options::update_option( 'master_user', $this->user_id );
 
 		wp_set_current_user( $this->second_user_id );
-		$user    = wp_get_current_user();
-		$blog_id = get_current_blog_id();
+		$user = wp_get_current_user();
 
-		// First call sets the transient.
-		$throttle_key = sprintf( 'rtc_notif_sent_%d_%d_%d', $blog_id, $post_id, $user->ID );
-		$this->assertFalse( get_transient( $throttle_key ) );
+		// First call sets the transient and fires the action.
+		$this->assertFalse( wpcom_get_blog_transient( 'rtc_collaborator_blocked_fired' ) );
 
-		REST_RTC_Notices::send_async_admin_notifications( $post_id, $user );
-		$this->assertNotFalse( get_transient( $throttle_key ) );
+		$fired    = 0;
+		$listener = function () use ( &$fired ) {
+			++$fired;
+		};
+		add_action( 'jetpack_rtc_collaborator_blocked', $listener );
+
+		REST_RTC_Notices::maybe_fire_collaborator_blocked( $post_id, $user );
+		$this->assertNotFalse( wpcom_get_blog_transient( 'rtc_collaborator_blocked_fired' ) );
+		$this->assertSame( 1, $fired );
+
+		// Second call is throttled — action does not fire again.
+		REST_RTC_Notices::maybe_fire_collaborator_blocked( $post_id, $user );
+		$this->assertSame( 1, $fired );
 
 		// Clean up.
-		delete_transient( $throttle_key );
+		remove_action( 'jetpack_rtc_collaborator_blocked', $listener );
+		wpcom_delete_blog_transient( 'rtc_collaborator_blocked_fired' );
 		remove_all_filters( 'jetpack_rtc_enable_limit_notices' );
 		\Jetpack_Options::delete_option( 'master_user' );
 		wp_set_current_user( $this->user_id );
 		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * Tests that the bell notification listener receives correct arguments.
+	 */
+	public function test_on_collaborator_blocked_calls_bell_notification() {
+		// on_collaborator_blocked should not throw when notes_send_callback is unavailable.
+		$user = wp_get_current_user();
+		REST_RTC_Notices::on_collaborator_blocked( 123, $user, $this->user_id );
+		$this->assertTrue( true );
 	}
 }

--- a/projects/packages/rtc/tests/php/RTC_Notices_Test.php
+++ b/projects/packages/rtc/tests/php/RTC_Notices_Test.php
@@ -109,6 +109,11 @@ class RTC_Notices_Test extends \WorDBless\BaseTestCase {
 		delete_user_option( $this->user_id, REST_RTC_Notices::OPTION_KEY );
 		delete_transient( REST_RTC_Notices::JOIN_REQUEST_OPTION . '_' . 999999 );
 
+		// Clean up rate-limit transients that may have been set by tests.
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE '%rtc_notif_sent_%'" );
+
 		// Reset the REST server so stale route registrations don't leak
 		// into other test classes.
 		global $wp_rest_server;
@@ -498,5 +503,73 @@ class RTC_Notices_Test extends \WorDBless\BaseTestCase {
 		$this->assertStringContainsString( '"maxPeersPerRoom"', $inline );
 		$this->assertStringContainsString( '"enableWelcomeNotice"', $inline );
 		$this->assertStringContainsString( '"enableLimitNotices"', $inline );
+	}
+
+	/**
+	 * Tests that plan owner ID returns 0 when no owner detection is available.
+	 */
+	public function test_plan_owner_id_returns_zero_without_detection() {
+		$this->assertSame( 0, RTC::get_plan_owner_id() );
+	}
+
+	/**
+	 * Tests that plan owner ID returns master_user via Jetpack_Options.
+	 */
+	public function test_plan_owner_id_via_jetpack_master_user() {
+		if ( ! class_exists( 'Jetpack_Options' ) ) {
+			$this->markTestSkipped( 'Jetpack_Options not available' );
+		}
+
+		\Jetpack_Options::update_option( 'master_user', $this->user_id );
+		$this->assertSame( $this->user_id, RTC::get_plan_owner_id() );
+
+		\Jetpack_Options::delete_option( 'master_user' );
+	}
+
+	/**
+	 * Tests that send_admin_bell_notification does not fail when
+	 * notes_send_callback is unavailable (non-WPCOM environment).
+	 */
+	public function test_bell_notification_skips_without_notes_function() {
+		// Should not throw — gracefully skips when notes_send_callback doesn't exist.
+		wpcom_send_bell_notification( $this->user_id, 'test_type', array( 'key' => 'value' ), 'dedup-1' );
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Tests that async notifications are rate-limited by transient.
+	 */
+	public function test_async_notifications_rate_limited() {
+		if ( ! class_exists( 'Jetpack_Options' ) ) {
+			$this->markTestSkipped( 'Jetpack_Options not available' );
+		}
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Rate Limit Test Post',
+				'post_status' => 'publish',
+			)
+		);
+
+		add_filter( 'jetpack_rtc_enable_limit_notices', '__return_true', 999 );
+		\Jetpack_Options::update_option( 'master_user', $this->user_id );
+
+		wp_set_current_user( $this->second_user_id );
+		$user    = wp_get_current_user();
+		$blog_id = get_current_blog_id();
+
+		// First call sets the transient.
+		$throttle_key = sprintf( 'rtc_notif_sent_%d_%d_%d', $blog_id, $post_id, $user->ID );
+		$this->assertFalse( get_transient( $throttle_key ) );
+
+		REST_RTC_Notices::send_async_admin_notifications( $post_id, $user );
+		$this->assertNotFalse( get_transient( $throttle_key ) );
+
+		// Clean up.
+		delete_transient( $throttle_key );
+		remove_all_filters( 'jetpack_rtc_enable_limit_notices' );
+		\Jetpack_Options::delete_option( 'master_user' );
+		wp_set_current_user( $this->user_id );
+		wp_delete_post( $post_id, true );
 	}
 }


### PR DESCRIPTION
Fixes DOTCOM-16367

## Proposed changes

* Add a reusable `lib/` directory to `jetpack-mu-wpcom` with generic helper functions that work on both Simple and Atomic/WoW sites:
  * `wpcom_get_site_owner_id()` — resolves the site/plan owner user ID across environments
  * `wpcom_is_site_owner()` — checks if the current user is the site owner
  * `wpcom_send_bell_notification()` — sends a WordPress.com bell notification (no-ops gracefully when unavailable)
* Add `AGENTS.md` to the lib directory as agent-first documentation for AI agents to discover available operations
* Update the RTC package to delegate `is_plan_owner()` and `get_plan_owner_id()` to the new lib functions
* When a non-admin user is blocked from joining an editor session due to the collaborator limit, send a rate-limited bell notification to the plan owner
  * Rate-limited to once per 24h per (blog, post, blocked user) combination
  * Only fires when `jetpack_rtc_enable_limit_notices` filter is enabled

### Other information

The `lib/` directory is designed as an **agent-first API surface** — the `AGENTS.md` file serves as the primary discovery mechanism for AI agents working in the codebase. The functions use the `wpcom_` prefix consistent with existing conventions and are loaded early via `lib/load.php`.

## Related product discussion/links

* peKye1-1Z1-p2

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Open a post editor on a WoW site with RTC enabled and `jetpack_rtc_enable_limit_notices` filter returning `true`
* With a non-admin user, try to join an editor session that has reached the collaborator limit
* Verify a bell notification is sent to the plan owner
* Verify that a second attempt within 24h does not send another notification (rate limiting via transient)
* Verify the notification does not fire when `jetpack_rtc_enable_limit_notices` is `false` (default)
