### PR TITLE
Newsletter: fix editor email stats timeout flashing errors (NL-578)

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-nl-578-editor-email-stats-timeout
+++ b/projects/plugins/jetpack/changelog/fix-nl-578-editor-email-stats-timeout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Newsletter: Fail silently on email stats fetch errors in the editor and skip the fetch for drafts so timeouts no longer flash as errors in Gutenberg.

--- a/projects/plugins/jetpack/extensions/shared/memberships/subscribers-affirmation.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/subscribers-affirmation.js
@@ -350,7 +350,12 @@ function SubscribersAffirmation( { accessLevel, prePublish = false } ) {
 
 			const _postEmailSentState = postId ? getPostEmailSentState( postId ) : null;
 			const emailSentAt = _postEmailSentState?.email_sent_at ?? null;
-			const shouldFetchTotalEmails = postId && blogId && postEmailResolved && emailSentAt == null;
+			// Only fetch email open stats for already-published posts. Drafts,
+			// auto-drafts, pending, and scheduled posts have never been emailed,
+			// so the WPCOM stats/opens/emails request would be a guaranteed miss
+			// (and can time out on large sites). See NL-578.
+			const shouldFetchTotalEmails =
+				postId && blogId && postEmailResolved && emailSentAt == null && status === 'publish';
 
 			return {
 				hasFinishedLoading: [
@@ -372,7 +377,7 @@ function SubscribersAffirmation( { accessLevel, prePublish = false } ) {
 					: null,
 			};
 		},
-		[ postId, blogId ]
+		[ postId, blogId, status ]
 	);
 
 	if ( ! hasFinishedLoading ) {

--- a/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/resolvers.js
@@ -286,7 +286,7 @@ export const getSubscriberCounts =
 
 export const getTotalEmailsSentCount =
 	( blogId, postId ) =>
-	async ( { dispatch, registry } ) => {
+	async ( { dispatch } ) => {
 		await executionLock.blockExecution( TOTAL_EMAILS_SENT_COUNT_EXECUTION_KEY );
 
 		const lock = executionLock.acquire( TOTAL_EMAILS_SENT_COUNT_EXECUTION_KEY );
@@ -294,8 +294,11 @@ export const getTotalEmailsSentCount =
 			const response = await fetchTotalEmailsSentCount( blogId, postId );
 			dispatch( setTotalEmailsSentCount( response?.total_sends ) );
 		} catch ( error ) {
-			dispatch( setApiState( API_STATE_NOTCONNECTED ) );
-			onError( error.message, registry );
+			// Email open stats are informational. Fail silently so a slow or
+			// failed WPCOM response (e.g. 5s timeout on stats/opens/emails) does
+			// not surface a snackbar error in the editor. See NL-578.
+			// eslint-disable-next-line no-console
+			console.warn( 'Failed to fetch total emails sent count:', error?.message );
 		} finally {
 			executionLock.release( lock );
 		}

--- a/projects/plugins/jetpack/extensions/store/membership-products/test/resolvers-test.js
+++ b/projects/plugins/jetpack/extensions/store/membership-products/test/resolvers-test.js
@@ -103,7 +103,10 @@ describe( 'Membership Products Resolvers', () => {
 			expect( apiFetch ).not.toHaveBeenCalled();
 		} );
 
-		test( 'WP_Error response: calls onError', async () => {
+		test( 'WP_Error response: fails silently (no onError, no dispatch)', async () => {
+			// Email stats are informational — errors should never flash in the
+			// editor (see NL-578).
+			const warnSpy = jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
 			apiFetch.mockResolvedValue( {
 				errors: { rest_forbidden: [ 'Sorry, you are not allowed.' ] },
 			} );
@@ -111,7 +114,26 @@ describe( 'Membership Products Resolvers', () => {
 			const thunk = getTotalEmailsSentCount( 123, 456 );
 			await thunk( { dispatch: mockDispatch, registry: mockRegistry } );
 
-			expect( utils.onError ).toHaveBeenCalled();
+			expect( utils.onError ).not.toHaveBeenCalled();
+			expect( mockDispatch ).not.toHaveBeenCalled();
+			expect( warnSpy ).toHaveBeenCalled();
+			warnSpy.mockRestore();
+		} );
+
+		test( 'apiFetch rejects (e.g. timeout): fails silently', async () => {
+			const warnSpy = jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
+			apiFetch.mockRejectedValue( new Error( 'cURL error 28: Operation timed out' ) );
+
+			const thunk = getTotalEmailsSentCount( 123, 456 );
+			await thunk( { dispatch: mockDispatch, registry: mockRegistry } );
+
+			expect( utils.onError ).not.toHaveBeenCalled();
+			expect( mockDispatch ).not.toHaveBeenCalled();
+			expect( warnSpy ).toHaveBeenCalledWith(
+				'Failed to fetch total emails sent count:',
+				'cURL error 28: Operation timed out'
+			);
+			warnSpy.mockRestore();
 		} );
 	} );
 } );


### PR DESCRIPTION
Fixes NL-578

## Proposed changes
* `getTotalEmailsSentCount` resolver now fails silently on error instead of dispatching a snackbar notice + flipping api state to disconnected. Email open rate is purely informational and should never surface as an editor error. Errors are logged to `console.warn` for debuggability.
* The Newsletter panel (`subscribers-affirmation.js`) now only triggers the email-open-rate fetch when `status === 'publish'`. Drafts, auto-drafts, pending, and scheduled posts have never been emailed, so the request would be a guaranteed miss (and contributed to the timeouts reported in the ticket).
* Extended `resolvers-test.js` with coverage for the rejected-promise (timeout) path and to assert the WP_Error path no longer calls `onError`/dispatches.

Error | Pre-publish | Post-publish email stats
---- | ---- | ----
<img width="551" height="159" alt="Screenshot 2026-04-08 at 1 50 32 PM" src="https://github.com/user-attachments/assets/de7a1c61-a2a1-4b73-9207-641f50c3f59e" /> | <img width="341" height="364" alt="Screenshot 2026-04-08 at 2 08 12 PM" src="https://github.com/user-attachments/assets/78797d13-a266-42e3-8edf-92aca18eab8c" /> | <img width="324" height="213" alt="Screenshot 2026-04-08 at 1 59 23 PM" src="https://github.com/user-attachments/assets/3323a3a8-6c24-493a-962a-307e2983344a" />


### Other information
The WPCOM `stats/opens/emails/{post}/rate` endpoint has a hard-coded 5s timeout on the client. On large sites (e.g. seths.blog, 147199084) the request regularly exceeds that, flashing `cURL error 28` in Gutenberg on every editor load.

The ticket also mentions `/stats/emails/summary` timing out on the Jetpack Stats dashboard Newsletter tab. That lives in the stats-admin package and is a separate surface — not fixed here; happy to open a follow-up.

## Related product discussion/links
* https://linear.app/a8c/issue/NL-578/editor-email-stats-fetch-can-timeout-and-flash-errors-found-on

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

### Unit tests
* `pnpm jest extensions/store/membership-products/test/resolvers-test.js` — 9/9 passing
* `pnpm jest extensions/shared/memberships/test/subscribers-affirmation-test.js` — 39/39 passing

### Manual — error no longer flashes
1. On a site with Jetpack Newsletter enabled, drop this file at `wp-content/mu-plugins/force-stats-timeout.php` to force the timeout:
   ```php
   <?php
   add_filter( 'pre_http_request', function( $preempt, $args, $url ) {
       if ( strpos( $url, 'stats/opens/emails' ) !== false ) {
           return new WP_Error( 'http_request_failed',
               'cURL error 28: Operation timed out after 5000 milliseconds with 0 bytes received' );
       }
       return $preempt;
   }, 10, 3 );
   ```
2. Open any published post in the block editor.
3. **Expected:** no snackbar error. Before this patch, a "cURL error 28" snackbar flashed in the corner.

### Manual — no fetch on drafts
1. Create a brand new post in the block editor.
2. Open devtools → Network, filter to `stats/opens/emails`.
3. **Expected:** no request fires. The Newsletter panel still renders the pre-publish affirmation copy.

### Manual — still works on published posts
1. Open a previously-sent published post that has email open stats.
2. **Expected:** the panel still loads email stats copy as it did before.

To test on Simple, sandbox the Simple site and public api.

🤖 Generated with [Claude Code](https://claude.com/claude-code)