### PR TITLE
Add `jetpack_account_protection_send_auth_email` filter for custom verification email handling #47999

### DIFF
--- a/projects/packages/account-protection/changelog/add-send-auth-email-filter
+++ b/projects/packages/account-protection/changelog/add-send-auth-email-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add `jetpack_account_protection_send_auth_email` filter to allow custom handling of the verification email.

--- a/projects/packages/account-protection/src/class-email-service.php
+++ b/projects/packages/account-protection/src/class-email-service.php
@@ -44,6 +44,25 @@ class Email_Service {
 	public function api_send_auth_email( int $user_id, string $auth_code ) {
 		$blog_id = Jetpack_Options::get_option( 'id' );
 
+		/**
+		 * Filters whether the Account Protection verification email should be handled externally.
+		 *
+		 * When the filter returns a truthy value, the default WPCOM API email send is skipped,
+		 * allowing sites to deliver the email locally (e.g. via `wp_mail()`).
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool   $handled  Whether the email has been handled. Default false.
+		 * @param int    $user_id  The user ID.
+		 * @param string $auth_code The authentication code.
+		 * @param int    $blog_id  The blog ID, or false if not available.
+		 */
+		$handled = apply_filters( 'jetpack_account_protection_send_auth_email', false, $user_id, $auth_code, $blog_id );
+
+		if ( $handled ) {
+			return true;
+		}
+
 		if ( ! $blog_id || ! $this->connection_manager->is_connected() ) {
 			return new \WP_Error( 'jetpack_connection_error', __( 'Jetpack is not connected. Please connect and try again.', 'jetpack-account-protection' ) );
 		}

--- a/projects/packages/account-protection/tests/php/Email_Service_Test.php
+++ b/projects/packages/account-protection/tests/php/Email_Service_Test.php
@@ -79,6 +79,51 @@ class Email_Service_Test extends BaseTestCase {
 		$this->assertMatchesRegularExpression( '/^[0-9]{6}$/', $new_transient['auth_code'], 'Auth code should be 6 digits.' );
 	}
 
+	public function test_api_send_auth_email_skips_api_call_when_filter_returns_truthy(): void {
+		$sut      = new Email_Service();
+		$user     = new \WP_User();
+		$user->ID = 1;
+
+		$filter_args = array();
+		$callback    = function ( $handled, $user_id, $auth_code, $blog_id ) use ( &$filter_args ) {
+			$filter_args = compact( 'handled', 'user_id', 'auth_code', 'blog_id' );
+			return true;
+		};
+
+		add_filter( 'jetpack_account_protection_send_auth_email', $callback, 10, 4 );
+
+		$result = $sut->api_send_auth_email( $user->ID, '123456' );
+
+		remove_filter( 'jetpack_account_protection_send_auth_email', $callback, 10 );
+
+		$this->assertTrue( $result, 'api_send_auth_email should return true when the filter short-circuits.' );
+		$this->assertNotEmpty( $filter_args, 'Filter callback should have been called.' );
+		$this->assertFalse( $filter_args['handled'], 'Default handled value should be false.' );
+		$this->assertSame( 1, $filter_args['user_id'], 'Filter should receive the user ID.' );
+		$this->assertSame( '123456', $filter_args['auth_code'], 'Filter should receive the auth code.' );
+	}
+
+	public function test_api_send_auth_email_proceeds_normally_when_filter_returns_falsy(): void {
+		Jetpack_Options::delete_option( 'id' );
+		$sut      = new Email_Service();
+		$user     = new \WP_User();
+		$user->ID = 1;
+
+		$callback = function () {
+			return false;
+		};
+
+		add_filter( 'jetpack_account_protection_send_auth_email', $callback, 10, 4 );
+
+		$result = $sut->api_send_auth_email( $user->ID, '123456' );
+
+		remove_filter( 'jetpack_account_protection_send_auth_email', $callback, 10 );
+
+		// Should continue to the normal flow and fail because blog_id is not set
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertEquals( 'jetpack_connection_error', $result->get_error_code() );
+	}
+
 	public function test_api_send_auth_email_returns_error_if_blog_id_not_available(): void {
 		Jetpack_Options::delete_option( 'id' );
 		$sut      = new Email_Service();

--- a/projects/packages/account-protection/tests/php/Email_Service_Test.php
+++ b/projects/packages/account-protection/tests/php/Email_Service_Test.php
@@ -84,7 +84,12 @@ class Email_Service_Test extends BaseTestCase {
 		$user     = new \WP_User();
 		$user->ID = 1;
 
-		$filter_args = array();
+		$filter_args = array(
+			'handled'   => null,
+			'user_id'   => null,
+			'auth_code' => null,
+			'blog_id'   => null,
+		);
 		$callback    = function ( $handled, $user_id, $auth_code, $blog_id ) use ( &$filter_args ) {
 			$filter_args = compact( 'handled', 'user_id', 'auth_code', 'blog_id' );
 			return true;


### PR DESCRIPTION
Fixes #47999

### Summary

Adds a `jetpack_account_protection_send_auth_email` filter in `Email_Service::api_send_auth_email()` that allows sites to handle the Account Protection verification email locally instead of via the WPCOM API.

### Problem

The password-detection verification email is sent entirely through the WPCOM API, bypassing `wp_mail()`. Sites using custom email branding (e.g. wrapping all outgoing emails in branded HTML templates) cannot intercept or customize this email, creating brand inconsistency.

### Solution

A new `jetpack_account_protection_send_auth_email` filter fires before the WPCOM API call:

```php
$handled = apply_filters(
    'jetpack_account_protection_send_auth_email',
    false,
    $user_id,
    $auth_code,
    $blog_id
);
```

| Parameter | Type | Description |
|---|---|---|
| `$handled` | `bool` | Whether the email has been handled. Default `false`. |
| `$user_id` | `int` | The user ID. |
| `$auth_code` | `string` | The 6-digit verification code. |
| `$blog_id` | `int\|false` | The blog ID. |

When the filter returns truthy, the WPCOM API call is skipped — the site is responsible for delivering the email. When no filter is attached, behavior is unchanged.

### Changelog

- `jetpack-account-protection`: Minor — Added `jetpack_account_protection_send_auth_email` filter

## Testing instructions:

1. **Verify default behavior is unchanged (no filter attached):**
   - Enable Account Protection on a Jetpack-connected site
   - Log in with a correct password to trigger the verification email flow
   - Confirm the verification email is still sent via the WPCOM API as before

2. **Verify the filter short-circuits the API call:**
   - Add the following to a plugin or theme's `functions.php`:
     ```php
     add_filter( 'jetpack_account_protection_send_auth_email', function( $handled, $user_id, $auth_code, $blog_id ) {
         // Send via wp_mail() instead
         $user = get_userdata( $user_id );
         wp_mail(
             $user->user_email,
             'Your verification code',
             sprintf( 'Your code is: %s', $auth_code )
         );
         return true;
     }, 10, 4 );
     ```
   - Log in with a correct password to trigger the verification flow
   - Confirm the email arrives via `wp_mail()` (with any site branding applied) instead of the Jetpack-branded WPCOM email
   - Confirm the verification code in the email works correctly on the verification screen

3. **Verify filter returning false continues normal flow:**
   - Change the filter callback to `return false;`
   - Trigger the verification flow again
   - Confirm the email is sent via the WPCOM API as usual

4. **Run unit tests:**
   ```sh
   cd projects/packages/account-protection
   composer phpunit
   ```
   - All 89 tests should pass

## Does this pull request change what data or activity we track or use?

No. This PR does not change any data tracking or collection. It only adds a filter hook that allows sites to optionally handle the verification email delivery locally. When no filter is attached, the existing WPCOM API behavior is completely unchanged. No new data is sent, stored, or exposed.
