### PR TITLE
JP Newsletter: Defer the call to is_connected()

### DIFF
--- a/projects/packages/newsletter/changelog/fix-newsletter-settings-early-is-connected
+++ b/projects/packages/newsletter/changelog/fix-newsletter-settings-early-is-connected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Defer is_connected() check from init to admin_menu callback to avoid caching a false result before External Storage providers are registered.

--- a/projects/packages/newsletter/src/class-settings.php
+++ b/projects/packages/newsletter/src/class-settings.php
@@ -136,12 +136,12 @@ class Settings {
 	 * (defaults to true). Set to false to hide the menu while keeping page accessible.
 	 */
 	public function add_wp_admin_menu() {
-		// On sites using Jetpack, only show the menu if the site is connected.
-		if ( ! ( new Connection_Manager() )->is_connected() ) {
+		if ( ! $this->expose_to_users() ) {
 			return;
 		}
 
-		if ( ! $this->expose_to_users() ) {
+		// On sites using Jetpack, only show the menu if the site is connected.
+		if ( ! ( new Connection_Manager() )->is_connected() ) {
 			return;
 		}
 

--- a/projects/packages/newsletter/src/class-settings.php
+++ b/projects/packages/newsletter/src/class-settings.php
@@ -118,14 +118,9 @@ class Settings {
 			return;
 		}
 
-		// On sites using Jetpack, only show the menu if the site is connected.
-		if ( ! ( new Connection_Manager() )->is_connected() ) {
-			return;
-		}
-
 		// Add admin menu item.
-		// The expose_to_users() check is deferred to add_wp_admin_menu() so that
-		// filters registered after init() are available when admin_menu fires.
+		// The expose_to_users() and is_connected() checks are deferred to add_wp_admin_menu()
+		// so that filters registered after init() are available when admin_menu fires.
 		// Use priority 999 to ensure menu items are queued BEFORE Admin_Menu::admin_menu_hook_callback
 		// runs at priority 1000 to process all queued items.
 		add_action( 'admin_menu', array( $this, 'add_wp_admin_menu' ), 999 );
@@ -141,6 +136,11 @@ class Settings {
 	 * (defaults to true). Set to false to hide the menu while keeping page accessible.
 	 */
 	public function add_wp_admin_menu() {
+		// On sites using Jetpack, only show the menu if the site is connected.
+		if ( ! ( new Connection_Manager() )->is_connected() ) {
+			return;
+		}
+
 		if ( ! $this->expose_to_users() ) {
 			return;
 		}

--- a/projects/packages/newsletter/tests/php/Settings_Test.php
+++ b/projects/packages/newsletter/tests/php/Settings_Test.php
@@ -38,6 +38,9 @@ class Settings_Test extends BaseTestCase {
 		remove_all_actions( 'admin_menu' );
 		remove_all_actions( 'admin_init' );
 		remove_all_filters( 'jetpack_module_configuration_url_subscriptions' );
+
+		// Clear the load action registered by add_wp_admin_menu on success.
+		remove_all_actions( 'load-jetpack_page_jetpack-newsletter' );
 	}
 
 	/**
@@ -52,7 +55,7 @@ class Settings_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test that add_wp_admin_menu does not register menu when not connected.
+	 * Test that add_wp_admin_menu does not register the menu when not connected.
 	 */
 	public function test_add_wp_admin_menu_does_not_register_menu_when_not_connected() {
 		// Ensure disconnected state.
@@ -63,15 +66,14 @@ class Settings_Test extends BaseTestCase {
 		$settings = new Settings();
 		$settings->add_wp_admin_menu();
 
-		// If the method returned early due to not connected, no menu page should exist.
-		$this->assertEmpty(
-			menu_page_url( 'jetpack-newsletter', false ),
+		$this->assertFalse(
+			has_action( 'load-jetpack_page_jetpack-newsletter', array( $settings, 'admin_init' ) ),
 			'Newsletter menu should not be registered when site is not connected'
 		);
 	}
 
 	/**
-	 * Test that add_wp_admin_menu registers menu when connected.
+	 * Test that add_wp_admin_menu registers the menu when connected.
 	 */
 	public function test_add_wp_admin_menu_registers_menu_when_connected() {
 		// Simulate connected state.
@@ -82,8 +84,8 @@ class Settings_Test extends BaseTestCase {
 		$settings = new Settings();
 		$settings->add_wp_admin_menu();
 
-		$this->assertNotEmpty(
-			menu_page_url( 'jetpack-newsletter', false ),
+		$this->assertNotFalse(
+			has_action( 'load-jetpack_page_jetpack-newsletter', array( $settings, 'admin_init' ) ),
 			'Newsletter menu should be registered when site is connected'
 		);
 	}

--- a/projects/packages/newsletter/tests/php/Settings_Test.php
+++ b/projects/packages/newsletter/tests/php/Settings_Test.php
@@ -52,39 +52,39 @@ class Settings_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test that init_hooks does not register the admin_menu action when the site is not connected.
+	 * Test that add_wp_admin_menu does not register menu when not connected.
 	 */
-	public function test_init_hooks_does_not_register_admin_menu_when_not_connected() {
+	public function test_add_wp_admin_menu_does_not_register_menu_when_not_connected() {
 		// Ensure disconnected state.
 		\Jetpack_Options::delete_option( 'id' );
 		\Jetpack_Options::delete_option( 'blog_token' );
 		( new Connection_Manager() )->reset_connection_status();
 
 		$settings = new Settings();
-		$settings->init_hooks();
+		$settings->add_wp_admin_menu();
 
-		$this->assertFalse(
-			has_action( 'admin_menu', array( $settings, 'add_wp_admin_menu' ) ),
-			'admin_menu action should not be registered when site is not connected'
+		// If the method returned early due to not connected, no menu page should exist.
+		$this->assertEmpty(
+			menu_page_url( 'jetpack-newsletter', false ),
+			'Newsletter menu should not be registered when site is not connected'
 		);
 	}
 
 	/**
-	 * Test that init_hooks registers the admin_menu action when the site is connected.
+	 * Test that add_wp_admin_menu registers menu when connected.
 	 */
-	public function test_init_hooks_registers_admin_menu_when_connected() {
+	public function test_add_wp_admin_menu_registers_menu_when_connected() {
 		// Simulate connected state.
 		\Jetpack_Options::update_option( 'id', 1234 );
 		\Jetpack_Options::update_option( 'blog_token', 'test_token.secret' );
 		( new Connection_Manager() )->reset_connection_status();
 
 		$settings = new Settings();
-		$settings->init_hooks();
+		$settings->add_wp_admin_menu();
 
-		$this->assertSame(
-			999,
-			has_action( 'admin_menu', array( $settings, 'add_wp_admin_menu' ) ),
-			'admin_menu action should be registered at priority 999 when site is connected'
+		$this->assertNotEmpty(
+			menu_page_url( 'jetpack-newsletter', false ),
+			'Newsletter menu should be registered when site is connected'
 		);
 	}
 }


### PR DESCRIPTION
Calling `is_connected()` this early can be problematic, especially for those registering custom storage providers. It's also just unnecessary to be calling it this early on every request.

Instead moving it down into the `admin_menu` hook.

Introduced in https://github.com/Automattic/jetpack/pull/47927 CC @jeherve 