### PR TITLE
number-formatters: add .duel-cache to .gitignore

### DIFF
--- a/projects/js-packages/number-formatters/.gitignore
+++ b/projects/js-packages/number-formatters/.gitignore
@@ -1,2 +1,3 @@
 dist/
 node_modules/
+.duel-cache/

--- a/projects/js-packages/number-formatters/changelog/fix-number-formatters-ignore_build_cache_files
+++ b/projects/js-packages/number-formatters/changelog/fix-number-formatters-ignore_build_cache_files
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Ensure build cache file is in .gitignore.
+
+


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
In #47887 we bumped the `@knighted/duel` dependency to v4. After that change, building the `number-formatters` package results in a `.duel-cache` folder.

Per [the dependency readme](https://github.com/knightedcodemonkey/duel/blob/1c22647e7e49638202a9e2e9c56e85bfe906616c/README.md), this should be added to `.gitignore`, so thus shall it be with this PR.

### Other information

Funny enough, one of the files in the `.duel-cache` folder is `dual.*`. 😄

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Run this: `jetpack build js-packages/number-formatters`

With `trunk` you'll see a `.duel-cache` folder, and with this branch you won't.