### PR TITLE
Paid Content block: refresh JWT on-demand instead of denying on stale end_date

### DIFF
--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -153,7 +153,7 @@ return [
         'extensions/blocks/opentable/opentable.php' => ['PhanTypeMismatchArgumentNullableInternal'],
         'extensions/blocks/pinterest/pinterest.php' => ['PhanTypeArraySuspiciousNullable'],
         'extensions/blocks/premium-content/_inc/access-check.php' => ['PhanUndeclaredMethod'],
-        'extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchArgument', 'PhanTypeSuspiciousNonTraversableForeach', 'PhanUndeclaredMethod'],
+        'extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php' => ['PhanParamSignatureMismatch', 'PhanTypeMismatchArgument', 'PhanTypeSuspiciousNonTraversableForeach'],
         'extensions/blocks/premium-content/_inc/subscription-service/class-jetpack-token-subscription-service.php' => ['PhanTypeMismatchReturn'],
         'extensions/blocks/premium-content/_inc/subscription-service/class-jwt.php' => ['PhanTypeMismatchReturnNullable'],
         'extensions/blocks/premium-content/_inc/subscription-service/class-wpcom-online-subscription-service.php' => ['PhanParamSignatureMismatch'],

--- a/projects/plugins/jetpack/changelog/fix-premium-content-refresh-before-deny
+++ b/projects/plugins/jetpack/changelog/fix-premium-content-refresh-before-deny
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Paid Content block: refresh the subscription token on-demand when it contains a stale end_date, preventing lockout after a subscription renewal.

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/access-check.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/access-check.php
@@ -140,6 +140,29 @@ function current_visitor_can_access( $attributes, $block ) {
 				break;
 			}
 		}
+
+		// Refresh-before-deny for the tier path. If the tier check denied access but the
+		// token already references a subscription whose product_id maps to one of the
+		// requested tiers, the most likely cause is a stale end_date from a renewal —
+		// attempt a single refresh against the WordPress.com token-refresh endpoint and
+		// re-check with the fresh subscriptions. Mirrors the same gate inside
+		// visitor_can_view_content() for the non-tier path.
+		if (
+			! $can_view
+			&& method_exists( $paywall, 'token_has_matching_product' )
+			&& $paywall->token_has_matching_product( $tier_ids, $subscriptions )
+		) {
+			$fresh_payload = $paywall->refresh_token_payload();
+			if ( ! empty( $fresh_payload ) ) {
+				$subscriptions = isset( $fresh_payload['subscriptions'] ) ? (array) $fresh_payload['subscriptions'] : array();
+				foreach ( $tier_ids as $tier_id ) {
+					$can_view = ! $paywall->maybe_gate_access_for_user_if_tier( $tier_id, $subscriptions );
+					if ( $can_view ) {
+						break;
+					}
+				}
+			}
+		}
 	}
 
 	$non_tier_ids = array_diff( $selected_plan_ids, $tier_ids );

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
@@ -109,60 +109,61 @@ abstract class Abstract_Token_Subscription_Service implements Subscription_Servi
 	}
 
 	/**
-	 * POST the current token to the WordPress.com refresh endpoint and return a
-	 * fresh JWT string, or null on any failure.
+	 * POST the current token to the WordPress.com memberships token-refresh endpoint
+	 * and return a fresh JWT string, or null on any failure.
 	 *
-	 * Response handling:
-	 *  - 200 with jwt_token → return fresh token string.
-	 *  - 400 (iat expired) / 401 (bad signature) → deterministic failure: clear the
-	 *    cookie so the visitor is routed through the normal auth flow on the next
-	 *    page load, and return null.
-	 *  - Any other non-200 / WP_Error / network timeout → transient failure: leave
-	 *    the cookie alone so a temporary endpoint outage does not mass-log-out
-	 *    subscribers, and return null.
+	 * Endpoint contract (POST /sites/<site_id>/memberships/token/refresh):
+	 *  - 200 + { success: true,  jwt_token: "<jwt>" } → fresh token; return it.
+	 *  - 200 + { success: false, ... }                → wpcom refused the refresh
+	 *    (token no longer eligible, or signature/site/user check failed).
+	 *    Deterministic; clear the cookie so the visitor is routed through the normal
+	 *    auth flow on the next page load.
+	 *  - Anything else (non-200, WP_Error, network timeout, malformed body) → transient;
+	 *    leave the cookie alone so a temporary outage does not mass-log-out subscribers.
 	 *
 	 * @param string $current_token The token to present for refresh.
 	 * @return string|null Fresh token string, or null on failure.
 	 */
 	protected function fetch_refreshed_token( $current_token ) {
+		$site_id = (int) $this->get_site_id();
+		if ( $site_id <= 0 ) {
+			return null;
+		}
+
 		$response = wp_remote_post(
-			self::REST_URL_ORIGIN . 'memberships/jwt/refresh',
+			sprintf(
+				'https://public-api.wordpress.com/rest/v1.1/sites/%d/memberships/token/refresh',
+				$site_id
+			),
 			array(
 				'timeout' => 10,
 				'headers' => array( 'Content-Type' => 'application/json' ),
 				'body'    => wp_json_encode(
-					array(
-						'token'   => $current_token,
-						'site_id' => $this->get_site_id(),
-					),
+					array( 'jwt_token' => $current_token ),
 					JSON_UNESCAPED_SLASHES
 				),
 			)
 		);
 
 		if ( is_wp_error( $response ) ) {
-			// Transient (network error / timeout). Leave cookie, deny.
 			return null;
 		}
 
-		$code = (int) wp_remote_retrieve_response_code( $response );
-
-		if ( 200 === $code ) {
-			$body = json_decode( wp_remote_retrieve_body( $response ), true );
-			if ( is_array( $body ) && ! empty( $body['token'] ) && is_string( $body['token'] ) ) {
-				return $body['token'];
-			}
-			// Malformed 200 — treat as transient.
+		if ( 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
 			return null;
 		}
 
-		if ( 400 === $code || 401 === $code ) {
-			// Deterministic failure — clear cookie so the subscriber re-authenticates.
-			self::clear_token_cookie();
+		$body = json_decode( wp_remote_retrieve_body( $response ), true );
+		if ( ! is_array( $body ) || ! isset( $body['success'] ) ) {
 			return null;
 		}
 
-		// Any other status (5xx, 403, 404, etc.) — transient. Leave cookie, deny.
+		if ( true === $body['success'] && ! empty( $body['jwt_token'] ) && is_string( $body['jwt_token'] ) ) {
+			return $body['jwt_token'];
+		}
+
+		// success === false → deterministic auth failure. Clear cookie.
+		self::clear_token_cookie();
 		return null;
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
@@ -136,7 +136,7 @@ abstract class Abstract_Token_Subscription_Service implements Subscription_Servi
 				$site_id
 			),
 			array(
-				'timeout' => 10,
+				'timeout' => 5,
 				'headers' => array( 'Content-Type' => 'application/json' ),
 				'body'    => wp_json_encode(
 					array( 'jwt_token' => $current_token ),
@@ -165,6 +165,29 @@ abstract class Abstract_Token_Subscription_Service implements Subscription_Servi
 		// success === false → deterministic auth failure. Clear cookie.
 		self::clear_token_cookie();
 		return null;
+	}
+
+	/**
+	 * Whether the token already carries a subscription whose product_id matches one of
+	 * the required plans. Used to gate the refresh path: combined with `validate_subscriptions`
+	 * having returned false, a match here implies the matching subscription's end_date is
+	 * in the past — the only case the refresh endpoint can help with.
+	 *
+	 * @param int[] $valid_plan_ids      Plan IDs required by the post.
+	 * @param array $token_subscriptions Subscriptions from the current token (keyed by product_id).
+	 * @return bool
+	 */
+	private function token_has_matching_product( array $valid_plan_ids, array $token_subscriptions ) {
+		if ( empty( $token_subscriptions ) ) {
+			return false;
+		}
+		foreach ( $valid_plan_ids as $plan_id ) {
+			$product_id = (int) get_post_meta( $plan_id, 'jetpack_memberships_product_id', true );
+			if ( $product_id > 0 && isset( $token_subscriptions[ $product_id ] ) ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**
@@ -255,10 +278,16 @@ abstract class Abstract_Token_Subscription_Service implements Subscription_Servi
 			$subscriptions      = (array) $payload['subscriptions'];
 			$is_paid_subscriber = static::validate_subscriptions( $valid_plan_ids, $subscriptions );
 
-			// If the token's subscriptions do not satisfy the required plans (e.g. the token has a
-			// stale end_date from before a subscription renewal), attempt a single refresh against
-			// the WordPress.com refresh endpoint before denying access.
-			if ( ! $is_paid_subscriber && ! empty( $valid_plan_ids ) ) {
+			// Only attempt a refresh in the specific stale-end_date case: the token already carries a
+			// subscription whose product_id matches one of the required plans, but validation failed
+			// (which, given the match, can only be because end_date is in the past). This excludes
+			// free subscribers, tier mismatches, and cancellations from triggering an HTTP call on
+			// every render.
+			if (
+				! $is_paid_subscriber
+				&& ! empty( $valid_plan_ids )
+				&& $this->token_has_matching_product( $valid_plan_ids, $subscriptions )
+			) {
 				$fresh_payload = $this->refresh_token_payload();
 				if ( ! empty( $fresh_payload ) ) {
 					$payload            = $fresh_payload;
@@ -683,13 +712,15 @@ abstract class Abstract_Token_Subscription_Service implements Subscription_Servi
 
 	/**
 	 * Clear the auth cookie.
+	 *
+	 * Always emits the clearing Set-Cookie header (when headers aren't already sent), even
+	 * if $_COOKIE is empty for this request. This matters for the URL-token entry path:
+	 * set_token_cookie() only emits a Set-Cookie header and never populates $_COOKIE, so a
+	 * $_COOKIE-based early-return here would let a freshly-set stale cookie escape clearing
+	 * on the same response.
 	 */
 	public static function clear_token_cookie() {
 		if ( defined( 'TESTING_IN_JETPACK' ) && TESTING_IN_JETPACK ) {
-			return;
-		}
-
-		if ( ! self::has_token_from_cookie() ) {
 			return;
 		}
 

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
@@ -88,7 +88,7 @@ abstract class Abstract_Token_Subscription_Service implements Subscription_Servi
 	 *
 	 * @return array|null Decoded fresh payload on success, null on any failure.
 	 */
-	protected function refresh_token_payload() {
+	public function refresh_token_payload() {
 		$current_token = $this->get_and_set_token_from_request();
 		if ( empty( $current_token ) ) {
 			return null;
@@ -177,7 +177,7 @@ abstract class Abstract_Token_Subscription_Service implements Subscription_Servi
 	 * @param array $token_subscriptions Subscriptions from the current token (keyed by product_id).
 	 * @return bool
 	 */
-	private function token_has_matching_product( array $valid_plan_ids, array $token_subscriptions ) {
+	public function token_has_matching_product( array $valid_plan_ids, array $token_subscriptions ) {
 		if ( empty( $token_subscriptions ) ) {
 			return false;
 		}

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
@@ -696,6 +696,14 @@ abstract class Abstract_Token_Subscription_Service implements Subscription_Servi
 	/**
 	 * Store the auth cookie.
 	 *
+	 * Updates `$_COOKIE` in memory so subsequent code in the same request (e.g. another
+	 * Premium Content block on the same post) reads the new value and doesn't re-trigger
+	 * a refresh against a now-stale value. The Set-Cookie header is emitted via the
+	 * standard `setcookie()` — on Atomic / wpcom the response is output-buffered so this
+	 * still works during `the_content`; on stricter self-hosted setups the header may
+	 * silently be dropped after output starts, in which case the browser keeps the prior
+	 * cookie value and the refresh fires again on the next visit (correct degradation).
+	 *
 	 * @param  string $token Auth token.
 	 * @return void
 	 */
@@ -703,91 +711,34 @@ abstract class Abstract_Token_Subscription_Service implements Subscription_Servi
 		if ( empty( $token ) ) {
 			return;
 		}
-		self::write_cookie( $token, MONTH_IN_SECONDS );
-	}
 
-	/**
-	 * Clear the auth cookie.
-	 *
-	 * Always updates $_COOKIE for in-request consistency, then either emits a clearing
-	 * Set-Cookie header (when headers haven't been sent) or schedules a JS-based cookie
-	 * clear for the footer (when they have — see write_cookie()).
-	 */
-	public static function clear_token_cookie() {
-		self::write_cookie( '', 0 );
-	}
+		$_COOKIE[ self::JWT_AUTH_TOKEN_COOKIE_NAME ] = $token;
 
-	/**
-	 * Persist or clear the auth cookie via the best mechanism available for the current
-	 * point in the request lifecycle.
-	 *
-	 * Always updates `$_COOKIE` so subsequent code in the same request sees the new value.
-	 * Then, if headers haven't been sent, uses the standard `setcookie()`. If headers have
-	 * already been sent — which is the common case for the refresh path that runs during
-	 * `the_content` after the theme has output `<!DOCTYPE html>` — registers a `wp_footer`
-	 * callback that emits an inline `<script>document.cookie = ...</script>` instead.
-	 *
-	 * The cookie isn't HttpOnly, so JS-write is equivalent to a Set-Cookie header for the
-	 * browser. Pages that grant paid-content access already opt out of HTML caching via
-	 * `jetpack_earn_remove_cache_headers`, so embedding the JWT in the page isn't a new
-	 * exposure relative to the existing JS-readable cookie.
-	 *
-	 * @param string $token   Token value, or empty string to clear the cookie.
-	 * @param int    $max_age Seconds until expiry. Use 0 to clear.
-	 */
-	private static function write_cookie( $token, $max_age ) {
-		if ( '' === $token ) {
-			unset( $_COOKIE[ self::JWT_AUTH_TOKEN_COOKIE_NAME ] );
-		} else {
-			$_COOKIE[ self::JWT_AUTH_TOKEN_COOKIE_NAME ] = $token;
+		if ( defined( 'TESTING_IN_JETPACK' ) && TESTING_IN_JETPACK ) {
+			return;
 		}
 
 		if ( ! headers_sent() ) {
-			if ( defined( 'TESTING_IN_JETPACK' ) && TESTING_IN_JETPACK ) {
-				// Skip setcookie() in tests to avoid "headers already sent" warnings from
-				// PHPUnit's preamble output. The $_COOKIE update above is enough for
-				// in-request assertions; the JS fallback is exercised by its own unit test.
-				return;
-			}
-			$expires = $max_age > 0 ? time() + $max_age : 1;
 			// phpcs:ignore Jetpack.Functions.SetCookie.FoundNonHTTPOnlyFalse
-			setcookie( self::JWT_AUTH_TOKEN_COOKIE_NAME, $token, $expires, '/', '', is_ssl(), false );
-			return;
+			setcookie( self::JWT_AUTH_TOKEN_COOKIE_NAME, $token, strtotime( '+1 month' ), '/', '', is_ssl(), false );
 		}
-
-		self::queue_cookie_update_via_js( $token, $max_age );
 	}
 
 	/**
-	 * Schedule a `wp_footer` callback that updates `document.cookie` to the given value.
-	 * Used as a fallback for `write_cookie()` when headers have already been sent.
-	 *
-	 * @param string $token   Token value, or empty string to clear.
-	 * @param int    $max_age Seconds until expiry. 0 to clear immediately.
-	 * @return void
+	 * Clear the auth cookie. Mirrors set_token_cookie(): updates `$_COOKIE` for
+	 * in-request consistency, then emits a clearing Set-Cookie header.
 	 */
-	public static function queue_cookie_update_via_js( $token, $max_age ) {
-		if ( ! function_exists( 'add_action' ) ) {
+	public static function clear_token_cookie() {
+		unset( $_COOKIE[ self::JWT_AUTH_TOKEN_COOKIE_NAME ] );
+
+		if ( defined( 'TESTING_IN_JETPACK' ) && TESTING_IN_JETPACK ) {
 			return;
 		}
-		$cookie_str = sprintf(
-			'%s=%s; path=/; max-age=%d%s',
-			self::JWT_AUTH_TOKEN_COOKIE_NAME,
-			$token,
-			max( 0, (int) $max_age ),
-			is_ssl() ? '; secure' : ''
-		);
-		add_action(
-			'wp_footer',
-			static function () use ( $cookie_str ) {
-				// wp_json_encode handles JS-string escaping (quotes, control chars, slashes).
-				printf(
-					'<script>document.cookie=%s;</script>',
-					wp_json_encode( $cookie_str, JSON_UNESCAPED_SLASHES ) // phpcs:ignore WordPress.Security.EscapeOutput
-				);
-			},
-			1
-		);
+
+		if ( ! headers_sent() ) {
+			// phpcs:ignore Jetpack.Functions.SetCookie.FoundNonHTTPOnlyFalse
+			setcookie( self::JWT_AUTH_TOKEN_COOKIE_NAME, '', 1, '/', '', is_ssl(), false );
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
@@ -149,8 +149,8 @@ abstract class Abstract_Token_Subscription_Service implements Subscription_Servi
 
 		if ( 200 === $code ) {
 			$body = json_decode( wp_remote_retrieve_body( $response ), true );
-			if ( is_array( $body ) && ! empty( $body['jwt_token'] ) && is_string( $body['jwt_token'] ) ) {
-				return $body['jwt_token'];
+			if ( is_array( $body ) && ! empty( $body['token'] ) && is_string( $body['token'] ) ) {
+				return $body['token'];
 			}
 			// Malformed 200 — treat as transient.
 			return null;

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
@@ -720,11 +720,11 @@ abstract class Abstract_Token_Subscription_Service implements Subscription_Servi
 	 * on the same response.
 	 */
 	public static function clear_token_cookie() {
+		unset( $_COOKIE[ self::JWT_AUTH_TOKEN_COOKIE_NAME ] );
+
 		if ( defined( 'TESTING_IN_JETPACK' ) && TESTING_IN_JETPACK ) {
 			return;
 		}
-
-		unset( $_COOKIE[ self::JWT_AUTH_TOKEN_COOKIE_NAME ] );
 
 		if ( ! headers_sent() ) {
 			// phpcs:ignore Jetpack.Functions.SetCookie.FoundNonHTTPOnlyFalse

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
@@ -77,6 +77,103 @@ abstract class Abstract_Token_Subscription_Service implements Subscription_Servi
 	}
 
 	/**
+	 * Attempt to refresh the current token against the WordPress.com refresh endpoint
+	 * and, on success, persist the fresh token in the cookie and return the decoded
+	 * payload.
+	 *
+	 * This is called when a subscriber has a JWT token whose subscription data is
+	 * stale (e.g. the cookie contains an old end_date from before a Stripe renewal).
+	 * The refresh endpoint accepts the existing token, re-queries billing, and
+	 * returns a fresh token reflecting current subscription state.
+	 *
+	 * @return array|null Decoded fresh payload on success, null on any failure.
+	 */
+	protected function refresh_token_payload() {
+		$current_token = $this->get_and_set_token_from_request();
+		if ( empty( $current_token ) ) {
+			return null;
+		}
+
+		$fresh_token = $this->fetch_refreshed_token( $current_token );
+		if ( empty( $fresh_token ) ) {
+			return null;
+		}
+
+		$fresh_payload = $this->decode_token( $fresh_token );
+		if ( empty( $fresh_payload ) ) {
+			return null;
+		}
+
+		$this->set_token_cookie( $fresh_token );
+		return $fresh_payload;
+	}
+
+	/**
+	 * POST the current token to the WordPress.com refresh endpoint and return a
+	 * fresh JWT string, or null on any failure.
+	 *
+	 * Response handling:
+	 *  - 200 with jwt_token → return fresh token string.
+	 *  - 400 (iat expired) / 401 (bad signature) → deterministic failure: clear the
+	 *    cookie so the visitor is routed through the normal auth flow on the next
+	 *    page load, and return null.
+	 *  - Any other non-200 / WP_Error / network timeout → transient failure: leave
+	 *    the cookie alone so a temporary endpoint outage does not mass-log-out
+	 *    subscribers, and return null.
+	 *
+	 * @param string $current_token The token to present for refresh.
+	 * @return string|null Fresh token string, or null on failure.
+	 */
+	protected function fetch_refreshed_token( $current_token ) {
+		$response = wp_remote_post(
+			self::REST_URL_ORIGIN . 'memberships/jwt/refresh',
+			array(
+				'timeout' => 10,
+				'headers' => array( 'Content-Type' => 'application/json' ),
+				'body'    => wp_json_encode(
+					array(
+						'token'   => $current_token,
+						'site_id' => $this->get_site_id(),
+					),
+					JSON_UNESCAPED_SLASHES
+				),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			// Transient (network error / timeout). Leave cookie, deny.
+			return null;
+		}
+
+		$code = (int) wp_remote_retrieve_response_code( $response );
+
+		if ( 200 === $code ) {
+			$body = json_decode( wp_remote_retrieve_body( $response ), true );
+			if ( is_array( $body ) && ! empty( $body['jwt_token'] ) && is_string( $body['jwt_token'] ) ) {
+				return $body['jwt_token'];
+			}
+			// Malformed 200 — treat as transient.
+			return null;
+		}
+
+		if ( 400 === $code || 401 === $code ) {
+			// Deterministic failure — clear cookie so the subscriber re-authenticates.
+			self::clear_token_cookie();
+			return null;
+		}
+
+		// Any other status (5xx, 403, 404, etc.) — transient. Leave cookie, deny.
+		return null;
+	}
+
+	/**
+	 * Get the site ID for the current site.
+	 *
+	 * @return int
+	 */
+	abstract public function get_site_id();
+
+	/**
 	 * Get the token payload .
 	 *
 	 * @return array
@@ -156,6 +253,19 @@ abstract class Abstract_Token_Subscription_Service implements Subscription_Servi
 			);
 			$subscriptions      = (array) $payload['subscriptions'];
 			$is_paid_subscriber = static::validate_subscriptions( $valid_plan_ids, $subscriptions );
+
+			// If the token's subscriptions do not satisfy the required plans (e.g. the token has a
+			// stale end_date from before a subscription renewal), attempt a single refresh against
+			// the WordPress.com refresh endpoint before denying access.
+			if ( ! $is_paid_subscriber && ! empty( $valid_plan_ids ) ) {
+				$fresh_payload = $this->refresh_token_payload();
+				if ( ! empty( $fresh_payload ) ) {
+					$payload            = $fresh_payload;
+					$is_blog_subscriber = isset( $payload['blog_sub'] ) && self::BLOG_SUB_ACTIVE === $payload['blog_sub'];
+					$subscriptions      = isset( $payload['subscriptions'] ) ? (array) $payload['subscriptions'] : array();
+					$is_paid_subscriber = static::validate_subscriptions( $valid_plan_ids, $subscriptions );
+				}
+			}
 		}
 
 		$has_access = $this->user_has_access( $access_level, $is_blog_subscriber, $is_paid_subscriber, get_the_ID(), $subscriptions );

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
@@ -158,8 +158,14 @@ abstract class Abstract_Token_Subscription_Service implements Subscription_Servi
 			return null;
 		}
 
-		if ( true === $body['success'] && ! empty( $body['jwt_token'] ) && is_string( $body['jwt_token'] ) ) {
-			return $body['jwt_token'];
+		if ( true === $body['success'] ) {
+			if ( ! empty( $body['jwt_token'] ) && is_string( $body['jwt_token'] ) ) {
+				return $body['jwt_token'];
+			}
+			// Malformed 200: success: true but no usable jwt_token. Treat as transient —
+			// leave the cookie alone rather than logging the visitor out over a response
+			// shape problem.
+			return null;
 		}
 
 		// success === false → deterministic auth failure. Clear cookie.

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
@@ -700,36 +700,94 @@ abstract class Abstract_Token_Subscription_Service implements Subscription_Servi
 	 * @return void
 	 */
 	private function set_token_cookie( $token ) {
-		if ( defined( 'TESTING_IN_JETPACK' ) && TESTING_IN_JETPACK ) {
+		if ( empty( $token ) ) {
 			return;
 		}
-
-		if ( ! empty( $token ) && ! headers_sent() ) {
-			// phpcs:ignore Jetpack.Functions.SetCookie.FoundNonHTTPOnlyFalse
-			setcookie( self::JWT_AUTH_TOKEN_COOKIE_NAME, $token, strtotime( '+1 month' ), '/', '', is_ssl(), false );
-		}
+		self::write_cookie( $token, MONTH_IN_SECONDS );
 	}
 
 	/**
 	 * Clear the auth cookie.
 	 *
-	 * Always emits the clearing Set-Cookie header (when headers aren't already sent), even
-	 * if $_COOKIE is empty for this request. This matters for the URL-token entry path:
-	 * set_token_cookie() only emits a Set-Cookie header and never populates $_COOKIE, so a
-	 * $_COOKIE-based early-return here would let a freshly-set stale cookie escape clearing
-	 * on the same response.
+	 * Always updates $_COOKIE for in-request consistency, then either emits a clearing
+	 * Set-Cookie header (when headers haven't been sent) or schedules a JS-based cookie
+	 * clear for the footer (when they have — see write_cookie()).
 	 */
 	public static function clear_token_cookie() {
-		unset( $_COOKIE[ self::JWT_AUTH_TOKEN_COOKIE_NAME ] );
+		self::write_cookie( '', 0 );
+	}
 
-		if ( defined( 'TESTING_IN_JETPACK' ) && TESTING_IN_JETPACK ) {
-			return;
+	/**
+	 * Persist or clear the auth cookie via the best mechanism available for the current
+	 * point in the request lifecycle.
+	 *
+	 * Always updates `$_COOKIE` so subsequent code in the same request sees the new value.
+	 * Then, if headers haven't been sent, uses the standard `setcookie()`. If headers have
+	 * already been sent — which is the common case for the refresh path that runs during
+	 * `the_content` after the theme has output `<!DOCTYPE html>` — registers a `wp_footer`
+	 * callback that emits an inline `<script>document.cookie = ...</script>` instead.
+	 *
+	 * The cookie isn't HttpOnly, so JS-write is equivalent to a Set-Cookie header for the
+	 * browser. Pages that grant paid-content access already opt out of HTML caching via
+	 * `jetpack_earn_remove_cache_headers`, so embedding the JWT in the page isn't a new
+	 * exposure relative to the existing JS-readable cookie.
+	 *
+	 * @param string $token   Token value, or empty string to clear the cookie.
+	 * @param int    $max_age Seconds until expiry. Use 0 to clear.
+	 */
+	private static function write_cookie( $token, $max_age ) {
+		if ( '' === $token ) {
+			unset( $_COOKIE[ self::JWT_AUTH_TOKEN_COOKIE_NAME ] );
+		} else {
+			$_COOKIE[ self::JWT_AUTH_TOKEN_COOKIE_NAME ] = $token;
 		}
 
 		if ( ! headers_sent() ) {
+			if ( defined( 'TESTING_IN_JETPACK' ) && TESTING_IN_JETPACK ) {
+				// Skip setcookie() in tests to avoid "headers already sent" warnings from
+				// PHPUnit's preamble output. The $_COOKIE update above is enough for
+				// in-request assertions; the JS fallback is exercised by its own unit test.
+				return;
+			}
+			$expires = $max_age > 0 ? time() + $max_age : 1;
 			// phpcs:ignore Jetpack.Functions.SetCookie.FoundNonHTTPOnlyFalse
-			setcookie( self::JWT_AUTH_TOKEN_COOKIE_NAME, '', 1, '/', '', is_ssl(), false );
+			setcookie( self::JWT_AUTH_TOKEN_COOKIE_NAME, $token, $expires, '/', '', is_ssl(), false );
+			return;
 		}
+
+		self::queue_cookie_update_via_js( $token, $max_age );
+	}
+
+	/**
+	 * Schedule a `wp_footer` callback that updates `document.cookie` to the given value.
+	 * Used as a fallback for `write_cookie()` when headers have already been sent.
+	 *
+	 * @param string $token   Token value, or empty string to clear.
+	 * @param int    $max_age Seconds until expiry. 0 to clear immediately.
+	 * @return void
+	 */
+	public static function queue_cookie_update_via_js( $token, $max_age ) {
+		if ( ! function_exists( 'add_action' ) ) {
+			return;
+		}
+		$cookie_str = sprintf(
+			'%s=%s; path=/; max-age=%d%s',
+			self::JWT_AUTH_TOKEN_COOKIE_NAME,
+			$token,
+			max( 0, (int) $max_age ),
+			is_ssl() ? '; secure' : ''
+		);
+		add_action(
+			'wp_footer',
+			static function () use ( $cookie_str ) {
+				// wp_json_encode handles JS-string escaping (quotes, control chars, slashes).
+				printf(
+					'<script>document.cookie=%s;</script>',
+					wp_json_encode( $cookie_str, JSON_UNESCAPED_SLASHES ) // phpcs:ignore WordPress.Security.EscapeOutput
+				);
+			},
+			1
+		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Jetpack_Premium_Content_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Jetpack_Premium_Content_Test.php
@@ -66,7 +66,6 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 		remove_all_filters( 'jetpack_is_connection_ready' );
 		remove_all_filters( PAYWALL_FILTER );
 		remove_all_filters( 'pre_http_request' );
-		remove_all_actions( 'wp_footer' );
 		Jetpack_Options::delete_option( 'id' );
 		$this->refresh_response_override = null;
 		$this->refresh_call_count        = 0;
@@ -580,37 +579,5 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 
 		$this->assertTrue( current_visitor_can_access( array( 'selectedPlanIds' => array( $plan_id ) ), array() ) );
 		$this->assertSame( 0, $this->refresh_call_count, 'Refresh endpoint should not be called when the token is still active.' );
-	}
-
-	/**
-	 * Refresh runs during `the_content`, well after the theme has output `<!DOCTYPE html>`
-	 * and headers have been sent — so `setcookie()` is a no-op. The fallback is to register
-	 * a `wp_footer` callback that updates `document.cookie`. Verify that callback exists
-	 * and emits a well-formed cookie-update snippet referencing the fresh token.
-	 *
-	 * @return void
-	 */
-	public function test_queue_cookie_update_via_js_emits_document_cookie_snippet() {
-		Abstract_Token_Subscription_Service::queue_cookie_update_via_js( 'fresh.jwt.token', MONTH_IN_SECONDS );
-
-		// Call only our registered priority-1 callback rather than firing the full
-		// wp_footer action — the latter triggers WP-core deprecation warnings unrelated
-		// to this test that the WP_UnitTestCase framework treats as failures.
-		global $wp_filter;
-		$this->assertArrayHasKey( 'wp_footer', $wp_filter, 'A wp_footer action should be registered after the JS-fallback path.' );
-		$priority_one_callbacks = $wp_filter['wp_footer']->callbacks[1] ?? array();
-		$this->assertNotEmpty( $priority_one_callbacks, 'The cookie-update callback should be registered at priority 1.' );
-
-		ob_start();
-		foreach ( $priority_one_callbacks as $cb ) {
-			call_user_func( $cb['function'] );
-		}
-		$output = ob_get_clean();
-
-		$this->assertMatchesRegularExpression(
-			'#^<script>document\.cookie="wp-jp-premium-content-session=fresh\.jwt\.token; path=/; max-age=' . MONTH_IN_SECONDS . '";</script>$#',
-			$output,
-			'The cookie-update snippet should contain the fresh token, path, and max-age, and nothing else.'
-		);
 	}
 }

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Jetpack_Premium_Content_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Jetpack_Premium_Content_Test.php
@@ -65,7 +65,7 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 	 * @return mixed
 	 */
 	public function mock_refresh_endpoint( $preempt, $args, $url ) {
-		if ( false !== strpos( $url, 'memberships/jwt/refresh' ) ) {
+		if ( false !== strpos( $url, 'memberships/token/refresh' ) ) {
 			if ( null !== $this->refresh_response_override ) {
 				return $this->refresh_response_override;
 			}
@@ -260,7 +260,13 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 				'code'    => 200,
 				'message' => 'OK',
 			),
-			'body'     => wp_json_encode( array( 'token' => $fresh_token ), JSON_UNESCAPED_SLASHES ),
+			'body'     => wp_json_encode(
+				array(
+					'success'   => true,
+					'jwt_token' => $fresh_token,
+				),
+				JSON_UNESCAPED_SLASHES
+			),
 			'headers'  => array(),
 			'cookies'  => array(),
 		);
@@ -319,7 +325,13 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 				'code'    => 200,
 				'message' => 'OK',
 			),
-			'body'     => wp_json_encode( array( 'token' => $empty_token ), JSON_UNESCAPED_SLASHES ),
+			'body'     => wp_json_encode(
+				array(
+					'success'   => true,
+					'jwt_token' => $empty_token,
+				),
+				JSON_UNESCAPED_SLASHES
+			),
 			'headers'  => array(),
 			'cookies'  => array(),
 		);
@@ -357,8 +369,10 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * When the refresh endpoint returns 401 (bad signature), access is denied
-	 * AND the cookie is cleared so the subscriber re-authenticates on next visit.
+	 * When the refresh endpoint returns 200 + { success: false } (wpcom refused the
+	 * refresh — token no longer eligible, or signature/site/user check failed),
+	 * access is denied AND the cookie is cleared so the subscriber re-authenticates
+	 * on next visit.
 	 *
 	 * @return void
 	 */
@@ -376,10 +390,16 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 
 		$this->refresh_response_override = array(
 			'response' => array(
-				'code'    => 401,
-				'message' => 'Unauthorized',
+				'code'    => 200,
+				'message' => 'OK',
 			),
-			'body'     => '',
+			'body'     => wp_json_encode(
+				array(
+					'success' => false,
+					'error'   => 'token-too-old',
+				),
+				JSON_UNESCAPED_SLASHES
+			),
 			'headers'  => array(),
 			'cookies'  => array(),
 		);

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Jetpack_Premium_Content_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Jetpack_Premium_Content_Test.php
@@ -30,6 +30,14 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 	 */
 	protected $refresh_response_override = null;
 
+	/**
+	 * Number of times the refresh endpoint mock was hit during a test. Lets tests
+	 * assert that refresh was (or was not) called, independent of the access outcome.
+	 *
+	 * @var int
+	 */
+	protected $refresh_call_count = 0;
+
 	public function set_up() {
 		parent::set_up();
 		Jetpack_Subscriptions::init();
@@ -51,6 +59,7 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 		remove_all_filters( PAYWALL_FILTER );
 		remove_all_filters( 'pre_http_request' );
 		$this->refresh_response_override = null;
+		$this->refresh_call_count        = 0;
 		unset( $_COOKIE['wp-jp-premium-content-session'] );
 		parent::tear_down();
 	}
@@ -66,6 +75,7 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 	 */
 	public function mock_refresh_endpoint( $preempt, $args, $url ) {
 		if ( false !== strpos( $url, 'memberships/token/refresh' ) ) {
+			++$this->refresh_call_count;
 			if ( null !== $this->refresh_response_override ) {
 				return $this->refresh_response_override;
 			}
@@ -430,6 +440,29 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A token with no subscription matching any required plan (free subscriber on a
+	 * paid post, or tier mismatch) must NOT trigger a refresh — refresh can only
+	 * resolve stale-end_date for an existing matching subscription, not conjure a
+	 * subscription that never existed. This guards against refresh-on-every-render
+	 * for the (much larger) never-paid and tier-mismatch populations.
+	 *
+	 * @return void
+	 */
+	public function test_refresh_not_called_when_token_has_no_matching_product() {
+		$users_plans           = $this->set_up_users_and_plans();
+		$regular_subscriber_id = $users_plans[1];
+		$plan_id               = $users_plans[3];
+
+		wp_set_current_user( $regular_subscriber_id );
+		// Free subscriber: blog_sub active, no paid subscriptions in token.
+		$payload = $this->get_payload( true, false );
+		$this->set_returned_token( $payload );
+
+		$this->assertFalse( current_visitor_can_access( array( 'selectedPlanIds' => array( $plan_id ) ), array() ) );
+		$this->assertSame( 0, $this->refresh_call_count, 'Refresh endpoint should not be called when the token has no matching product_id.' );
+	}
+
+	/**
 	 * An active subscription with a future end_date should not trigger a refresh
 	 * at all — no HTTP call is made.
 	 *
@@ -444,9 +477,7 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 		$valid_payload = $this->get_payload( true, true, time() + HOUR_IN_SECONDS );
 		$this->set_returned_token( $valid_payload );
 
-		// If a refresh call were made, this override would throw — proving it is not called.
-		$this->refresh_response_override = new WP_Error( 'should_not_be_called', 'refresh should not be called for valid token' );
-
 		$this->assertTrue( current_visitor_can_access( array( 'selectedPlanIds' => array( $plan_id ) ), array() ) );
+		$this->assertSame( 0, $this->refresh_call_count, 'Refresh endpoint should not be called when the token is still active.' );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Jetpack_Premium_Content_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Jetpack_Premium_Content_Test.php
@@ -24,9 +24,10 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 
 	/**
 	 * Optional override for the refresh endpoint response. If null, refresh is blocked
-	 * (simulates a transient 500). Tests can set this to control refresh behavior.
+	 * (simulates a transient 500). Tests can set this to control refresh behavior — an
+	 * array shape for normal HTTP responses, or a WP_Error to simulate transport failure.
 	 *
-	 * @var array|null
+	 * @var array|\WP_Error|null
 	 */
 	protected $refresh_response_override = null;
 
@@ -42,6 +43,9 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 		parent::set_up();
 		Jetpack_Subscriptions::init();
 		add_filter( 'jetpack_is_connection_ready', '__return_true' );
+		// Refresh endpoint URL embeds the site id; without this it resolves to 0 and the
+		// production code's `$site_id <= 0` guard short-circuits before any HTTP call.
+		Jetpack_Options::update_option( 'id', 12345 );
 		add_filter(
 			PAYWALL_FILTER,
 			function () {
@@ -58,6 +62,7 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 		remove_all_filters( 'jetpack_is_connection_ready' );
 		remove_all_filters( PAYWALL_FILTER );
 		remove_all_filters( 'pre_http_request' );
+		Jetpack_Options::delete_option( 'id' );
 		$this->refresh_response_override = null;
 		$this->refresh_call_count        = 0;
 		unset( $_COOKIE['wp-jp-premium-content-session'] );

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Jetpack_Premium_Content_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Jetpack_Premium_Content_Test.php
@@ -355,8 +355,10 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * When the refresh endpoint returns a transient failure (5xx), the original
-	 * stale token behavior should apply — access denied, cookie left alone.
+	 * When the refresh endpoint returns a transient failure (5xx), access is
+	 * denied AND the cookie is left intact — this is what distinguishes the
+	 * transient branch from the deterministic `success: false` branch, so we
+	 * assert both halves explicitly.
 	 *
 	 * @return void
 	 */
@@ -366,10 +368,12 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 		$plan_id            = $users_plans[3];
 
 		wp_set_current_user( $paid_subscriber_id );
-		$stale_payload = $this->get_payload( true, true, time() - HOUR_IN_SECONDS );
-		$this->set_returned_token( $stale_payload );
+		$stale_payload                            = $this->get_payload( true, true, time() - HOUR_IN_SECONDS );
+		$service                                  = subscription_service();
+		$token_string                             = JWT::encode( $stale_payload, $service->get_key() );
+		$_COOKIE['wp-jp-premium-content-session'] = $token_string;
+		$_GET['token']                            = $token_string;
 
-		// Refresh endpoint returns a 500 (the default mock behavior).
 		$this->refresh_response_override = array(
 			'response' => array(
 				'code'    => 500,
@@ -381,6 +385,8 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertFalse( current_visitor_can_access( array( 'selectedPlanIds' => array( $plan_id ) ), array() ) );
+		$this->assertSame( 1, $this->refresh_call_count, 'Refresh should have been attempted for a stale token with matching product_id.' );
+		$this->assertSame( $token_string, $_COOKIE['wp-jp-premium-content-session'] ?? null, 'Cookie must be preserved on transient failure so the next request can retry.' );
 	}
 
 	/**
@@ -425,8 +431,8 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A WP_Error from the HTTP layer (e.g. network timeout) is treated as a
-	 * transient failure — deny access, leave cookie alone.
+	 * A WP_Error from the HTTP layer (e.g. network timeout) is treated the same
+	 * as a 5xx: deny access, leave the cookie intact for the next request to retry.
 	 *
 	 * @return void
 	 */
@@ -436,12 +442,17 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 		$plan_id            = $users_plans[3];
 
 		wp_set_current_user( $paid_subscriber_id );
-		$stale_payload = $this->get_payload( true, true, time() - HOUR_IN_SECONDS );
-		$this->set_returned_token( $stale_payload );
+		$stale_payload                            = $this->get_payload( true, true, time() - HOUR_IN_SECONDS );
+		$service                                  = subscription_service();
+		$token_string                             = JWT::encode( $stale_payload, $service->get_key() );
+		$_COOKIE['wp-jp-premium-content-session'] = $token_string;
+		$_GET['token']                            = $token_string;
 
 		$this->refresh_response_override = new WP_Error( 'http_request_failed', 'cURL error 28: Operation timed out' );
 
 		$this->assertFalse( current_visitor_can_access( array( 'selectedPlanIds' => array( $plan_id ) ), array() ) );
+		$this->assertSame( 1, $this->refresh_call_count, 'Refresh should have been attempted for a stale token with matching product_id.' );
+		$this->assertSame( $token_string, $_COOKIE['wp-jp-premium-content-session'] ?? null, 'Cookie must be preserved on WP_Error so the next request can retry.' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Jetpack_Premium_Content_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Jetpack_Premium_Content_Test.php
@@ -439,6 +439,43 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * 200 + `{ success: true }` but with a missing / non-string `jwt_token` is a
+	 * malformed response shape, not an auth failure. Treat as transient: deny
+	 * access (no fresh token to validate against), but DON'T clear the cookie —
+	 * otherwise a server-side response-shape bug at wpcom would mass-log-out
+	 * subscribers.
+	 *
+	 * @return void
+	 */
+	public function test_refresh_before_deny_treats_malformed_success_as_transient() {
+		$users_plans        = $this->set_up_users_and_plans();
+		$paid_subscriber_id = $users_plans[2];
+		$plan_id            = $users_plans[3];
+
+		wp_set_current_user( $paid_subscriber_id );
+		$stale_payload                            = $this->get_payload( true, true, time() - HOUR_IN_SECONDS );
+		$service                                  = subscription_service();
+		$token_string                             = JWT::encode( $stale_payload, $service->get_key() );
+		$_COOKIE['wp-jp-premium-content-session'] = $token_string;
+		$_GET['token']                            = $token_string;
+
+		// success: true but no jwt_token field — malformed response.
+		$this->refresh_response_override = array(
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+			'body'     => wp_json_encode( array( 'success' => true ), JSON_UNESCAPED_SLASHES ),
+			'headers'  => array(),
+			'cookies'  => array(),
+		);
+
+		$this->assertFalse( current_visitor_can_access( array( 'selectedPlanIds' => array( $plan_id ) ), array() ) );
+		$this->assertSame( 1, $this->refresh_call_count, 'Refresh should have been attempted.' );
+		$this->assertSame( $token_string, $_COOKIE['wp-jp-premium-content-session'] ?? null, 'Cookie must be preserved on malformed success response so the next request can retry.' );
+	}
+
+	/**
 	 * When the refresh endpoint returns a transient failure (5xx), access is
 	 * denied AND the cookie is left intact — this is what distinguishes the
 	 * transient branch from the deterministic `success: false` branch, so we

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Jetpack_Premium_Content_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Jetpack_Premium_Content_Test.php
@@ -22,6 +22,14 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 
 	protected $product_id = 1234;
 
+	/**
+	 * Optional override for the refresh endpoint response. If null, refresh is blocked
+	 * (simulates a transient 500). Tests can set this to control refresh behavior.
+	 *
+	 * @var array|null
+	 */
+	protected $refresh_response_override = null;
+
 	public function set_up() {
 		parent::set_up();
 		Jetpack_Subscriptions::init();
@@ -32,6 +40,8 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 				return new Test_Jetpack_Token_Subscription_Service();
 			}
 		);
+		// Block or mock refresh endpoint HTTP calls in tests.
+		add_filter( 'pre_http_request', array( $this, 'mock_refresh_endpoint' ), 10, 3 );
 	}
 
 	public function tear_down() {
@@ -39,7 +49,37 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 		remove_all_filters( 'earn_get_user_subscriptions_for_site_id' );
 		remove_all_filters( 'jetpack_is_connection_ready' );
 		remove_all_filters( PAYWALL_FILTER );
+		remove_all_filters( 'pre_http_request' );
+		$this->refresh_response_override = null;
+		unset( $_COOKIE['wp-jp-premium-content-session'] );
 		parent::tear_down();
+	}
+
+	/**
+	 * Intercept HTTP calls to the refresh endpoint. Returns the override if set,
+	 * otherwise a transient 500 so refresh fails and existing behavior is preserved.
+	 *
+	 * @param mixed  $preempt Current preempt value.
+	 * @param array  $args    Request args.
+	 * @param string $url     Request URL.
+	 * @return mixed
+	 */
+	public function mock_refresh_endpoint( $preempt, $args, $url ) {
+		if ( false !== strpos( $url, 'memberships/jwt/refresh' ) ) {
+			if ( null !== $this->refresh_response_override ) {
+				return $this->refresh_response_override;
+			}
+			return array(
+				'response' => array(
+					'code'    => 500,
+					'message' => 'blocked in tests',
+				),
+				'body'     => '',
+				'headers'  => array(),
+				'cookies'  => array(),
+			);
+		}
+		return $preempt;
 	}
 
 	/**
@@ -194,5 +234,199 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 		// The plan id can be passed in 2 ways.
 		$this->assertTrue( current_visitor_can_access( array( 'selectedPlanIds' => array( $plan_id ) ), array() ) );
 		$this->assertTrue( current_visitor_can_access( array(), (object) array( 'context' => array( 'premium-content/planIds' => array( $plan_id ) ) ) ) );
+	}
+
+	/**
+	 * Helper: build a mock 200 response from the refresh endpoint with a fresh JWT
+	 * containing a subscription that expires in the future.
+	 *
+	 * @return array
+	 */
+	private function build_refresh_success_response() {
+		$service       = subscription_service();
+		$fresh_payload = array(
+			'blog_sub'      => 'active',
+			'subscriptions' => array(
+				$this->product_id => array(
+					'status'     => 'active',
+					'end_date'   => time() + HOUR_IN_SECONDS,
+					'product_id' => $this->product_id,
+				),
+			),
+		);
+		$fresh_token   = JWT::encode( $fresh_payload, $service->get_key() );
+		return array(
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+			'body'     => wp_json_encode( array( 'jwt_token' => $fresh_token ), JSON_UNESCAPED_SLASHES ),
+			'headers'  => array(),
+			'cookies'  => array(),
+		);
+	}
+
+	/**
+	 * When the token contains a stale (expired) end_date and the refresh endpoint
+	 * returns a fresh token with a valid subscription, access should be granted.
+	 * This covers the core renewal lockout bug.
+	 *
+	 * @return void
+	 */
+	public function test_refresh_before_deny_grants_access_on_successful_refresh() {
+		$users_plans        = $this->set_up_users_and_plans();
+		$paid_subscriber_id = $users_plans[2];
+		$plan_id            = $users_plans[3];
+
+		wp_set_current_user( $paid_subscriber_id );
+		// Stale token — end_date in the past.
+		$stale_payload = $this->get_payload( true, true, time() - HOUR_IN_SECONDS );
+		$this->set_returned_token( $stale_payload );
+
+		// Refresh endpoint returns a fresh token with a valid future end_date.
+		$this->refresh_response_override = $this->build_refresh_success_response();
+
+		$this->assertTrue( current_visitor_can_access( array( 'selectedPlanIds' => array( $plan_id ) ), array() ) );
+	}
+
+	/**
+	 * When the refresh endpoint returns 200 with a token whose subscriptions no
+	 * longer include the required plan (e.g. the subscription was cancelled),
+	 * access should be denied.
+	 *
+	 * @return void
+	 */
+	public function test_refresh_before_deny_denies_when_fresh_token_has_no_subscription() {
+		$users_plans        = $this->set_up_users_and_plans();
+		$paid_subscriber_id = $users_plans[2];
+		$plan_id            = $users_plans[3];
+
+		wp_set_current_user( $paid_subscriber_id );
+		$stale_payload = $this->get_payload( true, true, time() - HOUR_IN_SECONDS );
+		$this->set_returned_token( $stale_payload );
+
+		// Refresh returns a token with no subscriptions (cancelled).
+		$service                         = subscription_service();
+		$empty_token                     = JWT::encode(
+			array(
+				'blog_sub'      => 'active',
+				'subscriptions' => array(),
+			),
+			$service->get_key()
+		);
+		$this->refresh_response_override = array(
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+			'body'     => wp_json_encode( array( 'jwt_token' => $empty_token ), JSON_UNESCAPED_SLASHES ),
+			'headers'  => array(),
+			'cookies'  => array(),
+		);
+
+		$this->assertFalse( current_visitor_can_access( array( 'selectedPlanIds' => array( $plan_id ) ), array() ) );
+	}
+
+	/**
+	 * When the refresh endpoint returns a transient failure (5xx), the original
+	 * stale token behavior should apply — access denied, cookie left alone.
+	 *
+	 * @return void
+	 */
+	public function test_refresh_before_deny_denies_on_transient_failure() {
+		$users_plans        = $this->set_up_users_and_plans();
+		$paid_subscriber_id = $users_plans[2];
+		$plan_id            = $users_plans[3];
+
+		wp_set_current_user( $paid_subscriber_id );
+		$stale_payload = $this->get_payload( true, true, time() - HOUR_IN_SECONDS );
+		$this->set_returned_token( $stale_payload );
+
+		// Refresh endpoint returns a 500 (the default mock behavior).
+		$this->refresh_response_override = array(
+			'response' => array(
+				'code'    => 500,
+				'message' => 'Server Error',
+			),
+			'body'     => '',
+			'headers'  => array(),
+			'cookies'  => array(),
+		);
+
+		$this->assertFalse( current_visitor_can_access( array( 'selectedPlanIds' => array( $plan_id ) ), array() ) );
+	}
+
+	/**
+	 * When the refresh endpoint returns 401 (bad signature), access is denied
+	 * AND the cookie is cleared so the subscriber re-authenticates on next visit.
+	 *
+	 * @return void
+	 */
+	public function test_refresh_before_deny_clears_cookie_on_unauthorized() {
+		$users_plans        = $this->set_up_users_and_plans();
+		$paid_subscriber_id = $users_plans[2];
+		$plan_id            = $users_plans[3];
+
+		wp_set_current_user( $paid_subscriber_id );
+		$stale_payload                            = $this->get_payload( true, true, time() - HOUR_IN_SECONDS );
+		$service                                  = subscription_service();
+		$token_string                             = JWT::encode( $stale_payload, $service->get_key() );
+		$_COOKIE['wp-jp-premium-content-session'] = $token_string;
+		$_GET['token']                            = $token_string;
+
+		$this->refresh_response_override = array(
+			'response' => array(
+				'code'    => 401,
+				'message' => 'Unauthorized',
+			),
+			'body'     => '',
+			'headers'  => array(),
+			'cookies'  => array(),
+		);
+
+		$this->assertFalse( current_visitor_can_access( array( 'selectedPlanIds' => array( $plan_id ) ), array() ) );
+		// Cookie should be cleared from $_COOKIE (cannot assert setcookie header from PHPUnit).
+		$this->assertArrayNotHasKey( 'wp-jp-premium-content-session', $_COOKIE );
+	}
+
+	/**
+	 * A WP_Error from the HTTP layer (e.g. network timeout) is treated as a
+	 * transient failure — deny access, leave cookie alone.
+	 *
+	 * @return void
+	 */
+	public function test_refresh_before_deny_treats_wp_error_as_transient() {
+		$users_plans        = $this->set_up_users_and_plans();
+		$paid_subscriber_id = $users_plans[2];
+		$plan_id            = $users_plans[3];
+
+		wp_set_current_user( $paid_subscriber_id );
+		$stale_payload = $this->get_payload( true, true, time() - HOUR_IN_SECONDS );
+		$this->set_returned_token( $stale_payload );
+
+		$this->refresh_response_override = new WP_Error( 'http_request_failed', 'cURL error 28: Operation timed out' );
+
+		$this->assertFalse( current_visitor_can_access( array( 'selectedPlanIds' => array( $plan_id ) ), array() ) );
+	}
+
+	/**
+	 * An active subscription with a future end_date should not trigger a refresh
+	 * at all — no HTTP call is made.
+	 *
+	 * @return void
+	 */
+	public function test_refresh_not_called_when_subscription_is_active() {
+		$users_plans        = $this->set_up_users_and_plans();
+		$paid_subscriber_id = $users_plans[2];
+		$plan_id            = $users_plans[3];
+
+		wp_set_current_user( $paid_subscriber_id );
+		$valid_payload = $this->get_payload( true, true, time() + HOUR_IN_SECONDS );
+		$this->set_returned_token( $valid_payload );
+
+		// If a refresh call were made, this override would throw — proving it is not called.
+		$this->refresh_response_override = new WP_Error( 'should_not_be_called', 'refresh should not be called for valid token' );
+
+		$this->assertTrue( current_visitor_can_access( array( 'selectedPlanIds' => array( $plan_id ) ), array() ) );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Jetpack_Premium_Content_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Jetpack_Premium_Content_Test.php
@@ -260,7 +260,7 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 				'code'    => 200,
 				'message' => 'OK',
 			),
-			'body'     => wp_json_encode( array( 'jwt_token' => $fresh_token ), JSON_UNESCAPED_SLASHES ),
+			'body'     => wp_json_encode( array( 'token' => $fresh_token ), JSON_UNESCAPED_SLASHES ),
 			'headers'  => array(),
 			'cookies'  => array(),
 		);
@@ -319,7 +319,7 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 				'code'    => 200,
 				'message' => 'OK',
 			),
-			'body'     => wp_json_encode( array( 'jwt_token' => $empty_token ), JSON_UNESCAPED_SLASHES ),
+			'body'     => wp_json_encode( array( 'token' => $empty_token ), JSON_UNESCAPED_SLASHES ),
 			'headers'  => array(),
 			'cookies'  => array(),
 		);

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Jetpack_Premium_Content_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Jetpack_Premium_Content_Test.php
@@ -7,6 +7,8 @@ require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-membership
 require_once __DIR__ . '/class-test-jetpack-token-subscription-service.php';
 
 use Automattic\Jetpack\Extensions\Premium_Content\JWT;
+use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Abstract_Token_Subscription_Service;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversFunction;
 use Tests\Automattic\Jetpack\Extensions\Premium_Content\Test_Jetpack_Token_Subscription_Service;
 use function Automattic\Jetpack\Extensions\Premium_Content\current_visitor_can_access;
@@ -15,8 +17,10 @@ use const Automattic\Jetpack\Extensions\Premium_Content\PAYWALL_FILTER;
 
 /**
  * @covers ::Automattic\Jetpack\Extensions\Premium_Content\current_visitor_can_access
+ * @covers \Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Abstract_Token_Subscription_Service
  */
 #[CoversFunction( 'Automattic\\Jetpack\\Extensions\\Premium_Content\\current_visitor_can_access' )]
+#[CoversClass( Abstract_Token_Subscription_Service::class )]
 class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
 

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Jetpack_Premium_Content_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Jetpack_Premium_Content_Test.php
@@ -66,6 +66,7 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 		remove_all_filters( 'jetpack_is_connection_ready' );
 		remove_all_filters( PAYWALL_FILTER );
 		remove_all_filters( 'pre_http_request' );
+		remove_all_actions( 'wp_footer' );
 		Jetpack_Options::delete_option( 'id' );
 		$this->refresh_response_override = null;
 		$this->refresh_call_count        = 0;
@@ -579,5 +580,37 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 
 		$this->assertTrue( current_visitor_can_access( array( 'selectedPlanIds' => array( $plan_id ) ), array() ) );
 		$this->assertSame( 0, $this->refresh_call_count, 'Refresh endpoint should not be called when the token is still active.' );
+	}
+
+	/**
+	 * Refresh runs during `the_content`, well after the theme has output `<!DOCTYPE html>`
+	 * and headers have been sent — so `setcookie()` is a no-op. The fallback is to register
+	 * a `wp_footer` callback that updates `document.cookie`. Verify that callback exists
+	 * and emits a well-formed cookie-update snippet referencing the fresh token.
+	 *
+	 * @return void
+	 */
+	public function test_queue_cookie_update_via_js_emits_document_cookie_snippet() {
+		Abstract_Token_Subscription_Service::queue_cookie_update_via_js( 'fresh.jwt.token', MONTH_IN_SECONDS );
+
+		// Call only our registered priority-1 callback rather than firing the full
+		// wp_footer action — the latter triggers WP-core deprecation warnings unrelated
+		// to this test that the WP_UnitTestCase framework treats as failures.
+		global $wp_filter;
+		$this->assertArrayHasKey( 'wp_footer', $wp_filter, 'A wp_footer action should be registered after the JS-fallback path.' );
+		$priority_one_callbacks = $wp_filter['wp_footer']->callbacks[1] ?? array();
+		$this->assertNotEmpty( $priority_one_callbacks, 'The cookie-update callback should be registered at priority 1.' );
+
+		ob_start();
+		foreach ( $priority_one_callbacks as $cb ) {
+			call_user_func( $cb['function'] );
+		}
+		$output = ob_get_clean();
+
+		$this->assertMatchesRegularExpression(
+			'#^<script>document\.cookie="wp-jp-premium-content-session=fresh\.jwt\.token; path=/; max-age=' . MONTH_IN_SECONDS . '";</script>$#',
+			$output,
+			'The cookie-update snippet should contain the fresh token, path, and max-age, and nothing else.'
+		);
 	}
 }

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Jetpack_Premium_Content_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Jetpack_Premium_Content_Test.php
@@ -315,6 +315,86 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Newsletter-tier subscribers (`jetpack_memberships_type=tier`) route through
+	 * `maybe_gate_access_for_user_if_tier` in access-check.php rather than the
+	 * non-tier `visitor_can_view_content` path. Verify that the refresh-before-deny
+	 * logic also fires for the tier path when the token references the requested
+	 * tier's product_id but with a stale end_date. This is the population most
+	 * likely to hit the renewal-lockout bug in production.
+	 *
+	 * @return void
+	 */
+	public function test_refresh_before_deny_grants_tier_access_on_successful_refresh() {
+		$paid_subscriber_id = $this->factory->user->create(
+			array( 'user_email' => 'tier-paid@example.com' )
+		);
+		wp_set_current_user( $paid_subscriber_id );
+
+		// Create a newsletter tier whose product_id matches the test's token product_id.
+		$tier_plan_id = $this->factory->post->create(
+			array( 'post_type' => Jetpack_Memberships::$post_type_plan )
+		);
+		update_post_meta( $tier_plan_id, 'jetpack_memberships_product_id', $this->product_id );
+		update_post_meta( $tier_plan_id, 'jetpack_memberships_site_subscriber', true );
+		update_post_meta( $tier_plan_id, 'jetpack_memberships_price', 10 );
+		update_post_meta( $tier_plan_id, 'jetpack_memberships_currency', 'USD' );
+		update_post_meta( $tier_plan_id, 'jetpack_memberships_interval', '1 month' );
+		update_post_meta( $tier_plan_id, 'jetpack_memberships_type', 'tier' );
+
+		// Stale token — product_id matches the tier, but end_date is past.
+		$stale_payload = $this->get_payload( true, true, time() - HOUR_IN_SECONDS );
+		$this->set_returned_token( $stale_payload );
+
+		$this->refresh_response_override = $this->build_refresh_success_response();
+
+		$this->assertTrue(
+			current_visitor_can_access(
+				array( 'selectedPlanIds' => array( $tier_plan_id ) ),
+				array()
+			),
+			'Tier subscriber with a stale end_date should regain access after the refresh.'
+		);
+		$this->assertSame( 1, $this->refresh_call_count, 'Refresh endpoint should be called exactly once for the tier path.' );
+	}
+
+	/**
+	 * The tier path should NOT trigger a refresh when the token has no subscription
+	 * matching any of the required tiers — same narrowing as the non-tier path, to
+	 * keep refresh traffic limited to the renewal-stale case (not free subscribers
+	 * or tier mismatches).
+	 *
+	 * @return void
+	 */
+	public function test_refresh_not_called_for_tier_when_token_has_no_matching_product() {
+		$regular_subscriber_id = $this->factory->user->create(
+			array( 'user_email' => 'tier-free@example.com' )
+		);
+		wp_set_current_user( $regular_subscriber_id );
+
+		$tier_plan_id = $this->factory->post->create(
+			array( 'post_type' => Jetpack_Memberships::$post_type_plan )
+		);
+		update_post_meta( $tier_plan_id, 'jetpack_memberships_product_id', $this->product_id );
+		update_post_meta( $tier_plan_id, 'jetpack_memberships_site_subscriber', true );
+		update_post_meta( $tier_plan_id, 'jetpack_memberships_price', 10 );
+		update_post_meta( $tier_plan_id, 'jetpack_memberships_currency', 'USD' );
+		update_post_meta( $tier_plan_id, 'jetpack_memberships_interval', '1 month' );
+		update_post_meta( $tier_plan_id, 'jetpack_memberships_type', 'tier' );
+
+		// Free subscriber: blog_sub active, no paid subscriptions in token.
+		$payload = $this->get_payload( true, false );
+		$this->set_returned_token( $payload );
+
+		$this->assertFalse(
+			current_visitor_can_access(
+				array( 'selectedPlanIds' => array( $tier_plan_id ) ),
+				array()
+			)
+		);
+		$this->assertSame( 0, $this->refresh_call_count, 'Refresh endpoint must not fire for a free subscriber on a tier-gated post.' );
+	}
+
+	/**
 	 * When the refresh endpoint returns 200 with a token whose subscriptions no
 	 * longer include the required plan (e.g. the subscription was cancelled),
 	 * access should be denied.

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
@@ -61,7 +61,7 @@ class Jetpack_Subscriptions_Test extends WP_UnitTestCase {
 	 * @return mixed
 	 */
 	public function block_refresh_endpoint( $preempt, $args, $url ) {
-		if ( false !== strpos( $url, 'memberships/jwt/refresh' ) ) {
+		if ( false !== strpos( $url, 'memberships/token/refresh' ) ) {
 			return array(
 				'response' => array(
 					'code'    => 500,

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
@@ -35,6 +35,9 @@ class Jetpack_Subscriptions_Test extends WP_UnitTestCase {
 		parent::set_up();
 		Jetpack_Subscriptions::init();
 		add_filter( 'jetpack_is_connection_ready', '__return_true' );
+		// Block refresh endpoint HTTP calls in tests by default so stale tokens deny
+		// access (existing test expectations). Individual refresh tests can override.
+		add_filter( 'pre_http_request', array( $this, 'block_refresh_endpoint' ), 10, 3 );
 		$this->set_up_users();
 	}
 
@@ -42,8 +45,34 @@ class Jetpack_Subscriptions_Test extends WP_UnitTestCase {
 		// Clean up
 		remove_all_filters( 'earn_get_user_subscriptions_for_site_id' );
 		remove_all_filters( 'jetpack_is_connection_ready' );
+		remove_all_filters( 'pre_http_request' );
 
 		parent::tear_down();
+	}
+
+	/**
+	 * Default pre_http_request mock for the refresh endpoint — returns a 500 so that
+	 * refresh attempts fail transiently and the existing "expired subscription denies
+	 * access" expectations in the access matrix still hold.
+	 *
+	 * @param mixed  $preempt Current preempt value.
+	 * @param array  $args    Request args.
+	 * @param string $url     Request URL.
+	 * @return mixed
+	 */
+	public function block_refresh_endpoint( $preempt, $args, $url ) {
+		if ( false !== strpos( $url, 'memberships/jwt/refresh' ) ) {
+			return array(
+				'response' => array(
+					'code'    => 500,
+					'message' => 'blocked in tests',
+				),
+				'body'     => '',
+				'headers'  => array(),
+				'cookies'  => array(),
+			);
+		}
+		return $preempt;
 	}
 
 	private function set_up_users() {


### PR DESCRIPTION
Fixes NL-546

## Proposed changes

* Add a **refresh-before-deny** path to the Premium Content access check: when a token's subscriptions don't satisfy the required plan(s), POST the existing token to the WordPress.com memberships token-refresh endpoint, which re-queries billing and returns a fresh token reflecting current subscription state. On successful refresh, replace the cookie with the fresh token and re-run validation. Covers **both** the non-tier path (`Abstract_Token_Subscription_Service::visitor_can_view_content()`) and the newsletter-tier path (`current_visitor_can_access()` in `access-check.php`, which routes tier-gated posts through `maybe_gate_access_for_user_if_tier()`).
* Narrow the trigger to "token already has a subscription whose `product_id` matches a required plan" so refresh fires for the renewal-stale case but not for free, tier-mismatched, or cancelled visitors.
* Add new methods `refresh_token_payload()`, `fetch_refreshed_token()`, and `token_has_matching_product()` on the abstract service class. Declare the previously implicit `get_site_id()` contract as abstract since the refresh call needs it in the URL path.
* Add PHPUnit tests covering each branch of the response matrix on both paths.

### Endpoint contract

Calls `POST https://public-api.wordpress.com/rest/v1.1/sites/<site_id>/memberships/token/refresh` with body `{ "jwt_token": "<existing>" }`.

### Response handling

The JSON API endpoint always returns HTTP 200 and encodes auth failures in the body, so the Jetpack side branches on `body.success` rather than HTTP status:

| Response | Action |
|---|---|
| `200` + `{ success: true, jwt_token: "<jwt>" }` | Set cookie, re-run validation (may grant or deny based on fresh payload) |
| `200` + `{ success: false, ... }` (wpcom refused the refresh) | Clear cookie, deny — subscriber re-authenticates naturally on next visit |
| Non-`200` / `WP_Error` / network timeout / malformed body | Leave cookie, deny — treat as transient so an endpoint outage does not mass-log-out subscribers |
| `200` + `{ success: true, jwt_token: <empty subscriptions> }` | Cookie replaced with the empty fresh token → validation denies cleanly on this and future requests (no denial loop) |

### Other information

The companion wpcom hardening (210997-ghe-Automattic/wpcom) has shipped, so the Jetpack side is unblocked for review and merge.

**Root cause:** When a paid subscriber's subscription renews, the billing system records the new `end_date`, but the JWT cookie still contains the old snapshot. Subscription validation checks `end_date > time()` against the stale cookie value and denies access. The subscriber sees a "subscribe again" prompt but is told they're already subscribed.

**Scale:** ~10,953 subscribers renewing in the next 30 days across 1,421 sites are affected. Reports from at least 7 different sites over 5 years.

**Why this over the grace period approach:** A 1-day grace period (PR #47773) would cover the renewal window but leaves the underlying architecture unchanged — the JWT remains a static snapshot that never learns about billing events. This approach self-heals on any stale-`end_date` condition, not just renewal windows, and sets up the path to eventually drop `end_date` from the token entirely.

## Related product discussion/links

* https://linear.app/a8c/issue/NL-546
* https://linear.app/a8c/issue/MON-67
* wpcom-side companion: 210997-ghe-Automattic/wpcom
* Jetpack PR #22757 (original 2022 grace period fix, never merged)

## Does this pull request change what data or activity we track or use?

No new data. Adds an outbound HTTP POST to `public-api.wordpress.com/rest/v1.1/sites/<site_id>/memberships/token/refresh` carrying the existing JWT — both already known to WordPress.com.

## Testing instructions

### Prerequisites

Test on a WoA / wpcomstaging site with a Paid Content block. You'll need:

* A real paid subscription on the test site (e.g. comp yourself a subscription via Earn → Subscribers → Add Comp). The refresh endpoint re-queries billing for the `user_id` in the token, so the fresh JWT only reflects subscriptions billing actually has.
* The Jetpack Beta plugin pointed at `fix/premium-content-refresh-before-deny`.
* Test as a **truly anonymous visitor**. `current_visitor_can_access()` short-circuits at `current_user_can_edit()` — so if you're logged in (or proxied as) the site author/admin, the JWT/refresh path is skipped entirely and the test tells you nothing. The cleanest options:
  * Run the test request from your sandbox/SSH session with `curl`, or
  * Turn off the Automattic proxy and use a fresh incognito window.

### Manual test — successful refresh (non-tier and tier paths)

Repeat for two posts: one gated by a **non-tier** plan, and one gated by a **newsletter tier** (the production hot path for renewing subscribers).

1. From the site's SSH session, generate a stale JWT for your subscriber user. Substitute `<SITE_ID>`, `<SUBSCRIBER_USER_ID>`, and `<PRODUCT_ID>` (the `jetpack_memberships_product_id` post-meta on the plan post — *not* the local plan post ID; for tier plans these may differ):
   ```bash
   wp eval "
   require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/class-jwt.php';
   use Automattic\Jetpack\Extensions\Premium_Content\JWT;
   \$key = (new Automattic\Jetpack\Connection\Tokens())->get_access_token()->secret;
   \$payload = [
       'sub'           => <SITE_ID>,
       'user_id'       => <SUBSCRIBER_USER_ID>,
       'blog_sub'      => 'active',
       'subscriptions' => [ <PRODUCT_ID> => [ 'status' => 'active', 'end_date' => time() - 3600, 'product_id' => <PRODUCT_ID> ] ],
   ];
   echo JWT::encode(\$payload, \$key);
   "
   ```
2. Visit the gated post with `?token=<output>` as a truly anonymous visitor.
3. **Expected:** the Subscriber Content body renders. The `wp-jp-premium-content-session` cookie in the response is a **different** JWT than the one you put in the URL — decoding the payload (middle segment, base64) should show `iss: "http://wordpress.com/earn"`, an `iat` timestamp, and a future `end_date` (string-formatted like `"2027-06-09 00:00:00"`).

### Manual test — genuine cancellation

1. Subscribe and then cancel the subscription in billing.
2. Craft a stale token for that user (same snippet, end_date in the past).
3. Visit the gated post.
4. **Expected:** the refresh endpoint returns `{ success: true, jwt_token }` with empty `subscriptions`. Access is denied. Subsequent visits deny cleanly without repeated refresh calls.

### Manual test — narrowed trigger

1. As an anonymous visitor *without* any subscription, visit a paid post.
2. **Expected:** denial as before. No outbound POST to `memberships/token/refresh` (the token has no matching `product_id`, so the trigger doesn't fire).

### PHPUnit tests

Tests live in `Jetpack_Premium_Content_Test.php`:

* `test_refresh_before_deny_grants_access_on_successful_refresh` — happy path, non-tier
* `test_refresh_before_deny_grants_tier_access_on_successful_refresh` — happy path, tier
* `test_refresh_before_deny_denies_when_fresh_token_has_no_subscription` — cancellation
* `test_refresh_before_deny_denies_on_transient_failure` — 5xx, cookie preserved
* `test_refresh_before_deny_clears_cookie_on_unauthorized` — `success: false` deterministic, cookie cleared
* `test_refresh_before_deny_treats_wp_error_as_transient` — network failure, cookie preserved
* `test_refresh_not_called_when_token_has_no_matching_product` — free subscriber, no HTTP call
* `test_refresh_not_called_for_tier_when_token_has_no_matching_product` — same, tier-gated post
* `test_refresh_not_called_when_subscription_is_active` — valid token short-circuit

All tests mock the refresh endpoint via the `pre_http_request` filter to exercise each response branch without making real HTTP calls.

