### PR TITLE
script-data: siteHasFeature: Use indexOf instead of includes

### DIFF
--- a/projects/js-packages/script-data/changelog/remove-includes
+++ b/projects/js-packages/script-data/changelog/remove-includes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Use .indexOf instead of .includes for broader support without polyfills

--- a/projects/js-packages/script-data/src/utils.ts
+++ b/projects/js-packages/script-data/src/utils.ts
@@ -68,7 +68,7 @@ export function getActiveFeatures() {
  * @return {boolean} Whether the site has the feature.
  */
 export function siteHasFeature( feature: string ) {
-	return getActiveFeatures().includes( feature );
+	return getActiveFeatures().indexOf( feature ) !== -1;
 }
 
 /**


### PR DESCRIPTION


## Proposed changes
* In the script-data package, change `return getActiveFeatures().includes( feature );` to `return getActiveFeatures().indexOf( feature ) !== -1;`.

### Other information

* https://github.com/Automattic/jetpack/pull/47998, when built, caused script-data to pull in extra dependency:

```diff
diff --git a/jetpack_vendor/automattic/jetpack-assets/build/jetpack-script-data.asset.php b/jetpack_vendor/automattic/jetpack-assets/build/jetpack-script-data.asset.php
index e35b91d828..e974ff3d97 100644
--- a/jetpack_vendor/automattic/jetpack-assets/build/jetpack-script-data.asset.php
+++ b/jetpack_vendor/automattic/jetpack-assets/build/jetpack-script-data.asset.php
@@ -1 +1 @@
-<?php return array('dependencies' => array(), 'version' => '9bfc087a15fd30ecf36d');
+<?php return array('dependencies' => array('wp-polyfill'), 'version' => '9bfc087a15fd30ecf36d');
```

Before, it did not have the wp-polyfill dependency. This is an attempt to make the package not require it.

This seems to be related to [this core JS release](https://github.com/zloirock/core-js/releases/tag/v3.49.0) and [this safari bug](https://bugs.webkit.org/show_bug.cgi?id=309342) with `.includes`.

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?

## Testing instructions

* pnpm jetpack build
* Choose the plugin, jetpack
* Check `./projects/packages/assets/build/jetpack-script-data.asset.php`
* After this PR, the wp-polyfill dependency should be gone
