### PR TITLE
Celebration modal: Enqueue missing component styles

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-launch-celebration-modal-frontend-styles
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-launch-celebration-modal-frontend-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Launch button: Load celebration modal bundle CSS and wp-components on the front end so styling matches wp-admin.

--- a/projects/packages/jetpack-mu-wpcom/src/common/celebrate-launch/celebrate-launch-modal.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/common/celebrate-launch/celebrate-launch-modal.scss
@@ -2,6 +2,12 @@
 @use "@wordpress/base-styles/colors" as *;
 @use "@wordpress/base-styles/variables" as *;
 
+.launched__modal .components-modal__children-container p {
+	font-family: $font-family-body;
+	font-size: $font-size-medium;
+	line-height: $font-line-height-small;
+}
+
 .launched__modal .components-modal__children-container p:first-child {
 	margin-top: 0;
 }
@@ -21,6 +27,10 @@
 
 	&:hover .launchpad__clipboard-button {
 		opacity: 1;
+	}
+
+	.components-modal__children-container p {
+		margin: $grid-unit-15 0;
 	}
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
@@ -100,6 +100,42 @@ function wpcom_add_launch_button_to_admin_bar( WP_Admin_Bar $admin_bar ) {
 }
 
 /**
+ * Enqueue wp-components styles and the celebration modal bundle CSS.
+ *
+ * The celebration modal uses @wordpress/components (Modal, Button, Tooltip).
+ * On the frontend, wp-components CSS is not loaded automatically, so we enqueue
+ * it here together with the compiled bundle CSS that contains the modal's own styles.
+ */
+function wpcom_enqueue_components_styles() {
+	if ( ! wpcom_should_show_launch_button() ) {
+		return;
+	}
+
+	// Enqueue WordPress's built-in wp-components stylesheet.
+	// In admin contexts it may already be queued; wp_enqueue_style() is idempotent.
+	wp_enqueue_style( 'wp-components' );
+
+	// Enqueue the compiled bundle CSS (contains celebrate-launch-modal SCSS).
+	$css_file = is_rtl() ? 'adminbar-launch-button.rtl.css' : 'adminbar-launch-button.css';
+	$css_path = Jetpack_Mu_Wpcom::BASE_DIR . 'build/adminbar-launch-button/' . $css_file;
+
+	// Fall back to LTR file if RTL file is missing.
+	if ( ! file_exists( $css_path ) ) {
+		$css_file = 'adminbar-launch-button.css';
+		$css_path = Jetpack_Mu_Wpcom::BASE_DIR . 'build/adminbar-launch-button/' . $css_file;
+	}
+
+	if ( file_exists( $css_path ) ) {
+		wp_enqueue_style(
+			'adminbar-launch-button-bundle',
+			plugins_url( 'build/adminbar-launch-button/' . $css_file, Jetpack_Mu_Wpcom::BASE_FILE ),
+			array( 'wp-components' ),
+			filemtime( $css_path )
+		);
+	}
+}
+
+/**
  * Enqueue the necessary assets for the admin bar button.
  */
 function wpcom_enqueue_launch_button_assets() {
@@ -161,6 +197,8 @@ function wpcom_enqueue_admin_launch_button_assets() {
 }
 
 add_action( 'admin_bar_menu', 'wpcom_add_launch_button_to_admin_bar', 500 );
+add_action( 'wp_enqueue_scripts', 'wpcom_enqueue_components_styles' );
 add_action( 'wp_enqueue_scripts', 'wpcom_enqueue_launch_button_assets' );
+add_action( 'admin_enqueue_scripts', 'wpcom_enqueue_components_styles' );
 add_action( 'admin_enqueue_scripts', 'wpcom_enqueue_launch_button_assets' );
 add_action( 'admin_enqueue_scripts', 'wpcom_enqueue_admin_launch_button_assets' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
@@ -7,7 +7,6 @@
 
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom\Common;
-use Automattic\Jetpack\Status\Host;
 
 /**
  * Determine whether the launch button should be shown/enhanced on this request.
@@ -101,46 +100,6 @@ function wpcom_add_launch_button_to_admin_bar( WP_Admin_Bar $admin_bar ) {
 }
 
 /**
- * Enqueue `wp-components` styles for contexts where the block editor/admin bundle is not loaded.
- *
- * The celebration modal uses `@wordpress/components` (Modal, Button). Those styles are available in
- * wp-admin, but not on the front end with only the admin bar — without them, typography and chrome look wrong.
- *
- * @param string $version The asset version string.
- * @param bool   $should_enqueue Whether styles should be enqueued for this request.
- * @return void
- */
-function wpcom_launch_button_maybe_enqueue_wp_components_styles( $version, $should_enqueue ) {
-	if ( ! $should_enqueue ) {
-		return;
-	}
-
-	$stylesheet     = is_rtl() ? 'build/components/style-rtl.css' : 'build/components/style.css';
-	$stylesheet_url = plugins_url( 'gutenberg/' . $stylesheet );
-
-	if ( function_exists( 'gutenberg_url' ) ) {
-		// @phan-suppress-next-line PhanUndeclaredFunction
-		$stylesheet_url = gutenberg_url( $stylesheet );
-	}
-
-	wp_enqueue_style(
-		'wp-components',
-		$stylesheet_url,
-		array( 'dashicons' ),
-		$version
-	);
-}
-
-/**
- * Whether the launch button should load standalone `wp-components` styles for this request.
- *
- * @return bool
- */
-function wpcom_launch_button_needs_standalone_wp_components_styles(): bool {
-	return ! is_admin() || ( is_customize_preview() && ( new Host() )->is_wpcom_simple() );
-}
-
-/**
  * Enqueue the necessary assets for the admin bar button.
  */
 function wpcom_enqueue_launch_button_assets() {
@@ -152,35 +111,12 @@ function wpcom_enqueue_launch_button_assets() {
 	wp_enqueue_style( 'launch-banner', plugins_url( 'style.css', __FILE__ ), array(), $version );
 
 	$asset_file = include Jetpack_Mu_Wpcom::BASE_DIR . 'build/adminbar-launch-button/adminbar-launch-button.asset.php';
-	$bundle_ver = $asset_file['version'] ?? filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/adminbar-launch-button/adminbar-launch-button.js' );
-
-	$needs_wp_components = wpcom_launch_button_needs_standalone_wp_components_styles();
-	wpcom_launch_button_maybe_enqueue_wp_components_styles( $bundle_ver, $needs_wp_components );
-
-	$css_ext      = is_rtl() ? 'rtl.css' : 'css';
-	$css_relative = 'build/adminbar-launch-button/adminbar-launch-button.' . $css_ext;
-	$css_path     = Jetpack_Mu_Wpcom::BASE_DIR . $css_relative;
-	if ( is_rtl() && ! file_exists( $css_path ) ) {
-		$css_relative = 'build/adminbar-launch-button/adminbar-launch-button.css';
-		$css_path     = Jetpack_Mu_Wpcom::BASE_DIR . $css_relative;
-	}
-
-	$bundle_style_deps = $needs_wp_components ? array( 'wp-components' ) : array();
-
-	if ( file_exists( $css_path ) ) {
-		wp_enqueue_style(
-			'adminbar-launch-button-bundle',
-			plugins_url( $css_relative, Jetpack_Mu_Wpcom::BASE_FILE ),
-			$bundle_style_deps,
-			file_exists( $css_path ) ? filemtime( $css_path ) : $bundle_ver
-		);
-	}
 
 	wp_enqueue_script(
 		'adminbar-launch-button',
 		plugins_url( 'build/adminbar-launch-button/adminbar-launch-button.js', Jetpack_Mu_Wpcom::BASE_FILE ),
 		$asset_file['dependencies'] ?? array(),
-		$bundle_ver,
+		$asset_file['version'] ?? filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/adminbar-launch-button/adminbar-launch-button.js' ),
 		true
 	);
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
@@ -7,6 +7,7 @@
 
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom\Common;
+use Automattic\Jetpack\Status\Host;
 
 /**
  * Determine whether the launch button should be shown/enhanced on this request.
@@ -100,6 +101,46 @@ function wpcom_add_launch_button_to_admin_bar( WP_Admin_Bar $admin_bar ) {
 }
 
 /**
+ * Enqueue `wp-components` styles for contexts where the block editor/admin bundle is not loaded.
+ *
+ * The celebration modal uses `@wordpress/components` (Modal, Button). Those styles are available in
+ * wp-admin, but not on the front end with only the admin bar — without them, typography and chrome look wrong.
+ *
+ * @param string $version The asset version string.
+ * @param bool   $should_enqueue Whether styles should be enqueued for this request.
+ * @return void
+ */
+function wpcom_launch_button_maybe_enqueue_wp_components_styles( $version, $should_enqueue ) {
+	if ( ! $should_enqueue ) {
+		return;
+	}
+
+	$stylesheet     = is_rtl() ? 'build/components/style-rtl.css' : 'build/components/style.css';
+	$stylesheet_url = plugins_url( 'gutenberg/' . $stylesheet );
+
+	if ( function_exists( 'gutenberg_url' ) ) {
+		// @phan-suppress-next-line PhanUndeclaredFunction
+		$stylesheet_url = gutenberg_url( $stylesheet );
+	}
+
+	wp_enqueue_style(
+		'wp-components',
+		$stylesheet_url,
+		array( 'dashicons' ),
+		$version
+	);
+}
+
+/**
+ * Whether the launch button should load standalone `wp-components` styles for this request.
+ *
+ * @return bool
+ */
+function wpcom_launch_button_needs_standalone_wp_components_styles(): bool {
+	return ! is_admin() || ( is_customize_preview() && ( new Host() )->is_wpcom_simple() );
+}
+
+/**
  * Enqueue the necessary assets for the admin bar button.
  */
 function wpcom_enqueue_launch_button_assets() {
@@ -111,12 +152,35 @@ function wpcom_enqueue_launch_button_assets() {
 	wp_enqueue_style( 'launch-banner', plugins_url( 'style.css', __FILE__ ), array(), $version );
 
 	$asset_file = include Jetpack_Mu_Wpcom::BASE_DIR . 'build/adminbar-launch-button/adminbar-launch-button.asset.php';
+	$bundle_ver = $asset_file['version'] ?? filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/adminbar-launch-button/adminbar-launch-button.js' );
+
+	$needs_wp_components = wpcom_launch_button_needs_standalone_wp_components_styles();
+	wpcom_launch_button_maybe_enqueue_wp_components_styles( $bundle_ver, $needs_wp_components );
+
+	$css_ext      = is_rtl() ? 'rtl.css' : 'css';
+	$css_relative = 'build/adminbar-launch-button/adminbar-launch-button.' . $css_ext;
+	$css_path     = Jetpack_Mu_Wpcom::BASE_DIR . $css_relative;
+	if ( is_rtl() && ! file_exists( $css_path ) ) {
+		$css_relative = 'build/adminbar-launch-button/adminbar-launch-button.css';
+		$css_path     = Jetpack_Mu_Wpcom::BASE_DIR . $css_relative;
+	}
+
+	$bundle_style_deps = $needs_wp_components ? array( 'wp-components' ) : array();
+
+	if ( file_exists( $css_path ) ) {
+		wp_enqueue_style(
+			'adminbar-launch-button-bundle',
+			plugins_url( $css_relative, Jetpack_Mu_Wpcom::BASE_FILE ),
+			$bundle_style_deps,
+			file_exists( $css_path ) ? filemtime( $css_path ) : $bundle_ver
+		);
+	}
 
 	wp_enqueue_script(
 		'adminbar-launch-button',
 		plugins_url( 'build/adminbar-launch-button/adminbar-launch-button.js', Jetpack_Mu_Wpcom::BASE_FILE ),
 		$asset_file['dependencies'] ?? array(),
-		$asset_file['version'] ?? filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/adminbar-launch-button/adminbar-launch-button.js' ),
+		$bundle_ver,
 		true
 	);
 


### PR DESCRIPTION
Fixes DATSCI-1239

## Proposed changes

### Problem
The celebration launch modal was missing component styles:
- **Initial state**: `wp-components` styles were not enqueued anywhere, so the modal appeared unstyled only in wp-admin contexts where the block editor was present
- **After initial enqueue fix**: Styles were available in wp-admin, but on the frontend (where only the admin bar is shown), component styles and modal CSS were still missing
- **Secondary issue**: When styles were finally enqueued on the frontend, paragraph text was overridden by site's typography CSS variables and styles (different font-family, font-size, margins)

**Before:**
<img width="1753" height="643" alt="Screenshot 2026-04-07 at 19 49 55 - before" src="https://github.com/user-attachments/assets/09b63b9b-608d-4db3-af0e-c4983f3ac63b" />

**After:**
<img width="1728" height="587" alt="Screenshot 2026-04-09 at 00 15 59 - after" src="https://github.com/user-attachments/assets/fad2985d-c230-4380-a1eb-7c2116882e78" />
<img width="1728" height="591" alt="Screenshot 2026-04-09 at 00 16 10 - after" src="https://github.com/user-attachments/assets/1daf0ed7-bc4f-4999-8928-4b78fc918d20" />

### Solution
1. **Add `wpcom_enqueue_components_styles()` function** to enqueue:
   - `wp-components` stylesheet (WordPress's built-in components styles)
   - `adminbar-launch-button.css` (compiled modal SCSS) with `wp-components` as dependency
   - Hooked to both `wp_enqueue_scripts` (frontend) and `admin_enqueue_scripts` (wp-admin)

2. **Encapsulate paragraph typography** in the modal:
   - Add explicit `font-family`, `font-size`, `line-height`, and `margin` to prevent site CSS from overriding component styles
   - Uses WordPress base-styles variables for consistency

## Testing instructions

Test on both **Simple** and **Atomic** sites:

1. **From wp-admin**:
   - Go to wp-admin dashboard on an unlaunched site (logged in as admin)
   - Click "Launch site" button in admin bar
   - Verify celebration modal appears with proper styling:
     - Correct text size and font family (not overridden by site)
     - Proper button styling from wp-components
     - Confetti animation displays
     - Modal overlay and close button styled correctly

2. **From frontend**:
   - View any public page on the unlaunched site (logged in as admin)
   - Click "Launch site" button in admin bar
   - Verify celebration modal appears with consistent styling (same as wp-admin)
     - Text is readable with correct typography
     - All buttons and interactive elements styled properly
     - No style inheritance from site CSS

## Related product discussion/links

## Does this pull request change what data or activity we track or use?

No data tracking changes.