### PR TITLE
Forms: Enable mobile navigation sidebar toggle on all dashboard pages

### DIFF
--- a/projects/packages/forms/changelog/add-mobile-nav
+++ b/projects/packages/forms/changelog/add-mobile-nav
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Enable mobile navigation sidebar toggle on all Forms dashboard pages.

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -595,7 +595,6 @@ function StageInner() {
 
 	return (
 		<Page
-			showSidebarToggle={ false }
 			breadcrumbs={ breadcrumbs }
 			title={ title }
 			ariaLabel={ ariaLabel }

--- a/projects/packages/forms/routes/responses/inspector.tsx
+++ b/projects/packages/forms/routes/responses/inspector.tsx
@@ -17,7 +17,7 @@ import Response from './response';
 function Inspector() {
 	return (
 		<WpRouteDashboardSearchParamsProvider from="/responses/$view">
-			<Page showSidebarToggle={ false } hasPadding={ false }>
+			<Page hasPadding={ false }>
 				<Response />
 			</Page>
 		</WpRouteDashboardSearchParamsProvider>

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -573,7 +573,6 @@ function StageInner() {
 
 	return (
 		<Page
-			showSidebarToggle={ false }
 			breadcrumbs={ breadcrumbs }
 			badges={ badges }
 			title={ title }

--- a/projects/packages/forms/src/dashboard/components/inspector/single.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/single.tsx
@@ -129,7 +129,7 @@ const SingleResponseView = ( {
 	);
 
 	return (
-		<Page showSidebarToggle={ false } hasPadding={ false }>
+		<Page hasPadding={ false }>
 			<div className="jp-forms-response-content">
 				<HStack
 					spacing="0"


### PR DESCRIPTION
## Proposed changes

* Remove `showSidebarToggle={ false }` from all `Page` components in the Forms dashboard to enable the mobile navigation sidebar toggle on all pages.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions
### non CIAB 
* Open the Forms dashboard on a mobile viewport (or resize your browser to a narrow width).
* Navigate to the Forms list, Responses list, and individual Response inspector views.
* Verify that the sidebar navigation toggle button now DOES NOT appears on all pages.


### CIAB
* Open the Forms dashboard on a mobile viewport (or resize your browser to a narrow width).
* Navigate to the Forms list, Responses list, and individual Response inspector views.
* Verify that the sidebar navigation toggle button now appears on all pages.
* Verify that tapping/clicking the toggle opens the sidebar navigation.
