### PR TITLE
videopress: Remove an unnecessary wp-polyfill dependency from the player bridge build.

### DIFF
--- a/projects/packages/videopress/changelog/remove-player-bridge-wp-polyfill-dependency
+++ b/projects/packages/videopress/changelog/remove-player-bridge-wp-polyfill-dependency
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Remove an unnecessary wp-polyfill dependency from the player bridge build.

--- a/projects/packages/videopress/src/client/lib/player-bridge/index.ts
+++ b/projects/packages/videopress/src/client/lib/player-bridge/index.ts
@@ -51,7 +51,7 @@ export async function playerBridgeHandler(
 	const { event: eventName } = data;
 
 	// Propagate only allowed events.
-	if ( VIDEOPRESS_ALLOWED_LISTENING_EVENTS.includes( eventName ) ) {
+	if ( VIDEOPRESS_ALLOWED_LISTENING_EVENTS.indexOf( eventName ) !== -1 ) {
 		// Propagate only allowed origins.
 		const allowed_origins: Array< Origin > = [
 			'https://videopress.com',
@@ -64,7 +64,7 @@ export async function playerBridgeHandler(
 		}
 	}
 
-	if ( VIDEOPRESS_ALLOWED_EMITTING_EVENTS.includes( eventName ) ) {
+	if ( VIDEOPRESS_ALLOWED_EMITTING_EVENTS.indexOf( eventName ) !== -1 ) {
 		const videoPressIFrame = document.querySelector( 'iframe' );
 		const videoPressWindow = videoPressIFrame?.contentWindow;
 		if ( ! videoPressWindow ) {


### PR DESCRIPTION
Followup to #48010.


## Proposed changes
*  In plyer-bridge, change `.includes()` checks to use `.indexOf()` instead.

https://github.com/Automattic/jetpack/pull/47998, when built, caused jetpack-videopress/build/lib/player-bridge to pull in extra dependency:

```diff
diff --git a/jetpack_vendor/automattic/jetpack-videopress/build/lib/player-bridge.asset.php b/jetpack_vendor/automattic/jetpack-videopress/build/lib/player-bridge.asset.php
index e3780078b1..089c460b28 100644
--- a/jetpack_vendor/automattic/jetpack-videopress/build/lib/player-bridge.asset.php
+++ b/jetpack_vendor/automattic/jetpack-videopress/build/lib/player-bridge.asset.php
@@ -1 +1 @@
-<?php return array('dependencies' => array(), 'version' => '485b4121cf1a53eb3e32');
+<?php return array('dependencies' => array('wp-polyfill'), 'version' => '485b4121cf1a53eb3e32');
```

Before, it did not have the wp-polyfill dependency. This is an attempt to make the package not require it.

This seems to be related to [this core JS release](https://github.com/zloirock/core-js/releases/tag/v3.49.0) and [this safari bug](https://bugs.webkit.org/show_bug.cgi?id=309342) with `.includes`.

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?

## Testing instructions

* Go to '..'
*
