### PR TITLE
Charts: Tokenize spacing and border values with WPDS dimension/border tokens

### DIFF
--- a/projects/js-packages/charts/changelog/charts-199-spacing-border-tokenization
+++ b/projects/js-packages/charts/changelog/charts-199-spacing-border-tokenization
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Replace hardcoded spacing and border values in module SCSS with WPDS dimension and border design tokens.
+Charts: Replace hardcoded spacing and border values in module SCSS with WPDS dimension and border design tokens.

--- a/projects/js-packages/charts/changelog/charts-199-spacing-border-tokenization
+++ b/projects/js-packages/charts/changelog/charts-199-spacing-border-tokenization
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Replace hardcoded spacing and border values in module SCSS with WPDS dimension and border design tokens.

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
@@ -56,8 +56,8 @@
 	font-size: var(--wpds-font-size-sm, 12px);
 	font-style: normal;
 	font-weight: var(--wpds-font-weight-regular, 400);
-	line-height: var(--wpds-font-line-height-xs, 16px);
-	margin: 0 0 2px 0;
+	line-height: var(--wpds-font-line-height-sm, 20px);
+	margin: 0;
 	display: block;
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
@@ -54,11 +54,9 @@
 .step-label {
 	color: #757575;
 	font-size: var(--wpds-font-size-sm, 12px);
-	font-style: normal;
 	font-weight: var(--wpds-font-weight-regular, 400);
-	line-height: var(--wpds-font-line-height-sm, 20px);
-	margin: 0;
-	display: block;
+	line-height: var(--wpds-font-line-height-xs, 16px);
+	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
 }
@@ -66,11 +64,8 @@
 .step-rate {
 	color: #1e1e1e;
 	font-size: var(--wpds-font-size-md, 13px);
-	font-style: normal;
 	font-weight: var(--wpds-font-weight-medium, 499);
-	line-height: var(--wpds-font-line-height-sm, 20px);
-	margin: 0;
-	display: block;
+	line-height: var(--wpds-font-line-height-xs, 16px);
 }
 
 .bar-container {

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
@@ -124,7 +124,6 @@
 
 .empty-state {
 	text-align: center;
-	padding: 48px var(--wpds-dimension-padding-2xl, 24px);
 	color: #6b7280;
 	font-size: var(--wpds-font-size-lg, 16px);
 }

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
@@ -75,7 +75,7 @@
 
 .bar-container {
 	flex: 1;
-	border-radius: 4px;
+	border-radius: var(--wpds-border-radius-md, 4px);
 	position: relative;
 	cursor: pointer;
 }
@@ -83,7 +83,7 @@
 .funnel-bar {
 	width: 100%;
 	min-height: 4px;
-	border-radius: 4px 4px 0 0;
+	border-radius: var(--wpds-border-radius-md, 4px) var(--wpds-border-radius-md, 4px) 0 0;
 
 	&--animated {
 		transform-origin: bottom;
@@ -101,12 +101,12 @@
 }
 
 .tooltip-wrapper {
-	border-bottom: 1px solid var(--Gray-Gray-5, #dcdcde);
+	border-bottom: var(--wpds-border-width-xs, 1px) solid var(--Gray-Gray-5, #dcdcde);
 	background: var(--black-white-white, #fff);
 
 	// Override .visx-tooltip inline styles.
-	border-radius: 4px !important;
-	padding: 12px !important;
+	border-radius: var(--wpds-border-radius-md, 4px) !important;
+	padding: var(--wpds-dimension-padding-md, 12px) !important;
 	box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.15), 0 3px 9px 0 rgba(0, 0, 0, 0.12) !important;
 
 }
@@ -129,7 +129,7 @@
 
 .empty-state {
 	text-align: center;
-	padding: 48px 24px;
+	padding: 48px var(--wpds-dimension-padding-2xl, 24px);
 	color: #6b7280;
 	font-size: var(--wpds-font-size-lg, 16px);
 }

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.tsx
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.tsx
@@ -300,6 +300,8 @@ const ConversionFunnelChartInternal: FC< ConversionFunnelChartProps > = ( {
 		return (
 			<Stack
 				direction="column"
+				align="center"
+				justify="center"
 				data-testid="conversion-funnel-chart"
 				className={ clsx(
 					styles[ 'conversion-funnel-chart' ],

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.tsx
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.tsx
@@ -369,7 +369,7 @@ const ConversionFunnelChartInternal: FC< ConversionFunnelChartProps > = ( {
 								gap="xl"
 							>
 								{ /* Step Label and Rate */ }
-								<div>
+								<Stack direction="column" gap="xs">
 									{ renderStepLabel ? (
 										renderStepLabel( {
 											step,
@@ -390,7 +390,7 @@ const ConversionFunnelChartInternal: FC< ConversionFunnelChartProps > = ( {
 											{ formatPercentage( step.rate ) }
 										</span>
 									) }
-								</div>
+								</Stack>
 
 								{ /* Funnel Bar */ }
 								<Stack

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
@@ -34,7 +34,7 @@
 		}
 
 		.label {
-			padding-left: 8px;
+			padding-left: var(--wpds-dimension-padding-sm, 8px);
 		}
 	}
 
@@ -70,7 +70,7 @@
 }
 
 .emptyState {
-	padding: 32px 16px;
+	padding: var(--wpds-dimension-padding-3xl, 32px) var(--wpds-dimension-padding-lg, 16px);
 	text-align: center;
 	color: #666;
 	font-size: var(--wpds-font-size-md, 13px);

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
@@ -21,6 +21,10 @@
 	display: grid;
 	align-items: center;
 	grid-template-columns: 1fr;
+	// Outlier: not tokenized. The leaderboard's compact bar + gap + bar
+	// rhythm (6px bar, 6px row-gap, 6px bar) is intentional and does not
+	// map to any WPDS dimension token — gap-sm (8px) breaks the visual
+	// balance between the rows and the bars.
 	row-gap: 6px;
 	isolation: isolate;
 

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.module.scss
@@ -17,7 +17,7 @@
 	&__tooltip,
 	&__annotation-label-popover {
 		background: #fff;
-		padding: var(--wpds-dimension-padding-sm, 0.5rem);
+		padding: var(--wpds-dimension-padding-sm, 8px);
 	}
 
 	&__tooltip-date {
@@ -31,7 +31,7 @@
 
 	&__tooltip-label {
 		font-weight: var(--wpds-font-weight-medium, 499);
-		padding-right: var(--wpds-dimension-padding-lg, 1rem);
+		padding-right: var(--wpds-dimension-padding-lg, 16px);
 	}
 
 	&__annotations-overlay {
@@ -65,7 +65,7 @@
 		font-size: var(--wpds-font-size-md, 13px);
 		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 		position: fixed;
-		margin: var(--wpds-dimension-gap-sm, 0.5rem);
+		margin: var(--wpds-dimension-gap-sm, 8px);
 		visibility: hidden;
 
 		&--visible {
@@ -79,7 +79,7 @@
 	}
 
 	&__annotation-label-popover-content {
-		padding: var(--wpds-dimension-padding-sm, 0.5rem);
+		padding: var(--wpds-dimension-padding-sm, 8px);
 	}
 
 	&__annotation-label-popover-close-button {

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.module.scss
@@ -17,7 +17,7 @@
 	&__tooltip,
 	&__annotation-label-popover {
 		background: #fff;
-		padding: 0.5rem;
+		padding: var(--wpds-dimension-padding-sm, 0.5rem);
 	}
 
 	&__tooltip-date {
@@ -26,12 +26,12 @@
 	}
 
 	&__tooltip-row {
-		padding: 4px 0;
+		padding: var(--wpds-dimension-padding-xs, 4px) 0;
 	}
 
 	&__tooltip-label {
 		font-weight: var(--wpds-font-weight-medium, 499);
-		padding-right: 1rem;
+		padding-right: var(--wpds-dimension-padding-lg, 1rem);
 	}
 
 	&__annotations-overlay {
@@ -61,11 +61,11 @@
 		min-width: 125px;
 		background: #fff;
 		border: none;
-		border-radius: 4px;
+		border-radius: var(--wpds-border-radius-md, 4px);
 		font-size: var(--wpds-font-size-md, 13px);
 		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 		position: fixed;
-		margin: 0.5rem;
+		margin: var(--wpds-dimension-gap-sm, 0.5rem);
 		visibility: hidden;
 
 		&--visible {
@@ -79,7 +79,7 @@
 	}
 
 	&__annotation-label-popover-content {
-		padding: 0.5rem;
+		padding: var(--wpds-dimension-padding-sm, 0.5rem);
 	}
 
 	&__annotation-label-popover-close-button {

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.module.scss
@@ -22,7 +22,7 @@
 
 	&__tooltip-date {
 		font-weight: var(--wpds-font-weight-medium, 499);
-		padding-bottom: 10px;
+		padding-bottom: var(--wpds-dimension-padding-md, 12px);
 	}
 
 	&__tooltip-row {

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.module.scss
@@ -65,6 +65,9 @@
 		font-size: var(--wpds-font-size-md, 13px);
 		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 		position: fixed;
+		// Without margin set, the popover has margin:auto which upsets the
+		// positioning relative to the trigger button. A gap token is appropriate
+		// because it creates a gap to the trigger button.
 		margin: var(--wpds-dimension-gap-sm, 8px);
 		visibility: hidden;
 

--- a/projects/js-packages/charts/src/components/legend/private/base-legend.module.scss
+++ b/projects/js-packages/charts/src/components/legend/private/base-legend.module.scss
@@ -17,7 +17,7 @@
 		&:focus {
 			outline: 2px solid currentColor;
 			outline-offset: 2px;
-			border-radius: 4px;
+			border-radius: var(--wpds-border-radius-md, 4px);
 		}
 
 		&:focus:not(:focus-visible) {

--- a/projects/js-packages/charts/src/components/tooltip/base-tooltip.module.scss
+++ b/projects/js-packages/charts/src/components/tooltip/base-tooltip.module.scss
@@ -1,8 +1,8 @@
 .tooltip {
-	padding: 0.5rem;
+	padding: var(--wpds-dimension-padding-sm, 0.5rem);
 	background-color: rgba(0, 0, 0, 0.85);
 	color: #fff;
-	border-radius: 4px;
+	border-radius: var(--wpds-border-radius-md, 4px);
 	font-size: var(--wpds-font-size-md, 13px);
 	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 	position: absolute;

--- a/projects/js-packages/charts/src/components/tooltip/base-tooltip.module.scss
+++ b/projects/js-packages/charts/src/components/tooltip/base-tooltip.module.scss
@@ -1,5 +1,5 @@
 .tooltip {
-	padding: var(--wpds-dimension-padding-sm, 0.5rem);
+	padding: var(--wpds-dimension-padding-sm, 8px);
 	background-color: rgba(0, 0, 0, 0.85);
 	color: #fff;
 	border-radius: var(--wpds-border-radius-md, 4px);


### PR DESCRIPTION
Fixes [CHARTS-199](https://linear.app/a8c/issue/CHARTS-199/spacingborder-tokenization)

## Proposed changes
* Replace hardcoded spacing values (`padding`, `margin`, `gap`) in chart module SCSS with `--wpds-dimension-padding-*` and `--wpds-dimension-gap-*` design tokens.
* Replace hardcoded `border-radius: 4px` values with `--wpds-border-radius-md` (note: WPDS `border-radius-md` = 4px; the suggested `border-radius-sm` in the Linear ticket is actually 2px).
* Replace hardcoded `1px` border width on the funnel tooltip wrapper with `--wpds-border-width-xs`.
* Align fallbacks to the literal pixel values defined by the WPDS tokens (`0.5rem` → `8px`, `1rem` → `16px`) so the rendered value doesn't depend on the document root font-size.
* Eliminate hardcoded values that originally had no matching token by restructuring layout instead of leaving them as literals:
  * Funnel `step-label` 2px margin → wrap label and rate in a `Stack` with `gap-xs` (4px) and use `line-height-xs` on both. Bonus: drop redundant `display: block`/`margin: 0`/`font-style: normal` rules (flex items are auto-blockified) and add the missing `white-space: nowrap` so the label's existing `text-overflow: ellipsis` actually truncates.
  * Funnel empty-state `48px 24px` padding → add `align="center" justify="center"` to the parent `Stack` so the message is centered both axes within the chart's resolved height (matching the `SvgEmptyState` pattern). The 48px literal (which had no token) goes away entirely.
  * Line-chart tooltip-date `padding-bottom: 10px` → tokenized to `padding-md` (12px), the closer of the two adjacent tokens (sm = 8px, md = 12px).
* Token names verified against the authoritative source: `node_modules/@wordpress/theme/src/prebuilt/css/design-tokens.css`.

### Intentionally untouched
* **Leaderboard `row-gap: 6px`** — the leaderboard's bar rows use a compact `bar + gap + bar` rhythm (6px bar, 6px row-gap, 6px bar) that doesn't align to the WPDS dimension scale; the closest token (`gap-sm` = 8px) visibly breaks the balance. Documented inline as an outlier.
* **Leaderboard `--a8c--charts--leaderboard--bar--border-radius`** — the legacy CSS variable is left for [CHARTS-201](https://linear.app/a8c/issue/CHARTS-201/css-var-naming-consistency).
* **Story and test scaffolding** — all hardcoded spacing in `stories/`/`test/` files is demo-only and out of scope for the consumer-facing API.

## Related product discussion/links
* [CHARTS-199](https://linear.app/a8c/issue/CHARTS-199/spacingborder-tokenization)
* Design analysis P2: pgvZfX-yD-p2

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Run unit tests from `projects/js-packages/charts`: `pnpm test` — all 853 tests should pass.
* Open Storybook locally and visually inspect the affected stories — they should be visually identical to trunk except for the deliberate layout fixes called out below:
  * `Charts → Tooltip → Default` — base tooltip padding/border-radius unchanged.
  * `Charts → Line Chart → Annotations` — open an annotation popover; padding, margin, and border-radius unchanged.
  * `Charts → Conversion Funnel Chart → Default` — bar/funnel-bar border-radius unchanged. Hover a bar to confirm tooltip-wrapper padding/border-radius/border-bottom unchanged. The funnel bar position shifts up ~2px relative to trunk because the label/rate group is now slightly more compact (line-height-xs on both, gap-xs Stack between them).
  * `Charts → Conversion Funnel Chart → EmptyData` — the "No data available" message is now **centered both axes** within the chart's height (previously sat near the top with 48px/24px padding).
  * `Charts → Leaderboard Chart → Empty Data` — empty state padding (`32px 16px`) unchanged.
  * `Charts → Legend → *` — focus a legend item with the keyboard; the focus-ring border-radius is unchanged.
* Optional: in DevTools, inspect a tokenized property (e.g. `.tooltip` `padding`) and confirm the resolved value matches the previous literal. The WPDS provider is not active in default Storybook, so the CSS fallback should drive the rendered value.