### PR TITLE
Document WordPress UI + Theme integration defaults in AGENTS.md

### DIFF
--- a/projects/js-packages/charts/AGENTS.md
+++ b/projects/js-packages/charts/AGENTS.md
@@ -25,7 +25,7 @@ jp changelog add js-packages/charts -s patch -t changed -e "Charts: <user-facing
 The package is migrating to WordPress UI and Theme as its defaults. When adding or changing code, follow these defaults unless the task explicitly says otherwise:
 
 - **Design tokens (WPDS).** In SCSS, use `var(--wpds-dimension-*, <fallback>)`, `var(--wpds-border-*, <fallback>)`, and `var(--wpds-font-*, <fallback>)` instead of hardcoded px values for spacing, padding, margins, border radius, border width, font size, and font weight. Fallbacks must match the WPDS spec value for that token — do not invent fallback values.
-- **UI primitives.** Prefer `Stack` and the stable `Text` from `@wordpress/ui` over ad-hoc flexbox or raw `<span>`/`<div>` for layout and text. Do not use `__experimental*` exports from `@wordpress/components` (e.g. `__experimentalText`, `__experimentalHStack`, `__experimentalGrid`) — use the stable `@wordpress/ui` equivalents.
+- **UI primitives.** Prefer `Stack` and the stable `Text` from `@wordpress/ui` over ad-hoc flexbox or raw `<span>`/`<div>` for layout and text. Do not use `__experimental*` exports from `@wordpress/components` (e.g. `__experimentalText`, `__experimentalHStack`) — use the stable `@wordpress/ui` equivalents. Exception: `__experimentalGrid` has no stable alternative yet and is acceptable to use for now.
 - **Theming.** Theming flows through `@wordpress/theme`'s `ThemeProvider` (unlocked via private APIs in Storybook; see `src/stories/chart-decorator.tsx`). Do not manually override DS tokens in stories or components to achieve theming — pass a color through `ThemeProvider` instead.
 - **Chart element styles.** Read chart element styles via `getElementStyles` from `GlobalChartsProvider`, not directly from `theme`. This is the supported path for color/style resolution across themes.
 
@@ -56,7 +56,7 @@ The package is migrating to WordPress UI and Theme as its defaults. When adding 
 - Accessing colors/styles directly from `theme` rather than using `getElementStyles` from `GlobalChartsProvider`.
 - Hardcoding px values in SCSS for spacing, borders, or typography where a WPDS token (`--wpds-dimension-*`, `--wpds-border-*`, `--wpds-font-*`) exists.
 - CSS variable fallback values that diverge from the WPDS spec for that token.
-- Using `__experimental*` exports from `@wordpress/components` (e.g. `__experimentalText`, `__experimentalHStack`, `__experimentalGrid`) instead of the stable `@wordpress/ui` equivalents.
+- Using `__experimental*` exports from `@wordpress/components` (e.g. `__experimentalText`, `__experimentalHStack`) instead of the stable `@wordpress/ui` equivalents. (`__experimentalGrid` is excepted — no stable alternative exists yet.)
 - Manually overriding DS tokens in stories or components to achieve theming instead of passing a color through `@wordpress/theme`'s `ThemeProvider`.
 - Responsive wrappers that conflict with component sizing semantics (fixed-height charts, resize behavior, aspect-ratio assumptions).
 - Updating `.docs.mdx` without the corresponding `.api.mdx` when API docs are affected.

--- a/projects/js-packages/charts/AGENTS.md
+++ b/projects/js-packages/charts/AGENTS.md
@@ -25,7 +25,7 @@ jp changelog add js-packages/charts -s patch -t changed -e "Charts: <user-facing
 The package is migrating to WordPress UI and Theme as its defaults. When adding or changing code, follow these defaults unless the task explicitly says otherwise:
 
 - **Design tokens (WPDS).** In SCSS, use `var(--wpds-dimension-*, <fallback>)`, `var(--wpds-border-*, <fallback>)`, and `var(--wpds-font-*, <fallback>)` instead of hardcoded px values for spacing, padding, margins, border radius, border width, font size, and font weight. Fallbacks must match the WPDS spec value for that token — do not invent fallback values.
-- **UI primitives.** Prefer `Stack` and the stable `Text` from `@wordpress/ui` over ad-hoc flexbox or raw `<span>`/`<div>` for layout and text. Do not use `__experimental*` exports (e.g. `__experimentalText`) — use the stable `@wordpress/ui` equivalents.
+- **UI primitives.** Prefer `Stack` and the stable `Text` from `@wordpress/ui` over ad-hoc flexbox or raw `<span>`/`<div>` for layout and text. Do not use `__experimental*` exports from `@wordpress/components` (e.g. `__experimentalText`, `__experimentalHStack`, `__experimentalGrid`) — use the stable `@wordpress/ui` equivalents.
 - **Theming.** Theming flows through `@wordpress/theme`'s `ThemeProvider` (unlocked via private APIs in Storybook; see `src/stories/chart-decorator.tsx`). Do not manually override DS tokens in stories or components to achieve theming — pass a color through `ThemeProvider` instead.
 - **Chart element styles.** Read chart element styles via `getElementStyles` from `GlobalChartsProvider`, not directly from `theme`. This is the supported path for color/style resolution across themes.
 
@@ -56,7 +56,7 @@ The package is migrating to WordPress UI and Theme as its defaults. When adding 
 - Accessing colors/styles directly from `theme` rather than using `getElementStyles` from `GlobalChartsProvider`.
 - Hardcoding px values in SCSS for spacing, borders, or typography where a WPDS token (`--wpds-dimension-*`, `--wpds-border-*`, `--wpds-font-*`) exists.
 - CSS variable fallback values that diverge from the WPDS spec for that token.
-- Using `__experimentalText` (or other `__experimental*` exports) instead of the stable `@wordpress/ui` equivalents.
+- Using `__experimental*` exports from `@wordpress/components` (e.g. `__experimentalText`, `__experimentalHStack`, `__experimentalGrid`) instead of the stable `@wordpress/ui` equivalents.
 - Manually overriding DS tokens in stories or components to achieve theming instead of passing a color through `@wordpress/theme`'s `ThemeProvider`.
 - Responsive wrappers that conflict with component sizing semantics (fixed-height charts, resize behavior, aspect-ratio assumptions).
 - Updating `.docs.mdx` without the corresponding `.api.mdx` when API docs are affected.

--- a/projects/js-packages/charts/AGENTS.md
+++ b/projects/js-packages/charts/AGENTS.md
@@ -20,6 +20,17 @@ jp changelog add js-packages/charts -s patch -t changed -e "Charts: <user-facing
 - Accessibility behavior (keyboard navigation, accessible tooltips) is core chart behavior, not optional polish.
 - Charts are responsive by default — do not add external responsive wrappers that conflict with built-in sizing semantics.
 
+## WordPress UI + Theme Integration
+
+The package is migrating to WordPress UI and Theme as its defaults (see the Linear project [WordPress UI + Theme Integration](https://linear.app/a8c/project/wordpress-ui-theme-integration-7674aa8fa4a7)). When adding or changing code, follow these defaults unless the task explicitly says otherwise:
+
+- **Design tokens (WPDS).** In SCSS, use `var(--wpds-dimension-*, <fallback>)`, `var(--wpds-border-*, <fallback>)`, and `var(--wpds-font-*, <fallback>)` instead of hardcoded px values for spacing, padding, margins, border radius, border width, font size, and font weight. Fallbacks must match the WPDS spec value for that token — do not invent fallback values.
+- **UI primitives.** Prefer `Stack` and the stable `Text` from `@wordpress/ui` over ad-hoc flexbox or raw `<span>`/`<div>` for layout and text. Do not use `__experimental*` exports (e.g. `__experimentalText`) — use the stable `@wordpress/ui` equivalents.
+- **Theming.** Theming flows through `@wordpress/theme`'s `ThemeProvider` (unlocked via private APIs in Storybook; see `src/stories/chart-decorator.tsx`). Do not manually override DS tokens in stories or components to achieve theming — pass a color through `ThemeProvider` instead.
+- **Chart element styles.** Read chart element styles via `getElementStyles` from `GlobalChartsProvider`, not directly from `theme`. This is the supported path for color/style resolution across themes.
+
+Background reading: [design analysis](https://unifiedanalyticsp2.wordpress.com/2026/02/20/aligning-automattic-charts-with-wordpress-theme-package/) · [project P2](https://a8cchartsp2.wordpress.com/2026/04/02/wordpress-ui-theme-integration/).
+
 ## Documentation Workflow
 
 - For docs tasks agents should use the skill at `.agents/skills/charts-docs.md`.
@@ -43,8 +54,12 @@ jp changelog add js-packages/charts -s patch -t changed -e "Charts: <user-facing
 - Documenting props or behavior not present in stories and implementation.
 - Refactoring core composition/provider patterns as if they are accidental complexity.
 - Defining new chart prop interfaces that diverge from established base chart contracts (for example, not aligning with `BaseChartProps` when appropriate).
-- Using ad-hoc flexbox layouts where established layout primitives (e.g. `Stack`) should be preferred.
+- Using ad-hoc flexbox layouts where established layout primitives (e.g. `Stack` from `@wordpress/ui`) should be preferred.
 - Accessing colors/styles directly from `theme` rather than using `getElementStyles` from `GlobalChartsProvider`.
+- Hardcoding px values in SCSS for spacing, borders, or typography where a WPDS token (`--wpds-dimension-*`, `--wpds-border-*`, `--wpds-font-*`) exists.
+- CSS variable fallback values that diverge from the WPDS spec for that token.
+- Using `__experimentalText` (or other `__experimental*` exports) instead of the stable `@wordpress/ui` equivalents.
+- Manually overriding DS tokens in stories or components to achieve theming instead of passing a color through `@wordpress/theme`'s `ThemeProvider`.
 - Responsive wrappers that conflict with component sizing semantics (fixed-height charts, resize behavior, aspect-ratio assumptions).
 - Updating `.docs.mdx` without the corresponding `.api.mdx` when API docs are affected.
 - Not checking CSF file references in `.docs.mdx` when changing or removing stories.

--- a/projects/js-packages/charts/AGENTS.md
+++ b/projects/js-packages/charts/AGENTS.md
@@ -22,14 +22,12 @@ jp changelog add js-packages/charts -s patch -t changed -e "Charts: <user-facing
 
 ## WordPress UI + Theme Integration
 
-The package is migrating to WordPress UI and Theme as its defaults (see the Linear project [WordPress UI + Theme Integration](https://linear.app/a8c/project/wordpress-ui-theme-integration-7674aa8fa4a7)). When adding or changing code, follow these defaults unless the task explicitly says otherwise:
+The package is migrating to WordPress UI and Theme as its defaults. When adding or changing code, follow these defaults unless the task explicitly says otherwise:
 
 - **Design tokens (WPDS).** In SCSS, use `var(--wpds-dimension-*, <fallback>)`, `var(--wpds-border-*, <fallback>)`, and `var(--wpds-font-*, <fallback>)` instead of hardcoded px values for spacing, padding, margins, border radius, border width, font size, and font weight. Fallbacks must match the WPDS spec value for that token — do not invent fallback values.
 - **UI primitives.** Prefer `Stack` and the stable `Text` from `@wordpress/ui` over ad-hoc flexbox or raw `<span>`/`<div>` for layout and text. Do not use `__experimental*` exports (e.g. `__experimentalText`) — use the stable `@wordpress/ui` equivalents.
 - **Theming.** Theming flows through `@wordpress/theme`'s `ThemeProvider` (unlocked via private APIs in Storybook; see `src/stories/chart-decorator.tsx`). Do not manually override DS tokens in stories or components to achieve theming — pass a color through `ThemeProvider` instead.
 - **Chart element styles.** Read chart element styles via `getElementStyles` from `GlobalChartsProvider`, not directly from `theme`. This is the supported path for color/style resolution across themes.
-
-Background reading: [design analysis](https://unifiedanalyticsp2.wordpress.com/2026/02/20/aligning-automattic-charts-with-wordpress-theme-package/) · [project P2](https://a8cchartsp2.wordpress.com/2026/04/02/wordpress-ui-theme-integration/).
 
 ## Documentation Workflow
 

--- a/projects/js-packages/charts/changelog/charts-210-agents-md-wp-ui-theme
+++ b/projects/js-packages/charts/changelog/charts-210-agents-md-wp-ui-theme
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Charts: Document WordPress UI + Theme integration defaults in AGENTS.md.

--- a/projects/js-packages/charts/changelog/charts-210-agents-md-wp-ui-theme
+++ b/projects/js-packages/charts/changelog/charts-210-agents-md-wp-ui-theme
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Charts: Document WordPress UI + Theme integration defaults in AGENTS.md.
+Charts: Document WordPress UI + Theme integration defaults.


### PR DESCRIPTION
Fixes [CHARTS-210](https://linear.app/a8c/issue/CHARTS-210/charts-update-agentsmd-for-wordpress-ui-theme-integration-defaults).

## Proposed changes
* Adds a new **WordPress UI + Theme Integration** section to `projects/js-packages/charts/AGENTS.md` that codifies the defaults the package is migrating to: WPDS design tokens in SCSS (`--wpds-dimension-*`, `--wpds-border-*`, `--wpds-font-*` with spec-aligned fallbacks), `Stack`/stable `Text` from `@wordpress/ui` over ad-hoc flexbox and `__experimental*` exports, `@wordpress/theme`'s `ThemeProvider` as the theming entry point (no manual DS token overrides), and `getElementStyles` from `GlobalChartsProvider` for chart element styles.
* Extends **Common Pitfalls** with the inverse patterns so agents stop reintroducing them: hardcoded px values where a WPDS token exists, fallback values that diverge from the WPDS spec, `__experimentalText`, and manual DS token overrides in place of `ThemeProvider`.
* Adds a `changed` changelog entry. Documentation-only; no runtime code touched.

## Related product discussion/links
* Linear project: [WordPress UI + Theme Integration](https://linear.app/a8c/project/wordpress-ui-theme-integration-7674aa8fa4a7)
* Linear issue: [CHARTS-210](https://linear.app/a8c/issue/CHARTS-210/charts-update-agentsmd-for-wordpress-ui-theme-integration-defaults)
* Design analysis: pgvZfX-yD-p2
* Project P2: pgWg9p-2e-p2

## Does this pull request change what data or activity we track or use?
No. Documentation-only change to an agent-guidance file.

## Testing instructions

This PR only modifies `projects/js-packages/charts/AGENTS.md` and adds a changelog entry — there is nothing to exercise at runtime.

* Open `projects/js-packages/charts/AGENTS.md` and confirm the new **WordPress UI + Theme Integration** section reads clearly and renders correctly on GitHub.
* Confirm the **Common Pitfalls** additions are grouped with the related existing entries.
* Confirm the pre-existing sections (CRITICAL Rules, Changelog, Architecture Decisions, Documentation Workflow, Conventions, Definition of Done, References) are unchanged except where explicitly extended.
* Confirm the changelog entry exists at `projects/js-packages/charts/changelog/charts-210-agents-md-wp-ui-theme` (patch / changed).