### PR TITLE
Connection: Add hooks for external storage provider registration

### DIFF
--- a/projects/packages/connection/changelog/add-external-storage-provider-hooks
+++ b/projects/packages/connection/changelog/add-external-storage-provider-hooks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add hooks for external storage provider registration: `jetpack_external_storage_init` fires before the first storage read, and `jetpack_external_storage_provider_registered` fires after a provider is registered (invalidating cached connection status).

--- a/projects/packages/connection/src/class-external-storage.php
+++ b/projects/packages/connection/src/class-external-storage.php
@@ -31,8 +31,6 @@
 
 namespace Automattic\Jetpack\Connection;
 
-require_once __DIR__ . '/interface-storage-provider.php';
-
 /**
  * External Storage utilities class.
  *

--- a/projects/packages/connection/src/class-external-storage.php
+++ b/projects/packages/connection/src/class-external-storage.php
@@ -50,6 +50,15 @@ class External_Storage {
 	private static $provider = null;
 
 	/**
+	 * Whether the init action has already fired.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var bool
+	 */
+	private static $init_fired = false;
+
+	/**
 	 * Static cache to prevent logging same event multiple times in single request.
 	 *
 	 * @since 7.0.0
@@ -77,6 +86,19 @@ class External_Storage {
 	 */
 	public static function register_provider( Storage_Provider_Interface $provider ) {
 		self::$provider = $provider;
+
+		/**
+		 * Fires after an external storage provider is registered.
+		 *
+		 * This allows dependent systems (like the connection status cache in Manager)
+		 * to invalidate state that may have been computed before the provider was available.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param Storage_Provider_Interface $provider The registered storage provider.
+		 */
+		do_action( 'jetpack_external_storage_provider_registered', $provider );
+
 		return true;
 	}
 
@@ -91,6 +113,26 @@ class External_Storage {
 	 * @return mixed The value from external storage, or null for database fallback.
 	 */
 	public static function get_value( $key ) {
+		if ( ! self::$init_fired ) {
+			self::$init_fired = true;
+
+			/**
+			 * Fires before the first external storage read.
+			 *
+			 * Use this hook to register your storage provider via
+			 * External_Storage::register_provider(). This fires after the connection
+			 * package classes are loaded but before any connection status checks read
+			 * from external storage.
+			 *
+			 * Useful for mu-plugins that load before the plugin providing External_Storage,
+			 * since add_action() does not require the action or any classes to exist at
+			 * hook-registration time.
+			 *
+			 * @since $$next-version$$
+			 */
+			do_action( 'jetpack_external_storage_init' );
+		}
+
 		$provider = self::$provider;
 
 		// Check if we have a registered provider

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -213,6 +213,7 @@ class Manager {
 		add_action( 'pre_update_jetpack_option_master_user', array( $this, 'reset_connection_status' ) );
 		// phpcs:ignore WPCUT.SwitchBlog.SwitchBlog -- wpcom flags **every** use of switch_blog, apparently expecting valid instances to ignore or suppress the sniff.
 		add_action( 'switch_blog', array( $this, 'reset_connection_status' ) );
+		add_action( 'jetpack_external_storage_provider_registered', array( $this, 'reset_connection_status' ) );
 
 		self::$connection_invalidators_added = true;
 	}

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -213,7 +213,7 @@ class Manager {
 		add_action( 'pre_update_jetpack_option_master_user', array( $this, 'reset_connection_status' ) );
 		// phpcs:ignore WPCUT.SwitchBlog.SwitchBlog -- wpcom flags **every** use of switch_blog, apparently expecting valid instances to ignore or suppress the sniff.
 		add_action( 'switch_blog', array( $this, 'reset_connection_status' ) );
-		add_action( 'jetpack_external_storage_provider_registered', array( $this, 'reset_connection_status' ) );
+		add_action( 'jetpack_external_storage_provider_registered', array( $this, 'reset_connection_status' ), 10, 0 );
 
 		self::$connection_invalidators_added = true;
 	}

--- a/projects/packages/connection/tests/php/External_Storage_Test.php
+++ b/projects/packages/connection/tests/php/External_Storage_Test.php
@@ -41,6 +41,14 @@ class External_Storage_Test extends TestCase {
 			$logged_events_property->setAccessible( true );
 		}
 		$logged_events_property->setValue( null, array() );
+
+		// Reset the init_fired flag
+		$init_fired_property = $reflection->getProperty( 'init_fired' );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$init_fired_property->setAccessible( true );
+		}
+		$init_fired_property->setValue( null, false );
 	}
 
 	/**
@@ -247,5 +255,91 @@ class External_Storage_Test extends TestCase {
 		// Verify custom threshold value
 		$reflection = new \ReflectionMethod( $provider, 'get_empty_state_delay_threshold' );
 		$this->assertSame( 90, $reflection->invoke( $provider ) );
+	}
+
+	/**
+	 * Test that jetpack_external_storage_init fires on first get_value() call.
+	 */
+	public function test_init_action_fires_on_first_get_value() {
+		$fired = 0;
+		add_action(
+			'jetpack_external_storage_init',
+			function () use ( &$fired ) {
+				++$fired;
+			}
+		);
+
+		External_Storage::get_value( 'id' );
+		$this->assertSame( 1, $fired, 'Init action should fire on first get_value() call' );
+
+		External_Storage::get_value( 'blog_token' );
+		$this->assertSame( 1, $fired, 'Init action should not fire again on subsequent calls' );
+
+		remove_all_filters( 'jetpack_external_storage_init' );
+	}
+
+	/**
+	 * Test that a provider registered via the init action is used by the same get_value() call.
+	 */
+	public function test_init_action_allows_late_provider_registration() {
+		$provider = new class() implements \Automattic\Jetpack\Connection\Storage_Provider_Interface {
+			public function is_available() {
+				return true;
+			}
+			public function should_handle( $option_name ) {
+				return 'id' === $option_name;
+			}
+			public function get( $option_name ) {
+				return 'id' === $option_name ? 12345 : null;
+			}
+			public function get_environment_id() {
+				return 'test-late';
+			}
+		};
+
+		add_action(
+			'jetpack_external_storage_init',
+			function () use ( $provider ) {
+				External_Storage::register_provider( $provider );
+			}
+		);
+
+		$value = External_Storage::get_value( 'id' );
+		$this->assertSame( 12345, $value, 'Provider registered during init action should serve the triggering read' );
+
+		remove_all_filters( 'jetpack_external_storage_init' );
+	}
+
+	/**
+	 * Test that jetpack_external_storage_provider_registered fires on register_provider().
+	 */
+	public function test_provider_registered_action_fires() {
+		$received_provider = null;
+		add_action(
+			'jetpack_external_storage_provider_registered',
+			function ( $provider ) use ( &$received_provider ) {
+				$received_provider = $provider;
+			}
+		);
+
+		$provider = new class() implements \Automattic\Jetpack\Connection\Storage_Provider_Interface {
+			public function is_available() {
+				return true;
+			}
+			public function should_handle( $option_name ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+				return true;
+			}
+			public function get( $option_name ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+				return null;
+			}
+			public function get_environment_id() {
+				return 'test-registered';
+			}
+		};
+
+		External_Storage::register_provider( $provider );
+		$this->assertSame( $provider, $received_provider, 'Registered action should pass the provider instance' );
+
+		remove_all_filters( 'jetpack_external_storage_provider_registered' );
 	}
 }

--- a/projects/packages/connection/tests/php/External_Storage_Test.php
+++ b/projects/packages/connection/tests/php/External_Storage_Test.php
@@ -49,6 +49,10 @@ class External_Storage_Test extends TestCase {
 			$init_fired_property->setAccessible( true );
 		}
 		$init_fired_property->setValue( null, false );
+
+		// Remove any action callbacks added during tests
+		remove_all_filters( 'jetpack_external_storage_init' );
+		remove_all_filters( 'jetpack_external_storage_provider_registered' );
 	}
 
 	/**
@@ -274,8 +278,6 @@ class External_Storage_Test extends TestCase {
 
 		External_Storage::get_value( 'blog_token' );
 		$this->assertSame( 1, $fired, 'Init action should not fire again on subsequent calls' );
-
-		remove_all_filters( 'jetpack_external_storage_init' );
 	}
 
 	/**
@@ -306,8 +308,6 @@ class External_Storage_Test extends TestCase {
 
 		$value = External_Storage::get_value( 'id' );
 		$this->assertSame( 12345, $value, 'Provider registered during init action should serve the triggering read' );
-
-		remove_all_filters( 'jetpack_external_storage_init' );
 	}
 
 	/**
@@ -339,7 +339,5 @@ class External_Storage_Test extends TestCase {
 
 		External_Storage::register_provider( $provider );
 		$this->assertSame( $provider, $received_provider, 'Registered action should pass the provider instance' );
-
-		remove_all_filters( 'jetpack_external_storage_provider_registered' );
 	}
 }

--- a/projects/packages/connection/tests/php/ManagerIntegrationTest.php
+++ b/projects/packages/connection/tests/php/ManagerIntegrationTest.php
@@ -737,4 +737,56 @@ class ManagerIntegrationTest extends \WorDBless\BaseTestCase {
 			),
 		);
 	}
+
+	/**
+	 * Test that registering an external storage provider after is_connected() resets the cached status.
+	 */
+	public function test_registering_provider_invalidates_stale_is_connected() {
+		// Ensure clean state: no blog id, no token in DB.
+		\Jetpack_Options::delete_option( 'id' );
+		\Jetpack_Options::delete_option( 'blog_token' );
+		$this->reset_connection_status();
+
+		// First call: no provider, no DB data → false.
+		$this->assertFalse( $this->manager->is_connected() );
+
+		// Register a provider that supplies blog id and token.
+		$provider = new class() implements \Automattic\Jetpack\Connection\Storage_Provider_Interface {
+			public function is_available() {
+				return true;
+			}
+			public function should_handle( $option_name ) {
+				return in_array( $option_name, array( 'blog_token', 'id' ), true );
+			}
+			public function get( $option_name ) {
+				if ( 'id' === $option_name ) {
+					return 12345;
+				}
+				if ( 'blog_token' === $option_name ) {
+					return 'test.token';
+				}
+				return null;
+			}
+			public function get_environment_id() {
+				return 'test-invalidation';
+			}
+		};
+
+		// This should fire jetpack_external_storage_provider_registered,
+		// which resets the memoized is_connected value.
+		External_Storage::register_provider( $provider );
+
+		// Next call should re-evaluate with the provider and return true.
+		$this->assertTrue( $this->manager->is_connected() );
+
+		// Clean up: remove provider.
+		$reflection = new \ReflectionClass( External_Storage::class );
+		$prop       = $reflection->getProperty( 'provider' );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$prop->setAccessible( true );
+		}
+		$prop->setValue( null, null );
+		$this->reset_connection_status();
+	}
 }

--- a/projects/packages/connection/tests/php/ManagerIntegrationTest.php
+++ b/projects/packages/connection/tests/php/ManagerIntegrationTest.php
@@ -772,21 +772,32 @@ class ManagerIntegrationTest extends \WorDBless\BaseTestCase {
 			}
 		};
 
-		// This should fire jetpack_external_storage_provider_registered,
-		// which resets the memoized is_connected value.
-		External_Storage::register_provider( $provider );
+		try {
+			// This should fire jetpack_external_storage_provider_registered,
+			// which resets the memoized is_connected value.
+			External_Storage::register_provider( $provider );
 
-		// Next call should re-evaluate with the provider and return true.
-		$this->assertTrue( $this->manager->is_connected() );
+			// Next call should re-evaluate with the provider and return true.
+			$this->assertTrue( $this->manager->is_connected() );
+		} finally {
+			// Clean up: remove provider and reset init_fired.
+			$reflection = new \ReflectionClass( External_Storage::class );
 
-		// Clean up: remove provider.
-		$reflection = new \ReflectionClass( External_Storage::class );
-		$prop       = $reflection->getProperty( 'provider' );
-		// @todo Remove this call once we no longer need to support PHP <8.1.
-		if ( PHP_VERSION_ID < 80100 ) {
-			$prop->setAccessible( true );
+			$prop = $reflection->getProperty( 'provider' );
+			// @todo Remove this call once we no longer need to support PHP <8.1.
+			if ( PHP_VERSION_ID < 80100 ) {
+				$prop->setAccessible( true );
+			}
+			$prop->setValue( null, null );
+
+			$init_fired = $reflection->getProperty( 'init_fired' );
+			// @todo Remove this call once we no longer need to support PHP <8.1.
+			if ( PHP_VERSION_ID < 80100 ) {
+				$init_fired->setAccessible( true );
+			}
+			$init_fired->setValue( null, false );
+
+			$this->reset_connection_status();
 		}
-		$prop->setValue( null, null );
-		$this->reset_connection_status();
 	}
 }


### PR DESCRIPTION
## Proposed changes

* Add `jetpack_external_storage_init` action that fires before the first external storage read in `External_Storage::get_value()`. This gives mu-plugins (like CIAB/Garden) a guaranteed-safe point to register their storage provider via `add_action()` — no Jetpack classes need to exist at hook-registration time.
* Add `jetpack_external_storage_provider_registered` action that fires after `External_Storage::register_provider()` is called. `Manager::add_connection_status_invalidation_hooks()` listens for this and resets the memoized `is_connected()` result, so a provider registered "too late" still gets picked up on the next check.

### Why

On CIAB/Garden sites, connection data comes from external storage (Atomic Persistent Data), not the database. The storage provider is registered from a mu-plugin that loads before Jetpack. However, there was no guaranteed moment tween "Jetpack classes are available" and "Jetpack's first `is_connected()` call." A recent early call to `is_connected()` during Jetpack's load (newsletter module) caused the result to be memoized as `false` before the provider was registered, breaking Big Sky's assembler on garden sites.

These two hooks solve the problem from both directions:
- The **init hook** prevents the stale result by letting providers register at exactly the right time (before the first read)
- The **invalidation hook** is a safety net — if registration happens after a read, the cached status is cleared

Both are backward compatible. Existing consumers (wpcomsh/Atomic) register at include time before any reads; the new actions fire harmlessly with no effect.

## Related product discussion/links

* CIAB external storage timing issue with `is_connected()` memoization

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run the connection package PHP tests: `jetpack test php packes/connection`
* All 630 tests should pass, including 4 new tests:
  - `test_init_action_fires_on_first_get_value` — verifies the init action fires exactly once
  - `test_init_action_allows_late_provider_registration` — verifies a provider registered during the init action serves the triggering read
  - `test_provider_registered_action_fires` — verifies the registered action fires with the correct provider instance
  - `test_registering_provider_invalidates_stale_is_connected` — verifies registering a provider after `is_connected()` returned `false` clears the cached result