### PR TITLE
RTC: Inline keepalive Worker as a Blob URL to fix cross-origin failures

### DIFF
--- a/projects/packages/rtc/README.md
+++ b/projects/packages/rtc/README.md
@@ -42,7 +42,6 @@ The package has two main layers:
   - `pinghub-provider.ts` — Yjs provider (thin shell delegating to the manager).
   - `pinghub-manager.ts` — Per-room sync protocol, awareness, and reconnection logic.
   - `pinghub-bridge.ts` — WebSocket transport layer.
-  - `keepalive-worker.ts` — Web Worker for awareness keepalive ticks.
 
 ## Contribute
 

--- a/projects/packages/rtc/changelog/dotcom-16651-rtc-keepalive-web-worker-fails-to-construct-on-sites-that
+++ b/projects/packages/rtc/changelog/dotcom-16651-rtc-keepalive-web-worker-fails-to-construct-on-sites-that
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Inline the keepalive Web Worker as a Blob URL so it works on sites that load scripts from a different origin.

--- a/projects/packages/rtc/src/js/providers/pinghub/keepalive-worker.ts
+++ b/projects/packages/rtc/src/js/providers/pinghub/keepalive-worker.ts
@@ -1,9 +1,0 @@
-/**
- * Tiny Web Worker that sends a 'tick' message at a fixed interval.
- *
- * Web Worker timers are not throttled by browsers when the tab is in the
- * background, unlike main-thread setInterval which slows to ~1/min.
- * The main thread uses these ticks to re-broadcast awareness keepalives
- * so that remote peers don't time out this client after 30 seconds.
- */
-setInterval( () => postMessage( 'tick' ), 25 * 1000 );

--- a/projects/packages/rtc/src/js/providers/pinghub/pinghub-manager.ts
+++ b/projects/packages/rtc/src/js/providers/pinghub/pinghub-manager.ts
@@ -357,27 +357,74 @@ class PingHubConnection {
 }
 
 /**
- * Create a Web Worker that sends periodic 'tick' messages for awareness keepalive.
- *
- * @return Worker
+ * URL for the current keepalive worker's Blob, so we can revoke it on teardown.
  */
-function createKeepaliveWorker(): Worker {
-	const worker = new Worker( new URL( './keepalive-worker', import.meta.url ) );
-	worker.onmessage = () => {
-		for ( const [ , connection ] of rooms ) {
-			connection.broadcastLocalAwareness();
-		}
-	};
-	return worker;
+let keepaliveWorkerUrl: string | null = null;
+
+/**
+ * Fallback main-thread interval ID, used when a Web Worker cannot be created.
+ * Main-thread timers are throttled in background tabs, but this is better
+ * than failing entirely.
+ */
+let keepaliveFallbackTimer: ReturnType< typeof setInterval > | null = null;
+
+/**
+ * Invoke the awareness keepalive for every registered room.
+ */
+function runKeepaliveTick(): void {
+	for ( const [ , connection ] of rooms ) {
+		connection.broadcastLocalAwareness();
+	}
 }
 
 /**
- * Tear down the keepalive worker.
+ * Create a Web Worker that sends periodic 'tick' messages for awareness keepalive.
+ *
+ * The worker script is inlined as a Blob URL instead of loaded from a separate
+ * file. Web Workers are subject to same-origin policy: if the JS bundle is loaded
+ * from a different origin than the page (e.g. `s0.wp.com` scripts on a
+ * `*.wordpress.com` page), constructing a Worker from an external URL throws a
+ * SecurityError. Blob URLs are treated as same-origin with the page that created
+ * them, sidestepping the issue.
+ *
+ * @return Worker or null if the worker cannot be created.
+ */
+function createKeepaliveWorker(): Worker | null {
+	try {
+		const workerCode = "setInterval(function(){postMessage('tick');},25000);";
+		const blob = new Blob( [ workerCode ], { type: 'application/javascript' } );
+		keepaliveWorkerUrl = URL.createObjectURL( blob );
+		const worker = new Worker( keepaliveWorkerUrl );
+		worker.onmessage = runKeepaliveTick;
+		return worker;
+	} catch {
+		// Worker construction can fail if Blob/Worker APIs are unavailable
+		// or blocked by CSP. Fall back to a main-thread interval so RTC
+		// still works (awareness may be throttled in background tabs).
+		if ( keepaliveWorkerUrl ) {
+			URL.revokeObjectURL( keepaliveWorkerUrl );
+			keepaliveWorkerUrl = null;
+		}
+		keepaliveFallbackTimer = setInterval( runKeepaliveTick, 25 * 1000 );
+		return null;
+	}
+}
+
+/**
+ * Tear down the keepalive worker (or the fallback interval).
  */
 function destroyKeepaliveWorker(): void {
 	if ( keepaliveWorker ) {
 		keepaliveWorker.terminate();
 		keepaliveWorker = null;
+	}
+	if ( keepaliveWorkerUrl ) {
+		URL.revokeObjectURL( keepaliveWorkerUrl );
+		keepaliveWorkerUrl = null;
+	}
+	if ( keepaliveFallbackTimer !== null ) {
+		clearInterval( keepaliveFallbackTimer );
+		keepaliveFallbackTimer = null;
 	}
 }
 
@@ -455,7 +502,7 @@ function registerRoom( options: RegisterRoomOptions ): void {
 		areListenersRegistered = true;
 	}
 
-	if ( ! keepaliveWorker ) {
+	if ( ! keepaliveWorker && keepaliveFallbackTimer === null ) {
 		keepaliveWorker = createKeepaliveWorker();
 	}
 


### PR DESCRIPTION
Fixes DOTCOM-16651

## Proposed changes

* Inline the one-line keepalive Worker code as a Blob URL in `createKeepaliveWorker()` instead of loading it from a separate `keepalive-worker.ts` file via `new URL(..., import.meta.url)`.
* Add a main-thread `setInterval` fallback in case Worker construction fails for any other reason (CSP, old browser, etc.).
* Delete the now-unused `keepalive-worker.ts` file and the README reference to it.
* Revoke the Blob URL on teardown to avoid leaks.

## Why are these changes being made?

Real-time collaboration was silently and completely broken on sites whose JS bundles are loaded from a different origin than the page (e.g. `s0.wp.com/_static/...` scripts on a `*.wordpress.com` page). The keepalive Web Worker was loaded via:

```ts
new Worker( new URL( './keepalive-worker', import.meta.url ) )
```

`new URL('./keepalive-worker', import.meta.url)` resolves to whatever origin the bundle was loaded from. When that differs from the page origin, `new Worker(crossOriginUrl)` throws a `SecurityError` because Web Workers are subject to same-origin policy. The throw happens inside `registerRoom()` before `connection.connect()` is called, so no PingHub WebSocket is ever opened — affected users see no `pinghub_*` events in Logstash at all.

Example error from a user on elbowresearch.wordpress.com:

```
Uncaught (in promise) SecurityError: Failed to construct 'Worker':
Script at 'https://s0.wp.com/_static/479.js?minify=false&ver=...'
cannot be accessed from origin 'https://elbowresearch.wordpress.com'.
    at Object.registerRoom
    at c.connect
    at new c (PingHubProvider)
```

Blob URLs are treated as same-origin with the page that created them, so inlining the trivial worker code as a Blob sidesteps the cross-origin restriction entirely. Since the worker is literally one line (`setInterval(() => postMessage('tick'), 25000)`), inlining has no downside.

## Related product discussion/links

* DOTCOM-16651

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Open the block editor on elbowresearch.wordpress.com (or any site exhibiting the error)
* Before the fix: browser console shows `SecurityError: Failed to construct 'Worker'`; no PingHub WebSocket ever opens
* After the fix: no error; PingHub WebSocket connects normally; real-time collaboration works
* Also test on a site where RTC was already working (e.g. any regular wordpress.com site) to confirm no regression
* Verify in DevTools → Application → Workers that a worker is running, or in Network → WS that the WebSocket is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)