### PR TITLE
Forms: Add source filter to feedback REST API

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-source-filter-responses
+++ b/projects/packages/forms/changelog/fix-forms-source-filter-responses
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add source filter parameter to feedback REST API for filtering responses by source post ID, with fallback to post_parent for legacy data.

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -72,6 +72,7 @@ type QueryParams = {
 	order?: string;
 	is_unread?: boolean;
 	parent?: string;
+	source?: string;
 	before?: string;
 	after?: string;
 	search?: string;
@@ -305,7 +306,7 @@ function StageInner() {
 				queryArgs.is_unread = filter.value === 'unread';
 			}
 			if ( ! isSingleFormView && filter.field === 'source' ) {
-				queryArgs.parent = filter.value;
+				queryArgs.source = filter.value;
 			}
 			if ( filter.field === 'date' ) {
 				const [ year, month ] = filter.value.split( '/' ).map( Number );

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -36,6 +36,9 @@ class Jetpack_Forms {
 		// Add hook to delete file attachments when a feedback post is deleted
 		add_action( 'before_delete_post', array( '\Automattic\Jetpack\Forms\ContactForm\Contact_Form', 'delete_feedback_files' ) );
 
+		// Invalidate the source post IDs cache when a feedback post is permanently deleted.
+		add_action( 'deleted_post', array( '\Automattic\Jetpack\Forms\ContactForm\Feedback', 'invalidate_source_ids_cache_on_delete' ), 10, 2 );
+
 		// Enforces the availability of block support controls in the UI for classic themes.
 		add_filter( 'wp_theme_json_data_default', array( '\Automattic\Jetpack\Forms\ContactForm\Contact_Form', 'add_theme_json_data_for_classic_themes' ) );
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -40,6 +40,13 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	private $temp_source_filter_id;
 
 	/**
+	 * Cached SQL fragments for source filtering, to avoid recomputing per filter hook.
+	 *
+	 * @var array{join: string, where: string}|null
+	 */
+	private $temp_source_filter_sql;
+
+	/**
 	 * Get filtered list of supported integrations
 	 *
 	 * @return array Filtered list of supported integrations
@@ -1013,7 +1020,8 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		if ( ! empty( $this->temp_source_filter_id ) ) {
 			remove_filter( 'posts_join', array( $this, 'join_source_meta' ), 10 );
 			remove_filter( 'posts_where', array( $this, 'filter_by_source_id' ), 10 );
-			$this->temp_source_filter_id = null;
+			$this->temp_source_filter_id  = null;
+			$this->temp_source_filter_sql = null;
 		}
 
 		return $response;
@@ -1088,7 +1096,8 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		// Filter by source post ID using meta (with fallback to post_parent for old data).
 		$source = $request->get_param( 'source' );
 		if ( ! empty( $source ) ) {
-			$this->temp_source_filter_id = absint( $source );
+			$this->temp_source_filter_id  = absint( $source );
+			$this->temp_source_filter_sql = $this->get_source_filter_sql( $this->temp_source_filter_id );
 			add_filter( 'posts_join', array( $this, 'join_source_meta' ), 10, 2 );
 			add_filter( 'posts_where', array( $this, 'filter_by_source_id' ), 10, 2 );
 		}
@@ -1104,11 +1113,10 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	 * @return string Modified JOIN clause.
 	 */
 	public function join_source_meta( $join, $query ) {
-		if ( empty( $this->temp_source_filter_id ) || 'feedback' !== $query->get( 'post_type' ) ) {
+		if ( empty( $this->temp_source_filter_sql ) || 'feedback' !== $query->get( 'post_type' ) ) {
 			return $join;
 		}
-		$sql = $this->get_source_filter_sql( $this->temp_source_filter_id );
-		return $join . $sql['join'];
+		return $join . $this->temp_source_filter_sql['join'];
 	}
 
 	/**
@@ -1119,11 +1127,10 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	 * @return string Modified WHERE clause.
 	 */
 	public function filter_by_source_id( $where, $query ) {
-		if ( empty( $this->temp_source_filter_id ) || 'feedback' !== $query->get( 'post_type' ) ) {
+		if ( empty( $this->temp_source_filter_sql ) || 'feedback' !== $query->get( 'post_type' ) ) {
 			return $where;
 		}
-		$sql = $this->get_source_filter_sql( $this->temp_source_filter_id );
-		return $where . ' AND ' . $sql['where'];
+		return $where . ' AND ' . $this->temp_source_filter_sql['where'];
 	}
 
 	/**
@@ -1153,8 +1160,10 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'default'     => array(),
 		);
 		$query_params['source']         = array(
-			'description' => __( 'Limit result set to feedback submitted from a particular source post ID.', 'jetpack-forms' ),
-			'type'        => 'integer',
+			'description'       => __( 'Limit result set to feedback submitted from a particular source post ID.', 'jetpack-forms' ),
+			'type'              => 'integer',
+			'sanitize_callback' => 'absint',
+			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$query_params['is_unread']      = array(
 			'description'       => __( 'Limit result set to read or unread feedback items.', 'jetpack-forms' ),

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -904,6 +904,9 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			return rest_ensure_response( $data );
 		}
 
+		// Lazily backfill source meta for old feedback that doesn't have it yet.
+		Feedback::maybe_backfill_source_meta( $item->ID, $feedback_response );
+
 		$data['date'] = get_the_date( 'c', $data['id'] );
 		if ( rest_is_field_included( 'uid', $fields ) ) {
 			$data['uid'] = $feedback_response->get_feedback_id();

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -1103,8 +1103,8 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	 * @param WP_Query $query The WP_Query instance.
 	 * @return string Modified JOIN clause.
 	 */
-	public function join_source_meta( $join, $query ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Required by posts_join filter signature.
-		if ( empty( $this->temp_source_filter_id ) ) {
+	public function join_source_meta( $join, $query ) {
+		if ( empty( $this->temp_source_filter_id ) || 'feedback' !== $query->get( 'post_type' ) ) {
 			return $join;
 		}
 		$sql = $this->get_source_filter_sql( $this->temp_source_filter_id );
@@ -1118,8 +1118,8 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	 * @param WP_Query $query The WP_Query instance.
 	 * @return string Modified WHERE clause.
 	 */
-	public function filter_by_source_id( $where, $query ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Required by posts_where filter signature.
-		if ( empty( $this->temp_source_filter_id ) ) {
+	public function filter_by_source_id( $where, $query ) {
+		if ( empty( $this->temp_source_filter_id ) || 'feedback' !== $query->get( 'post_type' ) ) {
 			return $where;
 		}
 		$sql = $this->get_source_filter_sql( $this->temp_source_filter_id );

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -1013,7 +1013,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		if ( ! empty( $this->temp_source_filter_id ) ) {
 			remove_filter( 'posts_join', array( $this, 'join_source_meta' ), 10 );
 			remove_filter( 'posts_where', array( $this, 'filter_by_source_id' ), 10 );
-			unset( $this->temp_source_filter_id );
+			$this->temp_source_filter_id = null;
 		}
 
 		return $response;

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -33,6 +33,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 
 	/**
+	 * Temporary storage for the source filter ID used in query modifications.
+	 *
+	 * @var int|null
+	 */
+	private $temp_source_filter_id;
+
+	/**
 	 * Get filtered list of supported integrations
 	 *
 	 * @return array Filtered list of supported integrations
@@ -359,6 +366,12 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 						'sanitize_callback' => 'rest_sanitize_boolean',
 						'validate_callback' => 'rest_validate_request_arg',
 					),
+					'source'    => array(
+						'description'       => 'Limit results to feedback submitted from a specific source post ID.',
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+						'validate_callback' => 'rest_validate_request_arg',
+					),
 				),
 			)
 		);
@@ -414,8 +427,6 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	 * @return WP_REST_Response Response object on success.
 	 */
 	public function get_filters() {
-		// TODO: investigate how we can do this better regarding usage of $wpdb
-		// performance by querying all the entities, etc..
 		global $wpdb;
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$months = $wpdb->get_results(
@@ -424,10 +435,9 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			WHERE post_type = 'feedback'
 			ORDER BY post_date DESC"
 		);
+
+		$source_ids = Feedback::get_all_source_post_ids();
 		// phpcs:enable
-		$source_ids = Contact_Form_Plugin::get_all_parent_post_ids(
-			array_diff_key( array( 'post_status' => array( 'draft', 'publish', 'spam', 'trash' ) ), array( 'post_parent' => '' ) )
-		);
 
 		return rest_ensure_response(
 			array(
@@ -456,32 +466,40 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 
 		$search    = $request->get_param( 'search' );
 		$parent    = $request->get_param( 'parent' );
+		$source    = $request->get_param( 'source' );
 		$before    = $request->get_param( 'before' );
 		$after     = $request->get_param( 'after' );
 		$is_unread = $request->get_param( 'is_unread' );
 
-		$where_conditions = array( $wpdb->prepare( 'post_type = %s', 'feedback' ) );
+		$join_clause      = '';
+		$where_conditions = array( $wpdb->prepare( "{$wpdb->posts}.post_type = %s", 'feedback' ) );
 
 		if ( ! empty( $search ) ) {
 			$search_like        = '%' . $wpdb->esc_like( $search ) . '%';
-			$where_conditions[] = $wpdb->prepare( '(post_title LIKE %s OR post_content LIKE %s)', $search_like, $search_like );
+			$where_conditions[] = $wpdb->prepare( "({$wpdb->posts}.post_title LIKE %s OR {$wpdb->posts}.post_content LIKE %s)", $search_like, $search_like );
 		}
 
 		if ( ! empty( $parent ) ) {
-			$where_conditions[] = $wpdb->prepare( 'post_parent = %d', $parent );
+			$where_conditions[] = $wpdb->prepare( "{$wpdb->posts}.post_parent = %d", $parent );
+		}
+
+		if ( ! empty( $source ) ) {
+			$source_sql         = $this->get_source_filter_sql( absint( $source ) );
+			$join_clause       .= $source_sql['join'];
+			$where_conditions[] = $source_sql['where'];
 		}
 
 		if ( ! empty( $before ) ) {
-			$where_conditions[] = $wpdb->prepare( 'post_date <= %s', $before );
+			$where_conditions[] = $wpdb->prepare( "{$wpdb->posts}.post_date <= %s", $before );
 		}
 
 		if ( ! empty( $after ) ) {
-			$where_conditions[] = $wpdb->prepare( 'post_date >= %s', $after );
+			$where_conditions[] = $wpdb->prepare( "{$wpdb->posts}.post_date >= %s", $after );
 		}
 
 		if ( null !== $is_unread ) {
 			$comment_status     = $is_unread ? Feedback::STATUS_UNREAD : Feedback::STATUS_READ;
-			$where_conditions[] = $wpdb->prepare( 'comment_status = %s', $comment_status );
+			$where_conditions[] = $wpdb->prepare( "{$wpdb->posts}.comment_status = %s", $comment_status );
 		}
 
 		$where_clause = implode( ' AND ', $where_conditions );
@@ -490,11 +508,12 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$counts = $wpdb->get_row(
 			"SELECT
-			SUM(CASE WHEN post_status IN ('publish', 'draft') THEN 1 ELSE 0 END) as inbox,
-			SUM(CASE WHEN post_status = 'spam' THEN 1 ELSE 0 END) as spam,
-			SUM(CASE WHEN post_status = 'trash' THEN 1 ELSE 0 END) as trash
-			FROM $wpdb->posts
-			WHERE $where_clause",
+			SUM(CASE WHEN {$wpdb->posts}.post_status IN ('publish', 'draft') THEN 1 ELSE 0 END) as inbox,
+			SUM(CASE WHEN {$wpdb->posts}.post_status = 'spam' THEN 1 ELSE 0 END) as spam,
+			SUM(CASE WHEN {$wpdb->posts}.post_status = 'trash' THEN 1 ELSE 0 END) as trash
+			FROM {$wpdb->posts}
+			{$join_clause}
+			WHERE {$where_clause}",
 			ARRAY_A
 		);
 		// phpcs:enable
@@ -988,6 +1007,11 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			remove_filter( 'posts_where', array( $this, 'modify_query_for_invalid_ids' ), 10 );
 			unset( $this->temp_invalid_ids );
 		}
+		if ( ! empty( $this->temp_source_filter_id ) ) {
+			remove_filter( 'posts_join', array( $this, 'join_source_meta' ), 10 );
+			remove_filter( 'posts_where', array( $this, 'filter_by_source_id' ), 10 );
+			unset( $this->temp_source_filter_id );
+		}
 
 		return $response;
 	}
@@ -1023,6 +1047,28 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	}
 
 	/**
+	 * Returns the JOIN and WHERE SQL fragments for filtering by source post ID.
+	 *
+	 * Matches feedback with the _feedback_source_post_id meta set, or falls back
+	 * to post_parent for old feedback that doesn't have the meta yet.
+	 *
+	 * @param int $source_id The source post ID to filter by.
+	 * @return array{join: string, where: string} SQL fragments.
+	 */
+	private function get_source_filter_sql( $source_id ) {
+		global $wpdb;
+		$meta_key = esc_sql( Feedback::SOURCE_META_KEY );
+		return array(
+			'join'  => " LEFT JOIN {$wpdb->postmeta} AS source_meta ON ({$wpdb->posts}.ID = source_meta.post_id AND source_meta.meta_key = '{$meta_key}')",
+			'where' => $wpdb->prepare(
+				"(source_meta.meta_value = %s OR (source_meta.meta_id IS NULL AND {$wpdb->posts}.post_parent = %d))",
+				(string) $source_id,
+				$source_id
+			),
+		);
+	}
+
+	/**
 	 * Filters the query arguments for the feedback collection.
 	 *
 	 * @param array           $args    Key value array of query var to query value.
@@ -1036,7 +1082,45 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			$args['comment_status'] = $request['is_unread'] ? Feedback::STATUS_UNREAD : Feedback::STATUS_READ;
 		}
 
+		// Filter by source post ID using meta (with fallback to post_parent for old data).
+		$source = $request->get_param( 'source' );
+		if ( ! empty( $source ) ) {
+			$this->temp_source_filter_id = absint( $source );
+			add_filter( 'posts_join', array( $this, 'join_source_meta' ), 10, 2 );
+			add_filter( 'posts_where', array( $this, 'filter_by_source_id' ), 10, 2 );
+		}
+
 		return $args;
+	}
+
+	/**
+	 * Joins the postmeta table for source filtering.
+	 *
+	 * @param string   $join  The JOIN clause.
+	 * @param WP_Query $query The WP_Query instance.
+	 * @return string Modified JOIN clause.
+	 */
+	public function join_source_meta( $join, $query ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Required by posts_join filter signature.
+		if ( empty( $this->temp_source_filter_id ) ) {
+			return $join;
+		}
+		$sql = $this->get_source_filter_sql( $this->temp_source_filter_id );
+		return $join . $sql['join'];
+	}
+
+	/**
+	 * Filters feedback by source post ID, using meta with fallback to post_parent for old data.
+	 *
+	 * @param string   $where The WHERE clause.
+	 * @param WP_Query $query The WP_Query instance.
+	 * @return string Modified WHERE clause.
+	 */
+	public function filter_by_source_id( $where, $query ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Required by posts_where filter signature.
+		if ( empty( $this->temp_source_filter_id ) ) {
+			return $where;
+		}
+		$sql = $this->get_source_filter_sql( $this->temp_source_filter_id );
+		return $where . ' AND ' . $sql['where'];
 	}
 
 	/**
@@ -1064,6 +1148,10 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				'type' => 'integer',
 			),
 			'default'     => array(),
+		);
+		$query_params['source']         = array(
+			'description' => __( 'Limit result set to feedback submitted from a particular source post ID.', 'jetpack-forms' ),
+			'type'        => 'integer',
 		);
 		$query_params['is_unread']      = array(
 			'description'       => __( 'Limit result set to read or unread feedback items.', 'jetpack-forms' ),

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -1113,7 +1113,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	 * @return string Modified JOIN clause.
 	 */
 	public function join_source_meta( $join, $query ) {
-		if ( empty( $this->temp_source_filter_sql ) || 'feedback' !== $query->get( 'post_type' ) ) {
+		if ( empty( $this->temp_source_filter_sql ) || Feedback::POST_TYPE !== $query->get( 'post_type' ) ) {
 			return $join;
 		}
 		return $join . $this->temp_source_filter_sql['join'];
@@ -1127,7 +1127,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	 * @return string Modified WHERE clause.
 	 */
 	public function filter_by_source_id( $where, $query ) {
-		if ( empty( $this->temp_source_filter_sql ) || 'feedback' !== $query->get( 'post_type' ) ) {
+		if ( empty( $this->temp_source_filter_sql ) || Feedback::POST_TYPE !== $query->get( 'post_type' ) ) {
 			return $where;
 		}
 		return $where . ' AND ' . $this->temp_source_filter_sql['where'];

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -114,7 +114,7 @@ class Feedback {
 		// phpcs:enable
 
 		$source_ids = array_map( 'intval', $source_ids );
-		wp_cache_set( self::SOURCE_IDS_CACHE_KEY, $source_ids, self::CACHE_GROUP );
+		wp_cache_set( self::SOURCE_IDS_CACHE_KEY, $source_ids, self::CACHE_GROUP, HOUR_IN_SECONDS );
 
 		return $source_ids;
 	}

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -130,6 +130,28 @@ class Feedback {
 	}
 
 	/**
+	 * Backfills the source post ID meta from the feedback object's resolved source.
+	 *
+	 * For old feedback parented to a jetpack_form that doesn't have
+	 * _feedback_source_post_id set yet, this writes the meta so future
+	 * queries can filter by source without the post_parent fallback.
+	 *
+	 * @param int      $post_id  The feedback post ID.
+	 * @param Feedback $feedback The feedback object (already has source resolved from parsed content).
+	 */
+	public static function maybe_backfill_source_meta( $post_id, $feedback ) {
+		$existing = get_post_meta( $post_id, self::SOURCE_META_KEY, true );
+		if ( $existing ) {
+			return;
+		}
+
+		$source_id = $feedback->get_entry_id();
+		if ( is_numeric( $source_id ) && (int) $source_id > 0 ) {
+			add_post_meta( $post_id, self::SOURCE_META_KEY, (int) $source_id, true );
+		}
+	}
+
+	/**
 	 * The form field values.
 	 *
 	 * @var array
@@ -1442,7 +1464,7 @@ class Feedback {
 		// Store source post ID as meta for queryable source filtering.
 		$source_id = $this->source->get_id();
 		if ( is_numeric( $post_id ) && (int) $post_id > 0 && is_numeric( $source_id ) && (int) $source_id > 0 ) {
-			update_post_meta( $post_id, self::SOURCE_META_KEY, (int) $source_id );
+			add_post_meta( $post_id, self::SOURCE_META_KEY, (int) $source_id, true );
 			wp_cache_delete( self::SOURCE_IDS_CACHE_KEY, self::CACHE_GROUP );
 		}
 

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -36,6 +36,100 @@ class Feedback {
 	public const STATUS_READ = 'closed';
 
 	/**
+	 * Meta key used to store the source post ID on feedback posts.
+	 *
+	 * @var string
+	 */
+	public const SOURCE_META_KEY = '_feedback_source_post_id';
+
+	/**
+	 * Cache key for the source post IDs list.
+	 *
+	 * @var string
+	 */
+	private const SOURCE_IDS_CACHE_KEY = 'jetpack_forms_source_post_ids';
+
+	/**
+	 * Cache group for forms data.
+	 *
+	 * @var string
+	 */
+	private const CACHE_GROUP = 'jetpack_forms';
+
+	/**
+	 * Returns all distinct source post IDs for feedback entries.
+	 *
+	 * Uses the _feedback_source_post_id meta for new feedback, with a fallback
+	 * to post_parent for old feedback that doesn't have the meta yet (excluding
+	 * jetpack_form parents).
+	 *
+	 * @return array Array of unique source post IDs.
+	 */
+	public static function get_all_source_post_ids() {
+		$source_ids = wp_cache_get( self::SOURCE_IDS_CACHE_KEY, self::CACHE_GROUP );
+
+		if ( false !== $source_ids ) {
+			return $source_ids;
+		}
+
+		global $wpdb;
+
+		$meta_key     = self::SOURCE_META_KEY;
+		$statuses     = array( 'draft', 'publish', 'spam', 'trash' );
+		$placeholders = implode( ',', array_fill( 0, count( $statuses ), '%s' ) );
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		$source_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT DISTINCT source_id FROM (
+					SELECT CAST(pm.meta_value AS UNSIGNED) AS source_id
+					FROM {$wpdb->postmeta} pm
+					INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
+					WHERE pm.meta_key = %s
+					AND p.post_type = 'feedback'
+					AND p.post_status IN ({$placeholders})
+					AND pm.meta_value != '0' AND pm.meta_value != ''
+				UNION
+					SELECT p.post_parent AS source_id
+					FROM {$wpdb->posts} p
+					LEFT JOIN {$wpdb->postmeta} pm ON pm.post_id = p.ID AND pm.meta_key = %s
+					LEFT JOIN {$wpdb->posts} parent_post ON parent_post.ID = p.post_parent
+					WHERE p.post_type = 'feedback'
+					AND p.post_status IN ({$placeholders})
+					AND p.post_parent > 0
+					AND pm.meta_id IS NULL
+					AND (parent_post.post_type IS NULL OR parent_post.post_type != %s)
+				) AS combined_sources",
+				array_merge(
+					array( $meta_key ),
+					$statuses,
+					array( $meta_key ),
+					$statuses,
+					array( Contact_Form::POST_TYPE )
+				)
+			)
+		);
+		// phpcs:enable
+
+		$source_ids = array_map( 'intval', $source_ids );
+		wp_cache_set( self::SOURCE_IDS_CACHE_KEY, $source_ids, self::CACHE_GROUP );
+
+		return $source_ids;
+	}
+
+	/**
+	 * Invalidates the source post IDs cache when a feedback post is deleted.
+	 *
+	 * @param int      $post_id The deleted post ID.
+	 * @param \WP_Post $post    The deleted post object.
+	 */
+	public static function invalidate_source_ids_cache_on_delete( $post_id, $post ) {
+		if ( $post->post_type === self::POST_TYPE ) {
+			wp_cache_delete( self::SOURCE_IDS_CACHE_KEY, self::CACHE_GROUP );
+		}
+	}
+
+	/**
 	 * The form field values.
 	 *
 	 * @var array
@@ -1344,6 +1438,13 @@ class Feedback {
 				'comment_status' => self::STATUS_UNREAD, // New feedback is unread by default.
 			)
 		);
+
+		// Store source post ID as meta for queryable source filtering.
+		$source_id = $this->source->get_id();
+		if ( is_numeric( $post_id ) && (int) $post_id > 0 && is_numeric( $source_id ) && (int) $source_id > 0 ) {
+			update_post_meta( $post_id, self::SOURCE_META_KEY, (int) $source_id );
+			wp_cache_delete( self::SOURCE_IDS_CACHE_KEY, self::CACHE_GROUP );
+		}
 
 		// If this feedback does not have a jetpack_form parent,
 		// it's a classic form — mark the state accordingly.

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -78,6 +78,8 @@ class Feedback {
 		$statuses     = array( 'draft', 'publish', 'spam', 'trash' );
 		$placeholders = implode( ',', array_fill( 0, count( $statuses ), '%s' ) );
 
+		$post_type = self::POST_TYPE;
+
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 		$source_ids = $wpdb->get_col(
 			$wpdb->prepare(
@@ -86,7 +88,7 @@ class Feedback {
 					FROM {$wpdb->postmeta} pm
 					INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
 					WHERE pm.meta_key = %s
-					AND p.post_type = 'feedback'
+					AND p.post_type = %s
 					AND p.post_status IN ({$placeholders})
 					AND pm.meta_value != '0' AND pm.meta_value != ''
 				UNION
@@ -94,16 +96,16 @@ class Feedback {
 					FROM {$wpdb->posts} p
 					LEFT JOIN {$wpdb->postmeta} pm ON pm.post_id = p.ID AND pm.meta_key = %s
 					LEFT JOIN {$wpdb->posts} parent_post ON parent_post.ID = p.post_parent
-					WHERE p.post_type = 'feedback'
+					WHERE p.post_type = %s
 					AND p.post_status IN ({$placeholders})
 					AND p.post_parent > 0
 					AND pm.meta_id IS NULL
 					AND (parent_post.post_type IS NULL OR parent_post.post_type != %s)
 				) AS combined_sources",
 				array_merge(
-					array( $meta_key ),
+					array( $meta_key, $post_type ),
 					$statuses,
-					array( $meta_key ),
+					array( $meta_key, $post_type ),
 					$statuses,
 					array( Contact_Form::POST_TYPE )
 				)

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -147,7 +147,10 @@ class Feedback {
 
 		$source_id = $feedback->get_entry_id();
 		if ( is_numeric( $source_id ) && (int) $source_id > 0 ) {
-			add_post_meta( $post_id, self::SOURCE_META_KEY, (int) $source_id, true );
+			$meta_added = add_post_meta( $post_id, self::SOURCE_META_KEY, (int) $source_id, true );
+			if ( $meta_added ) {
+				wp_cache_delete( self::SOURCE_IDS_CACHE_KEY, self::CACHE_GROUP );
+			}
 		}
 	}
 

--- a/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-inbox-data.ts
@@ -248,6 +248,9 @@ export default function useInboxData( options: UseInboxDataOptions = {} ): UseIn
 		if ( currentQuery?.parent ) {
 			params.parent = currentQuery.parent;
 		}
+		if ( currentQuery?.source ) {
+			params.source = currentQuery.source;
+		}
 		if ( currentQuery?.before ) {
 			params.before = currentQuery.before;
 		}

--- a/projects/packages/forms/src/dashboard/inbox/stage/actions.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/stage/actions.tsx
@@ -36,6 +36,9 @@ const getCountQueryParams = ( currentQuery: QueryParams ): QueryParams => {
 	if ( currentQuery?.parent ) {
 		queryParams.parent = currentQuery.parent;
 	}
+	if ( currentQuery?.source ) {
+		queryParams.source = currentQuery.source;
+	}
 	if ( currentQuery?.before ) {
 		queryParams.before = currentQuery.before;
 	}

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.js
@@ -173,7 +173,7 @@ export default function InboxView( { parentId, pageTitle, pageSubtitle } = {} ) 
 				return accumulator;
 			}
 			if ( field === 'source' ) {
-				accumulator.parent = value;
+				accumulator.source = value;
 			}
 			if ( field === 'date' ) {
 				const [ year, month ] = value.split( '/' ).map( Number );

--- a/projects/packages/forms/src/dashboard/inbox/stage/types.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/stage/types.tsx
@@ -8,6 +8,7 @@ import type { StoreDescriptor } from '@wordpress/data';
 export type QueryParams = {
 	search?: string;
 	parent?: string;
+	source?: string;
 	before?: string;
 	after?: string;
 	is_unread?: boolean;

--- a/projects/packages/forms/src/dashboard/store/actions.js
+++ b/projects/packages/forms/src/dashboard/store/actions.js
@@ -80,6 +80,7 @@ export function setCurrentQuery( currentQuery ) {
 			previousQuery.search !== queryWithFormat.search ||
 			previousQuery.is_unread !== queryWithFormat.is_unread ||
 			previousQuery.parent !== queryWithFormat.parent ||
+			previousQuery.source !== queryWithFormat.source ||
 			previousQuery.before !== queryWithFormat.before ||
 			previousQuery.after !== queryWithFormat.after;
 

--- a/projects/packages/forms/src/dashboard/store/reducer.js
+++ b/projects/packages/forms/src/dashboard/store/reducer.js
@@ -66,7 +66,7 @@ const normalizeValue = value => {
  * @return {string} A stable key for caching.
  */
 export const getCacheKey = ( queryParams = {} ) => {
-	const keys = [ 'search', 'parent', 'before', 'after', 'is_unread' ];
+	const keys = [ 'search', 'parent', 'source', 'before', 'after', 'is_unread' ];
 	const parts = keys
 		.filter( key => queryParams[ key ] !== undefined )
 		.map( key => `${ key }:${ normalizeValue( queryParams[ key ] ) }` );

--- a/projects/packages/forms/src/dashboard/store/resolvers.js
+++ b/projects/packages/forms/src/dashboard/store/resolvers.js
@@ -33,6 +33,9 @@ export const getCounts =
 		if ( queryParams?.parent ) {
 			params.parent = queryParams.parent;
 		}
+		if ( queryParams?.source ) {
+			params.source = queryParams.source;
+		}
 		if ( queryParams?.before ) {
 			params.before = queryParams.before;
 		}

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -1316,58 +1316,70 @@ JSON_DATA{"1_name":"Test Author","2_email":"author@example.com","3_file":{"field
 	}
 
 	/**
-	 * Test that the source filter accepts a valid source parameter without error.
+	 * Test that the counts endpoint applies source filter SQL when source param is set.
 	 */
-	public function test_source_filter_returns_200() {
-		$request = new WP_REST_Request( 'GET', '/wp/v2/feedback' );
-		$request->set_param( 'source', 123 );
-		$response = $this->server->dispatch( $request );
+	public function test_counts_with_source_includes_source_filter_sql() {
+		$captured_query = null;
+		add_filter(
+			'wordbless_wpdb_query_results',
+			function ( $results, $query ) use ( &$captured_query ) {
+				if ( strpos( $query, 'SUM(CASE' ) !== false && strpos( $query, 'source_meta' ) !== false ) {
+					$captured_query = $query;
+				}
+				return $results;
+			},
+			10,
+			2
+		);
 
-		$this->assertEquals( 200, $response->get_status() );
-	}
-
-	/**
-	 * Test that the counts endpoint accepts source parameter without error.
-	 */
-	public function test_counts_with_source_returns_200() {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/feedback/counts' );
 		$request->set_param( 'source', 123 );
 		$response = $this->server->dispatch( $request );
 
 		$this->assertEquals( 200, $response->get_status() );
-		$data = $response->get_data();
-		$this->assertArrayHasKey( 'inbox', $data );
-		$this->assertArrayHasKey( 'spam', $data );
-		$this->assertArrayHasKey( 'trash', $data );
+		$this->assertNotNull( $captured_query, 'Counts query should include source filter SQL' );
+		$this->assertStringContainsString( '_feedback_source_post_id', $captured_query, 'Counts query should reference the source meta key' );
+		$this->assertStringContainsString( 'source_meta.meta_value', $captured_query, 'Counts query should filter by source meta value' );
+		$this->assertStringContainsString( 'post_parent', $captured_query, 'Counts query should include post_parent fallback' );
+
+		remove_all_filters( 'wordbless_wpdb_query_results' );
 	}
 
 	/**
-	 * Test that SOURCE_META_KEY constant is defined on Feedback class.
+	 * Test that source=0 does not inject source filter SQL.
 	 */
-	public function test_source_meta_key_constant_exists() {
-		$this->assertEquals( '_feedback_source_post_id', Feedback::SOURCE_META_KEY );
+	public function test_source_filter_with_zero_value_is_ignored() {
+		$captured_sql = '';
+
+		add_filter(
+			'posts_request',
+			function ( $sql ) use ( &$captured_sql ) {
+				$captured_sql = $sql;
+				return $sql;
+			},
+			99
+		);
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/feedback' );
+		$request->set_param( 'source', 0 );
+		$this->server->dispatch( $request );
+
+		$this->assertStringNotContainsString( 'source_meta', $captured_sql, 'source=0 should not inject source filter SQL' );
+
+		remove_all_filters( 'posts_request' );
 	}
 
 	/**
 	 * Test that the source filter adds the correct SQL JOIN and WHERE clauses.
 	 */
 	public function test_source_filter_modifies_query() {
-		$captured_join  = null;
-		$captured_where = null;
+		$captured_sql = null;
 
 		add_filter(
-			'posts_join',
-			function ( $join ) use ( &$captured_join ) {
-				$captured_join = $join;
-				return $join;
-			},
-			99
-		);
-		add_filter(
-			'posts_where',
-			function ( $where ) use ( &$captured_where ) {
-				$captured_where = $where;
-				return $where;
+			'posts_request',
+			function ( $sql ) use ( &$captured_sql ) {
+				$captured_sql = $sql;
+				return $sql;
 			},
 			99
 		);
@@ -1376,17 +1388,14 @@ JSON_DATA{"1_name":"Test Author","2_email":"author@example.com","3_file":{"field
 		$request->set_param( 'source', 42 );
 		$this->server->dispatch( $request );
 
-		$this->assertNotNull( $captured_join, 'JOIN clause should have been modified' );
-		$this->assertStringContainsString( 'source_meta', $captured_join, 'JOIN should include the source_meta alias' );
-		$this->assertStringContainsString( '_feedback_source_post_id', $captured_join, 'JOIN should reference the source meta key' );
+		$this->assertNotNull( $captured_sql, 'SQL query should have been built' );
+		$this->assertStringContainsString( 'source_meta', $captured_sql, 'SQL should include the source_meta alias' );
+		$this->assertStringContainsString( '_feedback_source_post_id', $captured_sql, 'SQL should reference the source meta key' );
+		$this->assertStringContainsString( 'source_meta.meta_value', $captured_sql, 'SQL should filter by source meta value' );
+		$this->assertStringContainsString( 'post_parent', $captured_sql, 'SQL should include post_parent fallback' );
+		$this->assertStringContainsString( 'source_meta.meta_id IS NULL', $captured_sql, 'SQL should check for missing meta in fallback' );
 
-		$this->assertNotNull( $captured_where, 'WHERE clause should have been modified' );
-		$this->assertStringContainsString( 'source_meta.meta_value', $captured_where, 'WHERE should filter by source meta value' );
-		$this->assertStringContainsString( 'post_parent', $captured_where, 'WHERE should include post_parent fallback' );
-		$this->assertStringContainsString( 'source_meta.meta_id IS NULL', $captured_where, 'WHERE should check for missing meta in fallback' );
-
-		remove_all_filters( 'posts_join' );
-		remove_all_filters( 'posts_where' );
+		remove_all_filters( 'posts_request' );
 	}
 
 	/**
@@ -1399,13 +1408,13 @@ JSON_DATA{"1_name":"Test Author","2_email":"author@example.com","3_file":{"field
 		$request->set_param( 'source', 42 );
 		$this->server->dispatch( $request );
 
-		// Second request without source — capture the JOIN to verify no leftover filter.
-		$captured_join = '';
+		// Second request without source — capture SQL to verify no leftover filter.
+		$captured_sql = '';
 		add_filter(
-			'posts_join',
-			function ( $join ) use ( &$captured_join ) {
-				$captured_join = $join;
-				return $join;
+			'posts_request',
+			function ( $sql ) use ( &$captured_sql ) {
+				$captured_sql = $sql;
+				return $sql;
 			},
 			99
 		);
@@ -1413,22 +1422,22 @@ JSON_DATA{"1_name":"Test Author","2_email":"author@example.com","3_file":{"field
 		$request2 = new WP_REST_Request( 'GET', '/wp/v2/feedback' );
 		$this->server->dispatch( $request2 );
 
-		$this->assertStringNotContainsString( 'source_meta', $captured_join, 'Source filter should not leak into subsequent requests' );
+		$this->assertStringNotContainsString( 'source_meta', $captured_sql, 'Source filter should not leak into subsequent requests' );
 
-		remove_all_filters( 'posts_join' );
+		remove_all_filters( 'posts_request' );
 	}
 
 	/**
 	 * Test that without source param, no source filter hooks are added.
 	 */
 	public function test_no_source_filter_without_param() {
-		$captured_join = '';
+		$captured_sql = '';
 
 		add_filter(
-			'posts_join',
-			function ( $join ) use ( &$captured_join ) {
-				$captured_join = $join;
-				return $join;
+			'posts_request',
+			function ( $sql ) use ( &$captured_sql ) {
+				$captured_sql = $sql;
+				return $sql;
 			},
 			99
 		);
@@ -1436,8 +1445,8 @@ JSON_DATA{"1_name":"Test Author","2_email":"author@example.com","3_file":{"field
 		$request = new WP_REST_Request( 'GET', '/wp/v2/feedback' );
 		$this->server->dispatch( $request );
 
-		$this->assertStringNotContainsString( 'source_meta', $captured_join, 'JOIN should not include source_meta when no source param' );
+		$this->assertStringNotContainsString( 'source_meta', $captured_sql, 'SQL should not include source_meta when no source param' );
 
-		remove_all_filters( 'posts_join' );
+		remove_all_filters( 'posts_request' );
 	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -1346,56 +1346,29 @@ JSON_DATA{"1_name":"Test Author","2_email":"author@example.com","3_file":{"field
 	}
 
 	/**
-	 * Test that source=0 does not inject source filter SQL.
-	 */
-	public function test_source_filter_with_zero_value_is_ignored() {
-		$captured_sql = '';
-
-		add_filter(
-			'posts_request',
-			function ( $sql ) use ( &$captured_sql ) {
-				$captured_sql = $sql;
-				return $sql;
-			},
-			99
-		);
-
-		$request = new WP_REST_Request( 'GET', '/wp/v2/feedback' );
-		$request->set_param( 'source', 0 );
-		$this->server->dispatch( $request );
-
-		$this->assertStringNotContainsString( 'source_meta', $captured_sql, 'source=0 should not inject source filter SQL' );
-
-		remove_all_filters( 'posts_request' );
-	}
-
-	/**
 	 * Test that the source filter adds the correct SQL JOIN and WHERE clauses.
 	 */
+	/**
+	 * Test that the source filter generates the correct SQL via get_source_filter_sql.
+	 */
 	public function test_source_filter_modifies_query() {
-		$captured_sql = null;
+		$endpoint = new Contact_Form_Endpoint( 'feedback' );
 
-		add_filter(
-			'posts_request',
-			function ( $sql ) use ( &$captured_sql ) {
-				$captured_sql = $sql;
-				return $sql;
-			},
-			99
-		);
+		// Use reflection to call private get_source_filter_sql method.
+		$method = new \ReflectionMethod( $endpoint, 'get_source_filter_sql' );
+		$method->setAccessible( true );
+		$sql = $method->invoke( $endpoint, 42 );
 
-		$request = new WP_REST_Request( 'GET', '/wp/v2/feedback' );
-		$request->set_param( 'source', 42 );
-		$this->server->dispatch( $request );
+		$this->assertArrayHasKey( 'join', $sql );
+		$this->assertArrayHasKey( 'where', $sql );
 
-		$this->assertNotNull( $captured_sql, 'SQL query should have been built' );
-		$this->assertStringContainsString( 'source_meta', $captured_sql, 'SQL should include the source_meta alias' );
-		$this->assertStringContainsString( '_feedback_source_post_id', $captured_sql, 'SQL should reference the source meta key' );
-		$this->assertStringContainsString( 'source_meta.meta_value', $captured_sql, 'SQL should filter by source meta value' );
-		$this->assertStringContainsString( 'post_parent', $captured_sql, 'SQL should include post_parent fallback' );
-		$this->assertStringContainsString( 'source_meta.meta_id IS NULL', $captured_sql, 'SQL should check for missing meta in fallback' );
+		$this->assertStringContainsString( 'source_meta', $sql['join'], 'JOIN should include the source_meta alias' );
+		$this->assertStringContainsString( '_feedback_source_post_id', $sql['join'], 'JOIN should reference the source meta key' );
 
-		remove_all_filters( 'posts_request' );
+		$this->assertStringContainsString( 'source_meta.meta_value', $sql['where'], 'WHERE should filter by source meta value' );
+		$this->assertStringContainsString( 'post_parent', $sql['where'], 'WHERE should include post_parent fallback' );
+		$this->assertStringContainsString( 'source_meta.meta_id IS NULL', $sql['where'], 'WHERE should check for missing meta in fallback' );
+		$this->assertStringContainsString( "'42'", $sql['where'], 'WHERE should include the source ID value' );
 	}
 
 	/**
@@ -1409,44 +1382,77 @@ JSON_DATA{"1_name":"Test Author","2_email":"author@example.com","3_file":{"field
 		$this->server->dispatch( $request );
 
 		// Second request without source — capture SQL to verify no leftover filter.
-		$captured_sql = '';
+		$found_source_sql = false;
 		add_filter(
-			'posts_request',
-			function ( $sql ) use ( &$captured_sql ) {
-				$captured_sql = $sql;
-				return $sql;
+			'wordbless_wpdb_query_results',
+			function ( $results, $query ) use ( &$found_source_sql ) {
+				if ( strpos( $query, 'source_meta' ) !== false ) {
+					$found_source_sql = true;
+				}
+				return $results;
 			},
-			99
+			10,
+			2
 		);
 
 		$request2 = new WP_REST_Request( 'GET', '/wp/v2/feedback' );
 		$this->server->dispatch( $request2 );
 
-		$this->assertStringNotContainsString( 'source_meta', $captured_sql, 'Source filter should not leak into subsequent requests' );
+		$this->assertFalse( $found_source_sql, 'Source filter should not leak into subsequent requests' );
 
-		remove_all_filters( 'posts_request' );
+		remove_all_filters( 'wordbless_wpdb_query_results' );
 	}
 
 	/**
 	 * Test that without source param, no source filter hooks are added.
 	 */
 	public function test_no_source_filter_without_param() {
-		$captured_sql = '';
+		$found_source_sql = false;
 
 		add_filter(
-			'posts_request',
-			function ( $sql ) use ( &$captured_sql ) {
-				$captured_sql = $sql;
-				return $sql;
+			'wordbless_wpdb_query_results',
+			function ( $results, $query ) use ( &$found_source_sql ) {
+				if ( strpos( $query, 'source_meta' ) !== false ) {
+					$found_source_sql = true;
+				}
+				return $results;
 			},
-			99
+			10,
+			2
 		);
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/feedback' );
 		$this->server->dispatch( $request );
 
-		$this->assertStringNotContainsString( 'source_meta', $captured_sql, 'SQL should not include source_meta when no source param' );
+		$this->assertFalse( $found_source_sql, 'SQL should not include source_meta when no source param' );
 
-		remove_all_filters( 'posts_request' );
+		remove_all_filters( 'wordbless_wpdb_query_results' );
+	}
+
+	/**
+	 * Test that source=0 does not inject source filter SQL.
+	 */
+	public function test_source_filter_with_zero_value_is_ignored() {
+		$found_source_sql = false;
+
+		add_filter(
+			'wordbless_wpdb_query_results',
+			function ( $results, $query ) use ( &$found_source_sql ) {
+				if ( strpos( $query, 'source_meta' ) !== false ) {
+					$found_source_sql = true;
+				}
+				return $results;
+			},
+			10,
+			2
+		);
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/feedback' );
+		$request->set_param( 'source', 0 );
+		$this->server->dispatch( $request );
+
+		$this->assertFalse( $found_source_sql, 'source=0 should not inject source filter SQL' );
+
+		remove_all_filters( 'wordbless_wpdb_query_results' );
 	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -1356,7 +1356,10 @@ JSON_DATA{"1_name":"Test Author","2_email":"author@example.com","3_file":{"field
 
 		// Use reflection to call private get_source_filter_sql method.
 		$method = new \ReflectionMethod( $endpoint, 'get_source_filter_sql' );
-		$sql    = $method->invoke( $endpoint, 42 );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+		$sql = $method->invoke( $endpoint, 42 );
 
 		$this->assertArrayHasKey( 'join', $sql );
 		$this->assertArrayHasKey( 'where', $sql );

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -1290,4 +1290,177 @@ JSON_DATA{"1_name":"Test Author","2_email":"author@example.com","3_file":{"field
 		$this->assertArrayHasKey( 'logged_in_user', $data );
 		$this->assertNull( $data['logged_in_user'] );
 	}
+
+	/**
+	 * Test that the source parameter is registered in the feedback collection schema.
+	 */
+	public function test_source_parameter_is_registered() {
+		$request  = new WP_REST_Request( 'OPTIONS', '/wp/v2/feedback' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertArrayHasKey( 'source', $data['endpoints'][0]['args'] );
+		$this->assertEquals( 'integer', $data['endpoints'][0]['args']['source']['type'] );
+	}
+
+	/**
+	 * Test that the source parameter is registered in the counts endpoint.
+	 */
+	public function test_source_parameter_is_registered_in_counts() {
+		$request  = new WP_REST_Request( 'OPTIONS', '/wp/v2/feedback/counts' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertArrayHasKey( 'source', $data['endpoints'][0]['args'] );
+		$this->assertEquals( 'integer', $data['endpoints'][0]['args']['source']['type'] );
+	}
+
+	/**
+	 * Test that the source filter accepts a valid source parameter without error.
+	 */
+	public function test_source_filter_returns_200() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/feedback' );
+		$request->set_param( 'source', 123 );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
+	 * Test that the counts endpoint accepts source parameter without error.
+	 */
+	public function test_counts_with_source_returns_200() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/feedback/counts' );
+		$request->set_param( 'source', 123 );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'inbox', $data );
+		$this->assertArrayHasKey( 'spam', $data );
+		$this->assertArrayHasKey( 'trash', $data );
+	}
+
+	/**
+	 * Test that SOURCE_META_KEY constant is defined on Feedback class.
+	 */
+	public function test_source_meta_key_constant_exists() {
+		$this->assertEquals( '_feedback_source_post_id', Feedback::SOURCE_META_KEY );
+	}
+
+	/**
+	 * Test that the source filter returns only feedback matching the source post ID.
+	 */
+	public function test_source_filter_returns_matching_feedback() {
+		$source_a = wp_insert_post(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'Page A',
+			)
+		);
+		$source_b = wp_insert_post(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'Page B',
+			)
+		);
+
+		// Feedback with source meta pointing to page A.
+		$fb_a = wp_insert_post(
+			array(
+				'post_type'      => 'feedback',
+				'post_status'    => 'publish',
+				'post_title'     => 'Feedback from Page A',
+				'comment_status' => 'open',
+			)
+		);
+		update_post_meta( $fb_a, Feedback::SOURCE_META_KEY, $source_a );
+
+		// Feedback with source meta pointing to page B.
+		$fb_b = wp_insert_post(
+			array(
+				'post_type'      => 'feedback',
+				'post_status'    => 'publish',
+				'post_title'     => 'Feedback from Page B',
+				'comment_status' => 'open',
+			)
+		);
+		update_post_meta( $fb_b, Feedback::SOURCE_META_KEY, $source_b );
+
+		// Filter by source A — should only return feedback A.
+		$request = new WP_REST_Request( 'GET', '/wp/v2/feedback' );
+		$request->set_param( 'source', $source_a );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$ids  = array_column( $data, 'id' );
+		$this->assertContains( $fb_a, $ids, 'Should include feedback from source A' );
+		$this->assertNotContains( $fb_b, $ids, 'Should not include feedback from source B' );
+	}
+
+	/**
+	 * Test that the source filter falls back to post_parent for old feedback without source meta.
+	 */
+	public function test_source_filter_falls_back_to_post_parent() {
+		$source_page = wp_insert_post(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'Old Contact Page',
+			)
+		);
+
+		// Old feedback: no source meta, post_parent points to the source page (classic form behavior).
+		$fb_old = wp_insert_post(
+			array(
+				'post_type'      => 'feedback',
+				'post_status'    => 'publish',
+				'post_title'     => 'Old Feedback',
+				'post_parent'    => $source_page,
+				'comment_status' => 'open',
+			)
+		);
+
+		// New feedback on same source: has meta.
+		$fb_new = wp_insert_post(
+			array(
+				'post_type'      => 'feedback',
+				'post_status'    => 'publish',
+				'post_title'     => 'New Feedback',
+				'comment_status' => 'open',
+			)
+		);
+		update_post_meta( $fb_new, Feedback::SOURCE_META_KEY, $source_page );
+
+		// Unrelated feedback on a different page.
+		$other_page = wp_insert_post(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'Other Page',
+			)
+		);
+		$fb_other   = wp_insert_post(
+			array(
+				'post_type'      => 'feedback',
+				'post_status'    => 'publish',
+				'post_title'     => 'Other Feedback',
+				'post_parent'    => $other_page,
+				'comment_status' => 'open',
+			)
+		);
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/feedback' );
+		$request->set_param( 'source', $source_page );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$ids = array_column( $response->get_data(), 'id' );
+		$this->assertContains( $fb_old, $ids, 'Should include old feedback via post_parent fallback' );
+		$this->assertContains( $fb_new, $ids, 'Should include new feedback via source meta' );
+		$this->assertNotContains( $fb_other, $ids, 'Should not include feedback from a different source' );
+	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -1348,9 +1348,6 @@ JSON_DATA{"1_name":"Test Author","2_email":"author@example.com","3_file":{"field
 	/**
 	 * Test that the source filter adds the correct SQL JOIN and WHERE clauses.
 	 */
-	/**
-	 * Test that the source filter generates the correct SQL via get_source_filter_sql.
-	 */
 	public function test_source_filter_modifies_query() {
 		$endpoint = new Contact_Form_Endpoint( 'feedback' );
 

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -1349,118 +1349,95 @@ JSON_DATA{"1_name":"Test Author","2_email":"author@example.com","3_file":{"field
 	}
 
 	/**
-	 * Test that the source filter returns only feedback matching the source post ID.
+	 * Test that the source filter adds the correct SQL JOIN and WHERE clauses.
 	 */
-	public function test_source_filter_returns_matching_feedback() {
-		$source_a = wp_insert_post(
-			array(
-				'post_type'   => 'page',
-				'post_status' => 'publish',
-				'post_title'  => 'Page A',
-			)
+	public function test_source_filter_modifies_query() {
+		$captured_join  = null;
+		$captured_where = null;
+
+		add_filter(
+			'posts_join',
+			function ( $join ) use ( &$captured_join ) {
+				$captured_join = $join;
+				return $join;
+			},
+			99
 		);
-		$source_b = wp_insert_post(
-			array(
-				'post_type'   => 'page',
-				'post_status' => 'publish',
-				'post_title'  => 'Page B',
-			)
+		add_filter(
+			'posts_where',
+			function ( $where ) use ( &$captured_where ) {
+				$captured_where = $where;
+				return $where;
+			},
+			99
 		);
 
-		// Feedback with source meta pointing to page A.
-		$fb_a = wp_insert_post(
-			array(
-				'post_type'      => 'feedback',
-				'post_status'    => 'publish',
-				'post_title'     => 'Feedback from Page A',
-				'comment_status' => 'open',
-			)
-		);
-		update_post_meta( $fb_a, Feedback::SOURCE_META_KEY, $source_a );
-
-		// Feedback with source meta pointing to page B.
-		$fb_b = wp_insert_post(
-			array(
-				'post_type'      => 'feedback',
-				'post_status'    => 'publish',
-				'post_title'     => 'Feedback from Page B',
-				'comment_status' => 'open',
-			)
-		);
-		update_post_meta( $fb_b, Feedback::SOURCE_META_KEY, $source_b );
-
-		// Filter by source A — should only return feedback A.
 		$request = new WP_REST_Request( 'GET', '/wp/v2/feedback' );
-		$request->set_param( 'source', $source_a );
-		$response = $this->server->dispatch( $request );
+		$request->set_param( 'source', 42 );
+		$this->server->dispatch( $request );
 
-		$this->assertEquals( 200, $response->get_status() );
-		$data = $response->get_data();
-		$ids  = array_column( $data, 'id' );
-		$this->assertContains( $fb_a, $ids, 'Should include feedback from source A' );
-		$this->assertNotContains( $fb_b, $ids, 'Should not include feedback from source B' );
+		$this->assertNotNull( $captured_join, 'JOIN clause should have been modified' );
+		$this->assertStringContainsString( 'source_meta', $captured_join, 'JOIN should include the source_meta alias' );
+		$this->assertStringContainsString( '_feedback_source_post_id', $captured_join, 'JOIN should reference the source meta key' );
+
+		$this->assertNotNull( $captured_where, 'WHERE clause should have been modified' );
+		$this->assertStringContainsString( 'source_meta.meta_value', $captured_where, 'WHERE should filter by source meta value' );
+		$this->assertStringContainsString( 'post_parent', $captured_where, 'WHERE should include post_parent fallback' );
+		$this->assertStringContainsString( 'source_meta.meta_id IS NULL', $captured_where, 'WHERE should check for missing meta in fallback' );
+
+		remove_all_filters( 'posts_join' );
+		remove_all_filters( 'posts_where' );
 	}
 
 	/**
-	 * Test that the source filter falls back to post_parent for old feedback without source meta.
+	 * Test that source filter hooks are cleaned up after get_items
+	 * by verifying a second request without source does not include source SQL.
 	 */
-	public function test_source_filter_falls_back_to_post_parent() {
-		$source_page = wp_insert_post(
-			array(
-				'post_type'   => 'page',
-				'post_status' => 'publish',
-				'post_title'  => 'Old Contact Page',
-			)
+	public function test_source_filter_hooks_are_cleaned_up() {
+		// First request with source filter.
+		$request = new WP_REST_Request( 'GET', '/wp/v2/feedback' );
+		$request->set_param( 'source', 42 );
+		$this->server->dispatch( $request );
+
+		// Second request without source — capture the JOIN to verify no leftover filter.
+		$captured_join = '';
+		add_filter(
+			'posts_join',
+			function ( $join ) use ( &$captured_join ) {
+				$captured_join = $join;
+				return $join;
+			},
+			99
 		);
 
-		// Old feedback: no source meta, post_parent points to the source page (classic form behavior).
-		$fb_old = wp_insert_post(
-			array(
-				'post_type'      => 'feedback',
-				'post_status'    => 'publish',
-				'post_title'     => 'Old Feedback',
-				'post_parent'    => $source_page,
-				'comment_status' => 'open',
-			)
-		);
+		$request2 = new WP_REST_Request( 'GET', '/wp/v2/feedback' );
+		$this->server->dispatch( $request2 );
 
-		// New feedback on same source: has meta.
-		$fb_new = wp_insert_post(
-			array(
-				'post_type'      => 'feedback',
-				'post_status'    => 'publish',
-				'post_title'     => 'New Feedback',
-				'comment_status' => 'open',
-			)
-		);
-		update_post_meta( $fb_new, Feedback::SOURCE_META_KEY, $source_page );
+		$this->assertStringNotContainsString( 'source_meta', $captured_join, 'Source filter should not leak into subsequent requests' );
 
-		// Unrelated feedback on a different page.
-		$other_page = wp_insert_post(
-			array(
-				'post_type'   => 'page',
-				'post_status' => 'publish',
-				'post_title'  => 'Other Page',
-			)
-		);
-		$fb_other   = wp_insert_post(
-			array(
-				'post_type'      => 'feedback',
-				'post_status'    => 'publish',
-				'post_title'     => 'Other Feedback',
-				'post_parent'    => $other_page,
-				'comment_status' => 'open',
-			)
+		remove_all_filters( 'posts_join' );
+	}
+
+	/**
+	 * Test that without source param, no source filter hooks are added.
+	 */
+	public function test_no_source_filter_without_param() {
+		$captured_join = '';
+
+		add_filter(
+			'posts_join',
+			function ( $join ) use ( &$captured_join ) {
+				$captured_join = $join;
+				return $join;
+			},
+			99
 		);
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/feedback' );
-		$request->set_param( 'source', $source_page );
-		$response = $this->server->dispatch( $request );
+		$this->server->dispatch( $request );
 
-		$this->assertEquals( 200, $response->get_status() );
-		$ids = array_column( $response->get_data(), 'id' );
-		$this->assertContains( $fb_old, $ids, 'Should include old feedback via post_parent fallback' );
-		$this->assertContains( $fb_new, $ids, 'Should include new feedback via source meta' );
-		$this->assertNotContains( $fb_other, $ids, 'Should not include feedback from a different source' );
+		$this->assertStringNotContainsString( 'source_meta', $captured_join, 'JOIN should not include source_meta when no source param' );
+
+		remove_all_filters( 'posts_join' );
 	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -1356,8 +1356,7 @@ JSON_DATA{"1_name":"Test Author","2_email":"author@example.com","3_file":{"field
 
 		// Use reflection to call private get_source_filter_sql method.
 		$method = new \ReflectionMethod( $endpoint, 'get_source_filter_sql' );
-		$method->setAccessible( true );
-		$sql = $method->invoke( $endpoint, 42 );
+		$sql    = $method->invoke( $endpoint, 42 );
 
 		$this->assertArrayHasKey( 'join', $sql );
 		$this->assertArrayHasKey( 'where', $sql );

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Creation_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Creation_Test.php
@@ -22,6 +22,14 @@ use WorDBless\BaseTestCase;
 #[CoversClass( Feedback::class )]
 class Feedback_Creation_Test extends BaseTestCase {
 
+	/**
+	 * Clean up after each test.
+	 */
+	protected function tear_down() {
+		parent::tear_down();
+		remove_all_filters( 'wordbless_wpdb_query_results' );
+	}
+
 	public function test_from_post_id_returns_null_for_invalid_post() {
 		$response = Feedback::get( 999999 );
 		$this->assertNull( $response );
@@ -86,10 +94,35 @@ class Feedback_Creation_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Helper: mock wpdb query results for get_all_source_post_ids().
+	 *
+	 * @param array $source_ids The source IDs to return from the query.
+	 */
+	private function mock_source_ids_query( $source_ids ) {
+		add_filter(
+			'wordbless_wpdb_query_results',
+			function ( $results, $query ) use ( $source_ids ) {
+				if ( strpos( $query, 'SELECT DISTINCT source_id' ) !== false ) {
+					return array_map(
+						function ( $id ) {
+							return (object) array( 'source_id' => (string) $id );
+						},
+						$source_ids
+					);
+				}
+				return $results;
+			},
+			10,
+			2
+		);
+	}
+
+	/**
 	 * Test that get_all_source_post_ids returns empty array when no feedback exists.
 	 */
 	public function test_get_all_source_post_ids_returns_empty_when_no_feedback() {
 		\wp_cache_delete( 'jetpack_forms_source_post_ids', 'jetpack_forms' );
+		$this->mock_source_ids_query( array() );
 
 		$source_ids = Feedback::get_all_source_post_ids();
 		$this->assertIsArray( $source_ids );
@@ -97,177 +130,68 @@ class Feedback_Creation_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test that get_all_source_post_ids returns source IDs from meta.
+	 * Test that get_all_source_post_ids returns source IDs from the query.
 	 */
-	public function test_get_all_source_post_ids_returns_ids_from_meta() {
+	public function test_get_all_source_post_ids_returns_ids() {
 		\wp_cache_delete( 'jetpack_forms_source_post_ids', 'jetpack_forms' );
-
-		$page_id = \wp_insert_post(
-			array(
-				'post_type'   => 'page',
-				'post_status' => 'publish',
-				'post_title'  => 'Source Page',
-			)
-		);
-
-		$fb_id = \wp_insert_post(
-			array(
-				'post_type'   => 'feedback',
-				'post_status' => 'publish',
-				'post_title'  => 'Feedback',
-			)
-		);
-		\update_post_meta( $fb_id, Feedback::SOURCE_META_KEY, $page_id );
+		$this->mock_source_ids_query( array( 42, 99 ) );
 
 		$source_ids = Feedback::get_all_source_post_ids();
-		$this->assertContains( $page_id, $source_ids );
+		$this->assertContains( 42, $source_ids );
+		$this->assertContains( 99, $source_ids );
 	}
 
 	/**
-	 * Test that get_all_source_post_ids falls back to post_parent for old feedback without meta.
-	 */
-	public function test_get_all_source_post_ids_falls_back_to_post_parent() {
-		\wp_cache_delete( 'jetpack_forms_source_post_ids', 'jetpack_forms' );
-
-		$page_id = \wp_insert_post(
-			array(
-				'post_type'   => 'page',
-				'post_status' => 'publish',
-				'post_title'  => 'Old Source Page',
-			)
-		);
-
-		// Old feedback: no source meta, post_parent points to the page.
-		\wp_insert_post(
-			array(
-				'post_type'   => 'feedback',
-				'post_status' => 'publish',
-				'post_title'  => 'Old Feedback',
-				'post_parent' => $page_id,
-			)
-		);
-
-		$source_ids = Feedback::get_all_source_post_ids();
-		$this->assertContains( $page_id, $source_ids );
-	}
-
-	/**
-	 * Test that get_all_source_post_ids excludes jetpack_form parents from the fallback.
-	 */
-	public function test_get_all_source_post_ids_excludes_jetpack_form_parents() {
-		\wp_cache_delete( 'jetpack_forms_source_post_ids', 'jetpack_forms' );
-
-		$form_id = \wp_insert_post(
-			array(
-				'post_type'   => Contact_Form::POST_TYPE,
-				'post_status' => 'publish',
-				'post_title'  => 'My Form',
-			)
-		);
-
-		// Feedback parented to a jetpack_form — should not appear as a source.
-		\wp_insert_post(
-			array(
-				'post_type'   => 'feedback',
-				'post_status' => 'publish',
-				'post_title'  => 'Form Feedback',
-				'post_parent' => $form_id,
-			)
-		);
-
-		$source_ids = Feedback::get_all_source_post_ids();
-		$this->assertNotContains( $form_id, $source_ids );
-	}
-
-	/**
-	 * Test that get_all_source_post_ids deduplicates IDs from meta and post_parent.
-	 */
-	public function test_get_all_source_post_ids_deduplicates() {
-		\wp_cache_delete( 'jetpack_forms_source_post_ids', 'jetpack_forms' );
-
-		$page_id = \wp_insert_post(
-			array(
-				'post_type'   => 'page',
-				'post_status' => 'publish',
-				'post_title'  => 'Shared Source',
-			)
-		);
-
-		// Old feedback via post_parent (no meta).
-		\wp_insert_post(
-			array(
-				'post_type'   => 'feedback',
-				'post_status' => 'publish',
-				'post_title'  => 'Old Feedback',
-				'post_parent' => $page_id,
-			)
-		);
-
-		// New feedback via meta.
-		$fb_new = \wp_insert_post(
-			array(
-				'post_type'   => 'feedback',
-				'post_status' => 'publish',
-				'post_title'  => 'New Feedback',
-			)
-		);
-		\update_post_meta( $fb_new, Feedback::SOURCE_META_KEY, $page_id );
-
-		$source_ids = Feedback::get_all_source_post_ids();
-		$this->assertCount( 1, array_keys( $source_ids, $page_id, true ), 'Source ID should appear only once' );
-	}
-
-	/**
-	 * Test that get_all_source_post_ids uses cache on second call.
+	 * Test that get_all_source_post_ids caches the result.
 	 */
 	public function test_get_all_source_post_ids_uses_cache() {
 		\wp_cache_delete( 'jetpack_forms_source_post_ids', 'jetpack_forms' );
-
-		$page_id = \wp_insert_post(
-			array(
-				'post_type'   => 'page',
-				'post_status' => 'publish',
-				'post_title'  => 'Cached Page',
-			)
-		);
-
-		$fb_id = \wp_insert_post(
-			array(
-				'post_type'   => 'feedback',
-				'post_status' => 'publish',
-				'post_title'  => 'Feedback',
-			)
-		);
-		\update_post_meta( $fb_id, Feedback::SOURCE_META_KEY, $page_id );
+		$this->mock_source_ids_query( array( 42 ) );
 
 		// First call populates cache.
 		$first_result = Feedback::get_all_source_post_ids();
+		$this->assertContains( 42, $first_result );
 
-		// Add new feedback with a different source — cache should still return old result.
-		$page_id_2 = \wp_insert_post(
-			array(
-				'post_type'   => 'page',
-				'post_status' => 'publish',
-				'post_title'  => 'New Page',
-			)
-		);
-		$fb_id_2   = \wp_insert_post(
-			array(
-				'post_type'   => 'feedback',
-				'post_status' => 'publish',
-				'post_title'  => 'Feedback 2',
-			)
-		);
-		\update_post_meta( $fb_id_2, Feedback::SOURCE_META_KEY, $page_id_2 );
+		// Replace mock with different data — cache should still return old result.
+		remove_all_filters( 'wordbless_wpdb_query_results' );
+		$this->mock_source_ids_query( array( 42, 99 ) );
 
 		$second_result = Feedback::get_all_source_post_ids();
 		$this->assertEquals( $first_result, $second_result, 'Second call should return cached result' );
-		$this->assertNotContains( $page_id_2, $second_result, 'New source should not appear in cached result' );
+		$this->assertNotContains( 99, $second_result, 'New source should not appear in cached result' );
 
-		// After cache clear, new source should appear.
+		// After cache clear, new data should appear.
 		\wp_cache_delete( 'jetpack_forms_source_post_ids', 'jetpack_forms' );
 		$fresh_result = Feedback::get_all_source_post_ids();
-		$this->assertContains( $page_id_2, $fresh_result, 'After cache clear, new source should appear' );
+		$this->assertContains( 99, $fresh_result, 'After cache clear, new source should appear' );
+	}
+
+	/**
+	 * Test that get_all_source_post_ids query includes the correct SQL structure.
+	 */
+	public function test_get_all_source_post_ids_query_uses_union_with_fallback() {
+		\wp_cache_delete( 'jetpack_forms_source_post_ids', 'jetpack_forms' );
+
+		$captured_query = null;
+		add_filter(
+			'wordbless_wpdb_query_results',
+			function ( $results, $query ) use ( &$captured_query ) {
+				if ( strpos( $query, 'SELECT DISTINCT source_id' ) !== false ) {
+					$captured_query = $query;
+				}
+				return $results;
+			},
+			10,
+			2
+		);
+
+		Feedback::get_all_source_post_ids();
+
+		$this->assertNotNull( $captured_query, 'Source IDs query should have been executed' );
+		$this->assertStringContainsString( '_feedback_source_post_id', $captured_query, 'Query should use the source meta key' );
+		$this->assertStringContainsString( 'UNION', $captured_query, 'Query should use UNION for meta + post_parent fallback' );
+		$this->assertStringContainsString( 'post_parent', $captured_query, 'Query should include post_parent fallback' );
+		$this->assertStringContainsString( Contact_Form::POST_TYPE, $captured_query, 'Query should exclude jetpack_form parents' );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Creation_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Creation_Test.php
@@ -167,9 +167,9 @@ class Feedback_Creation_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test that get_all_source_post_ids query includes the correct SQL structure.
+	 * Test that get_all_source_post_ids query references both meta and post_parent.
 	 */
-	public function test_get_all_source_post_ids_query_uses_union_with_fallback() {
+	public function test_get_all_source_post_ids_query_includes_meta_and_fallback() {
 		\wp_cache_delete( 'jetpack_forms_source_post_ids', 'jetpack_forms' );
 
 		$captured_query = null;
@@ -189,7 +189,6 @@ class Feedback_Creation_Test extends BaseTestCase {
 
 		$this->assertNotNull( $captured_query, 'Source IDs query should have been executed' );
 		$this->assertStringContainsString( '_feedback_source_post_id', $captured_query, 'Query should use the source meta key' );
-		$this->assertStringContainsString( 'UNION', $captured_query, 'Query should use UNION for meta + post_parent fallback' );
 		$this->assertStringContainsString( 'post_parent', $captured_query, 'Query should include post_parent fallback' );
 		$this->assertStringContainsString( Contact_Form::POST_TYPE, $captured_query, 'Query should exclude jetpack_form parents' );
 	}

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Creation_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Creation_Test.php
@@ -52,4 +52,249 @@ class Feedback_Creation_Test extends BaseTestCase {
 		$response   = Feedback::from_submission( $_post_data, $form );
 		$this->assertInstanceOf( Feedback::class, $response );
 	}
+
+	public function test_save_stores_source_meta() {
+		$_SERVER['REMOTE_ADDR']     = '127.0.0.1';
+		$_SERVER['HTTP_USER_AGENT'] = 'unit-test';
+		$_SERVER['HTTP_REFERER']    = 'test';
+
+		// Create a source post to serve as the page context.
+		$source_post_id = \wp_insert_post(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'Contact Page',
+			)
+		);
+		$source_post    = \get_post( $source_post_id );
+
+		$form       = new Contact_Form( array() );
+		$_post_data = array(
+			'name'  => 'Jane Doe',
+			'email' => 'jane@example.com',
+		);
+		$feedback   = Feedback::from_submission( $_post_data, $form, $source_post );
+		$result     = $feedback->save();
+
+		$this->assertNotEquals( 0, $result );
+
+		$saved_post = is_object( $result ) ? $result : \get_post( $result );
+		$this->assertNotNull( $saved_post );
+
+		$source_meta = \get_post_meta( $saved_post->ID, Feedback::SOURCE_META_KEY, true );
+		$this->assertEquals( $source_post_id, (int) $source_meta, 'Source meta should be set to the source page ID' );
+	}
+
+	/**
+	 * Test that get_all_source_post_ids returns empty array when no feedback exists.
+	 */
+	public function test_get_all_source_post_ids_returns_empty_when_no_feedback() {
+		\wp_cache_delete( 'jetpack_forms_source_post_ids', 'jetpack_forms' );
+
+		$source_ids = Feedback::get_all_source_post_ids();
+		$this->assertIsArray( $source_ids );
+		$this->assertEmpty( $source_ids );
+	}
+
+	/**
+	 * Test that get_all_source_post_ids returns source IDs from meta.
+	 */
+	public function test_get_all_source_post_ids_returns_ids_from_meta() {
+		\wp_cache_delete( 'jetpack_forms_source_post_ids', 'jetpack_forms' );
+
+		$page_id = \wp_insert_post(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'Source Page',
+			)
+		);
+
+		$fb_id = \wp_insert_post(
+			array(
+				'post_type'   => 'feedback',
+				'post_status' => 'publish',
+				'post_title'  => 'Feedback',
+			)
+		);
+		\update_post_meta( $fb_id, Feedback::SOURCE_META_KEY, $page_id );
+
+		$source_ids = Feedback::get_all_source_post_ids();
+		$this->assertContains( $page_id, $source_ids );
+	}
+
+	/**
+	 * Test that get_all_source_post_ids falls back to post_parent for old feedback without meta.
+	 */
+	public function test_get_all_source_post_ids_falls_back_to_post_parent() {
+		\wp_cache_delete( 'jetpack_forms_source_post_ids', 'jetpack_forms' );
+
+		$page_id = \wp_insert_post(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'Old Source Page',
+			)
+		);
+
+		// Old feedback: no source meta, post_parent points to the page.
+		\wp_insert_post(
+			array(
+				'post_type'   => 'feedback',
+				'post_status' => 'publish',
+				'post_title'  => 'Old Feedback',
+				'post_parent' => $page_id,
+			)
+		);
+
+		$source_ids = Feedback::get_all_source_post_ids();
+		$this->assertContains( $page_id, $source_ids );
+	}
+
+	/**
+	 * Test that get_all_source_post_ids excludes jetpack_form parents from the fallback.
+	 */
+	public function test_get_all_source_post_ids_excludes_jetpack_form_parents() {
+		\wp_cache_delete( 'jetpack_forms_source_post_ids', 'jetpack_forms' );
+
+		$form_id = \wp_insert_post(
+			array(
+				'post_type'   => Contact_Form::POST_TYPE,
+				'post_status' => 'publish',
+				'post_title'  => 'My Form',
+			)
+		);
+
+		// Feedback parented to a jetpack_form — should not appear as a source.
+		\wp_insert_post(
+			array(
+				'post_type'   => 'feedback',
+				'post_status' => 'publish',
+				'post_title'  => 'Form Feedback',
+				'post_parent' => $form_id,
+			)
+		);
+
+		$source_ids = Feedback::get_all_source_post_ids();
+		$this->assertNotContains( $form_id, $source_ids );
+	}
+
+	/**
+	 * Test that get_all_source_post_ids deduplicates IDs from meta and post_parent.
+	 */
+	public function test_get_all_source_post_ids_deduplicates() {
+		\wp_cache_delete( 'jetpack_forms_source_post_ids', 'jetpack_forms' );
+
+		$page_id = \wp_insert_post(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'Shared Source',
+			)
+		);
+
+		// Old feedback via post_parent (no meta).
+		\wp_insert_post(
+			array(
+				'post_type'   => 'feedback',
+				'post_status' => 'publish',
+				'post_title'  => 'Old Feedback',
+				'post_parent' => $page_id,
+			)
+		);
+
+		// New feedback via meta.
+		$fb_new = \wp_insert_post(
+			array(
+				'post_type'   => 'feedback',
+				'post_status' => 'publish',
+				'post_title'  => 'New Feedback',
+			)
+		);
+		\update_post_meta( $fb_new, Feedback::SOURCE_META_KEY, $page_id );
+
+		$source_ids = Feedback::get_all_source_post_ids();
+		$this->assertCount( 1, array_keys( $source_ids, $page_id, true ), 'Source ID should appear only once' );
+	}
+
+	/**
+	 * Test that get_all_source_post_ids uses cache on second call.
+	 */
+	public function test_get_all_source_post_ids_uses_cache() {
+		\wp_cache_delete( 'jetpack_forms_source_post_ids', 'jetpack_forms' );
+
+		$page_id = \wp_insert_post(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'Cached Page',
+			)
+		);
+
+		$fb_id = \wp_insert_post(
+			array(
+				'post_type'   => 'feedback',
+				'post_status' => 'publish',
+				'post_title'  => 'Feedback',
+			)
+		);
+		\update_post_meta( $fb_id, Feedback::SOURCE_META_KEY, $page_id );
+
+		// First call populates cache.
+		$first_result = Feedback::get_all_source_post_ids();
+
+		// Add new feedback with a different source — cache should still return old result.
+		$page_id_2 = \wp_insert_post(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'New Page',
+			)
+		);
+		$fb_id_2   = \wp_insert_post(
+			array(
+				'post_type'   => 'feedback',
+				'post_status' => 'publish',
+				'post_title'  => 'Feedback 2',
+			)
+		);
+		\update_post_meta( $fb_id_2, Feedback::SOURCE_META_KEY, $page_id_2 );
+
+		$second_result = Feedback::get_all_source_post_ids();
+		$this->assertEquals( $first_result, $second_result, 'Second call should return cached result' );
+		$this->assertNotContains( $page_id_2, $second_result, 'New source should not appear in cached result' );
+
+		// After cache clear, new source should appear.
+		\wp_cache_delete( 'jetpack_forms_source_post_ids', 'jetpack_forms' );
+		$fresh_result = Feedback::get_all_source_post_ids();
+		$this->assertContains( $page_id_2, $fresh_result, 'After cache clear, new source should appear' );
+	}
+
+	/**
+	 * Test that save() always invalidates the source IDs cache.
+	 */
+	public function test_save_invalidates_source_ids_cache() {
+		$_SERVER['REMOTE_ADDR']     = '127.0.0.1';
+		$_SERVER['HTTP_USER_AGENT'] = 'unit-test';
+		$_SERVER['HTTP_REFERER']    = 'test';
+
+		$page_id     = \wp_insert_post(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'Source Page',
+			)
+		);
+		$source_post = \get_post( $page_id );
+
+		// Seed the cache.
+		\wp_cache_set( 'jetpack_forms_source_post_ids', array( $page_id ), 'jetpack_forms' );
+
+		$form     = new Contact_Form( array() );
+		$feedback = Feedback::from_submission( array( 'name' => 'Test' ), $form, $source_post );
+		$feedback->save();
+
+		$cached = \wp_cache_get( 'jetpack_forms_source_post_ids', 'jetpack_forms' );
+		$this->assertFalse( $cached, 'Cache should be invalidated after save' );
+	}
 }


### PR DESCRIPTION
Fixes FORMS-671

The issue that this PR is trying to fix is the following. 

When a new feedback comes in from that is added via a synced form. We end up in the situation where we are not able to filter this feedback by source any more. 

The main issue is that source is ID is not stored as the post parent any more. Since the post parent is now the jetpack_form. 

This PR fixes this by setting the source ID on a post meta. This makes it possible to filter posts by query the post meta which gets stored when the feedback gets created. For backwards compatibility we also add the post meta when feedback that don't have it set yet. In the future versions we could remove the filtering by post_parent completely since most feedback will contain the source id in the post meta.

## Proposed changes

* Add a new `source` REST API query parameter to the feedback endpoints (`/wp/v2/feedback` and `/wp/v2/feedback/counts`) for filtering responses by the page/post they were submitted from.
* Store source post ID as `_feedback_source_post_id` meta on new feedback submissions using `add_post_meta`.
* Implement `get_all_source_post_ids()` on the `Feedback` class to populate the source filter dropdown, using meta with fallback to `post_parent` for legacy data (excluding `jetpack_form` parents).
* Add object caching for source post ID lookups with invalidation on feedback save, delete, and backfill.
* Lazily backfill `_feedback_source_post_id` meta for old feedback via `maybe_backfill_source_meta()`, called from `prepare_item_for_response()` — gradually migrates legacy data as it's served through the REST API.
* Extract shared `get_source_filter_sql()` helper to avoid duplicating JOIN/WHERE SQL between `get_counts()` and WP_Query filter hooks.
* Guard `join_source_meta` / `filter_by_source_id` with `post_type` check so they only modify feedback queries, not unrelated queries in the same request.
* Invalidate source IDs cache when a feedback post is permanently deleted (`deleted_post` hook).
* Update the JS dashboard (store, resolvers, hooks, stage views) to use the new `source` parameter instead of overloading `parent`.

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?

No. This adds a new post meta (`_feedback_source_post_id`) that stores the same source post ID that was previously only available via `post_parent`. No new tracking or external data collection.

## Testing instructions

1. Set up a site with the Jetpack Forms package.
2. Create two pages, each with a contact form. Submit feedback from both pages.
3. Go to the Forms dashboard (Responses view).
4. Use the "Source" filter dropdown — verify both source pages appear.
5. Select one source — verify only feedback from that page is shown.
6. Check the counts (inbox/spam/trash tabs) update correctly when a source filter is active.
7. Submit a new feedback entry — verify the source filter dropdown updates to include it.
8. Permanently delete all feedback from one source — verify that source disappears from the dropdown after cache refresh.
9. If you have old feedback (pre-existing before this PR), verify it still appears when filtering by source — the fallback to `post_parent` should handle legacy data, and it will be lazily backfilled with meta as it's served.
