### PR TITLE
storybook: Add missing `await`

### DIFF
--- a/projects/js-packages/storybook/changelog/try-storybook-missing-await
+++ b/projects/js-packages/storybook/changelog/try-storybook-missing-await
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add missing `await` in vitest config, which may be causing intermittent CI errors.

--- a/projects/js-packages/storybook/vitest.config.ts
+++ b/projects/js-packages/storybook/vitest.config.ts
@@ -15,7 +15,7 @@ export default defineConfig( {
 		projects: [
 			{
 				plugins: [
-					storybookTest( {
+					await storybookTest( {
 						configDir: `${ __dirname }/storybook`,
 						tags: {
 							skip: [ 'no-vitest' ],


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
We've been seeing occasional errors about
```
Failed to import test file .../@storybook/addon-vitest/dist/vitest-plugin/setup-file.js
```
Some upstream bug reports (e.g. 33664, 32895) suggest this is due to a missing `await`. Let's try adding that.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p1775755551544799-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* 🤷