### PR TITLE
Forms: Fix fatal error when field render value is an array

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-fatal-error
+++ b/projects/packages/forms/changelog/fix-forms-fatal-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent fatal error in get_legacy_extra_values when a field render value is an array

--- a/projects/packages/forms/changelog/fix-forms-fatal-error
+++ b/projects/packages/forms/changelog/fix-forms-fatal-error
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Prevent fatal error in get_legacy_extra_values when a field render value is an array
+Prevent fatal error when a non-checkbox field's render value or POST-submitted value is an array.

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -391,18 +391,11 @@ class Feedback {
 		}
 
 		if ( isset( $post_data[ $key ] ) ) {
-			$raw_value = wp_unslash( $post_data[ $key ] );
-
-			// Only checkbox-multiple legitimately accepts array values.
-			// For all other field types, take the first element if an array was submitted.
-			if ( is_array( $raw_value ) && $type !== 'checkbox-multiple' ) {
-				$raw_value = reset( $raw_value );
+			if ( is_array( $post_data[ $key ] ) ) {
+				return array_map( 'sanitize_textarea_field', wp_unslash( $post_data[ $key ] ) );
+			} else {
+				return sanitize_textarea_field( wp_unslash( $post_data[ $key ] ) );
 			}
-
-			if ( is_array( $raw_value ) ) {
-				return array_map( 'sanitize_textarea_field', $raw_value );
-			}
-			return sanitize_textarea_field( $raw_value );
 		}
 		return '';
 	}

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -649,10 +649,13 @@ class Feedback {
 		$special_fields   = array();
 		$non_extra_fields = array( 'email', 'name', 'url', 'subject', 'textarea', 'ip' );
 
-		// Create a map of special fields to check agains their values.
+		// Create a map of special fields to check against their values.
 		foreach ( $this->fields as $field ) {
-			if ( in_array( $field->get_type(), $non_extra_fields, true ) && $field->get_render_value( $context ) ) {
-				$special_fields[ $field->get_render_value( $context ) ] = true;
+			if ( in_array( $field->get_type(), $non_extra_fields, true ) ) {
+				$value = $field->get_render_value( $context );
+				if ( $value && ! is_array( $value ) ) {
+					$special_fields[ $value ] = true;
+				}
 			}
 		}
 
@@ -660,7 +663,8 @@ class Feedback {
 			if ( $field->compile_field( 'default' ) ) {
 				continue;
 			}
-			if ( $field->get_type() === 'basic' && isset( $special_fields[ $field->get_render_value() ] ) ) {
+			$render_value = $field->get_render_value();
+			if ( $field->get_type() === 'basic' && ! is_array( $render_value ) && isset( $special_fields[ $render_value ] ) ) {
 				++$count;
 				continue; // Skip fields that are already present in the non-extra fields.
 			}

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -391,11 +391,18 @@ class Feedback {
 		}
 
 		if ( isset( $post_data[ $key ] ) ) {
-			if ( is_array( $post_data[ $key ] ) ) {
-				return array_map( 'sanitize_textarea_field', wp_unslash( $post_data[ $key ] ) );
-			} else {
-				return sanitize_textarea_field( wp_unslash( $post_data[ $key ] ) );
+			$raw_value = wp_unslash( $post_data[ $key ] );
+
+			// Only checkbox-multiple legitimately accepts array values.
+			// For all other field types, take the first element if an array was submitted.
+			if ( is_array( $raw_value ) && $type !== 'checkbox-multiple' ) {
+				$raw_value = reset( $raw_value );
 			}
+
+			if ( is_array( $raw_value ) ) {
+				return array_map( 'sanitize_textarea_field', $raw_value );
+			}
+			return sanitize_textarea_field( $raw_value );
 		}
 		return '';
 	}
@@ -653,7 +660,10 @@ class Feedback {
 		foreach ( $this->fields as $field ) {
 			if ( in_array( $field->get_type(), $non_extra_fields, true ) ) {
 				$value = $field->get_render_value( $context );
-				if ( $value && ! is_array( $value ) ) {
+				if ( is_array( $value ) ) {
+					$value = reset( $value );
+				}
+				if ( $value ) {
 					$special_fields[ $value ] = true;
 				}
 			}
@@ -664,7 +674,10 @@ class Feedback {
 				continue;
 			}
 			$render_value = $field->get_render_value();
-			if ( $field->get_type() === 'basic' && ! is_array( $render_value ) && isset( $special_fields[ $render_value ] ) ) {
+			if ( is_array( $render_value ) ) {
+				$render_value = reset( $render_value );
+			}
+			if ( $field->get_type() === 'basic' && $render_value && isset( $special_fields[ $render_value ] ) ) {
 				++$count;
 				continue; // Skip fields that are already present in the non-extra fields.
 			}

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Legacy_Compatibility_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Legacy_Compatibility_Test.php
@@ -296,6 +296,36 @@ class Feedback_Legacy_Compatibility_Test extends BaseTestCase {
 		$this->assertEquals( '🙈', $response->get_field_value_by_label( 'message' ), 'Message field value should match' );
 	}
 
+	public function test_get_legacy_extra_values_with_array_post_data() {
+		$form_id    = Utility::get_form_id();
+		$_post_data = Utility::get_post_request(
+			array(
+				'email'   => array( 'first@example.com', 'second@example.com' ),
+				'name'    => 'Test User',
+				'message' => 'Hello, this is a test message.',
+			),
+			'g' . $form_id
+		);
+
+		$form = new Contact_Form(
+			array(
+				'title'       => 'Test Form',
+				'description' => 'This is a test form.',
+			),
+			"[contact-field label='Email' type='email' required='1'/][contact-field label='Name' type='name' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		$response = Feedback::from_submission( $_post_data, $form );
+
+		// This should not throw a TypeError even when the email field has array data.
+		$extra_values = $response->get_legacy_extra_values( 'submit' );
+		$this->assertIsArray( $extra_values, 'get_legacy_extra_values should return an array without fatal error' );
+
+		// Also test with default context.
+		$extra_values_default = $response->get_legacy_extra_values();
+		$this->assertIsArray( $extra_values_default, 'get_legacy_extra_values with default context should return an array without fatal error' );
+	}
+
 	public function test_escape_legacy_v2_special_characters_handeling() {
 		$post_id = Utility::create_legacy_feedback_v2(
 			array(

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Legacy_Compatibility_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Legacy_Compatibility_Test.php
@@ -363,6 +363,17 @@ class Feedback_Legacy_Compatibility_Test extends BaseTestCase {
 		$extra_values_submit = $response->get_legacy_extra_values( 'submit' );
 		$this->assertIsArray( $extra_values_submit, "get_legacy_extra_values(submit) should not fatal for {$type} with array value" );
 
+		// The Comment text field should appear in extra values with correct value.
+		$this->assertNotEmpty( $extra_values_submit, "Extra values should not be empty for {$type} with array value" );
+		$found_comment = false;
+		foreach ( $extra_values_submit as $value ) {
+			if ( $value === 'Hello world' ) {
+				$found_comment = true;
+				break;
+			}
+		}
+		$this->assertTrue( $found_comment, "Extra values should contain the Comment field value for {$type} test case" );
+
 		// 'default' context — implodes arrays to strings, verify it still works.
 		$extra_values_default = $response->get_legacy_extra_values( 'default' );
 		$this->assertIsArray( $extra_values_default, "get_legacy_extra_values(default) should not fatal for {$type} with array value" );
@@ -414,9 +425,19 @@ class Feedback_Legacy_Compatibility_Test extends BaseTestCase {
 		$value_default = $response->get_field_value_by_label( 'Colors', 'default' );
 		$this->assertEquals( 'red, blue, green', $value_default, 'checkbox-multiple value should be imploded in default context' );
 
-		// get_legacy_extra_values should work without fatal.
+		// get_legacy_extra_values should work without fatal and include the checkbox-multiple field.
 		$extra_values = $response->get_legacy_extra_values( 'submit' );
 		$this->assertIsArray( $extra_values, 'get_legacy_extra_values(submit) should work with checkbox-multiple' );
+
+		// checkbox-multiple is not in $non_extra_fields, so its value should appear in extra values.
+		$found_colors = false;
+		foreach ( $extra_values as $value ) {
+			if ( is_array( $value ) && $value === array( 'red', 'blue', 'green' ) ) {
+				$found_colors = true;
+				break;
+			}
+		}
+		$this->assertTrue( $found_colors, 'Extra values should contain the checkbox-multiple array value' );
 	}
 
 	public function test_escape_legacy_v2_special_characters_handeling() {

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Legacy_Compatibility_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Legacy_Compatibility_Test.php
@@ -317,11 +317,14 @@ class Feedback_Legacy_Compatibility_Test extends BaseTestCase {
 
 		$response = Feedback::from_submission( $_post_data, $form );
 
-		// This should not throw a TypeError even when the email field has array data.
+		// When an array is submitted for a single-value field like email,
+		// only the first value should be kept.
+		$this->assertEquals( 'first@example.com', $response->get_field_value_by_label( 'Email' ), 'Email field should use the first value from the array' );
+
+		// get_legacy_extra_values should not throw a TypeError.
 		$extra_values = $response->get_legacy_extra_values( 'submit' );
 		$this->assertIsArray( $extra_values, 'get_legacy_extra_values should return an array without fatal error' );
 
-		// Also test with default context.
 		$extra_values_default = $response->get_legacy_extra_values();
 		$this->assertIsArray( $extra_values_default, 'get_legacy_extra_values with default context should return an array without fatal error' );
 	}

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Legacy_Compatibility_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Legacy_Compatibility_Test.php
@@ -440,6 +440,64 @@ class Feedback_Legacy_Compatibility_Test extends BaseTestCase {
 		$this->assertTrue( $found_colors, 'Extra values should contain the checkbox-multiple array value' );
 	}
 
+	/**
+	 * Legacy v1 feedback stores checkbox-multiple values as JSON arrays in
+	 * post_content. When loaded, these become Feedback_Field objects with
+	 * type 'basic' (not 'checkbox-multiple') and an array value.
+	 *
+	 * Verify the full array is preserved through get_legacy_extra_values()
+	 * and not flattened to just the first element by the reset() guard.
+	 */
+	public function test_legacy_v1_checkbox_multiple_array_preserved() {
+		// In legacy v1 format, checkbox-multiple values are stored as JSON arrays.
+		// When loaded via process_legacy_values(), the field type becomes 'basic'.
+		$post_id = Utility::create_legacy_feedback(
+			array(
+				'1_Colors'  => array( 'red', 'blue', 'green' ),
+				'2_Name'    => 'Test User',
+				'3_Comment' => 'Hello world',
+			)
+		);
+
+		$response = Feedback::get( $post_id );
+		$this->assertInstanceOf( Feedback::class, $response );
+
+		// The array value should survive the round-trip through legacy format.
+		// In default context, get_render_default_value() implodes arrays to strings.
+		$value_default = $response->get_field_value_by_label( 'Colors', 'default' );
+		$this->assertEquals( 'red, blue, green', $value_default, 'Legacy v1 checkbox-multiple should be imploded in default context' );
+
+		// In submit context, get_render_submit_value() returns the raw value.
+		$value_submit = $response->get_field_value_by_label( 'Colors', 'submit' );
+		$this->assertIsArray( $value_submit, 'Legacy v1 checkbox-multiple should remain an array in submit context' );
+		$this->assertEquals( array( 'red', 'blue', 'green' ), $value_submit, 'Legacy v1 checkbox-multiple should preserve all values' );
+
+		// get_legacy_extra_values should not flatten the array via reset().
+		$extra_values_submit = $response->get_legacy_extra_values( 'submit' );
+		$this->assertIsArray( $extra_values_submit, 'get_legacy_extra_values(submit) should work with legacy checkbox-multiple' );
+
+		// The field should appear in extra values with all array items intact.
+		$found_colors = false;
+		foreach ( $extra_values_submit as $value ) {
+			if ( is_array( $value ) && $value === array( 'red', 'blue', 'green' ) ) {
+				$found_colors = true;
+				break;
+			}
+		}
+		$this->assertTrue( $found_colors, 'Legacy v1 checkbox-multiple array should not be flattened to first element' );
+
+		// Also verify default context preserves the imploded string.
+		$extra_values_default = $response->get_legacy_extra_values( 'default' );
+		$found_colors_string  = false;
+		foreach ( $extra_values_default as $value ) {
+			if ( $value === 'red, blue, green' ) {
+				$found_colors_string = true;
+				break;
+			}
+		}
+		$this->assertTrue( $found_colors_string, 'Legacy v1 checkbox-multiple should appear as imploded string in default context extra values' );
+	}
+
 	public function test_escape_legacy_v2_special_characters_handeling() {
 		$post_id = Utility::create_legacy_feedback_v2(
 			array(

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Legacy_Compatibility_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Legacy_Compatibility_Test.php
@@ -12,6 +12,7 @@ namespace Automattic\Jetpack\Forms\ContactForm;
 require_once __DIR__ . '/class-utility.php'; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use WorDBless\BaseTestCase;
 
 /**
@@ -297,34 +298,94 @@ class Feedback_Legacy_Compatibility_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Data provider: every field type in $non_extra_fields that must not
+	 * fatal when its value is an array.
+	 */
+	public static function data_provider_non_extra_field_types() {
+		return array(
+			'email'    => array( 'email', 'Email', array( 'first@example.com', 'second@example.com' ) ),
+			'name'     => array( 'name', 'Name', array( 'Alice', 'Bob' ) ),
+			'url'      => array( 'url', 'Website', array( 'https://example.com', 'https://another.com' ) ),
+			'subject'  => array( 'subject', 'Subject', array( 'Subject A', 'Subject B' ) ),
+			'textarea' => array( 'textarea', 'Message', array( 'First message', 'Second message' ) ),
+			'ip'       => array( 'ip', 'IP', array( '127.0.0.1', '192.168.1.1' ) ),
+		);
+	}
+
+	/**
 	 * Regression test: get_legacy_extra_values() must not fatal when a
-	 * non-extra field (email, name, url, subject, textarea, ip) holds an
-	 * array value.
+	 * non-extra field holds an array value.
 	 *
 	 * In production this happens when POST data contains multiple values
 	 * for the same field name, causing get_field_value() to store an array.
 	 * The 'submit' context is critical because get_render_submit_value()
 	 * returns $this->value without any array-to-string conversion — unlike
 	 * 'default' context which implodes arrays.
+	 *
+	 * @dataProvider data_provider_non_extra_field_types
 	 */
-	public function test_get_legacy_extra_values_with_array_field_value_does_not_fatal() {
+	#[DataProvider( 'data_provider_non_extra_field_types' )]
+	public function test_get_legacy_extra_values_with_array_field_value_does_not_fatal( $type, $label, $array_value ) {
 		$feedback_time  = current_time( 'mysql' );
-		$comment_author = 'Test User';
-		$feedback_title = "{$comment_author} - {$feedback_time}";
+		$feedback_title = "Test User - {$feedback_time}";
 
-		// Create a url-type field whose value is an array — simulating a POST
-		// where multiple values were submitted for the same field name.
-		$url_field  = new Feedback_Field( '1_Website', 'Website', array( 'https://example.com', 'https://another.com' ), 'url' );
-		$name_field = new Feedback_Field( '2_Name', 'Name', 'Test User', 'name' );
-		$text_field = new Feedback_Field( '3_Comment', 'Comment', 'Hello world', 'text' );
+		$array_field = new Feedback_Field( '1_' . $label, $label, $array_value, $type );
+		$text_field  = new Feedback_Field( '2_Comment', 'Comment', 'Hello world', 'text' );
 
 		$content = array(
 			'subject' => 'Test Subject',
 			'ip'      => '127.0.0.1',
 			'fields'  => array(
-				$url_field->serialize(),
-				$name_field->serialize(),
+				$array_field->serialize(),
 				$text_field->serialize(),
+			),
+		);
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'      => 'feedback',
+				'post_status'    => 'publish',
+				'post_title'     => addslashes( wp_kses( $feedback_title, array() ) ),
+				'post_date'      => $feedback_time,
+				'post_name'      => md5( $feedback_title . $type ),
+				'post_content'   => wp_json_encode( $content, JSON_UNESCAPED_SLASHES ),
+				'post_mime_type' => 'v2',
+				'post_parent'    => 0,
+			)
+		);
+
+		$response = Feedback::get( $post_id );
+		$this->assertInstanceOf( Feedback::class, $response, "Feedback should load for {$type} field" );
+
+		// 'submit' context — the production path (class-contact-form.php:2678).
+		// get_render_submit_value() returns the raw array, which without the fix
+		// triggers: TypeError: Cannot access offset of type array on array
+		$extra_values_submit = $response->get_legacy_extra_values( 'submit' );
+		$this->assertIsArray( $extra_values_submit, "get_legacy_extra_values(submit) should not fatal for {$type} with array value" );
+
+		// 'default' context — implodes arrays to strings, verify it still works.
+		$extra_values_default = $response->get_legacy_extra_values( 'default' );
+		$this->assertIsArray( $extra_values_default, "get_legacy_extra_values(default) should not fatal for {$type} with array value" );
+	}
+
+	/**
+	 * Verify that checkbox-multiple fields preserve their array values
+	 * through get_legacy_extra_values() — they are the one field type
+	 * that legitimately holds arrays.
+	 */
+	public function test_get_legacy_extra_values_preserves_checkbox_multiple_array() {
+		$feedback_time  = current_time( 'mysql' );
+		$feedback_title = "Test User - {$feedback_time}";
+
+		$checkbox_field = new Feedback_Field( '1_Colors', 'Colors', array( 'red', 'blue', 'green' ), 'checkbox-multiple' );
+		$name_field     = new Feedback_Field( '2_Name', 'Name', 'Test User', 'name' );
+
+		$content = array(
+			'subject' => 'Test Subject',
+			'ip'      => '127.0.0.1',
+			'fields'  => array(
+				$checkbox_field->serialize(),
+				$name_field->serialize(),
 			),
 		);
 
@@ -344,16 +405,18 @@ class Feedback_Legacy_Compatibility_Test extends BaseTestCase {
 		$response = Feedback::get( $post_id );
 		$this->assertInstanceOf( Feedback::class, $response );
 
-		// 'submit' context — the production path (class-contact-form.php:2678).
-		// get_render_submit_value() returns the raw array, which triggers:
-		// TypeError: Cannot access offset of type array on array
-		$extra_values_submit = $response->get_legacy_extra_values( 'submit' );
-		$this->assertIsArray( $extra_values_submit, 'get_legacy_extra_values(submit) should not fatal with array field values' );
+		// checkbox-multiple values should remain as arrays in submit/api contexts.
+		$value_submit = $response->get_field_value_by_label( 'Colors', 'submit' );
+		$this->assertIsArray( $value_submit, 'checkbox-multiple value should be an array in submit context' );
+		$this->assertEquals( array( 'red', 'blue', 'green' ), $value_submit, 'checkbox-multiple value should preserve all selected options' );
 
-		// 'default' context — safe because get_render_default_value() implodes arrays,
-		// but verify it still works.
-		$extra_values_default = $response->get_legacy_extra_values( 'default' );
-		$this->assertIsArray( $extra_values_default, 'get_legacy_extra_values(default) should not fatal with array field values' );
+		// In default context, arrays are imploded to a comma-separated string.
+		$value_default = $response->get_field_value_by_label( 'Colors', 'default' );
+		$this->assertEquals( 'red, blue, green', $value_default, 'checkbox-multiple value should be imploded in default context' );
+
+		// get_legacy_extra_values should work without fatal.
+		$extra_values = $response->get_legacy_extra_values( 'submit' );
+		$this->assertIsArray( $extra_values, 'get_legacy_extra_values(submit) should work with checkbox-multiple' );
 	}
 
 	public function test_escape_legacy_v2_special_characters_handeling() {

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Legacy_Compatibility_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Legacy_Compatibility_Test.php
@@ -296,37 +296,64 @@ class Feedback_Legacy_Compatibility_Test extends BaseTestCase {
 		$this->assertEquals( '🙈', $response->get_field_value_by_label( 'message' ), 'Message field value should match' );
 	}
 
-	public function test_get_legacy_extra_values_with_array_post_data() {
-		$form_id    = Utility::get_form_id();
-		$_post_data = Utility::get_post_request(
-			array(
-				'email'   => array( 'first@example.com', 'second@example.com' ),
-				'name'    => 'Test User',
-				'message' => 'Hello, this is a test message.',
+	/**
+	 * Regression test: get_legacy_extra_values() must not fatal when a
+	 * non-extra field (email, name, url, subject, textarea, ip) holds an
+	 * array value.
+	 *
+	 * In production this happens when POST data contains multiple values
+	 * for the same field name, causing get_field_value() to store an array.
+	 * The 'submit' context is critical because get_render_submit_value()
+	 * returns $this->value without any array-to-string conversion — unlike
+	 * 'default' context which implodes arrays.
+	 */
+	public function test_get_legacy_extra_values_with_array_field_value_does_not_fatal() {
+		$feedback_time  = current_time( 'mysql' );
+		$comment_author = 'Test User';
+		$feedback_title = "{$comment_author} - {$feedback_time}";
+
+		// Create a url-type field whose value is an array — simulating a POST
+		// where multiple values were submitted for the same field name.
+		$url_field  = new Feedback_Field( '1_Website', 'Website', array( 'https://example.com', 'https://another.com' ), 'url' );
+		$name_field = new Feedback_Field( '2_Name', 'Name', 'Test User', 'name' );
+		$text_field = new Feedback_Field( '3_Comment', 'Comment', 'Hello world', 'text' );
+
+		$content = array(
+			'subject' => 'Test Subject',
+			'ip'      => '127.0.0.1',
+			'fields'  => array(
+				$url_field->serialize(),
+				$name_field->serialize(),
+				$text_field->serialize(),
 			),
-			'g' . $form_id
 		);
 
-		$form = new Contact_Form(
+		$post_id = wp_insert_post(
 			array(
-				'title'       => 'Test Form',
-				'description' => 'This is a test form.',
-			),
-			"[contact-field label='Email' type='email' required='1'/][contact-field label='Name' type='name' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+				'post_type'      => 'feedback',
+				'post_status'    => 'publish',
+				'post_title'     => addslashes( wp_kses( $feedback_title, array() ) ),
+				'post_date'      => $feedback_time,
+				'post_name'      => md5( $feedback_title ),
+				'post_content'   => wp_json_encode( $content, JSON_UNESCAPED_SLASHES ),
+				'post_mime_type' => 'v2',
+				'post_parent'    => 0,
+			)
 		);
 
-		$response = Feedback::from_submission( $_post_data, $form );
+		$response = Feedback::get( $post_id );
+		$this->assertInstanceOf( Feedback::class, $response );
 
-		// When an array is submitted for a single-value field like email,
-		// only the first value should be kept.
-		$this->assertEquals( 'first@example.com', $response->get_field_value_by_label( 'Email' ), 'Email field should use the first value from the array' );
+		// 'submit' context — the production path (class-contact-form.php:2678).
+		// get_render_submit_value() returns the raw array, which triggers:
+		// TypeError: Cannot access offset of type array on array
+		$extra_values_submit = $response->get_legacy_extra_values( 'submit' );
+		$this->assertIsArray( $extra_values_submit, 'get_legacy_extra_values(submit) should not fatal with array field values' );
 
-		// get_legacy_extra_values should not throw a TypeError.
-		$extra_values = $response->get_legacy_extra_values( 'submit' );
-		$this->assertIsArray( $extra_values, 'get_legacy_extra_values should return an array without fatal error' );
-
-		$extra_values_default = $response->get_legacy_extra_values();
-		$this->assertIsArray( $extra_values_default, 'get_legacy_extra_values with default context should return an array without fatal error' );
+		// 'default' context — safe because get_render_default_value() implodes arrays,
+		// but verify it still works.
+		$extra_values_default = $response->get_legacy_extra_values( 'default' );
+		$this->assertIsArray( $extra_values_default, 'get_legacy_extra_values(default) should not fatal with array field values' );
 	}
 
 	public function test_escape_legacy_v2_special_characters_handeling() {


### PR DESCRIPTION
Fixes FORMS-670
## Proposed changes

Fixes `PHP Fatal error: Uncaught TypeError: Cannot access offset of type array on array` in `Feedback::get_legacy_extra_values()`.

**Root cause:** When a form field like `email`, `name`, or `url` receives array POST data (e.g. crafted requests sending `email[]=a&email[]=b`), `get_field_value()` stores the value as an array. In the `submit` context, `get_render_submit_value()` returns this raw array, which then gets used as an array key in `get_legacy_extra_values()` — causing a TypeError.

**Fix (two layers):**

1. **Source enforcement** (`get_field_value()`): For all field types except `checkbox-multiple` (the only type that legitimately accepts arrays), flatten array POST data to the first element. `file` and `image-select` already have dedicated early returns.

2. **Defensive guard** (`get_legacy_extra_values()`): If a render value is still an array (e.g. from pre-existing stored data), use `reset()` to extract the first element before using it as an array key — instead of crashing.

**Tests added:**
* Parameterized regression test across all 6 `$non_extra_fields` types (email, name, url, subject, textarea, ip) with array values in both `submit` and `default` contexts
* Verify `checkbox-multiple` arrays are preserved through `get_legacy_extra_values()` (v2 format with correct type)
* Verify legacy v1 `checkbox-multiple` arrays (stored with type `basic`) survive the round-trip and are not flattened by the `reset()` guard
* Assertions verify actual data correctness (field values, extra values contents), not just absence of fatal errors

## Related product discussion/links

* p1775768640031599-slack-C06QF6JJDTM

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Apply this patch to a site running the Jetpack Forms package
2. Create a contact form with fields like email, name, url, textarea
3. Submit the form normally — verify submissions work as before
4. Submit the form with array POST data for a single-value field (e.g. using a crafted request where the email parameter is an array) — verify no PHP Fatal Error occurs
5. Submit a form with a checkbox-multiple field — verify all selected options are preserved

**Automated:**
```bash
cd projects/packages/forms && composer test-php
```

Or run just the new tests:
```bash
cd projects/packages/forms && vendor/bin/phpunit-select-config phpunit.#.xml.dist --filter="test_get_legacy_extra_values_with_array_field_value_does_not_fatal|test_get_legacy_extra_values_preserves_checkbox_multiple_array|test_legacy_v1_checkbox_multiple_array_preserved"
```