### PR TITLE
Update site purchases to use WPCOM v1.2 /upgrades endpoint

### DIFF
--- a/projects/packages/backup/changelog/update-purchases-endpoint-v1.2
+++ b/projects/packages/backup/changelog/update-purchases-endpoint-v1.2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update purchases endpoint from v1.1 /sites/$site/purchases to v1.2 /upgrades?site=$site.

--- a/projects/packages/backup/src/class-jetpack-backup.php
+++ b/projects/packages/backup/src/class-jetpack-backup.php
@@ -588,14 +588,14 @@ class Jetpack_Backup {
 	}
 
 	/**
-	 * Returns the result of `/sites/%d/purchases` endpoint call.
+	 * Returns the result of `/upgrades` endpoint call.
 	 *
 	 * @return array of site purchases.
 	 */
 	public static function get_site_current_purchases() {
 
-		$request  = sprintf( '/sites/%d/purchases', Jetpack_Options::get_option( 'id' ) );
-		$response = Client::wpcom_json_api_request_as_blog( $request, '1.1' );
+		$request  = sprintf( '/upgrades?site=%d', Jetpack_Options::get_option( 'id' ) );
+		$response = Client::wpcom_json_api_request_as_blog( $request, '1.2' );
 
 		// Bail if there was an error or malformed response.
 		if ( is_wp_error( $response ) || ! is_array( $response ) || ! isset( $response['body'] ) ) {

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/use-filtered-plans.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/use-filtered-plans.ts
@@ -47,7 +47,7 @@ export function useFilteredPlans( { search }: UseFilteredPlansOptions ): {
 		);
 
 		return {
-			id: purchase.ID,
+			id: String( purchase.ID ),
 			title: purchase.product_name,
 			cards: $products.map( ( [ slug, product ] ) => {
 				const moduleSlug = PRODUCT_MODULES[ slug ] || slug;

--- a/projects/packages/my-jetpack/_inc/data/types.ts
+++ b/projects/packages/my-jetpack/_inc/data/types.ts
@@ -39,28 +39,23 @@ export type WP_Error = {
 };
 
 export type Purchase = {
-	ID: string;
-	user_id: string;
-	blog_id: string;
-	product_id: string;
+	ID: number;
+	user_id: number;
+	blog_id: number;
+	product_id: number;
 	subscribed_date: string;
-	renew: string;
-	auto_renew: string;
 	renew_date: string;
-	inactive_date: string | null;
-	active: string;
-	meta: string | object;
-	ownership_id: string;
+	meta: string | null;
+	ownership_id: number;
 	most_recent_renew_date: string;
 	amount: number;
-	expiry_date: string;
-	expiry_message: string;
-	expiry_sub_message: string;
+	expiry_date: string | null;
 	expiry_status: string;
 	partner_name: string | null;
 	partner_slug: string | null;
-	partner_key_id: string | null;
+	partner_key_id: number | null;
 	subscription_status: string;
+	is_auto_renew_enabled: boolean;
 	product_name: string;
 	product_slug: string;
 	product_type: string;
@@ -68,15 +63,12 @@ export type Purchase = {
 	blogname: string;
 	domain: string;
 	description: string;
-	attached_to_purchase_id: string | null;
+	attached_to_purchase_id: number | null;
 	included_domain: string;
 	included_domain_purchase_amount: number;
 	currency_code: string;
 	currency_symbol: string;
-	renewal_price_tier_slug: string | null;
 	renewal_price_tier_usage_quantity: number | null;
-	current_price_tier_slug: string | null;
-	current_price_tier_usage_quantity: number | null;
 	price_tier_list: Array< object >;
 	price_text: string;
 	bill_period_label: string;
@@ -96,7 +88,6 @@ export type Purchase = {
 	refund_period_in_days: number;
 	is_renewable: boolean;
 	is_renewal: boolean;
-	has_private_registration: boolean;
 	refund_amount: number;
 	refund_integer: number;
 	refund_currency_symbol: string;
@@ -106,5 +97,4 @@ export type Purchase = {
 	total_refund_integer: number;
 	total_refund_currency: string;
 	total_refund_text: string;
-	check_dns: boolean;
 };

--- a/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-paid-plan-needs-plugin-install-activation-notice.tsx
+++ b/projects/packages/my-jetpack/_inc/hooks/use-notification-watcher/use-paid-plan-needs-plugin-install-activation-notice.tsx
@@ -123,7 +123,7 @@ const usePaidPlanNeedsPluginInstallActivationNotice: NoticeHookType = (
 	const { noticeTitle, noticeMessage, buttonLabel } = useGetPaidPlanNeedsPluginsContent( {
 		alert,
 		planName,
-		planPurchaseId: planPurchase?.ID,
+		planPurchaseId: String( planPurchase?.ID ),
 	} );
 
 	const prepareProductsArray = useCallback(

--- a/projects/packages/my-jetpack/changelog/update-purchases-endpoint-v1.2
+++ b/projects/packages/my-jetpack/changelog/update-purchases-endpoint-v1.2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update purchases endpoint from v1.1 /sites/$site/purchases to v1.2 /upgrades?site=$site.

--- a/projects/packages/my-jetpack/global.d.ts
+++ b/projects/packages/my-jetpack/global.d.ts
@@ -336,28 +336,23 @@ type ProtectNeedsAttentionData = {
 };
 
 type Purchase = {
-	ID: string;
-	user_id: string;
-	blog_id: string;
-	product_id: string;
+	ID: number;
+	user_id: number;
+	blog_id: number;
+	product_id: number;
 	subscribed_date: string;
-	renew: string;
-	auto_renew: string;
 	renew_date: string;
-	inactive_date: string | null;
-	active: string;
-	meta: string | object;
-	ownership_id: string;
+	meta: string | null;
+	ownership_id: number;
 	most_recent_renew_date: string;
 	amount: number;
-	expiry_date: string;
-	expiry_message: string;
-	expiry_sub_message: string;
+	expiry_date: string | null;
 	expiry_status: string;
 	partner_name: string | null;
 	partner_slug: string | null;
-	partner_key_id: string | null;
+	partner_key_id: number | null;
 	subscription_status: string;
+	is_auto_renew_enabled: boolean;
 	product_name: string;
 	product_slug: string;
 	product_type: string;
@@ -365,15 +360,12 @@ type Purchase = {
 	blogname: string;
 	domain: string;
 	description: string;
-	attached_to_purchase_id: string | null;
+	attached_to_purchase_id: number | null;
 	included_domain: string;
 	included_domain_purchase_amount: number;
 	currency_code: string;
 	currency_symbol: string;
-	renewal_price_tier_slug: string | null;
 	renewal_price_tier_usage_quantity: number | null;
-	current_price_tier_slug: string | null;
-	current_price_tier_usage_quantity: number | null;
 	price_tier_list: Array< object >;
 	price_text: string;
 	bill_period_label: string;
@@ -393,7 +385,6 @@ type Purchase = {
 	refund_period_in_days: number;
 	is_renewable: boolean;
 	is_renewal: boolean;
-	has_private_registration: boolean;
 	refund_amount: number;
 	refund_integer: number;
 	refund_currency_symbol: string;
@@ -403,7 +394,6 @@ type Purchase = {
 	total_refund_integer: number;
 	total_refund_currency: string;
 	total_refund_text: string;
-	check_dns: boolean;
 };
 
 type ProtectData = {

--- a/projects/packages/my-jetpack/src/class-rest-purchases.php
+++ b/projects/packages/my-jetpack/src/class-rest-purchases.php
@@ -64,8 +64,8 @@ class REST_Purchases {
 	 */
 	public static function get_site_current_purchases() {
 		$site_id           = \Jetpack_Options::get_option( 'id' );
-		$wpcom_endpoint    = sprintf( '/sites/%1$d/purchases?locale=%2$s', $site_id, get_user_locale() );
-		$wpcom_api_version = '1.1';
+		$wpcom_endpoint    = sprintf( '/upgrades?site=%1$d&locale=%2$s', $site_id, get_user_locale() );
+		$wpcom_api_version = '1.2';
 		$response          = Client::wpcom_json_api_request_as_blog( $wpcom_endpoint, $wpcom_api_version );
 		$response_code     = wp_remote_retrieve_response_code( $response );
 		$body              = json_decode( wp_remote_retrieve_body( $response ) );

--- a/projects/packages/my-jetpack/src/class-wpcom-products.php
+++ b/projects/packages/my-jetpack/src/class-wpcom-products.php
@@ -330,8 +330,8 @@ class Wpcom_Products {
 		$site_id = Jetpack_Options::get_option( 'id' );
 
 		$response = Client::wpcom_json_api_request_as_blog(
-			sprintf( '/sites/%d/purchases', $site_id ),
-			'1.1',
+			sprintf( '/upgrades?site=%d', $site_id ),
+			'1.2',
 			array(
 				'method' => 'GET',
 			)

--- a/projects/packages/stats-admin/changelog/update-purchases-endpoint-v1.2
+++ b/projects/packages/stats-admin/changelog/update-purchases-endpoint-v1.2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update purchases endpoint from v1.1 /sites/$site/purchases to v1.2 /upgrades?site=$site.

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -1211,13 +1211,13 @@ class REST_Controller {
 	public function get_site_purchases( $req ) {
 		return WPCOM_Client::request_as_blog_cached(
 			sprintf(
-				'/sites/%d/purchases?%s',
+				'/upgrades?site=%d&%s',
 				Jetpack_Options::get_option( 'id' ),
 				$this->filter_and_build_query_string(
 					$req->get_query_params()
 				)
 			),
-			'v1.1',
+			'v1.2',
 			array( 'timeout' => 10 ),
 			null,
 			'rest',

--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-header/index.js
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-header/index.js
@@ -68,7 +68,7 @@ class MyPlanHeader extends Component {
 					purchaseID={ purchase.ID }
 				/>
 			);
-			if ( purchase.active === '1' ) {
+			if ( 'active' === purchase.subscription_status ) {
 				// Purchases might not have an expiration date, so we need to check
 				// for their existence (e.g.: lifetime plan like Golden Token).
 				if ( purchase.expiry_status === 'expired' && purchase.expiry_date !== null ) {

--- a/projects/plugins/jetpack/_inc/client/recommendations/prompts/product-suggestions/test/fixtures.js
+++ b/projects/plugins/jetpack/_inc/client/recommendations/prompts/product-suggestions/test/fixtures.js
@@ -92,12 +92,12 @@ export function buildInitialState() {
 export const sitePurchases = () => {
 	return [
 		{
-			active: '1',
+			subscription_status: 'active',
 			product_id: '2100',
 			product_slug: 'jetpack_backup_daily',
 		},
 		{
-			active: '1',
+			subscription_status: 'active',
 			product_id: '2106',
 			product_slug: 'jetpack_scan',
 		},

--- a/projects/plugins/jetpack/_inc/client/state/site/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/site/reducer.js
@@ -373,7 +373,7 @@ export function getSitePurchases( state ) {
  * @return {Array}        Active purchases for the site
  */
 export function getActiveSitePurchases( state ) {
-	return getSitePurchases( state ).filter( purchase => '1' === purchase.active );
+	return getSitePurchases( state ).filter( purchase => 'active' === purchase.subscription_status );
 }
 
 /**

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -62,14 +62,14 @@ class Jetpack_Core_API_Site_Endpoint {
 	}
 
 	/**
-	 * Returns the result of `/sites/%s/purchases` endpoint call.
+	 * Returns the result of `/upgrades` endpoint call.
 	 *
 	 * @return array of site purchases.
 	 */
 	public static function get_purchases() {
 		// Make the API request.
-		$request  = sprintf( '/sites/%d/purchases', Jetpack_Options::get_option( 'id' ) );
-		$response = Client::wpcom_json_api_request_as_blog( $request, '1.1' );
+		$request  = sprintf( '/upgrades?site=%d', Jetpack_Options::get_option( 'id' ) );
+		$response = Client::wpcom_json_api_request_as_blog( $request, '1.2' );
 
 		// Bail if there was an error or malformed response.
 		if ( is_wp_error( $response ) || ! is_array( $response ) || ! isset( $response['body'] ) ) {

--- a/projects/plugins/jetpack/changelog/update-purchases-endpoint-v1.2
+++ b/projects/plugins/jetpack/changelog/update-purchases-endpoint-v1.2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Update purchases endpoint from v1.1 /sites/$site/purchases to v1.2 /upgrades?site=$site.


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-1862/update-jetpack-to-use-12-version-of-upgrades-endpoint

## Proposed changes

* Switch all five PHP callers of the WPCOM purchases endpoint from v1.1 `/sites/$site/purchases` (returns `Store_Subscription` objects) to v1.2 `/upgrades?site=$site` (returns `Billing_Upgrade` objects): `class-rest-purchases.php`, `class-wpcom-products.php`, `class.jetpack-core-api-site-endpoints.php`, `class-rest-controller.php` (stats-admin), `class-jetpack-backup.php`
* Update `getActiveSitePurchases` in `reducer.js` and the equivalent check in `my-plan-header/index.js` from `purchase.active === '1'` to `purchase.subscription_status === 'active'` — the `active` field does not exist on `Billing_Upgrade`; `subscription_status` is the equivalent (`'active'` or `'inactive'`)
* Update the `Purchase` TypeScript type in `_inc/data/types.ts` and `global.d.ts` to match the `Billing_Upgrade` shape: remove stale fields (`active`, `auto_renew`, `renew`, `inactive_date`, `expiry_message`, `expiry_sub_message`, `renewal_price_tier_slug`, `current_price_tier_slug`, `current_price_tier_usage_quantity`, `has_private_registration`, `check_dns`); correct integer fields from `string` to `number` (`ID`, `user_id`, `blog_id`, `product_id`, `ownership_id`, `attached_to_purchase_id`, `partner_key_id`); fix `expiry_date` to `string | null`; add `is_auto_renew_enabled: boolean`

## Why is this change being made

In the billing SELECT query incident (pcO4xN-39R-p2) we discovered that Jetpack is still using v1.1. of the upgrades endpoint (`v1.1/sites/$site/purchases`) which uses the old version of fetching subscriptions that has some performance issues. We should see if we can fix that since we've upgraded all of those endpoints to a 1.2 version. I believe the correct newer version is `/v1.2/upgrades?site=$site`.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Connect a Jetpack site to WordPress.com with an active subscription
* Open the My Jetpack admin page (`wp-admin/admin.php?page=my-jetpack`) — the Plans section should display the active subscription name and expiry date correctly
* Open the legacy Jetpack dashboard Plans tab (`wp-admin/admin.php?page=jetpack#/plans`) — the current plan should still be displayed with correct activation/expiry state
* Confirm that the Jetpack Backup plugin's `jetpack/v4/site/current-purchases` REST endpoint returns valid purchase data
* Confirm that the Stats admin purchases route returns valid data