### PR TITLE
Forms: Make dashboard header actions consistent with other pages

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-wp-build-mobile-header-actions
+++ b/projects/packages/forms/changelog/fix-forms-wp-build-mobile-header-actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Change header actions to be consistent with other pages

--- a/projects/packages/forms/routes/shared.scss
+++ b/projects/packages/forms/routes/shared.scss
@@ -3,12 +3,6 @@
 @include meta.load-css("@wordpress/dataviews/build-style/style.css");
 
 .jp-forms-dataviews__view-actions {
-	// On small screens, switch to column-reverse stacking
-	@container (width < 500px) {
-		--wp-ui-stack-justify: flex-start;
-		flex-direction: column-reverse;
-		align-items: flex-start;
-	}
 
 	> div:not(:empty) {
 		min-height: 48px;

--- a/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/index.tsx
@@ -80,12 +80,7 @@ export default function DataViewsHeaderRow( {
 
 	return (
 		<>
-			<Stack
-				align="center"
-				className="jp-forms-dataviews__view-actions"
-				gap="sm"
-				justify="space-between"
-			>
+			<Stack className="jp-forms-dataviews__view-actions" justify="space-between">
 				<Stack align="center" gap="sm">
 					{ isSingleFormView ? (
 						<InboxStatusToggle


### PR DESCRIPTION
Fixes #

## Proposed changes

* Remove custom mobile-specific CSS overrides (`column-reverse` stacking, `flex-start` alignment) from the Forms DataViews header row
* Simplify the `<Stack>` component props in `DataViewsHeaderRow`, removing redundant `align` and `gap` props so it inherits default behavior consistent with other pages

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Go to the Jetpack Forms dashboard (wp-admin → Jetpack → Forms)
* View the page at various viewport widths (desktop, tablet, mobile)
* Verify the header actions (search, filters, view switcher) display consistently with other WP admin DataViews pages
* Confirm there is no layout breakage on small screens — the header actions should follow the default Stack behavior rather than custom column-reverse stacking
* Verify the header actions match the one from other pages in CIAB, like the Automations page.

<img width="1259" height="299" alt="Screenshot from 2026-04-09 19-32-03" src="https://github.com/user-attachments/assets/f53c4f71-503c-49dc-9e69-fe0a758941ce" />
<img width="453" height="305" alt="Screenshot from 2026-04-09 19-31-47" src="https://github.com/user-attachments/assets/b99e6368-e256-4c39-8454-a9fcffef1388" />

| Automations | Forms |
| - | - |
| <img width="453" height="305" alt="Screenshot from 2026-04-09 19-30-55" src="https://github.com/user-attachments/assets/ab059a1a-1ac3-47ca-bedb-64a57bbe1ee4" /> | <img width="453" height="305" alt="Screenshot from 2026-04-09 19-30-50" src="https://github.com/user-attachments/assets/445ae584-e632-462c-8190-c6502c3173d4" /> |
| <img width="1010" height="305" alt="Screenshot from 2026-04-09 19-30-35" src="https://github.com/user-attachments/assets/0aec9ce1-c672-40d6-9fdf-ff7312a3bb44" /> | <img width="1010" height="305" alt="Screenshot from 2026-04-09 19-30-12" src="https://github.com/user-attachments/assets/fdcc5c25-4dd8-4d59-abab-3619bd06a75c" /> |

