### PR TITLE
Forms: Fix form block not working when Blocks module is inactive

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-without-blocks-module
+++ b/projects/packages/forms/changelog/fix-forms-without-blocks-module
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fixed Forms block not working when the Blocks module is inactive by registering the block directly from the Forms package and providing the required editor initial state.
+Fixed the Form block when the Blocks module is inactive by registering it directly from the Forms package and providing the required editor initial state.

--- a/projects/packages/forms/changelog/fix-forms-without-blocks-module
+++ b/projects/packages/forms/changelog/fix-forms-without-blocks-module
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed Forms block not working when the Blocks module is inactive by registering the block directly from the Forms package and providing the required editor initial state.

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -847,6 +847,11 @@ class Contact_Form_Block {
 
 		$handle = 'jp-forms-blocks';
 
+		// Ensure the jetpack-blocks-editor dependency exists. When the Blocks module
+		// is inactive, nothing registers it, but the Forms editor JS needs the
+		// Jetpack_Editor_Initial_State global (with availability data) it provides.
+		self::maybe_register_blocks_editor_script();
+
 		Assets::register_script(
 			$handle,
 			'../../../dist/blocks/editor.js',
@@ -959,6 +964,48 @@ class Contact_Form_Block {
 				'strategy'   => 'defer',
 				'textdomain' => 'jetpack-forms',
 				'enqueue'    => true,
+			)
+		);
+	}
+
+	/**
+	 * Register a minimal jetpack-blocks-editor script when the Blocks module is inactive.
+	 *
+	 * The Forms editor JS depends on jetpack-blocks-editor for the
+	 * Jetpack_Editor_Initial_State global, which includes block availability data.
+	 * Normally the Blocks module registers this, but Forms needs to work independently.
+	 */
+	private static function maybe_register_blocks_editor_script() {
+		if ( wp_script_is( 'jetpack-blocks-editor', 'registered' ) ) {
+			return;
+		}
+
+		// When the Blocks module is active it will register the real script, so bail.
+		if ( class_exists( 'Jetpack' ) && ( new Modules() )->is_active( 'blocks' ) ) {
+			return;
+		}
+
+		// Register a minimal script to satisfy the dependency.
+		wp_register_script( 'jetpack-blocks-editor', '', array(), JETPACK__VERSION, true );
+		wp_register_style( 'jetpack-blocks-editor', false, array(), JETPACK__VERSION );
+
+		// Provide the initial state the Forms editor JS expects:
+		// - available_blocks: the JS block registration checks this before calling registerBlockType.
+		// - modules: the useModuleStatus hook reads this to decide whether to show the block
+		// or an "Activate Forms" placeholder.
+		// - feature_flags: hasFeatureFlag() reads this for central-form-management,
+		// form-webhooks, and multistep-form.
+		wp_localize_script(
+			'jetpack-blocks-editor',
+			'Jetpack_Editor_Initial_State',
+			array(
+				'available_blocks' => array(
+					'contact-form' => array( 'available' => true ),
+				),
+				'modules'          => array(
+					'contact-form' => array( 'activated' => true ),
+				),
+				'feature_flags'    => apply_filters( 'jetpack_block_editor_feature_flags', array() ),
 			)
 		);
 	}

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -441,6 +441,7 @@ class Contact_Form_Plugin {
 	 * Register the contact form block.
 	 */
 	private static function register_contact_form_blocks() {
+		Contact_Form_Block::register_block();
 		// Field render methods.
 		Contact_Form_Block::register_child_blocks();
 	}

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -375,6 +375,74 @@ class Contact_Form_Block_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test that register_block registers the jetpack/contact-form block type.
+	 */
+	public function test_register_block() {
+		$registry = WP_Block_Type_Registry::get_instance();
+
+		// Unregister if already registered from a previous test.
+		if ( $registry->is_registered( 'jetpack/contact-form' ) ) {
+			$registry->unregister( 'jetpack/contact-form' );
+		}
+
+		Contact_Form_Block::register_block();
+
+		$this->assertTrue( $registry->is_registered( 'jetpack/contact-form' ) );
+	}
+
+	/**
+	 * Test that maybe_register_blocks_editor_script registers a fallback
+	 * jetpack-blocks-editor script when the Blocks module is inactive.
+	 */
+	public function test_maybe_register_blocks_editor_script_registers_fallback() {
+		// Deregister the script if it exists from a previous test.
+		wp_deregister_script( 'jetpack-blocks-editor' );
+
+		$method = new \ReflectionMethod( Contact_Form_Block::class, 'maybe_register_blocks_editor_script' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+		$method->invoke( null );
+
+		// The fallback script should now be registered.
+		$this->assertTrue( wp_script_is( 'jetpack-blocks-editor', 'registered' ), 'jetpack-blocks-editor script should be registered as a fallback.' );
+
+		// The fallback style should also be registered.
+		$this->assertTrue( wp_style_is( 'jetpack-blocks-editor', 'registered' ), 'jetpack-blocks-editor style should be registered as a fallback.' );
+
+		// Verify the localized Jetpack_Editor_Initial_State data contains expected keys.
+		$scripts = wp_scripts();
+		$data    = $scripts->get_data( 'jetpack-blocks-editor', 'data' );
+
+		$this->assertNotEmpty( $data, 'jetpack-blocks-editor should have localized data.' );
+		$this->assertStringContainsString( 'available_blocks', $data );
+		$this->assertStringContainsString( 'contact-form', $data );
+		$this->assertStringContainsString( 'modules', $data );
+		$this->assertStringContainsString( 'feature_flags', $data );
+	}
+
+	/**
+	 * Test that maybe_register_blocks_editor_script is a no-op when the
+	 * script is already registered.
+	 */
+	public function test_maybe_register_blocks_editor_script_skips_when_already_registered() {
+		// Pre-register the script with a known src so we can verify it was not overwritten.
+		wp_deregister_script( 'jetpack-blocks-editor' );
+		wp_register_script( 'jetpack-blocks-editor', 'https://example.com/original.js', array(), '1.0', true );
+
+		$method = new \ReflectionMethod( Contact_Form_Block::class, 'maybe_register_blocks_editor_script' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+		$method->invoke( null );
+
+		// The original registration should be untouched.
+		$scripts = wp_scripts();
+		$script  = $scripts->registered['jetpack-blocks-editor'];
+		$this->assertSame( 'https://example.com/original.js', $script->src, 'Pre-existing script registration should not be overwritten.' );
+	}
+
+	/**
 	 * Test render_email with valid attributes.
 	 */
 	public function test_render_email_with_valid_attributes() {

--- a/projects/plugins/jetpack/changelog/fix-forms-without-blocks-module
+++ b/projects/plugins/jetpack/changelog/fix-forms-without-blocks-module
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Fixed the Form block not being usable when the Blocks module is inactive.

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/contact-form.php
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/contact-form.php
@@ -11,5 +11,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
 }
 
-// Block registration is now handled by Contact_Form_Plugin::register_contact_form_blocks()
-// in the jetpack-forms package, so it works regardless of the Blocks module being active.
+/*
+ * Register the block as a fallback when loaded via the Blocks module.
+ *
+ * The Forms package registers this block when the Forms (contact-form) module is active.
+ * When only the Blocks module is active, this ensures the block is still registered so
+ * admins see a nudge to activate the Forms module.
+ *
+ * Contact_Form_Block::register_block() calls can_manage_block() internally,
+ * and Blocks::jetpack_register_block() is a no-op if the block is already registered,
+ * so double-registration is not possible.
+ */
+add_action( 'init', array( Contact_Form_Block::class, 'register_block' ), 9 );

--- a/projects/plugins/jetpack/extensions/blocks/contact-form/contact-form.php
+++ b/projects/plugins/jetpack/extensions/blocks/contact-form/contact-form.php
@@ -11,5 +11,5 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
 }
 
-// Register the block
-add_action( 'init', array( Contact_Form_Block::class, 'register_block' ), 9 );
+// Block registration is now handled by Contact_Form_Plugin::register_contact_form_blocks()
+// in the jetpack-forms package, so it works regardless of the Blocks module being active.


### PR DESCRIPTION
Fixes FORMS-669

## Proposed changes

* Fix the Form block not being usable when the Blocks module is inactive but the Forms (contact-form) module is active.
* Move parent `jetpack/contact-form` block registration from the Blocks module's extension loader into the Forms package (`Contact_Form_Plugin::register_contact_form_blocks()`), so it registers regardless of the Blocks module.
* When the Blocks module is inactive, register a minimal `jetpack-blocks-editor` script with the required `Jetpack_Editor_Initial_State` data (`available_blocks`, `modules`, `feature_flags`) so the Forms editor JS loads and functions correctly.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Go to Jetpack → Settings (or use WP-CLI: `wp jetpack module deactivate blocks`) to deactivate the **Blocks** module while keeping the **Forms** module active.
2. Open the block editor and try inserting a **Form** block.
3. Verify the Form block appears in the inserter, renders correctly (not an "Activate Forms" placeholder), and is fully functional (can add fields, submit button, etc.).
4. Re-activate the **Blocks** module (`wp jetpack module activate blocks`).
5. Verify the Form block still works correctly with both modules active (no double-registration errors, no console errors).
6. Deactivate both modules and verify the Form block does not appear in the inserter.
