### PR TITLE
CI: Run Jetpack + wpcomsh PHPUnit tests on PHP 8.3

### DIFF
--- a/.github/files/generate-ci-matrix.php
+++ b/.github/files/generate-ci-matrix.php
@@ -92,9 +92,9 @@ $matrix[] = array(
 
 // Add wpcomsh tests.
 $matrix[] = array(
-	'name'         => 'PHP tests: PHP 8.1 WP latest with wpcomsh',
+	'name'         => 'PHP tests: PHP 8.3 WP latest with wpcomsh',
 	'script'       => 'test-php',
-	'php'          => '8.1',
+	'php'          => '8.3',
 	'wp'           => 'latest',
 	'timeout'      => 15, // 2025-11-06: Successful runs seem to take ~7 minutes.
 	'with-wpcomsh' => true,


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
We were running Jetpack + wpcomsh PHPUnit tests on PHP 8.1, a version that is no longer supported on WP.com. Let's bump it to PHP 8.3.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

CI should stay happy.