### PR TITLE
Revert "Revert "RTC: Bump WebSocket gradual rollout to 100% on simple sites""

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-16654-rtc-bump-ws-rollout-100-percent
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-16654-rtc-bump-ws-rollout-100-percent
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+RTC: Bump WebSocket gradual rollout to 100% on simple sites.

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/gutenberg-rtc.php
@@ -43,12 +43,7 @@ function wpcom_is_rtc_http_polling_rollout() {
  * @return bool
  */
 function wpcom_is_rtc_websocket_rollout() {
-	$blog_id = get_wpcom_blog_id();
-
-	if (
-		defined( 'IS_WPCOM' ) && IS_WPCOM &&
-		( $blog_id % 100 < 50 )
-	) {
+	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 		return true;
 	}
 	return false;


### PR DESCRIPTION
Reverts Automattic/jetpack#48042

Fixes DOTCOM-16654

## Proposed changes
* Bump the WebSocket RTC gradual rollout on WordPress.com Simple sites from 50% to 100%.
* The previous `$blog_id % 100 < 50` gating is removed, so every Simple site now qualifies for the WebSocket rollout.

## Related product discussion/links
* N/A

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a WordPress.com Simple site, open the block editor and confirm Real-Time Collaboration loads via the WebSocket provider, regardless of the blog ID.
* Confirm that Atomic sites (HTTP-polling rollout) and non-WPCOM environments are unaffected.