### PR TITLE
Add Titan Mail Premium & Ultra products to wpcom-features

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-titan-mail-premium-ultra-products
+++ b/projects/plugins/wpcomsh/changelog/add-titan-mail-premium-ultra-products
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add Titan Mail Premium and Ultra product constants to WPCOM_TITAN_MAIL_PRODUCTS for feature detection

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -37,6 +37,10 @@ class WPCOM_Features {
 	private const GAPPS_UNLIMITED                             = 'gapps_unlimited'; // 70
 	private const WP_TITAN_MAIL_MONTHLY                       = 'wp_titan_mail_monthly'; // 400
 	private const WP_TITAN_MAIL_YEARLY                        = 'wp_titan_mail_yearly'; // 401
+	private const WP_TITAN_MAIL_PREMIUM_MONTHLY               = 'wp_titan_mail_premium_monthly'; // 402
+	private const WP_TITAN_MAIL_PREMIUM_YEARLY                = 'wp_titan_mail_premium_yearly'; // 403
+	private const WP_TITAN_MAIL_ULTRA_MONTHLY                 = 'wp_titan_mail_ultra_monthly'; // 404
+	private const WP_TITAN_MAIL_ULTRA_YEARLY                  = 'wp_titan_mail_ultra_yearly'; // 405
 	private const WP_GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY = 'wp_google_workspace_business_starter_yearly'; // 690
 	private const WPCOM_SEARCH                                = 'wpcom_search'; // 800
 	private const WPCOM_SEARCH_MONTHLY                        = 'wpcom_search_monthly'; // 801
@@ -248,7 +252,7 @@ class WPCOM_Features {
 	private const WOO_HOSTED_PLANS              = array( self::WOO_HOSTED_BASIC_PLAN_MONTHLY, self::WOO_HOSTED_BASIC_PLAN_YEARLY, self::WOO_HOSTED_PRO_PLAN_MONTHLY, self::WOO_HOSTED_PRO_PLAN_YEARLY );
 	private const GOOGLE_WORKSPACE_PRODUCTS     = array( self::WP_GOOGLE_WORKSPACE_BUSINESS_STARTER_YEARLY );
 	private const GSUITE_PRODUCTS               = array( self::GAPPS, self::GAPPS_UNLIMITED );
-	private const WPCOM_TITAN_MAIL_PRODUCTS     = array( self::WP_TITAN_MAIL_MONTHLY, self::WP_TITAN_MAIL_YEARLY );
+	private const WPCOM_TITAN_MAIL_PRODUCTS     = array( self::WP_TITAN_MAIL_MONTHLY, self::WP_TITAN_MAIL_YEARLY, self::WP_TITAN_MAIL_PREMIUM_MONTHLY, self::WP_TITAN_MAIL_PREMIUM_YEARLY, self::WP_TITAN_MAIL_ULTRA_MONTHLY, self::WP_TITAN_MAIL_ULTRA_YEARLY );
 
 	private const WPCOM_PERSONAL_AND_PREMIUM_PLANS = array( self::WPCOM_PERSONAL_PLANS, self::WPCOM_PREMIUM_PLANS );
 	// Unlock Business-gated features for sites with the flex-cache-site sticker via the free plan.


### PR DESCRIPTION
## Proposed changes
- Add 4 new Titan Mail product constants: `WP_TITAN_MAIL_PREMIUM_MONTHLY` (402), `WP_TITAN_MAIL_PREMIUM_YEARLY` (403), `WP_TITAN_MAIL_ULTRA_MONTHLY` (404), `WP_TITAN_MAIL_ULTRA_YEARLY` (405).
- Include them in the `WPCOM_TITAN_MAIL_PRODUCTS` array so feature detection recognizes Premium and Ultra subscriptions.
- Syncs wpcomsh with wpcom changes from dotcom/wpcom#211295.

## Related product discussion/links
- 211295-ghe-Automattic/wpcom
- DOTEMP-98

## Does this pull request change what data or activity we track or use?
No. This only adds product ID constants to an existing feature-detection allowlist. It does not collect, store, or transmit any new data.

## Testing instructions
- `cd projects/plugins/wpcomsh`
- Run `composer phpcs` and `composer phpunit` and confirm they pass.
- In a PHP console (or a quick test), confirm the new product slugs resolve correctly:
  - `WPCOM_Features::has_feature_for_product( 'wp_titan_mail_premium_monthly' )` (and the `premium_yearly`, `ultra_monthly`, `ultra_yearly` variants) are recognized as Titan Mail products.
- Confirm existing Titan Mail products (`wp_titan_mail_monthly`, `wp_titan_mail_yearly`) continue to behave as before.
- Since these product IDs are not yet purchasable, there is no functional impact for existing sites.
