### PR TITLE
CLI: Make yargs args strict

### DIFF
--- a/tools/cli/cliRouter.js
+++ b/tools/cli/cliRouter.js
@@ -59,6 +59,7 @@ export async function cli() {
 
 	// This adds usage information on failure and demands that a subcommand must be passed.
 	argv
+		.strict()
 		.showHelpOnFail( true )
 		.demandCommand()
 		.recommendCommands()

--- a/tools/cli/commands/build.js
+++ b/tools/cli/commands/build.js
@@ -62,6 +62,7 @@ export function builder( yargs ) {
 			type: 'boolean',
 			description: 'Build for production.',
 		} )
+		.option( 'pnpm-install', { type: 'boolean', hidden: true } )
 		.option( 'no-pnpm-install', {
 			type: 'boolean',
 			description: 'Skip execution of `pnpm install` before the build.',

--- a/tools/cli/commands/changelog.js
+++ b/tools/cli/commands/changelog.js
@@ -28,6 +28,7 @@ export function changelogDefine( yargs ) {
 		'Runs the changelogger wizard',
 		yarg => {
 			yarg
+				.strict( false )
 				.positional( 'cmd', {
 					describe: 'Command for changelog script to run',
 					type: 'string',

--- a/tools/cli/commands/dependencies.js
+++ b/tools/cli/commands/dependencies.js
@@ -106,6 +106,7 @@ export function builder( yargs ) {
 			describe: 'Ignore the monorepo root.',
 			type: 'boolean',
 		} )
+		.option( 'dev', { type: 'boolean', hidden: true } )
 		.option( 'no-dev', {
 			describe: 'Do not consider dev dependencies.',
 			type: 'boolean',

--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -609,6 +609,7 @@ export function dockerDefine( yargs ) {
 		description: 'Docker stuff',
 		builder: yarg => {
 			yarg
+				.strict( false )
 				// Compose commands
 				.command( {
 					command: 'up',

--- a/tools/cli/commands/install.js
+++ b/tools/cli/commands/install.js
@@ -39,6 +39,7 @@ export function builder( yargs ) {
 			type: 'boolean',
 			description: 'Installs everything',
 		} )
+		.option( 'pnpm-install', { type: 'boolean', hidden: true } )
 		.option( 'no-pnpm-install', {
 			type: 'boolean',
 			description: 'Skip execution of `pnpm install`.',

--- a/tools/cli/commands/phan.js
+++ b/tools/cli/commands/phan.js
@@ -47,6 +47,7 @@ export async function builder( yargs ) {
 			type: 'boolean',
 			description: 'Run phan on everything.',
 		} )
+		.option( 'baseline', { type: 'boolean', hidden: true } )
 		.option( 'no-baseline', {
 			type: 'boolean',
 			description: 'Do not use the baseline file.',
@@ -60,6 +61,7 @@ export async function builder( yargs ) {
 			description:
 				'Update the Phan baselines, even if no baseline currently exists. But please try not to use this, fix the issues instead.',
 		} )
+		.option( 'use-uncommitted-composer-lock', { type: 'boolean', hidden: true } )
 		.option( 'no-use-uncommitted-composer-lock', {
 			type: 'boolean',
 			description: "Don't use uncommitted composer.lock files.",

--- a/tools/cli/commands/test.js
+++ b/tools/cli/commands/test.js
@@ -41,6 +41,7 @@ export async function builder( yargs ) {
 			type: 'boolean',
 			description: 'Run tests on everything.',
 		} )
+		.option( 'use-uncommitted-composer-lock', { type: 'boolean', hidden: true } )
 		.option( 'no-use-uncommitted-composer-lock', {
 			type: 'boolean',
 			description: "Don't use uncommitted composer.lock files.",
@@ -51,6 +52,7 @@ export async function builder( yargs ) {
 			default: os.availableParallelism(),
 			coerce: coerceConcurrency,
 		} )
+		.option( 'html', { type: 'boolean', hidden: true } )
 		.option( 'no-html', {
 			type: 'boolean',
 			description: 'For coverage tests, do not generate HTML reports.',


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
This one's a bit silly, but I was trying to use `--with-deps` instead of `--deps` when building, and it would happily build with no errors, but of course didn't build deps. By switching yargs to `strict` by default, it now shows the help page when there's an invalid arg passed.

Another common error is trying to use `--filter` with the `test` command, which isn't supported.

Some commands need option passthrough. Both `composer` and `pnpm` already override with `.strict( false )`. I added `changelog` and `docker` as well.

~There's also `docker`, which can use `--`, but those are handled differently in `argv._`.~ It turns out `docker` also needs passthrough, as it does things like `jetpack docker wp plugin --activate`.

Note that strict mode doesn't like negative (`no-*`) options by default. I could have set `boolean-negation` and update the JS vars, but I decided to just define the positive options as hidden.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Test various `jetpack` commands with valid and invalid flags, e.g.:

* `jetpack build plugins/crm --deps`: builds with deps
* `jetpack build plugins/crm --with-deps`: shows help
* `jetpack pnpm --version`: shows pnpm version
* `jetpack composer --version`: shows composer version
* `jetpack test js packages/connection --filter=asdf`: shows help
* `jetpack docker phpunit jetpack -- --filter=Jetpack_Components_Test`: runs filtered set of tests