### PR TITLE
Social: Fix independent scrolling in preview modal panels

### DIFF
--- a/projects/packages/publicize/_inc/components/customize-and-preview/customization-section/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/customization-section/styles.module.scss
@@ -8,6 +8,10 @@
 	// Allow fieldset to shrink below its content size in grid/flex layouts.
 	min-inline-size: 0;
 
+	@include gb.break-medium() {
+		overflow-y: auto;
+	}
+
 	legend {
 		color: gb.$gray-700;
 		// Float fixes the default fieldset/legend border and padding issues.

--- a/projects/packages/publicize/_inc/components/customize-and-preview/tab-panels/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/tab-panels/styles.module.scss
@@ -1,9 +1,12 @@
 @use "@automattic/jetpack-base-styles/gutenberg-base-styles" as gb;
 
 .tab-panel-wrapper {
+	min-height: 0;
+	overflow-y: auto;
 
 	@include gb.break-medium() {
 		display: grid;
+		overflow-y: unset;
 
 		&[data-variant="global"] {
 			grid-template-columns: clamp(200px, 33.33%, 350px) minmax(0, 1fr);
@@ -12,7 +15,10 @@
 
 	&[data-plan="paid"] {
 		border-top: 1px solid gb.$gray-200;
-		overflow: auto;
+
+		@include gb.break-medium() {
+			overflow: hidden;
+		}
 	}
 
 	[role="tablist"] {
@@ -32,10 +38,15 @@
 .tab-panel {
 
 	display: grid;
+	min-height: 0;
 
 	@include gb.break-medium() {
 		grid-template-rows: auto 1fr;
 		height: 100%;
+	}
+
+	:global(.components-tab-panel__tab-content) {
+		min-height: 0;
 	}
 
 	:global(.components-tab-panel__tabs-item) {
@@ -76,6 +87,10 @@
 	grid-template-columns: 1fr;
 	height: 100%;
 
+	@include gb.break-medium() {
+		overflow: hidden;
+	}
+
 	// On mobile per-network mode,
 	// move connection toggle above customization section
 	&[data-variant="per-network"] {
@@ -115,6 +130,10 @@
 .preview-wrapper {
 	display: flex;
 	flex-direction: column;
+
+	@include gb.break-medium() {
+		overflow-y: auto;
+	}
 
 	// Make the preview section fill remaining space
 	> :last-child {

--- a/projects/packages/publicize/_inc/components/unified-modal/social-post-preview/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/unified-modal/social-post-preview/styles.module.scss
@@ -1,4 +1,29 @@
+@use "@automattic/jetpack-base-styles/gutenberg-base-styles" as gb;
+
 .social-post-preview-screen {
+
+	// Make the inner flex column fill the screen so header/body/footer
+	// can distribute height properly.
+	> :global(.components-flex) {
+		height: 100%;
+	}
+
+	:global(.jp-navigator-modal__body) {
+		flex: 1;
+		min-height: 0;
+		height: auto;
+	}
+
+	// On mobile, let the content scroll naturally so everything is accessible.
+	// On desktop, contain scroll within individual panels.
+	:global(.jp-navigator-modal__content) {
+		min-height: 0;
+		overflow: auto;
+
+		@include gb.break-medium() {
+			overflow: hidden;
+		}
+	}
 
 	&[data-plan="paid"] {
 

--- a/projects/packages/publicize/changelog/fix-social-preview-scroll
+++ b/projects/packages/publicize/changelog/fix-social-preview-scroll
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social: Fix independent scrolling in preview modal panels on mobile


### PR DESCRIPTION
Fixes [SOCIAL-432](https://linear.app/a8c/issue/SOCIAL-432)

## Proposed changes
* Make scrolling working independently per each area (editor and preview content)
* Change only work for desktop. For mobile, the content scrolling still work as before.

![social-pr-scroll](https://github.com/user-attachments/assets/5f655ad4-0cc2-4ca1-a571-9d7f7e74c2b2)

## Related product discussion/links
p1HpG7-xW0

## Does this pull request change what data or activity we track or use?
No

## Testing instructions
[Use the docs](https://linear.app/a8c/document/development-and-testing-233742b93b35) for useful testing snippets.

* Upgrade account to see more elements in the modal
* Make your screen smaller
* See scroll working in the editor and the preview content
