### PR TITLE
Forms: Show loading state instead of stale data when switching form responses

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-wp-build-invalidate-data
+++ b/projects/packages/forms/changelog/fix-forms-wp-build-invalidate-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Show loading state instead of stale data when navigating between form response listings

--- a/projects/packages/forms/changelog/fix-forms-wp-build-invalidate-data
+++ b/projects/packages/forms/changelog/fix-forms-wp-build-invalidate-data
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Show loading state instead of stale data when navigating between form response listings
+Show loading state instead of stale data when navigating between form response listings.

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -332,7 +332,9 @@ function StageInner() {
 			return true;
 		}
 
-		return Object.keys( queryParams ).some(
+		const allKeys = new Set( [ ...Object.keys( currentQuery ), ...Object.keys( queryParams ) ] );
+
+		return Array.from( allKeys ).some(
 			key => currentQuery[ key ] !== queryParams[ key as keyof QueryParams ]
 		);
 	}, [ currentQuery, queryParams ] );

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -187,6 +187,7 @@ function StageInner() {
 		totalItemsInbox,
 		totalItemsSpam,
 		totalItemsTrash,
+		currentQuery,
 	} = useInboxData( { status: statusView } );
 
 	useEffect( () => {
@@ -321,6 +322,23 @@ function StageInner() {
 	useEffect( () => {
 		setCurrentQuery( queryParams );
 	}, [ queryParams, setCurrentQuery ] );
+
+	// Detect when the store's query hasn't caught up to the locally computed queryParams.
+	// setCurrentQuery runs in a useEffect (after paint), so for one render cycle the store
+	// still holds the previous query and useEntityRecords returns stale cached data.
+	// Force a loading state during that gap to avoid flashing old results.
+	const isQueryStale = useMemo( () => {
+		if ( ! currentQuery ) {
+			return true;
+		}
+
+		return (
+			currentQuery.status !== queryParams.status ||
+			currentQuery.page !== queryParams.page ||
+			currentQuery.parent !== queryParams.parent ||
+			currentQuery.search !== queryParams.search
+		);
+	}, [ currentQuery, queryParams ] );
 
 	// Keep selected responses in store for shared dashboard behavior (e.g., export).
 	useEffect( () => {
@@ -590,12 +608,12 @@ function StageInner() {
 						status={ statusView }
 					/>
 				}
-				data={ records || EMPTY_ARRAY }
+				data={ isQueryStale ? EMPTY_ARRAY : records || EMPTY_ARRAY }
 				fields={ fields as Field< unknown >[] }
 				view={ view }
 				onChangeView={ onChangeView }
 				paginationInfo={ paginationInfo }
-				isLoading={ isLoadingData }
+				isLoading={ isLoadingData || isQueryStale }
 				getItemId={ getItemId }
 				defaultLayouts={ defaultLayouts }
 				selection={ selection }

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -332,11 +332,8 @@ function StageInner() {
 			return true;
 		}
 
-		return (
-			currentQuery.status !== queryParams.status ||
-			currentQuery.page !== queryParams.page ||
-			currentQuery.parent !== queryParams.parent ||
-			currentQuery.search !== queryParams.search
+		return Object.keys( queryParams ).some(
+			key => currentQuery[ key ] !== queryParams[ key as keyof QueryParams ]
 		);
 	}, [ currentQuery, queryParams ] );
 


### PR DESCRIPTION
Fixes #

## Proposed changes

* Fix stale data flash when navigating between form response listings in the new Forms dashboard (wp-build routes, not legacy dashboard).
* When opening the responses of one form, going back, then opening another form's responses, the previous form's responses would briefly appear before the correct data loaded.
* Added a `isQueryStale` check that compares the locally computed query parameters against the store's current query. When they differ (during the one-render-cycle lag from `useEffect`), the DataViews component shows a loading state with empty data instead of stale records.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Go to **Jetpack → Forms** in wp-admin (requires the new wp-build dashboard, not the legacy one).
2. You should see a list of forms. Click the **Responses** action on any form that has responses.
3. Note the responses displayed. Click back to the forms list.
4. Click **Responses** on a *different* form (ideally one with a different number of responses).
5. **Before this fix:** You would briefly see the previous form's responses before the correct ones loaded.
6. **After this fix:** You should see a loading state (spinner) instead of stale data, followed by the correct responses.
