### PR TITLE
Sync: increase lock time tolerance in tests

### DIFF
--- a/projects/packages/sync/changelog/fix-sync-increase_lock_time_variance
+++ b/projects/packages/sync/changelog/fix-sync-increase_lock_time_variance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Tests: Increase lock time tolerance.

--- a/projects/packages/sync/tests/php/Dedicated_Sender_Test.php
+++ b/projects/packages/sync/tests/php/Dedicated_Sender_Test.php
@@ -352,7 +352,7 @@ class Dedicated_Sender_Test extends BaseTestCase {
 
 		$lock_expires_value = \Jetpack_Options::get_raw_option( $lock_expires_name );
 
-		$this->assertEqualsWithDelta( microtime( true ) + Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_TIMEOUT, $lock_expires_value, 0.01 );
+		$this->assertEqualsWithDelta( microtime( true ) + Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_TIMEOUT, $lock_expires_value, 0.02 );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
Periodically with the Code Coverage run, we get this error:
```
[packages/sync] 1) Automattic\Jetpack\Sync\Dedicated_Sender_Test::test_try_lock_spawn_request_without_existing_locks
[packages/sync] Failed asserting that 1775068844.460853 matches expected 1775068844.472507.
[packages/sync] 
[packages/sync] /home/runner/work/jetpack/jetpack/projects/packages/sync/tests/php/Dedicated_Sender_Test.php:355
```

The failures I've observed have a delta of `0.012` to `0.016`. This increases the delta tolerance from `0.01` to `0.02`.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->

Here are some reported failures in the past few months:
* p1770819381541419/1770816232.662079-slack-C034JEXD1RD
* p1772475040522169/1772473930.683619-slack-C034JEXD1RD
* p1775069775333009/1775069368.644619-slack-C034JEXD1RD
* p1775744562993409/1775743700.209249-slack-C034JEXD1RD
* p1775858726311629/1775858452.093249-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

I dunno.