### PR TITLE
JITM sidebar + Daily Writing Prompt: fix button-link border regression under WP 7.0

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-16580-fix-jitm-sidebar-button-link-border
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-16580-fix-jitm-sidebar-button-link-border
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+JITM sidebar upsell + Daily Writing Prompt: restore flat button-link styling when `.button` and `.button-link` classes combine under WP 7.0's updated stylesheet order.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-daily-writing-prompt/style.scss
@@ -5,6 +5,7 @@
 	margin: 1em 0;
 
 	button.button-link {
+		border: 0;
 		line-height: inherit;
 		min-height: auto;
 		// Override mobile styles.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.scss
@@ -73,6 +73,7 @@
 	.upsell_banner__action {
 		text-align: center;
 		line-height: 2;
+		min-height: 0;
 	}
 
 	.upsell_banner__dismiss.button-link {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.scss
@@ -77,10 +77,12 @@
 
 	.upsell_banner__dismiss.button-link {
 		background-color: transparent;
+		border: 0;
 		color: inherit;
 		min-height: 0;
 		font-size: 12px;
 		line-height: 16px;
+		padding: 0;
 		text-align: center;
 		margin-top: -2px;
 


### PR DESCRIPTION
Fixes DOTCOM-16580

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* In WP 7.0, the hoisted stylesheet ordering changed so core's `.wp-core-ui .button-link { border: 0 }` no longer reliably overrides `.wp-core-ui .button { border: 1px solid ... }` for buttons that carry both classes. The JITM sidebar upsell Dismiss button and the Daily Writing Prompt buttons both combine `button button-link`, so they rendered as bordered secondary buttons rather than plain text links.

* Explicitly zero out `border` (and `padding`, for the dismiss button) on the high-specificity selectors that already target these elements so the flat link appearance no longer depends on core's stylesheet order.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* You'll need a WoW site
* Go to `https://my.wordpress.com/sites/{siteSlug}.wpcomstaging.com/settings/wordpress?flags=dashboard/wp-beta-program`
* Choose 7.0 as the WP version
* Enable this branch on the site
* Go to `/wp-admin`
* Check that the buttons on the upsell banner and daily writing prompt look good:

|Before|After|
|---|---|
|<img width="413" height="496" alt="image" src="https://github.com/user-attachments/assets/6a2362a1-c2d1-452e-bcf6-b28346595e3b" />|<img width="413" height="496" alt="image" src="https://github.com/user-attachments/assets/6ab9a193-0fe4-46c9-aaa0-4b4f49fa2705" />|

|Before|After|
|---|---|
|<img width="1630" height="552" alt="image" src="https://github.com/user-attachments/assets/ad342e0c-3cb7-4148-8681-5662a8931a5e" />|<img width="1630" height="552" alt="image" src="https://github.com/user-attachments/assets/45606631-bd03-4c16-b5e0-b800c3c74669" />|