### PR TITLE
Added defensive check for wpcom taxonomies endpoint

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-wpcom-taxonomies-endpoint-handle-wp-error
+++ b/projects/plugins/jetpack/changelog/fix-wpcom-taxonomies-endpoint-handle-wp-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix taxonomies endpoint returning error when number parameter exceeds 1000.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-taxonomies-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-taxonomies-endpoint.php
@@ -97,6 +97,9 @@ class WPCOM_JSON_API_Get_Taxonomies_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 		$args = $this->query_args();
 		$args = $this->process_args( $args );
+		if ( is_wp_error( $args ) ) {
+			return $args;
+		}
 
 		if ( preg_match( '#/tags#i', $path ) ) {
 			return $this->tags( $args );


### PR DESCRIPTION
## Proposed changes
* `process_args()` already returned a `WP_Error` in that case, but `callback()` passed the error straight into `categories()` / `tags()`, which then treated it as an args array and threw errors when `get_categories()` / `get_tags()` ran against a `WP_Error` instead of a real args array.
* Added an `is_wp_error()` check in `callback()` so the error is returned to the client as a proper `400 invalid_number` response instead of blowing up downstream.
* No defensive check was added around `query_args()` returning a non-array: `WPCOM_JSON_API_Endpoint::query_args()` builds its result via `array_intersect_key()` and `cast_and_filter()`, both of which always return an array for this endpoint's schema, so guarding against a non-array return would be dead code.

## Related product discussion/links
* p1775998265866839-slack-C4N88L95W

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On **trunk**, go to the WordPress.com API console: https://developer.wordpress.com/docs/api/console/
* Pick the `GET /sites/$site/categories` endpoint, set `number` to a value greater than `1000` (e.g. `1500`), and run it against a site you have access to.
* Observe the error in your server logs.
* Switch to this branch (deploy to a JN site or your local environment) and repeat the same request.
* Verify the response still returns an error, but no logs are shown in your server logs.
* Also verify normal requests still work: `number=5`, `number=100`, `number=1000` (the boundary) should all return categories as expected.
* Repeat the same checks against `GET /sites/$site/tags`.