### PR TITLE
WordAds: Prevent PHP warning when status code is already set

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-invalid_header_call_after_http_response_code
+++ b/projects/plugins/jetpack/changelog/fix-invalid_header_call_after_http_response_code
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+WordAds: Prevent PHP warning when headers are already sent.

--- a/projects/plugins/jetpack/modules/wordads/class-wordads.php
+++ b/projects/plugins/jetpack/modules/wordads/class-wordads.php
@@ -249,7 +249,7 @@ class WordAds {
 			 */
 			$ads_txt_content = apply_filters( 'wordads_ads_txt', $ads_txt_transient );
 
-			http_response_code( 200 );
+			status_header( 200 );
 			header( 'Content-Type: text/plain; charset=utf-8' );
 			echo esc_html( $ads_txt_content );
 			die( 0 );


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
This PR addresses the following warning:
```
PHP Warning: http_response_code(): Calling http_response_code() after header('HTTP/...') has no effect in /wordpress/plugins/jetpack/15.7/modules/wordads/class-wordads.php on line 252
```

This would occur if something set the header status code prior to reaching this point. Using the `status_header()` wrapper from WordPress prevents this.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Not sure how to test this; hopefully reading the code itself is adequate.