### PR TITLE
Subscriptions: Prevent warning when $post global is malformed

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-subscriptions-address_warnings_in_the_wild
+++ b/projects/plugins/jetpack/changelog/fix-subscriptions-address_warnings_in_the_wild
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Subscriptions: Prevent warning when $post global is malformed.

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -233,8 +233,11 @@ HTML;
 			return false;
 		}
 
-		// Don't show if post is for subscribers only or has paywall block
+		// Don't show if post is not a post, is for subscribers only, or has paywall block
 		global $post;
+		if ( ! $post instanceof WP_Post ) {
+			return false;
+		}
 		if ( defined( 'Automattic\\Jetpack\\Extensions\\Subscriptions\\META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS' ) ) {
 			$access_level = get_post_meta( $post->ID, META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS, true );
 		} else {


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
We're getting some of these:
```
PHP Warning: Attempt to read property "ID" on array in /wordpress/plugins/jetpack/15.7/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php on line 239
```

Because `$post` is a global, third-party code can and does sometimes modify it. This PR ensures it's a `WP_Post` before trying to use it.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Looking at the code is probably the easiest option.
