### PR TITLE
Forms: request response field values as a keyed collection

### DIFF
--- a/projects/packages/forms/changelog/update-forms-responses-fields-format
+++ b/projects/packages/forms/changelog/update-forms-responses-fields-format
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Forms responses dashboard: request field values as a keyed collection from the API.

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -76,6 +76,7 @@ type QueryParams = {
 	before?: string;
 	after?: string;
 	search?: string;
+	fields_format?: string;
 };
 
 const DEFAULT_VIEW: View = {
@@ -289,6 +290,7 @@ function StageInner() {
 			page: view.page || 1,
 			orderby: view.sort?.field || 'date',
 			order: view.sort?.direction || 'desc',
+			fields_format: 'collection',
 		};
 
 		if ( view.search ) {


### PR DESCRIPTION
Fixes # N/A — Forms responses dashboard

## Proposed changes
* Pass `fields_format=collection` when requesting form responses so the API returns field values keyed by field id instead of as a positional array.
* Extend the `QueryParams` type in the responses stage with the new `fields_format` key.

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Open the Forms responses dashboard (Jetpack → Forms → Responses) on a site with existing form submissions.
* In the Network panel, inspect the request for responses and confirm the query string includes `fields_format=collection`.
* Confirm the dashboard still renders responses correctly (list view, pagination, sorting, search, filters).
* Open a single response and confirm field values display as expected.
