### PR TITLE
oEmbed: Prevent PHP warnings when a registered provider is malformed

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.media-extractor.php
+++ b/projects/plugins/jetpack/_inc/lib/class.media-extractor.php
@@ -349,7 +349,11 @@ class Jetpack_Media_Meta_Extractor {
 
 					// Check whether this "link" is really an embed.
 					foreach ( $oembed->providers as $matchmask => $data ) {
-						list( $providerurl, $regex ) = $data; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+						// Guard against malformed oEmbed providers.
+						if ( ! isset( $data[0] ) ) {
+							continue;
+						}
+						$regex = $data[1] ?? false;
 
 						// Turn the asterisk-type provider URLs into regex.
 						if ( ! $regex ) {

--- a/projects/plugins/jetpack/changelog/fix-jetpack-prevent_warnings_with_malformed_oembed_providers
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-prevent_warnings_with_malformed_oembed_providers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+oEmbed: Prevent PHP warnings when a registered provider is malformed.


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
There was a site generating about 10% of Jetpack-related PHP warnings on WP Cloud, all looking like this:
```
PHP Warning: Undefined array key 0 in /wordpress/plugins/jetpack/15.8-a.1/_inc/lib/class.media-extractor.php on line 352
PHP Warning: Undefined array key 1 in /wordpress/plugins/jetpack/15.8-a.1/_inc/lib/class.media-extractor.php on line 352
```

As it turned out, they had a plugin that was registering the oEmbed providers like so:

```
 [provider_key] => Array
    (
        [url] => some_url_regex
        [endpoint] => https://some_site/api/oembed
    )
```

Instead, it should have been like this:

```
[some_url_regex] => Array
    (
        [0] => https://some_site/api/oembed
        [1] => 1
    )
```

This PR adds a `continue` if index `0` is not set, and uses `false` for index `1` if not set.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

First, add an `mu-plugin`:
```
add_filter(
	'oembed_providers',
	function ( $providers ) {
		$providers['bad_provider'] = array(
			'url'      => '#https?://example\.site/.*#i',
			'endpoint' => 'https://example.site/api/oembed',
		);
		return $providers;
	}
);
```

1. Go to a new post page.
2. Paste a URL that doesn't have an oEmbed, e.g. `https://en.wikipedia.org/wiki/Rickrolling`
3. Do NOT click "Convert to link".
4. Save the post.
5. Visit the post on the front end.

On `trunk, you'll get an error from Jetpack. On this branch you will not.

Note that refreshing the editor will show a warning from Core; that's reported here:
https://core.trac.wordpress.org/ticket/65068