### PR TITLE
Sync: Increase lock tolerance in tests (part 2)

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-sync-increase_lock_tolerance_in_tests_part_2
+++ b/projects/plugins/jetpack/changelog/fix-sync-increase_lock_tolerance_in_tests_part_2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Sync: Increase lock time tolerance in tests.

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Sender_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Sender_Test.php
@@ -737,7 +737,7 @@ class Jetpack_Sync_Sender_Test extends Jetpack_Sync_TestBase {
 
 		$lock_expires_name  = $lock_option_name . '_expires';
 		$lock_expires_value = \Jetpack_Options::get_raw_option( $lock_expires_name );
-		$this->assertEqualsWithDelta( microtime( true ) + Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_TIMEOUT, $lock_expires_value, 0.01 );
+		$this->assertEqualsWithDelta( microtime( true ) + Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_TIMEOUT, $lock_expires_value, 0.02 );
 	}
 
 	/**
@@ -784,7 +784,7 @@ class Jetpack_Sync_Sender_Test extends Jetpack_Sync_TestBase {
 		$this->assertNotEmpty( \Jetpack_Options::get_raw_option( $lock_option_name ) );
 
 		$lock_expires_value = (float) \Jetpack_Options::get_raw_option( $lock_expires_name );
-		$this->assertEqualsWithDelta( microtime( true ) + Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_TIMEOUT, $lock_expires_value, 0.01 );
+		$this->assertEqualsWithDelta( microtime( true ) + Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_TIMEOUT, $lock_expires_value, 0.02 );
 	}
 
 	/**
@@ -807,7 +807,7 @@ class Jetpack_Sync_Sender_Test extends Jetpack_Sync_TestBase {
 		$this->assertNotEmpty( \Jetpack_Options::get_raw_option( $lock_option_name ) );
 
 		$lock_expires_value = (float) \Jetpack_Options::get_raw_option( $lock_expires_name );
-		$this->assertEqualsWithDelta( microtime( true ) + Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_TIMEOUT, $lock_expires_value, 0.01 );
+		$this->assertEqualsWithDelta( microtime( true ) + Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_TIMEOUT, $lock_expires_value, 0.02 );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
In #48054 I bumped the lock time variance for one method, but this affects a few others as well. This PR bumps it for the others.

The `test_do_sync_will_not_spawn_with_dedicated_sync_lock_set()` method doesn't have the same issue, as we're just storing and retrieving a value (presumably with allowance for float precision).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Hopefully this'll take this care of the rest of these issues.