### PR TITLE
Forms: Fix static front page preview showing blog index on wpcom sites

### DIFF
--- a/projects/packages/forms/changelog/edi-534-preview-button-renders-blog-post-index-instead-of-static
+++ b/projects/packages/forms/changelog/edi-534-preview-button-renders-blog-post-index-instead-of-static
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Rename 'preview_nonce' query var to 'jetpack_form_preview_nonce' to avoid collision with WordPress core preview URLs, which caused static front page previews to show the blog index on wpcom sites.

--- a/projects/packages/forms/src/contact-form/class-form-preview.php
+++ b/projects/packages/forms/src/contact-form/class-form-preview.php
@@ -35,7 +35,7 @@ class Form_Preview {
 	 *
 	 * @var string
 	 */
-	const PREVIEW_NONCE_QUERY_VAR = 'preview_nonce';
+	const PREVIEW_NONCE_QUERY_VAR = 'jetpack_form_preview_nonce';
 
 	/**
 	 * Flag to track if we're in preview mode.

--- a/projects/packages/forms/tests/php/contact-form/Form_Preview_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Form_Preview_Test.php
@@ -124,7 +124,7 @@ class Form_Preview_Test extends BaseTestCase {
 
 		$this->assertContains( 'existing', $result );
 		$this->assertContains( 'jetpack_form_preview', $result );
-		$this->assertContains( 'preview_nonce', $result );
+		$this->assertContains( 'jetpack_form_preview_nonce', $result );
 	}
 
 	/**
@@ -137,7 +137,7 @@ class Form_Preview_Test extends BaseTestCase {
 
 		$this->assertNotNull( $url );
 		$this->assertStringContainsString( 'jetpack_form_preview=' . $this->form_id, $url );
-		$this->assertStringContainsString( 'preview_nonce=', $url );
+		$this->assertStringContainsString( 'jetpack_form_preview_nonce=', $url );
 	}
 
 	/**
@@ -222,7 +222,7 @@ class Form_Preview_Test extends BaseTestCase {
 	 */
 	public function test_maybe_render_preview_no_vars() {
 		set_query_var( 'jetpack_form_preview', '' );
-		set_query_var( 'preview_nonce', '' );
+		set_query_var( 'jetpack_form_preview_nonce', '' );
 
 		$template = '/path/to/template.php';
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/EDI-534

## Proposed changes

* Rename Form_Preview's `preview_nonce` query var to `jetpack_form_preview_nonce` to avoid collision with WordPress core's preview URL parameter of the same name.

### Root cause

`Form_Preview` registered `preview_nonce` as a WordPress public query var. This collided with the `preview_nonce` parameter that WordPress core includes in post preview URLs (e.g. `/?preview_id=2&preview_nonce=abc&preview=true`).

When `preview_nonce` is a registered public query var, WordPress copies it from the URL into `WP_Query::$query` during `parse_request()`. The static front page detection in `WP_Query::parse_query()` only allows `preview`, `page`, `paged`, and `cpage` as query keys — the unexpected `preview_nonce` key causes the `array_diff` check to fail, so `is_home` is not converted to `is_page` and `is_singular` is not set.

There is a [backstop in `WP_Query::get_posts()` that sets `is_page=true` when `preview=true` is present, and it does fire. However, it does not update `is_singular`](https://github.com/WordPress/wordpress-develop/blob/aa72dfed4432cfd875f77d2c475f772c6623cae5/src/wp-includes/class-wp-query.php#L2042). Later in `get_posts()`, at line 2705, the [`!is_singular` branch](https://github.com/WordPress/wordpress-develop/blob/aa72dfed4432cfd875f77d2c475f772c6623cae5/src/wp-includes/class-wp-query.php#L2701) builds a combined post_type + post_status WHERE clause. Since `$post_type` is empty (set to `''` at line 2003 because `is_search` is false), line 2713 defaults to `post_type='post'` — overriding the correct `post_type='page'` that was set at line 2618 based on `is_page=true`. The resulting query — `WHERE ID=2 AND post_type='post'` — returns zero rows because the front page is a `page`, not a `post`.

With zero results, `redirect_canonical` strips the `preview` parameter from the URL and redirects. On the second request, with only `preview_nonce` left in the query, neither check can identify the request as the static front page, and WordPress falls back to the blog index template.

Arguably this is a bug in core. In  `WP_Query::get_posts()` it should recalculate `$this->is_singular` after changing `$this->is_page`.

## Related product discussion/links

* https://linear.app/a8c/issue/EDI-534

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Set up a site with a static front page (Settings → Reading → "A static page")
* Edit the homepage and use View → Preview in new tab
* Verify the preview shows the page content, not the blog post index
* Verify Jetpack Forms preview still works (create a form via the Forms dashboard, preview it)