### PR TITLE
Forms: Register central-form-management flag at bootstrap

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-cfm-flag
+++ b/projects/packages/forms/changelog/fix-forms-cfm-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Ensure central-form-management feature flag is registered at bootstrap so early callers (including the dashboard default-tab redirect) see the correct value.

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -79,6 +79,7 @@ class Contact_Form_Block {
 
 		add_filter( 'render_block_data', array( __CLASS__, 'find_nested_html_block' ), 10, 3 );
 		add_filter( 'render_block_core/html', array( __CLASS__, 'render_wrapped_html_block' ), 10, 2 );
+		add_filter( 'jetpack_block_editor_feature_flags', array( __CLASS__, 'register_feature' ) );
 		add_filter( 'pre_render_block', array( __CLASS__, 'pre_render_contact_form' ), 10, 3 );
 
 		add_filter( 'block_editor_rest_api_preload_paths', array( __CLASS__, 'preload_endpoints' ) );
@@ -101,6 +102,23 @@ class Contact_Form_Block {
 		$features['multistep-form'] = Current_Plan::supports( 'multistep-form' );
 		$features['form-webhooks']  = Current_Plan::supports( 'form-webhooks' );
 
+		return self::register_central_form_management_default( $features );
+	}
+
+	/**
+	 * Lightweight bootstrap default for the `central-form-management` feature flag.
+	 *
+	 * Registered from Util::init() so that early callers of
+	 * Contact_Form_Plugin::has_editor_feature_flag() — such as the Forms dashboard
+	 * default-tab redirect, which runs before the WP `init` hook fires — see the
+	 * correct flag value. Kept separate from register_feature() so the early-boot
+	 * code path avoids the Current_Plan::supports() calls used by the paid-plan flags.
+	 *
+	 * @param array $features - the features array.
+	 *
+	 * @return array
+	 */
+	public static function register_central_form_management_default( $features ) {
 		if ( ! isset( $features['central-form-management'] ) ) {
 			$features['central-form-management'] = true;
 		}

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -79,7 +79,6 @@ class Contact_Form_Block {
 
 		add_filter( 'render_block_data', array( __CLASS__, 'find_nested_html_block' ), 10, 3 );
 		add_filter( 'render_block_core/html', array( __CLASS__, 'render_wrapped_html_block' ), 10, 2 );
-		add_filter( 'jetpack_block_editor_feature_flags', array( __CLASS__, 'register_feature' ) );
 		add_filter( 'pre_render_block', array( __CLASS__, 'pre_render_contact_form' ), 10, 3 );
 
 		add_filter( 'block_editor_rest_api_preload_paths', array( __CLASS__, 'preload_endpoints' ) );

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -29,6 +29,11 @@ class Util {
 		add_filter( 'render_block', '\Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_unset_block_template_part_id_global', 10, 2 );
 		add_filter( 'widget_block_content', '\Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_filter_widget_block_content', 1, 3 );
 
+		// Register the block editor feature flags filter at bootstrap time so that early
+		// callers of Contact_Form_Plugin::has_editor_feature_flag() (e.g. the Forms dashboard
+		// redirect, which runs before the `init` hook fires) see the correct flag values.
+		add_filter( 'jetpack_block_editor_feature_flags', '\Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block::register_feature' );
+
 		add_action( 'init', '\Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::init', 9 );
 		add_action( 'grunion_scheduled_delete', '\Automattic\Jetpack\Forms\ContactForm\Util::grunion_delete_old_spam' );
 		add_action( 'grunion_scheduled_delete_temp', '\Automattic\Jetpack\Forms\ContactForm\Util::grunion_delete_old_temp_feedback' );

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -29,10 +29,13 @@ class Util {
 		add_filter( 'render_block', '\Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_unset_block_template_part_id_global', 10, 2 );
 		add_filter( 'widget_block_content', '\Automattic\Jetpack\Forms\ContactForm\Util::grunion_contact_form_filter_widget_block_content', 1, 3 );
 
-		// Register the block editor feature flags filter at bootstrap time so that early
-		// callers of Contact_Form_Plugin::has_editor_feature_flag() (e.g. the Forms dashboard
-		// redirect, which runs before the `init` hook fires) see the correct flag values.
-		add_filter( 'jetpack_block_editor_feature_flags', '\Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block::register_feature' );
+		// Register the default for the `central-form-management` feature flag at bootstrap
+		// so that early callers of Contact_Form_Plugin::has_editor_feature_flag() — such as
+		// the Forms dashboard default-tab redirect, which runs before the `init` hook fires —
+		// see the correct value. Only the lightweight default is registered here; paid-plan
+		// flags stay in Contact_Form_Block::register_feature(), hooked later from
+		// Contact_Form_Block::register_block() on `init` priority 9.
+		add_filter( 'jetpack_block_editor_feature_flags', '\Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block::register_central_form_management_default' );
 
 		add_action( 'init', '\Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::init', 9 );
 		add_action( 'grunion_scheduled_delete', '\Automattic\Jetpack\Forms\ContactForm\Util::grunion_delete_old_spam' );


### PR DESCRIPTION
Fixes #

## Proposed changes
* Move the `jetpack_block_editor_feature_flags` filter registration (for `Contact_Form_Block::register_feature`) out of `Contact_Form_Block::register_block()` and into `Util::init()`, which runs at plugin bootstrap.
* This ensures the `central-form-management` flag — which defaults to `true` via `register_feature()` — is actually visible to callers that run before the WP `init` hook fires. Previously the filter was only attached when `Contact_Form_Plugin::init()` executed at `init` priority 9, so synchronous early callers saw the flag as unset and fell back to `false`.
* Affected early callers that were silently seeing `false`:
  - `Dashboard::load_wp_build()` default-tab redirect (which picked the "inbox" responses tab instead of "forms").
  - `Contact_Form_Endpoint`'s `isCentralFormManagementEnabled` REST response.
* Uses a string callable (`'Namespace\Class::method'`) for the `add_filter` call so `Contact_Form_Block` is not autoloaded any earlier than before — PHP resolves the callback lazily when the filter fires.

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a site where Central Forms Management has not been explicitly toggled (so it relies on the default value from `register_feature()`), navigate to **Jetpack → Forms** from the wp-admin menu without any `p` query parameter.
* Before this fix: the dashboard lands on the **Responses** tab (`/responses/inbox`).
* After this fix: the dashboard lands on the **Forms** tab (`/forms`), because `has_editor_feature_flag( 'central-form-management' )` now correctly returns `true` during the early redirect in `Dashboard::load_wp_build()`.
* Also verify that `Contact_Form_Block::register_feature()` still runs exactly once (existing unit test `test_register_feature` should continue to pass) and that the contact form block still registers normally in the block editor.
