### PR TITLE
Forms: classic editor pick-existing-form modal with inline ref preview

### DIFF
--- a/projects/packages/forms/changelog/fix-classic-editor-cfm-modal
+++ b/projects/packages/forms/changelog/fix-classic-editor-cfm-modal
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Classic Editor: Replace the default form-insert buttons with a modal that lets users pick an existing saved form, preview it in an iframe, and insert a [contact-form ref="{id}"] shortcode. Hidden entirely when Central Forms Management is disabled.

--- a/projects/packages/forms/src/contact-form/class-editor-view.php
+++ b/projects/packages/forms/src/contact-form/class-editor-view.php
@@ -22,10 +22,23 @@ class Editor_View {
 	 * @param \WP_Screen $screen Data about current screen.
 	 */
 	public static function add_hooks( $screen ) {
-		if ( isset( $screen->base ) && 'post' === $screen->base ) {
-			add_action( 'admin_notices', array( __CLASS__, 'handle_editor_view_js' ) );
-			add_action( 'admin_head', array( __CLASS__, 'admin_head' ) );
+		if ( ! isset( $screen->base ) || 'post' !== $screen->base ) {
+			return;
 		}
+
+		// Without Central Forms Management there are no standalone jetpack_form
+		// posts for the picker to reference, so the classic-editor insert button
+		// is not registered at all.
+		static $cfm_enabled = null;
+		if ( null === $cfm_enabled ) {
+			$cfm_enabled = Contact_Form_Plugin::has_editor_feature_flag( 'central-form-management' );
+		}
+		if ( ! $cfm_enabled ) {
+			return;
+		}
+
+		add_action( 'admin_notices', array( __CLASS__, 'handle_editor_view_js' ) );
+		add_action( 'admin_head', array( __CLASS__, 'admin_head' ) );
 	}
 
 	/**
@@ -58,7 +71,11 @@ class Editor_View {
 	 * @return array
 	 */
 	public static function mce_external_plugins( $plugin_array ) {
-		$plugin_array['grunion_form'] = plugins_url( '../../dist/contact-form/js/tinymce-plugin-form-button.js', __FILE__ );
+		$plugin_array['grunion_form'] = add_query_arg(
+			'ver',
+			\JETPACK__VERSION,
+			plugins_url( '../../dist/contact-form/js/tinymce-plugin-form-button.js', __FILE__ )
+		);
 		return $plugin_array;
 	}
 
@@ -114,6 +131,10 @@ class Editor_View {
 									'[contact-field label="' . __( 'Email', 'jetpack-forms' ) . '" type="email" required="true" /]' .
 									'[contact-field label="' . __( 'Website', 'jetpack-forms' ) . '" type="url" /]' .
 									'[contact-field label="' . __( 'Message', 'jetpack-forms' ) . '" type="textarea" /]',
+				'rest_url'                 => esc_url_raw( rest_url( 'wp/v2/jetpack-forms' ) ),
+				'rest_nonce'               => wp_create_nonce( 'wp_rest' ),
+				'new_form_url'             => esc_url_raw( admin_url( 'post-new.php?post_type=jetpack_form' ) ),
+				'edit_form_url_template'   => esc_url_raw( admin_url( 'post.php?post=%d&action=edit' ) ),
 				'labels'                   => array(
 					'submit_button_text'  => __( 'Submit', 'jetpack-forms' ),
 					/** This filter is documented in \Automattic\Jetpack\Forms\ContactForm\Contact_Form */
@@ -121,11 +142,36 @@ class Editor_View {
 					'edit_close_ays'      => __( 'Are you sure you\'d like to stop editing this form without saving your changes?', 'jetpack-forms' ),
 					'quicktags_label'     => __( 'contact form', 'jetpack-forms' ),
 					'tinymce_label'       => __( 'Add contact form', 'jetpack-forms' ),
+					'picker_title'        => __( 'Insert a form', 'jetpack-forms' ),
+					'picker_intro'        => __( 'Choose one of your saved forms to insert into this post.', 'jetpack-forms' ),
+					'picker_select_label' => __( 'Select a form', 'jetpack-forms' ),
+					'picker_placeholder'  => __( 'Choose a form…', 'jetpack-forms' ),
+					'picker_preview'      => __( 'Preview', 'jetpack-forms' ),
+					'picker_preview_hint' => __( 'Select a form to preview it here.', 'jetpack-forms' ),
+					'picker_preview_err'  => __( 'Unable to load preview.', 'jetpack-forms' ),
+					'picker_loading'      => __( 'Loading forms…', 'jetpack-forms' ),
+					'picker_load_error'   => __( 'Unable to load your forms.', 'jetpack-forms' ),
+					'picker_empty_title'  => __( 'You don\'t have any forms yet', 'jetpack-forms' ),
+					'picker_empty_body'   => __( 'Create a form in the forms editor, then return here to insert it.', 'jetpack-forms' ),
+					'picker_new_form'     => __( 'Create a new form', 'jetpack-forms' ),
+					'picker_insert'       => __( 'Insert form', 'jetpack-forms' ),
+					'picker_cancel'       => __( 'Cancel', 'jetpack-forms' ),
+					'picker_close'        => __( 'Close', 'jetpack-forms' ),
+					'picker_untitled'     => __( '(no title)', 'jetpack-forms' ),
+					'ref_preview_title'   => __( 'Saved form', 'jetpack-forms' ),
+					'ref_preview_loading' => __( 'Loading form preview…', 'jetpack-forms' ),
+					'ref_preview_error'   => __( 'Unable to load the form preview.', 'jetpack-forms' ),
 				),
 			)
 		);
 
-		add_editor_style( plugin_dir_url( __FILE__ ) . '../../dist/contact-form/css/editor-style.css' );
+		add_editor_style(
+			add_query_arg(
+				'ver',
+				\JETPACK__VERSION,
+				plugin_dir_url( __FILE__ ) . '../../dist/contact-form/css/editor-style.css'
+			)
+		);
 	}
 
 	/**
@@ -293,6 +339,53 @@ class Editor_View {
 
 <script type="text/html" id="tmpl-grunion-field-edit-option">
 	<li><input type="text" name="option" /> <a class="delete-option" href="javascript:;"><span class="screen-reader-text"><?php esc_html_e( 'Delete Option', 'jetpack-forms' ); ?></span></a></li>
+</script>
+
+<script type="text/html" id="tmpl-grunion-form-picker-modal">
+	<div class="grunion-form-picker-overlay" tabindex="-1">
+		<div class="grunion-form-picker-dialog" role="dialog" aria-modal="true" aria-labelledby="grunion-form-picker-title">
+			<header class="grunion-form-picker-header">
+				<h1 id="grunion-form-picker-title">{{ data.labels.picker_title }}</h1>
+				<button type="button" class="grunion-form-picker-close" aria-label="{{ data.labels.picker_close }}">
+					<span aria-hidden="true">&times;</span>
+				</button>
+			</header>
+			<div class="grunion-form-picker-body">
+				<p class="grunion-form-picker-intro">{{ data.labels.picker_intro }}</p>
+				<div class="grunion-form-picker-controls">
+					<label class="grunion-form-picker-field">
+						<span>{{ data.labels.picker_select_label }}</span>
+						<select class="grunion-form-picker-select" disabled>
+							<option>{{ data.labels.picker_loading }}</option>
+						</select>
+					</label>
+					<a class="button grunion-form-picker-new" href="{{ data.new_form_url }}" target="_blank" rel="noopener noreferrer">
+						{{ data.labels.picker_new_form }}
+					</a>
+				</div>
+				<div class="grunion-form-picker-preview" aria-live="polite">
+					<h2 class="grunion-form-picker-preview-title">{{ data.labels.picker_preview }}</h2>
+					<div class="grunion-form-picker-preview-frame">
+						<p class="grunion-form-picker-preview-hint">{{ data.labels.picker_preview_hint }}</p>
+					</div>
+				</div>
+			</div>
+			<footer class="grunion-form-picker-footer">
+				<button type="button" class="button grunion-form-picker-cancel">{{ data.labels.picker_cancel }}</button>
+				<button type="button" class="button button-primary grunion-form-picker-insert" disabled>{{ data.labels.picker_insert }}</button>
+			</footer>
+		</div>
+	</div>
+</script>
+
+<script type="text/html" id="tmpl-grunion-form-picker-empty">
+	<div class="grunion-form-picker-empty">
+		<h2>{{ data.labels.picker_empty_title }}</h2>
+		<p>{{ data.labels.picker_empty_body }}</p>
+		<a class="button button-primary" href="{{ data.new_form_url }}" target="_blank" rel="noopener noreferrer">
+			{{ data.labels.picker_new_form }}
+		</a>
+	</div>
 </script>
 
 <script type="text/html" id="tmpl-grunion-editor-inline">

--- a/projects/packages/forms/src/contact-form/class-form-preview.php
+++ b/projects/packages/forms/src/contact-form/class-form-preview.php
@@ -199,6 +199,13 @@ class Form_Preview {
 		// Set preview mode flag.
 		self::$is_preview_mode = true;
 
+		// "bare" variant: render only the form itself, without theme chrome. Used by
+		// the Classic Editor inline preview so it sees a standalone form inside its iframe.
+		// Nonce / capability already verified above.
+		if ( ! empty( $_GET['bare'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			self::render_bare_preview( $form );
+		}
+
 		// Set up fake page query context.
 		$wp_query->is_page     = true;
 		$wp_query->is_singular = true;
@@ -290,6 +297,116 @@ class Form_Preview {
 		}
 
 		return $template;
+	}
+
+	/**
+	 * Render a "bare" form preview — no theme, no page chrome. Outputs a minimal
+	 * HTML document containing only the rendered form blocks and exits.
+	 *
+	 * Callers must have already verified access (nonce + capability).
+	 *
+	 * @param WP_Post $form The form post to render.
+	 * @return void
+	 */
+	private static function render_bare_preview( WP_Post $form ) {
+		// Render blocks first so any block-registered styles/scripts get enqueued
+		// before <head> / <footer> print. This mirrors how the frontend renders
+		// the form so every block (image-select, rating, etc.) contributes its
+		// own stylesheet and view script naturally.
+		self::$is_preview_mode = true;
+		ob_start();
+		foreach ( parse_blocks( $form->post_content ) as $block ) {
+			echo render_block( $block ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- render_block returns rendered HTML.
+		}
+		$rendered_form = (string) ob_get_clean();
+
+		// Form frontend stylesheet.
+		wp_enqueue_style( 'grunion.css' );
+		self::enqueue_preview_styles();
+
+		status_header( 200 );
+		nocache_headers();
+		header( 'Content-Type: text/html; charset=' . get_bloginfo( 'charset' ) );
+
+		?><!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title><?php echo esc_html__( 'Form preview', 'jetpack-forms' ); ?></title>
+		<?php
+		// Print everything wp_head would: registered styles (block styles, theme
+		// global styles via theme.json, the form's frontend CSS) and early scripts.
+		// Don't call wp_head() directly so we skip theme <head> injections we don't
+		// want (favicons, generator meta, SEO plugins, etc.).
+		wp_print_styles();
+		wp_custom_css_cb();
+		if ( function_exists( 'wp_print_font_faces' ) ) {
+			wp_print_font_faces();
+		}
+		if ( function_exists( 'wp_enqueue_global_styles' ) ) {
+			wp_enqueue_global_styles();
+			wp_print_styles();
+		}
+		?>
+	<style>
+		html, body { margin: 0; padding: 0; background: #fff; }
+		body {
+			font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+			padding: 16px;
+			color: #1d2327;
+			box-sizing: border-box;
+		}
+		/* Form should fill the preview iframe — ignore theme contentSize limits
+			and any user-set border on the form block. */
+		body.jetpack-form-bare-preview .wp-block-jetpack-contact-form,
+		body.jetpack-form-bare-preview .contact-form {
+			max-width: none !important;
+			width: 100%;
+			margin-left: 0;
+			margin-right: 0;
+			border: 0 !important;
+			box-shadow: none !important;
+		}
+		/* Fallback submit-button styling — classic themes (no theme.json) leave
+			wp-element-button unstyled and the browser paints its default 2px
+			outset. :where() keeps specificity at 0 so block themes' global
+			styles always win. */
+		:where(
+			body.jetpack-form-bare-preview .wp-block-button__link,
+			body.jetpack-form-bare-preview .wp-element-button,
+			body.jetpack-form-bare-preview button[type="submit"]
+		) {
+			background-color: #1e1e1e;
+			color: #fff;
+			border: 0;
+			border-radius: 2px;
+			padding: 0.667em 1.333em;
+			line-height: 1.2;
+			text-decoration: none;
+			cursor: default;
+		}
+		/* Preview only — disable interaction. */
+		body.jetpack-form-bare-preview form,
+		body.jetpack-form-bare-preview input,
+		body.jetpack-form-bare-preview textarea,
+		body.jetpack-form-bare-preview select,
+		body.jetpack-form-bare-preview button {
+			pointer-events: none;
+		}
+	</style>
+</head>
+<body class="jetpack-form-bare-preview">
+		<?php echo $rendered_form; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Already-rendered block HTML. ?>
+		<?php
+		// Print any block-registered footer styles/scripts (e.g. view scripts for
+		// interactive fields like image-select, rating).
+		wp_print_footer_scripts();
+		?>
+</body>
+</html>
+		<?php
+		exit;
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/css/editor-style.css
+++ b/projects/packages/forms/src/contact-form/css/editor-style.css
@@ -538,3 +538,53 @@ input[type="submit"]:focus {
 	margin-top: 0;
 	margin-bottom: 0;
 }
+
+/* Inline preview for [contact-form ref="{id}"] — the form is rendered inside
+   an iframe loading the site's bare preview URL, so every block-specific style
+   and script loads naturally (mirrors what the frontend shows). */
+
+/* Force block + full width on the wpview wrapper and our own wrapper. Firefox
+   otherwise falls back to the iframe's 300px HTML default because the wpview
+   wrapper doesn't always resolve to a block formatting context. */
+.wpview.wpview-wrap[data-wpview-type="contact-form"] {
+	display: block;
+	width: 100%;
+}
+
+.wpview.wpview-wrap[data-wpview-type="contact-form"] .jetpack-contact-form-ref-preview {
+	position: relative;
+	display: block;
+	box-sizing: border-box;
+	width: 100%;
+	padding: 0;
+	margin: 0;
+	background: #fff;
+	min-height: 120px;
+}
+
+.jetpack-contact-form-ref-preview.is-loaded {
+	min-height: 0;
+}
+
+.jetpack-contact-form-ref-preview .grunion-ref-preview-hint {
+	margin: 0;
+	padding: 24px;
+	color: #646970;
+	font-style: italic;
+	text-align: center;
+	background: #f6f7f7;
+}
+
+.wpview.wpview-wrap[data-wpview-type="contact-form"] .grunion-ref-preview-iframe {
+	display: block;
+	box-sizing: border-box;
+	width: 100%;
+	min-width: 100%;
+	max-width: 100%;
+	height: 320px;
+	border: 0;
+	background: #fff;
+
+	/* Prevent clicks inside the preview iframe from stealing TinyMCE selection. */
+	pointer-events: none;
+}

--- a/projects/packages/forms/src/contact-form/css/editor-ui.css
+++ b/projects/packages/forms/src/contact-form/css/editor-ui.css
@@ -16,3 +16,150 @@ i.mce-i-grunion::before,
 	height: 18px;
 	font: 18px/1 dashicons;
 }
+
+/* Pick-existing-form modal (classic editor). */
+.grunion-form-picker-overlay {
+	position: fixed;
+	inset: 0;
+	background: rgba(0, 0, 0, 0.5);
+	z-index: 160000;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 20px;
+	box-sizing: border-box;
+}
+
+.grunion-form-picker-dialog {
+	background: #fff;
+	width: 100%;
+	max-width: 780px;
+	max-height: calc(100vh - 40px);
+	display: flex;
+	flex-direction: column;
+	border-radius: 4px;
+	box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+	overflow: hidden;
+}
+
+.grunion-form-picker-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 16px 20px;
+	border-bottom: 1px solid #dcdcde;
+}
+
+.grunion-form-picker-header h1 {
+	margin: 0;
+	font-size: 18px;
+	line-height: 1.4;
+}
+
+.grunion-form-picker-close {
+	background: transparent;
+	border: 0;
+	font-size: 24px;
+	line-height: 1;
+	cursor: pointer;
+	padding: 4px 8px;
+	color: #1d2327;
+}
+
+.grunion-form-picker-close:hover,
+.grunion-form-picker-close:focus {
+	color: #2271b1;
+}
+
+.grunion-form-picker-body {
+	padding: 16px 20px;
+	overflow-y: auto;
+	flex: 1 1 auto;
+}
+
+.grunion-form-picker-intro {
+	margin-top: 0;
+}
+
+.grunion-form-picker-controls {
+	display: flex;
+	gap: 12px;
+	align-items: flex-end;
+	flex-wrap: wrap;
+	margin-bottom: 16px;
+}
+
+.grunion-form-picker-field {
+	flex: 1 1 260px;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.grunion-form-picker-field span {
+	font-weight: 600;
+}
+
+.grunion-form-picker-select {
+	width: 100%;
+	min-height: 32px;
+}
+
+.grunion-form-picker-preview {
+	border: 1px solid #dcdcde;
+	border-radius: 4px;
+	background: #f6f7f7;
+}
+
+.grunion-form-picker-preview-title {
+	margin: 0;
+	padding: 8px 12px;
+	font-size: 13px;
+	border-bottom: 1px solid #dcdcde;
+	background: #fff;
+}
+
+.grunion-form-picker-preview-frame {
+	min-height: 280px;
+	max-height: 50vh;
+	overflow: auto;
+	padding: 0;
+	background: #fff;
+	display: flex;
+	align-items: stretch;
+	justify-content: stretch;
+}
+
+.grunion-form-picker-preview-frame .grunion-form-picker-preview-hint {
+	margin: auto;
+	padding: 24px;
+	color: #646970;
+	font-style: italic;
+	text-align: center;
+}
+
+.grunion-form-picker-preview-iframe {
+	width: 100%;
+	min-height: 320px;
+	border: 0;
+	background: #fff;
+}
+
+.grunion-form-picker-empty {
+	text-align: center;
+	padding: 24px 12px;
+}
+
+.grunion-form-picker-empty h2 {
+	margin-top: 0;
+}
+
+.grunion-form-picker-footer {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+	padding: 12px 20px;
+	border-top: 1px solid #dcdcde;
+	background: #f6f7f7;
+}
+

--- a/projects/packages/forms/src/contact-form/js/editor-view.js
+++ b/projects/packages/forms/src/contact-form/js/editor-view.js
@@ -6,6 +6,24 @@
 		return;
 	}
 
+	function buildRefShortcode( refId ) {
+		return '[contact-form ref="' + refId + '"]';
+	}
+
+	function appendBareParam( url ) {
+		return url + ( url.indexOf( '?' ) > -1 ? '&' : '?' ) + 'bare=1';
+	}
+
+	function grunionGet( url ) {
+		return $.ajax( {
+			url: url,
+			method: 'GET',
+			beforeSend: function ( xhr ) {
+				xhr.setRequestHeader( 'X-WP-Nonce', grunionEditorView.rest_nonce );
+			},
+		} );
+	}
+
 	wp.mce.grunion_wp_view_renderer = {
 		shortcode_string: 'contact-form',
 		template: wp.template( 'grunion-contact-form' ),
@@ -25,7 +43,130 @@
 		edit_template: wp.template( 'grunion-field-edit' ),
 		editor_inline: wp.template( 'grunion-editor-inline' ),
 		editor_option: wp.template( 'grunion-field-edit-option' ),
+		ref_preview_promises: {},
+		fetchRefPreviewUrl: function ( refId ) {
+			if ( this.ref_preview_promises[ refId ] ) {
+				return this.ref_preview_promises[ refId ];
+			}
+			const url = grunionEditorView.rest_url + '/' + encodeURIComponent( refId ) + '/preview-url';
+			const deferred = $.Deferred();
+			grunionGet( url )
+				.done( function ( response ) {
+					if ( response && response.preview_url ) {
+						deferred.resolve( appendBareParam( response.preview_url ) );
+					} else {
+						deferred.reject();
+					}
+				} )
+				.fail( function () {
+					deferred.reject();
+				} );
+			this.ref_preview_promises[ refId ] = deferred.promise();
+			return this.ref_preview_promises[ refId ];
+		},
+		resizeRefIframe: function ( iframe ) {
+			try {
+				const doc = iframe.contentDocument || iframe.contentWindow.document;
+				if ( ! doc || ! doc.body ) {
+					return;
+				}
+				const height = Math.max(
+					doc.body.scrollHeight,
+					doc.documentElement ? doc.documentElement.scrollHeight : 0
+				);
+				if ( height <= 0 ) {
+					return;
+				}
+				const target = height + 10;
+				// Skip no-op writes so we don't trigger needless reflow each tick.
+				if ( iframe._grunionAppliedHeight === target ) {
+					return;
+				}
+				iframe._grunionAppliedHeight = target;
+				iframe.style.height = target + 'px';
+			} catch {
+				/* cross-origin fallback — leave default height */
+			}
+		},
+		hydrateRefPreviews: function () {
+			const self = this;
+			if ( ! window.tinyMCE || ! tinyMCE.activeEditor ) {
+				return;
+			}
+			const doc = tinyMCE.activeEditor.getDoc();
+			if ( ! doc ) {
+				return;
+			}
+			const wraps = doc.querySelectorAll(
+				'.jetpack-contact-form-ref-preview[data-form-ref]:not([data-grunion-loaded])'
+			);
+			wraps.forEach( function ( wrap ) {
+				const refId = parseInt( wrap.getAttribute( 'data-form-ref' ), 10 );
+				if ( ! refId ) {
+					return;
+				}
+				wrap.setAttribute( 'data-grunion-loaded', '1' );
+				self
+					.fetchRefPreviewUrl( refId )
+					.done( function ( previewUrl ) {
+						const iframe = wrap.querySelector( 'iframe.grunion-ref-preview-iframe' );
+						if ( ! iframe ) {
+							return;
+						}
+						iframe.addEventListener( 'load', function () {
+							self.resizeRefIframe( iframe );
+							// Re-measure after late-loading images/scripts settle.
+							setTimeout( function () {
+								self.resizeRefIframe( iframe );
+							}, 300 );
+							setTimeout( function () {
+								self.resizeRefIframe( iframe );
+							}, 1000 );
+							const hint = wrap.querySelector( '.grunion-ref-preview-hint' );
+							if ( hint ) {
+								hint.style.display = 'none';
+							}
+							wrap.classList.add( 'is-loaded' );
+						} );
+						iframe.setAttribute( 'src', previewUrl );
+					} )
+					.fail( function () {
+						wrap.removeAttribute( 'data-grunion-loaded' );
+						const hint = wrap.querySelector( '.grunion-ref-preview-hint' );
+						if ( hint ) {
+							hint.textContent = grunionEditorView.labels.ref_preview_error;
+						}
+					} );
+			} );
+		},
+		getRefContent: function ( refId ) {
+			const self = this;
+			// Hydrate once the view is mounted in TinyMCE.
+			setTimeout( function () {
+				self.hydrateRefPreviews();
+			}, 50 );
+			return (
+				'<div class="jetpack-contact-form-ref-preview" data-form-ref="' +
+				refId +
+				'">' +
+				'<p class="grunion-ref-preview-hint">' +
+				grunionEditorView.labels.ref_preview_loading +
+				'</p>' +
+				// width="100%" as an HTML attribute so the iframe stretches even
+				// if no CSS reaches it. Browsers map this to width:100%.
+				'<iframe class="grunion-ref-preview-iframe" scrolling="no" width="100%" frameborder="0" title="' +
+				grunionEditorView.labels.ref_preview_title +
+				'"></iframe>' +
+				'</div>'
+			);
+		},
 		getContent: function () {
+			const namedAttrs = ( this.shortcode.attrs && this.shortcode.attrs.named ) || {};
+			const refId = parseInt( namedAttrs.ref, 10 );
+			if ( refId > 0 ) {
+				return this.getRefContent( refId );
+			}
+
 			let content = this.shortcode.content,
 				index = 0,
 				field,
@@ -61,17 +202,34 @@
 			return this.template( options );
 		},
 		edit: function ( data, update_callback ) {
-			let shortcode_data = wp.shortcode.next( this.shortcode_string, data ),
-				shortcode = shortcode_data.shortcode,
-				$tinyMCE_document = $( tinyMCE.activeEditor.getDoc() ),
-				$view = $tinyMCE_document.find( '.wpview.wpview-wrap' ).filter( function () {
-					return $( this ).attr( 'data-mce-selected' );
-				} ),
-				$editframe = $( '<iframe scrolling="no" class="inline-edit-contact-form" />' ),
-				index = 0,
-				named,
-				fields = '',
-				field;
+			const shortcode_data = wp.shortcode.next( this.shortcode_string, data );
+			const shortcode = shortcode_data.shortcode;
+
+			// Synced forms (ref attribute) are managed in the form editor, not inline.
+			const refId = parseInt(
+				( shortcode.attrs && shortcode.attrs.named && shortcode.attrs.named.ref ) || '',
+				10
+			);
+			if ( refId > 0 ) {
+				// Restore the original shortcode so the view doesn't get stuck in edit mode.
+				update_callback( wp.shortcode.string( shortcode ) );
+				const template = grunionEditorView.edit_form_url_template || '';
+				if ( template ) {
+					const url = template.replace( '%d', String( refId ) );
+					window.open( url, '_blank', 'noopener' );
+				}
+				return;
+			}
+
+			const $tinyMCE_document = $( tinyMCE.activeEditor.getDoc() );
+			const $view = $tinyMCE_document.find( '.wpview.wpview-wrap' ).filter( function () {
+				return $( this ).attr( 'data-mce-selected' );
+			} );
+			const $editframe = $( '<iframe scrolling="no" class="inline-edit-contact-form" />' );
+			let index = 0;
+			let named;
+			let fields = '';
+			let field;
 
 			if ( ! shortcode.content ) {
 				shortcode.content = grunionEditorView.default_form;
@@ -230,20 +388,263 @@
 	};
 	wp.mce.views.register( 'contact-form', wp.mce.grunion_wp_view_renderer );
 
-	// Add the 'text' editor button.
+	const FormPickerModal = ( function () {
+		const labels = grunionEditorView.labels;
+		const modalTemplate = wp.template( 'grunion-form-picker-modal' );
+		const emptyTemplate = wp.template( 'grunion-form-picker-empty' );
+
+		let $overlay = null;
+		let $dialog = null;
+		let $select = null;
+		let $previewFrame = null;
+		let $insertBtn = null;
+		let invokingElement = null;
+		let pendingEditor = null;
+		let previewRequest = 0;
+
+		function getActiveEditor() {
+			if ( pendingEditor ) {
+				return pendingEditor;
+			}
+			const $wrap = $( '#wp-content-wrap' );
+			if ( $wrap.hasClass( 'tmce-active' ) && window.tinyMCE && tinyMCE.activeEditor ) {
+				return tinyMCE.activeEditor;
+			}
+			return null;
+		}
+
+		function insertShortcode( shortcode ) {
+			const editor = getActiveEditor();
+			if ( editor && ! editor.isHidden() ) {
+				editor.execCommand( 'mceInsertContent', 0, shortcode );
+				return true;
+			}
+			if ( window.QTags && $( '#wp-content-wrap' ).hasClass( 'html-active' ) ) {
+				QTags.insertContent( shortcode );
+				return true;
+			}
+			if ( window.tinyMCE && tinyMCE.activeEditor ) {
+				tinyMCE.activeEditor.execCommand( 'mceInsertContent', 0, shortcode );
+				return true;
+			}
+			window.console.error( 'Neither TinyMCE nor QuickTags is active. Unable to insert form.' );
+			return false;
+		}
+
+		function renderEmptyState() {
+			const $body = $dialog.find( '.grunion-form-picker-body' );
+			$body.html(
+				emptyTemplate( {
+					labels: labels,
+					new_form_url: grunionEditorView.new_form_url,
+				} )
+			);
+			$dialog.find( '.grunion-form-picker-insert' ).prop( 'disabled', true ).hide();
+		}
+
+		function fetchForms() {
+			return grunionGet(
+				grunionEditorView.rest_url +
+					'?per_page=100&status=publish&orderby=modified&order=desc&_fields=id,title,modified,status'
+			);
+		}
+
+		function fetchPreviewUrl( formId ) {
+			return grunionGet(
+				grunionEditorView.rest_url + '/' + encodeURIComponent( formId ) + '/preview-url'
+			);
+		}
+
+		function populateSelect( forms ) {
+			$select.empty().prop( 'disabled', false );
+			$select.append(
+				$( '<option />', {
+					value: '',
+					text: labels.picker_placeholder,
+				} )
+			);
+
+			forms.forEach( function ( form ) {
+				const title =
+					( form.title && form.title.rendered && form.title.rendered.trim() ) ||
+					labels.picker_untitled;
+				$select.append(
+					$( '<option />', {
+						value: form.id,
+						text: title,
+					} )
+				);
+			} );
+		}
+
+		function showPreviewMessage( message ) {
+			$previewFrame.html(
+				$( '<p />', {
+					class: 'grunion-form-picker-preview-hint',
+					text: message,
+				} )
+			);
+		}
+
+		function loadPreview( formId ) {
+			previewRequest++;
+			const requestId = previewRequest;
+
+			showPreviewMessage( labels.picker_loading );
+
+			fetchPreviewUrl( formId )
+				.done( function ( response ) {
+					if ( requestId !== previewRequest || ! $previewFrame ) {
+						return;
+					}
+					if ( ! response || ! response.preview_url ) {
+						showPreviewMessage( labels.picker_preview_err );
+						return;
+					}
+					const $iframe = $( '<iframe />', {
+						src: appendBareParam( response.preview_url ),
+						class: 'grunion-form-picker-preview-iframe',
+						title: labels.picker_preview,
+					} );
+					$previewFrame.empty().append( $iframe );
+				} )
+				.fail( function () {
+					if ( requestId !== previewRequest || ! $previewFrame ) {
+						return;
+					}
+					showPreviewMessage( labels.picker_preview_err );
+				} );
+		}
+
+		function onChange() {
+			const formId = parseInt( $select.val(), 10 );
+			if ( ! formId ) {
+				$insertBtn.prop( 'disabled', true );
+				showPreviewMessage( labels.picker_preview_hint );
+				return;
+			}
+			$insertBtn.prop( 'disabled', false );
+			loadPreview( formId );
+		}
+
+		function onInsert() {
+			const formId = parseInt( $select.val(), 10 );
+			if ( ! formId ) {
+				return;
+			}
+			if ( insertShortcode( buildRefShortcode( formId ) ) ) {
+				close();
+			}
+		}
+
+		function onKeydown( e ) {
+			if ( e.key === 'Escape' || e.keyCode === 27 ) {
+				e.preventDefault();
+				close();
+			}
+		}
+
+		function close() {
+			if ( ! $overlay ) {
+				return;
+			}
+			$( document ).off( 'keydown.grunionFormPicker' );
+			$overlay.remove();
+			$overlay = null;
+			$dialog = null;
+			$select = null;
+			$previewFrame = null;
+			$insertBtn = null;
+			pendingEditor = null;
+			previewRequest = 0;
+			if ( invokingElement && typeof invokingElement.focus === 'function' ) {
+				try {
+					invokingElement.focus();
+				} catch {
+					/* no-op */
+				}
+			}
+			invokingElement = null;
+		}
+
+		function open( opts ) {
+			if ( $overlay ) {
+				return;
+			}
+			opts = opts || {};
+			invokingElement = opts.invokingElement || document.activeElement;
+			pendingEditor = opts.editor || null;
+
+			$overlay = $(
+				modalTemplate( {
+					labels: labels,
+					new_form_url: grunionEditorView.new_form_url,
+				} )
+			);
+			$dialog = $overlay.find( '.grunion-form-picker-dialog' );
+			$select = $overlay.find( '.grunion-form-picker-select' );
+			$previewFrame = $overlay.find( '.grunion-form-picker-preview-frame' );
+			$insertBtn = $overlay.find( '.grunion-form-picker-insert' );
+
+			$( 'body' ).append( $overlay );
+
+			$overlay.on( 'click', function ( e ) {
+				if ( e.target === $overlay[ 0 ] ) {
+					close();
+				}
+			} );
+			$overlay
+				.find( '.grunion-form-picker-close, .grunion-form-picker-cancel' )
+				.on( 'click', close );
+			$overlay.on( 'change', '.grunion-form-picker-select', onChange );
+			$overlay.on( 'click', '.grunion-form-picker-insert', onInsert );
+			$( document ).on( 'keydown.grunionFormPicker', onKeydown );
+
+			setTimeout( function () {
+				const $focusTarget = $dialog.find( '.grunion-form-picker-close' );
+				if ( $focusTarget.length ) {
+					$focusTarget.trigger( 'focus' );
+				}
+			}, 0 );
+
+			fetchForms()
+				.done( function ( forms ) {
+					if ( ! $overlay ) {
+						return;
+					}
+					if ( ! Array.isArray( forms ) || forms.length === 0 ) {
+						renderEmptyState();
+						return;
+					}
+					populateSelect( forms );
+				} )
+				.fail( function () {
+					if ( ! $overlay ) {
+						return;
+					}
+					$select.empty().prop( 'disabled', true );
+					$select.append( $( '<option />', { text: labels.picker_load_error } ) );
+				} );
+		}
+
+		return { open: open, close: close };
+	} )();
+
 	QTags.addButton( 'grunion_shortcode', grunionEditorView.labels.quicktags_label, function () {
-		QTags.insertContent( '[contact-form]' + grunionEditorView.default_form + '[/contact-form]' );
+		FormPickerModal.open( { invokingElement: document.activeElement } );
 	} );
 
-	const $wp_content_wrap = $( '#wp-content-wrap' );
-	$( '#insert-jetpack-contact-form' ).on( 'click', function ( e ) {
+	$( document ).on( 'click', '#insert-jetpack-contact-form', function ( e ) {
 		e.preventDefault();
-		if ( $wp_content_wrap.hasClass( 'tmce-active' ) ) {
-			tinyMCE.execCommand( 'grunion_add_form' );
-		} else if ( $wp_content_wrap.hasClass( 'html-active' ) ) {
-			QTags.insertContent( '[contact-form]' + grunionEditorView.default_form + '[/contact-form]' );
-		} else {
-			window.console.error( 'Neither TinyMCE nor QuickTags is active. Unable to insert form.' );
-		}
+		FormPickerModal.open( { invokingElement: this } );
+	} );
+
+	// TinyMCE toolbar button dispatches this event via its mce command.
+	$( document ).on( 'grunion:openFormPicker', function ( e, payload ) {
+		payload = payload || {};
+		FormPickerModal.open( {
+			editor: payload.editor || null,
+			invokingElement: document.activeElement,
+		} );
 	} );
 } )( jQuery, wp, grunionEditorView );

--- a/projects/packages/forms/src/contact-form/js/tinymce-plugin-form-button.js
+++ b/projects/packages/forms/src/contact-form/js/tinymce-plugin-form-button.js
@@ -8,15 +8,10 @@
 				icon: 'grunion',
 			} );
 			editor.addCommand( 'grunion_add_form', function () {
-				if ( grunionEditorView.default_form ) {
-					editor.execCommand(
-						'mceInsertContent',
-						0,
-						'[contact-form]' + grunionEditorView.default_form + '[/contact-form]'
-					);
-				} else {
-					editor.execCommand( 'mceInsertContent', 0, '[contact-form /]' );
-				}
+				jQuery( document ).trigger( 'grunion:openFormPicker', {
+					editor: editor,
+					source: 'tinymce',
+				} );
 			} );
 		},
 


### PR DESCRIPTION
Fixes FORMS-642

## Proposed changes
* Classic Editor: replace the default "Add Contact Form" media button, TinyMCE toolbar button, and Text-editor "contact form" quicktag so they all open a new modal instead of scaffolding a raw `[contact-form]…[/contact-form]` shortcode inline.
* The modal lets the user pick from their existing `jetpack_form` posts (fetched via `/wp/v2/jetpack-forms`), previews the selected form in an iframe, and inserts a `[contact-form ref="{id}"]` shortcode on confirm.
* Empty state in the modal links to `wp-admin/post-new.php?post_type=jetpack_form` so users create new forms in the real forms editor.
* Inline `[contact-form ref="{id}"]` references now render the real form in the TinyMCE view via an iframe loading the existing preview URL with a new `&bare=1` mode that strips theme chrome but keeps all block/theme CSS. The pencil on a ref-based preview opens the form editor (`wp-admin/post.php?post={id}&action=edit`) in a new tab.
* Gated on the `central-form-management` feature flag: when CFM is disabled, no button is registered — the legacy inline shortcode editor for existing `[contact-form][contact-field …]` content is left completely untouched so older sites keep working.

Modal: Form picker

<img width="816" height="590" alt="Screenshot 2026-04-13 at 9 06 44 PM" src="https://github.com/user-attachments/assets/2710f3f5-0bd9-448c-a6b9-bfe93acfde4f" />

Form in the editor is a preview of the form. You can click the little pencil which takes you to the form editor for that form.

<img width="697" height="814" alt="Screenshot 2026-04-13 at 9 07 06 PM" src="https://github.com/user-attachments/assets/2e9f247f-ede5-4d7c-9cbc-233edad658f3" />


## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No — reuses the existing preview nonce + `edit_post` capability check for the bare-preview query.

## Testing instructions

### Setup
1. Activate the **Classic Editor** plugin on a site with Jetpack Forms and CFM enabled (default since #47826).
2. Have at least one `jetpack_form` post published via the Forms dashboard (or create one from the modal's empty state).
3. Open a post/page for editing in the classic editor.

### Primary path — new insertion flow
4. Click **Add Contact Form** (media button). The new modal opens with:
   * a "Choose a form…" dropdown listing your saved forms (most-recently-modified first),
   * a preview iframe that shows the real form when one is selected,
   * a "Create a new form" button that opens `post-new.php?post_type=jetpack_form` in a new tab.
5. Select a form → the iframe loads a clean preview (no theme header/footer).
6. Click **Insert form** → `[contact-form ref="{id}"]` lands in the editor. The inline TinyMCE preview should render the real form (fields + submit button). Publish and view on the frontend to confirm the form renders.
7. Repeat via the TinyMCE toolbar form button (same modal).
8. Switch to **Code** view, click the `contact form` quicktag → same modal opens; inserting uses `QTags.insertContent`.
9. With the modal open, verify **Escape**, clicking the overlay, clicking **Cancel**, and clicking the ✕ all close it without inserting. Focus returns to the button that opened it.

### Ref-based inline preview
10. With a `[contact-form ref="{id}"]` in the post, switch to Visual mode. The TinyMCE view should show the full form rendered inline, not a generic placeholder.
11. Click the pencil on the view → opens `post.php?post={id}&action=edit` in a new tab; the view exits edit mode cleanly in the post.

### Legacy behavior preserved
12. In a post containing a legacy `[contact-form]…[contact-field …]…[/contact-form]` (no `ref`), the inline field editor (pencil) should still work exactly as before — add/remove/reorder fields in the iframe editor.

### CFM disabled
13. Add `add_filter( 'jetpack_forms_alpha', '__return_false' );` via an mu-plugin (or equivalent). Reload the editor. The **Add Contact Form** media button, TinyMCE toolbar button, and quicktag should all be absent; the legacy inline editor for existing shortcodes continues to work.

### Empty state
14. Trash all `jetpack_form` posts, open the modal → empty state with **Create a new form** button linking to `post-new.php?post_type=jetpack_form`. No insert button is shown.

### Cross-browser
15. Chrome and Firefox both show the preview iframe at full editor width with the image-select / rating / file field blocks rendered correctly.

