### PR TITLE
External Media: fix Import Media button styles for WordPress 7.0

### DIFF
--- a/projects/packages/external-media/changelog/fix-external-media-import-button-wp70-styles
+++ b/projects/packages/external-media/changelog/fix-external-media-import-button-wp70-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Media Library: fix Import Media button styling for WordPress 7.0.

--- a/projects/packages/external-media/src/features/admin/external-media-import-button.js
+++ b/projects/packages/external-media/src/features/admin/external-media-import-button.js
@@ -8,7 +8,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		buttonContainer.className = 'wpcom-media-library-action-buttons';
 
 		const importButton = document.createElement( 'a' );
-		importButton.className = 'button-secondary';
+		importButton.className = 'page-title-action';
 		importButton.role = 'button';
 		importButton.innerHTML = __( 'Import Media', 'jetpack-external-media' );
 		importButton.href = window.JETPACK_EXTERNAL_MEDIA_IMPORT_BUTTON?.href;

--- a/projects/packages/external-media/src/features/admin/external-media-import-button.scss
+++ b/projects/packages/external-media/src/features/admin/external-media-import-button.scss
@@ -8,18 +8,8 @@
 		top: -3px;
 		vertical-align: baseline;
 
-		@media screen and (max-width: 782px) {
-
-			& {
-				margin-left: 0 !important;
-			}
-
-			&.button-secondary {
-				font-size: 14px;
-				padding: 10px 15px;
-				margin-bottom: 0;
-				line-height: 2.15384615;
-			}
+		&.page-title-action {
+			margin-left: 0;
 		}
 	}
 }


### PR DESCRIPTION
## Proposed changes
* Switch the Import Media button in the media library from `.button-secondary` to `.page-title-action`. In WordPress 7.0, `.button-secondary` hardcodes `line-height: 2.92307692`, which distorts the button's height next to the adjacent "Add New" button.
* Override the default `margin-left: 4px` on `.page-title-action` inside `.wpcom-media-library-action-buttons`, since the flex container already provides a 4px gap.
* Drop the now-redundant `@media (max-width: 782px)` block — core WP admin already styles `.page-title-action` appropriately at that breakpoint.

| Before | After |
| --- | --- |
| <img width="536" height="144" alt="Screenshot 2026-04-14 at 1 16 40 PM" src="https://github.com/user-attachments/assets/6cc47b9d-cd1c-4559-b05f-f0238db5eae4" /> | <img width="521" height="121" alt="Screenshot 2026-04-14 at 1 16 25 PM" src="https://github.com/user-attachments/assets/5168829e-4356-49ed-9fc0-76d89d6793b9" /> |

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Spin up a site running WordPress 7.0 with the External Media feature enabled (e.g., via the Jetpack plugin or the `jetpack-external-media` package).
* Visit `/wp-admin/upload.php`.
* Confirm the "Import Media" button appears next to the "Add New Media File" button and is the same height/size.
* Confirm the spacing between the two buttons is 4px (no doubled gap).
* Resize the viewport below 782px and confirm both buttons still render at the expected mobile size with consistent spacing.
