### PR TITLE
Image Studio: Add isDevMode property to imageStudioData

### DIFF
--- a/projects/plugins/jetpack/changelog/image-studio-devmode-prop
+++ b/projects/plugins/jetpack/changelog/image-studio-devmode-prop
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-Image Studio: Add isDevMode property to imageStudioData for dev/test environment detection
+Image Studio: Add isDevMode property to imageStudioData for dev/test environment detection.

--- a/projects/plugins/jetpack/changelog/image-studio-devmode-prop
+++ b/projects/plugins/jetpack/changelog/image-studio-devmode-prop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Image Studio: Add isDevMode property to imageStudioData for dev/test environment detection

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -66,6 +66,53 @@ function is_ciab_environment() {
 }
 
 /**
+ * Check if the site is in a development/testing environment.
+ *
+ * Matches the logic in Agents_Manager::is_dev_mode() so that analytics
+ * events fired from Image Studio can be tagged with is_test on the
+ * Calypso side.
+ *
+ * @return bool
+ */
+function is_dev_mode() {
+	// Known local environments.
+	$domain = wp_parse_url( get_site_url(), PHP_URL_HOST );
+	if (
+		$domain === 'localhost' ||
+		'.jurassic.tube' === stristr( $domain, '.jurassic.tube' ) ||
+		'.jurassic.ninja' === stristr( $domain, '.jurassic.ninja' )
+	) {
+		return true;
+	}
+
+	// Proxied A8C request via function.
+	if ( function_exists( 'wpcom_is_proxied_request' ) && wpcom_is_proxied_request() ) {
+		return true;
+	}
+
+	// Proxied A8C request via server variable or constant.
+	if (
+		( isset( $_SERVER['A8C_PROXIED_REQUEST'] ) && (bool) sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) ) ) ||
+		( defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST )
+	) {
+		return true;
+	}
+
+	if ( defined( 'AT_PROXIED_REQUEST' ) && AT_PROXIED_REQUEST && defined( 'ATOMIC_CLIENT_ID' ) ) {
+		switch ( ATOMIC_CLIENT_ID ) {
+			case 1:
+			case 2:
+			case 3: // Pressable
+			case 32:
+			case 118: // Commerce garden client (ciab)
+				return true;
+		}
+	}
+
+	return false;
+}
+
+/**
  * Signal to Big Sky that Jetpack is handling Image Studio.
  *
  * Sets the jetpack_image_studio_enabled filter to true so that
@@ -294,8 +341,9 @@ function do_enqueue_assets() {
 	);
 
 	$image_studio_data = array(
-		'enabled' => true,
-		'version' => '1.0',
+		'enabled'   => true,
+		'version'   => '1.0',
+		'isDevMode' => is_dev_mode(),
 	);
 
 	wp_add_inline_script(

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -72,6 +72,11 @@ function is_ciab_environment() {
  * events fired from Image Studio can be tagged with is_test on the
  * Calypso side.
  *
+ * Note: This intentionally duplicates the logic from
+ * Agents_Manager::is_dev_mode() in jetpack-mu-wpcom rather than calling
+ * it directly, because that package is only available on WordPress.com
+ * hosted sites, while Image Studio also runs on self-hosted Jetpack sites.
+ *
  * @return bool
  */
 function is_dev_mode() {

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -296,7 +296,7 @@ function do_enqueue_assets() {
 	$image_studio_data = array(
 		'enabled'   => true,
 		'version'   => '1.0',
-		'isDevMode' => jetpack_is_dev_mode(),
+		'isDevMode' => jetpack_is_internal_testing_environment(),
 	);
 
 	wp_add_inline_script(

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -66,58 +66,6 @@ function is_ciab_environment() {
 }
 
 /**
- * Check if the site is in a development/testing environment.
- *
- * Matches the logic in Agents_Manager::is_dev_mode() so that analytics
- * events fired from Image Studio can be tagged with is_test on the
- * Calypso side.
- *
- * Note: This intentionally duplicates the logic from
- * Agents_Manager::is_dev_mode() in jetpack-mu-wpcom rather than calling
- * it directly, because that package is only available on WordPress.com
- * hosted sites, while Image Studio also runs on self-hosted Jetpack sites.
- *
- * @return bool
- */
-function is_dev_mode() {
-	// Known local environments.
-	$domain = wp_parse_url( get_site_url(), PHP_URL_HOST );
-	if (
-		$domain === 'localhost' ||
-		'.jurassic.tube' === stristr( $domain, '.jurassic.tube' ) ||
-		'.jurassic.ninja' === stristr( $domain, '.jurassic.ninja' )
-	) {
-		return true;
-	}
-
-	// Proxied A8C request via function.
-	if ( function_exists( 'wpcom_is_proxied_request' ) && wpcom_is_proxied_request() ) {
-		return true;
-	}
-
-	// Proxied A8C request via server variable or constant.
-	if (
-		( isset( $_SERVER['A8C_PROXIED_REQUEST'] ) && (bool) sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) ) ) ||
-		( defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST )
-	) {
-		return true;
-	}
-
-	if ( defined( 'AT_PROXIED_REQUEST' ) && AT_PROXIED_REQUEST && defined( 'ATOMIC_CLIENT_ID' ) ) {
-		switch ( ATOMIC_CLIENT_ID ) {
-			case 1:
-			case 2:
-			case 3: // Pressable
-			case 32:
-			case 118: // Commerce garden client (ciab)
-				return true;
-		}
-	}
-
-	return false;
-}
-
-/**
  * Signal to Big Sky that Jetpack is handling Image Studio.
  *
  * Sets the jetpack_image_studio_enabled filter to true so that
@@ -348,7 +296,7 @@ function do_enqueue_assets() {
 	$image_studio_data = array(
 		'enabled'   => true,
 		'version'   => '1.0',
-		'isDevMode' => is_dev_mode(),
+		'isDevMode' => jetpack_is_dev_mode(),
 	);
 
 	wp_add_inline_script(

--- a/projects/plugins/jetpack/functions.global.php
+++ b/projects/plugins/jetpack/functions.global.php
@@ -497,12 +497,18 @@ if ( ! function_exists( 'jetpack_mastodon_get_instance_list' ) ) {
 	}
 }
 
-if ( ! function_exists( 'jetpack_is_dev_mode' ) ) {
+if ( ! function_exists( 'jetpack_is_internal_testing_environment' ) ) {
 	/**
-	 * Check if the site is in a development/testing environment.
+	 * Check if the site is an A8C-internal testing environment.
 	 *
 	 * Returns true for localhost, Jurassic Ninja/Tube sandboxes, A8C proxied
-	 * requests, and known Atomic client IDs used for internal testing.
+	 * requests, and known Atomic client IDs used for internal testing. Useful
+	 * for tagging analytics events as test traffic so they can be filtered out
+	 * of production reporting.
+	 *
+	 * Not to be confused with Jetpack's legacy "Development Mode", which is now
+	 * Status::is_offline_mode() and controls whether Jetpack connects to
+	 * WordPress.com.
 	 *
 	 * Note: This intentionally duplicates the logic from
 	 * Agents_Manager::is_dev_mode() in jetpack-mu-wpcom rather than calling
@@ -513,7 +519,7 @@ if ( ! function_exists( 'jetpack_is_dev_mode' ) ) {
 	 *
 	 * @return bool
 	 */
-	function jetpack_is_dev_mode() {
+	function jetpack_is_internal_testing_environment() {
 		// Known local environments.
 		$domain = (string) wp_parse_url( get_site_url(), PHP_URL_HOST );
 		if (

--- a/projects/plugins/jetpack/functions.global.php
+++ b/projects/plugins/jetpack/functions.global.php
@@ -496,3 +496,59 @@ if ( ! function_exists( 'jetpack_mastodon_get_instance_list' ) ) {
 		return (array) apply_filters( 'jetpack_mastodon_instance_list', $mastodon_instance_list );
 	}
 }
+
+if ( ! function_exists( 'jetpack_is_dev_mode' ) ) {
+	/**
+	 * Check if the site is in a development/testing environment.
+	 *
+	 * Returns true for localhost, Jurassic Ninja/Tube sandboxes, A8C proxied
+	 * requests, and known Atomic client IDs used for internal testing.
+	 *
+	 * Note: This intentionally duplicates the logic from
+	 * Agents_Manager::is_dev_mode() in jetpack-mu-wpcom rather than calling
+	 * it directly, because that package is only available on WordPress.com
+	 * hosted sites, while Jetpack also runs on self-hosted sites.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return bool
+	 */
+	function jetpack_is_dev_mode() {
+		// Known local environments.
+		$domain = wp_parse_url( get_site_url(), PHP_URL_HOST );
+		if (
+			$domain === 'localhost' ||
+			'.jurassic.tube' === stristr( $domain, '.jurassic.tube' ) ||
+			'.jurassic.ninja' === stristr( $domain, '.jurassic.ninja' )
+		) {
+			return true;
+		}
+
+		// Proxied A8C request via function.
+		if ( function_exists( 'wpcom_is_proxied_request' ) && wpcom_is_proxied_request() ) {
+			return true;
+		}
+
+		// Proxied A8C request via server variable or constant.
+		if (
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- boolean check only.
+			( isset( $_SERVER['A8C_PROXIED_REQUEST'] ) && (bool) sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) ) ) ||
+			( defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST )
+		) {
+			return true;
+		}
+
+		if ( defined( 'AT_PROXIED_REQUEST' ) && AT_PROXIED_REQUEST && defined( 'ATOMIC_CLIENT_ID' ) ) {
+			switch ( ATOMIC_CLIENT_ID ) {
+				case 1:
+				case 2:
+				case 3:
+				case 32:
+				case 118:
+					return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/projects/plugins/jetpack/functions.global.php
+++ b/projects/plugins/jetpack/functions.global.php
@@ -515,7 +515,7 @@ if ( ! function_exists( 'jetpack_is_dev_mode' ) ) {
 	 */
 	function jetpack_is_dev_mode() {
 		// Known local environments.
-		$domain = wp_parse_url( get_site_url(), PHP_URL_HOST );
+		$domain = (string) wp_parse_url( get_site_url(), PHP_URL_HOST );
 		if (
 			$domain === 'localhost' ||
 			'.jurassic.tube' === stristr( $domain, '.jurassic.tube' ) ||

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -558,20 +558,6 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test is_dev_mode returns true when wpcom_is_proxied_request() exists and returns true.
-	 */
-	public function test_is_dev_mode_true_for_wpcom_is_proxied_request() {
-		// Define the function if it doesn't already exist in this test run.
-		if ( ! function_exists( 'wpcom_is_proxied_request' ) ) {
-			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
-			function wpcom_is_proxied_request() {
-				return true;
-			}
-		}
-		$this->assertTrue( ImageStudio\is_dev_mode() );
-	}
-
-	/**
 	 * Test style is enqueued with wp-components dependency.
 	 */
 	public function test_style_enqueued_with_wp_components() {

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -505,6 +505,25 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test inline script includes isDevMode property.
+	 */
+	public function test_inline_script_includes_is_dev_mode() {
+		$this->enable_and_enqueue_block_editor();
+
+		$inline = $GLOBALS['wp_scripts']->get_data( ImageStudio\FEATURE_NAME, 'before' );
+
+		$this->assertIsArray( $inline );
+		$found = false;
+		foreach ( $inline as $line ) {
+			if ( is_string( $line ) && strpos( $line, 'imageStudioData' ) !== false ) {
+				$found = true;
+				$this->assertStringContainsString( '"isDevMode":', $line );
+			}
+		}
+		$this->assertTrue( $found, 'Inline script with imageStudioData not found.' );
+	}
+
+	/**
 	 * Test style is enqueued with wp-components dependency.
 	 */
 	public function test_style_enqueued_with_wp_components() {

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -50,6 +50,13 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	private $saved_wp_styles;
 
 	/**
+	 * Saved siteurl option for restoration in tear_down.
+	 *
+	 * @var string
+	 */
+	private $saved_siteurl;
+
+	/**
 	 * Set up before each test.
 	 */
 	public function set_up() {
@@ -64,7 +71,8 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 		// Ensure Big Sky is disabled by default so tests aren't affected by the
 		// Big_Sky class persisting across tests once simulate_big_sky_class() runs.
 		update_option( 'big_sky_enable', '0' );
-		$this->saved_screen = $GLOBALS['current_screen'] ?? null;
+		$this->saved_screen  = $GLOBALS['current_screen'] ?? null;
+		$this->saved_siteurl = get_option( 'siteurl' );
 	}
 
 	/**
@@ -78,6 +86,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 		remove_all_filters( 'jetpack_ai_enabled' );
 		( new \Automattic\Jetpack\Connection\Manager( 'jetpack' ) )->reset_connection_status();
 		delete_option( 'big_sky_enable' );
+		update_option( 'siteurl', $this->saved_siteurl );
 		$GLOBALS['current_screen'] = $this->saved_screen;
 		$GLOBALS['wp_scripts']     = $this->saved_wp_scripts;
 		$GLOBALS['wp_styles']      = $this->saved_wp_styles;

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -533,40 +533,6 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test is_dev_mode returns false for a production domain.
-	 */
-	public function test_is_dev_mode_returns_false_for_production() {
-		// Default test site URL is not localhost/jurassic, so should be false
-		// when no proxied-request indicators are set.
-		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
-		$this->assertFalse( ImageStudio\is_dev_mode() );
-	}
-
-	/**
-	 * Test is_dev_mode returns true for localhost.
-	 */
-	public function test_is_dev_mode_true_for_localhost() {
-		update_option( 'siteurl', 'http://localhost:8888' );
-		$this->assertTrue( ImageStudio\is_dev_mode() );
-	}
-
-	/**
-	 * Test is_dev_mode returns true for jurassic.ninja domain.
-	 */
-	public function test_is_dev_mode_true_for_jurassic_ninja() {
-		update_option( 'siteurl', 'https://mysite.jurassic.ninja' );
-		$this->assertTrue( ImageStudio\is_dev_mode() );
-	}
-
-	/**
-	 * Test is_dev_mode returns true for jurassic.tube domain.
-	 */
-	public function test_is_dev_mode_true_for_jurassic_tube() {
-		update_option( 'siteurl', 'https://mysite.jurassic.tube' );
-		$this->assertTrue( ImageStudio\is_dev_mode() );
-	}
-
-	/**
 	 * Test style is enqueued with wp-components dependency.
 	 */
 	public function test_style_enqueued_with_wp_components() {

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -524,6 +524,54 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test is_dev_mode returns false for a production domain.
+	 */
+	public function test_is_dev_mode_returns_false_for_production() {
+		// Default test site URL is not localhost/jurassic, so should be false
+		// when no proxied-request indicators are set.
+		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
+		$this->assertFalse( ImageStudio\is_dev_mode() );
+	}
+
+	/**
+	 * Test is_dev_mode returns true for localhost.
+	 */
+	public function test_is_dev_mode_true_for_localhost() {
+		update_option( 'siteurl', 'http://localhost:8888' );
+		$this->assertTrue( ImageStudio\is_dev_mode() );
+	}
+
+	/**
+	 * Test is_dev_mode returns true for jurassic.ninja domain.
+	 */
+	public function test_is_dev_mode_true_for_jurassic_ninja() {
+		update_option( 'siteurl', 'https://mysite.jurassic.ninja' );
+		$this->assertTrue( ImageStudio\is_dev_mode() );
+	}
+
+	/**
+	 * Test is_dev_mode returns true for jurassic.tube domain.
+	 */
+	public function test_is_dev_mode_true_for_jurassic_tube() {
+		update_option( 'siteurl', 'https://mysite.jurassic.tube' );
+		$this->assertTrue( ImageStudio\is_dev_mode() );
+	}
+
+	/**
+	 * Test is_dev_mode returns true when wpcom_is_proxied_request() exists and returns true.
+	 */
+	public function test_is_dev_mode_true_for_wpcom_is_proxied_request() {
+		// Define the function if it doesn't already exist in this test run.
+		if ( ! function_exists( 'wpcom_is_proxied_request' ) ) {
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
+			function wpcom_is_proxied_request() {
+				return true;
+			}
+		}
+		$this->assertTrue( ImageStudio\is_dev_mode() );
+	}
+
+	/**
 	 * Test style is enqueued with wp-components dependency.
 	 */
 	public function test_style_enqueued_with_wp_components() {

--- a/projects/plugins/jetpack/tests/php/general/Functions_Global_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Functions_Global_Test.php
@@ -8,11 +8,40 @@ use PHPUnit\Framework\Attributes\DataProvider;
  *
  * @covers ::jetpack_get_future_removed_version
  * @covers ::jetpack_get_vary_headers
+ * @covers ::jetpack_is_dev_mode
  */
 #[CoversFunction( 'jetpack_get_future_removed_version' )]
 #[CoversFunction( 'jetpack_get_vary_headers' )]
+#[CoversFunction( 'jetpack_is_dev_mode' )]
 class Functions_Global_Test extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Saved siteurl option for restoration in tear_down.
+	 *
+	 * @var string|null
+	 */
+	private $saved_siteurl;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->saved_siteurl = get_option( 'siteurl' );
+		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down() {
+		if ( null !== $this->saved_siteurl ) {
+			update_option( 'siteurl', $this->saved_siteurl );
+		}
+		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
+		parent::tear_down();
+	}
 
 	/**
 	 * Test string returned by jetpack_deprecated_function
@@ -66,5 +95,36 @@ class Functions_Global_Test extends WP_UnitTestCase {
 				'11.1',
 			),
 		);
+	}
+
+	/**
+	 * Test jetpack_is_dev_mode returns false for a production domain.
+	 */
+	public function test_jetpack_is_dev_mode_returns_false_for_production() {
+		$this->assertFalse( jetpack_is_dev_mode() );
+	}
+
+	/**
+	 * Test jetpack_is_dev_mode returns true for localhost.
+	 */
+	public function test_jetpack_is_dev_mode_true_for_localhost() {
+		update_option( 'siteurl', 'http://localhost:8888' );
+		$this->assertTrue( jetpack_is_dev_mode() );
+	}
+
+	/**
+	 * Test jetpack_is_dev_mode returns true for jurassic.ninja domain.
+	 */
+	public function test_jetpack_is_dev_mode_true_for_jurassic_ninja() {
+		update_option( 'siteurl', 'https://mysite.jurassic.ninja' );
+		$this->assertTrue( jetpack_is_dev_mode() );
+	}
+
+	/**
+	 * Test jetpack_is_dev_mode returns true for jurassic.tube domain.
+	 */
+	public function test_jetpack_is_dev_mode_true_for_jurassic_tube() {
+		update_option( 'siteurl', 'https://mysite.jurassic.tube' );
+		$this->assertTrue( jetpack_is_dev_mode() );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/general/Functions_Global_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Functions_Global_Test.php
@@ -8,11 +8,11 @@ use PHPUnit\Framework\Attributes\DataProvider;
  *
  * @covers ::jetpack_get_future_removed_version
  * @covers ::jetpack_get_vary_headers
- * @covers ::jetpack_is_dev_mode
+ * @covers ::jetpack_is_internal_testing_environment
  */
 #[CoversFunction( 'jetpack_get_future_removed_version' )]
 #[CoversFunction( 'jetpack_get_vary_headers' )]
-#[CoversFunction( 'jetpack_is_dev_mode' )]
+#[CoversFunction( 'jetpack_is_internal_testing_environment' )]
 class Functions_Global_Test extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
 
@@ -98,33 +98,33 @@ class Functions_Global_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test jetpack_is_dev_mode returns false for a production domain.
+	 * Test jetpack_is_internal_testing_environment returns false for a production domain.
 	 */
-	public function test_jetpack_is_dev_mode_returns_false_for_production() {
-		$this->assertFalse( jetpack_is_dev_mode() );
+	public function test_jetpack_is_internal_testing_environment_returns_false_for_production() {
+		$this->assertFalse( jetpack_is_internal_testing_environment() );
 	}
 
 	/**
-	 * Test jetpack_is_dev_mode returns true for localhost.
+	 * Test jetpack_is_internal_testing_environment returns true for localhost.
 	 */
-	public function test_jetpack_is_dev_mode_true_for_localhost() {
+	public function test_jetpack_is_internal_testing_environment_true_for_localhost() {
 		update_option( 'siteurl', 'http://localhost:8888' );
-		$this->assertTrue( jetpack_is_dev_mode() );
+		$this->assertTrue( jetpack_is_internal_testing_environment() );
 	}
 
 	/**
-	 * Test jetpack_is_dev_mode returns true for jurassic.ninja domain.
+	 * Test jetpack_is_internal_testing_environment returns true for jurassic.ninja domain.
 	 */
-	public function test_jetpack_is_dev_mode_true_for_jurassic_ninja() {
+	public function test_jetpack_is_internal_testing_environment_true_for_jurassic_ninja() {
 		update_option( 'siteurl', 'https://mysite.jurassic.ninja' );
-		$this->assertTrue( jetpack_is_dev_mode() );
+		$this->assertTrue( jetpack_is_internal_testing_environment() );
 	}
 
 	/**
-	 * Test jetpack_is_dev_mode returns true for jurassic.tube domain.
+	 * Test jetpack_is_internal_testing_environment returns true for jurassic.tube domain.
 	 */
-	public function test_jetpack_is_dev_mode_true_for_jurassic_tube() {
+	public function test_jetpack_is_internal_testing_environment_true_for_jurassic_tube() {
 		update_option( 'siteurl', 'https://mysite.jurassic.tube' );
-		$this->assertTrue( jetpack_is_dev_mode() );
+		$this->assertTrue( jetpack_is_internal_testing_environment() );
 	}
 }


### PR DESCRIPTION
Fixes FORNO-337

## Proposed changes
* Adds `is_dev_mode()` function to Image Studio that detects dev/test environments (localhost, Jurassic Ninja/Tube, proxied A8C requests, Atomic proxied requests)
* Passes the result as `isDevMode` in the `imageStudioData` inline script object, so the Calypso side ([wp-calypso#109983](https://github.com/Automattic/wp-calypso/pull/109983)) can tag analytics events as test traffic
* Logic mirrors `Agents_Manager::is_dev_mode()` so Image Studio works independently of Big Sky

## Related product discussion/links
* https://github.com/Automattic/wp-calypso/pull/109983/changes
* https://github.com/Automattic/jetpack/blob/trunk/projects/packages/jetpack-mu-wpcom/src/features/agents-manager/class-agents-manager.php#L558

## Does this pull request change what data or activity we track or use?
No new tracking. This adds a flag that allows the Calypso consumer to distinguish dev/test traffic from production traffic in existing analytics.

## Testing instructions
* Open Image Studio in the block editor on a local/dev environment
* Inspect the inline script for `imageStudioData` — confirm `isDevMode` is `true`
* Follow testing steps from https://github.com/Automattic/wp-calypso/pull/109983 to test end to end