### PR TITLE
Command Palette: fix broken styles on Stats admin page

### DIFF
--- a/projects/plugins/jetpack/_inc/site-switcher.php
+++ b/projects/plugins/jetpack/_inc/site-switcher.php
@@ -45,6 +45,10 @@ function jetpack_site_switcher_enqueue_scripts() {
 		true
 	);
 
+	// Ensure the command palette stylesheet is loaded; some admin pages (e.g. Stats)
+	// do not pull it in via other dependencies.
+	wp_enqueue_style( 'wp-commands' );
+
 	// Pass configuration to JavaScript
 	$api_path = ( defined( 'IS_WPCOM' ) && IS_WPCOM )
 		? '/rest/v1.1/me/sites/compact'

--- a/projects/plugins/jetpack/_inc/site-switcher.php
+++ b/projects/plugins/jetpack/_inc/site-switcher.php
@@ -45,8 +45,11 @@ function jetpack_site_switcher_enqueue_scripts() {
 		true
 	);
 
-	// Ensure the command palette stylesheet is loaded; some admin pages (e.g. Stats)
-	// do not pull it in via other dependencies.
+	// Ensure the command palette stylesheets are loaded. Some admin pages (e.g. Stats)
+	// don't pull these in via other dependencies, which leaves the palette unstyled.
+	// wp-commands does not declare wp-components as a style dependency in core, so
+	// both handles must be enqueued explicitly.
+	wp_enqueue_style( 'wp-components' );
 	wp_enqueue_style( 'wp-commands' );
 
 	// Pass configuration to JavaScript

--- a/projects/plugins/jetpack/changelog/2026-04-14-09-50-54-556713
+++ b/projects/plugins/jetpack/changelog/2026-04-14-09-50-54-556713
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Command Palette: fix broken styles on Stats and other admin pages that don't load wp-commands styles indirectly.


### PR DESCRIPTION
Fixes #

## Proposed changes
* Enqueue the `wp-commands` stylesheet alongside the `jetpack-site-switcher` script so the Command Palette has its proper styles on admin pages that don't pull the CSS in via other dependencies (notably the Stats admin page).

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* On a Jetpack-connected site, go to `wp-admin/admin.php?page=stats`.
* Open the Command Palette (⌘K / Ctrl+K).
* Before this change: the palette renders as a bare, narrow search input overlaying the page.
* After this change: the palette renders as a full, properly-styled modal with rounded corners, list styling, icons, etc.
* Verify the palette still looks correct on the main wp-admin Dashboard (where it worked before) and other admin pages.
