### PR TITLE
Search: fix applying white background globally vs just on dashboard

### DIFF
--- a/projects/packages/search/changelog/fix-dashboard-upsell-background
+++ b/projects/packages/search/changelog/fix-dashboard-upsell-background
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: Avoid forcing a white background in the upsell pricing grid view.

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.scss
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.scss
@@ -7,7 +7,6 @@
 }
 
 #jp-search-dashboard {
-	background-color: variables.$white;
 	color: variables.$black;
 	font-size: 16px;
 	// 32px = wpadminbar height
@@ -19,6 +18,7 @@
 	}
 
 	.jp-search-dashboard-page {
+		background-color: variables.$white;
 		width: 100%;
 	}
 


### PR DESCRIPTION
Fixes JETPACK-1536

## Proposed changes
<!--- Explain what functional changes your PR includes -->
*  Fixes upsell/pricing grid state of search dashboard background color not working well with Search dashboard's own background color.

(Note that the extra footer is WP.com specific)

### Before

<img width="1349" height="1120" alt="image" src="https://github.com/user-attachments/assets/0a48212e-34cf-4b0a-a97b-92b5ccd1e828" />


### After

<img width="1500" height="1093" alt="image" src="https://github.com/user-attachments/assets/1120325d-4e03-4672-be57-15c733a92edd" />

<img width="1285" height="1127" alt="image" src="https://github.com/user-attachments/assets/cc41bfdc-1a85-4e98-a360-ba73828fa682" />


## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* With a site where you haven't dismissed the search upsell (easiest probably on WP.com or Jurassic ninja), or short-circuit the code:
    * In `wrapped-dashboard.jsx`: return `<UpsellPage />` unconditionally in `AfterConnectionPage`.
* See white leaking white background color
* Regular search dash looks good