### PR TITLE
Disable REST API visibility for simple payments creator email

### DIFF
--- a/projects/packages/paypal-payments/changelog/fix-remove-spay-email-from-rest
+++ b/projects/packages/paypal-payments/changelog/fix-remove-spay-email-from-rest
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Hide the creators email of the Simple Payments block from the REST endpoints

--- a/projects/packages/paypal-payments/src/legacy/class-simple-payments.php
+++ b/projects/packages/paypal-payments/src/legacy/class-simple-payments.php
@@ -499,7 +499,7 @@ class Simple_Payments {
 				'description'       => esc_html__( 'Simple payments button; paypal email.', 'jetpack-paypal-payments' ),
 				'object_subtype'    => self::$post_type_product,
 				'sanitize_callback' => 'sanitize_email',
-				'show_in_rest'      => true,
+				'show_in_rest'      => false,
 				'single'            => true,
 				'type'              => 'string',
 			)


### PR DESCRIPTION
Fixes [SHILL-1889: Do not show the creator email in Jetpack Simple Payments](https://linear.app/a8c/issue/SHILL-1889/do-not-show-the-creator-email-in-jetpack-simple-payments)

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Hide the creator email from Simple Payments block.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Use the JN instance and create a Jetpack Simple Payments button
* Make sure it still works
