### PR TITLE
My Jetpack: fix Hybrid products not deactivating (MYJP-283)

### DIFF
--- a/projects/packages/my-jetpack/_inc/data/products/test/use-products.test.ts
+++ b/projects/packages/my-jetpack/_inc/data/products/test/use-products.test.ts
@@ -1,0 +1,73 @@
+import { renderHook } from '@testing-library/react';
+import { useAllProducts } from '../use-all-products';
+import useProducts from '../use-products';
+import type { ProductCamelCase } from '../../types';
+
+jest.mock( '../use-all-products' );
+
+type UseAllProductsReturn = ReturnType< typeof useAllProducts >;
+const mockUseAllProducts = useAllProducts as jest.MockedFunction< typeof useAllProducts >;
+
+const baseReturn: UseAllProductsReturn = {
+	data: {},
+	refetch: jest.fn().mockResolvedValue( { isError: false } ),
+	isLoading: false,
+	isRefetching: false,
+	isError: false,
+};
+
+const mockReturn = ( overrides: Partial< UseAllProductsReturn > = {} ) =>
+	mockUseAllProducts.mockReturnValue( { ...baseReturn, ...overrides } );
+
+describe( 'useProducts', () => {
+	const videopress = { slug: 'videopress', status: 'active' } as ProductCamelCase;
+	const boost = { slug: 'boost', status: 'inactive' } as ProductCamelCase;
+	const mockRefetch = jest.fn().mockResolvedValue( { isError: false } );
+
+	beforeEach( () => {
+		mockRefetch.mockClear();
+		mockReturn( {
+			data: { videopress, boost },
+			refetch: mockRefetch,
+		} );
+	} );
+
+	it( 'returns products matching the requested slugs from useAllProducts', () => {
+		const { result } = renderHook( () => useProducts( [ 'videopress', 'boost' ] ) );
+
+		expect( result.current.products ).toEqual( [ videopress, boost ] );
+	} );
+
+	it( 'accepts a single slug string', () => {
+		const { result } = renderHook( () => useProducts( 'videopress' ) );
+
+		expect( result.current.products ).toEqual( [ videopress ] );
+	} );
+
+	it( 'forwards loading and refetching flags from useAllProducts', () => {
+		mockReturn( {
+			refetch: mockRefetch,
+			isLoading: true,
+			isRefetching: true,
+		} );
+
+		const { result } = renderHook( () => useProducts( [ 'videopress' ] ) );
+
+		expect( result.current.isLoading ).toBe( true );
+		expect( result.current.isRefetching ).toBe( true );
+	} );
+
+	// Regression for MYJP-283: the previous `refetch` ran a separate
+	// `useSimpleQuery` and wrote results into `window.myJetpackInitialState`,
+	// bypassing the React Query cache that `useAllProducts` subscribes to —
+	// so the UI never re-rendered after mutations. The fix delegates `refetch`
+	// to `useAllProducts().refetch`, which invalidates the same cache entry
+	// the UI reads from.
+	it( 'delegates refetch() to useAllProducts().refetch', async () => {
+		const { result } = renderHook( () => useProducts( [ 'videopress' ] ) );
+
+		await result.current.refetch();
+
+		expect( mockRefetch ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/projects/packages/my-jetpack/_inc/data/products/use-products.ts
+++ b/projects/packages/my-jetpack/_inc/data/products/use-products.ts
@@ -1,57 +1,18 @@
 import { useCallback } from 'react';
-import { REST_API_SITE_PRODUCTS_ENDPOINT, QUERY_PRODUCT_KEY } from '../constants';
-import useSimpleQuery from '../use-simple-query';
 import { useAllProducts } from './use-all-products';
-import type { ProductSnakeCase, WP_Error } from '../types';
-import type { RefetchOptions, QueryObserverResult } from '@tanstack/react-query';
-
-// Create query to fetch new product data from the server
-const useFetchProducts = ( productIds: string[] ) => {
-	const productsQueryArg =
-		productIds && productIds?.length ? `?products=${ productIds?.join( ',' ) }` : '';
-	const queryResult = useSimpleQuery< { [ key: string ]: ProductSnakeCase } >( {
-		name: `${ QUERY_PRODUCT_KEY }`,
-		query: {
-			path: `${ REST_API_SITE_PRODUCTS_ENDPOINT }${ productsQueryArg }`,
-		},
-		options: { enabled: false },
-	} );
-
-	return queryResult;
-};
-
-// Fetch the product data from the server and update the global state
-const refetchProducts = async (
-	refetch: (
-		options?: RefetchOptions
-	) => Promise< QueryObserverResult< { [ key: string ]: ProductSnakeCase }, WP_Error > >
-) => {
-	const { data: refetchedProducts, isError, isLoading } = await refetch();
-	const prevProducts = window.myJetpackInitialState.products.items;
-
-	if ( isError || isLoading ) {
-		return;
-	}
-
-	Object.keys( refetchedProducts ).forEach( productSlug => {
-		window.myJetpackInitialState.products.items[ productSlug ] = {
-			...prevProducts[ productSlug ],
-			...refetchedProducts[ productSlug ],
-		};
-	} );
-};
 
 const useProducts = ( productSlugs: string | string[] ) => {
 	const productIds = Array.isArray( productSlugs ) ? productSlugs : [ productSlugs ];
 
-	const { data: allProducts, isLoading: isLoadingAllProducts } = useAllProducts();
-	const products = productIds?.map( productId => allProducts?.[ productId ] );
-	const { refetch, isLoading, isRefetching } = useFetchProducts( productIds );
+	const { data: allProducts, isLoading, isRefetching, refetch } = useAllProducts();
+	const products = productIds.map( productId => allProducts?.[ productId ] );
 
 	return {
 		products,
-		refetch: useCallback( () => refetchProducts( refetch ), [ refetch ] ),
-		isLoading: isLoading || isLoadingAllProducts,
+		refetch: useCallback( async () => {
+			await refetch();
+		}, [ refetch ] ),
+		isLoading,
 		isRefetching,
 	};
 };

--- a/projects/packages/my-jetpack/changelog/myjp-283-videopress-module-does-not-deactivate-from-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/myjp-283-videopress-module-does-not-deactivate-from-my-jetpack
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-My Jetpack: fix Hybrid products not deactivating when activated via the Jetpack-module path
+My Jetpack: Fix Hybrid products not deactivating when activated via the Jetpack-module path.

--- a/projects/packages/my-jetpack/changelog/myjp-283-videopress-module-does-not-deactivate-from-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/myjp-283-videopress-module-does-not-deactivate-from-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: fix Hybrid products not deactivating when activated via the Jetpack-module path

--- a/projects/packages/my-jetpack/src/products/class-hybrid-product.php
+++ b/projects/packages/my-jetpack/src/products/class-hybrid-product.php
@@ -143,8 +143,7 @@ abstract class Hybrid_Product extends Product {
 		$result  = parent::deactivate();
 		$modules = new Modules();
 
-		// Still treat a module as active when the option lists it, even if it's currently marked unavailable — the option is the source of truth for whether the product is still on.
-		if ( ! empty( static::$module_name ) && $modules->is_active( static::$module_name, false ) ) {
+		if ( ! empty( static::$module_name ) && $modules->is_active( static::$module_name ) ) {
 			if ( ! $modules->deactivate( static::$module_name ) ) {
 				return new WP_Error(
 					'module_deactivation_failed',

--- a/projects/packages/my-jetpack/src/products/class-hybrid-product.php
+++ b/projects/packages/my-jetpack/src/products/class-hybrid-product.php
@@ -140,10 +140,12 @@ abstract class Hybrid_Product extends Product {
 	 *                       WP_Error if the module deactivation failed.
 	 */
 	public static function deactivate() {
-		$result = parent::deactivate();
+		$result  = parent::deactivate();
+		$modules = new Modules();
 
-		if ( ! empty( static::$module_name ) && ( new Modules() )->is_active( static::$module_name ) ) {
-			if ( ! ( new Modules() )->deactivate( static::$module_name ) ) {
+		// Still treat a module as active when the option lists it, even if it's currently marked unavailable — the option is the source of truth for whether the product is still on.
+		if ( ! empty( static::$module_name ) && $modules->is_active( static::$module_name, false ) ) {
+			if ( ! $modules->deactivate( static::$module_name ) ) {
 				return new WP_Error(
 					'module_deactivation_failed',
 					__( 'Error deactivating Jetpack module', 'jetpack-my-jetpack' )

--- a/projects/packages/my-jetpack/src/products/class-hybrid-product.php
+++ b/projects/packages/my-jetpack/src/products/class-hybrid-product.php
@@ -129,6 +129,32 @@ abstract class Hybrid_Product extends Product {
 	}
 
 	/**
+	 * Deactivates the product.
+	 *
+	 * In addition to the parent's plugin deactivation, also deactivates the
+	 * matching Jetpack module when `static::$module_name` is set and the
+	 * module is currently active — otherwise Hybrid products activated via
+	 * the Jetpack-module path stay half-on after "deactivation".
+	 *
+	 * @return bool|WP_Error True on success (matches Product::deactivate()),
+	 *                       WP_Error if the module deactivation failed.
+	 */
+	public static function deactivate() {
+		$result = parent::deactivate();
+
+		if ( ! empty( static::$module_name ) && ( new Modules() )->is_active( static::$module_name ) ) {
+			if ( ! ( new Modules() )->deactivate( static::$module_name ) ) {
+				return new WP_Error(
+					'module_deactivation_failed',
+					__( 'Error deactivating Jetpack module', 'jetpack-my-jetpack' )
+				);
+			}
+		}
+
+		return $result;
+	}
+
+	/**
 	 * Install and activate the standalone plugin in the case it's missing.
 	 *
 	 * @return boolean|WP_Error

--- a/projects/packages/my-jetpack/tests/php/Hybrid_Product_Deactivate_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Hybrid_Product_Deactivate_Test.php
@@ -1,0 +1,247 @@
+<?php
+/**
+ * Tests for Hybrid_Product::deactivate() — covers the override that
+ * deactivates the Jetpack module alongside the plugin.
+ *
+ * @package automattic/my-jetpack
+ */
+
+namespace Automattic\Jetpack\My_Jetpack;
+
+use Automattic\Jetpack\Modules;
+use Automattic\Jetpack\My_Jetpack\Products\Backup;
+use Automattic\Jetpack\My_Jetpack\Products\Protect;
+use Automattic\Jetpack\My_Jetpack\Products\Search;
+use Automattic\Jetpack\My_Jetpack\Products\Social;
+use Automattic\Jetpack\My_Jetpack\Products\Videopress;
+use Jetpack_Options;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use WorDBless\Options as WorDBless_Options;
+use WorDBless\Users as WorDBless_Users;
+
+/**
+ * Unit tests for Hybrid_Product::deactivate().
+ *
+ * @covers \Automattic\Jetpack\My_Jetpack\Hybrid_Product::deactivate
+ */
+#[CoversMethod( Hybrid_Product::class, 'deactivate' )]
+class Hybrid_Product_Deactivate_Test extends TestCase {
+
+	/**
+	 * Counts invocations of the jetpack_pre_deactivate_module action,
+	 * keyed by module slug.
+	 *
+	 * @var array<string, int>
+	 */
+	private $pre_deactivate_calls = array();
+
+	/**
+	 * Closure registered against jetpack_pre_deactivate_module so we can
+	 * remove exactly the callback we added on tearDown.
+	 *
+	 * @var callable|null
+	 */
+	private $pre_deactivate_listener;
+
+	/**
+	 * Installs mock Jetpack plugin files, seeds the available-modules
+	 * option, and registers a scoped listener on
+	 * `jetpack_pre_deactivate_module` so we can count module deactivations
+	 * without using `remove_all_actions()`.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->install_mock_plugins();
+		wp_cache_delete( 'plugins', 'plugins' );
+
+		// Ensure JETPACK__VERSION and the mock Jetpack class are defined
+		// so Modules::get_available() returns our list instead of being
+		// short-circuited by the missing-Jetpack branch.
+		require_once WP_PLUGIN_DIR . '/jetpack/jetpack.php';
+
+		// Register the modules the Hybrid_Product subclasses care about
+		// as "available" so Modules::get_active() doesn't filter them out.
+		Jetpack_Options::update_option(
+			'available_modules',
+			array(
+				JETPACK__VERSION => array(
+					'videopress' => '1.0',
+					'search'     => '1.0',
+					'protect'    => '1.0',
+					'publicize'  => '1.0',
+				),
+			)
+		);
+
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_admin',
+				'user_pass'  => '123',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		$this->pre_deactivate_calls    = array();
+		$this->pre_deactivate_listener = function ( $module ) {
+			if ( ! isset( $this->pre_deactivate_calls[ $module ] ) ) {
+				$this->pre_deactivate_calls[ $module ] = 0;
+			}
+			++$this->pre_deactivate_calls[ $module ];
+		};
+		add_action( 'jetpack_pre_deactivate_module', $this->pre_deactivate_listener );
+	}
+
+	/**
+	 * Removes the scoped listener (never `remove_all_actions()`), then
+	 * clears WorDBless state.
+	 */
+	public function tearDown(): void {
+		if ( null !== $this->pre_deactivate_listener ) {
+			remove_action( 'jetpack_pre_deactivate_module', $this->pre_deactivate_listener );
+			$this->pre_deactivate_listener = null;
+		}
+
+		WorDBless_Options::init()->clear_options();
+		WorDBless_Users::init()->clear_all_users();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Install mock Jetpack and Videopress plugin files. The Jetpack mock
+	 * defines JETPACK__VERSION (needed by Modules::get_available()); the
+	 * Videopress mock lets one test assert that `parent::deactivate()`
+	 * actually deactivates the standalone plugin as a side effect. The
+	 * other Hybrid subclasses don't need standalone mocks — for them
+	 * `deactivate_plugins()` is a no-op on an uninstalled plugin.
+	 */
+	private function install_mock_plugins() {
+		if ( ! file_exists( WP_PLUGIN_DIR . '/jetpack' ) ) {
+			mkdir( WP_PLUGIN_DIR . '/jetpack', 0777, true );
+		}
+		if ( ! file_exists( WP_PLUGIN_DIR . '/jetpack-videopress' ) ) {
+			mkdir( WP_PLUGIN_DIR . '/jetpack-videopress', 0777, true );
+		}
+
+		copy( __DIR__ . '/assets/jetpack-mock-plugin.txt', WP_PLUGIN_DIR . '/jetpack/jetpack.php' );
+		copy( __DIR__ . '/assets/videopress-mock-plugin.txt', WP_PLUGIN_DIR . '/jetpack-videopress/jetpack-videopress.php' );
+	}
+
+	/**
+	 * Mark a module as active in the Jetpack active_modules option.
+	 *
+	 * @param string $module Module slug.
+	 */
+	private function set_module_active( $module ) {
+		$active = Jetpack_Options::get_option( 'active_modules', array() );
+		if ( ! in_array( $module, $active, true ) ) {
+			$active[] = $module;
+		}
+		Jetpack_Options::update_option( 'active_modules', $active );
+	}
+
+	/**
+	 * Data provider: every Hybrid_Product subclass that declares a
+	 * $module_name. Guards against future subclasses (or overrides) that
+	 * could silently drop the module-deactivation contract.
+	 *
+	 * @return array<string, array{0: class-string, 1: string}>
+	 */
+	public static function provide_hybrid_subclasses_with_modules() {
+		return array(
+			'videopress' => array( Videopress::class, 'videopress' ),
+			'search'     => array( Search::class, 'search' ),
+			'protect'    => array( Protect::class, 'protect' ),
+			'social'     => array( Social::class, 'publicize' ),
+		);
+	}
+
+	/**
+	 * Every Hybrid_Product subclass with a $module_name must, when its
+	 * module is active, deactivate the module as part of ::deactivate().
+	 *
+	 * @param class-string $class  Hybrid_Product subclass under test.
+	 * @param string       $module Jetpack module slug for the subclass.
+	 * @dataProvider provide_hybrid_subclasses_with_modules
+	 */
+	#[DataProvider( 'provide_hybrid_subclasses_with_modules' )]
+	public function test_deactivate_turns_off_active_module( $class, $module ) {
+		$this->set_module_active( $module );
+		$this->assertTrue( ( new Modules() )->is_active( $module ) );
+
+		$result = $class::deactivate();
+
+		$this->assertTrue( $result );
+		$this->assertFalse(
+			( new Modules() )->is_active( $module ),
+			"Module {$module} should be deactivated after {$class}::deactivate()."
+		);
+		$this->assertSame(
+			1,
+			$this->pre_deactivate_calls[ $module ] ?? 0,
+			"Modules::deactivate() should have been invoked exactly once for {$module}."
+		);
+	}
+
+	/**
+	 * When the Jetpack module is already inactive, ::deactivate() must
+	 * skip the module branch entirely — the is_active() gate is what
+	 * prevents a spurious jetpack_pre_deactivate_module action.
+	 */
+	public function test_deactivate_skips_modules_deactivate_when_module_inactive() {
+		$this->assertFalse( ( new Modules() )->is_active( 'videopress' ) );
+
+		$result = Videopress::deactivate();
+
+		$this->assertTrue( $result );
+		$this->assertFalse( ( new Modules() )->is_active( 'videopress' ) );
+		$this->assertArrayNotHasKey(
+			'videopress',
+			$this->pre_deactivate_calls,
+			'Modules::deactivate() must not be called when the module was already inactive.'
+		);
+	}
+
+	/**
+	 * Parent deactivate() is still invoked — the standalone plugin gets
+	 * deactivated as a side effect, not just the Jetpack module.
+	 */
+	public function test_deactivate_still_deactivates_the_plugin() {
+		activate_plugins( Videopress::get_installed_plugin_filename() );
+		$this->set_module_active( 'videopress' );
+
+		$this->assertTrue( Videopress::is_standalone_plugin_active() );
+
+		Videopress::deactivate();
+
+		$this->assertFalse(
+			Videopress::is_standalone_plugin_active(),
+			'parent::deactivate() should have deactivated the standalone plugin.'
+		);
+	}
+
+	/**
+	 * A Hybrid_Product subclass with an empty $module_name (Backup
+	 * inherits null from Product) must not touch the Modules API and
+	 * must not error.
+	 */
+	public function test_deactivate_noop_for_module_name_empty() {
+		$this->assertEmpty(
+			Backup::$module_name,
+			'Precondition: Backup should have an empty $module_name for this test to be meaningful.'
+		);
+
+		$result = Backup::deactivate();
+
+		$this->assertTrue( $result );
+		$this->assertSame(
+			array(),
+			$this->pre_deactivate_calls,
+			'No module-level deactivation should fire when $module_name is empty.'
+		);
+	}
+}

--- a/projects/packages/my-jetpack/tests/php/Hybrid_Product_Deactivate_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Hybrid_Product_Deactivate_Test.php
@@ -20,6 +20,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use WorDBless\Options as WorDBless_Options;
 use WorDBless\Users as WorDBless_Users;
+use WP_Error;
 
 /**
  * Unit tests for Hybrid_Product::deactivate().
@@ -211,7 +212,11 @@ class Hybrid_Product_Deactivate_Test extends TestCase {
 	 * deactivated as a side effect, not just the Jetpack module.
 	 */
 	public function test_deactivate_still_deactivates_the_plugin() {
-		activate_plugins( Videopress::get_installed_plugin_filename() );
+		$plugin_filename = Videopress::get_installed_plugin_filename();
+		if ( null === $plugin_filename ) {
+			$this->fail( 'Precondition: Videopress mock plugin should be installed.' );
+		}
+		activate_plugins( $plugin_filename );
 		$this->set_module_active( 'videopress' );
 
 		$this->assertTrue( Videopress::is_standalone_plugin_active() );
@@ -222,6 +227,28 @@ class Hybrid_Product_Deactivate_Test extends TestCase {
 			Videopress::is_standalone_plugin_active(),
 			'parent::deactivate() should have deactivated the standalone plugin.'
 		);
+	}
+
+	/**
+	 * When Modules::deactivate() fails to persist, Hybrid_Product::deactivate()
+	 * surfaces the failure as a WP_Error so the REST handler can return a 400.
+	 */
+	public function test_deactivate_returns_wp_error_when_module_deactivate_fails() {
+		$this->set_module_active( 'videopress' );
+
+		$block_update = static function ( $new_value, $old_value ) {
+			return $old_value;
+		};
+		add_filter( 'pre_update_option_jetpack_active_modules', $block_update, 10, 2 );
+
+		try {
+			$result = Videopress::deactivate();
+		} finally {
+			remove_filter( 'pre_update_option_jetpack_active_modules', $block_update, 10 );
+		}
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'module_deactivation_failed', $result->get_error_code() );
 	}
 
 	/**


### PR DESCRIPTION
Fixes MYJP-283

## Proposed changes
* Hybrid products on My Jetpack were only half-deactivating: `Hybrid_Product` symmetrically activated the Jetpack module via `Modules::activate()` in `do_product_specific_activation()`, but inherited `Product::deactivate()` which only calls `deactivate_plugins()`. When a Hybrid product was activated via the Jetpack-module path (e.g. "Start for free" with no standalone plugin installed yet), clicking deactivate left the module flag set in `jetpack_active_modules`, so the product silently stayed on — breaking media-library video uploads in the reporter's case.
* Add a matching `deactivate()` override in `Hybrid_Product` that, after `parent::deactivate()`, also calls `Modules::deactivate()` when `static::$module_name` is set and the module is currently active. Returns a `WP_Error` if module deactivation fails so the REST handler can surface it. Applies to all five Hybrid products: VideoPress, Backup, Search, Protect, Social.
* Fix an adjacent latent bug in `useProducts`: `refetch()` was built on top of a separate `useSimpleQuery` with a filtered `?products=...` path, so its TanStack Query cache key did not match the one `useAllProducts` subscribes to. Mutations "refetched" a cache the UI never read from and wrote results into `window.myJetpackInitialState` directly — which React doesn't re-render on. Delegate `refetch` directly to `useAllProducts().refetch` so the cache entry the UI actually reads from is the one being refreshed.
* PHP tests: new `Hybrid_Product_Deactivate_Test` with a `DataProvider` that covers all four Hybrid subclasses with a declared module (VideoPress, Search, Protect, Social), plus cases for the inactive-module short-circuit, the empty-`$module_name` no-op (Backup), and a parent-still-runs assertion.
* JS tests: new `use-products.test.ts` with a regression assertion that `useProducts().refetch` delegates to `useAllProducts().refetch`.

## Related product discussion/links
* MYJP-283

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
1. On a fresh JN site with Jetpack connected (site + user).
2. Go to **My Jetpack → Products**.
3. Filter by **Performance** and click **Learn more** on VideoPress.
4. Click **Start for free**.
5. Back on the Products screen, VideoPress shows the **Active** toggle. Click it to deactivate.
6. **Before this PR**: the success toast fires but the module stays on in `jetpack_active_modules` — confirmable via `wp option get jetpack_active_modules` — and subsequent media-library video uploads are silently blocked by the VideoPress quota path.
7. **After this PR**: `wp option get jetpack_active_modules` no longer contains `videopress`, and `wp eval 'echo (new Automattic\\Jetpack\\Modules())->is_active("videopress") ? "active" : "inactive";'` prints `inactive`.
8. Bonus: activate and deactivate Search, Protect, and Social through the same Products screen; each should toggle cleanly the first time without needing a second click.

https://github.com/user-attachments/assets/02218d82-0790-415c-b304-5e6fe8e88c75
