### PR TITLE
Tooling: Have pnpm use enableGlobalVirtualStore

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -134,6 +134,7 @@ jobs:
               - 'composer.lock'
               - 'package.json'
               - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
               - '**/composer.json'
               - '**/composer.lock'
               - '**/package.json'
@@ -165,6 +166,7 @@ jobs:
               - 'package.json'
               - 'tools/js-tools/package.json'
               - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
               - '.eslintignore'
               - '.eslintignore.root'
               - 'eslint.config.*'
@@ -177,6 +179,7 @@ jobs:
               - 'package.json'
               - 'tools/js-tools/package.json'
               - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
               - .stylelintignore
               - stylelint.config.mjs
               - '**/stylelint.config.{js,mjs,cjs}'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,6 +20,9 @@ strictPeerDependencies: true
 # No hoisting by default.
 hoistPattern: []
 
+# Allow git worktrees to share a single on-disk store, making each  worktree's node_modules symlink-only. Auto-disabled in CI environments.
+enableGlobalVirtualStore: true
+
 # Silence this warning. Our `jetpack dependencies build-order` (also used by `jetpack build --all`) checks for cycles itself, plus it has a way to indicate that a dep is only for testing.
 ignoreWorkspaceCycles: true
 

--- a/tools/cli/commands/dependencies.js
+++ b/tools/cli/commands/dependencies.js
@@ -21,6 +21,7 @@ infrastructureFileSets.base = new Set( [
 	'.github/versions.sh',
 	// If pnpm stuff changed, we should build/test everything since we can't know what the change will affect.
 	'pnpm-lock.yaml',
+	'pnpm-workspace.yaml',
 ] );
 infrastructureFileSets.test = new Set( [
 	...infrastructureFileSets.base,


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
Experimenting with `git` worktrees, I noticed an annoyance: running `pnpm install` was a bit slow. It turns out `pnpm` has a solution with the `enableGlobalVirtualStore` setting:
https://pnpm.io/11.x/git-worktrees#3-enable-the-global-virtual-store

This symlinks the packages from a global store rather than linking.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

CI should still be happy, and builds should still work, e.g.:
* `jetpack install -r` <- first run will rebuild things
* `jetpack install plugins/jetpack`

I ran this flow from `projects/plugins/jetpack`:
```
git worktree add ./some-feature -b some-feature
cd some-feature/
pnpm install
cd ..
git worktree remove some-feature
git branch -D some-feature
```

Without this change the `pnpm install` and the `git worktree remove` both took ~17s. With this change, they both took ~1s.