### PR TITLE
wpcomsh: Allow the renamed gutenberg-guidelines experiment on Atomic sites

### DIFF
--- a/projects/plugins/wpcomsh/changelog/2026-04-14-18-39-01-488545
+++ b/projects/plugins/wpcomsh/changelog/2026-04-14-18-39-01-488545
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Allow the renamed gutenberg-guidelines experiment alongside the existing gutenberg-content-guidelines experiment on Atomic sites.

--- a/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
+++ b/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
@@ -52,6 +52,7 @@ add_action( 'init', 'wpcomsh_remove_gutenberg_experiments' );
 function wpcomsh_filter_gutenberg_experiments() {
 	return array(
 		'gutenberg-content-guidelines' => true,
+		'gutenberg-guidelines'         => true,
 	);
 }
 


### PR DESCRIPTION
## Summary
- Adds `gutenberg-guidelines` to the list of allowed Gutenberg experiments on Atomic sites in `wpcomsh_filter_gutenberg_experiments()`.
- Keeps the existing `gutenberg-content-guidelines` experiment for backward compatibility with older Gutenberg versions.
- This is needed because the experiment was renamed in WordPress/gutenberg#77223.

Similar to #47581.

## Testing instructions
- Deploy to an Atomic test site with the latest Gutenberg plugin installed.
- Verify that the `gutenberg-guidelines` experiment is active by checking that content guidelines functionality works in the editor.
- Verify that `gutenberg-content-guidelines` still works on sites running older Gutenberg versions that haven't picked up the rename yet.

## Does this pull request change what data or activity we track or use?

No, this PR does not change any data tracking or privacy-related behavior. It only adds an experiment name to the allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)