### PR TITLE
Marketing Tools: Tidy premium plugins CTA (height + remove arrow)

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/2026-04-15-04-30-41-680283
+++ b/projects/packages/jetpack-mu-wpcom/changelog/2026-04-15-04-30-41-680283
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Marketing Tools: Set a fixed height on the premium plugins Get started button.

--- a/projects/packages/jetpack-mu-wpcom/src/features/marketing/marketing.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/marketing/marketing.php
@@ -187,7 +187,6 @@ function wpcom_display_marketing_tools_page() {
 				<p><?php esc_html_e( "We've added premium plugins to boost your site's capabilities. From bookings and subscriptions to email marketing and SEO tools, we have you covered.", 'jetpack-mu-wpcom' ); ?></p>
 				<a href="<?php echo esc_url( 'https://wordpress.com/plugins/' . $domain . '?ref=wpcom-marketing-tools' ); ?>" class="button button-primary">
 					<?php esc_html_e( 'Get started', 'jetpack-mu-wpcom' ); ?>
-					<span class="dashicons dashicons-arrow-right-alt"></span>
 				</a>
 			</div>
 			<div class="wpcom-marketing-tools-premium-plugins__image">

--- a/projects/packages/jetpack-mu-wpcom/src/features/marketing/marketing.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/marketing/marketing.scss
@@ -55,7 +55,6 @@
 
 	.button.button-primary {
 		display: flex;
-		gap: 8px;
 		align-items: center;
 		height: 40px;
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/marketing/marketing.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/marketing/marketing.scss
@@ -57,6 +57,7 @@
 		display: flex;
 		gap: 8px;
 		align-items: center;
+		height: 40px;
 	}
 }
 


### PR DESCRIPTION
Fixes #

## Proposed changes
* Set a fixed height of 40px on the "Get started" CTA button in the premium plugins section of the Marketing Tools page (`/wp-admin/tools.php?page=wpcom-marketing-tools`).
* Remove the right-arrow dashicon from the CTA.

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a WordPress.com or Jetpack mu-wpcom site, go to `/wp-admin/tools.php?page=wpcom-marketing-tools`.
* Confirm the "Get started" button in the premium plugins hero section renders at 40px tall and no longer shows an arrow icon after the label.