### PR TITLE
Reader Link: load only when masterbar is visible

### DIFF
--- a/projects/packages/newsletter/changelog/reader-link-admin-bar-visibility
+++ b/projects/packages/newsletter/changelog/reader-link-admin-bar-visibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Reader Link: Only enqueue styles when the admin bar is visible.

--- a/projects/packages/newsletter/src/class-reader-link.php
+++ b/projects/packages/newsletter/src/class-reader-link.php
@@ -38,6 +38,11 @@ class Reader_Link {
 		if ( self::$initialized ) {
 			return;
 		}
+
+		if ( ! is_user_logged_in() || ! is_admin_bar_showing() ) {
+			return;
+		}
+
 		self::$initialized = true;
 
 		$instance = new self();

--- a/projects/packages/newsletter/tests/php/Reader_Link_Test.php
+++ b/projects/packages/newsletter/tests/php/Reader_Link_Test.php
@@ -19,7 +19,6 @@ use WP_Admin_Bar;
  */
 #[CoversClass( Reader_Link::class )]
 class Reader_Link_Test extends BaseTestCase {
-
 	/**
 	 * Set up before each test.
 	 */
@@ -39,6 +38,32 @@ class Reader_Link_Test extends BaseTestCase {
 		remove_all_actions( 'admin_bar_menu' );
 		remove_all_actions( 'wp_enqueue_scripts' );
 		remove_all_actions( 'admin_enqueue_scripts' );
+
+		// Mirror production conditions required by Reader_Link::init().
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'newsletter_reader_admin_' . wp_rand(),
+				'user_pass'  => 'password',
+				'user_email' => 'newsletter-reader-admin-' . wp_rand() . '@example.com',
+				'role'       => 'administrator',
+			)
+		);
+		if ( is_wp_error( $user_id ) ) {
+			$this->fail( $user_id->get_error_message() );
+		}
+		wp_set_current_user( $user_id );
+		show_admin_bar( true );
+		add_filter( 'show_admin_bar', '__return_true' );
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down() {
+		remove_filter( 'show_admin_bar', '__return_true' );
+		wp_set_current_user( 0 );
+
+		parent::tear_down();
 	}
 
 	/**
@@ -85,22 +110,13 @@ class Reader_Link_Test extends BaseTestCase {
 		$second_instance = $this->get_reader_link_instance();
 
 		// Should be the same instance (init didn't run twice).
+		$this->assertInstanceOf( Reader_Link::class, $first_instance );
 		$this->assertSame( $first_instance, $second_instance );
-
-		// Verify hooks were only added once by checking callback count.
-		global $wp_filter;
-		$admin_bar_callbacks = 0;
-		if ( isset( $wp_filter['admin_bar_menu'] ) ) {
-			foreach ( $wp_filter['admin_bar_menu']->callbacks as $callbacks ) {
-				foreach ( $callbacks as $callback ) {
-					if ( is_array( $callback['function'] ) && $callback['function'][0] instanceof Reader_Link ) {
-						++$admin_bar_callbacks;
-					}
-				}
-			}
-		}
-
-		$this->assertSame( 1, $admin_bar_callbacks, 'Hook should only be registered once' );
+		$this->assertSame(
+			11,
+			has_action( 'admin_bar_menu', array( $first_instance, 'add_reader_menu' ) ),
+			'Hook should only be registered once'
+		);
 	}
 
 	/**
@@ -108,6 +124,7 @@ class Reader_Link_Test extends BaseTestCase {
 	 */
 	public function test_add_reader_menu_adds_menu_item() {
 		require_once ABSPATH . 'wp-includes/class-wp-admin-bar.php';
+		wp_set_current_user( 0 );
 
 		$wp_admin_bar = new WP_Admin_Bar();
 		$wp_admin_bar->initialize();
@@ -129,6 +146,7 @@ class Reader_Link_Test extends BaseTestCase {
 	 */
 	public function test_add_reader_menu_title_structure() {
 		require_once ABSPATH . 'wp-includes/class-wp-admin-bar.php';
+		wp_set_current_user( 0 );
 
 		$wp_admin_bar = new WP_Admin_Bar();
 		$wp_admin_bar->initialize();


### PR DESCRIPTION


## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Stops styles for masterbar Reader link from loading

Previously, when unlogged, in incognito, looking at the front of the website, I could see the styles loading:

<img width="1517" height="748" alt="Screenshot 2026-04-15 at 15 16 42" src="https://github.com/user-attachments/assets/a313919c-3a7a-4b3d-a4fb-cd186dcec67b" />

Now the link loads just when the masterbar is visible:

<img width="364" height="89" alt="Screenshot 2026-04-15 at 15 21 25" src="https://github.com/user-attachments/assets/ff01428e-7ad3-4a93-bbb6-27e4f8341284" />


## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* See Reader link while logged in as admin, and then not logged in. Check that styles don't load.