### PR TITLE
Settings: Show empty state when search returns no matching settings

### DIFF
--- a/projects/plugins/jetpack/_inc/client/settings/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/settings/index.jsx
@@ -1,5 +1,7 @@
 import { GlobalNotices, ThemeProvider } from '@automattic/jetpack-components';
 import { __, sprintf } from '@wordpress/i18n';
+import { search } from '@wordpress/icons';
+import { EmptyState, Stack } from '@wordpress/ui';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import { useLocation } from 'react-router';
@@ -44,13 +46,21 @@ class Settings extends Component {
 			<ThemeProvider>
 				<div className="jp-settings-container">
 					{ showEmptySearchState && (
-						<h2 className="jp-settings__section-title jp-settings__section-title--centered">
-							{ sprintf(
-								/* translators: %s: a search term entered in search form. */
-								__( 'No search results found for %s', 'jetpack' ),
-								searchTerm
-							) }
-						</h2>
+						<Stack justify="center" className="jp-settings__empty-search-results">
+							<EmptyState.Root>
+								<EmptyState.Visual>
+									<EmptyState.Icon icon={ search } />
+								</EmptyState.Visual>
+								<EmptyState.Title>{ __( 'No matching settings', 'jetpack' ) }</EmptyState.Title>
+								<EmptyState.Description>
+									{ sprintf(
+										/* translators: %s: a search term entered in search form. */
+										__( 'No search results found for %s', 'jetpack' ),
+										searchTerm
+									) }
+								</EmptyState.Description>
+							</EmptyState.Root>
+						</Stack>
 					) }
 					<Security
 						siteAdminUrl={ siteAdminUrl }

--- a/projects/plugins/jetpack/_inc/client/settings/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/settings/index.jsx
@@ -13,6 +13,7 @@ import SearchableModules from 'searchable-modules';
 import Security from 'security';
 import Sharing from 'sharing';
 import { isModuleActivated as isModuleActivatedSelector } from 'state/modules';
+import { hasAnyMatchingModule as hasAnyMatchingModuleSelector } from 'state/search';
 import Traffic from 'traffic';
 import Writing from 'writing';
 import { FEATURE_JETPACK_EARN } from '../lib/plans/constants';
@@ -29,6 +30,7 @@ class Settings extends Component {
 			siteRawUrl,
 			blogID,
 			userCanManageModules,
+			hasAnyMatchingModule,
 		} = this.props;
 		const { pathname } = location;
 		const commonProps = {
@@ -36,19 +38,20 @@ class Settings extends Component {
 			rewindStatus,
 			userCanManageModules,
 		};
+		const showEmptySearchState = !! searchTerm && ! hasAnyMatchingModule;
 
 		return (
 			<ThemeProvider>
 				<div className="jp-settings-container">
-					<div className="jp-no-results">
-						{ searchTerm
-							? sprintf(
-									/* translators: %s: a search term entered in search form. */
-									__( 'No search results found for %s', 'jetpack' ),
-									searchTerm
-							  )
-							: __( 'Enter a search term to find settings or close search.', 'jetpack' ) }
-					</div>
+					{ showEmptySearchState && (
+						<h2 className="jp-settings__section-title jp-settings__section-title--centered">
+							{ sprintf(
+								/* translators: %s: a search term entered in search form. */
+								__( 'No search results found for %s', 'jetpack' ),
+								searchTerm
+							) }
+						</h2>
+					) }
 					<Security
 						siteAdminUrl={ siteAdminUrl }
 						siteRawUrl={ siteRawUrl }
@@ -114,5 +117,6 @@ class Settings extends Component {
 export default connect( state => {
 	return {
 		isModuleActivated: module => isModuleActivatedSelector( state, module ),
+		hasAnyMatchingModule: hasAnyMatchingModuleSelector( state ),
 	};
 } )( props => <Settings { ...props } location={ useLocation() } /> );

--- a/projects/plugins/jetpack/_inc/client/settings/style.scss
+++ b/projects/plugins/jetpack/_inc/client/settings/style.scss
@@ -110,16 +110,6 @@
 		width: 100%;
 	}
 
-	.jp-no-results {
-		display: none;
-		font-size: rem.convert(14px);
-		line-height: 1.5;
-
-		&:last-of-type {
-			display: inherit;
-		}
-	}
-
 	@include breakpoints.breakpoint( "<480px" ) {
 
 		.dops-search.is-expanded-to-container {

--- a/projects/plugins/jetpack/_inc/client/settings/style.scss
+++ b/projects/plugins/jetpack/_inc/client/settings/style.scss
@@ -110,6 +110,19 @@
 		width: 100%;
 	}
 
+	.jp-settings__empty-search-results {
+		margin-block: rem.convert(64px);
+
+		// @wordpress/ui zeros margins on EmptyState.Title/Description inside
+		// @layer wp-ui-components, but unlayered admin styles (core + Jetpack)
+		// take precedence and reintroduce h2/p margins. Reset them here so the
+		// component renders with its intended tight spacing.
+		h2,
+		p {
+			margin: 0;
+		}
+	}
+
 	@include breakpoints.breakpoint( "<480px" ) {
 
 		.dops-search.is-expanded-to-container {

--- a/projects/plugins/jetpack/_inc/client/state/search/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/search/reducer.js
@@ -64,3 +64,18 @@ export function isModuleFound( state, module ) {
 			.indexOf( currentSearchTerm.toLowerCase() ) > -1
 	);
 }
+
+/**
+ * Returns whether any module matches the current search term.
+ *
+ * @param {object} state - Global state tree
+ * @return {boolean}      True only when there is an active search term and at least one module matches it.
+ */
+export function hasAnyMatchingModule( state ) {
+	if ( ! getSearchTerm( state ) ) {
+		return false;
+	}
+
+	const items = state.jetpack?.modules?.items ?? {};
+	return Object.values( items ).some( item => item?.module && isModuleFound( state, item.module ) );
+}

--- a/projects/plugins/jetpack/_inc/client/state/search/test/selectors.js
+++ b/projects/plugins/jetpack/_inc/client/state/search/test/selectors.js
@@ -1,4 +1,4 @@
-import { isModuleFound } from '../index';
+import { hasAnyMatchingModule, isModuleFound } from '../index';
 
 describe( 'Module found selector', () => {
 	let state = {};
@@ -67,5 +67,43 @@ describe( 'Module found selector', () => {
 				} );
 			}
 		);
+	} );
+} );
+
+describe( 'hasAnyMatchingModule selector', () => {
+	const buildState = ( searchTerm, items ) => ( {
+		jetpack: {
+			modules: { items },
+			search: { searchTerm },
+		},
+	} );
+
+	const items = {
+		photon: {
+			module: 'photon',
+			name: 'Photon',
+			description: 'Serve images from the WordPress.com CDN.',
+		},
+		protect: {
+			module: 'protect',
+			name: 'Protect',
+			description: 'Prevent brute-force login attacks.',
+		},
+	};
+
+	test( 'returns false when the search term is empty', () => {
+		expect( hasAnyMatchingModule( buildState( '', items ) ) ).toBe( false );
+	} );
+
+	test( 'returns false when the modules state has not loaded yet', () => {
+		expect( hasAnyMatchingModule( buildState( 'photon', undefined ) ) ).toBe( false );
+	} );
+
+	test( 'returns true when at least one module matches the search term', () => {
+		expect( hasAnyMatchingModule( buildState( 'brute-force', items ) ) ).toBe( true );
+	} );
+
+	test( 'returns false when no module matches the search term', () => {
+		expect( hasAnyMatchingModule( buildState( 'asdfqwerty', items ) ) ).toBe( false );
 	} );
 } );

--- a/projects/plugins/jetpack/changelog/jpprod-105-show-empty-state-message-on-settings-screen
+++ b/projects/plugins/jetpack/changelog/jpprod-105-show-empty-state-message-on-settings-screen
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Settings: Show an empty state when search returns no matching settings.


### PR DESCRIPTION
## Proposed changes

Typing into the Settings search bar could leave a completely blank screen when the term matched no settings — no message, no feedback. This PR surfaces a proper empty state so users get clear guidance instead of a blank canvas.

* Reliably show an empty-state message when the Jetpack Settings search returns no matches. Previously a `.jp-no-results` div was always rendered and its visibility was governed by a `display: none` + `:last-of-type` CSS trick that is fragile (`:last-of-type` is tag-based, not class-based) and in practice left the settings area blank.
* Drive visibility from Redux state via a new `hasAnyMatchingModule` selector in `state/search`, reusing the existing `isModuleFound` + `getModules` selectors.
* Render the empty state with the Gutenberg `EmptyState` compound component from `@wordpress/ui` (search icon + title + description), wrapped in a `Stack` for horizontal centering.
* Add `@wordpress/ui@0.10.0` to `plugins/jetpack` — one minor ahead of the `0.9.0` used elsewhere in the monorepo, because `EmptyState` was first exported in 0.10.0.
* Remove the obsolete `.jp-no-results` CSS block.

<img width="2436" height="1890" alt="CleanShot 2026-04-16 at 10 58 29@2x" src="https://github.com/user-attachments/assets/9dcb1cf3-a5bf-4a9c-a52e-ab790ea32a43" />


## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Open **Jetpack → Settings** in wp-admin.
2. Click the search icon in the settings header and enter a term that matches nothing, e.g. `asdfqwerty`.
3. Verify the empty-state card renders horizontally centered beneath the search bar, with the magnifying-glass icon, a **No matching settings** title, and a **No search results found for asdfqwerty** description.
4. Clear the search. Verify the normal settings sections return and no stray empty-state is shown.
5. Enter a term that matches at least one setting (e.g. `backup`, `sharing`). Verify the matching sections render and the empty state does not.
6. Confirm there is no visual regression on the non-search view of the settings screen.
