### PR TITLE
Remove mirror-repo config from premium-analytics package

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-mirror-repo-config
+++ b/projects/packages/premium-analytics/changelog/fix-mirror-repo-config
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Remove non-existent mirror-repo config that breaks trunk build.

--- a/projects/packages/premium-analytics/composer.json
+++ b/projects/packages/premium-analytics/composer.json
@@ -45,15 +45,11 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"extra": {
-		"autotagger": true,
-		"mirror-repo": "Automattic/jetpack-premium-analytics",
 		"textdomain": "jetpack-premium-analytics",
 		"version-constants": {
 			"::PACKAGE_VERSION": "src/class-analytics.php"
 		},
-		"changelogger": {
-			"link-template": "https://github.com/Automattic/jetpack-premium-analytics/compare/${old}...${new}"
-		},
+		"changelogger": {},
 		"branch-alias": {
 			"dev-trunk": "0.1.x-dev"
 		}


### PR DESCRIPTION
## What?

Removes `mirror-repo`, `autotagger`, and `changelogger.link-template` from the `premium-analytics` package `composer.json`. The mirror repo `Automattic/jetpack-premium-analytics` does not exist yet and its reference breaks the trunk build.

Closes WOOA7S-1351
Follow-up WOOA7S-1352

## Why?

Trunk build is failing after #48085 was merged. bradshawtm needs a green trunk for an alpha release.

## How?

Removed the three mirror-dependent keys from `extra` in `projects/packages/premium-analytics/composer.json`. Mirror + autotagger will be re-added once the repo is created (WOOA7S-1352).

## Testing

- Verify trunk build passes after merge.