### PR TITLE
VideoPress: Clear isDeleting flag after a delete completes

### DIFF
--- a/projects/packages/videopress/changelog/2026-04-15-15-16-30-702205
+++ b/projects/packages/videopress/changelog/2026-04-15-15-16-30-702205
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix stuck loading state on video card after deleting a video

--- a/projects/packages/videopress/changelog/2026-04-15-15-16-30-702205
+++ b/projects/packages/videopress/changelog/2026-04-15-15-16-30-702205
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix stuck loading state on video card after deleting a video
+Fix stuck loading state on video card after deleting a video.

--- a/projects/packages/videopress/src/client/state/reducers.js
+++ b/projects/packages/videopress/src/client/state/reducers.js
@@ -330,6 +330,7 @@ const videos = ( state, action ) => {
 						..._metaItems,
 						[ id ]: {
 							..._metaVideo,
+							isDeleting: false,
 							hasBeenDeleted,
 							deletedVideo,
 						},

--- a/projects/packages/videopress/src/client/state/test/reducers.js
+++ b/projects/packages/videopress/src/client/state/test/reducers.js
@@ -1,4 +1,4 @@
-import { SET_FEATURES, SET_IS_FETCHING_FEATURES } from '../constants';
+import { DELETE_VIDEO, REMOVE_VIDEO, SET_FEATURES, SET_IS_FETCHING_FEATURES } from '../constants';
 import reducers from '../reducers';
 
 describe( 'features reducer', () => {
@@ -72,5 +72,63 @@ describe( 'features reducer', () => {
 			isVideoPress1TBSupported: false,
 			isVideoPressUnlimitedSupported: false,
 		} );
+	} );
+} );
+
+describe( 'videos reducer - delete flow', () => {
+	const videoId = 1383;
+
+	const stateWithVideoMarkedForRemoval = () =>
+		reducers(
+			{
+				videos: {
+					items: [ { id: videoId, title: 'post-editor-mov' } ],
+					uploadedVideoCount: 1,
+					_meta: { processedAllVideosBeingRemoved: true, relyOnInitialState: true },
+				},
+			},
+			{ type: REMOVE_VIDEO, id: videoId }
+		);
+
+	it( 'REMOVE_VIDEO sets isDeleting on the video metadata', () => {
+		const state = stateWithVideoMarkedForRemoval();
+		expect( state.videos._meta.items[ videoId ].isDeleting ).toBe( true );
+		expect( state.videos._meta.videosBeingRemoved ).toEqual( [
+			{ id: videoId, processed: false, deleted: false },
+		] );
+	} );
+
+	it( 'DELETE_VIDEO clears isDeleting when the server confirms the delete', () => {
+		const afterRemove = stateWithVideoMarkedForRemoval();
+		const afterDelete = reducers( afterRemove, {
+			type: DELETE_VIDEO,
+			id: videoId,
+			hasBeenDeleted: true,
+			video: { id: videoId, title: 'post-editor-mov' },
+		} );
+
+		expect( afterDelete.videos._meta.items[ videoId ].isDeleting ).toBe( false );
+		expect( afterDelete.videos._meta.items[ videoId ].hasBeenDeleted ).toBe( true );
+		expect( afterDelete.videos.uploadedVideoCount ).toBe( 0 );
+	} );
+
+	it( 'DELETE_VIDEO clears isDeleting even when the server delete failed', () => {
+		// Regression guard: if the apiFetch DELETE fails or the response
+		// does not include { deleted: true }, the thunk still dispatches
+		// DELETE_VIDEO in its `finally` block with hasBeenDeleted=false.
+		// Without clearing isDeleting here, the video row stays stuck in
+		// a gray loading state forever and the user has no way to retry.
+		const afterRemove = stateWithVideoMarkedForRemoval();
+		const afterDelete = reducers( afterRemove, {
+			type: DELETE_VIDEO,
+			id: videoId,
+			hasBeenDeleted: false,
+			video: {},
+		} );
+
+		expect( afterDelete.videos._meta.items[ videoId ].isDeleting ).toBe( false );
+		expect( afterDelete.videos._meta.items[ videoId ].hasBeenDeleted ).toBe( false );
+		// Count is unchanged on failure.
+		expect( afterDelete.videos.uploadedVideoCount ).toBe( 1 );
 	} );
 } );


### PR DESCRIPTION
Fixes #

## Proposed changes
- Clear `isDeleting` on the video metadata inside the `DELETE_VIDEO` reducer. Previously the reducer spread `..._metaVideo` (which still carried `isDeleting: true` from `REMOVE_VIDEO`) and never reset it, so if the deleted video stayed in `state.videos.items` for any reason (refetch race, server/CDN caching, or a failed delete), the video row/card would stay stuck in a gray loading state and the user had to retry.
- Add reducer tests covering `REMOVE_VIDEO` setting the flag, `DELETE_VIDEO` clearing it on a successful delete, and `DELETE_VIDEO` clearing it on a failed delete.

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
1. Open the VideoPress admin dashboard at `/wp-admin/admin.php?page=jetpack-videopress`.
2. Upload a video (or use an existing one).
3. Hover the video card and click the red trash icon to open the **Delete video** confirmation modal.
4. Click **Delete**.
5. **Before this PR:** the card stays in a gray loading placeholder state forever; refreshing shows the video still there; clicking delete a second time works.
6. **With this PR:** the card disappears from the library and the empty state ("Let's add your first video below!") is shown immediately on the first attempt.
7. Run the package tests: `cd projects/packages/videopress && pnpm jest src/client/state/test/reducers.js` — all 8 tests should pass.
