### PR TITLE
Admin pages: unify layout under jetpack-admin-page-layout mixin

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3184,6 +3184,9 @@ importers:
       '@automattic/jetpack-api':
         specifier: workspace:*
         version: link:../../js-packages/api
+      '@automattic/jetpack-base-styles':
+        specifier: workspace:*
+        version: link:../../js-packages/base-styles
       '@automattic/jetpack-components':
         specifier: workspace:*
         version: link:../../js-packages/components

--- a/projects/js-packages/base-styles/admin-page-layout.scss
+++ b/projects/js-packages/base-styles/admin-page-layout.scss
@@ -1,0 +1,196 @@
+// Jetpack admin-page layout mixin.
+
+// Standardizes the layout of a Jetpack wp-admin page so <AdminPage> controls
+// the full content area: fixed Jetpack header at the top, the middle section
+// scrolls internally, JetpackFooter pinned at the bottom. No window-level
+// scroll; nothing leaks outside the scope.
+
+// Usage:
+
+//   @use "@automattic/jetpack-base-styles/admin-page-layout" as *;
+//   :global {
+//     body.jetpack_page_my-jetpack { @include jetpack-admin-page-layout; }
+//   }
+
+// Selector hooks this mixin relies on (all stable, not CSS-Modules hashed):
+
+//   wp-admin shell:          #wpcontent, #wpbody-content, #wpfooter
+//   <AdminPage> root:        .jp-admin-page   (added unconditionally by the
+//                                              <AdminPage> component from
+//                                              @automattic/jetpack-components)
+//   @wordpress/admin-ui:     .admin-ui-page, .admin-ui-page__header
+//   <JetpackFooter>:         .jetpack-footer
+
+// Implementation note — `postcss-custom-properties` with `preserve: false`:
+// several consumer packages in this monorepo (publicize, videopress, search,
+// jetpack plugin) resolve `var()` to its fallback at build time. That rules
+// out *runtime-toggled* custom properties (you can't use a CSS var to flip
+// `<AdminPage>`'s margin between the legacy and the new layout, because the
+// fallback wins before the override can reach it). It does NOT rule out
+// `var(--name, <fallback>)` used purely for readability and forward-
+// compatibility on size values — the compiled output is identical to
+// inlining the fallback. This mixin uses `var(--wp-admin-bar-height, …)`
+// (mirroring `projects/packages/forms/src/dashboard/inbox/style.scss`) so
+// the intent stays legible, and so packages that don't run the `preserve:
+// false` plugin can override the var at runtime. Immutable sizes (sidebar
+// widths, viewport breakpoints) use SCSS variables — they can't change at
+// runtime and there's no need to pay the custom-property indirection.
+
+// wp-admin chrome constants (see wp-admin.css).
+$jp-sidebar-width-expanded: 160px;     // default sidebar
+$jp-sidebar-width-folded: 36px;        // .folded preference OR .auto-fold class
+$jp-admin-bar-height-desktop: 32px;
+$jp-admin-bar-height-mobile: 46px;
+
+// Viewport breakpoints WP itself uses:
+//   ≤ 960px → WP toggles `.auto-fold` on <body>, narrows the sidebar to 36px
+//   ≤ 782px → sidebar goes off-canvas (0) regardless of .folded/.auto-fold
+// We mirror these breakpoints because WP's body-class state is not always
+// in sync with the rendered viewport (the `auto-fold` class can stay stale
+// after a narrow → wide window resize).
+$jp-breakpoint-auto-fold: 960px;
+$jp-breakpoint-mobile: 782px;
+
+@mixin jetpack-admin-page-layout {
+	// ── wp-admin chrome resets ────────────────────────────────────────
+	#wpcontent {
+		padding-left: 0;
+	}
+
+	// wp-admin's footer floats at the very bottom via `position: absolute`;
+	// we replace it with a pinned JetpackFooter inside the scope.
+	#wpfooter {
+		display: none;
+	}
+
+	// ── Viewport-pinned content column ────────────────────────────────
+	// `position: fixed` pins the content column to the viewport. The
+	// sidebar (`#adminmenumain`) is left untouched — it can grow past
+	// viewport; the window will scroll for it without disturbing the
+	// fixed content column. This is the pattern Calypso adopted in
+	// wp-calypso#109899 for its own admin pages.
+
+	// We intentionally do NOT constrain `#adminmenuwrap` with
+	// `overflow-y: auto` here: any overflow on a sidebar ancestor clips
+	// the absolutely-positioned `.wp-submenu` flyouts that appear on
+	// hover in both folded AND expanded modes (for parent menus whose
+	// submenu isn't auto-expanded). Letting the window scroll for a tall
+	// sidebar is the acceptable tradeoff.
+	#wpbody-content {
+		box-sizing: border-box;
+		position: fixed;
+		top: var(--wp-admin-bar-height, #{$jp-admin-bar-height-desktop});
+		left: $jp-sidebar-width-expanded;
+		right: 0;
+		bottom: 0;
+		// wp-admin core sets `width: 100%` on #wpbody-content (common.css).
+		// With `position: fixed`, that resolves to 100% of the viewport and
+		// overrides `right: 0`, making the column extend past the viewport
+		// by the sidebar width. `width: auto` lets left+right size it.
+		width: auto;
+		padding-bottom: 0;          // wp-admin default is 65px (clears #wpfooter).
+		overflow: hidden;
+		display: flex;
+		flex-direction: column;
+	}
+
+	// `.folded` is the user's persistent "Collapse menu" preference; WP
+	// keeps it set at every viewport width, so we match it unconditionally.
+	&.folded #wpbody-content {
+		left: $jp-sidebar-width-folded;
+	}
+
+	// `.auto-fold` is WP JS state, gated to narrow-desktop widths. Scope
+	// our match to the same media range WP uses in wp-admin.css, otherwise
+	// a stale `.auto-fold` class (WP doesn't always remove it on resize)
+	// would mis-offset the column at wide viewports where the sidebar has
+	// rebounded to 160px.
+	@media (max-width: #{$jp-breakpoint-auto-fold}) {
+
+		&.auto-fold #wpbody-content {
+			left: $jp-sidebar-width-folded;
+		}
+	}
+
+	// Every ancestor of <AdminPage> inside #wpbody-content must participate
+	// in the flex chain, or the column collapses at the first non-flex
+	// wrapper. Some pages mount their React tree with an extra wrapper in
+	// between (e.g. ThemeProvider from @automattic/jetpack-components adds
+	// a `display: block` div); `:has()` targets the whole chain regardless
+	// of depth. `min-width: 0` + `min-height: 0` let flex items shrink on
+	// both axes (defaults to content size which can cause overflow).
+	#wpbody-content :has(.jp-admin-page) {
+		flex: 1 1 auto;
+		min-height: 0;
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+	}
+
+	// ── <AdminPage> root ──────────────────────────────────────────────
+	// Neutralize the legacy -20px shift and make AdminPage a flex child
+	// that fills its parent column.
+	.jp-admin-page {
+		margin-left: 0;
+		display: flex;
+		flex-direction: column;
+		flex: 1 1 auto;
+		min-height: 0;
+		min-width: 0;
+	}
+
+	// ── admin-ui Page internals ───────────────────────────────────────
+	// admin-ui ships `.admin-ui-page` with `height: 100%`, which fills its
+	// parent's computed height. Paired with our flex chain, the element
+	// becomes a viewport-fitted flex column.
+	.admin-ui-page {
+		flex: 1 1 auto;
+		min-height: 0;
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.admin-ui-page__header {
+		flex-shrink: 0;              // pinned at top of the flex column.
+	}
+
+	// The scrollable middle. <AdminPage> does not pass `hasPadding` to
+	// admin-ui's <Page>, so `.admin-ui-page__content` is not rendered —
+	// children drop in as direct descendants of `.admin-ui-page`. Target
+	// anything that isn't the header or the footer.
+
+	// `overflow: auto` (both axes) lets any child wider than the column
+	// (dashboard grids with fixed column widths, wide tables, `100vw`
+	// descendants) scroll horizontally inside the middle instead of
+	// dragging the whole window into a horizontal scrollbar.
+	.admin-ui-page > :not(.admin-ui-page__header):not(.jetpack-footer) {
+		flex: 1 1 auto;
+		min-height: 0;
+		min-width: 0;
+		overflow: auto;
+	}
+
+	// ── <JetpackFooter> pinned at the bottom ─────────────────────────
+	.jetpack-footer {
+		flex-shrink: 0;
+	}
+
+	// ── Mobile: admin bar grows to 46px; sidebar goes off-canvas ─────
+	// Match `.folded` and `.auto-fold` explicitly: both outrank the bare
+	// `#wpbody-content` selector on specificity, so the media query needs
+	// equal specificity for `left: 0` to win over the desktop fold rules.
+	@media (max-width: #{$jp-breakpoint-mobile}) {
+
+		#wpbody-content,
+		&.folded #wpbody-content,
+		&.auto-fold #wpbody-content {
+			top: var(--wp-admin-bar-height, #{$jp-admin-bar-height-mobile});
+			left: 0;                 // sidebar slides out of flow at this width.
+		}
+
+		.jp-admin-page {
+			margin-left: 0;          // override legacy -10px @ ≤782px too.
+		}
+	}
+}

--- a/projects/js-packages/base-styles/changelog/add-admin-page-layout-mixin
+++ b/projects/js-packages/base-styles/changelog/add-admin-page-layout-mixin
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Added admin-page-layout mixin: a shared SCSS mixin that standardizes Jetpack wp-admin pages with a viewport-pinned content column (pinned header, scrolling middle, pinned footer). Consumed as `@use "@automattic/jetpack-base-styles/admin-page-layout"`.

--- a/projects/js-packages/base-styles/package.json
+++ b/projects/js-packages/base-styles/package.json
@@ -19,6 +19,7 @@
 		"build-production-js": "echo 'Not implemented.'"
 	},
 	"exports": {
+		"./admin-page-layout": "./admin-page-layout.scss",
 		"./gutenberg-base-styles": "./gutenberg-base-styles.scss",
 		"./package.json": "./package.json",
 		"./root-variables": "./root-variables.scss",

--- a/projects/js-packages/components/changelog/adminpage-stable-class
+++ b/projects/js-packages/components/changelog/adminpage-stable-class
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AdminPage: added a stable, non-hashed `jp-admin-page` class on the component root so shared SCSS mixins and global stylesheets can target AdminPage without coupling to the hashed CSS-Modules className.

--- a/projects/js-packages/components/components/admin-page/index.tsx
+++ b/projects/js-packages/components/components/admin-page/index.tsx
@@ -47,7 +47,10 @@ const AdminPage: FC< AdminPageProps > = ( {
 		restApi.setApiNonce( apiNonce );
 	}, [ apiRoot, apiNonce ] );
 
-	const rootClassName = clsx( styles[ 'admin-page' ], className, {
+	// `jp-admin-page` is a stable, non-hashed hook for global stylesheets and
+	// shared SCSS mixins (notably `jetpack-admin-page-layout` in
+	// @automattic/jetpack-base-styles). Do not rename.
+	const rootClassName = clsx( styles[ 'admin-page' ], 'jp-admin-page', className, {
 		[ styles.background ]: showBackground,
 		[ styles[ 'without-bottom-border' ] ]: tabs || ! showBottomBorder,
 	} );

--- a/projects/packages/backup/changelog/adopt-admin-page-layout
+++ b/projects/packages/backup/changelog/adopt-admin-page-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Adopt the shared Jetpack admin-page-layout mixin on the Backup admin page: pinned header, scrolling middle, pinned footer, no window-level scroll.

--- a/projects/packages/backup/src/js/components/Admin/style.scss
+++ b/projects/packages/backup/src/js/components/Admin/style.scss
@@ -1,5 +1,11 @@
 @use "@automattic/jetpack-base-styles/style" as jpbs;
+@use "@automattic/jetpack-base-styles/admin-page-layout" as *;
 @use "../masthead/calypso-mixins";
+
+body.jetpack_page_jetpack-backup {
+
+	@include jetpack-admin-page-layout;
+}
 
 .jp-header,
 .jp-footer {

--- a/projects/packages/newsletter/changelog/adopt-admin-page-layout
+++ b/projects/packages/newsletter/changelog/adopt-admin-page-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Adopt the shared Jetpack admin-page-layout mixin on the Newsletter admin page: pinned header, scrolling middle, pinned footer, no window-level scroll. Adds @automattic/jetpack-base-styles as a workspace dependency.

--- a/projects/packages/newsletter/package.json
+++ b/projects/packages/newsletter/package.json
@@ -34,6 +34,7 @@
 	"dependencies": {
 		"@automattic/jetpack-analytics": "workspace:*",
 		"@automattic/jetpack-api": "workspace:*",
+		"@automattic/jetpack-base-styles": "workspace:*",
 		"@automattic/jetpack-components": "workspace:*",
 		"@automattic/jetpack-connection": "workspace:*",
 		"@automattic/jetpack-script-data": "workspace:*",

--- a/projects/packages/newsletter/src/settings/style.scss
+++ b/projects/packages/newsletter/src/settings/style.scss
@@ -1,6 +1,13 @@
+@use "@automattic/jetpack-base-styles/admin-page-layout" as *;
+
 // Import dataviews styles for DataForm component
 @import "@wordpress/theme/design-tokens.css";
 @import "@wordpress/dataviews/build-style/style.css";
+
+body.jetpack_page_jetpack-newsletter {
+
+	@include jetpack-admin-page-layout;
+}
 
 #newsletter-settings-root * {
 	box-sizing: border-box;

--- a/projects/packages/publicize/_inc/components/admin-page/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/admin-page/styles.module.scss
@@ -1,4 +1,11 @@
+@use "@automattic/jetpack-base-styles/admin-page-layout" as *;
+
 :global {
+
+	body.jetpack_page_jetpack-social {
+
+		@include jetpack-admin-page-layout;
+	}
 
 	#wpbody-content {
 

--- a/projects/packages/publicize/changelog/adopt-admin-page-layout
+++ b/projects/packages/publicize/changelog/adopt-admin-page-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Adopt the shared Jetpack admin-page-layout mixin on the Social admin page: pinned header, scrolling middle, pinned footer, no window-level scroll.

--- a/projects/packages/search/changelog/adopt-admin-page-layout
+++ b/projects/packages/search/changelog/adopt-admin-page-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Adopt the shared Jetpack admin-page-layout mixin on the Search admin page. Drops the inline JetpackFooter render and `showFooter={false}` override so AdminPage's built-in footer lives inside the flex column that the mixin pins.

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -1,6 +1,5 @@
 import {
 	AdminPage,
-	JetpackFooter,
 	Button,
 	Container,
 	Col,
@@ -125,7 +124,6 @@ export default function DashboardPage( { isLoading = false } ) {
 				apiRoot={ apiRoot }
 				apiNonce={ apiNonce }
 				className="uses-new-admin-ui"
-				showFooter={ false }
 			>
 				<div className="jp-search-dashboard-top jp-search-dashboard-wrap">
 					{ /* Always in the DOM so JITM JS finds it immediately (Path A). */ }
@@ -186,7 +184,6 @@ export default function DashboardPage( { isLoading = false } ) {
 								isTogglingInstantSearch={ isTogglingInstantSearch }
 							/>
 						</div>
-						<JetpackFooter />
 						<NoticesList
 							notices={ notices }
 							handleLocalNoticeDismissClick={ handleLocalNoticeDismissClick }

--- a/projects/packages/search/src/dashboard/index.jsx
+++ b/projects/packages/search/src/dashboard/index.jsx
@@ -2,6 +2,7 @@ import { createReduxStore, register } from '@wordpress/data';
 import * as WPElement from '@wordpress/element';
 import SearchDashboard from './components/dashboard/wrapped-dashboard';
 import { STORE_ID, storeConfig } from './store';
+import './scss/admin-layout.scss';
 
 const store = createReduxStore( STORE_ID, storeConfig );
 register( store );

--- a/projects/packages/search/src/dashboard/scss/admin-layout.scss
+++ b/projects/packages/search/src/dashboard/scss/admin-layout.scss
@@ -1,0 +1,6 @@
+@use "@automattic/jetpack-base-styles/admin-page-layout" as *;
+
+body.jetpack_page_jetpack-search {
+
+	@include jetpack-admin-page-layout;
+}

--- a/projects/packages/videopress/changelog/adopt-admin-page-layout
+++ b/projects/packages/videopress/changelog/adopt-admin-page-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Adopt the shared Jetpack admin-page-layout mixin on the VideoPress admin page: pinned header, scrolling middle, pinned footer, no window-level scroll.

--- a/projects/packages/videopress/src/client/admin/style.module.scss
+++ b/projects/packages/videopress/src/client/admin/style.module.scss
@@ -1,3 +1,5 @@
+@use "@automattic/jetpack-base-styles/admin-page-layout" as *;
+
 $gray-300: #ddd;
 $border-width: 1px;
 $header-height: 60px;
@@ -5,6 +7,12 @@ $grid-unit: 8px;
 $grid-unit-20: 2 * $grid-unit; // 16px
 
 :global {
+
+	body.jetpack_page_jetpack-videopress {
+
+		@include jetpack-admin-page-layout;
+	}
+
 	// Supporting Gutenberg version (12.5.10) from latest WordPress release (6.0.2)
 	.jetpack_page_jetpack-videopress {
 		// https://github.com/WordPress/gutenberg/pull/40781

--- a/projects/plugins/boost/app/assets/src/css/admin-style.scss
+++ b/projects/plugins/boost/app/assets/src/css/admin-style.scss
@@ -4,4 +4,10 @@
 @use "main/wp-admin";
 @use "main/dashboard";
 @use "main/common";
+@use "@automattic/jetpack-base-styles/admin-page-layout" as *;
+
+body.jetpack_page_jetpack-boost {
+
+	@include jetpack-admin-page-layout;
+}
 

--- a/projects/plugins/boost/app/assets/src/js/layout/boost-admin-page/boost-admin-page.tsx
+++ b/projects/plugins/boost/app/assets/src/js/layout/boost-admin-page/boost-admin-page.tsx
@@ -35,7 +35,6 @@ const BoostAdminPage = ( {
 			subTitle={ __( 'Optimize your site performance and loading speed.', 'jetpack-boost' ) }
 			breadcrumbs={ breadcrumbs }
 			actions={ licenseAction }
-			showFooter={ false }
 			showBackground={ false }
 		>
 			{ children }

--- a/projects/plugins/boost/app/assets/src/js/layout/card-page/card-page.tsx
+++ b/projects/plugins/boost/app/assets/src/js/layout/card-page/card-page.tsx
@@ -1,5 +1,4 @@
 import BoostAdminPage from '$layout/boost-admin-page/boost-admin-page';
-import { JetpackFooter } from '@automattic/jetpack-components';
 import BackButton from '$features/ui/back-button/back-button';
 import JetpackLogo from '$svg/jetpack-green';
 import clsx from 'clsx';
@@ -37,10 +36,6 @@ const CardPage = ( {
 						</div>
 						{ footerNote && <footer className={ styles[ 'footer-note' ] }>{ footerNote }</footer> }
 					</div>
-				</div>
-
-				<div className={ styles.footer }>
-					<JetpackFooter />
 				</div>
 			</div>
 		</BoostAdminPage>

--- a/projects/plugins/boost/app/assets/src/js/layout/settings-page/settings-page.tsx
+++ b/projects/plugins/boost/app/assets/src/js/layout/settings-page/settings-page.tsx
@@ -1,6 +1,5 @@
 import SpeedScore from '$features/speed-score/speed-score';
 import BoostAdminPage from '$layout/boost-admin-page/boost-admin-page';
-import { JetpackFooter } from '@automattic/jetpack-components';
 import Support from './support/support';
 import Tips from './tips/tips';
 import clsx from 'clsx';
@@ -38,7 +37,6 @@ const SettingsPage = ( { children }: SettingsPageProps ) => {
 
 						{ hasPrioritySupport && <Support /> }
 
-						<JetpackFooter />
 						<NoticeManager />
 					</div>
 				</BoostAdminPage>

--- a/projects/plugins/boost/app/assets/src/js/pages/cache-debug-log/cache-debug-log.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/cache-debug-log/cache-debug-log.tsx
@@ -2,7 +2,7 @@ import { __ } from '@wordpress/i18n';
 import BoostAdminPage from '$layout/boost-admin-page/boost-admin-page';
 import styles from './cache-debug-log.module.scss';
 import clsx from 'clsx';
-import { CopyToClipboard, JetpackFooter, JetpackLogo } from '@automattic/jetpack-components';
+import { CopyToClipboard, JetpackLogo } from '@automattic/jetpack-components';
 import { useDebugLog } from '$features/page-cache/lib/stores';
 import { useNavigate } from 'react-router';
 import { recordBoostEvent } from '$lib/utils/analytics';
@@ -69,7 +69,6 @@ const CacheDebugLog = () => {
 						<pre className={ styles[ 'log-text' ] }>{ debugLog }</pre>
 					</div>
 				</div>
-				<JetpackFooter />
 			</div>
 		</BoostAdminPage>
 	);

--- a/projects/plugins/boost/app/assets/src/js/pages/getting-started/getting-started.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/getting-started/getting-started.tsx
@@ -4,7 +4,6 @@ import { getUpgradeURL, useConnection } from '$lib/stores/connection';
 import { recordBoostEvent } from '$lib/utils/analytics';
 import { BoostPricingTable } from '$features/boost-pricing-table/boost-pricing-table';
 import BoostAdminPage from '$layout/boost-admin-page/boost-admin-page';
-import { JetpackFooter } from '@automattic/jetpack-components';
 import styles from './getting-started.module.scss';
 import { useGettingStarted } from '$lib/stores/getting-started';
 import { useNavigate } from 'react-router';
@@ -101,7 +100,6 @@ const GettingStarted: FC = () => {
 						</div>
 					</div>
 				</div>
-				<JetpackFooter />
 			</div>
 		</BoostAdminPage>
 	);

--- a/projects/plugins/boost/changelog/adopt-admin-page-layout
+++ b/projects/plugins/boost/changelog/adopt-admin-page-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Adopt the shared Jetpack admin-page-layout mixin on the Boost admin pages. Drops inline JetpackFooter renders and `showFooter={false}` overrides so AdminPage's built-in footer lives inside the flex column that the mixin pins.

--- a/projects/plugins/jetpack/_inc/client/network-admin.scss
+++ b/projects/plugins/jetpack/_inc/client/network-admin.scss
@@ -1,0 +1,15 @@
+@use "@automattic/jetpack-base-styles/admin-page-layout" as *;
+
+// Sites: default view of the toplevel menu — WP emits
+//   `toplevel_page_jetpack-network-sites`.
+// Settings: secondary submenu — the body class prefix is derived from the
+//   menu *title* ("JP Network") sanitized to `jp-network`, producing
+//   `jp-network_page_jetpack-network-settings`. See the
+//   `admin_print_scripts-jp-network_page_jetpack-network-settings` hook in
+//   `tools/docker/mu-plugins/0-sandbox.php` for the canonical reference.
+// Both share `#jp-network-admin-root`; React branches on `data-page`.
+body.toplevel_page_jetpack-network-sites,
+body.jp-network_page_jetpack-network-settings {
+
+	@include jetpack-admin-page-layout;
+}

--- a/projects/plugins/jetpack/_inc/client/network-admin.tsx
+++ b/projects/plugins/jetpack/_inc/client/network-admin.tsx
@@ -8,6 +8,7 @@ import {
 import { createRoot } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useRef } from 'react';
+import './network-admin.scss';
 
 type PageType = 'sites' | 'settings';
 

--- a/projects/plugins/jetpack/changelog/network-admin-layout
+++ b/projects/plugins/jetpack/changelog/network-admin-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Adopt the shared Jetpack admin-page-layout on the JP Network admin pages (Sites and Settings): pinned header, scrolling middle, pinned footer, no window-level scroll.

--- a/projects/plugins/protect/changelog/adopt-admin-page-layout
+++ b/projects/plugins/protect/changelog/adopt-admin-page-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Adopt the shared Jetpack admin-page-layout mixin: pinned header, scrolling middle, pinned footer, no window-level scroll.

--- a/projects/plugins/protect/src/js/styles.module.scss
+++ b/projects/plugins/protect/src/js/styles.module.scss
@@ -1,4 +1,11 @@
+@use "@automattic/jetpack-base-styles/admin-page-layout" as *;
+
 :global {
+
+	body.jetpack_page_jetpack-protect {
+
+		@include jetpack-admin-page-layout;
+	}
 
 	* {
 		box-sizing: border-box;


### PR DESCRIPTION
Fixes #

## Proposed changes

Unifies the layout of Jetpack's wp-admin pages under a single, reusable SCSS mixin (`@automattic/jetpack-base-styles/admin-page-layout`). After this change, every migrated page renders with a viewport-pinned content column: the Jetpack header is pinned at the top, the middle section scrolls internally, and `<JetpackFooter>` is pinned at the bottom. No window-level scroll; nothing leaks outside the scope.

**Covered pages (8):**
- Protect
- Social (Publicize)
- VideoPress
- Backup
- Newsletter
- Search
- Boost (all sub-pages: BoostAdminPage, card-page, settings-page, cache-debug-log, getting-started)
- Jetpack Network Admin (Sites + Settings)

**Key mechanics, in order of commits:**

1. **`base-styles` mixin** — Introduces the mixin. Overrides WP core's `#wpbody-content { width: 100% }` (from `wp-admin/css/common.css`) with `width: auto` so `position: fixed + left + right: 0` can size the column correctly. Without this, `width: 100%` resolves to `100vw` under fixed positioning and pushes the column past the viewport by the sidebar width.
2. **`jetpack-components`** — Adds a stable `jp-admin-page` class on `<AdminPage>` so global stylesheets / shared mixins can target it without coupling to the hashed CSS-Modules class.
3. **Per-page adoption commits** — Each page does `@include jetpack-admin-page-layout` scoped to its body class (one commit per page/plugin). Search and Boost also drop inline `<JetpackFooter />` renders + `showFooter={false}` overrides so the footer lives inside AdminPage's flex column where the mixin can pin it.

**Viewport handling:**
- `.folded` body class (user's persistent "Collapse menu" preference) honored at every desktop width.
- `.auto-fold` body class gated to `@media (max-width: 960px)` (mirroring WP's own `wp-admin.css` scoping) so stale classes after a narrow → wide resize don't mis-offset the column.
- Mobile media query `(max-width: 782px)` explicitly matches `#wpbody-content`, `.folded #wpbody-content`, and `.auto-fold #wpbody-content` so `left: 0` wins via equal-specificity source order over the desktop fold rules.
- Sidebar widths (160, 36) and viewport breakpoints (960, 782) live in SCSS variables; admin-bar height remains `var(--wp-admin-bar-height, …)` for runtime override.

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

On a wp.com / Jurassic Ninja site with Jetpack, Boost, Protect, VideoPress, Backup, Newsletter, Search, Publicize, and (if multisite) the JP Network Admin enabled:

**Desktop (≥ 960px):**

1. Load each of the 8 pages listed above. Verify:
   - The Jetpack header is pinned at the top of the content area (immediately below the admin bar).
   - The content column aligns with the right edge of the viewport — no horizontal clipping, no horizontal scrollbar.
   - The JetpackFooter is pinned at the bottom of the content area.
   - The middle section scrolls internally (not the whole window) when content is taller than the viewport.

2. Click "Collapse menu" in the wp-admin sidebar to fold it. Verify the content column's left edge realigns to the 36px sidebar width on each page.

**Narrow desktop (783–960px):**

3. Resize the browser into this range. Verify WP auto-folds the sidebar and the content column's left edge realigns to 36px.

**Mobile (≤ 782px):**

4. Resize the browser to a mobile width. Verify:
   - Sidebar slides off-canvas (accessible via the hamburger menu).
   - Content column fills the full viewport width (no 36px or 160px offset).
   - Header/footer remain pinned.

**Resize stress test:**

5. Resize the browser from desktop → mobile → back to desktop. Verify the content column reflows correctly each time — no stuck 36px offset from a stale `.auto-fold` body class.

## Screenshots

### Desktop (1488×900)

| Page | Before | After |
|---|---|---|
| Protect | <img width="480" alt="protect before" src="https://github.com/user-attachments/assets/c771c500-bb9f-41d0-a624-9415d8e2a64c" /> | <img width="480" alt="protect after" src="https://github.com/user-attachments/assets/ed5976ec-868e-404f-a995-d302351b7902" /> |
| Social | <img width="480" alt="social before" src="https://github.com/user-attachments/assets/fd1083f2-3b21-403e-b937-9097dd42f7ec" /> | <img width="480" alt="social after" src="https://github.com/user-attachments/assets/b8b263d9-8a27-4ba3-a35e-9491c5b2d974" /> |
| VideoPress | <img width="480" alt="videopress before" src="https://github.com/user-attachments/assets/28bcf996-b397-4c44-a5fa-d27c9eb67ecf" /> | <img width="480" alt="videopress after" src="https://github.com/user-attachments/assets/1d049bc7-743f-4f8c-b27b-24c3cde71ae8" /> |
| Backup | <img width="480" alt="backup before" src="https://github.com/user-attachments/assets/cfccbeb4-2357-4f71-af92-cdc80248c72c" /> | <img width="480" alt="backup after" src="https://github.com/user-attachments/assets/24ca1cd5-0f0a-46a3-a4d3-ae5392c03740" /> |
| Newsletter | <img width="480" alt="newsletter before" src="https://github.com/user-attachments/assets/92319638-9680-4660-bbe2-190cdad670a5" /> | <img width="480" alt="newsletter after" src="https://github.com/user-attachments/assets/e3f9c2e8-a553-496f-9f28-fe943fae1816" /> |
| Search | <img width="480" alt="search before" src="https://github.com/user-attachments/assets/2d4e7f08-e479-44ad-94fa-c991061f3642" /> | <img width="480" alt="search after" src="https://github.com/user-attachments/assets/e02dc516-c77d-414d-a783-169fb00d5ee6" /> |
| Boost | <img width="480" alt="boost before" src="https://github.com/user-attachments/assets/07347baf-5fc9-4112-a2e0-45339dc8dd6f" /> | <img width="480" alt="boost after" src="https://github.com/user-attachments/assets/4c191795-1084-461c-9aea-370e97048d05" /> |
| Network Sites | <img width="480" alt="network-sites before" src="https://github.com/user-attachments/assets/9c2608c1-dc6e-4089-802f-7fb3cfd1e3f6" /> | <img width="480" alt="network-sites after" src="https://github.com/user-attachments/assets/3d97a8c6-b98e-4627-b643-f06067a196aa" /> |

### Mobile (600×900)

| Page | Before | After |
|---|---|---|
| Protect | <img width="300" alt="protect before" src="https://github.com/user-attachments/assets/4f9a8d13-e24d-4dea-b86b-cabca6bc81f0" /> | <img width="300" alt="protect after" src="https://github.com/user-attachments/assets/93d117cf-0c85-4c63-a0ee-fe097ab5a31f" /> |
| Social | <img width="300" alt="social before" src="https://github.com/user-attachments/assets/284e0b9c-34f3-44c6-9779-b7dd13c35cd2" /> | <img width="300" alt="social after" src="https://github.com/user-attachments/assets/e9c464db-8305-4972-8e96-394dd4ad8f68" /> |
| VideoPress | <img width="300" alt="videopress before" src="https://github.com/user-attachments/assets/d0cc7d77-acab-4001-b162-194b83e8e3cc" /> | <img width="300" alt="videopress after" src="https://github.com/user-attachments/assets/5cfb51db-ea5b-4dcb-8513-bad8960abcaa" /> |
| Backup | <img width="300" alt="backup before" src="https://github.com/user-attachments/assets/ac73f4bb-691f-4115-a16e-2dbe9543a292" /> | <img width="300" alt="backup after" src="https://github.com/user-attachments/assets/83ee80bf-73e5-4253-9d0a-095d2474d167" /> |
| Newsletter | <img width="300" alt="newsletter before" src="https://github.com/user-attachments/assets/d9b9f4c4-c17d-408b-9514-91e4d531d0d9" /> | <img width="300" alt="newsletter after" src="https://github.com/user-attachments/assets/ca472f0c-494f-48b1-bf69-87d3a403e846" /> |
| Search | <img width="300" alt="search before" src="https://github.com/user-attachments/assets/1f82654a-a290-4401-9c15-6ffe4afa2565" /> | <img width="300" alt="search after" src="https://github.com/user-attachments/assets/4d58467d-e929-47d6-b5cf-456c61a10245" /> |
| Boost | <img width="300" alt="boost before" src="https://github.com/user-attachments/assets/794ffec2-d66f-485c-a30c-23dd2a06c9f3" /> | <img width="300" alt="boost after" src="https://github.com/user-attachments/assets/7425a088-e6b0-4e39-be82-4454d9611d2f" /> |
| Network Sites | _not captured_ | <img width="300" alt="network-sites after" src="https://github.com/user-attachments/assets/10cdccc3-d57c-47ee-af68-a9e08469eedc" /> |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
