### PR TITLE
Survicate: suppress surveys while Help Center is open

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/survicate-suppress-on-help-center
+++ b/projects/packages/jetpack-mu-wpcom/changelog/survicate-suppress-on-help-center
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Survicate: suppress surveys while Help Center is open.

--- a/projects/packages/jetpack-mu-wpcom/src/features/survicate/class-survicate.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/survicate/class-survicate.php
@@ -139,6 +139,30 @@ class Survicate {
 	window.addEventListener( 'SurvicateReady', function () {
 		window._sva.setVisitorTraits( traits );
 	} );
+
+	// Close any visible Survicate survey when the Help Center opens.
+	// Mirrors the suppression logic in wp-calypso's @automattic/survicate package.
+	function initHelpCenterSuppression() {
+		if ( ! window.wp || ! window.wp.data || ! window.wp.data.subscribe ) {
+			return;
+		}
+		var wasOpen = false;
+		window.wp.data.subscribe( function () {
+			try {
+				var store = window.wp.data.select( 'automattic/help-center' );
+				var isOpen = !! ( store && store.isHelpCenterShown && store.isHelpCenterShown() );
+				if ( isOpen && ! wasOpen && window._sva && window._sva.closeSurvey ) {
+					window._sva.closeSurvey();
+				}
+				wasOpen = isOpen;
+			} catch ( e ) {}
+		} );
+	}
+	if ( document.readyState !== 'loading' ) {
+		initHelpCenterSuppression();
+	} else {
+		document.addEventListener( 'DOMContentLoaded', initHelpCenterSuppression );
+	}
 } )();
 JS
 		);

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/survicate/Survicate_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/survicate/Survicate_Test.php
@@ -359,6 +359,20 @@ class Survicate_Test extends \WorDBless\BaseTestCase {
 		$this->assertStringContainsString( 'test@example.com', $inline_script );
 	}
 
+	/**
+	 * Tests that enqueue_scripts includes Help Center suppression logic.
+	 */
+	public function test_enqueue_scripts_includes_help_center_suppression() {
+		$this->enqueue_survicate_scripts();
+
+		$inline_script = $this->get_inline_script();
+
+		$this->assertStringContainsString( 'initHelpCenterSuppression', $inline_script );
+		$this->assertStringContainsString( 'automattic/help-center', $inline_script );
+		$this->assertStringContainsString( 'isHelpCenterShown', $inline_script );
+		$this->assertStringContainsString( 'closeSurvey', $inline_script );
+	}
+
 	// ---- Singleton tests ----
 
 	/**


### PR DESCRIPTION
## Summary

- Close any visible Survicate survey when the Help Center opens in wp-admin, mirroring the suppression logic added to wp-calypso in Automattic/wp-calypso#109989
- Subscribes to the `automattic/help-center` `@wordpress/data` store and calls `window._sva.closeSurvey()` when the Help Center transitions to open
- Gracefully degrades when the data store or `wp.data` is unavailable (try/catch + null checks)

## Testing instructions

1. Open any wp-admin page on an Atomic/Simple site (English locale)
2. Verify Survicate SDK loads as before (check for `survey.survicate.com` in network tab)
3. Trigger a Survicate survey (or use `window._sva.showSurvey()` if available)
4. Open the Help Center — the survey should be dismissed
5. Close the Help Center — future surveys should work normally

## Related PRs

- Automattic/jetpack#47107 (original Survicate integration)
- Automattic/wp-calypso#109989 (Calypso counterpart this mirrors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)