### PR TITLE
Forms: apply source filter to response export (FORMS-679)

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-export-source-filter
+++ b/projects/packages/forms/changelog/fix-forms-export-source-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: make response exports respect the Source filter so the downloaded CSV matches the filtered inbox view.

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -491,7 +491,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		}
 
 		if ( ! empty( $source ) ) {
-			$source_sql         = $this->get_source_filter_sql( absint( $source ) );
+			$source_sql         = Feedback::get_source_filter_sql( absint( $source ) );
 			$join_clause       .= $source_sql['join'];
 			$where_conditions[] = $source_sql['where'];
 		}
@@ -1058,28 +1058,6 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	}
 
 	/**
-	 * Returns the JOIN and WHERE SQL fragments for filtering by source post ID.
-	 *
-	 * Matches feedback with the _feedback_source_post_id meta set, or falls back
-	 * to post_parent for old feedback that doesn't have the meta yet.
-	 *
-	 * @param int $source_id The source post ID to filter by.
-	 * @return array{join: string, where: string} SQL fragments.
-	 */
-	private function get_source_filter_sql( $source_id ) {
-		global $wpdb;
-		$meta_key = esc_sql( Feedback::SOURCE_META_KEY );
-		return array(
-			'join'  => " LEFT JOIN {$wpdb->postmeta} AS source_meta ON ({$wpdb->posts}.ID = source_meta.post_id AND source_meta.meta_key = '{$meta_key}')",
-			'where' => $wpdb->prepare(
-				"(source_meta.meta_value = %s OR (source_meta.meta_id IS NULL AND {$wpdb->posts}.post_parent = %d))",
-				(string) $source_id,
-				$source_id
-			),
-		);
-	}
-
-	/**
 	 * Filters the query arguments for the feedback collection.
 	 *
 	 * @param array           $args    Key value array of query var to query value.
@@ -1097,7 +1075,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		$source = $request->get_param( 'source' );
 		if ( ! empty( $source ) ) {
 			$this->temp_source_filter_id  = absint( $source );
-			$this->temp_source_filter_sql = $this->get_source_filter_sql( $this->temp_source_filter_id );
+			$this->temp_source_filter_sql = Feedback::get_source_filter_sql( $this->temp_source_filter_id );
 			add_filter( 'posts_join', array( $this, 'join_source_meta' ), 10, 2 );
 			add_filter( 'posts_where', array( $this, 'filter_by_source_id' ), 10, 2 );
 		}

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -3047,7 +3047,7 @@ class Contact_Form_Plugin {
 
 		$args = array(
 			'posts_per_page'   => -1,
-			'post_type'        => 'feedback',
+			'post_type'        => Feedback::POST_TYPE,
 			'post_status'      => array( 'publish', 'draft' ),
 			'order'            => 'ASC',
 			'fields'           => 'ids',
@@ -3090,6 +3090,8 @@ class Contact_Form_Plugin {
 		}
 
 		$source_id = ! empty( $_POST['source'] ) ? absint( $_POST['source'] ) : 0;
+		$join_cb   = null;
+		$where_cb  = null;
 
 		if ( $source_id > 0 ) {
 			$source_sql = Feedback::get_source_filter_sql( $source_id );
@@ -3109,11 +3111,15 @@ class Contact_Form_Plugin {
 
 			add_filter( 'posts_join', $join_cb, 10, 2 );
 			add_filter( 'posts_where', $where_cb, 10, 2 );
+		}
+
+		try {
 			$feedbacks = get_posts( $args );
-			remove_filter( 'posts_join', $join_cb, 10 );
-			remove_filter( 'posts_where', $where_cb, 10 );
-		} else {
-			$feedbacks = get_posts( $args );
+		} finally {
+			if ( $join_cb ) {
+				remove_filter( 'posts_join', $join_cb, 10 );
+				remove_filter( 'posts_where', $where_cb, 10 );
+			}
 		}
 
 		return $this->get_export_feedback_data( $feedbacks );

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -3089,7 +3089,32 @@ class Contact_Form_Plugin {
 			);
 		}
 
-		$feedbacks = get_posts( $args );
+		$source_id = ! empty( $_POST['source'] ) ? absint( $_POST['source'] ) : 0;
+
+		if ( $source_id > 0 ) {
+			$source_sql = Feedback::get_source_filter_sql( $source_id );
+
+			$join_cb  = function ( $join, $query ) use ( $source_sql ) {
+				if ( Feedback::POST_TYPE !== $query->get( 'post_type' ) ) {
+					return $join;
+				}
+				return $join . $source_sql['join'];
+			};
+			$where_cb = function ( $where, $query ) use ( $source_sql ) {
+				if ( Feedback::POST_TYPE !== $query->get( 'post_type' ) ) {
+					return $where;
+				}
+				return $where . ' AND ' . $source_sql['where'];
+			};
+
+			add_filter( 'posts_join', $join_cb, 10, 2 );
+			add_filter( 'posts_where', $where_cb, 10, 2 );
+			$feedbacks = get_posts( $args );
+			remove_filter( 'posts_join', $join_cb, 10 );
+			remove_filter( 'posts_where', $where_cb, 10 );
+		} else {
+			$feedbacks = get_posts( $args );
+		}
 
 		return $this->get_export_feedback_data( $feedbacks );
 	}

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -3092,6 +3092,7 @@ class Contact_Form_Plugin {
 		$source_id = ! empty( $_POST['source'] ) ? absint( $_POST['source'] ) : 0;
 		$join_cb   = null;
 		$where_cb  = null;
+		$feedbacks = array();
 
 		if ( $source_id > 0 ) {
 			$source_sql = Feedback::get_source_filter_sql( $source_id );
@@ -3116,8 +3117,10 @@ class Contact_Form_Plugin {
 		try {
 			$feedbacks = get_posts( $args );
 		} finally {
-			if ( $join_cb ) {
+			if ( is_callable( $join_cb ) ) {
 				remove_filter( 'posts_join', $join_cb, 10 );
+			}
+			if ( is_callable( $where_cb ) ) {
 				remove_filter( 'posts_where', $where_cb, 10 );
 			}
 		}

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -120,6 +120,29 @@ class Feedback {
 	}
 
 	/**
+	 * Returns the JOIN and WHERE SQL fragments for filtering feedback posts by source post ID.
+	 *
+	 * Matches feedback with the _feedback_source_post_id meta set, or falls back
+	 * to post_parent for old feedback that doesn't have the meta yet.
+	 *
+	 * @param int $source_id The source post ID to filter by.
+	 * @return array{join: string, where: string} SQL fragments.
+	 */
+	public static function get_source_filter_sql( $source_id ) {
+		global $wpdb;
+		$meta_key  = esc_sql( self::SOURCE_META_KEY );
+		$source_id = (int) $source_id;
+		return array(
+			'join'  => " LEFT JOIN {$wpdb->postmeta} AS source_meta ON ({$wpdb->posts}.ID = source_meta.post_id AND source_meta.meta_key = '{$meta_key}')",
+			'where' => $wpdb->prepare(
+				"(source_meta.meta_value = %s OR (source_meta.meta_id IS NULL AND {$wpdb->posts}.post_parent = %d))",
+				(string) $source_id,
+				$source_id
+			),
+		);
+	}
+
+	/**
 	 * Invalidates the source post IDs cache when a feedback post is deleted.
 	 *
 	 * @param int      $post_id The deleted post ID.

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -125,6 +125,8 @@ class Feedback {
 	 * Matches feedback with the _feedback_source_post_id meta set, or falls back
 	 * to post_parent for old feedback that doesn't have the meta yet.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @param int $source_id The source post ID to filter by.
 	 * @return array{join: string, where: string} SQL fragments.
 	 */

--- a/projects/packages/forms/src/dashboard/hooks/use-export-responses.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-export-responses.ts
@@ -90,6 +90,10 @@ export default function useExportResponses(): ExportHookReturn {
 			data.append( 'search', currentQuery.search || '' );
 			data.append( 'status', currentQuery.status );
 
+			if ( currentQuery.source ) {
+				data.append( 'source', currentQuery.source );
+			}
+
 			if ( currentQuery.before && currentQuery.after ) {
 				data.append( 'before', currentQuery.before );
 				data.append( 'after', currentQuery.after );

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -1346,17 +1346,11 @@ JSON_DATA{"1_name":"Test Author","2_email":"author@example.com","3_file":{"field
 	}
 
 	/**
-	 * Test that the source filter adds the correct SQL JOIN and WHERE clauses.
+	 * Test that the shared Feedback::get_source_filter_sql helper returns
+	 * the correct SQL JOIN and WHERE fragments.
 	 */
-	public function test_source_filter_modifies_query() {
-		$endpoint = new Contact_Form_Endpoint( 'feedback' );
-
-		// Use reflection to call private get_source_filter_sql method.
-		$method = new \ReflectionMethod( $endpoint, 'get_source_filter_sql' );
-		if ( PHP_VERSION_ID < 80100 ) {
-			$method->setAccessible( true );
-		}
-		$sql = $method->invoke( $endpoint, 42 );
+	public function test_source_filter_sql_helper_returns_expected_fragments() {
+		$sql = Feedback::get_source_filter_sql( 42 );
 
 		$this->assertArrayHasKey( 'join', $sql );
 		$this->assertArrayHasKey( 'where', $sql );

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -1678,4 +1678,123 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$this->assertTrue( $plugin->use_block_editor_for_post( true, $post ) );
 		$this->assertFalse( $plugin->use_block_editor_for_post( false, $post ) );
 	}
+
+	/**
+	 * Creates a user and grants the `export` cap via the `user_has_cap`
+	 * filter so tests don't depend on role/option state (which WorDBless
+	 * can clear between tests).
+	 *
+	 * Returns a cleanup closure that removes the cap filter.
+	 *
+	 * @param string $login The user login.
+	 * @return array{0:int,1:callable} [ user_id, cleanup callback ]
+	 */
+	private static function create_export_capable_user( $login ) {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => $login,
+				'user_pass'  => 'password',
+				'role'       => 'administrator',
+			)
+		);
+		$grant   = function ( $allcaps ) {
+			$allcaps['export'] = true;
+			return $allcaps;
+		};
+		add_filter( 'user_has_cap', $grant );
+		$cleanup = function () use ( $grant ) {
+			remove_filter( 'user_has_cap', $grant );
+		};
+		return array( $user_id, $cleanup );
+	}
+
+	/**
+	 * Regression test: the response export must apply the Source filter so the
+	 * downloaded CSV matches the filtered inbox view.
+	 *
+	 * Previously (regression from #48027) the export ignored `$_POST['source']`
+	 * and returned all feedback entries regardless of the dashboard's selected
+	 * source. Asserting that the feedback SQL issued during export includes the
+	 * shared source-filter JOIN/WHERE protects against that reintroducing.
+	 */
+	public function test_export_applies_source_filter_when_source_post_param_is_set() {
+		list( $admin_id, $cleanup_cap ) = self::create_export_capable_user( 'export_source_admin' );
+		wp_set_current_user( $admin_id );
+
+		$plugin = Contact_Form_Plugin::init();
+
+		$captured_query = null;
+		add_filter(
+			'wordbless_wpdb_query_results',
+			function ( $results, $query ) use ( &$captured_query ) {
+				if ( strpos( $query, 'source_meta' ) !== false ) {
+					$captured_query = $query;
+				}
+				return $results;
+			},
+			10,
+			2
+		);
+
+		$nonce                                 = wp_create_nonce( 'feedback_export' );
+		$_POST['feedback_export_nonce_csv']    = $nonce;
+		$_REQUEST['feedback_export_nonce_csv'] = $nonce;
+		$_POST['source']                       = '42';
+
+		$plugin->get_feedback_entries_from_post();
+
+		$this->assertNotNull( $captured_query, 'Export query should include the source filter SQL when $_POST[source] is set' );
+		$this->assertStringContainsString( '_feedback_source_post_id', $captured_query, 'Export query should reference the source meta key' );
+		$this->assertStringContainsString( 'source_meta.meta_value', $captured_query, 'Export query should filter by source meta value' );
+		$this->assertStringContainsString( 'post_parent', $captured_query, 'Export query should include the post_parent fallback' );
+
+		remove_all_filters( 'wordbless_wpdb_query_results' );
+		$cleanup_cap();
+		unset(
+			$_POST['feedback_export_nonce_csv'],
+			$_REQUEST['feedback_export_nonce_csv'],
+			$_POST['source']
+		);
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * Regression test: without `$_POST['source']`, the export must not inject
+	 * source-filter SQL (so unfiltered exports stay unfiltered).
+	 */
+	public function test_export_without_source_post_param_does_not_include_source_sql() {
+		list( $admin_id, $cleanup_cap ) = self::create_export_capable_user( 'export_no_source_admin' );
+		wp_set_current_user( $admin_id );
+
+		$plugin = Contact_Form_Plugin::init();
+
+		$found_source_sql = false;
+		add_filter(
+			'wordbless_wpdb_query_results',
+			function ( $results, $query ) use ( &$found_source_sql ) {
+				if ( strpos( $query, 'source_meta' ) !== false ) {
+					$found_source_sql = true;
+				}
+				return $results;
+			},
+			10,
+			2
+		);
+
+		$nonce                                 = wp_create_nonce( 'feedback_export' );
+		$_POST['feedback_export_nonce_csv']    = $nonce;
+		$_REQUEST['feedback_export_nonce_csv'] = $nonce;
+
+		$plugin->get_feedback_entries_from_post();
+
+		$this->assertFalse( $found_source_sql, 'Export query should not include source filter SQL when $_POST[source] is absent' );
+
+		remove_all_filters( 'wordbless_wpdb_query_results' );
+		$cleanup_cap();
+		unset(
+			$_POST['feedback_export_nonce_csv'],
+			$_REQUEST['feedback_export_nonce_csv']
+		);
+		wp_set_current_user( 0 );
+	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -1710,12 +1710,8 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 
 	/**
 	 * Regression test: the response export must apply the Source filter so the
-	 * downloaded CSV matches the filtered inbox view.
-	 *
-	 * Previously (regression from #48027) the export ignored `$_POST['source']`
-	 * and returned all feedback entries regardless of the dashboard's selected
-	 * source. Asserting that the feedback SQL issued during export includes the
-	 * shared source-filter JOIN/WHERE protects against that reintroducing.
+	 * downloaded CSV matches the filtered inbox view — the export handler must
+	 * read $_POST[source] and apply the same JOIN/WHERE the list view uses.
 	 */
 	public function test_export_applies_source_filter_when_source_post_param_is_set() {
 		list( $admin_id, $cleanup_cap ) = self::create_export_capable_user( 'export_source_admin' );
@@ -1741,21 +1737,23 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$_REQUEST['feedback_export_nonce_csv'] = $nonce;
 		$_POST['source']                       = '42';
 
-		$plugin->get_feedback_entries_from_post();
+		try {
+			$plugin->get_feedback_entries_from_post();
 
-		$this->assertNotNull( $captured_query, 'Export query should include the source filter SQL when $_POST[source] is set' );
-		$this->assertStringContainsString( '_feedback_source_post_id', $captured_query, 'Export query should reference the source meta key' );
-		$this->assertStringContainsString( 'source_meta.meta_value', $captured_query, 'Export query should filter by source meta value' );
-		$this->assertStringContainsString( 'post_parent', $captured_query, 'Export query should include the post_parent fallback' );
-
-		remove_all_filters( 'wordbless_wpdb_query_results' );
-		$cleanup_cap();
-		unset(
-			$_POST['feedback_export_nonce_csv'],
-			$_REQUEST['feedback_export_nonce_csv'],
-			$_POST['source']
-		);
-		wp_set_current_user( 0 );
+			$this->assertNotNull( $captured_query, 'Export query should include the source filter SQL when $_POST[source] is set' );
+			$this->assertStringContainsString( '_feedback_source_post_id', $captured_query, 'Export query should reference the source meta key' );
+			$this->assertStringContainsString( 'source_meta.meta_value', $captured_query, 'Export query should filter by source meta value' );
+			$this->assertStringContainsString( 'post_parent', $captured_query, 'Export query should include the post_parent fallback' );
+		} finally {
+			remove_all_filters( 'wordbless_wpdb_query_results' );
+			$cleanup_cap();
+			unset(
+				$_POST['feedback_export_nonce_csv'],
+				$_REQUEST['feedback_export_nonce_csv'],
+				$_POST['source']
+			);
+			wp_set_current_user( 0 );
+		}
 	}
 
 	/**
@@ -1785,16 +1783,18 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$_POST['feedback_export_nonce_csv']    = $nonce;
 		$_REQUEST['feedback_export_nonce_csv'] = $nonce;
 
-		$plugin->get_feedback_entries_from_post();
+		try {
+			$plugin->get_feedback_entries_from_post();
 
-		$this->assertFalse( $found_source_sql, 'Export query should not include source filter SQL when $_POST[source] is absent' );
-
-		remove_all_filters( 'wordbless_wpdb_query_results' );
-		$cleanup_cap();
-		unset(
-			$_POST['feedback_export_nonce_csv'],
-			$_REQUEST['feedback_export_nonce_csv']
-		);
-		wp_set_current_user( 0 );
+			$this->assertFalse( $found_source_sql, 'Export query should not include source filter SQL when $_POST[source] is absent' );
+		} finally {
+			remove_all_filters( 'wordbless_wpdb_query_results' );
+			$cleanup_cap();
+			unset(
+				$_POST['feedback_export_nonce_csv'],
+				$_REQUEST['feedback_export_nonce_csv']
+			);
+			wp_set_current_user( 0 );
+		}
 	}
 }


### PR DESCRIPTION
Fixes FORMS-679

## Proposed changes
* Dashboard: pass the active **Source** filter value to the Forms response export endpoint so the downloaded file matches the filtered inbox view.
* Backend: `get_feedback_entries_from_post()` now reads `$_POST['source']` and applies the same JOIN/WHERE (meta key `_feedback_source_post_id` with a `post_parent` fallback for legacy feedback) that the REST list endpoint uses, via scoped `posts_join` / `posts_where` filters.
* Extract `get_source_filter_sql()` from `Contact_Form_Endpoint` onto `Feedback` as a public static helper so the dashboard list view, status counts, and the export all share a single source of truth for source filtering.

This fixes a regression introduced in #48027, which wired up the Source filter on the dashboard list view but not on the export handler.

## Related product discussion/links
* Linear: FORMS-679
* Regression from #48027

## Does this pull request change what data or activity we track or use?
No — no new tracking or data collection. The `jetpack_forms_export_responses_modal_open` event is unchanged.

## Testing instructions
1. On a test site, create at least two posts/pages, each with a Jetpack Forms block, and submit several responses to each form so you have responses tied to different source posts.
2. Open **Jetpack → Forms** (the responses dashboard).
3. Apply the **Source** filter and pick a single source. Confirm the on-screen list narrows to just that source.
4. Click **Export → Download CSV**.
5. Open the downloaded CSV and confirm it contains **only** the responses from the selected source, and that its row count matches the filtered dashboard view.
6. Repeat step 3–5 with a Source filter **combined with** a search term and a date range — confirm the exported rows match the on-screen view for all filters compounded.
7. Clear the Source filter and export again — confirm all responses (scoped only by the remaining filters) are exported as before.
8. Switch to the **Spam** and **Trash** tabs and repeat the Source-filter export check — confirm the export still respects both the tab status and the source filter.
9. Legacy-data sanity check (optional but recommended): on a response that lacks the `_feedback_source_post_id` meta but has `post_parent` set (i.e. a feedback entry created before #48027), confirm the Source filter still matches it in both the dashboard list and the export.
