### PR TITLE
Docs: Update mirror repo instructions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Fixes #
 
 ## Related product discussion/links
 <!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
-*
+* 
 
 ## Does this pull request change what data or activity we track or use?
 <!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -390,7 +390,6 @@ Most projects in the monorepo should have a mirror repository holding a built ve
 	* Create the package in Packagist.
 	* Be sure that `automattic` is added as a maintainer.
 	* Configure a GitHub webhook to allow for auto-updates (see [Packagist docs](https://packagist.org/about#how-to-update-packages)).
-	* If creating under your own account, link your GitHub account to Packagist to enable syncing.
 3. If your project requires building, configure `.scripts.build-production` in your project's `composer.json` to run the necessary commands.
 4. If there are any files included in the monorepo that should not be included in the mirror, use `.gitattributes` to tag them with "production-exclude".
 5. If there are any built files in `.gitignore` that should be included in the mirror, use `.gitattributes` to tag them with "production-include".

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -372,18 +372,25 @@ This assumes you have PHP installed via Homebrew, e.g. you've done `brew install
 Most projects in the monorepo should have a mirror repository holding a built version of the project, ready for deployment. Follow these steps to create the mirror repo and configure the monorepo tooling to push to it.
 
 1. Create the mirror repo on GitHub. It will most likely be named like "<span>https://</span>github.com/Automattic/jetpack-_something_".
-   1. The repo's description should begin with `[READ ONLY]` and end with `This repository is a mirror; for issue tracking and development head here: https://github.com/automattic/jetpack`.
-   2. The default branch should be `trunk`, matching the monorepo.
-      * Note that you can't set the default branch until at least one branch is created in the repo.
-   3. In the repo's settings, turn off wikis, PRs, issues, projects, discussions, and so on.
-   4. Make sure that [matticbot](https://github.com/matticbot) can push to the repo. Usually no special configuration is needed for repos under the Automattic organization.
-   5. Make sure that Actions are enabled. The build process copies workflows from `.github/files/mirror-.github` into the mirror to do useful things like automatically close PRs with a reference back to the monorepo.
-      * Set "Approval for running fork pull request workflows from contributors" to "Require approval for all external contributors".
-      * Set "Workflow permissions" to "Read repository contents and packages permissions".
-   6. Set up any secrets and configuration needed (e.g. for [Autotagger](#autotagger) or [Autopublisher](#wordpressorg-svn-auto-publisher)). See PCYsg-xsv-p2#mirror-repo-secrets for details.
-2. For a PHP package (or a plugin listed in Packagist) you also need to go to packagist.org and create the package there. This requires pushing a first commit with a valid `composer.json` to the repository. That can be done by copying the new package's `composer.json` from the PR that introduced it.
-   1. Be sure that `automattic` is added as a maintainer.
-   2. If creating the package with your own account, make sure to link your GitHub account to Packagist so that you can sync the new package.
+	1. Set the repo description:
+		* Begin with `[READ ONLY]`.
+		* Add a description of the project.
+		* End with `This repository is a mirror; for issue tracking and development head here: https://github.com/automattic/jetpack`.
+	2. In the repo settings, turn off wikis, PRs, issues, projects, discussions, and so on.
+	3. If the mirror repo is not under the Automattic organization, make sure that [matticbot](https://github.com/matticbot) can push to the repo.
+	4. Configure Actions settings:
+		* Set "Allow all actions and reusable workflows". The build process copies workflows from `.github/files/mirror-.github` into the mirror to do useful things like automatically close PRs with a reference back to the monorepo.
+		* Set "Approval for running fork pull request workflows from contributors" to "Require approval for all external contributors".
+		* Set "Workflow permissions" to "Read repository contents and packages permissions".
+		* Disable "Allow GitHub Actions to create and approve pull requests", as PRs are created in the monorepo.
+	5. Set up any secrets and configuration needed (e.g. for [Autotagger](#autotagger) or [Autopublisher](#wordpressorg-svn-auto-publisher)). See PCYsg-xsv-p2#mirror-repo-secrets for details.
+	6. The default branch should be `trunk`, matching the monorepo. Note that you can't set the default branch until at least one branch is created in the repo.
+2. If this is a PHP package that will be published on Packagist, do the following:
+	* Copy the new package's `composer.json` from the PR that introduced it into the new repo and commit/push it to `trunk`.
+	* Create the package in Packagist.
+	* Be sure that `automattic` is added as a maintainer.
+	* Configure a GitHub webhook to allow for auto-updates (see [Packagist docs](https://packagist.org/about#how-to-update-packages)).
+	* If creating under your own account, link your GitHub account to Packagist to enable syncing.
 3. If your project requires building, configure `.scripts.build-production` in your project's `composer.json` to run the necessary commands.
 4. If there are any files included in the monorepo that should not be included in the mirror, use `.gitattributes` to tag them with "production-exclude".
 5. If there are any built files in `.gitignore` that should be included in the mirror, use `.gitattributes` to tag them with "production-include".

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -374,7 +374,7 @@ Most projects in the monorepo should have a mirror repository holding a built ve
 1. Create the mirror repo on GitHub. It will most likely be named like "<span>https://</span>github.com/Automattic/jetpack-_something_".
 	1. Set the repo description:
 		* Begin with `[READ ONLY]`.
-		* Add a description of the project.
+		* Include a description of the project.
 		* End with `This repository is a mirror; for issue tracking and development head here: https://github.com/automattic/jetpack`.
 	2. In the repo settings, turn off wikis, PRs, issues, projects, discussions, and so on.
 	3. If the mirror repo is not under the Automattic organization, make sure that [matticbot](https://github.com/matticbot) can push to the repo.


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
This reworks the mirror repo instructions. The content is largely the same with some minor restructuring:

* Broke up the repo description instructions; hopefully it's bit more readable.
* Put the default branch instructions at the end, since it's not really something that can be done right off.
* Moved Actions step content into substep, and added a `Disable "Allow GitHub Actions to create and approve pull requests"` step.
* Rewrote the Packagist step and mentioned creating a GitHub webhook.

Also, I added a space to the PR template.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* p1776275789774909/1776263835.995959-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Any objections or lies?