### PR TITLE
VideoPress: Fix block editor errors with Gutenberg 23 SandBox

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-gutenberg-23-sandbox
+++ b/projects/packages/videopress/changelog/fix-videopress-gutenberg-23-sandbox
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix block editor errors when used with Gutenberg 23.0.0+ (SandBox allow-same-origin default changed)
+Fix block editor errors when used with Gutenberg 23.0.0+, where the SandBox component no longer defaults to same-origin.

--- a/projects/packages/videopress/changelog/fix-videopress-gutenberg-23-sandbox
+++ b/projects/packages/videopress/changelog/fix-videopress-gutenberg-23-sandbox
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix block editor errors when used with Gutenberg 23.0.0+ (SandBox allow-same-origin default changed)

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
@@ -82,8 +82,12 @@ export default function Player( {
 	 * of the video player.
 	 */
 	function setVideoPlayerTemporaryHeight() {
+		const wrapper = videoWrapperRef.current;
+		if ( ! wrapper ) {
+			return;
+		}
 		setVideoPlayerTemporaryHeightState(
-			( videoWrapperRef.current.offsetWidth * videoRatio ) / 100 + temporaryHeighErrorCorrection
+			( wrapper.offsetWidth * videoRatio ) / 100 + temporaryHeighErrorCorrection
 		);
 	}
 
@@ -276,6 +280,7 @@ export default function Player( {
 								html={ html }
 								scripts={ sandboxScripts }
 								styles={ [ innerContainerStyle ] }
+								allowSameOrigin
 							/>
 						) }
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/test/index.test.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/test/index.test.tsx
@@ -2,26 +2,65 @@ import { render, screen, act } from '@testing-library/react';
 import { VideoBlockAttributes } from '../../../types';
 import Player from '../index';
 
-// Make the Player's message listener attach to the real jsdom window so we can
-// dispatch events in tests. The hook's internal calls are unaffected (same-module
-// scope), keeping them inert.
-jest.mock( '../../../../../hooks/use-video-player', () => {
-	const actual = jest.requireActual( '../../../../../hooks/use-video-player' );
-	return {
-		__esModule: true,
-		...actual,
-		getIframeWindowFromRef: jest.fn( () => globalThis ),
-	};
-} );
-
-// Stub SandBox to a plain div — the real component injects iframe scripts that
-// trigger MutationObserver errors in jsdom when no actual browser context exists.
+// Mirror the real SandBox contract: when `allowSameOrigin` is false, the
+// iframe is cross-origin and any property access on `iframe.contentWindow`
+// from the parent throws SecurityError. When `allowSameOrigin` is true, the
+// parent can reach into contentWindow as same-origin.
 jest.mock( '@wordpress/components', () => {
 	const actual = jest.requireActual( '@wordpress/components' );
+	const React = jest.requireActual( 'react' );
+
+	/**
+	 * Stand-in for `@wordpress/components` SandBox that creates a real iframe
+	 * child and switches its contentWindow between a same-origin Window and
+	 * a cross-origin Proxy based on the `allowSameOrigin` prop.
+	 *
+	 * @param {object}  props                 - Props forwarded from VideoPress.
+	 * @param {boolean} props.allowSameOrigin - Whether contentWindow should be same-origin.
+	 * @return {ReactElement} A div hosting the simulated sandbox iframe.
+	 */
+	function SandBoxMock( { allowSameOrigin }: { allowSameOrigin?: boolean } ) {
+		return React.createElement( 'div', {
+			ref: ( host: HTMLDivElement | null ) => {
+				// Direct DOM access is intentional — this mock simulates the real
+				// SandBox's iframe creation, which Testing Library cannot express.
+				// eslint-disable-next-line testing-library/no-node-access
+				if ( ! host || host.querySelector( 'iframe.components-sandbox' ) ) {
+					return;
+				}
+				const iframe = host.ownerDocument.createElement( 'iframe' );
+				iframe.className = 'components-sandbox';
+
+				if ( allowSameOrigin ) {
+					Object.defineProperty( iframe, 'contentWindow', {
+						value: globalThis,
+						configurable: true,
+					} );
+				} else {
+					// Any property read/write on a cross-origin Window throws
+					// a SecurityError. The Proxy mirrors that.
+					const throwSecurity = () => {
+						throw new DOMException(
+							'Blocked a frame with origin "https://sandbox.invalid" from accessing a cross-origin frame.',
+							'SecurityError'
+						);
+					};
+					const crossOriginWindow = new Proxy( {}, { get: throwSecurity, set: throwSecurity } );
+					Object.defineProperty( iframe, 'contentWindow', {
+						value: crossOriginWindow,
+						configurable: true,
+					} );
+				}
+
+				host.appendChild( iframe );
+			},
+		} );
+	}
+
 	return {
 		__esModule: true,
 		...actual,
-		SandBox: () => null,
+		SandBox: SandBoxMock,
 	};
 } );
 
@@ -59,11 +98,71 @@ const defaultProps = {
 	html: '',
 };
 
+/**
+ * Render while capturing the console.error stream. React routes errors
+ * thrown inside effects through console.error instead of propagating out of
+ * render(), so spying on that stream is how tests detect a SecurityError
+ * thrown from the sandbox iframe.
+ *
+ * @param {React.ReactElement} element - The element to render.
+ * @return {{ consoleErrors: unknown[][], view: ReturnType<typeof render> }} Captured console.error calls and the render result.
+ */
+function renderCapturingErrors( element: React.ReactElement ) {
+	const consoleErrors: unknown[][] = [];
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return -- needed in the finally cleanup below.
+	const spy = jest.spyOn( console, 'error' ).mockImplementation( ( ...args ) => {
+		consoleErrors.push( args );
+	} );
+	try {
+		const view = render( element );
+		return { consoleErrors, view };
+	} finally {
+		spy.mockRestore();
+	}
+}
+
 describe( 'Player', () => {
 	it( 'should render', () => {
 		render( <Player { ...defaultProps } /> );
 
 		expect( screen.getByRole( 'figure' ) ).toBeInTheDocument();
+	} );
+
+	describe( 'setVideoPlayerTemporaryHeight null safety', () => {
+		beforeEach( () => jest.useFakeTimers() );
+		afterEach( () => {
+			jest.useRealTimers();
+		} );
+
+		it( 'does not throw when the component unmounts before the deferred height calc runs', () => {
+			// A deferred height calculation scheduled at mount dereferences the
+			// wrapper ref. Unmounting before it fires must not crash.
+			const { unmount } = render( <Player { ...defaultProps } /> );
+
+			unmount();
+
+			expect( () => jest.runAllTimers() ).not.toThrow();
+		} );
+	} );
+
+	describe( 'cross-origin SandBox contract', () => {
+		it( 'mounts without raising a SecurityError from the sandbox iframe', () => {
+			const { consoleErrors } = renderCapturingErrors(
+				<Player { ...defaultProps } html="<iframe src='https://videopress.com/e/abc' />" />
+			);
+
+			const securityErrors = consoleErrors.filter( call =>
+				call.some(
+					arg =>
+						( arg instanceof Error && arg.name === 'SecurityError' ) ||
+						( typeof arg === 'string' &&
+							( arg.includes( 'SecurityError' ) || arg.includes( 'cross-origin' ) ) )
+				)
+			);
+
+			expect( securityErrors ).toEqual( [] );
+			expect( screen.getByRole( 'figure' ) ).toBeInTheDocument();
+		} );
 	} );
 
 	describe( 'videoPlayerEventsHandler origin check', () => {

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/index.tsx
@@ -232,7 +232,7 @@ type PosterFramePickerProps = {
  * @param {PosterFramePickerProps} props - Component properties
  * @return { ReactElement}          React component
  */
-function VideoFramePicker( {
+export function VideoFramePicker( {
 	guid,
 	isGeneratingPoster,
 	atTime = 0.1,
@@ -288,7 +288,7 @@ function VideoFramePicker( {
 				} ) }
 			>
 				{ ( ! playerIsReady || isGeneratingPoster ) && <Spinner /> }
-				<SandBox html={ html } scripts={ sandboxScripts } />
+				<SandBox html={ html } scripts={ sandboxScripts } allowSameOrigin />
 			</div>
 
 			{ isGeneratingPoster && (

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/test/index.test.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/poster-panel/test/index.test.tsx
@@ -1,0 +1,119 @@
+import { render } from '@testing-library/react';
+import { VideoFramePicker } from '../index';
+
+// Mirror the real SandBox contract: when `allowSameOrigin` is false, the
+// iframe is cross-origin and any property access on `iframe.contentWindow`
+// from the parent throws SecurityError. When `allowSameOrigin` is true, the
+// parent can reach into contentWindow as same-origin.
+jest.mock( '@wordpress/components', () => {
+	const actual = jest.requireActual( '@wordpress/components' );
+	const React = jest.requireActual( 'react' );
+
+	/**
+	 * Stand-in for `@wordpress/components` SandBox that creates a real iframe
+	 * child and switches its contentWindow between a same-origin Window and
+	 * a cross-origin Proxy based on the `allowSameOrigin` prop.
+	 *
+	 * @param {object}  props                 - Props forwarded from VideoPress.
+	 * @param {boolean} props.allowSameOrigin - Whether contentWindow should be same-origin.
+	 * @return {ReactElement} A div hosting the simulated sandbox iframe.
+	 */
+	function SandBoxMock( { allowSameOrigin }: { allowSameOrigin?: boolean } ) {
+		return React.createElement( 'div', {
+			ref: ( host: HTMLDivElement | null ) => {
+				// Direct DOM access is intentional — this mock simulates the real
+				// SandBox's iframe creation, which Testing Library cannot express.
+				// eslint-disable-next-line testing-library/no-node-access
+				if ( ! host || host.querySelector( 'iframe.components-sandbox' ) ) {
+					return;
+				}
+				const iframe = host.ownerDocument.createElement( 'iframe' );
+				iframe.className = 'components-sandbox';
+
+				if ( allowSameOrigin ) {
+					Object.defineProperty( iframe, 'contentWindow', {
+						value: globalThis,
+						configurable: true,
+					} );
+				} else {
+					const throwSecurity = () => {
+						throw new DOMException(
+							'Blocked a frame with origin "https://sandbox.invalid" from accessing a cross-origin frame.',
+							'SecurityError'
+						);
+					};
+					const crossOriginWindow = new Proxy( {}, { get: throwSecurity, set: throwSecurity } );
+					Object.defineProperty( iframe, 'contentWindow', {
+						value: crossOriginWindow,
+						configurable: true,
+					} );
+				}
+
+				host.appendChild( iframe );
+			},
+		} );
+	}
+
+	return {
+		__esModule: true,
+		...actual,
+		SandBox: SandBoxMock,
+	};
+} );
+
+// usePreview hits the core oEmbed endpoint. Return a static preview so the
+// picker settles synchronously and the SandBox receives its html.
+jest.mock( '../../../../../hooks/use-preview', () => ( {
+	__esModule: true,
+	usePreview: () => ( {
+		preview: { html: '<iframe src="https://videopress.com/e/abc" />' },
+		isRequestingEmbedPreview: false,
+	} ),
+} ) );
+
+/**
+ * Render while capturing the console.error stream. React routes errors
+ * thrown inside effects through console.error instead of propagating out of
+ * render(), so spying on that stream is how tests detect a SecurityError
+ * thrown from the sandbox iframe.
+ *
+ * @param {React.ReactElement} element - The element to render.
+ * @return {{ consoleErrors: unknown[][] }} Captured console.error arguments.
+ */
+function renderCapturingErrors( element: React.ReactElement ) {
+	const consoleErrors: unknown[][] = [];
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return -- needed in the finally cleanup below.
+	const spy = jest
+		.spyOn( console, 'error' )
+		.mockImplementation( ( ...args ) => consoleErrors.push( args ) );
+	try {
+		render( element );
+		return { consoleErrors };
+	} finally {
+		spy.mockRestore();
+	}
+}
+
+describe( 'VideoFramePicker', () => {
+	it( 'mounts without raising a SecurityError under Gutenberg 23 SandBox', () => {
+		const { consoleErrors } = renderCapturingErrors(
+			<VideoFramePicker
+				guid="abcdef1234"
+				atTime={ 0 }
+				duration={ 10000 }
+				onVideoFrameSelect={ () => {} }
+			/>
+		);
+
+		const securityErrors = consoleErrors.filter( call =>
+			call.some(
+				arg =>
+					( arg instanceof Error && arg.name === 'SecurityError' ) ||
+					( typeof arg === 'string' &&
+						( arg.includes( 'SecurityError' ) || arg.includes( 'cross-origin' ) ) )
+			)
+		);
+
+		expect( securityErrors ).toEqual( [] );
+	} );
+} );


### PR DESCRIPTION
Fixes #

## Proposed changes
* **VideoPress block fails to load under Gutenberg 23.0.0+.** Gutenberg [PR #77212](https://github.com/WordPress/gutenberg/pull/77212) changed `@wordpress/components` `SandBox` to default to a cross-origin iframe (sandbox attribute without `allow-same-origin`) unless `allowSameOrigin={true}` is passed. VideoPress's block editor code reaches into `iframe.contentWindow` to attach a `message` listener, which now throws `SecurityError` in the editor.
* Opt the two VideoPress `<SandBox>` call sites (the player and the poster frame picker) into same-origin mode via the new `allowSameOrigin` prop — matching how `core/embed` and `core/cover` handled the migration. The prop is silently ignored on older Gutenberg versions (which were always same-origin), so the change is backward-compatible and needs no version gating.
* Null-guard `setVideoPlayerTemporaryHeight` in `player/index.tsx`. It is called from a deferred `setTimeout(…, 0)` in the mount effect; under the render disruption caused by the SecurityError, the `videoWrapperRef.current` goes null before the callback fires, producing the reported `TypeError: Cannot read properties of null (reading 'offsetWidth')`. The guard protects the helper independently of the SandBox fix.
* Added tests that simulate the real SandBox cross-origin contract (via a Proxy whose property access throws `DOMException('SecurityError')`) and a fake-timer unmount test that reproduces the null-deref — both developed test-first and confirmed to fail on the pre-fix code for the right reason.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

**Automated tests**
* `cd projects/packages/videopress && pnpm exec jest components/player/test components/poster-panel/test`
* Expect 6 tests passing across 2 suites.

**Smoke test against Gutenberg 23.0.0+ (where the bug reproduces)**
1. Start a site with Gutenberg 23.0.0-rc or newer active (e.g. Jurassic Ninja with the Gutenberg rotation).
2. Open the browser devtools console, then create a new post and insert a VideoPress block. Pick any existing VideoPress video.
3. **Without the fix**, the console shows:
   * `SecurityError: Failed to read a named property 'addEventListener' from 'Window': Blocked a frame with origin "…" from accessing a cross-origin frame.`
   * `Uncaught TypeError: Cannot read properties of null (reading 'offsetWidth')` originating from `jetpack_vendor/automattic/jetpack-videopress/build/block-editor/blocks/video/index.js`.
4. **With the fix**, neither error appears and the VideoPress player renders normally.
5. Resize the block with the right-edge handle — confirm resize still works.
6. Open the block sidebar → Poster → **Pick from video** — confirm the frame-picker iframe loads and scrubbing advances the preview frame.
7. Enable **Preview on Hover** in the sidebar and hover the block — confirm the player plays/pauses correctly.

**Regression check against older Gutenberg**
1. On a second site running stable Gutenberg (or WP core without the Gutenberg plugin), insert a VideoPress block and confirm it still renders end-to-end. The unknown `allowSameOrigin` prop should be harmlessly ignored on older `SandBox` implementations.
