### PR TITLE
Charts: Fix stylelint max-line-length in line-chart popover comment

### DIFF
--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.module.scss
@@ -65,7 +65,12 @@
 		font-size: var(--wpds-font-size-md, 13px);
 		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 		position: fixed;
-		margin: 0.5rem;
+		// Without margin set, the popover has
+		// margin:auto which upsets the positioning
+		// relative to the trigger button. This
+		// creates a gap to the trigger button so
+		// the token is appropriate.
+		margin: var(--wpds-dimension-gap-sm, 8px);
 		visibility: hidden;
 
 		&--visible {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Proposed changes

* Break a long SCSS comment into multiple shorter lines to comply with the `@stylistic/max-line-length` (80 characters) stylelint rule.
* Replace the hardcoded `0.5rem` popover margin with the `--wpds-dimension-gap-sm` WPDS design token (fallback `8px`), consistent with the package's token migration.

## Testing instructions

* Run `npx stylelint "projects/js-packages/charts/src/charts/line-chart/line-chart.module.scss"` from the monorepo root — should pass with no errors.
* Verify the comment in `&__annotation-label-popover` is readable and each comment line stays under 80 characters.
<!-- CURSOR_AGENT_PR_BODY_END -->

p1771542772011189/1771542772.011189-slack-D0969612YQ6

<div><a href="https://cursor.com/agents/bc-9fdf877c-808b-5874-bb45-4e354bba3845"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9fdf877c-808b-5874-bb45-4e354bba3845"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>