### PR TITLE
SOCIAL-379 Fix closing for Jetpack Social modal overlay

### DIFF
--- a/projects/js-packages/components/changelog/fix-SOCIAL-379-fix-modal-overlay
+++ b/projects/js-packages/components/changelog/fix-SOCIAL-379-fix-modal-overlay
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Navigator modal: allow overlay closing when users click it.

--- a/projects/js-packages/components/components/navigator-modal/index.tsx
+++ b/projects/js-packages/components/components/navigator-modal/index.tsx
@@ -1,6 +1,6 @@
 import { Modal, Navigator } from '@wordpress/components';
 import clsx from 'clsx';
-import { useCallback, useContext } from 'react';
+import { useCallback, useContext, useEffect, useRef } from 'react';
 import { NavigatorModalContext } from './context.ts';
 import { Screen } from './screen.tsx';
 import './styles.scss';
@@ -24,16 +24,36 @@ function InternalNavigatorModal( {
 	...props
 }: Omit< ModalProps, 'onRequestClose' > ) {
 	const { onClose, initialPath } = useContext( NavigatorModalContext );
+	const overlayRef = useRef< HTMLDivElement >( null );
+	const isUserInteracting = useRef( false );
+
+	// Track pointer interaction on the overlay so we can distinguish
+	// user-initiated overlay clicks from the WP Modal dismisser mechanism,
+	// which also calls onRequestClose() without an event argument.
+	useEffect( () => {
+		const overlay = overlayRef.current;
+		if ( ! overlay ) {
+			return;
+		}
+		const handler = () => {
+			isUserInteracting.current = true;
+		};
+		overlay.addEventListener( 'pointerdown', handler );
+		return () => overlay.removeEventListener( 'pointerdown', handler );
+	}, [] );
 
 	// WordPress Modal's dismisser mechanism (ModalContext) calls onRequestClose()
 	// without arguments when another non-nested Modal mounts. We guard against
 	// this so that external modals (e.g. Image Studio) don't destroy this one.
 	// User-initiated closes (Escape, close button) always pass an event.
+	// Overlay clicks don't pass an event but are identified by the
+	// isUserInteracting flag set via the pointerdown listener above.
 	// The NavigatorModal's own Header/Footer close buttons call context.onClose
 	// directly and are unaffected by this guard.
 	const onRequestClose = useCallback(
 		( event?: React.SyntheticEvent ) => {
-			if ( event ) {
+			if ( event || isUserInteracting.current ) {
+				isUserInteracting.current = false;
 				onClose?.();
 			}
 		},
@@ -42,6 +62,7 @@ function InternalNavigatorModal( {
 
 	return (
 		<Modal
+			ref={ overlayRef }
 			__experimentalHideHeader
 			onRequestClose={ onRequestClose }
 			className={ clsx( 'jp-navigator-modal', className ) }

--- a/projects/js-packages/components/components/navigator-modal/test/component.tsx
+++ b/projects/js-packages/components/components/navigator-modal/test/component.tsx
@@ -3,27 +3,32 @@
 import { jest } from '@jest/globals';
 import { render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
+import { forwardRef } from 'react';
 
 const mockGoBack = jest.fn();
-
 // ESM-compatible mock - must be before dynamic import
 jest.unstable_mockModule( '@wordpress/components', () => ( {
-	Modal: ( {
-		children,
-		onRequestClose,
-	}: {
-		children: React.ReactNode;
-		onRequestClose?: ( event?: React.SyntheticEvent ) => void;
-	} ) => (
-		<div data-testid="mock-modal">
-			<button data-testid="close-with-event" onClick={ e => onRequestClose?.( e ) }>
-				Close with event
-			</button>
-			<button data-testid="close-without-event" onClick={ () => onRequestClose?.() }>
-				Close without event
-			</button>
-			{ children }
-		</div>
+	Modal: forwardRef(
+		(
+			{
+				children,
+				onRequestClose,
+			}: {
+				children: React.ReactNode;
+				onRequestClose?: ( event?: React.SyntheticEvent ) => void;
+			},
+			ref: React.Ref< HTMLDivElement >
+		) => (
+			<div data-testid="mock-modal" ref={ ref }>
+				<button data-testid="close-with-event" onClick={ e => onRequestClose?.( e ) }>
+					Close with event
+				</button>
+				<button data-testid="close-without-event" onClick={ () => onRequestClose?.() }>
+					Close without event
+				</button>
+				{ children }
+			</div>
+		)
 	),
 	Navigator: Object.assign(
 		( { children }: { children: React.ReactNode } ) => (
@@ -87,7 +92,7 @@ describe( 'NavigatorModal', () => {
 			expect( mockOnClose ).toHaveBeenCalledTimes( 1 );
 		} );
 
-		it( 'does not call onClose when WordPress Modal dismisser calls onRequestClose without an event', async () => {
+		it( 'calls onClose on overlay click (onRequestClose without event but after pointer interaction)', async () => {
 			const user = userEvent.setup();
 			const mockOnClose = jest.fn();
 
@@ -97,9 +102,12 @@ describe( 'NavigatorModal', () => {
 				</NavigatorModal>
 			);
 
+			// Clicking the button triggers pointerdown on the overlay (bubbles up
+			// to mock-modal ref), then the button calls onRequestClose() without event.
+			// This mirrors the real overlay click flow.
 			await user.click( screen.getByTestId( 'close-without-event' ) );
 
-			expect( mockOnClose ).not.toHaveBeenCalled();
+			expect( mockOnClose ).toHaveBeenCalledTimes( 1 );
 		} );
 
 		it( 'does not crash when onClose is not provided', async () => {


### PR DESCRIPTION
Fixes SOCIAL-379

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Fix the Jetpack Social preview modal flickering when clicking the overlay to close it.
* The WP Modal's overlay click handler calls onRequestClose() without an event argument. The existing guard in InternalNavigatorModal only allowed closes when an event was passed, so overlay clicks were blocked — the exit animation would play then revert, causing a visible background flicker.
* Track pointer interaction on the overlay via a ref flag (isUserInteracting) so we can distinguish user-initiated overlay clicks (should close).
* Update the Modal mock in tests to use forwardRef.
* Remove the existing dismisser test to reflect the new overlay click behavior and add a dedicated overlay click test.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Create JN for the branch.
* Open a WordPress site with Jetpack Social.
* Create or edit a post that has social connections configured.
* In the block editor sidebar, open the Jetpack Social panel and click "Preview and customize" to open the social preview modal.
* Click the dark overlay area outside the modal to close it.
* Before fix: The modal flickers (exit animation plays, background briefly visible, then modal snaps back).
* After fix: The modal closes cleanly on overlay click.
* Also verify closing via the ✕ button and Escape key still work as expected.
