### PR TITLE
Remove unused mirror-repo config from premium-analytics plugin

### DIFF
--- a/projects/plugins/premium-analytics/changelog/fix-mirror-config
+++ b/projects/plugins/premium-analytics/changelog/fix-mirror-config
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Remove unused mirror-repo and release-branch-prefix config from composer.json

--- a/projects/plugins/premium-analytics/composer.json
+++ b/projects/plugins/premium-analytics/composer.json
@@ -40,8 +40,6 @@
 	"extra": {
 		"autotagger": false,
 		"autorelease": false,
-		"mirror-repo": "Automattic/jetpack-premium-analytics-plugin",
-		"release-branch-prefix": "premium-analytics",
 		"changelogger": {
 			"versioning": "semver"
 		},

--- a/projects/plugins/premium-analytics/composer.lock
+++ b/projects/plugins/premium-analytics/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "59c99d35846a5d3b2beb37a096407c8b",
+    "content-hash": "56a08e78a224661f7b49cf03dd41a396",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",


### PR DESCRIPTION
## What?

Removes the `mirror-repo` and `release-branch-prefix` entries from the `premium-analytics` plugin's `composer.json`.

Fixes [WOOA7S-1353](https://linear.app/a8c/issue/WOOA7S-1353/remove-unused-mirror-repo-config-from-premium-analytics-plugin).

## Why?

The plugin defines `mirror-repo: Automattic/jetpack-premium-analytics-plugin`, but that repository does not exist on GitHub. This causes CI build failures when push-to-mirrors tries to push to a non-existent repo.

The plugin is a dev/testing harness with `autotagger` and `autorelease` both disabled. It does not need a mirror repo at this stage, as [discussed in PR #48087](https://github.com/Automattic/jetpack/pull/48087#discussion_r3080538651).

## How?

Removed `mirror-repo` and `release-branch-prefix` from `composer.json`. The build process will skip this plugin when generating `mirrors.txt`.

## Testing instructions

1. Verify CI build passes (no more "Mirror repo does not exist" error)
2. Confirm plugin still works locally with `jetpack docker`