### PR TITLE
Forms: scope-aware Delete Spam button (selection, filter, all)

### DIFF
--- a/projects/packages/forms/changelog/add-form-trash-spam-flow
+++ b/projects/packages/forms/changelog/add-form-trash-spam-flow
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Make Delete Spam button scope-aware: respects selected items, active filters (search, source, date, read/unread), or falls back to deleting all spam. The confirmation modal now shows the affected count.

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -276,14 +276,7 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				'methods'             => \WP_REST_Server::DELETABLE,
 				'callback'            => array( $this, 'delete_posts_by_status' ),
 				'permission_callback' => array( $this, 'delete_items_permissions_check' ),
-				'args'                => array(
-					'status' => array(
-						'type'     => 'string',
-						'enum'     => array( 'trash', 'spam' ),
-						'required' => false,
-						'default'  => 'trash',
-					),
-				),
+				'args'                => $this->get_bulk_scope_args( array( 'trash', 'spam' ), 'trash' ),
 			)
 		);
 
@@ -1200,12 +1193,168 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 	}
 
 	/**
-	 * Handles emptying Jetpack Forms responses based on status.
+	 * Builds the REST args for the scope-aware `/trash` endpoint.
 	 *
-	 * By default, it empties the trash, meaning it will delete all feedbacks in the trash (status = trash).
-	 * Passing a status will delete all feedbacks in the status.
-	 * The operation is non reversible and thus restricted to statuses spam and trash,
-	 * enforced by endpoint query args enum[spam, trash] but also double checked by the endpoint.
+	 * Scope is either an explicit list of `post_ids`, or the set of filters the
+	 * inbox list view exposes (search / source / date range / read-unread).
+	 * When `post_ids` is present, filter params are ignored.
+	 *
+	 * @param string[] $allowed_statuses Statuses that may be operated on.
+	 * @param string   $default_status   Default status if none is provided.
+	 * @return array
+	 */
+	protected function get_bulk_scope_args( $allowed_statuses, $default_status ) {
+		return array(
+			'status'    => array(
+				'type'     => 'string',
+				'enum'     => $allowed_statuses,
+				'required' => false,
+				'default'  => $default_status,
+			),
+			'post_ids'  => array(
+				'type'              => 'array',
+				'items'             => array( 'type' => 'integer' ),
+				'required'          => false,
+				'default'           => array(),
+				'sanitize_callback' => function ( $param ) {
+					return array_values( array_filter( array_map( 'absint', (array) $param ) ) );
+				},
+			),
+			'search'    => array(
+				'type'     => 'string',
+				'required' => false,
+			),
+			'parent'    => array(
+				'type'              => 'integer',
+				'required'          => false,
+				'sanitize_callback' => 'absint',
+			),
+			'source'    => array(
+				'type'              => 'integer',
+				'required'          => false,
+				'sanitize_callback' => 'absint',
+			),
+			'before'    => array(
+				'type'              => 'string',
+				'format'            => 'date-time',
+				'required'          => false,
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'after'     => array(
+				'type'              => 'string',
+				'format'            => 'date-time',
+				'required'          => false,
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'is_unread' => array(
+				'type'              => 'boolean',
+				'required'          => false,
+				'sanitize_callback' => 'rest_sanitize_boolean',
+			),
+		);
+	}
+
+	/**
+	 * Fetches a batch of feedback IDs within the requested status, honoring the
+	 * bulk-scope params (explicit IDs or filter query). Source filtering is
+	 * applied via the existing `posts_join` / `posts_where` hooks.
+	 *
+	 * @param WP_REST_Request $request    The request.
+	 * @param string          $status     Post status to scope to (`spam` or `trash`).
+	 * @param int             $batch_size Max IDs to return.
+	 * @return int[] Feedback post IDs.
+	 */
+	private function fetch_bulk_scope_batch( $request, $status, $batch_size ) {
+		$post_ids_param = (array) $request->get_param( 'post_ids' );
+		$has_explicit   = ! empty( $post_ids_param );
+
+		$query_args = array(
+			'post_type'      => 'feedback',
+			'post_status'    => $status,
+			'posts_per_page' => $batch_size, // phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page
+			'fields'         => 'ids',
+		);
+
+		if ( $has_explicit ) {
+			$query_args['post__in'] = $post_ids_param;
+			$query_args['orderby']  = 'post__in';
+		} else {
+			$search = $request->get_param( 'search' );
+			if ( is_string( $search ) && $search !== '' ) {
+				$query_args['s'] = $search;
+			}
+
+			$parent = $request->get_param( 'parent' );
+			if ( is_numeric( $parent ) && (int) $parent > 0 ) {
+				$query_args['post_parent'] = (int) $parent;
+			}
+
+			$before = $request->get_param( 'before' );
+			$after  = $request->get_param( 'after' );
+			if ( ! empty( $before ) || ! empty( $after ) ) {
+				$query_args['date_query'] = array_filter(
+					array(
+						'before' => $before,
+						'after'  => $after,
+					)
+				);
+			}
+
+			$is_unread = $request->get_param( 'is_unread' );
+			if ( null !== $is_unread ) {
+				$query_args['comment_status'] = $is_unread ? Feedback::STATUS_UNREAD : Feedback::STATUS_READ;
+			}
+		}
+
+		$query = new \WP_Query( $query_args );
+		return array_map( 'intval', $query->get_posts() );
+	}
+
+	/**
+	 * Attaches source-filter hooks if the request includes a `source` param and
+	 * no explicit `post_ids`. Returns true if hooks were attached (caller must
+	 * call `remove_source_filter_hooks()` after the loop).
+	 *
+	 * @param WP_REST_Request $request The request.
+	 * @return bool Whether hooks were attached.
+	 */
+	private function maybe_attach_source_filter_hooks( $request ) {
+		if ( ! empty( (array) $request->get_param( 'post_ids' ) ) ) {
+			return false;
+		}
+		$source = $request->get_param( 'source' );
+		$source = is_numeric( $source ) ? absint( $source ) : 0;
+		if ( $source <= 0 ) {
+			return false;
+		}
+		$this->temp_source_filter_id  = $source;
+		$this->temp_source_filter_sql = Feedback::get_source_filter_sql( $source );
+		add_filter( 'posts_join', array( $this, 'join_source_meta' ), 10, 2 );
+		add_filter( 'posts_where', array( $this, 'filter_by_source_id' ), 10, 2 );
+		return true;
+	}
+
+	/**
+	 * Removes source-filter hooks attached by `maybe_attach_source_filter_hooks`.
+	 */
+	private function remove_source_filter_hooks() {
+		remove_filter( 'posts_join', array( $this, 'join_source_meta' ), 10 );
+		remove_filter( 'posts_where', array( $this, 'filter_by_source_id' ), 10 );
+		$this->temp_source_filter_id  = null;
+		$this->temp_source_filter_sql = null;
+	}
+
+	/**
+	 * Handles permanently deleting Jetpack Forms responses by status.
+	 *
+	 * Scope resolution:
+	 *  - With `post_ids` → deletes those IDs (filtered to rows actually in `status`).
+	 *  - Else with any filter (search / source / before / after / is_unread) →
+	 *    deletes every response in `status` matching those filters.
+	 *  - Else → deletes every response in `status` (legacy behavior).
+	 *
+	 * The operation is non-reversible; restricted to statuses spam and trash via the
+	 * route args enum, and re-checked here for defense in depth.
 	 *
 	 * @param WP_REST_Request $request The request sent to the WP REST API.
 	 *
@@ -1219,24 +1368,22 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 		}
 
 		$status        = $from_status ?? 'trash';
-		$batch_size    = 1000; // Process in batches to avoid memory issues
+		$has_explicit  = ! empty( (array) $request->get_param( 'post_ids' ) );
+		$batch_size    = 1000;
 		$total_deleted = 0;
 		$has_more      = true;
+		$processed_ids = array();
+
+		$has_source_hooks = $this->maybe_attach_source_filter_hooks( $request );
 
 		while ( $has_more ) {
-			$query_args = array(
-				'post_type'      => 'feedback',
-				'post_status'    => $status,
-				'posts_per_page' => $batch_size, // phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page
-				'fields'         => 'ids', // Only get IDs to reduce memory usage
-			);
+			$post_ids = $this->fetch_bulk_scope_batch( $request, $status, $batch_size );
 
-			$query    = new \WP_Query( $query_args );
-			$post_ids = $query->get_posts();
+			if ( $has_explicit ) {
+				$post_ids = array_values( array_diff( $post_ids, $processed_ids ) );
+			}
 
 			if ( empty( $post_ids ) ) {
-				$has_more = false;
-
 				break;
 			}
 
@@ -1244,21 +1391,26 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 				$feedback_deleted = wp_delete_post( $post_id, true );
 
 				if ( ! $feedback_deleted ) {
-					if ( $status === 'trash' ) {
-						return new WP_REST_Response( array( 'error' => __( 'Failed to empty trash.', 'jetpack-forms' ) ), 400 );
+					if ( $has_source_hooks ) {
+						$this->remove_source_filter_hooks();
 					}
-
-					if ( $status === 'spam' ) {
-						return new WP_REST_Response( array( 'error' => __( 'Failed to empty spam.', 'jetpack-forms' ) ), 400 );
-					}
+					$error = $status === 'spam'
+						? __( 'Failed to empty spam.', 'jetpack-forms' )
+						: __( 'Failed to empty trash.', 'jetpack-forms' );
+					return new WP_REST_Response( array( 'error' => $error ), 400 );
 				}
 
+				$processed_ids[] = $post_id;
 				++$total_deleted;
 			}
 
 			if ( count( $post_ids ) < $batch_size ) {
 				$has_more = false;
 			}
+		}
+
+		if ( $has_source_hooks ) {
+			$this->remove_source_filter_hooks();
 		}
 
 		return new WP_REST_Response( array( 'deleted' => $total_deleted ), 200 );

--- a/projects/packages/forms/src/dashboard/components/empty-spam-button/confirmation-modal.tsx
+++ b/projects/packages/forms/src/dashboard/components/empty-spam-button/confirmation-modal.tsx
@@ -2,60 +2,98 @@
  * External dependencies
  */
 import { formatNumber } from '@automattic/number-formatters';
-import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import {
+	__experimentalConfirmDialog as ConfirmDialog, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalHeading as Heading, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import type { EmptySpamScopeMode } from '../../hooks/use-empty-spam';
 
 interface EmptySpamConfirmationModalProps {
 	isOpen: boolean;
 	onCancel: () => void;
 	onConfirm: () => void;
-	totalItemsSpam: number;
-	selectedResponsesCount: number;
+	scopeMode: EmptySpamScopeMode;
+	count: number;
 }
 
 /**
- * Confirmation modal for emptying spam.
+ * Produces the count-forward dialog title based on scope mode.
  *
- * @param {object}   props                        - Component props.
- * @param {boolean}  props.isOpen                 - Whether the modal is open.
- * @param {Function} props.onCancel               - Function to call when the user cancels.
- * @param {Function} props.onConfirm              - Function to call when the user confirms.
- * @param {number}   props.totalItemsSpam         - The total number of spam items.
- * @param {number}   props.selectedResponsesCount - The number of selected responses.
+ * @param mode  - The scope the action will operate on.
+ * @param count - Number of responses affected.
+ * @return Translated title string.
+ */
+function titleForScope( mode: EmptySpamScopeMode, count: number ): string {
+	const formatted = formatNumber( count );
+	switch ( mode ) {
+		case 'selection':
+			return sprintf(
+				/* translators: %s: The number of selected spam responses. */
+				_n(
+					'Delete %s selected spam response?',
+					'Delete %s selected spam responses?',
+					count,
+					'jetpack-forms'
+				),
+				formatted
+			);
+		case 'filtered':
+			return sprintf(
+				/* translators: %s: The number of spam responses matching the current filter. */
+				_n(
+					'Delete %s matching spam response?',
+					'Delete %s matching spam responses?',
+					count,
+					'jetpack-forms'
+				),
+				formatted
+			);
+		case 'all':
+		default:
+			return sprintf(
+				/* translators: %s: The total number of spam responses. */
+				_n( 'Delete %s spam response?', 'Delete all %s spam responses?', count, 'jetpack-forms' ),
+				formatted
+			);
+	}
+}
+
+/**
+ * Confirmation modal for the "Delete spam" button.
+ *
+ * @param  props           - Component props.
+ * @param  props.isOpen    - Whether the modal is open.
+ * @param  props.onCancel  - Function to call when the user cancels.
+ * @param  props.onConfirm - Function to call when the user confirms.
+ * @param  props.scopeMode - Which scope the action will use.
+ * @param  props.count     - Number of responses that will be affected.
  * @return {JSX.Element} The confirmation modal.
  */
 export default function EmptySpamConfirmationModal( {
 	isOpen,
 	onCancel,
 	onConfirm,
-	totalItemsSpam,
-	selectedResponsesCount,
+	scopeMode,
+	count,
 }: EmptySpamConfirmationModalProps ): JSX.Element {
 	return (
 		<ConfirmDialog
 			onCancel={ onCancel }
 			onConfirm={ onConfirm }
 			isOpen={ isOpen }
-			confirmButtonText={ __( 'Delete', 'jetpack-forms' ) }
+			size="medium"
+			confirmButtonText={ __( 'Delete forever', 'jetpack-forms' ) }
 		>
-			<h3>{ __( 'Delete forever', 'jetpack-forms' ) }</h3>
-			<p>
-				{ selectedResponsesCount > 0
-					? sprintf(
-							// translators: %s: the number of responses in spam
-							_n(
-								'%s response in spam will be deleted forever. This action cannot be undone.',
-								'All %s responses in spam will be deleted forever. This action cannot be undone.',
-								totalItemsSpam || 0,
-								'jetpack-forms'
-							),
-							formatNumber( totalItemsSpam )
-					  )
-					: __(
-							'All responses in spam will be deleted forever. This action cannot be undone.',
-							'jetpack-forms'
-					  ) }
-			</p>
+			<VStack spacing={ 4 }>
+				<Heading level={ 3 }>{ titleForScope( scopeMode, count ) }</Heading>
+				<Text>{ __( 'This action cannot be undone.', 'jetpack-forms' ) }</Text>
+			</VStack>
 		</ConfirmDialog>
 	);
 }

--- a/projects/packages/forms/src/dashboard/components/empty-spam-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/empty-spam-button/index.tsx
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
+import { formatNumber } from '@automattic/number-formatters';
 import { Button } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { trash } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import useEmptySpam from '../../hooks/use-empty-spam';
+import useEmptySpam, { type EmptySpamScope } from '../../hooks/use-empty-spam';
 import EmptySpamConfirmationModal from './confirmation-modal';
 
 interface EmptySpamButtonProps {
@@ -15,7 +16,25 @@ interface EmptySpamButtonProps {
 }
 
 /**
- * Renders a button to empty form responses.
+ * Label for the button showing the count of affected responses.
+ *
+ * @param scope - Current scope descriptor from the hook.
+ * @return Localized label.
+ */
+function labelForScope( scope: EmptySpamScope ): string {
+	if ( scope.mode === 'all' ) {
+		return __( 'Delete spam', 'jetpack-forms' );
+	}
+	return sprintf(
+		/* translators: %s: The number of spam responses that will be deleted. */
+		__( 'Delete spam (%s)', 'jetpack-forms' ),
+		formatNumber( scope.count )
+	);
+}
+
+/**
+ * Renders the "Delete spam" button, which adapts to the current scope
+ * (selection → filter → all spam) and opens the confirmation modal.
  *
  * @param {object} props                - Component props.
  * @param {number} props.totalItemsSpam - The total number of spam items (optional, will use hook if not provided).
@@ -31,8 +50,7 @@ const EmptySpamButton = ( {
 		onConfirmEmptying,
 		isEmpty,
 		isEmptying,
-		totalItemsSpam,
-		selectedResponsesCount,
+		scope,
 	} = useEmptySpam( {
 		totalItemsSpam: totalItemsSpamProp,
 	} );
@@ -50,14 +68,14 @@ const EmptySpamButton = ( {
 				showTooltip={ isEmpty }
 				variant="primary"
 			>
-				{ __( 'Delete spam', 'jetpack-forms' ) }
+				{ labelForScope( scope ) }
 			</Button>
 			<EmptySpamConfirmationModal
 				isOpen={ isConfirmDialogOpen }
 				onCancel={ closeConfirmDialog }
 				onConfirm={ onConfirmEmptying }
-				totalItemsSpam={ totalItemsSpam }
-				selectedResponsesCount={ selectedResponsesCount }
+				scopeMode={ scope.mode }
+				count={ scope.count }
 			/>
 		</>
 	);

--- a/projects/packages/forms/src/dashboard/hooks/use-empty-spam.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-empty-spam.ts
@@ -5,8 +5,8 @@ import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { formatNumber } from '@automattic/number-formatters';
 import apiFetch from '@wordpress/api-fetch';
 import { store as coreStore } from '@wordpress/core-data';
-import { useDispatch } from '@wordpress/data';
-import { useState, useCallback, useEffect } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useState, useCallback, useMemo } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 /**
@@ -14,6 +14,24 @@ import { store as noticesStore } from '@wordpress/notices';
  */
 import { store as dashboardStore } from '../store/index';
 import useInboxData from './use-inbox-data';
+
+export type EmptySpamScopeMode = 'selection' | 'filtered' | 'all';
+
+type BulkScopeParams = {
+	post_ids?: number[];
+	search?: string;
+	parent?: number;
+	source?: number;
+	before?: string;
+	after?: string;
+	is_unread?: boolean;
+};
+
+export type EmptySpamScope = {
+	mode: EmptySpamScopeMode;
+	count: number;
+	params: BulkScopeParams;
+};
 
 type UseEmptySpamReturn = {
 	isConfirmDialogOpen: boolean;
@@ -24,14 +42,28 @@ type UseEmptySpamReturn = {
 	isEmptying: boolean;
 	totalItemsSpam: number;
 	selectedResponsesCount: number;
+	scope: EmptySpamScope;
 };
 
+const toInt = ( value: unknown ): number | undefined => {
+	const n = typeof value === 'string' ? parseInt( value, 10 ) : Number( value );
+	return Number.isFinite( n ) && n > 0 ? n : undefined;
+};
+
+const nonEmptyString = ( value: unknown ): string | undefined =>
+	typeof value === 'string' && value !== '' ? value : undefined;
+
 /**
- * Hook to manage empty spam functionality.
+ * Hook to manage empty spam functionality with scope awareness.
+ *
+ * The button can act on three different scopes, in priority order:
+ * 1. `selection` — explicitly selected rows (`post_ids`).
+ * 2. `filtered` — every spam response matching the current search/source/date/read filters.
+ * 3. `all` — every spam response (legacy behavior when no selection or filter).
  *
  * @param props                - Optional props.
  * @param props.totalItemsSpam - The total number of spam items (optional, will use hook if not provided).
- * @return Object with empty spam state and handlers.
+ * @return Object with empty spam state, scope, and handlers.
  */
 export default function useEmptySpam( {
 	totalItemsSpam: totalItemsSpamProp,
@@ -40,21 +72,73 @@ export default function useEmptySpam( {
 } = {} ): UseEmptySpamReturn {
 	const [ isConfirmDialogOpen, setConfirmDialogOpen ] = useState( false );
 	const [ isEmptying, setIsEmptying ] = useState( false );
-	const [ isEmpty, setIsEmpty ] = useState( true );
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { invalidateResolutionForStoreSelector } = useDispatch( coreStore ) as unknown as {
 		invalidateResolutionForStoreSelector: ( selector: string ) => void;
 	};
 	const { invalidateCounts } = useDispatch( dashboardStore );
 
-	// Use props if provided, otherwise use hook
 	const hookData = useInboxData();
 	const totalItemsSpam = totalItemsSpamProp ?? hookData.totalItemsSpam ?? 0;
-	const { selectedResponsesCount } = hookData;
+	const { selectedResponsesCount, currentQuery } = hookData;
 
-	useEffect( () => {
-		setIsEmpty( ! totalItemsSpam );
-	}, [ totalItemsSpam ] );
+	const selectedIds = useSelect(
+		select =>
+			(
+				select( dashboardStore ) as unknown as {
+					getSelectedResponsesFromCurrentDataset: () => Array< number | string >;
+				}
+			 ).getSelectedResponsesFromCurrentDataset(),
+		[]
+	);
+
+	const scope = useMemo< EmptySpamScope >( () => {
+		const normalizedIds = ( selectedIds || [] )
+			.map( id => ( typeof id === 'string' ? parseInt( id, 10 ) : id ) )
+			.filter( ( id ): id is number => Number.isFinite( id ) && id > 0 );
+
+		if ( normalizedIds.length > 0 ) {
+			return {
+				mode: 'selection',
+				count: normalizedIds.length,
+				params: { post_ids: normalizedIds },
+			};
+		}
+
+		const params: BulkScopeParams = {};
+		const search = nonEmptyString( currentQuery?.search );
+		if ( search ) {
+			params.search = search;
+		}
+		const parent = toInt( currentQuery?.parent );
+		if ( parent ) {
+			params.parent = parent;
+		}
+		const source = toInt( currentQuery?.source );
+		if ( source ) {
+			params.source = source;
+		}
+		const before = nonEmptyString( currentQuery?.before );
+		if ( before ) {
+			params.before = before;
+		}
+		const after = nonEmptyString( currentQuery?.after );
+		if ( after ) {
+			params.after = after;
+		}
+		if ( currentQuery?.is_unread !== undefined ) {
+			params.is_unread = Boolean( currentQuery.is_unread );
+		}
+
+		const hasFilter = Object.keys( params ).length > 0;
+		return {
+			mode: hasFilter ? 'filtered' : 'all',
+			count: totalItemsSpam,
+			params,
+		};
+	}, [ selectedIds, currentQuery, totalItemsSpam ] );
+
+	const isEmpty = scope.count === 0;
 
 	const openConfirmDialog = useCallback( () => setConfirmDialogOpen( true ), [] );
 	const closeConfirmDialog = useCallback( () => setConfirmDialogOpen( false ), [] );
@@ -67,29 +151,32 @@ export default function useEmptySpam( {
 		closeConfirmDialog();
 		setIsEmptying( true );
 
-		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_empty_spam_click' );
+		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_empty_spam_click', {
+			scope: scope.mode,
+			count: scope.count,
+		} );
 
-		apiFetch( {
+		const payload: Record< string, unknown > = { status: 'spam', ...scope.params };
+
+		apiFetch< { deleted?: number } >( {
 			method: 'DELETE',
-			path: `/wp/v2/feedback/trash?status=spam`,
+			path: '/wp/v2/feedback/trash',
+			data: payload,
 		} )
-			.then( ( response: { deleted?: number } ) => {
+			.then( response => {
 				const deleted = response?.deleted ?? 0;
-				const successMessage =
-					deleted === 1
-						? __( 'Response deleted permanently.', 'jetpack-forms' )
-						: sprintf(
-								/* translators: %s: The number of responses. */
-								_n(
-									'%s response deleted permanently.',
-									'%s responses deleted permanently.',
-									deleted,
-									'jetpack-forms'
-								),
-								formatNumber( deleted )
-						  );
+				const message = sprintf(
+					/* translators: %s: The number of responses. */
+					_n(
+						'%s spam response deleted permanently.',
+						'%s spam responses deleted permanently.',
+						deleted,
+						'jetpack-forms'
+					),
+					formatNumber( deleted )
+				);
 
-				createSuccessNotice( successMessage, { type: 'snackbar', id: 'empty-spam' } );
+				createSuccessNotice( message, { type: 'snackbar', id: 'empty-spam' } );
 			} )
 			.catch( () => {
 				createErrorNotice( __( 'Could not empty spam.', 'jetpack-forms' ), {
@@ -99,9 +186,7 @@ export default function useEmptySpam( {
 			} )
 			.finally( () => {
 				setIsEmptying( false );
-				// invalidate counts to refresh the counts across all status tabs
 				invalidateCounts();
-				// invalidate all entity record resolutions (feedback items, forms list entries_count, etc.)
 				invalidateResolutionForStoreSelector( 'getEntityRecords' );
 			} );
 	}, [
@@ -112,6 +197,7 @@ export default function useEmptySpam( {
 		invalidateCounts,
 		isEmpty,
 		isEmptying,
+		scope,
 	] );
 
 	return {
@@ -123,5 +209,6 @@ export default function useEmptySpam( {
 		isEmptying,
 		totalItemsSpam,
 		selectedResponsesCount,
+		scope,
 	};
 }

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -695,8 +695,8 @@ export default function usePageHeaderDetails(
 								isOpen={ emptySpam.isConfirmDialogOpen }
 								onCancel={ emptySpam.closeConfirmDialog }
 								onConfirm={ emptySpam.onConfirmEmptying }
-								totalItemsSpam={ emptySpam.totalItemsSpam }
-								selectedResponsesCount={ emptySpam.selectedResponsesCount }
+								scopeMode={ emptySpam.scope.mode }
+								count={ emptySpam.scope.count }
 							/>,
 					  ]
 					: [] ),
@@ -869,8 +869,8 @@ export default function usePageHeaderDetails(
 		emptySpam.isConfirmDialogOpen,
 		emptySpam.closeConfirmDialog,
 		emptySpam.onConfirmEmptying,
-		emptySpam.totalItemsSpam,
-		emptySpam.selectedResponsesCount,
+		emptySpam.scope.mode,
+		emptySpam.scope.count,
 		renameFormItem,
 		closeRenameModal,
 		handleRename,

--- a/projects/packages/forms/tests/js/dashboard/components/empty-spam-button/index.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/components/empty-spam-button/index.test.jsx
@@ -29,6 +29,9 @@ await jest.unstable_mockModule( '@wordpress/components', () => ( {
 				<button onClick={ onConfirm }>{ confirmButtonText }</button>
 			</div>
 		) : null,
+	__experimentalHeading: ( { children } ) => <h3>{ children }</h3>,
+	__experimentalText: ( { children } ) => <span>{ children }</span>,
+	__experimentalVStack: ( { children } ) => <div>{ children }</div>,
 } ) );
 
 await jest.unstable_mockModule( '@wordpress/icons', () => ( {
@@ -85,6 +88,7 @@ await jest.unstable_mockModule( '@wordpress/data', () => {
 
 	const mockSelect = {
 		getSelectedResponsesCount: jest.fn().mockReturnValue( 0 ),
+		getSelectedResponsesFromCurrentDataset: jest.fn().mockReturnValue( [] ),
 		getCurrentStatus: jest.fn().mockReturnValue( 'trash' ),
 		getCurrentQuery: jest.fn().mockReturnValue( {} ),
 		getFilters: jest.fn().mockReturnValue( {} ),
@@ -182,7 +186,7 @@ describe( 'EmptySpamButton', () => {
 	it( 'renders correctly', () => {
 		renderWithProvider( <EmptySpamButton totalItemsSpam={ 1 } /> );
 
-		const button = screen.getByText( 'Delete spam' );
+		const button = screen.getByText( /^Delete spam/ );
 		expect( button ).toBeInTheDocument();
 		expect( button ).toHaveAttribute( 'type', 'button' );
 		expect( button ).toBeEnabled();
@@ -191,7 +195,7 @@ describe( 'EmptySpamButton', () => {
 	it( 'shows disabled state when spam is empty', () => {
 		renderWithProvider( <EmptySpamButton totalItemsSpam={ 0 } /> );
 
-		const button = screen.getByText( 'Delete spam' );
+		const button = screen.getByText( /^Delete spam/ );
 		expect( button ).toBeDisabled();
 		expect( button ).toHaveAttribute( 'aria-label', 'Spam is already empty.' );
 	} );
@@ -199,7 +203,7 @@ describe( 'EmptySpamButton', () => {
 	it( 'shows confirmation dialog when clicked', async () => {
 		renderWithProvider( <EmptySpamButton totalItemsSpam={ 1 } /> );
 
-		const button = screen.getByText( 'Delete spam' );
+		const button = screen.getByText( /^Delete spam/ );
 		await userEvent.click( button );
 
 		const dialog = screen.getByTestId( 'confirm-dialog' );
@@ -215,22 +219,23 @@ describe( 'EmptySpamButton', () => {
 		renderWithProvider( <EmptySpamButton totalItemsSpam={ 1 } /> );
 
 		// Click empty spam button
-		const button = screen.getByText( 'Delete spam' );
+		const button = screen.getByText( /^Delete spam/ );
 		await userEvent.click( button );
 
 		// Click confirm button
-		const confirmButton = screen.getByText( 'Delete' );
+		const confirmButton = screen.getByText( 'Delete forever' );
 		await userEvent.click( confirmButton );
 
-		// Verify API call
+		// Verify API call — scope is `all` (no selection, no filter), so payload is just status.
 		expect( apiFetch ).toHaveBeenCalledWith( {
 			method: 'DELETE',
-			path: '/wp/v2/feedback/trash?status=spam',
+			path: '/wp/v2/feedback/trash',
+			data: { status: 'spam' },
 		} );
 
-		// Verify success notice
+		// Verify success notice (pluralized with formatNumber).
 		expect( mockDispatch.createSuccessNotice ).toHaveBeenCalledWith(
-			'Response deleted permanently.',
+			expect.stringContaining( 'deleted permanently' ),
 			{ type: 'snackbar', id: 'empty-spam' }
 		);
 	} );

--- a/projects/packages/forms/tests/js/dashboard/hooks/use-empty-spam.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/hooks/use-empty-spam.test.jsx
@@ -33,10 +33,13 @@ await jest.unstable_mockModule( '../../../../src/dashboard/store', () => ( {
 await jest.unstable_mockModule( '../../../../src/dashboard/hooks/use-inbox-data', () => ( {
 	default: jest.fn( () => ( {
 		totalItemsSpam: 5,
-		selectedResponsesCount: 2,
+		selectedResponsesCount: 0,
 		currentQuery: { status: 'spam' },
 	} ) ),
 } ) );
+
+// Selected IDs the store selector returns. Tests mutate this to change scope.
+let selectedIdsFromStore = [];
 
 // Mock WordPress data
 await jest.unstable_mockModule( '@wordpress/data', () => {
@@ -65,34 +68,86 @@ await jest.unstable_mockModule( '@wordpress/data', () => {
 			}
 			return {};
 		} ),
+		useSelect: jest.fn( mapper =>
+			mapper( () => ( {
+				getSelectedResponsesFromCurrentDataset: () => selectedIdsFromStore,
+			} ) )
+		),
 	};
 } );
 
 // Import the hook after mocks are set up
 const useEmptySpamModule = await import( '../../../../src/dashboard/hooks/use-empty-spam' );
 const useEmptySpam = useEmptySpamModule.default;
+const useInboxDataModule = await import( '../../../../src/dashboard/hooks/use-inbox-data' );
+const apiFetchModule = await import( '@wordpress/api-fetch' );
+const analyticsModule = await import( '@automattic/jetpack-analytics' );
+const { useDispatch } = await import( '@wordpress/data' );
 
 describe( 'useEmptySpam', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
+		selectedIdsFromStore = [];
+		useInboxDataModule.default.mockReturnValue( {
+			totalItemsSpam: 5,
+			selectedResponsesCount: 0,
+			currentQuery: { status: 'spam' },
+		} );
+		apiFetchModule.default.mockImplementation( () => Promise.resolve( { deleted: 5 } ) );
 	} );
 
-	it( 'returns initial state', () => {
+	it( 'returns initial state in `all` scope', () => {
 		const { result } = renderHook( () => useEmptySpam() );
 
 		expect( result.current.isConfirmDialogOpen ).toBe( false );
 		expect( result.current.isEmpty ).toBe( false );
 		expect( result.current.isEmptying ).toBe( false );
 		expect( result.current.totalItemsSpam ).toBe( 5 );
-		expect( result.current.selectedResponsesCount ).toBe( 2 );
-		expect( typeof result.current.openConfirmDialog ).toBe( 'function' );
-		expect( typeof result.current.closeConfirmDialog ).toBe( 'function' );
-		expect( typeof result.current.onConfirmEmptying ).toBe( 'function' );
+		expect( result.current.scope.mode ).toBe( 'all' );
+		expect( result.current.scope.count ).toBe( 5 );
+		expect( result.current.scope.params ).toEqual( {} );
 	} );
 
-	it( 'sets isEmpty to true when totalItemsSpam is 0', async () => {
-		const useInboxDataModule = await import( '../../../../src/dashboard/hooks/use-inbox-data' );
-		useInboxDataModule.default.mockReturnValueOnce( {
+	it( 'reports selection scope when responses are selected', () => {
+		selectedIdsFromStore = [ 11, 22, '33' ];
+		useInboxDataModule.default.mockReturnValue( {
+			totalItemsSpam: 5,
+			selectedResponsesCount: 3,
+			currentQuery: { status: 'spam', search: 'ignored-because-selection-wins' },
+		} );
+
+		const { result } = renderHook( () => useEmptySpam() );
+
+		expect( result.current.scope.mode ).toBe( 'selection' );
+		expect( result.current.scope.count ).toBe( 3 );
+		expect( result.current.scope.params ).toEqual( { post_ids: [ 11, 22, 33 ] } );
+	} );
+
+	it( 'reports filtered scope when filters are active and no selection', () => {
+		useInboxDataModule.default.mockReturnValue( {
+			totalItemsSpam: 42,
+			selectedResponsesCount: 0,
+			currentQuery: {
+				status: 'spam',
+				search: 'viagra',
+				source: 99,
+				is_unread: true,
+			},
+		} );
+
+		const { result } = renderHook( () => useEmptySpam() );
+
+		expect( result.current.scope.mode ).toBe( 'filtered' );
+		expect( result.current.scope.count ).toBe( 42 );
+		expect( result.current.scope.params ).toEqual( {
+			search: 'viagra',
+			source: 99,
+			is_unread: true,
+		} );
+	} );
+
+	it( 'marks as empty when scope count is 0', () => {
+		useInboxDataModule.default.mockReturnValue( {
 			totalItemsSpam: 0,
 			selectedResponsesCount: 0,
 			currentQuery: {},
@@ -106,25 +161,23 @@ describe( 'useEmptySpam', () => {
 	it( 'opens and closes confirmation dialog', () => {
 		const { result } = renderHook( () => useEmptySpam() );
 
-		expect( result.current.isConfirmDialogOpen ).toBe( false );
-
 		act( () => {
 			result.current.openConfirmDialog();
 		} );
-
 		expect( result.current.isConfirmDialogOpen ).toBe( true );
 
 		act( () => {
 			result.current.closeConfirmDialog();
 		} );
-
 		expect( result.current.isConfirmDialogOpen ).toBe( false );
 	} );
 
-	it( 'calls API and shows success notice when emptying spam', async () => {
-		const apiFetchModule = await import( '@wordpress/api-fetch' );
-		const analyticsModule = await import( '@automattic/jetpack-analytics' );
-		const { useDispatch } = await import( '@wordpress/data' );
+	it( 'calls DELETE /trash with filter params and shows success notice', async () => {
+		useInboxDataModule.default.mockReturnValue( {
+			totalItemsSpam: 5,
+			selectedResponsesCount: 0,
+			currentQuery: { status: 'spam', search: 'spammy' },
+		} );
 
 		const { result } = renderHook( () => useEmptySpam() );
 
@@ -132,49 +185,75 @@ describe( 'useEmptySpam', () => {
 			await result.current.onConfirmEmptying();
 		} );
 
-		// Verify analytics event was recorded
 		expect( analyticsModule.default.tracks.recordEvent ).toHaveBeenCalledWith(
-			'jetpack_forms_empty_spam_click'
+			'jetpack_forms_empty_spam_click',
+			expect.objectContaining( { scope: 'filtered', count: 5 } )
 		);
 
-		// Verify API call
 		await waitFor( () => {
 			expect( apiFetchModule.default ).toHaveBeenCalledWith( {
 				method: 'DELETE',
-				path: '/wp/v2/feedback/trash?status=spam',
+				path: '/wp/v2/feedback/trash',
+				data: { status: 'spam', search: 'spammy' },
 			} );
 		} );
 
-		// Verify success notice
-		const mockDispatch = useDispatch( 'notices' );
+		const noticesDispatch = useDispatch( 'notices' );
 		await waitFor( () => {
-			expect( mockDispatch.createSuccessNotice ).toHaveBeenCalledWith(
+			expect( noticesDispatch.createSuccessNotice ).toHaveBeenCalledWith(
 				expect.stringContaining( 'deleted permanently' ),
 				{ type: 'snackbar', id: 'empty-spam' }
 			);
 		} );
+	} );
 
-		// Verify cache invalidation
-		const coreDispatch = useDispatch( 'core' );
-		const dashboardDispatch = useDispatch( 'dashboard' );
+	it( 'calls DELETE /trash with post_ids when items are selected', async () => {
+		selectedIdsFromStore = [ 1, 2, 3 ];
+
+		const { result } = renderHook( () => useEmptySpam() );
+
+		await act( async () => {
+			await result.current.onConfirmEmptying();
+		} );
+
+		expect( analyticsModule.default.tracks.recordEvent ).toHaveBeenCalledWith(
+			'jetpack_forms_empty_spam_click',
+			expect.objectContaining( { scope: 'selection', count: 3 } )
+		);
+
 		await waitFor( () => {
-			expect( coreDispatch.invalidateResolutionForStoreSelector ).toHaveBeenCalledWith(
-				'getEntityRecords'
-			);
-			expect( dashboardDispatch.invalidateCounts ).toHaveBeenCalled();
+			expect( apiFetchModule.default ).toHaveBeenCalledWith( {
+				method: 'DELETE',
+				path: '/wp/v2/feedback/trash',
+				data: { status: 'spam', post_ids: [ 1, 2, 3 ] },
+			} );
 		} );
 	} );
 
-	it( 'does not call API when isEmpty is true', async () => {
-		const useInboxDataModule = await import( '../../../../src/dashboard/hooks/use-inbox-data' );
-		useInboxDataModule.default.mockReturnValueOnce( {
+	it( 'shows error notice when delete fails', async () => {
+		apiFetchModule.default.mockImplementationOnce( () => Promise.reject( new Error( 'fail' ) ) );
+
+		const { result } = renderHook( () => useEmptySpam() );
+
+		await act( async () => {
+			await result.current.onConfirmEmptying();
+		} );
+
+		const noticesDispatch = useDispatch( 'notices' );
+		await waitFor( () => {
+			expect( noticesDispatch.createErrorNotice ).toHaveBeenCalledWith( 'Could not empty spam.', {
+				type: 'snackbar',
+				id: 'empty-spam-error',
+			} );
+		} );
+	} );
+
+	it( 'does not call API when scope count is 0', async () => {
+		useInboxDataModule.default.mockReturnValue( {
 			totalItemsSpam: 0,
 			selectedResponsesCount: 0,
 			currentQuery: {},
 		} );
-
-		const apiFetchModule = await import( '@wordpress/api-fetch' );
-		apiFetchModule.default.mockClear();
 
 		const { result } = renderHook( () => useEmptySpam() );
 
@@ -189,5 +268,6 @@ describe( 'useEmptySpam', () => {
 		const { result } = renderHook( () => useEmptySpam( { totalItemsSpam: 10 } ) );
 
 		expect( result.current.totalItemsSpam ).toBe( 10 );
+		expect( result.current.scope.count ).toBe( 10 );
 	} );
 } );


### PR DESCRIPTION
Fixes FORMS-678

## Proposed changes

* Make the "Delete spam" button scope-aware — it now respects selected items, active filters (search, source, date range, read/unread), or falls back to deleting all spam (legacy behavior).
* The button label adapts: shows `Delete spam` when unfiltered, or `Delete spam (N)` when filters or selection are active, reflecting how many responses will be affected.
* The confirmation modal now shows the exact count of affected responses in a scope-aware title (e.g. "Delete 42 matching spam responses?") using `VStack`/`Heading`/`Text` components for consistent styling.
* Backend: extended `DELETE /wp/v2/feedback/trash` to accept `post_ids[]` and filter params (`search`, `parent`, `source`, `before`, `after`, `is_unread`), with batched processing (1000 IDs per iteration) and source-filter hook lifecycle managed outside the batch loop.

## Related product discussion/links

* p1776216218689629-slack-C086RGTJT1D

## Does this pull request change what data or activity we track or use?

The existing `jetpack_forms_empty_spam_click` analytics event now includes `scope` (`selection`|`filtered`|`all`) and `count` properties.

## Testing instructions

1. Go to a site with Jetpack Forms and seed some spam responses (at least 20, spread across 2+ forms, some containing a known substring like "BUYCHEAP").
2. Navigate to **Forms → Responses → Spam** tab.

### Test: unfiltered (legacy behavior)
3. With no filters or selection active, the button should read **"Delete spam"** (no count).
4. Click it → modal should show total spam count in the title (e.g. "Delete all 20 spam responses?") and "This action cannot be undone." body text.
5. Click "Delete forever" → all spam is deleted, snackbar confirms count.

### Test: filtered scope
6. Re-seed spam. Type a search string (e.g. "BUYCHEAP") that matches a subset.
7. Button should now read **"Delete spam (N)"** where N is the matching count.
8. Click → modal title shows "Delete N matching spam responses?".
9. Confirm → only matching spam is deleted; non-matching spam remains.

### Test: source filter
10. Re-seed spam. Use the source/form dropdown to filter to one form.
11. Confirm the button count matches, and deletion only affects that form's spam.

### Test: selection scope
12. Re-seed spam. Select 3 specific rows manually.
13. Button should read **"Delete spam (3)"**.
14. Click → modal title shows "Delete 3 selected spam responses?".
15. Confirm → exactly those 3 are deleted; rest untouched.

### Test: zero matches
16. Search for a string with no matches → button should be disabled.

### Test: existing Empty Trash behavior
17. Go to the Trash tab → "Delete trash" button should still work as before (no regression).