### PR TITLE
VideoPress admin: tighten spacing and full-width hero on medium screens

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-admin-spacing
+++ b/projects/packages/videopress/changelog/fix-videopress-admin-spacing
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-VideoPress admin: fix checkbox→footer padding, full-width hero on medium screens, and remove empty pagination placeholder
+VideoPress admin: add padding around the Settings section, make the hero full width on medium screens, and remove an empty pagination placeholder below the video library.

--- a/projects/packages/videopress/changelog/fix-videopress-admin-spacing
+++ b/projects/packages/videopress/changelog/fix-videopress-admin-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress admin: fix checkbox→footer padding, full-width hero on medium screens, and remove empty pagination placeholder

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -242,7 +242,7 @@ const Admin = () => {
 								</Col>
 							) }
 
-							<Col sm={ 4 } md={ 4 } lg={ 8 }>
+							<Col sm={ 4 } md={ 8 } lg={ 8 }>
 								<Text variant="headline-small" mb={ 3 }>
 									{ __( 'High quality, ad-free video', 'jetpack-videopress-pkg' ) }
 								</Text>

--- a/projects/packages/videopress/src/client/admin/components/pagination/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/pagination/index.tsx
@@ -177,7 +177,7 @@ export const ConnectPagination = ( props: { className: string; disabled?: boolea
 export const ConnectLocalPagination = ( props: { className?: string; disabled?: boolean } ) => {
 	const { setPage, page, itemsPerPage, total, isFetching } = useLocalVideos();
 
-	return total < itemsPerPage ? null : (
+	return total <= itemsPerPage ? null : (
 		<Pagination
 			{ ...props }
 			perPage={ itemsPerPage }

--- a/projects/packages/videopress/src/client/admin/components/pagination/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/pagination/index.tsx
@@ -4,6 +4,7 @@
 import { Button, Text } from '@automattic/jetpack-components';
 import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
 import clsx from 'clsx';
+import { useEffect } from 'react';
 /**
  * Internal dependencies
  */
@@ -176,6 +177,12 @@ export const ConnectPagination = ( props: { className: string; disabled?: boolea
 
 export const ConnectLocalPagination = ( props: { className?: string; disabled?: boolean } ) => {
 	const { setPage, page, itemsPerPage, total, isFetching } = useLocalVideos();
+
+	useEffect( () => {
+		if ( total <= itemsPerPage && page > 1 ) {
+			setPage( 1 );
+		}
+	}, [ total, itemsPerPage, page, setPage ] );
 
 	return total <= itemsPerPage ? null : (
 		<Pagination

--- a/projects/packages/videopress/src/client/admin/components/pagination/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/pagination/index.tsx
@@ -162,9 +162,7 @@ export const ConnectPagination = ( props: { className: string; disabled?: boolea
 	};
 
 	const { page, itemsPerPage, total, isFetching } = useVideos();
-	return total <= itemsPerPage ? (
-		<div className={ clsx( props.className, styles[ 'pagination-placeholder' ] ) } />
-	) : (
+	return total <= itemsPerPage ? null : (
 		<Pagination
 			{ ...props }
 			perPage={ itemsPerPage }
@@ -179,9 +177,7 @@ export const ConnectPagination = ( props: { className: string; disabled?: boolea
 export const ConnectLocalPagination = ( props: { className?: string; disabled?: boolean } ) => {
 	const { setPage, page, itemsPerPage, total, isFetching } = useLocalVideos();
 
-	return total < itemsPerPage ? (
-		<div className={ clsx( props.className, styles[ 'pagination-placeholder' ] ) } />
-	) : (
+	return total < itemsPerPage ? null : (
 		<Pagination
 			{ ...props }
 			perPage={ itemsPerPage }

--- a/projects/packages/videopress/src/client/admin/components/pagination/style.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/pagination/style.module.scss
@@ -16,7 +16,3 @@
 		background-color: unset;
 	}
 }
-
-.pagination-placeholder {
-	height: calc(var(--spacing-base) * 4);
-}

--- a/projects/packages/videopress/src/client/admin/components/site-settings-section/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/site-settings-section/index.tsx
@@ -39,7 +39,7 @@ const SiteSettingsSection: FC< SiteSettingsSectionProps > = ( {
 		: null;
 
 	return (
-		<Container horizontalSpacing={ 0 } horizontalGap={ 0 }>
+		<Container horizontalSpacing={ 6 } horizontalGap={ 0 }>
 			<Col>
 				<Text variant="headline-small" mb={ 1 }>
 					{ __( 'Settings', 'jetpack-videopress-pkg' ) }

--- a/projects/plugins/jetpack/changelog/fix-videopress-admin-spacing
+++ b/projects/plugins/jetpack/changelog/fix-videopress-admin-spacing
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-VideoPress admin: fix checkbox→footer padding, full-width hero on medium screens, and remove empty pagination placeholder

--- a/projects/plugins/jetpack/changelog/fix-videopress-admin-spacing
+++ b/projects/plugins/jetpack/changelog/fix-videopress-admin-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+VideoPress admin: fix checkbox→footer padding, full-width hero on medium screens, and remove empty pagination placeholder

--- a/projects/plugins/videopress/changelog/fix-videopress-admin-spacing
+++ b/projects/plugins/videopress/changelog/fix-videopress-admin-spacing
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-VideoPress admin: fix checkbox→footer padding, full-width hero on medium screens, and remove empty pagination placeholder
+VideoPress admin: add padding around the Settings section, make the hero full width on medium screens, and remove an empty pagination placeholder below the video library.

--- a/projects/plugins/videopress/changelog/fix-videopress-admin-spacing
+++ b/projects/plugins/videopress/changelog/fix-videopress-admin-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress admin: fix checkbox→footer padding, full-width hero on medium screens, and remove empty pagination placeholder


### PR DESCRIPTION
## Proposed changes

A few small visual fixes on the VideoPress admin page:

Before | After
--- | ---
<img width="1510" height="989" alt="Screenshot 2026-04-16 at 3 17 23 PM" src="https://github.com/user-attachments/assets/c70598b5-8f31-4fab-93cb-337ffa70f8a5" /> | <img width="1510" height="989" alt="Screenshot 2026-04-16 at 3 12 50 PM" src="https://github.com/user-attachments/assets/fe09bb96-c58a-4d24-ae84-b5b219c71528" />


* **Settings section** no longer runs flush against the page footer. There's now breathing room above the "Settings" heading and below the privacy checkbox.
* **Hero area** now uses the full width on medium-sized screens. Previously the title and upgrade CTA were squeezed into the left half with empty space on the right.
* **Removed an invisible spacer** below the video library that was adding ~64px of empty space when there was only one page of videos. (See the note below — it was there for a reason.)

### About the pagination spacer

The placeholder was originally added so the layout wouldn't jump by 32px when filter/search results crossed the threshold between single-page and multi-page. Removing it trades that micro-jitter for a much cleaner layout on new/small libraries (which is the common case). Happy to revisit if the jitter on filter changes turns out to feel bad in practice.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. Sync this branch to a test site (or run locally).
2. Open the VideoPress admin page at `/wp-admin/admin.php?page=jetpack-videopress`.
3. **Desktop:** Scroll to the bottom — the "Video Privacy" checkbox should no longer touch the footer, and the space below the last video thumbnail should be tighter.
4. **Resize the window to around 768px wide:** the hero section's title and green upgrade box should now span the full content width instead of only the left half.
5. **Narrow mobile:** no change (was already full width).
6. **With many videos:** confirm real pagination still appears and looks right when there's more than one page.
