### PR TITLE
CI: Parallelize WP plugin installs

### DIFF
--- a/.github/files/setup-wordpress-env.sh
+++ b/.github/files/setup-wordpress-env.sh
@@ -51,7 +51,8 @@ export COMPOSER_MIRROR_PATH_REPOS=true
 
 BASE="$(pwd)"
 PKGVERSIONS="$(jq -nc 'reduce inputs as $in ({}; .[$in.name] |= ( $in.extra["branch-alias"]["dev-trunk"] // "dev-trunk" ) )' projects/packages/*/composer.json)"
-_install_plugin() {
+
+function _install_plugin {
 	DIR="${1%/composer.json}"
 	NAME="$(basename "$DIR")"
 

--- a/.github/files/setup-wordpress-env.sh
+++ b/.github/files/setup-wordpress-env.sh
@@ -51,9 +51,8 @@ export COMPOSER_MIRROR_PATH_REPOS=true
 
 BASE="$(pwd)"
 PKGVERSIONS="$(jq -nc 'reduce inputs as $in ({}; .[$in.name] |= ( $in.extra["branch-alias"]["dev-trunk"] // "dev-trunk" ) )' projects/packages/*/composer.json)"
-EXIT=0
-for PLUGIN in projects/plugins/*/composer.json; do
-	DIR="${PLUGIN%/composer.json}"
+_install_plugin() {
+	DIR="${1%/composer.json}"
 	NAME="$(basename "$DIR")"
 
 	echo "::group::Installing plugin $NAME into WordPress"
@@ -61,7 +60,7 @@ for PLUGIN in projects/plugins/*/composer.json; do
 	if php -r 'exit( preg_match( "/^>=\\s*(\\d+\\.\\d+)$/", $argv[1], $m ) && version_compare( PHP_VERSION, $m[1], "<" ) ? 0 : 1 );' "$( jq -r '.require.php // ""' "$DIR/composer.json" )"; then
 		echo "::endgroup::"
 		echo "Skipping install of plugin $NAME, requires PHP $( jq -r '.require.php // ""' "$DIR/composer.json" )"
-		continue
+		return 0
 	fi
 
 	if jq --arg script "skip-$TEST_SCRIPT" -e '.scripts[$script] // false' "$DIR/composer.json" > /dev/null; then
@@ -69,12 +68,11 @@ for PLUGIN in projects/plugins/*/composer.json; do
 		if [[ $CODE -eq 3 ]]; then
 			echo "::endgroup::"
 			echo "Skipping install of plugin $NAME due to skip-$TEST_SCRIPT script"
-			continue
+			return 0
 		elif [[ $CODE -ne 0 ]]; then
 			echo "::endgroup::"
 			echo "::error::Script skip-$TEST_SCRIPT for plugin $NAME failed to run! ($CODE)"
-			EXIT=1
-			continue
+			return 1
 		fi
 	fi
 
@@ -101,16 +99,12 @@ for PLUGIN in projects/plugins/*/composer.json; do
 			if ! composer update "${DEPS[@]}"; then
 				echo "::endgroup::"
 				echo "::error::plugins/$NAME: Platform reqs failed for PHP $(php -r 'echo PHP_VERSION;') and updating dev deps didn't help. The plugin is likely broken for that PHP version."
-				EXIT=1
-				cd "$BASE"
-				continue
+				return 1
 			fi
 		else
 			echo "::endgroup::"
 			echo "::error::plugins/$NAME: Platform reqs failed for PHP $(php -r 'echo PHP_VERSION;'). The plugin is likely broken for that PHP version."
-			EXIT=1
-			cd "$BASE"
-			continue
+			return 1
 		fi
 	fi
 	cd "$BASE"
@@ -140,6 +134,22 @@ for PLUGIN in projects/plugins/*/composer.json; do
 	echo "define( 'JETPACK_AUTOLOAD_DEV', true );" >> "$WP_TEST_CONFIG"
 
 	echo "::endgroup::"
+}
+
+EXIT=0
+PIDS=()
+TMPFILES=()
+for PLUGIN in projects/plugins/*/composer.json; do
+	TMPOUT=$(mktemp)
+	TMPFILES+=("$TMPOUT")
+	_install_plugin "$PLUGIN" >"$TMPOUT" 2>&1 &
+	PIDS+=($!)
+done
+
+for i in "${!PIDS[@]}"; do
+	wait "${PIDS[$i]}" || EXIT=1
+	cat "${TMPFILES[$i]}"
+	rm "${TMPFILES[$i]}"
 done
 
 # Install WooCommerce plugin used for some Jetpack integration tests.

--- a/.github/files/setup-wordpress-env.sh
+++ b/.github/files/setup-wordpress-env.sh
@@ -143,7 +143,7 @@ TMPFILES=()
 for PLUGIN in projects/plugins/*/composer.json; do
 	TMPOUT=$(mktemp)
 	TMPFILES+=("$TMPOUT")
-	_install_plugin "$PLUGIN" >"$TMPOUT" 2>&1 &
+	_install_plugin "$PLUGIN" &>"$TMPOUT" &
 	PIDS+=($!)
 done
 

--- a/.github/files/setup-wordpress-env.sh
+++ b/.github/files/setup-wordpress-env.sh
@@ -53,6 +53,7 @@ BASE="$(pwd)"
 PKGVERSIONS="$(jq -nc 'reduce inputs as $in ({}; .[$in.name] |= ( $in.extra["branch-alias"]["dev-trunk"] // "dev-trunk" ) )' projects/packages/*/composer.json)"
 
 function _install_plugin {
+	local CODE DBNAME DEPS DIR JSON NAME TMP WP_TEST_CONFIG
 	DIR="${1%/composer.json}"
 	NAME="$(basename "$DIR")"
 

--- a/.github/files/setup-wordpress-env.sh
+++ b/.github/files/setup-wordpress-env.sh
@@ -149,7 +149,7 @@ for PLUGIN in projects/plugins/*/composer.json; do
 done
 
 for i in "${!PIDS[@]}"; do
-	wait "${PIDS[$i]}" || EXIT=1
+	wait -f "${PIDS[$i]}" || EXIT=1
 	cat "${TMPFILES[$i]}"
 	rm "${TMPFILES[$i]}"
 done


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
We might squeeze out some optimization by parallelizing plugin installation when setting up the PHP test environment.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Let's see if the CI times are reduced.

Edit: it seems that step drops from 1m down to 30s (in each PHP test run). Not a huge savings, but not harmful.