### PR TITLE
wpcomsh: Customize fatal error screen with WordPress.com links

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-wpcomsh-fatal-error-screen
+++ b/projects/plugins/wpcomsh/changelog/add-wpcomsh-fatal-error-screen
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Customize the WordPress fatal error screen with WordPress.com support links.

--- a/projects/plugins/wpcomsh/fatal-error-screen.php
+++ b/projects/plugins/wpcomsh/fatal-error-screen.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Customizes WordPress's default fatal error screen with WordPress.com support links.
+ *
+ * @package wpcomsh
+ */
+
+/**
+ * Swaps wordpress.org links on the fatal error screen for their WordPress.com
+ * equivalents, and updates the trailing "Learn more" link text to match.
+ *
+ * Matches against core's translated source strings so the replacement works in
+ * any locale; the replacement text lives under the wpcomsh text domain.
+ *
+ * @param string $message HTML error message produced by WP_Fatal_Error_Handler.
+ * @return string
+ */
+function wpcomsh_customize_fatal_error_message( $message ) {
+	// Fatal handler can run before after_setup_theme and before i18n.php is required;
+	// i18n.php registers the wpcom-locale .mo rewrite (e.g. nb_NO -> no.mo) we depend on.
+	if ( ! is_textdomain_loaded( 'wpcomsh' ) ) {
+		require_once __DIR__ . '/i18n.php';
+		load_theme_textdomain( 'wpcomsh', WP_LANG_DIR . '/mu-plugins' );
+	}
+
+	// Match against core's translated source strings (text domain `default`) so
+	// the swap works in any locale; replacement text lives under `wpcomsh`.
+	// phpcs:disable WordPress.WP.I18n.TextDomainMismatch
+	$replacements = array(
+		__( 'https://wordpress.org/support/forums/', 'default' ) => 'https://wordpress.com/forums/',
+		__( 'https://wordpress.org/documentation/article/faq-troubleshooting/', 'default' ) => 'https://wordpress.com/support/plugins/troubleshooting/',
+		__( 'Learn more about troubleshooting WordPress.', 'default' ) => __(
+			/* translators: Replaces core's "Learn more about troubleshooting WordPress." link text on the fatal error screen. The link now points to WordPress.com support docs, hence the brand swap. */
+			'Learn more about troubleshooting WordPress.com.',
+			'wpcomsh'
+		),
+	);
+	// phpcs:enable WordPress.WP.I18n.TextDomainMismatch
+
+	return str_replace( array_keys( $replacements ), array_values( $replacements ), $message );
+}
+add_filter( 'wp_php_error_message', 'wpcomsh_customize_fatal_error_message' );

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -11,6 +11,9 @@
 
 define( 'WPCOMSH_VERSION', '9.0.0' );
 
+// Loaded first so the filter is registered before any other bootstrap that might fatal.
+require_once __DIR__ . '/fatal-error-screen.php';
+
 // If true, Typekit fonts will be available in addition to Google fonts
 add_filter( 'jetpack_fonts_enable_typekit', '__return_true' );
 


### PR DESCRIPTION
Fixes # N/A

## Proposed changes
* Add a `wp_php_error_message` filter in wpcomsh that swaps the wordpress.org links on WordPress's default fatal error screen for their WordPress.com equivalents:
  * `https://wordpress.org/support/forums/` → `https://wordpress.com/forums/`
  * `https://wordpress.org/documentation/article/faq-troubleshooting/` → `https://wordpress.com/support/plugins/troubleshooting/`
  * Link text `"Learn more about troubleshooting WordPress."` → `"Learn more about troubleshooting WordPress.com."`
* Match against core's translated source strings (text domain `default`) so the swap works in any locale; the new replacement text lives under the `wpcomsh` text domain with a `translators:` comment that names the core string it replaces.
* Lazy-load `i18n.php` inside the callback when the fatal handler runs before `i18n.php` has been required during bootstrap, so the wpcom locale-slug rewrite filter (e.g. `nb_NO → no.mo`, `de_DE_formal → de.mo`) is registered before `load_theme_textdomain` resolves the `.mo` path.
* Wire the new file in `wpcomsh.php` immediately after the version `define()`, before any other `require_once`, so the filter is registered before any other bootstrap code that might fatal.

## Related product discussion/links
* N/A

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

You'll need a WoA test site to verify, since the filter only loads via wpcomsh. A Jurassic Ninja site works.

1. Sync this branch to a JN site (e.g. via the `jetpack rsync` command).
2. Trigger a fatal error. The simplest way is to drop a one-line mu-plugin into `wp-content/mu-plugins/`:
   ```php
   <?php
   nonexistent_function_to_force_a_fatal();
   ```
3. Visit the site front end. You should see WordPress's standard "There has been a critical error on this website." screen.
4. Verify the trailing link reads **"Learn more about troubleshooting WordPress.com."** and points to `https://wordpress.com/support/plugins/troubleshooting/`.
5. Visit `wp-login.php` (a "protected endpoint"). The variant of the message that mentions support forums should now link **support forums** to `https://wordpress.com/forums/`.
6. To verify locale handling, switch the site language (Settings → General → Site Language) to a non-English locale that has translations for the core fatal-error string (e.g. French, German, Spanish), reload, and confirm the surrounding core text is still translated and that the swapped links/text still appear correctly.
7. Remove the test mu-plugin when done.

