### PR TITLE
Bump @types/wordpress__block-editor to 15.0.6

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,8 +181,8 @@ importers:
         specifier: 18.3.28
         version: 18.3.28
       '@types/wordpress__block-editor':
-        specifier: 15.0.5
-        version: 15.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 15.0.6
+        version: 15.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/api-fetch':
         specifier: 7.43.0
         version: 7.43.0
@@ -5275,8 +5275,8 @@ importers:
         specifier: 18.3.28
         version: 18.3.28
       '@types/wordpress__block-editor':
-        specifier: 15.0.5
-        version: 15.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 15.0.6
+        version: 15.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@typescript/native-preview':
         specifier: 7.0.0-dev.20260225.1
         version: 7.0.0-dev.20260225.1
@@ -9801,11 +9801,8 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@types/wordpress__block-editor@15.0.5':
-    resolution: {integrity: sha512-nQNBDiVISlJWelHG+V7ikSaDFHWeKx60IyCQIG2qiePaeqjHuOaWWVJl0H1QWyOMUnmDuro2Y+GNsaNvjufuXA==}
-
-  '@types/wordpress__blocks@15.10.2':
-    resolution: {integrity: sha512-d8+XJZ/QszWyCp7k9lbqDoJePl7/SLUueMxzAA9J2buRsvd4KXK5C5Y8BAU8WuLMG2Av1dRhTvr+izfLA9jynA==}
+  '@types/wordpress__block-editor@15.0.6':
+    resolution: {integrity: sha512-XDc596rkiNLOg0SZRONHojDRd7oE/+96nCBTQq51fJpAfgtHCPXQUs5hYJNaImxqWeuNrqYGpBgU5fFS7ZqRHw==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -22438,29 +22435,16 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@types/wordpress__block-editor@15.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@types/wordpress__block-editor@15.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@types/react': 18.3.28
-      '@types/wordpress__blocks': 15.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/blocks': 15.16.0(react@18.3.1)
       '@wordpress/components': 32.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/data': 10.43.0(react@18.3.1)
       '@wordpress/element': 6.43.0
       '@wordpress/global-styles-engine': 1.10.0(react@18.3.1)
       '@wordpress/keycodes': 4.43.0
       react-autosize-textarea: 7.1.0(patch_hash=5c09e1dee59caaaba3871f9d722f93e56b41169db486b059597e8f8c788aa464)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-    transitivePeerDependencies:
-      - '@emotion/is-prop-valid'
-      - react
-      - react-dom
-      - supports-color
-
-  '@types/wordpress__blocks@15.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@types/react': 18.3.28
-      '@wordpress/components': 32.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/data': 10.43.0(react@18.3.1)
-      '@wordpress/element': 6.43.0
-      '@wordpress/shortcode': 4.43.0
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - react

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,6 +32,8 @@ minimumReleaseAgeExclude:
   - '@wordpress/*'
   # Renovate security update: dompurify@3.4.0
   - dompurify@3.4.0
+  # Need to unblock @wordpress/* package updates
+  - '@types/wordpress__block-editor@15.0.6'
 trustPolicy: no-downgrade
 trustPolicyExclude:
   # https://github.com/paulmillr/chokidar/issues/1440

--- a/projects/js-packages/ai-client/changelog/update-types-wordpress__block-editor
+++ b/projects/js-packages/ai-client/changelog/update-types-wordpress__block-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update dependencies.

--- a/projects/js-packages/ai-client/package.json
+++ b/projects/js-packages/ai-client/package.json
@@ -42,7 +42,7 @@
 		"@microsoft/fetch-event-source": "2.0.1",
 		"@types/jest": "30.0.0",
 		"@types/react": "18.3.28",
-		"@types/wordpress__block-editor": "15.0.5",
+		"@types/wordpress__block-editor": "15.0.6",
 		"@wordpress/api-fetch": "7.43.0",
 		"@wordpress/base-styles": "6.19.0",
 		"@wordpress/blob": "4.43.0",

--- a/projects/plugins/jetpack/changelog/update-types-wordpress__block-editor
+++ b/projects/plugins/jetpack/changelog/update-types-wordpress__block-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Update dependencies.

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -147,7 +147,7 @@
 		"@testing-library/user-event": "14.6.1",
 		"@types/jest": "30.0.0",
 		"@types/react": "18.3.28",
-		"@types/wordpress__block-editor": "15.0.5",
+		"@types/wordpress__block-editor": "15.0.6",
 		"@typescript/native-preview": "7.0.0-dev.20260225.1",
 		"@wordpress/api-fetch": "7.43.0",
 		"@wordpress/blob": "4.43.0",


### PR DESCRIPTION


## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Unblock #48106 by removing the usage of `@types/wordpress__blocks` via `@types/wordpress__block-editor` 

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* CI should be happy