### PR TITLE
RTC: Add richer connection logging for debugging

### DIFF
--- a/projects/packages/rtc/changelog/dotcom-16773-add-more-logs
+++ b/projects/packages/rtc/changelog/dotcom-16773-add-more-logs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Add richer connection logging: channel path, JWT age at disconnect, wasClean flag, and reconnect attempt events.

--- a/projects/packages/rtc/src/js/providers/pinghub/pinghub-bridge.ts
+++ b/projects/packages/rtc/src/js/providers/pinghub/pinghub-bridge.ts
@@ -494,6 +494,7 @@ export class PingHubBridge {
 			logConnectionEvent( 'connected', {
 				time_to_connect_ms: elapsed,
 				active_rooms: this.registeredRooms.size,
+				channel: `editor/${ window.jetpackRTC?.currentPostType }/${ window.jetpackRTC?.currentPostId }`,
 			} );
 			this.connectingWaiters.splice( 0 ).forEach( ( { resolve } ) => resolve() );
 			for ( const room of this.registeredRooms ) {
@@ -508,8 +509,10 @@ export class PingHubBridge {
 			logConnectionEvent( 'disconnected', {
 				close_code: event.code,
 				close_reason: event.reason,
+				was_clean: event.wasClean,
 				connection_lifetime_ms: elapsed,
 				active_rooms: this.registeredRooms.size,
+				jwt_age_ms: this.cachedJwtTimestamp > 0 ? Date.now() - this.cachedJwtTimestamp : -1,
 			} );
 			const wasConnecting = this.wsState === 'connecting';
 			this.ws = null;

--- a/projects/packages/rtc/src/js/providers/pinghub/pinghub-manager.ts
+++ b/projects/packages/rtc/src/js/providers/pinghub/pinghub-manager.ts
@@ -2,7 +2,7 @@ import * as decoding from 'lib0/decoding';
 import * as encoding from 'lib0/encoding';
 import * as awarenessProtocol from 'y-protocols/awareness';
 import * as syncProtocol from 'y-protocols/sync';
-import { PingHubBridge, pixel } from './pinghub-bridge';
+import { PingHubBridge, logConnectionEvent, pixel } from './pinghub-bridge';
 import type { Awareness, ConnectionStatus } from '@wordpress/sync';
 import type * as Y from 'yjs';
 
@@ -188,6 +188,10 @@ class PingHubConnection {
 			return;
 		}
 		this.reconnectAttempts++;
+		logConnectionEvent( 'reconnecting', {
+			attempt: this.reconnectAttempts,
+			delay_ms: this.reconnectDelay,
+		} );
 		this.reconnectTimer = setTimeout( () => {
 			this.reconnectTimer = null;
 			if ( rooms.has( this.room ) ) {

--- a/projects/packages/rtc/src/rest-api/class-rest-connection-log.php
+++ b/projects/packages/rtc/src/rest-api/class-rest-connection-log.php
@@ -45,7 +45,7 @@ class REST_Connection_Log extends WP_REST_Controller {
 						'event'      => array(
 							'required' => true,
 							'type'     => 'string',
-							'enum'     => array( 'connected', 'disconnected', 'jwt_fetch_error' ),
+							'enum'     => array( 'connected', 'disconnected', 'reconnecting', 'jwt_fetch_error' ),
 						),
 						'properties' => array(
 							'required' => false,


### PR DESCRIPTION
Fixes DOTCOM-16773

## Proposed changes

Add additional fields to PingHub connection lifecycle logs to help diagnose issues like the 240-second disconnect pattern observed on some sites:

* **`connected` event**: add `channel` field (e.g. `editor/post/123`) to correlate failures with specific blogs/posts
* **`disconnected` event**: add `was_clean` (`CloseEvent.wasClean`) to distinguish clean server-initiated closes from TCP drops, and `jwt_age_ms` to detect JWT expiry as a disconnect cause
* **`reconnecting` event** (new): logged when the manager schedules a reconnect attempt, with `attempt` number and `delay_ms` — fills the gap between disconnect and the next connect in logs
* **REST endpoint**: add `reconnecting` to the allowed event enum

### Why

We've been investigating connection issues by analyzing Logstash logs. The current logging has blind spots:

1. We can't tell if a disconnect was a clean server close or a TCP drop (both show as code 1006)
2. We can't correlate disconnects with JWT token age (a 240-second disconnect pattern suggests proxy/JWT TTL issues)
3. We can't see reconnect attempts between a disconnect and the next connect — just a gap in the logs
4. We can't see which channel path was used for a successful connection

## Related product discussion/links

* DOTCOM-16773

## Does this pull request change what data or activity we track or use?

Yes — adds new fields to existing `pinghub_connected` and `pinghub_disconnected` Logstash events, and introduces a new `pinghub_reconnecting` event. All fields are non-PII (channel path, timing values, boolean flags).

## Testing instructions

* Open the block editor on a site with RTC enabled
* Check the browser's Network tab for POST requests to `/wpcom/v2/rtc/connection-log`
* Verify `connected` events include `channel` field
* Verify `disconnected` events include `was_clean` and `jwt_age_ms` fields
* Kill the WebSocket connection (e.g. via DevTools → Network → WS → close) and verify a `reconnecting` event appears in the logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)