### PR TITLE
CRM: migrate workflow row Edit button to @wordpress/ui

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4801,6 +4801,9 @@ importers:
       '@wordpress/theme':
         specifier: 0.11.0
         version: 0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.7.0)
+      '@wordpress/ui':
+        specifier: 0.11.0
+        version: 0.11.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.7.0)
       clsx:
         specifier: 2.1.1
         version: 2.1.1
@@ -17413,10 +17416,12 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-to-istanbul@9.3.0:

--- a/projects/plugins/crm/changelog/try-crm-button-wp-ui
+++ b/projects/plugins/crm/changelog/try-crm-button-wp-ui
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Internal refactor to use core WordPress UI primitives. No user-facing change.
+
+

--- a/projects/plugins/crm/package.json
+++ b/projects/plugins/crm/package.json
@@ -32,6 +32,7 @@
 		"@wordpress/i18n": "6.17.0",
 		"@wordpress/icons": "12.2.0",
 		"@wordpress/theme": "0.11.0",
+		"@wordpress/ui": "0.11.0",
 		"clsx": "2.1.1",
 		"prop-types": "15.8.1",
 		"react": "18.3.1",

--- a/projects/plugins/crm/src/js/components/automations-admin/components/workflow-row/index.tsx
+++ b/projects/plugins/crm/src/js/components/automations-admin/components/workflow-row/index.tsx
@@ -1,6 +1,7 @@
-import { Button, IconTooltip, ToggleControl } from '@automattic/jetpack-components';
+import { IconTooltip, ToggleControl } from '@automattic/jetpack-components';
 import { dispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/ui';
 import { useCallback } from 'react';
 import { useNavigate } from 'react-router';
 import { useMutateAutomationWorkflows } from 'crm/data/hooks/mutations';
@@ -89,7 +90,7 @@ export const WorkflowRow: FC< WorkflowRowProps > = props => {
 					</div>
 				</td>
 				<td className={ styles[ 'edit-button' ] }>
-					<Button variant={ 'secondary' } onClick={ onEditClick }>
+					<Button variant="outline" onClick={ onEditClick }>
 						{ __( 'Edit', 'zero-bs-crm' ) }
 					</Button>
 				</td>


### PR DESCRIPTION
## Proposed changes

* Swap the custom `Button` from `@automattic/jetpack-components` for `Button` from `@wordpress/ui` in the workflow row Edit action.
* Map `variant="secondary"` → `variant="outline"` per the new `@wordpress/ui` API.
* Adds `@wordpress/ui` to the CRM plugin's direct dependencies.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

First of a safe batch migrating Jetpack custom Button consumers to `@wordpress/ui` Button. Mechanical prop map only (no `isLoading`, `isDestructive`, `isExternalLink`, `href`, `icon`, `weight`, `fullWidth` involved — those cases will be addressed in separate, deliberate PRs).

## Isolated Storybook comparison

Both Button variants rendered side-by-side in an isolated Storybook story — accurate representation of the visual delta for the secondary → outline mapping.

![crm-workflow-edit](https://github.com/Automattic/jetpack/raw/screenshots/try/crm-button-wp-ui/before-after.png)

_Real-admin screenshot attempted but the CRM Automations module is a paid extension (`extkey: automations`, $79/year) gated behind the `jetpack_crm_automations_load_ui` filter. Not available on the vanilla WP.org install I used for the other PRs in this batch. The DOM-level change for this callsite (same `@wordpress/ui` Button primitive used in the Publicize + Protect PRs where real-screen captures are present) will render identically — the same `@wordpress/ui` Button with `variant="outline"` is used in PR #48150 (Publicize) where you can see the outline variant rendered live._

## Testing instructions

* Activate the Jetpack CRM Automations module (paid extension or via the `jetpack_crm_automations_load_ui` filter returning true).
* Go to the CRM Automations admin page.
* Verify the Edit button on each workflow row renders and opens the editor on click. Visual appearance will differ slightly (core outline style vs. the old Calypso secondary — matches the outline state shown in the sibling Publicize PR's real-screen capture).