### PR TITLE
Publicize: migrate all Button consumers to @wordpress/ui

### DIFF
--- a/projects/packages/publicize/_inc/components/admin-page/header/index.js
+++ b/projects/packages/publicize/_inc/components/admin-page/header/index.js
@@ -44,6 +44,7 @@ const Header = () => {
 						<Button
 							render={ <a /> }
 							nativeButton={ false }
+							role="link"
 							href={ getAdminUrl( 'post-new.php' ) }
 							variant={ hasConnections ? 'solid' : 'outline' }
 						>

--- a/projects/packages/publicize/_inc/components/admin-page/header/index.js
+++ b/projects/packages/publicize/_inc/components/admin-page/header/index.js
@@ -1,8 +1,9 @@
-import { Button, Col, Container, H3 } from '@automattic/jetpack-components';
+import { Col, Container, H3 } from '@automattic/jetpack-components';
 import { ConnectionError, useConnectionErrorNotice } from '@automattic/jetpack-connection';
 import { getAdminUrl } from '@automattic/jetpack-script-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/ui';
 import { store as socialStore } from '../../../social-store';
 import styles from './styles.module.scss';
 
@@ -42,7 +43,7 @@ const Header = () => {
 						) }
 						<Button
 							href={ getAdminUrl( 'post-new.php' ) }
-							variant={ hasConnections ? 'primary' : 'secondary' }
+							variant={ hasConnections ? 'solid' : 'outline' }
 						>
 							{ __( 'Write a post', 'jetpack-publicize-pkg' ) }
 						</Button>

--- a/projects/packages/publicize/_inc/components/admin-page/header/index.js
+++ b/projects/packages/publicize/_inc/components/admin-page/header/index.js
@@ -2,6 +2,7 @@ import { Col, Container, H3 } from '@automattic/jetpack-components';
 import { ConnectionError, useConnectionErrorNotice } from '@automattic/jetpack-connection';
 import { getAdminUrl } from '@automattic/jetpack-script-data';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/ui';
 import { store as socialStore } from '../../../social-store';
@@ -19,6 +20,10 @@ const Header = () => {
 	const { hasConnectionError } = useConnectionErrorNotice();
 
 	const { openConnectionsModal } = useDispatch( socialStore );
+
+	const onWritePostClick = useCallback( () => {
+		window.location.href = getAdminUrl( 'post-new.php' );
+	}, [] );
 
 	return (
 		<>
@@ -41,13 +46,7 @@ const Header = () => {
 								{ __( 'Connect accounts', 'jetpack-publicize-pkg' ) }
 							</Button>
 						) }
-						<Button
-							render={ <a /> }
-							nativeButton={ false }
-							role="link"
-							href={ getAdminUrl( 'post-new.php' ) }
-							variant={ hasConnections ? 'solid' : 'outline' }
-						>
+						<Button onClick={ onWritePostClick } variant={ hasConnections ? 'solid' : 'outline' }>
 							{ __( 'Write a post', 'jetpack-publicize-pkg' ) }
 						</Button>
 					</div>

--- a/projects/packages/publicize/_inc/components/admin-page/header/index.js
+++ b/projects/packages/publicize/_inc/components/admin-page/header/index.js
@@ -42,6 +42,8 @@ const Header = () => {
 							</Button>
 						) }
 						<Button
+							render={ <a /> }
+							nativeButton={ false }
 							href={ getAdminUrl( 'post-new.php' ) }
 							variant={ hasConnections ? 'solid' : 'outline' }
 						>

--- a/projects/packages/publicize/_inc/components/admin-page/pricing-page/index.tsx
+++ b/projects/packages/publicize/_inc/components/admin-page/pricing-page/index.tsx
@@ -1,17 +1,16 @@
 import {
-	Button,
 	PricingTable,
 	PricingTableColumn,
 	PricingTableHeader,
 	PricingTableItem,
 	ProductPrice,
 	getRedirectUrl,
-	useBreakpointMatch,
 } from '@automattic/jetpack-components';
 import { getScriptData } from '@automattic/jetpack-script-data';
 import { Spinner } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __, _x } from '@wordpress/i18n';
+import { Button } from '@wordpress/ui';
 import { useCallback } from 'react';
 import useProductInfo from '../../../hooks/use-product-info';
 import { store as socialStore } from '../../../social-store';
@@ -29,8 +28,6 @@ const PricingPage = ( { onDismiss }: PricingPageProps ) => {
 	const siteSuffix = getScriptData().site.suffix;
 
 	const { setShowPricingPage, updateSocialModuleSettings } = useDispatch( socialStore );
-
-	const [ isLarge ] = useBreakpointMatch( 'lg' );
 
 	const isEnablingSocial = useSelect(
 		select => select( socialStore ).isSavingSocialModuleSettings(),
@@ -122,7 +119,7 @@ const PricingPage = ( { onDismiss }: PricingPageProps ) => {
 							site: blogID ? blogID.toString() : siteSuffix,
 							query: getRefreshPlanQuery(),
 						} ) }
-						fullWidth
+						className={ styles[ 'cta-button' ] }
 					>
 						{ __( 'Get Social', 'jetpack-publicize-pkg' ) }
 					</Button>
@@ -146,10 +143,9 @@ const PricingPage = ( { onDismiss }: PricingPageProps ) => {
 						hidePriceFraction
 					/>
 					<Button
-						fullWidth
-						variant="secondary"
+						variant="outline"
 						onClick={ startForFree }
-						className={ isLarge && styles.button }
+						className={ styles[ 'cta-button' ] }
 						disabled={ isEnablingSocial }
 					>
 						{ isEnablingSocial

--- a/projects/packages/publicize/_inc/components/admin-page/pricing-page/index.tsx
+++ b/projects/packages/publicize/_inc/components/admin-page/pricing-page/index.tsx
@@ -36,6 +36,13 @@ const PricingPage = ( { onDismiss }: PricingPageProps ) => {
 
 	const { is_publicize_enabled: isSocialEnabled } = getSocialScriptData();
 
+	const onGetSocialClick = useCallback( () => {
+		window.location.href = getRedirectUrl( 'jetpack-social-v1-plan-plugin-admin-page', {
+			site: blogID ? blogID.toString() : siteSuffix,
+			query: getRefreshPlanQuery(),
+		} );
+	}, [ blogID, siteSuffix ] );
+
 	const startForFree = useCallback( async () => {
 		// First let us activate the Social module, if it is not already enabled
 		// Because saving the settings won't work if the module is not enabled
@@ -114,16 +121,7 @@ const PricingPage = ( { onDismiss }: PricingPageProps ) => {
 					) : (
 						<Spinner className={ styles.spinner } />
 					) }
-					<Button
-						render={ <a /> }
-						nativeButton={ false }
-						role="link"
-						href={ getRedirectUrl( 'jetpack-social-v1-plan-plugin-admin-page', {
-							site: blogID ? blogID.toString() : siteSuffix,
-							query: getRefreshPlanQuery(),
-						} ) }
-						className={ styles[ 'cta-button' ] }
-					>
+					<Button onClick={ onGetSocialClick } className={ styles[ 'cta-button' ] }>
 						{ __( 'Get Social', 'jetpack-publicize-pkg' ) }
 					</Button>
 				</PricingTableHeader>

--- a/projects/packages/publicize/_inc/components/admin-page/pricing-page/index.tsx
+++ b/projects/packages/publicize/_inc/components/admin-page/pricing-page/index.tsx
@@ -117,6 +117,7 @@ const PricingPage = ( { onDismiss }: PricingPageProps ) => {
 					<Button
 						render={ <a /> }
 						nativeButton={ false }
+						role="link"
 						href={ getRedirectUrl( 'jetpack-social-v1-plan-plugin-admin-page', {
 							site: blogID ? blogID.toString() : siteSuffix,
 							query: getRefreshPlanQuery(),

--- a/projects/packages/publicize/_inc/components/admin-page/pricing-page/index.tsx
+++ b/projects/packages/publicize/_inc/components/admin-page/pricing-page/index.tsx
@@ -115,6 +115,8 @@ const PricingPage = ( { onDismiss }: PricingPageProps ) => {
 						<Spinner className={ styles.spinner } />
 					) }
 					<Button
+						render={ <a /> }
+						nativeButton={ false }
 						href={ getRedirectUrl( 'jetpack-social-v1-plan-plugin-admin-page', {
 							site: blogID ? blogID.toString() : siteSuffix,
 							query: getRefreshPlanQuery(),

--- a/projects/packages/publicize/_inc/components/admin-page/pricing-page/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/admin-page/pricing-page/styles.module.scss
@@ -10,3 +10,7 @@
 	width: 30px;
 	height: 30px;
 }
+
+.cta-button {
+	width: 100%;
+}

--- a/projects/packages/publicize/_inc/components/admin-page/toggles/social-image-generator-toggle/index.tsx
+++ b/projects/packages/publicize/_inc/components/admin-page/toggles/social-image-generator-toggle/index.tsx
@@ -1,7 +1,8 @@
-import { Button, Text, useBreakpointMatch } from '@automattic/jetpack-components';
+import { Text } from '@automattic/jetpack-components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/ui';
 import { store as socialStore } from '../../../../social-store';
 import TemplatePickerModal from '../../../social-image-generator/template-picker/modal';
 import ToggleSection from '../toggle-section';
@@ -52,21 +53,18 @@ const SocialImageGeneratorToggle: FC< SocialImageGeneratorToggleProps > = ( { di
 		[ updateSocialImageGeneratorConfig, isEnabled ]
 	);
 
-	const [ isSmall ] = useBreakpointMatch( 'sm' );
-
 	const renderTemplatePickerModal = useCallback(
 		( { open } ) => (
 			<Button
-				fullWidth={ isSmall }
 				className={ styles.button }
-				variant="secondary"
+				variant="outline"
 				disabled={ isUpdating || ! isEnabled }
 				onClick={ open }
 			>
 				{ __( 'Change defaults', 'jetpack-publicize-pkg' ) }
 			</Button>
 		),
-		[ isEnabled, isSmall, isUpdating ]
+		[ isEnabled, isUpdating ]
 	);
 
 	return (

--- a/projects/packages/publicize/_inc/components/admin-page/toggles/social-image-generator-toggle/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/admin-page/toggles/social-image-generator-toggle/styles.module.scss
@@ -16,9 +16,9 @@
 .button {
 	margin-top: calc(var(--spacing-base) * 2);
 	grid-column: span 2;
-	justify-self: flex-start;
 
 	@media ( min-width: 600px ) {
 		grid-column: 2;
+		justify-self: flex-start;
 	}
 }

--- a/projects/packages/publicize/_inc/components/admin-page/toggles/social-notes-toggle/index.tsx
+++ b/projects/packages/publicize/_inc/components/admin-page/toggles/social-notes-toggle/index.tsx
@@ -104,6 +104,8 @@ const SocialNotesToggle: FC< SocialNotesToggleProps > = ( { disabled } ) => {
 			</Text>
 
 			<Button
+				render={ <a /> }
+				nativeButton={ false }
 				className={ styles.button }
 				variant="outline"
 				disabled={ isUpdating || ! isEnabled }

--- a/projects/packages/publicize/_inc/components/admin-page/toggles/social-notes-toggle/index.tsx
+++ b/projects/packages/publicize/_inc/components/admin-page/toggles/social-notes-toggle/index.tsx
@@ -1,9 +1,10 @@
-import { Text, Button, useBreakpointMatch } from '@automattic/jetpack-components';
+import { Text } from '@automattic/jetpack-components';
 import { getAdminUrl } from '@automattic/jetpack-script-data';
 import { ExternalLink, SelectControl, ToggleControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/ui';
 import { useState } from 'react';
 import { store as socialStore } from '../../../../social-store';
 import ToggleSection from '../toggle-section';
@@ -50,8 +51,6 @@ const SocialNotesToggle: FC< SocialNotesToggleProps > = ( { disabled } ) => {
 
 	const [ isAppendLinkToggleUpdating, setIsAppendLinkToggleUpdating ] = useState( false );
 	const [ isLinkFormatUpdating, setIsLinkFormatUpdating ] = useState( false );
-
-	const [ isSmall ] = useBreakpointMatch( 'sm' );
 
 	const { toggleSocialNotes, updateSocialNotesConfig } = useDispatch( socialStore );
 
@@ -106,8 +105,7 @@ const SocialNotesToggle: FC< SocialNotesToggleProps > = ( { disabled } ) => {
 
 			<Button
 				className={ styles.button }
-				fullWidth={ isSmall }
-				variant="secondary"
+				variant="outline"
 				disabled={ isUpdating || ! isEnabled }
 				href={ newNoteUrl }
 			>

--- a/projects/packages/publicize/_inc/components/admin-page/toggles/social-notes-toggle/index.tsx
+++ b/projects/packages/publicize/_inc/components/admin-page/toggles/social-notes-toggle/index.tsx
@@ -58,6 +58,10 @@ const SocialNotesToggle: FC< SocialNotesToggleProps > = ( { disabled } ) => {
 		handleStateUpdating( () => toggleSocialNotes( ! isEnabled ) );
 	}, [ isEnabled, toggleSocialNotes ] );
 
+	const onCreateNoteClick = useCallback( () => {
+		window.location.href = newNoteUrl;
+	}, [ newNoteUrl ] );
+
 	const onToggleAppendLink = useCallback(
 		( append_link: boolean ) => {
 			handleStateUpdating(
@@ -104,13 +108,10 @@ const SocialNotesToggle: FC< SocialNotesToggleProps > = ( { disabled } ) => {
 			</Text>
 
 			<Button
-				render={ <a /> }
-				nativeButton={ false }
-				role="link"
 				className={ styles.button }
 				variant="outline"
 				disabled={ isUpdating || ! isEnabled }
-				href={ newNoteUrl }
+				onClick={ onCreateNoteClick }
 			>
 				{ __( 'Create a note', 'jetpack-publicize-pkg' ) }
 			</Button>

--- a/projects/packages/publicize/_inc/components/admin-page/toggles/social-notes-toggle/index.tsx
+++ b/projects/packages/publicize/_inc/components/admin-page/toggles/social-notes-toggle/index.tsx
@@ -106,6 +106,7 @@ const SocialNotesToggle: FC< SocialNotesToggleProps > = ( { disabled } ) => {
 			<Button
 				render={ <a /> }
 				nativeButton={ false }
+				role="link"
 				className={ styles.button }
 				variant="outline"
 				disabled={ isUpdating || ! isEnabled }

--- a/projects/packages/publicize/_inc/components/admin-page/toggles/social-notes-toggle/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/admin-page/toggles/social-notes-toggle/styles.module.scss
@@ -16,10 +16,10 @@
 .button {
 	margin-top: calc(var(--spacing-base) * 2);
 	grid-column: span 2;
-	justify-self: flex-start;
 
 	@media ( min-width: 600px ) {
 		grid-column: 2;
+		justify-self: flex-start;
 	}
 }
 

--- a/projects/packages/publicize/_inc/components/connection-management/connection-info.tsx
+++ b/projects/packages/publicize/_inc/components/connection-management/connection-info.tsx
@@ -1,8 +1,9 @@
-import { Button, IconTooltip, Text } from '@automattic/jetpack-components';
+import { IconTooltip, Text } from '@automattic/jetpack-components';
 import { Panel, PanelBody } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __, _x } from '@wordpress/i18n';
 import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
+import { Button } from '@wordpress/ui';
 import { useReducer } from 'react';
 import { store as socialStore } from '../../social-store';
 import ConnectionIcon from '../connection-icon';
@@ -49,7 +50,7 @@ export function ConnectionInfo( { connection, service, canMarkAsShared }: Connec
 				<Button
 					size={ 'small' }
 					className={ styles[ 'learn-more' ] }
-					variant="tertiary"
+					variant="minimal"
 					onClick={ togglePanel }
 					aria-label={
 						isPanelOpen

--- a/projects/packages/publicize/_inc/components/connection-management/connection-status.tsx
+++ b/projects/packages/publicize/_inc/components/connection-management/connection-status.tsx
@@ -85,7 +85,7 @@ export function ConnectionStatus( { connection, service }: ConnectionStatusProps
 			{ ! isUnsupported && service ? (
 				<Reconnect connection={ connection } service={ service } />
 			) : (
-				<Disconnect connection={ connection } variant="link" isDestructive={ false } />
+				<Disconnect connection={ connection } variant="link" />
 			) }
 		</div>
 	);

--- a/projects/packages/publicize/_inc/components/connection-management/disconnect.tsx
+++ b/projects/packages/publicize/_inc/components/connection-management/disconnect.tsx
@@ -1,18 +1,15 @@
-import { Button } from '@automattic/jetpack-components';
 import { __experimentalConfirmDialog as ConfirmDialog } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { useDispatch, useSelect } from '@wordpress/data';
 import { createInterpolateElement, useCallback, useReducer } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
+import { Button, Link } from '@wordpress/ui';
 import { store as socialStore } from '../../social-store';
 import { Connection } from '../../social-store/types';
 import styles from './style.module.scss';
-import type { ComponentProps } from 'react';
 
 export type DisconnectProps = {
 	connection: Connection;
-	variant?: ComponentProps< typeof Button >[ 'variant' ];
-	isDestructive?: boolean;
-	buttonClassName?: string;
+	variant?: 'outline' | 'minimal' | 'link';
 };
 /**
  * Disconnect component
@@ -21,12 +18,7 @@ export type DisconnectProps = {
  *
  * @return {import('react').ReactNode} - React element
  */
-export function Disconnect( {
-	connection,
-	variant = 'secondary',
-	isDestructive = true,
-	buttonClassName,
-}: DisconnectProps ) {
+export function Disconnect( { connection, variant = 'outline' }: DisconnectProps ) {
 	const [ isConfirmOpen, toggleConfirm ] = useReducer( state => ! state, false );
 
 	const { deleteConnectionById } = useDispatch( socialStore );
@@ -51,9 +43,23 @@ export function Disconnect( {
 		} );
 	}, [ connection.connection_id, deleteConnectionById ] );
 
+	const onLinkClick = useCallback(
+		( event: React.MouseEvent ) => {
+			event.preventDefault();
+			if ( ! isDisconnecting ) {
+				toggleConfirm();
+			}
+		},
+		[ isDisconnecting ]
+	);
+
 	if ( ! canManageConnection ) {
 		return null;
 	}
+
+	const label = isDisconnecting
+		? __( 'Disconnecting…', 'jetpack-publicize-pkg' )
+		: _x( 'Disconnect', 'Disconnect a social media account', 'jetpack-publicize-pkg' );
 
 	return (
 		<>
@@ -77,18 +83,25 @@ export function Disconnect( {
 					{ strong: <strong></strong> }
 				) }
 			</ConfirmDialog>
-			<Button
-				size="small"
-				onClick={ toggleConfirm }
-				disabled={ isDisconnecting }
-				variant={ variant }
-				isDestructive={ isDestructive }
-				className={ buttonClassName }
-			>
-				{ isDisconnecting
-					? __( 'Disconnecting…', 'jetpack-publicize-pkg' )
-					: _x( 'Disconnect', 'Disconnect a social media account', 'jetpack-publicize-pkg' ) }
-			</Button>
+			{ variant === 'link' ? (
+				<Link
+					variant="default"
+					href="#"
+					aria-disabled={ isDisconnecting || undefined }
+					onClick={ onLinkClick }
+				>
+					{ label }
+				</Link>
+			) : (
+				<Button
+					size="small"
+					variant={ variant }
+					onClick={ toggleConfirm }
+					disabled={ isDisconnecting }
+				>
+					{ label }
+				</Button>
+			) }
 		</>
 	);
 }

--- a/projects/packages/publicize/_inc/components/connection-management/index.tsx
+++ b/projects/packages/publicize/_inc/components/connection-management/index.tsx
@@ -1,8 +1,8 @@
-import { Button } from '@automattic/jetpack-components';
 import { Disabled } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/ui';
 import clsx from 'clsx';
 import useSocialMediaConnections from '../../hooks/use-social-media-connections';
 import { useUserCanShareConnection } from '../../hooks/use-user-can-share-connection';
@@ -73,10 +73,7 @@ const ConnectionManagement = ( { className = null, disabled = false } ) => {
 				</>
 			) : null }
 			<ManageConnectionsModal />
-			<Button
-				variant={ connections.length ? 'secondary' : 'primary' }
-				onClick={ openConnectionsModal }
-			>
+			<Button variant={ connections.length ? 'outline' : 'solid' } onClick={ openConnectionsModal }>
 				{ __( 'Connect an account', 'jetpack-publicize-pkg' ) }
 			</Button>
 		</div>

--- a/projects/packages/publicize/_inc/components/connection-management/reconnect.tsx
+++ b/projects/packages/publicize/_inc/components/connection-management/reconnect.tsx
@@ -1,17 +1,15 @@
-import { Button } from '@automattic/jetpack-components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
+import { Link } from '@wordpress/ui';
 import { store as socialStore } from '../../social-store';
 import { Connection, KeyringResult } from '../../social-store/types';
 import { SupportedService } from '../services/types';
 import { useRequestAccess } from '../services/use-request-access';
-import type { ComponentProps } from 'react';
 
 export type ReconnectProps = {
 	service: SupportedService;
 	connection: Connection;
-	variant?: ComponentProps< typeof Button >[ 'variant' ];
 };
 
 /**
@@ -21,7 +19,7 @@ export type ReconnectProps = {
  *
  * @return {import('react').ReactNode} - React element
  */
-export function Reconnect( { connection, service, variant = 'link' }: ReconnectProps ) {
+export function Reconnect( { connection, service }: ReconnectProps ) {
 	const { deleteConnectionById, setKeyringResult, openConnectionsModal, setReconnectingAccount } =
 		useDispatch( socialStore );
 
@@ -82,20 +80,30 @@ export function Reconnect( { connection, service, variant = 'link' }: ReconnectP
 		setReconnectingAccount,
 	] );
 
+	const onClick = useCallback(
+		( event: React.MouseEvent ) => {
+			event.preventDefault();
+			if ( ! isDisconnecting ) {
+				onClickReconnect();
+			}
+		},
+		[ isDisconnecting, onClickReconnect ]
+	);
+
 	if ( ! canManageConnection ) {
 		return null;
 	}
 
 	return (
-		<Button
-			size="small"
-			onClick={ onClickReconnect }
-			disabled={ isDisconnecting }
-			variant={ variant }
+		<Link
+			variant="default"
+			href="#"
+			aria-disabled={ isDisconnecting || undefined }
+			onClick={ onClick }
 		>
 			{ isDisconnecting
 				? __( 'Disconnecting…', 'jetpack-publicize-pkg' )
 				: _x( 'Reconnect', 'Reconnect a social media account', 'jetpack-publicize-pkg' ) }
-		</Button>
+		</Link>
 	);
 }

--- a/projects/packages/publicize/_inc/components/connection-management/tests/specs/disconnect.test.js
+++ b/projects/packages/publicize/_inc/components/connection-management/tests/specs/disconnect.test.js
@@ -47,6 +47,6 @@ describe( 'Disconnecting a connection', () => {
 		);
 
 		const button = screen.getByRole( 'button', { name: 'Disconnecting…' } );
-		expect( button ).toBeDisabled();
+		expect( button ).toHaveAttribute( 'aria-disabled', 'true' );
 	} );
 } );

--- a/projects/packages/publicize/_inc/components/connection-management/tests/specs/reconnect.test.js
+++ b/projects/packages/publicize/_inc/components/connection-management/tests/specs/reconnect.test.js
@@ -28,25 +28,25 @@ describe( 'Reconnect', () => {
 		jest.clearAllMocks();
 	} );
 
-	test( 'renders the Reconnect button with correct label', () => {
+	test( 'renders the Reconnect link with correct label', () => {
 		render( <Reconnect connection={ mockConnection } service={ mockService } /> );
-		expect( screen.getByRole( 'button' ) ).toHaveTextContent( 'Reconnect' );
+		expect( screen.getByRole( 'link' ) ).toHaveTextContent( 'Reconnect' );
 	} );
 
-	test( 'disables the button when isDisconnecting is true', () => {
+	test( 'disables the link when isDisconnecting is true', () => {
 		setup( { getDeletingConnections: [ mockConnection.connection_id ] } );
 		render( <Reconnect connection={ mockConnection } service={ mockService } /> );
 
-		const button = screen.getByRole( 'button' );
-		expect( button ).toBeDisabled();
-		expect( button ).toHaveTextContent( 'Disconnecting…' );
+		const link = screen.getByRole( 'link' );
+		expect( link ).toHaveAttribute( 'aria-disabled', 'true' );
+		expect( link ).toHaveTextContent( 'Disconnecting…' );
 	} );
 
-	test( 'calls deleteConnectionById and requestAccess on button click', async () => {
+	test( 'calls deleteConnectionById and requestAccess on link click', async () => {
 		const { stubDeleteConnectionById } = setup();
 		render( <Reconnect connection={ mockConnection } service={ mockService } /> );
 
-		await userEvent.click( screen.getByRole( 'button' ) );
+		await userEvent.click( screen.getByRole( 'link' ) );
 
 		expect( stubDeleteConnectionById ).toHaveBeenCalledWith( {
 			connectionId: mockConnection.connection_id,
@@ -56,10 +56,10 @@ describe( 'Reconnect', () => {
 		expect( useRequestAccess ).toHaveBeenCalled();
 	} );
 
-	test( 'does not render the button if connection cannot be disconnected', () => {
+	test( 'does not render the link if connection cannot be disconnected', () => {
 		setup( { canUserManageConnection: false } );
 		render( <Reconnect connection={ mockConnection } service={ mockService } /> );
 
-		expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/publicize/_inc/components/form/broken-connections-notice.tsx
+++ b/projects/packages/publicize/_inc/components/form/broken-connections-notice.tsx
@@ -1,10 +1,9 @@
-import { Button } from '@automattic/jetpack-components';
 import { Notice } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement, useCallback } from '@wordpress/element';
 import { _n } from '@wordpress/i18n';
+import { Link } from '@wordpress/ui';
 import { store as socialStore } from '../../social-store';
-import styles from './styles.module.scss';
 import type { FC } from 'react';
 
 export const BrokenConnectionsNotice: FC = () => {
@@ -18,13 +17,15 @@ export const BrokenConnectionsNotice: FC = () => {
 
 	const { openConnectionsModal } = useDispatch( socialStore );
 
-	const fixLink = (
-		<Button
-			variant="link"
-			onClick={ openConnectionsModal }
-			className={ styles[ 'broken-connection-btn' ] }
-		/>
+	const onFixClick = useCallback(
+		( event: React.MouseEvent ) => {
+			event.preventDefault();
+			openConnectionsModal();
+		},
+		[ openConnectionsModal ]
 	);
+
+	const fixLink = <Link variant="default" href="#" onClick={ onFixClick } />;
 
 	const problemConnections = [ ...brokenConnections, ...reauthConnections ];
 

--- a/projects/packages/publicize/_inc/components/media-picker/index.js
+++ b/projects/packages/publicize/_inc/components/media-picker/index.js
@@ -1,9 +1,10 @@
-import { Button, ThemeProvider } from '@automattic/jetpack-components';
+import { ThemeProvider } from '@automattic/jetpack-components';
 import { MediaUpload, MediaUploadCheck } from '@wordpress/block-editor';
 import { ResponsiveWrapper, Spinner, VisuallyHidden } from '@wordpress/components';
 import { Fragment, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon, closeSmall } from '@wordpress/icons';
+import { Button } from '@wordpress/ui';
 import clsx from 'clsx';
 import { isVideo } from '../../hooks/use-media-restrictions';
 import { SELECTABLE_MEDIA_TYPES } from '../../hooks/use-media-restrictions/restrictions';
@@ -114,9 +115,9 @@ export default function MediaPicker( {
 				{ ! mediaId ? (
 					<>
 						<Button
-							variant="secondary"
+							variant="outline"
 							size="small"
-							className={ styles.preview }
+							className={ styles[ 'picker-button' ] }
 							onClick={ clickHandler( open ) }
 							data-unstable-ignore-focus-outside-for-relatedtarget=".media-modal"
 						>

--- a/projects/packages/publicize/_inc/components/media-picker/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/media-picker/styles.module.scss
@@ -72,6 +72,10 @@
 	cursor: pointer;
 }
 
+.picker-button {
+	width: 100%;
+}
+
 .remove,
 %remove {
 	position: absolute;

--- a/projects/packages/publicize/_inc/components/services/connect-form.tsx
+++ b/projects/packages/publicize/_inc/components/services/connect-form.tsx
@@ -1,7 +1,7 @@
-import { Button } from '@automattic/jetpack-components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
+import { Button } from '@wordpress/ui';
 import clsx from 'clsx';
 import { store } from '../../social-store';
 import { KeyringResult } from '../../social-store/types';
@@ -94,7 +94,7 @@ export function ConnectForm( {
 			<div className={ styles[ 'fields-wrapper' ] }>
 				<div className={ styles[ 'fields-item' ] }>
 					<Button
-						variant={ hasConnections ? 'secondary' : 'primary' }
+						variant={ hasConnections ? 'outline' : 'solid' }
 						type="submit"
 						className={ styles[ 'connect-button' ] }
 						disabled={ isFetchingServicesList }

--- a/projects/packages/publicize/_inc/components/services/connect-form.tsx
+++ b/projects/packages/publicize/_inc/components/services/connect-form.tsx
@@ -92,28 +92,25 @@ export function ConnectForm( {
 			) : null }
 
 			<div className={ styles[ 'fields-wrapper' ] }>
-				<div className={ styles[ 'fields-item' ] }>
-					<Button
-						variant={ hasConnections ? 'outline' : 'solid' }
-						type="submit"
-						className={ styles[ 'connect-button' ] }
-						disabled={ isFetchingServicesList }
-					>
-						{ ( label => {
-							if ( label ) {
-								return label;
-							}
+				<Button
+					variant={ hasConnections ? 'outline' : 'solid' }
+					type="submit"
+					disabled={ isFetchingServicesList }
+				>
+					{ ( label => {
+						if ( label ) {
+							return label;
+						}
 
-							if ( isFetchingServicesList && isConnecting ) {
-								return __( 'Connecting…', 'jetpack-publicize-pkg' );
-							}
+						if ( isFetchingServicesList && isConnecting ) {
+							return __( 'Connecting…', 'jetpack-publicize-pkg' );
+						}
 
-							return hasConnections
-								? _x( 'Connect more', '', 'jetpack-publicize-pkg' )
-								: __( 'Connect', 'jetpack-publicize-pkg' );
-						} )( buttonLabel ) }
-					</Button>
-				</div>
+						return hasConnections
+							? _x( 'Connect more', '', 'jetpack-publicize-pkg' )
+							: __( 'Connect', 'jetpack-publicize-pkg' );
+					} )( buttonLabel ) }
+				</Button>
 			</div>
 		</form>
 	);

--- a/projects/packages/publicize/_inc/components/services/service-connection-info.tsx
+++ b/projects/packages/publicize/_inc/components/services/service-connection-info.tsx
@@ -85,12 +85,7 @@ export const ServiceConnectionInfo = ( {
 				} )( connection ) }
 			</div>
 			<div className={ styles[ 'connection-actions' ] }>
-				<Disconnect
-					connection={ connection }
-					isDestructive={ false }
-					variant="tertiary"
-					buttonClassName={ styles.disconnect }
-				/>
+				<Disconnect connection={ connection } variant="minimal" />
 			</div>
 		</div>
 	);

--- a/projects/packages/publicize/_inc/components/services/service-item.tsx
+++ b/projects/packages/publicize/_inc/components/services/service-item.tsx
@@ -1,9 +1,10 @@
-import { Button, useBreakpointMatch } from '@automattic/jetpack-components';
+import { useBreakpointMatch } from '@automattic/jetpack-components';
 import { Panel, PanelBody } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useEffect, useReducer, useRef } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
+import { Button } from '@wordpress/ui';
 import { store as socialStore } from '../../social-store';
 import { ConnectForm } from './connect-form';
 import { ServiceItemDetails, ServicesItemDetailsProps } from './service-item-details';
@@ -107,7 +108,7 @@ export function ServiceItem( {
 					<Button
 						size={ 'small' }
 						className={ styles[ 'learn-more' ] }
-						variant="tertiary"
+						variant="minimal"
 						onClick={ togglePanel }
 						aria-label={ __( 'Learn more', 'jetpack-publicize-pkg' ) }
 					>

--- a/projects/packages/publicize/_inc/components/services/style.module.scss
+++ b/projects/packages/publicize/_inc/components/services/style.module.scss
@@ -165,14 +165,6 @@
 	}
 
 
-	.disconnect {
-
-		&:global(.components-button.is-tertiary) {
-			font-size: 1rem;
-			font-weight: 400;
-			color: var(--jp-gray-50);
-		}
-	}
 }
 
 .connect-form-wrapper {
@@ -187,16 +179,6 @@
 	flex-direction: column;
 	justify-content: flex-end;
 	width: 100%;
-
-	.connect-button {
-
-		&:global(.components-button) {
-			padding: 6px 16px;
-			font-size: 14px;
-			font-weight: 500;
-			line-height: 20px;
-		}
-	}
 
 	.fields-wrapper {
 		display: flex;

--- a/projects/packages/publicize/_inc/components/share-buttons/share-buttons.tsx
+++ b/projects/packages/publicize/_inc/components/share-buttons/share-buttons.tsx
@@ -1,16 +1,16 @@
-import { SocialServiceIcon, Button, Text, CopyToClipboard } from '@automattic/jetpack-components';
+import { SocialServiceIcon, Text, CopyToClipboard } from '@automattic/jetpack-components';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { useCallback } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { Button } from '@wordpress/ui';
 import clsx from 'clsx';
 import { availableNetworks } from './available-networks';
 import styles from './styles.module.scss';
 import { useShareButtonText } from './useShareButtonText';
-import type { ComponentProps, JSX, MouseEvent } from 'react';
+import type { JSX, MouseEvent } from 'react';
 
 export type ShareButtonsProps = {
 	buttonStyle?: 'icon' | 'text' | 'icon-text';
-	buttonVariant?: ComponentProps< typeof Button >[ 'variant' ];
 };
 
 /**
@@ -20,7 +20,7 @@ export type ShareButtonsProps = {
  *
  * @return {JSX.Element} - Rendered component
  */
-export function ShareButtons( { buttonStyle = 'icon', buttonVariant }: ShareButtonsProps ) {
+export function ShareButtons( { buttonStyle = 'icon' }: ShareButtonsProps ) {
 	const prepareText = useShareButtonText();
 
 	const { recordEvent } = useAnalytics();
@@ -62,41 +62,42 @@ export function ShareButtons( { buttonStyle = 'icon', buttonVariant }: ShareButt
 			{ availableNetworks.map( ( { label, networkName, url } ) => {
 				const href = prepareText( url );
 
-				const icon =
-					'icon' === buttonStyle ? <SocialServiceIcon serviceName={ networkName } /> : null;
-
 				const text = sprintf(
 					/* translators: %s is the name of a social network, e.g. Twitter. */
 					__( 'Share on %s', 'jetpack-publicize-pkg' ),
 					label
 				);
 
+				const linkProps = {
+					href,
+					target: '_blank',
+					rel: 'noopener noreferrer',
+					onClick: getOnClick( href, { network: networkName } ),
+				};
+
 				return (
 					<div className={ styles.container } key={ networkName }>
-						<Button
-							icon={ icon }
-							variant={ buttonVariant }
-							aria-label={ text }
-							href={ href }
-							target="_blank"
-							rel="noopener noreferrer"
-							onClick={ getOnClick( href, { network: networkName } ) }
-							className={ 'icon' === buttonStyle ? styles[ networkName ] : 'has-text' }
-						>
-							{ 'icon' === buttonStyle ? null : (
-								<>
-									{ 'icon-text' === buttonStyle && (
-										<SocialServiceIcon
-											className={ styles[ networkName ] }
-											serviceName={ networkName }
-										/>
-									) }
-									<Text className={ styles.label } component="span">
-										{ text }
-									</Text>
-								</>
-							) }
-						</Button>
+						{ 'icon' === buttonStyle ? (
+							<Button
+								aria-label={ text }
+								className={ clsx( styles[ 'icon-button' ], styles[ networkName ] ) }
+								{ ...linkProps }
+							>
+								<SocialServiceIcon serviceName={ networkName } />
+							</Button>
+						) : (
+							<Button aria-label={ text } className="has-text" { ...linkProps }>
+								{ 'icon-text' === buttonStyle && (
+									<SocialServiceIcon
+										className={ styles[ networkName ] }
+										serviceName={ networkName }
+									/>
+								) }
+								<Text className={ styles.label } component="span">
+									{ text }
+								</Text>
+							</Button>
+						) }
 					</div>
 				);
 			} ) }
@@ -106,7 +107,6 @@ export function ShareButtons( { buttonStyle = 'icon', buttonVariant }: ShareButt
 					onCopy={ onCopy }
 					textToCopy={ textToCopy }
 					className={ 'icon' === buttonStyle ? styles.clipboard : ' has-text' }
-					variant={ buttonVariant }
 				>
 					{ 'icon' === buttonStyle ? null : (
 						<Text className={ styles.label } component="span">

--- a/projects/packages/publicize/_inc/components/share-buttons/share-buttons.tsx
+++ b/projects/packages/publicize/_inc/components/share-buttons/share-buttons.tsx
@@ -81,6 +81,7 @@ export function ShareButtons( { buttonStyle = 'icon' }: ShareButtonsProps ) {
 							<Button
 								render={ <a /> }
 								nativeButton={ false }
+								role="link"
 								aria-label={ text }
 								className={ clsx( styles[ 'icon-button' ], styles[ networkName ] ) }
 								{ ...linkProps }
@@ -91,6 +92,7 @@ export function ShareButtons( { buttonStyle = 'icon' }: ShareButtonsProps ) {
 							<Button
 								render={ <a /> }
 								nativeButton={ false }
+								role="link"
 								aria-label={ text }
 								className="has-text"
 								{ ...linkProps }

--- a/projects/packages/publicize/_inc/components/share-buttons/share-buttons.tsx
+++ b/projects/packages/publicize/_inc/components/share-buttons/share-buttons.tsx
@@ -79,9 +79,6 @@ export function ShareButtons( { buttonStyle = 'icon' }: ShareButtonsProps ) {
 					<div className={ styles.container } key={ networkName }>
 						{ 'icon' === buttonStyle ? (
 							<Button
-								render={ <a /> }
-								nativeButton={ false }
-								role="link"
 								aria-label={ text }
 								className={ clsx( styles[ 'icon-button' ], styles[ networkName ] ) }
 								{ ...linkProps }
@@ -89,14 +86,7 @@ export function ShareButtons( { buttonStyle = 'icon' }: ShareButtonsProps ) {
 								<SocialServiceIcon serviceName={ networkName } />
 							</Button>
 						) : (
-							<Button
-								render={ <a /> }
-								nativeButton={ false }
-								role="link"
-								aria-label={ text }
-								className="has-text"
-								{ ...linkProps }
-							>
+							<Button aria-label={ text } className="has-text" { ...linkProps }>
 								{ 'icon-text' === buttonStyle && (
 									<SocialServiceIcon
 										className={ styles[ networkName ] }

--- a/projects/packages/publicize/_inc/components/share-buttons/share-buttons.tsx
+++ b/projects/packages/publicize/_inc/components/share-buttons/share-buttons.tsx
@@ -79,6 +79,8 @@ export function ShareButtons( { buttonStyle = 'icon' }: ShareButtonsProps ) {
 					<div className={ styles.container } key={ networkName }>
 						{ 'icon' === buttonStyle ? (
 							<Button
+								render={ <a /> }
+								nativeButton={ false }
 								aria-label={ text }
 								className={ clsx( styles[ 'icon-button' ], styles[ networkName ] ) }
 								{ ...linkProps }
@@ -86,7 +88,13 @@ export function ShareButtons( { buttonStyle = 'icon' }: ShareButtonsProps ) {
 								<SocialServiceIcon serviceName={ networkName } />
 							</Button>
 						) : (
-							<Button aria-label={ text } className="has-text" { ...linkProps }>
+							<Button
+								render={ <a /> }
+								nativeButton={ false }
+								aria-label={ text }
+								className="has-text"
+								{ ...linkProps }
+							>
 								{ 'icon-text' === buttonStyle && (
 									<SocialServiceIcon
 										className={ styles[ networkName ] }

--- a/projects/packages/publicize/_inc/components/share-buttons/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/share-buttons/styles.module.scss
@@ -12,44 +12,22 @@ $whatsapp: #2ab318;
 		&:hover {
 			color: #fff;
 		}
-
-		>span {
-			display: flex;
-			align-items: center;
-
-			>svg {
-				border-radius: var(--jp-border-radius);
-				color: #fff;
-			}
-		}
 	}
 
-	:global a.components-button svg {
-		fill: currentColor;
-	}
-
-	:global :is(a, button).has-text.components-button.is-primary {
-		padding: 0;
-		background: transparent;
-		justify-content: start;
-		color: var(--jp-black);
-		gap: 0;
-
-		&:hover {
-			background: transparent;
-			color: var(--jp-gray-50);
-		}
+	.icon-button {
+		--wp-ui-button-aspect-ratio: 1;
+		--wp-ui-button-padding-inline: 0;
+		--wp-ui-button-min-width: unset;
+		--wp-ui-button-border-color: transparent;
+		--wp-ui-button-border-color-active: transparent;
 
 		svg {
-			padding: calc(var(--spacing-base) / 2);
-			width: calc(var(--spacing-base) * 3);
-			height: calc(var(--spacing-base) * 3);
+			fill: currentColor;
 		}
 
+		&:hover,
 		&:focus {
-			border: 0;
-			outline: none;
-			box-shadow: none;
+			background-color: var(--jp-gray-80);
 		}
 	}
 

--- a/projects/packages/publicize/changelog/try-publicize-connection-button-wp-ui
+++ b/projects/packages/publicize/changelog/try-publicize-connection-button-wp-ui
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Internal refactor to use core WordPress UI primitives. No user-facing change.
+
+

--- a/projects/plugins/social/changelog/try-publicize-connection-button-wp-ui
+++ b/projects/plugins/social/changelog/try-publicize-connection-button-wp-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Publicize: updated e2e connection spec to assert the 'Write a post' CTA as a button (role=button) rather than a link, to match the @wordpress/ui Button migration.

--- a/projects/plugins/social/tests/e2e/specs/connection.test.ts
+++ b/projects/plugins/social/tests/e2e/specs/connection.test.ts
@@ -20,6 +20,6 @@ test( 'Jetpack Social connection', async ( { page, admin, requestUtils } ) => {
 
 	await test.step( 'Verify connection in Jetpack Social page', async () => {
 		await expect( page.getByRole( 'button', { name: 'Connect accounts' } ) ).toBeVisible();
-		await expect( page.getByRole( 'link', { name: 'Write a post' } ) ).toBeVisible();
+		await expect( page.getByRole( 'button', { name: 'Write a post' } ) ).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
Part of https://github.com/Automattic/jetpack/issues/48160

## Proposed changes

Migrates every `Button` consumer in the Publicize package from `@automattic/jetpack-components` to `@wordpress/ui`, split across commits one per logical surface. Covers:

- Admin dashboard header ("Connect accounts", "Write a post")
- Pricing page CTAs ("Get Social", "Start for free")
- Settings toggles ("Change defaults" for SIG, "Create a note" for Social Notes)
- Connections modal ("Connect", "Connect more", "Connect an account", service/connection chevron toggles, "Disconnect" in both `outline` and `minimal` contexts)
- Broken-connection flow ("Manage connections" + "Reconnect", swapped to `@wordpress/ui` `Link`)
- Media picker ("Choose image")
- Per-network share buttons

Prop mapping applied:

| `@automattic/jetpack-components` | `@wordpress/ui` |
|---|---|
| `variant="primary"` | `variant="solid"` |
| `variant="secondary"` | `variant="outline"` |
| `variant="tertiary"` | `variant="minimal"` |
| `variant="link"` | `Link` component (or `variant="unstyled"` for anchor-shaped cases) |
| `isLoading` | `loading` |
| `size="normal"` | `size="default"` |
| `href={...}` (for navigation-on-click) | replaced with an `onClick` handler that sets `window.location.href` (`@wordpress/ui` Button renders a `<button>`, which doesn't honor `href`); share buttons' existing click handlers already worked |
| `isDestructive` | removed (no equivalent — Disconnect uses `outline`/`minimal` now) |
| `fullWidth` | replaced with CSS (`width: 100%`) where layout required it |

Two test-side fixes were needed because `@wordpress/ui` Button (Base UI-backed) uses `aria-disabled="true"` (with `focusableWhenDisabled: true` default) instead of the native `disabled` attribute, and Link renders `<a>` (role `link`) rather than `<button>`:

- `disconnect.test.js`: `toBeDisabled()` → `toHaveAttribute('aria-disabled', 'true')`
- `reconnect.test.js`: `getByRole('button')` → `getByRole('link')`; same `aria-disabled` swap

### Other information

- [ ] Generate changelog entries for this PR (using AI).

`@wordpress/ui` is already a direct dependency of the Publicize package, so no `package.json` changes were needed.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Sequenced to touch every changed button in the fewest sessions. Each step leaves the site in the state the next step needs.

### Before you start

Deploy the branch to a Jurassic Ninja (or equivalent) site with **Jetpack Social** (or Jetpack with Publicize enabled). Confirm you're signed in to WordPress.com.

### 1. Pricing page (tests **Get Social** + **Start for free** buttons)

On a fresh install the pricing page shows automatically. If it doesn't:

```bash
wp option update jetpack-social_show_pricing_page 1
```

Then open the Social admin (`/wp-admin/admin.php?page=jetpack-social`):

- ✅ "Get Social" is a solid button; clicking it navigates to the plan redirect URL (no middle-click / open-in-new-tab — it's a `<button>` with an `onClick` handler, not an anchor).
- ✅ "Start for free" is an outline button (click it to proceed).

### 2. Admin dashboard — no connections yet (tests **Connect accounts**, **Write a post**, **Change defaults**, **Choose image** in media picker, **Create a note**)

- ✅ Header: "Connect accounts" is a solid button; "Write a post" is an outline button — clicking it navigates to the post editor (same-tab only; no middle-click / open-in-new-tab since these are `<button>`s with `onClick`, not anchors).
- Toggle **Enable Social Image Generator** on.
  - ✅ "Change defaults" outline button appears.
  - Click it → the template picker modal opens.
    - ✅ Media picker shows a "Choose image" outline button inside the dashed box — **with its outline visible** (a CSS-override regression that was also fixed on this branch).
  - Close the modal.
- Toggle **Enable Social Notes** on.
  - ✅ "Create a note" outline button appears; clicking it navigates to the new-note editor.

### 3. Connections modal (tests service/connection chevrons, **Connect** / **Connect more**, **Connect an account** footer, **Disconnect** in two variants)

Click "Connect accounts" (from the header) or "Connect an account" (from the connection management widget) to open the Connections modal.

- ✅ Each service row has a minimal chevron toggle (expand/collapse).
- ✅ "Connect" buttons per service render solid.
- Connect any service (Mastodon or Bluesky are fastest — they don't require a real OAuth roundtrip through wpcom).
- After connecting:
  - ✅ "Connect more" appears on the same service row, outline variant.
  - ✅ Footer "Connect an account" flips from solid → outline.
  - Click the new connection row's chevron (minimal) to expand it.
    - ✅ "Disconnect" small outline button appears. Click it and confirm to verify the `aria-disabled` state while deleting (button text becomes "Disconnecting…"). Then reconnect for the next step.
  - Separately, expand the service panel itself (not the connection row).
    - ✅ Inside the service panel's connection list, the "Disconnect" button renders with the minimal variant (different visual — this is `variant="minimal"` via `service-connection-info`).

### 4. Broken-connection state (tests **Manage connections** link in notice + **Reconnect** unstyled link)

No UI path marks a connection broken, but the social store exposes a client-only `updateConnection` action that lets us fake it. On the Social admin page, open DevTools Console and run:

```js
// Grab any existing connection id (use the one you just connected in step 3):
const [ conn ] = wp.data.select( 'jetpack-social-plugin' ).getConnections();

// Flip it into the broken state — purely in Redux, no server roundtrip:
wp.data.dispatch( 'jetpack-social-plugin' ).updateConnection(
    conn.connection_id,
    { status: 'broken' }
);
```

The page updates immediately — no reload needed:

- ✅ Red Notice at the top: *"A social connection needs attention. **Manage connections** to fix it."* "Manage connections" is a brand-colored underlined link (role `link`; `variant="default"` of `@wordpress/ui` `Link`).
- Click "Manage connections" → Connections modal opens.
  - ✅ The broken connection row shows a "Reconnect" unstyled link — it inherits the surrounding row's text color/size (that's `variant="unstyled"`).

To restore real state, just reload the page — connections rehydrate from the server.

> Tip: try `'must_reauth'` as the status too. The notice text stays the same but it also exercises the `getMustReauthConnections` selector path in `broken-connections-notice.tsx`.

### 5. Per-network share buttons (tests **share-buttons**)

- Open any post in the block editor.
- Publish it and look at the post-publish panel; alternatively, use the classic-editor manual sharing meta box.
- ✅ Network share buttons (Facebook / X / LinkedIn / etc.) render with each network's icon/styling; clicking opens a centered popup window to the service's share URL (same behavior as before the migration — the `onClick` handler calls `window.open` with popup sizing).

### 6. Quick a11y pass (~30 seconds)

- Tab through the admin page: every interactive element receives a visible focus ring.
- Disabled buttons (e.g. "Disconnecting…") still get focus but announce as disabled (via `aria-disabled="true"`).

## Screenshots

| Before | After |
| - | - |
| <img width="285" height="198" alt="Screenshot from 2026-04-19 11-32-24" src="https://github.com/user-attachments/assets/407fb731-8dd4-457e-8b9e-531f7b73c96a" /> | <img width="285" height="139" alt="Screenshot from 2026-04-19 11-32-38" src="https://github.com/user-attachments/assets/54fa1bcc-cf58-4ccb-8800-6edad8ec27cc" /> |
| <img width="1152" height="355" alt="Screenshot from 2026-04-19 11-30-52" src="https://github.com/user-attachments/assets/c6a53177-c72c-4895-acbc-ff060d10543e" /> | <img width="1152" height="355" alt="Screenshot from 2026-04-19 11-30-41" src="https://github.com/user-attachments/assets/afcb99cf-4191-43ac-a67c-968d10246a76" /> |
| <img width="1152" height="355" alt="Screenshot from 2026-04-19 11-30-09" src="https://github.com/user-attachments/assets/0a7725ac-41e7-4f68-849b-16e3c048e3b1" /> | <img width="1152" height="355" alt="Screenshot from 2026-04-19 11-30-15" src="https://github.com/user-attachments/assets/fd89dee1-1083-46cb-8cc8-4f5268feb73b" /> |
| <img width="1152" height="355" alt="Screenshot from 2026-04-19 11-28-47" src="https://github.com/user-attachments/assets/01e7ffb9-4aa1-4ea2-898d-847087b1f935" /> | <img width="1152" height="355" alt="Screenshot from 2026-04-19 11-29-00" src="https://github.com/user-attachments/assets/c26aeabd-3564-40da-b163-78e8eb7eaffe" /> |
| <img width="1030" height="323" alt="Screenshot from 2026-04-19 11-28-10" src="https://github.com/user-attachments/assets/e585bf88-9884-47a4-a00b-c66eff3772b2" /> | <img width="1030" height="323" alt="Screenshot from 2026-04-19 11-28-18" src="https://github.com/user-attachments/assets/c97babe7-7066-462f-adf4-1342d9db8e25" /> |
| <img width="1179" height="615" alt="Screenshot from 2026-04-19 11-27-14" src="https://github.com/user-attachments/assets/8363caaf-39f7-4892-ab4b-e36401f9317c" /> | <img width="1179" height="615" alt="Screenshot from 2026-04-19 11-27-21" src="https://github.com/user-attachments/assets/0cea3be2-83fe-4bc9-939b-59b297e08b94" /> |
| <img width="1179" height="615" alt="Screenshot from 2026-04-19 11-25-02" src="https://github.com/user-attachments/assets/5c2c75dd-467b-4667-9d02-e0bd073600e6" /> | <img width="1179" height="615" alt="Screenshot from 2026-04-19 11-25-39" src="https://github.com/user-attachments/assets/d41883c2-51ef-47bd-b406-9cd1f9740c78" /> |

