### PR TITLE
Protect: migrate firewall upgrade prompt button to @wordpress/ui

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5497,6 +5497,9 @@ importers:
       '@wordpress/icons':
         specifier: 12.2.0
         version: 12.2.0(react@18.3.1)
+      '@wordpress/ui':
+        specifier: 0.11.0
+        version: 0.11.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.7.0)
       '@wordpress/url':
         specifier: 4.44.0
         version: 4.44.0
@@ -17413,10 +17416,12 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-to-istanbul@9.3.0:

--- a/projects/plugins/protect/changelog/try-protect-firewall-upgrade-button-wp-ui
+++ b/projects/plugins/protect/changelog/try-protect-firewall-upgrade-button-wp-ui
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Internal refactor to use core WordPress UI primitives. No user-facing change.
+
+

--- a/projects/plugins/protect/package.json
+++ b/projects/plugins/protect/package.json
@@ -40,6 +40,7 @@
 		"@wordpress/element": "6.44.0",
 		"@wordpress/i18n": "6.17.0",
 		"@wordpress/icons": "12.2.0",
+		"@wordpress/ui": "0.11.0",
 		"@wordpress/url": "4.44.0",
 		"camelize": "1.0.1",
 		"clsx": "2.1.1",

--- a/projects/plugins/protect/src/js/routes/firewall/firewall-upgrade-prompt.jsx
+++ b/projects/plugins/protect/src/js/routes/firewall/firewall-upgrade-prompt.jsx
@@ -1,5 +1,5 @@
-import { Button } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/ui';
 import { useCallback } from 'react';
 import useAnalyticsTracks from '../../hooks/use-analytics-tracks';
 import usePlan from '../../hooks/use-plan';


### PR DESCRIPTION

Part of https://github.com/Automattic/jetpack/issues/48160

## Proposed changes

* Swap the custom `Button` from `@automattic/jetpack-components` for `Button` from `@wordpress/ui` in the firewall upgrade prompt.
* No prop changes — the button uses only `className` and `onClick`, and the default variant maps cleanly to `@wordpress/ui`'s `variant="solid"` default.
* Adds `@wordpress/ui` to the Protect plugin's direct dependencies.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

First of a safe batch migrating Jetpack custom Button consumers to `@wordpress/ui` Button. Mechanical prop map only (no `isLoading`, `isDestructive`, `isExternalLink`, `href`, `icon`, `weight`, `fullWidth` involved — those cases will be addressed in separate, deliberate PRs).

## Real-screen before / after

Captured on a live Jurassic Ninja site with Jetpack + Jetpack Protect installed, on the Firewall tab of the Protect admin (`/wp-admin/admin.php?page=jetpack-protect#/firewall`) on a free site (automatic rules not enabled → upgrade prompt renders).

| Before — `@automattic/jetpack-components` Button | After — `@wordpress/ui` Button |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/try/protect-firewall-upgrade-button-wp-ui-real/real-before.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/try/protect-firewall-upgrade-button-wp-ui-real/real-after.png) |

Button classes went from `components-button dops-button is-primary` (Jetpack wrapper) to `…__button …__is-brand …__is-solid` (`@wordpress/ui` primitive). The second "Upgrade to enable…" button further down the page is a separate `ContextualUpgradeTrigger` component (not touched by this PR).

## Isolated Storybook comparison

![protect-firewall-upgrade](https://github.com/Automattic/jetpack/raw/screenshots/try/protect-firewall-upgrade-button-wp-ui/before-after.png)

## Testing instructions

* Open the Jetpack Protect admin page on a site without the automatic firewall features enabled.
* Navigate to the Firewall tab and verify the upgrade prompt button at the top renders and invokes the upgrade flow on click. Visual appearance will differ slightly (core `@wordpress/ui` solid style vs. the old `@automattic/jetpack-components` primary).