### PR TITLE
Docker CLI: Enable parallel worktree environments with isolated ports and names

### DIFF
--- a/.agents/skills/work-on.md
+++ b/.agents/skills/work-on.md
@@ -1,0 +1,260 @@
+---
+description: End-to-end workflow from prompt to draft PR on an isolated Jetpack Docker instance. Plans, worktrees, implements, tests, screenshots, opens the PR.
+---
+
+# /work-on
+
+Drives a task prompt all the way to a draft pull request on its own worktree and its own `jp docker` instance, without touching the primary `jetpack_dev` environment. Depends on the parallel-environment CLI flags (`jp docker up --name ... --port ...`, `--port-phpmy/inbox/smtp/sftp`).
+
+> **CLI note.** All commands use `jp`, which is the canonical Jetpack monorepo CLI documented in `AGENTS.md`. If your local install exposes it as `jetpack` or `pnpm jetpack` instead, swap freely — they resolve to the same command.
+
+## When to use
+- New features or non-trivial bug fixes that should land as their own PR.
+- Changes where before/after screenshots matter.
+- Work you want fully isolated from the running `jetpack_dev` container.
+
+## When not to use
+- One-line trivial fixes (overhead isn't worth it).
+- Work that must mutate `jetpack_dev` state directly.
+- Tasks that depend on a live WordPress.com connection / Jurassic Tube tunnel — tunnels are not set up by this skill.
+
+## Modes
+
+Ask the user up front which mode to run, unless they've specified:
+
+1. **Full run** — plan → bootstrap → implement → verify → draft PR. Default.
+2. **Bootstrap only** — plan + worktree + docker up, then stop and hand off. Useful when the human wants to drive the implementation themselves.
+3. **Implement only** — resume Phases 5–11 against an existing `/work-on` bootstrap (worktree present, docker already running). Look for `.work-on/env.json` inside the target worktree to recover the slug/port map.
+
+## Preflight (always run)
+
+1. **Read `AGENTS.md`** for the current build, test, docker, changelog, and PR commands. Do not guess from memory — these change.
+2. **Read any project-level `.codex/README.md`** for the project you're about to touch (see the codex notes in `AGENTS.md` and the user's global instructions). It will save expensive re-exploration.
+3. **Git state**:
+   - `git fetch origin trunk --quiet`
+   - `git status` — the working tree must be clean before spawning a worktree.
+   - `git branch --show-current` — determine whether we're on `trunk` or a feature branch.
+4. **Continuation detection**:
+   - Current branch ≠ trunk AND has commits ahead of `origin/trunk` → ask the user: "This looks like a continuation of `<branch>`. Options: (a) add to that branch (force-push may be needed later to keep rebased), (b) branch off fresh from trunk. Which?" Act on the answer.
+   - A worktree already exists at the proposed path → ask whether to reuse or pick a different slug.
+   - A docker compose project matching the proposed `jetpack_<slug>` is already running → ask whether to reuse, stop, or pick a different slug.
+5. **Fill in missing details** by asking the user, not by guessing: Linear/P2/Figma links, plugin scope, whether the change is visual. The goal is a self-explanatory PR; blanks hurt that.
+
+## Phase 0 — Parse the prompt
+
+From the user's request, extract:
+- **Task slug** — kebab-case, ≤ 30 chars, safe as both `--name` and branch suffix (e.g. `fix-forms-label-wrap`).
+- **Target project(s)** — e.g. `projects/plugins/jetpack`, `projects/packages/forms`. If ambiguous, ask.
+- **Visual change?** — any UI/CSS/React/block markup implies yes. If yes, Phases 4 and 7 are mandatory.
+- **External references** — Linear ticket, P2 link (use the `abc1-2-p2` shorthand per AGENTS.md "Confidentiality"), Figma URL, GitHub issue. These feed the PR body.
+- **Scope boundary** — what is explicitly out of scope (useful to note in the PR).
+
+## Phase 1 — Orient & research
+
+- `git log -20 --oneline` on the target area for recent context.
+- Grep the codebase for existing patterns before writing anything new.
+- If the change is large (> ~200 LoC expected) or the area is unfamiliar, spawn one or two `Explore` agents on the top recent contributors' merged PRs in that area to pick up conventions.
+- Note any nearby tests — they're the first place the change can break.
+
+## Phase 2 — Plan
+
+Produce and show the user a plan that includes:
+- Files to touch (with line ranges where known).
+- Approach and trade-offs (2–3 bullets).
+- Test plan (manual and automated).
+- Whether a changelog entry is needed, for which project(s), and a draft entry.
+- Baseline-screenshot path (URL + what to capture) if visual.
+
+**Wait for user approval** before moving on, unless they've said "skip planning".
+
+## Phase 3 — Worktree & Docker bring-up
+
+Pick a slug (from Phase 0) and a free **port tuple** via the **Port allocation** section below. Record them.
+
+From the main checkout (the user's working directory):
+
+```
+git worktree add /path/to/jetpack-<slug> -b change/<slug> trunk
+cd /path/to/jetpack-<slug>
+pnpm install --frozen-lockfile --prefer-offline
+```
+
+Bring up the isolated Docker:
+
+```
+jp docker up -d \
+  --name <slug> \
+  --port <wp-port> \
+  --port-phpmy <phpmy-port> \
+  --port-inbox <inbox-port> \
+  --port-smtp <smtp-port> \
+  --port-sftp <sftp-port>
+jp docker install --name <slug> --port <wp-port>
+```
+
+Persist the choices for cleanup and resume. In the worktree:
+
+```
+mkdir -p .work-on
+echo '{"slug":"<slug>","branch":"change/<slug>","ports":{"wp":<wp-port>, ...}}' > .work-on/env.json
+```
+
+Mark `.work-on/` as locally-ignored so it never commits:
+
+```
+echo '.work-on/' >> .git/info/exclude
+```
+
+## Phase 4 — Baseline screenshot (visual changes only)
+
+Skip if Phase 0 classified the change as non-visual.
+
+1. Build the affected project on the pre-change worktree state (same commit as trunk, since no code has been written yet):
+   ```
+   jp build <project>
+   ```
+   The mounted volume means the running `jetpack_<slug>` container picks the new build up immediately.
+2. Auto-pick the browser tool based on what the change needs:
+   - **Playwright MCP** (default) — great for screenshots, clicks, form interaction, a11y labels, visual verification. Most tasks.
+   - **Chrome DevTools MCP** (`chrome-devtools-mcp:chrome-devtools` skill) — when the task needs perf metrics, network throttling, heavy console interrogation, or CDP-only features.
+3. Navigate to `http://localhost:<wp-port>/<path>` and capture `before.png` into `.work-on/screenshots/<slug>-before.png`.
+
+## Phase 5 — Implement
+
+Write the changes on the worktree branch.
+
+Guardrails from the root `CLAUDE.md`:
+- Minimal diff, match existing patterns, no speculative abstractions.
+- No new error handling/fallbacks for situations that can't happen.
+- No comments that describe *what*; only *why* if non-obvious.
+- No AI attribution in commits.
+
+**If the real implementation path diverges materially from the Phase 2 plan**, stop and confirm with the user before continuing.
+
+## Phase 6 — Quality gates
+
+All commands are in `AGENTS.md`. Run the subset that applies to the changed files:
+
+| Change type | Commands |
+|---|---|
+| PHP inside a project | `jp build <project>`, `jp test php <project>`, `jp phan <project>` |
+| JS/TS inside a project | `jp build <project>`, `jp test js <project>` (no-op if the project doesn't define it) |
+| WP-integration plugin (jetpack / crm / wpcomsh) | `jp docker phpunit <target>` — see `AGENTS.md` "Testing Prerequisites" |
+| Root / `tools/*` change | `pnpm test` inside the affected tool package |
+| Every change | lint the touched files: `npx eslint <files>` and project-local `composer lint` / PHPCS when present |
+
+**2-cycle fix limit.** If the same gate fails twice in a row, stop and show the user — don't keep grinding.
+
+## Phase 7 — Browser verify (visual changes only)
+
+1. Re-run `jp build <project>` to bake the implementation.
+2. Navigate to `http://localhost:<wp-port>/<path>` in the same browser tool used in Phase 4.
+3. Capture `after.png` to `.work-on/screenshots/<slug>-after.png`.
+4. Check the browser console; record any new errors.
+5. If a Figma URL was given in Phase 0, fetch the image (WebFetch) or ask the user to paste one, and compare visually.
+
+## Phase 8 — Changelog
+
+If any file under `projects/` changed, delegate to `.agents/skills/jetpack-changelog.md` now. Do it *before* the PR, not after — changelog wording often shakes out loose ends.
+
+`AGENTS.md` documents the significance/type vocabulary. For the Jetpack plugin specifically, the types are custom (`major | enhancement | compat | bugfix | other`) — check `projects/plugins/jetpack/composer.json`.
+
+## Phase 9 — Self-review
+
+- Read `git diff trunk..HEAD` end to end. Flag anything that looks like:
+  - dead code
+  - overfitting to a specific case
+  - drift from the Phase 2 plan
+- If the `simplify` skill is available in the user's environment (`/simplify`), invoke it.
+- Re-run Phase 6 gates if code moved. Re-run Phase 7 browser check if a UI file moved.
+
+## Phase 10 — Commit & PR
+
+Commits:
+- Imperative, present tense, component-prefixed: `Forms: Fix label wrap on mobile`.
+- Single line where possible. Short body only when the *why* isn't obvious from the diff.
+- **Never** include AI attribution footers in commit messages.
+
+Push:
+```
+git push -u origin change/<slug>
+```
+
+Create a **draft** PR by delegating to `.agents/skills/jetpack-pr.md`. Required additions for this skill:
+- `--draft` on `gh pr create`.
+- Embedded before/after screenshots when Phase 7 ran. Local paths do not render inline, so either:
+  - drop the images as a PR comment via `gh pr comment <num> --body-file <body-with-images>` (GitHub converts attachments to CDN URLs), OR
+  - prompt the user to drag-and-drop the images into the PR after creation and finalise the body.
+- Testing instructions copied from Phase 2's test plan and enriched with any Phase 6 gate outputs.
+- External references from Phase 0 (Linear / P2 / Figma / issue).
+- Use `--body-file` with `gh pr create`, never `--body` — heredoc escaping burns you on backticks and special chars.
+
+## Phase 11 — Cleanup
+
+Immediate:
+- `jp docker stop --name <slug>` — stops the containers and frees ports. The DB, uploads, and `node_modules` are kept on disk for easy resume on review feedback.
+
+Deferred (do NOT run automatically — wait for the PR to merge or an explicit user request):
+- `jp docker clean --name <slug>` — destroys that instance's DB data.
+- `git worktree remove /path/to/jetpack-<slug>` — removes the worktree.
+- `.work-on/` scratchpad goes with the worktree.
+
+Report to the user:
+- PR URL
+- Phase-by-phase gate summary (pass / fail / skipped)
+- Path to screenshots
+- What was deferred for merge-time cleanup
+
+---
+
+## Port allocation
+
+Main `jetpack_dev` uses: WP 80, phpMyAdmin 8181, Mailpit inbox 1080, Mailpit SMTP 25, SFTP 1022.
+
+Algorithm:
+1. List currently-bound host ports:
+   ```
+   docker ps --format '{{.Ports}}' | grep -oE '[0-9]+->' | tr -d '->' | sort -un
+   ```
+2. Pick the first band whose five ports are all unbound. Bands are deterministic so the same task slug tends to land in the same band on re-runs:
+
+   | Band | WP | phpMyAdmin | Mailpit inbox | Mailpit SMTP | SFTP |
+   |---|---|---|---|---|---|
+   | 1 | 8080 | 8281 | 1180 | 2525 | 1122 |
+   | 2 | 8090 | 8381 | 1280 | 2626 | 1222 |
+   | 3 | 8100 | 8481 | 1380 | 2727 | 1322 |
+   | 4 | 8110 | 8581 | 1480 | 2828 | 1422 |
+
+3. If all bands are taken, list running instances to the user and ask them to free a slot or pick explicit ports.
+
+Record the chosen ports in `.work-on/env.json` so Mode 3 (implement-only resume) can find them.
+
+## Docker instance tracking
+
+Before creating a new instance:
+```
+docker ps -a --filter 'name=jetpack_' --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'
+```
+Collisions: ask the user whether to reuse, stop + recreate, or pick a different slug.
+
+## When to pause and ask
+
+Default is to act, but ALWAYS stop and ask when:
+- Continuation is detected at preflight.
+- The plan diverges from expectations during implementation.
+- A gate fails twice on the same check (2-cycle limit).
+- All port bands are occupied.
+- The task turns out to need a live WordPress.com connection — tunnel setup is out of scope.
+- The user hasn't provided a link or slug and the inferred one feels wrong.
+
+Keep each prompt short: one question, give defaults, proceed on the answer.
+
+## Related skills
+- `.agents/skills/jetpack-changelog.md` — Phase 8.
+- `.agents/skills/jetpack-pr.md` — Phase 10.
+- `.agents/skills/jetpack-review-pr.md` — run before requesting a human reviewer.
+
+## Known limitations / future extensions
+- `/implement <slug>` — a companion skill that assumes a prior `/work-on` bootstrap (picks up from Phase 5 using `.work-on/env.json`). Not yet implemented.
+- Merge-time cleanup hook that removes the worktree + cleans Docker data once the PR merges. Not yet implemented.
+- First-class Jurassic Tube / wp.com-connected flows. Out of scope for now.

--- a/.agents/skills/work-on.md
+++ b/.agents/skills/work-on.md
@@ -139,7 +139,7 @@ WordPress image pulls can take several minutes on a cold cache — if `jp docker
 jp docker install --name <slug> --port "$(echo "$PORTS" | jq -r .wp)"
 ```
 
-Use `--clone-from <name>` to seed from a different running source instance (default source is `dev` when the flag is passed without a value).
+Use `--clone-from <name>` to seed from a specific running source instance. When the flag is omitted, the CLI auto-clones from `jetpack_dev` if it's running; pass `--no-clone` to opt out and get a fresh-install flow instead.
 
 Write the full session record to `$WORKTREE/.work-on/env.json` using the schema below. Mode 3 (implement-only resume) reads this file — fields are mandatory.
 

--- a/.agents/skills/work-on.md
+++ b/.agents/skills/work-on.md
@@ -37,7 +37,7 @@ The skill would:
 2. **Plan** the change (inspect the block's label CSS, identify breakpoint rule), show the plan, wait for approval.
 3. **Allocate ports** via `work-on/scripts/alloc-ports.sh fix-forms-label-wrap` → deterministic band 1 → WP 8080, phpMy 8281, Mailpit 1180/2525, SFTP 1122.
 4. **Bootstrap** via `work-on/scripts/bootstrap-worktree.sh fix-forms-label-wrap` → creates `../jetpack-fix-forms-label-wrap` on branch `change/fix-forms-label-wrap` off trunk, runs pnpm install, seeds `.work-on/`.
-5. `jp docker up -d --name fix-forms-label-wrap --port 8080 --port-phpmy 8281 --port-inbox 1180 --port-smtp 2525 --port-sftp 1122` → `jp docker install --name fix-forms-label-wrap --port 8080`.
+5. `jp docker up -d --name fix-forms-label-wrap --port 8080 --port-phpmy 8281 --port-inbox 1180 --port-smtp 2525 --port-sftp 1122 --clone-from dev` → `jp docker install --name fix-forms-label-wrap --port 8080` (usually a no-op after clone).
 6. **Baseline screenshot** of the affected block at `http://localhost:8080/...` → `.work-on/screenshots/fix-forms-label-wrap-before.png`.
 7. **Implement** the CSS fix.
 8. `jp build packages/forms` → `jp test js packages/forms` → `jp phan packages/forms`.
@@ -129,7 +129,8 @@ jp docker up -d \
   --port-phpmy "$(echo "$PORTS" | jq -r .phpmy)" \
   --port-inbox "$(echo "$PORTS" | jq -r .inbox)" \
   --port-smtp  "$(echo "$PORTS" | jq -r .smtp)" \
-  --port-sftp  "$(echo "$PORTS" | jq -r .sftp)"
+  --port-sftp  "$(echo "$PORTS" | jq -r .sftp)" \
+  --clone-from dev
 ```
 
 WordPress image pulls can take several minutes on a cold cache — if `jp docker install` fails with "WordPress install is incomplete! Perhaps it is still downloading?", wait ~30s and retry once before escalating. Then:
@@ -137,6 +138,8 @@ WordPress image pulls can take several minutes on a cold cache — if `jp docker
 ```bash
 jp docker install --name <slug> --port "$(echo "$PORTS" | jq -r .wp)"
 ```
+
+Use `--clone-from <name>` to seed from a different running source instance (default source is `dev` when the flag is passed without a value).
 
 Write the full session record to `$WORKTREE/.work-on/env.json` using the schema below. Mode 3 (implement-only resume) reads this file — fields are mandatory.
 

--- a/.agents/skills/work-on.md
+++ b/.agents/skills/work-on.md
@@ -1,17 +1,55 @@
 ---
-description: End-to-end workflow from prompt to draft PR on an isolated Jetpack Docker instance. Plans, worktrees, implements, tests, screenshots, opens the PR.
+description: End-to-end Jetpack workflow that turns a task prompt into a draft PR on its own isolated worktree and `jp docker` instance. Use whenever the user asks to "work on", "ship", "implement", "take to PR", "build and submit", or otherwise wants a change driven from plan → code → tests → screenshots → pull request, or when they ask for a parallel/isolated sandbox separate from their primary `jetpack_dev` container. Also use for "set up a branch for X", "spin up an env to try Y", "walk this spec through to a PR", and similar phrasings — even when the user doesn't name this skill directly. Prefer this over freehand coding whenever the request carries a concrete scope that ends at a reviewable PR.
 ---
 
 # /work-on
 
-Drives a task prompt all the way to a draft pull request on its own worktree and its own `jp docker` instance, without touching the primary `jetpack_dev` environment. Depends on the parallel-environment CLI flags (`jp docker up --name ... --port ...`, `--port-phpmy/inbox/smtp/sftp`).
+Drives a task prompt all the way to a draft pull request on its own worktree and its own `jp docker` instance, without touching the primary `jetpack_dev` environment. This skill exists because the default monorepo Docker setup is singleton — two `jp docker up` calls from different branches would otherwise collide — so parallel work requires the named-instance CLI flags and port isolation this skill relies on.
 
-> **CLI note.** All commands use `jp`, which is the canonical Jetpack monorepo CLI documented in `AGENTS.md`. If your local install exposes it as `jetpack` or `pnpm jetpack` instead, swap freely — they resolve to the same command.
+## Prerequisites
+
+- **Docker Desktop is running.** The port-allocation step calls `docker ps`; it fails silently on a stopped daemon.
+- **`jp` is on your PATH.** `jp` is the canonical CLI (see `AGENTS.md`). If your shell has it as `jetpack` or you invoke it as `pnpm jetpack`, substitute freely — every `jp` command below works identically under those aliases.
+- **`jq` is installed.** The scripts in `work-on/scripts/` use it to parse `.work-on/env.json`. `brew install jq` on macOS if missing.
+- **`pnpm install --frozen-lockfile` may fail** if the lockfile has drifted since the last pull. The bootstrap script falls back to a regular `pnpm install` automatically; don't panic if you see the warning.
+
+## Trigger phrases
+
+Match this skill when the user's request includes phrases like:
+
+- "work on [something]"
+- "implement [feature/spec/ticket]"
+- "ship [change]" / "take [this] to PR" / "build and PR"
+- "spin up a branch / worktree / sandbox for [X]"
+- "set up an isolated environment to try [Y]"
+- "walk this through to a PR"
+- "draft a PR that does [Z]"
+
+Ambiguous-but-likely triggers: "can you fix [specific thing] and open a PR", "make this happen end-to-end", "go do [task]" when the task has non-trivial scope. If the request is a one-line fix or obviously throwaway exploration, decline this skill and just code.
+
+## Example walkthrough
+
+**User:** "Can you work on fixing the label wrap on mobile in the Forms label block? Figma: https://figma.com/file/abc123"
+
+The skill would:
+
+1. **Parse** the prompt → slug `fix-forms-label-wrap`, project `projects/packages/forms`, visual = yes, Figma reference recorded.
+2. **Plan** the change (inspect the block's label CSS, identify breakpoint rule), show the plan, wait for approval.
+3. **Allocate ports** via `work-on/scripts/alloc-ports.sh fix-forms-label-wrap` → deterministic band 1 → WP 8080, phpMy 8281, Mailpit 1180/2525, SFTP 1122.
+4. **Bootstrap** via `work-on/scripts/bootstrap-worktree.sh fix-forms-label-wrap` → creates `../jetpack-fix-forms-label-wrap` on branch `change/fix-forms-label-wrap` off trunk, runs pnpm install, seeds `.work-on/`.
+5. `jp docker up -d --name fix-forms-label-wrap --port 8080 --port-phpmy 8281 --port-inbox 1180 --port-smtp 2525 --port-sftp 1122` → `jp docker install --name fix-forms-label-wrap --port 8080`.
+6. **Baseline screenshot** of the affected block at `http://localhost:8080/...` → `.work-on/screenshots/fix-forms-label-wrap-before.png`.
+7. **Implement** the CSS fix.
+8. `jp build packages/forms` → `jp test js packages/forms` → `jp phan packages/forms`.
+9. **After screenshot** → compare to Figma reference.
+10. `jp changelog add packages/forms -s patch -t fixed -e "Forms: Fix label wrap on mobile."`
+11. Commit (`Forms: Fix label wrap on mobile`), push, open **draft** PR via `jetpack-pr` skill with before/after attachments + testing steps + Figma link.
+12. `jp docker stop --name fix-forms-label-wrap`. Worktree stays for review follow-ups.
 
 ## When to use
-- New features or non-trivial bug fixes that should land as their own PR.
+- Non-trivial features or bug fixes that land as their own PR.
 - Changes where before/after screenshots matter.
-- Work you want fully isolated from the running `jetpack_dev` container.
+- Work you want isolated from a running `jetpack_dev` container.
 
 ## When not to use
 - One-line trivial fixes (overhead isn't worth it).
@@ -23,101 +61,99 @@ Drives a task prompt all the way to a draft pull request on its own worktree and
 Ask the user up front which mode to run, unless they've specified:
 
 1. **Full run** — plan → bootstrap → implement → verify → draft PR. Default.
-2. **Bootstrap only** — plan + worktree + docker up, then stop and hand off. Useful when the human wants to drive the implementation themselves.
-3. **Implement only** — resume Phases 5–11 against an existing `/work-on` bootstrap (worktree present, docker already running). Look for `.work-on/env.json` inside the target worktree to recover the slug/port map.
+2. **Bootstrap only** — plan + worktree + docker up, then stop and hand off. Useful when the human wants to drive implementation themselves.
+3. **Implement only** — resume Phases 5–11 against an existing `/work-on` bootstrap (worktree present, docker already running). The skill finds `.work-on/env.json` inside the target worktree and reads the slug/port map from it.
 
 ## Preflight (always run)
 
 1. **Read `AGENTS.md`** for the current build, test, docker, changelog, and PR commands. Do not guess from memory — these change.
-2. **Read any project-level `.codex/README.md`** for the project you're about to touch (see the codex notes in `AGENTS.md` and the user's global instructions). It will save expensive re-exploration.
+2. **Read any project-level `.codex/README.md`** for the project you're about to touch. It will save expensive re-exploration.
 3. **Git state**:
    - `git fetch origin trunk --quiet`
    - `git status` — the working tree must be clean before spawning a worktree.
    - `git branch --show-current` — determine whether we're on `trunk` or a feature branch.
 4. **Continuation detection**:
-   - Current branch ≠ trunk AND has commits ahead of `origin/trunk` → ask the user: "This looks like a continuation of `<branch>`. Options: (a) add to that branch (force-push may be needed later to keep rebased), (b) branch off fresh from trunk. Which?" Act on the answer.
+   - Current branch ≠ trunk AND has commits ahead of `origin/trunk` → ask: "This looks like a continuation of `<branch>`. Options: (a) add to that branch (force-push may be needed later to keep rebased), (b) branch off fresh from trunk. Which?" Act on the answer.
    - A worktree already exists at the proposed path → ask whether to reuse or pick a different slug.
-   - A docker compose project matching the proposed `jetpack_<slug>` is already running → ask whether to reuse, stop, or pick a different slug.
-5. **Fill in missing details** by asking the user, not by guessing: Linear/P2/Figma links, plugin scope, whether the change is visual. The goal is a self-explanatory PR; blanks hurt that.
+   - A docker compose project matching `jetpack_<slug>` is already running → ask whether to reuse, stop, or pick a different slug.
+5. **Fill in missing details** by asking the user, not by guessing: Linear/P2/Figma links, plugin scope, whether the change is visual. A self-explanatory PR needs these.
 
 ## Phase 0 — Parse the prompt
 
-From the user's request, extract:
+Extract:
 - **Task slug** — kebab-case, ≤ 30 chars, safe as both `--name` and branch suffix (e.g. `fix-forms-label-wrap`).
 - **Target project(s)** — e.g. `projects/plugins/jetpack`, `projects/packages/forms`. If ambiguous, ask.
 - **Visual change?** — any UI/CSS/React/block markup implies yes. If yes, Phases 4 and 7 are mandatory.
-- **External references** — Linear ticket, P2 link (use the `abc1-2-p2` shorthand per AGENTS.md "Confidentiality"), Figma URL, GitHub issue. These feed the PR body.
-- **Scope boundary** — what is explicitly out of scope (useful to note in the PR).
+- **External references** — Linear, P2 (use the `abc1-2-p2` shorthand per `AGENTS.md` "Confidentiality"), Figma, GitHub issue.
+- **Scope boundary** — anything explicitly out of scope.
 
 ## Phase 1 — Orient & research
 
-- `git log -20 --oneline` on the target area for recent context.
+- `git log -20 --oneline` on the target area.
 - Grep the codebase for existing patterns before writing anything new.
-- If the change is large (> ~200 LoC expected) or the area is unfamiliar, spawn one or two `Explore` agents on the top recent contributors' merged PRs in that area to pick up conventions.
-- Note any nearby tests — they're the first place the change can break.
+- If the change is large (> ~200 LoC expected) or the area is unfamiliar, spawn an `Explore` agent on the top recent contributors' merged PRs in that area to surface conventions.
+- Note nearby tests — they're the first place the change can break.
 
 ## Phase 2 — Plan
 
-Produce and show the user a plan that includes:
+Produce and show the user a plan containing:
 - Files to touch (with line ranges where known).
 - Approach and trade-offs (2–3 bullets).
 - Test plan (manual and automated).
-- Whether a changelog entry is needed, for which project(s), and a draft entry.
+- Changelog decision: needed? which project? draft entry text.
 - Baseline-screenshot path (URL + what to capture) if visual.
 
 **Wait for user approval** before moving on, unless they've said "skip planning".
 
 ## Phase 3 — Worktree & Docker bring-up
 
-Pick a slug (from Phase 0) and a free **port tuple** via the **Port allocation** section below. Record them.
+From the **main checkout**, allocate ports and bootstrap the worktree using the helper scripts so the details stay consistent across runs:
 
-From the main checkout (the user's working directory):
+```bash
+PORTS=$(.agents/skills/work-on/scripts/alloc-ports.sh <slug>)
+# PORTS is JSON, e.g. {"band":1,"wp":8080,"phpmy":8281,"inbox":1180,"smtp":2525,"sftp":1122}
 
+WORKTREE=$(.agents/skills/work-on/scripts/bootstrap-worktree.sh <slug>)
+# WORKTREE = /path/to/jetpack-<slug>, created on branch change/<slug> off origin/trunk
 ```
-git worktree add /path/to/jetpack-<slug> -b change/<slug> trunk
-cd /path/to/jetpack-<slug>
-pnpm install --frozen-lockfile --prefer-offline
-```
 
-Bring up the isolated Docker:
+If `alloc-ports.sh` exits 2, every band is taken — ask the user to stop one of the running instances or provide explicit ports.
 
-```
+Bring up the isolated Docker from within the worktree:
+
+```bash
+cd "$WORKTREE"
 jp docker up -d \
   --name <slug> \
-  --port <wp-port> \
-  --port-phpmy <phpmy-port> \
-  --port-inbox <inbox-port> \
-  --port-smtp <smtp-port> \
-  --port-sftp <sftp-port>
-jp docker install --name <slug> --port <wp-port>
+  --port  "$(echo "$PORTS" | jq -r .wp)" \
+  --port-phpmy "$(echo "$PORTS" | jq -r .phpmy)" \
+  --port-inbox "$(echo "$PORTS" | jq -r .inbox)" \
+  --port-smtp  "$(echo "$PORTS" | jq -r .smtp)" \
+  --port-sftp  "$(echo "$PORTS" | jq -r .sftp)"
 ```
 
-Persist the choices for cleanup and resume. In the worktree:
+WordPress image pulls can take several minutes on a cold cache — if `jp docker install` fails with "WordPress install is incomplete! Perhaps it is still downloading?", wait ~30s and retry once before escalating. Then:
 
-```
-mkdir -p .work-on
-echo '{"slug":"<slug>","branch":"change/<slug>","ports":{"wp":<wp-port>, ...}}' > .work-on/env.json
+```bash
+jp docker install --name <slug> --port "$(echo "$PORTS" | jq -r .wp)"
 ```
 
-Mark `.work-on/` as locally-ignored so it never commits:
-
-```
-echo '.work-on/' >> .git/info/exclude
-```
+Write the full session record to `$WORKTREE/.work-on/env.json` using the schema below. Mode 3 (implement-only resume) reads this file — fields are mandatory.
 
 ## Phase 4 — Baseline screenshot (visual changes only)
 
 Skip if Phase 0 classified the change as non-visual.
 
-1. Build the affected project on the pre-change worktree state (same commit as trunk, since no code has been written yet):
+1. Some projects need a one-time `jp install <project>` before the first build. Run it if the project hasn't been built in this worktree before.
+2. Build the affected project at the pre-change state (same commit as trunk, since no code has been written yet):
    ```
    jp build <project>
    ```
    The mounted volume means the running `jetpack_<slug>` container picks the new build up immediately.
-2. Auto-pick the browser tool based on what the change needs:
-   - **Playwright MCP** (default) — great for screenshots, clicks, form interaction, a11y labels, visual verification. Most tasks.
-   - **Chrome DevTools MCP** (`chrome-devtools-mcp:chrome-devtools` skill) — when the task needs perf metrics, network throttling, heavy console interrogation, or CDP-only features.
-3. Navigate to `http://localhost:<wp-port>/<path>` and capture `before.png` into `.work-on/screenshots/<slug>-before.png`.
+3. Auto-pick the browser tool:
+   - **Playwright MCP** (default) — best for screenshots, clicks, form interaction, a11y labels, visual comparison.
+   - **Chrome DevTools MCP** (via the `chrome-devtools-mcp:chrome-devtools` skill) — when the task needs perf metrics, network throttling, heavy console interrogation, or CDP-only features.
+4. Navigate to `http://localhost:<wp-port>/<path>` and save `.work-on/screenshots/<slug>-before.png`.
 
 ## Phase 5 — Implement
 
@@ -125,136 +161,182 @@ Write the changes on the worktree branch.
 
 Guardrails from the root `CLAUDE.md`:
 - Minimal diff, match existing patterns, no speculative abstractions.
-- No new error handling/fallbacks for situations that can't happen.
-- No comments that describe *what*; only *why* if non-obvious.
+- No new error handling for situations that can't happen.
+- Comments explain *why*, not *what*; only add when non-obvious.
 - No AI attribution in commits.
 
-**If the real implementation path diverges materially from the Phase 2 plan**, stop and confirm with the user before continuing.
+**If the real implementation path diverges materially from the Phase 2 plan**, stop and confirm before continuing.
 
 ## Phase 6 — Quality gates
 
-All commands are in `AGENTS.md`. Run the subset that applies to the changed files:
+All commands are in `AGENTS.md`. Run the subset that applies:
 
 | Change type | Commands |
 |---|---|
-| PHP inside a project | `jp build <project>`, `jp test php <project>`, `jp phan <project>` |
-| JS/TS inside a project | `jp build <project>`, `jp test js <project>` (no-op if the project doesn't define it) |
-| WP-integration plugin (jetpack / crm / wpcomsh) | `jp docker phpunit <target>` — see `AGENTS.md` "Testing Prerequisites" |
+| PHP in a project | `jp build <project>`, `jp test php <project>`, `jp phan <project>` |
+| JS/TS in a project | `jp build <project>`, `jp test js <project>` (no-op if the project doesn't define it) |
+| WP-integration plugin (jetpack / crm / wpcomsh) | `jp docker phpunit <target> -- --name <slug>` — the `--name` routes to the *worktree's* instance, not `jetpack_dev` |
 | Root / `tools/*` change | `pnpm test` inside the affected tool package |
 | Every change | lint the touched files: `npx eslint <files>` and project-local `composer lint` / PHPCS when present |
 
-**2-cycle fix limit.** If the same gate fails twice in a row, stop and show the user — don't keep grinding.
+**2-cycle fix limit.** If the same gate fails twice in a row, stop and show the user — don't keep grinding. Silent grinding is how a "15-minute fix" becomes an hour of wasted context.
 
 ## Phase 7 — Browser verify (visual changes only)
 
 1. Re-run `jp build <project>` to bake the implementation.
 2. Navigate to `http://localhost:<wp-port>/<path>` in the same browser tool used in Phase 4.
-3. Capture `after.png` to `.work-on/screenshots/<slug>-after.png`.
-4. Check the browser console; record any new errors.
-5. If a Figma URL was given in Phase 0, fetch the image (WebFetch) or ask the user to paste one, and compare visually.
+3. Save `.work-on/screenshots/<slug>-after.png`.
+4. Check the browser console; save any new errors to `.work-on/console-<slug>.log`.
+5. If a Figma URL was given, fetch the image (WebFetch) or ask the user to paste one, and compare.
 
 ## Phase 8 — Changelog
 
-If any file under `projects/` changed, delegate to `.agents/skills/jetpack-changelog.md` now. Do it *before* the PR, not after — changelog wording often shakes out loose ends.
+If any file under `projects/` changed, delegate to `.agents/skills/jetpack-changelog.md` **now**, not later. Changelog wording often shakes out loose ends — the act of summarising the user-visible change forces you to notice incomplete edges.
 
-`AGENTS.md` documents the significance/type vocabulary. For the Jetpack plugin specifically, the types are custom (`major | enhancement | compat | bugfix | other`) — check `projects/plugins/jetpack/composer.json`.
+`AGENTS.md` documents the significance/type vocabulary. The Jetpack plugin uses custom types (`major | enhancement | compat | bugfix | other`) — check `projects/plugins/jetpack/composer.json` before writing.
 
 ## Phase 9 — Self-review
 
-- Read `git diff trunk..HEAD` end to end. Flag anything that looks like:
-  - dead code
-  - overfitting to a specific case
-  - drift from the Phase 2 plan
-- If the `simplify` skill is available in the user's environment (`/simplify`), invoke it.
+- Read `git diff trunk..HEAD` end to end. Flag dead code, overfitting, drift from the Phase 2 plan.
+- If `/simplify` is available in the user's environment, invoke it.
 - Re-run Phase 6 gates if code moved. Re-run Phase 7 browser check if a UI file moved.
 
 ## Phase 10 — Commit & PR
 
 Commits:
-- Imperative, present tense, component-prefixed: `Forms: Fix label wrap on mobile`.
-- Single line where possible. Short body only when the *why* isn't obvious from the diff.
-- **Never** include AI attribution footers in commit messages.
+- Imperative, present-tense, component-prefixed: `Forms: Fix label wrap on mobile`.
+- Single-line commit subject when the diff speaks for itself; short body only when the *why* isn't obvious.
+- **Never** include AI attribution footers.
 
 Push:
 ```
 git push -u origin change/<slug>
 ```
 
-Create a **draft** PR by delegating to `.agents/skills/jetpack-pr.md`. Required additions for this skill:
-- `--draft` on `gh pr create`.
-- Embedded before/after screenshots when Phase 7 ran. Local paths do not render inline, so either:
-  - drop the images as a PR comment via `gh pr comment <num> --body-file <body-with-images>` (GitHub converts attachments to CDN URLs), OR
-  - prompt the user to drag-and-drop the images into the PR after creation and finalise the body.
-- Testing instructions copied from Phase 2's test plan and enriched with any Phase 6 gate outputs.
-- External references from Phase 0 (Linear / P2 / Figma / issue).
-- Use `--body-file` with `gh pr create`, never `--body` — heredoc escaping burns you on backticks and special chars.
+Create a **draft** PR by delegating to `.agents/skills/jetpack-pr.md`. Additions for this skill:
+
+- Pass `--draft` to `gh pr create`.
+- Apply `[Status] In Progress` rather than `[Status] Needs Review`. A draft is WIP; don't page the review team yet.
+- Use `--body-file`, never `--body` — heredoc escaping breaks on backticks and special chars.
+- **Screenshots**: local paths don't render in the body. Either (a) add the images as a PR comment via `gh pr comment <num> --body-file <file-with-![alt](path)>` so GitHub converts them to CDN URLs, then reference those URLs from the PR body, or (b) open the PR first and ask the user to drag the images in and finalise.
+- Embed: Phase 2 test plan, Phase 6 gate outputs, Phase 0 external references, before/after screenshot URLs.
+- Suggest reviewers if the user hasn't named any — pick the top 1–2 recent authors on the changed files from `git log --format='%an'`.
 
 ## Phase 11 — Cleanup
 
-Immediate:
-- `jp docker stop --name <slug>` — stops the containers and frees ports. The DB, uploads, and `node_modules` are kept on disk for easy resume on review feedback.
+**On success:**
 
-Deferred (do NOT run automatically — wait for the PR to merge or an explicit user request):
-- `jp docker clean --name <slug>` — destroys that instance's DB data.
-- `git worktree remove /path/to/jetpack-<slug>` — removes the worktree.
-- `.work-on/` scratchpad goes with the worktree.
+- `jp docker stop --name <slug>` — stops the containers and frees ports. DB, uploads, and `node_modules` remain on disk for review follow-ups.
 
-Report to the user:
-- PR URL
-- Phase-by-phase gate summary (pass / fail / skipped)
-- Path to screenshots
-- What was deferred for merge-time cleanup
+Do NOT run automatically — wait for PR merge or explicit user request:
+- `jp docker clean --name <slug>` (destroys that instance's DB).
+- `git worktree remove <path>` (removes the worktree + scratchpad).
+
+**On failure** (any phase errors out):
+
+- Attempt `jp docker stop --name <slug>` so the named instance doesn't sit orphaned holding ports.
+- Leave the worktree in place; the user may want to inspect the partial state.
+- Tell the user exactly which phase failed, what the error was, and which of the two cleanup paths to use next.
+
+**Report at the end** — always:
+- PR URL (or "not opened" if we stopped earlier).
+- Phase-by-phase status: pass / fail / skipped.
+- Path to `.work-on/screenshots/` and `.work-on/console-*.log`.
+- What was deferred for merge-time cleanup.
 
 ---
+
+## `.work-on/env.json` schema
+
+Written by Phase 3, read by Mode 3. Fields are required unless marked optional. Dates are ISO 8601 UTC.
+
+```json
+{
+  "slug": "fix-forms-label-wrap",
+  "branch": "change/fix-forms-label-wrap",
+  "worktree": "/Users/you/a8c/dev/jetpack-fix-forms-label-wrap",
+  "project": "projects/packages/forms",
+  "visual": true,
+  "band": 1,
+  "ports": {
+    "wp": 8080,
+    "phpmy": 8281,
+    "inbox": 1180,
+    "smtp": 2525,
+    "sftp": 1122
+  },
+  "references": {
+    "figma": "https://figma.com/file/abc123",
+    "linear": null,
+    "p2": null,
+    "issue": null
+  },
+  "created": "2026-04-17T15:30:00Z"
+}
+```
 
 ## Port allocation
 
 Main `jetpack_dev` uses: WP 80, phpMyAdmin 8181, Mailpit inbox 1080, Mailpit SMTP 25, SFTP 1022.
 
-Algorithm:
-1. List currently-bound host ports:
-   ```
-   docker ps --format '{{.Ports}}' | grep -oE '[0-9]+->' | tr -d '->' | sort -un
-   ```
-2. Pick the first band whose five ports are all unbound. Bands are deterministic so the same task slug tends to land in the same band on re-runs:
+Allocation is done by `work-on/scripts/alloc-ports.sh <slug>`. It reads `docker ps` for currently-bound host ports, picks the first band whose five ports are all unbound, and prints JSON on stdout. Bands are deterministic from the slug hash so the same task lands in the same band across restarts. Exit code 2 means every band is occupied — ask the user to free one.
 
-   | Band | WP | phpMyAdmin | Mailpit inbox | Mailpit SMTP | SFTP |
-   |---|---|---|---|---|---|
-   | 1 | 8080 | 8281 | 1180 | 2525 | 1122 |
-   | 2 | 8090 | 8381 | 1280 | 2626 | 1222 |
-   | 3 | 8100 | 8481 | 1380 | 2727 | 1322 |
-   | 4 | 8110 | 8581 | 1480 | 2828 | 1422 |
+Band map (kept in sync with the script):
 
-3. If all bands are taken, list running instances to the user and ask them to free a slot or pick explicit ports.
-
-Record the chosen ports in `.work-on/env.json` so Mode 3 (implement-only resume) can find them.
+| Band | WP | phpMyAdmin | Mailpit inbox | Mailpit SMTP | SFTP |
+|---|---|---|---|---|---|
+| 1 | 8080 | 8281 | 1180 | 2525 | 1122 |
+| 2 | 8090 | 8381 | 1280 | 2626 | 1222 |
+| 3 | 8100 | 8481 | 1380 | 2727 | 1322 |
+| 4 | 8110 | 8581 | 1480 | 2828 | 1422 |
 
 ## Docker instance tracking
 
 Before creating a new instance:
+
 ```
 docker ps -a --filter 'name=jetpack_' --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'
 ```
-Collisions: ask the user whether to reuse, stop + recreate, or pick a different slug.
+
+Collisions: ask the user to reuse, stop + recreate, or pick a different slug.
 
 ## When to pause and ask
 
-Default is to act, but ALWAYS stop and ask when:
+Default is to act, but stop and ask when:
 - Continuation is detected at preflight.
 - The plan diverges from expectations during implementation.
-- A gate fails twice on the same check (2-cycle limit).
+- A gate fails twice on the same check (the 2-cycle limit).
 - All port bands are occupied.
-- The task turns out to need a live WordPress.com connection — tunnel setup is out of scope.
-- The user hasn't provided a link or slug and the inferred one feels wrong.
+- The task turns out to need a live WordPress.com connection.
+- The inferred slug, project, or scope feels wrong or thin.
 
 Keep each prompt short: one question, give defaults, proceed on the answer.
+
+## Success signals
+
+The skill completed successfully if all of these hold:
+
+- `git branch --show-current` (inside the worktree) equals `change/<slug>`.
+- `git log origin/trunk..HEAD` is non-empty and every commit message is imperative, present-tense, and does NOT contain `Co-Authored-By: Claude` or `Generated with Claude Code`.
+- `gh pr view --json isDraft,state,body` returns `{"isDraft":true,"state":"OPEN"}` and the body contains a "Testing instructions" section.
+- `docker ps --filter name=jetpack_<slug>` lists **no running container** (Phase 11 immediate stop was honored).
+- `git worktree list | grep jetpack-<slug>` still shows the worktree present (deferred cleanup).
+- If the change was visual: `.work-on/screenshots/<slug>-before.png` and `<slug>-after.png` both exist and are >4 KB.
+- If any file under `projects/` changed: a new entry exists in that project's `changelog/` directory.
+- `.work-on/env.json` is valid JSON and round-trips through `jq` without error.
+
+Use these as the "definition of done" when you report back to the user — mention any that didn't hold.
 
 ## Related skills
 - `.agents/skills/jetpack-changelog.md` — Phase 8.
 - `.agents/skills/jetpack-pr.md` — Phase 10.
 - `.agents/skills/jetpack-review-pr.md` — run before requesting a human reviewer.
 
+## Scripts
+- `work-on/scripts/alloc-ports.sh` — port-band allocator.
+- `work-on/scripts/bootstrap-worktree.sh` — worktree + pnpm install + scratchpad.
+
 ## Known limitations / future extensions
-- `/implement <slug>` — a companion skill that assumes a prior `/work-on` bootstrap (picks up from Phase 5 using `.work-on/env.json`). Not yet implemented.
-- Merge-time cleanup hook that removes the worktree + cleans Docker data once the PR merges. Not yet implemented.
-- First-class Jurassic Tube / wp.com-connected flows. Out of scope for now.
+- `/implement <slug>` — companion skill that assumes a prior `/work-on` bootstrap (picks up from Phase 5 using `.work-on/env.json`). Not yet implemented.
+- Merge-time cleanup hook that removes the worktree + cleans Docker data once the PR merges.
+- First-class Jurassic Tube / wp.com-connected flows.

--- a/.agents/skills/work-on/scripts/alloc-ports.sh
+++ b/.agents/skills/work-on/scripts/alloc-ports.sh
@@ -7,7 +7,7 @@
 #
 # Usage:   alloc-ports.sh <slug>
 # Output:  JSON on stdout: {"band":N,"wp":N,"phpmy":N,"inbox":N,"smtp":N,"sftp":N}
-# Exit:    0 ok, 1 bad args, 2 no free band.
+# Exit:    0 ok, 1 bad args, 2 no free band, 3 lsof missing.
 
 set -euo pipefail
 
@@ -26,13 +26,18 @@ bands=(
 	"4 8110 8581 1480 2828 1422"
 )
 
-busy=$(docker ps --format '{{.Ports}}' 2>/dev/null \
-	| grep -oE '[0-9]+->' | cut -d'-' -f1 | sort -un || true)
+# Check real host port availability rather than just docker-forwarded ports:
+# docker ps misses anything bound by other processes (common on a12s' machines,
+# e.g. dev servers on 8080). lsof covers both docker-forwarded and host-bound
+# listeners in one call, and is available by default on macOS and Linux dev envs.
+if ! command -v lsof >/dev/null 2>&1; then
+	echo "alloc-ports.sh: lsof not found — cannot reliably check port availability." >&2
+	exit 3
+fi
 
 is_busy() {
 	local port="$1"
-	[[ -z "$busy" ]] && return 1
-	grep -qxF "$port" <<< "$busy"
+	lsof -iTCP:"$port" -sTCP:LISTEN -nP -t >/dev/null 2>&1
 }
 
 # Deterministic starting band from slug hash.
@@ -50,5 +55,5 @@ for (( i = 0; i < ${#bands[@]}; i++ )); do
 	fi
 done
 
-echo "No free port band. Busy ports: ${busy:-none}" >&2
+echo "No free port band — all candidate ports across bands are in use." >&2
 exit 2

--- a/.agents/skills/work-on/scripts/alloc-ports.sh
+++ b/.agents/skills/work-on/scripts/alloc-ports.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Allocate a free five-port tuple for a parallel `jp docker` instance.
+#
+# Bands are deterministic so repeat runs for the same slug land in the same
+# band when it's free. The script only picks an empty band — it never tries
+# to reuse a partially-occupied one.
+#
+# Usage:   alloc-ports.sh <slug>
+# Output:  JSON on stdout: {"band":N,"wp":N,"phpmy":N,"inbox":N,"smtp":N,"sftp":N}
+# Exit:    0 ok, 1 bad args, 2 no free band.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+	echo "Usage: $0 <slug>" >&2
+	exit 1
+fi
+
+slug="$1"
+
+# Keep in sync with the Port allocation table in work-on.md.
+bands=(
+	"1 8080 8281 1180 2525 1122"
+	"2 8090 8381 1280 2626 1222"
+	"3 8100 8481 1380 2727 1322"
+	"4 8110 8581 1480 2828 1422"
+)
+
+busy=$(docker ps --format '{{.Ports}}' 2>/dev/null \
+	| grep -oE '[0-9]+->' | cut -d'-' -f1 | sort -un || true)
+
+is_busy() {
+	local port="$1"
+	[[ -z "$busy" ]] && return 1
+	grep -qxF "$port" <<< "$busy"
+}
+
+# Deterministic starting band from slug hash.
+slug_hash=$(printf '%s' "$slug" | cksum | cut -d ' ' -f 1)
+start=$(( slug_hash % ${#bands[@]} ))
+
+for (( i = 0; i < ${#bands[@]}; i++ )); do
+	idx=$(( (start + i) % ${#bands[@]} ))
+	read -r band wp phpmy inbox smtp sftp <<< "${bands[$idx]}"
+	if ! is_busy "$wp" && ! is_busy "$phpmy" && ! is_busy "$inbox" \
+	  && ! is_busy "$smtp" && ! is_busy "$sftp"; then
+		printf '{"band":%s,"wp":%s,"phpmy":%s,"inbox":%s,"smtp":%s,"sftp":%s}\n' \
+			"$band" "$wp" "$phpmy" "$inbox" "$smtp" "$sftp"
+		exit 0
+	fi
+done
+
+echo "No free port band. Busy ports: ${busy:-none}" >&2
+exit 2

--- a/.agents/skills/work-on/scripts/bootstrap-worktree.sh
+++ b/.agents/skills/work-on/scripts/bootstrap-worktree.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Bootstrap a Jetpack worktree for /work-on.
+#
+# Creates a new worktree on branch `change/<slug>` branched off origin/trunk,
+# runs pnpm install (frozen lockfile with a graceful fallback when the lock
+# has drifted), seeds `.work-on/screenshots/`, and locally-ignores the
+# `.work-on/` scratchpad. It does NOT write env.json — that belongs to the
+# caller, which knows which ports were allocated.
+#
+# Usage:   bootstrap-worktree.sh <slug> [worktree-parent-dir]
+# Output:  the worktree path on stdout
+# Exit:    0 ok, 1 bad args, 3 target path already exists.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+	echo "Usage: $0 <slug> [worktree-parent-dir]" >&2
+	exit 1
+fi
+
+slug="$1"
+parent="${2:-$(dirname "$(pwd)")}"
+worktree="$parent/jetpack-$slug"
+branch="change/$slug"
+
+if [[ -e "$worktree" ]]; then
+	echo "Path already exists: $worktree" >&2
+	exit 3
+fi
+
+git fetch origin trunk --quiet
+git worktree add "$worktree" -b "$branch" origin/trunk
+
+(
+	cd "$worktree"
+	if ! pnpm install --frozen-lockfile --prefer-offline; then
+		echo "Frozen-lockfile install failed (lockfile likely drifted); retrying without --frozen-lockfile." >&2
+		pnpm install --prefer-offline
+	fi
+	mkdir -p .work-on/screenshots
+	if ! grep -qxF '.work-on/' .git/info/exclude 2>/dev/null; then
+		echo '.work-on/' >> .git/info/exclude
+	fi
+)
+
+echo "$worktree"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,8 @@ jp install plugins/jetpack        # Install project dependencies
 jp clean plugins/jetpack          # Clean build artifacts
 jp docker up -d                   # Start Docker environment
 jp docker install                 # Install WordPress in Docker
+# Parallel instances on a second worktree: `jp docker up -d --name <slug> --port <n> [--port-phpmy/-inbox/-smtp/-sftp <n>]`.
+# See tools/docker/README.md § "Parallel development environments", or use the `/work-on` skill end-to-end.
 jp phan                           # Run PHP static analysis
 ```
 

--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -617,10 +617,17 @@ const defaultDockerCmdHandler = async argv => {
 	}
 
 	// Auto-clone DB from a running source instance when spinning up a parallel one.
-	if ( argv.type === 'dev' && argv._[ 1 ] === 'up' && argv.detached ) {
+	// Gate on the target actually being up rather than on `--detached`: in foreground
+	// mode `composeExecutor` blocks until the user exits compose, at which point the
+	// target is stopped and there's nothing to clone into. Skipping silently in that
+	// case is friendlier than hard-requiring `-d`.
+	if ( argv.type === 'dev' && argv._[ 1 ] === 'up' ) {
 		const cloneReq = resolveCloneSource( argv );
 		if ( cloneReq ) {
-			if ( ! isProjectRunning( cloneReq.source ) ) {
+			const target = getProjectName( argv );
+			if ( ! isProjectRunning( target ) ) {
+				// Target never came up, or compose was foregrounded and already exited.
+			} else if ( ! isProjectRunning( cloneReq.source ) ) {
 				if ( cloneReq.explicit ) {
 					console.error(
 						chalk.red(
@@ -631,7 +638,7 @@ const defaultDockerCmdHandler = async argv => {
 				}
 				// Auto-clone: silent skip — user gets the normal fresh-install flow.
 			} else {
-				await cloneDatabase( argv, cloneReq.source, getProjectName( argv ), envOpts );
+				await cloneDatabase( argv, cloneReq.source, target, envOpts );
 			}
 		}
 	}

--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -10,6 +10,49 @@ import { dockerFolder, setConfig } from '../helpers/docker-config.js';
 let dockerComposeCmd = null;
 
 /**
+ * Normalize and validate a short project name to match Docker Compose rules.
+ *
+ * Compose requires project names to consist of lowercase alphanumeric characters, hyphens,
+ * and underscores, starting with a letter or digit. Uppercase input is auto-lowercased so
+ * `--name Feature` "just works"; anything else throws a clear error early, before compose.
+ *
+ * @param {string} name - User-supplied short name (e.g. from --name or --clone-from).
+ * @return {string} Normalized (lowercased) short name.
+ */
+export const normalizeProjectShortName = name => {
+	const original = String( name );
+	const normalized = original.toLowerCase();
+	if ( ! /^[a-z0-9][a-z0-9_-]*$/.test( normalized ) ) {
+		throw new Error(
+			`Invalid project name '${ original }'. Use only lowercase letters, digits, '-' and '_' (must start with a letter or digit).`
+		);
+	}
+	return normalized;
+};
+
+/**
+ * Build a yargs `coerce` handler that normalizes a project short-name option and prints
+ * a friendly note when it had to lowercase the input.
+ *
+ * @param {string} flag - The user-facing flag label (e.g. '--name').
+ * @return {Function} yargs coerce function.
+ */
+const coerceProjectShortName = flag => value => {
+	if ( value === undefined || value === null || value === '' ) {
+		return value;
+	}
+	const normalized = normalizeProjectShortName( value );
+	if ( normalized !== String( value ) ) {
+		console.warn(
+			chalk.yellow(
+				`Note: ${ flag } '${ value }' was normalized to '${ normalized }' (compose project names must be lowercase).`
+			)
+		);
+	}
+	return normalized;
+};
+
+/**
  * Sets default options that are common for most of the commands
  *
  * @param {object} yargs - Yargs
@@ -25,6 +68,7 @@ const defaultOpts = yargs =>
 		.option( 'name', {
 			alias: 'n',
 			describe: 'Project name',
+			coerce: coerceProjectShortName( '--name' ),
 		} )
 		.option( 'port', {
 			alias: 'p',
@@ -46,6 +90,7 @@ const defaultOpts = yargs =>
 			type: 'string',
 			describe:
 				'Clone the database from an existing running instance (short name, e.g. --clone-from dev). When omitted but --name is set, the default jetpack_dev instance is used automatically if running.',
+			coerce: coerceProjectShortName( '--clone-from' ),
 		} )
 		.option( 'clone', {
 			type: 'boolean',

--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -42,6 +42,17 @@ const defaultOpts = yargs =>
 		.option( 'port-sftp', {
 			describe: 'SFTP port',
 		} )
+		.option( 'clone-from', {
+			type: 'string',
+			describe:
+				'Clone the database from an existing running instance (short name, e.g. --clone-from dev). When omitted but --name is set, the default jetpack_dev instance is used automatically if running.',
+		} )
+		.option( 'clone', {
+			type: 'boolean',
+			default: true,
+			describe:
+				'Auto-clone the database from jetpack_dev when spinning up a parallel instance with --name. Use --no-clone to opt out and get a fresh install instead.',
+		} )
 		.option( 'ngrok', {
 			type: 'boolean',
 			describe: 'Flag to launch ngrok process',
@@ -105,6 +116,168 @@ export const buildEnv = argv => {
  */
 const setEnv = () => {
 	fs.closeSync( fs.openSync( `${ dockerFolder }/.env`, 'a' ) );
+};
+
+/**
+ * Decides which source instance to clone the DB from, if any.
+ *
+ * Purely argv-driven; whether the chosen source is actually running is checked by the caller.
+ *
+ * @param {object} argv - Yargs
+ * @return {{source: string, explicit: boolean} | null} Source compose project name and whether the user asked for it by name, or null to skip cloning.
+ */
+export const resolveCloneSource = argv => {
+	if ( argv.cloneFrom ) {
+		return { source: 'jetpack_' + argv.cloneFrom, explicit: true };
+	}
+	if ( argv.clone === false ) {
+		return null;
+	}
+	// Auto-clone only makes sense when the user is spinning up a parallel instance.
+	if ( ! argv.name ) {
+		return null;
+	}
+	const source = 'jetpack_dev';
+	if ( getProjectName( argv ) === source ) {
+		return null;
+	}
+	return { source, explicit: false };
+};
+
+/**
+ * Check whether a given compose project has at least one running container.
+ *
+ * @param {string} project - Compose project name (e.g. 'jetpack_dev').
+ * @return {boolean} true when any container for the project is currently running.
+ */
+const isProjectRunning = project => {
+	const res = spawnSync(
+		'docker',
+		[ 'ps', '-q', '--filter', `label=com.docker.compose.project=${ project }` ],
+		{ encoding: 'utf8' }
+	);
+	return res.status === 0 && res.stdout.trim().length > 0;
+};
+
+/**
+ * Clone the database of a running source instance into a freshly-started target instance.
+ *
+ * Waits for the target's WordPress container to be ready, then skips if the target is already
+ * installed, resets the target DB, pipes `wp db export` from source → `wp db import` into
+ * target, and runs `wp search-replace` to rewrite the source siteurl to the target URL.
+ *
+ * @param {object} argv      - Yargs
+ * @param {string} source    - Source compose project name (e.g. 'jetpack_dev').
+ * @param {string} target    - Target compose project name (e.g. 'jetpack_feature').
+ * @param {object} targetEnv - ENV map for the target (used to compute target port).
+ */
+const cloneDatabase = async ( argv, source, target, targetEnv ) => {
+	const sourceWp = `${ source }-wordpress-1`;
+	const targetWp = `${ target }-wordpress-1`;
+	const wpPath = '/var/www/html';
+
+	console.log( chalk.cyan( `Cloning database: ${ source } → ${ target }` ) );
+
+	// Wait for the target's WP container + DB to be reachable via wp-cli.
+	try {
+		await retry(
+			async () => {
+				const res = spawnSync(
+					'docker',
+					[ 'exec', targetWp, 'wp', 'db', 'check', `--path=${ wpPath }` ],
+					{
+						stdio: 'ignore',
+					}
+				);
+				if ( res.status !== 0 ) {
+					throw new Error( 'target not ready' );
+				}
+			},
+			{ times: 24, delay: 5000 }
+		);
+	} catch {
+		console.error(
+			chalk.red( `Target ${ target } did not become ready in time. Aborting clone.` )
+		);
+		process.exit( 1 );
+	}
+
+	// If the target is already installed (e.g. the user re-ran `up` on a working instance), do nothing.
+	const installedCheck = spawnSync(
+		'docker',
+		[ 'exec', targetWp, 'wp', 'core', 'is-installed', `--path=${ wpPath }` ],
+		{ stdio: 'ignore' }
+	);
+	if ( installedCheck.status === 0 ) {
+		console.log(
+			chalk.yellow( `Target ${ target } already has an installed WordPress — skipping clone.` )
+		);
+		return;
+	}
+
+	// Read the source siteurl so search-replace can rewrite it afterwards.
+	const siteurlRes = spawnSync(
+		'docker',
+		[ 'exec', sourceWp, 'wp', 'option', 'get', 'siteurl', `--path=${ wpPath }` ],
+		{ encoding: 'utf8' }
+	);
+	if ( siteurlRes.status !== 0 ) {
+		console.error(
+			chalk.red(
+				`Could not read siteurl from source ${ source }. Is it installed? (try \`jetpack docker install\` there first)`
+			)
+		);
+		process.exit( 1 );
+	}
+	const sourceSiteUrl = siteurlRes.stdout.trim();
+
+	const targetPort = String( targetEnv.PORT_WORDPRESS || 80 );
+	const targetSiteUrl =
+		targetPort === '80' ? 'http://localhost' : `http://localhost:${ targetPort }`;
+
+	// Reset the target DB so import doesn't collide with the minimal tables compose may have created.
+	checkProcessResult(
+		spawnSync( 'docker', [ 'exec', targetWp, 'wp', 'db', 'reset', '--yes', `--path=${ wpPath }` ], {
+			stdio: 'inherit',
+		} )
+	);
+
+	console.log( chalk.cyan( 'Dumping source DB and importing into target…' ) );
+	const pipe = spawnSync(
+		'bash',
+		[
+			'-c',
+			'docker exec "$1" wp db export - --path="$3" | docker exec -i "$2" wp db import - --path="$3"',
+			'--',
+			sourceWp,
+			targetWp,
+			wpPath,
+		],
+		{ stdio: 'inherit' }
+	);
+	checkProcessResult( pipe );
+
+	if ( sourceSiteUrl !== targetSiteUrl ) {
+		console.log( chalk.cyan( `Rewriting URLs: ${ sourceSiteUrl } → ${ targetSiteUrl }` ) );
+		const sr = spawnSync(
+			'docker',
+			[
+				'exec',
+				targetWp,
+				'wp',
+				'search-replace',
+				sourceSiteUrl,
+				targetSiteUrl,
+				'--all-tables',
+				'--skip-columns=guid',
+				`--path=${ wpPath }`,
+			],
+			{ stdio: 'inherit' }
+		);
+		checkProcessResult( sr );
+	}
+
+	console.log( chalk.green( `Clone complete. Target site ready at ${ targetSiteUrl }/` ) );
 };
 
 /**
@@ -396,6 +569,26 @@ const defaultDockerCmdHandler = async argv => {
 		};
 
 		await retry( getContent, { times: 24 } ); // 24 * 5000 = 120 sec
+	}
+
+	// Auto-clone DB from a running source instance when spinning up a parallel one.
+	if ( argv.type === 'dev' && argv._[ 1 ] === 'up' && argv.detached ) {
+		const cloneReq = resolveCloneSource( argv );
+		if ( cloneReq ) {
+			if ( ! isProjectRunning( cloneReq.source ) ) {
+				if ( cloneReq.explicit ) {
+					console.error(
+						chalk.red(
+							`--clone-from source '${ cloneReq.source }' is not running. Start it first, or omit --clone-from.`
+						)
+					);
+					process.exit( 1 );
+				}
+				// Auto-clone: silent skip — user gets the normal fresh-install flow.
+			} else {
+				await cloneDatabase( argv, cloneReq.source, getProjectName( argv ), envOpts );
+			}
+		}
 	}
 	printPostCmdMsg( argv );
 };

--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -30,6 +30,18 @@ const defaultOpts = yargs =>
 			alias: 'p',
 			describe: 'WP port',
 		} )
+		.option( 'port-phpmy', {
+			describe: 'phpMyAdmin port',
+		} )
+		.option( 'port-inbox', {
+			describe: 'Mailpit web UI port',
+		} )
+		.option( 'port-smtp', {
+			describe: 'Mailpit SMTP port',
+		} )
+		.option( 'port-sftp', {
+			describe: 'SFTP port',
+		} )
 		.option( 'ngrok', {
 			type: 'boolean',
 			describe: 'Flag to launch ngrok process',
@@ -41,10 +53,10 @@ const defaultOpts = yargs =>
  * @param {object} argv - Yargs
  * @return {string} Project name
  */
-const getProjectName = argv => {
-	let project = 'dev';
-	if ( argv.type === 'e2e' ) {
-		project = argv.name ? argv.name : 'e2e';
+export const getProjectName = argv => {
+	let project = argv.type === 'e2e' ? 'e2e' : 'dev';
+	if ( argv.name ) {
+		project = argv.name;
 	}
 
 	return 'jetpack_' + project;
@@ -56,10 +68,25 @@ const getProjectName = argv => {
  * @param {object} argv - Yargs
  * @return {object} key-value pairs of ENV variables
  */
-const buildEnv = argv => {
+export const buildEnv = argv => {
 	const envOpts = {};
-	if ( argv.type === 'e2e' ) {
-		envOpts.PORT_WORDPRESS = argv.port ? argv.port : 8889;
+	if ( argv.port ) {
+		envOpts.PORT_WORDPRESS = argv.port;
+	} else if ( argv.type === 'e2e' ) {
+		envOpts.PORT_WORDPRESS = 8889;
+	}
+
+	if ( argv.portPhpmy ) {
+		envOpts.PORT_PHPMY = argv.portPhpmy;
+	}
+	if ( argv.portInbox ) {
+		envOpts.PORT_INBOX = argv.portInbox;
+	}
+	if ( argv.portSmtp ) {
+		envOpts.PORT_SMTP = argv.portSmtp;
+	}
+	if ( argv.portSftp ) {
+		envOpts.PORT_SFTP = argv.portSftp;
 	}
 
 	envOpts.COMPOSE_PROJECT_NAME = getProjectName( argv );
@@ -109,7 +136,7 @@ const printPostCmdMsg = argv => {
 		return;
 	}
 	if ( argv._[ 1 ] === 'up' ) {
-		const port = argv.port ? argv.port : '';
+		const port = argv.port ? `:${ argv.port }` : '';
 		const msg = chalk.green( `Open http://localhost${ port }/ to see your site!` );
 		console.log( msg );
 	}

--- a/tools/cli/tests/unit/commands/docker.test.js
+++ b/tools/cli/tests/unit/commands/docker.test.js
@@ -13,7 +13,7 @@ jest.unstable_mockModule( 'fs', () => ( {
 	...fsStub,
 } ) );
 
-const { getProjectName, buildEnv, resolveCloneSource } = await import(
+const { getProjectName, buildEnv, resolveCloneSource, normalizeProjectShortName } = await import(
 	'../../../commands/docker.js'
 );
 
@@ -121,5 +121,32 @@ describe( 'resolveCloneSource', () => {
 
 	test( 'returns null when target would be the same as source (--name dev)', () => {
 		expect( resolveCloneSource( { type: 'dev', name: 'dev', clone: true } ) ).toBeNull();
+	} );
+} );
+
+describe( 'normalizeProjectShortName', () => {
+	test( 'lowercases mixed-case input', () => {
+		expect( normalizeProjectShortName( 'Feature' ) ).toBe( 'feature' );
+		expect( normalizeProjectShortName( 'MyTask' ) ).toBe( 'mytask' );
+		expect( normalizeProjectShortName( 'cloneTest' ) ).toBe( 'clonetest' );
+	} );
+
+	test( 'passes through already-valid names', () => {
+		expect( normalizeProjectShortName( 'feature' ) ).toBe( 'feature' );
+		expect( normalizeProjectShortName( 'my-task_2' ) ).toBe( 'my-task_2' );
+		expect( normalizeProjectShortName( '42-branch' ) ).toBe( '42-branch' );
+	} );
+
+	test( 'throws on invalid characters', () => {
+		expect( () => normalizeProjectShortName( 'my feature' ) ).toThrow( /Invalid project name/ );
+		expect( () => normalizeProjectShortName( 'foo/bar' ) ).toThrow( /Invalid project name/ );
+		expect( () => normalizeProjectShortName( 'dots.in.name' ) ).toThrow( /Invalid project name/ );
+	} );
+
+	test( 'throws when name starts with a non-alphanumeric character', () => {
+		expect( () => normalizeProjectShortName( '-leading-dash' ) ).toThrow( /Invalid project name/ );
+		expect( () => normalizeProjectShortName( '_leading-underscore' ) ).toThrow(
+			/Invalid project name/
+		);
 	} );
 } );

--- a/tools/cli/tests/unit/commands/docker.test.js
+++ b/tools/cli/tests/unit/commands/docker.test.js
@@ -1,0 +1,83 @@
+import { jest } from '@jest/globals';
+
+const fsStub = {
+	readFileSync: () => '',
+	writeFileSync: () => {},
+	existsSync: () => false,
+	mkdirSync: () => {},
+	closeSync: () => {},
+	openSync: () => 0,
+};
+jest.unstable_mockModule( 'fs', () => ( {
+	default: fsStub,
+	...fsStub,
+} ) );
+
+const { getProjectName, buildEnv } = await import( '../../../commands/docker.js' );
+
+describe( 'getProjectName', () => {
+	test( 'defaults to jetpack_dev for dev type with no name', () => {
+		expect( getProjectName( { type: 'dev' } ) ).toBe( 'jetpack_dev' );
+	} );
+
+	test( 'defaults to jetpack_e2e for e2e type with no name', () => {
+		expect( getProjectName( { type: 'e2e' } ) ).toBe( 'jetpack_e2e' );
+	} );
+
+	test( 'honors --name for dev type', () => {
+		expect( getProjectName( { type: 'dev', name: 'feature' } ) ).toBe( 'jetpack_feature' );
+	} );
+
+	test( 'honors --name for e2e type', () => {
+		expect( getProjectName( { type: 'e2e', name: 'custom' } ) ).toBe( 'jetpack_custom' );
+	} );
+} );
+
+describe( 'buildEnv', () => {
+	test( 'omits PORT_WORDPRESS for dev type when --port not set', () => {
+		const env = buildEnv( { type: 'dev' } );
+		expect( env.PORT_WORDPRESS ).toBeUndefined();
+		expect( env.COMPOSE_PROJECT_NAME ).toBe( 'jetpack_dev' );
+	} );
+
+	test( 'defaults PORT_WORDPRESS to 8889 for e2e without --port', () => {
+		const env = buildEnv( { type: 'e2e' } );
+		expect( env.PORT_WORDPRESS ).toBe( 8889 );
+	} );
+
+	test( 'honors --port for dev type', () => {
+		const env = buildEnv( { type: 'dev', port: 8080 } );
+		expect( env.PORT_WORDPRESS ).toBe( 8080 );
+	} );
+
+	test( '--port overrides the e2e default', () => {
+		const env = buildEnv( { type: 'e2e', port: 9000 } );
+		expect( env.PORT_WORDPRESS ).toBe( 9000 );
+	} );
+
+	test( 'passes auxiliary port flags through as env vars', () => {
+		const env = buildEnv( {
+			type: 'dev',
+			name: 'feature',
+			port: 8080,
+			portPhpmy: 8281,
+			portInbox: 1180,
+			portSmtp: 2525,
+			portSftp: 1122,
+		} );
+		expect( env.COMPOSE_PROJECT_NAME ).toBe( 'jetpack_feature' );
+		expect( env.PORT_WORDPRESS ).toBe( 8080 );
+		expect( env.PORT_PHPMY ).toBe( 8281 );
+		expect( env.PORT_INBOX ).toBe( 1180 );
+		expect( env.PORT_SMTP ).toBe( 2525 );
+		expect( env.PORT_SFTP ).toBe( 1122 );
+	} );
+
+	test( 'omits auxiliary port env vars when flags are not set', () => {
+		const env = buildEnv( { type: 'dev' } );
+		expect( env.PORT_PHPMY ).toBeUndefined();
+		expect( env.PORT_INBOX ).toBeUndefined();
+		expect( env.PORT_SMTP ).toBeUndefined();
+		expect( env.PORT_SFTP ).toBeUndefined();
+	} );
+} );

--- a/tools/cli/tests/unit/commands/docker.test.js
+++ b/tools/cli/tests/unit/commands/docker.test.js
@@ -13,7 +13,9 @@ jest.unstable_mockModule( 'fs', () => ( {
 	...fsStub,
 } ) );
 
-const { getProjectName, buildEnv } = await import( '../../../commands/docker.js' );
+const { getProjectName, buildEnv, resolveCloneSource } = await import(
+	'../../../commands/docker.js'
+);
 
 describe( 'getProjectName', () => {
 	test( 'defaults to jetpack_dev for dev type with no name', () => {
@@ -79,5 +81,45 @@ describe( 'buildEnv', () => {
 		expect( env.PORT_INBOX ).toBeUndefined();
 		expect( env.PORT_SMTP ).toBeUndefined();
 		expect( env.PORT_SFTP ).toBeUndefined();
+	} );
+} );
+
+describe( 'resolveCloneSource', () => {
+	test( 'returns null when --name is not set (primary dev instance path)', () => {
+		expect( resolveCloneSource( { type: 'dev', clone: true } ) ).toBeNull();
+	} );
+
+	test( 'auto-picks jetpack_dev when --name is set', () => {
+		expect( resolveCloneSource( { type: 'dev', name: 'feature', clone: true } ) ).toEqual( {
+			source: 'jetpack_dev',
+			explicit: false,
+		} );
+	} );
+
+	test( '--no-clone (clone=false) short-circuits auto-clone', () => {
+		expect( resolveCloneSource( { type: 'dev', name: 'feature', clone: false } ) ).toBeNull();
+	} );
+
+	test( '--clone-from wins over --no-clone', () => {
+		expect(
+			resolveCloneSource( { type: 'dev', name: 'feature', clone: false, cloneFrom: 'other' } )
+		).toEqual( { source: 'jetpack_other', explicit: true } );
+	} );
+
+	test( '--clone-from works without --name (explicit wins over auto gating)', () => {
+		expect( resolveCloneSource( { type: 'dev', clone: true, cloneFrom: 'other' } ) ).toEqual( {
+			source: 'jetpack_other',
+			explicit: true,
+		} );
+	} );
+
+	test( '--clone-from normalizes short name to full project name', () => {
+		expect(
+			resolveCloneSource( { type: 'dev', name: 'feature', clone: true, cloneFrom: 'scratch' } )
+		).toEqual( { source: 'jetpack_scratch', explicit: true } );
+	} );
+
+	test( 'returns null when target would be the same as source (--name dev)', () => {
+		expect( resolveCloneSource( { type: 'dev', name: 'dev', clone: true } ) ).toBeNull();
 	} );
 } );

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -147,6 +147,87 @@ jetpack docker down
 
 Will stop all of the containers created by this Docker compose configuration and remove them, too. It won’t remove the images. Just the containers that have just been stopped.
 
+### Parallel development environments
+
+You can run a second (or third, …) Jetpack Docker instance alongside your main one so that parallel work on different branches doesn't require tearing down your primary environment. The typical setup is: one checkout running `jetpack_dev`, plus one or more [git worktrees](https://git-scm.com/docs/git-worktree) each running their own named instance on non-default ports.
+
+#### Spinning up a parallel instance
+
+From your second checkout/worktree, pass `--name` and a free set of ports:
+
+```sh
+jetpack docker up -d \
+  --name feature \
+  --port 8080 \
+  --port-phpmy 8281 \
+  --port-inbox 1180 \
+  --port-smtp 2525 \
+  --port-sftp 1122
+```
+
+This gives you `jetpack_feature-*` containers running in parallel with `jetpack_dev-*`. Each instance gets its own database, its own volumes, and its own MailPit inbox.
+
+#### Flags
+
+| Flag | Applies to | Default | Description |
+|------|-----------|---------|-------------|
+| `--name <name>` | `dev`, `e2e` | `dev` (or `e2e`) | Compose project name suffix, used for isolation. Containers become `jetpack_<name>-*`. |
+| `--port <n>` | `dev`, `e2e` | `80` (`8889` for `e2e`) | Host port mapped to the WordPress container. |
+| `--port-phpmy <n>` | all | `8181` | Host port for phpMyAdmin. |
+| `--port-inbox <n>` | all | `1080` | Host port for the MailPit web UI. |
+| `--port-smtp <n>` | all | `25` | Host port for the MailPit SMTP server. |
+| `--port-sftp <n>` | all | `1022` | Host port for the SFTP container. |
+| `--clone-from <name>` | `dev` + `up` | — | Clone the DB from an existing running instance (e.g. `--clone-from dev`). The target site ends up with an installed WordPress populated from the source. |
+| `--no-clone` | `dev` + `up` | (auto-clone on) | Opt out of auto-cloning and get the default fresh-install flow instead. |
+
+#### Auto-clone behavior
+
+When you spin up a parallel instance with `--name <foo>`, by default the CLI will automatically clone the database from `jetpack_dev` if it's running. The goal is that `jetpack docker up -d --name feature --port 8080` gives you a fully working site at `http://localhost:8080/` with the same content, users, and Jetpack connection as your main instance — no separate `jetpack docker install` or reconnection needed.
+
+The auto-clone is only triggered when all of the following are true:
+
+* `--name` is set (i.e. you're creating a parallel instance — never on the primary `jetpack docker up`).
+* `jetpack_dev` has at least one running container.
+* `--no-clone` was not passed.
+* The target doesn't already have an installed WordPress (re-running `up` on an existing instance is a safe no-op).
+
+The clone runs `wp db export | wp db import` between the source and target containers, then `wp search-replace` on the target to rewrite the siteurl to `http://localhost:<target-port>`. `guid` columns are skipped as WP-CLI recommends.
+
+For explicit control:
+
+```sh
+# Clone from a specific source (not just jetpack_dev)
+jetpack docker up -d --name staging --port 8082 --clone-from feature
+
+# Opt out of cloning; get a fresh, uninstalled WordPress and run install yourself
+jetpack docker up -d --name clean --port 8090 --no-clone
+jetpack docker install --name clean --port 8090
+```
+
+#### Cleaning up a parallel instance
+
+```sh
+# Stop the instance (containers remain, can be resumed with `up -d` later)
+jetpack docker stop --name feature
+
+# Stop and remove containers
+jetpack docker down --name feature
+
+# Nuke everything for that instance: containers, volumes, MySQL data, logs
+jetpack docker clean --name feature
+
+# If you used a git worktree for this instance, remove it when you're done
+git worktree remove ../jetpack-feature
+```
+
+Each of the above needs the same `--name` you used when bringing the instance up. The primary `jetpack_dev` instance is untouched.
+
+#### Notes & gotchas
+
+* The `mailpit` container is no longer globally named — each instance gets its own `jetpack_<name>-mailpit-1`. Internal SMTP routing still uses the compose service name `mailpit`, so PHP mail from within any container routes to that instance's MailPit.
+* WordPress's `WP_SITEURL` / `WP_HOME` are dynamic via `HTTP_HOST`, so the same DB will happily serve requests on both the source and target ports after cloning. In practice this means your Jetpack connection works across instances on different localhost ports without reconnecting.
+* `e2e` keeps its defaults (`jetpack_e2e`, port `8889`) when no flags are passed — parallel-mode flags don't affect the e2e workflow.
+
 ### Running unit tests
 
 These commands require the WordPress container to be running.

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -177,7 +177,7 @@ This gives you `jetpack_feature-*` containers running in parallel with `jetpack_
 | `--port-inbox <n>` | all | `1080` | Host port for the MailPit web UI. |
 | `--port-smtp <n>` | all | `25` | Host port for the MailPit SMTP server. |
 | `--port-sftp <n>` | all | `1022` | Host port for the SFTP container. |
-| `--clone-from <name>` | `dev` + `up` | — | Clone the DB from an existing running instance (e.g. `--clone-from dev`). The target site ends up with an installed WordPress populated from the source. |
+| `--clone-from <name>` | `dev` + `up` | — | Clone the DB from an existing running instance (e.g. `--clone-from feature`). The target site ends up with an installed WordPress populated from the source. |
 | `--no-clone` | `dev` + `up` | (auto-clone on) | Opt out of auto-cloning and get the default fresh-install flow instead. |
 
 #### Auto-clone behavior

--- a/tools/docker/bin/install.sh
+++ b/tools/docker/bin/install.sh
@@ -20,10 +20,16 @@ if wp core is-installed; then
 	exit
 fi
 
+# Build the install URL, appending HOST_PORT when it's not the default 80.
+WP_URL="http://${WP_DOMAIN}"
+if [[ -n "$HOST_PORT" && "$HOST_PORT" != "80" ]]; then
+	WP_URL="${WP_URL}:${HOST_PORT}"
+fi
+
 # Install WP core
 echo 'Configuring WordPress...'
 wp core install \
-	--url="${WP_DOMAIN}" \
+	--url="${WP_URL}" \
 	--title="${WP_TITLE}" \
 	--admin_user="${WP_ADMIN_USER}" \
 	--admin_password="${WP_ADMIN_PASSWORD}" \
@@ -69,5 +75,5 @@ wp plugin is-active jetpack || wp plugin activate jetpack | sed 's/^/    /'
 echo
 echo 'Your site is ready! You can see it here:'
 echo
-echo "    http://${WP_DOMAIN}:${PORT_WORDPRESS}"
+echo "    ${WP_URL}"
 echo

--- a/tools/docker/jetpack-docker-config-default.yml
+++ b/tools/docker/jetpack-docker-config-default.yml
@@ -31,7 +31,6 @@ dev:
       ## https://mailpit.axllent.org/
       mailpit:
         image: axllent/mailpit
-        container_name: mailpit
         ports:
           - '${PORT_INBOX:-1080}:8025'
           - '${PORT_SMTP:-25}:1025'


### PR DESCRIPTION
Fixes # <!-- no ticket; internal infra improvement -->

## Proposed changes

Enables running two (or more) Jetpack monorepo Docker environments side by side from separate worktrees, so parallel work on different branches no longer requires swapping/tearing down the main dev container. A parallel instance auto-clones its DB from `jetpack_dev` at boot so it's immediately usable — no separate install or Jetpack reconnection dance.

* **CLI — `tools/cli/commands/docker.js`**
  * Honor `--name` for the `dev` container type (previously only `e2e` respected it), so a worktree can run as e.g. `jetpack_feature_*` without clobbering `jetpack_dev_*`.
  * Honor `--port` for the `dev` container type.
  * Add `--port-phpmy`, `--port-inbox`, `--port-smtp`, `--port-sftp` flags so the auxiliary services can be moved off their default ports when booting a second instance.
  * Add `--clone-from <name>` and `--no-clone`: when `--name` is set on `up -d`, the CLI now auto-clones the DB from a running `jetpack_dev` into the fresh target (via `wp db export | wp db import`, then `wp search-replace` to rewrite the siteurl to the target's `localhost:<port>`). Auto-clone is gated so it only triggers when spinning up a parallel instance, the source is running, and the target isn't already installed — the primary `jetpack docker up` flow is unchanged.
  * Fix the post-up message: `http://localhost${port}/` → `http://localhost:${port}/` (the colon was missing when `--port` was used).
  * Export `getProjectName`, `buildEnv`, and `resolveCloneSource` for unit testing.
* **Compose defaults — `tools/docker/jetpack-docker-config-default.yml`**
  * Drop the hardcoded `container_name: mailpit`. That identifier was global across Docker and blocked a second instance from bringing up its own mailpit service. With it removed, each project gets its own `<project>_mailpit_1` container, matching every other service. Internal SMTP routing is unaffected because `tools/docker/config/ssmtp.conf` references the compose service name `mailpit`, which resolves via the per-project network DNS.
* **Install script — `tools/docker/bin/install.sh`**
  * Build the install URL from `WP_DOMAIN` + `HOST_PORT` so `wp core install --url=…` stores the correct `siteurl`/`home` in the DB when a non-default port is used.
  * Replace the final "Your site is ready" line's reference to `${PORT_WORDPRESS}` (not actually forwarded into the container env) with the same computed URL.
* **Docs — `tools/docker/README.md`**
  * New **Parallel development environments** section documenting the flags, the auto-clone behavior (when it triggers, when it doesn't), explicit `--clone-from` / `--no-clone` usage, and cleanup (`stop` / `down` / `clean --name`, `git worktree remove`).
* **Tests — `tools/cli/tests/unit/commands/docker.test.js`**
  * 17 unit tests total covering the `--name` / `--port` matrix for both `dev` and `e2e`, the auxiliary port flags, and the full `resolveCloneSource` decision matrix (auto, `--no-clone`, explicit `--clone-from`, same-source guard, short-name normalization).
* **Skill — `.agents/skills/work-on.md`** (new)
  * Team-shared workflow skill built on top of the parallel-environment flags above. Takes a task prompt and drives it to a draft PR on its own worktree + `jp docker` instance (isolated from `jetpack_dev`): plans, spawns the environment, implements, runs build / test / phan gates, captures before/after screenshots for visual changes, generates a changelog entry when needed, and opens the draft PR. Ships with the CLI changes because it can't function without them.

## Related product discussion/links
<!-- internal: follow-up to a P2 about parallel worktree dev; no external links. -->

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

### Quick version — confirm no regressions on the single-instance flow

1. From the repo root: `jetpack docker up -d`
2. Open `http://localhost/` — site loads as usual.
3. Open `http://localhost:1080/` — Mailpit UI loads.
4. `docker ps` — note the mail container is now `jetpack_dev-mailpit-1` (previously just `mailpit`). All other container names are unchanged.
5. `jetpack docker stop` — everything stops cleanly.

### Two-instance parallel test (the feature)

The primary case the PR exists for: spin up a second instance that's immediately usable (auto-cloned from your installed `jetpack_dev`).

1. Make sure your primary `jetpack_dev` is up **and installed** (auto-clone reads from it):
   ```
   jetpack docker up -d
   jetpack docker install   # if not already installed
   ```
   Instance A serves on port 80, phpMyAdmin 8181, Mailpit 1080.
2. *(Optional)* Create a second worktree so you can use a different branch — not required for a smoke test:
   ```
   git worktree add --detach ../jetpack-smoke <this PR branch>
   cd ../jetpack-smoke
   pnpm install --frozen-lockfile --prefer-offline
   ```
3. **Boot the parallel instance** (`--name` is auto-lowercased if you pass mixed case, with a one-line notice):
   ```
   jetpack docker up -d \
     --name smoke \
     --port 8080 \
     --port-phpmy 8281 \
     --port-inbox 1180 \
     --port-smtp 2525 \
     --port-sftp 1122
   ```
   Expected output ends with:
   ```
   Cloning database: jetpack_dev → jetpack_smoke
   Dumping source DB and importing into target…
   Rewriting URLs: http://localhost → http://localhost:8080
   Success: Made N replacements.
   Clone complete. Target site ready at http://localhost:8080/
   ```
   You do **not** need to run `jetpack docker install --name smoke` — the site is already installed via the clone.
4. **Verify parallel operation**:
   * `docker ps` shows **both** sets of containers (`jetpack_dev-*` and `jetpack_smoke-*`) running simultaneously, ten containers total, no collisions.
   * `curl -sI http://localhost/` returns 200.
   * `curl -sI http://localhost:8080/` returns 200.
   * Both Mailpit UIs reachable at `http://localhost:1080/` and `http://localhost:1180/`.
   * `docker exec jetpack_smoke-wordpress-1 wp post list --path=/var/www/html --format=count` matches the same command against `jetpack_dev-wordpress-1` (clone copied all posts).
   * `docker exec jetpack_smoke-wordpress-1 wp db query "SELECT option_value FROM wp_options WHERE option_name='siteurl'" --path=/var/www/html` returns `http://localhost:8080` (the search-replace rewrote it; `wp option get siteurl` may report `http://localhost` because Jetpack's `wp-config.php` computes it from `$_SERVER['HTTP_HOST']` at runtime — both behaviors are correct).
5. **Verify the clone is a snapshot, not a live sync** (instances remain independent after boot):
   ```
   docker exec jetpack_dev-wordpress-1 wp option update smoke_test A --path=/var/www/html
   docker exec jetpack_dev-wordpress-1 wp option get smoke_test --path=/var/www/html   # → A
   docker exec jetpack_smoke-wordpress-1 wp option get smoke_test --path=/var/www/html # → not found
   docker exec jetpack_dev-wordpress-1 wp option delete smoke_test --path=/var/www/html
   ```
6. **Verify login on the parallel instance using your `jetpack_dev` credentials** (they're cloned, not the `default.env` ones):
   * Open `http://localhost:8080/wp-login.php`.
   * Log in with the admin user/password you use on `http://localhost/`.
   * `/wp-admin/` loads authenticated. The connected Jetpack account (if any) also carries over — one connection, two URLs, no reconnection needed.
7. **Teardown**:
   ```
   jetpack docker down --name smoke         # or `jetpack docker clean --name smoke` to also wipe data
   # If you made a worktree:
   git worktree remove --force ../jetpack-smoke
   ```

### Clone-behavior matrix

Worth sanity-checking each branch once:

| Invocation | Expected |
|---|---|
| `jetpack docker up -d` (no `--name`) | Unchanged — fresh install on `jetpack_dev`. No clone attempt. |
| `jetpack docker up -d --name foo --port 8090` with `jetpack_dev` **running** | Auto-clone from `jetpack_dev`. Site at `:8090` immediately usable. |
| `jetpack docker up -d --name foo --port 8090` with `jetpack_dev` **not running** | Auto-clone silently skipped. Fresh install flow — run `jetpack docker install --name foo --port 8090` to finish. |
| `jetpack docker up -d --name foo --port 8090 --no-clone` | Fresh, uninstalled WordPress. `jetpack docker install --name foo --port 8090` required afterwards. |
| `jetpack docker up -d --name foo --port 8090 --clone-from staging` | Clone from `jetpack_staging`. If `jetpack_staging` isn't running, the command errors out cleanly ("`--clone-from source 'jetpack_staging' is not running`") and exits non-zero. |
| Re-running `up -d --name foo --port 8090` on an already-cloned instance | Clone is skipped (target already installed), prints `Target jetpack_foo already has an installed WordPress — skipping clone.` |

### Regression notes to pay attention to

* **Primary `jetpack docker up` (no `--name`) never triggers auto-clone** — the main dev flow is completely unchanged. Auto-clone is gated on `--name` being set.
* **E2E environment** still defaults to `jetpack_e2e` project name and port 8889 when no flags are passed — `jetpack docker up -t e2e` should behave exactly as before. Covered by the new unit tests (`getProjectName`/`buildEnv` matrix).
* **Mailpit container rename** is the one behavioural change on the default flow: anything referring to the container by the literal name `mailpit` (rather than the service name, which is the usual compose way) will need to use `jetpack_dev-mailpit-1` instead. `ssmtp.conf` already uses the service name, so PHP mail in the container routes correctly without change.
* **Post-up URL message** now prints `http://localhost:8080/` when `--port 8080` is passed (previously printed `http://localhost8080/`, which was a harmless display bug).
* **`--name` / `--clone-from` are auto-normalized**: passing mixed case (e.g. `--name Feature`) is lowercased automatically with a one-line notice. Truly invalid characters (spaces, slashes, dots, leading `-`/`_`) error out cleanly before the command reaches compose.
