### PR TITLE
Publicize: Migrate Connect accounts button to @wordpress/ui Button (first #48152 slice)

### DIFF
--- a/.agents/skills/work-on.md
+++ b/.agents/skills/work-on.md
@@ -1,0 +1,260 @@
+---
+description: End-to-end workflow from prompt to draft PR on an isolated Jetpack Docker instance. Plans, worktrees, implements, tests, screenshots, opens the PR.
+---
+
+# /work-on
+
+Drives a task prompt all the way to a draft pull request on its own worktree and its own `jp docker` instance, without touching the primary `jetpack_dev` environment. Depends on the parallel-environment CLI flags (`jp docker up --name ... --port ...`, `--port-phpmy/inbox/smtp/sftp`).
+
+> **CLI note.** All commands use `jp`, which is the canonical Jetpack monorepo CLI documented in `AGENTS.md`. If your local install exposes it as `jetpack` or `pnpm jetpack` instead, swap freely — they resolve to the same command.
+
+## When to use
+- New features or non-trivial bug fixes that should land as their own PR.
+- Changes where before/after screenshots matter.
+- Work you want fully isolated from the running `jetpack_dev` container.
+
+## When not to use
+- One-line trivial fixes (overhead isn't worth it).
+- Work that must mutate `jetpack_dev` state directly.
+- Tasks that depend on a live WordPress.com connection / Jurassic Tube tunnel — tunnels are not set up by this skill.
+
+## Modes
+
+Ask the user up front which mode to run, unless they've specified:
+
+1. **Full run** — plan → bootstrap → implement → verify → draft PR. Default.
+2. **Bootstrap only** — plan + worktree + docker up, then stop and hand off. Useful when the human wants to drive the implementation themselves.
+3. **Implement only** — resume Phases 5–11 against an existing `/work-on` bootstrap (worktree present, docker already running). Look for `.work-on/env.json` inside the target worktree to recover the slug/port map.
+
+## Preflight (always run)
+
+1. **Read `AGENTS.md`** for the current build, test, docker, changelog, and PR commands. Do not guess from memory — these change.
+2. **Read any project-level `.codex/README.md`** for the project you're about to touch (see the codex notes in `AGENTS.md` and the user's global instructions). It will save expensive re-exploration.
+3. **Git state**:
+   - `git fetch origin trunk --quiet`
+   - `git status` — the working tree must be clean before spawning a worktree.
+   - `git branch --show-current` — determine whether we're on `trunk` or a feature branch.
+4. **Continuation detection**:
+   - Current branch ≠ trunk AND has commits ahead of `origin/trunk` → ask the user: "This looks like a continuation of `<branch>`. Options: (a) add to that branch (force-push may be needed later to keep rebased), (b) branch off fresh from trunk. Which?" Act on the answer.
+   - A worktree already exists at the proposed path → ask whether to reuse or pick a different slug.
+   - A docker compose project matching the proposed `jetpack_<slug>` is already running → ask whether to reuse, stop, or pick a different slug.
+5. **Fill in missing details** by asking the user, not by guessing: Linear/P2/Figma links, plugin scope, whether the change is visual. The goal is a self-explanatory PR; blanks hurt that.
+
+## Phase 0 — Parse the prompt
+
+From the user's request, extract:
+- **Task slug** — kebab-case, ≤ 30 chars, safe as both `--name` and branch suffix (e.g. `fix-forms-label-wrap`).
+- **Target project(s)** — e.g. `projects/plugins/jetpack`, `projects/packages/forms`. If ambiguous, ask.
+- **Visual change?** — any UI/CSS/React/block markup implies yes. If yes, Phases 4 and 7 are mandatory.
+- **External references** — Linear ticket, P2 link (use the `abc1-2-p2` shorthand per AGENTS.md "Confidentiality"), Figma URL, GitHub issue. These feed the PR body.
+- **Scope boundary** — what is explicitly out of scope (useful to note in the PR).
+
+## Phase 1 — Orient & research
+
+- `git log -20 --oneline` on the target area for recent context.
+- Grep the codebase for existing patterns before writing anything new.
+- If the change is large (> ~200 LoC expected) or the area is unfamiliar, spawn one or two `Explore` agents on the top recent contributors' merged PRs in that area to pick up conventions.
+- Note any nearby tests — they're the first place the change can break.
+
+## Phase 2 — Plan
+
+Produce and show the user a plan that includes:
+- Files to touch (with line ranges where known).
+- Approach and trade-offs (2–3 bullets).
+- Test plan (manual and automated).
+- Whether a changelog entry is needed, for which project(s), and a draft entry.
+- Baseline-screenshot path (URL + what to capture) if visual.
+
+**Wait for user approval** before moving on, unless they've said "skip planning".
+
+## Phase 3 — Worktree & Docker bring-up
+
+Pick a slug (from Phase 0) and a free **port tuple** via the **Port allocation** section below. Record them.
+
+From the main checkout (the user's working directory):
+
+```
+git worktree add /path/to/jetpack-<slug> -b change/<slug> trunk
+cd /path/to/jetpack-<slug>
+pnpm install --frozen-lockfile --prefer-offline
+```
+
+Bring up the isolated Docker:
+
+```
+jp docker up -d \
+  --name <slug> \
+  --port <wp-port> \
+  --port-phpmy <phpmy-port> \
+  --port-inbox <inbox-port> \
+  --port-smtp <smtp-port> \
+  --port-sftp <sftp-port>
+jp docker install --name <slug> --port <wp-port>
+```
+
+Persist the choices for cleanup and resume. In the worktree:
+
+```
+mkdir -p .work-on
+echo '{"slug":"<slug>","branch":"change/<slug>","ports":{"wp":<wp-port>, ...}}' > .work-on/env.json
+```
+
+Mark `.work-on/` as locally-ignored so it never commits:
+
+```
+echo '.work-on/' >> .git/info/exclude
+```
+
+## Phase 4 — Baseline screenshot (visual changes only)
+
+Skip if Phase 0 classified the change as non-visual.
+
+1. Build the affected project on the pre-change worktree state (same commit as trunk, since no code has been written yet):
+   ```
+   jp build <project>
+   ```
+   The mounted volume means the running `jetpack_<slug>` container picks the new build up immediately.
+2. Auto-pick the browser tool based on what the change needs:
+   - **Playwright MCP** (default) — great for screenshots, clicks, form interaction, a11y labels, visual verification. Most tasks.
+   - **Chrome DevTools MCP** (`chrome-devtools-mcp:chrome-devtools` skill) — when the task needs perf metrics, network throttling, heavy console interrogation, or CDP-only features.
+3. Navigate to `http://localhost:<wp-port>/<path>` and capture `before.png` into `.work-on/screenshots/<slug>-before.png`.
+
+## Phase 5 — Implement
+
+Write the changes on the worktree branch.
+
+Guardrails from the root `CLAUDE.md`:
+- Minimal diff, match existing patterns, no speculative abstractions.
+- No new error handling/fallbacks for situations that can't happen.
+- No comments that describe *what*; only *why* if non-obvious.
+- No AI attribution in commits.
+
+**If the real implementation path diverges materially from the Phase 2 plan**, stop and confirm with the user before continuing.
+
+## Phase 6 — Quality gates
+
+All commands are in `AGENTS.md`. Run the subset that applies to the changed files:
+
+| Change type | Commands |
+|---|---|
+| PHP inside a project | `jp build <project>`, `jp test php <project>`, `jp phan <project>` |
+| JS/TS inside a project | `jp build <project>`, `jp test js <project>` (no-op if the project doesn't define it) |
+| WP-integration plugin (jetpack / crm / wpcomsh) | `jp docker phpunit <target>` — see `AGENTS.md` "Testing Prerequisites" |
+| Root / `tools/*` change | `pnpm test` inside the affected tool package |
+| Every change | lint the touched files: `npx eslint <files>` and project-local `composer lint` / PHPCS when present |
+
+**2-cycle fix limit.** If the same gate fails twice in a row, stop and show the user — don't keep grinding.
+
+## Phase 7 — Browser verify (visual changes only)
+
+1. Re-run `jp build <project>` to bake the implementation.
+2. Navigate to `http://localhost:<wp-port>/<path>` in the same browser tool used in Phase 4.
+3. Capture `after.png` to `.work-on/screenshots/<slug>-after.png`.
+4. Check the browser console; record any new errors.
+5. If a Figma URL was given in Phase 0, fetch the image (WebFetch) or ask the user to paste one, and compare visually.
+
+## Phase 8 — Changelog
+
+If any file under `projects/` changed, delegate to `.agents/skills/jetpack-changelog.md` now. Do it *before* the PR, not after — changelog wording often shakes out loose ends.
+
+`AGENTS.md` documents the significance/type vocabulary. For the Jetpack plugin specifically, the types are custom (`major | enhancement | compat | bugfix | other`) — check `projects/plugins/jetpack/composer.json`.
+
+## Phase 9 — Self-review
+
+- Read `git diff trunk..HEAD` end to end. Flag anything that looks like:
+  - dead code
+  - overfitting to a specific case
+  - drift from the Phase 2 plan
+- If the `simplify` skill is available in the user's environment (`/simplify`), invoke it.
+- Re-run Phase 6 gates if code moved. Re-run Phase 7 browser check if a UI file moved.
+
+## Phase 10 — Commit & PR
+
+Commits:
+- Imperative, present tense, component-prefixed: `Forms: Fix label wrap on mobile`.
+- Single line where possible. Short body only when the *why* isn't obvious from the diff.
+- **Never** include AI attribution footers in commit messages.
+
+Push:
+```
+git push -u origin change/<slug>
+```
+
+Create a **draft** PR by delegating to `.agents/skills/jetpack-pr.md`. Required additions for this skill:
+- `--draft` on `gh pr create`.
+- Embedded before/after screenshots when Phase 7 ran. Local paths do not render inline, so either:
+  - drop the images as a PR comment via `gh pr comment <num> --body-file <body-with-images>` (GitHub converts attachments to CDN URLs), OR
+  - prompt the user to drag-and-drop the images into the PR after creation and finalise the body.
+- Testing instructions copied from Phase 2's test plan and enriched with any Phase 6 gate outputs.
+- External references from Phase 0 (Linear / P2 / Figma / issue).
+- Use `--body-file` with `gh pr create`, never `--body` — heredoc escaping burns you on backticks and special chars.
+
+## Phase 11 — Cleanup
+
+Immediate:
+- `jp docker stop --name <slug>` — stops the containers and frees ports. The DB, uploads, and `node_modules` are kept on disk for easy resume on review feedback.
+
+Deferred (do NOT run automatically — wait for the PR to merge or an explicit user request):
+- `jp docker clean --name <slug>` — destroys that instance's DB data.
+- `git worktree remove /path/to/jetpack-<slug>` — removes the worktree.
+- `.work-on/` scratchpad goes with the worktree.
+
+Report to the user:
+- PR URL
+- Phase-by-phase gate summary (pass / fail / skipped)
+- Path to screenshots
+- What was deferred for merge-time cleanup
+
+---
+
+## Port allocation
+
+Main `jetpack_dev` uses: WP 80, phpMyAdmin 8181, Mailpit inbox 1080, Mailpit SMTP 25, SFTP 1022.
+
+Algorithm:
+1. List currently-bound host ports:
+   ```
+   docker ps --format '{{.Ports}}' | grep -oE '[0-9]+->' | tr -d '->' | sort -un
+   ```
+2. Pick the first band whose five ports are all unbound. Bands are deterministic so the same task slug tends to land in the same band on re-runs:
+
+   | Band | WP | phpMyAdmin | Mailpit inbox | Mailpit SMTP | SFTP |
+   |---|---|---|---|---|---|
+   | 1 | 8080 | 8281 | 1180 | 2525 | 1122 |
+   | 2 | 8090 | 8381 | 1280 | 2626 | 1222 |
+   | 3 | 8100 | 8481 | 1380 | 2727 | 1322 |
+   | 4 | 8110 | 8581 | 1480 | 2828 | 1422 |
+
+3. If all bands are taken, list running instances to the user and ask them to free a slot or pick explicit ports.
+
+Record the chosen ports in `.work-on/env.json` so Mode 3 (implement-only resume) can find them.
+
+## Docker instance tracking
+
+Before creating a new instance:
+```
+docker ps -a --filter 'name=jetpack_' --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'
+```
+Collisions: ask the user whether to reuse, stop + recreate, or pick a different slug.
+
+## When to pause and ask
+
+Default is to act, but ALWAYS stop and ask when:
+- Continuation is detected at preflight.
+- The plan diverges from expectations during implementation.
+- A gate fails twice on the same check (2-cycle limit).
+- All port bands are occupied.
+- The task turns out to need a live WordPress.com connection — tunnel setup is out of scope.
+- The user hasn't provided a link or slug and the inferred one feels wrong.
+
+Keep each prompt short: one question, give defaults, proceed on the answer.
+
+## Related skills
+- `.agents/skills/jetpack-changelog.md` — Phase 8.
+- `.agents/skills/jetpack-pr.md` — Phase 10.
+- `.agents/skills/jetpack-review-pr.md` — run before requesting a human reviewer.
+
+## Known limitations / future extensions
+- `/implement <slug>` — a companion skill that assumes a prior `/work-on` bootstrap (picks up from Phase 5 using `.work-on/env.json`). Not yet implemented.
+- Merge-time cleanup hook that removes the worktree + cleans Docker data once the PR merges. Not yet implemented.
+- First-class Jurassic Tube / wp.com-connected flows. Out of scope for now.

--- a/.agents/skills/work-on.md
+++ b/.agents/skills/work-on.md
@@ -1,17 +1,55 @@
 ---
-description: End-to-end workflow from prompt to draft PR on an isolated Jetpack Docker instance. Plans, worktrees, implements, tests, screenshots, opens the PR.
+description: End-to-end Jetpack workflow that turns a task prompt into a draft PR on its own isolated worktree and `jp docker` instance. Use whenever the user asks to "work on", "ship", "implement", "take to PR", "build and submit", or otherwise wants a change driven from plan → code → tests → screenshots → pull request, or when they ask for a parallel/isolated sandbox separate from their primary `jetpack_dev` container. Also use for "set up a branch for X", "spin up an env to try Y", "walk this spec through to a PR", and similar phrasings — even when the user doesn't name this skill directly. Prefer this over freehand coding whenever the request carries a concrete scope that ends at a reviewable PR.
 ---
 
 # /work-on
 
-Drives a task prompt all the way to a draft pull request on its own worktree and its own `jp docker` instance, without touching the primary `jetpack_dev` environment. Depends on the parallel-environment CLI flags (`jp docker up --name ... --port ...`, `--port-phpmy/inbox/smtp/sftp`).
+Drives a task prompt all the way to a draft pull request on its own worktree and its own `jp docker` instance, without touching the primary `jetpack_dev` environment. This skill exists because the default monorepo Docker setup is singleton — two `jp docker up` calls from different branches would otherwise collide — so parallel work requires the named-instance CLI flags and port isolation this skill relies on.
 
-> **CLI note.** All commands use `jp`, which is the canonical Jetpack monorepo CLI documented in `AGENTS.md`. If your local install exposes it as `jetpack` or `pnpm jetpack` instead, swap freely — they resolve to the same command.
+## Prerequisites
+
+- **Docker Desktop is running.** The port-allocation step calls `docker ps`; it fails silently on a stopped daemon.
+- **`jp` is on your PATH.** `jp` is the canonical CLI (see `AGENTS.md`). If your shell has it as `jetpack` or you invoke it as `pnpm jetpack`, substitute freely — every `jp` command below works identically under those aliases.
+- **`jq` is installed.** The scripts in `work-on/scripts/` use it to parse `.work-on/env.json`. `brew install jq` on macOS if missing.
+- **`pnpm install --frozen-lockfile` may fail** if the lockfile has drifted since the last pull. The bootstrap script falls back to a regular `pnpm install` automatically; don't panic if you see the warning.
+
+## Trigger phrases
+
+Match this skill when the user's request includes phrases like:
+
+- "work on [something]"
+- "implement [feature/spec/ticket]"
+- "ship [change]" / "take [this] to PR" / "build and PR"
+- "spin up a branch / worktree / sandbox for [X]"
+- "set up an isolated environment to try [Y]"
+- "walk this through to a PR"
+- "draft a PR that does [Z]"
+
+Ambiguous-but-likely triggers: "can you fix [specific thing] and open a PR", "make this happen end-to-end", "go do [task]" when the task has non-trivial scope. If the request is a one-line fix or obviously throwaway exploration, decline this skill and just code.
+
+## Example walkthrough
+
+**User:** "Can you work on fixing the label wrap on mobile in the Forms label block? Figma: https://figma.com/file/abc123"
+
+The skill would:
+
+1. **Parse** the prompt → slug `fix-forms-label-wrap`, project `projects/packages/forms`, visual = yes, Figma reference recorded.
+2. **Plan** the change (inspect the block's label CSS, identify breakpoint rule), show the plan, wait for approval.
+3. **Allocate ports** via `work-on/scripts/alloc-ports.sh fix-forms-label-wrap` → deterministic band 1 → WP 8080, phpMy 8281, Mailpit 1180/2525, SFTP 1122.
+4. **Bootstrap** via `work-on/scripts/bootstrap-worktree.sh fix-forms-label-wrap` → creates `../jetpack-fix-forms-label-wrap` on branch `change/fix-forms-label-wrap` off trunk, runs pnpm install, seeds `.work-on/`.
+5. `jp docker up -d --name fix-forms-label-wrap --port 8080 --port-phpmy 8281 --port-inbox 1180 --port-smtp 2525 --port-sftp 1122` → `jp docker install --name fix-forms-label-wrap --port 8080`.
+6. **Baseline screenshot** of the affected block at `http://localhost:8080/...` → `.work-on/screenshots/fix-forms-label-wrap-before.png`.
+7. **Implement** the CSS fix.
+8. `jp build packages/forms` → `jp test js packages/forms` → `jp phan packages/forms`.
+9. **After screenshot** → compare to Figma reference.
+10. `jp changelog add packages/forms -s patch -t fixed -e "Forms: Fix label wrap on mobile."`
+11. Commit (`Forms: Fix label wrap on mobile`), push, open **draft** PR via `jetpack-pr` skill with before/after attachments + testing steps + Figma link.
+12. `jp docker stop --name fix-forms-label-wrap`. Worktree stays for review follow-ups.
 
 ## When to use
-- New features or non-trivial bug fixes that should land as their own PR.
+- Non-trivial features or bug fixes that land as their own PR.
 - Changes where before/after screenshots matter.
-- Work you want fully isolated from the running `jetpack_dev` container.
+- Work you want isolated from a running `jetpack_dev` container.
 
 ## When not to use
 - One-line trivial fixes (overhead isn't worth it).
@@ -23,101 +61,99 @@ Drives a task prompt all the way to a draft pull request on its own worktree and
 Ask the user up front which mode to run, unless they've specified:
 
 1. **Full run** — plan → bootstrap → implement → verify → draft PR. Default.
-2. **Bootstrap only** — plan + worktree + docker up, then stop and hand off. Useful when the human wants to drive the implementation themselves.
-3. **Implement only** — resume Phases 5–11 against an existing `/work-on` bootstrap (worktree present, docker already running). Look for `.work-on/env.json` inside the target worktree to recover the slug/port map.
+2. **Bootstrap only** — plan + worktree + docker up, then stop and hand off. Useful when the human wants to drive implementation themselves.
+3. **Implement only** — resume Phases 5–11 against an existing `/work-on` bootstrap (worktree present, docker already running). The skill finds `.work-on/env.json` inside the target worktree and reads the slug/port map from it.
 
 ## Preflight (always run)
 
 1. **Read `AGENTS.md`** for the current build, test, docker, changelog, and PR commands. Do not guess from memory — these change.
-2. **Read any project-level `.codex/README.md`** for the project you're about to touch (see the codex notes in `AGENTS.md` and the user's global instructions). It will save expensive re-exploration.
+2. **Read any project-level `.codex/README.md`** for the project you're about to touch. It will save expensive re-exploration.
 3. **Git state**:
    - `git fetch origin trunk --quiet`
    - `git status` — the working tree must be clean before spawning a worktree.
    - `git branch --show-current` — determine whether we're on `trunk` or a feature branch.
 4. **Continuation detection**:
-   - Current branch ≠ trunk AND has commits ahead of `origin/trunk` → ask the user: "This looks like a continuation of `<branch>`. Options: (a) add to that branch (force-push may be needed later to keep rebased), (b) branch off fresh from trunk. Which?" Act on the answer.
+   - Current branch ≠ trunk AND has commits ahead of `origin/trunk` → ask: "This looks like a continuation of `<branch>`. Options: (a) add to that branch (force-push may be needed later to keep rebased), (b) branch off fresh from trunk. Which?" Act on the answer.
    - A worktree already exists at the proposed path → ask whether to reuse or pick a different slug.
-   - A docker compose project matching the proposed `jetpack_<slug>` is already running → ask whether to reuse, stop, or pick a different slug.
-5. **Fill in missing details** by asking the user, not by guessing: Linear/P2/Figma links, plugin scope, whether the change is visual. The goal is a self-explanatory PR; blanks hurt that.
+   - A docker compose project matching `jetpack_<slug>` is already running → ask whether to reuse, stop, or pick a different slug.
+5. **Fill in missing details** by asking the user, not by guessing: Linear/P2/Figma links, plugin scope, whether the change is visual. A self-explanatory PR needs these.
 
 ## Phase 0 — Parse the prompt
 
-From the user's request, extract:
+Extract:
 - **Task slug** — kebab-case, ≤ 30 chars, safe as both `--name` and branch suffix (e.g. `fix-forms-label-wrap`).
 - **Target project(s)** — e.g. `projects/plugins/jetpack`, `projects/packages/forms`. If ambiguous, ask.
 - **Visual change?** — any UI/CSS/React/block markup implies yes. If yes, Phases 4 and 7 are mandatory.
-- **External references** — Linear ticket, P2 link (use the `abc1-2-p2` shorthand per AGENTS.md "Confidentiality"), Figma URL, GitHub issue. These feed the PR body.
-- **Scope boundary** — what is explicitly out of scope (useful to note in the PR).
+- **External references** — Linear, P2 (use the `abc1-2-p2` shorthand per `AGENTS.md` "Confidentiality"), Figma, GitHub issue.
+- **Scope boundary** — anything explicitly out of scope.
 
 ## Phase 1 — Orient & research
 
-- `git log -20 --oneline` on the target area for recent context.
+- `git log -20 --oneline` on the target area.
 - Grep the codebase for existing patterns before writing anything new.
-- If the change is large (> ~200 LoC expected) or the area is unfamiliar, spawn one or two `Explore` agents on the top recent contributors' merged PRs in that area to pick up conventions.
-- Note any nearby tests — they're the first place the change can break.
+- If the change is large (> ~200 LoC expected) or the area is unfamiliar, spawn an `Explore` agent on the top recent contributors' merged PRs in that area to surface conventions.
+- Note nearby tests — they're the first place the change can break.
 
 ## Phase 2 — Plan
 
-Produce and show the user a plan that includes:
+Produce and show the user a plan containing:
 - Files to touch (with line ranges where known).
 - Approach and trade-offs (2–3 bullets).
 - Test plan (manual and automated).
-- Whether a changelog entry is needed, for which project(s), and a draft entry.
+- Changelog decision: needed? which project? draft entry text.
 - Baseline-screenshot path (URL + what to capture) if visual.
 
 **Wait for user approval** before moving on, unless they've said "skip planning".
 
 ## Phase 3 — Worktree & Docker bring-up
 
-Pick a slug (from Phase 0) and a free **port tuple** via the **Port allocation** section below. Record them.
+From the **main checkout**, allocate ports and bootstrap the worktree using the helper scripts so the details stay consistent across runs:
 
-From the main checkout (the user's working directory):
+```bash
+PORTS=$(.agents/skills/work-on/scripts/alloc-ports.sh <slug>)
+# PORTS is JSON, e.g. {"band":1,"wp":8080,"phpmy":8281,"inbox":1180,"smtp":2525,"sftp":1122}
 
+WORKTREE=$(.agents/skills/work-on/scripts/bootstrap-worktree.sh <slug>)
+# WORKTREE = /path/to/jetpack-<slug>, created on branch change/<slug> off origin/trunk
 ```
-git worktree add /path/to/jetpack-<slug> -b change/<slug> trunk
-cd /path/to/jetpack-<slug>
-pnpm install --frozen-lockfile --prefer-offline
-```
 
-Bring up the isolated Docker:
+If `alloc-ports.sh` exits 2, every band is taken — ask the user to stop one of the running instances or provide explicit ports.
 
-```
+Bring up the isolated Docker from within the worktree:
+
+```bash
+cd "$WORKTREE"
 jp docker up -d \
   --name <slug> \
-  --port <wp-port> \
-  --port-phpmy <phpmy-port> \
-  --port-inbox <inbox-port> \
-  --port-smtp <smtp-port> \
-  --port-sftp <sftp-port>
-jp docker install --name <slug> --port <wp-port>
+  --port  "$(echo "$PORTS" | jq -r .wp)" \
+  --port-phpmy "$(echo "$PORTS" | jq -r .phpmy)" \
+  --port-inbox "$(echo "$PORTS" | jq -r .inbox)" \
+  --port-smtp  "$(echo "$PORTS" | jq -r .smtp)" \
+  --port-sftp  "$(echo "$PORTS" | jq -r .sftp)"
 ```
 
-Persist the choices for cleanup and resume. In the worktree:
+WordPress image pulls can take several minutes on a cold cache — if `jp docker install` fails with "WordPress install is incomplete! Perhaps it is still downloading?", wait ~30s and retry once before escalating. Then:
 
-```
-mkdir -p .work-on
-echo '{"slug":"<slug>","branch":"change/<slug>","ports":{"wp":<wp-port>, ...}}' > .work-on/env.json
+```bash
+jp docker install --name <slug> --port "$(echo "$PORTS" | jq -r .wp)"
 ```
 
-Mark `.work-on/` as locally-ignored so it never commits:
-
-```
-echo '.work-on/' >> .git/info/exclude
-```
+Write the full session record to `$WORKTREE/.work-on/env.json` using the schema below. Mode 3 (implement-only resume) reads this file — fields are mandatory.
 
 ## Phase 4 — Baseline screenshot (visual changes only)
 
 Skip if Phase 0 classified the change as non-visual.
 
-1. Build the affected project on the pre-change worktree state (same commit as trunk, since no code has been written yet):
+1. Some projects need a one-time `jp install <project>` before the first build. Run it if the project hasn't been built in this worktree before.
+2. Build the affected project at the pre-change state (same commit as trunk, since no code has been written yet):
    ```
    jp build <project>
    ```
    The mounted volume means the running `jetpack_<slug>` container picks the new build up immediately.
-2. Auto-pick the browser tool based on what the change needs:
-   - **Playwright MCP** (default) — great for screenshots, clicks, form interaction, a11y labels, visual verification. Most tasks.
-   - **Chrome DevTools MCP** (`chrome-devtools-mcp:chrome-devtools` skill) — when the task needs perf metrics, network throttling, heavy console interrogation, or CDP-only features.
-3. Navigate to `http://localhost:<wp-port>/<path>` and capture `before.png` into `.work-on/screenshots/<slug>-before.png`.
+3. Auto-pick the browser tool:
+   - **Playwright MCP** (default) — best for screenshots, clicks, form interaction, a11y labels, visual comparison.
+   - **Chrome DevTools MCP** (via the `chrome-devtools-mcp:chrome-devtools` skill) — when the task needs perf metrics, network throttling, heavy console interrogation, or CDP-only features.
+4. Navigate to `http://localhost:<wp-port>/<path>` and save `.work-on/screenshots/<slug>-before.png`.
 
 ## Phase 5 — Implement
 
@@ -125,136 +161,182 @@ Write the changes on the worktree branch.
 
 Guardrails from the root `CLAUDE.md`:
 - Minimal diff, match existing patterns, no speculative abstractions.
-- No new error handling/fallbacks for situations that can't happen.
-- No comments that describe *what*; only *why* if non-obvious.
+- No new error handling for situations that can't happen.
+- Comments explain *why*, not *what*; only add when non-obvious.
 - No AI attribution in commits.
 
-**If the real implementation path diverges materially from the Phase 2 plan**, stop and confirm with the user before continuing.
+**If the real implementation path diverges materially from the Phase 2 plan**, stop and confirm before continuing.
 
 ## Phase 6 — Quality gates
 
-All commands are in `AGENTS.md`. Run the subset that applies to the changed files:
+All commands are in `AGENTS.md`. Run the subset that applies:
 
 | Change type | Commands |
 |---|---|
-| PHP inside a project | `jp build <project>`, `jp test php <project>`, `jp phan <project>` |
-| JS/TS inside a project | `jp build <project>`, `jp test js <project>` (no-op if the project doesn't define it) |
-| WP-integration plugin (jetpack / crm / wpcomsh) | `jp docker phpunit <target>` — see `AGENTS.md` "Testing Prerequisites" |
+| PHP in a project | `jp build <project>`, `jp test php <project>`, `jp phan <project>` |
+| JS/TS in a project | `jp build <project>`, `jp test js <project>` (no-op if the project doesn't define it) |
+| WP-integration plugin (jetpack / crm / wpcomsh) | `jp docker phpunit <target> -- --name <slug>` — the `--name` routes to the *worktree's* instance, not `jetpack_dev` |
 | Root / `tools/*` change | `pnpm test` inside the affected tool package |
 | Every change | lint the touched files: `npx eslint <files>` and project-local `composer lint` / PHPCS when present |
 
-**2-cycle fix limit.** If the same gate fails twice in a row, stop and show the user — don't keep grinding.
+**2-cycle fix limit.** If the same gate fails twice in a row, stop and show the user — don't keep grinding. Silent grinding is how a "15-minute fix" becomes an hour of wasted context.
 
 ## Phase 7 — Browser verify (visual changes only)
 
 1. Re-run `jp build <project>` to bake the implementation.
 2. Navigate to `http://localhost:<wp-port>/<path>` in the same browser tool used in Phase 4.
-3. Capture `after.png` to `.work-on/screenshots/<slug>-after.png`.
-4. Check the browser console; record any new errors.
-5. If a Figma URL was given in Phase 0, fetch the image (WebFetch) or ask the user to paste one, and compare visually.
+3. Save `.work-on/screenshots/<slug>-after.png`.
+4. Check the browser console; save any new errors to `.work-on/console-<slug>.log`.
+5. If a Figma URL was given, fetch the image (WebFetch) or ask the user to paste one, and compare.
 
 ## Phase 8 — Changelog
 
-If any file under `projects/` changed, delegate to `.agents/skills/jetpack-changelog.md` now. Do it *before* the PR, not after — changelog wording often shakes out loose ends.
+If any file under `projects/` changed, delegate to `.agents/skills/jetpack-changelog.md` **now**, not later. Changelog wording often shakes out loose ends — the act of summarising the user-visible change forces you to notice incomplete edges.
 
-`AGENTS.md` documents the significance/type vocabulary. For the Jetpack plugin specifically, the types are custom (`major | enhancement | compat | bugfix | other`) — check `projects/plugins/jetpack/composer.json`.
+`AGENTS.md` documents the significance/type vocabulary. The Jetpack plugin uses custom types (`major | enhancement | compat | bugfix | other`) — check `projects/plugins/jetpack/composer.json` before writing.
 
 ## Phase 9 — Self-review
 
-- Read `git diff trunk..HEAD` end to end. Flag anything that looks like:
-  - dead code
-  - overfitting to a specific case
-  - drift from the Phase 2 plan
-- If the `simplify` skill is available in the user's environment (`/simplify`), invoke it.
+- Read `git diff trunk..HEAD` end to end. Flag dead code, overfitting, drift from the Phase 2 plan.
+- If `/simplify` is available in the user's environment, invoke it.
 - Re-run Phase 6 gates if code moved. Re-run Phase 7 browser check if a UI file moved.
 
 ## Phase 10 — Commit & PR
 
 Commits:
-- Imperative, present tense, component-prefixed: `Forms: Fix label wrap on mobile`.
-- Single line where possible. Short body only when the *why* isn't obvious from the diff.
-- **Never** include AI attribution footers in commit messages.
+- Imperative, present-tense, component-prefixed: `Forms: Fix label wrap on mobile`.
+- Single-line commit subject when the diff speaks for itself; short body only when the *why* isn't obvious.
+- **Never** include AI attribution footers.
 
 Push:
 ```
 git push -u origin change/<slug>
 ```
 
-Create a **draft** PR by delegating to `.agents/skills/jetpack-pr.md`. Required additions for this skill:
-- `--draft` on `gh pr create`.
-- Embedded before/after screenshots when Phase 7 ran. Local paths do not render inline, so either:
-  - drop the images as a PR comment via `gh pr comment <num> --body-file <body-with-images>` (GitHub converts attachments to CDN URLs), OR
-  - prompt the user to drag-and-drop the images into the PR after creation and finalise the body.
-- Testing instructions copied from Phase 2's test plan and enriched with any Phase 6 gate outputs.
-- External references from Phase 0 (Linear / P2 / Figma / issue).
-- Use `--body-file` with `gh pr create`, never `--body` — heredoc escaping burns you on backticks and special chars.
+Create a **draft** PR by delegating to `.agents/skills/jetpack-pr.md`. Additions for this skill:
+
+- Pass `--draft` to `gh pr create`.
+- Apply `[Status] In Progress` rather than `[Status] Needs Review`. A draft is WIP; don't page the review team yet.
+- Use `--body-file`, never `--body` — heredoc escaping breaks on backticks and special chars.
+- **Screenshots**: local paths don't render in the body. Either (a) add the images as a PR comment via `gh pr comment <num> --body-file <file-with-![alt](path)>` so GitHub converts them to CDN URLs, then reference those URLs from the PR body, or (b) open the PR first and ask the user to drag the images in and finalise.
+- Embed: Phase 2 test plan, Phase 6 gate outputs, Phase 0 external references, before/after screenshot URLs.
+- Suggest reviewers if the user hasn't named any — pick the top 1–2 recent authors on the changed files from `git log --format='%an'`.
 
 ## Phase 11 — Cleanup
 
-Immediate:
-- `jp docker stop --name <slug>` — stops the containers and frees ports. The DB, uploads, and `node_modules` are kept on disk for easy resume on review feedback.
+**On success:**
 
-Deferred (do NOT run automatically — wait for the PR to merge or an explicit user request):
-- `jp docker clean --name <slug>` — destroys that instance's DB data.
-- `git worktree remove /path/to/jetpack-<slug>` — removes the worktree.
-- `.work-on/` scratchpad goes with the worktree.
+- `jp docker stop --name <slug>` — stops the containers and frees ports. DB, uploads, and `node_modules` remain on disk for review follow-ups.
 
-Report to the user:
-- PR URL
-- Phase-by-phase gate summary (pass / fail / skipped)
-- Path to screenshots
-- What was deferred for merge-time cleanup
+Do NOT run automatically — wait for PR merge or explicit user request:
+- `jp docker clean --name <slug>` (destroys that instance's DB).
+- `git worktree remove <path>` (removes the worktree + scratchpad).
+
+**On failure** (any phase errors out):
+
+- Attempt `jp docker stop --name <slug>` so the named instance doesn't sit orphaned holding ports.
+- Leave the worktree in place; the user may want to inspect the partial state.
+- Tell the user exactly which phase failed, what the error was, and which of the two cleanup paths to use next.
+
+**Report at the end** — always:
+- PR URL (or "not opened" if we stopped earlier).
+- Phase-by-phase status: pass / fail / skipped.
+- Path to `.work-on/screenshots/` and `.work-on/console-*.log`.
+- What was deferred for merge-time cleanup.
 
 ---
+
+## `.work-on/env.json` schema
+
+Written by Phase 3, read by Mode 3. Fields are required unless marked optional. Dates are ISO 8601 UTC.
+
+```json
+{
+  "slug": "fix-forms-label-wrap",
+  "branch": "change/fix-forms-label-wrap",
+  "worktree": "/Users/you/a8c/dev/jetpack-fix-forms-label-wrap",
+  "project": "projects/packages/forms",
+  "visual": true,
+  "band": 1,
+  "ports": {
+    "wp": 8080,
+    "phpmy": 8281,
+    "inbox": 1180,
+    "smtp": 2525,
+    "sftp": 1122
+  },
+  "references": {
+    "figma": "https://figma.com/file/abc123",
+    "linear": null,
+    "p2": null,
+    "issue": null
+  },
+  "created": "2026-04-17T15:30:00Z"
+}
+```
 
 ## Port allocation
 
 Main `jetpack_dev` uses: WP 80, phpMyAdmin 8181, Mailpit inbox 1080, Mailpit SMTP 25, SFTP 1022.
 
-Algorithm:
-1. List currently-bound host ports:
-   ```
-   docker ps --format '{{.Ports}}' | grep -oE '[0-9]+->' | tr -d '->' | sort -un
-   ```
-2. Pick the first band whose five ports are all unbound. Bands are deterministic so the same task slug tends to land in the same band on re-runs:
+Allocation is done by `work-on/scripts/alloc-ports.sh <slug>`. It reads `docker ps` for currently-bound host ports, picks the first band whose five ports are all unbound, and prints JSON on stdout. Bands are deterministic from the slug hash so the same task lands in the same band across restarts. Exit code 2 means every band is occupied — ask the user to free one.
 
-   | Band | WP | phpMyAdmin | Mailpit inbox | Mailpit SMTP | SFTP |
-   |---|---|---|---|---|---|
-   | 1 | 8080 | 8281 | 1180 | 2525 | 1122 |
-   | 2 | 8090 | 8381 | 1280 | 2626 | 1222 |
-   | 3 | 8100 | 8481 | 1380 | 2727 | 1322 |
-   | 4 | 8110 | 8581 | 1480 | 2828 | 1422 |
+Band map (kept in sync with the script):
 
-3. If all bands are taken, list running instances to the user and ask them to free a slot or pick explicit ports.
-
-Record the chosen ports in `.work-on/env.json` so Mode 3 (implement-only resume) can find them.
+| Band | WP | phpMyAdmin | Mailpit inbox | Mailpit SMTP | SFTP |
+|---|---|---|---|---|---|
+| 1 | 8080 | 8281 | 1180 | 2525 | 1122 |
+| 2 | 8090 | 8381 | 1280 | 2626 | 1222 |
+| 3 | 8100 | 8481 | 1380 | 2727 | 1322 |
+| 4 | 8110 | 8581 | 1480 | 2828 | 1422 |
 
 ## Docker instance tracking
 
 Before creating a new instance:
+
 ```
 docker ps -a --filter 'name=jetpack_' --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'
 ```
-Collisions: ask the user whether to reuse, stop + recreate, or pick a different slug.
+
+Collisions: ask the user to reuse, stop + recreate, or pick a different slug.
 
 ## When to pause and ask
 
-Default is to act, but ALWAYS stop and ask when:
+Default is to act, but stop and ask when:
 - Continuation is detected at preflight.
 - The plan diverges from expectations during implementation.
-- A gate fails twice on the same check (2-cycle limit).
+- A gate fails twice on the same check (the 2-cycle limit).
 - All port bands are occupied.
-- The task turns out to need a live WordPress.com connection — tunnel setup is out of scope.
-- The user hasn't provided a link or slug and the inferred one feels wrong.
+- The task turns out to need a live WordPress.com connection.
+- The inferred slug, project, or scope feels wrong or thin.
 
 Keep each prompt short: one question, give defaults, proceed on the answer.
+
+## Success signals
+
+The skill completed successfully if all of these hold:
+
+- `git branch --show-current` (inside the worktree) equals `change/<slug>`.
+- `git log origin/trunk..HEAD` is non-empty and every commit message is imperative, present-tense, and does NOT contain `Co-Authored-By: Claude` or `Generated with Claude Code`.
+- `gh pr view --json isDraft,state,body` returns `{"isDraft":true,"state":"OPEN"}` and the body contains a "Testing instructions" section.
+- `docker ps --filter name=jetpack_<slug>` lists **no running container** (Phase 11 immediate stop was honored).
+- `git worktree list | grep jetpack-<slug>` still shows the worktree present (deferred cleanup).
+- If the change was visual: `.work-on/screenshots/<slug>-before.png` and `<slug>-after.png` both exist and are >4 KB.
+- If any file under `projects/` changed: a new entry exists in that project's `changelog/` directory.
+- `.work-on/env.json` is valid JSON and round-trips through `jq` without error.
+
+Use these as the "definition of done" when you report back to the user — mention any that didn't hold.
 
 ## Related skills
 - `.agents/skills/jetpack-changelog.md` — Phase 8.
 - `.agents/skills/jetpack-pr.md` — Phase 10.
 - `.agents/skills/jetpack-review-pr.md` — run before requesting a human reviewer.
 
+## Scripts
+- `work-on/scripts/alloc-ports.sh` — port-band allocator.
+- `work-on/scripts/bootstrap-worktree.sh` — worktree + pnpm install + scratchpad.
+
 ## Known limitations / future extensions
-- `/implement <slug>` — a companion skill that assumes a prior `/work-on` bootstrap (picks up from Phase 5 using `.work-on/env.json`). Not yet implemented.
-- Merge-time cleanup hook that removes the worktree + cleans Docker data once the PR merges. Not yet implemented.
-- First-class Jurassic Tube / wp.com-connected flows. Out of scope for now.
+- `/implement <slug>` — companion skill that assumes a prior `/work-on` bootstrap (picks up from Phase 5 using `.work-on/env.json`). Not yet implemented.
+- Merge-time cleanup hook that removes the worktree + cleans Docker data once the PR merges.
+- First-class Jurassic Tube / wp.com-connected flows.

--- a/.agents/skills/work-on/scripts/alloc-ports.sh
+++ b/.agents/skills/work-on/scripts/alloc-ports.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Allocate a free five-port tuple for a parallel `jp docker` instance.
+#
+# Bands are deterministic so repeat runs for the same slug land in the same
+# band when it's free. The script only picks an empty band — it never tries
+# to reuse a partially-occupied one.
+#
+# Usage:   alloc-ports.sh <slug>
+# Output:  JSON on stdout: {"band":N,"wp":N,"phpmy":N,"inbox":N,"smtp":N,"sftp":N}
+# Exit:    0 ok, 1 bad args, 2 no free band.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+	echo "Usage: $0 <slug>" >&2
+	exit 1
+fi
+
+slug="$1"
+
+# Keep in sync with the Port allocation table in work-on.md.
+bands=(
+	"1 8080 8281 1180 2525 1122"
+	"2 8090 8381 1280 2626 1222"
+	"3 8100 8481 1380 2727 1322"
+	"4 8110 8581 1480 2828 1422"
+)
+
+busy=$(docker ps --format '{{.Ports}}' 2>/dev/null \
+	| grep -oE '[0-9]+->' | cut -d'-' -f1 | sort -un || true)
+
+is_busy() {
+	local port="$1"
+	[[ -z "$busy" ]] && return 1
+	grep -qxF "$port" <<< "$busy"
+}
+
+# Deterministic starting band from slug hash.
+slug_hash=$(printf '%s' "$slug" | cksum | cut -d ' ' -f 1)
+start=$(( slug_hash % ${#bands[@]} ))
+
+for (( i = 0; i < ${#bands[@]}; i++ )); do
+	idx=$(( (start + i) % ${#bands[@]} ))
+	read -r band wp phpmy inbox smtp sftp <<< "${bands[$idx]}"
+	if ! is_busy "$wp" && ! is_busy "$phpmy" && ! is_busy "$inbox" \
+	  && ! is_busy "$smtp" && ! is_busy "$sftp"; then
+		printf '{"band":%s,"wp":%s,"phpmy":%s,"inbox":%s,"smtp":%s,"sftp":%s}\n' \
+			"$band" "$wp" "$phpmy" "$inbox" "$smtp" "$sftp"
+		exit 0
+	fi
+done
+
+echo "No free port band. Busy ports: ${busy:-none}" >&2
+exit 2

--- a/.agents/skills/work-on/scripts/bootstrap-worktree.sh
+++ b/.agents/skills/work-on/scripts/bootstrap-worktree.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Bootstrap a Jetpack worktree for /work-on.
+#
+# Creates a new worktree on branch `change/<slug>` branched off origin/trunk,
+# runs pnpm install (frozen lockfile with a graceful fallback when the lock
+# has drifted), seeds `.work-on/screenshots/`, and locally-ignores the
+# `.work-on/` scratchpad. It does NOT write env.json — that belongs to the
+# caller, which knows which ports were allocated.
+#
+# Usage:   bootstrap-worktree.sh <slug> [worktree-parent-dir]
+# Output:  the worktree path on stdout
+# Exit:    0 ok, 1 bad args, 3 target path already exists.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+	echo "Usage: $0 <slug> [worktree-parent-dir]" >&2
+	exit 1
+fi
+
+slug="$1"
+parent="${2:-$(dirname "$(pwd)")}"
+worktree="$parent/jetpack-$slug"
+branch="change/$slug"
+
+if [[ -e "$worktree" ]]; then
+	echo "Path already exists: $worktree" >&2
+	exit 3
+fi
+
+git fetch origin trunk --quiet
+git worktree add "$worktree" -b "$branch" origin/trunk
+
+(
+	cd "$worktree"
+	if ! pnpm install --frozen-lockfile --prefer-offline; then
+		echo "Frozen-lockfile install failed (lockfile likely drifted); retrying without --frozen-lockfile." >&2
+		pnpm install --prefer-offline
+	fi
+	mkdir -p .work-on/screenshots
+	if ! grep -qxF '.work-on/' .git/info/exclude 2>/dev/null; then
+		echo '.work-on/' >> .git/info/exclude
+	fi
+)
+
+echo "$worktree"

--- a/projects/packages/publicize/_inc/components/admin-page/header/index.js
+++ b/projects/packages/publicize/_inc/components/admin-page/header/index.js
@@ -3,6 +3,7 @@ import { ConnectionError, useConnectionErrorNotice } from '@automattic/jetpack-c
 import { getAdminUrl } from '@automattic/jetpack-script-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { Button as UiButton } from '@wordpress/ui';
 import { store as socialStore } from '../../../social-store';
 import styles from './styles.module.scss';
 
@@ -36,9 +37,9 @@ const Header = () => {
 					<H3 mt={ 2 }>{ __( 'Write once, post everywhere', 'jetpack-publicize-pkg' ) }</H3>
 					<div className={ styles.actions }>
 						{ isModuleEnabled && ! hasConnections && (
-							<Button onClick={ openConnectionsModal }>
+							<UiButton onClick={ openConnectionsModal }>
 								{ __( 'Connect accounts', 'jetpack-publicize-pkg' ) }
-							</Button>
+							</UiButton>
 						) }
 						<Button
 							href={ getAdminUrl( 'post-new.php' ) }

--- a/projects/packages/publicize/changelog/change-publicize-header-migrate-button
+++ b/projects/packages/publicize/changelog/change-publicize-header-migrate-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Social admin header: Use @wordpress/ui Button for the Connect accounts CTA.

--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -30,6 +30,18 @@ const defaultOpts = yargs =>
 			alias: 'p',
 			describe: 'WP port',
 		} )
+		.option( 'port-phpmy', {
+			describe: 'phpMyAdmin port',
+		} )
+		.option( 'port-inbox', {
+			describe: 'Mailpit web UI port',
+		} )
+		.option( 'port-smtp', {
+			describe: 'Mailpit SMTP port',
+		} )
+		.option( 'port-sftp', {
+			describe: 'SFTP port',
+		} )
 		.option( 'ngrok', {
 			type: 'boolean',
 			describe: 'Flag to launch ngrok process',
@@ -41,10 +53,10 @@ const defaultOpts = yargs =>
  * @param {object} argv - Yargs
  * @return {string} Project name
  */
-const getProjectName = argv => {
-	let project = 'dev';
-	if ( argv.type === 'e2e' ) {
-		project = argv.name ? argv.name : 'e2e';
+export const getProjectName = argv => {
+	let project = argv.type === 'e2e' ? 'e2e' : 'dev';
+	if ( argv.name ) {
+		project = argv.name;
 	}
 
 	return 'jetpack_' + project;
@@ -56,10 +68,25 @@ const getProjectName = argv => {
  * @param {object} argv - Yargs
  * @return {object} key-value pairs of ENV variables
  */
-const buildEnv = argv => {
+export const buildEnv = argv => {
 	const envOpts = {};
-	if ( argv.type === 'e2e' ) {
-		envOpts.PORT_WORDPRESS = argv.port ? argv.port : 8889;
+	if ( argv.port ) {
+		envOpts.PORT_WORDPRESS = argv.port;
+	} else if ( argv.type === 'e2e' ) {
+		envOpts.PORT_WORDPRESS = 8889;
+	}
+
+	if ( argv.portPhpmy ) {
+		envOpts.PORT_PHPMY = argv.portPhpmy;
+	}
+	if ( argv.portInbox ) {
+		envOpts.PORT_INBOX = argv.portInbox;
+	}
+	if ( argv.portSmtp ) {
+		envOpts.PORT_SMTP = argv.portSmtp;
+	}
+	if ( argv.portSftp ) {
+		envOpts.PORT_SFTP = argv.portSftp;
 	}
 
 	envOpts.COMPOSE_PROJECT_NAME = getProjectName( argv );
@@ -109,7 +136,7 @@ const printPostCmdMsg = argv => {
 		return;
 	}
 	if ( argv._[ 1 ] === 'up' ) {
-		const port = argv.port ? argv.port : '';
+		const port = argv.port ? `:${ argv.port }` : '';
 		const msg = chalk.green( `Open http://localhost${ port }/ to see your site!` );
 		console.log( msg );
 	}

--- a/tools/cli/tests/unit/commands/docker.test.js
+++ b/tools/cli/tests/unit/commands/docker.test.js
@@ -1,0 +1,83 @@
+import { jest } from '@jest/globals';
+
+const fsStub = {
+	readFileSync: () => '',
+	writeFileSync: () => {},
+	existsSync: () => false,
+	mkdirSync: () => {},
+	closeSync: () => {},
+	openSync: () => 0,
+};
+jest.unstable_mockModule( 'fs', () => ( {
+	default: fsStub,
+	...fsStub,
+} ) );
+
+const { getProjectName, buildEnv } = await import( '../../../commands/docker.js' );
+
+describe( 'getProjectName', () => {
+	test( 'defaults to jetpack_dev for dev type with no name', () => {
+		expect( getProjectName( { type: 'dev' } ) ).toBe( 'jetpack_dev' );
+	} );
+
+	test( 'defaults to jetpack_e2e for e2e type with no name', () => {
+		expect( getProjectName( { type: 'e2e' } ) ).toBe( 'jetpack_e2e' );
+	} );
+
+	test( 'honors --name for dev type', () => {
+		expect( getProjectName( { type: 'dev', name: 'feature' } ) ).toBe( 'jetpack_feature' );
+	} );
+
+	test( 'honors --name for e2e type', () => {
+		expect( getProjectName( { type: 'e2e', name: 'custom' } ) ).toBe( 'jetpack_custom' );
+	} );
+} );
+
+describe( 'buildEnv', () => {
+	test( 'omits PORT_WORDPRESS for dev type when --port not set', () => {
+		const env = buildEnv( { type: 'dev' } );
+		expect( env.PORT_WORDPRESS ).toBeUndefined();
+		expect( env.COMPOSE_PROJECT_NAME ).toBe( 'jetpack_dev' );
+	} );
+
+	test( 'defaults PORT_WORDPRESS to 8889 for e2e without --port', () => {
+		const env = buildEnv( { type: 'e2e' } );
+		expect( env.PORT_WORDPRESS ).toBe( 8889 );
+	} );
+
+	test( 'honors --port for dev type', () => {
+		const env = buildEnv( { type: 'dev', port: 8080 } );
+		expect( env.PORT_WORDPRESS ).toBe( 8080 );
+	} );
+
+	test( '--port overrides the e2e default', () => {
+		const env = buildEnv( { type: 'e2e', port: 9000 } );
+		expect( env.PORT_WORDPRESS ).toBe( 9000 );
+	} );
+
+	test( 'passes auxiliary port flags through as env vars', () => {
+		const env = buildEnv( {
+			type: 'dev',
+			name: 'feature',
+			port: 8080,
+			portPhpmy: 8281,
+			portInbox: 1180,
+			portSmtp: 2525,
+			portSftp: 1122,
+		} );
+		expect( env.COMPOSE_PROJECT_NAME ).toBe( 'jetpack_feature' );
+		expect( env.PORT_WORDPRESS ).toBe( 8080 );
+		expect( env.PORT_PHPMY ).toBe( 8281 );
+		expect( env.PORT_INBOX ).toBe( 1180 );
+		expect( env.PORT_SMTP ).toBe( 2525 );
+		expect( env.PORT_SFTP ).toBe( 1122 );
+	} );
+
+	test( 'omits auxiliary port env vars when flags are not set', () => {
+		const env = buildEnv( { type: 'dev' } );
+		expect( env.PORT_PHPMY ).toBeUndefined();
+		expect( env.PORT_INBOX ).toBeUndefined();
+		expect( env.PORT_SMTP ).toBeUndefined();
+		expect( env.PORT_SFTP ).toBeUndefined();
+	} );
+} );

--- a/tools/docker/bin/install.sh
+++ b/tools/docker/bin/install.sh
@@ -20,10 +20,16 @@ if wp core is-installed; then
 	exit
 fi
 
+# Build the install URL, appending HOST_PORT when it's not the default 80.
+WP_URL="http://${WP_DOMAIN}"
+if [[ -n "$HOST_PORT" && "$HOST_PORT" != "80" ]]; then
+	WP_URL="${WP_URL}:${HOST_PORT}"
+fi
+
 # Install WP core
 echo 'Configuring WordPress...'
 wp core install \
-	--url="${WP_DOMAIN}" \
+	--url="${WP_URL}" \
 	--title="${WP_TITLE}" \
 	--admin_user="${WP_ADMIN_USER}" \
 	--admin_password="${WP_ADMIN_PASSWORD}" \
@@ -69,5 +75,5 @@ wp plugin is-active jetpack || wp plugin activate jetpack | sed 's/^/    /'
 echo
 echo 'Your site is ready! You can see it here:'
 echo
-echo "    http://${WP_DOMAIN}:${PORT_WORDPRESS}"
+echo "    ${WP_URL}"
 echo

--- a/tools/docker/jetpack-docker-config-default.yml
+++ b/tools/docker/jetpack-docker-config-default.yml
@@ -31,7 +31,6 @@ dev:
       ## https://mailpit.axllent.org/
       mailpit:
         image: axllent/mailpit
-        container_name: mailpit
         ports:
           - '${PORT_INBOX:-1080}:8025'
           - '${PORT_SMTP:-25}:1025'


### PR DESCRIPTION
Fixes part of #48152
Part of https://github.com/Automattic/jetpack/issues/48160

## Proposed changes

Migrates a single Phase 1 call site from the deprecated `Button` in `@automattic/jetpack-components` to `Button` from `@wordpress/ui`, as part of the broader deprecation tracked in #48152.

* **File touched:** `projects/packages/publicize/_inc/components/admin-page/header/index.js`
* **Swap:** the `Connect accounts` CTA (a plain Button with no `variant`, `size`, `href`, `icon`, or other props beyond `onClick` + text). Imported as `Button as UiButton` so the file's second Button (which still has `href` + dynamic `variant` and needs a Phase 2 / Phase 4 decision) can keep using the jetpack-components Button unchanged.
* **Dep:** `@wordpress/ui@0.10.0` is already a dependency of `packages/publicize` — no new dependencies added.

This is intentionally the smallest possible step — the goal is to unblock the migration pattern and prove it works in a production plugin's code path. Follow-up PRs will tackle the remaining files package-by-package.

### Scope discovery during implementation

While preparing this PR, I checked every file listed under Phase 1 in #48152 for the publicize package. None of them are actually pure "straight swaps" — every one has `variant="link"`, `variant="primary|secondary"`, `size="small"`, or `isDestructive`. The only genuinely prop-less Button in publicize is this Connect accounts button. The issue's Phase 1 list likely needs a follow-up triage to reclassify files into the appropriate phase (Phase 2 for `variant="link"`, Phase 4 for dynamic variants).

## Related product discussion/links

* Issue: [#48152](https://github.com/Automattic/jetpack/issues/48152)
* Depends on (must merge first, or rebase afterwards): #48153 (parallel-env CLI flags + /work-on skill) — this PR was developed and tested from a `/work-on` isolated docker instance branched off #48153.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

### Automated

* `jp build packages/publicize` — passes.
* `jp test js packages/publicize` — passes.
* `npx eslint projects/packages/publicize/_inc/components/admin-page/header/index.js` — 3 errors reported, all pre-existing on `jetpack-publicize-pkg` text domain checks (this domain is correct per `AGENTS.md` in the package; babel's `@automattic/babel-plugin-replace-textdomain` replaces it at build time and eslint is unaware of the transform).

### Manual

1. Check out this branch and boot a Jetpack docker instance with the Social plugin active: `jp docker up -d`, `jp docker install`, then `docker exec <wp-container> wp plugin activate jetpack-social --allow-root`.
2. Build: `jp build packages/publicize`.
3. Log in as admin and open the Social admin page at `/wp-admin/admin.php?page=jetpack-social`.
4. Without any active social connections, verify the **Connect accounts** button renders where expected (right column, alongside *Write a post*). It should look and behave identically to before — `onClick` opens the Connections modal.
5. Create a social connection (or mock `hasConnections` to true) and verify the button hides, exactly as before.

### Screenshot evidence

This PR intentionally ships without before/after screenshots because the Social admin page (slug `jetpack-social`) is gated behind a menu registration that requires `Jetpack_Plan::supports('akismet' | 'antispam')` — which needs a live wp.com connection + plan data. That's unavailable in a clean local Docker instance without a Jurassic Tube tunnel. I verified the change via `jp build` + `jp test js` + code diff review. This menu-bootstrap caveat is a separate dev-env observation worth following up on independently — see the `/work-on` skill notes on `change/docker-cli-parallel-flags`.

The change is a pure component swap (identical rendered behavior: text + onClick), so visual regression risk is minimal. The Reviewer is welcome to spot-check visually if they have a connected dev site available.
