### PR TITLE
My Jetpack: use ui-icon instead of CheckmarkIcon

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-detail-card/index.jsx
@@ -1,5 +1,4 @@
 import {
-	CheckmarkIcon,
 	getIconBySlug,
 	StarIcon,
 	Text,
@@ -437,7 +436,7 @@ const ProductDetailCard = ( {
 
 				{ isBundleUpsell && hasPaidPlanForProduct && (
 					<div className={ styles[ 'product-has-required-plan' ] }>
-						<CheckmarkIcon size={ 36 } />
+						<Icon icon={ check } size={ 36 } />
 						<Text>{ __( 'Active on your site', 'jetpack-my-jetpack' ) }</Text>
 					</div>
 				) }

--- a/projects/packages/my-jetpack/changelog/rna-gridicon
+++ b/projects/packages/my-jetpack/changelog/rna-gridicon
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Replace Gridicon and CheckmarkIcon with Icon and named icon exports from `@wordpress/icons`.


### PR DESCRIPTION
Part of https://github.com/Automattic/jetpack/issues/48160


## Proposed changes
<!--- Explain what functional changes your PR includes -->
Just one-to-one replacement of checkmark:

<img width="1512" height="860" alt="Screenshot 2026-04-18 at 12 15 35" src="https://github.com/user-attachments/assets/59b248fb-7c9a-44ed-bae8-f5cabb925dfb" />
 

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->


First, go to My Jetpack.

The product-detail-card component is the interstitial/detail page shown when you click on a specific product from the My Jetpack overview. It's the full-screen product landing page, not the card on the main grid.

To see it in My Jetpack, navigate to My Jetpack → click any product card (e.g. Backup, Scan, Boost). That takes you to a URL like:

/wp-admin/admin.php?page=my-jetpack#/add-backup
The ProductDetailCard renders the large product description, pricing, features list, and CTA buttons on that interstitial screen. The CheckmarkIcon you changed specifically appears when isBundleUpsell && hasPaidPlanForProduct is true — so you'd see it on a bundle product (like Security or Complete) when the user already has a paid plan that covers it, showing the "Active on your site" checkmark.
