### PR TITLE
My Jetpack: migrate overview Button and Text to @wordpress/ui

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/connected-product-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connected-product-card/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Text } from '@automattic/jetpack-components';
+import { Text } from '@wordpress/ui';
 import { useEffect } from 'react';
 /**
  * Internal dependencies
@@ -56,7 +56,7 @@ const ConnectedProductCard: FC< ConnectedProductCardProps > = ( {
 		const cardDescription = preventWidows( defaultDescription );
 
 		return (
-			<Text variant="body-small" style={ { flexGrow: 1, marginBottom: '1rem' } }>
+			<Text variant="body-sm" style={ { flexGrow: 1, marginBottom: '1rem' } }>
 				{ cardDescription }
 			</Text>
 		);

--- a/projects/packages/my-jetpack/_inc/components/connection-status-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-status-card/index.tsx
@@ -1,9 +1,9 @@
-import { Text } from '@automattic/jetpack-components';
 import { CONNECTION_STORE_ID, ManageConnectionDialog } from '@automattic/jetpack-connection';
 import { currentUserCan, isWoASite } from '@automattic/jetpack-script-data';
 import { Button } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { Text } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useCallback, useMemo, useState } from 'react';
 import { useAllProducts } from '../../data/products/use-all-products';
@@ -171,7 +171,7 @@ const ConnectionStatusCard: ConnectionStatusCardType = ( {
 					</Button>
 				</h4>
 				<div>
-					<Text variant="body" className={ styles.description }>
+					<Text variant="body-md" className={ styles.description }>
 						{ state.description }
 					</Text>
 					{ state.action === 'CONNECT_USER' ? (

--- a/projects/packages/my-jetpack/_inc/components/plans-section/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/plans-section/index.tsx
@@ -1,9 +1,10 @@
-import { Button, Text } from '@automattic/jetpack-components';
+// TODO: migrate Button usages to @wordpress/ui Link (handled in a separate PR — all Buttons here use variant="link" + href + isExternalLink + weight="regular", which @wordpress/ui Button does not support).
+import { Button } from '@automattic/jetpack-components';
 import { getUserConnectionUrl } from '@automattic/jetpack-connection';
 import { getMyJetpackUrl } from '@automattic/jetpack-script-data';
 import { dateI18n, getDate } from '@wordpress/date';
 import { __, _n, _x, sprintf } from '@wordpress/i18n';
-import { Link } from '@wordpress/ui';
+import { Link, Text } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useCallback } from 'react';
 import { PRODUCT_STATUSES } from '../../constants';
@@ -124,7 +125,7 @@ const PlanExpiry: FC< PlanSectionProps > = ( { purchase } ) => {
 
 	if ( isLifetimePurchase( purchase ) ) {
 		return (
-			<Text variant="body" className={ styles[ 'expire-date' ] }>
+			<Text variant="body-md" className={ styles[ 'expire-date' ] }>
 				<span className={ styles[ 'expire-date--with-icon' ] }>
 					{ __( 'Never Expires', 'jetpack-my-jetpack' ) }
 				</span>
@@ -135,7 +136,7 @@ const PlanExpiry: FC< PlanSectionProps > = ( { purchase } ) => {
 
 	return (
 		<>
-			<Text variant="body" className={ clsx( styles[ 'expire-date' ], expiryMessageClassName ) }>
+			<Text variant="body-md" className={ clsx( styles[ 'expire-date' ], expiryMessageClassName ) }>
 				{ expiryMessage() }
 			</Text>
 			{ isExpiringPurchase && <Text>{ expiryAction() }</Text> }
@@ -324,7 +325,7 @@ const PlansSection: FC = () => {
 									/>
 								</svg>
 							</h4>
-							<Text variant="body" className={ clsx( styles[ 'expire-date' ] ) }>
+							<Text variant="body-md" className={ clsx( styles[ 'expire-date' ] ) }>
 								{ __( 'Free', 'jetpack-my-jetpack' ) }
 							</Text>
 						</section>

--- a/projects/packages/my-jetpack/_inc/components/product-card/recommendation-actions.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/recommendation-actions.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@automattic/jetpack-components';
+import { Button } from '@wordpress/ui';
 import clsx from 'clsx';
 import styles from './style.module.scss';
 import usePricingData from './use-pricing-data';
@@ -20,7 +20,7 @@ const RecommendationActions = ( { slug }: { slug: string } ) => {
 					</Button>
 				) }
 				{ secondaryAction && (
-					<Button size="small" variant="secondary" disabled={ isActivating } { ...secondaryAction }>
+					<Button size="small" variant="outline" disabled={ isActivating } { ...secondaryAction }>
 						{ secondaryAction.label }
 					</Button>
 				) }

--- a/projects/packages/my-jetpack/_inc/components/product-card/status.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-card/status.tsx
@@ -1,5 +1,5 @@
-import { Text } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
+import { Text } from '@wordpress/ui';
 import clsx from 'clsx';
 import { PRODUCT_STATUSES } from '../../constants';
 import styles from './style.module.scss';
@@ -113,7 +113,7 @@ const Status: FC< StatusProps > = ( {
 	);
 
 	return (
-		<Text variant="label" className={ statusClassName }>
+		<Text variant="body-sm" className={ statusClassName }>
 			{ flagLabel }
 		</Text>
 	);

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/backup-card/index.jsx
@@ -1,7 +1,7 @@
-import { Text, getRedirectUrl } from '@automattic/jetpack-components';
+import { getRedirectUrl } from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { Link } from '@wordpress/ui';
+import { Link, Text } from '@wordpress/ui';
 import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
 import { PRODUCT_STATUSES } from '../../../constants';
@@ -115,7 +115,7 @@ const BackupCard = props => {
 			{ isDeactivated && ! isBackupFailedReasonLoading && (
 				<div className={ styles.backupErrorContainer }>
 					<div className={ styles.contentContainer }>
-						<Text variant="body-small">
+						<Text variant="body-sm">
 							{ createInterpolateElement(
 								__(
 									'Backup was manually turned off. Please <a>contact support</a> to reactivate it.',
@@ -135,7 +135,7 @@ const BackupCard = props => {
 						<Gridicon icon="notice" size={ 16 } className={ styles.iconError } />
 					</div>
 					<div className={ styles.contentContainer }>
-						<Text variant="body-small" className="value-section__heading">
+						<Text variant="body-sm" className="value-section__heading">
 							{ __( 'The last backup attempt failed.', 'jetpack-my-jetpack' ) }
 							<InfoTooltip
 								tracksEventName={ 'backup_card_tooltip_open' }
@@ -159,7 +159,7 @@ const BackupCard = props => {
 								</>
 							</InfoTooltip>
 						</Text>
-						<Text variant="body-small" className={ styles.error_description }>
+						<Text variant="body-sm" className={ styles.error_description }>
 							{ __( 'Check out our troubleshooting guide.', 'jetpack-my-jetpack' ) }
 						</Text>
 					</div>
@@ -203,7 +203,7 @@ const WithBackupsValueSection = props => {
 	};
 
 	const WithBackupsDescription = () => (
-		<Text variant="body-small" className={ styles.description }>
+		<Text variant="body-sm" className={ styles.description }>
 			<span>{ __( 'Activity Detected', 'jetpack-my-jetpack' ) }</span>
 			<span className={ styles.time }>
 				{ getTimeSinceLastRenewableEvent( lastRewindableEventTime ) }

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/contextual-card-info.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/contextual-card-info.jsx
@@ -1,10 +1,11 @@
 /**
  * External dependencies
  */
-import { Text, LoadingPlaceholder } from '@automattic/jetpack-components';
+import { LoadingPlaceholder } from '@automattic/jetpack-components';
 import { formatNumberCompact } from '@automattic/number-formatters';
 import { __, sprintf } from '@wordpress/i18n';
 import { arrowUp, arrowDown, Icon } from '@wordpress/icons';
+import { Text } from '@wordpress/ui';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 /**

--- a/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-cards-section/videopress-card/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Text } from '@automattic/jetpack-components';
+import { Text } from '@wordpress/ui';
 import { useCallback, useMemo } from 'react';
 import { PRODUCT_STATUSES } from '../../../constants';
 import {
@@ -56,7 +56,7 @@ const VideopressCard: ProductCardComponent = props => {
 
 	const Description = useCallback( () => {
 		return (
-			<Text variant="body-small" className="description">
+			<Text variant="body-sm" className="description">
 				{ descriptionText || detail.description }
 				{ isPluginActive && ! videoCount && (
 					<InfoTooltip

--- a/projects/packages/my-jetpack/changelog/try-my-jetpack-overview-wp-ui
+++ b/projects/packages/my-jetpack/changelog/try-my-jetpack-overview-wp-ui
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Internal refactor to use core WordPress UI primitives. No user-facing change.
+
+


### PR DESCRIPTION
Partial of #48160 — My Jetpack dashboard section.

## Proposed changes

Per-page migration pass on the **My Jetpack overview page** (`/wp-admin/admin.php?page=my-jetpack#/overview`): swap safe `Text` and `Button` usages from `@automattic/jetpack-components` to `@wordpress/ui` v0.11.0. Adds `@wordpress/ui` to the `my-jetpack` package dependencies at the version already used by sibling packages (forms, newsletter, publicize, charts, components).

## Does this pull request change what data or activity we track or use?
No

### Files migrated (9)

**Text → `@wordpress/ui` Text** with variant mapping (`body`→`body-md`, `body-small`→`body-sm`, `label`→`body-sm`, `title-medium`→`heading-lg`):
- `packages/my-jetpack/_inc/components/connected-product-card/index.tsx`
- `packages/my-jetpack/_inc/components/product-card/status.tsx`
- `packages/my-jetpack/_inc/components/connection-status-card/index.tsx`
- `packages/my-jetpack/_inc/components/card/index.jsx`
- `packages/my-jetpack/_inc/components/plans-section/index.tsx` (Text only — Buttons left for follow-up)
- `packages/my-jetpack/_inc/components/product-cards-section/backup-card/index.jsx`
- `packages/my-jetpack/_inc/components/product-cards-section/videopress-card/index.tsx`
- `packages/my-jetpack/_inc/components/product-cards-section/contextual-card-info.jsx`

**Button → `@wordpress/ui` Button** (`variant="secondary"`→`"outline"`):
- `packages/my-jetpack/_inc/components/product-card/recommendation-actions.tsx`

### Other information
- [ ] Generate changelog entries for this PR (using AI).

## Out of scope (follow-up PRs)

- `action-button/index.tsx` + `action-button/secondary-button.tsx` — pervasive `href`/`isExternalLink`/`weight` — needs coordinated Link migration
- `plans-section/index.tsx` Button usages — all `variant="link"` + `href` + `isExternalLink` + `weight="regular"` (inline `TODO` at top of file)
- `golden-token/tooltip/index.tsx` — `variant="link"`
- `connection-status-card/index.tsx` `variant="link"` Button — kept on `@wordpress/components`
- Interstitial flow files — not on overview render path
- Col/Container → Stack, Gridicon → `@wordpress/icons`, and per-component migrations (JetpackIcon, JetpackLogo, LoadingPlaceholder, Notice, Spinner, UpsellBanner, GlobalNotices, DotPager, ThemeProvider) — separate PRs per issue #48160

## Real-screen before / after

Both screenshots captured on a live Jurassic Ninja site with Jetpack connected. Before = clean trunk rebuild (`54cb1b001a`). After = this branch's build with the migrations applied.

| Before (trunk, rebuilt) | After (this PR) |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/try/my-jetpack-overview-wp-ui/real-before.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/try/my-jetpack-overview-wp-ui/real-after.png) |

Both renders are pixel-identical (739,707 bytes each). DOM verification on the branch build: `__body-md`, `__body-sm`, `__heading-lg`, `__is-neutral` classes confirmed present — migration is live. No layout/visual regressions.

_Investigated an earlier visual "regression" I thought I saw in the Views chart — turned out to be a transient Stats-widget render state in my very first trunk screenshot (chart bars displayed at a larger relative height during initial data load). Subsequent renders of both trunk and this branch are identical. My PR does not affect the Stats widget._

## Notes on the migration

1. **Build order matters**: `pnpm jetpack build packages/my-jetpack --production` must run before `pnpm jetpack build plugins/jetpack --production` — the plugin build bundles pre-built package outputs, so package changes need to be refreshed first.
2. **Version parity**: pinned `@wordpress/ui` at `0.11.0` to match forms, newsletter, publicize, charts, and js-packages/components. A version mismatch would cause pnpm to resolve two copies and their CSS module hashes to differ.
3. **Text semantic change**: `@automattic/jetpack-components` Text renders `title-medium`→`<h3>`, `body`→`<p>`, etc. `@wordpress/ui` Text always renders `<span>`. Callsites on the overview page do not rely on block-level defaults, so no layout impact observed, but this is a consideration for future migrations of files where the variant was carrying block-level styling.

## Testing instructions

* Visit My Jetpack overview (`admin.php?page=my-jetpack#/overview`).
* Verify product cards, plan section, and connection status card render identically to trunk.
* Confirm no console errors.
* Spot-check Text typography and Button appearance in the admin.