### PR TITLE
Skills: Add jetpack-screenshot for before/after Jurassic Ninja shots

### DIFF
--- a/.agents/skills/jetpack-pr.md
+++ b/.agents/skills/jetpack-pr.md
@@ -16,8 +16,9 @@ Instructions:
    - Fixes #: Link to issue if applicable (or remove if none)
    - Proposed changes: Bullet points of functional changes
    - Testing instructions: Step-by-step how to test the changes
-5. Create the PR using `gh pr create`, providing the prepared content for the title and body (e.g., with `--title` and `--body` flags)
-6. Add required labels:
+5. If the diff touches UI (admin pages, blocks, components, CSS/SCSS, or JS/TSX under `projects/plugins/*` or `projects/js-packages/*`), suggest capturing real-screen before/after screenshots on a Jurassic Ninja site via the `jetpack-screenshot` skill and including them in the PR body. Skip the suggestion when the PR is purely backend/docs/tooling.
+6. Create the PR using `gh pr create`, providing the prepared content for the title and body (e.g., with `--title` and `--body` flags)
+7. Add required labels:
    - `[Status] *` - use `[Status] In Progress` by default, or `[Status] Needs Review` if ready for review
 
 When using `--title` and `--body` with `gh pr create`, the template is not auto-filled; you must format the PR body to match the template structure yourself. Alternatively, omit `--body` to open an editor with the template pre-filled. Deduce all information from git history and code changes - do not ask the user for input.

--- a/.agents/skills/jetpack-screenshot.md
+++ b/.agents/skills/jetpack-screenshot.md
@@ -7,7 +7,7 @@ description: >
   or says "/jetpack-screenshot". Works with any browser automation tool available
   to the agent (chrome-devtools MCP, Playwright MCP, cmux browser, or similar)
   and leans on jetpack-test-jurassic-ninja for syncing plugin state.
-allowed-tools: Bash(git rev-parse:*), Bash(git remote:*), Bash(git hash-object:*), Bash(git mktree:*), Bash(git commit-tree:*), Bash(git update-ref:*), Bash(git push:*), Bash(git rev-list:*), Bash(git show-ref:*), Bash(git diff:*), Bash(mktemp:*), Bash(ls:*), Bash(command -v:*), Bash(magick:*), Read
+allowed-tools: Bash(git rev-parse:*), Bash(git remote:*), Bash(git hash-object:*), Bash(git mktree:*), Bash(git commit-tree:*), Bash(git update-ref:*), Bash(git push:*), Bash(git rev-list:*), Bash(git show-ref:*), Bash(git diff:*), Bash(mktemp:*), Bash(command -v:*), Bash(magick:*)
 ---
 
 # Jetpack Screenshot — Before/After on Jurassic Ninja
@@ -17,8 +17,8 @@ Capture real-screen before/after screenshots on a Jurassic Ninja site for a Jetp
 Two pieces must exist in the environment — verify both before starting:
 
 1. **A browser automation tool** capable of: navigating to a URL, setting viewport size, waiting for load/idle, and capturing a PNG screenshot. Any of these is fine — pick whichever is connected, in this order of preference:
-   - **chrome-devtools MCP** (tools prefixed `mcp__chrome-devtools__*`) — preferred when both the main and `isolated` profile are available.
-   - **Playwright MCP** (tools prefixed `mcp__playwright__*` or similar).
+   - **chrome-devtools MCP** — look for tools like `navigate_page` / `take_screenshot`. Prefix varies by install (`mcp__chrome-devtools__*`, `mcp__plugin_<pkg>_chrome-devtools__*`, etc.).
+   - **Playwright MCP** — look for `browser_navigate` / `browser_take_screenshot`.
    - **cmux browser** (`cmux browser open|navigate|wait|screenshot …`, if the cmux socket is present at `/tmp/cmux.sock`).
    - A locally installable headless option (`npx playwright screenshot …`, `puppeteer`, etc.) as a last resort.
 
@@ -53,7 +53,7 @@ If none are available, tell the user:
 
 ### 4. A ready JN site
 
-Use the `jetpack-test-jurassic-ninja` skill's discovery step (load provider → list-sites) to find a target. If none exist, delegate the fix to that skill's guidance (create at https://jurassic.ninja/create).
+Run `jetpack-test-jurassic-ninja`'s pre-flight to ensure a target site is reachable. Let that skill own site discovery, SSH/password handling, and creation guidance — don't restate it here.
 
 ## Workflow
 
@@ -78,13 +78,13 @@ Allocate a temp dir once for all shots:
 OUT=$(mktemp -d -t jp-ss.XXXXXX)
 ```
 
+Open `https://{domain}/?auto_login` once, wait for the dashboard, and resize the viewport to the chosen size (default `1440×900`). Reuse the same page/surface for every path below — don't re-open or re-resize.
+
 Then, for each admin path, use the browser tool to:
 
-1. **Open** `https://{domain}/?auto_login` (first path only; reuse the same page/surface for subsequent paths).
-2. **Wait** for the dashboard to finish loading, then **navigate** to the admin path.
-3. **Resize** the viewport to the chosen size (default `1440×900`).
-4. **Wait** until the page is idle — a stable selector, `networkidle`, or `document.readyState === 'complete'`, whichever the browser tool supports.
-5. **Capture** a viewport (not full-page) PNG and save it as `$OUT/before-<slug>.png`. Derive `<slug>` from the last path segment or a short hash — one `<slug>` per admin path.
+1. **Navigate** to the admin path.
+2. **Wait** until the page is idle — a stable selector, `networkidle`, or `document.readyState === 'complete'`, whichever the browser tool supports.
+3. **Capture** a viewport (not full-page) PNG and save it as `$OUT/before-<slug>.png`. Derive `<slug>` from the last path segment or a short hash — one `<slug>` per admin path.
 
 Tool-specific hints:
 - **chrome-devtools MCP**: `new_page` → `navigate_page` → `resize_page` → `wait_for` or `evaluate_script` → `take_screenshot` with `fullPage: false`.
@@ -106,7 +106,8 @@ If the user wants one image per path instead of two, stitch with ImageMagick whe
 
 ```bash
 if command -v magick >/dev/null; then
-    for slug in $(ls "$OUT"/before-*.png | sed 's#.*/before-\(.*\)\.png#\1#'); do
+    for f in "$OUT"/before-*.png; do
+        slug="${f##*/before-}"; slug="${slug%.png}"
         magick "$OUT/before-$slug.png" "$OUT/after-$slug.png" +append "$OUT/before-after-$slug.png"
     done
 fi
@@ -116,26 +117,23 @@ Don't fail the skill if the composite step fails — just fall back to pushing t
 
 ### 6. Publish via git plumbing
 
-Build a tree with only the PNGs and push to `refs/heads/screenshots/<branch>` on `origin` (force-update). This uses plumbing commands so the working tree is never touched:
+Build a tree with only the PNGs and push to `refs/heads/screenshots/<branch>` on `origin` (force-update). This uses plumbing commands so the working tree is never touched. Pipe the loop directly into `git mktree` — accumulating entries via `$(printf '…\n')` strips trailing newlines and breaks multi-PNG runs.
 
 ```bash
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 REF="refs/heads/screenshots/${BRANCH}"
 
-TREE_ENTRIES=""
-for png in "$OUT"/*.png; do
-    BLOB="$(git hash-object -w "$png")"
-    NAME="$(basename "$png")"
-    TREE_ENTRIES+="$(printf '100644 blob %s\t%s\n' "$BLOB" "$NAME")"
-done
-
-TREE="$(echo "$TREE_ENTRIES" | git mktree)"
+TREE="$(
+    for png in "$OUT"/*.png; do
+        printf '100644 blob %s\t%s\n' "$(git hash-object -w "$png")" "$(basename "$png")"
+    done | git mktree
+)"
 COMMIT="$(git commit-tree "$TREE" -m "Screenshots for ${BRANCH}")"
 git update-ref "$REF" "$COMMIT"
 git push --force origin "$REF"
 ```
 
-If a screenshots ref already exists for this branch and the user has taken additional shots, prefer replacing (force-push) over appending — the ref is cheap, short-lived, and never merged.
+The ref is cheap, short-lived, and never merged — force-pushing on re-runs is the intended behavior.
 
 ### 7. Emit paste-ready markdown
 
@@ -155,7 +153,5 @@ If a side-by-side composite was produced, offer that markdown variant instead.
 
 ## Notes
 
-- The screenshots ref is separate from the PR branch — it never gets merged and doesn't show up in the PR diff.
-- GitHub serves the images from `raw/`, so privacy matches the repo: Jetpack is public; anything captured will be public. Don't capture pages that could contain private data (site-owner emails, tokens). Prefer a brand-new JN site for captures.
-- Screenshots render in the PR body without requiring the user to drag-and-drop into the GitHub web UI.
-- If rsync or capture fails partway through, the local temp dir still contains whatever was captured — report the path so the user can retry step 6 manually.
+- **Privacy:** Jetpack is a public repo and the screenshots ref is served from `raw.githubusercontent.com`. Anything captured becomes public. Don't point captures at pages that could expose private data (site-owner emails, tokens). Prefer a brand-new JN site.
+- **Recovery:** if rsync or capture fails partway through, the local temp dir still contains whatever was captured — report the path so the user can retry step 6 manually.

--- a/.agents/skills/jetpack-screenshot.md
+++ b/.agents/skills/jetpack-screenshot.md
@@ -1,0 +1,147 @@
+---
+description: >
+  Capture before/after UI screenshots of a Jetpack change on a live Jurassic Ninja site
+  and publish them to a screenshots ref on origin so they render in the PR body.
+  Use when the user wants before/after screenshots for a Jetpack PR, mentions
+  "jurassic ninja screenshot", "JN screenshot", "real-screen before/after",
+  or says "/jetpack-screenshot". Depends on the chrome-devtools MCP for
+  navigation/capture and on jetpack-test-jurassic-ninja for syncing plugin state.
+allowed-tools: Bash(git rev-parse:*), Bash(git remote:*), Bash(git hash-object:*), Bash(git mktree:*), Bash(git commit-tree:*), Bash(git update-ref:*), Bash(git push:*), Bash(git rev-list:*), Bash(git show-ref:*), Bash(mktemp:*), Bash(sips:*), Bash(file:*), Bash(ls:*), Read
+---
+
+# Jetpack Screenshot — Before/After on Jurassic Ninja
+
+Capture real-screen before/after screenshots on a Jurassic Ninja site for a Jetpack PR, then publish them to `refs/heads/screenshots/<branch>` on `origin` so they render inline in the PR body as `https://github.com/<org>/<repo>/raw/screenshots/<branch>/<file>.png`.
+
+Two pieces must exist in the environment — verify both before starting:
+
+1. The **chrome-devtools MCP** (tools prefixed `mcp__chrome-devtools__*`). Used to navigate, resize, and capture.
+2. A reachable **Jurassic Ninja site** with admin auto-login. Use the `jetpack-test-jurassic-ninja` skill for syncing plugin state to it.
+
+## Pre-flight Checks
+
+### 1. On a PR branch (not trunk)
+
+```bash
+git rev-parse --abbrev-ref HEAD
+```
+
+If the branch is `trunk`, stop — the screenshots ref encodes the branch name; run this from the feature branch.
+
+### 2. Remote is the Automattic Jetpack repo
+
+```bash
+git remote get-url origin
+```
+
+Expect `github.com:Automattic/jetpack` (SSH or HTTPS form). If not, stop and ask the user which remote to push screenshots to.
+
+### 3. chrome-devtools MCP available
+
+If `mcp__chrome-devtools__take_screenshot` is not in the tool list, tell the user:
+
+> The chrome-devtools MCP is not connected. Run `claude mcp list` to confirm, then reconnect it before continuing.
+
+### 4. A ready JN site
+
+Use the `jetpack-test-jurassic-ninja` skill's discovery step (load provider → list-sites) to find a target. If none exist, delegate the fix to that skill's guidance (create at https://jurassic.ninja/create).
+
+## Workflow
+
+Capture runs in two passes — **before** (pre-change baseline) and **after** (PR branch applied). The user decides what "before" means; the default is the current published state (from wp.org) already installed on the JN site. If the user wants trunk as the baseline, sync trunk first with `jetpack-test-jurassic-ninja`.
+
+### 1. Agree on what to capture
+
+Ask — once, concisely — for:
+- **Admin path(s)** to capture, e.g. `/wp-admin/admin.php?page=jetpack-protect#/firewall`. Accept one or more.
+- **Baseline** (`before` state): `wp.org` (default) or `trunk` (sync trunk via the JN skill first).
+- **Viewport**: default `1440x900`, override on request.
+
+Do not ask anything else — pick reasonable defaults for everything below.
+
+### 2. Capture the baseline (`before`)
+
+Ensure the baseline is in place on the JN site (no-op if baseline is "wp.org and Jetpack is already installed"; otherwise invoke `jetpack-test-jurassic-ninja` synced to `trunk`).
+
+For each admin path:
+
+1. `mcp__chrome-devtools__new_page` → `https://{domain}/?auto_login` (first path only; reuse page after)
+2. Wait for dashboard to load, then `navigate_page` to the admin path.
+3. `mcp__chrome-devtools__resize_page` to the chosen viewport.
+4. `mcp__chrome-devtools__wait_for` on a stable selector, or a short `evaluate_script` (`document.readyState === 'complete'`).
+5. `mcp__chrome-devtools__take_screenshot` with `fullPage: false` (viewport shot). Save as `before-<slug>.png` in a temp dir:
+
+   ```bash
+   OUT=$(mktemp -d -t jp-ss.XXXXXX)
+   ```
+
+   Use one `<slug>` per admin path, derived from the last path segment or a short hash.
+
+### 3. Apply the PR branch (`after` state)
+
+Invoke the `jetpack-test-jurassic-ninja` skill to rsync the plugin(s) modified by this branch. Determine the plugin from `git diff --name-only origin/trunk...HEAD | grep '^projects/plugins/' | cut -d/ -f3 | sort -u` — if exactly one plugin is touched, pass it; otherwise ask which to sync.
+
+### 4. Capture after
+
+Repeat the capture from step 2, saving each as `after-<slug>.png` in the same temp dir. Reuse the existing page — just `navigate_page` to the admin path and re-capture.
+
+### 5. (Optional) Side-by-side composite
+
+If the user wants one image per path instead of two, stitch with `sips` (macOS, always available):
+
+```bash
+# Horizontal concat via ImageMagick if installed; otherwise skip and push both files.
+if command -v magick >/dev/null; then
+    for slug in $(ls "$OUT"/before-*.png | sed 's#.*/before-\(.*\)\.png#\1#'); do
+        magick "$OUT/before-$slug.png" "$OUT/after-$slug.png" +append "$OUT/before-after-$slug.png"
+    done
+fi
+```
+
+Don't fail the skill if the composite step fails — just fall back to pushing the raw `before-*.png` / `after-*.png` pair.
+
+### 6. Publish via git plumbing
+
+Build a tree with only the PNGs and push to `refs/heads/screenshots/<branch>` on `origin` (force-update). This uses plumbing commands so the working tree is never touched:
+
+```bash
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+REF="refs/heads/screenshots/${BRANCH}"
+
+TREE_ENTRIES=""
+for png in "$OUT"/*.png; do
+    BLOB="$(git hash-object -w "$png")"
+    NAME="$(basename "$png")"
+    TREE_ENTRIES+="$(printf '100644 blob %s\t%s\n' "$BLOB" "$NAME")"
+done
+
+TREE="$(echo "$TREE_ENTRIES" | git mktree)"
+COMMIT="$(git commit-tree "$TREE" -m "Screenshots for ${BRANCH}")"
+git update-ref "$REF" "$COMMIT"
+git push --force origin "$REF"
+```
+
+If a screenshots ref already exists for this branch and the user has taken additional shots, prefer replacing (force-push) over appending — the ref is cheap, short-lived, and never merged.
+
+### 7. Emit paste-ready markdown
+
+Print one markdown block the user can paste into the PR body. Use `https://github.com/<org>/<repo>/raw/screenshots/<branch>/<file>.png` URLs. Example with a two-column table:
+
+```markdown
+## Real-screen before / after
+
+Captured on a live Jurassic Ninja site at `<admin-path>` at 1440×900.
+
+| Before | After |
+|---|---|
+| ![before](https://github.com/Automattic/jetpack/raw/screenshots/<branch>/before-<slug>.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/<branch>/after-<slug>.png) |
+```
+
+If a side-by-side composite was produced, offer that markdown variant instead.
+
+## Notes
+
+- The screenshots ref is separate from the PR branch — it never gets merged and doesn't show up in the PR diff.
+- GitHub serves the images from `raw/`, so privacy matches the repo: Jetpack is public; anything captured will be public. Don't capture pages that could contain private data (site-owner emails, tokens). Prefer a brand-new JN site for captures.
+- Screenshots render in the PR body without requiring the user to drag-and-drop into the GitHub web UI.
+- If rsync or capture fails partway through, the local temp dir still contains whatever was captured — report the path so the user can retry step 6 manually.

--- a/.agents/skills/jetpack-screenshot.md
+++ b/.agents/skills/jetpack-screenshot.md
@@ -4,8 +4,9 @@ description: >
   and publish them to a screenshots ref on origin so they render in the PR body.
   Use when the user wants before/after screenshots for a Jetpack PR, mentions
   "jurassic ninja screenshot", "JN screenshot", "real-screen before/after",
-  or says "/jetpack-screenshot". Depends on the chrome-devtools MCP for
-  navigation/capture and on jetpack-test-jurassic-ninja for syncing plugin state.
+  or says "/jetpack-screenshot". Works with any browser automation tool available
+  to the agent (chrome-devtools MCP, Playwright MCP, cmux browser, or similar)
+  and leans on jetpack-test-jurassic-ninja for syncing plugin state.
 allowed-tools: Bash(git rev-parse:*), Bash(git remote:*), Bash(git hash-object:*), Bash(git mktree:*), Bash(git commit-tree:*), Bash(git update-ref:*), Bash(git push:*), Bash(git rev-list:*), Bash(git show-ref:*), Bash(git diff:*), Bash(mktemp:*), Bash(ls:*), Bash(command -v:*), Bash(magick:*), Read
 ---
 
@@ -15,7 +16,13 @@ Capture real-screen before/after screenshots on a Jurassic Ninja site for a Jetp
 
 Two pieces must exist in the environment — verify both before starting:
 
-1. The **chrome-devtools MCP** (tools prefixed `mcp__chrome-devtools__*`). Used to navigate, resize, and capture.
+1. **A browser automation tool** capable of: navigating to a URL, setting viewport size, waiting for load/idle, and capturing a PNG screenshot. Any of these is fine — pick whichever is connected, in this order of preference:
+   - **chrome-devtools MCP** (tools prefixed `mcp__chrome-devtools__*`) — preferred when both the main and `isolated` profile are available.
+   - **Playwright MCP** (tools prefixed `mcp__playwright__*` or similar).
+   - **cmux browser** (`cmux browser open|navigate|wait|screenshot …`, if the cmux socket is present at `/tmp/cmux.sock`).
+   - A locally installable headless option (`npx playwright screenshot …`, `puppeteer`, etc.) as a last resort.
+
+   The rest of this skill refers to these as "the browser tool" — map each step to the equivalent call in whatever tool is available.
 2. A reachable **Jurassic Ninja site** with admin auto-login. Use the `jetpack-test-jurassic-ninja` skill for syncing plugin state to it.
 
 ## Pre-flight Checks
@@ -36,11 +43,13 @@ git remote get-url origin
 
 Expect `github.com:Automattic/jetpack` (SSH or HTTPS form). If not, stop and ask the user which remote to push screenshots to.
 
-### 3. chrome-devtools MCP available
+### 3. A browser automation tool is available
 
-If `mcp__chrome-devtools__take_screenshot` is not in the tool list, tell the user:
+Inventory what's connected in the current agent session, in preference order (chrome-devtools MCP → Playwright MCP → cmux browser → local Playwright/Puppeteer CLI). Pick the first one that can do all four of: navigate, resize, wait for load, and capture a PNG to disk.
 
-> The chrome-devtools MCP is not connected. Run `claude mcp list` to confirm, then reconnect it before continuing.
+If none are available, tell the user:
+
+> No browser automation tool is connected. Options: start the chrome-devtools MCP (`claude mcp list` to verify), connect a Playwright MCP, or run under cmux so `cmux browser` is reachable. Any of those is enough.
 
 ### 4. A ready JN site
 
@@ -63,19 +72,25 @@ Do not ask anything else — pick reasonable defaults for everything below.
 
 Ensure the baseline is in place on the JN site (no-op if baseline is "wp.org and Jetpack is already installed"; otherwise invoke `jetpack-test-jurassic-ninja` synced to `trunk`).
 
-For each admin path:
+Allocate a temp dir once for all shots:
 
-1. `mcp__chrome-devtools__new_page` → `https://{domain}/?auto_login` (first path only; reuse page after)
-2. Wait for dashboard to load, then `navigate_page` to the admin path.
-3. `mcp__chrome-devtools__resize_page` to the chosen viewport.
-4. `mcp__chrome-devtools__wait_for` on a stable selector, or a short `evaluate_script` (`document.readyState === 'complete'`).
-5. `mcp__chrome-devtools__take_screenshot` with `fullPage: false` (viewport shot). Save as `before-<slug>.png` in a temp dir:
+```bash
+OUT=$(mktemp -d -t jp-ss.XXXXXX)
+```
 
-   ```bash
-   OUT=$(mktemp -d -t jp-ss.XXXXXX)
-   ```
+Then, for each admin path, use the browser tool to:
 
-   Use one `<slug>` per admin path, derived from the last path segment or a short hash.
+1. **Open** `https://{domain}/?auto_login` (first path only; reuse the same page/surface for subsequent paths).
+2. **Wait** for the dashboard to finish loading, then **navigate** to the admin path.
+3. **Resize** the viewport to the chosen size (default `1440×900`).
+4. **Wait** until the page is idle — a stable selector, `networkidle`, or `document.readyState === 'complete'`, whichever the browser tool supports.
+5. **Capture** a viewport (not full-page) PNG and save it as `$OUT/before-<slug>.png`. Derive `<slug>` from the last path segment or a short hash — one `<slug>` per admin path.
+
+Tool-specific hints:
+- **chrome-devtools MCP**: `new_page` → `navigate_page` → `resize_page` → `wait_for` or `evaluate_script` → `take_screenshot` with `fullPage: false`.
+- **Playwright MCP**: `browser_navigate` → `browser_resize` → `browser_wait_for` → `browser_take_screenshot` with `fullPage: false`.
+- **cmux browser**: `cmux browser open` → `cmux browser $SURF navigate` → `cmux browser $SURF wait --load-state complete` → `cmux browser $SURF screenshot --out "$OUT/before-<slug>.png"`.
+- **Local Playwright CLI**: `npx playwright screenshot --viewport-size=1440,900 --wait-for-timeout=2000 "$URL" "$OUT/before-<slug>.png"`.
 
 ### 3. Apply the PR branch (`after` state)
 
@@ -83,7 +98,7 @@ Invoke the `jetpack-test-jurassic-ninja` skill to rsync the plugin(s) modified b
 
 ### 4. Capture after
 
-Repeat the capture from step 2, saving each as `after-<slug>.png` in the same temp dir. Reuse the existing page — just `navigate_page` to the admin path and re-capture.
+Repeat the capture from step 2, saving each as `after-<slug>.png` in the same temp dir. Reuse the existing page/surface — navigate to the admin path and re-capture. Do not open a fresh page unless the previous one was closed.
 
 ### 5. (Optional) Side-by-side composite
 

--- a/.agents/skills/jetpack-screenshot.md
+++ b/.agents/skills/jetpack-screenshot.md
@@ -6,7 +6,7 @@ description: >
   "jurassic ninja screenshot", "JN screenshot", "real-screen before/after",
   or says "/jetpack-screenshot". Depends on the chrome-devtools MCP for
   navigation/capture and on jetpack-test-jurassic-ninja for syncing plugin state.
-allowed-tools: Bash(git rev-parse:*), Bash(git remote:*), Bash(git hash-object:*), Bash(git mktree:*), Bash(git commit-tree:*), Bash(git update-ref:*), Bash(git push:*), Bash(git rev-list:*), Bash(git show-ref:*), Bash(mktemp:*), Bash(sips:*), Bash(file:*), Bash(ls:*), Read
+allowed-tools: Bash(git rev-parse:*), Bash(git remote:*), Bash(git hash-object:*), Bash(git mktree:*), Bash(git commit-tree:*), Bash(git update-ref:*), Bash(git push:*), Bash(git rev-list:*), Bash(git show-ref:*), Bash(git diff:*), Bash(mktemp:*), Bash(ls:*), Bash(command -v:*), Bash(magick:*), Read
 ---
 
 # Jetpack Screenshot — Before/After on Jurassic Ninja
@@ -87,10 +87,9 @@ Repeat the capture from step 2, saving each as `after-<slug>.png` in the same te
 
 ### 5. (Optional) Side-by-side composite
 
-If the user wants one image per path instead of two, stitch with `sips` (macOS, always available):
+If the user wants one image per path instead of two, stitch with ImageMagick when available:
 
 ```bash
-# Horizontal concat via ImageMagick if installed; otherwise skip and push both files.
 if command -v magick >/dev/null; then
     for slug in $(ls "$OUT"/before-*.png | sed 's#.*/before-\(.*\)\.png#\1#'); do
         magick "$OUT/before-$slug.png" "$OUT/after-$slug.png" +append "$OUT/before-after-$slug.png"

--- a/.claude/skills/jetpack-screenshot/SKILL.md
+++ b/.claude/skills/jetpack-screenshot/SKILL.md
@@ -1,0 +1,1 @@
+@../../../.agents/skills/jetpack-screenshot.md


### PR DESCRIPTION
## Proposed changes

* Add a new agent skill `jetpack-screenshot` at `.agents/skills/jetpack-screenshot.md` (with a pointer SKILL.md under `.claude/skills/jetpack-screenshot/`).
* The skill captures real-screen before/after screenshots on a Jurassic Ninja site — using the **chrome-devtools MCP** for navigation and capture, and leaning on the existing `jetpack-test-jurassic-ninja` skill for syncing plugin state to the JN site.
* After capture, the skill publishes the PNGs to `refs/heads/screenshots/<branch>` on `origin` via git plumbing (`hash-object` + `mktree` + `commit-tree` + `update-ref` + `push --force`). This keeps the working tree untouched, never shows up in the PR diff, and produces paste-ready `github.com/Automattic/jetpack/raw/screenshots/<branch>/<file>.png` URLs that render inline in the PR body.
* Nudges `jetpack-pr` to suggest running the skill when the diff touches UI (admin pages, blocks, components, CSS/SCSS, or JS/TSX under `projects/plugins/*` / `projects/js-packages/*`). Backend/docs/tooling PRs are unaffected.

The screenshots ref is never merged — it's a cheap, short-lived, force-updated ref that only exists to serve images for the PR body. Same pattern I've been using manually on recent `@wordpress/ui` migration PRs (e.g. [#48151](https://github.com/Automattic/jetpack/pull/48151)), now packaged so any contributor with the chrome-devtools MCP + a JN site can produce the same output without hand-running each step.

## Does this pull request change what data or activity we track or use?

No. This PR only adds agent-configuration files under `.agents/` and `.claude/` and does not touch any shipped Jetpack code, user-facing behavior, tracking, or stored data. The skill it describes runs locally on a contributor's machine against ephemeral Jurassic Ninja sandboxes; no data flows from the skill into Jetpack itself or into user sites.

## Testing instructions

1. From a Jetpack feature branch that touches UI, start Claude Code with the chrome-devtools MCP connected and at least one Jurassic Ninja site available.
2. Invoke the skill: "take before/after screenshots for this PR" (or `/jetpack-screenshot`).
3. When prompted, provide an admin path (e.g. `/wp-admin/admin.php?page=jetpack#/dashboard`). Accept the default viewport (1440×900) and default `wp.org` baseline unless you want `trunk`.
4. Let the skill capture the `before` shot, invoke `jetpack-test-jurassic-ninja` to rsync your branch, and capture the `after` shot.
5. Verify the skill reports: (a) a pushed ref under `origin/screenshots/<your-branch>`, and (b) a markdown block with `raw/screenshots/<your-branch>/…` URLs.
6. Paste the markdown into the PR body and confirm the images render on github.com.
7. Also run `/jetpack-pr` on a UI-touching branch and verify it surfaces a suggestion to run `jetpack-screenshot`. Run it on a backend-only branch and verify no suggestion is shown.

No changelog entry is required — changes are outside `/projects/`.
