### PR TITLE
Components: Migrate RadioControl to @wordpress/components

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
@@ -1,5 +1,4 @@
 import {
-	RadioControl,
 	ToggleControl,
 	getRedirectUrl,
 	Container,
@@ -7,7 +6,7 @@ import {
 	Chip,
 	Button as JetpackButton,
 } from '@automattic/jetpack-components';
-import { ExternalLink } from '@wordpress/components';
+import { ExternalLink, RadioControl } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useCallback, useState } from 'react';

--- a/projects/plugins/jetpack/changelog/update-newsletter-radio-control-direct-import
+++ b/projects/plugins/jetpack/changelog/update-newsletter-radio-control-direct-import
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Newsletter Settings: Import RadioControl directly from @wordpress/components.


### PR DESCRIPTION
## Proposed changes

- Newsletter Settings: Import `RadioControl` from `@wordpress/components` directly instead of the pass-through re-export in `@automattic/jetpack-components`. Prop API is identical, so no call-site changes beyond the import.
- The `RadioControl` re-export in `@automattic/jetpack-components` is left in place.

Target is `@wordpress/components` (not `@wordpress/ui`) because `@wordpress/ui@0.11.0` does not ship a `RadioControl`, and the Gutenberg Storybook's **Design System / Components** sidebar doesn't list one.

Part of #48160.

## Screenshots

| Surface | Before (trunk on JN) | After (this branch on JN) |
|---|---|---|
| Newsletter → Email configuration → "For each new post email, include" | ![before](https://raw.githubusercontent.com/Automattic/jetpack/screenshots/radio-control-migration-48170/screenshots/before-email-include-radios.png) | ![after](https://raw.githubusercontent.com/Automattic/jetpack/screenshots/radio-control-migration-48170/screenshots/after-email-include-radios.png) |
| Newsletter → Subscription replies → "Reply-to settings" | ![before](https://raw.githubusercontent.com/Automattic/jetpack/screenshots/radio-control-migration-48170/screenshots/before-reply-to-radios.png) | ![after](https://raw.githubusercontent.com/Automattic/jetpack/screenshots/radio-control-migration-48170/screenshots/after-reply-to-radios.png) |

_Baseline + feature JN site: \`thoughtfully-remarkable-device.jurassic.ninja\` · rsync target: \`plugins/jetpack\`_

**Note:** before/after files are byte-identical (\`cmp\` clean) — confirming the pass-through is a strict no-op and this change introduces no rendered-DOM difference. Screenshots are hosted on a sibling orphan branch (\`screenshots/radio-control-migration-48170\`) so this PR's file diff stays pure-code.

## Testing instructions

1. \`jetpack build plugins/jetpack --deps\`.
2. On a site with Jetpack connected, visit **Jetpack → Settings → Newsletter**. (If the new \`page=jetpack-newsletter\` dashboard is enabled, temporarily disable it via \`add_filter( 'jetpack_wp_admin_newsletter_settings_enabled', '__return_false' );\`.)
3. Scroll to **Email configuration**:
   - Confirm the **"For each new post email, include"** group toggles between Full text / Excerpt.
   - Confirm the **"Reply-to settings"** group toggles between the three options.

- [x] Changelog entry added
- [x] Visual diff reviewed (before/after are byte-identical)