### PR TITLE
Remove "beta" and "new" badges everywhere

### DIFF
--- a/projects/js-packages/components/changelog/remove-beta
+++ b/projects/js-packages/components/changelog/remove-beta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove "new" style variant from the Chip component.

--- a/projects/js-packages/components/components/chip/style.module.scss
+++ b/projects/js-packages/components/components/chip/style.module.scss
@@ -11,8 +11,4 @@
 	line-height: 20px;
 	font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 
-	&.is-new {
-		background-color: var(--jp-green-5);
-		color: var(--jp-green-50);
-	}
 }

--- a/projects/packages/my-jetpack/changelog/remove-beta
+++ b/projects/packages/my-jetpack/changelog/remove-beta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove New badge style from the Jetpack AI product interstitial.

--- a/projects/packages/publicize/_inc/components/admin-page/toggles/social-notes-toggle/index.tsx
+++ b/projects/packages/publicize/_inc/components/admin-page/toggles/social-notes-toggle/index.tsx
@@ -91,7 +91,6 @@ const SocialNotesToggle: FC< SocialNotesToggleProps > = ( { disabled } ) => {
 	return (
 		<ToggleSection
 			title={ __( 'Enable Social Notes', 'jetpack-publicize-pkg' ) }
-			beta
 			disabled={ isUpdating || disabled }
 			checked={ isEnabled }
 			onChange={ toggleStatus }

--- a/projects/packages/publicize/_inc/components/admin-page/toggles/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/admin-page/toggles/styles.module.scss
@@ -72,15 +72,3 @@
 		}
 	}
 }
-
-.beta {
-	background: var(--jp-green-5);
-	color: var(--jp-green-60);
-	padding: 0.5px 6px;
-	border-radius: 3px;
-	font-size: 0.9rem;
-	display: inline-block;
-	margin-inline-start: 16px;
-	transform: translateY(-2px);
-	line-height: 22px;
-}

--- a/projects/packages/publicize/_inc/components/admin-page/toggles/toggle-section.tsx
+++ b/projects/packages/publicize/_inc/components/admin-page/toggles/toggle-section.tsx
@@ -10,11 +10,6 @@ type ToggleSectionProps = {
 	title: string;
 
 	/**
-	 * Whether the toggle is in beta.
-	 */
-	beta?: boolean;
-
-	/**
 	 * Callback to be called when the toggle is clicked.
 	 */
 	onChange: () => void;
@@ -51,7 +46,6 @@ type ToggleSectionProps = {
  */
 const ToggleSection: FC< ToggleSectionProps > = ( {
 	title,
-	beta,
 	onChange,
 	checked,
 	disabled,
@@ -72,7 +66,6 @@ const ToggleSection: FC< ToggleSectionProps > = ( {
 			) }
 			<Text className={ styles.title } variant="title-medium">
 				{ title }
-				{ beta && <div className={ styles.beta }>Beta</div> }
 			</Text>
 
 			{ children }

--- a/projects/packages/publicize/_inc/components/services/service-item.tsx
+++ b/projects/packages/publicize/_inc/components/services/service-item.tsx
@@ -76,13 +76,6 @@ export function ServiceItem( {
 				<div className={ styles[ 'service-basics' ] }>
 					<div className={ styles.heading }>
 						<span className={ styles.title }>{ service.label }</span>
-						{ service.badges?.length ? (
-							<div className={ styles.badges }>
-								{ service.badges.map( ( badge, index ) => (
-									<span key={ index }>{ badge }</span>
-								) ) }
-							</div>
-						) : null }
 					</div>
 					{ ! isSmall && ! serviceConnections.length ? (
 						<span className={ styles.description }>{ service.description }</span>

--- a/projects/packages/publicize/_inc/components/services/style.module.scss
+++ b/projects/packages/publicize/_inc/components/services/style.module.scss
@@ -39,12 +39,6 @@
 		align-items: center;
 	}
 
-	.badges {
-		display: flex;
-		gap: 0.5rem;
-	}
-
-
 	.title {
 		font-size: 16px;
 		line-height: 24px;

--- a/projects/packages/publicize/_inc/components/services/types.ts
+++ b/projects/packages/publicize/_inc/components/services/types.ts
@@ -5,7 +5,6 @@ export interface ServiceUiDetails {
 	icon: React.ComponentType< { iconSize: number } >;
 	examples?: Array< React.ComponentType >;
 	needsCustomInputs?: boolean;
-	badges?: Array< React.ReactNode >;
 }
 
 export interface SupportedService extends ConnectionService, ServiceUiDetails {}

--- a/projects/packages/publicize/_inc/components/services/utils.tsx
+++ b/projects/packages/publicize/_inc/components/services/utils.tsx
@@ -1,6 +1,4 @@
 import { SocialServiceIcon } from '@automattic/jetpack-components';
-import { Badge } from '@automattic/ui';
-import '@automattic/ui/style.css';
 import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -22,8 +20,6 @@ import { XNotice } from './x-notice';
  * @return The UI details for the service.
  */
 export function getServiceUiDetails( id: ConnectionService[ 'id' ] ): ServiceUiDetails {
-	const badgeNew = <Badge intent="info">{ __( 'New', 'jetpack-publicize-pkg' ) }</Badge>;
-
 	switch ( id ) {
 		case 'bluesky':
 			return {
@@ -240,7 +236,6 @@ export function getServiceUiDetails( id: ConnectionService[ 'id' ] ): ServiceUiD
 		case 'x':
 			return {
 				icon: props => <SocialServiceIcon serviceName="x" { ...props } />,
-				badges: [ badgeNew ],
 				description: __( 'Share with your X network.', 'jetpack-publicize-pkg' ),
 				examples: [
 					() => (

--- a/projects/packages/publicize/changelog/remove-beta
+++ b/projects/packages/publicize/changelog/remove-beta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove Beta and New badges from the Social admin page.

--- a/projects/plugins/boost/app/assets/src/js/features/lcp/lcp.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/lcp/lcp.tsx
@@ -1,5 +1,4 @@
 import Module from '$features/module/module';
-import Pill from '$features/ui/pill/pill';
 import { recordBoostEvent } from '$lib/utils/analytics';
 import RefreshIcon from '$svg/refresh';
 import { Button } from '@automattic/jetpack-components';
@@ -40,12 +39,7 @@ const Lcp = () => {
 	return (
 		<Module
 			slug="lcp"
-			title={
-				<>
-					{ __( 'Optimize LCP Images', 'jetpack-boost' ) }
-					<Pill text={ __( 'Beta', 'jetpack-boost' ) } />
-				</>
-			}
+			title={ __( 'Optimize LCP Images', 'jetpack-boost' ) }
 			worksOffline={ false }
 			description={
 				<p>

--- a/projects/plugins/boost/changelog/remove-beta
+++ b/projects/plugins/boost/changelog/remove-beta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove Beta label from the Optimize LCP Images module.

--- a/projects/plugins/jetpack/_inc/client/recommendations/feature-summary/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/feature-summary/index.jsx
@@ -1,6 +1,4 @@
 import { ExternalLink } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import { Badge } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useCallback, useMemo } from 'react';
 import { connect } from 'react-redux';
@@ -27,7 +25,6 @@ const FeatureSummaryComponent = props => {
 		featureSlug,
 		stepRoute,
 		summaryActivateButtonLabel,
-		isNew,
 		isInstalling,
 		startFeatureInstall,
 		endFeatureInstall,
@@ -106,10 +103,6 @@ const FeatureSummaryComponent = props => {
 				<span className="jp-recommendations-feature-summary__display-name-text">
 					{ displayName }
 				</span>
-				{ isNew && (
-					/* translators: 'New' is shown as a badge to indicate that this content has not been viewed before. */
-					<Badge intent="stable">{ __( 'New', 'jetpack' ) }</Badge>
-				) }
 			</Button>
 			<div className="jp-recommendations-feature-summary__actions">{ ctaButton }</div>
 		</div>

--- a/projects/plugins/jetpack/_inc/client/recommendations/feature-summary/resource.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/feature-summary/resource.jsx
@@ -1,6 +1,4 @@
 import { ExternalLink } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import { Badge } from '@wordpress/ui';
 import { useCallback } from 'react';
 import { connect } from 'react-redux';
 import Button from 'components/button';
@@ -10,7 +8,7 @@ import { getSummaryResourceProps } from '../feature-utils';
 import './style.scss';
 
 const ResourceSummaryComponent = props => {
-	const { displayName, ctaLabel, ctaLink, resourceSlug, isNew, stepRoute } = props;
+	const { displayName, ctaLabel, ctaLink, resourceSlug, stepRoute } = props;
 	const onLearnMoreClick = useCallback( () => {
 		analytics.tracks.recordEvent( 'jetpack_recommendations_summary_learn_more_click', {
 			feature: resourceSlug,
@@ -34,10 +32,6 @@ const ResourceSummaryComponent = props => {
 				<span className="jp-recommendations-feature-summary__display-name-text">
 					{ displayName }
 				</span>
-				{ isNew && (
-					/* translators: 'New' is shown as a badge to indicate that this content has not been viewed before. */
-					<Badge intent="stable">{ __( 'New', 'jetpack' ) }</Badge>
-				) }
 			</Button>
 			<div className="jp-recommendations-feature-summary__actions">
 				<div className="jp-recommendations-feature-summary__cta">

--- a/projects/plugins/jetpack/_inc/client/recommendations/prompts/prompt-layout/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/recommendations/prompts/prompt-layout/index.jsx
@@ -1,6 +1,4 @@
 import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
-import { Badge } from '@wordpress/ui';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -39,8 +37,7 @@ const SideContent = ( { isLoading, illustration, illustrationClassName, sidebarC
 };
 
 const PromptLayoutComponent = props => {
-	const { answer, description, illustration, progressBar, question, content, isNew, sidebarCard } =
-		props;
+	const { answer, description, illustration, progressBar, question, content, sidebarCard } = props;
 
 	return (
 		<div
@@ -49,9 +46,8 @@ const PromptLayoutComponent = props => {
 			} ) }
 		>
 			<div className="jp-recommendations-question__content">
-				{ ( isNew || progressBar ) && (
+				{ progressBar && (
 					<div className="jp-recommendations-question__progress-bar-wrap">
-						{ isNew && <Badge intent="stable">{ __( 'New', 'jetpack' ) }</Badge> }
 						<div className="jp-recommendations-question__progress-bar">{ progressBar }</div>
 					</div>
 				) }

--- a/projects/plugins/jetpack/_inc/client/writing/composing.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/composing.jsx
@@ -1,6 +1,5 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { __, _x } from '@wordpress/i18n';
-import { Badge, Stack } from '@wordpress/ui';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import CompactCard from 'components/card/compact';
@@ -207,13 +206,9 @@ export class Composing extends Component {
 			),
 			aiAssistantLink = (
 				<CompactCard className="jp-settings-card__configure-link">
-					<Stack align="center" gap="sm">
-						<a href={ `${ this.props.siteAdminUrl }admin.php?page=my-jetpack#/jetpack-ai` }>
-							{ __( 'Learn more about all Jetpack AI features', 'jetpack' ) }
-						</a>
-						{ /* TODO: remove this Badge once it's no longer "new" */ }
-						<Badge intent="stable">{ __( 'New', 'jetpack' ) }</Badge>
-					</Stack>
+					<a href={ `${ this.props.siteAdminUrl }admin.php?page=my-jetpack#/jetpack-ai` }>
+						{ __( 'Learn more about all Jetpack AI features', 'jetpack' ) }
+					</a>
 				</CompactCard>
 			);
 

--- a/projects/plugins/jetpack/changelog/remove-beta
+++ b/projects/plugins/jetpack/changelog/remove-beta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Remove New badges from the writing settings and recommendations screens.


### PR DESCRIPTION
We're moving all current "beta" and "new" badges, as these are all pretty old already.

For more context, see internal ref p1776538759336609-slack-C0D96691V


## Proposed changes
<!--- Explain what functional changes your PR includes -->


### Social

Visible only when "Social" plugin is active, not when "Social" module is active in Jetpack plugin.

Before
<img width="962" height="263" alt="image" src="https://github.com/user-attachments/assets/604d1e4c-43a5-4b28-8c46-aa6b29a7e44f" />

After
<img width="943" height="220" alt="image" src="https://github.com/user-attachments/assets/ee5047e5-15c4-4e1f-865b-1930c7839653" />

### Other uses

- Social services 
- Recommendations
- Writing settings
- Overall admin page wrapper

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Go to '..'
*