### PR TITLE
Newsletter: Migrate ToggleControl off @automattic/jetpack-components

### DIFF
--- a/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/email-settings.jsx
@@ -1,13 +1,12 @@
 import {
 	RadioControl,
-	ToggleControl,
 	getRedirectUrl,
 	Container,
 	Col,
 	Chip,
 	Button as JetpackButton,
 } from '@automattic/jetpack-components';
-import { ExternalLink } from '@wordpress/components';
+import { ExternalLink, ToggleControl } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useCallback, useState } from 'react';
@@ -211,11 +210,11 @@ const EmailSettings = props => {
 				} }
 			>
 				<ToggleControl
+					__nextHasNoMarginBottom
 					disabled={ featuredImageInputDisabled }
 					checked={
 						isFeaturedImageInEmailEnabled && isSubscriptionsActive && ! featuredImageInputDisabled
 					}
-					toogling={ isSavingAnyOption( [ FEATURED_IMAGE_IN_EMAIL_OPTION ] ) }
 					label={ <span className="jp-form-toggle-explanation">{ featuredImageInfo }</span> }
 					onChange={ handleEnableFeaturedImageInEmailToggleChange }
 					className="email-settings__featured-image-toggle"
@@ -286,9 +285,9 @@ const EmailSettings = props => {
 				/>
 				<div className="email-settings__gravatar">
 					<ToggleControl
+						__nextHasNoMarginBottom
 						disabled={ gravatarInputDisabled }
 						checked={ isGravatarEnabled && isSubscriptionsActive }
-						toogling={ isSavingAnyOption( [ GRAVATER_OPTION ] ) }
 						label={
 							<span className="jp-form-toggle-explanation">
 								{ __( 'Show author avatar on your emails', 'jetpack' ) }
@@ -332,9 +331,9 @@ const EmailSettings = props => {
 					/>
 				</div>
 				<ToggleControl
+					__nextHasNoMarginBottom
 					disabled={ authorInputDisabled }
 					checked={ isAuthorEnabled && isSubscriptionsActive }
-					toogling={ isSavingAnyOption( [ AUTHOR_OPTION ] ) }
 					label={
 						<span className="jp-form-toggle-explanation">
 							{ __( 'Show author display name', 'jetpack' ) }
@@ -344,9 +343,9 @@ const EmailSettings = props => {
 				/>
 
 				<ToggleControl
+					__nextHasNoMarginBottom
 					disabled={ postDateInputDisabled }
 					checked={ isPostDateEnabled && isSubscriptionsActive }
-					toogling={ isSavingAnyOption( [ POST_DATE_OPTION ] ) }
 					label={
 						<span className="jp-form-toggle-explanation">
 							{ __( 'Add the post date', 'jetpack' ) }

--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter-categories.jsx
@@ -1,5 +1,5 @@
-import { ToggleControl, getRedirectUrl } from '@automattic/jetpack-components';
-import { ExternalLink } from '@wordpress/components';
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import { ExternalLink, ToggleControl } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
@@ -157,6 +157,7 @@ function NewsletterCategories( props ) {
 				</p>
 				<div className="newsletter-categories-toggle-wrapper">
 					<ToggleControl
+						__nextHasNoMarginBottom
 						disabled={ disabled }
 						checked={ isNewsletterCategoriesEnabled && isSubscriptionsActive }
 						onChange={ handleEnableNewsletterCategoriesToggleChange }

--- a/projects/plugins/jetpack/_inc/client/newsletter/newsletter.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/newsletter.jsx
@@ -1,4 +1,5 @@
-import { getRedirectUrl, ToggleControl } from '@automattic/jetpack-components';
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import { ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useCallback } from 'react';
 import { connect } from 'react-redux';
@@ -157,6 +158,7 @@ function Newsletter( props ) {
 				} }
 			>
 				<ToggleControl
+					__nextHasNoMarginBottom
 					checked={ isSubscriptionsActive && !! newsletterSendDefault }
 					disabled={
 						! isSubscriptionsActive ||
@@ -164,7 +166,6 @@ function Newsletter( props ) {
 						unavailableInOfflineMode ||
 						isSavingAnyOption( [ SUBSCRIPTIONS_MODULE_NAME, NEWSLETTER_SEND_DEFAULT_OPTION ] )
 					}
-					toggling={ isSavingAnyOption( [ NEWSLETTER_SEND_DEFAULT_OPTION ] ) }
 					onChange={ handleEmailPostToSubsDefaultToggle }
 					label={
 						<span className="jp-form-toggle-explanation">

--- a/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx
@@ -1,5 +1,4 @@
-import { ToggleControl } from '@automattic/jetpack-components';
-import { ExternalLink } from '@wordpress/components';
+import { ExternalLink, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { useCallback } from 'react';
@@ -33,7 +32,6 @@ import { SUBSCRIPTIONS_MODULE_NAME } from './constants';
 function SubscriptionsSettings( props ) {
 	const {
 		unavailableInOfflineMode,
-		isSavingAnyOption,
 		isStbEnabled,
 		isStcEnabled,
 		isSmEnabled,
@@ -164,9 +162,9 @@ function SubscriptionsSettings( props ) {
 				<FormFieldset>
 					<FormLegend>{ __( 'Homepage and posts', 'jetpack' ) }</FormLegend>
 					<ToggleControl
+						__nextHasNoMarginBottom
 						checked={ isSubscriptionsActive && isSubscribePostEndEnabled }
 						disabled={ isDisabled }
-						toggling={ isSavingAnyOption( [ 'jetpack_subscriptions_subscribe_post_end_enabled' ] ) }
 						onChange={ handleSubscribePostEndToggleChange }
 						label={
 							<span className="jp-form-toggle-explanation">
@@ -184,9 +182,9 @@ function SubscriptionsSettings( props ) {
 						}
 					/>
 					<ToggleControl
+						__nextHasNoMarginBottom
 						checked={ isSubscriptionsActive && isSmEnabled }
 						disabled={ isDisabled }
-						toggling={ isSavingAnyOption( [ 'sm_enabled' ] ) }
 						onChange={ handleSubscribeModalToggleChange }
 						label={
 							<span className="jp-form-toggle-explanation">
@@ -203,9 +201,9 @@ function SubscriptionsSettings( props ) {
 						}
 					/>
 					<ToggleControl
+						__nextHasNoMarginBottom
 						checked={ isSubscriptionsActive && isSubscribeOverlayEnabled }
 						disabled={ isDisabled }
-						toggling={ isSavingAnyOption( [ 'jetpack_subscribe_overlay_enabled' ] ) }
 						onChange={ handleSubscribeOverlayToggleChange }
 						label={
 							<span className="jp-form-toggle-explanation">
@@ -222,9 +220,9 @@ function SubscriptionsSettings( props ) {
 						}
 					/>
 					<ToggleControl
+						__nextHasNoMarginBottom
 						checked={ isSubscriptionsActive && isSubscribeFloatingEnabled }
 						disabled={ isDisabled }
-						toggling={ isSavingAnyOption( [ 'jetpack_subscribe_floating_button_enabled' ] ) }
 						onChange={ handleSubscribeFloatingToggleChange }
 						label={
 							<span className="jp-form-toggle-explanation">
@@ -245,11 +243,9 @@ function SubscriptionsSettings( props ) {
 					<FormFieldset>
 						<FormLegend>{ __( 'Navigation', 'jetpack' ) }</FormLegend>
 						<ToggleControl
+							__nextHasNoMarginBottom
 							checked={ isSubscriptionsActive && isSubscribeNavigationEnabled }
 							disabled={ isDisabled }
-							toggling={ isSavingAnyOption( [
-								'jetpack_subscriptions_subscribe_navigation_enabled',
-							] ) }
 							onChange={ handleSubscribeNavigationToggleChange }
 							label={
 								<span className="jp-form-toggle-explanation">
@@ -266,9 +262,9 @@ function SubscriptionsSettings( props ) {
 							}
 						/>
 						<ToggleControl
+							__nextHasNoMarginBottom
 							checked={ isSubscriptionsActive && isLoginNavigationEnabled }
 							disabled={ isDisabled }
-							toggling={ isSavingAnyOption( [ 'jetpack_subscriptions_login_navigation_enabled' ] ) }
 							onChange={ handleLoginNavigationToggleChange }
 							label={
 								<span className="jp-form-toggle-explanation">
@@ -289,9 +285,9 @@ function SubscriptionsSettings( props ) {
 				<FormFieldset>
 					<FormLegend>{ __( 'Comments', 'jetpack' ) }</FormLegend>
 					<ToggleControl
+						__nextHasNoMarginBottom
 						checked={ isSubscriptionsActive && isStbEnabled }
 						disabled={ isDisabled }
-						toggling={ isSavingAnyOption( [ 'stb_enabled' ] ) }
 						onChange={ handleSubscribeToBlogToggleChange }
 						label={
 							<span className="jp-form-toggle-explanation">
@@ -300,9 +296,9 @@ function SubscriptionsSettings( props ) {
 						}
 					/>
 					<ToggleControl
+						__nextHasNoMarginBottom
 						checked={ isSubscriptionsActive && isStcEnabled }
 						disabled={ isDisabled }
-						toggling={ isSavingAnyOption( [ 'stc_enabled' ] ) }
 						onChange={ handleSubscribeToCommentToggleChange }
 						label={
 							<span className="jp-form-toggle-explanation">

--- a/projects/plugins/jetpack/changelog/issue-48160-migrate-newsletter-toggle
+++ b/projects/plugins/jetpack/changelog/issue-48160-migrate-newsletter-toggle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Newsletter: Migrate ToggleControl off @automattic/jetpack-components to @wordpress/components.


### PR DESCRIPTION
## Proposed changes

- Swap `ToggleControl` imports from `@automattic/jetpack-components` to `@wordpress/components` across the Jetpack **Newsletter** settings screen (`plugins/jetpack/_inc/client/newsletter/`), covering the `Newsletter`, `Subscriptions`, `Email configuration`, and `Newsletter categories` sections.
- Drop the custom `toggling` prop (and a pre-existing `toogling` typo that was never doing anything). Every call site already sets `disabled={ isSavingAnyOption( … ) }`, so the toggle remains unclickable during saves — we lose only the wrapper's optimistic visual flip, matching the standard wp-admin behavior.
- Add `__nextHasNoMarginBottom` on each migrated call site to keep the wrapper's default margin-bottom behavior.
- Leave the `ToggleControl` re-export in `@automattic/jetpack-components` alone — dead-code removal is out of scope for this narrow consumer migration (see [#48160](https://github.com/Automattic/jetpack/issues/48160) for the tracking issue).

## Other information

Part of the [#48160](https://github.com/Automattic/jetpack/issues/48160) migration off `@automattic/jetpack-components`. Follows the same shape as [#48170](https://github.com/Automattic/jetpack/pull/48170) (RadioControl) and [#48156](https://github.com/Automattic/jetpack/pull/48156) (Badge).

Note: the old Newsletter settings tab in the Jetpack admin SPA is hidden by default since [#47750](https://github.com/Automattic/jetpack/pull/47750) (`jetpack_wp_admin_newsletter_settings_enabled` filter defaults to `true`, redirecting users to the new dedicated Newsletter page). The old screen still renders when a site filters that back to `false`, which is how the before/after screenshots below were captured.

## Screenshots

| Surface | Before (baseline) | After (this branch) |
|---|---|---|
| Newsletter settings screen (`admin.php?page=jetpack#/newsletter`) | ![before](https://github.com/Automattic/jetpack/raw/screenshots/issue-48160/migrate-newsletter-toggle/before-newsletter-settings.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/issue-48160/migrate-newsletter-toggle/after-newsletter-settings.png) |

_JN rsync target: `plugins/jetpack` · Baseline: trunk (sync-current — the branch was identical to trunk at capture time) · JN site: `thoughtfully-remarkable-device.jurassic.ninja` · Pre/post renders are pixel-identical, as expected for Option A (direct library swap, no optimistic flip behavior change needed because `disabled` already blocks interaction during saves)._

## Testing instructions

Reproduce the old Newsletter settings UI by setting `jetpack_wp_admin_newsletter_settings_enabled` to `false` via a mu-plugin (`add_filter( 'jetpack_wp_admin_newsletter_settings_enabled', '__return_false' );`).

- [ ] Visit Jetpack → Settings → Newsletter.
- [ ] Verify the four sections render: **Newsletter**, **Subscriptions** (Homepage and posts / Navigation / Comments), **Newsletter categories**, and **Email configuration** (Email byline toggles, Featured image toggle).
- [ ] Toggle each `ToggleControl` — the toggle should flip, save in the background, and the persisted state should match after the request resolves. The toggle is disabled during save (same as before).
- [ ] Browser console is clean on mount and during toggling.
- [ ] No visible margin regressions between sections.

- [x] Changelog entry added (`plugins/jetpack`, patch / other).
- [x] Visual diff reviewed — before/after are pixel-identical.