### PR TITLE
Performance: Migrate ToggleControl to @wordpress/components

### DIFF
--- a/projects/plugins/jetpack/_inc/client/performance/media.jsx
+++ b/projects/plugins/jetpack/_inc/client/performance/media.jsx
@@ -1,4 +1,5 @@
-import { ProgressBar, ToggleControl, getRedirectUrl } from '@automattic/jetpack-components';
+import { ProgressBar, getRedirectUrl } from '@automattic/jetpack-components';
+import { ToggleControl } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { Component } from 'react';
@@ -114,9 +115,12 @@ class Media extends Component {
 						</ModuleToggle>
 						<FormFieldset>
 							<ToggleControl
+								__nextHasNoMarginBottom
 								id="videopress-site-privacy"
-								disabled={ ! this.props.getOptionValue( 'videopress' ) }
-								toggling={ this.props.isSavingAnyOption( 'videopress_private_enabled_for_site' ) }
+								disabled={
+									! this.props.getOptionValue( 'videopress' ) ||
+									this.props.isSavingAnyOption( 'videopress_private_enabled_for_site' )
+								}
 								checked={ this.props.getOptionValue( 'videopress_private_enabled_for_site' ) }
 								onChange={ this.togglePrivacySetting }
 								label={

--- a/projects/plugins/jetpack/_inc/client/performance/search.jsx
+++ b/projects/plugins/jetpack/_inc/client/performance/search.jsx
@@ -1,4 +1,5 @@
-import { ToggleControl, getRedirectUrl } from '@automattic/jetpack-components';
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import { ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Fragment, useCallback, useEffect } from 'react';
 import { connect } from 'react-redux';
@@ -92,9 +93,9 @@ function Search( props ) {
 
 						<FormFieldset>
 							<ToggleControl
+								__nextHasNoMarginBottom
 								checked={ isModuleEnabled && isInstantSearchEnabled }
-								disabled={ togglingModule || ! props.hasInstantSearch }
-								toggling={ togglingInstantSearch }
+								disabled={ togglingModule || ! props.hasInstantSearch || togglingInstantSearch }
 								onChange={ toggleInstantSearch }
 								label={
 									<span className="jp-form-toggle-explanation">

--- a/projects/plugins/jetpack/_inc/client/performance/speed-up-site.jsx
+++ b/projects/plugins/jetpack/_inc/client/performance/speed-up-site.jsx
@@ -1,4 +1,5 @@
-import { ToggleControl, getRedirectUrl } from '@automattic/jetpack-components';
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import { ToggleControl } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -248,10 +249,10 @@ const SpeedUpSite = withModuleSettingsFormHelpers(
 								</p>
 								{ canAppearInSearch && (
 									<ToggleControl
+										__nextHasNoMarginBottom
 										checked={ siteAcceleratorStatus }
-										toggling={ togglingSiteAccelerator }
 										onChange={ this.handleSiteAcceleratorChange }
-										disabled={ ! canDisplaySiteAcceleratorSettings }
+										disabled={ ! canDisplaySiteAcceleratorSettings || togglingSiteAccelerator }
 										label={
 											<span className="jp-form-toggle-explanation">
 												{ __( 'Enable site accelerator', 'jetpack' ) }

--- a/projects/plugins/jetpack/changelog/issue-48160-migrate-performance-toggle-control
+++ b/projects/plugins/jetpack/changelog/issue-48160-migrate-performance-toggle-control
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Performance settings: import ToggleControl from @wordpress/components instead of @automattic/jetpack-components.


### PR DESCRIPTION
## Proposed changes

- Swap the three `ToggleControl` usages on the Jetpack Performance settings screen off the `@automattic/jetpack-components` wrapper and onto `@wordpress/components` directly. Files: `_inc/client/performance/speed-up-site.jsx`, `media.jsx`, `search.jsx`.
- Translate the wrapper's `toggling` prop to `disabled={ toggling || existingDisabled }` at each call site so click-blocking during in-flight saves is preserved.
- Add `__nextHasNoMarginBottom` at each call site (the wrapper set this automatically).
- Narrow-scope PR: the wrapper at `projects/js-packages/components/components/toggle-control/` and its re-export in `@automattic/jetpack-components` are untouched. Dead-code cleanup, if desired, belongs in a follow-up.

## Other information

Part of #48160.

The `@automattic/jetpack-components` `ToggleControl` wrapper does more than re-export the upstream primitive — it styles the track in Jetpack green, ships custom track/thumb sizing, fades opacity while saving, and optimistically flips the thumb before the API round-trip returns. `@wordpress/ui` has no `ToggleControl` yet, so this consumer lands on `@wordpress/components` as an interim step. Expected UX deltas on the Performance screen:

- Thumb color when ON shifts from `--jp-green-40` → `--wp-admin-theme-color`.
- Track/thumb revert to the stock `@wordpress/components` `FormToggle` sizing.
- No `is-toggling` opacity fade while a setting is saving.
- No optimistic thumb flip — the thumb moves only after the save resolves. Click-blocking is preserved via `disabled`.

## Screenshots

| Surface | Before (baseline on JN) | After (this branch on JN) |
|---|---|---|
| Performance settings screen | ![before](https://github.com/Automattic/jetpack/raw/screenshots/issue-48160/migrate-performance-toggle-control/before-performance-settings.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/issue-48160/migrate-performance-toggle-control/after-performance-settings.png) |

_JN rsync target: `plugins/jetpack` · Baseline: current JN state with Jetpack connected · JN site: `thoughtfully-remarkable-device.jurassic.ninja`_

## Testing instructions

- [ ] Visit **Jetpack → Settings → Performance** in wp-admin.
- [ ] **Performance & speed** section: click **Enable site accelerator**. Confirm that during the save the toggle is not clickable again (click-blocking preserved) and that the thumb moves after the save resolves. Turn it off again to confirm the round-trip in both directions.
- [ ] **Media → VideoPress**: enable VideoPress via the module toggle, then flip **Video Privacy: Restrict views to members of this site**. Confirm click-blocking during save.
- [ ] **Search** (paid feature): with Jetpack Search + Instant Search available, flip **Enable instant search experience**. Confirm click-blocking during save and that the toggle is disabled while the parent Search module is saving.
- [ ] No console warnings about `__nextHasNoMarginBottom` or deprecated props on the Performance screen.
- [ ] Changelog entry added for `plugins/jetpack` (`other`/`patch`).