### PR TITLE
Security Settings: Import ToggleControl from @wordpress/components

### DIFF
--- a/projects/plugins/jetpack/_inc/client/security/allowList.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/allowList.jsx
@@ -1,4 +1,4 @@
-import { ToggleControl } from '@automattic/jetpack-components';
+import { ToggleControl } from '@wordpress/components';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -144,11 +144,8 @@ const AllowList = class extends Component {
 					<FormFieldset>
 						<div className="waf__settings__toggle-setting">
 							<ToggleControl
+								__nextHasNoMarginBottom={ true }
 								checked={ this.props.settings?.ipAllowListEnabled }
-								toggling={
-									this.props.isUpdatingWafSettings &&
-									this.state.ipAllowListEnabled !== this.props.settings?.ipAllowListEnabled
-								}
 								disabled={ baseInputDisabledCase }
 								onChange={ this.toggleIpAllowList }
 								label={

--- a/projects/plugins/jetpack/_inc/client/security/sso.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/sso.jsx
@@ -1,6 +1,6 @@
-import { getRedirectUrl, ToggleControl, Gridicon } from '@automattic/jetpack-components';
+import { getRedirectUrl, Gridicon } from '@automattic/jetpack-components';
 import { useConnection } from '@automattic/jetpack-connection';
-import { Button, ExternalLink } from '@wordpress/components';
+import { Button, ExternalLink, ToggleControl } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import * as cookie from 'cookie';
@@ -180,6 +180,7 @@ export const SSO = withModuleSettingsFormHelpers(
 							</ModuleToggle>
 							<FormFieldset>
 								<ToggleControl
+									__nextHasNoMarginBottom={ true }
 									checked={
 										isSSOActive &&
 										this.props.getOptionValue( 'jetpack_sso_match_by_email', 'sso', false )
@@ -189,7 +190,6 @@ export const SSO = withModuleSettingsFormHelpers(
 										unavailableInOfflineMode ||
 										this.props.isSavingAnyOption( [ 'sso' ] )
 									}
-									toggling={ this.props.isSavingAnyOption( [ 'jetpack_sso_match_by_email' ] ) }
 									onChange={ this.handleMatchByEmailToggleChange }
 									label={
 										<span className="jp-form-toggle-explanation">
@@ -198,6 +198,7 @@ export const SSO = withModuleSettingsFormHelpers(
 									}
 								/>
 								<ToggleControl
+									__nextHasNoMarginBottom={ true }
 									checked={
 										( isSSOActive &&
 											this.props.getOptionValue( 'jetpack_sso_require_two_step', 'sso', false ) ) ||
@@ -209,7 +210,6 @@ export const SSO = withModuleSettingsFormHelpers(
 										isTwoStepEnforced ||
 										this.props.isSavingAnyOption( [ 'sso' ] )
 									}
-									toggling={ this.props.isSavingAnyOption( [ 'jetpack_sso_require_two_step' ] ) }
 									onChange={ this.handleTwoStepToggleChange }
 									label={
 										<span className="jp-form-toggle-explanation">

--- a/projects/plugins/jetpack/_inc/client/security/waf.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/waf.jsx
@@ -1,5 +1,5 @@
-import { getRedirectUrl, ToggleControl, Status } from '@automattic/jetpack-components';
-import { ExternalLink } from '@wordpress/components';
+import { getRedirectUrl, Status } from '@automattic/jetpack-components';
+import { ExternalLink, ToggleControl } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { Component } from 'react';
@@ -217,14 +217,11 @@ export const Waf = class extends Component {
 		const automaticRulesSettings = (
 			<div className="waf__settings__toggle-setting">
 				<ToggleControl
+					__nextHasNoMarginBottom={ true }
 					checked={
 						this.props.hasScan || this.props.settings?.automaticRulesAvailable
 							? this.props.settings?.automaticRulesEnabled
 							: false
-					}
-					toggling={
-						this.props.isUpdatingWafSettings &&
-						this.state.automaticRulesEnabled !== this.props.settings?.automaticRulesEnabled
 					}
 					disabled={
 						baseInputDisabledCase ||
@@ -246,12 +243,9 @@ export const Waf = class extends Component {
 		const shareDataSettings = (
 			<div className="waf__settings__toggle-setting">
 				<ToggleControl
+					__nextHasNoMarginBottom={ true }
 					checked={ this.props.settings?.shareData }
 					disabled={ baseInputDisabledCase }
-					toggling={
-						this.props.isUpdatingWafSettings &&
-						this.state.shareData !== this.props.settings?.shareData
-					}
 					onChange={ this.toggleShareData }
 					label={
 						<div className="waf__settings__toggle-setting__label">
@@ -287,12 +281,9 @@ export const Waf = class extends Component {
 		const shareDebugDataSettings = (
 			<div className="waf__settings__toggle-setting">
 				<ToggleControl
+					__nextHasNoMarginBottom={ true }
 					checked={ this.props.settings?.shareDebugData }
 					disabled={ baseInputDisabledCase }
-					toggling={
-						this.props.isUpdatingWafSettings &&
-						this.state.shareDebugData !== this.props.settings?.shareDebugData
-					}
 					onChange={ this.toggleShareDebugData }
 					label={
 						<div className="waf__settings__toggle-setting__label">
@@ -406,11 +397,8 @@ export const Waf = class extends Component {
 		const ipBlockListSettings = (
 			<div className="waf__settings__toggle-setting">
 				<ToggleControl
+					__nextHasNoMarginBottom={ true }
 					checked={ this.props.settings?.ipBlockListEnabled }
-					toggling={
-						this.props.isUpdatingWafSettings &&
-						this.state.ipBlockListEnabled !== this.props.settings?.ipBlockListEnabled
-					}
 					disabled={ baseInputDisabledCase }
 					onChange={ this.toggleIpBlockList }
 					label={

--- a/projects/plugins/jetpack/changelog/update-security-toggle-control-direct-import
+++ b/projects/plugins/jetpack/changelog/update-security-toggle-control-direct-import
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Security settings: Import ToggleControl directly from @wordpress/components.


### PR DESCRIPTION
## Proposed changes

- Move the `ToggleControl` import in `projects/plugins/jetpack/_inc/client/security/waf.jsx`, `sso.jsx`, and `allowList.jsx` from `@automattic/jetpack-components` to `@wordpress/components` — 7 call sites total.
- Add `__nextHasNoMarginBottom={ true }` on every migrated `<ToggleControl>` so the bottom margin matches the default the jetpack-components wrapper was setting, and the upstream deprecation warning stays quiet.
- Drop the wrapper-only `toggling` prop from the 7 migrated sites. The upstream `@wordpress/components` `ToggleControl` has no equivalent. The user-visible loss is the brief optimistic knob-flip + 0.6 opacity dim during the save round-trip on WAF / Allow List / SSO toggles. See the follow-up note below for a functional gap (rapid-re-click guard) that should be closed in a later PR.

Part of [#48160](https://github.com/Automattic/jetpack/issues/48160). Follows the consumer-only migration shape of [#48170](https://github.com/Automattic/jetpack/pull/48170) (RadioControl).

## Out of scope

- The `ToggleControl` wrapper in `projects/js-packages/components/components/toggle-control/` (and its re-export from the package `index.ts`) is intentionally left in place — other consumers still use it, and removing it is a separate concern.
- The `ModuleToggle` wrapper at `_inc/client/components/module-toggle/index.jsx` also still imports `ToggleControl` from `@automattic/jetpack-components`; its migration will be a follow-up PR (it changes behavior for `account-protection.jsx`, `monitor.jsx`, `protect.jsx`, and the module-level rows on `waf.jsx` / `sso.jsx`).

## Follow-up (to address in a later PR)

The removed `toggling` prop also short-circuited `onChange` while a save was in flight, acting as a rapid-re-click guard. The existing `disabled={ … }` guards on the migrated toggles do **not** fully replace that:

- **WAF / Allow List toggles (5 sites):** `baseInputDisabledCase` checks `isFetchingWafSettings` and `isSavingAnyOption([ 'waf' ])`, but **not** `isUpdatingWafSettings`. Those are separate Redux slices — `isUpdatingWafSettings` lives in `state.jetpack.waf.requests` (flipped by `WAF_SETTINGS_UPDATE` / `_SUCCESS` / `_FAIL`), while `isSavingAnyOption` reads `state.jetpack.settings.requests.settingsSent`, which `updateWafSettings` does not populate. So the toggle stays enabled during the WAF-settings round-trip.
- **SSO toggles (2 sites):** the old `toggling` checked the specific option key (`jetpack_sso_match_by_email` / `jetpack_sso_require_two_step`), but `disabled` only checks the module key (`sso`). Different entries in `settingsSent` — same gap.

**Impact:** minor. Saves are fast (~200–500ms), duplicate updates are idempotent, and `WAF_SETTINGS_UPDATE_SUCCESS` overwrites local state with the server response (last-write-wins). Worst case is a brief UI flicker if the user rapid-clicks and responses arrive out of order. No data risk.

**Suggested fix in the follow-up PR:**

- `waf.jsx` / `allowList.jsx`: add `this.props.isUpdatingWafSettings` to `baseInputDisabledCase`.
- `sso.jsx`: OR `isSavingAnyOption([ 'jetpack_sso_match_by_email' ])` / `isSavingAnyOption([ 'jetpack_sso_require_two_step' ])` into each toggle's `disabled`.

## Does this pull request change what data or activity we track or use?
No.

## Screenshots

Before / after on a live Jurassic Ninja site, with Firewall enabled so all the migrated toggles are visible. The two images are **byte-identical** (same SHA-256) — the change is a pure import swap with no rendered-at-rest difference. The `toggling` UX regression (optimistic flip + dim) only appears during the save round-trip and cannot be captured in a static screenshot.

| Surface | Before (trunk baseline on JN) | After (this branch on JN) |
|---|---|---|
| Security settings (full page) | ![before](https://github.com/Automattic/jetpack/raw/screenshots/claude/practical-galileo-14bf1c/before-security.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/claude/practical-galileo-14bf1c/after-security.png) |

_JN rsync target: `plugins/jetpack` · Baseline: `trunk` · JN site: `thoughtfully-remarkable-device.jurassic.ninja`_

## Testing instructions

- [ ] Changelog entry added for `projects/plugins/jetpack`.
- [ ] On a Jetpack site, go to **Jetpack → Settings → Security**. Enable Firewall. Confirm all inner toggles render identically to trunk: Automatic rules, Manual rules (IP block list), Share basic data, Share detailed data, Always allowed IP addresses (allow list), and the SSO toggles under WordPress.com login (Match accounts by email, Require Two-Step).
- [ ] Flip each migrated toggle once and verify the setting persists across reload — this exercises the `disabled`-based in-flight guard that replaces the removed `toggling` prop.
- [ ] Check the browser console on the Security page: no `ToggleControl` margin-related deprecation warnings should appear.