### PR TITLE
RFC: Self-managing NewBadge / BetaBadge backed by an auto-expiring registry

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/new-badge/index.tsx
+++ b/projects/plugins/jetpack/_inc/client/components/new-badge/index.tsx
@@ -1,0 +1,55 @@
+/**
+ * Self-managing "New" / "Beta" badges, gated by the new-features registry.
+ *
+ * `<NewBadge feature="jetpack-ai" />` renders a green `@wordpress/ui` Badge
+ * while the feature is flagged in `lib/new-features` AND within its window.
+ * Past the window, the component returns null — no consumer change required.
+ *
+ * Use these instead of inline `<Badge>New</Badge>` so feature ageing is
+ * centralised and translator strings are consistent.
+ */
+
+import { _x } from '@wordpress/i18n';
+import { Badge } from '@wordpress/ui';
+import { useNewFeature } from 'lib/new-features';
+
+type Props = {
+	/** Slug registered in `lib/new-features`. */
+	feature: string;
+};
+
+/**
+ * Renders a "New" badge while `feature` is flagged as new.
+ *
+ * @param props         - Component props.
+ * @param props.feature - Slug registered in `lib/new-features`.
+ * @return The Badge, or null when the feature isn't flagged or has expired.
+ */
+export function NewBadge( { feature }: Props ) {
+	if ( ! useNewFeature( feature, 'new' ) ) {
+		return null;
+	}
+	return (
+		<Badge intent="stable">
+			{ _x( 'New', 'Indicates a recently-launched feature.', 'jetpack' ) }
+		</Badge>
+	);
+}
+
+/**
+ * Renders a "Beta" badge while `feature` is flagged with the beta variant.
+ *
+ * @param props         - Component props.
+ * @param props.feature - Slug registered in `lib/new-features`.
+ * @return The Badge, or null when the feature isn't flagged or has expired.
+ */
+export function BetaBadge( { feature }: Props ) {
+	if ( ! useNewFeature( feature, 'beta' ) ) {
+		return null;
+	}
+	return (
+		<Badge intent="informational">
+			{ _x( 'Beta', 'Indicates an experimental, not-yet-final feature.', 'jetpack' ) }
+		</Badge>
+	);
+}

--- a/projects/plugins/jetpack/_inc/client/lib/new-features/index.ts
+++ b/projects/plugins/jetpack/_inc/client/lib/new-features/index.ts
@@ -1,0 +1,61 @@
+/**
+ * Registry-driven "New" / "Beta" feature flags.
+ *
+ * Surfaces a feature as recently-introduced for a bounded window. Past the
+ * window, lookups return false and any consuming Badge silently disappears —
+ * no follow-up code change required, no `// TODO: remove this badge once it's
+ * no longer new` comment to rot in the source for years.
+ *
+ * To flag a feature: add an entry to NEW_FEATURES below. To un-flag: do nothing
+ * (it expires automatically) or delete the entry early.
+ */
+
+export type NewFeatureVariant = 'new' | 'beta';
+
+export type NewFeatureEntry = {
+	/** Stable identifier consumers pass into the hook / components. */
+	slug: string;
+	/** ISO date the feature was introduced (UTC). */
+	addedAt: string;
+	/** How long the badge should render. Default 90 days. */
+	durationDays?: number;
+	/** Defaults to 'new'. */
+	variant?: NewFeatureVariant;
+	/** Free-form context for humans reading the registry — never rendered. */
+	note?: string;
+};
+
+const DEFAULT_DURATION_DAYS = 90;
+
+/**
+ * The single source of truth for which features render a "New"/"Beta" badge.
+ *
+ * Keep this file under source control review like any other config. A periodic
+ * cleanup (or lint rule) can prune entries past their expiry, but expired
+ * entries are inert and don't affect rendering — they're just clutter.
+ */
+export const NEW_FEATURES: readonly NewFeatureEntry[] = [
+	{
+		slug: 'jetpack-ai',
+		addedAt: '2024-07-22',
+		durationDays: 365,
+		note: 'AI Assistant entry link added in #38414. Flagged retroactively to demo the registry pattern.',
+	},
+];
+
+/**
+ * Returns true when the feature is currently flagged and within its window.
+ *
+ * @param slug    - The feature slug to look up.
+ * @param variant - Defaults to 'new'.
+ * @return True when the feature should render its badge, false otherwise.
+ */
+export function useNewFeature( slug: string, variant: NewFeatureVariant = 'new' ): boolean {
+	const entry = NEW_FEATURES.find( e => e.slug === slug && ( e.variant ?? 'new' ) === variant );
+	if ( ! entry ) {
+		return false;
+	}
+	const ageMs = Date.now() - new Date( entry.addedAt ).getTime();
+	const durationMs = ( entry.durationDays ?? DEFAULT_DURATION_DAYS ) * 86_400_000;
+	return ageMs >= 0 && ageMs < durationMs;
+}

--- a/projects/plugins/jetpack/_inc/client/writing/composing.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/composing.jsx
@@ -1,4 +1,4 @@
-import { Chip, getRedirectUrl } from '@automattic/jetpack-components';
+import { getRedirectUrl } from '@automattic/jetpack-components';
 import { __, _x } from '@wordpress/i18n';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -6,6 +6,7 @@ import CompactCard from 'components/card/compact';
 import { FormFieldset } from 'components/forms';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import { ModuleToggle } from 'components/module-toggle';
+import { NewBadge } from 'components/new-badge';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import { showMyJetpack } from 'state/initial-state';
@@ -209,8 +210,7 @@ export class Composing extends Component {
 					<a href={ `${ this.props.siteAdminUrl }admin.php?page=my-jetpack#/jetpack-ai` }>
 						{ __( 'Learn more about all Jetpack AI features', 'jetpack' ) }
 					</a>
-					{ /* TODO: remove this Chip once it's not longer "new" */ }
-					<Chip type="new" text={ __( 'New', 'jetpack' ) } />
+					<NewBadge feature="jetpack-ai" />
 				</CompactCard>
 			);
 

--- a/projects/plugins/jetpack/changelog/try-new-feature-badge-registry
+++ b/projects/plugins/jetpack/changelog/try-new-feature-badge-registry
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Componentry: Introduce NewBadge and BetaBadge components backed by an auto-expiring registry, removing the need for stale TODO comments around feature-launch flags.


### PR DESCRIPTION
**Proof-of-concept / RFC. Not for merge as-is.** See #48162 for the actual Chip migration.

## Problem

`<Badge>New</Badge>` plus a `// TODO: remove once not "new"` comment is the standard pattern. Those TODOs rot — the one this PR replaces in `composing.jsx` was added in #38414 in **July 2024 (21 months ago)**.

## Proposal

Drive "New"/"Beta" badges from a tiny per-plugin registry that auto-expires entries:

```ts
// _inc/client/lib/new-features/index.ts
export const NEW_FEATURES = [
    { slug: 'jetpack-ai', addedAt: '2024-07-22', durationDays: 365 },
];
```

```jsx
// any consumer
<NewBadge feature="jetpack-ai" />
```

`<NewBadge>` and `<BetaBadge>` consume `useNewFeature(slug)` which checks the registry + the date window and returns `null` when the feature isn't flagged or the window has elapsed. No consumer change needed when a feature ages out — registry edits drive the lifecycle.

## What's in this PR

- `_inc/client/lib/new-features/index.ts` — registry, types, `useNewFeature` hook
- `_inc/client/components/new-badge/index.tsx` — `<NewBadge>` and `<BetaBadge>`
- `composing.jsx` migrated from `<Chip type="new" text={...} />` + the 21-month TODO → `<NewBadge feature="jetpack-ai" />`

## Out of scope

- Migrating other "new"-pill consumers (Recommendations, My Jetpack AI interstitial, Boost `<Pill>`, Protect badges) — would follow if the pattern is approved.
- ESLint rule that warns on expired entries — mentioned in the design discussion, not built here.
- Promoting `<NewBadge>` / `<BetaBadge>` to `js-packages/components` — defer until the pattern proves itself in one plugin.
- Tests — the hook is trivially testable; tests would land before merge if the pattern is approved.

## Looking for

Yes/no on the pattern. Bikeshed on the registry shape (date-based vs. version-based expiry, where it lives, whether to also gate via PHP).

## Related

- Tracking issue: #48160
- Active Chip migration: #48162
