### PR TITLE
Admin pages: honor WP.com nav-unification 272px sidebar width

### DIFF
--- a/projects/js-packages/base-styles/admin-page-layout.scss
+++ b/projects/js-packages/base-styles/admin-page-layout.scss
@@ -37,8 +37,9 @@
 // runtime and there's no need to pay the custom-property indirection.
 
 // wp-admin chrome constants (see wp-admin.css).
-$jp-sidebar-width-expanded: 160px;     // default sidebar
-$jp-sidebar-width-folded: 36px;        // .folded preference OR .auto-fold class
+$jp-sidebar-width-expanded: 160px;             // default sidebar
+$jp-sidebar-width-folded: 36px;                // .folded preference OR .auto-fold class
+$jp-sidebar-width-nav-unification: 272px;      // body.is-nav-unification (WP.com wp-admin)
 $jp-admin-bar-height-desktop: 32px;
 $jp-admin-bar-height-mobile: 46px;
 
@@ -48,6 +49,9 @@ $jp-admin-bar-height-mobile: 46px;
 // We mirror these breakpoints because WP's body-class state is not always
 // in sync with the rendered viewport (the `auto-fold` class can stay stale
 // after a narrow → wide window resize).
+// WP.com's "nav-unification" (body.is-nav-unification) keeps the sidebar at
+// 272px above the auto-fold breakpoint; below 960px it narrows to 36px like
+// vanilla wp-admin, and below 782px it goes off-canvas.
 $jp-breakpoint-auto-fold: 960px;
 $jp-breakpoint-mobile: 782px;
 
@@ -109,6 +113,21 @@ $jp-breakpoint-mobile: 782px;
 
 		&.auto-fold #wpbody-content {
 			left: $jp-sidebar-width-folded;
+		}
+	}
+
+	// WP.com's wp-admin sets `body.is-nav-unification` and renders a 272px
+	// sidebar (instead of wp-admin's default 160px) at expanded widths.
+	// Below the auto-fold breakpoint the sidebar narrows to 36px like
+	// vanilla wp-admin (core's `.auto-fold` rule wins by higher specificity),
+	// and `.folded` (user preference) always narrows to 36px — both of those
+	// cases are already covered above. The only state that needs adjusting
+	// is the expanded default at ≥ 961px. The `:not(.folded)` guard lets
+	// the `.folded` rule keep winning at wide widths on nav-unification too.
+	@media (min-width: #{$jp-breakpoint-auto-fold + 1px}) {
+
+		&.is-nav-unification:not(.folded) #wpbody-content {
+			left: $jp-sidebar-width-nav-unification;
 		}
 	}
 

--- a/projects/js-packages/base-styles/changelog/fix-admin-page-layout-nav-unification-sidebar
+++ b/projects/js-packages/base-styles/changelog/fix-admin-page-layout-nav-unification-sidebar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+admin-page-layout: honor WP.com nav-unification's 272px sidebar width at expanded viewports so the content column aligns with the visible sidebar instead of leaving a 112px gap.


### PR DESCRIPTION
Fixes a regression from #48109 that shipped the `jetpack-admin-page-layout` mixin.

## Proposed changes

The mixin hardcodes a 160px sidebar at expanded widths. On WordPress.com's wp-admin (`body.is-nav-unification`) the sidebar is actually **272px**, so the pinned content column started 112px inside the visible sidebar and extended past the viewport on the right — visibly cropping Newsletter, Social, Search, Protect, VideoPress, Backup, Boost, and Jetpack Network Admin when accessed from WordPress.com.

* Add `$jp-sidebar-width-nav-unification: 272px` alongside the existing sidebar-width constants.
* Add a single media-gated rule (`@media (min-width: 961px) { &.is-nav-unification:not(.folded) #wpbody-content { left: 272px } }`) right after the existing `.auto-fold` rule.
* No consumer package changes — every page that `@include jetpack-admin-page-layout;` picks up the fix.

**Why only one rule is needed:**

| Viewport | `.folded` | `.auto-fold` | Sidebar on nav-unification | Existing mixin output | Correct? |
|---|---|---|---|---|---|
| ≥ 961 | — | on | **272** | 160 | ❌ → fixed by this PR |
| ≥ 961 | on | — | 36 | 36 | ✅ (folded rule wins by specificity) |
| 783–960 | — | on | 36 | 36 | ✅ (auto-fold @media rule) |
| 783–960 | on | — | 36 | 36 | ✅ |
| ≤ 782 | any | any | 0 (off-canvas) | 0 | ✅ |

The only broken state on nav-unification is the expanded default at ≥ 961px; every other state already resolved correctly via specificity or existing media-gated rules. The `:not(.folded)` guard preserves the folded rule's win at wide widths.

## Related product discussion/links

* #48109 (original layout mixin PR)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

On a WordPress.com site with Jetpack plugins installed (Newsletter, Social, Search, etc.), sign in to the wp-admin (any site where `body` carries `is-nav-unification`):

1. Navigate to `/wp-admin/admin.php?page=jetpack-newsletter`.
2. At a desktop viewport (≥ 961px), verify the content column's left edge aligns flush with the right edge of the 272px sidebar — no gap, no horizontal clipping, no horizontal scrollbar.
3. Click **Collapse menu** in the sidebar. Verify the content column realigns to the 36px folded sidebar.
4. Resize to 900px. Verify the sidebar auto-folds to 36px and the content column realigns.
5. Resize to 600px. Verify the sidebar slides off-canvas and the content fills the full viewport.
6. Repeat 1–5 on `admin.php?page=jetpack-social` and `admin.php?page=jetpack-search`.
7. On a self-hosted site (no nav-unification, 160px sidebar), verify none of the above regresses — the column should still align to 160px at expanded widths.

## Measurements (before/after, 1280×720, nav-unification)

| Element | Before | After |
|---|---|---|
| `#adminmenuwrap` width | 272px | 272px |
| `#wpbody-content` `left` | **160px** ❌ | **272px** ✅ |
| `#wpbody-content` x | 160 | 272 |
| `#wpbody-content` width | 1120 (112px off-screen) | 1008 (flush) |

Empirically confirmed on https://outside34.wordpress.com/wp-admin/admin.php?page=jetpack-newsletter (and `jetpack-social`, `jetpack-search`) at 600/900/961/1280px viewports, and with `.folded` toggled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
