### PR TITLE
Social: render JetpackFooter on all sites for parity with peer pages

### DIFF
--- a/projects/packages/publicize/_inc/components/admin-page/index.tsx
+++ b/projects/packages/publicize/_inc/components/admin-page/index.tsx
@@ -92,7 +92,6 @@ export const SocialAdminPage = () => {
 			title={ 'Social' /** "Social" is a product name, do not translate. */ }
 			subTitle={ subTitle }
 			actions={ licenseAction }
-			showFooter={ isJetpackSite }
 		>
 			<GlobalNotices />
 			{ isJetpackSite && ! hasSocialPaidFeatures() && showPricingPage && ! pricingPageDismissed ? (

--- a/projects/packages/publicize/changelog/fix-social-admin-page-restore-footer
+++ b/projects/packages/publicize/changelog/fix-social-admin-page-restore-footer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social admin page: render the JetpackFooter unconditionally for parity with every other Jetpack admin page (Newsletter, Search, Backup, Protect, VideoPress, Boost, Network Admin).


### PR DESCRIPTION
## Proposed changes

`SocialAdminPage` passes `showFooter={ isJetpackSite }` to `<AdminPage>`, where `isJetpackSite = isJetpackSelfHostedSite()`. On WordPress.com (Simple and Atomic), this resolves to `false`, hiding the `<JetpackFooter>`.

Every other Jetpack admin page — Newsletter, Search, Backup, Protect, VideoPress, Boost, Jetpack Network Admin — renders the footer unconditionally (the default). Social was the lone exception, creating a visible inconsistency on WordPress.com. This PR drops the override so `showFooter` falls back to its `true` default.

The `isJetpackSite` variable is still used two lines up for the "Use license key" action button and for gating the pricing page, so it stays; only the `showFooter` prop is removed.

Introduced in #41393 (2023). The original rationale (hiding "irrelevant UI" on WordPress.com) no longer holds now that the footer is standard chrome across all Jetpack admin surfaces.

## Related product discussion/links

* Follow-up to #48109 (admin-page layout unification) and #48182 (nav-unification sidebar fix), both of which treat the JetpackFooter as a pinned, always-present element.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. On a WordPress.com site (Simple or Atomic), open `/wp-admin/admin.php?page=jetpack-social`.
2. Verify the Jetpack footer ("An Automattic Airline" + Jetpack logo) is now rendered, pinned at the bottom of the content column.
3. Compare against `admin.php?page=jetpack-newsletter` and `admin.php?page=jetpack-search` — all three should now present the same footer treatment.
4. On a self-hosted Jetpack site, verify nothing regresses — the footer was already rendering there, and should continue to.
5. Verify the "Use license key" button still appears on self-hosted sites without paid Social features (the `isJetpackSite` check for that button is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
