### PR TITLE
Forms: fix Show summary toggle on blocks with legacy customThankyou

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-custom-thankyou-show-summary-toggle
+++ b/projects/packages/forms/changelog/fix-forms-custom-thankyou-show-summary-toggle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix Show summary toggle being reverted on forms with legacy customThankyou="noSummary".

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -146,7 +146,7 @@ type JetpackContactFormAttributes = {
 	ref?: number;
 	to: string;
 	subject: string;
-	// Legacy support for the customThankyou attribute
+	// Legacy attribute kept for one-shot migration in edit.tsx; see useEffect below.
 	customThankyou: CustomThankyouType;
 	customThankyouHeading: string;
 	customThankyouMessage: string;
@@ -225,20 +225,18 @@ function JetpackContactFormEdit( {
 		errorType: syncedFormErrorType,
 	} = useSyncedForm( ref );
 
-	// Backward compatibility for the deprecated customThankyou attribute.
-	// Older forms will have a customThankyou attribute set, but not a confirmationType attribute
-	// and not a disableSummary attribute, so we need to set it here.
+	// One-shot migration for the deprecated customThankyou attribute. The
+	// setAttributes call dirties the post so the cleaned attributes get
+	// persisted on the next save. The legacy attribute is cleared to '' in
+	// the same update so the effect cannot re-fire when the user toggles
+	// disableSummary or confirmationType afterward.
 	useEffect( () => {
-		// Migrate redirect setting from deprecated customThankyou attribute
-		if ( customThankyou === 'redirect' && confirmationType !== 'redirect' ) {
-			setAttributes( { confirmationType: 'redirect' } );
+		if ( customThankyou === 'redirect' ) {
+			setAttributes( { customThankyou: '', confirmationType: 'redirect' } );
+		} else if ( customThankyou === 'noSummary' || customThankyou === 'message' ) {
+			setAttributes( { customThankyou: '', disableSummary: true } );
 		}
-
-		// Migrate disableSummary from deprecated customThankyou attribute
-		if ( [ 'noSummary', 'message' ].includes( customThankyou ) && ! disableSummary ) {
-			setAttributes( { disableSummary: true } );
-		}
-	}, [ confirmationType, customThankyou, disableSummary, setAttributes ] );
+	}, [ customThankyou, setAttributes ] );
 
 	const steps = useFormSteps( clientId );
 


### PR DESCRIPTION
Fixes #

## Proposed changes

* Rewrite the `customThankyou` migration `useEffect` in `edit.tsx` so it (a) clears `customThankyou` to `''` in the same `setAttributes` call that writes the modern attribute, and (b) only depends on `customThankyou` itself — not `disableSummary` / `confirmationType`.

### Why

The previous `useEffect` (added in #46866) re-fired every time `customThankyou`, `confirmationType`, or `disableSummary` changed. For a block saved with `customThankyou: "noSummary"`:

1. On load, the effect saw `customThankyou === 'noSummary' && !disableSummary`, called `setAttributes({ disableSummary: true })`, but left `customThankyou` in place.
2. The user flipped the "Show summary" toggle → `disableSummary` became `false`.
3. The effect re-ran with the same condition still true → forced `disableSummary: true` again → toggle reverted.

The fix is small: on the first render that sees a legacy `customThankyou`, clear it (`customThankyou: ''`) in the same update that sets `disableSummary` / `confirmationType`. `customThankyou === ''` is the default, so after that first update the condition is permanently false and nothing re-fires on subsequent user toggles. `setAttributes` also properly dirties the post, so the cleaned attributes actually persist on save.

PHP backward-compat fallbacks in `class-contact-form.php` are left in place so posts whose `post_content` still has `customThankyou` (never re-opened in the editor) keep rendering correctly on the frontend.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. In a fresh post, add a Jetpack Form block via the inserter.
2. Switch to Code Editor and edit the form block's opening comment to include the legacy attribute, e.g.:
   ```html
   <!-- wp:jetpack/contact-form {"customThankyou":"noSummary","subject":"Test"} -->
   ...existing inner blocks...
   <!-- /wp:jetpack/contact-form -->
   ```
3. Switch back to Visual Editor. The migration runs immediately: `customThankyou` is cleared and `disableSummary: true` is set. **Save the post**, then reload. Re-open Code Editor — `customThankyou` is gone from the comment and `"disableSummary":true` is present.
4. In the sidebar under "Confirmation", "Show summary" is off. Toggle it on. It stays on across saves and reloads. On trunk today the toggle flicks back immediately.
5. Repeat with `"customThankyou":"redirect"` — migration sets `confirmationType: "redirect"` and the Redirect URL field appears.
6. Repeat with `"customThankyou":"message"` — migrates to `disableSummary: true` (same behaviour as `noSummary`).
7. A fresh form block behaves normally; the migration branch doesn't fire.
8. Frontend: a post whose stored `post_content` still has `customThankyou: "noSummary"` (never re-opened in the editor) continues to hide the summary on render — the PHP fallback in `class-contact-form.php` is intentionally kept.
