### PR TITLE
Writing Settings: Import ToggleControl from @wordpress/components

### DIFF
--- a/projects/plugins/jetpack/_inc/client/writing/custom-content-types.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/custom-content-types.jsx
@@ -1,4 +1,5 @@
-import { ToggleControl, getRedirectUrl } from '@automattic/jetpack-components';
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import { ToggleControl } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Component } from 'react';
@@ -139,13 +140,13 @@ export class CustomContentTypes extends Component {
 					>
 						<p> { testimonialText } </p>
 						<ToggleControl
+							__nextHasNoMarginBottom={ true }
 							checked={
 								this.props.getOptionValue( 'jetpack_testimonial' )
 									? this.props.getOptionValue( 'jetpack_testimonial' )
 									: false
 							}
 							disabled={ disabledByOverride || woa_theme_supports_jetpack_testimonial }
-							toggling={ this.props.isSavingAnyOption( 'jetpack_testimonial' ) }
 							onChange={ this.handleTestimonialToggleChange }
 							disabledReason={ testimonialDisabledReason }
 							label={
@@ -179,13 +180,13 @@ export class CustomContentTypes extends Component {
 					>
 						<p>{ portfolioText }</p>
 						<ToggleControl
+							__nextHasNoMarginBottom={ true }
 							checked={
 								this.props.getOptionValue( 'jetpack_portfolio' )
 									? this.props.getOptionValue( 'jetpack_portfolio' )
 									: false
 							}
 							disabled={ disabledByOverride || woa_theme_supports_jetpack_portfolio }
-							toggling={ this.props.isSavingAnyOption( 'jetpack_portfolio' ) }
 							onChange={ this.handlePortfolioToggleChange }
 							disabledReason={ portfolioDisabledReason }
 							label={

--- a/projects/plugins/jetpack/_inc/client/writing/custom-content-types.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/custom-content-types.jsx
@@ -53,18 +53,11 @@ export class CustomContentTypes extends Component {
 		}
 
 		const disabledByOverride = this.props.customContentTypeIsOverridden;
-		const disabledReason =
-			disabledByOverride &&
-			__( 'This feature has been disabled by a site administrator.', 'jetpack' );
 
 		const woa_theme_supports_jetpack_portfolio =
 			typeof jetpack_portfolio_theme_supports !== 'undefined'
 				? jetpack_portfolio_theme_supports // eslint-disable-line no-undef
 				: false;
-		const portfolioDisabledReason =
-			! disabledReason && woa_theme_supports_jetpack_portfolio
-				? __( 'This feature is already supported by your theme.', 'jetpack' )
-				: '';
 		const portfolioText = woa_theme_supports_jetpack_portfolio
 			? createInterpolateElement(
 					__(
@@ -99,10 +92,6 @@ export class CustomContentTypes extends Component {
 			typeof jetpack_testimonial_theme_supports !== 'undefined'
 				? jetpack_testimonial_theme_supports // eslint-disable-line no-undef
 				: false;
-		const testimonialDisabledReason =
-			! disabledReason && woa_theme_supports_jetpack_testimonial
-				? __( 'This feature is already supported by your theme.', 'jetpack' )
-				: '';
 		const testimonialText = woa_theme_supports_jetpack_testimonial
 			? createInterpolateElement(
 					__(
@@ -148,7 +137,6 @@ export class CustomContentTypes extends Component {
 							}
 							disabled={ disabledByOverride || woa_theme_supports_jetpack_testimonial }
 							onChange={ this.handleTestimonialToggleChange }
-							disabledReason={ testimonialDisabledReason }
 							label={
 								<span className="jp-form-toggle-explanation">
 									{ __( 'Testimonials', 'jetpack' ) }
@@ -188,7 +176,6 @@ export class CustomContentTypes extends Component {
 							}
 							disabled={ disabledByOverride || woa_theme_supports_jetpack_portfolio }
 							onChange={ this.handlePortfolioToggleChange }
-							disabledReason={ portfolioDisabledReason }
 							label={
 								<span className="jp-form-toggle-explanation">
 									{ __( 'Portfolios', 'jetpack' ) }

--- a/projects/plugins/jetpack/_inc/client/writing/writing-media.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/writing-media.jsx
@@ -1,4 +1,5 @@
-import { ToggleControl, getRedirectUrl } from '@automattic/jetpack-components';
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import { ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { connect } from 'react-redux';
 import { FormFieldset, FormLegend, FormLabel, FormSelect } from 'components/forms';
@@ -45,9 +46,9 @@ function WritingMedia( props ) {
 	 */
 	const renderToggle = ( checked, optionName, onChangeHandler, label ) => (
 		<ToggleControl
+			__nextHasNoMarginBottom={ true }
 			checked={ checked }
 			disabled={ ! isCarouselActive || props.isSavingAnyOption( [ 'carousel' ] ) }
-			toggling={ props.isSavingAnyOption( [ optionName ] ) }
 			onChange={ onChangeHandler }
 			label={ label }
 		/>

--- a/projects/plugins/jetpack/changelog/update-writing-toggle-control-direct-import
+++ b/projects/plugins/jetpack/changelog/update-writing-toggle-control-direct-import
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Writing settings: Import ToggleControl directly from @wordpress/components.


### PR DESCRIPTION
Refs #48160

## Proposed changes

- Import `ToggleControl` directly from `@wordpress/components` in the Jetpack plugin Writing settings page ([`writing-media.jsx`](projects/plugins/jetpack/_inc/client/writing/writing-media.jsx), [`custom-content-types.jsx`](projects/plugins/jetpack/_inc/client/writing/custom-content-types.jsx)) instead of the `@automattic/jetpack-components` re-export.
- Drop the wrapper-only `toggling={}` prop (accepting a minor in-flight UX loss — `disabled` guards still prevent double-submit).
- Add `__nextHasNoMarginBottom={ true }` on every call site to silence the deprecation warning. Margin behavior is unchanged — the wrapper already passed this flag internally.
- Drop the unsupported `disabledReason` prop on the testimonial/portfolio toggles and the dead helper vars that computed those strings. The wrapper was silently dropping `disabledReason` too (it's not in the wrapper's destructured props), so this is a no-op for current users.
- Part of the `@automattic/jetpack-components` consumer migration tracked in [#48160](https://github.com/Automattic/jetpack/issues/48160). Follows the same pattern used for the Security settings in [#48179](https://github.com/Automattic/jetpack/pull/48179).

Out of scope:

- `ModuleToggle` usages (still route through `_inc/client/components/module-toggle`, which imports from `@automattic/jetpack-components`). Follow-up.
- The js-packages `ToggleControl` wrapper at `projects/js-packages/components/components/toggle-control/` is left untouched.

## Related product discussion/links

N/A — no standalone P2/Slack thread. Tracked under [#48160](https://github.com/Automattic/jetpack/issues/48160).

## Does this pull request change what data or activity we track or use?

No.

## Screenshots

Captured on a live Jurassic Ninja site at `admin.php?page=jetpack#/writing` at 1440×900. The "before" is trunk rsync'd to JN; the "after" is this branch rsync'd to the same site.

_The two PNGs are byte-identical — expected for a pure import swap. The `@automattic/jetpack-components` wrapper re-exported the same `@wordpress/components` `ToggleControl` with `__nextHasNoMarginBottom={ true }` as a default, so the at-rest visual output matches. The behavioral difference (no mid-save opacity via `toggling`) only shows during an active save and is not captured here._

| Surface | Before (baseline on JN) | After (this branch on JN) |
|---|---|---|
| Writing settings (Media / Carousel toggles) | ![before](https://github.com/Automattic/jetpack/raw/screenshots/claude/busy-goldberg-1c10d1/before-writing-settings.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/claude/busy-goldberg-1c10d1/after-writing-settings.png) |

_JN rsync target: `plugins/jetpack` · Baseline: `trunk` · JN site: `thoughtfully-remarkable-device.jurassic.ninja`_

_Note: the Testimonials / Portfolios toggles in `custom-content-types.jsx` are also migrated here but aren't shown above because the JN site is on a block theme (`twentytwentyfour`) and `Jetpack_Testimonial::site_should_display_testimonials()` returns false for FSE themes without the option explicitly enabled. The code path is covered by the build + typecheck + JS test gates._

## Testing instructions

1. Check out the branch, run `pnpm jetpack build --deps plugins/jetpack`, and load the Jetpack plugin on a site using a **classic theme** (so the Custom Content Types card renders).
2. Navigate to **Jetpack → Settings → Writing**.
3. In the **Media** card, toggle **Carousel** on, then verify the "Show photo Exif metadata in carousel" and "Show comments area in carousel" toggles render, are enabled, and persist when clicked.
4. In the **Custom Content Types** card, verify the **Testimonials** and **Portfolios** toggles render and persist when clicked.
5. Open the browser console and confirm no `__nextHasNoMarginBottom` deprecation warnings appear when opening the Writing tab.

_Sign-off: changelog entry added for `plugins/jetpack`; visual diff reviewed (byte-identical at rest — mid-save opacity change is the expected behavior delta)._
