### PR TITLE
Traffic Settings: Import ToggleControl from @wordpress/components

### DIFF
--- a/projects/plugins/jetpack/_inc/client/traffic/blaze.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/blaze.jsx
@@ -1,5 +1,6 @@
-import { getRedirectUrl, ToggleControl } from '@automattic/jetpack-components';
+import { getRedirectUrl } from '@automattic/jetpack-components';
 import { isWoASite } from '@automattic/jetpack-script-data';
+import { ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { connect } from 'react-redux';
 import Card from 'components/card';
@@ -66,6 +67,7 @@ function Blaze( props ) {
 		if ( ! canInit && reason === 'user_not_connected' ) {
 			return (
 				<ToggleControl
+					__nextHasNoMarginBottom={ true }
 					disabled={ true }
 					label={ __( 'Attract high-quality traffic to your site using Blaze.', 'jetpack' ) }
 				/>
@@ -75,6 +77,7 @@ function Blaze( props ) {
 		if ( ! canInit ) {
 			return (
 				<ToggleControl
+					__nextHasNoMarginBottom={ true }
 					disabled={ true }
 					label={ __( 'Blaze is not available on your site.', 'jetpack' ) }
 				/>

--- a/projects/plugins/jetpack/_inc/client/traffic/google-analytics.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/google-analytics.jsx
@@ -1,5 +1,5 @@
-import { getRedirectUrl, ToggleControl } from '@automattic/jetpack-components';
-import { ExternalLink } from '@wordpress/components';
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import { ExternalLink, ToggleControl } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { Component } from 'react';
@@ -107,6 +107,7 @@ export const GoogleAnalytics = withModuleSettingsFormHelpers(
 					{ ! this.props.isUnavailableInOfflineMode( 'google-analytics' ) && (
 						<SettingsGroup hasChild>
 							<ToggleControl
+								__nextHasNoMarginBottom={ true }
 								checked={ this.isActive() }
 								disabled={ this.isSaving() }
 								onChange={ this.toggleActive }
@@ -148,6 +149,7 @@ export const GoogleAnalytics = withModuleSettingsFormHelpers(
 									</FormFieldset>
 									<FormFieldset>
 										<ToggleControl
+											__nextHasNoMarginBottom={ true }
 											checked={ this.getOptionValue( 'anonymize_ip' ) }
 											onChange={ this.onToggleChange( 'anonymize_ip' ) }
 											disabled={ this.isSaving() }

--- a/projects/plugins/jetpack/_inc/client/traffic/related-posts.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/related-posts.jsx
@@ -1,4 +1,5 @@
-import { ToggleControl, getRedirectUrl } from '@automattic/jetpack-components';
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import { ToggleControl } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { Component } from 'react';
@@ -136,13 +137,13 @@ class RelatedPostsComponent extends Component {
 					</ModuleToggle>
 					<FormFieldset>
 						<ToggleControl
+							__nextHasNoMarginBottom={ true }
 							checked={ this.props.getOptionValue( 'show_headline', 'related-posts' ) }
 							disabled={
 								! isRelatedPostsActive ||
 								unavailableInOfflineMode ||
 								this.props.isSavingAnyOption( [ 'related-posts' ] )
 							}
-							toggling={ this.props.isSavingAnyOption( [ 'show_headline' ] ) }
 							onChange={ this.handleShowHeadlineToggleChange }
 							label={
 								<span className="jp-form-toggle-explanation">
@@ -151,13 +152,13 @@ class RelatedPostsComponent extends Component {
 							}
 						/>
 						<ToggleControl
+							__nextHasNoMarginBottom={ true }
 							checked={ this.props.getOptionValue( 'show_thumbnails', 'related-posts' ) }
 							disabled={
 								! isRelatedPostsActive ||
 								unavailableInOfflineMode ||
 								this.props.isSavingAnyOption( [ 'related-posts' ] )
 							}
-							toggling={ this.props.isSavingAnyOption( [ 'show_thumbnails' ] ) }
 							onChange={ this.handleShowThumbnailsToggleChange }
 							label={
 								<span className="jp-form-toggle-explanation">

--- a/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
@@ -1,9 +1,10 @@
-import { getRedirectUrl, ToggleControl } from '@automattic/jetpack-components';
+import { getRedirectUrl } from '@automattic/jetpack-components';
 import {
 	FacebookLinkPreview,
 	TwitterLinkPreview,
 	GoogleSearchPreview,
 } from '@automattic/social-previews';
+import { ToggleControl } from '@wordpress/components';
 import { __, _x, _n, sprintf } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { Component } from 'react';
@@ -244,11 +245,11 @@ export const SEO = withModuleSettingsFormHelpers(
 							{ this.props.seoEnhancerAvailable && this.props.hasSeoEnhancer && (
 								<FormFieldset>
 									<ToggleControl
+										__nextHasNoMarginBottom={ true }
 										id="seo-enhancer"
 										disabled={
 											! this.props.getOptionValue( 'seo-tools' ) || ! this.props.hasSeoEnhancer
 										}
-										toggling={ this.props.isSavingAnyOption( 'ai_seo_enhancer_enabled' ) }
 										checked={
 											this.props.hasSeoEnhancer &&
 											this.props.getOptionValue( 'ai_seo_enhancer_enabled' )

--- a/projects/plugins/jetpack/_inc/client/traffic/site-stats.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/site-stats.jsx
@@ -1,4 +1,5 @@
-import { getRedirectUrl, ToggleControl } from '@automattic/jetpack-components';
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import { ToggleControl } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import clsx from 'clsx';
@@ -230,13 +231,13 @@ class SiteStatsComponent extends Component {
 					>
 						<FormFieldset className="jp-stats-form-fieldset">
 							<ToggleControl
+								__nextHasNoMarginBottom={ true }
 								checked={ !! this.props.getOptionValue( 'admin_bar' ) }
 								disabled={
 									! isStatsActive ||
 									unavailableInOfflineMode ||
 									this.props.isSavingAnyOption( [ 'stats' ] )
 								}
-								toggling={ this.props.isSavingAnyOption( [ 'admin_bar' ] ) }
 								onChange={ this.handleStatsOptionToggle( 'admin_bar' ) }
 								label={ __(
 									'Include a small chart in your admin bar with a 48-hour traffic snapshot',
@@ -248,13 +249,13 @@ class SiteStatsComponent extends Component {
 							<FormLegend>{ __( 'Count logged in page views from', 'jetpack' ) }</FormLegend>
 							{ Object.keys( siteRoles ).map( key => (
 								<ToggleControl
+									__nextHasNoMarginBottom={ true }
 									checked={ this.state[ `count_roles_${ key }` ] }
 									disabled={
 										! isStatsActive ||
 										unavailableInOfflineMode ||
 										this.props.isSavingAnyOption( [ 'stats' ] )
 									}
-									toggling={ this.props.isSavingAnyOption( [ `count_roles_${ key }` ] ) }
 									onChange={ this.handleRoleToggleChange( key, 'count_roles' ) }
 									key={ `count_roles-${ key }` }
 									label={ siteRoles[ key ].name }
@@ -264,6 +265,7 @@ class SiteStatsComponent extends Component {
 						<FormFieldset className="jp-stats-form-fieldset">
 							<FormLegend>{ __( 'Allow Jetpack Stats to be viewed by', 'jetpack' ) }</FormLegend>
 							<ToggleControl
+								__nextHasNoMarginBottom={ true }
 								checked={ true }
 								disabled={ true }
 								label={ siteRoles.administrator.name }
@@ -271,13 +273,13 @@ class SiteStatsComponent extends Component {
 							{ Object.keys( siteRoles ).map( key =>
 								'administrator' !== key ? (
 									<ToggleControl
+										__nextHasNoMarginBottom={ true }
 										checked={ this.state[ `roles_${ key }` ] }
 										disabled={
 											! isStatsActive ||
 											unavailableInOfflineMode ||
 											this.props.isSavingAnyOption( [ 'stats' ] )
 										}
-										toggling={ this.props.isSavingAnyOption( [ `roles_${ key }` ] ) }
 										onChange={ this.handleRoleToggleChange( key, 'roles' ) }
 										key={ `roles-${ key }` }
 										label={ siteRoles[ key ].name }
@@ -288,9 +290,9 @@ class SiteStatsComponent extends Component {
 						<FormFieldset className="jp-stats-form-fieldset">
 							<FormLegend>{ __( 'WordPress.com Reader', 'jetpack' ) }</FormLegend>
 							<ToggleControl
+								__nextHasNoMarginBottom={ true }
 								checked={ this.state.wpcom_reader_views_enabled }
 								disabled={ ! isStatsActive || unavailableInOfflineMode }
-								toggling={ this.props.isSavingAnyOption( [ 'wpcom_reader_views_enabled' ] ) }
 								onChange={ this.handleOptionToggle( 'wpcom_reader_views_enabled' ) }
 								label={ __( 'Show post views for this site.', 'jetpack' ) }
 							/>

--- a/projects/plugins/jetpack/changelog/traffic-toggle-control-wp-components
+++ b/projects/plugins/jetpack/changelog/traffic-toggle-control-wp-components
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Traffic Settings: Import ToggleControl from @wordpress/components


### PR DESCRIPTION
Fixes #48160 (partial — one box on the tracking issue).

## Proposed changes

- Migrate the `ToggleControl` usages on the Jetpack **Traffic** settings page (Site Stats, Related Posts, Google Analytics, Blaze, SEO) off the `@automattic/jetpack-components` wrapper and onto `@wordpress/components` directly.
- Add `__nextHasNoMarginBottom={ true }` on every call site so margin matches what the wrapper was setting by default and no deprecation warning fires.
- Drop the wrapper's `toggling` prop (not present on the upstream component). Existing `disabled` guards keep repeat submissions from firing while settings are in flight; the only user-visible loss is the short optimistic-flip / dim effect during the save round-trip.

The `@automattic/jetpack-components` wrapper and its other consumers (including the `ModuleToggle` wrapper used elsewhere on the same page) are intentionally left alone — separate follow-up.

Same shape as #48179 (Security Settings).

The 5 files touched have 12 direct `ToggleControl` call sites in total:
- `blaze.jsx` (2 — disabled fallback toggles)
- `google-analytics.jsx` (2)
- `related-posts.jsx` (2)
- `seo.jsx` (1 — AI SEO enhancer)
- `site-stats.jsx` (5)

## Related product discussion/links

- Tracking issue: #48160
- Reference PR (same shape, Security Settings): #48179

## Does this pull request change what data or activity we track or use?

No. This is a UI-layer refactor: only the import source of `ToggleControl` and its rendered `__nextHasNoMarginBottom` / `toggling` props change. No telemetry, option storage, REST surface, or user data flow is modified.

## Screenshots

| Surface | Before (baseline on JN) | After (this branch on JN) |
|---|---|---|
| Traffic settings (full page, foldables collapsed) | ![before](https://github.com/Automattic/jetpack/raw/screenshots/traffic/toggle-control-wp-components/before-traffic-collapsed.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/traffic/toggle-control-wp-components/after-traffic-collapsed.png) |

The two PNGs are byte-for-byte identical (CRC32 `0x868c8034` for both, captured via `html2canvas` against the same DOM after the trunk-equivalent and post-migration rsyncs respectively). That confirms the migration produces zero rendered-pixel change at rest — expected, because the wrapper was already passing `__nextHasNoMarginBottom={ true }` through to the upstream component, and the only visible difference (`toggling` dim) only appears during an in-flight save.

_JN rsync target: `plugins/jetpack` · Baseline: `trunk` · JN site: `https://thoughtfully-remarkable-device.jurassic.ninja`_

## Testing instructions

- [ ] On a connected Jetpack site, visit **Jetpack → Settings → Traffic**.
- [ ] Toggle each of the following and confirm they save and persist (no console errors):
  - Related Posts: `Highlight related content with a heading`, `Show a thumbnail image where available`
  - SEO (when AI SEO enhancer is available): `Automatically generate SEO title…`
  - Site Stats foldable → `Include a small chart in your admin bar…`, `Count logged in page views from` rows, `Allow Jetpack Stats to be viewed by` rows, `Show post views for this site.`
- [ ] Verify the deprecation warning about `__nextHasNoMarginBottom` no longer fires for these toggles.
- [ ] Confirm the `ModuleToggle`-driven toggles (e.g. `Show related content after posts`, `Customize your SEO settings`, `Add canonical URLs to archive pages`, the Blaze module switch) and their in-flight dim effect still work as before — they're untouched by this PR.

- [x] Changelog entry added
- [x] Visual diff reviewed (both PNGs are byte-identical)
