### PR TITLE
Discussion Settings: Import ToggleControl from @wordpress/components

### DIFF
--- a/projects/plugins/jetpack/_inc/client/discussion/comments.jsx
+++ b/projects/plugins/jetpack/_inc/client/discussion/comments.jsx
@@ -1,4 +1,5 @@
-import { ToggleControl, getRedirectUrl } from '@automattic/jetpack-components';
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import { ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Component } from 'react';
 import { FormFieldset, FormLabel, FormSelect } from 'components/forms';
@@ -167,15 +168,13 @@ class CommentsComponent extends Component {
 											this.props.isSavingAnyOption( [ 'markdown' ] ) ||
 											'inactive' === this.props.getModuleOverride( 'markdown' )
 										}
-										toggling={ this.props.isSavingAnyOption( [
-											'wpcom_publish_comments_with_markdown',
-										] ) }
 										onChange={ this.handleMarkdownCommentsToggle }
 										label={
 											<span className="jp-form-toggle-explanation">
 												{ __( 'Enable Markdown use for comments.', 'jetpack' ) }
 											</span>
 										}
+										__nextHasNoMarginBottom={ true }
 									/>
 								</FormFieldset>
 								<SupportInfo

--- a/projects/plugins/jetpack/changelog/claude-awesome-hoover-ae306a
+++ b/projects/plugins/jetpack/changelog/claude-awesome-hoover-ae306a
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Discussion Settings: Import ToggleControl directly from @wordpress/components.


### PR DESCRIPTION
Part of #48160

## Proposed changes

- Migrate the `ToggleControl` usage in the Jetpack Discussion settings (the "Enable Markdown use for comments" toggle) off the `@automattic/jetpack-components` wrapper and onto `@wordpress/components` directly.
- Add `__nextHasNoMarginBottom={ true }` on the call site so margin matches what the wrapper was setting by default and no deprecation warning fires.
- Drop the wrapper's `toggling` prop (not present on the upstream component). Existing `disabled` guards keep repeat submissions from firing while settings are in flight; the only user-visible loss is the short optimistic-flip / dim effect during the save round-trip.

The `@automattic/jetpack-components` wrapper and the `ModuleToggle` consumers on the same page (Comments, Gravatar Hovercards, Comment Likes — they go through a different wrapper at `_inc/client/components/module-toggle`) are intentionally left alone — separate follow-up.

## Related product discussion/links

- #48160 — Jetpack UI modernization: migrate `@automattic/jetpack-components` consumers to `@wordpress/ui` / `@wordpress/components`.
- Reference PR #48179 — same migration pattern applied to Security settings (WAF/SSO/Allow List).

## Does this pull request change what data or activity we track or use?
No.

## Screenshots

| Surface | Before (baseline on JN) | After (this branch on JN) |
|---|---|---|
| Jetpack Discussion settings — Markdown toggle | ![before](https://github.com/Automattic/jetpack/raw/screenshots/claude/awesome-hoover-ae306a/before-discussion-markdown-toggle.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/claude/awesome-hoover-ae306a/after-discussion-markdown-toggle.png) |

_JN rsync target: `plugins/jetpack` · Baseline: current trunk build on JN · JN site: `thoughtfully-remarkable-device.jurassic.ninja`_

Before and after are byte-identical: the `@automattic/jetpack-components` wrapper already defaulted `__nextHasNoMarginBottom={ true }` and did not set `size="small"` for this consumer, so the migrated call renders the same pixels. The behavioral difference (no `toggling` dim during in-flight save) does not appear in a static screenshot.

## Testing instructions

- [ ] Open **Jetpack → Settings → Discussion**.
- [ ] Confirm the "Enable Markdown use for comments" toggle still appears below the Gravatar Hovercards module toggle and above Comment Likes, with the same spacing as before.
- [ ] Toggle it on/off and confirm the Markdown module activates/deactivates as expected; the toggle reflects the saved state after the request finishes.
- [ ] Confirm no `__nextHasNoMarginBottom` deprecation warning is logged to the browser console while loading/interacting with the page.
- [ ] Other toggles on the page (Comments, Gravatar Hovercards, Comment Likes) are untouched — they go through the `ModuleToggle` wrapper and should behave exactly as before.
- [ ] Changelog entry added for `plugins/jetpack`.
- [ ] Visual diff reviewed.
