### PR TITLE
VideoPress: migrate ProgressBar to @wordpress/components

### DIFF
--- a/projects/packages/videopress/changelog/2026-04-19-18-25-57-163910
+++ b/projects/packages/videopress/changelog/2026-04-19-18-25-57-163910
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Admin dashboard: migrate video storage meter and video thumbnail upload progress to @wordpress/components ProgressBar; drop unused progressBarClassName prop.

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -248,10 +248,7 @@ const Admin = () => {
 								</Text>
 
 								{ hasVideoPressPurchase && (
-									<ConnectVideoStorageMeter
-										className={ styles[ 'storage-meter' ] }
-										progressBarClassName={ styles[ 'storage-meter__progress-bar' ] }
-									/>
+									<ConnectVideoStorageMeter className={ styles[ 'storage-meter' ] } />
 								) }
 
 								{ hasVideos ? (

--- a/projects/packages/videopress/src/client/admin/components/admin-page/styles.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/styles.module.scss
@@ -60,10 +60,6 @@
 	margin-bottom: calc(var(--spacing-base) * 4);
 }
 
-.storage-meter__progress-bar {
-	background-color: var(--jp-gray);
-}
-
 .query-no-results {
 	font-style: italic;
 }

--- a/projects/packages/videopress/src/client/admin/components/video-storage-meter/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-storage-meter/index.tsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { ProgressBar, Text } from '@automattic/jetpack-components';
+import { Text } from '@automattic/jetpack-components';
+import { ProgressBar } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { filesize } from 'filesize';
@@ -25,12 +26,7 @@ import type { FC, ReactNode } from 'react';
  * @param {VideoStorageMeterProps} props - Component props.
  * @return {ReactNode} - VideoStorageMeter react component.
  */
-const VideoStorageMeter: FC< VideoStorageMeterProps > = ( {
-	className,
-	progressBarClassName,
-	total,
-	used,
-} ) => {
+const VideoStorageMeter: FC< VideoStorageMeterProps > = ( { className, total, used } ) => {
 	if ( ! total || used == null ) {
 		return null;
 	}
@@ -40,8 +36,8 @@ const VideoStorageMeter: FC< VideoStorageMeterProps > = ( {
 	const totalLabel = filesize( total, { base: 10 } );
 
 	return (
-		<div className={ clsx( className ) }>
-			<Text className={ clsx( styles[ 'percentage-description' ] ) }>
+		<div className={ clsx( styles.meter, className ) }>
+			<Text className={ styles[ 'percentage-description' ] }>
 				{ sprintf(
 					/* translators: %1$s is the storage percentage, from 0% to 100%, %2$s is the total storage. */
 					__( '%1$s of %2$s of cloud video storage', 'jetpack-videopress-pkg' ),
@@ -49,10 +45,7 @@ const VideoStorageMeter: FC< VideoStorageMeterProps > = ( {
 					totalLabel
 				) }
 			</Text>
-			<ProgressBar
-				className={ clsx( styles[ 'progress-bar' ], progressBarClassName ) }
-				progress={ progress }
-			></ProgressBar>
+			<ProgressBar value={ Math.min( progress * 100, 100 ) } />
 		</div>
 	);
 };

--- a/projects/packages/videopress/src/client/admin/components/video-storage-meter/stories/index.mdx
+++ b/projects/packages/videopress/src/client/admin/components/video-storage-meter/stories/index.mdx
@@ -30,9 +30,3 @@ The used cloud space, in bytes.
 - type: `string`
 
 Optional classname to apply to the root element.
-
-### progressBarClassName
-
-- type: `string`
-
-* Optional classname to apply to the progress bar element.

--- a/projects/packages/videopress/src/client/admin/components/video-storage-meter/style.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/video-storage-meter/style.module.scss
@@ -3,6 +3,7 @@
 	margin-bottom: calc(var(--spacing-base) * 2); // 16px;
 }
 
-.progress-bar {
-	margin-top: calc(var(--spacing-base) * 2); // 16px;
+.meter > div {
+	height: 12px;
+	width: 100%;
 }

--- a/projects/packages/videopress/src/client/admin/components/video-storage-meter/types.ts
+++ b/projects/packages/videopress/src/client/admin/components/video-storage-meter/types.ts
@@ -5,11 +5,6 @@ export type VideoStorageMeterProps = {
 	className?: string;
 
 	/**
-	 * Optional classname to apply to the progress bar element.
-	 */
-	progressBarClassName?: string;
-
-	/**
 	 * The total available space, in bytes.
 	 */
 	total: number;

--- a/projects/packages/videopress/src/client/admin/components/video-thumbnail/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/video-thumbnail/index.tsx
@@ -6,10 +6,9 @@ import {
 	Button,
 	useBreakpointMatch,
 	LoadingPlaceholder,
-	ProgressBar,
 	ThemeProvider,
 } from '@automattic/jetpack-components';
-import { Dropdown } from '@wordpress/components';
+import { Dropdown, ProgressBar } from '@wordpress/components';
 import { gmdateI18n } from '@wordpress/date';
 import { __, sprintf } from '@wordpress/i18n';
 import {
@@ -141,11 +140,7 @@ const UploadingThumbnail = ( {
 
 	return (
 		<div className={ clsx( styles[ 'custom-thumbnail' ], { [ styles[ 'is-row' ] ]: isRow } ) }>
-			<ProgressBar
-				className={ styles[ 'progress-bar' ] }
-				size="small"
-				progress={ uploadProgress }
-			/>
+			<ProgressBar value={ Math.min( uploadProgress * 100, 100 ) } />
 			<Text variant={ isRow ? 'body-extra-small' : 'body' } className={ styles[ 'upload-text' ] }>
 				{ infoText }
 			</Text>

--- a/projects/packages/videopress/src/client/admin/components/video-thumbnail/style.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/video-thumbnail/style.module.scss
@@ -93,24 +93,20 @@
 	flex-direction: column;
 	gap: var(--spacing-base);
 
+	> div {
+		height: 3px;
+	}
+
 	.pulse {
 		animation: pulse 1.5s infinite;
 	}
 
 	&.is-row {
 
-		.progress-bar {
-			max-width: 80px;
-		}
-
 		.upload-text {
 			margin-top: 0;
 		}
 	}
-}
-
-.progress-bar {
-	max-width: 112px;
 }
 
 .upload-text {

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/style.scss
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/style.scss
@@ -606,6 +606,10 @@
 .jp-dash-item__videopress-storage {
 	margin-top: rem.convert(16px);
 
+	> div {
+		height: 12px;
+	}
+
 	span {
 		margin-top: rem.convert(10px);
 		display: block;

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/videopress.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/videopress.jsx
@@ -1,4 +1,5 @@
-import { ProgressBar, getRedirectUrl } from '@automattic/jetpack-components';
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import { ProgressBar } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
@@ -95,7 +96,9 @@ class DashVideoPress extends Component {
 								</p>
 								{ shouldDisplayStorage && (
 									<div className="jp-dash-item__videopress-storage">
-										<ProgressBar progress={ videoPressStorageUsed / 1000000 } />
+										<ProgressBar
+											value={ Math.min( ( videoPressStorageUsed / 1000000 ) * 100, 100 ) }
+										/>
 										<span>
 											{ createInterpolateElement(
 												sprintf(

--- a/projects/plugins/jetpack/_inc/client/performance/media.jsx
+++ b/projects/plugins/jetpack/_inc/client/performance/media.jsx
@@ -1,5 +1,5 @@
-import { ProgressBar, getRedirectUrl } from '@automattic/jetpack-components';
-import { ToggleControl } from '@wordpress/components';
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import { ProgressBar, ToggleControl } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { Component } from 'react';
@@ -87,7 +87,7 @@ class Media extends Component {
 				</p>
 				{ shouldDisplayStorage && (
 					<div className="media__videopress-storage">
-						<ProgressBar progress={ videoPressStorageUsed / 1000000 } />
+						<ProgressBar value={ Math.min( ( videoPressStorageUsed / 1000000 ) * 100, 100 ) } />
 						<span>
 							{ createInterpolateElement(
 								sprintf(

--- a/projects/plugins/jetpack/_inc/client/performance/style.scss
+++ b/projects/plugins/jetpack/_inc/client/performance/style.scss
@@ -10,6 +10,10 @@
 	margin-bottom: 1.5rem;
 	max-width: 50%;
 
+	> div {
+		height: 12px;
+	}
+
 	span {
 		margin-top: rem.convert(10px);
 		display: block;

--- a/projects/plugins/jetpack/changelog/2026-04-19-17-39-54-327253
+++ b/projects/plugins/jetpack/changelog/2026-04-19-17-39-54-327253
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+VideoPress storage meters: replace custom Jetpack ProgressBar with @wordpress/components ProgressBar.


### PR DESCRIPTION
Part of #48160

## Proposed changes
* Replace the custom `ProgressBar` from `@automattic/jetpack-components` with the native `ProgressBar` from `@wordpress/components` on VideoPress-related progress bars:
  * VideoPress admin dashboard storage meter (`packages/videopress` · `VideoStorageMeter`).
  * VideoPress thumbnail upload progress (`packages/videopress` · `VideoThumbnail`).
  * Jetpack plugin VideoPress storage meters in Performance settings and the At-a-Glance dashboard card.
* Convert the `progress` (0–1) prop to the WP `value` (0–100) prop, clamped to 100 to match the previous component's internal behavior.
* Drop the `progressBarClassName` prop from `VideoStorageMeter` (only consumer was the admin page, which only used it for a background-color override that the WP default already provides).
* Restore the previous bar dimensions with small scoped overrides: 12px height (storage meters), 3px height (thumbnail upload), 100% width (VideoPress admin storage meter). WP's default Track is 1.5px tall.
* Clean up orphaned CSS after the prop removal.

## Related product discussion/links
* Parent issue: #48160 (Jetpack UI Modernization)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

### VideoPress admin dashboard (packages/videopress)
1. Visit `wp-admin/admin.php?page=jetpack-videopress` on a site with a paid VideoPress plan and at least one uploaded video.
2. Confirm the storage meter renders under "High quality, ad-free video" with:
   * a 12px-tall, full-width bar
   * the percentage label above (e.g. "50% of 1 TB of cloud video storage")
3. Upload a new video via the video library. While uploading, confirm the thumbnail tile shows a thin (3px) progress bar beneath the "Uploading X%" label, and that it renders correctly in both card view and row view.

### Jetpack plugin — Performance settings
1. Go to Jetpack → Settings → Writing → Media on a site with a paid VideoPress (non-unlimited) plan.
2. Confirm the VideoPress storage meter renders with a 12px bar and the "Using NGB of 1TB" label below.

### Jetpack plugin — At-a-Glance dashboard card
1. Go to Jetpack → Dashboard on the same site configuration and ensure the VideoPress card shows the storage meter with a 12px bar and the "Using NGB of 1TB" label.

### Regression checks
* Visit the VideoPress admin dashboard on an Atomic site or on an unlimited-storage plan and confirm the storage meter is still hidden.
* Confirm storybook stories for `VideoStorageMeter` and `VideoThumbnail` still render.

| Before | After |
| - | - |
| <img width="770" height="271" alt="Screenshot from 2026-04-19 16-05-33" src="https://github.com/user-attachments/assets/f668bf68-24c8-41bc-bc35-855a66c81776" /> | <img width="770" height="271" alt="Screenshot from 2026-04-19 16-05-39" src="https://github.com/user-attachments/assets/d448c458-4a69-4ab2-9fb1-6cf9d68f9b06" /> |
|  <img width="722" height="340" alt="Screenshot from 2026-04-19 16-06-37" src="https://github.com/user-attachments/assets/a8c35940-1fdd-48b9-9675-aebb20c78cea" /> | <img width="722" height="340" alt="Screenshot from 2026-04-19 16-06-45" src="https://github.com/user-attachments/assets/c9b470ac-c3a3-4293-81f5-37218b9b50cf" /> |
| <img width="722" height="340" alt="Screenshot from 2026-04-19 16-08-36" src="https://github.com/user-attachments/assets/23ac1bc7-95ba-42ed-8e74-ca5e9971757a" /> | <img width="722" height="340" alt="Screenshot from 2026-04-19 16-08-54" src="https://github.com/user-attachments/assets/90af04b7-67a4-4265-8187-d8605261b317" /> |
| <img width="477" height="340" alt="Screenshot from 2026-04-19 16-10-03" src="https://github.com/user-attachments/assets/f8c11978-15ff-4d3c-a118-ae1bee10704d" /> | <img width="477" height="340" alt="Screenshot from 2026-04-19 16-10-18" src="https://github.com/user-attachments/assets/520e02de-9b81-45f2-a1eb-7d6ccdc64e01" /> |
