### PR TITLE
Forms: remove orphaned SCSS @use imports from dashboard partials

### DIFF
--- a/projects/packages/forms/changelog/update-forms-dead-scss-use
+++ b/projects/packages/forms/changelog/update-forms-dead-scss-use
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Dashboard: remove orphaned SCSS @use imports that were never referenced.

--- a/projects/packages/forms/routes/responses/response/style.scss
+++ b/projects/packages/forms/routes/responses/response/style.scss
@@ -2,9 +2,6 @@
  * Response View Component Styles
  */
 
-@use "@wordpress/base-styles/breakpoints";
-@use "@wordpress/base-styles/variables";
-
 $inspector-padding: 16px;
 
 .jp-forms-response-header {

--- a/projects/packages/forms/src/dashboard/components/feedback-comments/style.scss
+++ b/projects/packages/forms/src/dashboard/components/feedback-comments/style.scss
@@ -3,7 +3,6 @@
  */
 
 @use "@wordpress/base-styles/breakpoints";
-@use "@wordpress/base-styles/variables";
 @use "../../mixins";
 
 .jp-forms__feedback-comments {

--- a/projects/packages/forms/src/dashboard/components/inspector/response-meta/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-meta/style.scss
@@ -1,5 +1,4 @@
 
-@use "@wordpress/base-styles/breakpoints";
 @use "@wordpress/base-styles/variables";
 
 .jp-forms__inbox-response-meta {

--- a/projects/packages/forms/src/dashboard/components/inspector/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/style.scss
@@ -3,7 +3,6 @@
  */
 
 @use "@wordpress/base-styles/breakpoints";
-@use "@wordpress/base-styles/variables";
 @use "../../mixins";
 
 // Main response container

--- a/projects/packages/forms/src/dashboard/components/page/style.scss
+++ b/projects/packages/forms/src/dashboard/components/page/style.scss
@@ -1,6 +1,5 @@
 @use "@wordpress/base-styles/variables";
 @use "@wordpress/base-styles/mixins";
-@use "@wordpress/base-styles/colors";
 
 // Stack component styles for layout
 .jp-forms-stack {

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -1,6 +1,4 @@
-@use "@wordpress/base-styles/breakpoints";
 @use "@wordpress/base-styles/variables";
-@use "@wordpress/base-styles/colors";
 @use "../mixins";
 @use "../../blocks/shared/styles/empty_image_option" as *;
 @use "../design-tokens";


### PR DESCRIPTION
Part of #48160.

## Proposed changes

Remove `@use "@wordpress/base-styles/{breakpoints,colors,variables}"` imports from six forms dashboard SCSS files where the imported namespace was never referenced. Same root cause as #48184 — stale imports left behind after the only consumer was removed upstream (#46732 for the `inbox/style.scss` ones; the others are sibling orphans surfaced while auditing the package).

Files touched (9 `@use` lines total):

| File | Removed |
|---|---|
| `src/dashboard/inbox/style.scss` | `breakpoints`, `colors` |
| `src/dashboard/components/inspector/style.scss` | `variables` |
| `src/dashboard/components/inspector/response-meta/style.scss` | `breakpoints` |
| `src/dashboard/components/feedback-comments/style.scss` | `variables` |
| `src/dashboard/components/page/style.scss` | `colors` |
| `routes/responses/response/style.scss` | `breakpoints`, `variables` |

### Why this is safe

* **Compiled CSS is byte-identical.** The WP base-style partials (`breakpoints`, `colors`, `variables`) emit no top-level rules — they're pure Sass definitions. Removing an unreferenced `@use` of a definition-only partial produces zero output change.
* **No transitive re-export.** Sass `@use` namespaces are scoped to the importing file. Only `@forward` re-exports — and there are zero `@forward` directives anywhere in `projects/packages/forms`.
* **No external Sass consumer.** Verified via local grep plus OpenGrok search across wpcom, calypso, dash, mage, and engineering: nothing `@use`s or `@import`s any of the six edited files. The only external hits are webpack-emitted source-path comments inside Jetpack's own compiled JS bundle — regenerated every build.
* **Dashboard webpack build passes** (2.4s, both LTR/RTL bundles emitted, no Sass errors).

## Related product discussion/links

* Tracking issue: #48160
* Companion PR (same `#46732` root cause, `.jp-forms-filters-bar` dead SCSS): #48184
* Claim comment: https://github.com/Automattic/jetpack/issues/48160#issuecomment-4276752211

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `pnpm --filter @automattic/jetpack-forms build:dashboard` — should complete without Sass errors.
* Optionally compare `projects/packages/forms/build/jetpack-forms-dashboard.css` before and after this branch — the output should be byte-identical.

- [x] Changelog entry added (`packages/forms`, patch / removed).