### PR TITLE
Search: fix upsell page horizontal overflow on mobile

### DIFF
--- a/projects/packages/search/changelog/fix-search-upsell-page-mobile-overflow
+++ b/projects/packages/search/changelog/fix-search-upsell-page-mobile-overflow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix mobile overflow on the upsell/pricing page so cards no longer get clipped.

--- a/projects/packages/search/src/dashboard/components/pages/upsell-page/index.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/upsell-page/index.jsx
@@ -200,7 +200,7 @@ const NewPricingComponent = ( { sendToCartPaid, sendToCartFree } ) => {
 	} ).format( unitQuantityRaw );
 
 	return (
-		<Container horizontalSpacing={ 8 }>
+		<Container horizontalSpacing={ 8 } className="jp-search-upsell-container">
 			{ hasConnectionError && (
 				<Col lg={ 12 } md={ 12 } sm={ 12 }>
 					<ConnectionError />

--- a/projects/packages/search/src/dashboard/components/pages/upsell-page/styles.scss
+++ b/projects/packages/search/src/dashboard/components/pages/upsell-page/styles.scss
@@ -1,5 +1,14 @@
 @use "scss/variables";
 
+// Container ships with width:100% + padding without border-box, so it
+// overflows its parent. Force border-box and let descendants shrink past
+// their intrinsic width.
+.jp-search-upsell-container,
+.jp-search-upsell-container * {
+	box-sizing: border-box;
+	min-width: 0;
+}
+
 .price-tip {
 	display: flex;
 	height: 20px;

--- a/projects/plugins/search/changelog/fix-search-upsell-page-mobile-overflow
+++ b/projects/plugins/search/changelog/fix-search-upsell-page-mobile-overflow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix mobile overflow on the upsell/pricing page so cards no longer get clipped.


### PR DESCRIPTION
Fixes #

## Proposed changes
* Scope a `box-sizing: border-box; min-width: 0` rule to the Search upsell/pricing page's inner `Container` so it stops overflowing its parent on small viewports.

The shared layout `Container` (from `@automattic/jetpack-components`) ships with `width: 100%` plus breakpoint padding (16/18/24px) but **without** `box-sizing: border-box`. As a result, when the Search upsell page wraps its content in `<Container horizontalSpacing={ 8 }>`, the rendered element is ~32px wider than its parent on mobile. The enclosing `AdminSectionHero` (`overflow: hidden`) then clips the heading and the pricing card off-screen.

The fix is intentionally local to the Search upsell page (a new `jp-search-upsell-container` className with a small SCSS rule). Touching the shared `Container` component would risk regressing every other admin page that depends on its current sizing behaviour.

Desktop layout is unchanged — the inner `Container` is still centered at `max-width: 1088px`.

Before:
<img width="390" height="844" alt="search-pricing-mobile-390" src="https://github.com/user-attachments/assets/159e4558-2fb8-47d2-81a9-7331c6aa4aa9" />

After:
<img width="390" height="844" alt="search-pricing-mobile-390-after" src="https://github.com/user-attachments/assets/59f0c67d-6040-4c26-9bfb-0c53996a1d80" />


## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. Have a Jetpack site that does **not** have a Search plan (so the upsell page renders). If you don't have one handy, you can short-circuit `supportsSearch` to `false` in `projects/packages/search/src/dashboard/components/dashboard/wrapped-dashboard.jsx`.
2. Build the package and plugin: `pnpm jetpack build packages/search plugins/search`.
3. Visit `wp-admin/admin.php?page=jetpack-search`.
4. Resize the browser to a mobile viewport (e.g. 390×844, or use DevTools device emulation).
5. **Before:** the heading "The best WordPress search experience" is cut off mid-word, the pricing card extends past the right edge of the viewport, and there is no horizontal scroll (content is clipped by `overflow:hidden`).
6. **After:** the heading wraps cleanly, the pricing card fits within the viewport with proper padding on both sides, and feature rows render fully.
7. Resize back to desktop (≥ 1280px) — the layout should be unchanged from before: pricing block centered with the off-white hero background extending edge-to-edge as on other Jetpack admin pages.
