### PR TITLE
Admin pages: hide #screen-meta-links in shared layout mixin

### DIFF
--- a/projects/js-packages/base-styles/admin-page-layout.scss
+++ b/projects/js-packages/base-styles/admin-page-layout.scss
@@ -67,6 +67,19 @@ $jp-breakpoint-mobile: 782px;
 		display: none;
 	}
 
+	// `#screen-meta-links` (the "Screen Options" / "Help" tabs container) is
+	// always emitted by core's admin header, even when empty. Core CSS gives
+	// it `margin: 0 10px 20px 0`, and on WP.com (`is-nav-unification`) the
+	// wpcom toolbar adds extra buttons + margins. With `#wpbody-content`
+	// flipped to `position: fixed` flex, that bottom margin reserves a 20px
+	// slot at the top of the column and pushes `.jp-admin-page` down. None of
+	// our React admin pages register screen-options or help tabs, so hide it.
+	// (`#screen-meta` itself stays alone — core defaults it to `display:none`
+	// and toggles it on click; we never trigger that here.)
+	#screen-meta-links {
+		display: none;
+	}
+
 	// ── Viewport-pinned content column ────────────────────────────────
 	// `position: fixed` pins the content column to the viewport. The
 	// sidebar (`#adminmenumain`) is left untouched — it can grow past

--- a/projects/js-packages/base-styles/changelog/fix-admin-page-layout-hide-screen-meta-links
+++ b/projects/js-packages/base-styles/changelog/fix-admin-page-layout-hide-screen-meta-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Hide #screen-meta-links inside the jetpack-admin-page-layout mixin so the wp-admin Screen Options/Help wrapper stops reserving a 20px slot at the top of the content column.

--- a/projects/packages/search/changelog/fix-admin-page-layout-hide-screen-meta-links
+++ b/projects/packages/search/changelog/fix-admin-page-layout-hide-screen-meta-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Drop the local `#screen-meta` / `#screen-meta-links` hide rule now that the shared admin-page-layout mixin handles it.

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.scss
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.scss
@@ -1,11 +1,6 @@
 @use "scss/variables";
 @use "scss/rna-styles";
 
-#screen-meta,
-#screen-meta-links {
-	display: none;
-}
-
 #jp-search-dashboard {
 	color: variables.$black;
 	font-size: 16px;


### PR DESCRIPTION
Fixes #

## Proposed changes
* Hide `#screen-meta-links` inside the shared `jetpack-admin-page-layout` mixin so it stops reserving a 20px slot at the top of the content column on every Jetpack admin page.
* Drop the now-redundant local hide rule from the Search dashboard SCSS (was the only consumer carrying its own copy).

### Context

Core wp-admin always emits `#screen-meta-links` (the "Screen Options" / "Help" tabs container) in `wp-admin/admin-header.php`, even when empty, and core CSS gives it `margin: 0 10px 20px 0`. On WP.com hosted sites (`is-nav-unification`) the wpcom toolbar adds extra buttons too.

With `#wpbody-content` flipped to `position: fixed` flex by `jetpack-admin-page-layout` (introduced in #48109), that bottom margin reserves a ~20px slot at the top of the content column and pushes `.jp-admin-page` down by exactly 20px on every Jetpack admin page rendered through the WP.com shell. Self-hosted Jetpack sites don't render the wrapper at all (something in the local stack suppresses it), which is why this regression only shows up on the Calypso side and was missed in local testing.

`#screen-meta` itself is **not** hidden by this PR — core defaults it to `display: none` and only toggles it on click via the screen-meta-links buttons, which we've now hidden, so it never opens. Adding a redundant rule for it would be noise.

## Related product discussion/links
* Original layout-mixin PR: #48109
* Follow-up that uncovered this on the WP.com side: this PR

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

This regression is **only visible on WP.com hosted sites** (or any environment where the WP shell still emits `#screen-meta-links`). Self-hosted local Jetpack sites won't render the element at all — testing locally will show no visual change.

To verify on WP.com:

1. Open any Jetpack admin page on a hosted site, e.g. `https://<your-site>/wp-admin/admin.php?page=jetpack-social`, in a mobile viewport (~390×844).
2. **Before:** there's a noticeable ~20px empty band between the WP admin bar and the `.jp-admin-page` content. In DevTools you'll find `#screen-meta-links` with `display: block`, `height: 0`, `margin-bottom: 20px`.
3. **After this PR ships and is deployed:** the gap is gone, `.jp-admin-page` sits flush against the admin bar. `#screen-meta-links` is `display: none` via the mixin.
4. To preview the after-state without deploying, open DevTools and run `document.getElementById('screen-meta-links').style.display = 'none'` — content should jump up by 20px.

Pages to spot-check (all use the mixin): My Jetpack, Backup, Boost, Newsletter, Protect, Search, Social, VideoPress, plus the Jetpack network admin page.
