### PR TITLE
ModuleToggle: import ToggleControl from @wordpress/components

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/dash-item/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/dash-item/index.jsx
@@ -87,7 +87,7 @@ export class DashItem extends Component {
 					<ModuleToggle
 						slug={ this.props.module }
 						activated={ this.props.getOptionValue( this.props.module ) }
-						toggling={ this.props.isUpdating( this.props.module ) }
+						disabled={ this.props.isUpdating( this.props.module ) }
 						toggleModule={ this.toggleModule }
 						compact={ true }
 					/>

--- a/projects/plugins/jetpack/_inc/client/components/module-toggle/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/module-toggle/index.jsx
@@ -1,4 +1,5 @@
-import { getRedirectUrl, ToggleControl } from '@automattic/jetpack-components';
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import { ToggleControl } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
@@ -96,8 +97,8 @@ class ModuleToggleComponent extends Component {
 	render() {
 		return (
 			<ToggleControl
+				__nextHasNoMarginBottom={ true }
 				checked={ this.props.activated }
-				toggling={ this.props.toggling }
 				className={ this.props.className }
 				disabled={ this.props.disabled || this.isDisabledByOverride() }
 				onChange={ this.toggleModule }

--- a/projects/plugins/jetpack/_inc/client/discussion/comments.jsx
+++ b/projects/plugins/jetpack/_inc/client/discussion/comments.jsx
@@ -84,9 +84,10 @@ class CommentsComponent extends Component {
 						<ModuleToggle
 							slug="comments"
 							compact
-							disabled={ commentsUnavailableInOfflineMode }
+							disabled={
+								commentsUnavailableInOfflineMode || this.props.isSavingAnyOption( 'comments' )
+							}
 							activated={ this.props.getOptionValue( 'comments' ) }
-							toggling={ this.props.isSavingAnyOption( 'comments' ) }
 							toggleModule={ this.props.toggleModuleNow }
 						>
 							<span className="jp-form-toggle-explanation">{ comments.description }</span>
@@ -140,8 +141,8 @@ class CommentsComponent extends Component {
 									<ModuleToggle
 										slug="gravatar-hovercards"
 										compact
+										disabled={ this.props.isSavingAnyOption( 'gravatar-hovercards' ) }
 										activated={ this.props.getOptionValue( 'gravatar-hovercards' ) }
-										toggling={ this.props.isSavingAnyOption( 'gravatar-hovercards' ) }
 										toggleModule={ this.props.toggleModuleNow }
 									>
 										<span className="jp-form-toggle-explanation">{ gravatar.description }</span>
@@ -190,9 +191,10 @@ class CommentsComponent extends Component {
 									<ModuleToggle
 										slug="comment-likes"
 										compact
-										disabled={ commentLikesUnavailable }
+										disabled={
+											commentLikesUnavailable || this.props.isSavingAnyOption( 'comment-likes' )
+										}
 										activated={ commentLikesActive }
-										toggling={ this.props.isSavingAnyOption( 'comment-likes' ) }
 										toggleModule={ this.props.toggleModuleNow }
 									>
 										<span className="jp-form-toggle-explanation">

--- a/projects/plugins/jetpack/_inc/client/earn/ads.jsx
+++ b/projects/plugins/jetpack/_inc/client/earn/ads.jsx
@@ -195,9 +195,8 @@ export const Ads = withModuleSettingsFormHelpers(
 
 						<ModuleToggle
 							slug="wordads"
-							disabled={ unavailableInOfflineMode }
+							disabled={ unavailableInOfflineMode || this.props.isSavingAnyOption( 'wordads' ) }
 							activated={ isAdsActive }
-							toggling={ this.props.isSavingAnyOption( 'wordads' ) }
 							toggleModule={ this.props.toggleModuleNow }
 						>
 							<span className="jp-form-toggle-explanation">

--- a/projects/plugins/jetpack/_inc/client/performance/media.jsx
+++ b/projects/plugins/jetpack/_inc/client/performance/media.jsx
@@ -104,9 +104,11 @@ class Media extends Component {
 					<>
 						<ModuleToggle
 							slug="videopress"
-							disabled={ this.props.isUnavailableInOfflineMode( 'videopress' ) }
+							disabled={
+								this.props.isUnavailableInOfflineMode( 'videopress' ) ||
+								this.props.isSavingAnyOption( 'videopress' )
+							}
 							activated={ this.props.getOptionValue( 'videopress' ) }
-							toggling={ this.props.isSavingAnyOption( 'videopress' ) }
 							toggleModule={ this.props.toggleModuleNow }
 						>
 							<span className="jp-form-toggle-explanation">

--- a/projects/plugins/jetpack/_inc/client/performance/search.jsx
+++ b/projects/plugins/jetpack/_inc/client/performance/search.jsx
@@ -82,7 +82,7 @@ function Search( props ) {
 						<ModuleToggle
 							activated={ isModuleEnabled }
 							compact
-							toggling={ togglingModule }
+							disabled={ togglingModule }
 							slug="search"
 							toggleModule={ toggleSearchModule }
 						>

--- a/projects/plugins/jetpack/_inc/client/performance/speed-up-site.jsx
+++ b/projects/plugins/jetpack/_inc/client/performance/speed-up-site.jsx
@@ -264,9 +264,11 @@ const SpeedUpSite = withModuleSettingsFormHelpers(
 									{ foundPhoton && (
 										<ModuleToggle
 											slug="photon"
-											disabled={ this.props.isUnavailableInOfflineMode( 'photon' ) }
+											disabled={
+												this.props.isUnavailableInOfflineMode( 'photon' ) ||
+												this.props.isSavingAnyOption( 'photon' )
+											}
 											activated={ this.props.getOptionValue( 'photon' ) }
-											toggling={ this.props.isSavingAnyOption( 'photon' ) }
 											toggleModule={ this.toggleModule }
 										>
 											<span className="jp-form-toggle-explanation">
@@ -277,8 +279,8 @@ const SpeedUpSite = withModuleSettingsFormHelpers(
 									{ foundAssetCdn && (
 										<ModuleToggle
 											slug="photon-cdn"
+											disabled={ this.props.isSavingAnyOption( 'photon-cdn' ) }
 											activated={ this.props.getOptionValue( 'photon-cdn' ) }
-											toggling={ this.props.isSavingAnyOption( 'photon-cdn' ) }
 											toggleModule={ this.toggleModule }
 										>
 											<span className="jp-form-toggle-explanation">

--- a/projects/plugins/jetpack/_inc/client/reader/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/reader/index.jsx
@@ -109,9 +109,8 @@ function Reader( props ) {
 			<ModuleToggle
 				slug={ moduleName }
 				activated={ isReaderModuleActive }
-				toggling={ isSavingAnyOption( moduleName ) }
 				toggleModule={ toggleModule }
-				disabled={ cannotBeToggled }
+				disabled={ cannotBeToggled || isSavingAnyOption( moduleName ) }
 			>
 				<span className="jp-form-toggle-explanation">
 					{ __( 'Add a link to the Reader in the top navigation bar', 'jetpack' ) }

--- a/projects/plugins/jetpack/_inc/client/security/account-protection.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/account-protection.jsx
@@ -72,9 +72,12 @@ const AccountProtectionComponent = class extends Component {
 					<ModuleToggle
 						slug="account-protection"
 						compact
-						disabled={ ! isSupported || unavailableInOfflineMode }
+						disabled={
+							! isSupported ||
+							unavailableInOfflineMode ||
+							this.props.isSavingAnyOption( MODULE_NAME )
+						}
 						activated={ isActive }
-						toggling={ this.props.isSavingAnyOption( MODULE_NAME ) }
 						toggleModule={ this.props.toggleModuleNow }
 					>
 						<span className="jp-form-toggle-explanation">

--- a/projects/plugins/jetpack/_inc/client/security/monitor.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/monitor.jsx
@@ -43,9 +43,12 @@ export const Monitor = withModuleSettingsFormHelpers(
 					>
 						<ModuleToggle
 							slug="monitor"
-							disabled={ unavailableInOfflineMode || ! hasConnectedOwner }
+							disabled={
+								unavailableInOfflineMode ||
+								! hasConnectedOwner ||
+								this.props.isSavingAnyOption( 'monitor' )
+							}
 							activated={ isMonitorActive }
-							toggling={ this.props.isSavingAnyOption( 'monitor' ) }
 							toggleModule={ this.props.toggleModuleNow }
 						>
 							<span className="jp-form-toggle-explanation">

--- a/projects/plugins/jetpack/_inc/client/security/protect.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/protect.jsx
@@ -33,9 +33,8 @@ const ProtectComponent = class extends Component {
 					<ModuleToggle
 						slug="protect"
 						compact
-						disabled={ unavailableInOfflineMode }
+						disabled={ unavailableInOfflineMode || this.props.isSavingAnyOption( 'protect' ) }
 						activated={ isProtectActive }
-						toggling={ this.props.isSavingAnyOption( 'protect' ) }
 						toggleModule={ this.props.toggleModuleNow }
 					>
 						<span className="jp-form-toggle-explanation">

--- a/projects/plugins/jetpack/_inc/client/security/sso.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/sso.jsx
@@ -163,9 +163,12 @@ export const SSO = withModuleSettingsFormHelpers(
 							</p>
 							<ModuleToggle
 								slug="sso"
-								disabled={ unavailableInOfflineMode || ! this.props.hasConnectedOwner }
+								disabled={
+									unavailableInOfflineMode ||
+									! this.props.hasConnectedOwner ||
+									this.props.isSavingAnyOption( 'sso' )
+								}
 								activated={ isSSOActive }
-								toggling={ this.props.isSavingAnyOption( 'sso' ) }
 								// eslint-disable-next-line react/jsx-no-bind
 								toggleModule={ name => {
 									if ( isSSOActive ) {

--- a/projects/plugins/jetpack/_inc/client/security/waf.jsx
+++ b/projects/plugins/jetpack/_inc/client/security/waf.jsx
@@ -497,9 +497,8 @@ export const Waf = class extends Component {
 				>
 					<ModuleToggle
 						slug="waf"
-						disabled={ unavailableInOfflineMode }
+						disabled={ unavailableInOfflineMode || this.props.isSavingAnyOption( 'waf' ) }
 						activated={ isWafActive }
-						toggling={ this.props.isSavingAnyOption( 'waf' ) }
 						toggleModule={ this.props.toggleModuleNow }
 					>
 						<span className="jp-form-toggle-explanation">

--- a/projects/plugins/jetpack/_inc/client/sharing/likes.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/likes.jsx
@@ -75,9 +75,8 @@ export const Likes = withModuleSettingsFormHelpers(
 						</p>
 						<ModuleToggle
 							slug="likes"
-							disabled={ unavailableInOfflineMode }
+							disabled={ unavailableInOfflineMode || this.props.isSavingAnyOption( 'likes' ) }
 							activated={ isActive }
-							toggling={ this.props.isSavingAnyOption( 'likes' ) }
 							toggleModule={ this.props.toggleModuleNow }
 						>
 							<span className="jp-form-toggle-explanation">

--- a/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/publicize.jsx
@@ -64,9 +64,13 @@ export const Publicize = withModuleSettingsFormHelpers(
 
 						<ModuleToggle
 							slug="publicize"
-							disabled={ isOfflineMode || ! isLinked || ! userCanManageModules }
+							disabled={
+								isOfflineMode ||
+								! isLinked ||
+								! userCanManageModules ||
+								this.props.isSavingAnyOption( 'publicize' )
+							}
 							activated={ isActive }
-							toggling={ this.props.isSavingAnyOption( 'publicize' ) }
 							toggleModule={ this.props.toggleModuleNow }
 						>
 							<span className="jp-form-toggle-explanation">

--- a/projects/plugins/jetpack/_inc/client/sharing/share-buttons.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/share-buttons.jsx
@@ -68,8 +68,8 @@ export const ShareButtons = withModuleSettingsFormHelpers(
 				const toggle = (
 					<ModuleToggle
 						slug="sharedaddy"
+						disabled={ this.props.isSavingAnyOption( 'sharedaddy' ) }
 						activated={ isActive }
-						toggling={ this.props.isSavingAnyOption( 'sharedaddy' ) }
 						toggleModule={ this.props.toggleModuleNow }
 					>
 						<span className="jp-form-toggle-explanation">

--- a/projects/plugins/jetpack/_inc/client/traffic/blaze.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/blaze.jsx
@@ -88,8 +88,7 @@ function Blaze( props ) {
 			<ModuleToggle
 				slug="blaze"
 				activated={ blazeActive }
-				disabled={ unavailableInOfflineMode || ! hasConnectedOwner }
-				toggling={ isSavingAnyOption( 'blaze' ) }
+				disabled={ unavailableInOfflineMode || ! hasConnectedOwner || isSavingAnyOption( 'blaze' ) }
 				toggleModule={ toggleModuleNow }
 			>
 				<span className="jp-form-toggle-explanation">

--- a/projects/plugins/jetpack/_inc/client/traffic/related-posts.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/related-posts.jsx
@@ -126,9 +126,8 @@ class RelatedPostsComponent extends Component {
 					</p>
 					<ModuleToggle
 						slug="related-posts"
-						disabled={ unavailableInOfflineMode }
+						disabled={ unavailableInOfflineMode || this.props.isSavingAnyOption( 'related-posts' ) }
 						activated={ isRelatedPostsActive }
-						toggling={ this.props.isSavingAnyOption( 'related-posts' ) }
 						toggleModule={ this.props.toggleModuleNow }
 					>
 						<span className="jp-form-toggle-explanation">

--- a/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
@@ -231,10 +231,11 @@ export const SEO = withModuleSettingsFormHelpers(
 							<ModuleToggle
 								slug="seo-tools"
 								activated={ isSeoActive }
-								toggling={ this.props.isSavingAnyOption( seo.module ) }
 								disabled={
-									this.props.isSavingAnyOption( this.constants.moduleOptionsArray ) ||
-									hasConflictingSeoPlugin
+									this.props.isSavingAnyOption( [
+										seo.module,
+										...this.constants.moduleOptionsArray,
+									] ) || hasConflictingSeoPlugin
 								}
 								toggleModule={ this.props.toggleModuleNow }
 							>
@@ -281,10 +282,11 @@ export const SEO = withModuleSettingsFormHelpers(
 						<ModuleToggle
 							slug="canonical-urls"
 							activated={ this.props.getOptionValue( 'canonical-urls' ) }
-							toggling={ this.props.isSavingAnyOption( 'canonical-urls' ) }
 							disabled={
-								this.props.isSavingAnyOption( this.constants.moduleOptionsArray ) ||
-								hasConflictingSeoPlugin
+								this.props.isSavingAnyOption( [
+									'canonical-urls',
+									...this.constants.moduleOptionsArray,
+								] ) || hasConflictingSeoPlugin
 							}
 							toggleModule={ this.props.toggleModuleNow }
 						>

--- a/projects/plugins/jetpack/_inc/client/traffic/shortlinks.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/shortlinks.jsx
@@ -29,9 +29,8 @@ class Shortlinks extends Component {
 				>
 					<ModuleToggle
 						slug="shortlinks"
-						disabled={ ! isSiteConnected }
+						disabled={ ! isSiteConnected || this.props.isSavingAnyOption( 'shortlinks' ) }
 						activated={ this.props.shortlinksActive }
-						toggling={ this.props.isSavingAnyOption( 'shortlinks' ) }
 						toggleModule={ this.props.toggleModuleNow }
 					>
 						<span className="jp-form-toggle-explanation">

--- a/projects/plugins/jetpack/_inc/client/traffic/sitemaps.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/sitemaps.jsx
@@ -63,8 +63,8 @@ export class Sitemaps extends Component {
 					<ModuleToggle
 						slug="sitemaps"
 						compact
+						disabled={ this.props.isSavingAnyOption( 'sitemaps' ) }
 						activated={ this.props.getOptionValue( 'sitemaps' ) }
-						toggling={ this.props.isSavingAnyOption( 'sitemaps' ) }
 						toggleModule={ this.props.toggleModuleNow }
 					>
 						<span className="jp-form-toggle-explanation">

--- a/projects/plugins/jetpack/_inc/client/traffic/verification-services.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/verification-services.jsx
@@ -95,7 +95,6 @@ class VerificationServicesComponent extends Component {
 					<ModuleToggle
 						slug={ verification.module }
 						activated={ isVerificationActive }
-						toggling={ this.props.isSavingAnyOption( [ verification.module ] ) }
 						disabled={ this.props.isSavingAnyOption( [ verification.module ] ) }
 						toggleModule={ this.props.toggleModuleNow }
 					>

--- a/projects/plugins/jetpack/_inc/client/writing/composing.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/composing.jsx
@@ -78,8 +78,8 @@ export class Composing extends Component {
 					<FormFieldset>
 						<ModuleToggle
 							slug="copy-post"
+							disabled={ this.props.isSavingAnyOption( 'copy-post' ) }
 							activated={ !! this.props.getOptionValue( 'copy-post' ) }
-							toggling={ this.props.isSavingAnyOption( 'copy-post' ) }
 							toggleModule={ this.props.toggleModuleNow }
 						>
 							<span className="jp-form-toggle-explanation">{ copyPost.description }</span>
@@ -101,13 +101,13 @@ export class Composing extends Component {
 					<FormFieldset>
 						<ModuleToggle
 							slug="markdown"
-							activated={
-								!! this.props.getOptionValue( 'wpcom_publish_posts_with_markdown', 'markdown' )
-							}
-							toggling={ this.props.isSavingAnyOption( [
+							disabled={ this.props.isSavingAnyOption( [
 								'markdown',
 								'wpcom_publish_posts_with_markdown',
 							] ) }
+							activated={
+								!! this.props.getOptionValue( 'wpcom_publish_posts_with_markdown', 'markdown' )
+							}
 							toggleModule={ this.updateFormStateByMarkdown }
 						>
 							<span className="jp-form-toggle-explanation">{ markdown.description }</span>
@@ -129,8 +129,8 @@ export class Composing extends Component {
 					<FormFieldset>
 						<ModuleToggle
 							slug="latex"
+							disabled={ this.props.isSavingAnyOption( [ 'latex' ] ) }
 							activated={ !! this.props.getOptionValue( 'latex' ) }
-							toggling={ this.props.isSavingAnyOption( [ 'latex' ] ) }
 							toggleModule={ this.props.toggleModuleNow }
 						>
 							<span className="jp-form-toggle-explanation">{ latex.description }</span>
@@ -149,8 +149,8 @@ export class Composing extends Component {
 					<FormFieldset>
 						<ModuleToggle
 							slug="shortcodes"
+							disabled={ this.props.isSavingAnyOption( [ 'shortcodes' ] ) }
 							activated={ !! this.props.getOptionValue( 'shortcodes' ) }
-							toggling={ this.props.isSavingAnyOption( [ 'shortcodes' ] ) }
 							toggleModule={ this.props.toggleModuleNow }
 						>
 							<span className="jp-form-toggle-explanation">
@@ -175,8 +175,8 @@ export class Composing extends Component {
 						<FormFieldset>
 							<ModuleToggle
 								slug="blocks"
+								disabled={ this.props.isSavingAnyOption( [ 'blocks' ] ) }
 								activated={ !! this.props.getOptionValue( 'blocks' ) }
-								toggling={ this.props.isSavingAnyOption( [ 'blocks' ] ) }
 								toggleModule={ this.props.toggleModuleNow }
 							>
 								<span className="jp-form-toggle-explanation">

--- a/projects/plugins/jetpack/_inc/client/writing/post-by-email.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/post-by-email.jsx
@@ -73,9 +73,8 @@ class PostByEmail extends Component {
 						<ModuleToggle
 							slug="post-by-email"
 							compact
-							disabled={ disabledControls }
+							disabled={ disabledControls || this.props.isSavingAnyOption( 'post-by-email' ) }
 							activated={ isPbeActive }
-							toggling={ this.props.isSavingAnyOption( 'post-by-email' ) }
 							toggleModule={ this.props.toggleModuleNow }
 						>
 							<span className="jp-form-toggle-explanation">

--- a/projects/plugins/jetpack/_inc/client/writing/widgets.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/widgets.jsx
@@ -35,8 +35,8 @@ class Widgets extends Component {
 					>
 						<ModuleToggle
 							slug="widgets"
+							disabled={ this.props.isSavingAnyOption( 'widgets' ) }
 							activated={ this.props.widgetsActive }
-							toggling={ this.props.isSavingAnyOption( 'widgets' ) }
 							toggleModule={ this.props.toggleModuleNow }
 						>
 							<span className="jp-form-toggle-explanation">
@@ -61,8 +61,8 @@ class Widgets extends Component {
 					>
 						<ModuleToggle
 							slug="widget-visibility"
+							disabled={ this.props.isSavingAnyOption( 'widget-visibility' ) }
 							activated={ this.props.widgetVisibilityActive }
-							toggling={ this.props.isSavingAnyOption( 'widget-visibility' ) }
 							toggleModule={ this.props.toggleModuleNow }
 						>
 							<span className="jp-form-toggle-explanation">

--- a/projects/plugins/jetpack/_inc/client/writing/writing-media.jsx
+++ b/projects/plugins/jetpack/_inc/client/writing/writing-media.jsx
@@ -77,8 +77,8 @@ function WritingMedia( props ) {
 				</p>
 				<ModuleToggle
 					slug="carousel"
+					disabled={ props.isSavingAnyOption( 'carousel' ) }
 					activated={ isCarouselActive }
-					toggling={ props.isSavingAnyOption( 'carousel' ) }
 					toggleModule={ props.toggleModuleNow }
 				>
 					<span className="jp-form-toggle-explanation">

--- a/projects/plugins/jetpack/changelog/update-module-toggle-wp-components
+++ b/projects/plugins/jetpack/changelog/update-module-toggle-wp-components
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+ModuleToggle: import ToggleControl from @wordpress/components instead of @automattic/jetpack-components.


### PR DESCRIPTION
Fixes #

## Proposed changes

Continues the migration started in #48177 / #48179 / #48189 / #48190 / #48186 by moving the underlying `ToggleControl` of the shared `ModuleToggle` wrapper from `@automattic/jetpack-components` to `@wordpress/components`.

* `module-toggle/index.jsx`: import `ToggleControl` from `@wordpress/components`, add `__nextHasNoMarginBottom` (matches the wrapper's prior default and avoids a deprecation warning), and stop forwarding the `toggling` prop (not present on the upstream component).
* Remove the now-dead `toggling=...` prop from every `<ModuleToggle>` consumer in the Jetpack settings UI (~32 call sites across 26 files: Dashboard At-a-Glance card, plus Security / Performance / Writing / Sharing / Discussion / Traffic / Reader / Monetize / Newsletter settings).
* For each consumer, the saving condition that was on `toggling=` is now folded into the existing `disabled` expression so click-blocking during a save is preserved. Each call site was inspected individually to combine the new condition with whatever was already in `disabled` (offline mode, owner connection, plugin conflicts, etc.) — not a bulk find/replace.

The only user-visible loss is the brief optimistic-flip / dim animation during the save round-trip — same trade-off accepted in the previous PRs.

Direct `<ToggleControl>` consumers that still import from `@automattic/jetpack-components` (`newsletter/subscriptions-settings.jsx`, the inner toggles in `earn/ads.jsx`, line 170 of `newsletter/newsletter.jsx`) are intentionally left alone — they belong to a separate follow-up.

## Related product discussion/links

* Part of #48160.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Open `wp-admin/admin.php?page=jetpack#/dashboard` and confirm the At-a-Glance toggles (Brute force protection, Downtime monitoring, Image Accelerator, Search, VideoPress, etc.) render and toggle correctly.
2. Walk every Settings tab and confirm each `ModuleToggle` row renders with the same spacing/styling as before and that flipping the toggle still saves cleanly:
   * Security (Downtime monitoring, Account protection, Brute force protection, Always allowed IPs, WordPress.com login)
   * Performance (Search, Site accelerator, Speed up image/static load times, VideoPress, Video Privacy)
   * Writing (Carousel, Composing × 5, Widgets × 2, Post by Email)
   * Sharing (Jetpack Social, Sharing buttons, Like buttons)
   * Discussion (Comments, Gravatar hovercards, Comment Likes)
   * Traffic (Related Posts, SEO, Stats, Blaze, Shortlinks, Sitemaps, Site Verification, Canonical URLs)
   * Reader (Add a link to the Reader)
   * Monetize (Ads)
   * Newsletter (`?page=jetpack-newsletter`)
3. Toggle one module on/off — verify the toggle becomes `disabled` while the save is in flight (mouse cursor + visual disabled state), and re-enables when the save completes. The previous "optimistic flip + dim" animation is intentionally gone.
4. With `JETPACK_DEV_DEBUG` enabled, set a module override (e.g. `jetpack_active_modules` filter) and confirm the override-disabled state and "managed by a site administrator" help text still appear on the corresponding `ModuleToggle`.

## Real-screen before / after

Captured on a live local dev site at 1440×900. Pixel diff between baseline (trunk) and this PR is ≈0% on every page (the only diffs are unrelated drift in the Jetpack sidebar notification badge and the live Stats chart).

| Page | Before | After |
|---|---|---|
| Dashboard (At a Glance) | <img width="1440" height="3553" alt="before-dashboard" src="https://github.com/user-attachments/assets/e1ba3f61-586c-47de-9d34-dc024e02eed5" /> | <img width="1440" height="3553" alt="dashboard" src="https://github.com/user-attachments/assets/a7074d36-a2b0-483c-ba3d-5ac2b1a8b7d2" /> |
| Security | <img width="1440" height="1750" alt="before-security" src="https://github.com/user-attachments/assets/8feb7cc2-59c9-4b4d-98ff-4d0cc4160961" /> | <img width="1440" height="1750" alt="security" src="https://github.com/user-attachments/assets/1c89605f-d84b-4e76-be3f-523900f7f9c4" /> |
| Performance | <img width="1440" height="1413" alt="before-performance" src="https://github.com/user-attachments/assets/8eabc814-42f5-4e0a-a0d0-c68189450e9a" /> | <img width="1440" height="1413" alt="performance" src="https://github.com/user-attachments/assets/eea201fb-4e63-47ff-9ac0-a70a3926c00e" /> |
| Writing | <img width="1440" height="2106" alt="before-writing" src="https://github.com/user-attachments/assets/ab175921-58cc-4d1e-a5a2-d9e8d7e0aeea" /> | <img width="1440" height="2106" alt="writing" src="https://github.com/user-attachments/assets/bd7cb3f8-689d-442b-80fb-6043cd928f29" /> |
| Sharing | <img width="1440" height="1382" alt="before-sharing" src="https://github.com/user-attachments/assets/9c07daa5-59b4-4850-a719-4982dc9796c9" /> | <img width="1440" height="1382" alt="sharing" src="https://github.com/user-attachments/assets/73ead97f-563e-4246-a26a-d096acc283ac" /> |
| Discussion | <img width="1440" height="1042" alt="before-discussion" src="https://github.com/user-attachments/assets/560d13a7-6410-41a5-8e5c-c528e56d76ae" /> | <img width="1440" height="1042" alt="discussion" src="https://github.com/user-attachments/assets/fdee3502-d0ab-4983-b03b-ca502facbf16" /> |
| Traffic | <img width="1440" height="2895" alt="before-traffic" src="https://github.com/user-attachments/assets/5fc43dd3-c586-45c8-a277-64de2becd284" /> | <img width="1440" height="2895" alt="traffic" src="https://github.com/user-attachments/assets/4a68ce0f-43fb-4a09-8bdd-38ee2a56d16a" /> |
| Reader | <img width="1440" height="1042" alt="before-reader" src="https://github.com/user-attachments/assets/c774ec8e-1946-4bd2-afb6-c072cd39dd5a" /> | <img width="1440" height="1042" alt="reader" src="https://github.com/user-attachments/assets/e1d26e62-3749-40af-ade8-6a98e084aebe" /> |
| Monetize | <img width="1440" height="1690" alt="before-monetize" src="https://github.com/user-attachments/assets/9d566683-ba42-4906-b8b6-bfb1beab282e" /> | <img width="1440" height="1690" alt="monetize" src="https://github.com/user-attachments/assets/3bd4940e-2d6e-494d-abbe-1ae2b03d0844" /> |
| Newsletter | <img width="1440" height="1042" alt="before-newsletter" src="https://github.com/user-attachments/assets/c5e4521f-cdf4-4840-a87b-402cb7806edb" /> | <img width="1440" height="1042" alt="newsletter" src="https://github.com/user-attachments/assets/740496d2-e280-43d4-bec7-94596e0fe5f8" /> |







