### PR TITLE
RTC: Temporarily disable default on WoW sites

### DIFF
--- a/projects/packages/rtc/changelog/dotcom-16781-temporarily-disable-rtc-on-atomic-sites
+++ b/projects/packages/rtc/changelog/dotcom-16781-temporarily-disable-rtc-on-atomic-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+RTC: Temporarily disable RTC on Atomic sites

--- a/projects/packages/rtc/src/class-rtc.php
+++ b/projects/packages/rtc/src/class-rtc.php
@@ -243,6 +243,12 @@ class RTC {
 		if ( ! self::is_allowed() ) {
 			return '0';
 		}
+
+		// Temporarily disable RTC while an issue with CRDT documents is investigated/fixed.
+		if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
+			return '0';
+		}
+
 		// RTC allowed and option is not stored yet
 		if ( $option === self::OPTION_NEW ) {
 			// If the old option is set, use that.

--- a/projects/packages/rtc/tests/php/RTC_Test.php
+++ b/projects/packages/rtc/tests/php/RTC_Test.php
@@ -9,6 +9,8 @@ declare( strict_types = 1 );
 
 use Automattic\Jetpack\RTC;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 /**
  * Tests for the RTC package.
@@ -501,6 +503,24 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_default_rtc_option_returns_0_when_not_allowed() {
 		$this->assertSame( '0', RTC::default_rtc_option() );
+	}
+
+	/**
+	 * Tests that default_rtc_option returns '0' on Atomic even when RTC is allowed.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_default_rtc_option_returns_0_on_atomic() {
+		add_filter( 'jetpack_rtc_enabled', '__return_true' );
+
+		if ( ! defined( 'IS_ATOMIC' ) ) {
+			define( 'IS_ATOMIC', true );
+		}
+
+		$this->assertSame( '0', RTC::default_rtc_option( '', RTC::OPTION_OLD ) );
 	}
 
 	/**

--- a/projects/packages/rtc/tests/php/RTC_Test.php
+++ b/projects/packages/rtc/tests/php/RTC_Test.php
@@ -9,7 +9,6 @@ declare( strict_types = 1 );
 
 use Automattic\Jetpack\RTC;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 /**
@@ -509,10 +508,8 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	 * Tests that default_rtc_option returns '0' on Atomic even when RTC is allowed.
 	 *
 	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
 	 */
 	#[RunInSeparateProcess]
-	#[PreserveGlobalState( false )]
 	public function test_default_rtc_option_returns_0_on_atomic() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
 

--- a/projects/packages/rtc/tests/php/RTC_Test.php
+++ b/projects/packages/rtc/tests/php/RTC_Test.php
@@ -9,7 +9,6 @@ declare( strict_types = 1 );
 
 use Automattic\Jetpack\RTC;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 /**
  * Tests for the RTC package.
@@ -502,22 +501,6 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_default_rtc_option_returns_0_when_not_allowed() {
 		$this->assertSame( '0', RTC::default_rtc_option() );
-	}
-
-	/**
-	 * Tests that default_rtc_option returns '0' on Atomic even when RTC is allowed.
-	 *
-	 * @runInSeparateProcess
-	 */
-	#[RunInSeparateProcess]
-	public function test_default_rtc_option_returns_0_on_atomic() {
-		add_filter( 'jetpack_rtc_enabled', '__return_true' );
-
-		if ( ! defined( 'IS_ATOMIC' ) ) {
-			define( 'IS_ATOMIC', true );
-		}
-
-		$this->assertSame( '0', RTC::default_rtc_option( '', RTC::OPTION_OLD ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes DOTCOM-16781

## Proposed changes

Changes the default RTC setting so it's disabled by default on WoW sites. This way, we can investigate an ongoing issue with the CRDT documents that is affecting the editing experience of users. 

## Related product discussion/links

N/A

## Does this pull request change what data or activity we track or use?
No

## Testing instructions
- Apply these changes to your WoW site
- Go to Settings > Writing
- If you never changed the RTC settings (i.e. the blog option is not stored in the DB), it should be disabled now
