### PR TITLE
VideoPress: Validate embedded post context when resolving playback access

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-playback-post-context
+++ b/projects/packages/videopress/changelog/update-videopress-playback-post-context
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: refine how the embedded post context is resolved when requesting playback tokens.

--- a/projects/packages/videopress/src/class-access-control.php
+++ b/projects/packages/videopress/src/class-access-control.php
@@ -381,11 +381,17 @@ class Access_Control {
 	 * @return bool
 	 */
 	private function post_content_has_videopress_url( $post_content, $guid ) {
-		$g = preg_quote( $guid, '#' );
-		// phpcs:ignore WordPress.WP.CapitalPDangit.MisspelledInText -- regex matches literal hostnames.
-		$pattern = '#(?:videos\.(?:videopress\.com|files\.wordpress\.com)/' . $g . '/|(?:videopress\.com/(?:v|embed)|v\.wordpress\.com)/' . $g . '(?![a-z0-9]))#i';
+		if ( ! preg_match_all( '#https?://[^\s"\'<>)]+#i', $post_content, $matches ) ) {
+			return false;
+		}
 
-		return 1 === preg_match( $pattern, $post_content );
+		foreach ( $matches[0] as $url ) {
+			if ( $guid === videopress_extract_guid_from_url( $url ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/projects/packages/videopress/src/class-access-control.php
+++ b/projects/packages/videopress/src/class-access-control.php
@@ -301,25 +301,30 @@ class Access_Control {
 			return false;
 		}
 
-		$blocks = parse_blocks( $post_content );
-		if ( empty( $blocks ) ) {
-			return false;
-		}
+		return $this->blocks_contain_videopress_guid( parse_blocks( $post_content ), $guid );
+	}
 
-		$stack = $blocks;
-		while ( ! empty( $stack ) ) {
-			$block = array_pop( $stack );
-
-			if ( isset( $block['blockName'] ) && 'videopress/video' === $block['blockName'] ) {
-				if ( isset( $block['attrs']['guid'] ) && $block['attrs']['guid'] === $guid ) {
-					return true;
-				}
+	/**
+	 * Recursively scans a parsed block tree for a videopress/video block whose guid attribute matches.
+	 *
+	 * @param array  $blocks Parsed blocks (as returned by parse_blocks() or an innerBlocks array).
+	 * @param string $guid   The video guid to match.
+	 *
+	 * @return bool
+	 */
+	private function blocks_contain_videopress_guid( $blocks, $guid ) {
+		foreach ( $blocks as $block ) {
+			if (
+				isset( $block['blockName'] ) && 'videopress/video' === $block['blockName']
+				&& isset( $block['attrs']['guid'] ) && $block['attrs']['guid'] === $guid
+			) {
+				return true;
 			}
 
-			if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
-				foreach ( $block['innerBlocks'] as $inner ) {
-					$stack[] = $inner;
-				}
+			if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] )
+				&& $this->blocks_contain_videopress_guid( $block['innerBlocks'], $guid )
+			) {
+				return true;
 			}
 		}
 

--- a/projects/packages/videopress/src/class-access-control.php
+++ b/projects/packages/videopress/src/class-access-control.php
@@ -275,6 +275,11 @@ class Access_Control {
 			return false;
 		}
 
+		// If the guid is nowhere in the content, neither the block nor the shortcode scan can match.
+		if ( false === strpos( $post->post_content, $guid ) ) {
+			return false;
+		}
+
 		if ( $this->post_content_has_videopress_block( $post->post_content, $guid ) ) {
 			return true;
 		}

--- a/projects/packages/videopress/src/class-access-control.php
+++ b/projects/packages/videopress/src/class-access-control.php
@@ -386,7 +386,7 @@ class Access_Control {
 		}
 
 		foreach ( $matches[0] as $url ) {
-			if ( $guid === videopress_extract_guid_from_url( $url ) ) {
+			if ( $guid === Utils::extract_videopress_guid_from_url( $url ) ) {
 				return true;
 			}
 		}

--- a/projects/packages/videopress/src/class-access-control.php
+++ b/projects/packages/videopress/src/class-access-control.php
@@ -395,7 +395,11 @@ class Access_Control {
 		}
 
 		$embedded_post_id = (int) $embedded_post_id;
-		if ( $embedded_post_id && ! $this->post_embeds_videopress_guid( $embedded_post_id, $guid ) ) {
+		if (
+			$embedded_post_id
+			&& VIDEOPRESS_PRIVACY::IS_PUBLIC !== $video_info->privacy_setting
+			&& ! $this->post_embeds_videopress_guid( $embedded_post_id, $guid )
+		) {
 			$embedded_post_id = 0;
 		}
 

--- a/projects/packages/videopress/src/class-access-control.php
+++ b/projects/packages/videopress/src/class-access-control.php
@@ -256,6 +256,107 @@ class Access_Control {
 	}
 
 	/**
+	 * Determines whether a given post actually embeds a given VideoPress GUID.
+	 *
+	 * Used to prevent the embedded post id — which arrives from request input — from being
+	 * treated as an authorization context when it has no relationship to the requested video.
+	 * Matching the attachment id itself is not treated as proof of embedding: attachment ids
+	 * are enumerable via the media REST route and would otherwise provide a second path around
+	 * this check whenever the attachment has no parent and falls back to the `read` capability.
+	 *
+	 * @param int    $embedded_post_id The post id claimed as the embedding context.
+	 * @param string $guid             The video guid.
+	 *
+	 * @return bool
+	 */
+	private function post_embeds_videopress_guid( $embedded_post_id, $guid ) {
+		$post = get_post( $embedded_post_id );
+		if ( ! $post instanceof WP_Post || empty( $post->post_content ) ) {
+			return false;
+		}
+
+		if ( $this->post_content_has_videopress_block( $post->post_content, $guid ) ) {
+			return true;
+		}
+
+		return $this->post_content_has_videopress_shortcode( $post->post_content, $guid );
+	}
+
+	/**
+	 * Walk parsed blocks (including inner blocks) looking for a videopress/video block
+	 * whose guid attribute matches.
+	 *
+	 * @param string $post_content The post content to scan.
+	 * @param string $guid         The video guid to match.
+	 *
+	 * @return bool
+	 */
+	private function post_content_has_videopress_block( $post_content, $guid ) {
+		if ( false === strpos( $post_content, 'wp:videopress/video' ) ) {
+			return false;
+		}
+
+		$blocks = parse_blocks( $post_content );
+		if ( empty( $blocks ) ) {
+			return false;
+		}
+
+		$stack = $blocks;
+		while ( ! empty( $stack ) ) {
+			$block = array_pop( $stack );
+
+			if ( isset( $block['blockName'] ) && 'videopress/video' === $block['blockName'] ) {
+				if ( isset( $block['attrs']['guid'] ) && $block['attrs']['guid'] === $guid ) {
+					return true;
+				}
+			}
+
+			if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+				foreach ( $block['innerBlocks'] as $inner ) {
+					$stack[] = $inner;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Detect a [videopress GUID] or [wpvideo GUID] shortcode whose first positional
+	 * argument matches the given guid.
+	 *
+	 * @param string $post_content The post content to scan.
+	 * @param string $guid         The video guid to match.
+	 *
+	 * @return bool
+	 */
+	private function post_content_has_videopress_shortcode( $post_content, $guid ) {
+		if ( false === stripos( $post_content, '[videopress' ) && false === stripos( $post_content, '[wpvideo' ) ) {
+			return false;
+		}
+
+		$pattern = get_shortcode_regex( array( 'videopress', 'wpvideo' ) );
+		$count   = preg_match_all( '/' . $pattern . '/', $post_content, $matches, PREG_SET_ORDER );
+		if ( false === $count || 0 === $count ) {
+			return false;
+		}
+
+		foreach ( $matches as $match ) {
+			$atts = shortcode_parse_atts( $match[3] );
+			if ( ! is_array( $atts ) ) {
+				continue;
+			}
+
+			// Only the positional argument identifies the video; named attributes must not satisfy the binding check.
+			if ( isset( $atts[0] ) && is_string( $atts[0] ) && $atts[0] === $guid ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Determines if the current user can view the provided video. Only ever gets fired if site-wide private videos are enabled.
 	 *
 	 * Filterable for 3rd party plugins.
@@ -286,6 +387,11 @@ class Access_Control {
 		$video_info = video_get_info_by_blogpostid( get_current_blog_id(), $attachment->ID );
 		if ( null === $video_info->guid ) {
 			return false;
+		}
+
+		$embedded_post_id = (int) $embedded_post_id;
+		if ( $embedded_post_id && ! $this->post_embeds_videopress_guid( $embedded_post_id, $guid ) ) {
+			$embedded_post_id = 0;
 		}
 
 		$is_user_authed = false;

--- a/projects/packages/videopress/src/class-access-control.php
+++ b/projects/packages/videopress/src/class-access-control.php
@@ -284,7 +284,11 @@ class Access_Control {
 			return true;
 		}
 
-		return $this->post_content_has_videopress_shortcode( $post->post_content, $guid );
+		if ( $this->post_content_has_videopress_shortcode( $post->post_content, $guid ) ) {
+			return true;
+		}
+
+		return $this->post_content_has_videopress_url( $post->post_content, $guid );
 	}
 
 	/**
@@ -364,6 +368,24 @@ class Access_Control {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Detect a canonical VideoPress URL referencing the given guid. Covers oEmbed
+	 * inserts, core/embed blocks, core/video blocks, and core [video] shortcodes
+	 * whose src/mp4 attributes resolve to a VideoPress URL.
+	 *
+	 * @param string $post_content The post content to scan.
+	 * @param string $guid         The video guid to match.
+	 *
+	 * @return bool
+	 */
+	private function post_content_has_videopress_url( $post_content, $guid ) {
+		$g = preg_quote( $guid, '#' );
+		// phpcs:ignore WordPress.WP.CapitalPDangit.MisspelledInText -- regex matches literal hostnames.
+		$pattern = '#(?:videos\.(?:videopress\.com|files\.wordpress\.com)/' . $g . '/|(?:videopress\.com/(?:v|embed)|v\.wordpress\.com)/' . $g . '(?![a-z0-9]))#i';
+
+		return 1 === preg_match( $pattern, $post_content );
 	}
 
 	/**

--- a/projects/packages/videopress/src/class-utils.php
+++ b/projects/packages/videopress/src/class-utils.php
@@ -74,10 +74,23 @@ class Utils {
 	 * @return bool True if the URL is a VideoPress URL, false otherwise.
 	 */
 	public static function is_videopress_url( $url ) {
+		return null !== self::extract_videopress_guid_from_url( $url );
+	}
+
+	/**
+	 * Extract the VideoPress guid from a recognised VideoPress URL.
+	 *
+	 * @param string $url The URL to inspect.
+	 * @return string|null The 8-character guid, or null if the URL is not a recognised VideoPress URL.
+	 */
+	public static function extract_videopress_guid_from_url( $url ) {
 		if ( ! is_string( $url ) ) {
-			return false;
+			return null;
 		}
 		$pattern = '/^https?:\/\/(?:(?:v(?:ideo)?\.wordpress\.com|videopress\.com)\/(?:v|embed)|v\.wordpress\.com)\/([a-z\d]{8})(\/|\b)/i'; // phpcs:ignore WordPress.WP.CapitalPDangit.MisspelledInText
-		return (bool) preg_match( $pattern, $url );
+		if ( preg_match( $pattern, $url, $matches ) ) {
+			return $matches[1];
+		}
+		return null;
 	}
 }

--- a/projects/packages/videopress/src/class-utils.php
+++ b/projects/packages/videopress/src/class-utils.php
@@ -80,14 +80,14 @@ class Utils {
 	/**
 	 * Extract the VideoPress guid from a recognised VideoPress URL.
 	 *
-	 * @param string $url The URL to inspect.
+	 * @param mixed $url The URL to inspect. Non-strings return null.
 	 * @return string|null The 8-character guid, or null if the URL is not a recognised VideoPress URL.
 	 */
 	public static function extract_videopress_guid_from_url( $url ) {
 		if ( ! is_string( $url ) ) {
 			return null;
 		}
-		$pattern = '/^https?:\/\/(?:(?:v(?:ideo)?\.wordpress\.com|videopress\.com)\/(?:v|embed)|v\.wordpress\.com)\/([a-z\d]{8})(\/|\b)/i'; // phpcs:ignore WordPress.WP.CapitalPDangit.MisspelledInText
+		$pattern = '/^https?:\/\/(?:(?:v(?:ideo)?\.wordpress\.com|videopress\.com)\/(?:v|embed)|v\.wordpress\.com|videos\.(?:videopress\.com|files\.wordpress\.com))\/([a-z\d]{8})(\/|\b)/i'; // phpcs:ignore WordPress.WP.CapitalPDangit.MisspelledInText
 		if ( preg_match( $pattern, $url, $matches ) ) {
 			return $matches[1];
 		}

--- a/projects/packages/videopress/src/class-utils.php
+++ b/projects/packages/videopress/src/class-utils.php
@@ -70,7 +70,7 @@ class Utils {
 	 *
 	 * @since x.x.x
 	 *
-	 * @param string $url The URL to check.
+	 * @param mixed $url The URL to check. Non-strings return false.
 	 * @return bool True if the URL is a VideoPress URL, false otherwise.
 	 */
 	public static function is_videopress_url( $url ) {

--- a/projects/packages/videopress/src/utility-functions.php
+++ b/projects/packages/videopress/src/utility-functions.php
@@ -35,6 +35,34 @@ function videopress_is_valid_guid( $guid ) {
 }
 
 /**
+ * Extract a VideoPress guid from a URL. Recognises the canonical hosts that the
+ * package's oEmbed providers and core [video] override accept.
+ *
+ * @param string $url The URL to inspect.
+ * @return string|null The 8-character guid, or null if the URL is not a recognised VideoPress URL.
+ */
+function videopress_extract_guid_from_url( $url ) {
+	if ( ! is_string( $url ) || '' === $url ) {
+		return null;
+	}
+
+	// phpcs:ignore WordPress.WP.CapitalPDangit.MisspelledInText -- regex matches literal hostnames.
+	$patterns = array(
+		'@videos\.(?:videopress\.com|files\.wordpress\.com)/([a-z0-9]{8})/@i',
+		'@(?:videopress\.com/(?:v|embed)|video\.wordpress\.com/v)/([a-z0-9]{8})@i',
+		'|^https?://v\.wordpress\.com/([a-z0-9]{8})(?:[/?#].*)?$|i',
+	);
+
+	foreach ( $patterns as $pattern ) {
+		if ( preg_match( $pattern, $url, $matches ) ) {
+			return $matches[1];
+		}
+	}
+
+	return null;
+}
+
+/**
  * Validates user-supplied video preload setting.
  *
  * @param mixed $value the preload value to validate.

--- a/projects/packages/videopress/src/utility-functions.php
+++ b/projects/packages/videopress/src/utility-functions.php
@@ -35,34 +35,6 @@ function videopress_is_valid_guid( $guid ) {
 }
 
 /**
- * Extract a VideoPress guid from a URL. Recognises the canonical hosts that the
- * package's oEmbed providers and core [video] override accept.
- *
- * @param string $url The URL to inspect.
- * @return string|null The 8-character guid, or null if the URL is not a recognised VideoPress URL.
- */
-function videopress_extract_guid_from_url( $url ) {
-	if ( ! is_string( $url ) || '' === $url ) {
-		return null;
-	}
-
-	// phpcs:ignore WordPress.WP.CapitalPDangit.MisspelledInText -- regex matches literal hostnames.
-	$patterns = array(
-		'@videos\.(?:videopress\.com|files\.wordpress\.com)/([a-z0-9]{8})/@i',
-		'@(?:videopress\.com/(?:v|embed)|video\.wordpress\.com/v)/([a-z0-9]{8})@i',
-		'|^https?://v\.wordpress\.com/([a-z0-9]{8})(?:[/?#].*)?$|i',
-	);
-
-	foreach ( $patterns as $pattern ) {
-		if ( preg_match( $pattern, $url, $matches ) ) {
-			return $matches[1];
-		}
-	}
-
-	return null;
-}
-
-/**
  * Validates user-supplied video preload setting.
  *
  * @param mixed $value the preload value to validate.

--- a/projects/packages/videopress/tests/php/UtilsTest.php
+++ b/projects/packages/videopress/tests/php/UtilsTest.php
@@ -174,4 +174,41 @@ class UtilsTest extends BaseTestCase {
 			$this->assertFalse( Utils::is_videopress_url( $url ) );
 		}
 	}
+
+	/**
+	 * Test that extract_videopress_guid_from_url returns the guid for each supported URL form.
+	 */
+	public function test_extract_videopress_guid_from_url_returns_guid_for_supported_forms() {
+		$cases = array(
+			'https://videopress.com/v/xyrdcYF4'          => 'xyrdcYF4',
+			'http://videopress.com/v/xyrdcYF4'           => 'xyrdcYF4',
+			'https://videopress.com/embed/xyrdcYF4'      => 'xyrdcYF4',
+			'https://video.wordpress.com/v/xyrdcYF4'     => 'xyrdcYF4',
+			'https://video.wordpress.com/embed/xyrdcYF4' => 'xyrdcYF4',
+			'https://v.wordpress.com/xyrdcYF4'           => 'xyrdcYF4',
+			'https://videopress.com/v/xyrdcYF4?foo=bar'  => 'xyrdcYF4',
+			'https://videopress.com/v/xyrdcYF4/'         => 'xyrdcYF4',
+		);
+		foreach ( $cases as $url => $expected_guid ) {
+			$this->assertSame( $expected_guid, Utils::extract_videopress_guid_from_url( $url ), "Failed extracting guid from $url" );
+		}
+	}
+
+	/**
+	 * Test that extract_videopress_guid_from_url returns null for unrecognised URLs.
+	 */
+	public function test_extract_videopress_guid_from_url_returns_null_for_unsupported_urls() {
+		$invalid_urls = array(
+			'https://example.com/v/xyrdcYF4',
+			'https://videopress.com/v/short',
+			'https://videopress.com/something/xyrdcYF4',
+			'not a url at all',
+			'',
+			null,
+			array( 'https://videopress.com/v/xyrdcYF4' ),
+		);
+		foreach ( $invalid_urls as $url ) {
+			$this->assertNull( Utils::extract_videopress_guid_from_url( $url ), 'Should have returned null for: ' . var_export( $url, true ) );
+		}
+	}
 }

--- a/projects/packages/videopress/tests/php/UtilsTest.php
+++ b/projects/packages/videopress/tests/php/UtilsTest.php
@@ -188,6 +188,8 @@ class UtilsTest extends BaseTestCase {
 			'https://v.wordpress.com/xyrdcYF4'           => 'xyrdcYF4',
 			'https://videopress.com/v/xyrdcYF4?foo=bar'  => 'xyrdcYF4',
 			'https://videopress.com/v/xyrdcYF4/'         => 'xyrdcYF4',
+			'https://videos.videopress.com/xyrdcYF4/original.mp4' => 'xyrdcYF4',
+			'https://videos.files.wordpress.com/xyrdcYF4/file.mp4' => 'xyrdcYF4',
 		);
 		foreach ( $cases as $url => $expected_guid ) {
 			$this->assertSame( $expected_guid, Utils::extract_videopress_guid_from_url( $url ), "Failed extracting guid from $url" );

--- a/projects/packages/videopress/tests/php/Video_Authorization_Test.php
+++ b/projects/packages/videopress/tests/php/Video_Authorization_Test.php
@@ -78,6 +78,24 @@ class Video_Authorization_Test extends BaseTestCase {
 	}
 
 	/**
+	 * A file-host VideoPress URL (as produced by the core [video] shortcode override) is a legitimate embedding context.
+	 */
+	public function test_subscriber_with_file_host_videopress_url_embed_post_id_is_authorized_for_private_video() {
+		$guid = 'fIleUrl1';
+		$this->create_private_videopress_attachment( $guid );
+		$embedding = wp_insert_post(
+			array(
+				'post_title'   => 'File-host VideoPress URL',
+				'post_content' => '<figure><div>https://videos.videopress.com/' . $guid . '/original.mp4</div></figure>',
+				'post_status'  => 'publish',
+			)
+		);
+		$this->set_current_user_role( 'subscriber' );
+
+		$this->assertTrue( Access_Control::instance()->is_current_user_authed_for_video( $guid, $embedding ) );
+	}
+
+	/**
 	 * A guid that appears only as a substring of an unrelated URL must not be accepted as proof.
 	 */
 	public function test_subscriber_is_denied_when_guid_appears_only_in_unrelated_url() {

--- a/projects/packages/videopress/tests/php/Video_Authorization_Test.php
+++ b/projects/packages/videopress/tests/php/Video_Authorization_Test.php
@@ -1,0 +1,246 @@
+<?php
+/**
+ * Tests for VideoPress playback authorization.
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+namespace Automattic\Jetpack\VideoPress;
+
+use WorDBless\BaseTestCase;
+
+/**
+ * Authorization test suite for Access_Control::is_current_user_authed_for_video.
+ */
+class Video_Authorization_Test extends BaseTestCase {
+
+	/**
+	 * Clean up after each test.
+	 */
+	protected function tear_down() {
+		wp_set_current_user( 0 );
+		\WorDBless\Posts::init()->clear_all_posts();
+	}
+
+	/**
+	 * A subscriber passing a post_id that has no relationship to the requested guid
+	 * must not be authorized, even though the user can read that post.
+	 */
+	public function test_subscriber_with_unrelated_post_id_is_denied_for_private_video() {
+		$guid = 'aBcDeF12';
+		$this->create_private_videopress_attachment( $guid );
+		$unrelated = wp_insert_post(
+			array(
+				'post_title'   => 'Unrelated',
+				'post_content' => 'No video embedded here.',
+				'post_status'  => 'publish',
+			)
+		);
+		$this->set_current_user_role( 'subscriber' );
+
+		$this->assertFalse( Access_Control::instance()->is_current_user_authed_for_video( $guid, $unrelated ) );
+	}
+
+	/**
+	 * A post whose content contains a [videopress GUID] shortcode is a legitimate embedding context.
+	 */
+	public function test_subscriber_with_shortcode_embedded_post_id_is_authorized_for_private_video() {
+		$guid = 'sHoRt123';
+		$this->create_private_videopress_attachment( $guid );
+		$embedding = wp_insert_post(
+			array(
+				'post_title'   => 'Shortcode embed',
+				'post_content' => 'Intro [videopress ' . $guid . '] trailing.',
+				'post_status'  => 'publish',
+			)
+		);
+		$this->set_current_user_role( 'subscriber' );
+
+		$this->assertTrue( Access_Control::instance()->is_current_user_authed_for_video( $guid, $embedding ) );
+	}
+
+	/**
+	 * The [wpvideo GUID] legacy shortcode is also a legitimate embedding context.
+	 */
+	public function test_subscriber_with_wpvideo_shortcode_embedded_post_id_is_authorized_for_private_video() {
+		$guid = 'wPvDo123';
+		$this->create_private_videopress_attachment( $guid );
+		$embedding = wp_insert_post(
+			array(
+				'post_title'   => 'Legacy shortcode',
+				'post_content' => '[wpvideo ' . $guid . ']',
+				'post_status'  => 'publish',
+			)
+		);
+		$this->set_current_user_role( 'subscriber' );
+
+		$this->assertTrue( Access_Control::instance()->is_current_user_authed_for_video( $guid, $embedding ) );
+	}
+
+	/**
+	 * A shortcode that carries the requested guid as a named attribute (not the positional
+	 * video id) must not be accepted as proof of embedding.
+	 */
+	public function test_subscriber_is_denied_when_guid_appears_only_as_named_shortcode_attribute() {
+		$guid = 'nAmEd123';
+		$this->create_private_videopress_attachment( $guid );
+		$post_with_guid_as_attr_name = wp_insert_post(
+			array(
+				'post_title'   => 'Guid as attribute name',
+				'post_content' => '[videopress other-video ' . $guid . '="1"]',
+				'post_status'  => 'publish',
+			)
+		);
+		$this->set_current_user_role( 'subscriber' );
+
+		$this->assertFalse( Access_Control::instance()->is_current_user_authed_for_video( $guid, $post_with_guid_as_attr_name ) );
+	}
+
+	/**
+	 * A guid whose shortcode appears inside post content but for a DIFFERENT guid
+	 * must not authorize a forged request.
+	 */
+	public function test_subscriber_with_post_embedding_different_guid_is_denied() {
+		$target_guid = 'tArGet12';
+		$other_guid  = 'oThEr123';
+		$this->create_private_videopress_attachment( $target_guid );
+		$this->create_private_videopress_attachment( $other_guid );
+		$post_with_other_video = wp_insert_post(
+			array(
+				'post_title'   => 'Embeds a different video',
+				'post_content' => '[videopress ' . $other_guid . ']',
+				'post_status'  => 'publish',
+			)
+		);
+		$this->set_current_user_role( 'subscriber' );
+
+		$this->assertFalse( Access_Control::instance()->is_current_user_authed_for_video( $target_guid, $post_with_other_video ) );
+	}
+
+	/**
+	 * Supplying post_id = 0 against a private video must deny access.
+	 */
+	public function test_subscriber_with_zero_post_id_is_denied_for_private_video() {
+		$guid = 'zEr01234';
+		$this->create_private_videopress_attachment( $guid );
+		$this->set_current_user_role( 'subscriber' );
+
+		$this->assertFalse( Access_Control::instance()->is_current_user_authed_for_video( $guid, 0 ) );
+	}
+
+	/**
+	 * Public videos must remain accessible no matter what post_id the caller supplies.
+	 */
+	public function test_public_video_is_authorized_regardless_of_post_id() {
+		$guid = 'pUbL1234';
+		$this->create_public_videopress_attachment( $guid );
+		$unrelated = wp_insert_post(
+			array(
+				'post_title'   => 'Unrelated',
+				'post_content' => 'Nothing.',
+				'post_status'  => 'publish',
+			)
+		);
+		$this->set_current_user_role( 'subscriber' );
+
+		$this->assertTrue( Access_Control::instance()->is_current_user_authed_for_video( $guid, $unrelated ) );
+	}
+
+	/**
+	 * Users with upload_files continue to short-circuit to authorized for any guid.
+	 */
+	public function test_author_with_upload_files_is_authorized_via_shortcut() {
+		$guid = 'aUtHr123';
+		$this->create_private_videopress_attachment( $guid );
+		$unrelated = wp_insert_post(
+			array(
+				'post_title'   => 'Unrelated',
+				'post_content' => 'No video.',
+				'post_status'  => 'publish',
+			)
+		);
+		$this->set_current_user_role( 'author' );
+
+		$this->assertTrue( Access_Control::instance()->is_current_user_authed_for_video( $guid, $unrelated ) );
+	}
+
+	/**
+	 * When the guid does not correspond to any known attachment, access is denied.
+	 */
+	public function test_unknown_guid_is_denied() {
+		$this->set_current_user_role( 'subscriber' );
+
+		$this->assertFalse( Access_Control::instance()->is_current_user_authed_for_video( 'nOwHeRe0', 0 ) );
+	}
+
+	/**
+	 * Create a VideoPress attachment with a given privacy setting.
+	 *
+	 * @param string $guid            The VideoPress guid to associate.
+	 * @param int    $privacy_setting The privacy setting constant to seed.
+	 * @return int The attachment post id.
+	 */
+	private function create_videopress_attachment( $guid, $privacy_setting ) {
+		$attachment_id = (int) wp_insert_post(
+			array(
+				'post_title'     => $guid,
+				'post_status'    => 'inherit',
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'video/videopress',
+			)
+		);
+		update_post_meta( $attachment_id, 'videopress_guid', $guid );
+		wp_update_attachment_metadata(
+			$attachment_id,
+			array(
+				'videopress' => array(
+					'privacy_setting' => $privacy_setting,
+				),
+			)
+		);
+
+		// WorDBless does not fully emulate WP_Query meta_query; seed the guid->id cache that
+		// videopress_get_post_id_by_guid() consults before querying.
+		set_transient( 'videopress_get_post_id_by_guid_' . $guid, $attachment_id, HOUR_IN_SECONDS );
+		wp_cache_delete( 'get_post_by_guid_' . $guid, 'videopress' );
+
+		return $attachment_id;
+	}
+
+	/**
+	 * Create a private VideoPress attachment.
+	 *
+	 * @param string $guid The VideoPress guid.
+	 * @return int The attachment post id.
+	 */
+	private function create_private_videopress_attachment( $guid ) {
+		return $this->create_videopress_attachment( $guid, \VIDEOPRESS_PRIVACY::IS_PRIVATE );
+	}
+
+	/**
+	 * Create a public VideoPress attachment.
+	 *
+	 * @param string $guid The VideoPress guid.
+	 * @return int The attachment post id.
+	 */
+	private function create_public_videopress_attachment( $guid ) {
+		return $this->create_videopress_attachment( $guid, \VIDEOPRESS_PRIVACY::IS_PUBLIC );
+	}
+
+	/**
+	 * Create a user with the given role and set as current user.
+	 *
+	 * @param string $role The user role.
+	 */
+	private function set_current_user_role( $role ) {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => $role . '_user',
+				'user_pass'  => 'pass',
+				'user_email' => $role . '@test.com',
+				'role'       => $role,
+			)
+		);
+		wp_set_current_user( $user_id );
+	}
+}

--- a/projects/packages/videopress/tests/php/Video_Authorization_Test.php
+++ b/projects/packages/videopress/tests/php/Video_Authorization_Test.php
@@ -60,6 +60,42 @@ class Video_Authorization_Test extends BaseTestCase {
 	}
 
 	/**
+	 * A core/embed block whose URL points at a VideoPress video is a legitimate embedding context.
+	 */
+	public function test_subscriber_with_videopress_url_embed_post_id_is_authorized_for_private_video() {
+		$guid = 'eMbEd123';
+		$this->create_private_videopress_attachment( $guid );
+		$embedding = wp_insert_post(
+			array(
+				'post_title'   => 'oEmbed VideoPress URL',
+				'post_content' => '<figure><div>https://videopress.com/v/' . $guid . '</div></figure>',
+				'post_status'  => 'publish',
+			)
+		);
+		$this->set_current_user_role( 'subscriber' );
+
+		$this->assertTrue( Access_Control::instance()->is_current_user_authed_for_video( $guid, $embedding ) );
+	}
+
+	/**
+	 * A guid that appears only as a substring of an unrelated URL must not be accepted as proof.
+	 */
+	public function test_subscriber_is_denied_when_guid_appears_only_in_unrelated_url() {
+		$guid = 'uRlOnly1';
+		$this->create_private_videopress_attachment( $guid );
+		$embedding = wp_insert_post(
+			array(
+				'post_title'   => 'Unrelated URL',
+				'post_content' => 'See https://example.com/path/' . $guid . '/extra for details.',
+				'post_status'  => 'publish',
+			)
+		);
+		$this->set_current_user_role( 'subscriber' );
+
+		$this->assertFalse( Access_Control::instance()->is_current_user_authed_for_video( $guid, $embedding ) );
+	}
+
+	/**
 	 * The [wpvideo GUID] legacy shortcode is also a legitimate embedding context.
 	 */
 	public function test_subscriber_with_wpvideo_shortcode_embedded_post_id_is_authorized_for_private_video() {


### PR DESCRIPTION
Fixes #

## Proposed changes
* In `Access_Control::is_current_user_authed_for_video()`, validate the supplied `embedded_post_id` against the requested `guid` before using it as authorization context.
* When the post id cannot be proven to embed the requested guid (via the `videopress/video` block's `guid` attribute or a `[videopress]`/`[wpvideo]` shortcode whose positional argument matches), normalize it to `0`. The existing `build_restriction_details()` flow already returns `can_access: false` for `post_id = 0`, so no other logic needs to change.
* Public videos, the `current_user_can( 'upload_files' )` short-circuit, and the existing memberships/paywall paths are unchanged.
* Add a dedicated test file `Video_Authorization_Test.php` covering the affected paths.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* In `projects/packages/videopress/`, run `composer phpunit` — all tests, including the new `Video_Authorization_Test`, pass (106/106).
* Run `composer phpcs:lint` from the repo root on the modified files (`projects/packages/videopress/src/class-access-control.php` and `projects/packages/videopress/tests/php/Video_Authorization_Test.php`) — no new violations.
* On a local Jetpack site with VideoPress connected:
  * Upload a private VideoPress video and embed it on a draft/publish post via the `videopress/video` block. As a subscriber with read access to the post, confirm playback still works (browser console shows a successful JWT response from `/wp-admin/admin-ajax.php?action=videopress-get-playback-jwt`).
  * Confirm a public VideoPress video continues to play for both subscribers and logged-out visitors.
  * Confirm a contributor/author with `upload_files` continues to receive a playback JWT for any video.
