### PR TITLE
Backup: migrate storage meter ProgressBar to @wordpress/components

### DIFF
--- a/projects/packages/backup/changelog/update-backup-progressbar
+++ b/projects/packages/backup/changelog/update-backup-progressbar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Storage meter: migrate ProgressBar to @wordpress/components; preserve color-by-usage-level styling via scoped CSS.

--- a/projects/packages/backup/src/js/components/backup-storage-space/storage-meter/index.jsx
+++ b/projects/packages/backup/src/js/components/backup-storage-space/storage-meter/index.jsx
@@ -1,25 +1,24 @@
-import { ProgressBar } from '@automattic/jetpack-components';
+import { ProgressBar } from '@wordpress/components';
 import { StorageUsageLevels } from '../storage-usage-levels';
 import './style.scss';
 
+const STORAGE_METER_CLASS_NAMES = {
+	[ StorageUsageLevels.Full ]: 'full-warning',
+	[ StorageUsageLevels.Critical ]: 'red-warning',
+	[ StorageUsageLevels.Warning ]: 'yellow-warning',
+	[ StorageUsageLevels.Normal ]: 'no-warning',
+	[ StorageUsageLevels.BackupsDiscarded ]: 'full-warning',
+};
+
 const StorageMeter = ( { storageUsed, storageLimit, usageLevel } ) => {
-	const STORAGE_METER_CLASS_NAMES = {
-		[ StorageUsageLevels.Full ]: 'full-warning',
-		[ StorageUsageLevels.Critical ]: 'red-warning',
-		[ StorageUsageLevels.Warning ]: 'yellow-warning',
-		[ StorageUsageLevels.Normal ]: 'no-warning',
-		[ StorageUsageLevels.BackupsDiscarded ]: 'full-warning',
-	};
+	const progress = ( storageUsed ?? 0 ) / ( storageLimit ?? Infinity );
 	return (
-		<>
-			<div className="backup-storage-space__progress-bar">
-				<ProgressBar
-					className={ [ 'progress-bar', STORAGE_METER_CLASS_NAMES[ usageLevel ] ] }
-					progressClassName={ 'progress-bar__progress' }
-					progress={ ( storageUsed ?? 0 ) / ( storageLimit ?? Infinity ) }
-				/>
-			</div>
-		</>
+		<div className="backup-storage-space__progress-bar">
+			<ProgressBar
+				className={ STORAGE_METER_CLASS_NAMES[ usageLevel ] }
+				value={ Math.min( progress * 100, 100 ) }
+			/>
+		</div>
 	);
 };
 

--- a/projects/packages/backup/src/js/components/backup-storage-space/storage-meter/style.scss
+++ b/projects/packages/backup/src/js/components/backup-storage-space/storage-meter/style.scss
@@ -4,12 +4,15 @@
 	margin-top: 24px;
 	margin-bottom: 16px;
 
-	.progress-bar {
+	// WP ProgressBar Track
+	> div {
 		height: 100%;
+		width: 100%;
 		border-radius: 12px; /* stylelint-disable-line scales/radii */
 		background-color: var(--jp-gray-5);
 
-		.progress-bar__progress {
+		// WP ProgressBar Indicator (the progress fill)
+		> div {
 			// Unless we're 100% full, the left side of the bar
 			// is rounded and the right side is flat
 			/* stylelint-disable-next-line scales/radii */
@@ -26,36 +29,24 @@
 			max-width: calc(100% - 12px);
 		}
 
-		&.no-warning {
-
-			.progress-bar__progress {
-				background-color: var(--jp-black);
-			}
+		&.no-warning > div {
+			background-color: var(--jp-black);
 		}
 
-		&.yellow-warning {
-
-			.progress-bar__progress {
-				background-color: var(--jp-yellow-20);
-			}
+		&.yellow-warning > div {
+			background-color: var(--jp-yellow-20);
 		}
 
-		&.red-warning {
-
-			.progress-bar__progress {
-				background-color: var(--jp-red-40);
-			}
+		&.red-warning > div {
+			background-color: var(--jp-red-40);
 		}
 
 		// When the bar is full, we can show the filled portion
 		// at full width, with a rounded right side
-		&.full-warning {
-
-			.progress-bar__progress {
-				max-width: initial;
-				background-color: var(--jp-red-40);
-				border-radius: 12px; /* stylelint-disable-line scales/radii */
-			}
+		&.full-warning > div {
+			max-width: initial;
+			background-color: var(--jp-red-40);
+			border-radius: 12px; /* stylelint-disable-line scales/radii */
 		}
 	}
 }


### PR DESCRIPTION
Part of #48160

## Proposed changes
* Replace the custom `ProgressBar` from `@automattic/jetpack-components` with the native `ProgressBar` from `@wordpress/components` in the Backup storage meter (`packages/backup` · `StorageMeter`).
* Convert `progress` (0–1) → `value` (0–100), clamped to 100 to match the previous component's internal clamp (matters when `storageUsed > storageLimit` — the `BackupsDiscarded` / `Full` case).
* Rewrite `storage-meter/style.scss` to target WP's emotion-styled DOM (`> div` for the Track, `> div > div` for the Indicator), preserving all existing behavior:
  * The 24px pill-shaped track with 12px border-radius
  * The four color states: `no-warning` (black), `yellow-warning`, `red-warning`, `full-warning` (red, fully rounded)
  * The `min-width: 12px` / `max-width: calc(100% - 12px)` "rounded left, flat right" geometry on the indicator
  * `max-width: initial` + full border-radius when the bar is at the `Full` state
* Hoist `STORAGE_METER_CLASS_NAMES` out of the component body so the object literal isn't recreated on every render.
* Drop the now-unused `progressClassName` prop and the redundant fragment wrapper.

## Related product discussion/links
* Parent issue: #48160 (Jetpack UI Modernization) — ticks the "Backup → ProgressBar" item.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

The storage meter renders only when the Backup plugin's admin page loads *and* the selectors `getBackupStorageLimit()` and `getBackupSize()` return non-null/positive values — both come from the Jetpack Backup REST API which requires an active Backup subscription on wpcom.

### Verify on a site with Backup enabled (e.g. Jurassic Ninja)
1. Activate the Jetpack Backup plugin and ensure the site has an active Backup plan.
2. Visit `wp-admin/admin.php?page=jetpack-backup`.
3. Confirm the "Cloud storage space" section renders with a 24px pill-shaped progress bar.
4. Inspect the bar visually against trunk:
   * Normal state (<65% used): black fill, rounded-left/flat-right edge
   * Warning state (65–80% used): yellow fill
   * Critical state (80–100% used): red fill, still with rounded-left/flat-right edge
   * Full state (≥100% used): red fill spanning the full width with both sides rounded

### Verifying locally (when no Backup plan is attached)
If your local site does not have a paid Backup plan, `getBackupStorageLimit()` returns `null` and the component short-circuits to render nothing. Two options:
- Temporarily force-render by editing `packages/backup/src/js/components/backup-storage-space/index.jsx:29` to `const showComponent = true;` and passing hardcoded `storageUsed` / `storageLimit` / `usageLevel` to `<StorageMeter>`. Revert before committing.
- Or drop a mu-plugin that filters `rest_post_dispatch` on `/jetpack/v4/site/backup/policies` to inject a `storage_limit_bytes` value.

### Regression checks
* Confirm the rest of the Backup admin page (section header, "Cloud storage is almost full" banner, storage usage details, upsell prompt) renders as before.
* Confirm nothing else in the Backup package regressed — there is only one consumer of `StorageMeter` (`packages/backup/src/js/components/backup-storage-space/index.jsx`).
