### PR TITLE
Monetize settings: import ToggleControl from @wordpress/components

### DIFF
--- a/projects/plugins/jetpack/_inc/client/earn/ads.jsx
+++ b/projects/plugins/jetpack/_inc/client/earn/ads.jsx
@@ -1,6 +1,6 @@
-import { ToggleControl, getRedirectUrl } from '@automattic/jetpack-components';
+import { getRedirectUrl } from '@automattic/jetpack-components';
 import { isWoASite } from '@automattic/jetpack-script-data';
-import { ExternalLink } from '@wordpress/components';
+import { ExternalLink, ToggleControl } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { Component } from 'react';
@@ -60,13 +60,13 @@ export const Ads = withModuleSettingsFormHelpers(
 					} }
 				>
 					<ToggleControl
+						__nextHasNoMarginBottom={ true }
 						checked={ wordads_custom_adstxt_enabled }
 						disabled={
 							! isAdsActive ||
 							unavailableInOfflineMode ||
-							this.props.isSavingAnyOption( [ 'wordads' ] )
+							this.props.isSavingAnyOption( [ 'wordads', 'wordads_custom_adstxt_enabled' ] )
 						}
-						toggling={ this.props.isSavingAnyOption( [ 'wordads_custom_adstxt_enabled' ] ) }
 						onChange={ this.handleChange( 'wordads_custom_adstxt_enabled' ) }
 						label={ __( 'Customize your ads.txt file', 'jetpack' ) }
 					/>
@@ -207,46 +207,46 @@ export const Ads = withModuleSettingsFormHelpers(
 						<FormFieldset>
 							<FormLegend>{ __( 'Display ads below posts on', 'jetpack' ) }</FormLegend>
 							<ToggleControl
+								__nextHasNoMarginBottom={ true }
 								checked={ wordads_display_front_page }
 								disabled={
 									! isAdsActive ||
 									unavailableInOfflineMode ||
-									this.props.isSavingAnyOption( [ 'wordads' ] )
+									this.props.isSavingAnyOption( [ 'wordads', 'wordads_display_front_page' ] )
 								}
-								toggling={ this.props.isSavingAnyOption( [ 'wordads_display_front_page' ] ) }
 								onChange={ this.handleChange( 'wordads_display_front_page' ) }
 								label={ __( 'Front page', 'jetpack' ) }
 							/>
 							<ToggleControl
+								__nextHasNoMarginBottom={ true }
 								checked={ wordads_display_post }
 								disabled={
 									! isAdsActive ||
 									unavailableInOfflineMode ||
-									this.props.isSavingAnyOption( [ 'wordads' ] )
+									this.props.isSavingAnyOption( [ 'wordads', 'wordads_display_post' ] )
 								}
-								toggling={ this.props.isSavingAnyOption( [ 'wordads_display_post' ] ) }
 								onChange={ this.handleChange( 'wordads_display_post' ) }
 								label={ __( 'Posts', 'jetpack' ) }
 							/>
 							<ToggleControl
+								__nextHasNoMarginBottom={ true }
 								checked={ wordads_display_page }
 								disabled={
 									! isAdsActive ||
 									unavailableInOfflineMode ||
-									this.props.isSavingAnyOption( [ 'wordads' ] )
+									this.props.isSavingAnyOption( [ 'wordads', 'wordads_display_page' ] )
 								}
-								toggling={ this.props.isSavingAnyOption( [ 'wordads_display_page' ] ) }
 								onChange={ this.handleChange( 'wordads_display_page' ) }
 								label={ __( 'Pages', 'jetpack' ) }
 							/>
 							<ToggleControl
+								__nextHasNoMarginBottom={ true }
 								checked={ wordads_display_archive }
 								disabled={
 									! isAdsActive ||
 									unavailableInOfflineMode ||
-									this.props.isSavingAnyOption( [ 'wordads' ] )
+									this.props.isSavingAnyOption( [ 'wordads', 'wordads_display_archive' ] )
 								}
-								toggling={ this.props.isSavingAnyOption( [ 'wordads_display_archive' ] ) }
 								onChange={ this.handleChange( 'wordads_display_archive' ) }
 								label={ __( 'Archives', 'jetpack' ) }
 							/>
@@ -254,35 +254,35 @@ export const Ads = withModuleSettingsFormHelpers(
 						<FormFieldset>
 							<FormLegend>{ __( 'Additional ad placements', 'jetpack' ) }</FormLegend>
 							<ToggleControl
+								__nextHasNoMarginBottom={ true }
 								checked={ enable_header_ad }
 								disabled={
 									! isAdsActive ||
 									unavailableInOfflineMode ||
-									this.props.isSavingAnyOption( [ 'wordads' ] )
+									this.props.isSavingAnyOption( [ 'wordads', 'enable_header_ad' ] )
 								}
-								toggling={ this.props.isSavingAnyOption( [ 'enable_header_ad' ] ) }
 								onChange={ this.handleChange( 'enable_header_ad' ) }
 								label={ __( 'Top of each page', 'jetpack' ) }
 							/>
 							<ToggleControl
+								__nextHasNoMarginBottom={ true }
 								checked={ wordads_second_belowpost }
 								disabled={
 									! isAdsActive ||
 									unavailableInOfflineMode ||
-									this.props.isSavingAnyOption( [ 'wordads' ] )
+									this.props.isSavingAnyOption( [ 'wordads', 'wordads_second_belowpost' ] )
 								}
-								toggling={ this.props.isSavingAnyOption( [ 'wordads_second_belowpost' ] ) }
 								onChange={ this.handleChange( 'wordads_second_belowpost' ) }
 								label={ __( 'Second ad below post', 'jetpack' ) }
 							/>
 							<ToggleControl
+								__nextHasNoMarginBottom={ true }
 								checked={ wordads_inline_enabled }
 								disabled={
 									! isAdsActive ||
 									unavailableInOfflineMode ||
-									this.props.isSavingAnyOption( [ 'wordads' ] )
+									this.props.isSavingAnyOption( [ 'wordads', 'wordads_inline_enabled' ] )
 								}
-								toggling={ this.props.isSavingAnyOption( [ 'wordads_inline_enabled' ] ) }
 								onChange={ this.handleChange( 'wordads_inline_enabled' ) }
 								label={ __( 'Inline within post content', 'jetpack' ) }
 							/>
@@ -301,13 +301,13 @@ export const Ads = withModuleSettingsFormHelpers(
 						} }
 					>
 						<ToggleControl
+							__nextHasNoMarginBottom={ true }
 							checked={ wordads_ccpa_enabled }
 							disabled={
 								! isAdsActive ||
 								unavailableInOfflineMode ||
-								this.props.isSavingAnyOption( [ 'wordads' ] )
+								this.props.isSavingAnyOption( [ 'wordads', 'wordads_ccpa_enabled' ] )
 							}
-							toggling={ this.props.isSavingAnyOption( [ 'wordads_ccpa_enabled' ] ) }
 							onChange={ this.handleChange( 'wordads_ccpa_enabled' ) }
 							label={ __(
 								'Enable targeted advertising to site visitors in all US states.',
@@ -384,13 +384,13 @@ export const Ads = withModuleSettingsFormHelpers(
 						} }
 					>
 						<ToggleControl
+							__nextHasNoMarginBottom={ true }
 							checked={ wordads_cmp_enabled }
 							disabled={
 								! isAdsActive ||
 								unavailableInOfflineMode ||
-								this.props.isSavingAnyOption( [ 'wordads' ] )
+								this.props.isSavingAnyOption( [ 'wordads', 'wordads_cmp_enabled' ] )
 							}
-							toggling={ this.props.isSavingAnyOption( [ 'wordads_cmp_enabled' ] ) }
 							onChange={ this.handleChange( 'wordads_cmp_enabled' ) }
 							label={ __( 'Enable GDPR Consent Banner', 'jetpack' ) }
 						/>

--- a/projects/plugins/jetpack/changelog/update-toggle-control-wp-components-direct
+++ b/projects/plugins/jetpack/changelog/update-toggle-control-wp-components-direct
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Monetize settings: import ToggleControl from @wordpress/components instead of @automattic/jetpack-components.


### PR DESCRIPTION
Fixes #

## Proposed changes

Follow-up to #48197 (which migrated the shared `ModuleToggle` wrapper and its consumers). This PR finishes the direct `<ToggleControl>` migration in the main Jetpack settings client: the Monetize (Ads) settings had 10 `<ToggleControl>` instances still importing from `@automattic/jetpack-components`.

* `earn/ads.jsx`: split the import so `ToggleControl` comes from `@wordpress/components` (alongside `ExternalLink`), leaving `getRedirectUrl` with `@automattic/jetpack-components`.
* Add `__nextHasNoMarginBottom` on all 10 call sites so spacing matches the wrapper's prior default and no deprecation warning fires.
* Drop the `toggling` prop (not present on the upstream component) and fold each option key into the existing `disabled` expression alongside `'wordads'` (so click-blocking during a save is preserved). The only user-visible loss is the short optimistic-flip / dim animation — same trade-off accepted in the earlier PRs.

### Note on the `isSavingAnyOption` call-site consolidation

Each migrated toggle used to call `isSavingAnyOption` **twice** — once inside `disabled` (`[ 'wordads' ]`) and once inside `toggling` (`[ <specific_option> ]`). After removing `toggling`, instead of adding a second `||` clause, I merged both keys into a single array:

```jsx
// before
disabled={ ! isAdsActive || unavailableInOfflineMode || isSavingAnyOption( [ 'wordads' ] ) }
toggling={ isSavingAnyOption( [ 'wordads_display_front_page' ] ) }

// after
disabled={
    ! isAdsActive ||
    unavailableInOfflineMode ||
    isSavingAnyOption( [ 'wordads', 'wordads_display_front_page' ] )
}
```

`isSavingAnyOption` forwards to `isUpdatingSetting( state, settings )` at [`state/settings/reducer.js:136`](../blob/trunk/projects/plugins/jetpack/_inc/client/state/settings/reducer.js#L136), which when passed an array does an **OR across keys** (`.some( ... settings.includes( key ) )`). So `isSavingAnyOption( [ a, b ] )` is semantically identical to `isSavingAnyOption( [ a ] ) || isSavingAnyOption( [ b ] )` — one call, one `.some()` pass, and it reads closer to the intent ("disable while any of these keys is saving").

I kept `'wordads'` in each array to preserve the exact guard set of the original code, even though it's arguably redundant with `! isAdsActive` (the module has to be active for the nested toggles to be interactive in the first place). Dropping `'wordads'` would be a further cleanup but changes behavior in edge cases I didn't want to take on in this PR.

The 10 migrated toggles are:

* `Customize your ads.txt file` (`wordads_custom_adstxt_enabled`)
* `Display ads below posts on` group: Front page, Posts, Pages, Archives
* `Additional ad placements` group: Top of each page, Second ad below post, Inline within post content
* `Enable targeted advertising to site visitors in all US states.` (`wordads_ccpa_enabled`)
* `Enable GDPR Consent Banner` (`wordads_cmp_enabled`)

The `<ModuleToggle slug="wordads">` above these toggles is intentionally left alone — it belongs to the `ModuleToggle` migration in #48197.

After this lands, the only remaining `ToggleControl` imports from `@automattic/jetpack-components` in the main Jetpack settings client are inside the `ModuleToggle` wrapper itself (handled in #48197).

## Related product discussion/links

* Follow-up to #48197, part of the same migration kicked off in #48177 / #48179 / #48189 / #48190 / #48186.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Open `wp-admin/admin.php?page=jetpack#/earn` (the Monetize tab of Jetpack Settings).
2. Confirm every toggle row in the **Ads** card renders with the same spacing/styling as before (see the before/after table below): Front page, Posts, Pages, Archives, Top of each page, Second ad below post, Inline within post content, Enable targeted advertising…, Enable GDPR Consent Banner, Customize your ads.txt file.
3. Enable the Ads module (the `<ModuleToggle>` at the top of the card) — verify that the nested toggles become enabled and that flipping each one saves cleanly. While the save is in flight the toggle should be visually `disabled` (mouse cursor + disabled state) instead of the previous optimistic-flip/dim animation.
4. Enable **Enable targeted advertising to site visitors in all US states** — confirm the conditional "Privacy Policy URL" form and helper copy still appear.
5. Enable **Customize your ads.txt file** — confirm the conditional textarea still appears.

## Real-screen before / after

Captured on a live local dev site at 1440×900 with the Ads module off. Both PNGs are **byte-identical** (pixel-for-pixel match, zero differences) between a fresh `trunk` build and this branch.

| Before (trunk) | After (this PR) |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/update/toggle-control-wp-components-direct/before-monetize.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/update/toggle-control-wp-components-direct/after-monetize.png) |


