### PR TITLE
Added jetpack_top_posts_title filter to top post block/widget output

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-top-posts-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-top-posts-helper.php
@@ -108,7 +108,7 @@ class Jetpack_Top_Posts_Helper {
 			}
 
 			if ( $post['public'] ) {
-				$top_posts[] = array(
+				$top_post = array(
 					'id'        => $post_id,
 					'author'    => get_the_author_meta( 'display_name', get_post_field( 'post_author', $post_id ) ), // @phan-suppress-current-line PhanTypeMismatchArgument @phan-suppress-current-line UnusedSuppression -- Fixed in WP 6.9, but then we need a suppression for the WP 6.8 compat run. @todo Remove this suppression when we drop WP <6.9.
 					'context'   => get_the_category( $post_id ) ? get_the_category( $post_id ) : get_the_tags( $post_id ),
@@ -120,6 +120,23 @@ class Jetpack_Top_Posts_Helper {
 					'views'     => isset( $post['views'] ) ? $post['views'] : 0,
 					'thumbnail' => $thumbnail,
 				);
+
+				/**
+				 * Allows modifying the title of each individual post returned by the Top Posts helper.
+				 *
+				 * Applies to both the Top Posts block's front-end output and the REST
+				 * response used by the block editor preview.
+				 *
+				 * @module stats
+				 *
+				 * @since $$next-version$$
+				 *
+				 * @param string $post_title Post title.
+				 * @param array  $top_post   Information about the post.
+				 */
+				$top_post['title'] = apply_filters( 'jetpack_top_posts_item_title', $top_post['title'], $top_post );
+
+				$top_posts[] = $top_post;
 			}
 		}
 

--- a/projects/plugins/jetpack/changelog/add-top-posts-block-post-title-filter
+++ b/projects/plugins/jetpack/changelog/add-top-posts-block-post-title-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Top Posts block: add filter allowing customization of the posts' titles in the block.

--- a/projects/plugins/jetpack/extensions/blocks/top-posts/top-posts.php
+++ b/projects/plugins/jetpack/extensions/blocks/top-posts/top-posts.php
@@ -111,12 +111,7 @@ function load_assets( $attributes ) {
 			$output .= '</a>';
 		}
 
-		/**
-		 * Adds the ability to modify the titles of posts in the block output.
-		 */
-		$title = apply_filters( 'jetpack_blocks_top_posts_title', $item['title'], $item );
-
-		$output .= '<span class="jetpack-top-posts-title"><a href="' . esc_url( $item['href'] ) . '">' . esc_html( $title ) . '</a></span>';
+		$output .= '<span class="jetpack-top-posts-title"><a href="' . esc_url( $item['href'] ) . '">' . esc_html( $item['title'] ) . '</a></span>';
 
 		if ( $attributes['displayDate'] ) {
 			$output .= '<span class="jetpack-top-posts-date has-small-font-size">' . esc_html( $item['date'] ) . '</span>';

--- a/projects/plugins/jetpack/extensions/blocks/top-posts/top-posts.php
+++ b/projects/plugins/jetpack/extensions/blocks/top-posts/top-posts.php
@@ -111,7 +111,12 @@ function load_assets( $attributes ) {
 			$output .= '</a>';
 		}
 
-		$output .= '<span class="jetpack-top-posts-title"><a href="' . esc_url( $item['href'] ) . '">' . esc_html( apply_filters( 'jetpack_top_posts_title', $item['title'], $item ) ) . '</a></span>';
+		/**
+		 * Adds the ability to modify the titles of posts in the block output.
+		 */
+		$title = apply_filters( 'jetpack_blocks_top_posts_title', $item['title'], $item );
+
+		$output .= '<span class="jetpack-top-posts-title"><a href="' . esc_url( $item['href'] ) . '">' . esc_html( $title ) . '</a></span>';
 
 		if ( $attributes['displayDate'] ) {
 			$output .= '<span class="jetpack-top-posts-date has-small-font-size">' . esc_html( $item['date'] ) . '</span>';

--- a/projects/plugins/jetpack/extensions/blocks/top-posts/top-posts.php
+++ b/projects/plugins/jetpack/extensions/blocks/top-posts/top-posts.php
@@ -111,7 +111,7 @@ function load_assets( $attributes ) {
 			$output .= '</a>';
 		}
 
-		$output .= '<span class="jetpack-top-posts-title"><a href="' . esc_url( $item['href'] ) . '">' . esc_html( $item['title'] ) . '</a></span>';
+		$output .= '<span class="jetpack-top-posts-title"><a href="' . esc_url( $item['href'] ) . '">' . esc_html( apply_filters( 'jetpack_top_posts_title', $item['title'], $item ) ) . '</a></span>';
 
 		if ( $attributes['displayDate'] ) {
 			$output .= '<span class="jetpack-top-posts-date has-small-font-size">' . esc_html( $item['date'] ) . '</span>';


### PR DESCRIPTION
Fixes #

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* This adds a filter so we can append and prepend custom elements to post titles eg  *Updated*, *NEW* etc

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* n/a

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Nothing major, this is just a simple filter PR