### PR TITLE
wpcomsh: Report recovery-mode state to wpcom

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-recovery-mode-sync
+++ b/projects/plugins/wpcomsh/changelog/add-recovery-mode-sync
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Signal recovery-mode state to WPcom (via /sites/{blog_id}/recovery-mode-status) so the dashboard can surface "needs recovery" and related states for sites that have hit a fatal error.
+Report recovery-mode state to wpcom (via /sites/{blog_id}/recovery-mode-status) so wpcom-side consumers can surface "needs recovery" and related states for sites that have hit a fatal error.

--- a/projects/plugins/wpcomsh/changelog/add-recovery-mode-sync
+++ b/projects/plugins/wpcomsh/changelog/add-recovery-mode-sync
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Signal recovery-mode state to WPcom (via /sites/{blog_id}/recovery-mode-status) so the dashboard can surface "needs recovery" and related states for sites that have hit a fatal error.

--- a/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
+++ b/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
@@ -62,7 +62,6 @@ class WPCOMSH_Recovery_Mode_Sync {
 	 */
 	public static function capture_email_last_sent() {
 		self::snapshot();
-		self::$payload['recovery_mode_email_last_sent'] = (int) get_option( self::EMAIL_LAST_SENT_OPTION, 0 );
 		self::trace(
 			'captured email_last_sent',
 			array( 'value' => self::$payload['recovery_mode_email_last_sent'] )
@@ -82,7 +81,6 @@ class WPCOMSH_Recovery_Mode_Sync {
 		$now = time();
 		update_option( self::ENTERED_AT_OPTION, $now, false );
 		self::snapshot();
-		self::$payload['recovery_session_entered_at'] = $now;
 		self::trace(
 			'captured session_start',
 			array(
@@ -105,7 +103,6 @@ class WPCOMSH_Recovery_Mode_Sync {
 		$now = time();
 		update_option( self::EXITED_AT_OPTION, $now, false );
 		self::snapshot();
-		self::$payload['recovery_session_exited_at'] = $now;
 		self::trace(
 			'captured session_end',
 			array(

--- a/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
+++ b/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Signal WordPress recovery-mode state to WPcom via a dedicated endpoint so the
- * WordPress.com dashboard can surface "needs recovery" / "in recovery" states
- * to site admins.
+ * Report WordPress recovery-mode state to wpcom via a dedicated endpoint so
+ * wpcom-side consumers can surface "needs recovery" / "in recovery" states
+ * for the site.
  *
  * Three timestamps are POSTed to `/sites/{blog_id}/recovery-mode-status`:
  *
@@ -14,7 +14,7 @@
  *   - `recovery_session_exited_at`     — wpcomsh-managed; updated on deletion
  *     of `{session_id}_paused_extensions`, i.e. when the admin exits recovery.
  *
- * The POST runs from a PHP shutdown function so the signal reaches WPcom even
+ * The POST runs from a PHP shutdown function so the signal reaches wpcom even
  * on fatal-error requests, matching the pattern used by migrate-guru-canary.
  *
  * @package wpcomsh
@@ -23,7 +23,7 @@
 use Automattic\Jetpack\Connection\Client as Jetpack_Connection_Client;
 
 /**
- * Captures recovery-mode option writes and forwards a state snapshot to WPcom
+ * Captures recovery-mode option writes and forwards a state snapshot to wpcom
  * on PHP shutdown.
  */
 class WPCOMSH_Recovery_Mode_Sync {
@@ -106,8 +106,8 @@ class WPCOMSH_Recovery_Mode_Sync {
 	}
 
 	/**
-	 * PHP-shutdown callback: POST the current state snapshot to WPcom so the
-	 * signal reaches the dashboard even when this request is dying from a fatal.
+	 * PHP-shutdown callback: POST the current state snapshot to wpcom so the
+	 * signal reaches wpcom even when this request is dying from a fatal.
 	 */
 	public static function send() {
 		if ( self::$payload === null ) {

--- a/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
+++ b/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
@@ -128,19 +128,25 @@ class WPCOMSH_Recovery_Mode_Sync {
 	 * signal reaches wpcom even when this request is dying from a fatal.
 	 */
 	public static function send() {
+		self::trace( 'send() entered' );
+
 		if ( self::$payload === null ) {
+			self::trace( 'send() aborting: null payload' );
 			return;
 		}
 		if ( ! class_exists( Jetpack_Connection_Client::class ) ) {
+			self::trace( 'send() aborting: Jetpack Connection Client class missing' );
 			return;
 		}
 		if ( ! function_exists( '_wpcom_get_current_blog_id' ) ) {
+			self::trace( 'send() aborting: _wpcom_get_current_blog_id() not defined' );
 			return;
 		}
 
 		try {
 			$wpcom_blog_id = _wpcom_get_current_blog_id();
 			if ( ! $wpcom_blog_id ) {
+				self::trace( 'send() aborting: blog_id is falsy', array( 'value' => $wpcom_blog_id ) );
 				return;
 			}
 

--- a/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
+++ b/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
@@ -55,8 +55,12 @@ class WPCOMSH_Recovery_Mode_Sync {
 		add_action( 'add_option_' . self::EMAIL_LAST_SENT_OPTION, array( __CLASS__, 'capture_email_last_sent' ) );
 		add_action( 'update_option_' . self::EMAIL_LAST_SENT_OPTION, array( __CLASS__, 'capture_email_last_sent' ) );
 
+		// Only `added_option` signals a new recovery session. `updated_option`
+		// fires for in-session extension additions and — crucially — during
+		// exit unwinding when `WP_Paused_Extensions_Storage::delete_all()` of
+		// one type rewrites the session option with remaining entries of the
+		// other type; treating that as a new entry would clobber entered_at.
 		add_action( 'added_option', array( __CLASS__, 'capture_session_start' ), 10, 1 );
-		add_action( 'updated_option', array( __CLASS__, 'capture_session_start' ), 10, 1 );
 		add_action( 'deleted_option', array( __CLASS__, 'capture_session_end' ), 10, 1 );
 	}
 

--- a/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
+++ b/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Signal WordPress recovery-mode state to WPcom via a dedicated endpoint so the
+ * WordPress.com dashboard can surface "needs recovery" / "in recovery" states
+ * to site admins.
+ *
+ * Three timestamps are POSTed to `/sites/{blog_id}/recovery-mode-status`:
+ *
+ *   - `recovery_mode_email_last_sent`  — written by WP core each time a fatal
+ *     triggers a recovery email (rate-limited to ~1/day).
+ *   - `recovery_session_entered_at`    — wpcomsh-managed; updated on any write
+ *     to `{session_id}_paused_extensions`, i.e. when the admin enters a
+ *     recovery session by clicking the email link.
+ *   - `recovery_session_exited_at`     — wpcomsh-managed; updated on deletion
+ *     of `{session_id}_paused_extensions`, i.e. when the admin exits recovery.
+ *
+ * The POST runs from a PHP shutdown function so the signal reaches WPcom even
+ * on fatal-error requests, matching the pattern used by migrate-guru-canary.
+ *
+ * @package wpcomsh
+ */
+
+use Automattic\Jetpack\Connection\Client as Jetpack_Connection_Client;
+
+/**
+ * Captures recovery-mode option writes and forwards a state snapshot to WPcom
+ * on PHP shutdown.
+ */
+class WPCOMSH_Recovery_Mode_Sync {
+
+	private const EMAIL_LAST_SENT_OPTION          = 'recovery_mode_email_last_sent';
+	private const ENTERED_AT_OPTION               = 'wpcomsh_recovery_session_entered_at';
+	private const EXITED_AT_OPTION                = 'wpcomsh_recovery_session_exited_at';
+	private const PAUSED_EXTENSIONS_OPTION_SUFFIX = '_paused_extensions';
+
+	/**
+	 * Pending state snapshot. Null until the first observed change this
+	 * request — its non-null-ness doubles as the "send needed" flag.
+	 *
+	 * @var array<string,int>|null
+	 */
+	private static $payload = null;
+
+	/**
+	 * Whether the PHP shutdown callback has been registered this request.
+	 *
+	 * @var bool
+	 */
+	private static $shutdown_registered = false;
+
+	/**
+	 * Register option-change listeners.
+	 */
+	public static function init() {
+		add_action( 'add_option_' . self::EMAIL_LAST_SENT_OPTION, array( __CLASS__, 'capture_email_last_sent' ) );
+		add_action( 'update_option_' . self::EMAIL_LAST_SENT_OPTION, array( __CLASS__, 'capture_email_last_sent' ) );
+
+		add_action( 'added_option', array( __CLASS__, 'capture_session_start' ), 10, 1 );
+		add_action( 'updated_option', array( __CLASS__, 'capture_session_start' ), 10, 1 );
+		add_action( 'deleted_option', array( __CLASS__, 'capture_session_end' ), 10, 1 );
+	}
+
+	/**
+	 * Listener for the recovery-mode email timestamp.
+	 */
+	public static function capture_email_last_sent() {
+		self::snapshot();
+		self::$payload['recovery_mode_email_last_sent'] = (int) get_option( self::EMAIL_LAST_SENT_OPTION, 0 );
+		self::register_shutdown();
+	}
+
+	/**
+	 * Listener for option writes that may represent entering a recovery session.
+	 *
+	 * @param string $option Option name.
+	 */
+	public static function capture_session_start( $option ) {
+		if ( ! self::is_paused_extensions_option( $option ) ) {
+			return;
+		}
+		$now = time();
+		update_option( self::ENTERED_AT_OPTION, $now, false );
+		self::snapshot();
+		self::$payload['recovery_session_entered_at'] = $now;
+		self::register_shutdown();
+	}
+
+	/**
+	 * Listener for option deletions that represent exiting a recovery session.
+	 *
+	 * @param string $option Option name.
+	 */
+	public static function capture_session_end( $option ) {
+		if ( ! self::is_paused_extensions_option( $option ) ) {
+			return;
+		}
+		$now = time();
+		update_option( self::EXITED_AT_OPTION, $now, false );
+		self::snapshot();
+		self::$payload['recovery_session_exited_at'] = $now;
+		self::register_shutdown();
+	}
+
+	/**
+	 * PHP-shutdown callback: POST the current state snapshot to WPcom so the
+	 * signal reaches the dashboard even when this request is dying from a fatal.
+	 */
+	public static function send() {
+		if ( self::$payload === null ) {
+			return;
+		}
+		if ( ! class_exists( Jetpack_Connection_Client::class ) ) {
+			return;
+		}
+		if ( ! function_exists( '_wpcom_get_current_blog_id' ) ) {
+			return;
+		}
+
+		try {
+			$wpcom_blog_id = _wpcom_get_current_blog_id();
+			if ( ! $wpcom_blog_id ) {
+				return;
+			}
+
+			Jetpack_Connection_Client::wpcom_json_api_request_as_blog(
+				sprintf( '/sites/%s/recovery-mode-status', $wpcom_blog_id ),
+				'v2',
+				array( 'method' => 'POST' ),
+				self::$payload,
+				'wpcom'
+			);
+		} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// Mid-shutdown there is nothing actionable; the next observable
+			// state change will trigger another send.
+		}
+	}
+
+	/**
+	 * Populate the in-memory state snapshot once per request.
+	 */
+	private static function snapshot() {
+		if ( self::$payload !== null ) {
+			return;
+		}
+		self::$payload = array(
+			'recovery_mode_email_last_sent' => (int) get_option( self::EMAIL_LAST_SENT_OPTION, 0 ),
+			'recovery_session_entered_at'   => (int) get_option( self::ENTERED_AT_OPTION, 0 ),
+			'recovery_session_exited_at'    => (int) get_option( self::EXITED_AT_OPTION, 0 ),
+		);
+	}
+
+	/**
+	 * Register the PHP-level shutdown callback once per request.
+	 */
+	private static function register_shutdown() {
+		if ( self::$shutdown_registered ) {
+			return;
+		}
+		self::$shutdown_registered = true;
+		register_shutdown_function( array( __CLASS__, 'send' ) );
+	}
+
+	/**
+	 * Whether the given option name is a recovery-session paused-extensions
+	 * option (session-scoped, dynamically named).
+	 *
+	 * @param string $option Option name.
+	 * @return bool
+	 */
+	private static function is_paused_extensions_option( $option ) {
+		return is_string( $option ) && str_ends_with( $option, self::PAUSED_EXTENSIONS_OPTION_SUFFIX );
+	}
+}
+
+WPCOMSH_Recovery_Mode_Sync::init();

--- a/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
+++ b/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
@@ -34,12 +34,12 @@ class WPCOMSH_Recovery_Mode_Sync {
 	private const PAUSED_EXTENSIONS_OPTION_SUFFIX = '_paused_extensions';
 
 	/**
-	 * Pending state snapshot. Null until the first observed change this
-	 * request — its non-null-ness doubles as the "send needed" flag.
+	 * Pending state snapshot. Empty until the first capture this request —
+	 * its non-emptiness doubles as the "send needed" flag.
 	 *
-	 * @var array<string,int>|null
+	 * @var array<string,int>
 	 */
-	private static $payload = null;
+	private static $payload = array();
 
 	/**
 	 * Register option-change listeners.
@@ -125,7 +125,7 @@ class WPCOMSH_Recovery_Mode_Sync {
 	 * the dying request.
 	 */
 	public static function send() {
-		if ( self::$payload === null ) {
+		if ( empty( self::$payload ) ) {
 			return;
 		}
 		if ( ! class_exists( Jetpack_Connection_Client::class ) ) {
@@ -201,7 +201,7 @@ class WPCOMSH_Recovery_Mode_Sync {
 	 * Populate the in-memory state snapshot once per request.
 	 */
 	private static function snapshot() {
-		if ( self::$payload !== null ) {
+		if ( ! empty( self::$payload ) ) {
 			return;
 		}
 		self::$payload = array(

--- a/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
+++ b/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
@@ -70,6 +70,10 @@ class WPCOMSH_Recovery_Mode_Sync {
 	public static function capture_email_last_sent() {
 		self::snapshot();
 		self::$payload['recovery_mode_email_last_sent'] = (int) get_option( self::EMAIL_LAST_SENT_OPTION, 0 );
+		self::trace(
+			'captured email_last_sent',
+			array( 'value' => self::$payload['recovery_mode_email_last_sent'] )
+		);
 		self::register_shutdown();
 	}
 
@@ -86,6 +90,13 @@ class WPCOMSH_Recovery_Mode_Sync {
 		update_option( self::ENTERED_AT_OPTION, $now, false );
 		self::snapshot();
 		self::$payload['recovery_session_entered_at'] = $now;
+		self::trace(
+			'captured session_start',
+			array(
+				'option'     => $option,
+				'entered_at' => $now,
+			)
+		);
 		self::register_shutdown();
 	}
 
@@ -102,6 +113,13 @@ class WPCOMSH_Recovery_Mode_Sync {
 		update_option( self::EXITED_AT_OPTION, $now, false );
 		self::snapshot();
 		self::$payload['recovery_session_exited_at'] = $now;
+		self::trace(
+			'captured session_end',
+			array(
+				'option'    => $option,
+				'exited_at' => $now,
+			)
+		);
 		self::register_shutdown();
 	}
 
@@ -126,16 +144,41 @@ class WPCOMSH_Recovery_Mode_Sync {
 				return;
 			}
 
-			Jetpack_Connection_Client::wpcom_json_api_request_as_blog(
+			self::trace(
+				'posting state',
+				array(
+					'blog_id' => $wpcom_blog_id,
+					'payload' => self::$payload,
+				)
+			);
+
+			$response = Jetpack_Connection_Client::wpcom_json_api_request_as_blog(
 				sprintf( '/sites/%s/recovery-mode-status', $wpcom_blog_id ),
 				'v2',
 				array( 'method' => 'POST' ),
 				self::$payload,
 				'wpcom'
 			);
-		} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-			// Mid-shutdown there is nothing actionable; the next observable
-			// state change will trigger another send.
+
+			if ( is_wp_error( $response ) ) {
+				WPCOMSH_Log::unsafe_direct_log(
+					'recovery-mode-sync: post returned WP_Error',
+					array( 'error' => $response->get_error_message() )
+				);
+			} else {
+				$code = (int) wp_remote_retrieve_response_code( $response );
+				if ( $code < 200 || $code >= 300 ) {
+					WPCOMSH_Log::unsafe_direct_log(
+						'recovery-mode-sync: post returned non-2xx',
+						array( 'code' => $code )
+					);
+				}
+			}
+		} catch ( \Throwable $e ) {
+			WPCOMSH_Log::unsafe_direct_log(
+				'recovery-mode-sync: post threw',
+				array( 'exception' => $e->getMessage() )
+			);
 		}
 	}
 
@@ -173,6 +216,28 @@ class WPCOMSH_Recovery_Mode_Sync {
 	 */
 	private static function is_paused_extensions_option( $option ) {
 		return is_string( $option ) && str_ends_with( $option, self::PAUSED_EXTENSIONS_OPTION_SUFFIX );
+	}
+
+	/**
+	 * Emit a trace log to error_log when opted in via filter. Default is off.
+	 *
+	 * Enable on a specific site with:
+	 *   add_filter( 'wpcomsh_recovery_mode_sync_logging_enabled', '__return_true' );
+	 *
+	 * @param string $message Trace message.
+	 * @param array  $extra   Optional structured context.
+	 */
+	private static function trace( $message, $extra = array() ) {
+		/**
+		 * Whether to emit recovery-mode-sync trace logs to error_log.
+		 *
+		 * @param bool $enabled Defaults to false.
+		 */
+		if ( ! apply_filters( 'wpcomsh_recovery_mode_sync_logging_enabled', false ) ) {
+			return;
+		}
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		error_log( 'wpcomsh_recovery_mode_sync: ' . $message . ' ' . wp_json_encode( $extra, JSON_UNESCAPED_SLASHES ) );
 	}
 }
 

--- a/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
+++ b/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
@@ -42,14 +42,14 @@ class WPCOMSH_Recovery_Mode_Sync {
 	private static $payload = null;
 
 	/**
-	 * Whether the PHP shutdown callback has been registered this request.
+	 * Register option-change listeners and the PHP shutdown callback.
 	 *
-	 * @var bool
-	 */
-	private static $shutdown_registered = false;
-
-	/**
-	 * Register option-change listeners.
+	 * The shutdown function is registered up front (not lazily) because the
+	 * option writes that trigger a capture often happen from *within* WP's
+	 * own fatal-handler shutdown callback — and `register_shutdown_function`
+	 * called from inside a shutdown callback isn't reliably executed.
+	 * Registering during `init()` guarantees our callback is queued before
+	 * WP's fatal handler runs and so fires after it.
 	 */
 	public static function init() {
 		add_action( 'add_option_' . self::EMAIL_LAST_SENT_OPTION, array( __CLASS__, 'capture_email_last_sent' ) );
@@ -62,6 +62,8 @@ class WPCOMSH_Recovery_Mode_Sync {
 		// other type; treating that as a new entry would clobber entered_at.
 		add_action( 'added_option', array( __CLASS__, 'capture_session_start' ), 10, 1 );
 		add_action( 'deleted_option', array( __CLASS__, 'capture_session_end' ), 10, 1 );
+
+		register_shutdown_function( array( __CLASS__, 'send' ) );
 	}
 
 	/**
@@ -74,7 +76,6 @@ class WPCOMSH_Recovery_Mode_Sync {
 			'captured email_last_sent',
 			array( 'value' => self::$payload['recovery_mode_email_last_sent'] )
 		);
-		self::register_shutdown();
 	}
 
 	/**
@@ -97,7 +98,6 @@ class WPCOMSH_Recovery_Mode_Sync {
 				'entered_at' => $now,
 			)
 		);
-		self::register_shutdown();
 	}
 
 	/**
@@ -120,7 +120,6 @@ class WPCOMSH_Recovery_Mode_Sync {
 				'exited_at' => $now,
 			)
 		);
-		self::register_shutdown();
 	}
 
 	/**
@@ -200,17 +199,6 @@ class WPCOMSH_Recovery_Mode_Sync {
 			'recovery_session_entered_at'   => (int) get_option( self::ENTERED_AT_OPTION, 0 ),
 			'recovery_session_exited_at'    => (int) get_option( self::EXITED_AT_OPTION, 0 ),
 		);
-	}
-
-	/**
-	 * Register the PHP-level shutdown callback once per request.
-	 */
-	private static function register_shutdown() {
-		if ( self::$shutdown_registered ) {
-			return;
-		}
-		self::$shutdown_registered = true;
-		register_shutdown_function( array( __CLASS__, 'send' ) );
 	}
 
 	/**

--- a/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
+++ b/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
@@ -137,6 +137,18 @@ class WPCOMSH_Recovery_Mode_Sync {
 			return;
 		}
 
+		// The Connection Client signs requests with wp_rand() / wp_generate_password(),
+		// both defined in pluggable.php. That file is loaded late in WP's bootstrap and
+		// is often not yet available when we're called from inside WP's fatal-handler
+		// shutdown path (the exact case this feature exists to handle). Load it here.
+		if ( ! function_exists( 'wp_rand' ) && defined( 'ABSPATH' ) ) {
+			require_once ABSPATH . 'wp-includes/pluggable.php';
+		}
+		if ( ! function_exists( 'wp_rand' ) ) {
+			self::trace( 'send() aborting: wp_rand() unavailable' );
+			return;
+		}
+
 		try {
 			$wpcom_blog_id = _wpcom_get_current_blog_id();
 			if ( ! $wpcom_blog_id ) {

--- a/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
+++ b/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
@@ -142,7 +142,10 @@ class WPCOMSH_Recovery_Mode_Sync {
 		// is often not yet available when we're called from inside WP's fatal-handler
 		// shutdown path (the exact case this feature exists to handle). Load it here.
 		if ( ! function_exists( 'wp_rand' ) && defined( 'ABSPATH' ) ) {
-			require_once ABSPATH . 'wp-includes/pluggable.php';
+			$pluggable_path = ABSPATH . 'wp-includes/pluggable.php';
+			if ( file_exists( $pluggable_path ) ) {
+				require_once $pluggable_path;
+			}
 		}
 		if ( ! function_exists( 'wp_rand' ) ) {
 			self::trace( 'send() aborting: wp_rand() unavailable' );

--- a/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
+++ b/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
@@ -230,8 +230,12 @@ class WPCOMSH_Recovery_Mode_Sync {
 		if ( ! apply_filters( 'wpcomsh_recovery_mode_sync_logging_enabled', false ) ) {
 			return;
 		}
+		static $request_id = null;
+		if ( $request_id === null ) {
+			$request_id = substr( md5( uniqid( '', true ) ), 0, 8 );
+		}
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-		error_log( 'wpcomsh_recovery_mode_sync: ' . $message . ' ' . wp_json_encode( $extra, JSON_UNESCAPED_SLASHES ) );
+		error_log( 'wpcomsh_recovery_mode_sync[' . $request_id . ']: ' . $message . ' ' . wp_json_encode( $extra, JSON_UNESCAPED_SLASHES ) );
 	}
 }
 

--- a/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
+++ b/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
@@ -42,14 +42,7 @@ class WPCOMSH_Recovery_Mode_Sync {
 	private static $payload = null;
 
 	/**
-	 * Register option-change listeners and the PHP shutdown callback.
-	 *
-	 * The shutdown function is registered up front (not lazily) because the
-	 * option writes that trigger a capture often happen from *within* WP's
-	 * own fatal-handler shutdown callback — and `register_shutdown_function`
-	 * called from inside a shutdown callback isn't reliably executed.
-	 * Registering during `init()` guarantees our callback is queued before
-	 * WP's fatal handler runs and so fires after it.
+	 * Register option-change listeners.
 	 */
 	public static function init() {
 		add_action( 'add_option_' . self::EMAIL_LAST_SENT_OPTION, array( __CLASS__, 'capture_email_last_sent' ) );
@@ -62,8 +55,6 @@ class WPCOMSH_Recovery_Mode_Sync {
 		// other type; treating that as a new entry would clobber entered_at.
 		add_action( 'added_option', array( __CLASS__, 'capture_session_start' ), 10, 1 );
 		add_action( 'deleted_option', array( __CLASS__, 'capture_session_end' ), 10, 1 );
-
-		register_shutdown_function( array( __CLASS__, 'send' ) );
 	}
 
 	/**
@@ -76,6 +67,7 @@ class WPCOMSH_Recovery_Mode_Sync {
 			'captured email_last_sent',
 			array( 'value' => self::$payload['recovery_mode_email_last_sent'] )
 		);
+		self::send();
 	}
 
 	/**
@@ -98,6 +90,7 @@ class WPCOMSH_Recovery_Mode_Sync {
 				'entered_at' => $now,
 			)
 		);
+		self::send();
 	}
 
 	/**
@@ -120,17 +113,19 @@ class WPCOMSH_Recovery_Mode_Sync {
 				'exited_at' => $now,
 			)
 		);
+		self::send();
 	}
 
 	/**
-	 * PHP-shutdown callback: POST the current state snapshot to wpcom so the
-	 * signal reaches wpcom even when this request is dying from a fatal.
+	 * POST the current state snapshot to wpcom. Called synchronously from each
+	 * capture listener — we deliberately do *not* defer to a PHP shutdown
+	 * function because option writes that trigger a capture often happen from
+	 * inside WP's own fatal-handler shutdown callback, and shutdown callbacks
+	 * registered at that point (or even earlier) are not reliably invoked on
+	 * the dying request.
 	 */
 	public static function send() {
-		self::trace( 'send() entered' );
-
 		if ( self::$payload === null ) {
-			self::trace( 'send() aborting: null payload' );
 			return;
 		}
 		if ( ! class_exists( Jetpack_Connection_Client::class ) ) {
@@ -166,22 +161,22 @@ class WPCOMSH_Recovery_Mode_Sync {
 			);
 
 			if ( is_wp_error( $response ) ) {
-				WPCOMSH_Log::unsafe_direct_log(
-					'recovery-mode-sync: post returned WP_Error',
+				self::trace(
+					'post returned WP_Error',
 					array( 'error' => $response->get_error_message() )
 				);
 			} else {
 				$code = (int) wp_remote_retrieve_response_code( $response );
 				if ( $code < 200 || $code >= 300 ) {
-					WPCOMSH_Log::unsafe_direct_log(
-						'recovery-mode-sync: post returned non-2xx',
+					self::trace(
+						'post returned non-2xx',
 						array( 'code' => $code )
 					);
 				}
 			}
 		} catch ( \Throwable $e ) {
-			WPCOMSH_Log::unsafe_direct_log(
-				'recovery-mode-sync: post threw',
+			self::trace(
+				'post threw',
 				array( 'exception' => $e->getMessage() )
 			);
 		}

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -146,6 +146,7 @@ require_once __DIR__ . '/feature-plugins/masterbar.php';
 require_once __DIR__ . '/feature-plugins/migrate-guru-canary.php';
 require_once __DIR__ . '/feature-plugins/nav-redesign.php';
 require_once __DIR__ . '/feature-plugins/post-list.php';
+require_once __DIR__ . '/feature-plugins/class-wpcomsh-recovery-mode-sync.php';
 require_once __DIR__ . '/feature-plugins/sensei-pro-mods.php';
 require_once __DIR__ . '/feature-plugins/smtp-email-priority.php';
 require_once __DIR__ . '/feature-plugins/staging-sites.php';


### PR DESCRIPTION
Fixes #

## Proposed changes
* New wpcomsh feature-plugin (`class-wpcomsh-recovery-mode-sync.php`) that captures WordPress recovery-mode option writes and POSTs a state snapshot to `/sites/{blog_id}/recovery-mode-status` on wpcom (endpoint to be created on the wpcom side).
* Three integer timestamps are reported: `recovery_mode_email_last_sent` (written by WP core when a fatal triggers a recovery email), `recovery_session_entered_at` (set on first write to `{session_id}_paused_extensions`, i.e. admin clicked the recovery link), `recovery_session_exited_at` (set on deletion of that option, i.e. admin exited recovery).
* The POST runs **synchronously from each option-change listener**, not via a PHP shutdown function. Recovery option writes commonly happen from inside WP's own fatal-handler shutdown callback, and `register_shutdown_function` called from that point is not reliably invoked — verified empirically via per-request-ID traces showing the capture and the send landed in different requests. Posting synchronously keeps the call inside a known-good stack frame.
* `updated_option` listener for `*_paused_extensions` is intentionally *not* registered: `WP_Paused_Extensions_Storage::delete_all()` rewrites the option via `update_option()` when removing one extension type while entries of the other type remain, which would otherwise clobber `entered_at` to the exit time.
* Because the POST runs from inside the fatal-handler shutdown path, the Jetpack Connection Client's signing helpers (`wp_rand()` / `wp_generate_password()`) may not be available yet — `pluggable.php` is loaded late in WP bootstrap. The class guards `function_exists( 'wp_rand' )`, requires `ABSPATH . 'wp-includes/pluggable.php'` when needed (with a `file_exists` guard), and aborts cleanly if signing primitives are still unavailable.

These three fields let wpcom-side consumers compute a full state machine (Needs recovery / In recovery / Recently recovered / Expired unresolved / Healthy) without requiring any history tracking on their side.

## Observability
* Diagnostic traces are emitted through a filter-gated helper (`self::trace()`), matching the `migrate-guru-canary.php` pattern. Off by default. Flip per-site via:
  ```php
  add_filter( 'wpcomsh_recovery_mode_sync_logging_enabled', '__return_true' );
  ```
* Traces tag each line with an 8-hex-char per-request ID so the capture line and the corresponding POST line can be correlated across interleaved log output.
* Captured events, POST payload, non-2xx responses, `WP_Error` responses, exceptions, and each abort reason (missing class, missing helper, falsy blog id, missing `wp_rand`) are all traced.

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
Yes. Three integer timestamps describing the site's recovery-mode state are POSTed to wpcom:

* `recovery_mode_email_last_sent` — Unix timestamp of WP's last recovery email send.
* `recovery_session_entered_at` — Unix timestamp of when an admin last entered recovery mode.
* `recovery_session_exited_at` — Unix timestamp of when an admin last exited recovery mode.

No content, error messages, recovery tokens/keys, or user identifiers are sent. Payload is three `int` fields. Data applies only to sites running wpcomsh (wpcom Atomic).

## Testing instructions
1. Deploy this branch to an Atomic test site (e.g. `jetpack rsync plugins/wpcomsh <site>`).
2. Install a plugin that fatals on load (e.g. a regular plugin that calls `trigger_error( 'boom', E_USER_ERROR );`) and activate it.
3. (Optional, for verifying traces) add a must-use plugin with `add_filter( 'wpcomsh_recovery_mode_sync_logging_enabled', '__return_true' );` and `tail -f` the PHP-FPM error log.
4. Visit the front-end once to trigger WP's fatal-error handler. WP sends a recovery email.
5. Confirm an outbound POST to `/sites/<blog_id>/recovery-mode-status` containing `recovery_mode_email_last_sent` with a fresh timestamp. If traces are on, expect lines like `wpcomsh_recovery_mode_sync[<id>]: captured email_last_sent …` immediately followed by `wpcomsh_recovery_mode_sync[<id>]: posting state …` with a matching request ID.
6. Click the recovery link in the email. Confirm another POST fires, now with `recovery_session_entered_at` populated and `recovery_mode_email_last_sent` unchanged.
7. Exit recovery mode via the admin bar button. Confirm a third POST fires, with `recovery_session_exited_at` populated and `recovery_session_entered_at` **unchanged** (regression test for the `delete_all()` clobber).
8. Load a normal page (no fatal). Confirm no outbound POST — the listener only runs when a recovery option was written.

Note: the wpcom-side endpoint `POST /sites/{blog_id}/recovery-mode-status` must exist to accept the payload. Until it lands, requests will 404 server-side but wpcomsh behavior is still exercised and observable locally.