### PR TITLE
Fix block description links breaking inserter search by adding toString fallback

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-add-block-description-links-to-string
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-add-block-description-links-to-string
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix block description links breaking inserter search by adding `toString` fallback.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/index.tsx
@@ -26,9 +26,8 @@ const createLocalizedDescriptionWithLearnMore = (
 	} );
 
 	// When the description is used as a string (e.g. inserter search), fall back to the original text.
-	element.toString = () => String( description );
-
-	return element;
+	// React elements are frozen in dev mode, so we spread into a new object.
+	return { ...element, toString: () => String( description ) };
 };
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/index.tsx
@@ -17,13 +17,18 @@ const createLocalizedDescriptionWithLearnMore = (
 	postId: number
 ) => {
 	const localizedUrl = localizeUrl( url );
-	return createInterpolateElement( '<InlineSupportLink />', {
+	const element = createInterpolateElement( '<InlineSupportLink />', {
 		InlineSupportLink: (
 			<DescriptionSupportLink title={ String( title ) } url={ localizedUrl } postId={ postId }>
 				{ description }
 			</DescriptionSupportLink>
 		),
 	} );
+
+	// When the description is used as a string (e.g. inserter search), fall back to the original text.
+	element.toString = () => String( description );
+
+	return element;
 };
 
 /**


### PR DESCRIPTION
Fixes #

## Proposed changes

* Add a `toString` method to the React element returned by `createLocalizedDescriptionWithLearnMore`, so that when the block description is coerced to a string (e.g. during inserter search), it returns the original plain-text description instead of `[object Object]`.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Open the block inserter in the WordPress editor.
* Search for a block that has a "Learn more" support link in its description (e.g. `core/freeform` block should be returned when searching for `editor`).
* Verify the block appears in search results - previously the search would fail to match because the description was `[object Object]`.