### PR TITLE
Google Fonts: hide My Jetpack toggle unless active, update description

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/utils.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/utils.ts
@@ -2,8 +2,16 @@ import { getScriptData } from '@automattic/jetpack-script-data';
 import { __ } from '@wordpress/i18n';
 import { JETPACK_PRODUCTS_NOT_FOR_MULTISITE } from '../../../constants';
 import { ProductCamelCase } from '../../../data/types';
-import { MyJetpackModule } from '../../../types';
+import { JetpackModuleSlug, MyJetpackModule } from '../../../types';
 import { ProductFilter, ProductSection } from './types';
+
+/**
+ * Legacy modules that should only appear in the module list when they are already active.
+ * New users will not see these modules; existing users keep the ability to deactivate them.
+ */
+const LEGACY_MODULES_VISIBLE_ONLY_WHEN_ACTIVE: readonly string[] = [
+	'google-fonts' satisfies JetpackModuleSlug,
+];
 
 /**
  * Get the choices for the products filter.
@@ -119,7 +127,9 @@ export function filterSections(
 export function filterAndSortModules(
 	modules: Array< MyJetpackModule >
 ): Array< MyJetpackModule > {
-	const $modules = [ ...modules ].filter( Boolean );
+	const $modules = [ ...modules ]
+		.filter( Boolean )
+		.filter( m => ! LEGACY_MODULES_VISIBLE_ONLY_WHEN_ACTIVE.includes( m.module ) || m.activated );
 
 	$modules.sort( ( a, b ) => a.name.localeCompare( b.name ) );
 

--- a/projects/packages/my-jetpack/changelog/remove-my-jetpack-google-fonts-toggle
+++ b/projects/packages/my-jetpack/changelog/remove-my-jetpack-google-fonts-toggle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: hide the Google Fonts module toggle unless the module is already active.

--- a/projects/plugins/jetpack/changelog/remove-my-jetpack-google-fonts-toggle
+++ b/projects/plugins/jetpack/changelog/remove-my-jetpack-google-fonts-toggle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Google Fonts: update module description to note native WordPress support.

--- a/projects/plugins/jetpack/modules/google-fonts.php
+++ b/projects/plugins/jetpack/modules/google-fonts.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Module Name: Google Fonts (Beta)
- * Module Description: Customize your site's typography with a selection of Google Fonts.
+ * Module Description: This feature is now supported natively in WordPress when using any block theme. To use Google Fonts, refer to the WordPress.org Font Library documentation.
  * Sort Order: 1
  * Recommendation Order: 2
  * First Introduced: 10.8.0


### PR DESCRIPTION
Fixes JETPACK-1533

## Proposed changes
* My Jetpack: add a `LEGACY_MODULES_VISIBLE_ONLY_WHEN_ACTIVE` filter in `filterAndSortModules` so legacy modules (currently just `google-fonts`) only appear in the module list when already active. Users who already have the module on keep the ability to deactivate it; new users never see the toggle.
* Jetpack: update the Google Fonts module description to make it clear that the feature is now supported natively in WordPress when using any block theme, and point users to the WordPress.org Font Library documentation.

## Related product discussion/links
* JETPACK-1533

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Start from a site where the Google Fonts module is **inactive** (default).
* Open **Jetpack → My Jetpack**, switch to the **Other** category or scroll the free module list. Confirm the Google Fonts toggle is **not** displayed, and is not returned when searching for "Google Fonts" or "fonts".
* Activate the Google Fonts module (via WP-CLI: `wp jetpack module activate google-fonts`, or by re-enabling the filter temporarily).
* Reload My Jetpack. Confirm the Google Fonts toggle **is** now displayed, with the updated description:
  > *"This feature is now supported natively in WordPress when using any block theme. To use Google Fonts, refer to the WordPress.org Font Library documentation."*
* Confirm deactivating the module from that toggle works as before, and that after deactivation + reload, the toggle disappears again.