### PR TITLE
SEO: Pre-filter Content screen from Overview deep-links

### DIFF
--- a/projects/packages/seo/_inc/data/use-seo-posts.ts
+++ b/projects/packages/seo/_inc/data/use-seo-posts.ts
@@ -7,6 +7,11 @@ import type { SeoPostsResponse, SeoPostUpdatePayload } from './content-types';
 interface UseSeoPostsArgs {
 	postType?: string;
 	status?: string;
+	/**
+	 * Filter by computed SEO tier — any combination of 'good', 'fair',
+	 * 'poor'. Passed as a comma-separated `seo_status` query arg.
+	 */
+	seoStatus?: string[];
 	page?: number;
 	perPage?: number;
 	search?: string;
@@ -19,6 +24,9 @@ export const useSeoPosts = ( args: UseSeoPostsArgs ) => {
 		page: String( args.page ?? 1 ),
 		per_page: String( args.perPage ?? 20 ),
 		...( args.search ? { search: args.search } : {} ),
+		...( args.seoStatus && args.seoStatus.length > 0
+			? { seo_status: args.seoStatus.join( ',' ) }
+			: {} ),
 	};
 	const path = addQueryArgs( `/${ REST_NAMESPACE }/posts`, query );
 	return useSimpleQuery< SeoPostsResponse >( {

--- a/projects/packages/seo/_inc/screens/content/index.tsx
+++ b/projects/packages/seo/_inc/screens/content/index.tsx
@@ -2,9 +2,10 @@
 
 import { Notice, Spinner } from '@wordpress/components';
 import { DataViews } from '@wordpress/dataviews';
-import { useMemo, useState } from '@wordpress/element';
+import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
+import { useSearchParams } from 'react-router';
 import { useSeoPosts } from '../../data/use-seo-posts';
 import SerpPreviewModal, { type SerpPreviewPayload } from '../shared/serp-preview-modal';
 import EditSeoModal from './edit-seo-modal';
@@ -37,15 +38,61 @@ const DEFAULT_VIEW: View = {
 	titleField: 'title',
 };
 
+const isSeoStatus = ( value: string | null ): value is SeoStatus =>
+	value === 'good' || value === 'fair' || value === 'poor';
+
 const ContentScreen: FC = () => {
-	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
+	const [ searchParams ] = useSearchParams();
+	// Seed the initial view from a `?status=good|fair|poor` query param so
+	// the Overview's Content SEO health card can deep-link to a pre-filtered
+	// list. Captured at mount only — users can clear the filter afterwards.
+	const [ view, setView ] = useState< View >( () => {
+		const initialStatus = searchParams.get( 'status' );
+		if ( ! isSeoStatus( initialStatus ) ) {
+			return DEFAULT_VIEW;
+		}
+		return {
+			...DEFAULT_VIEW,
+			filters: [ { field: 'seo_status', operator: 'isAny', value: [ initialStatus ] } ],
+		};
+	} );
 	const [ editItem, setEditItem ] = useState< SeoPostItem | null >( null );
 	const [ previewItem, setPreviewItem ] = useState< SeoPostItem | null >( null );
+
+	// Pull the user's current `seo_status` filter out of the DataViews
+	// view so we can forward it to the REST endpoint. The endpoint post-
+	// filters on the computed tier — DataViews alone would just hide rows
+	// from the client page without re-fetching.
+	const seoStatusFilter = view.filters?.find( filter => filter.field === 'seo_status' )?.value as
+		| string[]
+		| undefined;
+
+	// DataViews keeps the filter bar visibility in private internal state
+	// (only auto-opens for `isPrimary` filters, which also locks the
+	// toggle). When we arrive pre-filtered via `/content?status=…` we
+	// still want the chip visible on first paint, so we simulate a click
+	// on DataViews' own visibility toggle once. The toggle stays live
+	// after, so the user can collapse the bar normally.
+	const screenRef = useRef< HTMLDivElement >( null );
+	const hasOpenedFiltersRef = useRef( false );
+	useEffect( () => {
+		if ( hasOpenedFiltersRef.current || ! seoStatusFilter?.length ) {
+			return;
+		}
+		const toggle = screenRef.current?.querySelector< HTMLButtonElement >(
+			'.dataviews-filters__visibility-toggle'
+		);
+		if ( toggle && toggle.getAttribute( 'aria-pressed' ) !== 'true' ) {
+			toggle.click();
+			hasOpenedFiltersRef.current = true;
+		}
+	}, [ seoStatusFilter ] );
 
 	const { data, isLoading, isError, error } = useSeoPosts( {
 		page: view.page ?? 1,
 		perPage: view.perPage ?? 20,
 		search: view.search,
+		seoStatus: seoStatusFilter,
 	} );
 
 	const fields: Field< SeoPostItem >[] = useMemo(
@@ -172,7 +219,7 @@ const ContentScreen: FC = () => {
 	return (
 		<>
 			{ isLoading && ! data && <Spinner /> }
-			<div className={ styles.dataviewsWrapper }>
+			<div className={ styles.dataviewsWrapper } ref={ screenRef }>
 				<DataViews< SeoPostItem >
 					data={ items }
 					fields={ fields }

--- a/projects/packages/seo/_inc/screens/content/style.module.scss
+++ b/projects/packages/seo/_inc/screens/content/style.module.scss
@@ -14,16 +14,19 @@
 	border-radius: 50%;
 }
 
+// WPDS decorative-icon tokens — same rail as the Overview's SeverityDot
+// and the Content SEO health card bullets, so Good/Fair/Poor read the
+// same colour everywhere.
 .trafficGood {
-	background: #4ab866;
+	background: var(--wpds-color-fg-content-success-weak, #007f30);
 }
 
 .trafficFair {
-	background: #dba617;
+	background: var(--wpds-color-fg-content-warning-weak, #926300);
 }
 
 .trafficPoor {
-	background: #cc1818;
+	background: var(--wpds-color-fg-content-error-weak, #cc1818);
 }
 
 .field {
@@ -55,11 +58,11 @@
 .dataviewsWrapper {
 	display: flex;
 	flex-direction: column;
-	height: calc( 100vh - 200px );
+	height: calc(100vh - 200px);
 	min-height: 480px;
 
 	// DataViews uses an internal flex layout; give it room to breathe.
-	:global( .dataviews-wrapper ) {
+	:global(.dataviews-wrapper) {
 		flex: 1;
 		min-height: 0;
 	}

--- a/projects/packages/seo/changelog/content-prefilter-links
+++ b/projects/packages/seo/changelog/content-prefilter-links
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+SEO: The Content screen accepts a `?status=good|fair|poor` query arg that pre-filters the DataViews table to the matching SEO tier, and the `/posts` REST endpoint now accepts a `seo_status` arg to filter results by the same computed tier.

--- a/projects/packages/seo/src/class-rest-controller.php
+++ b/projects/packages/seo/src/class-rest-controller.php
@@ -49,27 +49,35 @@ class REST_Controller {
 				'callback'            => array( __CLASS__, 'get_posts' ),
 				'permission_callback' => array( __CLASS__, 'permissions_check' ),
 				'args'                => array(
-					'post_type' => array(
+					'post_type'  => array(
 						'type'    => 'string',
 						'default' => 'post',
 					),
-					'status'    => array(
+					'status'     => array(
 						'type'    => 'string',
 						'default' => 'publish,draft',
 					),
-					'per_page'  => array(
+					'per_page'   => array(
 						'type'    => 'integer',
 						'default' => 20,
 						'minimum' => 1,
 						'maximum' => 100,
 					),
-					'page'      => array(
+					'page'       => array(
 						'type'    => 'integer',
 						'default' => 1,
 						'minimum' => 1,
 					),
-					'search'    => array(
+					'search'     => array(
 						'type' => 'string',
+					),
+					// Comma-separated list of computed-status tiers to keep —
+					// e.g. `good,fair` or `poor`. Matches the filter values on
+					// the Content DataViews screen and the Overview's Content
+					// SEO health card.
+					'seo_status' => array(
+						'type'    => 'string',
+						'default' => '',
 					),
 				),
 			)
@@ -230,11 +238,64 @@ class REST_Controller {
 	 * @return WP_REST_Response
 	 */
 	public static function get_posts( WP_REST_Request $request ) {
-		$post_type = (string) $request->get_param( 'post_type' );
-		$status    = array_filter( array_map( 'trim', explode( ',', (string) $request->get_param( 'status' ) ) ) );
-		$per_page  = max( 1, min( 100, (int) $request->get_param( 'per_page' ) ) );
-		$page      = max( 1, (int) $request->get_param( 'page' ) );
-		$search    = (string) $request->get_param( 'search' );
+		$post_type    = (string) $request->get_param( 'post_type' );
+		$status       = array_filter( array_map( 'trim', explode( ',', (string) $request->get_param( 'status' ) ) ) );
+		$per_page     = max( 1, min( 100, (int) $request->get_param( 'per_page' ) ) );
+		$page         = max( 1, (int) $request->get_param( 'page' ) );
+		$search       = (string) $request->get_param( 'search' );
+		$status_param = (string) $request->get_param( 'seo_status' );
+		$seo_filter   = array_values(
+			array_filter(
+				array_map( 'trim', explode( ',', $status_param ) ),
+				static function ( $tier ) {
+					return in_array( $tier, array( 'good', 'fair', 'poor' ), true );
+				}
+			)
+		);
+
+		// `seo_status` is computed per-post (title/description length plus
+		// noindex), so it cannot be pushed down into WP_Query. When a filter
+		// is supplied we fetch a bounded page of candidates, compute each
+		// status, then paginate the filtered slice in PHP.
+		if ( count( $seo_filter ) > 0 ) {
+			$candidate_args = array(
+				'post_type'      => $post_type,
+				'post_status'    => $status,
+				// Matches the cap used by the Overview content-stats
+				// counter — high enough for nearly every real site, low
+				// enough to keep the dashboard snappy.
+				'posts_per_page' => 500, // phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page -- Bounded cap, documented above.
+				'no_found_rows'  => false,
+				'orderby'        => 'date',
+				'order'          => 'DESC',
+			);
+			if ( '' !== $search ) {
+				$candidate_args['s'] = $search;
+			}
+
+			$candidate_query = new \WP_Query( $candidate_args );
+			$matching        = array();
+			foreach ( $candidate_query->posts as $post ) {
+				$item = self::map_post_to_item( $post );
+				if ( in_array( $item['seo_status'], $seo_filter, true ) ) {
+					$matching[] = $item;
+				}
+			}
+
+			$total    = count( $matching );
+			$max_page = max( 1, (int) ceil( $total / $per_page ) );
+			$offset   = ( $page - 1 ) * $per_page;
+			$window   = array_slice( $matching, $offset, $per_page );
+
+			return new WP_REST_Response(
+				array(
+					'items' => $window,
+					'total' => $total,
+					'pages' => $max_page,
+					'page'  => $page,
+				)
+			);
+		}
 
 		$query_args = array(
 			'post_type'      => $post_type,
@@ -611,7 +672,7 @@ class REST_Controller {
 			array(
 				'post_type'      => array_values( $post_types ),
 				'post_status'    => 'publish',
-				'posts_per_page' => 500,
+				'posts_per_page' => 500, // phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page -- Bounded cap, documented above.
 				'fields'         => 'ids',
 			)
 		);


### PR DESCRIPTION
## Proposed changes

* The Overview's Content SEO health card deep-links to `/content?status=good|fair|poor`. The Content screen now reads that query arg on mount and seeds the DataViews filter to the matching SEO tier.
* A one-shot effect simulates a click on DataViews' own visibility toggle so the Status chip is visible on arrival — without marking the filter as primary (which would lock the toggle). Toggle stays fully interactive afterwards.
* **Backend:** `/jetpack-seo/v1/posts` accepts a comma-separated `seo_status` arg. Since the tier is computed per-post and cannot be pushed into a `WP_Query` `meta_query`, the endpoint fetches up to 500 candidates, computes `seo_status` for each, and paginates the filtered slice in PHP.
* Aligns the Content traffic-light dot colours with the same WPDS decorative-icon tokens (`--wpds-color-fg-content-{success,warning,error}-weak`) used by the Overview severity dots so Good / Fair / Poor read identically across both screens.

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Visit the Overview; click **View** on any Content SEO health bucket.
* Confirm the Content screen loads with the Status filter chip showing the selected tier and the table showing only posts in that tier.
* Click the chip's close (×) — filter clears and all posts return.
* Toggle the filter bar via the funnel button — bar collapses and expands normally (primary-lock is off).
* Manually visit `/content?status=fair` and `/content?status=poor` to confirm each tier filters correctly.
* Open the Content page without a query arg — loads unfiltered as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)