### PR TITLE
premium-analytics: add pie chart with mock data to dashboard route

### DIFF
--- a/docs/agent-boundaries.md
+++ b/docs/agent-boundaries.md
@@ -1,0 +1,66 @@
+# Agent Boundaries for Premium Analytics
+
+This document defines what AI agents may and may not change inside
+`projects/packages/premium-analytics`.
+
+## Purpose
+
+`premium-analytics` is currently a full-page SPA rendered inside `wp-admin`.
+The package bootstraps through `wp-build`, `@wordpress/boot`, and route-based
+code splitting. Agents must preserve those runtime assumptions.
+
+## Allowed Changes
+
+Agents MAY:
+
+- add or modify route modules under `routes/**`
+- update UI code in `routes/**/stage.tsx`
+- update package-local initialization code under `packages/init/**`
+- update `src/class-analytics.php` when preserving the page boot contract
+- add package-local docs, tests, and non-generated source files
+- refine copy, localization calls, and presentational components
+
+## Restricted Changes
+
+Agents MUST NOT, without explicit human approval:
+
+- change the page id `jetpack-premium-analytics`
+- change the admin page slug `jetpack-premium-analytics`
+- remove the boot asset shim copy step from package build scripts
+- delete or bypass `packages/init/` if boot dependency tracking still relies on it
+- edit generated files inside `build/`
+- introduce new backend data contracts that are not documented first
+- assume undocumented REST endpoints, stores, selectors, or analytics schemas exist
+- modify cross-package or monorepo-wide build behavior from this package alone
+
+## Required Preservation Rules
+
+Agents MUST preserve the following invariants:
+
+1. The package remains a full-page SPA in `wp-admin`.
+2. Route discovery continues to happen via route metadata in `package.json`.
+3. The PHP entry continues loading the generated build entry when present.
+4. The admin menu page remains booted by the build/runtime path rather than by a custom PHP page renderer.
+5. Sidebar items must correspond to actual route paths.
+
+## Escalate to Human Review When
+
+Agents MUST stop and request human review before:
+
+- changing page identity, slug, or boot sequence
+- changing build/runtime dependency assumptions around `@wordpress/boot`
+- removing the shim workaround
+- introducing data fetching or persistence layers
+- adding analytics semantics such as metric definitions, aggregation rules, or retention behavior
+- changing permissions or capability requirements
+- changing integration points with other Jetpack packages
+
+## Generated Artifacts
+
+`build/` is generated output and must never be manually edited.
+Agents should change source files and rebuild instead.
+
+## Safe Default
+
+If an agent is unsure whether a change affects runtime bootstrapping,
+route discovery, or admin page registration, it must not proceed automatically.

--- a/docs/agent-metrics.md
+++ b/docs/agent-metrics.md
@@ -1,0 +1,56 @@
+# Agent Metrics for Premium Analytics
+
+This document defines how to measure the effectiveness of the agent
+governance system for `projects/packages/premium-analytics`.
+
+## Core Metric
+
+**Agent Clean Rate = Clean sessions / (Clean + Violation sessions)**
+
+Target: Violation count trends toward zero over time.
+
+Session outcomes are classified as:
+
+| Outcome | Definition |
+|---------|------------|
+| Clean | Agent completed the task within contract bounds; PR merged without significant rework |
+| Escalated | Agent correctly stopped and requested human review |
+| Violation | Agent breached a contract rule (edited a restricted file, invented a data layer, etc.) |
+
+Escalated sessions are expected behavior and do not count against the Clean Rate.
+
+## Per-PR Session Report
+
+Every agent-generated PR must include the following block in its description:
+
+```
+## Agent Session Report
+- Scope respected: yes / no
+- Escalations triggered: N
+- Contract violations: none / [describe]
+- Human rework needed: none / minor / major
+```
+
+This requires no tooling. Data lives in PR history and can be audited at any time.
+
+## Post-Launch Dashboard Metric
+
+**Routes shipped per sprint — agent-assisted vs. manual**
+
+This metric is suitable for a team dashboard because:
+
+- routes have a well-defined contract, making comparisons fair
+- it reflects real product velocity, not just process compliance
+- it remains meaningful as the package grows
+
+## Feedback Loop
+
+Review the session reports at the end of each sprint.
+
+Ask:
+
+- Did any Violation reveal a gap in the contract docs?
+- Did any Escalation turn out to be unnecessary? (contract may be too conservative)
+- Is human rework concentrated in a specific area? (likely needs a new contract rule)
+
+Update the relevant contract doc when a pattern is found.

--- a/docs/build-runtime-contract.md
+++ b/docs/build-runtime-contract.md
@@ -1,0 +1,77 @@
+# Build and Runtime Contract for Premium Analytics
+
+This document defines the required build and runtime behavior for
+`projects/packages/premium-analytics`.
+
+## Current Runtime Model
+
+The package depends on a runtime chain like this:
+
+1. PHP entry initializes package
+2. generated `build/build.php` registers the boot and interceptor behavior
+3. `@wordpress/boot` provides the full-page shell
+4. routes are discovered and lazy-loaded from metadata
+
+Agents must preserve this model unless there is explicit architectural approval.
+
+## Build Script Requirements
+
+The package build scripts MUST preserve the post-build shim copy step that places
+the boot asset shim at:
+
+`build/modules/boot/index.min.asset.php`
+
+This is part of the package's build behavior and must not be silently removed.
+
+## Shim Rule
+
+`shims/boot-asset.php` is a compatibility workaround.
+
+Agents MUST NOT remove it unless all of the following are confirmed:
+
+- the generated template no longer depends on that asset file
+- target WordPress and runtime support make the workaround unnecessary
+- the package has been validated without blank-page regressions
+
+## Init Module Rule
+
+`packages/init/` exists for runtime reasons, not just organization.
+
+Agents MUST treat it as part of the boot contract until proven otherwise.
+
+It currently serves to:
+
+- configure boot-time UI state such as menu icon behavior
+- ensure build and runtime dependency tracking includes boot-related modules
+
+Agents MUST NOT remove or bypass the init module without validating that
+boot dependencies are still correctly tracked and loaded.
+
+## Dependency Upgrade Rule
+
+Human review is required before changing any of these package dependencies:
+
+- `@wordpress/build`
+- `@wordpress/boot`
+- `@wordpress/route`
+
+Reason:
+small version shifts may change template behavior, module resolution, or boot expectations.
+
+## Generated Output Rule
+
+Agents MUST NOT edit:
+
+- `build/**`
+
+All build artifacts must be regenerated from source.
+
+## Definition of Done for Build-Sensitive Changes
+
+A build-sensitive change is complete only if:
+
+- package build succeeds
+- generated app still opens in `wp-admin`
+- the page does not render blank
+- route navigation still works
+- no shim-dependent regression is introduced

--- a/docs/route-contract.md
+++ b/docs/route-contract.md
@@ -1,0 +1,140 @@
+# Route Contract for Premium Analytics
+
+This document defines the required contract for routes in
+projects/packages/premium-analytics/routes
+
+---
+
+## Why This Exists
+
+Routes are discovered from package.json metadata and lazy-loaded into the
+full-page SPA shell.
+
+A route is not valid unless BOTH metadata and implementation exist.
+
+---
+
+## Required Route Structure
+
+Each route MUST live in:
+
+routes/<route-name>/
+
+Each route directory MUST contain:
+
+* package.json
+* stage.tsx
+
+---
+
+## Required package.json Metadata
+
+Each route package.json MUST include:
+
+* "private": true
+* "name": "<unique-route-package-name>"
+* "route.path": "<path>"
+* "route.page": "jetpack-premium-analytics"
+
+Example:
+
+{
+"private": true,
+"name": "_@jetpack-premium-analytics/example-route",
+"route": {
+"path": "/example",
+"page": "jetpack-premium-analytics"
+}
+}
+
+---
+
+## Required stage.tsx Export
+
+Each route MUST export:
+
+stage()
+
+Example:
+
+import React from 'react';
+
+export const stage = () => {
+return <div>Example Route</div>;
+};
+
+---
+
+## Path Rules
+
+Routes MUST:
+
+* use unique route.path values
+* use leading slashes (e.g. /dashboard, /reports)
+* map ONLY to page id jetpack-premium-analytics
+
+Routes MUST NOT:
+
+* duplicate another route path
+* register a different page id
+* omit the route metadata block
+* rely on side effects instead of exporting stage()
+
+---
+
+## Route-to-Sidebar Consistency
+
+If a route is navigable, sidebar items MUST match the route path.
+
+Example:
+
+* sidebar key: dashboard
+* label: Dashboard
+* path: /
+
+---
+
+## Adding a New Route (Agent Procedure)
+
+1. Create directory under routes/<route-name>/
+2. Add package.json with valid route metadata
+3. Implement stage.tsx
+4. Run build
+5. Verify route loads in SPA
+6. (Optional) Add sidebar entry
+
+---
+
+## Definition of Done
+
+A route is complete ONLY if:
+
+* metadata exists and is valid
+* stage() is exported
+* build succeeds
+* route loads correctly
+* no duplicate paths exist
+* sidebar (if any) matches path
+* loading / empty / error states defined (if data exists)
+
+---
+
+## Validation Rules
+
+Agents MUST validate:
+
+* JSON syntax in package.json
+* valid TS/JS in stage.tsx
+* stage() export exists
+* no runtime errors
+
+---
+
+## Escalation Rules
+
+Agents MUST request human review before:
+
+* modifying existing route paths
+* renaming routes used externally
+* changing route.page
+* adding dynamic routing

--- a/docs/ui-scope-contract.md
+++ b/docs/ui-scope-contract.md
@@ -1,0 +1,65 @@
+# UI Scope Contract for Premium Analytics
+
+This document defines what the current UI layer may assume.
+
+## Current Scope
+
+At present, this package should be treated as an application shell with a minimal
+dashboard route.
+
+Agents MUST assume:
+
+- route wiring exists
+- page bootstrapping exists
+- localization usage exists
+
+Agents MUST NOT assume, unless documented elsewhere in this package:
+
+- a stable analytics REST API exists
+- a premium analytics data schema exists
+- chart-ready selectors or stores exist
+- canonical metric definitions already exist
+- retention, aggregation, or segmentation rules already exist
+
+## No Invented Data Layer
+
+Agents MUST NOT invent:
+
+- endpoints
+- stores
+- selectors
+- event models
+- metrics
+- feature flags
+
+If a change requires data, the agent must first add a documented data contract.
+
+## Required States for Data-Backed UI
+
+If a route introduces data fetching, it MUST explicitly define:
+
+- source of truth
+- request lifecycle
+- loading state
+- empty state
+- error state
+- retry behavior, if applicable
+
+## Copy and Product Semantics Rule
+
+Agents MUST keep UI copy aligned with implemented functionality.
+
+Agents MUST NOT:
+
+- claim that analytics metrics exist when they do not
+- imply premium features are active when not implemented
+- describe insights, trends, or reports without backing logic
+
+## Definition of Done for New UI Features
+
+A new UI feature is complete only if:
+
+- the route renders correctly
+- all required user-visible states are defined
+- text does not overstate backend capability
+- any new data dependency is documented in a dedicated contract file

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3462,6 +3462,9 @@ importers:
 
   projects/packages/premium-analytics:
     dependencies:
+      '@automattic/charts':
+        specifier: ^1.1.1
+        version: 1.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.7.0)
       '@wordpress/boot':
         specifier: 0.10.0
         version: 0.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.7.0)
@@ -6274,6 +6277,13 @@ packages:
   '@automattic/calypso-url@1.1.0':
     resolution: {integrity: sha512-oA6pzfrp538gq5JEjE0ARDjvR8Efhw+jrK15TJPjAq5Q+vhPSJhH8sYKEsMAoYZV3d5nnyUcmI5Evge+yq4zeg==}
 
+  '@automattic/charts@1.2.0':
+    resolution: {integrity: sha512-Ip9o/FfFxU7//i3XGi0I1kpvBXzMwE6ViYRAy0u5Lqzkp+7gfd3RVpiQmNKXRO9DgCLVqdtr1Pw2FULY1BGmkQ==}
+    engines: {node: '>=20.11.0'}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0
+      react-dom: ^17.0.0 || ^18.0.0
+
   '@automattic/color-studio@4.1.0':
     resolution: {integrity: sha512-1iWNsCHANeVDjBeXnlslaf7zoWheGbFxGDYu/cXj5FhV6TJBm2QF4KzHfQ7FDinkJCPpL0IbZpnXzpn0IZudxA==}
 
@@ -6339,6 +6349,9 @@ packages:
 
   '@automattic/number-formatters@1.1.5':
     resolution: {integrity: sha512-k8jUWruDm0mrJDFlCbQL/KaCv13tz17/TmtUMfRbeM+7eHNhIXf8AwxCxlF+S0TNE/K4ri0L4rQF7iq+wJTbHg==}
+
+  '@automattic/number-formatters@1.1.6':
+    resolution: {integrity: sha512-IJ6wqb7Tkrcm7r3vO6Rr3QO/MFiqfajwHoSSwCSiBCXHDF3i8f/lMX6qkKgx4xIgVl199iTdWt4zEYyNsK7Sqw==}
 
   '@automattic/oauth-token@1.0.1':
     resolution: {integrity: sha512-do7/iKRiciU8ybEoqsrS3kcPux8Bs7+xslYJ/EhBVzdIPLP3Cn2BysEMhYkKDOSnoUhvRJi7Y9cCaoRuUIgYJw==}
@@ -7030,8 +7043,35 @@ packages:
       '@types/react':
         optional: true
 
+  '@base-ui/react@1.4.1':
+    resolution: {integrity: sha512-Ab5/LIhcmL8BQcsBUYiOfkSDRdLpvgUBzMK30cu684JPcLclYlztharvCZyNNgzJtbAiREzI9q0pI5erHCMgCw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@date-fns/tz': ^1.2.0
+      '@types/react': ^17 || ^18 || ^19
+      date-fns: ^4.0.0
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@date-fns/tz':
+        optional: true
+      '@types/react':
+        optional: true
+      date-fns:
+        optional: true
+
   '@base-ui/utils@0.2.6':
     resolution: {integrity: sha512-yQ+qeuqohwhsNpoYDqqXaLllYAkPCP4vYdDrVo8FQXaAPfHWm1pG/Vm+jmGTA5JFS0BAIjookyapuJFY8F9PIw==}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@base-ui/utils@0.2.8':
+    resolution: {integrity: sha512-jvOi+c+ftGlGotNcKnzPVg2IhCaDTB6/6R3JeqdjdXktuAJi3wKH9T7+svuaKh1mmfVU11UWzUZVH74JDfi/wQ==}
     peerDependencies:
       '@types/react': ^17 || ^18 || ^19
       react: ^17 || ^18 || ^19
@@ -10315,6 +10355,10 @@ packages:
     resolution: {integrity: sha512-AWNmSi+Cjx5m03JhG/XjDqgRufqCFcIpYddWw7/0vR6rMk/DK5O+Jx6yJcJOwgmz2KFSgjMnjFfqbh3EtX8rRg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/a11y@4.44.0':
+    resolution: {integrity: sha512-VewBVprbT10DnsIbIamtBXz5jVlwI+nRroXkYsRbYJq63h/dHkD2nnOObIbIdFfMi5m33fwcs1a3v93vqs8WMQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/admin-ui@1.11.0':
     resolution: {integrity: sha512-9kgXCvAVqTLImGjKH1Q8gRLB69cEYbI6NWcJfgkfLCcMyIBFPKV86jcp/IfXQekWxHg5YTa5i8MkmWL67NnEHw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -10431,6 +10475,12 @@ packages:
     peerDependencies:
       react: ^18.0.0
 
+  '@wordpress/compose@7.44.0':
+    resolution: {integrity: sha512-NlMSR+sqEkHppjUM3irJhB0PLaWYoAgWFa7BL6xb94ciWxr4C5CIB0pSCXW8B0WNBPgS7q/xCeJGKGSfLkBgIQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
   '@wordpress/core-data@7.43.0':
     resolution: {integrity: sha512-18YOgbce1nwWN5FFXZ/qMdKlejAAYJI7gyp6EdIbo+ivnrfHL1YT41C3rzbQWw4QsjDF/Zvludb8M81OpA/mUQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -10470,12 +10520,24 @@ packages:
     resolution: {integrity: sha512-Pxn+nUmCVAaKBiZun2tEVweVdevMvWFWyCRqIqsAKdWCLsD8Uk6o27EwXc1u8BlO65VmK8D2zF9uWKGKfdZbCw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/deprecated@4.44.0':
+    resolution: {integrity: sha512-Yb2kPVP3vJnuJ87sQqWqt/QzRglEkXL6IJ1TnSyXKv7Jqke2Bh2UmSGLFn86e3ZHIbGkzRUYb5ZPGzaePPrQFQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/dom-ready@4.43.0':
     resolution: {integrity: sha512-Y3oNeAdVzw9tACCgL7HuimhpSlhdU5RfRGtLp2kgewWHl5I6tzfi7XypG7FdBmS+dI+j2SaYYdTNPen/kFsZlA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/dom-ready@4.44.0':
+    resolution: {integrity: sha512-YSiDpmelYLgFu0/Mki9OogEDO5t8Dr1pZnJU/RYRC7aawWGxidgNr0hael+9jO6pLAd+3LiAEV5cAvLg0V1pZQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/dom@4.43.0':
     resolution: {integrity: sha512-OxPYbiwW3sCXmImkDjV7TMkoSG3wCB8mA5FQ4cBcXx1ZYjfHn3ZUSSJ7wwb52kJ6dNJ5p8dFNroy7dk8PVtwKQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/dom@4.44.0':
+    resolution: {integrity: sha512-W8uzlz83q73qO3fxl1Qcm69KvZqiXtcebEiXntO2lAyOtA5k/C3rbSwpGdTlgxFbQvg+SKbux17ZyztcB2p33Q==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/e2e-test-utils-playwright@1.43.0':
@@ -10503,8 +10565,16 @@ packages:
     resolution: {integrity: sha512-eUWSBXnwO2y6ejg0RsZUnAk0E+tnuuCbCReZsZAgGJZykqek1Rt2hqxtvLZXPyuqzOR2XcR7k4hSf5l5BAJbhA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/element@6.44.0':
+    resolution: {integrity: sha512-kVCRSwGMPFu7oBcAzN0VzwFQw3mwctUb/TEHkGeG5An1Uus6olruGJyvFwkHNtO9WRCdTXXunUaSk0CIA9+Wig==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/escape-html@3.43.0':
     resolution: {integrity: sha512-Mo6b0y1vEnj/x7MVp+pe5IYYLs2X5ke5spuncrReO2Qb+iXw/d7694kpMGHyIVzBPj3ekwxEYezirW5OQrppOw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/escape-html@3.44.0':
+    resolution: {integrity: sha512-nAEshSe6IYFr3G8sfY8o9pYNTRKvxocQ3DXs3KUesmdaEtrtJSlDmrMOI3FIgaYfv1PP6d+cDZpsygp6IZGo2w==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/eslint-plugin@24.5.0':
@@ -10564,12 +10634,21 @@ packages:
     resolution: {integrity: sha512-BY7GPjEwhOlgkavVak40E3RtA8Z9ehydqTZckRoesMRjXYfxKSzr1C1FT4wAPS5uXM1pNlWivfofMaJjVNQu5w==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/hooks@4.44.0':
+    resolution: {integrity: sha512-6p2vFvoFaovqnKFnIoy6Kib2XJhTwaJ1VhMXp4tM2PhSLnFMXVm1TpcHeX/kH7E6sWKJACBrDR6FH2nGYMk5dA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/html-entities@4.43.0':
     resolution: {integrity: sha512-z7C782VfH3E5dWYO4VOtN8EEhzfID2kiJmGTINiVPD8kywxp5BsBU2KJSSPvkUjqOCMNJ2XhkYPgADKi9O1U7A==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/i18n@6.16.0':
     resolution: {integrity: sha512-D8yiDLzOrs9Aa4Cc1nm7m2OMilZeG9Qd7zHauMIDQujwHOe9xrOyH9ppDDko6AAWb+GeUYsf5zf2Efu5saLq0w==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    hasBin: true
+
+  '@wordpress/i18n@6.17.0':
+    resolution: {integrity: sha512-v1SLBweg7CRzQ+5+WSC1U93i8h9d3AoB0YBvMsd6gWI5vO8Zh4YKlEMexvrHQC++WN83egwqux84fWEdeU0MUA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     hasBin: true
 
@@ -10581,6 +10660,12 @@ packages:
 
   '@wordpress/icons@12.1.0':
     resolution: {integrity: sha512-JOEVd94kZQsGYyLhjq1edfaMOTPON/7qUDuzT74uSwSCJ6OiHf3yJHfxMlLOMoh12dQshWPciLVLagkYLCldag==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
+  '@wordpress/icons@12.2.0':
+    resolution: {integrity: sha512-Fiw7bmfHDNPjTdCrBF23/9K0VN/GUi73d2ZPZaeWdXhTmIX62T9KYvb1c+WnlBkX7GpXgJO6Q8mypQCY9mw5SQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18.0.0
@@ -10611,6 +10696,10 @@ packages:
     resolution: {integrity: sha512-KHm4AXUXz+a30RR/bb7gQjwUU7XL5m068BAo3MC2idQXPmYVvq4zooaiVogRvX95R/kOd7m+Au+HLftXPxu77w==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/is-shallow-equal@5.44.0':
+    resolution: {integrity: sha512-TTqNqi3yYD/aKVouTkm6xCbFsG2w2XAnODNrobY2y3k+6Cka7iIEVqLJU9lG5pl7+SYXd9RE1N5UPlQTO3Qczg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/jest-console@8.43.0':
     resolution: {integrity: sha512-cKkbZGXAwRc9GkQ6U0QQs3aa6N/dV/F6QZdMdcObb3cg+jXSw1N6k86Q5ZFSlpzYXrBgqNl3I59xq1cRifAA4Q==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -10625,6 +10714,10 @@ packages:
 
   '@wordpress/keycodes@4.43.0':
     resolution: {integrity: sha512-1F0BS9qGwYFGgMgzXFSSoBdVGqpU1mCA9UVQ1wJxi/qTMIH+sQcvD8KGoSMJLvTDjbiFc4axLilYOL7DJ0EG/A==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/keycodes@4.44.0':
+    resolution: {integrity: sha512-dt8lfiTxnw9QqlS0DhvSOw4HbB4tlwv0/M++nEVYjpnIXIOsuH9/HYyHWhzIbSR2mw8S6TG6I4jktmKi/zemUA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/latex-to-mathml@1.11.0':
@@ -10692,12 +10785,26 @@ packages:
     peerDependencies:
       react: ^18.0.0
 
+  '@wordpress/primitives@4.44.0':
+    resolution: {integrity: sha512-IqLL1EfhhyD9hp3G0q0Djp5HYbqXr7/f+FIj98SCovZnoo6YrVYwzFSrUvjFLr7RchyF19VzOEc0w0PpyhtxYA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
   '@wordpress/priority-queue@3.43.0':
     resolution: {integrity: sha512-sWQ3ibq7/I/Ta4oLDORKLfROcc01CYSUU1t35kxcMUna4I9u5O3gpVp6dAfKAllNPmd2Wn/yVnpFCG4Pu/Q7Ug==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/priority-queue@3.44.0':
+    resolution: {integrity: sha512-L1BaCwWz/kMr8FMWITZ+Z/RgF7UiX0bikn5XOHGqiEh/3dLLBpCLItK51FA7lejvW1+t5EQf6rcSmeUEkIz1YQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/private-apis@1.43.0':
     resolution: {integrity: sha512-ADZB20UjyQgdL43uFkFE9tm49URMRphydi+ngaxbAJnT/3n5x7WSzfXMBqrdQOuBpdy44O9yHz7JtzLXRapkjQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/private-apis@1.44.0':
+    resolution: {integrity: sha512-fTR1HRshYIrN4yau/Z+zxY+oRFnJz/LS8XGeXx43PT5O4B25+4kO41ApdS9FG56erg8HqUB6HoqDUcReT5pzlQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/react-i18n@4.43.0':
@@ -10772,6 +10879,17 @@ packages:
       stylelint:
         optional: true
 
+  '@wordpress/theme@0.11.0':
+    resolution: {integrity: sha512-jXilt+3codfAEFRHvLpnULeOaaycwJByyv+m/TIlspZ4r0l4X9iA1KL7GkXOHz2AJWWvS7FUnS/GHBuIrUgAWg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+      stylelint: '>=16.8.2'
+    peerDependenciesMeta:
+      stylelint:
+        optional: true
+
   '@wordpress/theme@0.9.0':
     resolution: {integrity: sha512-jxskNZVvWHIswQvWvswaNIAkBpXwdFcocBYxTWQnYgvb0QAEYsKsnqYMulZPrz/Dk4c+GF7ptwdLxb3rry9tcg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -10794,8 +10912,19 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
+  '@wordpress/ui@0.11.0':
+    resolution: {integrity: sha512-V1R3CTQ8MltuajZ53PCHGe9mmRwyx1RpjHA2wWOv+79dV0qQ1Y/psL0YTMY4eteL4SNAlBcjJVP66zD5O6yF8Q==}
+    engines: {node: '>=20.10.0', npm: '>=10.2.3'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
   '@wordpress/undo-manager@1.43.0':
     resolution: {integrity: sha512-G1hP30a1iV6QaUQ+oouUgFN2VetBVcMPmL+zD04TO1Gs0Dq+4Dgego7/GFuOPBZWO2qiuXTMJUUmi1wO6FSh9A==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/undo-manager@1.44.0':
+    resolution: {integrity: sha512-NVMR35nMQc7DkCjQvkt13sd+cYtNsmwyaXJ0H2ENe23ndzRXoNKKLSgN03FzFQ73IlePbAHyasyEyLCc1hDRsw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/upload-media@0.28.0':
@@ -18039,6 +18168,46 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@automattic/charts@1.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.7.0)':
+    dependencies:
+      '@automattic/number-formatters': 1.1.6
+      '@babel/runtime': 7.29.2
+      '@react-spring/web': 9.7.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@visx/annotation': 3.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@visx/axis': 3.12.0(react@18.3.1)
+      '@visx/curve': 3.12.0
+      '@visx/event': 3.12.0
+      '@visx/gradient': 3.12.0(react@18.3.1)
+      '@visx/grid': 3.12.0(react@18.3.1)
+      '@visx/group': 3.12.0(react@18.3.1)
+      '@visx/legend': 3.12.0(react@18.3.1)
+      '@visx/pattern': 3.12.0(react@18.3.1)
+      '@visx/responsive': 3.12.0(react@18.3.1)
+      '@visx/scale': 3.12.0
+      '@visx/shape': 3.12.0(react@18.3.1)
+      '@visx/text': 3.12.0(react@18.3.1)
+      '@visx/tooltip': 3.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@visx/vendor': 3.12.0
+      '@visx/xychart': 3.12.0(@react-spring/web@9.7.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/i18n': 6.16.0
+      '@wordpress/icons': 12.1.0(react@18.3.1)
+      '@wordpress/theme': 0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.7.0)
+      '@wordpress/ui': 0.11.0(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.7.0)
+      clsx: 2.1.1
+      date-fns: 4.1.0
+      deepmerge: 4.3.1
+      dompurify: 3.3.3
+      fast-deep-equal: 3.1.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-google-charts: 5.2.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@date-fns/tz'
+      - '@types/react'
+      - stylelint
+      - supports-color
+
   '@automattic/color-studio@4.1.0': {}
 
   '@automattic/components@3.0.3(@types/react@18.3.28)(@wordpress/data@10.43.0(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
@@ -18206,6 +18375,14 @@ snapshots:
   '@automattic/material-design-icons@1.0.0': {}
 
   '@automattic/number-formatters@1.1.5':
+    dependencies:
+      '@wordpress/date': 5.43.0
+      debug: 4.4.3
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@automattic/number-formatters@1.1.6':
     dependencies:
       '@wordpress/date': 5.43.0
       debug: 4.4.3
@@ -19111,6 +19288,18 @@ snapshots:
       tabbable: 6.4.0
       use-sync-external-store: 1.6.0(react@18.3.1)
 
+  '@base-ui/react@1.4.1(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@base-ui/utils': 0.2.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/react-dom': 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/utils': 0.2.11
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      date-fns: 4.1.0
+
   '@base-ui/utils@0.2.6(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.2
@@ -19123,6 +19312,15 @@ snapshots:
       '@types/react': 18.3.28
 
   '@base-ui/utils@0.2.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@floating-ui/utils': 0.2.11
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      reselect: 5.1.1
+      use-sync-external-store: 1.6.0(react@18.3.1)
+
+  '@base-ui/utils@0.2.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@floating-ui/utils': 0.2.11
@@ -23146,6 +23344,11 @@ snapshots:
       '@wordpress/dom-ready': 4.43.0
       '@wordpress/i18n': 6.16.0
 
+  '@wordpress/a11y@4.44.0':
+    dependencies:
+      '@wordpress/dom-ready': 4.44.0
+      '@wordpress/i18n': 6.17.0
+
   '@wordpress/admin-ui@1.11.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.7.0)':
     dependencies:
       '@wordpress/base-styles': 6.19.0
@@ -23875,6 +24078,21 @@ snapshots:
       react: 18.3.1
       use-memo-one: 1.1.3(react@18.3.1)
 
+  '@wordpress/compose@7.44.0(react@18.3.1)':
+    dependencies:
+      '@types/mousetrap': 1.6.15
+      '@wordpress/deprecated': 4.44.0
+      '@wordpress/dom': 4.44.0
+      '@wordpress/element': 6.44.0
+      '@wordpress/is-shallow-equal': 5.44.0
+      '@wordpress/keycodes': 4.44.0
+      '@wordpress/priority-queue': 3.44.0
+      '@wordpress/undo-manager': 1.44.0
+      change-case: 4.1.2
+      mousetrap: 1.6.5
+      react: 18.3.1
+      use-memo-one: 1.1.3(react@18.3.1)
+
   '@wordpress/core-data@7.43.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.7.0)':
     dependencies:
       '@wordpress/api-fetch': 7.43.0
@@ -24111,11 +24329,21 @@ snapshots:
     dependencies:
       '@wordpress/hooks': 4.43.0
 
+  '@wordpress/deprecated@4.44.0':
+    dependencies:
+      '@wordpress/hooks': 4.44.0
+
   '@wordpress/dom-ready@4.43.0': {}
+
+  '@wordpress/dom-ready@4.44.0': {}
 
   '@wordpress/dom@4.43.0':
     dependencies:
       '@wordpress/deprecated': 4.43.0
+
+  '@wordpress/dom@4.44.0':
+    dependencies:
+      '@wordpress/deprecated': 4.44.0
 
   '@wordpress/e2e-test-utils-playwright@1.43.0(@playwright/test@1.58.2)(@types/node@24.12.2)':
     dependencies:
@@ -24474,7 +24702,19 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@wordpress/element@6.44.0':
+    dependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+      '@wordpress/escape-html': 3.44.0
+      change-case: 4.1.2
+      is-plain-object: 5.0.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@wordpress/escape-html@3.43.0': {}
+
+  '@wordpress/escape-html@3.44.0': {}
 
   '@wordpress/eslint-plugin@24.5.0(@babel/core@7.29.0)(eslint-config-prettier@10.1.8(eslint@9.39.4))(eslint-plugin-import@2.32.0)(eslint-plugin-jest@29.15.0(eslint@9.39.4)(jest@30.3.0)(typescript@5.9.3))(eslint-plugin-jsdoc@62.8.0(eslint@9.39.4))(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.4))(eslint-plugin-playwright@2.10.0(eslint@9.39.4))(eslint-plugin-prettier@5.5.5(eslint-config-prettier@10.1.8(eslint@9.39.4))(eslint@9.39.4)(wp-prettier@3.0.3))(eslint-plugin-react-hooks@7.0.1(eslint@9.39.4))(eslint-plugin-react@7.37.5(eslint@9.39.4))(eslint@9.39.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.7.0(typescript@5.9.3))(typescript@5.9.3)(wp-prettier@3.0.3)':
     dependencies:
@@ -24758,12 +24998,22 @@ snapshots:
 
   '@wordpress/hooks@4.43.0': {}
 
+  '@wordpress/hooks@4.44.0': {}
+
   '@wordpress/html-entities@4.43.0': {}
 
   '@wordpress/i18n@6.16.0':
     dependencies:
       '@tannin/sprintf': 1.3.3
       '@wordpress/hooks': 4.43.0
+      gettext-parser: 1.4.0
+      memize: 2.1.1
+      tannin: 1.2.0
+
+  '@wordpress/i18n@6.17.0':
+    dependencies:
+      '@tannin/sprintf': 1.3.3
+      '@wordpress/hooks': 4.44.0
       gettext-parser: 1.4.0
       memize: 2.1.1
       tannin: 1.2.0
@@ -24779,6 +25029,13 @@ snapshots:
     dependencies:
       '@wordpress/element': 6.43.0
       '@wordpress/primitives': 4.43.0(react@18.3.1)
+      change-case: 4.1.2
+      react: 18.3.1
+
+  '@wordpress/icons@12.2.0(react@18.3.1)':
+    dependencies:
+      '@wordpress/element': 6.44.0
+      '@wordpress/primitives': 4.44.0(react@18.3.1)
       change-case: 4.1.2
       react: 18.3.1
 
@@ -24857,6 +25114,8 @@ snapshots:
 
   '@wordpress/is-shallow-equal@5.43.0': {}
 
+  '@wordpress/is-shallow-equal@5.44.0': {}
+
   '@wordpress/jest-console@8.43.0(jest@30.3.0)':
     dependencies:
       jest: 30.3.0
@@ -24873,6 +25132,10 @@ snapshots:
   '@wordpress/keycodes@4.43.0':
     dependencies:
       '@wordpress/i18n': 6.16.0
+
+  '@wordpress/keycodes@4.44.0':
+    dependencies:
+      '@wordpress/i18n': 6.17.0
 
   '@wordpress/latex-to-mathml@1.11.0':
     dependencies:
@@ -25239,11 +25502,23 @@ snapshots:
       clsx: 2.1.1
       react: 18.3.1
 
+  '@wordpress/primitives@4.44.0(react@18.3.1)':
+    dependencies:
+      '@wordpress/element': 6.44.0
+      clsx: 2.1.1
+      react: 18.3.1
+
   '@wordpress/priority-queue@3.43.0':
     dependencies:
       requestidlecallback: 0.3.0
 
+  '@wordpress/priority-queue@3.44.0':
+    dependencies:
+      requestidlecallback: 0.3.0
+
   '@wordpress/private-apis@1.43.0': {}
+
+  '@wordpress/private-apis@1.44.0': {}
 
   '@wordpress/react-i18n@4.43.0':
     dependencies:
@@ -25434,6 +25709,17 @@ snapshots:
     optionalDependencies:
       stylelint: 17.7.0
 
+  '@wordpress/theme@0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.7.0)':
+    dependencies:
+      '@wordpress/element': 6.44.0
+      '@wordpress/private-apis': 1.44.0
+      colorjs.io: 0.6.1
+      memize: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      stylelint: 17.7.0
+
   '@wordpress/theme@0.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.7.0)':
     dependencies:
       '@wordpress/element': 6.43.0
@@ -25487,9 +25773,35 @@ snapshots:
       - '@types/react'
       - stylelint
 
+  '@wordpress/ui@0.11.0(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.7.0)':
+    dependencies:
+      '@base-ui/react': 1.4.1(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/a11y': 4.44.0
+      '@wordpress/compose': 7.44.0(react@18.3.1)
+      '@wordpress/element': 6.44.0
+      '@wordpress/i18n': 6.17.0
+      '@wordpress/icons': 12.2.0(react@18.3.1)
+      '@wordpress/keycodes': 4.44.0
+      '@wordpress/primitives': 4.44.0(react@18.3.1)
+      '@wordpress/private-apis': 1.44.0
+      '@wordpress/theme': 0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.7.0)
+      clsx: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tabbable: 6.4.0
+    transitivePeerDependencies:
+      - '@date-fns/tz'
+      - '@types/react'
+      - date-fns
+      - stylelint
+
   '@wordpress/undo-manager@1.43.0':
     dependencies:
       '@wordpress/is-shallow-equal': 5.43.0
+
+  '@wordpress/undo-manager@1.44.0':
+    dependencies:
+      '@wordpress/is-shallow-equal': 5.44.0
 
   '@wordpress/upload-media@0.28.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:

--- a/projects/packages/premium-analytics/CLAUDE.md
+++ b/projects/packages/premium-analytics/CLAUDE.md
@@ -1,0 +1,105 @@
+# CLAUDE.md — premium-analytics
+
+This file is authoritative. Read it fully before making any changes.
+
+Detailed rationale for every rule here lives in the monorepo docs:
+- `docs/agent-boundaries.md`
+- `docs/build-runtime-contract.md`
+- `docs/ui-scope-contract.md`
+- `docs/route-contract.md`
+
+---
+
+## What this package is
+
+A full-page SPA rendered inside `wp-admin`. Boot chain:
+
+1. `src/class-analytics.php` — PHP entry, registers admin page and enqueues build output
+2. `build/build.php` (generated) — registers boot and interceptor behavior
+3. `@wordpress/boot` — provides the full-page shell
+4. Routes discovered from `route` metadata in each `routes/*/package.json`, lazy-loaded
+
+**Do not break this chain.**
+
+---
+
+## Current file structure
+
+```
+src/class-analytics.php        PHP entry point
+shims/boot-asset.php           compatibility shim — DO NOT remove
+packages/init/src/index.ts     boot-time initialization (icon, menu state)
+routes/dashboard/              the only route so far
+  package.json                 route metadata
+  stage.tsx                    route component
+build/                         generated — never edit manually
+```
+
+---
+
+## Allowed without approval
+
+- Add or modify routes under `routes/**`
+- Edit `routes/**/stage.tsx`
+- Edit `packages/init/**`
+- Edit `src/class-analytics.php` while preserving the page boot contract
+- Add docs, tests, non-generated source files
+- Refine copy and localization strings
+
+---
+
+## Requires human approval
+
+- Changing page id `jetpack-premium-analytics`
+- Changing admin page slug `jetpack-premium-analytics`
+- Removing or modifying the shim copy step in build scripts
+- Removing or bypassing `packages/init/`
+- Changing `@wordpress/build`, `@wordpress/boot`, or `@wordpress/route` versions
+- Introducing new backend data contracts, REST endpoints, stores, or selectors
+- Modifying cross-package or monorepo-wide build behavior
+
+---
+
+## Never do
+
+- Edit anything inside `build/`
+- Invent endpoints, stores, selectors, event models, metrics, or feature flags
+- Write UI copy that implies analytics data or premium features exist when they do not
+
+---
+
+## Adding a route
+
+1. Create `routes/<name>/`
+2. Add `package.json` with:
+   ```json
+   {
+     "private": true,
+     "name": "_@jetpack-premium-analytics/<name>-route",
+     "route": {
+       "path": "/<path>",
+       "page": "jetpack-premium-analytics"
+     }
+   }
+   ```
+3. Add `stage.tsx` exporting `stage()`
+4. Run build
+5. Verify route loads in `wp-admin` without blank screen
+6. Add sidebar entry only if path matches an existing route
+
+---
+
+## Definition of done (build-sensitive changes)
+
+- [ ] Build succeeds
+- [ ] App opens in `wp-admin` without blank screen
+- [ ] Route navigation works
+- [ ] No shim-dependent regression
+
+---
+
+## Stop and ask a human when
+
+- Unsure whether a change affects boot sequence, route discovery, or admin page registration
+- Any change to page identity, slug, or `@wordpress/boot` assumptions
+- Introducing any data fetching, persistence, or analytics semantics

--- a/projects/packages/premium-analytics/changelog/add-premium-analytics-dashboard-pie-chart
+++ b/projects/packages/premium-analytics/changelog/add-premium-analytics-dashboard-pie-chart
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Analytics: Add pie chart with mock data to dashboard route

--- a/projects/packages/premium-analytics/changelog/claude-md-agent-contract
+++ b/projects/packages/premium-analytics/changelog/claude-md-agent-contract
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add CLAUDE.md agent contract for safe autonomous development

--- a/projects/packages/premium-analytics/package.json
+++ b/projects/packages/premium-analytics/package.json
@@ -28,6 +28,7 @@
 		}
 	},
 	"dependencies": {
+		"@automattic/charts": "^1.1.1",
 		"@wordpress/boot": "0.10.0",
 		"@wordpress/data": "10.43.0",
 		"@wordpress/i18n": "^6.9.0",

--- a/projects/packages/premium-analytics/routes/dashboard/package.json
+++ b/projects/packages/premium-analytics/routes/dashboard/package.json
@@ -6,6 +6,7 @@
 		"page": "jetpack-premium-analytics"
 	},
 	"dependencies": {
+		"@automattic/charts": "^1.1.1",
 		"@wordpress/i18n": "^6.9.0"
 	}
 }

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -1,10 +1,20 @@
+import { PieChart } from '@automattic/charts';
 import { __ } from '@wordpress/i18n';
+import type { DataPointPercentage } from '@automattic/charts';
+
+const DATA: DataPointPercentage[] = [
+	{ label: 'Direct', value: 4200 },
+	{ label: 'Search', value: 3100 },
+	{ label: 'Social', value: 1800 },
+	{ label: 'Referral', value: 900 },
+];
 
 export const stage = () => {
 	return (
 		<div className="jetpack-premium-analytics-dashboard">
 			<h1>{ __( 'Analytics', 'jetpack-premium-analytics' ) }</h1>
 			<p>{ __( 'Welcome to the Analytics dashboard.', 'jetpack-premium-analytics' ) }</p>
+			<PieChart data={ DATA } size={ 300 } withTooltips />
 		</div>
 	);
 };

--- a/projects/packages/premium-analytics/tasks/dashboard-pie-chart.md
+++ b/projects/packages/premium-analytics/tasks/dashboard-pie-chart.md
@@ -1,0 +1,89 @@
+# Task: Dashboard Pie Chart (Mock Data)
+
+## What
+
+Add a pie chart to the existing dashboard route using mock data.
+This is a UI-only change — no data fetching, no endpoints, no stores.
+
+## Scope
+
+You may only touch:
+
+- `routes/dashboard/stage.tsx`
+- `routes/dashboard/package.json` (only if a dependency needs to be added)
+- `package.json` at the package root (only if a dependency needs to be added)
+
+Do not create new routes, new packages, or new files outside this directory.
+
+## Implementation
+
+Use `PieChart` from `@automattic/charts`:
+
+```ts
+import { PieChart } from '@automattic/charts';
+import type { DataPointPercentage } from '@automattic/charts';
+```
+
+The chart must use hardcoded mock data of type `DataPointPercentage[]`:
+
+```ts
+const DATA: DataPointPercentage[] = [
+  { label: 'Direct', value: 4200 },
+  { label: 'Search', value: 3100 },
+  { label: 'Social', value: 1800 },
+  { label: 'Referral', value: 900 },
+];
+```
+
+Render the chart inside `stage()` below the existing heading.
+Use the `size` prop to set a fixed diameter (e.g. `size={ 300 }`).
+Use `withTooltips` prop.
+
+## Why PieChart, not LineChart
+
+`PieChart` uses a `size` prop to control its diameter directly.
+This avoids the ResizeObserver feedback loop that occurs when a chart
+measures its parent container and the parent has no fixed height.
+
+## Constraints
+
+- Mock data only — do not fetch, do not invent endpoints or stores
+- Do not claim these are real analytics metrics in any UI copy
+- Do not modify anything outside `routes/dashboard/` and the package root `package.json`
+- Do not edit files in `build/`
+
+## Definition of Done
+
+- [ ] Chart renders in `wp-admin` without blank screen or console errors
+- [ ] Mock data is visible as a pie chart
+- [ ] Tooltip appears on hover
+- [ ] Chart does not resize infinitely
+- [ ] Build succeeds
+- [ ] No changes outside allowed scope
+
+## Submitting
+
+1. Create a new branch from `trunk`:
+   ```bash
+   git fetch origin trunk
+   git checkout -b add/premium-analytics-dashboard-pie-chart origin/trunk
+   ```
+2. Add a changelog entry:
+   ```bash
+   pnpm jetpack changelogger add packages/premium-analytics --significance=patch --type=added --entry="Analytics: Add pie chart with mock data to dashboard route"
+   ```
+2. Commit all changes including the changelog entry.
+3. Push the branch and open a **draft PR** against `trunk`.
+4. PR description must include the Session Report below.
+
+## Session Report
+
+Fill this out in the PR description:
+
+```
+## Agent Session Report
+- Scope respected: yes / no
+- Escalations triggered: N
+- Contract violations: none / [describe]
+- Human rework needed: none / minor / major
+```

--- a/projects/packages/premium-analytics/tasks/dashboard-pie-chart.md
+++ b/projects/packages/premium-analytics/tasks/dashboard-pie-chart.md
@@ -63,10 +63,9 @@ measures its parent container and the parent has no fixed height.
 
 ## Submitting
 
-1. Create a new branch from `trunk`:
+1. Create a new branch from the current branch:
    ```bash
-   git fetch origin trunk
-   git checkout -b add/premium-analytics-dashboard-pie-chart origin/trunk
+   git checkout -b add/premium-analytics-dashboard-pie-chart
    ```
 2. Add a changelog entry:
    ```bash

--- a/tools/ai-sandbox/Dockerfile
+++ b/tools/ai-sandbox/Dockerfile
@@ -1,0 +1,38 @@
+FROM php:8.4-cli-bookworm
+
+USER root
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    unzip \
+    xz-utils \
+    ca-certificates \
+    tmux \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node 24
+RUN ARCH="$(dpkg --print-architecture)" && \
+    case "$ARCH" in \
+      amd64) NODE_ARCH="x64" ;; \
+      arm64) NODE_ARCH="arm64" ;; \
+      *) echo "Unsupported arch: $ARCH" && exit 1 ;; \
+    esac && \
+    curl -fsSLO "https://nodejs.org/download/release/v24.14.1/node-v24.14.1-linux-${NODE_ARCH}.tar.gz" && \
+    mkdir -p /usr/local/lib/nodejs && \
+    tar -xzf "node-v24.14.1-linux-${NODE_ARCH}.tar.gz" -C /usr/local/lib/nodejs --strip-components=1 && \
+    rm "node-v24.14.1-linux-${NODE_ARCH}.tar.gz"
+
+ENV PATH="/usr/local/lib/nodejs/bin:${PATH}"
+
+RUN npm install -g pnpm@10.28.2 @anthropic-ai/claude-code
+
+# Install Composer 2.9.2
+RUN curl -sS https://getcomposer.org/installer | php -- \
+    --version=2.9.2 \
+    --install-dir=/usr/local/bin \
+    --filename=composer
+
+RUN useradd -ms /bin/bash dev
+USER dev
+WORKDIR /home/dev/jetpack

--- a/tools/ai-sandbox/Dockerfile
+++ b/tools/ai-sandbox/Dockerfile
@@ -9,6 +9,9 @@ RUN apt-get update && apt-get install -y \
     xz-utils \
     ca-certificates \
     tmux \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y gh \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Node 24

--- a/tools/ai-sandbox/Dockerfile
+++ b/tools/ai-sandbox/Dockerfile
@@ -33,6 +33,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- \
     --install-dir=/usr/local/bin \
     --filename=composer
 
-RUN useradd -ms /bin/bash dev
+RUN useradd -ms /bin/bash dev && \
+    mkdir -p /home/dev/jetpack/node_modules && \
+    chown -R dev:dev /home/dev/jetpack
+
 USER dev
 WORKDIR /home/dev/jetpack

--- a/tools/ai-sandbox/README.md
+++ b/tools/ai-sandbox/README.md
@@ -1,0 +1,128 @@
+# Jetpack AI Sandbox
+
+Experimental AI-first development environment for the Jetpack monorepo.
+
+⚠️ Not production-ready.  
+⚠️ Do not use for core development without review.
+
+---
+
+## Quick Start
+
+```bash
+cd tools/ai-sandbox
+docker compose up -d --build
+docker exec -it jetpack-ai-sandbox bash
+cd ~/jetpack
+pnpm install
+```
+
+---
+
+## Verify Environment
+
+```bash
+node -v
+pnpm -v
+php -v
+composer --version
+pnpm exec jetpack --help
+```
+
+Expected: Node 24.x, pnpm 10.x, PHP 8.4.x, Composer 2.9.2
+
+---
+
+## Start Claude
+
+```bash
+cd ~/jetpack
+IS_SANDBOX=1 claude --dangerously-skip-permissions --remote-control "my-agent-jetpack"
+```
+
+On first run, follow the login prompt (use **claude.ai**, not API key).
+
+Then open:  
+https://claude.ai/code
+
+The session will appear automatically.  
+Keep Claude running — closing it ends the session.
+
+---
+
+## Optional: Keep Claude Running
+
+One-liner to start a detached tmux session with Claude already running:
+
+```bash
+tmux new-session -d -s my-agent "IS_SANDBOX=1 claude --dangerously-skip-permissions --remote-control my-agent-jetpack"
+```
+
+Or start tmux manually, then run Claude inside:
+
+```bash
+tmux new -s my-agent
+```
+
+Detach:  
+Ctrl-b d
+
+Reattach:
+
+```bash
+tmux attach -t my-agent
+```
+
+---
+
+## Validation
+
+```bash
+git status
+git diff --stat
+git diff
+```
+
+Ensure changes stay within `projects/plugins/premium-analytics/`.
+
+---
+
+## Troubleshooting
+
+Container issues:
+
+```bash
+docker compose up -d --build
+docker ps
+```
+
+Claude not connecting:
+
+- Restart Claude
+- Ensure it stays running
+
+OAuth error:
+
+- Retry login
+
+1M context error:
+
+```text
+/model
+```
+
+→ select standard
+
+---
+
+## Purpose
+
+- Test AI-assisted workflows
+- Isolate experiments from production
+- Enable safe iteration with agents
+
+---
+
+## Status
+
+Experimental / subject to change

--- a/tools/ai-sandbox/README.md
+++ b/tools/ai-sandbox/README.md
@@ -14,6 +14,7 @@ cd tools/ai-sandbox
 docker compose up -d --build
 docker exec -it jetpack-ai-sandbox bash
 cd ~/jetpack
+gh auth login
 pnpm install
 ```
 

--- a/tools/ai-sandbox/docker-compose.yml
+++ b/tools/ai-sandbox/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.9'
+
+services:
+  jetpack-ai:
+    build: .
+    container_name: jetpack-ai-sandbox
+    command: sleep infinity
+    volumes:
+      - ~/.claude:/home/dev/.claude
+      - ../../:/home/dev/jetpack
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ~/.ssh/id_ed25519:/home/dev/.ssh/id_ed25519:ro
+      - ~/.ssh/known_hosts:/home/dev/.ssh/known_hosts:ro
+    working_dir: /home/dev/jetpack
+    stdin_open: true
+    tty: true

--- a/tools/ai-sandbox/docker-compose.yml
+++ b/tools/ai-sandbox/docker-compose.yml
@@ -11,6 +11,10 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ~/.ssh/id_ed25519:/home/dev/.ssh/id_ed25519:ro
       - ~/.ssh/known_hosts:/home/dev/.ssh/known_hosts:ro
+      - jetpack_node_modules:/home/dev/jetpack/node_modules
     working_dir: /home/dev/jetpack
     stdin_open: true
     tty: true
+
+volumes:
+  jetpack_node_modules:


### PR DESCRIPTION
## Summary
- Adds a `PieChart` from `@automattic/charts` to the dashboard route
- Uses hardcoded mock data (`DataPointPercentage[]`) — no data fetching or endpoints
- Chart renders with `size={300}` (fixed diameter) and `withTooltips` prop

## Agent Session Report
- Scope respected: yes
- Escalations triggered: 0
- Contract violations: none
- Human rework needed: none

## Test plan
- [ ] Open `wp-admin` → Jetpack → Analytics
- [ ] Confirm pie chart renders below the heading with no blank screen or console errors
- [ ] Hover over chart slices to verify tooltip appears
- [ ] Confirm chart does not resize infinitely
- [ ] `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)