### PR TITLE
premium-analytics: add pie chart with mock data to dashboard route

### DIFF
--- a/docs/agent-boundaries.md
+++ b/docs/agent-boundaries.md
@@ -1,0 +1,66 @@
+# Agent Boundaries for Premium Analytics
+
+This document defines what AI agents may and may not change inside
+`projects/packages/premium-analytics`.
+
+## Purpose
+
+`premium-analytics` is currently a full-page SPA rendered inside `wp-admin`.
+The package bootstraps through `wp-build`, `@wordpress/boot`, and route-based
+code splitting. Agents must preserve those runtime assumptions.
+
+## Allowed Changes
+
+Agents MAY:
+
+- add or modify route modules under `routes/**`
+- update UI code in `routes/**/stage.tsx`
+- update package-local initialization code under `packages/init/**`
+- update `src/class-analytics.php` when preserving the page boot contract
+- add package-local docs, tests, and non-generated source files
+- refine copy, localization calls, and presentational components
+
+## Restricted Changes
+
+Agents MUST NOT, without explicit human approval:
+
+- change the page id `jetpack-premium-analytics`
+- change the admin page slug `jetpack-premium-analytics`
+- remove the boot asset shim copy step from package build scripts
+- delete or bypass `packages/init/` if boot dependency tracking still relies on it
+- edit generated files inside `build/`
+- introduce new backend data contracts that are not documented first
+- assume undocumented REST endpoints, stores, selectors, or analytics schemas exist
+- modify cross-package or monorepo-wide build behavior from this package alone
+
+## Required Preservation Rules
+
+Agents MUST preserve the following invariants:
+
+1. The package remains a full-page SPA in `wp-admin`.
+2. Route discovery continues to happen via route metadata in `package.json`.
+3. The PHP entry continues loading the generated build entry when present.
+4. The admin menu page remains booted by the build/runtime path rather than by a custom PHP page renderer.
+5. Sidebar items must correspond to actual route paths.
+
+## Escalate to Human Review When
+
+Agents MUST stop and request human review before:
+
+- changing page identity, slug, or boot sequence
+- changing build/runtime dependency assumptions around `@wordpress/boot`
+- removing the shim workaround
+- introducing data fetching or persistence layers
+- adding analytics semantics such as metric definitions, aggregation rules, or retention behavior
+- changing permissions or capability requirements
+- changing integration points with other Jetpack packages
+
+## Generated Artifacts
+
+`build/` is generated output and must never be manually edited.
+Agents should change source files and rebuild instead.
+
+## Safe Default
+
+If an agent is unsure whether a change affects runtime bootstrapping,
+route discovery, or admin page registration, it must not proceed automatically.

--- a/docs/agent-metrics.md
+++ b/docs/agent-metrics.md
@@ -1,0 +1,56 @@
+# Agent Metrics for Premium Analytics
+
+This document defines how to measure the effectiveness of the agent
+governance system for `projects/packages/premium-analytics`.
+
+## Core Metric
+
+**Agent Clean Rate = Clean sessions / (Clean + Violation sessions)**
+
+Target: Violation count trends toward zero over time.
+
+Session outcomes are classified as:
+
+| Outcome | Definition |
+|---------|------------|
+| Clean | Agent completed the task within contract bounds; PR merged without significant rework |
+| Escalated | Agent correctly stopped and requested human review |
+| Violation | Agent breached a contract rule (edited a restricted file, invented a data layer, etc.) |
+
+Escalated sessions are expected behavior and do not count against the Clean Rate.
+
+## Per-PR Session Report
+
+Every agent-generated PR must include the following block in its description:
+
+```
+## Agent Session Report
+- Scope respected: yes / no
+- Escalations triggered: N
+- Contract violations: none / [describe]
+- Human rework needed: none / minor / major
+```
+
+This requires no tooling. Data lives in PR history and can be audited at any time.
+
+## Post-Launch Dashboard Metric
+
+**Routes shipped per sprint — agent-assisted vs. manual**
+
+This metric is suitable for a team dashboard because:
+
+- routes have a well-defined contract, making comparisons fair
+- it reflects real product velocity, not just process compliance
+- it remains meaningful as the package grows
+
+## Feedback Loop
+
+Review the session reports at the end of each sprint.
+
+Ask:
+
+- Did any Violation reveal a gap in the contract docs?
+- Did any Escalation turn out to be unnecessary? (contract may be too conservative)
+- Is human rework concentrated in a specific area? (likely needs a new contract rule)
+
+Update the relevant contract doc when a pattern is found.

--- a/docs/build-runtime-contract.md
+++ b/docs/build-runtime-contract.md
@@ -1,0 +1,77 @@
+# Build and Runtime Contract for Premium Analytics
+
+This document defines the required build and runtime behavior for
+`projects/packages/premium-analytics`.
+
+## Current Runtime Model
+
+The package depends on a runtime chain like this:
+
+1. PHP entry initializes package
+2. generated `build/build.php` registers the boot and interceptor behavior
+3. `@wordpress/boot` provides the full-page shell
+4. routes are discovered and lazy-loaded from metadata
+
+Agents must preserve this model unless there is explicit architectural approval.
+
+## Build Script Requirements
+
+The package build scripts MUST preserve the post-build shim copy step that places
+the boot asset shim at:
+
+`build/modules/boot/index.min.asset.php`
+
+This is part of the package's build behavior and must not be silently removed.
+
+## Shim Rule
+
+`shims/boot-asset.php` is a compatibility workaround.
+
+Agents MUST NOT remove it unless all of the following are confirmed:
+
+- the generated template no longer depends on that asset file
+- target WordPress and runtime support make the workaround unnecessary
+- the package has been validated without blank-page regressions
+
+## Init Module Rule
+
+`packages/init/` exists for runtime reasons, not just organization.
+
+Agents MUST treat it as part of the boot contract until proven otherwise.
+
+It currently serves to:
+
+- configure boot-time UI state such as menu icon behavior
+- ensure build and runtime dependency tracking includes boot-related modules
+
+Agents MUST NOT remove or bypass the init module without validating that
+boot dependencies are still correctly tracked and loaded.
+
+## Dependency Upgrade Rule
+
+Human review is required before changing any of these package dependencies:
+
+- `@wordpress/build`
+- `@wordpress/boot`
+- `@wordpress/route`
+
+Reason:
+small version shifts may change template behavior, module resolution, or boot expectations.
+
+## Generated Output Rule
+
+Agents MUST NOT edit:
+
+- `build/**`
+
+All build artifacts must be regenerated from source.
+
+## Definition of Done for Build-Sensitive Changes
+
+A build-sensitive change is complete only if:
+
+- package build succeeds
+- generated app still opens in `wp-admin`
+- the page does not render blank
+- route navigation still works
+- no shim-dependent regression is introduced

--- a/docs/route-contract.md
+++ b/docs/route-contract.md
@@ -1,0 +1,140 @@
+# Route Contract for Premium Analytics
+
+This document defines the required contract for routes in
+projects/packages/premium-analytics/routes
+
+---
+
+## Why This Exists
+
+Routes are discovered from package.json metadata and lazy-loaded into the
+full-page SPA shell.
+
+A route is not valid unless BOTH metadata and implementation exist.
+
+---
+
+## Required Route Structure
+
+Each route MUST live in:
+
+routes/<route-name>/
+
+Each route directory MUST contain:
+
+* package.json
+* stage.tsx
+
+---
+
+## Required package.json Metadata
+
+Each route package.json MUST include:
+
+* "private": true
+* "name": "<unique-route-package-name>"
+* "route.path": "<path>"
+* "route.page": "jetpack-premium-analytics"
+
+Example:
+
+{
+"private": true,
+"name": "_@jetpack-premium-analytics/example-route",
+"route": {
+"path": "/example",
+"page": "jetpack-premium-analytics"
+}
+}
+
+---
+
+## Required stage.tsx Export
+
+Each route MUST export:
+
+stage()
+
+Example:
+
+import React from 'react';
+
+export const stage = () => {
+return <div>Example Route</div>;
+};
+
+---
+
+## Path Rules
+
+Routes MUST:
+
+* use unique route.path values
+* use leading slashes (e.g. /dashboard, /reports)
+* map ONLY to page id jetpack-premium-analytics
+
+Routes MUST NOT:
+
+* duplicate another route path
+* register a different page id
+* omit the route metadata block
+* rely on side effects instead of exporting stage()
+
+---
+
+## Route-to-Sidebar Consistency
+
+If a route is navigable, sidebar items MUST match the route path.
+
+Example:
+
+* sidebar key: dashboard
+* label: Dashboard
+* path: /
+
+---
+
+## Adding a New Route (Agent Procedure)
+
+1. Create directory under routes/<route-name>/
+2. Add package.json with valid route metadata
+3. Implement stage.tsx
+4. Run build
+5. Verify route loads in SPA
+6. (Optional) Add sidebar entry
+
+---
+
+## Definition of Done
+
+A route is complete ONLY if:
+
+* metadata exists and is valid
+* stage() is exported
+* build succeeds
+* route loads correctly
+* no duplicate paths exist
+* sidebar (if any) matches path
+* loading / empty / error states defined (if data exists)
+
+---
+
+## Validation Rules
+
+Agents MUST validate:
+
+* JSON syntax in package.json
+* valid TS/JS in stage.tsx
+* stage() export exists
+* no runtime errors
+
+---
+
+## Escalation Rules
+
+Agents MUST request human review before:
+
+* modifying existing route paths
+* renaming routes used externally
+* changing route.page
+* adding dynamic routing

--- a/docs/ui-scope-contract.md
+++ b/docs/ui-scope-contract.md
@@ -1,0 +1,65 @@
+# UI Scope Contract for Premium Analytics
+
+This document defines what the current UI layer may assume.
+
+## Current Scope
+
+At present, this package should be treated as an application shell with a minimal
+dashboard route.
+
+Agents MUST assume:
+
+- route wiring exists
+- page bootstrapping exists
+- localization usage exists
+
+Agents MUST NOT assume, unless documented elsewhere in this package:
+
+- a stable analytics REST API exists
+- a premium analytics data schema exists
+- chart-ready selectors or stores exist
+- canonical metric definitions already exist
+- retention, aggregation, or segmentation rules already exist
+
+## No Invented Data Layer
+
+Agents MUST NOT invent:
+
+- endpoints
+- stores
+- selectors
+- event models
+- metrics
+- feature flags
+
+If a change requires data, the agent must first add a documented data contract.
+
+## Required States for Data-Backed UI
+
+If a route introduces data fetching, it MUST explicitly define:
+
+- source of truth
+- request lifecycle
+- loading state
+- empty state
+- error state
+- retry behavior, if applicable
+
+## Copy and Product Semantics Rule
+
+Agents MUST keep UI copy aligned with implemented functionality.
+
+Agents MUST NOT:
+
+- claim that analytics metrics exist when they do not
+- imply premium features are active when not implemented
+- describe insights, trends, or reports without backing logic
+
+## Definition of Done for New UI Features
+
+A new UI feature is complete only if:
+
+- the route renders correctly
+- all required user-visible states are defined
+- text does not overstate backend capability
+- any new data dependency is documented in a dedicated contract file

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3462,6 +3462,9 @@ importers:
 
   projects/packages/premium-analytics:
     dependencies:
+      '@automattic/charts':
+        specifier: workspace:*
+        version: link:../../js-packages/charts
       '@wordpress/boot':
         specifier: 0.10.0
         version: 0.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.7.0)

--- a/projects/packages/premium-analytics/CLAUDE.md
+++ b/projects/packages/premium-analytics/CLAUDE.md
@@ -1,0 +1,105 @@
+# CLAUDE.md — premium-analytics
+
+This file is authoritative. Read it fully before making any changes.
+
+Detailed rationale for every rule here lives in the monorepo docs:
+- `docs/agent-boundaries.md`
+- `docs/build-runtime-contract.md`
+- `docs/ui-scope-contract.md`
+- `docs/route-contract.md`
+
+---
+
+## What this package is
+
+A full-page SPA rendered inside `wp-admin`. Boot chain:
+
+1. `src/class-analytics.php` — PHP entry, registers admin page and enqueues build output
+2. `build/build.php` (generated) — registers boot and interceptor behavior
+3. `@wordpress/boot` — provides the full-page shell
+4. Routes discovered from `route` metadata in each `routes/*/package.json`, lazy-loaded
+
+**Do not break this chain.**
+
+---
+
+## Current file structure
+
+```
+src/class-analytics.php        PHP entry point
+shims/boot-asset.php           compatibility shim — DO NOT remove
+packages/init/src/index.ts     boot-time initialization (icon, menu state)
+routes/dashboard/              the only route so far
+  package.json                 route metadata
+  stage.tsx                    route component
+build/                         generated — never edit manually
+```
+
+---
+
+## Allowed without approval
+
+- Add or modify routes under `routes/**`
+- Edit `routes/**/stage.tsx`
+- Edit `packages/init/**`
+- Edit `src/class-analytics.php` while preserving the page boot contract
+- Add docs, tests, non-generated source files
+- Refine copy and localization strings
+
+---
+
+## Requires human approval
+
+- Changing page id `jetpack-premium-analytics`
+- Changing admin page slug `jetpack-premium-analytics`
+- Removing or modifying the shim copy step in build scripts
+- Removing or bypassing `packages/init/`
+- Changing `@wordpress/build`, `@wordpress/boot`, or `@wordpress/route` versions
+- Introducing new backend data contracts, REST endpoints, stores, or selectors
+- Modifying cross-package or monorepo-wide build behavior
+
+---
+
+## Never do
+
+- Edit anything inside `build/`
+- Invent endpoints, stores, selectors, event models, metrics, or feature flags
+- Write UI copy that implies analytics data or premium features exist when they do not
+
+---
+
+## Adding a route
+
+1. Create `routes/<name>/`
+2. Add `package.json` with:
+   ```json
+   {
+     "private": true,
+     "name": "_@jetpack-premium-analytics/<name>-route",
+     "route": {
+       "path": "/<path>",
+       "page": "jetpack-premium-analytics"
+     }
+   }
+   ```
+3. Add `stage.tsx` exporting `stage()`
+4. Run build
+5. Verify route loads in `wp-admin` without blank screen
+6. Add sidebar entry only if path matches an existing route
+
+---
+
+## Definition of done (build-sensitive changes)
+
+- [ ] Build succeeds
+- [ ] App opens in `wp-admin` without blank screen
+- [ ] Route navigation works
+- [ ] No shim-dependent regression
+
+---
+
+## Stop and ask a human when
+
+- Unsure whether a change affects boot sequence, route discovery, or admin page registration
+- Any change to page identity, slug, or `@wordpress/boot` assumptions
+- Introducing any data fetching, persistence, or analytics semantics

--- a/projects/packages/premium-analytics/changelog/add-premium-analytics-dashboard-pie-chart
+++ b/projects/packages/premium-analytics/changelog/add-premium-analytics-dashboard-pie-chart
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Analytics: Add pie chart with mock data to dashboard route

--- a/projects/packages/premium-analytics/changelog/claude-md-agent-contract
+++ b/projects/packages/premium-analytics/changelog/claude-md-agent-contract
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add CLAUDE.md agent contract for safe autonomous development

--- a/projects/packages/premium-analytics/package.json
+++ b/projects/packages/premium-analytics/package.json
@@ -28,6 +28,7 @@
 		}
 	},
 	"dependencies": {
+		"@automattic/charts": "workspace:*",
 		"@wordpress/boot": "0.10.0",
 		"@wordpress/data": "10.43.0",
 		"@wordpress/i18n": "^6.9.0",

--- a/projects/packages/premium-analytics/routes/dashboard/package.json
+++ b/projects/packages/premium-analytics/routes/dashboard/package.json
@@ -6,6 +6,7 @@
 		"page": "jetpack-premium-analytics"
 	},
 	"dependencies": {
+		"@automattic/charts": "workspace:*",
 		"@wordpress/i18n": "^6.9.0"
 	}
 }

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -1,10 +1,19 @@
+import { PieChart } from '@automattic/charts';
 import { __ } from '@wordpress/i18n';
+import type { DataPointPercentage } from '@automattic/charts';
+
+const DATA: DataPointPercentage[] = [
+	{ label: 'Direct', value: 4200 },
+	{ label: 'Search', value: 3100 },
+	{ label: 'Social', value: 1800 },
+	{ label: 'Referral', value: 900 },
+];
 
 export const stage = () => {
 	return (
 		<div className="jetpack-premium-analytics-dashboard">
 			<h1>{ __( 'Analytics', 'jetpack-premium-analytics' ) }</h1>
-			<p>{ __( 'Welcome to the Analytics dashboard.', 'jetpack-premium-analytics' ) }</p>
+			<PieChart data={ DATA } size={ 300 } withTooltips />
 		</div>
 	);
 };

--- a/projects/packages/premium-analytics/tasks/dashboard-pie-chart.md
+++ b/projects/packages/premium-analytics/tasks/dashboard-pie-chart.md
@@ -1,0 +1,89 @@
+# Task: Dashboard Pie Chart (Mock Data)
+
+## What
+
+Add a pie chart to the existing dashboard route using mock data.
+This is a UI-only change — no data fetching, no endpoints, no stores.
+
+## Scope
+
+You may only touch:
+
+- `routes/dashboard/stage.tsx`
+- `routes/dashboard/package.json` (only if a dependency needs to be added)
+- `package.json` at the package root (only if a dependency needs to be added)
+
+Do not create new routes, new packages, or new files outside this directory.
+
+## Implementation
+
+Use `PieChart` from `@automattic/charts`:
+
+```ts
+import { PieChart } from '@automattic/charts';
+import type { DataPointPercentage } from '@automattic/charts';
+```
+
+The chart must use hardcoded mock data of type `DataPointPercentage[]`:
+
+```ts
+const DATA: DataPointPercentage[] = [
+  { label: 'Direct', value: 4200 },
+  { label: 'Search', value: 3100 },
+  { label: 'Social', value: 1800 },
+  { label: 'Referral', value: 900 },
+];
+```
+
+Render the chart inside `stage()` below the existing heading.
+Use the `size` prop to set a fixed diameter (e.g. `size={ 300 }`).
+Use `withTooltips` prop.
+
+## Why PieChart, not LineChart
+
+`PieChart` uses a `size` prop to control its diameter directly.
+This avoids the ResizeObserver feedback loop that occurs when a chart
+measures its parent container and the parent has no fixed height.
+
+## Constraints
+
+- Mock data only — do not fetch, do not invent endpoints or stores
+- Do not claim these are real analytics metrics in any UI copy
+- Do not modify anything outside `routes/dashboard/` and the package root `package.json`
+- Do not edit files in `build/`
+
+## Definition of Done
+
+- [ ] Chart renders in `wp-admin` without blank screen or console errors
+- [ ] Mock data is visible as a pie chart
+- [ ] Tooltip appears on hover
+- [ ] Chart does not resize infinitely
+- [ ] Build succeeds
+- [ ] No changes outside allowed scope
+
+## Submitting
+
+1. Create a new branch from `trunk`:
+   ```bash
+   git fetch origin trunk
+   git checkout -b add/premium-analytics-dashboard-pie-chart origin/trunk
+   ```
+2. Add a changelog entry:
+   ```bash
+   pnpm jetpack changelogger add packages/premium-analytics --significance=patch --type=added --entry="Analytics: Add pie chart with mock data to dashboard route"
+   ```
+2. Commit all changes including the changelog entry.
+3. Push the branch and open a **draft PR** against `trunk`.
+4. PR description must include the Session Report below.
+
+## Session Report
+
+Fill this out in the PR description:
+
+```
+## Agent Session Report
+- Scope respected: yes / no
+- Escalations triggered: N
+- Contract violations: none / [describe]
+- Human rework needed: none / minor / major
+```

--- a/projects/packages/premium-analytics/tasks/dashboard-pie-chart.md
+++ b/projects/packages/premium-analytics/tasks/dashboard-pie-chart.md
@@ -63,10 +63,9 @@ measures its parent container and the parent has no fixed height.
 
 ## Submitting
 
-1. Create a new branch from `trunk`:
+1. Create a new branch from the current branch:
    ```bash
-   git fetch origin trunk
-   git checkout -b add/premium-analytics-dashboard-pie-chart origin/trunk
+   git checkout -b add/premium-analytics-dashboard-pie-chart
    ```
 2. Add a changelog entry:
    ```bash

--- a/tools/ai-sandbox/Dockerfile
+++ b/tools/ai-sandbox/Dockerfile
@@ -1,0 +1,38 @@
+FROM php:8.4-cli-bookworm
+
+USER root
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    unzip \
+    xz-utils \
+    ca-certificates \
+    tmux \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node 24
+RUN ARCH="$(dpkg --print-architecture)" && \
+    case "$ARCH" in \
+      amd64) NODE_ARCH="x64" ;; \
+      arm64) NODE_ARCH="arm64" ;; \
+      *) echo "Unsupported arch: $ARCH" && exit 1 ;; \
+    esac && \
+    curl -fsSLO "https://nodejs.org/download/release/v24.14.1/node-v24.14.1-linux-${NODE_ARCH}.tar.gz" && \
+    mkdir -p /usr/local/lib/nodejs && \
+    tar -xzf "node-v24.14.1-linux-${NODE_ARCH}.tar.gz" -C /usr/local/lib/nodejs --strip-components=1 && \
+    rm "node-v24.14.1-linux-${NODE_ARCH}.tar.gz"
+
+ENV PATH="/usr/local/lib/nodejs/bin:${PATH}"
+
+RUN npm install -g pnpm@10.28.2 @anthropic-ai/claude-code
+
+# Install Composer 2.9.2
+RUN curl -sS https://getcomposer.org/installer | php -- \
+    --version=2.9.2 \
+    --install-dir=/usr/local/bin \
+    --filename=composer
+
+RUN useradd -ms /bin/bash dev
+USER dev
+WORKDIR /home/dev/jetpack

--- a/tools/ai-sandbox/Dockerfile
+++ b/tools/ai-sandbox/Dockerfile
@@ -9,6 +9,9 @@ RUN apt-get update && apt-get install -y \
     xz-utils \
     ca-certificates \
     tmux \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y gh \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Node 24

--- a/tools/ai-sandbox/Dockerfile
+++ b/tools/ai-sandbox/Dockerfile
@@ -33,6 +33,9 @@ RUN curl -sS https://getcomposer.org/installer | php -- \
     --install-dir=/usr/local/bin \
     --filename=composer
 
-RUN useradd -ms /bin/bash dev
+RUN useradd -ms /bin/bash dev && \
+    mkdir -p /home/dev/jetpack/node_modules && \
+    chown -R dev:dev /home/dev/jetpack
+
 USER dev
 WORKDIR /home/dev/jetpack

--- a/tools/ai-sandbox/README.md
+++ b/tools/ai-sandbox/README.md
@@ -1,0 +1,128 @@
+# Jetpack AI Sandbox
+
+Experimental AI-first development environment for the Jetpack monorepo.
+
+⚠️ Not production-ready.  
+⚠️ Do not use for core development without review.
+
+---
+
+## Quick Start
+
+```bash
+cd tools/ai-sandbox
+docker compose up -d --build
+docker exec -it jetpack-ai-sandbox bash
+cd ~/jetpack
+pnpm install
+```
+
+---
+
+## Verify Environment
+
+```bash
+node -v
+pnpm -v
+php -v
+composer --version
+pnpm exec jetpack --help
+```
+
+Expected: Node 24.x, pnpm 10.x, PHP 8.4.x, Composer 2.9.2
+
+---
+
+## Start Claude
+
+```bash
+cd ~/jetpack
+IS_SANDBOX=1 claude --dangerously-skip-permissions --remote-control "my-agent-jetpack"
+```
+
+On first run, follow the login prompt (use **claude.ai**, not API key).
+
+Then open:  
+https://claude.ai/code
+
+The session will appear automatically.  
+Keep Claude running — closing it ends the session.
+
+---
+
+## Optional: Keep Claude Running
+
+One-liner to start a detached tmux session with Claude already running:
+
+```bash
+tmux new-session -d -s my-agent "IS_SANDBOX=1 claude --dangerously-skip-permissions --remote-control my-agent-jetpack"
+```
+
+Or start tmux manually, then run Claude inside:
+
+```bash
+tmux new -s my-agent
+```
+
+Detach:  
+Ctrl-b d
+
+Reattach:
+
+```bash
+tmux attach -t my-agent
+```
+
+---
+
+## Validation
+
+```bash
+git status
+git diff --stat
+git diff
+```
+
+Ensure changes stay within `projects/plugins/premium-analytics/`.
+
+---
+
+## Troubleshooting
+
+Container issues:
+
+```bash
+docker compose up -d --build
+docker ps
+```
+
+Claude not connecting:
+
+- Restart Claude
+- Ensure it stays running
+
+OAuth error:
+
+- Retry login
+
+1M context error:
+
+```text
+/model
+```
+
+→ select standard
+
+---
+
+## Purpose
+
+- Test AI-assisted workflows
+- Isolate experiments from production
+- Enable safe iteration with agents
+
+---
+
+## Status
+
+Experimental / subject to change

--- a/tools/ai-sandbox/README.md
+++ b/tools/ai-sandbox/README.md
@@ -14,6 +14,7 @@ cd tools/ai-sandbox
 docker compose up -d --build
 docker exec -it jetpack-ai-sandbox bash
 cd ~/jetpack
+gh auth login
 pnpm install
 ```
 

--- a/tools/ai-sandbox/docker-compose.yml
+++ b/tools/ai-sandbox/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.9'
+
+services:
+  jetpack-ai:
+    build: .
+    container_name: jetpack-ai-sandbox
+    command: sleep infinity
+    volumes:
+      - ~/.claude:/home/dev/.claude
+      - ../../:/home/dev/jetpack
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ~/.ssh/id_ed25519:/home/dev/.ssh/id_ed25519:ro
+      - ~/.ssh/known_hosts:/home/dev/.ssh/known_hosts:ro
+    working_dir: /home/dev/jetpack
+    stdin_open: true
+    tty: true

--- a/tools/ai-sandbox/docker-compose.yml
+++ b/tools/ai-sandbox/docker-compose.yml
@@ -11,6 +11,10 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ~/.ssh/id_ed25519:/home/dev/.ssh/id_ed25519:ro
       - ~/.ssh/known_hosts:/home/dev/.ssh/known_hosts:ro
+      - jetpack_node_modules:/home/dev/jetpack/node_modules
     working_dir: /home/dev/jetpack
     stdin_open: true
     tty: true
+
+volumes:
+  jetpack_node_modules:


### PR DESCRIPTION
## Summary
- Adds `PieChart` from `@automattic/charts` to the dashboard route (`routes/dashboard/stage.tsx`)
- Uses hardcoded mock data (`DataPointPercentage[]`) — no data fetching or endpoints
- Chart renders with `size={300}` and `withTooltips` enabled

## Test plan
- [ ] Build succeeds (`pnpm build` in `projects/packages/premium-analytics`)
- [ ] Chart renders in `wp-admin` without blank screen or console errors
- [ ] Mock data is visible as a pie chart with four segments (Direct, Search, Social, Referral)
- [ ] Tooltip appears on hover
- [ ] Chart does not resize infinitely

## Agent Session Report
- Scope respected: yes
- Escalations triggered: 0
- Contract violations: none
- Human rework needed: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)