### PR TITLE
premium-analytics: add pie chart with mock data to dashboard route

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3462,6 +3462,9 @@ importers:
 
   projects/packages/premium-analytics:
     dependencies:
+      '@automattic/charts':
+        specifier: workspace:*
+        version: link:../../js-packages/charts
       '@wordpress/boot':
         specifier: 0.10.0
         version: 0.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@17.7.0)

--- a/projects/packages/premium-analytics/changelog/add-premium-analytics-dashboard-pie-chart
+++ b/projects/packages/premium-analytics/changelog/add-premium-analytics-dashboard-pie-chart
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Analytics: Add pie chart with mock data to dashboard route

--- a/projects/packages/premium-analytics/package.json
+++ b/projects/packages/premium-analytics/package.json
@@ -28,6 +28,7 @@
 		}
 	},
 	"dependencies": {
+		"@automattic/charts": "workspace:*",
 		"@wordpress/boot": "0.10.0",
 		"@wordpress/data": "10.43.0",
 		"@wordpress/i18n": "^6.9.0",

--- a/projects/packages/premium-analytics/routes/dashboard/package.json
+++ b/projects/packages/premium-analytics/routes/dashboard/package.json
@@ -6,6 +6,7 @@
 		"page": "jetpack-premium-analytics"
 	},
 	"dependencies": {
+		"@automattic/charts": "workspace:*",
 		"@wordpress/i18n": "^6.9.0"
 	}
 }

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -1,10 +1,20 @@
+import { PieChart } from '@automattic/charts';
 import { __ } from '@wordpress/i18n';
+import type { DataPointPercentage } from '@automattic/charts';
+
+const DATA: DataPointPercentage[] = [
+	{ label: 'Direct', value: 4200 },
+	{ label: 'Search', value: 3100 },
+	{ label: 'Social', value: 1800 },
+	{ label: 'Referral', value: 900 },
+];
 
 export const stage = () => {
 	return (
 		<div className="jetpack-premium-analytics-dashboard">
 			<h1>{ __( 'Analytics', 'jetpack-premium-analytics' ) }</h1>
 			<p>{ __( 'Welcome to the Analytics dashboard.', 'jetpack-premium-analytics' ) }</p>
+			<PieChart data={ DATA } size={ 300 } withTooltips />
 		</div>
 	);
 };


### PR DESCRIPTION
## Summary

- Add `PieChart` from `@automattic/charts` to the dashboard route
- Uses hardcoded mock data (`DataPointPercentage[]`) — no data fetching
- `size={300}` avoids ResizeObserver feedback loop
- `withTooltips` enabled

## Agent Session Report

- Scope respected: yes
- Escalations triggered: 0
- Contract violations: none
- Human rework needed: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)