### PR TITLE
VideoPress: fix PHP warning when video info lookup returns false

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-guid-warning
+++ b/projects/packages/videopress/changelog/fix-videopress-guid-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix PHP warning when video info lookup returns false on WPCOM.

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
@@ -218,7 +218,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 		} else {
 			$blog_id    = get_current_blog_id();
 			$info       = video_get_info_by_blogpostid( $blog_id, $post_id );
-			$found_guid = $info->guid;
+			$found_guid = $info ? $info->guid : '';
 		}
 
 		if ( ! $found_guid ) {

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
@@ -436,7 +436,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 		} else {
 			$blog_id = get_current_blog_id();
 			$info    = video_get_info_by_blogpostid( $blog_id, $post_id );
-			$guid    = $info->guid;
+			$guid    = $info ? $info->guid : '';
 		}
 
 		if ( ! $guid ) {


### PR DESCRIPTION
Fixes #

## Proposed changes
* Guard against `video_get_info_by_blogpostid()` returning `false` in `videopress_video_belong_to_site()` so accessing `->guid` no longer emits `Warning: Attempt to read property "guid" on false` in `class-wpcom-rest-api-v2-endpoint-videopress.php:221`.
* When no video info is found, the endpoint now returns `{ "video-belong-to-site": false }` cleanly.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a WPCOM site, call `/wpcom/v2/sites/{site_id}/videopress/{guid}/check-ownership/{post_id}` with a `post_id` that has no associated VideoPress video info.
* Confirm the PHP error log no longer records `Attempt to read property "guid" on false` from this endpoint.
* Confirm the response body is `{ "video-belong-to-site": false }`.
* Repeat with a `post_id` that does own the given `guid`; response should be `{ "video-belong-to-site": true }`.
