### PR TITLE
Search: Remove redundant @wordpress/interactivity import from display only block view.js

### DIFF
--- a/projects/packages/search/changelog/drop-redundant-interactivity-import
+++ b/projects/packages/search/changelog/drop-redundant-interactivity-import
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove redundant @wordpress/interactivity import from no-results block view.

--- a/projects/packages/search/changelog/drop-redundant-interactivity-import
+++ b/projects/packages/search/changelog/drop-redundant-interactivity-import
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Remove redundant @wordpress/interactivity import from no-results block view.
+Remove redundant @wordpress/interactivity imports from display-only block views.

--- a/projects/packages/search/src/search-blocks/blocks/load-more/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/load-more/view.js
@@ -1,4 +1,3 @@
 // loadMore action is defined in store/index.js. Import the store + styles.
-import '@wordpress/interactivity';
 import '../../store';
 import './style.scss';

--- a/projects/packages/search/src/search-blocks/blocks/no-results/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/no-results/view.js
@@ -1,4 +1,3 @@
 // Display-only block. View module pulls in the shared store so
 // state.showNoResults is defined on pages that only use this block.
-import '@wordpress/interactivity';
 import '../../store';

--- a/projects/packages/search/src/search-blocks/blocks/results-count/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/results-count/view.js
@@ -1,5 +1,4 @@
 // Display-only block. View module pulls in the style + shared store so
 // state.resultsCountText is defined and updates re-render the node.
-import '@wordpress/interactivity';
 import '../../store';
 import './style.scss';

--- a/projects/packages/search/src/search-blocks/blocks/search-results/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-results/view.js
@@ -1,5 +1,4 @@
 // Intentionally empty: this block is fully declarative.
 // Importing the store registers the shared actions/state on pages with this block.
-import '@wordpress/interactivity';
 import '../../store';
 import './style.scss';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes RSM-275

## Proposed changes

* Remove the standalone `import '@wordpress/interactivity'` from all four display-only block view modules:
  - `blocks/no-results/view.js`
  - `blocks/search-results/view.js`
  - `blocks/load-more/view.js`
  - `blocks/results-count/view.js`

The import is a no-op in each case: the shared store (`../../store`) already imports `{ store } from '@wordpress/interactivity'`, and ES module evaluation is cached by the runtime. The stray side-effect imports just add resolved-but-empty module dependencies to the view bundles.

The two blocks that *do* use `@wordpress/interactivity` directly (`search-input` and `sort-control`) are left untouched — their named import of `{ store }` is functional.

## Related product discussion/links

* Linear: RSM-275
* PR #48198 — Claude bot review (Pass 4) "Minor Notes"

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Verify that no `import '@wordpress/interactivity'` side-effect imports remain in `projects/packages/search/src/search-blocks/blocks/*/view.js`.
* Confirm each display-only block still has `import '../../store'` intact, which transitively pulls in `@wordpress/interactivity` via the store module.
* No functional behavior change — this is a dead-import cleanup across all display-only blocks.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [RSM-275](https://linear.app/a8c/issue/RSM-275/search-30-drop-redundant-wordpressinteractivity-import-in-no)

<div><a href="https://cursor.com/agents/bc-1b679a84-d283-4909-9b26-850579c27b35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b679a84-d283-4909-9b26-850579c27b35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

