### PR TITLE
Search 3.0: keep results list in DOM so aria-live announcements fire

### DIFF
--- a/projects/packages/search/changelog/fix-search-results-aria-live-region
+++ b/projects/packages/search/changelog/fix-search-results-aria-live-region
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search 3.0: Keep the search results list in the DOM so screen readers announce updates from the ARIA live region.

--- a/projects/packages/search/src/search-blocks/blocks/search-results/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/search-results/render.php
@@ -29,7 +29,6 @@ namespace Automattic\Jetpack\Search;
 
 	<ul
 		class="jetpack-search-results__list"
-		data-wp-bind--hidden="state.isLoading"
 		aria-live="polite"
 	>
 		<template

--- a/projects/packages/search/src/search-blocks/blocks/search-results/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/search-results/style.scss
@@ -15,10 +15,6 @@
 		list-style: none;
 		margin: 0;
 		padding: 0;
-
-		&[hidden] {
-			display: none;
-		}
 	}
 
 	.jetpack-search-results__item {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes RSM-273

## Proposed changes

* Remove `data-wp-bind--hidden="state.isLoading"` from the search-results `<ul>` in `projects/packages/search/src/search-blocks/blocks/search-results/render.php`. Toggling `hidden` (which applies `display: none`) on an `aria-live` region prevents screen readers from announcing new content when it arrives — the ARIA spec requires live regions to remain visible when their content changes. The empty list takes no space, so layout is unaffected.
* Drop the now-unused `.jetpack-search-results__list[hidden]` rule in `search-results/style.scss`.
* The existing separate loading `<div>` still handles the visual "Loading…" indicator, and the outer wrapper keeps `data-wp-bind--aria-busy="state.isLoading"` so assistive tech is still told when a query is in flight.

## Related product discussion/links

* Linear: RSM-273
* Follow-up to #48198 (Claude bot Pass 4 review: "aria-live region is hidden during load").

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Enable the Search 3.0 blocks and place the Search Results block on a page (see the Search Blocks pattern).
2. With VoiceOver (macOS) or NVDA (Windows) running, focus the search input and run a query.
3. Confirm that after the request resolves, the screen reader announces the updated results (e.g. the first result's title) from the `<ul aria-live="polite">`. Previously, no announcement fired because the `<ul>` was toggled to `display: none` during the request.
4. Throttle the network in DevTools and run several queries in succession; verify there is no visual flicker of stale results between queries. (If a flicker appears in the future, swap in `data-wp-bind--aria-busy` on the `<ul>` itself rather than hiding it.)

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [RSM-273](https://linear.app/a8c/issue/RSM-273/search-30-keep-the-search-results-ul-in-the-dom-so-aria-live)

<div><a href="https://cursor.com/agents/bc-3277f283-10fb-4880-aa72-68694833fff5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3277f283-10fb-4880-aa72-68694833fff5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

