### PR TITLE
Search 3.0: fix load-more button loading states

### DIFF
--- a/projects/packages/search/changelog/fix-jps3-load-more-loading-state
+++ b/projects/packages/search/changelog/fix-jps3-load-more-loading-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search 3.0: hide the load-more wrapper while a first-page search is in flight, and swap the button for a spinner while paginating.

--- a/projects/packages/search/src/search-blocks/blocks/load-more/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/load-more/render.php
@@ -17,7 +17,7 @@ namespace Automattic\Jetpack\Search;
 	<button
 		class="jetpack-search-load-more__button"
 		data-wp-on--click="actions.loadMore"
-		data-wp-bind--disabled="state.isLoadingMore"
+		data-wp-bind--hidden="state.isLoadingMore"
 	>
 		<?php esc_html_e( 'Load more results', 'jetpack-search-pkg' ); ?>
 	</button>

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -85,15 +85,17 @@ const { state, actions } = store( NAMESPACE, {
 		},
 
 		/**
-		 * Derived load-more wrapper visibility. Only checks `pageHandle`
-		 * (whether another page is available) — the button and spinner
-		 * inside handle their own loading-state visibility, which lets
-		 * the spinner remain visible while `isLoadingMore` is true.
+		 * Derived load-more wrapper visibility. Hidden while the first-page
+		 * fetch is in flight so a stale `pageHandle` from the previous query
+		 * doesn't flash a "Load more" button against results that no longer
+		 * match. `isLoadingMore` (paginating the current query) stays
+		 * orthogonal — the wrapper stays visible and its children swap the
+		 * button for a spinner via their own bindings.
 		 *
 		 * @return {boolean} True when the load-more wrapper should show.
 		 */
 		get showLoadMore() {
-			return !! state.pageHandle;
+			return !! state.pageHandle && ! state.isLoading;
 		},
 	},
 


### PR DESCRIPTION
Fixes #

## Proposed changes
* **Wrapper visibility** — `state.showLoadMore` now ANDs in `! state.isLoading`, so the load-more block collapses during a first-page fetch (new query, sort change, deep link). Previously the previous query's `pageHandle` flashed a "Load more" button against results that no longer matched until the new response arrived.
* **Button vs. spinner** — `jetpack/load-more`'s button now binds `data-wp-bind--hidden` to `state.isLoadingMore` instead of `data-wp-bind--disabled`. While paginating, the wrapper stays in flow; the button disappears and the adjacent "Loading…" spinner takes its place — matching the UX for a loading-next-page action.

Both paths leave `isLoadingMore` (pagination) orthogonal to `isLoading` (first-page fetch).

This is a pure polish / bug-fix PR against the Phase 1 Interactivity API foundation (#48198). Split out from #48227 so it can land independently of the Phase 2 filter-blocks work.

## Related product discussion/links
n/a

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. Rsync the `jetpack` plugin to a Jurassic Ninja site and activate Jetpack Search.
2. Insert the **Blog Search Page** pattern on a new page and publish.
3. Visit `/?s=foo` for a term with more than 10 results, then:
   - Click **Load more results**. Verify the button is replaced by a "Loading…" spinner while the request is in flight; once the response arrives, the new results append and the button returns (or disappears if there are no more pages).
   - From a loaded state, submit a new search. Verify the load-more wrapper collapses immediately (no brief "Load more" flash against stale results) and reappears only after the new response lands.
   - Do a sort change from the same row. Verify the same collapse-and-return behavior.
4. Run `pnpm --filter jetpack-search test` to confirm the existing JS coverage still passes.