### PR TITLE
Search 3.0: add icons for Jetpack Search blocks

### DIFF
--- a/projects/packages/search/changelog/feature-jps3-block-icons
+++ b/projects/packages/search/changelog/feature-jps3-block-icons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Search 3.0: add icons for the Jetpack Search blocks and improve Blog Search pattern keywords.

--- a/projects/packages/search/src/search-blocks/blocks/active-filters/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/active-filters/block.json
@@ -5,6 +5,7 @@
 	"version": "0.1.0",
 	"title": "Active Filters",
 	"category": "jetpack-search",
+	"icon": "tag",
 	"description": "Pills showing the currently selected Jetpack Search filters.",
 	"supports": { "html": false, "interactivity": true },
 	"textdomain": "jetpack-search-pkg",

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/block.json
@@ -5,6 +5,7 @@
 	"version": "0.1.0",
 	"title": "Checkbox Filter",
 	"category": "jetpack-search",
+	"icon": "filter",
 	"description": "Checkbox filter for Jetpack Search. Use a variation (Category, Tag, Post Type, Author, Custom Taxonomy) or configure manually.",
 	"supports": {
 		"html": false,

--- a/projects/packages/search/src/search-blocks/blocks/load-more/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/load-more/block.json
@@ -5,6 +5,7 @@
 	"version": "0.1.0",
 	"title": "Load More",
 	"category": "jetpack-search",
+	"icon": "plus-alt2",
 	"description": "Loads the next page of Jetpack Search results.",
 	"supports": { "html": false, "interactivity": true },
 	"textdomain": "jetpack-search-pkg",

--- a/projects/packages/search/src/search-blocks/blocks/no-results/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/no-results/block.json
@@ -5,6 +5,7 @@
 	"version": "0.1.0",
 	"title": "No Results",
 	"category": "jetpack-search",
+	"icon": "no-alt",
 	"description": "Message shown when Jetpack Search returns no results.",
 	"supports": { "html": false, "interactivity": true },
 	"textdomain": "jetpack-search-pkg",

--- a/projects/packages/search/src/search-blocks/blocks/results-count/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/results-count/block.json
@@ -5,6 +5,7 @@
 	"version": "0.1.0",
 	"title": "Results Count",
 	"category": "jetpack-search",
+	"icon": "info-outline",
 	"description": "Displays the Jetpack Search results count.",
 	"supports": { "html": false, "interactivity": true },
 	"textdomain": "jetpack-search-pkg",

--- a/projects/packages/search/src/search-blocks/blocks/search-input/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/block.json
@@ -5,6 +5,7 @@
 	"version": "0.1.0",
 	"title": "Search Input",
 	"category": "jetpack-search",
+	"icon": "search",
 	"description": "Text input that drives Jetpack Search results.",
 	"supports": {
 		"html": false,

--- a/projects/packages/search/src/search-blocks/blocks/search-results/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/search-results/block.json
@@ -5,6 +5,7 @@
 	"version": "0.1.0",
 	"title": "Search Results",
 	"category": "jetpack-search",
+	"icon": "list-view",
 	"description": "Displays Jetpack Search results.",
 	"supports": {
 		"html": false,

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/block.json
@@ -5,6 +5,7 @@
 	"version": "0.1.0",
 	"title": "Sort Control",
 	"category": "jetpack-search",
+	"icon": "sort",
 	"description": "Controls the order of Jetpack Search results.",
 	"supports": { "html": false, "interactivity": true },
 	"textdomain": "jetpack-search-pkg",

--- a/projects/packages/search/src/search-blocks/patterns/blog-search.php
+++ b/projects/packages/search/src/search-blocks/patterns/blog-search.php
@@ -13,6 +13,12 @@ register_block_pattern(
 		'title'       => __( 'Blog Search Page', 'jetpack-search-pkg' ),
 		'description' => __( 'A full-page search layout with sidebar filters and a result list powered by Jetpack Search.', 'jetpack-search-pkg' ),
 		'categories'  => array( 'jetpack-search' ),
+		'keywords'    => array(
+			__( 'search', 'jetpack-search-pkg' ),
+			__( 'blog', 'jetpack-search-pkg' ),
+			__( 'results', 'jetpack-search-pkg' ),
+			__( 'jetpack search', 'jetpack-search-pkg' ),
+		),
 		'content'     => '<!-- wp:group {"style":{"spacing":{"blockGap":"1.5rem"}}} -->
 <div class="wp-block-group">
 <!-- wp:jetpack/search-input /-->


### PR DESCRIPTION
Fixes RSM-270.

## Proposed changes
* Declare `icon` on every Jetpack Search block's `block.json` (dashicon slugs: `search`, `list-view`, `filter`, `tag`, `sort`, `info-outline`, `no-alt`, `plus-alt2`). Each block now shows a distinct glyph in the inserter, list view, and parent selector instead of the "no icon" placeholder flagged in #48198 (r3114795179).
* Add search-related `keywords` to the Blog Search Page pattern so it surfaces reliably in the pattern inserter. `register_block_pattern()` has no per-pattern icon field.

Covers all 8 blocks: `search-input`, `search-results`, `filter-checkbox`, `active-filters`, `sort-control`, `results-count`, `no-results`, `load-more`.

Site-editor placeholder previews (so blocks don't render as empty shells when `ServerSideRender` runs in an editor context without live state) ship in a follow-up PR.

## Related product discussion/links
* Linear: RSM-270
* Review comment that flagged the missing icons: #48198 (r3114795179)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. Sync the branch to a Jurassic Ninja site or local WP install with `jetpack_search_blocks_enabled` on.
2. In the block inserter, open the "Jetpack Search" category and confirm every block (Search Input, Search Results, Checkbox Filter, Active Filters, Sort Control, Results Count, No Results, Load More) renders its own dashicon rather than the generic "no icon" tile.
3. Insert the **Blog Search Page** pattern from the pattern inserter. Searching for `search`, `blog`, `results`, or `jetpack search` should surface it.
4. On the front end, load a page containing the blocks and run a query — behavior is unchanged (this PR does not touch `render.php`, the Interactivity store, or view scripts).

<img width="334" height="329" alt="Screenshot 2026-04-22 at 3 54 17 PM" src="https://github.com/user-attachments/assets/bfc64c55-430c-47ed-ac91-3346531559fd" />
