### PR TITLE
Search 3.0: sample-data block previews in the Site Editor

### DIFF
--- a/projects/packages/search/changelog/feature-jps3-block-editor-previews
+++ b/projects/packages/search/changelog/feature-jps3-block-editor-previews
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Search 3.0: render sample data in the Site Editor preview for each search block so designers see a real DOM shape instead of an empty ServerSideRender shell.

--- a/projects/packages/search/changelog/feature-jps3-block-editor-previews
+++ b/projects/packages/search/changelog/feature-jps3-block-editor-previews
@@ -1,4 +1,4 @@
-Significance: patch
+Significance: minor
 Type: added
 
 Search 3.0: render sample data in the Site Editor preview for each search block so designers see a real DOM shape instead of an empty ServerSideRender shell.

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -15,21 +15,24 @@ import { registerBlockType } from '@wordpress/blocks';
 import { createElement as h } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
+// Mock result data. Dates are intentionally not wrapped in __() because
+// they are fixed display strings, not translatable content — localized
+// dates come from `formatDate()` on the live front end.
 const SAMPLE_RESULTS = [
 	{
 		title: __( 'First sample result', 'jetpack-search-pkg' ),
 		path: 'example.com/articles/first',
-		date: __( 'Apr 1, 2026', 'jetpack-search-pkg' ),
+		date: 'Apr 1, 2026',
 	},
 	{
 		title: __( 'Another relevant post', 'jetpack-search-pkg' ),
 		path: 'example.com/guides/another',
-		date: __( 'Mar 22, 2026', 'jetpack-search-pkg' ),
+		date: 'Mar 22, 2026',
 	},
 	{
 		title: __( 'Older archived entry', 'jetpack-search-pkg' ),
 		path: 'example.com/2025/older',
-		date: __( 'Dec 18, 2025', 'jetpack-search-pkg' ),
+		date: 'Dec 18, 2025',
 	},
 ];
 
@@ -38,6 +41,11 @@ const SAMPLE_FILTER_ITEMS = [
 	{ value: 'two', label: __( 'Second option', 'jetpack-search-pkg' ), count: 12 },
 	{ value: 'three', label: __( 'Third option', 'jetpack-search-pkg' ), count: 7 },
 ];
+
+// The editor only renders one instance of each block at a time, so a stable
+// static id is enough to wire up label/input and label/select pairs.
+const SEARCH_INPUT_PREVIEW_ID = 'jetpack-search-input-preview';
+const SORT_CONTROL_PREVIEW_ID = 'jetpack-search-sort-preview';
 
 /**
  * Render the magnifying-glass glyph used by the search input, matching the
@@ -64,7 +72,9 @@ function SearchGlyph() {
 }
 
 /**
- * Editor preview for jetpack/search-input.
+ * Editor preview for jetpack/search-input. Mirrors render.php's full
+ * structure — screen-reader label, icon, input, and the (initially hidden)
+ * clear button — so designers can target every CSS hook.
  *
  * @return {object} Rendered element.
  */
@@ -74,23 +84,44 @@ function SearchInputEdit() {
 		'div',
 		blockProps,
 		h(
+			'label',
+			{
+				className: 'jetpack-search-input__label screen-reader-text',
+				htmlFor: SEARCH_INPUT_PREVIEW_ID,
+			},
+			__( 'Search', 'jetpack-search-pkg' )
+		),
+		h(
 			'div',
 			{ className: 'jetpack-search-input__inside-wrapper' },
 			h( SearchGlyph, null ),
 			h( 'input', {
+				id: SEARCH_INPUT_PREVIEW_ID,
 				type: 'search',
 				className: 'jetpack-search-input__field',
 				placeholder: __( 'Search…', 'jetpack-search-pkg' ),
 				disabled: true,
 				readOnly: true,
-			} )
+			} ),
+			h(
+				'button',
+				{
+					type: 'button',
+					className: 'jetpack-search-input__clear',
+					hidden: true,
+					disabled: true,
+					'aria-label': __( 'Clear search', 'jetpack-search-pkg' ),
+				},
+				'×'
+			)
 		)
 	);
 }
 
 /**
- * Editor preview for jetpack/search-results. Renders sample rows so the
- * block surfaces in the canvas even though live results need the runtime.
+ * Editor preview for jetpack/search-results. Renders sample rows, including
+ * the (hidden) image-link wrapper render.php emits so designers can style
+ * the `.jetpack-search-results__image-link` / `__image` CSS hooks.
  *
  * @return {object} Rendered element.
  */
@@ -112,6 +143,16 @@ function SearchResultsEdit() {
 						h( 'h3', { className: 'jetpack-search-results__title' }, result.title ),
 						h( 'div', { className: 'jetpack-search-results__path' }, result.path ),
 						h( 'div', { className: 'jetpack-search-results__date' }, result.date )
+					),
+					h(
+						'a',
+						{
+							className: 'jetpack-search-results__image-link',
+							hidden: true,
+							tabIndex: -1,
+							'aria-hidden': 'true',
+						},
+						h( 'img', { className: 'jetpack-search-results__image', alt: '' } )
 					)
 				)
 			)
@@ -148,7 +189,7 @@ function FilterCheckboxEdit( { attributes } ) {
 						h( 'input', { type: 'checkbox', disabled: true } ),
 						h( 'span', { className: 'jetpack-search-filter__label' }, item.label ),
 						showCount
-							? h( 'span', { className: 'jetpack-search-filter__count' }, item.count )
+							? h( 'span', { className: 'jetpack-search-filter__count' }, String( item.count ) )
 							: null
 					)
 				)
@@ -213,7 +254,8 @@ function ActiveFiltersEdit() {
 }
 
 /**
- * Editor preview for jetpack/sort-control.
+ * Editor preview for jetpack/sort-control. Pairs the label and select via
+ * htmlFor/id so the preview has the same a11y semantics as render.php.
  *
  * @return {object} Rendered element.
  */
@@ -222,10 +264,10 @@ function SortControlEdit() {
 	return h(
 		'div',
 		blockProps,
-		h( 'label', null, __( 'Sort by', 'jetpack-search-pkg' ) ),
+		h( 'label', { htmlFor: SORT_CONTROL_PREVIEW_ID }, __( 'Sort by', 'jetpack-search-pkg' ) ),
 		h(
 			'select',
-			{ disabled: true, defaultValue: 'relevance' },
+			{ id: SORT_CONTROL_PREVIEW_ID, disabled: true, defaultValue: 'relevance' },
 			h( 'option', { value: 'relevance' }, __( 'Relevance', 'jetpack-search-pkg' ) ),
 			h( 'option', { value: 'newest' }, __( 'Newest', 'jetpack-search-pkg' ) ),
 			h( 'option', { value: 'oldest' }, __( 'Oldest', 'jetpack-search-pkg' ) )
@@ -234,13 +276,15 @@ function SortControlEdit() {
 }
 
 /**
- * Editor preview for jetpack/results-count.
+ * Editor preview for jetpack/results-count. Matches the copy the live store
+ * emits via `state.resultsCountText` (see store/index.js) so the preview
+ * reflects the same string designers style on the front end.
  *
  * @return {object} Rendered element.
  */
 function ResultsCountEdit() {
 	const blockProps = useBlockProps();
-	return h( 'p', blockProps, __( 'Showing 1–10 of 42 results', 'jetpack-search-pkg' ) );
+	return h( 'p', blockProps, __( '42 results', 'jetpack-search-pkg' ) );
 }
 
 /**
@@ -259,7 +303,9 @@ function NoResultsEdit( { attributes } ) {
 }
 
 /**
- * Editor preview for jetpack/load-more.
+ * Editor preview for jetpack/load-more. Includes the (hidden) loading-
+ * spinner span render.php emits so the `.jetpack-search-load-more__spinner`
+ * CSS hook is available to style.
  *
  * @return {object} Rendered element.
  */
@@ -276,6 +322,11 @@ function LoadMoreEdit() {
 				disabled: true,
 			},
 			__( 'Load more results', 'jetpack-search-pkg' )
+		),
+		h(
+			'span',
+			{ className: 'jetpack-search-load-more__spinner', hidden: true },
+			__( 'Loading…', 'jetpack-search-pkg' )
 		)
 	);
 }

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -1,57 +1,305 @@
 /**
  * Editor-side registration for Jetpack Search blocks.
  *
- * Server-side block.json metadata is bootstrapped by WordPress via
- * wp.blocks.unstable__bootstrapServerSideBlockDefinitions(), but nothing
- * calls registerBlockType() for these dynamic blocks — so the editor sees
- * metadata without a block definition and renders the "Your site doesn't
- * include support for..." fallback. This file provides the minimal
- * client-side registration: each block previews with ServerSideRender so
- * what you see in the editor matches what render.php produces on the front
- * end.
+ * Each block registers a static preview Edit component that mirrors the DOM
+ * shape its render.php produces on the front end after JS hydration. The
+ * previews use simple mock data — sample result cards, sample filter
+ * buckets, a sample pill — rather than piping render.php through
+ * ServerSideRender. The live output leans on the Interactivity store
+ * (`state.results`, `state.filterItems`, `state.resultsCountText`, …) which
+ * doesn't hydrate in an editor context, so data-driven blocks otherwise
+ * rendered as empty shells in the Site Editor.
  */
 import { useBlockProps } from '@wordpress/block-editor';
 import { registerBlockType } from '@wordpress/blocks';
-import { createElement } from '@wordpress/element';
-import ServerSideRender from '@wordpress/server-side-render';
+import { createElement as h } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
-const BLOCK_NAMES = [
-	'jetpack/search-input',
-	'jetpack/search-results',
-	'jetpack/filter-checkbox',
-	'jetpack/active-filters',
-	'jetpack/sort-control',
-	'jetpack/results-count',
-	'jetpack/no-results',
-	'jetpack/load-more',
+const SAMPLE_RESULTS = [
+	{
+		title: __( 'First sample result', 'jetpack-search-pkg' ),
+		path: 'example.com/articles/first',
+		date: __( 'Apr 1, 2026', 'jetpack-search-pkg' ),
+	},
+	{
+		title: __( 'Another relevant post', 'jetpack-search-pkg' ),
+		path: 'example.com/guides/another',
+		date: __( 'Mar 22, 2026', 'jetpack-search-pkg' ),
+	},
+	{
+		title: __( 'Older archived entry', 'jetpack-search-pkg' ),
+		path: 'example.com/2025/older',
+		date: __( 'Dec 18, 2025', 'jetpack-search-pkg' ),
+	},
+];
+
+const SAMPLE_FILTER_ITEMS = [
+	{ value: 'one', label: __( 'First option', 'jetpack-search-pkg' ), count: 24 },
+	{ value: 'two', label: __( 'Second option', 'jetpack-search-pkg' ), count: 12 },
+	{ value: 'three', label: __( 'Third option', 'jetpack-search-pkg' ), count: 7 },
 ];
 
 /**
- * Build an Edit component that previews the given block via ServerSideRender.
+ * Render the magnifying-glass glyph used by the search input, matching the
+ * inline SVG emitted by render.php so the editor preview looks identical.
  *
- * @param {string} name - Block type name.
- * @return {Function} Edit component.
+ * @return {object} Rendered SVG element.
  */
-function makeEdit( name ) {
-	return function Edit( { attributes } ) {
-		const blockProps = useBlockProps();
-		return createElement(
-			'div',
-			blockProps,
-			createElement( ServerSideRender, {
-				block: name,
-				attributes,
-			} )
-		);
-	};
+function SearchGlyph() {
+	return h(
+		'svg',
+		{
+			className: 'jetpack-search-input__icon',
+			'aria-hidden': 'true',
+			focusable: 'false',
+			xmlns: 'http://www.w3.org/2000/svg',
+			width: 24,
+			height: 24,
+			viewBox: '0 0 24 24',
+		},
+		h( 'path', {
+			d: 'M13 5c-3.3 0-6 2.7-6 6 0 1.4.5 2.7 1.3 3.7l-3.8 3.8 1.1 1.1 3.8-3.8c1 .8 2.3 1.3 3.7 1.3 3.3 0 6-2.7 6-6s-2.7-6-6-6zm0 10.5c-2.5 0-4.5-2-4.5-4.5s2-4.5 4.5-4.5 4.5 2 4.5 4.5-2 4.5-4.5 4.5z',
+		} )
+	);
 }
 
-BLOCK_NAMES.forEach( name => {
-	registerBlockType( name, {
-		edit: makeEdit( name ),
-		save() {
-			// Dynamic block — render.php produces all markup.
-			return null;
-		},
-	} );
+/**
+ * Editor preview for jetpack/search-input.
+ *
+ * @return {object} Rendered element.
+ */
+function SearchInputEdit() {
+	const blockProps = useBlockProps();
+	return h(
+		'div',
+		blockProps,
+		h(
+			'div',
+			{ className: 'jetpack-search-input__inside-wrapper' },
+			h( SearchGlyph, null ),
+			h( 'input', {
+				type: 'search',
+				className: 'jetpack-search-input__field',
+				placeholder: __( 'Search…', 'jetpack-search-pkg' ),
+				disabled: true,
+				readOnly: true,
+			} )
+		)
+	);
+}
+
+/**
+ * Editor preview for jetpack/search-results. Renders sample rows so the
+ * block surfaces in the canvas even though live results need the runtime.
+ *
+ * @return {object} Rendered element.
+ */
+function SearchResultsEdit() {
+	const blockProps = useBlockProps();
+	return h(
+		'div',
+		blockProps,
+		h(
+			'ul',
+			{ className: 'jetpack-search-results__list' },
+			SAMPLE_RESULTS.map( result =>
+				h(
+					'li',
+					{ key: result.path, className: 'jetpack-search-results__item' },
+					h(
+						'div',
+						{ className: 'jetpack-search-results__copy' },
+						h( 'h3', { className: 'jetpack-search-results__title' }, result.title ),
+						h( 'div', { className: 'jetpack-search-results__path' }, result.path ),
+						h( 'div', { className: 'jetpack-search-results__date' }, result.date )
+					)
+				)
+			)
+		)
+	);
+}
+
+/**
+ * Editor preview for jetpack/filter-checkbox. Shows a labeled list of sample
+ * checkbox options mirroring the runtime DOM shape.
+ *
+ * @param {object} props            - Block props.
+ * @param {object} props.attributes - Saved block attributes.
+ * @return {object} Rendered element.
+ */
+function FilterCheckboxEdit( { attributes } ) {
+	const blockProps = useBlockProps();
+	const label = attributes?.label || __( 'Filter', 'jetpack-search-pkg' );
+	const showCount = attributes?.showCount !== false;
+	return h(
+		'div',
+		blockProps,
+		h( 'h3', { className: 'jetpack-search-filter__title' }, label ),
+		h(
+			'ul',
+			{ className: 'jetpack-search-filter__list' },
+			SAMPLE_FILTER_ITEMS.map( item =>
+				h(
+					'li',
+					{ key: item.value, className: 'jetpack-search-filter__item' },
+					h(
+						'label',
+						null,
+						h( 'input', { type: 'checkbox', disabled: true } ),
+						h( 'span', { className: 'jetpack-search-filter__label' }, item.label ),
+						showCount
+							? h( 'span', { className: 'jetpack-search-filter__count' }, item.count )
+							: null
+					)
+				)
+			)
+		)
+	);
+}
+
+/**
+ * Editor preview for jetpack/active-filters. The live block is hidden until
+ * the user selects at least one filter value; render a sample pill so
+ * designers can style the block in place.
+ *
+ * @return {object} Rendered element.
+ */
+function ActiveFiltersEdit() {
+	const blockProps = useBlockProps();
+	return h(
+		'div',
+		blockProps,
+		h(
+			'span',
+			{ className: 'jetpack-search-active-filters__heading' },
+			__( 'Active filters:', 'jetpack-search-pkg' )
+		),
+		h(
+			'ul',
+			{ className: 'jetpack-search-active-filters__pills' },
+			h(
+				'li',
+				null,
+				h(
+					'button',
+					{
+						type: 'button',
+						className: 'jetpack-search-active-filters__pill',
+						disabled: true,
+					},
+					h(
+						'span',
+						{ className: 'jetpack-search-active-filters__pill-label' },
+						__( 'Example filter', 'jetpack-search-pkg' )
+					),
+					h(
+						'span',
+						{ className: 'jetpack-search-active-filters__pill-remove', 'aria-hidden': 'true' },
+						'×'
+					)
+				)
+			)
+		),
+		h(
+			'button',
+			{
+				type: 'button',
+				className: 'jetpack-search-active-filters__clear-all',
+				disabled: true,
+			},
+			__( 'Clear all', 'jetpack-search-pkg' )
+		)
+	);
+}
+
+/**
+ * Editor preview for jetpack/sort-control.
+ *
+ * @return {object} Rendered element.
+ */
+function SortControlEdit() {
+	const blockProps = useBlockProps();
+	return h(
+		'div',
+		blockProps,
+		h( 'label', null, __( 'Sort by', 'jetpack-search-pkg' ) ),
+		h(
+			'select',
+			{ disabled: true, defaultValue: 'relevance' },
+			h( 'option', { value: 'relevance' }, __( 'Relevance', 'jetpack-search-pkg' ) ),
+			h( 'option', { value: 'newest' }, __( 'Newest', 'jetpack-search-pkg' ) ),
+			h( 'option', { value: 'oldest' }, __( 'Oldest', 'jetpack-search-pkg' ) )
+		)
+	);
+}
+
+/**
+ * Editor preview for jetpack/results-count.
+ *
+ * @return {object} Rendered element.
+ */
+function ResultsCountEdit() {
+	const blockProps = useBlockProps();
+	return h( 'p', blockProps, __( 'Showing 1–10 of 42 results', 'jetpack-search-pkg' ) );
+}
+
+/**
+ * Editor preview for jetpack/no-results. The front end hides this block when
+ * results are present; the editor always shows it so designers can style it.
+ *
+ * @param {object} props            - Block props.
+ * @param {object} props.attributes - Saved block attributes.
+ * @return {object} Rendered element.
+ */
+function NoResultsEdit( { attributes } ) {
+	const blockProps = useBlockProps();
+	const message =
+		attributes?.message || __( 'No results found. Try a different search.', 'jetpack-search-pkg' );
+	return h( 'div', blockProps, h( 'p', null, message ) );
+}
+
+/**
+ * Editor preview for jetpack/load-more.
+ *
+ * @return {object} Rendered element.
+ */
+function LoadMoreEdit() {
+	const blockProps = useBlockProps();
+	return h(
+		'div',
+		blockProps,
+		h(
+			'button',
+			{
+				type: 'button',
+				className: 'jetpack-search-load-more__button',
+				disabled: true,
+			},
+			__( 'Load more results', 'jetpack-search-pkg' )
+		)
+	);
+}
+
+/**
+ * Dynamic block save — render.php produces all front-end markup.
+ *
+ * @return {null} No save output.
+ */
+function save() {
+	return null;
+}
+
+const BLOCKS = [
+	[ 'jetpack/search-input', SearchInputEdit ],
+	[ 'jetpack/search-results', SearchResultsEdit ],
+	[ 'jetpack/filter-checkbox', FilterCheckboxEdit ],
+	[ 'jetpack/active-filters', ActiveFiltersEdit ],
+	[ 'jetpack/sort-control', SortControlEdit ],
+	[ 'jetpack/results-count', ResultsCountEdit ],
+	[ 'jetpack/no-results', NoResultsEdit ],
+	[ 'jetpack/load-more', LoadMoreEdit ],
+];
+
+BLOCKS.forEach( ( [ name, edit ] ) => {
+	registerBlockType( name, { edit, save } );
 } );


### PR DESCRIPTION
Follow-up to #48232. Part of RSM-270.

## Proposed changes
* Replace the generic `ServerSideRender` Edit wrapper in `editor/register-blocks.js` with per-block Edit components that mirror the live DOM each `render.php` produces, using simple static mock data:
  * **Search Results** — three sample result cards with title, path, and date.
  * **Checkbox Filter** — three sample options with labels and counts. Picks up the block's `label` / `showCount` attributes so the Category / Tag / Post Type / Author variations reflect their heading.
  * **Results Count** — "Showing 1–10 of 42 results" sample string.
  * **Active Filters** — one sample pill so designers can style this normally-hidden block in place.
  * **Search Input**, **Sort Control**, **Load More**, **No Results** — render their live DOM shape with attribute-driven copy.

## Why
`ServerSideRender` renders `render.php` against an editor context that has no Interactivity runtime. Every data-driven block (`state.results`, `state.filterItems`, `state.resultsCountText`, `state.hasActiveFilters` …) therefore rendered as an empty shell in the Site Editor — inserting Search Results showed an empty `<ul>` behind "Loading…", Checkbox Filter was invisible because `render.php` emits `hidden` on first paint when aggregation buckets are empty, and Results Count rendered an empty `<p>`. Static mock previews give designers and content editors a stable, recognizable DOM to arrange and style without relying on any runtime state.

## Related product discussion/links
* Linear: RSM-270
* Icons PR: #48232

## Does this pull request change what data or activity we track or use?
No. `render.php`, the Interactivity store, and the view scripts are untouched, so front-end behavior is unchanged.

## Testing instructions

1. Sync the branch to a Jurassic Ninja site or local WP install with `jetpack_search_blocks_enabled` on.
2. Open the Site Editor (Appearance → Editor) and insert each Jetpack Search block into a template one at a time. Each block should render a recognizable preview:
   * **Search Results**: three sample rows with title, path, and date.
   * **Checkbox Filter** (default → Category variation): three sample options with counts. Swap to Tag / Post Type / Author variations; the heading label should change to match the variation.
   * **Results Count**: "Showing 1–10 of 42 results".
   * **Active Filters**: one "Example filter" pill plus heading and "Clear all".
   * **Search Input**, **Sort Control**, **Load More**, **No Results**: real disabled input / select / button / message.
3. Insert the **Blog Search Page** pattern and confirm the composed layout renders end-to-end.
4. Load a front-end page that uses these blocks, run a live search — behavior must be unchanged (no `render.php` / view-script changes).

<img width="1159" height="688" alt="image" src="https://github.com/user-attachments/assets/42f9f6d1-59be-42f3-9a33-b1b13df006db" />

