### PR TITLE
Search 3.0: reuse results-count block as search loading indicator

### DIFF
--- a/projects/packages/search/changelog/fix-jps3-results-count-loading-indicator
+++ b/projects/packages/search/changelog/fix-jps3-results-count-loading-indicator
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search 3.0: reuse the results-count block as the loading indicator ("Searching…") so the control row doesn't flicker between queries.

--- a/projects/packages/search/src/search-blocks/blocks/search-results/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/search-results/render.php
@@ -20,13 +20,6 @@ namespace Automattic\Jetpack\Search;
 	data-wp-init="callbacks.initialize"
 	data-wp-bind--aria-busy="state.isLoading"
 >
-	<div
-		class="jetpack-search-results__loading"
-		data-wp-bind--hidden="!state.isLoading"
-	>
-		<?php esc_html_e( 'Loading…', 'jetpack-search-pkg' ); ?>
-	</div>
-
 	<ul
 		class="jetpack-search-results__list"
 		aria-live="polite"

--- a/projects/packages/search/src/search-blocks/blocks/search-results/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/search-results/style.scss
@@ -1,16 +1,5 @@
 .wp-block-jetpack-search-results {
 
-	.jetpack-search-results__loading {
-		padding: 1rem;
-		text-align: center;
-		color: inherit;
-		opacity: 0.6;
-
-		&[hidden] {
-			display: none;
-		}
-	}
-
 	.jetpack-search-results__list {
 		list-style: none;
 		margin: 0;

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -43,7 +43,14 @@ function* fetchResults( pageHandle ) {
 const { state, actions } = store( NAMESPACE, {
 	state: {
 		/**
-		 * Short human-readable results count for display blocks.
+		 * Short human-readable results count for display blocks. Doubles
+		 * as the loading indicator: returning "Searching…" in-place
+		 * keeps the results-count element populated across the transition
+		 * from one query to the next, so the flex row containing it
+		 * doesn't collapse and re-expand on every keystroke-triggered
+		 * search. There is no separate spinner/skeleton — this text is
+		 * the loading state, and the search-results wrapper carries
+		 * `aria-busy` for assistive tech.
 		 *
 		 * NOTE: not localized. `@wordpress/i18n` isn't available as an
 		 * Interactivity API script module (WP only registers
@@ -53,17 +60,20 @@ const { state, actions } = store( NAMESPACE, {
 		 * module, or switch to seeding translated plural forms from PHP
 		 * via `wp_interactivity_state()`. See PR #48198.
 		 *
-		 * @return {string} Text such as "42 results".
+		 * @return {string} "Searching…" while a search is in flight,
+		 * "Found 42 results" once a query resolves with hits, or an
+		 * empty string in every other case — pre-search, error, or
+		 * zero hits. The no-results block owns the empty-state copy.
 		 */
 		get resultsCountText() {
 			if ( state.isLoading ) {
-				return '';
+				return 'Searching…';
 			}
 			const total = state.totalResults;
 			if ( total === 0 ) {
 				return '';
 			}
-			return `${ total } result${ total === 1 ? '' : 's' }`;
+			return `Found ${ total } result${ total === 1 ? '' : 's' }`;
 		},
 
 		/**


### PR DESCRIPTION
Fixes [SEARCH-134](https://linear.app/a8c/issue/SEARCH-134/search-30-reuse-results-count-block-as-loading-indicator-to-reduce-ux).

## Proposed changes

* `resultsCountText` (in `store/index.js`) now returns `"Searching…"` while `isLoading` is true, and `"Found N result(s)"` once the fetch resolves with hits. Previously it returned an empty string during loading, which collapsed the results-count element and caused a visible flicker in the flex row it shares with sort-control.
* Zero-hit and pre-search states still return an empty string — the no-results block owns the empty-state copy, and the `render.php` paragraph is intentionally always-mounted to preserve the flex layout.
* Dropped the now-redundant `.jetpack-search-results__loading` "Loading…" div (and its styles) from the search-results block — the results-count slot already communicates the loading state.
* Removed `data-wp-bind--hidden="state.isLoading"` from the results `<ul>` so stale results stay visible during the next query. Combined with the in-place "Searching…" indicator, the page stops snapping vertical height on every keystroke. Screen readers still get `aria-busy` on the wrapper.
* i18n caveat unchanged: strings are not localized because `@wordpress/i18n` isn't available as an Interactivity API script module yet. See the `NOTE` in the getter's JSDoc (carried forward from #48198).

## Related product discussion/links

* [SEARCH-134](https://linear.app/a8c/issue/SEARCH-134/search-30-reuse-results-count-block-as-loading-indicator-to-reduce-ux)
* Builds on #48198 (Interactivity API foundation) and #48231 (load-more loading states)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Build the search package: \`jp build packages/search\`.
2. Activate a block theme and place the **Blog Search Page** pattern on a page (it composes the search-input, results-count, sort-control, search-results, load-more, no-results blocks).
3. Navigate to the page with no query in the URL — the results-count slot should be empty.
4. Issue a search with a non-trivial query.
   * While the request is in flight, the results-count paragraph should read **"Searching…"** in its usual position (same row as sort-control), and the previous result list should stay on screen.
   * Once results land, it should switch to **"Found N results"** (or **"Found 1 result"**) and the list content should update in place without the page height jumping.
5. Issue a second, different query without reloading.
   * Text should flip directly from the previous \`Found …\` value to \`Searching…\` and back — no empty frame between them.
   * Stale results should remain visible until new ones arrive, then swap in.
6. Search for something guaranteed to return zero hits.
   * During the fetch: \`Searching…\`.
   * After the fetch: results-count goes empty and the no-results block ("No results found. Try a different search.") takes over below.
7. Confirm the previous standalone "Loading…" message inside the search-results block is gone — there should only be the one "Searching…" indicator in the results-count position.
8. Spot-check with a screen reader that \`aria-busy\` still flips on the results wrapper during loading.