### PR TITLE
Sites endpoint: expose jetpack_recovery_mode_status option

### DIFF
--- a/projects/plugins/jetpack/changelog/2026-04-22-08-25-30-621544
+++ b/projects/plugins/jetpack/changelog/2026-04-22-08-25-30-621544
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Sites endpoint: expose jetpack_recovery_mode_status option so callers can read recovery-mode state from wpcom.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -239,6 +239,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_commercial_reasons',
 		'wpcom_admin_interface',
 		'wpcom_classic_early_release',
+		'jetpack_recovery_mode_status',
 	);
 
 	/**
@@ -309,6 +310,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_commercial_reasons',
 		'wpcom_admin_interface',
 		'wpcom_classic_early_release',
+		'jetpack_recovery_mode_status',
 	);
 
 	/**
@@ -981,6 +983,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 				case 'wpcom_classic_early_release':
 					$options[ $key ] = $site->get_wpcom_classic_early_release();
+					break;
+				case 'jetpack_recovery_mode_status':
+					$options[ $key ] = $site->get_jetpack_recovery_mode_status();
 					break;
 			}
 		}

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1769,13 +1769,10 @@ abstract class SAL_Site {
 	/**
 	 * Get Jetpack recovery mode status.
 	 *
-	 * @return array
+	 * @return array|null
 	 */
 	public function get_jetpack_recovery_mode_status() {
 		$status = get_option( 'jetpack_recovery_mode_status' );
-		if ( is_array( $status ) ) {
-			return $status;
-		}
-		return array();
+		return is_array( $status ) ? $status : null;
 	}
 }

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1765,4 +1765,17 @@ abstract class SAL_Site {
 	public function is_big_sky_enabled() {
 		return false;
 	}
+
+	/**
+	 * Get Jetpack recovery mode status.
+	 *
+	 * @return array
+	 */
+	public function get_jetpack_recovery_mode_status() {
+		$status = get_option( 'jetpack_recovery_mode_status' );
+		if ( is_array( $status ) ) {
+			return $status;
+		}
+		return array();
+	}
 }


### PR DESCRIPTION
Fixes #

Follow-up to #48213 (Jetpack: wpcomsh sync of recovery-mode state) and Automattic/wpcom#212459 (wpcom: `POST /sites/{blog_id}/recovery-mode-status` endpoint + storage as blog option `jetpack_recovery_mode_status`).

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Adds `jetpack_recovery_mode_status` to the `options` bucket of the `GET /rest/v1.1/sites/:siteId` response, so wpcom consumers can surface recovery-mode state for Jetpack/Atomic sites.
* SAL base (`sal/class.json-api-site-base.php`): new `get_jetpack_recovery_mode_status()` accessor that returns the option value if it's an array, otherwise `array()` (same defensive pattern as `get_site_goals()`).
* GET site endpoint (`json-endpoints/class.wpcom-json-api-get-site-endpoint.php`):
  - Registers `jetpack_recovery_mode_status` in `$site_options_format`.
  - Adds a `case 'jetpack_recovery_mode_status':` branch in `render_option_keys()` that dispatches to the new accessor.
  - Adds the key to `$jetpack_response_option_additions` so Jetpack/Atomic sites get the option decorated from the wpcom-side value.

The returned shape matches what is stored by wpcom: an associative array with `recovery_mode_email_last_sent`, `recovery_session_entered_at`, `recovery_session_exited_at` (all Unix timestamps). An empty array means no recovery-mode signal has been recorded yet.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* Jetpack upstream: #48213

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
No. This only exposes an existing site-level option (already stored on wpcom by the linked PRs) through the existing sites endpoint — it does not collect any new data.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
1. Apply this branch to a Jetpack-connected test site (a Jurassic Ninja site with wpcomsh works well) and ensure the wpcom-side counterpart (Automattic/wpcom#212459) is deployed.
2. Confirm the base case: query `GET /rest/v1.1/sites/<blog_id>?fields=options` and verify the response's `options` object now contains a `jetpack_recovery_mode_status` key. With no recovery event recorded, the value should be `[]` (empty array).
3. Trigger the sync by having the site enter recovery mode (e.g. force a fatal from a mu-plugin and click the recovery email link) — or, more directly, update the `jetpack_recovery_mode_status` blog option on wpcom to a non-empty array via an internal tool.
4. Re-query the sites endpoint and verify the `options.jetpack_recovery_mode_status` payload now reflects the expected keys: `recovery_mode_email_last_sent`, `recovery_session_entered_at`, `recovery_session_exited_at`.
5. Verify the field is only surfaced to callers with edit rights (it's under `options`, which is gated by the existing `$no_member_fields` logic — a logged-out request should not see it).
