### PR TITLE
wpcomsh: align fatal-error screen copy + details with recovery-mode email

### DIFF
--- a/projects/plugins/wpcomsh/changelog/try-wpcomsh-fatal-screen-alignment
+++ b/projects/plugins/wpcomsh/changelog/try-wpcomsh-fatal-screen-alignment
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-wpcom-fatal-error: rename the fatal-error screen's "Likely cause" heading to "Suspected plugin" / "Suspected theme", identify theme-origin fatals and show the same card with a Switch theme link, and add a collapsible Environment section (WordPress / PHP / theme / server).
+wpcom-fatal-error: rename the fatal-error screen's "Likely cause" heading to "Suspected plugin" / "Suspected theme", identify theme-origin fatals so the card shows the theme's name / version / description, and surface Error details + Environment (WordPress / PHP / theme / server) as always-visible sections below the card.

--- a/projects/plugins/wpcomsh/changelog/try-wpcomsh-fatal-screen-alignment
+++ b/projects/plugins/wpcomsh/changelog/try-wpcomsh-fatal-screen-alignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+wpcom-fatal-error: rename the admin screen's 'Likely cause' heading to 'Suspected plugin' and add an Environment section (WordPress / PHP / theme / server), aligning with the recovery-mode email copy.

--- a/projects/plugins/wpcomsh/changelog/try-wpcomsh-fatal-screen-alignment
+++ b/projects/plugins/wpcomsh/changelog/try-wpcomsh-fatal-screen-alignment
@@ -1,4 +1,4 @@
-Significance: patch
+Significance: minor
 Type: changed
 
-wpcom-fatal-error: rename the admin screen's 'Likely cause' heading to 'Suspected plugin' and add an Environment section (WordPress / PHP / theme / server), aligning with the recovery-mode email copy.
+wpcom-fatal-error: rename the fatal-error screen's "Likely cause" heading to "Suspected plugin" / "Suspected theme", identify theme-origin fatals and show the same card with a Switch theme link, and add a collapsible Environment section (WordPress / PHP / theme / server).

--- a/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-helpers.php
+++ b/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-helpers.php
@@ -46,9 +46,14 @@ function wpcomsh_fatal_current_user_id() {
 }
 
 /**
- * Identify the plugin associated with a fatal, using the error's absolute
- * file path. Looks up the plugin header (Name, Version, Description) so the
- * screen can name the likely cause.
+ * Identify the extension (plugin, mu-plugin, or theme) associated with a
+ * fatal, using the error's absolute file path. Looks up the Name / Version
+ * / Description headers so the screen can name the likely cause.
+ *
+ * `basename` is the plugin basename (e.g. "akismet/akismet.php") for
+ * plugins and mu-plugins, and the theme stylesheet slug for themes — the
+ * screen uses it to build the appropriate action (signed deactivation
+ * form for plugins, themes.php link for themes).
  *
  * @param array $error Error details from WP_Fatal_Error_Handler.
  * @return array{name:string, version:string, description:string, basename:string, kind:string}|null
@@ -65,6 +70,20 @@ function wpcomsh_fatal_identify_plugin( $error ) {
 	}
 
 	try {
+		if ( 'themes' === $kind ) {
+			$theme = wp_get_theme( $slug );
+			if ( $theme->exists() ) {
+				return array(
+					'name'        => (string) $theme->get( 'Name' ),
+					'version'     => (string) $theme->get( 'Version' ),
+					'description' => wp_strip_all_tags( (string) $theme->get( 'Description' ) ),
+					'basename'    => $slug,
+					'kind'        => $kind,
+				);
+			}
+			return null;
+		}
+
 		if ( ! function_exists( 'get_plugin_data' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
@@ -91,8 +110,12 @@ function wpcomsh_fatal_identify_plugin( $error ) {
 }
 
 /**
- * Map an absolute file path to a plugin slug + base dir + kind
- * ("plugins" or "mu-plugins"). Returned as a list: [ slug, base_dir, kind ].
+ * Map an absolute file path to an extension slug + base dir + kind
+ * ("plugins", "mu-plugins", or "themes"). Returned as a list:
+ * [ slug, base_dir, kind ].
+ *
+ * The theme root is resolved via `get_theme_root()` so symlinked or
+ * relocated theme directories still match.
  *
  * @param string $abs_file Absolute path reported by the fatal handler.
  * @return array{0:string,1:string,2:string}
@@ -111,6 +134,16 @@ function wpcomsh_fatal_classify_plugin_path( $abs_file ) {
 			WPMU_PLUGIN_DIR,
 			'mu-plugins',
 		);
+	}
+	if ( function_exists( 'get_theme_root' ) ) {
+		$theme_root = (string) get_theme_root();
+		if ( '' !== $theme_root && 0 === strpos( $abs_file, $theme_root . '/' ) ) {
+			return array(
+				strtok( substr( $abs_file, strlen( $theme_root ) + 1 ), '/' ),
+				$theme_root,
+				'themes',
+			);
+		}
 	}
 	return array( '', '', '' );
 }

--- a/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-helpers.php
+++ b/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-helpers.php
@@ -182,3 +182,39 @@ function wpcomsh_fatal_build_recovery_url() {
 		return '';
 	}
 }
+
+/**
+ * Collect environment details (WordPress / PHP / active theme / server)
+ * shown in the fatal-error screen's Environment section and reused by the
+ * recovery-mode email. Helps support triage without making the recipient
+ * hunt for them.
+ *
+ * Each entry is a ready-to-print "Label: value" line; the template renders
+ * them inside a <pre>, so line-for-line layout matters.
+ *
+ * @return string[]
+ */
+function wpcomsh_fatal_get_environment_lines() {
+	global $wp_version;
+
+	$lines = array();
+
+	$lines[] = sprintf( 'WordPress: %s', isset( $wp_version ) ? (string) $wp_version : 'unknown' );
+	$lines[] = sprintf( 'PHP: %s', PHP_VERSION );
+
+	try {
+		$theme = wp_get_theme();
+		if ( $theme && $theme->exists() ) {
+			$lines[] = sprintf( 'Theme: %s %s', (string) $theme->get( 'Name' ), (string) $theme->get( 'Version' ) );
+		}
+	} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- best-effort; omit theme on failure.
+		// Fall through.
+	}
+
+	$server = isset( $_SERVER['SERVER_SOFTWARE'] ) ? sanitize_text_field( (string) wp_unslash( $_SERVER['SERVER_SOFTWARE'] ) ) : '';
+	if ( '' !== $server ) {
+		$lines[] = sprintf( 'Server: %s', $server );
+	}
+
+	return $lines;
+}

--- a/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-screen.css
+++ b/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-screen.css
@@ -23,10 +23,20 @@
 	color: #1d2327;
 }
 
-.wpcomsh-fatal-notice {
+.wpcomsh-fatal-subhead-alert {
 	display: flex;
-	gap: 12px;
-	align-items: flex-start;
+	align-items: center;
+	gap: 6px;
+}
+
+.wpcomsh-fatal-subhead-icon {
+	display: inline-flex;
+	align-items: center;
+	color: #d63638;
+	line-height: 0;
+}
+
+.wpcomsh-fatal-notice {
 	margin: 0 0 20px;
 	padding: 16px;
 	border-radius: 6px;
@@ -34,16 +44,8 @@
 	border: 1px solid #f1b1b3;
 }
 
-.wpcomsh-fatal-notice-icon {
-	flex: 0 0 auto;
-	color: #d63638;
-	line-height: 0;
-	margin-top: 1px;
-}
-
-.wpcomsh-fatal-notice-body {
-	flex: 1 1 auto;
-	min-width: 0;
+.wpcomsh-fatal-notice > :last-child {
+	margin-bottom: 0;
 }
 
 .wpcomsh-fatal-notice-title {
@@ -147,16 +149,23 @@
 	margin-top: 24px;
 	padding-top: 16px;
 	border-top: 1px solid #dcdcde;
-	font-size: 13px;
 }
 
-.wpcomsh-fatal-details summary {
-	cursor: pointer;
-	color: #3c434a;
+.wpcomsh-fatal-details + .wpcomsh-fatal-details {
+	margin-top: 16px;
+	padding-top: 0;
+	border-top: 0;
+}
+
+.wpcomsh-fatal-details-heading {
+	margin: 0 0 8px;
+	font-size: 14px;
+	font-weight: 600;
+	color: #1d2327;
 }
 
 .wpcomsh-fatal-details pre {
-	margin-top: 8px;
+	margin: 0;
 	padding: 12px;
 	background: #f6f7f7;
 	border: 1px solid #dcdcde;

--- a/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-screen.php
+++ b/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-screen.php
@@ -59,7 +59,7 @@ function wpcomsh_fatal_load_textdomain() {
  * @param array $error Error details from WP_Fatal_Error_Handler.
  * @return array Associative array with keys: is_admin (bool),
  *     plugin (array|null), error_message (string), deactivate_form (array|null),
- *     recovery_url (string), support_url (string).
+ *     recovery_url (string), support_url (string), environment (string[]).
  */
 function wpcomsh_fatal_build_render_context( $error ) {
 	$user_id  = wpcomsh_fatal_current_user_id();
@@ -81,6 +81,7 @@ function wpcomsh_fatal_build_render_context( $error ) {
 		'deactivate_form' => $can_deactivate ? wpcomsh_fatal_build_deactivate_form( $plugin['basename'] ) : null,
 		'recovery_url'    => $can_recover ? wpcomsh_fatal_build_recovery_url() : '',
 		'support_url'     => 'https://wordpress.com/help/contact',
+		'environment'     => $is_admin ? wpcomsh_fatal_get_environment_lines() : array(),
 	);
 }
 
@@ -141,7 +142,7 @@ function wpcomsh_fatal_render_admin_view( $ctx ) {
 	<p><?php esc_html_e( 'There has been a critical error on this website. Here is what we know and what you can do next.', 'wpcomsh' ); ?></p>
 
 	<?php if ( $ctx['plugin'] ) : ?>
-		<h3 class="wpcomsh-fatal-subhead"><?php esc_html_e( 'Likely cause', 'wpcomsh' ); ?></h3>
+		<h3 class="wpcomsh-fatal-subhead"><?php esc_html_e( 'Suspected plugin', 'wpcomsh' ); ?></h3>
 		<?php wpcomsh_fatal_render_cause_notice( $ctx['plugin'], $ctx['deactivate_form'] ); ?>
 	<?php endif; ?>
 
@@ -152,6 +153,13 @@ function wpcomsh_fatal_render_admin_view( $ctx ) {
 		<details class="wpcomsh-fatal-details">
 			<summary><?php esc_html_e( 'Error details', 'wpcomsh' ); ?></summary>
 			<pre><?php echo esc_html( $ctx['error_message'] ); ?></pre>
+		</details>
+	<?php endif; ?>
+
+	<?php if ( ! empty( $ctx['environment'] ) ) : ?>
+		<details class="wpcomsh-fatal-details">
+			<summary><?php esc_html_e( 'Environment', 'wpcomsh' ); ?></summary>
+			<pre><?php echo esc_html( implode( "\n", $ctx['environment'] ) ); ?></pre>
 		</details>
 		<?php
 	endif;

--- a/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-screen.php
+++ b/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-screen.php
@@ -59,7 +59,8 @@ function wpcomsh_fatal_load_textdomain() {
  * @param array $error Error details from WP_Fatal_Error_Handler.
  * @return array Associative array with keys: is_admin (bool),
  *     plugin (array|null), error_message (string), deactivate_form (array|null),
- *     recovery_url (string), support_url (string), environment (string[]).
+ *     switch_theme_url (string), recovery_url (string), support_url (string),
+ *     environment (string[]).
  */
 function wpcomsh_fatal_build_render_context( $error ) {
 	$user_id  = wpcomsh_fatal_current_user_id();
@@ -72,16 +73,22 @@ function wpcomsh_fatal_build_render_context( $error ) {
 		&& ! empty( $plugin['basename'] )
 		&& user_can( $user_id, 'deactivate_plugin', $plugin['basename'] );
 
+	$can_switch_theme = $user_id
+		&& $plugin
+		&& 'themes' === $plugin['kind']
+		&& user_can( $user_id, 'switch_themes' );
+
 	$can_recover = $user_id && user_can( $user_id, 'resume_plugins' );
 
 	return array(
-		'is_admin'        => $is_admin,
-		'plugin'          => $plugin,
-		'error_message'   => $is_admin ? (string) ( $error['message'] ?? '' ) : '',
-		'deactivate_form' => $can_deactivate ? wpcomsh_fatal_build_deactivate_form( $plugin['basename'] ) : null,
-		'recovery_url'    => $can_recover ? wpcomsh_fatal_build_recovery_url() : '',
-		'support_url'     => 'https://wordpress.com/help/contact',
-		'environment'     => $is_admin ? wpcomsh_fatal_get_environment_lines() : array(),
+		'is_admin'         => $is_admin,
+		'plugin'           => $plugin,
+		'error_message'    => $is_admin ? (string) ( $error['message'] ?? '' ) : '',
+		'deactivate_form'  => $can_deactivate ? wpcomsh_fatal_build_deactivate_form( $plugin['basename'] ) : null,
+		'switch_theme_url' => $can_switch_theme ? admin_url( 'themes.php' ) : '',
+		'recovery_url'     => $can_recover ? wpcomsh_fatal_build_recovery_url() : '',
+		'support_url'      => 'https://wordpress.com/help/contact',
+		'environment'      => $is_admin ? wpcomsh_fatal_get_environment_lines() : array(),
 	);
 }
 
@@ -142,8 +149,16 @@ function wpcomsh_fatal_render_admin_view( $ctx ) {
 	<p><?php esc_html_e( 'There has been a critical error on this website. Here is what we know and what you can do next.', 'wpcomsh' ); ?></p>
 
 	<?php if ( $ctx['plugin'] ) : ?>
-		<h3 class="wpcomsh-fatal-subhead"><?php esc_html_e( 'Suspected plugin', 'wpcomsh' ); ?></h3>
-		<?php wpcomsh_fatal_render_cause_notice( $ctx['plugin'], $ctx['deactivate_form'] ); ?>
+		<h3 class="wpcomsh-fatal-subhead">
+			<?php
+			if ( 'themes' === $ctx['plugin']['kind'] ) {
+				esc_html_e( 'Suspected theme', 'wpcomsh' );
+			} else {
+				esc_html_e( 'Suspected plugin', 'wpcomsh' );
+			}
+			?>
+		</h3>
+		<?php wpcomsh_fatal_render_cause_notice( $ctx['plugin'], $ctx['deactivate_form'], $ctx['switch_theme_url'] ); ?>
 	<?php endif; ?>
 
 	<h3 class="wpcomsh-fatal-subhead"><?php esc_html_e( 'What you can try next', 'wpcomsh' ); ?></h3>
@@ -166,14 +181,22 @@ function wpcomsh_fatal_render_admin_view( $ctx ) {
 }
 
 /**
- * Render the red "likely cause" notice card: plugin name, description,
- * and the Deactivate action when a signed form is available.
+ * Render the red "suspected extension" notice card: name + version +
+ * description, plus an action when the viewer can remedy the problem.
  *
- * @param array      $plugin          Plugin info from wpcomsh_fatal_identify_plugin().
- * @param array|null $deactivate_form Signed form data from wpcomsh_fatal_build_deactivate_form(), or null to hide the action.
+ * The action branches by kind:
+ *   - Plugins / mu-plugins: signed POST form that deactivates the plugin
+ *     (only rendered when `$deactivate_form` is provided; mu-plugins can't
+ *     be deactivated through WordPress and get no action).
+ *   - Themes: plain link to the Themes admin page, where the user can
+ *     switch to a different theme.
+ *
+ * @param array      $plugin            Extension info from wpcomsh_fatal_identify_plugin().
+ * @param array|null $deactivate_form   Signed form data from wpcomsh_fatal_build_deactivate_form(), or null.
+ * @param string     $switch_theme_url  URL of the Themes admin page, or '' when unavailable.
  * @return void
  */
-function wpcomsh_fatal_render_cause_notice( $plugin, $deactivate_form ) {
+function wpcomsh_fatal_render_cause_notice( $plugin, $deactivate_form, $switch_theme_url = '' ) {
 	?>
 	<div class="wpcomsh-fatal-notice wpcomsh-fatal-notice-error">
 		<div class="wpcomsh-fatal-notice-icon" aria-hidden="true">
@@ -189,7 +212,11 @@ function wpcomsh_fatal_render_cause_notice( $plugin, $deactivate_form ) {
 			<?php if ( ! empty( $plugin['description'] ) ) : ?>
 				<div class="wpcomsh-fatal-notice-desc"><?php echo esc_html( $plugin['description'] ); ?></div>
 			<?php endif; ?>
-			<?php if ( $deactivate_form ) : ?>
+			<?php if ( 'themes' === $plugin['kind'] && '' !== $switch_theme_url ) : ?>
+				<a class="wpcomsh-fatal-btn" href="<?php echo esc_url( $switch_theme_url ); ?>">
+					<?php esc_html_e( 'Switch theme', 'wpcomsh' ); ?>
+				</a>
+			<?php elseif ( $deactivate_form ) : ?>
 				<form method="post"
 					action="<?php echo esc_url( $deactivate_form['action'] ); ?>"
 					onsubmit="return confirm('<?php echo esc_js( __( 'Deactivate this plugin? Your site should load again immediately.', 'wpcomsh' ) ); // phpcs:ignore Jetpack.Functions.EscJs.Found -- esc_attr(json_encode(...)) would double-escape quotes inside onsubmit="..." and break the string. ?>');">

--- a/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-screen.php
+++ b/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-screen.php
@@ -59,8 +59,7 @@ function wpcomsh_fatal_load_textdomain() {
  * @param array $error Error details from WP_Fatal_Error_Handler.
  * @return array Associative array with keys: is_admin (bool),
  *     plugin (array|null), error_message (string), deactivate_form (array|null),
- *     switch_theme_url (string), recovery_url (string), support_url (string),
- *     environment (string[]).
+ *     recovery_url (string), support_url (string), environment (string[]).
  */
 function wpcomsh_fatal_build_render_context( $error ) {
 	$user_id  = wpcomsh_fatal_current_user_id();
@@ -73,22 +72,16 @@ function wpcomsh_fatal_build_render_context( $error ) {
 		&& ! empty( $plugin['basename'] )
 		&& user_can( $user_id, 'deactivate_plugin', $plugin['basename'] );
 
-	$can_switch_theme = $user_id
-		&& $plugin
-		&& 'themes' === $plugin['kind']
-		&& user_can( $user_id, 'switch_themes' );
-
 	$can_recover = $user_id && user_can( $user_id, 'resume_plugins' );
 
 	return array(
-		'is_admin'         => $is_admin,
-		'plugin'           => $plugin,
-		'error_message'    => $is_admin ? (string) ( $error['message'] ?? '' ) : '',
-		'deactivate_form'  => $can_deactivate ? wpcomsh_fatal_build_deactivate_form( $plugin['basename'] ) : null,
-		'switch_theme_url' => $can_switch_theme ? admin_url( 'themes.php' ) : '',
-		'recovery_url'     => $can_recover ? wpcomsh_fatal_build_recovery_url() : '',
-		'support_url'      => 'https://wordpress.com/help/contact',
-		'environment'      => $is_admin ? wpcomsh_fatal_get_environment_lines() : array(),
+		'is_admin'        => $is_admin,
+		'plugin'          => $plugin,
+		'error_message'   => $is_admin ? (string) ( $error['message'] ?? '' ) : '',
+		'deactivate_form' => $can_deactivate ? wpcomsh_fatal_build_deactivate_form( $plugin['basename'] ) : null,
+		'recovery_url'    => $can_recover ? wpcomsh_fatal_build_recovery_url() : '',
+		'support_url'     => 'https://wordpress.com/help/contact',
+		'environment'     => $is_admin ? wpcomsh_fatal_get_environment_lines() : array(),
 	);
 }
 
@@ -149,7 +142,10 @@ function wpcomsh_fatal_render_admin_view( $ctx ) {
 	<p><?php esc_html_e( 'There has been a critical error on this website. Here is what we know and what you can do next.', 'wpcomsh' ); ?></p>
 
 	<?php if ( $ctx['plugin'] ) : ?>
-		<h3 class="wpcomsh-fatal-subhead">
+		<h3 class="wpcomsh-fatal-subhead wpcomsh-fatal-subhead-alert">
+			<span class="wpcomsh-fatal-subhead-icon" aria-hidden="true">
+				<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+			</span>
 			<?php
 			if ( 'themes' === $ctx['plugin']['kind'] ) {
 				esc_html_e( 'Suspected theme', 'wpcomsh' );
@@ -158,77 +154,69 @@ function wpcomsh_fatal_render_admin_view( $ctx ) {
 			}
 			?>
 		</h3>
-		<?php wpcomsh_fatal_render_cause_notice( $ctx['plugin'], $ctx['deactivate_form'], $ctx['switch_theme_url'] ); ?>
+		<?php wpcomsh_fatal_render_cause_notice( $ctx['plugin'], $ctx['deactivate_form'] ); ?>
 	<?php endif; ?>
 
 	<h3 class="wpcomsh-fatal-subhead"><?php esc_html_e( 'What you can try next', 'wpcomsh' ); ?></h3>
 	<?php wpcomsh_fatal_render_next_steps( $ctx['recovery_url'], $ctx['support_url'] ); ?>
 
 	<?php if ( '' !== $ctx['error_message'] ) : ?>
-		<details class="wpcomsh-fatal-details">
-			<summary><?php esc_html_e( 'Error details', 'wpcomsh' ); ?></summary>
+		<div class="wpcomsh-fatal-details">
+			<h3 class="wpcomsh-fatal-details-heading"><?php esc_html_e( 'Error details', 'wpcomsh' ); ?></h3>
 			<pre><?php echo esc_html( $ctx['error_message'] ); ?></pre>
-		</details>
+		</div>
 	<?php endif; ?>
 
 	<?php if ( ! empty( $ctx['environment'] ) ) : ?>
-		<details class="wpcomsh-fatal-details">
-			<summary><?php esc_html_e( 'Environment', 'wpcomsh' ); ?></summary>
+		<div class="wpcomsh-fatal-details">
+			<h3 class="wpcomsh-fatal-details-heading"><?php esc_html_e( 'Environment', 'wpcomsh' ); ?></h3>
 			<pre><?php echo esc_html( implode( "\n", $ctx['environment'] ) ); ?></pre>
-		</details>
+		</div>
 		<?php
 	endif;
 }
 
 /**
- * Render the red "suspected extension" notice card: name + version +
- * description, plus an action when the viewer can remedy the problem.
+ * Render the "suspected extension" notice card: name + version +
+ * description, plus a Deactivate action when the viewer can act on it.
  *
- * The action branches by kind:
- *   - Plugins / mu-plugins: signed POST form that deactivates the plugin
- *     (only rendered when `$deactivate_form` is provided; mu-plugins can't
- *     be deactivated through WordPress and get no action).
- *   - Themes: plain link to the Themes admin page, where the user can
- *     switch to a different theme.
+ * Themes don't get an in-card action. Navigating to themes.php while the
+ * broken theme is still active would re-hit the same fatal, so we route
+ * the user through core recovery mode via the link in "What you can try
+ * next" instead. A future follow-up could build a signed "switch to
+ * default theme" endpoint mirroring the plugin deactivator.
  *
- * @param array      $plugin            Extension info from wpcomsh_fatal_identify_plugin().
- * @param array|null $deactivate_form   Signed form data from wpcomsh_fatal_build_deactivate_form(), or null.
- * @param string     $switch_theme_url  URL of the Themes admin page, or '' when unavailable.
+ * The alert icon lives in the sibling `<h3>` heading (see
+ * `wpcomsh_fatal_render_admin_view`); this card renders only the content.
+ *
+ * @param array      $plugin          Extension info from wpcomsh_fatal_identify_plugin().
+ * @param array|null $deactivate_form Signed form data from wpcomsh_fatal_build_deactivate_form(), or null.
  * @return void
  */
-function wpcomsh_fatal_render_cause_notice( $plugin, $deactivate_form, $switch_theme_url = '' ) {
+function wpcomsh_fatal_render_cause_notice( $plugin, $deactivate_form ) {
 	?>
 	<div class="wpcomsh-fatal-notice wpcomsh-fatal-notice-error">
-		<div class="wpcomsh-fatal-notice-icon" aria-hidden="true">
-			<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
-		</div>
-		<div class="wpcomsh-fatal-notice-body">
-			<div class="wpcomsh-fatal-notice-title">
-				<strong><?php echo esc_html( $plugin['name'] ); ?></strong>
-				<?php if ( ! empty( $plugin['version'] ) ) : ?>
-					<span class="wpcomsh-fatal-notice-ver">v<?php echo esc_html( $plugin['version'] ); ?></span>
-				<?php endif; ?>
-			</div>
-			<?php if ( ! empty( $plugin['description'] ) ) : ?>
-				<div class="wpcomsh-fatal-notice-desc"><?php echo esc_html( $plugin['description'] ); ?></div>
-			<?php endif; ?>
-			<?php if ( 'themes' === $plugin['kind'] && '' !== $switch_theme_url ) : ?>
-				<a class="wpcomsh-fatal-btn" href="<?php echo esc_url( $switch_theme_url ); ?>">
-					<?php esc_html_e( 'Switch theme', 'wpcomsh' ); ?>
-				</a>
-			<?php elseif ( $deactivate_form ) : ?>
-				<form method="post"
-					action="<?php echo esc_url( $deactivate_form['action'] ); ?>"
-					onsubmit="return confirm('<?php echo esc_js( __( 'Deactivate this plugin? Your site should load again immediately.', 'wpcomsh' ) ); // phpcs:ignore Jetpack.Functions.EscJs.Found -- esc_attr(json_encode(...)) would double-escape quotes inside onsubmit="..." and break the string. ?>');">
-					<?php foreach ( $deactivate_form['fields'] as $field_name => $field_value ) : ?>
-						<input type="hidden" name="<?php echo esc_attr( $field_name ); ?>" value="<?php echo esc_attr( $field_value ); ?>" />
-					<?php endforeach; ?>
-					<button type="submit" class="wpcomsh-fatal-btn wpcomsh-fatal-btn-destructive">
-						<?php esc_html_e( 'Deactivate', 'wpcomsh' ); ?>
-					</button>
-				</form>
+		<div class="wpcomsh-fatal-notice-title">
+			<strong><?php echo esc_html( $plugin['name'] ); ?></strong>
+			<?php if ( ! empty( $plugin['version'] ) ) : ?>
+				<span class="wpcomsh-fatal-notice-ver">v<?php echo esc_html( $plugin['version'] ); ?></span>
 			<?php endif; ?>
 		</div>
+		<?php if ( ! empty( $plugin['description'] ) ) : ?>
+			<div class="wpcomsh-fatal-notice-desc"><?php echo esc_html( $plugin['description'] ); ?></div>
+		<?php endif; ?>
+		<?php if ( $deactivate_form ) : ?>
+			<form method="post"
+				action="<?php echo esc_url( $deactivate_form['action'] ); ?>"
+				onsubmit="return confirm('<?php echo esc_js( __( 'Deactivate this plugin? Your site should load again immediately.', 'wpcomsh' ) ); // phpcs:ignore Jetpack.Functions.EscJs.Found -- esc_attr(json_encode(...)) would double-escape quotes inside onsubmit="..." and break the string. ?>');">
+				<?php foreach ( $deactivate_form['fields'] as $field_name => $field_value ) : ?>
+					<input type="hidden" name="<?php echo esc_attr( $field_name ); ?>" value="<?php echo esc_attr( $field_value ); ?>" />
+				<?php endforeach; ?>
+				<button type="submit" class="wpcomsh-fatal-btn wpcomsh-fatal-btn-destructive">
+					<?php esc_html_e( 'Deactivate', 'wpcomsh' ); ?>
+				</button>
+			</form>
+		<?php endif; ?>
 	</div>
 	<?php
 }

--- a/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-screen.php
+++ b/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-screen.php
@@ -72,7 +72,13 @@ function wpcomsh_fatal_build_render_context( $error ) {
 		&& ! empty( $plugin['basename'] )
 		&& user_can( $user_id, 'deactivate_plugin', $plugin['basename'] );
 
-	$can_recover = $user_id && user_can( $user_id, 'resume_plugins' );
+	// Recovery-mode capability depends on the kind of extension that
+	// fataled: a theme-origin fatal needs `resume_themes`, everything
+	// else (plugins, mu-plugins, unknown) needs `resume_plugins`.
+	$recover_cap = ( $plugin && 'themes' === $plugin['kind'] )
+		? 'resume_themes'
+		: 'resume_plugins';
+	$can_recover = $user_id && user_can( $user_id, $recover_cap );
 
 	return array(
 		'is_admin'        => $is_admin,


### PR DESCRIPTION
## Summary

Follow-up to #48238 (recovery-mode email rewrite), bringing the fatal-error screen in line with the email's copy, structure, and information architecture — plus extending the identifier to cover theme-origin fatals.

**Copy + layout alignment**
- Renames the "Likely cause" heading to **"Suspected plugin"** / **"Suspected theme"** — same wording as the email.
- Moves the red alert icon out of the notice card and into the heading.
- Replaces the Error details `<details>`/`<summary>` disclosure with an always-visible heading + `<pre>` block. Adds a new always-visible **Environment** section (WP / PHP / active theme / server). Matches the email, where `<details>` is stripped by Gmail/Outlook anyway.
- Environment lines come from a new shared helper `wpcomsh_fatal_get_environment_lines()` in `fatal-error-helpers.php`, usable by both screen and email (the email PR's local copy can be removed on rebase).

**Theme identification**
- Extends `wpcomsh_fatal_classify_plugin_path()` to detect files under `get_theme_root()` and `wpcomsh_fatal_identify_plugin()` to pull `Name` / `Version` / `Description` via `wp_get_theme()`.
- Theme-origin fatals now surface the same "Suspected theme" card with name + version + description.
- **No in-card Switch theme action.** We initially added one linking to `themes.php`, but that page re-hits the same fatal while the broken theme is still active — landmine UX. The working path is core recovery mode: it auto-suspends the broken theme for the session and falls back to `WP_DEFAULT_THEME`, so the recovery-mode link already in "What you can try next" is the correct primary CTA.

## Open question — B: signed theme-switcher?

Same reason we have the signed `wpcomsh_deactivate` endpoint for plugins (so WP.com admins without wp-admin credentials can still act), we could build a signed "switch to default theme" endpoint — HMAC over `(slug|expiry|LOGGED_IN_COOKIE)` with `AUTH_SALT`, posted to the existing deactivator entry point.

Tradeoffs:
- **Pro**: password-less recovery for theme fatals on WP.com, symmetrical with plugin flow.
- **Con**: "switch theme" may not be what the user actually wants — they might prefer to roll the theme back, investigate, or pick a specific replacement. Forcing a switch to the default theme is opinionated.
- **Alternative**: signed "enter recovery mode" endpoint — lets the admin make the decision themselves.

Happy to build whichever, as a follow-up.

## Testing instructions

### Plugin fatal (regression check)
1. SSH into a test site and add `throw new Error('plugin fatal test');` to a plugin's main PHP file (e.g. `wp-content/plugins/hello.php`).
2. Load the front of the site while signed in as admin.
3. Confirm:
   - Heading reads **"⚠ Suspected plugin"** (SVG alert icon inline with the text, red).
   - Card shows plugin Name / version / description with no in-card icon column.
   - **Deactivate** button is present; clicking it clears the fatal.
   - **Error details** section is always visible (no disclosure toggle) — shows the raw PHP error.
   - **Environment** section appears below it with WordPress / PHP / Theme / Server lines.
4. Restore the plugin file.

### Theme fatal (new)
1. `wp option get stylesheet` to find the active theme slug.
2. `echo "<?php throw new Error('theme fatal test');" >> wp-content/themes/{slug}/functions.php`.
3. Load the site as admin.
4. Confirm:
   - Heading reads **"⚠ Suspected theme"**.
   - Card shows the theme's Name / version / description from `wp_get_theme()`.
   - **No Switch theme button** (by design — see summary).
   - Error details + Environment render as for the plugin case.
5. Click the recovery-mode link in "What you can try next"; confirm wp-admin loads with the default fallback theme and the broken theme can be switched out.
6. Delete the injected line to restore.

### Anonymous viewer
- Log out / use a private window and load the site with either fatal active. Confirm the public "This site is temporarily unavailable" copy — no card, no details, no Environment.

## Does this pull request change what data or activity we track or use?

No. This PR is purely presentational — it restructures an existing admin-only screen (copy, icon placement, two previously-collapsible sections now always visible) and extends extension identification (already using `get_plugins()`) to cover themes via `wp_get_theme()`. No new tracking, no new data collection, no new external calls. The Environment section surfaces values (WordPress / PHP / active theme / server software) that are already locally available to the admin; they're displayed on the fatal screen, not transmitted anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)