### PR TITLE
My Jetpack: fix missing background on "Supercharge my site" button

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/onboarding-screen/connection-form/connection-form.tsx
+++ b/projects/packages/my-jetpack/_inc/components/onboarding-screen/connection-form/connection-form.tsx
@@ -46,6 +46,7 @@ const ConnectionForm = () => {
 			</Text>
 
 			<Button
+				variant="primary"
 				className={ styles[ 'submit-button' ] }
 				disabled={ isConnecting }
 				aria-busy={ isConnecting }

--- a/projects/packages/my-jetpack/changelog/fix-supercharge-my-site-button-background
+++ b/projects/packages/my-jetpack/changelog/fix-supercharge-my-site-button-background
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Restore background on the "Supercharge my site" onboarding button by using the core Button's primary variant.


### PR DESCRIPTION
Fixes MYJP-301

## Proposed changes

- Pass `variant="primary"` to the core `Button` rendering the "Supercharge my site" onboarding CTA so it picks up WordPress's built-in primary styling (background, hover/focus, disabled).

## Related product discussion/links

- Regression introduced in #47317 (Componentry: remove Jetpack color overrides on core components), which stripped the button's background/border/hover/disabled styles from `styles.module.scss` without handing the Button off to a core variant.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Either disconnect Jetpack on your local dev site so the onboarding screen is reachable:
   ```
   jetpack docker wp jetpack disconnect blog
   ```
   …or spin up a fresh JN site from this branch.
2. Visit **Jetpack → My Jetpack** in wp-admin. You should land on the onboarding/connection screen with the "Supercharge my site" CTA.
3. **Before** this patch (trunk): the button renders with no background — just the text on the page background.
4. **After** this patch: the button renders with the standard WordPress primary styling (solid background, visible hover/focus/disabled states).
5. Click the button → confirm the connection flow still starts (the button goes into its disabled/spinner state while connecting) and that the disabled state is also visibly styled.

| Before | After |
| ------ | ----- |
|<img width="483" height="357" alt="Screenshot 2026-04-22 at 7 26 23 PM" src="https://github.com/user-attachments/assets/830da9f3-70c1-4983-a18a-ab6b52a55923" />|<img width="487" height="352" alt="Screenshot 2026-04-22 at 7 26 14 PM" src="https://github.com/user-attachments/assets/b1a3c08c-4046-4151-9fe4-8d9c408d1436" />|
