### PR TITLE
Activity Log: Phase 0 — package scaffold

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1831,6 +1831,82 @@ importers:
 
   projects/packages/account-protection: {}
 
+  projects/packages/activity-log:
+    dependencies:
+      '@automattic/jetpack-components':
+        specifier: workspace:*
+        version: link:../../js-packages/components
+      '@automattic/jetpack-connection':
+        specifier: workspace:*
+        version: link:../../js-packages/connection
+      '@tanstack/react-query':
+        specifier: 5.90.8
+        version: 5.90.8(react@18.3.1)
+      '@wordpress/api-fetch':
+        specifier: 7.44.0
+        version: 7.44.0
+      '@wordpress/components':
+        specifier: 32.6.0
+        version: 32.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/date':
+        specifier: 5.44.0
+        version: 5.44.0
+      '@wordpress/element':
+        specifier: 6.44.0
+        version: 6.44.0
+      '@wordpress/i18n':
+        specifier: 6.17.0
+        version: 6.17.0
+      '@wordpress/icons':
+        specifier: 12.2.0
+        version: 12.2.0(react@18.3.1)
+      react:
+        specifier: 18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: 18.3.1
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@automattic/jetpack-base-styles':
+        specifier: workspace:*
+        version: link:../../js-packages/base-styles
+      '@automattic/jetpack-webpack-config':
+        specifier: workspace:*
+        version: link:../../js-packages/webpack-config
+      '@babel/core':
+        specifier: 7.29.0
+        version: 7.29.0
+      '@babel/preset-env':
+        specifier: 7.29.2
+        version: 7.29.2(@babel/core@7.29.0)
+      '@babel/runtime':
+        specifier: 7.29.2
+        version: 7.29.2
+      '@types/react':
+        specifier: 18.3.28
+        version: 18.3.28
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260225.1
+        version: 7.0.0-dev.20260225.1
+      '@wordpress/browserslist-config':
+        specifier: 6.44.0
+        version: 6.44.0
+      concurrently:
+        specifier: 9.2.1
+        version: 9.2.1
+      sass-embedded:
+        specifier: 1.97.3
+        version: 1.97.3
+      sass-loader:
+        specifier: 16.0.5
+        version: 16.0.5(sass-embedded@1.97.3)(webpack@5.105.2)
+      webpack:
+        specifier: 5.105.2
+        version: 5.105.2(webpack-cli@6.0.1)
+      webpack-cli:
+        specifier: 6.0.1
+        version: 6.0.1(webpack@5.105.2)
+
   projects/packages/admin-ui:
     devDependencies:
       '@automattic/jetpack-base-styles':

--- a/projects/packages/activity-log/.babelrc
+++ b/projects/packages/activity-log/.babelrc
@@ -1,0 +1,12 @@
+{
+	"presets": [
+		[
+			"@babel/preset-env",
+			{
+				"targets": {
+					"node": "current"
+				}
+			}
+		]
+	]
+}

--- a/projects/packages/activity-log/.gitattributes
+++ b/projects/packages/activity-log/.gitattributes
@@ -1,0 +1,15 @@
+# Files not needed to be distributed.
+.babelrc         export-ignore
+.gitattributes   export-ignore
+.github/         export-ignore
+.gitignore       export-ignore
+
+# Files not needed in the production build.
+.phpcs.dir.xml   production-exclude
+/changelog/**    production-exclude
+/tests/**        production-exclude
+types.d.ts       production-exclude
+/src/js/**       production-exclude
+
+# Files needed in the production build.
+build/**         production-include

--- a/projects/packages/activity-log/.gitignore
+++ b/projects/packages/activity-log/.gitignore
@@ -1,0 +1,6 @@
+wordpress
+node_modules
+vendor
+jetpack_vendor
+.cache
+build

--- a/projects/packages/activity-log/.phan/config.php
+++ b/projects/packages/activity-log/.phan/config.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * This configuration will be read and overlaid on top of the
+ * default configuration. Command-line arguments will be applied
+ * after this file is read.
+ *
+ * @package automattic/jetpack-activity-log
+ */
+
+// Require base config.
+require __DIR__ . '/../../../../.phan/config.base.php';
+
+return make_phan_config( dirname( __DIR__ ) );

--- a/projects/packages/activity-log/.phpcs.dir.xml
+++ b/projects/packages/activity-log/.phpcs.dir.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<ruleset>
+
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="jetpack-activity-log" />
+			</property>
+		</properties>
+	</rule>
+	<rule ref="Jetpack.Functions.I18n">
+		<properties>
+			<property name="text_domain" value="jetpack-activity-log" />
+		</properties>
+	</rule>
+
+	<rule ref="WordPress.Utils.I18nTextDomainFixer">
+		<properties>
+			<property name="old_text_domain" type="array" />
+			<property name="new_text_domain" value="jetpack-activity-log" />
+		</properties>
+	</rule>
+
+</ruleset>

--- a/projects/packages/activity-log/README.md
+++ b/projects/packages/activity-log/README.md
@@ -1,0 +1,15 @@
+# Activity Log
+
+Activity Log UI for the Jetpack plugin in wp-admin.
+
+## Using this package in your WordPress plugin
+
+If you plan on using this package in your WordPress plugin, we would recommend that you use [Jetpack Autoloader](https://packagist.org/packages/automattic/jetpack-autoloader) as your autoloader. This will allow for maximum interoperability with other plugins that use this package as well.
+
+## Security
+
+Need to report a security vulnerability? Go to [https://automattic.com/security/](https://automattic.com/security/) or directly to our security bug bounty site [https://hackerone.com/automattic](https://hackerone.com/automattic).
+
+## License
+
+jetpack-activity-log is licensed under [GNU General Public License v2 (or later)](./LICENSE.txt)

--- a/projects/packages/activity-log/actions.php
+++ b/projects/packages/activity-log/actions.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Action Hooks for the Jetpack Activity Log package.
+ *
+ * @package automattic/jetpack-activity-log
+ */
+
+// If WordPress's plugin API is available already, use it. If not,
+// drop data into `$wp_filter` for `WP_Hook::build_preinitialized_hooks()`.
+if ( function_exists( 'add_filter' ) ) {
+	$add_filter = 'add_filter';
+} else {
+	$add_filter = function ( $name, $cb, $priority = 10, $accepted_args = 1 ) {
+		global $wp_filter;
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$wp_filter[ $name ][ $priority ][] = array(
+			'accepted_args' => $accepted_args,
+			'function'      => $cb,
+		);
+	};
+}
+
+// Set up package version hook.
+$add_filter( 'jetpack_package_versions', 'Automattic\\Jetpack\\Activity_Log\\Package_Version::send_package_version_to_tracker' );

--- a/projects/packages/activity-log/babel.config.js
+++ b/projects/packages/activity-log/babel.config.js
@@ -1,0 +1,10 @@
+const config = {
+	presets: [
+		[
+			'@automattic/jetpack-webpack-config/babel/preset',
+			{ pluginReplaceTextdomain: { textdomain: 'jetpack-activity-log' } },
+		],
+	],
+};
+
+module.exports = config;

--- a/projects/packages/activity-log/changelog/add-package-scaffold
+++ b/projects/packages/activity-log/changelog/add-package-scaffold
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Initial scaffold for the Activity Log package that will host the in-wp-admin Activity Log UI.

--- a/projects/packages/activity-log/composer.json
+++ b/projects/packages/activity-log/composer.json
@@ -1,0 +1,76 @@
+{
+	"name": "automattic/jetpack-activity-log",
+	"description": "Activity Log UI for the Jetpack plugin in wp-admin.",
+	"type": "jetpack-library",
+	"license": "GPL-2.0-or-later",
+	"require": {
+		"php": ">=7.2",
+		"automattic/jetpack-admin-ui": "@dev",
+		"automattic/jetpack-assets": "@dev",
+		"automattic/jetpack-autoloader": "@dev",
+		"automattic/jetpack-composer-plugin": "@dev",
+		"automattic/jetpack-connection": "@dev",
+		"automattic/jetpack-status": "@dev"
+	},
+	"require-dev": {
+		"automattic/jetpack-changelogger": "@dev",
+		"yoast/phpunit-polyfills": "^4.0.0",
+		"automattic/jetpack-test-environment": "@dev",
+		"automattic/phpunit-select-config": "@dev"
+	},
+	"suggest": {
+		"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+	},
+	"autoload": {
+		"files": [
+			"actions.php"
+		],
+		"classmap": [
+			"src/"
+		]
+	},
+	"scripts": {
+		"build-development": [
+			"pnpm run build"
+		],
+		"build-production": [
+			"pnpm run build-production-concurrently"
+		],
+		"watch": [
+			"Composer\\Config::disableProcessTimeout",
+			"pnpm run watch"
+		]
+	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../*",
+			"options": {
+				"monorepo": true
+			}
+		}
+	],
+	"minimum-stability": "dev",
+	"prefer-stable": true,
+	"extra": {
+		"autotagger": true,
+		"mirror-repo": "Automattic/jetpack-activity-log",
+		"textdomain": "jetpack-activity-log",
+		"version-constants": {
+			"::PACKAGE_VERSION": "src/class-package-version.php"
+		},
+		"changelogger": {
+			"link-template": "https://github.com/Automattic/jetpack-activity-log/compare/v${old}...v${new}"
+		},
+		"branch-alias": {
+			"dev-trunk": "0.1.x-dev"
+		}
+	},
+	"config": {
+		"allow-plugins": {
+			"roots/wordpress-core-installer": true,
+			"automattic/jetpack-autoloader": true,
+			"automattic/jetpack-composer-plugin": true
+		}
+	}
+}

--- a/projects/packages/activity-log/package.json
+++ b/projects/packages/activity-log/package.json
@@ -1,0 +1,55 @@
+{
+	"private": true,
+	"description": "Activity Log UI for the Jetpack plugin in wp-admin.",
+	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/activity-log/#readme",
+	"bugs": {
+		"url": "https://github.com/Automattic/jetpack/labels/[Package] Activity Log"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Automattic/jetpack.git",
+		"directory": "projects/packages/activity-log"
+	},
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic",
+	"scripts": {
+		"build": "pnpm run clean && pnpm run build-client",
+		"build-client": "webpack",
+		"build-production-concurrently": "pnpm run clean && concurrently 'NODE_ENV=production BABEL_ENV=production pnpm run build-client' && pnpm run validate",
+		"clean": "rm -rf build/",
+		"typecheck": "tsgo --noEmit",
+		"validate": "pnpm exec validate-es build/",
+		"watch": "pnpm run build && webpack watch"
+	},
+	"browserslist": [
+		"extends @wordpress/browserslist-config"
+	],
+	"dependencies": {
+		"@automattic/jetpack-components": "workspace:*",
+		"@automattic/jetpack-connection": "workspace:*",
+		"@tanstack/react-query": "5.90.8",
+		"@wordpress/api-fetch": "7.44.0",
+		"@wordpress/components": "32.6.0",
+		"@wordpress/date": "5.44.0",
+		"@wordpress/element": "6.44.0",
+		"@wordpress/i18n": "6.17.0",
+		"@wordpress/icons": "12.2.0",
+		"react": "18.3.1",
+		"react-dom": "18.3.1"
+	},
+	"devDependencies": {
+		"@automattic/jetpack-base-styles": "workspace:*",
+		"@automattic/jetpack-webpack-config": "workspace:*",
+		"@babel/core": "7.29.0",
+		"@babel/preset-env": "7.29.2",
+		"@babel/runtime": "7.29.2",
+		"@types/react": "18.3.28",
+		"@typescript/native-preview": "7.0.0-dev.20260225.1",
+		"@wordpress/browserslist-config": "6.44.0",
+		"concurrently": "9.2.1",
+		"sass-embedded": "1.97.3",
+		"sass-loader": "16.0.5",
+		"webpack": "5.105.2",
+		"webpack-cli": "6.0.1"
+	}
+}

--- a/projects/packages/activity-log/src/class-initial-state.php
+++ b/projects/packages/activity-log/src/class-initial-state.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * The Activity Log React initial state.
+ *
+ * @package automattic/jetpack-activity-log
+ */
+
+// After changing this file, consider increasing the version number ("VXXX") in all the files using this namespace, in
+// order to ensure that the specific version of this file always get loaded. Otherwise, Jetpack autoloader might decide
+// to load an older/newer version of the class (if, for example, both the standalone and bundled versions of the plugin
+// are installed, or in some other cases).
+namespace Automattic\Jetpack\Activity_Log\V0001;
+
+use Automattic\Jetpack\Status;
+use Jetpack_Options;
+use function admin_url;
+use function esc_url;
+use function esc_url_raw;
+use function get_bloginfo;
+use function get_site_url;
+use function plugins_url;
+use function rest_url;
+use function wp_create_nonce;
+use function wp_json_encode;
+
+/**
+ * The Activity Log React initial state.
+ */
+class Initial_State {
+	/**
+	 * Get the initial state data.
+	 *
+	 * @return array
+	 */
+	private function get_data() {
+		return array(
+			'API'           => array(
+				'WP_API_root'  => esc_url_raw( rest_url() ),
+				'WP_API_nonce' => wp_create_nonce( 'wp_rest' ),
+			),
+			'jetpackStatus' => array(
+				'calypsoSlug' => ( new Status() )->get_site_suffix(),
+			),
+			'siteData'      => array(
+				'id'       => Jetpack_Options::get_option( 'id' ),
+				'title'    => get_bloginfo( 'name' ) ? get_bloginfo( 'name' ) : get_site_url(),
+				'adminUrl' => esc_url( admin_url() ),
+			),
+			'assets'        => array(
+				'buildUrl' => plugins_url( '../build/', __FILE__ ),
+			),
+		);
+	}
+
+	/**
+	 * Render the initial state into a JavaScript variable.
+	 *
+	 * @return string
+	 */
+	public function render() {
+		return 'var JPACTIVITYLOG_INITIAL_STATE=' . wp_json_encode( $this->get_data(), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ) . ';';
+	}
+}

--- a/projects/packages/activity-log/src/class-jetpack-activity-log.php
+++ b/projects/packages/activity-log/src/class-jetpack-activity-log.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Primary class for the Jetpack Activity Log package.
+ *
+ * @package automattic/jetpack-activity-log
+ */
+
+// After changing this file, consider increasing the version number ("VXXX") in all the files using this namespace, in
+// order to ensure that the specific version of this file always get loaded. Otherwise, Jetpack autoloader might decide
+// to load an older/newer version of the class (if, for example, both the standalone and bundled versions of the plugin
+// are installed, or in some other cases).
+namespace Automattic\Jetpack\Activity_Log\V0001;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
+use Automattic\Jetpack\Activity_Log\V0001\Initial_State as Activity_Log_Initial_State;
+use Automattic\Jetpack\Admin_UI\Admin_Menu;
+use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use function add_action;
+use function current_user_can;
+use function did_action;
+use function do_action;
+use function is_multisite;
+use function wp_add_inline_script;
+
+/**
+ * Class Jetpack_Activity_Log
+ *
+ * Registers the Activity Log admin page and its REST routes inside the
+ * main Jetpack plugin.
+ */
+class Jetpack_Activity_Log {
+
+	/**
+	 * Admin page slug.
+	 *
+	 * @var string
+	 */
+	const PAGE_SLUG = 'jetpack-activity-log';
+
+	/**
+	 * Script handle for the admin bundle.
+	 *
+	 * @var string
+	 */
+	const SCRIPT_HANDLE = 'jetpack-activity-log';
+
+	/**
+	 * Entry point. Idempotent: safe to call from multiple bootstraps.
+	 */
+	public static function initialize() {
+		if ( did_action( 'jetpack_activity_log_initialized' ) ) {
+			return;
+		}
+
+		add_action( 'admin_menu', array( __CLASS__, 'add_wp_admin_submenu' ) );
+		add_action( 'rest_api_init', array( __CLASS__, 'register_rest_routes' ) );
+
+		/**
+		 * Fires once the Jetpack Activity Log package has wired its hooks.
+		 *
+		 * @since 0.1.0
+		 */
+		do_action( 'jetpack_activity_log_initialized' );
+	}
+
+	/**
+	 * Register the Activity Log submenu under Jetpack.
+	 *
+	 * Mirrors the gating used by the legacy my-jetpack "Activity Log" menu
+	 * item (connected user + non-multisite).
+	 *
+	 * @return string|null The resulting page's hook suffix, if registered.
+	 */
+	public static function add_wp_admin_submenu() {
+		if ( ! self::is_available() ) {
+			return null;
+		}
+
+		$page_suffix = Admin_Menu::add_menu(
+			/** "Activity Log" is a product name, do not translate. */
+			'Activity Log',
+			'Activity Log',
+			'manage_options',
+			self::PAGE_SLUG,
+			array( __CLASS__, 'render_page' ),
+			14
+		);
+
+		if ( $page_suffix ) {
+			add_action( 'load-' . $page_suffix, array( __CLASS__, 'admin_init' ) );
+		}
+
+		return $page_suffix;
+	}
+
+	/**
+	 * Whether the Activity Log page should be shown to the current user.
+	 *
+	 * @return bool
+	 */
+	public static function is_available() {
+		if ( is_multisite() ) {
+			return false;
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return false;
+		}
+
+		return ( new Connection_Manager() )->is_user_connected();
+	}
+
+	/**
+	 * Fires when the admin page is loaded.
+	 */
+	public static function admin_init() {
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_admin_scripts' ) );
+	}
+
+	/**
+	 * Enqueue the admin bundle and seed initial state.
+	 */
+	public static function enqueue_admin_scripts() {
+		Assets::register_script(
+			self::SCRIPT_HANDLE,
+			'../build/index.js',
+			__FILE__,
+			array(
+				'in_footer'  => true,
+				'textdomain' => 'jetpack-activity-log',
+			)
+		);
+		Assets::enqueue_script( self::SCRIPT_HANDLE );
+
+		wp_add_inline_script( self::SCRIPT_HANDLE, ( new Activity_Log_Initial_State() )->render(), 'before' );
+		Connection_Initial_State::render_script( self::SCRIPT_HANDLE );
+	}
+
+	/**
+	 * Render the admin page root node. React mounts into this element.
+	 */
+	public static function render_page() {
+		?>
+			<div id="jetpack-activity-log-root"></div>
+		<?php
+	}
+
+	/**
+	 * Register the REST routes backing the Activity Log UI.
+	 *
+	 * Routes are added in Phase 2. This method exists now so that the
+	 * `jetpack/v4/activity-log` namespace is reserved and the hook is wired.
+	 */
+	public static function register_rest_routes() {
+		REST_Controller::register_rest_routes();
+	}
+}

--- a/projects/packages/activity-log/src/class-package-version.php
+++ b/projects/packages/activity-log/src/class-package-version.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * The Package_Version class.
+ *
+ * @package automattic/jetpack-activity-log
+ */
+
+namespace Automattic\Jetpack\Activity_Log;
+
+/**
+ * The Package_Version class.
+ *
+ * Does *not* use namespaced versioning ("VXXXX") because send_package_version_to_tracker() is used as a
+ * "jetpack_package_versions" filter, and said filter gets run during a plugin upgrade, so it always expects to
+ * find the "Package_Version" class with the same namespace, name, and interface.
+ */
+class Package_Version {
+
+	const PACKAGE_VERSION = '0.1.0-alpha';
+
+	const PACKAGE_SLUG = 'activity-log';
+
+	/**
+	 * Adds the package slug and version to the package version tracker's data.
+	 *
+	 * @param array $package_versions The package version array.
+	 *
+	 * @return array The package version array.
+	 */
+	public static function send_package_version_to_tracker( $package_versions ) {
+		$package_versions[ self::PACKAGE_SLUG ] = self::PACKAGE_VERSION;
+
+		return $package_versions;
+	}
+}

--- a/projects/packages/activity-log/src/class-rest-controller.php
+++ b/projects/packages/activity-log/src/class-rest-controller.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * The Activity Log REST Controller.
+ *
+ * Registers the `/jetpack/v4/activity-log/*` routes that back the admin
+ * UI. Phase 0 reserves the namespace; concrete endpoints land in Phase 2.
+ *
+ * @package automattic/jetpack-activity-log
+ */
+
+// After changing this file, consider increasing the version number ("VXXX") in all the files using this namespace, in
+// order to ensure that the specific version of this file always get loaded. Otherwise, Jetpack autoloader might decide
+// to load an older/newer version of the class (if, for example, both the standalone and bundled versions of the plugin
+// are installed, or in some other cases).
+namespace Automattic\Jetpack\Activity_Log\V0001;
+
+use function current_user_can;
+
+/**
+ * REST routes for the Activity Log UI.
+ */
+class REST_Controller {
+
+	/**
+	 * REST namespace used by this package.
+	 *
+	 * @var string
+	 */
+	const REST_NAMESPACE = 'jetpack/v4';
+
+	/**
+	 * Register the Activity Log REST routes.
+	 *
+	 * Hooked on `rest_api_init` by {@see Jetpack_Activity_Log::initialize()}.
+	 */
+	public static function register_rest_routes() {
+		// Routes land in Phase 2:
+		// - GET    /jetpack/v4/activity-log           list with filters + pagination
+		// - GET    /jetpack/v4/activity-log/counts    counts per group for filter UI
+		// - GET    /jetpack/v4/activity-log/{id}      single event lookup
+	}
+
+	/**
+	 * Permission callback for Activity Log endpoints.
+	 *
+	 * @return bool
+	 */
+	public static function permissions_callback() {
+		return current_user_can( 'manage_options' );
+	}
+}

--- a/projects/packages/activity-log/src/js/components/Admin.jsx
+++ b/projects/packages/activity-log/src/js/components/Admin.jsx
@@ -1,0 +1,21 @@
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Placeholder Admin component. The real UI lands in Phase 3, ported from
+ * Calypso Dashboard's `client/dashboard/sites/logs-activity/`.
+ *
+ * @return {import('react').ReactElement} The Activity Log admin page placeholder.
+ */
+export default function Admin() {
+	return (
+		<div className="jp-activity-log">
+			<h1>{ __( 'Activity Log', 'jetpack-activity-log' ) }</h1>
+			<p>
+				{ __(
+					'Activity Log is being ported into Jetpack. The full UI will appear here soon.',
+					'jetpack-activity-log'
+				) }
+			</p>
+		</div>
+	);
+}

--- a/projects/packages/activity-log/src/js/index.js
+++ b/projects/packages/activity-log/src/js/index.js
@@ -1,0 +1,34 @@
+import { ThemeProvider } from '@automattic/jetpack-components';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import * as WPElement from '@wordpress/element';
+import Admin from './components/Admin';
+
+const queryClient = new QueryClient( {
+	defaultOptions: {
+		queries: {
+			staleTime: Infinity,
+		},
+	},
+} );
+
+/**
+ * Initial render function.
+ */
+function render() {
+	const container = document.getElementById( 'jetpack-activity-log-root' );
+
+	if ( null === container ) {
+		return;
+	}
+
+	const component = (
+		<QueryClientProvider client={ queryClient }>
+			<ThemeProvider>
+				<Admin />
+			</ThemeProvider>
+		</QueryClientProvider>
+	);
+	WPElement.createRoot( container ).render( component );
+}
+
+render();

--- a/projects/packages/activity-log/tsconfig.json
+++ b/projects/packages/activity-log/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "jetpack-js-tools/tsconfig.base.json",
+	"include": [ "./src/js", "types.d.ts" ]
+}

--- a/projects/packages/activity-log/types.d.ts
+++ b/projects/packages/activity-log/types.d.ts
@@ -1,0 +1,4 @@
+declare module '*.svg' {
+	const content: string;
+	export default content;
+}

--- a/projects/packages/activity-log/webpack.config.js
+++ b/projects/packages/activity-log/webpack.config.js
@@ -1,0 +1,56 @@
+const path = require( 'path' );
+const jetpackWebpackConfig = require( '@automattic/jetpack-webpack-config/webpack' );
+
+module.exports = [
+	{
+		entry: {
+			index: './src/js/index.js',
+		},
+		mode: jetpackWebpackConfig.mode,
+		devtool: jetpackWebpackConfig.devtool,
+		output: {
+			...jetpackWebpackConfig.output,
+			path: path.resolve( './build' ),
+		},
+		optimization: {
+			...jetpackWebpackConfig.optimization,
+		},
+		resolve: {
+			...jetpackWebpackConfig.resolve,
+		},
+		node: false,
+		plugins: [ ...jetpackWebpackConfig.StandardPlugins() ],
+		module: {
+			strictExportPresence: true,
+			rules: [
+				// Transpile JavaScript
+				jetpackWebpackConfig.TranspileRule( {
+					exclude: /node_modules\//,
+				} ),
+
+				// Transpile @automattic/jetpack-* in node_modules too.
+				jetpackWebpackConfig.TranspileRule( {
+					includeNodeModules: [ '@automattic/jetpack-' ],
+				} ),
+
+				// Workarounds for non-extracted `@wordpress/*` packages.
+				...jetpackWebpackConfig.BundledWpPkgsTranspileRules(),
+
+				// Handle CSS.
+				jetpackWebpackConfig.CssRule( {
+					extensions: [ 'css', 'sass', 'scss' ],
+					extraLoaders: [ { loader: 'sass-loader', options: { api: 'modern-compiler' } } ],
+				} ),
+
+				// Handle images.
+				jetpackWebpackConfig.FileRule(),
+			],
+		},
+		externals: {
+			...jetpackWebpackConfig.externals,
+			jetpackConfig: JSON.stringify( {
+				consumer_slug: 'jetpack-activity-log',
+			} ),
+		},
+	},
+];

--- a/projects/plugins/jetpack/changelog/add-activity-log-package
+++ b/projects/plugins/jetpack/changelog/add-activity-log-package
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Wire the new Activity Log package so it registers its admin page and REST namespace during plugin bootstrap.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -7,6 +7,7 @@
  * @package automattic/jetpack
  */
 
+use Automattic\Jetpack\Activity_Log\V0001\Jetpack_Activity_Log as Activity_Log_Init;
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Boost_Speed_Score\Speed_Score;
 use Automattic\Jetpack\Config;
@@ -866,6 +867,7 @@ class Jetpack {
 	public function late_initialization() {
 		add_action( 'after_setup_theme', array( 'Jetpack', 'load_modules' ), -2 );
 		My_Jetpack_Initializer::init();
+		Activity_Log_Init::initialize();
 
 		// Initialize Boost Speed Score
 		new Speed_Score( array(), 'jetpack-dashboard' );

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -14,6 +14,7 @@
 		"automattic/block-delimiter": "@dev",
 		"automattic/jetpack-a8c-mc-stats": "@dev",
 		"automattic/jetpack-account-protection": "@dev",
+		"automattic/jetpack-activity-log": "@dev",
 		"automattic/jetpack-admin-ui": "@dev",
 		"automattic/jetpack-assets": "@dev",
 		"automattic/jetpack-autoloader": "@dev",

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4fd91d0e9458bade498f43254d740fd2",
+    "content-hash": "fd07c60eb4a335c419a71e5685f9828b",
     "packages": [
         {
             "name": "automattic/block-delimiter",
@@ -189,6 +189,75 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Account protection",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-activity-log",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/activity-log",
+                "reference": "60da5f505adc949e2e2e4ad152bf93fc31d5cad7"
+            },
+            "require": {
+                "automattic/jetpack-admin-ui": "@dev",
+                "automattic/jetpack-assets": "@dev",
+                "automattic/jetpack-autoloader": "@dev",
+                "automattic/jetpack-composer-plugin": "@dev",
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-status": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-activity-log",
+                "textdomain": "jetpack-activity-log",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-package-version.php"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-activity-log/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "actions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "pnpm run build-production-concurrently"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Activity Log UI for the Jetpack plugin in wp-admin.",
             "transport-options": {
                 "relative": true
             }
@@ -6561,6 +6630,7 @@
         "automattic/block-delimiter": 20,
         "automattic/jetpack-a8c-mc-stats": 20,
         "automattic/jetpack-account-protection": 20,
+        "automattic/jetpack-activity-log": 20,
         "automattic/jetpack-admin-ui": 20,
         "automattic/jetpack-assets": 20,
         "automattic/jetpack-autoloader": 20,


### PR DESCRIPTION
Refs #48242 — **Phase 0 of 5**. This PR targets the integration branch \`try-jetpack-activity-log-page\`; final merge to \`trunk\` happens after all phases land.

## Proposed changes

Lays down the scaffolding needed for the Activity Log port, and nothing else. No user-visible behavior change on top of what my-jetpack already provides.

- New package at \`projects/packages/activity-log/\` mirroring \`projects/packages/backup/\`'s layout: \`composer.json\`, \`package.json\`, webpack + Babel + PHPCS + Phan configs, \`.gitattributes\` / \`.gitignore\`.
- \`Automattic\Jetpack\Activity_Log\V0001\Jetpack_Activity_Log::initialize()\` registers an admin submenu (\`jetpack-activity-log\`, position 14, \`manage_options\`), gated the same way the existing my-jetpack "Activity Log ↗" item is (connected user + non-multisite).
- \`Initial_State\` seeds \`JPACTIVITYLOG_INITIAL_STATE\` with API root, nonce, site id, admin URL, asset paths.
- \`REST_Controller::register_rest_routes()\` reserves the \`jetpack/v4/activity-log\` namespace — no concrete routes yet; they land in Phase 2.
- React root at \`<div id="jetpack-activity-log-root">\` with a placeholder \`<Admin />\` component behind \`QueryClientProvider\` + \`ThemeProvider\`.
- Main Jetpack plugin wires in the package via composer dep + a single \`Activity_Log_Init::initialize()\` call in \`Jetpack::late_initialization()\`.

## Related product discussion/links

Tracking issue: https://github.com/Automattic/jetpack/issues/48242

## Does this pull request change what data or activity we track or use?

No. The package reserves a REST namespace but registers no handlers yet, and the placeholder page makes no network calls.

## Intentional non-change

The existing my-jetpack "Activity Log ↗" Cloud-redirect item in \`projects/packages/my-jetpack/src/class-activitylog.php\` is left in place. During Phase 0 the new menu and the old one both appear under Jetpack. Phase 1 removes the old redirect.

## Testing instructions

Run on a WP install with Jetpack connected (not multisite, \`manage_options\` user):

1. Pull this branch, \`jetpack install plugins/jetpack\`, \`jetpack build packages/activity-log\`.
2. Visit any wp-admin page. Under the Jetpack menu, confirm you see **two** "Activity Log" entries — the original one with the \`↗\` arrow (Cloud redirect), and a new one without an arrow (this PR). Both at position 14.
3. Click the new "Activity Log" (no arrow). Expect to land on \`admin.php?page=jetpack-activity-log\`, rendering:
   > # Activity Log
   > Activity Log is being ported into Jetpack. The full UI will appear here soon.
4. Hit \`/wp-json/jetpack/v4/activity-log\` — should 404 (namespace reserved, no handlers registered yet). This is expected.
5. Multisite / disconnected user smoke check: disconnect WPCOM or test on multisite. The new menu item should not appear.

PHPCS, the jetpack autoloader, and \`webpack\` all pass locally.

## Next

Phase 1 (menu swap) will follow on a new sub-branch against \`try-jetpack-activity-log-page\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)