### PR TITLE
Fix heading hierarchy in search overlay (#27947)

### DIFF
--- a/projects/packages/search/changelog/fix-search-overlay-heading-hierarchy
+++ b/projects/packages/search/changelog/fix-search-overlay-heading-hierarchy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: changed search overlay heading from h1 to h2 to fix heading hierarchy on pages that already have an h1.

--- a/projects/packages/search/src/instant-search/components/overlay.jsx
+++ b/projects/packages/search/src/instant-search/components/overlay.jsx
@@ -98,9 +98,9 @@ const Overlay = props => {
 			].join( ' ' ) }
 			role="dialog"
 		>
-			<h1 id="jetpack-instant-search__overlay-title" className="screen-reader-text">
+			<h2 id="jetpack-instant-search__overlay-title" className="screen-reader-text">
 				{ __( 'Search results', 'jetpack-search-pkg' ) }
-			</h1>
+			</h2>
 			{ children }
 		</div>
 	);


### PR DESCRIPTION
## Summary
Changes the search results heading in the instant search overlay from `<h1>` to `<h2>`, since the page already has an `<h1>` element (the site title). This fixes accessibility and SEO issues caused by duplicate h1 tags.

## Context
- Fixes #27947 (open 3.5 years)
- Multiple support tickets have flagged this: 8299265-zen, 9805115-zen, 10040029-zen, 11060803-zd-a8c
- SEO tools warn users about duplicate h1 tags when the search overlay is open

## Changes
- `projects/packages/search/src/instant-search/components/overlay.jsx`: Changed `<h1>` to `<h2>` (both opening and closing tags)

## Notes
- CSS is unaffected — `overlay.scss` targets all h1-h6 with the same styling via `@include helper.remove-header-styling()`
- The `aria-labelledby` attribute references the element by `id`, not tag name, so accessibility is preserved
- Not visually tested — requesting reviewer verification

## Testing instructions

1. Open a site with Jetpack Search enabled (instant search overlay)
2. Trigger the search overlay by clicking the search icon or using the search form
3. Inspect the DOM (right-click → Inspect Element) and look for the element with `id="jetpack-instant-search__overlay-title"`
4. Verify the element is now an `<h2>` instead of an `<h1>`
5. Verify the overlay still functions correctly: opens, closes on Escape, shows search results, and the screen-reader text is present

## Does this pull request change what data or activity we track or use?

No. This is a purely cosmetic HTML tag change (`h1` → `h2`) with no impact on data, tracking, or privacy.