### PR TITLE
Add jetpack-wp-abilities package

### DIFF
--- a/projects/packages/wp-abilities/.gitattributes
+++ b/projects/packages/wp-abilities/.gitattributes
@@ -1,0 +1,13 @@
+# Files not needed to be distributed in the package.
+.gitattributes    export-ignore
+.github/          export-ignore
+
+# Files to include in the mirror repo, but excluded via gitignore
+# Remember to end all directories with `/**` to properly tag every file.
+# /src/js/example.min.js  production-include
+
+# Files to exclude from the mirror repo, but included in the monorepo.
+# Remember to end all directories with `/**` to properly tag every file.
+.gitignore        production-exclude
+changelog/**      production-exclude
+tests/**          production-exclude

--- a/projects/packages/wp-abilities/.gitignore
+++ b/projects/packages/wp-abilities/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+node_modules/

--- a/projects/packages/wp-abilities/.phan/config.php
+++ b/projects/packages/wp-abilities/.phan/config.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * This configuration will be read and overlaid on top of the
+ * default configuration. Command-line arguments will be applied
+ * after this file is read.
+ *
+ * @package automattic/jetpack-wp-abilities
+ */
+
+// Require base config.
+require __DIR__ . '/../../../../.phan/config.base.php';
+
+return make_phan_config( dirname( __DIR__ ) );

--- a/projects/packages/wp-abilities/.phpcs.dir.xml
+++ b/projects/packages/wp-abilities/.phpcs.dir.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<ruleset>
+
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="jetpack-wp-abilities" />
+			</property>
+		</properties>
+	</rule>
+	<rule ref="Jetpack.Functions.I18n">
+		<properties>
+			<property name="text_domain" value="jetpack-wp-abilities" />
+		</properties>
+	</rule>
+
+	<rule ref="WordPress.Utils.I18nTextDomainFixer">
+		<properties>
+			<property name="old_text_domain" type="array" />
+			<property name="new_text_domain" value="jetpack-wp-abilities" />
+		</properties>
+	</rule>
+
+</ruleset>

--- a/projects/packages/wp-abilities/CHANGELOG.md
+++ b/projects/packages/wp-abilities/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+

--- a/projects/packages/wp-abilities/CHANGELOG.md
+++ b/projects/packages/wp-abilities/CHANGELOG.md
@@ -4,6 +4,3 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-

--- a/projects/packages/wp-abilities/README.md
+++ b/projects/packages/wp-abilities/README.md
@@ -65,17 +65,33 @@ If an ability spec omits `category`, the registrar auto-injects `get_category_sl
 
 ## Gating registration for gradual rollout
 
-Every registration passes through the `jetpack_wp_abilities_should_register` filter. Returning `false` skips that registration — this is how you roll out a category or an ability gradually (per user, per site, per feature flag).
+Registration is **opt-in**. `init()` checks the `jetpack_wp_abilities_enabled` filter, which defaults to `false`. Return `true` to turn registration on for this request, typically gated on a site option, user capability, or feature flag.
 
 ```php
-// Roll out My Plugin abilities only on sites that have opted in.
+// Enable Jetpack abilities registration on sites that have opted in.
+add_filter(
+	'jetpack_wp_abilities_enabled',
+	static function ( bool $enabled ): bool {
+		return (bool) get_option( 'my_abilities_rollout_enabled', false );
+	}
+);
+```
+
+Because the default is `false`, a plugin that extends `Registrar` and calls `MyRegistrar::init()` registers nothing until a site explicitly flips the flag.
+
+### Per-registration gate
+
+For finer-grained control, every category and every ability also passes through the `jetpack_wp_abilities_should_register` filter (only reached when `jetpack_wp_abilities_enabled` has already returned `true`). Returning `false` skips a single registration.
+
+```php
+// Globally enabled, but hold back a single ability until it's GA.
 add_filter(
 	'jetpack_wp_abilities_should_register',
 	static function ( bool $enabled, string $type, string $slug ): bool {
-		if ( ! str_starts_with( $slug, 'my-plugin' ) ) {
-			return $enabled;
+		if ( 'ability' === $type && 'my-plugin/experimental-write' === $slug ) {
+			return current_user_can( 'manage_options' );
 		}
-		return (bool) get_option( 'my_plugin_abilities_enabled', false );
+		return $enabled;
 	},
 	10,
 	3

--- a/projects/packages/wp-abilities/README.md
+++ b/projects/packages/wp-abilities/README.md
@@ -1,0 +1,76 @@
+# Jetpack WP Abilities
+
+Shared utilities for registering a category and its abilities with the [WordPress Abilities API](https://make.wordpress.org/core/) from Jetpack packages and plugins.
+
+The `Registrar` base class owns the boilerplate every consumer would otherwise hand-roll: hooking into `wp_abilities_api_categories_init` / `wp_abilities_api_init` (or dispatching immediately when those actions have already fired), and guarding the Abilities API function calls so the class is safe on WordPress versions older than 6.9.
+
+## Usage
+
+Extend `Registrar`, override the three static getters, and call `init()` from the consumer's bootstrap.
+
+```php
+use Automattic\Jetpack\WP_Abilities\Registrar;
+
+class My_Plugin_Abilities extends Registrar {
+
+	public static function get_category_slug(): string {
+		return 'my-plugin';
+	}
+
+	public static function get_category_definition(): array {
+		return array(
+			'label'       => 'My Plugin',
+			'description' => __( 'Abilities for My Plugin.', 'my-plugin' ),
+		);
+	}
+
+	public static function get_abilities(): array {
+		return array(
+			'my-plugin/get-things' => array(
+				'label'               => __( 'List things', 'my-plugin' ),
+				'description'         => __( 'Return the list of things the user can access.', 'my-plugin' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'default'              => array(),
+					'properties'           => array(),
+					'additionalProperties' => false,
+				),
+				'execute_callback'    => array( __CLASS__, 'get_things' ),
+				'permission_callback' => array( __CLASS__, 'can_read_things' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+		);
+	}
+
+	public static function can_read_things(): bool {
+		return current_user_can( 'read' );
+	}
+
+	public static function get_things( $input = null ) {
+		return array( 'things' => array() );
+	}
+}
+
+My_Plugin_Abilities::init();
+```
+
+If an ability spec omits `category`, the registrar auto-injects `get_category_slug()`. If the spec sets `category` explicitly (for cross-registrar shared abilities), the explicit value is preserved.
+
+## Using this package in your WordPress plugin
+
+If you plan on using this package in your WordPress plugin, we recommend using [Jetpack Autoloader](https://packagist.org/packages/automattic/jetpack-autoloader) as your autoloader for maximum interoperability with other plugins that use this package.
+
+## Security
+
+Need to report a security vulnerability? Go to [https://automattic.com/security/](https://automattic.com/security/) or directly to our security bug bounty site [https://hackerone.com/automattic](https://hackerone.com/automattic).
+
+## License
+
+Jetpack WP Abilities is licensed under [GNU General Public License v2 (or later)](./LICENSE.txt).

--- a/projects/packages/wp-abilities/README.md
+++ b/projects/packages/wp-abilities/README.md
@@ -63,6 +63,27 @@ My_Plugin_Abilities::init();
 
 If an ability spec omits `category`, the registrar auto-injects `get_category_slug()`. If the spec sets `category` explicitly (for cross-registrar shared abilities), the explicit value is preserved.
 
+## Gating registration for gradual rollout
+
+Every registration passes through the `jetpack_wp_abilities_should_register` filter. Returning `false` skips that registration — this is how you roll out a category or an ability gradually (per user, per site, per feature flag).
+
+```php
+// Roll out My Plugin abilities only on sites that have opted in.
+add_filter(
+	'jetpack_wp_abilities_should_register',
+	static function ( bool $enabled, string $type, string $slug ): bool {
+		if ( ! str_starts_with( $slug, 'my-plugin' ) ) {
+			return $enabled;
+		}
+		return (bool) get_option( 'my_plugin_abilities_enabled', false );
+	},
+	10,
+	3
+);
+```
+
+The filter fires once per category and once per individual ability, so callbacks can switch on `$type` (`'category'` or `'ability'`) and/or `$slug` for granular control.
+
 ## Using this package in your WordPress plugin
 
 If you plan on using this package in your WordPress plugin, we recommend using [Jetpack Autoloader](https://packagist.org/packages/automattic/jetpack-autoloader) as your autoloader for maximum interoperability with other plugins that use this package.

--- a/projects/packages/wp-abilities/changelog/add-wp-abilities-package
+++ b/projects/packages/wp-abilities/changelog/add-wp-abilities-package
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Initial release of a shared Abilities API registrar base class.

--- a/projects/packages/wp-abilities/composer.json
+++ b/projects/packages/wp-abilities/composer.json
@@ -1,0 +1,59 @@
+{
+	"name": "automattic/jetpack-wp-abilities",
+	"description": "Shared utilities for registering abilities with the WordPress Abilities API from Jetpack packages and plugins.",
+	"type": "jetpack-library",
+	"license": "GPL-2.0-or-later",
+	"require": {
+		"php": ">=7.2"
+	},
+	"require-dev": {
+		"brain/monkey": "^2.6.2",
+		"yoast/phpunit-polyfills": "^4.0.0",
+		"automattic/jetpack-changelogger": "@dev",
+		"automattic/phpunit-select-config": "@dev"
+	},
+	"suggest": {
+		"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+	},
+	"autoload": {
+		"classmap": [
+			"src/"
+		]
+	},
+	"scripts": {
+		"phpunit": [
+			"phpunit-select-config phpunit.#.xml.dist --colors=always"
+		],
+		"test-coverage": [
+			"php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+		],
+		"test-php": [
+			"@composer phpunit"
+		]
+	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../../packages/*",
+			"options": {
+				"monorepo": true
+			}
+		}
+	],
+	"minimum-stability": "dev",
+	"prefer-stable": true,
+	"extra": {
+		"autotagger": true,
+		"mirror-repo": "Automattic/jetpack-wp-abilities",
+		"changelogger": {
+			"link-template": "https://github.com/automattic/jetpack-wp-abilities/compare/v${old}...v${new}"
+		},
+		"branch-alias": {
+			"dev-trunk": "0.1.x-dev"
+		},
+		"textdomain": "jetpack-wp-abilities",
+		"version-constants": {
+			"::PACKAGE_VERSION": "src/class-registrar.php"
+		}
+	}
+}

--- a/projects/packages/wp-abilities/phpunit.11.xml.dist
+++ b/projects/packages/wp-abilities/phpunit.11.xml.dist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+	bootstrap="tests/php/bootstrap.php"
+	cacheDirectory=".phpunit.cache"
+	colors="true"
+	executionOrder="depends"
+	beStrictAboutOutputDuringTests="true"
+	displayDetailsOnPhpunitDeprecations="true"
+	displayDetailsOnTestsThatTriggerDeprecations="true"
+	displayDetailsOnTestsThatTriggerErrors="true"
+	displayDetailsOnTestsThatTriggerNotices="true"
+	displayDetailsOnTestsThatTriggerWarnings="true"
+	failOnDeprecation="true"
+	failOnEmptyTestSuite="true"
+	failOnPhpunitDeprecation="true"
+	failOnNotice="true"
+	failOnRisky="true"
+	failOnWarning="true"
+>
+	<testsuites>
+		<testsuite name="main">
+			<directory suffix="Test.php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+
+	<source>
+		<include>
+			<!-- Better to only include "src" than to add "." and then exclude "tests", "vendor", and so on, as PHPUnit still scans the excluded directories. -->
+			<!-- Add additional lines for any files or directories outside of src/ that need coverage. -->
+			<directory suffix=".php">src</directory>
+		</include>
+	</source>
+	<coverage ignoreDeprecatedCodeUnits="true">
+	</coverage>
+</phpunit>

--- a/projects/packages/wp-abilities/phpunit.12.xml.dist
+++ b/projects/packages/wp-abilities/phpunit.12.xml.dist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+	bootstrap="tests/php/bootstrap.php"
+	cacheDirectory=".phpunit.cache"
+	colors="true"
+	executionOrder="depends"
+	beStrictAboutOutputDuringTests="true"
+	displayDetailsOnPhpunitDeprecations="true"
+	displayDetailsOnTestsThatTriggerDeprecations="true"
+	displayDetailsOnTestsThatTriggerErrors="true"
+	displayDetailsOnTestsThatTriggerNotices="true"
+	displayDetailsOnTestsThatTriggerWarnings="true"
+	failOnDeprecation="true"
+	failOnEmptyTestSuite="true"
+	failOnPhpunitDeprecation="true"
+	failOnNotice="true"
+	failOnRisky="true"
+	failOnWarning="true"
+>
+	<testsuites>
+		<testsuite name="main">
+			<directory suffix="Test.php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+
+	<source>
+		<include>
+			<!-- Better to only include "src" than to add "." and then exclude "tests", "vendor", and so on, as PHPUnit still scans the excluded directories. -->
+			<!-- Add additional lines for any files or directories outside of src/ that need coverage. -->
+			<directory suffix=".php">src</directory>
+		</include>
+	</source>
+	<coverage ignoreDeprecatedCodeUnits="true">
+	</coverage>
+</phpunit>

--- a/projects/packages/wp-abilities/phpunit.8.xml.dist
+++ b/projects/packages/wp-abilities/phpunit.8.xml.dist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+	bootstrap="tests/php/bootstrap.php"
+	cacheResultFile=".phpunit.cache/test-results"
+	colors="true"
+	executionOrder="depends"
+	beStrictAboutOutputDuringTests="true"
+	failOnRisky="true"
+	failOnWarning="true"
+>
+	<testsuites>
+		<testsuite name="main">
+			<directory suffix="Test.php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/projects/packages/wp-abilities/phpunit.9.xml.dist
+++ b/projects/packages/wp-abilities/phpunit.9.xml.dist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+	bootstrap="tests/php/bootstrap.php"
+	cacheResultFile=".phpunit.cache/test-results"
+	colors="true"
+	executionOrder="depends"
+	beStrictAboutOutputDuringTests="true"
+	failOnRisky="true"
+	failOnWarning="true"
+>
+	<testsuites>
+		<testsuite name="main">
+			<directory suffix="Test.php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/projects/packages/wp-abilities/src/class-registrar.php
+++ b/projects/packages/wp-abilities/src/class-registrar.php
@@ -88,7 +88,9 @@ abstract class Registrar {
 	/**
 	 * Register the category with the WordPress Abilities API.
 	 *
-	 * Safe to call directly or as a hook callback.
+	 * Safe to call directly or as a hook callback. Passes the category slug
+	 * through the `jetpack_wp_abilities_should_register` filter so consumers
+	 * can gate registration per-site, per-user, or per-feature-flag.
 	 *
 	 * @return void
 	 */
@@ -97,13 +99,21 @@ abstract class Registrar {
 			return;
 		}
 
-		wp_register_ability_category( static::get_category_slug(), static::get_category_definition() );
+		$slug = static::get_category_slug();
+		if ( ! self::should_register( 'category', $slug ) ) {
+			return;
+		}
+
+		wp_register_ability_category( $slug, static::get_category_definition() );
 	}
 
 	/**
 	 * Register every ability returned by `get_abilities()`.
 	 *
-	 * Safe to call directly or as a hook callback.
+	 * Safe to call directly or as a hook callback. Each ability slug is
+	 * passed through the `jetpack_wp_abilities_should_register` filter
+	 * individually, so consumers can enable a subset of abilities on a
+	 * subset of sites or users.
 	 *
 	 * @return void
 	 */
@@ -115,10 +125,39 @@ abstract class Registrar {
 		$category_slug = static::get_category_slug();
 
 		foreach ( static::get_abilities() as $slug => $spec ) {
+			if ( ! self::should_register( 'ability', $slug ) ) {
+				continue;
+			}
 			if ( ! isset( $spec['category'] ) ) {
 				$spec['category'] = $category_slug;
 			}
 			wp_register_ability( $slug, $spec );
 		}
+	}
+
+	/**
+	 * Apply the shared registration filter.
+	 *
+	 * @param string $type One of 'category' or 'ability'.
+	 * @param string $slug The slug being registered.
+	 * @return bool True when registration should proceed, false to skip.
+	 */
+	private static function should_register( string $type, string $slug ): bool {
+		/**
+		 * Filters whether an Abilities API category or ability should be registered.
+		 *
+		 * Returning false from any filter callback skips the registration,
+		 * which is how consumers gate rollout per-site, per-user, or per
+		 * feature flag. The filter fires once per category and once per
+		 * individual ability, so callbacks can allow-list or deny-list by
+		 * `$slug`.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool   $enabled Whether to register. Default true.
+		 * @param string $type    Either 'category' or 'ability'.
+		 * @param string $slug    The category or ability slug being registered.
+		 */
+		return (bool) apply_filters( 'jetpack_wp_abilities_should_register', true, $type, $slug );
 	}
 }

--- a/projects/packages/wp-abilities/src/class-registrar.php
+++ b/projects/packages/wp-abilities/src/class-registrar.php
@@ -65,13 +65,34 @@ abstract class Registrar {
 	/**
 	 * Wire up the Abilities API registrations.
 	 *
-	 * For each of the two Abilities API lifecycle actions we either hook our
-	 * registration method or — if the action has already fired — dispatch
-	 * immediately, so late-loading plugins still register on time.
+	 * Gated behind the `jetpack_wp_abilities_enabled` filter, which defaults
+	 * to `false`. Consumers opt in explicitly — per site, per user, or via
+	 * feature flag — so abilities roll out gradually rather than flipping on
+	 * for every site the moment the package loads.
+	 *
+	 * When the filter returns `true`, each of the two Abilities API lifecycle
+	 * actions either gets a registration callback hooked, or — if the action
+	 * has already fired — dispatches immediately so late-loading plugins
+	 * still register on time.
 	 *
 	 * @return void
 	 */
 	public static function init() {
+		/**
+		 * Filters whether Jetpack Abilities API registration should run.
+		 *
+		 * Default `false`. Return `true` to enable registration for this
+		 * request, typically gated on a site option, user capability, or
+		 * feature flag to support staged rollout.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool $enabled Whether to register abilities. Default false.
+		 */
+		if ( ! apply_filters( 'jetpack_wp_abilities_enabled', false ) ) {
+			return;
+		}
+
 		if ( did_action( self::CATEGORIES_INIT_ACTION ) ) {
 			static::register_category();
 		} else {

--- a/projects/packages/wp-abilities/src/class-registrar.php
+++ b/projects/packages/wp-abilities/src/class-registrar.php
@@ -149,7 +149,7 @@ abstract class Registrar {
 			if ( ! self::should_register( 'ability', $slug ) ) {
 				continue;
 			}
-			if ( ! isset( $spec['category'] ) ) {
+			if ( ! array_key_exists( 'category', $spec ) ) {
 				$spec['category'] = $category_slug;
 			}
 			wp_register_ability( $slug, $spec );

--- a/projects/packages/wp-abilities/src/class-registrar.php
+++ b/projects/packages/wp-abilities/src/class-registrar.php
@@ -6,7 +6,8 @@
  * @package automattic/jetpack-wp-abilities
  */
 
-// @phan-file-suppress PhanUndeclaredFunction -- Abilities API added in WP 6.9. We guard with function_exists() checks so the package is safe on older WP. @todo Remove this line when the minimum supported WordPress version is 6.9.
+// @phan-file-suppress PhanUndeclaredFunction @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9. We guard with function_exists() checks so the package is safe on older WP. @todo Remove this line when the minimum supported WordPress version is 6.9.
+// @phan-file-suppress PhanAbstractStaticMethodCallInStatic -- static:: dispatches to the concrete subclass for the three abstract getters; callers must not instantiate Registrar itself.
 
 namespace Automattic\Jetpack\WP_Abilities;
 

--- a/projects/packages/wp-abilities/src/class-registrar.php
+++ b/projects/packages/wp-abilities/src/class-registrar.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Abstract base class for registering a category and its abilities with the
+ * WordPress Abilities API.
+ *
+ * @package automattic/jetpack-wp-abilities
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction -- Abilities API added in WP 6.9. We guard with function_exists() checks so the package is safe on older WP. @todo Remove this line when the minimum supported WordPress version is 6.9.
+
+namespace Automattic\Jetpack\WP_Abilities;
+
+/**
+ * Abstract base class that owns the boilerplate every Jetpack abilities
+ * registrar needs: hooking into the Abilities API lifecycle actions (or
+ * calling the registration methods directly when those actions have already
+ * fired), and guarding the Abilities API function calls so the class is safe
+ * to load on WP < 6.9.
+ *
+ * Consumers extend this class and override `get_category_slug()`,
+ * `get_category_definition()`, and `get_abilities()`.
+ */
+abstract class Registrar {
+
+	const PACKAGE_VERSION = '0.1.0-alpha';
+
+	/**
+	 * Action fired by the Abilities API when ability categories should register.
+	 */
+	const CATEGORIES_INIT_ACTION = 'wp_abilities_api_categories_init';
+
+	/**
+	 * Action fired by the Abilities API when abilities should register.
+	 */
+	const ABILITIES_INIT_ACTION = 'wp_abilities_api_init';
+
+	/**
+	 * Return the category slug this registrar owns (e.g. "jetpack-forms").
+	 *
+	 * @return string
+	 */
+	abstract public static function get_category_slug(): string;
+
+	/**
+	 * Return the category definition passed to `wp_register_ability_category()`.
+	 *
+	 * Expected shape: [ 'label' => string, 'description' => string ].
+	 *
+	 * @return array
+	 */
+	abstract public static function get_category_definition(): array;
+
+	/**
+	 * Return the abilities this registrar owns as a `[ slug => spec ]` map.
+	 *
+	 * Each spec is passed as-is to `wp_register_ability()`. If a spec omits
+	 * `category`, the registrar auto-injects `get_category_slug()`. If the spec
+	 * sets `category` explicitly, it is preserved unchanged.
+	 *
+	 * @return array<string, array>
+	 */
+	abstract public static function get_abilities(): array;
+
+	/**
+	 * Wire up the Abilities API registrations.
+	 *
+	 * For each of the two Abilities API lifecycle actions we either hook our
+	 * registration method or — if the action has already fired — dispatch
+	 * immediately, so late-loading plugins still register on time.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		if ( did_action( self::CATEGORIES_INIT_ACTION ) ) {
+			static::register_category();
+		} else {
+			add_action( self::CATEGORIES_INIT_ACTION, array( static::class, 'register_category' ) );
+		}
+
+		if ( did_action( self::ABILITIES_INIT_ACTION ) ) {
+			static::register_abilities();
+		} else {
+			add_action( self::ABILITIES_INIT_ACTION, array( static::class, 'register_abilities' ) );
+		}
+	}
+
+	/**
+	 * Register the category with the WordPress Abilities API.
+	 *
+	 * Safe to call directly or as a hook callback.
+	 *
+	 * @return void
+	 */
+	public static function register_category() {
+		if ( ! function_exists( 'wp_register_ability_category' ) ) {
+			return;
+		}
+
+		wp_register_ability_category( static::get_category_slug(), static::get_category_definition() );
+	}
+
+	/**
+	 * Register every ability returned by `get_abilities()`.
+	 *
+	 * Safe to call directly or as a hook callback.
+	 *
+	 * @return void
+	 */
+	public static function register_abilities() {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return;
+		}
+
+		$category_slug = static::get_category_slug();
+
+		foreach ( static::get_abilities() as $slug => $spec ) {
+			if ( ! isset( $spec['category'] ) ) {
+				$spec['category'] = $category_slug;
+			}
+			wp_register_ability( $slug, $spec );
+		}
+	}
+}

--- a/projects/packages/wp-abilities/tests/php/.phpcs.dir.xml
+++ b/projects/packages/wp-abilities/tests/php/.phpcs.dir.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<ruleset>
+	<rule ref="Jetpack-Tests" />
+</ruleset>

--- a/projects/packages/wp-abilities/tests/php/RegistrarTest.php
+++ b/projects/packages/wp-abilities/tests/php/RegistrarTest.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\WP_Abilities;
 
 use Brain\Monkey;
 use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
@@ -251,6 +252,50 @@ class RegistrarTest extends TestCase {
 		TestFixtureRegistrar::init();
 		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Deliberate: asserts repeat init() calls are safe.
 		TestFixtureRegistrar::init();
+	}
+
+	/**
+	 * Returning false from the should-register filter blocks category registration.
+	 */
+	public function test_filter_blocks_category_registration(): void {
+		Filters\expectApplied( 'jetpack_wp_abilities_should_register' )
+			->once()
+			->with( true, 'category', 'fixture/slug' )
+			->andReturn( false );
+
+		Functions\expect( 'wp_register_ability_category' )->never();
+
+		TestFixtureRegistrar::register_category();
+	}
+
+	/**
+	 * Returning false from the should-register filter blocks ability registration.
+	 */
+	public function test_filter_blocks_all_abilities_when_returning_false(): void {
+		Filters\expectApplied( 'jetpack_wp_abilities_should_register' )
+			->andReturn( false );
+
+		Functions\expect( 'wp_register_ability' )->never();
+
+		TestFixtureRegistrar::register_abilities();
+	}
+
+	/**
+	 * The filter fires per ability slug, so consumers can allow-list individually.
+	 */
+	public function test_filter_allows_per_ability_allow_list(): void {
+		Filters\expectApplied( 'jetpack_wp_abilities_should_register' )
+			->andReturnUsing(
+				static function ( $enabled, $type, $slug ) {
+					return 'ability' === $type && 'fixture/alpha' === $slug;
+				}
+			);
+
+		Functions\expect( 'wp_register_ability' )
+			->once()
+			->with( 'fixture/alpha', \Mockery::type( 'array' ) );
+
+		TestFixtureRegistrar::register_abilities();
 	}
 
 	/**

--- a/projects/packages/wp-abilities/tests/php/RegistrarTest.php
+++ b/projects/packages/wp-abilities/tests/php/RegistrarTest.php
@@ -45,9 +45,36 @@ class RegistrarTest extends TestCase {
 	}
 
 	/**
+	 * Enable the top-level gate filter for tests that exercise init().
+	 */
+	private function enable_abilities(): void {
+		Filters\expectApplied( 'jetpack_wp_abilities_enabled' )->andReturn( true );
+	}
+
+	/**
+	 * The gate filter defaults to false: init() must register nothing.
+	 */
+	public function test_init_is_disabled_by_default(): void {
+		Filters\expectApplied( 'jetpack_wp_abilities_enabled' )
+			->once()
+			->with( false )
+			->andReturn( false );
+
+		Functions\expect( 'did_action' )->never();
+		Actions\expectAdded( Registrar::CATEGORIES_INIT_ACTION )->never();
+		Actions\expectAdded( Registrar::ABILITIES_INIT_ACTION )->never();
+		Functions\expect( 'wp_register_ability_category' )->never();
+		Functions\expect( 'wp_register_ability' )->never();
+
+		TestFixtureRegistrar::init();
+	}
+
+	/**
 	 * Neither lifecycle action has fired: init() hooks both, calls neither registrar.
 	 */
 	public function test_init_adds_hooks_when_neither_action_fired(): void {
+		$this->enable_abilities();
+
 		Functions\when( 'did_action' )->justReturn( 0 );
 
 		Actions\expectAdded( Registrar::CATEGORIES_INIT_ACTION )
@@ -67,6 +94,8 @@ class RegistrarTest extends TestCase {
 	 * Categories-init already fired: register category directly, still hook abilities.
 	 */
 	public function test_init_registers_category_directly_when_categories_action_already_fired(): void {
+		$this->enable_abilities();
+
 		Functions\when( 'did_action' )->alias(
 			static function ( $action ) {
 				return Registrar::CATEGORIES_INIT_ACTION === $action ? 1 : 0;
@@ -93,6 +122,8 @@ class RegistrarTest extends TestCase {
 	 * Abilities-init already fired: register abilities directly, still hook category.
 	 */
 	public function test_init_registers_abilities_directly_when_abilities_action_already_fired(): void {
+		$this->enable_abilities();
+
 		Functions\when( 'did_action' )->alias(
 			static function ( $action ) {
 				return Registrar::ABILITIES_INIT_ACTION === $action ? 1 : 0;
@@ -111,6 +142,8 @@ class RegistrarTest extends TestCase {
 	 * Both actions already fired: everything runs directly, nothing is hooked.
 	 */
 	public function test_init_registers_both_directly_when_both_actions_already_fired(): void {
+		$this->enable_abilities();
+
 		Functions\when( 'did_action' )->justReturn( 1 );
 
 		Functions\expect( 'wp_register_ability_category' )->once();
@@ -244,6 +277,8 @@ class RegistrarTest extends TestCase {
 	 * Repeated init() calls are safe: the library does not dedupe, WordPress does.
 	 */
 	public function test_init_is_safe_to_call_repeatedly(): void {
+		$this->enable_abilities();
+
 		Functions\when( 'did_action' )->justReturn( 0 );
 
 		Actions\expectAdded( Registrar::CATEGORIES_INIT_ACTION )->twice();

--- a/projects/packages/wp-abilities/tests/php/RegistrarTest.php
+++ b/projects/packages/wp-abilities/tests/php/RegistrarTest.php
@@ -1,0 +1,337 @@
+<?php
+/**
+ * Tests for Automattic\Jetpack\WP_Abilities\Registrar.
+ *
+ * @package automattic/jetpack-wp-abilities
+ */
+
+namespace Automattic\Jetpack\WP_Abilities;
+
+use Brain\Monkey;
+use Brain\Monkey\Actions;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
+// phpcs:disable Squiz.Commenting.ClassComment.Missing
+
+/**
+ * Unit tests for the abstract Registrar base class.
+ *
+ * @covers \Automattic\Jetpack\WP_Abilities\Registrar
+ */
+#[CoversClass( Registrar::class )]
+class RegistrarTest extends TestCase {
+	use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
+	/**
+	 * Set up Brain Monkey.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	/**
+	 * Tear down Brain Monkey.
+	 */
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Neither lifecycle action has fired: init() hooks both, calls neither registrar.
+	 */
+	public function test_init_adds_hooks_when_neither_action_fired(): void {
+		Functions\when( 'did_action' )->justReturn( 0 );
+
+		Actions\expectAdded( Registrar::CATEGORIES_INIT_ACTION )
+			->once()
+			->with( array( TestFixtureRegistrar::class, 'register_category' ) );
+		Actions\expectAdded( Registrar::ABILITIES_INIT_ACTION )
+			->once()
+			->with( array( TestFixtureRegistrar::class, 'register_abilities' ) );
+
+		Functions\expect( 'wp_register_ability_category' )->never();
+		Functions\expect( 'wp_register_ability' )->never();
+
+		TestFixtureRegistrar::init();
+	}
+
+	/**
+	 * Categories-init already fired: register category directly, still hook abilities.
+	 */
+	public function test_init_registers_category_directly_when_categories_action_already_fired(): void {
+		Functions\when( 'did_action' )->alias(
+			static function ( $action ) {
+				return Registrar::CATEGORIES_INIT_ACTION === $action ? 1 : 0;
+			}
+		);
+
+		Functions\expect( 'wp_register_ability_category' )
+			->once()
+			->with(
+				'fixture/slug',
+				array(
+					'label'       => 'Fixture',
+					'description' => 'A fixture category.',
+				)
+			);
+
+		Actions\expectAdded( Registrar::CATEGORIES_INIT_ACTION )->never();
+		Actions\expectAdded( Registrar::ABILITIES_INIT_ACTION )->once();
+
+		TestFixtureRegistrar::init();
+	}
+
+	/**
+	 * Abilities-init already fired: register abilities directly, still hook category.
+	 */
+	public function test_init_registers_abilities_directly_when_abilities_action_already_fired(): void {
+		Functions\when( 'did_action' )->alias(
+			static function ( $action ) {
+				return Registrar::ABILITIES_INIT_ACTION === $action ? 1 : 0;
+			}
+		);
+
+		Functions\expect( 'wp_register_ability' )->times( 2 );
+
+		Actions\expectAdded( Registrar::CATEGORIES_INIT_ACTION )->once();
+		Actions\expectAdded( Registrar::ABILITIES_INIT_ACTION )->never();
+
+		TestFixtureRegistrar::init();
+	}
+
+	/**
+	 * Both actions already fired: everything runs directly, nothing is hooked.
+	 */
+	public function test_init_registers_both_directly_when_both_actions_already_fired(): void {
+		Functions\when( 'did_action' )->justReturn( 1 );
+
+		Functions\expect( 'wp_register_ability_category' )->once();
+		Functions\expect( 'wp_register_ability' )->times( 2 );
+
+		Actions\expectAdded( Registrar::CATEGORIES_INIT_ACTION )->never();
+		Actions\expectAdded( Registrar::ABILITIES_INIT_ACTION )->never();
+
+		TestFixtureRegistrar::init();
+	}
+
+	/**
+	 * Register_category() passes subclass slug + definition through unchanged.
+	 */
+	public function test_register_category_registers_with_slug_and_definition(): void {
+		Functions\expect( 'wp_register_ability_category' )
+			->once()
+			->with(
+				'fixture/slug',
+				array(
+					'label'       => 'Fixture',
+					'description' => 'A fixture category.',
+				)
+			);
+
+		TestFixtureRegistrar::register_category();
+	}
+
+	/**
+	 * Register_category() no-ops when the Abilities API is not declared (WP < 6.9).
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_register_category_returns_early_when_api_unavailable(): void {
+		self::assertFalse(
+			function_exists( 'wp_register_ability_category' ),
+			'Guard test requires the Abilities API not to be declared.'
+		);
+
+		TestFixtureRegistrar::register_category();
+
+		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * Each ability is registered; specs without `category` get the subclass slug injected.
+	 */
+	public function test_register_abilities_registers_each_with_auto_injected_category(): void {
+		Functions\expect( 'wp_register_ability' )
+			->once()
+			->with(
+				'fixture/alpha',
+				\Mockery::on(
+					static function ( $spec ) {
+						return is_array( $spec )
+							&& isset( $spec['category'] )
+							&& 'fixture/slug' === $spec['category']
+							&& 'Alpha' === $spec['label'];
+					}
+				)
+			);
+		Functions\expect( 'wp_register_ability' )
+			->once()
+			->with(
+				'fixture/beta',
+				\Mockery::on(
+					static function ( $spec ) {
+						return is_array( $spec )
+							&& isset( $spec['category'] )
+							&& 'fixture/slug' === $spec['category']
+							&& 'Beta' === $spec['label'];
+					}
+				)
+			);
+
+		TestFixtureRegistrar::register_abilities();
+	}
+
+	/**
+	 * A spec that sets `category` explicitly keeps the value the subclass provided.
+	 */
+	public function test_register_abilities_preserves_explicit_category(): void {
+		Functions\expect( 'wp_register_ability' )
+			->once()
+			->with(
+				'fixture/shared',
+				\Mockery::on(
+					static function ( $spec ) {
+						return is_array( $spec )
+							&& isset( $spec['category'] )
+							&& 'other/slug' === $spec['category'];
+					}
+				)
+			);
+
+		TestExplicitCategoryRegistrar::register_abilities();
+	}
+
+	/**
+	 * Register_abilities() no-ops when the Abilities API is not declared (WP < 6.9).
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_register_abilities_returns_early_when_api_unavailable(): void {
+		self::assertFalse(
+			function_exists( 'wp_register_ability' ),
+			'Guard test requires the Abilities API not to be declared.'
+		);
+
+		TestFixtureRegistrar::register_abilities();
+
+		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * An empty abilities map makes no registration calls and does not error.
+	 */
+	public function test_register_abilities_handles_empty_map(): void {
+		Functions\expect( 'wp_register_ability' )->never();
+
+		TestEmptyRegistrar::register_abilities();
+	}
+
+	/**
+	 * Repeated init() calls are safe: the library does not dedupe, WordPress does.
+	 */
+	public function test_init_is_safe_to_call_repeatedly(): void {
+		Functions\when( 'did_action' )->justReturn( 0 );
+
+		Actions\expectAdded( Registrar::CATEGORIES_INIT_ACTION )->twice();
+		Actions\expectAdded( Registrar::ABILITIES_INIT_ACTION )->twice();
+
+		TestFixtureRegistrar::init();
+		TestFixtureRegistrar::init();
+	}
+
+	/**
+	 * Late static binding ensures two subclasses register with their own slugs.
+	 */
+	public function test_static_binding_honours_subclass(): void {
+		Functions\expect( 'wp_register_ability_category' )
+			->once()
+			->with( 'fixture/slug', \Mockery::type( 'array' ) );
+		Functions\expect( 'wp_register_ability_category' )
+			->once()
+			->with( 'other/slug', \Mockery::type( 'array' ) );
+
+		TestFixtureRegistrar::register_category();
+		TestExplicitCategoryRegistrar::register_category();
+	}
+}
+
+// phpcs:disable Squiz.Commenting.FunctionComment.Missing -- Fixture subclasses below implement the Registrar contract; their method bodies are the documentation.
+
+class TestFixtureRegistrar extends Registrar {
+	public static function get_category_slug(): string {
+		return 'fixture/slug';
+	}
+
+	public static function get_category_definition(): array {
+		return array(
+			'label'       => 'Fixture',
+			'description' => 'A fixture category.',
+		);
+	}
+
+	public static function get_abilities(): array {
+		return array(
+			'fixture/alpha' => array(
+				'label'       => 'Alpha',
+				'description' => 'First fixture ability.',
+			),
+			'fixture/beta'  => array(
+				'label'       => 'Beta',
+				'description' => 'Second fixture ability.',
+			),
+		);
+	}
+}
+
+class TestExplicitCategoryRegistrar extends Registrar {
+	public static function get_category_slug(): string {
+		return 'other/slug';
+	}
+
+	public static function get_category_definition(): array {
+		return array(
+			'label'       => 'Other',
+			'description' => 'Another fixture category.',
+		);
+	}
+
+	public static function get_abilities(): array {
+		return array(
+			'fixture/shared' => array(
+				'label'       => 'Shared',
+				'description' => 'Ability that names its own category.',
+				'category'    => 'other/slug',
+			),
+		);
+	}
+}
+
+class TestEmptyRegistrar extends Registrar {
+	public static function get_category_slug(): string {
+		return 'empty/slug';
+	}
+
+	public static function get_category_definition(): array {
+		return array(
+			'label'       => 'Empty',
+			'description' => 'No abilities.',
+		);
+	}
+
+	public static function get_abilities(): array {
+		return array();
+	}
+}

--- a/projects/packages/wp-abilities/tests/php/RegistrarTest.php
+++ b/projects/packages/wp-abilities/tests/php/RegistrarTest.php
@@ -249,6 +249,7 @@ class RegistrarTest extends TestCase {
 		Actions\expectAdded( Registrar::ABILITIES_INIT_ACTION )->twice();
 
 		TestFixtureRegistrar::init();
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Deliberate: asserts repeat init() calls are safe.
 		TestFixtureRegistrar::init();
 	}
 

--- a/projects/packages/wp-abilities/tests/php/bootstrap.php
+++ b/projects/packages/wp-abilities/tests/php/bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Bootstrap.
+ *
+ * @package automattic/jetpack-wp-abilities
+ */
+
+/**
+ * Include the composer autoloader.
+ */
+require_once __DIR__ . '/../../vendor/autoload.php';


### PR DESCRIPTION
Fixes RSM-1031

## Proposed changes

* Add a new `automattic/jetpack-wp-abilities` package with an abstract `Registrar` base class that owns the boilerplate every Jetpack abilities consumer currently hand-rolls: hooking into `wp_abilities_api_categories_init` / `wp_abilities_api_init` (or dispatching immediately when those actions have already fired), and guarding the Abilities API function calls so the class is safe on WP < 6.9.
* Consumers extend the class and override three small static methods (`get_category_slug()`, `get_category_definition()`, `get_abilities()`), then call `::init()` once. If an ability spec omits `category`, the base auto-injects `get_category_slug()`; explicit values are preserved.
* **Gated rollout.** `init()` is gated behind the `jetpack_wp_abilities_enabled` filter, which defaults to `false`. Nothing registers until a site opts in — typically via a site option, user capability, or feature flag. This lets us introduce abilities gradually to a subset of users/sites rather than flipping them on globally the moment the package loads.
* **Per-slug gate (finer control).** When the top-level gate passes, every category and every individual ability additionally passes through `jetpack_wp_abilities_should_register`, which receives `$type` (`'category'` or `'ability'`) and `$slug`. Returning `false` skips that single registration — useful for hiding a specific experimental ability while everything else ships.
* Ship with a PHPUnit + Brain Monkey test suite (16 tests, 37 assertions) covering every branch, including both filters (default-false gate, per-slug allow-list) and the two WP < 6.9 "API function not declared" guards (exercised in isolated PHP subprocesses so Brain Monkey's eval'd stubs from earlier tests don't leak).

The pattern currently lives in `projects/packages/forms/src/abilities/class-forms-abilities.php` and (landed upstream, not yet in trunk) in Related Posts. This package is the shared home so future consumers stop copy-pasting.

## Related product discussion/links

* Pattern reference: [WooCommerce Payments `Abilities_Registrar`](https://raw.githubusercontent.com/Automattic/woocommerce-payments/410e207e522e71170215fbd5b1bfff25f8d39b4e/src/Internal/Abilities/Abilities_Registrar.php)
* Existing in-monorepo consumer to migrate in a follow-up: `projects/packages/forms/src/abilities/class-forms-abilities.php`

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. `cd projects/packages/wp-abilities`
2. `composer install`
3. Run the tests:
   * `composer test-php` — expect `OK (16 tests, 37 assertions)` on PHP 7.4 / 8.x / 8.4.
4. Run the linter:
   * From the monorepo root: `composer phpcs:lint -- projects/packages/wp-abilities` — expect no violations.
5. Validate the manifest and changelog entry:
   * `composer validate --strict` (inside the package) — expect "composer.json is valid".
   * `jetpack changelog validate packages/wp-abilities` — expect a success message.
6. Exercise the public API from a scratch subclass:
   ```php
   class My_Abilities extends \Automattic\Jetpack\WP_Abilities\Registrar {
       public static function get_category_slug(): string { return 'my-plugin'; }
       public static function get_category_definition(): array {
           return array( 'label' => 'My Plugin', 'description' => 'Abilities for My Plugin.' );
       }
       public static function get_abilities(): array { return array(); }
   }
   My_Abilities::init();
   ```
   * Without the opt-in filter, nothing registers (confirm the category and abilities do **not** appear at `/wp-json/wp-abilities/v1/categories` or `/abilities`).
   * Add `add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );` and reload — the category now appears.
   * Hook `jetpack_wp_abilities_should_register` and `return false` for a specific slug; confirm only that one drops out while the rest register.
