### PR TITLE
Add Write — distraction-free front-end editor for WordPress.com

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-write-editor
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-write-editor
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add Write, a distraction-free front-end editor at /write/ for WordPress.com sites. Gated by blog sticker.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -303,7 +303,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/wpcom-wpadmin-page-view/wpcom-wpadmin-page-view.php';
 
 		// Write: distraction-free front-end editor. Gated by blog sticker for gradual rollout.
-		if ( wpcom_has_blog_sticker( 'wpcom-write-editor', get_current_blog_id() ) ) {
+		if ( wpcom_has_blog_sticker( 'wpcom-write-editor', get_wpcom_blog_id() ) ) {
 			require_once __DIR__ . '/features/write/write.php';
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -302,6 +302,11 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/wpcom-widgets/wpcom-widgets.php';
 		require_once __DIR__ . '/features/wpcom-wpadmin-page-view/wpcom-wpadmin-page-view.php';
 
+		// Write: distraction-free front-end editor. Gated by blog sticker for gradual rollout.
+		if ( wpcom_has_blog_sticker( 'wpcom-write-editor', get_current_blog_id() ) ) {
+			require_once __DIR__ . '/features/write/write.php';
+		}
+
 		/*
 		 * Temporarily disable client-side media processing.
 		 *

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -457,6 +457,8 @@
 }
 
 .bw-content p {
+	font-size: inherit;
+	line-height: inherit;
 	margin: 0 0 1.25em;
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -1,0 +1,1139 @@
+/* Write — Distraction-free writing */
+
+/* ===== Reset for the writing page ===== */
+.bw-app {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, sans-serif;
+	color: #1a1a1a;
+	background: #fff;
+	min-height: 100vh;
+}
+
+/* ===== Top bar ===== */
+.bw-topbar {
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	z-index: 100;
+	height: 56px;
+	background: #fff;
+	border-bottom: 1px solid #f0f0f0;
+	display: flex;
+	align-items: center;
+	padding: 0 24px;
+}
+
+body.admin-bar .bw-topbar {
+	top: 32px;
+	transition: top 0.4s ease;
+}
+
+body.admin-bar #wpadminbar {
+	transition: transform 0.4s ease;
+}
+
+body.admin-bar.bw-focused #wpadminbar {
+	transform: translateY(-100%);
+}
+
+body.admin-bar.bw-focused .bw-topbar {
+	top: 0;
+}
+
+body.admin-bar.bw-focused .bw-main {
+	padding-top: 96px;
+}
+
+@media screen and (max-width: 782px) {
+
+	body.admin-bar .bw-topbar {
+		top: 46px;
+	}
+
+	body.admin-bar.bw-focused .bw-topbar {
+		top: 0;
+	}
+}
+
+/* Help toggle */
+.bw-help-toggle {
+	width: 28px;
+	height: 28px;
+	border-radius: 50%;
+	border: 1px solid #e0e0e0;
+	background: transparent;
+	color: #bbb;
+	font-size: 13px;
+	font-weight: 600;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	margin-left: 8px;
+	transition: all 0.15s ease;
+	font-family: inherit;
+}
+
+.bw-help-toggle:hover {
+	border-color: #999;
+	color: #666;
+}
+
+.bw-help-popover {
+	position: absolute;
+	top: 48px;
+	left: 60px;
+	z-index: 200;
+	background: #fff;
+	border-radius: 10px;
+	padding: 16px 20px;
+	min-width: 260px;
+	box-shadow: 0 4px 24px rgba(0, 0, 0, 0.1);
+	animation: bw-fade-in 0.12s ease;
+}
+
+.bw-help-popover[hidden] {
+	display: none;
+}
+
+.bw-help-title {
+	font-size: 11px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
+	color: #999;
+	margin-bottom: 12px;
+}
+
+.bw-help-row {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	padding: 5px 0;
+	font-size: 13px;
+	color: #555;
+}
+
+.bw-help-row kbd {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 24px;
+	height: 22px;
+	padding: 0 6px;
+	background: #f5f5f5;
+	border: 1px solid #e0e0e0;
+	border-radius: 4px;
+	font-size: 12px;
+	font-family: inherit;
+	color: #333;
+}
+
+.bw-help-row .bw-help-icon {
+	font-size: 16px;
+	width: 24px;
+	text-align: center;
+	color: #888;
+}
+
+.bw-back {
+	font-size: 22px;
+	color: #999;
+	text-decoration: none;
+	width: 36px;
+	height: 36px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: 50%;
+	transition: all 0.15s ease;
+}
+
+.bw-back:hover {
+	background: #f5f5f5;
+	color: #333;
+}
+
+.bw-status {
+	flex: 1;
+	text-align: center;
+	font-size: 14px;
+	color: #999;
+	font-weight: 400;
+}
+
+.bw-topbar-actions {
+	display: flex;
+	gap: 8px;
+}
+
+.bw-btn {
+	border: none;
+	border-radius: 20px;
+	padding: 8px 20px;
+	font-size: 14px;
+	font-weight: 500;
+	cursor: pointer;
+	transition: all 0.15s ease;
+}
+
+.bw-btn:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+}
+
+.bw-btn-draft {
+	background: transparent;
+	color: #666;
+	border: 1px solid #ddd;
+}
+
+.bw-btn-draft:hover:not(:disabled) {
+	border-color: #999;
+	color: #333;
+}
+
+.bw-btn-publish {
+	background: #2171b1;
+	color: #fff;
+}
+
+.bw-btn-publish:hover:not(:disabled) {
+	background: #1a5f99;
+}
+
+/* ===== Main writing area ===== */
+.bw-main {
+	padding-top: 96px;
+	padding-bottom: 40vh;
+	display: flex;
+	justify-content: center;
+}
+
+body.admin-bar .bw-main {
+	padding-top: 128px;
+}
+
+.bw-editor {
+	width: 100%;
+	max-width: 720px;
+	padding: 0 24px;
+}
+
+/* Title */
+.bw-title {
+	display: block;
+	width: 100%;
+	border: none;
+	outline: none;
+	font-size: 2.5rem;
+	font-weight: 700;
+	line-height: 1.2;
+	color: #1a1a1a;
+	padding: 0;
+	margin-bottom: 16px;
+	font-family: inherit;
+	background: transparent;
+	resize: none;
+	overflow: hidden;
+	box-sizing: border-box;
+	field-sizing: content;
+}
+
+.bw-title::placeholder {
+	color: #ccc;
+}
+
+/* Category pills */
+.bw-categories {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+	margin-bottom: 16px;
+}
+
+.bw-cat {
+	border: 1px solid #e0e0e0;
+	background: transparent;
+	color: #999;
+	border-radius: 16px;
+	padding: 4px 14px;
+	font-size: 13px;
+	font-family: inherit;
+	cursor: pointer;
+	transition: all 0.15s ease;
+}
+
+.bw-cat:hover {
+	border-color: #bbb;
+	color: #666;
+}
+
+.bw-cat-selected {
+	background: #1a1a1a;
+	border-color: #1a1a1a;
+	color: #fff;
+}
+
+.bw-cat-selected:hover {
+	background: #333;
+	border-color: #333;
+	color: #fff;
+}
+
+/* Leave confirmation modal */
+.bw-leave-modal {
+	background: #fff;
+	border-radius: 12px;
+	padding: 32px;
+	width: 380px;
+	max-width: 90vw;
+	box-shadow: 0 8px 40px rgba(0, 0, 0, 0.15);
+	text-align: center;
+}
+
+.bw-leave-modal h3 {
+	margin: 0 0 8px;
+	font-size: 18px;
+	font-weight: 600;
+}
+
+.bw-leave-modal p {
+	color: #666;
+	font-size: 14px;
+	margin: 0 0 24px;
+}
+
+.bw-leave-actions {
+	display: flex;
+	gap: 10px;
+	justify-content: center;
+}
+
+.bw-btn-leave {
+	background: #d63638;
+	color: #fff;
+	text-decoration: none;
+	border-radius: 20px;
+	padding: 8px 20px;
+	font-size: 14px;
+	font-weight: 500;
+	border: none;
+	cursor: pointer;
+	transition: background 0.15s ease;
+}
+
+.bw-btn-leave:hover {
+	background: #b32d2e;
+	color: #fff;
+}
+
+/* Slash command menu */
+.bw-slash-menu {
+	position: absolute;
+	z-index: 202;
+	background: #fff;
+	border-radius: 12px;
+	padding: 6px;
+	min-width: 240px;
+	box-shadow: 0 4px 24px rgba(0, 0, 0, 0.12);
+	border: 1px solid #f0f0f0;
+	animation: bw-fade-in 0.1s ease;
+}
+
+.bw-slash-menu[hidden] {
+	display: none;
+}
+
+.bw-slash-item {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 10px 12px;
+	border-radius: 8px;
+	cursor: pointer;
+	transition: background 0.1s ease;
+}
+
+.bw-slash-item:hover,
+.bw-slash-item-active {
+	background: #f5f5f5;
+}
+
+.bw-slash-item strong {
+	display: block;
+	font-size: 14px;
+	font-weight: 500;
+	color: #1a1a1a;
+}
+
+.bw-slash-desc {
+	display: block;
+	font-size: 12px;
+	color: #999;
+	margin-top: 1px;
+}
+
+.bw-slash-icon {
+	width: 36px;
+	height: 36px;
+	border-radius: 8px;
+	background: #f5f5f5;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 16px;
+	font-weight: 600;
+	color: #555;
+	flex-shrink: 0;
+}
+
+/* Floating category picker */
+.bw-cat-fab {
+	position: fixed;
+	bottom: 24px;
+	right: 24px;
+	z-index: 200;
+	width: 44px;
+	height: 44px;
+	border-radius: 50%;
+	background: #1e1e1e;
+	color: #fff;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	cursor: pointer;
+	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+	transition: all 0.15s ease;
+}
+
+.bw-cat-fab:hover {
+	background: #333;
+	transform: scale(1.05);
+}
+
+.bw-cat-fab-icon {
+	font-size: 20px;
+	width: 20px;
+	height: 20px;
+	line-height: 20px;
+}
+
+.bw-cat-popover {
+	position: fixed;
+	bottom: 80px;
+	right: 24px;
+	z-index: 201;
+	background: #fff;
+	border-radius: 12px;
+	padding: 16px;
+	min-width: 180px;
+	box-shadow: 0 4px 24px rgba(0, 0, 0, 0.12);
+	animation: bw-fade-in 0.12s ease;
+}
+
+.bw-cat-popover[hidden] {
+	display: none;
+}
+
+.bw-cat-popover-header {
+	font-size: 11px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
+	color: #999;
+	margin-bottom: 10px;
+}
+
+.bw-cat-popover-list {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+}
+
+/* Separator between title and content */
+.bw-separator {
+	width: 48px;
+	height: 1px;
+	background: #e0e0e0;
+	margin-bottom: 24px;
+}
+
+/* ===== Custom caret ===== */
+.bw-content,
+.bw-title {
+	caret-color: #2171b1;
+}
+
+/* ===== Custom selection ===== */
+.bw-content ::selection,
+.bw-content::selection,
+.bw-title::selection {
+	background: rgba(33, 113, 177, 0.15);
+	color: inherit;
+}
+
+/* Content area */
+.bw-content {
+	min-height: 60vh;
+	font-size: 1.125rem;
+	line-height: 1.8;
+	color: #333;
+	outline: none;
+	overflow-wrap: break-word;
+	word-break: normal;
+}
+
+.bw-content:empty::before {
+	content: attr(data-placeholder);
+	color: #ccc;
+	pointer-events: none;
+}
+
+.bw-content p {
+	margin: 0 0 1.25em;
+}
+
+.bw-content h1,
+.bw-content h2,
+.bw-content h3 {
+	font-weight: 700;
+	line-height: 1.3;
+	margin: 1.5em 0 0.5em;
+	color: #1a1a1a;
+}
+
+.bw-content h2 {
+	font-size: 1.625rem;
+}
+
+.bw-content h3 {
+	font-size: 1.25rem;
+}
+
+.bw-content blockquote {
+	border-left: 3px solid #e0e0e0;
+	padding-left: 1.25em;
+	margin: 1.5em 0;
+	color: #555;
+	font-style: italic;
+}
+
+.bw-content hr {
+	border: none;
+	height: 1px;
+	background: #e0e0e0;
+	margin: 2em 0;
+}
+
+.bw-content a {
+	color: #2171b1;
+	text-decoration: underline;
+	text-underline-offset: 2px;
+	transition: color 0.15s ease;
+}
+
+.bw-content a:hover {
+	color: #1a5f99;
+}
+
+.bw-content strong,
+.bw-content b {
+	font-weight: 700;
+}
+
+.bw-content em,
+.bw-content i {
+	font-style: italic;
+}
+
+/* Images in content */
+.bw-content figure,
+.bw-content .bw-image-figure {
+	margin: 2em 0;
+	padding: 0;
+	position: relative;
+}
+
+.bw-content figure .bw-img-controls,
+.bw-content .bw-image-figure .bw-img-controls {
+	position: relative;
+	display: block;
+}
+
+.bw-content figure .bw-img-delete,
+.bw-content .bw-image-figure .bw-img-delete {
+	position: absolute;
+	top: 10px;
+	right: 10px;
+	width: 32px;
+	height: 32px;
+	border-radius: 50%;
+	background: rgba(0, 0, 0, 0.6);
+	backdrop-filter: blur(4px);
+	color: #fff;
+	border: none;
+	font-size: 16px;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	opacity: 0;
+	transform: scale(0.8);
+	transition: opacity 0.15s ease, transform 0.15s ease, background 0.15s ease;
+	z-index: 5;
+}
+
+.bw-img-controls:hover .bw-img-delete {
+	opacity: 1;
+	transform: scale(1);
+}
+
+.bw-img-controls .bw-img-delete:hover {
+	background: rgba(214, 54, 56, 0.85);
+}
+
+/* Alt text button */
+.bw-img-alt {
+	position: absolute;
+	bottom: 10px;
+	left: 10px;
+	padding: 4px 10px;
+	border-radius: 4px;
+	background: rgba(0, 0, 0, 0.6);
+	backdrop-filter: blur(4px);
+	color: #fff;
+	border: none;
+	font-size: 11px;
+	font-weight: 700;
+	letter-spacing: 0.05em;
+	cursor: pointer;
+	opacity: 0;
+	transform: scale(0.8);
+	transition: opacity 0.15s ease, transform 0.15s ease, background 0.15s ease;
+	z-index: 5;
+}
+
+.bw-img-controls:hover .bw-img-alt {
+	opacity: 1;
+	transform: scale(1);
+}
+
+.bw-img-alt:hover {
+	background: rgba(33, 113, 177, 0.85);
+}
+
+/* Alt text inline input */
+.bw-img-alt-input {
+	position: absolute;
+	bottom: 10px;
+	left: 10px;
+	right: 10px;
+	z-index: 6;
+	padding: 8px 12px;
+	border: none;
+	border-radius: 6px;
+	background: rgba(0, 0, 0, 0.7);
+	backdrop-filter: blur(8px);
+	color: #fff;
+	font-size: 13px;
+	font-family: inherit;
+	outline: none;
+	box-sizing: border-box;
+	animation: bw-fade-in 0.12s ease;
+}
+
+.bw-img-alt-input::placeholder {
+	color: rgba(255, 255, 255, 0.5);
+}
+
+/* Caption button */
+.bw-img-caption-btn {
+	position: absolute;
+	bottom: 10px;
+	left: 60px;
+	padding: 4px 10px;
+	border-radius: 4px;
+	background: rgba(0, 0, 0, 0.6);
+	backdrop-filter: blur(4px);
+	color: #fff;
+	border: none;
+	font-size: 11px;
+	font-weight: 600;
+	cursor: pointer;
+	opacity: 0;
+	transform: scale(0.8);
+	transition: opacity 0.15s ease, transform 0.15s ease, background 0.15s ease;
+	z-index: 5;
+}
+
+.bw-img-controls:hover .bw-img-caption-btn {
+	opacity: 1;
+	transform: scale(1);
+}
+
+.bw-img-caption-btn:hover {
+	background: rgba(33, 113, 177, 0.85);
+}
+
+/* Figcaption */
+.bw-figcaption {
+	text-align: center;
+	font-size: 0.875rem;
+	color: #999;
+	padding: 8px 0 0;
+	outline: none;
+}
+
+.bw-figcaption:empty::before {
+	content: attr(data-placeholder);
+	color: #ccc;
+	pointer-events: none;
+}
+
+.bw-content img {
+	max-width: 100%;
+	height: auto;
+	border-radius: 4px;
+	display: block;
+}
+
+/* Video embeds */
+.bw-video-figure {
+	margin: 2em 0;
+	padding: 0;
+}
+
+.bw-video-wrap {
+	position: relative;
+	padding-bottom: 56.25%; /* 16:9 */
+	height: 0;
+	overflow: hidden;
+	border-radius: 6px;
+}
+
+.bw-video-wrap iframe {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	border: none;
+}
+
+/* ===== Floating formatting toolbar ===== */
+.bw-toolbar {
+	position: absolute;
+	z-index: 200;
+	background: #1e1e1e;
+	border-radius: 8px;
+	padding: 4px;
+	display: flex;
+	align-items: center;
+	gap: 2px;
+	box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+	animation: bw-fade-in 0.12s ease;
+}
+
+.bw-toolbar[hidden] {
+	display: none;
+}
+
+@keyframes bw-fade-in {
+
+	from {
+		opacity: 0;
+		transform: translateY(4px);
+	}
+
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+.bw-tool {
+	width: 34px;
+	height: 34px;
+	border: none;
+	border-radius: 6px;
+	background: transparent;
+	color: #ccc;
+	font-size: 15px;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	transition: all 0.1s ease;
+}
+
+.bw-tool .dashicons {
+	font-size: 18px;
+	width: 18px;
+	height: 18px;
+	line-height: 18px;
+}
+
+.bw-tool:hover {
+	background: #333;
+	color: #fff;
+}
+
+.bw-tool-active {
+	background: #444;
+	color: #fff;
+}
+
+.bw-tool-divider {
+	width: 1px;
+	height: 20px;
+	background: #444;
+	margin: 0 4px;
+}
+
+/* ===== Link popover ===== */
+.bw-link-popover {
+	position: absolute;
+	z-index: 201;
+	background: #fff;
+	border-radius: 8px;
+	padding: 8px;
+	box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	animation: bw-fade-in 0.12s ease;
+}
+
+.bw-link-popover[hidden] {
+	display: none;
+}
+
+.bw-link-input {
+	border: 1px solid #ddd;
+	border-radius: 6px;
+	padding: 6px 10px;
+	font-size: 14px;
+	outline: none;
+	width: 240px;
+	font-family: inherit;
+}
+
+.bw-link-input:focus {
+	border-color: #2171b1;
+}
+
+.bw-link-apply {
+	border: none;
+	background: #2171b1;
+	color: #fff;
+	border-radius: 6px;
+	padding: 6px 12px;
+	font-size: 13px;
+	font-weight: 500;
+	cursor: pointer;
+}
+
+.bw-link-remove {
+	border: none;
+	background: transparent;
+	color: #999;
+	font-size: 18px;
+	cursor: pointer;
+	padding: 4px 8px;
+}
+
+.bw-link-remove:hover {
+	color: #d63638;
+}
+
+/* ===== Image modal ===== */
+.bw-image-overlay {
+	position: fixed;
+	inset: 0;
+	z-index: 300;
+	background: rgba(0, 0, 0, 0.4);
+	backdrop-filter: blur(4px);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	animation: bw-fade-in 0.15s ease;
+}
+
+.bw-image-overlay[hidden] {
+	display: none;
+}
+
+.bw-image-modal {
+	background: #fff;
+	border-radius: 12px;
+	padding: 32px;
+	width: 420px;
+	max-width: 90vw;
+	box-shadow: 0 8px 40px rgba(0, 0, 0, 0.15);
+}
+
+.bw-image-modal h3 {
+	margin: 0 0 20px;
+	font-size: 18px;
+	font-weight: 600;
+	color: #1a1a1a;
+}
+
+.bw-upload-zone {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	height: 120px;
+	border: 2px dashed #ddd;
+	border-radius: 8px;
+	color: #999;
+	font-size: 14px;
+	cursor: pointer;
+	transition: all 0.15s ease;
+	position: relative;
+	overflow: hidden;
+	z-index: 0;
+}
+
+.bw-upload-zone span {
+	position: relative;
+	z-index: 2;
+	transition: color 0.3s ease;
+}
+
+.bw-upload-zone:hover {
+	border-color: #2171b1;
+	color: #2171b1;
+}
+
+/* Water fill animation */
+.bw-upload-zone::before {
+	content: "";
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	height: 0%;
+	background: linear-gradient(180deg, rgba(33, 113, 177, 0.08) 0%, rgba(33, 113, 177, 0.18) 100%);
+	z-index: 1;
+	transition: height 0.4s ease-out;
+	border-radius: 0 0 6px 6px;
+}
+
+/* Wave effect on top of the water */
+.bw-upload-zone::after {
+	content: "";
+	position: absolute;
+	left: -10%;
+	right: -10%;
+	height: 12px;
+	bottom: 0%;
+	z-index: 1;
+	background: transparent;
+	border-radius: 50%;
+	box-shadow: 0 -4px 8px rgba(33, 113, 177, 0.12);
+	transition: bottom 0.4s ease-out;
+	opacity: 0;
+}
+
+.bw-upload-zone.bw-uploading {
+	border-color: #2171b1;
+	border-style: solid;
+	cursor: wait;
+}
+
+.bw-upload-zone.bw-uploading span {
+	color: #2171b1;
+	font-weight: 500;
+}
+
+.bw-upload-zone.bw-uploading::before {
+	animation: bw-water-fill 2.5s ease-in-out infinite;
+}
+
+.bw-upload-zone.bw-uploading::after {
+	opacity: 1;
+	animation: bw-wave-rise 2.5s ease-in-out infinite, bw-wave-wobble 1.2s ease-in-out infinite alternate;
+}
+
+@keyframes bw-water-fill {
+
+	0% {
+		height: 5%;
+	}
+
+	50% {
+		height: 75%;
+	}
+
+	100% {
+		height: 95%;
+	}
+}
+
+@keyframes bw-wave-rise {
+
+	0% {
+		bottom: 5%;
+	}
+
+	50% {
+		bottom: 75%;
+	}
+
+	100% {
+		bottom: 95%;
+	}
+}
+
+@keyframes bw-wave-wobble {
+
+	0% {
+		transform: translateX(-2%) scaleY(1);
+	}
+
+	100% {
+		transform: translateX(2%) scaleY(0.6);
+	}
+}
+
+.bw-upload-preview {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	border-radius: 6px;
+	animation: bw-fade-in 0.2s ease;
+	position: absolute;
+	top: 0;
+	left: 0;
+	display: none;
+}
+
+.bw-upload-has-preview {
+	border: none;
+	padding: 0;
+	overflow: hidden;
+}
+
+.bw-image-divider {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	margin: 16px 0;
+	color: #ccc;
+	font-size: 13px;
+}
+
+.bw-image-divider::before,
+.bw-image-divider::after {
+	content: "";
+	flex: 1;
+	height: 1px;
+	background: #eee;
+}
+
+.bw-image-url-input {
+	width: 100%;
+	border: 1px solid #ddd;
+	border-radius: 8px;
+	padding: 10px 14px;
+	font-size: 14px;
+	outline: none;
+	font-family: inherit;
+	box-sizing: border-box;
+}
+
+.bw-image-url-input:focus {
+	border-color: #2171b1;
+}
+
+.bw-featured-toggle {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-top: 14px;
+	font-size: 14px;
+	color: #555;
+	cursor: pointer;
+}
+
+.bw-featured-toggle input[type="checkbox"] {
+	accent-color: #2171b1;
+	width: 16px;
+	height: 16px;
+	cursor: pointer;
+}
+
+/* ===== Floating "Write" FAB (shown on other pages) ===== */
+.bw-write-fab {
+	position: fixed;
+	bottom: 24px;
+	right: 24px;
+	z-index: 9999;
+	width: 52px;
+	height: 52px;
+	border-radius: 50%;
+	background: #2171b1;
+	color: #fff;
+	font-size: 22px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	text-decoration: none;
+	box-shadow: 0 4px 16px rgba(26, 137, 23, 0.35);
+	transition: all 0.2s ease;
+}
+
+.bw-write-fab:hover {
+	transform: scale(1.08);
+	box-shadow: 0 6px 24px rgba(26, 137, 23, 0.45);
+	color: #fff;
+}
+
+/* Edit FAB on single posts */
+.bw-edit-fab {
+	position: fixed;
+	bottom: 88px;
+	right: 24px;
+	z-index: 9999;
+	background: #1e1e1e;
+	color: #fff;
+	font-size: 14px;
+	font-weight: 500;
+	padding: 10px 18px;
+	border-radius: 24px;
+	text-decoration: none;
+	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+	transition: all 0.15s ease;
+}
+
+.bw-edit-fab:hover {
+	background: #333;
+	color: #fff;
+}
+
+/* ===== Responsive ===== */
+@media (max-width: 768px) {
+
+	.bw-title {
+		font-size: 1.75rem;
+	}
+
+	.bw-content {
+		font-size: 1rem;
+		line-height: 1.8;
+	}
+
+	.bw-topbar {
+		padding: 0 16px;
+	}
+
+	.bw-editor {
+		padding: 0 16px;
+	}
+
+	.bw-btn-draft {
+		display: none;
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -23,37 +23,6 @@
 	padding: 0 24px;
 }
 
-body.admin-bar .bw-topbar {
-	top: 32px;
-	transition: top 0.4s ease;
-}
-
-body.admin-bar #wpadminbar {
-	transition: transform 0.4s ease;
-}
-
-body.admin-bar.bw-focused #wpadminbar {
-	transform: translateY(-100%);
-}
-
-body.admin-bar.bw-focused .bw-topbar {
-	top: 0;
-}
-
-body.admin-bar.bw-focused .bw-main {
-	padding-top: 96px;
-}
-
-@media screen and (max-width: 782px) {
-
-	body.admin-bar .bw-topbar {
-		top: 46px;
-	}
-
-	body.admin-bar.bw-focused .bw-topbar {
-		top: 0;
-	}
-}
 
 /* Help toggle */
 .bw-help-toggle {
@@ -210,9 +179,6 @@ body.admin-bar.bw-focused .bw-main {
 	justify-content: center;
 }
 
-body.admin-bar .bw-main {
-	padding-top: 128px;
-}
 
 .bw-editor {
 	width: 100%;

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -97,6 +97,10 @@ function convertToBlocks( html ) {
 			blocks.push(
 				`<!-- wp:quote -->\n<blockquote class="wp-block-quote">${ quoteInner }</blockquote>\n<!-- /wp:quote -->`
 			);
+		} else if ( tag === 'hr' ) {
+			blocks.push(
+				'<!-- wp:separator -->\n<hr class="wp-block-separator has-alpha-channel-opacity"/>\n<!-- /wp:separator -->'
+			);
 		} else {
 			// Fallback: wrap in paragraph.
 			blocks.push( `<!-- wp:paragraph -->\n<p>${ inner }</p>\n<!-- /wp:paragraph -->` );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1,0 +1,1167 @@
+/**
+ * Write — WordPress.com — Interactivity API Store
+ *
+ * A distraction-free front-end writing experience.
+ * Creates WordPress posts with proper block markup via the REST API.
+ */
+
+/* eslint-disable @wordpress/no-global-get-selection -- Write serves a full page, not an iframe or shadow DOM. */
+
+// eslint-disable-next-line import/no-unresolved -- Provided by WordPress at runtime via wp_register_script_module.
+import { store, getElement, getContext } from '@wordpress/interactivity';
+
+// Save/restore the selection so we can insert images after the modal closes.
+let savedRange = null;
+
+/**
+ * Save the current text selection so it can be restored after a modal closes.
+ */
+function saveSelection() {
+	const sel = window.getSelection();
+	if ( sel.rangeCount > 0 ) {
+		savedRange = sel.getRangeAt( 0 ).cloneRange();
+	}
+}
+
+/**
+ * Restore a previously saved text selection.
+ */
+function restoreSelection() {
+	if ( ! savedRange ) return;
+	const sel = window.getSelection();
+	sel.removeAllRanges();
+	sel.addRange( savedRange );
+}
+
+/**
+ * Convert contentEditable HTML into WordPress block markup.
+ *
+ * @param {string} html - The innerHTML from the contenteditable area.
+ * @return {string} Serialized Gutenberg block markup.
+ */
+function convertToBlocks( html ) {
+	const tmp = document.createElement( 'div' );
+	tmp.innerHTML = html;
+
+	const blocks = [];
+
+	for ( const node of tmp.childNodes ) {
+		if ( node.nodeType === Node.TEXT_NODE ) {
+			const text = node.textContent.trim();
+			if ( text ) {
+				blocks.push( `<!-- wp:paragraph -->\n<p>${ text }</p>\n<!-- /wp:paragraph -->` );
+			}
+			continue;
+		}
+
+		if ( node.nodeType !== Node.ELEMENT_NODE ) continue;
+
+		const tag = node.tagName.toLowerCase();
+		const inner = node.innerHTML.trim();
+
+		if ( ! inner && ! [ 'figure', 'img', 'hr' ].includes( tag ) ) continue;
+
+		if ( tag === 'p' || tag === 'div' ) {
+			blocks.push( `<!-- wp:paragraph -->\n<p>${ inner }</p>\n<!-- /wp:paragraph -->` );
+		} else if ( /^h[1-6]$/.test( tag ) ) {
+			const level = parseInt( tag.charAt( 1 ), 10 );
+			blocks.push(
+				`<!-- wp:heading {"level":${ level }} -->\n<${ tag } class="wp-block-heading">${ inner }</${ tag }>\n<!-- /wp:heading -->`
+			);
+		} else if ( tag === 'figure' && node.querySelector( 'iframe' ) ) {
+			const iframe = node.querySelector( 'iframe' );
+			const src = iframe.getAttribute( 'src' ) || '';
+			// Convert embed URL back to watch URL for wp:embed.
+			let originalUrl = src;
+			let provider = 'youtube';
+			const ytMatch = src.match( /youtube\.com\/embed\/([a-zA-Z0-9_-]+)/ );
+			if ( ytMatch ) originalUrl = 'https://www.youtube.com/watch?v=' + ytMatch[ 1 ];
+			const vimeoMatch = src.match( /player\.vimeo\.com\/video\/(\d+)/ );
+			if ( vimeoMatch ) {
+				originalUrl = 'https://vimeo.com/' + vimeoMatch[ 1 ];
+				provider = 'vimeo';
+			}
+			blocks.push(
+				`<!-- wp:embed {"url":"${ originalUrl }","type":"video","providerNameSlug":"${ provider }","responsive":true} -->\n<figure class="wp-block-embed is-type-video is-provider-${ provider } wp-block-embed-${ provider }"><div class="wp-block-embed__wrapper">\n${ originalUrl }\n</div></figure>\n<!-- /wp:embed -->`
+			);
+		} else if ( tag === 'figure' && node.querySelector( 'img' ) ) {
+			const img = node.querySelector( 'img' );
+			const src = img.getAttribute( 'src' ) || '';
+			const alt = img.getAttribute( 'alt' ) || '';
+			blocks.push(
+				`<!-- wp:image -->\n<figure class="wp-block-image"><img src="${ src }" alt="${ alt }"/></figure>\n<!-- /wp:image -->`
+			);
+		} else if ( tag === 'blockquote' ) {
+			// inner may already contain <p> tags from contentEditable.
+			const quoteInner = inner.startsWith( '<p' ) ? inner : `<p>${ inner }</p>`;
+			blocks.push(
+				`<!-- wp:quote -->\n<blockquote class="wp-block-quote">${ quoteInner }</blockquote>\n<!-- /wp:quote -->`
+			);
+		} else {
+			// Fallback: wrap in paragraph.
+			blocks.push( `<!-- wp:paragraph -->\n<p>${ inner }</p>\n<!-- /wp:paragraph -->` );
+		}
+	}
+
+	return blocks.join( '\n\n' );
+}
+
+/**
+ * Position the toolbar near the current text selection.
+ */
+function positionToolbar() {
+	const sel = window.getSelection();
+	if ( ! sel.rangeCount ) return;
+
+	const toolbar = document.querySelector( '.bw-toolbar' );
+	if ( ! toolbar ) return;
+
+	const range = sel.getRangeAt( 0 );
+	const rect = range.getBoundingClientRect();
+	const toolbarWidth = toolbar.offsetWidth;
+	let left = rect.left + rect.width / 2 - toolbarWidth / 2;
+	left = Math.max( 8, Math.min( left, window.innerWidth - toolbarWidth - 8 ) );
+	const top = rect.top - 52 + window.scrollY;
+
+	toolbar.style.position = 'absolute';
+	toolbar.style.left = left + 'px';
+	toolbar.style.top = top + 'px';
+}
+
+/**
+ * Position the slash command menu below the current cursor.
+ */
+function positionSlashMenu() {
+	const sel = window.getSelection();
+	if ( ! sel.rangeCount ) return;
+
+	const menu = document.querySelector( '.bw-slash-menu' );
+	if ( ! menu ) return;
+
+	const range = sel.getRangeAt( 0 );
+	const rect = range.getBoundingClientRect();
+	const menuWidth = menu.offsetWidth;
+	let left = rect.left;
+	left = Math.max( 8, Math.min( left, window.innerWidth - menuWidth - 8 ) );
+	const top = rect.bottom + 8 + window.scrollY;
+
+	menu.style.position = 'absolute';
+	menu.style.left = left + 'px';
+	menu.style.top = top + 'px';
+}
+
+/**
+ * Remove the slash text from the current line before inserting a block.
+ */
+function clearSlashText() {
+	const sel = window.getSelection();
+	if ( ! sel.rangeCount ) return;
+
+	const node = sel.anchorNode;
+	if ( node && node.nodeType === Node.TEXT_NODE && node.textContent.trim().startsWith( '/' ) ) {
+		node.textContent = '';
+	}
+}
+
+/**
+ * Convert a YouTube/Vimeo URL to an embeddable URL.
+ *
+ * @param {string} url - The video URL to convert.
+ * @return {string|null} The embeddable URL, or null if not recognized.
+ */
+function getEmbedUrl( url ) {
+	// YouTube
+	let match = url.match(
+		/(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([a-zA-Z0-9_-]{11})/
+	);
+	if ( match ) return 'https://www.youtube.com/embed/' + match[ 1 ];
+
+	// Vimeo
+	match = url.match( /vimeo\.com\/(\d+)/ );
+	if ( match ) return 'https://player.vimeo.com/video/' + match[ 1 ];
+
+	return null;
+}
+
+/**
+ * Add delete buttons to image/video figures in the content area.
+ */
+function addDeleteButtons() {
+	const content = document.querySelector( '.bw-content' );
+	if ( ! content ) return;
+
+	content.querySelectorAll( 'figure, .bw-image-figure, .bw-video-figure' ).forEach( fig => {
+		if ( fig.querySelector( '.bw-img-delete' ) ) return;
+
+		// Wrap img in a positioning container so buttons stay anchored to the image.
+		const img = fig.querySelector( 'img' );
+		if ( img && ! img.parentElement.classList.contains( 'bw-img-controls' ) ) {
+			const wrapper = document.createElement( 'div' );
+			wrapper.className = 'bw-img-controls';
+			wrapper.contentEditable = 'false';
+			img.before( wrapper );
+			wrapper.appendChild( img );
+		}
+		const controls = fig.querySelector( '.bw-img-controls' ) || fig;
+
+		// Delete button.
+		const btn = document.createElement( 'button' );
+		btn.className = 'bw-img-delete';
+		btn.innerHTML = '&times;';
+		btn.contentEditable = 'false';
+		btn.addEventListener( 'click', e => {
+			e.preventDefault();
+			e.stopPropagation();
+			fig.style.opacity = '0';
+			fig.style.transform = 'scale(0.95)';
+			fig.style.transition = 'opacity 0.2s ease, transform 0.2s ease';
+			setTimeout( () => fig.remove(), 200 );
+		} );
+		controls.appendChild( btn );
+
+		// Alt text button (only for images, not videos).
+		const imgEl = controls.querySelector( 'img' );
+		if ( ! imgEl ) return;
+
+		const altBtn = document.createElement( 'button' );
+		altBtn.className = 'bw-img-alt';
+		altBtn.textContent = 'ALT';
+		altBtn.contentEditable = 'false';
+		altBtn.addEventListener( 'click', e => {
+			e.preventDefault();
+			e.stopPropagation();
+
+			const existing = controls.querySelector( '.bw-img-alt-input' );
+			if ( existing ) {
+				existing.remove();
+				return;
+			}
+
+			const input = document.createElement( 'input' );
+			input.type = 'text';
+			input.className = 'bw-img-alt-input';
+			input.placeholder = 'Describe this image...';
+			input.value = imgEl.alt || '';
+			input.contentEditable = 'false';
+			input.addEventListener( 'click', ev => ev.stopPropagation() );
+			input.addEventListener( 'keydown', ev => {
+				ev.stopPropagation();
+				if ( ev.key === 'Enter' ) {
+					imgEl.alt = input.value;
+					input.remove();
+				}
+				if ( ev.key === 'Escape' ) {
+					input.remove();
+				}
+			} );
+			input.addEventListener( 'blur', () => {
+				imgEl.alt = input.value;
+				setTimeout( () => input.remove(), 150 );
+			} );
+			controls.appendChild( input );
+			input.focus();
+		} );
+		controls.appendChild( altBtn );
+
+		// Caption button.
+		const capBtn = document.createElement( 'button' );
+		capBtn.className = 'bw-img-caption-btn';
+		capBtn.textContent = 'Caption';
+		capBtn.contentEditable = 'false';
+		capBtn.addEventListener( 'click', e => {
+			e.preventDefault();
+			e.stopPropagation();
+
+			let figcaption = fig.querySelector( 'figcaption' );
+			if ( figcaption ) {
+				figcaption.focus();
+				return;
+			}
+
+			figcaption = document.createElement( 'figcaption' );
+			figcaption.className = 'bw-figcaption';
+			figcaption.contentEditable = 'true';
+			figcaption.setAttribute( 'data-placeholder', 'Write a caption...' );
+			figcaption.addEventListener( 'click', ev => ev.stopPropagation() );
+			fig.appendChild( figcaption );
+
+			// Listen on the figure for keydown so we catch it before the content area.
+			fig.addEventListener( 'keydown', ev => {
+				if (
+					ev.key === 'Enter' &&
+					fig.querySelector( 'figcaption' ) &&
+					fig.querySelector( 'figcaption' ).contains( document.getSelection().anchorNode )
+				) {
+					ev.preventDefault();
+					ev.stopImmediatePropagation();
+					let next = fig.nextElementSibling;
+					if ( ! next || next.tagName === 'FIGURE' ) {
+						next = document.createElement( 'p' );
+						next.innerHTML = '<br>';
+						fig.after( next );
+					}
+					const range = document.createRange();
+					range.setStart( next, 0 );
+					range.collapse( true );
+					const sel = window.getSelection();
+					sel.removeAllRanges();
+					sel.addRange( range );
+				}
+			} );
+			figcaption.focus();
+		} );
+		controls.appendChild( capBtn );
+	} );
+}
+
+// Tell the browser to use <p> tags for new paragraphs in contentEditable.
+document.execCommand( 'defaultParagraphSeparator', false, 'p' );
+
+// Seed the content area with an empty <p> so the cursor starts inside a paragraph.
+// This ensures Enter creates proper <p> tags from the very first line.
+const contentReady2 = setInterval( () => {
+	const contentEl = document.querySelector( '.bw-content' );
+	if ( ! contentEl ) return;
+	clearInterval( contentReady2 );
+
+	if ( ! contentEl.innerHTML.trim() ) {
+		contentEl.innerHTML = '<p><br></p>';
+	}
+}, 200 );
+
+// Watch for new figures being added.
+if ( typeof MutationObserver !== 'undefined' ) {
+	const contentReady = setInterval( () => {
+		const content = document.querySelector( '.bw-content' );
+		if ( ! content ) return;
+		clearInterval( contentReady );
+		addDeleteButtons();
+		new MutationObserver( addDeleteButtons ).observe( content, { childList: true, subtree: true } );
+	}, 200 );
+}
+
+/**
+ * Reset the image upload zone to its default state.
+ */
+function resetUploadZone() {
+	const zone = document.getElementById( 'bw-upload-zone' );
+	if ( ! zone ) return;
+	// Remove any existing preview.
+	const old = zone.querySelector( '.bw-upload-preview' );
+	if ( old ) old.remove();
+	// Reset classes.
+	zone.classList.remove( 'bw-upload-has-preview', 'bw-uploading' );
+	// Show label, hide saving.
+	const label = zone.querySelector( '.bw-upload-label' );
+	if ( label ) label.style.display = '';
+	const saving = zone.querySelector( '.bw-upload-saving' );
+	if ( saving ) saving.style.display = 'none';
+	// Clear file input.
+	const input = zone.querySelector( 'input[type="file"]' );
+	if ( input ) input.value = '';
+}
+
+/**
+ * Show a preview image in the upload zone.
+ *
+ * @param {string} src - The image source URL to preview.
+ */
+function showUploadPreview( src ) {
+	const zone = document.getElementById( 'bw-upload-zone' );
+	if ( ! zone ) return;
+	// Remove old preview if any.
+	const old = zone.querySelector( '.bw-upload-preview' );
+	if ( old ) old.remove();
+	// Hide label.
+	const label = zone.querySelector( '.bw-upload-label' );
+	if ( label ) label.style.display = 'none';
+	const saving = zone.querySelector( '.bw-upload-saving' );
+	if ( saving ) saving.style.display = 'none';
+	// Create fresh img.
+	const img = document.createElement( 'img' );
+	img.className = 'bw-upload-preview';
+	img.src = src;
+	img.alt = 'Preview';
+	img.style.display = 'block';
+	zone.classList.add( 'bw-upload-has-preview' );
+	zone.classList.remove( 'bw-uploading' );
+	zone.insertBefore( img, zone.firstChild );
+}
+
+/**
+ * Insert a new empty block (h2, blockquote, etc.) replacing the slash command line.
+ *
+ * @param {string} tag - The HTML tag name for the new block (e.g. 'h2', 'blockquote').
+ */
+function insertNewBlock( tag ) {
+	const content = document.querySelector( '.bw-content' );
+	if ( ! content ) return;
+
+	const sel = window.getSelection();
+	const newEl = document.createElement( tag );
+	newEl.innerHTML = '<br>';
+
+	// Find the paragraph containing the slash command by scanning direct children.
+	let slashBlock = null;
+	for ( const child of content.children ) {
+		if ( /^(P|DIV)$/i.test( child.tagName ) && /^\/\S*$/.test( child.textContent.trim() ) ) {
+			slashBlock = child;
+			break;
+		}
+	}
+
+	if ( slashBlock ) {
+		slashBlock.after( newEl );
+		slashBlock.remove();
+	} else {
+		content.appendChild( newEl );
+	}
+
+	// Place cursor inside the new element.
+	const range = document.createRange();
+	range.setStart( newEl, 0 );
+	range.collapse( true );
+	sel.removeAllRanges();
+	sel.addRange( range );
+
+	state.showSlashMenu = false;
+}
+
+const { state } = store( 'wpcom-write', {
+	state: {
+		formatBold: false,
+		formatItalic: false,
+		formatHeading: false,
+		formatQuote: false,
+		imageUrl: '',
+	},
+
+	actions: {
+		updateTitle() {
+			const el = getElement();
+			state.title = el.ref.value;
+			// Auto-resize textarea height for browsers without field-sizing support.
+			el.ref.style.height = 'auto';
+			el.ref.style.height = el.ref.scrollHeight + 'px';
+		},
+
+		handleTitleKeyDown( event ) {
+			if ( event.key === 'Enter' ) {
+				event.preventDefault();
+				const content = document.querySelector( '.bw-content' );
+				if ( content ) {
+					content.focus();
+					document.body.classList.add( 'bw-focused' );
+					// Ensure the cursor starts inside a paragraph.
+					if ( ! content.querySelector( 'p' ) ) {
+						document.execCommand( 'formatBlock', false, 'p' );
+					}
+				}
+			}
+		},
+
+		handleBack( event ) {
+			// Don't warn if the post has been saved/published, or if we're editing an existing post with no changes.
+			if ( state.isPublished || state.hasSaved ) {
+				return;
+			}
+
+			const content = document.querySelector( '.bw-content' );
+			const hasContent = state.title.trim() || ( content && content.textContent.trim() );
+
+			// If editing an existing post, don't warn (content was already saved before).
+			if ( state.editPostId > 0 ) {
+				return;
+			}
+
+			if ( hasContent ) {
+				event.preventDefault();
+				state.showLeaveConfirm = true;
+			}
+		},
+
+		cancelLeave() {
+			state.showLeaveConfirm = false;
+		},
+
+		enterFocus() {
+			document.body.classList.add( 'bw-focused' );
+		},
+
+		checkFormatting() {
+			// Check for slash commands first.
+			const { actions } = store( 'wpcom-write' );
+			actions.checkSlashCommand();
+
+			const sel = window.getSelection();
+			const text = sel.toString().trim();
+
+			if ( ! text ) {
+				state.showToolbar = false;
+				state.showLinkInput = false;
+				return;
+			}
+
+			state.formatBold = document.queryCommandState( 'bold' );
+			state.formatItalic = document.queryCommandState( 'italic' );
+
+			// Check if inside a heading or blockquote.
+			let node = sel.anchorNode;
+			state.formatHeading = false;
+			state.formatQuote = false;
+			while ( node && node !== document.body ) {
+				if ( node.nodeType === Node.ELEMENT_NODE ) {
+					if ( /^H[1-6]$/.test( node.tagName ) ) state.formatHeading = true;
+					if ( node.tagName === 'BLOCKQUOTE' ) state.formatQuote = true;
+				}
+				node = node.parentNode;
+			}
+
+			state.showToolbar = true;
+			requestAnimationFrame( positionToolbar );
+		},
+
+		handleKeyDown( event ) {
+			// Slash menu keyboard navigation.
+			if ( state.showSlashMenu ) {
+				if ( event.key === 'Escape' ) {
+					event.preventDefault();
+					state.showSlashMenu = false;
+					return;
+				}
+
+				const visible = [ ...document.querySelectorAll( '.bw-slash-item' ) ].filter(
+					el => el.style.display !== 'none'
+				);
+
+				if ( ! visible.length ) return;
+
+				const active = document.querySelector( '.bw-slash-item-active' );
+				let idx = active ? visible.indexOf( active ) : -1;
+
+				if ( event.key === 'ArrowDown' || event.key === 'Tab' ) {
+					event.preventDefault();
+					if ( active ) active.classList.remove( 'bw-slash-item-active' );
+					idx = ( idx + 1 ) % visible.length;
+					visible[ idx ].classList.add( 'bw-slash-item-active' );
+					return;
+				}
+
+				if ( event.key === 'ArrowUp' ) {
+					event.preventDefault();
+					if ( active ) active.classList.remove( 'bw-slash-item-active' );
+					idx = idx <= 0 ? visible.length - 1 : idx - 1;
+					visible[ idx ].classList.add( 'bw-slash-item-active' );
+					return;
+				}
+
+				if ( event.key === 'Enter' ) {
+					event.preventDefault();
+					const target = active || visible[ 0 ];
+					if ( target ) {
+						// Map menu items to actions by their label text.
+						const label = target.querySelector( 'strong' )?.textContent?.toLowerCase();
+						const { actions: a } = store( 'wpcom-write' );
+						const actionMap = {
+							heading: a.insertHeading,
+							image: a.insertImage,
+							video: a.insertVideo,
+							quote: a.insertQuote,
+							divider: a.insertDivider,
+						};
+						if ( actionMap[ label ] ) {
+							actionMap[ label ]();
+						}
+					}
+					return;
+				}
+			}
+
+			// Enter key: break out of blockquotes/headings and ensure paragraphs.
+			if ( event.key === 'Enter' && ! event.shiftKey ) {
+				const sel = window.getSelection();
+				if ( sel.rangeCount ) {
+					let node = sel.anchorNode;
+					// Walk up to find if we're inside a blockquote or heading.
+					let block = null;
+					while ( node && ! node.classList?.contains( 'bw-content' ) ) {
+						if (
+							node.nodeType === Node.ELEMENT_NODE &&
+							( node.tagName === 'BLOCKQUOTE' || /^H[1-6]$/.test( node.tagName ) )
+						) {
+							block = node;
+							break;
+						}
+						node = node.parentNode;
+					}
+
+					// If at the end of a blockquote or heading, break out to a paragraph.
+					if ( block ) {
+						const range = sel.getRangeAt( 0 );
+						const textAfterCursor = range.cloneRange();
+						textAfterCursor.selectNodeContents( block );
+						textAfterCursor.setStart( range.endContainer, range.endOffset );
+						const remaining = textAfterCursor.toString().trim();
+
+						if ( ! remaining ) {
+							event.preventDefault();
+							const p = document.createElement( 'p' );
+							p.innerHTML = '<br>';
+							block.after( p );
+							const newRange = document.createRange();
+							newRange.setStart( p, 0 );
+							newRange.collapse( true );
+							sel.removeAllRanges();
+							sel.addRange( newRange );
+						}
+					}
+				}
+			}
+		},
+
+		checkSlashCommand() {
+			const sel = window.getSelection();
+			if ( ! sel.rangeCount ) {
+				state.showSlashMenu = false;
+				return;
+			}
+
+			const node = sel.anchorNode;
+			if ( ! node || node.nodeType !== Node.TEXT_NODE ) {
+				state.showSlashMenu = false;
+				return;
+			}
+
+			const text = node.textContent;
+			// Show menu when the line starts with "/" and optionally a filter after it.
+			if ( /^\/\S*$/.test( text.trim() ) ) {
+				state.slashFilter = text.trim().slice( 1 ).toLowerCase();
+				state.showSlashMenu = true;
+				requestAnimationFrame( positionSlashMenu );
+
+				// Filter menu items and reset active highlight.
+				const items = document.querySelectorAll( '.bw-slash-item' );
+				let firstVisible = null;
+				items.forEach( item => {
+					item.classList.remove( 'bw-slash-item-active' );
+					const label = item.querySelector( 'strong' ).textContent.toLowerCase();
+					const show = label.includes( state.slashFilter );
+					item.style.display = show ? '' : 'none';
+					if ( show && ! firstVisible ) firstVisible = item;
+				} );
+				// Auto-highlight the first visible item.
+				if ( firstVisible ) firstVisible.classList.add( 'bw-slash-item-active' );
+			} else {
+				state.showSlashMenu = false;
+			}
+		},
+
+		preventToolbarBlur( event ) {
+			// Prevent the toolbar from stealing focus from the content area.
+			event.preventDefault();
+		},
+
+		formatBold() {
+			document.execCommand( 'bold' );
+			state.formatBold = document.queryCommandState( 'bold' );
+		},
+
+		formatItalic() {
+			document.execCommand( 'italic' );
+			state.formatItalic = document.queryCommandState( 'italic' );
+		},
+
+		formatHeading() {
+			if ( state.formatHeading ) {
+				document.execCommand( 'formatBlock', false, 'p' );
+				state.formatHeading = false;
+			} else {
+				document.execCommand( 'formatBlock', false, 'h2' );
+				state.formatHeading = true;
+				state.formatQuote = false;
+			}
+		},
+
+		formatQuote() {
+			if ( state.formatQuote ) {
+				document.execCommand( 'formatBlock', false, 'p' );
+				state.formatQuote = false;
+			} else {
+				document.execCommand( 'formatBlock', false, 'blockquote' );
+				state.formatQuote = true;
+				state.formatHeading = false;
+			}
+		},
+
+		toggleLinkInput() {
+			if ( state.showLinkInput ) {
+				state.showLinkInput = false;
+				return;
+			}
+
+			// Save selection before the toolbar steals focus.
+			saveSelection();
+
+			// Pre-fill if cursor is inside a link.
+			const sel = window.getSelection();
+			let node = sel.anchorNode;
+			state.linkUrl = '';
+			while ( node && node !== document.body ) {
+				if ( node.nodeType === Node.ELEMENT_NODE && node.tagName === 'A' ) {
+					state.linkUrl = node.href;
+					break;
+				}
+				node = node.parentNode;
+			}
+
+			state.showLinkInput = true;
+
+			// Position the link popover below the toolbar.
+			requestAnimationFrame( () => {
+				const toolbar = document.querySelector( '.bw-toolbar' );
+				const popover = document.querySelector( '.bw-link-popover' );
+				if ( ! toolbar || ! popover ) return;
+
+				const rect = toolbar.getBoundingClientRect();
+				popover.style.position = 'absolute';
+				popover.style.left = toolbar.style.left;
+				popover.style.top = rect.bottom + 8 + window.scrollY + 'px';
+
+				// Focus the input.
+				const input = popover.querySelector( '.bw-link-input' );
+				if ( input ) input.focus();
+			} );
+		},
+
+		updateLinkUrl() {
+			const el = getElement();
+			state.linkUrl = el.ref.value;
+		},
+
+		handleLinkKeyDown( event ) {
+			if ( event.key === 'Enter' ) {
+				event.preventDefault();
+				restoreSelection();
+				if ( state.linkUrl ) {
+					document.execCommand( 'createLink', false, state.linkUrl );
+				}
+				state.showLinkInput = false;
+				state.showToolbar = false;
+			}
+			if ( event.key === 'Escape' ) {
+				event.preventDefault();
+				state.showLinkInput = false;
+				state.showToolbar = false;
+			}
+		},
+
+		applyLink() {
+			restoreSelection();
+			if ( state.linkUrl ) {
+				document.execCommand( 'createLink', false, state.linkUrl );
+			}
+			state.showLinkInput = false;
+			state.showToolbar = false;
+		},
+
+		removeLink() {
+			restoreSelection();
+			document.execCommand( 'unlink' );
+			state.showLinkInput = false;
+			state.showToolbar = false;
+		},
+
+		toggleFeaturedImage() {
+			state.setAsFeatured = ! state.setAsFeatured;
+		},
+
+		updateImageAlt() {
+			const el = getElement();
+			state.imageAlt = el.ref.value;
+		},
+
+		openImageModal() {
+			saveSelection();
+			state.showToolbar = false;
+			state.imageUrl = '';
+			state.imageAlt = '';
+			state.setAsFeatured = false;
+			state.uploadedMediaId = 0;
+			resetUploadZone();
+			state.showImageModal = true;
+		},
+
+		closeImageModal() {
+			state.showImageModal = false;
+			resetUploadZone();
+		},
+
+		stopPropagation( event ) {
+			event.stopPropagation();
+		},
+
+		updateImageUrl() {
+			const el = getElement();
+			state.imageUrl = el.ref.value;
+		},
+
+		insertImageFromUrl() {
+			if ( ! state.imageUrl ) return;
+
+			// Handle featured image from uploaded media.
+			if ( state.setAsFeatured && state.uploadedMediaId ) {
+				state.featuredMediaId = state.uploadedMediaId;
+			}
+
+			restoreSelection();
+			const figure = document.createElement( 'figure' );
+			figure.className = 'bw-image-figure';
+			const img = document.createElement( 'img' );
+			img.src = state.imageUrl;
+			img.alt = state.imageAlt || '';
+			figure.appendChild( img );
+
+			const content = document.querySelector( '.bw-content' );
+
+			// Find the parent block (direct child of .bw-content) to insert after.
+			const sel = window.getSelection();
+			let insertAfter = null;
+			if ( sel.rangeCount ) {
+				let node = sel.anchorNode;
+				while ( node && node !== content && node.parentNode !== content ) {
+					node = node.parentNode;
+				}
+				if ( node && node.parentNode === content ) {
+					insertAfter = node;
+				}
+			}
+
+			const p = document.createElement( 'p' );
+			p.innerHTML = '<br>';
+
+			if ( insertAfter ) {
+				insertAfter.after( figure );
+				figure.after( p );
+			} else {
+				content.appendChild( figure );
+				content.appendChild( p );
+			}
+
+			// Move cursor to the new paragraph.
+			const range = document.createRange();
+			range.setStart( p, 0 );
+			range.collapse( true );
+			sel.removeAllRanges();
+			sel.addRange( range );
+
+			state.showImageModal = false;
+			resetUploadZone();
+		},
+
+		async uploadImage() {
+			const el = getElement();
+			const file = el.ref.files[ 0 ];
+			if ( ! file ) return;
+
+			state.isUploading = true;
+			const zone = document.getElementById( 'bw-upload-zone' );
+			if ( zone ) {
+				zone.classList.add( 'bw-uploading' );
+				const label = zone.querySelector( '.bw-upload-label' );
+				if ( label ) label.style.display = 'none';
+				const saving = zone.querySelector( '.bw-upload-saving' );
+				if ( saving ) saving.style.display = '';
+			}
+
+			const formData = new FormData();
+			formData.append( 'file', file );
+
+			try {
+				const media = await window.wp.apiFetch( {
+					path: state.mediaPath,
+					method: 'POST',
+					body: formData,
+				} );
+				state.imageUrl = media.source_url;
+				state.isUploading = false;
+				if ( zone ) zone.classList.remove( 'bw-uploading' );
+
+				// Store the uploaded URL and media ID — wait for "Insert image" click.
+				state.imageUrl = media.source_url;
+				if ( ! state.imageAlt && media.alt_text ) {
+					state.imageAlt = media.alt_text;
+				}
+				if ( state.setAsFeatured ) {
+					state.featuredMediaId = media.id;
+				}
+				state.uploadedMediaId = media.id;
+
+				// Show preview.
+				showUploadPreview( media.source_url );
+			} catch ( err ) {
+				state.isUploading = false;
+				if ( zone ) zone.classList.remove( 'bw-uploading' );
+				state.message = 'Upload failed: ' + err.message;
+				setTimeout( () => {
+					state.message = '';
+				}, 3000 );
+			}
+		},
+
+		insertHeading() {
+			insertNewBlock( 'h2' );
+		},
+
+		insertImage() {
+			clearSlashText();
+			state.showSlashMenu = false;
+			saveSelection();
+			state.showImageModal = true;
+			state.imageUrl = '';
+		},
+
+		insertQuote() {
+			insertNewBlock( 'blockquote' );
+		},
+
+		insertVideo() {
+			clearSlashText();
+			state.showSlashMenu = false;
+			saveSelection();
+			state.showVideoModal = true;
+			state.videoUrl = '';
+		},
+
+		closeVideoModal() {
+			state.showVideoModal = false;
+		},
+
+		updateVideoUrl() {
+			const el = getElement();
+			state.videoUrl = el.ref.value;
+		},
+
+		handleVideoKeyDown( event ) {
+			if ( event.key === 'Enter' ) {
+				event.preventDefault();
+				const { actions } = store( 'wpcom-write' );
+				actions.insertVideoEmbed();
+			}
+		},
+
+		insertVideoEmbed() {
+			if ( ! state.videoUrl ) return;
+
+			const embedUrl = getEmbedUrl( state.videoUrl );
+			if ( ! embedUrl ) {
+				state.message = 'Please paste a valid YouTube or Vimeo URL';
+				setTimeout( () => {
+					state.message = '';
+				}, 3000 );
+				return;
+			}
+
+			restoreSelection();
+
+			const wrapper = document.createElement( 'figure' );
+			wrapper.className = 'bw-video-figure';
+			wrapper.innerHTML = `<div class="bw-video-wrap"><iframe src="${ embedUrl }" frameborder="0" allowfullscreen></iframe></div>`;
+
+			const content = document.querySelector( '.bw-content' );
+			const sel = window.getSelection();
+
+			let insertAfter = null;
+			if ( sel.rangeCount ) {
+				let node = sel.anchorNode;
+				while ( node && node !== content && node.parentNode !== content ) {
+					node = node.parentNode;
+				}
+				if ( node && node.parentNode === content ) {
+					insertAfter = node;
+				}
+			}
+
+			const p = document.createElement( 'p' );
+			p.innerHTML = '<br>';
+
+			if ( insertAfter ) {
+				insertAfter.after( wrapper );
+				wrapper.after( p );
+			} else {
+				content.appendChild( wrapper );
+				content.appendChild( p );
+			}
+
+			const range = document.createRange();
+			range.setStart( p, 0 );
+			range.collapse( true );
+			sel.removeAllRanges();
+			sel.addRange( range );
+
+			state.showVideoModal = false;
+		},
+
+		insertDivider() {
+			clearSlashText();
+			const hr = document.createElement( 'hr' );
+			const p = document.createElement( 'p' );
+			p.innerHTML = '<br>';
+
+			const sel = window.getSelection();
+			if ( sel.rangeCount ) {
+				const range = sel.getRangeAt( 0 );
+				// Find the parent block to insert after.
+				let block = range.startContainer;
+				while (
+					block &&
+					block.parentNode &&
+					! block.parentNode.classList.contains( 'bw-content' )
+				) {
+					block = block.parentNode;
+				}
+				if ( block && block.parentNode ) {
+					block.after( hr );
+					hr.after( p );
+					// Remove empty block left behind.
+					if ( block.textContent.trim() === '' ) {
+						block.remove();
+					}
+					// Move cursor to new paragraph.
+					const newRange = document.createRange();
+					newRange.setStart( p, 0 );
+					newRange.collapse( true );
+					sel.removeAllRanges();
+					sel.addRange( newRange );
+				}
+			}
+			state.showSlashMenu = false;
+		},
+
+		toggleHelp() {
+			state.showHelp = ! state.showHelp;
+			if ( state.showHelp ) {
+				const close = e => {
+					if ( e.target.closest( '.bw-help-popover' ) || e.target.closest( '.bw-help-toggle' ) )
+						return;
+					state.showHelp = false;
+					document.removeEventListener( 'click', close );
+				};
+				setTimeout( () => document.addEventListener( 'click', close ), 0 );
+			}
+		},
+
+		toggleCatPicker( event ) {
+			event.stopPropagation();
+			state.showCatPicker = ! state.showCatPicker;
+
+			if ( state.showCatPicker ) {
+				const close = e => {
+					if ( e.target.closest( '.bw-cat-popover' ) || e.target.closest( '.bw-cat-fab' ) ) return;
+					state.showCatPicker = false;
+					document.removeEventListener( 'click', close );
+				};
+				// Delay so the current click doesn't immediately close it.
+				setTimeout( () => document.addEventListener( 'click', close ), 0 );
+			}
+		},
+
+		toggleCategory() {
+			const ctx = getContext();
+			ctx.catSelected = ! ctx.catSelected;
+			state.categories[ ctx.catIndex ].selected = ctx.catSelected;
+		},
+
+		async publish() {
+			await savePost( 'publish' );
+		},
+
+		async saveDraft() {
+			await savePost( 'draft' );
+		},
+	},
+} );
+
+/**
+ * Save or publish the current post via the REST API.
+ *
+ * @param {string} postStatus - The desired post status ('publish' or 'draft').
+ */
+async function savePost( postStatus ) {
+	if ( ! state.title.trim() ) {
+		state.message = 'Please add a title';
+		setTimeout( () => {
+			state.message = '';
+		}, 2500 );
+		return;
+	}
+
+	const content = document.querySelector( '.bw-content' );
+	if ( ! content || ! content.innerHTML.trim() ) {
+		state.message = 'Please write something';
+		setTimeout( () => {
+			state.message = '';
+		}, 2500 );
+		return;
+	}
+
+	const isEditing = state.editPostId > 0;
+	const isUpdate = isEditing && postStatus === 'publish';
+
+	state.isSaving = true;
+	let savingMessage = 'Saving draft...';
+	if ( isUpdate ) {
+		savingMessage = 'Updating...';
+	} else if ( postStatus === 'publish' ) {
+		savingMessage = 'Publishing...';
+	}
+	state.message = savingMessage;
+
+	const blockMarkup = convertToBlocks( content.innerHTML );
+
+	// Collect selected category IDs.
+	const selectedCats = state.categories.filter( c => c.selected ).map( c => c.id );
+
+	// If editing, PUT to the existing post. If new, POST to create.
+	const path = isEditing ? state.postsPath + '/' + state.editPostId : state.postsPath;
+
+	try {
+		const post = await window.wp.apiFetch( {
+			path,
+			method: 'POST',
+			data: {
+				title: state.title,
+				content: blockMarkup,
+				status: postStatus,
+				categories: selectedCats,
+				featured_media: state.featuredMediaId || 0,
+			},
+		} );
+
+		// Store the post ID so subsequent saves update the same post.
+		if ( ! isEditing ) {
+			state.editPostId = post.id;
+		}
+
+		if ( postStatus === 'publish' ) {
+			state.isPublished = true;
+			state.message = isUpdate ? 'Updated!' : 'Published!';
+			setTimeout( () => {
+				window.location.href = post.link;
+			}, 800 );
+		} else {
+			state.editPostId = post.id;
+			state.hasSaved = true;
+			state.message = 'Draft saved';
+			state.isSaving = false;
+			setTimeout( () => {
+				state.message = '';
+			}, 2500 );
+		}
+	} catch ( err ) {
+		state.message = 'Error: ' + err.message;
+		state.isSaving = false;
+		setTimeout( () => {
+			state.message = '';
+		}, 4000 );
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -455,7 +455,6 @@ const { state } = store( 'wpcom-write', {
 				const content = document.querySelector( '.bw-content' );
 				if ( content ) {
 					content.focus();
-					document.body.classList.add( 'bw-focused' );
 					// Ensure the cursor starts inside a paragraph.
 					if ( ! content.querySelector( 'p' ) ) {
 						document.execCommand( 'formatBlock', false, 'p' );
@@ -486,10 +485,6 @@ const { state } = store( 'wpcom-write', {
 
 		cancelLeave() {
 			state.showLeaveConfirm = false;
-		},
-
-		enterFocus() {
-			document.body.classList.add( 'bw-focused' );
 		},
 
 		checkFormatting() {

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -248,7 +248,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 	</header>
 
 	<!-- Writing area -->
-	<main class="bw-main" data-wp-on--click="actions.enterFocus">
+	<main class="bw-main">
 		<div class="bw-editor">
 			<textarea
 				class="bw-title"
@@ -265,7 +265,6 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 				data-wp-on--mouseup="actions.checkFormatting"
 				data-wp-on--keyup="actions.checkFormatting"
 				data-wp-on--keydown="actions.handleKeyDown"
-				data-wp-on--click="actions.enterFocus"
 				data-placeholder="Tell your story..."
 			><?php echo $edit_content ? wp_kses_post( $edit_content ) : '<p><br></p>'; ?></div>
 		</div>

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -267,7 +267,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 				data-wp-on--keydown="actions.handleKeyDown"
 				data-wp-on--click="actions.enterFocus"
 				data-placeholder="Tell your story..."
-			><?php echo wp_kses_post( $edit_content ); ?></div>
+			><?php echo $edit_content ? wp_kses_post( $edit_content ) : '<p><br></p>'; ?></div>
 		</div>
 	</main>
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -226,7 +226,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 	<header class="bw-topbar">
 		<a href="<?php echo esc_url( admin_url() ); ?>" class="bw-back" title="Back to dashboard" data-wp-on--click="actions.handleBack">&larr;</a>
 		<button class="bw-help-toggle" data-wp-on--click="actions.toggleHelp" title="Shortcuts">?</button>
-		<div class="bw-help-popover" data-wp-bind--hidden="!state.showHelp">
+		<div class="bw-help-popover" hidden data-wp-bind--hidden="!state.showHelp">
 			<div class="bw-help-title">Tips</div>
 			<div class="bw-help-row"><kbd>/</kbd><span>Insert a heading, image, video, quote or divider</span></div>
 			<div class="bw-help-row"><kbd>Select text</kbd><span>Formatting toolbar appears</span></div>
@@ -273,6 +273,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 	<!-- Floating formatting toolbar -->
 	<div
 		class="bw-toolbar"
+		hidden
 		data-wp-bind--hidden="!state.showToolbar"
 		data-wp-on--mousedown="actions.preventToolbarBlur"
 	>
@@ -288,7 +289,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 	</div>
 
 	<!-- Link input popover -->
-	<div class="bw-link-popover" data-wp-bind--hidden="!state.showLinkInput">
+	<div class="bw-link-popover" hidden data-wp-bind--hidden="!state.showLinkInput">
 		<input
 			type="url"
 			class="bw-link-input"
@@ -344,7 +345,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 	</div>
 
 	<!-- Slash command menu -->
-	<div class="bw-slash-menu" data-wp-bind--hidden="!state.showSlashMenu">
+	<div class="bw-slash-menu" hidden data-wp-bind--hidden="!state.showSlashMenu">
 		<div class="bw-slash-item" data-wp-on--click="actions.insertHeading" data-wp-on--mousedown="actions.preventToolbarBlur">
 			<span class="bw-slash-icon">H</span>
 			<div><strong>Heading</strong><span class="bw-slash-desc">Large section heading</span></div>
@@ -386,7 +387,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 	<div class="bw-cat-fab" data-wp-on--click="actions.toggleCatPicker">
 		<span class="bw-cat-fab-icon dashicons dashicons-admin-generic"></span>
 	</div>
-	<div class="bw-cat-popover" data-wp-bind--hidden="!state.showCatPicker">
+	<div class="bw-cat-popover" hidden data-wp-bind--hidden="!state.showCatPicker">
 		<div class="bw-cat-popover-header">Categories</div>
 		<div class="bw-cat-popover-list">
 			<?php

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -138,10 +138,11 @@ add_action(
 function wpcom_write_render_admin_page() {
 	// Check if editing an existing post.
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only GET parameter, gated by capability check via add_submenu_page.
-	$edit_post_id = isset( $_GET['post'] ) ? absint( $_GET['post'] ) : 0;
-	$edit_title   = '';
-	$edit_content = '';
-	$post_status  = 'new';
+	$edit_post_id     = isset( $_GET['post'] ) ? absint( $_GET['post'] ) : 0;
+	$edit_title       = '';
+	$edit_content     = '';
+	$post_status      = 'new';
+	$edit_featured_id = 0;
 
 	if ( $edit_post_id ) {
 		$edit_post = get_post( $edit_post_id );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -192,7 +192,7 @@ function wpcom_write_render_admin_page() {
 			'videoUrl'         => '',
 			'imageAlt'         => '',
 			'setAsFeatured'    => false,
-			'featuredMediaId'  => $edit_featured_id ?? 0,
+			'featuredMediaId'  => $edit_featured_id,
 			'isUploading'      => false,
 			'categories'       => $categories_data,
 			'showCatPicker'    => false,

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -1,0 +1,417 @@
+<?php
+/**
+ * Write — A distraction-free front-end writing experience for WordPress.com.
+ *
+ * Based on Jamie Marsland's Write plugin (https://github.com/jamiemarsland/Write).
+ * Registers a wp-admin page that serves a clean, full-screen writing surface.
+ * Posts are saved as proper Gutenberg block markup via the REST API.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! defined( 'WPCOM_WRITE_VERSION' ) ) {
+	define(
+		'WPCOM_WRITE_VERSION',
+		class_exists( '\Automattic\Jetpack\Jetpack_Mu_Wpcom' )
+			? \Automattic\Jetpack\Jetpack_Mu_Wpcom::PACKAGE_VERSION
+			: '1.0.0-dev'
+	);
+}
+
+/**
+ * Get the URL for a Write feature asset file.
+ *
+ * Uses plugins_url() when loaded via a plugin (production). Falls back to
+ * a computed URL for local development where plugins_url() can't resolve
+ * the monorepo path.
+ *
+ * @param string $file The asset filename (e.g. 'view.js', 'style.css').
+ * @return string The full URL to the asset.
+ */
+function wpcom_write_asset_url( $file ) {
+	$url = plugins_url( $file, __FILE__ );
+
+	// In local dev (Docker), __FILE__ resolves to an absolute monorepo path that
+	// plugins_url() can't map to a web-accessible URL. Detect this and fall back
+	// to the known plugin symlink path.
+	if ( strpos( $url, '/plugins/usr/' ) !== false || strpos( $url, '/plugins/Users/' ) !== false ) {
+		$url = content_url( 'plugins/jetpack-mu-wpcom-plugin/jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/write/' . $file );
+	}
+
+	return $url;
+}
+
+/**
+ * Get the URL to the Write editor.
+ *
+ * @return string The admin URL for the Write page.
+ */
+function wpcom_write_url() {
+	return admin_url( 'admin.php?page=write' );
+}
+
+/**
+ * Register the script module on init.
+ */
+add_action(
+	'init',
+	function () {
+		wp_register_script_module(
+			'wpcom-write/view',
+			wpcom_write_asset_url( 'view.js' ),
+			array( '@wordpress/interactivity' ),
+			WPCOM_WRITE_VERSION
+		);
+	}
+);
+
+/**
+ * Register the Write admin page.
+ *
+ * Uses an empty parent to create a hidden page (no menu entry) — access is
+ * via the admin bar "Write" link. Renders inside wp-admin's normal page
+ * lifecycle so that wp.apiFetch and its middleware are fully configured.
+ */
+add_action(
+	'admin_menu',
+	function () {
+		add_submenu_page(
+			'', // Hidden — no parent menu.
+			'Write',
+			'Write',
+			'publish_posts',
+			'write',
+			'wpcom_write_render_admin_page'
+		);
+	}
+);
+
+/**
+ * Enqueue Write assets only on the Write admin page.
+ */
+add_action(
+	'admin_enqueue_scripts',
+	function () {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only page routing.
+		if ( ! isset( $_GET['page'] ) || 'write' !== $_GET['page'] ) {
+			return;
+		}
+
+		wp_enqueue_script_module( 'wpcom-write/view' );
+		wp_enqueue_style(
+			'wpcom-write',
+			wpcom_write_asset_url( 'style.css' ),
+			array( 'dashicons' ),
+			WPCOM_WRITE_VERSION
+		);
+
+		// Add CSS to hide wp-admin chrome for a full-screen writing experience.
+		// This works with the platform rather than against it — wp-admin's scripts
+		// (including wp-api-fetch middleware) are fully loaded and configured.
+		$hide_chrome_css = '
+			#wpadminbar,
+			#adminmenuwrap,
+			#adminmenuback,
+			#adminmenumain,
+			#wpfooter { display: none !important; }
+			#wpcontent,
+			#wpbody,
+			#wpbody-content { margin-left: 0 !important; padding: 0 !important; }
+			.wrap { margin: 0 !important; padding: 0 !important; max-width: none !important; }
+			html.wp-toolbar { padding-top: 0 !important; }
+		';
+		wp_add_inline_style( 'wpcom-write', $hide_chrome_css );
+	}
+);
+
+/**
+ * Render the Write admin page.
+ *
+ * Called by add_submenu_page as the page callback. Runs inside wp-admin's
+ * normal page lifecycle, so wp.apiFetch is fully configured with the correct
+ * REST root URL and auth middleware.
+ */
+function wpcom_write_render_admin_page() {
+	// Check if editing an existing post.
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only GET parameter, gated by capability check via add_submenu_page.
+	$edit_post_id = isset( $_GET['post'] ) ? absint( $_GET['post'] ) : 0;
+	$edit_title   = '';
+	$edit_content = '';
+	$post_status  = 'new';
+
+	if ( $edit_post_id ) {
+		$edit_post = get_post( $edit_post_id );
+		if ( $edit_post && current_user_can( 'edit_post', $edit_post_id ) ) {
+			$edit_title = $edit_post->post_title;
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Core filter needed to render blocks.
+			$edit_content     = apply_filters( 'the_content', $edit_post->post_content );
+			$post_status      = $edit_post->post_status;
+			$edit_featured_id = (int) get_post_thumbnail_id( $edit_post_id );
+		} else {
+			$edit_post_id = 0;
+		}
+	}
+
+	// Build categories list for the UI.
+	$all_cats        = get_categories( array( 'hide_empty' => false ) );
+	$selected_cats   = $edit_post_id ? wp_get_post_categories( $edit_post_id ) : array();
+	$categories_data = array();
+	foreach ( $all_cats as $cat ) {
+		$categories_data[] = array(
+			'id'       => $cat->term_id,
+			'name'     => $cat->name,
+			'selected' => in_array( $cat->term_id, $selected_cats, true ),
+		);
+	}
+
+	// Seed Interactivity API state.
+	wp_interactivity_state(
+		'wpcom-write',
+		array(
+			'postsPath'        => '/wp/v2/posts',
+			'mediaPath'        => '/wp/v2/media',
+			'homeUrl'          => home_url( '/' ),
+			'adminUrl'         => admin_url(),
+			'writeUrl'         => wpcom_write_url(),
+			'editPostId'       => $edit_post_id,
+			'postStatus'       => $post_status,
+			'title'            => $edit_title,
+			'isSaving'         => false,
+			'isPublished'      => false,
+			'message'          => '',
+			'showToolbar'      => false,
+			'showLinkInput'    => false,
+			'linkUrl'          => '',
+			'showImageModal'   => false,
+			'showVideoModal'   => false,
+			'videoUrl'         => '',
+			'imageAlt'         => '',
+			'setAsFeatured'    => false,
+			'featuredMediaId'  => $edit_featured_id ?? 0,
+			'isUploading'      => false,
+			'categories'       => $categories_data,
+			'showCatPicker'    => false,
+			'showHelp'         => false,
+			'showSlashMenu'    => false,
+			'slashFilter'      => '',
+			'showLeaveConfirm' => false,
+		)
+	);
+
+	// Output the editor UI inside wp-admin's wrapper.
+	wpcom_write_template( $edit_title, $edit_content, $edit_post_id, $categories_data );
+}
+
+/**
+ * Render the distraction-free writing UI.
+ *
+ * This outputs HTML inside wp-admin's page wrapper (not a standalone page).
+ * The wp-admin chrome is hidden via CSS added in admin_enqueue_scripts.
+ *
+ * @param string $edit_title      The post title when editing.
+ * @param string $edit_content    The post content when editing.
+ * @param int    $edit_post_id    The post ID when editing, 0 for new posts.
+ * @param array  $categories_data Array of category data for the picker.
+ */
+function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_id = 0, $categories_data = array() ) {
+	?>
+<div data-wp-interactive="wpcom-write" class="bw-app">
+
+	<!-- Top bar -->
+	<header class="bw-topbar">
+		<a href="<?php echo esc_url( admin_url() ); ?>" class="bw-back" title="Back to dashboard" data-wp-on--click="actions.handleBack">&larr;</a>
+		<button class="bw-help-toggle" data-wp-on--click="actions.toggleHelp" title="Shortcuts">?</button>
+		<div class="bw-help-popover" data-wp-bind--hidden="!state.showHelp">
+			<div class="bw-help-title">Tips</div>
+			<div class="bw-help-row"><kbd>/</kbd><span>Insert a heading, image, video, quote or divider</span></div>
+			<div class="bw-help-row"><kbd>Select text</kbd><span>Formatting toolbar appears</span></div>
+			<div class="bw-help-row"><kbd>Tab</kbd><span>Navigate slash menu options</span></div>
+		</div>
+		<span class="bw-status" data-wp-text="state.message"></span>
+		<div class="bw-topbar-actions">
+			<button
+				class="bw-btn bw-btn-draft"
+				data-wp-on--click="actions.saveDraft"
+				data-wp-bind--disabled="state.isSaving"
+			>Save draft</button>
+			<button
+				class="bw-btn bw-btn-publish"
+				data-wp-on--click="actions.publish"
+				data-wp-bind--disabled="state.isSaving"
+			><?php echo $edit_post_id ? 'Update' : 'Publish'; ?></button>
+		</div>
+	</header>
+
+	<!-- Writing area -->
+	<main class="bw-main" data-wp-on--click="actions.enterFocus">
+		<div class="bw-editor">
+			<textarea
+				class="bw-title"
+				placeholder="Title"
+				rows="1"
+				data-wp-on--input="actions.updateTitle"
+				data-wp-on--keydown="actions.handleTitleKeyDown"
+				autocomplete="off"
+			><?php echo esc_textarea( $edit_title ); ?></textarea>
+			<div class="bw-separator"></div>
+			<div
+				class="bw-content"
+				contenteditable="true"
+				data-wp-on--mouseup="actions.checkFormatting"
+				data-wp-on--keyup="actions.checkFormatting"
+				data-wp-on--keydown="actions.handleKeyDown"
+				data-wp-on--click="actions.enterFocus"
+				data-placeholder="Tell your story..."
+			><?php echo wp_kses_post( $edit_content ); ?></div>
+		</div>
+	</main>
+
+	<!-- Floating formatting toolbar -->
+	<div
+		class="bw-toolbar"
+		data-wp-bind--hidden="!state.showToolbar"
+		data-wp-on--mousedown="actions.preventToolbarBlur"
+	>
+		<button class="bw-tool" data-wp-on--click="actions.formatHeading" data-wp-class--bw-tool-active="state.formatHeading" title="Heading"><span class="dashicons dashicons-heading"></span></button>
+		<span class="bw-tool-divider"></span>
+		<button class="bw-tool" data-wp-on--click="actions.formatBold" data-wp-class--bw-tool-active="state.formatBold" title="Bold"><span class="dashicons dashicons-editor-bold"></span></button>
+		<button class="bw-tool" data-wp-on--click="actions.formatItalic" data-wp-class--bw-tool-active="state.formatItalic" title="Italic"><span class="dashicons dashicons-editor-italic"></span></button>
+		<span class="bw-tool-divider"></span>
+		<button class="bw-tool" data-wp-on--click="actions.formatQuote" data-wp-class--bw-tool-active="state.formatQuote" title="Quote"><span class="dashicons dashicons-format-quote"></span></button>
+		<span class="bw-tool-divider"></span>
+		<button class="bw-tool" data-wp-on--click="actions.toggleLinkInput" title="Link"><span class="dashicons dashicons-admin-links"></span></button>
+		<button class="bw-tool" data-wp-on--click="actions.openImageModal" title="Image"><span class="dashicons dashicons-format-image"></span></button>
+	</div>
+
+	<!-- Link input popover -->
+	<div class="bw-link-popover" data-wp-bind--hidden="!state.showLinkInput">
+		<input
+			type="url"
+			class="bw-link-input"
+			placeholder="Paste or type a link..."
+			data-wp-on--input="actions.updateLinkUrl"
+			data-wp-on--keydown="actions.handleLinkKeyDown"
+		/>
+		<button class="bw-link-apply" data-wp-on--click="actions.applyLink">Apply</button>
+		<button class="bw-link-remove" data-wp-on--click="actions.removeLink">&times;</button>
+	</div>
+
+	<!-- Image modal -->
+	<div class="bw-image-overlay" hidden data-wp-bind--hidden="!state.showImageModal" data-wp-on--click="actions.closeImageModal">
+		<div class="bw-image-modal" data-wp-on--click="actions.stopPropagation">
+			<h3>Add an image</h3>
+			<label class="bw-upload-zone" id="bw-upload-zone">
+				<span class="bw-upload-label">Drop a file or click to upload</span>
+				<span class="bw-upload-saving" style="display:none;">Uploading...</span>
+				<input type="file" accept="image/*" data-wp-on--change="actions.uploadImage" hidden />
+			</label>
+			<div class="bw-image-divider"><span>or</span></div>
+			<input
+				type="url"
+				class="bw-image-url-input"
+				placeholder="Paste an image URL..."
+				data-wp-on--input="actions.updateImageUrl"
+			/>
+			<input
+				type="text"
+				class="bw-image-url-input"
+				placeholder="Alt text (describe the image)..."
+				data-wp-on--input="actions.updateImageAlt"
+				style="margin-top:12px;"
+			/>
+			<label class="bw-featured-toggle">
+				<input type="checkbox" data-wp-on--change="actions.toggleFeaturedImage" />
+				<span>Set as featured image</span>
+			</label>
+			<button class="bw-btn bw-btn-publish" data-wp-on--click="actions.insertImageFromUrl" style="width:100%;margin-top:12px;">Insert image</button>
+		</div>
+	</div>
+
+	<!-- Leave confirmation -->
+	<div class="bw-image-overlay" hidden data-wp-bind--hidden="!state.showLeaveConfirm" data-wp-on--click="actions.cancelLeave">
+		<div class="bw-leave-modal" data-wp-on--click="actions.stopPropagation">
+			<h3>You have unsaved changes</h3>
+			<p>Are you sure you want to leave? Your work will be lost.</p>
+			<div class="bw-leave-actions">
+				<button class="bw-btn bw-btn-draft" data-wp-on--click="actions.cancelLeave">Keep writing</button>
+				<a href="<?php echo esc_url( admin_url() ); ?>" class="bw-btn bw-btn-leave">Leave</a>
+			</div>
+		</div>
+	</div>
+
+	<!-- Slash command menu -->
+	<div class="bw-slash-menu" data-wp-bind--hidden="!state.showSlashMenu">
+		<div class="bw-slash-item" data-wp-on--click="actions.insertHeading" data-wp-on--mousedown="actions.preventToolbarBlur">
+			<span class="bw-slash-icon">H</span>
+			<div><strong>Heading</strong><span class="bw-slash-desc">Large section heading</span></div>
+		</div>
+		<div class="bw-slash-item" data-wp-on--click="actions.insertImage" data-wp-on--mousedown="actions.preventToolbarBlur">
+			<span class="bw-slash-icon">&#9653;</span>
+			<div><strong>Image</strong><span class="bw-slash-desc">Upload or embed an image</span></div>
+		</div>
+		<div class="bw-slash-item" data-wp-on--click="actions.insertQuote" data-wp-on--mousedown="actions.preventToolbarBlur">
+			<span class="bw-slash-icon">&ldquo;</span>
+			<div><strong>Quote</strong><span class="bw-slash-desc">Highlight a quote</span></div>
+		</div>
+		<div class="bw-slash-item" data-wp-on--click="actions.insertVideo" data-wp-on--mousedown="actions.preventToolbarBlur">
+			<span class="bw-slash-icon">&#9654;</span>
+			<div><strong>Video</strong><span class="bw-slash-desc">Embed a YouTube or Vimeo video</span></div>
+		</div>
+		<div class="bw-slash-item" data-wp-on--click="actions.insertDivider" data-wp-on--mousedown="actions.preventToolbarBlur">
+			<span class="bw-slash-icon">&mdash;</span>
+			<div><strong>Divider</strong><span class="bw-slash-desc">A horizontal separator</span></div>
+		</div>
+	</div>
+
+	<!-- Video modal -->
+	<div class="bw-image-overlay" hidden data-wp-bind--hidden="!state.showVideoModal" data-wp-on--click="actions.closeVideoModal">
+		<div class="bw-image-modal" data-wp-on--click="actions.stopPropagation">
+			<h3>Embed a video</h3>
+			<input
+				type="url"
+				class="bw-image-url-input"
+				placeholder="Paste a YouTube or Vimeo URL..."
+				data-wp-on--input="actions.updateVideoUrl"
+				data-wp-on--keydown="actions.handleVideoKeyDown"
+			/>
+			<button class="bw-btn bw-btn-publish" data-wp-on--click="actions.insertVideoEmbed" style="width:100%;margin-top:12px;">Embed video</button>
+		</div>
+	</div>
+
+	<!-- Floating category picker -->
+	<div class="bw-cat-fab" data-wp-on--click="actions.toggleCatPicker">
+		<span class="bw-cat-fab-icon dashicons dashicons-admin-generic"></span>
+	</div>
+	<div class="bw-cat-popover" data-wp-bind--hidden="!state.showCatPicker">
+		<div class="bw-cat-popover-header">Categories</div>
+		<div class="bw-cat-popover-list">
+			<?php
+			foreach ( $categories_data as $i => $cat ) :
+				$cat_context = esc_attr(
+					wp_json_encode(
+						array(
+							'catIndex'    => $i,
+							'catSelected' => $cat['selected'],
+						),
+						JSON_HEX_TAG | JSON_HEX_AMP
+					)
+				);
+				?>
+			<button
+				class="bw-cat<?php echo $cat['selected'] ? ' bw-cat-selected' : ''; ?>"
+				data-wp-on--click="actions.toggleCategory"
+				data-wp-context='<?php echo $cat_context; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped above. ?>'
+				data-wp-class--bw-cat-selected="context.catSelected"
+			><?php echo esc_html( $cat['name'] ); ?></button>
+			<?php endforeach; ?>
+		</div>
+	</div>
+
+</div>
+	<?php
+}
+

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * Write Feature Tests
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/write/write.php';
+
+/**
+ * Class Write_Test
+ */
+class Write_Test extends \WorDBless\BaseTestCase {
+
+	/**
+	 * Administrator user ID.
+	 *
+	 * @var int
+	 */
+	private $admin_id;
+
+	/**
+	 * Subscriber user ID (cannot publish posts).
+	 *
+	 * @var int
+	 */
+	private $subscriber_id;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->admin_id = wp_insert_user(
+			array(
+				'user_login' => 'write_admin',
+				'user_pass'  => 'password',
+				'user_email' => 'write_admin@example.com',
+				'role'       => 'administrator',
+			)
+		);
+
+		$this->subscriber_id = wp_insert_user(
+			array(
+				'user_login' => 'write_subscriber',
+				'user_pass'  => 'password',
+				'user_email' => 'write_subscriber@example.com',
+				'role'       => 'subscriber',
+			)
+		);
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		wp_set_current_user( 0 );
+		delete_option( 'wpcom_write_rewrite_version' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Test that the render callback for the admin page exists.
+	 */
+	public function test_admin_page_render_callback_exists() {
+		$this->assertTrue(
+			function_exists( 'wpcom_write_render_admin_page' ),
+			'Write render callback should be defined.'
+		);
+	}
+
+	/**
+	 * Test that wpcom_write_url returns the expected admin URL.
+	 */
+	public function test_write_url_format() {
+		$url = wpcom_write_url();
+		$this->assertStringContainsString( 'admin.php?page=write', $url );
+	}
+
+	/**
+	 * Test that the wpcom-write script module is registered after init.
+	 */
+	public function test_script_module_is_registered() {
+		do_action( 'init' );
+
+		// Verify the script module was registered by checking it can be enqueued without error.
+		wp_enqueue_script_module( 'wpcom-write/view' );
+		$this->assertTrue( true, 'Script module registration and enqueue did not throw.' );
+	}
+
+	/**
+	 * Render the Write template with wp_head/wp_footer hooks removed to avoid
+	 * side effects from other features (e.g. missing build assets).
+	 *
+	 * @param string $title      Post title.
+	 * @param string $content    Post content.
+	 * @param int    $post_id    Post ID (0 for new).
+	 * @param array  $categories Categories data.
+	 * @return string The rendered HTML.
+	 */
+	private function render_template( $title = '', $content = '', $post_id = 0, $categories = array() ) {
+		remove_all_actions( 'wp_head' );
+		remove_all_actions( 'wp_footer' );
+
+		ob_start();
+		wpcom_write_template( $title, $content, $post_id, $categories );
+		return ob_get_clean();
+	}
+
+	/**
+	 * Test that the template function outputs the expected HTML structure.
+	 */
+	public function test_template_outputs_editor_markup() {
+		wp_set_current_user( $this->admin_id );
+
+		$output = $this->render_template();
+
+		$this->assertStringContainsString( 'data-wp-interactive="wpcom-write"', $output );
+		$this->assertStringContainsString( 'class="bw-app"', $output );
+		$this->assertStringContainsString( 'class="bw-content"', $output );
+		$this->assertStringContainsString( 'contenteditable="true"', $output );
+		$this->assertStringContainsString( 'Tell your story...', $output );
+		$this->assertStringContainsString( 'Save draft', $output );
+		$this->assertStringContainsString( 'Publish', $output );
+	}
+
+	/**
+	 * Test that the template shows "Update" instead of "Publish" when editing.
+	 */
+	public function test_template_shows_update_when_editing() {
+		wp_set_current_user( $this->admin_id );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Test Post',
+				'post_status' => 'publish',
+				'post_author' => $this->admin_id,
+			)
+		);
+
+		$output = $this->render_template( 'Test Post', '<p>Content</p>', $post_id );
+
+		$this->assertStringContainsString( 'Update', $output );
+		$this->assertStringNotContainsString( '>Publish<', $output );
+	}
+
+	/**
+	 * Test that the template includes the title when editing.
+	 */
+	public function test_template_includes_edit_title() {
+		wp_set_current_user( $this->admin_id );
+
+		$output = $this->render_template( 'My Great Post' );
+
+		$this->assertStringContainsString( 'My Great Post', $output );
+	}
+
+	/**
+	 * Test that the Interactivity API state includes required fields.
+	 */
+	public function test_interactivity_state_is_seeded() {
+		// We can't easily test wp_interactivity_state() directly since it
+		// stores state internally. Instead, verify the function exists and
+		// our template_redirect callback would call it by checking the
+		// query var filter is registered.
+		$this->assertTrue(
+			function_exists( 'wp_interactivity_state' ),
+			'wp_interactivity_state() should be available.'
+		);
+	}
+
+	/**
+	 * Test that the asset URL helper returns a valid URL.
+	 */
+	public function test_asset_url_returns_url_containing_filename() {
+		$url = wpcom_write_asset_url( 'view.js' );
+		$this->assertStringContainsString( 'view.js', $url );
+		$this->assertStringContainsString( 'write', $url );
+	}
+
+	/**
+	 * Test that the asset URL helper works for CSS files.
+	 */
+	public function test_asset_url_works_for_css() {
+		$url = wpcom_write_asset_url( 'style.css' );
+		$this->assertStringContainsString( 'style.css', $url );
+		$this->assertStringContainsString( 'write', $url );
+	}
+}


### PR DESCRIPTION
## Proposed changes

Add a simplified, distraction-free writing surface for WordPress.com sites, served as a hidden wp-admin page at `admin.php?page=write`.

* Full-screen writing experience — intercepts before wp-admin chrome renders, no sidebar or admin header
* Built on the WordPress Interactivity API — no build step, no React
* Floating formatting toolbar (bold, italic, heading, quote, link, image)
* Slash commands for headings, images, videos, quotes, dividers
* Image upload with alt text, captions, and featured image support
* Video embedding (YouTube/Vimeo)
* Category picker via floating popover
* Saves posts as valid Gutenberg block markup via the REST API — posts are fully editable in the block editor afterward
* Gated by the `wpcom-write-editor` blog sticker for gradual rollout

Uses wp-admin context (rather than a front-end `/write/` URL) so that REST API calls for saving posts and uploading media work correctly on WordPress.com simple sites, where `/wp-json/` is not available on the front-end.

<img width="1336" height="727" alt="Screenshot 2026-04-23 at 10 40 34 AM" src="https://github.com/user-attachments/assets/d8198501-c00e-410d-8805-4009092f70f4" />


## Related product discussion/links

RSM-587

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

### Local testing (Docker)

1. Check out this branch
2. Start the Docker environment:
   ```bash
   nvm use 24.14.1
   pnpm jetpack docker up -d
   ```
3. Create a mu-plugin to load Write directly (jetpack-mu-wpcom-plugin has a pre-existing crash in gutenberg-rtc that blocks full loading):
   ```bash
   cat > tools/docker/mu-plugins/load-write.php << 'MUEOF'
   <?php
   require_once '/usr/local/src/jetpack-monorepo/projects/packages/jetpack-mu-wpcom/src/features/write/write.php';
   MUEOF
   ```
4. **Do NOT activate the jetpack-mu-wpcom-plugin** — it will crash the site due to a pre-existing issue in the gutenberg-rtc feature. The mu-plugin from step 3 loads Write directly.

5. Navigate to `http://localhost/wp-admin/admin.php?page=write` while logged in

6. **If CSS/JS is missing:** The Write page may load without styles or interactivity. This happens because `plugins_url()` can't resolve the monorepo path when Write is loaded via the mu-plugin workaround. The code has a fallback for this (`wpcom_write_asset_url()`), but it relies on the `jetpack-mu-wpcom-plugin` directory existing at `wp-content/plugins/jetpack-mu-wpcom-plugin/`. To fix:
   - Activate the jetpack-mu-wpcom-plugin briefly: `pnpm jetpack docker wp plugin activate jetpack-mu-wpcom-plugin`
   - Then immediately deactivate it: `pnpm jetpack docker wp plugin deactivate jetpack-mu-wpcom-plugin`
   - This registers the plugin path so `plugins_url()` can resolve asset URLs through the symlink. You only need to do this once.
   - Alternatively, verify the symlink exists: `jetpack-mu-wpcom-plugin/jetpack_vendor/automattic/jetpack-mu-wpcom` should point to the monorepo package.

### Simple site testing

- Apply the `wpcom-write-editor` blog sticker to a test site.
- Apply these changes to your sandbox: `bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/write-editor` and sandbox the site and public api.
- Turn on write access: `allow-sandbox-production-writes "10 minutes"`
- Visit `yoursite.wordpress.com/wp-admin/admin.php?page=write`.

### WoW Atomic site testing

- Create a WoA dev blog.
- Apply the `wpcom-write-editor` blog sticker.
- Add the Jetpack beta plugin and for the Site Helper (wpcomsh) select this branch: `add/write-editor`
- Visit `yoursite.wpcomstaging.com/wp-admin/admin.php?page=write`.

### What to test

* Full-screen experience — no wp-admin sidebar or header visible
* Title field auto-resizes, Enter in title jumps to content area
* Type `/` to see slash command menu (heading, image, quote, video, divider)
* Select text to see floating formatting toolbar (bold, italic, heading, quote, link, image)
* Upload an image via the image modal, set as featured image
* Embed a YouTube or Vimeo video
* Save as draft, then publish — verify post is created with valid block markup
* Visit the published post, confirm it renders correctly
* No flash of modal overlays on page load

**Known issues:**
- Missing translations
- Missing a11y

🤖 Generated with [Claude Code](https://claude.com/claude-code)