### PR TITLE
Forms: Add jetpack-forms/list-forms ability

### DIFF
--- a/projects/packages/forms/changelog/add-forms-list-forms-ability
+++ b/projects/packages/forms/changelog/add-forms-list-forms-ability
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Register the jetpack-forms/list-forms ability to list pages that host a contact form and have received at least one response.

--- a/projects/packages/forms/src/abilities/class-forms-abilities.php
+++ b/projects/packages/forms/src/abilities/class-forms-abilities.php
@@ -13,6 +13,7 @@
 namespace Automattic\Jetpack\Forms\Abilities;
 
 use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Endpoint;
+use Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin;
 
 /**
  * Class Forms_Abilities
@@ -83,6 +84,7 @@ class Forms_Abilities {
 		self::register_get_responses_ability();
 		self::register_update_response_ability();
 		self::register_get_status_counts_ability();
+		self::register_list_forms_ability();
 	}
 
 	/**
@@ -263,6 +265,38 @@ class Forms_Abilities {
 	}
 
 	/**
+	 * Register ability to list forms.
+	 *
+	 * @return void
+	 */
+	private static function register_list_forms_ability() {
+		wp_register_ability(
+			'jetpack-forms/list-forms',
+			array(
+				'label'               => __( 'List forms', 'jetpack-forms' ),
+				'description'         => __( 'List the posts and pages on the site that contain a Jetpack contact form and have received at least one response. Returns each parent post with its ID, title, URL, and type. Useful for discovering which forms exist before calling get-responses with a parent filter.', 'jetpack-forms' ),
+				'category'            => self::CATEGORY_SLUG,
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'default'              => array(),
+					'properties'           => array(),
+					'additionalProperties' => false,
+				),
+				'execute_callback'    => array( __CLASS__, 'list_forms' ),
+				'permission_callback' => array( __CLASS__, 'can_edit_pages' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			)
+		);
+	}
+
+	/**
 	 * Check if user can edit pages.
 	 *
 	 * @return bool
@@ -383,5 +417,44 @@ class Forms_Abilities {
 		}
 
 		return (array) $response->get_data();
+	}
+
+	/**
+	 * List forms callback.
+	 *
+	 * Returns the distinct parent posts that own feedback entries — i.e. the
+	 * pages and posts on the site that host a Jetpack contact form and have
+	 * received at least one submission. An agent can pair these IDs with the
+	 * `parent` filter on jetpack-forms/get-responses to scope response queries.
+	 *
+	 * @param array $args Unused. Accepted for ability callback signature parity.
+	 * @return array List of forms with id, title, url, and post type.
+	 */
+	public static function list_forms( $args = array() ) {
+		unset( $args );
+
+		$parent_ids = Contact_Form_Plugin::get_all_parent_post_ids();
+		$forms      = array();
+
+		foreach ( $parent_ids as $parent_id ) {
+			$parent_id = (int) $parent_id;
+			if ( $parent_id <= 0 ) {
+				continue;
+			}
+
+			$post = get_post( $parent_id );
+			if ( ! $post ) {
+				continue;
+			}
+
+			$forms[] = array(
+				'id'        => $parent_id,
+				'title'     => get_the_title( $post ),
+				'url'       => get_permalink( $post ),
+				'post_type' => $post->post_type,
+			);
+		}
+
+		return array( 'forms' => $forms );
 	}
 }

--- a/projects/packages/forms/tests/php/abilities/Forms_Abilities_Test.php
+++ b/projects/packages/forms/tests/php/abilities/Forms_Abilities_Test.php
@@ -138,6 +138,7 @@ class Forms_Abilities_Test extends BaseTestCase {
 			'jetpack-forms/get-responses',
 			'jetpack-forms/update-response',
 			'jetpack-forms/get-status-counts',
+			'jetpack-forms/list-forms',
 		);
 
 		foreach ( $expected_abilities as $ability_name ) {
@@ -310,5 +311,45 @@ class Forms_Abilities_Test extends BaseTestCase {
 		$this->assertArrayHasKey( 'inbox', $result );
 		$this->assertArrayHasKey( 'spam', $result );
 		$this->assertArrayHasKey( 'trash', $result );
+	}
+
+	/**
+	 * Test list_forms callback returns the expected array shape when there are no forms.
+	 */
+	public function test_list_forms_callback_empty() {
+		wp_set_current_user( self::$user_id );
+
+		$result = Forms_Abilities::list_forms();
+
+		$this->assertIsArray( $result, 'list_forms should return an array' );
+		$this->assertArrayHasKey( 'forms', $result );
+		$this->assertSame( array(), $result['forms'], 'forms should be empty without feedback' );
+	}
+
+	/**
+	 * Test list_forms ability execution through the Abilities API.
+	 */
+	public function test_list_forms_ability() {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API functions not available' );
+			return;
+		}
+
+		$this->simulate_doing_wp_abilities_categories_init_action();
+		Forms_Abilities::register_category();
+
+		$this->simulate_doing_wp_abilities_init_action();
+		Forms_Abilities::register_abilities();
+
+		wp_set_current_user( self::$user_id );
+
+		$ability = wp_get_ability( 'jetpack-forms/list-forms' );
+		$this->assertNotNull( $ability, 'list-forms ability should exist' );
+
+		$result = $ability->execute( array() );
+
+		$this->assertNotInstanceOf( \WP_Error::class, $result, 'list-forms should not return WP_Error' );
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'forms', $result );
 	}
 }


### PR DESCRIPTION
Fixes # N/A

## Proposed changes
* Register a new `jetpack-forms/list-forms` ability (`readonly`, `idempotent`, `show_in_rest`) in `Forms_Abilities`. It returns the distinct parent posts that own feedback entries — i.e. the pages and posts on the site that host a Jetpack contact form and have received at least one submission.
* Each entry is `{ id, title, url, post_type }`. Agents can use the returned IDs with the `parent` filter on `jetpack-forms/get-responses` to scope response queries to a specific form.
* Delegates to the existing `Contact_Form_Plugin::get_all_parent_post_ids()`, so there is no new query shape or migration — this ability just surfaces data the dashboard already reads.
* Uses the same `can_edit_pages` permission callback as the existing Forms abilities.

## Related product discussion/links
* Abilities Everywhere — Jetpack Forms now has four abilities: `get-responses`, `update-response`, `get-status-counts`, `list-forms`.

## Does this pull request change what data or activity we track or use?
No. Reads existing post data; no new collection or transmission.

## Testing instructions

1. From the monorepo root: `pnpm jetpack test php packages/forms tests/php/abilities/Forms_Abilities_Test.php` — expect `OK (13 tests, 33 assertions)`.
2. Lint: `composer phpcs:lint -- projects/packages/forms/src/abilities/class-forms-abilities.php projects/packages/forms/tests/php/abilities/Forms_Abilities_Test.php` — expect no violations.
3. Against a real WP 6.9+ site that has Jetpack Forms enabled and at least one page with a contact form that has received a submission:
   * Log in as an administrator, then hit `GET /wp-json/wp-abilities/v1/abilities` — the response should include `jetpack-forms/list-forms`.
   * Execute the ability via `POST /wp-json/wp-abilities/v1/abilities/jetpack-forms/list-forms/run` with an empty body; response shape should be `{ "forms": [ { "id": …, "title": "…", "url": "…", "post_type": "page|post" }, … ] }`.
   * Confirm each returned `id` is a post/page that contains a `jetpack/contact-form` block.
   * As a user without `edit_pages`, the ability should return a permission error.
