### PR TITLE
Search: take over theme search template with Jetpack Search layout

### DIFF
--- a/projects/packages/search/changelog/feature-search-template-takeover
+++ b/projects/packages/search/changelog/feature-search-template-takeover
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search: register a plugin-origin block template so the Jetpack Search layout takes over the theme's search results page, and share its markup with the Blog Search Page pattern.

--- a/projects/packages/search/changelog/feature-search-template-takeover
+++ b/projects/packages/search/changelog/feature-search-template-takeover
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Search: register a plugin-origin block template so the Jetpack Search layout takes over the theme's search results page, and share its markup with the Blog Search Page pattern.
+Search: register a plugin-origin block template so the Jetpack Search layout takes over the theme's search results page.

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -224,16 +224,29 @@ class Search_Blocks {
 	 * footer template parts so the plugin-registered template renders the
 	 * same page users get from inserting the pattern directly. Markup lives
 	 * in `templates/jetpack-search.html` — the canonical block-theme format
-	 * for block templates — with a single `%s` placeholder for the filter
-	 * sidebar heading so that string still goes through `esc_html__()`.
+	 * for block templates — with a `{{FILTER_HEADING}}` placeholder for the
+	 * filter-sidebar heading so that string still goes through `esc_html__()`.
+	 *
+	 * Memoized: `register_search_template()` runs on every `init`, and the
+	 * template markup is identical every request, so read the file and run
+	 * the translation substitution once per process.
 	 *
 	 * @return string Block markup for a complete page template.
 	 */
-	protected static function get_search_template_content() {
+	protected static function get_search_template_content(): string {
+		static $content = null;
+		if ( null !== $content ) {
+			return $content;
+		}
 		$template_path = __DIR__ . '/templates/jetpack-search.html';
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- local, bundled template file; wp_remote_get() is for remote URLs.
-		$template = is_readable( $template_path ) ? (string) file_get_contents( $template_path ) : '';
-		return sprintf( $template, esc_html__( 'Filter options', 'jetpack-search-pkg' ) );
+		$raw     = is_readable( $template_path ) ? (string) file_get_contents( $template_path ) : '';
+		$content = str_replace(
+			'{{FILTER_HEADING}}',
+			esc_html__( 'Filter options', 'jetpack-search-pkg' ),
+			$raw
+		);
+		return $content;
 	}
 
 	/**
@@ -281,22 +294,27 @@ class Search_Blocks {
 	 * @return string
 	 */
 	protected static function get_parent_plugin_slug(): string {
-		if ( ! function_exists( 'is_plugin_active' ) ) {
-			if ( ! defined( 'ABSPATH' ) ) {
-				return 'jetpack-search';
-			}
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		$fallback = 'jetpack-search';
+		if ( ! function_exists( 'get_option' ) ) {
+			return $fallback;
+		}
+		// Read the same option `is_plugin_active()` reads, then union in
+		// network-activated plugins when on multisite. Avoids pulling
+		// wp-admin/includes/plugin.php into front-end requests.
+		$active = (array) get_option( 'active_plugins', array() );
+		if ( function_exists( 'is_multisite' ) && is_multisite() && function_exists( 'get_site_option' ) ) {
+			$active = array_merge( $active, array_keys( (array) get_site_option( 'active_sitewide_plugins', array() ) ) );
 		}
 		$preferred = array(
 			'jetpack-search' => 'jetpack-search/jetpack-search.php',
 			'jetpack'        => 'jetpack/jetpack.php',
 		);
 		foreach ( $preferred as $slug => $plugin_file ) {
-			if ( is_plugin_active( $plugin_file ) ) {
+			if ( in_array( $plugin_file, $active, true ) ) {
 				return $slug;
 			}
 		}
-		return 'jetpack-search';
+		return $fallback;
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -235,8 +235,8 @@ class Search_Blocks {
 <!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">
 
-<!-- wp:group {"style":{"spacing":{"blockGap":"1.5rem"}}} -->
-<div class="wp-block-group">
+<!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"1.5rem"}}} -->
+<div class="wp-block-group alignwide">
 <!-- wp:jetpack/search-input /-->
 
 <!-- wp:columns {"style":{"spacing":{"blockGap":"2rem"}}} -->

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -302,26 +302,39 @@ class Search_Blocks {
 	}
 
 	/**
-	 * Directory slug of the plugin that loaded this package.
+	 * Directory slug of the plugin that should own the template in the
+	 * Site Editor UI.
 	 *
-	 * The Site Editor labels plugin-registered templates by looking up an
+	 * The Templates list labels plugin-registered templates by looking up an
 	 * active plugin whose directory slug matches the namespace portion of
-	 * the registered template name. Hardcoding a namespace here would only
-	 * resolve to a plugin name under one of the hosts — the package is
-	 * shipped by both the standalone Jetpack Search plugin (`jetpack-search`)
-	 * and the Jetpack monolith (`jetpack`). Deriving the slug from the
-	 * package's installed path lets both hosts get the correct label
-	 * ("Jetpack Search" vs. "Jetpack") without duplicating configuration.
+	 * the registered template name. We pick the slug by preference rather
+	 * than by install path so that on sites running both the Jetpack
+	 * monolith and the standalone Jetpack Search plugin, the more-specific
+	 * "Jetpack Search" label always wins:
+	 *
+	 * - Jetpack Search plugin active → `jetpack-search` → "Jetpack Search"
+	 * - Otherwise Jetpack plugin active → `jetpack` → "Jetpack"
+	 * - Neither active (unexpected) → `jetpack-search` fallback
 	 *
 	 * @return string
 	 */
 	protected static function get_parent_plugin_slug(): string {
-		if ( ! class_exists( Package::class ) || ! function_exists( 'plugin_basename' ) ) {
-			return 'jetpack-search';
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			if ( ! defined( 'ABSPATH' ) ) {
+				return 'jetpack-search';
+			}
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
-		$relative = plugin_basename( rtrim( Package::get_installed_path(), '/\\' ) );
-		$slug     = strtok( $relative, '/' );
-		return false === $slug ? 'jetpack-search' : $slug;
+		$preferred = array(
+			'jetpack-search' => 'jetpack-search/jetpack-search.php',
+			'jetpack'        => 'jetpack/jetpack.php',
+		);
+		foreach ( $preferred as $slug => $plugin_file ) {
+			if ( is_plugin_active( $plugin_file ) ) {
+				return $slug;
+			}
+		}
+		return 'jetpack-search';
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -337,10 +337,22 @@ class Search_Blocks {
 	 * Site Editor customizations (stored in the DB keyed by this slug) still
 	 * take precedence over the plugin-registered default.
 	 *
+	 * Existing occurrences of the slug are stripped first so the hierarchy
+	 * can't accumulate duplicates from a second init pass or another filter
+	 * on the same hook.
+	 *
 	 * @param string[] $templates Template hierarchy slugs.
 	 * @return string[]
 	 */
 	public static function prepend_search_template( $templates ) {
+		$templates = array_values(
+			array_filter(
+				(array) $templates,
+				static function ( $slug ) {
+					return self::SEARCH_TEMPLATE_SLUG !== $slug;
+				}
+			)
+		);
 		array_unshift( $templates, self::SEARCH_TEMPLATE_SLUG );
 		return $templates;
 	}

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -217,56 +217,62 @@ class Search_Blocks {
 	}
 
 	/**
-	 * Return the block markup for the search layout (filters sidebar + results).
+	 * Build the full search page template content.
 	 *
-	 * Shared by the "Blog Search Page" pattern and the search template.
+	 * Mirrors the "Blog Search Page" pattern's layout (see
+	 * `src/search-blocks/patterns/blog-search.php`) wrapped in header/main/
+	 * footer template parts so the plugin-registered template renders the
+	 * same page users get from inserting the pattern directly. The two
+	 * strings are intentionally kept independent — the pattern is the
+	 * canonical layout on trunk and we mirror it here rather than extracting
+	 * a shared helper, so the pattern file stays unchanged.
 	 *
-	 * @return string Block markup.
+	 * @return string Block markup for a complete page template.
 	 */
-	public static function get_search_layout_content() {
-		return '<!-- wp:columns {"style":{"spacing":{"blockGap":"2rem"}}} -->
-<div class="wp-block-columns">
+	protected static function get_search_template_content() {
+		return '<!-- wp:template-part {"slug":"header"} /-->
 
-<!-- wp:column {"width":"260px"} -->
-<div class="wp-block-column" style="flex-basis:260px">
+<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+<main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">
+
+<!-- wp:group {"style":{"spacing":{"blockGap":"1.5rem"}}} -->
+<div class="wp-block-group">
 <!-- wp:jetpack/search-input /-->
-<!-- wp:jetpack/active-filters /-->
-<!-- wp:jetpack/filter-checkbox {"filterType":"taxonomy","taxonomy":"category","label":"Category"} /-->
-<!-- wp:jetpack/filter-checkbox {"filterType":"taxonomy","taxonomy":"post_tag","label":"Tag"} /-->
-<!-- wp:jetpack/filter-checkbox {"filterType":"post_type","label":"Post Type"} /-->
-</div>
-<!-- /wp:column -->
+
+<!-- wp:columns {"style":{"spacing":{"blockGap":"2rem"}}} -->
+<div class="wp-block-columns">
 
 <!-- wp:column -->
 <div class="wp-block-column">
-<!-- wp:jetpack/sort-control /-->
+<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group">
 <!-- wp:jetpack/results-count /-->
+<!-- wp:jetpack/sort-control /-->
+</div>
+<!-- /wp:group -->
+
 <!-- wp:jetpack/search-results /-->
 <!-- wp:jetpack/no-results /-->
 <!-- wp:jetpack/load-more /-->
 </div>
 <!-- /wp:column -->
 
+<!-- wp:column {"width":"260px","style":{"border":{"left":{"color":"#e0e0e0","width":"1px"}},"spacing":{"padding":{"left":"2rem"}}}} -->
+<div class="wp-block-column" style="border-left-color:#e0e0e0;border-left-width:1px;padding-left:2rem;flex-basis:260px">
+<!-- wp:heading {"level":2,"style":{"typography":{"fontSize":"1.25rem"}}} -->
+<h2 class="wp-block-heading" style="font-size:1.25rem">' . esc_html__( 'Filter options', 'jetpack-search-pkg' ) . '</h2>
+<!-- /wp:heading -->
+<!-- wp:jetpack/active-filters /-->
+<!-- wp:jetpack/filter-checkbox {"filterType":"taxonomy","taxonomy":"category"} /-->
+<!-- wp:jetpack/filter-checkbox {"filterType":"taxonomy","taxonomy":"post_tag"} /-->
+<!-- wp:jetpack/filter-checkbox {"filterType":"post_type"} /-->
 </div>
-<!-- /wp:columns -->';
-	}
+<!-- /wp:column -->
 
-	/**
-	 * Build the full search page template content.
-	 *
-	 * Wraps the shared search layout in header/main/footer template parts.
-	 *
-	 * @return string Block markup for a complete page template.
-	 */
-	protected static function get_search_template_content() {
-		$layout = static::get_search_layout_content();
-
-		return '<!-- wp:template-part {"slug":"header"} /-->
-
-<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
-<main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">
-
-' . $layout . '
+</div>
+<!-- /wp:columns -->
+</div>
+<!-- /wp:group -->
 
 </main>
 <!-- /wp:group -->

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -21,6 +21,16 @@ class Search_Blocks {
 	const RESERVED_QUERY_PARAMS = array( 's', 'orderby' );
 
 	/**
+	 * Template slug used for the Jetpack Search page template.
+	 */
+	const SEARCH_TEMPLATE_SLUG = 'search';
+
+	/**
+	 * Plugin namespace used in the template ID.
+	 */
+	const TEMPLATE_NAMESPACE = 'jetpack-search';
+
+	/**
 	 * Register block types and hook into WordPress.
 	 *
 	 * The caller (Initializer) is responsible for gating this behind the
@@ -29,6 +39,8 @@ class Search_Blocks {
 	public static function init() {
 		add_action( 'init', array( static::class, 'register_blocks' ) );
 		add_filter( 'block_categories_all', array( static::class, 'register_block_category' ) );
+		add_filter( 'get_block_templates', array( static::class, 'inject_search_template' ), 10, 3 );
+		add_filter( 'search_template_hierarchy', array( static::class, 'prepend_search_template' ) );
 		add_action( 'wp_enqueue_scripts', array( static::class, 'seed_interactivity_state' ) );
 		add_action( 'enqueue_block_editor_assets', array( static::class, 'enqueue_editor_assets' ) );
 	}
@@ -202,6 +214,137 @@ class Search_Blocks {
 		foreach ( $pattern_files as $pattern_file ) {
 			require_once $pattern_file;
 		}
+	}
+
+	/**
+	 * Return the block markup for the search layout (filters sidebar + results).
+	 *
+	 * Shared by the "Blog Search Page" pattern and the search template.
+	 *
+	 * @return string Block markup.
+	 */
+	public static function get_search_layout_content() {
+		return '<!-- wp:columns {"style":{"spacing":{"blockGap":"2rem"}}} -->
+<div class="wp-block-columns">
+
+<!-- wp:column {"width":"260px"} -->
+<div class="wp-block-column" style="flex-basis:260px">
+<!-- wp:jetpack/search-input /-->
+<!-- wp:jetpack/active-filters /-->
+<!-- wp:jetpack/filter-checkbox {"filterType":"taxonomy","taxonomy":"category","label":"Category"} /-->
+<!-- wp:jetpack/filter-checkbox {"filterType":"taxonomy","taxonomy":"post_tag","label":"Tag"} /-->
+<!-- wp:jetpack/filter-checkbox {"filterType":"post_type","label":"Post Type"} /-->
+</div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column">
+<!-- wp:jetpack/sort-control /-->
+<!-- wp:jetpack/results-count /-->
+<!-- wp:jetpack/search-results /-->
+<!-- wp:jetpack/no-results /-->
+<!-- wp:jetpack/load-more /-->
+</div>
+<!-- /wp:column -->
+
+</div>
+<!-- /wp:columns -->';
+	}
+
+	/**
+	 * Build the full search page template content.
+	 *
+	 * Wraps the shared search layout in header/main/footer template parts.
+	 *
+	 * @return string Block markup for a complete page template.
+	 */
+	protected static function get_search_template_content() {
+		$layout = static::get_search_layout_content();
+
+		return '<!-- wp:template-part {"slug":"header"} /-->
+
+<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+<main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">
+
+' . $layout . '
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer"} /-->';
+	}
+
+	/**
+	 * Build a WP_Block_Template object for the search template.
+	 *
+	 * @return \WP_Block_Template
+	 */
+	protected static function build_search_block_template() {
+		$template                 = new \WP_Block_Template();
+		$template->id             = self::TEMPLATE_NAMESPACE . '//' . self::SEARCH_TEMPLATE_SLUG;
+		$template->theme          = self::TEMPLATE_NAMESPACE;
+		$template->slug           = self::SEARCH_TEMPLATE_SLUG;
+		$template->title          = __( 'Search', 'jetpack-search-pkg' );
+		$template->description    = __( 'Displays search results with Jetpack Search filters.', 'jetpack-search-pkg' );
+		$template->content        = static::get_search_template_content();
+		$template->type           = 'wp_template';
+		$template->source         = 'plugin';
+		$template->origin         = 'plugin';
+		$template->status         = 'publish';
+		$template->has_theme_file = false;
+		$template->is_custom      = false;
+
+		return $template;
+	}
+
+	/**
+	 * Inject the Jetpack Search template into the block template list.
+	 *
+	 * Uses the `get_block_templates` filter (available since WP 5.9) so this
+	 * works on all WordPress versions that support block themes. Users can
+	 * customize the template in the Site Editor — the database version takes
+	 * priority automatically.
+	 *
+	 * @param \WP_Block_Template[] $query_result Templates returned by the query.
+	 * @param array                $query        Template query arguments.
+	 * @param string               $template_type 'wp_template' or 'wp_template_part'.
+	 * @return \WP_Block_Template[]
+	 */
+	public static function inject_search_template( $query_result, $query, $template_type ) {
+		if ( 'wp_template' !== $template_type || ! wp_is_block_theme() ) {
+			return $query_result;
+		}
+
+		// If a specific slug set is requested and ours isn't in it, bail.
+		if ( ! empty( $query['slug__in'] ) && ! in_array( self::SEARCH_TEMPLATE_SLUG, $query['slug__in'], true ) ) {
+			return $query_result;
+		}
+
+		// Don't inject if the user already has a customized version (stored in DB).
+		foreach ( $query_result as $existing ) {
+			if ( self::SEARCH_TEMPLATE_SLUG === $existing->slug && 'custom' === $existing->source ) {
+				return $query_result;
+			}
+		}
+
+		$query_result[] = static::build_search_block_template();
+		return $query_result;
+	}
+
+	/**
+	 * Prepend the Jetpack Search template slug to the search template hierarchy.
+	 *
+	 * WordPress checks slugs in order — the first match wins. By prepending our
+	 * plugin-registered template slug, it takes priority over the theme's
+	 * search.html. If a user customizes the template in the Site Editor, the
+	 * database version takes priority over both.
+	 *
+	 * @param string[] $templates Template hierarchy slugs.
+	 * @return string[]
+	 */
+	public static function prepend_search_template( $templates ) {
+		array_unshift( $templates, self::SEARCH_TEMPLATE_SLUG );
+		return $templates;
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -22,8 +22,13 @@ class Search_Blocks {
 
 	/**
 	 * Template slug used for the Jetpack Search page template.
+	 *
+	 * Intentionally distinct from WordPress's `search` slug so the plugin
+	 * template never collides with (and gets deduplicated against) a block
+	 * theme's own `search.html`. `search_template_hierarchy` prepends this
+	 * slug so it still wins on `/?s=...` requests.
 	 */
-	const SEARCH_TEMPLATE_SLUG = 'search';
+	const SEARCH_TEMPLATE_SLUG = 'jetpack-search';
 
 	/**
 	 * Plugin namespace used in the template ID.
@@ -38,8 +43,8 @@ class Search_Blocks {
 	 */
 	public static function init() {
 		add_action( 'init', array( static::class, 'register_blocks' ) );
+		add_action( 'init', array( static::class, 'register_search_template' ) );
 		add_filter( 'block_categories_all', array( static::class, 'register_block_category' ) );
-		add_filter( 'get_block_templates', array( static::class, 'inject_search_template' ), 10, 3 );
 		add_filter( 'search_template_hierarchy', array( static::class, 'prepend_search_template' ) );
 		add_action( 'wp_enqueue_scripts', array( static::class, 'seed_interactivity_state' ) );
 		add_action( 'enqueue_block_editor_assets', array( static::class, 'enqueue_editor_assets' ) );
@@ -275,69 +280,42 @@ class Search_Blocks {
 	}
 
 	/**
-	 * Build a WP_Block_Template object for the search template.
+	 * Register the Jetpack Search page template with the block-template
+	 * registry so it surfaces in the Site Editor's Templates list and can be
+	 * resolved via the template hierarchy.
 	 *
-	 * @return \WP_Block_Template
+	 * Uses `register_block_template()` (WP 6.7+). Jetpack requires WP 6.8+,
+	 * so the function is always present at runtime — the function_exists
+	 * guard is defensive for phpstan/phan and edge environments.
+	 *
+	 * DB-stored customizations continue to take precedence: if a site owner
+	 * edits this template in the Site Editor, the `custom` source wins during
+	 * resolution automatically.
 	 */
-	protected static function build_search_block_template() {
-		$template                 = new \WP_Block_Template();
-		$template->id             = self::TEMPLATE_NAMESPACE . '//' . self::SEARCH_TEMPLATE_SLUG;
-		$template->theme          = self::TEMPLATE_NAMESPACE;
-		$template->slug           = self::SEARCH_TEMPLATE_SLUG;
-		$template->title          = __( 'Search', 'jetpack-search-pkg' );
-		$template->description    = __( 'Displays search results with Jetpack Search filters.', 'jetpack-search-pkg' );
-		$template->content        = static::get_search_template_content();
-		$template->type           = 'wp_template';
-		$template->source         = 'plugin';
-		$template->origin         = 'plugin';
-		$template->status         = 'publish';
-		$template->has_theme_file = false;
-		$template->is_custom      = false;
-
-		return $template;
+	public static function register_search_template() {
+		if ( ! function_exists( 'register_block_template' ) ) {
+			return;
+		}
+		register_block_template(
+			self::TEMPLATE_NAMESPACE . '//' . self::SEARCH_TEMPLATE_SLUG,
+			array(
+				'title'       => __( 'Jetpack Search', 'jetpack-search-pkg' ),
+				'description' => __( 'Displays search results with Jetpack Search filters.', 'jetpack-search-pkg' ),
+				'content'     => static::get_search_template_content(),
+			)
+		);
 	}
 
 	/**
-	 * Inject the Jetpack Search template into the block template list.
+	 * Prepend the Jetpack Search template slug to the search template hierarchy
+	 * so `/?s=…` requests resolve to our plugin-registered template instead of
+	 * the theme's `search.html`.
 	 *
-	 * Uses the `get_block_templates` filter (available since WP 5.9) so this
-	 * works on all WordPress versions that support block themes. Users can
-	 * customize the template in the Site Editor — the database version takes
-	 * priority automatically.
-	 *
-	 * @param \WP_Block_Template[] $query_result Templates returned by the query.
-	 * @param array                $query        Template query arguments.
-	 * @param string               $template_type 'wp_template' or 'wp_template_part'.
-	 * @return \WP_Block_Template[]
-	 */
-	public static function inject_search_template( $query_result, $query, $template_type ) {
-		if ( 'wp_template' !== $template_type || ! wp_is_block_theme() ) {
-			return $query_result;
-		}
-
-		// If a specific slug set is requested and ours isn't in it, bail.
-		if ( ! empty( $query['slug__in'] ) && ! in_array( self::SEARCH_TEMPLATE_SLUG, $query['slug__in'], true ) ) {
-			return $query_result;
-		}
-
-		// Don't inject if the user already has a customized version (stored in DB).
-		foreach ( $query_result as $existing ) {
-			if ( self::SEARCH_TEMPLATE_SLUG === $existing->slug && 'custom' === $existing->source ) {
-				return $query_result;
-			}
-		}
-
-		$query_result[] = static::build_search_block_template();
-		return $query_result;
-	}
-
-	/**
-	 * Prepend the Jetpack Search template slug to the search template hierarchy.
-	 *
-	 * WordPress checks slugs in order — the first match wins. By prepending our
-	 * plugin-registered template slug, it takes priority over the theme's
-	 * search.html. If a user customizes the template in the Site Editor, the
-	 * database version takes priority over both.
+	 * Core resolves each slug in order, stopping at the first template it
+	 * finds. Because our slug is unique (`jetpack-search`, not `search`), the
+	 * theme's `search.html` is never consulted when this prepend is in effect.
+	 * Site Editor customizations (stored in the DB keyed by this slug) still
+	 * take precedence over the plugin-registered default.
 	 *
 	 * @param string[] $templates Template hierarchy slugs.
 	 * @return string[]

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -303,13 +303,12 @@ class Search_Blocks {
 	 * @return string
 	 */
 	protected static function get_parent_plugin_slug(): string {
-		// Read the same option `is_plugin_active()` reads, then union in
-		// network-activated plugins when on multisite. Avoids pulling
-		// wp-admin/includes/plugin.php into front-end requests.
-		$active = (array) get_option( 'active_plugins', array() );
-		if ( is_multisite() ) {
-			$active = array_merge( $active, array_keys( (array) get_site_option( 'active_sitewide_plugins', array() ) ) );
-		}
+		// Helper::get_active_plugins() already centralizes single-site +
+		// multisite active-plugin discovery (reads `active_plugins`, unions
+		// network-activated plugins from `active_sitewide_plugins`, dedupes).
+		// Reuse it so multisite/activation behavior stays consistent across
+		// the package if it ever evolves.
+		$active    = Helper::get_active_plugins();
 		$preferred = array(
 			'jetpack-search' => 'jetpack-search/jetpack-search.php',
 			'jetpack'        => 'jetpack/jetpack.php',

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -222,62 +222,18 @@ class Search_Blocks {
 	 * Mirrors the "Blog Search Page" pattern's layout (see
 	 * `src/search-blocks/patterns/blog-search.php`) wrapped in header/main/
 	 * footer template parts so the plugin-registered template renders the
-	 * same page users get from inserting the pattern directly. The two
-	 * strings are intentionally kept independent — the pattern is the
-	 * canonical layout on trunk and we mirror it here rather than extracting
-	 * a shared helper, so the pattern file stays unchanged.
+	 * same page users get from inserting the pattern directly. Markup lives
+	 * in `templates/jetpack-search.html` — the canonical block-theme format
+	 * for block templates — with a single `%s` placeholder for the filter
+	 * sidebar heading so that string still goes through `esc_html__()`.
 	 *
 	 * @return string Block markup for a complete page template.
 	 */
 	protected static function get_search_template_content() {
-		return '<!-- wp:template-part {"slug":"header"} /-->
-
-<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
-<main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">
-
-<!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"1.5rem"}}} -->
-<div class="wp-block-group alignwide">
-<!-- wp:jetpack/search-input /-->
-
-<!-- wp:columns {"style":{"spacing":{"blockGap":"2rem"}}} -->
-<div class="wp-block-columns">
-
-<!-- wp:column -->
-<div class="wp-block-column">
-<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group">
-<!-- wp:jetpack/results-count /-->
-<!-- wp:jetpack/sort-control /-->
-</div>
-<!-- /wp:group -->
-
-<!-- wp:jetpack/search-results /-->
-<!-- wp:jetpack/no-results /-->
-<!-- wp:jetpack/load-more /-->
-</div>
-<!-- /wp:column -->
-
-<!-- wp:column {"width":"260px","style":{"border":{"left":{"color":"#e0e0e0","width":"1px"}},"spacing":{"padding":{"left":"2rem"}}}} -->
-<div class="wp-block-column" style="border-left-color:#e0e0e0;border-left-width:1px;padding-left:2rem;flex-basis:260px">
-<!-- wp:heading {"level":2,"style":{"typography":{"fontSize":"1.25rem"}}} -->
-<h2 class="wp-block-heading" style="font-size:1.25rem">' . esc_html__( 'Filter options', 'jetpack-search-pkg' ) . '</h2>
-<!-- /wp:heading -->
-<!-- wp:jetpack/active-filters /-->
-<!-- wp:jetpack/filter-checkbox {"filterType":"taxonomy","taxonomy":"category"} /-->
-<!-- wp:jetpack/filter-checkbox {"filterType":"taxonomy","taxonomy":"post_tag"} /-->
-<!-- wp:jetpack/filter-checkbox {"filterType":"post_type"} /-->
-</div>
-<!-- /wp:column -->
-
-</div>
-<!-- /wp:columns -->
-</div>
-<!-- /wp:group -->
-
-</main>
-<!-- /wp:group -->
-
-<!-- wp:template-part {"slug":"footer"} /-->';
+		$template_path = __DIR__ . '/templates/jetpack-search.html';
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- local, bundled template file; wp_remote_get() is for remote URLs.
+		$template = is_readable( $template_path ) ? (string) file_get_contents( $template_path ) : '';
+		return sprintf( $template, esc_html__( 'Filter options', 'jetpack-search-pkg' ) );
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -299,7 +299,7 @@ class Search_Blocks {
 		register_block_template(
 			self::TEMPLATE_NAMESPACE . '//' . self::SEARCH_TEMPLATE_SLUG,
 			array(
-				'title'       => __( 'Jetpack Search', 'jetpack-search-pkg' ),
+				'title'       => __( 'Jetpack Search Results', 'jetpack-search-pkg' ),
 				'description' => __( 'Displays search results with Jetpack Search filters.', 'jetpack-search-pkg' ),
 				'content'     => static::get_search_template_content(),
 			)

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -31,11 +31,6 @@ class Search_Blocks {
 	const SEARCH_TEMPLATE_SLUG = 'jetpack-search';
 
 	/**
-	 * Plugin namespace used in the template ID.
-	 */
-	const TEMPLATE_NAMESPACE = 'jetpack-search';
-
-	/**
 	 * Register block types and hook into WordPress.
 	 *
 	 * The caller (Initializer) is responsible for gating this behind the
@@ -297,13 +292,36 @@ class Search_Blocks {
 			return;
 		}
 		register_block_template(
-			self::TEMPLATE_NAMESPACE . '//' . self::SEARCH_TEMPLATE_SLUG,
+			static::get_parent_plugin_slug() . '//' . self::SEARCH_TEMPLATE_SLUG,
 			array(
 				'title'       => __( 'Jetpack Search Results', 'jetpack-search-pkg' ),
 				'description' => __( 'Displays search results with Jetpack Search filters.', 'jetpack-search-pkg' ),
 				'content'     => static::get_search_template_content(),
 			)
 		);
+	}
+
+	/**
+	 * Directory slug of the plugin that loaded this package.
+	 *
+	 * The Site Editor labels plugin-registered templates by looking up an
+	 * active plugin whose directory slug matches the namespace portion of
+	 * the registered template name. Hardcoding a namespace here would only
+	 * resolve to a plugin name under one of the hosts — the package is
+	 * shipped by both the standalone Jetpack Search plugin (`jetpack-search`)
+	 * and the Jetpack monolith (`jetpack`). Deriving the slug from the
+	 * package's installed path lets both hosts get the correct label
+	 * ("Jetpack Search" vs. "Jetpack") without duplicating configuration.
+	 *
+	 * @return string
+	 */
+	protected static function get_parent_plugin_slug(): string {
+		if ( ! class_exists( Package::class ) || ! function_exists( 'plugin_basename' ) ) {
+			return 'jetpack-search';
+		}
+		$relative = plugin_basename( rtrim( Package::get_installed_path(), '/\\' ) );
+		$slug     = strtok( $relative, '/' );
+		return false === $slug ? 'jetpack-search' : $slug;
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -266,12 +266,21 @@ class Search_Blocks {
 		if ( ! function_exists( 'register_block_template' ) ) {
 			return;
 		}
+		$content = static::get_search_template_content();
+		// Skip registration if the bundled template file is missing or
+		// unreadable. Since this template's slug is prepended to the
+		// search hierarchy, registering with empty content would take
+		// over `/?s=...` and render a blank page; bailing here lets core
+		// fall through to the theme's `search.html` instead.
+		if ( '' === $content ) {
+			return;
+		}
 		register_block_template(
 			static::get_parent_plugin_slug() . '//' . self::SEARCH_TEMPLATE_SLUG,
 			array(
 				'title'       => __( 'Jetpack Search Results', 'jetpack-search-pkg' ),
 				'description' => __( 'Displays search results with Jetpack Search filters.', 'jetpack-search-pkg' ),
-				'content'     => static::get_search_template_content(),
+				'content'     => $content,
 			)
 		);
 	}

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -303,15 +303,11 @@ class Search_Blocks {
 	 * @return string
 	 */
 	protected static function get_parent_plugin_slug(): string {
-		$fallback = 'jetpack-search';
-		if ( ! function_exists( 'get_option' ) ) {
-			return $fallback;
-		}
 		// Read the same option `is_plugin_active()` reads, then union in
 		// network-activated plugins when on multisite. Avoids pulling
 		// wp-admin/includes/plugin.php into front-end requests.
 		$active = (array) get_option( 'active_plugins', array() );
-		if ( function_exists( 'is_multisite' ) && is_multisite() && function_exists( 'get_site_option' ) ) {
+		if ( is_multisite() ) {
 			$active = array_merge( $active, array_keys( (array) get_site_option( 'active_sitewide_plugins', array() ) ) );
 		}
 		$preferred = array(
@@ -323,7 +319,7 @@ class Search_Blocks {
 				return $slug;
 			}
 		}
-		return $fallback;
+		return 'jetpack-search';
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/patterns/blog-search.php
+++ b/projects/packages/search/src/search-blocks/patterns/blog-search.php
@@ -19,43 +19,6 @@ register_block_pattern(
 			__( 'results', 'jetpack-search-pkg' ),
 			__( 'jetpack search', 'jetpack-search-pkg' ),
 		),
-		'content'     => '<!-- wp:group {"style":{"spacing":{"blockGap":"1.5rem"}}} -->
-<div class="wp-block-group">
-<!-- wp:jetpack/search-input /-->
-
-<!-- wp:columns {"style":{"spacing":{"blockGap":"2rem"}}} -->
-<div class="wp-block-columns">
-
-<!-- wp:column -->
-<div class="wp-block-column">
-<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group">
-<!-- wp:jetpack/results-count /-->
-<!-- wp:jetpack/sort-control /-->
-</div>
-<!-- /wp:group -->
-
-<!-- wp:jetpack/search-results /-->
-<!-- wp:jetpack/no-results /-->
-<!-- wp:jetpack/load-more /-->
-</div>
-<!-- /wp:column -->
-
-<!-- wp:column {"width":"260px","style":{"border":{"left":{"color":"#e0e0e0","width":"1px"}},"spacing":{"padding":{"left":"2rem"}}}} -->
-<div class="wp-block-column" style="border-left-color:#e0e0e0;border-left-width:1px;padding-left:2rem;flex-basis:260px">
-<!-- wp:heading {"level":2,"style":{"typography":{"fontSize":"1.25rem"}}} -->
-<h2 class="wp-block-heading" style="font-size:1.25rem">' . esc_html__( 'Filter options', 'jetpack-search-pkg' ) . '</h2>
-<!-- /wp:heading -->
-<!-- wp:jetpack/active-filters /-->
-<!-- wp:jetpack/filter-checkbox {"filterType":"taxonomy","taxonomy":"category"} /-->
-<!-- wp:jetpack/filter-checkbox {"filterType":"taxonomy","taxonomy":"post_tag"} /-->
-<!-- wp:jetpack/filter-checkbox {"filterType":"post_type"} /-->
-</div>
-<!-- /wp:column -->
-
-</div>
-<!-- /wp:columns -->
-</div>
-<!-- /wp:group -->',
+		'content'     => \Automattic\Jetpack\Search\Search_Blocks::get_search_layout_content(),
 	)
 );

--- a/projects/packages/search/src/search-blocks/patterns/blog-search.php
+++ b/projects/packages/search/src/search-blocks/patterns/blog-search.php
@@ -19,6 +19,43 @@ register_block_pattern(
 			__( 'results', 'jetpack-search-pkg' ),
 			__( 'jetpack search', 'jetpack-search-pkg' ),
 		),
-		'content'     => \Automattic\Jetpack\Search\Search_Blocks::get_search_layout_content(),
+		'content'     => '<!-- wp:group {"style":{"spacing":{"blockGap":"1.5rem"}}} -->
+<div class="wp-block-group">
+<!-- wp:jetpack/search-input /-->
+
+<!-- wp:columns {"style":{"spacing":{"blockGap":"2rem"}}} -->
+<div class="wp-block-columns">
+
+<!-- wp:column -->
+<div class="wp-block-column">
+<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group">
+<!-- wp:jetpack/results-count /-->
+<!-- wp:jetpack/sort-control /-->
+</div>
+<!-- /wp:group -->
+
+<!-- wp:jetpack/search-results /-->
+<!-- wp:jetpack/no-results /-->
+<!-- wp:jetpack/load-more /-->
+</div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"260px","style":{"border":{"left":{"color":"#e0e0e0","width":"1px"}},"spacing":{"padding":{"left":"2rem"}}}} -->
+<div class="wp-block-column" style="border-left-color:#e0e0e0;border-left-width:1px;padding-left:2rem;flex-basis:260px">
+<!-- wp:heading {"level":2,"style":{"typography":{"fontSize":"1.25rem"}}} -->
+<h2 class="wp-block-heading" style="font-size:1.25rem">' . esc_html__( 'Filter options', 'jetpack-search-pkg' ) . '</h2>
+<!-- /wp:heading -->
+<!-- wp:jetpack/active-filters /-->
+<!-- wp:jetpack/filter-checkbox {"filterType":"taxonomy","taxonomy":"category"} /-->
+<!-- wp:jetpack/filter-checkbox {"filterType":"taxonomy","taxonomy":"post_tag"} /-->
+<!-- wp:jetpack/filter-checkbox {"filterType":"post_type"} /-->
+</div>
+<!-- /wp:column -->
+
+</div>
+<!-- /wp:columns -->
+</div>
+<!-- /wp:group -->',
 	)
 );

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search.html
@@ -1,0 +1,48 @@
+<!-- wp:template-part {"slug":"header"} /-->
+
+<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+<main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">
+
+<!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"1.5rem"}}} -->
+<div class="wp-block-group alignwide">
+<!-- wp:jetpack/search-input /-->
+
+<!-- wp:columns {"style":{"spacing":{"blockGap":"2rem"}}} -->
+<div class="wp-block-columns">
+
+<!-- wp:column -->
+<div class="wp-block-column">
+<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group">
+<!-- wp:jetpack/results-count /-->
+<!-- wp:jetpack/sort-control /-->
+</div>
+<!-- /wp:group -->
+
+<!-- wp:jetpack/search-results /-->
+<!-- wp:jetpack/no-results /-->
+<!-- wp:jetpack/load-more /-->
+</div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"260px","style":{"border":{"left":{"color":"#e0e0e0","width":"1px"}},"spacing":{"padding":{"left":"2rem"}}}} -->
+<div class="wp-block-column" style="border-left-color:#e0e0e0;border-left-width:1px;padding-left:2rem;flex-basis:260px">
+<!-- wp:heading {"level":2,"style":{"typography":{"fontSize":"1.25rem"}}} -->
+<h2 class="wp-block-heading" style="font-size:1.25rem">%s</h2>
+<!-- /wp:heading -->
+<!-- wp:jetpack/active-filters /-->
+<!-- wp:jetpack/filter-checkbox {"filterType":"taxonomy","taxonomy":"category"} /-->
+<!-- wp:jetpack/filter-checkbox {"filterType":"taxonomy","taxonomy":"post_tag"} /-->
+<!-- wp:jetpack/filter-checkbox {"filterType":"post_type"} /-->
+</div>
+<!-- /wp:column -->
+
+</div>
+<!-- /wp:columns -->
+</div>
+<!-- /wp:group -->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search.html
@@ -28,7 +28,7 @@
 <!-- wp:column {"width":"260px","style":{"border":{"left":{"color":"#e0e0e0","width":"1px"}},"spacing":{"padding":{"left":"2rem"}}}} -->
 <div class="wp-block-column" style="border-left-color:#e0e0e0;border-left-width:1px;padding-left:2rem;flex-basis:260px">
 <!-- wp:heading {"level":2,"style":{"typography":{"fontSize":"1.25rem"}}} -->
-<h2 class="wp-block-heading" style="font-size:1.25rem">%s</h2>
+<h2 class="wp-block-heading" style="font-size:1.25rem">{{FILTER_HEADING}}</h2>
 <!-- /wp:heading -->
 <!-- wp:jetpack/active-filters /-->
 <!-- wp:jetpack/filter-checkbox {"filterType":"taxonomy","taxonomy":"category"} /-->

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -158,4 +158,114 @@ class Search_Blocks_Test extends TestCase {
 			$GLOBALS['wp_query'] = $original_query;
 		}
 	}
+
+	/**
+	 * The takeover hinges on `search` being replaced by `jetpack-search` at
+	 * the front of the hierarchy: that's what makes core resolve our plugin
+	 * template instead of the theme's `search.html`.
+	 */
+	public function test_prepend_search_template_puts_unique_slug_first() {
+		$result = Search_Blocks::prepend_search_template( array( 'search', 'index' ) );
+		$this->assertSame( array( 'jetpack-search', 'search', 'index' ), $result );
+	}
+
+	/**
+	 * `register_search_template()` must push the template into
+	 * WP_Block_Templates_Registry (so it shows up in the Site Editor's
+	 * Templates list) and the stored content must reference the Jetpack
+	 * Search blocks that make the page useful.
+	 */
+	public function test_register_search_template_registers_via_block_template_api() {
+		if ( ! function_exists( 'register_block_template' ) ) {
+			$this->markTestSkipped( 'register_block_template() unavailable in this test environment.' );
+		}
+		// Isolate from any prior registration — the registry is a singleton
+		// across tests, and register_block_template() errors on duplicates.
+		$registry = \WP_Block_Templates_Registry::get_instance();
+		foreach ( array( 'jetpack-search//jetpack-search', 'jetpack//jetpack-search' ) as $name ) {
+			if ( $registry->is_registered( $name ) ) {
+				$registry->unregister( $name );
+			}
+		}
+
+		Search_Blocks::register_search_template();
+
+		$namespace = $this->invoke_protected( 'get_parent_plugin_slug' );
+		$expected  = $namespace . '//jetpack-search';
+		$this->assertTrue( $registry->is_registered( $expected ), "Template $expected should be registered." );
+
+		$registered = $registry->get_registered( $expected );
+		$this->assertSame( 'Jetpack Search Results', $registered->title );
+		// Core blocks that make up the layout — guards against an accidental
+		// empty-file read or a placeholder substitution that blows away the body.
+		$this->assertStringContainsString( '<!-- wp:jetpack/search-results /-->', $registered->content );
+		$this->assertStringContainsString( '<!-- wp:jetpack/filter-checkbox', $registered->content );
+		// The `{{FILTER_HEADING}}` placeholder must have been substituted —
+		// if it leaks into the registry, the heading renders as `{{FILTER_HEADING}}`
+		// on the front end.
+		$this->assertStringNotContainsString( '{{FILTER_HEADING}}', $registered->content );
+
+		$registry->unregister( $expected );
+	}
+
+	/**
+	 * When both the Jetpack monolith and the standalone Jetpack Search plugin
+	 * are active, the more-specific "Jetpack Search" label must win so the
+	 * Site Editor shows the template under Search rather than the umbrella
+	 * Jetpack plugin.
+	 */
+	public function test_get_parent_plugin_slug_prefers_jetpack_search_over_jetpack() {
+		$original = get_option( 'active_plugins', array() );
+		update_option( 'active_plugins', array( 'jetpack/jetpack.php', 'jetpack-search/jetpack-search.php' ) );
+		try {
+			$this->assertSame( 'jetpack-search', $this->invoke_protected( 'get_parent_plugin_slug' ) );
+		} finally {
+			update_option( 'active_plugins', $original );
+		}
+	}
+
+	/**
+	 * With only the Jetpack monolith active, the label should fall to
+	 * "Jetpack" — that's the only plugin WP can resolve to a name.
+	 */
+	public function test_get_parent_plugin_slug_uses_jetpack_when_only_jetpack_active() {
+		$original = get_option( 'active_plugins', array() );
+		update_option( 'active_plugins', array( 'jetpack/jetpack.php' ) );
+		try {
+			$this->assertSame( 'jetpack', $this->invoke_protected( 'get_parent_plugin_slug' ) );
+		} finally {
+			update_option( 'active_plugins', $original );
+		}
+	}
+
+	/**
+	 * Neither preferred plugin active (shouldn't happen — the package is only
+	 * loaded by one of them — but test the safe fallback so a misconfigured
+	 * site doesn't break template registration with an invalid namespace).
+	 */
+	public function test_get_parent_plugin_slug_falls_back_when_neither_active() {
+		$original = get_option( 'active_plugins', array() );
+		update_option( 'active_plugins', array( 'some-other-plugin/some-other-plugin.php' ) );
+		try {
+			$this->assertSame( 'jetpack-search', $this->invoke_protected( 'get_parent_plugin_slug' ) );
+		} finally {
+			update_option( 'active_plugins', $original );
+		}
+	}
+
+	/**
+	 * Invoke a protected static on Search_Blocks from test code. Reflection
+	 * is the cheapest way to cover this logic without leaking visibility
+	 * just for testability.
+	 *
+	 * @param string $method Method name.
+	 * @param mixed  ...$args Positional args.
+	 * @return mixed
+	 */
+	private function invoke_protected( string $method, ...$args ) {
+		// setAccessible() is a no-op since PHP 8.1 and deprecated in 8.5,
+		// so just invoke directly — ReflectionMethod::invoke() already
+		// bypasses visibility.
+		return ( new \ReflectionMethod( Search_Blocks::class, $method ) )->invoke( null, ...$args );
+	}
 }

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -170,6 +170,18 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
+	 * If the slug is already in the hierarchy (e.g. a second init pass or
+	 * another filter already prepended it), the result must not contain
+	 * duplicate `jetpack-search` entries — core would otherwise do two
+	 * identical registry lookups per search request.
+	 */
+	public function test_prepend_search_template_dedupes_existing_slug() {
+		$result = Search_Blocks::prepend_search_template( array( 'jetpack-search', 'search', 'index' ) );
+		$this->assertSame( array( 'jetpack-search', 'search', 'index' ), $result );
+		$this->assertCount( 1, array_keys( $result, 'jetpack-search', true ) );
+	}
+
+	/**
 	 * `register_search_template()` must push the template into
 	 * WP_Block_Templates_Registry (so it shows up in the Site Editor's
 	 * Templates list) and the stored content must reference the Jetpack
@@ -212,8 +224,9 @@ class Search_Blocks_Test extends TestCase {
 	 * If the bundled template file can't be read, registration must be a
 	 * no-op — otherwise the slug we prepended to `search_template_hierarchy`
 	 * would resolve to an empty plugin template and take over `/?s=...`
-	 * with a blank page. Simulate the missing-file case by swapping in a
-	 * no-op content filter (the actual file is always present in the repo).
+	 * with a blank page. Simulate the missing-file case with an anonymous
+	 * subclass that overrides `get_search_template_content()` to return ''
+	 * (the actual file is always present in the repo).
 	 */
 	public function test_register_search_template_skips_when_content_empty() {
 		if ( ! function_exists( 'register_block_template' ) ) {

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -209,6 +209,39 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
+	 * If the bundled template file can't be read, registration must be a
+	 * no-op — otherwise the slug we prepended to `search_template_hierarchy`
+	 * would resolve to an empty plugin template and take over `/?s=...`
+	 * with a blank page. Simulate the missing-file case by swapping in a
+	 * no-op content filter (the actual file is always present in the repo).
+	 */
+	public function test_register_search_template_skips_when_content_empty() {
+		if ( ! function_exists( 'register_block_template' ) ) {
+			$this->markTestSkipped( 'register_block_template() unavailable in this test environment.' );
+		}
+		$registry = \WP_Block_Templates_Registry::get_instance();
+		foreach ( array( 'jetpack-search//jetpack-search', 'jetpack//jetpack-search' ) as $name ) {
+			if ( $registry->is_registered( $name ) ) {
+				$registry->unregister( $name );
+			}
+		}
+
+		// Stub empty content by temporarily overriding the method's output
+		// via a mock subclass. Simplest: run register_search_template on a
+		// subclass that returns '' from get_search_template_content().
+		$anon = new class() extends Search_Blocks {
+			protected static function get_search_template_content(): string {
+				return '';
+			}
+		};
+		$anon::register_search_template();
+
+		foreach ( array( 'jetpack-search//jetpack-search', 'jetpack//jetpack-search' ) as $name ) {
+			$this->assertFalse( $registry->is_registered( $name ), "Template $name should NOT be registered when content is empty." );
+		}
+	}
+
+	/**
 	 * When both the Jetpack monolith and the standalone Jetpack Search plugin
 	 * are active, the more-specific "Jetpack Search" label must win so the
 	 * Site Editor shows the template under Search rather than the umbrella
@@ -263,9 +296,13 @@ class Search_Blocks_Test extends TestCase {
 	 * @return mixed
 	 */
 	private function invoke_protected( string $method, ...$args ) {
-		// setAccessible() is a no-op since PHP 8.1 and deprecated in 8.5,
-		// so just invoke directly — ReflectionMethod::invoke() already
-		// bypasses visibility.
-		return ( new \ReflectionMethod( Search_Blocks::class, $method ) )->invoke( null, ...$args );
+		$ref = new \ReflectionMethod( Search_Blocks::class, $method );
+		// setAccessible() became a no-op in 8.1 and was deprecated in 8.5,
+		// but the package supports PHP 7.2+ where the call is still required
+		// for ReflectionMethod::invoke() to reach a protected method.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$ref->setAccessible( true );
+		}
+		return $ref->invoke( null, ...$args );
 	}
 }


### PR DESCRIPTION
Fixes SEARCH-135

## Why

- **Defaults that work out of the box.** Site owners get the full Jetpack Search layout on `/?s=...` the moment the blocks feature flag is on — no manual theme editing required.
- **Faster iteration.** Once the template ships with the package, layout improvements land via a package release. Today, iterating on the Search block layout means asking users (or ourselves) to re-edit the theme's `search.html` in the Site Editor every time we change something — a ratchet that slows every UI change. Shipping the template in-package makes us own the default and decouples layout iteration from any specific theme.
- **Theme's original search template is preserved.** Because we register under a unique slug (`jetpack-search`) rather than overwriting the theme's `search`, the theme's `search.html` stays intact on disk. If a user disables the plugin, their original search experience comes back automatically — no cleanup step, no "now go restore your template" tickets.
- **Blocks are individually editable in the Site Editor.** A plugin-registered template renders the Jetpack Search blocks as first-class template blocks, so site owners can click into each block and tweak its attributes directly. The pattern-based alternative would have required them to detach blocks from the pattern instance before they could customize anything — an extra step every time and a confusing mental model.
- **Customization still wins.** DB-stored Site Editor overrides take precedence over the plugin-registered template, so site owners can still tune or replace the layout.

## Proposed changes
* Add `src/search-blocks/templates/jetpack-search.html` containing the full search-page layout (header/main/footer template parts wrapping search-input, results + sort on the left, filters on the right). `Search_Blocks::get_search_template_content()` reads that file once per process and runs it through `str_replace()` to substitute a `{{FILTER_HEADING}}` placeholder with the translated "Filter options" heading.
* Register a plugin-origin template with slug `jetpack-search` via `register_block_template()` (WP 6.7+; Jetpack requires 6.8). The template surfaces in the Site Editor's Templates list. Registration is skipped if the bundled HTML can't be read, so a broken deployment falls through to the theme's `search.html` instead of taking over with a blank page.
* Derive the template namespace from the active host plugin so the Site Editor label resolves correctly: `jetpack-search` when the standalone Jetpack Search plugin is active ("Jetpack Search"), `jetpack` when running under the monolith ("Jetpack"). Read `active_plugins` (and `active_sitewide_plugins` on multisite) directly — no `wp-admin/includes/plugin.php` include on the front end.
* Prepend `jetpack-search` to `search_template_hierarchy` so core resolves our plugin template before the theme's `search.html`. The unique slug sidesteps registry-vs-theme dedup that was previously hiding the template from the Site Editor list on themes shipping their own `search.html`. Existing occurrences of the slug are stripped before prepending so the hierarchy can't accumulate duplicates from a second init pass or another filter.
* The Blog Search Page pattern (`src/search-blocks/patterns/blog-search.php`) is left byte-identical to trunk. The template mirrors the pattern's layout rather than sharing a helper with it — intentional: the pattern is the canonical trunk layout and the template is an independent copy, so future edits to one surface never reshape the other through an indirection. If the two drift over time, that's acceptable; a shared helper can be introduced later if both surfaces need to move together.
* DB-stored Site Editor customizations still win during resolution (unchanged behavior).

## Related product discussion/links
* [SEARCH-135](https://linear.app/a8c/issue/SEARCH-135/search-take-over-the-themes-search-template-with-a-jetpack-search)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
1. On a site with a block theme (e.g. Twenty Twenty-Five) and the Jetpack Search blocks feature flag enabled, activate the `jetpack-search` package build.
2. In the Site Editor → Templates (`site-editor.php?p=/template`), confirm a new **"Jetpack Search Results"** template is listed, labelled **"Jetpack Search"** (standalone plugin) or **"Jetpack"** (monolith).
3. From the front end, load `/?s=anything`. The page should render the Jetpack Search layout (filters sidebar + interactive results) instead of the theme's default `search.html`.
4. Open the "Jetpack Search Results" template in the Site Editor, click into one of the Jetpack Search blocks, and confirm you can edit its attributes directly (no "detach pattern" step required).
5. Edit the template and save. Reload `/?s=anything` and confirm the DB-stored customization is what renders.
6. Reset that customization; the plugin-registered default should come back.
7. Disable the Jetpack Search package / plugin. Reload `/?s=anything` and confirm the theme's original `search.html` renders — no cleanup needed.
8. Insert the "Blog Search Page" pattern on a regular page. Confirm the pattern still renders as it does on trunk (layout unchanged by this branch).