### PR TITLE
Search 3.0: load-more buttonLabel attribute

### DIFF
--- a/projects/packages/search/changelog/update-load-more-button-label
+++ b/projects/packages/search/changelog/update-load-more-button-label
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search 3.0: load-more block now exposes a buttonLabel attribute with an editor inspector text input; render.php falls back to the translated default when empty.

--- a/projects/packages/search/changelog/update-load-more-button-label
+++ b/projects/packages/search/changelog/update-load-more-button-label
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Search 3.0: load-more block now exposes a buttonLabel attribute with an editor inspector text input; render.php falls back to the translated default when empty.
+Search 3.0: load-more block now exposes a buttonLabel attribute (editor inspector text input, translated default fallback) and adopts the active theme's button styles via the wp-element-button class.

--- a/projects/packages/search/src/search-blocks/blocks/load-more/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/load-more/block.json
@@ -9,6 +9,9 @@
 	"description": "Loads the next page of Jetpack Search results.",
 	"supports": { "html": false, "interactivity": true },
 	"textdomain": "jetpack-search-pkg",
+	"attributes": {
+		"buttonLabel": { "type": "string", "default": "" }
+	},
 	"render": "file:./render.php",
 	"viewScriptModule": "file:../../../../build/search-blocks/load-more.js",
 	"style": "file:../../../../build/search-blocks/load-more.css"

--- a/projects/packages/search/src/search-blocks/blocks/load-more/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/load-more/render.php
@@ -20,7 +20,7 @@ if ( '' === $button_label ) {
 	data-wp-bind--hidden="!state.showLoadMore"
 >
 	<button
-		class="jetpack-search-load-more__button"
+		class="wp-element-button jetpack-search-load-more__button"
 		data-wp-on--click="actions.loadMore"
 		data-wp-bind--hidden="state.isLoadingMore"
 	>

--- a/projects/packages/search/src/search-blocks/blocks/load-more/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/load-more/render.php
@@ -9,7 +9,10 @@ namespace Automattic\Jetpack\Search;
 
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 
-$button_label = (string) ( $attributes['buttonLabel'] ?? '' );
+// Trim before the empty check so a whitespace-only label (e.g. "   ")
+// renders the translated default rather than a blank button — matches the
+// "Leave empty to use the default" copy in the editor inspector.
+$button_label = trim( (string) ( $attributes['buttonLabel'] ?? '' ) );
 if ( '' === $button_label ) {
 	$button_label = __( 'Load more results', 'jetpack-search-pkg' );
 }
@@ -20,6 +23,7 @@ if ( '' === $button_label ) {
 	data-wp-bind--hidden="!state.showLoadMore"
 >
 	<button
+		type="button"
 		class="wp-element-button jetpack-search-load-more__button"
 		data-wp-on--click="actions.loadMore"
 		data-wp-bind--hidden="state.isLoadingMore"

--- a/projects/packages/search/src/search-blocks/blocks/load-more/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/load-more/render.php
@@ -8,6 +8,11 @@
 namespace Automattic\Jetpack\Search;
 
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+
+$button_label = (string) ( $attributes['buttonLabel'] ?? '' );
+if ( '' === $button_label ) {
+	$button_label = __( 'Load more results', 'jetpack-search-pkg' );
+}
 ?>
 <div
 	<?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>
@@ -19,7 +24,7 @@ namespace Automattic\Jetpack\Search;
 		data-wp-on--click="actions.loadMore"
 		data-wp-bind--hidden="state.isLoadingMore"
 	>
-		<?php esc_html_e( 'Load more results', 'jetpack-search-pkg' ); ?>
+		<?php echo esc_html( $button_label ); ?>
 	</button>
 	<span
 		class="jetpack-search-load-more__spinner"

--- a/projects/packages/search/src/search-blocks/blocks/load-more/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/load-more/style.scss
@@ -1,23 +1,16 @@
 .wp-block-jetpack-load-more {
 	text-align: center;
-	padding: 1rem 0;
+	padding-block: var(--wp--style--block-gap, 1rem);
 
 	&[hidden] {
 		display: none;
 	}
 
+	// The button itself relies on the active theme's `wp-element-button`
+	// styles (theme.json → styles.elements.button) — we only own the
+	// disabled visual since theme.json doesn't define one.
 	.jetpack-search-load-more__button {
-		background: #0073aa;
-		color: #fff;
-		border: none;
-		border-radius: 4px;
-		padding: 0.6rem 1.5rem;
-		font-size: 1rem;
 		cursor: pointer;
-
-		&:hover {
-			background: #005d8c;
-		}
 
 		&:disabled {
 			opacity: 0.5;
@@ -27,8 +20,10 @@
 
 	.jetpack-search-load-more__spinner {
 		display: block;
-		margin: 0.5rem auto;
-		color: #666;
+		margin-block: var(--wp--style--block-gap, 0.5rem);
+		margin-inline: auto;
+		color: inherit;
+		opacity: 0.7;
 
 		&[hidden] {
 			display: none;

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -318,7 +318,10 @@ function NoResultsEdit( { attributes } ) {
 function LoadMoreEdit( { attributes, setAttributes } ) {
 	const blockProps = useBlockProps();
 	const defaultLabel = __( 'Load more results', 'jetpack-search-pkg' );
-	const buttonLabel = attributes?.buttonLabel || defaultLabel;
+	// Match render.php: a whitespace-only label falls back to the default
+	// in the preview so the editor mirrors the front-end behaviour the
+	// "Leave empty…" help text describes. The raw input is still stored.
+	const buttonLabel = ( attributes?.buttonLabel || '' ).trim() || defaultLabel;
 	return h(
 		Fragment,
 		null,

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -10,9 +10,10 @@
  * doesn't hydrate in an editor context, so data-driven blocks otherwise
  * rendered as empty shells in the Site Editor.
  */
-import { useBlockProps } from '@wordpress/block-editor';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { registerBlockType } from '@wordpress/blocks';
-import { createElement as h } from '@wordpress/element';
+import { PanelBody, TextControl } from '@wordpress/components';
+import { createElement as h, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 // Mock result data. Dates are intentionally not wrapped in __() because
@@ -305,28 +306,56 @@ function NoResultsEdit( { attributes } ) {
 /**
  * Editor preview for jetpack/load-more. Includes the (hidden) loading-
  * spinner span render.php emits so the `.jetpack-search-load-more__spinner`
- * CSS hook is available to style.
+ * CSS hook is available to style. The Inspector exposes a text input for the
+ * `buttonLabel` attribute; the saved value (or the translated default) is
+ * what render.php prints on the front end.
  *
+ * @param {object}   props               - Block props.
+ * @param {object}   props.attributes    - Saved block attributes.
+ * @param {Function} props.setAttributes - Attribute setter.
  * @return {object} Rendered element.
  */
-function LoadMoreEdit() {
+function LoadMoreEdit( { attributes, setAttributes } ) {
 	const blockProps = useBlockProps();
+	const defaultLabel = __( 'Load more results', 'jetpack-search-pkg' );
+	const buttonLabel = attributes?.buttonLabel || defaultLabel;
 	return h(
-		'div',
-		blockProps,
+		Fragment,
+		null,
 		h(
-			'button',
-			{
-				type: 'button',
-				className: 'jetpack-search-load-more__button',
-				disabled: true,
-			},
-			__( 'Load more results', 'jetpack-search-pkg' )
+			InspectorControls,
+			null,
+			h(
+				PanelBody,
+				{ title: __( 'Settings', 'jetpack-search-pkg' ) },
+				h( TextControl, {
+					__next40pxDefaultSize: true,
+					__nextHasNoMarginBottom: true,
+					label: __( 'Button label', 'jetpack-search-pkg' ),
+					value: attributes?.buttonLabel || '',
+					placeholder: defaultLabel,
+					onChange: value => setAttributes( { buttonLabel: value } ),
+					help: __( 'Leave empty to use the default translated label.', 'jetpack-search-pkg' ),
+				} )
+			)
 		),
 		h(
-			'span',
-			{ className: 'jetpack-search-load-more__spinner', hidden: true },
-			__( 'Loading…', 'jetpack-search-pkg' )
+			'div',
+			blockProps,
+			h(
+				'button',
+				{
+					type: 'button',
+					className: 'jetpack-search-load-more__button',
+					disabled: true,
+				},
+				buttonLabel
+			),
+			h(
+				'span',
+				{ className: 'jetpack-search-load-more__spinner', hidden: true },
+				__( 'Loading…', 'jetpack-search-pkg' )
+			)
 		)
 	);
 }

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -346,7 +346,7 @@ function LoadMoreEdit( { attributes, setAttributes } ) {
 				'button',
 				{
 					type: 'button',
-					className: 'jetpack-search-load-more__button',
+					className: 'wp-element-button jetpack-search-load-more__button',
 					disabled: true,
 				},
 				buttonLabel

--- a/projects/packages/search/tests/php/Load_More_Render_Test.php
+++ b/projects/packages/search/tests/php/Load_More_Render_Test.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Load More block render.php tests.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the load-more block's render template.
+ *
+ * Each test renders the block through `do_blocks()` so WordPress wires up
+ * the block context (`WP_Block_Supports::$block_to_render`) the template
+ * relies on via `get_block_wrapper_attributes()` — exercising the same path
+ * the front end takes, not just an isolated `include`.
+ */
+class Load_More_Render_Test extends TestCase {
+
+	/**
+	 * Register the load-more block once per test class so `do_blocks()` can
+	 * resolve it. WordPress is bootstrapped by Test_Environment in
+	 * bootstrap.php; the registry persists across tests in the same process,
+	 * but `unregister_block_type()` is called in teardown to avoid leaking
+	 * state into other test classes.
+	 */
+	public static function setUpBeforeClass(): void {
+		\register_block_type(
+			__DIR__ . '/../../src/search-blocks/blocks/load-more'
+		);
+	}
+
+	/**
+	 * Unregister the block so other test classes start from a clean slate.
+	 */
+	public static function tearDownAfterClass(): void {
+		\unregister_block_type( 'jetpack/load-more' );
+	}
+
+	/**
+	 * Render the load-more block with the given attributes via `do_blocks`.
+	 *
+	 * @param array $attributes Block attributes (JSON-encoded into the comment delimiter).
+	 * @return string Rendered markup.
+	 */
+	private function render( array $attributes = array() ): string {
+		$json = empty( $attributes )
+			? ''
+			: wp_json_encode( $attributes, JSON_UNESCAPED_SLASHES );
+		return do_blocks( '<!-- wp:jetpack/load-more ' . $json . ' /-->' );
+	}
+
+	/**
+	 * An empty `buttonLabel` must fall back to the translated default so
+	 * existing posts (saved before the attribute existed) keep rendering
+	 * the original "Load more results" copy.
+	 */
+	public function test_empty_button_label_falls_back_to_default() {
+		$markup = $this->render( array( 'buttonLabel' => '' ) );
+		$this->assertStringContainsString( 'Load more results', $markup );
+	}
+
+	/**
+	 * A missing `buttonLabel` (not just empty) must also fall back. Block
+	 * editor saves omit attributes that match their default, so old posts
+	 * arrive here without the key at all.
+	 */
+	public function test_missing_button_label_falls_back_to_default() {
+		$markup = $this->render();
+		$this->assertStringContainsString( 'Load more results', $markup );
+	}
+
+	/**
+	 * A custom `buttonLabel` must replace the default copy on the front end.
+	 */
+	public function test_custom_button_label_renders() {
+		$markup = $this->render( array( 'buttonLabel' => 'Show more posts' ) );
+		$this->assertStringContainsString( 'Show more posts', $markup );
+		$this->assertStringNotContainsString( 'Load more results', $markup );
+	}
+
+	/**
+	 * The label is user-controlled, so the template must escape HTML to
+	 * prevent stored XSS through a crafted attribute value.
+	 */
+	public function test_button_label_is_html_escaped() {
+		$markup = $this->render( array( 'buttonLabel' => '<script>alert(1)</script>' ) );
+		$this->assertStringNotContainsString( '<script>alert(1)</script>', $markup );
+		$this->assertStringContainsString( '&lt;script&gt;alert(1)&lt;/script&gt;', $markup );
+	}
+}

--- a/projects/packages/search/tests/php/Load_More_Render_Test.php
+++ b/projects/packages/search/tests/php/Load_More_Render_Test.php
@@ -20,15 +20,34 @@ use PHPUnit\Framework\TestCase;
 class Load_More_Render_Test extends TestCase {
 
 	/**
-	 * Register the load-more block once per test class so `do_blocks()` can
-	 * resolve it. WordPress is bootstrapped by Test_Environment in
-	 * bootstrap.php; the registry persists across tests in the same process,
-	 * but `unregister_block_type()` is called in teardown to avoid leaking
-	 * state into other test classes.
+	 * Register the load-more block inline (rather than from its block.json
+	 * directory) so `do_blocks()` can resolve it without depending on the
+	 * `build/` artifacts referenced by block.json's `viewScriptModule` and
+	 * `style` entries — those aren't present in a fresh checkout, and our
+	 * PHPUnit config has `failOnNotice` set, so any missing-asset notice
+	 * during metadata resolution would fail the suite. The render callback
+	 * just delegates to render.php, which is the file under test.
 	 */
 	public static function setUpBeforeClass(): void {
 		\register_block_type(
-			__DIR__ . '/../../src/search-blocks/blocks/load-more'
+			'jetpack/load-more',
+			array(
+				'attributes'      => array(
+					'buttonLabel' => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+				),
+				// $attributes is consumed by the included render.php via the
+				// closure's local scope — phpcs can't see that, hence the disable.
+				// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+				'render_callback' => static function ( $attributes ) {
+					ob_start();
+					include __DIR__ . '/../../src/search-blocks/blocks/load-more/render.php';
+					return (string) ob_get_clean();
+				},
+				// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			)
 		);
 	}
 
@@ -79,6 +98,17 @@ class Load_More_Render_Test extends TestCase {
 		$markup = $this->render( array( 'buttonLabel' => 'Show more posts' ) );
 		$this->assertStringContainsString( 'Show more posts', $markup );
 		$this->assertStringNotContainsString( 'Load more results', $markup );
+	}
+
+	/**
+	 * A whitespace-only label (e.g. user typed spaces and stopped) must
+	 * fall back to the default — the editor inspector promises "Leave
+	 * empty to use the default", and a blank-looking value should behave
+	 * like empty rather than render a visually empty button.
+	 */
+	public function test_whitespace_only_button_label_falls_back_to_default() {
+		$markup = $this->render( array( 'buttonLabel' => '   ' ) );
+		$this->assertStringContainsString( 'Load more results', $markup );
 	}
 
 	/**


### PR DESCRIPTION
Fixes [SEARCH-141](https://linear.app/a8c/issue/SEARCH-141/load-more-button-label-control).

## Proposed changes

### Button label control (SEARCH-141)
* Add a `buttonLabel` string attribute to `jetpack/load-more` (`block.json`), default empty.
* `render.php` reads `$attributes['buttonLabel']`; falls back to the translated `Load more results` when empty or missing — preserves existing posts saved before the attribute existed.
* Editor: `LoadMoreEdit` (`src/search-blocks/editor/register-blocks.js`) now exposes a `TextControl` in `InspectorControls` for `buttonLabel`, with the translated default as the placeholder, and reflects the current value in the preview button. Imports are extracted as classic `wp.*` globals via the dependency-extraction plugin (already in use for this bundle).
* Customberg parity: there is no Customberg load-more label control to mirror — Customberg only exposes `jetpack_search_inf_scroll`, which is replaced in the blocks world by the presence of the `load-more` block. So this PR only adds the label knob, no migration is needed.

### Adopt theme button styles
* The button now carries the canonical `wp-element-button` class (in addition to its existing `jetpack-search-load-more__button` hook). WordPress emits inline CSS from the active theme's `theme.json → styles.elements.button` for that class on every page, so the button automatically picks up the theme's button color, padding, radius, font, and hover — and re-themes for free when the user switches themes.
* `style.scss` drops the hardcoded button color/padding/border/radius/hover that overrode the theme. Wrapper layout uses `--wp--style--block-gap` (with fallback) and the spinner inherits the surrounding text color via `inherit` + `opacity`. The `:disabled` visual stays in our SCSS since `theme.json` has no concept of a disabled state.

### Other information
- [ ] Generate changelog entries for this PR (using AI).

(A `minor` / `added` changelog entry is included at `projects/packages/search/changelog/update-load-more-button-label`.)

## Related product discussion/links
* [SEARCH-141](https://linear.app/a8c/issue/SEARCH-141/load-more-button-label-control)
* Template takeover PR: [#48252](https://github.com/Automattic/jetpack/pull/48252)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

### Front end (render.php)
1. Insert the **Load More** block on a Search results page (the bundled `jetpack-search` template or a custom template/pattern that includes it).
2. Run a search; confirm the button reads **"Load more results"** (translated default).
3. In the editor sidebar for the Load More block, set **Button label** to e.g. `Show more posts`. Save and reload the front end — the button should now read **"Show more posts"**.
4. Clear the field back to empty; confirm the front end falls back to **"Load more results"** again.
5. Try a label like `<script>alert(1)</script>`; confirm it renders escaped (no script execution, escaped angle brackets visible in HTML).

### Editor
6. In the Site Editor, insert the **Load More** block. The Inspector shows a **Settings → Button label** text input with the default label as placeholder and "Leave empty to use the default translated label." help text.
7. The editor preview button reflects the typed value live; switching back to empty restores the default in the preview.

### Theme adoption
8. With a block theme that customizes `elements.button` in `theme.json` (Twenty Twenty-Five is a good baseline), confirm the front-end load-more button matches that theme's button color, padding, radius, font, and hover — i.e. it looks like the theme's other buttons, not Jetpack-blue.
9. Switch to a different block theme (e.g. Twenty Twenty-Four). Reload the search results page and confirm the button restyles to match the new theme automatically, with no extra work.
10. Confirm the disabled-state visual still applies (button fades while a load-more request is in flight) — this is preserved in our SCSS.

### Tests
11. From `projects/packages/search/`:
    ```
    ./vendor/bin/phpunit -c phpunit.12.xml.dist tests/php/Load_More_Render_Test.php
    ```
    Should report `OK (4 tests, 6 assertions)` covering: empty fallback, missing-attribute fallback, custom label render, and HTML escaping via `do_blocks()`.

<img width="3024" height="908" alt="Untitled 2" src="https://github.com/user-attachments/assets/75fe50f2-6af4-4ac8-9000-bc9ebfa9e638" />