### PR TITLE
Search 3.0: match the block inserter category header to Forms / Monetize / Grow

### DIFF
--- a/projects/packages/search/changelog/update-search-category-header
+++ b/projects/packages/search/changelog/update-search-category-header
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Search 3.0: add the Jetpack logo to the "Jetpack Search" block category heading so it matches the Forms, Monetize, and Grow headings in the block inserter.
+Search 3.0: rename the block inserter category to "Search" with the Jetpack logo so it matches the Forms, Monetize, and Grow headings.

--- a/projects/packages/search/changelog/update-search-category-header
+++ b/projects/packages/search/changelog/update-search-category-header
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search 3.0: add the Jetpack logo to the "Jetpack Search" block category heading so it matches the Forms, Monetize, and Grow headings in the block inserter.

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -41,18 +41,19 @@ const BLOCKS = [
 	[ 'jetpack/load-more', LoadMoreEdit ],
 ];
 
-// Attach the Jetpack logo to the "Jetpack Search" block category so the
-// inserter heading matches the Forms / Monetize / Grow headings. The
-// category itself is registered server-side via the `block_categories_all`
-// filter (see Search_Blocks::register_block_category); core strips SVG
-// `icon` values at that PHP boundary, so the icon has to be applied
-// client-side with setCategories().
+// Shape the "Jetpack Search" block category to match the Forms / Monetize /
+// Grow headings in the inserter: the Jetpack logo next to a single-word
+// label (the logo carries the branding, so the label drops the "Jetpack"
+// prefix). The category itself is registered server-side via the
+// `block_categories_all` filter (see Search_Blocks::register_block_category);
+// core strips SVG `icon` values at that PHP boundary, so the icon has to be
+// applied client-side with setCategories().
 setCategories(
 	getCategories().map( category =>
 		category.slug === 'jetpack-search'
 			? {
 					...category,
-					title: __( 'Jetpack Search', 'jetpack-search-pkg' ),
+					title: __( 'Search', 'jetpack-search-pkg' ),
 					icon: <JetpackLogo showText={ false } height={ 24 } />,
 			  }
 			: category

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -54,7 +54,7 @@ setCategories(
 			? {
 					...category,
 					title: __( 'Search', 'jetpack-search-pkg' ),
-					icon: <JetpackLogo showText={ false } height={ 24 } />,
+					icon: <JetpackLogo showText={ false } height={ 24 } width={ 24 } />,
 			  }
 			: category
 	)

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -15,7 +15,9 @@
  * those components up to WordPress — touching one block's preview should
  * only require edits inside that block's folder.
  */
-import { registerBlockType } from '@wordpress/blocks';
+import JetpackLogo from '@automattic/jetpack-components/jetpack-logo';
+import { getCategories, registerBlockType, setCategories } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
 import ActiveFiltersEdit from '../blocks/active-filters/edit';
 import FilterCheckboxEdit from '../blocks/filter-checkbox/edit';
 import LoadMoreEdit from '../blocks/load-more/edit';
@@ -38,6 +40,24 @@ const BLOCKS = [
 	[ 'jetpack/no-results', NoResultsEdit ],
 	[ 'jetpack/load-more', LoadMoreEdit ],
 ];
+
+// Attach the Jetpack logo to the "Jetpack Search" block category so the
+// inserter heading matches the Forms / Monetize / Grow headings. The
+// category itself is registered server-side via the `block_categories_all`
+// filter (see Search_Blocks::register_block_category); core strips SVG
+// `icon` values at that PHP boundary, so the icon has to be applied
+// client-side with setCategories().
+setCategories(
+	getCategories().map( category =>
+		category.slug === 'jetpack-search'
+			? {
+					...category,
+					title: __( 'Jetpack Search', 'jetpack-search-pkg' ),
+					icon: <JetpackLogo showText={ false } height={ 24 } />,
+			  }
+			: category
+	)
+);
 
 BLOCKS.forEach( ( [ name, edit ] ) => {
 	registerBlockType( name, { edit, save } );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #

## Proposed changes
* Rename the block inserter category heading from **Jetpack Search** to **Search** and show the Jetpack logo next to it so it reads the same way as **Forms**, **Monetize**, and **Grow** in the same inserter (the logo carries the Jetpack branding, so the label drops the prefix).
* Server-side registration via `block_categories_all` stays in place, but core silently drops the `icon` key for non-scalar values at that PHP boundary. The icon and the shorter title are therefore applied client-side in `register-blocks.js` with `setCategories()`, the same pattern used elsewhere in Jetpack (`projects/plugins/jetpack/extensions/shared/block-category.js`).
* Uses `JetpackLogo` from `@automattic/jetpack-components/jetpack-logo`, which has no SCSS side-effects, so the editor bundle doesn't pick up a CSS chunk from the shared icon module.

## Related product discussion/links
* peKye1-1Z1-p2 (see RSM-827 / RSM-270 follow-up)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Enable the `jetpack_search_blocks_enabled` feature flag on a site running this build of the Jetpack Search package.
* Open the Site Editor (or a page with the post editor) and click the **+** inserter.
* Scroll to the **Search** category header.
* Confirm the heading has the same Jetpack logo as **Forms**, **Monetize**, and **Grow**, and that the label reads **Search** (not **Jetpack Search**).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [RSM-827](https://linear.app/a8c/issue/RSM-827/update-category-header-to-match-forms-monetize-and-grow)

<div><a href="https://cursor.com/agents/bc-8d0542a9-be62-440c-9375-b3957d9f4a0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d0542a9-be62-440c-9375-b3957d9f4a0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

