### PR TITLE
Search 3.0: localise Interactivity API view-bundle strings

### DIFF
--- a/projects/packages/search/changelog/rsm-267-search-30-localise-interactivity-api-view-bundle-strings-via
+++ b/projects/packages/search/changelog/rsm-267-search-30-localise-interactivity-api-view-bundle-strings-via
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search 3.0: localize Interactivity API view-bundle strings (results count, loading indicator, and active-filter pill aria labels) via wp_interactivity_state.

--- a/projects/packages/search/src/search-blocks/blocks/active-filters/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/active-filters/view.js
@@ -45,14 +45,15 @@ store( NAMESPACE, {
 		 * `ariaLabel` is what screen readers announce — the visible "×" is
 		 * aria-hidden, and the visible label alone ("Category: news") reads
 		 * as a plain noun phrase with no hint that activating the button
-		 * removes the filter. The "Remove " prefix is locked to English
-		 * for the same reason noted in store/index.js' resultsCountText:
-		 * `@wordpress/i18n` isn't available in Interactivity view bundles.
+		 * removes the filter. The "Remove %s" format is seeded in PHP via
+		 * `Search_Blocks::build_initial_strings()` because the view bundle
+		 * can't import `@wordpress/i18n`.
 		 *
 		 * @return {Array<object>} Array of pill descriptors with id, filterKey, value, label, ariaLabel.
 		 */
 		get activePills() {
 			const { state } = store( NAMESPACE );
+			const removeFormat = state.strings?.removeFilter ?? 'Remove %s';
 			const pills = [];
 			for ( const [ filterKey, values ] of Object.entries( state.activeFilters ?? {} ) ) {
 				if ( ! Array.isArray( values ) ) {
@@ -67,7 +68,7 @@ store( NAMESPACE, {
 						filterKey,
 						value,
 						label,
-						ariaLabel: `Remove ${ label }`,
+						ariaLabel: removeFormat.replace( '%s', label ),
 					} );
 				}
 			}

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -535,6 +535,40 @@ class Search_Blocks {
 			'isLoading'     => '' !== $search_query || ! empty( $active_filters ),
 			'isLoadingMore' => false,
 			'hasError'      => false,
+
+			// Translated view-bundle strings. The Interactivity API view bundle
+			// can't import @wordpress/i18n (only @wordpress/interactivity is
+			// registered as a script module), so any JS-produced text is seeded
+			// here and read via state.strings.* on the client. Both _n() forms
+			// are seeded so the client can pick based on the live totalResults
+			// without a round trip; languages with more than two plural forms
+			// degrade to "plural for all count > 1" as an accepted tradeoff.
+			'strings'       => static::build_initial_strings(),
+		);
+	}
+
+	/**
+	 * Seed translated view-bundle strings for the Interactivity API store.
+	 *
+	 * @return array<string, string>
+	 */
+	protected static function build_initial_strings(): array {
+		if ( ! function_exists( '__' ) || ! function_exists( '_n' ) ) {
+			return array(
+				'searching'          => 'Searching…',
+				'resultsCountSingle' => 'Found %d result',
+				'resultsCountPlural' => 'Found %d results',
+				'removeFilter'       => 'Remove %s',
+			);
+		}
+		return array(
+			'searching'          => __( 'Searching…', 'jetpack-search-pkg' ),
+			/* translators: %d: number of results. */
+			'resultsCountSingle' => _n( 'Found %d result', 'Found %d results', 1, 'jetpack-search-pkg' ),
+			/* translators: %d: number of results. */
+			'resultsCountPlural' => _n( 'Found %d result', 'Found %d results', 2, 'jetpack-search-pkg' ),
+			/* translators: %s: filter label (e.g. "Category: News"). Announced by screen readers when focus lands on a filter pill's remove button. */
+			'removeFilter'       => __( 'Remove %s', 'jetpack-search-pkg' ),
 		);
 	}
 

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -66,14 +66,16 @@ const { state, actions } = store( NAMESPACE, {
 		 */
 		get resultsCountText() {
 			if ( state.isLoading ) {
-				return state.strings.searching;
+				return state.strings?.searching ?? 'Searching…';
 			}
 			const total = state.totalResults;
 			if ( total === 0 ) {
 				return '';
 			}
 			const template =
-				total === 1 ? state.strings.resultsCountSingle : state.strings.resultsCountPlural;
+				total === 1
+					? state.strings?.resultsCountSingle ?? 'Found %d result'
+					: state.strings?.resultsCountPlural ?? 'Found %d results';
 			return template.replace( '%d', total );
 		},
 

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -44,36 +44,37 @@ const { state, actions } = store( NAMESPACE, {
 	state: {
 		/**
 		 * Short human-readable results count for display blocks. Doubles
-		 * as the loading indicator: returning "Searching…" in-place
-		 * keeps the results-count element populated across the transition
-		 * from one query to the next, so the flex row containing it
-		 * doesn't collapse and re-expand on every keystroke-triggered
-		 * search. There is no separate spinner/skeleton — this text is
-		 * the loading state, and the search-results wrapper carries
-		 * `aria-busy` for assistive tech.
+		 * as the loading indicator: returning the "searching" string
+		 * in-place keeps the results-count element populated across the
+		 * transition from one query to the next, so the flex row
+		 * containing it doesn't collapse and re-expand on every
+		 * keystroke-triggered search. There is no separate
+		 * spinner/skeleton — this text is the loading state, and the
+		 * search-results wrapper carries `aria-busy` for assistive tech.
 		 *
-		 * NOTE: not localized. `@wordpress/i18n` isn't available as an
-		 * Interactivity API script module (WP only registers
-		 * `@wordpress/interactivity`), and the dependency-extraction
-		 * plugin throws when any other `@wordpress/*` is imported into
-		 * an ESM view bundle. Revisit when WP registers wp-i18n as a
-		 * module, or switch to seeding translated plural forms from PHP
-		 * via `wp_interactivity_state()`. See PR #48198.
+		 * Strings are seeded from PHP via `wp_interactivity_state()`
+		 * (see `Search_Blocks::build_initial_strings()`) because the
+		 * view bundle can't import `@wordpress/i18n` — WP only registers
+		 * `@wordpress/interactivity` as a script module. Languages with
+		 * more than two plural forms degrade to "plural for all count
+		 * > 1" since the count is dynamic on the client.
 		 *
-		 * @return {string} "Searching…" while a search is in flight,
-		 * "Found 42 results" once a query resolves with hits, or an
-		 * empty string in every other case — pre-search, error, or
-		 * zero hits. The no-results block owns the empty-state copy.
+		 * @return {string} Translated "Searching…" while a search is in
+		 * flight, "Found 42 results" once a query resolves with hits,
+		 * or an empty string in every other case — pre-search, error,
+		 * or zero hits. The no-results block owns the empty-state copy.
 		 */
 		get resultsCountText() {
 			if ( state.isLoading ) {
-				return 'Searching…';
+				return state.strings.searching;
 			}
 			const total = state.totalResults;
 			if ( total === 0 ) {
 				return '';
 			}
-			return `Found ${ total } result${ total === 1 ? '' : 's' }`;
+			const template =
+				total === 1 ? state.strings.resultsCountSingle : state.strings.resultsCountPlural;
+			return template.replace( '%d', total );
 		},
 
 		/**

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -34,6 +34,7 @@ class Search_Blocks_Test extends TestCase {
 			'isLoading',
 			'isLoadingMore',
 			'hasError',
+			'strings',
 		);
 
 		$this->assertTrue( class_exists( Search_Blocks::class ) );
@@ -41,6 +42,26 @@ class Search_Blocks_Test extends TestCase {
 		foreach ( $required_keys as $key ) {
 			$this->assertArrayHasKey( $key, $state, "Missing key: $key" );
 		}
+	}
+
+	/**
+	 * View-bundle strings seeded here are the sole i18n channel for the
+	 * Interactivity API bundle — it can't import @wordpress/i18n. Both
+	 * plural forms must be seeded so the client can pick based on the
+	 * live totalResults, and the format string must carry a `%d` token.
+	 */
+	public function test_build_initial_state_seeds_translated_strings() {
+		$state = Search_Blocks::build_initial_state();
+		$this->assertArrayHasKey( 'strings', $state );
+		$strings = $state['strings'];
+		$this->assertArrayHasKey( 'searching', $strings );
+		$this->assertArrayHasKey( 'resultsCountSingle', $strings );
+		$this->assertArrayHasKey( 'resultsCountPlural', $strings );
+		$this->assertArrayHasKey( 'removeFilter', $strings );
+		$this->assertNotSame( '', $strings['searching'] );
+		$this->assertStringContainsString( '%d', $strings['resultsCountSingle'] );
+		$this->assertStringContainsString( '%d', $strings['resultsCountPlural'] );
+		$this->assertStringContainsString( '%s', $strings['removeFilter'] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes [RSM-267](https://linear.app/a8c/issue/RSM-267/search-30-localise-interactivity-api-view-bundle-strings-via-wp)

## Proposed changes

Closes the Phase 1 gap where the Interactivity API view bundle for Jetpack Search blocks emitted hardcoded English. The view bundle can't import `@wordpress/i18n` (WP only registers `@wordpress/interactivity` as a script module, and `@wordpress/dependency-extraction-webpack-plugin` throws on any other `@wordpress/*` import into an ESM bundle), so this PR routes all JS-produced strings through `wp_interactivity_state()` instead.

* Add a `strings` key to `Search_Blocks::build_initial_state()`, populated by a new `build_initial_strings()` helper. Seeds four translated strings via `__()` / `_n()` on the `jetpack-search-pkg` text domain.
* Seed both `_n()` plural forms (for counts `1` and `2`) so the client can pick based on live `totalResults` without a round trip. Languages with more than two plural forms degrade to "plural for all count > 1" — an accepted tradeoff for dynamic-count text without `@wordpress/i18n` on the client.
* Refactor `resultsCountText` in `src/search-blocks/store/index.js` to read `state.strings.searching` / `resultsCountSingle` / `resultsCountPlural` and substitute `%d`.
* Refactor the `activePills.ariaLabel` output in `src/search-blocks/blocks/active-filters/view.js` to read `state.strings.removeFilter` and substitute `%s`. This third offender — the "Remove %s" aria label — was flagged during the audit; the existing code comment there explicitly deferred to this ticket.
* Drop the two `NOTE: not localized` comment blocks.
* Extend `test_build_initial_state_shape` with the new `strings` key and add `test_build_initial_state_seeds_translated_strings` covering all four keys and their format tokens.

## Related product discussion/links

* Linear: [RSM-267](https://linear.app/a8c/issue/RSM-267/search-30-localise-interactivity-api-view-bundle-strings-via-wp)
* Phase 1 PR that introduced the workaround: #48198 (see [reviewer exchange on `I18nLoaderPlugin: false`](https://github.com/Automattic/jetpack/pull/48198#discussion_r3118719111))
* Loading-indicator reuse that introduced the second non-localised string: #48234
* Active-filters pill aria label that introduced the third: #48227

## Does this pull request change what data or activity we track or use?

No. Tracking and data flow are unchanged. This is purely a localisation refactor — same strings, just routed through gettext.

## Testing instructions

1. Check out this branch and run `jetpack build packages/search`.
2. **English baseline (en_US):** on a site with the Jetpack Search blocks inserted, confirm the results-count block still renders `Searching…` while a query is in flight, `Found 1 result` for a one-hit query, and `Found 42 results` for multi-hit queries. Confirm the active-filters pill aria label is `Remove Category: News` (inspect the button's `aria-label` attribute).
3. **Non-English locale:** switch the blog's site language to French (`fr_FR`) via Settings → General (or for the faster path, set the locale via WP-CLI: `wp site switch-language fr_FR`). Reload a page carrying the search blocks.
   * First paint (SSR + initial hydration): the results-count block should render translated text from the seeded state (`state.strings.*`).
   * Post-hydration updates: type a new query and confirm the translated strings are used for the loading indicator and results-count output as the count changes.
   * Active filters: toggle a filter on, focus the remove "×" button, and confirm the screen-reader announcement / DOM `aria-label` uses the translated format.
4. Run `composer phpunit --filter Search_Blocks_Test` in `projects/packages/search` — all 15 tests should pass. Run `pnpm test-scripts` — all 204 tests should pass.
5. Sanity check the bundle: `grep -r "Searching…" projects/packages/search/build/` should return nothing (confirming the English literal is no longer baked into the view bundle).

