### PR TITLE
Search 3.0: adapt block colors to the active theme palette

### DIFF
--- a/projects/packages/search/changelog/fix-jps3-hardcoded-block-colors
+++ b/projects/packages/search/changelog/fix-jps3-hardcoded-block-colors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search 3.0: swap hardcoded colors in block styles for theme-aware tokens so the search blocks adapt to the active theme palette and dark backgrounds.

--- a/projects/packages/search/src/search-blocks/blocks/active-filters/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/active-filters/edit.js
@@ -33,7 +33,7 @@ export default function ActiveFiltersEdit() {
 					'button',
 					{
 						type: 'button',
-						className: 'jetpack-search-active-filters__pill',
+						className: 'wp-element-button jetpack-search-active-filters__pill',
 						disabled: true,
 					},
 					h(
@@ -53,7 +53,7 @@ export default function ActiveFiltersEdit() {
 			'button',
 			{
 				type: 'button',
-				className: 'jetpack-search-active-filters__clear-all',
+				className: 'wp-element-button jetpack-search-active-filters__clear-all',
 				disabled: true,
 			},
 			__( 'Clear all', 'jetpack-search-pkg' )

--- a/projects/packages/search/src/search-blocks/blocks/active-filters/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/active-filters/edit.js
@@ -53,7 +53,7 @@ export default function ActiveFiltersEdit() {
 			'button',
 			{
 				type: 'button',
-				className: 'wp-element-button jetpack-search-active-filters__clear-all',
+				className: 'jetpack-search-active-filters__clear-all',
 				disabled: true,
 			},
 			__( 'Clear all', 'jetpack-search-pkg' )

--- a/projects/packages/search/src/search-blocks/blocks/active-filters/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/active-filters/render.php
@@ -45,7 +45,7 @@ foreach ( (array) $seeded_active as $values ) {
 			<li>
 				<button
 					type="button"
-					class="jetpack-search-active-filters__pill"
+					class="wp-element-button jetpack-search-active-filters__pill"
 					data-wp-on--click="actions.onRemovePill"
 					data-wp-bind--aria-label="context.pill.ariaLabel"
 				>
@@ -60,7 +60,7 @@ foreach ( (array) $seeded_active as $values ) {
 	</ul>
 	<button
 		type="button"
-		class="jetpack-search-active-filters__clear-all"
+		class="wp-element-button jetpack-search-active-filters__clear-all"
 		data-wp-on--click="actions.clearFilters"
 	>
 		<?php esc_html_e( 'Clear all', 'jetpack-search-pkg' ); ?>

--- a/projects/packages/search/src/search-blocks/blocks/active-filters/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/active-filters/render.php
@@ -60,7 +60,7 @@ foreach ( (array) $seeded_active as $values ) {
 	</ul>
 	<button
 		type="button"
-		class="wp-element-button jetpack-search-active-filters__clear-all"
+		class="jetpack-search-active-filters__clear-all"
 		data-wp-on--click="actions.clearFilters"
 	>
 		<?php esc_html_e( 'Clear all', 'jetpack-search-pkg' ); ?>

--- a/projects/packages/search/src/search-blocks/blocks/active-filters/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/active-filters/style.scss
@@ -11,7 +11,10 @@
 	.jetpack-search-active-filters__heading {
 		font-size: 0.8rem;
 		font-weight: 600;
-		color: #555;
+		// Inherit the theme's text color so the heading adapts to dark
+		// themes and the site palette.
+		color: inherit;
+		opacity: 0.8;
 	}
 
 	.jetpack-search-active-filters__pills {
@@ -23,16 +26,18 @@
 		padding: 0;
 	}
 
+	// Pills and the clear-all button rely on the active theme's
+	// `wp-element-button` styles (theme.json → styles.elements.button) so
+	// they adapt to the site palette. We only override what we need — shape,
+	// spacing, and the remove-icon weight.
 	.jetpack-search-active-filters__pill {
 		display: inline-flex;
 		align-items: center;
 		gap: 0.25rem;
-		background: #0073aa;
-		color: #fff;
-		border: none;
 		border-radius: 12px;
 		padding: 0.2rem 0.6rem;
 		font-size: 0.8rem;
+		line-height: 1.2;
 		cursor: pointer;
 	}
 
@@ -42,11 +47,10 @@
 	}
 
 	.jetpack-search-active-filters__clear-all {
-		background: none;
-		border: 1px solid #ccc;
 		border-radius: 4px;
 		padding: 0.2rem 0.5rem;
 		font-size: 0.8rem;
+		line-height: 1.2;
 		cursor: pointer;
 	}
 }

--- a/projects/packages/search/src/search-blocks/blocks/active-filters/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/active-filters/style.scss
@@ -26,10 +26,9 @@
 		padding: 0;
 	}
 
-	// Pills and the clear-all button rely on the active theme's
-	// `wp-element-button` styles (theme.json → styles.elements.button) so
-	// they adapt to the site palette. We only override what we need — shape,
-	// spacing, and the remove-icon weight.
+	// Pills carry `wp-element-button` so they adopt the active theme's
+	// button palette (theme.json → styles.elements.button). We only
+	// override what we need — pill shape, spacing, and remove-icon weight.
 	.jetpack-search-active-filters__pill {
 		display: inline-flex;
 		align-items: center;
@@ -46,7 +45,14 @@
 		line-height: 1;
 	}
 
+	// Clear-all keeps its outlined / secondary look so it stays visually
+	// distinct from the filled pills. Core's `is-style-outline` only
+	// applies inside a `.wp-block-button` wrapper, so use theme-aware
+	// CSS-wide values (`currentColor`, `inherit`, transparent) here.
 	.jetpack-search-active-filters__clear-all {
+		background: transparent;
+		border: 1px solid currentColor;
+		color: inherit;
 		border-radius: 4px;
 		padding: 0.2rem 0.5rem;
 		font-size: 0.8rem;

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/style.scss
@@ -10,7 +10,9 @@
 		text-transform: uppercase;
 		letter-spacing: 0.05em;
 		margin: 0 0 0.5rem;
-		color: #444;
+		// Inherit the theme's text color so the heading adapts to dark
+		// themes and the site palette.
+		color: inherit;
 	}
 
 	.jetpack-search-filter__list {
@@ -36,8 +38,12 @@
 
 	.jetpack-search-filter__count {
 		font-size: 0.8rem;
-		color: #888;
-		background: #f0f0f0;
+		// Inherit the theme's text color for the count number, and derive
+		// the pill background from `currentColor` so it stays legible on
+		// any theme / dark background. `color-mix` is supported across all
+		// evergreen browsers we target.
+		color: inherit;
+		background: color-mix(in sRGB, currentColor 12%, transparent);
 		border-radius: 10px;
 		padding: 0 0.4rem;
 
@@ -49,7 +55,10 @@
 	.jetpack-search-filter__all-selected {
 		margin: 0;
 		font-size: 0.75rem;
-		color: #888;
+		// Inherit the theme's text color; opacity keeps the muted look
+		// across light and dark themes.
+		color: inherit;
+		opacity: 0.7;
 		font-style: italic;
 
 		&[hidden] {

--- a/projects/packages/search/src/search-blocks/blocks/results-count/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/results-count/style.scss
@@ -1,5 +1,8 @@
 .wp-block-jetpack-results-count {
 	font-size: 0.85rem;
-	color: #666;
+	// Inherit the theme's text color so the block adapts to the site palette
+	// and dark themes. Opacity keeps the muted look.
+	color: inherit;
+	opacity: 0.7;
 	margin: 0;
 }

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
@@ -8,13 +8,20 @@
 
 	label {
 		font-size: 0.9rem;
-		color: #555;
+		// Inherit the theme's text color so the label adapts to dark themes
+		// and the site palette.
+		color: inherit;
+		opacity: 0.8;
 	}
 
 	select {
-		border: 1px solid #ccc;
+		// Use currentColor for the border and inherit the theme's text/
+		// background colors so the control matches the surrounding palette.
+		border: 1px solid currentColor;
 		border-radius: 4px;
 		padding: 0.3rem 0.5rem;
 		font-size: 0.9rem;
+		color: inherit;
+		background: transparent;
 	}
 }

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
@@ -14,9 +14,13 @@
 		opacity: 0.8;
 	}
 
-	// Leave the <select> unstyled on purpose: native browser controls
-	// render correctly on any background and stay accessible on every
-	// platform without per-OS workarounds (e.g. transparent backgrounds
-	// breaking the dropdown list on Windows). The label above carries
-	// the theme-aware text color; the select itself uses the OS chrome.
+	// Leave the <select>'s colors / border / background to the browser:
+	// native controls render correctly on any background and stay
+	// accessible on every platform without per-OS workarounds (e.g.
+	// transparent backgrounds breaking the dropdown list on Windows).
+	// Padding is safe to nudge — it doesn't affect the dropdown chrome —
+	// and matching the clear-all button keeps the toolbar row balanced.
+	select {
+		padding: 0.2rem 0.5rem;
+	}
 }

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
@@ -14,14 +14,9 @@
 		opacity: 0.8;
 	}
 
-	select {
-		// Use currentColor for the border and inherit the theme's text/
-		// background colors so the control matches the surrounding palette.
-		border: 1px solid currentColor;
-		border-radius: 4px;
-		padding: 0.3rem 0.5rem;
-		font-size: 0.9rem;
-		color: inherit;
-		background: transparent;
-	}
+	// Leave the <select> unstyled on purpose: native browser controls
+	// render correctly on any background and stay accessible on every
+	// platform without per-OS workarounds (e.g. transparent backgrounds
+	// breaking the dropdown list on Windows). The label above carries
+	// the theme-aware text color; the select itself uses the OS chrome.
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes RSM-268.

## Proposed changes

The new Jetpack Search blocks had several hardcoded colors in their SCSS (`#555`, `#666`, `#444`, `#888`, `#ccc`, `#f0f0f0`, and the pill's `#0073aa` background). On a theme/section with a dark background — e.g. Twenty Twenty-Five's coloured sections — the muted text blended into the background and the pills ignored the theme palette, matching what was reported in the Linear issue.

This PR swaps the fixed colors for theme-aware tokens so the blocks pick up the active theme's text/background/button palette:

- **Results count**, **sort control label**, **active-filters heading**, **filter headings (Tag/Category/Post type)**, **'All filters applied'** note, and **filter count badge**: `color: inherit` (+ subtle `opacity` for the muted ones).
- **Sort control select**: dropped the border / radius / background overrides entirely so the native browser control is used (restyling `<select>` is a known cross-browser headache — e.g. `background: transparent` breaks the dropdown list on some Windows configurations). Padding is the one property that's safe to nudge without touching the dropdown chrome, so the select gets `padding: 0.2rem 0.5rem` to line up with the clear-all button on the same row.
- **Filter count badge background**: `color-mix(in srgb, currentColor 12%, transparent)` so the capsule stays visible on both light and dark backgrounds without hardcoding a grey.
- **Active-filter pills**: now carry the `wp-element-button` class and drop the hardcoded `#0073aa`/`#fff` overrides, so they inherit the theme.json button palette (same pattern the load-more button already uses).
- **Clear-all button**: keeps its outlined / secondary look so it stays visually distinct from the filled pills, but uses theme-aware values (`background: transparent`, `border: 1px solid currentColor`, `color: inherit`) instead of the previous hardcoded `#ccc` border. Core's `is-style-outline` only applies inside a `.wp-block-button` wrapper, which the search blocks deliberately avoid, so a small block-scoped rule using CSS-wide values is the cleanest portable equivalent.

No markup or behavior changes beyond the extra class name on the active-filter pills, so block previews in the editor remain in sync (`edit.js` updated to match).

## Related product discussion/links

* Linear: RSM-268

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Activate Twenty Twenty-Five and insert the Jetpack Search block / pattern on a page that uses a coloured background (e.g. a Group block with a dark background color or the TT5 "Search results" pattern).
2. Before this change: the "Found N results", "Sort by", "Active filters:", "Tag/Category/Post Type" headings, and "All filters applied" text render in hardcoded mid-grey against the dark background and are barely readable; the active filter pills are always `#0073aa` blue regardless of theme.
3. With this change: the same text inherits the theme's contrast color and stays legible; the pills adopt the theme's button palette via `wp-element-button`; the "Clear all" button remains visually distinct as an outlined secondary control; the sort control's `<select>` falls back to the native browser picker at a height that matches the surrounding controls.
4. Switch to a light theme/background and confirm nothing regresses — muted text should still read as muted thanks to the `opacity` values, and the count badge background remains a subtle tint of the current text color.

## Before / after (dark background, mimicking TT5)

![Before: hardcoded colors vanish against a dark theme background](https://cursor.com/artifacts/c/art-1c7728af-3477-401c-96a5-d3a2f8bbf72a)

![After: text and controls adopt the theme palette; clear-all stays distinct; native select padded to match](https://cursor.com/artifacts/c/art-904896dd-5256-4a56-9474-5fa7a6c7c60c)

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [RSM-268](https://linear.app/a8c/issue/RSM-268/hardcoded-colors-in-block-scss)

<div><a href="https://cursor.com/agents/bc-716bd496-cb0d-47cb-b041-d5ac451d8486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-716bd496-cb0d-47cb-b041-d5ac451d8486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

