### PR TITLE
Forms: add filter to hide action buttons in notification emails

### DIFF
--- a/projects/packages/forms/changelog/fix-47000-accessibility-email-field
+++ b/projects/packages/forms/changelog/fix-47000-accessibility-email-field
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Forms: add jetpack_forms_email_show_actions option to hide action buttons in notification emails

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -171,7 +171,7 @@ class Feedback_Email_Renderer {
 		/**
 		 * Filters whether to show action buttons in notification emails.
 		 *
-		 * @since 0.40.0
+		 * @since $$next-version$$
 		 *
 		 * @param bool $show Whether to show the action buttons. Default true.
 		 */

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -175,8 +175,8 @@ class Feedback_Email_Renderer {
 		 *
 		 * @param bool $show Whether to show the action buttons. Default true.
 		 */
-	
 		$show_email_actions = apply_filters( 'jetpack_forms_email_show_actions', true );
+
 		if ( $feedback_status !== 'jp-temp-feedback' && $show_email_actions ) {
 			$dashboard_url = Forms_Dashboard::get_forms_admin_url( $status, $post_id );
 			// Test responses don't get a Mark-as-spam link in the email — marking

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -171,6 +171,8 @@ class Feedback_Email_Renderer {
 		/**
 		 * Filters whether to show action buttons in notification emails.
 		 *
+		 * @module contact-form
+		 * 
 		 * @since $$next-version$$
 		 *
 		 * @param bool $show Whether to show the action buttons. Default true.

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -168,8 +168,15 @@ class Feedback_Email_Renderer {
 		$mark_as_spam_url        = '';
 		$footer_mark_as_spam_url = '';
 
-		// Check if email action buttons are enabled.
-$show_email_actions = apply_filters( 'jetpack_forms_email_show_actions', true );
+		/**
+		 * Filters whether to show action buttons in notification emails.
+		 *
+		 * @since 0.40.0
+		 *
+		 * @param bool $show Whether to show the action buttons. Default true.
+		 */
+	
+		$show_email_actions = apply_filters( 'jetpack_forms_email_show_actions', true );
 		if ( $feedback_status !== 'jp-temp-feedback' && $show_email_actions ) {
 			$dashboard_url = Forms_Dashboard::get_forms_admin_url( $status, $post_id );
 			// Test responses don't get a Mark-as-spam link in the email — marking

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -168,7 +168,9 @@ class Feedback_Email_Renderer {
 		$mark_as_spam_url        = '';
 		$footer_mark_as_spam_url = '';
 
-		if ( $feedback_status !== 'jp-temp-feedback' ) {
+		// Check if email action buttons are enabled.
+$show_email_actions = get_option( 'jetpack_forms_email_show_actions', true );
+		if ( $feedback_status !== 'jp-temp-feedback' && $show_email_actions ) {
 			$dashboard_url = Forms_Dashboard::get_forms_admin_url( $status, $post_id );
 			// Test responses don't get a Mark-as-spam link in the email — marking
 			// a test entry as spam from email is confusing and the form owner can

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -169,7 +169,7 @@ class Feedback_Email_Renderer {
 		$footer_mark_as_spam_url = '';
 
 		// Check if email action buttons are enabled.
-$show_email_actions = get_option( 'jetpack_forms_email_show_actions', true );
+$show_email_actions = apply_filters( 'jetpack_forms_email_show_actions', true );
 		if ( $feedback_status !== 'jp-temp-feedback' && $show_email_actions ) {
 			$dashboard_url = Forms_Dashboard::get_forms_admin_url( $status, $post_id );
 			// Test responses don't get a Mark-as-spam link in the email — marking

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -172,7 +172,7 @@ class Feedback_Email_Renderer {
 		 * Filters whether to show action buttons in notification emails.
 		 *
 		 * @module contact-form
-		 * 
+		 *
 		 * @since $$next-version$$
 		 *
 		 * @param bool $show Whether to show the action buttons. Default true.

--- a/projects/plugins/jetpack/changelog/fix-47000-accessibility-email-field
+++ b/projects/plugins/jetpack/changelog/fix-47000-accessibility-email-field
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: add jetpack_forms_email_show_actions option to hide action buttons in notification emails

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -820,7 +820,7 @@ function render_for_website( $data, $classes, $styles ) {
 							>
 								<?php echo esc_html( $data['subscribe_placeholder'] ); ?>
 							</label>
-							<?php
+							<?php													
 							printf(
 								'<input
 									required="required"
@@ -833,6 +833,7 @@ function render_for_website( $data, $classes, $styles ) {
 									value="%4$s"
 									id="%5$s"
 									%6$s
+									aria-label="%7$s"
 								/>',
 								( ! empty( $classes['email_field'] )
 									? 'class="' . esc_attr( $classes['email_field'] ) . '"'
@@ -840,8 +841,31 @@ function render_for_website( $data, $classes, $styles ) {
 								),
 								( ! empty( $styles['email_field'] )
 									? esc_attr( $styles['email_field'] )
-									: 'width: 95%; padding: 1px 10px'
+									: 'width: 95%; padding: 1px 10px; opacity: 1; color: #333; background-color: #f9f9f9; border: 1px solid #ccc;'
 								),
+								
+								( ! empty( $data['subscribe_email'] ) ? '' : esc_attr( $data['subscribe_placeholder'] ) ),
+								esc_attr( $data['subscribe_email'] ),
+								esc_attr( $subscribe_field_id ),
+								( ! empty( $data['subscribe_email'] )
+									? 'disabled title="' . esc_attr__( "You're logged in with this email", 'jetpack' ) . '"'
+									: 'title="' . esc_attr__( 'Please fill in this field.', 'jetpack' ) . '"'
+								),
+								
+								( ! empty( $data['subscribe_email'] )
+									? sprintf( esc_attr__( 'Subscribe with %s', 'jetpack' ), esc_attr( $data['subscribe_email'] ) )
+									: ''
+								)
+							);
+								/>',
+								( ! empty( $classes['email_field'] )
+									? 'class="' . esc_attr( $classes['email_field'] ) . '"'
+									: ''
+								),
+								( ! empty( $styles['email_field'] )
+    ? esc_attr( $styles['email_field'] )
+    : 'width: 95%; padding: 1px 10px; opacity: 1; color: #333; background-color: #f9f9f9; border: 1px solid #ccc;'
+),
 								esc_attr( $data['subscribe_placeholder'] ),
 								esc_attr( $data['subscribe_email'] ),
 								esc_attr( $subscribe_field_id ),

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/subscriptions.php
@@ -820,7 +820,7 @@ function render_for_website( $data, $classes, $styles ) {
 							>
 								<?php echo esc_html( $data['subscribe_placeholder'] ); ?>
 							</label>
-							<?php													
+							<?php
 							printf(
 								'<input
 									required="required"
@@ -833,7 +833,6 @@ function render_for_website( $data, $classes, $styles ) {
 									value="%4$s"
 									id="%5$s"
 									%6$s
-									aria-label="%7$s"
 								/>',
 								( ! empty( $classes['email_field'] )
 									? 'class="' . esc_attr( $classes['email_field'] ) . '"'
@@ -841,31 +840,8 @@ function render_for_website( $data, $classes, $styles ) {
 								),
 								( ! empty( $styles['email_field'] )
 									? esc_attr( $styles['email_field'] )
-									: 'width: 95%; padding: 1px 10px; opacity: 1; color: #333; background-color: #f9f9f9; border: 1px solid #ccc;'
+									: 'width: 95%; padding: 1px 10px'
 								),
-								
-								( ! empty( $data['subscribe_email'] ) ? '' : esc_attr( $data['subscribe_placeholder'] ) ),
-								esc_attr( $data['subscribe_email'] ),
-								esc_attr( $subscribe_field_id ),
-								( ! empty( $data['subscribe_email'] )
-									? 'disabled title="' . esc_attr__( "You're logged in with this email", 'jetpack' ) . '"'
-									: 'title="' . esc_attr__( 'Please fill in this field.', 'jetpack' ) . '"'
-								),
-								
-								( ! empty( $data['subscribe_email'] )
-									? sprintf( esc_attr__( 'Subscribe with %s', 'jetpack' ), esc_attr( $data['subscribe_email'] ) )
-									: ''
-								)
-							);
-								/>',
-								( ! empty( $classes['email_field'] )
-									? 'class="' . esc_attr( $classes['email_field'] ) . '"'
-									: ''
-								),
-								( ! empty( $styles['email_field'] )
-    ? esc_attr( $styles['email_field'] )
-    : 'width: 95%; padding: 1px 10px; opacity: 1; color: #333; background-color: #f9f9f9; border: 1px solid #ccc;'
-),
 								esc_attr( $data['subscribe_placeholder'] ),
 								esc_attr( $data['subscribe_email'] ),
 								esc_attr( $subscribe_field_id ),


### PR DESCRIPTION
Fixes #45532

## Proposed changes

Adds a `jetpack_forms_email_show_actions` filter option (default: `true`) to
`Feedback_Email_Renderer::build_email_content()` that controls whether the
"View in Dashboard" and "Mark as Spam" action buttons are included in contact
form notification emails.

Previously, these buttons were always injected into notification emails after
the Jetpack 15.1.1 update. This caused dashboard URLs to appear in email
replies when site owners forwarded or replied to form notifications

## Testing instructions

1. Set up a Jetpack-connected site with a Contact Form block
2. Submit the form and verify action buttons appear in the notification email (default behavior unchanged)
3. Run `wp option update jetpack_forms_email_show_actions 0` in WP-CLI
4. Submit the form again — "View in Dashboard" and "Mark as Spam" buttons should no longer appear in the email
5. Run `wp option update jetpack_forms_email_show_actions 1` to restore default

## Does this pull request change what data or activity we track or use?

No. This PR only adds a WordPress option flag to conditionally suppress
action buttons in outbound emails. No new data is tracked or stored.