### PR TITLE
ci: Add a check for valid mirror repos

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -756,7 +756,7 @@ jobs:
     name: Mirror repo check
     runs-on: ubuntu-latest
     needs: changed_files
-    if: github.event_name == 'pull_request' && needs.changed_files.projectcomposerjsons == 'true'
+    if: github.event_name == 'pull_request' && needs.changed_files.outputs.projectcomposerjsons == 'true'
     timeout-minutes: 5  # 2026-04-16: Should just be a minute or two.
     steps:
       # We don't need full git history, but we do need everything up to the merge-base.

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -78,6 +78,9 @@ jobs:
       # Whether any auto-updated Phan stub files were changed.
       phanstubs: ${{ steps.filter.outputs.phanstubs == 'true' }}
 
+      # Whether any project composer.json files were changed (for the mirror-repos check).
+      projectcomposerjsons: ${{ steps.filter.outputs.projectcomposerjsons == 'true' }}
+
     steps:
       - if: github.event_name == 'pull_request'
         uses: actions/checkout@v6
@@ -202,6 +205,8 @@ jobs:
             phanstubs:
               # If auto-generated Phan stub files are changed, we may want to post a warning to the PR.
               - '.phan/stubs/**'
+            projectcomposerjsons:
+              - 'projects/*/*/composer.json'
 
       - if: github.event_name == 'pull_request'
         id: filterPHP
@@ -746,3 +751,46 @@ jobs:
             echo "::error::Phan baselines have changed (good job!). Run \`jetpack phan --update-baseline ${PROJECTS[*]}\` to update them."
           fi
           exit 1
+
+  mirror_repos:
+    name: Mirror repo check
+    runs-on: ubuntu-latest
+    needs: changed_files
+    if: github.event_name == 'pull_request' && needs.changed_files.projectcomposerjsons == 'true'
+    timeout-minutes: 5  # 2026-04-16: Should just be a minute or two.
+    steps:
+      # We don't need full git history, but we do need everything up to the merge-base.
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 10
+      - uses: ./.github/actions/deepen-to-merge-base
+      - name: Check mirrors
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          MBASE=$( git merge-base "$BASE" "$HEAD" )
+          EXIT=0
+          for f in $( git -c core.quotepath=off diff --name-only "$BASE...$HEAD" -- 'projects/*/*/composer.json' ); do
+            if [[ ! -f "$f" ]]; then
+              echo "$f: File was deleted, so it has no mirror"
+              continue
+            fi
+
+            OLDMIRROR=$( { git show "$MBASE:$f" 2>/dev/null || true; } | jq -r '.extra["mirror-repo"] // empty' )
+            NEWMIRROR=$( jq -r '.extra["mirror-repo"] // empty' "$f" )
+            echo "$f: old version has mirror $OLDMIRROR, new has mirror $NEWMIRROR"
+            if [[ -z "$NEWMIRROR" ]]; then
+              echo "$f: No mirror repo in current version"
+            elif [[ "$NEWMIRROR" = "$OLDMIRROR" ]]; then
+              echo "$f: Mirror repo $NEWMIRROR is unchanged"
+            else
+              echo "$f: Mirror changed from ${OLDMIRROR:-none} → $NEWMIRROR"
+              LINE=$(jq --stream 'if length == 1 then .[0][:-1] else .[0] end | if . == ["extra","mirror-repo"] then input_line_number else empty end' "$f" | head -n 1)
+              if ! CIERRORLINE=" file=$f,line=$LINE" tools/audit-mirror-repos.sh "$NEWMIRROR"; then
+                EXIT=1
+              fi
+            fi
+          done
+          exit "$EXIT"

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -756,7 +756,7 @@ jobs:
     name: Mirror repo check
     runs-on: ubuntu-latest
     needs: changed_files
-    if: github.event_name == 'pull_request' && needs.changed_files.outputs.projectcomposerjsons == 'true'
+    if: github.event_name == 'pull_request' && needs.changed_files.outputs.projectcomposerjsons == 'true' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     timeout-minutes: 5  # 2026-04-16: Should just be a minute or two.
     steps:
       # We don't need full git history, but we do need everything up to the merge-base.

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -769,7 +769,7 @@ jobs:
         env:
           BASE: ${{ github.event.pull_request.base.sha }}
           HEAD: ${{ github.event.pull_request.head.sha }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.API_TOKEN_GITHUB }}
         run: |
           MBASE=$( git merge-base "$BASE" "$HEAD" )
           EXIT=0

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -769,6 +769,7 @@ jobs:
         env:
           BASE: ${{ github.event.pull_request.base.sha }}
           HEAD: ${{ github.event.pull_request.head.sha }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           MBASE=$( git merge-base "$BASE" "$HEAD" )
           EXIT=0

--- a/tools/audit-mirror-repos.sh
+++ b/tools/audit-mirror-repos.sh
@@ -10,9 +10,11 @@ BASE=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 # Print help and exit.
 function usage {
 	cat <<-EOH
-		usage: $0 [-q]
+		usage: $0 [-q] [repo]
 
 		Check that all mirror repos are configured correctly.
+
+		If passed an argument, checks only that repo.
 	EOH
 	exit 1
 }
@@ -35,7 +37,7 @@ function err {
 	fi
 	echo "  ❌ $*$S"
 	if [[ -n "$CI" ]]; then
-		echo "::error::$* in $repo"
+		echo "::error${CIERRORLINE}::$* in $repo"
 	fi
 }
 
@@ -81,12 +83,27 @@ fi
 DESC_RE1='^\[READ ONLY\] '
 DESC_RE2=' This repository is a mirror([,;] f|\. F)or issue tracking and development,? (go|head) (to:?|here:) https://github\.com/[Aa]utomattic/[Jj]etpack/?\.?$'
 
+if [[ -n "$1" ]]; then
+	REPOS="$1"
+else
+	REPOS=$( jq -r '.extra["mirror-repo"] // empty' projects/*/*/composer.json | sort -u )
+fi
+
 cd "$BASE"
-for repo in $( jq -r '.extra["mirror-repo"] // empty' projects/*/*/composer.json | sort -u ); do
+for repo in $REPOS; do
 
 	info ""
 	info "$repo:"
-	JSON=$( gh api "/repos/$repo" || die "Failed to fetch data for $repo" )
+	if ! JSON=$( gh api "/repos/$repo" ); then
+		if jq -e '.status == 404 or .status == "404"' <<<"$JSON" &>/dev/null; then
+			err "Repo is not found"
+		elif jq -e '.message' <<<"$JSON" &>/dev/null; then
+			err "Failed to fetch data: $( jq -e '.message' <<<"$JSON" )"
+		else
+			err "Failed to fetch data"
+		fi
+		continue
+	fi
 
 	D=$( jq -r '.description' <<<"$JSON" )
 	if [[ "$D" =~ $DESC_RE1 ]]; then
@@ -101,23 +118,37 @@ for repo in $( jq -r '.extra["mirror-repo"] // empty' projects/*/*/composer.json
 	elif [[ "$D" =~ $DESC_RE2 ]]; then
 		ok "Description has reference to the monorepo"
 	else
-		err "Description does not have the standard reference to the monorepo"
+		err "Description does not have the standard reference to the monorepo: \"This repository is a mirror; for issue tracking and development head here: https://github.com/automattic/jetpack\""
 		info "    $D"
 	fi
 
-	check '.visibility' '"public"' "Visibility is $( jq -r '.visibility' <<<"$JSON" )"
-	check '.default_branch' '"trunk"' "Default branch is $( jq -r '.default_branch' <<<"$JSON" )"
+	check '.archived' false 'Not archived' 'Repo is archived'
+	check '.disabled' false 'Not disabled' 'Repo is disabled'
+	check '.visibility' '"public"' 'Visibility is public' "Visibility is $( jq -r '.visibility' <<<"$JSON" ), should be public"
+	check '.default_branch' '"trunk"' 'Default branch is trunk' "Default branch is $( jq -r '.default_branch' <<<"$JSON" ), should be trunk"
 	check '.has_issues' false 'Issues disabled' 'Issues not disabled'
 	check '.has_pull_requests' false 'PRs disabled' 'PRs not disabled'
 	check '.has_discussions' false 'Discussions disabled' 'Discussions not disabled'
 	check '.has_projects' false 'Projects disabled' 'Projects not disabled'
 	check '.has_wiki' false 'Wiki disabled' 'Wiki not disabled'
 
-	JSON=$( gh api "/repos/$repo/actions/permissions/fork-pr-contributor-approval" || die "Failed to fetch fork-pr-contributor-approval setting for $repo" )
-	check '.approval_policy' '"all_external_contributors"' 'Actions approval policy set to "All external contributors"' "Actions approval policy set to $( jq -r '.approval_policy' <<<"$JSON" )"
+	JSON=
+	if JSON=$( gh api "/repos/$repo/actions/permissions/fork-pr-contributor-approval" ); then
+		check '.approval_policy' '"all_external_contributors"' 'Actions approval policy set to "All external contributors"' "Actions approval policy set to $( jq -r '.approval_policy' <<<"$JSON" ), should be \"All external contributors\""
+	elif jq -e '.message' <<<"$JSON" &>/dev/null; then
+		err "Failed to fetch fork-pr-contributor-approval setting: $( jq -e '.message' <<<"$JSON" )"
+	else
+		err "Failed to fetch fork-pr-contributor-approval setting"
+	fi
 
-	JSON=$( gh api "/repos/$repo/actions/permissions/workflow" || die "Failed to fetch workflow permissions setting for $repo" )
-	check '.default_workflow_permissions' '"read"' "Actions workflow permissions set to \"$( jq -r '.default_workflow_permissions' <<<"$JSON" )\""
+	JSON=
+	if JSON=$( gh api "/repos/$repo/actions/permissions/workflow" ); then
+		check '.default_workflow_permissions' '"read"' 'Actions workflow permissions set to "read"' "Actions workflow permissions set to \"$( jq -r '.default_workflow_permissions' <<<"$JSON" )\", should be \"read\""
+	elif jq -e '.message' <<<"$JSON" &>/dev/null; then
+		err "Failed to fetch workflow permissions setting: $( jq -e '.message' <<<"$JSON" )"
+	else
+		err "Failed to fetch workflow permissions setting"
+	fi
 done
 
 if [[ -z "$QUIET" ]]; then

--- a/tools/audit-mirror-repos.sh
+++ b/tools/audit-mirror-repos.sh
@@ -81,7 +81,7 @@ if ! gh auth status --hostname github.com &> /dev/null; then
 fi
 
 DESC_RE1='^\[READ ONLY\] '
-DESC_RE2=' This repository is a mirror([,;] f|\. F)or issue tracking and development,? (go|head) (to:?|here:) https://github\.com/[Aa]utomattic/[Jj]etpack/?\.?$'
+DESC_RE2=' This repository is a mirror([,;] f|\. F)or issue tracking and development,? (go|head) (to:?|here:) https://github\.com/[Aa]utomattic/[Jj]etpack/?\.?\s*$'
 
 if [[ -n "$1" ]]; then
 	REPOS="$1"


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
Adding a project with an invalid mirror repo breaks the "push to mirrors" job on trunk. We should have a check on the PR that flags invalid mirrors being added so they get set up before the merge.

Since we already have `tools/audit-mirror-repos.sh`, probably we can take advantage of that to check that it not only exists but also is configured correctly.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p1776347302143589/1776332161.446949-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Make a PR based on this one that changes a mirror repo, ideally to one that has an error. Does it get flagged in CI?
  * [x] https://github.com/Automattic/jetpack/actions/runs/24843385504?pr=48268