### PR TITLE
wpcomsh: bump at-pressable-podcasting to 2.0.6

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-wpcomsh-podcasting-tracks
+++ b/projects/plugins/wpcomsh/changelog/update-wpcomsh-podcasting-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Podcasting: Add Tracks instrumentation for publishing events on Atomic/Pressable sites.

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"php": ">=8.1",
-		"automattic/at-pressable-podcasting": "^2.0.5",
+		"automattic/at-pressable-podcasting": "^2.0.6",
 		"automattic/custom-fonts": "^3.0",
 		"automattic/custom-fonts-typekit": "^2.0",
 		"automattic/text-media-widget-styles": "^2.0",

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -4,27 +4,27 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a7cd1b2d4d28b9decbe21a0e6b47e8d9",
+    "content-hash": "4cd43737267f38b079932925de9a1ab8",
     "packages": [
         {
             "name": "automattic/at-pressable-podcasting",
-            "version": "v2.0.5",
+            "version": "v2.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/automattic/at-pressable-podcasting.git",
-                "reference": "c512aa27b2c33aee33bc024177c17f2745c52dfa"
+                "reference": "768ce866bc1b7aa926ef22f705bb3ca9d6e905cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/automattic/at-pressable-podcasting/zipball/c512aa27b2c33aee33bc024177c17f2745c52dfa",
-                "reference": "c512aa27b2c33aee33bc024177c17f2745c52dfa",
+                "url": "https://api.github.com/repos/automattic/at-pressable-podcasting/zipball/768ce866bc1b7aa926ef22f705bb3ca9d6e905cb",
+                "reference": "768ce866bc1b7aa926ef22f705bb3ca9d6e905cb",
                 "shasum": ""
             },
             "type": "wordpress-plugin",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "time": "2025-11-24T21:07:37+00:00"
+            "time": "2026-04-23T14:42:02+00:00"
         },
         {
             "name": "automattic/block-delimiter",


### PR DESCRIPTION
Bumps the `automattic/at-pressable-podcasting` dependency so we pick up the Tracks instrumentation added in Automattic/at-pressable-podcasting#27, released as v2.0.6.

This brings Atomic/Pressable parity with Simple for the three podcast publishing Tracks events (`wpcom_podcast_episode_published`, `wpcom_podcast_show_launched`, `wpcom_podcast_media_uploaded`).

## Proposed changes:

* Bump `automattic/at-pressable-podcasting` from `^2.0.5` to `^2.0.6` in wpcomsh.
* Refresh `composer.lock`.

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you will see a generated comment below with a script to run)?

## Does this pull request change what data or activity we track or use?

no

## Testing instructions:

The feature was verified in the source repo; this PR just pulls the release in.

1. On an Atomic/Pressable sandbox with the new wpcomsh build, publish a podcast episode (audio or video).
2. Confirm `wpcom_podcast_episode_published` / `wpcom_podcast_show_launched` / `wpcom_podcast_media_uploaded` fire via the Tracks dispatcher without fatals.
