### PR TITLE
CI: Prune tool-setup usage

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Setup tools
         uses: ./.github/actions/tool-setup
+        with:
+          php: false
 
       # Required for list-changed-projects.sh
       - name: Install monorepo

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -393,13 +393,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: github.event_name == 'push' || needs.changed_files.outputs.js == 'true' || needs.changed_files.outputs.misc_js == 'true'
-    timeout-minutes: 10  # 2025-11-06: Runs now take ~5 minutes due to now installing all php/js deps to ensure valid linting.
+    timeout-minutes: 10  # 2025-11-06: Runs now take ~5 minutes due to now installing all JS deps to ensure valid linting.
 
     steps:
       - uses: actions/checkout@v6
 
       - name: Setup tools
         uses: ./.github/actions/tool-setup
+        with:
+          php: false
 
       - name: Monorepo pnpm install
         run: pnpm install
@@ -428,6 +430,8 @@ jobs:
 
       - name: Setup tools
         uses: ./.github/actions/tool-setup
+        with:
+          php: false
 
       - name: Monorepo pnpm install
         run: pnpm install
@@ -453,6 +457,8 @@ jobs:
 
       - name: Setup tools
         uses: ./.github/actions/tool-setup
+        with:
+          php: false
 
       - name: Monorepo pnpm install
         run: pnpm install
@@ -658,6 +664,8 @@ jobs:
       - uses: actions/checkout@v6
       - name: Setup tools
         uses: ./.github/actions/tool-setup
+        with:
+          php: false
       - name: Pnpm install
         run: pnpm install
       - name: Run type checking

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -375,6 +375,8 @@ jobs:
 
       - name: Setup tools
         uses: ./.github/actions/tool-setup
+        with:
+          php: false
 
       - name: Monorepo install
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -378,6 +378,12 @@ jobs:
         with:
           php: false
 
+      - name: Monorepo install
+        run: |
+          echo "::group::Pnpm"
+          pnpm install
+          echo "::endgroup::"
+
       - name: Detect changed projects
         id: changed
         run: |
@@ -386,13 +392,6 @@ jobs:
 
           ANY=$( jq --argjson changed "$CHANGED" --argjson projects "$PROJECTS" -n '$changed | with_entries( select( $projects[ .key ] ) ) | any' )
           echo "any=${ANY}" >> "$GITHUB_OUTPUT"
-
-      - name: Monorepo install
-        if: steps.changed.outputs.any == 'true'
-        run: |
-          echo "::group::Pnpm"
-          pnpm install
-          echo "::endgroup::"
 
       - name: Install playwright
         if: steps.changed.outputs.any == 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -378,12 +378,6 @@ jobs:
         with:
           php: false
 
-      - name: Monorepo install
-        run: |
-          echo "::group::Pnpm"
-          pnpm install
-          echo "::endgroup::"
-
       - name: Detect changed projects
         id: changed
         run: |
@@ -392,6 +386,13 @@ jobs:
 
           ANY=$( jq --argjson changed "$CHANGED" --argjson projects "$PROJECTS" -n '$changed | with_entries( select( $projects[ .key ] ) ) | any' )
           echo "any=${ANY}" >> "$GITHUB_OUTPUT"
+
+      - name: Monorepo install
+        if: steps.changed.outputs.any == 'true'
+        run: |
+          echo "::group::Pnpm"
+          pnpm install
+          echo "::endgroup::"
 
       - name: Install playwright
         if: steps.changed.outputs.any == 'true'

--- a/.github/workflows/wpcloud.yml
+++ b/.github/workflows/wpcloud.yml
@@ -36,11 +36,6 @@ jobs:
         with:
           # Match PHP version on WP Cloud so the right vendor packages get installed.
           php: 8.3
-      - name: Monorepo install
-        run: |
-          echo "::group::Pnpm"
-          pnpm install
-          echo "::endgroup::"
       - name: Detect if wpcomsh has changed
         id: changed
         run: |
@@ -48,6 +43,12 @@ jobs:
 
           WPCOMSH_CHANGED="$(jq --argjson changed "$CHANGED" -n '$changed | has( "plugins/wpcomsh" ) ')"
           echo "wpcomsh=${WPCOMSH_CHANGED}" >> "$GITHUB_OUTPUT"
+      - name: Monorepo install
+        if: steps.changed.outputs.wpcomsh == 'true'
+        run: |
+          echo "::group::Pnpm"
+          pnpm install
+          echo "::endgroup::"
       - name: Build wpcomsh
         if: steps.changed.outputs.wpcomsh == 'true'
         run: |

--- a/.github/workflows/wpcloud.yml
+++ b/.github/workflows/wpcloud.yml
@@ -36,6 +36,11 @@ jobs:
         with:
           # Match PHP version on WP Cloud so the right vendor packages get installed.
           php: 8.3
+      - name: Monorepo install
+        run: |
+          echo "::group::Pnpm"
+          pnpm install
+          echo "::endgroup::"
       - name: Detect if wpcomsh has changed
         id: changed
         run: |
@@ -43,12 +48,6 @@ jobs:
 
           WPCOMSH_CHANGED="$(jq --argjson changed "$CHANGED" -n '$changed | has( "plugins/wpcomsh" ) ')"
           echo "wpcomsh=${WPCOMSH_CHANGED}" >> "$GITHUB_OUTPUT"
-      - name: Monorepo install
-        if: steps.changed.outputs.wpcomsh == 'true'
-        run: |
-          echo "::group::Pnpm"
-          pnpm install
-          echo "::endgroup::"
       - name: Build wpcomsh
         if: steps.changed.outputs.wpcomsh == 'true'
         run: |


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
This is an exploration of tweaks to the `tool-setup` action and adjacent tasks. The script itself is fairly lean, but we can be more selective in when we install things. AI had a few suggestions, so I poked at them:
* `php: false`: this saves ~15s when we use it, and this PR adds it to a few jobs
* `node: false`: this saves ~10s when we use it, but we already use it where we can
* `imagick`: extension compilation can take a while, but the current PHP installs come with it precompiled, so no savings here
* "Monorepo install": sometimes we run this even when it turns out we won't be doing any work (storybook, WP Cloud), but while it looks like it'd save us some time, it'd actually end up running `jetpack dependencies` which would run `pnpm install`, so no savings here

In the end, this probably won't save much if any wall time, but shouldn't hurt.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Is CI still happy?