### PR TITLE
CI: Use per-PHP-version cache

### DIFF
--- a/.github/actions/tool-setup/action.yml
+++ b/.github/actions/tool-setup/action.yml
@@ -81,9 +81,9 @@ runs:
       uses: actions/cache@v5
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        key: ${{ runner.os }}-composer-php${{ steps.versions.outputs.php-version }}-${{ hashFiles('**/composer.lock') }}
         restore-keys: |
-          ${{ runner.os }}-composer-
+          ${{ runner.os }}-composer-php${{ steps.versions.outputs.php-version }}-
 
     - name: Setup pnpm
       if: steps.versions.outputs.node-version != 'false'


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
The cache was shared across PHP versions, which probably means we miss the cache a lot. That said, it probably won't save much time.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

The first run should take a bit longer, but once the caches are populated, maybe it'll be quicker. Perhaps this can be confirmed with a second commit in this branch.