### PR TITLE
CI: Skip monorepo key when checking for non-mirrored require-dev packages

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -146,6 +146,7 @@ jobs:
 
           echo "Checking for non-mirrored require-dev packages, in case this is testing a release branch"
           for SLUG in $( jq -r 'keys[]' <<<"$CHANGED" ); do
+            [[ "$SLUG" == "monorepo" ]] && continue
             PKGS=()
             readarray -t PKGS < <( jq -r '.extra["non-mirrored-require-dev"] // empty | .[] | . += "=@dev"' "projects/$SLUG/composer.json" )
             if [[ ${#PKGS[@]} -gt 0 ]]; then


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
I noticed this in the `test.yml` workflow logs:
`jq: error: Could not open file projects/monorepo/composer.json: No such file or directory`

Since the `jq` call was in a process substitution, it didn't break anything, but let's handle it better with a `continue`.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Check the "Composer Install" step of a PHP Tests run. The error should no longer appear.