### PR TITLE
Abilities API: register jetpack-modules (get-modules, set-module-status)

### DIFF
--- a/projects/plugins/jetpack/changelog/add-jetpack-modules-abilities
+++ b/projects/plugins/jetpack/changelog/add-jetpack-modules-abilities
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Abilities API: register jetpack-modules/get-modules and jetpack-modules/set-module-status for WP 6.9+.
+Abilities API: register jetpack/get-modules and jetpack/set-module-status for WP 6.9+.

--- a/projects/plugins/jetpack/changelog/add-jetpack-modules-abilities
+++ b/projects/plugins/jetpack/changelog/add-jetpack-modules-abilities
@@ -1,4 +1,4 @@
 Significance: minor
-Type: added
+Type: enhancement
 
 Abilities API: register jetpack-modules/get-modules and jetpack-modules/set-module-status for WP 6.9+.

--- a/projects/plugins/jetpack/changelog/add-jetpack-modules-abilities
+++ b/projects/plugins/jetpack/changelog/add-jetpack-modules-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Abilities API: register jetpack-modules/get-modules and jetpack-modules/set-module-status for WP 6.9+.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -753,6 +753,9 @@ class Jetpack {
 		// Add 5-star
 		add_filter( 'plugin_row_meta', array( $this, 'add_5_star_review_link' ), 10, 2 );
 		add_action( 'init', array( Deprecate::class, 'instance' ) );
+
+		// Register Jetpack module management abilities (WordPress Abilities API, WP 6.9+).
+		\Automattic\Jetpack\Plugin\Abilities\Modules_Abilities::init();
 	}
 
 	/**

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -56,6 +56,7 @@
 		"automattic/jetpack-sync": "@dev",
 		"automattic/jetpack-videopress": "@dev",
 		"automattic/jetpack-waf": "@dev",
+		"automattic/jetpack-wp-abilities": "@dev",
 		"automattic/woocommerce-analytics": "^0.16"
 	},
 	"require-dev": {

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -3545,6 +3545,65 @@
             }
         },
         {
+            "name": "automattic/jetpack-wp-abilities",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/wp-abilities",
+                "reference": "d38d63604cbefe504f12a74a956502a648fdf521"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "brain/monkey": "^2.6.2",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-wp-abilities",
+                "changelogger": {
+                    "link-template": "https://github.com/automattic/jetpack-wp-abilities/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                },
+                "textdomain": "jetpack-wp-abilities",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-registrar.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Shared utilities for registering abilities with the WordPress Abilities API from Jetpack packages and plugins.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "automattic/jetpack-wp-build-polyfills",
             "version": "dev-trunk",
             "dist": {
@@ -5666,6 +5725,7 @@
         "automattic/jetpack-sync": 20,
         "automattic/jetpack-videopress": 20,
         "automattic/jetpack-waf": 20,
+        "automattic/jetpack-wp-abilities": 20,
         "automattic/patchwork-redefine-exit": 20,
         "automattic/phpunit-select-config": 20
     },

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5c48ed06727e20b7215499494f079762",
+    "content-hash": "ff5646ec92656db4a5e84144887bd6ab",
     "packages": [
         {
             "name": "automattic/block-delimiter",
@@ -3550,13 +3550,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/wp-abilities",
-                "reference": "d38d63604cbefe504f12a74a956502a648fdf521"
+                "reference": "e71e43ab54aaf244b0cb2e29999da393164021f5"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"

--- a/projects/plugins/jetpack/src/abilities/class-modules-abilities.php
+++ b/projects/plugins/jetpack/src/abilities/class-modules-abilities.php
@@ -149,10 +149,10 @@ class Modules_Abilities extends Registrar {
 						'idempotent'  => true,
 					),
 					'show_in_rest' => true,
-					'mcp' => array(
-					    'public' => true,
-					    'type' => 'tool', // default is already "tool", but can be explicit.
-					)
+					'mcp'          => array(
+						'public' => true,
+						'type'   => 'tool', // default is already "tool", but can be explicit.
+					),
 				),
 			),
 		);
@@ -241,10 +241,10 @@ class Modules_Abilities extends Registrar {
 
 		$active_filter  = array_key_exists( 'active', $input ) && is_bool( $input['active'] ) ? $input['active'] : null;
 		$feature_filter = isset( $input['feature'] ) && is_string( $input['feature'] ) && '' !== $input['feature']
-			? mb_strtolower( $input['feature'] )
+			? strtolower( $input['feature'] )
 			: null;
 		$search_filter  = isset( $input['search'] ) && is_string( $input['search'] ) && '' !== $input['search']
-			? mb_strtolower( $input['search'] )
+			? strtolower( $input['search'] )
 			: null;
 
 		$out = array();
@@ -259,15 +259,15 @@ class Modules_Abilities extends Registrar {
 			}
 
 			if ( null !== $feature_filter ) {
-				$features_lower = array_map( 'mb_strtolower', $summary['feature'] );
+				$features_lower = array_map( 'strtolower', $summary['feature'] );
 				if ( ! in_array( $feature_filter, $features_lower, true ) ) {
 					continue;
 				}
 			}
 
 			if ( null !== $search_filter ) {
-				$haystack = mb_strtolower( $summary['slug'] . ' ' . $summary['name'] . ' ' . $summary['description'] );
-				if ( false === mb_strpos( $haystack, $search_filter ) ) {
+				$haystack = strtolower( $summary['slug'] . ' ' . $summary['name'] . ' ' . $summary['description'] );
+				if ( false === strpos( $haystack, $search_filter ) ) {
 					continue;
 				}
 			}

--- a/projects/plugins/jetpack/src/abilities/class-modules-abilities.php
+++ b/projects/plugins/jetpack/src/abilities/class-modules-abilities.php
@@ -1,0 +1,362 @@
+<?php
+/**
+ * Jetpack Modules Abilities Registration
+ *
+ * Registers Jetpack module management abilities with the WordPress Abilities API.
+ *
+ * @package automattic/jetpack
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9; suppressions needed for older-WP compatibility runs.
+
+namespace Automattic\Jetpack\Plugin\Abilities;
+
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use Jetpack;
+
+/**
+ * Registers Jetpack module management abilities with the WordPress Abilities API.
+ *
+ * Exposes a filtered read (`get-modules`) and a declarative state-setter
+ * (`set-module-status`) so AI agents can discover and toggle Jetpack modules
+ * through the standard `wp-abilities/v1` REST surface.
+ */
+class Modules_Abilities extends Registrar {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_slug(): string {
+		return 'jetpack-modules';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_definition(): array {
+		return array(
+			// "Jetpack" is a product name and should not be translated.
+			'label'       => 'Jetpack Modules',
+			'description' => __( 'Abilities for discovering and toggling Jetpack modules.', 'jetpack' ),
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_abilities(): array {
+		$module_schema = array(
+			'type'       => 'object',
+			'properties' => array(
+				'slug'                     => array( 'type' => 'string' ),
+				'name'                     => array( 'type' => 'string' ),
+				'description'              => array( 'type' => 'string' ),
+				'active'                   => array( 'type' => 'boolean' ),
+				'sort'                     => array( 'type' => 'integer' ),
+				'feature'                  => array(
+					'type'  => 'array',
+					'items' => array( 'type' => 'string' ),
+				),
+				'plan_classes'             => array(
+					'type'  => 'array',
+					'items' => array( 'type' => 'string' ),
+				),
+				'requires_connection'      => array( 'type' => 'boolean' ),
+				'requires_user_connection' => array( 'type' => 'boolean' ),
+				'auto_activate'            => array( 'type' => 'string' ),
+			),
+		);
+
+		return array(
+			'jetpack-modules/get-modules'       => array(
+				'label'               => __( 'Get Jetpack modules', 'jetpack' ),
+				'description'         => __( 'Return zero or more Jetpack modules as an array. Each element has { slug, name, description, active, sort, feature, plan_classes, requires_connection, requires_user_connection, auto_activate }. Combine slug / active / feature / search filters to narrow the list. When slug is provided and unknown, the result is an empty array (not an error). Use this before calling jetpack-modules/set-module-status to enumerate legal slugs.', 'jetpack' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'default'              => array(),
+					'properties'           => array(
+						'slug'    => array(
+							'type'        => 'string',
+							'description' => __( 'Return a single module by slug. Unknown slugs yield an empty array.', 'jetpack' ),
+							'minLength'   => 1,
+						),
+						'active'  => array(
+							'type'        => 'boolean',
+							'description' => __( 'When set, only return modules whose current active state matches this value.', 'jetpack' ),
+						),
+						'feature' => array(
+							'type'        => 'string',
+							'description' => __( 'Case-insensitive match against a module\'s feature tag (e.g. "Recommended", "Security", "Performance").', 'jetpack' ),
+							'minLength'   => 1,
+						),
+						'search'  => array(
+							'type'        => 'string',
+							'description' => __( 'Case-insensitive substring match against the module name, slug, and description.', 'jetpack' ),
+							'minLength'   => 1,
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'  => 'array',
+					'items' => $module_schema,
+				),
+				'execute_callback'    => array( __CLASS__, 'get_modules' ),
+				'permission_callback' => array( __CLASS__, 'can_view_modules' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+
+			'jetpack-modules/set-module-status' => array(
+				'label'               => __( 'Set Jetpack module status', 'jetpack' ),
+				'description'         => __( 'Set a Jetpack module\'s active state. Idempotent — setting a module to its current state returns changed=false. Returns { slug, active, changed }. Call jetpack-modules/get-modules first to enumerate valid slugs. Modules requiring a Jetpack connection or a paid plan may fail with jetpack_modules_activate_failed; the message indicates the next step.', 'jetpack' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'required'             => array( 'slug', 'active' ),
+					'properties'           => array(
+						'slug'   => array(
+							'type'        => 'string',
+							'description' => __( 'The Jetpack module slug (e.g. "stats", "sso", "sharedaddy").', 'jetpack' ),
+							'minLength'   => 1,
+						),
+						'active' => array(
+							'type'        => 'boolean',
+							'description' => __( 'Desired active state. true activates the module; false deactivates it.', 'jetpack' ),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'slug'    => array( 'type' => 'string' ),
+						'active'  => array( 'type' => 'boolean' ),
+						'changed' => array( 'type' => 'boolean' ),
+					),
+				),
+				'execute_callback'    => array( __CLASS__, 'set_module_status' ),
+				'permission_callback' => array( __CLASS__, 'can_manage_modules' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+		);
+	}
+
+	/**
+	 * Permission check: can the current user read module listings?
+	 *
+	 * Mirrors the capability used by the Jetpack admin page so subscribers and
+	 * contributors are denied.
+	 */
+	public static function can_view_modules(): bool {
+		return current_user_can( 'jetpack_admin_page' );
+	}
+
+	/**
+	 * Permission check: can the current user toggle modules?
+	 */
+	public static function can_manage_modules(): bool {
+		return current_user_can( 'jetpack_manage_modules' )
+			&& current_user_can( 'jetpack_activate_modules' );
+	}
+
+	/**
+	 * Build the high-signal summary shape used by `get-modules`.
+	 *
+	 * Adapts the raw `Jetpack::get_module()` array down to the fields agents
+	 * actually consume — dropping internal bookkeeping like `module_tags`,
+	 * changelog URLs, and file paths. Applies the site's current locale to
+	 * `name` and `description` so agent-facing output mirrors what a user
+	 * would see in the admin UI.
+	 *
+	 * @param string $slug      Module slug.
+	 * @param bool   $is_active Whether the module is currently active. Passed in to avoid
+	 *                          O(N) calls to the `jetpack_active_modules` filter in a list loop.
+	 * @return array|null Compact module entry, or null when the module has no info.
+	 */
+	private static function summarize_module( $slug, $is_active ) {
+		$mod = Jetpack::get_module( $slug );
+		if ( ! is_array( $mod ) ) {
+			return null;
+		}
+
+		$i18n = function_exists( 'jetpack_get_module_i18n' ) ? jetpack_get_module_i18n( $slug ) : array();
+		$name = isset( $i18n['name'] ) ? (string) $i18n['name'] : ( isset( $mod['name'] ) ? (string) $mod['name'] : $slug );
+		$desc = isset( $i18n['description'] ) ? (string) $i18n['description'] : ( isset( $mod['description'] ) ? (string) $mod['description'] : '' );
+
+		return array(
+			'slug'                     => $slug,
+			'name'                     => $name,
+			'description'              => $desc,
+			'active'                   => $is_active,
+			'sort'                     => isset( $mod['sort'] ) ? (int) $mod['sort'] : 10,
+			'feature'                  => isset( $mod['feature'] ) && is_array( $mod['feature'] ) ? array_values( $mod['feature'] ) : array(),
+			'plan_classes'             => isset( $mod['plan_classes'] ) && is_array( $mod['plan_classes'] ) ? array_values( $mod['plan_classes'] ) : array(),
+			'requires_connection'      => ! empty( $mod['requires_connection'] ),
+			'requires_user_connection' => ! empty( $mod['requires_user_connection'] ),
+			'auto_activate'            => isset( $mod['auto_activate'] ) ? (string) $mod['auto_activate'] : 'No',
+		);
+	}
+
+	/**
+	 * Consolidated read callback. Returns an array of module summaries.
+	 *
+	 * When `slug` is provided, returns a 0- or 1-element array; unknown slugs
+	 * yield an empty array rather than a `WP_Error` so the shape is uniform.
+	 *
+	 * @param array|null $input Input matching the ability's input_schema.
+	 * @return array
+	 */
+	public static function get_modules( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		// Fetch the active-slug map once per call — `Jetpack::is_module_active()` fires the
+		// user-extensible `jetpack_active_modules` filter on each call, so looking up
+		// active state per-module in a loop amplifies any hook cost by N.
+		$active_map = array_flip( Jetpack::get_active_modules() );
+
+		if ( isset( $input['slug'] ) && is_string( $input['slug'] ) && '' !== $input['slug'] ) {
+			if ( ! Jetpack::is_module( $input['slug'] ) ) {
+				return array();
+			}
+			$summary = self::summarize_module( $input['slug'], isset( $active_map[ $input['slug'] ] ) );
+			return null === $summary ? array() : array( $summary );
+		}
+
+		$active_filter  = array_key_exists( 'active', $input ) && is_bool( $input['active'] ) ? $input['active'] : null;
+		$feature_filter = isset( $input['feature'] ) && is_string( $input['feature'] ) && '' !== $input['feature']
+			? mb_strtolower( $input['feature'] )
+			: null;
+		$search_filter  = isset( $input['search'] ) && is_string( $input['search'] ) && '' !== $input['search']
+			? mb_strtolower( $input['search'] )
+			: null;
+
+		$out = array();
+		foreach ( Jetpack::get_available_modules() as $slug ) {
+			$summary = self::summarize_module( $slug, isset( $active_map[ $slug ] ) );
+			if ( null === $summary ) {
+				continue;
+			}
+
+			if ( null !== $active_filter && $summary['active'] !== $active_filter ) {
+				continue;
+			}
+
+			if ( null !== $feature_filter ) {
+				$features_lower = array_map( 'mb_strtolower', $summary['feature'] );
+				if ( ! in_array( $feature_filter, $features_lower, true ) ) {
+					continue;
+				}
+			}
+
+			if ( null !== $search_filter ) {
+				$haystack = mb_strtolower( $summary['slug'] . ' ' . $summary['name'] . ' ' . $summary['description'] );
+				if ( false === mb_strpos( $haystack, $search_filter ) ) {
+					continue;
+				}
+			}
+
+			$out[] = $summary;
+		}
+
+		usort(
+			$out,
+			static function ( $a, $b ) {
+				if ( $a['sort'] === $b['sort'] ) {
+					return strcmp( $a['slug'], $b['slug'] );
+				}
+				return $a['sort'] <=> $b['sort'];
+			}
+		);
+
+		return $out;
+	}
+
+	/**
+	 * Declarative state-setter callback. Idempotent: returns changed=false
+	 * when the desired state already matches current state.
+	 *
+	 * @param array|null $input Input matching the ability's input_schema.
+	 * @return array|\WP_Error
+	 */
+	public static function set_module_status( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		if ( ! isset( $input['slug'] ) || ! is_string( $input['slug'] ) || '' === $input['slug'] ) {
+			return new \WP_Error(
+				'jetpack_modules_missing_slug',
+				__( 'A module slug is required. Call jetpack-modules/get-modules to enumerate valid slugs.', 'jetpack' )
+			);
+		}
+
+		if ( ! array_key_exists( 'active', $input ) ) {
+			return new \WP_Error(
+				'jetpack_modules_missing_active',
+				__( 'A desired active state (boolean) is required.', 'jetpack' )
+			);
+		}
+		if ( ! is_bool( $input['active'] ) ) {
+			return new \WP_Error(
+				'jetpack_modules_invalid_active',
+				__( 'The active parameter must be a boolean. Strings like "true" / "false" are not accepted.', 'jetpack' )
+			);
+		}
+
+		$slug    = $input['slug'];
+		$desired = $input['active'];
+
+		if ( ! Jetpack::is_module( $slug ) ) {
+			return new \WP_Error(
+				'jetpack_modules_invalid_slug',
+				__( 'Unknown Jetpack module slug. Call jetpack-modules/get-modules to enumerate valid slugs.', 'jetpack' )
+			);
+		}
+
+		$current = Jetpack::is_module_active( $slug );
+
+		if ( $desired === $current ) {
+			return array(
+				'slug'    => $slug,
+				'active'  => $current,
+				'changed' => false,
+			);
+		}
+
+		if ( $desired ) {
+			// Always pass exit=false, redirect=false so the ability runs headless over REST.
+			$ok = Jetpack::activate_module( $slug, false, false );
+			if ( ! $ok ) {
+				return new \WP_Error(
+					'jetpack_modules_activate_failed',
+					__( 'Unable to activate the module. It may require a Jetpack connection or a higher plan. Inspect requires_connection and plan_classes on the module and retry after those preconditions are met.', 'jetpack' )
+				);
+			}
+		} else {
+			$ok = Jetpack::deactivate_module( $slug );
+			if ( ! $ok ) {
+				return new \WP_Error(
+					'jetpack_modules_deactivate_failed',
+					__( 'Unable to deactivate the module.', 'jetpack' )
+				);
+			}
+		}
+
+		return array(
+			'slug'    => $slug,
+			'active'  => $desired,
+			'changed' => true,
+		);
+	}
+}

--- a/projects/plugins/jetpack/src/abilities/class-modules-abilities.php
+++ b/projects/plugins/jetpack/src/abilities/class-modules-abilities.php
@@ -110,6 +110,10 @@ class Modules_Abilities extends Registrar {
 						'idempotent'  => true,
 					),
 					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => true,
+						'type'   => 'tool', // default is already "tool", but can be explicit.
+					),
 				),
 			),
 
@@ -231,12 +235,17 @@ class Modules_Abilities extends Registrar {
 		// active state per-module in a loop amplifies any hook cost by N.
 		$active_map = array_flip( Jetpack::get_active_modules() );
 
+		// Narrow the candidate set up front when `slug` is supplied; remaining
+		// filters (active / feature / search) still apply so combinations like
+		// { slug: 'stats', active: false } correctly return an empty array when
+		// stats is active.
 		if ( isset( $input['slug'] ) && is_string( $input['slug'] ) && '' !== $input['slug'] ) {
 			if ( ! Jetpack::is_module( $input['slug'] ) ) {
 				return array();
 			}
-			$summary = self::summarize_module( $input['slug'], isset( $active_map[ $input['slug'] ] ) );
-			return null === $summary ? array() : array( $summary );
+			$candidate_slugs = array( $input['slug'] );
+		} else {
+			$candidate_slugs = Jetpack::get_available_modules();
 		}
 
 		$active_filter  = array_key_exists( 'active', $input ) && is_bool( $input['active'] ) ? $input['active'] : null;
@@ -248,7 +257,7 @@ class Modules_Abilities extends Registrar {
 			: null;
 
 		$out = array();
-		foreach ( Jetpack::get_available_modules() as $slug ) {
+		foreach ( $candidate_slugs as $slug ) {
 			$summary = self::summarize_module( $slug, isset( $active_map[ $slug ] ) );
 			if ( null === $summary ) {
 				continue;

--- a/projects/plugins/jetpack/src/abilities/class-modules-abilities.php
+++ b/projects/plugins/jetpack/src/abilities/class-modules-abilities.php
@@ -149,6 +149,10 @@ class Modules_Abilities extends Registrar {
 						'idempotent'  => true,
 					),
 					'show_in_rest' => true,
+					'mcp' => array(
+					    'public' => true,
+					    'type' => 'tool', // default is already "tool", but can be explicit.
+					)
 				),
 			),
 		);

--- a/projects/plugins/jetpack/src/abilities/class-modules-abilities.php
+++ b/projects/plugins/jetpack/src/abilities/class-modules-abilities.php
@@ -27,7 +27,7 @@ class Modules_Abilities extends Registrar {
 	 * {@inheritDoc}
 	 */
 	public static function get_category_slug(): string {
-		return 'jetpack-modules';
+		return 'jetpack';
 	}
 
 	/**
@@ -36,8 +36,8 @@ class Modules_Abilities extends Registrar {
 	public static function get_category_definition(): array {
 		return array(
 			// "Jetpack" is a product name and should not be translated.
-			'label'       => 'Jetpack Modules',
-			'description' => __( 'Abilities for discovering and toggling Jetpack modules.', 'jetpack' ),
+			'label'       => 'Jetpack',
+			'description' => __( 'Abilities exposed by the Jetpack plugin.', 'jetpack' ),
 		);
 	}
 
@@ -68,9 +68,9 @@ class Modules_Abilities extends Registrar {
 		);
 
 		return array(
-			'jetpack-modules/get-modules'       => array(
+			'jetpack/get-modules'       => array(
 				'label'               => __( 'Get Jetpack modules', 'jetpack' ),
-				'description'         => __( 'Return zero or more Jetpack modules as an array. Each element has { slug, name, description, active, sort, feature, plan_classes, requires_connection, requires_user_connection, auto_activate }. Combine slug / active / feature / search filters to narrow the list. When slug is provided and unknown, the result is an empty array (not an error). Use this before calling jetpack-modules/set-module-status to enumerate legal slugs.', 'jetpack' ),
+				'description'         => __( 'Return zero or more Jetpack modules as an array. Each element has { slug, name, description, active, sort, feature, plan_classes, requires_connection, requires_user_connection, auto_activate }. Combine slug / active / feature / search filters to narrow the list. When slug is provided and unknown, the result is an empty array (not an error). Use this before calling jetpack/set-module-status to enumerate legal slugs.', 'jetpack' ),
 				'input_schema'        => array(
 					'type'                 => 'object',
 					'default'              => array(),
@@ -117,9 +117,9 @@ class Modules_Abilities extends Registrar {
 				),
 			),
 
-			'jetpack-modules/set-module-status' => array(
+			'jetpack/set-module-status' => array(
 				'label'               => __( 'Set Jetpack module status', 'jetpack' ),
-				'description'         => __( 'Set a Jetpack module\'s active state. Idempotent — setting a module to its current state returns changed=false. Returns { slug, active, changed }. Call jetpack-modules/get-modules first to enumerate valid slugs. Modules requiring a Jetpack connection or a paid plan may fail with jetpack_modules_activate_failed; the message indicates the next step.', 'jetpack' ),
+				'description'         => __( 'Set a Jetpack module\'s active state. Idempotent — setting a module to its current state returns changed=false. Returns { slug, active, changed }. Call jetpack/get-modules first to enumerate valid slugs. Modules requiring a Jetpack connection or a paid plan may fail with jetpack_modules_activate_failed; the message indicates the next step.', 'jetpack' ),
 				'input_schema'        => array(
 					'type'                 => 'object',
 					'required'             => array( 'slug', 'active' ),
@@ -310,7 +310,7 @@ class Modules_Abilities extends Registrar {
 		if ( ! isset( $input['slug'] ) || ! is_string( $input['slug'] ) || '' === $input['slug'] ) {
 			return new \WP_Error(
 				'jetpack_modules_missing_slug',
-				__( 'A module slug is required. Call jetpack-modules/get-modules to enumerate valid slugs.', 'jetpack' )
+				__( 'A module slug is required. Call jetpack/get-modules to enumerate valid slugs.', 'jetpack' )
 			);
 		}
 
@@ -333,7 +333,7 @@ class Modules_Abilities extends Registrar {
 		if ( ! Jetpack::is_module( $slug ) ) {
 			return new \WP_Error(
 				'jetpack_modules_invalid_slug',
-				__( 'Unknown Jetpack module slug. Call jetpack-modules/get-modules to enumerate valid slugs.', 'jetpack' )
+				__( 'Unknown Jetpack module slug. Call jetpack/get-modules to enumerate valid slugs.', 'jetpack' )
 			);
 		}
 

--- a/projects/plugins/jetpack/src/abilities/class-modules-abilities.php
+++ b/projects/plugins/jetpack/src/abilities/class-modules-abilities.php
@@ -335,6 +335,22 @@ class Modules_Abilities extends Registrar {
 		}
 
 		if ( $desired ) {
+			// Preflight: Jetpack::activate_module() ignores its $exit/$redirect flags when a
+			// conflicting standalone plugin (e.g. WordPress.com Stats vs. the stats module) is
+			// active — it calls wp_safe_redirect()+exit() and would terminate this REST request
+			// mid-response. Refuse here with a structured error instead.
+			$conflict = self::find_conflicting_active_plugin( $slug );
+			if ( null !== $conflict ) {
+				return new \WP_Error(
+					'jetpack_modules_conflicting_plugin_active',
+					sprintf(
+						/* translators: %s: name of the conflicting plugin that must be deactivated first. */
+						__( 'Cannot activate the module while a conflicting plugin (%s) is active. Deactivate it on the WordPress Plugins screen, then retry.', 'jetpack' ),
+						$conflict
+					)
+				);
+			}
+
 			// Always pass exit=false, redirect=false so the ability runs headless over REST.
 			$ok = Jetpack::activate_module( $slug, false, false );
 			if ( ! $ok ) {
@@ -353,10 +369,63 @@ class Modules_Abilities extends Registrar {
 			}
 		}
 
+		// Re-check state: activate_module() / deactivate_module() can return truthy even when a
+		// pre_update_option_jetpack_active_modules filter blocks the option write, so the response
+		// would otherwise lie about reaching the requested state.
+		$actual = Jetpack::is_module_active( $slug );
+		if ( $desired !== $actual ) {
+			return new \WP_Error(
+				'jetpack_modules_state_mismatch',
+				__( 'The module did not reach the requested state. A filter on jetpack_active_modules may have rejected the change.', 'jetpack' )
+			);
+		}
+
 		return array(
 			'slug'    => $slug,
-			'active'  => $desired,
+			'active'  => $actual,
 			'changed' => true,
 		);
+	}
+
+	/**
+	 * Return the human-readable name of the first standalone plugin currently active that
+	 * would force {@see Jetpack::activate_module()} to redirect/exit, or null when none.
+	 *
+	 * Mirrors the lookup in {@see Jetpack_Client_Server::deactivate_plugin()}: prefer the
+	 * known plugin file path, fall back to a name match across active plugins.
+	 *
+	 * @param string $slug Module slug.
+	 * @return string|null
+	 */
+	private static function find_conflicting_active_plugin( $slug ) {
+		$jetpack = Jetpack::init();
+		if ( empty( $jetpack->plugins_to_deactivate[ $slug ] ) ) {
+			return null;
+		}
+
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		$active_plugins = null;
+		foreach ( $jetpack->plugins_to_deactivate[ $slug ] as $candidate ) {
+			list( $plugin_file, $plugin_name ) = $candidate;
+
+			if ( is_plugin_active( $plugin_file ) ) {
+				return $plugin_name;
+			}
+
+			if ( null === $active_plugins ) {
+				$active_plugins = Jetpack::get_active_plugins();
+			}
+			foreach ( $active_plugins as $active ) {
+				$data = get_plugin_data( WP_PLUGIN_DIR . '/' . $active );
+				if ( isset( $data['Name'] ) && $data['Name'] === $plugin_name ) {
+					return $plugin_name;
+				}
+			}
+		}
+
+		return null;
 	}
 }

--- a/projects/plugins/jetpack/tests/php/src/Modules_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Modules_Abilities_Test.php
@@ -207,7 +207,9 @@ class Modules_Abilities_Test extends WP_UnitTestCase {
 		$this->fire_abilities_lifecycle();
 
 		$registered_slugs = array_map(
-			static fn ( $a ) => $a->get_name(),
+			static function ( $a ) {
+				return $a->get_name();
+			},
 			wp_get_abilities()
 		);
 		foreach ( array_keys( Modules_Abilities::get_abilities() ) as $slug ) {

--- a/projects/plugins/jetpack/tests/php/src/Modules_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Modules_Abilities_Test.php
@@ -1,0 +1,414 @@
+<?php
+/**
+ * Tests for the Modules_Abilities Registrar subclass.
+ *
+ * @package automattic/jetpack
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9.
+
+use Automattic\Jetpack\Plugin\Abilities\Modules_Abilities;
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * @covers \Automattic\Jetpack\Plugin\Abilities\Modules_Abilities
+ */
+#[CoversClass( Modules_Abilities::class )]
+class Modules_Abilities_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Administrator user id, created once per test.
+	 *
+	 * @var int
+	 */
+	private $admin_id;
+
+	/**
+	 * Subscriber user id, created once per test.
+	 *
+	 * @var int
+	 */
+	private $subscriber_id;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->admin_id      = wp_insert_user(
+			array(
+				'user_login' => 'modules_abilities_admin_' . wp_generate_password( 8, false, false ),
+				'user_pass'  => 'pw',
+				'user_email' => 'admin_' . wp_generate_password( 6, false, false ) . '@example.test',
+				'role'       => 'administrator',
+			)
+		);
+		$this->subscriber_id = wp_insert_user(
+			array(
+				'user_login' => 'modules_abilities_sub_' . wp_generate_password( 8, false, false ),
+				'user_pass'  => 'pw',
+				'user_email' => 'sub_' . wp_generate_password( 6, false, false ) . '@example.test',
+				'role'       => 'subscriber',
+			)
+		);
+
+		// Default: gate open for most test cases.
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+	}
+
+	public function tear_down() {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+		remove_all_filters( 'jetpack_wp_abilities_should_register' );
+		wp_set_current_user( 0 );
+
+		remove_action( Registrar::CATEGORIES_INIT_ACTION, array( Modules_Abilities::class, 'register_category' ) );
+		remove_action( Registrar::ABILITIES_INIT_ACTION, array( Modules_Abilities::class, 'register_abilities' ) );
+
+		// Unregister anything this test left behind so the singleton registry stays clean
+		// between tests (the WP Abilities Registry persists across tests within a process).
+		if ( function_exists( 'wp_unregister_ability' ) ) {
+			foreach ( array_keys( Modules_Abilities::get_abilities() ) as $slug ) {
+				wp_unregister_ability( $slug );
+			}
+		}
+		if ( function_exists( 'wp_unregister_ability_category' ) ) {
+			wp_unregister_ability_category( Modules_Abilities::get_category_slug() );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Hook the registrar callbacks and fire the API lifecycle actions so registrations
+	 * happen inside the action callstack — `wp_register_ability(_category)` enforces
+	 * `doing_action()`, so direct invocation outside the hook is rejected.
+	 */
+	private function fire_abilities_lifecycle(): void {
+		add_action( Registrar::CATEGORIES_INIT_ACTION, array( Modules_Abilities::class, 'register_category' ) );
+		add_action( Registrar::ABILITIES_INIT_ACTION, array( Modules_Abilities::class, 'register_abilities' ) );
+		do_action( Registrar::CATEGORIES_INIT_ACTION );
+		do_action( Registrar::ABILITIES_INIT_ACTION );
+	}
+
+	public function test_category_slug_is_plugin_scoped() {
+		$this->assertSame( 'jetpack-modules', Modules_Abilities::get_category_slug() );
+	}
+
+	public function test_category_definition_has_label_and_description() {
+		$def = Modules_Abilities::get_category_definition();
+		$this->assertArrayHasKey( 'label', $def );
+		$this->assertArrayHasKey( 'description', $def );
+		$this->assertIsString( $def['label'] );
+		$this->assertIsString( $def['description'] );
+	}
+
+	public function test_abilities_map_is_non_empty_and_namespaced() {
+		$abilities = Modules_Abilities::get_abilities();
+		$this->assertNotEmpty( $abilities );
+		foreach ( array_keys( $abilities ) as $slug ) {
+			$this->assertStringStartsWith( 'jetpack-modules/', $slug );
+		}
+	}
+
+	public function test_no_spec_sets_category_explicitly() {
+		// Registrar auto-injects category; specs that set it are redundant and drift.
+		foreach ( Modules_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertArrayNotHasKey(
+				'category',
+				$spec,
+				"Ability {$slug} should not set its own category — Registrar injects it."
+			);
+		}
+	}
+
+	public function test_consolidated_surface_exposes_get_modules_and_set_module_status() {
+		$abilities = Modules_Abilities::get_abilities();
+		$this->assertArrayHasKey( 'jetpack-modules/get-modules', $abilities );
+		$this->assertArrayHasKey( 'jetpack-modules/set-module-status', $abilities );
+	}
+
+	public function test_get_modules_is_annotated_readonly_idempotent() {
+		$spec = Modules_Abilities::get_abilities()['jetpack-modules/get-modules'];
+		$this->assertTrue( $spec['meta']['annotations']['readonly'] );
+		$this->assertFalse( $spec['meta']['annotations']['destructive'] );
+		$this->assertTrue( $spec['meta']['annotations']['idempotent'] );
+	}
+
+	public function test_set_module_status_is_annotated_non_readonly_idempotent() {
+		$spec = Modules_Abilities::get_abilities()['jetpack-modules/set-module-status'];
+		$this->assertFalse( $spec['meta']['annotations']['readonly'] );
+		$this->assertFalse( $spec['meta']['annotations']['destructive'] );
+		$this->assertTrue( $spec['meta']['annotations']['idempotent'] );
+	}
+
+	public function test_init_registers_nothing_when_gate_filter_is_false() {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+
+		Modules_Abilities::init();
+
+		$this->assertFalse(
+			has_action( Registrar::CATEGORIES_INIT_ACTION, array( Modules_Abilities::class, 'register_category' ) )
+		);
+		$this->assertFalse(
+			has_action( Registrar::ABILITIES_INIT_ACTION, array( Modules_Abilities::class, 'register_abilities' ) )
+		);
+	}
+
+	public function test_init_hooks_lifecycle_actions_when_gate_is_true() {
+		Modules_Abilities::init();
+
+		$this->assertNotFalse(
+			has_action( Registrar::CATEGORIES_INIT_ACTION, array( Modules_Abilities::class, 'register_category' ) )
+		);
+		$this->assertNotFalse(
+			has_action( Registrar::ABILITIES_INIT_ACTION, array( Modules_Abilities::class, 'register_abilities' ) )
+		);
+	}
+
+	public function test_register_abilities_registers_every_slug() {
+		if ( ! function_exists( 'wp_get_abilities' ) || ! function_exists( 'wp_register_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API not available in this WP version.' );
+		}
+
+		$this->fire_abilities_lifecycle();
+
+		$registered_slugs = array();
+		foreach ( wp_get_abilities() as $ability ) {
+			$name = $ability->get_name();
+			if ( str_starts_with( $name, 'jetpack-modules/' ) ) {
+				$registered_slugs[] = $name;
+			}
+		}
+
+		foreach ( array_keys( Modules_Abilities::get_abilities() ) as $slug ) {
+			$this->assertContains( $slug, $registered_slugs, "Ability {$slug} should be registered." );
+		}
+	}
+
+	public function test_per_ability_allow_list_filter_is_respected() {
+		if ( ! function_exists( 'wp_get_ability' ) || ! function_exists( 'wp_register_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API not available in this WP version.' );
+		}
+
+		add_filter(
+			'jetpack_wp_abilities_should_register',
+			static function ( $enabled, $type, $slug ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Filter signature requires this parameter even when we don't branch on it.
+				if ( 'ability' === $type ) {
+					return false;
+				}
+				return $enabled;
+			},
+			10,
+			3
+		);
+
+		$this->fire_abilities_lifecycle();
+
+		$registered_slugs = array_map(
+			static fn ( $a ) => $a->get_name(),
+			wp_get_abilities()
+		);
+		foreach ( array_keys( Modules_Abilities::get_abilities() ) as $slug ) {
+			$this->assertNotContains( $slug, $registered_slugs, "Ability {$slug} must be filtered out." );
+		}
+	}
+
+	public function test_register_abilities_auto_injects_category() {
+		if ( ! function_exists( 'wp_get_ability' ) || ! function_exists( 'wp_register_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API not available in this WP version.' );
+		}
+
+		$this->fire_abilities_lifecycle();
+
+		foreach ( array_keys( Modules_Abilities::get_abilities() ) as $slug ) {
+			$registered = wp_get_ability( $slug );
+			$this->assertNotNull( $registered, "Ability {$slug} should be registered." );
+			$this->assertSame(
+				'jetpack-modules',
+				$registered->get_category(),
+				"Ability {$slug} should have category auto-injected."
+			);
+		}
+	}
+
+	public function test_can_view_modules_allows_admin() {
+		wp_set_current_user( $this->admin_id );
+		$this->assertTrue( Modules_Abilities::can_view_modules() );
+	}
+
+	public function test_can_view_modules_denies_subscriber() {
+		wp_set_current_user( $this->subscriber_id );
+		$this->assertFalse( Modules_Abilities::can_view_modules() );
+	}
+
+	public function test_can_view_modules_denies_anonymous() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( Modules_Abilities::can_view_modules() );
+	}
+
+	public function test_can_manage_modules_allows_admin() {
+		wp_set_current_user( $this->admin_id );
+		$this->assertTrue( Modules_Abilities::can_manage_modules() );
+	}
+
+	public function test_can_manage_modules_denies_subscriber() {
+		wp_set_current_user( $this->subscriber_id );
+		$this->assertFalse( Modules_Abilities::can_manage_modules() );
+	}
+
+	public function test_get_modules_returns_array() {
+		wp_set_current_user( $this->admin_id );
+		$result = Modules_Abilities::get_modules( array() );
+		$this->assertIsArray( $result );
+		$this->assertNotEmpty( $result, 'Jetpack ships with modules; an unfiltered list should be non-empty.' );
+	}
+
+	public function test_get_modules_summary_shape_is_high_signal() {
+		wp_set_current_user( $this->admin_id );
+		$result = Modules_Abilities::get_modules( array() );
+		$this->assertIsArray( $result );
+
+		$expected_keys = array(
+			'slug',
+			'name',
+			'description',
+			'active',
+			'sort',
+			'feature',
+			'plan_classes',
+			'requires_connection',
+			'requires_user_connection',
+			'auto_activate',
+		);
+		foreach ( $result as $summary ) {
+			foreach ( $expected_keys as $key ) {
+				$this->assertArrayHasKey( $key, $summary, "Summary missing key {$key} for slug " . ( $summary['slug'] ?? '?' ) );
+			}
+			$this->assertIsBool( $summary['active'] );
+			$this->assertIsArray( $summary['feature'] );
+			$this->assertIsArray( $summary['plan_classes'] );
+			// Raw Jetpack::get_module() keys should NOT leak through.
+			$this->assertArrayNotHasKey( 'module_tags', $summary );
+			$this->assertArrayNotHasKey( 'deactivate', $summary );
+			$this->assertArrayNotHasKey( 'recommendation_order', $summary );
+		}
+	}
+
+	public function test_get_modules_with_unknown_slug_returns_empty_array() {
+		// Consolidated read: unknown slug is a no-match, not an error — shape is uniform.
+		wp_set_current_user( $this->admin_id );
+		$result = Modules_Abilities::get_modules( array( 'slug' => 'this-module-does-not-exist-ever' ) );
+		$this->assertSame( array(), $result );
+	}
+
+	public function test_get_modules_with_known_slug_returns_one_element_array() {
+		wp_set_current_user( $this->admin_id );
+		$all = Modules_Abilities::get_modules( array() );
+		if ( empty( $all ) ) {
+			$this->markTestSkipped( 'No modules available to probe.' );
+		}
+		$slug   = $all[0]['slug'];
+		$result = Modules_Abilities::get_modules( array( 'slug' => $slug ) );
+		$this->assertCount( 1, $result );
+		$this->assertSame( $slug, $result[0]['slug'] );
+	}
+
+	public function test_get_modules_filters_by_active_state() {
+		wp_set_current_user( $this->admin_id );
+		$active_only = Modules_Abilities::get_modules( array( 'active' => true ) );
+		$this->assertIsArray( $active_only );
+		foreach ( $active_only as $summary ) {
+			$this->assertTrue( $summary['active'], "Expected only active modules, got {$summary['slug']}." );
+		}
+
+		$inactive_only = Modules_Abilities::get_modules( array( 'active' => false ) );
+		$this->assertIsArray( $inactive_only );
+		foreach ( $inactive_only as $summary ) {
+			$this->assertFalse( $summary['active'], "Expected only inactive modules, got {$summary['slug']}." );
+		}
+	}
+
+	public function test_get_modules_is_sorted_deterministically() {
+		wp_set_current_user( $this->admin_id );
+		$first  = Modules_Abilities::get_modules( array() );
+		$second = Modules_Abilities::get_modules( array() );
+		$this->assertSame( $first, $second, 'Repeated calls must return results in identical order.' );
+	}
+
+	public function test_set_module_status_rejects_missing_slug() {
+		wp_set_current_user( $this->admin_id );
+		$result = Modules_Abilities::set_module_status( array( 'active' => true ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_modules_missing_slug', $result->get_error_code() );
+	}
+
+	public function test_set_module_status_rejects_empty_string_slug() {
+		wp_set_current_user( $this->admin_id );
+		$result = Modules_Abilities::set_module_status(
+			array(
+				'slug'   => '',
+				'active' => true,
+			)
+		);
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_modules_missing_slug', $result->get_error_code() );
+	}
+
+	public function test_set_module_status_rejects_missing_active() {
+		wp_set_current_user( $this->admin_id );
+		$result = Modules_Abilities::set_module_status( array( 'slug' => 'stats' ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_modules_missing_active', $result->get_error_code() );
+	}
+
+	public function test_set_module_status_rejects_non_boolean_active() {
+		// Regression guard: the schema declares boolean; the execute callback should
+		// refuse string "true"/"false" with a distinct "invalid type" code so callers
+		// can differentiate missing-field from wrong-type.
+		wp_set_current_user( $this->admin_id );
+		$result = Modules_Abilities::set_module_status(
+			array(
+				'slug'   => 'stats',
+				'active' => 'true',
+			)
+		);
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_modules_invalid_active', $result->get_error_code() );
+	}
+
+	public function test_set_module_status_rejects_unknown_slug() {
+		wp_set_current_user( $this->admin_id );
+		$result = Modules_Abilities::set_module_status(
+			array(
+				'slug'   => 'this-module-does-not-exist-ever',
+				'active' => true,
+			)
+		);
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_modules_invalid_slug', $result->get_error_code() );
+	}
+
+	public function test_set_module_status_is_idempotent_for_current_state() {
+		wp_set_current_user( $this->admin_id );
+		$all = Modules_Abilities::get_modules( array() );
+		if ( empty( $all ) ) {
+			$this->markTestSkipped( 'No modules available to probe.' );
+		}
+
+		$target = $all[0];
+		// Setting a module to its current state must be a no-op.
+		$result = Modules_Abilities::set_module_status(
+			array(
+				'slug'   => $target['slug'],
+				'active' => $target['active'],
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $target['slug'], $result['slug'] );
+		$this->assertSame( $target['active'], $result['active'] );
+		$this->assertFalse( $result['changed'], 'Setting current state must return changed=false.' );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/src/Modules_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Modules_Abilities_Test.php
@@ -92,7 +92,7 @@ class Modules_Abilities_Test extends WP_UnitTestCase {
 	}
 
 	public function test_category_slug_is_plugin_scoped() {
-		$this->assertSame( 'jetpack-modules', Modules_Abilities::get_category_slug() );
+		$this->assertSame( 'jetpack', Modules_Abilities::get_category_slug() );
 	}
 
 	public function test_category_definition_has_label_and_description() {
@@ -107,7 +107,7 @@ class Modules_Abilities_Test extends WP_UnitTestCase {
 		$abilities = Modules_Abilities::get_abilities();
 		$this->assertNotEmpty( $abilities );
 		foreach ( array_keys( $abilities ) as $slug ) {
-			$this->assertStringStartsWith( 'jetpack-modules/', $slug );
+			$this->assertStringStartsWith( 'jetpack/', $slug );
 		}
 	}
 
@@ -124,26 +124,26 @@ class Modules_Abilities_Test extends WP_UnitTestCase {
 
 	public function test_consolidated_surface_exposes_get_modules_and_set_module_status() {
 		$abilities = Modules_Abilities::get_abilities();
-		$this->assertArrayHasKey( 'jetpack-modules/get-modules', $abilities );
-		$this->assertArrayHasKey( 'jetpack-modules/set-module-status', $abilities );
+		$this->assertArrayHasKey( 'jetpack/get-modules', $abilities );
+		$this->assertArrayHasKey( 'jetpack/set-module-status', $abilities );
 	}
 
 	public function test_get_modules_is_annotated_readonly_idempotent() {
-		$spec = Modules_Abilities::get_abilities()['jetpack-modules/get-modules'];
+		$spec = Modules_Abilities::get_abilities()['jetpack/get-modules'];
 		$this->assertTrue( $spec['meta']['annotations']['readonly'] );
 		$this->assertFalse( $spec['meta']['annotations']['destructive'] );
 		$this->assertTrue( $spec['meta']['annotations']['idempotent'] );
 	}
 
 	public function test_set_module_status_is_annotated_non_readonly_idempotent() {
-		$spec = Modules_Abilities::get_abilities()['jetpack-modules/set-module-status'];
+		$spec = Modules_Abilities::get_abilities()['jetpack/set-module-status'];
 		$this->assertFalse( $spec['meta']['annotations']['readonly'] );
 		$this->assertFalse( $spec['meta']['annotations']['destructive'] );
 		$this->assertTrue( $spec['meta']['annotations']['idempotent'] );
 	}
 
 	public function test_both_abilities_opt_into_mcp_as_public_tool() {
-		foreach ( array( 'jetpack-modules/get-modules', 'jetpack-modules/set-module-status' ) as $slug ) {
+		foreach ( array( 'jetpack/get-modules', 'jetpack/set-module-status' ) as $slug ) {
 			$spec = Modules_Abilities::get_abilities()[ $slug ];
 			$this->assertSame( true, $spec['meta']['mcp']['public'], "{$slug} must opt into MCP." );
 			$this->assertSame( 'tool', $spec['meta']['mcp']['type'], "{$slug} must be exposed as an MCP tool." );
@@ -185,7 +185,7 @@ class Modules_Abilities_Test extends WP_UnitTestCase {
 		$registered_slugs = array();
 		foreach ( wp_get_abilities() as $ability ) {
 			$name = $ability->get_name();
-			if ( str_starts_with( $name, 'jetpack-modules/' ) ) {
+			if ( str_starts_with( $name, 'jetpack/' ) ) {
 				$registered_slugs[] = $name;
 			}
 		}
@@ -236,7 +236,7 @@ class Modules_Abilities_Test extends WP_UnitTestCase {
 			$registered = wp_get_ability( $slug );
 			$this->assertNotNull( $registered, "Ability {$slug} should be registered." );
 			$this->assertSame(
-				'jetpack-modules',
+				'jetpack',
 				$registered->get_category(),
 				"Ability {$slug} should have category auto-injected."
 			);

--- a/projects/plugins/jetpack/tests/php/src/Modules_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Modules_Abilities_Test.php
@@ -358,6 +358,21 @@ class Modules_Abilities_Test extends WP_UnitTestCase {
 		$this->assertSame( 'jetpack_modules_missing_slug', $result->get_error_code() );
 	}
 
+	public function test_set_module_status_treats_zero_slug_as_unknown_not_missing() {
+		// Regression guard for the classic PHP empty('0') == true gotcha: a '0' slug is a
+		// non-empty string and must reach the slug-validity check, which rejects it as unknown
+		// rather than misclassifying it as a missing slug.
+		wp_set_current_user( $this->admin_id );
+		$result = Modules_Abilities::set_module_status(
+			array(
+				'slug'   => '0',
+				'active' => true,
+			)
+		);
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_modules_invalid_slug', $result->get_error_code() );
+	}
+
 	public function test_set_module_status_rejects_missing_active() {
 		wp_set_current_user( $this->admin_id );
 		$result = Modules_Abilities::set_module_status( array( 'slug' => 'stats' ) );
@@ -412,5 +427,36 @@ class Modules_Abilities_Test extends WP_UnitTestCase {
 		$this->assertSame( $target['slug'], $result['slug'] );
 		$this->assertSame( $target['active'], $result['active'] );
 		$this->assertFalse( $result['changed'], 'Setting current state must return changed=false.' );
+	}
+
+	public function test_set_module_status_deactivates_active_module_and_reports_changed() {
+		// State-change coverage for the deactivation path. Activation requires a Jetpack
+		// connection (see Jetpack_Sync_Modules_Test::test_sync_activate_module_event for the
+		// same constraint), but deactivation is connection-agnostic — seed an active module
+		// directly and assert the function flips it off, reports changed=true, and verifies
+		// the persisted state via Jetpack::is_module_active().
+		wp_set_current_user( $this->admin_id );
+
+		$available = Jetpack::get_available_modules();
+		if ( empty( $available ) ) {
+			$this->markTestSkipped( 'No Jetpack modules available to toggle.' );
+		}
+		$slug = reset( $available );
+
+		\Jetpack_Options::update_option( 'active_modules', array( $slug ) );
+		$this->assertTrue( Jetpack::is_module_active( $slug ), 'Sanity: seeded module should report active.' );
+
+		$result = Modules_Abilities::set_module_status(
+			array(
+				'slug'   => $slug,
+				'active' => false,
+			)
+		);
+
+		$this->assertIsArray( $result, 'Deactivation should not return WP_Error for a seeded active module.' );
+		$this->assertSame( $slug, $result['slug'] );
+		$this->assertFalse( $result['active'] );
+		$this->assertTrue( $result['changed'], 'Flipping a state change must report changed=true.' );
+		$this->assertFalse( Jetpack::is_module_active( $slug ), 'Module should be inactive after deactivation.' );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/src/Modules_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Modules_Abilities_Test.php
@@ -142,6 +142,14 @@ class Modules_Abilities_Test extends WP_UnitTestCase {
 		$this->assertTrue( $spec['meta']['annotations']['idempotent'] );
 	}
 
+	public function test_both_abilities_opt_into_mcp_as_public_tool() {
+		foreach ( array( 'jetpack-modules/get-modules', 'jetpack-modules/set-module-status' ) as $slug ) {
+			$spec = Modules_Abilities::get_abilities()[ $slug ];
+			$this->assertSame( true, $spec['meta']['mcp']['public'], "{$slug} must opt into MCP." );
+			$this->assertSame( 'tool', $spec['meta']['mcp']['type'], "{$slug} must be exposed as an MCP tool." );
+		}
+	}
+
 	public function test_init_registers_nothing_when_gate_filter_is_false() {
 		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
 		add_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
@@ -315,6 +323,34 @@ class Modules_Abilities_Test extends WP_UnitTestCase {
 		$result = Modules_Abilities::get_modules( array( 'slug' => $slug ) );
 		$this->assertCount( 1, $result );
 		$this->assertSame( $slug, $result[0]['slug'] );
+	}
+
+	public function test_get_modules_slug_lookup_still_honors_other_filters() {
+		// Regression guard: { slug, active } must apply the active filter even though
+		// slug narrows the candidate set to a single module — otherwise callers
+		// combining filters get a false positive for a module that doesn't match.
+		wp_set_current_user( $this->admin_id );
+		$all = Modules_Abilities::get_modules( array() );
+		if ( empty( $all ) ) {
+			$this->markTestSkipped( 'No modules available to probe.' );
+		}
+		$probe  = $all[0];
+		$result = Modules_Abilities::get_modules(
+			array(
+				'slug'   => $probe['slug'],
+				'active' => ! $probe['active'],
+			)
+		);
+		$this->assertSame( array(), $result );
+
+		$matching = Modules_Abilities::get_modules(
+			array(
+				'slug'   => $probe['slug'],
+				'active' => $probe['active'],
+			)
+		);
+		$this->assertCount( 1, $matching );
+		$this->assertSame( $probe['slug'], $matching[0]['slug'] );
 	}
 
 	public function test_get_modules_filters_by_active_state() {


### PR DESCRIPTION
Fixes #

## Proposed changes
* Register a new `jetpack-modules` category with the WordPress Abilities API (WP 6.9+), exposed through the standard `wp-abilities/v1` REST surface and the `@wordpress/abilities` JS client.
* Ship two consolidated abilities instead of four atomic CRUD ones:
  - `jetpack-modules/get-modules` — filtered read. Optional `slug`, `active`, `feature`, `search` filters; always returns a uniform array of high-signal module summaries (drops internal `module_tags`, `changelog`, `plan_classes_raw` and other fields agents can't use).
  - `jetpack-modules/set-module-status` — declarative, idempotent state-setter. Required `slug` + `active: bool`; setting a module to its current state returns `changed=false`.
* Implement via `Modules_Abilities extends Registrar` (from the new `jetpack-wp-abilities` package) — the subclass only supplies the three abstract getters; lifecycle, `jetpack_wp_abilities_enabled` gate, `did_action()` late-load, and per-ability allow-list filter are inherited. One-line wiring from `class.jetpack.php`.
* Add `automattic/jetpack-wp-abilities: @dev` to the plugin's `composer.json` and commit the resulting lockfile update (CI uses `--frozen-lockfile`).
* Localize `name` / `description` in the summary shape via `jetpack_get_module_i18n()` so agent-facing strings match the admin UI on non-English sites.
* Add 29 PHPUnit tests covering Registrar wiring (gate default, hook addition, lifecycle dispatch, per-ability allow-list, category auto-injection), abstract getters, permission callbacks (admin / subscriber / anon), consolidated-read shape + filters + determinism, and declarative-write idempotency + edge cases (missing slug, empty-string slug, `'0'` slug, missing `active`, non-boolean `active`, unknown slug).

## Related product discussion/links
* Abilities API package: `projects/packages/wp-abilities/` (PR #48246).

## Does this pull request change what data or activity we track or use?
No. This PR adds a registration surface that is gated behind the `jetpack_wp_abilities_enabled` filter (default `false`). No new data is collected; the two abilities wrap existing `Jetpack::get_module()` / `activate_module()` / `deactivate_module()` capabilities that have been part of Jetpack for years, and they reuse the existing `jetpack_admin_page` / `jetpack_manage_modules` / `jetpack_activate_modules` capability checks.

## Testing instructions

**Automated:**

```bash
cd projects/plugins/jetpack
composer phpunit -- --filter Modules_Abilities_Test
# Expect: OK (29 tests, 823 assertions)
```

**Manual (requires opting into the gate):**

1. Ensure WP 6.9+ is running (this PR's abilities only register on WP with the Abilities API available).
2. Opt in to the Jetpack abilities surface for your test site — e.g. in a mu-plugin:
   ```php
   add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
   ```
3. Log in as an administrator, then confirm the category + abilities register:
   ```bash
   wp eval 'var_export( array_keys( wp_get_abilities() ) );' | grep jetpack-modules
   # Expect: 'jetpack-modules/get-modules' and 'jetpack-modules/set-module-status'
   ```
4. Hit the REST surface:
   ```bash
   # List / filter modules
   curl -u admin:pass http://localhost/wp-json/wp-abilities/v1/abilities/jetpack-modules/get-modules/run \
     -H 'Content-Type: application/json' \
     -d '{"input":{"active":true}}'

   # Toggle a module (idempotent: re-run, observe "changed":false)
   curl -u admin:pass http://localhost/wp-json/wp-abilities/v1/abilities/jetpack-modules/set-module-status/run \
     -H 'Content-Type: application/json' \
     -d '{"input":{"slug":"stats","active":true}}'
   ```
5. Verify the deny paths:
   - Log out or switch to a subscriber. Both abilities should return a 403 via `permission_callback`.
   - Call `set-module-status` with an unknown slug. Expect `jetpack_modules_invalid_slug` with a message that points to `get-modules` to enumerate valid slugs.
   - Call `set-module-status` with `"active": "true"` (string). Expect `jetpack_modules_invalid_active`.
