### PR TITLE
Search: search-input authoring controls (placeholder, showIcon, submitOnly)

### DIFF
--- a/projects/packages/search/changelog/add-search-139-search-input-attrs
+++ b/projects/packages/search/changelog/add-search-139-search-input-attrs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Search Blocks: search-input gains placeholder (declared), showIcon, and submitOnly attributes with matching inspector controls.

--- a/projects/packages/search/src/search-blocks/blocks/search-input/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/block.json
@@ -11,6 +11,11 @@
 		"html": false,
 		"interactivity": true
 	},
+	"attributes": {
+		"placeholder": { "type": "string", "default": "" },
+		"showIcon": { "type": "boolean", "default": true },
+		"submitOnly": { "type": "boolean", "default": false }
+	},
 	"textdomain": "jetpack-search-pkg",
 	"render": "file:./render.php",
 	"viewScriptModule": "file:../../../../build/search-blocks/search-input.js",

--- a/projects/packages/search/src/search-blocks/blocks/search-input/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/edit.js
@@ -88,7 +88,7 @@ export default function SearchInputEdit( { attributes, setAttributes } ) {
 					checked: submitOnly,
 					onChange: value => setAttributes( { submitOnly: value } ),
 					help: __(
-						'When enabled, queries fire on Enter instead of on every keystroke.',
+						'When enabled, queries fire on Enter or when clearing the field, instead of on every keystroke.',
 						'jetpack-search-pkg'
 					),
 				} )
@@ -126,7 +126,7 @@ export default function SearchInputEdit( { attributes, setAttributes } ) {
 						disabled: true,
 						'aria-label': __( 'Clear search', 'jetpack-search-pkg' ),
 					},
-					'×'
+					'✕'
 				)
 			)
 		)

--- a/projects/packages/search/src/search-blocks/blocks/search-input/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/edit.js
@@ -3,10 +3,13 @@
  *
  * Mirrors render.php's full structure — screen-reader label, icon, input,
  * and the (initially hidden) clear button — so designers can target every
- * CSS hook.
+ * CSS hook. The inspector exposes the three authoring knobs the front-end
+ * honours: placeholder copy, whether the magnifying-glass icon renders,
+ * and whether queries fire live or only on submit.
  */
-import { useBlockProps } from '@wordpress/block-editor';
-import { createElement as h, useId } from '@wordpress/element';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
+import { createElement as h, Fragment, useId } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -36,46 +39,95 @@ function SearchGlyph() {
 /**
  * Edit component for the search-input block.
  *
+ * @param {object}   props               - Block props.
+ * @param {object}   props.attributes    - Saved block attributes.
+ * @param {Function} props.setAttributes - Attribute setter.
  * @return {object} Rendered element.
  */
-export default function SearchInputEdit() {
+export default function SearchInputEdit( { attributes, setAttributes } ) {
 	const blockProps = useBlockProps();
 	// Per-instance id keeps the label→input association valid when the editor
 	// renders more than one Search Input on the same canvas.
 	const inputId = useId();
+	const defaultPlaceholder = __( 'Search…', 'jetpack-search-pkg' );
+	// Match render.php: a whitespace-only placeholder falls back to the
+	// translated default in the preview so the editor mirrors the front end.
+	const placeholder = ( attributes?.placeholder || '' ).trim() || defaultPlaceholder;
+	const showIcon = attributes?.showIcon !== false;
+	const submitOnly = !! attributes?.submitOnly;
 	return h(
-		'div',
-		blockProps,
+		Fragment,
+		null,
 		h(
-			'label',
-			{
-				className: 'jetpack-search-input__label screen-reader-text',
-				htmlFor: inputId,
-			},
-			__( 'Search', 'jetpack-search-pkg' )
+			InspectorControls,
+			null,
+			h(
+				PanelBody,
+				{ title: __( 'Settings', 'jetpack-search-pkg' ) },
+				h( TextControl, {
+					__next40pxDefaultSize: true,
+					__nextHasNoMarginBottom: true,
+					label: __( 'Placeholder', 'jetpack-search-pkg' ),
+					value: attributes?.placeholder || '',
+					placeholder: defaultPlaceholder,
+					onChange: value => setAttributes( { placeholder: value } ),
+					help: __(
+						'Leave empty to use the default translated placeholder.',
+						'jetpack-search-pkg'
+					),
+				} ),
+				h( ToggleControl, {
+					__nextHasNoMarginBottom: true,
+					label: __( 'Show search icon', 'jetpack-search-pkg' ),
+					checked: showIcon,
+					onChange: value => setAttributes( { showIcon: value } ),
+				} ),
+				h( ToggleControl, {
+					__nextHasNoMarginBottom: true,
+					label: __( 'Search on submit only', 'jetpack-search-pkg' ),
+					checked: submitOnly,
+					onChange: value => setAttributes( { submitOnly: value } ),
+					help: __(
+						'When enabled, queries fire on Enter instead of on every keystroke.',
+						'jetpack-search-pkg'
+					),
+				} )
+			)
 		),
 		h(
 			'div',
-			{ className: 'jetpack-search-input__inside-wrapper' },
-			h( SearchGlyph, null ),
-			h( 'input', {
-				id: inputId,
-				type: 'search',
-				className: 'jetpack-search-input__field',
-				placeholder: __( 'Search…', 'jetpack-search-pkg' ),
-				disabled: true,
-				readOnly: true,
-			} ),
+			blockProps,
 			h(
-				'button',
+				'label',
 				{
-					type: 'button',
-					className: 'jetpack-search-input__clear',
-					hidden: true,
-					disabled: true,
-					'aria-label': __( 'Clear search', 'jetpack-search-pkg' ),
+					className: 'jetpack-search-input__label screen-reader-text',
+					htmlFor: inputId,
 				},
-				'×'
+				__( 'Search', 'jetpack-search-pkg' )
+			),
+			h(
+				'div',
+				{ className: 'jetpack-search-input__inside-wrapper' },
+				showIcon && h( SearchGlyph, null ),
+				h( 'input', {
+					id: inputId,
+					type: 'search',
+					className: 'jetpack-search-input__field',
+					placeholder,
+					disabled: true,
+					readOnly: true,
+				} ),
+				h(
+					'button',
+					{
+						type: 'button',
+						className: 'jetpack-search-input__clear',
+						hidden: true,
+						disabled: true,
+						'aria-label': __( 'Clear search', 'jetpack-search-pkg' ),
+					},
+					'×'
+				)
 			)
 		)
 	);

--- a/projects/packages/search/src/search-blocks/blocks/search-input/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/render.php
@@ -12,7 +12,15 @@ namespace Automattic\Jetpack\Search;
 
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 
-$placeholder   = $attributes['placeholder'] ?? __( 'Search…', 'jetpack-search-pkg' );
+// Trim so a whitespace-only placeholder still falls back to the translated
+// default — block.json's static default can't be localized, so the empty/
+// whitespace case resolves here.
+$placeholder = trim( (string) ( $attributes['placeholder'] ?? '' ) );
+if ( '' === $placeholder ) {
+	$placeholder = __( 'Search…', 'jetpack-search-pkg' );
+}
+$show_icon     = ! isset( $attributes['showIcon'] ) || (bool) $attributes['showIcon'];
+$submit_only   = ! empty( $attributes['submitOnly'] );
 $initial_query = (string) get_search_query();
 $input_id      = wp_unique_id( 'jetpack-search-input-' );
 ?>
@@ -24,15 +32,21 @@ $input_id      = wp_unique_id( 'jetpack-search-input-' );
 		<?php esc_html_e( 'Search', 'jetpack-search-pkg' ); ?>
 	</label>
 	<div class="jetpack-search-input__inside-wrapper">
+		<?php if ( $show_icon ) : ?>
 		<svg class="jetpack-search-input__icon" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
 			<path d="M13 5c-3.3 0-6 2.7-6 6 0 1.4.5 2.7 1.3 3.7l-3.8 3.8 1.1 1.1 3.8-3.8c1 .8 2.3 1.3 3.7 1.3 3.3 0 6-2.7 6-6s-2.7-6-6-6zm0 10.5c-2.5 0-4.5-2-4.5-4.5s2-4.5 4.5-4.5 4.5 2 4.5 4.5-2 4.5-4.5 4.5z" />
 		</svg>
+		<?php endif; ?>
 		<input
 			id="<?php echo esc_attr( $input_id ); ?>"
 			type="search"
 			class="jetpack-search-input__field"
 			placeholder="<?php echo esc_attr( $placeholder ); ?>"
 			value="<?php echo esc_attr( $initial_query ); ?>"
+			<?php
+			if ( $submit_only ) :
+				?>
+				data-submit-only="true"<?php endif; ?>
 			data-wp-bind--value="state.searchQuery"
 			data-wp-on--input="actions.onSearchInput"
 			data-wp-on--keydown="actions.onSearchKeydown"

--- a/projects/packages/search/src/search-blocks/blocks/search-input/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/render.php
@@ -19,7 +19,7 @@ $placeholder = trim( (string) ( $attributes['placeholder'] ?? '' ) );
 if ( '' === $placeholder ) {
 	$placeholder = __( 'Search…', 'jetpack-search-pkg' );
 }
-$show_icon     = ! isset( $attributes['showIcon'] ) || (bool) $attributes['showIcon'];
+$show_icon     = (bool) ( $attributes['showIcon'] ?? true );
 $submit_only   = ! empty( $attributes['submitOnly'] );
 $initial_query = (string) get_search_query();
 $input_id      = wp_unique_id( 'jetpack-search-input-' );

--- a/projects/packages/search/src/search-blocks/blocks/search-input/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/view.js
@@ -42,6 +42,14 @@ store( NAMESPACE, {
 		onSearchInput( event ) {
 			const { state } = store( NAMESPACE );
 			state.searchQuery = event.target.value;
+			// `submitOnly` inputs still keep `state.searchQuery` in sync so
+			// bindings render the typed value, but defer the actual API call
+			// until Enter / the clear button — useful for sites that want
+			// fewer requests than the default live-search debounce produces.
+			if ( event.target.dataset.submitOnly === 'true' ) {
+				cancelPendingSearch( event.target );
+				return;
+			}
 			scheduleSearch( event.target );
 		},
 

--- a/projects/packages/search/tests/js/search-blocks/search-input-block-json.test.js
+++ b/projects/packages/search/tests/js/search-blocks/search-input-block-json.test.js
@@ -1,0 +1,15 @@
+// Guards the search-input block.json contract. Attribute names and defaults
+// are part of the public API: posts saved against one shape must keep
+// rendering correctly if the defaults drift, so we pin them here rather than
+// relying on spot-checks in render.php tests.
+
+import blockJson from '../../../src/search-blocks/blocks/search-input/block.json';
+
+describe( 'search-input block.json', () => {
+	it( 'declares the three authoring attributes with the documented defaults', () => {
+		const attrs = blockJson.attributes;
+		expect( attrs.placeholder ).toEqual( { type: 'string', default: '' } );
+		expect( attrs.showIcon ).toEqual( { type: 'boolean', default: true } );
+		expect( attrs.submitOnly ).toEqual( { type: 'boolean', default: false } );
+	} );
+} );

--- a/projects/packages/search/tests/php/Search_Input_Render_Test.php
+++ b/projects/packages/search/tests/php/Search_Input_Render_Test.php
@@ -111,8 +111,9 @@ class Search_Input_Render_Test extends TestCase {
 	 * copy.
 	 */
 	public function test_empty_placeholder_falls_back_to_default() {
-		$markup = $this->render( array( 'placeholder' => '' ) );
-		$this->assertStringContainsString( 'placeholder="Search…"', $markup );
+		$markup   = $this->render( array( 'placeholder' => '' ) );
+		$expected = 'placeholder="' . esc_attr( __( 'Search…', 'jetpack-search-pkg' ) ) . '"';
+		$this->assertStringContainsString( $expected, $markup );
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Search_Input_Render_Test.php
+++ b/projects/packages/search/tests/php/Search_Input_Render_Test.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Search Input block render.php tests.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the search-input block's render template.
+ *
+ * Each test renders the block through `do_blocks()` so WordPress wires up the
+ * block context (`WP_Block_Supports::$block_to_render`) the template relies on
+ * via `get_block_wrapper_attributes()` — exercising the same path the front
+ * end takes.
+ */
+class Search_Input_Render_Test extends TestCase {
+
+	/**
+	 * Register the search-input block inline so `do_blocks()` can resolve it
+	 * without depending on the `build/` artifacts referenced by block.json —
+	 * those aren't present in a fresh checkout and our PHPUnit config has
+	 * `failOnNotice` set. The render callback just delegates to render.php,
+	 * which is the file under test.
+	 */
+	public static function setUpBeforeClass(): void {
+		\register_block_type(
+			'jetpack/search-input',
+			array(
+				'attributes'      => array(
+					'placeholder' => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'showIcon'    => array(
+						'type'    => 'boolean',
+						'default' => true,
+					),
+					'submitOnly'  => array(
+						'type'    => 'boolean',
+						'default' => false,
+					),
+				),
+				// $attributes is consumed by the included render.php via the
+				// closure's local scope — phpcs can't see that, hence the disable.
+				// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+				'render_callback' => static function ( $attributes ) {
+					ob_start();
+					include __DIR__ . '/../../src/search-blocks/blocks/search-input/render.php';
+					return (string) ob_get_clean();
+				},
+				// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			)
+		);
+	}
+
+	/**
+	 * Unregister the block so other test classes start from a clean slate.
+	 */
+	public static function tearDownAfterClass(): void {
+		\unregister_block_type( 'jetpack/search-input' );
+	}
+
+	/**
+	 * Render the search-input block with the given attributes via `do_blocks`.
+	 *
+	 * @param array $attributes Block attributes (JSON-encoded into the comment delimiter).
+	 * @return string Rendered markup.
+	 */
+	private function render( array $attributes = array() ): string {
+		$json = empty( $attributes )
+			? ''
+			: wp_json_encode( $attributes, JSON_UNESCAPED_SLASHES );
+		return do_blocks( '<!-- wp:jetpack/search-input ' . $json . ' /-->' );
+	}
+
+	/**
+	 * The default render (no attributes) must emit the magnifying-glass icon
+	 * so posts saved before `showIcon` existed keep their search glyph.
+	 */
+	public function test_default_renders_icon() {
+		$markup = $this->render();
+		$this->assertStringContainsString( 'jetpack-search-input__icon', $markup );
+	}
+
+	/**
+	 * `showIcon: true` must emit the icon SVG — the explicit-true case.
+	 */
+	public function test_show_icon_true_renders_icon() {
+		$markup = $this->render( array( 'showIcon' => true ) );
+		$this->assertStringContainsString( 'jetpack-search-input__icon', $markup );
+	}
+
+	/**
+	 * `showIcon: false` must omit the icon SVG entirely. The surrounding
+	 * wrapper + input still render so the block stays functional.
+	 */
+	public function test_show_icon_false_hides_icon() {
+		$markup = $this->render( array( 'showIcon' => false ) );
+		$this->assertStringNotContainsString( 'jetpack-search-input__icon', $markup );
+		// The input itself must still render.
+		$this->assertStringContainsString( 'jetpack-search-input__field', $markup );
+	}
+
+	/**
+	 * An empty placeholder must fall back to the translated default so posts
+	 * saved before the attribute was declared keep rendering the "Search…"
+	 * copy.
+	 */
+	public function test_empty_placeholder_falls_back_to_default() {
+		$markup = $this->render( array( 'placeholder' => '' ) );
+		$this->assertStringContainsString( 'placeholder="Search…"', $markup );
+	}
+
+	/**
+	 * A custom placeholder must replace the default copy on the front end.
+	 */
+	public function test_custom_placeholder_renders() {
+		$markup = $this->render( array( 'placeholder' => 'Find recipes' ) );
+		$this->assertStringContainsString( 'placeholder="Find recipes"', $markup );
+	}
+
+	/**
+	 * The placeholder is user-controlled so the template must escape HTML
+	 * to prevent stored XSS through a crafted attribute value.
+	 */
+	public function test_placeholder_is_attribute_escaped() {
+		$markup = $this->render( array( 'placeholder' => '"><script>alert(1)</script>' ) );
+		$this->assertStringNotContainsString( '<script>alert(1)</script>', $markup );
+	}
+
+	/**
+	 * `submitOnly: true` must emit the opt-in data attribute so view.js can
+	 * skip the debounced live search for that input.
+	 */
+	public function test_submit_only_emits_data_attribute() {
+		$markup = $this->render( array( 'submitOnly' => true ) );
+		$this->assertStringContainsString( 'data-submit-only="true"', $markup );
+	}
+
+	/**
+	 * The default (live search) must not emit the opt-in data attribute.
+	 */
+	public function test_submit_only_default_omits_data_attribute() {
+		$markup = $this->render();
+		$this->assertStringNotContainsString( 'data-submit-only', $markup );
+	}
+}


### PR DESCRIPTION
Fixes #

## Proposed changes
* Declare the existing `placeholder` attribute in `search-input/block.json` (it was read in `render.php` but never declared, so editor-saved values were dropped).
* Add `showIcon` boolean attribute (default `true`). `render.php` now conditionally emits the magnifying-glass SVG based on this flag; the editor preview mirrors the toggle.
* Add `submitOnly` boolean attribute (default `false`). When enabled, `view.js` still keeps `state.searchQuery` in sync on input so bindings update, but skips the debounced live search — queries then fire on Enter (existing keydown handler) or when the user clicks the clear button. Live search remains the default to match the instant-search overlay's UX.
* Editor inspector surfaces all three controls in a single Settings panel (placeholder `TextControl`, two `ToggleControl`s). Empty / whitespace-only placeholder values fall back to the translated default in both the preview and `render.php`, matching the load-more block's pattern.
* Integration tests for `render.php` (icon shown/hidden, placeholder fallback, submit-only data attribute) and a block.json contract test pinning attribute defaults.

## Related product discussion/links
* Linear: https://linear.app/a8c/issue/SEARCH-139/search-input-authoring-controls

## Does this pull request change what data or activity we track or use?
No.

## Screenshots

Full side-by-side gallery in [this PR comment](https://github.com/Automattic/jetpack/pull/48280#issuecomment-4310386626). Raw PNGs hosted on the [`screenshots/pr-48280`](https://github.com/Automattic/jetpack/tree/screenshots/pr-48280) branch.

### Editor — Inspector on Search Input

| Before (`trunk`) | After (this PR) |
|---|---|
| ![before editor](https://github.com/user-attachments/assets/d7395443-dc43-4387-823c-883209d2215f) | ![after editor](https://github.com/user-attachments/assets/849efeb1-ffa4-4820-b6ab-afc87cc4d785) |
| No Settings panel — only Advanced. | Settings panel with Placeholder, Show search icon, Search on submit only. |

### Front-end — `showIcon: false` + `placeholder: "Find recipes"`

| Before (`trunk`) | After (this PR) |
|---|---|
| ![before no-icon](https://github.com/user-attachments/assets/2a2a5e2e-708c-4c3a-ac2b-bbb7a52c774f) | ![after no-icon](https://github.com/user-attachments/assets/824129b9-730c-46b3-be5b-ca51ba6af9df) |
| `showIcon` ignored — SVG always renders. | SVG suppressed when `showIcon: false`. |

## Testing instructions
1. On a site with Jetpack Search Blocks enabled, insert a Jetpack Search page (or add a `jetpack/search-input` block to a page that also has `jetpack/search-results`).
2. Open the block inspector for Search Input. The Settings panel should show three controls: **Placeholder** (text), **Show search icon** (toggle), **Search on submit only** (toggle).
3. **Placeholder**
   * Leave the field empty and view the post on the front end — the input's `placeholder` attribute should be the translated `Search…` default.
   * Enter `Find recipes`, save, reload — the `placeholder` attribute should now be `Find recipes`.
4. **Show search icon**
   * Toggle off → the editor preview and front-end markup should no longer contain the magnifying-glass SVG (`jetpack-search-input__icon` class should be absent).
   * Toggle on → the SVG returns.
5. **Search on submit only**
   * Leave off (default): typing into the input should debounce-fire a search on every keystroke as before.
   * Toggle on: typing should only update the displayed value but no API call should be made until you press **Enter** or click the clear (✕) button. Verify in the Network panel that requests are batched.
6. Regressions: confirm the keydown-on-Enter search still works in both modes, and the clear button resets the query.

### Automated tests
* `cd projects/packages/search && composer phpunit` — `Search_Input_Render_Test` covers icon show/hide, placeholder fallback/escape, and the `submitOnly` data attribute.
* `pnpm --filter ./projects/packages/search test` — `search-input-block-json.test.js` pins the declared attribute defaults.
