### PR TITLE
Search: filter-checkbox inspector controls + bucketSortOrder

### DIFF
--- a/projects/packages/search/changelog/add-search-144-filter-checkbox-inspector
+++ b/projects/packages/search/changelog/add-search-144-filter-checkbox-inspector
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Search Blocks: filter-checkbox gains inspector controls for label, showCount, and maxItems, plus a bucketSortOrder attribute (count | alpha, default count).
+Search Blocks: add inspector controls for label, showCount, and maxItems, plus a bucketSortOrder attribute (count | alpha, default count) to filter-checkbox.

--- a/projects/packages/search/changelog/add-search-144-filter-checkbox-inspector
+++ b/projects/packages/search/changelog/add-search-144-filter-checkbox-inspector
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Search Blocks: filter-checkbox gains inspector controls for label, showCount, and maxItems, plus a bucketSortOrder attribute (count | alpha, default count).

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/block.json
@@ -24,7 +24,12 @@
 		},
 		"label": { "type": "string", "default": "" },
 		"showCount": { "type": "boolean", "default": true },
-		"maxItems": { "type": "integer", "default": 10 }
+		"maxItems": { "type": "integer", "default": 10 },
+		"bucketSortOrder": {
+			"type": "string",
+			"default": "count",
+			"enum": [ "count", "alpha" ]
+		}
 	},
 	"render": "file:./render.php",
 	"viewScriptModule": "file:../../../../build/search-blocks/filter-checkbox.js",

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/class-filter-checkbox.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/class-filter-checkbox.php
@@ -90,12 +90,26 @@ class Filter_Checkbox {
 		}
 
 		return array(
-			'filterKey'  => $filter_key,
-			'filterType' => (string) ( $attributes['filterType'] ?? '' ),
-			'taxonomy'   => sanitize_key( (string) ( $attributes['taxonomy'] ?? '' ) ),
-			'label'      => $label,
-			'showCount'  => (bool) ( $attributes['showCount'] ?? true ),
-			'maxItems'   => max( 1, (int) ( $attributes['maxItems'] ?? 10 ) ),
+			'filterKey'       => $filter_key,
+			'filterType'      => (string) ( $attributes['filterType'] ?? '' ),
+			'taxonomy'        => sanitize_key( (string) ( $attributes['taxonomy'] ?? '' ) ),
+			'label'           => $label,
+			'showCount'       => (bool) ( $attributes['showCount'] ?? true ),
+			'maxItems'        => max( 1, (int) ( $attributes['maxItems'] ?? 10 ) ),
+			'bucketSortOrder' => static::normalize_bucket_sort_order( $attributes['bucketSortOrder'] ?? null ),
 		);
+	}
+
+	/**
+	 * Normalize the bucketSortOrder attribute. Unknown values fall back to
+	 * `count` so aggregation requests always carry a valid ES `order` key and
+	 * the rendered bucket order matches the instant-search overlay default
+	 * (count, descending).
+	 *
+	 * @param mixed $value Raw attribute value.
+	 * @return string Either 'count' or 'alpha'.
+	 */
+	public static function normalize_bucket_sort_order( $value ): string {
+		return 'alpha' === $value ? 'alpha' : 'count';
 	}
 }

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/class-filter-checkbox.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/class-filter-checkbox.php
@@ -84,7 +84,7 @@ class Filter_Checkbox {
 	 * @return array<string, mixed>
 	 */
 	public static function build_config( array $attributes, string $filter_key ): array {
-		$label = (string) ( $attributes['label'] ?? '' );
+		$label = sanitize_text_field( (string) ( $attributes['label'] ?? '' ) );
 		if ( '' === $label ) {
 			$label = static::default_label( $attributes );
 		}

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
@@ -2,10 +2,22 @@
  * Editor preview for jetpack/filter-checkbox.
  *
  * Shows a labeled list of sample checkbox options mirroring the runtime DOM
- * shape so designers can style the filter list in place.
+ * shape so designers can style the filter list in place. The inspector
+ * exposes the user-tunable attributes (label, showCount, maxItems,
+ * bucketSortOrder); the variation-defining attributes — `filterType` and
+ * `taxonomy` — are set by the Category / Tag / Post Type / Author / Custom
+ * Taxonomy variations registered in class-search-blocks.php and are not
+ * surfaced here to keep block instances routable to a known filter schema.
  */
-import { useBlockProps } from '@wordpress/block-editor';
-import { createElement as h } from '@wordpress/element';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	PanelBody,
+	SelectControl,
+	RangeControl,
+	TextControl,
+	ToggleControl,
+} from '@wordpress/components';
+import { createElement as h, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 const SAMPLE_FILTER_ITEMS = [
@@ -17,33 +29,93 @@ const SAMPLE_FILTER_ITEMS = [
 /**
  * Edit component for the filter-checkbox block.
  *
- * @param {object} props            - Block props.
- * @param {object} props.attributes - Saved block attributes.
+ * @param {object}   props               - Block props.
+ * @param {object}   props.attributes    - Saved block attributes.
+ * @param {Function} props.setAttributes - Attribute setter.
  * @return {object} Rendered element.
  */
-export default function FilterCheckboxEdit( { attributes } ) {
+export default function FilterCheckboxEdit( { attributes, setAttributes } ) {
 	const blockProps = useBlockProps();
-	const label = attributes?.label || __( 'Filter', 'jetpack-search-pkg' );
+	const rawLabel = attributes?.label || '';
+	const previewLabel = rawLabel || __( 'Filter', 'jetpack-search-pkg' );
 	const showCount = attributes?.showCount !== false;
+	const maxItems = Math.max(
+		1,
+		Number.isFinite( attributes?.maxItems ) ? attributes.maxItems : 10
+	);
+	// Unknown values fall back to `count` so the preview controls always
+	// reflect a valid enum option; render.php normalizes the same way.
+	const bucketSortOrder = attributes?.bucketSortOrder === 'alpha' ? 'alpha' : 'count';
 	return h(
-		'div',
-		blockProps,
-		h( 'h3', { className: 'jetpack-search-filter__title' }, label ),
+		Fragment,
+		null,
 		h(
-			'ul',
-			{ className: 'jetpack-search-filter__list' },
-			SAMPLE_FILTER_ITEMS.map( item =>
-				h(
-					'li',
-					{ key: item.value, className: 'jetpack-search-filter__item' },
+			InspectorControls,
+			null,
+			h(
+				PanelBody,
+				{ title: __( 'Settings', 'jetpack-search-pkg' ) },
+				h( TextControl, {
+					__next40pxDefaultSize: true,
+					__nextHasNoMarginBottom: true,
+					label: __( 'Label', 'jetpack-search-pkg' ),
+					value: rawLabel,
+					placeholder: __( 'Filter', 'jetpack-search-pkg' ),
+					onChange: value => setAttributes( { label: value } ),
+					help: __(
+						'Leave empty to use the variation’s default label (e.g. Category, Tag).',
+						'jetpack-search-pkg'
+					),
+				} ),
+				h( ToggleControl, {
+					__nextHasNoMarginBottom: true,
+					label: __( 'Show result counts', 'jetpack-search-pkg' ),
+					checked: showCount,
+					onChange: value => setAttributes( { showCount: !! value } ),
+				} ),
+				h( RangeControl, {
+					__next40pxDefaultSize: true,
+					__nextHasNoMarginBottom: true,
+					label: __( 'Maximum items', 'jetpack-search-pkg' ),
+					value: maxItems,
+					min: 1,
+					max: 50,
+					onChange: value => setAttributes( { maxItems: Math.max( 1, value || 1 ) } ),
+				} ),
+				h( SelectControl, {
+					__next40pxDefaultSize: true,
+					__nextHasNoMarginBottom: true,
+					label: __( 'Sort order', 'jetpack-search-pkg' ),
+					value: bucketSortOrder,
+					options: [
+						{ value: 'count', label: __( 'Most results first', 'jetpack-search-pkg' ) },
+						{ value: 'alpha', label: __( 'Alphabetical', 'jetpack-search-pkg' ) },
+					],
+					onChange: value =>
+						setAttributes( { bucketSortOrder: value === 'alpha' ? 'alpha' : 'count' } ),
+				} )
+			)
+		),
+		h(
+			'div',
+			blockProps,
+			h( 'h3', { className: 'jetpack-search-filter__title' }, previewLabel ),
+			h(
+				'ul',
+				{ className: 'jetpack-search-filter__list' },
+				SAMPLE_FILTER_ITEMS.slice( 0, maxItems ).map( item =>
 					h(
-						'label',
-						null,
-						h( 'input', { type: 'checkbox', disabled: true } ),
-						h( 'span', { className: 'jetpack-search-filter__label' }, item.label ),
-						showCount
-							? h( 'span', { className: 'jetpack-search-filter__count' }, String( item.count ) )
-							: null
+						'li',
+						{ key: item.value, className: 'jetpack-search-filter__item' },
+						h(
+							'label',
+							null,
+							h( 'input', { type: 'checkbox', disabled: true } ),
+							h( 'span', { className: 'jetpack-search-filter__label' }, item.label ),
+							showCount
+								? h( 'span', { className: 'jetpack-search-filter__count' }, String( item.count ) )
+								: null
+						)
 					)
 				)
 			)

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
@@ -31,6 +31,11 @@ const SAMPLE_FILTER_ITEMS = [
  * fallback label for the inspector placeholder. Returns '' for custom
  * taxonomies (caller should then fall back to the generic "Filter").
  *
+ * Keep in sync with Filter_Checkbox::default_label() in
+ * src/search-blocks/blocks/filter-checkbox/class-filter-checkbox.php — both
+ * must recognize the same (filterType, taxonomy) pairs or the empty-label
+ * preview heading will disagree with the server-rendered front end.
+ *
  * @param {object} attributes - Block attributes.
  * @return {string} Variation default label, or '' when not a built-in variation.
  */
@@ -93,7 +98,7 @@ export default function FilterCheckboxEdit( { attributes, setAttributes } ) {
 					placeholder: placeholderLabel,
 					onChange: value => setAttributes( { label: value } ),
 					help: __(
-						'Leave empty to use the variation’s default label (e.g. Category, Tag).',
+						"Leave empty to use the variation's default label (e.g. Category, Tag).",
 						'jetpack-search-pkg'
 					),
 				} ),

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
@@ -27,6 +27,34 @@ const SAMPLE_FILTER_ITEMS = [
 ];
 
 /**
+ * Mirror of Filter_Checkbox::default_label(): resolve the variation-specific
+ * fallback label for the inspector placeholder. Returns '' for custom
+ * taxonomies (caller should then fall back to the generic "Filter").
+ *
+ * @param {object} attributes - Block attributes.
+ * @return {string} Variation default label, or '' when not a built-in variation.
+ */
+function variationDefaultLabel( attributes ) {
+	const filterType = attributes?.filterType || '';
+	if ( filterType === 'post_type' ) {
+		return __( 'Post Type', 'jetpack-search-pkg' );
+	}
+	if ( filterType === 'author' ) {
+		return __( 'Author', 'jetpack-search-pkg' );
+	}
+	if ( filterType === 'taxonomy' ) {
+		const taxonomy = attributes?.taxonomy || '';
+		if ( taxonomy === 'category' ) {
+			return __( 'Category', 'jetpack-search-pkg' );
+		}
+		if ( taxonomy === 'post_tag' ) {
+			return __( 'Tag', 'jetpack-search-pkg' );
+		}
+	}
+	return '';
+}
+
+/**
  * Edit component for the filter-checkbox block.
  *
  * @param {object}   props               - Block props.
@@ -37,7 +65,9 @@ const SAMPLE_FILTER_ITEMS = [
 export default function FilterCheckboxEdit( { attributes, setAttributes } ) {
 	const blockProps = useBlockProps();
 	const rawLabel = attributes?.label || '';
-	const previewLabel = rawLabel || __( 'Filter', 'jetpack-search-pkg' );
+	const variationLabel = variationDefaultLabel( attributes );
+	const placeholderLabel = variationLabel || __( 'Filter', 'jetpack-search-pkg' );
+	const previewLabel = rawLabel || placeholderLabel;
 	const showCount = attributes?.showCount !== false;
 	const maxItems = Math.max(
 		1,
@@ -60,7 +90,7 @@ export default function FilterCheckboxEdit( { attributes, setAttributes } ) {
 					__nextHasNoMarginBottom: true,
 					label: __( 'Label', 'jetpack-search-pkg' ),
 					value: rawLabel,
-					placeholder: __( 'Filter', 'jetpack-search-pkg' ),
+					placeholder: placeholderLabel,
 					onChange: value => setAttributes( { label: value } ),
 					help: __(
 						'Leave empty to use the variation’s default label (e.g. Category, Tag).',

--- a/projects/packages/search/src/search-blocks/store/api.js
+++ b/projects/packages/search/src/search-blocks/store/api.js
@@ -92,6 +92,14 @@ export function resolveFilterFields( config ) {
  * Build ES aggregation requests from the filterConfigs registered by each
  * filter-checkbox block's render.php.
  *
+ * The `order` key maps the block's `bucketSortOrder` attribute to the ES
+ * `terms` agg order clause: `count` → `{ _count: 'desc' }` (the ES default,
+ * matched to the instant-search overlay), `alpha` → `{ _key: 'asc' }` which
+ * sorts by the aggregation's slug_slash_name key. That's "good enough"
+ * alphabetical for built-in variations since the slug typically leads with
+ * the same letter as the display name; a label-accurate sort would require
+ * a post-aggregation resort in the client.
+ *
  * @param {object} filterConfigs - { [filterKey]: FilterConfig } map.
  * @return {object} Aggregations payload for the v1.3 search API.
  */
@@ -102,8 +110,13 @@ export function buildAggregations( filterConfigs ) {
 		if ( ! aggField ) {
 			continue;
 		}
+		const order = config?.bucketSortOrder === 'alpha' ? { _key: 'asc' } : { _count: 'desc' };
 		aggregations[ filterKey ] = {
-			terms: { field: aggField, size: Math.max( 1, config.maxItems ?? 10 ) },
+			terms: {
+				field: aggField,
+				size: Math.max( 1, config.maxItems ?? 10 ),
+				order,
+			},
 		};
 	}
 	return aggregations;

--- a/projects/packages/search/tests/js/search-blocks/api.test.js
+++ b/projects/packages/search/tests/js/search-blocks/api.test.js
@@ -133,6 +133,31 @@ describe( 'buildSearchUrl', () => {
 		);
 	} );
 
+	it( 'flattens per-filter bucketSortOrder into the aggregation URL params', () => {
+		const url = buildSearchUrl( {
+			siteId: 12345,
+			searchQuery: 'boots',
+			sortOrder: 'relevance',
+			pageHandle: null,
+			isPrivateSite: false,
+			isWpcom: false,
+			apiRoot: 'https://example.com/wp-json/',
+			filterConfigs: {
+				category: {
+					filterType: 'taxonomy',
+					taxonomy: 'category',
+					maxItems: 10,
+					bucketSortOrder: 'count',
+				},
+				authors: { filterType: 'author', maxItems: 5, bucketSortOrder: 'alpha' },
+			},
+		} );
+		// Default `count` → _count=desc.
+		expect( url ).toContain( 'aggregations%5Bcategory%5D%5Bterms%5D%5Border%5D%5B_count%5D=desc' );
+		// `alpha` → _key=asc on the per-filter agg.
+		expect( url ).toContain( 'aggregations%5Bauthors%5D%5Bterms%5D%5Border%5D%5B_key%5D=asc' );
+	} );
+
 	it( 'omits aggregations and filter when no configs or selections are supplied', () => {
 		const url = buildSearchUrl( {
 			siteId: 12345,
@@ -210,8 +235,20 @@ describe( 'buildAggregations', () => {
 			authors: { filterType: 'author', maxItems: 5 },
 		} );
 		expect( aggs ).toEqual( {
-			category: { terms: { field: 'category.slug_slash_name', size: 7 } },
-			authors: { terms: { field: 'author_login_slash_name', size: 5 } },
+			category: {
+				terms: {
+					field: 'category.slug_slash_name',
+					size: 7,
+					order: { _count: 'desc' },
+				},
+			},
+			authors: {
+				terms: {
+					field: 'author_login_slash_name',
+					size: 5,
+					order: { _count: 'desc' },
+				},
+			},
 		} );
 	} );
 
@@ -227,6 +264,27 @@ describe( 'buildAggregations', () => {
 			bogus: { filterType: 'taxonomy', taxonomy: '' },
 		} );
 		expect( aggs ).toEqual( {} );
+	} );
+
+	it( 'uses `_count: desc` order by default (instant-search parity)', () => {
+		const aggs = buildAggregations( {
+			category: { filterType: 'taxonomy', taxonomy: 'category' },
+		} );
+		expect( aggs.category.terms.order ).toEqual( { _count: 'desc' } );
+	} );
+
+	it( 'maps bucketSortOrder=alpha to `_key: asc`', () => {
+		const aggs = buildAggregations( {
+			category: { filterType: 'taxonomy', taxonomy: 'category', bucketSortOrder: 'alpha' },
+		} );
+		expect( aggs.category.terms.order ).toEqual( { _key: 'asc' } );
+	} );
+
+	it( 'falls back to `_count: desc` for unknown bucketSortOrder values', () => {
+		const aggs = buildAggregations( {
+			category: { filterType: 'taxonomy', taxonomy: 'category', bucketSortOrder: 'bogus' },
+		} );
+		expect( aggs.category.terms.order ).toEqual( { _count: 'desc' } );
 	} );
 } );
 

--- a/projects/packages/search/tests/php/Filter_Checkbox_Test.php
+++ b/projects/packages/search/tests/php/Filter_Checkbox_Test.php
@@ -190,6 +190,23 @@ class Filter_Checkbox_Test extends TestCase {
 	}
 
 	/**
+	 * The label passes through sanitize_text_field() before it reaches the
+	 * Interactivity state so stored block attributes with stray HTML, tabs, or
+	 * newlines can never leak into aggregation-layer metadata or the rendered
+	 * heading. Output is still esc_html()'d separately in render.php.
+	 */
+	public function test_build_config_sanitizes_label() {
+		$config = Filter_Checkbox::build_config(
+			array(
+				'filterType' => 'post_type',
+				'label'      => "  <b>Topic</b>\nextra  ",
+			),
+			'post_types'
+		);
+		$this->assertSame( 'Topic extra', $config['label'] );
+	}
+
+	/**
 	 * An invalid bucketSortOrder in the stored attributes must never reach
 	 * the config map — the JS `buildAggregations()` path maps anything
 	 * non-'alpha' to the count-desc order, but normalizing up front keeps

--- a/projects/packages/search/tests/php/Filter_Checkbox_Test.php
+++ b/projects/packages/search/tests/php/Filter_Checkbox_Test.php
@@ -125,7 +125,7 @@ class Filter_Checkbox_Test extends TestCase {
 	/**
 	 * Config shape mirrors what the JS store consumes: missing label falls
 	 * back to default_label(); falsy `showCount` round-trips as a boolean;
-	 * `maxItems` clamps to >= 1.
+	 * `maxItems` clamps to >= 1; `bucketSortOrder` defaults to `count`.
 	 */
 	public function test_build_config_shape_and_defaults() {
 		$config = Filter_Checkbox::build_config(
@@ -137,12 +137,13 @@ class Filter_Checkbox_Test extends TestCase {
 		);
 		$this->assertSame(
 			array(
-				'filterKey'  => 'category',
-				'filterType' => 'taxonomy',
-				'taxonomy'   => 'category',
-				'label'      => 'Category',
-				'showCount'  => true,
-				'maxItems'   => 10,
+				'filterKey'       => 'category',
+				'filterType'      => 'taxonomy',
+				'taxonomy'        => 'category',
+				'label'           => 'Category',
+				'showCount'       => true,
+				'maxItems'        => 10,
+				'bucketSortOrder' => 'count',
 			),
 			$config
 		);
@@ -150,17 +151,19 @@ class Filter_Checkbox_Test extends TestCase {
 		// Explicit label wins over the default.
 		$custom = Filter_Checkbox::build_config(
 			array(
-				'filterType' => 'taxonomy',
-				'taxonomy'   => 'category',
-				'label'      => 'Topic',
-				'showCount'  => false,
-				'maxItems'   => 5,
+				'filterType'      => 'taxonomy',
+				'taxonomy'        => 'category',
+				'label'           => 'Topic',
+				'showCount'       => false,
+				'maxItems'        => 5,
+				'bucketSortOrder' => 'alpha',
 			),
 			'category'
 		);
 		$this->assertSame( 'Topic', $custom['label'] );
 		$this->assertFalse( $custom['showCount'] );
 		$this->assertSame( 5, $custom['maxItems'] );
+		$this->assertSame( 'alpha', $custom['bucketSortOrder'] );
 
 		// maxItems must clamp to at least 1 so the ES aggregation size is valid.
 		$clamped = Filter_Checkbox::build_config(
@@ -171,5 +174,35 @@ class Filter_Checkbox_Test extends TestCase {
 			'post_types'
 		);
 		$this->assertSame( 1, $clamped['maxItems'] );
+	}
+
+	/**
+	 * The bucketSortOrder attribute accepts only `count` | `alpha`; anything
+	 * else falls back to `count` so aggregation requests always have a valid
+	 * `order` clause and bucket order matches the instant-search overlay default.
+	 */
+	public function test_normalize_bucket_sort_order() {
+		$this->assertSame( 'count', Filter_Checkbox::normalize_bucket_sort_order( null ) );
+		$this->assertSame( 'count', Filter_Checkbox::normalize_bucket_sort_order( '' ) );
+		$this->assertSame( 'count', Filter_Checkbox::normalize_bucket_sort_order( 'count' ) );
+		$this->assertSame( 'count', Filter_Checkbox::normalize_bucket_sort_order( 'bogus' ) );
+		$this->assertSame( 'alpha', Filter_Checkbox::normalize_bucket_sort_order( 'alpha' ) );
+	}
+
+	/**
+	 * An invalid bucketSortOrder in the stored attributes must never reach
+	 * the config map — the JS `buildAggregations()` path maps anything
+	 * non-'alpha' to the count-desc order, but normalizing up front keeps
+	 * the serialized Interactivity state narrow.
+	 */
+	public function test_build_config_falls_back_bucket_sort_order_for_unknown_values() {
+		$config = Filter_Checkbox::build_config(
+			array(
+				'filterType'      => 'post_type',
+				'bucketSortOrder' => 'something-else',
+			),
+			'post_types'
+		);
+		$this->assertSame( 'count', $config['bucketSortOrder'] );
 	}
 }


### PR DESCRIPTION
## Proposed changes
* Expose `label`, `showCount`, and `maxItems` in the filter-checkbox block inspector (all three were already declared in `block.json` but had no editor UI).
* Add a new `bucketSortOrder` attribute (enum `count` | `alpha`, default `count`) with a SelectControl in the inspector. `count` preserves parity with the instant-search overlay (ES `terms` agg default of `_count: desc`); `alpha` maps to `_key: asc`.
* `Filter_Checkbox::build_config()` + a new `normalize_bucket_sort_order()` helper carry the attribute through to the JS store; `buildAggregations()` wires the `order` clause onto each per-filter `terms` agg.
* Unit tests: PHP `test_normalize_bucket_sort_order` + updated `test_build_config_shape_and_defaults`; JS cases for default/alpha/unknown in `buildAggregations` plus an integration test asserting the flattened aggregation URL params carry the per-filter `order` key.
* Changelog entry: `add-search-144-filter-checkbox-inspector` (patch / added).

## Related product discussion/links
* Linear: https://linear.app/a8c/issue/SEARCH-144/filter-checkbox-inspector-exposure-bucket-sort-order

## Does this pull request change what data or activity we track or use?
No.

## Screenshots

Before / after captured on a live WP editor at 1440×900 — see [the full comparison comment](https://github.com/Automattic/jetpack/pull/48281#issuecomment-4310403309) for the editor + network-URL diffs.

| Before (`trunk`) | After (PR) |
|---|---|
| ![before-editor](https://github.com/user-attachments/assets/8ec31ef0-3e0c-488d-9cc6-280cdeaaf737) | ![after-editor](https://github.com/user-attachments/assets/6e2eb69b-50fa-406a-a5a4-53fb9592d0dd) |

## Testing instructions

### Inspector controls (editor)
1. On a site with Jetpack Search available, open any post/page and insert the **Checkbox Filter** block (or any of the Category / Tag / Post Type / Author / Custom Taxonomy variations).
2. Open the block inspector → **Settings**. Confirm the panel now exposes:
   * **Label** — a text input with a help message noting that the variation default is used when empty.
   * **Show result counts** — toggle. Disabling it hides the count span in the editor preview and on the front end.
   * **Maximum items** — range 1–50. Dropping below the sample preview count (3) trims the in-editor preview list.
   * **Sort order** — select with "Most results first" (`count`) and "Alphabetical" (`alpha`).
3. Save the post. Reopen it; attribute values round-trip.

### bucketSortOrder — aggregation request shape
1. With the block inserted on a search page, load the front end and inspect the outgoing request to `public-api.wordpress.com/rest/v1.3/sites/<id>/search` (or the Atomic / wpcom-origin equivalent for private sites).
2. With **Sort order → Most results first**, confirm the URL contains `aggregations[<filterKey>][terms][order][_count]=desc` (URL-encoded).
3. Switch the block to **Alphabetical**, save, and reload. Confirm the URL now contains `aggregations[<filterKey>][terms][order][_key]=asc`.
4. Confirm the aggregation bucket list in the rendered filter reorders accordingly (count-desc vs. key-asc).

### Regression
1. Confirm the existing Category / Tag / Post Type / Author / Custom Taxonomy variations still set `filterType` + `taxonomy` correctly — those attributes remain variation-driven and are **not** surfaced in the inspector.
2. `composer phpunit` in `projects/packages/search` passes (190 tests).
3. `pnpm run test-scripts` in the same package passes (208 tests).
