### PR TITLE
Search: sort-control default sort + presentation controls

### DIFF
--- a/projects/packages/search/changelog/add-search-138-sort-control-attrs
+++ b/projects/packages/search/changelog/add-search-138-sort-control-attrs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Search Blocks: sort-control gains defaultSort, availableSortOptions, label, and displayAs attributes.

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/block.json
@@ -9,6 +9,24 @@
 	"description": "Controls the order of Jetpack Search results.",
 	"supports": { "html": false, "interactivity": true },
 	"textdomain": "jetpack-search-pkg",
+	"attributes": {
+		"defaultSort": {
+			"type": "string",
+			"default": "relevance",
+			"enum": [ "relevance", "newest", "oldest", "rating_desc", "price_asc", "price_desc" ]
+		},
+		"availableSortOptions": {
+			"type": "array",
+			"default": [ "relevance", "newest", "oldest", "rating_desc", "price_asc", "price_desc" ],
+			"items": { "type": "string" }
+		},
+		"label": { "type": "string", "default": "" },
+		"displayAs": {
+			"type": "string",
+			"default": "select",
+			"enum": [ "select", "radio" ]
+		}
+	},
 	"render": "file:./render.php",
 	"viewScriptModule": "file:../../../../build/search-blocks/sort-control.js",
 	"style": "file:../../../../build/search-blocks/sort-control.css"

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/block.json
@@ -13,14 +13,14 @@
 		"defaultSort": {
 			"type": "string",
 			"default": "relevance",
-			"enum": [ "relevance", "newest", "oldest", "rating_desc", "price_asc", "price_desc" ]
+			"enum": [ "relevance", "newest", "oldest" ]
 		},
 		"availableSortOptions": {
 			"type": "array",
 			"default": [ "relevance", "newest", "oldest" ],
 			"items": {
 				"type": "string",
-				"enum": [ "relevance", "newest", "oldest", "rating_desc", "price_asc", "price_desc" ]
+				"enum": [ "relevance", "newest", "oldest" ]
 			}
 		},
 		"label": { "type": "string", "default": "" },

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/block.json
@@ -17,7 +17,7 @@
 		},
 		"availableSortOptions": {
 			"type": "array",
-			"default": [ "relevance", "newest", "oldest", "rating_desc", "price_asc", "price_desc" ],
+			"default": [ "relevance", "newest", "oldest" ],
 			"items": {
 				"type": "string",
 				"enum": [ "relevance", "newest", "oldest", "rating_desc", "price_asc", "price_desc" ]

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/block.json
@@ -18,7 +18,10 @@
 		"availableSortOptions": {
 			"type": "array",
 			"default": [ "relevance", "newest", "oldest", "rating_desc", "price_asc", "price_desc" ],
-			"items": { "type": "string" }
+			"items": {
+				"type": "string",
+				"enum": [ "relevance", "newest", "oldest", "rating_desc", "price_asc", "price_desc" ]
+			}
 		},
 		"label": { "type": "string", "default": "" },
 		"displayAs": {

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/class-sort-control.php
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/class-sort-control.php
@@ -20,31 +20,20 @@ class Sort_Control {
 
 	/**
 	 * Sort keys valid on the non-product side of the store. `parse_url_sort()`
-	 * on Search_Blocks only parses these three, so keeping a block's
-	 * `defaultSort` to one of them guarantees the URL-round-trip path stays
-	 * intact. Product-format keys (rating/price) are appended conditionally at
-	 * render time by `get_all_option_keys()`.
+	 * on Search_Blocks only parses these three, and the block intentionally
+	 * exposes the same set — product-format keys (rating/price) land in a
+	 * WooCommerce integration follow-up (RSM-1082).
 	 */
 	const BASE_SORT_KEYS = array( 'relevance', 'newest', 'oldest' );
 
 	/**
-	 * Product-format-only sort keys. Always exposed at the block level per the
-	 * pragmatic choice in SEARCH-138: the editor author sees them as options,
-	 * and the runtime store decides whether to apply them based on
-	 * `resultFormat`. Listing them here keeps render.php/edit.js from having
-	 * to know about WooCommerce directly.
-	 */
-	const PRODUCT_SORT_KEYS = array( 'rating_desc', 'price_asc', 'price_desc' );
-
-	/**
 	 * All keys the block may render. Order is meaningful — `<option>` / radio
-	 * rows come out in this sequence, so base keys stay ahead of
-	 * product-only keys for non-product stores.
+	 * rows come out in this sequence.
 	 *
 	 * @return string[]
 	 */
 	public static function get_all_option_keys(): array {
-		return array_merge( self::BASE_SORT_KEYS, self::PRODUCT_SORT_KEYS );
+		return self::BASE_SORT_KEYS;
 	}
 
 	/**
@@ -56,12 +45,9 @@ class Sort_Control {
 	 */
 	public static function get_option_labels(): array {
 		return array(
-			'relevance'   => __( 'Relevance', 'jetpack-search-pkg' ),
-			'newest'      => __( 'Newest', 'jetpack-search-pkg' ),
-			'oldest'      => __( 'Oldest', 'jetpack-search-pkg' ),
-			'rating_desc' => __( 'Rating', 'jetpack-search-pkg' ),
-			'price_asc'   => __( 'Price: low to high', 'jetpack-search-pkg' ),
-			'price_desc'  => __( 'Price: high to low', 'jetpack-search-pkg' ),
+			'relevance' => __( 'Relevance', 'jetpack-search-pkg' ),
+			'newest'    => __( 'Newest', 'jetpack-search-pkg' ),
+			'oldest'    => __( 'Oldest', 'jetpack-search-pkg' ),
 		);
 	}
 

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/class-sort-control.php
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/class-sort-control.php
@@ -12,9 +12,11 @@ namespace Automattic\Jetpack\Search;
  *
  * Centralizes the list of valid sort keys, their translated labels, and the
  * attribute-normalization logic so render.php and the block's own unit tests
- * share one source of truth. Keys mirror `VALID_SORT_KEYS` in
- * src/instant-search/lib/constants.js so deep links round-trip between the
- * two surfaces.
+ * share one source of truth. The block currently exposes only the base sort
+ * keys (`relevance`, `newest`, `oldest`); product-format keys present in
+ * instant-search's `VALID_SORT_KEYS` (src/instant-search/lib/constants.js)
+ * are intentionally deferred to the WooCommerce integration tracked under
+ * RSM-1082.
  */
 class Sort_Control {
 
@@ -140,8 +142,11 @@ class Sort_Control {
 	 * @return string|null Sort key or null when no URL sort is present.
 	 */
 	public static function parse_url_sort( ?array $allowed_keys = null ): ?string {
+		// `?orderby[]=x` lands as an array — passing that to sanitize_key()
+		// would emit a PHP warning (and PHPUnit fails on those). Bail early
+		// so a malformed URL can't poison the rendered control.
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only URL state.
-		if ( ! isset( $_GET['orderby'] ) ) {
+		if ( ! isset( $_GET['orderby'] ) || ! is_scalar( $_GET['orderby'] ) ) {
 			return null;
 		}
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only URL state.

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/class-sort-control.php
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/class-sort-control.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Sort-control block helpers.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+/**
+ * Helper methods for the jetpack/sort-control block.
+ *
+ * Centralizes the list of valid sort keys, their translated labels, and the
+ * attribute-normalization logic so render.php and the block's own unit tests
+ * share one source of truth. Keys mirror `VALID_SORT_KEYS` in
+ * src/instant-search/lib/constants.js so deep links round-trip between the
+ * two surfaces.
+ */
+class Sort_Control {
+
+	/**
+	 * Sort keys valid on the non-product side of the store. `parse_url_sort()`
+	 * on Search_Blocks only parses these three, so keeping a block's
+	 * `defaultSort` to one of them guarantees the URL-round-trip path stays
+	 * intact. Product-format keys (rating/price) are appended conditionally at
+	 * render time by `get_all_option_keys()`.
+	 */
+	const BASE_SORT_KEYS = array( 'relevance', 'newest', 'oldest' );
+
+	/**
+	 * Product-format-only sort keys. Always exposed at the block level per the
+	 * pragmatic choice in SEARCH-138: the editor author sees them as options,
+	 * and the runtime store decides whether to apply them based on
+	 * `resultFormat`. Listing them here keeps render.php/edit.js from having
+	 * to know about WooCommerce directly.
+	 */
+	const PRODUCT_SORT_KEYS = array( 'rating_desc', 'price_asc', 'price_desc' );
+
+	/**
+	 * All keys the block may render. Order is meaningful — `<option>` / radio
+	 * rows come out in this sequence, so base keys stay ahead of
+	 * product-only keys for non-product stores.
+	 *
+	 * @return string[]
+	 */
+	public static function get_all_option_keys(): array {
+		return array_merge( self::BASE_SORT_KEYS, self::PRODUCT_SORT_KEYS );
+	}
+
+	/**
+	 * Translated labels for each sort key. A separate accessor (rather than a
+	 * class constant) so the strings go through `__()` at call time — class
+	 * constants can't hold translation-function output.
+	 *
+	 * @return array<string, string>  Map of sort key → label.
+	 */
+	public static function get_option_labels(): array {
+		return array(
+			'relevance'   => __( 'Relevance', 'jetpack-search-pkg' ),
+			'newest'      => __( 'Newest', 'jetpack-search-pkg' ),
+			'oldest'      => __( 'Oldest', 'jetpack-search-pkg' ),
+			'rating_desc' => __( 'Rating', 'jetpack-search-pkg' ),
+			'price_asc'   => __( 'Price: low to high', 'jetpack-search-pkg' ),
+			'price_desc'  => __( 'Price: high to low', 'jetpack-search-pkg' ),
+		);
+	}
+
+	/**
+	 * Normalize the `defaultSort` attribute. Any unknown value — including a
+	 * missing attribute on legacy posts — collapses to `relevance` so the
+	 * fallback matches the `parse_url_sort()` default on the Search_Blocks
+	 * class and the store's `DEFAULT_SORT_ORDER` in url-state.js.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string
+	 */
+	public static function normalize_default_sort( array $attributes ): string {
+		$candidate = (string) ( $attributes['defaultSort'] ?? 'relevance' );
+		return in_array( $candidate, self::get_all_option_keys(), true ) ? $candidate : 'relevance';
+	}
+
+	/**
+	 * Resolve the final ordered list of sort keys this block will render.
+	 * Preserves the canonical order from `get_all_option_keys()` rather than
+	 * the order the attribute array arrived in — keeps the UI stable across
+	 * saves and prevents a garbage attribute value (unknown key) from leaking
+	 * into the rendered DOM.
+	 *
+	 * Whenever the filtered list would be empty (attribute is empty, or every
+	 * entry is unknown) we fall back to the full set so an author's
+	 * misconfiguration never renders a dropdown with zero options.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string[]
+	 */
+	public static function resolve_available_options( array $attributes ): array {
+		$all      = self::get_all_option_keys();
+		$provided = $attributes['availableSortOptions'] ?? null;
+		if ( ! is_array( $provided ) ) {
+			return $all;
+		}
+		$allowed = array_values(
+			array_filter(
+				$all,
+				static function ( $key ) use ( $provided ) {
+					return in_array( $key, $provided, true );
+				}
+			)
+		);
+		if ( empty( $allowed ) ) {
+			return $all;
+		}
+		return $allowed;
+	}
+
+	/**
+	 * Normalize the `displayAs` attribute. Unknown values collapse to
+	 * `select` so a garbage attribute can't produce markup the view script
+	 * doesn't know how to bind against.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string  'select' or 'radio'.
+	 */
+	public static function normalize_display_as( array $attributes ): string {
+		$candidate = (string) ( $attributes['displayAs'] ?? 'select' );
+		return 'radio' === $candidate ? 'radio' : 'select';
+	}
+
+	/**
+	 * Resolve the user-visible label. Falls back to the translated default
+	 * "Sort by" when the author hasn't supplied one — mirrors the pre-
+	 * SEARCH-138 copy so posts saved before the attribute existed keep the
+	 * same labelling.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string
+	 */
+	public static function resolve_label( array $attributes ): string {
+		$label = trim( (string) ( $attributes['label'] ?? '' ) );
+		if ( '' === $label ) {
+			return __( 'Sort by', 'jetpack-search-pkg' );
+		}
+		return $label;
+	}
+
+	/**
+	 * Read `?orderby=…` off the current request. Returns the key when it
+	 * matches one of the exposed options, or `null` when the URL has no
+	 * sort parameter (or the value is unrecognized) — letting the caller
+	 * fall back to the block's `defaultSort` attribute.
+	 *
+	 * Mirrors `Search_Blocks::parse_url_sort()` but extends the accepted
+	 * set to every option this block may render: a radio UI can expose a
+	 * product-format sort key the Search_Blocks state-seeder doesn't
+	 * recognise, and a deep link to that key should still select it.
+	 *
+	 * @param string[]|null $allowed_keys Restrict accepted values to this
+	 *   list. Defaults to every option the block knows about.
+	 * @return string|null Sort key or null when no URL sort is present.
+	 */
+	public static function parse_url_sort( ?array $allowed_keys = null ): ?string {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only URL state.
+		if ( ! isset( $_GET['orderby'] ) ) {
+			return null;
+		}
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only URL state.
+		$raw  = sanitize_key( wp_unslash( $_GET['orderby'] ) );
+		$pool = $allowed_keys ?? self::get_all_option_keys();
+		return in_array( $raw, $pool, true ) ? $raw : null;
+	}
+}

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/class-sort-control.php
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/class-sort-control.php
@@ -18,12 +18,7 @@ namespace Automattic\Jetpack\Search;
  */
 class Sort_Control {
 
-	/**
-	 * Sort keys valid on the non-product side of the store. `parse_url_sort()`
-	 * on Search_Blocks only parses these three, and the block intentionally
-	 * exposes the same set — product-format keys (rating/price) land in a
-	 * WooCommerce integration follow-up (RSM-1082).
-	 */
+	/** Product-format keys (rating/price) land in RSM-1082. */
 	const BASE_SORT_KEYS = array( 'relevance', 'newest', 'oldest' );
 
 	/**

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/edit.js
@@ -11,13 +11,10 @@ import { CheckboxControl, PanelBody, SelectControl, TextControl } from '@wordpre
 import { createElement as h, Fragment, useId } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
-// Keep the base / product-format split aligned with Sort_Control::BASE_SORT_KEYS
-// and ::PRODUCT_SORT_KEYS on the PHP side. A divergence here would let the
-// editor expose a key the render callback drops, so the author would set up
-// a Sort by … option that never appears on the front end.
-const BASE_SORT_KEYS = [ 'relevance', 'newest', 'oldest' ];
-const PRODUCT_SORT_KEYS = [ 'rating_desc', 'price_asc', 'price_desc' ];
-const ALL_SORT_KEYS = [ ...BASE_SORT_KEYS, ...PRODUCT_SORT_KEYS ];
+// Must stay in lock-step with Sort_Control::BASE_SORT_KEYS on the PHP side.
+// Product-format keys (rating/price) will rejoin once the WooCommerce
+// integration lands — tracked in RSM-1082.
+const ALL_SORT_KEYS = [ 'relevance', 'newest', 'oldest' ];
 
 /**
  * Translated human-readable labels for each sort key. Declared as a function
@@ -32,9 +29,6 @@ function getSortLabels() {
 		relevance: __( 'Relevance', 'jetpack-search-pkg' ),
 		newest: __( 'Newest', 'jetpack-search-pkg' ),
 		oldest: __( 'Oldest', 'jetpack-search-pkg' ),
-		rating_desc: __( 'Rating', 'jetpack-search-pkg' ),
-		price_asc: __( 'Price: low to high', 'jetpack-search-pkg' ),
-		price_desc: __( 'Price: high to low', 'jetpack-search-pkg' ),
 	};
 }
 

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/edit.js
@@ -111,8 +111,18 @@ export default function SortControlEdit( { attributes, setAttributes } ) {
 				__next40pxDefaultSize: true,
 				__nextHasNoMarginBottom: true,
 				label: __( 'Default sort', 'jetpack-search-pkg' ),
-				value: defaultSort,
-				options: ALL_SORT_KEYS.map( key => ( { value: key, label: labels[ key ] } ) ),
+				// Use the `defaultSort` attribute when it's still in `available`
+				// so the <select> stays bound to its persisted value. When the
+				// author has just unchecked the current default from the list,
+				// fall back to the first available option so the control binds
+				// to something visible instead of rendering a blank selection.
+				value: available.includes( defaultSort ) ? defaultSort : available[ 0 ],
+				// Only offer keys the author has actually enabled. Showing the
+				// full list here would let the author pick a default that
+				// `availableSortOptions` excludes — the render callback already
+				// falls back gracefully, but the editor would misleadingly show
+				// a "saved default" the front end never honors.
+				options: available.map( key => ( { value: key, label: labels[ key ] } ) ),
 				onChange: value => setAttributes( { defaultSort: value } ),
 				help: __(
 					'Applied on first load when the URL carries no sort parameter.',

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/edit.js
@@ -1,33 +1,185 @@
 /**
  * Editor preview for jetpack/sort-control.
  *
- * Pairs the label and select via htmlFor/id so the preview has the same
- * a11y semantics as render.php.
+ * Mirrors the DOM shape of render.php so authors see the live block match
+ * the `displayAs` / `availableSortOptions` / `label` / `defaultSort`
+ * attributes without needing to flip to the front end. Pairs the label and
+ * control via htmlFor/id so the preview has the same a11y semantics too.
  */
-import { useBlockProps } from '@wordpress/block-editor';
-import { createElement as h, useId } from '@wordpress/element';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { CheckboxControl, PanelBody, SelectControl, TextControl } from '@wordpress/components';
+import { createElement as h, Fragment, useId } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+
+// Keep the base / product-format split aligned with Sort_Control::BASE_SORT_KEYS
+// and ::PRODUCT_SORT_KEYS on the PHP side. A divergence here would let the
+// editor expose a key the render callback drops, so the author would set up
+// a Sort by … option that never appears on the front end.
+const BASE_SORT_KEYS = [ 'relevance', 'newest', 'oldest' ];
+const PRODUCT_SORT_KEYS = [ 'rating_desc', 'price_asc', 'price_desc' ];
+const ALL_SORT_KEYS = [ ...BASE_SORT_KEYS, ...PRODUCT_SORT_KEYS ];
+
+/**
+ * Translated human-readable labels for each sort key. Declared as a function
+ * (rather than a module-level object) so the `__()` calls run after the
+ * block editor's i18n is loaded — otherwise the strings would be cached in
+ * the source locale on module init.
+ *
+ * @return {Object<string,string>} Map of sort key → label.
+ */
+function getSortLabels() {
+	return {
+		relevance: __( 'Relevance', 'jetpack-search-pkg' ),
+		newest: __( 'Newest', 'jetpack-search-pkg' ),
+		oldest: __( 'Oldest', 'jetpack-search-pkg' ),
+		rating_desc: __( 'Rating', 'jetpack-search-pkg' ),
+		price_asc: __( 'Price: low to high', 'jetpack-search-pkg' ),
+		price_desc: __( 'Price: high to low', 'jetpack-search-pkg' ),
+	};
+}
+
+/**
+ * Resolve the effective list of sort keys to render. Mirrors
+ * `Sort_Control::resolve_available_options()` on the PHP side: unknown keys
+ * drop, canonical order wins, and an empty list falls back to the full set
+ * so a misconfigured block never shows a control with zero options.
+ *
+ * @param {string[]|undefined} stored - Saved `availableSortOptions` value.
+ * @return {string[]} Ordered sort keys to render.
+ */
+function resolveAvailable( stored ) {
+	if ( ! Array.isArray( stored ) ) {
+		return ALL_SORT_KEYS;
+	}
+	const filtered = ALL_SORT_KEYS.filter( key => stored.includes( key ) );
+	return filtered.length === 0 ? ALL_SORT_KEYS : filtered;
+}
 
 /**
  * Edit component for the sort-control block.
  *
+ * @param {object}   props               - Block props.
+ * @param {object}   props.attributes    - Saved block attributes.
+ * @param {Function} props.setAttributes - Attribute setter.
  * @return {object} Rendered element.
  */
-export default function SortControlEdit() {
+export default function SortControlEdit( { attributes, setAttributes } ) {
 	const blockProps = useBlockProps();
-	// Per-instance id keeps the label→select association valid when the editor
-	// renders more than one Sort Control on the same canvas.
-	const selectId = useId();
-	return h(
-		'div',
-		blockProps,
-		h( 'label', { htmlFor: selectId }, __( 'Sort by', 'jetpack-search-pkg' ) ),
+	// Per-instance id keeps the label→control association valid when the
+	// editor renders more than one Sort Control on the same canvas.
+	const baseId = useId();
+
+	const labels = getSortLabels();
+	const defaultSort = ALL_SORT_KEYS.includes( attributes?.defaultSort )
+		? attributes.defaultSort
+		: 'relevance';
+	const displayAs = 'radio' === attributes?.displayAs ? 'radio' : 'select';
+	const storedAvailable = Array.isArray( attributes?.availableSortOptions )
+		? attributes.availableSortOptions
+		: ALL_SORT_KEYS;
+	const available = resolveAvailable( storedAvailable );
+	const labelText = ( attributes?.label || '' ).trim() || __( 'Sort by', 'jetpack-search-pkg' );
+
+	// If the saved default no longer appears in `availableSortOptions` (e.g.
+	// the author just unchecked it), fall back to the first visible option so
+	// the preview reflects a value the dropdown can actually represent.
+	const previewSelected = available.includes( defaultSort ) ? defaultSort : available[ 0 ];
+
+	const toggleAvailable = ( sortKey, checked ) => {
+		const next = checked
+			? ALL_SORT_KEYS.filter( key => key === sortKey || storedAvailable.includes( key ) )
+			: storedAvailable.filter( key => key !== sortKey );
+		setAttributes( { availableSortOptions: next } );
+	};
+
+	const inspector = h(
+		InspectorControls,
+		null,
 		h(
-			'select',
-			{ id: selectId, disabled: true, defaultValue: 'relevance' },
-			h( 'option', { value: 'relevance' }, __( 'Relevance', 'jetpack-search-pkg' ) ),
-			h( 'option', { value: 'newest' }, __( 'Newest', 'jetpack-search-pkg' ) ),
-			h( 'option', { value: 'oldest' }, __( 'Oldest', 'jetpack-search-pkg' ) )
+			PanelBody,
+			{ title: __( 'Sort Settings', 'jetpack-search-pkg' ) },
+			h( TextControl, {
+				__next40pxDefaultSize: true,
+				__nextHasNoMarginBottom: true,
+				label: __( 'Label', 'jetpack-search-pkg' ),
+				value: attributes?.label || '',
+				placeholder: __( 'Sort by', 'jetpack-search-pkg' ),
+				onChange: value => setAttributes( { label: value } ),
+				help: __( 'Leave empty to use the default translated label.', 'jetpack-search-pkg' ),
+			} ),
+			h( SelectControl, {
+				__next40pxDefaultSize: true,
+				__nextHasNoMarginBottom: true,
+				label: __( 'Default sort', 'jetpack-search-pkg' ),
+				value: defaultSort,
+				options: ALL_SORT_KEYS.map( key => ( { value: key, label: labels[ key ] } ) ),
+				onChange: value => setAttributes( { defaultSort: value } ),
+				help: __(
+					'Applied on first load when the URL carries no sort parameter.',
+					'jetpack-search-pkg'
+				),
+			} ),
+			h( SelectControl, {
+				__next40pxDefaultSize: true,
+				__nextHasNoMarginBottom: true,
+				label: __( 'Display as', 'jetpack-search-pkg' ),
+				value: displayAs,
+				options: [
+					{ value: 'select', label: __( 'Dropdown', 'jetpack-search-pkg' ) },
+					{ value: 'radio', label: __( 'Radio buttons', 'jetpack-search-pkg' ) },
+				],
+				onChange: value => setAttributes( { displayAs: value } ),
+			} )
+		),
+		h(
+			PanelBody,
+			{ title: __( 'Available options', 'jetpack-search-pkg' ) },
+			ALL_SORT_KEYS.map( key =>
+				h( CheckboxControl, {
+					key,
+					__nextHasNoMarginBottom: true,
+					label: labels[ key ],
+					checked: storedAvailable.includes( key ),
+					onChange: checked => toggleAvailable( key, checked ),
+				} )
+			)
 		)
 	);
+
+	const preview =
+		'radio' === displayAs
+			? h(
+					'fieldset',
+					{ className: 'jetpack-search-sort-control__radio-group' },
+					h( 'legend', null, labelText ),
+					available.map( key => {
+						const radioId = `${ baseId }-${ key }`;
+						return h(
+							'div',
+							{ key, className: 'jetpack-search-sort-control__radio-item' },
+							h( 'input', {
+								type: 'radio',
+								id: radioId,
+								name: baseId,
+								value: key,
+								checked: previewSelected === key,
+								disabled: true,
+								readOnly: true,
+							} ),
+							h( 'label', { htmlFor: radioId }, labels[ key ] )
+						);
+					} )
+			  )
+			: h(
+					Fragment,
+					null,
+					h( 'label', { htmlFor: baseId }, labelText ),
+					h(
+						'select',
+						{ id: baseId, disabled: true, value: previewSelected, onChange: () => {} },
+						available.map( key => h( 'option', { key, value: key }, labels[ key ] ) )
+					)
+			  );
+
+	return h( Fragment, null, inspector, h( 'div', blockProps, preview ) );
 }

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/edit.js
@@ -11,9 +11,7 @@ import { CheckboxControl, PanelBody, SelectControl, TextControl } from '@wordpre
 import { createElement as h, Fragment, useId } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
-// Must stay in lock-step with Sort_Control::BASE_SORT_KEYS on the PHP side.
-// Product-format keys (rating/price) will rejoin once the WooCommerce
-// integration lands — tracked in RSM-1082.
+// Mirror Sort_Control::BASE_SORT_KEYS. Product-format keys rejoin in RSM-1082.
 const ALL_SORT_KEYS = [ 'relevance', 'newest', 'oldest' ];
 
 /**

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/edit.js
@@ -89,7 +89,17 @@ export default function SortControlEdit( { attributes, setAttributes } ) {
 		const next = checked
 			? ALL_SORT_KEYS.filter( key => key === sortKey || storedAvailable.includes( key ) )
 			: storedAvailable.filter( key => key !== sortKey );
-		setAttributes( { availableSortOptions: next } );
+		// If the author just unchecked the current `defaultSort`, move the
+		// attribute onto the first still-available key in the same setAttributes
+		// call. Without this, `defaultSort` would keep the stale value on disk
+		// — the render callback falls back gracefully, but the editor's inspector
+		// would re-bind to `available[0]` visually while the saved attribute
+		// still held the unchecked key, which is confusing to reason about.
+		const update = { availableSortOptions: next };
+		if ( ! checked && sortKey === defaultSort && next.length > 0 ) {
+			update.defaultSort = next[ 0 ];
+		}
+		setAttributes( update );
 	};
 
 	const inspector = h(

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/edit.js
@@ -81,15 +81,23 @@ export default function SortControlEdit( { attributes, setAttributes } ) {
 		const next = checked
 			? ALL_SORT_KEYS.filter( key => key === sortKey || storedAvailable.includes( key ) )
 			: storedAvailable.filter( key => key !== sortKey );
-		// If the author just unchecked the current `defaultSort`, move the
-		// attribute onto the first still-available key in the same setAttributes
-		// call. Without this, `defaultSort` would keep the stale value on disk
-		// — the render callback falls back gracefully, but the editor's inspector
-		// would re-bind to `available[0]` visually while the saved attribute
-		// still held the unchecked key, which is confusing to reason about.
-		const update = { availableSortOptions: next };
-		if ( ! checked && sortKey === defaultSort && next.length > 0 ) {
-			update.defaultSort = next[ 0 ];
+		// Persisting `[]` would make the preview fall back to "all options"
+		// (matching `resolveAvailable()` and the PHP renderer) while every
+		// inspector checkbox stays unchecked — an inspector/preview mismatch
+		// authors can't easily reason about. Snap the empty case back to the
+		// canonical full set so the saved attribute always matches what
+		// renders.
+		const normalizedNext = next.length === 0 ? ALL_SORT_KEYS : next;
+		// If the author just unchecked the current `defaultSort` AND it's no
+		// longer in the saved set, move the attribute onto the first still-
+		// available key in the same setAttributes call. Without this,
+		// `defaultSort` would keep the stale value on disk — the render
+		// callback falls back gracefully, but the editor's inspector would
+		// re-bind to `available[0]` visually while the saved attribute still
+		// held the unchecked key, which is confusing to reason about.
+		const update = { availableSortOptions: normalizedNext };
+		if ( ! checked && sortKey === defaultSort && ! normalizedNext.includes( defaultSort ) ) {
+			update.defaultSort = normalizedNext[ 0 ];
 		}
 		setAttributes( update );
 	};

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/render.php
@@ -36,6 +36,15 @@ if ( ! in_array( $effective_sort, $options, true ) ) {
 	$effective_sort = $options[0];
 }
 
+// `wp_interactivity_data_wp_context()` (used in the radio template) was
+// introduced in WP 6.5; calling it on older cores would fatal. Fall back
+// to the `select` variant — its template only emits inert
+// `data-wp-bind--*` attributes, which degrade harmlessly without
+// Interactivity.
+if ( 'radio' === $display_as && ! function_exists( 'wp_interactivity_data_wp_context' ) ) {
+	$display_as = 'select';
+}
+
 // Push the resolved sort into the shared Interactivity state so the
 // JS store hydrates against the same value the server rendered. Core's
 // `wp_interactivity_state()` deep-merges, so this overrides whatever the

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/render.php
@@ -2,6 +2,10 @@
 /**
  * Sort Control block render.
  *
+ * WordPress passes `$attributes` in at runtime; VariableAnalysis can't see
+ * that because this file is include()'d rather than declared as a callback
+ * parameter, hence the sniff disable.
+ *
  * @package automattic/jetpack-search
  */
 
@@ -9,22 +13,96 @@ namespace Automattic\Jetpack\Search;
 
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 
+// @phan-suppress-next-line PhanUndeclaredGlobalVariable -- WP always supplies $attributes.
+$attrs         = (array) $attributes;
+$options       = Sort_Control::resolve_available_options( $attrs );
+$option_labels = Sort_Control::get_option_labels();
+$default_sort  = Sort_Control::normalize_default_sort( $attrs );
+$display_as    = Sort_Control::normalize_display_as( $attrs );
+$label         = Sort_Control::resolve_label( $attrs );
+
+// Determine the effective sort for first paint and hydration. A URL
+// `?orderby=…` always wins so deep links keep their meaning — same
+// precedence as the instant-search overlay. When no URL sort is present,
+// fall back to the block's `defaultSort` attribute.
+$url_sort       = Sort_Control::parse_url_sort( $options );
+$effective_sort = $url_sort ?? $default_sort;
+if ( ! in_array( $effective_sort, $options, true ) ) {
+	// `defaultSort` may land outside `availableSortOptions` (e.g. an
+	// author saved a default, then unchecked it from the list). Rather
+	// than render a control that can't represent the current state,
+	// pick the first allowed option so the selection is always a valid
+	// choice.
+	$effective_sort = $options[0];
+}
+
+// Push the resolved sort into the shared Interactivity state so the
+// JS store hydrates against the same value the server rendered. Core's
+// `wp_interactivity_state()` deep-merges, so this overrides whatever the
+// Search_Blocks state seeder wrote (which knows only about the legacy
+// `newest`/`oldest` URL keys — a product-format URL sort would otherwise
+// collapse to `relevance` before the block saw it).
+if ( function_exists( 'wp_interactivity_state' ) ) {
+	wp_interactivity_state( 'jetpack-search', array( 'sortOrder' => $effective_sort ) );
+}
+
 $select_id = wp_unique_id( 'jetpack-search-sort-' );
 ?>
 <div
 	<?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>
 	data-wp-interactive="jetpack-search"
 >
-	<label for="<?php echo esc_attr( $select_id ); ?>">
-		<?php esc_html_e( 'Sort by', 'jetpack-search-pkg' ); ?>
-	</label>
-	<select
-		id="<?php echo esc_attr( $select_id ); ?>"
-		data-wp-bind--value="state.sortOrder"
-		data-wp-on--change="actions.onSortChange"
-	>
-		<option value="relevance"><?php esc_html_e( 'Relevance', 'jetpack-search-pkg' ); ?></option>
-		<option value="newest"><?php esc_html_e( 'Newest', 'jetpack-search-pkg' ); ?></option>
-		<option value="oldest"><?php esc_html_e( 'Oldest', 'jetpack-search-pkg' ); ?></option>
-	</select>
+	<?php if ( 'radio' === $display_as ) : ?>
+		<?php
+		// Shared `name` groups the radios so the browser enforces single-
+		// selection semantics across the whole block instance. The wrapper's
+		// uniquely generated id doubles as the group name — two sort-control
+		// blocks on the same page therefore get distinct names and don't
+		// interfere with each other.
+		$group_name = $select_id;
+		?>
+		<fieldset class="jetpack-search-sort-control__radio-group">
+			<legend><?php echo esc_html( $label ); ?></legend>
+			<?php foreach ( $options as $sort_key ) : ?>
+				<?php
+				$option_label = $option_labels[ $sort_key ] ?? $sort_key;
+				$radio_id     = $select_id . '-' . sanitize_key( $sort_key );
+				?>
+				<div
+					class="jetpack-search-sort-control__radio-item"
+					<?php echo wp_kses_data( wp_interactivity_data_wp_context( array( 'sortKey' => $sort_key ) ) ); ?>
+				>
+					<input
+						type="radio"
+						id="<?php echo esc_attr( $radio_id ); ?>"
+						name="<?php echo esc_attr( $group_name ); ?>"
+						value="<?php echo esc_attr( $sort_key ); ?>"
+						<?php checked( $effective_sort, $sort_key ); ?>
+						data-wp-bind--checked="state.isSortOptionSelected"
+						data-wp-on--change="actions.onSortChange"
+					/>
+					<label for="<?php echo esc_attr( $radio_id ); ?>">
+						<?php echo esc_html( $option_label ); ?>
+					</label>
+				</div>
+			<?php endforeach; ?>
+		</fieldset>
+	<?php else : ?>
+		<label for="<?php echo esc_attr( $select_id ); ?>">
+			<?php echo esc_html( $label ); ?>
+		</label>
+		<select
+			id="<?php echo esc_attr( $select_id ); ?>"
+			data-wp-bind--value="state.sortOrder"
+			data-wp-on--change="actions.onSortChange"
+		>
+			<?php foreach ( $options as $sort_key ) : ?>
+				<?php $option_label = $option_labels[ $sort_key ] ?? $sort_key; ?>
+				<option
+					value="<?php echo esc_attr( $sort_key ); ?>"
+					<?php selected( $effective_sort, $sort_key ); ?>
+				><?php echo esc_html( $option_label ); ?></option>
+			<?php endforeach; ?>
+		</select>
+	<?php endif; ?>
 </div>

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/render.php
@@ -45,12 +45,16 @@ if ( 'radio' === $display_as && ! function_exists( 'wp_interactivity_data_wp_con
 	$display_as = 'select';
 }
 
-// Push the resolved sort into the shared Interactivity state so the
-// JS store hydrates against the same value the server rendered. Core's
-// `wp_interactivity_state()` deep-merges, so this overrides whatever the
-// Search_Blocks state seeder wrote (which knows only about the legacy
-// `newest`/`oldest` URL keys — a product-format URL sort would otherwise
-// collapse to `relevance` before the block saw it).
+// Seed the shared Interactivity state with the resolved sort so the JS
+// store hydrates against the value the server rendered. Whether this seed
+// "wins" depends on theme type: under classic themes the block renders
+// during `wp_enqueue_scripts`, after the Search_Blocks state seeder, so
+// `wp_interactivity_state()`'s deep-merge layers on top. Under FSE/block
+// themes the block template renders before `wp_enqueue_scripts` fires —
+// the Search_Blocks seeder later overwrites this `sortOrder`, falling
+// back to `relevance` for any sort key it doesn't recognise. Resolving
+// the FSE precedence is tracked separately; this call still does the
+// right thing under classic themes and is harmless under FSE.
 if ( function_exists( 'wp_interactivity_state' ) ) {
 	wp_interactivity_state( 'jetpack-search', array( 'sortOrder' => $effective_sort ) );
 }

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
@@ -23,4 +23,31 @@
 	select {
 		padding: 0.2rem 0.5rem;
 	}
+
+	// Reset browser defaults on the radio-variant fieldset. Without this the
+	// block would render a bordered box around the radio group, which doesn't
+	// match the inline look of the select variant and surprises theme authors
+	// who style the block as a single row.
+	.jetpack-search-sort-control__radio-group {
+		display: flex;
+		align-items: center;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+		border: 0;
+		margin: 0;
+		padding: 0;
+
+		legend {
+			font-size: 0.9rem;
+			color: #555;
+			padding: 0;
+		}
+	}
+
+	.jetpack-search-sort-control__radio-item {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+		font-size: 0.9rem;
+	}
 }

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
@@ -39,7 +39,11 @@
 
 		legend {
 			font-size: 0.9rem;
-			color: #555;
+			// Match the select variant's `label` so the radio fieldset adapts
+			// to dark themes and the site palette instead of pinning to a
+			// hard-coded grey.
+			color: inherit;
+			opacity: 0.8;
 			padding: 0;
 		}
 	}

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
@@ -45,7 +45,7 @@
 	}
 
 	.jetpack-search-sort-control__radio-item {
-		display: inline-flex;
+		display: flex;
 		align-items: center;
 		gap: 0.25rem;
 		font-size: 0.9rem;

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/view.js
@@ -1,13 +1,35 @@
-import { store } from '@wordpress/interactivity';
+import { store, getContext } from '@wordpress/interactivity';
 import '../../store';
 import './style.scss';
 
 const NAMESPACE = 'jetpack-search';
 
 store( NAMESPACE, {
+	state: {
+		/**
+		 * Bound to each radio input's `checked` attribute so the visible
+		 * selection stays in sync with `state.sortOrder` across popstate
+		 * navigations and programmatic updates. Each radio's wrapper carries
+		 * a `data-wp-context='{"sortKey":"…"}'` with its own sort key — the
+		 * getter reads that via `getContext()` and compares against the
+		 * single shared `state.sortOrder`.
+		 *
+		 * Unused by the `<select>` variant, which binds `value` directly
+		 * against the store state.
+		 *
+		 * @return {boolean} True when this radio represents the active sort.
+		 */
+		get isSortOptionSelected() {
+			const { state } = store( NAMESPACE );
+			const { sortKey } = getContext();
+			return state.sortOrder === sortKey;
+		},
+	},
 	actions: {
 		/**
-		 * Apply a new sort order and re-run search.
+		 * Apply a new sort order and re-run search. Shared between the
+		 * `<select>` change event and radio change events; `event.target.value`
+		 * carries the selected sort key in both cases.
 		 *
 		 * @param {Event} event - Change event.
 		 * @yield {Promise} search action.

--- a/projects/packages/search/src/search-blocks/store/url-state.js
+++ b/projects/packages/search/src/search-blocks/store/url-state.js
@@ -1,16 +1,10 @@
 // Valid UI/URL values for `orderby`. Must mirror
-// `Sort_Control::get_all_option_keys()` on the PHP side — the sort-control
-// block can expose every key here, so dropping one from the whitelist would
-// cause the store to silently collapse a valid user selection to the default
-// on reload or browser back/forward.
-const VALID_SORT_ORDERS = [
-	'relevance',
-	'newest',
-	'oldest',
-	'rating_desc',
-	'price_asc',
-	'price_desc',
-];
+// `Sort_Control::get_all_option_keys()` on the PHP side — dropping one from
+// the whitelist would cause the store to silently collapse a valid user
+// selection to the default on reload or browser back/forward. Product-format
+// keys (rating/price) will rejoin the whitelist when the WooCommerce
+// integration lands (RSM-1082).
+const VALID_SORT_ORDERS = [ 'relevance', 'newest', 'oldest' ];
 const DEFAULT_SORT_ORDER = 'relevance';
 
 // Reserved query params — not treated as filter keys on parse. Mirrors the

--- a/projects/packages/search/src/search-blocks/store/url-state.js
+++ b/projects/packages/search/src/search-blocks/store/url-state.js
@@ -1,9 +1,4 @@
-// Valid UI/URL values for `orderby`. Must mirror
-// `Sort_Control::get_all_option_keys()` on the PHP side — dropping one from
-// the whitelist would cause the store to silently collapse a valid user
-// selection to the default on reload or browser back/forward. Product-format
-// keys (rating/price) will rejoin the whitelist when the WooCommerce
-// integration lands (RSM-1082).
+// Mirror `Sort_Control::get_all_option_keys()`. Product-format keys rejoin in RSM-1082.
 const VALID_SORT_ORDERS = [ 'relevance', 'newest', 'oldest' ];
 const DEFAULT_SORT_ORDER = 'relevance';
 

--- a/projects/packages/search/src/search-blocks/store/url-state.js
+++ b/projects/packages/search/src/search-blocks/store/url-state.js
@@ -1,7 +1,16 @@
-// Valid UI/URL values for `orderby`. Must mirror `Search_Blocks::parse_url_sort()`
-// on the PHP side so deep links round-trip the same sort on first paint and
-// hydration.
-const VALID_SORT_ORDERS = [ 'relevance', 'newest', 'oldest' ];
+// Valid UI/URL values for `orderby`. Must mirror
+// `Sort_Control::get_all_option_keys()` on the PHP side — the sort-control
+// block can expose every key here, so dropping one from the whitelist would
+// cause the store to silently collapse a valid user selection to the default
+// on reload or browser back/forward.
+const VALID_SORT_ORDERS = [
+	'relevance',
+	'newest',
+	'oldest',
+	'rating_desc',
+	'price_asc',
+	'price_desc',
+];
 const DEFAULT_SORT_ORDER = 'relevance';
 
 // Reserved query params — not treated as filter keys on parse. Mirrors the

--- a/projects/packages/search/tests/js/search-blocks/sort-control-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/sort-control-edit.test.jsx
@@ -1,15 +1,11 @@
-// The search package doesn't ship `@testing-library/user-event`, so
-// these tests stay on the synchronous `fireEvent` helpers — adequate for
-// a block editor component whose reactions fire synchronously against
-// the mocked WordPress controls.
 /* eslint-disable testing-library/prefer-user-event */
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import SortControlEdit from '../../../src/search-blocks/blocks/sort-control/edit';
 
 // InspectorControls, PanelBody and the wrapper components from @wordpress
 // own portal/slot machinery that doesn't wire up under jsdom. Replace them
-// with pass-through render helpers so their children — the controls the
-// component actually drives — land in the testing DOM.
+// with pass-through render helpers so the checkbox / select / text controls
+// the component drives land in the testing DOM.
 jest.mock( '@wordpress/block-editor', () => ( {
 	useBlockProps: () => ( { className: 'wp-block-jetpack-sort-control' } ),
 	InspectorControls: ( { children } ) => <div data-testid="inspector">{ children }</div>,
@@ -24,7 +20,7 @@ jest.mock( '@wordpress/components', () => ( {
 			{ children }
 		</section>
 	),
-	TextControl: ( { label, value, placeholder, onChange } ) => {
+	TextControl: ( { label, value, onChange } ) => {
 		const id = nextControlId();
 		return (
 			<>
@@ -33,7 +29,6 @@ jest.mock( '@wordpress/components', () => ( {
 					id={ id }
 					type="text"
 					value={ value || '' }
-					placeholder={ placeholder }
 					onChange={ event => onChange( event.target.value ) }
 				/>
 			</>
@@ -75,43 +70,26 @@ jest.mock( '@wordpress/i18n', () => ( {
 } ) );
 
 describe( 'SortControlEdit', () => {
-	it( 'renders the select preview with the default label when no attributes are saved', () => {
-		render( <SortControlEdit attributes={ {} } setAttributes={ jest.fn() } /> );
-		expect( screen.getAllByText( 'Sort by' ).length ).toBeGreaterThan( 0 );
+	it( 'renders the dropdown preview with the default label and swaps to radios when displayAs=radio', () => {
+		const { rerender } = render(
+			<SortControlEdit attributes={ {} } setAttributes={ jest.fn() } />
+		);
 		expect( screen.getByRole( 'combobox', { name: 'Sort by' } ) ).toBeInTheDocument();
-	} );
 
-	it( 'swaps to a radio group when displayAs is radio and marks the default as checked', () => {
-		render(
+		rerender(
 			<SortControlEdit
-				attributes={ {
-					displayAs: 'radio',
-					defaultSort: 'newest',
-					availableSortOptions: [ 'relevance', 'newest', 'oldest' ],
-				} }
+				attributes={ { displayAs: 'radio', defaultSort: 'newest' } }
 				setAttributes={ jest.fn() }
 			/>
 		);
 		const fieldset = screen.getByRole( 'group' );
-		expect( within( fieldset ).getAllByRole( 'radio' ) ).toHaveLength( 3 );
 		expect( within( fieldset ).getByRole( 'radio', { name: 'Newest' } ) ).toBeChecked();
 	} );
 
-	it( 'filters the preview to only keys present in availableSortOptions', () => {
-		render(
-			<SortControlEdit
-				attributes={ { availableSortOptions: [ 'relevance', 'oldest' ] } }
-				setAttributes={ jest.fn() }
-			/>
-		);
-		const select = screen.getByRole( 'combobox', { name: 'Sort by' } );
-		const values = within( select )
-			.getAllByRole( 'option' )
-			.map( option => option.value );
-		expect( values ).toEqual( [ 'relevance', 'oldest' ] );
-	} );
-
 	it( 'moves defaultSort onto the next available key when the author unchecks the current default', () => {
+		// This is the subtle correctness case: without the sync, the saved
+		// `defaultSort` would keep the stale value on disk while the
+		// inspector's Default-sort select visually rebinds to another key.
 		const onSetAttributes = jest.fn();
 		render(
 			<SortControlEdit
@@ -127,104 +105,5 @@ describe( 'SortControlEdit', () => {
 			availableSortOptions: [ 'relevance', 'oldest' ],
 			defaultSort: 'relevance',
 		} );
-	} );
-
-	it( 'leaves defaultSort alone when the author unchecks a non-default key', () => {
-		const onSetAttributes = jest.fn();
-		render(
-			<SortControlEdit
-				attributes={ {
-					defaultSort: 'newest',
-					availableSortOptions: [ 'relevance', 'newest', 'oldest' ],
-				} }
-				setAttributes={ onSetAttributes }
-			/>
-		);
-		fireEvent.click( screen.getByRole( 'checkbox', { name: 'Oldest' } ) );
-		expect( onSetAttributes ).toHaveBeenCalledWith( {
-			availableSortOptions: [ 'relevance', 'newest' ],
-		} );
-	} );
-
-	it( 're-adds a key in canonical order when the author re-checks it', () => {
-		const onSetAttributes = jest.fn();
-		render(
-			<SortControlEdit
-				attributes={ { availableSortOptions: [ 'relevance', 'oldest' ] } }
-				setAttributes={ onSetAttributes }
-			/>
-		);
-		fireEvent.click( screen.getByRole( 'checkbox', { name: 'Newest' } ) );
-		expect( onSetAttributes ).toHaveBeenCalledWith( {
-			availableSortOptions: [ 'relevance', 'newest', 'oldest' ],
-		} );
-	} );
-
-	it( 'offers only enabled keys as choices in the Default sort select', () => {
-		render(
-			<SortControlEdit
-				attributes={ { availableSortOptions: [ 'relevance', 'oldest' ] } }
-				setAttributes={ jest.fn() }
-			/>
-		);
-		const select = screen.getByRole( 'combobox', { name: 'Default sort' } );
-		const values = within( select )
-			.getAllByRole( 'option' )
-			.map( option => option.value );
-		expect( values ).toEqual( [ 'relevance', 'oldest' ] );
-	} );
-
-	it( 'uses the author-supplied label verbatim in the preview', () => {
-		render( <SortControlEdit attributes={ { label: 'Order by' } } setAttributes={ jest.fn() } /> );
-		expect( screen.getAllByText( 'Order by' ).length ).toBeGreaterThan( 0 );
-	} );
-
-	it( 'writes the label attribute when the author edits the text control', () => {
-		const onSetAttributes = jest.fn();
-		render( <SortControlEdit attributes={ {} } setAttributes={ onSetAttributes } /> );
-		fireEvent.change( screen.getByRole( 'textbox', { name: 'Label' } ), {
-			target: { value: 'Order results by' },
-		} );
-		expect( onSetAttributes ).toHaveBeenCalledWith( { label: 'Order results by' } );
-	} );
-
-	it( 'writes defaultSort when the author changes the Default sort select', () => {
-		const onSetAttributes = jest.fn();
-		render(
-			<SortControlEdit
-				attributes={ {
-					defaultSort: 'relevance',
-					availableSortOptions: [ 'relevance', 'newest' ],
-				} }
-				setAttributes={ onSetAttributes }
-			/>
-		);
-		fireEvent.change( screen.getByRole( 'combobox', { name: 'Default sort' } ), {
-			target: { value: 'newest' },
-		} );
-		expect( onSetAttributes ).toHaveBeenCalledWith( { defaultSort: 'newest' } );
-	} );
-
-	it( 'writes displayAs when the author flips to the radio variant', () => {
-		const onSetAttributes = jest.fn();
-		render( <SortControlEdit attributes={ {} } setAttributes={ onSetAttributes } /> );
-		fireEvent.change( screen.getByRole( 'combobox', { name: 'Display as' } ), {
-			target: { value: 'radio' },
-		} );
-		expect( onSetAttributes ).toHaveBeenCalledWith( { displayAs: 'radio' } );
-	} );
-
-	it( 'falls back to every canonical key when availableSortOptions is missing entirely', () => {
-		render(
-			<SortControlEdit
-				attributes={ { displayAs: 'radio', defaultSort: 'relevance' } }
-				setAttributes={ jest.fn() }
-			/>
-		);
-		const fieldset = screen.getByRole( 'group' );
-		const values = within( fieldset )
-			.getAllByRole( 'radio' )
-			.map( radio => radio.value );
-		expect( values ).toEqual( [ 'relevance', 'newest', 'oldest' ] );
 	} );
 } );

--- a/projects/packages/search/tests/js/search-blocks/sort-control-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/sort-control-edit.test.jsx
@@ -100,7 +100,7 @@ describe( 'SortControlEdit', () => {
 	it( 'filters the preview to only keys present in availableSortOptions', () => {
 		render(
 			<SortControlEdit
-				attributes={ { availableSortOptions: [ 'relevance', 'rating_desc' ] } }
+				attributes={ { availableSortOptions: [ 'relevance', 'oldest' ] } }
 				setAttributes={ jest.fn() }
 			/>
 		);
@@ -108,7 +108,7 @@ describe( 'SortControlEdit', () => {
 		const values = within( select )
 			.getAllByRole( 'option' )
 			.map( option => option.value );
-		expect( values ).toEqual( [ 'relevance', 'rating_desc' ] );
+		expect( values ).toEqual( [ 'relevance', 'oldest' ] );
 	} );
 
 	it( 'moves defaultSort onto the next available key when the author unchecks the current default', () => {
@@ -163,7 +163,7 @@ describe( 'SortControlEdit', () => {
 	it( 'offers only enabled keys as choices in the Default sort select', () => {
 		render(
 			<SortControlEdit
-				attributes={ { availableSortOptions: [ 'relevance', 'price_asc' ] } }
+				attributes={ { availableSortOptions: [ 'relevance', 'oldest' ] } }
 				setAttributes={ jest.fn() }
 			/>
 		);
@@ -171,7 +171,7 @@ describe( 'SortControlEdit', () => {
 		const values = within( select )
 			.getAllByRole( 'option' )
 			.map( option => option.value );
-		expect( values ).toEqual( [ 'relevance', 'price_asc' ] );
+		expect( values ).toEqual( [ 'relevance', 'oldest' ] );
 	} );
 
 	it( 'uses the author-supplied label verbatim in the preview', () => {
@@ -225,13 +225,6 @@ describe( 'SortControlEdit', () => {
 		const values = within( fieldset )
 			.getAllByRole( 'radio' )
 			.map( radio => radio.value );
-		expect( values ).toEqual( [
-			'relevance',
-			'newest',
-			'oldest',
-			'rating_desc',
-			'price_asc',
-			'price_desc',
-		] );
+		expect( values ).toEqual( [ 'relevance', 'newest', 'oldest' ] );
 	} );
 } );

--- a/projects/packages/search/tests/js/search-blocks/sort-control-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/sort-control-edit.test.jsx
@@ -1,0 +1,237 @@
+// The search package doesn't ship `@testing-library/user-event`, so
+// these tests stay on the synchronous `fireEvent` helpers — adequate for
+// a block editor component whose reactions fire synchronously against
+// the mocked WordPress controls.
+/* eslint-disable testing-library/prefer-user-event */
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import SortControlEdit from '../../../src/search-blocks/blocks/sort-control/edit';
+
+// InspectorControls, PanelBody and the wrapper components from @wordpress
+// own portal/slot machinery that doesn't wire up under jsdom. Replace them
+// with pass-through render helpers so their children — the controls the
+// component actually drives — land in the testing DOM.
+jest.mock( '@wordpress/block-editor', () => ( {
+	useBlockProps: () => ( { className: 'wp-block-jetpack-sort-control' } ),
+	InspectorControls: ( { children } ) => <div data-testid="inspector">{ children }</div>,
+} ) );
+
+let controlIdCounter = 0;
+const nextControlId = () => `mock-control-${ ++controlIdCounter }`;
+
+jest.mock( '@wordpress/components', () => ( {
+	PanelBody: ( { title, children } ) => (
+		<section data-testid="panel" aria-label={ title }>
+			{ children }
+		</section>
+	),
+	TextControl: ( { label, value, placeholder, onChange } ) => {
+		const id = nextControlId();
+		return (
+			<>
+				<label htmlFor={ id }>{ label }</label>
+				<input
+					id={ id }
+					type="text"
+					value={ value || '' }
+					placeholder={ placeholder }
+					onChange={ event => onChange( event.target.value ) }
+				/>
+			</>
+		);
+	},
+	SelectControl: ( { label, value, options, onChange } ) => {
+		const id = nextControlId();
+		return (
+			<>
+				<label htmlFor={ id }>{ label }</label>
+				<select id={ id } value={ value } onChange={ event => onChange( event.target.value ) }>
+					{ options.map( option => (
+						<option key={ option.value } value={ option.value }>
+							{ option.label }
+						</option>
+					) ) }
+				</select>
+			</>
+		);
+	},
+	CheckboxControl: ( { label, checked, onChange } ) => {
+		const id = nextControlId();
+		return (
+			<>
+				<input
+					id={ id }
+					type="checkbox"
+					checked={ !! checked }
+					onChange={ event => onChange( event.target.checked ) }
+				/>
+				<label htmlFor={ id }>{ label }</label>
+			</>
+		);
+	},
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: text => text,
+} ) );
+
+describe( 'SortControlEdit', () => {
+	it( 'renders the select preview with the default label when no attributes are saved', () => {
+		render( <SortControlEdit attributes={ {} } setAttributes={ jest.fn() } /> );
+		expect( screen.getAllByText( 'Sort by' ).length ).toBeGreaterThan( 0 );
+		expect( screen.getByRole( 'combobox', { name: 'Sort by' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'swaps to a radio group when displayAs is radio and marks the default as checked', () => {
+		render(
+			<SortControlEdit
+				attributes={ {
+					displayAs: 'radio',
+					defaultSort: 'newest',
+					availableSortOptions: [ 'relevance', 'newest', 'oldest' ],
+				} }
+				setAttributes={ jest.fn() }
+			/>
+		);
+		const fieldset = screen.getByRole( 'group' );
+		expect( within( fieldset ).getAllByRole( 'radio' ) ).toHaveLength( 3 );
+		expect( within( fieldset ).getByRole( 'radio', { name: 'Newest' } ) ).toBeChecked();
+	} );
+
+	it( 'filters the preview to only keys present in availableSortOptions', () => {
+		render(
+			<SortControlEdit
+				attributes={ { availableSortOptions: [ 'relevance', 'rating_desc' ] } }
+				setAttributes={ jest.fn() }
+			/>
+		);
+		const select = screen.getByRole( 'combobox', { name: 'Sort by' } );
+		const values = within( select )
+			.getAllByRole( 'option' )
+			.map( option => option.value );
+		expect( values ).toEqual( [ 'relevance', 'rating_desc' ] );
+	} );
+
+	it( 'moves defaultSort onto the next available key when the author unchecks the current default', () => {
+		const onSetAttributes = jest.fn();
+		render(
+			<SortControlEdit
+				attributes={ {
+					defaultSort: 'newest',
+					availableSortOptions: [ 'relevance', 'newest', 'oldest' ],
+				} }
+				setAttributes={ onSetAttributes }
+			/>
+		);
+		fireEvent.click( screen.getByRole( 'checkbox', { name: 'Newest' } ) );
+		expect( onSetAttributes ).toHaveBeenCalledWith( {
+			availableSortOptions: [ 'relevance', 'oldest' ],
+			defaultSort: 'relevance',
+		} );
+	} );
+
+	it( 'leaves defaultSort alone when the author unchecks a non-default key', () => {
+		const onSetAttributes = jest.fn();
+		render(
+			<SortControlEdit
+				attributes={ {
+					defaultSort: 'newest',
+					availableSortOptions: [ 'relevance', 'newest', 'oldest' ],
+				} }
+				setAttributes={ onSetAttributes }
+			/>
+		);
+		fireEvent.click( screen.getByRole( 'checkbox', { name: 'Oldest' } ) );
+		expect( onSetAttributes ).toHaveBeenCalledWith( {
+			availableSortOptions: [ 'relevance', 'newest' ],
+		} );
+	} );
+
+	it( 're-adds a key in canonical order when the author re-checks it', () => {
+		const onSetAttributes = jest.fn();
+		render(
+			<SortControlEdit
+				attributes={ { availableSortOptions: [ 'relevance', 'oldest' ] } }
+				setAttributes={ onSetAttributes }
+			/>
+		);
+		fireEvent.click( screen.getByRole( 'checkbox', { name: 'Newest' } ) );
+		expect( onSetAttributes ).toHaveBeenCalledWith( {
+			availableSortOptions: [ 'relevance', 'newest', 'oldest' ],
+		} );
+	} );
+
+	it( 'offers only enabled keys as choices in the Default sort select', () => {
+		render(
+			<SortControlEdit
+				attributes={ { availableSortOptions: [ 'relevance', 'price_asc' ] } }
+				setAttributes={ jest.fn() }
+			/>
+		);
+		const select = screen.getByRole( 'combobox', { name: 'Default sort' } );
+		const values = within( select )
+			.getAllByRole( 'option' )
+			.map( option => option.value );
+		expect( values ).toEqual( [ 'relevance', 'price_asc' ] );
+	} );
+
+	it( 'uses the author-supplied label verbatim in the preview', () => {
+		render( <SortControlEdit attributes={ { label: 'Order by' } } setAttributes={ jest.fn() } /> );
+		expect( screen.getAllByText( 'Order by' ).length ).toBeGreaterThan( 0 );
+	} );
+
+	it( 'writes the label attribute when the author edits the text control', () => {
+		const onSetAttributes = jest.fn();
+		render( <SortControlEdit attributes={ {} } setAttributes={ onSetAttributes } /> );
+		fireEvent.change( screen.getByRole( 'textbox', { name: 'Label' } ), {
+			target: { value: 'Order results by' },
+		} );
+		expect( onSetAttributes ).toHaveBeenCalledWith( { label: 'Order results by' } );
+	} );
+
+	it( 'writes defaultSort when the author changes the Default sort select', () => {
+		const onSetAttributes = jest.fn();
+		render(
+			<SortControlEdit
+				attributes={ {
+					defaultSort: 'relevance',
+					availableSortOptions: [ 'relevance', 'newest' ],
+				} }
+				setAttributes={ onSetAttributes }
+			/>
+		);
+		fireEvent.change( screen.getByRole( 'combobox', { name: 'Default sort' } ), {
+			target: { value: 'newest' },
+		} );
+		expect( onSetAttributes ).toHaveBeenCalledWith( { defaultSort: 'newest' } );
+	} );
+
+	it( 'writes displayAs when the author flips to the radio variant', () => {
+		const onSetAttributes = jest.fn();
+		render( <SortControlEdit attributes={ {} } setAttributes={ onSetAttributes } /> );
+		fireEvent.change( screen.getByRole( 'combobox', { name: 'Display as' } ), {
+			target: { value: 'radio' },
+		} );
+		expect( onSetAttributes ).toHaveBeenCalledWith( { displayAs: 'radio' } );
+	} );
+
+	it( 'falls back to every canonical key when availableSortOptions is missing entirely', () => {
+		render(
+			<SortControlEdit
+				attributes={ { displayAs: 'radio', defaultSort: 'relevance' } }
+				setAttributes={ jest.fn() }
+			/>
+		);
+		const fieldset = screen.getByRole( 'group' );
+		const values = within( fieldset )
+			.getAllByRole( 'radio' )
+			.map( radio => radio.value );
+		expect( values ).toEqual( [
+			'relevance',
+			'newest',
+			'oldest',
+			'rating_desc',
+			'price_asc',
+			'price_desc',
+		] );
+	} );
+} );

--- a/projects/packages/search/tests/js/search-blocks/sort-control-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/sort-control-edit.test.jsx
@@ -2,10 +2,7 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import SortControlEdit from '../../../src/search-blocks/blocks/sort-control/edit';
 
-// InspectorControls, PanelBody and the wrapper components from @wordpress
-// own portal/slot machinery that doesn't wire up under jsdom. Replace them
-// with pass-through render helpers so the checkbox / select / text controls
-// the component drives land in the testing DOM.
+// @wordpress slot/portal components don't render under jsdom; pass-through.
 jest.mock( '@wordpress/block-editor', () => ( {
 	useBlockProps: () => ( { className: 'wp-block-jetpack-sort-control' } ),
 	InspectorControls: ( { children } ) => <div data-testid="inspector">{ children }</div>,
@@ -87,9 +84,6 @@ describe( 'SortControlEdit', () => {
 	} );
 
 	it( 'moves defaultSort onto the next available key when the author unchecks the current default', () => {
-		// This is the subtle correctness case: without the sync, the saved
-		// `defaultSort` would keep the stale value on disk while the
-		// inspector's Default-sort select visually rebinds to another key.
 		const onSetAttributes = jest.fn();
 		render(
 			<SortControlEdit

--- a/projects/packages/search/tests/js/search-blocks/sort-control-view.test.js
+++ b/projects/packages/search/tests/js/search-blocks/sort-control-view.test.js
@@ -1,0 +1,75 @@
+// `@wordpress/interactivity` isn't resolvable under Jest — the webpack
+// build extracts it as an external. Mock it virtually so the view module
+// can register its store, capturing the getter and action in the process.
+
+const captured = {
+	state: {},
+	actions: {},
+};
+const contextRef = { current: { sortKey: '' } };
+
+jest.mock(
+	'@wordpress/interactivity',
+	() => ( {
+		store: ( _namespace, config ) => {
+			if ( config ) {
+				const descriptors = Object.getOwnPropertyDescriptors( config.state || {} );
+				for ( const key of Object.keys( descriptors ) ) {
+					const descriptor = descriptors[ key ];
+					if ( typeof descriptor.get === 'function' ) {
+						Object.defineProperty( captured.state, key, descriptor );
+					} else {
+						captured.state[ key ] = descriptor.value;
+					}
+				}
+				Object.assign( captured.actions, config.actions || {} );
+			}
+			return { state: captured.state, actions: captured.actions };
+		},
+		getContext: () => contextRef.current,
+	} ),
+	{ virtual: true }
+);
+
+// The shared search store module has its own `store()` side-effect against
+// the real interactivity runtime — stub it to a no-op so importing view.js
+// only hits the mock above.
+jest.mock( '../../../src/search-blocks/store', () => ( {} ), { virtual: true } );
+
+// SCSS import is a side-effect for the webpack build, noise for Jest.
+jest.mock( '../../../src/search-blocks/blocks/sort-control/style.scss', () => ( {} ), {
+	virtual: true,
+} );
+
+require( '../../../src/search-blocks/blocks/sort-control/view' );
+
+describe( 'sort-control view store', () => {
+	beforeEach( () => {
+		captured.state.sortOrder = 'relevance';
+		contextRef.current = { sortKey: '' };
+	} );
+
+	it( 'returns true from isSortOptionSelected when the radio key matches the active sort', () => {
+		captured.state.sortOrder = 'newest';
+		contextRef.current = { sortKey: 'newest' };
+		expect( captured.state.isSortOptionSelected ).toBe( true );
+	} );
+
+	it( 'returns false from isSortOptionSelected when the radio key differs from the active sort', () => {
+		captured.state.sortOrder = 'newest';
+		contextRef.current = { sortKey: 'oldest' };
+		expect( captured.state.isSortOptionSelected ).toBe( false );
+	} );
+
+	it( 'writes the selected sort key into state and triggers a new search', () => {
+		const search = jest.fn();
+		captured.actions.search = search;
+		const event = { target: { value: 'newest' } };
+		const generator = captured.actions.onSortChange( event );
+		const step = generator.next();
+		expect( captured.state.sortOrder ).toBe( 'newest' );
+		expect( search ).toHaveBeenCalledTimes( 1 );
+		expect( step.done ).toBe( false );
+		expect( generator.next().done ).toBe( true );
+	} );
+} );

--- a/projects/packages/search/tests/js/search-blocks/sort-control-view.test.js
+++ b/projects/packages/search/tests/js/search-blocks/sort-control-view.test.js
@@ -1,7 +1,4 @@
-// `@wordpress/interactivity` isn't resolvable under Jest — the webpack
-// build extracts it as an external. Mock it virtually so the view module
-// can register its store, capturing the getter and action in the process.
-
+// `@wordpress/interactivity` is an externalized dep — mock virtually.
 const captured = {
 	state: {},
 	actions: {},
@@ -31,12 +28,7 @@ jest.mock(
 	{ virtual: true }
 );
 
-// The shared search store module has its own `store()` side-effect against
-// the real interactivity runtime — stub it to a no-op so importing view.js
-// only hits the mock above.
 jest.mock( '../../../src/search-blocks/store', () => ( {} ), { virtual: true } );
-
-// SCSS import is a side-effect for the webpack build, noise for Jest.
 jest.mock( '../../../src/search-blocks/blocks/sort-control/style.scss', () => ( {} ), {
 	virtual: true,
 } );

--- a/projects/packages/search/tests/js/search-blocks/url-state.test.js
+++ b/projects/packages/search/tests/js/search-blocks/url-state.test.js
@@ -34,13 +34,14 @@ describe( 'stateToUrlParams', () => {
 	} );
 
 	it.each( [ 'rating_desc', 'price_asc', 'price_desc' ] )(
-		'serializes product-format sort order %s',
+		'omits product-format sort order %s until WooCommerce integration lands',
 		sortOrder => {
-			// Guards against VALID_SORT_ORDERS drifting from
-			// Sort_Control::get_all_option_keys() — a missing key here would
-			// silently drop the param and reset shared links to relevance.
+			// Product-format keys are tracked for reintroduction in RSM-1082.
+			// Until then they are *not* in `VALID_SORT_ORDERS`, so the store
+			// must not serialize them — a shared link carrying one should
+			// collapse to relevance on the receiver.
 			const params = stateToUrlParams( { searchQuery: '', sortOrder } );
-			expect( params.get( 'orderby' ) ).toBe( sortOrder );
+			expect( params.has( 'orderby' ) ).toBe( false );
 		}
 	);
 
@@ -87,10 +88,13 @@ describe( 'urlParamsToState', () => {
 	} );
 
 	it.each( [ 'rating_desc', 'price_asc', 'price_desc' ] )(
-		'accepts product-format sort order %s from URL',
+		'collapses product-format sort order %s to relevance until WooCommerce integration lands',
 		sortOrder => {
+			// Mirror of the serializer guard — see RSM-1082. A deep link carrying
+			// one of these keys today must not hydrate into the store; the PR
+			// that adds WooCommerce support will flip both checks back.
 			const state = urlParamsToState( new URLSearchParams( `orderby=${ sortOrder }` ) );
-			expect( state.sortOrder ).toBe( sortOrder );
+			expect( state.sortOrder ).toBe( 'relevance' );
 		}
 	);
 

--- a/projects/packages/search/tests/js/search-blocks/url-state.test.js
+++ b/projects/packages/search/tests/js/search-blocks/url-state.test.js
@@ -33,17 +33,12 @@ describe( 'stateToUrlParams', () => {
 		expect( params.has( 'orderby' ) ).toBe( false );
 	} );
 
-	it.each( [ 'rating_desc', 'price_asc', 'price_desc' ] )(
-		'omits product-format sort order %s until WooCommerce integration lands',
-		sortOrder => {
-			// Product-format keys are tracked for reintroduction in RSM-1082.
-			// Until then they are *not* in `VALID_SORT_ORDERS`, so the store
-			// must not serialize them — a shared link carrying one should
-			// collapse to relevance on the receiver.
-			const params = stateToUrlParams( { searchQuery: '', sortOrder } );
-			expect( params.has( 'orderby' ) ).toBe( false );
-		}
-	);
+	it( 'omits product-format sort orders until WooCommerce integration lands (RSM-1082)', () => {
+		// `price_asc` stands in for the full product-format set — they share
+		// one whitelist branch, so a single case is enough to guard it.
+		const params = stateToUrlParams( { searchQuery: '', sortOrder: 'price_asc' } );
+		expect( params.has( 'orderby' ) ).toBe( false );
+	} );
 
 	it( 'omits unknown sort orders', () => {
 		const params = stateToUrlParams( { searchQuery: '', sortOrder: 'bogus' } );
@@ -87,16 +82,11 @@ describe( 'urlParamsToState', () => {
 		expect( state.sortOrder ).toBe( 'relevance' );
 	} );
 
-	it.each( [ 'rating_desc', 'price_asc', 'price_desc' ] )(
-		'collapses product-format sort order %s to relevance until WooCommerce integration lands',
-		sortOrder => {
-			// Mirror of the serializer guard — see RSM-1082. A deep link carrying
-			// one of these keys today must not hydrate into the store; the PR
-			// that adds WooCommerce support will flip both checks back.
-			const state = urlParamsToState( new URLSearchParams( `orderby=${ sortOrder }` ) );
-			expect( state.sortOrder ).toBe( 'relevance' );
-		}
-	);
+	it( 'collapses product-format URL sort to relevance until WooCommerce integration lands (RSM-1082)', () => {
+		// Same single-case guard as the serializer direction above.
+		const state = urlParamsToState( new URLSearchParams( 'orderby=price_asc' ) );
+		expect( state.sortOrder ).toBe( 'relevance' );
+	} );
 
 	it( 'collapses unknown sort order to relevance', () => {
 		const state = urlParamsToState( new URLSearchParams( 'orderby=bogus' ) );

--- a/projects/packages/search/tests/js/search-blocks/url-state.test.js
+++ b/projects/packages/search/tests/js/search-blocks/url-state.test.js
@@ -33,6 +33,22 @@ describe( 'stateToUrlParams', () => {
 		expect( params.has( 'orderby' ) ).toBe( false );
 	} );
 
+	it.each( [ 'rating_desc', 'price_asc', 'price_desc' ] )(
+		'serializes product-format sort order %s',
+		sortOrder => {
+			// Guards against VALID_SORT_ORDERS drifting from
+			// Sort_Control::get_all_option_keys() — a missing key here would
+			// silently drop the param and reset shared links to relevance.
+			const params = stateToUrlParams( { searchQuery: '', sortOrder } );
+			expect( params.get( 'orderby' ) ).toBe( sortOrder );
+		}
+	);
+
+	it( 'omits unknown sort orders', () => {
+		const params = stateToUrlParams( { searchQuery: '', sortOrder: 'bogus' } );
+		expect( params.has( 'orderby' ) ).toBe( false );
+	} );
+
 	it( 'serializes active filters as flat top-level array params', () => {
 		const params = stateToUrlParams( {
 			searchQuery: '',
@@ -67,6 +83,19 @@ describe( 'urlParamsToState', () => {
 
 	it( 'defaults sort order to relevance when absent', () => {
 		const state = urlParamsToState( new URLSearchParams( '' ) );
+		expect( state.sortOrder ).toBe( 'relevance' );
+	} );
+
+	it.each( [ 'rating_desc', 'price_asc', 'price_desc' ] )(
+		'accepts product-format sort order %s from URL',
+		sortOrder => {
+			const state = urlParamsToState( new URLSearchParams( `orderby=${ sortOrder }` ) );
+			expect( state.sortOrder ).toBe( sortOrder );
+		}
+	);
+
+	it( 'collapses unknown sort order to relevance', () => {
+		const state = urlParamsToState( new URLSearchParams( 'orderby=bogus' ) );
 		expect( state.sortOrder ).toBe( 'relevance' );
 	} );
 

--- a/projects/packages/search/tests/js/search-blocks/url-state.test.js
+++ b/projects/packages/search/tests/js/search-blocks/url-state.test.js
@@ -34,8 +34,6 @@ describe( 'stateToUrlParams', () => {
 	} );
 
 	it( 'omits product-format sort orders until WooCommerce integration lands (RSM-1082)', () => {
-		// `price_asc` stands in for the full product-format set — they share
-		// one whitelist branch, so a single case is enough to guard it.
 		const params = stateToUrlParams( { searchQuery: '', sortOrder: 'price_asc' } );
 		expect( params.has( 'orderby' ) ).toBe( false );
 	} );
@@ -83,7 +81,6 @@ describe( 'urlParamsToState', () => {
 	} );
 
 	it( 'collapses product-format URL sort to relevance until WooCommerce integration lands (RSM-1082)', () => {
-		// Same single-case guard as the serializer direction above.
 		const state = urlParamsToState( new URLSearchParams( 'orderby=price_asc' ) );
 		expect( state.sortOrder ).toBe( 'relevance' );
 	} );

--- a/projects/packages/search/tests/php/Sort_Control_Render_Test.php
+++ b/projects/packages/search/tests/php/Sort_Control_Render_Test.php
@@ -90,39 +90,18 @@ class Sort_Control_Render_Test extends TestCase {
 	}
 
 	/**
-	 * Default render path: only the base sort keys appear in a `<select>`
-	 * with the "Sort by" legacy label. Product-format keys (rating/price)
-	 * are opt-in — they must not leak into the default rendering of a
-	 * freshly-inserted block.
+	 * Default render path: every base sort key appears in a `<select>`
+	 * with the "Sort by" legacy label. The block ships with only the three
+	 * base keys — product-format sort keys are deferred to the WooCommerce
+	 * integration (RSM-1082).
 	 */
-	public function test_default_attributes_render_select_with_base_options_only() {
+	public function test_default_attributes_render_select_with_base_options() {
 		$markup = $this->render();
 		$this->assertStringContainsString( '<select', $markup );
 		$this->assertStringContainsString( 'Sort by', $markup );
 		foreach ( array( 'relevance', 'newest', 'oldest' ) as $key ) {
 			$this->assertStringContainsString( 'value="' . $key . '"', $markup );
 		}
-		foreach ( array( 'rating_desc', 'price_asc', 'price_desc' ) as $key ) {
-			$this->assertStringNotContainsString( 'value="' . $key . '"', $markup );
-		}
-	}
-
-	/**
-	 * When the author explicitly opts into product-format sort keys, they
-	 * must render alongside the base keys in the canonical
-	 * base-then-product order. Guards against `resolve_available_options()`
-	 * dropping keys the enum actually permits.
-	 */
-	public function test_product_format_options_render_when_enabled() {
-		$markup = $this->render(
-			array(
-				'availableSortOptions' => array( 'relevance', 'rating_desc', 'price_asc', 'price_desc' ),
-			)
-		);
-		foreach ( array( 'rating_desc', 'price_asc', 'price_desc' ) as $key ) {
-			$this->assertStringContainsString( 'value="' . $key . '"', $markup );
-		}
-		$this->assertStringContainsString( 'Price: low to high', $markup );
 	}
 
 	/**
@@ -148,7 +127,6 @@ class Sort_Control_Render_Test extends TestCase {
 		$this->assertStringContainsString( 'value="relevance"', $markup );
 		$this->assertStringContainsString( 'value="newest"', $markup );
 		$this->assertStringNotContainsString( 'value="oldest"', $markup );
-		$this->assertStringNotContainsString( 'value="price_asc"', $markup );
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Sort_Control_Render_Test.php
+++ b/projects/packages/search/tests/php/Sort_Control_Render_Test.php
@@ -90,9 +90,8 @@ class Sort_Control_Render_Test extends TestCase {
 	}
 
 	/**
-	 * Default render path: every base sort key appears in a `<select>`
-	 * with the "Sort by" legacy label. The block ships with only the three
-	 * base keys — product-format sort keys are deferred to the WooCommerce
+	 * Default render path: dropdown, legacy "Sort by" label, every base
+	 * option present. Product-format keys are deferred to the WooCommerce
 	 * integration (RSM-1082).
 	 */
 	public function test_default_attributes_render_select_with_base_options() {
@@ -105,42 +104,13 @@ class Sort_Control_Render_Test extends TestCase {
 	}
 
 	/**
-	 * `displayAs=radio` must emit a `<fieldset>` with one `<input type="radio">`
-	 * per exposed option. The render contract says "radio group per displayAs"
-	 * — a regression here would silently keep rendering a dropdown.
+	 * `displayAs=radio` must emit a `<fieldset>` of radios, not a dropdown.
 	 */
 	public function test_display_as_radio_renders_fieldset_with_radios() {
 		$markup = $this->render( array( 'displayAs' => 'radio' ) );
 		$this->assertStringContainsString( '<fieldset', $markup );
 		$this->assertStringNotContainsString( '<select', $markup );
 		$this->assertStringContainsString( 'type="radio"', $markup );
-		$this->assertStringContainsString( 'value="relevance"', $markup );
-		$this->assertStringContainsString( 'value="newest"', $markup );
-	}
-
-	/**
-	 * `availableSortOptions` must filter the rendered list: keys not in the
-	 * array must not produce options, keys in the array must.
-	 */
-	public function test_available_options_filters_rendered_options() {
-		$markup = $this->render( array( 'availableSortOptions' => array( 'relevance', 'newest' ) ) );
-		$this->assertStringContainsString( 'value="relevance"', $markup );
-		$this->assertStringContainsString( 'value="newest"', $markup );
-		$this->assertStringNotContainsString( 'value="oldest"', $markup );
-	}
-
-	/**
-	 * When the URL carries no sort param, `defaultSort` must become the
-	 * server-rendered selected option so the first-paint dropdown matches
-	 * what the JS store will hydrate once the store override lands.
-	 */
-	public function test_default_sort_preselected_when_url_has_no_orderby() {
-		$markup = $this->render( array( 'defaultSort' => 'newest' ) );
-		// selected() emits `selected='selected'` under PHP's checked() helper.
-		$this->assertMatchesRegularExpression(
-			'/<option[^>]*value="newest"[^>]*selected/',
-			$markup
-		);
 	}
 
 	/**
@@ -165,15 +135,6 @@ class Sort_Control_Render_Test extends TestCase {
 	}
 
 	/**
-	 * A user-provided `label` must appear in the rendered markup in place
-	 * of the translated "Sort by" default.
-	 */
-	public function test_custom_label_replaces_default() {
-		$markup = $this->render( array( 'label' => 'Order by' ) );
-		$this->assertStringContainsString( 'Order by', $markup );
-	}
-
-	/**
 	 * Labels are user-controlled, so the template must escape HTML to
 	 * prevent stored XSS through a crafted attribute value.
 	 */
@@ -181,42 +142,5 @@ class Sort_Control_Render_Test extends TestCase {
 		$markup = $this->render( array( 'label' => '<script>alert(1)</script>' ) );
 		$this->assertStringNotContainsString( '<script>alert(1)</script>', $markup );
 		$this->assertStringContainsString( '&lt;script&gt;alert(1)&lt;/script&gt;', $markup );
-	}
-
-	/**
-	 * In radio mode, the block-default option must carry the `checked`
-	 * attribute so the server-rendered DOM matches the hydrated state.
-	 */
-	public function test_radio_mode_checks_default_sort() {
-		$markup = $this->render(
-			array(
-				'displayAs'   => 'radio',
-				'defaultSort' => 'oldest',
-			)
-		);
-		$this->assertMatchesRegularExpression(
-			'/<input[^>]*value="oldest"[^>]*checked/',
-			$markup
-		);
-	}
-
-	/**
-	 * When `defaultSort` lands outside `availableSortOptions` (e.g. an
-	 * author saved a default, then unchecked it from the list), render.php
-	 * must keep rendering — falling back to the first exposed option rather
-	 * than emitting a control whose selected value is absent.
-	 */
-	public function test_default_sort_outside_available_falls_back_to_first_option() {
-		$markup = $this->render(
-			array(
-				'defaultSort'          => 'newest',
-				'availableSortOptions' => array( 'relevance', 'oldest' ),
-			)
-		);
-		$this->assertStringNotContainsString( 'value="newest"', $markup );
-		$this->assertMatchesRegularExpression(
-			'/<option[^>]*value="relevance"[^>]*selected/',
-			$markup
-		);
 	}
 }

--- a/projects/packages/search/tests/php/Sort_Control_Render_Test.php
+++ b/projects/packages/search/tests/php/Sort_Control_Render_Test.php
@@ -7,7 +7,7 @@
 
 namespace Automattic\Jetpack\Search;
 
-use PHPUnit\Framework\TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
  * Integration tests for the sort-control block's render template.

--- a/projects/packages/search/tests/php/Sort_Control_Render_Test.php
+++ b/projects/packages/search/tests/php/Sort_Control_Render_Test.php
@@ -89,11 +89,7 @@ class Sort_Control_Render_Test extends TestCase {
 		return do_blocks( '<!-- wp:jetpack/sort-control ' . $json . ' /-->' );
 	}
 
-	/**
-	 * Default render path: dropdown, legacy "Sort by" label, every base
-	 * option present. Product-format keys are deferred to the WooCommerce
-	 * integration (RSM-1082).
-	 */
+	/** Default render: dropdown, "Sort by", all base options. Product keys deferred to RSM-1082. */
 	public function test_default_attributes_render_select_with_base_options() {
 		$markup = $this->render();
 		$this->assertStringContainsString( '<select', $markup );
@@ -103,9 +99,7 @@ class Sort_Control_Render_Test extends TestCase {
 		}
 	}
 
-	/**
-	 * `displayAs=radio` must emit a `<fieldset>` of radios, not a dropdown.
-	 */
+	/** `displayAs=radio` emits a `<fieldset>` of radios, not a dropdown. */
 	public function test_display_as_radio_renders_fieldset_with_radios() {
 		$markup = $this->render( array( 'displayAs' => 'radio' ) );
 		$this->assertStringContainsString( '<fieldset', $markup );
@@ -113,10 +107,7 @@ class Sort_Control_Render_Test extends TestCase {
 		$this->assertStringContainsString( 'type="radio"', $markup );
 	}
 
-	/**
-	 * A URL `?orderby=oldest` must win over the block's `defaultSort` —
-	 * deep links keep their meaning even when the block default differs.
-	 */
+	/** URL `?orderby=` wins over `defaultSort` so deep links keep their meaning. */
 	public function test_url_sort_wins_over_default_sort() {
 		$_GET = array( 'orderby' => 'oldest' );
 		try {
@@ -134,10 +125,7 @@ class Sort_Control_Render_Test extends TestCase {
 		}
 	}
 
-	/**
-	 * Labels are user-controlled, so the template must escape HTML to
-	 * prevent stored XSS through a crafted attribute value.
-	 */
+	/** Label is user-controlled; must be HTML-escaped to block stored XSS. */
 	public function test_label_is_html_escaped() {
 		$markup = $this->render( array( 'label' => '<script>alert(1)</script>' ) );
 		$this->assertStringNotContainsString( '<script>alert(1)</script>', $markup );

--- a/projects/packages/search/tests/php/Sort_Control_Render_Test.php
+++ b/projects/packages/search/tests/php/Sort_Control_Render_Test.php
@@ -35,7 +35,7 @@ class Sort_Control_Render_Test extends TestCase {
 					),
 					'availableSortOptions' => array(
 						'type'    => 'array',
-						'default' => array( 'relevance', 'newest', 'oldest', 'rating_desc', 'price_asc', 'price_desc' ),
+						'default' => array( 'relevance', 'newest', 'oldest' ),
 					),
 					'label'                => array(
 						'type'    => 'string',
@@ -90,17 +90,39 @@ class Sort_Control_Render_Test extends TestCase {
 	}
 
 	/**
-	 * Default render path: every built-in option appears in a `<select>`
-	 * with the "Sort by" legacy label. Guards against attribute defaults
-	 * regressing for posts saved before SEARCH-138.
+	 * Default render path: only the base sort keys appear in a `<select>`
+	 * with the "Sort by" legacy label. Product-format keys (rating/price)
+	 * are opt-in — they must not leak into the default rendering of a
+	 * freshly-inserted block.
 	 */
-	public function test_default_attributes_render_select_with_all_options() {
+	public function test_default_attributes_render_select_with_base_options_only() {
 		$markup = $this->render();
 		$this->assertStringContainsString( '<select', $markup );
 		$this->assertStringContainsString( 'Sort by', $markup );
-		foreach ( array( 'relevance', 'newest', 'oldest', 'rating_desc', 'price_asc', 'price_desc' ) as $key ) {
+		foreach ( array( 'relevance', 'newest', 'oldest' ) as $key ) {
 			$this->assertStringContainsString( 'value="' . $key . '"', $markup );
 		}
+		foreach ( array( 'rating_desc', 'price_asc', 'price_desc' ) as $key ) {
+			$this->assertStringNotContainsString( 'value="' . $key . '"', $markup );
+		}
+	}
+
+	/**
+	 * When the author explicitly opts into product-format sort keys, they
+	 * must render alongside the base keys in the canonical
+	 * base-then-product order. Guards against `resolve_available_options()`
+	 * dropping keys the enum actually permits.
+	 */
+	public function test_product_format_options_render_when_enabled() {
+		$markup = $this->render(
+			array(
+				'availableSortOptions' => array( 'relevance', 'rating_desc', 'price_asc', 'price_desc' ),
+			)
+		);
+		foreach ( array( 'rating_desc', 'price_asc', 'price_desc' ) as $key ) {
+			$this->assertStringContainsString( 'value="' . $key . '"', $markup );
+		}
+		$this->assertStringContainsString( 'Price: low to high', $markup );
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Sort_Control_Render_Test.php
+++ b/projects/packages/search/tests/php/Sort_Control_Render_Test.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * Sort Control block render.php tests.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Integration tests for the sort-control block's render template.
+ *
+ * Each test renders through `do_blocks()` so WordPress wires up the block
+ * context `get_block_wrapper_attributes()` needs — exercising the same path
+ * the front end takes, not just an isolated `include`.
+ */
+class Sort_Control_Render_Test extends TestCase {
+
+	/**
+	 * Register the sort-control block inline so `do_blocks()` can resolve it
+	 * without requiring the `build/` artifacts referenced by block.json's
+	 * `viewScriptModule` and `style` entries. The render callback forwards
+	 * `$attributes` to the render.php under test.
+	 */
+	public static function setUpBeforeClass(): void {
+		\register_block_type(
+			'jetpack/sort-control',
+			array(
+				'attributes'      => array(
+					'defaultSort'          => array(
+						'type'    => 'string',
+						'default' => 'relevance',
+					),
+					'availableSortOptions' => array(
+						'type'    => 'array',
+						'default' => array( 'relevance', 'newest', 'oldest', 'rating_desc', 'price_asc', 'price_desc' ),
+					),
+					'label'                => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'displayAs'            => array(
+						'type'    => 'string',
+						'default' => 'select',
+					),
+				),
+				// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+				'render_callback' => static function ( $attributes ) {
+					ob_start();
+					include __DIR__ . '/../../src/search-blocks/blocks/sort-control/render.php';
+					return (string) ob_get_clean();
+				},
+				// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			)
+		);
+	}
+
+	/**
+	 * Release the block registration so subsequent test classes don't
+	 * collide with our inline attribute schema.
+	 */
+	public static function tearDownAfterClass(): void {
+		\unregister_block_type( 'jetpack/sort-control' );
+	}
+
+	/**
+	 * Reset `$_GET` between tests so URL parsing never leaks across cases.
+	 * Interactivity state carries across tests, but render.php always writes
+	 * `sortOrder` deterministically from attrs + URL, so each render
+	 * overwrites whatever the previous one left behind.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$_GET = array();
+	}
+
+	/**
+	 * Render the sort-control block with the given attributes via `do_blocks`.
+	 *
+	 * @param array $attributes Block attributes (JSON-encoded into the comment delimiter).
+	 * @return string Rendered markup.
+	 */
+	private function render( array $attributes = array() ): string {
+		$json = empty( $attributes )
+			? ''
+			: wp_json_encode( $attributes, JSON_UNESCAPED_SLASHES );
+		return do_blocks( '<!-- wp:jetpack/sort-control ' . $json . ' /-->' );
+	}
+
+	/**
+	 * Default render path: every built-in option appears in a `<select>`
+	 * with the "Sort by" legacy label. Guards against attribute defaults
+	 * regressing for posts saved before SEARCH-138.
+	 */
+	public function test_default_attributes_render_select_with_all_options() {
+		$markup = $this->render();
+		$this->assertStringContainsString( '<select', $markup );
+		$this->assertStringContainsString( 'Sort by', $markup );
+		foreach ( array( 'relevance', 'newest', 'oldest', 'rating_desc', 'price_asc', 'price_desc' ) as $key ) {
+			$this->assertStringContainsString( 'value="' . $key . '"', $markup );
+		}
+	}
+
+	/**
+	 * `displayAs=radio` must emit a `<fieldset>` with one `<input type="radio">`
+	 * per exposed option. The render contract says "radio group per displayAs"
+	 * — a regression here would silently keep rendering a dropdown.
+	 */
+	public function test_display_as_radio_renders_fieldset_with_radios() {
+		$markup = $this->render( array( 'displayAs' => 'radio' ) );
+		$this->assertStringContainsString( '<fieldset', $markup );
+		$this->assertStringNotContainsString( '<select', $markup );
+		$this->assertStringContainsString( 'type="radio"', $markup );
+		$this->assertStringContainsString( 'value="relevance"', $markup );
+		$this->assertStringContainsString( 'value="newest"', $markup );
+	}
+
+	/**
+	 * `availableSortOptions` must filter the rendered list: keys not in the
+	 * array must not produce options, keys in the array must.
+	 */
+	public function test_available_options_filters_rendered_options() {
+		$markup = $this->render( array( 'availableSortOptions' => array( 'relevance', 'newest' ) ) );
+		$this->assertStringContainsString( 'value="relevance"', $markup );
+		$this->assertStringContainsString( 'value="newest"', $markup );
+		$this->assertStringNotContainsString( 'value="oldest"', $markup );
+		$this->assertStringNotContainsString( 'value="price_asc"', $markup );
+	}
+
+	/**
+	 * When the URL carries no sort param, `defaultSort` must become the
+	 * server-rendered selected option so the first-paint dropdown matches
+	 * what the JS store will hydrate once the store override lands.
+	 */
+	public function test_default_sort_preselected_when_url_has_no_orderby() {
+		$markup = $this->render( array( 'defaultSort' => 'newest' ) );
+		// selected() emits `selected='selected'` under PHP's checked() helper.
+		$this->assertMatchesRegularExpression(
+			'/<option[^>]*value="newest"[^>]*selected/',
+			$markup
+		);
+	}
+
+	/**
+	 * A URL `?orderby=oldest` must win over the block's `defaultSort` —
+	 * deep links keep their meaning even when the block default differs.
+	 */
+	public function test_url_sort_wins_over_default_sort() {
+		$_GET = array( 'orderby' => 'oldest' );
+		try {
+			$markup = $this->render( array( 'defaultSort' => 'newest' ) );
+			$this->assertMatchesRegularExpression(
+				'/<option[^>]*value="oldest"[^>]*selected/',
+				$markup
+			);
+			$this->assertDoesNotMatchRegularExpression(
+				'/<option[^>]*value="newest"[^>]*selected/',
+				$markup
+			);
+		} finally {
+			$_GET = array();
+		}
+	}
+
+	/**
+	 * A user-provided `label` must appear in the rendered markup in place
+	 * of the translated "Sort by" default.
+	 */
+	public function test_custom_label_replaces_default() {
+		$markup = $this->render( array( 'label' => 'Order by' ) );
+		$this->assertStringContainsString( 'Order by', $markup );
+	}
+
+	/**
+	 * Labels are user-controlled, so the template must escape HTML to
+	 * prevent stored XSS through a crafted attribute value.
+	 */
+	public function test_label_is_html_escaped() {
+		$markup = $this->render( array( 'label' => '<script>alert(1)</script>' ) );
+		$this->assertStringNotContainsString( '<script>alert(1)</script>', $markup );
+		$this->assertStringContainsString( '&lt;script&gt;alert(1)&lt;/script&gt;', $markup );
+	}
+
+	/**
+	 * In radio mode, the block-default option must carry the `checked`
+	 * attribute so the server-rendered DOM matches the hydrated state.
+	 */
+	public function test_radio_mode_checks_default_sort() {
+		$markup = $this->render(
+			array(
+				'displayAs'   => 'radio',
+				'defaultSort' => 'oldest',
+			)
+		);
+		$this->assertMatchesRegularExpression(
+			'/<input[^>]*value="oldest"[^>]*checked/',
+			$markup
+		);
+	}
+
+	/**
+	 * When `defaultSort` lands outside `availableSortOptions` (e.g. an
+	 * author saved a default, then unchecked it from the list), render.php
+	 * must keep rendering — falling back to the first exposed option rather
+	 * than emitting a control whose selected value is absent.
+	 */
+	public function test_default_sort_outside_available_falls_back_to_first_option() {
+		$markup = $this->render(
+			array(
+				'defaultSort'          => 'newest',
+				'availableSortOptions' => array( 'relevance', 'oldest' ),
+			)
+		);
+		$this->assertStringNotContainsString( 'value="newest"', $markup );
+		$this->assertMatchesRegularExpression(
+			'/<option[^>]*value="relevance"[^>]*selected/',
+			$markup
+		);
+	}
+}

--- a/projects/packages/search/tests/php/Sort_Control_Test.php
+++ b/projects/packages/search/tests/php/Sort_Control_Test.php
@@ -32,12 +32,7 @@ class Sort_Control_Test extends TestCase {
 		$this->assertSame( 'newest', Sort_Control::normalize_default_sort( array( 'defaultSort' => 'newest' ) ) );
 	}
 
-	/**
-	 * Product-format keys (rating/price) live behind a WooCommerce integration
-	 * that hasn't landed yet — tracked in RSM-1082. Until then they must
-	 * collapse to `relevance` so a stray saved attribute can't render an
-	 * option the block no longer knows about.
-	 */
+	/** Product-format keys are deferred to RSM-1082. */
 	public function test_normalize_default_sort_rejects_product_key_until_woocommerce_integration() {
 		$this->assertSame( 'relevance', Sort_Control::normalize_default_sort( array( 'defaultSort' => 'price_asc' ) ) );
 	}

--- a/projects/packages/search/tests/php/Sort_Control_Test.php
+++ b/projects/packages/search/tests/php/Sort_Control_Test.php
@@ -33,11 +33,13 @@ class Sort_Control_Test extends TestCase {
 	}
 
 	/**
-	 * Product-format keys are allowed at the block level even on non-product
-	 * stores — per SEARCH-138's "always expose and let store decide" choice.
+	 * Product-format keys (rating/price) live behind a WooCommerce integration
+	 * that hasn't landed yet — tracked in RSM-1082. Until then they must
+	 * collapse to `relevance` so a stray saved attribute can't render an
+	 * option the block no longer knows about.
 	 */
-	public function test_normalize_default_sort_accepts_product_key() {
-		$this->assertSame( 'price_asc', Sort_Control::normalize_default_sort( array( 'defaultSort' => 'price_asc' ) ) );
+	public function test_normalize_default_sort_rejects_product_key_until_woocommerce_integration() {
+		$this->assertSame( 'relevance', Sort_Control::normalize_default_sort( array( 'defaultSort' => 'price_asc' ) ) );
 	}
 
 	/**
@@ -54,7 +56,7 @@ class Sort_Control_Test extends TestCase {
 	 */
 	public function test_resolve_available_options_defaults_to_full_list() {
 		$this->assertSame(
-			array( 'relevance', 'newest', 'oldest', 'rating_desc', 'price_asc', 'price_desc' ),
+			array( 'relevance', 'newest', 'oldest' ),
 			Sort_Control::resolve_available_options( array() )
 		);
 	}

--- a/projects/packages/search/tests/php/Sort_Control_Test.php
+++ b/projects/packages/search/tests/php/Sort_Control_Test.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Sort_Control helper tests.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the Sort_Control helper class used by the jetpack/sort-control
+ * block. Covers attribute normalization so render.php can trust the inputs
+ * it receives regardless of what a garbage block attribute carries.
+ */
+class Sort_Control_Test extends TestCase {
+
+	/**
+	 * A missing `defaultSort` attribute must fall back to `relevance` — the
+	 * same default `parse_url_sort()` returns when the URL has no `orderby`.
+	 */
+	public function test_normalize_default_sort_falls_back_when_missing() {
+		$this->assertSame( 'relevance', Sort_Control::normalize_default_sort( array() ) );
+	}
+
+	/**
+	 * Known sort keys must pass through unchanged so block-saved values stay
+	 * stable across renders.
+	 */
+	public function test_normalize_default_sort_accepts_known_key() {
+		$this->assertSame( 'newest', Sort_Control::normalize_default_sort( array( 'defaultSort' => 'newest' ) ) );
+	}
+
+	/**
+	 * Product-format keys are allowed at the block level even on non-product
+	 * stores — per SEARCH-138's "always expose and let store decide" choice.
+	 */
+	public function test_normalize_default_sort_accepts_product_key() {
+		$this->assertSame( 'price_asc', Sort_Control::normalize_default_sort( array( 'defaultSort' => 'price_asc' ) ) );
+	}
+
+	/**
+	 * Unknown keys collapse to `relevance` so a garbage attribute can't leak
+	 * into the rendered control or the seeded Interactivity state.
+	 */
+	public function test_normalize_default_sort_rejects_unknown_key() {
+		$this->assertSame( 'relevance', Sort_Control::normalize_default_sort( array( 'defaultSort' => 'drop-tables' ) ) );
+	}
+
+	/**
+	 * A missing `availableSortOptions` attribute must fall back to every
+	 * option so the control renders the full list by default.
+	 */
+	public function test_resolve_available_options_defaults_to_full_list() {
+		$this->assertSame(
+			array( 'relevance', 'newest', 'oldest', 'rating_desc', 'price_asc', 'price_desc' ),
+			Sort_Control::resolve_available_options( array() )
+		);
+	}
+
+	/**
+	 * Filtering must preserve the canonical order from get_all_option_keys(),
+	 * not the order the attribute array arrived in — otherwise save/load
+	 * round-trips could reshuffle the dropdown.
+	 */
+	public function test_resolve_available_options_preserves_canonical_order() {
+		$this->assertSame(
+			array( 'relevance', 'oldest' ),
+			Sort_Control::resolve_available_options(
+				array( 'availableSortOptions' => array( 'oldest', 'relevance' ) )
+			)
+		);
+	}
+
+	/**
+	 * Unknown keys inside the attribute array must be dropped silently so a
+	 * stray/typo'd value can't render an `<option>` that the JS store would
+	 * reject at change time.
+	 */
+	public function test_resolve_available_options_drops_unknown_keys() {
+		$this->assertSame(
+			array( 'relevance', 'newest' ),
+			Sort_Control::resolve_available_options(
+				array( 'availableSortOptions' => array( 'relevance', 'newest', 'bogus' ) )
+			)
+		);
+	}
+
+	/**
+	 * An empty array falls back to the full list rather than rendering a
+	 * control with zero options — otherwise an accidental `[]` from the
+	 * inspector would produce an empty `<select>` that the user can't fix.
+	 */
+	public function test_resolve_available_options_empty_falls_back_to_all() {
+		$this->assertSame(
+			Sort_Control::get_all_option_keys(),
+			Sort_Control::resolve_available_options( array( 'availableSortOptions' => array() ) )
+		);
+	}
+
+	/**
+	 * A non-array value (e.g. a string from a misconfigured saved block)
+	 * must be handled defensively — fall back to the full list.
+	 */
+	public function test_resolve_available_options_non_array_falls_back_to_all() {
+		$this->assertSame(
+			Sort_Control::get_all_option_keys(),
+			Sort_Control::resolve_available_options( array( 'availableSortOptions' => 'relevance' ) )
+		);
+	}
+
+	/**
+	 * `displayAs` defaults to `select` so existing posts (saved before the
+	 * attribute existed) keep rendering a dropdown.
+	 */
+	public function test_normalize_display_as_defaults_to_select() {
+		$this->assertSame( 'select', Sort_Control::normalize_display_as( array() ) );
+	}
+
+	/**
+	 * `radio` is the only non-default value the block supports.
+	 */
+	public function test_normalize_display_as_accepts_radio() {
+		$this->assertSame( 'radio', Sort_Control::normalize_display_as( array( 'displayAs' => 'radio' ) ) );
+	}
+
+	/**
+	 * Unknown values must collapse to `select` so a garbage attribute can't
+	 * produce markup the view script doesn't know how to bind against.
+	 */
+	public function test_normalize_display_as_rejects_unknown_value() {
+		$this->assertSame( 'select', Sort_Control::normalize_display_as( array( 'displayAs' => 'grid' ) ) );
+	}
+
+	/**
+	 * Missing label falls back to the translated default so pre-SEARCH-138
+	 * posts keep the original "Sort by" copy.
+	 */
+	public function test_resolve_label_falls_back_when_empty() {
+		$this->assertSame( 'Sort by', Sort_Control::resolve_label( array() ) );
+		$this->assertSame( 'Sort by', Sort_Control::resolve_label( array( 'label' => '' ) ) );
+	}
+
+	/**
+	 * A whitespace-only label must behave as empty — the editor inspector
+	 * help copy says "Leave empty to use the default", and a blank-looking
+	 * value shouldn't render a visually empty label.
+	 */
+	public function test_resolve_label_treats_whitespace_as_empty() {
+		$this->assertSame( 'Sort by', Sort_Control::resolve_label( array( 'label' => '   ' ) ) );
+	}
+
+	/**
+	 * A user-supplied label passes through (trimmed) unchanged.
+	 */
+	public function test_resolve_label_returns_user_value() {
+		$this->assertSame( 'Order by', Sort_Control::resolve_label( array( 'label' => '  Order by  ' ) ) );
+	}
+}


### PR DESCRIPTION
Fixes SEARCH-138

## Proposed changes
* Adds four attributes to the `jetpack/sort-control` block: `defaultSort` (enum, defaults to `relevance`), `availableSortOptions` (array of sort keys, defaults to all), `label` (text shown next to/above the control), and `displayAs` (`select` or `radio`).
* Factors attribute normalization into a new `Sort_Control` helper class so `render.php` and the block's tests share one source of truth for defaults, option filtering, and label resolution.
* `render.php` emits either a `<select>` or a `<fieldset>` of radios depending on `displayAs`, restricts the rendered keys to `availableSortOptions`, uses the `label` attribute (falls back to the translated `Sort by`), and seeds the Interactivity store's `sortOrder` from `defaultSort` when the URL carries no `?orderby=…`.
* URL deep links still win over `defaultSort` — `?orderby=newest` / `?orderby=oldest` keep their meaning (parsed by `Search_Blocks`), with the render-state override tightening the seed value against the block's allow-list.
* Editor `edit.js` now renders an inspector (`Label`, `Default sort`, `Display as`, and a checkbox list for `Available options`) and previews the saved `displayAs` shape so authors see the final control inline.
* Product-format sort keys (`rating_desc`, `price_asc`, `price_desc`) are intentionally **deferred** to the WooCommerce integration tracked under [RSM-1082](https://linear.app/a8c/issue/RSM-1082); only the base keys (`relevance`, `newest`, `oldest`) are exposed at the block level for now.
* Adds PHPUnit coverage: `Sort_Control_Test` for attribute-normalization edge cases and `Sort_Control_Render_Test` integration tests that render through `do_blocks()` for both display modes, URL-vs-default precedence, label escaping, and the `defaultSort` ∉ `availableSortOptions` fallback.

## Related product discussion/links
* Linear: https://linear.app/a8c/issue/SEARCH-138/sort-control-default-sort-presentation-controls

## Does this pull request change what data or activity we track or use?
No.

## Screenshots

Captured on a block-theme docker env; the same test page drove both columns — trunk ignores the new attributes, the feature branch reads them.

### Editor — inspector on the Sort Control block

| Before (`trunk`) | After (this PR) |
|---|---|
| ![before editor](https://github.com/user-attachments/assets/851fc56f-0984-467a-8a26-49ac3b6ad341) | ![after editor](https://github.com/user-attachments/assets/c2edc055-a2fa-457d-931d-2360a6979c38) |

### Front-end — select (default) display mode

`after` uses `defaultSort=newest`, `label="Order by"`, `availableSortOptions=["relevance","newest","oldest"]`.

| Before (`trunk`) | After (this PR) |
|---|---|
| ![before frontend select](https://github.com/user-attachments/assets/e5a2a400-e996-4e7e-8fd2-958c9e254c57) | ![after frontend select](https://github.com/user-attachments/assets/3834a3a3-3cad-4112-a542-b44c1ed7761f) |

### Front-end — radio display mode (new)

| Before (`trunk`) | After (this PR) |
|---|---|
| _N/A — radio mode doesn't exist on trunk_ | ![after frontend radio](https://github.com/user-attachments/assets/b34315fd-5f49-473f-bda5-bff503820a15) |

See the accompanying review comment for an observation about `defaultSort` hydration under block themes.

## Testing instructions
1. Insert or navigate to a page containing the Jetpack Search **Sort Control** block in the block editor.
2. Open the block inspector and confirm the new panels:
   * **Sort Settings** with `Label`, `Default sort`, and `Display as`.
   * **Available options** with a checkbox per sort key.
3. Verify `defaultSort`:
   * Set it to `Newest`, save, visit a page where the block renders, and confirm the front-end control shows `Newest` pre-selected when the URL has no `?orderby=…`.
   * Add `?orderby=oldest` to the URL and confirm `Oldest` wins over the saved default.
4. Verify `availableSortOptions`:
   * Uncheck `Oldest` in the inspector and save. The front-end dropdown should no longer offer `Oldest`.
   * Uncheck every option and confirm the control falls back to the full set rather than rendering empty.
5. Verify `label`:
   * Set it to `Order by` — confirm the front end shows that text instead of `Sort by`.
   * Clear the label and confirm `Sort by` returns.
6. Verify `displayAs`:
   * Switch to `Radio buttons` — confirm the front end renders a `<fieldset>` with one radio per available option and the default/URL-selected key has `checked` applied on first paint.
   * Switch back to `Dropdown` — confirm the `<select>` renders as before.
7. Run the PHPUnit suite for the package: `cd projects/packages/search && composer phpunit`.

