### PR TITLE
Search: results-count template attribute for custom count strings

### DIFF
--- a/projects/packages/search/changelog/add-search-142-results-count-template
+++ b/projects/packages/search/changelog/add-search-142-results-count-template
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Search Blocks: results-count gains a template attribute for customizing the results-count string with %1$d/%2$d/%3$d/%4$s placeholders.

--- a/projects/packages/search/src/search-blocks/blocks/results-count/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/results-count/block.json
@@ -9,6 +9,9 @@
 	"description": "Displays the Jetpack Search results count.",
 	"supports": { "html": false, "interactivity": true },
 	"textdomain": "jetpack-search-pkg",
+	"attributes": {
+		"template": { "type": "string", "default": "" }
+	},
 	"render": "file:./render.php",
 	"viewScriptModule": "file:../../../../build/search-blocks/results-count.js",
 	"style": "file:../../../../build/search-blocks/results-count.css"

--- a/projects/packages/search/src/search-blocks/blocks/results-count/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/results-count/edit.js
@@ -1,20 +1,63 @@
 /**
  * Editor preview for jetpack/results-count.
  *
- * Matches the copy the live store emits via `state.resultsCountText`
- * (see store/index.js) so the preview reflects the same string designers
- * style on the front end.
+ * Mirrors the formatter the shared store getter runs on the front end so the
+ * preview reflects the same string designers style when the block hydrates.
+ * The Inspector exposes a text input for the `template` attribute; render.php
+ * pushes that value into `state.strings.resultsCountTemplate` (or leaves the
+ * PHP-translated default in place when it's empty), which the store getter
+ * then feeds into `formatResultsCountText` against live search state.
  */
-import { useBlockProps } from '@wordpress/block-editor';
-import { createElement as h } from '@wordpress/element';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, TextControl } from '@wordpress/components';
+import { createElement as h, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { formatResultsCountText } from './format';
+
+// Sample values used to preview the template in the editor. Kept stable so
+// the preview reads consistently regardless of the user's template choice.
+const SAMPLE = { first: 1, last: 10, total: 42, query: 'boots' };
 
 /**
  * Edit component for the results-count block.
  *
+ * @param {object}   props               - Block props.
+ * @param {object}   props.attributes    - Saved block attributes.
+ * @param {Function} props.setAttributes - Attribute setter.
  * @return {object} Rendered element.
  */
-export default function ResultsCountEdit() {
+export default function ResultsCountEdit( { attributes, setAttributes } ) {
 	const blockProps = useBlockProps();
-	return h( 'p', blockProps, __( '42 results', 'jetpack-search-pkg' ) );
+	/* translators: %1$d: first shown result (1-based), %2$d: last shown result, %3$d: total result count. */
+	const defaultTemplate = __( 'Showing %1$d–%2$d of %3$d results', 'jetpack-search-pkg' );
+	// Match render.php: a whitespace-only template falls back to the default
+	// in the preview so the editor mirrors the front-end behaviour the
+	// "Leave empty…" help text describes. The raw input is still stored.
+	const template = ( attributes?.template || '' ).trim() || defaultTemplate;
+	return h(
+		Fragment,
+		null,
+		h(
+			InspectorControls,
+			null,
+			h(
+				PanelBody,
+				{ title: __( 'Settings', 'jetpack-search-pkg' ) },
+				h( TextControl, {
+					__next40pxDefaultSize: true,
+					__nextHasNoMarginBottom: true,
+					label: __( 'Results count template', 'jetpack-search-pkg' ),
+					value: attributes?.template || '',
+					placeholder: defaultTemplate,
+					onChange: value => setAttributes( { template: value } ),
+					/* translators: The %1$d, %2$d, %3$d, and %4$s sequences are placeholder tokens authors type literally into the template — they must be preserved verbatim in the translation. */
+					help: __(
+						'Available placeholders: %1$d (first shown), %2$d (last shown), %3$d (total), %4$s (query). Leave empty to use the default translated template.',
+						'jetpack-search-pkg'
+					),
+				} )
+			)
+		),
+		h( 'p', blockProps, formatResultsCountText( template, SAMPLE ) )
+	);
 }

--- a/projects/packages/search/src/search-blocks/blocks/results-count/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/results-count/edit.js
@@ -28,8 +28,12 @@ const SAMPLE = { first: 1, last: 10, total: 42, query: 'boots' };
  */
 export default function ResultsCountEdit( { attributes, setAttributes } ) {
 	const blockProps = useBlockProps();
-	/* translators: %1$d: first shown result (1-based), %2$d: last shown result, %3$d: total result count. */
-	const defaultTemplate = __( 'Showing %1$d–%2$d of %3$d results', 'jetpack-search-pkg' );
+	// Comment attached directly to the __() call: the minifier merges adjacent
+	// `const` declarations and can misplace a preceding translator comment,
+	// dropping it from the built bundle and tripping the i18n-check plugin.
+	const defaultTemplate =
+		/* translators: %1$d: first shown result (1-based), %2$d: last shown result, %3$d: total result count. */
+		__( 'Showing %1$d–%2$d of %3$d results', 'jetpack-search-pkg' );
 	// Match render.php: a whitespace-only template falls back to the default
 	// in the preview so the editor mirrors the front-end behaviour the
 	// "Leave empty…" help text describes. The raw input is still stored.

--- a/projects/packages/search/src/search-blocks/blocks/results-count/format.js
+++ b/projects/packages/search/src/search-blocks/blocks/results-count/format.js
@@ -1,0 +1,38 @@
+/**
+ * Pure template formatter for the results-count block. Kept in its own
+ * module so it can be unit-tested without pulling in
+ * `@wordpress/interactivity` (which needs a DOM) through the store, and so
+ * the same function powers the editor preview (edit.js) and the runtime
+ * getter (store/index.js) without duplicating the substitution logic.
+ *
+ * Recognized placeholders: `%1$d` first shown, `%2$d` last shown,
+ * `%3$d` total, `%4$s` query.
+ *
+ * Any other printf-style placeholder (e.g. `%5$d`, `%1$s`, `%10$d`) is
+ * left untouched rather than silently stripped — authors get a visible
+ * hint when they mistype or reach for an unsupported index.
+ *
+ * @param {string} template   - Raw template string.
+ * @param {object} vars       - Interpolation variables.
+ * @param {number} vars.first - 1-based index of the first shown result.
+ * @param {number} vars.last  - 1-based index of the last shown result.
+ * @param {number} vars.total - Total result count from the search response.
+ * @param {string} vars.query - Current search query.
+ * @return {string} Template with supported placeholders substituted.
+ */
+export function formatResultsCountText( template, { first, last, total, query } ) {
+	const map = {
+		'%1$d': String( first ),
+		'%2$d': String( last ),
+		'%3$d': String( total ),
+		'%4$s': String( query ),
+	};
+	// Match any `%<digits>$<letter>` sequence so both known and unknown
+	// placeholders flow through `replace()`; the callback restores unknown
+	// matches verbatim via the default branch. There is no escape sequence
+	// for emitting a literal `%1$d`-style token — templates here are short
+	// human copy, not arbitrary text that might collide with placeholders.
+	return String( template ?? '' ).replace( /%\d+\$[a-zA-Z]/g, match =>
+		Object.prototype.hasOwnProperty.call( map, match ) ? map[ match ] : match
+	);
+}

--- a/projects/packages/search/src/search-blocks/blocks/results-count/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/results-count/render.php
@@ -8,8 +8,31 @@
 namespace Automattic\Jetpack\Search;
 
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
-?>
-<?php
+
+// Trim so a whitespace-only attribute falls back to the translated default —
+// mirrors the "Leave empty to use the default" copy in the editor inspector.
+// Recognized placeholders: %1$d (first shown), %2$d (last shown), %3$d (total),
+// %4$s (query). The JS formatter in store/index.js interpolates from live
+// store state so the string updates as results load and the user paginates;
+// unknown placeholders are left as-is so typos surface rather than silently
+// vanish.
+//
+// A non-empty custom template overrides `strings.resultsCountTemplate` in the
+// shared Interactivity state seeded by `Search_Blocks::build_initial_strings()`.
+// The override is global per namespace (not keyed per-instance), so two
+// results-count blocks with different templates on the same page collapse to
+// a last-render-wins behavior — preferred over threading a per-instance
+// context key through every template binding, since multi-instance use is
+// rare in practice. Empty / whitespace / missing templates skip the call so
+// the server-seeded default stays authoritative.
+$template = trim( (string) ( $attributes['template'] ?? '' ) );
+if ( '' !== $template && function_exists( 'wp_interactivity_state' ) ) {
+	wp_interactivity_state(
+		'jetpack-search',
+		array( 'strings' => array( 'resultsCountTemplate' => $template ) )
+	);
+}
+
 // Intentionally render the element even when the count text is empty. The
 // Blog Search Page pattern places results-count and sort-control in a flex
 // group with `justifyContent: space-between`; removing the element from the

--- a/projects/packages/search/src/search-blocks/blocks/results-count/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/results-count/view.js
@@ -1,4 +1,8 @@
-// Display-only block. View module pulls in the style + shared store so
-// state.resultsCountText is defined and updates re-render the node.
+// The results-count block binds `data-wp-text="state.resultsCountText"`; the
+// getter lives in `../../store` where it can read the seeded `state.strings`
+// (including the translated `resultsCountTemplate` default and any per-render
+// override from render.php). Importing the store here guarantees the module
+// ships whenever this block is on the page, and the stylesheet import brings
+// in the block's flex-row styling.
 import '../../store';
 import './style.scss';

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -555,20 +555,23 @@ class Search_Blocks {
 	protected static function build_initial_strings(): array {
 		if ( ! function_exists( '__' ) || ! function_exists( '_n' ) ) {
 			return array(
-				'searching'          => 'Searching…',
-				'resultsCountSingle' => 'Found %d result',
-				'resultsCountPlural' => 'Found %d results',
-				'removeFilter'       => 'Remove %s',
+				'searching'            => 'Searching…',
+				'resultsCountSingle'   => 'Found %d result',
+				'resultsCountPlural'   => 'Found %d results',
+				'resultsCountTemplate' => 'Showing %1$d–%2$d of %3$d results',
+				'removeFilter'         => 'Remove %s',
 			);
 		}
 		return array(
-			'searching'          => __( 'Searching…', 'jetpack-search-pkg' ),
+			'searching'            => __( 'Searching…', 'jetpack-search-pkg' ),
 			/* translators: %d: number of results. */
-			'resultsCountSingle' => _n( 'Found %d result', 'Found %d results', 1, 'jetpack-search-pkg' ),
+			'resultsCountSingle'   => _n( 'Found %d result', 'Found %d results', 1, 'jetpack-search-pkg' ),
 			/* translators: %d: number of results. */
-			'resultsCountPlural' => _n( 'Found %d result', 'Found %d results', 2, 'jetpack-search-pkg' ),
+			'resultsCountPlural'   => _n( 'Found %d result', 'Found %d results', 2, 'jetpack-search-pkg' ),
+			/* translators: Default format for the results-count block. %1$d: first shown result (1-based), %2$d: last shown result, %3$d: total result count. Authors can override this per block instance via the block's Template inspector control; the %4$s placeholder (current search query) is recognised by the view-bundle formatter but omitted from the default so the string reads cleanly with no query echo. */
+			'resultsCountTemplate' => __( 'Showing %1$d–%2$d of %3$d results', 'jetpack-search-pkg' ),
 			/* translators: %s: filter label (e.g. "Category: News"). Announced by screen readers when focus lands on a filter pill's remove button. */
-			'removeFilter'       => __( 'Remove %s', 'jetpack-search-pkg' ),
+			'removeFilter'         => __( 'Remove %s', 'jetpack-search-pkg' ),
 		);
 	}
 

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -1,4 +1,5 @@
 import { store } from '@wordpress/interactivity';
+import { formatResultsCountText } from '../blocks/results-count/format';
 import { buildSearchUrl } from './api';
 import { normalizeResult } from './result-utils';
 import { pushStateToUrl, readStateFromUrl } from './url-state';
@@ -55,14 +56,20 @@ const { state, actions } = store( NAMESPACE, {
 		 * Strings are seeded from PHP via `wp_interactivity_state()`
 		 * (see `Search_Blocks::build_initial_strings()`) because the
 		 * view bundle can't import `@wordpress/i18n` — WP only registers
-		 * `@wordpress/interactivity` as a script module. Languages with
-		 * more than two plural forms degrade to "plural for all count
-		 * > 1" since the count is dynamic on the client.
+		 * `@wordpress/interactivity` as a script module. When
+		 * `resultsCountTemplate` is present (default: translated
+		 * `Showing %1$d–%2$d of %3$d results`, overridable by the
+		 * results-count block's `template` attribute), the template
+		 * formatter runs so authors can customise copy and surface the
+		 * current query. Languages with more than two plural forms
+		 * degrade to "plural for all count > 1" since the count is
+		 * dynamic on the client.
 		 *
 		 * @return {string} Translated "Searching…" while a search is in
-		 * flight, "Found 42 results" once a query resolves with hits,
-		 * or an empty string in every other case — pre-search, error,
-		 * or zero hits. The no-results block owns the empty-state copy.
+		 * flight, the formatted template (or "Found N results" when no
+		 * template is seeded) once a query resolves with hits, or an
+		 * empty string in every other case — pre-search, error, or zero
+		 * hits. The no-results block owns the empty-state copy.
 		 */
 		get resultsCountText() {
 			if ( state.isLoading ) {
@@ -72,11 +79,28 @@ const { state, actions } = store( NAMESPACE, {
 			if ( total === 0 ) {
 				return '';
 			}
-			const template =
+			const template = state.strings?.resultsCountTemplate;
+			if ( template ) {
+				const last = Array.isArray( state.results ) ? state.results.length : 0;
+				// `first` is always 1 when any result exists because load-more
+				// is append-only: each page's hits are concatenated onto the
+				// same `state.results` array, so the visible window always
+				// starts at the first result. The placeholder is still
+				// exposed for authors whose custom templates want to spell
+				// out "1" explicitly, and to leave room for a future
+				// offset-pagination variant without a template break.
+				return formatResultsCountText( template, {
+					first: last > 0 ? 1 : 0,
+					last,
+					total,
+					query: state.searchQuery ?? '',
+				} );
+			}
+			const fallback =
 				total === 1
 					? state.strings?.resultsCountSingle ?? 'Found %d result'
 					: state.strings?.resultsCountPlural ?? 'Found %d results';
-			return template.replace( '%d', total );
+			return fallback.replace( '%d', total );
 		},
 
 		/**

--- a/projects/packages/search/tests/js/search-blocks/results-count-format.test.js
+++ b/projects/packages/search/tests/js/search-blocks/results-count-format.test.js
@@ -1,0 +1,76 @@
+import { formatResultsCountText } from '../../../src/search-blocks/blocks/results-count/format';
+
+describe( 'formatResultsCountText', () => {
+	const VARS = { first: 1, last: 10, total: 42, query: 'boots' };
+
+	it( 'substitutes the default template', () => {
+		expect( formatResultsCountText( 'Showing %1$d–%2$d of %3$d results', VARS ) ).toBe(
+			'Showing 1–10 of 42 results'
+		);
+	} );
+
+	it( 'substitutes the query placeholder', () => {
+		expect( formatResultsCountText( 'Showing %1$d–%2$d of %3$d results for %4$s', VARS ) ).toBe(
+			'Showing 1–10 of 42 results for boots'
+		);
+	} );
+
+	it( 'supports placeholders in any order and repeated', () => {
+		// Exercising order + repeats together guards against a replace-sequential
+		// bug (where replacing %1$d first could feed its output into a later
+		// %3$d match) — each placeholder must resolve from the original string.
+		expect( formatResultsCountText( '%3$d total, %4$s query, %1$d first, %3$d again', VARS ) ).toBe(
+			'42 total, boots query, 1 first, 42 again'
+		);
+	} );
+
+	it( 'leaves unsupported indices untouched', () => {
+		// %5$d is a reasonable author typo; it must surface visibly rather than
+		// being silently stripped so the mistake is debuggable on the page.
+		expect( formatResultsCountText( '%1$d of %5$d (%3$d)', VARS ) ).toBe( '1 of %5$d (42)' );
+		expect( formatResultsCountText( '%10$d items', VARS ) ).toBe( '%10$d items' );
+	} );
+
+	it( 'leaves unsupported specifiers untouched', () => {
+		// %1$s has a known index but the wrong specifier — our map only accepts
+		// exact matches, so the placeholder stays as-is.
+		expect( formatResultsCountText( '%1$s plus %3$d', VARS ) ).toBe( '%1$s plus 42' );
+		expect( formatResultsCountText( '%4$d plus %4$s', VARS ) ).toBe( '%4$d plus boots' );
+	} );
+
+	it( 'does not rescan substituted output for placeholders', () => {
+		// If the query contains something that looks like a placeholder,
+		// that substring must survive as a literal — otherwise a search for
+		// "%3$d" would get rewritten to the total count on substitution.
+		expect(
+			formatResultsCountText( 'Query: %4$s, total: %3$d', {
+				...VARS,
+				query: '%3$d',
+			} )
+		).toBe( 'Query: %3$d, total: 42' );
+	} );
+
+	it( 'coerces non-string input safely', () => {
+		expect( formatResultsCountText( null, VARS ) ).toBe( '' );
+		expect( formatResultsCountText( undefined, VARS ) ).toBe( '' );
+	} );
+
+	it( 'returns templates with no placeholders unchanged', () => {
+		expect( formatResultsCountText( 'Results below:', VARS ) ).toBe( 'Results below:' );
+		expect( formatResultsCountText( '', VARS ) ).toBe( '' );
+	} );
+
+	it( 'coerces numeric vars to strings', () => {
+		// total=0 still needs a string substitution (not a dropped placeholder);
+		// the getter short-circuits at total===0 before calling the formatter,
+		// but the formatter itself must handle the edge case cleanly.
+		expect(
+			formatResultsCountText( 'Showing %1$d–%2$d of %3$d', {
+				first: 0,
+				last: 0,
+				total: 0,
+				query: '',
+			} )
+		).toBe( 'Showing 0–0 of 0' );
+	} );
+} );

--- a/projects/packages/search/tests/php/Results_Count_Render_Test.php
+++ b/projects/packages/search/tests/php/Results_Count_Render_Test.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Results Count block render.php tests.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the results-count block's render template.
+ *
+ * Each test renders the block through `do_blocks()` so WordPress wires up
+ * the block context (`WP_Block_Supports::$block_to_render`) the template
+ * relies on via `get_block_wrapper_attributes()` — exercising the same path
+ * the front end takes, not just an isolated `include`.
+ */
+class Results_Count_Render_Test extends TestCase {
+
+	/**
+	 * Register the results-count block inline (rather than from its block.json
+	 * directory) so `do_blocks()` can resolve it without depending on the
+	 * `build/` artifacts referenced by block.json's `viewScriptModule` and
+	 * `style` entries — those aren't present in a fresh checkout, and our
+	 * PHPUnit config has `failOnNotice` set, so any missing-asset notice
+	 * during metadata resolution would fail the suite. The render callback
+	 * just delegates to render.php, which is the file under test.
+	 */
+	public static function setUpBeforeClass(): void {
+		\register_block_type(
+			'jetpack/results-count',
+			array(
+				'attributes'      => array(
+					'template' => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+				),
+				// $attributes is consumed by the included render.php via the
+				// closure's local scope — phpcs can't see that, hence the disable.
+				// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+				'render_callback' => static function ( $attributes ) {
+					ob_start();
+					include __DIR__ . '/../../src/search-blocks/blocks/results-count/render.php';
+					return (string) ob_get_clean();
+				},
+				// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			)
+		);
+	}
+
+	/**
+	 * Unregister the block so other test classes start from a clean slate.
+	 */
+	public static function tearDownAfterClass(): void {
+		\unregister_block_type( 'jetpack/results-count' );
+	}
+
+	/**
+	 * Clear any seeded Interactivity state between tests so a custom template
+	 * written by one test can't leak into another's default-template
+	 * assertions. `wp_interactivity_state()` merges into a process-global
+	 * store, and the suite exercises that store directly.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		if ( function_exists( 'wp_interactivity' ) ) {
+			// Re-seed the namespace with an empty strings map. Passing an
+			// empty override on the `strings` key is how we zero out a prior
+			// `resultsCountTemplate` value without introducing a new helper
+			// on the core API surface.
+			wp_interactivity_state( 'jetpack-search', array( 'strings' => array( 'resultsCountTemplate' => '' ) ) );
+		}
+	}
+
+	/**
+	 * Render the results-count block with the given attributes via `do_blocks`.
+	 *
+	 * @param array $attributes Block attributes (JSON-encoded into the comment delimiter).
+	 * @return string Rendered markup.
+	 */
+	private function render( array $attributes = array() ): string {
+		$json = empty( $attributes )
+			? ''
+			: wp_json_encode( $attributes, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+		return do_blocks( '<!-- wp:jetpack/results-count ' . $json . ' /-->' );
+	}
+
+	/**
+	 * Read the current `strings.resultsCountTemplate` value from the
+	 * Interactivity state store. Returns '' when no override has been seeded,
+	 * which matches the render.php contract: only a non-empty user-supplied
+	 * template writes to state.
+	 *
+	 * @return string
+	 */
+	private function seeded_template(): string {
+		if ( ! function_exists( 'wp_interactivity_state' ) ) {
+			return '';
+		}
+		$state = wp_interactivity_state( 'jetpack-search' );
+		return (string) ( $state['strings']['resultsCountTemplate'] ?? '' );
+	}
+
+	/**
+	 * An empty `template` must leave the global default in place so existing
+	 * posts (saved before the attribute existed) keep rendering the original
+	 * "Showing …" copy from `Search_Blocks::build_initial_strings()`. render.php
+	 * signals "use the default" by not seeding any override.
+	 */
+	public function test_empty_template_does_not_override_default() {
+		$this->render( array( 'template' => '' ) );
+		$this->assertSame( '', $this->seeded_template() );
+	}
+
+	/**
+	 * A missing `template` (not just empty) must also leave the default in
+	 * place. Block editor saves omit attributes that match their default, so
+	 * old posts arrive here without the key at all.
+	 */
+	public function test_missing_template_does_not_override_default() {
+		$this->render();
+		$this->assertSame( '', $this->seeded_template() );
+	}
+
+	/**
+	 * A whitespace-only template (e.g. user typed spaces and stopped) must
+	 * fall back to the default — matches the "Leave empty to use the default"
+	 * promise in the editor inspector and keeps the block from pushing a
+	 * blank string into shared state where it would blank out the getter's
+	 * template branch for every other render on the page.
+	 */
+	public function test_whitespace_only_template_does_not_override_default() {
+		$this->render( array( 'template' => '   ' ) );
+		$this->assertSame( '', $this->seeded_template() );
+	}
+
+	/**
+	 * A custom non-empty template is pushed into `state.strings.resultsCountTemplate`
+	 * so the view-bundle getter reads it (instead of the default seeded by
+	 * `Search_Blocks::build_initial_strings()`) when formatting the count.
+	 */
+	public function test_custom_template_overrides_state() {
+		$custom = 'Showing %1$d of %3$d results for %4$s';
+		$this->render( array( 'template' => $custom ) );
+		$this->assertSame( $custom, $this->seeded_template() );
+	}
+
+	/**
+	 * An unsupported placeholder (e.g. %5$d) must survive into state verbatim.
+	 * render.php never formats the template itself — it only forwards the raw
+	 * string, and the JS formatter leaves unknown placeholders in place so
+	 * authors get a visible hint on the front end rather than a silent swallow.
+	 */
+	public function test_unsupported_placeholder_survives_state() {
+		$custom = 'Page %1$d–%2$d, extra=%5$d, total=%3$d';
+		$this->render( array( 'template' => $custom ) );
+		$this->assertSame( $custom, $this->seeded_template() );
+	}
+
+	/**
+	 * The template is user-controlled. `wp_interactivity_state()` serialises
+	 * its payload into a single JSON blob in the output HTML, so any HTML in
+	 * the template must ride through as escaped JSON text rather than as a
+	 * live `<script>` element in the rendered page.
+	 */
+	public function test_template_with_html_is_not_rendered_as_markup() {
+		$markup = $this->render( array( 'template' => '<script>alert(1)</script>' ) );
+		$this->assertStringNotContainsString( '<script>alert(1)</script>', $markup );
+	}
+
+	/**
+	 * The rendered element must carry the Interactivity wiring the store
+	 * getter relies on: the namespace and the text binding. The searching
+	 * label now flows through `state.strings.searching` (seeded by
+	 * `build_initial_strings()`) instead of `data-wp-context`, so render.php
+	 * no longer emits a context attribute at all — we assert both facts so a
+	 * regression that reintroduces per-instance context would fail loudly.
+	 */
+	public function test_renders_interactivity_wiring_without_context() {
+		$markup = $this->render();
+		$this->assertStringContainsString( 'data-wp-interactive="jetpack-search"', $markup );
+		$this->assertStringContainsString( 'data-wp-text="state.resultsCountText"', $markup );
+		$this->assertStringNotContainsString( 'data-wp-context', $markup );
+	}
+}


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add a `template` attribute to `jetpack/results-count` (default: translated `Showing %1$d–%2$d of %3$d results`).
* Expose an editor inspector text input for the template, with help text listing the supported placeholders and a "leave empty to use the default" fallback.
* Supported placeholders: `%1$d` (first shown), `%2$d` (last shown), `%3$d` (total), `%4$s` (query). Unsupported placeholders (`%5$d`, `%1$s`, `%10$d`, …) are left as-is so author typos surface visibly.
* `render.php` seeds both the template and the translated `Searching…` label into `data-wp-context`; `blocks/results-count/view.js` registers a context-aware `state.resultsCountText` getter that composes the template with live store state (`isLoading`, `totalResults`, `results.length`, `searchQuery`). The previous hard-coded strings are removed from `store/index.js` since results-count is the sole consumer.
* Pure formatter in `blocks/results-count/format.js` is shared between the front-end view bundle and the editor preview so both paths format identically.

## Related product discussion/links
* Linear: https://linear.app/a8c/issue/SEARCH-142/results-count-template-string-control

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
1. On a WordPress dev site with Jetpack Search blocks enabled, insert the "Blog Search Page" pattern into a page.
2. Select the Results Count block; confirm the Inspector sidebar shows a **Settings → Results count template** text field with help text listing the four placeholders.
3. **Default fallback:** leave the field empty, save, and visit the page. Run a search that returns results — the block should read `Showing 1–N of TOTAL results` (translated for non-English locales).
4. **Custom template:** set the template to `Showing %1$d of %3$d for "%4$s"`, save, search for e.g. `boots`, and verify the front end reads `Showing 1 of 12 for "boots"` (numbers will vary by site data).
5. **Dynamic updates:** with the custom template applied, keep load-more in the same row and click it — `%2$d` (or `%1$d` etc.) should tick up as more results render, confirming the formatter is driven by live store state rather than a static SSR value.
6. **Query placeholder:** set the template to `Results for %4$s (%3$d total)` and confirm the query text appears verbatim, including when you change the search term — it should update without a page reload.
7. **Unsupported placeholder fallback:** set the template to `Showing %1$d–%5$d of %3$d items` and verify the rendered front-end string keeps `%5$d` literal (e.g. `Showing 1–%5$d of 12 items`) — it must not disappear or crash the block. Same check for `%1$s` (wrong specifier) and `%10$d` (unsupported index).
8. **Whitespace-only template:** type three spaces into the inspector, save, and verify the front end falls back to the default translated template — the block must not render as visually blank.
9. **Loading state:** trigger a slow search (e.g. in devtools throttle network) and verify the block shows the translated `Searching…` copy while the request is in flight, then swaps to the formatted template once results arrive.
10. **Zero-results:** search for a term with no matches; confirm results-count renders empty (so the no-results block owns that copy) while the row layout stays intact.
11. **XSS safety:** set the template to `<script>alert(1)</script>` via the inspector, save, view the front end — it must not execute; the literal text should appear escaped.
12. Run `cd projects/packages/search && composer phpunit` and `pnpm jest tests/js/search-blocks` — both suites pass.