### PR TITLE
Monitor abilities: register jetpack-monitor category via Registrar

### DIFF
--- a/projects/plugins/jetpack/changelog/add-monitor-abilities
+++ b/projects/plugins/jetpack/changelog/add-monitor-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Abilities API: register jetpack-monitor/get-monitor-status and jetpack-monitor/set-notifications for WP 6.9+.

--- a/projects/plugins/jetpack/changelog/monitor-abilities-core-site-category
+++ b/projects/plugins/jetpack/changelog/monitor-abilities-core-site-category
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Monitor abilities: register under the WordPress core site ability category instead of a plugin-scoped jetpack-monitor category

--- a/projects/plugins/jetpack/changelog/monitor-abilities-error-signals
+++ b/projects/plugins/jetpack/changelog/monitor-abilities-error-signals
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Monitor abilities: return WP_Error with steering message when not connected or service unreachable

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -763,9 +763,6 @@ class Jetpack {
 		// Jetpack plugin for now: the Connection package no longer auto-wires these, so
 		// connection-only consumers (Boost, Protect, Search, etc.) do not register them yet.
 		\Automattic\Jetpack\Connection\Abilities\Connection_Abilities::init();
-
-		// Register Jetpack Monitor abilities (WordPress Abilities API, WP 6.9+).
-		\Automattic\Jetpack\Plugin\Abilities\Monitor_Abilities::init();
 	}
 
 	/**

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -763,6 +763,9 @@ class Jetpack {
 		// Jetpack plugin for now: the Connection package no longer auto-wires these, so
 		// connection-only consumers (Boost, Protect, Search, etc.) do not register them yet.
 		\Automattic\Jetpack\Connection\Abilities\Connection_Abilities::init();
+
+		// Register Jetpack Monitor abilities (WordPress Abilities API, WP 6.9+).
+		\Automattic\Jetpack\Plugin\Abilities\Monitor_Abilities::init();
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/monitor.php
+++ b/projects/plugins/jetpack/modules/monitor.php
@@ -138,3 +138,6 @@ class Jetpack_Monitor {
 }
 
 new Jetpack_Monitor();
+
+// Register Jetpack Monitor abilities (WordPress Abilities API, WP 6.9+).
+\Automattic\Jetpack\Plugin\Abilities\Monitor_Abilities::init();

--- a/projects/plugins/jetpack/src/abilities/class-monitor-abilities.php
+++ b/projects/plugins/jetpack/src/abilities/class-monitor-abilities.php
@@ -75,6 +75,10 @@ class Monitor_Abilities extends Registrar {
 						'idempotent'  => true,
 					),
 					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => true,
+						'type'   => 'tool',
+					),
 				),
 			),
 
@@ -108,6 +112,10 @@ class Monitor_Abilities extends Registrar {
 						'idempotent'  => true,
 					),
 					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => true,
+						'type'   => 'tool',
+					),
 				),
 			),
 		);
@@ -201,7 +209,10 @@ class Monitor_Abilities extends Registrar {
 
 	/**
 	 * Execute: declarative state-setter. Idempotent — compares desired vs current
-	 * and returns changed=false when they match.
+	 * and returns changed=false when they match. Either way the local
+	 * `monitor_receive_notifications` option is synced to the remote value (after
+	 * the write on a change, and on the no-op path) so the legacy REST reader,
+	 * which trusts that option first, never reports a stale state.
 	 *
 	 * @param array|null $input Input matching the ability's input_schema.
 	 * @return array|\WP_Error
@@ -243,6 +254,15 @@ class Monitor_Abilities extends Registrar {
 		}
 
 		if ( $desired === $current ) {
+			// Sync the local `monitor_receive_notifications` option to the
+			// known-good remote value even on a no-op. The legacy
+			// `Jetpack_Core_Json_Api_Endpoints::get_remote_value` reader trusts
+			// this option before falling back to a remote read, so a stale local
+			// value would let it report the wrong state. The changed=true path
+			// below mirrors the option after a write; mirroring here keeps the
+			// unchanged path self-healing too.
+			update_option( 'monitor_receive_notifications', $current );
+
 			return array(
 				'enabled' => $current,
 				'changed' => false,

--- a/projects/plugins/jetpack/src/abilities/class-monitor-abilities.php
+++ b/projects/plugins/jetpack/src/abilities/class-monitor-abilities.php
@@ -139,7 +139,7 @@ class Monitor_Abilities extends Registrar {
 	 * @param array|null $input Ability input (no parameters accepted).
 	 * @return array
 	 */
-	public static function get_monitor_status( $input = null ) {
+	public static function get_monitor_status( $input = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Abilities API contract requires execute callbacks to accept the input array even when the schema declares no parameters.
 		$module_active  = Jetpack::is_module_active( self::MODULE_SLUG );
 		$user_connected = ( new Connection_Manager( 'jetpack' ) )->is_user_connected();
 

--- a/projects/plugins/jetpack/src/abilities/class-monitor-abilities.php
+++ b/projects/plugins/jetpack/src/abilities/class-monitor-abilities.php
@@ -29,21 +29,35 @@ class Monitor_Abilities extends Registrar {
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * Monitor abilities live under the WordPress core `site` category — it is
+	 * registered by the Abilities API itself, so we reference it by slug and
+	 * never register it ourselves (see the no-op `register_category()` below).
 	 */
 	public static function get_category_slug(): string {
-		return 'jetpack-monitor';
+		return 'site';
 	}
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * Unused: the `site` category is owned by WordPress core, so
+	 * `register_category()` is a no-op and this definition is never passed to
+	 * `wp_register_ability_category()`. It remains only to satisfy the abstract
+	 * Registrar contract.
 	 */
 	public static function get_category_definition(): array {
-		return array(
-			// translators: "Jetpack" is a product name and should not be translated.
-			'label'       => __( 'Jetpack Monitor', 'jetpack' ),
-			'description' => __( 'Abilities for inspecting and configuring Jetpack Downtime Monitor.', 'jetpack' ),
-		);
+		return array();
 	}
+
+	/**
+	 * No-op: the `site` ability category is registered by the WordPress core
+	 * Abilities API. Re-registering it here would clobber the core definition,
+	 * so this registrar only references the category by slug.
+	 *
+	 * @return void
+	 */
+	public static function register_category() {}
 
 	/**
 	 * {@inheritDoc}

--- a/projects/plugins/jetpack/src/abilities/class-monitor-abilities.php
+++ b/projects/plugins/jetpack/src/abilities/class-monitor-abilities.php
@@ -39,8 +39,8 @@ class Monitor_Abilities extends Registrar {
 	 */
 	public static function get_category_definition(): array {
 		return array(
-			// "Jetpack" is a product name and should not be translated.
-			'label'       => 'Jetpack Monitor',
+			// translators: "Jetpack" is a product name and should not be translated.
+			'label'       => __( 'Jetpack Monitor', 'jetpack' ),
 			'description' => __( 'Abilities for inspecting and configuring Jetpack Downtime Monitor.', 'jetpack' ),
 		);
 	}
@@ -256,7 +256,7 @@ class Monitor_Abilities extends Registrar {
 
 	/**
 	 * Fetch the last downtime timestamp from the remote Monitor service,
-	 * using the same 10-minute transient cache that the legacy module uses.
+	 * reusing the same transient key and 10-minute TTL written by the legacy module.
 	 *
 	 * @return string|null|\WP_Error YYYY-MM-DD HH:mm:ss string, null when no
 	 *                               downtime has been recorded, or WP_Error on

--- a/projects/plugins/jetpack/src/abilities/class-monitor-abilities.php
+++ b/projects/plugins/jetpack/src/abilities/class-monitor-abilities.php
@@ -52,7 +52,7 @@ class Monitor_Abilities extends Registrar {
 		return array(
 			'jetpack-monitor/get-monitor-status' => array(
 				'label'               => __( 'Get Jetpack Monitor status', 'jetpack' ),
-				'description'         => __( 'Return the current Downtime Monitor state as { module_active, user_connected, notifications_enabled, last_status_change }. notifications_enabled is a boolean (does the current user receive downtime alerts). last_status_change is the timestamp of the most recent up/down status transition recorded by the Monitor service, as a "YYYY-MM-DD HH:mm:ss" UTC string, or null when no transition has been recorded — this reflects the legacy last_status_change projection, not necessarily the last time downtime began. Both notifications_enabled and last_status_change are null when the user is not connected to Jetpack or the remote service is unreachable. These abilities are only registered while the Monitor module is active; if they are absent from wp_get_abilities(), activate the Monitor module first.', 'jetpack' ),
+				'description'         => __( 'Return the current Downtime Monitor state as { module_active, user_connected, notifications_enabled, last_status_change }. notifications_enabled is a boolean (does the current user receive downtime alerts). last_status_change is the timestamp of the most recent up/down status transition recorded by the Monitor service, as a "YYYY-MM-DD HH:mm:ss" UTC string, or null when no transition has been recorded — this reflects the legacy last_status_change projection, not necessarily the last time downtime began. Fails with jetpack_monitor_not_connected when the current user is not connected to Jetpack (connect first via the My Jetpack admin page), or jetpack_monitor_service_unreachable when the remote Monitor service cannot be reached. These abilities are only registered while the Monitor module is active; if they are absent from wp_get_abilities(), activate the Monitor module first.', 'jetpack' ),
 				'input_schema'        => array(
 					'type'                 => 'object',
 					'additionalProperties' => false,
@@ -62,7 +62,7 @@ class Monitor_Abilities extends Registrar {
 					'properties' => array(
 						'module_active'         => array( 'type' => 'boolean' ),
 						'user_connected'        => array( 'type' => 'boolean' ),
-						'notifications_enabled' => array( 'type' => array( 'boolean', 'null' ) ),
+						'notifications_enabled' => array( 'type' => 'boolean' ),
 						'last_status_change'    => array( 'type' => array( 'string', 'null' ) ),
 					),
 				),
@@ -132,39 +132,70 @@ class Monitor_Abilities extends Registrar {
 	}
 
 	/**
-	 * Execute: overview read. Always returns the same shape; fields that depend
-	 * on the remote service degrade to null when the user is not connected to
-	 * Jetpack or the service is unreachable. `module_active` is always true here
-	 * — these abilities are only registered while the Monitor module is active —
-	 * but the field is kept in the output for explicit, self-describing responses.
+	 * Execute: overview read. Returns the full
+	 * `{ module_active, user_connected, notifications_enabled, last_status_change }`
+	 * shape on the happy path. Surfaces precondition and transport failures as
+	 * `WP_Error` so callers (especially AI agents) get an actionable next step
+	 * instead of opaque null fields:
+	 *
+	 * - `jetpack_monitor_module_inactive` — Monitor module is not active.
+	 *   Defensive: in practice this is unreachable because the abilities are
+	 *   only registered while the module is active.
+	 * - `jetpack_monitor_not_connected` — the current user is not connected to
+	 *   Jetpack; the remote read needs the user's token. Steers the caller to
+	 *   the My Jetpack admin page to connect.
+	 * - `jetpack_monitor_service_unreachable` — the remote Monitor service
+	 *   returned an error for one of the two underlying XML-RPC reads
+	 *   (`isUserInNotifications` or `getLastDowntime`). Transient — retry later.
+	 *
+	 * `last_status_change` remains `null` on the happy path when no up/down
+	 * transition has been recorded yet; that is the documented "no data yet"
+	 * signal, not a failure.
 	 *
 	 * @param array|null $input Ability input (no parameters accepted).
-	 * @return array
+	 * @return array|\WP_Error
 	 */
 	public static function get_monitor_status( $input = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Abilities API contract requires execute callbacks to accept the input array even when the schema declares no parameters.
 		$module_active  = Jetpack::is_module_active( self::MODULE_SLUG );
 		$user_connected = static::is_user_connected_to_jetpack();
 
-		$notifications_enabled = null;
-		$last_status_change    = null;
+		if ( ! $module_active ) {
+			return new \WP_Error(
+				'jetpack_monitor_module_inactive',
+				__( 'The Monitor module is not active. Activate it before reading Monitor status.', 'jetpack' )
+			);
+		}
 
-		if ( $module_active && $user_connected ) {
-			$state = static::fetch_notifications_state();
-			if ( ! is_wp_error( $state ) ) {
-				$notifications_enabled = $state;
-			}
+		if ( ! $user_connected ) {
+			return new \WP_Error(
+				'jetpack_monitor_not_connected',
+				__( 'User is not connected to Jetpack. Connect first via the My Jetpack admin page, then retry this ability.', 'jetpack' )
+			);
+		}
 
-			$status_change = static::fetch_last_status_change();
-			if ( ! is_wp_error( $status_change ) ) {
-				$last_status_change = $status_change;
-			}
+		$state = static::fetch_notifications_state();
+		if ( is_wp_error( $state ) ) {
+			return new \WP_Error(
+				'jetpack_monitor_service_unreachable',
+				__( 'The remote Jetpack Monitor service is unreachable. Retry shortly; this is typically transient.', 'jetpack' ),
+				array( 'underlying' => $state->get_error_code() )
+			);
+		}
+
+		$status_change = static::fetch_last_status_change();
+		if ( is_wp_error( $status_change ) ) {
+			return new \WP_Error(
+				'jetpack_monitor_service_unreachable',
+				__( 'The remote Jetpack Monitor service is unreachable. Retry shortly; this is typically transient.', 'jetpack' ),
+				array( 'underlying' => $status_change->get_error_code() )
+			);
 		}
 
 		return array(
 			'module_active'         => $module_active,
 			'user_connected'        => $user_connected,
-			'notifications_enabled' => $notifications_enabled,
-			'last_status_change'    => $last_status_change,
+			'notifications_enabled' => (bool) $state,
+			'last_status_change'    => $status_change,
 		);
 	}
 

--- a/projects/plugins/jetpack/src/abilities/class-monitor-abilities.php
+++ b/projects/plugins/jetpack/src/abilities/class-monitor-abilities.php
@@ -330,7 +330,7 @@ class Monitor_Abilities extends Registrar {
 	protected static function fetch_last_status_change() {
 		$cached = get_transient( 'monitor_last_downtime' );
 		if ( false !== $cached ) {
-			return is_string( $cached ) && '' !== $cached ? $cached : null;
+			return self::normalize_last_status_change( $cached );
 		}
 
 		$xml = new Jetpack_IXR_Client();
@@ -344,6 +344,37 @@ class Monitor_Abilities extends Registrar {
 
 		$response = $xml->getResponse();
 		set_transient( 'monitor_last_downtime', $response, 10 * MINUTE_IN_SECONDS );
-		return is_string( $response ) && '' !== $response ? $response : null;
+		return self::normalize_last_status_change( $response );
+	}
+
+	/**
+	 * Normalize a `last_status_change` value into the documented contract:
+	 * a `YYYY-MM-DD HH:mm:ss` UTC string, or `null` for "no transition yet".
+	 *
+	 * Jetpack Monitor v1 returns an empty string when no transition has been
+	 * recorded; Monitor v2 may instead surface a MySQL zero-date
+	 * (`0000-00-00 00:00:00`) or some other sentinel. Collapse every "no value"
+	 * representation to `null` so the ability's `null` contract stays stable
+	 * regardless of which backend is active.
+	 *
+	 * @param mixed $value Raw remote/cached value.
+	 * @return string|null Pass-through timestamp string, or null when absent.
+	 */
+	protected static function normalize_last_status_change( $value ) {
+		if ( ! is_string( $value ) ) {
+			return null;
+		}
+
+		$value = trim( $value );
+		if ( '' === $value || 0 === strncmp( $value, '0000-00-00', 10 ) ) {
+			return null;
+		}
+
+		$ts = strtotime( $value );
+		if ( false === $ts || $ts <= 0 ) {
+			return null;
+		}
+
+		return $value;
 	}
 }

--- a/projects/plugins/jetpack/src/abilities/class-monitor-abilities.php
+++ b/projects/plugins/jetpack/src/abilities/class-monitor-abilities.php
@@ -52,7 +52,7 @@ class Monitor_Abilities extends Registrar {
 		return array(
 			'jetpack-monitor/get-monitor-status' => array(
 				'label'               => __( 'Get Jetpack Monitor status', 'jetpack' ),
-				'description'         => __( 'Return the current Downtime Monitor state as { module_active, user_connected, notifications_enabled, last_downtime }. notifications_enabled is a boolean (does the current user receive downtime alerts) and last_downtime is a "YYYY-MM-DD HH:mm:ss" UTC string or null when no downtime has been recorded. Both are null when module_active or user_connected is false, or when the remote service is unreachable — inspect module_active and user_connected to decide the next step. Use this to verify preconditions before calling jetpack-monitor/set-notifications.', 'jetpack' ),
+				'description'         => __( 'Return the current Downtime Monitor state as { module_active, user_connected, notifications_enabled, last_status_change }. notifications_enabled is a boolean (does the current user receive downtime alerts). last_status_change is the timestamp of the most recent up/down status transition recorded by the Monitor service, as a "YYYY-MM-DD HH:mm:ss" UTC string, or null when no transition has been recorded — this reflects the legacy last_status_change projection, not necessarily the last time downtime began. Both notifications_enabled and last_status_change are null when the user is not connected to Jetpack or the remote service is unreachable. These abilities are only registered while the Monitor module is active; if they are absent from wp_get_abilities(), activate the Monitor module first.', 'jetpack' ),
 				'input_schema'        => array(
 					'type'                 => 'object',
 					'additionalProperties' => false,
@@ -63,7 +63,7 @@ class Monitor_Abilities extends Registrar {
 						'module_active'         => array( 'type' => 'boolean' ),
 						'user_connected'        => array( 'type' => 'boolean' ),
 						'notifications_enabled' => array( 'type' => array( 'boolean', 'null' ) ),
-						'last_downtime'         => array( 'type' => array( 'string', 'null' ) ),
+						'last_status_change'    => array( 'type' => array( 'string', 'null' ) ),
 					),
 				),
 				'execute_callback'    => array( __CLASS__, 'get_monitor_status' ),
@@ -80,7 +80,7 @@ class Monitor_Abilities extends Registrar {
 
 			'jetpack-monitor/set-notifications'  => array(
 				'label'               => __( 'Set Jetpack Monitor notifications', 'jetpack' ),
-				'description'         => __( 'Enable or disable downtime email notifications for the current user. Idempotent — setting the state to the current value returns changed=false. Returns { enabled, changed }. Preconditions: the Monitor module must be active and the current user must be connected to Jetpack; call jetpack-monitor/get-monitor-status first to verify. Fails with jetpack_monitor_module_inactive (call jetpack-modules/set-module-status with slug "monitor" and active true) or jetpack_monitor_not_connected when preconditions are not met.', 'jetpack' ),
+				'description'         => __( 'Enable or disable downtime email notifications for the current user. Idempotent — setting the state to the current value returns changed=false. Returns { enabled, changed }. Preconditions: the Monitor module must be active and the current user must be connected to Jetpack; call jetpack-monitor/get-monitor-status first to verify the connection. Fails with jetpack_monitor_module_inactive (activate the Monitor module first — these abilities are only registered while the module is active, so this error indicates a race) or jetpack_monitor_not_connected when preconditions are not met.', 'jetpack' ),
 				'input_schema'        => array(
 					'type'                 => 'object',
 					'required'             => array( 'enabled' ),
@@ -133,28 +133,30 @@ class Monitor_Abilities extends Registrar {
 
 	/**
 	 * Execute: overview read. Always returns the same shape; fields that depend
-	 * on the remote service degrade to null when preconditions aren't met or the
-	 * service is unreachable.
+	 * on the remote service degrade to null when the user is not connected to
+	 * Jetpack or the service is unreachable. `module_active` is always true here
+	 * — these abilities are only registered while the Monitor module is active —
+	 * but the field is kept in the output for explicit, self-describing responses.
 	 *
 	 * @param array|null $input Ability input (no parameters accepted).
 	 * @return array
 	 */
 	public static function get_monitor_status( $input = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Abilities API contract requires execute callbacks to accept the input array even when the schema declares no parameters.
 		$module_active  = Jetpack::is_module_active( self::MODULE_SLUG );
-		$user_connected = ( new Connection_Manager( 'jetpack' ) )->is_user_connected();
+		$user_connected = static::is_user_connected_to_jetpack();
 
 		$notifications_enabled = null;
-		$last_downtime         = null;
+		$last_status_change    = null;
 
 		if ( $module_active && $user_connected ) {
-			$state = self::fetch_notifications_state();
+			$state = static::fetch_notifications_state();
 			if ( ! is_wp_error( $state ) ) {
 				$notifications_enabled = $state;
 			}
 
-			$downtime = self::fetch_last_downtime();
-			if ( ! is_wp_error( $downtime ) ) {
-				$last_downtime = $downtime;
+			$status_change = static::fetch_last_status_change();
+			if ( ! is_wp_error( $status_change ) ) {
+				$last_status_change = $status_change;
 			}
 		}
 
@@ -162,7 +164,7 @@ class Monitor_Abilities extends Registrar {
 			'module_active'         => $module_active,
 			'user_connected'        => $user_connected,
 			'notifications_enabled' => $notifications_enabled,
-			'last_downtime'         => $last_downtime,
+			'last_status_change'    => $last_status_change,
 		);
 	}
 
@@ -192,11 +194,11 @@ class Monitor_Abilities extends Registrar {
 		if ( ! Jetpack::is_module_active( self::MODULE_SLUG ) ) {
 			return new \WP_Error(
 				'jetpack_monitor_module_inactive',
-				__( 'The Monitor module is not active. Call jetpack-modules/set-module-status with slug "monitor" and active true before configuring notifications.', 'jetpack' )
+				__( 'The Monitor module is not active. Activate it before configuring notifications.', 'jetpack' )
 			);
 		}
 
-		if ( ! ( new Connection_Manager( 'jetpack' ) )->is_user_connected() ) {
+		if ( ! static::is_user_connected_to_jetpack() ) {
 			return new \WP_Error(
 				'jetpack_monitor_not_connected',
 				__( 'The current user is not connected to Jetpack. Connect the user to Jetpack before configuring Monitor notifications.', 'jetpack' )
@@ -204,7 +206,7 @@ class Monitor_Abilities extends Registrar {
 		}
 
 		$desired = $input['enabled'];
-		$current = self::fetch_notifications_state();
+		$current = static::fetch_notifications_state();
 		if ( is_wp_error( $current ) ) {
 			return $current;
 		}
@@ -216,13 +218,9 @@ class Monitor_Abilities extends Registrar {
 			);
 		}
 
-		$xml = new Jetpack_IXR_Client( array( 'user_id' => get_current_user_id() ) );
-		$xml->query( 'jetpack.monitor.setNotifications', $desired );
-		if ( $xml->isError() ) {
-			return new \WP_Error(
-				'jetpack_monitor_notifications_update_failed',
-				sprintf( '%s: %s', $xml->getErrorCode(), $xml->getErrorMessage() )
-			);
+		$applied = static::apply_notifications_update( $desired );
+		if ( is_wp_error( $applied ) ) {
+			return $applied;
 		}
 
 		// Mirror the write to the `monitor_receive_notifications` option so the
@@ -237,12 +235,41 @@ class Monitor_Abilities extends Registrar {
 	}
 
 	/**
+	 * Whether the current user is connected to Jetpack.
+	 *
+	 * Extracted as a protected seam so tests can override the connection check
+	 * without standing up a full Jetpack token fixture.
+	 */
+	protected static function is_user_connected_to_jetpack(): bool {
+		return ( new Connection_Manager( 'jetpack' ) )->is_user_connected();
+	}
+
+	/**
+	 * Send the IXR `jetpack.monitor.setNotifications` request to apply the
+	 * desired state on the remote Monitor service.
+	 *
+	 * @param bool $enabled Desired notification state.
+	 * @return true|\WP_Error True on success, WP_Error on remote failure.
+	 */
+	protected static function apply_notifications_update( bool $enabled ) {
+		$xml = new Jetpack_IXR_Client( array( 'user_id' => get_current_user_id() ) );
+		$xml->query( 'jetpack.monitor.setNotifications', $enabled );
+		if ( $xml->isError() ) {
+			return new \WP_Error(
+				'jetpack_monitor_notifications_update_failed',
+				sprintf( '%s: %s', $xml->getErrorCode(), $xml->getErrorMessage() )
+			);
+		}
+		return true;
+	}
+
+	/**
 	 * Fetch the current notifications state from the remote Monitor service.
 	 *
 	 * @return bool|\WP_Error Boolean preference when the remote call succeeds,
 	 *                        WP_Error when the remote call fails.
 	 */
-	private static function fetch_notifications_state() {
+	protected static function fetch_notifications_state() {
 		$xml = new Jetpack_IXR_Client( array( 'user_id' => get_current_user_id() ) );
 		$xml->query( 'jetpack.monitor.isUserInNotifications' );
 		if ( $xml->isError() ) {
@@ -255,14 +282,21 @@ class Monitor_Abilities extends Registrar {
 	}
 
 	/**
-	 * Fetch the last downtime timestamp from the remote Monitor service,
-	 * reusing the same transient key and 10-minute TTL written by the legacy module.
+	 * Fetch the last up/down status-change timestamp from the remote Monitor
+	 * service, reusing the same transient key and 10-minute TTL written by the
+	 * legacy module.
+	 *
+	 * The remote `jetpack.monitor.getLastDowntime` XML-RPC method returns the
+	 * legacy `last_status_change` projection — the time of the most recent
+	 * up/down transition, not strictly when downtime began. The transient key
+	 * stays `monitor_last_downtime` because that is what the legacy module
+	 * writes and we share its cache.
 	 *
 	 * @return string|null|\WP_Error YYYY-MM-DD HH:mm:ss string, null when no
-	 *                               downtime has been recorded, or WP_Error on
-	 *                               a remote failure.
+	 *                               transition has been recorded, or WP_Error
+	 *                               on a remote failure.
 	 */
-	private static function fetch_last_downtime() {
+	protected static function fetch_last_status_change() {
 		$cached = get_transient( 'monitor_last_downtime' );
 		if ( false !== $cached ) {
 			return is_string( $cached ) && '' !== $cached ? $cached : null;

--- a/projects/plugins/jetpack/src/abilities/class-monitor-abilities.php
+++ b/projects/plugins/jetpack/src/abilities/class-monitor-abilities.php
@@ -1,0 +1,284 @@
+<?php
+/**
+ * Jetpack Monitor Abilities Registration
+ *
+ * Registers Jetpack Downtime Monitor abilities with the WordPress Abilities API.
+ *
+ * @package automattic/jetpack
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9; suppressions needed for older-WP compatibility runs.
+
+namespace Automattic\Jetpack\Plugin\Abilities;
+
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use Jetpack;
+use Jetpack_IXR_Client;
+
+/**
+ * Registers Jetpack Downtime Monitor abilities with the WordPress Abilities API.
+ *
+ * Exposes a zero-arg overview read (`get-monitor-status`) and a declarative
+ * state-setter (`set-notifications`) so AI agents can inspect and configure the
+ * site's Downtime Monitor through the standard `wp-abilities/v1` REST surface.
+ */
+class Monitor_Abilities extends Registrar {
+
+	private const MODULE_SLUG = 'monitor';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_slug(): string {
+		return 'jetpack-monitor';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_definition(): array {
+		return array(
+			// "Jetpack" is a product name and should not be translated.
+			'label'       => 'Jetpack Monitor',
+			'description' => __( 'Abilities for inspecting and configuring Jetpack Downtime Monitor.', 'jetpack' ),
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_abilities(): array {
+		return array(
+			'jetpack-monitor/get-monitor-status' => array(
+				'label'               => __( 'Get Jetpack Monitor status', 'jetpack' ),
+				'description'         => __( 'Return the current Downtime Monitor state as { module_active, user_connected, notifications_enabled, last_downtime }. notifications_enabled is a boolean (does the current user receive downtime alerts) and last_downtime is a "YYYY-MM-DD HH:mm:ss" UTC string or null when no downtime has been recorded. Both are null when module_active or user_connected is false, or when the remote service is unreachable — inspect module_active and user_connected to decide the next step. Use this to verify preconditions before calling jetpack-monitor/set-notifications.', 'jetpack' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'module_active'         => array( 'type' => 'boolean' ),
+						'user_connected'        => array( 'type' => 'boolean' ),
+						'notifications_enabled' => array( 'type' => array( 'boolean', 'null' ) ),
+						'last_downtime'         => array( 'type' => array( 'string', 'null' ) ),
+					),
+				),
+				'execute_callback'    => array( __CLASS__, 'get_monitor_status' ),
+				'permission_callback' => array( __CLASS__, 'can_view_monitor' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+
+			'jetpack-monitor/set-notifications'  => array(
+				'label'               => __( 'Set Jetpack Monitor notifications', 'jetpack' ),
+				'description'         => __( 'Enable or disable downtime email notifications for the current user. Idempotent — setting the state to the current value returns changed=false. Returns { enabled, changed }. Preconditions: the Monitor module must be active and the current user must be connected to Jetpack; call jetpack-monitor/get-monitor-status first to verify. Fails with jetpack_monitor_module_inactive (call jetpack-modules/set-module-status with slug "monitor" and active true) or jetpack_monitor_not_connected when preconditions are not met.', 'jetpack' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'required'             => array( 'enabled' ),
+					'properties'           => array(
+						'enabled' => array(
+							'type'        => 'boolean',
+							'description' => __( 'Desired notification state. true enables downtime email notifications for the current user; false disables them.', 'jetpack' ),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'enabled' => array( 'type' => 'boolean' ),
+						'changed' => array( 'type' => 'boolean' ),
+					),
+				),
+				'execute_callback'    => array( __CLASS__, 'set_notifications' ),
+				'permission_callback' => array( __CLASS__, 'can_manage_monitor' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+		);
+	}
+
+	/**
+	 * Permission check: can the current user read Monitor status?
+	 */
+	public static function can_view_monitor(): bool {
+		return current_user_can( 'jetpack_admin_page' );
+	}
+
+	/**
+	 * Permission check: can the current user manage Monitor notifications?
+	 *
+	 * Notifications are a per-user preference that affects the caller's own inbox,
+	 * so `jetpack_admin_page` (the same capability that gates the admin settings UI)
+	 * is the right gate — no stricter cap is warranted.
+	 */
+	public static function can_manage_monitor(): bool {
+		return current_user_can( 'jetpack_admin_page' );
+	}
+
+	/**
+	 * Execute: overview read. Always returns the same shape; fields that depend
+	 * on the remote service degrade to null when preconditions aren't met or the
+	 * service is unreachable.
+	 *
+	 * @param array|null $input Ability input (no parameters accepted).
+	 * @return array
+	 */
+	public static function get_monitor_status( $input = null ) {
+		$module_active  = Jetpack::is_module_active( self::MODULE_SLUG );
+		$user_connected = ( new Connection_Manager( 'jetpack' ) )->is_user_connected();
+
+		$notifications_enabled = null;
+		$last_downtime         = null;
+
+		if ( $module_active && $user_connected ) {
+			$state = self::fetch_notifications_state();
+			if ( ! is_wp_error( $state ) ) {
+				$notifications_enabled = $state;
+			}
+
+			$downtime = self::fetch_last_downtime();
+			if ( ! is_wp_error( $downtime ) ) {
+				$last_downtime = $downtime;
+			}
+		}
+
+		return array(
+			'module_active'         => $module_active,
+			'user_connected'        => $user_connected,
+			'notifications_enabled' => $notifications_enabled,
+			'last_downtime'         => $last_downtime,
+		);
+	}
+
+	/**
+	 * Execute: declarative state-setter. Idempotent — compares desired vs current
+	 * and returns changed=false when they match.
+	 *
+	 * @param array|null $input Input matching the ability's input_schema.
+	 * @return array|\WP_Error
+	 */
+	public static function set_notifications( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		if ( ! array_key_exists( 'enabled', $input ) ) {
+			return new \WP_Error(
+				'jetpack_monitor_missing_enabled',
+				__( 'A desired enabled state (boolean) is required.', 'jetpack' )
+			);
+		}
+		if ( ! is_bool( $input['enabled'] ) ) {
+			return new \WP_Error(
+				'jetpack_monitor_invalid_enabled',
+				__( 'The enabled parameter must be a boolean. Strings like "true" / "false" are not accepted.', 'jetpack' )
+			);
+		}
+
+		if ( ! Jetpack::is_module_active( self::MODULE_SLUG ) ) {
+			return new \WP_Error(
+				'jetpack_monitor_module_inactive',
+				__( 'The Monitor module is not active. Call jetpack-modules/set-module-status with slug "monitor" and active true before configuring notifications.', 'jetpack' )
+			);
+		}
+
+		if ( ! ( new Connection_Manager( 'jetpack' ) )->is_user_connected() ) {
+			return new \WP_Error(
+				'jetpack_monitor_not_connected',
+				__( 'The current user is not connected to Jetpack. Connect the user to Jetpack before configuring Monitor notifications.', 'jetpack' )
+			);
+		}
+
+		$desired = $input['enabled'];
+		$current = self::fetch_notifications_state();
+		if ( is_wp_error( $current ) ) {
+			return $current;
+		}
+
+		if ( $desired === $current ) {
+			return array(
+				'enabled' => $current,
+				'changed' => false,
+			);
+		}
+
+		$xml = new Jetpack_IXR_Client( array( 'user_id' => get_current_user_id() ) );
+		$xml->query( 'jetpack.monitor.setNotifications', $desired );
+		if ( $xml->isError() ) {
+			return new \WP_Error(
+				'jetpack_monitor_notifications_update_failed',
+				sprintf( '%s: %s', $xml->getErrorCode(), $xml->getErrorMessage() )
+			);
+		}
+
+		// Mirror the write to the `monitor_receive_notifications` option so the
+		// legacy `Jetpack_Core_Json_Api_Endpoints::get_remote_value` reader — the
+		// only other reader of this option — stays in sync with the remote state.
+		update_option( 'monitor_receive_notifications', $desired );
+
+		return array(
+			'enabled' => $desired,
+			'changed' => true,
+		);
+	}
+
+	/**
+	 * Fetch the current notifications state from the remote Monitor service.
+	 *
+	 * @return bool|\WP_Error Boolean preference when the remote call succeeds,
+	 *                        WP_Error when the remote call fails.
+	 */
+	private static function fetch_notifications_state() {
+		$xml = new Jetpack_IXR_Client( array( 'user_id' => get_current_user_id() ) );
+		$xml->query( 'jetpack.monitor.isUserInNotifications' );
+		if ( $xml->isError() ) {
+			return new \WP_Error(
+				'jetpack_monitor_notifications_data_unavailable',
+				sprintf( '%s: %s', $xml->getErrorCode(), $xml->getErrorMessage() )
+			);
+		}
+		return (bool) $xml->getResponse();
+	}
+
+	/**
+	 * Fetch the last downtime timestamp from the remote Monitor service,
+	 * using the same 10-minute transient cache that the legacy module uses.
+	 *
+	 * @return string|null|\WP_Error YYYY-MM-DD HH:mm:ss string, null when no
+	 *                               downtime has been recorded, or WP_Error on
+	 *                               a remote failure.
+	 */
+	private static function fetch_last_downtime() {
+		$cached = get_transient( 'monitor_last_downtime' );
+		if ( false !== $cached ) {
+			return is_string( $cached ) && '' !== $cached ? $cached : null;
+		}
+
+		$xml = new Jetpack_IXR_Client();
+		$xml->query( 'jetpack.monitor.getLastDowntime' );
+		if ( $xml->isError() ) {
+			return new \WP_Error(
+				'jetpack_monitor_downtime_data_unavailable',
+				sprintf( '%s: %s', $xml->getErrorCode(), $xml->getErrorMessage() )
+			);
+		}
+
+		$response = $xml->getResponse();
+		set_transient( 'monitor_last_downtime', $response, 10 * MINUTE_IN_SECONDS );
+		return is_string( $response ) && '' !== $response ? $response : null;
+	}
+}

--- a/projects/plugins/jetpack/tests/php/src/Monitor_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Monitor_Abilities_Test.php
@@ -11,6 +11,8 @@ use Automattic\Jetpack\Plugin\Abilities\Monitor_Abilities;
 use Automattic\Jetpack\WP_Abilities\Registrar;
 use PHPUnit\Framework\Attributes\CoversClass;
 
+require_once __DIR__ . '/class-monitor-abilities-test-stub.php';
+
 /**
  * @covers \Automattic\Jetpack\Plugin\Abilities\Monitor_Abilities
  */
@@ -300,7 +302,7 @@ class Monitor_Abilities_Test extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'module_active', $result );
 		$this->assertArrayHasKey( 'user_connected', $result );
 		$this->assertArrayHasKey( 'notifications_enabled', $result );
-		$this->assertArrayHasKey( 'last_downtime', $result );
+		$this->assertArrayHasKey( 'last_status_change', $result );
 		$this->assertIsBool( $result['module_active'] );
 		$this->assertIsBool( $result['user_connected'] );
 	}
@@ -314,7 +316,7 @@ class Monitor_Abilities_Test extends WP_UnitTestCase {
 		$this->assertFalse( $result['module_active'] );
 		$this->assertFalse( $result['user_connected'] );
 		$this->assertNull( $result['notifications_enabled'] );
-		$this->assertNull( $result['last_downtime'] );
+		$this->assertNull( $result['last_status_change'] );
 	}
 
 	public function test_get_monitor_status_reports_module_active_when_filter_flags_it() {
@@ -366,8 +368,10 @@ class Monitor_Abilities_Test extends WP_UnitTestCase {
 	}
 
 	public function test_set_notifications_errors_when_module_inactive() {
-		// Precondition gate: module inactive → error before any IXR call, with a
-		// message that steers the agent to jetpack-modules/set-module-status.
+		// Precondition gate: module inactive → error before any IXR call.
+		// Belt-and-braces — in practice this branch is unreachable in production
+		// because the ability is only registered while the module is active, but
+		// the callback still checks defensively in case of a race or direct call.
 		wp_set_current_user( $this->admin_id );
 		$result = Monitor_Abilities::set_notifications( array( 'enabled' => true ) );
 		$this->assertInstanceOf( \WP_Error::class, $result );
@@ -391,5 +395,95 @@ class Monitor_Abilities_Test extends WP_UnitTestCase {
 		$result = Monitor_Abilities::set_notifications( array( 'enabled' => true ) );
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'jetpack_monitor_not_connected', $result->get_error_code() );
+	}
+
+	// -------------------- Success-path coverage via test double --------------------
+
+	/**
+	 * Success-path tests need a seam: the production callback talks to a real
+	 * remote Monitor service via IXR, and a connected Jetpack user. The
+	 * `Monitor_Abilities_Test_Stub` test double (defined below this class) overrides
+	 * the protected seams so we can drive `set_notifications()` through its
+	 * end-to-end logic without standing up a Jetpack token fixture.
+	 */
+	public function test_set_notifications_returns_changed_true_when_state_flips() {
+		wp_set_current_user( $this->admin_id );
+
+		add_filter(
+			'jetpack_active_modules',
+			static function ( $mods ) {
+				$mods   = is_array( $mods ) ? $mods : array();
+				$mods[] = 'monitor';
+				return array_values( array_unique( $mods ) );
+			}
+		);
+
+		Monitor_Abilities_Test_Stub::reset( false );
+
+		$result = Monitor_Abilities_Test_Stub::set_notifications( array( 'enabled' => true ) );
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['enabled'] );
+		$this->assertTrue( $result['changed'] );
+		$this->assertSame( 1, Monitor_Abilities_Test_Stub::$apply_calls, 'IXR setNotifications should have been called exactly once.' );
+		$this->assertTrue( Monitor_Abilities_Test_Stub::$last_applied, 'apply_notifications_update should have been called with the desired value.' );
+		// `update_option` stores booleans as '1'/'' through the DB roundtrip; assert truthiness
+		// rather than the exact string so this test is robust to env differences.
+		$this->assertTrue( (bool) get_option( 'monitor_receive_notifications' ), 'monitor_receive_notifications option should mirror the new state.' );
+	}
+
+	public function test_set_notifications_returns_changed_false_when_state_matches() {
+		wp_set_current_user( $this->admin_id );
+
+		add_filter(
+			'jetpack_active_modules',
+			static function ( $mods ) {
+				$mods   = is_array( $mods ) ? $mods : array();
+				$mods[] = 'monitor';
+				return array_values( array_unique( $mods ) );
+			}
+		);
+
+		Monitor_Abilities_Test_Stub::reset( true );
+
+		$result = Monitor_Abilities_Test_Stub::set_notifications( array( 'enabled' => true ) );
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['enabled'] );
+		$this->assertFalse( $result['changed'] );
+		$this->assertSame( 0, Monitor_Abilities_Test_Stub::$apply_calls, 'Idempotent no-op: apply_notifications_update should not run when desired matches current.' );
+		$sentinel = '__monitor_abilities_option_unset__';
+		$this->assertSame( $sentinel, get_option( 'monitor_receive_notifications', $sentinel ), 'No-op: the mirrored option should not be written.' );
+	}
+
+	// -------------------- Real bootstrap path --------------------
+
+	/**
+	 * When the Monitor module is inactive, modules/monitor.php is never loaded
+	 * by Jetpack, so the Monitor_Abilities::init() call inside it never runs and
+	 * the abilities are not registered. This codifies the gated-registration
+	 * contract — discovery of Monitor in the inactive state belongs to a future
+	 * module-management ability category, not here.
+	 */
+	public function test_abilities_are_not_registered_when_monitor_module_is_inactive() {
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
+			$this->markTestSkipped( 'Abilities API not available in this WP version.' );
+		}
+
+		// Do NOT fire the lifecycle or call init() — this mirrors the real
+		// bootstrap path when monitor.php has not been included by Jetpack.
+		$registered_slugs = array();
+		foreach ( wp_get_abilities() as $ability ) {
+			$name = $ability->get_name();
+			if ( str_starts_with( $name, 'jetpack-monitor/' ) ) {
+				$registered_slugs[] = $name;
+			}
+		}
+
+		$this->assertSame(
+			array(),
+			$registered_slugs,
+			'Monitor abilities must not be registered while the Monitor module is inactive (modules/monitor.php not loaded).'
+		);
 	}
 }

--- a/projects/plugins/jetpack/tests/php/src/Monitor_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Monitor_Abilities_Test.php
@@ -10,6 +10,7 @@
 use Automattic\Jetpack\Plugin\Abilities\Monitor_Abilities;
 use Automattic\Jetpack\WP_Abilities\Registrar;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 require_once __DIR__ . '/class-monitor-abilities-test-stub.php';
 
@@ -585,6 +586,47 @@ class Monitor_Abilities_Test extends WP_UnitTestCase {
 			array(),
 			$registered_slugs,
 			'Monitor abilities must not be registered while the Monitor module is inactive (modules/monitor.php not loaded).'
+		);
+	}
+
+	// -------------------- normalize_last_status_change --------------------
+
+	/**
+	 * Inputs and expected outputs for the last-status-change normalizer.
+	 *
+	 * Covers every "no transition yet" representation we want to collapse to
+	 * null — empty string (Jetpack Monitor v1's sentinel), whitespace-only,
+	 * MySQL zero-date variants (anticipated Monitor v2), non-strings — plus a
+	 * legitimate timestamp that must pass through verbatim.
+	 *
+	 * @return array<string, array{0: mixed, 1: string|null}>
+	 */
+	public static function provider_normalize_last_status_change(): array {
+		return array(
+			'empty string'                   => array( '', null ),
+			'whitespace only'                => array( "  \t\n", null ),
+			'mysql zero-date'                => array( '0000-00-00 00:00:00', null ),
+			'mysql zero-date no time'        => array( '0000-00-00', null ),
+			'non-string null'                => array( null, null ),
+			'non-string integer'             => array( 0, null ),
+			'non-string false'               => array( false, null ),
+			'unparseable string'             => array( 'not-a-timestamp', null ),
+			'valid timestamp passes through' => array( '2024-01-15 12:34:56', '2024-01-15 12:34:56' ),
+		);
+	}
+
+	/**
+	 * @dataProvider provider_normalize_last_status_change
+	 *
+	 * @param mixed       $input    Raw value from the remote or cache.
+	 * @param string|null $expected Normalized contract value.
+	 */
+	#[DataProvider( 'provider_normalize_last_status_change' )]
+	public function test_normalize_last_status_change_collapses_no_value_representations_to_null( $input, $expected ) {
+		$this->assertSame(
+			$expected,
+			Monitor_Abilities_Test_Stub::expose_normalize_last_status_change( $input ),
+			'normalize_last_status_change should pass legitimate timestamps through unchanged and collapse every "no value" representation to null.'
 		);
 	}
 }

--- a/projects/plugins/jetpack/tests/php/src/Monitor_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Monitor_Abilities_Test.php
@@ -154,6 +154,33 @@ class Monitor_Abilities_Test extends WP_UnitTestCase {
 		$this->assertTrue( $spec['meta']['annotations']['idempotent'] );
 	}
 
+	/**
+	 * Both abilities are agent-facing, so each must expose the `meta.mcp`
+	 * descriptor (public tool) alongside `show_in_rest`, matching the sibling
+	 * `jetpack/get-modules` and `jetpack/set-module-status` definitions.
+	 *
+	 * @dataProvider provider_ability_slugs
+	 *
+	 * @param string $slug Ability slug to inspect.
+	 */
+	public function test_abilities_expose_public_mcp_tool_metadata( string $slug ) {
+		$meta = Monitor_Abilities::get_abilities()[ $slug ]['meta'];
+		$this->assertTrue( $meta['show_in_rest'], "{$slug} should be exposed in REST." );
+		$this->assertArrayHasKey( 'mcp', $meta, "{$slug} should carry mcp metadata so MCP/agent tooling can discover it." );
+		$this->assertTrue( $meta['mcp']['public'], "{$slug} mcp metadata should be public." );
+		$this->assertSame( 'tool', $meta['mcp']['type'], "{$slug} mcp metadata should be a tool." );
+	}
+
+	/**
+	 * @return array<string, array{0: string}>
+	 */
+	public function provider_ability_slugs(): array {
+		return array(
+			'get-monitor-status' => array( 'jetpack-monitor/get-monitor-status' ),
+			'set-notifications'  => array( 'jetpack-monitor/set-notifications' ),
+		);
+	}
+
 	// -------------------- Registrar wiring --------------------
 
 	/**
@@ -437,14 +464,20 @@ class Monitor_Abilities_Test extends WP_UnitTestCase {
 
 		Monitor_Abilities_Test_Stub::reset( true );
 
+		// Seed a stale local option (false) that disagrees with the remote state
+		// (true) to exercise the self-healing sync on the no-op path.
+		update_option( 'monitor_receive_notifications', false );
+
 		$result = Monitor_Abilities_Test_Stub::set_notifications( array( 'enabled' => true ) );
 
 		$this->assertIsArray( $result );
 		$this->assertTrue( $result['enabled'] );
 		$this->assertFalse( $result['changed'] );
 		$this->assertSame( 0, Monitor_Abilities_Test_Stub::$apply_calls, 'Idempotent no-op: apply_notifications_update should not run when desired matches current.' );
-		$sentinel = '__monitor_abilities_option_unset__';
-		$this->assertSame( $sentinel, get_option( 'monitor_receive_notifications', $sentinel ), 'No-op: the mirrored option should not be written.' );
+		// Even on a no-op the local option is synced to the known-good remote
+		// value (true here) so the legacy REST reader, which trusts this option
+		// before going remote, can't surface a stale state.
+		$this->assertTrue( (bool) get_option( 'monitor_receive_notifications' ), 'No-op should still sync the mirrored option to the remote value.' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/src/Monitor_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Monitor_Abilities_Test.php
@@ -289,37 +289,25 @@ class Monitor_Abilities_Test extends WP_UnitTestCase {
 	// -------------------- Execute callbacks --------------------
 
 	/**
-	 * Get_monitor_status() always returns the full four-key shape.
+	 * With the module inactive, get_monitor_status() short-circuits with a
+	 * `jetpack_monitor_module_inactive` WP_Error before hitting any remote read.
 	 */
-	public function test_get_monitor_status_returns_full_shape() {
-		wp_set_current_user( $this->admin_id );
-
-		// Default test env: module not in active modules filter, user not connected.
-		// Both fields should degrade to null; shape must still contain all four keys.
-		$result = Monitor_Abilities::get_monitor_status();
-
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'module_active', $result );
-		$this->assertArrayHasKey( 'user_connected', $result );
-		$this->assertArrayHasKey( 'notifications_enabled', $result );
-		$this->assertArrayHasKey( 'last_status_change', $result );
-		$this->assertIsBool( $result['module_active'] );
-		$this->assertIsBool( $result['user_connected'] );
-	}
-
-	public function test_get_monitor_status_returns_nulls_when_preconditions_unmet() {
+	public function test_get_monitor_status_errors_when_module_inactive() {
 		wp_set_current_user( $this->admin_id );
 
 		$result = Monitor_Abilities::get_monitor_status();
 
-		// Without an active module + user connection, both remote-derived fields are null.
-		$this->assertFalse( $result['module_active'] );
-		$this->assertFalse( $result['user_connected'] );
-		$this->assertNull( $result['notifications_enabled'] );
-		$this->assertNull( $result['last_status_change'] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_monitor_module_inactive', $result->get_error_code() );
 	}
 
-	public function test_get_monitor_status_reports_module_active_when_filter_flags_it() {
+	/**
+	 * With the module active but no Jetpack user connection, get_monitor_status()
+	 * returns a `jetpack_monitor_not_connected` WP_Error with a message that
+	 * steers the caller to the My Jetpack admin page — agents need an actionable
+	 * next step, not opaque null fields.
+	 */
+	public function test_get_monitor_status_errors_when_user_not_connected() {
 		wp_set_current_user( $this->admin_id );
 
 		add_filter(
@@ -333,7 +321,9 @@ class Monitor_Abilities_Test extends WP_UnitTestCase {
 
 		$result = Monitor_Abilities::get_monitor_status();
 
-		$this->assertTrue( $result['module_active'] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_monitor_not_connected', $result->get_error_code() );
+		$this->assertStringContainsString( 'My Jetpack', $result->get_error_message() );
 	}
 
 	public function test_set_notifications_rejects_missing_enabled() {
@@ -454,6 +444,117 @@ class Monitor_Abilities_Test extends WP_UnitTestCase {
 		$this->assertSame( 0, Monitor_Abilities_Test_Stub::$apply_calls, 'Idempotent no-op: apply_notifications_update should not run when desired matches current.' );
 		$sentinel = '__monitor_abilities_option_unset__';
 		$this->assertSame( $sentinel, get_option( 'monitor_receive_notifications', $sentinel ), 'No-op: the mirrored option should not be written.' );
+	}
+
+	/**
+	 * Happy-path: module active, user connected, both remote reads succeed.
+	 * The returned shape is the documented four-key contract with no nulls
+	 * except the (legitimate) `last_status_change=null` "no transition recorded
+	 * yet" signal.
+	 */
+	public function test_get_monitor_status_returns_full_shape_on_success() {
+		wp_set_current_user( $this->admin_id );
+
+		add_filter(
+			'jetpack_active_modules',
+			static function ( $mods ) {
+				$mods   = is_array( $mods ) ? $mods : array();
+				$mods[] = 'monitor';
+				return array_values( array_unique( $mods ) );
+			}
+		);
+
+		Monitor_Abilities_Test_Stub::reset( true, '2024-01-15 12:34:56' );
+
+		$result = Monitor_Abilities_Test_Stub::get_monitor_status();
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['module_active'] );
+		$this->assertTrue( $result['user_connected'] );
+		$this->assertTrue( $result['notifications_enabled'] );
+		$this->assertSame( '2024-01-15 12:34:56', $result['last_status_change'] );
+	}
+
+	/**
+	 * Module active, user connected, no transition recorded yet — null is a
+	 * legitimate signal (not a failure), so the happy-path shape still applies.
+	 */
+	public function test_get_monitor_status_allows_null_last_status_change_when_no_transition() {
+		wp_set_current_user( $this->admin_id );
+
+		add_filter(
+			'jetpack_active_modules',
+			static function ( $mods ) {
+				$mods   = is_array( $mods ) ? $mods : array();
+				$mods[] = 'monitor';
+				return array_values( array_unique( $mods ) );
+			}
+		);
+
+		Monitor_Abilities_Test_Stub::reset( false, null );
+
+		$result = Monitor_Abilities_Test_Stub::get_monitor_status();
+
+		$this->assertIsArray( $result );
+		$this->assertFalse( $result['notifications_enabled'] );
+		$this->assertNull( $result['last_status_change'] );
+	}
+
+	/**
+	 * Remote `isUserInNotifications` fails → surface as
+	 * `jetpack_monitor_service_unreachable` so callers know to retry rather than
+	 * misread a null field as "notifications are off".
+	 */
+	public function test_get_monitor_status_errors_when_notifications_fetch_fails() {
+		wp_set_current_user( $this->admin_id );
+
+		add_filter(
+			'jetpack_active_modules',
+			static function ( $mods ) {
+				$mods   = is_array( $mods ) ? $mods : array();
+				$mods[] = 'monitor';
+				return array_values( array_unique( $mods ) );
+			}
+		);
+
+		Monitor_Abilities_Test_Stub::reset(
+			new \WP_Error( 'jetpack_monitor_notifications_data_unavailable', 'remote down' ),
+			'2024-01-15 12:34:56'
+		);
+
+		$result = Monitor_Abilities_Test_Stub::get_monitor_status();
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_monitor_service_unreachable', $result->get_error_code() );
+	}
+
+	/**
+	 * Remote `getLastDowntime` fails → also surfaces as
+	 * `jetpack_monitor_service_unreachable`. We deliberately do not split this
+	 * into a per-call error code — both reads back the same Monitor service, so
+	 * one unreachable code is the right level of granularity for callers.
+	 */
+	public function test_get_monitor_status_errors_when_last_status_change_fetch_fails() {
+		wp_set_current_user( $this->admin_id );
+
+		add_filter(
+			'jetpack_active_modules',
+			static function ( $mods ) {
+				$mods   = is_array( $mods ) ? $mods : array();
+				$mods[] = 'monitor';
+				return array_values( array_unique( $mods ) );
+			}
+		);
+
+		Monitor_Abilities_Test_Stub::reset(
+			true,
+			new \WP_Error( 'jetpack_monitor_downtime_data_unavailable', 'remote down' )
+		);
+
+		$result = Monitor_Abilities_Test_Stub::get_monitor_status();
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_monitor_service_unreachable', $result->get_error_code() );
 	}
 
 	// -------------------- Real bootstrap path --------------------

--- a/projects/plugins/jetpack/tests/php/src/Monitor_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Monitor_Abilities_Test.php
@@ -76,9 +76,9 @@ class Monitor_Abilities_Test extends WP_UnitTestCase {
 				wp_unregister_ability( $slug );
 			}
 		}
-		if ( function_exists( 'wp_unregister_ability_category' ) ) {
-			wp_unregister_ability_category( Monitor_Abilities::get_category_slug() );
-		}
+		// Note: we intentionally do NOT unregister the category here — Monitor
+		// abilities live under the WordPress core `site` category, which this
+		// registrar never registers and must never tear down.
 
 		delete_transient( 'monitor_last_downtime' );
 		delete_option( 'monitor_receive_notifications' );
@@ -92,27 +92,65 @@ class Monitor_Abilities_Test extends WP_UnitTestCase {
 	 * `doing_action()`, so direct invocation outside the hook is rejected.
 	 */
 	private function fire_abilities_lifecycle(): void {
+		// Monitor abilities live under the core `site` category, which in
+		// production is registered by WordPress core on the
+		// `wp_abilities_api_categories_init` action. The isolated unit-test
+		// lifecycle does not carry core's registration over, so without this
+		// the category is absent when `register_abilities()` runs and
+		// `wp_register_ability()` rejects every ability ("category not
+		// registered"). Register the `site` category here, scoped to the
+		// categories-init action (where `wp_register_ability_category()` is
+		// permitted) and guarded so a re-fire — or a build where core already
+		// registered it — does not trigger an "already registered" notice.
+		$ensure_site_category = static function () {
+			if (
+				function_exists( 'wp_has_ability_category' )
+				&& function_exists( 'wp_register_ability_category' )
+				&& ! wp_has_ability_category( 'site' )
+			) {
+				wp_register_ability_category(
+					'site',
+					array(
+						'label'       => 'Site',
+						'description' => 'Abilities that retrieve or modify site information and settings.',
+					)
+				);
+			}
+		};
+		add_action( Registrar::CATEGORIES_INIT_ACTION, $ensure_site_category, 1 );
+
 		add_action( Registrar::CATEGORIES_INIT_ACTION, array( Monitor_Abilities::class, 'register_category' ) );
 		add_action( Registrar::ABILITIES_INIT_ACTION, array( Monitor_Abilities::class, 'register_abilities' ) );
 		do_action( Registrar::CATEGORIES_INIT_ACTION );
 		do_action( Registrar::ABILITIES_INIT_ACTION );
+
+		remove_action( Registrar::CATEGORIES_INIT_ACTION, $ensure_site_category, 1 );
 	}
 
 	// -------------------- Abstract getters --------------------
 
 	/**
-	 * Category slug is namespaced under the plugin.
+	 * Category slug is the WordPress core `site` category.
 	 */
-	public function test_category_slug_is_plugin_scoped() {
-		$this->assertSame( 'jetpack-monitor', Monitor_Abilities::get_category_slug() );
+	public function test_category_slug_is_core_site_category() {
+		$this->assertSame( 'site', Monitor_Abilities::get_category_slug() );
 	}
 
-	public function test_category_definition_has_label_and_description() {
-		$def = Monitor_Abilities::get_category_definition();
-		$this->assertArrayHasKey( 'label', $def );
-		$this->assertArrayHasKey( 'description', $def );
-		$this->assertIsString( $def['label'] );
-		$this->assertIsString( $def['description'] );
+	public function test_register_category_is_a_noop() {
+		// The `site` category is owned by WordPress core; this registrar must
+		// not register a plugin-scoped category of its own.
+		if ( ! function_exists( 'wp_has_ability_category' ) ) {
+			$this->markTestSkipped( 'Abilities API not available in this WP version.' );
+		}
+
+		add_action( Registrar::CATEGORIES_INIT_ACTION, array( Monitor_Abilities::class, 'register_category' ) );
+		do_action( Registrar::CATEGORIES_INIT_ACTION );
+
+		// Firing the registrar's (no-op) category callback must not have created
+		// a legacy `jetpack-monitor` category. `wp_has_ability_category()`
+		// returns a clean bool (no `_doing_it_wrong`), unlike
+		// `wp_get_ability_category()` which flags an unregistered lookup.
+		$this->assertFalse( wp_has_ability_category( 'jetpack-monitor' ) );
 	}
 
 	public function test_abilities_map_is_non_empty_and_namespaced() {
@@ -273,7 +311,7 @@ class Monitor_Abilities_Test extends WP_UnitTestCase {
 			$registered = wp_get_ability( $slug );
 			$this->assertNotNull( $registered, "Ability {$slug} should be registered." );
 			$this->assertSame(
-				'jetpack-monitor',
+				'site',
 				$registered->get_category(),
 				"Ability {$slug} should have category auto-injected."
 			);

--- a/projects/plugins/jetpack/tests/php/src/Monitor_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Monitor_Abilities_Test.php
@@ -1,0 +1,381 @@
+<?php
+/**
+ * Tests for the Monitor_Abilities Registrar subclass.
+ *
+ * @package automattic/jetpack
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9.
+
+use Automattic\Jetpack\Plugin\Abilities\Monitor_Abilities;
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * @covers \Automattic\Jetpack\Plugin\Abilities\Monitor_Abilities
+ */
+#[CoversClass( Monitor_Abilities::class )]
+class Monitor_Abilities_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Administrator user id, created once per test.
+	 *
+	 * @var int
+	 */
+	private $admin_id;
+
+	/**
+	 * Subscriber user id, created once per test.
+	 *
+	 * @var int
+	 */
+	private $subscriber_id;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->admin_id      = wp_insert_user(
+			array(
+				'user_login' => 'monitor_abilities_admin_' . wp_generate_password( 8, false, false ),
+				'user_pass'  => 'pw',
+				'user_email' => 'admin_' . wp_generate_password( 6, false, false ) . '@example.test',
+				'role'       => 'administrator',
+			)
+		);
+		$this->subscriber_id = wp_insert_user(
+			array(
+				'user_login' => 'monitor_abilities_sub_' . wp_generate_password( 8, false, false ),
+				'user_pass'  => 'pw',
+				'user_email' => 'sub_' . wp_generate_password( 6, false, false ) . '@example.test',
+				'role'       => 'subscriber',
+			)
+		);
+
+		// Default: gate open for most test cases.
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+	}
+
+	public function tear_down() {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+		remove_all_filters( 'jetpack_wp_abilities_should_register' );
+		remove_all_filters( 'jetpack_active_modules' );
+		wp_set_current_user( 0 );
+
+		remove_action( Registrar::CATEGORIES_INIT_ACTION, array( Monitor_Abilities::class, 'register_category' ) );
+		remove_action( Registrar::ABILITIES_INIT_ACTION, array( Monitor_Abilities::class, 'register_abilities' ) );
+
+		// Unregister anything this test left behind so the singleton registry stays clean
+		// between tests (the WP Abilities Registry persists across tests within a process).
+		if ( function_exists( 'wp_unregister_ability' ) ) {
+			foreach ( array_keys( Monitor_Abilities::get_abilities() ) as $slug ) {
+				wp_unregister_ability( $slug );
+			}
+		}
+		if ( function_exists( 'wp_unregister_ability_category' ) ) {
+			wp_unregister_ability_category( Monitor_Abilities::get_category_slug() );
+		}
+
+		delete_transient( 'monitor_last_downtime' );
+		delete_option( 'monitor_receive_notifications' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Hook the registrar callbacks and fire the API lifecycle actions so registrations
+	 * happen inside the action callstack — `wp_register_ability(_category)` enforces
+	 * `doing_action()`, so direct invocation outside the hook is rejected.
+	 */
+	private function fire_abilities_lifecycle(): void {
+		add_action( Registrar::CATEGORIES_INIT_ACTION, array( Monitor_Abilities::class, 'register_category' ) );
+		add_action( Registrar::ABILITIES_INIT_ACTION, array( Monitor_Abilities::class, 'register_abilities' ) );
+		do_action( Registrar::CATEGORIES_INIT_ACTION );
+		do_action( Registrar::ABILITIES_INIT_ACTION );
+	}
+
+	// -------------------- Abstract getters --------------------
+
+	public function test_category_slug_is_plugin_scoped() {
+		$this->assertSame( 'jetpack-monitor', Monitor_Abilities::get_category_slug() );
+	}
+
+	public function test_category_definition_has_label_and_description() {
+		$def = Monitor_Abilities::get_category_definition();
+		$this->assertArrayHasKey( 'label', $def );
+		$this->assertArrayHasKey( 'description', $def );
+		$this->assertIsString( $def['label'] );
+		$this->assertIsString( $def['description'] );
+	}
+
+	public function test_abilities_map_is_non_empty_and_namespaced() {
+		$abilities = Monitor_Abilities::get_abilities();
+		$this->assertNotEmpty( $abilities );
+		foreach ( array_keys( $abilities ) as $slug ) {
+			$this->assertStringStartsWith( 'jetpack-monitor/', $slug );
+		}
+	}
+
+	public function test_no_spec_sets_category_explicitly() {
+		// Registrar auto-injects category; specs that set it are redundant and drift.
+		foreach ( Monitor_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertArrayNotHasKey(
+				'category',
+				$spec,
+				"Ability {$slug} should not set its own category — Registrar injects it."
+			);
+		}
+	}
+
+	public function test_surface_exposes_get_status_and_set_notifications() {
+		$abilities = Monitor_Abilities::get_abilities();
+		$this->assertArrayHasKey( 'jetpack-monitor/get-monitor-status', $abilities );
+		$this->assertArrayHasKey( 'jetpack-monitor/set-notifications', $abilities );
+	}
+
+	public function test_get_monitor_status_is_annotated_readonly_idempotent() {
+		$spec = Monitor_Abilities::get_abilities()['jetpack-monitor/get-monitor-status'];
+		$this->assertTrue( $spec['meta']['annotations']['readonly'] );
+		$this->assertFalse( $spec['meta']['annotations']['destructive'] );
+		$this->assertTrue( $spec['meta']['annotations']['idempotent'] );
+	}
+
+	public function test_set_notifications_is_annotated_non_readonly_idempotent() {
+		$spec = Monitor_Abilities::get_abilities()['jetpack-monitor/set-notifications'];
+		$this->assertFalse( $spec['meta']['annotations']['readonly'] );
+		$this->assertFalse( $spec['meta']['annotations']['destructive'] );
+		$this->assertTrue( $spec['meta']['annotations']['idempotent'] );
+	}
+
+	// -------------------- Registrar wiring --------------------
+
+	public function test_init_registers_nothing_when_gate_filter_is_false() {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+
+		Monitor_Abilities::init();
+
+		$this->assertFalse(
+			has_action( Registrar::CATEGORIES_INIT_ACTION, array( Monitor_Abilities::class, 'register_category' ) )
+		);
+		$this->assertFalse(
+			has_action( Registrar::ABILITIES_INIT_ACTION, array( Monitor_Abilities::class, 'register_abilities' ) )
+		);
+	}
+
+	public function test_init_hooks_lifecycle_actions_when_gate_is_true() {
+		Monitor_Abilities::init();
+
+		$this->assertNotFalse(
+			has_action( Registrar::CATEGORIES_INIT_ACTION, array( Monitor_Abilities::class, 'register_category' ) )
+		);
+		$this->assertNotFalse(
+			has_action( Registrar::ABILITIES_INIT_ACTION, array( Monitor_Abilities::class, 'register_abilities' ) )
+		);
+	}
+
+	public function test_register_abilities_registers_every_slug() {
+		if ( ! function_exists( 'wp_get_abilities' ) || ! function_exists( 'wp_register_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API not available in this WP version.' );
+		}
+
+		$this->fire_abilities_lifecycle();
+
+		$registered_slugs = array();
+		foreach ( wp_get_abilities() as $ability ) {
+			$name = $ability->get_name();
+			if ( str_starts_with( $name, 'jetpack-monitor/' ) ) {
+				$registered_slugs[] = $name;
+			}
+		}
+
+		foreach ( array_keys( Monitor_Abilities::get_abilities() ) as $slug ) {
+			$this->assertContains( $slug, $registered_slugs, "Ability {$slug} should be registered." );
+		}
+	}
+
+	public function test_per_ability_allow_list_filter_is_respected() {
+		if ( ! function_exists( 'wp_get_ability' ) || ! function_exists( 'wp_register_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API not available in this WP version.' );
+		}
+
+		add_filter(
+			'jetpack_wp_abilities_should_register',
+			static function ( $enabled, $type, $slug ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Filter signature requires this parameter even when we don't branch on it.
+				if ( 'ability' === $type ) {
+					return false;
+				}
+				return $enabled;
+			},
+			10,
+			3
+		);
+
+		$this->fire_abilities_lifecycle();
+
+		$registered_slugs = array_map(
+			static fn ( $a ) => $a->get_name(),
+			wp_get_abilities()
+		);
+		foreach ( array_keys( Monitor_Abilities::get_abilities() ) as $slug ) {
+			$this->assertNotContains( $slug, $registered_slugs, "Ability {$slug} must be filtered out." );
+		}
+	}
+
+	public function test_register_abilities_auto_injects_category() {
+		if ( ! function_exists( 'wp_get_ability' ) || ! function_exists( 'wp_register_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API not available in this WP version.' );
+		}
+
+		$this->fire_abilities_lifecycle();
+
+		foreach ( array_keys( Monitor_Abilities::get_abilities() ) as $slug ) {
+			$registered = wp_get_ability( $slug );
+			$this->assertNotNull( $registered, "Ability {$slug} should be registered." );
+			$this->assertSame(
+				'jetpack-monitor',
+				$registered->get_category(),
+				"Ability {$slug} should have category auto-injected."
+			);
+		}
+	}
+
+	// -------------------- Permission callbacks --------------------
+
+	public function test_can_view_monitor_allows_admin() {
+		wp_set_current_user( $this->admin_id );
+		$this->assertTrue( Monitor_Abilities::can_view_monitor() );
+	}
+
+	public function test_can_view_monitor_denies_subscriber() {
+		wp_set_current_user( $this->subscriber_id );
+		$this->assertFalse( Monitor_Abilities::can_view_monitor() );
+	}
+
+	public function test_can_view_monitor_denies_anonymous() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( Monitor_Abilities::can_view_monitor() );
+	}
+
+	public function test_can_manage_monitor_allows_admin() {
+		wp_set_current_user( $this->admin_id );
+		$this->assertTrue( Monitor_Abilities::can_manage_monitor() );
+	}
+
+	public function test_can_manage_monitor_denies_subscriber() {
+		wp_set_current_user( $this->subscriber_id );
+		$this->assertFalse( Monitor_Abilities::can_manage_monitor() );
+	}
+
+	public function test_can_manage_monitor_denies_anonymous() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( Monitor_Abilities::can_manage_monitor() );
+	}
+
+	// -------------------- Execute callbacks --------------------
+
+	public function test_get_monitor_status_returns_full_shape() {
+		wp_set_current_user( $this->admin_id );
+
+		// Default test env: module not in active modules filter, user not connected.
+		// Both fields should degrade to null; shape must still contain all four keys.
+		$result = Monitor_Abilities::get_monitor_status();
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'module_active', $result );
+		$this->assertArrayHasKey( 'user_connected', $result );
+		$this->assertArrayHasKey( 'notifications_enabled', $result );
+		$this->assertArrayHasKey( 'last_downtime', $result );
+		$this->assertIsBool( $result['module_active'] );
+		$this->assertIsBool( $result['user_connected'] );
+	}
+
+	public function test_get_monitor_status_returns_nulls_when_preconditions_unmet() {
+		wp_set_current_user( $this->admin_id );
+
+		$result = Monitor_Abilities::get_monitor_status();
+
+		// Without an active module + user connection, both remote-derived fields are null.
+		$this->assertFalse( $result['module_active'] );
+		$this->assertFalse( $result['user_connected'] );
+		$this->assertNull( $result['notifications_enabled'] );
+		$this->assertNull( $result['last_downtime'] );
+	}
+
+	public function test_get_monitor_status_reports_module_active_when_filter_flags_it() {
+		wp_set_current_user( $this->admin_id );
+
+		add_filter(
+			'jetpack_active_modules',
+			static function ( $mods ) {
+				$mods   = is_array( $mods ) ? $mods : array();
+				$mods[] = 'monitor';
+				return array_values( array_unique( $mods ) );
+			}
+		);
+
+		$result = Monitor_Abilities::get_monitor_status();
+
+		$this->assertTrue( $result['module_active'] );
+	}
+
+	public function test_set_notifications_rejects_missing_enabled() {
+		wp_set_current_user( $this->admin_id );
+		$result = Monitor_Abilities::set_notifications( array() );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_monitor_missing_enabled', $result->get_error_code() );
+	}
+
+	public function test_set_notifications_rejects_null_input() {
+		wp_set_current_user( $this->admin_id );
+		$result = Monitor_Abilities::set_notifications( null );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_monitor_missing_enabled', $result->get_error_code() );
+	}
+
+	public function test_set_notifications_rejects_non_boolean_enabled_string() {
+		// Regression guard: the schema declares boolean; the execute callback should
+		// refuse string "true"/"false" with a distinct "invalid type" code so callers
+		// can differentiate missing-field from wrong-type.
+		wp_set_current_user( $this->admin_id );
+		$result = Monitor_Abilities::set_notifications( array( 'enabled' => 'true' ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_monitor_invalid_enabled', $result->get_error_code() );
+	}
+
+	public function test_set_notifications_rejects_non_boolean_enabled_integer() {
+		wp_set_current_user( $this->admin_id );
+		$result = Monitor_Abilities::set_notifications( array( 'enabled' => 1 ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_monitor_invalid_enabled', $result->get_error_code() );
+	}
+
+	public function test_set_notifications_errors_when_module_inactive() {
+		// Precondition gate: module inactive → error before any IXR call, with a
+		// message that steers the agent to jetpack-modules/set-module-status.
+		wp_set_current_user( $this->admin_id );
+		$result = Monitor_Abilities::set_notifications( array( 'enabled' => true ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_monitor_module_inactive', $result->get_error_code() );
+	}
+
+	public function test_set_notifications_errors_when_user_not_connected() {
+		// With the module active but no Jetpack user connection, writes can't be
+		// authorized — the IXR call needs the user's token. Error before calling out.
+		wp_set_current_user( $this->admin_id );
+
+		add_filter(
+			'jetpack_active_modules',
+			static function ( $mods ) {
+				$mods   = is_array( $mods ) ? $mods : array();
+				$mods[] = 'monitor';
+				return array_values( array_unique( $mods ) );
+			}
+		);
+
+		$result = Monitor_Abilities::set_notifications( array( 'enabled' => true ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_monitor_not_connected', $result->get_error_code() );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/src/Monitor_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Monitor_Abilities_Test.php
@@ -97,6 +97,9 @@ class Monitor_Abilities_Test extends WP_UnitTestCase {
 
 	// -------------------- Abstract getters --------------------
 
+	/**
+	 * Category slug is namespaced under the plugin.
+	 */
 	public function test_category_slug_is_plugin_scoped() {
 		$this->assertSame( 'jetpack-monitor', Monitor_Abilities::get_category_slug() );
 	}
@@ -150,6 +153,9 @@ class Monitor_Abilities_Test extends WP_UnitTestCase {
 
 	// -------------------- Registrar wiring --------------------
 
+	/**
+	 * Gate filter false => init() short-circuits and hooks nothing.
+	 */
 	public function test_init_registers_nothing_when_gate_filter_is_false() {
 		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
 		add_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
@@ -215,7 +221,9 @@ class Monitor_Abilities_Test extends WP_UnitTestCase {
 		$this->fire_abilities_lifecycle();
 
 		$registered_slugs = array_map(
-			static fn ( $a ) => $a->get_name(),
+			static function ( $a ) {
+				return $a->get_name();
+			},
 			wp_get_abilities()
 		);
 		foreach ( array_keys( Monitor_Abilities::get_abilities() ) as $slug ) {
@@ -243,6 +251,9 @@ class Monitor_Abilities_Test extends WP_UnitTestCase {
 
 	// -------------------- Permission callbacks --------------------
 
+	/**
+	 * Admins can view monitor status.
+	 */
 	public function test_can_view_monitor_allows_admin() {
 		wp_set_current_user( $this->admin_id );
 		$this->assertTrue( Monitor_Abilities::can_view_monitor() );
@@ -275,6 +286,9 @@ class Monitor_Abilities_Test extends WP_UnitTestCase {
 
 	// -------------------- Execute callbacks --------------------
 
+	/**
+	 * Get_monitor_status() always returns the full four-key shape.
+	 */
 	public function test_get_monitor_status_returns_full_shape() {
 		wp_set_current_user( $this->admin_id );
 

--- a/projects/plugins/jetpack/tests/php/src/Monitor_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Monitor_Abilities_Test.php
@@ -163,6 +163,7 @@ class Monitor_Abilities_Test extends WP_UnitTestCase {
 	 *
 	 * @param string $slug Ability slug to inspect.
 	 */
+	#[DataProvider( 'provider_ability_slugs' )]
 	public function test_abilities_expose_public_mcp_tool_metadata( string $slug ) {
 		$meta = Monitor_Abilities::get_abilities()[ $slug ]['meta'];
 		$this->assertTrue( $meta['show_in_rest'], "{$slug} should be exposed in REST." );
@@ -174,7 +175,7 @@ class Monitor_Abilities_Test extends WP_UnitTestCase {
 	/**
 	 * @return array<string, array{0: string}>
 	 */
-	public function provider_ability_slugs(): array {
+	public static function provider_ability_slugs(): array {
 		return array(
 			'get-monitor-status' => array( 'jetpack-monitor/get-monitor-status' ),
 			'set-notifications'  => array( 'jetpack-monitor/set-notifications' ),

--- a/projects/plugins/jetpack/tests/php/src/class-monitor-abilities-test-stub.php
+++ b/projects/plugins/jetpack/tests/php/src/class-monitor-abilities-test-stub.php
@@ -14,7 +14,8 @@ use Automattic\Jetpack\Plugin\Abilities\Monitor_Abilities;
  * Test-only subclass overriding Monitor_Abilities's protected seams.
  *
  * - is_user_connected_to_jetpack(): always true.
- * - fetch_notifications_state(): returns the seeded value from ::reset().
+ * - fetch_notifications_state(): returns the seeded value (bool or WP_Error).
+ * - fetch_last_status_change(): returns the seeded value (string|null|WP_Error).
  * - apply_notifications_update(): records each call instead of hitting IXR.
  */
 class Monitor_Abilities_Test_Stub extends Monitor_Abilities {
@@ -22,9 +23,18 @@ class Monitor_Abilities_Test_Stub extends Monitor_Abilities {
 	/**
 	 * Seeded remote state for fetch_notifications_state().
 	 *
-	 * @var bool
+	 * @var bool|\WP_Error
 	 */
 	public static $current_state = false;
+
+	/**
+	 * Seeded remote response for fetch_last_status_change(). When `false`, the
+	 * stub falls through to a default `null` (no transition recorded) to keep
+	 * the legacy set_notifications tests working without a manual seed.
+	 *
+	 * @var string|null|false|\WP_Error
+	 */
+	public static $last_status_change = null;
 
 	/**
 	 * Number of apply_notifications_update() calls in the current test.
@@ -43,12 +53,14 @@ class Monitor_Abilities_Test_Stub extends Monitor_Abilities {
 	/**
 	 * Reset test-double state and seed the simulated remote state.
 	 *
-	 * @param bool $current_state Simulated current notifications state.
+	 * @param bool|\WP_Error              $current_state      Simulated current notifications state.
+	 * @param string|null|\WP_Error|false $last_status_change Simulated last status change.
 	 */
-	public static function reset( bool $current_state ): void {
-		self::$current_state = $current_state;
-		self::$apply_calls   = 0;
-		self::$last_applied  = null;
+	public static function reset( $current_state, $last_status_change = null ): void {
+		self::$current_state      = $current_state;
+		self::$last_status_change = $last_status_change;
+		self::$apply_calls        = 0;
+		self::$last_applied       = null;
 	}
 
 	/**
@@ -61,10 +73,19 @@ class Monitor_Abilities_Test_Stub extends Monitor_Abilities {
 	/**
 	 * Return the seeded simulated remote state.
 	 *
-	 * @return bool
+	 * @return bool|\WP_Error
 	 */
 	protected static function fetch_notifications_state() {
 		return self::$current_state;
+	}
+
+	/**
+	 * Return the seeded simulated last-status-change response.
+	 *
+	 * @return string|null|\WP_Error
+	 */
+	protected static function fetch_last_status_change() {
+		return self::$last_status_change;
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/src/class-monitor-abilities-test-stub.php
+++ b/projects/plugins/jetpack/tests/php/src/class-monitor-abilities-test-stub.php
@@ -100,4 +100,15 @@ class Monitor_Abilities_Test_Stub extends Monitor_Abilities {
 		self::$current_state = $enabled;
 		return true;
 	}
+
+	/**
+	 * Public passthrough exposing the protected normalize_last_status_change
+	 * helper so tests can drive it directly without reflection.
+	 *
+	 * @param mixed $value Raw remote/cached value.
+	 * @return string|null
+	 */
+	public static function expose_normalize_last_status_change( $value ) {
+		return parent::normalize_last_status_change( $value );
+	}
 }

--- a/projects/plugins/jetpack/tests/php/src/class-monitor-abilities-test-stub.php
+++ b/projects/plugins/jetpack/tests/php/src/class-monitor-abilities-test-stub.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Test-only subclass of Monitor_Abilities that overrides the protected seams
+ * (user-connection check, remote state fetch, remote update apply) so the
+ * success path can be exercised without a Jetpack token fixture or live IXR
+ * endpoint.
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\Plugin\Abilities\Monitor_Abilities;
+
+/**
+ * Test-only subclass overriding Monitor_Abilities's protected seams.
+ *
+ * - is_user_connected_to_jetpack(): always true.
+ * - fetch_notifications_state(): returns the seeded value from ::reset().
+ * - apply_notifications_update(): records each call instead of hitting IXR.
+ */
+class Monitor_Abilities_Test_Stub extends Monitor_Abilities {
+
+	/**
+	 * Seeded remote state for fetch_notifications_state().
+	 *
+	 * @var bool
+	 */
+	public static $current_state = false;
+
+	/**
+	 * Number of apply_notifications_update() calls in the current test.
+	 *
+	 * @var int
+	 */
+	public static $apply_calls = 0;
+
+	/**
+	 * Last value passed to apply_notifications_update().
+	 *
+	 * @var bool|null
+	 */
+	public static $last_applied = null;
+
+	/**
+	 * Reset test-double state and seed the simulated remote state.
+	 *
+	 * @param bool $current_state Simulated current notifications state.
+	 */
+	public static function reset( bool $current_state ): void {
+		self::$current_state = $current_state;
+		self::$apply_calls   = 0;
+		self::$last_applied  = null;
+	}
+
+	/**
+	 * Always-connected for tests — bypasses the real Connection_Manager check.
+	 */
+	protected static function is_user_connected_to_jetpack(): bool {
+		return true;
+	}
+
+	/**
+	 * Return the seeded simulated remote state.
+	 *
+	 * @return bool
+	 */
+	protected static function fetch_notifications_state() {
+		return self::$current_state;
+	}
+
+	/**
+	 * Record the call instead of sending the real IXR request.
+	 *
+	 * @param bool $enabled Desired state.
+	 * @return true
+	 */
+	protected static function apply_notifications_update( bool $enabled ) {
+		++self::$apply_calls;
+		self::$last_applied  = $enabled;
+		self::$current_state = $enabled;
+		return true;
+	}
+}


### PR DESCRIPTION
Fixes #

## Proposed changes

* Register two WordPress Abilities API abilities for Jetpack Downtime Monitor via the shared `Registrar` base class:
  * `jetpack-monitor/get-monitor-status` — zero-arg read returning `{ module_active, user_connected, notifications_enabled, last_status_change }` on the happy path. `last_status_change` is the timestamp of the most recent up/down transition (the legacy `last_status_change` projection), or `null` when no transition has been recorded yet — the only legitimate null on the success path. Fails with `WP_Error` codes when preconditions aren't met: `jetpack_monitor_module_inactive` (defensive — unreachable in practice), `jetpack_monitor_not_connected` (with a steering message pointing the caller to the My Jetpack admin page), or `jetpack_monitor_service_unreachable` when either underlying XML-RPC read fails. This replaces the earlier null-fields-on-failure behavior so agents get an actionable next step.
  * `jetpack-monitor/set-notifications` — declarative state-setter taking `{ enabled }`, idempotent; returns `{ enabled, changed }`. Errors with `jetpack_monitor_not_connected` when the user isn't connected to Jetpack; `jetpack_monitor_module_inactive` is reachable only via a race (see below). Either outcome (changed write **or** no-op) syncs the local `monitor_receive_notifications` option to the known-good remote value, so the legacy `Jetpack_Core_Json_Api_Endpoints::get_remote_value` reader — which trusts that option before falling back to a remote read — can never surface a stale state.
* Both abilities set `show_in_rest` **and** `meta.mcp` (`public => true`, `type => tool`), matching the sibling `jetpack/get-modules` / `jetpack/set-module-status` definitions, so they're discoverable by MCP/agent tooling rather than REST-only.
* Wire `Monitor_Abilities::init()` from `modules/monitor.php`, which Jetpack only loads when the Monitor module is active. **The Monitor abilities are therefore only registered while the Monitor module is active** — `wp_get_abilities()` will not return `jetpack-monitor/*` slugs when Monitor is inactive. This keeps the always-on ability surface minimal; future module-management abilities (out of scope here) will be the discovery/activation entry point for module-gated categories like this one.
* `Registrar::init()` handles the `jetpack_wp_abilities_enabled` gate, category/abilities lifecycle hooks, and WP < 6.9 compatibility — no manual `add_action` plumbing required.
* Added as a minor changelog entry under `enhancement`.

## Related product discussion/links

* Tracking surface for Radical Speed Month — "Abilities Everywhere".

## Does this pull request change what data or activity we track or use?

No. The abilities wrap the existing `jetpack.monitor.isUserInNotifications`, `jetpack.monitor.setNotifications`, and `jetpack.monitor.getLastDowntime` XML-RPC endpoints that the Monitor module already uses. No new data is collected or transmitted.

## Testing instructions

1. Install/activate Jetpack from this branch and connect the site + user.
2. Opt in to the Abilities API:
   ```php
   add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
   ```
   (mu-plugin or snippet)
3. With the Monitor module **active**, confirm the abilities register:
   ```bash
   wp eval 'foreach ( wp_get_abilities() as $a ) { if ( str_starts_with( $a->get_name(), "jetpack-monitor/" ) ) echo $a->get_name() . "\n"; }'
   ```
   Expected output:
   ```
   jetpack-monitor/get-monitor-status
   jetpack-monitor/set-notifications
   ```
4. REST surface check:
   ```bash
   curl -s -u admin:app_password https://example.test/wp-json/wp-abilities/v1/abilities | jq '[.[] | select(.name | startswith("jetpack-monitor/"))] | length'
   ```
   Expect `2`.
5. MCP metadata check — confirm both abilities advertise the public MCP tool descriptor:
   ```bash
   wp eval 'foreach ( array( "jetpack-monitor/get-monitor-status", "jetpack-monitor/set-notifications" ) as $s ) { var_export( wp_get_ability( $s )->get_meta()["mcp"] ?? null ); echo "\n"; }'
   ```
   Each should print `array ( 'public' => true, 'type' => 'tool' )`.
6. With the Monitor module **inactive** (`wp jetpack module deactivate monitor`), re-run the step 3 command — expect **empty output**. The abilities load alongside the module by design.
7. With the Monitor module **active** and the user connected, exercise `get-monitor-status`:
   ```bash
   wp eval 'var_export( wp_get_ability( "jetpack-monitor/get-monitor-status" )->execute( [] ) );'
   ```
   Expect an array with `module_active=true`, `user_connected=true`, a boolean `notifications_enabled`, and either a `"YYYY-MM-DD HH:mm:ss"` UTC string or `null` for `last_status_change` (the "no transition recorded yet" signal).
8. Exercise idempotency on `set-notifications`, then confirm the local option mirrors remote even on a no-op:
   ```bash
   wp eval 'var_export( wp_get_ability( "jetpack-monitor/set-notifications" )->execute( [ "enabled" => true ] ) );'
   wp eval 'var_export( wp_get_ability( "jetpack-monitor/set-notifications" )->execute( [ "enabled" => true ] ) );'
   wp option get monitor_receive_notifications
   ```
   First call → `[ 'enabled' => true, 'changed' => true ]`; second call → `[ 'enabled' => true, 'changed' => false ]`. The `monitor_receive_notifications` option should read `1` after the no-op (mirrored from the remote value), even if it was previously stale.
9. Run with a disconnected user — both abilities should now surface an actionable `WP_Error` instead of silent nulls:
   ```bash
   wp eval 'var_export( wp_get_ability( "jetpack-monitor/get-monitor-status" )->execute( [] ) );'
   wp eval 'var_export( wp_get_ability( "jetpack-monitor/set-notifications" )->execute( [ "enabled" => true ] ) );'
   ```
   Both should return a `WP_Error` with code `jetpack_monitor_not_connected`. The `get-monitor-status` error message should mention "My Jetpack" — that's the steering hint for callers.
10. PHPUnit:
    ```bash
    cd projects/plugins/jetpack && composer phpunit -- --filter Monitor_Abilities_Test
    ```
    Covers Registrar wiring, abstract getters, permissions, schema edge cases, success-path coverage (`changed:true` / `changed:false`, including the no-op local-option sync) for `set-notifications`, the public MCP tool metadata on both abilities, the new `WP_Error` paths on `get-monitor-status` (module inactive, user not connected, both `service_unreachable` variants), the `normalize_last_status_change` normalizer (empty/whitespace/zero-date/valid/non-string), and the negative bootstrap test confirming abilities are NOT registered when the Monitor module is inactive.

Permissions: both abilities are gated on `current_user_can( 'jetpack_admin_page' )`, matching the legacy Monitor admin UI. Notifications are a per-user preference, so the same gate is appropriate for the write.
