### PR TITLE
Abilities skills: audit + ship-wp-ability + wp-abilities-api + wp-abilities-verify

### DIFF
--- a/.agents/skills/ship-wp-ability.md
+++ b/.agents/skills/ship-wp-ability.md
@@ -1,0 +1,332 @@
+---
+name: ship-wp-ability
+description: "Use when shipping a new set of WP Abilities for a Jetpack plugin or package — scaffolds a Registrar-extending class, permissions, input/output schemas, PHPUnit tests (including Registrar-wiring assertions), bootstrap wiring, and a changelog entry."
+compatibility: "Targets WordPress 6.9+ (PHP 7.2.24+). Requires the `jetpack-wp-abilities` package (`projects/packages/wp-abilities`). Filesystem-based agent with bash."
+---
+
+# Ship WP Ability
+
+## When to use
+
+Use this skill when the task is to ship a new set of WP Abilities for:
+
+- a Jetpack module exposed through the main plugin (`projects/plugins/jetpack/`),
+- a Jetpack package with its own abilities surface (`projects/packages/forms`, `boost`, `search`, `stats`, ...),
+- any feature that needs to be callable via `wp-abilities/v1` or `@wordpress/abilities`.
+
+Typical invocations:
+
+- `/ship-wp-ability for jetpack modules`
+- `/ship-wp-ability for Forms responses`
+- `/ship-wp-ability for Boost cache`
+
+If the task is *designing* which abilities to register (grouping, naming, shape), invoke `wp-abilities-audit` first. If the task is *verifying* an existing surface (annotation correctness, schema soundness), invoke `wp-abilities-verify` instead. This skill produces the code.
+
+## Inputs required
+
+- **Target domain** — free-form phrase from the user (e.g. "jetpack modules").
+- **Host project** — where the class lives: `projects/plugins/jetpack/` (plugin context) or `projects/packages/<pkg>/` (package context).
+- **Operations list** — which reads and writes to expose. Default to 1-3 abilities with narrow writes + broader reads. See grouping heuristic below.
+- **Capability set** — which capability each operation gates on. Prefer domain-specific Jetpack caps over `manage_options`.
+
+If any of these are ambiguous, stop and ask. Do not guess the capability.
+
+## Procedure
+
+### 1) Create an isolated worktree
+
+Work happens in a git worktree, not on the current branch. Invoke the `jetpack-worktree` skill to create one with an isolated Docker environment. Suggested branch name: `add/ship-<name>-abilities` (e.g. `add/ship-modules-abilities`, `add/ship-boost-cache-abilities`).
+
+If `jetpack-worktree` is unavailable, fall back to:
+
+```bash
+git worktree add -b add/ship-<name>-abilities ../jetpack-ship-<name> trunk
+cd ../jetpack-ship-<name>
+```
+
+All subsequent steps run inside the worktree. Don't mix work with an existing branch.
+
+### 2) Scope the domain
+
+Locate the target's source under `projects/plugins/jetpack/` or `projects/packages/<name>/`. Read the host project's `composer.json` and confirm `automattic/jetpack-wp-abilities` is listed under `require`. If not, add it now (e.g. `"automattic/jetpack-wp-abilities": "@dev"` for monorepo-linked packages) — the composer update step runs after the class is in place.
+
+### 3) Decide the ability set — consolidate aggressively, wrap intent
+
+Read `references/consolidation-heuristic.md`, `references/agent-ergonomics.md`, and `wp-abilities-api/references/grouping-heuristic.md` first. Two load-bearing principles from Anthropic's tool-writing guidance:
+
+- **Wrap the agent's intent, not the REST controller.** If the agent's real task requires chaining `get-X` → `list-Y` → `do-Z`, build a single `do-Z-for-X` ability that does all three under the hood. Atomic REST-bindings are an anti-pattern: *"tools that merely wrap existing software functionality or API endpoints — whether or not the tools are appropriate for agents."*
+- **Fewer abilities beats more.** Agents benefit when each ability is a powerful filter/state-setter rather than an atomic CRUD operation.
+
+Default rules (see the consolidation heuristic for worked examples):
+
+- **Collapse `list-X` + `get-X` into one filtered read** (`get-Xs`). Make slug/id an optional filter that returns a 0- or 1-element array. Put all other useful filters (active, status, feature, search, date ranges) into the same input schema.
+- **Replace verb pairs with declarative state-setters.** `set-module-status({slug, active})` beats `activate-module` + `deactivate-module`. The state param is required; the callback compares desired-vs-current and is idempotent by construction.
+- **Every read returns the same object shape** regardless of which filter is present. Don't switch between "summary" and "detail" shapes based on input — that's a trap. Use an `expand`/`include` param if different depths are genuinely needed.
+- **Group reads around the question a user would type**, not around REST atomization ("list responses with filters", not "list by status + list by date + list by author").
+- **Zero-arg overview abilities** (counts, status summaries) are high-leverage and cheap — keep them if they answer a question the filtered read can't.
+
+Before finalizing `get_abilities()`, walk the checklist at the end of `references/consolidation-heuristic.md`. If any check fails without a listed exception, merge further.
+
+Do NOT consolidate across these hard boundaries:
+
+- Reads and writes (different `permission_callback`, different `meta.annotations.readonly`).
+- Destructive and non-destructive writes (different `meta.annotations.destructive`).
+- Unrelated state surfaces on the same resource (e.g. `set-module-status` vs. `set-module-config` — same resource, different state).
+
+### 4) Pick the category, the host, and the file path — colocate with the feature
+
+**Read `references/module-colocation.md` first** — it walks the three-case decision and lists the exact path for each. The short version:
+
+- **Case A — module-backed ability** (Monitor, Stats, Subscriptions, Likes, VaultPress, Search, ...): file goes **inside the module**, not in the global `src/abilities/` tree. Path: `projects/plugins/jetpack/modules/<slug>/abilities/class-<slug>-abilities.php`. The module file is only loaded when the module is active, so the ability registrar only runs when the module is active — **no `is_module_active()` guard needed, and none is wanted**.
+- **Case B — package-backed feature** (Forms, Boost, Search, ...): file goes inside the package. Path: `projects/packages/<pkg>/src/abilities/class-<name>-abilities.php`.
+- **Case C — plugin-core / always-on ability** (e.g. `Modules_Abilities`, connection-state readers): file goes in the plugin's global tree. Path: `projects/plugins/jetpack/src/abilities/class-<name>-abilities.php`. Use this case **only** when the ability genuinely doesn't belong to any module or package.
+
+Then the rest of the naming:
+
+- **Category slug:** kebab-case, plugin-scoped. Good: `jetpack-monitor`, `jetpack-forms`, `jetpack-modules`. Bad: `monitor`, `forms`.
+- **Ability slugs:** `<category>/<verb>-<object>`, e.g. `jetpack-monitor/get-monitor-status`.
+- **Class name:** `<Name>_Abilities` (e.g. `Monitor_Abilities`, `Forms_Abilities`, `Modules_Abilities`).
+- **Namespace:** plugin context (Case A, Case C) → `Automattic\Jetpack\Plugin\Abilities`. Package context (Case B) → `Automattic\Jetpack\<Pkg>\Abilities`.
+
+If you're unsure which case applies: does the ability call code that only exists when a module is active (e.g. `Jetpack_Monitor::something()`)? Case A. Does the ability live in or only make sense for a specific package? Case B. Neither? Case C — and double-check you're not actually Case A.
+
+### 5) Write the class extending `Registrar`
+
+Follow `references/class-skeleton.md`. Three abstract methods must be implemented:
+
+- `get_category_slug(): string` — returns the kebab-case slug from step 4.
+- `get_category_definition(): array` — returns `[ 'label' => ..., 'description' => ... ]`.
+- `get_abilities(): array` — returns a `[ slug => spec ]` map.
+
+Do NOT write an `init()` method. `Registrar::init()` handles the hook lifecycle, the `jetpack_wp_abilities_enabled` gate, and `did_action()` late-load. Just call `<Name>_Abilities::init()` from the bootstrap.
+
+### 6) Write each ability spec
+
+Read `references/agent-ergonomics.md` first — it distills Anthropic's "Writing tools for agents" guidance into rules for the Abilities API surface (descriptions as specs, semantic identifiers, high-signal responses, the `response_format` pattern, token ceilings on lists, errors that steer the next call). The checklist at the end of that reference is the gate before you move on.
+
+For every entry in `get_abilities()`:
+
+- `label` + `description` — both translatable via `__()`. Descriptions are what the agent reads at decision time; include **return shape, idempotency language, required preconditions, related abilities**. "Activate a module" is a label, not a description.
+- `input_schema` — JSON Schema, `type: object`, `additionalProperties: false`, explicit `properties`. Cross-link `wp-abilities-api/references/input-schema-gotchas.md` for three runtime traps:
+  1. Schema defaults are NOT auto-injected into `$input`; normalize defaults at the top of the execute callback.
+  2. Pagination key drift (`per_page` vs `pagesize`); translate before delegating.
+  3. `empty()`-based ID validation misclassifies the string `'0'`; use `isset()` + type check + `'' === $value`.
+- `output_schema` — mirror the returned shape. Optional but recommended for the `/wp-abilities/v1/run` surface.
+- `execute_callback` — `[ __CLASS__, 'method_name' ]`. Method signature is `( $input = null )`. Return value is a plain array (or `WP_Error`). Keep the shape **high-signal** — don't return raw `$mod` / `WP_Post` / option dumps; summarize. See the anti-patterns section of `references/agent-ergonomics.md`.
+- `permission_callback` — `[ __CLASS__, 'can_method' ]`. See the permissions table below.
+- `meta.annotations` — `readonly`, `destructive`, `idempotent` booleans. These must match execute behavior; `wp-abilities-verify` will flag mismatches.
+- `meta.show_in_rest` — `true` when the ability should be callable via REST.
+- **Do NOT set `category`** in the spec. `Registrar` auto-injects it. Setting it duplicates info that drifts.
+- `WP_Error` codes — use the shared vocabulary in `wp-abilities-api/references/error-code-vocabulary.md` (`<plugin>_not_initialized`, `<plugin>_missing_<field>`, `<plugin>_invalid_<field>`, `<plugin>_<resource>_data_unavailable`). The **message** should tell the agent *what to do next* — e.g. "Unknown module slug. Call jetpack-modules/get-modules to enumerate." — not just restate the error condition.
+- **Pagination** — any list-shaped read needs `page`/`per_page` (or `limit`/`cursor`) with a `default` of ~20 and a `maximum` of ~100. Enforce the max in the callback. Even if today's dataset is small, don't ship ability specs that return unbounded lists.
+
+### 7) Pick permissions
+
+Inline decision table:
+
+| Shape | Capability pattern | Example |
+|---|---|---|
+| Public read | `return true;` | rare; site-wide catalog |
+| Authenticated read | `is_user_logged_in()` | "my drafts" |
+| Admin view | `current_user_can( 'jetpack_admin_page' )` | list modules |
+| Admin write | `current_user_can( 'jetpack_manage_modules' ) && current_user_can( 'jetpack_activate_modules' )` | toggle module |
+| Per-object write | `current_user_can( 'edit_post', $id )` | update a specific response |
+| Core fallback | `current_user_can( 'manage_options' )` | only when no Jetpack-specific cap fits |
+
+Rules:
+
+- Prefer narrow Jetpack-specific caps over `manage_options`.
+- Differentiate read (`can_view_*`) from write (`can_manage_*`). Never reuse a view check to gate a write.
+- `permission_callback` returns `bool` or `WP_Error`. Never throws.
+- Callbacks receive no arguments; they inspect global user state.
+
+### 8) Wire into the host — choose based on the case from step 4
+
+**Where `::init()` is called determines when the ability registers.** Pick the wiring point that matches the case from step 4. A single line; the class is autoloaded, so no `require_once` is needed.
+
+**Case A — module-backed:** wire from **inside the module file** so registration is gated by module activation automatically.
+
+```php
+// projects/plugins/jetpack/modules/<slug>.php, at the bottom of the file:
+\Automattic\Jetpack\Plugin\Abilities\<Slug>_Abilities::init();
+```
+
+Jetpack's `load_modules()` only includes `modules/<slug>.php` when the module is active, so the call only happens when the module is on. Do **not** wire from `class.jetpack.php` — that loads the ability regardless of module state, which is the anti-pattern `references/module-colocation.md` exists to prevent.
+
+**Case B — package-backed:** wire from the package's **existing bootstrap** (e.g. `Contact_Form_Plugin::init()` for Forms, `Jetpack_Boost::init()` for Boost). Never from the consumer plugin's `class.jetpack.php`.
+
+**Case C — plugin-core / always-on:** wire from `class.jetpack.php` in the plugin's constructor or `plugins_loaded` handler. Use this **only** when the ability isn't tied to a module or package.
+
+```php
+// Case C only — projects/plugins/jetpack/class.jetpack.php:
+\Automattic\Jetpack\Plugin\Abilities\<Name>_Abilities::init();
+```
+
+The Jetpack plugin's `composer.json` declares `"autoload": { "classmap": ["src"] }` and modules are classmap-discovered too, so the class loads from whichever of the three locations you chose once `composer dump-autoload` runs (step 9). If you see the legacy `require_once JETPACK__PLUGIN_DIR . 'src/abilities/class-<x>-abilities.php';` pattern in `class.jetpack.php`, treat it as redundant: the class is already in the classmap, and adding `require_once` is the wrong fix for a stale-autoloader problem.
+
+Placement timing matters: `::init()` must run before `wp_abilities_api_init` fires — for Case A that's automatic (modules load early), for Case B the package's bootstrap is already early enough, for Case C put it in the constructor or `plugins_loaded`.
+
+### 9) Link the monorepo dependency and refresh the autoloader
+
+Because `automattic/jetpack-wp-abilities` is a monorepo package and the subclass references its `Registrar` base, the host project's autoloader must pick up the dependency before tests or any runtime code can find the class.
+
+Run these from inside the worktree:
+
+```bash
+cd projects/plugins/jetpack         # or projects/packages/<pkg>/
+composer update automattic/jetpack-wp-abilities    # first time the dep is added
+# OR, if composer.json already required it before this change:
+composer install
+composer dump-autoload               # cheap, catches stale autoload after adding new classes
+```
+
+Expected result: `composer.lock` in the host project updates (symlink / path repo target now points at the monorepo copy), and `vendor/composer/autoload_classmap.php` (or `autoload_psr4.php`) sees both the new `<Name>_Abilities` class and the `Automattic\Jetpack\WP_Abilities\Registrar` base.
+
+**`composer dump-autoload` is what makes the new class findable** — it's not optional. The Jetpack plugin uses classmap autoload, so until the classmap is regenerated, the bootstrap call to `<Name>_Abilities::init()` will fatal with "class not found" even though the file is on disk.
+
+If `composer update automattic/jetpack-wp-abilities` reports "Nothing to modify in lock," the dep was already linked — just run `composer dump-autoload`.
+
+### 10) Write tests
+
+Follow `references/test-templates.md`. The test file lives at:
+
+- Plugin context: `projects/plugins/jetpack/tests/php/src/<Name>_Abilities_Test.php` (extends `WP_UnitTestCase`, uses `WP_UnitTestCase_Fix` trait + `#[CoversClass]` attribute).
+- Package context: `projects/packages/<pkg>/tests/php/abilities/<Name>AbilitiesTest.php` (extends `PHPUnit\Framework\TestCase`, uses Brain Monkey + Mockery).
+
+Required coverage:
+
+- **Registrar wiring** (the differentiating value-add):
+  - `jetpack_wp_abilities_enabled` defaulting false → `init()` registers nothing.
+  - Filter enabled, neither action fired → both lifecycle hooks added.
+  - Filter enabled, `wp_abilities_api_categories_init` already fired → category registered directly, abilities still hooked.
+  - Per-ability `jetpack_wp_abilities_should_register` filter — returning false skips that ability.
+  - Category auto-injection — abilities whose spec omits `category` get the subclass's slug.
+- **Abstract getters** — `get_category_slug`, `get_category_definition`, `get_abilities` return the expected shapes.
+- **Permission callbacks** — allowed user returns true; denied user returns false; unauthenticated returns false.
+- **Execute callbacks** — happy path for each ability returns the documented shape.
+- **Consolidated-read contract** — `get-<objects>` with unknown id returns an empty array (not `WP_Error`); shape is the same whether or not `id` is provided.
+- **Declarative-write idempotency** — `set-<object>-<attribute>` with desired==current returns `changed=false`; with desired!=current returns `changed=true` after transition.
+- **Schema edge cases** — missing required field returns `WP_Error`; empty-string ID rejected; wrong type rejected; the literal string `'0'` accepted (regression guard against `empty()`).
+
+### 11) Add the changelog entry — use the tool, then validate
+
+**Do not hand-write the file.** Each project has its own allowed `Type:` values (the Jetpack plugin uses `enhancement`; packages use `added`; others differ), and hand-crafted entries silently ship the wrong type. Use the changelogger CLI — it reads the project config and rejects invalid types at the source:
+
+```bash
+cd projects/plugins/jetpack                      # or projects/packages/<pkg>/
+vendor/bin/changelogger add \
+  --no-interaction \
+  --significance=minor \
+  --type=enhancement \                           # plugin: enhancement; package: added
+  --entry="Abilities API: register abilities for <domain> on WP 6.9+." \
+  --filename=add-<name>-abilities
+```
+
+(If you prefer the Docker workflow, `jp changelog add` is equivalent.)
+
+Then run the linter — **this is a mandatory gate before step 12, same check CI runs:**
+
+```bash
+vendor/bin/changelogger validate
+```
+
+Must exit 0 with no output. If it fails, fix and re-run; never suppress with `--no-strict`. Do not hand-edit the generated file — the tool wrote it correctly; manual edits reintroduce encoding / header / type mistakes.
+
+### 12) Run the tests
+
+- Plugin: `cd projects/plugins/jetpack && composer phpunit -- --filter <Name>_Abilities_Test`
+- Package: `cd projects/packages/<pkg> && composer phpunit -- --filter <Name>AbilitiesTest`
+
+Every assertion group in `references/test-templates.md` (Registrar wiring, abstract getters, permissions, execute, schema edge cases) must pass before proceeding. If the autoloader can't find the new class, re-run `composer dump-autoload` inside the host project.
+
+### 13) Run `/simplify` and apply findings
+
+Before committing, invoke the `simplify` skill on the changes. It reviews the new code for reuse opportunities (e.g. an existing helper that does what `delegate_to_rest_controller` already does), overengineering (abstractions with one caller, premature factories), and inefficiency.
+
+- Accept findings that genuinely reduce code without losing test coverage.
+- Reject findings that would break the Registrar-wiring assertions (e.g. "inline `get_abilities()` since it's only called once" — no, the abstract method contract matters).
+- Re-run `composer phpunit -- --filter <Name>_Abilities_Test` (step 12) after each fix. All assertion groups must stay green.
+
+### 14) Commit — include the updated `composer.lock`
+
+This PR adds a dependency to `composer.json`, so `composer.lock` must be committed alongside it. CI runs with `--frozen-lockfile`; a missing or stale lockfile fails the build.
+
+Stage and commit:
+
+```bash
+git add \
+  projects/<plugin-or-package>/composer.json \
+  projects/<plugin-or-package>/composer.lock \
+  projects/<plugin-or-package>/src/abilities/class-<name>-abilities.php \
+  projects/<plugin-or-package>/tests/.../<Name>_Abilities_Test.php \
+  projects/<plugin-or-package>/changelog/add-<name>-abilities \
+  <bootstrap file with the one-line ::init() call>
+git commit -m "<Name> abilities: register <domain> via Registrar"
+```
+
+Do NOT stage unrelated lock drift in other packages — only the host project's `composer.lock` should move.
+
+### 15) Push, open a draft PR, and run `/jetpack-review-pr`
+
+Push the branch and open a draft PR (use the `jetpack-pr` skill for templating). Once the PR exists, invoke the `jetpack-review-pr` skill with the PR number — it covers bugs, security, performance, WP/Jetpack conventions, and test-coverage gaps that `/simplify` wouldn't catch.
+
+Treat the review as a loop, not a one-shot:
+
+1. Run `/jetpack-review-pr <pr-number>`.
+2. For each finding, decide: **fix** (actionable bug/convention), **defer** (tracked separately, explain why in a PR comment), or **reject** (valid disagreement, explain).
+3. Apply fixes in follow-up commits on the same branch.
+4. Re-run `composer phpunit -- --filter <Name>_Abilities_Test` after each fix.
+5. Re-run `/jetpack-review-pr` once findings are addressed to confirm no regressions were introduced.
+
+Common issues this review tends to catch for Abilities PRs:
+
+- Missing nonce or capability check beyond `permission_callback` (e.g. write paths that touch options without additional guarding).
+- Schema that accepts unsanitized strings passed into `wpdb` or `update_option` keys.
+- Error code strings that don't follow the `<plugin>_*` vocabulary (cross-link to `wp-abilities-api/references/error-code-vocabulary.md`).
+- Missing i18n text domain on `__()` strings.
+- Annotations that don't match behavior — hand off to `wp-abilities-verify` and fix the annotations or the execute, not the test assertion.
+
+Mark the PR ready-for-review only after the review loop converges (no open blocking findings) and tests still pass.
+
+## Verification
+
+- Work landed in an isolated worktree (not `trunk` or a pre-existing branch).
+- `references/agent-ergonomics.md` end-of-file checklist walked for each ability — descriptions include return shape + preconditions + related abilities; outputs are high-signal; identifiers human-readable; lists paginated; errors steer the next call.
+- `references/consolidation-heuristic.md` end-of-file checklist walked — no unnecessary list+get splits; no verb pairs; uniform return shape per ability.
+- The target project's `composer phpunit -- --filter <Name>_Abilities_Test` passes — every assertion group in `references/test-templates.md` green.
+- `composer.lock` in the host project is staged and committed; no lock drift in unrelated packages.
+- `/simplify` was run and its findings were applied, deferred, or rejected with reasoning.
+- `/jetpack-review-pr` was run against the open PR and converged — no open blocking findings.
+- `wp-abilities-verify` in static mode against the host project passes: new abilities recognized, annotations match behavior, schemas valid.
+- In a running WP environment with the `jetpack_wp_abilities_enabled` filter returning true, `wp_get_abilities()` lists the new slugs and `/wp-json/wp-abilities/v1/abilities` exposes them.
+- Changelog entry exists at the expected path and has the three required lines (significance, type, blank line, message).
+- `vendor/bin/changelogger validate` (run from the host project) exits 0 — same linter CI uses. No warnings accepted without explicit reasoning.
+- **Colocation lint** from `references/module-colocation.md` produces no `COLOCATION FAIL` output. Module-backed abilities live inside their modules; `class.jetpack.php` does not wire any module-backed `<Slug>_Abilities::init()`.
+- **Activation-gating test** passes: the test asserting that the ability does not register when its backing module is inactive (Case A only) is green. See `references/test-templates.md`.
+
+## Failure modes / debugging
+
+- **Nothing registers at runtime.** `jetpack_wp_abilities_enabled` defaults to `false`. Tests must filter it true (`Filters\expectApplied('jetpack_wp_abilities_enabled')->andReturn(true)`), and live sites need to opt in via a feature flag, option, or site-specific filter.
+- **The class loads but hooks don't fire.** You're loading the file too late — after `wp_abilities_api_init` has already fired — and you also skipped `Registrar::init()`'s late-load path by overriding `init()`. Don't override `init()`; let the base class run.
+- **You see the legacy manual-hook pattern elsewhere** (e.g. `projects/plugins/jetpack/src/abilities/class-modules-abilities.php`, `projects/packages/forms/src/abilities/class-forms-abilities.php`). These predate the `Registrar` package. Don't copy them. Extend `Registrar` and implement the three abstract methods.
+- **Module-backed ability landed in `projects/plugins/jetpack/src/abilities/` and is wired from `class.jetpack.php`** (the PR #48284 pattern). Colocation lint will catch this. The ability loads on every request regardless of module state, pollutes the API surface when the module is off, and pays autoload cost for nothing. Move the file into `modules/<slug>/abilities/` and wire from `modules/<slug>.php`.
+- **Adding `if ( Jetpack::is_module_active( '<slug>' ) )` around the `::init()` call in `class.jetpack.php`.** Better than not guarding, but still wrong — you're re-implementing what `load_modules()` does for free. Move the wiring into the module file instead.
+- **Duplicate `category` in a spec.** Silent smell — `Registrar` injects the slug when missing. Setting `'category' => self::CATEGORY_SLUG` in each spec is redundant and drifts.
+- **Annotation mismatch** (`readonly: true` on a writer, `destructive: false` on a deleter). `wp-abilities-verify` is the source of truth; this skill doesn't re-check annotation correctness.
+- **Description is a label, not a spec.** `"Activate a module."` tells the agent nothing. Rewrite to include return shape, idempotency, preconditions, and which abilities typically precede or follow. See `references/agent-ergonomics.md`.
+- **Raw backing-object dump in the response.** Returning `Jetpack::get_module()` verbatim, a full `WP_Post`, or a REST controller payload unadapted leaks internal fields the agent can't use and wastes context. Summarize to the shape the agent actually consumes.
+- **Unbounded list response.** A `list-*` / `get-*s` read with no `per_page` or `limit` ceiling is a latent OOM on the agent side. Cap at ~100 items, paginate past that.
+- **Composer autoload out of date** after adding a new class → `composer dump-autoload` inside the host project. If the `Registrar` base class itself isn't found, step 9 was skipped; run `composer update automattic/jetpack-wp-abilities` (or `composer install`).
+- **Reaching for `require_once` to "fix" class-not-found.** Don't. The Jetpack plugin uses classmap autoload on `src/`; packages use PSR-4. Both are regenerated by `composer dump-autoload`. Adding a manual `require_once` patches the symptom but leaves the autoloader broken — future tests, REST dispatch, and CLI commands will all fail the same way until the autoloader is rebuilt.
+- **CI fails with "lockfile out of date"** → step 14 was skipped. Commit the updated `composer.lock` for the host project.
+- **CI fails with "Invalid type" on the changelog entry.** Step 11 was bypassed by hand-writing the file instead of using `vendor/bin/changelogger add`. Delete the entry, re-run the `changelogger add` command, then `changelogger validate` — the tool knows which types the host project accepts.
+- **`/simplify` suggests deleting the `get_abilities()` method or inlining `Registrar::init()`.** Reject. These are abstract-contract methods; removing them breaks the subclassing relationship and every Registrar-wiring test.
+- **`/jetpack-review-pr` flags "inconsistent error codes."** Cross-link `wp-abilities-api/references/error-code-vocabulary.md` and update the codes to match the `<plugin>_*` vocabulary. Don't argue — the vocabulary is cross-plugin contract.
+- **`did_action()` returning 0 in unit tests** where you expected the action to be fired. Package tests with Brain Monkey need `Functions\when('did_action')->justReturn(0)` (or an alias that returns the action you care about). Plugin tests using `WorDBless\BaseTestCase` need to simulate the action manually — see the `simulate_doing_wp_abilities_*_action()` helpers in `projects/packages/forms/tests/php/abilities/Forms_Abilities_Test.php`.
+
+## Escalation
+
+- When the ability surface needs a new WordPress capability or a new backend endpoint, stop and open a discussion — don't invent caps or endpoints as part of shipping abilities.
+- When the grouping is ambiguous (is this one ability with filters or three separate ones?), invoke `wp-abilities-audit` to produce an audit document first, then come back here.
+- When the abilities wrap an existing REST controller through a shared API client, read `wp-abilities-api/references/delegate-helper-pattern.md` and `wp-abilities-api/references/plugin-family-patterns.md` to pick Pattern A (shared-API-client) vs Pattern B (zero-arg controllers).
+- For canonical details on the base class and its lifecycle, read `projects/packages/wp-abilities/src/class-registrar.php` and `projects/packages/wp-abilities/tests/php/RegistrarTest.php`.

--- a/.agents/skills/ship-wp-ability/references/agent-ergonomics.md
+++ b/.agents/skills/ship-wp-ability/references/agent-ergonomics.md
@@ -1,0 +1,111 @@
+# Agent ergonomics — writing abilities agents actually want to call
+
+Source: Anthropic's ["Writing tools for agents"](https://www.anthropic.com/engineering/writing-tools-for-agents) guidance, applied to the WP Abilities API surface. Abilities are tools. Agents read them token-by-token from a single context window, pick one, call it, and spend more tokens parsing the response. Every byte costs.
+
+Use this alongside `consolidation-heuristic.md` — that file answers *how many abilities*; this one answers *what goes inside each one*.
+
+## Think in workflows, not REST endpoints
+
+> **Anti-pattern:** *"tools that merely wrap existing software functionality or API endpoints — whether or not the tools are appropriate for agents."*
+
+Before spec'ing an ability, ask: **what task is the agent trying to accomplish?** If the answer requires chaining `get-X`, `list-Y`, `get-Z`, and then `do-thing`, you haven't built an ability — you've built a REST client binding. Build the high-leverage compound:
+
+- `schedule-event` (find availability + create event) beats `list-users` + `list-events` + `create-event`.
+- `get-customer-context` (recent orders + open tickets + last contact) beats `get-customer` + `list-orders` + `list-tickets`.
+- `set-module-status` (check current + transition if needed + return change) beats `get-module` + `activate-module` + `deactivate-module`.
+
+Wrap the agent's *intent*, not the *REST controller*.
+
+## Descriptions are specs, not labels
+
+> *"Write as if explaining to a new team member, making implicit context explicit."*
+
+- Bad: `'description' => __( 'Activate a module.', ... )`.
+- Good: `'description' => __( 'Activate a Jetpack module by slug. Returns { slug, active, changed }. Idempotent — already-active modules return changed=false. Requires a Jetpack connection; modules that require a paid plan will fail with jetpack_modules_activate_failed and should be retried only after the plan is upgraded.', ... )`.
+
+Include:
+- **Return shape** in words (fields, types, when empty).
+- **Idempotency / side-effect** language (even if also in `meta.annotations`).
+- **Required preconditions** (connection, plan, capability, setting).
+- **Relationship hints** — what other abilities are typically called before or after.
+- **Vocabulary definitions** — if the ability uses a term of art (`slug`, `feature tag`, `response status`), define it inline the first time.
+
+Descriptions are what the agent reads at decision time. The agent has no docs.
+
+## Parameter names are contracts
+
+- **Semantic over generic.** `module_slug` or just `slug` in a `jetpack-modules/*` namespace is fine; `value` or `name` is not.
+- **No overloading.** A parameter called `filter` that accepts both a string and an array, or means "filter" sometimes and "search" others, is a trap. Split it.
+- **`additionalProperties: false`** on every input schema. Typos become errors with actionable messages instead of silent no-ops.
+- **Required only what's truly required.** Optional filters should be optional. Don't force the agent to pass `{ include: null }`.
+
+## Response shapes: high signal, semantic IDs, stable contract
+
+> *"Return only high signal information back to agents."* + *"Merely resolving arbitrary alphanumeric UUIDs to more semantically meaningful and interpretable language... significantly improves Claude's precision."*
+
+Rules:
+
+- **High-signal only.** Cut `mime_type`, internal `_meta`, numeric DB ids agents can't act on, and every field the agent's next likely call won't consume. Every field costs context.
+- **Prefer human-readable identifiers.** Module `slug` beats `term_id`. Post `slug` beats `post->ID` when both are stable.
+- **Same shape every call.** Never return a summary when called one way and a detail object when called another. Use an optional filter param for verbosity (below), not input-dependent shape-shifting.
+- **Sort deterministically.** Agents do diff-based reasoning; unstable ordering forces them to sort client-side or re-query.
+
+### The `response_format` pattern
+
+When there's genuine demand for both concise and detailed output, expose the choice — don't branch on unrelated inputs:
+
+```php
+'response_format' => array(
+    'type'        => 'string',
+    'enum'        => array( 'concise', 'detailed' ),
+    'default'     => 'concise',
+    'description' => __( 'concise returns slug, name, active. detailed adds plan requirements, feature tags, connection state.', 'jetpack' ),
+),
+```
+
+The execute callback branches on this; the output_schema documents both shapes via `oneOf`. Agents pick what they need.
+
+## Pagination and token ceilings
+
+> *"Implement pagination, range selection, filtering with sensible default parameter values."* + Claude Code defaults to 25,000 token response limits.
+
+Even if the underlying data is small today, it won't stay small. On every list-shaped read:
+
+- Accept `page` + `per_page`, or a `limit` + `cursor` pair.
+- Set `per_page` `default` to ~20 and `maximum` to 100. Document both in the schema.
+- In the callback, enforce the maximum — never trust schema validation alone.
+- When the response is truncated, include `{ has_more: true, next_cursor: '...' }` or `{ total: N, returned: M }` so the agent knows to paginate.
+
+For modules specifically (~30 items), full lists are fine today. For Forms responses, Stats, Subscribers — paginate from day one.
+
+## Errors that guide the next call
+
+> *"Clearly communicate specific and actionable improvements."* Errors are how you steer the agent away from dead-ends.
+
+- **Code** uses the shared vocabulary (`<plugin>_missing_<field>`, `<plugin>_invalid_<field>`, `<plugin>_not_initialized`, `<plugin>_<resource>_data_unavailable`) — see `wp-abilities-api/references/error-code-vocabulary.md`.
+- **Message** tells the agent *what to do next*. Not `"Invalid input."` → `"Unknown Jetpack module slug. Call jetpack-modules/get-modules to enumerate available slugs."` Note the cross-ability hint.
+- **Never return stack traces or PHP warnings** — they're noise that crowds out actionable signal.
+- **For transient failures** (network, rate limit, plan-upgrade-in-progress), say so — agents can retry with backoff when they know it's transient.
+
+## Anti-patterns specific to WP Abilities
+
+1. **Returning `$mod` verbatim from `Jetpack::get_module()`** — it's a dump of internal fields (`module_tags`, `changelog URL`, plan classes) most agents ignore. Summarize.
+2. **Returning full `WP_Post` objects** — `post_content_filtered`, `post_password`, `to_ping`, `guid` are noise. Build a summary.
+3. **Exposing raw option keys** (`jetpack_options[registered]`) — opaque and schema-less.
+4. **Letting REST schema leak through** — the Abilities input schema should be tailored to agent intent, not a copy of the backing controller's schema. Rename, drop, and default aggressively.
+5. **UUID-shaped IDs when a slug works** — `a1b2c3d4-...` is three times the tokens of `contact-form`.
+6. **Two abilities that differ only by verb** (activate/deactivate, enable/disable) — consolidate into one `set-<attribute>` with a required state param (see `consolidation-heuristic.md`).
+7. **Abilities named after REST endpoints** (`get-jp-v2-modules`) instead of agent intent (`get-modules`).
+8. **Optional parameters that behave differently when absent vs `null` vs empty string** — the Abilities API doesn't inject defaults; normalize at the top of every execute callback.
+
+## Checklist before you finalize each ability
+
+- [ ] The description reads like onboarding docs for a new engineer — return shape, idempotency, preconditions, related abilities.
+- [ ] Parameter names are semantic within the namespace and unambiguous across abilities.
+- [ ] `additionalProperties: false` on the input schema.
+- [ ] Output is high-signal — every field answers a question the agent will ask.
+- [ ] Identifiers are human-readable (slug, name) over opaque (UUID, numeric DB id) where both are stable.
+- [ ] Lists paginate by default or are provably bounded forever.
+- [ ] Error codes follow the shared vocabulary and error messages tell the agent what to do next, not just what went wrong.
+- [ ] No REST controller response shape leaks through unadapted.
+- [ ] The ability wraps the agent's intent, not an underlying API method.

--- a/.agents/skills/ship-wp-ability/references/class-skeleton.md
+++ b/.agents/skills/ship-wp-ability/references/class-skeleton.md
@@ -1,0 +1,340 @@
+# Registrar subclass skeleton
+
+Two templates below — one for the plugin context (class lives under `projects/plugins/jetpack/src/abilities/`) and one for the package context (class lives under `projects/packages/<pkg>/src/abilities/`). The shape is identical; the namespace root differs.
+
+Each template shows one **read** ability and one **write** ability so the annotation and permission contrasts are visible. Both demonstrate the consolidated shape — a filtered `get-<objects>` with optional single-id filter, and a declarative `set-<object>-<attribute>` state-setter. See `references/consolidation-heuristic.md` for why; don't split these into `list-` / `get-` / `activate-` / `deactivate-` atomic variants. Before copying the template, read `references/agent-ergonomics.md` for description, response-shape, pagination, and error-message guidance — the template gives you the skeleton; ergonomics makes it worth calling.
+
+Canonical reference for the base class: `projects/packages/wp-abilities/src/class-registrar.php`. Canonical fixture examples: the `TestFixtureRegistrar`, `TestExplicitCategoryRegistrar`, and `TestEmptyRegistrar` classes at the bottom of `projects/packages/wp-abilities/tests/php/RegistrarTest.php`.
+
+## What `Registrar` does for you
+
+Do not re-implement any of this in the subclass:
+
+- **Top-level feature gate** — reads `apply_filters( 'jetpack_wp_abilities_enabled', false )`. Default false: abilities roll out gradually, not on every site the moment the package loads.
+- **Lifecycle hooks** — wires `wp_abilities_api_categories_init` and `wp_abilities_api_init`. Also handles the late-load case: if either action has already fired by the time `init()` is called, the corresponding registration runs synchronously rather than hooking.
+- **Per-category / per-ability allow-listing** — every registration passes through `apply_filters( 'jetpack_wp_abilities_should_register', true, $type, $slug )` so site owners can gate individual slugs.
+- **WP < 6.9 compatibility** — guards every call to `wp_register_ability_category()` and `wp_register_ability()` with `function_exists()`.
+- **Category auto-injection** — if a spec in `get_abilities()` omits the `category` key, the base class injects `get_category_slug()`. Don't set `category` manually.
+
+The subclass just needs the three abstract getters plus execute + permission callbacks.
+
+## Plugin-context template
+
+Path: `projects/plugins/jetpack/src/abilities/class-<name>-abilities.php`
+
+```php
+<?php
+/**
+ * Jetpack <Domain> Abilities Registration
+ *
+ * Registers Jetpack <domain-label> abilities with the WordPress Abilities API.
+ *
+ * @package automattic/jetpack
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9; suppressions needed for older-WP compatibility runs.
+
+namespace Automattic\Jetpack\Plugin\Abilities;
+
+use Automattic\Jetpack\WP_Abilities\Registrar;
+
+/**
+ * Registers Jetpack <domain-label> abilities with the WordPress Abilities API.
+ *
+ * Exposes <one-line summary of what the abilities do> so AI agents can
+ * <read/manage> <domain-label> through the standard `wp-abilities/v1` REST
+ * surface.
+ */
+class <Name>_Abilities extends Registrar {
+
+	public static function get_category_slug(): string {
+		return 'jetpack-<name>';
+	}
+
+	public static function get_category_definition(): array {
+		return array(
+			// "Jetpack" is a product name and should not be translated.
+			'label'       => 'Jetpack <Domain-Label>',
+			'description' => __( 'Abilities for <one-line purpose>.', 'jetpack' ),
+		);
+	}
+
+	public static function get_abilities(): array {
+		// One consolidated read + one declarative write. See references/consolidation-heuristic.md.
+		$object_schema = array(
+			'type'       => 'object',
+			'properties' => array(
+				'id'     => array( 'type' => 'string' ),
+				'name'   => array( 'type' => 'string' ),
+				'status' => array( 'type' => 'string' ),
+			),
+		);
+
+		return array(
+			// Consolidated read: slug/id is an OPTIONAL filter that returns a 0- or 1-element array.
+			// Do NOT add a second `get-<object>` ability — the single-id case is handled here.
+			'jetpack-<name>/get-<objects>' => array(
+				'label'               => __( 'Get <objects>', 'jetpack' ),
+				'description'         => __( 'Return zero or more <objects> as an array. Combine id/status/search filters to narrow the result. When id is provided, returns at most one element.', 'jetpack' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'default'              => array(),
+					'properties'           => array(
+						'id'     => array(
+							'type'        => 'string',
+							'description' => __( 'Return a single <object> by id. Unknown ids yield an empty array.', 'jetpack' ),
+							'minLength'   => 1,
+						),
+						'status' => array(
+							'type'        => 'string',
+							'description' => __( 'Filter by status.', 'jetpack' ),
+							'enum'        => array( 'active', 'inactive' ),
+						),
+						'search' => array(
+							'type'        => 'string',
+							'description' => __( 'Case-insensitive substring match against name.', 'jetpack' ),
+							'minLength'   => 1,
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'  => 'array',
+					'items' => $object_schema,
+				),
+				'execute_callback'    => array( __CLASS__, 'get_<objects>' ),
+				'permission_callback' => array( __CLASS__, 'can_view_<objects>' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+
+			// Declarative write: `set-<object>-<attribute>`, required state param, idempotent.
+			// Do NOT ship a symmetric verb pair (activate/deactivate, enable/disable) — merge here.
+			'jetpack-<name>/set-<object>-status' => array(
+				'label'               => __( 'Set <object> status', 'jetpack' ),
+				'description'         => __( 'Set the status of a single <object>. Idempotent: setting a <object> to its current status returns changed=false.', 'jetpack' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'required'             => array( 'id', 'status' ),
+					'properties'           => array(
+						'id'     => array(
+							'type'        => 'string',
+							'description' => __( 'Identifier of the <object>.', 'jetpack' ),
+							'minLength'   => 1,
+						),
+						'status' => array(
+							'type'        => 'string',
+							'description' => __( 'Desired status.', 'jetpack' ),
+							'enum'        => array( 'active', 'inactive' ),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'id'      => array( 'type' => 'string' ),
+						'status'  => array( 'type' => 'string' ),
+						'changed' => array( 'type' => 'boolean' ),
+					),
+				),
+				'execute_callback'    => array( __CLASS__, 'set_<object>_status' ),
+				'permission_callback' => array( __CLASS__, 'can_manage_<objects>' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+		);
+	}
+
+	/**
+	 * Permission check for read abilities.
+	 */
+	public static function can_view_<objects>(): bool {
+		return current_user_can( 'jetpack_admin_page' );
+	}
+
+	/**
+	 * Permission check for write abilities.
+	 */
+	public static function can_manage_<objects>(): bool {
+		return current_user_can( 'jetpack_manage_modules' )
+			&& current_user_can( 'jetpack_activate_modules' );
+	}
+
+	/**
+	 * Execute: unified read. Returns a 0- or 1-element array when `id` is provided,
+	 * or the full filtered list otherwise. Shape is the same either way.
+	 *
+	 * @param array|null $input Input matching the ability's input_schema.
+	 * @return array
+	 */
+	public static function get_<objects>( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		// Single-id short-circuit.
+		if ( isset( $input['id'] ) && is_string( $input['id'] ) && '' !== $input['id'] ) {
+			$one = self::fetch_one_<object>( $input['id'] );
+			return null === $one ? array() : array( $one );
+		}
+
+		// Full filtered list.
+		$status_filter = isset( $input['status'] ) && is_string( $input['status'] ) && '' !== $input['status']
+			? $input['status']
+			: null;
+		$search_filter = isset( $input['search'] ) && is_string( $input['search'] ) && '' !== $input['search']
+			? mb_strtolower( $input['search'] )
+			: null;
+
+		$out = array();
+		foreach ( self::fetch_all_<object>_ids() as $id ) {
+			$one = self::fetch_one_<object>( $id );
+			if ( null === $one ) {
+				continue;
+			}
+			if ( null !== $status_filter && $one['status'] !== $status_filter ) {
+				continue;
+			}
+			if ( null !== $search_filter
+				&& false === mb_strpos( mb_strtolower( $one['name'] ), $search_filter )
+			) {
+				continue;
+			}
+			$out[] = $one;
+		}
+		return $out;
+	}
+
+	/**
+	 * Execute: declarative state-setter. Idempotent — compares desired vs current.
+	 *
+	 * @param array|null $input Input matching the ability's input_schema.
+	 * @return array|\WP_Error
+	 */
+	public static function set_<object>_status( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		// Required-id validation: not empty(), so "0" remains a legal id.
+		if ( ! isset( $input['id'] ) || ! is_string( $input['id'] ) || '' === $input['id'] ) {
+			return new \WP_Error(
+				'jetpack_<name>_missing_id',
+				__( 'A <object> id is required.', 'jetpack' )
+			);
+		}
+		if ( ! isset( $input['status'] ) || ! is_string( $input['status'] ) ) {
+			return new \WP_Error(
+				'jetpack_<name>_missing_status',
+				__( 'A desired status is required.', 'jetpack' )
+			);
+		}
+
+		$id      = $input['id'];
+		$desired = $input['status'];
+		$current = self::fetch_current_status( $id ); // string|null
+
+		if ( null === $current ) {
+			return new \WP_Error(
+				'jetpack_<name>_invalid_id',
+				__( 'Unknown <object>.', 'jetpack' )
+			);
+		}
+
+		if ( $desired === $current ) {
+			return array(
+				'id'      => $id,
+				'status'  => $current,
+				'changed' => false,
+			);
+		}
+
+		// ... domain logic to transition from $current to $desired ...
+
+		return array(
+			'id'      => $id,
+			'status'  => $desired,
+			'changed' => true,
+		);
+	}
+}
+```
+
+## Package-context template
+
+Path: `projects/packages/<pkg>/src/abilities/class-<name>-abilities.php`
+
+Only two things change from the plugin template:
+
+1. **Namespace** — `Automattic\Jetpack\<Pkg>\Abilities` instead of `Automattic\Jetpack\Plugin\Abilities`.
+2. **Text domain** — the package's text domain (`jetpack-forms`, `jetpack-boost`, ...) instead of `jetpack`.
+
+```php
+<?php
+/**
+ * Jetpack <Pkg> <Domain> Abilities Registration
+ *
+ * @package automattic/jetpack-<pkg>
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Ability API added in WP 6.9.
+
+namespace Automattic\Jetpack\<Pkg>\Abilities;
+
+use Automattic\Jetpack\WP_Abilities\Registrar;
+
+class <Name>_Abilities extends Registrar {
+
+	public static function get_category_slug(): string {
+		return 'jetpack-<pkg>';
+	}
+
+	public static function get_category_definition(): array {
+		return array(
+			'label'       => 'Jetpack <Pkg-Label>',
+			'description' => __( 'Abilities for <one-line purpose>.', 'jetpack-<pkg>' ),
+		);
+	}
+
+	public static function get_abilities(): array {
+		return array(
+			// ... same spec shape as plugin template ...
+		);
+	}
+
+	// ... same permission + execute methods as plugin template ...
+}
+```
+
+## Wiring template
+
+Add one line to the host project's bootstrap (`class.jetpack.php` for the plugin, `Jetpack_<Pkg>::init_boot()` or equivalent for packages):
+
+```php
+\Automattic\Jetpack\Plugin\Abilities\<Name>_Abilities::init();
+```
+
+**Do not add a `require_once`.** The Jetpack plugin's `composer.json` uses `"autoload": { "classmap": ["src"] }`, which means Composer's classmap autoloader picks up every class under `projects/plugins/jetpack/src/` once `composer dump-autoload` has been run. Packages use PSR-4 autoload and behave the same way — the namespace-to-path mapping is enough.
+
+If you see an older `require_once JETPACK__PLUGIN_DIR . 'src/abilities/class-<x>-abilities.php';` line next to an existing `::init()` call (e.g. `class.jetpack.php:758` for `Modules_Abilities`), it's redundant with the classmap and exists only to survive a stale autoloader. The correct fix for "class not found" after adding a new file is `composer dump-autoload`, not a `require_once` line.
+
+## Anti-patterns to avoid
+
+- **Don't write your own `init()` method.** `Registrar::init()` owns the lifecycle. Overriding it loses the filter gate, the `did_action()` late-load path, and the per-ability allow-list filter.
+- **Don't add a `CATEGORY_SLUG` class constant just to reuse it in each spec.** `get_category_slug()` is the single source; base class auto-injects.
+- **Don't set `'category' => self::CATEGORY_SLUG` on each ability spec.** Redundant with auto-injection.
+- **Don't copy `projects/plugins/jetpack/src/abilities/class-modules-abilities.php` or `projects/packages/forms/src/abilities/class-forms-abilities.php` as a starting point.** Both predate `Registrar` and use the manual `add_action`/`did_action` pattern. Extend `Registrar` instead.
+- **Don't rely on `input_schema` `default` values being present in `$input`.** The Abilities API does not inject them. Normalize at the top of each execute callback.
+- **Don't use `empty()` to validate required string IDs.** `empty('0')` is true; the literal `'0'` is a legal ID string. Use `isset() && is_string() && '' !== $value`.
+- **Don't ship `list-<objects>` + `get-<object>` as separate abilities.** Merge into one filtered `get-<objects>` with optional id. See `references/consolidation-heuristic.md`.
+- **Don't ship verb pairs** (`activate-*` + `deactivate-*`, `enable-*` + `disable-*`, `publish-*` + `unpublish-*`). Merge into one `set-*-status` with a required state parameter. Always idempotent (no-op when desired == current).
+- **Don't switch output shapes based on input** — an ability that returns a summary when called one way and a detail object when called another way is a trap. Pick one shape and stick with it; use an `expand`/`include` filter if you genuinely need two depths.

--- a/.agents/skills/ship-wp-ability/references/consolidation-heuristic.md
+++ b/.agents/skills/ship-wp-ability/references/consolidation-heuristic.md
@@ -1,0 +1,83 @@
+# Consolidation heuristic — fewer, more powerful abilities
+
+The default temptation when shipping abilities is to mirror the REST or admin surface one-to-one: one ability per CRUD verb, one per state transition, one per filter. Resist it. Agents benefit from **fewer, more capable abilities** over many atomic ones.
+
+## Why consolidate
+
+- **Fewer slugs to remember.** Every ability is a name and a shape the agent has to know. Halving the count halves the mental overhead.
+- **One call, multiple filters.** Combining filters in a single ability avoids list-then-filter round-trips over REST.
+- **Declarative writes beat verb pairs.** `set-module-status` with `{slug, active}` is symmetric, idempotent, and self-documenting. `activate-module` + `deactivate-module` is two slugs for the same state concept.
+- **Consistent return shapes.** One shape per ability makes the agent's downstream reasoning tractable. Shape-changing based on input is a trap.
+
+## The two consolidation moves
+
+### Move 1: Collapse list + detail into a filtered read
+
+If you have `list-<objects>` and `get-<object>` as separate abilities, merge them.
+
+- Name the merged ability `get-<objects>` (plural).
+- Add `slug` (or `id`) as an **optional** filter. Present → return a 0- or 1-element array. Absent → return the full filtered list.
+- Add the other useful filters in the same schema: `active`, `status`, `feature`, `search`, `parent`, date ranges.
+- **Always return an array of the same object shape.** Don't switch between "summary" and "detail" shapes based on input — that's the shape-changing trap.
+
+If agents genuinely need a richer "detail" shape (headers, plan requirements, diagnostics), add an `expand` or `include` input param; don't split into a second ability.
+
+### Move 2: Replace verb pairs with declarative state-setters
+
+If you have `<verb>-<object>` + `<anti-verb>-<object>` (activate/deactivate, publish/unpublish, enable/disable, open/close), merge them.
+
+- Name the merged ability `set-<object>-<attribute>` (e.g. `set-module-status`, `set-post-visibility`, `set-subscription-state`).
+- Make the state param **required** (`active: bool`, `status: 'published'|'draft'`, `visibility: 'public'|'private'`).
+- Make it **idempotent**: compare desired vs current. If equal, return `changed: false` with the current state. If different, transition and return `changed: true`.
+- Output shape is the same whether or not a change happened.
+
+## Worked example — `Modules_Abilities`
+
+**Before: 4 abilities**
+
+```
+jetpack-modules/list-modules       input: { active_only?: bool }
+jetpack-modules/get-module         input: { slug: string (required) }
+jetpack-modules/activate-module    input: { slug: string (required) }
+jetpack-modules/deactivate-module  input: { slug: string (required) }
+```
+
+Problems:
+- `list-modules` only filters on one boolean. If the agent wants "active Security-tagged modules matching 'share'", it takes three round-trips.
+- `get-module` duplicates the list's object shape but for N=1.
+- `activate` + `deactivate` are a classic verb pair; agents have to branch on intent instead of describing the desired state.
+
+**After: 2 abilities**
+
+```
+jetpack-modules/get-modules        input: { slug?, active?, feature?, search? }
+                                   output: array of module objects (0..N)
+
+jetpack-modules/set-module-status  input: { slug: required, active: required }
+                                   output: { slug, active, changed }
+```
+
+Gains:
+- 50% fewer slugs.
+- Any combination of filters in one call.
+- Declarative, idempotent writes: `set-module-status({slug: 'stats', active: true})` is a no-op if already active, a transition otherwise.
+- Same return shape on every call.
+
+Lose nothing except the bespoke detail-shape for `get-module` (which was already misaligned with its declared schema anyway).
+
+## When NOT to consolidate
+
+- **Different permission contracts.** Read and write have different `permission_callback`s — never merge them into one ability with a `mode` switch; you'll violate the `meta.annotations.readonly` contract.
+- **Different side-effect classes.** Don't merge a cache-invalidation trigger with a data write; one is destructive, one isn't, and `meta.annotations.destructive` has to match.
+- **Unrelated domains.** `set-module-status` and `set-module-config` are both writes on modules, but they touch different state — keep them separate.
+- **Genuinely different shapes.** If the "detail" variant returns fundamentally different fields (not just a superset), separate abilities are honest. The Modules case didn't meet this bar.
+
+## Checklist before you finalize `get_abilities()`
+
+- [ ] Did you combine `list-X` and `get-X` into `get-Xs` with optional slug/id?
+- [ ] Did you combine `<verb>` + `<anti-verb>` pairs into `set-X-<attribute>`?
+- [ ] Is every read's return shape the same regardless of which filter is present?
+- [ ] Is every write idempotent (no-op when desired == current)?
+- [ ] Could a downstream agent answer 80% of its questions in one call per ability?
+
+If the answer to any of the first four is "no" and you don't have a listed exception above, merge further.

--- a/.agents/skills/ship-wp-ability/references/module-colocation.md
+++ b/.agents/skills/ship-wp-ability/references/module-colocation.md
@@ -1,0 +1,100 @@
+# Module colocation — where the ability code lives
+
+Abilities must live **with the feature they expose**. An ability for the Monitor module loads only when Monitor is active; an ability for the Forms package loads with the Forms package; an always-on ability (one that manages modules themselves) lives in the plugin's core `src/`. Putting a module-backed ability in the plugin's global `src/abilities/` tree and wiring it unconditionally in `class.jetpack.php` — as PR [#48284](https://github.com/Automattic/jetpack/pull/48284) did for Monitor — loads that code even when the module is deactivated, pollutes the Abilities API surface with operations the user can't perform, and is the canonical anti-pattern this reference exists to prevent.
+
+## The three cases
+
+Walk this decision tree **before** step 4 of the skill.
+
+### Case A — Module-backed ability (most common)
+
+The ability wraps a Jetpack module (`monitor`, `stats`, `subscriptions`, `likes`, `vaultpress`, `search`, `related-posts`, ...). The module is a flat file at `projects/plugins/jetpack/modules/<slug>.php` (possibly with a companion directory `modules/<slug>/`). Jetpack's `load_modules()` only includes the module file when the module is active.
+
+**File location:** inside the module's directory.
+
+- Small ability (one class): `projects/plugins/jetpack/modules/<slug>/abilities/class-<slug>-abilities.php` (create the directory if the module doesn't have one yet).
+- Tiny ability (dozen lines): inline at the bottom of `modules/<slug>.php` is acceptable.
+
+**Wiring:** from inside the module file (or the module's main class constructor / `init()`). Never from `class.jetpack.php`.
+
+```php
+// projects/plugins/jetpack/modules/<slug>.php, at the bottom:
+
+require_once __DIR__ . '/<slug>/abilities/class-<slug>-abilities.php';
+\Automattic\Jetpack\Plugin\Abilities\<Slug>_Abilities::init();
+```
+
+Because the module file is only included when the module is active, the ability registrar only runs when the module is active. No `Jetpack::is_module_active()` guard is needed.
+
+**Test:** add the activation-gating assertion from `test-templates.md` — the ability class must not even be loadable outside the module's load path.
+
+### Case B — Package-backed feature
+
+The feature lives in its own Composer package under `projects/packages/<pkg>/` (Forms, Boost, Search, Stats-CLI, etc.). The package has its own bootstrap class; it's loaded via Composer autoload when the consumer plugin requires it.
+
+**File location:** `projects/packages/<pkg>/src/abilities/class-<name>-abilities.php`.
+
+**Wiring:** from the package's own bootstrap — whatever method is already the entry point for that package's runtime (e.g. `Contact_Form_Plugin::init()` for Forms, `Jetpack_Boost::init()` for Boost). Never from the consumer plugin's `class.jetpack.php`.
+
+Package-level features typically already gate themselves on "is this package meant to run right now?" via the consumer plugin's load sequence, so additional module-active guards are usually unnecessary. If the package ships as both a module and a standalone plugin, the package's own bootstrap is the right place for any gating.
+
+### Case C — Plugin-core / always-on ability
+
+The ability is about the plugin itself, not any specific module: enumerating modules, reading connection status, fetching plugin version. `Modules_Abilities` is the canonical example — it manages the module system, so it can't live inside any one module.
+
+**File location:** `projects/plugins/jetpack/src/abilities/class-<name>-abilities.php`.
+
+**Wiring:** one line in `class.jetpack.php`, loaded unconditionally (subject to the `jetpack_wp_abilities_enabled` feature gate `Registrar::init()` already applies).
+
+Use this case **only** when the ability genuinely doesn't belong to any module or package. When in doubt, it's Case A.
+
+## Anti-patterns
+
+1. **Module ability in `src/abilities/` with unconditional wiring in `class.jetpack.php`.** Loads and registers the ability even when the module is inactive. PR #48284's Monitor placement is the live example.
+2. **Module ability in `src/abilities/` with an `is_module_active()` guard.** Better than (1) but still wrong — the file is still loaded on every request, every request pays the autoload cost, and the test harness has to mock the module-activation check. Colocate inside the module instead; the module's own load gate does the work for free.
+3. **Package ability in `projects/plugins/jetpack/src/abilities/`.** Couples the plugin to package internals; breaks when the package is used by a non-plugin consumer (standalone package, different host plugin).
+4. **Multiple modules' abilities in one shared file.** Each module's abilities stay with that module. A shared file couples their load timing and breaks colocation.
+
+## What the skill enforces
+
+- **Step 4** (Pick the category and file path) forces the decision above — module vs package vs plugin-core — before a file path is chosen.
+- **Step 8** (Wire into the host) wires based on case:
+  - Case A → line inside `modules/<slug>.php` (or the module's main class init).
+  - Case B → line inside the package's existing bootstrap method.
+  - Case C → line inside `class.jetpack.php`.
+- **Tests** (`references/test-templates.md`) include an activation-gating assertion for Case A: when the module file has not been loaded, `Registrar::init()` must register nothing. The test proves the ability can't leak into the REST surface when the module is off.
+- **Verification** runs a grep-based colocation lint (see next section) to catch any regression that puts module-backed code into `src/abilities/`.
+
+## Colocation lint
+
+Run from the host project root after wiring and tests:
+
+```bash
+# 1. No module-backed ability should live in src/abilities/ unless it's Case C.
+#    Flag anything in src/abilities/ whose class name is <Module>_Abilities
+#    where <module> also exists as a Jetpack module file.
+find projects/plugins/jetpack/src/abilities -maxdepth 1 -type f -name 'class-*-abilities.php' 2>/dev/null |
+  while read -r f; do
+    base=$(basename "$f" | sed 's/^class-\(.*\)-abilities\.php$/\1/')
+    if [ -f "projects/plugins/jetpack/modules/${base}.php" ]; then
+      echo "COLOCATION FAIL: $f is a module-backed ability; move to modules/${base}/abilities/ and wire from modules/${base}.php"
+    fi
+  done
+
+# 2. class.jetpack.php must not init any module-backed <Module>_Abilities class.
+#    Any <Slug>_Abilities::init() call in class.jetpack.php whose slug also names
+#    a module is a colocation violation. Class names are snake_case on word
+#    boundaries (Related_Posts_Abilities, Monitor_Abilities), so slug =
+#    lowercase with underscores→dashes.
+grep -oE '[A-Z][A-Za-z_]+_Abilities::init\(\)' projects/plugins/jetpack/class.jetpack.php 2>/dev/null |
+  while read -r call; do
+    slug=$(echo "$call" | sed 's/_Abilities::init()//' | tr '[:upper:]_' '[:lower:]-')
+    if [ -f "projects/plugins/jetpack/modules/${slug}.php" ]; then
+      echo "COLOCATION FAIL: ${slug} is a module; its abilities should init from modules/${slug}.php, not class.jetpack.php"
+    fi
+  done
+```
+
+Both blocks must produce no output. If either prints a `COLOCATION FAIL` line, fix before committing — move the file, re-wire from the module, and re-run tests. Handles both bash and zsh; no-match cases are silent.
+
+This lint is additive to `wp-abilities-verify` (which checks annotation correctness and schema soundness, not colocation). Run both.

--- a/.agents/skills/ship-wp-ability/references/test-templates.md
+++ b/.agents/skills/ship-wp-ability/references/test-templates.md
@@ -1,0 +1,536 @@
+# Test templates for Registrar subclasses
+
+Two templates — one per host-project type. Each template covers the same five assertion groups:
+
+1. **Registrar wiring** — gate filter defaulting false, hook wiring, late-load, per-ability allow-list, category auto-injection. This is the differentiating value-add; a hand-rolled ability class without these assertions is incomplete.
+2. **Module-activation gating (Case A only)** — for module-backed abilities, the ability must not register when the backing module is inactive. Because Case A wires `::init()` from inside `modules/<slug>.php` (which Jetpack only includes for active modules), the assertion is: when `Jetpack::is_module_active()` returns false, `<Name>_Abilities::init()` either never runs OR, if defensively called, registers nothing. See `references/module-colocation.md`.
+2. **Abstract getters** — the three static methods return the expected shapes.
+3. **Permission callbacks** — allowed user returns true; denied user returns false; unauth returns false.
+4. **Execute callbacks** — happy path for each ability.
+5. **Schema edge cases** — missing required, empty-string ID, wrong type.
+
+Canonical references:
+
+- Package-context Brain Monkey patterns: `projects/packages/wp-abilities/tests/php/RegistrarTest.php`
+- Plugin-context WP_UnitTestCase patterns: look for `_Test.php` files under `projects/plugins/jetpack/tests/php/src/`
+- Real-world Abilities test (DB-less): `projects/packages/forms/tests/php/abilities/Forms_Abilities_Test.php`
+
+## Plugin context (`projects/plugins/jetpack/tests/php/src/<Name>_Abilities_Test.php`)
+
+Uses `WP_UnitTestCase` with full WP test environment available. Can create users via `wp_insert_user()` and call `wp_set_current_user()` to exercise permission callbacks end-to-end.
+
+```php
+<?php
+/**
+ * Tests for the <Name>_Abilities Registrar subclass.
+ *
+ * @package automattic/jetpack
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9.
+
+use Automattic\Jetpack\Plugin\Abilities\<Name>_Abilities;
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * @covers \Automattic\Jetpack\Plugin\Abilities\<Name>_Abilities
+ */
+#[CoversClass( <Name>_Abilities::class )]
+class <Name>_Abilities_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/** @var int */
+	private static $admin_id;
+
+	/** @var int */
+	private static $subscriber_id;
+
+	public function set_up() {
+		parent::set_up();
+
+		self::$admin_id = wp_insert_user(
+			array(
+				'user_login' => 'ship_ability_admin_' . wp_generate_password( 8, false ),
+				'user_pass'  => 'pw',
+				'role'       => 'administrator',
+			)
+		);
+		self::$subscriber_id = wp_insert_user(
+			array(
+				'user_login' => 'ship_ability_sub_' . wp_generate_password( 8, false ),
+				'user_pass'  => 'pw',
+				'role'       => 'subscriber',
+			)
+		);
+
+		// Default: gate open for most test cases.
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+	}
+
+	public function tear_down() {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		remove_all_filters( 'jetpack_wp_abilities_should_register' );
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	// -------------------- Abstract getters --------------------
+
+	public function test_category_slug_is_plugin_scoped() {
+		$this->assertSame( 'jetpack-<name>', <Name>_Abilities::get_category_slug() );
+	}
+
+	public function test_category_definition_has_label_and_description() {
+		$def = <Name>_Abilities::get_category_definition();
+		$this->assertArrayHasKey( 'label', $def );
+		$this->assertArrayHasKey( 'description', $def );
+	}
+
+	public function test_abilities_map_is_non_empty_and_namespaced() {
+		$abilities = <Name>_Abilities::get_abilities();
+		$this->assertNotEmpty( $abilities );
+		foreach ( array_keys( $abilities ) as $slug ) {
+			$this->assertStringStartsWith( 'jetpack-<name>/', $slug );
+		}
+	}
+
+	public function test_no_spec_sets_category_explicitly() {
+		// Registrar auto-injects category; specs that set it are redundant and drift.
+		foreach ( <Name>_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertArrayNotHasKey(
+				'category',
+				$spec,
+				"Ability {$slug} should not set its own category — Registrar injects it."
+			);
+		}
+	}
+
+	// -------------------- Registrar wiring --------------------
+
+	public function test_init_registers_nothing_when_gate_filter_is_false() {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+
+		<Name>_Abilities::init();
+
+		$this->assertFalse(
+			has_action( 'wp_abilities_api_categories_init', array( <Name>_Abilities::class, 'register_category' ) )
+		);
+		$this->assertFalse(
+			has_action( 'wp_abilities_api_init', array( <Name>_Abilities::class, 'register_abilities' ) )
+		);
+
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+	}
+
+	public function test_init_hooks_lifecycle_actions_when_gate_is_true() {
+		<Name>_Abilities::init();
+
+		$this->assertNotFalse(
+			has_action( 'wp_abilities_api_categories_init', array( <Name>_Abilities::class, 'register_category' ) )
+		);
+		$this->assertNotFalse(
+			has_action( 'wp_abilities_api_init', array( <Name>_Abilities::class, 'register_abilities' ) )
+		);
+	}
+
+	// -------------------- Module-activation gating (Case A only) --------------------
+	// Drop this block if the ability is Case B (package) or Case C (plugin-core).
+	// For Case A, the ability class lives in modules/<slug>/abilities/ and is wired from
+	// modules/<slug>.php — so the registrar only loads when the module is active.
+
+	public function test_ability_class_is_colocated_with_module() {
+		// The file must live inside the module, not in the plugin-global src/abilities/ tree.
+		$reflector = new \ReflectionClass( <Name>_Abilities::class );
+		$path      = $reflector->getFileName();
+		$this->assertStringContainsString(
+			'/modules/<slug>/',
+			$path,
+			'Module-backed abilities must live inside their module directory, not in src/abilities/. ' .
+				'See .agents/skills/ship-wp-ability/references/module-colocation.md.'
+		);
+		$this->assertStringNotContainsString(
+			'/src/abilities/',
+			$path,
+			'Found a module-backed ability in the plugin-global src/abilities/ tree. Move it into modules/<slug>/abilities/.'
+		);
+	}
+
+	public function test_not_wired_from_class_jetpack_php() {
+		// Scan class.jetpack.php — a module-backed registrar must not be init'd from the plugin bootstrap.
+		$bootstrap = file_get_contents( JETPACK__PLUGIN_DIR . 'class.jetpack.php' );
+		$this->assertStringNotContainsString(
+			'<Name>_Abilities::init()',
+			$bootstrap,
+			'class.jetpack.php must not init a module-backed ability. Wire from modules/<slug>.php instead.'
+		);
+	}
+
+	public function test_registers_nothing_when_module_inactive() {
+		// Simulate the module being deactivated. When Jetpack::is_module_active( '<slug>' ) is false,
+		// Jetpack does not include modules/<slug>.php — so Registrar::init() is never called and
+		// nothing registers. We assert the user-visible outcome: no ability slugs under our namespace.
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
+			$this->markTestSkipped( 'Abilities API not available.' );
+		}
+
+		// Force-deactivate the module for the duration of the test.
+		$previously_active = Jetpack::is_module_active( '<slug>' );
+		if ( $previously_active ) {
+			Jetpack::deactivate_module( '<slug>' );
+		}
+
+		// Do NOT call <Name>_Abilities::init() here — we're simulating Jetpack not loading the module file.
+		// Reset any already-registered abilities from this class (prior test runs may have registered them).
+		foreach ( array_keys( <Name>_Abilities::get_abilities() ) as $slug ) {
+			if ( null !== wp_get_ability( $slug ) && function_exists( 'wp_deregister_ability' ) ) {
+				wp_deregister_ability( $slug );
+			}
+		}
+
+		foreach ( array_keys( <Name>_Abilities::get_abilities() ) as $slug ) {
+			$this->assertNull(
+				wp_get_ability( $slug ),
+				"Ability {$slug} must not be registered when the <slug> module is inactive."
+			);
+		}
+
+		if ( $previously_active ) {
+			Jetpack::activate_module( '<slug>', false, false );
+		}
+	}
+
+	public function test_register_abilities_registers_every_slug() {
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
+			$this->markTestSkipped( 'Abilities API not available.' );
+		}
+
+		<Name>_Abilities::register_category();
+		<Name>_Abilities::register_abilities();
+
+		$registered = array_map(
+			static fn ( $a ) => $a->get_name(),
+			array_filter(
+				wp_get_abilities(),
+				static fn ( $a ) => str_starts_with( $a->get_name(), 'jetpack-<name>/' )
+			)
+		);
+
+		foreach ( array_keys( <Name>_Abilities::get_abilities() ) as $slug ) {
+			$this->assertContains( $slug, $registered, "Ability {$slug} should be registered." );
+		}
+	}
+
+	public function test_per_ability_allow_list_filter_is_respected() {
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
+			$this->markTestSkipped( 'Abilities API not available.' );
+		}
+
+		add_filter(
+			'jetpack_wp_abilities_should_register',
+			static function ( $enabled, $type, $slug ) {
+				if ( 'ability' === $type ) {
+					// Deny every ability.
+					return false;
+				}
+				return $enabled;
+			},
+			10,
+			3
+		);
+
+		<Name>_Abilities::register_category();
+		<Name>_Abilities::register_abilities();
+
+		foreach ( array_keys( <Name>_Abilities::get_abilities() ) as $slug ) {
+			$this->assertNull( wp_get_ability( $slug ), "Ability {$slug} must be filtered out." );
+		}
+	}
+
+	// -------------------- Permission callbacks --------------------
+
+	public function test_can_view_allows_admin() {
+		wp_set_current_user( self::$admin_id );
+		$this->assertTrue( <Name>_Abilities::can_view_<objects>() );
+	}
+
+	public function test_can_view_denies_subscriber() {
+		wp_set_current_user( self::$subscriber_id );
+		$this->assertFalse( <Name>_Abilities::can_view_<objects>() );
+	}
+
+	public function test_can_view_denies_anonymous() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( <Name>_Abilities::can_view_<objects>() );
+	}
+
+	public function test_can_manage_denies_subscriber() {
+		wp_set_current_user( self::$subscriber_id );
+		$this->assertFalse( <Name>_Abilities::can_manage_<objects>() );
+	}
+
+	// -------------------- Execute callbacks --------------------
+
+	public function test_get_<objects>_returns_array() {
+		wp_set_current_user( self::$admin_id );
+		$result = <Name>_Abilities::get_<objects>( array() );
+		$this->assertIsArray( $result );
+	}
+
+	public function test_get_<objects>_with_unknown_id_returns_empty_array() {
+		// Consolidated read: unknown id is a no-match, not an error — agents treat the shape uniformly.
+		wp_set_current_user( self::$admin_id );
+		$result = <Name>_Abilities::get_<objects>( array( 'id' => 'does-not-exist-ever' ) );
+		$this->assertSame( array(), $result );
+	}
+
+	public function test_set_<object>_status_rejects_missing_id() {
+		wp_set_current_user( self::$admin_id );
+		$result = <Name>_Abilities::set_<object>_status( array( 'status' => 'active' ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_<name>_missing_id', $result->get_error_code() );
+	}
+
+	public function test_set_<object>_status_rejects_empty_string_id() {
+		wp_set_current_user( self::$admin_id );
+		$result = <Name>_Abilities::set_<object>_status( array( 'id' => '', 'status' => 'active' ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+	}
+
+	public function test_set_<object>_status_accepts_zero_string_id() {
+		// Regression guard: empty('0') is true, but '0' is a legal ID.
+		wp_set_current_user( self::$admin_id );
+		$result = <Name>_Abilities::set_<object>_status( array( 'id' => '0', 'status' => 'active' ) );
+		$this->assertNotInstanceOf( \WP_Error::class, $result );
+	}
+
+	public function test_set_<object>_status_is_idempotent_for_current_state() {
+		// Declarative writes must no-op when desired == current, returning changed=false.
+		wp_set_current_user( self::$admin_id );
+		$first  = <Name>_Abilities::set_<object>_status( array( 'id' => '<known-id>', 'status' => 'active' ) );
+		$second = <Name>_Abilities::set_<object>_status( array( 'id' => '<known-id>', 'status' => 'active' ) );
+		$this->assertIsArray( $second );
+		$this->assertFalse( $second['changed'], 'Second call with the same desired state must be a no-op.' );
+	}
+}
+```
+
+## Package context (`projects/packages/<pkg>/tests/php/abilities/<Name>AbilitiesTest.php`)
+
+Uses Brain Monkey + Mockery. No WP test env; WP function calls are mocked. Base class is `PHPUnit\Framework\TestCase`. Mirrors `projects/packages/wp-abilities/tests/php/RegistrarTest.php`.
+
+```php
+<?php
+/**
+ * Unit tests for the <Name>_Abilities Registrar subclass.
+ *
+ * @package automattic/jetpack-<pkg>
+ */
+
+namespace Automattic\Jetpack\<Pkg>\Abilities;
+
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use Brain\Monkey;
+use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Automattic\Jetpack\<Pkg>\Abilities\<Name>_Abilities
+ */
+#[CoversClass( <Name>_Abilities::class )]
+class <Name>AbilitiesTest extends TestCase {
+	use \Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/** Enable the top-level gate. */
+	private function enable_abilities(): void {
+		Filters\expectApplied( 'jetpack_wp_abilities_enabled' )->andReturn( true );
+	}
+
+	// -------------------- Abstract getters --------------------
+
+	public function test_category_slug_is_package_scoped(): void {
+		$this->assertSame( 'jetpack-<pkg>', <Name>_Abilities::get_category_slug() );
+	}
+
+	public function test_category_definition_has_label_and_description(): void {
+		$def = <Name>_Abilities::get_category_definition();
+		$this->assertArrayHasKey( 'label', $def );
+		$this->assertArrayHasKey( 'description', $def );
+	}
+
+	public function test_abilities_map_is_non_empty_and_namespaced(): void {
+		$abilities = <Name>_Abilities::get_abilities();
+		$this->assertNotEmpty( $abilities );
+		foreach ( array_keys( $abilities ) as $slug ) {
+			$this->assertStringStartsWith( 'jetpack-<pkg>/', $slug );
+		}
+	}
+
+	public function test_no_spec_sets_category_explicitly(): void {
+		foreach ( <Name>_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertArrayNotHasKey(
+				'category',
+				$spec,
+				"Ability {$slug} should not set its own category."
+			);
+		}
+	}
+
+	// -------------------- Registrar wiring --------------------
+
+	public function test_init_is_disabled_by_default(): void {
+		Filters\expectApplied( 'jetpack_wp_abilities_enabled' )
+			->once()
+			->with( false )
+			->andReturn( false );
+
+		Functions\expect( 'did_action' )->never();
+		Actions\expectAdded( Registrar::CATEGORIES_INIT_ACTION )->never();
+		Actions\expectAdded( Registrar::ABILITIES_INIT_ACTION )->never();
+
+		<Name>_Abilities::init();
+	}
+
+	public function test_init_adds_hooks_when_neither_action_fired(): void {
+		$this->enable_abilities();
+		Functions\when( 'did_action' )->justReturn( 0 );
+
+		Actions\expectAdded( Registrar::CATEGORIES_INIT_ACTION )
+			->once()
+			->with( array( <Name>_Abilities::class, 'register_category' ) );
+		Actions\expectAdded( Registrar::ABILITIES_INIT_ACTION )
+			->once()
+			->with( array( <Name>_Abilities::class, 'register_abilities' ) );
+
+		Functions\expect( 'wp_register_ability_category' )->never();
+		Functions\expect( 'wp_register_ability' )->never();
+
+		<Name>_Abilities::init();
+	}
+
+	public function test_init_registers_directly_when_both_actions_already_fired(): void {
+		$this->enable_abilities();
+		Functions\when( 'did_action' )->justReturn( 1 );
+
+		$ability_count = count( <Name>_Abilities::get_abilities() );
+
+		Filters\expectApplied( 'jetpack_wp_abilities_should_register' )
+			->atLeast()->times( 1 )
+			->andReturn( true );
+
+		Functions\expect( 'wp_register_ability_category' )->once();
+		Functions\expect( 'wp_register_ability' )->times( $ability_count );
+
+		Actions\expectAdded( Registrar::CATEGORIES_INIT_ACTION )->never();
+		Actions\expectAdded( Registrar::ABILITIES_INIT_ACTION )->never();
+
+		<Name>_Abilities::init();
+	}
+
+	public function test_register_abilities_injects_category_on_specs_that_omit_it(): void {
+		Functions\expect( 'wp_register_ability' )
+			->atLeast()->times( 1 )
+			->with(
+				\Mockery::type( 'string' ),
+				\Mockery::on(
+					static function ( $spec ) {
+						return is_array( $spec )
+							&& isset( $spec['category'] )
+							&& 'jetpack-<pkg>' === $spec['category'];
+					}
+				)
+			);
+
+		Filters\expectApplied( 'jetpack_wp_abilities_should_register' )
+			->atLeast()->times( 1 )
+			->andReturn( true );
+
+		<Name>_Abilities::register_abilities();
+	}
+
+	public function test_register_abilities_respects_per_ability_allow_list(): void {
+		Filters\expectApplied( 'jetpack_wp_abilities_should_register' )
+			->andReturnUsing(
+				static function ( $enabled, $type, $slug ) {
+					return 'ability' !== $type; // Deny every ability.
+				}
+			);
+
+		Functions\expect( 'wp_register_ability' )->never();
+
+		<Name>_Abilities::register_abilities();
+	}
+
+	// -------------------- Permission callbacks --------------------
+
+	public function test_can_view_allows_capable_user(): void {
+		Functions\expect( 'current_user_can' )
+			->with( 'jetpack_admin_page' )
+			->andReturn( true );
+
+		$this->assertTrue( <Name>_Abilities::can_view_<objects>() );
+	}
+
+	public function test_can_view_denies_incapable_user(): void {
+		Functions\expect( 'current_user_can' )
+			->with( 'jetpack_admin_page' )
+			->andReturn( false );
+
+		$this->assertFalse( <Name>_Abilities::can_view_<objects>() );
+	}
+
+	// -------------------- Execute callbacks --------------------
+
+	public function test_get_<objects>_returns_array(): void {
+		$result = <Name>_Abilities::get_<objects>( array() );
+		$this->assertIsArray( $result );
+	}
+
+	public function test_get_<objects>_with_unknown_id_returns_empty_array(): void {
+		// Consolidated read: unknown id is a no-match, not an error.
+		$result = <Name>_Abilities::get_<objects>( array( 'id' => 'does-not-exist-ever' ) );
+		$this->assertSame( array(), $result );
+	}
+
+	public function test_set_<object>_status_rejects_missing_id(): void {
+		$result = <Name>_Abilities::set_<object>_status( array( 'status' => 'active' ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_<pkg>_missing_id', $result->get_error_code() );
+	}
+
+	public function test_set_<object>_status_accepts_zero_string_id(): void {
+		// Regression guard: empty('0') is true, but '0' is a legal ID.
+		$result = <Name>_Abilities::set_<object>_status( array( 'id' => '0', 'status' => 'active' ) );
+		$this->assertNotInstanceOf( \WP_Error::class, $result );
+	}
+
+	public function test_set_<object>_status_is_idempotent_for_current_state(): void {
+		// Declarative writes must no-op when desired == current.
+		$first  = <Name>_Abilities::set_<object>_status( array( 'id' => '<known-id>', 'status' => 'active' ) );
+		$second = <Name>_Abilities::set_<object>_status( array( 'id' => '<known-id>', 'status' => 'active' ) );
+		$this->assertIsArray( $second );
+		$this->assertFalse( $second['changed'], 'Second call with the same desired state must be a no-op.' );
+	}
+}
+```
+
+## Notes
+
+- Brain Monkey's `Functions\expect()` vs `Functions\when()`: use `expect()` for behavior that must happen (call counts); use `when()` for stubs that answer whenever called.
+- The Mockery `\Mockery::on(...)` matcher lets you assert on the full spec shape — use it to confirm category injection happened, annotations are present, etc.
+- When testing a `WP_Error` return from a package-context test, make sure `\WP_Error` is autoloaded. The `jetpack-wp-abilities` package already depends on `yoast/phpunit-polyfills` and `brain/monkey`; if the package test bootstrap doesn't pull in a WP test-utility shim that declares `WP_Error`, either add one or exercise the error case in the plugin-context test suite instead.
+- `#[RunInSeparateProcess]` + `#[PreserveGlobalState(false)]` is the pattern for guarding WP < 6.9 compat tests (no Abilities API declared). See `RegistrarTest::test_register_category_returns_early_when_api_unavailable()`.

--- a/.agents/skills/wp-abilities-api.md
+++ b/.agents/skills/wp-abilities-api.md
@@ -1,0 +1,102 @@
+---
+name: wp-abilities-api
+description: "Use when working with the WordPress Abilities API (wp_register_ability, wp_register_ability_category, /wp-json/wp-abilities/v1/*, @wordpress/abilities) including defining abilities, categories, meta, REST exposure, and permissions checks for clients."
+compatibility: "Targets WordPress 6.9+ (PHP 7.2.24+). Filesystem-based agent with bash + node. Some workflows require WP-CLI."
+---
+
+# WP Abilities API
+
+## When to use
+
+Use this skill when the task involves:
+
+- registering abilities or ability categories in PHP,
+- exposing abilities to clients via REST (`wp-abilities/v1`),
+- consuming abilities in JS (notably `@wordpress/abilities`),
+- diagnosing “ability doesn’t show up” / “client can’t see ability” / “REST returns empty”.
+
+## Inputs required
+
+- Repo root (run `wp-project-triage` first if you haven’t).
+- Target WordPress version(s) and whether this is WP core or a plugin/theme.
+- Where the change should live (plugin vs theme vs mu-plugin).
+
+## Procedure
+
+### 1) Confirm availability and version constraints
+
+- If this is WP core work, check `signals.isWpCoreCheckout` and `versions.wordpress.core`.
+- If the project targets WP < 6.9, you may need the Abilities API plugin/package rather than relying on core.
+
+### 2) Find existing Abilities usage
+
+Search for these in the repo:
+
+- `wp_register_ability(`
+- `wp_register_ability_category(`
+- `wp_abilities_api_init`
+- `wp_abilities_api_categories_init`
+- `wp-abilities/v1`
+- `@wordpress/abilities`
+
+If none exist, decide whether you’re introducing Abilities API fresh (new registrations + client consumption) or only consuming.
+
+### 3) Register categories (optional)
+
+If you need a logical grouping, register an ability category early (see `wp-abilities-api/references/php-registration.md`).
+
+### 4) Register abilities (PHP)
+
+For grouping decisions (how many abilities to register, and where to put filters vs new ability names), read `wp-abilities-api/references/grouping-heuristic.md` first — it keeps you from shipping one atomic ability per REST operation.
+
+For shared helper patterns when multiple execute callbacks delegate to existing REST controllers, see `wp-abilities-api/references/plugin-family-patterns.md` (pick the shared-API-client vs zero-arg-controllers shape) and `wp-abilities-api/references/delegate-helper-pattern.md` (the canonical `delegate_to_rest_controller` helper and when NOT to use it).
+
+Implement the ability in PHP registration with:
+
+- stable `id` (namespaced),
+- `label`/`description`,
+- `category`,
+- `meta`:
+  - add `readonly: true` when the ability is informational,
+  - set `show_in_rest: true` for abilities you want visible to clients.
+
+Use the documented init hooks for Abilities API registration so they load at the right time (see `wp-abilities-api/references/php-registration.md`).
+
+### 5) Confirm REST exposure
+
+- Verify the REST endpoints exist and return expected results (see `wp-abilities-api/references/rest-api.md`).
+- If the client still can’t see the ability, confirm `meta.show_in_rest` is enabled and you’re querying the right endpoint.
+
+### 6) Consume from JS (if needed)
+
+- Prefer `@wordpress/abilities` APIs for client-side access and checks.
+- Ensure build tooling includes the dependency and the project’s build pipeline bundles it.
+
+## Verification
+
+- `wp-project-triage` indicates `signals.usesAbilitiesApi: true` after your change (if applicable).
+- REST check (in a WP environment): endpoints under `wp-abilities/v1` return your ability and category when expected.
+- If the repo has tests, add/update coverage near:
+  - PHP: ability registration and meta exposure
+  - JS: ability consumption and UI gating
+
+## Failure modes / debugging
+
+- Ability never appears:
+  - registration code not running (wrong hook / file not loaded),
+  - missing `meta.show_in_rest`,
+  - incorrect category/ID mismatch.
+- REST shows ability but JS doesn’t:
+  - wrong REST base/namespace,
+  - JS dependency not bundled,
+  - caching (object/page caches) masking changes.
+- Execute callback returns unexpected errors or silently ignores input:
+  - `input_schema` defaults aren't being applied, pagination key drift between the ability and the backing, or `empty()`-based ID validation — see `wp-abilities-api/references/input-schema-gotchas.md`.
+  - Inconsistent or hand-rolled `WP_Error` codes — see `wp-abilities-api/references/error-code-vocabulary.md` for the standardized vocabulary.
+
+## Escalation
+
+- If you’re uncertain about version support, confirm target WP core versions and whether Abilities API is expected from core or as a plugin.
+- For canonical details, consult:
+  - `wp-abilities-api/references/rest-api.md`
+  - `wp-abilities-api/references/php-registration.md`

--- a/.agents/skills/wp-abilities-api/references/delegate-helper-pattern.md
+++ b/.agents/skills/wp-abilities-api/references/delegate-helper-pattern.md
@@ -1,0 +1,215 @@
+# Delegate helper pattern
+
+When an ability's execute callback needs to hand work to an existing REST controller instead of duplicating business logic, extract a `delegate_to_rest_controller` helper. This reference documents the canonical signature, the three guards every implementation needs, the dual response-shape unwrap, and when NOT to use the helper at all.
+
+Read `plugin-family-patterns.md` first — the helper's exact shape depends on whether your plugin follows the shared-API-client pattern or the zero-arg-controllers pattern.
+
+## Why this helper exists
+
+List-style read abilities typically repeat the same four steps in every execute callback:
+
+1. Validate the plugin is initialized (class exists + dependencies resolved).
+2. Build a `WP_REST_Request` and copy the ability's `$input` onto it as params.
+3. Instantiate the backing controller and invoke the named method.
+4. Unwrap the response (controllers return either a raw array or a `WP_REST_Response`).
+
+Four abilities × this repetition = the boilerplate dominates the callback body. Extracting a helper keeps each execute callback a 3–4 line function that reads like pseudocode.
+
+## When to extract
+
+After the **second** list-style ability lands. Before the third ability gets added, refactor the duplicated code out of the first two execute callbacks into a private static helper. Convert subsequent abilities to call the helper as you add them.
+
+If the plugin only ever ships one or two abilities, inline the code. The helper's payoff is at 3+ callers.
+
+## Canonical signature (Pattern A — shared-API-client)
+
+```php
+/**
+ * Delegate an ability's execute callback to a REST controller.
+ *
+ * Builds a WP_REST_Request from the ability's input, instantiates the
+ * backing controller with the plugin's shared API client, invokes the
+ * named method, and normalizes the return so callers always see
+ * array|\WP_Error. Controllers in this plugin return either a
+ * WP_REST_Response or a raw array; the helper unwraps both shapes.
+ *
+ * Not used by zero-arg abilities — those call their controller directly
+ * so we don't synthesize a WP_REST_Request just to discard it.
+ *
+ * @param string     $controller_class Fully-qualified controller class (no leading backslash).
+ * @param string     $method           Controller method to invoke on the built request.
+ * @param string     $route            REST route string used when constructing WP_REST_Request.
+ * @param array|null $input            Ability input; each key/value becomes a request param.
+ * @param string     $http_method      HTTP method for WP_REST_Request. Defaults to 'GET'; writes pass 'POST'.
+ * @return array|\WP_Error             Response payload as an array, or WP_Error on failure.
+ */
+private static function delegate_to_rest_controller(
+    string $controller_class,
+    string $method,
+    string $route,
+    ?array $input,
+    string $http_method = 'GET'
+) {
+    $fqcn = '\\' . $controller_class;
+
+    // Guard 1: controller class is loaded.
+    if ( ! class_exists( $fqcn ) ) {
+        return new \WP_Error(
+            '<plugin>_not_initialized',
+            __( '<Plugin> is not initialized.', '<text-domain>' )
+        );
+    }
+
+    // Guard 2: shared API client is available.
+    $api_client = null;
+    if ( class_exists( '\<Plugin_Main_Class>' ) && method_exists( '\<Plugin_Main_Class>', 'get_<client_accessor>' ) ) {
+        $api_client = \<Plugin_Main_Class>::get_<client_accessor>();
+    }
+    if ( null === $api_client ) {
+        return new \WP_Error(
+            '<plugin>_not_initialized',
+            __( '<Plugin> is not initialized.', '<text-domain>' )
+        );
+    }
+
+    // Build the request.
+    $request = new \WP_REST_Request( $http_method, $route );
+    if ( null !== $input ) {
+        foreach ( $input as $param => $value ) {
+            $request->set_param( $param, $value );
+        }
+    }
+
+    // Invoke + guard 3: WP_Error short-circuit + dual-shape unwrap.
+    $controller = new $fqcn( $api_client );
+    $response   = $controller->{$method}( $request );
+
+    if ( is_wp_error( $response ) ) {
+        return $response;
+    }
+    if ( $response instanceof \WP_REST_Response ) {
+        $data = $response->get_data();
+        return is_array( $data ) ? $data : [];
+    }
+    return is_array( $response ) ? $response : [];
+}
+```
+
+Positional (not named) arguments on purpose — the helper is called from every list ability and keyword-args for PHP 8 would add visual noise. Order is intentional: controller, method, route, input, http_method (the defaultable tail).
+
+## The three guards
+
+### 1. `class_exists` on the controller
+
+Execute callbacks can be reached on sites where the plugin's classes haven't loaded (tests, WP-CLI with limited bootstrap, admin pages with conditional autoloading). Check is cheap; without it a missing class produces a fatal.
+
+Note `'\\' . $controller_class` — accept controller class names without a leading backslash (readable in config arrays) and re-add it so `class_exists` and `new $fqcn(...)` both root-resolve.
+
+### 2. Required dependency (API client) null-check
+
+For Pattern A plugins the accessor is a `public static` method on the main plugin class. Both `class_exists` on the plugin class AND `method_exists` on the accessor are guarded because either could be absent during partial bootstraps. A null return from the accessor is also treated as "not initialized".
+
+Missing this argument produces `ArgumentCountError: Too few arguments to function <Controller>::__construct(), 0 passed` — a PHP fatal. The standardized `<plugin>_not_initialized` error code is documented in `error-code-vocabulary.md`.
+
+For Pattern B plugins, this guard is either skipped entirely (zero-arg constructor) or replaced with construction-time scalar args passed in via an optional `constructor_args` parameter.
+
+### 3. `is_wp_error` short-circuit
+
+Before trying to unwrap the response, check if it's already a `WP_Error`. Several controllers return `WP_Error` for both validation failures and upstream failures; that error needs to bubble up intact so the agent can see the upstream code.
+
+## Dual response-shape unwrap
+
+```php
+if ( $response instanceof \WP_REST_Response ) {
+    $data = $response->get_data();
+    return is_array( $data ) ? $data : [];
+}
+return is_array( $response ) ? $response : [];
+```
+
+Real WordPress REST controllers return either:
+- A `WP_REST_Response` (the output of `rest_ensure_response( ... )` or `new WP_REST_Response( ... )`), or
+- A raw array (typical when a controller delegates to an internal request-handler class that returns the decoded transport payload directly).
+
+Both happen. The helper unwraps `WP_REST_Response` via `get_data()` and passes raw arrays through. The `is_array(...) ? ... : []` coalesce defends against a non-array return type that the ability's `output_schema` would have rejected downstream anyway — returning `[]` fails safely rather than leaking a surprising type.
+
+## When NOT to use the helper
+
+Two categories of abilities bypass the helper and call the backing directly:
+
+### Zero-arg backing methods
+
+If the backing method takes no `WP_REST_Request` parameter, don't synthesize a request just to discard it. Call the method directly:
+
+```php
+public static function execute_get_overview( $input = null ) {
+    if ( ! class_exists( '\My_Plugin_REST_Overview_Controller' ) ) {
+        return new \WP_Error( '<plugin>_not_initialized', __( '<Plugin> is not initialized.', '<text-domain>' ) );
+    }
+
+    $api_client = /* ... same accessor check ... */;
+    if ( null === $api_client ) {
+        return new \WP_Error( '<plugin>_not_initialized', __( '<Plugin> is not initialized.', '<text-domain>' ) );
+    }
+
+    $controller = new \My_Plugin_REST_Overview_Controller( $api_client );
+    $response   = $controller->get_overview(); // No $request argument.
+
+    if ( is_wp_error( $response ) ) {
+        return $response;
+    }
+    return is_array( $response ) ? $response : [];
+}
+```
+
+### Abilities that use a non-REST service
+
+If the execute callback reaches a service directly (e.g. `My_Plugin::get_account_service()->get_cached_account_data()`) rather than a REST controller, stay on the direct path. The ability is not REST-backed and the helper would add a construction step for no gain.
+
+## Rule of thumb
+
+**If the backing method's signature includes `WP_REST_Request`, use the helper. Otherwise direct-path.**
+
+## Conversion pattern — before and after
+
+Before extraction (inline in the execute callback):
+
+```php
+public static function execute_get_things( $input = null ) {
+    if ( ! class_exists( '\My_Plugin_REST_Things_Controller' ) ) {
+        return new \WP_Error( '<plugin>_not_initialized', __( '<Plugin> is not initialized.', '<text-domain>' ) );
+    }
+    $api_client = \My_Plugin::get_api_client();
+    if ( ! $api_client ) {
+        return new \WP_Error( '<plugin>_not_initialized', __( '<Plugin> is not initialized.', '<text-domain>' ) );
+    }
+    $request = new \WP_REST_Request( 'GET', '/my-plugin/v1/things' );
+    foreach ( (array) $input as $param => $value ) {
+        $request->set_param( $param, $value );
+    }
+    $controller = new \My_Plugin_REST_Things_Controller( $api_client );
+    $response   = $controller->get_things( $request );
+    // ... unwrap ...
+}
+```
+
+After extraction:
+
+```php
+public static function execute_get_things( $input = null ) {
+    return self::delegate_to_rest_controller(
+        'My_Plugin_REST_Things_Controller',
+        'get_things',
+        '/my-plugin/v1/things',
+        is_array( $input ) ? $input : null
+    );
+}
+```
+
+Note the `is_array( $input ) ? $input : null` — the helper signature is `?array`, and passing `null` tells it to build the request with no params at all. This matters because the Abilities API sometimes invokes a callback with no input object.
+
+## Related references
+
+- `plugin-family-patterns.md` — choosing the helper's constructor shape.
+- `error-code-vocabulary.md` — the `<plugin>_not_initialized` code and its siblings.
+- `input-schema-gotchas.md` — callbacks for list abilities often need `per_page` pagination translation BEFORE calling the helper.

--- a/.agents/skills/wp-abilities-api/references/error-code-vocabulary.md
+++ b/.agents/skills/wp-abilities-api/references/error-code-vocabulary.md
@@ -15,7 +15,7 @@ Without a convention, every plugin invents its own codes and agents can't reason
 
 ## Vocabulary
 
-Substitute `<plugin>` with the plugin's slug in lowercase, underscores only (e.g. `woopayments`, `jetpack_forms`). This matches WordPress error-code conventions. If the plugin already has a house style for error codes (WooPayments uses `woopayments`, not `woo_payments`), mirror that — consistency within a plugin trumps consistency across the vocabulary.
+Substitute `<plugin>` with the plugin's slug in lowercase, underscores only (e.g. `jetpack_forms`, `jetpack_stats`). This matches WordPress error-code conventions. If the plugin already has a house style for error codes — multi-word slugs sometimes normalize to a single-word prefix — mirror that; consistency within a plugin trumps consistency across the vocabulary.
 
 | Code | When to use | Agent behavior |
 |---|---|---|
@@ -75,7 +75,7 @@ If the backing controller talks to a third-party API (Stripe, WPCOM, another Saa
 ## Code naming rules
 
 1. **Lowercase, underscores only.** `<plugin>_missing_order_id`, not `<plugin>-missingOrderId` or `<Plugin>-MissingOrderId`.
-2. **Plugin prefix first.** Multi-word slugs should normalize to a single-word prefix where the plugin already does (e.g. `woopayments` rather than `woo_payments`).
+2. **Plugin prefix first.** Use the plugin's existing slug convention; multi-word slugs sometimes normalize to a single-word prefix in error codes.
 3. **Action second.** Use one of `missing`, `invalid`, `not_initialized`, `<resource>_data_unavailable`.
 4. **Field or resource name last.** `<plugin>_missing_dispute_id`, not `<plugin>_dispute_id_missing`. This matches English phrasing ("a dispute_id is required") and is faster to skim in error logs.
 

--- a/.agents/skills/wp-abilities-api/references/error-code-vocabulary.md
+++ b/.agents/skills/wp-abilities-api/references/error-code-vocabulary.md
@@ -1,0 +1,123 @@
+# Error code vocabulary
+
+Every `WP_Error` returned from an ability's execute callback should use a code drawn from this small vocabulary. A consistent vocabulary lets the agent (or the caller in your automation) build retry and recovery logic that matches on codes instead of parsing error messages.
+
+## Why standardized codes matter
+
+Agents that orchestrate multiple abilities need to know: "did this fail because of my input, or because something downstream is unreachable?" The answer drives retry strategy:
+
+- Bootstrap failures → surface to the human, don't retry.
+- Input shape errors → fix the input and retry the same call.
+- Transient backend errors → retry with backoff; may succeed on its own.
+- Upstream third-party errors → may need a different strategy entirely.
+
+Without a convention, every plugin invents its own codes and agents can't reason uniformly across them. The categories below cover 95% of real-world ability errors; sticking to them means an agent that learned the retry logic for one plugin can reuse it for the next.
+
+## Vocabulary
+
+Substitute `<plugin>` with the plugin's slug in lowercase, underscores only (e.g. `woopayments`, `jetpack_forms`). This matches WordPress error-code conventions. If the plugin already has a house style for error codes (WooPayments uses `woopayments`, not `woo_payments`), mirror that — consistency within a plugin trumps consistency across the vocabulary.
+
+| Code | When to use | Agent behavior |
+|---|---|---|
+| `<plugin>_not_initialized` | Plugin class missing, shared service accessor returns null, required dependency isn't resolvable. | Not retriable from the agent side. Usually a config or bootstrap-ordering problem. Escalate. |
+| `<plugin>_missing_<field>` | A required input field is missing or empty (your execute callback's own check, not the schema-validator's). | Agent should add the field and retry. |
+| `<plugin>_invalid_<field>` | Field is present but semantically wrong (bad enum value, malformed date, wrong type). | Agent should correct the value and retry. |
+| `<plugin>_<resource>_data_unavailable` | Backing service returned a transient error (cache miss + remote failure, upstream 5xx, stale-while-revalidate failed). | Agent can retry, probably with backoff. |
+| `ability_invalid_input` | The Abilities API's own schema-validator rejected the input before the execute callback ran. | Equivalent to `<plugin>_missing_<field>` or `<plugin>_invalid_<field>`, just thrown earlier in the pipeline. Agent should fix input. |
+
+### `ability_invalid_input` — the earlier path
+
+When an ability is invoked via the Abilities API REST bridge, the registered `input_schema` runs first. Missing required fields or type mismatches produce `WP_Error( 'ability_invalid_input' )` BEFORE the execute callback fires. Direct invocation (unit tests, non-REST wrappers) bypasses schema validation and hits your execute callback's own checks instead, producing `<plugin>_missing_<field>` / `<plugin>_invalid_<field>`.
+
+Both paths are acceptable — end-agent-facing behavior is equivalent (deterministic validation error, no side effects). Document the observation in the ability's PR description or "notes for reviewers" so reviewers know both codes are expected in different harness runs.
+
+## Worked examples
+
+```php
+// Bootstrap incomplete — plugin class missing or accessor returned null.
+return new \WP_Error(
+    '<plugin>_not_initialized',
+    __( '<Plugin> is not initialized.', '<text-domain>' )
+);
+
+// Required field missing (execute-callback check, schema was bypassed).
+return new \WP_Error(
+    '<plugin>_missing_<field>',
+    __( 'A <field> is required to <do the thing>.', '<text-domain>' )
+);
+
+// Field present but malformed.
+return new \WP_Error(
+    '<plugin>_invalid_<field>',
+    sprintf(
+        /* translators: %s: input parameter name. */
+        __( 'The "%s" parameter must be an ISO 8601 date-time string.', '<text-domain>' ),
+        $key
+    )
+);
+
+// Transient backend error.
+return new \WP_Error(
+    '<plugin>_<resource>_data_unavailable',
+    __( 'Unable to retrieve <resource> data. The cache may be stale or the remote service returned an error.', '<text-domain>' )
+);
+```
+
+## Upstream codes can bubble through — and usually should
+
+If the backing controller talks to a third-party API (Stripe, WPCOM, another SaaS), its own error codes may surface verbatim in `WP_Error::get_error_code()` the ability returns. Typical examples:
+
+- `resource_missing` — Stripe's "object ID not found" code. Tells an agent the specific ID was wrong.
+- `rate_limited` — upstream throttling. Tells an agent to slow down.
+
+**Let these through rather than re-wrapping.** A re-wrapped `<plugin>_<resource>_not_found` loses the information that would help the agent act. Document the upstream codes you've observed in the ability's `description` or PR notes so reviewers know they're expected.
+
+## Code naming rules
+
+1. **Lowercase, underscores only.** `<plugin>_missing_order_id`, not `<plugin>-missingOrderId` or `<Plugin>-MissingOrderId`.
+2. **Plugin prefix first.** Multi-word slugs should normalize to a single-word prefix where the plugin already does (e.g. `woopayments` rather than `woo_payments`).
+3. **Action second.** Use one of `missing`, `invalid`, `not_initialized`, `<resource>_data_unavailable`.
+4. **Field or resource name last.** `<plugin>_missing_dispute_id`, not `<plugin>_dispute_id_missing`. This matches English phrasing ("a dispute_id is required") and is faster to skim in error logs.
+
+## Internationalization
+
+Error MESSAGES are translatable via `__()` or `sprintf(__())`. Error CODES are not — they're stable machine identifiers.
+
+```php
+// WRONG — don't translate the code.
+return new \WP_Error( __( '<plugin>_missing_order_id', '<text-domain>' ), ... );
+
+// RIGHT — code is a literal, message is translatable.
+return new \WP_Error(
+    '<plugin>_missing_order_id',
+    __( 'An order_id is required.', '<text-domain>' )
+);
+```
+
+When a message interpolates a parameter name or value, include a translator comment:
+
+```php
+return new \WP_Error(
+    '<plugin>_invalid_date',
+    sprintf(
+        /* translators: %s: input parameter name. */
+        __( 'The "%s" parameter must be an ISO 8601 date-time string.', '<text-domain>' ),
+        $key
+    )
+);
+```
+
+## Don't over-specify
+
+The goal is consistent codes across all of a plugin's abilities, not ultra-fine granularity. `<plugin>_missing_dispute_id` is the right level. `<plugin>_missing_dispute_id_in_submit_evidence_context` is not — the ability name belongs in `WP_Error::get_error_data()` or in the agent's calling context, not in the code.
+
+## Summary — the four questions
+
+When writing an execute callback, ask in order:
+
+1. Can the plugin even service this call? → `<plugin>_not_initialized`.
+2. Is the required input present? → `<plugin>_missing_<field>`.
+3. Is the required input the right shape? → `<plugin>_invalid_<field>`.
+4. Did the backing service choke? → `<plugin>_<resource>_data_unavailable`, or let the upstream code bubble through.
+
+Four categories, one consistent code vocabulary per plugin. That's enough for agents to build reliable retry logic on top.

--- a/.agents/skills/wp-abilities-api/references/grouping-heuristic.md
+++ b/.agents/skills/wp-abilities-api/references/grouping-heuristic.md
@@ -1,0 +1,80 @@
+# Grouping heuristic — picking which abilities to register
+
+How to decide WHAT to register when a plugin already has a REST (or internal service) surface. The hard part of adopting the Abilities API is not the registration syntax — it's picking the right granularity so agents can actually use the result.
+
+## Three observed approaches
+
+| Approach | Shape | Example | Verdict |
+|---|---|---|---|
+| **Action-bundle** | One ability bundles many sub-operations behind an action string. | `my_plugin_account` with `action: "get" \| "update" \| "delete"`. | Reference only. Hides the ability surface from the agent's tool-list and defeats the Abilities API's introspection model — agents can't see what a bundle can do until they invoke it. |
+| **REST-atomization** | One ability per HTTP method per resource (typically 5 per resource: list, get, create, update, delete). | `orders-list`, `orders-get`, `orders-create`, `orders-update`, `orders-delete`. | Explodes the agent's tool-list. Agents spend context picking between near-duplicates and often still miss the right one. Doesn't match how humans ask questions. |
+| **Semantic-intent** | One ability per real-world question or state transition. Filter parameters in `input_schema` collapse N variants into 1. | Jetpack Forms `jetpack-forms/get-responses` with `status`, `is_unread`, `search`, date-range — 1 ability replaces what would be 8+ atomized variants. | **Recommended.** |
+
+## Why semantic-intent wins
+
+1. **Agent tool-list context is finite.** Every registered ability consumes tokens on every agent turn that includes the tool list. A semantic ability collapses 8 REST variants into 1 entry and frees that context for reasoning.
+2. **Users think in questions, not HTTP verbs.** "Which form responses are unread?" maps cleanly to one ability with an `is_unread` filter. It does NOT map to 8 abilities (`get-unread-responses`, `get-spam-responses`, `get-trashed-responses`, ...).
+3. **The Abilities API's `input_schema` is designed for rich inputs.** Enum constraints, date-time formats, and required-field validation do the variant-splitting job that atomization would delegate to the ability name.
+4. **Writes stay narrow anyway.** A write ability should already be one state transition; atomization and semantic-intent converge for writes.
+
+## Rules that make it work
+
+### 1. Group reads by the question a user would type
+
+Draft the question in plain English. That question is the ability. The filter parameters go in `input_schema`.
+
+- WRONG: one ability per status value.
+- RIGHT: one `get-<resource>` ability with `status: { type: "string", enum: [...] }`.
+
+### 2. Keep writes narrow — one state transition per ability
+
+A write ability should do exactly one thing the agent can reason about in isolation and explain to a user. Different state transitions → different abilities (different consequences, different annotations, different permission implications).
+
+- WRONG: `update-resource` that branches internally on an action enum.
+- RIGHT: `submit-evidence` and `close-resource` as separate abilities.
+
+### 3. Prefer 1 ability with filter params over N abilities with no params
+
+Ask: "if the backing added a new filter value, would that create a new ability?" If not, the filter belongs in `input_schema`, not in the ability name.
+
+### 4. Zero-arg overview abilities are high-leverage
+
+When enumerating the backing surface, specifically look for zero-argument aggregate or "overview" endpoints — "what's my balance?", "what's my next payout?", "what's my form response count?". These answer the highest-frequency user questions with zero input and zero room for agent error. Flag them even if they weren't in the original plan.
+
+### 5. Don't ship abilities you can't explain in one sentence
+
+Every ability's `label` + `description` should fit in an agent's tool-selection prompt. If you can't describe the ability in one sentence without "and", that's usually a sign it's two abilities.
+
+## Worked example A — Jetpack Forms: 3 abilities for the whole responses surface
+
+Jetpack Forms' responses surface in the WP admin exposes: a list with 8+ filters, a detail view, bulk status changes (spam/trash/publish), read/unread toggles, and a count-by-status dashboard summary.
+
+REST-atomization would ship ~6 abilities (list, get, delete, update, bulk-update, count). Jetpack Forms instead registers **three**:
+
+- `jetpack-forms/get-responses` — list/search, with `status`, `is_unread`, `search`, `before`, `after`, `parent` in `input_schema`.
+- `jetpack-forms/update-response` — one write that covers status changes AND read-state toggles on a single response (semantically "modify a response").
+- `jetpack-forms/get-status-counts` — the dashboard summary ability. Zero-arg-friendly (only optional filters).
+
+Why three works: a user asking "show me spam responses from last week" uses one ability. An agent updating one response to `spam` uses one ability. The dashboard-style "how many unread?" uses one ability. The entire product surface fits in three tool-list entries.
+
+Canonical file: [`Automattic/jetpack/projects/packages/forms/src/abilities/class-forms-abilities.php`](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/forms/src/abilities/class-forms-abilities.php).
+
+## Worked example B — WooPayments disputes: one ability with a status filter, not eight
+
+WooPayments' `GET /wc/v3/payments/disputes` accepts `status_is`, `status_is_not`, `date_before`, `date_after`, `date_between`, `store_currency_is`, `match`, `search`. Status values include `warning_needs_response`, `needs_response`, `under_review`, `won`, `lost`, and several more.
+
+- Atomization would ship ~8 abilities (`get-disputes-warning-needs-response`, `get-disputes-won`, `get-disputes-lost`, ...).
+- Semantic-intent ships **one** — `woopayments/get-disputes` with `status_is: { type: "string", enum: ["warning_needs_response", "needs_response", "under_review", "won", "lost", ...] }`.
+
+The user question "which disputes need a response?" becomes one ability invocation with `status_is: "needs_response"`. The agent doesn't scan a list of 8 near-identical tool names; it scans one, and the enum documents what values are valid.
+
+The same plugin also registers a zero-arg `get-payout-overview` ability (next payout date + amount) because "when do I get paid?" is the single highest-frequency merchant question and the backing endpoint takes no arguments. That one ability has outsized value for one line of registration code — rule 4 in action.
+
+## Escape hatch — when atomization is right
+
+Two cases where one-ability-per-operation IS appropriate:
+
+1. **Genuinely different permission models.** If `create-<resource>` and `delete-<resource>` require different capabilities or different confirmation flows, splitting is honest.
+2. **Different destructive / idempotent annotations.** An ability that both reads and writes cannot honestly declare `readonly: true`; split the read-only part into its own ability.
+
+These exceptions tend to coincide with rule 2 (one state transition per ability) — not a contradiction.

--- a/.agents/skills/wp-abilities-api/references/grouping-heuristic.md
+++ b/.agents/skills/wp-abilities-api/references/grouping-heuristic.md
@@ -59,16 +59,16 @@ Why three works: a user asking "show me spam responses from last week" uses one 
 
 Canonical file: [`Automattic/jetpack/projects/packages/forms/src/abilities/class-forms-abilities.php`](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/forms/src/abilities/class-forms-abilities.php).
 
-## Worked example B — WooPayments disputes: one ability with a status filter, not eight
+## Worked example B — A filtered-list endpoint: one ability with an enum, not eight
 
-WooPayments' `GET /wc/v3/payments/disputes` accepts `status_is`, `status_is_not`, `date_before`, `date_after`, `date_between`, `store_currency_is`, `match`, `search`. Status values include `warning_needs_response`, `needs_response`, `under_review`, `won`, `lost`, and several more.
+Suppose a plugin exposes `GET /<plugin>/v1/items` accepting filters `status`, `is_unread`, `date_before`, `date_after`, `search`. The `status` enum has values like `pending`, `active`, `paused`, `archived`, `expired`, `flagged`, and several more.
 
-- Atomization would ship ~8 abilities (`get-disputes-warning-needs-response`, `get-disputes-won`, `get-disputes-lost`, ...).
-- Semantic-intent ships **one** — `woopayments/get-disputes` with `status_is: { type: "string", enum: ["warning_needs_response", "needs_response", "under_review", "won", "lost", ...] }`.
+- Atomization would ship ~8 abilities (`get-pending-items`, `get-active-items`, `get-paused-items`, `get-archived-items`, ...).
+- Semantic-intent ships **one** — `<plugin>/get-items` with `status: { type: "string", enum: ["pending", "active", "paused", "archived", "expired", "flagged", ...] }`.
 
-The user question "which disputes need a response?" becomes one ability invocation with `status_is: "needs_response"`. The agent doesn't scan a list of 8 near-identical tool names; it scans one, and the enum documents what values are valid.
+The user question "which items need a response?" becomes one ability invocation with `status: "pending"`. The agent doesn't scan a list of 8 near-identical tool names; it scans one, and the enum documents what values are valid.
 
-The same plugin also registers a zero-arg `get-payout-overview` ability (next payout date + amount) because "when do I get paid?" is the single highest-frequency merchant question and the backing endpoint takes no arguments. That one ability has outsized value for one line of registration code — rule 4 in action.
+A companion zero-arg `<plugin>/get-overview` ability — for example "how many of each status, in one call?" — is high-leverage by rule 4: one line of registration code answers one of the highest-frequency questions in the plugin's UI.
 
 ## Escape hatch — when atomization is right
 

--- a/.agents/skills/wp-abilities-api/references/input-schema-gotchas.md
+++ b/.agents/skills/wp-abilities-api/references/input-schema-gotchas.md
@@ -1,0 +1,221 @@
+# Input schema gotchas
+
+Three surprises the Abilities API's `input_schema` will ship with if you rely on schema declarations alone. All three have been caught in real plugin work after the schema looked correct and tests passed; each has a defensive pattern that makes the execute callback robust regardless.
+
+## 1. Schema `default` values are NOT injected into execute callback input
+
+### Problem
+
+`wp_register_ability()` lets you declare per-property defaults in `input_schema`:
+
+```php
+'input_schema' => [
+    'type'       => 'object',
+    'properties' => [
+        'submit' => [
+            'type'        => 'boolean',
+            'default'     => false,
+            'description' => __( 'Whether to submit evidence for review.', '<text-domain>' ),
+        ],
+    ],
+],
+```
+
+The Abilities API's validate path enforces `type` and `required`, but it does NOT populate missing properties with their declared `default`. If an agent invokes the ability with `{ dispute_id: "dp_..." }` and omits `submit`, the execute callback receives `$input` **without** a `submit` key — it does not get `$input['submit'] = false`.
+
+### Symptoms
+
+- Boolean defaults silently become "undefined" in the callback and any `if ( $input['submit'] )` check compares against `null`, which works by accident but fails `isset` checks and strict-type branches.
+- Integer pagination defaults like `'page' => [ 'default' => 1 ]` never reach the backing controller, so pagination falls back to the controller's internal default rather than the one declared in the schema.
+- Object defaults (`'metadata' => [ 'default' => [] ]`) become `null` rather than `[]` and any `foreach ( $input['metadata'] as ... )` hits a type error.
+
+### Fix — normalize defaults explicitly in the execute callback
+
+```php
+public static function execute_submit_evidence( $input = null ) {
+    if ( ! is_array( $input ) ) {
+        $input = [];
+    }
+
+    // Apply schema defaults the Abilities API does not inject.
+    if ( ! array_key_exists( 'submit', $input ) || null === $input['submit'] ) {
+        $input['submit'] = false;
+    }
+    $input['submit'] = (bool) $input['submit'];
+
+    if ( ! array_key_exists( 'metadata', $input ) || null === $input['metadata'] ) {
+        $input['metadata'] = [];
+    }
+
+    // ... rest of callback
+}
+```
+
+The `array_key_exists` + null-check pattern catches both "missing key" and "explicit null" (some serializers produce nulls for optional fields).
+
+Keep the declared `default` in `input_schema` anyway — it documents the expected behavior for anyone reading the registration and is visible to agents in the schema introspection endpoints. Just don't rely on it for runtime population.
+
+## 2. Pagination parameter-name drift
+
+### Problem
+
+The `input_schema` convention across most WordPress REST endpoints is `per_page` (matching WP core REST list endpoints and `WP_REST_Controller`'s `get_collection_params()`). Some plugin REST controllers, however, delegate to an internal request-builder class that reads a different key (e.g. `pagesize` or `page_size`), typically for historical reasons.
+
+If the ability's `input_schema` exposes `per_page` and the backing controller reads `pagesize`, the agent's `per_page: 50` silently never reaches pagination — the value is accepted, forwarded verbatim to the backing, and then ignored. Agents keep getting the default page size and suspect their filter is broken.
+
+### Symptoms
+
+- List abilities return the backing controller's default page size regardless of the agent's `per_page` input.
+- Integration tests that only check "a list came back" pass; only a test asserting `count( $response['data'] )` catches it.
+- Harness runs show the raw response count matching the default (25, 10, etc.) for every call.
+
+### Detection heuristic
+
+Before shipping a paginated ability, grep the backing controller's call chain:
+
+```bash
+# Check the backing controller and anything it delegates to.
+grep -rn "pagesize\|page_size" <path/to/backing-controller.php> <path/to/request-helpers/>
+```
+
+If `pagesize` (or any non-`per_page` key) appears in the chain and the ability's schema exposes `per_page`, the execute callback MUST translate.
+
+### Fix — translate before delegating
+
+```php
+/**
+ * Translate pagination keys for abilities whose backing reads a non-standard key.
+ *
+ * Abilities expose `per_page` uniformly for agent-facing consistency; this
+ * helper rewrites it to whatever key the backing actually reads.
+ *
+ * @param array|null $input Ability input (or null).
+ * @return array|null       Input with `per_page` rewritten to `<backing_key>` when present.
+ */
+private static function translate_pagination_keys( $input ) {
+    if ( ! is_array( $input ) ) {
+        return $input;
+    }
+    if ( isset( $input['per_page'] ) ) {
+        $input['<backing_key>'] = $input['per_page'];
+        unset( $input['per_page'] );
+    }
+    return $input;
+}
+
+public static function execute_get_things( $input = null ) {
+    $input = self::translate_pagination_keys( is_array( $input ) ? $input : null );
+
+    return self::delegate_to_rest_controller(
+        '<Backing_Controller_Class>',
+        'get_things',
+        '/my-plugin/v1/things',
+        $input
+    );
+}
+```
+
+Place the translation BEFORE the delegate call so `per_page` never reaches the backing.
+
+### When NOT to apply this
+
+Do not apply blindly. If the backing reads `per_page` directly (most modern WP REST controllers do), adding this translation would silently break pagination by renaming the key to something the backing doesn't understand.
+
+**Always grep the backing first.** The translation is only correct for a specific backing chain; it's not a general safety net.
+
+## 3. ID validation must not use `empty()`
+
+### Problem
+
+PHP's `empty()` is permissive in ways that bite ID validation:
+
+```php
+empty( '0' )   // true  — but "0" is a legal string ID (order ID, row ID, post ID in some code paths)
+empty( 0 )     // true  — same for integer zero
+empty( [] )    // true  — expected, but same keyword used for different cases
+```
+
+An execute callback that guards required IDs with `empty( $input['order_id'] )` will false-reject a legitimate `"0"` and return a "missing" error for input that's actually present. The agent retries with the same input, gets the same error, and the call is stuck.
+
+### Symptoms
+
+- Abilities reject specific IDs ending in zero or consisting of zero.
+- Unit tests written with non-zero IDs pass; a regression lands the day an agent tries a real zero-ID.
+- `WP_Error( '<plugin>_missing_<field>' )` fires for input the schema validator would have accepted.
+
+### Fix — three explicit checks
+
+```php
+if ( ! isset( $input['order_id'] )
+    || ! is_string( $input['order_id'] )
+    || '' === $input['order_id']
+) {
+    return new \WP_Error(
+        '<plugin>_missing_order_id',
+        __( 'An order_id is required to fetch order detail.', '<text-domain>' )
+    );
+}
+```
+
+Three separate checks, each non-redundant:
+
+1. `! isset( ... )` — the key is present on the array.
+2. `! is_string( ... )` — type is right. (For integer IDs, use `is_int` + non-negative check instead.) Without this, a caller that passes `123` (integer) where the schema documents a string would fall through to a later step that does `rawurlencode( $input['order_id'] )` and produces a cryptic coercion error rather than a clean missing-field response.
+3. `'' === $input[ ... ]` — non-empty in the strict sense. Rejects empty string only; accepts `"0"` as a legal value.
+
+Use the standardized `<plugin>_missing_<field>` error code (see `error-code-vocabulary.md`) for this case.
+
+### Add a regression-guard unit test
+
+The guard is load-bearing enough that it deserves an explicit test — otherwise someone will simplify it back to `empty()` in a future refactor:
+
+```php
+public function test_execute_returns_wp_error_when_id_not_a_string(): void {
+    $result = My_Plugin_Abilities::execute_get_thing( [ 'order_id' => 123 ] );
+    $this->assertInstanceOf( \WP_Error::class, $result );
+    $this->assertSame( '<plugin>_missing_order_id', $result->get_error_code() );
+}
+```
+
+The integer `123` is a fine canary — it's non-empty, it `isset`s, but it's not a string. A callback that only uses `isset` + `empty` would false-pass this input and fall through to the URL construction with an integer argument.
+
+## Putting the three together
+
+A hardened execute callback for a list-style ability with a required ID, schema defaults, and backing pagination drift:
+
+```php
+public static function execute_get_thing_details( $input = null ) {
+    if ( ! is_array( $input ) ) {
+        $input = [];
+    }
+
+    // Gotcha 3: required-ID validation (not empty()).
+    if ( ! isset( $input['thing_id'] )
+        || ! is_string( $input['thing_id'] )
+        || '' === $input['thing_id']
+    ) {
+        return new \WP_Error(
+            '<plugin>_missing_thing_id',
+            __( 'A thing_id is required.', '<text-domain>' )
+        );
+    }
+
+    // Gotcha 1: apply defaults the Abilities API doesn't inject.
+    if ( ! array_key_exists( 'include_history', $input ) || null === $input['include_history'] ) {
+        $input['include_history'] = false;
+    }
+    $input['include_history'] = (bool) $input['include_history'];
+
+    // Gotcha 2: translate pagination before delegating (only if backing reads a non-standard key).
+    $input = self::translate_pagination_keys( $input );
+
+    return self::delegate_to_rest_controller(
+        '<Backing_Controller_Class>',
+        'get_thing',
+        '/my-plugin/v1/things/' . rawurlencode( $input['thing_id'] ),
+        $input
+    );
+}
+```
+
+Each of the three lines the callback adds on top of the "just delegate" pattern has a paid-for bug behind it. Keep them.

--- a/.agents/skills/wp-abilities-api/references/php-registration.md
+++ b/.agents/skills/wp-abilities-api/references/php-registration.md
@@ -1,0 +1,66 @@
+# PHP registration quick guide
+
+Key concepts and entrypoints for the WordPress Abilities API:
+
+- Register ability categories and abilities in PHP.
+- Use the Abilities API init hooks to ensure registration occurs at the right lifecycle time.
+
+## Hook order (critical)
+
+**Categories must be registered before abilities.** Use the correct hooks:
+
+1. `wp_abilities_api_categories_init` — Register categories here first.
+2. `wp_abilities_api_init` — Register abilities here (after categories exist).
+
+**Warning:** Registering abilities outside `wp_abilities_api_init` triggers `_doing_it_wrong()` and the registration will fail.
+
+```php
+// 1. Register category first
+add_action( 'wp_abilities_api_categories_init', function() {
+    wp_register_ability_category( 'my-plugin', [
+        'label' => __( 'My Plugin', 'my-plugin' ),
+    ] );
+} );
+
+// 2. Then register abilities
+add_action( 'wp_abilities_api_init', function() {
+    wp_register_ability( 'my-plugin/get-info', [
+        'label'       => __( 'Get Site Info', 'my-plugin' ),
+        'description' => __( 'Returns basic site information.', 'my-plugin' ),
+        'category'    => 'my-plugin',
+        'execute_callback' => 'my_plugin_get_info_callback',
+        'meta'        => [ 'show_in_rest' => true ],
+    ] );
+} );
+```
+
+## Common primitives
+
+- `wp_register_ability_category( $category_id, $args )`
+- `wp_register_ability( $ability_id, $args )`
+
+## Key arguments for `wp_register_ability()`
+
+| Argument | Description |
+|----------|-------------|
+| `label` | Human-readable name for UI (e.g., command palette) |
+| `description` | What the ability does |
+| `category` | Category ID (must be registered first) |
+| `execute_callback` | Function that executes the ability |
+| `input_schema` | JSON Schema for expected input (enables validation) |
+| `output_schema` | JSON Schema for returned output |
+| `permission_callback` | Optional function to check if current user can execute |
+| `meta.show_in_rest` | Set `true` to expose via REST API |
+| `meta.readonly` | Set `true` if ability is informational only |
+
+## Recommended patterns
+
+- Namespace IDs (e.g. `my-plugin:feature.edit`).
+- Treat IDs as stable API; changing IDs is a breaking change.
+- Use `input_schema` and `output_schema` for validation and to help AI agents understand usage.
+- Always include a `permission_callback` for abilities that modify data.
+
+## References
+
+- Abilities API handbook: https://developer.wordpress.org/apis/abilities-api/
+- Dev note: https://make.wordpress.org/core/2025/11/10/abilities-api-in-wordpress-6-9/

--- a/.agents/skills/wp-abilities-api/references/plugin-family-patterns.md
+++ b/.agents/skills/wp-abilities-api/references/plugin-family-patterns.md
@@ -1,0 +1,216 @@
+# Plugin-family patterns
+
+When you adopt the Abilities API inside an existing plugin, the plugin's architecture dictates HOW your execute callbacks call the existing business logic. Two patterns cover most real-world WordPress plugins. Pick one up front — the choice ripples through your delegate helper, your tests, and your error codes.
+
+## Pattern A — Shared-API-client ("Woo-family")
+
+Common in plugins that talk to a remote service (Stripe, a first-party SaaS, an upstream API). The plugin bootstraps a single API client, exposes it via a static accessor on a main plugin class, and every REST controller takes that client as a constructor argument.
+
+### Detection
+
+```bash
+# Inspect the backing REST controller's __construct signature.
+grep -n "public function __construct" <path/to/rest-controller.php>
+```
+
+If the constructor takes a required typed argument (e.g. `My_Plugin_API_Client $api_client`), you're in Pattern A. Confirm the plugin has a central accessor:
+
+```bash
+grep -rn "get_api_client\|get_.*_api_client\|get_service" <path/to/plugin/main-class.php>
+```
+
+You're looking for a `public static function get_<something>()` that returns the shared client.
+
+### Minimal skeleton
+
+```php
+<?php
+namespace My_Plugin\Abilities;
+
+class Abilities_Registrar {
+
+    const CATEGORY_SLUG = 'my-plugin';
+
+    public static function init() {
+        add_action( 'wp_abilities_api_categories_init', [ __CLASS__, 'register_category' ] );
+        add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
+    }
+
+    public static function register_abilities() {
+        wp_register_ability(
+            'my-plugin/get-things',
+            [
+                'label'               => __( 'Get things', 'my-plugin' ),
+                'description'         => __( 'List things with filters.', 'my-plugin' ),
+                'category'            => self::CATEGORY_SLUG,
+                'input_schema'        => [ /* ... */ ],
+                'execute_callback'    => [ __CLASS__, 'execute_get_things' ],
+                'permission_callback' => [ __CLASS__, 'current_user_has_capability' ],
+                'meta'                => [
+                    'annotations'  => [ 'readonly' => true, 'destructive' => false, 'idempotent' => true ],
+                    'show_in_rest' => true,
+                ],
+            ]
+        );
+    }
+
+    public static function execute_get_things( $input = null ) {
+        return self::delegate_to_rest_controller(
+            'My_Plugin_REST_Things_Controller',
+            'get_things',
+            '/my-plugin/v1/things',
+            is_array( $input ) ? $input : null
+        );
+    }
+
+    private static function delegate_to_rest_controller( $controller_class, $method, $route, $input, $http_method = 'GET' ) {
+        $fqcn = '\\' . $controller_class;
+        if ( ! class_exists( $fqcn ) ) {
+            return new \WP_Error( 'my_plugin_not_initialized', __( 'My Plugin is not initialized.', 'my-plugin' ) );
+        }
+
+        // Pattern A specifics: fetch the shared API client and null-check.
+        $api_client = null;
+        if ( class_exists( '\My_Plugin' ) && method_exists( '\My_Plugin', 'get_api_client' ) ) {
+            $api_client = \My_Plugin::get_api_client();
+        }
+        if ( null === $api_client ) {
+            return new \WP_Error( 'my_plugin_not_initialized', __( 'My Plugin is not initialized.', 'my-plugin' ) );
+        }
+
+        $request = new \WP_REST_Request( $http_method, $route );
+        if ( is_array( $input ) ) {
+            foreach ( $input as $param => $value ) {
+                $request->set_param( $param, $value );
+            }
+        }
+
+        $controller = new $fqcn( $api_client );
+        $response   = $controller->{$method}( $request );
+
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+        if ( $response instanceof \WP_REST_Response ) {
+            $data = $response->get_data();
+            return is_array( $data ) ? $data : [];
+        }
+        return is_array( $response ) ? $response : [];
+    }
+}
+```
+
+### Testing implications
+
+- **Bootstrap test doubles need the API client.** Unit tests that instantiate controllers must provide a mocked or stubbed client; otherwise the constructor fails with `ArgumentCountError: Too few arguments`.
+- **The "not initialized" error path is reachable and must be covered.** One unit test should stub the accessor to return null and assert the ability returns `<plugin>_not_initialized`. This is a common failure during partial bootstraps (WP-CLI with restricted loading, test harnesses, admin pages with conditional autoloading).
+- **Integration tests need real or faked HTTP.** The backing controller will hit the upstream unless the API client is mocked, so integration harnesses typically route through a fake transport.
+
+Worked example: WooPayments' `Abilities_Registrar` uses this pattern. Controllers extend `WC_Payments_REST_Controller`, whose constructor takes a `WC_Payments_API_Client`; the shared client comes from `WC_Payments::get_payments_api_client()`.
+
+## Pattern B — Zero-arg controllers ("Jetpack-family")
+
+Common in plugins/packages that delegate primarily to WordPress core mechanisms (custom post types, options, meta) and don't maintain a single shared API client. Controllers instantiate cleanly without a dependency graph.
+
+### Detection
+
+```bash
+grep -n "public function __construct" <path/to/rest-controller.php>
+```
+
+If the constructor takes no required arguments, or takes only simple scalars you can hardcode at the ability call site (e.g. a post-type string), you're in Pattern B.
+
+Also grep the plugin's main bootstrap class for the absence of a singleton API accessor — if there isn't one, Pattern B is the honest choice.
+
+### Minimal skeleton
+
+```php
+<?php
+namespace My_Plugin\Abilities;
+
+class Abilities_Registrar {
+
+    const CATEGORY_SLUG = 'my-plugin';
+
+    public static function init() {
+        add_action( 'wp_abilities_api_categories_init', [ __CLASS__, 'register_category' ] );
+        add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
+    }
+
+    public static function register_abilities() {
+        wp_register_ability(
+            'my-plugin/get-things',
+            [
+                /* ... */
+                'execute_callback' => [ __CLASS__, 'execute_get_things' ],
+                /* ... */
+            ]
+        );
+    }
+
+    public static function execute_get_things( $input = null ) {
+        $input    = is_array( $input ) ? $input : [];
+        $endpoint = new \My_Plugin_Things_Endpoint();
+        $request  = new \WP_REST_Request( 'GET', '/my-plugin/v1/things' );
+
+        foreach ( [ 'page', 'per_page', 'status', 'search' ] as $key ) {
+            if ( isset( $input[ $key ] ) ) {
+                $request->set_param( $key, $input[ $key ] );
+            }
+        }
+
+        $response = $endpoint->get_items( $request );
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+        return $response instanceof \WP_REST_Response ? $response->get_data() : $response;
+    }
+}
+```
+
+No helper is required — the construction step is a single line and inlining per callback stays readable. If you do extract a helper, it takes a `constructor_args` parameter because the controller class isn't constant across abilities:
+
+```php
+private static function delegate_to_rest_controller(
+    string $controller_class,
+    string $method,
+    string $route,
+    ?array $input,
+    string $http_method = 'GET',
+    array $constructor_args = []
+): array|\WP_Error { /* ... */ }
+```
+
+See `delegate-helper-pattern.md` for the full helper signature and guards.
+
+### Testing implications
+
+- **No API-client mock needed.** Unit tests instantiate the ability registrar directly and call `execute_*` with input arrays.
+- **Test at the `wp_get_ability()` level when possible.** In Pattern B the backing controller often exists in WordPress core territory (e.g. custom post types), so integration tests can exercise the full pipeline without a fake transport.
+- **The `<plugin>_not_initialized` failure mode is less common.** It still exists — if a package isn't loaded, `class_exists` on the backing controller still fails — but the surface area is smaller.
+
+Worked example: Jetpack Forms' `Forms_Abilities` class instantiates `Contact_Form_Endpoint( 'feedback' )` per execute callback. No shared helper in the registrar; the construction step is inline. Canonical file: [`Automattic/jetpack/projects/packages/forms/src/abilities/class-forms-abilities.php`](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/forms/src/abilities/class-forms-abilities.php).
+
+## Hybrid cases
+
+A single plugin can legitimately use both patterns across different abilities:
+
+- A Pattern A ability for backing controllers that talk to the upstream service.
+- A Pattern B ability for backing controllers that only touch WP core (e.g. a CPT-based settings endpoint in the same plugin).
+
+If this happens, the helper in `delegate-helper-pattern.md` can support both via optional `constructor_args` — but resist the temptation to over-engineer until you have at least two Pattern B abilities that would share the helper.
+
+## Anti-pattern — inventing an API client where there isn't one
+
+Don't introduce a fake shared API client to fit Pattern A's helper shape. If the plugin is genuinely stateless / CPT-driven, Pattern B's inline construction is the honest answer. The helper is scaffolding that pays back when you have 4+ abilities sharing the build-request → instantiate → unwrap flow; before that, inline code is faster to read and review.
+
+## Picking quickly
+
+| Signal | Likely pattern |
+|---|---|
+| Backing controller's `__construct` takes an API-client-like object | A |
+| Plugin has a `Plugin::get_*_client()` static accessor | A |
+| Plugin talks to an external SaaS / upstream HTTP service | A |
+| Backing controller `__construct` is zero-arg or only takes scalars | B |
+| Backing is a CPT / options / meta wrapper | B |
+| Plugin is a Jetpack-style first-party WordPress package | B |

--- a/.agents/skills/wp-abilities-api/references/plugin-family-patterns.md
+++ b/.agents/skills/wp-abilities-api/references/plugin-family-patterns.md
@@ -2,7 +2,7 @@
 
 When you adopt the Abilities API inside an existing plugin, the plugin's architecture dictates HOW your execute callbacks call the existing business logic. Two patterns cover most real-world WordPress plugins. Pick one up front — the choice ripples through your delegate helper, your tests, and your error codes.
 
-## Pattern A — Shared-API-client ("Woo-family")
+## Pattern A — Shared-API-client
 
 Common in plugins that talk to a remote service (Stripe, a first-party SaaS, an upstream API). The plugin bootstraps a single API client, exposes it via a static accessor on a main plugin class, and every REST controller takes that client as a constructor argument.
 
@@ -106,9 +106,9 @@ class Abilities_Registrar {
 - **The "not initialized" error path is reachable and must be covered.** One unit test should stub the accessor to return null and assert the ability returns `<plugin>_not_initialized`. This is a common failure during partial bootstraps (WP-CLI with restricted loading, test harnesses, admin pages with conditional autoloading).
 - **Integration tests need real or faked HTTP.** The backing controller will hit the upstream unless the API client is mocked, so integration harnesses typically route through a fake transport.
 
-Worked example: WooPayments' `Abilities_Registrar` uses this pattern. Controllers extend `WC_Payments_REST_Controller`, whose constructor takes a `WC_Payments_API_Client`; the shared client comes from `WC_Payments::get_payments_api_client()`.
+Worked example: a plugin where every REST controller extends a shared `<Plugin>_REST_Controller` base whose constructor takes a `<Plugin>_API_Client`. The shared client is exposed via a static accessor on the main plugin class (`<Plugin>::get_api_client()`). The Abilities_Registrar fetches the client once per execute call and passes it into a freshly-constructed controller.
 
-## Pattern B — Zero-arg controllers ("Jetpack-family")
+## Pattern B — Zero-arg controllers
 
 Common in plugins/packages that delegate primarily to WordPress core mechanisms (custom post types, options, meta) and don't maintain a single shared API client. Controllers instantiate cleanly without a dependency graph.
 

--- a/.agents/skills/wp-abilities-api/references/rest-api.md
+++ b/.agents/skills/wp-abilities-api/references/rest-api.md
@@ -1,0 +1,13 @@
+# REST API quick guide (`wp-abilities/v1`)
+
+The Abilities API exposes endpoints under the REST namespace:
+
+- `wp-abilities/v1/abilities`
+- `wp-abilities/v1/categories`
+
+Debug checklist:
+
+- Confirm the route exists under `wp-json/wp-abilities/v1/...`.
+- Verify the ability/category shows in REST responses.
+- If missing, confirm `meta.show_in_rest` is enabled for that ability.
+

--- a/.agents/skills/wp-abilities-audit.md
+++ b/.agents/skills/wp-abilities-audit.md
@@ -119,14 +119,15 @@ document structure must match `wp-abilities-audit/references/audit-schema.md` ex
 3. "Controller Inventory" table.
 4. "Notes and Surprises" prose section.
 
-**Worked examples** (reference implementations of what the output should
-look like):
+**Reference shapes** of audit docs:
 
-- `/Users/rtiodev/rtiodev_vault/plans/2026-04-20-abilities-everywhere-woopayments-audit.md`
-  — WooPayments (shared-API-client pattern, single capability gate).
-- `/Users/rtiodev/rtiodev_vault/plans/2026-04-20-abilities-audit-woocommerce-subscriptions.md`
-  — WooCommerce Subscriptions (post-type-backed capabilities, inherited
-  controllers, compound `{read, write}` gate).
+- WooPayments-style — shared-API-client pattern, single capability gate.
+- WooCommerce Subscriptions-style — post-type-backed capabilities,
+  inherited controllers, compound `{read, write}` gate.
+
+See `wp-abilities-audit/references/audit-schema.md` for the field-by-field
+schema and the legal shapes for `capability_gate`, `proposed_abilities`,
+`excluded_from_mvp`, and `surfaced_gaps`.
 
 ### 7. (Optional) Designate a reference implementation ability
 

--- a/.agents/skills/wp-abilities-audit.md
+++ b/.agents/skills/wp-abilities-audit.md
@@ -1,0 +1,182 @@
+---
+name: wp-abilities-audit
+description: "Audit a WordPress plugin's REST surface and produce a standardized audit document proposing Abilities API registrations. Produces a markdown doc with a YAML schema consumable by downstream implementation and verification skills. Works on any WP plugin."
+compatibility: "Targets WordPress 6.9+ (PHP 7.2.24+). Filesystem-based agent with bash + node. Requires access to the plugin checkout; some workflows benefit from WP-CLI but don't require it."
+---
+
+# WP Abilities Audit
+
+Produce a standardized audit document for a WordPress plugin's REST surface,
+proposing a set of Abilities API registrations grouped by semantic intent. The
+audit doc is the planning artifact that downstream implement and verify skills
+consume via a hard handoff — if the implement skill can't find a valid audit
+doc conforming to this schema, it errors out rather than guessing.
+
+This skill works on any Automattic-owned WordPress plugin (or any plugin that
+exposes a REST surface). Plugin classification is handled by `wp-project-triage`;
+this skill consumes the triage output and applies the audit workflow generically.
+
+## When to use
+
+- The task is "register Abilities API abilities for a WP plugin" and no audit
+  doc exists yet.
+- Planning participation in a multi-plugin abilities rollout and need a
+  shareable, standardized audit artifact.
+- Pre-flight checking a plugin's agent-readiness before implementing abilities.
+- A PM or non-implementer wants to scope the work before engineering picks it up.
+
+## Inputs required
+
+1. **Plugin checkout path** — working tree of the plugin to audit.
+2. **Triage output** — run `wp-project-triage` first if not already done. The
+   audit consumes `signals.usesAbilitiesApi`, `versions.wordpress`, and
+   `project.kind` from the report.
+3. **Maintainer / team name** — recorded in the audit's `auditor` field.
+4. **Output path** — where the audit doc should land (typically the user's
+   vault / plans directory). Default explicit over implicit; ask if not
+   provided rather than writing into the plugin worktree.
+
+## Prerequisites
+
+- `wp-project-triage` has run successfully and classified the plugin.
+- The plugin has at least one REST controller. If enumeration finds zero
+  controllers, the audit doesn't apply — see "Failure modes" below.
+
+## Procedure
+
+### 1. Enumerate REST controllers
+
+Read `wp-abilities-audit/references/controller-enumeration.md` now — it covers the two observed
+enumeration paths (glob for standard layouts, grep as the universal fallback)
+and when to use each.
+
+Record every controller class + file + REST base + routes in a "Controller
+Inventory" table. The inventory is exhaustive even though only a subset
+becomes proposed abilities.
+
+### 2. For each controller, extract the backing fields
+
+For every controller found, extract the fields the audit schema requires:
+class, file, HTTP method, route, route-registration line number, callback
+name, callback line number, permission callback, whether the callback takes
+a `WP_REST_Request` argument or is zero-arg, and the return type.
+
+Read `wp-abilities-audit/references/audit-schema.md` now for the exact field list and the shape
+of `proposed_abilities` entries. Line-number fields may be `null` for
+inherited callbacks — the schema allows this and pairs it with an optional
+`inherited_from` field.
+
+### 3. Confirm capability gate(s)
+
+Trace each controller's `permission_callback` to its `current_user_can()` call
+(or to the post-type capability machinery if the controller extends a
+post-type-backed base).
+
+Read `wp-abilities-audit/references/capability-gate-tracing.md` now — it documents the two
+common mechanisms (direct `check_permission()` vs post-type-backed
+`wc_rest_check_post_permissions()`) and how to represent each in the schema.
+Note explicitly whether read and write gates differ: compound gates are
+represented as a `{read, write}` object, not a single string.
+
+### 4. Propose abilities using semantic-intent grouping
+
+Do NOT atomize one ability per HTTP method. Apply the semantic-intent grouping
+heuristic — it's the only grouping rule this skill uses.
+
+Read `wp-abilities-api/references/grouping-heuristic.md` now — do NOT
+re-derive the rules here. Short version: one ability per real-world question
+or state transition, with filter parameters in `input_schema` collapsing N
+variants into 1.
+
+For each proposed ability, fill in every field in the `proposed_abilities`
+schema: `name`, `intent`, `backing`, `permission`, `return_type`, `effort`
+(S/M/L), `annotations` (readonly/destructive/idempotent), `notes`, `risks`.
+
+### 5. Surface gaps and deferred items
+
+Three buckets:
+
+- **`excluded_from_mvp`** — candidates intentionally deferred for risk reasons
+  (real-money writes, irreversible state changes, or prerequisite design
+  work). Each entry gets a one-sentence reason.
+- **`surfaced_gaps`** — MVP candidates with no backing endpoint (ability with
+  `backing: null`), plus high-value endpoints discovered during enumeration
+  that aren't in the MVP list but would be easy future wins.
+- **Risks per ability** — anything about a backing endpoint that the
+  implementer must handle (no idempotency key, two-phase behavior,
+  state-transition caveats, zero-arg endpoints registered with
+  `permission_callback => '__return_true'` that must NOT copy that into the
+  ability registration).
+
+### 6. Write the audit doc
+
+Write to the explicit output path collected in "Inputs required". The
+document structure must match `wp-abilities-audit/references/audit-schema.md` exactly:
+
+1. `Last updated: YYYY-MM-DD HH:MM` header.
+2. YAML block with all required top-level metadata + `proposed_abilities`,
+   `excluded_from_mvp`, `surfaced_gaps`.
+3. "Controller Inventory" table.
+4. "Notes and Surprises" prose section.
+
+**Worked examples** (reference implementations of what the output should
+look like):
+
+- `/Users/rtiodev/rtiodev_vault/plans/2026-04-20-abilities-everywhere-woopayments-audit.md`
+  — WooPayments (shared-API-client pattern, single capability gate).
+- `/Users/rtiodev/rtiodev_vault/plans/2026-04-20-abilities-audit-woocommerce-subscriptions.md`
+  — WooCommerce Subscriptions (post-type-backed capabilities, inherited
+  controllers, compound `{read, write}` gate).
+
+### 7. (Optional) Designate a reference implementation ability
+
+Set `reference_ability: true` on the first ability the implement skill should
+land — typically the smallest, safest, highest-leverage read. This gives
+downstream workflows a deterministic starting point.
+
+## Verification
+
+- The audit conforms to `wp-abilities-audit/references/audit-schema.md` (all required top-level
+  fields present, at least one entry in `proposed_abilities`, annotations
+  complete on every ability).
+- `plugin_family` is populated from `wp-project-triage` output.
+- `capability_gate` is a string for single-cap plugins or a `{read, write}`
+  object for post-type-backed plugins.
+- Every ability with `backing: null` also appears in `surfaced_gaps`.
+- The doc passes the precondition check used by the downstream implement
+  skill (see `wp-abilities-audit/references/audit-schema.md` for the required-field list).
+
+## Failure modes / debugging
+
+- **Plugin has no REST controllers** — audit doesn't apply. Consider
+  hooks/filters-based abilities (out of scope for this skill's current
+  version) or skip abilities adoption for this plugin.
+- **Plugin inherits controllers from another repo** (common for WooCommerce
+  extensions extending `WC_REST_Orders_Controller` etc.) — capture with
+  `backing.inherited_from: "<parent FQCN>"`. Line-number fields may be
+  `null` per the schema.
+- **Compound capability gate (distinct read/write caps)** — use the
+  structured `{read, write}` form documented in
+  `wp-abilities-audit/references/capability-gate-tracing.md`. Don't smuggle a `/`-separated
+  string into a field typed as a single cap.
+- **Ambiguous grouping** — route to
+  `wp-abilities-api/references/grouping-heuristic.md`. Do not invent
+  alternative grouping rules in the audit doc.
+- **Zero-arg endpoints with `permission_callback => '__return_true'`** —
+  legal at the REST layer, but the ability's own `permission_callback` must
+  match the plugin's merchant gate. Never promote `'__return_true'` into an
+  ability registration. Note this in the ability's `risks`.
+- **Output path defaults to plugin worktree** — always ask the user for an
+  explicit output directory (e.g. their vault `plans/`). Writing the audit
+  into the plugin's own git history pollutes the worktree and buries the
+  artifact.
+
+## Escalation
+
+- If the plugin uses an enumeration convention not covered by
+  `wp-abilities-audit/references/controller-enumeration.md` (neither the standard glob nor the
+  grep fallback produces a complete inventory), update that reference with
+  the new convention and open a PR so future audits cover it deterministically.
+- If capability tracing hits a mechanism not covered by
+  `wp-abilities-audit/references/capability-gate-tracing.md`, extend that file rather than
+  encoding the new case in the audit's "Notes and Surprises" only.

--- a/.agents/skills/wp-abilities-audit.md
+++ b/.agents/skills/wp-abilities-audit.md
@@ -74,7 +74,7 @@ post-type-backed base).
 
 Read `wp-abilities-audit/references/capability-gate-tracing.md` now — it documents the two
 common mechanisms (direct `check_permission()` vs post-type-backed
-`wc_rest_check_post_permissions()`) and how to represent each in the schema.
+permission helpers in core or plugin code) and how to represent each in the schema.
 Note explicitly whether read and write gates differ: compound gates are
 represented as a `{read, write}` object, not a single string.
 
@@ -121,9 +121,12 @@ document structure must match `wp-abilities-audit/references/audit-schema.md` ex
 
 **Reference shapes** of audit docs:
 
-- WooPayments-style — shared-API-client pattern, single capability gate.
-- WooCommerce Subscriptions-style — post-type-backed capabilities,
-  inherited controllers, compound `{read, write}` gate.
+- Single-cap plugin with a shared API client — one capability gate for the
+  whole plugin, every controller takes the shared client as a constructor
+  argument.
+- Post-type-backed plugin — compound `{read, write}` capabilities derived
+  from a CPT's `capability_type` map, controllers often inherited from
+  WordPress core REST base classes.
 
 See `wp-abilities-audit/references/audit-schema.md` for the field-by-field
 schema and the legal shapes for `capability_gate`, `proposed_abilities`,
@@ -152,8 +155,9 @@ downstream workflows a deterministic starting point.
 - **Plugin has no REST controllers** — audit doesn't apply. Consider
   hooks/filters-based abilities (out of scope for this skill's current
   version) or skip abilities adoption for this plugin.
-- **Plugin inherits controllers from another repo** (common for WooCommerce
-  extensions extending `WC_REST_Orders_Controller` etc.) — capture with
+- **Plugin inherits controllers from another repo** (common when extending
+  WordPress core REST base classes or another plugin's controllers) —
+  capture with
   `backing.inherited_from: "<parent FQCN>"`. Line-number fields may be
   `null` per the schema.
 - **Compound capability gate (distinct read/write caps)** — use the

--- a/.agents/skills/wp-abilities-audit/references/audit-schema.md
+++ b/.agents/skills/wp-abilities-audit/references/audit-schema.md
@@ -6,9 +6,9 @@ verify skills consume it and error out on invalid or missing fields.
 
 Two reference shapes the schema below is designed to cover:
 
-- Single-cap plugin with a shared API client (WooPayments-style).
+- Single-cap plugin with a shared API client.
 - Post-type-backed plugin with compound `{read, write}` caps and inherited
-  controllers (WooCommerce Subscriptions-style).
+  controllers.
 
 ## File layout
 
@@ -32,12 +32,12 @@ A `Last updated: YYYY-MM-DD HH:MM` header sits above everything.
 
 | Field | Type | Description |
 |---|---|---|
-| `plugin` | string | Plugin slug (e.g. `woopayments`, `woocommerce-subscriptions`, `jetpack-forms`). |
-| `repo` | string | `Owner/Repository` (e.g. `Automattic/woocommerce-payments`). |
-| `plugin_family` | string | Classification from `wp-project-triage`. REQUIRED. Common values: `woo-payments`, `woo-extension`, `jetpack`, plus any family triage adds over time. Free-form string — downstream consumers treat unknown values as opaque rather than erroring. |
+| `plugin` | string | Plugin slug (e.g. `jetpack-forms`, `jetpack-stats`, `jetpack-subscriptions`). |
+| `repo` | string | `Owner/Repository` (e.g. `Automattic/jetpack`). |
+| `plugin_family` | string | Classification from `wp-project-triage`. REQUIRED. Common values: `jetpack`, `jetpack-package`, plus any family triage adds over time. Free-form string — downstream consumers treat unknown values as opaque rather than erroring. |
 | `branch_audited` | string | Git branch the audit was run against. |
 | `audited_at` | string | ISO date (YYYY-MM-DD). |
-| `auditor` | string | Human auditor name + team (e.g. `Rafael (Gamma)`). |
+| `auditor` | string | Human auditor name + team. |
 | `baseline_abilities` | integer | Count of abilities already registered by the plugin at audit time. Usually 0. |
 | `capability_gate` | string OR object | The capability gate the base controller resolves to. Accept either a single string (single-cap plugins) OR a `{read, write}` object (post-type-backed or otherwise compound gates). See `capability-gate-tracing.md` for the mechanisms. |
 
@@ -46,17 +46,17 @@ A `Last updated: YYYY-MM-DD HH:MM` header sits above everything.
 Two legal shapes, both consumed by downstream skills:
 
 ```yaml
-# Single-cap plugin (e.g. WooPayments — manage_woocommerce uniformly)
-capability_gate: manage_woocommerce  # confirmed at includes/admin/class-wc-payments-rest-controller.php line 64
+# Single-cap plugin (one capability for the whole plugin)
+capability_gate: manage_options  # confirmed at includes/rest/class-<plugin>-rest-controller.php line 64
 ```
 
 ```yaml
-# Compound read/write (e.g. WooCommerce Subscriptions — post-type-backed)
+# Compound read/write (post-type-backed CPT with map_meta_cap)
 capability_gate:
-  read: read_private_shop_orders
-  write: edit_shop_orders
+  read: read_private_<cpt-base>s
+  write: edit_<cpt-base>s
   confirmed: true
-  verified_at: "shop_subscription capability_type='shop_order' → WC core includes/wc-rest-functions.php line 229"
+  verified_at: "<cpt-slug> capability_type='<cpt-base>' → core map_meta_cap()"
 ```
 
 A legacy compound-string form exists in the wild (`"<read_cap> / <write_cap>"`)
@@ -102,14 +102,14 @@ as a warning, not an error:
 | `route_registration_line` | integer OR `null` | Line number of the `register_rest_route(` call, or `null` when inherited from a parent controller that lives outside the plugin repo. |
 | `callback` | string | Controller method name that handles the route. |
 | `callback_line` | integer OR `null` | Line number of the callback method definition, or `null` when inherited. |
-| `inherited_from` | string (optional) | Fully-qualified parent class name when the route and/or callback is inherited (e.g. `WC_REST_Orders_Controller`). Pair with `null` line numbers. Lets downstream skills skip the re-grep step cleanly. |
+| `inherited_from` | string (optional) | Fully-qualified parent class name when the route and/or callback is inherited (e.g. `WP_REST_Posts_Controller`). Pair with `null` line numbers. Lets downstream skills skip the re-grep step cleanly. |
 
 ### `permission` object
 
 | Field | Type | Description |
 |---|---|---|
 | `callback` | string | The method name used as `permission_callback`. |
-| `resolves_to` | string | The `current_user_can()` call(s) it ultimately resolves to. For compound gates, include both (e.g. `"current_user_can('read_private_shop_orders')` for read; `current_user_can('edit_shop_orders')` for write"). |
+| `resolves_to` | string | The `current_user_can()` call(s) it ultimately resolves to. For compound gates, include both (e.g. `"current_user_can('read_private_<cpt-base>s')` for read; `current_user_can('edit_<cpt-base>s')` for write"). |
 | `confirmed` | bool | `true` if verified against source; `false` if inferred. |
 
 ## `excluded_from_mvp` — array
@@ -162,12 +162,12 @@ Last updated: 2026-04-20 14:30
 ```yaml
 plugin: example-plugin
 repo: Owner/example-plugin
-plugin_family: woo-extension
+plugin_family: jetpack
 branch_audited: feat/abilities-example-plugin
 audited_at: 2026-04-20
 auditor: Your Name (Your Team)
 baseline_abilities: 0
-capability_gate: manage_woocommerce  # confirmed at includes/rest-api/class-example-rest-controller.php line 32
+capability_gate: manage_options  # confirmed at includes/rest-api/class-example-rest-controller.php line 32
 
 proposed_abilities:
 
@@ -183,7 +183,7 @@ proposed_abilities:
       callback_line: 52
     permission:
       callback: check_permission
-      resolves_to: "current_user_can('manage_woocommerce')"
+      resolves_to: "current_user_can('manage_options')"
       confirmed: true
     return_type: "WP_REST_Response (wrapping array)"
     effort: S
@@ -205,7 +205,7 @@ proposed_abilities:
       callback_line: 120
     permission:
       callback: check_permission
-      resolves_to: "current_user_can('manage_woocommerce')"
+      resolves_to: "current_user_can('manage_options')"
       confirmed: true
     return_type: "WP_REST_Response (updated item object)"
     effort: M
@@ -235,7 +235,7 @@ surfaced_gaps:
 ### Capability gate is uniform
 Every controller inherits `Example_Base_REST_Controller` and uses
 `check_permission` verbatim as the `permission_callback`. No per-route
-overrides. Safe to treat `manage_woocommerce` as the single gate.
+overrides. Safe to treat `manage_options` as the single gate.
 ````
 
 ## Known limitations

--- a/.agents/skills/wp-abilities-audit/references/audit-schema.md
+++ b/.agents/skills/wp-abilities-audit/references/audit-schema.md
@@ -1,0 +1,258 @@
+# Audit Document Schema
+
+The canonical schema for an abilities audit doc. Every audit produced by
+`wp-abilities-audit` must conform to this schema — downstream implement and
+verify skills consume it and error out on invalid or missing fields.
+
+Two complete reference implementations live in the author's vault:
+
+- `/Users/rtiodev/rtiodev_vault/plans/2026-04-20-abilities-everywhere-woopayments-audit.md`
+  (single-cap plugin with a shared API client).
+- `/Users/rtiodev/rtiodev_vault/plans/2026-04-20-abilities-audit-woocommerce-subscriptions.md`
+  (post-type-backed plugin with compound `{read, write}` caps and inherited
+  controllers).
+
+## File layout
+
+```
+<output-dir>/<YYYY-MM-DD>-abilities-audit-<plugin-slug>.md
+```
+
+`<output-dir>` is explicit — collected from the user, not inferred. Typical
+values are the user's vault `plans/` directory or a dedicated audit repo.
+Writing into the plugin worktree is discouraged (pollutes git history).
+
+The body has two parts:
+
+1. A fenced ` ```yaml ` block holding structured fields (top-level metadata
+   + `proposed_abilities`, `excluded_from_mvp`, `surfaced_gaps`).
+2. Prose sections below: "Controller Inventory" table + "Notes and Surprises".
+
+A `Last updated: YYYY-MM-DD HH:MM` header sits above everything.
+
+## Top-level fields (all required)
+
+| Field | Type | Description |
+|---|---|---|
+| `plugin` | string | Plugin slug (e.g. `woopayments`, `woocommerce-subscriptions`, `jetpack-forms`). |
+| `repo` | string | `Owner/Repository` (e.g. `Automattic/woocommerce-payments`). |
+| `plugin_family` | string | Classification from `wp-project-triage`. REQUIRED. Common values: `woo-payments`, `woo-extension`, `jetpack`, plus any family triage adds over time. Free-form string — downstream consumers treat unknown values as opaque rather than erroring. |
+| `branch_audited` | string | Git branch the audit was run against. |
+| `audited_at` | string | ISO date (YYYY-MM-DD). |
+| `auditor` | string | Human auditor name + team (e.g. `Rafael (Gamma)`). |
+| `baseline_abilities` | integer | Count of abilities already registered by the plugin at audit time. Usually 0. |
+| `capability_gate` | string OR object | The capability gate the base controller resolves to. Accept either a single string (single-cap plugins) OR a `{read, write}` object (post-type-backed or otherwise compound gates). See `capability-gate-tracing.md` for the mechanisms. |
+
+### `capability_gate` representations
+
+Two legal shapes, both consumed by downstream skills:
+
+```yaml
+# Single-cap plugin (e.g. WooPayments — manage_woocommerce uniformly)
+capability_gate: manage_woocommerce  # confirmed at includes/admin/class-wc-payments-rest-controller.php line 64
+```
+
+```yaml
+# Compound read/write (e.g. WooCommerce Subscriptions — post-type-backed)
+capability_gate:
+  read: read_private_shop_orders
+  write: edit_shop_orders
+  confirmed: true
+  verified_at: "shop_subscription capability_type='shop_order' → WC core includes/wc-rest-functions.php line 229"
+```
+
+A legacy compound-string form exists in the wild (`"<read_cap> / <write_cap>"`)
+and is accepted for backwards compatibility, but the structured form above is
+the preferred representation for new audits.
+
+## `proposed_abilities` — array
+
+Each entry:
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Kebab-case `<plugin-slug>/<ability>`. |
+| `intent` | string | One sentence, user-question framed. |
+| `backing` | object or `null` | See below. `null` marks an ability with no backing endpoint (a known gap). |
+| `permission` | object or `null` | See below. `null` when `backing` is null. |
+| `return_type` | string | Short description (e.g. `WP_REST_Response (wrapping array)`). Hint-only; not machine-parsed. |
+| `effort` | enum | `S`, `M`, or `L`. |
+| `annotations` | object | `{ readonly: bool, destructive: bool, idempotent: bool }`. All three required. |
+| `notes` | array of strings | Implementer-facing detail (filter params, edge cases, alternative backings). |
+| `risks` | array of strings | Anything the implementer must handle (missing idempotency key, two-phase behavior, `permission_callback => '__return_true'` at the REST layer that must not copy into the ability, etc.). |
+| `reference_ability` | bool (optional) | If `true`, marks this ability as the reference implementation — the first one the implement skill should land. Exactly zero or one ability per audit may set this. |
+
+### `backing: null` semantics
+
+An ability with `backing: null` is a known gap (the auditor identified a
+valuable ability that has no backing endpoint yet). The schema permits this
+as a warning, not an error:
+
+- The ability MUST also appear in `surfaced_gaps` with a one-line rationale.
+- Downstream implement skills pause for human resolution rather than failing.
+- The audit is still valid; `backing: null` is intentional output, not
+  missing data.
+
+### `backing` object
+
+| Field | Type | Description |
+|---|---|---|
+| `class` | string | Fully-qualified PHP class name. |
+| `file` | string | Path relative to plugin root. |
+| `method` | enum | HTTP method: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`. |
+| `route` | string | Full REST route path. |
+| `route_registration_line` | integer OR `null` | Line number of the `register_rest_route(` call, or `null` when inherited from a parent controller that lives outside the plugin repo. |
+| `callback` | string | Controller method name that handles the route. |
+| `callback_line` | integer OR `null` | Line number of the callback method definition, or `null` when inherited. |
+| `inherited_from` | string (optional) | Fully-qualified parent class name when the route and/or callback is inherited (e.g. `WC_REST_Orders_Controller`). Pair with `null` line numbers. Lets downstream skills skip the re-grep step cleanly. |
+
+### `permission` object
+
+| Field | Type | Description |
+|---|---|---|
+| `callback` | string | The method name used as `permission_callback`. |
+| `resolves_to` | string | The `current_user_can()` call(s) it ultimately resolves to. For compound gates, include both (e.g. `"current_user_can('read_private_shop_orders')` for read; `current_user_can('edit_shop_orders')` for write"). |
+| `confirmed` | bool | `true` if verified against source; `false` if inferred. |
+
+## `excluded_from_mvp` — array
+
+Abilities intentionally deferred for risk reasons. Each entry:
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Proposed ability name (kebab-case). |
+| `reason` | string | One sentence why it's deferred. |
+
+## `surfaced_gaps` — array
+
+MVP candidates with no backing endpoint (paired with `backing: null` above),
+plus high-value endpoints discovered during enumeration that aren't in MVP
+but would make future follow-up work. Each entry:
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Proposed ability name. |
+| `one_line_rationale` | string | Why it would be high-leverage. |
+
+## Prose sections (required)
+
+### Controller Inventory
+
+A Markdown table with columns `Class | File | REST Base | Routes`. Must list
+every controller enumeration found, even ones that aren't backing any MVP
+ability. This gives reviewers a full picture and catches "why isn't X in the
+MVP?" questions.
+
+### Notes and Surprises
+
+Free-form prose capturing anything that didn't fit the structured schema:
+capability-gate mismatches between controllers, hardcoded route paths, dual
+controllers with different output shapes, two-phase endpoint semantics, and
+any judgment calls the auditor made.
+
+## Minimal valid example
+
+Copy-pasteable starting point for a new audit:
+
+````markdown
+---
+Last updated: 2026-04-20 14:30
+---
+
+# Example Plugin Abilities — Phase 1 Audit
+
+```yaml
+plugin: example-plugin
+repo: Owner/example-plugin
+plugin_family: woo-extension
+branch_audited: feat/abilities-example-plugin
+audited_at: 2026-04-20
+auditor: Your Name (Your Team)
+baseline_abilities: 0
+capability_gate: manage_woocommerce  # confirmed at includes/rest-api/class-example-rest-controller.php line 32
+
+proposed_abilities:
+
+  - name: example-plugin/get-items
+    intent: "List items with filters (status, customer, date range) so an agent can answer 'which items need attention?' in one call."
+    backing:
+      class: Example_REST_Items_Controller
+      file: includes/rest-api/class-example-rest-items-controller.php
+      method: GET
+      route: /example/v1/items
+      route_registration_line: 26
+      callback: get_items
+      callback_line: 52
+    permission:
+      callback: check_permission
+      resolves_to: "current_user_can('manage_woocommerce')"
+      confirmed: true
+    return_type: "WP_REST_Response (wrapping array)"
+    effort: S
+    annotations: { readonly: true, destructive: false, idempotent: true }
+    notes:
+      - "get_items(WP_REST_Request $request) requires a WP_REST_Request; construct one in the ability execute_callback."
+    risks: []
+    reference_ability: true
+
+  - name: example-plugin/close-item
+    intent: "Close a single item — terminal state transition, non-reversible."
+    backing:
+      class: Example_REST_Items_Controller
+      file: includes/rest-api/class-example-rest-items-controller.php
+      method: POST
+      route: /example/v1/items/{id}/close
+      route_registration_line: 41
+      callback: close_item
+      callback_line: 120
+    permission:
+      callback: check_permission
+      resolves_to: "current_user_can('manage_woocommerce')"
+      confirmed: true
+    return_type: "WP_REST_Response (updated item object)"
+    effort: M
+    annotations: { readonly: false, destructive: true, idempotent: false }
+    notes:
+      - "Close is terminal — no reopen endpoint exists."
+    risks:
+      - "No idempotency key on the backing endpoint; duplicate POSTs may produce inconsistent audit trails."
+
+excluded_from_mvp:
+  - name: example-plugin/delete-item
+    reason: "Hard delete is irreversible and lacks an undo endpoint; defer until soft-delete is designed."
+
+surfaced_gaps:
+  - name: example-plugin/get-overview
+    one_line_rationale: "A zero-arg overview endpoint answering 'what's the current state of all items?' would be the highest-leverage ability but no backing endpoint exists yet."
+```
+
+## Controller Inventory
+
+| Class | File | REST Base | Routes |
+|---|---|---|---|
+| Example_REST_Items_Controller | includes/rest-api/class-example-rest-items-controller.php | example/v1/items | GET /example/v1/items, POST /example/v1/items/{id}/close |
+
+## Notes and Surprises
+
+### Capability gate is uniform
+Every controller inherits `Example_Base_REST_Controller` and uses
+`check_permission` verbatim as the `permission_callback`. No per-route
+overrides. Safe to treat `manage_woocommerce` as the single gate.
+````
+
+## Known limitations
+
+Documented so downstream skills have an explicit contract:
+
+- **`capability_gate` string-with-inline-comment form** loses data when parsed
+  by strict YAML parsers (comments are dropped). The structured object form is
+  preferred; string form is accepted for backwards compatibility.
+- **`return_type` is hint-only.** Prose for the human auditor; not
+  machine-parseable. Downstream skills use runtime `is_wp_error(...)` and
+  `instanceof WP_REST_Response` checks regardless of what this field says.
+- **Line numbers drift.** `route_registration_line` and `callback_line` are
+  captured at audit time and may bit-rot. Downstream skills re-locate routes
+  by `(class, callback)` and do not rely on exact line numbers.
+- **`inherited_from` + `null` line numbers** are the canonical way to
+  represent routes/callbacks defined in a parent class that lives outside
+  the plugin repo.

--- a/.agents/skills/wp-abilities-audit/references/audit-schema.md
+++ b/.agents/skills/wp-abilities-audit/references/audit-schema.md
@@ -4,13 +4,11 @@ The canonical schema for an abilities audit doc. Every audit produced by
 `wp-abilities-audit` must conform to this schema — downstream implement and
 verify skills consume it and error out on invalid or missing fields.
 
-Two complete reference implementations live in the author's vault:
+Two reference shapes the schema below is designed to cover:
 
-- `/Users/rtiodev/rtiodev_vault/plans/2026-04-20-abilities-everywhere-woopayments-audit.md`
-  (single-cap plugin with a shared API client).
-- `/Users/rtiodev/rtiodev_vault/plans/2026-04-20-abilities-audit-woocommerce-subscriptions.md`
-  (post-type-backed plugin with compound `{read, write}` caps and inherited
-  controllers).
+- Single-cap plugin with a shared API client (WooPayments-style).
+- Post-type-backed plugin with compound `{read, write}` caps and inherited
+  controllers (WooCommerce Subscriptions-style).
 
 ## File layout
 

--- a/.agents/skills/wp-abilities-audit/references/capability-gate-tracing.md
+++ b/.agents/skills/wp-abilities-audit/references/capability-gate-tracing.md
@@ -6,7 +6,7 @@ controllers gate on. The audit's `capability_gate` field and each ability's
 controller docblock says.
 
 Validation runs against multiple plugins surfaced two common mechanisms —
-document both explicitly so the auditor doesn't hard-code WooPayments-style
+document both explicitly so the auditor doesn't hard-code single-cap-style
 assumptions.
 
 ## Mechanism A — Direct (`check_permission()` returning a single cap)
@@ -21,11 +21,11 @@ once. Every route in the controller uses that method as
 - The base controller has a method like:
   ```php
   public function check_permission() {
-      return current_user_can( 'manage_woocommerce' );
+      return current_user_can( 'manage_options' );
   }
   ```
-- Controllers extend the plugin's own base, not a WooCommerce/WordPress core
-  post-type-backed class.
+- Controllers extend the plugin's own base, not a WordPress core or
+  third-party post-type-backed class.
 - The grep `grep -n 'current_user_can' <base-controller>.php` yields one hit.
 
 ### How to trace
@@ -43,42 +43,43 @@ Trace once: the single `current_user_can()` call is the plugin's gate.
 ### How to represent in the audit
 
 ```yaml
-capability_gate: manage_woocommerce  # confirmed at includes/admin/class-<plugin>-rest-controller.php line 64
+capability_gate: manage_options  # confirmed at includes/admin/class-<plugin>-rest-controller.php line 64
 ```
 
-Example: WooPayments — every controller inherits
-`WC_Payments_REST_Controller::check_permission()` which resolves to
-`current_user_can('manage_woocommerce')`. One gate for the whole plugin.
+Worked example: a plugin where every controller inherits a
+`<Plugin>_REST_Controller::check_permission()` method that resolves to a
+single `current_user_can('<cap>')` call. One gate, one trace, one record.
 
-## Mechanism B — Post-type-backed (`wc_rest_check_post_permissions()`)
+## Mechanism B — Post-type-backed (CPT permission helpers)
 
-The controller extends a WooCommerce/WordPress core class that dispatches to
-the post-type capability map. There is no local `check_permission()` — the
-permission callback resolves dynamically at request time based on the
-request context (read vs write) and the post type's `cap` object.
+The controller extends a WordPress core or in-house base class that
+dispatches to the post-type capability map. There is no local
+`check_permission()` — the permission callback resolves dynamically at
+request time based on the request context (read vs write) and the post
+type's `cap` object.
 
 ### Identifying signs
 
 - The controller's base class is one of:
-  - `WC_REST_Orders_Controller` (WooCommerce core)
-  - `WC_REST_Posts_Controller`
-  - `WP_REST_Posts_Controller`
-  - Similar post-type-backed bases.
+  - `WP_REST_Posts_Controller` (WordPress core)
+  - `WP_REST_Controller` with a CPT-driven `permission_callback`
+  - A plugin-specific base extending one of the above.
 - No local `check_permission()` — permission callbacks are inherited.
-- The post type is registered with `capability_type => '<cpt_name>'` and
+- The post type is registered with `capability_type => '<cpt-base>'` and
   meta caps are mapped (usually by `map_meta_cap` in core).
 
 ### How to trace
 
 ```bash
 # Find the post-type registration.
-grep -rn "register_post_type\s*(\s*['\"]<cpt_name>['\"]" .
+grep -rn "register_post_type\s*(\s*['\"]<cpt-slug>['\"]" .
 
 # Check the capability_type and meta caps configuration.
 # The caps bag typically looks like:
-#   capability_type => '<shadow_type>' (e.g. 'shop_order' for shop_subscription)
-# which means the post type inherits the caps of the shadow type, which in
-# turn are registered by the plugin's Install class (grep for 'get_core_capabilities').
+#   capability_type => '<cpt-base>'
+# which means the post type's caps map to read_private_<cpt-base>s /
+# edit_<cpt-base>s via core's map_meta_cap (or a plugin filter that
+# customizes the mapping).
 ```
 
 Dynamic resolution typically lands at:
@@ -95,10 +96,10 @@ Use the structured `{read, write}` form from `audit-schema.md`:
 
 ```yaml
 capability_gate:
-  read: read_private_shop_orders
-  write: edit_shop_orders
+  read: read_private_<cpt-base>s
+  write: edit_<cpt-base>s
   confirmed: true
-  verified_at: "shop_subscription capability_type='shop_order' → WC core wc_rest_check_post_permissions() at includes/wc-rest-functions.php line 229"
+  verified_at: "<cpt-slug> capability_type='<cpt-base>' → core map_meta_cap()"
 ```
 
 In each ability's `permission` block, spell out both calls:
@@ -106,13 +107,13 @@ In each ability's `permission` block, spell out both calls:
 ```yaml
 permission:
   callback: get_items_permissions_check
-  resolves_to: "wc_rest_check_post_permissions('shop_subscription', 'read') → current_user_can('read_private_shop_orders')"
+  resolves_to: "permission helper for '<cpt-slug>', 'read' → current_user_can('read_private_<cpt-base>s')"
   confirmed: true
 ```
 
-Example: WooCommerce Subscriptions — `shop_subscription` is registered with
-`capability_type='shop_order'`, so reads gate on `read_private_shop_orders`
-and writes gate on `edit_shop_orders`. The audit captures both.
+Worked example: a plugin that registers a CPT (`<cpt-slug>`) with a
+`capability_type='<cpt-base>'`, so reads gate on `read_private_<cpt-base>s`
+and writes gate on `edit_<cpt-base>s`. The audit captures both.
 
 ## Compound-string form (accepted, not preferred)
 
@@ -120,7 +121,7 @@ Some earlier audits encoded compound gates as a single string with a `/`
 separator:
 
 ```yaml
-capability_gate: read_private_shop_orders / edit_shop_orders
+capability_gate: read_private_<cpt-base>s / edit_<cpt-base>s
 ```
 
 This is accepted for backwards compatibility, but:
@@ -158,6 +159,6 @@ that are safe to expose). The audit still needs a gate:
   "__return_true (public)"`) so the auditor isn't hiding reality.
 - Add a risk note: the **ability** registration must NOT copy
   `'__return_true'` — the ability's own `permission_callback` must match the
-  plugin's merchant gate (`manage_woocommerce`, `edit_pages`, etc.). The
-  ability layer is the agent-facing surface and needs that gate even when
-  the underlying REST route is public.
+  plugin's admin gate (e.g. `manage_options`, `edit_pages`). The ability
+  layer is the agent-facing surface and needs that gate even when the
+  underlying REST route is public.

--- a/.agents/skills/wp-abilities-audit/references/capability-gate-tracing.md
+++ b/.agents/skills/wp-abilities-audit/references/capability-gate-tracing.md
@@ -1,0 +1,163 @@
+# Capability-Gate Tracing
+
+How to resolve the actual capability (or capabilities) a plugin's REST
+controllers gate on. The audit's `capability_gate` field and each ability's
+`permission.resolves_to` field need to reflect reality, not what the
+controller docblock says.
+
+Validation runs against multiple plugins surfaced two common mechanisms —
+document both explicitly so the auditor doesn't hard-code WooPayments-style
+assumptions.
+
+## Mechanism A — Direct (`check_permission()` returning a single cap)
+
+The base REST controller declares a `check_permission()` (or
+`permissions_check()`) method that calls `current_user_can('<some_cap>')`
+once. Every route in the controller uses that method as
+`permission_callback`.
+
+### Identifying signs
+
+- The base controller has a method like:
+  ```php
+  public function check_permission() {
+      return current_user_can( 'manage_woocommerce' );
+  }
+  ```
+- Controllers extend the plugin's own base, not a WooCommerce/WordPress core
+  post-type-backed class.
+- The grep `grep -n 'current_user_can' <base-controller>.php` yields one hit.
+
+### How to trace
+
+```bash
+# Locate the base controller (usually the parent of every REST controller).
+grep -rn 'extends .*REST_Controller' includes/ | head
+
+# Read its permission_callback implementation.
+grep -n 'check_permission\|permissions_check' <base-controller>.php
+```
+
+Trace once: the single `current_user_can()` call is the plugin's gate.
+
+### How to represent in the audit
+
+```yaml
+capability_gate: manage_woocommerce  # confirmed at includes/admin/class-<plugin>-rest-controller.php line 64
+```
+
+Example: WooPayments — every controller inherits
+`WC_Payments_REST_Controller::check_permission()` which resolves to
+`current_user_can('manage_woocommerce')`. One gate for the whole plugin.
+
+## Mechanism B — Post-type-backed (`wc_rest_check_post_permissions()`)
+
+The controller extends a WooCommerce/WordPress core class that dispatches to
+the post-type capability map. There is no local `check_permission()` — the
+permission callback resolves dynamically at request time based on the
+request context (read vs write) and the post type's `cap` object.
+
+### Identifying signs
+
+- The controller's base class is one of:
+  - `WC_REST_Orders_Controller` (WooCommerce core)
+  - `WC_REST_Posts_Controller`
+  - `WP_REST_Posts_Controller`
+  - Similar post-type-backed bases.
+- No local `check_permission()` — permission callbacks are inherited.
+- The post type is registered with `capability_type => '<cpt_name>'` and
+  meta caps are mapped (usually by `map_meta_cap` in core).
+
+### How to trace
+
+```bash
+# Find the post-type registration.
+grep -rn "register_post_type\s*(\s*['\"]<cpt_name>['\"]" .
+
+# Check the capability_type and meta caps configuration.
+# The caps bag typically looks like:
+#   capability_type => '<shadow_type>' (e.g. 'shop_order' for shop_subscription)
+# which means the post type inherits the caps of the shadow type, which in
+# turn are registered by the plugin's Install class (grep for 'get_core_capabilities').
+```
+
+Dynamic resolution typically lands at:
+
+- **Read context** (GET list / GET item): `current_user_can('read_private_<type>s')` or `current_user_can('read_<type>', $id)`.
+- **Write context** (POST / PUT / DELETE): `current_user_can('edit_<type>s')` or `current_user_can('delete_<type>s', $id)`.
+
+The two often differ — post-type-backed plugins routinely have distinct read
+and write caps.
+
+### How to represent in the audit
+
+Use the structured `{read, write}` form from `audit-schema.md`:
+
+```yaml
+capability_gate:
+  read: read_private_shop_orders
+  write: edit_shop_orders
+  confirmed: true
+  verified_at: "shop_subscription capability_type='shop_order' → WC core wc_rest_check_post_permissions() at includes/wc-rest-functions.php line 229"
+```
+
+In each ability's `permission` block, spell out both calls:
+
+```yaml
+permission:
+  callback: get_items_permissions_check
+  resolves_to: "wc_rest_check_post_permissions('shop_subscription', 'read') → current_user_can('read_private_shop_orders')"
+  confirmed: true
+```
+
+Example: WooCommerce Subscriptions — `shop_subscription` is registered with
+`capability_type='shop_order'`, so reads gate on `read_private_shop_orders`
+and writes gate on `edit_shop_orders`. The audit captures both.
+
+## Compound-string form (accepted, not preferred)
+
+Some earlier audits encoded compound gates as a single string with a `/`
+separator:
+
+```yaml
+capability_gate: read_private_shop_orders / edit_shop_orders
+```
+
+This is accepted for backwards compatibility, but:
+
+- Downstream consumers have to heuristically split on `/`.
+- YAML comments after the string are silently dropped by strict parsers, so
+  provenance gets lost.
+- The `{read, write}` object form is machine-parseable and carries
+  `confirmed` and `verified_at` in-band.
+
+Prefer the structured form for any new audit.
+
+## Procedure — trace every route you'll back
+
+For each proposed ability, walk the chain once:
+
+1. Find the route's `permission_callback` in the controller.
+2. Determine whether it's Mechanism A (local method, single cap) or
+   Mechanism B (inherited, post-type-backed, dynamic).
+3. Resolve to the actual `current_user_can()` call(s). For B, resolve BOTH
+   read and write if the ability crosses contexts.
+4. Record in the ability's `permission.resolves_to` field verbatim — the
+   string should read as an actual trace, not a best-guess summary.
+5. If every route in the plugin resolves to the same cap (or same
+   `{read, write}` pair), hoist it into the top-level `capability_gate`. If
+   any route diverges, record the divergence in "Notes and Surprises".
+
+## Common pitfall — `permission_callback => '__return_true'`
+
+Zero-arg public endpoints sometimes declare `permission_callback =>
+'__return_true'` at the REST layer (e.g. status lookups, enumerated lists
+that are safe to expose). The audit still needs a gate:
+
+- Record the REST-layer value as-is (`resolves_to:
+  "__return_true (public)"`) so the auditor isn't hiding reality.
+- Add a risk note: the **ability** registration must NOT copy
+  `'__return_true'` — the ability's own `permission_callback` must match the
+  plugin's merchant gate (`manage_woocommerce`, `edit_pages`, etc.). The
+  ability layer is the agent-facing surface and needs that gate even when
+  the underlying REST route is public.

--- a/.agents/skills/wp-abilities-audit/references/controller-enumeration.md
+++ b/.agents/skills/wp-abilities-audit/references/controller-enumeration.md
@@ -1,0 +1,112 @@
+# Controller Enumeration
+
+How to produce an exhaustive list of a plugin's REST controllers — the first
+step of every audit. Plugin family classification is handled separately by
+`wp-project-triage`; this reference covers the mechanics of finding controller
+classes inside whatever layout the plugin happens to use.
+
+## Two enumeration paths
+
+Observed across the plugins audited to date, there are exactly two paths that
+together cover every layout seen in the wild:
+
+| Path | When it works | How it works |
+|---|---|---|
+| **Glob** | Plugins that follow the standard `includes/admin/class-*-rest-*-controller.php` layout (WooCommerce core extensions, classic WooPayments). | Fast, deterministic, easy to script. Returns a complete list in one shell call. |
+| **Grep** | Any non-standard layout — `includes/api/`, `includes/rest-api/`, `src/rest/`, monorepo package directories, or anything else. | Universal fallback: grep every PHP file under the plugin root for `register_rest_route(` call sites, then collect the enclosing class for each hit. |
+
+### Default order
+
+1. **Try glob first** — it's faster and produces a cleaner inventory.
+2. **Fall back to grep** if glob returns zero hits (or clearly undercounts
+   against what you see in the plugin's public documentation / admin UI).
+
+Running both and de-duplicating is legal; it catches monorepos that have
+*some* controllers under the standard layout and *others* under a package
+directory.
+
+## Glob — standard layout
+
+```bash
+# From the plugin root:
+ls includes/admin/class-*-rest-*-controller.php 2>/dev/null
+ls includes/reports/class-*-rest-*-controller.php 2>/dev/null
+```
+
+What you'll see in repos that match this convention:
+
+- WooPayments (`Automattic/woocommerce-payments`) — every controller under
+  `includes/admin/class-wc-rest-payments-*-controller.php` plus some under
+  `includes/reports/`.
+- WooCommerce core's internal REST controllers use the same pattern.
+
+If glob returns 5+ hits, it's almost always the complete inventory. If it
+returns 0-2, fall through to grep.
+
+## Grep — universal fallback
+
+```bash
+# From the plugin root:
+grep -rn --include='*.php' 'register_rest_route(' .
+```
+
+For each hit:
+
+1. Open the file.
+2. Walk up to the enclosing class declaration.
+3. Record `(class, file, route, callback, permission_callback)`.
+
+This path matters because it's the only one that finds controllers in
+non-standard locations:
+
+- **WooCommerce Subscriptions** — controllers live under `includes/api/` and
+  `includes/api/legacy/`. The standard WooPayments glob returns zero; grep is
+  mandatory.
+- **Jetpack Forms** (and most Jetpack packages) — controllers live under
+  `projects/packages/<name>/src/` with no conventional filename. Grep is
+  again mandatory.
+- **Custom plugin layouts** — anything with `src/Rest/`, `lib/rest/`,
+  `api/v1/`, etc. Grep catches them all.
+
+## Inherited routes
+
+A controller can extend a base class in a different repo. The prime example:
+`WC_REST_Subscriptions_Controller extends WC_REST_Orders_Controller`, where
+the parent lives in WooCommerce core (`/Users/*/src/woocommerce/`) — not the
+Subscriptions repo. The `parent::register_routes()` dispatch appears in the
+Subscriptions source, but the literal `register_rest_route(` call is in core.
+
+Handling:
+
+- Record the route on the child class (that's where the plugin's REST surface
+  actually exposes it).
+- Set `backing.route_registration_line: null` and
+  `backing.callback_line: null` in the audit schema.
+- Add `backing.inherited_from: "<parent FQCN>"` so downstream skills can tell
+  the inheritance case from a plain missing line number.
+- Consider running grep against the parent repo too when you need to confirm
+  the callback's request handling — inherited callbacks behave as whatever
+  the parent defines, not what the plugin repo documents.
+
+See `audit-schema.md` for the exact field shapes.
+
+## Exhaustiveness is the goal
+
+The "Controller Inventory" table in the audit doc must list every controller
+the enumeration found — not just ones backing proposed abilities. A reviewer
+asking "why isn't controller X in the MVP?" should be able to point at the
+inventory and see the explicit answer (usually: "excluded from MVP because…"
+or "surfaced as a gap because…").
+
+If your inventory has 3 entries and the plugin clearly exposes more, either
+the enumeration is incomplete (re-run grep with broader patterns) or you're
+filtering the inventory instead of the proposal list. Fix the inventory
+first; filter after.
+
+## Escalation
+
+If neither glob nor grep produces a complete inventory — for example a
+plugin that registers routes dynamically from config or via a factory that
+does not contain a literal `register_rest_route(` string — document the
+enumeration gap in "Notes and Surprises", and extend this reference with the
+new pattern once understood.

--- a/.agents/skills/wp-abilities-audit/references/controller-enumeration.md
+++ b/.agents/skills/wp-abilities-audit/references/controller-enumeration.md
@@ -72,9 +72,9 @@ non-standard locations:
 
 A controller can extend a base class in a different repo. The prime example:
 `WC_REST_Subscriptions_Controller extends WC_REST_Orders_Controller`, where
-the parent lives in WooCommerce core (`/Users/*/src/woocommerce/`) — not the
-Subscriptions repo. The `parent::register_routes()` dispatch appears in the
-Subscriptions source, but the literal `register_rest_route(` call is in core.
+the parent lives in WooCommerce core — not the Subscriptions repo. The
+`parent::register_routes()` dispatch appears in the Subscriptions source,
+but the literal `register_rest_route(` call is in core.
 
 Handling:
 

--- a/.agents/skills/wp-abilities-audit/references/controller-enumeration.md
+++ b/.agents/skills/wp-abilities-audit/references/controller-enumeration.md
@@ -12,7 +12,7 @@ together cover every layout seen in the wild:
 
 | Path | When it works | How it works |
 |---|---|---|
-| **Glob** | Plugins that follow the standard `includes/admin/class-*-rest-*-controller.php` layout (WooCommerce core extensions, classic WooPayments). | Fast, deterministic, easy to script. Returns a complete list in one shell call. |
+| **Glob** | Plugins that follow the standard `includes/admin/class-*-rest-*-controller.php` layout. | Fast, deterministic, easy to script. Returns a complete list in one shell call. |
 | **Grep** | Any non-standard layout — `includes/api/`, `includes/rest-api/`, `src/rest/`, monorepo package directories, or anything else. | Universal fallback: grep every PHP file under the plugin root for `register_rest_route(` call sites, then collect the enclosing class for each hit. |
 
 ### Default order
@@ -33,12 +33,10 @@ ls includes/admin/class-*-rest-*-controller.php 2>/dev/null
 ls includes/reports/class-*-rest-*-controller.php 2>/dev/null
 ```
 
-What you'll see in repos that match this convention:
-
-- WooPayments (`Automattic/woocommerce-payments`) — every controller under
-  `includes/admin/class-wc-rest-payments-*-controller.php` plus some under
-  `includes/reports/`.
-- WooCommerce core's internal REST controllers use the same pattern.
+Repos that match this convention typically have all REST controllers
+under `includes/admin/class-<plugin>-rest-*-controller.php` (sometimes with
+companion files under `includes/reports/` or similar feature-specific
+directories).
 
 If glob returns 5+ hits, it's almost always the complete inventory. If it
 returns 0-2, fall through to grep.
@@ -59,22 +57,22 @@ For each hit:
 This path matters because it's the only one that finds controllers in
 non-standard locations:
 
-- **WooCommerce Subscriptions** — controllers live under `includes/api/` and
-  `includes/api/legacy/`. The standard WooPayments glob returns zero; grep is
-  mandatory.
-- **Jetpack Forms** (and most Jetpack packages) — controllers live under
-  `projects/packages/<name>/src/` with no conventional filename. Grep is
-  again mandatory.
+- **Jetpack packages** (Forms, Subscriptions, Stats, etc.) — controllers
+  live under `projects/packages/<name>/src/` with no conventional filename.
+  Grep is mandatory.
+- **Plugins with non-standard layouts** — `includes/api/`,
+  `includes/api/legacy/`, or any other in-house convention. The standard
+  glob returns zero; grep is mandatory.
 - **Custom plugin layouts** — anything with `src/Rest/`, `lib/rest/`,
   `api/v1/`, etc. Grep catches them all.
 
 ## Inherited routes
 
-A controller can extend a base class in a different repo. The prime example:
-`WC_REST_Subscriptions_Controller extends WC_REST_Orders_Controller`, where
-the parent lives in WooCommerce core — not the Subscriptions repo. The
-`parent::register_routes()` dispatch appears in the Subscriptions source,
-but the literal `register_rest_route(` call is in core.
+A controller can extend a base class in a different repo. Example shape:
+`<Plugin>_REST_<Resource>_Controller extends <Base>_REST_Controller`, where
+the parent lives in WordPress core (or another plugin) — not the plugin's
+own source. The `parent::register_routes()` dispatch appears in the plugin
+source, but the literal `register_rest_route(` call is in the parent.
 
 Handling:
 

--- a/.agents/skills/wp-abilities-verify.md
+++ b/.agents/skills/wp-abilities-verify.md
@@ -1,0 +1,179 @@
+---
+name: wp-abilities-verify
+description: "Verify a WordPress plugin's Abilities API registrations: enumerate abilities via REST, check annotation correctness including the adversarial readonly-but-writes detection, validate permissions and schemas, and validate audit documents produced by wp-abilities-audit."
+compatibility: "Targets WordPress 6.9+ plugins (PHP 7.2.24+). Requires a runnable environment (wp-env, docker-based dev stack, or equivalent) for runtime mode; static mode runs entirely from the plugin checkout with no env. Filesystem-based agent with bash + node."
+---
+
+# WP Abilities Verify
+
+Verify a WordPress plugin's Abilities API registrations. The centerpiece is
+the **adversarial annotation-correctness check**: a `readonly: true` ability
+that actually writes (via `wpdb->update`, `update_option`, `wp_insert_*`, a
+non-GET delegate, etc.) is a security and UX disaster because agents plan
+actions on the basis of the annotations they introspect. This skill catches
+those lies.
+
+The skill also validates audit docs produced by `wp-abilities-audit` (shared
+precondition with the downstream implement skill), runs permission and schema
+lints, and optionally executes each ability against a live environment.
+
+## When to use
+
+- After abilities have been registered in the plugin but before a PR lands.
+- As a health-check on an already-shipped plugin (catch regressions where a
+  refactor turned a readonly ability into a writing one).
+- To validate an audit document before handing it to an implementer.
+
+## Two modes
+
+- **Static mode** — runs from the plugin checkout. No env. Enumerates via
+  source grep, runs the adversarial readonly-but-writes checks, runs schema
+  and permission lints, and validates audit docs.
+- **Runtime mode** — requires a running env. Does everything static does
+  PLUS: `wp_get_abilities()` for authoritative enumeration, executes each
+  ability with curated inputs, confirms permission roundtrip against real
+  users, verifies idempotent reads are byte-for-byte identical on twin calls.
+
+Both modes produce the same structured report format.
+
+## Inputs required
+
+1. **Plugin checkout path** — working tree to verify.
+2. **Mode** — `static` or `runtime`. Default to static if unspecified.
+3. **(Runtime only) Env-up command** — read the plugin's `AGENTS.md`.
+   Common patterns: `npm run wp-env start`, `jetpack docker up`, or a
+   composer-based bring-up. Do NOT assume `npm run wp-env` works.
+4. **(Optional) Audit doc path** — enables cross-checks between the audit
+   and the registered abilities, and validates the audit itself.
+5. **Report output path** — explicit path, typically the user's vault.
+
+## Prerequisites
+
+- `wp-project-triage` has been run on the plugin.
+- The plugin has at least one registered ability in source. If
+  `wp_register_ability(` returns zero hits, there is nothing to verify —
+  return a clear "no abilities registered" report, not an empty PASS.
+
+## Procedure
+
+### 1. (If audit provided) Validate the audit doc
+
+Read `wp-abilities-verify/references/audit-schema-validation.md`. Validate the audit against
+the canonical schema owned by `wp-abilities-audit`. Surface missing
+required top-level fields, missing per-ability fields, more than one
+ability with `reference_ability: true`, or `plugin_family` mismatch with
+triage. `backing: null` is a WARN, not a FAIL.
+
+### 2. Enumerate abilities statically
+
+Read `wp-abilities-verify/references/static-enumeration.md`. Scan for `wp_register_ability(`
+calls, extract names and annotation blocks. Handle fluent builders,
+variable-indirected `input_schema` values, multi-line arrays, and heredoc
+callbacks. Record ability-name → source-file + line + annotations.
+
+### 3. (Runtime only) Enumerate via REST + wp-cli
+
+Read `wp-abilities-verify/references/runtime-harness.md`. Bring up the env using the command
+from AGENTS.md, then enumerate via `wp_get_abilities()` over wp-cli and
+cross-check against the static inventory. Source-only → FAIL (registration
+not firing). Runtime-only → WARN (dynamic registration path).
+
+### 4. Annotation-correctness checks (the adversarial core)
+
+Read `wp-abilities-verify/references/annotation-correctness.md`. This is what makes verify a
+distinct skill rather than just "run the tests". Three claims:
+
+- `readonly: true` → callback must not write. Grep for `wpdb->update`,
+  `wpdb->insert`, `wpdb->delete`, `update_option`, `add_option`,
+  `delete_option`, `update_post_meta`, `wp_insert_*`, `wp_update_*`,
+  `wp_delete_*`, `->update_`, `->create_`, `->insert_`, `->delete_`,
+  non-GET `wp_remote_*`, or `delegate_to_rest_controller` with non-GET.
+- `destructive: false` → callback must not delete, refund, cancel, close
+  disputes, or trash content.
+- `idempotent: true` → no `rand()`, no `wp_create_nonce`, no sequence
+  increments. Runtime: twin invocations must match byte-for-byte.
+
+False positives get suppressed via an inline `// verify-ignore: readonly`
+comment — see the reference.
+
+### 5. Permission gate roundtrip
+
+Read `wp-abilities-verify/references/permission-roundtrip.md`. Static: the registered
+`permission_callback` must reference a capability via `current_user_can(...)`,
+or be `'__return_true'` (WARN), or match the allow-list. Runtime: subscriber
+and unauthenticated denied; admin allowed (unless deliberately public).
+
+If an audit was provided, cross-check the registered capability against
+the audit's `capability_gate`. Mismatch → FAIL.
+
+### 6. Schema lints
+
+Read `wp-abilities-verify/references/schema-lints.md`. Static lints: `additionalProperties:
+false` unless deliberately accepting extras; every required field has a
+description; enums non-empty; no `$ref`; defaults primitive or `null`;
+`reference_ability: true` implies no `required` inputs.
+
+Cross-reference `wp-abilities-api/references/input-schema-gotchas.md`
+for the three runtime gotchas (defaults not injected, pagination drift,
+`empty()` ID validation).
+
+### 7. Error-code vocabulary conformance
+
+Cross-reference `wp-abilities-api/references/error-code-vocabulary.md`.
+Grep each callback for `new WP_Error(` / `new \WP_Error(` and lint the
+first-argument code literal. Non-vocabulary codes → WARN.
+
+## Verification
+
+The run produces a structured markdown report at the user-specified path:
+
+```
+---
+Last updated: <YYYY-MM-DD HH:MM>
+---
+
+# <Plugin> Abilities Verification — <Static|Runtime> Mode
+
+## Status: <PASS|WARN|FAIL>
+
+## Audit doc validation (if provided)
+
+## Static inventory
+
+## Annotation correctness
+| Ability | Claim | Result | Evidence |
+|---|---|---|---|
+| <ability> | readonly=true | FAIL | line 142: `wpdb->update()` |
+
+## Permission gates
+
+## Schema lints
+
+## Error-code vocabulary
+```
+
+Every ability is OK, WARN, or FAIL. A single FAIL → top-line FAIL; WARNs
+without FAILs → WARN; otherwise PASS.
+
+## Failure modes / debugging
+
+- **Env not reachable (runtime)** — env-up failed or Docker isn't running.
+  Re-run `wp-project-triage`, then fix the env. Don't fall back silently
+  to static without noting it in the report.
+- **No abilities in source** — return a clear "nothing to verify" report.
+- **Audit schema mismatch** — point at
+  `wp-abilities-verify/references/audit-schema-validation.md`; don't auto-fix the audit.
+- **False positive on readonly-writes** — see
+  `wp-abilities-verify/references/annotation-correctness.md` for the `// verify-ignore`
+  mechanism. Document why each suppression is legitimate.
+- **Runtime enumeration smaller than static** — registration hook isn't
+  firing. Check init hook timing, activation state, autoloader order.
+
+## Escalation
+
+- Adversarial false positives on a legitimate pattern → add an allow-list
+  entry to `wp-abilities-verify/references/annotation-correctness.md` and document the
+  rationale. Don't loosen the regexes themselves.
+- Audit-schema validator rejects a legitimate audit → the canonical schema
+  in `wp-abilities-audit/references/audit-schema.md` has evolved. Update
+  `wp-abilities-verify/references/audit-schema-validation.md` to match and sync both.

--- a/.agents/skills/wp-abilities-verify/references/annotation-correctness.md
+++ b/.agents/skills/wp-abilities-verify/references/annotation-correctness.md
@@ -1,0 +1,271 @@
+# Annotation Correctness
+
+The adversarial core of this skill. This is what makes `wp-abilities-verify`
+a distinct skill rather than a thin wrapper around "run the tests".
+
+## Why this matters
+
+Agents plan actions on the basis of the annotations they introspect. If an
+ability is annotated `readonly: true`, an orchestrator will confidently
+invoke it in a dry-run, speculative exploration, or multi-agent fan-out
+without thinking twice — because `readonly` means "can't break anything".
+
+A `readonly: true` ability that actually writes is therefore:
+
+1. **A security hazard** — agents will invoke it in contexts where side
+   effects are forbidden.
+2. **A UX disaster** — the agent's mental model of what happened diverges
+   silently from reality. The human operator can't reason about what
+   state the system is in.
+3. **Undetectable at the annotation-layer** — the annotation says
+   `readonly: true`; nothing in the registration forces it to be true.
+
+Unit tests won't catch this class of bug because the mock the test
+constructs looks just like the real writer. What catches it is reading the
+execute callback body and comparing what it does against what the
+annotation says it does. That's this file.
+
+The same logic applies to `destructive: false` ("won't delete anything")
+and `idempotent: true` ("same input, same result, same effect").
+
+## The three claims
+
+| Annotation | What it promises | What to check |
+|---|---|---|
+| `readonly: true` | No writes. GET-style side-effect-free. | No `wpdb->insert/update/delete`, `update_option`, `wp_insert_*`, non-GET delegates, etc. |
+| `destructive: false` | Won't irreversibly destroy data or forfeit money. | No `wp_delete_*`, `wp_trash_post`, `->refund`, `->cancel`, `->close_dispute`. |
+| `idempotent: true` | Same input always produces same effect. | No `rand()`, nonce generation, sequence increments, timestamps-in-response. Runtime: twin invocations byte-identical. |
+
+These overlap but are not redundant: `readonly` is the strictest,
+`destructive: false` is weaker (updates that don't destroy are OK), and
+`idempotent` is orthogonal (a POST that writes the same row twice is both
+"writes" and "idempotent").
+
+## Static adversarial checks
+
+These grep-based checks run against the plugin checkout with no env.
+They're the heart of the skill.
+
+### Step 1 — locate the execute callback body
+
+For each ability in the static inventory, resolve its `execute_callback`:
+
+```bash
+# 1. Find the ability registration.
+grep -rn "wp_register_ability( *'<plugin>/<ability-name>'" <plugin-root>/
+
+# 2. Find the execute_callback => key in the same array literal.
+#    Usually a few lines below the name.
+
+# 3. The callback value is either:
+#    a) [ ClassName::class, 'method' ] — look in ClassName for `public function method` or `public static function method`.
+#    b) [ $this, 'method' ] — look in the current class.
+#    c) 'function_name' — look for `function function_name` top-level.
+#    d) An anonymous function — the body is literally there.
+```
+
+Record the file + starting line + ending line of the callback. All
+subsequent greps target that byte range.
+
+### Step 2 — readonly-but-writes check
+
+Against callbacks annotated `readonly: true`, run these patterns. ANY hit
+means the annotation is a lie and the ability FAILs the adversarial check.
+
+```bash
+# Direct $wpdb writes.
+grep -nE '\$wpdb->(update|insert|delete|replace)\b' <file> | awk -v s=<start> -v e=<end> '$1 >= s && $1 <= e'
+
+# Raw SQL with write verbs.
+grep -nE '\$wpdb->query\s*\([^)]*(UPDATE|INSERT|DELETE|REPLACE|TRUNCATE|ALTER)' <file>
+
+# Options API writes.
+grep -nE '\b(update_option|add_option|delete_option|update_site_option|add_site_option|delete_site_option)\s*\(' <file>
+
+# Post and post-meta writes.
+grep -nE '\bwp_(insert|update|delete|trash)_post\s*\(' <file>
+grep -nE '\b(update|add|delete)_post_meta\s*\(' <file>
+
+# User writes.
+grep -nE '\bwp_(insert|update|delete)_user\s*\(' <file>
+grep -nE '\b(update|add|delete)_user_meta\s*\(' <file>
+
+# Term writes.
+grep -nE '\bwp_(insert|update|delete)_term\s*\(' <file>
+grep -nE '\b(update|add|delete)_term_meta\s*\(' <file>
+
+# Comment writes.
+grep -nE '\bwp_(insert|update|delete|trash|spam)_comment\s*\(' <file>
+
+# Method-name write-verb patterns on controllers / services.
+grep -nE '->(create|insert|update|delete|remove|save|store|write|destroy|purge|archive|restore|disable|enable|activate|deactivate|revoke|grant)_' <file>
+
+# Non-GET HTTP delegations.
+grep -nE '\bwp_remote_(post|request|delete)\b' <file>
+grep -nE "delegate_to_rest_controller\s*\([^)]*(POST|PUT|DELETE|PATCH)" <file>
+
+# Transients — may be legitimate read-path caching; flag as WARN not FAIL.
+# See "False-positive allow-list" below.
+grep -nE '\b(set_transient|delete_transient|set_site_transient|delete_site_transient)\s*\(' <file>
+```
+
+### Step 3 — destructive-but-says-false check
+
+Against callbacks annotated `destructive: false`:
+
+```bash
+# Deletion verbs.
+grep -nE '\bwp_(delete|trash)_(post|user|term|comment|attachment)\s*\(' <file>
+grep -nE '->(delete|destroy|purge|revoke|forfeit|cancel|refund|chargeback|close_dispute|void|terminate)_' <file>
+
+# Payment-system destructive verbs.
+grep -nE '->(refund|cancel|void|dispute|chargeback)\s*\(' <file>
+
+# Data-removal verbs.
+grep -nE '\bdelete_user_data\s*\(' <file>
+grep -nE '\bwp_delete_user\s*\(' <file>
+```
+
+### Step 4 — idempotent-but-nondeterministic check
+
+Against callbacks annotated `idempotent: true`:
+
+```bash
+# Randomness.
+grep -nE '\b(rand|mt_rand|random_int|random_bytes|wp_rand)\s*\(' <file>
+grep -nE '\bwp_generate_(uuid4|password|auth_cookie)\s*\(' <file>
+
+# Nonce generation (per-call, non-deterministic by design).
+grep -nE '\bwp_create_nonce\s*\(' <file>
+
+# Time-based payloads — time() in the response means twin calls differ.
+# Flag as WARN, not FAIL: many legitimate read callbacks include a
+# `generated_at` field. Runtime byte-comparison catches the real violations.
+grep -nE '\b(time|microtime|current_time|date|wp_date)\s*\(' <file>
+
+# Sequence increments.
+grep -nE '\+\+\s*;|\$[a-z_]+\s*\+=\s*1\b' <file>
+```
+
+## Precedence and severity
+
+Not every hit is equal weight.
+
+| Pattern | Severity on `readonly: true` | Severity on `destructive: false` |
+|---|---|---|
+| `wpdb->update/insert/delete` | FAIL | FAIL (delete) / WARN (update) |
+| `update_option` / `update_post_meta` | FAIL | WARN |
+| `wp_insert_*` / `wp_update_*` | FAIL | WARN (unless delete) |
+| `wp_delete_*` / `wp_trash_*` | FAIL | FAIL |
+| `->refund`, `->cancel`, `->close_dispute` | FAIL | FAIL |
+| Non-GET `delegate_to_rest_controller` | FAIL | depends on method |
+| `wp_remote_post` / `wp_remote_delete` | FAIL | WARN |
+| `set_transient` / `delete_transient` | WARN (caching is ambiguous) | OK |
+| `rand()` / `wp_create_nonce` | N/A | N/A |
+| `time()` in response | N/A | N/A |
+
+Severity is deliberately sharp on the patterns that matter (deletion,
+money-moving verbs, non-GET delegates) and soft on ambiguous patterns
+(transients, time-in-response) to preserve signal quality.
+
+## False-positive allow-list
+
+Some legitimate patterns trip these checks. Two suppression mechanisms:
+
+### Inline suppression — per-line
+
+Add a comment immediately before or on the offending line:
+
+```php
+// verify-ignore: readonly -- writes to read-through cache; semantically a read.
+set_transient( $cache_key, $data, HOUR_IN_SECONDS );
+```
+
+Suppression format: `// verify-ignore: <annotation-name> -- <one-line reason>`.
+
+Legal annotation names: `readonly`, `destructive`, `idempotent`, `all`.
+
+The grep-scanner skips any line with a matching `verify-ignore` comment.
+`// verify-ignore: all` suppresses every check on that line; narrower is
+better.
+
+### File-level allow-list — in this reference
+
+Patterns that recur across many plugins get listed here so agents don't
+re-invent the suppression rationale:
+
+| Pattern | Why it's legitimate on a readonly ability |
+|---|---|
+| `set_transient($cache_key, $data, ...)` after a cache-miss | Read-through cache populating on fetch. Side-effect, but not a semantic write. Suppress with `// verify-ignore: readonly`. |
+| `update_user_meta( $user_id, 'last_read_at', time() )` | Tracking that the user read something. Arguably a write, but doesn't change the data the ability returns. WARN, not FAIL. |
+| `do_action( 'my_plugin_after_read', ... )` | Emitting an event. If a listener writes, that's on the listener, not the ability. OK. |
+| `$logger->info(...)` or similar logging | Diagnostic, not a semantic write. OK. |
+
+Anything not in this list should be reviewed case-by-case. Don't add
+entries speculatively — only add one after hitting a real false positive
+in a real audit.
+
+## Runtime check complement
+
+When runtime mode is on, add one more check that static cannot do:
+**twin-invocation diff for `idempotent: true` abilities**.
+
+```bash
+# Via wp-cli (substitute the plugin's env-up + wp-cli invocation per AGENTS.md).
+<env-cli> wp --user=admin eval '
+$a = wp_get_ability( "<plugin>/<ability>" );
+$r1 = $a->execute( [ <same-input> ] );
+$r2 = $a->execute( [ <same-input> ] );
+echo var_export( $r1 === $r2, true ) . PHP_EOL;  // should print "true"
+echo md5( serialize( $r1 ) ) . PHP_EOL;
+echo md5( serialize( $r2 ) ) . PHP_EOL;
+'
+```
+
+Expected output: `true` followed by two identical hashes. Differ → FAIL
+with the two serialized payloads as evidence.
+
+Note: `idempotent: true` abilities that legitimately embed a timestamp
+(e.g. `generated_at` in the response) will fail this strict check. Either
+remove the timestamp (preferred — it's never load-bearing for the agent)
+or loosen the annotation to `idempotent: false`.
+
+## Report format
+
+Each adversarial check finding gets one row in the run's
+"Annotation correctness" table:
+
+```markdown
+| Ability | Claim | Result | Evidence |
+|---|---|---|---|
+| woopayments/get-disputes | readonly=true | OK | no write patterns detected |
+| woopayments/get-transactions | readonly=true | FAIL | `src/Abilities/Transactions.php:142`: `$wpdb->update( $table, ... )` |
+| woopayments/submit-dispute-evidence | destructive=false | OK | no destructive patterns detected |
+| woopayments/submit-dispute-evidence | idempotent=false | N/A | not claimed idempotent |
+```
+
+The evidence column MUST cite the file + line number of the offending
+pattern, so a reviewer can jump straight to the lie and either fix the
+code or add a suppression.
+
+## Why grep and not a full PHP parser
+
+A full AST parser (`nikic/php-parser`) would catch more edge cases —
+method-chain writes via variable indirection, for instance. But:
+
+1. It requires Composer + a PHP environment just to run the static check.
+2. It slows down the check from <1s to tens of seconds on a large plugin.
+3. It adds a dependency verify has to maintain.
+
+Grep catches 90%+ of real violations with no dependencies. The 10% that
+slip through surface in runtime mode via the twin-invocation diff or via
+code review. A future contribution can add an opt-in AST-based variant if
+we hit enough false-negatives to justify the complexity.
+
+## Escalation
+
+If verify trips a false positive on a pattern that's genuinely common
+across plugins (not a plugin-specific quirk), add it to the "File-level
+allow-list" above in a focused PR. Include the rationale. Don't loosen
+the regex patterns — narrower with an explicit allow-list is easier to
+audit than broader regexes.

--- a/.agents/skills/wp-abilities-verify/references/annotation-correctness.md
+++ b/.agents/skills/wp-abilities-verify/references/annotation-correctness.md
@@ -238,10 +238,10 @@ Each adversarial check finding gets one row in the run's
 ```markdown
 | Ability | Claim | Result | Evidence |
 |---|---|---|---|
-| woopayments/get-disputes | readonly=true | OK | no write patterns detected |
-| woopayments/get-transactions | readonly=true | FAIL | `src/Abilities/Transactions.php:142`: `$wpdb->update( $table, ... )` |
-| woopayments/submit-dispute-evidence | destructive=false | OK | no destructive patterns detected |
-| woopayments/submit-dispute-evidence | idempotent=false | N/A | not claimed idempotent |
+| jetpack-forms/get-responses | readonly=true | OK | no write patterns detected |
+| jetpack-forms/get-status-counts | readonly=true | FAIL | `src/abilities/class-forms-abilities.php:142`: `$wpdb->update( $table, ... )` |
+| jetpack-forms/update-response | destructive=false | OK | no destructive patterns detected |
+| jetpack-forms/update-response | idempotent=false | N/A | not claimed idempotent |
 ```
 
 The evidence column MUST cite the file + line number of the offending

--- a/.agents/skills/wp-abilities-verify/references/audit-schema-validation.md
+++ b/.agents/skills/wp-abilities-verify/references/audit-schema-validation.md
@@ -1,0 +1,206 @@
+# Audit Schema Validation
+
+Hard contract for validating an audit document produced by `wp-abilities-audit`.
+The canonical schema lives in
+`../../wp-abilities-audit/references/audit-schema.md`; this reference
+duplicates only the validation-relevant field list so verify can fail fast
+without cross-reading another skill mid-run. Keep both in sync — if the
+canonical schema evolves, update this file to match.
+
+Verify owns this validator rather than audit because it's the "validate"
+half of the initiative: verify fails fast on a malformed audit so the
+downstream implement skill never has to guess.
+
+## Where the audit doc lives and what it looks like
+
+An audit doc is a markdown file named
+`<YYYY-MM-DD>-abilities-audit-<plugin-slug>.md`. Structure:
+
+1. `Last updated: <YYYY-MM-DD HH:MM>` header at the top.
+2. An H1 title.
+3. A fenced ` ```yaml ` block with the structured fields (top-level
+   metadata + `proposed_abilities`, `excluded_from_mvp`, `surfaced_gaps`).
+4. A "Controller Inventory" table (prose; not validated structurally).
+5. A "Notes and Surprises" prose section.
+
+The validator's job is to parse the YAML block and assert the required
+fields are present and well-formed.
+
+## How to parse
+
+The YAML lives inside the markdown as a fenced block. To extract:
+
+```bash
+# Scan for the ```yaml fence and capture until the closing ``` fence.
+awk '/^```yaml$/{f=1;next} /^```$/{f=0} f' <audit-doc.md> > /tmp/audit.yaml
+```
+
+If the audit has multiple YAML blocks (it shouldn't, but defensively), take
+the first one with `proposed_abilities` as a top-level key.
+
+Parse with any YAML library — `js-yaml` from Node, `yaml` (Python), or
+`yq` from the command line. None of the fields require non-standard YAML
+features (no anchors, no aliases), so a plain `yaml.load` is sufficient.
+
+## Required top-level fields
+
+Every one of these must be present and non-empty. Missing → FAIL.
+
+| Field | Type | Notes |
+|---|---|---|
+| `plugin` | string | Plugin slug, e.g. `woopayments`. |
+| `repo` | string | `Owner/Repository` form. |
+| `plugin_family` | string | From `wp-project-triage`. Free-form. Cross-check against the CWD's triage output when available. |
+| `branch_audited` | string | Git branch. |
+| `audited_at` | string | ISO date `YYYY-MM-DD`. |
+| `auditor` | string | Human name + team. |
+| `baseline_abilities` | integer | Usually 0. |
+| `capability_gate` | string OR object | See below. |
+| `proposed_abilities` | array | At least one entry. |
+
+### `capability_gate` shape check
+
+Two legal shapes; accept both:
+
+1. Single string — `capability_gate: manage_woocommerce` (single-cap plugin).
+2. Object — `capability_gate: { read: <cap>, write: <cap>, confirmed: bool, verified_at: string }`
+   (post-type-backed or otherwise compound gate).
+
+A legacy compound-string form `"<read_cap> / <write_cap>"` exists in the
+wild. Accept for backwards compatibility; WARN.
+
+Anything else → FAIL.
+
+## Required per-ability fields
+
+For each entry in `proposed_abilities`, these must be present:
+
+| Field | Type | Notes |
+|---|---|---|
+| `name` | string | Kebab-case `<plugin-slug>/<ability>`. |
+| `intent` | string | One-sentence user question. |
+| `backing` | object OR `null` | See below. `null` = WARN, not FAIL. |
+| `permission` | object OR `null` | `null` only if `backing` is null. |
+| `return_type` | string | Hint-only; any non-empty string passes. |
+| `effort` | enum | One of `S`, `M`, `L`. |
+| `annotations` | object | `{ readonly, destructive, idempotent }` — all three booleans required. |
+| `notes` | array of strings | May be empty `[]`. |
+| `risks` | array of strings | May be empty `[]`. |
+
+### `annotations` required sub-fields
+
+| Key | Type | Notes |
+|---|---|---|
+| `readonly` | bool | Required. Missing → FAIL. |
+| `destructive` | bool | Required. Missing → FAIL. |
+| `idempotent` | bool | Required. Missing → FAIL. |
+
+All three must be booleans. String `"true"` / `"false"` → FAIL (YAML
+should parse as bools; a string indicates a quoting bug in the audit).
+
+### `backing` object fields (when not null)
+
+| Field | Type | Notes |
+|---|---|---|
+| `class` | string | Fully-qualified PHP class name. |
+| `method` | enum | `GET` / `POST` / `PUT` / `DELETE` / `PATCH`. |
+| `route` | string | REST route. |
+| `callback` | string | Callback method name. |
+| `file` | string | Path relative to plugin root. |
+| `route_registration_line` | integer OR `null` | `null` only when `inherited_from` is set. |
+| `callback_line` | integer OR `null` | Same. |
+| `inherited_from` | string (optional) | Parent class FQCN when callback lives outside the plugin repo. |
+
+Soft rules (WARN, not FAIL):
+
+- `backing: null` — the ability is a known gap. MUST also appear in
+  `surfaced_gaps` by `name`. If it's missing from `surfaced_gaps`, FAIL
+  (inconsistent audit).
+- `inherited_from` is present and the line numbers are `null` — OK. The
+  validator does NOT source-verify the parent class (lives outside the
+  plugin repo).
+- `route_registration_line` or `callback_line` is `null` but
+  `inherited_from` is absent → WARN (ambiguous; schema says line numbers
+  may drift but expects a reason they're absent).
+
+### `permission` object fields (when not null)
+
+| Field | Type | Notes |
+|---|---|---|
+| `callback` | string | Method name used as `permission_callback`. |
+| `resolves_to` | string | The `current_user_can(...)` call(s). |
+| `confirmed` | bool | Verified against source. |
+
+## Invariants (whole-audit checks)
+
+Run these after per-field validation passes:
+
+### Exactly 0 or 1 abilities with `reference_ability: true`
+
+Count abilities where `reference_ability` is `true`. More than 1 → FAIL
+(the schema permits one reference; multiple are ambiguous for the
+downstream implement skill).
+
+```js
+const refCount = audit.proposed_abilities.filter(a => a.reference_ability === true).length;
+if (refCount > 1) fail("multiple abilities claim reference_ability: true");
+```
+
+### `plugin_family` cross-check
+
+If `wp-project-triage` output is available for the CWD, compare
+`audit.plugin_family` against the triage's classification. Mismatch →
+WARN (not FAIL — `plugin_family` is free-form and downstream skills
+treat unknown values as opaque).
+
+If triage output is not available (e.g. verify is invoked on an audit
+doc alone, no plugin checkout nearby), skip this check.
+
+### Every `backing: null` ability appears in `surfaced_gaps`
+
+```js
+const gapNames = new Set((audit.surfaced_gaps || []).map(g => g.name));
+for (const ability of audit.proposed_abilities) {
+  if (ability.backing === null && !gapNames.has(ability.name)) {
+    fail(`ability ${ability.name} has backing: null but is missing from surfaced_gaps`);
+  }
+}
+```
+
+### `excluded_from_mvp` and `surfaced_gaps` may be empty arrays
+
+Both are optional; empty arrays are legal. Missing entirely → WARN
+(schema expects them, even if empty).
+
+## Output format
+
+Report each check in the run's final report under an "Audit doc
+validation" section:
+
+```markdown
+## Audit doc validation
+
+| Check | Result | Detail |
+|---|---|---|
+| Top-level required fields | OK | All 9 present |
+| `capability_gate` shape | OK | string (single-cap) |
+| Per-ability fields | WARN | 1 ability has `backing: null` (intentional) |
+| `reference_ability` uniqueness | OK | 1 ability marked |
+| `plugin_family` triage cross-check | OK | matches `woo-payments` |
+| `surfaced_gaps` consistency | OK | all `backing: null` entries present |
+```
+
+A single FAIL in this section makes the whole run FAIL; verify cannot
+meaningfully continue without a trustworthy audit. WARN entries don't
+block the rest of the procedure.
+
+## Future deterministic helper
+
+A `scripts/validate_audit.mjs` script can automate this check end-to-end
+(load markdown → extract YAML fence → parse → apply all rules → emit
+structured report). Out of scope for the current contribution, but
+mentioned here so a future PR has an obvious place to land.
+
+Until that exists, the procedure is manual-but-deterministic: follow the
+checklist above in order, emit the report section, and fail fast on any
+missing required field.

--- a/.agents/skills/wp-abilities-verify/references/audit-schema-validation.md
+++ b/.agents/skills/wp-abilities-verify/references/audit-schema-validation.md
@@ -48,7 +48,7 @@ Every one of these must be present and non-empty. Missing → FAIL.
 
 | Field | Type | Notes |
 |---|---|---|
-| `plugin` | string | Plugin slug, e.g. `woopayments`. |
+| `plugin` | string | Plugin slug, e.g. `jetpack-forms`. |
 | `repo` | string | `Owner/Repository` form. |
 | `plugin_family` | string | From `wp-project-triage`. Free-form. Cross-check against the CWD's triage output when available. |
 | `branch_audited` | string | Git branch. |
@@ -62,7 +62,7 @@ Every one of these must be present and non-empty. Missing → FAIL.
 
 Two legal shapes; accept both:
 
-1. Single string — `capability_gate: manage_woocommerce` (single-cap plugin).
+1. Single string — `capability_gate: manage_options` (single-cap plugin).
 2. Object — `capability_gate: { read: <cap>, write: <cap>, confirmed: bool, verified_at: string }`
    (post-type-backed or otherwise compound gate).
 
@@ -186,7 +186,7 @@ validation" section:
 | `capability_gate` shape | OK | string (single-cap) |
 | Per-ability fields | WARN | 1 ability has `backing: null` (intentional) |
 | `reference_ability` uniqueness | OK | 1 ability marked |
-| `plugin_family` triage cross-check | OK | matches `woo-payments` |
+| `plugin_family` triage cross-check | OK | matches `jetpack` |
 | `surfaced_gaps` consistency | OK | all `backing: null` entries present |
 ```
 

--- a/.agents/skills/wp-abilities-verify/references/permission-roundtrip.md
+++ b/.agents/skills/wp-abilities-verify/references/permission-roundtrip.md
@@ -24,7 +24,7 @@ Inspect the callback's body. It must match one of these shapes:
 
 ```php
 public static function check_permission() {
-    return current_user_can( 'manage_woocommerce' );
+    return current_user_can( 'manage_options' );
 }
 ```
 
@@ -170,10 +170,10 @@ If an audit doc was provided, the audit's `capability_gate` field (or the
 per-ability `permission.resolves_to`) declares what the gate should be.
 Compare the registered capability against the audit's declared one:
 
-- Audit says `manage_woocommerce`, registration resolves to
-  `manage_woocommerce` → OK.
-- Audit says `manage_woocommerce`, registration resolves to
-  `manage_options` → FAIL. Either the audit is wrong or the registration
+- Audit says `manage_options`, registration resolves to
+  `manage_options` → OK.
+- Audit says `manage_options`, registration resolves to
+  `edit_pages` → FAIL. Either the audit is wrong or the registration
   drifted.
 - Audit is a compound `{read, write}` gate and the registration uses
   Shape B with both caps → OK.
@@ -193,8 +193,8 @@ compares.
 
 | Ability | Shape | Resolved cap(s) | anon | subscriber | admin | Audit match |
 |---|---|---|---|---|---|---|
-| <ability> | A | manage_woocommerce | false | false | true | OK |
-| <ability> | B | read:read_private_shop_orders, write:edit_shop_orders | false | false | true | OK |
+| <ability> | A | manage_options | false | false | true | OK |
+| <ability> | B | read:read_private_<cpt-base>s, write:edit_<cpt-base>s | false | false | true | OK |
 | <ability> | C | __return_true (public) | true | true | true | WARN |
 | <ability> | E | (literal true) | true | true | true | FAIL |
 ```

--- a/.agents/skills/wp-abilities-verify/references/permission-roundtrip.md
+++ b/.agents/skills/wp-abilities-verify/references/permission-roundtrip.md
@@ -1,0 +1,212 @@
+# Permission Roundtrip
+
+Verify that the registered `permission_callback` on every ability actually
+gates on a real capability — statically (by source inspection) and, in
+runtime mode, by exercising the gate against subscriber and admin users.
+
+## Static check
+
+Every ability registration includes a `permission_callback`:
+
+```php
+wp_register_ability(
+    'myplugin/get-things',
+    [
+        'permission_callback' => [ self::class, 'check_permission' ],
+        // ...
+    ]
+);
+```
+
+Inspect the callback's body. It must match one of these shapes:
+
+### Shape A — direct `current_user_can(...)` check (preferred)
+
+```php
+public static function check_permission() {
+    return current_user_can( 'manage_woocommerce' );
+}
+```
+
+→ OK. Record the resolved capability.
+
+### Shape B — compound read/write check
+
+```php
+public static function check_permission( $request ) {
+    if ( 'GET' === $request->get_method() ) {
+        return current_user_can( 'read_private_shop_orders' );
+    }
+    return current_user_can( 'edit_shop_orders' );
+}
+```
+
+→ OK. Record both capabilities.
+
+### Shape C — `'__return_true'` (deliberate public ability)
+
+```php
+'permission_callback' => '__return_true',
+```
+
+→ WARN. Most abilities should gate; a public ability is rare and needs
+explicit justification in the registration (code comment) or the audit
+doc's `risks` array.
+
+### Shape D — delegated to a helper that resolves to `current_user_can(...)`
+
+```php
+public static function check_permission() {
+    return self::user_is_authorized();
+}
+
+private static function user_is_authorized() {
+    return current_user_can( 'manage_options' );
+}
+```
+
+→ OK, but trace the helper to confirm it resolves to a `current_user_can`
+call. If the helper returns `true` unconditionally (functionally
+equivalent to `'__return_true'`), treat as Shape C.
+
+### Shape E — `return true;` or similar unconditional literal
+
+```php
+public static function check_permission() {
+    return true;  // functionally __return_true but harder to grep for
+}
+```
+
+→ FAIL. This is worse than Shape C because it hides the public-access
+pattern from a casual grep. Change to `'__return_true'` (explicit) or
+add a real capability check.
+
+### Shape F — `is_user_logged_in()` only
+
+```php
+public static function check_permission() {
+    return is_user_logged_in();
+}
+```
+
+→ WARN. This lets any authenticated user — including subscribers — call
+the ability. Rarely what's intended. If deliberate, document in code
+comment; otherwise tighten.
+
+## Static grep patterns
+
+Locate the permission callback for each ability:
+
+```bash
+# 1. Find the permission_callback => value in the registration array.
+grep -rn --include='*.php' -A 40 "wp_register_ability\s*(\s*'<plugin>/<ability>'" <plugin-root>/ \
+    | grep -E "'permission_callback'\s*=>"
+
+# 2. Resolve the callback reference (same pattern as execute_callback — see static-enumeration.md).
+
+# 3. Inspect the callback body.
+grep -nE "current_user_can\s*\(\s*['\"]([^'\"]+)['\"]|__return_true|return\s+true\s*;|is_user_logged_in\s*\(" <callback-file>
+```
+
+Classify each ability by shape A-F above and record the resolved
+capability (or `__return_true`, or `<unresolvable>`).
+
+## Runtime check
+
+With the env running, exercise the gate against three user roles:
+
+```bash
+<env-cli> wp --user=admin eval '
+$ability = wp_get_ability( "<plugin>/<ability-name>" );
+
+// Unauthenticated.
+wp_set_current_user( 0 );
+$anon = $ability->user_can_execute();
+
+// Subscriber.
+$sub = wp_create_user( "verify_sub_" . time(), "x", "verify_sub_" . time() . "@example.test" );
+$user = get_user_by( "id", $sub );
+$user->set_role( "subscriber" );
+wp_set_current_user( $sub );
+$subscriber = $ability->user_can_execute();
+
+// Admin.
+wp_set_current_user( 1 );
+$admin = $ability->user_can_execute();
+
+echo "anon=" . var_export( $anon, true ) . PHP_EOL;
+echo "subscriber=" . var_export( $subscriber, true ) . PHP_EOL;
+echo "admin=" . var_export( $admin, true ) . PHP_EOL;
+'
+```
+
+Expected for a standard (non-public) ability:
+
+```
+anon=false
+subscriber=false
+admin=true
+```
+
+Expected for a deliberate public ability (Shape C):
+
+```
+anon=true
+subscriber=true
+admin=true
+```
+
+Any deviation → FAIL. Common causes:
+
+- `admin=false` — the capability check references a cap admin doesn't
+  have, or the callback has a bug.
+- `subscriber=true` on a non-public ability — permission callback is
+  too permissive (Shape E or F, not Shape A).
+- `anon=true` on a non-public ability — same, with worse exposure.
+
+## Audit cross-check
+
+If an audit doc was provided, the audit's `capability_gate` field (or the
+per-ability `permission.resolves_to`) declares what the gate should be.
+Compare the registered capability against the audit's declared one:
+
+- Audit says `manage_woocommerce`, registration resolves to
+  `manage_woocommerce` → OK.
+- Audit says `manage_woocommerce`, registration resolves to
+  `manage_options` → FAIL. Either the audit is wrong or the registration
+  drifted.
+- Audit is a compound `{read, write}` gate and the registration uses
+  Shape B with both caps → OK.
+- Audit is a compound gate but the registration uses Shape A (single
+  cap only) → FAIL. Write-path abilities would inherit the read gate
+  and under-authorize writes.
+
+Cross-reference
+`../wp-abilities-audit/references/capability-gate-tracing.md` for the
+tracing mechanics — this skill's validator re-derives the same trace and
+compares.
+
+## Output format
+
+```markdown
+## Permission gates
+
+| Ability | Shape | Resolved cap(s) | anon | subscriber | admin | Audit match |
+|---|---|---|---|---|---|---|
+| <ability> | A | manage_woocommerce | false | false | true | OK |
+| <ability> | B | read:read_private_shop_orders, write:edit_shop_orders | false | false | true | OK |
+| <ability> | C | __return_true (public) | true | true | true | WARN |
+| <ability> | E | (literal true) | true | true | true | FAIL |
+```
+
+## Static-only mode caveats
+
+Without runtime mode, only the source-inspection columns are populated.
+The table becomes:
+
+| Ability | Shape | Resolved cap(s) | Audit match |
+|---|---|---|---|
+
+The roundtrip columns get omitted rather than guessed. Static-mode
+reports should make this explicit in the section header:
+`Permission gates (static inspection only)`.

--- a/.agents/skills/wp-abilities-verify/references/runtime-harness.md
+++ b/.agents/skills/wp-abilities-verify/references/runtime-harness.md
@@ -25,11 +25,10 @@ Read the plugin's `AGENTS.md` for the canonical env bring-up command. Do
 NOT assume `npm run wp-env start` works for every plugin. Observed
 patterns:
 
-- **Woo-family (WooPayments, WooCommerce extensions)** — `npm run wp-env start`
-  (runs `@wordpress/env` with the plugin's `.wp-env.json`).
-- **Jetpack-family** — `jetpack docker up` or a package-local
+- **Jetpack monorepo** — `jetpack docker up` or a package-local
   `composer install && composer test-php --setup-only`.
-- **Plain wp-env plugin** — `npx wp-env start`.
+- **wp-env plugin** — `npm run wp-env start` (runs `@wordpress/env` with
+  the plugin's `.wp-env.json`) or `npx wp-env start`.
 - **Dev Docker stack** — a plugin-specific `docker-compose up -d`.
 
 If `AGENTS.md` doesn't document it, ask the user rather than guessing.
@@ -306,5 +305,6 @@ Observed pattern (from the canonical harness-output example):
    section so reviewers can see what verify caught.
 
 The canonical example: an `ArgumentCountError` from a controller
-constructor caught by a runtime harness run on a WooPayments-style plugin,
-then fixed in a dedicated small commit before re-running the harness.
+constructor caught by a runtime harness run on a plugin using the
+shared-API-client pattern, then fixed in a dedicated small commit before
+re-running the harness.

--- a/.agents/skills/wp-abilities-verify/references/runtime-harness.md
+++ b/.agents/skills/wp-abilities-verify/references/runtime-harness.md
@@ -305,7 +305,6 @@ Observed pattern (from the canonical harness-output example):
 4. Preserve the pre-fix trace in the report under a "Pre-fix status"
    section so reviewers can see what verify caught.
 
-The canonical example is
-`/Users/rtiodev/rtiodev_vault/plans/2026-04-20-abilities-everywhere-woopayments-harness-output.md`
-— exactly this class of ArgumentCountError was caught by a runtime
-harness run and fixed in a dedicated small commit.
+The canonical example: an `ArgumentCountError` from a controller
+constructor caught by a runtime harness run on a WooPayments-style plugin,
+then fixed in a dedicated small commit before re-running the harness.

--- a/.agents/skills/wp-abilities-verify/references/runtime-harness.md
+++ b/.agents/skills/wp-abilities-verify/references/runtime-harness.md
@@ -1,0 +1,311 @@
+# Runtime Harness
+
+The runtime-mode procedure. Everything static-mode does, plus six canonical
+checks that need a live `wp_get_abilities()` call.
+
+Static mode catches structural problems (annotation lies, schema lint
+failures, audit mismatches). Runtime mode catches the class of bug that
+only surfaces against a booted WordPress: missing constructor arguments,
+bootstrap-ordering issues, schema-validator paths, capability-roundtrip
+failures, and idempotency violations at the response-byte level.
+
+## Harness rule: stop on first fatal
+
+If any step below produces a PHP fatal, STOP. Later steps won't produce
+meaningful output. Capture the failure, escalate to the plugin's
+implementer to fix, then re-run from step 1.
+
+A `WP_Error` return is acceptable — any `<plugin>_*` or upstream-prefixed
+error means the execute callback handled the error path gracefully. Only
+PHP fatals block.
+
+## Step 0 — identify the env-up command
+
+Read the plugin's `AGENTS.md` for the canonical env bring-up command. Do
+NOT assume `npm run wp-env start` works for every plugin. Observed
+patterns:
+
+- **Woo-family (WooPayments, WooCommerce extensions)** — `npm run wp-env start`
+  (runs `@wordpress/env` with the plugin's `.wp-env.json`).
+- **Jetpack-family** — `jetpack docker up` or a package-local
+  `composer install && composer test-php --setup-only`.
+- **Plain wp-env plugin** — `npx wp-env start`.
+- **Dev Docker stack** — a plugin-specific `docker-compose up -d`.
+
+If `AGENTS.md` doesn't document it, ask the user rather than guessing.
+Record the env-up command + the corresponding wp-cli invocation (e.g.
+`npx wp-env run cli wp`, `jetpack docker cli wp`) and use them uniformly
+for the rest of the harness.
+
+In this file, `<env-cli>` is shorthand for whatever wp-cli invocation the
+plugin uses.
+
+## Step 1 — bring up the env and sanity-check
+
+```bash
+<env-up-command>
+<env-cli> wp core version
+<env-cli> wp plugin list --status=active
+<env-cli> wp eval 'var_export( function_exists( "wp_get_abilities" ) );'
+```
+
+Confirm:
+
+- WordPress version >= 6.9 (abilities API available in core).
+- The plugin being verified is active.
+- `wp_get_abilities` exists (true if WP >= 6.9, else abilities API plugin
+  must be active).
+
+Any "no" answer halts the harness.
+
+## Check 1 — ability names match source-expected list
+
+Enumerate runtime abilities and diff against the static inventory from
+`static-enumeration.md`:
+
+```bash
+<env-cli> wp --user=admin eval '
+$names = array_filter(
+    array_keys( (array) wp_get_abilities() ),
+    fn( $n ) => str_starts_with( $n, "<plugin-slug>/" )
+);
+sort( $names );
+echo "count=" . count( $names ) . PHP_EOL;
+echo implode( PHP_EOL, $names ) . PHP_EOL;
+'
+```
+
+Compare against the static inventory:
+
+- Source contains ability, runtime missing → FAIL. Registration hook
+  isn't firing; check init hook timing and plugin activation.
+- Runtime contains ability, source missing → WARN. Dynamic registration
+  path the enumerator couldn't follow. Document but don't block.
+- Counts match → OK.
+
+## Check 2 — annotations read back as declared
+
+```bash
+<env-cli> wp --user=admin eval '
+$names = array_filter(
+    array_keys( (array) wp_get_abilities() ),
+    fn( $n ) => str_starts_with( $n, "<plugin-slug>/" )
+);
+sort( $names );
+foreach ( $names as $name ) {
+    $a = wp_get_ability( $name );
+    $m = $a->get_meta();
+    printf(
+        "%s | readonly=%s | destructive=%s | idempotent=%s | category=%s" . PHP_EOL,
+        $name,
+        var_export( $m["annotations"]["readonly"], true ),
+        var_export( $m["annotations"]["destructive"], true ),
+        var_export( $m["annotations"]["idempotent"], true ),
+        $a->get_category()
+    );
+}'
+```
+
+Cross-reference each annotation against the audit's declared value (if an
+audit was provided) AND against the static inventory's declared value.
+Mismatch on either axis → FAIL.
+
+This check complements the static adversarial check from
+`annotation-correctness.md`: static checks the callback's actual
+behavior; runtime checks what the registration hook resolved to at boot
+time. Both must agree for the annotations to be trustworthy.
+
+## Check 3 — each read ability's `execute([])` returns OK or a standard-vocabulary WP_Error
+
+```bash
+<env-cli> wp --user=admin eval '
+$reads = [
+    "<plugin-slug>/<read-ability-1>",
+    "<plugin-slug>/<read-ability-2>",
+    // ...
+];
+foreach ( $reads as $name ) {
+    $r = wp_get_ability( $name )->execute( [] );
+    echo $name . ": " . ( is_wp_error( $r ) ? "WP_Error(" . $r->get_error_code() . ")" : "OK" ) . PHP_EOL;
+}'
+```
+
+Acceptable outcomes:
+
+- `OK` — the ability returned an array.
+- `WP_Error(<plugin>_not_initialized)` — bootstrap guard fired (e.g.
+  un-bootstrapped account). Happy error path.
+- `WP_Error(<plugin>_<resource>_data_unavailable)` — transient backend
+  error. Acceptable.
+- `WP_Error(<upstream_code>)` — upstream error bubbled through (e.g.
+  Stripe's `resource_missing`). Document, don't block.
+
+Unacceptable:
+
+- PHP fatal → stop the harness.
+- `WP_Error` with a non-vocabulary code → WARN. Cross-reference
+  `../wp-abilities-api/references/error-code-vocabulary.md`.
+
+Abilities with required input get invoked separately with a
+synthetic-but-plausible value:
+
+```bash
+<env-cli> wp --user=admin eval '
+$r = wp_get_ability( "<plugin>/<ability-with-required-input>" )
+    ->execute([ "<field>" => "<synthetic-id>" ]);
+echo "<ability>: " . ( is_wp_error( $r ) ? "WP_Error(" . $r->get_error_code() . ")" : "OK" ) . PHP_EOL;
+'
+```
+
+A synthetic ID on a fresh store typically triggers upstream
+`resource_missing` or `<plugin>_<resource>_data_unavailable`. Both are
+acceptable.
+
+## Check 4 — each write ability's missing-input returns `ability_invalid_input` or `<plugin>_missing_<field>`
+
+```bash
+<env-cli> wp --user=admin eval '
+$a = wp_get_ability( "<plugin>/<write-ability>" );
+
+$r1 = $a->execute( [] );
+echo "missing: " . ( is_wp_error( $r1 ) ? "WP_Error(" . $r1->get_error_code() . ")" : "UNEXPECTED_OK" ) . PHP_EOL;
+
+$r2 = $a->execute( [ "<required_field>" => 123 ] );
+echo "non-string: " . ( is_wp_error( $r2 ) ? "WP_Error(" . $r2->get_error_code() . ")" : "UNEXPECTED_OK" ) . PHP_EOL;
+'
+```
+
+Acceptable codes, per
+`../wp-abilities-api/references/error-code-vocabulary.md`:
+
+- `ability_invalid_input` — the Abilities API's schema validator fired
+  first (normal REST-bridge path).
+- `<plugin>_missing_<field>` — the execute callback's own guard fired
+  (direct-invocation path).
+- `<plugin>_invalid_<field>` — same, for the wrong-type case.
+
+`UNEXPECTED_OK` → FAIL. Validation is missing; the ability accepted
+no-input and proceeded to do something it shouldn't have.
+
+## Check 5 — permission gate denies subscriber, allows admin
+
+```bash
+<env-cli> wp --user=admin eval '
+// Admin path.
+wp_set_current_user( 1 );
+$ability = wp_get_ability( "<plugin>/<any-ability>" );
+echo "admin: " . var_export( $ability->user_can_execute(), true ) . PHP_EOL;
+
+// Subscriber path.
+$sub = wp_create_user( "verify_sub_" . time(), "x", "verify_sub_" . time() . "@example.test" );
+$user = get_user_by( "id", $sub );
+$user->set_role( "subscriber" );
+wp_set_current_user( $sub );
+echo "subscriber: " . var_export( $ability->user_can_execute(), true ) . PHP_EOL;
+'
+```
+
+Expected:
+
+```
+admin: true
+subscriber: false
+```
+
+Any inversion is a bug in the registered `permission_callback`. See
+`permission-roundtrip.md` for the deeper cross-checks (audit's declared
+capability → registered callback → resolved `current_user_can(...)`).
+
+Public abilities (deliberately ungated) expect `subscriber: true` AND
+`admin: true`. Verify that the ability's `permission_callback` is
+`'__return_true'` in source before accepting this outcome.
+
+## Check 6 — idempotent reads return byte-for-byte identical results on twin invocations
+
+Per `annotation-correctness.md` step "Runtime check complement":
+
+```bash
+<env-cli> wp --user=admin eval '
+$a = wp_get_ability( "<plugin>/<idempotent-read-ability>" );
+$r1 = $a->execute( [ /* same input */ ] );
+$r2 = $a->execute( [ /* same input */ ] );
+$h1 = md5( serialize( $r1 ) );
+$h2 = md5( serialize( $r2 ) );
+echo "match=" . var_export( $h1 === $h2, true ) . PHP_EOL;
+echo "h1=$h1" . PHP_EOL;
+echo "h2=$h2" . PHP_EOL;
+'
+```
+
+Expected: `match=true` and two identical hashes.
+
+Twin-invocation differ on an `idempotent: true` ability → FAIL. Common
+causes:
+
+- Response embeds `time()` or `current_time()`.
+- Response embeds a nonce.
+- Response embeds a non-deterministic queue state.
+
+Either remove the nondeterministic field (preferred) or change the
+annotation to `idempotent: false`. Don't loosen the check.
+
+## Output format
+
+The runtime harness writes a dedicated section in the run report:
+
+```markdown
+## Runtime harness
+
+**Env:** wp-env (Docker), WordPress 6.9, <plugin> <version>
+**Captured:** <YYYY-MM-DD HH:MM>
+
+### Check 1 — enumeration
+
+count=7 (expected 7 from static inventory)
+<sorted list>
+
+### Check 2 — annotations
+
+| Ability | readonly | destructive | idempotent | Matches source? |
+|---|---|---|---|---|
+
+### Check 3 — read execution
+
+| Ability | Result |
+|---|---|
+
+### Check 4 — write input validation
+
+| Ability | Missing-input code | Wrong-type code |
+|---|---|---|
+
+### Check 5 — permission gate
+
+| Ability | admin | subscriber | Expected |
+|---|---|---|---|
+
+### Check 6 — idempotency
+
+| Ability | match | h1 | h2 |
+|---|---|---|---|
+
+### Notes / surprises
+
+<Anything unexpected that didn't block.>
+```
+
+## When the harness catches a bug
+
+Observed pattern (from the canonical harness-output example):
+
+1. Harness surfaces a PHP fatal (e.g. `ArgumentCountError: Too few
+   arguments to function <controller>::__construct`).
+2. Implementer fixes the bug in a focused commit.
+3. Harness re-runs; write the post-fix output as the headline status.
+4. Preserve the pre-fix trace in the report under a "Pre-fix status"
+   section so reviewers can see what verify caught.
+
+The canonical example is
+`/Users/rtiodev/rtiodev_vault/plans/2026-04-20-abilities-everywhere-woopayments-harness-output.md`
+— exactly this class of ArgumentCountError was caught by a runtime
+harness run and fixed in a dedicated small commit.

--- a/.agents/skills/wp-abilities-verify/references/schema-lints.md
+++ b/.agents/skills/wp-abilities-verify/references/schema-lints.md
@@ -1,0 +1,232 @@
+# Schema Lints
+
+Static lints against an ability's `input_schema` (and to a lesser extent,
+output schema when one is declared). Complements the adversarial
+annotation checks: schema hygiene is about agent legibility, not
+correctness-versus-behavior.
+
+The target audience is orchestrating agents: they read the schema to
+figure out how to call the ability. A schema that's hard to parse,
+ambiguous, or misleading wastes agent turns even when the ability
+itself works perfectly.
+
+## The lints
+
+### Lint 1 — `additionalProperties: false` unless deliberately accepting extras
+
+```php
+'input_schema' => [
+    'type'       => 'object',
+    'properties' => [ /* ... */ ],
+    'additionalProperties' => false,  // <-- required unless extras are intentional
+],
+```
+
+**Why:** without this, an agent passing typos (e.g. `par_page` instead of
+`per_page`) gets accepted silently, the backing controller ignores the
+typo key, and the behavior differs from what the agent expected. Fail
+fast on unknown keys.
+
+**Grep:**
+
+```bash
+# Find input_schema blocks.
+grep -rn --include='*.php' -A 30 "'input_schema'\s*=>\s*\[" <plugin-root>/ \
+    | grep -E "'additionalProperties'\s*=>\s*(true|false)"
+```
+
+**Result:**
+
+- `additionalProperties: false` declared → OK.
+- `additionalProperties: true` declared → WARN. Inspect: is this a
+  deliberate pass-through (e.g. Stripe metadata fields that the user
+  controls)? Document in a comment; otherwise tighten.
+- Not declared at all → FAIL. (JSON Schema default is `true`, so
+  omission is equivalent to `true` but worse — no explicit signal to
+  the reader.)
+
+**Deliberate-extras exemption:** payment systems pass through
+merchant-defined metadata. A pattern like:
+
+```php
+'metadata' => [
+    'type'        => 'object',
+    'additionalProperties' => true,  // merchant-controlled metadata
+    'description' => __( 'Free-form key/value metadata stored on the payment.', '<text-domain>' ),
+],
+```
+
+is legitimate at the property level. Top-level
+`additionalProperties: false` should still apply — the object as a
+whole has a finite key set, even if one of those keys is itself a
+bag-of-attributes.
+
+### Lint 2 — every required field has a description
+
+```php
+'properties' => [
+    'order_id' => [
+        'type'        => 'string',
+        'description' => __( 'The order ID to fetch.', '<text-domain>' ),  // <-- required
+    ],
+],
+'required' => [ 'order_id' ],
+```
+
+**Why:** required fields are where agents most need guidance. Missing
+descriptions push the agent into guessing from the field name alone,
+which fails on any non-obvious case (date formats, ID conventions,
+enum semantics).
+
+**Check:**
+
+For each key in `required`, its entry in `properties` must have a
+non-empty `description`. Empty or missing → FAIL (required field is
+opaque).
+
+Optional fields may also benefit from descriptions but their absence is
+a WARN, not a FAIL.
+
+### Lint 3 — enums are non-empty
+
+```php
+'status' => [
+    'type' => 'string',
+    'enum' => [ 'pending', 'active', 'cancelled' ],  // <-- at least one value
+],
+```
+
+**Why:** an empty `enum` accepts no values, effectively rejecting every
+input. Almost always a bug.
+
+**Check:** any `'enum' => []` → FAIL.
+
+A single-value enum is legal but unusual; WARN and prompt for review —
+often an artifact of a copy-paste that lost the other values.
+
+### Lint 4 — no `$ref`
+
+```php
+// WRONG — don't do this in ability schemas.
+'input_schema' => [
+    'type' => 'object',
+    'properties' => [
+        'address' => [ '$ref' => '#/definitions/Address' ],
+    ],
+],
+```
+
+**Why:** agents read the schema via the REST introspection endpoint. A
+`$ref` forces the agent to follow a reference to see what `address`
+looks like — wastes a turn and often breaks because the referenced
+schema isn't in the same document. Inline the shape instead.
+
+**Check:** any `'$ref'` in an `input_schema` → FAIL.
+
+### Lint 5 — default values are primitive or `null`
+
+```php
+// OK — primitive defaults.
+'per_page' => [ 'type' => 'integer', 'default' => 25 ],
+'submit'   => [ 'type' => 'boolean', 'default' => false ],
+'status'   => [ 'type' => 'string',  'default' => 'pending' ],
+'metadata' => [ 'type' => 'object',  'default' => null ],
+
+// WRONG — complex expression as default.
+'created_at' => [ 'type' => 'string', 'default' => gmdate( 'c' ) ],
+```
+
+**Why:** a default that evaluates per-call is both non-deterministic
+(twin invocations can differ, violating `idempotent: true`) and
+surprising to agents that expect defaults to be static values.
+
+**Check:** each `'default'` value must be a scalar literal (`true`,
+`false`, integer, float, quoted string, `null`) or an empty array
+literal. A function call, variable reference, or computed expression →
+FAIL.
+
+### Lint 6 — `reference_ability: true` implies no required inputs
+
+From `../wp-abilities-audit/references/audit-schema.md`:
+
+> Exactly zero or one ability per audit may set `reference_ability: true`.
+
+The reference ability is the first one a downstream implement skill
+lands — typically the smallest, safest, highest-leverage read. It gets
+invoked as a bootstrap call to confirm the abilities registration works
+end-to-end, so it must work with `execute([])`:
+
+**Check:** if an audit doc is provided and an ability has
+`reference_ability: true`, its `input_schema.required` array must be
+empty or absent. Required inputs on the reference ability → FAIL.
+
+If no audit is provided, this lint is skipped (no reference ability
+declared).
+
+### Lint 7 — top-level `type: object` declared
+
+```php
+'input_schema' => [
+    'type'       => 'object',  // <-- required
+    'properties' => [ /* ... */ ],
+],
+```
+
+**Why:** agents may see a schema without a top-level `type` and reject
+it as ill-formed. Abilities always take an object-shaped input; be
+explicit.
+
+**Check:** the top-level schema MUST have `'type' => 'object'`. Missing
+→ FAIL.
+
+## Cross-reference: the three runtime gotchas
+
+Static lints can't catch runtime gotchas. Cross-reference
+`../wp-abilities-api/references/input-schema-gotchas.md` for the three
+patterns that need defensive code in the execute callback:
+
+1. **Schema `default` values are NOT injected into callback input** —
+   the callback must re-apply defaults via `array_key_exists` + null
+   checks.
+2. **Pagination parameter-name drift** — if the backing reads `pagesize`
+   but the schema exposes `per_page`, the callback must translate before
+   delegating.
+3. **ID validation must not use `empty()`** — `empty( "0" )` is true,
+   but `"0"` is a legal ID. Use `isset + is_string + '' === ...`
+   instead.
+
+Static mode can only detect the schema-declaration side of these:
+
+- Gotcha 1: the lint catches missing `default` values that are obviously
+  expected (e.g. a boolean with `required: false` but no default).
+  Flag as WARN.
+- Gotcha 2: grep the callback body for the `per_page`/`pagesize`
+  translation helper; if the schema exposes `per_page` and the backing
+  reads `pagesize`, the helper should be present. Absence → FAIL.
+- Gotcha 3: grep the callback body for `empty( $input[ <required_key> ] )`
+  on required string IDs. Hit → FAIL (use `isset + is_string + ''`).
+
+Runtime mode confirms these patterns via actual invocation — the
+harness's "missing-input code" and "wrong-type code" checks from
+`runtime-harness.md` step 4.
+
+## Output format
+
+Report schema lints in the run report under a "Schema lints" section:
+
+```markdown
+## Schema lints
+
+| Ability | Lint | Result | Detail |
+|---|---|---|---|
+| <ability> | additionalProperties | FAIL | not declared |
+| <ability> | required-field descriptions | OK | 3/3 required fields documented |
+| <ability> | enum non-empty | OK | no enums |
+| <ability> | no $ref | OK | inline |
+| <ability> | primitive defaults | FAIL | `created_at` uses `gmdate('c')` |
+| <ability> | reference_ability implies no required | N/A | not reference ability |
+| <ability> | top-level type:object | OK | declared |
+```
+
+A single FAIL lint on any ability feeds into the run's top-line status
+per the main SKILL.md "Verification" section.

--- a/.agents/skills/wp-abilities-verify/references/static-enumeration.md
+++ b/.agents/skills/wp-abilities-verify/references/static-enumeration.md
@@ -1,0 +1,262 @@
+# Static Enumeration
+
+Enumerate a plugin's abilities from source, with no running environment.
+This is the first step of every static-mode run and the cross-check for
+every runtime-mode run.
+
+Static enumeration is necessarily best-effort — PHP's dynamism (variable
+indirection, runtime-conditional registration) means a full inventory
+only comes from a live `wp_get_abilities()` call. When static and runtime
+inventories diverge, trust runtime; static drives the diff so the
+reviewer knows where to look.
+
+## Target: `wp_register_ability( '<name>', [ ... ] )` calls
+
+The canonical registration shape:
+
+```php
+wp_register_ability(
+    '<plugin-slug>/<ability-name>',
+    [
+        'label'           => __( '...', '<text-domain>' ),
+        'description'     => __( '...', '<text-domain>' ),
+        'category'        => '<category-slug>',
+        'input_schema'    => [ /* ... */ ],
+        'execute_callback' => [ self::class, 'execute_my_ability' ],
+        'permission_callback' => [ self::class, 'check_permission' ],
+        'meta'            => [
+            'annotations' => [
+                'readonly'    => true,
+                'destructive' => false,
+                'idempotent'  => true,
+            ],
+            'show_in_rest' => true,
+        ],
+    ]
+);
+```
+
+Find the calls, extract the names, and follow the callback references to
+locate the execute-callback body.
+
+## Step 1 — find every registration call
+
+```bash
+grep -rn --include='*.php' "wp_register_ability\s*(" <plugin-root>/
+```
+
+For each hit, capture the starting line. The next 40-100 lines are
+usually the array literal — the exact end-line is whatever line balances
+the opening `[` or `(`.
+
+If the plugin has zero hits, return a clear "no abilities registered"
+report per the main SKILL.md "Failure modes" section. Don't fabricate
+an empty inventory.
+
+## Step 2 — extract each ability name
+
+The first argument to `wp_register_ability` is the ability name. Usually
+a literal string:
+
+```bash
+# Greedy capture of single- or double-quoted first argument.
+grep -rn --include='*.php' -E "wp_register_ability\s*\(\s*['\"]([^'\"]+)['\"]" <plugin-root>/ \
+    | sed -nE "s/.*wp_register_ability\s*\(\s*['\"]([^'\"]+)['\"].*/\1/p"
+```
+
+If the first argument is a variable (`wp_register_ability( $ability_name, ... )`),
+trace the variable:
+
+- Recent assignment in the same function → resolve at audit time.
+- Constant (`MyPlugin\ABILITY_NAME`) → resolve via a follow-up grep.
+- Truly dynamic (computed from config or loops) → flag as a limitation
+  and recommend the caller use runtime mode for authoritative
+  enumeration.
+
+## Step 3 — extract the annotation block
+
+The annotations live at `meta.annotations.{readonly,destructive,idempotent}`.
+
+For each registration, read the array literal from the starting line
+forward until the matching close paren. Inside, find:
+
+```php
+'annotations' => [
+    'readonly'    => true,
+    'destructive' => false,
+    'idempotent'  => true,
+],
+```
+
+Patterns to handle:
+
+### 3.1 — short-form one-liner
+
+```php
+'annotations' => [ 'readonly' => true, 'destructive' => false, 'idempotent' => true ],
+```
+
+### 3.2 — multi-line (most common)
+
+Use a multi-line regex or read lines until the next `],`:
+
+```bash
+grep -nE "'(readonly|destructive|idempotent)'\s*=>\s*(true|false)" <file>
+```
+
+### 3.3 — values via variables
+
+```php
+'annotations' => self::annotations_for_read(),
+```
+
+Resolve the helper method. If it returns an array literal, treat as
+resolvable. If it builds the array dynamically, record the ability with
+`annotations: <unresolved>` and flag: the adversarial checks can still
+run against the execute callback, but the declared annotations can't be
+compared statically — runtime mode required for that comparison.
+
+### 3.4 — inherited / constant annotations
+
+```php
+'annotations' => self::READONLY_ANNOTATIONS,
+```
+
+Find the class constant; treat as resolvable.
+
+## Step 4 — follow the execute callback to its body
+
+`execute_callback` is one of:
+
+```php
+// Array form (most common with static class method).
+'execute_callback' => [ self::class, 'execute_get_things' ],
+'execute_callback' => [ My_Class::class, 'execute_get_things' ],
+'execute_callback' => [ $this, 'execute_get_things' ],
+
+// String form (top-level function).
+'execute_callback' => 'my_plugin_execute_get_things',
+
+// Closure.
+'execute_callback' => function( $input ) { /* ... */ },
+```
+
+For each form:
+
+- **Array form**: find `class <name>` in the plugin, then
+  `(public|protected|private)( static)?\s+function\s+<method>\s*\(` inside
+  that class. Record the file + start line + end line (find the matching
+  `}` — use the brace-matching heuristic).
+- **String form**: grep for `function <name>\s*\(`.
+- **Closure**: the body is literally inline in the registration; the
+  start line is the `function(` line, the end line is the matching `}`.
+
+Record per ability: `ability_name → (callback_file, callback_start_line, callback_end_line)`.
+The annotation-correctness checks grep inside this range.
+
+## Step 5 — handle fluent builder patterns
+
+Some plugins wrap registrations in helper functions:
+
+```php
+register_get_foo_ability();
+register_get_bar_ability();
+
+function register_get_foo_ability() {
+    wp_register_ability(
+        'myplugin/get-foo',
+        [ /* ... */ ]
+    );
+}
+```
+
+The `grep 'wp_register_ability'` still finds these — they're one level of
+indirection but still literal. No special handling needed.
+
+The trickier pattern:
+
+```php
+foreach ( [ 'foo', 'bar', 'baz' ] as $slug ) {
+    wp_register_ability( "myplugin/get-{$slug}", [ /* ... */ ] );
+}
+```
+
+Here the ability name is dynamic. Record each computed name as a
+limitation and recommend runtime enumeration.
+
+## Step 6 — handle `input_schema` via helper methods
+
+```php
+'input_schema' => self::input_schema_for_get_disputes(),
+```
+
+The schema lints in `schema-lints.md` need the actual schema. Resolve
+the helper; if it returns an array literal, use it. If the helper builds
+the schema conditionally, flag as unresolvable and skip the static schema
+lints for that ability (runtime mode via the `wp_get_ability(...)->get_input_schema()`
+API is authoritative).
+
+## Step 7 — handle heredoc callbacks (rare but real)
+
+A handful of plugins register abilities with inline heredoc SQL:
+
+```php
+'execute_callback' => function() {
+    global $wpdb;
+    return $wpdb->get_results( <<<SQL
+        SELECT ...
+    SQL );
+},
+```
+
+The grep patterns from `annotation-correctness.md` work on the PHP body,
+not the SQL inside the heredoc. A `SELECT` inside a heredoc is a read
+regardless; an `INSERT` or `UPDATE` inside a heredoc on a `readonly: true`
+ability is a lie. The regex in annotation-correctness catches
+`$wpdb->query(...UPDATE|INSERT|DELETE)` on a single line, but a heredoc
+spans lines. Use multi-line grep:
+
+```bash
+grep -PzoE '\$wpdb->query\s*\([^)]*<<<SQL[^S]*(UPDATE|INSERT|DELETE)' <file>
+```
+
+Document this as a known gap: single-line write patterns are reliably
+detected; multi-line heredoc writes require the multi-line grep variant
+above.
+
+## Limits of static enumeration
+
+Cases where static enumeration produces incomplete or ambiguous output:
+
+- Variable-indirected names (`foreach` over a slug list).
+- Variable-indirected annotations (annotations built from config).
+- Conditional registration (`if ( feature_enabled() ) wp_register_ability(...)`).
+- Variable-indirected callbacks (`[ $this, $callback_name ]`).
+
+Every case above gets recorded in the report's "Static enumeration
+limitations" section. When these occur, recommend the caller re-run in
+runtime mode to get the authoritative inventory from
+`wp_get_abilities()`.
+
+## Output format
+
+```markdown
+## Static inventory
+
+Found <N> ability registrations across <M> files:
+
+| Ability | Source file | Registration line | Callback file | Callback lines |
+|---|---|---|---|---|
+| myplugin/get-foo | src/Abilities.php | 42 | src/Abilities.php | 102-134 |
+| myplugin/submit-bar | src/Abilities.php | 68 | src/Services/Bar.php | 58-91 |
+
+### Limitations
+
+- <ability>: annotations built dynamically in `annotations_for_read()`;
+  recommend runtime mode for annotation cross-check.
+```
+
+This inventory is the input to the annotation-correctness, schema-lint,
+permission-roundtrip, and error-code-vocabulary checks. Each of those
+references operates on the `(callback_file, callback_start_line,
+callback_end_line)` byte range.

--- a/.claude/skills/ship-wp-ability/SKILL.md
+++ b/.claude/skills/ship-wp-ability/SKILL.md
@@ -1,0 +1,1 @@
+@../../../.agents/skills/ship-wp-ability.md

--- a/.claude/skills/wp-abilities-api/SKILL.md
+++ b/.claude/skills/wp-abilities-api/SKILL.md
@@ -1,0 +1,1 @@
+@../../../.agents/skills/wp-abilities-api.md

--- a/.claude/skills/wp-abilities-audit/SKILL.md
+++ b/.claude/skills/wp-abilities-audit/SKILL.md
@@ -1,0 +1,1 @@
+@../../../.agents/skills/wp-abilities-audit.md

--- a/.claude/skills/wp-abilities-verify/SKILL.md
+++ b/.claude/skills/wp-abilities-verify/SKILL.md
@@ -1,0 +1,1 @@
+@../../../.agents/skills/wp-abilities-verify.md


### PR DESCRIPTION
Fixes RSM-1634

## Proposed changes

Adds four companion skills for working with the WordPress Abilities API in the Jetpack monorepo. They share a single `.agents/skills/` layout with `@`-include pointers under `.claude/skills/`.

### `wp-abilities-audit` (new) — audits a plugin's REST surface and produces a standardized audit doc

A 7-step procedural skill that takes a plugin checkout (after `wp-project-triage` has classified it) and walks an agent through:

* Enumerating REST controllers — glob for standard layouts, grep as the universal fallback — into a "Controller Inventory" table.
* For each controller, extracting the backing fields the audit schema requires (callback names, line numbers, `permission_callback`, return type, inheritance).
* Tracing each `permission_callback` to its `current_user_can()` call (or to post-type capability machinery for post-type-backed plugins) — represented as a single string for single-cap plugins or a `{read, write}` object for compound gates.
* Proposing abilities using the **semantic-intent grouping** heuristic — deferred to `wp-abilities-api/references/grouping-heuristic.md` so the rule has a single source of truth — instead of one-ability-per-HTTP-method.
* Surfacing gaps and deferred items into `excluded_from_mvp`, `surfaced_gaps`, and per-ability `risks` (zero-arg endpoints registered with `permission_callback => '__return_true'` are flagged here so they don't get promoted into ability registrations).
* Writing the audit doc to an explicit user-supplied output path — never the plugin worktree — in a fixed structure: `Last updated:` header → YAML block → "Controller Inventory" table → "Notes and Surprises" prose.

The audit doc is the planning artifact downstream implement and verify skills consume via a hard handoff: if `ship-wp-ability` or `wp-abilities-verify` can't find a valid audit doc conforming to the schema, they error out rather than guess.

Three references:

```
wp-abilities-audit.md                            183 lines  (7-step procedure)
wp-abilities-audit/references/
    audit-schema.md                              256        canonical schema downstream skills validate against
    capability-gate-tracing.md                   163        permission_callback → cap, single vs compound
    controller-enumeration.md                    112        glob + grep enumeration paths
```

Closes the orphan `@`-pointer at `.claude/skills/wp-abilities-audit/SKILL.md`.

### `ship-wp-ability` (new) — scaffolds a new Abilities surface end-to-end

A 15-step procedural skill that takes a target ("for jetpack modules", "for Forms responses", "for Boost cache") and walks an agent through:

* Creating an isolated worktree (via `jetpack-worktree`).
* Picking the right **colocation** for the ability code: module-backed → `modules/<slug>/abilities/` wired from `modules/<slug>.php` (so `Jetpack::load_modules()` gates registration automatically), package-backed → `projects/packages/<pkg>/src/abilities/`, plugin-core → `projects/plugins/jetpack/src/abilities/`. Includes an executable colocation lint + reflection-based test that fail if a module-backed ability leaks into the plugin's global `src/abilities/` tree (the shape PR #48284 currently has).
* Extending the shared `Automattic\Jetpack\WP_Abilities\Registrar` base class (shipped in #48246), so subclasses never hand-roll the `jetpack_wp_abilities_enabled` gate, `did_action()` late-load handling, or per-ability allow-list filtering.
* **Consolidation heuristic** — prefer fewer, more powerful abilities: collapse `list-X` + `get-X` into filtered `get-Xs`; replace `activate-`/`deactivate-` verb pairs with declarative idempotent `set-X-status` state-setters.
* **Agent ergonomics** distilled from Anthropic's *[Writing tools for agents](https://www.anthropic.com/engineering/writing-tools-for-agents)* — description-as-spec, semantic identifiers, high-signal responses, `response_format` pattern, mandatory pagination ceilings, errors that steer the next call.
* Changelog step uses `vendor/bin/changelogger add` (enforces per-project `Type:` values) instead of hand-writing entries, then `changelogger validate` as a mandatory gate — prevents the class of bug where `Type: added` lands in a Jetpack-plugin entry that only accepts `enhancement`/`compat`/`bugfix`/`major`/`other`.
* Runs `/simplify` pre-commit and `/jetpack-review-pr` post-PR as part of the loop.

Five references:

```
ship-wp-ability.md                           332 lines  (15-step procedure)
ship-wp-ability/references/
    module-colocation.md                     100        Case A/B/C + executable lint
    consolidation-heuristic.md                83        fewer-and-more-powerful rules
    agent-ergonomics.md                      111        Anthropic's tool-writing guide
    class-skeleton.md                        340        Registrar subclass templates
    test-templates.md                        536        WP_UnitTestCase + Brain Monkey
```

### `wp-abilities-api` (companion reference) — generic Abilities API skill

Reference skill for anyone working on `wp_register_ability`, `wp_register_ability_category`, `/wp-json/wp-abilities/v1/*`, or `@wordpress/abilities`. Seven deep-dive references: grouping heuristic, delegate-helper pattern, input-schema gotchas, error-code vocabulary, plugin-family patterns, PHP registration, REST API.

Cross-referenced from `ship-wp-ability` and `wp-abilities-audit` — specifically `grouping-heuristic.md`, `input-schema-gotchas.md`, and `error-code-vocabulary.md`.

### `wp-abilities-verify` (companion reference) — adversarial post-implementation check

Validates that an implemented Abilities surface is annotation-correct and schema-sound (static and runtime modes). Six references: static enumeration, runtime harness, annotation correctness, permission roundtrip, schema lints, audit schema validation.

`ship-wp-ability` hands off to `wp-abilities-verify` in its verification step, and `wp-abilities-verify` validates audit docs against the canonical schema owned by `wp-abilities-audit` — so all four skills are designed to work together.

### Out of scope

* No changes to `projects/` — skill/docs only, so no changelog entry.

## Related product discussion/links

* Built on top of the `jetpack-wp-abilities` package from #48246.
* Designed to produce PRs shaped like #48246 (plugin-core Case C) and to fix the module-colocation issue in #48284 (module-backed Case A — the linter in `module-colocation.md` would flag the current placement of `Monitor_Abilities`).
* Part of the Radical Speed Month "Abilities Everywhere" initiative.

## Does this pull request change what data or activity we track or use?

No — skill/documentation-only change. No runtime code, no data flows, no tracking.

## Testing instructions

Skills are loaded by the Claude Code harness at session start; they take effect immediately after files land. No build step.

1. From the repo root, confirm all four skills' include pointers resolve:

   ```bash
   for s in wp-abilities-audit ship-wp-ability wp-abilities-api wp-abilities-verify; do
     target=$(cat .claude/skills/$s/SKILL.md | sed 's/^@//')
     [ -e ".claude/skills/$s/$target" ] && echo "OK: $s" || echo "BROKEN: $s"
   done
   ```

   All four should say OK.

2. In a fresh Claude Code session run inside this branch, confirm all four skills appear in the available-skills list.

3. Dry-run `/ship-wp-ability for jetpack monitor` and confirm Claude:
   * Reads `references/module-colocation.md` and classifies Monitor as Case A.
   * Places the class at `modules/monitor/abilities/class-monitor-abilities.php`, not `src/abilities/`.
   * Wires `::init()` from inside `modules/monitor.php`, not `class.jetpack.php`.
   * Consolidates to two abilities (one filtered read + one declarative state-setter).
   * Uses `vendor/bin/changelogger add` with `--type=enhancement` (plugin-context).
   * Runs `vendor/bin/changelogger validate`, `composer phpunit`, then `/simplify`.

4. Run the colocation lint from `references/module-colocation.md` against the current repo to confirm it's bash/zsh-safe and produces no false positives:

   ```bash
   find projects/plugins/jetpack/src/abilities -maxdepth 1 -type f -name 'class-*-abilities.php' 2>/dev/null |
     while read -r f; do
       base=$(basename "$f" | sed 's/^class-\(.*\)-abilities\.php$/\1/')
       [ -f "projects/plugins/jetpack/modules/${base}.php" ] && echo "COLOCATION FAIL: $f"
     done
   grep -oE '[A-Z][A-Za-z_]+_Abilities::init\(\)' projects/plugins/jetpack/class.jetpack.php 2>/dev/null |
     while read -r call; do
       slug=$(echo "$call" | sed 's/_Abilities::init()//' | tr '[:upper:]_' '[:lower:]-')
       [ -f "projects/plugins/jetpack/modules/${slug}.php" ] && echo "COLOCATION FAIL: $slug"
     done
   ```

   Both blocks should produce no output on this branch. Simulating `Monitor_Abilities::init()` in `class.jetpack.php` should emit `COLOCATION FAIL: monitor is a module; should init from modules/monitor.php`.
