### PR TITLE
Stats: register jetpack-stats abilities

### DIFF
--- a/projects/packages/stats/changelog/add-stats-abilities
+++ b/projects/packages/stats/changelog/add-stats-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Abilities API: register jetpack-stats abilities for site overview, top content, post views, visits, followers, and stats configuration.

--- a/projects/packages/stats/composer.json
+++ b/projects/packages/stats/composer.json
@@ -7,7 +7,8 @@
 		"php": ">=7.2",
 		"automattic/jetpack-connection": "@dev",
 		"automattic/jetpack-constants": "@dev",
-		"automattic/jetpack-status": "@dev"
+		"automattic/jetpack-status": "@dev",
+		"automattic/jetpack-wp-abilities": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^4.0.0",

--- a/projects/packages/stats/src/abilities/class-stats-abilities.php
+++ b/projects/packages/stats/src/abilities/class-stats-abilities.php
@@ -35,11 +35,13 @@ class Stats_Abilities extends Registrar {
 	 *
 	 * Internal keys (`blog_id`, `notices`, `views`, `collapse_nudges`,
 	 * `version`, `odyssey_stats_changed_at`) are deliberately excluded —
-	 * agents can't act on them and they'd bloat the response. The per-key
-	 * type (bool / role-array) is read from `Options::get_defaults()` at
-	 * runtime, not duplicated here.
+	 * agents can't act on them and they'd bloat the response.
+	 * `enable_odyssey_stats` is also excluded: it's a UI dashboard toggle
+	 * with no meaningful agent use case. The per-key type (bool /
+	 * role-array) is read from `Options::get_defaults()` at runtime, not
+	 * duplicated here.
 	 */
-	const CONFIG_KEYS = array( 'admin_bar', 'roles', 'count_roles', 'do_not_track', 'enable_odyssey_stats' );
+	const CONFIG_KEYS = array( 'admin_bar', 'roles', 'count_roles', 'do_not_track' );
 
 	/**
 	 * Allowed `type` values for `get-top-content`.
@@ -464,7 +466,7 @@ class Stats_Abilities extends Registrar {
 		return array(
 			'label'               => __( 'Get Stats configuration', 'jetpack-stats' ),
 			'description'         => __(
-				'Read the current Jetpack Stats configuration: who sees the Stats admin bar + menu, whose visits are counted, DNT behavior, and Odyssey Stats enablement. Shape: { admin_bar, roles, count_roles, do_not_track, enable_odyssey_stats }. `roles` is an array of role slugs that can view Stats; `count_roles` is an array of role slugs whose visits are counted. Call jetpack-stats/set-stats-config to change any of these.',
+				'Read the current Jetpack Stats configuration: who sees the Stats admin bar + menu, whose visits are counted, and DNT behavior. Shape: { admin_bar, roles, count_roles, do_not_track }. `roles` is an array of role slugs that can view Stats; `count_roles` is an array of role slugs whose visits are counted. Call jetpack-stats/set-stats-config to change any of these.',
 				'jetpack-stats'
 			),
 			'input_schema'        => array(
@@ -500,34 +502,30 @@ class Stats_Abilities extends Registrar {
 		return array(
 			'label'               => __( 'Set Stats configuration', 'jetpack-stats' ),
 			'description'         => __(
-				'Update one or more Jetpack Stats configuration fields. All fields are optional; only fields present in the call are written, and unrelated keys are preserved. Idempotent — setting a value to its current state returns changed=false. Shape: { changed, config: { admin_bar, roles, count_roles, do_not_track, enable_odyssey_stats } }. Role slugs in `roles` and `count_roles` are validated against the site\'s registered roles; unknown slugs return jetpack_stats_invalid_role. Narrowing `roles` can revoke Stats access for whole groups of users — confirm with the user before removing roles.',
+				'Update one or more Jetpack Stats configuration fields. All fields are optional; only fields present in the call are written, and unrelated keys are preserved. Idempotent — setting a value to its current state returns changed=false. Shape: { changed, config: { admin_bar, roles, count_roles, do_not_track } }. Role slugs in `roles` and `count_roles` are validated against the site\'s registered roles; unknown slugs return jetpack_stats_invalid_role. Narrowing `roles` can revoke Stats access for whole groups of users — confirm with the user before removing roles.',
 				'jetpack-stats'
 			),
 			'input_schema'        => array(
 				'type'                 => 'object',
 				'properties'           => array(
-					'admin_bar'            => array(
+					'admin_bar'    => array(
 						'type'        => 'boolean',
 						'description' => __( 'Whether to show the Stats item in the admin bar for users who can view Stats.', 'jetpack-stats' ),
 					),
-					'roles'                => array(
+					'roles'        => array(
 						'type'        => 'array',
 						'description' => __( 'Role slugs that can view Stats. Must be non-empty; each slug must be a registered role.', 'jetpack-stats' ),
 						'items'       => array( 'type' => 'string' ),
 						'minItems'    => 1,
 					),
-					'count_roles'          => array(
+					'count_roles'  => array(
 						'type'        => 'array',
 						'description' => __( 'Role slugs whose visits are counted. May be empty (count visits from all users).', 'jetpack-stats' ),
 						'items'       => array( 'type' => 'string' ),
 					),
-					'do_not_track'         => array(
+					'do_not_track' => array(
 						'type'        => 'boolean',
 						'description' => __( 'Whether to honor the browser Do Not Track header.', 'jetpack-stats' ),
-					),
-					'enable_odyssey_stats' => array(
-						'type'        => 'boolean',
-						'description' => __( 'Whether to render the Odyssey Stats dashboard.', 'jetpack-stats' ),
 					),
 				),
 				'additionalProperties' => false,
@@ -565,17 +563,16 @@ class Stats_Abilities extends Registrar {
 	 */
 	private static function config_output_properties(): array {
 		return array(
-			'admin_bar'            => array( 'type' => 'boolean' ),
-			'roles'                => array(
+			'admin_bar'    => array( 'type' => 'boolean' ),
+			'roles'        => array(
 				'type'  => 'array',
 				'items' => array( 'type' => 'string' ),
 			),
-			'count_roles'          => array(
+			'count_roles'  => array(
 				'type'  => 'array',
 				'items' => array( 'type' => 'string' ),
 			),
-			'do_not_track'         => array( 'type' => 'boolean' ),
-			'enable_odyssey_stats' => array( 'type' => 'boolean' ),
+			'do_not_track' => array( 'type' => 'boolean' ),
 		);
 	}
 

--- a/projects/packages/stats/src/abilities/class-stats-abilities.php
+++ b/projects/packages/stats/src/abilities/class-stats-abilities.php
@@ -1,0 +1,1275 @@
+<?php
+/**
+ * Jetpack Stats Abilities Registration.
+ *
+ * Registers Jetpack Stats abilities with the WordPress Abilities API.
+ *
+ * @package automattic/jetpack-stats
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9; suppressions needed for older-WP compatibility runs.
+
+namespace Automattic\Jetpack\Stats\Abilities;
+
+use Automattic\Jetpack\Stats\Options;
+use Automattic\Jetpack\Stats\WPCOM_Stats;
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use WP_Error;
+
+/**
+ * Registers Jetpack Stats abilities with the WordPress Abilities API.
+ *
+ * Exposes a small, consolidated surface for reading Jetpack Stats traffic
+ * insights and managing site-level Stats configuration so AI agents can
+ * answer site-owner questions through the standard `wp-abilities/v1` REST
+ * surface. Seven abilities wrap ~25 atomic WPCOM Stats endpoints plus the
+ * `stats_options` WP option.
+ */
+class Stats_Abilities extends Registrar {
+
+	const CATEGORY_SLUG = 'jetpack-stats';
+	const ERROR_PREFIX  = 'jetpack_stats_';
+
+	/**
+	 * Whitelist of stats_options keys exposed via the config abilities.
+	 *
+	 * Internal keys (`blog_id`, `notices`, `views`, `collapse_nudges`,
+	 * `version`, `odyssey_stats_changed_at`) are deliberately excluded —
+	 * agents can't act on them and they'd bloat the response.
+	 */
+	const CONFIG_KEYS = array( 'admin_bar', 'roles', 'count_roles', 'do_not_track', 'enable_odyssey_stats' );
+
+	/**
+	 * Subset of CONFIG_KEYS whose values are boolean.
+	 *
+	 * Read + write paths coerce to bool before comparison/emit so agents
+	 * never see `1`/`"true"` drift in place of real booleans.
+	 */
+	const CONFIG_BOOL_KEYS = array( 'admin_bar', 'do_not_track', 'enable_odyssey_stats' );
+
+	/**
+	 * Allowed `type` values for `get-top-content`.
+	 */
+	const TOP_CONTENT_TYPES = array( 'posts', 'referrers', 'search-terms', 'clicks', 'tags', 'authors', 'countries', 'downloads', 'video-plays' );
+
+	/**
+	 * Allowed aggregation periods for timeseries + top-content reads.
+	 */
+	const PERIODS = array( 'day', 'week', 'month', 'year' );
+
+	/**
+	 * Normalization table for `get-top-content`.
+	 *
+	 * Each entry describes how to project a WPCOM `days -> <date> -> <list>`
+	 * array of rows into the uniform `{ rank, label, value, href? }` shape.
+	 * `countries` (needs `country-info` join) and `tags` (flat `tags` array,
+	 * no `days` envelope) are special-cased in the callback.
+	 */
+	const TOP_CONTENT_MAP = array(
+		'posts'        => array( 'list' => 'postviews',    'label' => 'title',    'value' => 'views',          'href' => 'href' ),
+		'referrers'    => array( 'list' => 'referrers',    'label' => 'name',     'value' => 'views' ),
+		'search-terms' => array( 'list' => 'search_terms', 'label' => 'term',     'value' => 'views' ),
+		'clicks'       => array( 'list' => 'clicks',       'label' => 'name',     'value' => 'views',          'href' => 'url',          'label_fallback' => 'url' ),
+		'authors'      => array( 'list' => 'authors',      'label' => 'name',     'value' => 'views' ),
+		'downloads'    => array( 'list' => 'files',        'label' => 'filename', 'value' => 'download_count', 'href' => 'relative_url', 'label_fallback' => 'relative_url' ),
+		'video-plays'  => array( 'list' => 'plays',        'label' => 'title',    'value' => 'plays' ),
+	);
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_slug(): string {
+		return self::CATEGORY_SLUG;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_category_definition(): array {
+		return array(
+			// "Jetpack" is a product name and should not be translated.
+			'label'       => 'Jetpack Stats',
+			'description' => __( 'Abilities for reading Jetpack Stats traffic insights and managing site-level Stats configuration.', 'jetpack-stats' ),
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_abilities(): array {
+		return array(
+			'jetpack-stats/get-site-overview' => self::spec_get_site_overview(),
+			'jetpack-stats/get-top-content'   => self::spec_get_top_content(),
+			'jetpack-stats/get-post-views'    => self::spec_get_post_views(),
+			'jetpack-stats/get-visits'        => self::spec_get_visits(),
+			'jetpack-stats/get-followers'     => self::spec_get_followers(),
+			'jetpack-stats/get-stats-config'  => self::spec_get_stats_config(),
+			'jetpack-stats/set-stats-config'  => self::spec_set_stats_config(),
+		);
+	}
+
+	/* ---------------------------------------------------------------------
+	 * Ability specs
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Spec: jetpack-stats/get-site-overview.
+	 */
+	private static function spec_get_site_overview(): array {
+		return array(
+			'label'               => __( 'Get site stats overview', 'jetpack-stats' ),
+			'description'         => __(
+				'Return a single zero-argument snapshot answering "how is my site doing right now?" — today\'s views/visitors, this week/month totals, the current posting streak, today\'s top post, and top referrer. Shape: { date, views_today, visitors_today, views_week, views_month, streak: { current_length, longest_length, longest_start, longest_end }, top_post: { id, title, views }, top_referrer: { name, views }, partial: bool, errors?: [string] }. Composes the WPCOM stats/summary, stats/highlights, and stats/streak endpoints — if any sub-call fails, `partial` is true and `errors` lists the failed sub-calls; missing data is never silently substituted with zeros. Precondition: the site must be connected to WordPress.com; a disconnected site returns jetpack_stats_not_connected. Results cached for ~5 minutes by WPCOM_Stats — safe to poll.',
+				'jetpack-stats'
+			),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'properties'           => new \stdClass(),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'date'            => array( 'type' => 'string' ),
+					'views_today'     => array( 'type' => 'integer' ),
+					'visitors_today'  => array( 'type' => 'integer' ),
+					'views_week'      => array( 'type' => 'integer' ),
+					'views_month'     => array( 'type' => 'integer' ),
+					'streak'          => array( 'type' => 'object' ),
+					'top_post'        => array( 'type' => array( 'object', 'null' ) ),
+					'top_referrer'    => array( 'type' => array( 'object', 'null' ) ),
+					'partial'         => array( 'type' => 'boolean' ),
+					'errors'          => array( 'type' => 'array' ),
+				),
+			),
+			'execute_callback'    => array( __CLASS__, 'get_site_overview' ),
+			'permission_callback' => array( __CLASS__, 'can_view_stats' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'show_in_rest' => true,
+			),
+		);
+	}
+
+	/**
+	 * Spec: jetpack-stats/get-top-content.
+	 */
+	private static function spec_get_top_content(): array {
+		return array(
+			'label'               => __( 'Get top stats content', 'jetpack-stats' ),
+			'description'         => __(
+				'Return the top items for a chosen content type — posts, referrers, search terms, outbound clicks, tags/categories, authors, countries, downloads, or video plays — in one filtered call. Replaces nine atomic WPCOM endpoints with a single ability. Uniform shape: { type, period, date, num, max, items: [ { rank, label, value, href? } ] } — agents MUST NOT see a different shape per type. `label` is human-readable (post title, referrer host, search term, country name, etc.). `value` is the view/hit count for that item. `href` is present only when the item has a canonical URL. Precondition: site must be connected to WordPress.com.',
+				'jetpack-stats'
+			),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'type' ),
+				'properties'           => array(
+					'type'   => array(
+						'type'        => 'string',
+						'description' => __( 'Which top-N surface to fetch.', 'jetpack-stats' ),
+						'enum'        => self::TOP_CONTENT_TYPES,
+					),
+					'period' => array(
+						'type'        => 'string',
+						'description' => __( 'Aggregation period.', 'jetpack-stats' ),
+						'enum'        => self::PERIODS,
+						'default'     => 'day',
+					),
+					'date'   => array(
+						'type'        => 'string',
+						'description' => __( 'End date (YYYY-MM-DD). Defaults to today.', 'jetpack-stats' ),
+						'pattern'     => '^[0-9]{4}-[0-9]{2}-[0-9]{2}$',
+					),
+					'num'    => array(
+						'type'        => 'integer',
+						'description' => __( 'How many prior periods to roll up (1-90).', 'jetpack-stats' ),
+						'minimum'     => 1,
+						'maximum'     => 90,
+						'default'     => 1,
+					),
+					'max'    => array(
+						'type'        => 'integer',
+						'description' => __( 'Results cap (1-100).', 'jetpack-stats' ),
+						'minimum'     => 1,
+						'maximum'     => 100,
+						'default'     => 20,
+					),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'type'   => array( 'type' => 'string' ),
+					'period' => array( 'type' => 'string' ),
+					'date'   => array( 'type' => 'string' ),
+					'num'    => array( 'type' => 'integer' ),
+					'max'    => array( 'type' => 'integer' ),
+					'items'  => array( 'type' => 'array' ),
+				),
+			),
+			'execute_callback'    => array( __CLASS__, 'get_top_content' ),
+			'permission_callback' => array( __CLASS__, 'can_view_stats' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'show_in_rest' => true,
+			),
+		);
+	}
+
+	/**
+	 * Spec: jetpack-stats/get-post-views.
+	 */
+	private static function spec_get_post_views(): array {
+		return array(
+			'label'               => __( 'Get views for a post', 'jetpack-stats' ),
+			'description'         => __(
+				'Return views history for a single post: total views, timeseries of per-period views, and the period metadata. Shape: { post_id, total_views, period, num, date, series: [ { date, views } ] }. Accepts post_id as integer or numeric string (the literal "0" is rejected only because WordPress has no post 0 — any positive numeric value is legal). Precondition: site must be connected to WordPress.com. Related: call jetpack-stats/get-top-content with type=posts first to discover which posts to drill into.',
+				'jetpack-stats'
+			),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'required'             => array( 'post_id' ),
+				'properties'           => array(
+					'post_id' => array(
+						'type'        => array( 'integer', 'string' ),
+						'description' => __( 'The post ID to fetch views for. Must be positive.', 'jetpack-stats' ),
+					),
+					'period'  => array(
+						'type'        => 'string',
+						'description' => __( 'Aggregation period.', 'jetpack-stats' ),
+						'enum'        => self::PERIODS,
+						'default'     => 'day',
+					),
+					'num'     => array(
+						'type'        => 'integer',
+						'description' => __( 'How many prior periods to include (1-90).', 'jetpack-stats' ),
+						'minimum'     => 1,
+						'maximum'     => 90,
+						'default'     => 30,
+					),
+					'date'    => array(
+						'type'        => 'string',
+						'description' => __( 'End date (YYYY-MM-DD). Defaults to today.', 'jetpack-stats' ),
+						'pattern'     => '^[0-9]{4}-[0-9]{2}-[0-9]{2}$',
+					),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'post_id'     => array( 'type' => 'integer' ),
+					'total_views' => array( 'type' => 'integer' ),
+					'period'      => array( 'type' => 'string' ),
+					'num'         => array( 'type' => 'integer' ),
+					'date'        => array( 'type' => 'string' ),
+					'series'      => array( 'type' => 'array' ),
+				),
+			),
+			'execute_callback'    => array( __CLASS__, 'get_post_views' ),
+			'permission_callback' => array( __CLASS__, 'can_view_stats' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'show_in_rest' => true,
+			),
+		);
+	}
+
+	/**
+	 * Spec: jetpack-stats/get-visits.
+	 */
+	private static function spec_get_visits(): array {
+		return array(
+			'label'               => __( 'Get site visits timeseries', 'jetpack-stats' ),
+			'description'         => __(
+				'Return a site-level views/visitors/likes/comments timeseries — answers "is traffic trending up?". Shape: { unit, quantity, date, fields, series: [ { date, views, visitors, likes, comments } ] }. Every series row always includes every field listed in the request (no per-row omission). Precondition: site must be connected to WordPress.com.',
+				'jetpack-stats'
+			),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'properties'           => array(
+					'unit'     => array(
+						'type'        => 'string',
+						'description' => __( 'Granularity of each data point.', 'jetpack-stats' ),
+						'enum'        => self::PERIODS,
+						'default'     => 'day',
+					),
+					'quantity' => array(
+						'type'        => 'integer',
+						'description' => __( 'How many data points to return (1-90).', 'jetpack-stats' ),
+						'minimum'     => 1,
+						'maximum'     => 90,
+						'default'     => 30,
+					),
+					'date'     => array(
+						'type'        => 'string',
+						'description' => __( 'End date (YYYY-MM-DD). Defaults to today.', 'jetpack-stats' ),
+						'pattern'     => '^[0-9]{4}-[0-9]{2}-[0-9]{2}$',
+					),
+					'fields'   => array(
+						'type'        => 'array',
+						'description' => __( 'Which metrics to include in each row. Defaults to views+visitors.', 'jetpack-stats' ),
+						'items'       => array(
+							'type' => 'string',
+							'enum' => array( 'views', 'visitors', 'likes', 'comments' ),
+						),
+						'default'     => array( 'views', 'visitors' ),
+					),
+				),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'unit'     => array( 'type' => 'string' ),
+					'quantity' => array( 'type' => 'integer' ),
+					'date'     => array( 'type' => 'string' ),
+					'fields'   => array( 'type' => 'array' ),
+					'series'   => array( 'type' => 'array' ),
+				),
+			),
+			'execute_callback'    => array( __CLASS__, 'get_visits' ),
+			'permission_callback' => array( __CLASS__, 'can_view_stats' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'show_in_rest' => true,
+			),
+		);
+	}
+
+	/**
+	 * Spec: jetpack-stats/get-followers.
+	 */
+	private static function spec_get_followers(): array {
+		return array(
+			'label'               => __( 'Get follower counts', 'jetpack-stats' ),
+			'description'         => __(
+				'Return a breakdown of follower counts across email, WordPress.com, comment, and publicize (per-service) — answers "how is my audience growing?" in one call. Shape: { total, email, wpcom, comment, publicize: { <service>: count }, partial: bool, errors?: [string] }. Composes three WPCOM endpoints — if any sub-call fails, `partial` is true and `errors` lists the failed sub-calls; missing sources are NOT substituted with zero. Precondition: site must be connected to WordPress.com.',
+				'jetpack-stats'
+			),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'properties'           => new \stdClass(),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'total'     => array( 'type' => 'integer' ),
+					'email'     => array( 'type' => 'integer' ),
+					'wpcom'     => array( 'type' => 'integer' ),
+					'comment'   => array( 'type' => 'integer' ),
+					'publicize' => array( 'type' => 'object' ),
+					'partial'   => array( 'type' => 'boolean' ),
+					'errors'    => array( 'type' => 'array' ),
+				),
+			),
+			'execute_callback'    => array( __CLASS__, 'get_followers' ),
+			'permission_callback' => array( __CLASS__, 'can_view_stats' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'show_in_rest' => true,
+			),
+		);
+	}
+
+	/**
+	 * Spec: jetpack-stats/get-stats-config.
+	 */
+	private static function spec_get_stats_config(): array {
+		return array(
+			'label'               => __( 'Get Stats configuration', 'jetpack-stats' ),
+			'description'         => __(
+				'Read the current Jetpack Stats configuration: who sees the Stats admin bar + menu, whose visits are counted, DNT behavior, and Odyssey Stats enablement. Shape: { admin_bar, roles, count_roles, do_not_track, enable_odyssey_stats }. `roles` is an array of role slugs that can view Stats; `count_roles` is an array of role slugs whose visits are counted. Call jetpack-stats/set-stats-config to change any of these.',
+				'jetpack-stats'
+			),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'properties'           => new \stdClass(),
+				'additionalProperties' => false,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => self::config_output_properties(),
+			),
+			'execute_callback'    => array( __CLASS__, 'get_stats_config' ),
+			'permission_callback' => array( __CLASS__, 'can_view_stats' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'show_in_rest' => true,
+			),
+		);
+	}
+
+	/**
+	 * Spec: jetpack-stats/set-stats-config.
+	 */
+	private static function spec_set_stats_config(): array {
+		return array(
+			'label'               => __( 'Set Stats configuration', 'jetpack-stats' ),
+			'description'         => __(
+				'Update one or more Jetpack Stats configuration fields. All fields are optional; only fields present in the call are written, and unrelated keys are preserved. Idempotent — setting a value to its current state returns changed=false. Shape: { changed, config: { admin_bar, roles, count_roles, do_not_track, enable_odyssey_stats } }. Role slugs in `roles` and `count_roles` are validated against the site\'s registered roles; unknown slugs return jetpack_stats_invalid_role. Narrowing `roles` can revoke Stats access for whole groups of users — confirm with the user before removing roles.',
+				'jetpack-stats'
+			),
+			'input_schema'        => array(
+				'type'                 => 'object',
+				'properties'           => array(
+					'admin_bar'            => array(
+						'type'        => 'boolean',
+						'description' => __( 'Whether to show the Stats item in the admin bar for users who can view Stats.', 'jetpack-stats' ),
+					),
+					'roles'                => array(
+						'type'        => 'array',
+						'description' => __( 'Role slugs that can view Stats. Must be non-empty; each slug must be a registered role.', 'jetpack-stats' ),
+						'items'       => array( 'type' => 'string' ),
+						'minItems'    => 1,
+					),
+					'count_roles'          => array(
+						'type'        => 'array',
+						'description' => __( 'Role slugs whose visits are counted. May be empty (count visits from all users).', 'jetpack-stats' ),
+						'items'       => array( 'type' => 'string' ),
+					),
+					'do_not_track'         => array(
+						'type'        => 'boolean',
+						'description' => __( 'Whether to honor the browser Do Not Track header.', 'jetpack-stats' ),
+					),
+					'enable_odyssey_stats' => array(
+						'type'        => 'boolean',
+						'description' => __( 'Whether to render the Odyssey Stats dashboard.', 'jetpack-stats' ),
+					),
+				),
+				'additionalProperties' => false,
+				'minProperties'        => 1,
+			),
+			'output_schema'       => array(
+				'type'       => 'object',
+				'properties' => array(
+					'changed' => array( 'type' => 'boolean' ),
+					'config'  => array(
+						'type'       => 'object',
+						'properties' => self::config_output_properties(),
+					),
+				),
+			),
+			'execute_callback'    => array( __CLASS__, 'set_stats_config' ),
+			'permission_callback' => array( __CLASS__, 'can_manage_stats_config' ),
+			'meta'                => array(
+				'annotations'  => array(
+					'readonly'    => false,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+				'show_in_rest' => true,
+			),
+		);
+	}
+
+	/**
+	 * Output schema properties shared by get-stats-config and set-stats-config's `config` field.
+	 */
+	private static function config_output_properties(): array {
+		return array(
+			'admin_bar'            => array( 'type' => 'boolean' ),
+			'roles'                => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+			'count_roles'          => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+			'do_not_track'         => array( 'type' => 'boolean' ),
+			'enable_odyssey_stats' => array( 'type' => 'boolean' ),
+		);
+	}
+
+	/* ---------------------------------------------------------------------
+	 * Permission callbacks
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Read-side permission: view_stats.
+	 *
+	 * The Stats package's `Main::map_meta_caps` maps `view_stats` to the
+	 * user's `read` capability when their role is listed in
+	 * `stats_options['roles']`. Honored on self-hosted sites.
+	 *
+	 * @return bool
+	 */
+	public static function can_view_stats(): bool {
+		return current_user_can( 'view_stats' );
+	}
+
+	/**
+	 * Write-side permission: manage_options.
+	 *
+	 * Stats configuration writes modify the `stats_options` WP option,
+	 * which includes the very roles that gate `view_stats`. Guard with the
+	 * site-admin capability, not `view_stats`, so readers can't escalate.
+	 *
+	 * @return bool
+	 */
+	public static function can_manage_stats_config(): bool {
+		return current_user_can( 'manage_options' );
+	}
+
+	/* ---------------------------------------------------------------------
+	 * Execute callbacks
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Execute: get-site-overview.
+	 *
+	 * @param array|null $input Ignored — zero-arg ability.
+	 * @return array|WP_Error
+	 */
+	public static function get_site_overview( $input = null ) {
+		unset( $input );
+		$stats = self::get_wpcom_stats();
+
+		$summary   = $stats->get_stats_summary();
+		$highlights = $stats->get_highlights();
+		$streak    = $stats->get_streak();
+
+		$errors = array();
+		if ( is_wp_error( $summary ) ) {
+			$errors[] = 'summary';
+			$summary  = array();
+		}
+		if ( is_wp_error( $highlights ) ) {
+			$errors[] = 'highlights';
+			$highlights = array();
+		}
+		if ( is_wp_error( $streak ) ) {
+			$errors[] = 'streak';
+			$streak   = array();
+		}
+
+		// If every sub-call failed, surface a single WP_Error instead of an all-null response.
+		if ( count( $errors ) === 3 ) {
+			return new WP_Error(
+				self::ERROR_PREFIX . 'data_unavailable',
+				__( 'Stats data could not be fetched from WordPress.com. Confirm the site is connected and try again.', 'jetpack-stats' )
+			);
+		}
+
+		$highlights_today    = isset( $highlights['today'] ) && is_array( $highlights['today'] ) ? $highlights['today'] : array();
+		$highlights_top_post = isset( $highlights_today['top_post'] ) && is_array( $highlights_today['top_post'] )
+			? $highlights_today['top_post']
+			: null;
+
+		$out = array(
+			'date'           => isset( $summary['date'] ) ? (string) $summary['date'] : ( isset( $highlights_today['date'] ) ? (string) $highlights_today['date'] : '' ),
+			'views_today'    => self::as_int( $summary, 'views' ),
+			'visitors_today' => self::as_int( $summary, 'visitors' ),
+			'views_week'     => self::as_int( $summary, 'period_total_views' ),
+			'views_month'    => isset( $highlights_today['views_month'] ) ? (int) $highlights_today['views_month'] : 0,
+			'streak'         => self::extract_streak_summary( $streak ),
+			'top_post'       => null === $highlights_top_post ? null : array(
+				'id'    => isset( $highlights_top_post['id'] ) ? (int) $highlights_top_post['id'] : 0,
+				'title' => isset( $highlights_top_post['title'] ) ? (string) $highlights_top_post['title'] : '',
+				'views' => isset( $highlights_top_post['views'] ) ? (int) $highlights_top_post['views'] : 0,
+			),
+			'top_referrer'   => self::extract_top_referrer( $highlights_today ),
+			'partial'        => ! empty( $errors ),
+		);
+
+		if ( ! empty( $errors ) ) {
+			$out['errors'] = array_values( $errors );
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Execute: get-top-content.
+	 *
+	 * @param array|null $input Input matching the ability's input_schema.
+	 * @return array|WP_Error
+	 */
+	public static function get_top_content( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		if ( ! isset( $input['type'] ) || ! in_array( $input['type'], self::TOP_CONTENT_TYPES, true ) ) {
+			return new WP_Error(
+				self::ERROR_PREFIX . 'missing_type',
+				sprintf(
+					/* translators: %s: comma-separated list of valid type values. */
+					__( 'A `type` is required. Valid values: %s.', 'jetpack-stats' ),
+					implode( ', ', self::TOP_CONTENT_TYPES )
+				)
+			);
+		}
+
+		$type   = $input['type'];
+		$period = isset( $input['period'] ) && in_array( $input['period'], self::PERIODS, true ) ? $input['period'] : 'day';
+		$date   = self::sanitize_date( $input['date'] ?? null );
+		$num    = self::clamp_int( $input['num'] ?? 1, 1, 90, 1 );
+		$max    = self::clamp_int( $input['max'] ?? 20, 1, 100, 20 );
+
+		$args = array(
+			'period' => $period,
+			'date'   => $date,
+			'num'    => $num,
+			'max'    => $max,
+		);
+
+		$stats = self::get_wpcom_stats();
+		$raw   = self::fetch_top_content_raw( $stats, $type, $args );
+		if ( is_wp_error( $raw ) ) {
+			return $raw;
+		}
+
+		$items = self::normalize_top_content_items( $type, $raw, $max );
+
+		return array(
+			'type'   => $type,
+			'period' => $period,
+			'date'   => $date,
+			'num'    => $num,
+			'max'    => $max,
+			'items'  => $items,
+		);
+	}
+
+	/**
+	 * Execute: get-post-views.
+	 *
+	 * @param array|null $input Input matching the ability's input_schema.
+	 * @return array|WP_Error
+	 */
+	public static function get_post_views( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		// Use isset()+is_numeric() — NOT empty() — so the literal "0" is rejected by the `> 0` check, not by a truthiness accident.
+		if ( ! isset( $input['post_id'] ) || ! is_numeric( $input['post_id'] ) || (int) $input['post_id'] <= 0 ) {
+			return new WP_Error(
+				self::ERROR_PREFIX . 'missing_post_id',
+				__( 'A positive post_id is required.', 'jetpack-stats' )
+			);
+		}
+
+		$post_id = (int) $input['post_id'];
+		$period  = isset( $input['period'] ) && in_array( $input['period'], self::PERIODS, true ) ? $input['period'] : 'day';
+		$num     = self::clamp_int( $input['num'] ?? 30, 1, 90, 30 );
+		$date    = self::sanitize_date( $input['date'] ?? null );
+
+		$args = array(
+			'period' => $period,
+			'num'    => $num,
+			'date'   => $date,
+		);
+
+		$stats = self::get_wpcom_stats();
+		$raw   = $stats->get_post_views( $post_id, $args );
+		if ( is_wp_error( $raw ) ) {
+			return $raw;
+		}
+
+		return array(
+			'post_id'     => $post_id,
+			'total_views' => isset( $raw['views'] ) ? (int) $raw['views'] : 0,
+			'period'      => $period,
+			'num'         => $num,
+			'date'        => $date,
+			'series'      => self::extract_post_views_series( $raw ),
+		);
+	}
+
+	/**
+	 * Execute: get-visits.
+	 *
+	 * @param array|null $input Input matching the ability's input_schema.
+	 * @return array|WP_Error
+	 */
+	public static function get_visits( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		$unit     = isset( $input['unit'] ) && in_array( $input['unit'], self::PERIODS, true ) ? $input['unit'] : 'day';
+		$quantity = self::clamp_int( $input['quantity'] ?? 30, 1, 90, 30 );
+		$date     = self::sanitize_date( $input['date'] ?? null );
+
+		$allowed_fields = array( 'views', 'visitors', 'likes', 'comments' );
+		$fields         = isset( $input['fields'] ) && is_array( $input['fields'] ) && ! empty( $input['fields'] )
+			? array_values( array_intersect( $allowed_fields, $input['fields'] ) )
+			: array( 'views', 'visitors' );
+		if ( empty( $fields ) ) {
+			$fields = array( 'views', 'visitors' );
+		}
+
+		$args = array(
+			'unit'     => $unit,
+			'quantity' => $quantity,
+			'date'     => $date,
+			'stat_fields' => implode( ',', $fields ),
+		);
+
+		$stats = self::get_wpcom_stats();
+		$raw   = $stats->get_visits( $args );
+		if ( is_wp_error( $raw ) ) {
+			return $raw;
+		}
+
+		return array(
+			'unit'     => $unit,
+			'quantity' => $quantity,
+			'date'     => $date,
+			'fields'   => $fields,
+			'series'   => self::normalize_visits_series( $raw, $fields ),
+		);
+	}
+
+	/**
+	 * Execute: get-followers.
+	 *
+	 * @param array|null $input Ignored — zero-arg ability.
+	 * @return array|WP_Error
+	 */
+	public static function get_followers( $input = null ) {
+		unset( $input );
+		$stats = self::get_wpcom_stats();
+
+		$followers         = $stats->get_followers();
+		$comment_followers = $stats->get_comment_followers();
+		$publicize         = $stats->get_publicize_followers();
+
+		$errors = array();
+		if ( is_wp_error( $followers ) ) {
+			$errors[] = 'followers';
+			$followers = array();
+		}
+		if ( is_wp_error( $comment_followers ) ) {
+			$errors[] = 'comment_followers';
+			$comment_followers = array();
+		}
+		if ( is_wp_error( $publicize ) ) {
+			$errors[] = 'publicize_followers';
+			$publicize = array();
+		}
+
+		if ( count( $errors ) === 3 ) {
+			return new WP_Error(
+				self::ERROR_PREFIX . 'data_unavailable',
+				__( 'Follower data could not be fetched from WordPress.com. Confirm the site is connected and try again.', 'jetpack-stats' )
+			);
+		}
+
+		$email = 0;
+		$wpcom = 0;
+		if ( isset( $followers['subscribers'] ) && is_array( $followers['subscribers'] ) ) {
+			foreach ( $followers['subscribers'] as $sub ) {
+				if ( isset( $sub['type'] ) && 'email' === $sub['type'] ) {
+					$email += isset( $sub['value'] ) ? (int) $sub['value'] : 0;
+				} elseif ( isset( $sub['type'] ) && 'wpcom' === $sub['type'] ) {
+					$wpcom += isset( $sub['value'] ) ? (int) $sub['value'] : 0;
+				}
+			}
+		} else {
+			$email = isset( $followers['email'] ) ? (int) $followers['email'] : 0;
+			$wpcom = isset( $followers['wpcom'] ) ? (int) $followers['wpcom'] : 0;
+		}
+
+		$comment = isset( $comment_followers['total'] ) ? (int) $comment_followers['total'] : 0;
+
+		$publicize_by_service = array();
+		if ( isset( $publicize['services'] ) && is_array( $publicize['services'] ) ) {
+			foreach ( $publicize['services'] as $row ) {
+				if ( isset( $row['service'], $row['followers'] ) ) {
+					$publicize_by_service[ (string) $row['service'] ] = (int) $row['followers'];
+				}
+			}
+		}
+
+		$total = $email + $wpcom + $comment + array_sum( $publicize_by_service );
+
+		$out = array(
+			'total'     => $total,
+			'email'     => $email,
+			'wpcom'     => $wpcom,
+			'comment'   => $comment,
+			'publicize' => $publicize_by_service,
+			'partial'   => ! empty( $errors ),
+		);
+
+		if ( ! empty( $errors ) ) {
+			$out['errors'] = $errors;
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Execute: get-stats-config.
+	 *
+	 * @param array|null $input Ignored — zero-arg ability.
+	 * @return array
+	 */
+	public static function get_stats_config( $input = null ) {
+		unset( $input );
+		return self::config_snapshot();
+	}
+
+	/**
+	 * Execute: set-stats-config.
+	 *
+	 * @param array|null $input Input matching the ability's input_schema.
+	 * @return array|WP_Error
+	 */
+	public static function set_stats_config( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		// At least one of the whitelisted keys must be present.
+		$provided = array_intersect_key( $input, array_flip( self::CONFIG_KEYS ) );
+		if ( empty( $provided ) ) {
+			return new WP_Error(
+				self::ERROR_PREFIX . 'missing_config_field',
+				sprintf(
+					/* translators: %s: comma-separated list of writable field names. */
+					__( 'Provide at least one of: %s.', 'jetpack-stats' ),
+					implode( ', ', self::CONFIG_KEYS )
+				)
+			);
+		}
+
+		// Validate role slugs against registered roles.
+		$known_roles = array_keys( wp_roles()->roles );
+		foreach ( array( 'roles', 'count_roles' ) as $role_field ) {
+			if ( ! array_key_exists( $role_field, $provided ) ) {
+				continue;
+			}
+			if ( ! is_array( $provided[ $role_field ] ) ) {
+				return new WP_Error(
+					self::ERROR_PREFIX . 'invalid_' . $role_field,
+					sprintf(
+						/* translators: %s: the offending field name. */
+						__( 'Field `%s` must be an array of role slugs.', 'jetpack-stats' ),
+						$role_field
+					)
+				);
+			}
+			$sanitized = array();
+			foreach ( $provided[ $role_field ] as $role ) {
+				if ( ! is_string( $role ) || '' === $role ) {
+					return new WP_Error(
+						self::ERROR_PREFIX . 'invalid_role',
+						sprintf(
+							/* translators: 1: field name, 2: comma-separated list of valid role slugs. */
+							__( 'Role slugs in `%1$s` must be non-empty strings. Known roles: %2$s.', 'jetpack-stats' ),
+							$role_field,
+							implode( ', ', $known_roles )
+						)
+					);
+				}
+				if ( ! in_array( $role, $known_roles, true ) ) {
+					return new WP_Error(
+						self::ERROR_PREFIX . 'invalid_role',
+						sprintf(
+							/* translators: 1: unknown role slug, 2: field name, 3: comma-separated list of valid role slugs. */
+							__( 'Unknown role `%1$s` in `%2$s`. Known roles: %3$s.', 'jetpack-stats' ),
+							$role,
+							$role_field,
+							implode( ', ', $known_roles )
+						)
+					);
+				}
+				$sanitized[] = $role;
+			}
+			$provided[ $role_field ] = array_values( array_unique( $sanitized ) );
+		}
+
+		$before  = self::config_snapshot();
+		$changes = array();
+		foreach ( $provided as $key => $value ) {
+			if ( in_array( $key, self::CONFIG_BOOL_KEYS, true ) ) {
+				$value = (bool) $value;
+			}
+			$current = $before[ $key ] ?? null;
+			if ( $current === $value ) {
+				continue;
+			}
+			$changes[ $key ] = $value;
+		}
+
+		if ( ! empty( $changes ) ) {
+			// One merged write instead of N get+update cycles via set_option.
+			Options::set_options( $changes );
+		}
+
+		return array(
+			'changed' => ! empty( $changes ),
+			'config'  => self::config_snapshot(),
+		);
+	}
+
+	/* ---------------------------------------------------------------------
+	 * Helpers
+	 * ---------------------------------------------------------------------
+	 */
+
+	/**
+	 * Build a whitelisted snapshot of the current Stats configuration.
+	 *
+	 * @return array
+	 */
+	private static function config_snapshot(): array {
+		$options = Options::get_options();
+		$out     = array();
+		foreach ( self::CONFIG_KEYS as $key ) {
+			$raw = $options[ $key ] ?? null;
+			if ( in_array( $key, self::CONFIG_BOOL_KEYS, true ) ) {
+				$out[ $key ] = (bool) $raw;
+			} elseif ( in_array( $key, array( 'roles', 'count_roles' ), true ) ) {
+				$out[ $key ] = is_array( $raw ) ? array_values( $raw ) : array();
+			} else {
+				$out[ $key ] = $raw;
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * Return a WPCOM_Stats instance. Filterable for tests.
+	 *
+	 * @return WPCOM_Stats
+	 */
+	protected static function get_wpcom_stats(): WPCOM_Stats {
+		/**
+		 * Filters the WPCOM_Stats instance used by the Stats abilities.
+		 *
+		 * Primarily for tests — production code should not override this
+		 * filter. Swapping the instance lets tests intercept the WPCOM
+		 * client calls without hitting the network.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param WPCOM_Stats $wpcom_stats The default instance.
+		 */
+		$instance = apply_filters( 'jetpack_stats_abilities_wpcom_stats', new WPCOM_Stats() );
+		return $instance instanceof WPCOM_Stats ? $instance : new WPCOM_Stats();
+	}
+
+	/**
+	 * Dispatch top-content raw fetch to the right WPCOM_Stats method.
+	 *
+	 * @param WPCOM_Stats $stats Client.
+	 * @param string      $type  Content type enum.
+	 * @param array       $args  Pre-built `{ period, date, num, max }` args — ignored for `tags` which takes only `max`.
+	 * @return array|WP_Error
+	 */
+	private static function fetch_top_content_raw( WPCOM_Stats $stats, string $type, array $args ) {
+		switch ( $type ) {
+			case 'posts':
+				return $stats->get_top_posts( $args );
+			case 'referrers':
+				return $stats->get_referrers( $args );
+			case 'search-terms':
+				return $stats->get_search_terms( $args );
+			case 'clicks':
+				return $stats->get_clicks( $args );
+			case 'tags':
+				// get_tags has a narrower arg surface — pass only `max`.
+				return $stats->get_tags( array( 'max' => $args['max'] ) );
+			case 'authors':
+				return $stats->get_top_authors( $args );
+			case 'countries':
+				return $stats->get_views_by_country( $args );
+			case 'downloads':
+				return $stats->get_file_downloads( $args );
+			case 'video-plays':
+				return $stats->get_video_plays( $args );
+		}
+
+		return new WP_Error( self::ERROR_PREFIX . 'invalid_type', __( 'Unknown top-content type.', 'jetpack-stats' ) );
+	}
+
+	/**
+	 * Normalize a WPCOM top-content response into the uniform item shape.
+	 *
+	 * Most `type` values follow the `days -> <first-day> -> <list-key>` shape
+	 * and project through `TOP_CONTENT_MAP`. `tags` (flat `tags` array, no
+	 * `days` envelope) and `countries` (needs `country-info` code-to-name
+	 * join) are special-cased.
+	 *
+	 * @param string $type Content type enum.
+	 * @param array  $raw  Raw WPCOM response.
+	 * @param int    $max  Result cap.
+	 * @return array List of { rank, label, value, href? } items.
+	 */
+	private static function normalize_top_content_items( string $type, array $raw, int $max ): array {
+		if ( 'tags' === $type ) {
+			$rows = array();
+			$tags = isset( $raw['tags'] ) && is_array( $raw['tags'] ) ? $raw['tags'] : array();
+			foreach ( $tags as $tag ) {
+				$rows[] = array(
+					'label' => isset( $tag['tag'] ) ? (string) $tag['tag'] : '',
+					'value' => isset( $tag['views'] ) ? (int) $tag['views'] : 0,
+				);
+			}
+			return self::rank_and_cap( $rows, $max );
+		}
+
+		$day_data = self::first_day( $raw );
+
+		if ( 'countries' === $type ) {
+			$rows         = array();
+			$list         = isset( $day_data['views'] ) && is_array( $day_data['views'] ) ? $day_data['views'] : array();
+			$country_info = isset( $raw['country-info'] ) && is_array( $raw['country-info'] ) ? $raw['country-info'] : array();
+			foreach ( $list as $v ) {
+				$code   = isset( $v['country_code'] ) ? (string) $v['country_code'] : '';
+				$rows[] = array(
+					'label' => (string) ( $country_info[ $code ]['country_full'] ?? $code ),
+					'value' => isset( $v['views'] ) ? (int) $v['views'] : 0,
+				);
+			}
+			return self::rank_and_cap( $rows, $max );
+		}
+
+		$map = self::TOP_CONTENT_MAP[ $type ] ?? null;
+		if ( null === $map ) {
+			return array();
+		}
+
+		$rows = array();
+		$list = isset( $day_data[ $map['list'] ] ) && is_array( $day_data[ $map['list'] ] ) ? $day_data[ $map['list'] ] : array();
+		foreach ( $list as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+			$label = isset( $row[ $map['label'] ] ) && '' !== $row[ $map['label'] ] ? (string) $row[ $map['label'] ] : '';
+			if ( '' === $label && isset( $map['label_fallback'] ) && isset( $row[ $map['label_fallback'] ] ) ) {
+				$label = (string) $row[ $map['label_fallback'] ];
+			}
+			$entry = array(
+				'label' => $label,
+				'value' => isset( $row[ $map['value'] ] ) ? (int) $row[ $map['value'] ] : 0,
+			);
+			if ( isset( $map['href'], $row[ $map['href'] ] ) ) {
+				$entry['href'] = (string) $row[ $map['href'] ];
+			}
+			$rows[] = $entry;
+		}
+		return self::rank_and_cap( $rows, $max );
+	}
+
+	/**
+	 * Pick the first `days` entry from a WPCOM days-keyed response.
+	 *
+	 * Different top-content endpoints key their per-day data under `days`
+	 * (posts, referrers, authors, countries, ...) or `days -> <date>`; a few
+	 * flatten it entirely (tags). This helper handles the common case.
+	 *
+	 * @param array $raw Raw WPCOM response.
+	 * @return array The first day's sub-array, or [].
+	 */
+	private static function first_day( array $raw ): array {
+		if ( ! isset( $raw['days'] ) || ! is_array( $raw['days'] ) || empty( $raw['days'] ) ) {
+			return array();
+		}
+		$first = reset( $raw['days'] );
+		return is_array( $first ) ? $first : array();
+	}
+
+	/**
+	 * Rank, cap, and strip null href fields.
+	 *
+	 * @param array $rows Unranked rows.
+	 * @param int   $max  Result cap.
+	 * @return array Ranked + capped rows with `rank` injected.
+	 */
+	private static function rank_and_cap( array $rows, int $max ): array {
+		$rows = array_slice( $rows, 0, $max );
+		$out  = array();
+		foreach ( $rows as $i => $row ) {
+			$entry = array(
+				'rank'  => $i + 1,
+				'label' => isset( $row['label'] ) ? (string) $row['label'] : '',
+				'value' => isset( $row['value'] ) ? (int) $row['value'] : 0,
+			);
+			if ( isset( $row['href'] ) && '' !== $row['href'] ) {
+				$entry['href'] = $row['href'];
+			}
+			$out[] = $entry;
+		}
+		return $out;
+	}
+
+	/**
+	 * Extract a compact streak summary from the WPCOM streak response.
+	 *
+	 * @param array $streak Raw WPCOM streak response.
+	 * @return array Compact `{ current_length, longest_length, longest_start, longest_end }`.
+	 */
+	private static function extract_streak_summary( array $streak ): array {
+		$data = isset( $streak['streak'] ) && is_array( $streak['streak'] ) ? $streak['streak'] : array();
+		return array(
+			'current_length' => isset( $data['currentStreakLength'] ) ? (int) $data['currentStreakLength'] : 0,
+			'longest_length' => isset( $data['longestStreakLength'] ) ? (int) $data['longestStreakLength'] : 0,
+			'longest_start'  => isset( $data['longestStreakStart'] ) ? (string) $data['longestStreakStart'] : '',
+			'longest_end'    => isset( $data['longestStreakEnd'] ) ? (string) $data['longestStreakEnd'] : '',
+		);
+	}
+
+	/**
+	 * Extract the top referrer from a highlights `today` block.
+	 *
+	 * @param array $today Highlights today block.
+	 * @return array|null { name, views } or null.
+	 */
+	private static function extract_top_referrer( array $today ): ?array {
+		$list = isset( $today['top_referrers'] ) && is_array( $today['top_referrers'] ) ? $today['top_referrers'] : array();
+		if ( empty( $list ) ) {
+			return null;
+		}
+		$first = $list[0];
+		if ( ! is_array( $first ) ) {
+			return null;
+		}
+		return array(
+			'name'  => isset( $first['name'] ) ? (string) $first['name'] : '',
+			'views' => isset( $first['views'] ) ? (int) $first['views'] : 0,
+		);
+	}
+
+	/**
+	 * Extract a post-views series from the WPCOM get_post_views response.
+	 *
+	 * WPCOM returns `data` as a list of `[date, views]` tuples under the
+	 * `fields` header. We normalize to `[{ date, views }]`.
+	 *
+	 * @param array $raw Raw WPCOM response.
+	 * @return array
+	 */
+	private static function extract_post_views_series( array $raw ): array {
+		if ( ! isset( $raw['data'] ) || ! is_array( $raw['data'] ) ) {
+			return array();
+		}
+
+		$fields = isset( $raw['fields'] ) && is_array( $raw['fields'] ) ? $raw['fields'] : array( 'period', 'views' );
+		$date_idx  = array_search( 'period', $fields, true );
+		$views_idx = array_search( 'views', $fields, true );
+		if ( false === $date_idx ) {
+			$date_idx = 0;
+		}
+		if ( false === $views_idx ) {
+			$views_idx = 1;
+		}
+
+		$series = array();
+		foreach ( $raw['data'] as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+			$series[] = array(
+				'date'  => isset( $row[ $date_idx ] ) ? (string) $row[ $date_idx ] : '',
+				'views' => isset( $row[ $views_idx ] ) ? (int) $row[ $views_idx ] : 0,
+			);
+		}
+		return $series;
+	}
+
+	/**
+	 * Normalize the WPCOM get_visits response into `[{ date, <field>: int, ... }]`.
+	 *
+	 * @param array $raw    Raw WPCOM response.
+	 * @param array $fields Requested metric fields.
+	 * @return array
+	 */
+	private static function normalize_visits_series( array $raw, array $fields ): array {
+		if ( ! isset( $raw['data'] ) || ! is_array( $raw['data'] ) ) {
+			return array();
+		}
+
+		$raw_fields = isset( $raw['fields'] ) && is_array( $raw['fields'] ) ? $raw['fields'] : array();
+		$field_idx  = array();
+		foreach ( $raw_fields as $idx => $name ) {
+			$field_idx[ (string) $name ] = $idx;
+		}
+		$date_idx = $field_idx['period'] ?? 0;
+
+		$series = array();
+		foreach ( $raw['data'] as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+			$entry = array(
+				'date' => isset( $row[ $date_idx ] ) ? (string) $row[ $date_idx ] : '',
+			);
+			foreach ( $fields as $field ) {
+				$idx            = $field_idx[ $field ] ?? null;
+				$entry[ $field ] = ( null !== $idx && isset( $row[ $idx ] ) ) ? (int) $row[ $idx ] : 0;
+			}
+			$series[] = $entry;
+		}
+		return $series;
+	}
+
+	/**
+	 * Normalize a candidate date string. Returns today's date (UTC) on bad input.
+	 *
+	 * @param mixed $raw Raw input value.
+	 * @return string YYYY-MM-DD.
+	 */
+	private static function sanitize_date( $raw ): string {
+		if ( is_string( $raw ) && 1 === preg_match( '/^\d{4}-\d{2}-\d{2}$/', $raw ) ) {
+			return $raw;
+		}
+		return gmdate( 'Y-m-d' );
+	}
+
+	/**
+	 * Clamp an integer into [$min, $max] with a default on bad input.
+	 *
+	 * @param mixed $raw     Raw input.
+	 * @param int   $min     Minimum.
+	 * @param int   $max     Maximum.
+	 * @param int   $default Default on bad input.
+	 * @return int
+	 */
+	private static function clamp_int( $raw, int $min, int $max, int $default ): int {
+		if ( ! is_numeric( $raw ) ) {
+			return $default;
+		}
+		$v = (int) $raw;
+		if ( $v < $min ) {
+			return $min;
+		}
+		if ( $v > $max ) {
+			return $max;
+		}
+		return $v;
+	}
+
+	/**
+	 * Safely read an int field from an array.
+	 *
+	 * @param array  $arr Array.
+	 * @param string $key Key.
+	 * @return int
+	 */
+	private static function as_int( array $arr, string $key ): int {
+		return isset( $arr[ $key ] ) ? (int) $arr[ $key ] : 0;
+	}
+}

--- a/projects/packages/stats/src/abilities/class-stats-abilities.php
+++ b/projects/packages/stats/src/abilities/class-stats-abilities.php
@@ -189,6 +189,10 @@ class Stats_Abilities extends Registrar {
 					'idempotent'  => true,
 				),
 				'show_in_rest' => true,
+				'mcp'          => array(
+					'public' => true,
+					'type'   => 'tool', // default is already "tool", but can be explicit.
+				),
 			),
 		);
 	}
@@ -260,6 +264,10 @@ class Stats_Abilities extends Registrar {
 					'idempotent'  => true,
 				),
 				'show_in_rest' => true,
+				'mcp'          => array(
+					'public' => true,
+					'type'   => 'tool', // default is already "tool", but can be explicit.
+				),
 			),
 		);
 	}
@@ -323,6 +331,10 @@ class Stats_Abilities extends Registrar {
 					'idempotent'  => true,
 				),
 				'show_in_rest' => true,
+				'mcp'          => array(
+					'public' => true,
+					'type'   => 'tool', // default is already "tool", but can be explicit.
+				),
 			),
 		);
 	}
@@ -389,6 +401,10 @@ class Stats_Abilities extends Registrar {
 					'idempotent'  => true,
 				),
 				'show_in_rest' => true,
+				'mcp'          => array(
+					'public' => true,
+					'type'   => 'tool', // default is already "tool", but can be explicit.
+				),
 			),
 		);
 	}
@@ -429,6 +445,10 @@ class Stats_Abilities extends Registrar {
 					'idempotent'  => true,
 				),
 				'show_in_rest' => true,
+				'mcp'          => array(
+					'public' => true,
+					'type'   => 'tool', // default is already "tool", but can be explicit.
+				),
 			),
 		);
 	}
@@ -461,6 +481,10 @@ class Stats_Abilities extends Registrar {
 					'idempotent'  => true,
 				),
 				'show_in_rest' => true,
+				'mcp'          => array(
+					'public' => true,
+					'type'   => 'tool', // default is already "tool", but can be explicit.
+				),
 			),
 		);
 	}
@@ -524,6 +548,10 @@ class Stats_Abilities extends Registrar {
 					'idempotent'  => true,
 				),
 				'show_in_rest' => true,
+				'mcp'          => array(
+					'public' => true,
+					'type'   => 'tool', // default is already "tool", but can be explicit.
+				),
 			),
 		);
 	}

--- a/projects/packages/stats/src/abilities/class-stats-abilities.php
+++ b/projects/packages/stats/src/abilities/class-stats-abilities.php
@@ -35,17 +35,11 @@ class Stats_Abilities extends Registrar {
 	 *
 	 * Internal keys (`blog_id`, `notices`, `views`, `collapse_nudges`,
 	 * `version`, `odyssey_stats_changed_at`) are deliberately excluded —
-	 * agents can't act on them and they'd bloat the response.
+	 * agents can't act on them and they'd bloat the response. The per-key
+	 * type (bool / role-array) is read from `Options::get_defaults()` at
+	 * runtime, not duplicated here.
 	 */
 	const CONFIG_KEYS = array( 'admin_bar', 'roles', 'count_roles', 'do_not_track', 'enable_odyssey_stats' );
-
-	/**
-	 * Subset of CONFIG_KEYS whose values are boolean.
-	 *
-	 * Read + write paths coerce to bool before comparison/emit so agents
-	 * never see `1`/`"true"` drift in place of real booleans.
-	 */
-	const CONFIG_BOOL_KEYS = array( 'admin_bar', 'do_not_track', 'enable_odyssey_stats' );
 
 	/**
 	 * Allowed `type` values for `get-top-content`.
@@ -56,11 +50,6 @@ class Stats_Abilities extends Registrar {
 	 * Allowed aggregation periods for timeseries + top-content reads.
 	 */
 	const PERIODS = array( 'day', 'week', 'month', 'year' );
-
-	/**
-	 * Subset of CONFIG_KEYS whose values are arrays of role slugs.
-	 */
-	const CONFIG_ROLE_KEYS = array( 'roles', 'count_roles' );
 
 	/**
 	 * Allowed metric fields for `get-visits`.
@@ -923,10 +912,15 @@ class Stats_Abilities extends Registrar {
 
 		// Validate role slugs against registered roles — but only load the role list
 		// if the caller is actually writing a role field. Boolean-only writes skip
-		// the wp_roles() resolution entirely.
+		// the wp_roles() resolution entirely. Role fields are detected from the
+		// option's default value type (array → role list).
+		$defaults    = Options::get_defaults();
 		$known_roles = null;
-		foreach ( self::CONFIG_ROLE_KEYS as $role_field ) {
+		foreach ( self::CONFIG_KEYS as $role_field ) {
 			if ( ! array_key_exists( $role_field, $provided ) ) {
+				continue;
+			}
+			if ( ! is_array( $defaults[ $role_field ] ?? null ) ) {
 				continue;
 			}
 			if ( null === $known_roles ) {
@@ -984,7 +978,7 @@ class Stats_Abilities extends Registrar {
 		$before  = self::config_snapshot();
 		$changes = array();
 		foreach ( $provided as $key => $value ) {
-			if ( in_array( $key, self::CONFIG_BOOL_KEYS, true ) ) {
+			if ( is_bool( $defaults[ $key ] ?? null ) ) {
 				$value = (bool) $value;
 			}
 			$current = $before[ $key ] ?? null;
@@ -1022,13 +1016,15 @@ class Stats_Abilities extends Registrar {
 	 * @return array
 	 */
 	private static function config_snapshot(): array {
-		$options = Options::get_options();
-		$out     = array();
+		$options  = Options::get_options();
+		$defaults = Options::get_defaults();
+		$out      = array();
 		foreach ( self::CONFIG_KEYS as $key ) {
-			$raw = $options[ $key ] ?? null;
-			if ( in_array( $key, self::CONFIG_BOOL_KEYS, true ) ) {
+			$raw     = $options[ $key ] ?? null;
+			$default = $defaults[ $key ] ?? null;
+			if ( is_bool( $default ) ) {
 				$out[ $key ] = (bool) $raw;
-			} elseif ( in_array( $key, self::CONFIG_ROLE_KEYS, true ) ) {
+			} elseif ( is_array( $default ) ) {
 				$out[ $key ] = is_array( $raw ) ? array_values( $raw ) : array();
 			} else {
 				$out[ $key ] = $raw;

--- a/projects/packages/stats/src/abilities/class-stats-abilities.php
+++ b/projects/packages/stats/src/abilities/class-stats-abilities.php
@@ -713,8 +713,10 @@ class Stats_Abilities extends Registrar {
 		$date     = self::sanitize_date( $input['date'] ?? null );
 
 		$allowed_fields = array( 'views', 'visitors', 'likes', 'comments' );
-		$fields         = isset( $input['fields'] ) && is_array( $input['fields'] ) && ! empty( $input['fields'] )
-			? array_values( array_intersect( $allowed_fields, $input['fields'] ) )
+		// Preserve the caller's order — array_intersect returns keys from its FIRST argument,
+		// so pass the user input first. Then filter out anything not in the allowed set.
+		$fields = isset( $input['fields'] ) && is_array( $input['fields'] ) && ! empty( $input['fields'] )
+			? array_values( array_intersect( $input['fields'], $allowed_fields ) )
 			: array( 'views', 'visitors' );
 		if ( empty( $fields ) ) {
 			$fields = array( 'views', 'visitors' );
@@ -854,11 +856,16 @@ class Stats_Abilities extends Registrar {
 			);
 		}
 
-		// Validate role slugs against registered roles.
-		$known_roles = array_keys( wp_roles()->roles );
+		// Validate role slugs against registered roles — but only load the role list
+		// if the caller is actually writing a role field. Boolean-only writes skip
+		// the wp_roles() resolution entirely.
+		$known_roles = null;
 		foreach ( array( 'roles', 'count_roles' ) as $role_field ) {
 			if ( ! array_key_exists( $role_field, $provided ) ) {
 				continue;
+			}
+			if ( null === $known_roles ) {
+				$known_roles = array_keys( wp_roles()->roles );
 			}
 			if ( ! is_array( $provided[ $role_field ] ) ) {
 				return new WP_Error(
@@ -913,14 +920,19 @@ class Stats_Abilities extends Registrar {
 			$changes[ $key ] = $value;
 		}
 
+		// `changed` is derived from the POST-WRITE snapshot, not from `$changes` alone —
+		// if update_option fails or refuses to persist for any reason (DB error,
+		// serialization mismatch), we must not claim a change that didn't happen.
 		if ( ! empty( $changes ) ) {
 			// One merged write instead of N get+update cycles via set_option.
 			Options::set_options( $changes );
 		}
 
+		$after = self::config_snapshot();
+
 		return array(
-			'changed' => ! empty( $changes ),
-			'config'  => self::config_snapshot(),
+			'changed' => $after !== $before,
+			'config'  => $after,
 		);
 	}
 
@@ -1167,14 +1179,14 @@ class Stats_Abilities extends Registrar {
 			return array();
 		}
 
-		$fields = isset( $raw['fields'] ) && is_array( $raw['fields'] ) ? $raw['fields'] : array( 'period', 'views' );
+		$fields    = isset( $raw['fields'] ) && is_array( $raw['fields'] ) ? $raw['fields'] : array( 'period', 'views' );
 		$date_idx  = array_search( 'period', $fields, true );
 		$views_idx = array_search( 'views', $fields, true );
-		if ( false === $date_idx ) {
-			$date_idx = 0;
-		}
-		if ( false === $views_idx ) {
-			$views_idx = 1;
+		if ( false === $date_idx || false === $views_idx ) {
+			// If either column is missing from the WPCOM response, the positional
+			// fallback is unsafe (we might collide date/views on column 0). Drop
+			// to empty rather than emit lies.
+			return array();
 		}
 
 		$series = array();

--- a/projects/packages/stats/src/abilities/class-stats-abilities.php
+++ b/projects/packages/stats/src/abilities/class-stats-abilities.php
@@ -73,9 +73,12 @@ class Stats_Abilities extends Registrar {
 			'href'  => 'href',
 		),
 		'referrers'    => array(
-			'list'  => 'referrers',
+			// WPCOM `stats/referrers` keys per-day data under `groups`, not `referrers` —
+			// each group exposes `name`, `total`, and (sometimes) `url`.
+			'list'  => 'groups',
 			'label' => 'name',
-			'value' => 'views',
+			'value' => 'total',
+			'href'  => 'url',
 		),
 		'search-terms' => array(
 			'list'  => 'search_terms',
@@ -154,7 +157,7 @@ class Stats_Abilities extends Registrar {
 		return array(
 			'label'               => __( 'Get site stats overview', 'jetpack-stats' ),
 			'description'         => __(
-				'Return a single zero-argument snapshot answering "how is my site doing right now?" — today\'s views/visitors, this week/month totals, the current posting streak, today\'s top post, and top referrer. Shape: { date, views_today, visitors_today, views_week, views_month, streak: { current_length, longest_length, longest_start, longest_end }, top_post: { id, title, views }, top_referrer: { name, views }, partial: bool, errors?: [string] }. Composes the WPCOM stats/summary, stats/highlights, and stats/streak endpoints — if any sub-call fails, `partial` is true and `errors` lists the failed sub-calls; missing data is never silently substituted with zeros. Precondition: the site must be connected to WordPress.com; a disconnected site returns jetpack_stats_not_connected. Results cached for ~5 minutes by WPCOM_Stats — safe to poll.',
+				'Return a single zero-argument snapshot answering "how is my site doing right now?" — today\'s views/visitors, this week/month totals, the current posting streak, today\'s top post, and top referrer. Shape: { date, views_today, visitors_today, views_week, views_month, streak: { current_length, longest_length, longest_start, longest_end }, top_post: { id, title, views }, top_referrer: { name, views }, partial: bool, errors?: [string] }. Composes the WPCOM stats/summary, stats/highlights, and stats/streak endpoints — if any sub-call fails, `partial` is true and `errors` lists the failed sub-calls; when `partial` is true, count fields owned by the failed sub-call(s) are placeholder zeros rather than confirmed counts (cross-reference `errors` before treating a `0` as authoritative). If every sub-call fails, returns `jetpack_stats_data_unavailable`. Precondition: the site must be connected to WordPress.com. Results cached for ~5 minutes by WPCOM_Stats — safe to poll.',
 				'jetpack-stats'
 			),
 			'input_schema'        => array(
@@ -397,7 +400,7 @@ class Stats_Abilities extends Registrar {
 		return array(
 			'label'               => __( 'Get follower counts', 'jetpack-stats' ),
 			'description'         => __(
-				'Return a breakdown of follower counts across email, WordPress.com, comment, and publicize (per-service) — answers "how is my audience growing?" in one call. Shape: { total, email, wpcom, comment, publicize: { <service>: count }, partial: bool, errors?: [string] }. Composes three WPCOM endpoints — if any sub-call fails, `partial` is true and `errors` lists the failed sub-calls; missing sources are NOT substituted with zero. Precondition: site must be connected to WordPress.com.',
+				'Return a breakdown of follower counts across email, WordPress.com, comment, and publicize (per-service) — answers "how is my audience growing?" in one call. Shape: { total, email, wpcom, comment, publicize: { <service>: count }, partial: bool, errors?: [string] }. Composes three WPCOM endpoints — if any sub-call fails, `partial` is true and `errors` lists the failed sub-calls; when `partial` is true, source counts owned by the failed sub-call(s) are placeholder zeros rather than confirmed zero counts (cross-reference `errors` before treating a `0` as authoritative). Precondition: site must be connected to WordPress.com.',
 				'jetpack-stats'
 			),
 			'input_schema'        => array(
@@ -917,6 +920,15 @@ class Stats_Abilities extends Registrar {
 						__( 'Field `%s` must be an array of role slugs.', 'jetpack-stats' ),
 						$role_field
 					)
+				);
+			}
+			// `roles` gates `view_stats` — an empty array would lock every user out, including
+			// the caller. Schema validation enforces minItems=1 on REST input, but direct PHP
+			// callers bypass that path; reject explicitly here.
+			if ( 'roles' === $role_field && empty( $provided[ $role_field ] ) ) {
+				return new WP_Error(
+					self::ERROR_PREFIX . 'invalid_roles',
+					__( 'Field `roles` must be a non-empty array of role slugs — an empty list would revoke Stats access for every user.', 'jetpack-stats' )
 				);
 			}
 			$sanitized = array();

--- a/projects/packages/stats/src/abilities/class-stats-abilities.php
+++ b/projects/packages/stats/src/abilities/class-stats-abilities.php
@@ -66,13 +66,46 @@ class Stats_Abilities extends Registrar {
 	 * no `days` envelope) are special-cased in the callback.
 	 */
 	const TOP_CONTENT_MAP = array(
-		'posts'        => array( 'list' => 'postviews',    'label' => 'title',    'value' => 'views',          'href' => 'href' ),
-		'referrers'    => array( 'list' => 'referrers',    'label' => 'name',     'value' => 'views' ),
-		'search-terms' => array( 'list' => 'search_terms', 'label' => 'term',     'value' => 'views' ),
-		'clicks'       => array( 'list' => 'clicks',       'label' => 'name',     'value' => 'views',          'href' => 'url',          'label_fallback' => 'url' ),
-		'authors'      => array( 'list' => 'authors',      'label' => 'name',     'value' => 'views' ),
-		'downloads'    => array( 'list' => 'files',        'label' => 'filename', 'value' => 'download_count', 'href' => 'relative_url', 'label_fallback' => 'relative_url' ),
-		'video-plays'  => array( 'list' => 'plays',        'label' => 'title',    'value' => 'plays' ),
+		'posts'        => array(
+			'list'  => 'postviews',
+			'label' => 'title',
+			'value' => 'views',
+			'href'  => 'href',
+		),
+		'referrers'    => array(
+			'list'  => 'referrers',
+			'label' => 'name',
+			'value' => 'views',
+		),
+		'search-terms' => array(
+			'list'  => 'search_terms',
+			'label' => 'term',
+			'value' => 'views',
+		),
+		'clicks'       => array(
+			'list'           => 'clicks',
+			'label'          => 'name',
+			'value'          => 'views',
+			'href'           => 'url',
+			'label_fallback' => 'url',
+		),
+		'authors'      => array(
+			'list'  => 'authors',
+			'label' => 'name',
+			'value' => 'views',
+		),
+		'downloads'    => array(
+			'list'           => 'files',
+			'label'          => 'filename',
+			'value'          => 'download_count',
+			'href'           => 'relative_url',
+			'label_fallback' => 'relative_url',
+		),
+		'video-plays'  => array(
+			'list'  => 'plays',
+			'label' => 'title',
+			'value' => 'plays',
+		),
 	);
 
 	/**
@@ -108,7 +141,8 @@ class Stats_Abilities extends Registrar {
 		);
 	}
 
-	/* ---------------------------------------------------------------------
+	/*
+	---------------------------------------------------------------------
 	 * Ability specs
 	 * ---------------------------------------------------------------------
 	 */
@@ -131,16 +165,16 @@ class Stats_Abilities extends Registrar {
 			'output_schema'       => array(
 				'type'       => 'object',
 				'properties' => array(
-					'date'            => array( 'type' => 'string' ),
-					'views_today'     => array( 'type' => 'integer' ),
-					'visitors_today'  => array( 'type' => 'integer' ),
-					'views_week'      => array( 'type' => 'integer' ),
-					'views_month'     => array( 'type' => 'integer' ),
-					'streak'          => array( 'type' => 'object' ),
-					'top_post'        => array( 'type' => array( 'object', 'null' ) ),
-					'top_referrer'    => array( 'type' => array( 'object', 'null' ) ),
-					'partial'         => array( 'type' => 'boolean' ),
-					'errors'          => array( 'type' => 'array' ),
+					'date'           => array( 'type' => 'string' ),
+					'views_today'    => array( 'type' => 'integer' ),
+					'visitors_today' => array( 'type' => 'integer' ),
+					'views_week'     => array( 'type' => 'integer' ),
+					'views_month'    => array( 'type' => 'integer' ),
+					'streak'         => array( 'type' => 'object' ),
+					'top_post'       => array( 'type' => array( 'object', 'null' ) ),
+					'top_referrer'   => array( 'type' => array( 'object', 'null' ) ),
+					'partial'        => array( 'type' => 'boolean' ),
+					'errors'         => array( 'type' => 'array' ),
 				),
 			),
 			'execute_callback'    => array( __CLASS__, 'get_site_overview' ),
@@ -497,14 +531,21 @@ class Stats_Abilities extends Registrar {
 	private static function config_output_properties(): array {
 		return array(
 			'admin_bar'            => array( 'type' => 'boolean' ),
-			'roles'                => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
-			'count_roles'          => array( 'type' => 'array', 'items' => array( 'type' => 'string' ) ),
+			'roles'                => array(
+				'type'  => 'array',
+				'items' => array( 'type' => 'string' ),
+			),
+			'count_roles'          => array(
+				'type'  => 'array',
+				'items' => array( 'type' => 'string' ),
+			),
 			'do_not_track'         => array( 'type' => 'boolean' ),
 			'enable_odyssey_stats' => array( 'type' => 'boolean' ),
 		);
 	}
 
-	/* ---------------------------------------------------------------------
+	/*
+	---------------------------------------------------------------------
 	 * Permission callbacks
 	 * ---------------------------------------------------------------------
 	 */
@@ -535,7 +576,8 @@ class Stats_Abilities extends Registrar {
 		return current_user_can( 'manage_options' );
 	}
 
-	/* ---------------------------------------------------------------------
+	/*
+	---------------------------------------------------------------------
 	 * Execute callbacks
 	 * ---------------------------------------------------------------------
 	 */
@@ -550,9 +592,9 @@ class Stats_Abilities extends Registrar {
 		unset( $input );
 		$stats = self::get_wpcom_stats();
 
-		$summary   = $stats->get_stats_summary();
+		$summary    = $stats->get_stats_summary();
 		$highlights = $stats->get_highlights();
-		$streak    = $stats->get_streak();
+		$streak     = $stats->get_streak();
 
 		$errors = array();
 		if ( is_wp_error( $summary ) ) {
@@ -560,7 +602,7 @@ class Stats_Abilities extends Registrar {
 			$summary  = array();
 		}
 		if ( is_wp_error( $highlights ) ) {
-			$errors[] = 'highlights';
+			$errors[]   = 'highlights';
 			$highlights = array();
 		}
 		if ( is_wp_error( $streak ) ) {
@@ -598,7 +640,7 @@ class Stats_Abilities extends Registrar {
 		);
 
 		if ( ! empty( $errors ) ) {
-			$out['errors'] = array_values( $errors );
+			$out['errors'] = $errors;
 		}
 
 		return $out;
@@ -723,9 +765,9 @@ class Stats_Abilities extends Registrar {
 		}
 
 		$args = array(
-			'unit'     => $unit,
-			'quantity' => $quantity,
-			'date'     => $date,
+			'unit'        => $unit,
+			'quantity'    => $quantity,
+			'date'        => $date,
 			'stat_fields' => implode( ',', $fields ),
 		);
 
@@ -760,15 +802,15 @@ class Stats_Abilities extends Registrar {
 
 		$errors = array();
 		if ( is_wp_error( $followers ) ) {
-			$errors[] = 'followers';
+			$errors[]  = 'followers';
 			$followers = array();
 		}
 		if ( is_wp_error( $comment_followers ) ) {
-			$errors[] = 'comment_followers';
+			$errors[]          = 'comment_followers';
 			$comment_followers = array();
 		}
 		if ( is_wp_error( $publicize ) ) {
-			$errors[] = 'publicize_followers';
+			$errors[]  = 'publicize_followers';
 			$publicize = array();
 		}
 
@@ -799,7 +841,7 @@ class Stats_Abilities extends Registrar {
 		$publicize_by_service = array();
 		if ( isset( $publicize['services'] ) && is_array( $publicize['services'] ) ) {
 			foreach ( $publicize['services'] as $row ) {
-				if ( isset( $row['service'], $row['followers'] ) ) {
+				if ( isset( $row['service'] ) && isset( $row['followers'] ) ) {
 					$publicize_by_service[ (string) $row['service'] ] = (int) $row['followers'];
 				}
 			}
@@ -936,7 +978,8 @@ class Stats_Abilities extends Registrar {
 		);
 	}
 
-	/* ---------------------------------------------------------------------
+	/*
+	---------------------------------------------------------------------
 	 * Helpers
 	 * ---------------------------------------------------------------------
 	 */
@@ -1078,7 +1121,7 @@ class Stats_Abilities extends Registrar {
 				'label' => $label,
 				'value' => isset( $row[ $map['value'] ] ) ? (int) $row[ $map['value'] ] : 0,
 			);
-			if ( isset( $map['href'], $row[ $map['href'] ] ) ) {
+			if ( isset( $map['href'] ) && isset( $row[ $map['href'] ] ) ) {
 				$entry['href'] = (string) $row[ $map['href'] ];
 			}
 			$rows[] = $entry;
@@ -1230,7 +1273,7 @@ class Stats_Abilities extends Registrar {
 				'date' => isset( $row[ $date_idx ] ) ? (string) $row[ $date_idx ] : '',
 			);
 			foreach ( $fields as $field ) {
-				$idx            = $field_idx[ $field ] ?? null;
+				$idx             = $field_idx[ $field ] ?? null;
 				$entry[ $field ] = ( null !== $idx && isset( $row[ $idx ] ) ) ? (int) $row[ $idx ] : 0;
 			}
 			$series[] = $entry;

--- a/projects/packages/stats/src/abilities/class-stats-abilities.php
+++ b/projects/packages/stats/src/abilities/class-stats-abilities.php
@@ -58,6 +58,21 @@ class Stats_Abilities extends Registrar {
 	const PERIODS = array( 'day', 'week', 'month', 'year' );
 
 	/**
+	 * Subset of CONFIG_KEYS whose values are arrays of role slugs.
+	 */
+	const CONFIG_ROLE_KEYS = array( 'roles', 'count_roles' );
+
+	/**
+	 * Allowed metric fields for `get-visits`.
+	 */
+	const VISIT_FIELDS = array( 'views', 'visitors', 'likes', 'comments' );
+
+	/**
+	 * Default metric fields for `get-visits` when the caller omits `fields`.
+	 */
+	const DEFAULT_VISIT_FIELDS = array( 'views', 'visitors' );
+
+	/**
 	 * Normalization table for `get-top-content`.
 	 *
 	 * Each entry describes how to project a WPCOM `days -> <date> -> <list>`
@@ -375,9 +390,9 @@ class Stats_Abilities extends Registrar {
 						'description' => __( 'Which metrics to include in each row. Defaults to views+visitors.', 'jetpack-stats' ),
 						'items'       => array(
 							'type' => 'string',
-							'enum' => array( 'views', 'visitors', 'likes', 'comments' ),
+							'enum' => self::VISIT_FIELDS,
 						),
-						'default'     => array( 'views', 'visitors' ),
+						'default'     => self::DEFAULT_VISIT_FIELDS,
 					),
 				),
 				'additionalProperties' => false,
@@ -623,31 +638,19 @@ class Stats_Abilities extends Registrar {
 		unset( $input );
 		$stats = self::get_wpcom_stats();
 
-		$summary    = $stats->get_stats_summary();
-		$highlights = $stats->get_highlights();
-		$streak     = $stats->get_streak();
-
-		$errors = array();
-		if ( is_wp_error( $summary ) ) {
-			$errors[] = 'summary';
-			$summary  = array();
+		$composed = self::compose_subcalls(
+			array(
+				'summary'    => $stats->get_stats_summary(),
+				'highlights' => $stats->get_highlights(),
+				'streak'     => $stats->get_streak(),
+			),
+			__( 'Stats data could not be fetched from WordPress.com. Confirm the site is connected and try again.', 'jetpack-stats' )
+		);
+		if ( is_wp_error( $composed ) ) {
+			return $composed;
 		}
-		if ( is_wp_error( $highlights ) ) {
-			$errors[]   = 'highlights';
-			$highlights = array();
-		}
-		if ( is_wp_error( $streak ) ) {
-			$errors[] = 'streak';
-			$streak   = array();
-		}
-
-		// If every sub-call failed, surface a single WP_Error instead of an all-null response.
-		if ( count( $errors ) === 3 ) {
-			return new WP_Error(
-				self::ERROR_PREFIX . 'data_unavailable',
-				__( 'Stats data could not be fetched from WordPress.com. Confirm the site is connected and try again.', 'jetpack-stats' )
-			);
-		}
+		[ 'summary' => $summary, 'highlights' => $highlights, 'streak' => $streak ] = $composed['values'];
+		$errors = $composed['errors'];
 
 		$highlights_today    = isset( $highlights['today'] ) && is_array( $highlights['today'] ) ? $highlights['today'] : array();
 		$highlights_top_post = isset( $highlights_today['top_post'] ) && is_array( $highlights_today['top_post'] )
@@ -655,7 +658,7 @@ class Stats_Abilities extends Registrar {
 			: null;
 
 		$out = array(
-			'date'           => isset( $summary['date'] ) ? (string) $summary['date'] : ( isset( $highlights_today['date'] ) ? (string) $highlights_today['date'] : '' ),
+			'date'           => self::first_string( array( $summary, $highlights_today ), 'date' ),
 			'views_today'    => self::as_int( $summary, 'views' ),
 			'visitors_today' => self::as_int( $summary, 'visitors' ),
 			'views_week'     => self::as_int( $summary, 'period_total_views' ),
@@ -698,7 +701,7 @@ class Stats_Abilities extends Registrar {
 		}
 
 		$type   = $input['type'];
-		$period = isset( $input['period'] ) && in_array( $input['period'], self::PERIODS, true ) ? $input['period'] : 'day';
+		$period = self::pick_period( $input['period'] ?? null );
 		$date   = self::sanitize_date( $input['date'] ?? null );
 		$num    = self::clamp_int( $input['num'] ?? 1, 1, 90, 1 );
 		$max    = self::clamp_int( $input['max'] ?? 20, 1, 100, 20 );
@@ -746,7 +749,7 @@ class Stats_Abilities extends Registrar {
 		}
 
 		$post_id = (int) $input['post_id'];
-		$period  = isset( $input['period'] ) && in_array( $input['period'], self::PERIODS, true ) ? $input['period'] : 'day';
+		$period  = self::pick_period( $input['period'] ?? null );
 		$num     = self::clamp_int( $input['num'] ?? 30, 1, 90, 30 );
 		$date    = self::sanitize_date( $input['date'] ?? null );
 
@@ -781,18 +784,16 @@ class Stats_Abilities extends Registrar {
 	public static function get_visits( $input = null ) {
 		$input = is_array( $input ) ? $input : array();
 
-		$unit     = isset( $input['unit'] ) && in_array( $input['unit'], self::PERIODS, true ) ? $input['unit'] : 'day';
+		$unit     = self::pick_period( $input['unit'] ?? null );
 		$quantity = self::clamp_int( $input['quantity'] ?? 30, 1, 90, 30 );
 		$date     = self::sanitize_date( $input['date'] ?? null );
 
-		$allowed_fields = array( 'views', 'visitors', 'likes', 'comments' );
-		// Preserve the caller's order — array_intersect returns keys from its FIRST argument,
-		// so pass the user input first. Then filter out anything not in the allowed set.
-		$fields = isset( $input['fields'] ) && is_array( $input['fields'] ) && ! empty( $input['fields'] )
-			? array_values( array_intersect( $input['fields'], $allowed_fields ) )
-			: array( 'views', 'visitors' );
+		// Pass user input FIRST to array_intersect so caller-supplied field order is preserved.
+		$fields = isset( $input['fields'] ) && is_array( $input['fields'] )
+			? array_values( array_intersect( $input['fields'], self::VISIT_FIELDS ) )
+			: array();
 		if ( empty( $fields ) ) {
-			$fields = array( 'views', 'visitors' );
+			$fields = self::DEFAULT_VISIT_FIELDS;
 		}
 
 		$args = array(
@@ -827,30 +828,21 @@ class Stats_Abilities extends Registrar {
 		unset( $input );
 		$stats = self::get_wpcom_stats();
 
-		$followers         = $stats->get_followers();
-		$comment_followers = $stats->get_comment_followers();
-		$publicize         = $stats->get_publicize_followers();
-
-		$errors = array();
-		if ( is_wp_error( $followers ) ) {
-			$errors[]  = 'followers';
-			$followers = array();
+		$composed = self::compose_subcalls(
+			array(
+				'followers'           => $stats->get_followers(),
+				'comment_followers'   => $stats->get_comment_followers(),
+				'publicize_followers' => $stats->get_publicize_followers(),
+			),
+			__( 'Follower data could not be fetched from WordPress.com. Confirm the site is connected and try again.', 'jetpack-stats' )
+		);
+		if ( is_wp_error( $composed ) ) {
+			return $composed;
 		}
-		if ( is_wp_error( $comment_followers ) ) {
-			$errors[]          = 'comment_followers';
-			$comment_followers = array();
-		}
-		if ( is_wp_error( $publicize ) ) {
-			$errors[]  = 'publicize_followers';
-			$publicize = array();
-		}
-
-		if ( count( $errors ) === 3 ) {
-			return new WP_Error(
-				self::ERROR_PREFIX . 'data_unavailable',
-				__( 'Follower data could not be fetched from WordPress.com. Confirm the site is connected and try again.', 'jetpack-stats' )
-			);
-		}
+		$followers         = $composed['values']['followers'];
+		$comment_followers = $composed['values']['comment_followers'];
+		$publicize         = $composed['values']['publicize_followers'];
+		$errors            = $composed['errors'];
 
 		$email = 0;
 		$wpcom = 0;
@@ -933,7 +925,7 @@ class Stats_Abilities extends Registrar {
 		// if the caller is actually writing a role field. Boolean-only writes skip
 		// the wp_roles() resolution entirely.
 		$known_roles = null;
-		foreach ( array( 'roles', 'count_roles' ) as $role_field ) {
+		foreach ( self::CONFIG_ROLE_KEYS as $role_field ) {
 			if ( ! array_key_exists( $role_field, $provided ) ) {
 				continue;
 			}
@@ -1036,13 +1028,72 @@ class Stats_Abilities extends Registrar {
 			$raw = $options[ $key ] ?? null;
 			if ( in_array( $key, self::CONFIG_BOOL_KEYS, true ) ) {
 				$out[ $key ] = (bool) $raw;
-			} elseif ( in_array( $key, array( 'roles', 'count_roles' ), true ) ) {
+			} elseif ( in_array( $key, self::CONFIG_ROLE_KEYS, true ) ) {
 				$out[ $key ] = is_array( $raw ) ? array_values( $raw ) : array();
 			} else {
 				$out[ $key ] = $raw;
 			}
 		}
 		return $out;
+	}
+
+	/**
+	 * Compose multiple WPCOM sub-call results into a partial-tolerant envelope.
+	 *
+	 * Each named result is either an array (kept as-is) or a WP_Error
+	 * (replaced with `[]` and its key recorded under `errors`). Returns
+	 * `jetpack_stats_data_unavailable` if every sub-call failed.
+	 *
+	 * @param array  $named_results       Map of error-tag => array|WP_Error.
+	 * @param string $all_failed_message  Message for the all-failed WP_Error.
+	 * @return array{values: array, errors: array}|WP_Error
+	 */
+	private static function compose_subcalls( array $named_results, string $all_failed_message ) {
+		$values = array();
+		$errors = array();
+		foreach ( $named_results as $tag => $result ) {
+			if ( is_wp_error( $result ) ) {
+				$errors[]       = (string) $tag;
+				$values[ $tag ] = array();
+			} else {
+				$values[ $tag ] = $result;
+			}
+		}
+
+		if ( count( $errors ) === count( $named_results ) ) {
+			return new WP_Error( self::ERROR_PREFIX . 'data_unavailable', $all_failed_message );
+		}
+
+		return array(
+			'values' => $values,
+			'errors' => $errors,
+		);
+	}
+
+	/**
+	 * Return the first non-empty string at `$key` across the given source arrays.
+	 *
+	 * @param array[] $sources Ordered list of arrays to probe.
+	 * @param string  $key     Key to read from each array.
+	 * @return string
+	 */
+	private static function first_string( array $sources, string $key ): string {
+		foreach ( $sources as $source ) {
+			if ( isset( $source[ $key ] ) && '' !== $source[ $key ] ) {
+				return (string) $source[ $key ];
+			}
+		}
+		return '';
+	}
+
+	/**
+	 * Resolve an aggregation period from raw input, defaulting to `day`.
+	 *
+	 * @param mixed $raw Raw input value.
+	 * @return string One of self::PERIODS.
+	 */
+	private static function pick_period( $raw ): string {
+		return is_string( $raw ) && in_array( $raw, self::PERIODS, true ) ? $raw : 'day';
 	}
 
 	/**
@@ -1053,10 +1104,6 @@ class Stats_Abilities extends Registrar {
 	protected static function get_wpcom_stats(): WPCOM_Stats {
 		/**
 		 * Filters the WPCOM_Stats instance used by the Stats abilities.
-		 *
-		 * Primarily for tests — production code should not override this
-		 * filter. Swapping the instance lets tests intercept the WPCOM
-		 * client calls without hitting the network.
 		 *
 		 * @since $$next-version$$
 		 *

--- a/projects/packages/stats/src/abilities/class-stats-abilities.php
+++ b/projects/packages/stats/src/abilities/class-stats-abilities.php
@@ -20,7 +20,7 @@ use WP_Error;
  * Registers Jetpack Stats abilities with the WordPress Abilities API.
  *
  * Exposes a small, consolidated surface for reading Jetpack Stats traffic
- * insights and managing site-level Stats configuration so AI agents can
+ * insights and managing site-level Stats settings so AI agents can
  * answer site-owner questions through the standard `wp-abilities/v1` REST
  * surface. Seven abilities wrap ~25 atomic WPCOM Stats endpoints plus the
  * `stats_options` WP option.
@@ -31,7 +31,7 @@ class Stats_Abilities extends Registrar {
 	const ERROR_PREFIX  = 'jetpack_stats_';
 
 	/**
-	 * Whitelist of stats_options keys exposed via the config abilities.
+	 * Whitelist of stats_options keys exposed via the settings abilities.
 	 *
 	 * Internal keys (`blog_id`, `notices`, `views`, `collapse_nudges`,
 	 * `version`, `odyssey_stats_changed_at`) are deliberately excluded —
@@ -41,7 +41,7 @@ class Stats_Abilities extends Registrar {
 	 * role-array) is read from `Options::get_defaults()` at runtime, not
 	 * duplicated here.
 	 */
-	const CONFIG_KEYS = array( 'admin_bar', 'roles', 'count_roles', 'do_not_track' );
+	const SETTINGS_KEYS = array( 'admin_bar', 'roles', 'count_roles', 'do_not_track' );
 
 	/**
 	 * Allowed `type` values for `get-top-content`.
@@ -131,7 +131,7 @@ class Stats_Abilities extends Registrar {
 		return array(
 			// "Jetpack" is a product name and should not be translated.
 			'label'       => 'Jetpack Stats',
-			'description' => __( 'Abilities for reading Jetpack Stats traffic insights and managing site-level Stats configuration.', 'jetpack-stats' ),
+			'description' => __( 'Abilities for reading Jetpack Stats traffic insights and managing site-level Stats settings.', 'jetpack-stats' ),
 		);
 	}
 
@@ -145,8 +145,8 @@ class Stats_Abilities extends Registrar {
 			'jetpack-stats/get-post-views'    => self::spec_get_post_views(),
 			'jetpack-stats/get-visits'        => self::spec_get_visits(),
 			'jetpack-stats/get-followers'     => self::spec_get_followers(),
-			'jetpack-stats/get-stats-config'  => self::spec_get_stats_config(),
-			'jetpack-stats/set-stats-config'  => self::spec_set_stats_config(),
+			'jetpack-stats/get-settings'      => self::spec_get_settings(),
+			'jetpack-stats/update-settings'   => self::spec_update_settings(),
 		);
 	}
 
@@ -460,13 +460,13 @@ class Stats_Abilities extends Registrar {
 	}
 
 	/**
-	 * Spec: jetpack-stats/get-stats-config.
+	 * Spec: jetpack-stats/get-settings.
 	 */
-	private static function spec_get_stats_config(): array {
+	private static function spec_get_settings(): array {
 		return array(
-			'label'               => __( 'Get Stats configuration', 'jetpack-stats' ),
+			'label'               => __( 'Get Stats settings', 'jetpack-stats' ),
 			'description'         => __(
-				'Read the current Jetpack Stats configuration: who sees the Stats admin bar + menu, whose visits are counted, and DNT behavior. Shape: { admin_bar, roles, count_roles, do_not_track }. `roles` is an array of role slugs that can view Stats; `count_roles` is an array of role slugs whose visits are counted. Call jetpack-stats/set-stats-config to change any of these.',
+				'Read the current Jetpack Stats settings: who sees the Stats admin bar + menu, whose visits are counted, and DNT behavior. Shape: { admin_bar, roles, count_roles, do_not_track }. `roles` is an array of role slugs that can view Stats; `count_roles` is an array of role slugs whose visits are counted. Call jetpack-stats/update-settings to change any of these.',
 				'jetpack-stats'
 			),
 			'input_schema'        => array(
@@ -476,9 +476,9 @@ class Stats_Abilities extends Registrar {
 			),
 			'output_schema'       => array(
 				'type'       => 'object',
-				'properties' => self::config_output_properties(),
+				'properties' => self::settings_output_properties(),
 			),
-			'execute_callback'    => array( __CLASS__, 'get_stats_config' ),
+			'execute_callback'    => array( __CLASS__, 'get_settings' ),
 			'permission_callback' => array( __CLASS__, 'can_view_stats' ),
 			'meta'                => array(
 				'annotations'  => array(
@@ -496,13 +496,13 @@ class Stats_Abilities extends Registrar {
 	}
 
 	/**
-	 * Spec: jetpack-stats/set-stats-config.
+	 * Spec: jetpack-stats/update-settings.
 	 */
-	private static function spec_set_stats_config(): array {
+	private static function spec_update_settings(): array {
 		return array(
-			'label'               => __( 'Set Stats configuration', 'jetpack-stats' ),
+			'label'               => __( 'Update Stats settings', 'jetpack-stats' ),
 			'description'         => __(
-				'Update one or more Jetpack Stats configuration fields. All fields are optional; only fields present in the call are written, and unrelated keys are preserved. Idempotent — setting a value to its current state returns changed=false. Shape: { changed, config: { admin_bar, roles, count_roles, do_not_track } }. Role slugs in `roles` and `count_roles` are validated against the site\'s registered roles; unknown slugs return jetpack_stats_invalid_role. Narrowing `roles` can revoke Stats access for whole groups of users — confirm with the user before removing roles.',
+				'Update one or more Jetpack Stats settings. All fields are optional; only fields present in the call are written, and unrelated keys are preserved. Idempotent — setting a value to its current state returns changed=false. Shape: { changed, settings: { admin_bar, roles, count_roles, do_not_track } }. Role slugs in `roles` and `count_roles` are validated against the site\'s registered roles; unknown slugs return jetpack_stats_invalid_role. Narrowing `roles` can revoke Stats access for whole groups of users — confirm with the user before removing roles.',
 				'jetpack-stats'
 			),
 			'input_schema'        => array(
@@ -534,15 +534,15 @@ class Stats_Abilities extends Registrar {
 			'output_schema'       => array(
 				'type'       => 'object',
 				'properties' => array(
-					'changed' => array( 'type' => 'boolean' ),
-					'config'  => array(
+					'changed'  => array( 'type' => 'boolean' ),
+					'settings' => array(
 						'type'       => 'object',
-						'properties' => self::config_output_properties(),
+						'properties' => self::settings_output_properties(),
 					),
 				),
 			),
-			'execute_callback'    => array( __CLASS__, 'set_stats_config' ),
-			'permission_callback' => array( __CLASS__, 'can_manage_stats_config' ),
+			'execute_callback'    => array( __CLASS__, 'update_settings' ),
+			'permission_callback' => array( __CLASS__, 'can_manage_settings' ),
 			'meta'                => array(
 				'annotations'  => array(
 					'readonly'    => false,
@@ -559,9 +559,9 @@ class Stats_Abilities extends Registrar {
 	}
 
 	/**
-	 * Output schema properties shared by get-stats-config and set-stats-config's `config` field.
+	 * Output schema properties shared by get-settings and update-settings' `settings` field.
 	 */
-	private static function config_output_properties(): array {
+	private static function settings_output_properties(): array {
 		return array(
 			'admin_bar'    => array( 'type' => 'boolean' ),
 			'roles'        => array(
@@ -604,7 +604,7 @@ class Stats_Abilities extends Registrar {
 	 *
 	 * @return bool
 	 */
-	public static function can_manage_stats_config(): bool {
+	public static function can_manage_settings(): bool {
 		return current_user_can( 'manage_options' );
 	}
 
@@ -875,34 +875,34 @@ class Stats_Abilities extends Registrar {
 	}
 
 	/**
-	 * Execute: get-stats-config.
+	 * Execute: get-settings.
 	 *
 	 * @param array|null $input Ignored — zero-arg ability.
 	 * @return array
 	 */
-	public static function get_stats_config( $input = null ) {
+	public static function get_settings( $input = null ) {
 		unset( $input );
-		return self::config_snapshot();
+		return self::settings_snapshot();
 	}
 
 	/**
-	 * Execute: set-stats-config.
+	 * Execute: update-settings.
 	 *
 	 * @param array|null $input Input matching the ability's input_schema.
 	 * @return array|WP_Error
 	 */
-	public static function set_stats_config( $input = null ) {
+	public static function update_settings( $input = null ) {
 		$input = is_array( $input ) ? $input : array();
 
 		// At least one of the whitelisted keys must be present.
-		$provided = array_intersect_key( $input, array_flip( self::CONFIG_KEYS ) );
+		$provided = array_intersect_key( $input, array_flip( self::SETTINGS_KEYS ) );
 		if ( empty( $provided ) ) {
 			return new WP_Error(
-				self::ERROR_PREFIX . 'missing_config_field',
+				self::ERROR_PREFIX . 'missing_setting_field',
 				sprintf(
 					/* translators: %s: comma-separated list of writable field names. */
 					__( 'Provide at least one of: %s.', 'jetpack-stats' ),
-					implode( ', ', self::CONFIG_KEYS )
+					implode( ', ', self::SETTINGS_KEYS )
 				)
 			);
 		}
@@ -913,7 +913,7 @@ class Stats_Abilities extends Registrar {
 		// option's default value type (array → role list).
 		$defaults    = Options::get_defaults();
 		$known_roles = null;
-		foreach ( self::CONFIG_KEYS as $role_field ) {
+		foreach ( self::SETTINGS_KEYS as $role_field ) {
 			if ( ! array_key_exists( $role_field, $provided ) ) {
 				continue;
 			}
@@ -972,7 +972,7 @@ class Stats_Abilities extends Registrar {
 			$provided[ $role_field ] = array_values( array_unique( $sanitized ) );
 		}
 
-		$before  = self::config_snapshot();
+		$before  = self::settings_snapshot();
 		$changes = array();
 		foreach ( $provided as $key => $value ) {
 			if ( is_bool( $defaults[ $key ] ?? null ) ) {
@@ -993,11 +993,11 @@ class Stats_Abilities extends Registrar {
 			Options::set_options( $changes );
 		}
 
-		$after = self::config_snapshot();
+		$after = self::settings_snapshot();
 
 		return array(
-			'changed' => $after !== $before,
-			'config'  => $after,
+			'changed'  => $after !== $before,
+			'settings' => $after,
 		);
 	}
 
@@ -1012,11 +1012,11 @@ class Stats_Abilities extends Registrar {
 	 *
 	 * @return array
 	 */
-	private static function config_snapshot(): array {
+	private static function settings_snapshot(): array {
 		$options  = Options::get_options();
 		$defaults = Options::get_defaults();
 		$out      = array();
-		foreach ( self::CONFIG_KEYS as $key ) {
+		foreach ( self::SETTINGS_KEYS as $key ) {
 			$raw     = $options[ $key ] ?? null;
 			$default = $defaults[ $key ] ?? null;
 			if ( is_bool( $default ) ) {

--- a/projects/packages/stats/src/class-main.php
+++ b/projects/packages/stats/src/class-main.php
@@ -10,6 +10,7 @@ namespace Automattic\Jetpack\Stats;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Modules;
+use Automattic\Jetpack\Stats\Abilities\Stats_Abilities;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Visitor;
 use WP_User;
@@ -83,6 +84,12 @@ class Main {
 
 		// Set up package version hook.
 		add_filter( 'jetpack_package_versions', __NAMESPACE__ . '\Package_Version::send_package_version_to_tracker' );
+
+		// Register WP Abilities API surface. Gated behind the
+		// `jetpack_wp_abilities_enabled` filter inside Registrar::init(),
+		// which defaults to false — so this call is safe to make unconditionally
+		// and still opt-in per-site until the flag is flipped.
+		Stats_Abilities::init();
 	}
 
 	/**

--- a/projects/packages/stats/src/class-options.php
+++ b/projects/packages/stats/src/class-options.php
@@ -151,9 +151,13 @@ class Options {
 	/**
 	 * Default Stats related options.
 	 *
+	 * Exposed so consumers (e.g. the Abilities API surface) can introspect
+	 * each option's default value and infer its type without redeclaring
+	 * a parallel allow-list of bool/array fields.
+	 *
 	 * @return array
 	 */
-	protected static function get_defaults() {
+	public static function get_defaults() {
 		return array(
 			'admin_bar'                => true,
 			'roles'                    => array( 'administrator' ),

--- a/projects/packages/stats/tests/php/abilities/Stats_Abilities_Test.php
+++ b/projects/packages/stats/tests/php/abilities/Stats_Abilities_Test.php
@@ -203,7 +203,7 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 			'jetpack-stats/get-post-views',
 			'jetpack-stats/get-visits',
 			'jetpack-stats/get-followers',
-			'jetpack-stats/get-stats-config',
+			'jetpack-stats/get-settings',
 		);
 		$abilities  = Stats_Abilities::get_abilities();
 		foreach ( $read_slugs as $slug ) {
@@ -222,9 +222,9 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 		}
 	}
 
-	public function test_set_stats_config_is_not_readonly_but_idempotent(): void {
+	public function test_update_settings_is_not_readonly_but_idempotent(): void {
 		$abilities = Stats_Abilities::get_abilities();
-		$ann       = $abilities['jetpack-stats/set-stats-config']['meta']['annotations'];
+		$ann       = $abilities['jetpack-stats/update-settings']['meta']['annotations'];
 		$this->assertFalse( $ann['readonly'] );
 		$this->assertFalse( $ann['destructive'] );
 		$this->assertTrue( $ann['idempotent'] );
@@ -334,7 +334,7 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 
 		$this->assertTrue( wp_has_ability( 'jetpack-stats/get-site-overview' ) );
 		$this->assertFalse( wp_has_ability( 'jetpack-stats/get-top-content' ) );
-		$this->assertFalse( wp_has_ability( 'jetpack-stats/set-stats-config' ) );
+		$this->assertFalse( wp_has_ability( 'jetpack-stats/update-settings' ) );
 	}
 
 	public function test_can_view_stats_allows_admin(): void {
@@ -352,14 +352,14 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 		$this->assertFalse( Stats_Abilities::can_view_stats() );
 	}
 
-	public function test_can_manage_stats_config_allows_admin(): void {
+	public function test_can_manage_settings_allows_admin(): void {
 		wp_set_current_user( self::$admin_id );
-		$this->assertTrue( Stats_Abilities::can_manage_stats_config() );
+		$this->assertTrue( Stats_Abilities::can_manage_settings() );
 	}
 
-	public function test_can_manage_stats_config_denies_subscriber(): void {
+	public function test_can_manage_settings_denies_subscriber(): void {
 		wp_set_current_user( self::$subscriber_id );
-		$this->assertFalse( Stats_Abilities::can_manage_stats_config() );
+		$this->assertFalse( Stats_Abilities::can_manage_settings() );
 	}
 
 	public function test_get_site_overview_returns_composed_shape(): void {
@@ -992,8 +992,8 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 		$this->assertContains( 'comment_followers', $result['errors'] );
 	}
 
-	public function test_get_stats_config_returns_whitelisted_fields_only(): void {
-		$result = Stats_Abilities::get_stats_config();
+	public function test_get_settings_returns_whitelisted_fields_only(): void {
+		$result = Stats_Abilities::get_settings();
 
 		$this->assertIsArray( $result );
 		$this->assertSame(
@@ -1006,11 +1006,11 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 		$this->assertArrayNotHasKey( 'notices', $result );
 	}
 
-	public function test_get_stats_config_classifies_types_from_options_defaults(): void {
+	public function test_get_settings_classifies_types_from_options_defaults(): void {
 		// Regression guard: the snapshot derives bool/array typing from
 		// Options::get_defaults() rather than a duplicated allow-list, so a new
 		// option type added in Options must propagate here without code changes.
-		$result = Stats_Abilities::get_stats_config();
+		$result = Stats_Abilities::get_settings();
 
 		$this->assertIsBool( $result['admin_bar'] );
 		$this->assertIsBool( $result['do_not_track'] );
@@ -1018,51 +1018,51 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 		$this->assertIsArray( $result['count_roles'] );
 	}
 
-	public function test_set_stats_config_rejects_empty_input(): void {
-		$result = Stats_Abilities::set_stats_config( array() );
+	public function test_update_settings_rejects_empty_input(): void {
+		$result = Stats_Abilities::update_settings( array() );
 		$this->assertInstanceOf( \WP_Error::class, $result );
-		$this->assertSame( 'jetpack_stats_missing_config_field', $result->get_error_code() );
+		$this->assertSame( 'jetpack_stats_missing_setting_field', $result->get_error_code() );
 	}
 
-	public function test_set_stats_config_rejects_unknown_role(): void {
-		$result = Stats_Abilities::set_stats_config( array( 'roles' => array( 'robot' ) ) );
+	public function test_update_settings_rejects_unknown_role(): void {
+		$result = Stats_Abilities::update_settings( array( 'roles' => array( 'robot' ) ) );
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'jetpack_stats_invalid_role', $result->get_error_code() );
 	}
 
-	public function test_set_stats_config_rejects_empty_roles_to_prevent_lockout(): void {
+	public function test_update_settings_rejects_empty_roles_to_prevent_lockout(): void {
 		// Schema validation enforces minItems=1 on REST input, but direct PHP callers bypass
 		// that path; an empty `roles` array would revoke `view_stats` for every user, including
 		// the caller. Reject explicitly.
-		$result = Stats_Abilities::set_stats_config( array( 'roles' => array() ) );
+		$result = Stats_Abilities::update_settings( array( 'roles' => array() ) );
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'jetpack_stats_invalid_roles', $result->get_error_code() );
 	}
 
-	public function test_set_stats_config_changes_admin_bar(): void {
-		$before = Stats_Abilities::get_stats_config();
+	public function test_update_settings_changes_admin_bar(): void {
+		$before = Stats_Abilities::get_settings();
 		$this->assertTrue( $before['admin_bar'] );
 
-		$result = Stats_Abilities::set_stats_config( array( 'admin_bar' => false ) );
+		$result = Stats_Abilities::update_settings( array( 'admin_bar' => false ) );
 
 		$this->assertIsArray( $result );
 		$this->assertTrue( $result['changed'] );
-		$this->assertFalse( $result['config']['admin_bar'] );
+		$this->assertFalse( $result['settings']['admin_bar'] );
 	}
 
-	public function test_set_stats_config_is_idempotent_for_current_state(): void {
-		$before = Stats_Abilities::get_stats_config();
-		$result = Stats_Abilities::set_stats_config( array( 'admin_bar' => $before['admin_bar'] ) );
+	public function test_update_settings_is_idempotent_for_current_state(): void {
+		$before = Stats_Abilities::get_settings();
+		$result = Stats_Abilities::update_settings( array( 'admin_bar' => $before['admin_bar'] ) );
 		$this->assertFalse( $result['changed'], 'Desired == current must be a no-op.' );
 	}
 
-	public function test_set_stats_config_accepts_empty_count_roles(): void {
-		$result = Stats_Abilities::set_stats_config( array( 'count_roles' => array() ) );
+	public function test_update_settings_accepts_empty_count_roles(): void {
+		$result = Stats_Abilities::update_settings( array( 'count_roles' => array() ) );
 		$this->assertIsArray( $result );
-		$this->assertSame( array(), $result['config']['count_roles'] );
+		$this->assertSame( array(), $result['settings']['count_roles'] );
 	}
 
-	public function test_set_stats_config_preserves_unrelated_option_keys(): void {
+	public function test_update_settings_preserves_unrelated_option_keys(): void {
 		// Seed an unrelated internal key.
 		update_option(
 			'stats_options',
@@ -1076,12 +1076,12 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 		// Force-reset the static cache so the next get_options() re-reads.
 		self::reset_static_property( Options::class, 'options', array() );
 
-		Stats_Abilities::set_stats_config( array( 'admin_bar' => false ) );
+		Stats_Abilities::update_settings( array( 'admin_bar' => false ) );
 
 		$this->assertSame(
 			array( 'do_not_clobber' => 1 ),
 			Options::get_option( 'notices' ),
-			'set-stats-config must not blow away unrelated internal option keys.'
+			'update-settings must not blow away unrelated internal option keys.'
 		);
 	}
 

--- a/projects/packages/stats/tests/php/abilities/Stats_Abilities_Test.php
+++ b/projects/packages/stats/tests/php/abilities/Stats_Abilities_Test.php
@@ -1,0 +1,803 @@
+<?php
+/**
+ * Tests for the Stats_Abilities Registrar subclass.
+ *
+ * @package automattic/jetpack-stats
+ * @phan-file-suppress PhanPluginDuplicateAdjacentStatement -- Intentional for idempotency tests.
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9.
+
+namespace Automattic\Jetpack\Stats\Abilities;
+
+use Automattic\Jetpack\Stats\Main;
+use Automattic\Jetpack\Stats\Options;
+use Automattic\Jetpack\Stats\StatsBaseTestCase;
+use Automattic\Jetpack\Stats\WPCOM_Stats;
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * Unit tests for Stats_Abilities registration and execution.
+ *
+ * Run from projects/packages/stats:
+ *
+ *   composer phpunit -- --filter Stats_Abilities_Test
+ */
+#[CoversClass( Stats_Abilities::class )]
+class Stats_Abilities_Test extends StatsBaseTestCase {
+
+	/**
+	 * The admin user id.
+	 *
+	 * @var int
+	 */
+	private static $admin_id;
+
+	/**
+	 * The subscriber user id.
+	 *
+	 * @var int
+	 */
+	private static $subscriber_id;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		// Force Stats\Main to re-run its constructor each test. Main is a singleton —
+		// its constructor adds the `map_meta_cap` filter that maps `view_stats` to
+		// `read` for configured roles, but WorDBless's _restore_hooks() wipes all
+		// filters back to the state captured before test #1. Without this reset,
+		// only the first test sees the cap mapping.
+		$ref  = new \ReflectionClass( Main::class );
+		$prop = $ref->getProperty( 'instance' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$prop->setAccessible( true );
+		}
+		$prop->setValue( null, null );
+		Main::init();
+
+		self::$admin_id = wp_insert_user(
+			array(
+				'user_login' => 'stats_abilities_admin_' . wp_generate_password( 8, false ),
+				'user_pass'  => 'pw',
+				'role'       => 'administrator',
+			)
+		);
+		self::$subscriber_id = wp_insert_user(
+			array(
+				'user_login' => 'stats_abilities_sub_' . wp_generate_password( 8, false ),
+				'user_pass'  => 'pw',
+				'role'       => 'subscriber',
+			)
+		);
+
+		// Most tests open the gate; the specific "disabled by default" test closes it explicitly.
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+
+		// Reset any hooks a prior test may have added for the Registrar lifecycle actions.
+		// We do NOT touch the Abilities registry here — accessing it via wp_has_ability()
+		// would fire wp_abilities_api_init as a side effect (WP_Abilities_Registry::get_instance()
+		// does do_action() on first call), breaking the init()-hooked-correctly assertions below.
+		remove_action( 'wp_abilities_api_categories_init', array( Stats_Abilities::class, 'register_category' ) );
+		remove_action( 'wp_abilities_api_init', array( Stats_Abilities::class, 'register_abilities' ) );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function tear_down() {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		remove_all_filters( 'jetpack_wp_abilities_should_register' );
+		remove_all_filters( 'jetpack_stats_abilities_wpcom_stats' );
+		remove_action( 'wp_abilities_api_categories_init', array( Stats_Abilities::class, 'register_category' ) );
+		remove_action( 'wp_abilities_api_init', array( Stats_Abilities::class, 'register_abilities' ) );
+		wp_set_current_user( 0 );
+
+		// Only touch the registry if it has already been instantiated by something
+		// in this test (e.g., register_abilities / wp_has_ability). Otherwise this
+		// would force-instantiate it and fire wp_abilities_api_init as a side effect.
+		if ( did_action( 'wp_abilities_api_init' ) ) {
+			$this->deregister_category_and_abilities();
+		}
+
+		// Reset Options static cache so config-writes don't leak across tests.
+		$ref  = new \ReflectionClass( Options::class );
+		$prop = $ref->getProperty( 'options' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$prop->setAccessible( true );
+		}
+		$prop->setValue( null, array() );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Remove our category + abilities from the registry so tests don't bleed.
+	 */
+	private function deregister_category_and_abilities(): void {
+		if ( function_exists( 'wp_has_ability' ) && function_exists( 'wp_unregister_ability' ) ) {
+			foreach ( array_keys( Stats_Abilities::get_abilities() ) as $slug ) {
+				if ( wp_has_ability( $slug ) ) {
+					wp_unregister_ability( $slug );
+				}
+			}
+		}
+		if ( function_exists( 'wp_has_ability_category' ) && function_exists( 'wp_unregister_ability_category' ) ) {
+			if ( wp_has_ability_category( Stats_Abilities::CATEGORY_SLUG ) ) {
+				wp_unregister_ability_category( Stats_Abilities::CATEGORY_SLUG );
+			}
+		}
+	}
+
+	/**
+	 * Simulate the `wp_abilities_api_categories_init` action having fired.
+	 */
+	private function simulate_categories_init_fired(): void {
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_categories_init';
+	}
+
+	/**
+	 * Simulate the `wp_abilities_api_init` action having fired.
+	 */
+	private function simulate_abilities_init_fired(): void {
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_init';
+	}
+
+	// ========== Abstract getters ==========
+
+	public function test_category_slug_is_jetpack_stats(): void {
+		$this->assertSame( 'jetpack-stats', Stats_Abilities::get_category_slug() );
+	}
+
+	public function test_category_definition_has_label_and_description(): void {
+		$def = Stats_Abilities::get_category_definition();
+		$this->assertArrayHasKey( 'label', $def );
+		$this->assertArrayHasKey( 'description', $def );
+		$this->assertNotSame( '', $def['label'] );
+		$this->assertNotSame( '', $def['description'] );
+	}
+
+	public function test_abilities_map_is_non_empty_and_namespaced(): void {
+		$abilities = Stats_Abilities::get_abilities();
+		$this->assertNotEmpty( $abilities );
+		foreach ( array_keys( $abilities ) as $slug ) {
+			$this->assertStringStartsWith( 'jetpack-stats/', $slug );
+		}
+	}
+
+	public function test_no_spec_sets_category_explicitly(): void {
+		// Registrar auto-injects category; specs that set it are redundant and drift.
+		foreach ( Stats_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertArrayNotHasKey(
+				'category',
+				$spec,
+				"Ability {$slug} should not set its own category — Registrar injects it."
+			);
+		}
+	}
+
+	public function test_every_spec_declares_annotations_permission_and_execute(): void {
+		foreach ( Stats_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertArrayHasKey( 'execute_callback', $spec, "Ability {$slug} missing execute_callback" );
+			$this->assertIsCallable( $spec['execute_callback'], "Ability {$slug} execute_callback is not callable" );
+			$this->assertArrayHasKey( 'permission_callback', $spec, "Ability {$slug} missing permission_callback" );
+			$this->assertIsCallable( $spec['permission_callback'], "Ability {$slug} permission_callback is not callable" );
+			$this->assertArrayHasKey( 'meta', $spec, "Ability {$slug} missing meta" );
+			$this->assertArrayHasKey( 'annotations', $spec['meta'], "Ability {$slug} missing meta.annotations" );
+			foreach ( array( 'readonly', 'destructive', 'idempotent' ) as $flag ) {
+				$this->assertArrayHasKey( $flag, $spec['meta']['annotations'], "Ability {$slug} missing annotation {$flag}" );
+				$this->assertIsBool( $spec['meta']['annotations'][ $flag ], "Ability {$slug} annotation {$flag} must be bool" );
+			}
+		}
+	}
+
+	public function test_read_abilities_declared_readonly_and_non_destructive(): void {
+		$read_slugs = array(
+			'jetpack-stats/get-site-overview',
+			'jetpack-stats/get-top-content',
+			'jetpack-stats/get-post-views',
+			'jetpack-stats/get-visits',
+			'jetpack-stats/get-followers',
+			'jetpack-stats/get-stats-config',
+		);
+		$abilities  = Stats_Abilities::get_abilities();
+		foreach ( $read_slugs as $slug ) {
+			$this->assertArrayHasKey( $slug, $abilities );
+			$ann = $abilities[ $slug ]['meta']['annotations'];
+			$this->assertTrue( $ann['readonly'], "{$slug} should be readonly" );
+			$this->assertFalse( $ann['destructive'], "{$slug} should not be destructive" );
+			$this->assertTrue( $ann['idempotent'], "{$slug} should be idempotent" );
+		}
+	}
+
+	public function test_set_stats_config_is_not_readonly_but_idempotent(): void {
+		$abilities = Stats_Abilities::get_abilities();
+		$ann       = $abilities['jetpack-stats/set-stats-config']['meta']['annotations'];
+		$this->assertFalse( $ann['readonly'] );
+		$this->assertFalse( $ann['destructive'] );
+		$this->assertTrue( $ann['idempotent'] );
+	}
+
+	// ========== Registrar wiring ==========
+
+	public function test_init_registers_nothing_when_gate_filter_is_false(): void {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+
+		Stats_Abilities::init();
+
+		$this->assertFalse(
+			has_action(
+				'wp_abilities_api_categories_init',
+				array( Stats_Abilities::class, 'register_category' )
+			)
+		);
+		$this->assertFalse(
+			has_action(
+				'wp_abilities_api_init',
+				array( Stats_Abilities::class, 'register_abilities' )
+			)
+		);
+
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+	}
+
+	public function test_init_hooks_lifecycle_actions_when_gate_is_true(): void {
+		// Only valid when the Abilities API lifecycle actions have NOT yet fired.
+		// WP_Abilities_Registry::get_instance() fires `wp_abilities_api_init` on first call
+		// (in response to any wp_has_ability / wp_register_ability call elsewhere in the run),
+		// which would push the Registrar down its synchronous late-load path and this test
+		// would assert against a world it doesn't apply to.
+		if ( did_action( 'wp_abilities_api_init' ) || did_action( 'wp_abilities_api_categories_init' ) ) {
+			$this->markTestSkipped( 'Abilities API lifecycle already fired in this test run; late-load path covered elsewhere.' );
+		}
+
+		Stats_Abilities::init();
+
+		$this->assertNotFalse(
+			has_action(
+				'wp_abilities_api_categories_init',
+				array( Stats_Abilities::class, 'register_category' )
+			)
+		);
+		$this->assertNotFalse(
+			has_action(
+				'wp_abilities_api_init',
+				array( Stats_Abilities::class, 'register_abilities' )
+			)
+		);
+	}
+
+	public function test_register_abilities_registers_every_slug_with_auto_injected_category(): void {
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
+			$this->markTestSkipped( 'Abilities API not available.' );
+		}
+
+		$this->simulate_categories_init_fired();
+		Stats_Abilities::register_category();
+
+		$this->simulate_abilities_init_fired();
+		Stats_Abilities::register_abilities();
+
+		foreach ( array_keys( Stats_Abilities::get_abilities() ) as $slug ) {
+			$this->assertTrue( wp_has_ability( $slug ), "Ability {$slug} should be registered." );
+		}
+	}
+
+	public function test_per_ability_allow_list_filter_is_respected(): void {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API not available.' );
+		}
+
+		add_filter(
+			'jetpack_wp_abilities_should_register',
+			static function ( $enabled, $type, $slug ) {
+				// Allow only the zero-arg overview; deny the rest.
+				if ( 'ability' === $type ) {
+					return 'jetpack-stats/get-site-overview' === $slug;
+				}
+				return $enabled;
+			},
+			10,
+			3
+		);
+
+		$this->simulate_categories_init_fired();
+		Stats_Abilities::register_category();
+
+		$this->simulate_abilities_init_fired();
+		Stats_Abilities::register_abilities();
+
+		$this->assertTrue( wp_has_ability( 'jetpack-stats/get-site-overview' ) );
+		$this->assertFalse( wp_has_ability( 'jetpack-stats/get-top-content' ) );
+		$this->assertFalse( wp_has_ability( 'jetpack-stats/set-stats-config' ) );
+	}
+
+	// ========== Permission callbacks ==========
+
+	public function test_can_view_stats_allows_admin(): void {
+		wp_set_current_user( self::$admin_id );
+		$this->assertTrue( Stats_Abilities::can_view_stats() );
+	}
+
+	public function test_can_view_stats_denies_subscriber(): void {
+		wp_set_current_user( self::$subscriber_id );
+		$this->assertFalse( Stats_Abilities::can_view_stats() );
+	}
+
+	public function test_can_view_stats_denies_anonymous(): void {
+		wp_set_current_user( 0 );
+		$this->assertFalse( Stats_Abilities::can_view_stats() );
+	}
+
+	public function test_can_manage_stats_config_allows_admin(): void {
+		wp_set_current_user( self::$admin_id );
+		$this->assertTrue( Stats_Abilities::can_manage_stats_config() );
+	}
+
+	public function test_can_manage_stats_config_denies_subscriber(): void {
+		wp_set_current_user( self::$subscriber_id );
+		$this->assertFalse( Stats_Abilities::can_manage_stats_config() );
+	}
+
+	// ========== Execute: get-site-overview ==========
+
+	public function test_get_site_overview_returns_composed_shape(): void {
+		$this->filter_wpcom_stats(
+			array(
+				'get_stats_summary' => array(
+					'date'               => '2026-04-23',
+					'period'             => 'day',
+					'views'              => 120,
+					'visitors'           => 90,
+					'likes'              => 4,
+					'comments'           => 2,
+					'period_total_views' => 840,
+				),
+				'get_highlights'    => array(
+					'today' => array(
+						'date'          => '2026-04-23',
+						'views_month'   => 3500,
+						'top_post'      => array( 'id' => 7, 'title' => 'Hello world', 'views' => 42 ),
+						'top_referrers' => array(
+							array( 'name' => 'wordpress.com', 'views' => 60 ),
+							array( 'name' => 'google.com', 'views' => 30 ),
+						),
+					),
+				),
+				'get_streak'        => array(
+					'streak' => array(
+						'currentStreakLength' => 3,
+						'longestStreakLength' => 12,
+						'longestStreakStart'  => '2026-01-01',
+						'longestStreakEnd'    => '2026-01-12',
+					),
+				),
+			)
+		);
+
+		$result = Stats_Abilities::get_site_overview();
+
+		$this->assertIsArray( $result );
+		$this->assertSame( '2026-04-23', $result['date'] );
+		$this->assertSame( 120, $result['views_today'] );
+		$this->assertSame( 90, $result['visitors_today'] );
+		$this->assertSame( 840, $result['views_week'] );
+		$this->assertSame( 3500, $result['views_month'] );
+		$this->assertSame( 3, $result['streak']['current_length'] );
+		$this->assertSame( 12, $result['streak']['longest_length'] );
+		$this->assertSame( array( 'id' => 7, 'title' => 'Hello world', 'views' => 42 ), $result['top_post'] );
+		$this->assertSame( array( 'name' => 'wordpress.com', 'views' => 60 ), $result['top_referrer'] );
+		$this->assertFalse( $result['partial'] );
+		$this->assertArrayNotHasKey( 'errors', $result );
+	}
+
+	public function test_get_site_overview_flags_partial_when_one_subcall_fails(): void {
+		$this->filter_wpcom_stats(
+			array(
+				'get_stats_summary' => array( 'date' => '2026-04-23', 'views' => 10 ),
+				'get_highlights'    => new \WP_Error( 'boom', 'nope' ),
+				'get_streak'        => array( 'streak' => array( 'currentStreakLength' => 1 ) ),
+			)
+		);
+
+		$result = Stats_Abilities::get_site_overview();
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['partial'] );
+		$this->assertContains( 'highlights', $result['errors'] );
+		$this->assertSame( 10, $result['views_today'] );
+		$this->assertNull( $result['top_post'] );
+	}
+
+	public function test_get_site_overview_returns_wp_error_when_all_subcalls_fail(): void {
+		$this->filter_wpcom_stats(
+			array(
+				'get_stats_summary' => new \WP_Error( 'boom', 'nope' ),
+				'get_highlights'    => new \WP_Error( 'boom', 'nope' ),
+				'get_streak'        => new \WP_Error( 'boom', 'nope' ),
+			)
+		);
+
+		$result = Stats_Abilities::get_site_overview();
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_stats_data_unavailable', $result->get_error_code() );
+	}
+
+	// ========== Execute: get-top-content ==========
+
+	public function test_get_top_content_rejects_missing_type(): void {
+		$result = Stats_Abilities::get_top_content( array() );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_stats_missing_type', $result->get_error_code() );
+	}
+
+	public function test_get_top_content_posts_uniform_shape(): void {
+		$this->filter_wpcom_stats(
+			array(
+				'get_top_posts' => array(
+					'days' => array(
+						'2026-04-23' => array(
+							'postviews' => array(
+								array( 'id' => 1, 'title' => 'Alpha', 'views' => 100, 'href' => 'https://x/alpha' ),
+								array( 'id' => 2, 'title' => 'Beta',  'views' => 50,  'href' => 'https://x/beta' ),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$result = Stats_Abilities::get_top_content( array( 'type' => 'posts', 'date' => '2026-04-23', 'max' => 5 ) );
+
+		$this->assertSame( 'posts', $result['type'] );
+		$this->assertSame( 'day', $result['period'] );
+		$this->assertSame( '2026-04-23', $result['date'] );
+		$this->assertCount( 2, $result['items'] );
+		$this->assertSame( 1, $result['items'][0]['rank'] );
+		$this->assertSame( 'Alpha', $result['items'][0]['label'] );
+		$this->assertSame( 100, $result['items'][0]['value'] );
+		$this->assertSame( 'https://x/alpha', $result['items'][0]['href'] );
+		$this->assertSame( 2, $result['items'][1]['rank'] );
+	}
+
+	public function test_get_top_content_search_terms_uniform_shape(): void {
+		$this->filter_wpcom_stats(
+			array(
+				'get_search_terms' => array(
+					'days' => array(
+						'2026-04-23' => array(
+							'search_terms' => array(
+								array( 'term' => 'jetpack', 'views' => 20 ),
+								array( 'term' => 'stats',   'views' => 7 ),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$result = Stats_Abilities::get_top_content( array( 'type' => 'search-terms', 'date' => '2026-04-23' ) );
+
+		$this->assertSame( 'search-terms', $result['type'] );
+		$this->assertCount( 2, $result['items'] );
+		$this->assertSame( 'jetpack', $result['items'][0]['label'] );
+		$this->assertSame( 20, $result['items'][0]['value'] );
+		// No href for search terms.
+		$this->assertArrayNotHasKey( 'href', $result['items'][0] );
+	}
+
+	public function test_get_top_content_countries_uses_country_name(): void {
+		$this->filter_wpcom_stats(
+			array(
+				'get_views_by_country' => array(
+					'days'         => array(
+						'2026-04-23' => array(
+							'views' => array(
+								array( 'country_code' => 'FR', 'views' => 12 ),
+								array( 'country_code' => 'DE', 'views' => 9 ),
+							),
+						),
+					),
+					'country-info' => array(
+						'FR' => array( 'country_full' => 'France' ),
+						'DE' => array( 'country_full' => 'Germany' ),
+					),
+				),
+			)
+		);
+
+		$result = Stats_Abilities::get_top_content( array( 'type' => 'countries', 'date' => '2026-04-23' ) );
+
+		$this->assertSame( 'France', $result['items'][0]['label'] );
+		$this->assertSame( 'Germany', $result['items'][1]['label'] );
+	}
+
+	public function test_get_top_content_tags_handles_flat_shape(): void {
+		$this->filter_wpcom_stats(
+			array(
+				'get_tags' => array(
+					'tags' => array(
+						array( 'tag' => 'news', 'views' => 40 ),
+						array( 'tag' => 'updates', 'views' => 15 ),
+					),
+				),
+			)
+		);
+
+		$result = Stats_Abilities::get_top_content( array( 'type' => 'tags' ) );
+
+		$this->assertCount( 2, $result['items'] );
+		$this->assertSame( 'news', $result['items'][0]['label'] );
+		$this->assertSame( 40, $result['items'][0]['value'] );
+	}
+
+	public function test_get_top_content_enforces_max_cap(): void {
+		$this->filter_wpcom_stats(
+			array(
+				'get_top_posts' => array(
+					'days' => array(
+						'2026-04-23' => array(
+							'postviews' => array(
+								array( 'title' => 'A', 'views' => 1 ),
+								array( 'title' => 'B', 'views' => 1 ),
+								array( 'title' => 'C', 'views' => 1 ),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$result = Stats_Abilities::get_top_content( array( 'type' => 'posts', 'max' => 2 ) );
+
+		$this->assertCount( 2, $result['items'] );
+	}
+
+	public function test_get_top_content_propagates_wp_error(): void {
+		$this->filter_wpcom_stats(
+			array(
+				'get_top_posts' => new \WP_Error( 'wpcom_boom', 'bad' ),
+			)
+		);
+
+		$result = Stats_Abilities::get_top_content( array( 'type' => 'posts' ) );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+	}
+
+	// ========== Execute: get-post-views ==========
+
+	public function test_get_post_views_rejects_missing_post_id(): void {
+		$result = Stats_Abilities::get_post_views( array() );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_stats_missing_post_id', $result->get_error_code() );
+	}
+
+	public function test_get_post_views_rejects_post_id_zero(): void {
+		// Regression guard: post ID 0 is not a legal post; but our validation uses `> 0`, not `empty()`,
+		// which means a future ID-like value of string "0" behaves deterministically (also rejected
+		// by the positive check, not accidentally by falsy coercion).
+		$result = Stats_Abilities::get_post_views( array( 'post_id' => '0' ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_stats_missing_post_id', $result->get_error_code() );
+	}
+
+	public function test_get_post_views_rejects_non_numeric_post_id(): void {
+		$result = Stats_Abilities::get_post_views( array( 'post_id' => 'not-a-number' ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+	}
+
+	public function test_get_post_views_accepts_numeric_string(): void {
+		$this->filter_wpcom_stats(
+			array(
+				'get_post_views' => array(
+					'views'  => 42,
+					'fields' => array( 'period', 'views' ),
+					'data'   => array(
+						array( '2026-04-22', 20 ),
+						array( '2026-04-23', 22 ),
+					),
+				),
+			)
+		);
+
+		$result = Stats_Abilities::get_post_views( array( 'post_id' => '7' ) );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 7, $result['post_id'] );
+		$this->assertSame( 42, $result['total_views'] );
+		$this->assertCount( 2, $result['series'] );
+		$this->assertSame( array( 'date' => '2026-04-22', 'views' => 20 ), $result['series'][0] );
+	}
+
+	// ========== Execute: get-visits ==========
+
+	public function test_get_visits_normalizes_series_rows(): void {
+		$this->filter_wpcom_stats(
+			array(
+				'get_visits' => array(
+					'fields' => array( 'period', 'views', 'visitors' ),
+					'data'   => array(
+						array( '2026-04-22', 100, 70 ),
+						array( '2026-04-23', 120, 90 ),
+					),
+				),
+			)
+		);
+
+		$result = Stats_Abilities::get_visits( array( 'unit' => 'day', 'quantity' => 2 ) );
+
+		$this->assertSame( array( 'views', 'visitors' ), $result['fields'] );
+		$this->assertCount( 2, $result['series'] );
+		$this->assertSame( array( 'date' => '2026-04-22', 'views' => 100, 'visitors' => 70 ), $result['series'][0] );
+	}
+
+	public function test_get_visits_always_includes_requested_fields_even_when_missing_from_backing(): void {
+		// If WPCOM omits a field, we still emit it as 0 so the agent can iterate uniformly.
+		$this->filter_wpcom_stats(
+			array(
+				'get_visits' => array(
+					'fields' => array( 'period', 'views' ),
+					'data'   => array( array( '2026-04-23', 100 ) ),
+				),
+			)
+		);
+
+		$result = Stats_Abilities::get_visits( array( 'fields' => array( 'views', 'likes' ) ) );
+
+		$this->assertSame( array( 'views', 'likes' ), $result['fields'] );
+		$this->assertSame( 100, $result['series'][0]['views'] );
+		$this->assertSame( 0, $result['series'][0]['likes'] );
+	}
+
+	// ========== Execute: get-followers ==========
+
+	public function test_get_followers_composes_three_subcalls(): void {
+		$this->filter_wpcom_stats(
+			array(
+				'get_followers'           => array( 'email' => 10, 'wpcom' => 25 ),
+				'get_comment_followers'   => array( 'total' => 4 ),
+				'get_publicize_followers' => array(
+					'services' => array(
+						array( 'service' => 'twitter', 'followers' => 300 ),
+						array( 'service' => 'facebook', 'followers' => 80 ),
+					),
+				),
+			)
+		);
+
+		$result = Stats_Abilities::get_followers();
+
+		$this->assertSame( 10, $result['email'] );
+		$this->assertSame( 25, $result['wpcom'] );
+		$this->assertSame( 4, $result['comment'] );
+		$this->assertSame( array( 'twitter' => 300, 'facebook' => 80 ), $result['publicize'] );
+		$this->assertSame( 10 + 25 + 4 + 300 + 80, $result['total'] );
+		$this->assertFalse( $result['partial'] );
+	}
+
+	public function test_get_followers_flags_partial_on_subcall_error(): void {
+		$this->filter_wpcom_stats(
+			array(
+				'get_followers'           => array( 'email' => 5, 'wpcom' => 10 ),
+				'get_comment_followers'   => new \WP_Error( 'boom', 'bad' ),
+				'get_publicize_followers' => array( 'services' => array() ),
+			)
+		);
+
+		$result = Stats_Abilities::get_followers();
+
+		$this->assertTrue( $result['partial'] );
+		$this->assertContains( 'comment_followers', $result['errors'] );
+	}
+
+	// ========== Execute: get-stats-config ==========
+
+	public function test_get_stats_config_returns_whitelisted_fields_only(): void {
+		$result = Stats_Abilities::get_stats_config();
+
+		$this->assertIsArray( $result );
+		$this->assertSame(
+			array( 'admin_bar', 'roles', 'count_roles', 'do_not_track', 'enable_odyssey_stats' ),
+			array_keys( $result )
+		);
+		// Internal keys must NOT leak.
+		$this->assertArrayNotHasKey( 'blog_id', $result );
+		$this->assertArrayNotHasKey( 'version', $result );
+		$this->assertArrayNotHasKey( 'notices', $result );
+	}
+
+	// ========== Execute: set-stats-config ==========
+
+	public function test_set_stats_config_rejects_empty_input(): void {
+		$result = Stats_Abilities::set_stats_config( array() );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_stats_missing_config_field', $result->get_error_code() );
+	}
+
+	public function test_set_stats_config_rejects_unknown_role(): void {
+		$result = Stats_Abilities::set_stats_config( array( 'roles' => array( 'robot' ) ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_stats_invalid_role', $result->get_error_code() );
+	}
+
+	public function test_set_stats_config_changes_admin_bar(): void {
+		$before = Stats_Abilities::get_stats_config();
+		$this->assertTrue( $before['admin_bar'] );
+
+		$result = Stats_Abilities::set_stats_config( array( 'admin_bar' => false ) );
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['changed'] );
+		$this->assertFalse( $result['config']['admin_bar'] );
+	}
+
+	public function test_set_stats_config_is_idempotent_for_current_state(): void {
+		$before = Stats_Abilities::get_stats_config();
+		$result = Stats_Abilities::set_stats_config( array( 'admin_bar' => $before['admin_bar'] ) );
+		$this->assertFalse( $result['changed'], 'Desired == current must be a no-op.' );
+	}
+
+	public function test_set_stats_config_accepts_empty_count_roles(): void {
+		$result = Stats_Abilities::set_stats_config( array( 'count_roles' => array() ) );
+		$this->assertIsArray( $result );
+		$this->assertSame( array(), $result['config']['count_roles'] );
+	}
+
+	public function test_set_stats_config_preserves_unrelated_option_keys(): void {
+		// Seed an unrelated internal key.
+		update_option(
+			'stats_options',
+			array(
+				'admin_bar' => true,
+				'roles'     => array( 'administrator' ),
+				'notices'   => array( 'do_not_clobber' => 1 ),
+				'version'   => Main::STATS_VERSION,
+			)
+		);
+		// Force-reset the static cache so the next get_options() re-reads.
+		$ref  = new \ReflectionClass( Options::class );
+		$prop = $ref->getProperty( 'options' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$prop->setAccessible( true );
+		}
+		$prop->setValue( null, array() );
+
+		Stats_Abilities::set_stats_config( array( 'admin_bar' => false ) );
+
+		$this->assertSame(
+			array( 'do_not_clobber' => 1 ),
+			Options::get_option( 'notices' ),
+			'set-stats-config must not blow away unrelated internal option keys.'
+		);
+	}
+
+	// ========== Helpers ==========
+
+	/**
+	 * Install a filter that makes the abilities class use a stubbed WPCOM_Stats.
+	 *
+	 * @param array $method_returns Map of WPCOM_Stats method => return value (array or WP_Error).
+	 */
+	private function filter_wpcom_stats( array $method_returns ): void {
+		$stub = $this->createStub( WPCOM_Stats::class );
+		foreach ( $method_returns as $method => $value ) {
+			$stub->method( $method )->willReturn( $value );
+		}
+
+		add_filter(
+			'jetpack_stats_abilities_wpcom_stats',
+			static function () use ( $stub ) {
+				return $stub;
+			}
+		);
+	}
+}

--- a/projects/packages/stats/tests/php/abilities/Stats_Abilities_Test.php
+++ b/projects/packages/stats/tests/php/abilities/Stats_Abilities_Test.php
@@ -52,12 +52,7 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 		// `read` for configured roles, but WorDBless's _restore_hooks() wipes all
 		// filters back to the state captured before test #1. Without this reset,
 		// only the first test sees the cap mapping.
-		$ref  = new \ReflectionClass( Main::class );
-		$prop = $ref->getProperty( 'instance' );
-		if ( PHP_VERSION_ID < 80100 ) {
-			$prop->setAccessible( true );
-		}
-		$prop->setValue( null, null );
+		self::reset_static_property( Main::class, 'instance', null );
 		Main::init();
 
 		self::$admin_id      = wp_insert_user(
@@ -105,12 +100,7 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 		}
 
 		// Reset Options static cache so config-writes don't leak across tests.
-		$ref  = new \ReflectionClass( Options::class );
-		$prop = $ref->getProperty( 'options' );
-		if ( PHP_VERSION_ID < 80100 ) {
-			$prop->setAccessible( true );
-		}
-		$prop->setValue( null, array() );
+		self::reset_static_property( Options::class, 'options', array() );
 
 		parent::tear_down();
 	}
@@ -490,25 +480,22 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 	public function test_get_top_content_posts_uniform_shape(): void {
 		$this->filter_wpcom_stats(
 			array(
-				'get_top_posts' => array(
-					'days' => array(
-						'2026-04-23' => array(
-							'postviews' => array(
-								array(
-									'id'    => 1,
-									'title' => 'Alpha',
-									'views' => 100,
-									'href'  => 'https://x/alpha',
-								),
-								array(
-									'id'    => 2,
-									'title' => 'Beta',
-									'views' => 50,
-									'href'  => 'https://x/beta',
-								),
-							),
+				'get_top_posts' => self::days_fixture(
+					'postviews',
+					array(
+						array(
+							'id'    => 1,
+							'title' => 'Alpha',
+							'views' => 100,
+							'href'  => 'https://x/alpha',
 						),
-					),
+						array(
+							'id'    => 2,
+							'title' => 'Beta',
+							'views' => 50,
+							'href'  => 'https://x/beta',
+						),
+					)
 				),
 			)
 		);
@@ -535,21 +522,18 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 	public function test_get_top_content_search_terms_uniform_shape(): void {
 		$this->filter_wpcom_stats(
 			array(
-				'get_search_terms' => array(
-					'days' => array(
-						'2026-04-23' => array(
-							'search_terms' => array(
-								array(
-									'term'  => 'jetpack',
-									'views' => 20,
-								),
-								array(
-									'term'  => 'stats',
-									'views' => 7,
-								),
-							),
+				'get_search_terms' => self::days_fixture(
+					'search_terms',
+					array(
+						array(
+							'term'  => 'jetpack',
+							'views' => 20,
 						),
-					),
+						array(
+							'term'  => 'stats',
+							'views' => 7,
+						),
+					)
 				),
 			)
 		);
@@ -634,25 +618,22 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 	public function test_get_top_content_enforces_max_cap(): void {
 		$this->filter_wpcom_stats(
 			array(
-				'get_top_posts' => array(
-					'days' => array(
-						'2026-04-23' => array(
-							'postviews' => array(
-								array(
-									'title' => 'A',
-									'views' => 1,
-								),
-								array(
-									'title' => 'B',
-									'views' => 1,
-								),
-								array(
-									'title' => 'C',
-									'views' => 1,
-								),
-							),
+				'get_top_posts' => self::days_fixture(
+					'postviews',
+					array(
+						array(
+							'title' => 'A',
+							'views' => 1,
 						),
-					),
+						array(
+							'title' => 'B',
+							'views' => 1,
+						),
+						array(
+							'title' => 'C',
+							'views' => 1,
+						),
+					)
 				),
 			)
 		);
@@ -680,26 +661,23 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 	}
 
 	public function test_get_top_content_referrers_normalizes_groups_shape(): void {
-		// WPCOM `stats/referrers` keys per-day data under `groups` (NOT `referrers`),
-		// each with `name`/`total`/optional `url`. This regression-guards the mapping.
+		// Regression guard: WPCOM `stats/referrers` keys per-day data under `groups`,
+		// not `referrers`. The mapping must read from `groups -> name/total/url?`.
 		$this->filter_wpcom_stats(
 			array(
-				'get_referrers' => array(
-					'days' => array(
-						'2026-04-23' => array(
-							'groups' => array(
-								array(
-									'name'  => 'wordpress.com',
-									'url'   => 'https://wordpress.com',
-									'total' => 60,
-								),
-								array(
-									'name'  => 'Search Engines',
-									'total' => 25,
-								),
-							),
+				'get_referrers' => self::days_fixture(
+					'groups',
+					array(
+						array(
+							'name'  => 'wordpress.com',
+							'url'   => 'https://wordpress.com',
+							'total' => 60,
 						),
-					),
+						array(
+							'name'  => 'Search Engines',
+							'total' => 25,
+						),
+					)
 				),
 			)
 		);
@@ -718,30 +696,26 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 		$this->assertSame( 'https://wordpress.com', $result['items'][0]['href'] );
 		$this->assertSame( 'Search Engines', $result['items'][1]['label'] );
 		$this->assertSame( 25, $result['items'][1]['value'] );
-		// Groups without a `url` must omit `href` rather than emit an empty string.
 		$this->assertArrayNotHasKey( 'href', $result['items'][1] );
 	}
 
 	public function test_get_top_content_clicks_uniform_shape(): void {
 		$this->filter_wpcom_stats(
 			array(
-				'get_clicks' => array(
-					'days' => array(
-						'2026-04-23' => array(
-							'clicks' => array(
-								array(
-									'name'  => 'Docs',
-									'url'   => 'https://docs.example/x',
-									'views' => 9,
-								),
-								array(
-									// No `name` — normalization should fall back to `url`.
-									'url'   => 'https://example.com/y',
-									'views' => 3,
-								),
-							),
+				'get_clicks' => self::days_fixture(
+					'clicks',
+					array(
+						array(
+							'name'  => 'Docs',
+							'url'   => 'https://docs.example/x',
+							'views' => 9,
 						),
-					),
+						array(
+							// No `name` — normalization should fall back to `url`.
+							'url'   => 'https://example.com/y',
+							'views' => 3,
+						),
+					)
 				),
 			)
 		);
@@ -765,21 +739,18 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 	public function test_get_top_content_authors_uniform_shape(): void {
 		$this->filter_wpcom_stats(
 			array(
-				'get_top_authors' => array(
-					'days' => array(
-						'2026-04-23' => array(
-							'authors' => array(
-								array(
-									'name'  => 'Ada',
-									'views' => 80,
-								),
-								array(
-									'name'  => 'Grace',
-									'views' => 30,
-								),
-							),
+				'get_top_authors' => self::days_fixture(
+					'authors',
+					array(
+						array(
+							'name'  => 'Ada',
+							'views' => 80,
 						),
-					),
+						array(
+							'name'  => 'Grace',
+							'views' => 30,
+						),
+					)
 				),
 			)
 		);
@@ -800,23 +771,20 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 	public function test_get_top_content_downloads_uniform_shape(): void {
 		$this->filter_wpcom_stats(
 			array(
-				'get_file_downloads' => array(
-					'days' => array(
-						'2026-04-23' => array(
-							'files' => array(
-								array(
-									'filename'       => 'whitepaper.pdf',
-									'relative_url'   => '/downloads/whitepaper.pdf',
-									'download_count' => 42,
-								),
-								array(
-									// No `filename` — normalization should fall back to relative_url.
-									'relative_url'   => '/downloads/spec.zip',
-									'download_count' => 7,
-								),
-							),
+				'get_file_downloads' => self::days_fixture(
+					'files',
+					array(
+						array(
+							'filename'       => 'whitepaper.pdf',
+							'relative_url'   => '/downloads/whitepaper.pdf',
+							'download_count' => 42,
 						),
-					),
+						array(
+							// No `filename` — normalization should fall back to relative_url.
+							'relative_url'   => '/downloads/spec.zip',
+							'download_count' => 7,
+						),
+					)
 				),
 			)
 		);
@@ -839,21 +807,18 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 	public function test_get_top_content_video_plays_uniform_shape(): void {
 		$this->filter_wpcom_stats(
 			array(
-				'get_video_plays' => array(
-					'days' => array(
-						'2026-04-23' => array(
-							'plays' => array(
-								array(
-									'title' => 'Launch demo',
-									'plays' => 200,
-								),
-								array(
-									'title' => 'Tutorial',
-									'plays' => 75,
-								),
-							),
+				'get_video_plays' => self::days_fixture(
+					'plays',
+					array(
+						array(
+							'title' => 'Launch demo',
+							'plays' => 200,
 						),
-					),
+						array(
+							'title' => 'Tutorial',
+							'plays' => 75,
+						),
+					)
 				),
 			)
 		);
@@ -1097,12 +1062,7 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 			)
 		);
 		// Force-reset the static cache so the next get_options() re-reads.
-		$ref  = new \ReflectionClass( Options::class );
-		$prop = $ref->getProperty( 'options' );
-		if ( PHP_VERSION_ID < 80100 ) {
-			$prop->setAccessible( true );
-		}
-		$prop->setValue( null, array() );
+		self::reset_static_property( Options::class, 'options', array() );
 
 		Stats_Abilities::set_stats_config( array( 'admin_bar' => false ) );
 
@@ -1111,6 +1071,41 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 			Options::get_option( 'notices' ),
 			'set-stats-config must not blow away unrelated internal option keys.'
 		);
+	}
+
+	/**
+	 * Build a single-day WPCOM `stats/<endpoint>` fixture.
+	 *
+	 * Most top-content endpoints share the shape `days -> <date> -> <list_key> -> [rows]`;
+	 * this helper keeps the fixture wiring uniform and out of each test body.
+	 *
+	 * @param string $list_key Per-day list key (e.g. `postviews`, `groups`, `clicks`).
+	 * @param array  $rows     Row dictionaries.
+	 * @param string $date     Day key (defaults to the canonical fixture date).
+	 * @return array
+	 */
+	private static function days_fixture( string $list_key, array $rows, string $date = '2026-04-23' ): array {
+		return array(
+			'days' => array(
+				$date => array( $list_key => $rows ),
+			),
+		);
+	}
+
+	/**
+	 * Reset a class's static property (defeats inter-test caches).
+	 *
+	 * @param string $class Fully qualified class name.
+	 * @param string $prop  Property name.
+	 * @param mixed  $value New value.
+	 */
+	private static function reset_static_property( string $class, string $prop, $value ): void {
+		$ref      = new \ReflectionClass( $class );
+		$property = $ref->getProperty( $prop );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$property->setValue( null, $value );
 	}
 
 	/**

--- a/projects/packages/stats/tests/php/abilities/Stats_Abilities_Test.php
+++ b/projects/packages/stats/tests/php/abilities/Stats_Abilities_Test.php
@@ -997,7 +997,7 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 
 		$this->assertIsArray( $result );
 		$this->assertSame(
-			array( 'admin_bar', 'roles', 'count_roles', 'do_not_track', 'enable_odyssey_stats' ),
+			array( 'admin_bar', 'roles', 'count_roles', 'do_not_track' ),
 			array_keys( $result )
 		);
 		// Internal keys must NOT leak.
@@ -1014,7 +1014,6 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 
 		$this->assertIsBool( $result['admin_bar'] );
 		$this->assertIsBool( $result['do_not_track'] );
-		$this->assertIsBool( $result['enable_odyssey_stats'] );
 		$this->assertIsArray( $result['roles'] );
 		$this->assertIsArray( $result['count_roles'] );
 	}

--- a/projects/packages/stats/tests/php/abilities/Stats_Abilities_Test.php
+++ b/projects/packages/stats/tests/php/abilities/Stats_Abilities_Test.php
@@ -3,7 +3,6 @@
  * Tests for the Stats_Abilities Registrar subclass.
  *
  * @package automattic/jetpack-stats
- * @phan-file-suppress PhanPluginDuplicateAdjacentStatement -- Intentional for idempotency tests.
  */
 
 // @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9.
@@ -14,7 +13,6 @@ use Automattic\Jetpack\Stats\Main;
 use Automattic\Jetpack\Stats\Options;
 use Automattic\Jetpack\Stats\StatsBaseTestCase;
 use Automattic\Jetpack\Stats\WPCOM_Stats;
-use Automattic\Jetpack\WP_Abilities\Registrar;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
@@ -23,6 +21,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
  * Run from projects/packages/stats:
  *
  *   composer phpunit -- --filter Stats_Abilities_Test
+ *
+ * @covers \Automattic\Jetpack\Stats\Abilities\Stats_Abilities
  */
 #[CoversClass( Stats_Abilities::class )]
 class Stats_Abilities_Test extends StatsBaseTestCase {
@@ -60,7 +60,7 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 		$prop->setValue( null, null );
 		Main::init();
 
-		self::$admin_id = wp_insert_user(
+		self::$admin_id      = wp_insert_user(
 			array(
 				'user_login' => 'stats_abilities_admin_' . wp_generate_password( 8, false ),
 				'user_pass'  => 'pw',
@@ -149,8 +149,6 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 		$wp_current_filter[] = 'wp_abilities_api_init';
 	}
 
-	// ========== Abstract getters ==========
-
 	public function test_category_slug_is_jetpack_stats(): void {
 		$this->assertSame( 'jetpack-stats', Stats_Abilities::get_category_slug() );
 	}
@@ -223,8 +221,6 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 		$this->assertFalse( $ann['destructive'] );
 		$this->assertTrue( $ann['idempotent'] );
 	}
-
-	// ========== Registrar wiring ==========
 
 	public function test_init_registers_nothing_when_gate_filter_is_false(): void {
 		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
@@ -319,8 +315,6 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 		$this->assertFalse( wp_has_ability( 'jetpack-stats/set-stats-config' ) );
 	}
 
-	// ========== Permission callbacks ==========
-
 	public function test_can_view_stats_allows_admin(): void {
 		wp_set_current_user( self::$admin_id );
 		$this->assertTrue( Stats_Abilities::can_view_stats() );
@@ -346,8 +340,6 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 		$this->assertFalse( Stats_Abilities::can_manage_stats_config() );
 	}
 
-	// ========== Execute: get-site-overview ==========
-
 	public function test_get_site_overview_returns_composed_shape(): void {
 		$this->filter_wpcom_stats(
 			array(
@@ -364,10 +356,20 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 					'today' => array(
 						'date'          => '2026-04-23',
 						'views_month'   => 3500,
-						'top_post'      => array( 'id' => 7, 'title' => 'Hello world', 'views' => 42 ),
+						'top_post'      => array(
+							'id'    => 7,
+							'title' => 'Hello world',
+							'views' => 42,
+						),
 						'top_referrers' => array(
-							array( 'name' => 'wordpress.com', 'views' => 60 ),
-							array( 'name' => 'google.com', 'views' => 30 ),
+							array(
+								'name'  => 'wordpress.com',
+								'views' => 60,
+							),
+							array(
+								'name'  => 'google.com',
+								'views' => 30,
+							),
 						),
 					),
 				),
@@ -392,8 +394,21 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 		$this->assertSame( 3500, $result['views_month'] );
 		$this->assertSame( 3, $result['streak']['current_length'] );
 		$this->assertSame( 12, $result['streak']['longest_length'] );
-		$this->assertSame( array( 'id' => 7, 'title' => 'Hello world', 'views' => 42 ), $result['top_post'] );
-		$this->assertSame( array( 'name' => 'wordpress.com', 'views' => 60 ), $result['top_referrer'] );
+		$this->assertSame(
+			array(
+				'id'    => 7,
+				'title' => 'Hello world',
+				'views' => 42,
+			),
+			$result['top_post']
+		);
+		$this->assertSame(
+			array(
+				'name'  => 'wordpress.com',
+				'views' => 60,
+			),
+			$result['top_referrer']
+		);
 		$this->assertFalse( $result['partial'] );
 		$this->assertArrayNotHasKey( 'errors', $result );
 	}
@@ -401,7 +416,10 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 	public function test_get_site_overview_flags_partial_when_one_subcall_fails(): void {
 		$this->filter_wpcom_stats(
 			array(
-				'get_stats_summary' => array( 'date' => '2026-04-23', 'views' => 10 ),
+				'get_stats_summary' => array(
+					'date'  => '2026-04-23',
+					'views' => 10,
+				),
 				'get_highlights'    => new \WP_Error( 'boom', 'nope' ),
 				'get_streak'        => array( 'streak' => array( 'currentStreakLength' => 1 ) ),
 			)
@@ -431,8 +449,6 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 		$this->assertSame( 'jetpack_stats_data_unavailable', $result->get_error_code() );
 	}
 
-	// ========== Execute: get-top-content ==========
-
 	public function test_get_top_content_rejects_missing_type(): void {
 		$result = Stats_Abilities::get_top_content( array() );
 		$this->assertInstanceOf( \WP_Error::class, $result );
@@ -446,8 +462,18 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 					'days' => array(
 						'2026-04-23' => array(
 							'postviews' => array(
-								array( 'id' => 1, 'title' => 'Alpha', 'views' => 100, 'href' => 'https://x/alpha' ),
-								array( 'id' => 2, 'title' => 'Beta',  'views' => 50,  'href' => 'https://x/beta' ),
+								array(
+									'id'    => 1,
+									'title' => 'Alpha',
+									'views' => 100,
+									'href'  => 'https://x/alpha',
+								),
+								array(
+									'id'    => 2,
+									'title' => 'Beta',
+									'views' => 50,
+									'href'  => 'https://x/beta',
+								),
 							),
 						),
 					),
@@ -455,7 +481,13 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 			)
 		);
 
-		$result = Stats_Abilities::get_top_content( array( 'type' => 'posts', 'date' => '2026-04-23', 'max' => 5 ) );
+		$result = Stats_Abilities::get_top_content(
+			array(
+				'type' => 'posts',
+				'date' => '2026-04-23',
+				'max'  => 5,
+			)
+		);
 
 		$this->assertSame( 'posts', $result['type'] );
 		$this->assertSame( 'day', $result['period'] );
@@ -475,8 +507,14 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 					'days' => array(
 						'2026-04-23' => array(
 							'search_terms' => array(
-								array( 'term' => 'jetpack', 'views' => 20 ),
-								array( 'term' => 'stats',   'views' => 7 ),
+								array(
+									'term'  => 'jetpack',
+									'views' => 20,
+								),
+								array(
+									'term'  => 'stats',
+									'views' => 7,
+								),
 							),
 						),
 					),
@@ -484,7 +522,12 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 			)
 		);
 
-		$result = Stats_Abilities::get_top_content( array( 'type' => 'search-terms', 'date' => '2026-04-23' ) );
+		$result = Stats_Abilities::get_top_content(
+			array(
+				'type' => 'search-terms',
+				'date' => '2026-04-23',
+			)
+		);
 
 		$this->assertSame( 'search-terms', $result['type'] );
 		$this->assertCount( 2, $result['items'] );
@@ -501,8 +544,14 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 					'days'         => array(
 						'2026-04-23' => array(
 							'views' => array(
-								array( 'country_code' => 'FR', 'views' => 12 ),
-								array( 'country_code' => 'DE', 'views' => 9 ),
+								array(
+									'country_code' => 'FR',
+									'views'        => 12,
+								),
+								array(
+									'country_code' => 'DE',
+									'views'        => 9,
+								),
 							),
 						),
 					),
@@ -514,7 +563,12 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 			)
 		);
 
-		$result = Stats_Abilities::get_top_content( array( 'type' => 'countries', 'date' => '2026-04-23' ) );
+		$result = Stats_Abilities::get_top_content(
+			array(
+				'type' => 'countries',
+				'date' => '2026-04-23',
+			)
+		);
 
 		$this->assertSame( 'France', $result['items'][0]['label'] );
 		$this->assertSame( 'Germany', $result['items'][1]['label'] );
@@ -525,8 +579,14 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 			array(
 				'get_tags' => array(
 					'tags' => array(
-						array( 'tag' => 'news', 'views' => 40 ),
-						array( 'tag' => 'updates', 'views' => 15 ),
+						array(
+							'tag'   => 'news',
+							'views' => 40,
+						),
+						array(
+							'tag'   => 'updates',
+							'views' => 15,
+						),
 					),
 				),
 			)
@@ -546,9 +606,18 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 					'days' => array(
 						'2026-04-23' => array(
 							'postviews' => array(
-								array( 'title' => 'A', 'views' => 1 ),
-								array( 'title' => 'B', 'views' => 1 ),
-								array( 'title' => 'C', 'views' => 1 ),
+								array(
+									'title' => 'A',
+									'views' => 1,
+								),
+								array(
+									'title' => 'B',
+									'views' => 1,
+								),
+								array(
+									'title' => 'C',
+									'views' => 1,
+								),
 							),
 						),
 					),
@@ -556,7 +625,12 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 			)
 		);
 
-		$result = Stats_Abilities::get_top_content( array( 'type' => 'posts', 'max' => 2 ) );
+		$result = Stats_Abilities::get_top_content(
+			array(
+				'type' => 'posts',
+				'max'  => 2,
+			)
+		);
 
 		$this->assertCount( 2, $result['items'] );
 	}
@@ -572,8 +646,6 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 
 		$this->assertInstanceOf( \WP_Error::class, $result );
 	}
-
-	// ========== Execute: get-post-views ==========
 
 	public function test_get_post_views_rejects_missing_post_id(): void {
 		$result = Stats_Abilities::get_post_views( array() );
@@ -615,10 +687,14 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 		$this->assertSame( 7, $result['post_id'] );
 		$this->assertSame( 42, $result['total_views'] );
 		$this->assertCount( 2, $result['series'] );
-		$this->assertSame( array( 'date' => '2026-04-22', 'views' => 20 ), $result['series'][0] );
+		$this->assertSame(
+			array(
+				'date'  => '2026-04-22',
+				'views' => 20,
+			),
+			$result['series'][0]
+		);
 	}
-
-	// ========== Execute: get-visits ==========
 
 	public function test_get_visits_normalizes_series_rows(): void {
 		$this->filter_wpcom_stats(
@@ -633,11 +709,23 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 			)
 		);
 
-		$result = Stats_Abilities::get_visits( array( 'unit' => 'day', 'quantity' => 2 ) );
+		$result = Stats_Abilities::get_visits(
+			array(
+				'unit'     => 'day',
+				'quantity' => 2,
+			)
+		);
 
 		$this->assertSame( array( 'views', 'visitors' ), $result['fields'] );
 		$this->assertCount( 2, $result['series'] );
-		$this->assertSame( array( 'date' => '2026-04-22', 'views' => 100, 'visitors' => 70 ), $result['series'][0] );
+		$this->assertSame(
+			array(
+				'date'     => '2026-04-22',
+				'views'    => 100,
+				'visitors' => 70,
+			),
+			$result['series'][0]
+		);
 	}
 
 	public function test_get_visits_always_includes_requested_fields_even_when_missing_from_backing(): void {
@@ -658,17 +746,24 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 		$this->assertSame( 0, $result['series'][0]['likes'] );
 	}
 
-	// ========== Execute: get-followers ==========
-
 	public function test_get_followers_composes_three_subcalls(): void {
 		$this->filter_wpcom_stats(
 			array(
-				'get_followers'           => array( 'email' => 10, 'wpcom' => 25 ),
+				'get_followers'           => array(
+					'email' => 10,
+					'wpcom' => 25,
+				),
 				'get_comment_followers'   => array( 'total' => 4 ),
 				'get_publicize_followers' => array(
 					'services' => array(
-						array( 'service' => 'twitter', 'followers' => 300 ),
-						array( 'service' => 'facebook', 'followers' => 80 ),
+						array(
+							'service'   => 'twitter',
+							'followers' => 300,
+						),
+						array(
+							'service'   => 'facebook',
+							'followers' => 80,
+						),
 					),
 				),
 			)
@@ -679,7 +774,13 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 		$this->assertSame( 10, $result['email'] );
 		$this->assertSame( 25, $result['wpcom'] );
 		$this->assertSame( 4, $result['comment'] );
-		$this->assertSame( array( 'twitter' => 300, 'facebook' => 80 ), $result['publicize'] );
+		$this->assertSame(
+			array(
+				'twitter'  => 300,
+				'facebook' => 80,
+			),
+			$result['publicize']
+		);
 		$this->assertSame( 10 + 25 + 4 + 300 + 80, $result['total'] );
 		$this->assertFalse( $result['partial'] );
 	}
@@ -687,7 +788,10 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 	public function test_get_followers_flags_partial_on_subcall_error(): void {
 		$this->filter_wpcom_stats(
 			array(
-				'get_followers'           => array( 'email' => 5, 'wpcom' => 10 ),
+				'get_followers'           => array(
+					'email' => 5,
+					'wpcom' => 10,
+				),
 				'get_comment_followers'   => new \WP_Error( 'boom', 'bad' ),
 				'get_publicize_followers' => array( 'services' => array() ),
 			)
@@ -698,8 +802,6 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 		$this->assertTrue( $result['partial'] );
 		$this->assertContains( 'comment_followers', $result['errors'] );
 	}
-
-	// ========== Execute: get-stats-config ==========
 
 	public function test_get_stats_config_returns_whitelisted_fields_only(): void {
 		$result = Stats_Abilities::get_stats_config();
@@ -714,8 +816,6 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 		$this->assertArrayNotHasKey( 'version', $result );
 		$this->assertArrayNotHasKey( 'notices', $result );
 	}
-
-	// ========== Execute: set-stats-config ==========
 
 	public function test_set_stats_config_rejects_empty_input(): void {
 		$result = Stats_Abilities::set_stats_config( array() );
@@ -779,8 +879,6 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 			'set-stats-config must not blow away unrelated internal option keys.'
 		);
 	}
-
-	// ========== Helpers ==========
 
 	/**
 	 * Install a filter that makes the abilities class use a stubbed WPCOM_Stats.

--- a/projects/packages/stats/tests/php/abilities/Stats_Abilities_Test.php
+++ b/projects/packages/stats/tests/php/abilities/Stats_Abilities_Test.php
@@ -225,6 +225,13 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 		}
 	}
 
+	public function test_every_ability_opts_into_mcp_as_public_tool(): void {
+		foreach ( Stats_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertSame( true, $spec['meta']['mcp']['public'], "{$slug} must opt into MCP." );
+			$this->assertSame( 'tool', $spec['meta']['mcp']['type'], "{$slug} must be exposed as an MCP tool." );
+		}
+	}
+
 	public function test_set_stats_config_is_not_readonly_but_idempotent(): void {
 		$abilities = Stats_Abilities::get_abilities();
 		$ann       = $abilities['jetpack-stats/set-stats-config']['meta']['annotations'];

--- a/projects/packages/stats/tests/php/abilities/Stats_Abilities_Test.php
+++ b/projects/packages/stats/tests/php/abilities/Stats_Abilities_Test.php
@@ -134,19 +134,30 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 	}
 
 	/**
-	 * Simulate the `wp_abilities_api_categories_init` action having fired.
+	 * Run a callable while the given Abilities API lifecycle action appears to be firing.
+	 *
+	 * The Registrar guards its register_* methods with `doing_action()`. Pushing onto
+	 * `$wp_current_filter` simulates that the action is currently running; we always
+	 * pop the entry afterward so the simulated action doesn't leak into later tests
+	 * (which would corrupt `current_filter()` / `doing_action()` state).
+	 *
+	 * @param string   $action Action name to simulate.
+	 * @param callable $fn     Callable to run while the action is "firing".
 	 */
-	private function simulate_categories_init_fired(): void {
+	private function with_simulated_action( string $action, callable $fn ): void {
 		global $wp_current_filter;
-		$wp_current_filter[] = 'wp_abilities_api_categories_init';
-	}
-
-	/**
-	 * Simulate the `wp_abilities_api_init` action having fired.
-	 */
-	private function simulate_abilities_init_fired(): void {
-		global $wp_current_filter;
-		$wp_current_filter[] = 'wp_abilities_api_init';
+		$wp_current_filter[] = $action;
+		try {
+			$fn();
+		} finally {
+			// Defensive: pop only our own entry, in case the callback pushed/popped its own actions.
+			for ( $i = count( $wp_current_filter ) - 1; $i >= 0; $i-- ) {
+				if ( $wp_current_filter[ $i ] === $action ) {
+					array_splice( $wp_current_filter, $i, 1 );
+					break;
+				}
+			}
+		}
 	}
 
 	public function test_category_slug_is_jetpack_stats(): void {
@@ -275,11 +286,18 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 			$this->markTestSkipped( 'Abilities API not available.' );
 		}
 
-		$this->simulate_categories_init_fired();
-		Stats_Abilities::register_category();
-
-		$this->simulate_abilities_init_fired();
-		Stats_Abilities::register_abilities();
+		$this->with_simulated_action(
+			'wp_abilities_api_categories_init',
+			static function () {
+				Stats_Abilities::register_category();
+			}
+		);
+		$this->with_simulated_action(
+			'wp_abilities_api_init',
+			static function () {
+				Stats_Abilities::register_abilities();
+			}
+		);
 
 		foreach ( array_keys( Stats_Abilities::get_abilities() ) as $slug ) {
 			$this->assertTrue( wp_has_ability( $slug ), "Ability {$slug} should be registered." );
@@ -304,11 +322,18 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 			3
 		);
 
-		$this->simulate_categories_init_fired();
-		Stats_Abilities::register_category();
-
-		$this->simulate_abilities_init_fired();
-		Stats_Abilities::register_abilities();
+		$this->with_simulated_action(
+			'wp_abilities_api_categories_init',
+			static function () {
+				Stats_Abilities::register_category();
+			}
+		);
+		$this->with_simulated_action(
+			'wp_abilities_api_init',
+			static function () {
+				Stats_Abilities::register_abilities();
+			}
+		);
 
 		$this->assertTrue( wp_has_ability( 'jetpack-stats/get-site-overview' ) );
 		$this->assertFalse( wp_has_ability( 'jetpack-stats/get-top-content' ) );
@@ -647,6 +672,198 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 		$this->assertInstanceOf( \WP_Error::class, $result );
 	}
 
+	public function test_get_top_content_referrers_normalizes_groups_shape(): void {
+		// WPCOM `stats/referrers` keys per-day data under `groups` (NOT `referrers`),
+		// each with `name`/`total`/optional `url`. This regression-guards the mapping.
+		$this->filter_wpcom_stats(
+			array(
+				'get_referrers' => array(
+					'days' => array(
+						'2026-04-23' => array(
+							'groups' => array(
+								array(
+									'name'  => 'wordpress.com',
+									'url'   => 'https://wordpress.com',
+									'total' => 60,
+								),
+								array(
+									'name'  => 'Search Engines',
+									'total' => 25,
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$result = Stats_Abilities::get_top_content(
+			array(
+				'type' => 'referrers',
+				'date' => '2026-04-23',
+			)
+		);
+
+		$this->assertSame( 'referrers', $result['type'] );
+		$this->assertCount( 2, $result['items'] );
+		$this->assertSame( 'wordpress.com', $result['items'][0]['label'] );
+		$this->assertSame( 60, $result['items'][0]['value'] );
+		$this->assertSame( 'https://wordpress.com', $result['items'][0]['href'] );
+		$this->assertSame( 'Search Engines', $result['items'][1]['label'] );
+		$this->assertSame( 25, $result['items'][1]['value'] );
+		// Groups without a `url` must omit `href` rather than emit an empty string.
+		$this->assertArrayNotHasKey( 'href', $result['items'][1] );
+	}
+
+	public function test_get_top_content_clicks_uniform_shape(): void {
+		$this->filter_wpcom_stats(
+			array(
+				'get_clicks' => array(
+					'days' => array(
+						'2026-04-23' => array(
+							'clicks' => array(
+								array(
+									'name'  => 'Docs',
+									'url'   => 'https://docs.example/x',
+									'views' => 9,
+								),
+								array(
+									// No `name` — normalization should fall back to `url`.
+									'url'   => 'https://example.com/y',
+									'views' => 3,
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$result = Stats_Abilities::get_top_content(
+			array(
+				'type' => 'clicks',
+				'date' => '2026-04-23',
+			)
+		);
+
+		$this->assertSame( 'clicks', $result['type'] );
+		$this->assertCount( 2, $result['items'] );
+		$this->assertSame( 'Docs', $result['items'][0]['label'] );
+		$this->assertSame( 9, $result['items'][0]['value'] );
+		$this->assertSame( 'https://docs.example/x', $result['items'][0]['href'] );
+		$this->assertSame( 'https://example.com/y', $result['items'][1]['label'] );
+		$this->assertSame( 'https://example.com/y', $result['items'][1]['href'] );
+	}
+
+	public function test_get_top_content_authors_uniform_shape(): void {
+		$this->filter_wpcom_stats(
+			array(
+				'get_top_authors' => array(
+					'days' => array(
+						'2026-04-23' => array(
+							'authors' => array(
+								array(
+									'name'  => 'Ada',
+									'views' => 80,
+								),
+								array(
+									'name'  => 'Grace',
+									'views' => 30,
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$result = Stats_Abilities::get_top_content(
+			array(
+				'type' => 'authors',
+				'date' => '2026-04-23',
+			)
+		);
+
+		$this->assertCount( 2, $result['items'] );
+		$this->assertSame( 'Ada', $result['items'][0]['label'] );
+		$this->assertSame( 80, $result['items'][0]['value'] );
+		$this->assertArrayNotHasKey( 'href', $result['items'][0] );
+	}
+
+	public function test_get_top_content_downloads_uniform_shape(): void {
+		$this->filter_wpcom_stats(
+			array(
+				'get_file_downloads' => array(
+					'days' => array(
+						'2026-04-23' => array(
+							'files' => array(
+								array(
+									'filename'       => 'whitepaper.pdf',
+									'relative_url'   => '/downloads/whitepaper.pdf',
+									'download_count' => 42,
+								),
+								array(
+									// No `filename` — normalization should fall back to relative_url.
+									'relative_url'   => '/downloads/spec.zip',
+									'download_count' => 7,
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$result = Stats_Abilities::get_top_content(
+			array(
+				'type' => 'downloads',
+				'date' => '2026-04-23',
+			)
+		);
+
+		$this->assertCount( 2, $result['items'] );
+		$this->assertSame( 'whitepaper.pdf', $result['items'][0]['label'] );
+		$this->assertSame( 42, $result['items'][0]['value'] );
+		$this->assertSame( '/downloads/whitepaper.pdf', $result['items'][0]['href'] );
+		$this->assertSame( '/downloads/spec.zip', $result['items'][1]['label'] );
+		$this->assertSame( '/downloads/spec.zip', $result['items'][1]['href'] );
+	}
+
+	public function test_get_top_content_video_plays_uniform_shape(): void {
+		$this->filter_wpcom_stats(
+			array(
+				'get_video_plays' => array(
+					'days' => array(
+						'2026-04-23' => array(
+							'plays' => array(
+								array(
+									'title' => 'Launch demo',
+									'plays' => 200,
+								),
+								array(
+									'title' => 'Tutorial',
+									'plays' => 75,
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$result = Stats_Abilities::get_top_content(
+			array(
+				'type' => 'video-plays',
+				'date' => '2026-04-23',
+			)
+		);
+
+		$this->assertCount( 2, $result['items'] );
+		$this->assertSame( 'Launch demo', $result['items'][0]['label'] );
+		$this->assertSame( 200, $result['items'][0]['value'] );
+		$this->assertArrayNotHasKey( 'href', $result['items'][0] );
+	}
+
 	public function test_get_post_views_rejects_missing_post_id(): void {
 		$result = Stats_Abilities::get_post_views( array() );
 		$this->assertInstanceOf( \WP_Error::class, $result );
@@ -827,6 +1044,15 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 		$result = Stats_Abilities::set_stats_config( array( 'roles' => array( 'robot' ) ) );
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'jetpack_stats_invalid_role', $result->get_error_code() );
+	}
+
+	public function test_set_stats_config_rejects_empty_roles_to_prevent_lockout(): void {
+		// Schema validation enforces minItems=1 on REST input, but direct PHP callers bypass
+		// that path; an empty `roles` array would revoke `view_stats` for every user, including
+		// the caller. Reject explicitly.
+		$result = Stats_Abilities::set_stats_config( array( 'roles' => array() ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_stats_invalid_roles', $result->get_error_code() );
 	}
 
 	public function test_set_stats_config_changes_admin_bar(): void {

--- a/projects/packages/stats/tests/php/abilities/Stats_Abilities_Test.php
+++ b/projects/packages/stats/tests/php/abilities/Stats_Abilities_Test.php
@@ -1006,6 +1006,19 @@ class Stats_Abilities_Test extends StatsBaseTestCase {
 		$this->assertArrayNotHasKey( 'notices', $result );
 	}
 
+	public function test_get_stats_config_classifies_types_from_options_defaults(): void {
+		// Regression guard: the snapshot derives bool/array typing from
+		// Options::get_defaults() rather than a duplicated allow-list, so a new
+		// option type added in Options must propagate here without code changes.
+		$result = Stats_Abilities::get_stats_config();
+
+		$this->assertIsBool( $result['admin_bar'] );
+		$this->assertIsBool( $result['do_not_track'] );
+		$this->assertIsBool( $result['enable_odyssey_stats'] );
+		$this->assertIsArray( $result['roles'] );
+		$this->assertIsArray( $result['count_roles'] );
+	}
+
 	public function test_set_stats_config_rejects_empty_input(): void {
 		$result = Stats_Abilities::set_stats_config( array() );
 		$this->assertInstanceOf( \WP_Error::class, $result );

--- a/projects/plugins/jetpack/changelog/add-ship-stats-abilities
+++ b/projects/plugins/jetpack/changelog/add-ship-stats-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Add stats abilities

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -3049,12 +3049,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats",
-                "reference": "21404943feba5a6e1b57197aa3df02cee0b413fe"
+                "reference": "927d43834de1e46b37cfba8bba95f4ddd7edf251"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-constants": "@dev",
                 "automattic/jetpack-status": "@dev",
+                "automattic/jetpack-wp-abilities": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-ship-stats-abilities
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-ship-stats-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add stats wp abbilities

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cb604d11abbeff7a486a2a15be7837c6",
+    "content-hash": "b75cc6cc6217dbca51f8bee7af4e35e7",
     "packages": [
         {
             "name": "automattic/block-delimiter",
@@ -12,13 +12,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/block-delimiter",
-                "reference": "38b17cad3ac0259b1358356beb4744d6ca606488"
+                "reference": "65f01ae1ff7636fd52709a61c203756ab190d7e3"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -76,13 +75,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/a8c-mc-stats",
-                "reference": "68b92cc77ac41309dbf2f7a16eecd4e0c9cb03a9"
+                "reference": "4877940876f9da0f0a796d37814f591f2392b748"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -130,7 +128,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "7b96f52e31ef50047c34a7f27870bd1c52f36787"
+                "reference": "36bf27e8bb95ad8b98897a3f0be80deffbe850b6"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -138,7 +136,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-logo": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
@@ -208,7 +205,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "116afa785e69beb00f93503b12e0b0f4a0753ebb"
+                "reference": "a4c3991ea97f5705663221c8ebff9758b46fd683"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -216,7 +213,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
@@ -279,7 +275,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/blaze",
-                "reference": "441a3689be7e956db950f27520952b81a249fedd"
+                "reference": "f600123b4b3ab650ab4f927971069b83f52d8ef6"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -292,7 +288,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -355,14 +350,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/blocks",
-                "reference": "34625c73a31fc7c9566591dc38d4ec3ef18c78b1"
+                "reference": "3a5646bd6d55bbc1a27880efe63dabe2ca208c6d"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
@@ -412,7 +406,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/classic-theme-helper",
-                "reference": "2a0ad5d46ab475954e8ec3d2d633234c06316b91"
+                "reference": "59ad12b263b6ca34f09350ba9547d5ff381a11d4"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -421,7 +415,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -479,13 +472,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/compat",
-                "reference": "f344c74fa490eee8870adf5cbf68c6a841c1e2ee"
+                "reference": "cca3c26e1aa14e6cfe16ed55099dd1fc39362778"
             },
             "require": {
                 "php": ">=7.2"
-            },
-            "require-dev": {
-                "automattic/jetpack-changelogger": "@dev"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -516,14 +506,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer-plugin",
-                "reference": "eb028c7425d0591689e2a0b3047c278d8ff2395e"
+                "reference": "5757fcdb855bc654b788aa1d75b3442e068c83ee"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -577,7 +566,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "f43150bda979c1855db4ab23655bf26d12e75786"
+                "reference": "37cff8191289fa89742688ce970f25f702cb6ba8"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -590,7 +579,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-licensing": "@dev",
                 "automattic/jetpack-sync": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
@@ -664,13 +652,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/constants",
-                "reference": "378a5d122aedfc25d3aa42ab913803c85a8c857b"
+                "reference": "95cc69c8b39c9bc26cc430988a7de1297a654324"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -719,13 +706,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "40cbfeb8412019423305cb3d071d1cd8ec5fccc3"
+                "reference": "b9aac1ae0b83275be407fad1ddd02a390bf68494"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -773,14 +759,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/explat",
-                "reference": "1da7eabd28e234c67a03fc7bff5760b383a0d91d"
+                "reference": "cd4e942a9037ee10214454b5ab621d9ff29141d6"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -849,14 +834,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/google-analytics",
-                "reference": "28cb18c8c47204ca7b0217f7c4b02527a8fd873f"
+                "reference": "0bbac6ede0742d16be602fcdfd70e47580935449"
             },
             "require": {
                 "automattic/jetpack-status": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -915,7 +899,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/image-cdn",
-                "reference": "79b4ce2978edf4a5f586ceab9c2058a6cfcbef94"
+                "reference": "a56b0996e0af0641be4ab5a487fe24ed39fb20e5"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -923,7 +907,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -976,13 +959,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/ip",
-                "reference": "4c8f48266f1fe2551103c6293e2957e185f87a94"
+                "reference": "edf860f4e7e7096f7abfdc4083762c75ca7e64fb"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1035,7 +1017,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "9236be3cd8bc85e4bfe49110ae26a78d7195c5f9"
+                "reference": "9bd15c67655ee061b5041261b7f1fbfeb228d3e1"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -1048,7 +1030,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1111,13 +1092,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/logo",
-                "reference": "ffa8535e2da982620164c7a251f0b2fbe46d3f16"
+                "reference": "340235b11e6729a362dcf53389a72c52b590a3ff"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -1165,7 +1145,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/masterbar",
-                "reference": "713257694eab74ca2b21290a99ac6cc1ffb392e1"
+                "reference": "7838d67127972c359395f6ff63f5c328a192b44f"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1181,7 +1161,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/patchwork-redefine-exit": "@dev",
                 "automattic/phpunit-select-config": "@dev",
@@ -1248,7 +1227,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "ccc0a533c472ed92f9b43addc2681eb33e536359"
+                "reference": "8ccf42e3bb801d5edfc343c3648afe1976f7d6fc"
             },
             "require": {
                 "automattic/block-delimiter": "@dev",
@@ -1272,7 +1251,6 @@
                 "symfony/filesystem": "^6.0.0"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
@@ -1336,7 +1314,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/newsletter",
-                "reference": "405b39959d548729a98d187391cb940e7fca500c"
+                "reference": "8d9bb031a70efedb0d178e6c596dd487e80cca35"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1348,7 +1326,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1415,13 +1392,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/password-checker",
-                "reference": "33cc919e4b75e07ed12975588c42ae2ea723a9a4"
+                "reference": "48727ad4c6f29f009ac074465e36d4d387e3f82e"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1471,14 +1447,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "26f4ed44e15ea1e285b6b80870c7b8f3da56e9f8"
+                "reference": "ef664f6fcfde0b888d66e6f3d9893daeb4fa75a0"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
@@ -1534,7 +1509,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/post-media",
-                "reference": "28b5f5b5b8ca9858e6c5ce23a4e852c756713960"
+                "reference": "6b1f642a168a1de8765232161d31001fbcea62eb"
             },
             "require": {
                 "automattic/block-delimiter": "@dev",
@@ -1543,7 +1518,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1602,14 +1576,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/redirect",
-                "reference": "44d6ec93e4d3b3db6287bf82f316a294d7ef868d"
+                "reference": "eff84ae54899356e87f28a2afe89745e26411ee7"
             },
             "require": {
                 "automattic/jetpack-status": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1658,13 +1631,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/roles",
-                "reference": "f7098eb11833c5fddfff032427d8576039aa3521"
+                "reference": "ae54f8dc58bd6bd7e82cf661afe5f2e8951cdd0c"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1713,7 +1685,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/rtc",
-                "reference": "e8f440cdd4bedae187d26ee2c873bc9b52a88a66"
+                "reference": "8aef1a19335f20d685a42cf862a96c38ba3b34ec"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1721,7 +1693,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1780,7 +1751,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats",
-                "reference": "089d88f8d263d41a36963e33c5d6330c0b0841a2"
+                "reference": "927d43834de1e46b37cfba8bba95f4ddd7edf251"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1790,7 +1761,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1848,7 +1818,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "d3cc7e7297df5dafcd3640b17e26ec24623f5096"
+                "reference": "c886544c38d3fd36c7120099a9c0b85d9776f416"
             },
             "require": {
                 "automattic/jetpack-blaze": "@dev",
@@ -1861,7 +1831,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1917,14 +1886,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "8ce7c4c3d0a7c4ec9fce7b3002ba635afd5bc952"
+                "reference": "76cc443bfab1ccafe0e07fc050735bb33341f5a5"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-ip": "@dev",
                 "automattic/jetpack-plans": "@dev",
@@ -1982,7 +1950,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/subscribers-dashboard",
-                "reference": "d7a821c0f511c388a71049050807f4a1b56e9503"
+                "reference": "66832602601278e0202880bef8da1a396d34fa45"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1994,7 +1962,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -2061,7 +2028,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "39ff3d14b536ba6a0f501d28d436dcea93ce6857"
+                "reference": "946cdc6936bc54e9b5d22f0129003c0f9c9e475b"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -2073,7 +2040,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-search": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/jetpack-waf": "@dev",
@@ -2134,13 +2100,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/wp-abilities",
-                "reference": "d38d63604cbefe504f12a74a956502a648fdf521"
+                "reference": "e71e43ab54aaf244b0cb2e29999da393164021f5"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -2193,7 +2158,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/scheduled-updates",
-                "reference": "3f52602bf5f9547ed9d5081beac4660a8887dcfb"
+                "reference": "0fb9f0f3c89bc6c9e00a502220847efe72c1513a"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -2204,7 +2169,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -2918,96 +2882,12 @@
     ],
     "packages-dev": [
         {
-            "name": "automattic/jetpack-changelogger",
-            "version": "dev-trunk",
-            "dist": {
-                "type": "path",
-                "url": "../../packages/changelogger",
-                "reference": "b5353c88e04d5fae32ee501b1a0a4234ee968e56"
-            },
-            "require": {
-                "composer-runtime-api": "^2.2.0",
-                "php": ">=7.2.5",
-                "symfony/console": "^5.4 || ^6.4 || ^7.1",
-                "symfony/process": "^5.4 || ^6.4 || ^7.1"
-            },
-            "require-dev": {
-                "automattic/phpunit-select-config": "@dev",
-                "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-                "yoast/phpunit-polyfills": "^4.0.0"
-            },
-            "bin": [
-                "bin/changelogger"
-            ],
-            "type": "project",
-            "extra": {
-                "autotagger": true,
-                "branch-alias": {
-                    "dev-trunk": "6.0.x-dev"
-                },
-                "mirror-repo": "Automattic/jetpack-changelogger",
-                "version-constants": {
-                    "::VERSION": "src/Application.php"
-                },
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-changelogger/compare/${old}...${new}"
-                },
-                "dependencies": {
-                    "test-only": [
-                        "packages/phpunit-select-config"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\Changelogger\\": "src",
-                    "Automattic\\Jetpack\\Changelog\\": "lib"
-                }
-            },
-            "autoload-dev": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\Changelogger\\Tests\\": "tests/php/includes/src",
-                    "Automattic\\Jetpack\\Changelog\\Tests\\": "tests/php/includes/lib"
-                }
-            },
-            "scripts": {
-                "phpunit": [
-                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
-                ],
-                "test-coverage": [
-                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
-                ],
-                "test-php": [
-                    "@composer phpunit"
-                ],
-                "post-install-cmd": [
-                    "rm -f vendor/bin/changelogger && ln -s ../../bin/local-changelogger vendor/bin/changelogger"
-                ],
-                "post-update-cmd": [
-                    "rm -f vendor/bin/changelogger && ln -s ../../bin/local-changelogger vendor/bin/changelogger"
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Jetpack Changelogger tool. Allows for managing changelogs by dropping change files into a changelog directory with each PR.",
-            "keywords": [
-                "changelog",
-                "cli",
-                "dev",
-                "keepachangelog"
-            ],
-            "transport-options": {
-                "relative": true
-            }
-        },
-        {
             "name": "automattic/phpunit-select-config",
             "version": "dev-trunk",
             "dist": {
                 "type": "path",
                 "url": "../../packages/phpunit-select-config",
-                "reference": "3f16352a5a43bdd583b78d895d092a1e1b74c397"
+                "reference": "9e44d830cefeebc6c9b5a108cfab1ac3c1e3fd98"
             },
             "require": {
                 "composer-runtime-api": "^2.2.2",
@@ -3016,7 +2896,6 @@
             },
             "require-dev": {
                 "antecedent/patchwork": "^2.2",
-                "automattic/jetpack-changelogger": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
@@ -3733,59 +3612,6 @@
                 }
             ],
             "time": "2026-04-13T05:38:19+00:00"
-        },
-        {
-            "name": "psr/container",
-            "version": "2.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/container.git",
-                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
-                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Container\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common Container Interface (PHP FIG PSR-11)",
-            "homepage": "https://github.com/php-fig/container",
-            "keywords": [
-                "PSR-11",
-                "container",
-                "container-interface",
-                "container-interop",
-                "psr"
-            ],
-            "support": {
-                "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/2.0.2"
-            },
-            "time": "2021-11-05T16:47:00+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -4737,580 +4563,6 @@
             "time": "2024-10-20T05:08:20+00:00"
         },
         {
-            "name": "symfony/console",
-            "version": "v7.4.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/console.git",
-                "reference": "1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707",
-                "reference": "1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/service-contracts": "^2.5|^3",
-                "symfony/string": "^7.2|^8.0"
-            },
-            "conflict": {
-                "symfony/dependency-injection": "<6.4",
-                "symfony/dotenv": "<6.4",
-                "symfony/event-dispatcher": "<6.4",
-                "symfony/lock": "<6.4",
-                "symfony/process": "<6.4"
-            },
-            "provide": {
-                "psr/log-implementation": "1.0|2.0|3.0"
-            },
-            "require-dev": {
-                "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
-                "symfony/http-foundation": "^6.4|^7.0|^8.0",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0",
-                "symfony/lock": "^6.4|^7.0|^8.0",
-                "symfony/messenger": "^6.4|^7.0|^8.0",
-                "symfony/process": "^6.4|^7.0|^8.0",
-                "symfony/stopwatch": "^6.4|^7.0|^8.0",
-                "symfony/var-dumper": "^6.4|^7.0|^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Console\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Eases the creation of beautiful and testable command line interfaces",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "cli",
-                "command-line",
-                "console",
-                "terminal"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.8"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-03-30T13:54:39+00:00"
-        },
-        {
-            "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/contracts",
-                    "name": "symfony/contracts"
-                },
-                "branch-alias": {
-                    "dev-main": "3.6-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "function.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "A generic function and convention to trigger deprecation notices",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-09-25T14:21:43+00:00"
-        },
-        {
-            "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.34.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "ad1b7b9092976d6c948b8a187cec9faaea9ec1df"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/ad1b7b9092976d6c948b8a187cec9faaea9ec1df",
-                "reference": "ad1b7b9092976d6c948b8a187cec9faaea9ec1df",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "suggest": {
-                "ext-intl": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for intl's grapheme_* functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "grapheme",
-                "intl",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.34.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-04-10T16:19:22+00:00"
-        },
-        {
-            "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.34.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "suggest": {
-                "ext-intl": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for intl's Normalizer class and related functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "intl",
-                "normalizer",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.34.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-09-09T11:45:10+00:00"
-        },
-        {
-            "name": "symfony/process",
-            "version": "v7.4.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/60f19cd3badc8de688421e21e4305eba50f8089a",
-                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Process\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Executes commands in sub-processes",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/process/tree/v7.4.8"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-03-24T13:12:05+00:00"
-        },
-        {
-            "name": "symfony/service-contracts",
-            "version": "v3.6.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "psr/container": "^1.1|^2.0",
-                "symfony/deprecation-contracts": "^2.5|^3"
-            },
-            "conflict": {
-                "ext-psr": "<1.1|>=2"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/contracts",
-                    "name": "symfony/contracts"
-                },
-                "branch-alias": {
-                    "dev-main": "3.6-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Contracts\\Service\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Test/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Generic abstractions related to writing services",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "abstractions",
-                "contracts",
-                "decoupling",
-                "interfaces",
-                "interoperability",
-                "standards"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-07-15T11:30:57+00:00"
-        },
-        {
-            "name": "symfony/string",
-            "version": "v8.0.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/string.git",
-                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/ae9488f874d7603f9d2dfbf120203882b645d963",
-                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.4",
-                "symfony/polyfill-ctype": "^1.8",
-                "symfony/polyfill-intl-grapheme": "^1.33",
-                "symfony/polyfill-intl-normalizer": "^1.0",
-                "symfony/polyfill-mbstring": "^1.0"
-            },
-            "conflict": {
-                "symfony/translation-contracts": "<2.5"
-            },
-            "require-dev": {
-                "symfony/emoji": "^7.4|^8.0",
-                "symfony/http-client": "^7.4|^8.0",
-                "symfony/intl": "^7.4|^8.0",
-                "symfony/translation-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^7.4|^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "Resources/functions.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Component\\String\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "grapheme",
-                "i18n",
-                "string",
-                "unicode",
-                "utf-8",
-                "utf8"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/string/tree/v8.0.8"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-03-30T15:14:47+00:00"
-        },
-        {
             "name": "theseer/tokenizer",
             "version": "2.0.1",
             "source": {
@@ -5427,7 +4679,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "automattic/jetpack-changelogger": 20,
         "automattic/jetpack-composer-plugin": 20,
         "automattic/jetpack-mu-wpcom": 20,
         "automattic/phpunit-select-config": 20

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b75cc6cc6217dbca51f8bee7af4e35e7",
+    "content-hash": "cb604d11abbeff7a486a2a15be7837c6",
     "packages": [
         {
             "name": "automattic/block-delimiter",
@@ -12,12 +12,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/block-delimiter",
-                "reference": "65f01ae1ff7636fd52709a61c203756ab190d7e3"
+                "reference": "38b17cad3ac0259b1358356beb4744d6ca606488"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -75,12 +76,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/a8c-mc-stats",
-                "reference": "4877940876f9da0f0a796d37814f591f2392b748"
+                "reference": "68b92cc77ac41309dbf2f7a16eecd4e0c9cb03a9"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -128,7 +130,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "36bf27e8bb95ad8b98897a3f0be80deffbe850b6"
+                "reference": "7b96f52e31ef50047c34a7f27870bd1c52f36787"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -136,6 +138,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-logo": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
@@ -205,7 +208,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "a4c3991ea97f5705663221c8ebff9758b46fd683"
+                "reference": "116afa785e69beb00f93503b12e0b0f4a0753ebb"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -213,6 +216,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
@@ -275,7 +279,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/blaze",
-                "reference": "f600123b4b3ab650ab4f927971069b83f52d8ef6"
+                "reference": "441a3689be7e956db950f27520952b81a249fedd"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -288,6 +292,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -350,13 +355,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/blocks",
-                "reference": "3a5646bd6d55bbc1a27880efe63dabe2ca208c6d"
+                "reference": "34625c73a31fc7c9566591dc38d4ec3ef18c78b1"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
@@ -406,7 +412,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/classic-theme-helper",
-                "reference": "59ad12b263b6ca34f09350ba9547d5ff381a11d4"
+                "reference": "2a0ad5d46ab475954e8ec3d2d633234c06316b91"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -415,6 +421,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -472,10 +479,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/compat",
-                "reference": "cca3c26e1aa14e6cfe16ed55099dd1fc39362778"
+                "reference": "f344c74fa490eee8870adf5cbf68c6a841c1e2ee"
             },
             "require": {
                 "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -506,13 +516,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer-plugin",
-                "reference": "5757fcdb855bc654b788aa1d75b3442e068c83ee"
+                "reference": "eb028c7425d0591689e2a0b3047c278d8ff2395e"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -566,7 +577,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "37cff8191289fa89742688ce970f25f702cb6ba8"
+                "reference": "f43150bda979c1855db4ab23655bf26d12e75786"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -579,6 +590,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-licensing": "@dev",
                 "automattic/jetpack-sync": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
@@ -652,12 +664,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/constants",
-                "reference": "95cc69c8b39c9bc26cc430988a7de1297a654324"
+                "reference": "378a5d122aedfc25d3aa42ab913803c85a8c857b"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -706,12 +719,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "b9aac1ae0b83275be407fad1ddd02a390bf68494"
+                "reference": "40cbfeb8412019423305cb3d071d1cd8ec5fccc3"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -759,13 +773,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/explat",
-                "reference": "cd4e942a9037ee10214454b5ab621d9ff29141d6"
+                "reference": "1da7eabd28e234c67a03fc7bff5760b383a0d91d"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -834,13 +849,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/google-analytics",
-                "reference": "0bbac6ede0742d16be602fcdfd70e47580935449"
+                "reference": "28cb18c8c47204ca7b0217f7c4b02527a8fd873f"
             },
             "require": {
                 "automattic/jetpack-status": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -899,7 +915,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/image-cdn",
-                "reference": "a56b0996e0af0641be4ab5a487fe24ed39fb20e5"
+                "reference": "79b4ce2978edf4a5f586ceab9c2058a6cfcbef94"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -907,6 +923,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -959,12 +976,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/ip",
-                "reference": "edf860f4e7e7096f7abfdc4083762c75ca7e64fb"
+                "reference": "4c8f48266f1fe2551103c6293e2957e185f87a94"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1017,7 +1035,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "9bd15c67655ee061b5041261b7f1fbfeb228d3e1"
+                "reference": "9236be3cd8bc85e4bfe49110ae26a78d7195c5f9"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -1030,6 +1048,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1092,12 +1111,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/logo",
-                "reference": "340235b11e6729a362dcf53389a72c52b590a3ff"
+                "reference": "ffa8535e2da982620164c7a251f0b2fbe46d3f16"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -1145,7 +1165,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/masterbar",
-                "reference": "7838d67127972c359395f6ff63f5c328a192b44f"
+                "reference": "713257694eab74ca2b21290a99ac6cc1ffb392e1"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1161,6 +1181,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/patchwork-redefine-exit": "@dev",
                 "automattic/phpunit-select-config": "@dev",
@@ -1227,7 +1248,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "8ccf42e3bb801d5edfc343c3648afe1976f7d6fc"
+                "reference": "ccc0a533c472ed92f9b43addc2681eb33e536359"
             },
             "require": {
                 "automattic/block-delimiter": "@dev",
@@ -1251,6 +1272,7 @@
                 "symfony/filesystem": "^6.0.0"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
@@ -1314,7 +1336,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/newsletter",
-                "reference": "8d9bb031a70efedb0d178e6c596dd487e80cca35"
+                "reference": "405b39959d548729a98d187391cb940e7fca500c"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1326,6 +1348,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1392,12 +1415,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/password-checker",
-                "reference": "48727ad4c6f29f009ac074465e36d4d387e3f82e"
+                "reference": "33cc919e4b75e07ed12975588c42ae2ea723a9a4"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1447,13 +1471,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "ef664f6fcfde0b888d66e6f3d9893daeb4fa75a0"
+                "reference": "26f4ed44e15ea1e285b6b80870c7b8f3da56e9f8"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
@@ -1509,7 +1534,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/post-media",
-                "reference": "6b1f642a168a1de8765232161d31001fbcea62eb"
+                "reference": "28b5f5b5b8ca9858e6c5ce23a4e852c756713960"
             },
             "require": {
                 "automattic/block-delimiter": "@dev",
@@ -1518,6 +1543,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1576,13 +1602,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/redirect",
-                "reference": "eff84ae54899356e87f28a2afe89745e26411ee7"
+                "reference": "44d6ec93e4d3b3db6287bf82f316a294d7ef868d"
             },
             "require": {
                 "automattic/jetpack-status": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1631,12 +1658,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/roles",
-                "reference": "ae54f8dc58bd6bd7e82cf661afe5f2e8951cdd0c"
+                "reference": "f7098eb11833c5fddfff032427d8576039aa3521"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1685,7 +1713,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/rtc",
-                "reference": "8aef1a19335f20d685a42cf862a96c38ba3b34ec"
+                "reference": "e8f440cdd4bedae187d26ee2c873bc9b52a88a66"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1693,6 +1721,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1751,15 +1780,17 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats",
-                "reference": "21404943feba5a6e1b57197aa3df02cee0b413fe"
+                "reference": "089d88f8d263d41a36963e33c5d6330c0b0841a2"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-constants": "@dev",
                 "automattic/jetpack-status": "@dev",
+                "automattic/jetpack-wp-abilities": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1817,7 +1848,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "c886544c38d3fd36c7120099a9c0b85d9776f416"
+                "reference": "d3cc7e7297df5dafcd3640b17e26ec24623f5096"
             },
             "require": {
                 "automattic/jetpack-blaze": "@dev",
@@ -1830,6 +1861,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1885,13 +1917,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "76cc443bfab1ccafe0e07fc050735bb33341f5a5"
+                "reference": "8ce7c4c3d0a7c4ec9fce7b3002ba635afd5bc952"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-ip": "@dev",
                 "automattic/jetpack-plans": "@dev",
@@ -1949,7 +1982,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/subscribers-dashboard",
-                "reference": "66832602601278e0202880bef8da1a396d34fa45"
+                "reference": "d7a821c0f511c388a71049050807f4a1b56e9503"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1961,6 +1994,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -2027,7 +2061,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "946cdc6936bc54e9b5d22f0129003c0f9c9e475b"
+                "reference": "39ff3d14b536ba6a0f501d28d436dcea93ce6857"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -2039,6 +2073,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-search": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/jetpack-waf": "@dev",
@@ -2094,12 +2129,71 @@
             }
         },
         {
+            "name": "automattic/jetpack-wp-abilities",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/wp-abilities",
+                "reference": "d38d63604cbefe504f12a74a956502a648fdf521"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "brain/monkey": "^2.6.2",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-wp-abilities",
+                "changelogger": {
+                    "link-template": "https://github.com/automattic/jetpack-wp-abilities/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                },
+                "textdomain": "jetpack-wp-abilities",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-registrar.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Shared utilities for registering abilities with the WordPress Abilities API from Jetpack packages and plugins.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "automattic/scheduled-updates",
             "version": "dev-trunk",
             "dist": {
                 "type": "path",
                 "url": "../../packages/scheduled-updates",
-                "reference": "0fb9f0f3c89bc6c9e00a502220847efe72c1513a"
+                "reference": "3f52602bf5f9547ed9d5081beac4660a8887dcfb"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -2110,6 +2204,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -2823,12 +2918,96 @@
     ],
     "packages-dev": [
         {
+            "name": "automattic/jetpack-changelogger",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/changelogger",
+                "reference": "b5353c88e04d5fae32ee501b1a0a4234ee968e56"
+            },
+            "require": {
+                "composer-runtime-api": "^2.2.0",
+                "php": ">=7.2.5",
+                "symfony/console": "^5.4 || ^6.4 || ^7.1",
+                "symfony/process": "^5.4 || ^6.4 || ^7.1"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "bin": [
+                "bin/changelogger"
+            ],
+            "type": "project",
+            "extra": {
+                "autotagger": true,
+                "branch-alias": {
+                    "dev-trunk": "6.0.x-dev"
+                },
+                "mirror-repo": "Automattic/jetpack-changelogger",
+                "version-constants": {
+                    "::VERSION": "src/Application.php"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-changelogger/compare/${old}...${new}"
+                },
+                "dependencies": {
+                    "test-only": [
+                        "packages/phpunit-select-config"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Automattic\\Jetpack\\Changelogger\\": "src",
+                    "Automattic\\Jetpack\\Changelog\\": "lib"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Automattic\\Jetpack\\Changelogger\\Tests\\": "tests/php/includes/src",
+                    "Automattic\\Jetpack\\Changelog\\Tests\\": "tests/php/includes/lib"
+                }
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "post-install-cmd": [
+                    "rm -f vendor/bin/changelogger && ln -s ../../bin/local-changelogger vendor/bin/changelogger"
+                ],
+                "post-update-cmd": [
+                    "rm -f vendor/bin/changelogger && ln -s ../../bin/local-changelogger vendor/bin/changelogger"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Jetpack Changelogger tool. Allows for managing changelogs by dropping change files into a changelog directory with each PR.",
+            "keywords": [
+                "changelog",
+                "cli",
+                "dev",
+                "keepachangelog"
+            ],
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "automattic/phpunit-select-config",
             "version": "dev-trunk",
             "dist": {
                 "type": "path",
                 "url": "../../packages/phpunit-select-config",
-                "reference": "9e44d830cefeebc6c9b5a108cfab1ac3c1e3fd98"
+                "reference": "3f16352a5a43bdd583b78d895d092a1e1b74c397"
             },
             "require": {
                 "composer-runtime-api": "^2.2.2",
@@ -2837,6 +3016,7 @@
             },
             "require-dev": {
                 "antecedent/patchwork": "^2.2",
+                "automattic/jetpack-changelogger": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
@@ -3553,6 +3733,59 @@
                 }
             ],
             "time": "2026-04-13T05:38:19+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
+            },
+            "time": "2021-11-05T16:47:00+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -4504,6 +4737,580 @@
             "time": "2024-10-20T05:08:20+00:00"
         },
         {
+            "name": "symfony/console",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707",
+                "reference": "1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/string": "^7.2|^8.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<6.4",
+                "symfony/dotenv": "<6.4",
+                "symfony/event-dispatcher": "<6.4",
+                "symfony/lock": "<6.4",
+                "symfony/process": "<6.4"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0|2.0|3.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/lock": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/stopwatch": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Eases the creation of beautiful and testable command line interfaces",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "cli",
+                "command-line",
+                "console",
+                "terminal"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-30T13:54:39+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:21:43+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.34.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "ad1b7b9092976d6c948b8a187cec9faaea9ec1df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/ad1b7b9092976d6c948b8a187cec9faaea9ec1df",
+                "reference": "ad1b7b9092976d6c948b8a187cec9faaea9ec1df",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.34.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.34.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.34.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/60f19cd3badc8de688421e21e4305eba50f8089a",
+                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Executes commands in sub-processes",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v3.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-15T11:30:57+00:00"
+        },
+        {
+            "name": "symfony/string",
+            "version": "v8.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/string.git",
+                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/string/zipball/ae9488f874d7603f9d2dfbf120203882b645d963",
+                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-intl-grapheme": "^1.33",
+                "symfony/polyfill-intl-normalizer": "^1.0",
+                "symfony/polyfill-mbstring": "^1.0"
+            },
+            "conflict": {
+                "symfony/translation-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/emoji": "^7.4|^8.0",
+                "symfony/http-client": "^7.4|^8.0",
+                "symfony/intl": "^7.4|^8.0",
+                "symfony/translation-contracts": "^2.5|^3.0",
+                "symfony/var-exporter": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v8.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-30T15:14:47+00:00"
+        },
+        {
             "name": "theseer/tokenizer",
             "version": "2.0.1",
             "source": {
@@ -4620,6 +5427,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "automattic/jetpack-changelogger": 20,
         "automattic/jetpack-composer-plugin": 20,
         "automattic/jetpack-mu-wpcom": 20,
         "automattic/phpunit-select-config": 20

--- a/projects/plugins/search/changelog/add-ship-stats-abilities
+++ b/projects/plugins/search/changelog/add-ship-stats-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add stats wp abbilities

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bfb790e6ddd2d795d6f26bb73100fe38",
+    "content-hash": "1713dfb91c65a17b385655c9ec176e71",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -12,13 +12,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/a8c-mc-stats",
-                "reference": "68b92cc77ac41309dbf2f7a16eecd4e0c9cb03a9"
+                "reference": "4877940876f9da0f0a796d37814f591f2392b748"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -66,7 +65,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "7b96f52e31ef50047c34a7f27870bd1c52f36787"
+                "reference": "36bf27e8bb95ad8b98897a3f0be80deffbe850b6"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -74,7 +73,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-logo": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
@@ -144,7 +142,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "116afa785e69beb00f93503b12e0b0f4a0753ebb"
+                "reference": "a4c3991ea97f5705663221c8ebff9758b46fd683"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -152,7 +150,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
@@ -215,14 +212,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/autoloader",
-                "reference": "68901f3b3a256085ebd939a3461ee833be10f86d"
+                "reference": "8f0a2f6a6e125dc5e36f16323624fb2dfbc65a4b"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -284,14 +280,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/boost-core",
-                "reference": "2971e11f238462df5de64ea0641bf8d1d54a7db7"
+                "reference": "9de6afbaacddab2c6d544eaab8970ee93398defa"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -340,14 +335,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/boost-speed-score",
-                "reference": "30562e15109877d91d5f450d89bfbc3339bfaa4b"
+                "reference": "4df20352a60b6984f670dfbb680b902e1087a152"
             },
             "require": {
                 "automattic/jetpack-boost-core": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -405,14 +399,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer-plugin",
-                "reference": "eb028c7425d0591689e2a0b3047c278d8ff2395e"
+                "reference": "5757fcdb855bc654b788aa1d75b3442e068c83ee"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -466,14 +459,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/config",
-                "reference": "e29d7636760a80608d7856f2e3b28b54539923e5"
+                "reference": "c57552fadeaa0ee131577eea652128b3686f62cc"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
                 "automattic/jetpack-account-protection": "@dev",
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-import": "@dev",
                 "automattic/jetpack-jitm": "@dev",
@@ -538,7 +530,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "f43150bda979c1855db4ab23655bf26d12e75786"
+                "reference": "37cff8191289fa89742688ce970f25f702cb6ba8"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -551,7 +543,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-licensing": "@dev",
                 "automattic/jetpack-sync": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
@@ -625,13 +616,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/constants",
-                "reference": "378a5d122aedfc25d3aa42ab913803c85a8c857b"
+                "reference": "95cc69c8b39c9bc26cc430988a7de1297a654324"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -680,13 +670,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "40cbfeb8412019423305cb3d071d1cd8ec5fccc3"
+                "reference": "b9aac1ae0b83275be407fad1ddd02a390bf68494"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -734,14 +723,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/explat",
-                "reference": "1da7eabd28e234c67a03fc7bff5760b383a0d91d"
+                "reference": "cd4e942a9037ee10214454b5ab621d9ff29141d6"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -810,13 +798,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/ip",
-                "reference": "4c8f48266f1fe2551103c6293e2957e185f87a94"
+                "reference": "edf860f4e7e7096f7abfdc4083762c75ca7e64fb"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -869,7 +856,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "9236be3cd8bc85e4bfe49110ae26a78d7195c5f9"
+                "reference": "9bd15c67655ee061b5041261b7f1fbfeb228d3e1"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -882,7 +869,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -945,14 +931,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/licensing",
-                "reference": "b7c57a00a82602b59389d48cdf5dd4f46730ad69"
+                "reference": "cdf9ec6ab1867c05ce74b0997f1db92b339a0c21"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1002,13 +987,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/logo",
-                "reference": "ffa8535e2da982620164c7a251f0b2fbe46d3f16"
+                "reference": "340235b11e6729a362dcf53389a72c52b590a3ff"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -1056,7 +1040,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "fc9c4d94537b80b76ba17f10234e3c6c7090b1e9"
+                "reference": "27a1a0b0ca6700aa6cd2173ea9eb95733bab5f35"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1076,7 +1060,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-search": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/jetpack-videopress": "@dev",
@@ -1095,7 +1078,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.34.x-dev"
+                    "dev-trunk": "5.35.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"
@@ -1159,13 +1142,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/password-checker",
-                "reference": "33cc919e4b75e07ed12975588c42ae2ea723a9a4"
+                "reference": "48727ad4c6f29f009ac074465e36d4d387e3f82e"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1215,14 +1197,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "26f4ed44e15ea1e285b6b80870c7b8f3da56e9f8"
+                "reference": "ef664f6fcfde0b888d66e6f3d9893daeb4fa75a0"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
@@ -1278,7 +1259,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plugins-installer",
-                "reference": "c26351d6a169c26719a964ef89c1cc986b5fbbfe"
+                "reference": "bd93ed5a6bc02b4ff2a39cf063d56d9a6b91ee01"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -1286,7 +1267,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -1335,14 +1315,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/protect-models",
-                "reference": "47d85cc433228c6278e5a10225e27a8cf6848971"
+                "reference": "edf29e968d079fbe4d36fbb534c1cc4d319af8c4"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1401,7 +1380,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/protect-status",
-                "reference": "1ee77a6b620cfd98e260f4b9dbfe9fd1e360a8d0"
+                "reference": "b61d5b605dfc0ca24c9212d792b75a12f2d2e273"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1412,7 +1391,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1471,14 +1449,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/redirect",
-                "reference": "44d6ec93e4d3b3db6287bf82f316a294d7ef868d"
+                "reference": "eff84ae54899356e87f28a2afe89745e26411ee7"
             },
             "require": {
                 "automattic/jetpack-status": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1527,13 +1504,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/roles",
-                "reference": "f7098eb11833c5fddfff032427d8576039aa3521"
+                "reference": "ae54f8dc58bd6bd7e82cf661afe5f2e8951cdd0c"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1582,7 +1558,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "e49842144a76dca4219f31c503d93093a5fcfa7d"
+                "reference": "a668ed6e366ed2b980f02b9ddd5ead603403f005"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1595,7 +1571,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1612,7 +1587,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.56.x-dev"
+                    "dev-trunk": "0.57.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"
@@ -1665,7 +1640,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats",
-                "reference": "089d88f8d263d41a36963e33c5d6330c0b0841a2"
+                "reference": "927d43834de1e46b37cfba8bba95f4ddd7edf251"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1675,7 +1650,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1733,14 +1707,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "8ce7c4c3d0a7c4ec9fce7b3002ba635afd5bc952"
+                "reference": "76cc443bfab1ccafe0e07fc050735bb33341f5a5"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-ip": "@dev",
                 "automattic/jetpack-plans": "@dev",
@@ -1798,7 +1771,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "39ff3d14b536ba6a0f501d28d436dcea93ce6857"
+                "reference": "946cdc6936bc54e9b5d22f0129003c0f9c9e475b"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1810,7 +1783,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-search": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/jetpack-waf": "@dev",
@@ -1871,13 +1843,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/wp-abilities",
-                "reference": "d38d63604cbefe504f12a74a956502a648fdf521"
+                "reference": "e71e43ab54aaf244b0cb2e29999da393164021f5"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1927,96 +1898,12 @@
     ],
     "packages-dev": [
         {
-            "name": "automattic/jetpack-changelogger",
-            "version": "dev-trunk",
-            "dist": {
-                "type": "path",
-                "url": "../../packages/changelogger",
-                "reference": "b5353c88e04d5fae32ee501b1a0a4234ee968e56"
-            },
-            "require": {
-                "composer-runtime-api": "^2.2.0",
-                "php": ">=7.2.5",
-                "symfony/console": "^5.4 || ^6.4 || ^7.1",
-                "symfony/process": "^5.4 || ^6.4 || ^7.1"
-            },
-            "require-dev": {
-                "automattic/phpunit-select-config": "@dev",
-                "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-                "yoast/phpunit-polyfills": "^4.0.0"
-            },
-            "bin": [
-                "bin/changelogger"
-            ],
-            "type": "project",
-            "extra": {
-                "autotagger": true,
-                "branch-alias": {
-                    "dev-trunk": "6.0.x-dev"
-                },
-                "mirror-repo": "Automattic/jetpack-changelogger",
-                "version-constants": {
-                    "::VERSION": "src/Application.php"
-                },
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-changelogger/compare/${old}...${new}"
-                },
-                "dependencies": {
-                    "test-only": [
-                        "packages/phpunit-select-config"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\Changelogger\\": "src",
-                    "Automattic\\Jetpack\\Changelog\\": "lib"
-                }
-            },
-            "autoload-dev": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\Changelogger\\Tests\\": "tests/php/includes/src",
-                    "Automattic\\Jetpack\\Changelog\\Tests\\": "tests/php/includes/lib"
-                }
-            },
-            "scripts": {
-                "phpunit": [
-                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
-                ],
-                "test-coverage": [
-                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
-                ],
-                "test-php": [
-                    "@composer phpunit"
-                ],
-                "post-install-cmd": [
-                    "rm -f vendor/bin/changelogger && ln -s ../../bin/local-changelogger vendor/bin/changelogger"
-                ],
-                "post-update-cmd": [
-                    "rm -f vendor/bin/changelogger && ln -s ../../bin/local-changelogger vendor/bin/changelogger"
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Jetpack Changelogger tool. Allows for managing changelogs by dropping change files into a changelog directory with each PR.",
-            "keywords": [
-                "changelog",
-                "cli",
-                "dev",
-                "keepachangelog"
-            ],
-            "transport-options": {
-                "relative": true
-            }
-        },
-        {
             "name": "automattic/phpunit-select-config",
             "version": "dev-trunk",
             "dist": {
                 "type": "path",
                 "url": "../../packages/phpunit-select-config",
-                "reference": "3f16352a5a43bdd583b78d895d092a1e1b74c397"
+                "reference": "9e44d830cefeebc6c9b5a108cfab1ac3c1e3fd98"
             },
             "require": {
                 "composer-runtime-api": "^2.2.2",
@@ -2025,7 +1912,6 @@
             },
             "require-dev": {
                 "antecedent/patchwork": "^2.2",
-                "automattic/jetpack-changelogger": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
@@ -2742,59 +2628,6 @@
                 }
             ],
             "time": "2026-04-13T05:38:19+00:00"
-        },
-        {
-            "name": "psr/container",
-            "version": "2.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/container.git",
-                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
-                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Container\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common Container Interface (PHP FIG PSR-11)",
-            "homepage": "https://github.com/php-fig/container",
-            "keywords": [
-                "PSR-11",
-                "container",
-                "container-interface",
-                "container-interop",
-                "psr"
-            ],
-            "support": {
-                "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/2.0.2"
-            },
-            "time": "2021-11-05T16:47:00+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -3746,748 +3579,6 @@
             "time": "2024-10-20T05:08:20+00:00"
         },
         {
-            "name": "symfony/console",
-            "version": "v7.4.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/console.git",
-                "reference": "1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707",
-                "reference": "1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/service-contracts": "^2.5|^3",
-                "symfony/string": "^7.2|^8.0"
-            },
-            "conflict": {
-                "symfony/dependency-injection": "<6.4",
-                "symfony/dotenv": "<6.4",
-                "symfony/event-dispatcher": "<6.4",
-                "symfony/lock": "<6.4",
-                "symfony/process": "<6.4"
-            },
-            "provide": {
-                "psr/log-implementation": "1.0|2.0|3.0"
-            },
-            "require-dev": {
-                "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
-                "symfony/http-foundation": "^6.4|^7.0|^8.0",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0",
-                "symfony/lock": "^6.4|^7.0|^8.0",
-                "symfony/messenger": "^6.4|^7.0|^8.0",
-                "symfony/process": "^6.4|^7.0|^8.0",
-                "symfony/stopwatch": "^6.4|^7.0|^8.0",
-                "symfony/var-dumper": "^6.4|^7.0|^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Console\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Eases the creation of beautiful and testable command line interfaces",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "cli",
-                "command-line",
-                "console",
-                "terminal"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.8"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-03-30T13:54:39+00:00"
-        },
-        {
-            "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/contracts",
-                    "name": "symfony/contracts"
-                },
-                "branch-alias": {
-                    "dev-main": "3.6-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "function.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "A generic function and convention to trigger deprecation notices",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-09-25T14:21:43+00:00"
-        },
-        {
-            "name": "symfony/polyfill-ctype",
-            "version": "v1.34.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
-                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "provide": {
-                "ext-ctype": "*"
-            },
-            "suggest": {
-                "ext-ctype": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for ctype functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "ctype",
-                "polyfill",
-                "portable"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.34.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-04-10T16:19:22+00:00"
-        },
-        {
-            "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.34.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "ad1b7b9092976d6c948b8a187cec9faaea9ec1df"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/ad1b7b9092976d6c948b8a187cec9faaea9ec1df",
-                "reference": "ad1b7b9092976d6c948b8a187cec9faaea9ec1df",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "suggest": {
-                "ext-intl": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for intl's grapheme_* functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "grapheme",
-                "intl",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.34.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-04-10T16:19:22+00:00"
-        },
-        {
-            "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.34.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "suggest": {
-                "ext-intl": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for intl's Normalizer class and related functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "intl",
-                "normalizer",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.34.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-09-09T11:45:10+00:00"
-        },
-        {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.34.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
-                "shasum": ""
-            },
-            "require": {
-                "ext-iconv": "*",
-                "php": ">=7.2"
-            },
-            "provide": {
-                "ext-mbstring": "*"
-            },
-            "suggest": {
-                "ext-mbstring": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for the Mbstring extension",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "mbstring",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.34.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-04-10T17:25:58+00:00"
-        },
-        {
-            "name": "symfony/process",
-            "version": "v7.4.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/60f19cd3badc8de688421e21e4305eba50f8089a",
-                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Process\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Executes commands in sub-processes",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/process/tree/v7.4.8"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-03-24T13:12:05+00:00"
-        },
-        {
-            "name": "symfony/service-contracts",
-            "version": "v3.6.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "psr/container": "^1.1|^2.0",
-                "symfony/deprecation-contracts": "^2.5|^3"
-            },
-            "conflict": {
-                "ext-psr": "<1.1|>=2"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/contracts",
-                    "name": "symfony/contracts"
-                },
-                "branch-alias": {
-                    "dev-main": "3.6-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Contracts\\Service\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Test/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Generic abstractions related to writing services",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "abstractions",
-                "contracts",
-                "decoupling",
-                "interfaces",
-                "interoperability",
-                "standards"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-07-15T11:30:57+00:00"
-        },
-        {
-            "name": "symfony/string",
-            "version": "v8.0.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/string.git",
-                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/ae9488f874d7603f9d2dfbf120203882b645d963",
-                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.4",
-                "symfony/polyfill-ctype": "^1.8",
-                "symfony/polyfill-intl-grapheme": "^1.33",
-                "symfony/polyfill-intl-normalizer": "^1.0",
-                "symfony/polyfill-mbstring": "^1.0"
-            },
-            "conflict": {
-                "symfony/translation-contracts": "<2.5"
-            },
-            "require-dev": {
-                "symfony/emoji": "^7.4|^8.0",
-                "symfony/http-client": "^7.4|^8.0",
-                "symfony/intl": "^7.4|^8.0",
-                "symfony/translation-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^7.4|^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "Resources/functions.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Component\\String\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "grapheme",
-                "i18n",
-                "string",
-                "unicode",
-                "utf-8",
-                "utf8"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/string/tree/v8.0.8"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-03-30T15:14:47+00:00"
-        },
-        {
             "name": "theseer/tokenizer",
             "version": "2.0.1",
             "source": {
@@ -4605,7 +3696,6 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "automattic/jetpack-autoloader": 20,
-        "automattic/jetpack-changelogger": 20,
         "automattic/jetpack-composer-plugin": 20,
         "automattic/jetpack-config": 20,
         "automattic/jetpack-connection": 20,

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1713dfb91c65a17b385655c9ec176e71",
+    "content-hash": "bfb790e6ddd2d795d6f26bb73100fe38",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -12,12 +12,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/a8c-mc-stats",
-                "reference": "4877940876f9da0f0a796d37814f591f2392b748"
+                "reference": "68b92cc77ac41309dbf2f7a16eecd4e0c9cb03a9"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -65,7 +66,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "36bf27e8bb95ad8b98897a3f0be80deffbe850b6"
+                "reference": "7b96f52e31ef50047c34a7f27870bd1c52f36787"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -73,6 +74,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-logo": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
@@ -142,7 +144,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "a4c3991ea97f5705663221c8ebff9758b46fd683"
+                "reference": "116afa785e69beb00f93503b12e0b0f4a0753ebb"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -150,6 +152,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
@@ -212,13 +215,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/autoloader",
-                "reference": "8f0a2f6a6e125dc5e36f16323624fb2dfbc65a4b"
+                "reference": "68901f3b3a256085ebd939a3461ee833be10f86d"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -280,13 +284,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/boost-core",
-                "reference": "9de6afbaacddab2c6d544eaab8970ee93398defa"
+                "reference": "2971e11f238462df5de64ea0641bf8d1d54a7db7"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -335,13 +340,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/boost-speed-score",
-                "reference": "4df20352a60b6984f670dfbb680b902e1087a152"
+                "reference": "30562e15109877d91d5f450d89bfbc3339bfaa4b"
             },
             "require": {
                 "automattic/jetpack-boost-core": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -399,13 +405,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer-plugin",
-                "reference": "5757fcdb855bc654b788aa1d75b3442e068c83ee"
+                "reference": "eb028c7425d0591689e2a0b3047c278d8ff2395e"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -459,13 +466,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/config",
-                "reference": "c57552fadeaa0ee131577eea652128b3686f62cc"
+                "reference": "e29d7636760a80608d7856f2e3b28b54539923e5"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
                 "automattic/jetpack-account-protection": "@dev",
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-import": "@dev",
                 "automattic/jetpack-jitm": "@dev",
@@ -530,7 +538,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "37cff8191289fa89742688ce970f25f702cb6ba8"
+                "reference": "f43150bda979c1855db4ab23655bf26d12e75786"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -543,6 +551,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-licensing": "@dev",
                 "automattic/jetpack-sync": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
@@ -616,12 +625,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/constants",
-                "reference": "95cc69c8b39c9bc26cc430988a7de1297a654324"
+                "reference": "378a5d122aedfc25d3aa42ab913803c85a8c857b"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -670,12 +680,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "b9aac1ae0b83275be407fad1ddd02a390bf68494"
+                "reference": "40cbfeb8412019423305cb3d071d1cd8ec5fccc3"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -723,13 +734,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/explat",
-                "reference": "cd4e942a9037ee10214454b5ab621d9ff29141d6"
+                "reference": "1da7eabd28e234c67a03fc7bff5760b383a0d91d"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -798,12 +810,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/ip",
-                "reference": "edf860f4e7e7096f7abfdc4083762c75ca7e64fb"
+                "reference": "4c8f48266f1fe2551103c6293e2957e185f87a94"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -856,7 +869,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "9bd15c67655ee061b5041261b7f1fbfeb228d3e1"
+                "reference": "9236be3cd8bc85e4bfe49110ae26a78d7195c5f9"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -869,6 +882,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -931,13 +945,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/licensing",
-                "reference": "cdf9ec6ab1867c05ce74b0997f1db92b339a0c21"
+                "reference": "b7c57a00a82602b59389d48cdf5dd4f46730ad69"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -987,12 +1002,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/logo",
-                "reference": "340235b11e6729a362dcf53389a72c52b590a3ff"
+                "reference": "ffa8535e2da982620164c7a251f0b2fbe46d3f16"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -1040,7 +1056,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "27a1a0b0ca6700aa6cd2173ea9eb95733bab5f35"
+                "reference": "fc9c4d94537b80b76ba17f10234e3c6c7090b1e9"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1060,6 +1076,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-search": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/jetpack-videopress": "@dev",
@@ -1078,7 +1095,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.35.x-dev"
+                    "dev-trunk": "5.34.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"
@@ -1142,12 +1159,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/password-checker",
-                "reference": "48727ad4c6f29f009ac074465e36d4d387e3f82e"
+                "reference": "33cc919e4b75e07ed12975588c42ae2ea723a9a4"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1197,13 +1215,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "ef664f6fcfde0b888d66e6f3d9893daeb4fa75a0"
+                "reference": "26f4ed44e15ea1e285b6b80870c7b8f3da56e9f8"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
@@ -1259,7 +1278,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plugins-installer",
-                "reference": "bd93ed5a6bc02b4ff2a39cf063d56d9a6b91ee01"
+                "reference": "c26351d6a169c26719a964ef89c1cc986b5fbbfe"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -1267,6 +1286,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -1315,13 +1335,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/protect-models",
-                "reference": "edf29e968d079fbe4d36fbb534c1cc4d319af8c4"
+                "reference": "47d85cc433228c6278e5a10225e27a8cf6848971"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1380,7 +1401,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/protect-status",
-                "reference": "b61d5b605dfc0ca24c9212d792b75a12f2d2e273"
+                "reference": "1ee77a6b620cfd98e260f4b9dbfe9fd1e360a8d0"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1391,6 +1412,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1449,13 +1471,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/redirect",
-                "reference": "eff84ae54899356e87f28a2afe89745e26411ee7"
+                "reference": "44d6ec93e4d3b3db6287bf82f316a294d7ef868d"
             },
             "require": {
                 "automattic/jetpack-status": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1504,12 +1527,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/roles",
-                "reference": "ae54f8dc58bd6bd7e82cf661afe5f2e8951cdd0c"
+                "reference": "f7098eb11833c5fddfff032427d8576039aa3521"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1558,7 +1582,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/search",
-                "reference": "a668ed6e366ed2b980f02b9ddd5ead603403f005"
+                "reference": "e49842144a76dca4219f31c503d93093a5fcfa7d"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1571,6 +1595,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1587,7 +1612,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-search/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.57.x-dev"
+                    "dev-trunk": "0.56.x-dev"
                 },
                 "version-constants": {
                     "::VERSION": "src/class-package.php"
@@ -1640,15 +1665,17 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats",
-                "reference": "21404943feba5a6e1b57197aa3df02cee0b413fe"
+                "reference": "089d88f8d263d41a36963e33c5d6330c0b0841a2"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-constants": "@dev",
                 "automattic/jetpack-status": "@dev",
+                "automattic/jetpack-wp-abilities": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1706,13 +1733,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "76cc443bfab1ccafe0e07fc050735bb33341f5a5"
+                "reference": "8ce7c4c3d0a7c4ec9fce7b3002ba635afd5bc952"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-ip": "@dev",
                 "automattic/jetpack-plans": "@dev",
@@ -1770,7 +1798,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "946cdc6936bc54e9b5d22f0129003c0f9c9e475b"
+                "reference": "39ff3d14b536ba6a0f501d28d436dcea93ce6857"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1782,6 +1810,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-search": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/jetpack-waf": "@dev",
@@ -1835,16 +1864,159 @@
             "transport-options": {
                 "relative": true
             }
+        },
+        {
+            "name": "automattic/jetpack-wp-abilities",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/wp-abilities",
+                "reference": "d38d63604cbefe504f12a74a956502a648fdf521"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "brain/monkey": "^2.6.2",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-wp-abilities",
+                "changelogger": {
+                    "link-template": "https://github.com/automattic/jetpack-wp-abilities/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                },
+                "textdomain": "jetpack-wp-abilities",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-registrar.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Shared utilities for registering abilities with the WordPress Abilities API from Jetpack packages and plugins.",
+            "transport-options": {
+                "relative": true
+            }
         }
     ],
     "packages-dev": [
+        {
+            "name": "automattic/jetpack-changelogger",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/changelogger",
+                "reference": "b5353c88e04d5fae32ee501b1a0a4234ee968e56"
+            },
+            "require": {
+                "composer-runtime-api": "^2.2.0",
+                "php": ">=7.2.5",
+                "symfony/console": "^5.4 || ^6.4 || ^7.1",
+                "symfony/process": "^5.4 || ^6.4 || ^7.1"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "bin": [
+                "bin/changelogger"
+            ],
+            "type": "project",
+            "extra": {
+                "autotagger": true,
+                "branch-alias": {
+                    "dev-trunk": "6.0.x-dev"
+                },
+                "mirror-repo": "Automattic/jetpack-changelogger",
+                "version-constants": {
+                    "::VERSION": "src/Application.php"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-changelogger/compare/${old}...${new}"
+                },
+                "dependencies": {
+                    "test-only": [
+                        "packages/phpunit-select-config"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Automattic\\Jetpack\\Changelogger\\": "src",
+                    "Automattic\\Jetpack\\Changelog\\": "lib"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Automattic\\Jetpack\\Changelogger\\Tests\\": "tests/php/includes/src",
+                    "Automattic\\Jetpack\\Changelog\\Tests\\": "tests/php/includes/lib"
+                }
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "post-install-cmd": [
+                    "rm -f vendor/bin/changelogger && ln -s ../../bin/local-changelogger vendor/bin/changelogger"
+                ],
+                "post-update-cmd": [
+                    "rm -f vendor/bin/changelogger && ln -s ../../bin/local-changelogger vendor/bin/changelogger"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Jetpack Changelogger tool. Allows for managing changelogs by dropping change files into a changelog directory with each PR.",
+            "keywords": [
+                "changelog",
+                "cli",
+                "dev",
+                "keepachangelog"
+            ],
+            "transport-options": {
+                "relative": true
+            }
+        },
         {
             "name": "automattic/phpunit-select-config",
             "version": "dev-trunk",
             "dist": {
                 "type": "path",
                 "url": "../../packages/phpunit-select-config",
-                "reference": "9e44d830cefeebc6c9b5a108cfab1ac3c1e3fd98"
+                "reference": "3f16352a5a43bdd583b78d895d092a1e1b74c397"
             },
             "require": {
                 "composer-runtime-api": "^2.2.2",
@@ -1853,6 +2025,7 @@
             },
             "require-dev": {
                 "antecedent/patchwork": "^2.2",
+                "automattic/jetpack-changelogger": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
@@ -2137,16 +2310,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "12.5.6",
+            "version": "12.5.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "876099a072646c7745f673d7aeab5382c4439691"
+                "reference": "a25bde1f8f83849f441ef5713c6466e470872a71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/876099a072646c7745f673d7aeab5382c4439691",
-                "reference": "876099a072646c7745f673d7aeab5382c4439691",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/a25bde1f8f83849f441ef5713c6466e470872a71",
+                "reference": "a25bde1f8f83849f441ef5713c6466e470872a71",
                 "shasum": ""
             },
             "require": {
@@ -2201,7 +2374,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.6"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.5"
             },
             "funding": [
                 {
@@ -2221,7 +2394,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-15T08:23:17+00:00"
+            "time": "2026-04-13T04:53:32+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -2482,16 +2655,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.5.23",
+            "version": "12.5.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c54fcf3d6bcb6e96ac2f7e40097dc37b5f139969"
+                "reference": "92f7744ca5f5701c9e4b4a60d9e143f2d84956da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c54fcf3d6bcb6e96ac2f7e40097dc37b5f139969",
-                "reference": "c54fcf3d6bcb6e96ac2f7e40097dc37b5f139969",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/92f7744ca5f5701c9e4b4a60d9e143f2d84956da",
+                "reference": "92f7744ca5f5701c9e4b4a60d9e143f2d84956da",
                 "shasum": ""
             },
             "require": {
@@ -2505,15 +2678,15 @@
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.3",
-                "phpunit/php-code-coverage": "^12.5.6",
+                "phpunit/php-code-coverage": "^12.5.5",
                 "phpunit/php-file-iterator": "^6.0.1",
                 "phpunit/php-invoker": "^6.0.0",
                 "phpunit/php-text-template": "^5.0.0",
                 "phpunit/php-timer": "^8.0.0",
                 "sebastian/cli-parser": "^4.2.0",
-                "sebastian/comparator": "^7.1.6",
+                "sebastian/comparator": "^7.1.5",
                 "sebastian/diff": "^7.0.0",
-                "sebastian/environment": "^8.1.0",
+                "sebastian/environment": "^8.0.4",
                 "sebastian/exporter": "^7.0.2",
                 "sebastian/global-state": "^8.0.2",
                 "sebastian/object-enumerator": "^7.0.0",
@@ -2560,7 +2733,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.23"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.19"
             },
             "funding": [
                 {
@@ -2568,7 +2741,60 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-04-18T06:12:49+00:00"
+            "time": "2026-04-13T05:38:19+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
+            },
+            "time": "2021-11-05T16:47:00+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2641,16 +2867,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "7.1.6",
+            "version": "7.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "c769009dee98f494e0edc3fd4f4087501688f11e"
+                "reference": "c284f55811f43d555e51e8e5c166ac40d3e33c63"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/c769009dee98f494e0edc3fd4f4087501688f11e",
-                "reference": "c769009dee98f494e0edc3fd4f4087501688f11e",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/c284f55811f43d555e51e8e5c166ac40d3e33c63",
+                "reference": "c284f55811f43d555e51e8e5c166ac40d3e33c63",
                 "shasum": ""
             },
             "require": {
@@ -2709,7 +2935,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.6"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.5"
             },
             "funding": [
                 {
@@ -2729,7 +2955,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-14T08:23:15+00:00"
+            "time": "2026-04-08T04:43:00+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -2858,16 +3084,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "8.1.0",
+            "version": "8.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "b121608b28a13f721e76ffbbd386d08eff58f3f6"
+                "reference": "7b8842c2d8e85d0c3a5831236bf5869af6ab2a11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/b121608b28a13f721e76ffbbd386d08eff58f3f6",
-                "reference": "b121608b28a13f721e76ffbbd386d08eff58f3f6",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/7b8842c2d8e85d0c3a5831236bf5869af6ab2a11",
+                "reference": "7b8842c2d8e85d0c3a5831236bf5869af6ab2a11",
                 "shasum": ""
             },
             "require": {
@@ -2882,7 +3108,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "8.1-dev"
+                    "dev-main": "8.0-dev"
                 }
             },
             "autoload": {
@@ -2910,7 +3136,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
                 "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/8.1.0"
+                "source": "https://github.com/sebastianbergmann/environment/tree/8.0.4"
             },
             "funding": [
                 {
@@ -2930,7 +3156,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-15T12:13:01+00:00"
+            "time": "2026-03-15T07:05:40+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -3520,6 +3746,748 @@
             "time": "2024-10-20T05:08:20+00:00"
         },
         {
+            "name": "symfony/console",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707",
+                "reference": "1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/string": "^7.2|^8.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<6.4",
+                "symfony/dotenv": "<6.4",
+                "symfony/event-dispatcher": "<6.4",
+                "symfony/lock": "<6.4",
+                "symfony/process": "<6.4"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0|2.0|3.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/lock": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/stopwatch": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Eases the creation of beautiful and testable command line interfaces",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "cli",
+                "command-line",
+                "console",
+                "terminal"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-30T13:54:39+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:21:43+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.34.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.34.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.34.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "ad1b7b9092976d6c948b8a187cec9faaea9ec1df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/ad1b7b9092976d6c948b8a187cec9faaea9ec1df",
+                "reference": "ad1b7b9092976d6c948b8a187cec9faaea9ec1df",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.34.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.34.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.34.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.34.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.34.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T17:25:58+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/60f19cd3badc8de688421e21e4305eba50f8089a",
+                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Executes commands in sub-processes",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v3.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-15T11:30:57+00:00"
+        },
+        {
+            "name": "symfony/string",
+            "version": "v8.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/string.git",
+                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/string/zipball/ae9488f874d7603f9d2dfbf120203882b645d963",
+                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-intl-grapheme": "^1.33",
+                "symfony/polyfill-intl-normalizer": "^1.0",
+                "symfony/polyfill-mbstring": "^1.0"
+            },
+            "conflict": {
+                "symfony/translation-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/emoji": "^7.4|^8.0",
+                "symfony/http-client": "^7.4|^8.0",
+                "symfony/intl": "^7.4|^8.0",
+                "symfony/translation-contracts": "^2.5|^3.0",
+                "symfony/var-exporter": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v8.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-30T15:14:47+00:00"
+        },
+        {
             "name": "theseer/tokenizer",
             "version": "2.0.1",
             "source": {
@@ -3637,6 +4605,7 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "automattic/jetpack-autoloader": 20,
+        "automattic/jetpack-changelogger": 20,
         "automattic/jetpack-composer-plugin": 20,
         "automattic/jetpack-config": 20,
         "automattic/jetpack-connection": 20,

--- a/projects/plugins/wpcomsh/changelog/add-ship-stats-abilities
+++ b/projects/plugins/wpcomsh/changelog/add-ship-stats-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add stats wp abbilities

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -4,27 +4,27 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5888fdf5b3ab632a0f07f80f5ca8dc17",
+    "content-hash": "a7cd1b2d4d28b9decbe21a0e6b47e8d9",
     "packages": [
         {
             "name": "automattic/at-pressable-podcasting",
-            "version": "v2.0.7",
+            "version": "v2.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/automattic/at-pressable-podcasting.git",
-                "reference": "b3920eb6e94594aadb0c678f6c8328191091a9be"
+                "reference": "c512aa27b2c33aee33bc024177c17f2745c52dfa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/automattic/at-pressable-podcasting/zipball/b3920eb6e94594aadb0c678f6c8328191091a9be",
-                "reference": "b3920eb6e94594aadb0c678f6c8328191091a9be",
+                "url": "https://api.github.com/repos/automattic/at-pressable-podcasting/zipball/c512aa27b2c33aee33bc024177c17f2745c52dfa",
+                "reference": "c512aa27b2c33aee33bc024177c17f2745c52dfa",
                 "shasum": ""
             },
             "type": "wordpress-plugin",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "time": "2026-04-24T20:01:37+00:00"
+            "time": "2025-11-24T21:07:37+00:00"
         },
         {
             "name": "automattic/block-delimiter",
@@ -32,12 +32,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/block-delimiter",
-                "reference": "65f01ae1ff7636fd52709a61c203756ab190d7e3"
+                "reference": "38b17cad3ac0259b1358356beb4744d6ca606488"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -143,12 +144,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/a8c-mc-stats",
-                "reference": "4877940876f9da0f0a796d37814f591f2392b748"
+                "reference": "68b92cc77ac41309dbf2f7a16eecd4e0c9cb03a9"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -196,7 +198,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "36bf27e8bb95ad8b98897a3f0be80deffbe850b6"
+                "reference": "7b96f52e31ef50047c34a7f27870bd1c52f36787"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -204,6 +206,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-logo": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
@@ -273,7 +276,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "a4c3991ea97f5705663221c8ebff9758b46fd683"
+                "reference": "116afa785e69beb00f93503b12e0b0f4a0753ebb"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -281,6 +284,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
@@ -343,13 +347,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/autoloader",
-                "reference": "8f0a2f6a6e125dc5e36f16323624fb2dfbc65a4b"
+                "reference": "68901f3b3a256085ebd939a3461ee833be10f86d"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -411,7 +416,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/blaze",
-                "reference": "f600123b4b3ab650ab4f927971069b83f52d8ef6"
+                "reference": "441a3689be7e956db950f27520952b81a249fedd"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -424,6 +429,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -486,13 +492,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/blocks",
-                "reference": "3a5646bd6d55bbc1a27880efe63dabe2ca208c6d"
+                "reference": "34625c73a31fc7c9566591dc38d4ec3ef18c78b1"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
@@ -542,7 +549,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/classic-theme-helper",
-                "reference": "59ad12b263b6ca34f09350ba9547d5ff381a11d4"
+                "reference": "2a0ad5d46ab475954e8ec3d2d633234c06316b91"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -551,6 +558,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -608,10 +616,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/compat",
-                "reference": "cca3c26e1aa14e6cfe16ed55099dd1fc39362778"
+                "reference": "f344c74fa490eee8870adf5cbf68c6a841c1e2ee"
             },
             "require": {
                 "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -642,13 +653,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer-plugin",
-                "reference": "5757fcdb855bc654b788aa1d75b3442e068c83ee"
+                "reference": "eb028c7425d0591689e2a0b3047c278d8ff2395e"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -702,13 +714,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/config",
-                "reference": "c57552fadeaa0ee131577eea652128b3686f62cc"
+                "reference": "e29d7636760a80608d7856f2e3b28b54539923e5"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
                 "automattic/jetpack-account-protection": "@dev",
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-import": "@dev",
                 "automattic/jetpack-jitm": "@dev",
@@ -773,7 +786,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "37cff8191289fa89742688ce970f25f702cb6ba8"
+                "reference": "f43150bda979c1855db4ab23655bf26d12e75786"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -786,6 +799,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-licensing": "@dev",
                 "automattic/jetpack-sync": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
@@ -859,12 +873,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/constants",
-                "reference": "95cc69c8b39c9bc26cc430988a7de1297a654324"
+                "reference": "378a5d122aedfc25d3aa42ab913803c85a8c857b"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -913,12 +928,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "b9aac1ae0b83275be407fad1ddd02a390bf68494"
+                "reference": "40cbfeb8412019423305cb3d071d1cd8ec5fccc3"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -966,13 +982,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/explat",
-                "reference": "cd4e942a9037ee10214454b5ab621d9ff29141d6"
+                "reference": "1da7eabd28e234c67a03fc7bff5760b383a0d91d"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -1041,13 +1058,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/google-analytics",
-                "reference": "0bbac6ede0742d16be602fcdfd70e47580935449"
+                "reference": "28cb18c8c47204ca7b0217f7c4b02527a8fd873f"
             },
             "require": {
                 "automattic/jetpack-status": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1106,7 +1124,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/image-cdn",
-                "reference": "a56b0996e0af0641be4ab5a487fe24ed39fb20e5"
+                "reference": "79b4ce2978edf4a5f586ceab9c2058a6cfcbef94"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1114,6 +1132,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1166,12 +1185,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/ip",
-                "reference": "edf860f4e7e7096f7abfdc4083762c75ca7e64fb"
+                "reference": "4c8f48266f1fe2551103c6293e2957e185f87a94"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1224,7 +1244,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "9bd15c67655ee061b5041261b7f1fbfeb228d3e1"
+                "reference": "9236be3cd8bc85e4bfe49110ae26a78d7195c5f9"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -1237,6 +1257,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1299,12 +1320,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/logo",
-                "reference": "340235b11e6729a362dcf53389a72c52b590a3ff"
+                "reference": "ffa8535e2da982620164c7a251f0b2fbe46d3f16"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -1352,7 +1374,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/masterbar",
-                "reference": "7838d67127972c359395f6ff63f5c328a192b44f"
+                "reference": "713257694eab74ca2b21290a99ac6cc1ffb392e1"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1368,6 +1390,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/patchwork-redefine-exit": "@dev",
                 "automattic/phpunit-select-config": "@dev",
@@ -1434,7 +1457,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "8ccf42e3bb801d5edfc343c3648afe1976f7d6fc"
+                "reference": "ccc0a533c472ed92f9b43addc2681eb33e536359"
             },
             "require": {
                 "automattic/block-delimiter": "@dev",
@@ -1458,6 +1481,7 @@
                 "symfony/filesystem": "^6.0.0"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
@@ -1521,7 +1545,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/newsletter",
-                "reference": "8d9bb031a70efedb0d178e6c596dd487e80cca35"
+                "reference": "405b39959d548729a98d187391cb940e7fca500c"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1533,6 +1557,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1599,12 +1624,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/password-checker",
-                "reference": "48727ad4c6f29f009ac074465e36d4d387e3f82e"
+                "reference": "33cc919e4b75e07ed12975588c42ae2ea723a9a4"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1654,13 +1680,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "ef664f6fcfde0b888d66e6f3d9893daeb4fa75a0"
+                "reference": "26f4ed44e15ea1e285b6b80870c7b8f3da56e9f8"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
@@ -1716,13 +1743,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/post-list",
-                "reference": "a505863c233f349c48e611943b0fef24f332032c"
+                "reference": "b80081090e9695ec2c03b7830039abf9495cf85b"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1781,7 +1809,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/post-media",
-                "reference": "6b1f642a168a1de8765232161d31001fbcea62eb"
+                "reference": "28b5f5b5b8ca9858e6c5ce23a4e852c756713960"
             },
             "require": {
                 "automattic/block-delimiter": "@dev",
@@ -1790,6 +1818,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1848,13 +1877,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/redirect",
-                "reference": "eff84ae54899356e87f28a2afe89745e26411ee7"
+                "reference": "44d6ec93e4d3b3db6287bf82f316a294d7ef868d"
             },
             "require": {
                 "automattic/jetpack-status": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1903,12 +1933,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/roles",
-                "reference": "ae54f8dc58bd6bd7e82cf661afe5f2e8951cdd0c"
+                "reference": "f7098eb11833c5fddfff032427d8576039aa3521"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1957,7 +1988,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/rtc",
-                "reference": "8aef1a19335f20d685a42cf862a96c38ba3b34ec"
+                "reference": "e8f440cdd4bedae187d26ee2c873bc9b52a88a66"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1965,6 +1996,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -2023,15 +2055,17 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats",
-                "reference": "21404943feba5a6e1b57197aa3df02cee0b413fe"
+                "reference": "089d88f8d263d41a36963e33c5d6330c0b0841a2"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-constants": "@dev",
                 "automattic/jetpack-status": "@dev",
+                "automattic/jetpack-wp-abilities": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -2089,7 +2123,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "c886544c38d3fd36c7120099a9c0b85d9776f416"
+                "reference": "d3cc7e7297df5dafcd3640b17e26ec24623f5096"
             },
             "require": {
                 "automattic/jetpack-blaze": "@dev",
@@ -2102,6 +2136,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -2157,13 +2192,14 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "76cc443bfab1ccafe0e07fc050735bb33341f5a5"
+                "reference": "8ce7c4c3d0a7c4ec9fce7b3002ba635afd5bc952"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-ip": "@dev",
                 "automattic/jetpack-plans": "@dev",
@@ -2221,7 +2257,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/subscribers-dashboard",
-                "reference": "66832602601278e0202880bef8da1a396d34fa45"
+                "reference": "d7a821c0f511c388a71049050807f4a1b56e9503"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -2233,6 +2269,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -2299,7 +2336,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "946cdc6936bc54e9b5d22f0129003c0f9c9e475b"
+                "reference": "39ff3d14b536ba6a0f501d28d436dcea93ce6857"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -2311,6 +2348,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-search": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/jetpack-waf": "@dev",
@@ -2366,12 +2404,71 @@
             }
         },
         {
+            "name": "automattic/jetpack-wp-abilities",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/wp-abilities",
+                "reference": "d38d63604cbefe504f12a74a956502a648fdf521"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "brain/monkey": "^2.6.2",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-wp-abilities",
+                "changelogger": {
+                    "link-template": "https://github.com/automattic/jetpack-wp-abilities/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                },
+                "textdomain": "jetpack-wp-abilities",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-registrar.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Shared utilities for registering abilities with the WordPress Abilities API from Jetpack packages and plugins.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "automattic/scheduled-updates",
             "version": "dev-trunk",
             "dist": {
                 "type": "path",
                 "url": "../../packages/scheduled-updates",
-                "reference": "0fb9f0f3c89bc6c9e00a502220847efe72c1513a"
+                "reference": "3f52602bf5f9547ed9d5081beac4660a8887dcfb"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -2382,6 +2479,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -3001,7 +3099,7 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.37.0",
+            "version": "v1.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -3060,7 +3158,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.34.0"
             },
             "funding": [
                 {
@@ -3084,7 +3182,7 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.37.0",
+            "version": "v1.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
@@ -3145,7 +3243,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.34.0"
             },
             "funding": [
                 {
@@ -3243,16 +3341,16 @@
         },
         {
             "name": "wp-php-toolkit/bytestream",
-            "version": "v0.6.2",
+            "version": "v0.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/bytestream.git",
-                "reference": "bf3e28e6f6e51e7abeec16e3f8c3a096e0aa2a02"
+                "reference": "664b3f6930afcd057acd3eb92370ba99853858f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/bytestream/zipball/bf3e28e6f6e51e7abeec16e3f8c3a096e0aa2a02",
-                "reference": "bf3e28e6f6e51e7abeec16e3f8c3a096e0aa2a02",
+                "url": "https://api.github.com/repos/wp-php-toolkit/bytestream/zipball/664b3f6930afcd057acd3eb92370ba99853858f0",
+                "reference": "664b3f6930afcd057acd3eb92370ba99853858f0",
                 "shasum": ""
             },
             "require": {
@@ -3287,30 +3385,30 @@
             "description": "ByteStream component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/bytestream/issues",
-                "source": "https://github.com/wp-php-toolkit/bytestream/tree/v0.6.2"
+                "source": "https://github.com/wp-php-toolkit/bytestream/tree/v0.5.1"
             },
-            "time": "2026-04-10T20:16:27+00:00"
+            "time": "2025-09-11T23:53:08+00:00"
         },
         {
             "name": "wp-php-toolkit/data-liberation",
-            "version": "v0.6.2",
+            "version": "v0.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/data-liberation.git",
-                "reference": "3502454cd1c760b929329cb4f744ada6eb08ba73"
+                "reference": "b42d4b045a3a0b124ec361de3b5873d85c9bb549"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/data-liberation/zipball/3502454cd1c760b929329cb4f744ada6eb08ba73",
-                "reference": "3502454cd1c760b929329cb4f744ada6eb08ba73",
+                "url": "https://api.github.com/repos/wp-php-toolkit/data-liberation/zipball/b42d4b045a3a0b124ec361de3b5873d85c9bb549",
+                "reference": "b42d4b045a3a0b124ec361de3b5873d85c9bb549",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.6.2",
-                "wp-php-toolkit/filesystem": "^0.6.2",
-                "wp-php-toolkit/http-client": "^0.6.2",
-                "wp-php-toolkit/xml": "^0.6.2"
+                "wp-php-toolkit/bytestream": "^0.5.1",
+                "wp-php-toolkit/filesystem": "^0.5.1",
+                "wp-php-toolkit/http-client": "^0.5.1",
+                "wp-php-toolkit/xml": "^0.5.1"
             },
             "type": "library",
             "autoload": {
@@ -3342,22 +3440,22 @@
             "description": "Data Liberation component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/data-liberation/issues",
-                "source": "https://github.com/wp-php-toolkit/data-liberation/tree/v0.6.2"
+                "source": "https://github.com/wp-php-toolkit/data-liberation/tree/v0.5.1"
             },
-            "time": "2026-04-27T14:15:30+00:00"
+            "time": "2026-04-02T14:37:51+00:00"
         },
         {
             "name": "wp-php-toolkit/encoding",
-            "version": "v0.6.2",
+            "version": "v0.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/encoding.git",
-                "reference": "f814ff6cae957449baa16f7dabe840cca756db6a"
+                "reference": "aafe834847cc45133836b0462f22fa1511eb3b5a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/encoding/zipball/f814ff6cae957449baa16f7dabe840cca756db6a",
-                "reference": "f814ff6cae957449baa16f7dabe840cca756db6a",
+                "url": "https://api.github.com/repos/wp-php-toolkit/encoding/zipball/aafe834847cc45133836b0462f22fa1511eb3b5a",
+                "reference": "aafe834847cc45133836b0462f22fa1511eb3b5a",
                 "shasum": ""
             },
             "require": {
@@ -3391,27 +3489,27 @@
             "description": "Encoding component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/encoding/issues",
-                "source": "https://github.com/wp-php-toolkit/encoding/tree/v0.6.2"
+                "source": "https://github.com/wp-php-toolkit/encoding/tree/v0.5.1"
             },
-            "time": "2026-04-10T20:16:27+00:00"
+            "time": "2025-11-20T12:04:55+00:00"
         },
         {
             "name": "wp-php-toolkit/filesystem",
-            "version": "v0.6.2",
+            "version": "v0.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/filesystem.git",
-                "reference": "36c54d8007b949c98a9fc460914367bcdc9b778f"
+                "reference": "900e4d8e1a8ef79e59e6efa52a1e0d46eb47e8e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/filesystem/zipball/36c54d8007b949c98a9fc460914367bcdc9b778f",
-                "reference": "36c54d8007b949c98a9fc460914367bcdc9b778f",
+                "url": "https://api.github.com/repos/wp-php-toolkit/filesystem/zipball/900e4d8e1a8ef79e59e6efa52a1e0d46eb47e8e2",
+                "reference": "900e4d8e1a8ef79e59e6efa52a1e0d46eb47e8e2",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.6.2"
+                "wp-php-toolkit/bytestream": "^0.5.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -3445,22 +3543,22 @@
             "description": "Filesystem component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/filesystem/issues",
-                "source": "https://github.com/wp-php-toolkit/filesystem/tree/v0.6.2"
+                "source": "https://github.com/wp-php-toolkit/filesystem/tree/v0.5.1"
             },
-            "time": "2026-04-27T14:15:30+00:00"
+            "time": "2026-04-02T14:37:51+00:00"
         },
         {
             "name": "wp-php-toolkit/html",
-            "version": "v0.6.2",
+            "version": "v0.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/html.git",
-                "reference": "d7dac562cdaff693d830ede7f35cf490a397678e"
+                "reference": "7b3863dfd82d76bd9c54e6e10a3ba317110a6e92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/html/zipball/d7dac562cdaff693d830ede7f35cf490a397678e",
-                "reference": "d7dac562cdaff693d830ede7f35cf490a397678e",
+                "url": "https://api.github.com/repos/wp-php-toolkit/html/zipball/7b3863dfd82d76bd9c54e6e10a3ba317110a6e92",
+                "reference": "7b3863dfd82d76bd9c54e6e10a3ba317110a6e92",
                 "shasum": ""
             },
             "require": {
@@ -3495,29 +3593,29 @@
             "description": "HTML component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/html/issues",
-                "source": "https://github.com/wp-php-toolkit/html/tree/v0.6.2"
+                "source": "https://github.com/wp-php-toolkit/html/tree/v0.5.1"
             },
-            "time": "2026-04-10T20:16:27+00:00"
+            "time": "2025-09-08T13:34:24+00:00"
         },
         {
             "name": "wp-php-toolkit/http-client",
-            "version": "v0.6.2",
+            "version": "v0.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/http-client.git",
-                "reference": "1174f1e20e1f4c60a3274006ebed791ac6bccd77"
+                "reference": "c9f79808c164578c6080ac87a4ecc335c78dd947"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/http-client/zipball/1174f1e20e1f4c60a3274006ebed791ac6bccd77",
-                "reference": "1174f1e20e1f4c60a3274006ebed791ac6bccd77",
+                "url": "https://api.github.com/repos/wp-php-toolkit/http-client/zipball/c9f79808c164578c6080ac87a4ecc335c78dd947",
+                "reference": "c9f79808c164578c6080ac87a4ecc335c78dd947",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.6.2",
-                "wp-php-toolkit/data-liberation": "^0.6.2",
-                "wp-php-toolkit/filesystem": "^0.6.2"
+                "wp-php-toolkit/bytestream": "^0.5.1",
+                "wp-php-toolkit/data-liberation": "^0.5.1",
+                "wp-php-toolkit/filesystem": "^0.5.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -3548,30 +3646,30 @@
             "description": "HttpClient component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/http-client/issues",
-                "source": "https://github.com/wp-php-toolkit/http-client/tree/v0.6.2"
+                "source": "https://github.com/wp-php-toolkit/http-client/tree/v0.5.1"
             },
-            "time": "2026-04-27T14:15:30+00:00"
+            "time": "2026-04-02T14:37:51+00:00"
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "v0.1.47",
+            "version": "v0.1.44",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/reprint-exporter.git",
-                "reference": "3c56b78f4d19add36f8448421d1ed4fdda135bb6"
+                "reference": "80f0e0b6cd809ac81f45a13af627681bb46a3557"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/reprint-exporter/zipball/3c56b78f4d19add36f8448421d1ed4fdda135bb6",
-                "reference": "3c56b78f4d19add36f8448421d1ed4fdda135bb6",
+                "url": "https://api.github.com/repos/wp-php-toolkit/reprint-exporter/zipball/80f0e0b6cd809ac81f45a13af627681bb46a3557",
+                "reference": "80f0e0b6cd809ac81f45a13af627681bb46a3557",
                 "shasum": ""
             },
             "require": {
                 "ext-pdo": "*",
                 "ext-pdo_mysql": "*",
                 "php": ">=7.4",
-                "wp-php-toolkit/data-liberation": "^0.6.2",
-                "wp-php-toolkit/html": "^0.6.2"
+                "wp-php-toolkit/data-liberation": "^0.5.1",
+                "wp-php-toolkit/html": "^0.5.1"
             },
             "type": "library",
             "autoload": {
@@ -3597,30 +3695,30 @@
             "description": "Streaming export engine used by the Reprint Exporter WordPress plugin",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/reprint-exporter/issues",
-                "source": "https://github.com/wp-php-toolkit/reprint-exporter/tree/v0.1.47"
+                "source": "https://github.com/wp-php-toolkit/reprint-exporter/tree/v0.1.44"
             },
-            "time": "2026-04-27T14:34:36+00:00"
+            "time": "2026-04-16T16:07:42+00:00"
         },
         {
             "name": "wp-php-toolkit/reprint-importer",
-            "version": "v0.1.47",
+            "version": "v0.1.44",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/reprint-importer.git",
-                "reference": "e56a796721f559d9a5932bf14d65cab0de51350e"
+                "reference": "9aa2108c7fa7050f5f589cd61887e50c70c00763"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/reprint-importer/zipball/e56a796721f559d9a5932bf14d65cab0de51350e",
-                "reference": "e56a796721f559d9a5932bf14d65cab0de51350e",
+                "url": "https://api.github.com/repos/wp-php-toolkit/reprint-importer/zipball/9aa2108c7fa7050f5f589cd61887e50c70c00763",
+                "reference": "9aa2108c7fa7050f5f589cd61887e50c70c00763",
                 "shasum": ""
             },
             "require": {
                 "ext-pdo": "*",
                 "ext-pdo_mysql": "*",
                 "php": ">=7.4",
-                "wp-php-toolkit/data-liberation": "^0.6.2",
-                "wp-php-toolkit/html": "^0.6.2",
+                "wp-php-toolkit/data-liberation": "^0.5.1",
+                "wp-php-toolkit/html": "^0.5.1",
                 "wp-php-toolkit/reprint-exporter": "*@dev"
             },
             "bin": [
@@ -3634,27 +3732,27 @@
             "description": "Streaming site importer with CLI and PHAR distribution support",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/reprint-importer/issues",
-                "source": "https://github.com/wp-php-toolkit/reprint-importer/tree/v0.1.47"
+                "source": "https://github.com/wp-php-toolkit/reprint-importer/tree/v0.1.44"
             },
-            "time": "2026-04-27T14:34:36+00:00"
+            "time": "2026-04-16T14:19:55+00:00"
         },
         {
             "name": "wp-php-toolkit/xml",
-            "version": "v0.6.2",
+            "version": "v0.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/xml.git",
-                "reference": "65e8a47d350179a3217b4acaf4f3597f977a9194"
+                "reference": "8ec4e2f16b18313d52c8a61a6528afacf1ceb34a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/xml/zipball/65e8a47d350179a3217b4acaf4f3597f977a9194",
-                "reference": "65e8a47d350179a3217b4acaf4f3597f977a9194",
+                "url": "https://api.github.com/repos/wp-php-toolkit/xml/zipball/8ec4e2f16b18313d52c8a61a6528afacf1ceb34a",
+                "reference": "8ec4e2f16b18313d52c8a61a6528afacf1ceb34a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/encoding": "^0.6.2"
+                "wp-php-toolkit/encoding": "^0.5.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -3685,19 +3783,103 @@
             "description": "XML component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/xml/issues",
-                "source": "https://github.com/wp-php-toolkit/xml/tree/v0.6.2"
+                "source": "https://github.com/wp-php-toolkit/xml/tree/v0.5.1"
             },
-            "time": "2026-04-27T14:15:30+00:00"
+            "time": "2026-04-02T14:37:51+00:00"
         }
     ],
     "packages-dev": [
+        {
+            "name": "automattic/jetpack-changelogger",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/changelogger",
+                "reference": "b5353c88e04d5fae32ee501b1a0a4234ee968e56"
+            },
+            "require": {
+                "composer-runtime-api": "^2.2.0",
+                "php": ">=7.2.5",
+                "symfony/console": "^5.4 || ^6.4 || ^7.1",
+                "symfony/process": "^5.4 || ^6.4 || ^7.1"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "bin": [
+                "bin/changelogger"
+            ],
+            "type": "project",
+            "extra": {
+                "autotagger": true,
+                "branch-alias": {
+                    "dev-trunk": "6.0.x-dev"
+                },
+                "mirror-repo": "Automattic/jetpack-changelogger",
+                "version-constants": {
+                    "::VERSION": "src/Application.php"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-changelogger/compare/${old}...${new}"
+                },
+                "dependencies": {
+                    "test-only": [
+                        "packages/phpunit-select-config"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Automattic\\Jetpack\\Changelogger\\": "src",
+                    "Automattic\\Jetpack\\Changelog\\": "lib"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Automattic\\Jetpack\\Changelogger\\Tests\\": "tests/php/includes/src",
+                    "Automattic\\Jetpack\\Changelog\\Tests\\": "tests/php/includes/lib"
+                }
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "post-install-cmd": [
+                    "rm -f vendor/bin/changelogger && ln -s ../../bin/local-changelogger vendor/bin/changelogger"
+                ],
+                "post-update-cmd": [
+                    "rm -f vendor/bin/changelogger && ln -s ../../bin/local-changelogger vendor/bin/changelogger"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Jetpack Changelogger tool. Allows for managing changelogs by dropping change files into a changelog directory with each PR.",
+            "keywords": [
+                "changelog",
+                "cli",
+                "dev",
+                "keepachangelog"
+            ],
+            "transport-options": {
+                "relative": true
+            }
+        },
         {
             "name": "automattic/phpunit-select-config",
             "version": "dev-trunk",
             "dist": {
                 "type": "path",
                 "url": "../../packages/phpunit-select-config",
-                "reference": "9e44d830cefeebc6c9b5a108cfab1ac3c1e3fd98"
+                "reference": "3f16352a5a43bdd583b78d895d092a1e1b74c397"
             },
             "require": {
                 "composer-runtime-api": "^2.2.2",
@@ -3706,6 +3888,7 @@
             },
             "require-dev": {
                 "antecedent/patchwork": "^2.2",
+                "automattic/jetpack-changelogger": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
@@ -3990,16 +4173,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "12.5.6",
+            "version": "12.5.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "876099a072646c7745f673d7aeab5382c4439691"
+                "reference": "a25bde1f8f83849f441ef5713c6466e470872a71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/876099a072646c7745f673d7aeab5382c4439691",
-                "reference": "876099a072646c7745f673d7aeab5382c4439691",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/a25bde1f8f83849f441ef5713c6466e470872a71",
+                "reference": "a25bde1f8f83849f441ef5713c6466e470872a71",
                 "shasum": ""
             },
             "require": {
@@ -4054,7 +4237,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.6"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.5"
             },
             "funding": [
                 {
@@ -4074,7 +4257,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-15T08:23:17+00:00"
+            "time": "2026-04-13T04:53:32+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -4335,16 +4518,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.5.23",
+            "version": "12.5.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c54fcf3d6bcb6e96ac2f7e40097dc37b5f139969"
+                "reference": "92f7744ca5f5701c9e4b4a60d9e143f2d84956da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c54fcf3d6bcb6e96ac2f7e40097dc37b5f139969",
-                "reference": "c54fcf3d6bcb6e96ac2f7e40097dc37b5f139969",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/92f7744ca5f5701c9e4b4a60d9e143f2d84956da",
+                "reference": "92f7744ca5f5701c9e4b4a60d9e143f2d84956da",
                 "shasum": ""
             },
             "require": {
@@ -4358,15 +4541,15 @@
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.3",
-                "phpunit/php-code-coverage": "^12.5.6",
+                "phpunit/php-code-coverage": "^12.5.5",
                 "phpunit/php-file-iterator": "^6.0.1",
                 "phpunit/php-invoker": "^6.0.0",
                 "phpunit/php-text-template": "^5.0.0",
                 "phpunit/php-timer": "^8.0.0",
                 "sebastian/cli-parser": "^4.2.0",
-                "sebastian/comparator": "^7.1.6",
+                "sebastian/comparator": "^7.1.5",
                 "sebastian/diff": "^7.0.0",
-                "sebastian/environment": "^8.1.0",
+                "sebastian/environment": "^8.0.4",
                 "sebastian/exporter": "^7.0.2",
                 "sebastian/global-state": "^8.0.2",
                 "sebastian/object-enumerator": "^7.0.0",
@@ -4413,7 +4596,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.23"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.19"
             },
             "funding": [
                 {
@@ -4421,7 +4604,60 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-04-18T06:12:49+00:00"
+            "time": "2026-04-13T05:38:19+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
+            },
+            "time": "2021-11-05T16:47:00+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -4494,16 +4730,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "7.1.6",
+            "version": "7.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "c769009dee98f494e0edc3fd4f4087501688f11e"
+                "reference": "c284f55811f43d555e51e8e5c166ac40d3e33c63"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/c769009dee98f494e0edc3fd4f4087501688f11e",
-                "reference": "c769009dee98f494e0edc3fd4f4087501688f11e",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/c284f55811f43d555e51e8e5c166ac40d3e33c63",
+                "reference": "c284f55811f43d555e51e8e5c166ac40d3e33c63",
                 "shasum": ""
             },
             "require": {
@@ -4562,7 +4798,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.6"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.5"
             },
             "funding": [
                 {
@@ -4582,7 +4818,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-14T08:23:15+00:00"
+            "time": "2026-04-08T04:43:00+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -4711,16 +4947,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "8.1.0",
+            "version": "8.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "b121608b28a13f721e76ffbbd386d08eff58f3f6"
+                "reference": "7b8842c2d8e85d0c3a5831236bf5869af6ab2a11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/b121608b28a13f721e76ffbbd386d08eff58f3f6",
-                "reference": "b121608b28a13f721e76ffbbd386d08eff58f3f6",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/7b8842c2d8e85d0c3a5831236bf5869af6ab2a11",
+                "reference": "7b8842c2d8e85d0c3a5831236bf5869af6ab2a11",
                 "shasum": ""
             },
             "require": {
@@ -4735,7 +4971,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "8.1-dev"
+                    "dev-main": "8.0-dev"
                 }
             },
             "autoload": {
@@ -4763,7 +4999,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
                 "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/8.1.0"
+                "source": "https://github.com/sebastianbergmann/environment/tree/8.0.4"
             },
             "funding": [
                 {
@@ -4783,7 +5019,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-15T12:13:01+00:00"
+            "time": "2026-03-15T07:05:40+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -5373,6 +5609,580 @@
             "time": "2024-10-20T05:08:20+00:00"
         },
         {
+            "name": "symfony/console",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707",
+                "reference": "1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/string": "^7.2|^8.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<6.4",
+                "symfony/dotenv": "<6.4",
+                "symfony/event-dispatcher": "<6.4",
+                "symfony/lock": "<6.4",
+                "symfony/process": "<6.4"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0|2.0|3.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/lock": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/stopwatch": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Eases the creation of beautiful and testable command line interfaces",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "cli",
+                "command-line",
+                "console",
+                "terminal"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-30T13:54:39+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:21:43+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.34.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "ad1b7b9092976d6c948b8a187cec9faaea9ec1df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/ad1b7b9092976d6c948b8a187cec9faaea9ec1df",
+                "reference": "ad1b7b9092976d6c948b8a187cec9faaea9ec1df",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.34.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.34.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.34.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/60f19cd3badc8de688421e21e4305eba50f8089a",
+                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Executes commands in sub-processes",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v3.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-15T11:30:57+00:00"
+        },
+        {
+            "name": "symfony/string",
+            "version": "v8.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/string.git",
+                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/string/zipball/ae9488f874d7603f9d2dfbf120203882b645d963",
+                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-intl-grapheme": "^1.33",
+                "symfony/polyfill-intl-normalizer": "^1.0",
+                "symfony/polyfill-mbstring": "^1.0"
+            },
+            "conflict": {
+                "symfony/translation-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/emoji": "^7.4|^8.0",
+                "symfony/http-client": "^7.4|^8.0",
+                "symfony/intl": "^7.4|^8.0",
+                "symfony/translation-contracts": "^2.5|^3.0",
+                "symfony/var-exporter": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v8.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-30T15:14:47+00:00"
+        },
+        {
             "name": "theseer/tokenizer",
             "version": "2.0.1",
             "source": {
@@ -5490,6 +6300,7 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "automattic/jetpack-autoloader": 20,
+        "automattic/jetpack-changelogger": 20,
         "automattic/jetpack-composer-plugin": 20,
         "automattic/jetpack-config": 20,
         "automattic/jetpack-explat": 20,

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -4,27 +4,27 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a7cd1b2d4d28b9decbe21a0e6b47e8d9",
+    "content-hash": "5888fdf5b3ab632a0f07f80f5ca8dc17",
     "packages": [
         {
             "name": "automattic/at-pressable-podcasting",
-            "version": "v2.0.5",
+            "version": "v2.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/automattic/at-pressable-podcasting.git",
-                "reference": "c512aa27b2c33aee33bc024177c17f2745c52dfa"
+                "reference": "b3920eb6e94594aadb0c678f6c8328191091a9be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/automattic/at-pressable-podcasting/zipball/c512aa27b2c33aee33bc024177c17f2745c52dfa",
-                "reference": "c512aa27b2c33aee33bc024177c17f2745c52dfa",
+                "url": "https://api.github.com/repos/automattic/at-pressable-podcasting/zipball/b3920eb6e94594aadb0c678f6c8328191091a9be",
+                "reference": "b3920eb6e94594aadb0c678f6c8328191091a9be",
                 "shasum": ""
             },
             "type": "wordpress-plugin",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "time": "2025-11-24T21:07:37+00:00"
+            "time": "2026-04-24T20:01:37+00:00"
         },
         {
             "name": "automattic/block-delimiter",
@@ -32,13 +32,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/block-delimiter",
-                "reference": "38b17cad3ac0259b1358356beb4744d6ca606488"
+                "reference": "65f01ae1ff7636fd52709a61c203756ab190d7e3"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -144,13 +143,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/a8c-mc-stats",
-                "reference": "68b92cc77ac41309dbf2f7a16eecd4e0c9cb03a9"
+                "reference": "4877940876f9da0f0a796d37814f591f2392b748"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -198,7 +196,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "7b96f52e31ef50047c34a7f27870bd1c52f36787"
+                "reference": "36bf27e8bb95ad8b98897a3f0be80deffbe850b6"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -206,7 +204,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-logo": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
@@ -276,7 +273,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/assets",
-                "reference": "116afa785e69beb00f93503b12e0b0f4a0753ebb"
+                "reference": "a4c3991ea97f5705663221c8ebff9758b46fd683"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -284,7 +281,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
@@ -347,14 +343,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/autoloader",
-                "reference": "68901f3b3a256085ebd939a3461ee833be10f86d"
+                "reference": "8f0a2f6a6e125dc5e36f16323624fb2dfbc65a4b"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -416,7 +411,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/blaze",
-                "reference": "441a3689be7e956db950f27520952b81a249fedd"
+                "reference": "f600123b4b3ab650ab4f927971069b83f52d8ef6"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -429,7 +424,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -492,14 +486,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/blocks",
-                "reference": "34625c73a31fc7c9566591dc38d4ec3ef18c78b1"
+                "reference": "3a5646bd6d55bbc1a27880efe63dabe2ca208c6d"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
@@ -549,7 +542,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/classic-theme-helper",
-                "reference": "2a0ad5d46ab475954e8ec3d2d633234c06316b91"
+                "reference": "59ad12b263b6ca34f09350ba9547d5ff381a11d4"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -558,7 +551,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -616,13 +608,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/compat",
-                "reference": "f344c74fa490eee8870adf5cbf68c6a841c1e2ee"
+                "reference": "cca3c26e1aa14e6cfe16ed55099dd1fc39362778"
             },
             "require": {
                 "php": ">=7.2"
-            },
-            "require-dev": {
-                "automattic/jetpack-changelogger": "@dev"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -653,14 +642,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/composer-plugin",
-                "reference": "eb028c7425d0591689e2a0b3047c278d8ff2395e"
+                "reference": "5757fcdb855bc654b788aa1d75b3442e068c83ee"
             },
             "require": {
                 "composer-plugin-api": "^2.2",
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "composer/composer": "^2.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -714,14 +702,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/config",
-                "reference": "e29d7636760a80608d7856f2e3b28b54539923e5"
+                "reference": "c57552fadeaa0ee131577eea652128b3686f62cc"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
                 "automattic/jetpack-account-protection": "@dev",
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-import": "@dev",
                 "automattic/jetpack-jitm": "@dev",
@@ -786,7 +773,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "f43150bda979c1855db4ab23655bf26d12e75786"
+                "reference": "37cff8191289fa89742688ce970f25f702cb6ba8"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -799,7 +786,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-licensing": "@dev",
                 "automattic/jetpack-sync": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
@@ -873,13 +859,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/constants",
-                "reference": "378a5d122aedfc25d3aa42ab913803c85a8c857b"
+                "reference": "95cc69c8b39c9bc26cc430988a7de1297a654324"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -928,13 +913,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/device-detection",
-                "reference": "40cbfeb8412019423305cb3d071d1cd8ec5fccc3"
+                "reference": "b9aac1ae0b83275be407fad1ddd02a390bf68494"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -982,14 +966,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/explat",
-                "reference": "1da7eabd28e234c67a03fc7bff5760b383a0d91d"
+                "reference": "cd4e942a9037ee10214454b5ab621d9ff29141d6"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -1058,14 +1041,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/google-analytics",
-                "reference": "28cb18c8c47204ca7b0217f7c4b02527a8fd873f"
+                "reference": "0bbac6ede0742d16be602fcdfd70e47580935449"
             },
             "require": {
                 "automattic/jetpack-status": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1124,7 +1106,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/image-cdn",
-                "reference": "79b4ce2978edf4a5f586ceab9c2058a6cfcbef94"
+                "reference": "a56b0996e0af0641be4ab5a487fe24ed39fb20e5"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1132,7 +1114,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1185,13 +1166,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/ip",
-                "reference": "4c8f48266f1fe2551103c6293e2957e185f87a94"
+                "reference": "edf860f4e7e7096f7abfdc4083762c75ca7e64fb"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1244,7 +1224,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jitm",
-                "reference": "9236be3cd8bc85e4bfe49110ae26a78d7195c5f9"
+                "reference": "9bd15c67655ee061b5041261b7f1fbfeb228d3e1"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -1257,7 +1237,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1320,13 +1299,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/logo",
-                "reference": "ffa8535e2da982620164c7a251f0b2fbe46d3f16"
+                "reference": "340235b11e6729a362dcf53389a72c52b590a3ff"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -1374,7 +1352,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/masterbar",
-                "reference": "713257694eab74ca2b21290a99ac6cc1ffb392e1"
+                "reference": "7838d67127972c359395f6ff63f5c328a192b44f"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1390,7 +1368,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/patchwork-redefine-exit": "@dev",
                 "automattic/phpunit-select-config": "@dev",
@@ -1457,7 +1434,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/jetpack-mu-wpcom",
-                "reference": "ccc0a533c472ed92f9b43addc2681eb33e536359"
+                "reference": "8ccf42e3bb801d5edfc343c3648afe1976f7d6fc"
             },
             "require": {
                 "automattic/block-delimiter": "@dev",
@@ -1481,7 +1458,6 @@
                 "symfony/filesystem": "^6.0.0"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
@@ -1545,7 +1521,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/newsletter",
-                "reference": "405b39959d548729a98d187391cb940e7fca500c"
+                "reference": "8d9bb031a70efedb0d178e6c596dd487e80cca35"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1557,7 +1533,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1624,13 +1599,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/password-checker",
-                "reference": "33cc919e4b75e07ed12975588c42ae2ea723a9a4"
+                "reference": "48727ad4c6f29f009ac074465e36d4d387e3f82e"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1680,14 +1654,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "26f4ed44e15ea1e285b6b80870c7b8f3da56e9f8"
+                "reference": "ef664f6fcfde0b888d66e6f3d9893daeb4fa75a0"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
@@ -1743,14 +1716,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/post-list",
-                "reference": "b80081090e9695ec2c03b7830039abf9495cf85b"
+                "reference": "a505863c233f349c48e611943b0fef24f332032c"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1809,7 +1781,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/post-media",
-                "reference": "28b5f5b5b8ca9858e6c5ce23a4e852c756713960"
+                "reference": "6b1f642a168a1de8765232161d31001fbcea62eb"
             },
             "require": {
                 "automattic/block-delimiter": "@dev",
@@ -1818,7 +1790,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1877,14 +1848,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/redirect",
-                "reference": "44d6ec93e4d3b3db6287bf82f316a294d7ef868d"
+                "reference": "eff84ae54899356e87f28a2afe89745e26411ee7"
             },
             "require": {
                 "automattic/jetpack-status": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1933,13 +1903,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/roles",
-                "reference": "f7098eb11833c5fddfff032427d8576039aa3521"
+                "reference": "ae54f8dc58bd6bd7e82cf661afe5f2e8951cdd0c"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -1988,7 +1957,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/rtc",
-                "reference": "e8f440cdd4bedae187d26ee2c873bc9b52a88a66"
+                "reference": "8aef1a19335f20d685a42cf862a96c38ba3b34ec"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1996,7 +1965,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -2055,7 +2023,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats",
-                "reference": "089d88f8d263d41a36963e33c5d6330c0b0841a2"
+                "reference": "927d43834de1e46b37cfba8bba95f4ddd7edf251"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -2065,7 +2033,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -2123,7 +2090,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "d3cc7e7297df5dafcd3640b17e26ec24623f5096"
+                "reference": "c886544c38d3fd36c7120099a9c0b85d9776f416"
             },
             "require": {
                 "automattic/jetpack-blaze": "@dev",
@@ -2136,7 +2103,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -2192,14 +2158,13 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "8ce7c4c3d0a7c4ec9fce7b3002ba635afd5bc952"
+                "reference": "76cc443bfab1ccafe0e07fc050735bb33341f5a5"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-ip": "@dev",
                 "automattic/jetpack-plans": "@dev",
@@ -2257,7 +2222,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/subscribers-dashboard",
-                "reference": "d7a821c0f511c388a71049050807f4a1b56e9503"
+                "reference": "66832602601278e0202880bef8da1a396d34fa45"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -2269,7 +2234,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -2336,7 +2300,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/sync",
-                "reference": "39ff3d14b536ba6a0f501d28d436dcea93ce6857"
+                "reference": "946cdc6936bc54e9b5d22f0129003c0f9c9e475b"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -2348,7 +2312,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-search": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/jetpack-waf": "@dev",
@@ -2409,13 +2372,12 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/wp-abilities",
-                "reference": "d38d63604cbefe504f12a74a956502a648fdf521"
+                "reference": "e71e43ab54aaf244b0cb2e29999da393164021f5"
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "brain/monkey": "^2.6.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -2468,7 +2430,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/scheduled-updates",
-                "reference": "3f52602bf5f9547ed9d5081beac4660a8887dcfb"
+                "reference": "0fb9f0f3c89bc6c9e00a502220847efe72c1513a"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -2479,7 +2441,6 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
@@ -3790,96 +3751,12 @@
     ],
     "packages-dev": [
         {
-            "name": "automattic/jetpack-changelogger",
-            "version": "dev-trunk",
-            "dist": {
-                "type": "path",
-                "url": "../../packages/changelogger",
-                "reference": "b5353c88e04d5fae32ee501b1a0a4234ee968e56"
-            },
-            "require": {
-                "composer-runtime-api": "^2.2.0",
-                "php": ">=7.2.5",
-                "symfony/console": "^5.4 || ^6.4 || ^7.1",
-                "symfony/process": "^5.4 || ^6.4 || ^7.1"
-            },
-            "require-dev": {
-                "automattic/phpunit-select-config": "@dev",
-                "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-                "yoast/phpunit-polyfills": "^4.0.0"
-            },
-            "bin": [
-                "bin/changelogger"
-            ],
-            "type": "project",
-            "extra": {
-                "autotagger": true,
-                "branch-alias": {
-                    "dev-trunk": "6.0.x-dev"
-                },
-                "mirror-repo": "Automattic/jetpack-changelogger",
-                "version-constants": {
-                    "::VERSION": "src/Application.php"
-                },
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-changelogger/compare/${old}...${new}"
-                },
-                "dependencies": {
-                    "test-only": [
-                        "packages/phpunit-select-config"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\Changelogger\\": "src",
-                    "Automattic\\Jetpack\\Changelog\\": "lib"
-                }
-            },
-            "autoload-dev": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\Changelogger\\Tests\\": "tests/php/includes/src",
-                    "Automattic\\Jetpack\\Changelog\\Tests\\": "tests/php/includes/lib"
-                }
-            },
-            "scripts": {
-                "phpunit": [
-                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
-                ],
-                "test-coverage": [
-                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
-                ],
-                "test-php": [
-                    "@composer phpunit"
-                ],
-                "post-install-cmd": [
-                    "rm -f vendor/bin/changelogger && ln -s ../../bin/local-changelogger vendor/bin/changelogger"
-                ],
-                "post-update-cmd": [
-                    "rm -f vendor/bin/changelogger && ln -s ../../bin/local-changelogger vendor/bin/changelogger"
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Jetpack Changelogger tool. Allows for managing changelogs by dropping change files into a changelog directory with each PR.",
-            "keywords": [
-                "changelog",
-                "cli",
-                "dev",
-                "keepachangelog"
-            ],
-            "transport-options": {
-                "relative": true
-            }
-        },
-        {
             "name": "automattic/phpunit-select-config",
             "version": "dev-trunk",
             "dist": {
                 "type": "path",
                 "url": "../../packages/phpunit-select-config",
-                "reference": "3f16352a5a43bdd583b78d895d092a1e1b74c397"
+                "reference": "9e44d830cefeebc6c9b5a108cfab1ac3c1e3fd98"
             },
             "require": {
                 "composer-runtime-api": "^2.2.2",
@@ -3888,7 +3765,6 @@
             },
             "require-dev": {
                 "antecedent/patchwork": "^2.2",
-                "automattic/jetpack-changelogger": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
             "bin": [
@@ -4605,59 +4481,6 @@
                 }
             ],
             "time": "2026-04-13T05:38:19+00:00"
-        },
-        {
-            "name": "psr/container",
-            "version": "2.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/container.git",
-                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
-                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Container\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common Container Interface (PHP FIG PSR-11)",
-            "homepage": "https://github.com/php-fig/container",
-            "keywords": [
-                "PSR-11",
-                "container",
-                "container-interface",
-                "container-interop",
-                "psr"
-            ],
-            "support": {
-                "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/2.0.2"
-            },
-            "time": "2021-11-05T16:47:00+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -5609,580 +5432,6 @@
             "time": "2024-10-20T05:08:20+00:00"
         },
         {
-            "name": "symfony/console",
-            "version": "v7.4.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/console.git",
-                "reference": "1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707",
-                "reference": "1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/service-contracts": "^2.5|^3",
-                "symfony/string": "^7.2|^8.0"
-            },
-            "conflict": {
-                "symfony/dependency-injection": "<6.4",
-                "symfony/dotenv": "<6.4",
-                "symfony/event-dispatcher": "<6.4",
-                "symfony/lock": "<6.4",
-                "symfony/process": "<6.4"
-            },
-            "provide": {
-                "psr/log-implementation": "1.0|2.0|3.0"
-            },
-            "require-dev": {
-                "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
-                "symfony/http-foundation": "^6.4|^7.0|^8.0",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0",
-                "symfony/lock": "^6.4|^7.0|^8.0",
-                "symfony/messenger": "^6.4|^7.0|^8.0",
-                "symfony/process": "^6.4|^7.0|^8.0",
-                "symfony/stopwatch": "^6.4|^7.0|^8.0",
-                "symfony/var-dumper": "^6.4|^7.0|^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Console\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Eases the creation of beautiful and testable command line interfaces",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "cli",
-                "command-line",
-                "console",
-                "terminal"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.8"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-03-30T13:54:39+00:00"
-        },
-        {
-            "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/contracts",
-                    "name": "symfony/contracts"
-                },
-                "branch-alias": {
-                    "dev-main": "3.6-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "function.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "A generic function and convention to trigger deprecation notices",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-09-25T14:21:43+00:00"
-        },
-        {
-            "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.34.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "ad1b7b9092976d6c948b8a187cec9faaea9ec1df"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/ad1b7b9092976d6c948b8a187cec9faaea9ec1df",
-                "reference": "ad1b7b9092976d6c948b8a187cec9faaea9ec1df",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "suggest": {
-                "ext-intl": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for intl's grapheme_* functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "grapheme",
-                "intl",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.34.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-04-10T16:19:22+00:00"
-        },
-        {
-            "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.34.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "suggest": {
-                "ext-intl": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for intl's Normalizer class and related functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "intl",
-                "normalizer",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.34.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-09-09T11:45:10+00:00"
-        },
-        {
-            "name": "symfony/process",
-            "version": "v7.4.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/60f19cd3badc8de688421e21e4305eba50f8089a",
-                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Process\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Executes commands in sub-processes",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/process/tree/v7.4.8"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-03-24T13:12:05+00:00"
-        },
-        {
-            "name": "symfony/service-contracts",
-            "version": "v3.6.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "psr/container": "^1.1|^2.0",
-                "symfony/deprecation-contracts": "^2.5|^3"
-            },
-            "conflict": {
-                "ext-psr": "<1.1|>=2"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/contracts",
-                    "name": "symfony/contracts"
-                },
-                "branch-alias": {
-                    "dev-main": "3.6-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Contracts\\Service\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Test/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Generic abstractions related to writing services",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "abstractions",
-                "contracts",
-                "decoupling",
-                "interfaces",
-                "interoperability",
-                "standards"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-07-15T11:30:57+00:00"
-        },
-        {
-            "name": "symfony/string",
-            "version": "v8.0.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/string.git",
-                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/ae9488f874d7603f9d2dfbf120203882b645d963",
-                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.4",
-                "symfony/polyfill-ctype": "^1.8",
-                "symfony/polyfill-intl-grapheme": "^1.33",
-                "symfony/polyfill-intl-normalizer": "^1.0",
-                "symfony/polyfill-mbstring": "^1.0"
-            },
-            "conflict": {
-                "symfony/translation-contracts": "<2.5"
-            },
-            "require-dev": {
-                "symfony/emoji": "^7.4|^8.0",
-                "symfony/http-client": "^7.4|^8.0",
-                "symfony/intl": "^7.4|^8.0",
-                "symfony/translation-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^7.4|^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "Resources/functions.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Component\\String\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "grapheme",
-                "i18n",
-                "string",
-                "unicode",
-                "utf-8",
-                "utf8"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/string/tree/v8.0.8"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-03-30T15:14:47+00:00"
-        },
-        {
             "name": "theseer/tokenizer",
             "version": "2.0.1",
             "source": {
@@ -6300,7 +5549,6 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "automattic/jetpack-autoloader": 20,
-        "automattic/jetpack-changelogger": 20,
         "automattic/jetpack-composer-plugin": 20,
         "automattic/jetpack-config": 20,
         "automattic/jetpack-explat": 20,


### PR DESCRIPTION
Fixes # N/A

## Proposed changes

* Adds `Automattic\Jetpack\Stats\Abilities\Stats_Abilities`, a `Registrar` subclass that registers seven consolidated WordPress Abilities under the `jetpack-stats` category:
  * `jetpack-stats/get-site-overview` — zero-arg "how is my site doing?" snapshot (views today/week/month, visitors, streak, top post, top referrer); composes `WPCOM_Stats::get_stats_summary` + `get_highlights` + `get_streak` with `partial: true` / `errors: [...]` when any sub-call fails.
  * `jetpack-stats/get-top-content` — one filtered read over nine top-N surfaces (`posts`, `referrers`, `search-terms`, `clicks`, `tags`, `authors`, `countries`, `downloads`, `video-plays`) returning a uniform `{ rank, label, value, href? }` shape. Replaces what would have been ~9 atomic abilities.
  * `jetpack-stats/get-post-views` — per-post views timeseries with positive-integer `post_id` validation (guards the `empty('0')` trap).
  * `jetpack-stats/get-visits` — site views/visitors/likes/comments timeseries with `fields` selector; every row always includes every requested field (0 when WPCOM omits) so agents can iterate uniformly.
  * `jetpack-stats/get-followers` — composed email + WordPress.com + comment + publicize breakdown with the same `partial`/`errors` convention.
  * `jetpack-stats/get-stats-config` + `jetpack-stats/set-stats-config` — whitelisted read and declarative-state-setter for `stats_options` (`admin_bar`, `roles`, `count_roles`, `do_not_track`, `enable_odyssey_stats`). Writes use `Options::set_options()` for a single batched DB update, validate role slugs against registered roles, are idempotent when desired == current, and preserve unrelated internal keys (`notices`, `version`, …).
* Adds a compound capability gate: reads use `current_user_can( 'view_stats' )` (honored on self-hosted via `Stats\Main::map_meta_caps`); config writes use `current_user_can( 'manage_options' )` so a viewer role can't escalate by rewriting `roles`.
* Wires the registrar from `Stats\Main::__construct()` as a single `Stats_Abilities::init()` call. Gated behind `apply_filters( 'jetpack_wp_abilities_enabled', false )` in `Registrar::init()` — default is off, so this PR ships dormant until a site opts in.
* Adds `automattic/jetpack-wp-abilities` to the Stats package's `composer.json` require list.
* Adds 41 PHPUnit tests (233 assertions) covering abstract contract, Registrar wiring (gate default false, lifecycle hooks added, per-ability allow-list filter), permissions (admin/subscriber/anonymous), execute paths for every ability (with a stubbed `WPCOM_Stats`), the `'0'` post-id regression guard, schema edge cases, declarative-write idempotency, and uniform per-type shape for `get-top-content`.

## Related product discussion/links

* Design doc / audit: `plans/2026-04-23-abilities-audit-jetpack-stats.md` in this checkout (walks the consolidation heuristic applied to WPCOM_Stats' ~25 methods).

## Does this pull request change what data or activity we track or use?

No. The abilities wrap existing `WPCOM_Stats` reads and `stats_options` reads/writes; no new telemetry is introduced. `do_not_track` remains a user-settable option.

## Testing instructions

1. Check out this branch and run `composer install` inside `projects/packages/stats/`.
2. From `projects/packages/stats/`, run `composer phpunit -- --filter Stats_Abilities_Test`. All 41 tests should pass with no notices.
3. On a site running Jetpack with the Stats module active and connected to WordPress.com, enable the abilities surface:
   ```php
   add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
   ```
4. As an administrator, hit `GET /wp-json/wp-abilities/v1/abilities`. Confirm the seven `jetpack-stats/*` slugs are listed.
5. Invoke `jetpack-stats/get-site-overview` via `POST /wp-json/wp-abilities/v1/run/jetpack-stats/get-site-overview` with an empty body. You should get `{ date, views_today, visitors_today, views_week, views_month, streak: {...}, top_post: {...}|null, top_referrer: {...}|null, partial: false }`. If the site is not connected to WordPress.com, confirm you get `WP_Error` with code `jetpack_stats_data_unavailable`.
6. Invoke `jetpack-stats/get-top-content` with `{ "type": "posts", "max": 5 }`. Confirm the response contains `items: [ { rank: 1, label: "…", value: N, href?: "…" }, … ]`.
7. As a subscriber, confirm the same endpoints return a permission error — reads require `view_stats`, config writes require `manage_options`.
8. Invoke `jetpack-stats/set-stats-config` with `{ "admin_bar": false }`. Confirm `{ changed: true, config: { admin_bar: false, roles: [...], ... } }`. Call it again with the same body — confirm `changed: false`.
9. Invoke `jetpack-stats/set-stats-config` with `{ "roles": ["not_a_real_role"] }`. Confirm `WP_Error` with code `jetpack_stats_invalid_role` and a message listing the valid slugs.
