### PR TITLE
Search 3.0: add Compact Search block pattern with filter + sort popovers

### DIFF
--- a/projects/packages/search/changelog/add-search-30-compact-pattern
+++ b/projects/packages/search/changelog/add-search-30-compact-pattern
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search 3.0: Add Compact Search block pattern with inline filter and sort popover controls.

--- a/projects/packages/search/src/search-blocks/blocks/filter-popover/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/filter-popover/block.json
@@ -1,0 +1,18 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "jetpack/filter-popover",
+	"version": "0.1.0",
+	"title": "Filter Popover",
+	"category": "jetpack-search",
+	"icon": "filter",
+	"description": "Compact filter trigger that opens a popover containing filter checkboxes.",
+	"supports": {
+		"html": false,
+		"interactivity": true
+	},
+	"textdomain": "jetpack-search-pkg",
+	"render": "file:./render.php",
+	"viewScriptModule": "file:../../../../build/search-blocks/filter-popover.js",
+	"style": "file:../../../../build/search-blocks/filter-popover.css"
+}

--- a/projects/packages/search/src/search-blocks/blocks/filter-popover/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-popover/edit.js
@@ -46,7 +46,7 @@ export default function FilterPopoverEdit() {
 					'aria-hidden': 'true',
 					focusable: 'false',
 				},
-				h( 'path', { fill: 'currentColor', d: 'M4 5h16v2l-6 6v5l-4 2v-7L4 7V5Z' } )
+				h( 'path', { fill: 'currentColor', d: 'M3 6h18v2H3V6Zm3 5h12v2H6v-2Zm3 5h6v2H9v-2Z' } )
 			),
 			h( 'span', { className: 'screen-reader-text' }, __( 'Filter results', 'jetpack-search-pkg' ) )
 		),

--- a/projects/packages/search/src/search-blocks/blocks/filter-popover/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-popover/edit.js
@@ -1,8 +1,8 @@
 /**
  * Editor preview for jetpack/filter-popover.
  *
- * Renders the trigger + an always-open panel in the editor so inner blocks
- * are visible and editable. Real popover behaviour is front-end only.
+ * Renders the trigger + a closed panel in the editor so the full Search
+ * pattern preview mirrors the front-end default state.
  */
 import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import { createElement as h } from '@wordpress/element';
@@ -33,7 +33,7 @@ export default function FilterPopoverEdit() {
 				type: 'button',
 				className: 'jetpack-search-filter-popover__trigger',
 				'aria-haspopup': 'dialog',
-				'aria-expanded': 'true',
+				'aria-expanded': 'false',
 				disabled: true,
 			},
 			h(
@@ -55,6 +55,9 @@ export default function FilterPopoverEdit() {
 			{
 				className:
 					'jetpack-search-filter-popover__panel jetpack-search-filter-popover__panel--editor',
+				role: 'dialog',
+				'aria-label': __( 'Filters', 'jetpack-search-pkg' ),
+				hidden: true,
 			},
 			h( InnerBlocks, { template: TEMPLATE, allowedBlocks: ALLOWED } )
 		)

--- a/projects/packages/search/src/search-blocks/blocks/filter-popover/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-popover/edit.js
@@ -1,0 +1,69 @@
+/**
+ * Editor preview for jetpack/filter-popover.
+ *
+ * Renders the trigger + an always-open panel in the editor so inner blocks
+ * are visible and editable. Real popover behaviour is front-end only.
+ */
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import { createElement as h } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+const TEMPLATE = [
+	[ 'jetpack/active-filters' ],
+	[ 'jetpack/filter-checkbox', { filterType: 'taxonomy', taxonomy: 'category' } ],
+	[ 'jetpack/filter-checkbox', { filterType: 'taxonomy', taxonomy: 'post_tag' } ],
+	[ 'jetpack/filter-checkbox', { filterType: 'post_type' } ],
+];
+
+const ALLOWED = [ 'jetpack/filter-checkbox', 'jetpack/active-filters' ];
+
+/**
+ * Edit component for the filter-popover block.
+ *
+ * @return {object} Rendered element.
+ */
+export default function FilterPopoverEdit() {
+	const blockProps = useBlockProps( { className: 'jetpack-search-filter-popover' } );
+	return h(
+		'div',
+		blockProps,
+		h(
+			'button',
+			{
+				type: 'button',
+				className: 'jetpack-search-filter-popover__trigger',
+				'aria-haspopup': 'dialog',
+				'aria-expanded': 'true',
+				disabled: true,
+			},
+			h(
+				'svg',
+				{
+					className: 'jetpack-search-filter-popover__icon',
+					width: 18,
+					height: 18,
+					viewBox: '0 0 24 24',
+					'aria-hidden': 'true',
+					focusable: 'false',
+				},
+				h( 'path', { fill: 'currentColor', d: 'M4 5h16v2l-6 6v5l-4 2v-7L4 7V5Z' } )
+			),
+			h( 'span', { className: 'screen-reader-text' }, __( 'Filter results', 'jetpack-search-pkg' ) )
+		),
+		h(
+			'div',
+			{
+				className:
+					'jetpack-search-filter-popover__panel jetpack-search-filter-popover__panel--editor',
+			},
+			h( InnerBlocks, { template: TEMPLATE, allowedBlocks: ALLOWED } )
+		)
+	);
+}
+
+/**
+ * Save component — only renders InnerBlocks.Content.
+ *
+ * @return {object} Rendered element.
+ */
+export const save = () => h( InnerBlocks.Content, {} );

--- a/projects/packages/search/src/search-blocks/blocks/filter-popover/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-popover/render.php
@@ -38,9 +38,13 @@ $panel_id = wp_unique_id( 'jetpack-search-filter-panel-' );
 		<span
 			class="jetpack-search-filter-popover__badge"
 			data-wp-bind--hidden="!state.activeFilterCount"
-			data-wp-text="state.activeFilterCount"
 			hidden
-		></span>
+		>
+			<span
+				class="jetpack-search-filter-popover__badge-count"
+				data-wp-text="state.activeFilterCount"
+			></span>
+		</span>
 	</button>
 	<div
 		id="<?php echo esc_attr( $panel_id ); ?>"

--- a/projects/packages/search/src/search-blocks/blocks/filter-popover/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-popover/render.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Filter Popover block render.
+ *
+ * Wraps inner blocks (filter-checkbox + active-filters) in a trigger-button
+ * + popover-panel shell. Popover state is owned by the Interactivity API
+ * store (`state.isFilterPopoverOpen`); see `store/index.js`.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+
+$panel_id = wp_unique_id( 'jetpack-search-filter-panel-' );
+?>
+<div
+	<?php echo wp_kses_data( get_block_wrapper_attributes( array( 'class' => 'jetpack-search-filter-popover' ) ) ); ?>
+	data-wp-interactive="jetpack-search"
+	data-jetpack-search-popover-root
+	data-wp-on-window--click="actions.onWindowClickClosePopovers"
+	data-wp-on-window--keydown="actions.onEscapeClosePopovers"
+>
+	<button
+		type="button"
+		class="jetpack-search-filter-popover__trigger"
+		aria-haspopup="dialog"
+		data-wp-bind--aria-expanded="state.isFilterPopoverOpen"
+		aria-controls="<?php echo esc_attr( $panel_id ); ?>"
+		data-wp-on--click="actions.toggleFilterPopover"
+	>
+		<svg class="jetpack-search-filter-popover__icon" width="18" height="18" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+			<path fill="currentColor" d="M4 5h16v2l-6 6v5l-4 2v-7L4 7V5Z"/>
+		</svg>
+		<span class="screen-reader-text"><?php esc_html_e( 'Filter results', 'jetpack-search-pkg' ); ?></span>
+		<span
+			class="jetpack-search-filter-popover__badge"
+			data-wp-bind--hidden="!state.activeFilterCount"
+			data-wp-text="state.activeFilterCount"
+			hidden
+		></span>
+	</button>
+	<div
+		id="<?php echo esc_attr( $panel_id ); ?>"
+		class="jetpack-search-filter-popover__panel"
+		role="dialog"
+		aria-label="<?php esc_attr_e( 'Filters', 'jetpack-search-pkg' ); ?>"
+		data-wp-bind--hidden="!state.isFilterPopoverOpen"
+		hidden
+	>
+		<?php
+		// @phan-suppress-next-line PhanUndeclaredGlobalVariable -- $content is provided by WP at block render.
+		echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Inner block HTML is already escaped by each child block's renderer.
+		?>
+	</div>
+</div>

--- a/projects/packages/search/src/search-blocks/blocks/filter-popover/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-popover/render.php
@@ -26,7 +26,9 @@ $panel_id = wp_unique_id( 'jetpack-search-filter-panel-' );
 		type="button"
 		class="jetpack-search-filter-popover__trigger"
 		aria-haspopup="dialog"
+		aria-expanded="false"
 		data-wp-bind--aria-expanded="state.isFilterPopoverOpen"
+		disabled
 		data-wp-bind--disabled="state.isFilterTriggerDisabled"
 		aria-controls="<?php echo esc_attr( $panel_id ); ?>"
 		data-wp-on--click="actions.toggleFilterPopover"

--- a/projects/packages/search/src/search-blocks/blocks/filter-popover/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-popover/render.php
@@ -27,6 +27,7 @@ $panel_id = wp_unique_id( 'jetpack-search-filter-panel-' );
 		class="jetpack-search-filter-popover__trigger"
 		aria-haspopup="dialog"
 		data-wp-bind--aria-expanded="state.isFilterPopoverOpen"
+		data-wp-bind--disabled="state.isFilterTriggerDisabled"
 		aria-controls="<?php echo esc_attr( $panel_id ); ?>"
 		data-wp-on--click="actions.toggleFilterPopover"
 	>

--- a/projects/packages/search/src/search-blocks/blocks/filter-popover/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-popover/render.php
@@ -31,7 +31,7 @@ $panel_id = wp_unique_id( 'jetpack-search-filter-panel-' );
 		data-wp-on--click="actions.toggleFilterPopover"
 	>
 		<svg class="jetpack-search-filter-popover__icon" width="18" height="18" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-			<path fill="currentColor" d="M4 5h16v2l-6 6v5l-4 2v-7L4 7V5Z"/>
+			<path fill="currentColor" d="M3 6h18v2H3V6Zm3 5h12v2H6v-2Zm3 5h6v2H9v-2Z"/>
 		</svg>
 		<span class="screen-reader-text"><?php esc_html_e( 'Filter results', 'jetpack-search-pkg' ); ?></span>
 		<span

--- a/projects/packages/search/src/search-blocks/blocks/filter-popover/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filter-popover/style.scss
@@ -73,10 +73,12 @@
 		flex-direction: column;
 		gap: 1rem;
 		padding: 12px;
-		background: var(--wp--preset--color--background, #fff);
-		// The panel uses a light surface, so don't inherit a low-contrast
-		// body accent color from the surrounding page.
-		color: var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, #111));
+		--jetpack-search-popover-background: var(--wp--preset--color--background, #fff);
+		--jetpack-search-popover-color: var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, #111));
+		background: var(--jetpack-search-popover-background);
+		// The panel owns its surface, so don't inherit a low-contrast body
+		// accent color from the surrounding page.
+		color: var(--jetpack-search-popover-color);
 		// Reset the inherited theme base size so popover body text tracks the
 		// search-results title (also 1rem) instead of the host theme's
 		// oversized default. Rem-based children (filter title, count pill)

--- a/projects/packages/search/src/search-blocks/blocks/filter-popover/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filter-popover/style.scss
@@ -73,8 +73,8 @@
 		flex-direction: column;
 		gap: 1rem;
 		padding: 12px;
-		--jetpack-search-popover-background: var(--wp--preset--color--background, #fff);
-		--jetpack-search-popover-color: var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, #111));
+		--jetpack-search-popover-background: var(--wp--preset--color--base, #fff);
+		--jetpack-search-popover-color: var(--wp--preset--color--contrast, #111);
 		background: var(--jetpack-search-popover-background);
 		// The panel owns its surface, so don't inherit a low-contrast body
 		// accent color from the surrounding page.

--- a/projects/packages/search/src/search-blocks/blocks/filter-popover/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filter-popover/style.scss
@@ -36,8 +36,8 @@
 		// (white bg behind a white-on-white badge). Text inversion is done on
 		// the inner count span instead.
 		position: absolute;
-		top: 0;
-		right: 0;
+		inset-block-start: 0;
+		inset-inline-end: 0;
 		transform: translate(50%, -50%);
 		box-sizing: border-box;
 		min-width: 16px;
@@ -52,6 +52,10 @@
 		&[hidden] {
 			display: none;
 		}
+
+		:dir(rtl) & {
+			transform: translate(-50%, -50%);
+		}
 	}
 
 	&__badge-count {
@@ -60,8 +64,8 @@
 
 	&__panel {
 		position: absolute;
-		right: 0;
-		top: calc(100% + 4px);
+		inset-inline-end: 0;
+		inset-block-start: calc(100% + 4px);
 		min-width: 260px;
 		max-width: min(360px, 90vw);
 		z-index: 20;

--- a/projects/packages/search/src/search-blocks/blocks/filter-popover/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filter-popover/style.scss
@@ -3,6 +3,7 @@
 	display: inline-block;
 
 	&__trigger {
+		position: relative;
 		display: inline-flex;
 		align-items: center;
 		justify-content: center;
@@ -29,22 +30,32 @@
 	}
 
 	&__badge {
+		// Keep the badge element itself at the inherited theme text color so
+		// `currentColor` below resolves to the readable ink — not to the
+		// inverted text color, which made the pill invisible on light themes
+		// (white bg behind a white-on-white badge). Text inversion is done on
+		// the inner count span instead.
 		position: absolute;
-		top: -4px;
-		right: -4px;
+		top: 0;
+		right: 0;
+		transform: translate(50%, -50%);
+		box-sizing: border-box;
 		min-width: 16px;
 		height: 16px;
 		padding: 0 4px;
 		font-size: 11px;
 		line-height: 16px;
 		text-align: center;
-		color: var(--wp--preset--color--background, #fff);
 		background: color-mix(in sRGB, currentColor 85%, transparent);
 		border-radius: 8px;
 
 		&[hidden] {
 			display: none;
 		}
+	}
+
+	&__badge-count {
+		color: var(--wp--preset--color--background, #fff);
 	}
 
 	&__panel {
@@ -54,9 +65,17 @@
 		min-width: 260px;
 		max-width: min(360px, 90vw);
 		z-index: 20;
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
 		padding: 12px;
 		background: var(--wp--preset--color--background, #fff);
 		color: inherit;
+		// Reset the inherited theme base size so popover body text tracks the
+		// search-results title (also 1rem) instead of the host theme's
+		// oversized default. Rem-based children (filter title, count pill)
+		// keep their explicit sizes.
+		font-size: 1rem;
 		border: 1px solid;
 		border-color: color-mix(in sRGB, currentColor 15%, transparent);
 		border-radius: 4px;

--- a/projects/packages/search/src/search-blocks/blocks/filter-popover/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filter-popover/style.scss
@@ -73,12 +73,10 @@
 		flex-direction: column;
 		gap: 1rem;
 		padding: 12px;
-		--jetpack-search-popover-background: var(--wp--preset--color--base, #fff);
-		--jetpack-search-popover-color: var(--wp--preset--color--contrast, #111);
-		background: var(--jetpack-search-popover-background);
+		background: var(--wp--preset--color--base);
 		// The panel owns its surface, so don't inherit a low-contrast body
 		// accent color from the surrounding page.
-		color: var(--jetpack-search-popover-color);
+		color: var(--wp--preset--color--contrast);
 		// Reset the inherited theme base size so popover body text tracks the
 		// search-results title (also 1rem) instead of the host theme's
 		// oversized default. Rem-based children (filter title, count pill)

--- a/projects/packages/search/src/search-blocks/blocks/filter-popover/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filter-popover/style.scss
@@ -17,9 +17,14 @@
 		border-radius: 4px;
 		cursor: pointer;
 
-		&:hover,
+		&:hover:not(:disabled),
 		&[aria-expanded="true"] {
 			background: color-mix(in sRGB, currentColor 6%, transparent);
+		}
+
+		&:disabled {
+			cursor: not-allowed;
+			opacity: 0.4;
 		}
 	}
 

--- a/projects/packages/search/src/search-blocks/blocks/filter-popover/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filter-popover/style.scss
@@ -1,0 +1,69 @@
+.jetpack-search-filter-popover {
+	position: relative;
+	display: inline-block;
+
+	&__trigger {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		gap: 4px;
+		width: 2rem;
+		height: 2rem;
+		padding: 0;
+		border: 1px solid;
+		border-color: color-mix(in sRGB, currentColor 20%, transparent);
+		background: transparent;
+		color: inherit;
+		border-radius: 4px;
+		cursor: pointer;
+
+		&:hover,
+		&[aria-expanded="true"] {
+			background: color-mix(in sRGB, currentColor 6%, transparent);
+		}
+	}
+
+	&__badge {
+		position: absolute;
+		top: -4px;
+		right: -4px;
+		min-width: 16px;
+		height: 16px;
+		padding: 0 4px;
+		font-size: 11px;
+		line-height: 16px;
+		text-align: center;
+		color: var(--wp--preset--color--background, #fff);
+		background: color-mix(in sRGB, currentColor 85%, transparent);
+		border-radius: 8px;
+
+		&[hidden] {
+			display: none;
+		}
+	}
+
+	&__panel {
+		position: absolute;
+		right: 0;
+		top: calc(100% + 4px);
+		min-width: 260px;
+		max-width: min(360px, 90vw);
+		z-index: 20;
+		padding: 12px;
+		background: var(--wp--preset--color--background, #fff);
+		color: inherit;
+		border: 1px solid;
+		border-color: color-mix(in sRGB, currentColor 15%, transparent);
+		border-radius: 4px;
+		box-shadow: 0 4px 16px color-mix(in sRGB, currentColor 12%, transparent);
+
+		&[hidden] {
+			display: none;
+		}
+
+		&--editor {
+			position: static;
+			box-shadow: none;
+		}
+	}
+}

--- a/projects/packages/search/src/search-blocks/blocks/filter-popover/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filter-popover/style.scss
@@ -74,7 +74,9 @@
 		gap: 1rem;
 		padding: 12px;
 		background: var(--wp--preset--color--background, #fff);
-		color: inherit;
+		// The panel uses a light surface, so don't inherit a low-contrast
+		// body accent color from the surrounding page.
+		color: var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, #111));
 		// Reset the inherited theme base size so popover body text tracks the
 		// search-results title (also 1rem) instead of the host theme's
 		// oversized default. Rem-based children (filter title, count pill)

--- a/projects/packages/search/src/search-blocks/blocks/filter-popover/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-popover/view.js
@@ -1,1 +1,2 @@
 import '../../store';
+import './style.scss';

--- a/projects/packages/search/src/search-blocks/blocks/filter-popover/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-popover/view.js
@@ -1,0 +1,1 @@
+import '../../store';

--- a/projects/packages/search/src/search-blocks/blocks/no-results/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/no-results/edit.js
@@ -1,9 +1,9 @@
 /**
  * Editor preview for jetpack/no-results.
  *
- * The front end hides this block when results are present; the editor always
- * shows it so designers can style it. The Inspector exposes a text input for
- * the `message` attribute, which is read by render.php on the front end.
+ * The front end hides this block when results are present. The editor keeps
+ * that successful-results preview clean while still exposing the message
+ * setting in the Inspector.
  */
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { PanelBody, TextControl } from '@wordpress/components';
@@ -21,7 +21,6 @@ import { __ } from '@wordpress/i18n';
 export default function NoResultsEdit( { attributes, setAttributes } ) {
 	const blockProps = useBlockProps();
 	const defaultMessage = __( 'No results found. Try a different search.', 'jetpack-search-pkg' );
-	const message = attributes.message || defaultMessage;
 	return h(
 		Fragment,
 		null,
@@ -42,6 +41,6 @@ export default function NoResultsEdit( { attributes, setAttributes } ) {
 				} )
 			)
 		),
-		h( 'div', blockProps, h( 'p', null, message ) )
+		h( 'div', { ...blockProps, hidden: true, 'aria-hidden': 'true' } )
 	);
 }

--- a/projects/packages/search/src/search-blocks/blocks/search-input/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/style.scss
@@ -1,3 +1,10 @@
+// Inside the Compact Search pattern's toolbar, the input grows to fill the
+// remaining row width so the filter / sort triggers sit right next to it.
+.jetpack-search-compact-toolbar > .wp-block-jetpack-search-input {
+	flex: 1 1 0;
+	min-width: 0;
+}
+
 .wp-block-jetpack-search-input {
 
 	.jetpack-search-input__inside-wrapper {

--- a/projects/packages/search/src/search-blocks/blocks/search-results/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/search-results/block.json
@@ -7,6 +7,13 @@
 	"category": "jetpack-search",
 	"icon": "list-view",
 	"description": "Displays Jetpack Search results.",
+	"attributes": {
+		"layout": {
+			"type": "string",
+			"enum": [ "card", "compact" ],
+			"default": "card"
+		}
+	},
 	"supports": {
 		"html": false,
 		"interactivity": true

--- a/projects/packages/search/src/search-blocks/blocks/search-results/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-results/edit.js
@@ -10,19 +10,16 @@ const SAMPLE_RESULTS = [
 		title: __( 'First sample result', 'jetpack-search-pkg' ),
 		path: 'example.com/articles/first',
 		date: 'Apr 1, 2026',
-		author: 'Ada Lovelace',
 	},
 	{
 		title: __( 'Another relevant post', 'jetpack-search-pkg' ),
 		path: 'example.com/guides/another',
 		date: 'Mar 22, 2026',
-		author: 'Grace Hopper',
 	},
 	{
 		title: __( 'Older archived entry', 'jetpack-search-pkg' ),
 		path: 'example.com/2025/older',
 		date: 'Dec 18, 2025',
-		author: 'Katherine Johnson',
 	},
 ];
 
@@ -57,9 +54,7 @@ export default function SearchResultsEdit( { attributes } ) {
 						h(
 							'div',
 							{ className: 'jetpack-search-results__meta' },
-							h( 'span', { className: 'jetpack-search-results__date' }, result.date ),
-							isCompact &&
-								h( 'span', { className: 'jetpack-search-results__author' }, result.author )
+							h( 'span', { className: 'jetpack-search-results__date' }, result.date )
 						)
 					),
 					! isCompact &&

--- a/projects/packages/search/src/search-blocks/blocks/search-results/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-results/edit.js
@@ -1,42 +1,44 @@
 /**
  * Editor preview for jetpack/search-results.
- *
- * Renders sample rows, including the (hidden) image-link wrapper render.php
- * emits so designers can style the `.jetpack-search-results__image-link` /
- * `__image` CSS hooks.
  */
 import { useBlockProps } from '@wordpress/block-editor';
 import { createElement as h } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
-// Mock result data. Dates are intentionally not wrapped in __() because
-// they are fixed display strings, not translatable content — localized
-// dates come from `formatDate()` on the live front end.
 const SAMPLE_RESULTS = [
 	{
 		title: __( 'First sample result', 'jetpack-search-pkg' ),
 		path: 'example.com/articles/first',
 		date: 'Apr 1, 2026',
+		author: 'Ada Lovelace',
 	},
 	{
 		title: __( 'Another relevant post', 'jetpack-search-pkg' ),
 		path: 'example.com/guides/another',
 		date: 'Mar 22, 2026',
+		author: 'Grace Hopper',
 	},
 	{
 		title: __( 'Older archived entry', 'jetpack-search-pkg' ),
 		path: 'example.com/2025/older',
 		date: 'Dec 18, 2025',
+		author: 'Katherine Johnson',
 	},
 ];
 
 /**
- * Edit component for the search-results block.
+ * Editor preview for the search-results block.
  *
+ * @param {object} props            - Block props.
+ * @param {object} props.attributes - Block attributes.
  * @return {object} Rendered element.
  */
-export default function SearchResultsEdit() {
-	const blockProps = useBlockProps();
+export default function SearchResultsEdit( { attributes } ) {
+	const layout = attributes?.layout ?? 'card';
+	const isCompact = layout === 'compact';
+	const blockProps = useBlockProps( {
+		className: isCompact ? 'jetpack-search-results--compact' : 'jetpack-search-results--card',
+	} );
 	return h(
 		'div',
 		blockProps,
@@ -51,19 +53,26 @@ export default function SearchResultsEdit() {
 						'div',
 						{ className: 'jetpack-search-results__copy' },
 						h( 'h3', { className: 'jetpack-search-results__title' }, result.title ),
-						h( 'div', { className: 'jetpack-search-results__path' }, result.path ),
-						h( 'div', { className: 'jetpack-search-results__date' }, result.date )
+						! isCompact && h( 'div', { className: 'jetpack-search-results__path' }, result.path ),
+						h(
+							'div',
+							{ className: 'jetpack-search-results__meta' },
+							h( 'span', { className: 'jetpack-search-results__date' }, result.date ),
+							isCompact &&
+								h( 'span', { className: 'jetpack-search-results__author' }, result.author )
+						)
 					),
-					h(
-						'a',
-						{
-							className: 'jetpack-search-results__image-link',
-							hidden: true,
-							tabIndex: -1,
-							'aria-hidden': 'true',
-						},
-						h( 'img', { className: 'jetpack-search-results__image', alt: '' } )
-					)
+					! isCompact &&
+						h(
+							'a',
+							{
+								className: 'jetpack-search-results__image-link',
+								hidden: true,
+								tabIndex: -1,
+								'aria-hidden': 'true',
+							},
+							h( 'img', { className: 'jetpack-search-results__image', alt: '' } )
+						)
 				)
 			)
 		)

--- a/projects/packages/search/src/search-blocks/blocks/search-results/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/search-results/render.php
@@ -2,20 +2,21 @@
 /**
  * Search Results block render.
  *
- * Pure template — no PHP pre-fetch. Search_Blocks::seed_interactivity_state()
- * already seeds empty `results` / `aggregations` / `totalResults` plus an
- * `isLoading` flag that's true whenever the URL carries a search query or
- * filter selection, so the JS store fetches on hydration without flashing
- * the no-results block first.
- *
  * @package automattic/jetpack-search
  */
 
 namespace Automattic\Jetpack\Search;
 
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+
+// @phan-suppress-next-line PhanUndeclaredGlobalVariable
+$layout        = ( (array) $attributes )['layout'] ?? 'card';
+$is_compact    = 'compact' === $layout;
+$wrapper_class = $is_compact ? 'jetpack-search-results--compact' : 'jetpack-search-results--card';
+$wrapper_attrs = get_block_wrapper_attributes( array( 'class' => $wrapper_class ) );
 ?>
 <div
-	<?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>
+	<?php echo wp_kses_data( $wrapper_attrs ); ?>
 	data-wp-interactive="jetpack-search"
 	data-wp-init="callbacks.initialize"
 	data-wp-bind--aria-busy="state.isLoading"
@@ -50,30 +51,43 @@ namespace Automattic\Jetpack\Search;
 							</template>
 						</a>
 					</h3>
-					<div
-						class="jetpack-search-results__path"
-						data-wp-bind--hidden="!context.result.path"
-						data-wp-text="context.result.path"
-					></div>
-					<div
-						class="jetpack-search-results__date"
-						data-wp-bind--hidden="!context.result.dateLabel"
-						data-wp-text="context.result.dateLabel"
-					></div>
+					<?php if ( ! $is_compact ) : ?>
+						<div
+							class="jetpack-search-results__path"
+							data-wp-bind--hidden="!context.result.path"
+							data-wp-text="context.result.path"
+						></div>
+					<?php endif; ?>
+					<div class="jetpack-search-results__meta">
+						<span
+							class="jetpack-search-results__date"
+							data-wp-bind--hidden="!context.result.dateLabel"
+							data-wp-text="context.result.dateLabel"
+						></span>
+						<?php if ( $is_compact ) : ?>
+							<span
+								class="jetpack-search-results__author"
+								data-wp-bind--hidden="!context.result.author"
+								data-wp-text="context.result.author"
+							></span>
+						<?php endif; ?>
+					</div>
 				</div>
-				<a
-					class="jetpack-search-results__image-link"
-					data-wp-bind--href="context.result.permalink"
-					data-wp-bind--hidden="!context.result.imageUrl"
-					tabindex="-1"
-					aria-hidden="true"
-				>
-					<img
-						class="jetpack-search-results__image"
-						data-wp-bind--src="context.result.imageUrl"
-						alt=""
-					/>
-				</a>
+				<?php if ( ! $is_compact ) : ?>
+					<a
+						class="jetpack-search-results__image-link"
+						data-wp-bind--href="context.result.permalink"
+						data-wp-bind--hidden="!context.result.imageUrl"
+						tabindex="-1"
+						aria-hidden="true"
+					>
+						<img
+							class="jetpack-search-results__image"
+							data-wp-bind--src="context.result.imageUrl"
+							alt=""
+						/>
+					</a>
+				<?php endif; ?>
 			</li>
 		</template>
 	</ul>

--- a/projects/packages/search/src/search-blocks/blocks/search-results/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/search-results/render.php
@@ -64,13 +64,6 @@ $wrapper_attrs = get_block_wrapper_attributes( array( 'class' => $wrapper_class 
 							data-wp-bind--hidden="!context.result.dateLabel"
 							data-wp-text="context.result.dateLabel"
 						></span>
-						<?php if ( $is_compact ) : ?>
-							<span
-								class="jetpack-search-results__author"
-								data-wp-bind--hidden="!context.result.author"
-								data-wp-text="context.result.author"
-							></span>
-						<?php endif; ?>
 					</div>
 				</div>
 				<?php if ( ! $is_compact ) : ?>

--- a/projects/packages/search/src/search-blocks/blocks/search-results/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/search-results/render.php
@@ -37,7 +37,7 @@ $wrapper_attrs = get_block_wrapper_attributes( array( 'class' => $wrapper_class 
 							data-wp-bind--href="context.result.permalink"
 						>
 							<span
-								data-wp-bind--hidden="context.result.hasTitleHighlight"
+								data-wp-bind--hidden="context.result.hasTitlePieces"
 								data-wp-text="context.result.title"
 							></span>
 							<template

--- a/projects/packages/search/src/search-blocks/blocks/search-results/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/search-results/style.scss
@@ -129,7 +129,7 @@
 
 	.jetpack-search-results__author::before {
 		content: "·";
-		margin-right: 0.75rem;
+		margin-inline-end: 0.75rem;
 		opacity: 0.6;
 	}
 }

--- a/projects/packages/search/src/search-blocks/blocks/search-results/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/search-results/style.scss
@@ -40,7 +40,7 @@
 	}
 
 	.jetpack-search-results__highlight {
-		background: rgba(255, 230, 0, 0.35);
+		background: var(--jetpack-search-highlight-background, color-mix(in sRGB, currentColor 18%, transparent));
 		font-weight: 700;
 	}
 

--- a/projects/packages/search/src/search-blocks/blocks/search-results/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/search-results/style.scss
@@ -126,4 +126,8 @@
 		font-size: 0.875em;
 		opacity: 0.75;
 	}
+
+	.jetpack-search-results__date {
+		margin-top: 0;
+	}
 }

--- a/projects/packages/search/src/search-blocks/blocks/search-results/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/search-results/style.scss
@@ -126,10 +126,4 @@
 		font-size: 0.875em;
 		opacity: 0.75;
 	}
-
-	.jetpack-search-results__author::before {
-		content: "·";
-		margin-inline-end: 0.75rem;
-		opacity: 0.6;
-	}
 }

--- a/projects/packages/search/src/search-blocks/blocks/search-results/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/search-results/style.scss
@@ -85,3 +85,51 @@
 		border-radius: 4px;
 	}
 }
+
+.jetpack-search-results--compact {
+
+	.jetpack-search-results__list {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+		list-style: none;
+		margin: 0;
+		padding: 0;
+	}
+
+	.jetpack-search-results__item {
+		padding: 0.5rem 0;
+		border-top: 1px solid;
+		border-color: color-mix(in sRGB, currentColor 15%, transparent);
+
+		&:first-child {
+			border-top: none;
+		}
+	}
+
+	.jetpack-search-results__copy {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: baseline;
+		gap: 0.25rem 0.75rem;
+	}
+
+	.jetpack-search-results__title {
+		font-size: 1rem;
+		font-weight: 500;
+		margin: 0;
+	}
+
+	.jetpack-search-results__meta {
+		display: flex;
+		gap: 0.75rem;
+		font-size: 0.875em;
+		opacity: 0.75;
+	}
+
+	.jetpack-search-results__author::before {
+		content: "·";
+		margin-right: 0.75rem;
+		opacity: 0.6;
+	}
+}

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/block.json
@@ -27,7 +27,7 @@
 		"displayAs": {
 			"type": "string",
 			"default": "select",
-			"enum": [ "select", "radio" ]
+			"enum": [ "select", "radio", "popover" ]
 		}
 	},
 	"render": "file:./render.php",

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/block.json
@@ -28,6 +28,10 @@
 			"type": "string",
 			"default": "select",
 			"enum": [ "select", "radio", "popover" ]
+		},
+		"display": {
+			"type": "string",
+			"enum": [ "select", "popover" ]
 		}
 	},
 	"render": "file:./render.php",

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/class-sort-control.php
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/class-sort-control.php
@@ -106,7 +106,11 @@ class Sort_Control {
 	 */
 	public static function normalize_display_as( array $attributes ): string {
 		$candidate = (string) ( $attributes['displayAs'] ?? 'select' );
-		return in_array( $candidate, array( 'radio', 'popover' ), true ) ? $candidate : 'select';
+		if ( in_array( $candidate, array( 'radio', 'popover' ), true ) ) {
+			return $candidate;
+		}
+		$legacy_candidate = (string) ( $attributes['display'] ?? 'select' );
+		return 'popover' === $legacy_candidate ? 'popover' : 'select';
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/class-sort-control.php
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/class-sort-control.php
@@ -102,11 +102,11 @@ class Sort_Control {
 	 * doesn't know how to bind against.
 	 *
 	 * @param array $attributes Block attributes.
-	 * @return string  'select' or 'radio'.
+	 * @return string  'select', 'radio', or 'popover'.
 	 */
 	public static function normalize_display_as( array $attributes ): string {
 		$candidate = (string) ( $attributes['displayAs'] ?? 'select' );
-		return 'radio' === $candidate ? 'radio' : 'select';
+		return in_array( $candidate, array( 'radio', 'popover' ), true ) ? $candidate : 'select';
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/edit.js
@@ -64,9 +64,12 @@ export default function SortControlEdit( { attributes, setAttributes } ) {
 	const defaultSort = ALL_SORT_KEYS.includes( attributes?.defaultSort )
 		? attributes.defaultSort
 		: 'relevance';
-	const displayAs = [ 'radio', 'popover' ].includes( attributes?.displayAs )
-		? attributes.displayAs
-		: 'select';
+	let displayAs = 'select';
+	if ( [ 'radio', 'popover' ].includes( attributes?.displayAs ) ) {
+		displayAs = attributes.displayAs;
+	} else if ( 'popover' === attributes?.display ) {
+		displayAs = 'popover';
+	}
 	const blockProps = useBlockProps( {
 		className: 'popover' === displayAs ? 'jetpack-search-sort--popover' : undefined,
 	} );
@@ -153,7 +156,7 @@ export default function SortControlEdit( { attributes, setAttributes } ) {
 					{ value: 'radio', label: __( 'Inline links', 'jetpack-search-pkg' ) },
 					{ value: 'popover', label: __( 'Popover', 'jetpack-search-pkg' ) },
 				],
-				onChange: value => setAttributes( { displayAs: value } ),
+				onChange: value => setAttributes( { displayAs: value, display: undefined } ),
 			} )
 		),
 		h(

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/edit.js
@@ -194,7 +194,7 @@ export default function SortControlEdit( { attributes, setAttributes } ) {
 				},
 				h( 'path', {
 					fill: 'currentColor',
-					d: 'M3 6h18v2H3V6Zm3 5h12v2H6v-2Zm3 5h6v2H9v-2Z',
+					d: 'M8 4l-4 4h3v12h2V8h3L8 4zm8 16l4-4h-3V4h-2v12h-3l4 4z',
 				} )
 			),
 			h( 'span', { className: 'screen-reader-text' }, __( 'Sort results', 'jetpack-search-pkg' ) )

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/edit.js
@@ -56,7 +56,6 @@ function resolveAvailable( stored ) {
  * @return {object} Rendered element.
  */
 export default function SortControlEdit( { attributes, setAttributes } ) {
-	const blockProps = useBlockProps();
 	// Per-instance id keeps the label→control association valid when the
 	// editor renders more than one Sort Control on the same canvas.
 	const baseId = useId();
@@ -65,7 +64,12 @@ export default function SortControlEdit( { attributes, setAttributes } ) {
 	const defaultSort = ALL_SORT_KEYS.includes( attributes?.defaultSort )
 		? attributes.defaultSort
 		: 'relevance';
-	const displayAs = 'radio' === attributes?.displayAs ? 'radio' : 'select';
+	const displayAs = [ 'radio', 'popover' ].includes( attributes?.displayAs )
+		? attributes.displayAs
+		: 'select';
+	const blockProps = useBlockProps( {
+		className: 'popover' === displayAs ? 'jetpack-search-sort--popover' : undefined,
+	} );
 	const storedAvailable = Array.isArray( attributes?.availableSortOptions )
 		? attributes.availableSortOptions
 		: ALL_SORT_KEYS;
@@ -147,6 +151,7 @@ export default function SortControlEdit( { attributes, setAttributes } ) {
 				options: [
 					{ value: 'select', label: __( 'Dropdown', 'jetpack-search-pkg' ) },
 					{ value: 'radio', label: __( 'Inline links', 'jetpack-search-pkg' ) },
+					{ value: 'popover', label: __( 'Popover', 'jetpack-search-pkg' ) },
 				],
 				onChange: value => setAttributes( { displayAs: value } ),
 			} )
@@ -166,40 +171,69 @@ export default function SortControlEdit( { attributes, setAttributes } ) {
 		)
 	);
 
-	const preview =
-		'radio' === displayAs
-			? h(
-					'fieldset',
-					{ className: 'jetpack-search-sort-control__radio-group' },
-					h( 'legend', null, labelText ),
-					available.map( key => {
-						const radioId = `${ baseId }-${ key }`;
-						return h(
-							'div',
-							{ key, className: 'jetpack-search-sort-control__radio-item' },
-							h( 'input', {
-								type: 'radio',
-								id: radioId,
-								name: baseId,
-								value: key,
-								checked: previewSelected === key,
-								disabled: true,
-								readOnly: true,
-							} ),
-							h( 'label', { htmlFor: radioId }, labels[ key ] )
-						);
-					} )
-			  )
-			: h(
-					Fragment,
-					null,
-					h( 'label', { htmlFor: baseId }, labelText ),
-					h(
-						'select',
-						{ id: baseId, disabled: true, value: previewSelected, onChange: () => {} },
-						available.map( key => h( 'option', { key, value: key }, labels[ key ] ) )
-					)
-			  );
+	let preview;
+	if ( 'popover' === displayAs ) {
+		preview = h(
+			'button',
+			{
+				type: 'button',
+				className: 'jetpack-search-sort__trigger',
+				'aria-haspopup': 'menu',
+				'aria-expanded': 'false',
+				disabled: true,
+			},
+			h(
+				'svg',
+				{
+					className: 'jetpack-search-sort__icon',
+					width: 18,
+					height: 18,
+					viewBox: '0 0 24 24',
+					'aria-hidden': 'true',
+					focusable: 'false',
+				},
+				h( 'path', {
+					fill: 'currentColor',
+					d: 'M3 6h18v2H3V6Zm3 5h12v2H6v-2Zm3 5h6v2H9v-2Z',
+				} )
+			),
+			h( 'span', { className: 'screen-reader-text' }, __( 'Sort results', 'jetpack-search-pkg' ) )
+		);
+	} else if ( 'radio' === displayAs ) {
+		preview = h(
+			'fieldset',
+			{ className: 'jetpack-search-sort-control__radio-group' },
+			h( 'legend', null, labelText ),
+			available.map( key => {
+				const radioId = `${ baseId }-${ key }`;
+				return h(
+					'div',
+					{ key, className: 'jetpack-search-sort-control__radio-item' },
+					h( 'input', {
+						type: 'radio',
+						id: radioId,
+						name: baseId,
+						value: key,
+						checked: previewSelected === key,
+						disabled: true,
+						readOnly: true,
+					} ),
+					h( 'label', { htmlFor: radioId }, labels[ key ] )
+				);
+			} )
+		);
+	} else {
+		preview = h(
+			Fragment,
+			null,
+			h( 'label', { htmlFor: baseId }, labelText ),
+			h(
+				'select',
+				{ id: baseId, disabled: true, value: previewSelected, onChange: () => {} },
+				available.map( key => h( 'option', { key, value: key }, labels[ key ] ) )
+			)
+		);
+	}
 
 	return h( Fragment, null, inspector, h( 'div', blockProps, preview ) );
 }

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/render.php
@@ -85,7 +85,7 @@ $checked_getters = array(
 			data-wp-on--click="actions.toggleSortPopover"
 		>
 			<svg class="jetpack-search-sort__icon" width="18" height="18" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-				<path fill="currentColor" d="M3 6h18v2H3V6Zm3 5h12v2H6v-2Zm3 5h6v2H9v-2Z"/>
+				<path fill="currentColor" d="M8 4l-4 4h3v12h2V8h3L8 4zm8 16l4-4h-3V4h-2v12h-3l4 4z"/>
 			</svg>
 			<span class="screen-reader-text"><?php esc_html_e( 'Sort results', 'jetpack-search-pkg' ); ?></span>
 		</button>

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/render.php
@@ -22,7 +22,7 @@ $display_as    = Sort_Control::normalize_display_as( $attrs );
 $label         = Sort_Control::resolve_label( $attrs );
 
 // Determine the effective sort for first paint and hydration. A URL
-// `?orderby=…` always wins so deep links keep their meaning — same
+// `?orderby=...` always wins so deep links keep their meaning -- same
 // precedence as the instant-search overlay. When no URL sort is present,
 // fall back to the block's `defaultSort` attribute.
 $url_sort       = Sort_Control::parse_url_sort( $options );
@@ -38,7 +38,7 @@ if ( ! in_array( $effective_sort, $options, true ) ) {
 
 // `wp_interactivity_data_wp_context()` (used in the radio template) was
 // introduced in WP 6.5; calling it on older cores would fatal. Fall back
-// to the `select` variant — its template only emits inert
+// to the `select` variant -- its template only emits inert
 // `data-wp-bind--*` attributes, which degrade harmlessly without
 // Interactivity.
 if ( 'radio' === $display_as && ! function_exists( 'wp_interactivity_data_wp_context' ) ) {
@@ -50,7 +50,7 @@ if ( 'radio' === $display_as && ! function_exists( 'wp_interactivity_data_wp_con
 // "wins" depends on theme type: under classic themes the block renders
 // during `wp_enqueue_scripts`, after the Search_Blocks state seeder, so
 // `wp_interactivity_state()`'s deep-merge layers on top. Under FSE/block
-// themes the block template renders before `wp_enqueue_scripts` fires —
+// themes the block template renders before `wp_enqueue_scripts` fires --
 // the Search_Blocks seeder later overwrites this `sortOrder`, falling
 // back to `relevance` for any sort key it doesn't recognise. Resolving
 // the FSE precedence is tracked separately; this call still does the
@@ -60,62 +60,117 @@ if ( function_exists( 'wp_interactivity_state' ) ) {
 }
 
 $select_id = wp_unique_id( 'jetpack-search-sort-' );
+$menu_id   = wp_unique_id( 'jetpack-search-sort-menu-' );
+
+$checked_getters = array(
+	'relevance' => 'state.isSortByRelevance',
+	'newest'    => 'state.isSortByNewest',
+	'oldest'    => 'state.isSortByOldest',
+);
 ?>
-<div
-	<?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>
-	data-wp-interactive="jetpack-search"
->
-	<?php if ( 'radio' === $display_as ) : ?>
-		<?php
-		// Shared `name` groups the radios so the browser enforces single-
-		// selection semantics across the whole block instance. The wrapper's
-		// uniquely generated id doubles as the group name — two sort-control
-		// blocks on the same page therefore get distinct names and don't
-		// interfere with each other.
-		$group_name = $select_id;
-		?>
-		<fieldset class="jetpack-search-sort-control__radio-group">
-			<legend><?php echo esc_html( $label ); ?></legend>
-			<?php foreach ( $options as $sort_key ) : ?>
-				<?php
-				$option_label = $option_labels[ $sort_key ] ?? $sort_key;
-				$radio_id     = $select_id . '-' . sanitize_key( $sort_key );
-				?>
-				<div
-					class="jetpack-search-sort-control__radio-item"
-					<?php echo wp_kses_data( wp_interactivity_data_wp_context( array( 'sortKey' => $sort_key ) ) ); ?>
-				>
-					<input
-						type="radio"
-						id="<?php echo esc_attr( $radio_id ); ?>"
-						name="<?php echo esc_attr( $group_name ); ?>"
-						value="<?php echo esc_attr( $sort_key ); ?>"
-						<?php checked( $effective_sort, $sort_key ); ?>
-						data-wp-bind--checked="state.isSortOptionSelected"
-						data-wp-on--change="actions.onSortChange"
-					/>
-					<label for="<?php echo esc_attr( $radio_id ); ?>">
-						<?php echo esc_html( $option_label ); ?>
-					</label>
-				</div>
-			<?php endforeach; ?>
-		</fieldset>
-	<?php else : ?>
-		<label for="<?php echo esc_attr( $select_id ); ?>">
-			<?php echo esc_html( $label ); ?>
-		</label>
-		<select
-			id="<?php echo esc_attr( $select_id ); ?>"
-			data-wp-bind--value="state.sortOrder"
-			data-wp-on--change="actions.onSortChange"
+<?php if ( 'popover' === $display_as ) : ?>
+	<div
+		<?php echo wp_kses_data( get_block_wrapper_attributes( array( 'class' => 'jetpack-search-sort--popover' ) ) ); ?>
+		data-wp-interactive="jetpack-search"
+		data-jetpack-search-popover-root
+		data-wp-on-window--click="actions.onWindowClickClosePopovers"
+		data-wp-on-window--keydown="actions.onEscapeClosePopovers"
+	>
+		<button
+			type="button"
+			class="jetpack-search-sort__trigger"
+			aria-haspopup="menu"
+			data-wp-bind--aria-expanded="state.isSortPopoverOpen"
+			aria-controls="<?php echo esc_attr( $menu_id ); ?>"
+			data-wp-on--click="actions.toggleSortPopover"
+		>
+			<svg class="jetpack-search-sort__icon" width="18" height="18" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+				<path fill="currentColor" d="M3 6h18v2H3V6Zm3 5h12v2H6v-2Zm3 5h6v2H9v-2Z"/>
+			</svg>
+			<span class="screen-reader-text"><?php esc_html_e( 'Sort results', 'jetpack-search-pkg' ); ?></span>
+		</button>
+		<div
+			id="<?php echo esc_attr( $menu_id ); ?>"
+			class="jetpack-search-sort__menu"
+			role="menu"
+			data-wp-bind--hidden="!state.isSortPopoverOpen"
+			hidden
 		>
 			<?php foreach ( $options as $sort_key ) : ?>
-				<?php $option_label = $option_labels[ $sort_key ] ?? $sort_key; ?>
-				<option
+				<?php
+				$option_label    = $option_labels[ $sort_key ] ?? $sort_key;
+				$checked_binding = $checked_getters[ $sort_key ] ?? 'false';
+				?>
+				<button
+					type="button"
+					role="menuitemradio"
+					class="jetpack-search-sort__menu-item"
 					value="<?php echo esc_attr( $sort_key ); ?>"
-					<?php selected( $effective_sort, $sort_key ); ?>
-				><?php echo esc_html( $option_label ); ?></option>
+					data-wp-bind--aria-checked="<?php echo esc_attr( $checked_binding ); ?>"
+					data-wp-on--click="actions.selectSortOrder"
+				>
+					<?php echo esc_html( $option_label ); ?>
+				</button>
 			<?php endforeach; ?>
-		</select>
-	<?php endif; ?>
-</div>
+		</div>
+	</div>
+<?php else : ?>
+	<div
+		<?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>
+		data-wp-interactive="jetpack-search"
+	>
+		<?php if ( 'radio' === $display_as ) : ?>
+			<?php
+			// Shared `name` groups the radios so the browser enforces single-
+			// selection semantics across the whole block instance. The wrapper's
+			// uniquely generated id doubles as the group name -- two sort-control
+			// blocks on the same page therefore get distinct names and don't
+			// interfere with each other.
+			$group_name = $select_id;
+			?>
+			<fieldset class="jetpack-search-sort-control__radio-group">
+				<legend><?php echo esc_html( $label ); ?></legend>
+				<?php foreach ( $options as $sort_key ) : ?>
+					<?php
+					$option_label = $option_labels[ $sort_key ] ?? $sort_key;
+					$radio_id     = $select_id . '-' . sanitize_key( $sort_key );
+					?>
+					<div
+						class="jetpack-search-sort-control__radio-item"
+						<?php echo wp_kses_data( wp_interactivity_data_wp_context( array( 'sortKey' => $sort_key ) ) ); ?>
+					>
+						<input
+							type="radio"
+							id="<?php echo esc_attr( $radio_id ); ?>"
+							name="<?php echo esc_attr( $group_name ); ?>"
+							value="<?php echo esc_attr( $sort_key ); ?>"
+							<?php checked( $effective_sort, $sort_key ); ?>
+							data-wp-bind--checked="state.isSortOptionSelected"
+							data-wp-on--change="actions.onSortChange"
+						/>
+						<label for="<?php echo esc_attr( $radio_id ); ?>">
+							<?php echo esc_html( $option_label ); ?>
+						</label>
+					</div>
+				<?php endforeach; ?>
+			</fieldset>
+		<?php else : ?>
+			<label for="<?php echo esc_attr( $select_id ); ?>">
+				<?php echo esc_html( $label ); ?>
+			</label>
+			<select
+				id="<?php echo esc_attr( $select_id ); ?>"
+				data-wp-bind--value="state.sortOrder"
+				data-wp-on--change="actions.onSortChange"
+			>
+				<?php foreach ( $options as $sort_key ) : ?>
+					<?php $option_label = $option_labels[ $sort_key ] ?? $sort_key; ?>
+					<option
+						value="<?php echo esc_attr( $sort_key ); ?>"
+						<?php selected( $effective_sort, $sort_key ); ?>
+					><?php echo esc_html( $option_label ); ?></option>
+				<?php endforeach; ?>
+			</select>
+		<?php endif; ?>
+	</div>
+<?php endif; ?>

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/render.php
@@ -81,6 +81,7 @@ $checked_getters = array(
 			class="jetpack-search-sort__trigger"
 			aria-haspopup="menu"
 			data-wp-bind--aria-expanded="state.isSortPopoverOpen"
+			data-wp-bind--disabled="state.isSortTriggerDisabled"
 			aria-controls="<?php echo esc_attr( $menu_id ); ?>"
 			data-wp-on--click="actions.toggleSortPopover"
 		>

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/render.php
@@ -80,7 +80,9 @@ $checked_getters = array(
 			type="button"
 			class="jetpack-search-sort__trigger"
 			aria-haspopup="menu"
+			aria-expanded="false"
 			data-wp-bind--aria-expanded="state.isSortPopoverOpen"
+			disabled
 			data-wp-bind--disabled="state.isSortTriggerDisabled"
 			aria-controls="<?php echo esc_attr( $menu_id ); ?>"
 			data-wp-on--click="actions.toggleSortPopover"

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
@@ -112,3 +112,71 @@
 		}
 	}
 }
+
+.jetpack-search-sort--popover {
+	position: relative;
+	display: inline-block;
+
+	.jetpack-search-sort__trigger {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 2rem;
+		height: 2rem;
+		padding: 0;
+		border: 1px solid;
+		border-color: color-mix(in sRGB, currentColor 20%, transparent);
+		background: transparent;
+		color: inherit;
+		border-radius: 4px;
+		cursor: pointer;
+
+		&:hover,
+		&[aria-expanded="true"] {
+			background: color-mix(in sRGB, currentColor 6%, transparent);
+		}
+	}
+
+	.jetpack-search-sort__menu {
+		position: absolute;
+		right: 0;
+		top: calc(100% + 4px);
+		min-width: 160px;
+		z-index: 20;
+		display: flex;
+		flex-direction: column;
+		padding: 4px;
+		background: var(--wp--preset--color--background, #fff);
+		color: inherit;
+		border: 1px solid;
+		border-color: color-mix(in sRGB, currentColor 15%, transparent);
+		border-radius: 4px;
+		box-shadow: 0 4px 16px color-mix(in sRGB, currentColor 12%, transparent);
+
+		&[hidden] {
+			display: none;
+		}
+	}
+
+	.jetpack-search-sort__menu-item {
+		appearance: none;
+		border: none;
+		background: transparent;
+		color: inherit;
+		padding: 6px 8px;
+		text-align: left;
+		font: inherit;
+		border-radius: 2px;
+		cursor: pointer;
+
+		&:hover,
+		&:focus-visible {
+			background: color-mix(in sRGB, currentColor 8%, transparent);
+		}
+
+		&[aria-checked="true"]::before {
+			content: "✓";
+			margin-right: 6px;
+		}
+	}
+}

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
@@ -152,7 +152,9 @@
 		flex-direction: column;
 		padding: 4px;
 		background: var(--wp--preset--color--background, #fff);
-		color: inherit;
+		// The menu uses a light surface, so don't inherit a low-contrast
+		// body accent color from the surrounding page.
+		color: var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, #111));
 		// Reset the inherited theme base size so menu items track the
 		// search-results title (also 1rem) instead of the host theme's
 		// oversized default. `font: inherit` on menu items picks this up.

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
@@ -151,8 +151,8 @@
 		display: flex;
 		flex-direction: column;
 		padding: 4px;
-		--jetpack-search-popover-background: var(--wp--preset--color--background, #fff);
-		--jetpack-search-popover-color: var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, #111));
+		--jetpack-search-popover-background: var(--wp--preset--color--base, #fff);
+		--jetpack-search-popover-color: var(--wp--preset--color--contrast, #111);
 		background: var(--jetpack-search-popover-background);
 		// The menu owns its surface, so don't inherit a low-contrast body
 		// accent color from the surrounding page.

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
@@ -144,8 +144,8 @@
 
 	.jetpack-search-sort__menu {
 		position: absolute;
-		right: 0;
-		top: calc(100% + 4px);
+		inset-inline-end: 0;
+		inset-block-start: calc(100% + 4px);
 		min-width: 160px;
 		z-index: 20;
 		display: flex;
@@ -173,7 +173,7 @@
 		background: transparent;
 		color: inherit;
 		padding: 6px 8px;
-		text-align: left;
+		text-align: start;
 		font: inherit;
 		border-radius: 2px;
 		cursor: pointer;
@@ -185,7 +185,7 @@
 
 		&[aria-checked="true"]::before {
 			content: "✓";
-			margin-right: 6px;
+			margin-inline-end: 6px;
 		}
 	}
 }

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
@@ -151,10 +151,12 @@
 		display: flex;
 		flex-direction: column;
 		padding: 4px;
-		background: var(--wp--preset--color--background, #fff);
-		// The menu uses a light surface, so don't inherit a low-contrast
-		// body accent color from the surrounding page.
-		color: var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, #111));
+		--jetpack-search-popover-background: var(--wp--preset--color--background, #fff);
+		--jetpack-search-popover-color: var(--wp--preset--color--contrast, var(--wp--preset--color--foreground, #111));
+		background: var(--jetpack-search-popover-background);
+		// The menu owns its surface, so don't inherit a low-contrast body
+		// accent color from the surrounding page.
+		color: var(--jetpack-search-popover-color);
 		// Reset the inherited theme base size so menu items track the
 		// search-results title (also 1rem) instead of the host theme's
 		// oversized default. `font: inherit` on menu items picks this up.

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
@@ -131,9 +131,14 @@
 		border-radius: 4px;
 		cursor: pointer;
 
-		&:hover,
+		&:hover:not(:disabled),
 		&[aria-expanded="true"] {
 			background: color-mix(in sRGB, currentColor 6%, transparent);
+		}
+
+		&:disabled {
+			cursor: not-allowed;
+			opacity: 0.4;
 		}
 	}
 
@@ -148,6 +153,10 @@
 		padding: 4px;
 		background: var(--wp--preset--color--background, #fff);
 		color: inherit;
+		// Reset the inherited theme base size so menu items track the
+		// search-results title (also 1rem) instead of the host theme's
+		// oversized default. `font: inherit` on menu items picks this up.
+		font-size: 1rem;
 		border: 1px solid;
 		border-color: color-mix(in sRGB, currentColor 15%, transparent);
 		border-radius: 4px;

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
@@ -151,12 +151,10 @@
 		display: flex;
 		flex-direction: column;
 		padding: 4px;
-		--jetpack-search-popover-background: var(--wp--preset--color--base, #fff);
-		--jetpack-search-popover-color: var(--wp--preset--color--contrast, #111);
-		background: var(--jetpack-search-popover-background);
+		background: var(--wp--preset--color--base);
 		// The menu owns its surface, so don't inherit a low-contrast body
 		// accent color from the surrounding page.
-		color: var(--jetpack-search-popover-color);
+		color: var(--wp--preset--color--contrast);
 		// Reset the inherited theme base size so menu items track the
 		// search-results title (also 1rem) instead of the host theme's
 		// oversized default. `font: inherit` on menu items picks this up.

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -20,6 +20,7 @@ import { getCategories, registerBlockType, setCategories } from '@wordpress/bloc
 import { __ } from '@wordpress/i18n';
 import ActiveFiltersEdit from '../blocks/active-filters/edit';
 import FilterCheckboxEdit from '../blocks/filter-checkbox/edit';
+import FilterPopoverEdit, { save as filterPopoverSave } from '../blocks/filter-popover/edit';
 import LoadMoreEdit from '../blocks/load-more/edit';
 import NoResultsEdit from '../blocks/no-results/edit';
 import ResultsCountEdit from '../blocks/results-count/edit';
@@ -35,6 +36,7 @@ const BLOCKS = [
 	[ 'jetpack/search-results', SearchResultsEdit ],
 	[ 'jetpack/filter-checkbox', FilterCheckboxEdit ],
 	[ 'jetpack/active-filters', ActiveFiltersEdit ],
+	[ 'jetpack/filter-popover', FilterPopoverEdit, filterPopoverSave ],
 	[ 'jetpack/sort-control', SortControlEdit ],
 	[ 'jetpack/results-count', ResultsCountEdit ],
 	[ 'jetpack/no-results', NoResultsEdit ],
@@ -60,6 +62,6 @@ setCategories(
 	)
 );
 
-BLOCKS.forEach( ( [ name, edit ] ) => {
-	registerBlockType( name, { edit, save } );
+BLOCKS.forEach( ( [ name, edit, blockSave ] ) => {
+	registerBlockType( name, { edit, save: blockSave ?? save } );
 } );

--- a/projects/packages/search/src/search-blocks/patterns/compact-search.php
+++ b/projects/packages/search/src/search-blocks/patterns/compact-search.php
@@ -25,11 +25,9 @@ register_block_pattern(
 		'content'     => '<!-- wp:group {"style":{"spacing":{"blockGap":"1rem"}}} -->
 <div class="wp-block-group">
 
-<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group">
+<!-- wp:group {"className":"jetpack-search-compact-toolbar","layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<div class="wp-block-group jetpack-search-compact-toolbar">
 <!-- wp:jetpack/search-input /-->
-<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group">
 <!-- wp:jetpack/filter-popover -->
 <!-- wp:jetpack/active-filters /-->
 <!-- wp:jetpack/filter-checkbox {"filterType":"taxonomy","taxonomy":"category"} /-->
@@ -37,8 +35,6 @@ register_block_pattern(
 <!-- wp:jetpack/filter-checkbox {"filterType":"post_type"} /-->
 <!-- /wp:jetpack/filter-popover -->
 <!-- wp:jetpack/sort-control {"display":"popover"} /-->
-</div>
-<!-- /wp:group -->
 </div>
 <!-- /wp:group -->
 

--- a/projects/packages/search/src/search-blocks/patterns/compact-search.php
+++ b/projects/packages/search/src/search-blocks/patterns/compact-search.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Compact Search block pattern.
+ *
+ * Single-row toolbar (search input + filter popover + sort popover) over a
+ * compact result list. Mirrors the WordPress Dataview list layout.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+register_block_pattern(
+	'jetpack-search/compact-search',
+	array(
+		'title'       => __( 'Compact Search', 'jetpack-search-pkg' ),
+		'description' => __( 'A compact Jetpack Search toolbar with inline filter and sort controls, plus a dense result list.', 'jetpack-search-pkg' ),
+		'categories'  => array( 'jetpack-search' ),
+		'keywords'    => array(
+			__( 'search', 'jetpack-search-pkg' ),
+			__( 'compact', 'jetpack-search-pkg' ),
+			__( 'list', 'jetpack-search-pkg' ),
+			__( 'jetpack search', 'jetpack-search-pkg' ),
+		),
+		'content'     => '<!-- wp:group {"style":{"spacing":{"blockGap":"1rem"}}} -->
+<div class="wp-block-group">
+
+<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group">
+<!-- wp:jetpack/search-input /-->
+<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<div class="wp-block-group">
+<!-- wp:jetpack/filter-popover -->
+<!-- wp:jetpack/active-filters /-->
+<!-- wp:jetpack/filter-checkbox {"filterType":"taxonomy","taxonomy":"category"} /-->
+<!-- wp:jetpack/filter-checkbox {"filterType":"taxonomy","taxonomy":"post_tag"} /-->
+<!-- wp:jetpack/filter-checkbox {"filterType":"post_type"} /-->
+<!-- /wp:jetpack/filter-popover -->
+<!-- wp:jetpack/sort-control {"display":"popover"} /-->
+</div>
+<!-- /wp:group -->
+</div>
+<!-- /wp:group -->
+
+<!-- wp:jetpack/results-count /-->
+<!-- wp:jetpack/search-results {"layout":"compact"} /-->
+<!-- wp:jetpack/no-results /-->
+<!-- wp:jetpack/load-more /-->
+
+</div>
+<!-- /wp:group -->',
+	)
+);

--- a/projects/packages/search/src/search-blocks/patterns/compact-search.php
+++ b/projects/packages/search/src/search-blocks/patterns/compact-search.php
@@ -34,7 +34,7 @@ register_block_pattern(
 <!-- wp:jetpack/filter-checkbox {"filterType":"taxonomy","taxonomy":"post_tag"} /-->
 <!-- wp:jetpack/filter-checkbox {"filterType":"post_type"} /-->
 <!-- /wp:jetpack/filter-popover -->
-<!-- wp:jetpack/sort-control {"display":"popover"} /-->
+<!-- wp:jetpack/sort-control {"displayAs":"popover"} /-->
 </div>
 <!-- /wp:group -->
 

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -140,6 +140,37 @@ const { state, actions } = store( NAMESPACE, {
 		get activeFilterCount() {
 			return countActiveFilters( state.activeFilters );
 		},
+
+		/**
+		 * True when the current sort order is "relevance". Used by the sort
+		 * popover menu to set `aria-checked` on the Relevance menu item.
+		 * Interactivity API `data-wp-bind` only evaluates simple property
+		 * paths, so inline `===` comparisons are not supported — derived
+		 * booleans must live here.
+		 *
+		 * @return {boolean} Whether sortOrder is "relevance".
+		 */
+		get isSortByRelevance() {
+			return state.sortOrder === 'relevance';
+		},
+
+		/**
+		 * True when the current sort order is "newest".
+		 *
+		 * @return {boolean} Whether sortOrder is "newest".
+		 */
+		get isSortByNewest() {
+			return state.sortOrder === 'newest';
+		},
+
+		/**
+		 * True when the current sort order is "oldest".
+		 *
+		 * @return {boolean} Whether sortOrder is "oldest".
+		 */
+		get isSortByOldest() {
+			return state.sortOrder === 'oldest';
+		},
 	},
 
 	actions: {
@@ -326,6 +357,41 @@ const { state, actions } = store( NAMESPACE, {
 			state.sortOrder = next;
 			state.isSortPopoverOpen = false;
 			yield actions.search();
+		},
+
+		/**
+		 * Close any open popover when clicking outside it. Bound to
+		 * `data-wp-on-window--click` so the handler fires on every click;
+		 * early-exit when the click target lives inside any element marked
+		 * with `data-jetpack-search-popover-root`.
+		 *
+		 * @param {Event} event - Window click event.
+		 */
+		onWindowClickClosePopovers( event ) {
+			if ( ! state.isFilterPopoverOpen && ! state.isSortPopoverOpen ) {
+				return;
+			}
+			const target = event?.target;
+			if ( target && target.closest && target.closest( '[data-jetpack-search-popover-root]' ) ) {
+				return;
+			}
+			state.isFilterPopoverOpen = false;
+			state.isSortPopoverOpen = false;
+		},
+
+		/**
+		 * Close popovers on Escape.
+		 *
+		 * @param {KeyboardEvent} event - Window keydown event.
+		 */
+		onEscapeClosePopovers( event ) {
+			if ( event?.key !== 'Escape' ) {
+				return;
+			}
+			if ( state.isFilterPopoverOpen || state.isSortPopoverOpen ) {
+				state.isFilterPopoverOpen = false;
+				state.isSortPopoverOpen = false;
+			}
 		},
 	},
 

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -179,6 +179,19 @@ const { state, actions } = store( NAMESPACE, {
 		},
 
 		/**
+		 * True when the sort-popover trigger should be disabled: there are
+		 * no results to sort AND the sort order is still the default. Mirrors
+		 * `isFilterTriggerDisabled` — opening the popover pre-search shows a
+		 * menu that would do nothing. Remains enabled when the user has
+		 * already picked a non-default sort so they can switch back.
+		 *
+		 * @return {boolean} Whether the sort trigger is disabled.
+		 */
+		get isSortTriggerDisabled() {
+			return state.totalResults === 0 && state.sortOrder === 'relevance';
+		},
+
+		/**
 		 * True when the current sort order is "newest".
 		 *
 		 * @return {boolean} Whether sortOrder is "newest".

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -1,5 +1,6 @@
 import { store } from '@wordpress/interactivity';
 import { buildSearchUrl } from './api';
+import { isEventInsidePopoverRoot } from './popover-events';
 import { countActiveFilters, normalizeResult } from './result-utils';
 import { pushStateToUrl, readStateFromUrl } from './url-state';
 
@@ -399,8 +400,8 @@ const { state, actions } = store( NAMESPACE, {
 		/**
 		 * Close any open popover when clicking outside it. Bound to
 		 * `data-wp-on-window--click` so the handler fires on every click;
-		 * early-exit when the click target lives inside any element marked
-		 * with `data-jetpack-search-popover-root`.
+		 * early-exit when the click began inside any element marked with
+		 * `data-jetpack-search-popover-root`.
 		 *
 		 * @param {Event} event - Window click event.
 		 */
@@ -408,8 +409,7 @@ const { state, actions } = store( NAMESPACE, {
 			if ( ! state.isFilterPopoverOpen && ! state.isSortPopoverOpen ) {
 				return;
 			}
-			const target = event?.target;
-			if ( target && target.closest && target.closest( '[data-jetpack-search-popover-root]' ) ) {
+			if ( isEventInsidePopoverRoot( event ) ) {
 				return;
 			}
 			state.isFilterPopoverOpen = false;

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -6,7 +6,7 @@ import { pushStateToUrl, readStateFromUrl } from './url-state';
 
 const NAMESPACE = 'jetpack-search';
 let initialized = false;
-// Monotonic token used to drop stale `search()` responses. Incremented on
+// Monotonic token used to drop stale async result responses. Incremented on
 // every new search; in-flight responses compare their token against the
 // latest before touching store state, so a slow request for an older query
 // can't overwrite fresh results when the user changes query or sort mid-fetch.
@@ -229,6 +229,7 @@ const { state, actions } = store( NAMESPACE, {
 		*search( { syncUrl = true } = {} ) {
 			const myToken = ++searchToken;
 			state.isLoading = true;
+			state.isLoadingMore = false;
 			state.hasError = false;
 			try {
 				const data = yield* fetchResults( null );
@@ -265,19 +266,30 @@ const { state, actions } = store( NAMESPACE, {
 			if ( ! state.pageHandle || state.isLoading || state.isLoadingMore ) {
 				return;
 			}
+			const myToken = searchToken;
 			state.isLoadingMore = true;
 			state.hasError = false;
 			try {
 				const data = yield* fetchResults( state.pageHandle );
+				// A first-page search started while this pagination request was
+				// in-flight. Its response owns the list, so don't append stale
+				// items from the old query/filter/sort state.
+				if ( myToken !== searchToken ) {
+					return;
+				}
 				state.results = [
 					...state.results,
 					...( data.results ?? [] ).map( r => normalizeResult( r, state.locale ) ),
 				];
 				state.pageHandle = data.page_handle ?? null;
 			} catch {
-				state.hasError = true;
+				if ( myToken === searchToken ) {
+					state.hasError = true;
+				}
 			} finally {
-				state.isLoadingMore = false;
+				if ( myToken === searchToken ) {
+					state.isLoadingMore = false;
+				}
 			}
 		},
 

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -1,6 +1,6 @@
 import { store } from '@wordpress/interactivity';
 import { buildSearchUrl } from './api';
-import { normalizeResult } from './result-utils';
+import { countActiveFilters, normalizeResult } from './result-utils';
 import { pushStateToUrl, readStateFromUrl } from './url-state';
 
 const NAMESPACE = 'jetpack-search';
@@ -123,6 +123,16 @@ const { state, actions } = store( NAMESPACE, {
 			return Object.values( state.activeFilters ?? {} ).some(
 				v => Array.isArray( v ) && v.length > 0
 			);
+		},
+
+		/**
+		 * Total selected filter values across all filter keys. Used by the
+		 * filter-popover trigger to render a count badge.
+		 *
+		 * @return {number} Count of selected filter values.
+		 */
+		get activeFilterCount() {
+			return countActiveFilters( state.activeFilters );
 		},
 	},
 

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -42,6 +42,12 @@ function* fetchResults( pageHandle ) {
 
 const { state, actions } = store( NAMESPACE, {
 	state: {
+		// UI: popover open flags. Kept as separate booleans so only one
+		// popover can be open at a time — the toggle actions close the
+		// other when opening this one.
+		isFilterPopoverOpen: false,
+		isSortPopoverOpen: false,
+
 		/**
 		 * Short human-readable results count for display blocks. Doubles
 		 * as the loading indicator: returning the "searching" string
@@ -274,6 +280,52 @@ const { state, actions } = store( NAMESPACE, {
 			state.sortOrder = sortOrder;
 			state.activeFilters = activeFilters;
 			yield actions.search( { syncUrl: false } );
+		},
+
+		/**
+		 * Toggle the filter popover. Closes the sort popover if it's open.
+		 */
+		toggleFilterPopover() {
+			state.isFilterPopoverOpen = ! state.isFilterPopoverOpen;
+			if ( state.isFilterPopoverOpen ) {
+				state.isSortPopoverOpen = false;
+			}
+		},
+
+		/**
+		 * Toggle the sort popover. Closes the filter popover if it's open.
+		 */
+		toggleSortPopover() {
+			state.isSortPopoverOpen = ! state.isSortPopoverOpen;
+			if ( state.isSortPopoverOpen ) {
+				state.isFilterPopoverOpen = false;
+			}
+		},
+
+		/**
+		 * Close every popover. Bound to Escape key and outside-click handlers.
+		 */
+		closeAllPopovers() {
+			state.isFilterPopoverOpen = false;
+			state.isSortPopoverOpen = false;
+		},
+
+		/**
+		 * Change sort order from a popover menu item and close the popover.
+		 * `event.currentTarget.value` carries the new sortOrder.
+		 *
+		 * @param {Event} event - Click event from the menu item.
+		 * @yield {Promise} Search fetch.
+		 */
+		*selectSortOrder( event ) {
+			const next = event?.currentTarget?.value;
+			if ( ! next || next === state.sortOrder ) {
+				state.isSortPopoverOpen = false;
+				return;
+			}
+			state.sortOrder = next;
+			state.isSortPopoverOpen = false;
+			yield actions.search();
 		},
 	},
 

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -142,6 +142,30 @@ const { state, actions } = store( NAMESPACE, {
 		},
 
 		/**
+		 * True when the filter-popover trigger should be disabled: there are
+		 * no aggregation buckets to filter on AND no active filters to clear.
+		 * Opening the popover in that state would show an empty panel, so we
+		 * gate the affordance itself. Remains enabled while any filter is
+		 * active so users can still open the popover to remove pills even
+		 * when the current query returns no results.
+		 *
+		 * @return {boolean} Whether the filter trigger is disabled.
+		 */
+		get isFilterTriggerDisabled() {
+			if ( state.hasActiveFilters ) {
+				return false;
+			}
+			const aggs = state.aggregations ?? {};
+			for ( const key of Object.keys( aggs ) ) {
+				const buckets = aggs[ key ]?.buckets;
+				if ( Array.isArray( buckets ) && buckets.length > 0 ) {
+					return false;
+				}
+			}
+			return true;
+		},
+
+		/**
 		 * True when the current sort order is "relevance". Used by the sort
 		 * popover menu to set `aria-checked` on the Relevance menu item.
 		 * Interactivity API `data-wp-bind` only evaluates simple property

--- a/projects/packages/search/src/search-blocks/store/popover-events.js
+++ b/projects/packages/search/src/search-blocks/store/popover-events.js
@@ -1,0 +1,20 @@
+const POPOVER_ROOT_SELECTOR = '[data-jetpack-search-popover-root]';
+
+/**
+ * Determine whether an event originated inside a search popover root.
+ *
+ * Prefer `composedPath()` because Interactivity API updates can detach the
+ * clicked target before the window click handler runs.
+ *
+ * @param {Event} event - Browser event.
+ * @return {boolean} Whether the event started inside a popover root.
+ */
+export function isEventInsidePopoverRoot( event ) {
+	const path = typeof event?.composedPath === 'function' ? event.composedPath() : [];
+	if ( Array.isArray( path ) && path.some( node => node?.matches?.( POPOVER_ROOT_SELECTOR ) ) ) {
+		return true;
+	}
+
+	const target = event?.target;
+	return !! target?.closest?.( POPOVER_ROOT_SELECTOR );
+}

--- a/projects/packages/search/src/search-blocks/store/result-utils.js
+++ b/projects/packages/search/src/search-blocks/store/result-utils.js
@@ -165,6 +165,10 @@ export function normalizeResult( raw, locale = 'en-US' ) {
 	const imageUrl = toSafeUrl( imageSrc );
 	const plainTitle = String( fields[ 'title.default' ] ?? fields.title ?? '' );
 	const titlePieces = tokenizeHighlight( highlight.title );
+	const rawAuthor = fields[ 'author.name' ];
+	const author = Array.isArray( rawAuthor )
+		? String( rawAuthor[ 0 ] ?? '' )
+		: String( rawAuthor ?? '' );
 	return {
 		id: String( raw?.result_id ?? fields.post_id ?? permalink ),
 		title: plainTitle,
@@ -175,6 +179,7 @@ export function normalizeResult( raw, locale = 'en-US' ) {
 		permalink,
 		path: formatPath( permalink ),
 		dateLabel: formatDate( fields.date, locale ),
+		author,
 		imageUrl,
 	};
 }

--- a/projects/packages/search/src/search-blocks/store/result-utils.js
+++ b/projects/packages/search/src/search-blocks/store/result-utils.js
@@ -175,7 +175,7 @@ export function normalizeResult( raw, locale = 'en-US' ) {
 		// Rendered when the API returns a highlighted title; template
 		// falls back to `title` when this is empty.
 		titlePieces,
-		hasTitleHighlight: titlePieces.length > 0,
+		hasTitlePieces: titlePieces.length > 0,
 		permalink,
 		path: formatPath( permalink ),
 		dateLabel: formatDate( fields.date, locale ),

--- a/projects/packages/search/src/search-blocks/store/result-utils.js
+++ b/projects/packages/search/src/search-blocks/store/result-utils.js
@@ -183,3 +183,19 @@ export function normalizeResult( raw, locale = 'en-US' ) {
 		imageUrl,
 	};
 }
+
+/**
+ * Count the total number of selected filter values across all filter keys.
+ *
+ * @param {object} activeFilters - Map of filterKey → array of selected values.
+ * @return {number} Total selected values; 0 if input is not a plain object.
+ */
+export function countActiveFilters( activeFilters ) {
+	if ( ! activeFilters || typeof activeFilters !== 'object' ) {
+		return 0;
+	}
+	return Object.values( activeFilters ).reduce(
+		( sum, v ) => sum + ( Array.isArray( v ) ? v.length : 0 ),
+		0
+	);
+}

--- a/projects/packages/search/src/search-blocks/store/result-utils.js
+++ b/projects/packages/search/src/search-blocks/store/result-utils.js
@@ -165,10 +165,6 @@ export function normalizeResult( raw, locale = 'en-US' ) {
 	const imageUrl = toSafeUrl( imageSrc );
 	const plainTitle = String( fields[ 'title.default' ] ?? fields.title ?? '' );
 	const titlePieces = tokenizeHighlight( highlight.title );
-	const rawAuthor = fields[ 'author.name' ];
-	const author = Array.isArray( rawAuthor )
-		? String( rawAuthor[ 0 ] ?? '' )
-		: String( rawAuthor ?? '' );
 	return {
 		id: String( raw?.result_id ?? fields.post_id ?? permalink ),
 		title: plainTitle,
@@ -179,7 +175,6 @@ export function normalizeResult( raw, locale = 'en-US' ) {
 		permalink,
 		path: formatPath( permalink ),
 		dateLabel: formatDate( fields.date, locale ),
-		author,
 		imageUrl,
 	};
 }

--- a/projects/packages/search/tests/js/search-blocks/api.test.js
+++ b/projects/packages/search/tests/js/search-blocks/api.test.js
@@ -1,9 +1,17 @@
 import {
+	SEARCH_FIELDS,
 	buildAggregations,
 	buildFilterClause,
 	buildSearchUrl,
 	resolveFilterFields,
 } from '../../../src/search-blocks/store/api';
+
+describe( 'SEARCH_FIELDS', () => {
+	it( 'does not request author fields for result cards', () => {
+		expect( SEARCH_FIELDS ).not.toContain( 'author.name' );
+		expect( SEARCH_FIELDS ).not.toContain( 'author' );
+	} );
+} );
 
 describe( 'buildSearchUrl', () => {
 	it( 'builds public API URL for non-private sites', () => {

--- a/projects/packages/search/tests/js/search-blocks/filter-popover-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/filter-popover-edit.test.jsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import FilterPopoverEdit from '../../../src/search-blocks/blocks/filter-popover/edit';
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	useBlockProps: props => ( { ...props, className: props?.className } ),
+	InnerBlocks: () => <div data-testid="filter-popover-inner-blocks" />,
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: text => text,
+} ) );
+
+describe( 'FilterPopoverEdit', () => {
+	it( 'renders the editor preview with the filter panel closed', () => {
+		render( <FilterPopoverEdit /> );
+
+		expect( screen.getByRole( 'button', { name: 'Filter results' } ) ).toHaveAttribute(
+			'aria-expanded',
+			'false'
+		);
+		expect( screen.getByRole( 'dialog', { hidden: true } ) ).toHaveAttribute( 'hidden' );
+		expect( screen.getByRole( 'dialog', { hidden: true } ) ).toHaveAttribute(
+			'aria-label',
+			'Filters'
+		);
+	} );
+} );

--- a/projects/packages/search/tests/js/search-blocks/no-results-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/no-results-edit.test.jsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import NoResultsEdit from '../../../src/search-blocks/blocks/no-results/edit';
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	useBlockProps: () => ( { className: 'wp-block-jetpack-no-results' } ),
+	InspectorControls: ( { children } ) => <div data-testid="inspector">{ children }</div>,
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	PanelBody: ( { title, children } ) => (
+		<section data-testid="panel" aria-label={ title }>
+			{ children }
+		</section>
+	),
+	TextControl: ( { label, value, onChange, placeholder } ) => {
+		const id = 'no-results-message-control';
+		return (
+			<>
+				<label htmlFor={ id }>{ label }</label>
+				<input
+					id={ id }
+					type="text"
+					value={ value || '' }
+					placeholder={ placeholder }
+					onChange={ event => onChange( event.target.value ) }
+				/>
+			</>
+		);
+	},
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: text => text,
+} ) );
+
+describe( 'NoResultsEdit', () => {
+	it( 'keeps the no-results message out of the successful-results preview', () => {
+		render( <NoResultsEdit attributes={ {} } setAttributes={ jest.fn() } /> );
+
+		expect( screen.getByRole( 'textbox', { name: 'Message' } ) ).toBeInTheDocument();
+		expect(
+			screen.queryByText( 'No results found. Try a different search.' )
+		).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/search/tests/js/search-blocks/popover-events.test.js
+++ b/projects/packages/search/tests/js/search-blocks/popover-events.test.js
@@ -1,0 +1,42 @@
+import { isEventInsidePopoverRoot } from '../../../src/search-blocks/store/popover-events';
+
+describe( 'isEventInsidePopoverRoot', () => {
+	it( 'detects clicks that began inside a popover after the target is detached', () => {
+		document.body.innerHTML = `
+			<div data-jetpack-search-popover-root>
+				<button type="button">Remove filter</button>
+			</div>
+		`;
+
+		const root = document.querySelector( '[data-jetpack-search-popover-root]' );
+		const button = document.querySelector( 'button' );
+		const event = {
+			target: button,
+			composedPath: () => [ button, root, document.body, document, window ],
+		};
+
+		button.remove();
+
+		expect( isEventInsidePopoverRoot( event ) ).toBe( true );
+	} );
+
+	it( 'falls back to the current target ancestry when composedPath is unavailable', () => {
+		document.body.innerHTML = `
+			<div data-jetpack-search-popover-root>
+				<button type="button">Clear all</button>
+			</div>
+		`;
+
+		expect( isEventInsidePopoverRoot( { target: document.querySelector( 'button' ) } ) ).toBe(
+			true
+		);
+	} );
+
+	it( 'ignores clicks outside search popovers', () => {
+		document.body.innerHTML = '<button type="button">Outside</button>';
+
+		expect( isEventInsidePopoverRoot( { target: document.querySelector( 'button' ) } ) ).toBe(
+			false
+		);
+	} );
+} );

--- a/projects/packages/search/tests/js/search-blocks/result-utils.test.js
+++ b/projects/packages/search/tests/js/search-blocks/result-utils.test.js
@@ -273,9 +273,20 @@ describe( 'normalizeResult', () => {
 			permalink: '',
 			path: '',
 			dateLabel: '',
-			author: '',
 			imageUrl: '',
 		} );
+	} );
+
+	it( 'does not expose author data from the API response', () => {
+		const raw = {
+			result_id: '1',
+			fields: {
+				'permalink.url.raw': 'https://example.com/a',
+				'title.default': 'Post',
+				'author.name': 'Ada Lovelace',
+			},
+		};
+		expect( normalizeResult( raw ) ).not.toHaveProperty( 'author' );
 	} );
 } );
 
@@ -300,42 +311,5 @@ describe( 'countActiveFilters', () => {
 
 	it( 'ignores non-array values defensively', () => {
 		expect( countActiveFilters( { category: 'news' } ) ).toBe( 0 );
-	} );
-} );
-
-describe( 'normalizeResult author', () => {
-	it( 'extracts author.name from fields', () => {
-		const raw = {
-			result_id: '1',
-			fields: {
-				'permalink.url.raw': 'https://example.com/a',
-				'title.default': 'Post',
-				'author.name': 'Ada Lovelace',
-			},
-		};
-		expect( normalizeResult( raw ).author ).toBe( 'Ada Lovelace' );
-	} );
-
-	it( 'handles author.name as array (v1.3 field shape)', () => {
-		const raw = {
-			result_id: '1',
-			fields: {
-				'permalink.url.raw': 'https://example.com/a',
-				'title.default': 'Post',
-				'author.name': [ 'Ada Lovelace' ],
-			},
-		};
-		expect( normalizeResult( raw ).author ).toBe( 'Ada Lovelace' );
-	} );
-
-	it( 'returns empty string when author field is missing', () => {
-		const raw = {
-			result_id: '1',
-			fields: {
-				'permalink.url.raw': 'https://example.com/a',
-				'title.default': 'Post',
-			},
-		};
-		expect( normalizeResult( raw ).author ).toBe( '' );
 	} );
 } );

--- a/projects/packages/search/tests/js/search-blocks/result-utils.test.js
+++ b/projects/packages/search/tests/js/search-blocks/result-utils.test.js
@@ -1,4 +1,5 @@
 import {
+	countActiveFilters,
 	formatDate,
 	formatPath,
 	normalizeResult,
@@ -275,6 +276,30 @@ describe( 'normalizeResult', () => {
 			author: '',
 			imageUrl: '',
 		} );
+	} );
+} );
+
+describe( 'countActiveFilters', () => {
+	it( 'returns 0 for empty object', () => {
+		expect( countActiveFilters( {} ) ).toBe( 0 );
+	} );
+
+	it( 'returns 0 for null / undefined', () => {
+		expect( countActiveFilters( null ) ).toBe( 0 );
+		expect( countActiveFilters( undefined ) ).toBe( 0 );
+	} );
+
+	it( 'sums selected values across all filter keys', () => {
+		const active = {
+			category: [ 'news', 'opinion' ],
+			post_tag: [ 'a' ],
+			post_type: [],
+		};
+		expect( countActiveFilters( active ) ).toBe( 3 );
+	} );
+
+	it( 'ignores non-array values defensively', () => {
+		expect( countActiveFilters( { category: 'news' } ) ).toBe( 0 );
 	} );
 } );
 

--- a/projects/packages/search/tests/js/search-blocks/result-utils.test.js
+++ b/projects/packages/search/tests/js/search-blocks/result-utils.test.js
@@ -272,7 +272,45 @@ describe( 'normalizeResult', () => {
 			permalink: '',
 			path: '',
 			dateLabel: '',
+			author: '',
 			imageUrl: '',
 		} );
+	} );
+} );
+
+describe( 'normalizeResult author', () => {
+	it( 'extracts author.name from fields', () => {
+		const raw = {
+			result_id: '1',
+			fields: {
+				'permalink.url.raw': 'https://example.com/a',
+				'title.default': 'Post',
+				'author.name': 'Ada Lovelace',
+			},
+		};
+		expect( normalizeResult( raw ).author ).toBe( 'Ada Lovelace' );
+	} );
+
+	it( 'handles author.name as array (v1.3 field shape)', () => {
+		const raw = {
+			result_id: '1',
+			fields: {
+				'permalink.url.raw': 'https://example.com/a',
+				'title.default': 'Post',
+				'author.name': [ 'Ada Lovelace' ],
+			},
+		};
+		expect( normalizeResult( raw ).author ).toBe( 'Ada Lovelace' );
+	} );
+
+	it( 'returns empty string when author field is missing', () => {
+		const raw = {
+			result_id: '1',
+			fields: {
+				'permalink.url.raw': 'https://example.com/a',
+				'title.default': 'Post',
+			},
+		};
+		expect( normalizeResult( raw ).author ).toBe( '' );
 	} );
 } );

--- a/projects/packages/search/tests/js/search-blocks/result-utils.test.js
+++ b/projects/packages/search/tests/js/search-blocks/result-utils.test.js
@@ -215,7 +215,7 @@ describe( 'normalizeResult', () => {
 			permalink: '//example.com/2026/04/20/hi/',
 			path: '2026 › 04 › 20 › hi',
 			imageUrl: '//cdn.example.com/img.jpg',
-			hasTitleHighlight: true,
+			hasTitlePieces: true,
 		} );
 		expect( r.titlePieces ).toEqual( [ { index: 0, text: 'Hello', isHighlight: true } ] );
 		expect( r.dateLabel ).toMatch( /Apr 20, 2026/ );
@@ -230,14 +230,14 @@ describe( 'normalizeResult', () => {
 		).toBe( '//example.com/a/' );
 	} );
 
-	it( 'hasTitleHighlight is false when no mark tags present', () => {
+	it( 'hasTitlePieces is true when highlight title contains plain text only', () => {
 		const r = normalizeResult( {
 			...RAW,
 			highlight: { title: 'no highlights here' },
 		} );
-		// tokenizeHighlight still yields one piece (isHighlight=false), so we
-		// need to confirm hasTitleHighlight reflects the absence of any mark.
-		expect( r.hasTitleHighlight ).toBe( true );
+		// The template should render titlePieces whenever the API returns
+		// highlight title tokens, even when none of them contain <mark>.
+		expect( r.hasTitlePieces ).toBe( true );
 	} );
 
 	it( 'defaults to empty title when both title.default and title are missing', () => {
@@ -269,7 +269,7 @@ describe( 'normalizeResult', () => {
 			id: '',
 			title: '',
 			titlePieces: [],
-			hasTitleHighlight: false,
+			hasTitlePieces: false,
 			permalink: '',
 			path: '',
 			dateLabel: '',

--- a/projects/packages/search/tests/js/search-blocks/search-results-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/search-results-edit.test.jsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import SearchResultsEdit from '../../../src/search-blocks/blocks/search-results/edit';
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	useBlockProps: props => ( { ...props, className: props?.className } ),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: text => text,
+} ) );
+
+describe( 'SearchResultsEdit', () => {
+	it( 'does not show author names in the compact preview', () => {
+		render( <SearchResultsEdit attributes={ { layout: 'compact' } } /> );
+
+		expect( screen.getByText( 'First sample result' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Apr 1, 2026' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Ada Lovelace' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Grace Hopper' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Katherine Johnson' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/search/tests/js/search-blocks/sort-control-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/sort-control-edit.test.jsx
@@ -91,6 +91,12 @@ describe( 'SortControlEdit', () => {
 		expect( screen.queryByRole( 'combobox', { name: 'Sort by' } ) ).not.toBeInTheDocument();
 	} );
 
+	it( 'keeps legacy display=popover blocks as an icon trigger preview', () => {
+		render( <SortControlEdit attributes={ { display: 'popover' } } setAttributes={ jest.fn() } /> );
+		expect( screen.getByRole( 'button', { name: 'Sort results' } ) ).toBeDisabled();
+		expect( screen.queryByRole( 'combobox', { name: 'Sort by' } ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'moves defaultSort onto the next available key when the author unchecks the current default', () => {
 		const onSetAttributes = jest.fn();
 		render(

--- a/projects/packages/search/tests/js/search-blocks/sort-control-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/sort-control-edit.test.jsx
@@ -83,6 +83,14 @@ describe( 'SortControlEdit', () => {
 		expect( within( fieldset ).getByRole( 'radio', { name: 'Newest' } ) ).toBeChecked();
 	} );
 
+	it( 'renders an icon trigger preview when displayAs=popover', () => {
+		render(
+			<SortControlEdit attributes={ { displayAs: 'popover' } } setAttributes={ jest.fn() } />
+		);
+		expect( screen.getByRole( 'button', { name: 'Sort results' } ) ).toBeDisabled();
+		expect( screen.queryByRole( 'combobox', { name: 'Sort by' } ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'moves defaultSort onto the next available key when the author unchecks the current default', () => {
 		const onSetAttributes = jest.fn();
 		render(

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -3,7 +3,87 @@
 // the api.js and url-state.js helpers that back the store actions.
 // Full store action testing is covered by E2E tests.
 
+const captured = {
+	state: {},
+	actions: {},
+};
+const originalFetch = global.fetch;
+
+jest.mock(
+	'@wordpress/interactivity',
+	() => ( {
+		store: ( _namespace, config ) => {
+			if ( config ) {
+				const descriptors = Object.getOwnPropertyDescriptors( config.state || {} );
+				for ( const key of Object.keys( descriptors ) ) {
+					Object.defineProperty( captured.state, key, descriptors[ key ] );
+				}
+				Object.assign( captured.actions, config.actions || {} );
+			}
+			return { state: captured.state, actions: captured.actions };
+		},
+	} ),
+	{ virtual: true }
+);
+
+import { actions, state } from '../../../src/search-blocks/store';
 import { stateToUrlParams, urlParamsToState } from '../../../src/search-blocks/store/url-state';
+
+/**
+ * Create a mock fetch response whose promise can be resolved after another action runs.
+ *
+ * @return {{promise: Promise<object>, resolve: Function}} Deferred response.
+ */
+function createDeferredResponse() {
+	let resolve;
+	const promise = new Promise( res => {
+		resolve = res;
+	} );
+	return { promise, resolve };
+}
+
+/**
+ * Create a minimal fetch Response mock.
+ *
+ * @param {object} data - Parsed JSON body.
+ * @return {{json: Function}} Response-like object.
+ */
+function createResponse( data ) {
+	return {
+		json: jest.fn().mockResolvedValue( data ),
+	};
+}
+
+/**
+ * Create a raw API result for store normalization.
+ *
+ * @param {string} title - Result title.
+ * @return {object} Raw search result.
+ */
+function createResult( title ) {
+	return {
+		result_id: title.toLowerCase().replaceAll( ' ', '-' ),
+		fields: {
+			'title.default': title,
+			'permalink.url.raw': `example.com/${ title.toLowerCase().replaceAll( ' ', '-' ) }/`,
+			date: '2026-04-01T00:00:00',
+		},
+	};
+}
+
+/**
+ * Resolve each promise yielded by an Interactivity API action generator.
+ *
+ * @param {Generator} generator - Action generator.
+ * @return {Promise<*>} Final generator return value.
+ */
+async function runGenerator( generator ) {
+	let step = generator.next();
+	while ( ! step.done ) {
+		step = generator.next( await step.value );
+	}
+	return step.value;
+}
 
 describe( 'store helpers round-trip', () => {
 	it( 'serializes and deserializes state without loss', () => {
@@ -28,5 +108,77 @@ describe( 'store helpers round-trip', () => {
 	it( 'drops an invalid `sortOrder` from serialized output', () => {
 		const params = stateToUrlParams( { searchQuery: 'boots', sortOrder: 'bogus' } );
 		expect( params.has( 'orderby' ) ).toBe( false );
+	} );
+} );
+
+describe( 'store actions', () => {
+	beforeEach( () => {
+		Object.assign( state, {
+			siteId: 123,
+			searchQuery: 'old query',
+			sortOrder: 'relevance',
+			pageHandle: 'old-page',
+			isPrivateSite: false,
+			isWpcom: false,
+			apiRoot: 'https://example.com/wp-json/',
+			homeUrl: 'https://example.com',
+			activeFilters: {},
+			filterConfigs: {},
+			results: [ { title: 'Existing result' } ],
+			locale: 'en-US',
+			isLoading: false,
+			isLoadingMore: false,
+			hasError: false,
+			totalResults: 1,
+			aggregations: {},
+		} );
+		Object.defineProperty( global, 'fetch', {
+			configurable: true,
+			writable: true,
+			value: jest.fn(),
+		} );
+	} );
+
+	afterEach( () => {
+		if ( originalFetch ) {
+			Object.defineProperty( global, 'fetch', {
+				configurable: true,
+				writable: true,
+				value: originalFetch,
+			} );
+		} else {
+			delete global.fetch;
+		}
+	} );
+
+	it( 'drops load-more responses superseded by a new search', async () => {
+		const loadMoreResponse = createDeferredResponse();
+		global.fetch.mockReturnValueOnce( loadMoreResponse.promise ).mockResolvedValueOnce(
+			createResponse( {
+				results: [ createResult( 'Fresh result' ) ],
+				total: 1,
+				page_handle: null,
+				aggregations: {},
+			} )
+		);
+
+		const loadMorePromise = runGenerator( actions.loadMore() );
+		expect( state.isLoadingMore ).toBe( true );
+
+		state.searchQuery = 'fresh query';
+		await runGenerator( actions.search( { syncUrl: false } ) );
+
+		loadMoreResponse.resolve(
+			createResponse( {
+				results: [ createResult( 'Stale page result' ) ],
+				page_handle: 'stale-next-page',
+			} )
+		);
+		await loadMorePromise;
+
+		expect( state.results ).toHaveLength( 1 );
+		expect( state.results[ 0 ].title ).toBe( 'Fresh result' );
+		expect( state.pageHandle ).toBeNull();
+		expect( state.isLoadingMore ).toBe( false );
 	} );
 } );

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -1,11 +1,10 @@
-// The Interactivity API store cannot be easily unit-tested in Jest because
-// `@wordpress/interactivity` relies on a browser DOM. These tests verify
-// the api.js and url-state.js helpers that back the store actions.
-// Full store action testing is covered by E2E tests.
+// Mock the Interactivity API store so the Search block store can be exercised
+// in Jest without booting the browser runtime.
 
 const captured = {
 	state: {},
 	actions: {},
+	callbacks: {},
 };
 const originalFetch = global.fetch;
 
@@ -19,6 +18,7 @@ jest.mock(
 					Object.defineProperty( captured.state, key, descriptors[ key ] );
 				}
 				Object.assign( captured.actions, config.actions || {} );
+				Object.assign( captured.callbacks, config.callbacks || {} );
 			}
 			return { state: captured.state, actions: captured.actions };
 		},
@@ -28,6 +28,8 @@ jest.mock(
 
 import { actions, state } from '../../../src/search-blocks/store';
 import { stateToUrlParams, urlParamsToState } from '../../../src/search-blocks/store/url-state';
+
+const originalActions = { ...actions };
 
 /**
  * Create a mock fetch response whose promise can be resolved after another action runs.
@@ -113,6 +115,7 @@ describe( 'store helpers round-trip', () => {
 
 describe( 'store actions', () => {
 	beforeEach( () => {
+		Object.assign( actions, originalActions );
 		Object.assign( state, {
 			siteId: 123,
 			searchQuery: 'old query',
@@ -131,6 +134,9 @@ describe( 'store actions', () => {
 			hasError: false,
 			totalResults: 1,
 			aggregations: {},
+			strings: {},
+			isFilterPopoverOpen: false,
+			isSortPopoverOpen: false,
 		} );
 		Object.defineProperty( global, 'fetch', {
 			configurable: true,
@@ -149,6 +155,7 @@ describe( 'store actions', () => {
 		} else {
 			delete global.fetch;
 		}
+		jest.restoreAllMocks();
 	} );
 
 	it( 'drops load-more responses superseded by a new search', async () => {
@@ -180,5 +187,210 @@ describe( 'store actions', () => {
 		expect( state.results[ 0 ].title ).toBe( 'Fresh result' );
 		expect( state.pageHandle ).toBeNull();
 		expect( state.isLoadingMore ).toBe( false );
+	} );
+
+	it( 'adds and removes selected filter values before searching', async () => {
+		const search = jest.spyOn( actions, 'search' ).mockResolvedValue();
+
+		await runGenerator( actions.setFilter( 'category', 'news' ) );
+		expect( state.activeFilters ).toEqual( { category: [ 'news' ] } );
+
+		await runGenerator( actions.setFilter( 'category', 'updates' ) );
+		expect( state.activeFilters ).toEqual( { category: [ 'news', 'updates' ] } );
+
+		await runGenerator( actions.setFilter( 'category', 'news' ) );
+		expect( state.activeFilters ).toEqual( { category: [ 'updates' ] } );
+
+		await runGenerator( actions.setFilter( 'category', 'updates' ) );
+		expect( state.activeFilters ).toEqual( {} );
+		expect( search ).toHaveBeenCalledTimes( 4 );
+	} );
+
+	it( 'clears filters only when filters are active', async () => {
+		const search = jest.spyOn( actions, 'search' ).mockResolvedValue();
+
+		await runGenerator( actions.clearFilters() );
+		expect( search ).not.toHaveBeenCalled();
+
+		state.activeFilters = { tag: [ 'react' ] };
+		await runGenerator( actions.clearFilters() );
+
+		expect( state.activeFilters ).toEqual( {} );
+		expect( search ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'keeps filter and sort popovers mutually exclusive', () => {
+		state.isSortPopoverOpen = true;
+		actions.toggleFilterPopover();
+		expect( state.isFilterPopoverOpen ).toBe( true );
+		expect( state.isSortPopoverOpen ).toBe( false );
+
+		state.isFilterPopoverOpen = true;
+		actions.toggleSortPopover();
+		expect( state.isSortPopoverOpen ).toBe( true );
+		expect( state.isFilterPopoverOpen ).toBe( false );
+
+		actions.closeAllPopovers();
+		expect( state.isFilterPopoverOpen ).toBe( false );
+		expect( state.isSortPopoverOpen ).toBe( false );
+	} );
+
+	it( 'selects a new sort order and closes the sort popover', async () => {
+		const search = jest.spyOn( actions, 'search' ).mockResolvedValue();
+		state.sortOrder = 'relevance';
+		state.isSortPopoverOpen = true;
+
+		await runGenerator( actions.selectSortOrder( { currentTarget: { value: 'newest' } } ) );
+
+		expect( state.sortOrder ).toBe( 'newest' );
+		expect( state.isSortPopoverOpen ).toBe( false );
+		expect( search ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'closes the sort popover without searching when sort selection is unchanged', async () => {
+		const search = jest.spyOn( actions, 'search' ).mockResolvedValue();
+		state.sortOrder = 'relevance';
+		state.isSortPopoverOpen = true;
+
+		await runGenerator( actions.selectSortOrder( { currentTarget: { value: 'relevance' } } ) );
+
+		expect( state.sortOrder ).toBe( 'relevance' );
+		expect( state.isSortPopoverOpen ).toBe( false );
+		expect( search ).not.toHaveBeenCalled();
+	} );
+
+	it( 'closes popovers on outside click but keeps them open for inside clicks', () => {
+		document.body.innerHTML =
+			'<div data-jetpack-search-popover-root><button id="inside"></button></div><button id="outside"></button>';
+		state.isFilterPopoverOpen = true;
+		const insideEvent = new MouseEvent( 'click', { bubbles: true } );
+		Object.defineProperty( insideEvent, 'target', {
+			value: document.getElementById( 'inside' ),
+		} );
+
+		actions.onWindowClickClosePopovers( insideEvent );
+		expect( state.isFilterPopoverOpen ).toBe( true );
+
+		const outsideEvent = new MouseEvent( 'click', { bubbles: true } );
+		Object.defineProperty( outsideEvent, 'target', {
+			value: document.getElementById( 'outside' ),
+		} );
+
+		actions.onWindowClickClosePopovers( outsideEvent );
+		expect( state.isFilterPopoverOpen ).toBe( false );
+	} );
+
+	it( 'closes open popovers on Escape only', () => {
+		state.isFilterPopoverOpen = true;
+		state.isSortPopoverOpen = true;
+
+		actions.onEscapeClosePopovers( { key: 'Enter' } );
+		expect( state.isFilterPopoverOpen ).toBe( true );
+		expect( state.isSortPopoverOpen ).toBe( true );
+
+		actions.onEscapeClosePopovers( { key: 'Escape' } );
+		expect( state.isFilterPopoverOpen ).toBe( false );
+		expect( state.isSortPopoverOpen ).toBe( false );
+	} );
+} );
+
+describe( 'store getters', () => {
+	beforeEach( () => {
+		Object.assign( state, {
+			isLoading: false,
+			hasError: false,
+			results: [ { title: 'Existing result' } ],
+			searchQuery: 'react',
+			totalResults: 0,
+			pageHandle: null,
+			activeFilters: {},
+			aggregations: {},
+			sortOrder: 'relevance',
+			strings: {
+				searching: 'Looking…',
+				resultsCountSingle: 'Found %d item',
+				resultsCountPlural: 'Found %d items',
+			},
+		} );
+	} );
+
+	it( 'formats the results count for loading, singular, plural, and empty states', () => {
+		state.isLoading = true;
+		expect( state.resultsCountText ).toBe( 'Looking…' );
+
+		state.isLoading = false;
+		state.totalResults = 1;
+		expect( state.resultsCountText ).toBe( 'Found 1 item' );
+
+		state.totalResults = 3;
+		expect( state.resultsCountText ).toBe( 'Found 3 items' );
+
+		state.totalResults = 0;
+		expect( state.resultsCountText ).toBe( '' );
+	} );
+
+	it( 'derives result, load-more, and filter visibility flags', () => {
+		state.results = [];
+		expect( state.showNoResults ).toBe( true );
+
+		state.hasError = true;
+		expect( state.showNoResults ).toBe( false );
+
+		state.hasError = false;
+		state.pageHandle = 'next-page';
+		expect( state.showLoadMore ).toBe( true );
+
+		state.isLoading = true;
+		expect( state.showLoadMore ).toBe( false );
+
+		state.isLoading = false;
+		state.activeFilters = { category: [ 'news', 'updates' ] };
+		expect( state.hasActiveFilters ).toBe( true );
+		expect( state.activeFilterCount ).toBe( 2 );
+	} );
+
+	it( 'enables the filter trigger for active filters or available aggregation buckets', () => {
+		expect( state.isFilterTriggerDisabled ).toBe( true );
+
+		state.aggregations = { category: { buckets: [ { key: 'news', doc_count: 2 } ] } };
+		expect( state.isFilterTriggerDisabled ).toBe( false );
+
+		state.aggregations = {};
+		state.activeFilters = { category: [ 'news' ] };
+		expect( state.isFilterTriggerDisabled ).toBe( false );
+	} );
+
+	it( 'derives sort state and trigger disabled state', () => {
+		expect( state.isSortByRelevance ).toBe( true );
+		expect( state.isSortTriggerDisabled ).toBe( true );
+
+		state.sortOrder = 'newest';
+		expect( state.isSortByNewest ).toBe( true );
+		expect( state.isSortTriggerDisabled ).toBe( false );
+
+		state.sortOrder = 'oldest';
+		expect( state.isSortByOldest ).toBe( true );
+	} );
+} );
+
+describe( 'store callbacks', () => {
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	it( 'initializes popstate handling and runs one URL-seeded search', () => {
+		const addEventListener = jest.spyOn( window, 'addEventListener' );
+		Object.assign( actions, originalActions );
+		jest.spyOn( actions, 'handlePopState' ).mockImplementation();
+		const search = jest.spyOn( actions, 'search' ).mockImplementation();
+		state.searchQuery = 'seeded';
+
+		captured.callbacks.initialize();
+		captured.callbacks.initialize();
+
+		expect( addEventListener ).toHaveBeenCalledTimes( 1 );
+		expect( addEventListener ).toHaveBeenCalledWith( 'popstate', actions.handlePopState );
+		expect( search ).toHaveBeenCalledTimes( 1 );
+		expect( search ).toHaveBeenCalledWith( { syncUrl: false } );
 	} );
 } );

--- a/projects/packages/search/tests/php/Search_Results_Render_Test.php
+++ b/projects/packages/search/tests/php/Search_Results_Render_Test.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Search Results block render.php tests.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Integration tests for the search-results block render template.
+ */
+class Search_Results_Render_Test extends TestCase {
+
+	/**
+	 * Register the search-results block inline so `do_blocks()` can resolve it
+	 * without depending on built artifacts.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		\register_block_type(
+			'jetpack/search-results',
+			array(
+				'attributes'      => array(
+					'layout' => array(
+						'type'    => 'string',
+						'default' => 'card',
+					),
+				),
+				// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+				'render_callback' => static function ( $attributes ) {
+					ob_start();
+					include __DIR__ . '/../../src/search-blocks/blocks/search-results/render.php';
+					return (string) ob_get_clean();
+				},
+				// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			)
+		);
+	}
+
+	/**
+	 * Unregister the block so other test classes start from a clean slate.
+	 */
+	public static function tearDownAfterClass(): void {
+		\unregister_block_type( 'jetpack/search-results' );
+		parent::tearDownAfterClass();
+	}
+
+	/**
+	 * Render the search-results block with the given attributes via `do_blocks`.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string Rendered markup.
+	 */
+	private function render( array $attributes = array() ): string {
+		$json = empty( $attributes )
+			? ''
+			: wp_json_encode( $attributes, JSON_UNESCAPED_SLASHES );
+		return do_blocks( '<!-- wp:jetpack/search-results ' . $json . ' /-->' );
+	}
+
+	/**
+	 * Compact result rows match Instant Search's normal single-site result
+	 * metadata and do not render an author byline.
+	 */
+	public function test_compact_layout_does_not_render_author_slot() {
+		$markup = $this->render( array( 'layout' => 'compact' ) );
+		$this->assertStringContainsString( 'jetpack-search-results--compact', $markup );
+		$this->assertStringNotContainsString( 'jetpack-search-results__author', $markup );
+		$this->assertStringNotContainsString( 'context.result.author', $markup );
+	}
+}

--- a/projects/packages/search/tests/php/Sort_Control_Render_Test.php
+++ b/projects/packages/search/tests/php/Sort_Control_Render_Test.php
@@ -45,6 +45,9 @@ class Sort_Control_Render_Test extends TestCase {
 						'type'    => 'string',
 						'default' => 'select',
 					),
+					'display'              => array(
+						'type' => 'string',
+					),
 				),
 				// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 				'render_callback' => static function ( $attributes ) {
@@ -110,6 +113,18 @@ class Sort_Control_Render_Test extends TestCase {
 	/** `displayAs=popover` emits the compact icon trigger and menu. */
 	public function test_display_as_popover_renders_menu() {
 		$markup = $this->render( array( 'displayAs' => 'popover' ) );
+		$this->assertStringContainsString( 'jetpack-search-sort--popover', $markup );
+		$this->assertStringContainsString( 'aria-haspopup="menu"', $markup );
+		$this->assertStringContainsString( 'role="menu"', $markup );
+		$this->assertStringNotContainsString( '<select', $markup );
+	}
+
+	/**
+	 * Blocks inserted before `displayAs` landed used `display=popover`.
+	 * They must keep rendering the compact icon trigger.
+	 */
+	public function test_legacy_display_popover_renders_menu() {
+		$markup = $this->render( array( 'display' => 'popover' ) );
 		$this->assertStringContainsString( 'jetpack-search-sort--popover', $markup );
 		$this->assertStringContainsString( 'aria-haspopup="menu"', $markup );
 		$this->assertStringContainsString( 'role="menu"', $markup );

--- a/projects/packages/search/tests/php/Sort_Control_Render_Test.php
+++ b/projects/packages/search/tests/php/Sort_Control_Render_Test.php
@@ -107,6 +107,15 @@ class Sort_Control_Render_Test extends TestCase {
 		$this->assertStringContainsString( 'type="radio"', $markup );
 	}
 
+	/** `displayAs=popover` emits the compact icon trigger and menu. */
+	public function test_display_as_popover_renders_menu() {
+		$markup = $this->render( array( 'displayAs' => 'popover' ) );
+		$this->assertStringContainsString( 'jetpack-search-sort--popover', $markup );
+		$this->assertStringContainsString( 'aria-haspopup="menu"', $markup );
+		$this->assertStringContainsString( 'role="menu"', $markup );
+		$this->assertStringNotContainsString( '<select', $markup );
+	}
+
 	/** URL `?orderby=` wins over `defaultSort` so deep links keep their meaning. */
 	public function test_url_sort_wins_over_default_sort() {
 		$_GET = array( 'orderby' => 'oldest' );

--- a/projects/packages/search/tests/php/Sort_Control_Test.php
+++ b/projects/packages/search/tests/php/Sort_Control_Test.php
@@ -130,6 +130,13 @@ class Sort_Control_Test extends TestCase {
 	}
 
 	/**
+	 * `display=popover` was used before this block adopted `displayAs`.
+	 */
+	public function test_normalize_display_as_accepts_legacy_display_popover() {
+		$this->assertSame( 'popover', Sort_Control::normalize_display_as( array( 'display' => 'popover' ) ) );
+	}
+
+	/**
 	 * Unknown values must collapse to `select` so a garbage attribute can't
 	 * produce markup the view script doesn't know how to bind against.
 	 */

--- a/projects/packages/search/tests/php/Sort_Control_Test.php
+++ b/projects/packages/search/tests/php/Sort_Control_Test.php
@@ -116,10 +116,17 @@ class Sort_Control_Test extends TestCase {
 	}
 
 	/**
-	 * `radio` is the only non-default value the block supports.
+	 * `radio` and `popover` are the supported non-default presentations.
 	 */
 	public function test_normalize_display_as_accepts_radio() {
 		$this->assertSame( 'radio', Sort_Control::normalize_display_as( array( 'displayAs' => 'radio' ) ) );
+	}
+
+	/**
+	 * `popover` uses the compact toolbar icon trigger and menu.
+	 */
+	public function test_normalize_display_as_accepts_popover() {
+		$this->assertSame( 'popover', Sort_Control::normalize_display_as( array( 'displayAs' => 'popover' ) ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes [RSM-1071](https://linear.app/a8c/issue/RSM-1071/search-30-compact-search-pattern-with-inline-filter-sort-controls)

<!-- Linear: https://linear.app/a8c/issue/RSM-1071/search-30-compact-search-pattern-with-inline-filter-sort-controls -->

## Proposed changes

Adds a **Compact Search** Jetpack Search block pattern: a single-row toolbar (search + filter popover + sort popover) over a dense result list, inspired by the WordPress Dataview list layout.

- **New block**: `jetpack/filter-popover` — a container for `filter-checkbox` + `active-filters` inner blocks, surfaced as an icon trigger with an active-filter count badge; opens a `role="dialog"` panel.
- **Existing blocks extended**:
  - `jetpack/search-results` now supports `layout: "card" | "compact"`. Compact mode hides the breadcrumb path and image, renders title + date in a dense row, and omits author bylines to match normal single-site Instant Search result metadata.
  - `jetpack/sort-control` now supports `displayAs: "select" | "radio" | "popover"`. Popover mode renders an icon trigger -> `role="menu"` with `menuitemradio` options, and still supports older saved `display="popover"` block markup.
- **Interactivity store**: adds `isFilterPopoverOpen` / `isSortPopoverOpen` state, `toggleFilterPopover` / `toggleSortPopover` / `closeAllPopovers` / `selectSortOrder` actions, `onWindowClickClosePopovers` / `onEscapeClosePopovers` window handlers for Dataview-style outside-click + Esc close, plus `activeFilterCount` and sort-state derived getters.
- **Editor previews**: compact preview states now mirror the front-end default/successful-results state: popovers are closed by default, and the no-results message is not shown alongside sample results.
- **Result data**: result card normalization keeps only fields the Search block UI renders; author byline data is not exposed for compact results.
- **Pattern**: new `compact-search.php` composes `search-input` + `filter-popover` (with category / tag / post-type `filter-checkbox` children) + `sort-control[displayAs=popover]` + `results-count` + `search-results[layout=compact]` + `no-results` + `load-more`.

All new styles use `currentColor` / `color-mix` / `var(--wp--preset--color--background)` so they inherit the active theme palette.

## Related product discussion/links

- Linear: [RSM-1071](https://linear.app/a8c/issue/RSM-1071/search-30-compact-search-pattern-with-inline-filter-sort-controls)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Requires the Jetpack Search blocks feature flag to be enabled.

If Jetpack Instant Search is enabled on the test site, disable it before testing on a search results page; otherwise the Instant Search overlay intercepts `?s=...` requests and the compact toolbar cannot be exercised.

1. In a wp-env (or any WP site with this package mounted), create a new page.
2. Open the block inserter -> **Patterns** -> **Jetpack Search** -> insert **Compact Search**.
3. Save and view the page.

**Editor preview:**

- The inserted pattern preview shows the compact toolbar and sample results.
- The filter and sort popovers are closed by default.
- The no-results message is not displayed under the sample results.
- Compact sample results show title + date only; no author byline is displayed.

**Golden path:**

- You see a single row containing: a search input on the left, and a **filter** icon + **sort** icon on the right.
- Results render below as a compact list: title + date, no author, no excerpt/image, tight vertical rhythm.

**Filter popover:**

- Click the filter icon. A popover opens containing the **Active Filters** summary plus **Category**, **Tag**, and **Post Type** checkbox lists (each with live aggregation counts).
- Tick one or more checkboxes — results update, the popover stays open, and a numeric **badge** appears on the filter trigger showing the total count of selected values across all dimensions.
- Close the popover. Re-open. State is preserved.

**Sort popover:**

- Click the sort icon. A menu opens with **Relevance**, **Newest**, **Oldest**. The currently selected option shows a checkmark.
- Pick a different option — the list resorts and the popover closes.

**Accessibility / Dataview parity:**

- Tab order reaches search input -> filter trigger -> sort trigger.
- Open a popover: the trigger's `aria-expanded` flips to `true`.
- Press `Escape` — the open popover closes.
- Click outside an open popover — it closes.
- Opening the filter popover while the sort popover is open should close the sort popover (and vice versa).

**Theme inheritance:**

- Switch the active theme to one with a dark background (or change the enclosing Group block's palette).
- All new UI (trigger borders, hover backgrounds, panel backgrounds, badge) should remain legible.

**Regression check:**

- Insert the original **Blog Search Page** pattern on another page. It should still render its full sidebar layout with the native `<select>` for sort and the same `search-results` "card" layout as before.

## Screenshots (from the issue, for reference)

Target initial UI, filter-open state, and filter-applied state are documented on [RSM-1071](https://linear.app/a8c/issue/RSM-1071/search-30-compact-search-pattern-with-inline-filter-sort-controls) — the one deliberate departure from Dataview is using a sort icon where Dataview uses a gear.
