### PR TITLE
jetpack-mu-wpcom: Add Instagram importer entry in wp-admin/import.php

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-instagram-importer-entry
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-instagram-importer-entry
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add Instagram importer entry to wp-admin/import.php, redirecting to the Calypso Instagram importer step.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-imports/wpcom-imports.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-imports/wpcom-imports.php
@@ -20,11 +20,13 @@ function wpcom_imports_register_imports() {
 
 	$squarespace_description = __( 'Import <strong>posts, comments, images and tags</strong> from a Squarespace export file.', 'jetpack-mu-wpcom' );
 	$medium_description      = __( 'Import <strong>posts</strong> from a Medium export file.', 'jetpack-mu-wpcom' );
+	$instagram_description   = __( 'Import <strong>posts and images</strong> from an Instagram export archive.', 'jetpack-mu-wpcom' );
 	$wix_description         = __( 'Import <strong>posts, pages, and media</strong> from your Wix.com site.', 'jetpack-mu-wpcom' );
 	$substack_description    = __( 'Import <strong>content and subscribers</strong> from your Substack site.', 'jetpack-mu-wpcom' );
 
 	register_importer( 'wpcom-squarespace', __( 'Squarespace', 'jetpack-mu-wpcom' ), $squarespace_description, $page );
 	register_importer( 'wpcom-medium', __( 'Medium', 'jetpack-mu-wpcom' ), $medium_description, $page );
+	register_importer( 'wpcom-instagram', __( 'Instagram', 'jetpack-mu-wpcom' ), $instagram_description, $page );
 	register_importer( 'wpcom-wix', __( 'Wix', 'jetpack-mu-wpcom' ), $wix_description, $page );
 	register_importer( 'wpcom-substack', __( 'Substack', 'jetpack-mu-wpcom' ), $substack_description, $page );
 }
@@ -63,6 +65,24 @@ add_action(
 		$domain = wp_parse_url( home_url(), PHP_URL_HOST );
 		// phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
 		wp_redirect( 'https://wordpress.com/setup/site-setup/importerMedium?ref=wp-admin-importers-list-direct-importer&siteSlug=' . $domain );
+		exit();
+	}
+);
+
+/**
+ * Redirect to Calypso Stepper Instagram importer.
+ */
+add_action(
+	'load-importer-wpcom-instagram',
+	/**
+	 * Redirect to the Instagram importer in the Calypso Stepper.
+	 *
+	 * @return never-return
+	 */
+	function () {
+		$domain = wp_parse_url( home_url(), PHP_URL_HOST );
+		// phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
+		wp_redirect( 'https://wordpress.com/setup/site-setup/importerInstagram?ref=wp-admin-importers-list-direct-importer&siteSlug=' . $domain );
 		exit();
 	}
 );


### PR DESCRIPTION
Related https://linear.app/a8c/issue/RSM-1524

## Proposed changes
* Adds a new Instagram importer entry for Atomic and Simple Sites in WP-Admin/import.php
* Clicking "Run Importer" redirects to `https://wordpress.com/setup/site-setup/importerInstagram` with `siteSlug` param

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Apply this PR on your sandbox and on your Atomic site
* Go to WP-Admin/import.php
* Notice that there's a new "Instagram" importer entry
* Click on "Run Importer"
* Notice that you're redirected to `https://wordpress.com/setup/site-setup/importerInstagram?ref=wp-admin-importers-list-direct-importer&siteSlug=<your-site>`
