### PR TITLE
Search: filter-checkbox Filter type inspector control

### DIFF
--- a/projects/packages/search/changelog/add-rsm-1078-filter-checkbox-type-selector
+++ b/projects/packages/search/changelog/add-rsm-1078-filter-checkbox-type-selector
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Search Blocks: add inspector Filter type control so authors can swap a filter-checkbox between Category, Tag, Post Type, Author, and Custom Taxonomy variations without re-inserting the block.

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
@@ -3,11 +3,10 @@
  *
  * Shows a labeled list of sample checkbox options mirroring the runtime DOM
  * shape so designers can style the filter list in place. The inspector
- * exposes the user-tunable attributes (label, showCount, maxItems,
- * bucketSortOrder); the variation-defining attributes — `filterType` and
- * `taxonomy` — are set by the Category / Tag / Post Type / Author / Custom
- * Taxonomy variations registered in class-search-blocks.php and are not
- * surfaced here to keep block instances routable to a known filter schema.
+ * exposes the user-tunable attributes (filter type, label, showCount,
+ * maxItems, bucketSortOrder). The filter-type control lets authors swap
+ * between the Category / Tag / Post Type / Author / Custom Taxonomy
+ * variations without deleting and re-inserting the block.
  */
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import {
@@ -25,6 +24,71 @@ const SAMPLE_FILTER_ITEMS = [
 	{ value: 'two', label: __( 'Second option', 'jetpack-search-pkg' ), count: 12 },
 	{ value: 'three', label: __( 'Third option', 'jetpack-search-pkg' ), count: 7 },
 ];
+
+// Variation identifiers mirror the variation `name`s registered in
+// Search_Blocks::register_variations() so the inspector picker and the
+// block-inserter picker describe the same set of filter schemas.
+const VARIATION_CATEGORY = 'category';
+const VARIATION_POST_TAG = 'post_tag';
+const VARIATION_POST_TYPE = 'post_type';
+const VARIATION_AUTHOR = 'author';
+const VARIATION_CUSTOM_TAXONOMY = 'custom_taxonomy';
+
+/**
+ * Identify which built-in variation the current (filterType, taxonomy) pair
+ * matches. Any taxonomy-family block that isn't `category` or `post_tag` is
+ * treated as a custom taxonomy so the slug input reveals itself.
+ *
+ * @param {object} attributes - Block attributes.
+ * @return {string} Variation identifier.
+ */
+function deriveVariation( attributes ) {
+	const filterType = attributes?.filterType || '';
+	if ( filterType === 'post_type' ) {
+		return VARIATION_POST_TYPE;
+	}
+	if ( filterType === 'author' ) {
+		return VARIATION_AUTHOR;
+	}
+	const taxonomy = attributes?.taxonomy || '';
+	if ( taxonomy === 'category' ) {
+		return VARIATION_CATEGORY;
+	}
+	if ( taxonomy === 'post_tag' ) {
+		return VARIATION_POST_TAG;
+	}
+	return VARIATION_CUSTOM_TAXONOMY;
+}
+
+/**
+ * Map a variation identifier back to the (filterType, taxonomy) attribute
+ * pair the JS store and PHP helpers expect. Switching to "Custom taxonomy"
+ * preserves any user-entered slug so toggling off-and-back doesn't force a
+ * re-entry; built-in categorical slugs (category, post_tag) are dropped
+ * because they'd be miscategorized as custom.
+ *
+ * @param {string} variation        - Target variation identifier.
+ * @param {string} previousTaxonomy - Current taxonomy attribute value.
+ * @return {{filterType: string, taxonomy: string}} Attribute pair.
+ */
+function variationToAttributes( variation, previousTaxonomy ) {
+	switch ( variation ) {
+		case VARIATION_CATEGORY:
+			return { filterType: 'taxonomy', taxonomy: 'category' };
+		case VARIATION_POST_TAG:
+			return { filterType: 'taxonomy', taxonomy: 'post_tag' };
+		case VARIATION_POST_TYPE:
+			return { filterType: 'post_type', taxonomy: '' };
+		case VARIATION_AUTHOR:
+			return { filterType: 'author', taxonomy: '' };
+		case VARIATION_CUSTOM_TAXONOMY:
+		default: {
+			const preserved =
+				previousTaxonomy === 'category' || previousTaxonomy === 'post_tag' ? '' : previousTaxonomy;
+			return { filterType: 'taxonomy', taxonomy: preserved };
+		}
+	}
+}
 
 /**
  * Mirror of Filter_Checkbox::default_label(): resolve the variation-specific
@@ -81,6 +145,23 @@ export default function FilterCheckboxEdit( { attributes, setAttributes } ) {
 	// Unknown values fall back to `count` so the preview controls always
 	// reflect a valid enum option; render.php normalizes the same way.
 	const bucketSortOrder = attributes?.bucketSortOrder === 'alpha' ? 'alpha' : 'count';
+	const currentVariation = deriveVariation( attributes );
+	const taxonomy = attributes?.taxonomy || '';
+
+	// Swapping the filter type via the inspector shouldn't wipe an author's
+	// custom label, but when the stored label still matches the prior
+	// variation's seeded default (i.e., the variation default was never
+	// edited), clear it so the new variation's default shows through the
+	// placeholder instead of stale copy from the old variation.
+	const onVariationChange = nextVariation => {
+		const next = variationToAttributes( nextVariation, taxonomy );
+		const priorDefault = variationDefaultLabel( attributes );
+		if ( rawLabel && priorDefault && rawLabel === priorDefault ) {
+			next.label = '';
+		}
+		setAttributes( next );
+	};
+
 	return h(
 		Fragment,
 		null,
@@ -90,6 +171,40 @@ export default function FilterCheckboxEdit( { attributes, setAttributes } ) {
 			h(
 				PanelBody,
 				{ title: __( 'Settings', 'jetpack-search-pkg' ) },
+				h( SelectControl, {
+					__next40pxDefaultSize: true,
+					__nextHasNoMarginBottom: true,
+					label: __( 'Filter type', 'jetpack-search-pkg' ),
+					value: currentVariation,
+					options: [
+						{ value: VARIATION_CATEGORY, label: __( 'Category', 'jetpack-search-pkg' ) },
+						{ value: VARIATION_POST_TAG, label: __( 'Tag', 'jetpack-search-pkg' ) },
+						{ value: VARIATION_POST_TYPE, label: __( 'Post Type', 'jetpack-search-pkg' ) },
+						{ value: VARIATION_AUTHOR, label: __( 'Author', 'jetpack-search-pkg' ) },
+						{
+							value: VARIATION_CUSTOM_TAXONOMY,
+							label: __( 'Custom taxonomy', 'jetpack-search-pkg' ),
+						},
+					],
+					onChange: onVariationChange,
+					help: __(
+						'What this filter groups results by. Switch without deleting the block.',
+						'jetpack-search-pkg'
+					),
+				} ),
+				currentVariation === VARIATION_CUSTOM_TAXONOMY
+					? h( TextControl, {
+							__next40pxDefaultSize: true,
+							__nextHasNoMarginBottom: true,
+							label: __( 'Taxonomy slug', 'jetpack-search-pkg' ),
+							value: taxonomy,
+							onChange: value => setAttributes( { taxonomy: value } ),
+							help: __(
+								'The registered taxonomy slug to filter by (e.g. genre, product_cat).',
+								'jetpack-search-pkg'
+							),
+					  } )
+					: null,
 				h( TextControl, {
 					__next40pxDefaultSize: true,
 					__nextHasNoMarginBottom: true,

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
@@ -28,11 +28,11 @@ const SAMPLE_FILTER_ITEMS = [
 // Variation identifiers mirror the variation `name`s registered in
 // Search_Blocks::register_variations() so the inspector picker and the
 // block-inserter picker describe the same set of filter schemas.
-const VARIATION_CATEGORY = 'category';
-const VARIATION_POST_TAG = 'post_tag';
-const VARIATION_POST_TYPE = 'post_type';
-const VARIATION_AUTHOR = 'author';
-const VARIATION_CUSTOM_TAXONOMY = 'custom_taxonomy';
+export const VARIATION_CATEGORY = 'category';
+export const VARIATION_POST_TAG = 'post_tag';
+export const VARIATION_POST_TYPE = 'post_type';
+export const VARIATION_AUTHOR = 'author';
+export const VARIATION_CUSTOM_TAXONOMY = 'custom_taxonomy';
 
 /**
  * Identify which built-in variation the current (filterType, taxonomy) pair
@@ -42,7 +42,7 @@ const VARIATION_CUSTOM_TAXONOMY = 'custom_taxonomy';
  * @param {object} attributes - Block attributes.
  * @return {string} Variation identifier.
  */
-function deriveVariation( attributes ) {
+export function deriveVariation( attributes ) {
 	const filterType = attributes?.filterType || '';
 	if ( filterType === 'post_type' ) {
 		return VARIATION_POST_TYPE;
@@ -62,25 +62,33 @@ function deriveVariation( attributes ) {
 
 /**
  * Map a variation identifier back to the (filterType, taxonomy) attribute
- * pair the JS store and PHP helpers expect. Switching to "Custom taxonomy"
- * preserves any user-entered slug so toggling off-and-back doesn't force a
- * re-entry; built-in categorical slugs (category, post_tag) are dropped
- * because they'd be miscategorized as custom.
+ * pair the JS store and PHP helpers expect.
+ *
+ * Author and Post Type variations carry `previousTaxonomy` forward so a
+ * Custom-taxonomy → Author/Post Type → Custom-taxonomy round-trip doesn't
+ * force the author to re-enter their slug. render.php ignores `taxonomy`
+ * whenever `filterType` isn't 'taxonomy', so the preserved value is purely
+ * UI state and never reaches the aggregation request.
+ *
+ * Category and Tag overwrite `taxonomy` with their built-in slugs, which
+ * means a Custom → Category → Custom round-trip *will* clear the slug.
+ * On the return trip we deliberately drop 'category' and 'post_tag' so the
+ * Taxonomy slug input doesn't surface them as custom-typed slugs.
  *
  * @param {string} variation        - Target variation identifier.
  * @param {string} previousTaxonomy - Current taxonomy attribute value.
  * @return {{filterType: string, taxonomy: string}} Attribute pair.
  */
-function variationToAttributes( variation, previousTaxonomy ) {
+export function variationToAttributes( variation, previousTaxonomy ) {
 	switch ( variation ) {
 		case VARIATION_CATEGORY:
 			return { filterType: 'taxonomy', taxonomy: 'category' };
 		case VARIATION_POST_TAG:
 			return { filterType: 'taxonomy', taxonomy: 'post_tag' };
 		case VARIATION_POST_TYPE:
-			return { filterType: 'post_type', taxonomy: '' };
+			return { filterType: 'post_type', taxonomy: previousTaxonomy || '' };
 		case VARIATION_AUTHOR:
-			return { filterType: 'author', taxonomy: '' };
+			return { filterType: 'author', taxonomy: previousTaxonomy || '' };
 		case VARIATION_CUSTOM_TAXONOMY:
 		default: {
 			const preserved =
@@ -103,7 +111,7 @@ function variationToAttributes( variation, previousTaxonomy ) {
  * @param {object} attributes - Block attributes.
  * @return {string} Variation default label, or '' when not a built-in variation.
  */
-function variationDefaultLabel( attributes ) {
+export function variationDefaultLabel( attributes ) {
 	const filterType = attributes?.filterType || '';
 	if ( filterType === 'post_type' ) {
 		return __( 'Post Type', 'jetpack-search-pkg' );

--- a/projects/packages/search/tests/js/search-blocks/filter-checkbox-edit.test.js
+++ b/projects/packages/search/tests/js/search-blocks/filter-checkbox-edit.test.js
@@ -1,0 +1,150 @@
+// Pins the pure helpers behind the filter-checkbox inspector. The component
+// itself is integration-tested via the editor; here we lock the variation
+// identification, attribute mapping, and label-default logic in isolation
+// because subtle changes (e.g. dropping `previousTaxonomy` for Author) have
+// silently broken slug round-trips in the past.
+
+import {
+	deriveVariation,
+	variationToAttributes,
+	variationDefaultLabel,
+	VARIATION_CATEGORY,
+	VARIATION_POST_TAG,
+	VARIATION_POST_TYPE,
+	VARIATION_AUTHOR,
+	VARIATION_CUSTOM_TAXONOMY,
+} from '../../../src/search-blocks/blocks/filter-checkbox/edit.js';
+
+describe( 'deriveVariation', () => {
+	it( 'maps the four built-in (filterType, taxonomy) pairs to their variation ids', () => {
+		expect( deriveVariation( { filterType: 'taxonomy', taxonomy: 'category' } ) ).toBe(
+			VARIATION_CATEGORY
+		);
+		expect( deriveVariation( { filterType: 'taxonomy', taxonomy: 'post_tag' } ) ).toBe(
+			VARIATION_POST_TAG
+		);
+		expect( deriveVariation( { filterType: 'post_type' } ) ).toBe( VARIATION_POST_TYPE );
+		expect( deriveVariation( { filterType: 'author' } ) ).toBe( VARIATION_AUTHOR );
+	} );
+
+	it( 'treats any non-built-in taxonomy slug as Custom Taxonomy', () => {
+		expect( deriveVariation( { filterType: 'taxonomy', taxonomy: 'genre' } ) ).toBe(
+			VARIATION_CUSTOM_TAXONOMY
+		);
+		expect( deriveVariation( { filterType: 'taxonomy', taxonomy: 'product_cat' } ) ).toBe(
+			VARIATION_CUSTOM_TAXONOMY
+		);
+	} );
+
+	it( 'falls back to Custom Taxonomy when filterType is empty (defensive)', () => {
+		// block.json declares `filterType: 'taxonomy'` and `taxonomy: 'category'`
+		// as defaults, so a freshly-inserted block always satisfies the Category
+		// branch above. This guards a hypothetical legacy save where the
+		// attributes are blank — the slug input shows up so the author can
+		// recover, instead of misclassifying as a built-in variation.
+		expect( deriveVariation( {} ) ).toBe( VARIATION_CUSTOM_TAXONOMY );
+		expect( deriveVariation( { filterType: '', taxonomy: '' } ) ).toBe( VARIATION_CUSTOM_TAXONOMY );
+	} );
+} );
+
+describe( 'variationToAttributes', () => {
+	it( 'returns the canonical (filterType, taxonomy) pair for each built-in variation', () => {
+		expect( variationToAttributes( VARIATION_CATEGORY, '' ) ).toEqual( {
+			filterType: 'taxonomy',
+			taxonomy: 'category',
+		} );
+		expect( variationToAttributes( VARIATION_POST_TAG, '' ) ).toEqual( {
+			filterType: 'taxonomy',
+			taxonomy: 'post_tag',
+		} );
+	} );
+
+	it( 'preserves previousTaxonomy for Author and Post Type so Custom-slug round-trips survive', () => {
+		// render.php ignores `taxonomy` when filterType isn't 'taxonomy', so
+		// keeping the slug here is purely UI state — but it lets the author
+		// flip Custom → Author → Custom without retyping `genre`.
+		expect( variationToAttributes( VARIATION_POST_TYPE, 'genre' ) ).toEqual( {
+			filterType: 'post_type',
+			taxonomy: 'genre',
+		} );
+		expect( variationToAttributes( VARIATION_AUTHOR, 'product_cat' ) ).toEqual( {
+			filterType: 'author',
+			taxonomy: 'product_cat',
+		} );
+		expect( variationToAttributes( VARIATION_AUTHOR, '' ) ).toEqual( {
+			filterType: 'author',
+			taxonomy: '',
+		} );
+	} );
+
+	it( 'preserves a custom slug when re-selecting Custom Taxonomy', () => {
+		expect( variationToAttributes( VARIATION_CUSTOM_TAXONOMY, 'genre' ) ).toEqual( {
+			filterType: 'taxonomy',
+			taxonomy: 'genre',
+		} );
+	} );
+
+	it( 'drops built-in `category` / `post_tag` when switching to Custom Taxonomy', () => {
+		// Otherwise these would surface as user-typed slugs in the Taxonomy
+		// slug input, which would be wrong: they're built-in variations.
+		expect( variationToAttributes( VARIATION_CUSTOM_TAXONOMY, 'category' ) ).toEqual( {
+			filterType: 'taxonomy',
+			taxonomy: '',
+		} );
+		expect( variationToAttributes( VARIATION_CUSTOM_TAXONOMY, 'post_tag' ) ).toEqual( {
+			filterType: 'taxonomy',
+			taxonomy: '',
+		} );
+	} );
+
+	it( 'falls through to Custom Taxonomy for unknown variation ids (defensive)', () => {
+		expect( variationToAttributes( 'not-a-real-variation', 'genre' ) ).toEqual( {
+			filterType: 'taxonomy',
+			taxonomy: 'genre',
+		} );
+	} );
+
+	it( 'preserves a custom slug across Custom → Author → Custom', () => {
+		// Simulates the inspector workflow: user types `genre`, swaps to
+		// Author, swaps back to Custom Taxonomy. The slug must come back.
+		const step1 = variationToAttributes( VARIATION_CUSTOM_TAXONOMY, 'genre' );
+		const step2 = variationToAttributes( VARIATION_AUTHOR, step1.taxonomy );
+		const step3 = variationToAttributes( VARIATION_CUSTOM_TAXONOMY, step2.taxonomy );
+		expect( step3.taxonomy ).toBe( 'genre' );
+	} );
+
+	it( 'preserves a custom slug across Custom → Post Type → Custom', () => {
+		const step1 = variationToAttributes( VARIATION_CUSTOM_TAXONOMY, 'product_cat' );
+		const step2 = variationToAttributes( VARIATION_POST_TYPE, step1.taxonomy );
+		const step3 = variationToAttributes( VARIATION_CUSTOM_TAXONOMY, step2.taxonomy );
+		expect( step3.taxonomy ).toBe( 'product_cat' );
+	} );
+
+	it( 'intentionally clears the slug across Custom → Category → Custom', () => {
+		// Once the author swaps through Category, the stored taxonomy is
+		// `category`, which we drop on the way back to avoid presenting it
+		// as a custom-typed slug. Documented behavior, not a regression.
+		const step1 = variationToAttributes( VARIATION_CUSTOM_TAXONOMY, 'genre' );
+		const step2 = variationToAttributes( VARIATION_CATEGORY, step1.taxonomy );
+		const step3 = variationToAttributes( VARIATION_CUSTOM_TAXONOMY, step2.taxonomy );
+		expect( step3.taxonomy ).toBe( '' );
+	} );
+} );
+
+describe( 'variationDefaultLabel', () => {
+	it( 'returns the seeded variation label for each built-in variation', () => {
+		expect( variationDefaultLabel( { filterType: 'taxonomy', taxonomy: 'category' } ) ).toBe(
+			'Category'
+		);
+		expect( variationDefaultLabel( { filterType: 'taxonomy', taxonomy: 'post_tag' } ) ).toBe(
+			'Tag'
+		);
+		expect( variationDefaultLabel( { filterType: 'post_type' } ) ).toBe( 'Post Type' );
+		expect( variationDefaultLabel( { filterType: 'author' } ) ).toBe( 'Author' );
+	} );
+
+	it( 'returns empty string for custom taxonomies so the caller falls back to the generic placeholder', () => {
+		expect( variationDefaultLabel( { filterType: 'taxonomy', taxonomy: 'genre' } ) ).toBe( '' );
+		expect( variationDefaultLabel( {} ) ).toBe( '' );
+	} );
+} );


### PR DESCRIPTION
Fixes [RSM-1078](https://linear.app/a8c/issue/RSM-1078/address-feedback-from-pr-48281-comment)

## Why this change

Before this PR, the filter-checkbox block had **no** way to change its filter type after insertion. Once an author dropped a *Filter by Category* block into a Search Results template, that block was permanently a Category filter — the variation was baked in by the block-inserter picker and the inspector had no control to swap it. Authors who wanted to convert it to a Tag, Post Type, Author, or Custom Taxonomy filter had to delete the block and insert a fresh one (which also wiped any inspector tweaks they had made — sort order, max items, custom label, count toggle).

This PR adds the missing affordance: a **Filter type** select at the top of the inspector that swaps the underlying variation in place. The block's other settings (label, max items, sort order, show counts) survive the swap, and a new **Taxonomy slug** input appears when *Custom Taxonomy* is selected so authors can target taxonomies the variation picker doesn't list (e.g. `genre`, `product_cat`).

![Filter type inspector control — Custom taxonomy with slug `genre`](https://github.com/user-attachments/assets/d7d2b8c6-6c23-4d3a-a338-83cd6e57b01c)

Inspector states for every variation: [Category](https://github.com/user-attachments/assets/a9e2f69f-ee0d-4d38-b9a9-c298eebdcd75) · [Tag](https://github.com/user-attachments/assets/6cc79b0a-7341-4884-b58c-3d0eed648324) · [Post Type](https://github.com/user-attachments/assets/407b45bd-dda6-4be3-b2f8-3ba10453d2ec) · [Author](https://github.com/user-attachments/assets/710e10b2-066d-4846-9e64-7da095f7a35b) · [Custom taxonomy](https://github.com/user-attachments/assets/d7d2b8c6-6c23-4d3a-a338-83cd6e57b01c) · [Custom label preserved across swap](https://github.com/user-attachments/assets/1fa72a0b-f18d-4e7e-b4f7-0cd932928606)

## Proposed changes
* Add a **Filter type** `SelectControl` to the filter-checkbox block inspector. Options mirror the registered variations: *Category*, *Tag*, *Post Type*, *Author*, *Custom Taxonomy*. Choosing one updates `filterType` (and `taxonomy`, where applicable) in one shot.
* When *Custom Taxonomy* is selected, reveal a secondary **Taxonomy slug** `TextControl`. Switching to *Author* or *Post Type* and back preserves the slug; switching through *Category* or *Tag* drops the slug deliberately so built-in slugs don't surface as custom-typed values.
* When the author swaps the filter type and the stored label still matches the prior variation's seeded default (i.e., was never customized), clear the label so the new variation's default shows through the placeholder. A user-edited label is left alone.

## Related product discussion/links
* Linear: https://linear.app/a8c/issue/RSM-1078/address-feedback-from-pr-48281-comment
* Follow-up on: [PR #48281](https://github.com/Automattic/jetpack/pull/48281) — [reviewer comment](https://github.com/Automattic/jetpack/pull/48281#issuecomment-4310404439)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

### Inspector — Filter type selector
1. On a site with Jetpack Search available, open any post/page and insert the **Checkbox Filter** block via any variation (e.g. *Filter by Category*).
2. Open the block inspector → **Settings**. Confirm the new **Filter type** select sits at the top of the panel with the current variation preselected and the help text *"What this filter groups results by. Switch without deleting the block."*.
3. Swap the value to **Tag**. Confirm:
   * The editor preview heading updates from *Category* to *Tag* (placeholder only — if you had typed a custom label, it stays).
   * Re-opening the inspector shows the new value.
4. Swap to **Post Type** and **Author**. Confirm the preview heading updates to the corresponding default. The previously-stored taxonomy slug is preserved as UI state for round-trips back to *Custom taxonomy* (render.php ignores `taxonomy` when `filterType` isn't `'taxonomy'`, so this is purely an editor convenience).
5. Swap to **Custom taxonomy**. Confirm a **Taxonomy slug** `TextControl` appears below the select with help text *"The registered taxonomy slug to filter by (e.g. genre, product_cat)."*. Type a slug (e.g. `genre`), save, reload — the slug round-trips.
6. Swap to **Author** and back to **Custom taxonomy** — the slug `genre` should still be there.
7. Swap back to **Category**. Confirm the slug input disappears and the preview heading returns to *Category*. (Round-tripping through Category/Tag intentionally clears the custom slug.)

### Label preservation across variation swaps
1. Insert the block as *Filter by Category* (variation seeds `label = "Category"`).
2. Open the inspector and swap the filter type to **Tag**. The label field should clear (placeholder now reads *Tag*) because the stored label was still the prior variation's default.
3. Insert another *Filter by Category* block. In the **Label** field, type *Topic*. Swap the filter type to **Tag**. The label should remain *Topic* (author customization preserved).

### Aggregation-request shape (no regression)
1. With any variation inserted on a front-end search page, confirm the aggregation URL still carries `aggregations[<filterKey>][terms][order][_count]=desc` (default) or `[_key]=asc` (with **Sort order → Alphabetical**). The `bucketSortOrder` behavior introduced in #48281 is unchanged.

### Regression
1. Inserting the block through the variation picker still seeds the variation's `label`, `filterType`, and `taxonomy` attributes as before — the new inspector control just gives authors a second entry point.
2. `composer phpunit` in `projects/packages/search` passes (200 tests). No PHP helpers changed.
3. `pnpm run test-scripts` in the same package passes (222 tests, including 13 new tests pinning the variation/attribute/label helpers).
