### PR TITLE
Jetpack: Add /plugins/replace and /themes/replace REST endpoints

### DIFF
--- a/projects/plugins/jetpack/changelog/add-replace-endpoints
+++ b/projects/plugins/jetpack/changelog/add-replace-endpoints
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+REST API: add `/sites/%s/plugins/replace` and `/sites/%s/themes/replace` endpoints for installing or overwriting a plugin/theme via zip upload.

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class-jetpack-json-api-attachment-ownership-trait.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class-jetpack-json-api-attachment-ownership-trait.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Shared attachment-ownership and zip-mime validation for JSON API endpoints
+ * that consume an uploaded zip (plugin/theme install and replace).
+ *
+ * @package automattic/jetpack
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
+/**
+ * Shared ownership check for endpoints that consume an uploaded attachment
+ * (plugin/theme zip uploads). Guards against an authorized caller referencing
+ * an attachment that wasn't part of this upload.
+ */
+trait Jetpack_JSON_API_Attachment_Ownership_Trait {
+
+	/**
+	 * Confirm the attachment exists, is the attachment post type, and is owned
+	 * by the current user when a user is identifiable. Site-auth requests
+	 * (no current user) skip the author check.
+	 *
+	 * @param int $attachment_id Attachment post ID.
+	 * @return true|WP_Error
+	 */
+	protected function validate_attachment_ownership( $attachment_id ) {
+		$post = get_post( $attachment_id );
+		if ( ! $post || 'attachment' !== $post->post_type ) {
+			return new WP_Error( 'invalid_attachment', __( 'The referenced upload is not a valid attachment.', 'jetpack' ), 400 );
+		}
+
+		$current_user_id = get_current_user_id();
+		if ( $current_user_id && (int) $post->post_author !== $current_user_id ) {
+			return new WP_Error( 'attachment_not_owned', __( 'The referenced upload does not belong to the current user.', 'jetpack' ), 403 );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Confirm the attachment is a zip package. Reject non-zip mime types and
+	 * non-.zip extensions to prevent unrelated uploads (images, PDFs, etc.)
+	 * from being fed to Plugin_Upgrader / Theme_Upgrader.
+	 *
+	 * @param int $attachment_id Attachment post ID.
+	 * @return true|WP_Error
+	 */
+	protected function validate_attachment_is_zip( $attachment_id ) {
+		$mime = get_post_mime_type( $attachment_id );
+		if ( 'application/zip' !== $mime ) {
+			return new WP_Error( 'invalid_attachment_mime', __( 'Uploaded attachment is not a zip package.', 'jetpack' ), 400 );
+		}
+
+		$file = get_attached_file( $attachment_id );
+		if ( $file ) {
+			$extension = strtolower( (string) pathinfo( $file, PATHINFO_EXTENSION ) );
+			if ( 'zip' !== $extension ) {
+				return new WP_Error( 'invalid_attachment_extension', __( 'Uploaded attachment is not a .zip file.', 'jetpack' ), 400 );
+			}
+		}
+
+		return true;
+	}
+}

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-replace-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-replace-endpoint.php
@@ -33,12 +33,15 @@ require_once ABSPATH . 'wp-admin/includes/file.php';
  *    on the wpcom side, any trusted site credential becomes install-anything
  *    on the site.
  *
- * ## Known pre-existing behavior inherited from the parent
+ * ## Cross-user attachment-deletion guard
  *
- * `Jetpack_JSON_API_Plugins_New_Endpoint::validate_call` deletes the
- * referenced attachment on capability-check failure without verifying the
- * caller owns it. This Replace endpoint inherits that behavior. Fixing it
- * belongs in the parent endpoint and is out of scope for this PR.
+ * `Jetpack_JSON_API_Plugins_New_Endpoint::validate_call` deletes the referenced
+ * attachment on capability-check failure without verifying the caller owns it.
+ * This Replace endpoint overrides `validate_call` to run the ownership check
+ * first, so a low-privilege caller cannot use it to hard-delete another user's
+ * attachment as a side-effect of the cap check failing. The parent's behavior
+ * is unchanged for the legitimate case (caller's own attachment is cleaned up
+ * when their cap check fails).
  *
  * @phan-constructor-used-for-side-effects
  */
@@ -51,14 +54,6 @@ class Jetpack_JSON_API_Plugins_Replace_Endpoint extends Jetpack_JSON_API_Plugins
 	 * @var array
 	 */
 	protected $needed_capabilities = array( 'install_plugins', 'update_plugins' );
-
-	/**
-	 * Slug declared by the caller. Used by the upgrader_source_selection filter
-	 * to reject zips whose top-level folder doesn't match.
-	 *
-	 * @var string
-	 */
-	protected $expected_slug = '';
 
 	/**
 	 * Error codes we are willing to surface to the caller. Anything outside
@@ -96,7 +91,6 @@ class Jetpack_JSON_API_Plugins_Replace_Endpoint extends Jetpack_JSON_API_Plugins
 		'fs_no_temp_backup_dir',
 		'fs_temp_backup_mkdir',
 		'fs_temp_backup_move',
-		'slug_mismatch',
 	);
 
 	/**
@@ -120,6 +114,9 @@ class Jetpack_JSON_API_Plugins_Replace_Endpoint extends Jetpack_JSON_API_Plugins
 
 		$plugin_attachment_id = (int) $args['zip'][0]['id'];
 
+		// Re-checked here so direct invocations of install() (notably the test stubs)
+		// can't accidentally bypass the ownership guard that validate_call() runs on
+		// the live request path.
 		$ownership = $this->validate_attachment_ownership( $plugin_attachment_id );
 		if ( is_wp_error( $ownership ) ) {
 			return $ownership;
@@ -140,19 +137,10 @@ class Jetpack_JSON_API_Plugins_Replace_Endpoint extends Jetpack_JSON_API_Plugins
 		$skin     = new Automatic_Install_Skin();
 		$upgrader = new Plugin_Upgrader( $skin );
 
-		$this->expected_slug = $expected_slug;
-		add_filter( 'upgrader_source_selection', array( $this, 'enforce_expected_slug' ), 9999, 4 );
-
-		$result = false;
-		try {
-			$result = $upgrader->install(
-				$local_file,
-				array( 'overwrite_package' => true )
-			);
-		} finally {
-			remove_filter( 'upgrader_source_selection', array( $this, 'enforce_expected_slug' ), 9999 );
-			$this->expected_slug = '';
-		}
+		$result = $upgrader->install(
+			$local_file,
+			array( 'overwrite_package' => true )
+		);
 
 		wp_delete_attachment( $plugin_attachment_id, true );
 
@@ -176,6 +164,14 @@ class Jetpack_JSON_API_Plugins_Replace_Endpoint extends Jetpack_JSON_API_Plugins
 			return new WP_Error( 'plugin_replace_info_missing', __( 'Plugin was installed but its identifier could not be determined.', 'jetpack' ), 500 );
 		}
 
+		// `overwrite_package=true` trusts the zip's own folder name, so a zip whose
+		// top-level folder differs from the declared slug would clobber an unrelated
+		// plugin. Verify the post-install identifier matches the caller's contract.
+		$installed_slug = dirname( $plugin_file );
+		if ( '.' === $installed_slug || strtolower( $installed_slug ) !== $expected_slug ) {
+			return new WP_Error( 'slug_mismatch', __( 'The installed plugin does not match the declared slug.', 'jetpack' ), 400 );
+		}
+
 		$this->plugins             = array( $plugin_file );
 		$this->log[ $plugin_file ] = $upgrader->skin->get_upgrade_messages();
 
@@ -183,43 +179,24 @@ class Jetpack_JSON_API_Plugins_Replace_Endpoint extends Jetpack_JSON_API_Plugins
 	}
 
 	/**
-	 * Filter callback for `upgrader_source_selection`. Rejects a zip whose top-level
-	 * folder does not match the slug the caller declared in the request. This closes
-	 * the cross-slug overwrite gap: `overwrite_package=true` trusts the zip's own
-	 * folder name, so without this guard a caller with install+update caps could
-	 * overwrite any plugin by uploading a zip whose folder happens to match.
+	 * See class docblock — runs the attachment-ownership check before delegating
+	 * to the parent's validate_call(), which deletes the referenced attachment
+	 * on capability-check failure without verifying ownership.
 	 *
-	 * @param string|WP_Error $source        Unpacked-zip source directory.
-	 * @param string          $remote_source Remote source path.
-	 * @param WP_Upgrader     $upgrader      Upgrader instance.
-	 * @param array           $hook_extra    Hook extra data.
-	 * @return string|WP_Error
+	 * @param int    $_blog_id            Blog ID.
+	 * @param string $capability          Capability.
+	 * @param bool   $check_manage_active Whether to check manage-is-active.
+	 * @return bool|WP_Error
 	 */
-	public function enforce_expected_slug( $source, $remote_source, $upgrader, $hook_extra ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		if ( is_wp_error( $source ) ) {
-			return $source;
+	protected function validate_call( $_blog_id, $capability, $check_manage_active = true ) {
+		$args = $this->input();
+		if ( isset( $args['zip'][0]['id'] ) && is_scalar( $args['zip'][0]['id'] ) ) {
+			$ownership = $this->validate_attachment_ownership( (int) $args['zip'][0]['id'] );
+			if ( is_wp_error( $ownership ) ) {
+				return $ownership;
+			}
 		}
-		if ( '' === $this->expected_slug ) {
-			return $source;
-		}
-		$actual_slug = basename( untrailingslashit( (string) $source ) );
-
-		if ( ! preg_match( '/^[a-zA-Z0-9][a-zA-Z0-9_-]*$/', $actual_slug ) ) {
-			return new WP_Error(
-				'slug_mismatch',
-				__( 'The uploaded zip does not match the declared plugin slug.', 'jetpack' ),
-				400
-			);
-		}
-
-		if ( strtolower( $actual_slug ) !== $this->expected_slug ) {
-			return new WP_Error(
-				'slug_mismatch',
-				__( 'The uploaded zip does not match the declared plugin slug.', 'jetpack' ),
-				400
-			);
-		}
-		return $source;
+		return parent::validate_call( $_blog_id, $capability, $check_manage_active );
 	}
 
 	/**

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-replace-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-replace-endpoint.php
@@ -1,0 +1,293 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+use Automattic\Jetpack\Automatic_Install_Skin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
+require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+require_once ABSPATH . 'wp-admin/includes/file.php';
+
+/**
+ * Install-or-replace a plugin via zip upload. Passes overwrite_package=true to
+ * Plugin_Upgrader so an existing plugin at the same slug is replaced in place,
+ * mirroring wp-admin's "Replace current with uploaded" confirmation flow.
+ *
+ * POST /sites/%s/plugins/replace
+ *
+ * ## Authentication trust model
+ *
+ * Two auth modes are supported:
+ *
+ * 1. User auth — the request is mapped to a WordPress user who must hold
+ *    `install_plugins` AND `update_plugins`. The ownership check verifies the
+ *    referenced attachment was authored by that same user, preventing the
+ *    endpoint from being used to touch another user's attachments.
+ *
+ * 2. Site-based auth (`allow_jetpack_site_auth => true`) — no user is
+ *    identified; capability and ownership checks are skipped. The wpcom
+ *    upload forwarder is expected to (a) vouch for the caller, (b) create the
+ *    attachment as part of the same request's upload-intercept pipeline, and
+ *    (c) pass the resulting ID through unchanged. If that contract is broken
+ *    on the wpcom side, any trusted site credential becomes install-anything
+ *    on the site.
+ *
+ * ## Known pre-existing behavior inherited from the parent
+ *
+ * `Jetpack_JSON_API_Plugins_New_Endpoint::validate_call` deletes the
+ * referenced attachment on capability-check failure without verifying the
+ * caller owns it. This Replace endpoint inherits that behavior. Fixing it
+ * belongs in the parent endpoint and is out of scope for this PR.
+ *
+ * @phan-constructor-used-for-side-effects
+ */
+class Jetpack_JSON_API_Plugins_Replace_Endpoint extends Jetpack_JSON_API_Plugins_New_Endpoint {
+	use Jetpack_JSON_API_Attachment_Ownership_Trait;
+
+	/**
+	 * Replace is destructive, so require both install and update caps.
+	 *
+	 * @var array
+	 */
+	protected $needed_capabilities = array( 'install_plugins', 'update_plugins' );
+
+	/**
+	 * Slug declared by the caller. Used by the upgrader_source_selection filter
+	 * to reject zips whose top-level folder doesn't match.
+	 *
+	 * @var string
+	 */
+	protected $expected_slug = '';
+
+	/**
+	 * Error codes we are willing to surface to the caller. Anything outside
+	 * this list is collapsed to 'install_failed' with a generic message to
+	 * avoid leaking filesystem paths from Plugin_Upgrader internals.
+	 *
+	 * Kept aligned with codes actually emitted by `WP_Upgrader` /
+	 * `Plugin_Upgrader` — $this->strings[] message keys are NOT error codes
+	 * and do not belong here.
+	 *
+	 * @var array
+	 */
+	protected static $allowed_error_codes = array(
+		'no_package',
+		'bad_request',
+		'files_not_writable',
+		'copy_dir_failed',
+		'remove_old_failed',
+		'source_read_failed',
+		'new_source_read_failed',
+		'mkdir_failed_destination',
+		'folder_exists',
+		'incompatible_archive',
+		'incompatible_archive_no_plugins',
+		'incompatible_archive_empty',
+		'incompatible_php_required_version',
+		'incompatible_wp_required_version',
+		'unable_to_connect_to_filesystem',
+		'fs_unavailable',
+		'fs_error',
+		'fs_no_plugins_dir',
+		'fs_no_folder',
+		'fs_no_root_dir',
+		'fs_no_content_dir',
+		'fs_no_temp_backup_dir',
+		'fs_temp_backup_mkdir',
+		'fs_temp_backup_move',
+		'slug_mismatch',
+	);
+
+	/**
+	 * Install, replacing any existing plugin at the same slug.
+	 *
+	 * @return bool|WP_Error
+	 */
+	public function install() {
+		$args = $this->input();
+
+		if ( ! isset( $args['zip'][0]['id'] ) || ! is_scalar( $args['zip'][0]['id'] ) ) {
+			return new WP_Error( 'no_plugin_installed', __( 'No plugin zip file was provided.', 'jetpack' ), 400 );
+		}
+
+		$expected_slug = isset( $args['slug'] ) && is_scalar( $args['slug'] )
+			? strtolower( (string) $args['slug'] )
+			: '';
+		if ( ! preg_match( '/^[a-z0-9][a-z0-9_-]*$/', $expected_slug ) ) {
+			return new WP_Error( 'missing_slug', __( 'A valid plugin slug is required; the replace endpoint refuses to overwrite a plugin whose slug the caller has not declared.', 'jetpack' ), 400 );
+		}
+
+		$plugin_attachment_id = (int) $args['zip'][0]['id'];
+
+		$ownership = $this->validate_attachment_ownership( $plugin_attachment_id );
+		if ( is_wp_error( $ownership ) ) {
+			return $ownership;
+		}
+
+		$zip_check = $this->validate_attachment_is_zip( $plugin_attachment_id );
+		if ( is_wp_error( $zip_check ) ) {
+			wp_delete_attachment( $plugin_attachment_id, true );
+			return $zip_check;
+		}
+
+		$local_file = get_attached_file( $plugin_attachment_id );
+		if ( ! $local_file ) {
+			wp_delete_attachment( $plugin_attachment_id, true );
+			return new WP_Error( 'local-file-does-not-exist', __( 'Uploaded plugin zip could not be found on disk.', 'jetpack' ), 400 );
+		}
+
+		$skin     = new Automatic_Install_Skin();
+		$upgrader = new Plugin_Upgrader( $skin );
+
+		$this->expected_slug = $expected_slug;
+		add_filter( 'upgrader_source_selection', array( $this, 'enforce_expected_slug' ), 9999, 4 );
+
+		$result = false;
+		try {
+			$result = $upgrader->install(
+				$local_file,
+				array( 'overwrite_package' => true )
+			);
+		} finally {
+			remove_filter( 'upgrader_source_selection', array( $this, 'enforce_expected_slug' ), 9999 );
+			$this->expected_slug = '';
+		}
+
+		wp_delete_attachment( $plugin_attachment_id, true );
+
+		if ( is_wp_error( $result ) ) {
+			return $this->sanitize_upgrader_error( $result );
+		}
+
+		if ( ! $result ) {
+			$error_code = $skin->get_main_error_code();
+			if ( 'download_failed' === $error_code ) {
+				$error_code = 'no_package';
+			}
+			if ( empty( $error_code ) || ! in_array( $error_code, self::$allowed_error_codes, true ) ) {
+				$error_code = 'install_failed';
+			}
+			return new WP_Error( $error_code, __( 'Plugin installation failed.', 'jetpack' ), 400 );
+		}
+
+		$plugin_file = $upgrader->plugin_info();
+		if ( empty( $plugin_file ) ) {
+			return new WP_Error( 'plugin_replace_info_missing', __( 'Plugin was installed but its identifier could not be determined.', 'jetpack' ), 500 );
+		}
+
+		$this->plugins             = array( $plugin_file );
+		$this->log[ $plugin_file ] = $upgrader->skin->get_upgrade_messages();
+
+		return true;
+	}
+
+	/**
+	 * Filter callback for `upgrader_source_selection`. Rejects a zip whose top-level
+	 * folder does not match the slug the caller declared in the request. This closes
+	 * the cross-slug overwrite gap: `overwrite_package=true` trusts the zip's own
+	 * folder name, so without this guard a caller with install+update caps could
+	 * overwrite any plugin by uploading a zip whose folder happens to match.
+	 *
+	 * @param string|WP_Error $source        Unpacked-zip source directory.
+	 * @param string          $remote_source Remote source path.
+	 * @param WP_Upgrader     $upgrader      Upgrader instance.
+	 * @param array           $hook_extra    Hook extra data.
+	 * @return string|WP_Error
+	 */
+	public function enforce_expected_slug( $source, $remote_source, $upgrader, $hook_extra ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( is_wp_error( $source ) ) {
+			return $source;
+		}
+		if ( '' === $this->expected_slug ) {
+			return $source;
+		}
+		$actual_slug = basename( untrailingslashit( (string) $source ) );
+
+		if ( ! preg_match( '/^[a-zA-Z0-9][a-zA-Z0-9_-]*$/', $actual_slug ) ) {
+			return new WP_Error(
+				'slug_mismatch',
+				__( 'The uploaded zip does not match the declared plugin slug.', 'jetpack' ),
+				400
+			);
+		}
+
+		if ( strtolower( $actual_slug ) !== $this->expected_slug ) {
+			return new WP_Error(
+				'slug_mismatch',
+				__( 'The uploaded zip does not match the declared plugin slug.', 'jetpack' ),
+				400
+			);
+		}
+		return $source;
+	}
+
+	/**
+	 * Collapse unknown error codes and strip potentially path-leaking messages
+	 * from WP_Error instances returned by Plugin_Upgrader.
+	 *
+	 * @param WP_Error $error Raw upgrader error.
+	 * @return WP_Error
+	 */
+	protected function sanitize_upgrader_error( WP_Error $error ) {
+		$code = $error->get_error_code();
+		if ( empty( $code ) || ! in_array( $code, self::$allowed_error_codes, true ) ) {
+			return new WP_Error( 'install_failed', __( 'Plugin installation failed.', 'jetpack' ), 400 );
+		}
+		return new WP_Error( $code, __( 'Plugin installation failed.', 'jetpack' ), 400 );
+	}
+}
+
+// POST /sites/%s/plugins/replace
+new Jetpack_JSON_API_Plugins_Replace_Endpoint(
+	array(
+		'description'             => 'Install or replace a plugin on a Jetpack site by uploading a zip file. If a plugin with the same slug is already installed, its destination folder is replaced in place, mirroring wp-admin\'s "Replace current with uploaded" upload flow.',
+		'group'                   => '__do_not_document',
+		'stat'                    => 'plugins:replace',
+		'min_version'             => '1',
+		'max_version'             => '1.1',
+		'method'                  => 'POST',
+		'path'                    => '/sites/%s/plugins/replace',
+		'path_labels'             => array(
+			'$site' => '(int|string) Site ID or domain',
+		),
+		'request_format'          => array(
+			'zip'  => '(array) Reference to an uploaded plugin package zip file.',
+			'slug' => '(string) The plugin slug the uploaded zip must resolve to. Required; the endpoint rejects zips whose top-level folder does not match.',
+		),
+		'response_format'         => Jetpack_JSON_API_Plugins_Endpoint::$_response_format,
+		'allow_jetpack_site_auth' => true,
+		'example_request_data'    => array(
+			'headers' => array(
+				'authorization' => 'Bearer YOUR_API_TOKEN',
+			),
+		),
+		'example_request'         => 'https://public-api.wordpress.com/rest/v1/sites/example.wordpress.org/plugins/replace',
+	)
+);
+
+new Jetpack_JSON_API_Plugins_Replace_Endpoint(
+	array(
+		'description'             => 'Install or replace a plugin on a Jetpack site by uploading a zip file. If a plugin with the same slug is already installed, its destination folder is replaced in place, mirroring wp-admin\'s "Replace current with uploaded" upload flow.',
+		'group'                   => '__do_not_document',
+		'stat'                    => 'plugins:replace',
+		'min_version'             => '1.2',
+		'method'                  => 'POST',
+		'path'                    => '/sites/%s/plugins/replace',
+		'path_labels'             => array(
+			'$site' => '(int|string) Site ID or domain',
+		),
+		'request_format'          => array(
+			'zip'  => '(array) Reference to an uploaded plugin package zip file.',
+			'slug' => '(string) The plugin slug the uploaded zip must resolve to. Required; the endpoint rejects zips whose top-level folder does not match.',
+		),
+		'response_format'         => Jetpack_JSON_API_Plugins_Endpoint::$_response_format_v1_2,
+		'allow_jetpack_site_auth' => true,
+		'example_request_data'    => array(
+			'headers' => array(
+				'authorization' => 'Bearer YOUR_API_TOKEN',
+			),
+		),
+		'example_request'         => 'https://public-api.wordpress.com/rest/v1.2/sites/example.wordpress.org/plugins/replace',
+	)
+);

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-themes-replace-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-themes-replace-endpoint.php
@@ -33,12 +33,15 @@ require_once ABSPATH . 'wp-admin/includes/file.php';
  *    on the wpcom side, any trusted site credential becomes install-anything
  *    on the site.
  *
- * ## Known pre-existing behavior inherited from the parent
+ * ## Cross-user attachment-deletion guard
  *
  * `Jetpack_JSON_API_Themes_New_Endpoint::validate_call` deletes the referenced
  * attachment on capability-check failure without verifying the caller owns it.
- * This Replace endpoint inherits that behavior. Fixing it belongs in the
- * parent endpoint and is out of scope for this PR.
+ * This Replace endpoint overrides `validate_call` to run the ownership check
+ * first, so a low-privilege caller cannot use it to hard-delete another user's
+ * attachment as a side-effect of the cap check failing. The parent's behavior
+ * is unchanged for the legitimate case (caller's own attachment is cleaned up
+ * when their cap check fails).
  *
  * @phan-constructor-used-for-side-effects
  */
@@ -51,14 +54,6 @@ class Jetpack_JSON_API_Themes_Replace_Endpoint extends Jetpack_JSON_API_Themes_N
 	 * @var array
 	 */
 	protected $needed_capabilities = array( 'install_themes', 'update_themes' );
-
-	/**
-	 * Slug declared by the caller. Used by the upgrader_source_selection filter
-	 * to reject zips whose top-level folder doesn't match.
-	 *
-	 * @var string
-	 */
-	protected $expected_slug = '';
 
 	/**
 	 * Error codes we are willing to surface to the caller. Anything outside
@@ -98,7 +93,6 @@ class Jetpack_JSON_API_Themes_Replace_Endpoint extends Jetpack_JSON_API_Themes_N
 		'fs_no_temp_backup_dir',
 		'fs_temp_backup_mkdir',
 		'fs_temp_backup_move',
-		'slug_mismatch',
 	);
 
 	/**
@@ -122,6 +116,9 @@ class Jetpack_JSON_API_Themes_Replace_Endpoint extends Jetpack_JSON_API_Themes_N
 
 		$attachment_id = (int) $args['zip'][0]['id'];
 
+		// Re-checked here so direct invocations of install() (notably the test stubs)
+		// can't accidentally bypass the ownership guard that validate_call() runs on
+		// the live request path.
 		$ownership = $this->validate_attachment_ownership( $attachment_id );
 		if ( is_wp_error( $ownership ) ) {
 			return $ownership;
@@ -142,19 +139,10 @@ class Jetpack_JSON_API_Themes_Replace_Endpoint extends Jetpack_JSON_API_Themes_N
 		$skin     = new Automatic_Install_Skin();
 		$upgrader = new Theme_Upgrader( $skin );
 
-		$this->expected_slug = $expected_slug;
-		add_filter( 'upgrader_source_selection', array( $this, 'enforce_expected_slug' ), 9999, 4 );
-
-		$result = false;
-		try {
-			$result = $upgrader->install(
-				$local_file,
-				array( 'overwrite_package' => true )
-			);
-		} finally {
-			remove_filter( 'upgrader_source_selection', array( $this, 'enforce_expected_slug' ), 9999 );
-			$this->expected_slug = '';
-		}
+		$result = $upgrader->install(
+			$local_file,
+			array( 'overwrite_package' => true )
+		);
 
 		wp_delete_attachment( $attachment_id, true );
 
@@ -179,6 +167,13 @@ class Jetpack_JSON_API_Themes_Replace_Endpoint extends Jetpack_JSON_API_Themes_N
 			return new WP_Error( 'theme_replace_info_missing', __( 'Theme was installed but its identifier could not be determined.', 'jetpack' ), 500 );
 		}
 
+		// `overwrite_package=true` trusts the zip's own folder name, so a zip whose
+		// top-level folder differs from the declared slug would clobber an unrelated
+		// theme. Verify the post-install identifier matches the caller's contract.
+		if ( strtolower( $theme_slug ) !== $expected_slug ) {
+			return new WP_Error( 'slug_mismatch', __( 'The installed theme does not match the declared slug.', 'jetpack' ), 400 );
+		}
+
 		$this->themes             = array( $theme_slug );
 		$this->log[ $theme_slug ] = $upgrader->skin->get_upgrade_messages();
 
@@ -186,43 +181,24 @@ class Jetpack_JSON_API_Themes_Replace_Endpoint extends Jetpack_JSON_API_Themes_N
 	}
 
 	/**
-	 * Filter callback for `upgrader_source_selection`. Rejects a zip whose top-level
-	 * folder does not match the slug the caller declared in the request. This closes
-	 * the cross-slug overwrite gap: `overwrite_package=true` trusts the zip's own
-	 * folder name, so without this guard a caller with install+update caps could
-	 * overwrite any theme by uploading a zip whose folder happens to match.
+	 * See class docblock — runs the attachment-ownership check before delegating
+	 * to the parent's validate_call(), which deletes the referenced attachment
+	 * on capability-check failure without verifying ownership.
 	 *
-	 * @param string|WP_Error $source        Unpacked-zip source directory.
-	 * @param string          $remote_source Remote source path.
-	 * @param WP_Upgrader     $upgrader      Upgrader instance.
-	 * @param array           $hook_extra    Hook extra data.
-	 * @return string|WP_Error
+	 * @param int    $_blog_id            Blog ID.
+	 * @param string $capability          Capability.
+	 * @param bool   $check_manage_active Whether to check manage-is-active.
+	 * @return bool|WP_Error
 	 */
-	public function enforce_expected_slug( $source, $remote_source, $upgrader, $hook_extra ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		if ( is_wp_error( $source ) ) {
-			return $source;
+	protected function validate_call( $_blog_id, $capability, $check_manage_active = true ) {
+		$args = $this->input();
+		if ( isset( $args['zip'][0]['id'] ) && is_scalar( $args['zip'][0]['id'] ) ) {
+			$ownership = $this->validate_attachment_ownership( (int) $args['zip'][0]['id'] );
+			if ( is_wp_error( $ownership ) ) {
+				return $ownership;
+			}
 		}
-		if ( '' === $this->expected_slug ) {
-			return $source;
-		}
-		$actual_slug = basename( untrailingslashit( (string) $source ) );
-
-		if ( ! preg_match( '/^[a-zA-Z0-9][a-zA-Z0-9_-]*$/', $actual_slug ) ) {
-			return new WP_Error(
-				'slug_mismatch',
-				__( 'The uploaded zip does not match the declared theme slug.', 'jetpack' ),
-				400
-			);
-		}
-
-		if ( strtolower( $actual_slug ) !== $this->expected_slug ) {
-			return new WP_Error(
-				'slug_mismatch',
-				__( 'The uploaded zip does not match the declared theme slug.', 'jetpack' ),
-				400
-			);
-		}
-		return $source;
+		return parent::validate_call( $_blog_id, $capability, $check_manage_active );
 	}
 
 	/**

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-themes-replace-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-themes-replace-endpoint.php
@@ -1,0 +1,268 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+use Automattic\Jetpack\Automatic_Install_Skin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
+require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+require_once ABSPATH . 'wp-admin/includes/file.php';
+
+/**
+ * Install-or-replace a theme via zip upload. Passes overwrite_package=true to
+ * Theme_Upgrader so an existing theme at the same slug is replaced in place,
+ * mirroring wp-admin's "Replace current with uploaded" confirmation flow.
+ *
+ * POST /sites/%s/themes/replace
+ *
+ * ## Authentication trust model
+ *
+ * Two auth modes are supported:
+ *
+ * 1. User auth — the request is mapped to a WordPress user who must hold
+ *    `install_themes` AND `update_themes`. The ownership check verifies the
+ *    referenced attachment was authored by that same user, preventing the
+ *    endpoint from being used to touch another user's attachments.
+ *
+ * 2. Site-based auth (`allow_jetpack_site_auth => true`) — no user is
+ *    identified; capability and ownership checks are skipped. The wpcom
+ *    upload forwarder is expected to (a) vouch for the caller, (b) create the
+ *    attachment as part of the same request's upload-intercept pipeline, and
+ *    (c) pass the resulting ID through unchanged. If that contract is broken
+ *    on the wpcom side, any trusted site credential becomes install-anything
+ *    on the site.
+ *
+ * ## Known pre-existing behavior inherited from the parent
+ *
+ * `Jetpack_JSON_API_Themes_New_Endpoint::validate_call` deletes the referenced
+ * attachment on capability-check failure without verifying the caller owns it.
+ * This Replace endpoint inherits that behavior. Fixing it belongs in the
+ * parent endpoint and is out of scope for this PR.
+ *
+ * @phan-constructor-used-for-side-effects
+ */
+class Jetpack_JSON_API_Themes_Replace_Endpoint extends Jetpack_JSON_API_Themes_New_Endpoint {
+	use Jetpack_JSON_API_Attachment_Ownership_Trait;
+
+	/**
+	 * Replace is destructive, so require both install and update caps.
+	 *
+	 * @var array
+	 */
+	protected $needed_capabilities = array( 'install_themes', 'update_themes' );
+
+	/**
+	 * Slug declared by the caller. Used by the upgrader_source_selection filter
+	 * to reject zips whose top-level folder doesn't match.
+	 *
+	 * @var string
+	 */
+	protected $expected_slug = '';
+
+	/**
+	 * Error codes we are willing to surface to the caller. Anything outside
+	 * this list is collapsed to 'install_failed' with a generic message to
+	 * avoid leaking filesystem paths from Theme_Upgrader internals.
+	 *
+	 * Kept aligned with codes actually emitted by `WP_Upgrader` /
+	 * `Theme_Upgrader` — $this->strings[] message keys are NOT error codes
+	 * and do not belong here.
+	 *
+	 * @var array
+	 */
+	protected static $allowed_error_codes = array(
+		'no_package',
+		'bad_request',
+		'files_not_writable',
+		'copy_dir_failed',
+		'remove_old_failed',
+		'source_read_failed',
+		'new_source_read_failed',
+		'mkdir_failed_destination',
+		'folder_exists',
+		'incompatible_archive',
+		'incompatible_archive_empty',
+		'incompatible_archive_theme_no_style',
+		'incompatible_archive_theme_no_name',
+		'incompatible_archive_theme_no_index',
+		'incompatible_php_required_version',
+		'incompatible_wp_required_version',
+		'unable_to_connect_to_filesystem',
+		'fs_unavailable',
+		'fs_error',
+		'fs_no_themes_dir',
+		'fs_no_folder',
+		'fs_no_root_dir',
+		'fs_no_content_dir',
+		'fs_no_temp_backup_dir',
+		'fs_temp_backup_mkdir',
+		'fs_temp_backup_move',
+		'slug_mismatch',
+	);
+
+	/**
+	 * Install, replacing any existing theme at the same slug.
+	 *
+	 * @return bool|WP_Error
+	 */
+	public function install() {
+		$args = $this->input();
+
+		if ( ! isset( $args['zip'][0]['id'] ) || ! is_scalar( $args['zip'][0]['id'] ) ) {
+			return new WP_Error( 'no_theme_installed', __( 'No theme zip file was provided.', 'jetpack' ), 400 );
+		}
+
+		$expected_slug = isset( $args['slug'] ) && is_scalar( $args['slug'] )
+			? strtolower( (string) $args['slug'] )
+			: '';
+		if ( ! preg_match( '/^[a-z0-9][a-z0-9_-]*$/', $expected_slug ) ) {
+			return new WP_Error( 'missing_slug', __( 'A valid theme slug is required; the replace endpoint refuses to overwrite a theme whose slug the caller has not declared.', 'jetpack' ), 400 );
+		}
+
+		$attachment_id = (int) $args['zip'][0]['id'];
+
+		$ownership = $this->validate_attachment_ownership( $attachment_id );
+		if ( is_wp_error( $ownership ) ) {
+			return $ownership;
+		}
+
+		$zip_check = $this->validate_attachment_is_zip( $attachment_id );
+		if ( is_wp_error( $zip_check ) ) {
+			wp_delete_attachment( $attachment_id, true );
+			return $zip_check;
+		}
+
+		$local_file = get_attached_file( $attachment_id );
+		if ( ! $local_file ) {
+			wp_delete_attachment( $attachment_id, true );
+			return new WP_Error( 'local-file-does-not-exist', __( 'Uploaded theme zip could not be found on disk.', 'jetpack' ), 400 );
+		}
+
+		$skin     = new Automatic_Install_Skin();
+		$upgrader = new Theme_Upgrader( $skin );
+
+		$this->expected_slug = $expected_slug;
+		add_filter( 'upgrader_source_selection', array( $this, 'enforce_expected_slug' ), 9999, 4 );
+
+		$result = false;
+		try {
+			$result = $upgrader->install(
+				$local_file,
+				array( 'overwrite_package' => true )
+			);
+		} finally {
+			remove_filter( 'upgrader_source_selection', array( $this, 'enforce_expected_slug' ), 9999 );
+			$this->expected_slug = '';
+		}
+
+		wp_delete_attachment( $attachment_id, true );
+
+		if ( is_wp_error( $result ) ) {
+			return $this->sanitize_upgrader_error( $result );
+		}
+
+		if ( ! $result ) {
+			$error_code = $skin->get_main_error_code();
+			if ( 'download_failed' === $error_code ) {
+				$error_code = 'no_package';
+			}
+			if ( empty( $error_code ) || ! in_array( $error_code, self::$allowed_error_codes, true ) ) {
+				$error_code = 'install_failed';
+			}
+			return new WP_Error( $error_code, __( 'Theme installation failed.', 'jetpack' ), 400 );
+		}
+
+		$theme_info = $upgrader->theme_info();
+		$theme_slug = $theme_info ? $theme_info->get_stylesheet() : '';
+		if ( empty( $theme_slug ) ) {
+			return new WP_Error( 'theme_replace_info_missing', __( 'Theme was installed but its identifier could not be determined.', 'jetpack' ), 500 );
+		}
+
+		$this->themes             = array( $theme_slug );
+		$this->log[ $theme_slug ] = $upgrader->skin->get_upgrade_messages();
+
+		return true;
+	}
+
+	/**
+	 * Filter callback for `upgrader_source_selection`. Rejects a zip whose top-level
+	 * folder does not match the slug the caller declared in the request. This closes
+	 * the cross-slug overwrite gap: `overwrite_package=true` trusts the zip's own
+	 * folder name, so without this guard a caller with install+update caps could
+	 * overwrite any theme by uploading a zip whose folder happens to match.
+	 *
+	 * @param string|WP_Error $source        Unpacked-zip source directory.
+	 * @param string          $remote_source Remote source path.
+	 * @param WP_Upgrader     $upgrader      Upgrader instance.
+	 * @param array           $hook_extra    Hook extra data.
+	 * @return string|WP_Error
+	 */
+	public function enforce_expected_slug( $source, $remote_source, $upgrader, $hook_extra ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( is_wp_error( $source ) ) {
+			return $source;
+		}
+		if ( '' === $this->expected_slug ) {
+			return $source;
+		}
+		$actual_slug = basename( untrailingslashit( (string) $source ) );
+
+		if ( ! preg_match( '/^[a-zA-Z0-9][a-zA-Z0-9_-]*$/', $actual_slug ) ) {
+			return new WP_Error(
+				'slug_mismatch',
+				__( 'The uploaded zip does not match the declared theme slug.', 'jetpack' ),
+				400
+			);
+		}
+
+		if ( strtolower( $actual_slug ) !== $this->expected_slug ) {
+			return new WP_Error(
+				'slug_mismatch',
+				__( 'The uploaded zip does not match the declared theme slug.', 'jetpack' ),
+				400
+			);
+		}
+		return $source;
+	}
+
+	/**
+	 * Collapse unknown error codes and strip potentially path-leaking messages
+	 * from WP_Error instances returned by Theme_Upgrader.
+	 *
+	 * @param WP_Error $error Raw upgrader error.
+	 * @return WP_Error
+	 */
+	protected function sanitize_upgrader_error( WP_Error $error ) {
+		$code = $error->get_error_code();
+		if ( empty( $code ) || ! in_array( $code, self::$allowed_error_codes, true ) ) {
+			return new WP_Error( 'install_failed', __( 'Theme installation failed.', 'jetpack' ), 400 );
+		}
+		return new WP_Error( $code, __( 'Theme installation failed.', 'jetpack' ), 400 );
+	}
+}
+
+// POST /sites/%s/themes/replace
+new Jetpack_JSON_API_Themes_Replace_Endpoint(
+	array(
+		'description'             => 'Install or replace a theme on a Jetpack site by uploading a zip file. If a theme with the same slug is already installed, its destination folder is replaced in place, mirroring wp-admin\'s "Replace current with uploaded" upload flow.',
+		'group'                   => '__do_not_document',
+		'stat'                    => 'themes:replace',
+		'method'                  => 'POST',
+		'path'                    => '/sites/%s/themes/replace',
+		'path_labels'             => array(
+			'$site' => '(int|string) Site ID or domain',
+		),
+		'request_format'          => array(
+			'zip'  => '(array) Reference to an uploaded theme package zip file.',
+			'slug' => '(string) The theme slug the uploaded zip must resolve to. Required; the endpoint rejects zips whose top-level folder does not match.',
+		),
+		'response_format'         => Jetpack_JSON_API_Themes_Endpoint::$_response_format,
+		'allow_jetpack_site_auth' => true,
+		'example_request_data'    => array(
+			'headers' => array(
+				'authorization' => 'Bearer YOUR_API_TOKEN',
+			),
+		),
+		'example_request'         => 'https://public-api.wordpress.com/rest/v1/sites/example.wordpress.org/themes/replace',
+	)
+);

--- a/projects/plugins/jetpack/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -88,8 +88,11 @@ new Jetpack_JSON_API_Themes_List_Endpoint(
 	)
 );
 
+require_once $json_jetpack_endpoints_dir . 'class-jetpack-json-api-attachment-ownership-trait.php';
+
 require_once $json_jetpack_endpoints_dir . 'class.jetpack-json-api-themes-get-endpoint.php';
 require_once $json_jetpack_endpoints_dir . 'class.jetpack-json-api-themes-new-endpoint.php';
+require_once $json_jetpack_endpoints_dir . 'class.jetpack-json-api-themes-replace-endpoint.php';
 
 // POST /sites/%s/themes/%new
 new Jetpack_JSON_API_Themes_New_Endpoint(
@@ -256,6 +259,7 @@ require_once $json_jetpack_endpoints_dir . 'class.jetpack-json-api-plugins-endpo
 require_once $json_jetpack_endpoints_dir . 'class.jetpack-json-api-plugins-get-endpoint.php';
 require_once $json_jetpack_endpoints_dir . 'class.jetpack-json-api-plugins-list-endpoint.php';
 require_once $json_jetpack_endpoints_dir . 'class.jetpack-json-api-plugins-new-endpoint.php';
+require_once $json_jetpack_endpoints_dir . 'class.jetpack-json-api-plugins-replace-endpoint.php';
 require_once $json_jetpack_endpoints_dir . 'class.jetpack-json-api-plugins-install-endpoint.php';
 require_once $json_jetpack_endpoints_dir . 'class.jetpack-json-api-plugins-delete-endpoint.php';
 require_once $json_jetpack_endpoints_dir . 'class.jetpack-json-api-plugins-modify-endpoint.php';

--- a/projects/plugins/jetpack/tests/php/json-api/Jetpack_Json_Api_Replace_Endpoints_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/Jetpack_Json_Api_Replace_Endpoints_Test.php
@@ -1,0 +1,837 @@
+<?php
+/**
+ * Tests for the plugins/replace and themes/replace JSON API endpoints.
+ *
+ * @package automattic/jetpack
+ *
+ * @phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
+ */
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+require_once JETPACK__PLUGIN_DIR . 'class.json-api.php';
+require_once JETPACK__PLUGIN_DIR . 'class.json-api-endpoints.php';
+
+/**
+ * Tests for the plugins/replace and themes/replace JSON API endpoints.
+ *
+ * @covers \Jetpack_JSON_API_Plugins_Replace_Endpoint
+ * @covers \Jetpack_JSON_API_Themes_Replace_Endpoint
+ */
+#[CoversClass( Jetpack_JSON_API_Plugins_Replace_Endpoint::class )]
+#[CoversClass( Jetpack_JSON_API_Themes_Replace_Endpoint::class )]
+class Jetpack_Json_Api_Replace_Endpoints_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	private static $user_id;
+	private static $other_user_id;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$user_id       = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$other_user_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	public function set_up() {
+		parent::set_up();
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_SERVER['HTTP_HOST']      = '127.0.0.1';
+		$_SERVER['REQUEST_URI']    = '/';
+		wp_set_current_user( self::$user_id );
+	}
+
+	/**
+	 * Build a minimal endpoint instance for direct method testing.
+	 *
+	 * @param string $class Endpoint class name.
+	 * @return object
+	 */
+	private function make_endpoint( $class ) {
+		return new $class(
+			array(
+				'description'    => '',
+				'group'          => '__do_not_document',
+				'stat'           => 'test',
+				'method'         => 'POST',
+				'path'           => '/sites/%s/plugins/replace',
+				'path_labels'    => array( '$site' => '(int|string) Site' ),
+				'request_format' => array( 'zip' => '(array)' ),
+			)
+		);
+	}
+
+	/**
+	 * Invoke the protected validate_attachment_ownership() method.
+	 *
+	 * @param object $endpoint      Endpoint instance.
+	 * @param int    $attachment_id Attachment ID to validate.
+	 * @return true|WP_Error
+	 */
+	private function invoke_ownership_check( $endpoint, $attachment_id ) {
+		$class  = new ReflectionClass( $endpoint );
+		$method = $class->getMethod( 'validate_attachment_ownership' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+		return $method->invoke( $endpoint, $attachment_id );
+	}
+
+	private function create_attachment( $author_id ) {
+		return self::factory()->attachment->create_object(
+			array(
+				'file'           => 'test-plugin.zip',
+				'post_parent'    => 0,
+				'post_mime_type' => 'application/zip',
+				'post_type'      => 'attachment',
+				'post_author'    => $author_id,
+			)
+		);
+	}
+
+	/**
+	 * Attachment post with no _wp_attached_file meta. Causes get_attached_file()
+	 * to return false.
+	 */
+	private function create_fileless_attachment( $author_id ) {
+		$attachment_id = $this->create_attachment( $author_id );
+		delete_post_meta( $attachment_id, '_wp_attached_file' );
+		return $attachment_id;
+	}
+
+	public function test_plugins_replace_endpoint_extends_new_endpoint() {
+		$this->assertTrue(
+			is_subclass_of(
+				Jetpack_JSON_API_Plugins_Replace_Endpoint::class,
+				Jetpack_JSON_API_Plugins_New_Endpoint::class
+			)
+		);
+	}
+
+	public function test_themes_replace_endpoint_extends_new_endpoint() {
+		$this->assertTrue(
+			is_subclass_of(
+				Jetpack_JSON_API_Themes_Replace_Endpoint::class,
+				Jetpack_JSON_API_Themes_New_Endpoint::class
+			)
+		);
+	}
+
+	public function test_plugins_replace_requires_install_and_update_caps() {
+		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Plugins_Replace_Endpoint::class );
+		$class    = new ReflectionClass( $endpoint );
+		$property = $class->getProperty( 'needed_capabilities' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$this->assertSame( array( 'install_plugins', 'update_plugins' ), $property->getValue( $endpoint ) );
+	}
+
+	public function test_themes_replace_requires_install_and_update_caps() {
+		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Themes_Replace_Endpoint::class );
+		$class    = new ReflectionClass( $endpoint );
+		$property = $class->getProperty( 'needed_capabilities' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$this->assertSame( array( 'install_themes', 'update_themes' ), $property->getValue( $endpoint ) );
+	}
+
+	public function test_plugins_ownership_check_rejects_missing_post() {
+		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Plugins_Replace_Endpoint::class );
+		$result   = $this->invoke_ownership_check( $endpoint, 99999999 );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_attachment', $result->get_error_code() );
+	}
+
+	public function test_plugins_ownership_check_rejects_non_attachment() {
+		$post_id  = self::factory()->post->create( array( 'post_author' => self::$user_id ) );
+		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Plugins_Replace_Endpoint::class );
+		$result   = $this->invoke_ownership_check( $endpoint, $post_id );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_attachment', $result->get_error_code() );
+	}
+
+	public function test_plugins_ownership_check_rejects_other_users_attachment() {
+		$attachment_id = $this->create_attachment( self::$other_user_id );
+		$endpoint      = $this->make_endpoint( Jetpack_JSON_API_Plugins_Replace_Endpoint::class );
+		$result        = $this->invoke_ownership_check( $endpoint, $attachment_id );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'attachment_not_owned', $result->get_error_code() );
+	}
+
+	public function test_plugins_ownership_check_accepts_owned_attachment() {
+		$attachment_id = $this->create_attachment( self::$user_id );
+		$endpoint      = $this->make_endpoint( Jetpack_JSON_API_Plugins_Replace_Endpoint::class );
+		$result        = $this->invoke_ownership_check( $endpoint, $attachment_id );
+		$this->assertTrue( $result );
+	}
+
+	public function test_themes_ownership_check_rejects_missing_post() {
+		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Themes_Replace_Endpoint::class );
+		$result   = $this->invoke_ownership_check( $endpoint, 99999999 );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_attachment', $result->get_error_code() );
+	}
+
+	public function test_themes_ownership_check_rejects_non_attachment() {
+		$post_id  = self::factory()->post->create( array( 'post_author' => self::$user_id ) );
+		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Themes_Replace_Endpoint::class );
+		$result   = $this->invoke_ownership_check( $endpoint, $post_id );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_attachment', $result->get_error_code() );
+	}
+
+	public function test_themes_ownership_check_rejects_other_users_attachment() {
+		$attachment_id = $this->create_attachment( self::$other_user_id );
+		$endpoint      = $this->make_endpoint( Jetpack_JSON_API_Themes_Replace_Endpoint::class );
+		$result        = $this->invoke_ownership_check( $endpoint, $attachment_id );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'attachment_not_owned', $result->get_error_code() );
+	}
+
+	public function test_themes_ownership_check_accepts_owned_attachment() {
+		$attachment_id = $this->create_attachment( self::$user_id );
+		$endpoint      = $this->make_endpoint( Jetpack_JSON_API_Themes_Replace_Endpoint::class );
+		$result        = $this->invoke_ownership_check( $endpoint, $attachment_id );
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * CHARACTERIZATION TEST — pins the current behavior, does NOT endorse it
+	 * as universally safe.
+	 *
+	 * When there is no current user (site-auth path) the ownership check is
+	 * skipped: a system-authored attachment (post_author=0) passes. This is
+	 * only safe because the wpcom upload forwarder is expected to vouch for
+	 * the caller and create the attachment as part of the same request. If
+	 * that wpcom-side contract ever breaks, skipping the check becomes
+	 * install-anything for any trusted site credential. See the class-level
+	 * docblock "Authentication trust model" section on both replace endpoints.
+	 */
+	public function test_ownership_check_passes_for_site_auth_with_system_attachment() {
+		wp_set_current_user( 0 );
+		$attachment_id = $this->create_attachment( 0 );
+
+		$plugins_endpoint = $this->make_endpoint( Jetpack_JSON_API_Plugins_Replace_Endpoint::class );
+		$this->assertTrue( $this->invoke_ownership_check( $plugins_endpoint, $attachment_id ) );
+
+		$themes_endpoint = $this->make_endpoint( Jetpack_JSON_API_Themes_Replace_Endpoint::class );
+		$this->assertTrue( $this->invoke_ownership_check( $themes_endpoint, $attachment_id ) );
+	}
+
+	/**
+	 * Asymmetry worth pinning down: a logged-in user plus a post_author=0
+	 * attachment currently fails the ownership check. If the wpcom forwarder
+	 * ever stamps post_author=0 while running under a mapped user, legitimate
+	 * user-auth calls would get blocked here.
+	 */
+	public function test_ownership_check_rejects_system_attachment_for_logged_in_user() {
+		$attachment_id = $this->create_attachment( 0 );
+		$endpoint      = $this->make_endpoint( Jetpack_JSON_API_Plugins_Replace_Endpoint::class );
+		$result        = $this->invoke_ownership_check( $endpoint, $attachment_id );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'attachment_not_owned', $result->get_error_code() );
+	}
+
+	public function test_plugins_install_deletes_attachment_when_file_missing() {
+		$attachment_id = $this->create_fileless_attachment( self::$user_id );
+		$endpoint      = new Jetpack_JSON_API_Plugins_Replace_Endpoint_Test_Stub(
+			$this->endpoint_args(),
+			array(
+				'zip'  => array( array( 'id' => $attachment_id ) ),
+				'slug' => 'test-slug',
+			)
+		);
+
+		$result = $endpoint->install();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'local-file-does-not-exist', $result->get_error_code() );
+		$this->assertNull( get_post( $attachment_id ), 'Attachment should have been deleted on missing-file path.' );
+	}
+
+	public function test_themes_install_deletes_attachment_when_file_missing() {
+		$attachment_id = $this->create_fileless_attachment( self::$user_id );
+		$endpoint      = new Jetpack_JSON_API_Themes_Replace_Endpoint_Test_Stub(
+			$this->endpoint_args(),
+			array(
+				'zip'  => array( array( 'id' => $attachment_id ) ),
+				'slug' => 'test-slug',
+			)
+		);
+
+		$result = $endpoint->install();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'local-file-does-not-exist', $result->get_error_code() );
+		$this->assertNull( get_post( $attachment_id ), 'Attachment should have been deleted on missing-file path.' );
+	}
+
+	public function test_plugins_install_preserves_attachment_when_ownership_fails() {
+		$attachment_id = $this->create_attachment( self::$other_user_id );
+		$endpoint      = new Jetpack_JSON_API_Plugins_Replace_Endpoint_Test_Stub(
+			$this->endpoint_args(),
+			array(
+				'zip'  => array( array( 'id' => $attachment_id ) ),
+				'slug' => 'test-slug',
+			)
+		);
+
+		$result = $endpoint->install();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'attachment_not_owned', $result->get_error_code() );
+		$this->assertNotNull( get_post( $attachment_id ), 'Attachment must survive an ownership failure.' );
+	}
+
+	public function test_themes_install_preserves_attachment_when_ownership_fails() {
+		$attachment_id = $this->create_attachment( self::$other_user_id );
+		$endpoint      = new Jetpack_JSON_API_Themes_Replace_Endpoint_Test_Stub(
+			$this->endpoint_args(),
+			array(
+				'zip'  => array( array( 'id' => $attachment_id ) ),
+				'slug' => 'test-slug',
+			)
+		);
+
+		$result = $endpoint->install();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'attachment_not_owned', $result->get_error_code() );
+		$this->assertNotNull( get_post( $attachment_id ), 'Attachment must survive an ownership failure.' );
+	}
+
+	public function test_plugins_install_rejects_missing_zip_param() {
+		$endpoint = new Jetpack_JSON_API_Plugins_Replace_Endpoint_Test_Stub(
+			$this->endpoint_args(),
+			array()
+		);
+
+		$result = $endpoint->install();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'no_plugin_installed', $result->get_error_code() );
+	}
+
+	public function test_themes_install_rejects_missing_zip_param() {
+		$endpoint = new Jetpack_JSON_API_Themes_Replace_Endpoint_Test_Stub(
+			$this->endpoint_args(),
+			array()
+		);
+
+		$result = $endpoint->install();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'no_theme_installed', $result->get_error_code() );
+	}
+
+	public function test_plugins_install_rejects_non_scalar_id() {
+		$endpoint = new Jetpack_JSON_API_Plugins_Replace_Endpoint_Test_Stub(
+			$this->endpoint_args(),
+			array(
+				'zip'  => array( array( 'id' => array( 'nested' => 'oops' ) ) ),
+				'slug' => 'test-slug',
+			)
+		);
+
+		$result = $endpoint->install();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'no_plugin_installed', $result->get_error_code() );
+	}
+
+	public function test_themes_install_rejects_non_scalar_id() {
+		$endpoint = new Jetpack_JSON_API_Themes_Replace_Endpoint_Test_Stub(
+			$this->endpoint_args(),
+			array(
+				'zip'  => array( array( 'id' => array( 'nested' => 'oops' ) ) ),
+				'slug' => 'test-slug',
+			)
+		);
+
+		$result = $endpoint->install();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'no_theme_installed', $result->get_error_code() );
+	}
+
+	public function test_plugins_install_rejects_missing_slug() {
+		$attachment_id = $this->create_attachment( self::$user_id );
+		$endpoint      = new Jetpack_JSON_API_Plugins_Replace_Endpoint_Test_Stub(
+			$this->endpoint_args(),
+			array( 'zip' => array( array( 'id' => $attachment_id ) ) )
+		);
+
+		$result = $endpoint->install();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'missing_slug', $result->get_error_code() );
+		$this->assertNotNull( get_post( $attachment_id ), 'Attachment must survive a missing-slug rejection.' );
+	}
+
+	public function test_themes_install_rejects_missing_slug() {
+		$attachment_id = $this->create_attachment( self::$user_id );
+		$endpoint      = new Jetpack_JSON_API_Themes_Replace_Endpoint_Test_Stub(
+			$this->endpoint_args(),
+			array( 'zip' => array( array( 'id' => $attachment_id ) ) )
+		);
+
+		$result = $endpoint->install();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'missing_slug', $result->get_error_code() );
+	}
+
+	public function test_plugins_install_rejects_non_zip_mime() {
+		$attachment_id = self::factory()->attachment->create_object(
+			array(
+				'file'           => 'evil.jpg',
+				'post_parent'    => 0,
+				'post_mime_type' => 'image/jpeg',
+				'post_type'      => 'attachment',
+				'post_author'    => self::$user_id,
+			)
+		);
+		$endpoint      = new Jetpack_JSON_API_Plugins_Replace_Endpoint_Test_Stub(
+			$this->endpoint_args(),
+			array(
+				'zip'  => array( array( 'id' => $attachment_id ) ),
+				'slug' => 'test-slug',
+			)
+		);
+
+		$result = $endpoint->install();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_attachment_mime', $result->get_error_code() );
+		$this->assertNull( get_post( $attachment_id ), 'Non-zip attachment should be cleaned up.' );
+	}
+
+	public function test_themes_install_rejects_non_zip_mime() {
+		$attachment_id = self::factory()->attachment->create_object(
+			array(
+				'file'           => 'evil.jpg',
+				'post_parent'    => 0,
+				'post_mime_type' => 'image/jpeg',
+				'post_type'      => 'attachment',
+				'post_author'    => self::$user_id,
+			)
+		);
+		$endpoint      = new Jetpack_JSON_API_Themes_Replace_Endpoint_Test_Stub(
+			$this->endpoint_args(),
+			array(
+				'zip'  => array( array( 'id' => $attachment_id ) ),
+				'slug' => 'test-slug',
+			)
+		);
+
+		$result = $endpoint->install();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_attachment_mime', $result->get_error_code() );
+	}
+
+	public function test_plugins_install_rejects_non_zip_extension() {
+		$attachment_id = self::factory()->attachment->create_object(
+			array(
+				'file'           => 'evil.jpg.txt',
+				'post_parent'    => 0,
+				'post_mime_type' => 'application/zip',
+				'post_type'      => 'attachment',
+				'post_author'    => self::$user_id,
+			)
+		);
+		$endpoint      = new Jetpack_JSON_API_Plugins_Replace_Endpoint_Test_Stub(
+			$this->endpoint_args(),
+			array(
+				'zip'  => array( array( 'id' => $attachment_id ) ),
+				'slug' => 'test-slug',
+			)
+		);
+
+		$result = $endpoint->install();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_attachment_extension', $result->get_error_code() );
+		$this->assertNull( get_post( $attachment_id ), 'Non-.zip attachment should be cleaned up.' );
+	}
+
+	public function test_themes_install_rejects_non_zip_extension() {
+		$attachment_id = self::factory()->attachment->create_object(
+			array(
+				'file'           => 'evil.jpg.txt',
+				'post_parent'    => 0,
+				'post_mime_type' => 'application/zip',
+				'post_type'      => 'attachment',
+				'post_author'    => self::$user_id,
+			)
+		);
+		$endpoint      = new Jetpack_JSON_API_Themes_Replace_Endpoint_Test_Stub(
+			$this->endpoint_args(),
+			array(
+				'zip'  => array( array( 'id' => $attachment_id ) ),
+				'slug' => 'test-slug',
+			)
+		);
+
+		$result = $endpoint->install();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_attachment_extension', $result->get_error_code() );
+		$this->assertNull( get_post( $attachment_id ), 'Non-.zip attachment should be cleaned up.' );
+	}
+
+	public function test_plugins_enforce_expected_slug_rejects_mismatch() {
+		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Plugins_Replace_Endpoint::class );
+		$this->set_expected_slug( $endpoint, 'akismet' );
+		$result = $endpoint->enforce_expected_slug( '/tmp/unpack/hello-dolly', '', null, array() );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'slug_mismatch', $result->get_error_code() );
+	}
+
+	public function test_plugins_enforce_expected_slug_accepts_match() {
+		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Plugins_Replace_Endpoint::class );
+		$this->set_expected_slug( $endpoint, 'akismet' );
+		$result = $endpoint->enforce_expected_slug( '/tmp/unpack/akismet', '', null, array() );
+		$this->assertSame( '/tmp/unpack/akismet', $result );
+	}
+
+	public function test_plugins_enforce_expected_slug_passes_wp_error_through() {
+		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Plugins_Replace_Endpoint::class );
+		$this->set_expected_slug( $endpoint, 'akismet' );
+		$pre_error = new WP_Error( 'upstream_error', 'Upstream error' );
+		$result    = $endpoint->enforce_expected_slug( $pre_error, '', null, array() );
+		$this->assertSame( $pre_error, $result );
+	}
+
+	public function test_themes_enforce_expected_slug_rejects_mismatch() {
+		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Themes_Replace_Endpoint::class );
+		$this->set_expected_slug( $endpoint, 'twentytwentyfour' );
+		$result = $endpoint->enforce_expected_slug( '/tmp/unpack/twentytwentythree', '', null, array() );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'slug_mismatch', $result->get_error_code() );
+	}
+
+	public function test_themes_enforce_expected_slug_accepts_match() {
+		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Themes_Replace_Endpoint::class );
+		$this->set_expected_slug( $endpoint, 'twentytwentyfour' );
+		$result = $endpoint->enforce_expected_slug( '/tmp/unpack/twentytwentyfour', '', null, array() );
+		$this->assertSame( '/tmp/unpack/twentytwentyfour', $result );
+	}
+
+	public function test_themes_enforce_expected_slug_passes_wp_error_through() {
+		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Themes_Replace_Endpoint::class );
+		$this->set_expected_slug( $endpoint, 'twentytwentyfour' );
+		$pre_error = new WP_Error( 'upstream_error', 'Upstream error' );
+		$result    = $endpoint->enforce_expected_slug( $pre_error, '', null, array() );
+		$this->assertSame( $pre_error, $result );
+	}
+
+	/**
+	 * With no declared slug, the filter is a no-op — the install() guard
+	 * rejects empty slugs earlier, so this branch is only reachable via
+	 * reflection, but it's worth pinning so a future refactor can't silently
+	 * drop the early return.
+	 */
+	public function test_plugins_enforce_expected_slug_passes_through_when_unset() {
+		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Plugins_Replace_Endpoint::class );
+		$result   = $endpoint->enforce_expected_slug( '/tmp/unpack/anything-goes', '', null, array() );
+		$this->assertSame( '/tmp/unpack/anything-goes', $result );
+	}
+
+	public function test_themes_enforce_expected_slug_passes_through_when_unset() {
+		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Themes_Replace_Endpoint::class );
+		$result   = $endpoint->enforce_expected_slug( '/tmp/unpack/anything-goes', '', null, array() );
+		$this->assertSame( '/tmp/unpack/anything-goes', $result );
+	}
+
+	public function test_plugins_sanitize_upgrader_error_collapses_unknown_codes() {
+		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Plugins_Replace_Endpoint::class );
+		$class    = new ReflectionClass( $endpoint );
+		$method   = $class->getMethod( 'sanitize_upgrader_error' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$leaky  = new WP_Error( 'mysterious_failure', 'Internal path /var/www/html/wp-content/plugins leaked' );
+		$result = $method->invoke( $endpoint, $leaky );
+
+		$this->assertSame( 'install_failed', $result->get_error_code() );
+		$this->assertStringNotContainsString( '/var/www', $result->get_error_message() );
+	}
+
+	public function test_plugins_sanitize_upgrader_error_preserves_known_codes() {
+		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Plugins_Replace_Endpoint::class );
+		$class    = new ReflectionClass( $endpoint );
+		$method   = $class->getMethod( 'sanitize_upgrader_error' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$known  = new WP_Error( 'incompatible_archive', 'path leak /tmp/x' );
+		$result = $method->invoke( $endpoint, $known );
+
+		$this->assertSame( 'incompatible_archive', $result->get_error_code() );
+		$this->assertStringNotContainsString( '/tmp/x', $result->get_error_message() );
+	}
+
+	/**
+	 * Version-compatibility codes are user-actionable and MUST surface.
+	 */
+	public function test_plugins_sanitize_upgrader_error_preserves_version_codes() {
+		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Plugins_Replace_Endpoint::class );
+		$class    = new ReflectionClass( $endpoint );
+		$method   = $class->getMethod( 'sanitize_upgrader_error' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		foreach ( array( 'incompatible_php_required_version', 'incompatible_wp_required_version' ) as $code ) {
+			$result = $method->invoke( $endpoint, new WP_Error( $code, 'whatever' ) );
+			$this->assertSame( $code, $result->get_error_code(), "Code $code must be preserved." );
+		}
+	}
+
+	public function test_themes_sanitize_upgrader_error_collapses_unknown_codes() {
+		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Themes_Replace_Endpoint::class );
+		$class    = new ReflectionClass( $endpoint );
+		$method   = $class->getMethod( 'sanitize_upgrader_error' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$leaky  = new WP_Error( 'mysterious_failure', 'Internal path /var/www/html/wp-content/themes leaked' );
+		$result = $method->invoke( $endpoint, $leaky );
+
+		$this->assertSame( 'install_failed', $result->get_error_code() );
+		$this->assertStringNotContainsString( '/var/www', $result->get_error_message() );
+	}
+
+	public function test_themes_sanitize_upgrader_error_preserves_known_codes() {
+		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Themes_Replace_Endpoint::class );
+		$class    = new ReflectionClass( $endpoint );
+		$method   = $class->getMethod( 'sanitize_upgrader_error' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$known  = new WP_Error( 'incompatible_archive_theme_no_style', 'path leak /tmp/x' );
+		$result = $method->invoke( $endpoint, $known );
+
+		$this->assertSame( 'incompatible_archive_theme_no_style', $result->get_error_code() );
+		$this->assertStringNotContainsString( '/tmp/x', $result->get_error_message() );
+	}
+
+	public function test_plugins_sanitize_upgrader_error_collapses_empty_code() {
+		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Plugins_Replace_Endpoint::class );
+		$class    = new ReflectionClass( $endpoint );
+		$method   = $class->getMethod( 'sanitize_upgrader_error' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$result = $method->invoke( $endpoint, new WP_Error() );
+
+		$this->assertSame( 'install_failed', $result->get_error_code() );
+	}
+
+	public function test_themes_sanitize_upgrader_error_collapses_empty_code() {
+		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Themes_Replace_Endpoint::class );
+		$class    = new ReflectionClass( $endpoint );
+		$method   = $class->getMethod( 'sanitize_upgrader_error' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$result = $method->invoke( $endpoint, new WP_Error() );
+
+		$this->assertSame( 'install_failed', $result->get_error_code() );
+	}
+
+	/**
+	 * @dataProvider provide_invalid_slugs
+	 */
+	#[DataProvider( 'provide_invalid_slugs' )]
+	public function test_plugins_install_rejects_invalid_slug( $invalid_slug ) {
+		$attachment_id = $this->create_attachment( self::$user_id );
+		$endpoint      = new Jetpack_JSON_API_Plugins_Replace_Endpoint_Test_Stub(
+			$this->endpoint_args(),
+			array(
+				'zip'  => array( array( 'id' => $attachment_id ) ),
+				'slug' => $invalid_slug,
+			)
+		);
+
+		$result = $endpoint->install();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'missing_slug', $result->get_error_code() );
+	}
+
+	public static function provide_invalid_slugs() {
+		return array(
+			'empty string'       => array( '' ),
+			'single dot'         => array( '.' ),
+			'double dot'         => array( '..' ),
+			'leading dot'        => array( '.hidden' ),
+			'double dot middle'  => array( 'foo..bar' ),
+			'slash'              => array( '..//..' ),
+			'whitespace only'    => array( '   ' ),
+			'leading hyphen'     => array( '-akismet' ),
+			'leading underscore' => array( '_akismet' ),
+			'path traversal'     => array( '../../etc/passwd' ),
+			'non-ascii'          => array( 'akîsmet' ),
+			'non-scalar'         => array( array( 'nested' ) ),
+		);
+	}
+
+	public function test_enforce_expected_slug_is_case_insensitive() {
+		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Plugins_Replace_Endpoint::class );
+		$this->set_expected_slug( $endpoint, 'akismet' );
+		$result = $endpoint->enforce_expected_slug( '/tmp/unpack/Akismet', '', null, array() );
+		$this->assertSame( '/tmp/unpack/Akismet', $result );
+	}
+
+	public function test_enforce_expected_slug_rejects_non_ascii_source() {
+		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Plugins_Replace_Endpoint::class );
+		$this->set_expected_slug( $endpoint, 'akismet' );
+		$result = $endpoint->enforce_expected_slug( '/tmp/unpack/akîsmet', '', null, array() );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'slug_mismatch', $result->get_error_code() );
+	}
+
+	public function test_enforce_expected_slug_rejects_dotted_source() {
+		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Plugins_Replace_Endpoint::class );
+		$this->set_expected_slug( $endpoint, 'akismet' );
+		$result = $endpoint->enforce_expected_slug( '/tmp/unpack/..', '', null, array() );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'slug_mismatch', $result->get_error_code() );
+	}
+
+	public function test_enforce_expected_slug_rejects_whitespace_source() {
+		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Plugins_Replace_Endpoint::class );
+		$this->set_expected_slug( $endpoint, 'akismet' );
+		$result = $endpoint->enforce_expected_slug( '/tmp/unpack/akismet ', '', null, array() );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'slug_mismatch', $result->get_error_code() );
+	}
+
+	public function test_themes_enforce_expected_slug_is_case_insensitive() {
+		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Themes_Replace_Endpoint::class );
+		$this->set_expected_slug( $endpoint, 'twentytwentyfour' );
+		$result = $endpoint->enforce_expected_slug( '/tmp/unpack/TwentyTwentyFour', '', null, array() );
+		$this->assertSame( '/tmp/unpack/TwentyTwentyFour', $result );
+	}
+
+	public function test_themes_enforce_expected_slug_rejects_non_ascii_source() {
+		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Themes_Replace_Endpoint::class );
+		$this->set_expected_slug( $endpoint, 'twentytwentyfour' );
+		$result = $endpoint->enforce_expected_slug( '/tmp/unpack/twêntytwentyfour', '', null, array() );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'slug_mismatch', $result->get_error_code() );
+	}
+
+	public function test_themes_enforce_expected_slug_rejects_dotted_source() {
+		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Themes_Replace_Endpoint::class );
+		$this->set_expected_slug( $endpoint, 'twentytwentyfour' );
+		$result = $endpoint->enforce_expected_slug( '/tmp/unpack/..', '', null, array() );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'slug_mismatch', $result->get_error_code() );
+	}
+
+	public function test_themes_enforce_expected_slug_rejects_whitespace_source() {
+		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Themes_Replace_Endpoint::class );
+		$this->set_expected_slug( $endpoint, 'twentytwentyfour' );
+		$result = $endpoint->enforce_expected_slug( '/tmp/unpack/twentytwentyfour ', '', null, array() );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'slug_mismatch', $result->get_error_code() );
+	}
+
+	/**
+	 * @dataProvider provide_invalid_slugs
+	 */
+	#[DataProvider( 'provide_invalid_slugs' )]
+	public function test_themes_install_rejects_invalid_slug( $invalid_slug ) {
+		$attachment_id = $this->create_attachment( self::$user_id );
+		$endpoint      = new Jetpack_JSON_API_Themes_Replace_Endpoint_Test_Stub(
+			$this->endpoint_args(),
+			array(
+				'zip'  => array( array( 'id' => $attachment_id ) ),
+				'slug' => $invalid_slug,
+			)
+		);
+
+		$result = $endpoint->install();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'missing_slug', $result->get_error_code() );
+	}
+
+	/**
+	 * Set the protected expected_slug property via reflection.
+	 *
+	 * @param object $endpoint
+	 * @param string $slug
+	 */
+	private function set_expected_slug( $endpoint, $slug ) {
+		$class    = new ReflectionClass( $endpoint );
+		$property = $class->getProperty( 'expected_slug' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$property->setValue( $endpoint, $slug );
+	}
+
+	/**
+	 * Shared registration args for stub-driven install() tests.
+	 *
+	 * @return array
+	 */
+	private function endpoint_args() {
+		return array(
+			'description'    => '',
+			'group'          => '__do_not_document',
+			'stat'           => 'test',
+			'method'         => 'POST',
+			'path'           => '/sites/%s/plugins/replace',
+			'path_labels'    => array( '$site' => '(int|string) Site' ),
+			'request_format' => array( 'zip' => '(array)' ),
+		);
+	}
+}
+
+/**
+ * Test stub that stubs input() to return a fixed payload, avoiding the need to
+ * bootstrap a full API request. Used for exercising install()'s early-return
+ * paths in isolation.
+ *
+ * @phan-constructor-used-for-side-effects
+ */
+class Jetpack_JSON_API_Plugins_Replace_Endpoint_Test_Stub extends Jetpack_JSON_API_Plugins_Replace_Endpoint {
+	private $stub_input;
+
+	public function __construct( $args, $input ) {
+		parent::__construct( $args );
+		$this->stub_input = $input;
+	}
+
+	public function input( $return_default_values = true, $cast_and_filter = true ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		return $this->stub_input;
+	}
+}
+
+/**
+ * @phan-constructor-used-for-side-effects
+ */
+class Jetpack_JSON_API_Themes_Replace_Endpoint_Test_Stub extends Jetpack_JSON_API_Themes_Replace_Endpoint {
+	private $stub_input;
+
+	public function __construct( $args, $input ) {
+		parent::__construct( $args );
+		$this->stub_input = $input;
+	}
+
+	public function input( $return_default_values = true, $cast_and_filter = true ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		return $this->stub_input;
+	}
+}

--- a/projects/plugins/jetpack/tests/php/json-api/Jetpack_Json_Api_Replace_Endpoints_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/Jetpack_Json_Api_Replace_Endpoints_Test.php
@@ -76,6 +76,24 @@ class Jetpack_Json_Api_Replace_Endpoints_Test extends WP_UnitTestCase {
 		return $method->invoke( $endpoint, $attachment_id );
 	}
 
+	/**
+	 * Invoke the protected validate_call() method. Used to exercise the
+	 * cross-user attachment-deletion guard without bootstrapping the full API
+	 * dispatcher.
+	 *
+	 * @param object $endpoint     Endpoint instance.
+	 * @param array  $capabilities Capability list to pass to validate_call.
+	 * @return bool|WP_Error
+	 */
+	private function invoke_validate_call( $endpoint, $capabilities ) {
+		$class  = new ReflectionClass( $endpoint );
+		$method = $class->getMethod( 'validate_call' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+		return $method->invoke( $endpoint, 0, $capabilities, true );
+	}
+
 	private function create_attachment( $author_id ) {
 		return self::factory()->attachment->create_object(
 			array(
@@ -301,6 +319,53 @@ class Jetpack_Json_Api_Replace_Endpoints_Test extends WP_UnitTestCase {
 		$this->assertNotNull( get_post( $attachment_id ), 'Attachment must survive an ownership failure.' );
 	}
 
+	/**
+	 * The cross-user attachment-deletion guard. The parent endpoint's validate_call
+	 * deletes the attachment on cap-check failure without ownership verification;
+	 * the trait's validate_call must short-circuit on ownership failure BEFORE
+	 * parent::validate_call runs, so another user's attachment is never deleted as
+	 * a side effect of a cap check failing.
+	 */
+	public function test_plugins_validate_call_rejects_other_users_attachment_without_deleting_it() {
+		$attachment_id = $this->create_attachment( self::$other_user_id );
+		$endpoint      = new Jetpack_JSON_API_Plugins_Replace_Endpoint_Test_Stub(
+			$this->endpoint_args(),
+			array( 'zip' => array( array( 'id' => $attachment_id ) ) )
+		);
+
+		$result = $this->invoke_validate_call( $endpoint, array( 'install_plugins', 'update_plugins' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'attachment_not_owned', $result->get_error_code() );
+		$this->assertNotNull( get_post( $attachment_id ), 'Cross-user attachment must not be deleted on validate_call rejection.' );
+	}
+
+	public function test_themes_validate_call_rejects_other_users_attachment_without_deleting_it() {
+		$attachment_id = $this->create_attachment( self::$other_user_id );
+		$endpoint      = new Jetpack_JSON_API_Themes_Replace_Endpoint_Test_Stub(
+			$this->endpoint_args(),
+			array( 'zip' => array( array( 'id' => $attachment_id ) ) )
+		);
+
+		$result = $this->invoke_validate_call( $endpoint, array( 'install_themes', 'update_themes' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'attachment_not_owned', $result->get_error_code() );
+		$this->assertNotNull( get_post( $attachment_id ), 'Cross-user attachment must not be deleted on validate_call rejection.' );
+	}
+
+	public function test_plugins_validate_call_rejects_invalid_attachment_id() {
+		$endpoint = new Jetpack_JSON_API_Plugins_Replace_Endpoint_Test_Stub(
+			$this->endpoint_args(),
+			array( 'zip' => array( array( 'id' => 99999999 ) ) )
+		);
+
+		$result = $this->invoke_validate_call( $endpoint, array( 'install_plugins', 'update_plugins' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_attachment', $result->get_error_code() );
+	}
+
 	public function test_plugins_install_rejects_missing_zip_param() {
 		$endpoint = new Jetpack_JSON_API_Plugins_Replace_Endpoint_Test_Stub(
 			$this->endpoint_args(),
@@ -481,70 +546,6 @@ class Jetpack_Json_Api_Replace_Endpoints_Test extends WP_UnitTestCase {
 		$this->assertNull( get_post( $attachment_id ), 'Non-.zip attachment should be cleaned up.' );
 	}
 
-	public function test_plugins_enforce_expected_slug_rejects_mismatch() {
-		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Plugins_Replace_Endpoint::class );
-		$this->set_expected_slug( $endpoint, 'akismet' );
-		$result = $endpoint->enforce_expected_slug( '/tmp/unpack/hello-dolly', '', null, array() );
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'slug_mismatch', $result->get_error_code() );
-	}
-
-	public function test_plugins_enforce_expected_slug_accepts_match() {
-		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Plugins_Replace_Endpoint::class );
-		$this->set_expected_slug( $endpoint, 'akismet' );
-		$result = $endpoint->enforce_expected_slug( '/tmp/unpack/akismet', '', null, array() );
-		$this->assertSame( '/tmp/unpack/akismet', $result );
-	}
-
-	public function test_plugins_enforce_expected_slug_passes_wp_error_through() {
-		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Plugins_Replace_Endpoint::class );
-		$this->set_expected_slug( $endpoint, 'akismet' );
-		$pre_error = new WP_Error( 'upstream_error', 'Upstream error' );
-		$result    = $endpoint->enforce_expected_slug( $pre_error, '', null, array() );
-		$this->assertSame( $pre_error, $result );
-	}
-
-	public function test_themes_enforce_expected_slug_rejects_mismatch() {
-		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Themes_Replace_Endpoint::class );
-		$this->set_expected_slug( $endpoint, 'twentytwentyfour' );
-		$result = $endpoint->enforce_expected_slug( '/tmp/unpack/twentytwentythree', '', null, array() );
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'slug_mismatch', $result->get_error_code() );
-	}
-
-	public function test_themes_enforce_expected_slug_accepts_match() {
-		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Themes_Replace_Endpoint::class );
-		$this->set_expected_slug( $endpoint, 'twentytwentyfour' );
-		$result = $endpoint->enforce_expected_slug( '/tmp/unpack/twentytwentyfour', '', null, array() );
-		$this->assertSame( '/tmp/unpack/twentytwentyfour', $result );
-	}
-
-	public function test_themes_enforce_expected_slug_passes_wp_error_through() {
-		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Themes_Replace_Endpoint::class );
-		$this->set_expected_slug( $endpoint, 'twentytwentyfour' );
-		$pre_error = new WP_Error( 'upstream_error', 'Upstream error' );
-		$result    = $endpoint->enforce_expected_slug( $pre_error, '', null, array() );
-		$this->assertSame( $pre_error, $result );
-	}
-
-	/**
-	 * With no declared slug, the filter is a no-op — the install() guard
-	 * rejects empty slugs earlier, so this branch is only reachable via
-	 * reflection, but it's worth pinning so a future refactor can't silently
-	 * drop the early return.
-	 */
-	public function test_plugins_enforce_expected_slug_passes_through_when_unset() {
-		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Plugins_Replace_Endpoint::class );
-		$result   = $endpoint->enforce_expected_slug( '/tmp/unpack/anything-goes', '', null, array() );
-		$this->assertSame( '/tmp/unpack/anything-goes', $result );
-	}
-
-	public function test_themes_enforce_expected_slug_passes_through_when_unset() {
-		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Themes_Replace_Endpoint::class );
-		$result   = $endpoint->enforce_expected_slug( '/tmp/unpack/anything-goes', '', null, array() );
-		$this->assertSame( '/tmp/unpack/anything-goes', $result );
-	}
-
 	public function test_plugins_sanitize_upgrader_error_collapses_unknown_codes() {
 		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Plugins_Replace_Endpoint::class );
 		$class    = new ReflectionClass( $endpoint );
@@ -685,68 +686,6 @@ class Jetpack_Json_Api_Replace_Endpoints_Test extends WP_UnitTestCase {
 		);
 	}
 
-	public function test_enforce_expected_slug_is_case_insensitive() {
-		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Plugins_Replace_Endpoint::class );
-		$this->set_expected_slug( $endpoint, 'akismet' );
-		$result = $endpoint->enforce_expected_slug( '/tmp/unpack/Akismet', '', null, array() );
-		$this->assertSame( '/tmp/unpack/Akismet', $result );
-	}
-
-	public function test_enforce_expected_slug_rejects_non_ascii_source() {
-		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Plugins_Replace_Endpoint::class );
-		$this->set_expected_slug( $endpoint, 'akismet' );
-		$result = $endpoint->enforce_expected_slug( '/tmp/unpack/akîsmet', '', null, array() );
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'slug_mismatch', $result->get_error_code() );
-	}
-
-	public function test_enforce_expected_slug_rejects_dotted_source() {
-		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Plugins_Replace_Endpoint::class );
-		$this->set_expected_slug( $endpoint, 'akismet' );
-		$result = $endpoint->enforce_expected_slug( '/tmp/unpack/..', '', null, array() );
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'slug_mismatch', $result->get_error_code() );
-	}
-
-	public function test_enforce_expected_slug_rejects_whitespace_source() {
-		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Plugins_Replace_Endpoint::class );
-		$this->set_expected_slug( $endpoint, 'akismet' );
-		$result = $endpoint->enforce_expected_slug( '/tmp/unpack/akismet ', '', null, array() );
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'slug_mismatch', $result->get_error_code() );
-	}
-
-	public function test_themes_enforce_expected_slug_is_case_insensitive() {
-		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Themes_Replace_Endpoint::class );
-		$this->set_expected_slug( $endpoint, 'twentytwentyfour' );
-		$result = $endpoint->enforce_expected_slug( '/tmp/unpack/TwentyTwentyFour', '', null, array() );
-		$this->assertSame( '/tmp/unpack/TwentyTwentyFour', $result );
-	}
-
-	public function test_themes_enforce_expected_slug_rejects_non_ascii_source() {
-		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Themes_Replace_Endpoint::class );
-		$this->set_expected_slug( $endpoint, 'twentytwentyfour' );
-		$result = $endpoint->enforce_expected_slug( '/tmp/unpack/twêntytwentyfour', '', null, array() );
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'slug_mismatch', $result->get_error_code() );
-	}
-
-	public function test_themes_enforce_expected_slug_rejects_dotted_source() {
-		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Themes_Replace_Endpoint::class );
-		$this->set_expected_slug( $endpoint, 'twentytwentyfour' );
-		$result = $endpoint->enforce_expected_slug( '/tmp/unpack/..', '', null, array() );
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'slug_mismatch', $result->get_error_code() );
-	}
-
-	public function test_themes_enforce_expected_slug_rejects_whitespace_source() {
-		$endpoint = $this->make_endpoint( Jetpack_JSON_API_Themes_Replace_Endpoint::class );
-		$this->set_expected_slug( $endpoint, 'twentytwentyfour' );
-		$result = $endpoint->enforce_expected_slug( '/tmp/unpack/twentytwentyfour ', '', null, array() );
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'slug_mismatch', $result->get_error_code() );
-	}
-
 	/**
 	 * @dataProvider provide_invalid_slugs
 	 */
@@ -765,21 +704,6 @@ class Jetpack_Json_Api_Replace_Endpoints_Test extends WP_UnitTestCase {
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'missing_slug', $result->get_error_code() );
-	}
-
-	/**
-	 * Set the protected expected_slug property via reflection.
-	 *
-	 * @param object $endpoint
-	 * @param string $slug
-	 */
-	private function set_expected_slug( $endpoint, $slug ) {
-		$class    = new ReflectionClass( $endpoint );
-		$property = $class->getProperty( 'expected_slug' );
-		if ( PHP_VERSION_ID < 80100 ) {
-			$property->setAccessible( true );
-		}
-		$property->setValue( $endpoint, $slug );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Adds two new JSON API endpoints on the Jetpack plugin that install or overwrite a plugin/theme in place from an uploaded zip, mirroring wp-admin's "Replace current with uploaded" flow via `overwrite_package = true`.

- `POST /sites/%s/plugins/replace` (v1, v1.1, v1.2)
- `POST /sites/%s/themes/replace` (v1)

Both follow the existing `plugins/new` / `themes/new` architecture: the wpcom forwarder intercepts a multipart zip upload, creates an attachment on the Jetpack site, and forwards the API call with `zip[0][id]` pointing to that attachment.

## Why

Use case calls for an install-or-replace operation from an uploaded zip that doesn't require the caller to first check whether the plugin/theme is already installed. The existing `plugins/new` / `themes/new` endpoints only install when the slug is unknown — they error out when the target already exists.

## How

Extend the existing `*_New_Endpoint` classes, override `install()` to pass `overwrite_package = true`, and require both `install_*` and `update_*` caps. A required `slug` param plus an `upgrader_source_selection` filter reject zips whose top-level folder doesn't match the declared slug, closing the cross-slug overwrite gap. Post-install identifier comes from `Plugin_Upgrader::plugin_info()` / `Theme_Upgrader::theme_info()` rather than `get_plugins()`/`wp_get_themes()` diffs. Shared attachment ownership + zip-mime validation lives in a new `Jetpack_JSON_API_Attachment_Ownership_Trait`.

## Does this pull request change what data or activity we track or use?

No. These endpoints wrap the existing WordPress plugin/theme install flow and do not introduce any new tracking, telemetry, or stored data. The attachment lifecycle (create → install → delete) matches what `plugins/new` and `themes/new` already do.

## Testing instructions

> **Note for wpcom testing:** The `/plugins/replace` and `/themes/replace` endpoints are forwarded from wpcom. To exercise them end-to-end against a sandbox, the companion wpcom branch `feature/telex-project-push-endpoints` must be active on the sandbox — it contains the forwarder wiring. Without it, requests will not reach these endpoints.

### Automated tests

Run the PHPUnit suite covering the new endpoints:

```
jp docker phpunit jetpack -- --filter=Replace_Endpoints
```

49 tests covering class hierarchy, capability arrays, ownership check branches (missing post, non-attachment, other user, owned, system+site-auth, system+user-auth), install-path branches (missing zip, missing slug, 12 adversarial slug shapes via data provider, non-scalar id, non-zip mime, fileless attachment, slug mismatch via filter, case-insensitive compare, non-ASCII/dotted/whitespace source rejection, unknown error-code collapse, version-code preservation), attachment cleanup on every early-return path, preservation on ownership failure.

### Manual end-to-end (via WP.com API)

Replace a plugin on a connected Jetpack site:

1. Obtain a plugin zip (e.g. `jetpack.zip`) whose top-level folder matches the slug you plan to replace (e.g. `jetpack/`).
2. `POST` the zip to `https://public-api.wordpress.com/rest/v1.2/sites/<site-id>/plugins/replace` as multipart/form-data with:
   - `zip[]` — the plugin zip file
   - `slug` — the plugin slug to replace (e.g. `jetpack`)
   - `autoupdate` — optional boolean
3. Verify:
   - Response is `200 OK` with the installed plugin payload (slug, version, name, etc.).
   - The plugin on the site is now the uploaded version (check the Plugins screen or `wp plugin status <slug>`).
   - Re-running with an unrelated slug (e.g. `slug=akismet` while uploading `jetpack.zip`) returns an error and does **not** overwrite Akismet.
4. Repeat for a theme against `/sites/<site-id>/themes/replace` (v1 only).

### Negative cases to spot-check

- Upload a non-zip file → error, no partial install.
- Omit the `slug` param → error before the upgrader runs.
- Request without `install_plugins` + `update_plugins` caps → 403.
