### PR TITLE
VideoPress: treat unlimited-storage feature as paid VideoPress purchase

### DIFF
--- a/projects/packages/videopress/changelog/fix-vidp-236-legacy-security-upsell
+++ b/projects/packages/videopress/changelog/fix-vidp-236-legacy-security-upsell
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix upsell incorrectly shown to legacy Jetpack Security plan customers who have unlimited (but not 1TB) VideoPress storage.

--- a/projects/packages/videopress/src/client/admin/hooks/use-plan/index.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-plan/index.ts
@@ -47,10 +47,9 @@ export const usePlan = (): usePlanProps => {
 		product: videoPressProduct,
 		productPrice,
 
-		hasVideoPressPurchase:
-			( resolvedFeatures?.isVideoPress1TBSupported ||
-				resolvedFeatures?.isVideoPressUnlimitedSupported ) ??
-			false,
+		hasVideoPressPurchase: Boolean(
+			resolvedFeatures?.isVideoPress1TBSupported || resolvedFeatures?.isVideoPressUnlimitedSupported
+		),
 		isFetchingFeatures,
 	};
 };

--- a/projects/packages/videopress/src/client/admin/hooks/use-plan/index.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-plan/index.ts
@@ -47,7 +47,10 @@ export const usePlan = (): usePlanProps => {
 		product: videoPressProduct,
 		productPrice,
 
-		hasVideoPressPurchase: resolvedFeatures?.isVideoPress1TBSupported ?? false,
+		hasVideoPressPurchase:
+			( resolvedFeatures?.isVideoPress1TBSupported ||
+				resolvedFeatures?.isVideoPressUnlimitedSupported ) ??
+			false,
 		isFetchingFeatures,
 	};
 };

--- a/projects/packages/videopress/src/client/admin/hooks/use-plan/test/index.test.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-plan/test/index.test.ts
@@ -144,6 +144,20 @@ describe( 'usePlan hasVideoPressPurchase logic', () => {
 		expect( result.hasVideoPressPurchase ).toBe( true );
 	} );
 
+	it( 'returns true when only isVideoPressUnlimitedSupported is true (legacy Security Daily)', () => {
+		mockFeaturesData = {
+			features: {
+				isVideoPressSupported: true,
+				isVideoPress1TBSupported: false,
+				isVideoPressUnlimitedSupported: true,
+			},
+			isFetchingFeatures: false,
+		};
+
+		const result = importUsePlan();
+		expect( result.hasVideoPressPurchase ).toBe( true );
+	} );
+
 	it( 'returns isFetchingFeatures state from store', () => {
 		mockFeaturesData = {
 			features: undefined,


### PR DESCRIPTION
Fixes [VIDP-236](https://linear.app/a8c/issue/VIDP-236).

## Proposed changes
* In the `usePlan` hook, derive `hasVideoPressPurchase` from **either** `isVideoPress1TBSupported` **or** `isVideoPressUnlimitedSupported`.
* Add a unit test for the unlimited-only case (legacy Jetpack Security Daily).

## Related product discussion/links
* Linear: VIDP-236
* Related prior fix: #46835 (VIDP-215)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

### Background
`wpcomsh/wpcom-features/class-wpcom-features.php` maps two VideoPress entitlements:
- `videopress-1tb-storage` — granted to Complete, VideoPress, Premium, Business plans.
- `videopress-unlimited-storage` — granted to legacy purchases **before 2021-10-07**, including Jetpack Security Daily/Realtime/T1/T2, Premium, Business, and Complete.

Legacy Jetpack Security Daily customers (who purchased before the 2021-10-07 cutoff) receive `videopress-unlimited-storage` but *not* `videopress-1tb-storage`. Before this PR, the VideoPress admin UI derived `hasVideoPressPurchase` from `isVideoPress1TBSupported` only, so those customers were incorrectly shown the "You have used your free video upload" upsell and the "Add new video" button was disabled.

### Unit tests
```
cd projects/packages/videopress
pnpm jest src/client/admin/hooks/use-plan
```
All 7 cases should pass, including the new "returns true when only isVideoPressUnlimitedSupported is true" case.

### Manual verification
1. Simulate a legacy Security Daily site by having the WPCOM `/sites/%d/features` response include `videopress-unlimited-storage` in `active` but not `videopress-1tb-storage`. The simplest local approach is to filter `videopress/v1/features` output (or mock `Automattic\Jetpack\My_Jetpack\Product::get_site_features_from_wpcom()`) to return:
   ```php
   [ 'active' => [ 'videopress', 'videopress-unlimited-storage' ] ]
   ```
2. Visit Jetpack → VideoPress.
3. Confirm the storage meter no longer shows the "free video used" upsell.
4. Confirm the "Add new video" button is enabled and uploads proceed.
5. Repeat with an active set that includes neither flag (truly free tier) and confirm the upsell *is* still shown.
6. Repeat with `videopress-1tb-storage` only and confirm the UI continues to treat it as a paid plan (no regression on the original VIDP-215 fix).