### PR TITLE
feat(ai): add MCP activity log link and Tracks analytics events

### DIFF
--- a/projects/plugins/jetpack/_inc/client/ai/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/main.jsx
@@ -6,9 +6,10 @@
 
 import { AdminPage, JetpackLogo } from '@automattic/jetpack-components';
 import { Spinner } from '@wordpress/components';
-import { useCallback, useState } from '@wordpress/element';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Notice, Stack } from '@wordpress/ui';
+import analytics from 'lib/analytics';
 import McpHub from './mcp/index';
 import McpRead from './mcp/read';
 import McpSetup from './mcp/setup';
@@ -16,7 +17,7 @@ import McpUpsell from './mcp/upsell';
 import { useMcpSettings } from './mcp/use-mcp-settings';
 import McpWrite from './mcp/write';
 
-const { blogId, apiRoot, apiNonce } = window?.jetpackAiSettings ?? {};
+const { blogId, siteRawUrl, apiRoot, apiNonce } = window?.jetpackAiSettings ?? {};
 
 const VIEW_TITLES = {
 	hub: __( 'AI', 'jetpack' ),
@@ -73,6 +74,12 @@ export default function App() {
 	const [ saveError, setSaveError ] = useState( null );
 	const { isLoading, savingToolIds, mcpAbilities, hasMcpAccess, error, updateMcpAbilities } =
 		useMcpSettings();
+
+	useEffect( () => {
+		if ( ! isLoading && hasMcpAccess ) {
+			analytics.tracks.recordEvent( 'jp_mcp_settings_viewed' );
+		}
+	}, [ isLoading, hasMcpAccess ] );
 
 	const handleUpdate = useCallback(
 		update => {
@@ -138,6 +145,7 @@ export default function App() {
 							<McpHub
 								mcpAbilities={ mcpAbilities }
 								blogId={ blogId }
+								siteRawUrl={ siteRawUrl }
 								savingToolIds={ savingToolIds }
 								onNavigate={ setView }
 								onUpdate={ handleUpdate }

--- a/projects/plugins/jetpack/_inc/client/ai/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/main.jsx
@@ -17,7 +17,7 @@ import McpUpsell from './mcp/upsell';
 import { useMcpSettings } from './mcp/use-mcp-settings';
 import McpWrite from './mcp/write';
 
-const { blogId, siteRawUrl, apiRoot, apiNonce } = window?.jetpackAiSettings ?? {};
+const { blogId, apiRoot, apiNonce } = window?.jetpackAiSettings ?? {};
 
 const VIEW_TITLES = {
 	hub: __( 'AI', 'jetpack' ),
@@ -145,7 +145,6 @@ export default function App() {
 							<McpHub
 								mcpAbilities={ mcpAbilities }
 								blogId={ blogId }
-								siteRawUrl={ siteRawUrl }
 								savingToolIds={ savingToolIds }
 								onNavigate={ setView }
 								onUpdate={ handleUpdate }

--- a/projects/plugins/jetpack/_inc/client/ai/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/main.jsx
@@ -77,7 +77,7 @@ export default function App() {
 
 	useEffect( () => {
 		if ( ! isLoading && hasMcpAccess ) {
-			analytics.tracks.recordEvent( 'jp_mcp_settings_viewed' );
+			analytics.tracks.recordEvent( 'jetpack_mcp_settings_viewed' );
 		}
 	}, [ isLoading, hasMcpAccess ] );
 

--- a/projects/plugins/jetpack/_inc/client/ai/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/main.jsx
@@ -17,7 +17,7 @@ import McpUpsell from './mcp/upsell';
 import { useMcpSettings } from './mcp/use-mcp-settings';
 import McpWrite from './mcp/write';
 
-const { blogId, apiRoot, apiNonce } = window?.jetpackAiSettings ?? {};
+const { blogId, activityLogUrl, apiRoot, apiNonce } = window?.jetpackAiSettings ?? {};
 
 const VIEW_TITLES = {
 	hub: __( 'AI', 'jetpack' ),
@@ -145,6 +145,7 @@ export default function App() {
 							<McpHub
 								mcpAbilities={ mcpAbilities }
 								blogId={ blogId }
+								activityLogUrl={ activityLogUrl }
 								savingToolIds={ savingToolIds }
 								onNavigate={ setView }
 								onUpdate={ handleUpdate }

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/index.jsx
@@ -166,20 +166,12 @@ function ConnectRow( { title, description, onClick } ) {
  * @param {object}   props               - Component props.
  * @param {object}   props.mcpAbilities  - Full mcp_abilities object from API.
  * @param {number}   props.blogId        - Current site's blog ID.
- * @param {string}   props.siteRawUrl    - Site raw URL for activity log link.
  * @param {Set}      props.savingToolIds - Set of toolIds currently being saved.
  * @param {Function} props.onNavigate    - Called with 'read' | 'write' | 'setup'.
  * @param {Function} props.onUpdate      - Called with partial mcp_abilities update.
  * @return {object} Component markup.
  */
-export default function McpHub( {
-	mcpAbilities,
-	blogId,
-	siteRawUrl,
-	savingToolIds,
-	onNavigate,
-	onUpdate,
-} ) {
+export default function McpHub( { mcpAbilities, blogId, savingToolIds, onNavigate, onUpdate } ) {
 	const accountAbilities = getAccountMcpAbilities( mcpAbilities ?? {} );
 	const siteContextToolIds = getSiteContextToolIds( mcpAbilities ?? {} );
 	const siteAbilities = getSiteMcpAbilities( mcpAbilities ?? {}, blogId );
@@ -290,11 +282,11 @@ export default function McpHub( {
 				</Card>
 			) }
 
-			{ isMcpEnabled && siteRawUrl && (
+			{ isMcpEnabled && (
 				<Card>
 					<a
 						className="jetpack-ai-mcp__connect-row"
-						href={ getRedirectUrl( 'calypso-activity-log', { site: siteRawUrl } ) }
+						href={ getRedirectUrl( 'cloud-activity-log-wp-menu', { site: blogId } ) }
 						target="_blank"
 						rel="noopener noreferrer"
 					>

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/index.jsx
@@ -3,6 +3,7 @@
  * Shows the enable/disable toggle and navigation to Read, Write, and Setup sub-views.
  */
 
+import { getRedirectUrl } from '@automattic/jetpack-components';
 import {
 	Card,
 	CardBody,
@@ -13,8 +14,18 @@ import {
 } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { seen, pencil, connection, chevronRight, info, published, caution } from '@wordpress/icons';
+import {
+	seen,
+	pencil,
+	connection,
+	chevronRight,
+	info,
+	published,
+	caution,
+	list,
+} from '@wordpress/icons';
 import { Badge, Button, Stack } from '@wordpress/ui';
+import analytics from 'lib/analytics';
 import { isWriteTool } from './categories';
 import {
 	getAccountMcpAbilities,
@@ -155,12 +166,20 @@ function ConnectRow( { title, description, onClick } ) {
  * @param {object}   props               - Component props.
  * @param {object}   props.mcpAbilities  - Full mcp_abilities object from API.
  * @param {number}   props.blogId        - Current site's blog ID.
+ * @param {string}   props.siteRawUrl    - Site raw URL for activity log link.
  * @param {Set}      props.savingToolIds - Set of toolIds currently being saved.
  * @param {Function} props.onNavigate    - Called with 'read' | 'write' | 'setup'.
  * @param {Function} props.onUpdate      - Called with partial mcp_abilities update.
  * @return {object} Component markup.
  */
-export default function McpHub( { mcpAbilities, blogId, savingToolIds, onNavigate, onUpdate } ) {
+export default function McpHub( {
+	mcpAbilities,
+	blogId,
+	siteRawUrl,
+	savingToolIds,
+	onNavigate,
+	onUpdate,
+} ) {
 	const accountAbilities = getAccountMcpAbilities( mcpAbilities ?? {} );
 	const siteContextToolIds = getSiteContextToolIds( mcpAbilities ?? {} );
 	const siteAbilities = getSiteMcpAbilities( mcpAbilities ?? {}, blogId );
@@ -191,6 +210,7 @@ export default function McpHub( { mcpAbilities, blogId, savingToolIds, onNavigat
 
 	const handleMcpToggle = useCallback(
 		enabled => {
+			analytics.tracks.recordEvent( 'jp_mcp_enabled_toggled', { enabled } );
 			const abilities = {};
 			if ( enabled ) {
 				readTools.forEach( ( [ toolId ] ) => {
@@ -267,6 +287,32 @@ export default function McpHub( { mcpAbilities, blogId, savingToolIds, onNavigat
 						) }
 						onClick={ navigateToSetup }
 					/>
+				</Card>
+			) }
+
+			{ isMcpEnabled && siteRawUrl && (
+				<Card>
+					<a
+						className="jetpack-ai-mcp__connect-row"
+						href={ getRedirectUrl( 'calypso-activity-log', { site: siteRawUrl } ) }
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						<span className="jetpack-ai-mcp__connect-row-icon">
+							<Icon icon={ list } size={ 24 } />
+						</span>
+						<span className="jetpack-ai-mcp__connect-row-text">
+							<Text as="p" className="jetpack-ai-mcp__connect-row-title" weight={ 600 }>
+								{ __( 'Activity log', 'jetpack' ) }
+							</Text>
+							<Text as="p" className="jetpack-ai-mcp__connect-row-description" variant="muted">
+								{ __( 'Review recent actions taken by AI agents on your site.', 'jetpack' ) }
+							</Text>
+						</span>
+						<span className="jetpack-ai-mcp__connect-row-chevron">
+							<Icon icon={ chevronRight } size={ 24 } />
+						</span>
+					</a>
 				</Card>
 			) }
 		</>

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/index.jsx
@@ -209,7 +209,7 @@ export default function McpHub( {
 
 	const handleMcpToggle = useCallback(
 		enabled => {
-			analytics.tracks.recordEvent( 'jp_mcp_enabled_toggled', { enabled } );
+			analytics.tracks.recordEvent( 'jetpack_mcp_enabled_toggled', { enabled } );
 			const abilities = {};
 			if ( enabled ) {
 				readTools.forEach( ( [ toolId ] ) => {

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/index.jsx
@@ -3,7 +3,6 @@
  * Shows the enable/disable toggle and navigation to Read, Write, and Setup sub-views.
  */
 
-import { getRedirectUrl } from '@automattic/jetpack-components';
 import {
 	Card,
 	CardBody,
@@ -163,15 +162,23 @@ function ConnectRow( { title, description, onClick } ) {
 /**
  * MCP hub component.
  *
- * @param {object}   props               - Component props.
- * @param {object}   props.mcpAbilities  - Full mcp_abilities object from API.
- * @param {number}   props.blogId        - Current site's blog ID.
- * @param {Set}      props.savingToolIds - Set of toolIds currently being saved.
- * @param {Function} props.onNavigate    - Called with 'read' | 'write' | 'setup'.
- * @param {Function} props.onUpdate      - Called with partial mcp_abilities update.
+ * @param {object}   props                - Component props.
+ * @param {object}   props.mcpAbilities   - Full mcp_abilities object from API.
+ * @param {number}   props.blogId         - Current site's blog ID.
+ * @param {string}   props.activityLogUrl - URL for the activity log link.
+ * @param {Set}      props.savingToolIds  - Set of toolIds currently being saved.
+ * @param {Function} props.onNavigate     - Called with 'read' | 'write' | 'setup'.
+ * @param {Function} props.onUpdate       - Called with partial mcp_abilities update.
  * @return {object} Component markup.
  */
-export default function McpHub( { mcpAbilities, blogId, savingToolIds, onNavigate, onUpdate } ) {
+export default function McpHub( {
+	mcpAbilities,
+	blogId,
+	activityLogUrl,
+	savingToolIds,
+	onNavigate,
+	onUpdate,
+} ) {
 	const accountAbilities = getAccountMcpAbilities( mcpAbilities ?? {} );
 	const siteContextToolIds = getSiteContextToolIds( mcpAbilities ?? {} );
 	const siteAbilities = getSiteMcpAbilities( mcpAbilities ?? {}, blogId );
@@ -270,7 +277,7 @@ export default function McpHub( { mcpAbilities, blogId, savingToolIds, onNavigat
 			</Card>
 
 			{ isMcpEnabled && (
-				<Card>
+				<Card className="jetpack-ai-mcp__action-card">
 					<ConnectRow
 						title={ __( 'Connect external AI agent', 'jetpack' ) }
 						description={ __(
@@ -282,11 +289,11 @@ export default function McpHub( { mcpAbilities, blogId, savingToolIds, onNavigat
 				</Card>
 			) }
 
-			{ isMcpEnabled && (
-				<Card>
+			{ isMcpEnabled && activityLogUrl && (
+				<Card className="jetpack-ai-mcp__action-card">
 					<a
 						className="jetpack-ai-mcp__connect-row"
-						href={ getRedirectUrl( 'cloud-activity-log-wp-menu', { site: blogId } ) }
+						href={ activityLogUrl }
 						target="_blank"
 						rel="noopener noreferrer"
 					>

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/read.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/read.jsx
@@ -15,6 +15,7 @@ import {
 import { Fragment, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Stack } from '@wordpress/ui';
+import analytics from 'lib/analytics';
 import {
 	CATEGORY_ORDER,
 	SUB_CATEGORY_ORDER,
@@ -122,6 +123,11 @@ export default function McpRead( { mcpAbilities, blogId, savingToolIds, onUpdate
 
 	const handleToolChange = useCallback(
 		( toolId, enabled ) => {
+			analytics.tracks.recordEvent( 'jp_mcp_allowlist_updated', {
+				tool_id: toolId,
+				enabled,
+				view: 'read',
+			} );
 			onUpdate( {
 				sites: [
 					{
@@ -136,6 +142,11 @@ export default function McpRead( { mcpAbilities, blogId, savingToolIds, onUpdate
 
 	const handleEnableAll = useCallback(
 		( categoryTools, enabled ) => {
+			analytics.tracks.recordEvent( 'jp_mcp_allowlist_updated', {
+				enabled,
+				tool_count: categoryTools.length,
+				view: 'read',
+			} );
 			const overrides = {};
 			categoryTools.forEach( ( [ toolId ] ) => {
 				overrides[ toolId ] = enabled;

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/read.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/read.jsx
@@ -123,7 +123,7 @@ export default function McpRead( { mcpAbilities, blogId, savingToolIds, onUpdate
 
 	const handleToolChange = useCallback(
 		( toolId, enabled ) => {
-			analytics.tracks.recordEvent( 'jp_mcp_allowlist_updated', {
+			analytics.tracks.recordEvent( 'jetpack_mcp_allowlist_updated', {
 				tool_id: toolId,
 				enabled,
 				view: 'read',
@@ -142,7 +142,7 @@ export default function McpRead( { mcpAbilities, blogId, savingToolIds, onUpdate
 
 	const handleEnableAll = useCallback(
 		( categoryTools, enabled ) => {
-			analytics.tracks.recordEvent( 'jp_mcp_allowlist_updated', {
+			analytics.tracks.recordEvent( 'jetpack_mcp_allowlist_updated', {
 				enabled,
 				tool_count: categoryTools.length,
 				view: 'read',

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/style.scss
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/style.scss
@@ -24,8 +24,13 @@
 		}
 	}
 
+	&__action-card {
+		overflow: hidden;
+	}
+
 	&__connect-row {
 		display: flex;
+		box-sizing: border-box;
 		gap: 16px;
 		align-items: flex-start;
 		padding: 24px;

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/style.scss
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/style.scss
@@ -98,7 +98,7 @@
 	}
 
 	&__access-card {
-		// Override default card margin if any
+		overflow: hidden;
 	}
 }
 

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/style.scss
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/style.scss
@@ -36,6 +36,15 @@
 		text-align: left;
 		border-radius: 0;
 
+		// Reset browser link styles when rendered as <a>
+		&,
+		&:visited,
+		&:hover,
+		&:active {
+			color: inherit;
+			text-decoration: none;
+		}
+
 		&:hover {
 			background: var(--color-surface-backdrop, #f0f0f1);
 		}

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/write.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/write.jsx
@@ -16,6 +16,7 @@ import {
 import { Fragment, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Stack } from '@wordpress/ui';
+import analytics from 'lib/analytics';
 import {
 	CATEGORY_ORDER,
 	SUB_CATEGORY_ORDER,
@@ -123,6 +124,11 @@ export default function McpWrite( { mcpAbilities, blogId, savingToolIds, onUpdat
 
 	const handleToolChange = useCallback(
 		( toolId, enabled ) => {
+			analytics.tracks.recordEvent( 'jp_mcp_allowlist_updated', {
+				tool_id: toolId,
+				enabled,
+				view: 'write',
+			} );
 			onUpdate( {
 				sites: [
 					{
@@ -137,6 +143,11 @@ export default function McpWrite( { mcpAbilities, blogId, savingToolIds, onUpdat
 
 	const handleEnableAll = useCallback(
 		( categoryTools, enabled ) => {
+			analytics.tracks.recordEvent( 'jp_mcp_allowlist_updated', {
+				enabled,
+				tool_count: categoryTools.length,
+				view: 'write',
+			} );
 			const overrides = {};
 			categoryTools.forEach( ( [ toolId ] ) => {
 				overrides[ toolId ] = enabled;

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/write.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/write.jsx
@@ -124,7 +124,7 @@ export default function McpWrite( { mcpAbilities, blogId, savingToolIds, onUpdat
 
 	const handleToolChange = useCallback(
 		( toolId, enabled ) => {
-			analytics.tracks.recordEvent( 'jp_mcp_allowlist_updated', {
+			analytics.tracks.recordEvent( 'jetpack_mcp_allowlist_updated', {
 				tool_id: toolId,
 				enabled,
 				view: 'write',
@@ -143,7 +143,7 @@ export default function McpWrite( { mcpAbilities, blogId, savingToolIds, onUpdat
 
 	const handleEnableAll = useCallback(
 		( categoryTools, enabled ) => {
-			analytics.tracks.recordEvent( 'jp_mcp_allowlist_updated', {
+			analytics.tracks.recordEvent( 'jetpack_mcp_allowlist_updated', {
 				enabled,
 				tool_count: categoryTools.length,
 				view: 'write',

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
@@ -10,6 +10,9 @@
 
 use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Redirect;
+use Automattic\Jetpack\Status;
+use Automattic\Jetpack\Status\Host;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
@@ -77,7 +80,13 @@ class Jetpack_AI_Page extends Jetpack_Admin_Page {
 			$script_version = $asset_manifest['version'];
 		}
 
-		$blog_id = Connection_Manager::get_site_id( true );
+		$blog_id     = Connection_Manager::get_site_id( true );
+		$site_suffix = ( new Status() )->get_site_suffix();
+		// On Atomic, jetpack-mu-wpcom replaces the cloud redirect with a direct WPCOM URL.
+		// Mirror that behaviour here so the activity log link resolves consistently.
+		$activity_log_url = ( new Host() )->is_woa_site()
+			? 'https://wordpress.com/activity-log/' . $site_suffix
+			: Redirect::get_url( 'cloud-activity-log-wp-menu', array( 'site' => $blog_id ? $blog_id : $site_suffix ) );
 
 		wp_enqueue_script(
 			'jetpack-ai-admin',
@@ -93,12 +102,13 @@ class Jetpack_AI_Page extends Jetpack_Admin_Page {
 			'jetpack-ai-admin',
 			'var jetpackAiSettings = ' . wp_json_encode(
 				array(
-					'blogId'       => $blog_id ? (int) $blog_id : 0,
-					'siteAdminUrl' => admin_url(),
-					'apiRoot'      => esc_url_raw( rest_url() ),
-					'apiNonce'     => wp_create_nonce( 'wp_rest' ),
-					'pluginUrl'    => plugins_url( '', JETPACK__PLUGIN_FILE ),
-					'upgradeUrl'   => 'https://wordpress.com/plans/' . rawurlencode( wp_parse_url( home_url(), PHP_URL_HOST ) ?? '' ),
+					'blogId'         => $blog_id ? (int) $blog_id : 0,
+					'activityLogUrl' => $activity_log_url,
+					'siteAdminUrl'   => admin_url(),
+					'apiRoot'        => esc_url_raw( rest_url() ),
+					'apiNonce'       => wp_create_nonce( 'wp_rest' ),
+					'pluginUrl'      => plugins_url( '', JETPACK__PLUGIN_FILE ),
+					'upgradeUrl'     => 'https://wordpress.com/plans/' . rawurlencode( wp_parse_url( home_url(), PHP_URL_HOST ) ?? '' ),
 				),
 				JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 			) . ';',

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
@@ -82,10 +82,15 @@ class Jetpack_AI_Page extends Jetpack_Admin_Page {
 
 		$blog_id     = Connection_Manager::get_site_id( true );
 		$site_suffix = ( new Status() )->get_site_suffix();
+		// Use the plain hostname for the Atomic activity log URL — get_site_suffix() can
+		// include '::' for subdirectory installs, which would break the URL. This matches
+		// the approach used by jetpack-mu-wpcom for the sidebar Activity Log link.
+		$site_host = wp_parse_url( home_url(), PHP_URL_HOST );
 		// On Atomic, jetpack-mu-wpcom replaces the cloud redirect with a direct WPCOM URL.
 		// Mirror that behaviour here so the activity log link resolves consistently.
-		$activity_log_url = ( new Host() )->is_woa_site()
-			? 'https://wordpress.com/activity-log/' . $site_suffix
+		$activity_log_site = ( is_string( $site_host ) && '' !== $site_host ) ? $site_host : $site_suffix;
+		$activity_log_url  = ( new Host() )->is_woa_site()
+			? 'https://wordpress.com/activity-log/' . $activity_log_site
 			: Redirect::get_url( 'cloud-activity-log-wp-menu', array( 'site' => $blog_id ? $blog_id : $site_suffix ) );
 
 		wp_enqueue_script(

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
@@ -10,6 +10,7 @@
 
 use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Status;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
@@ -77,7 +78,8 @@ class Jetpack_AI_Page extends Jetpack_Admin_Page {
 			$script_version = $asset_manifest['version'];
 		}
 
-		$blog_id = Connection_Manager::get_site_id( true );
+		$blog_id      = Connection_Manager::get_site_id( true );
+		$site_raw_url = ( new Status() )->get_site_suffix();
 
 		wp_enqueue_script(
 			'jetpack-ai-admin',
@@ -94,6 +96,7 @@ class Jetpack_AI_Page extends Jetpack_Admin_Page {
 			'var jetpackAiSettings = ' . wp_json_encode(
 				array(
 					'blogId'       => $blog_id ? (int) $blog_id : 0,
+					'siteRawUrl'   => $site_raw_url,
 					'siteAdminUrl' => admin_url(),
 					'apiRoot'      => esc_url_raw( rest_url() ),
 					'apiNonce'     => wp_create_nonce( 'wp_rest' ),

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
@@ -10,7 +10,6 @@
 
 use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
-use Automattic\Jetpack\Status;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
@@ -78,8 +77,7 @@ class Jetpack_AI_Page extends Jetpack_Admin_Page {
 			$script_version = $asset_manifest['version'];
 		}
 
-		$blog_id      = Connection_Manager::get_site_id( true );
-		$site_raw_url = ( new Status() )->get_site_suffix();
+		$blog_id = Connection_Manager::get_site_id( true );
 
 		wp_enqueue_script(
 			'jetpack-ai-admin',
@@ -96,7 +94,6 @@ class Jetpack_AI_Page extends Jetpack_Admin_Page {
 			'var jetpackAiSettings = ' . wp_json_encode(
 				array(
 					'blogId'       => $blog_id ? (int) $blog_id : 0,
-					'siteRawUrl'   => $site_raw_url,
 					'siteAdminUrl' => admin_url(),
 					'apiRoot'      => esc_url_raw( rest_url() ),
 					'apiNonce'     => wp_create_nonce( 'wp_rest' ),

--- a/projects/plugins/jetpack/changelog/aiint-357-jetpack-ai-mcp-activity-log-and-metrics
+++ b/projects/plugins/jetpack/changelog/aiint-357-jetpack-ai-mcp-activity-log-and-metrics
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+AI MCP settings: add activity log link and Tracks analytics events (jp_mcp_settings_viewed, jp_mcp_enabled_toggled, jp_mcp_allowlist_updated)


### PR DESCRIPTION
Fixes #

## Proposed changes

* Add an "Activity log" link card to the MCP hub, shown when MCP is enabled. The URL is computed in PHP: on Atomic sites it uses `https://wordpress.com/activity-log/{host}` directly (matching `jetpack-mu-wpcom`'s sidebar behavior); on self-hosted/JN it uses the `cloud-activity-log-wp-menu` redirect slug. The resolved URL is passed to React as `activityLogUrl` in the `jetpackAiSettings` inline script.
* Use `wp_parse_url( home_url(), PHP_URL_HOST )` for the Atomic URL to avoid broken links on subdirectory installs where `get_site_suffix()` can return values containing `::`.
* Add three Tracks analytics events to the MCP settings UI:
  * `jetpack_mcp_settings_viewed` — fires on page load when the user has MCP access
  * `jetpack_mcp_enabled_toggled` — fires when the site-level MCP toggle is changed, with `{ enabled: bool }`
  * `jetpack_mcp_allowlist_updated` — fires on per-tool and category "Enable all" toggles, with `{ tool_id?, enabled, tool_count?, view: 'read'|'write' }`

## Related product discussion/links

* PRD: Turnkey MCP for Self-Hosted Jetpack Sites
* Previous PR: #48048 (MCP settings UI)

## Does this pull request change what data or activity we track or use?

Yes — adds three new Tracks events (`jetpack_mcp_settings_viewed`, `jetpack_mcp_enabled_toggled`, `jetpack_mcp_allowlist_updated`) as specified in the PRD's Data Tracking Requirements section.

## Testing instructions

**Activity log link:**

1. On a self-hosted Jetpack site connected to WordPress.com, go to `wp-admin/admin.php?page=ai`
2. Enable MCP access using the toggle
3. Verify an "Activity log" card appears below "Connect external AI agent"
4. Click it — on Atomic it should open `https://wordpress.com/activity-log/{domain}`; on self-hosted/JN it should open `https://cloud.jetpack.com/activity-log/{blogId}`
5. Disable MCP — confirm the activity log card disappears

**Tracks events (requires MC/Tracks test environment):**

1. Navigate to `wp-admin/admin.php?page=ai` — confirm `jetpack_mcp_settings_viewed` fires once
2. Toggle the "Enable MCP access" toggle on/off — confirm `jetpack_mcp_enabled_toggled` fires with correct `enabled` value
3. Go to Read or Write sub-view, toggle an individual tool — confirm `jetpack_mcp_allowlist_updated` fires with `tool_id`, `enabled`, and `view`
4. Use the "Enable all" category toggle — confirm `jetpack_mcp_allowlist_updated` fires with `tool_count` and `view`
