### PR TITLE
wpcomsh: Allow gutenberg-no-tinymce Gutenberg experiment on Atomic

### DIFF
--- a/projects/plugins/wpcomsh/changelog/enable-gutenberg-no-tinymce-experiment
+++ b/projects/plugins/wpcomsh/changelog/enable-gutenberg-no-tinymce-experiment
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+wpcomsh: Enable gutenberg-no-tinymce experiment on Atomic

--- a/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
+++ b/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
@@ -53,6 +53,7 @@ function wpcomsh_filter_gutenberg_experiments() {
 	return array(
 		'gutenberg-content-guidelines' => true,
 		'gutenberg-guidelines'         => true,
+		'gutenberg-no-tinymce'         => true,
 	);
 }
 


### PR DESCRIPTION
## Summary

Enables the `gutenberg-no-tinymce` experiment on Atomic sites, effectively turning off the Classic block and TinyMCE by default.

## Testing instructions

- Deploy to a WoW dev site (via Jetpack Beta plugin or `jetpack rsync`)
- Start writing a new post and verify the "Classic" block does not exist. 
- Run in browser console: `wp.blocks.getBlockTypes().filter( ( { name } ) => name.indexOf('freeform') >= 0 )` — should return no blocks

## Does this pull request change what data or activity we track or use?

No, this PR does not change what data or activity we track or use. It only enables an existing Gutenberg experiment feature.