### PR TITLE
CI: Remove Composer cache

### DIFF
--- a/.github/actions/tool-setup/action.yml
+++ b/.github/actions/tool-setup/action.yml
@@ -69,6 +69,11 @@ runs:
         composer config --global github-protocols https
         composer config --global use-github-api false
 
+    # We used to set up caching of Composer's cache-files-dir here,
+    # but removed that in April 2026 (#48301) after some testing revealed that
+    # the time needed to save/restore the cache was about the same as the time
+    # needed for Composer to just download the packages fresh.
+
     - name: Setup pnpm
       if: steps.versions.outputs.node-version != 'false'
       uses: pnpm/action-setup@v5.0.0

--- a/.github/actions/tool-setup/action.yml
+++ b/.github/actions/tool-setup/action.yml
@@ -69,22 +69,6 @@ runs:
         composer config --global github-protocols https
         composer config --global use-github-api false
 
-    - name: Get Composer cache directory
-      if: steps.versions.outputs.php-version != 'false'
-      id: composer-cache
-      shell: bash
-      run: |
-        # Get Composer cache directory
-        echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
-    - name: Use composer cache
-      if: steps.versions.outputs.php-version != 'false'
-      uses: actions/cache@v5
-      with:
-        path: ${{ steps.composer-cache.outputs.dir }}
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-composer-
-
     - name: Setup pnpm
       if: steps.versions.outputs.node-version != 'false'
       uses: pnpm/action-setup@v5.0.0


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
It seems using Composer cache is not saving us time. The post-run job itself can take 30s (searching the filesystem to create the hash), so let's just drop it at this stage.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* p1777041320333849-slack-C05Q5HSS013

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Verify CI runs are not slower.