### PR TITLE
wpcomsh: drop A8C_PROXIED_REQUEST gate from reprint export

### DIFF
--- a/projects/plugins/wpcomsh/changelog/reprint-drop-proxy-check
+++ b/projects/plugins/wpcomsh/changelog/reprint-drop-proxy-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Drop the A8C_PROXIED_REQUEST gate from the ?reprint-api export handler so Playground clients can reach it. Authentication still relies on HMAC + the 60-minute activation window.

--- a/projects/plugins/wpcomsh/feature-plugins/reprint-exporter-api.php
+++ b/projects/plugins/wpcomsh/feature-plugins/reprint-exporter-api.php
@@ -10,11 +10,10 @@
  *   callback only accepts Jetpack-signed requests, so it can only be
  *   invoked through the WPCOM public API proxy.
  * * ?reprint-api export requires the reprint_exporter_enabled site
- *   option to be a unix timestamp within the last 60 minutes AND the
- *   request to carry A8C_PROXIED_REQUEST (set by a8c infrastructure
- *   for Automattician proxy sessions). Each accepted request bumps
- *   the timestamp; the streaming endpoint stays internal-only until
- *   Studio ships.
+ *   option to be a unix timestamp within the last 60 minutes, AND a
+ *   valid HMAC signature produced with the per-site shared secret.
+ *   Each accepted request bumps the timestamp, so an idle site
+ *   auto-closes the gate.
  *
  * Data flow has two phases that use different auth and network paths:
  *
@@ -178,21 +177,15 @@ add_filter( 'site_settings_endpoint_update_reprint_exporter_enabled', 'wpcomsh_r
 // -- Helpers ------------------------------------------------------------------
 
 /**
- * Gate for the ?reprint-api export handler: option timestamp within
- * the last 60 minutes AND a proxied-Automattician request.
+ * Gate for the ?reprint-api export handler: the reprint_exporter_enabled
+ * option must hold a unix timestamp within the last 60 minutes. HMAC
+ * verification happens separately in the request handler.
  *
  * @return bool
  */
 function _should_expose_reprint_exporter_on_this_site(): bool {
 	$enabled_at = (int) get_option( 'reprint_exporter_enabled', 0 );
-	if ( $enabled_at <= 0 || ( time() - $enabled_at ) > HOUR_IN_SECONDS ) {
-		return false;
-	}
-
-	// A8C_PROXIED_REQUEST is set by the a8c infrastructure layer (nginx)
-	// for Automattician proxy sessions — not forgeable by clients.
-	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-	return ! empty( $_SERVER['A8C_PROXIED_REQUEST'] );
+	return $enabled_at > 0 && ( time() - $enabled_at ) <= HOUR_IN_SECONDS;
 }
 
 /**

--- a/projects/plugins/wpcomsh/tests/ReprintExporterApiTest.php
+++ b/projects/plugins/wpcomsh/tests/ReprintExporterApiTest.php
@@ -17,7 +17,6 @@ class ReprintExporterApiTest extends WP_UnitTestCase {
 	public function tear_down() {
 		delete_option( 'reprint_exporter_secret' );
 		delete_option( 'reprint_exporter_enabled' );
-		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
 
 		global $wp_rest_server;
 		$wp_rest_server = null;
@@ -33,10 +32,8 @@ class ReprintExporterApiTest extends WP_UnitTestCase {
 	private function set_available( bool $available ) {
 		if ( $available ) {
 			update_option( 'reprint_exporter_enabled', time() );
-			$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		} else {
 			delete_option( 'reprint_exporter_enabled' );
-			unset( $_SERVER['A8C_PROXIED_REQUEST'] );
 		}
 	}
 


### PR DESCRIPTION
The `?reprint-api` export handler currently requires `A8C_PROXIED_REQUEST`, a header the a8c nginx layer sets for Automattician proxy sessions. WordPress Playground runs in the browser and cannot go through that proxy, so the export is unreachable from Studio/Playground — which is the entire target audience for this endpoint.

This PR removes that check. The export is still gated:

- **Activation window.** `reprint_exporter_enabled` must hold a unix timestamp within the last 60 minutes. Each accepted request bumps it, so an idle site auto-closes the gate.
- **HMAC on every request.** `Site_Export_HMAC_Server` verifies `X-Auth-Signature` against the per-site `reprint_exporter_secret`, with a 5-minute clock-skew window, nonce length check, and content-hash binding to the request body.
- **Secret rotation is proxy-only.** `/wpcomsh/v1/reprint/rotate-export-secret` only accepts Jetpack-signed requests coming through the WPCOM public API and runs `is_super_admin()` against the mapped user. Without a rotated secret the HMAC check cannot pass.
- **Opt-in per site.** The activation option has to be set via the site-settings API before the window even opens.

Net: a caller without the rotated secret and an active window still gets nothing; dropping the proxy check just lets a legitimate Playground client actually reach the handler.

/cc @zaerl for review.