### PR TITLE
My Jetpack: add Modules link to the footer

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/build-optional-menu-items.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/build-optional-menu-items.ts
@@ -1,0 +1,63 @@
+import { __, _x } from '@wordpress/i18n';
+
+type FooterMenuItem = {
+	href?: string;
+	label: string;
+	onClick?: () => void;
+	onKeyDown?: ( event: KeyboardEvent ) => void;
+	title?: string;
+	role?: string;
+};
+
+type BuildOptionalMenuItemsArgs = {
+	adminUrl: string;
+	isDevVersion: boolean;
+	userIsAdmin: boolean;
+	isSiteConnected: boolean;
+	isWpcomPlatform: boolean;
+	onModulesClick: () => void;
+	onResetClick: () => void;
+	onResetKeyDown: ( event: KeyboardEvent ) => void;
+};
+
+const buildOptionalMenuItems = ( {
+	adminUrl,
+	isDevVersion,
+	userIsAdmin,
+	isSiteConnected,
+	isWpcomPlatform,
+	onModulesClick,
+	onResetClick,
+	onResetKeyDown,
+}: BuildOptionalMenuItemsArgs ): FooterMenuItem[] => {
+	const items: FooterMenuItem[] = [];
+
+	if ( userIsAdmin && isSiteConnected && ! isWpcomPlatform ) {
+		items.push( {
+			label: _x(
+				'Modules',
+				'Navigation item. Noun. Links to a list of modules for Jetpack.',
+				'jetpack-my-jetpack'
+			),
+			title: __(
+				'Access the full list of Jetpack modules available on your site.',
+				'jetpack-my-jetpack'
+			),
+			href: `${ adminUrl }admin.php?page=jetpack_modules`,
+			onClick: onModulesClick,
+		} );
+	}
+
+	if ( isDevVersion && userIsAdmin ) {
+		items.push( {
+			label: 'Reset options (devs)',
+			role: 'button',
+			onClick: onResetClick,
+			onKeyDown: onResetKeyDown,
+		} );
+	}
+
+	return items;
+};
+
+export default buildOptionalMenuItems;

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/build-optional-menu-items.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/build-optional-menu-items.ts
@@ -14,7 +14,7 @@ type BuildOptionalMenuItemsArgs = {
 	isDevVersion: boolean;
 	userIsAdmin: boolean;
 	isSiteConnected: boolean;
-	isWpcomPlatform: boolean;
+	isJetpackPluginActive: boolean;
 	onModulesClick: () => void;
 	onResetClick: () => void;
 	onResetKeyDown: ( event: KeyboardEvent ) => void;
@@ -25,14 +25,14 @@ const buildOptionalMenuItems = ( {
 	isDevVersion,
 	userIsAdmin,
 	isSiteConnected,
-	isWpcomPlatform,
+	isJetpackPluginActive,
 	onModulesClick,
 	onResetClick,
 	onResetKeyDown,
 }: BuildOptionalMenuItemsArgs ): FooterMenuItem[] => {
 	const items: FooterMenuItem[] = [];
 
-	if ( userIsAdmin && isSiteConnected && ! isWpcomPlatform ) {
+	if ( userIsAdmin && isSiteConnected && isJetpackPluginActive ) {
 		items.push( {
 			label: _x(
 				'Modules',

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -10,7 +10,8 @@ import {
 	Notice,
 	useBreakpointMatch,
 } from '@automattic/jetpack-components';
-import { __ } from '@wordpress/i18n';
+import { isWpcomPlatformSite } from '@automattic/jetpack-script-data';
+import { __, _x } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useContext, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router';
@@ -85,7 +86,7 @@ export default function MyJetpackScreen() {
 	} = getMyJetpackWindowInitialState();
 
 	const { isSectionVisible } = useEvaluationRecommendations();
-	const { apiRoot, apiNonce } = useMyJetpackConnection();
+	const { apiRoot, apiNonce, isSiteConnected } = useMyJetpackConnection();
 	const { currentNotice } = useContext( NoticeContext );
 	const {
 		message: noticeMessage,
@@ -161,12 +162,34 @@ export default function MyJetpackScreen() {
 		return null;
 	}
 
+	const modulesMenuItem = {
+		label: _x(
+			'Modules',
+			'Navigation item. Noun. Links to a list of modules for Jetpack.',
+			'jetpack-my-jetpack'
+		),
+		title: __(
+			'Access the full list of Jetpack modules available on your site.',
+			'jetpack-my-jetpack'
+		),
+		href: `${ adminUrl }admin.php?page=jetpack_modules`,
+		onClick: () => recordEvent( 'jetpack_myjetpack_footer_link_click', { link: 'modules' } ),
+	};
+
 	const resetOptionsMenuItem = {
 		label: 'Reset options (devs)',
 		role: 'button',
 		onClick: () => resetJetpackOptions(),
 		onKeyDown: e => onKeyDownCallback( e, () => resetJetpackOptions() ),
 	};
+
+	const optionalMenuItems = [];
+	if ( userIsAdmin && isSiteConnected && ! isWpcomPlatformSite() ) {
+		optionalMenuItems.push( modulesMenuItem );
+	}
+	if ( isDevVersion && userIsAdmin ) {
+		optionalMenuItems.push( resetOptionsMenuItem );
+	}
 
 	return (
 		<AdminPage
@@ -175,7 +198,7 @@ export default function MyJetpackScreen() {
 			apiRoot={ apiRoot }
 			apiNonce={ apiNonce }
 			title="Jetpack"
-			optionalMenuItems={ isDevVersion && userIsAdmin ? [ resetOptionsMenuItem ] : [] }
+			optionalMenuItems={ optionalMenuItems }
 			className={ styles[ 'my-jetpack-screen' ] }
 			showBottomBorder={ false }
 		>

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -11,7 +11,7 @@ import {
 	useBreakpointMatch,
 } from '@automattic/jetpack-components';
 import { isWpcomPlatformSite } from '@automattic/jetpack-script-data';
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useContext, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router';
@@ -36,6 +36,7 @@ import { MyJetpackTabPanel } from '../my-jetpack-tab-panel';
 import { MY_JETPACK_SECTION_OVERVIEW } from '../my-jetpack-tab-panel/constants';
 import { isValidMyJetpackSection } from '../my-jetpack-tab-panel/utils';
 import OnboardingTour from '../onboarding-tour';
+import buildOptionalMenuItems from './build-optional-menu-items';
 import styles from './styles.module.scss';
 
 const GlobalNotice = ( { message, title, options } ) => {
@@ -162,34 +163,16 @@ export default function MyJetpackScreen() {
 		return null;
 	}
 
-	const modulesMenuItem = {
-		label: _x(
-			'Modules',
-			'Navigation item. Noun. Links to a list of modules for Jetpack.',
-			'jetpack-my-jetpack'
-		),
-		title: __(
-			'Access the full list of Jetpack modules available on your site.',
-			'jetpack-my-jetpack'
-		),
-		href: `${ adminUrl }admin.php?page=jetpack_modules`,
-		onClick: () => recordEvent( 'jetpack_myjetpack_footer_link_click', { link: 'modules' } ),
-	};
-
-	const resetOptionsMenuItem = {
-		label: 'Reset options (devs)',
-		role: 'button',
-		onClick: () => resetJetpackOptions(),
-		onKeyDown: e => onKeyDownCallback( e, () => resetJetpackOptions() ),
-	};
-
-	const optionalMenuItems = [];
-	if ( userIsAdmin && isSiteConnected && ! isWpcomPlatformSite() ) {
-		optionalMenuItems.push( modulesMenuItem );
-	}
-	if ( isDevVersion && userIsAdmin ) {
-		optionalMenuItems.push( resetOptionsMenuItem );
-	}
+	const optionalMenuItems = buildOptionalMenuItems( {
+		adminUrl,
+		isDevVersion,
+		userIsAdmin,
+		isSiteConnected,
+		isWpcomPlatform: isWpcomPlatformSite(),
+		onModulesClick: () => recordEvent( 'jetpack_myjetpack_footer_link_click', { link: 'modules' } ),
+		onResetClick: () => resetJetpackOptions(),
+		onResetKeyDown: e => onKeyDownCallback( e, () => resetJetpackOptions() ),
+	} );
 
 	return (
 		<AdminPage

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -10,7 +10,6 @@ import {
 	Notice,
 	useBreakpointMatch,
 } from '@automattic/jetpack-components';
-import { isWpcomPlatformSite } from '@automattic/jetpack-script-data';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useContext, useEffect, useLayoutEffect, useRef, useState } from 'react';
@@ -84,6 +83,7 @@ export default function MyJetpackScreen() {
 		sandboxedDomain,
 		isDevVersion,
 		userIsAdmin,
+		isJetpackPluginActive,
 	} = getMyJetpackWindowInitialState();
 
 	const { isSectionVisible } = useEvaluationRecommendations();
@@ -168,7 +168,7 @@ export default function MyJetpackScreen() {
 		isDevVersion,
 		userIsAdmin,
 		isSiteConnected,
-		isWpcomPlatform: isWpcomPlatformSite(),
+		isJetpackPluginActive,
 		onModulesClick: () => recordEvent( 'jetpack_myjetpack_footer_link_click', { link: 'modules' } ),
 		onResetClick: () => resetJetpackOptions(),
 		onResetKeyDown: e => onKeyDownCallback( e, () => resetJetpackOptions() ),

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/test/build-optional-menu-items.test.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/test/build-optional-menu-items.test.ts
@@ -8,7 +8,7 @@ const baseArgs = {
 	isDevVersion: false,
 	userIsAdmin: true,
 	isSiteConnected: true,
-	isWpcomPlatform: false,
+	isJetpackPluginActive: true,
 	onModulesClick: jest.fn(),
 	onResetClick: jest.fn(),
 	onResetKeyDown: jest.fn(),
@@ -38,8 +38,8 @@ describe( 'buildOptionalMenuItems', () => {
 			expect( items.find( item => item.label === 'Modules' ) ).toBeUndefined();
 		} );
 
-		it( 'omits the Modules link on wpcom-platform sites (Simple/WoA)', () => {
-			const items = buildOptionalMenuItems( { ...baseArgs, isWpcomPlatform: true } );
+		it( 'omits the Modules link when the main Jetpack plugin is not active', () => {
+			const items = buildOptionalMenuItems( { ...baseArgs, isJetpackPluginActive: false } );
 
 			expect( items.find( item => item.label === 'Modules' ) ).toBeUndefined();
 		} );
@@ -103,7 +103,7 @@ describe( 'buildOptionalMenuItems', () => {
 			...baseArgs,
 			userIsAdmin: false,
 			isSiteConnected: false,
-			isWpcomPlatform: true,
+			isJetpackPluginActive: false,
 			isDevVersion: false,
 		} );
 

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/test/build-optional-menu-items.test.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/test/build-optional-menu-items.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @jest-environment node
+ */
+import buildOptionalMenuItems from '../build-optional-menu-items';
+
+const baseArgs = {
+	adminUrl: 'https://example.com/wp-admin/',
+	isDevVersion: false,
+	userIsAdmin: true,
+	isSiteConnected: true,
+	isWpcomPlatform: false,
+	onModulesClick: jest.fn(),
+	onResetClick: jest.fn(),
+	onResetKeyDown: jest.fn(),
+};
+
+describe( 'buildOptionalMenuItems', () => {
+	describe( 'Modules link', () => {
+		it( 'includes the Modules link for an admin on a connected self-hosted site', () => {
+			const items = buildOptionalMenuItems( baseArgs );
+
+			expect( items ).toHaveLength( 1 );
+			expect( items[ 0 ] ).toMatchObject( {
+				label: 'Modules',
+				href: 'https://example.com/wp-admin/admin.php?page=jetpack_modules',
+			} );
+		} );
+
+		it( 'omits the Modules link for non-admin users', () => {
+			const items = buildOptionalMenuItems( { ...baseArgs, userIsAdmin: false } );
+
+			expect( items.find( item => item.label === 'Modules' ) ).toBeUndefined();
+		} );
+
+		it( 'omits the Modules link when the site is not connected', () => {
+			const items = buildOptionalMenuItems( { ...baseArgs, isSiteConnected: false } );
+
+			expect( items.find( item => item.label === 'Modules' ) ).toBeUndefined();
+		} );
+
+		it( 'omits the Modules link on wpcom-platform sites (Simple/WoA)', () => {
+			const items = buildOptionalMenuItems( { ...baseArgs, isWpcomPlatform: true } );
+
+			expect( items.find( item => item.label === 'Modules' ) ).toBeUndefined();
+		} );
+
+		it( 'invokes onModulesClick when the Modules link is clicked', () => {
+			const onModulesClick = jest.fn();
+			const items = buildOptionalMenuItems( { ...baseArgs, onModulesClick } );
+
+			items[ 0 ].onClick?.();
+
+			expect( onModulesClick ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	describe( 'Reset options entry (dev only)', () => {
+		it( 'includes the Reset options entry for an admin on a dev build', () => {
+			const items = buildOptionalMenuItems( { ...baseArgs, isDevVersion: true } );
+
+			const reset = items.find( item => item.label === 'Reset options (devs)' );
+			expect( reset ).toBeDefined();
+			expect( reset?.role ).toBe( 'button' );
+		} );
+
+		it( 'omits the Reset options entry on non-dev builds', () => {
+			const items = buildOptionalMenuItems( { ...baseArgs, isDevVersion: false } );
+
+			expect( items.find( item => item.label === 'Reset options (devs)' ) ).toBeUndefined();
+		} );
+
+		it( 'omits the Reset options entry for non-admin users on a dev build', () => {
+			const items = buildOptionalMenuItems( {
+				...baseArgs,
+				isDevVersion: true,
+				userIsAdmin: false,
+			} );
+
+			expect( items.find( item => item.label === 'Reset options (devs)' ) ).toBeUndefined();
+		} );
+
+		it( 'wires onResetClick and onResetKeyDown to the Reset options entry', () => {
+			const onResetClick = jest.fn();
+			const onResetKeyDown = jest.fn();
+			const items = buildOptionalMenuItems( {
+				...baseArgs,
+				isDevVersion: true,
+				onResetClick,
+				onResetKeyDown,
+			} );
+
+			const reset = items.find( item => item.label === 'Reset options (devs)' );
+			reset?.onClick?.();
+			reset?.onKeyDown?.( { key: 'Enter' } as unknown as KeyboardEvent );
+
+			expect( onResetClick ).toHaveBeenCalledTimes( 1 );
+			expect( onResetKeyDown ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	it( 'returns an empty array when nothing applies', () => {
+		const items = buildOptionalMenuItems( {
+			...baseArgs,
+			userIsAdmin: false,
+			isSiteConnected: false,
+			isWpcomPlatform: true,
+			isDevVersion: false,
+		} );
+
+		expect( items ).toEqual( [] );
+	} );
+} );

--- a/projects/packages/my-jetpack/changelog/add-modules-footer-link
+++ b/projects/packages/my-jetpack/changelog/add-modules-footer-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+My Jetpack: add Modules link to the footer for admins on connected, non-WordPress.com sites.

--- a/projects/packages/my-jetpack/changelog/add-modules-footer-link
+++ b/projects/packages/my-jetpack/changelog/add-modules-footer-link
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-My Jetpack: add Modules link to the footer for admins on connected, non-WordPress.com sites.
+My Jetpack: add Modules link to the footer for admins on connected sites running the main Jetpack plugin.

--- a/projects/packages/my-jetpack/global.d.ts
+++ b/projects/packages/my-jetpack/global.d.ts
@@ -642,6 +642,7 @@ interface Window {
 		};
 		topJetpackMenuItemUrl: string;
 		isAtomic: boolean;
+		isJetpackPluginActive: boolean;
 		sandboxedDomain: string;
 		isDevVersion: boolean;
 		userIsAdmin: string;

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -326,6 +326,7 @@ class Initializer {
 				'sandboxedDomain'        => $sandboxed_domain,
 				'isDevVersion'           => $is_dev_version,
 				'isAtomic'               => ( new Status_Host() )->is_woa_site(),
+				'isJetpackPluginActive'  => class_exists( 'Jetpack' ),
 				'latestBoostSpeedScores' => $latest_score,
 			)
 		);

--- a/projects/packages/my-jetpack/tests/jest.setup.js
+++ b/projects/packages/my-jetpack/tests/jest.setup.js
@@ -1,9 +1,10 @@
-window.JP_CONNECTION_INITIAL_STATE = {
+const globalScope = typeof window !== 'undefined' ? window : globalThis;
+globalScope.JP_CONNECTION_INITIAL_STATE = {
 	userConnectionData: {
 		currentUser: {
 			wpcomUser: { Id: 99999, login: 'bobsacramento', display_name: 'Bob Sacrmaneto' },
 		},
 	},
 };
-window.myJetpackInitialState = {};
-window.myJetpackRest = {};
+globalScope.myJetpackInitialState = {};
+globalScope.myJetpackRest = {};


### PR DESCRIPTION
## Proposed changes

- Adds a new "Modules" item to the My Jetpack footer's optional menu. The link points to the legacy Jetpack modules admin page (`admin.php?page=jetpack_modules`).
- The item is only shown when all of the following are true: the current user is an admin, the site is connected, and the site is not a WordPress.com platform site.
- Tracks clicks via `jetpack_myjetpack_footer_link_click` with `link: 'modules'`.
- Keeps the existing dev-only "Reset options" item. Both items are now composed into a single `optionalMenuItems` array passed to `AdminPage`.

## Does this pull request change what data or activity we track or use?

Adds a new tracks event name/property pair:

- Event: `jetpack_myjetpack_footer_link_click`
- Property: `link: 'modules'`

No new user data is collected; this follows the existing footer-link tracking pattern.

## Testing instructions

1. Install/activate Jetpack on a self-hosted site connected to WordPress.com.
2. Log in as an admin and visit My Jetpack (admin.php?page=my-jetpack).
3. Scroll to the footer and confirm the "Modules" link is visible.
4. Click it and confirm it navigates to the Jetpack modules page (admin.php?page=jetpack_modules).
5. Confirm the tracks event jetpack_myjetpack_footer_link_click fires with link: 'modules'.
6. As a non-admin user, confirm the link is not shown.
7. On a disconnected site or a WordPress.com platform (Simple/Atomic) site, confirm the link is not shown.
8. In a dev build, confirm the "Reset options" item still appears alongside "Modules".
