### PR TITLE
Write: Replace highlight-to-format with persistent top toolbar

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-persistent-top-toolbar
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-persistent-top-toolbar
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Write: Replace highlight-to-format floating toolbar with a persistent top toolbar.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -14,7 +14,7 @@
 	top: 0;
 	left: 0;
 	right: 0;
-	z-index: 100;
+	z-index: 100000;
 	height: 56px;
 	background: #fff;
 	border-bottom: 1px solid #f0f0f0;
@@ -171,9 +171,264 @@
 	background: #1a5f99;
 }
 
+/* ===== Persistent formatting toolbar ===== */
+.bw-toolbar {
+	position: fixed;
+	top: 56px;
+	left: 0;
+	right: 0;
+	z-index: 99999;
+	background: #fff;
+	border-bottom: 1px solid #f0f0f0;
+	height: 44px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+
+.bw-toolbar-scroll {
+	display: flex;
+	align-items: center;
+	gap: 2px;
+	padding: 0 16px;
+	max-width: 720px;
+}
+
+@keyframes bw-fade-in {
+
+	from {
+		opacity: 0;
+		transform: translateY(4px);
+	}
+
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+.bw-tool {
+	width: 34px;
+	height: 34px;
+	border: none;
+	border-radius: 6px;
+	background: transparent;
+	color: #555;
+	font-size: 15px;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	transition: all 0.1s ease;
+	flex-shrink: 0;
+}
+
+.bw-tool .dashicons {
+	font-size: 18px;
+	width: 18px;
+	height: 18px;
+	line-height: 18px;
+}
+
+.bw-tool:hover {
+	background: #f0f0f0;
+	color: #1a1a1a;
+}
+
+.bw-tool-active {
+	background: #e8e8e8;
+	color: #1a1a1a;
+}
+
+.bw-tool-divider {
+	width: 1px;
+	height: 20px;
+	background: #e0e0e0;
+	margin: 0 4px;
+	flex-shrink: 0;
+}
+
+/* Heading dropdown toggle */
+.bw-tool-heading-toggle {
+	width: auto;
+	padding: 0 8px;
+	gap: 4px;
+	font-size: 13px;
+	font-weight: 500;
+	white-space: nowrap;
+}
+
+.bw-tool-label {
+	font-size: 13px;
+	font-weight: 500;
+}
+
+.bw-tool-caret {
+	font-size: 10px;
+	color: #999;
+}
+
+/* Dropdown wrapper (for heading and color menus) */
+.bw-tool-dropdown-wrap {
+	position: relative;
+	flex-shrink: 0;
+}
+
+/* Heading menu dropdown */
+.bw-heading-menu {
+	position: absolute;
+	top: 100%;
+	left: 0;
+	margin-top: 4px;
+	z-index: 210;
+	background: #fff;
+	border-radius: 8px;
+	padding: 4px;
+	min-width: 160px;
+	box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+	border: 1px solid #f0f0f0;
+}
+
+.bw-heading-menu:not([hidden]) {
+	animation: bw-fade-in 0.12s ease;
+}
+
+.bw-heading-menu[hidden] {
+	display: none;
+}
+
+.bw-heading-option {
+	display: block;
+	width: 100%;
+	padding: 8px 12px;
+	border: none;
+	border-radius: 6px;
+	background: transparent;
+	text-align: start;
+	cursor: pointer;
+	font-family: inherit;
+	font-size: 14px;
+	color: #333;
+	transition: background 0.1s ease;
+}
+
+.bw-heading-option:hover {
+	background: #f5f5f5;
+}
+
+.bw-heading-option-h2 span {
+	font-size: 18px;
+	font-weight: 700;
+}
+
+.bw-heading-option-h3 span {
+	font-size: 15px;
+	font-weight: 700;
+}
+
+/* Text color menu */
+.bw-color-menu {
+	position: absolute;
+	top: 100%;
+	left: 50%;
+	transform: translateX(-50%);
+	margin-top: 4px;
+	z-index: 210;
+	background: #fff;
+	border-radius: 8px;
+	padding: 8px;
+	display: flex;
+	gap: 6px;
+	box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+	border: 1px solid #f0f0f0;
+}
+
+.bw-color-menu:not([hidden]) {
+	animation: bw-fade-in 0.12s ease;
+}
+
+.bw-color-menu[hidden] {
+	display: none;
+}
+
+.bw-color-swatch {
+	width: 24px;
+	height: 24px;
+	border-radius: 50%;
+	border: 2px solid #fff;
+	cursor: pointer;
+	transition: transform 0.1s ease, box-shadow 0.1s ease;
+	box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+}
+
+.bw-color-swatch:hover {
+	transform: scale(1.15);
+	box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.2);
+}
+
+/* ===== Link popover (below toolbar) ===== */
+.bw-link-popover {
+	position: fixed;
+	top: 100px;
+	left: 50%;
+	transform: translateX(-50%);
+	z-index: 201;
+	background: #fff;
+	border-radius: 8px;
+	padding: 8px;
+	box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	animation: bw-fade-in 0.12s ease;
+}
+
+.bw-link-popover[hidden] {
+	display: none;
+}
+
+.bw-link-input {
+	border: 1px solid #ddd;
+	border-radius: 6px;
+	padding: 6px 10px;
+	font-size: 14px;
+	outline: none;
+	width: 280px;
+	font-family: inherit;
+}
+
+.bw-link-input:focus {
+	border-color: #2171b1;
+}
+
+.bw-link-apply {
+	border: none;
+	background: #2171b1;
+	color: #fff;
+	border-radius: 6px;
+	padding: 6px 12px;
+	font-size: 13px;
+	font-weight: 500;
+	cursor: pointer;
+}
+
+.bw-link-remove {
+	border: none;
+	background: transparent;
+	color: #999;
+	font-size: 18px;
+	cursor: pointer;
+	padding: 4px 8px;
+}
+
+.bw-link-remove:hover {
+	color: #d63638;
+}
+
 /* ===== Main writing area ===== */
 .bw-main {
-	padding-top: 96px;
+	padding-top: 120px;
 	padding-bottom: 40vh;
 	display: flex;
 	justify-content: center;
@@ -515,6 +770,28 @@
 	font-style: italic;
 }
 
+.bw-content s,
+.bw-content strike {
+	text-decoration: line-through;
+}
+
+.bw-content u {
+	text-decoration: underline;
+	text-underline-offset: 2px;
+}
+
+/* Lists in content */
+.bw-content ul,
+.bw-content ol {
+	margin: 0 0 1.25em;
+	padding-inline-start: 1.5em;
+}
+
+.bw-content li {
+	margin-bottom: 0.25em;
+	line-height: inherit;
+}
+
 /* Images in content */
 .bw-content figure,
 .bw-content .bw-image-figure {
@@ -687,132 +964,6 @@
 	width: 100%;
 	height: 100%;
 	border: none;
-}
-
-/* ===== Floating formatting toolbar ===== */
-.bw-toolbar {
-	position: absolute;
-	z-index: 200;
-	background: #1e1e1e;
-	border-radius: 8px;
-	padding: 4px;
-	display: flex;
-	align-items: center;
-	gap: 2px;
-	box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
-	animation: bw-fade-in 0.12s ease;
-}
-
-.bw-toolbar[hidden] {
-	display: none;
-}
-
-@keyframes bw-fade-in {
-
-	from {
-		opacity: 0;
-		transform: translateY(4px);
-	}
-
-	to {
-		opacity: 1;
-		transform: translateY(0);
-	}
-}
-
-.bw-tool {
-	width: 34px;
-	height: 34px;
-	border: none;
-	border-radius: 6px;
-	background: transparent;
-	color: #ccc;
-	font-size: 15px;
-	cursor: pointer;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	transition: all 0.1s ease;
-}
-
-.bw-tool .dashicons {
-	font-size: 18px;
-	width: 18px;
-	height: 18px;
-	line-height: 18px;
-}
-
-.bw-tool:hover {
-	background: #333;
-	color: #fff;
-}
-
-.bw-tool-active {
-	background: #444;
-	color: #fff;
-}
-
-.bw-tool-divider {
-	width: 1px;
-	height: 20px;
-	background: #444;
-	margin: 0 4px;
-}
-
-/* ===== Link popover ===== */
-.bw-link-popover {
-	position: absolute;
-	z-index: 201;
-	background: #fff;
-	border-radius: 8px;
-	padding: 8px;
-	box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
-	display: flex;
-	align-items: center;
-	gap: 6px;
-	animation: bw-fade-in 0.12s ease;
-}
-
-.bw-link-popover[hidden] {
-	display: none;
-}
-
-.bw-link-input {
-	border: 1px solid #ddd;
-	border-radius: 6px;
-	padding: 6px 10px;
-	font-size: 14px;
-	outline: none;
-	width: 240px;
-	font-family: inherit;
-}
-
-.bw-link-input:focus {
-	border-color: #2171b1;
-}
-
-.bw-link-apply {
-	border: none;
-	background: #2171b1;
-	color: #fff;
-	border-radius: 6px;
-	padding: 6px 12px;
-	font-size: 13px;
-	font-weight: 500;
-	cursor: pointer;
-}
-
-.bw-link-remove {
-	border: none;
-	background: transparent;
-	color: #999;
-	font-size: 18px;
-	cursor: pointer;
-	padding: 4px 8px;
-}
-
-.bw-link-remove:hover {
-	color: #d63638;
 }
 
 /* ===== Image modal ===== */
@@ -1103,5 +1254,49 @@
 
 	.bw-btn-draft {
 		display: none;
+	}
+
+	/* Toolbar scrolls horizontally on mobile */
+	.bw-toolbar-scroll {
+		justify-content: flex-start;
+		padding: 0 12px;
+		overflow-x: auto;
+		-webkit-overflow-scrolling: touch;
+		scrollbar-width: none;
+	}
+
+	.bw-toolbar-scroll::-webkit-scrollbar {
+		display: none;
+	}
+
+	/* Escape the overflow scroll container on mobile */
+	.bw-heading-menu {
+		position: fixed;
+		top: 104px;
+		left: 16px;
+		transform: none;
+		margin-top: 0;
+	}
+
+	.bw-color-menu {
+		position: fixed;
+		top: 104px;
+		right: 16px;
+		left: auto;
+		transform: none;
+		margin-top: 0;
+	}
+
+	/* Link popover adapts to mobile width */
+	.bw-link-popover {
+		left: 16px;
+		right: 16px;
+		transform: none;
+		width: auto;
+	}
+
+	.bw-link-input {
+		width: 100%;
+		flex: 1;
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -1300,12 +1300,17 @@
 		margin-top: 0;
 	}
 
+	.bw-color-menu:not([hidden]) {
+		animation: bw-fade-in 0.12s ease;
+	}
+
 	/* Link popover adapts to mobile width */
 	.bw-link-popover {
 		left: 16px;
 		right: 16px;
 		transform: none;
 		width: auto;
+		animation: bw-fade-in 0.12s ease;
 	}
 
 	.bw-link-input {

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -208,6 +208,19 @@
 	}
 }
 
+@keyframes bw-fade-in-centered {
+
+	from {
+		opacity: 0;
+		transform: translateX(-50%) translateY(4px);
+	}
+
+	to {
+		opacity: 1;
+		transform: translateX(-50%) translateY(0);
+	}
+}
+
 .bw-tool {
 	width: 34px;
 	height: 34px;
@@ -345,7 +358,7 @@
 }
 
 .bw-color-menu:not([hidden]) {
-	animation: bw-fade-in 0.12s ease;
+	animation: bw-fade-in-centered 0.12s ease;
 }
 
 .bw-color-menu[hidden] {
@@ -381,7 +394,7 @@
 	display: flex;
 	align-items: center;
 	gap: 6px;
-	animation: bw-fade-in 0.12s ease;
+	animation: bw-fade-in-centered 0.12s ease;
 }
 
 .bw-link-popover[hidden] {

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -278,7 +278,7 @@
 }
 
 .bw-tool-caret {
-	font-size: 10px;
+	font-size: 12px;
 	color: #999;
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -16,6 +16,7 @@ let savedRange = null;
 // Stored references for dropdown close handlers to prevent listener leaks.
 let headingMenuCloseHandler = null;
 let textColorMenuCloseHandler = null;
+let linkPopoverCloseHandler = null;
 
 /**
  * Save the current text selection so it can be restored after a modal closes.
@@ -978,6 +979,11 @@ const { state } = store( 'wpcom-write', {
 		// --- Link ---
 
 		toggleLinkInput() {
+			// Always clean up any existing listener first.
+			if ( linkPopoverCloseHandler ) {
+				document.removeEventListener( 'click', linkPopoverCloseHandler );
+				linkPopoverCloseHandler = null;
+			}
 			if ( state.showLinkInput ) {
 				state.showLinkInput = false;
 				return;
@@ -1009,12 +1015,17 @@ const { state } = store( 'wpcom-write', {
 			} );
 
 			// Close when clicking outside the popover.
-			const closeLink = e => {
-				if ( e.target.closest( '.bw-link-popover' ) ) return;
+			linkPopoverCloseHandler = e => {
+				if (
+					e.target.closest( '.bw-link-popover' ) ||
+					e.target.closest( '[data-wp-on--click="actions.toggleLinkInput"]' )
+				)
+					return;
 				state.showLinkInput = false;
-				document.removeEventListener( 'click', closeLink );
+				document.removeEventListener( 'click', linkPopoverCloseHandler );
+				linkPopoverCloseHandler = null;
 			};
-			setTimeout( () => document.addEventListener( 'click', closeLink ), 0 );
+			setTimeout( () => document.addEventListener( 'click', linkPopoverCloseHandler ), 0 );
 		},
 
 		updateLinkUrl() {

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -39,9 +39,52 @@ function restoreSelection() {
  * @param {string} html - The innerHTML from the contenteditable area.
  * @return {string} Serialized Gutenberg block markup.
  */
+/**
+ * Normalize color markup from contentEditable before block serialization.
+ *
+ * The foreColor command creates <font color="..."> (legacy) or
+ * <span style="color:..."> (modern). Convert both to clean <span> elements
+ * with inline styles, and strip the default text color (#333333).
+ *
+ * @param {HTMLElement} container - The container to normalize in place.
+ */
+function normalizeColorMarkup( container ) {
+	// Convert <font color="..."> to <span style="color:...">.
+	container.querySelectorAll( 'font[color]' ).forEach( font => {
+		const color = font.getAttribute( 'color' );
+		const span = document.createElement( 'span' );
+		// Skip default color — unwrap the element entirely.
+		if ( color && color.toLowerCase() !== '#333333' ) {
+			span.style.color = color;
+		}
+		span.innerHTML = font.innerHTML;
+		font.replaceWith( span );
+	} );
+
+	// Strip default-colored spans (unwrap them, keeping their content).
+	container.querySelectorAll( 'span' ).forEach( span => {
+		const color = span.style.color;
+		if ( ! color ) return;
+		// Detect default color in various formats.
+		const isDefault = color === '#333333' || color === '#333' || color === 'rgb(51, 51, 51)';
+		if ( isDefault ) {
+			span.replaceWith( ...span.childNodes );
+		}
+	} );
+}
+
+/**
+ * Convert contentEditable HTML into WordPress block markup.
+ *
+ * @param {string} html - The innerHTML from the contenteditable area.
+ * @return {string} Serialized Gutenberg block markup.
+ */
 function convertToBlocks( html ) {
 	const tmp = document.createElement( 'div' );
 	tmp.innerHTML = html;
+
+	// Normalize color markup before serialization.
+	normalizeColorMarkup( tmp );
 
 	const blocks = [];
 
@@ -61,12 +104,23 @@ function convertToBlocks( html ) {
 
 		if ( ! inner && ! [ 'figure', 'img', 'hr' ].includes( tag ) ) continue;
 
+		// Check for text alignment.
+		const align = node.style && node.style.textAlign;
+		const alignAttr =
+			align && [ 'center', 'right' ].includes( align ) ? ` style="text-align:${ align }"` : '';
+		const alignJson =
+			align && [ 'center', 'right' ].includes( align ) ? `,"align":"${ align }"` : '';
+
 		if ( tag === 'p' || tag === 'div' ) {
-			blocks.push( `<!-- wp:paragraph -->\n<p>${ inner }</p>\n<!-- /wp:paragraph -->` );
+			blocks.push(
+				`<!-- wp:paragraph${
+					alignJson ? ` {${ alignJson.slice( 1 ) }}` : ''
+				} -->\n<p${ alignAttr }>${ inner }</p>\n<!-- /wp:paragraph -->`
+			);
 		} else if ( /^h[1-6]$/.test( tag ) ) {
 			const level = parseInt( tag.charAt( 1 ), 10 );
 			blocks.push(
-				`<!-- wp:heading {"level":${ level }} -->\n<${ tag } class="wp-block-heading">${ inner }</${ tag }>\n<!-- /wp:heading -->`
+				`<!-- wp:heading {"level":${ level }${ alignJson }} -->\n<${ tag } class="wp-block-heading"${ alignAttr }>${ inner }</${ tag }>\n<!-- /wp:heading -->`
 			);
 		} else if ( tag === 'figure' && node.querySelector( 'iframe' ) ) {
 			const iframe = node.querySelector( 'iframe' );
@@ -97,6 +151,14 @@ function convertToBlocks( html ) {
 			blocks.push(
 				`<!-- wp:quote -->\n<blockquote class="wp-block-quote">${ quoteInner }</blockquote>\n<!-- /wp:quote -->`
 			);
+		} else if ( tag === 'ul' ) {
+			blocks.push(
+				`<!-- wp:list -->\n<ul class="wp-block-list">${ inner }</ul>\n<!-- /wp:list -->`
+			);
+		} else if ( tag === 'ol' ) {
+			blocks.push(
+				`<!-- wp:list {"ordered":true} -->\n<ol class="wp-block-list">${ inner }</ol>\n<!-- /wp:list -->`
+			);
 		} else if ( tag === 'hr' ) {
 			blocks.push(
 				'<!-- wp:separator -->\n<hr class="wp-block-separator has-alpha-channel-opacity"/>\n<!-- /wp:separator -->'
@@ -108,28 +170,6 @@ function convertToBlocks( html ) {
 	}
 
 	return blocks.join( '\n\n' );
-}
-
-/**
- * Position the toolbar near the current text selection.
- */
-function positionToolbar() {
-	const sel = window.getSelection();
-	if ( ! sel.rangeCount ) return;
-
-	const toolbar = document.querySelector( '.bw-toolbar' );
-	if ( ! toolbar ) return;
-
-	const range = sel.getRangeAt( 0 );
-	const rect = range.getBoundingClientRect();
-	const toolbarWidth = toolbar.offsetWidth;
-	let left = rect.left + rect.width / 2 - toolbarWidth / 2;
-	left = Math.max( 8, Math.min( left, window.innerWidth - toolbarWidth - 8 ) );
-	const top = rect.top - 52 + window.scrollY;
-
-	toolbar.style.position = 'absolute';
-	toolbar.style.left = left + 'px';
-	toolbar.style.top = top + 'px';
 }
 
 /**
@@ -333,7 +373,7 @@ const contentReady2 = setInterval( () => {
 	}
 }, 200 );
 
-// Watch for new figures being added.
+// Watch for new figures being added, and set up paste-to-link.
 if ( typeof MutationObserver !== 'undefined' ) {
 	const contentReady = setInterval( () => {
 		const content = document.querySelector( '.bw-content' );
@@ -341,6 +381,18 @@ if ( typeof MutationObserver !== 'undefined' ) {
 		clearInterval( contentReady );
 		addDeleteButtons();
 		new MutationObserver( addDeleteButtons ).observe( content, { childList: true, subtree: true } );
+
+		// Highlight text + paste URL → create a link.
+		content.addEventListener( 'paste', event => {
+			const sel = window.getSelection();
+			if ( ! sel.rangeCount || sel.isCollapsed ) return;
+
+			const pasted = event.clipboardData.getData( 'text/plain' );
+			if ( pasted && /^https?:\/\/\S+$/i.test( pasted.trim() ) ) {
+				event.preventDefault();
+				document.execCommand( 'createLink', false, pasted.trim() );
+			}
+		} );
 	}, 200 );
 }
 
@@ -431,6 +483,101 @@ function insertNewBlock( tag ) {
 	state.showSlashMenu = false;
 }
 
+/**
+ * Detect the current formatting state at the cursor position.
+ * Updates all toolbar button states.
+ */
+function updateFormattingState() {
+	state.formatBold = document.queryCommandState( 'bold' );
+	state.formatItalic = document.queryCommandState( 'italic' );
+	state.formatUnderline = document.queryCommandState( 'underline' );
+	state.formatStrikethrough = document.queryCommandState( 'strikeThrough' );
+	state.formatOList = document.queryCommandState( 'insertOrderedList' );
+	state.formatUList = document.queryCommandState( 'insertUnorderedList' );
+
+	// Check block-level formatting by walking up from cursor.
+	const sel = window.getSelection();
+	state.formatHeading = false;
+	state.formatQuote = false;
+	state.headingLabel = 'Normal';
+	state.formatAlignLeft = true;
+	state.formatAlignCenter = false;
+	state.formatAlignRight = false;
+
+	if ( sel.rangeCount ) {
+		let node = sel.anchorNode;
+		while ( node && node !== document.body ) {
+			if ( node.nodeType === Node.ELEMENT_NODE ) {
+				if ( node.tagName === 'H2' ) {
+					state.formatHeading = true;
+					state.headingLabel = 'Heading 2';
+				} else if ( node.tagName === 'H3' ) {
+					state.formatHeading = true;
+					state.headingLabel = 'Heading 3';
+				} else if ( /^H[1-6]$/.test( node.tagName ) ) {
+					state.formatHeading = true;
+				}
+				if ( node.tagName === 'BLOCKQUOTE' ) {
+					state.formatQuote = true;
+				}
+				// Detect alignment from the nearest block element.
+				if ( /^(P|H[1-6]|DIV|BLOCKQUOTE)$/.test( node.tagName ) && node.style.textAlign ) {
+					const align = node.style.textAlign;
+					state.formatAlignLeft = align === 'left' || align === 'start' || align === '';
+					state.formatAlignCenter = align === 'center';
+					state.formatAlignRight = align === 'right';
+				}
+			}
+			node = node.parentNode;
+		}
+	}
+}
+
+/**
+ * Position a dropdown menu precisely on mobile by calculating from the toolbar.
+ *
+ * On mobile, dropdown menus use position:fixed to escape the overflow:auto
+ * scroll container. This calculates the correct top position from the toolbar.
+ *
+ * @param {string} selector - CSS selector for the dropdown menu.
+ */
+function positionDropdownOnMobile( selector ) {
+	if ( window.innerWidth > 768 ) return;
+
+	requestAnimationFrame( () => {
+		const menu = document.querySelector( selector );
+		const toolbar = document.querySelector( '.bw-toolbar' );
+		if ( ! menu || ! toolbar ) return;
+
+		const toolbarRect = toolbar.getBoundingClientRect();
+		menu.style.top = toolbarRect.bottom + 4 + 'px';
+	} );
+}
+
+/**
+ * Clean up stray <div> elements created by justify commands.
+ *
+ * Some browsers wrap content in a <div> when using justifyLeft/Center/Right
+ * instead of applying text-align to the existing block. This replaces those
+ * divs with <p> elements carrying the same text-align style.
+ */
+function cleanupAlignmentDivs() {
+	const content = document.querySelector( '.bw-content' );
+	if ( ! content ) return;
+
+	content.querySelectorAll( ':scope > div' ).forEach( div => {
+		// Skip intentional divs (image controls, etc.).
+		if ( div.classList.length > 0 ) return;
+
+		const p = document.createElement( 'p' );
+		if ( div.style.textAlign ) {
+			p.style.textAlign = div.style.textAlign;
+		}
+		p.innerHTML = div.innerHTML;
+		div.replaceWith( p );
+	} );
+}
+
 const { state } = store( 'wpcom-write', {
 	state: {
 		formatBold: false,
@@ -438,6 +585,7 @@ const { state } = store( 'wpcom-write', {
 		formatHeading: false,
 		formatQuote: false,
 		imageUrl: '',
+		headingLabel: 'Normal',
 	},
 
 	actions: {
@@ -492,35 +640,19 @@ const { state } = store( 'wpcom-write', {
 			const { actions } = store( 'wpcom-write' );
 			actions.checkSlashCommand();
 
-			const sel = window.getSelection();
-			const text = sel.toString().trim();
-
-			if ( ! text ) {
-				state.showToolbar = false;
-				state.showLinkInput = false;
-				return;
-			}
-
-			state.formatBold = document.queryCommandState( 'bold' );
-			state.formatItalic = document.queryCommandState( 'italic' );
-
-			// Check if inside a heading or blockquote.
-			let node = sel.anchorNode;
-			state.formatHeading = false;
-			state.formatQuote = false;
-			while ( node && node !== document.body ) {
-				if ( node.nodeType === Node.ELEMENT_NODE ) {
-					if ( /^H[1-6]$/.test( node.tagName ) ) state.formatHeading = true;
-					if ( node.tagName === 'BLOCKQUOTE' ) state.formatQuote = true;
-				}
-				node = node.parentNode;
-			}
-
-			state.showToolbar = true;
-			requestAnimationFrame( positionToolbar );
+			// Update all formatting button states based on cursor position.
+			updateFormattingState();
 		},
 
 		handleKeyDown( event ) {
+			// Ctrl+K / Cmd+K to toggle link input.
+			if ( ( event.ctrlKey || event.metaKey ) && event.key === 'k' ) {
+				event.preventDefault();
+				const { actions: a } = store( 'wpcom-write' );
+				a.toggleLinkInput();
+				return;
+			}
+
 			// Slash menu keyboard navigation.
 			if ( state.showSlashMenu ) {
 				if ( event.key === 'Escape' ) {
@@ -660,6 +792,8 @@ const { state } = store( 'wpcom-write', {
 			event.preventDefault();
 		},
 
+		// --- Inline formatting ---
+
 		formatBold() {
 			document.execCommand( 'bold' );
 			state.formatBold = document.queryCommandState( 'bold' );
@@ -670,16 +804,129 @@ const { state } = store( 'wpcom-write', {
 			state.formatItalic = document.queryCommandState( 'italic' );
 		},
 
-		formatHeading() {
-			if ( state.formatHeading ) {
-				document.execCommand( 'formatBlock', false, 'p' );
-				state.formatHeading = false;
-			} else {
-				document.execCommand( 'formatBlock', false, 'h2' );
-				state.formatHeading = true;
-				state.formatQuote = false;
+		formatUnderline() {
+			document.execCommand( 'underline' );
+			state.formatUnderline = document.queryCommandState( 'underline' );
+		},
+
+		formatStrikethrough() {
+			document.execCommand( 'strikeThrough' );
+			state.formatStrikethrough = document.queryCommandState( 'strikeThrough' );
+		},
+
+		// --- Text color ---
+
+		toggleTextColorMenu() {
+			state.showTextColorMenu = ! state.showTextColorMenu;
+			state.showHeadingMenu = false;
+			if ( state.showTextColorMenu ) {
+				positionDropdownOnMobile( '.bw-color-menu' );
 			}
 		},
+
+		setTextColorDefault() {
+			// Use foreColor with the default text color instead of removeFormat,
+			// which would strip all inline formatting (bold, italic, etc.).
+			document.execCommand( 'foreColor', false, '#333333' );
+			state.showTextColorMenu = false;
+		},
+
+		setTextColorRed() {
+			document.execCommand( 'foreColor', false, '#d63638' );
+			state.showTextColorMenu = false;
+		},
+
+		setTextColorBlue() {
+			document.execCommand( 'foreColor', false, '#2171b1' );
+			state.showTextColorMenu = false;
+		},
+
+		setTextColorGreen() {
+			document.execCommand( 'foreColor', false, '#00a32a' );
+			state.showTextColorMenu = false;
+		},
+
+		setTextColorYellow() {
+			document.execCommand( 'foreColor', false, '#dba617' );
+			state.showTextColorMenu = false;
+		},
+
+		setTextColorPurple() {
+			document.execCommand( 'foreColor', false, '#8c5db0' );
+			state.showTextColorMenu = false;
+		},
+
+		// --- Heading dropdown ---
+
+		toggleHeadingMenu() {
+			state.showHeadingMenu = ! state.showHeadingMenu;
+			state.showTextColorMenu = false;
+			if ( state.showHeadingMenu ) {
+				positionDropdownOnMobile( '.bw-heading-menu' );
+			}
+		},
+
+		setHeadingNormal() {
+			document.execCommand( 'formatBlock', false, 'p' );
+			state.formatHeading = false;
+			state.showHeadingMenu = false;
+		},
+
+		setHeadingH2() {
+			document.execCommand( 'formatBlock', false, 'h2' );
+			state.formatHeading = true;
+			state.formatQuote = false;
+			state.showHeadingMenu = false;
+		},
+
+		setHeadingH3() {
+			document.execCommand( 'formatBlock', false, 'h3' );
+			state.formatHeading = true;
+			state.formatQuote = false;
+			state.showHeadingMenu = false;
+		},
+
+		// --- Alignment ---
+
+		alignLeft() {
+			document.execCommand( 'justifyLeft' );
+			cleanupAlignmentDivs();
+			state.formatAlignLeft = true;
+			state.formatAlignCenter = false;
+			state.formatAlignRight = false;
+		},
+
+		alignCenter() {
+			document.execCommand( 'justifyCenter' );
+			cleanupAlignmentDivs();
+			state.formatAlignLeft = false;
+			state.formatAlignCenter = true;
+			state.formatAlignRight = false;
+		},
+
+		alignRight() {
+			document.execCommand( 'justifyRight' );
+			cleanupAlignmentDivs();
+			state.formatAlignLeft = false;
+			state.formatAlignCenter = false;
+			state.formatAlignRight = true;
+		},
+
+		// --- Lists ---
+
+		formatUList() {
+			document.execCommand( 'insertUnorderedList' );
+			state.formatUList = document.queryCommandState( 'insertUnorderedList' );
+			state.formatOList = document.queryCommandState( 'insertOrderedList' );
+		},
+
+		formatOList() {
+			document.execCommand( 'insertOrderedList' );
+			state.formatOList = document.queryCommandState( 'insertOrderedList' );
+			state.formatUList = document.queryCommandState( 'insertUnorderedList' );
+		},
+
+		// --- Block formatting ---
 
 		formatQuote() {
 			if ( state.formatQuote ) {
@@ -691,6 +938,8 @@ const { state } = store( 'wpcom-write', {
 				state.formatHeading = false;
 			}
 		},
+
+		// --- Link ---
 
 		toggleLinkInput() {
 			if ( state.showLinkInput ) {
@@ -715,18 +964,10 @@ const { state } = store( 'wpcom-write', {
 
 			state.showLinkInput = true;
 
-			// Position the link popover below the toolbar.
+			// Focus the link input.
 			requestAnimationFrame( () => {
-				const toolbar = document.querySelector( '.bw-toolbar' );
 				const popover = document.querySelector( '.bw-link-popover' );
-				if ( ! toolbar || ! popover ) return;
-
-				const rect = toolbar.getBoundingClientRect();
-				popover.style.position = 'absolute';
-				popover.style.left = toolbar.style.left;
-				popover.style.top = rect.bottom + 8 + window.scrollY + 'px';
-
-				// Focus the input.
+				if ( ! popover ) return;
 				const input = popover.querySelector( '.bw-link-input' );
 				if ( input ) input.focus();
 			} );
@@ -745,12 +986,15 @@ const { state } = store( 'wpcom-write', {
 					document.execCommand( 'createLink', false, state.linkUrl );
 				}
 				state.showLinkInput = false;
-				state.showToolbar = false;
+				// Refocus content area.
+				const content = document.querySelector( '.bw-content' );
+				if ( content ) content.focus();
 			}
 			if ( event.key === 'Escape' ) {
 				event.preventDefault();
 				state.showLinkInput = false;
-				state.showToolbar = false;
+				const content = document.querySelector( '.bw-content' );
+				if ( content ) content.focus();
 			}
 		},
 
@@ -760,15 +1004,15 @@ const { state } = store( 'wpcom-write', {
 				document.execCommand( 'createLink', false, state.linkUrl );
 			}
 			state.showLinkInput = false;
-			state.showToolbar = false;
 		},
 
 		removeLink() {
 			restoreSelection();
 			document.execCommand( 'unlink' );
 			state.showLinkInput = false;
-			state.showToolbar = false;
 		},
+
+		// --- Image ---
 
 		toggleFeaturedImage() {
 			state.setAsFeatured = ! state.setAsFeatured;
@@ -781,7 +1025,6 @@ const { state } = store( 'wpcom-write', {
 
 		openImageModal() {
 			saveSelection();
-			state.showToolbar = false;
 			state.imageUrl = '';
 			state.imageAlt = '';
 			state.setAsFeatured = false;
@@ -906,6 +1149,8 @@ const { state } = store( 'wpcom-write', {
 				}, 3000 );
 			}
 		},
+
+		// --- Slash commands ---
 
 		insertHeading() {
 			insertNewBlock( 'h2' );
@@ -1035,6 +1280,8 @@ const { state } = store( 'wpcom-write', {
 			}
 			state.showSlashMenu = false;
 		},
+
+		// --- UI toggles ---
 
 		toggleHelp() {
 			state.showHelp = ! state.showHelp;

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -13,6 +13,10 @@ import { store, getElement, getContext } from '@wordpress/interactivity';
 // Save/restore the selection so we can insert images after the modal closes.
 let savedRange = null;
 
+// Stored references for dropdown close handlers to prevent listener leaks.
+let headingMenuCloseHandler = null;
+let textColorMenuCloseHandler = null;
+
 /**
  * Save the current text selection so it can be restored after a modal closes.
  */
@@ -38,7 +42,7 @@ function restoreSelection() {
  *
  * The foreColor command creates <font color="..."> (legacy) or
  * <span style="color:..."> (modern). Convert both to clean <span> elements
- * with inline styles, and strip the default text color (#333333).
+ * with inline styles, and strip the default text color (#1a1a1a).
  *
  * @param {HTMLElement} container - The container to normalize in place.
  */
@@ -48,7 +52,7 @@ function normalizeColorMarkup( container ) {
 		const color = font.getAttribute( 'color' );
 		const span = document.createElement( 'span' );
 		// Skip default color — unwrap the element entirely.
-		if ( color && color.toLowerCase() !== '#333333' ) {
+		if ( color && color.toLowerCase() !== '#1a1a1a' ) {
 			span.style.color = color;
 		}
 		span.innerHTML = font.innerHTML;
@@ -60,7 +64,7 @@ function normalizeColorMarkup( container ) {
 		const color = span.style.color;
 		if ( ! color ) return;
 		// Detect default color in various formats.
-		const isDefault = color === '#333333' || color === '#333' || color === 'rgb(51, 51, 51)';
+		const isDefault = color === '#1a1a1a' || color === 'rgb(26, 26, 26)';
 		if ( isDefault ) {
 			span.replaceWith( ...span.childNodes );
 		}
@@ -142,8 +146,11 @@ function convertToBlocks( html ) {
 		} else if ( tag === 'blockquote' ) {
 			// inner may already contain <p> tags from contentEditable.
 			const quoteInner = inner.startsWith( '<p' ) ? inner : `<p>${ inner }</p>`;
+			const hasQuoteAlign = align && [ 'center', 'right' ].includes( align );
+			const quoteAlignAttr = hasQuoteAlign ? ` style="text-align:${ align }"` : '';
+			const quoteAlignJson = hasQuoteAlign ? ` {"align":"${ align }"}` : '';
 			blocks.push(
-				`<!-- wp:quote -->\n<blockquote class="wp-block-quote">${ quoteInner }</blockquote>\n<!-- /wp:quote -->`
+				`<!-- wp:quote${ quoteAlignJson } -->\n<blockquote class="wp-block-quote"${ quoteAlignAttr }>${ quoteInner }</blockquote>\n<!-- /wp:quote -->`
 			);
 		} else if ( tag === 'ul' ) {
 			blocks.push(
@@ -813,25 +820,31 @@ const { state } = store( 'wpcom-write', {
 		toggleTextColorMenu() {
 			state.showTextColorMenu = ! state.showTextColorMenu;
 			state.showHeadingMenu = false;
+			// Always clean up any existing listener first.
+			if ( textColorMenuCloseHandler ) {
+				document.removeEventListener( 'click', textColorMenuCloseHandler );
+				textColorMenuCloseHandler = null;
+			}
 			if ( state.showTextColorMenu ) {
 				positionDropdownOnMobile( '.bw-color-menu' );
-				const close = e => {
+				textColorMenuCloseHandler = e => {
 					if (
 						e.target.closest( '.bw-color-menu' ) ||
 						e.target.closest( '[data-wp-on--click="actions.toggleTextColorMenu"]' )
 					)
 						return;
 					state.showTextColorMenu = false;
-					document.removeEventListener( 'click', close );
+					document.removeEventListener( 'click', textColorMenuCloseHandler );
+					textColorMenuCloseHandler = null;
 				};
-				setTimeout( () => document.addEventListener( 'click', close ), 0 );
+				setTimeout( () => document.addEventListener( 'click', textColorMenuCloseHandler ), 0 );
 			}
 		},
 
 		setTextColorDefault() {
 			// Use foreColor with the default text color instead of removeFormat,
 			// which would strip all inline formatting (bold, italic, etc.).
-			document.execCommand( 'foreColor', false, '#333333' );
+			document.execCommand( 'foreColor', false, '#1a1a1a' );
 			state.showTextColorMenu = false;
 		},
 
@@ -865,30 +878,38 @@ const { state } = store( 'wpcom-write', {
 		toggleHeadingMenu() {
 			state.showHeadingMenu = ! state.showHeadingMenu;
 			state.showTextColorMenu = false;
+			// Always clean up any existing listener first.
+			if ( headingMenuCloseHandler ) {
+				document.removeEventListener( 'click', headingMenuCloseHandler );
+				headingMenuCloseHandler = null;
+			}
 			if ( state.showHeadingMenu ) {
 				positionDropdownOnMobile( '.bw-heading-menu' );
-				const close = e => {
+				headingMenuCloseHandler = e => {
 					if (
 						e.target.closest( '.bw-heading-menu' ) ||
 						e.target.closest( '.bw-tool-heading-toggle' )
 					)
 						return;
 					state.showHeadingMenu = false;
-					document.removeEventListener( 'click', close );
+					document.removeEventListener( 'click', headingMenuCloseHandler );
+					headingMenuCloseHandler = null;
 				};
-				setTimeout( () => document.addEventListener( 'click', close ), 0 );
+				setTimeout( () => document.addEventListener( 'click', headingMenuCloseHandler ), 0 );
 			}
 		},
 
 		setHeadingNormal() {
 			document.execCommand( 'formatBlock', false, 'p' );
 			state.formatHeading = false;
+			state.headingLabel = 'Normal';
 			state.showHeadingMenu = false;
 		},
 
 		setHeadingH2() {
 			document.execCommand( 'formatBlock', false, 'h2' );
 			state.formatHeading = true;
+			state.headingLabel = 'Heading 2';
 			state.formatQuote = false;
 			state.showHeadingMenu = false;
 		},
@@ -896,6 +917,7 @@ const { state } = store( 'wpcom-write', {
 		setHeadingH3() {
 			document.execCommand( 'formatBlock', false, 'h3' );
 			state.formatHeading = true;
+			state.headingLabel = 'Heading 3';
 			state.formatQuote = false;
 			state.showHeadingMenu = false;
 		},
@@ -970,7 +992,7 @@ const { state } = store( 'wpcom-write', {
 			state.linkUrl = '';
 			while ( node && node !== document.body ) {
 				if ( node.nodeType === Node.ELEMENT_NODE && node.tagName === 'A' ) {
-					state.linkUrl = node.href;
+					state.linkUrl = node.getAttribute( 'href' ) || '';
 					break;
 				}
 				node = node.parentNode;
@@ -985,6 +1007,14 @@ const { state } = store( 'wpcom-write', {
 				const input = popover.querySelector( '.bw-link-input' );
 				if ( input ) input.focus();
 			} );
+
+			// Close when clicking outside the popover.
+			const closeLink = e => {
+				if ( e.target.closest( '.bw-link-popover' ) ) return;
+				state.showLinkInput = false;
+				document.removeEventListener( 'click', closeLink );
+			};
+			setTimeout( () => document.addEventListener( 'click', closeLink ), 0 );
 		},
 
 		updateLinkUrl() {

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -34,12 +34,6 @@ function restoreSelection() {
 }
 
 /**
- * Convert contentEditable HTML into WordPress block markup.
- *
- * @param {string} html - The innerHTML from the contenteditable area.
- * @return {string} Serialized Gutenberg block markup.
- */
-/**
  * Normalize color markup from contentEditable before block serialization.
  *
  * The foreColor command creates <font color="..."> (legacy) or
@@ -821,6 +815,16 @@ const { state } = store( 'wpcom-write', {
 			state.showHeadingMenu = false;
 			if ( state.showTextColorMenu ) {
 				positionDropdownOnMobile( '.bw-color-menu' );
+				const close = e => {
+					if (
+						e.target.closest( '.bw-color-menu' ) ||
+						e.target.closest( '[data-wp-on--click="actions.toggleTextColorMenu"]' )
+					)
+						return;
+					state.showTextColorMenu = false;
+					document.removeEventListener( 'click', close );
+				};
+				setTimeout( () => document.addEventListener( 'click', close ), 0 );
 			}
 		},
 
@@ -863,6 +867,16 @@ const { state } = store( 'wpcom-write', {
 			state.showTextColorMenu = false;
 			if ( state.showHeadingMenu ) {
 				positionDropdownOnMobile( '.bw-heading-menu' );
+				const close = e => {
+					if (
+						e.target.closest( '.bw-heading-menu' ) ||
+						e.target.closest( '.bw-tool-heading-toggle' )
+					)
+						return;
+					state.showHeadingMenu = false;
+					document.removeEventListener( 'click', close );
+				};
+				setTimeout( () => document.addEventListener( 'click', close ), 0 );
 			}
 		},
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -790,7 +790,9 @@ const { state } = store( 'wpcom-write', {
 		},
 
 		preventToolbarBlur( event ) {
-			// Prevent the toolbar from stealing focus from the content area.
+			// Prevent the toolbar from stealing focus from the content area,
+			// but allow normal interaction with form inputs (text selection, cursor).
+			if ( event.target.closest( 'input, textarea' ) ) return;
 			event.preventDefault();
 		},
 
@@ -1041,13 +1043,20 @@ const { state } = store( 'wpcom-write', {
 					document.execCommand( 'createLink', false, state.linkUrl );
 				}
 				state.showLinkInput = false;
-				// Refocus content area.
+				if ( linkPopoverCloseHandler ) {
+					document.removeEventListener( 'click', linkPopoverCloseHandler );
+					linkPopoverCloseHandler = null;
+				}
 				const content = document.querySelector( '.bw-content' );
 				if ( content ) content.focus();
 			}
 			if ( event.key === 'Escape' ) {
 				event.preventDefault();
 				state.showLinkInput = false;
+				if ( linkPopoverCloseHandler ) {
+					document.removeEventListener( 'click', linkPopoverCloseHandler );
+					linkPopoverCloseHandler = null;
+				}
 				const content = document.querySelector( '.bw-content' );
 				if ( content ) content.focus();
 			}
@@ -1059,12 +1068,24 @@ const { state } = store( 'wpcom-write', {
 				document.execCommand( 'createLink', false, state.linkUrl );
 			}
 			state.showLinkInput = false;
+			if ( linkPopoverCloseHandler ) {
+				document.removeEventListener( 'click', linkPopoverCloseHandler );
+				linkPopoverCloseHandler = null;
+			}
+			const content = document.querySelector( '.bw-content' );
+			if ( content ) content.focus();
 		},
 
 		removeLink() {
 			restoreSelection();
 			document.execCommand( 'unlink' );
 			state.showLinkInput = false;
+			if ( linkPopoverCloseHandler ) {
+				document.removeEventListener( 'click', linkPopoverCloseHandler );
+				linkPopoverCloseHandler = null;
+			}
+			const content = document.querySelector( '.bw-content' );
+			if ( content ) content.focus();
 		},
 
 		// --- Image ---

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! defined( 'WPCOM_WRITE_VERSION' ) ) {
 	// Use file modification time to bust CDN caches when files change.
-	define( 'WPCOM_WRITE_VERSION', (string) filemtime( __DIR__ . '/view.js' ) );
+	define( 'WPCOM_WRITE_VERSION', (string) max( filemtime( __DIR__ . '/view.js' ), filemtime( __DIR__ . '/style.css' ) ) );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -14,12 +14,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! defined( 'WPCOM_WRITE_VERSION' ) ) {
-	define(
-		'WPCOM_WRITE_VERSION',
-		class_exists( '\Automattic\Jetpack\Jetpack_Mu_Wpcom' )
-			? \Automattic\Jetpack\Jetpack_Mu_Wpcom::PACKAGE_VERSION
-			: '1.0.0-dev'
-	);
+	// Use file modification time to bust CDN caches when files change.
+	define( 'WPCOM_WRITE_VERSION', (string) filemtime( __DIR__ . '/view.js' ) );
 }
 
 /**
@@ -117,12 +113,16 @@ add_action(
 			#adminmenuwrap,
 			#adminmenuback,
 			#adminmenumain,
-			#wpfooter { display: none !important; }
+			#wpfooter,
+			#wpcom-help-center,
+			.wp-admin-bar-fix { display: none !important; }
 			#wpcontent,
 			#wpbody,
 			#wpbody-content { margin-left: 0 !important; padding: 0 !important; }
 			.wrap { margin: 0 !important; padding: 0 !important; max-width: none !important; }
 			html.wp-toolbar { padding-top: 0 !important; }
+			body.admin-bar { padding-top: 0 !important; margin-top: 0 !important; }
+			html { margin-top: 0 !important; }
 		';
 		wp_add_inline_style( 'wpcom-write', $hide_chrome_css );
 	}
@@ -173,33 +173,41 @@ function wpcom_write_render_admin_page() {
 	wp_interactivity_state(
 		'wpcom-write',
 		array(
-			'postsPath'        => '/wp/v2/posts',
-			'mediaPath'        => '/wp/v2/media',
-			'homeUrl'          => home_url( '/' ),
-			'adminUrl'         => admin_url(),
-			'writeUrl'         => wpcom_write_url(),
-			'editPostId'       => $edit_post_id,
-			'postStatus'       => $post_status,
-			'title'            => $edit_title,
-			'isSaving'         => false,
-			'isPublished'      => false,
-			'message'          => '',
-			'showToolbar'      => false,
-			'showLinkInput'    => false,
-			'linkUrl'          => '',
-			'showImageModal'   => false,
-			'showVideoModal'   => false,
-			'videoUrl'         => '',
-			'imageAlt'         => '',
-			'setAsFeatured'    => false,
-			'featuredMediaId'  => $edit_featured_id,
-			'isUploading'      => false,
-			'categories'       => $categories_data,
-			'showCatPicker'    => false,
-			'showHelp'         => false,
-			'showSlashMenu'    => false,
-			'slashFilter'      => '',
-			'showLeaveConfirm' => false,
+			'postsPath'           => '/wp/v2/posts',
+			'mediaPath'           => '/wp/v2/media',
+			'homeUrl'             => home_url( '/' ),
+			'adminUrl'            => admin_url(),
+			'writeUrl'            => wpcom_write_url(),
+			'editPostId'          => $edit_post_id,
+			'postStatus'          => $post_status,
+			'title'               => $edit_title,
+			'isSaving'            => false,
+			'isPublished'         => false,
+			'message'             => '',
+			'showLinkInput'       => false,
+			'linkUrl'             => '',
+			'showImageModal'      => false,
+			'showVideoModal'      => false,
+			'videoUrl'            => '',
+			'imageAlt'            => '',
+			'setAsFeatured'       => false,
+			'featuredMediaId'     => $edit_featured_id,
+			'isUploading'         => false,
+			'categories'          => $categories_data,
+			'showCatPicker'       => false,
+			'showHelp'            => false,
+			'showSlashMenu'       => false,
+			'slashFilter'         => '',
+			'showLeaveConfirm'    => false,
+			'showHeadingMenu'     => false,
+			'showTextColorMenu'   => false,
+			'formatStrikethrough' => false,
+			'formatUnderline'     => false,
+			'formatAlignLeft'     => true,
+			'formatAlignCenter'   => false,
+			'formatAlignRight'    => false,
+			'formatOList'         => false,
+			'formatUList'         => false,
 		)
 	);
 
@@ -229,7 +237,9 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 		<div class="bw-help-popover" hidden data-wp-bind--hidden="!state.showHelp">
 			<div class="bw-help-title">Tips</div>
 			<div class="bw-help-row"><kbd>/</kbd><span>Insert a heading, image, video, quote or divider</span></div>
-			<div class="bw-help-row"><kbd>Select text</kbd><span>Formatting toolbar appears</span></div>
+			<div class="bw-help-row"><kbd>Ctrl+B</kbd><span>Bold</span></div>
+			<div class="bw-help-row"><kbd>Ctrl+I</kbd><span>Italic</span></div>
+			<div class="bw-help-row"><kbd>Ctrl+K</kbd><span>Insert link</span></div>
 			<div class="bw-help-row"><kbd>Tab</kbd><span>Navigate slash menu options</span></div>
 		</div>
 		<span class="bw-status" data-wp-text="state.message"></span>
@@ -246,6 +256,72 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 			><?php echo $edit_post_id ? 'Update' : 'Publish'; ?></button>
 		</div>
 	</header>
+
+	<!-- Persistent formatting toolbar -->
+	<div
+		class="bw-toolbar"
+		data-wp-on--mousedown="actions.preventToolbarBlur"
+	>
+		<div class="bw-toolbar-scroll">
+			<!-- Heading dropdown -->
+			<div class="bw-tool-dropdown-wrap">
+				<button class="bw-tool bw-tool-heading-toggle" data-wp-on--click="actions.toggleHeadingMenu" data-wp-class--bw-tool-active="state.formatHeading" title="Text style">
+					<span class="bw-tool-label" data-wp-text="state.headingLabel">Normal</span>
+					<span class="bw-tool-caret">&#9662;</span>
+				</button>
+				<div class="bw-heading-menu" hidden data-wp-bind--hidden="!state.showHeadingMenu">
+					<button class="bw-heading-option" data-wp-on--click="actions.setHeadingNormal" data-wp-on--mousedown="actions.preventToolbarBlur"><span>Normal</span></button>
+					<button class="bw-heading-option bw-heading-option-h2" data-wp-on--click="actions.setHeadingH2" data-wp-on--mousedown="actions.preventToolbarBlur"><span>Heading 2</span></button>
+					<button class="bw-heading-option bw-heading-option-h3" data-wp-on--click="actions.setHeadingH3" data-wp-on--mousedown="actions.preventToolbarBlur"><span>Heading 3</span></button>
+				</div>
+			</div>
+			<span class="bw-tool-divider"></span>
+			<!-- Inline formatting -->
+			<button class="bw-tool" data-wp-on--click="actions.formatBold" data-wp-class--bw-tool-active="state.formatBold" title="Bold"><span class="dashicons dashicons-editor-bold"></span></button>
+			<button class="bw-tool" data-wp-on--click="actions.formatItalic" data-wp-class--bw-tool-active="state.formatItalic" title="Italic"><span class="dashicons dashicons-editor-italic"></span></button>
+			<button class="bw-tool" data-wp-on--click="actions.formatUnderline" data-wp-class--bw-tool-active="state.formatUnderline" title="Underline"><span class="dashicons dashicons-editor-underline"></span></button>
+			<button class="bw-tool" data-wp-on--click="actions.formatStrikethrough" data-wp-class--bw-tool-active="state.formatStrikethrough" title="Strikethrough"><span class="dashicons dashicons-editor-strikethrough"></span></button>
+			<!-- Text color -->
+			<div class="bw-tool-dropdown-wrap">
+				<button class="bw-tool" data-wp-on--click="actions.toggleTextColorMenu" title="Text color"><span class="dashicons dashicons-admin-appearance"></span></button>
+				<div class="bw-color-menu" hidden data-wp-bind--hidden="!state.showTextColorMenu" data-wp-on--mousedown="actions.preventToolbarBlur">
+					<button class="bw-color-swatch" style="background:#1a1a1a;" data-wp-on--click="actions.setTextColorDefault" title="Default"></button>
+					<button class="bw-color-swatch" style="background:#d63638;" data-wp-on--click="actions.setTextColorRed" title="Red"></button>
+					<button class="bw-color-swatch" style="background:#2171b1;" data-wp-on--click="actions.setTextColorBlue" title="Blue"></button>
+					<button class="bw-color-swatch" style="background:#00a32a;" data-wp-on--click="actions.setTextColorGreen" title="Green"></button>
+					<button class="bw-color-swatch" style="background:#dba617;" data-wp-on--click="actions.setTextColorYellow" title="Yellow"></button>
+					<button class="bw-color-swatch" style="background:#8c5db0;" data-wp-on--click="actions.setTextColorPurple" title="Purple"></button>
+				</div>
+			</div>
+			<span class="bw-tool-divider"></span>
+			<!-- Alignment -->
+			<button class="bw-tool" data-wp-on--click="actions.alignLeft" data-wp-class--bw-tool-active="state.formatAlignLeft" title="Align left"><span class="dashicons dashicons-editor-alignleft"></span></button>
+			<button class="bw-tool" data-wp-on--click="actions.alignCenter" data-wp-class--bw-tool-active="state.formatAlignCenter" title="Align center"><span class="dashicons dashicons-editor-aligncenter"></span></button>
+			<button class="bw-tool" data-wp-on--click="actions.alignRight" data-wp-class--bw-tool-active="state.formatAlignRight" title="Align right"><span class="dashicons dashicons-editor-alignright"></span></button>
+			<span class="bw-tool-divider"></span>
+			<!-- Lists -->
+			<button class="bw-tool" data-wp-on--click="actions.formatUList" data-wp-class--bw-tool-active="state.formatUList" title="Bulleted list"><span class="dashicons dashicons-editor-ul"></span></button>
+			<button class="bw-tool" data-wp-on--click="actions.formatOList" data-wp-class--bw-tool-active="state.formatOList" title="Numbered list"><span class="dashicons dashicons-editor-ol"></span></button>
+			<span class="bw-tool-divider"></span>
+			<!-- Block-level -->
+			<button class="bw-tool" data-wp-on--click="actions.toggleLinkInput" data-wp-class--bw-tool-active="state.showLinkInput" title="Link"><span class="dashicons dashicons-admin-links"></span></button>
+			<button class="bw-tool" data-wp-on--click="actions.formatQuote" data-wp-class--bw-tool-active="state.formatQuote" title="Quote"><span class="dashicons dashicons-format-quote"></span></button>
+			<button class="bw-tool" data-wp-on--click="actions.openImageModal" title="Image"><span class="dashicons dashicons-format-image"></span></button>
+		</div>
+	</div>
+
+	<!-- Link input popover -->
+	<div class="bw-link-popover" hidden data-wp-bind--hidden="!state.showLinkInput" data-wp-on--mousedown="actions.preventToolbarBlur">
+		<input
+			type="url"
+			class="bw-link-input"
+			placeholder="Paste or type a link..."
+			data-wp-on--input="actions.updateLinkUrl"
+			data-wp-on--keydown="actions.handleLinkKeyDown"
+		/>
+		<button class="bw-link-apply" data-wp-on--click="actions.applyLink">Apply</button>
+		<button class="bw-link-remove" data-wp-on--click="actions.removeLink">&times;</button>
+	</div>
 
 	<!-- Writing area -->
 	<main class="bw-main">
@@ -269,37 +345,6 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 			><?php echo $edit_content ? wp_kses_post( $edit_content ) : '<p><br></p>'; ?></div>
 		</div>
 	</main>
-
-	<!-- Floating formatting toolbar -->
-	<div
-		class="bw-toolbar"
-		hidden
-		data-wp-bind--hidden="!state.showToolbar"
-		data-wp-on--mousedown="actions.preventToolbarBlur"
-	>
-		<button class="bw-tool" data-wp-on--click="actions.formatHeading" data-wp-class--bw-tool-active="state.formatHeading" title="Heading"><span class="dashicons dashicons-heading"></span></button>
-		<span class="bw-tool-divider"></span>
-		<button class="bw-tool" data-wp-on--click="actions.formatBold" data-wp-class--bw-tool-active="state.formatBold" title="Bold"><span class="dashicons dashicons-editor-bold"></span></button>
-		<button class="bw-tool" data-wp-on--click="actions.formatItalic" data-wp-class--bw-tool-active="state.formatItalic" title="Italic"><span class="dashicons dashicons-editor-italic"></span></button>
-		<span class="bw-tool-divider"></span>
-		<button class="bw-tool" data-wp-on--click="actions.formatQuote" data-wp-class--bw-tool-active="state.formatQuote" title="Quote"><span class="dashicons dashicons-format-quote"></span></button>
-		<span class="bw-tool-divider"></span>
-		<button class="bw-tool" data-wp-on--click="actions.toggleLinkInput" title="Link"><span class="dashicons dashicons-admin-links"></span></button>
-		<button class="bw-tool" data-wp-on--click="actions.openImageModal" title="Image"><span class="dashicons dashicons-format-image"></span></button>
-	</div>
-
-	<!-- Link input popover -->
-	<div class="bw-link-popover" hidden data-wp-bind--hidden="!state.showLinkInput">
-		<input
-			type="url"
-			class="bw-link-input"
-			placeholder="Paste or type a link..."
-			data-wp-on--input="actions.updateLinkUrl"
-			data-wp-on--keydown="actions.handleLinkKeyDown"
-		/>
-		<button class="bw-link-apply" data-wp-on--click="actions.applyLink">Apply</button>
-		<button class="bw-link-remove" data-wp-on--click="actions.removeLink">&times;</button>
-	</div>
 
 	<!-- Image modal -->
 	<div class="bw-image-overlay" hidden data-wp-bind--hidden="!state.showImageModal" data-wp-on--click="actions.closeImageModal">
@@ -415,4 +460,3 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 </div>
 	<?php
 }
-

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -316,6 +316,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 			type="url"
 			class="bw-link-input"
 			placeholder="Paste or type a link..."
+			data-wp-bind--value="state.linkUrl"
 			data-wp-on--input="actions.updateLinkUrl"
 			data-wp-on--keydown="actions.handleLinkKeyDown"
 		/>

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -189,4 +189,112 @@ class Write_Test extends \WorDBless\BaseTestCase {
 		$this->assertStringContainsString( 'style.css', $url );
 		$this->assertStringContainsString( 'write', $url );
 	}
+
+	/**
+	 * Test that the persistent toolbar is rendered with the correct structure.
+	 */
+	public function test_template_contains_persistent_toolbar() {
+		wp_set_current_user( $this->admin_id );
+
+		$output = $this->render_template();
+
+		// Toolbar is a fixed bar, not a floating element.
+		$this->assertStringContainsString( 'class="bw-toolbar"', $output );
+		$this->assertStringContainsString( 'class="bw-toolbar-scroll"', $output );
+	}
+
+	/**
+	 * Test that the toolbar is always visible (no hidden attribute or show/hide bindings).
+	 */
+	public function test_toolbar_always_visible() {
+		wp_set_current_user( $this->admin_id );
+
+		$output = $this->render_template();
+
+		$this->assertStringContainsString( 'class="bw-toolbar"', $output );
+		// Toolbar should not have hidden attribute or hidden binding.
+		$this->assertStringNotContainsString( 'bw-toolbar"' . "\n" . '		hidden', $output );
+	}
+
+	/**
+	 * Test that the toolbar contains all required formatting buttons.
+	 */
+	public function test_toolbar_contains_formatting_buttons() {
+		wp_set_current_user( $this->admin_id );
+
+		$output = $this->render_template();
+
+		// Inline formatting.
+		$this->assertStringContainsString( 'actions.formatBold', $output );
+		$this->assertStringContainsString( 'actions.formatItalic', $output );
+		$this->assertStringContainsString( 'actions.formatUnderline', $output );
+		$this->assertStringContainsString( 'actions.formatStrikethrough', $output );
+
+		// Alignment.
+		$this->assertStringContainsString( 'actions.alignLeft', $output );
+		$this->assertStringContainsString( 'actions.alignCenter', $output );
+		$this->assertStringContainsString( 'actions.alignRight', $output );
+
+		// Lists.
+		$this->assertStringContainsString( 'actions.formatUList', $output );
+		$this->assertStringContainsString( 'actions.formatOList', $output );
+
+		// Block-level.
+		$this->assertStringContainsString( 'actions.toggleLinkInput', $output );
+		$this->assertStringContainsString( 'actions.formatQuote', $output );
+		$this->assertStringContainsString( 'actions.openImageModal', $output );
+	}
+
+	/**
+	 * Test that the heading dropdown menu is rendered.
+	 */
+	public function test_toolbar_contains_heading_dropdown() {
+		wp_set_current_user( $this->admin_id );
+
+		$output = $this->render_template();
+
+		$this->assertStringContainsString( 'actions.toggleHeadingMenu', $output );
+		$this->assertStringContainsString( 'class="bw-heading-menu"', $output );
+		$this->assertStringContainsString( 'actions.setHeadingNormal', $output );
+		$this->assertStringContainsString( 'actions.setHeadingH2', $output );
+		$this->assertStringContainsString( 'actions.setHeadingH3', $output );
+	}
+
+	/**
+	 * Test that the text color picker is rendered.
+	 */
+	public function test_toolbar_contains_text_color_picker() {
+		wp_set_current_user( $this->admin_id );
+
+		$output = $this->render_template();
+
+		$this->assertStringContainsString( 'actions.toggleTextColorMenu', $output );
+		$this->assertStringContainsString( 'class="bw-color-menu"', $output );
+		$this->assertStringContainsString( 'class="bw-color-swatch"', $output );
+	}
+
+	/**
+	 * Test that the Interactivity API state includes new toolbar state fields.
+	 */
+	public function test_interactivity_state_includes_toolbar_fields() {
+		wp_set_current_user( $this->admin_id );
+
+		// Render the admin page which calls wp_interactivity_state().
+		ob_start();
+		wpcom_write_render_admin_page();
+		ob_end_clean();
+
+		// Use reflection to read the stored state via the global.
+		$state = wp_interactivity_state( 'wpcom-write' );
+
+		$this->assertArrayHasKey( 'showHeadingMenu', $state );
+		$this->assertArrayHasKey( 'showTextColorMenu', $state );
+		$this->assertArrayHasKey( 'formatStrikethrough', $state );
+		$this->assertArrayHasKey( 'formatUnderline', $state );
+		$this->assertArrayHasKey( 'formatAlignLeft', $state );
+		$this->assertArrayHasKey( 'formatAlignCenter', $state );
+		$this->assertArrayHasKey( 'formatAlignRight', $state );
+		$this->assertArrayHasKey( 'formatOList', $state );
+		$this->assertArrayHasKey( 'formatUList', $state );
+	}
 }


### PR DESCRIPTION
Fixes RSM-589

## Proposed changes

Replace the floating "highlight text to see toolbar" pattern with a persistent formatting toolbar fixed below the topbar, always visible on the Write page.

* Toolbar always visible — no show/hide logic, no focus dependency
* Heading dropdown with Normal, H2, H3 options
* Inline formatting: bold, italic, underline, strikethrough
* Text color picker with 6 preset colors (default resets color without stripping other formatting)
* Text alignment: left, center, right (with automatic div-to-p cleanup)
* Ordered and unordered list buttons
* Link, blockquote, and image buttons (carried over from floating toolbar)
* Highlight text + paste URL to create a link
* Horizontally scrollable toolbar on mobile with JS-positioned dropdowns
* Fade-in on dropdown menus
* Updated `convertToBlocks()` to serialize lists, text-align, and color markup to Gutenberg markup
* Ctrl+K keyboard shortcut for link input
* 6 new PHP tests covering toolbar markup, state, and structure
* Higher z-index and broader chrome-hiding for Atomic compatibility

Mobile | Desktop
--- | ---
<img width="247" height="436" alt="Screenshot 2026-04-24 at 2 13 23 PM" src="https://github.com/user-attachments/assets/b219b656-fe8e-4804-9c4a-fc2b622b6f83" /> | <img width="853" height="540" alt="Screenshot 2026-04-24 at 2 13 11 PM" src="https://github.com/user-attachments/assets/8b02d540-9479-441a-9dc9-0b8f613b3194" />


## Known limitations (follow-ups needed)

* **Lists** (RSM-590) — basic insert works, but nesting, Tab to indent, and Enter to exit list need the dedicated list support issue. There's also no bullet points yet.
* **Heading levels** (RSM-591) — dropdown has H2/H3 but full heading support (slash command integration, edge cases) is a separate issue.
* a11y and i18n

## Related product discussion/links

* Linear: RSM-589

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Enable the `wpcom-write-editor` blog sticker on a test site
2. See https://github.com/Automattic/jetpack/pull/48305#issuecomment-4315277443 for applying the change to Simple and Atomic sites. On Simple, the site and API will need to be sandboxed and write access turned on.
3. Navigate to `/wp-admin/admin.php?page=write`
4. The formatting toolbar should be visible below the topbar immediately on page load
5. Verify all toolbar buttons:
   - Click "Normal" dropdown → should show Normal, Heading 2, Heading 3 options
   - Select text → click B, I, U, S buttons → verify formatting applies and button highlights
   - Click paintbrush icon → color swatches should appear, clicking one colors selected text
   - Click alignment buttons → text should align left/center/right
   - Click list buttons → should create bulleted/numbered lists
   - Click link button → link popover appears below toolbar
   - Click quote button → converts block to blockquote
   - Click image button → image upload modal appears
6. Select text and paste a URL → should create a link instead of replacing the text
7. Toolbar should remain visible when clicking between title and content area
8. On mobile (or narrow viewport): toolbar should scroll horizontally, dropdowns should appear as fixed overlays
9. Write and publish a post → verify content saves correctly with new block types (lists, aligned text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
