### PR TITLE
Survicate: Suppress surveys while Help Center is open on Atomic sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/survicate-suppress-in-help-center
+++ b/projects/packages/jetpack-mu-wpcom/changelog/survicate-suppress-in-help-center
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Survicate: Suppress surveys while the Help Center is open on Atomic sites.

--- a/projects/packages/jetpack-mu-wpcom/src/features/survicate/class-survicate.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/survicate/class-survicate.php
@@ -128,6 +128,10 @@ class Survicate {
 			'wpcom-survicate',
 			<<<JS
 ( function () {
+	if ( window.__wpcomSurvicateInit ) {
+		return;
+	}
+	window.__wpcomSurvicateInit = true;
 	if ( window.innerWidth < 480 ) {
 		return;
 	}
@@ -155,13 +159,15 @@ class Survicate {
 
 	if ( window.wp && window.wp.data && typeof window.wp.data.subscribe === 'function' ) {
 		var wasShown = isHelpCenterShown();
+		// Scope the subscription to the Help Center store so the callback does not
+		// fire on every dispatch across all registered stores (e.g. block editor).
 		window.wp.data.subscribe( function () {
 			var shown = isHelpCenterShown();
 			if ( shown && ! wasShown ) {
 				closeAnySurvey();
 			}
 			wasShown = shown;
-		} );
+		}, 'automattic/help-center' );
 	}
 
 	window.addEventListener( 'SurvicateReady', function () {
@@ -173,6 +179,9 @@ class Survicate {
 		}
 
 		if ( typeof window._sva.addEventListener === 'function' ) {
+			// The SDK does not expose a pre-display hook, so we close on the
+			// post-display event. This causes a brief flash but is the best the
+			// public API allows.
 			window._sva.addEventListener( 'survey_displayed', function () {
 				if ( isHelpCenterShown() ) {
 					closeAnySurvey();

--- a/projects/packages/jetpack-mu-wpcom/src/features/survicate/class-survicate.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/survicate/class-survicate.php
@@ -119,7 +119,7 @@ class Survicate {
 		wp_register_script(
 			'wpcom-survicate',
 			false,
-			array(),
+			array( 'wp-data' ),
 			'1.0',
 			false
 		);
@@ -136,8 +136,49 @@ class Survicate {
 	script.async = true;
 	document.head.appendChild( script );
 	var traits = {$traits_json};
+
+	// The Help Center registers this @wordpress/data store from a separate bundle
+	// loaded from widgets.wp.com; reads are guarded in case it is not yet registered.
+	function isHelpCenterShown() {
+		try {
+			var store = window.wp && window.wp.data && window.wp.data.select( 'automattic/help-center' );
+			return !! ( store && typeof store.isHelpCenterShown === 'function' && store.isHelpCenterShown() );
+		} catch ( e ) {
+			return false;
+		}
+	}
+	function closeAnySurvey() {
+		if ( window._sva && typeof window._sva.closeSurvey === 'function' ) {
+			window._sva.closeSurvey();
+		}
+	}
+
+	if ( window.wp && window.wp.data && typeof window.wp.data.subscribe === 'function' ) {
+		var wasShown = isHelpCenterShown();
+		window.wp.data.subscribe( function () {
+			var shown = isHelpCenterShown();
+			if ( shown && ! wasShown ) {
+				closeAnySurvey();
+			}
+			wasShown = shown;
+		} );
+	}
+
 	window.addEventListener( 'SurvicateReady', function () {
 		window._sva.setVisitorTraits( traits );
+
+		// Covers the race where the Help Center opened before the SDK finished loading.
+		if ( isHelpCenterShown() ) {
+			closeAnySurvey();
+		}
+
+		if ( typeof window._sva.addEventListener === 'function' ) {
+			window._sva.addEventListener( 'survey_displayed', function () {
+				if ( isHelpCenterShown() ) {
+					closeAnySurvey();
+				}
+			} );
+		}
 	} );
 } )();
 JS

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/survicate/Survicate_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/survicate/Survicate_Test.php
@@ -346,6 +346,8 @@ class Survicate_Test extends \WorDBless\BaseTestCase {
 	 * Tests that enqueue_scripts registers the script and includes expected inline JS.
 	 */
 	public function test_enqueue_scripts_registers_script_with_expected_inline_js() {
+		global $wp_scripts;
+
 		$this->enqueue_survicate_scripts();
 
 		$this->assertTrue( wp_script_is( 'wpcom-survicate', 'enqueued' ) );
@@ -357,6 +359,10 @@ class Survicate_Test extends \WorDBless\BaseTestCase {
 		$this->assertStringContainsString( 'SurvicateReady', $inline_script );
 		$this->assertStringContainsString( 'setVisitorTraits', $inline_script );
 		$this->assertStringContainsString( 'test@example.com', $inline_script );
+		$this->assertStringContainsString( 'automattic/help-center', $inline_script );
+		$this->assertStringContainsString( 'survey_displayed', $inline_script );
+
+		$this->assertContains( 'wp-data', $wp_scripts->registered['wpcom-survicate']->deps );
 	}
 
 	// ---- Singleton tests ----


### PR DESCRIPTION
Task-related: DOTOBRD-428


## Proposed changes

* Suppress Survicate surveys on Atomic sites while the Help Center is open. Ports the spirit of Calypso PR [Automattic/wp-calypso#109989](https://github.com/Automattic/wp-calypso/pull/109989) into the PHP-injected Survicate loader in `jetpack-mu-wpcom`.
* Subscribes to the `automattic/help-center` `@wordpress/data` store and calls `window._sva.closeSurvey()` whenever the Help Center transitions from hidden to shown.
* Inside the existing `SurvicateReady` handler, closes any survey that becomes visible at SDK-ready time if the Help Center is already open, and registers a `_sva.addEventListener( 'survey_displayed', … )` hook that closes surveys triggered by Survicate's own URL / time-based rules while the Help Center is open.
* Adds `wp-data` to the script's enqueue dependencies so `window.wp.data` is reliably present before the inline script runs.

## Related product discussion/links

* Calypso side of the same fix: [Automattic/wp-calypso#109989](https://github.com/Automattic/wp-calypso/pull/109989).
* Task-related: DOTOBRD-428 (from the Calypso PR).

## Does this pull request change what data or activity we track or use?

No. Visitor traits, tracking, and the Survicate workspace key are unchanged. This only gates *when* a survey is allowed to display.

## Testing instructions

Rsync the dev plugin to an Atomic test site per `projects/packages/jetpack-mu-wpcom/src/features/help-center/AGENTS.md`:

```php
// wp-config.php on the target site
define( 'JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN', true );
define( 'JETPACK_AUTOLOAD_DEV', true );
```

Then:

* Visit wp-admin on the Atomic site as an English-locale logged-in user. In DevTools, confirm the Survicate SDK loads (`window._sva` exists shortly after page load).
* **Normal behavior (Help Center closed):** trigger a Survicate survey (Survicate dashboard "Preview" mode, or a configured debug trigger). Confirm the survey displays.
* **Close-on-open:** trigger a survey so it is visible, then click the Help Center icon in the admin bar. Confirm the survey closes.
* **Active suppression:** open the Help Center first. Then trigger a survey. Confirm the survey never displays, or flashes briefly and immediately closes (the `survey_displayed` listener fires and calls `closeSurvey()`).
* **Back to normal:** close the Help Center and trigger a survey again. Confirm surveys display normally.
* **Regression check:** with the Help Center closed throughout a session, confirm surveys still display as they do today.
* Repeat in the block editor (`gutenberg` variant) — the Help Center SlotFill toolbar button is present there and the same suppression should apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
