### PR TITLE
CI: Skip plugin installation when unneeded and use per-plugin Composer cache dir when installation is needed

### DIFF
--- a/.github/files/setup-wordpress-env.sh
+++ b/.github/files/setup-wordpress-env.sh
@@ -62,6 +62,12 @@ function _install_plugin {
 
 	echo "::group::Installing plugin $NAME into WordPress"
 
+	if [[ -n "$CHANGED" ]] && ! jq --argjson changed "$CHANGED" --arg p "plugins/$NAME" -ne '$changed[$p] // false' > /dev/null; then
+		echo "::endgroup::"
+		echo "Skipping install of plugin $NAME, not in CHANGED"
+		return 0
+	fi
+
 	if php -r 'exit( preg_match( "/^>=\\s*(\\d+\\.\\d+)$/", $argv[1], $m ) && version_compare( PHP_VERSION, $m[1], "<" ) ? 0 : 1 );' "$( jq -r '.require.php // ""' "$DIR/composer.json" )"; then
 		echo "::endgroup::"
 		echo "Skipping install of plugin $NAME, requires PHP $( jq -r '.require.php // ""' "$DIR/composer.json" )"

--- a/.github/files/setup-wordpress-env.sh
+++ b/.github/files/setup-wordpress-env.sh
@@ -57,6 +57,9 @@ function _install_plugin {
 	DIR="${1%/composer.json}"
 	NAME="$(basename "$DIR")"
 
+	# Isolate composer cache per plugin, as a shared composer cache breaks during parallel writes.
+	export COMPOSER_CACHE_DIR="/tmp/composer-cache-$NAME"
+
 	echo "::group::Installing plugin $NAME into WordPress"
 
 	if php -r 'exit( preg_match( "/^>=\\s*(\\d+\\.\\d+)$/", $argv[1], $m ) && version_compare( PHP_VERSION, $m[1], "<" ) ? 0 : 1 );' "$( jq -r '.require.php // ""' "$DIR/composer.json" )"; then

--- a/.github/files/setup-wordpress-env.sh
+++ b/.github/files/setup-wordpress-env.sh
@@ -62,8 +62,6 @@ function _install_plugin {
 
 	# Isolate composer cache per plugin, as a shared composer cache breaks during parallel writes.
 	export COMPOSER_CACHE_DIR="/tmp/composer-cache-$NAME"
-	# But first let's pre-seed it with the default cache from earlier.
-	cp -a "$DEFAULT_COMPOSER_CACHE_DIR" "$COMPOSER_CACHE_DIR"
 
 	echo "::group::Installing plugin $NAME into WordPress"
 
@@ -91,6 +89,9 @@ function _install_plugin {
 			return 1
 		fi
 	fi
+
+	# Pre-seed the per-plugin cache with packages already downloaded by earlier steps (e.g. tools/php-test-env).
+	cp -a "$DEFAULT_COMPOSER_CACHE_DIR" "$COMPOSER_CACHE_DIR"
 
 	cd "$DIR"
 	if [[ ! -f "composer.lock" ]]; then

--- a/.github/files/setup-wordpress-env.sh
+++ b/.github/files/setup-wordpress-env.sh
@@ -52,6 +52,9 @@ export COMPOSER_MIRROR_PATH_REPOS=true
 BASE="$(pwd)"
 PKGVERSIONS="$(jq -nc 'reduce inputs as $in ({}; .[$in.name] |= ( $in.extra["branch-alias"]["dev-trunk"] // "dev-trunk" ) )' projects/packages/*/composer.json)"
 
+# Capture default Composer cache so we can pre-seed each plugin's cache from packages already downloaded by earlier steps (e.g. tools/php-test-env).
+DEFAULT_COMPOSER_CACHE_DIR="$(composer config cache-dir)"
+
 function _install_plugin {
 	local CODE DBNAME DEPS DIR JSON NAME TMP WP_TEST_CONFIG
 	DIR="${1%/composer.json}"
@@ -59,6 +62,8 @@ function _install_plugin {
 
 	# Isolate composer cache per plugin, as a shared composer cache breaks during parallel writes.
 	export COMPOSER_CACHE_DIR="/tmp/composer-cache-$NAME"
+	# But first let's pre-seed it with the default cache from earlier.
+	cp -a "$DEFAULT_COMPOSER_CACHE_DIR" "$COMPOSER_CACHE_DIR"
 
 	echo "::group::Installing plugin $NAME into WordPress"
 


### PR DESCRIPTION
## Proposed changes

In #48133 I parallelized the `compose install` of some plugins, but it seems Composer caches are clashing. Let's see if we can retain the speed gains with the following changes:

1. Use per-plugin Composer cache dirs
2. Skip install if the plugin isn't in `$CHANGED`
3. Pre-seed per-plugin caches with default cache created in earlier steps.

If not, we may as well revert the other PR. For a benchmark on the "Setup WordPress environment for plugin tests" step in PHP 8.3 + WP latest, [a pre-parallel run took 1m16](https://github.com/Automattic/jetpack/actions/runs/24768215372/job/72467607748) and [a post-parallel run took 39s](https://github.com/Automattic/jetpack/actions/runs/24905799073/job/72934743495), so we're hoping to keep ~30s.

Edit: [Looks like 43s](https://github.com/Automattic/jetpack/actions/runs/24912657959/job/72957707858?pr=48308).

<details>
<summary>Example output of the failure looked like this</summary>

```
    - Installing yoast/phpunit-polyfills (4.0.0): Extracting archive
      Failed to extract symfony/service-contracts: (9) /usr/bin/unzip -qq /home/runner/work/jetpack/jetpack/projects/plugins/search/vendor/composer/tmp-e941f2687cd60871625072751cc1e77d.zip -d /home/runner/work/jetpack/jetpack/projects/plugins/search/vendor/composer/1967c5eb
  
  [/home/runner/work/jetpack/jetpack/projects/plugins/search/vendor/composer/tmp-e941f2687cd60871625072751cc1e77d.zip]
    End-of-central-directory signature not found.  Either this file is not
    a zipfile, or it constitutes one disk of a multi-part archive.  In the
    latter case the central directory and zipfile comment will be found on
    the last disk(s) of this archive.
  unzip:  cannot find zipfile directory in one of /home/runner/work/jetpack/jetpack/projects/plugins/search/vendor/composer/tmp-e941f2687cd60871625072751cc1e77d.zip or
          /home/runner/work/jetpack/jetpack/projects/plugins/search/vendor/composer/tmp-e941f2687cd60871625072751cc1e77d.zip.zip, and cannot find /home/runner/work/jetpack/jetpack/projects/plugins/search/vendor/composer/tmp-e941f2687cd60871625072751cc1e77d.zip.ZIP, period.
  
      The archive may contain identical file names with different capitalization (which fails on case insensitive filesystems)
      Unzip with unzip command failed, falling back to ZipArchive class
      Additional debug info, please report to https://github.com/composer/composer/issues/11148 if you see this:
  File size: 0
  File SHA1: da39a3ee5e6b4b0d3255bfef95601890afd80709
  First 100 bytes (hex): 
  Last 100 bytes (hex): 
  Origin URL: https://api.github.com/repos/symfony/service-contracts/zipball/d78d39c1599bd1188b8e26bb341da52c3c6d8a66
  Response Headers: []
      Install of symfony/service-contracts failed
  Error: '/home/runner/work/jetpack/jetpack/projects/plugins/search/vendor/composer/tmp-e941f2687cd60871625072751cc1e77d.zip' is a corrupted zip archive (0 bytes), try again.
  
  In ZipDownloader.php line 254:
                                                                                 
    '/home/runner/work/jetpack/jetpack/projects/plugins/search/vendor/composer/  
    tmp-e941f2687cd60871625072751cc1e77d.zip' is a corrupted zip archive (0 byt  
    es), try again.                                                              
                                                                                 
  
  update [--with WITH] [--prefer-source] [--prefer-dist] [--prefer-install PREFER-INSTALL] [--dry-run] [--dev] [--no-dev] [--lock] [--no-install] [--no-audit] [--audit-format AUDIT-FORMAT] [--no-security-blocking] [--no-autoloader] [--no-suggest] [--no-progress] [-w|--with-dependencies] [-W|--with-all-dependencies] [-v|vv|vvv|--verbose] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--apcu-autoloader-prefix APCU-AUTOLOADER-PREFIX] [--ignore-platform-req IGNORE-PLATFORM-REQ] [--ignore-platform-reqs] [--prefer-stable] [--prefer-lowest] [-m|--minimal-changes] [--patch-only] [-i|--interactive] [--root-reqs] [--bump-after-update [BUMP-AFTER-UPDATE]] [--] [<packages>...]
  
Error: plugins/search: Platform reqs failed for PHP 8.0.30 and updating dev deps didn't help. The plugin is likely broken for that PHP version.
```
</details>

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* p1777053064654059-slack-C05Q5HSS013

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Verify the "Setup WordPress environment for plugin tests" step takes less than 1m.