### PR TITLE
Reader: Improve comment author gravatar urls

### DIFF
--- a/projects/plugins/jetpack/changelog/improve-comment-author-gravatar-urls
+++ b/projects/plugins/jetpack/changelog/improve-comment-author-gravatar-urls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Comment: Improve author Gravatar URLs by converting email-based or no login URLs to hashed versions.

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1459,9 +1459,13 @@ abstract class WPCOM_JSON_API_Endpoint {
 			$name       = $author->comment_author;
 			$first_name = '';
 			$last_name  = '';
-			$url        = $author->comment_author_url;
 			$avatar_url = $this->api->get_avatar_url( $author );
 			$nice       = '';
+			$url        = $author->comment_author_url;
+			// Convert Gravatar URLs containing an email address to the hashed version.
+			if ( preg_match( '#^https?://(?:www\.)?gravatar\.com/([^/?]+)#i', $url, $matches ) && is_email( $matches[1] ) ) {
+				$url = 'https://gravatar.com/' . md5( strtolower( trim( $matches[1] ) ) );
+			}
 
 			// Add additional user data to the response if a valid user ID is available.
 			if ( 0 < $id ) {
@@ -1532,7 +1536,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 			$url        = $user->user_url;
 			$nice       = $user->user_nicename;
 		}
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM && ! $is_jetpack ) {
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM && ! $is_jetpack && $id > 0 ) {
 			/**
 			 * Allow customizing the blog ID returned with the author in WordPress.com REST API queries.
 			 *

--- a/projects/plugins/jetpack/tests/php/json-api/Jetpack_Base_Json_Api_Endpoints_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/Jetpack_Base_Json_Api_Endpoints_Test.php
@@ -209,6 +209,37 @@ class Jetpack_Base_Json_Api_Endpoints_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test get_author returns hashed email profile_URL for anonymous comment authors (user_id=0).
+	 *
+	 * This verifies the $id > 0 guard on the IS_WPCOM branch: anonymous comment authors
+	 * should always get a hashed-email profile URL instead of an incomplete login-based one.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_get_author_anonymous_comment_author_gets_hashed_email_profile_url() {
+		$endpoint = $this->get_dummy_endpoint();
+
+		$comment_data                       = new stdClass();
+		$comment_data->comment_author_email = 'anonymous@example.com';
+		$comment_data->comment_author       = 'Anonymous Visitor';
+		$comment_data->comment_author_url   = 'https://example.com';
+		$comment_data->user_id              = 0;
+		$comment_data->comment_author_IP    = '127.0.0.1';
+
+		$comment = new WP_Comment( $comment_data );
+
+		$author = $endpoint->get_author( $comment );
+
+		$expected_profile_url = 'https://gravatar.com/' . md5( strtolower( trim( 'anonymous@example.com' ) ) );
+		$this->assertSame(
+			$expected_profile_url,
+			$author->profile_URL, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			'Anonymous comment author (user_id=0) should get a hashed-email profile URL.'
+		);
+	}
+
+	/**
 	 * Test get_author converts Gravatar URLs containing an email to the hashed version.
 	 *
 	 * @group json-api

--- a/projects/plugins/jetpack/tests/php/json-api/Jetpack_Base_Json_Api_Endpoints_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/Jetpack_Base_Json_Api_Endpoints_Test.php
@@ -209,6 +209,116 @@ class Jetpack_Base_Json_Api_Endpoints_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test get_author converts Gravatar URLs containing an email to the hashed version.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_get_author_converts_gravatar_email_url_to_hash() {
+		$endpoint = $this->get_dummy_endpoint();
+
+		$comment_data                       = new stdClass();
+		$comment_data->comment_author_email = 'foo@bar.foo';
+		$comment_data->comment_author       = 'Test Author';
+		$comment_data->comment_author_url   = 'https://gravatar.com/foo@bar.foo';
+		$comment_data->user_id              = 0;
+		$comment_data->comment_author_IP    = '';
+
+		$comment = new WP_Comment( $comment_data );
+
+		$author = $endpoint->get_author( $comment );
+
+		$expected_url = 'https://gravatar.com/' . md5( 'foo@bar.foo' );
+		$this->assertSame(
+			$expected_url,
+			$author->URL, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			'Gravatar URL with email should be converted to hashed version.'
+		);
+	}
+
+	/**
+	 * Test get_author does not modify Gravatar URLs that already use a hash.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_get_author_preserves_gravatar_hash_url() {
+		$hash     = md5( 'foo@bar.foo' );
+		$endpoint = $this->get_dummy_endpoint();
+
+		$comment_data                       = new stdClass();
+		$comment_data->comment_author_email = 'foo@bar.foo';
+		$comment_data->comment_author       = 'Test Author';
+		$comment_data->comment_author_url   = 'https://gravatar.com/' . $hash;
+		$comment_data->user_id              = 0;
+		$comment_data->comment_author_IP    = '';
+
+		$comment = new WP_Comment( $comment_data );
+
+		$author = $endpoint->get_author( $comment );
+
+		$this->assertSame(
+			'https://gravatar.com/' . $hash,
+			$author->URL, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			'Gravatar URL with hash should not be modified.'
+		);
+	}
+
+	/**
+	 * Test get_author does not modify non-Gravatar URLs.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_get_author_preserves_non_gravatar_url() {
+		$endpoint = $this->get_dummy_endpoint();
+
+		$comment_data                       = new stdClass();
+		$comment_data->comment_author_email = 'foo@bar.foo';
+		$comment_data->comment_author       = 'Test Author';
+		$comment_data->comment_author_url   = 'https://example.com/profile';
+		$comment_data->user_id              = 0;
+		$comment_data->comment_author_IP    = '';
+
+		$comment = new WP_Comment( $comment_data );
+
+		$author = $endpoint->get_author( $comment );
+
+		$this->assertSame(
+			'https://example.com/profile',
+			$author->URL, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			'Non-Gravatar URLs should not be modified.'
+		);
+	}
+
+	/**
+	 * Test get_author does not modify Gravatar URLs with a non-email username path.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_get_author_preserves_gravatar_username_url() {
+		$endpoint = $this->get_dummy_endpoint();
+
+		$comment_data                       = new stdClass();
+		$comment_data->comment_author_email = 'foo@bar.foo';
+		$comment_data->comment_author       = 'Test Author';
+		$comment_data->comment_author_url   = 'https://gravatar.com/johndoe';
+		$comment_data->user_id              = 0;
+		$comment_data->comment_author_IP    = '';
+
+		$comment = new WP_Comment( $comment_data );
+
+		$author = $endpoint->get_author( $comment );
+
+		$this->assertSame(
+			'https://gravatar.com/johndoe',
+			$author->URL, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			'Gravatar URL with username (not email) should not be modified.'
+		);
+	}
+
+	/**
 	 * Generate a dummy endpoint.
 	 */
 	private function get_dummy_endpoint() {


### PR DESCRIPTION
Closes: [READ-479](https://linear.app/a8c/issue/READ-479/reader-user-avatar-improve-404-avatars)

## Proposed changes
<!--- Explain what functional changes your PR includes -->

Improve author Gravatar URLs by converting email-based or no login URLs to hashed versions.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* GET `rest/v1.1/sites/59434311/posts/41098/replies`
* Verify No `hash` on URL field that contains gravatar URL and Incomplete `profile_URL`.
* Checkout this PR. Repeat above steps. Verify the corrected fields.
