### PR TITLE
My Jetpack: Adopt jetpack-admin-page-layout mixin

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/help/content.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/help/content.tsx
@@ -1,8 +1,10 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
 import { useCallback } from 'react';
 import { FullWidthSeparator } from '../full-width-separator';
+import parentStyles from '../styles.module.scss';
 import { HelpCards } from './cards';
 import { HelpFooter } from './footer';
 import styles from './styles.module.scss';
@@ -21,33 +23,46 @@ export function HelpContent() {
 	}, [ trackHelpRequest ] );
 
 	return (
-		<section>
-			<h2>{ __( 'Need assistance?', 'jetpack-my-jetpack' ) }</h2>
-			<p className={ styles.description }>
-				{ __(
-					'Browse our expert guides to get help with setup, features, and troubleshooting.',
-					'jetpack-my-jetpack'
+		<>
+			<section
+				className={ clsx(
+					parentStyles[ 'constrained-section' ],
+					parentStyles[ 'tab-content-wrapper' ]
 				) }
-			</p>
-			<Button
-				variant="primary"
-				href={ getRedirectUrl( 'jetpack-support' ) }
-				target="_blank"
-				rel="noopener noreferrer"
-				className={ styles.cta }
-				onClick={ handleExploreHelpCenterClick }
 			>
-				<span>
-					{ __( 'Explore our Help Center', 'jetpack-my-jetpack' ) }
-					<span role="presentation" aria-hidden="true">
-						&nbsp;
-						{ '↗' }
+				<h2>{ __( 'Need assistance?', 'jetpack-my-jetpack' ) }</h2>
+				<p className={ styles.description }>
+					{ __(
+						'Browse our expert guides to get help with setup, features, and troubleshooting.',
+						'jetpack-my-jetpack'
+					) }
+				</p>
+				<Button
+					variant="primary"
+					href={ getRedirectUrl( 'jetpack-support' ) }
+					target="_blank"
+					rel="noopener noreferrer"
+					className={ styles.cta }
+					onClick={ handleExploreHelpCenterClick }
+				>
+					<span>
+						{ __( 'Explore our Help Center', 'jetpack-my-jetpack' ) }
+						<span role="presentation" aria-hidden="true">
+							&nbsp;
+							{ '↗' }
+						</span>
 					</span>
-				</span>
-			</Button>
-			<HelpCards />
+				</Button>
+				<HelpCards />
+			</section>
+
 			<FullWidthSeparator />
-			<HelpFooter />
-		</section>
+
+			<div className={ styles.footer }>
+				<div className={ clsx( parentStyles[ 'constrained-section' ], styles[ 'footer-inner' ] ) }>
+					<HelpFooter />
+				</div>
+			</div>
+		</>
 	);
 }

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/help/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/help/styles.module.scss
@@ -1,5 +1,4 @@
 @use "@automattic/jetpack-base-styles/gutenberg-base-styles" as gb;
-@use "../styles.module.scss" as parent;
 
 .description {
 	font-size: 1rem;
@@ -32,23 +31,8 @@
 }
 
 .footer {
-	width: 100vw;
-	margin-inline-start: calc(-50vw + 50%);
+	width: 100%;
 	background: var(--studio-white, #fff);
-
-	/* Center the content within the full-width background */
-	display: flex;
-	justify-content: center;
-
-	// 1128 + 3rem (96px) = 1224px + 64px (no idea what that is) = 1288px
-	@media (max-width: 1288px) {
-		// I have to hardcode --max-container-width because
-		// media queries don't work with CSS variables
-		margin-inline-start: -3rem; // Match the parent's padding-inline
-		margin-inline-end: -3rem;
-		width: calc(100% + 6rem); // Compensate for the negative margins
-		padding-inline: 3rem;
-	}
 
 	section {
 		max-width: 35rem;
@@ -65,14 +49,6 @@
 .footer-inner {
 	padding-top: 2.5rem;
 	padding-bottom: 1.5rem;
-	width: 100%;
-	padding-inline: 3rem;
-
-	@include parent.full-width-container;
-
-	@media ( max-width: 1288px ) {
-		padding-inline: 0;
-	}
 }
 
 .footer-learn-more {

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/overview/content.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/overview/content.tsx
@@ -1,9 +1,11 @@
 import { Col, Container } from '@automattic/jetpack-components';
 import { currentUserCan } from '@automattic/jetpack-script-data';
+import clsx from 'clsx';
 import ConnectionsSection from '../../connections-section';
 import PlansSection from '../../plans-section';
 import ProductCardsSection from '../../product-cards-section';
 import { FullWidthSeparator } from '../full-width-separator';
+import parentStyles from '../styles.module.scss';
 import { A4AUpsell } from './a4a-upsell';
 import styles from './styles.module.scss';
 
@@ -14,21 +16,28 @@ import styles from './styles.module.scss';
  */
 export function OverviewContent() {
 	return (
-		<div>
-			<div className={ styles.products }>
-				<ProductCardsSection />
+		<>
+			<div
+				className={ clsx(
+					parentStyles[ 'constrained-section' ],
+					parentStyles[ 'tab-content-wrapper' ]
+				) }
+			>
+				<div className={ styles.products }>
+					<ProductCardsSection />
+				</div>
+
+				{ currentUserCan( 'manage_options' ) ? (
+					<div className={ styles[ 'jetpack-manage-upsell' ] }>
+						<A4AUpsell />
+					</div>
+				) : null }
 			</div>
 
-			{ currentUserCan( 'manage_options' ) ? (
-				<div className={ styles[ 'jetpack-manage-upsell' ] }>
-					<A4AUpsell />
-				</div>
-			) : null }
-
 			<FullWidthSeparator />
+
 			<div className={ styles.footer }>
-				{ /* Needed to show different background colour */ }
-				<div className={ styles[ 'footer-inner' ] }>
+				<div className={ clsx( parentStyles[ 'constrained-section' ], styles[ 'footer-inner' ] ) }>
 					<Container horizontalSpacing={ 0 } className={ styles[ 'footer-container' ] }>
 						<Col sm={ 4 } md={ 4 } lg={ 6 }>
 							<PlansSection />
@@ -39,6 +48,6 @@ export function OverviewContent() {
 					</Container>
 				</div>
 			</div>
-		</div>
+		</>
 	);
 }

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/overview/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/overview/styles.module.scss
@@ -1,6 +1,3 @@
-@use "@automattic/jetpack-base-styles/gutenberg-base-styles" as gb;
-@use "../styles.module.scss" as parent;
-
 .products {
 	margin-bottom: 3rem;
 }
@@ -10,33 +7,13 @@
 }
 
 .footer {
-	width: 100vw;
-	margin-inline-start: calc(-50vw + 50%);
+	width: 100%;
 	background: var(--studio-white, #fff);
-
-	/* Center the content within the full-width background */
-	display: flex;
-	justify-content: center;
-
-	// 1128 + 3rem (96px) = 1224px + 64px (no idea what that is) = 1288px
-	@media ( max-width: 1288px ) {
-		// I have to hardcode --max-container-width
-		// because media queries don't work with CSS variables
-		margin-inline-start: -3rem; // Match the parent's padding-inline
-		margin-inline-end: -3rem;
-		width: calc(100% + 6rem); // Compensate for the negative margins
-		padding-inline: 3rem;
-	}
 }
 
 .footer-inner {
 	padding-top: 2.5rem;
 	padding-bottom: 1.5rem;
-	margin: 0 auto;
-	width: 100%;
-	padding-inline: 3rem;
-
-	@include parent.full-width-container;
 
 	a,
 	a.components-external-link,

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/content.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/content.tsx
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
+import parentStyles from '../styles.module.scss';
 import { Products } from './products';
 import styles from './styles.module.scss';
 
@@ -10,7 +11,14 @@ import styles from './styles.module.scss';
  */
 const ProductsContent = () => {
 	return (
-		<section className={ clsx( styles.content, styles[ 'my-jetpack-products-tab__content' ] ) }>
+		<section
+			className={ clsx(
+				parentStyles[ 'constrained-section' ],
+				parentStyles[ 'tab-content-wrapper' ],
+				styles.content,
+				styles[ 'my-jetpack-products-tab__content' ]
+			) }
+		>
 			<h2>{ __( 'Products', 'jetpack-my-jetpack' ) }</h2>
 			<p className={ styles.description }>
 				{ __(

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/styles.module.scss
@@ -17,13 +17,23 @@
 	}
 }
 
-.tab-content-wrapper {
-	padding-block-start: 2.5rem;
+@mixin full-width-container {
+	max-width: var(--max-container-width);
+	margin: 0 auto;
+}
+
+.constrained-section {
+
+	@include full-width-container;
 	padding-inline: 3rem;
 
 	@media (max-width: gb.$break-medium ) {
 		padding-inline: 1.5rem;
 	}
+}
+
+.tab-content-wrapper {
+	padding-block-start: 2.5rem;
 
 	h2 {
 
@@ -35,15 +45,7 @@
 
 .full-width-separator {
 	border-top: 1px solid var(--jp-gray);
-	width: 100vw;
-	position: relative;
-	inset-inline-start: 50%;
-	margin-inline-start: -50vw;
-}
-
-@mixin full-width-container {
-	max-width: var(--max-container-width);
-	margin: 0 auto;
+	width: 100%;
 }
 
 .my-jetpack-tab-panel--full-width {
@@ -64,10 +66,5 @@
 
 	:global(.components-tab-panel__tab-content) {
 		background-color: #fcfcfc;
-
-		.my-jetpack-tab-panel-inner {
-
-			@include full-width-container;
-		}
 	}
 }

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/tab-content.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/tab-content.tsx
@@ -1,8 +1,6 @@
-import clsx from 'clsx';
 import { HelpContent } from './help/content';
 import { OverviewContent } from './overview/content';
 import { ProductsContent } from './products/content';
-import styles from './styles.module.scss';
 import { MyJetpackSection } from './types';
 import type { ComponentType } from 'react';
 
@@ -30,11 +28,5 @@ export function TabContent( { name }: TabContentProps ) {
 		return null;
 	}
 
-	return (
-		<div className={ styles[ 'my-jetpack-tab-panel-inner' ] }>
-			<div className={ clsx( styles[ 'tab-content-wrapper' ] ) }>
-				<ContentComponent />
-			</div>
-		</div>
-	);
+	return <ContentComponent />;
 }

--- a/projects/packages/my-jetpack/_inc/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/style.module.scss
@@ -1,4 +1,11 @@
+@use "@automattic/jetpack-base-styles/admin-page-layout" as *;
+
 :global {
+
+	body.jetpack_page_my-jetpack {
+
+		@include jetpack-admin-page-layout;
+	}
 
 	// Hello Dolly compatibility fix
 	body.jetpack_page_my-jetpack p#dolly {

--- a/projects/packages/my-jetpack/changelog/adopt-admin-page-layout-mixin
+++ b/projects/packages/my-jetpack/changelog/adopt-admin-page-layout-mixin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Adopt jetpack-admin-page-layout mixin.

--- a/projects/packages/my-jetpack/changelog/fix-tab-panel-full-width-elements
+++ b/projects/packages/my-jetpack/changelog/fix-tab-panel-full-width-elements
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: restructure tab panel so full-width separators and footers no longer rely on viewport-width math, eliminating the horizontal scrollbar that appeared when the page scrollbar was present.


### PR DESCRIPTION
## Proposed changes

- Adopts the shared `jetpack-admin-page-layout` SCSS mixin (from `@automattic/jetpack-base-styles`) for the My Jetpack admin page, bringing it in line with the 8 other Jetpack admin pages migrated in the prior layout-unification series (Network admin, Boost, Search, Newsletter, Backup, VideoPress, Publicize, Protect).
- After this change the My Jetpack page has a fixed Jetpack header, an internally-scrolling middle section, and a `JetpackFooter` pinned to the bottom of the viewport — no window-level scroll, consistent with the other migrated pages.
- Removes the per-package layout compensation that the mixin now handles (wp-admin padding/margin counters, any local `#wpfooter` overrides or height-calc workarounds — see the diff for specifics).
- `ScrollToTop` updated to scroll the internal `#wpbody-content` container rather than `window`, since the window no longer scrolls on this page.
- **Tab panel restructure (second commit).** Reworks `MyJetpackTabPanel` so its full-width children — the under-tabs separator, the in-tab separators in Overview/Help, and the Overview/Help white footers — are rendered as direct, naturally-full-width siblings of the tab-content area instead of being broken out of a constrained inner with `100vw` / `-50vw` math. The viewport-width math equates `100vw` with the container's content area, which only holds when the page itself has no scrollbar; under the new admin-page-layout (which introduces an internal scroll container) the breakout overshot by the scrollbar's width and produced a horizontal scrollbar of its own. The new structure exposes two composable utilities (`.constrained-section` and `.tab-content-wrapper`) that each content component applies to its own constrained blocks, while full-width pieces sit outside them. Both Overview and Help footers also drop the 1288px hardcoded media-query fallback that was tied to the old breakout.

  ## Before / After

  <details>
  <summary>Desktop (1440×900)</summary>

  | Tab | Before | After |
  |---|---|---|
  | Overview | <img width="1440" height="900" alt="before-desktop-overview" src="https://github.com/user-attachments/assets/74a95fb0-f28e-4ade-b39e-8916fbe70f99" /> | <img width="1440" height="900" alt="after-desktop-overview" src="https://github.com/user-attachments/assets/86d1d460-e4c2-4458-a1d5-ba45b0d3d2d2" /> |
  | Products | <img width="1440" height="900" alt="before-desktop-products" src="https://github.com/user-attachments/assets/4858069c-a700-4b61-9d1d-7eb23ebbe3e0" /> | <img width="1440" height="900" alt="after-desktop-products" src="https://github.com/user-attachments/assets/d01d95cd-3b31-4f75-8a3d-ff8c6895f452" /> |
  | Help     | <img width="1440" height="900" alt="before-desktop-help" src="https://github.com/user-attachments/assets/820ee2d9-66b9-4624-9442-2710ce636ae6" /> | <img width="1440" height="900" alt="after-desktop-help" src="https://github.com/user-attachments/assets/1b3705a9-c85f-429c-9a12-e4d8e9657a9e" /> |


  </details>

  <details>
  <summary>Mobile (390×844)</summary>

  | Tab | Before | After |
  |---|---|---|
  | Overview | <img width="390" height="844" alt="before-mobile-overview" src="https://github.com/user-attachments/assets/a7e18ee2-1334-43da-a6c7-75dd0584e709" /> | <img width="390" height="844" alt="after-mobile-overview" src="https://github.com/user-attachments/assets/02d03f8b-eecc-49ad-a2f4-7eb5e0bd5aa8" /> |
  | Products | <img width="390" height="844" alt="before-mobile-products" src="https://github.com/user-attachments/assets/922f5ee8-a700-4c4c-988c-f339393a4fea" /> | <img width="390" height="844" alt="after-mobile-products" src="https://github.com/user-attachments/assets/3685e5f0-548c-4b5a-a7d0-3207b8687a9c" /> |
  | Help     | <img width="390" height="844" alt="before-mobile-help" src="https://github.com/user-attachments/assets/dfc79203-1d6f-4cc7-9875-817c8dc48890" /> | <img width="390" height="844" alt="after-mobile-help" src="https://github.com/user-attachments/assets/e985987e-5b2e-4a8d-8dab-b74815ad52d2" /> |


  </details>

## Does this pull request change what data or activity we track or use?

No. This is layout/CSS only. No data collection, no new tracks events, no permission changes.

## Testing instructions

1. Install/activate Jetpack on a connected site and log in as an admin.
2. Visit My Jetpack (`admin.php?page=my-jetpack`).
3. Confirm the Jetpack header stays pinned to the top when you scroll inside the page content.
4. Confirm the `JetpackFooter` is pinned to the bottom of the viewport (not floating mid-page on tall content, not missing on short content).
5. Confirm there is **no horizontal scrollbar** at desktop widths (e.g. 1440px and 1200px) or at the ≤782px mobile breakpoint. This was the regression the second commit fixes — `document.documentElement.scrollWidth` should equal `clientWidth`.
6. Resize the window across the 782px and 960px breakpoints. Confirm the sidebar offset and body-content column width stay correct (no dead gap on the right, no content clipping on the left).
7. Toggle the sidebar manually (`.folded`) — confirm layout adjusts.
8. Confirm the admin bar (32px desktop / 46px mobile) is correctly accounted for — no overlap with the Jetpack header, no gap.
9. Click through Overview / Products / Help tabs. On each:
    - The horizontal separator immediately below the tabs should span the full panel width.
    - Constrained content blocks (cards, descriptions, charts, A4A upsell, help cards) should center inside the panel with the standard `--max-container-width` constraint.
    - On Overview and Help: the white-background footer at the bottom (Plans+Connections / HelpFooter respectively) should render edge-to-edge of the panel, with its inner content re-constrained to the same max-width column as the rest of the page.
10. Click around the My Jetpack internal routes (onboarding flow, product interstitials, connection screens) and confirm each still renders without regressions.
11. Confirm `ScrollToTop` still works when navigating between internal routes — the content area should scroll to the top, not stay where the previous route left it.
12. Confirm JITM cards (if any active) still render in their usual spot.
13. Confirm the "Modules" and "Reset options" footer links (if present) still render and work.

