### PR TITLE
Write: Fix jarring line reflow while typing caused by theme's text-wrap

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-write_text_wrap
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-write_text_wrap
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write: Fix jarring line reflow while typing caused by theme's text-wrap

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -204,6 +204,7 @@
 	overflow: hidden;
 	box-sizing: border-box;
 	field-sizing: content;
+	text-wrap: stable;
 }
 
 .bw-title::placeholder {
@@ -448,6 +449,11 @@
 	outline: none;
 	overflow-wrap: break-word;
 	word-break: normal;
+	text-wrap: stable;
+}
+
+.bw-content * {
+	text-wrap: stable;
 }
 
 .bw-content:empty::before {


### PR DESCRIPTION
Fixes RSM-1234                                                                                                                            
                                                                                                                                             
  ## Proposed changes
                                                                                                                                             
  * Set `text-wrap: stable` on `.bw-title`, `.bw-content`, and `.bw-content *` to override themes that apply `text-wrap: pretty` to block elements, preventing previously-typed lines from re-wrapping while the user is actively editing.                                         
                                                                                                                                             
  ## Related product discussion/links                                                                                                      
                                                                                                                                             
  * n/a

  ## Does this pull request change what data or activity we track or use?                                                                    
   
  No.                                                                                                                                        
                                                                                                                                           
  ## Testing instructions

1. Go to the Write editor (`wp-admin/admin.php?page=write`) on a site using a theme that applies `text-wrap: pretty` to block elements (e.g. Twenty Twenty-Five).
2.  Type a paragraph long enough to wrap across multiple lines.                                                                              
3. Continue typing — previously-wrapped lines should remain stable with no mid-sentence word shifts.
