### PR TITLE
Add reusable Claude Code review workflow

### DIFF
--- a/.github/workflows/claude-review-shared.yml
+++ b/.github/workflows/claude-review-shared.yml
@@ -28,7 +28,22 @@ on:
         required: true
 
 jobs:
+  guard:
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Reject callers outside Automattic org
+        run: |
+          case "$CALLER_OWNER" in
+            Automattic) ;;
+            *) echo "Caller $CALLER_REPO is not allowed." >&2; exit 1 ;;
+          esac
+        env:
+          CALLER_OWNER: ${{ github.repository_owner }}
+          CALLER_REPO: ${{ github.repository }}
+
   claude:
+    needs: guard
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/claude-review-shared.yml
+++ b/.github/workflows/claude-review-shared.yml
@@ -1,41 +1,25 @@
 name: Claude Code (shared, reusable)
 
-# Reusable workflow that other Automattic repos call via workflow_call to get
-# the same AI code review behavior as the monorepo's claude.yml.
+# workflow_call reusable: satellites invoke this to get claude.yml's AI code
+# review behavior, with the skill and slash commands living only in the
+# monorepo.
 #
-# Skill files live at .agents/skills/jetpack-review-pr.md and .claude/commands/
-# jetpack-*.md in this repo, and are the single source of truth. Callers do not
-# maintain copies; the workflow sparse-checks-out monorepo trunk at runtime to
-# fetch them.
+# - The skill (.agents/skills/jetpack-review-pr.md) and slash commands
+#   (.claude/commands/jetpack-*.md) are sparse-checked-out from monorepo trunk
+#   at runtime and copied into the caller's workspace. Satellites must not
+#   maintain copies; any caller files at those paths get overwritten each run.
 #
-# Caller responsibilities (NOT handled here):
-#   - Trigger conditions (issue_comment, pull_request_review_comment, etc.).
-#   - Author gating (e.g. author_association in MEMBER/OWNER).
-#   - Body matching (e.g. contains(comment.body, '@claude')).
-#   - Granting secrets.ANTHROPIC_API_KEY at the satellite repo. The workflow
-#     fails opaquely if missing.
-# See Automattic/jetpack/.github/workflows/claude.yml for a reference caller.
+# - See claude.yml for caller reference. The caller wires triggers, author
+#   gating, and body matching, and provides secrets.ANTHROPIC_API_KEY at the
+#   satellite repo.
 #
-# Permissions: the satellite's GITHUB_TOKEN scope in this called job is set by
-# the permissions block below, NOT by the satellite caller's workflow-level
-# permissions. Satellites cannot tighten the scope from their side. The
-# id-token: write grant is required by anthropics/claude-code-action (it mints
-# an OIDC token for the claude[bot] identity) and must not be removed.
+# - The permissions block below sets the satellite's GITHUB_TOKEN scope for
+#   this job; satellites can't tighten or loosen it from their workflow file.
+#   id-token: write is required by claude-code-action for OIDC and must stay.
 #
-# Wire-up overwrites pre-existing satellite files at .claude/commands/jetpack-
-# review-pr.md, jetpack-pr.md, jetpack-changelog.md, and .agents/skills/jetpack-
-# review-pr.md. Satellites must not customize those paths; fork the workflow
-# if you need different behavior.
-#
-# Supply chain: this workflow checks out Automattic/jetpack@trunk on every run.
-# A bad commit to trunk in the skill files affects every satellite on its next
-# invocation. This is the explicit "single source of truth" tradeoff. Satellites
-# that want defense-in-depth MAY SHA-pin the reusable workflow itself in their
-# `uses:` line; the skill content stays on trunk by design.
-#
-# OIDC: satellites that trust GitHub OIDC for cloud roles must condition on
-# job_workflow_ref (not just repository), since a compromised monorepo trunk
-# could otherwise mint tokens the satellite cloud trust accepts.
+# - ref:trunk on the sparse-checkout means skill changes ship to satellites
+#   with no per-satellite bumps. Satellites that prefer to gate skill changes
+#   on an explicit bump MAY SHA-pin THIS workflow file in their `uses:` line.
 
 on:
   workflow_call:

--- a/.github/workflows/claude-review-shared.yml
+++ b/.github/workflows/claude-review-shared.yml
@@ -1,0 +1,77 @@
+name: Claude Code (shared, reusable)
+
+# Reusable workflow that other Automattic repos can call via workflow_call
+# to get the same AI code review behavior as the monorepo's claude.yml.
+#
+# The review skill lives at .agents/skills/jetpack-review-pr.md in this
+# repo and is the single source of truth — callers don't maintain copies.
+# At runtime, the workflow checks out this monorepo to fetch the skill,
+# then runs anthropics/claude-code-action against the caller's repo
+# context (PR, issue, comment).
+#
+# The caller is responsible for trigger conditions (@claude mention,
+# author_association, etc.) and for granting the necessary permissions
+# and secrets.
+
+on:
+  workflow_call:
+    secrets:
+      ANTHROPIC_API_KEY:
+        required: true
+
+jobs:
+  claude:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: read
+      id-token: write
+    steps:
+      - name: Checkout caller repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Fetch shared review skill from Jetpack monorepo
+        uses: actions/checkout@v6
+        with:
+          repository: Automattic/jetpack
+          ref: trunk
+          sparse-checkout: |
+            .agents/skills/jetpack-review-pr.md
+            .claude/commands/jetpack-review-pr.md
+            .claude/commands/jetpack-pr.md
+            .claude/commands/jetpack-changelog.md
+          sparse-checkout-cone-mode: false
+          path: .jetpack-shared
+          fetch-depth: 1
+
+      - name: Wire up shared slash commands and skill
+        run: |
+          mkdir -p .claude/commands .agents/skills
+          cp .jetpack-shared/.claude/commands/jetpack-review-pr.md .claude/commands/
+          cp .jetpack-shared/.claude/commands/jetpack-pr.md .claude/commands/
+          cp .jetpack-shared/.claude/commands/jetpack-changelog.md .claude/commands/
+          cp .jetpack-shared/.agents/skills/jetpack-review-pr.md .agents/skills/
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6 # v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          additional_permissions: |
+            actions: read
+          claude_args: >-
+            --max-turns 30
+            --allowedTools
+            "Bash(gh issue *)"
+            "Bash(gh pr *)"
+            "Bash(git diff *)"
+            "Bash(git log *)"
+            "Bash(git show *)"
+            Read
+            Write
+            Glob
+            Grep

--- a/.github/workflows/claude-review-shared.yml
+++ b/.github/workflows/claude-review-shared.yml
@@ -1,17 +1,41 @@
 name: Claude Code (shared, reusable)
 
-# Reusable workflow that other Automattic repos can call via workflow_call
-# to get the same AI code review behavior as the monorepo's claude.yml.
+# Reusable workflow that other Automattic repos call via workflow_call to get
+# the same AI code review behavior as the monorepo's claude.yml.
 #
-# The review skill lives at .agents/skills/jetpack-review-pr.md in this
-# repo and is the single source of truth — callers don't maintain copies.
-# At runtime, the workflow checks out this monorepo to fetch the skill,
-# then runs anthropics/claude-code-action against the caller's repo
-# context (PR, issue, comment).
+# Skill files live at .agents/skills/jetpack-review-pr.md and .claude/commands/
+# jetpack-*.md in this repo, and are the single source of truth. Callers do not
+# maintain copies; the workflow sparse-checks-out monorepo trunk at runtime to
+# fetch them.
 #
-# The caller is responsible for trigger conditions (@claude mention,
-# author_association, etc.) and for granting the necessary permissions
-# and secrets.
+# Caller responsibilities (NOT handled here):
+#   - Trigger conditions (issue_comment, pull_request_review_comment, etc.).
+#   - Author gating (e.g. author_association in MEMBER/OWNER).
+#   - Body matching (e.g. contains(comment.body, '@claude')).
+#   - Granting secrets.ANTHROPIC_API_KEY at the satellite repo. The workflow
+#     fails opaquely if missing.
+# See Automattic/jetpack/.github/workflows/claude.yml for a reference caller.
+#
+# Permissions: the satellite's GITHUB_TOKEN scope in this called job is set by
+# the permissions block below, NOT by the satellite caller's workflow-level
+# permissions. Satellites cannot tighten the scope from their side. The
+# id-token: write grant is required by anthropics/claude-code-action (it mints
+# an OIDC token for the claude[bot] identity) and must not be removed.
+#
+# Wire-up overwrites pre-existing satellite files at .claude/commands/jetpack-
+# review-pr.md, jetpack-pr.md, jetpack-changelog.md, and .agents/skills/jetpack-
+# review-pr.md. Satellites must not customize those paths; fork the workflow
+# if you need different behavior.
+#
+# Supply chain: this workflow checks out Automattic/jetpack@trunk on every run.
+# A bad commit to trunk in the skill files affects every satellite on its next
+# invocation. This is the explicit "single source of truth" tradeoff. Satellites
+# that want defense-in-depth MAY SHA-pin the reusable workflow itself in their
+# `uses:` line; the skill content stays on trunk by design.
+#
+# OIDC: satellites that trust GitHub OIDC for cloud roles must condition on
+# job_workflow_ref (not just repository), since a compromised monorepo trunk
+# could otherwise mint tokens the satellite cloud trust accepts.
 
 on:
   workflow_call:
@@ -56,6 +80,7 @@ jobs:
           cp .jetpack-shared/.claude/commands/jetpack-pr.md .claude/commands/
           cp .jetpack-shared/.claude/commands/jetpack-changelog.md .claude/commands/
           cp .jetpack-shared/.agents/skills/jetpack-review-pr.md .agents/skills/
+          rm -rf .jetpack-shared
 
       - name: Run Claude Code
         uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6 # v1

--- a/.github/workflows/claude-review-shared.yml
+++ b/.github/workflows/claude-review-shared.yml
@@ -18,8 +18,7 @@ name: Claude Code (shared, reusable)
 #   id-token: write is required by claude-code-action for OIDC and must stay.
 #
 # - ref:trunk on the sparse-checkout means skill changes ship to satellites
-#   with no per-satellite bumps. Satellites that prefer to gate skill changes
-#   on an explicit bump MAY SHA-pin THIS workflow file in their `uses:` line.
+#   with no per-satellite bumps.
 
 on:
   workflow_call:


### PR DESCRIPTION
@kraftbj @anomiex @lezama Adding y'all bc you touched Claude workflows in this repo. 🙏🏾

## Proposed changes

* Add `.github/workflows/claude-review-shared.yml` — a `workflow_call` reusable workflow that other Automattic repos can call to get the same AI review behavior as `claude.yml`. Sparse-checks-out this monorepo's `.agents/skills/jetpack-review-pr.md` + `.claude/commands/*.md` at runtime, then runs `anthropics/claude-code-action`. Single source of truth for the skill stays here.
* Includes a caller-org guard that rejects invocations from outside the `Automattic` org (mirrors [the pattern in `woocommerce/.github`'s reusable AI-review workflow](https://github.com/woocommerce/.github/blob/trunk/.github/workflows/ai-code-review.yml#L48)). The reusable lives in a public repo, so the guard makes the support contract explicit.
* `claude.yml` is unchanged.

## Related product discussion/links

* Linear: QAO-424 - rolling this out to JPOP-Happiness-touched Jetpack satellites (`jetpack-crm`, `jetpack-videopress`, `WP-Job-Manager`).
* Companion PR on `Automattic/jetpack-videopress` necessary to add the first satellite caller. https://github.com/Automattic/jetpack-videopress/compare/add/ai-code-review

## Does this pull request change what data or activity we track or use?

No. Same action, same key, same skill, same review output.

## Testing instructions

The reusable workflow has no observable behavior in this repo on its own (no events trigger it directly). End-to-end test runs through the satellite caller PR: once both land, drop \`@claude /jetpack-review-pr <PR> quick\` on a \`jetpack-videopress\` PR (MEMBER/OWNER) and verify a review posts back.