### PR TITLE
WPCOM_REST_API_V2_Endpoint_AI: Optimize to prevent unnecessary overhead

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php
@@ -49,7 +49,11 @@ class WPCOM_REST_API_V2_Endpoint_AI extends WP_REST_Controller {
 		}
 
 		$this->register_basic_routes();
-		$this->register_ai_chat_routes();
+
+		// When AI chat is disabled, the routes are not registered (404).
+		if ( Jetpack_AI_Helper::is_ai_chat_enabled() ) {
+			$this->register_ai_chat_routes();
+		}
 
 		if ( \Jetpack_AI_Helper::is_enabled() ) {
 			$this->register_routes();
@@ -124,7 +128,7 @@ class WPCOM_REST_API_V2_Endpoint_AI extends WP_REST_Controller {
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'request_chat_with_site' ),
-					'permission_callback' => array( 'Jetpack_AI_Helper', 'is_ai_chat_enabled' ),
+					'permission_callback' => '__return_true',
 				),
 				'args' => array(
 					'query'         => array(
@@ -148,7 +152,7 @@ class WPCOM_REST_API_V2_Endpoint_AI extends WP_REST_Controller {
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'rank_response' ),
-					'permission_callback' => array( 'Jetpack_AI_Helper', 'is_ai_chat_enabled' ),
+					'permission_callback' => '__return_true',
 				),
 				'args' => array(
 					'cache_key' => array(

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php
@@ -37,23 +37,23 @@ class WPCOM_REST_API_V2_Endpoint_AI extends WP_REST_Controller {
 		$this->is_wpcom                     = true;
 		$this->wpcom_is_wpcom_only_endpoint = true;
 
+		add_action( 'rest_api_init', array( $this, 'register_all_routes' ) );
+	}
+
+	/**
+	 * Register all routes, loading Jetpack_AI_Helper first.
+	 */
+	public function register_all_routes() {
 		if ( ! class_exists( 'Jetpack_AI_Helper' ) ) {
 			require_once JETPACK__PLUGIN_DIR . '_inc/lib/class-jetpack-ai-helper.php';
 		}
 
-		// Register routes that don't require Jetpack AI to be enabled.
-		add_action( 'rest_api_init', array( $this, 'register_basic_routes' ) );
+		$this->register_basic_routes();
+		$this->register_ai_chat_routes();
 
-		if ( Jetpack_AI_Helper::is_ai_chat_enabled() ) {
-			add_action( 'rest_api_init', array( $this, 'register_ai_chat_routes' ) );
+		if ( \Jetpack_AI_Helper::is_enabled() ) {
+			$this->register_routes();
 		}
-
-		if ( ! \Jetpack_AI_Helper::is_enabled() ) {
-			return;
-		}
-
-		// Register routes that require Jetpack AI to be enabled.
-		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
 	}
 
 	/**
@@ -124,7 +124,7 @@ class WPCOM_REST_API_V2_Endpoint_AI extends WP_REST_Controller {
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'request_chat_with_site' ),
-					'permission_callback' => '__return_true',
+					'permission_callback' => array( 'Jetpack_AI_Helper', 'is_ai_chat_enabled' ),
 				),
 				'args' => array(
 					'query'         => array(
@@ -148,7 +148,7 @@ class WPCOM_REST_API_V2_Endpoint_AI extends WP_REST_Controller {
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'rank_response' ),
-					'permission_callback' => '__return_true',
+					'permission_callback' => array( 'Jetpack_AI_Helper', 'is_ai_chat_enabled' ),
 				),
 				'args' => array(
 					'cache_key' => array(

--- a/projects/plugins/jetpack/changelog/update-wpcom_rest_api_v2_endpoint_ai-prevent-calls
+++ b/projects/plugins/jetpack/changelog/update-wpcom_rest_api_v2_endpoint_ai-prevent-calls
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Endpoints: Ensure the WPCOM_REST_API_V2_Endpoint_AI does not require files, nor make function calls, unless directly called.


### PR DESCRIPTION
Related to SYNC-320

## Proposed changes

* This PR aims to improve the performance of endpoints generally, by ensuring requires, function calls, and DB calls, are not made within the `__construct` function or in the file directly, as all endpoint file will load regardless of the endpoint being called. 
* Specifically what has changed here:
 * The `require_once` moves to `register_all_routes`, which only fires on REST API
  requests via `rest_api_init`. On any non-REST page load, `class-jetpack-ai-helper.php` is never touched.
* Additionally, function calls via `Jetpack_AI_Helper` will also only be made on REST requests.
* This includes `Jetpack_AI_Helper::is_ai_chat_enabled`, which results in DB hits to check
  connection status and plan info, and `is_enabled`.
* We also consolidated route registration — three separate add_action( 'rest_api_init', ... ) calls were collapsed into one  (`register_all_routes`), which explicitly loads `Jetpack_AI_Helper` first before registering any routes. This makes the load order unambiguous and easier to reason about.

Note - there is still wp-admin/editor REST bootstrap overhead here, as the intention without being too familiar with the endpoint it to ensure behaviour matches previous behaviour (eg. we only register routes when these specific checks pass, vs another alternative which would be to always register routes but only load the helpers in eg. permission checks so they only run when the endpoint is directly called).

## Related product discussion/links

* This is part of the RSM project to reduce request time overhead at scale.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This testing confirms that the endpoint functionality itself is not impacted.

* On a Jetpack API sandboxed site, add the following snippet with a code snippets plugin:
```
add_filter( 'jetpack_ai_chat_enabled', function( $default ) {
    return true;
}, 10, 1 );
```
* Additionally, ensure you have a Search plan.
* Then, in the WP.com developer console, do a GET request for the `/jetpack-search/ai/search` endpoint. Example:
<img width="760" height="72" alt="Screenshot 2026-04-26 at 13 23 55" src="https://github.com/user-attachments/assets/e7def72c-6d7d-4f3b-a03f-74f2055ceeb1" />

* Grab the cache_key from the response, then visit the  GET`/ai/rank` endpoint via the console, entering the cache key.
