### PR TITLE
Modules: rewrite legacy Backbone list-table as React + <AdminPage>

### DIFF
--- a/projects/plugins/jetpack/_inc/client/modules-admin/index.tsx
+++ b/projects/plugins/jetpack/_inc/client/modules-admin/index.tsx
@@ -29,15 +29,14 @@
 
 import { AdminPage, ThemeProvider, getRedirectUrl } from '@automattic/jetpack-components';
 import {
-	Button,
 	SearchControl,
 	ToggleControl,
 	__experimentalToggleGroupControl as ToggleGroupControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
 import { createRoot } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { Button, Stack } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useCallback, useMemo, useState } from 'react';
 import './style.scss';
@@ -292,14 +291,24 @@ function ModulesAdminApp() {
 	}, [] );
 
 	const headerActions = (
-		<HStack spacing={ 2 } justify="flex-end">
-			<Button variant="secondary" href={ adminUrl( 'admin.php?page=jetpack#/dashboard' ) }>
+		<Stack direction="row" gap="sm" justify="flex-end">
+			<Button
+				variant="outline"
+				tone="neutral"
+				nativeButton={ false }
+				render={ <a href={ adminUrl( 'admin.php?page=jetpack#/dashboard' ) } /> }
+			>
 				{ __( 'Dashboard', 'jetpack' ) }
 			</Button>
-			<Button variant="secondary" href={ adminUrl( 'admin.php?page=jetpack#/settings' ) }>
+			<Button
+				variant="outline"
+				tone="neutral"
+				nativeButton={ false }
+				render={ <a href={ adminUrl( 'admin.php?page=jetpack#/settings' ) } /> }
+			>
 				{ __( 'Settings', 'jetpack' ) }
 			</Button>
-		</HStack>
+		</Stack>
 	);
 
 	if ( ! data ) {

--- a/projects/plugins/jetpack/_inc/client/modules-admin/index.tsx
+++ b/projects/plugins/jetpack/_inc/client/modules-admin/index.tsx
@@ -199,7 +199,18 @@ function ModuleRow( { item }: { item: JetpackModule } ) {
 				'is-unavailable': ! item.available,
 			} ) }
 		>
-			<div className="jp-modules-admin__row-name">{ item.name }</div>
+			{ item.learn_more_button ? (
+				<a
+					className="jp-modules-admin__row-name"
+					href={ item.learn_more_button }
+					target="_blank"
+					rel="noreferrer noopener"
+				>
+					{ item.name }
+				</a>
+			) : (
+				<div className="jp-modules-admin__row-name">{ item.name }</div>
+			) }
 			<div className="jp-modules-admin__row-actions">
 				{ item.configurable && (
 					<span

--- a/projects/plugins/jetpack/_inc/client/modules-admin/index.tsx
+++ b/projects/plugins/jetpack/_inc/client/modules-admin/index.tsx
@@ -1,31 +1,13 @@
-// Modules admin page (React entry point).
+// Modules admin page React entry. Mounts a list view (search, active/inactive
+// filter, sort, tag sub-filter, per-row activate/deactivate toggle) into the
+// `<div id="jp-modules-admin-root">` emitted by `Jetpack_Settings_Page`,
+// dressed in `<AdminPage>` chrome and the shared `jetpack-admin-page-layout`
+// SCSS mixin.
 //
-// Option C draft v1: replaces the legacy Backbone rendering of
-// `admin.php?page=jetpack_modules` with a React tree wrapped in <AdminPage>,
-// styled via the shared `jetpack-admin-page-layout` mixin.
-//
-// Visual goal: preserve trunk's two-column layout (list left, filter sidebar
-// right). Modernization comes from swapping primitives — Activate/Deactivate
-// buttons become a <ToggleControl>; segmented filters use <ToggleGroupControl>;
-// the top-right Dashboard/Settings links are passed to <AdminPage>'s `actions`
-// slot.
-//
-// v1 scope:
-//   - Module list from the existing `jetpackModulesData` blob.
-//   - Search, active/inactive filter, sort (alphabetical / newest / popular).
-//   - Tag sub-filter with counts.
-//   - Per-row activate / deactivate via existing server URLs (nonce redirect —
-//     the page reloads with fresh data, no client-side state mutation needed).
-//   - Settings-link passthrough (server-rendered `configurable` anchor).
-//   - Dashboard / Settings as header actions on the right.
-//
-// Deferred (follow-ups):
-//   - Bulk activate / deactivate (dropdown + Apply, with row checkboxes).
-//   - Thickbox "More info" per-module modal.
-//   - URL state sync (replaceState for search/filter/tag/sort).
-//
-// The PHP layer (`Jetpack_Settings_Page::page_render`) emits a single
-// `<div id="jp-modules-admin-root">` for this entry to mount into.
+// Per-row toggle navigates to the existing
+// `admin.php?page=jetpack&action=activate|deactivate` server URLs. The server
+// redirects back and the page reloads with fresh module state, so no
+// client-side state mutation or REST roundtrip is needed.
 
 import { AdminPage, ThemeProvider, getRedirectUrl } from '@automattic/jetpack-components';
 import {

--- a/projects/plugins/jetpack/_inc/client/modules-admin/index.tsx
+++ b/projects/plugins/jetpack/_inc/client/modules-admin/index.tsx
@@ -322,6 +322,7 @@ function TagButton( {
  * @param {Function} props.onChangeBulkAction - Called with the new bulk action value.
  * @param {number}   props.selectedCount      - How many modules are currently selected (across all filters).
  * @param {Function} props.onApply            - Called when the Apply button is pressed.
+ * @param {boolean}  props.applying           - Whether a bulk submission is in flight (toggles loading + disabled).
  * @return {import('react').ReactNode} Toolbar markup.
  */
 function BulkActionsToolbar( {
@@ -332,6 +333,7 @@ function BulkActionsToolbar( {
 	onChangeBulkAction,
 	selectedCount,
 	onApply,
+	applying,
 }: {
 	allSelected: boolean;
 	someSelected: boolean;
@@ -340,6 +342,7 @@ function BulkActionsToolbar( {
 	onChangeBulkAction: ( value: BulkAction ) => void;
 	selectedCount: number;
 	onApply: () => void;
+	applying: boolean;
 } ) {
 	const masterRef = useRef< HTMLInputElement | null >( null );
 	useEffect( () => {
@@ -383,7 +386,12 @@ function BulkActionsToolbar( {
 					{ value: 'bulk-deactivate', label: __( 'Deactivate', 'jetpack' ) },
 				] }
 			/>
-			<Button variant="secondary" onClick={ onApply } disabled={ ! canApply }>
+			<Button
+				onClick={ onApply }
+				disabled={ ! canApply || applying }
+				loading={ applying }
+				loadingAnnouncement={ __( 'Applying…', 'jetpack' ) }
+			>
 				{ __( 'Apply', 'jetpack' ) }
 			</Button>
 			{ selectedCount > 0 && (
@@ -493,6 +501,7 @@ function ModulesAdminApp() {
 	// behavior and keeps the implementation simple.
 	const [ selected, setSelected ] = useState< Set< string > >( () => new Set() );
 	const [ bulkAction, setBulkAction ] = useState< BulkAction >( '' );
+	const [ applying, setApplying ] = useState( false );
 
 	const onChangeBulkAction = useCallback( ( v: BulkAction ) => setBulkAction( v ), [] );
 
@@ -530,7 +539,7 @@ function ModulesAdminApp() {
 	);
 
 	const onApplyBulk = useCallback( () => {
-		if ( ! bulkAction || selected.size === 0 || ! data ) {
+		if ( ! bulkAction || selected.size === 0 || ! data || applying ) {
 			return;
 		}
 		const params = new URLSearchParams();
@@ -538,8 +547,15 @@ function ModulesAdminApp() {
 		params.set( 'action', bulkAction );
 		selected.forEach( slug => params.append( 'modules[]', slug ) );
 		params.set( '_wpnonce', data.nonces.bulk );
-		window.location.href = adminUrl( `admin.php?${ params.toString() }` );
-	}, [ bulkAction, selected, data ] );
+		const url = adminUrl( `admin.php?${ params.toString() }` );
+
+		// Flip to loading first so React can paint the spinner before the
+		// page navigates away. setTimeout(0) yields one frame to the browser.
+		setApplying( true );
+		setTimeout( () => {
+			window.location.href = url;
+		}, 0 );
+	}, [ bulkAction, selected, data, applying ] );
 
 	const headerActions = (
 		<Stack direction="row" gap="sm" justify="flex-end">
@@ -589,6 +605,7 @@ function ModulesAdminApp() {
 							onChangeBulkAction={ onChangeBulkAction }
 							selectedCount={ selected.size }
 							onApply={ onApplyBulk }
+							applying={ applying }
 						/>
 						<div className="jp-modules-admin__list" role="list">
 							{ filtered.length ? (

--- a/projects/plugins/jetpack/_inc/client/modules-admin/index.tsx
+++ b/projects/plugins/jetpack/_inc/client/modules-admin/index.tsx
@@ -12,6 +12,7 @@
 import { AdminPage, ThemeProvider, getRedirectUrl } from '@automattic/jetpack-components';
 import {
 	SearchControl,
+	SelectControl,
 	ToggleControl,
 	__experimentalToggleGroupControl as ToggleGroupControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption, // eslint-disable-line @wordpress/no-unsafe-wp-apis
@@ -20,7 +21,7 @@ import { createRoot } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button, Stack } from '@wordpress/ui';
 import clsx from 'clsx';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import './style.scss';
 
 type JetpackModule = {
@@ -55,6 +56,7 @@ declare global {
 
 type FilterActive = 'all' | 'true' | 'false';
 type SortKey = 'name' | 'introduced' | 'sort';
+type BulkAction = '' | 'bulk-activate' | 'bulk-deactivate';
 
 const FILTER_VALUES: readonly FilterActive[] = [ 'all', 'true', 'false' ] as const;
 const SORT_VALUES: readonly SortKey[] = [ 'name', 'introduced', 'sort' ] as const;
@@ -173,11 +175,21 @@ const toggleUrl = ( item: JetpackModule ): string | null => {
 /**
  * Module list row.
  *
- * @param {object}        props      - Props.
- * @param {JetpackModule} props.item - Module data.
+ * @param {object}        props          - Props.
+ * @param {JetpackModule} props.item     - Module data.
+ * @param {boolean}       props.selected - Whether this row is checked for bulk action.
+ * @param {Function}      props.onSelect - Called with (slug, checked) when the row checkbox toggles.
  * @return {import('react').ReactNode} Row markup.
  */
-function ModuleRow( { item }: { item: JetpackModule } ) {
+function ModuleRow( {
+	item,
+	selected,
+	onSelect,
+}: {
+	item: JetpackModule;
+	selected: boolean;
+	onSelect: ( slug: string, checked: boolean ) => void;
+} ) {
 	const href = toggleUrl( item );
 	const ariaLabel = item.activated
 		? // translators: %s: module name.
@@ -191,6 +203,11 @@ function ModuleRow( { item }: { item: JetpackModule } ) {
 		}
 	}, [ href ] );
 
+	const onSelectChange = useCallback(
+		( e: React.ChangeEvent< HTMLInputElement > ) => onSelect( item.module, e.target.checked ),
+		[ onSelect, item.module ]
+	);
+
 	return (
 		<div
 			id={ item.module }
@@ -199,6 +216,19 @@ function ModuleRow( { item }: { item: JetpackModule } ) {
 				'is-unavailable': ! item.available,
 			} ) }
 		>
+			<div className="jp-modules-admin__row-select">
+				{ item.available && (
+					<input
+						type="checkbox"
+						checked={ selected }
+						onChange={ onSelectChange }
+						aria-label={
+							// translators: %s: module name.
+							__( 'Select %s', 'jetpack' ).replace( '%s', item.name )
+						}
+					/>
+				) }
+			</div>
 			{ item.learn_more_button ? (
 				<a
 					className="jp-modules-admin__row-name"
@@ -273,6 +303,98 @@ function TagButton( {
 		>
 			{ label } <span className="jp-modules-admin__tag-count">({ count })</span>
 		</button>
+	);
+}
+
+/**
+ * Bulk-actions toolbar shown above the module list. Renders a master
+ * "select all" checkbox (scoped to the currently filtered + available
+ * rows), a Bulk actions select, and an Apply button. Submitting routes
+ * to the existing `admin.php?page=jetpack&action=bulk-…` URL — the
+ * server validates the nonce, runs activate/deactivate per slug, and
+ * redirects back so module state refreshes naturally.
+ *
+ * @param {object}   props                    - Props.
+ * @param {boolean}  props.allSelected        - All filtered+available rows are checked.
+ * @param {boolean}  props.someSelected       - At least one filtered+available row is checked.
+ * @param {Function} props.onToggleSelectAll  - Called with the desired master state.
+ * @param {string}   props.bulkAction         - Currently chosen bulk action ('' = none).
+ * @param {Function} props.onChangeBulkAction - Called with the new bulk action value.
+ * @param {number}   props.selectedCount      - How many modules are currently selected (across all filters).
+ * @param {Function} props.onApply            - Called when the Apply button is pressed.
+ * @return {import('react').ReactNode} Toolbar markup.
+ */
+function BulkActionsToolbar( {
+	allSelected,
+	someSelected,
+	onToggleSelectAll,
+	bulkAction,
+	onChangeBulkAction,
+	selectedCount,
+	onApply,
+}: {
+	allSelected: boolean;
+	someSelected: boolean;
+	onToggleSelectAll: ( checked: boolean ) => void;
+	bulkAction: BulkAction;
+	onChangeBulkAction: ( value: BulkAction ) => void;
+	selectedCount: number;
+	onApply: () => void;
+} ) {
+	const masterRef = useRef< HTMLInputElement | null >( null );
+	useEffect( () => {
+		if ( masterRef.current ) {
+			masterRef.current.indeterminate = ! allSelected && someSelected;
+		}
+	}, [ allSelected, someSelected ] );
+
+	const onMasterChange = useCallback(
+		( e: React.ChangeEvent< HTMLInputElement > ) => onToggleSelectAll( e.target.checked ),
+		[ onToggleSelectAll ]
+	);
+
+	const onSelectChange = useCallback(
+		( v: string ) => onChangeBulkAction( v as BulkAction ),
+		[ onChangeBulkAction ]
+	);
+
+	const canApply = bulkAction !== '' && selectedCount > 0;
+
+	return (
+		<div className="jp-modules-admin__bulk-toolbar">
+			<input
+				ref={ masterRef }
+				type="checkbox"
+				className="jp-modules-admin__bulk-master"
+				checked={ allSelected }
+				onChange={ onMasterChange }
+				aria-label={ __( 'Select all modules in the current view', 'jetpack' ) }
+			/>
+			<SelectControl
+				__nextHasNoMarginBottom
+				className="jp-modules-admin__bulk-select"
+				label={ __( 'Bulk actions', 'jetpack' ) }
+				hideLabelFromVision
+				value={ bulkAction }
+				onChange={ onSelectChange }
+				options={ [
+					{ value: '', label: __( 'Bulk actions', 'jetpack' ) },
+					{ value: 'bulk-activate', label: __( 'Activate', 'jetpack' ) },
+					{ value: 'bulk-deactivate', label: __( 'Deactivate', 'jetpack' ) },
+				] }
+			/>
+			<Button variant="secondary" onClick={ onApply } disabled={ ! canApply }>
+				{ __( 'Apply', 'jetpack' ) }
+			</Button>
+			{ selectedCount > 0 && (
+				<span className="jp-modules-admin__bulk-count" aria-live="polite">
+					{
+						// translators: %d: number of modules selected for bulk action.
+						__( '%d selected', 'jetpack' ).replace( '%d', String( selectedCount ) )
+					}
+				</span>
+			) }
+		</div>
 	);
 }
 
@@ -365,6 +487,60 @@ function ModulesAdminApp() {
 		setSortBy( v as SortKey );
 	}, [] );
 
+	// Bulk-action selection. Selection is a `Set<slug>` that persists across
+	// filter changes — modules that are selected but no longer visible still
+	// submit on Apply. This is intentional: it matches the legacy form
+	// behavior and keeps the implementation simple.
+	const [ selected, setSelected ] = useState< Set< string > >( () => new Set() );
+	const [ bulkAction, setBulkAction ] = useState< BulkAction >( '' );
+
+	const onChangeBulkAction = useCallback( ( v: BulkAction ) => setBulkAction( v ), [] );
+
+	const onSelectRow = useCallback( ( slug: string, checked: boolean ) => {
+		setSelected( prev => {
+			const next = new Set( prev );
+			if ( checked ) {
+				next.add( slug );
+			} else {
+				next.delete( slug );
+			}
+			return next;
+		} );
+	}, [] );
+
+	// "Available + currently visible" rows are what the master checkbox toggles.
+	const filteredAvailable = useMemo( () => filtered.filter( i => i.available ), [ filtered ] );
+	const allSelected =
+		filteredAvailable.length > 0 && filteredAvailable.every( i => selected.has( i.module ) );
+	const someSelected = filteredAvailable.some( i => selected.has( i.module ) );
+
+	const onToggleSelectAll = useCallback(
+		( checked: boolean ) => {
+			setSelected( prev => {
+				const next = new Set( prev );
+				if ( checked ) {
+					filteredAvailable.forEach( i => next.add( i.module ) );
+				} else {
+					filteredAvailable.forEach( i => next.delete( i.module ) );
+				}
+				return next;
+			} );
+		},
+		[ filteredAvailable ]
+	);
+
+	const onApplyBulk = useCallback( () => {
+		if ( ! bulkAction || selected.size === 0 || ! data ) {
+			return;
+		}
+		const params = new URLSearchParams();
+		params.set( 'page', 'jetpack' );
+		params.set( 'action', bulkAction );
+		selected.forEach( slug => params.append( 'modules[]', slug ) );
+		params.set( '_wpnonce', data.nonces.bulk );
+		window.location.href = adminUrl( `admin.php?${ params.toString() }` );
+	}, [ bulkAction, selected, data ] );
+
 	const headerActions = (
 		<Stack direction="row" gap="sm" justify="flex-end">
 			<Button
@@ -404,14 +580,32 @@ function ModulesAdminApp() {
 		>
 			<div className="jp-modules-admin">
 				<div className="jp-modules-admin__layout">
-					<div className="jp-modules-admin__list" role="list">
-						{ filtered.length ? (
-							filtered.map( item => <ModuleRow key={ item.module } item={ item } /> )
-						) : (
-							<div className="jp-modules-admin__empty">
-								{ __( 'No modules found.', 'jetpack' ) }
-							</div>
-						) }
+					<div className="jp-modules-admin__main">
+						<BulkActionsToolbar
+							allSelected={ allSelected }
+							someSelected={ someSelected }
+							onToggleSelectAll={ onToggleSelectAll }
+							bulkAction={ bulkAction }
+							onChangeBulkAction={ onChangeBulkAction }
+							selectedCount={ selected.size }
+							onApply={ onApplyBulk }
+						/>
+						<div className="jp-modules-admin__list" role="list">
+							{ filtered.length ? (
+								filtered.map( item => (
+									<ModuleRow
+										key={ item.module }
+										item={ item }
+										selected={ selected.has( item.module ) }
+										onSelect={ onSelectRow }
+									/>
+								) )
+							) : (
+								<div className="jp-modules-admin__empty">
+									{ __( 'No modules found.', 'jetpack' ) }
+								</div>
+							) }
+						</div>
 					</div>
 
 					<aside className="jp-modules-admin__sidebar" aria-label={ __( 'Filters', 'jetpack' ) }>

--- a/projects/plugins/jetpack/_inc/client/modules-admin/index.tsx
+++ b/projects/plugins/jetpack/_inc/client/modules-admin/index.tsx
@@ -20,7 +20,7 @@ import { createRoot } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button, Stack } from '@wordpress/ui';
 import clsx from 'clsx';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import './style.scss';
 
 type JetpackModule = {
@@ -55,6 +55,82 @@ declare global {
 
 type FilterActive = 'all' | 'true' | 'false';
 type SortKey = 'name' | 'introduced' | 'sort';
+
+const FILTER_VALUES: readonly FilterActive[] = [ 'all', 'true', 'false' ] as const;
+const SORT_VALUES: readonly SortKey[] = [ 'name', 'introduced', 'sort' ] as const;
+
+type FilterState = {
+	search: string;
+	filterActive: FilterActive;
+	sortBy: SortKey;
+	moduleTag: string;
+};
+
+const DEFAULT_FILTER_STATE: FilterState = {
+	search: '',
+	filterActive: 'all',
+	sortBy: 'name',
+	moduleTag: '',
+};
+
+/**
+ * Read the four filter values from the current URL. Unknown values fall
+ * back to defaults so a hand-typed or stale URL never wedges the page.
+ *
+ * @return {FilterState} Seed state for the four filter inputs.
+ */
+const readFilterStateFromUrl = (): FilterState => {
+	if ( typeof window === 'undefined' ) {
+		return DEFAULT_FILTER_STATE;
+	}
+	const params = new URLSearchParams( window.location.search );
+	const filterParam = params.get( 'filter' );
+	const sortParam = params.get( 'sort' );
+	return {
+		search: params.get( 'search' ) || '',
+		filterActive: FILTER_VALUES.includes( filterParam as FilterActive )
+			? ( filterParam as FilterActive )
+			: 'all',
+		sortBy: SORT_VALUES.includes( sortParam as SortKey ) ? ( sortParam as SortKey ) : 'name',
+		moduleTag: params.get( 'tag' ) || '',
+	};
+};
+
+/**
+ * Reflect the four filter values into the URL via `history.replaceState`.
+ * Defaults (e.g. empty search, `filter=all`) are dropped so a clean URL
+ * stays clean. Only our four params are touched — `page=jetpack_modules`
+ * and anything else WP appends is preserved.
+ *
+ * @param {FilterState} state - Current filter values.
+ */
+const writeFilterStateToUrl = ( state: FilterState ): void => {
+	if ( typeof window === 'undefined' ) {
+		return;
+	}
+	const params = new URLSearchParams( window.location.search );
+	const set = ( key: string, value: string, isDefault: boolean ) => {
+		if ( isDefault ) {
+			params.delete( key );
+		} else {
+			params.set( key, value );
+		}
+	};
+	set( 'search', state.search, state.search === '' );
+	set( 'filter', state.filterActive, state.filterActive === 'all' );
+	set( 'sort', state.sortBy, state.sortBy === 'name' );
+	set( 'tag', state.moduleTag, state.moduleTag === '' );
+
+	const query = params.toString();
+	const next = `${ window.location.pathname }${ query ? `?${ query }` : '' }${
+		window.location.hash
+	}`;
+	if (
+		next !== `${ window.location.pathname }${ window.location.search }${ window.location.hash }`
+	) {
+		window.history.replaceState( window.history.state, '', next );
+	}
+};
 
 const adminUrl = ( path: string ): string => {
 	// WordPress injects this global on all admin screens.
@@ -198,10 +274,16 @@ function ModulesAdminApp() {
 	const data = window.jetpackModulesData;
 	const rawModules = useMemo( () => ( data ? Object.values( data.modules ) : [] ), [ data ] );
 
-	const [ search, setSearch ] = useState( '' );
-	const [ filterActive, setFilterActive ] = useState< FilterActive >( 'all' );
-	const [ sortBy, setSortBy ] = useState< SortKey >( 'name' );
-	const [ moduleTag, setModuleTag ] = useState< string >( '' );
+	// Seed once from the URL so refresh / shared links restore filter state.
+	const initialState = useMemo( readFilterStateFromUrl, [] );
+	const [ search, setSearch ] = useState( initialState.search );
+	const [ filterActive, setFilterActive ] = useState< FilterActive >( initialState.filterActive );
+	const [ sortBy, setSortBy ] = useState< SortKey >( initialState.sortBy );
+	const [ moduleTag, setModuleTag ] = useState< string >( initialState.moduleTag );
+
+	useEffect( () => {
+		writeFilterStateToUrl( { search, filterActive, sortBy, moduleTag } );
+	}, [ search, filterActive, sortBy, moduleTag ] );
 
 	const tagCounts = useMemo( () => {
 		const counts: Record< string, number > = {};

--- a/projects/plugins/jetpack/_inc/client/modules-admin/index.tsx
+++ b/projects/plugins/jetpack/_inc/client/modules-admin/index.tsx
@@ -158,6 +158,7 @@ function ModuleRow( { item }: { item: JetpackModule } ) {
 				) : (
 					<ToggleControl
 						__nextHasNoMarginBottom
+						label=""
 						checked={ item.activated }
 						onChange={ onToggle }
 						aria-label={ ariaLabel }

--- a/projects/plugins/jetpack/_inc/client/modules-admin/index.tsx
+++ b/projects/plugins/jetpack/_inc/client/modules-admin/index.tsx
@@ -1,0 +1,407 @@
+// Modules admin page (React entry point).
+//
+// Option C draft v1: replaces the legacy Backbone rendering of
+// `admin.php?page=jetpack_modules` with a React tree wrapped in <AdminPage>,
+// styled via the shared `jetpack-admin-page-layout` mixin.
+//
+// Visual goal: preserve trunk's two-column layout (list left, filter sidebar
+// right). Modernization comes from swapping primitives — Activate/Deactivate
+// buttons become a <ToggleControl>; segmented filters use <ToggleGroupControl>;
+// the top-right Dashboard/Settings links are passed to <AdminPage>'s `actions`
+// slot.
+//
+// v1 scope:
+//   - Module list from the existing `jetpackModulesData` blob.
+//   - Search, active/inactive filter, sort (alphabetical / newest / popular).
+//   - Tag sub-filter with counts.
+//   - Per-row activate / deactivate via existing server URLs (nonce redirect —
+//     the page reloads with fresh data, no client-side state mutation needed).
+//   - Settings-link passthrough (server-rendered `configurable` anchor).
+//   - Dashboard / Settings as header actions on the right.
+//
+// Deferred (follow-ups):
+//   - Bulk activate / deactivate (dropdown + Apply, with row checkboxes).
+//   - Thickbox "More info" per-module modal.
+//   - URL state sync (replaceState for search/filter/tag/sort).
+//
+// The PHP layer (`Jetpack_Settings_Page::page_render`) emits a single
+// `<div id="jp-modules-admin-root">` for this entry to mount into.
+
+import { AdminPage, ThemeProvider, getRedirectUrl } from '@automattic/jetpack-components';
+import {
+	Button,
+	SearchControl,
+	ToggleControl,
+	__experimentalToggleGroupControl as ToggleGroupControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/components';
+import { createRoot } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
+import { useCallback, useMemo, useState } from 'react';
+import './style.scss';
+
+type JetpackModule = {
+	module: string;
+	name: string;
+	description: string;
+	long_description?: string;
+	search_terms?: string;
+	sort?: number;
+	introduced?: string;
+	module_tags: string[];
+	activated: boolean;
+	available: boolean;
+	disabled?: string;
+	configurable?: string; // Server-rendered HTML anchor, may be empty.
+	learn_more_button?: string;
+	activate_nonce?: string;
+	deactivate_nonce?: string;
+	unavailable_reason?: string;
+};
+
+declare global {
+	interface Window {
+		jetpackModulesData?: {
+			modules: Record< string, JetpackModule >;
+			i18n: { search_placeholder: string };
+			modalinfo?: string | false;
+			nonces: { bulk: string };
+		};
+	}
+}
+
+type FilterActive = 'all' | 'true' | 'false';
+type SortKey = 'name' | 'introduced' | 'sort';
+
+const adminUrl = ( path: string ): string => {
+	// WordPress injects this global on all admin screens.
+	const base =
+		( window as unknown as { ajaxurl?: string } ).ajaxurl?.replace( /admin-ajax\.php$/, '' ) ||
+		'/wp-admin/';
+	return `${ base }${ path }`;
+};
+
+/**
+ * Build the toggle URL for a module row using the existing server-side
+ * nonce. The server page handler at `admin.php?page=jetpack&action=...`
+ * redirects back to the referrer after completing the toggle, which is
+ * why we don't need an optimistic client-side update.
+ *
+ * @param {JetpackModule} item - Module row.
+ * @return {string | null} URL or null if unavailable.
+ */
+const toggleUrl = ( item: JetpackModule ): string | null => {
+	if ( ! item.available ) {
+		return null;
+	}
+	if ( item.activated && item.deactivate_nonce ) {
+		return adminUrl(
+			`admin.php?page=jetpack&action=deactivate&module=${ encodeURIComponent(
+				item.module
+			) }&_wpnonce=${ encodeURIComponent( item.deactivate_nonce ) }`
+		);
+	}
+	if ( ! item.activated && item.activate_nonce ) {
+		return adminUrl(
+			`admin.php?page=jetpack&action=activate&module=${ encodeURIComponent(
+				item.module
+			) }&_wpnonce=${ encodeURIComponent( item.activate_nonce ) }`
+		);
+	}
+	return null;
+};
+
+/**
+ * Module list row.
+ *
+ * @param {object}        props      - Props.
+ * @param {JetpackModule} props.item - Module data.
+ * @return {import('react').ReactNode} Row markup.
+ */
+function ModuleRow( { item }: { item: JetpackModule } ) {
+	const href = toggleUrl( item );
+	const ariaLabel = item.activated
+		? // translators: %s: module name.
+		  __( 'Deactivate %s', 'jetpack' ).replace( '%s', item.name )
+		: // translators: %s: module name.
+		  __( 'Activate %s', 'jetpack' ).replace( '%s', item.name );
+
+	const onToggle = useCallback( () => {
+		if ( href ) {
+			window.location.href = href;
+		}
+	}, [ href ] );
+
+	return (
+		<div
+			id={ item.module }
+			className={ clsx( 'jp-modules-admin__row', {
+				'is-active': item.activated,
+				'is-unavailable': ! item.available,
+			} ) }
+		>
+			<div className="jp-modules-admin__row-name">{ item.name }</div>
+			<div className="jp-modules-admin__row-actions">
+				{ item.configurable && (
+					<span
+						className="jp-modules-admin__row-configure"
+						// Server-generated markup from `Jetpack::get_modules()` — typically
+						// a single <a href="...#/…">Configure</a>. Trusted output.
+						// eslint-disable-next-line react/no-danger
+						dangerouslySetInnerHTML={ { __html: item.configurable } }
+					/>
+				) }
+				{ ! item.available && item.unavailable_reason ? (
+					<span className="jp-modules-admin__row-unavailable">{ item.unavailable_reason }</span>
+				) : (
+					<ToggleControl
+						__nextHasNoMarginBottom
+						checked={ item.activated }
+						onChange={ onToggle }
+						aria-label={ ariaLabel }
+						disabled={ ! href }
+					/>
+				) }
+			</div>
+		</div>
+	);
+}
+
+/**
+ * Tag-list button. Pulls the tag click handler out so the button's
+ * `onClick` is a stable per-instance callback instead of a re-bound
+ * arrow function on every render of the parent.
+ *
+ * @param {object}   props          - Props.
+ * @param {string}   props.tag      - Tag value (empty string acts as "All").
+ * @param {string}   props.label    - Display label.
+ * @param {number}   props.count    - Count to render after the label.
+ * @param {boolean}  props.selected - Whether this tag is currently selected.
+ * @param {Function} props.onSelect - Called with the tag value when clicked.
+ * @return {import('react').ReactNode} Button.
+ */
+function TagButton( {
+	tag,
+	label,
+	count,
+	selected,
+	onSelect,
+}: {
+	tag: string;
+	label: string;
+	count: number;
+	selected: boolean;
+	onSelect: ( tag: string ) => void;
+} ) {
+	const onClick = useCallback( () => onSelect( tag ), [ onSelect, tag ] );
+	return (
+		<button
+			type="button"
+			className={ clsx( 'jp-modules-admin__tag', { 'is-selected': selected } ) }
+			onClick={ onClick }
+		>
+			{ label } <span className="jp-modules-admin__tag-count">({ count })</span>
+		</button>
+	);
+}
+
+/**
+ * Main modules admin app.
+ *
+ * @return {import('react').ReactNode} App tree.
+ */
+function ModulesAdminApp() {
+	const data = window.jetpackModulesData;
+	const rawModules = useMemo( () => ( data ? Object.values( data.modules ) : [] ), [ data ] );
+
+	const [ search, setSearch ] = useState( '' );
+	const [ filterActive, setFilterActive ] = useState< FilterActive >( 'all' );
+	const [ sortBy, setSortBy ] = useState< SortKey >( 'name' );
+	const [ moduleTag, setModuleTag ] = useState< string >( '' );
+
+	const tagCounts = useMemo( () => {
+		const counts: Record< string, number > = {};
+		rawModules.forEach( m =>
+			( m.module_tags || [] ).forEach( t => {
+				counts[ t ] = ( counts[ t ] || 0 ) + 1;
+			} )
+		);
+		return counts;
+	}, [ rawModules ] );
+
+	const filtered = useMemo( () => {
+		let items = [ ...rawModules ];
+
+		if ( moduleTag ) {
+			items = items.filter( i => ( i.module_tags || [] ).includes( moduleTag ) );
+		}
+
+		if ( filterActive !== 'all' ) {
+			const want = filterActive === 'true';
+			items = items.filter( i => !! i.activated === want );
+		}
+
+		if ( search ) {
+			const needle = search.toLowerCase();
+			items = items.filter( i =>
+				[
+					i.name,
+					i.description,
+					i.long_description,
+					i.search_terms,
+					( i.module_tags || [] ).join( ' ' ),
+				]
+					.filter( Boolean )
+					.join( ' ' )
+					.toLowerCase()
+					.includes( needle )
+			);
+		}
+
+		const dir = sortBy === 'introduced' ? -1 : 1;
+		items.sort( ( a, b ) => {
+			const av = ( a as unknown as Record< string, unknown > )[ sortBy ];
+			const bv = ( b as unknown as Record< string, unknown > )[ sortBy ];
+			if ( av === bv ) {
+				return 0;
+			}
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			return ( av as any ) > ( bv as any ) ? dir : -dir;
+		} );
+
+		// Push unavailable modules to the bottom.
+		items.sort( ( a, b ) => Number( b.available ) - Number( a.available ) );
+
+		return items;
+	}, [ rawModules, moduleTag, filterActive, search, sortBy ] );
+
+	const sortedTags = useMemo(
+		() => Object.keys( tagCounts ).sort( ( a, b ) => a.localeCompare( b ) ),
+		[ tagCounts ]
+	);
+
+	const onChangeFilterActive = useCallback( ( v: string | number | undefined ) => {
+		setFilterActive( v as FilterActive );
+	}, [] );
+
+	const onChangeSortBy = useCallback( ( v: string | number | undefined ) => {
+		setSortBy( v as SortKey );
+	}, [] );
+
+	const headerActions = (
+		<HStack spacing={ 2 } justify="flex-end">
+			<Button variant="secondary" href={ adminUrl( 'admin.php?page=jetpack#/dashboard' ) }>
+				{ __( 'Dashboard', 'jetpack' ) }
+			</Button>
+			<Button variant="secondary" href={ adminUrl( 'admin.php?page=jetpack#/settings' ) }>
+				{ __( 'Settings', 'jetpack' ) }
+			</Button>
+		</HStack>
+	);
+
+	if ( ! data ) {
+		return (
+			<AdminPage title={ __( 'Modules', 'jetpack' ) } actions={ headerActions }>
+				<p>{ __( 'No module data available.', 'jetpack' ) }</p>
+			</AdminPage>
+		);
+	}
+
+	return (
+		<AdminPage
+			title={ __( 'Modules', 'jetpack' ) }
+			actions={ headerActions }
+			optionalMenuItems={ [
+				{ label: __( 'Support', 'jetpack' ), href: getRedirectUrl( 'jetpack-support' ) },
+			] }
+		>
+			<div className="jp-modules-admin">
+				<div className="jp-modules-admin__layout">
+					<div className="jp-modules-admin__list" role="list">
+						{ filtered.length ? (
+							filtered.map( item => <ModuleRow key={ item.module } item={ item } /> )
+						) : (
+							<div className="jp-modules-admin__empty">
+								{ __( 'No modules found.', 'jetpack' ) }
+							</div>
+						) }
+					</div>
+
+					<aside className="jp-modules-admin__sidebar" aria-label={ __( 'Filters', 'jetpack' ) }>
+						<SearchControl
+							__nextHasNoMarginBottom
+							className="jp-modules-admin__search"
+							value={ search }
+							onChange={ setSearch }
+							placeholder={ data.i18n.search_placeholder }
+						/>
+
+						<ToggleGroupControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							isBlock
+							label={ __( 'View', 'jetpack' ) }
+							value={ filterActive }
+							onChange={ onChangeFilterActive }
+						>
+							<ToggleGroupControlOption value="all" label={ __( 'All', 'jetpack' ) } />
+							<ToggleGroupControlOption value="true" label={ __( 'Active', 'jetpack' ) } />
+							<ToggleGroupControlOption value="false" label={ __( 'Inactive', 'jetpack' ) } />
+						</ToggleGroupControl>
+
+						<ToggleGroupControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							isBlock
+							label={ __( 'Sort by', 'jetpack' ) }
+							value={ sortBy }
+							onChange={ onChangeSortBy }
+						>
+							<ToggleGroupControlOption value="name" label={ __( 'Alphabetical', 'jetpack' ) } />
+							<ToggleGroupControlOption value="introduced" label={ __( 'Newest', 'jetpack' ) } />
+							<ToggleGroupControlOption value="sort" label={ __( 'Popular', 'jetpack' ) } />
+						</ToggleGroupControl>
+
+						<div className="jp-modules-admin__tags">
+							<div className="jp-modules-admin__tags-label">{ __( 'Show', 'jetpack' ) }</div>
+							<ul>
+								<li>
+									<TagButton
+										tag=""
+										label={ __( 'All', 'jetpack' ) }
+										count={ rawModules.length }
+										selected={ moduleTag === '' }
+										onSelect={ setModuleTag }
+									/>
+								</li>
+								{ sortedTags.map( tag => (
+									<li key={ tag }>
+										<TagButton
+											tag={ tag }
+											label={ tag }
+											count={ tagCounts[ tag ] }
+											selected={ moduleTag === tag }
+											onSelect={ setModuleTag }
+										/>
+									</li>
+								) ) }
+							</ul>
+						</div>
+					</aside>
+				</div>
+			</div>
+		</AdminPage>
+	);
+}
+
+const container = document.getElementById( 'jp-modules-admin-root' );
+if ( container ) {
+	const root = createRoot( container );
+	root.render(
+		<ThemeProvider targetDom={ document.body }>
+			<ModulesAdminApp />
+		</ThemeProvider>
+	);
+}

--- a/projects/plugins/jetpack/_inc/client/modules-admin/style.scss
+++ b/projects/plugins/jetpack/_inc/client/modules-admin/style.scss
@@ -59,6 +59,14 @@ $jp-modules-admin-muted: #50575e;
 
 	&__row-name {
 		font-weight: 500;
+		color: inherit;
+		text-decoration: none;
+
+		&:hover,
+		&:focus-visible {
+			color: var(--wp-admin-theme-color, #2271b1);
+			text-decoration: underline;
+		}
 	}
 
 	&__row-actions {

--- a/projects/plugins/jetpack/_inc/client/modules-admin/style.scss
+++ b/projects/plugins/jetpack/_inc/client/modules-admin/style.scss
@@ -29,6 +29,43 @@ $jp-modules-admin-muted: #50575e;
 		}
 	}
 
+	&__main {
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+	}
+
+	&__bulk-toolbar {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+		padding: 8px 12px;
+		background: #fff;
+		border: 1px solid $jp-modules-admin-border;
+		border-radius: 4px;
+	}
+
+	&__bulk-master {
+		flex: 0 0 auto;
+		margin: 0 4px;
+	}
+
+	&__bulk-select {
+		flex: 0 0 auto;
+		min-width: 160px;
+
+		// Suppress the SelectControl margin-bottom default.
+		.components-base-control__field {
+			margin-bottom: 0;
+		}
+	}
+
+	&__bulk-count {
+		color: $jp-modules-admin-muted;
+		font-size: 12px;
+		margin-left: auto;
+	}
+
 	&__list {
 		background: #fff;
 		border: 1px solid $jp-modules-admin-border;
@@ -38,7 +75,7 @@ $jp-modules-admin-muted: #50575e;
 
 	&__row {
 		display: grid;
-		grid-template-columns: 1fr auto;
+		grid-template-columns: auto 1fr auto;
 		align-items: center;
 		gap: 16px;
 		padding: 12px 16px;
@@ -55,6 +92,12 @@ $jp-modules-admin-muted: #50575e;
 		&.is-unavailable {
 			opacity: 0.7;
 		}
+	}
+
+	&__row-select {
+
+		// Reserve checkbox-width even for unavailable rows so names line up.
+		min-width: 16px;
 	}
 
 	&__row-name {

--- a/projects/plugins/jetpack/_inc/client/modules-admin/style.scss
+++ b/projects/plugins/jetpack/_inc/client/modules-admin/style.scss
@@ -1,0 +1,155 @@
+// Modules admin page styles. Scope the shared jetpack-admin-page-layout mixin
+// to the wp-admin body class for `admin.php?page=jetpack_modules`. WP emits
+// `admin_page_jetpack_modules` for this screen (the submenu is registered
+// against an empty parent, so it resolves to `admin_page_*` — see
+// class.jetpack-settings-page.php).
+
+@use "@automattic/jetpack-base-styles/admin-page-layout" as *;
+
+body.admin_page_jetpack_modules {
+
+	@include jetpack-admin-page-layout;
+}
+
+$jp-modules-admin-bg-active: #f6f7f7;
+$jp-modules-admin-border: #dcdcde;
+$jp-modules-admin-muted: #50575e;
+
+.jp-modules-admin {
+	padding: 24px;
+
+	&__layout {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) 280px;
+		gap: 24px;
+		align-items: start;
+
+		@media (max-width: 960px) {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	&__list {
+		background: #fff;
+		border: 1px solid $jp-modules-admin-border;
+		border-radius: 4px;
+		overflow: hidden;
+	}
+
+	&__row {
+		display: grid;
+		grid-template-columns: 1fr auto;
+		align-items: center;
+		gap: 16px;
+		padding: 12px 16px;
+		border-bottom: 1px solid $jp-modules-admin-border;
+
+		&:last-child {
+			border-bottom: none;
+		}
+
+		&.is-active {
+			background: $jp-modules-admin-bg-active;
+		}
+
+		&.is-unavailable {
+			opacity: 0.7;
+		}
+	}
+
+	&__row-name {
+		font-weight: 500;
+	}
+
+	&__row-actions {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+
+		// Inherit the muted color for the server-rendered Configure link.
+		.jp-modules-admin__row-configure a {
+			color: $jp-modules-admin-muted;
+			text-decoration: none;
+
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+
+	&__row-unavailable {
+		color: $jp-modules-admin-muted;
+		font-size: 12px;
+		font-style: italic;
+	}
+
+	&__empty {
+		padding: 32px;
+		text-align: center;
+		color: $jp-modules-admin-muted;
+	}
+
+	&__sidebar {
+		display: flex;
+		flex-direction: column;
+		gap: 24px;
+		position: sticky;
+		top: 16px;
+	}
+
+	&__search {
+		// SearchControl ships its own borders; just ensure it stretches.
+		width: 100%;
+	}
+
+	&__tags {
+
+		.jp-modules-admin__tags-label {
+			font-size: 11px;
+			font-weight: 500;
+			text-transform: uppercase;
+			letter-spacing: 0.04em;
+			color: $jp-modules-admin-muted;
+			margin-bottom: 8px;
+		}
+
+		ul {
+			list-style: none;
+			margin: 0;
+			padding: 0;
+		}
+
+		li {
+			margin: 0;
+		}
+	}
+
+	&__tag {
+		appearance: none;
+		background: none;
+		border: none;
+		padding: 4px 0;
+		font: inherit;
+		color: var(--wp-admin-theme-color, #2271b1);
+		cursor: pointer;
+		text-align: left;
+		text-decoration: underline;
+
+		&:hover {
+			text-decoration: none;
+		}
+
+		&.is-selected {
+			font-weight: 600;
+			color: inherit;
+			text-decoration: none;
+		}
+	}
+
+	&__tag-count {
+		color: $jp-modules-admin-muted;
+		text-decoration: none;
+		font-weight: 400;
+		margin-left: 4px;
+	}
+}

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -106,20 +106,17 @@ abstract class Jetpack_Admin_Page {
 			return;
 		}
 
-		// Check if we are looking at the main dashboard.
-		if ( isset( $_GET['page'] ) && 'jetpack' === $_GET['page'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- View logic.
+		// Pages whose React tree provides its own header/footer chrome (via
+		// `<AdminPage>`) skip the legacy `wrap_ui()` wrapper to avoid stacking
+		// two mastheads and two footers around the same content.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- View logic.
+		$page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
+		if ( in_array( $page, array( 'jetpack', 'jetpack_modules' ), true ) ) {
 			$this->page_render();
 			return;
 		}
 
-		$args = array();
-
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( isset( $_GET['page'] ) && 'jetpack_modules' === $_GET['page'] ) {
-			$args['is-wide'] = true;
-		}
-
-		self::wrap_ui( array( $this, 'page_render' ), $args );
+		self::wrap_ui( array( $this, 'page_render' ), array() );
 	}
 
 	/**

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-settings-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-settings-page.php
@@ -46,10 +46,22 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 
 	/**
 	 * Renders the module list table where you can use bulk action or row
-	 * actions to activate/deactivate and configure modules
+	 * actions to activate/deactivate and configure modules.
+	 *
+	 * Option C draft: this now renders a single `<div id="jp-modules-admin-root">`
+	 * that the React bundle (`modules-admin.min.js`, enqueued via
+	 * `Jetpack_Modules_List_Table::__construct`) mounts into. The legacy
+	 * Backbone-driven markup below has been removed from the rendered output;
+	 * the Backbone sources (`jetpack-modules.js`, `.models.js`, `.views.js`) are
+	 * left in place but no longer enqueued, so a single-commit revert restores
+	 * the old experience.
+	 *
+	 * @since $$next-version$$
 	 */
 	public function page_render() {
-		$list_table = new Jetpack_Modules_List_Table();
+		// Instantiate the list table purely for the side effect of registering
+		// and enqueuing the React bundle + `jetpackModulesData` localized blob.
+		new Jetpack_Modules_List_Table();
 
 		// We have static.html so let's continue trying to fetch the others.
 		$noscript_notice = @file_get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static-noscript-notice.html' ); //phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents, Not fetching a remote file.
@@ -82,92 +94,7 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 		}
 		echo $noscript_notice; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		?>
-
-		<div class="jetpack-module-list">
-			<div class="wrap">
-				<div class="manage-left jp-static-block">
-					<table class="table table-bordered fixed-top jetpack-modules">
-						<thead>
-							<tr>
-								<th class="check-column"><input type="checkbox" class="checkall"></th>
-								<th colspan="2">
-									<?php $list_table->unprotected_display_tablenav( 'top' ); ?>
-									<span class="filter-search">
-										<button type="button" class="button">Filter</button>
-									</span>
-								</th>
-							</tr>
-						</thead>
-					</table>
-					<form class="jetpack-modules-list-table-form" onsubmit="return false;">
-						<table class="<?php echo esc_attr( implode( ' ', $list_table->get_table_classes() ) ); ?>">
-							<tbody id="the-list">
-							<?php $list_table->display_rows_or_placeholder(); ?>
-							</tbody>
-						</table>
-					</form>
-				</div>
-				<div class="manage-right">
-					<div class="bumper">
-						<form class="navbar-form" role="search">
-							<input type="hidden" name="page" value="jetpack_modules" />
-							<?php $list_table->search_box( __( 'Search', 'jetpack' ), 'srch-term' ); ?>
-							<p><?php esc_html_e( 'View', 'jetpack' ); ?></p>
-							<span class="dops-button-group button-group filter-active">
-								<button type="button" class="dops-button is-compact button
-								<?php // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This is view logic.
-								if ( empty( $_GET['activated'] ) ) {
-									echo 'active';
-								}
-								?>
-									">
-								<?php esc_html_e( 'All', 'jetpack' ); ?></button>
-								<button type="button" class="dops-button button
-								<?php // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This is view logic.
-								if ( ! empty( $_GET['activated'] ) && 'true' === $_GET['activated'] ) {
-									echo 'active';
-								}
-								?>
-								" data-filter-by="activated" data-filter-value="true"><?php esc_html_e( 'Active', 'jetpack' ); ?></button>
-								<button type="button" class="dops-button button
-								<?php // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This is view logic.
-								if ( ! empty( $_GET['activated'] ) && 'false' === $_GET['activated'] ) {
-									echo 'active';
-								}
-								?>
-								" data-filter-by="activated" data-filter-value="false"><?php esc_html_e( 'Inactive', 'jetpack' ); ?></button>
-							</span>
-							<p><?php esc_html_e( 'Sort by', 'jetpack' ); ?></p>
-							<span class="dops-button-group button-group sort">
-								<button type="button" class="dops-button button
-								<?php // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This is view logic.
-								if ( empty( $_GET['sort_by'] ) ) {
-									echo 'active';
-								}
-								?>
-								" data-sort-by="name"><?php esc_html_e( 'Alphabetical', 'jetpack' ); ?></button>
-								<button type="button" class="dops-button button
-								<?php // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This is view logic.
-								if ( ! empty( $_GET['sort_by'] ) && 'introduced' === $_GET['sort_by'] ) {
-									echo 'active';
-								}
-								?>
-								" data-sort-by="introduced" data-sort-order="reverse"><?php esc_html_e( 'Newest', 'jetpack' ); ?></button>
-								<button type="button" class="dops-button button
-								<?php // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This is view logic.
-								if ( ! empty( $_GET['sort_by'] ) && 'sort' === $_GET['sort_by'] ) {
-									echo 'active';
-								}
-								?>
-								" data-sort-by="sort"><?php esc_html_e( 'Popular', 'jetpack' ); ?></button>
-							</span>
-							<p><?php esc_html_e( 'Show', 'jetpack' ); ?></p>
-							<?php $list_table->views(); ?>
-						</form>
-					</div>
-				</div>
-			</div>
-		</div><!-- /.content -->
+		<div id="jp-modules-admin-root" class="jp-modules-admin-root"></div>
 		<?php
 
 		$tracking = new Tracking();

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-settings-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-settings-page.php
@@ -45,22 +45,20 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 	}
 
 	/**
-	 * Renders the module list table where you can use bulk action or row
-	 * actions to activate/deactivate and configure modules.
+	 * Render the page body.
 	 *
-	 * Option C draft: this now renders a single `<div id="jp-modules-admin-root">`
-	 * that the React bundle (`modules-admin.min.js`, enqueued via
-	 * `Jetpack_Modules_List_Table::__construct`) mounts into. The legacy
-	 * Backbone-driven markup below has been removed from the rendered output;
-	 * the Backbone sources (`jetpack-modules.js`, `.models.js`, `.views.js`) are
-	 * left in place but no longer enqueued, so a single-commit revert restores
-	 * the old experience.
+	 * Emits a single mount point (`<div id="jp-modules-admin-root">`) for the
+	 * React `modules-admin` bundle, plus the noscript and REST-disabled
+	 * fallback notices. `Jetpack_Modules_List_Table`'s constructor enqueues
+	 * the bundle and localizes the `jetpackModulesData` blob the React app
+	 * reads on mount.
 	 *
 	 * @since $$next-version$$
 	 */
 	public function page_render() {
-		// Instantiate the list table purely for the side effect of registering
-		// and enqueuing the React bundle + `jetpackModulesData` localized blob.
+		// `Jetpack_Modules_List_Table::__construct` enqueues the React bundle
+		// and localizes `jetpackModulesData`, so instantiate it for the side
+		// effect.
 		// @phan-suppress-next-line PhanNoopNew -- Constructor enqueues scripts.
 		new Jetpack_Modules_List_Table();
 

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-settings-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-settings-page.php
@@ -61,6 +61,7 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 	public function page_render() {
 		// Instantiate the list table purely for the side effect of registering
 		// and enqueuing the React bundle + `jetpackModulesData` localized blob.
+		// @phan-suppress-next-line PhanNoopNew -- Constructor enqueues scripts.
 		new Jetpack_Modules_List_Table();
 
 		// We have static.html so let's continue trying to fetch the others.

--- a/projects/plugins/jetpack/changelog/modules-page-bulk-actions
+++ b/projects/plugins/jetpack/changelog/modules-page-bulk-actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Modules admin page: restore bulk activate / deactivate. Adds a per-row checkbox column, a "Select all" master checkbox scoped to the current view, and a Bulk actions select + Apply button above the list. Submits to the existing admin.php?page=jetpack&action=bulk-(activate|deactivate) handler with the bulk nonce; the server redirects back so module state refreshes naturally.

--- a/projects/plugins/jetpack/changelog/modules-page-name-link
+++ b/projects/plugins/jetpack/changelog/modules-page-name-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Modules admin page: render the module name as a link to its `learn_more_button` URL (the module's docs / product / wp-admin page), opening in a new tab — matching trunk's Backbone behavior. Modules without a `learn_more_button` keep the static name label.

--- a/projects/plugins/jetpack/changelog/modules-page-react-rewrite
+++ b/projects/plugins/jetpack/changelog/modules-page-react-rewrite
@@ -1,4 +1,4 @@
 Significance: minor
-Type: changed
+Type: enhancement
 
 Modules admin page (`admin.php?page=jetpack_modules`): rewrite the legacy Backbone list-table view as a React tree wrapped in <AdminPage>, using the shared jetpack-admin-page-layout mixin. Activate/Deactivate buttons become <ToggleControl>; segmented filters use <ToggleGroupControl>; Dashboard/Settings move to the AdminPage actions slot. Backbone sources are unenqueued but left in place for a single-commit revert.

--- a/projects/plugins/jetpack/changelog/modules-page-react-rewrite
+++ b/projects/plugins/jetpack/changelog/modules-page-react-rewrite
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Modules admin page (`admin.php?page=jetpack_modules`): rewrite the legacy Backbone list-table view as a React tree wrapped in <AdminPage>, using the shared jetpack-admin-page-layout mixin. Activate/Deactivate buttons become <ToggleControl>; segmented filters use <ToggleGroupControl>; Dashboard/Settings move to the AdminPage actions slot. Backbone sources are unenqueued but left in place for a single-commit revert.

--- a/projects/plugins/jetpack/changelog/modules-page-url-state-sync
+++ b/projects/plugins/jetpack/changelog/modules-page-url-state-sync
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Modules admin page: persist search/filter/sort/tag in the URL via history.replaceState so a refresh or shared link restores filter state. Defaults are dropped from the URL to keep clean URLs clean.

--- a/projects/plugins/jetpack/class.jetpack-modules-list-table.php
+++ b/projects/plugins/jetpack/class.jetpack-modules-list-table.php
@@ -47,15 +47,10 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 		<h1 class="screen-reader-text"><?php esc_html_e( 'Jetpack Modules List', 'jetpack' ); ?></h1>
 		<?php
 
-		// Option C draft: enqueue the React modules-admin bundle instead of
-		// the legacy Backbone scripts. The Backbone sources
-		// (`_inc/jetpack-modules.js`, `.models.js`, `.views.js`) are left in
-		// the repo unchanged — a single-commit revert of this block restores
-		// the old enqueue path if the React draft is rejected.
-		//
-		// Mirrors the direct-enqueue pattern used by `network-admin.js`
-		// (see class.jetpack-network.php::enqueue_network_admin_scripts())
-		// because webpack emits this entry as `modules-admin.js` (no .min
+		// Enqueue the React `modules-admin` bundle. Mirrors the direct-enqueue
+		// pattern used by `network-admin.js` (see
+		// `class.jetpack-network.php::enqueue_network_admin_scripts()`)
+		// because webpack emits this entry as `modules-admin.js` (no `.min`
 		// suffix) with a sibling `.asset.php` dependency manifest.
 		//
 		// @since $$next-version$$

--- a/projects/plugins/jetpack/class.jetpack-modules-list-table.php
+++ b/projects/plugins/jetpack/class.jetpack-modules-list-table.php
@@ -5,8 +5,6 @@
  * @package automattic/jetpack
  */
 
-use Automattic\Jetpack\Assets;
-
 if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
 }
@@ -49,57 +47,55 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 		<h1 class="screen-reader-text"><?php esc_html_e( 'Jetpack Modules List', 'jetpack' ); ?></h1>
 		<?php
 
-		wp_register_script(
-			'models.jetpack-modules',
-			Assets::get_file_url_for_environment(
-				'_inc/build/jetpack-modules.models.min.js',
-				'_inc/jetpack-modules.models.js'
-			),
-			array( 'jquery', 'backbone' ),
-			JETPACK__VERSION,
-			false // @todo Can this be put in the footer?
-		);
-		wp_register_script(
-			'views.jetpack-modules',
-			Assets::get_file_url_for_environment(
-				'_inc/build/jetpack-modules.views.min.js',
-				'_inc/jetpack-modules.views.js'
-			),
-			array( 'jquery', 'backbone', 'wp-util' ),
-			JETPACK__VERSION,
-			false // @todo Can this be put in the footer?
-		);
-		wp_register_script(
-			'jetpack-modules-list-table',
-			Assets::get_file_url_for_environment(
-				'_inc/build/jetpack-modules.min.js',
-				'_inc/jetpack-modules.js'
-			),
-			array(
-				'views.jetpack-modules',
-				'models.jetpack-modules',
-				'jquery',
-			),
-			JETPACK__VERSION,
-			true
-		);
+		// Option C draft: enqueue the React modules-admin bundle instead of
+		// the legacy Backbone scripts. The Backbone sources
+		// (`_inc/jetpack-modules.js`, `.models.js`, `.views.js`) are left in
+		// the repo unchanged — a single-commit revert of this block restores
+		// the old enqueue path if the React draft is rejected.
+		//
+		// Mirrors the direct-enqueue pattern used by `network-admin.js`
+		// (see class.jetpack-network.php::enqueue_network_admin_scripts())
+		// because webpack emits this entry as `modules-admin.js` (no .min
+		// suffix) with a sibling `.asset.php` dependency manifest.
+		//
+		// @since $$next-version$$
+		$build_dir         = JETPACK__PLUGIN_DIR . '_inc/build/';
+		$script_asset_path = $build_dir . 'modules-admin.asset.php';
+		if ( file_exists( $script_asset_path ) ) {
+			$script_asset = require $script_asset_path;
 
-		wp_localize_script(
-			'jetpack-modules-list-table',
-			'jetpackModulesData',
-			array(
-				'modules'   => Jetpack::get_translated_modules( $this->all_items ),
-				'i18n'      => array(
-					'search_placeholder' => __( 'Search modules…', 'jetpack' ),
-				),
-				'modalinfo' => $this->module_info_check( $modal_info, $this->all_items ),
-				'nonces'    => array(
-					'bulk' => wp_create_nonce( 'bulk-jetpack_page_jetpack_modules' ),
-				),
-			)
-		);
+			wp_enqueue_script(
+				'jetpack-modules-admin',
+				plugins_url( '_inc/build/modules-admin.js', JETPACK__PLUGIN_FILE ),
+				$script_asset['dependencies'],
+				$script_asset['version'],
+				true
+			);
 
-		wp_enqueue_script( 'jetpack-modules-list-table' );
+			wp_enqueue_style(
+				'jetpack-modules-admin',
+				plugins_url( '_inc/build/modules-admin.css', JETPACK__PLUGIN_FILE ),
+				array(),
+				$script_asset['version']
+			);
+
+			wp_set_script_translations( 'jetpack-modules-admin', 'jetpack' );
+
+			wp_localize_script(
+				'jetpack-modules-admin',
+				'jetpackModulesData',
+				array(
+					'modules'   => Jetpack::get_translated_modules( $this->all_items ),
+					'i18n'      => array(
+						'search_placeholder' => __( 'Search modules…', 'jetpack' ),
+					),
+					'modalinfo' => $this->module_info_check( $modal_info, $this->all_items ),
+					'nonces'    => array(
+						'bulk' => wp_create_nonce( 'bulk-jetpack_page_jetpack_modules' ),
+					),
+				)
+			);
+		}
 
 		/**
 		 * Filters the js_templates callback value.

--- a/projects/plugins/jetpack/tools/webpack.config.js
+++ b/projects/plugins/jetpack/tools/webpack.config.js
@@ -158,6 +158,7 @@ module.exports = [
 			},
 			'plugins-page': path.join( __dirname, '../_inc/client', 'plugins-entry.js' ),
 			'network-admin': path.join( __dirname, '../_inc/client', 'network-admin.tsx' ),
+			'modules-admin': path.join( __dirname, '../_inc/client', 'modules-admin', 'index.tsx' ),
 		},
 		plugins: [
 			...sharedWebpackConfig.plugins,


### PR DESCRIPTION
## Proposed changes

Modules admin page (`admin.php?page=jetpack_modules`) — *the last classic Jetpack admin screen still rendered through the Backbone list-table view* — is rewritten as a React tree wrapped in `<AdminPage>`, dressed in the shared `jetpack-admin-page-layout` SCSS mixin (matching the rest of the admin-page-layout-unification series).

* Visual goal: parity with trunk. Two-column layout (list left, filter sidebar right), preserved active-row highlight, preserved "Configure" link before each action, preserved offline-mode handling and `unavailable_reason` text.
* Modernization comes from primitive swaps:
    * Activate / Deactivate buttons → `<ToggleControl>`.
    * Segmented filters (View / Sort by) → `<ToggleGroupControl>`.
    * Top-right Dashboard / Settings links → `<AdminPage>`'s `actions` slot.
* `class.jetpack-admin-page.php::render()` now bypasses `wrap_ui()` for both `page=jetpack` and `page=jetpack_modules` so the React tree is the *only* chrome on the page (no double masthead, no double footer).
* `class.jetpack-settings-page.php::page_render()` collapses to a single root div + the noscript / REST-disabled notices.
* `class.jetpack-modules-list-table.php` drops the three Backbone `wp_register_script` calls and enqueues the new `modules-admin` bundle plus the existing `jetpackModulesData` localized blob.
* Backbone sources (`_inc/jetpack-modules.js`, `.models.js`, `.views.js`) are left in place but no longer enqueued, so a single-commit revert restores the old experience.

## Subsequent commits — feature parity restored

The three items originally cut from v1 have now landed in this PR (separate commits, easy to read in isolation):

* **`c11e6eafd8` — URL state sync.** `search` / `filter` / `sort` / `tag` seed from `URLSearchParams` on mount and reflect into the URL via `history.replaceState` on every change. Defaults are dropped so a clean URL stays clean.
* **`7fcd75fc12` — Module name link.** Each module name is rendered as `<a href={item.learn_more_button} target="_blank" rel="noreferrer noopener">` — matching trunk's Backbone `js_template` behavior. Modules without a `learn_more_button` keep the static name label.
* **`087bfcbf62` — Bulk activate / deactivate.** Adds a per-row checkbox column, a master "select all" checkbox scoped to the current view (with indeterminate state when partial), and a Bulk actions select + Apply button above the list. Submits to the existing `admin.php?page=jetpack&action=bulk-(activate|deactivate)` handler with `nonces.bulk` — the server validates the nonce, runs activate/deactivate per slug, and redirects back so module state refreshes naturally.

## Before / After

**Trunk (before):** legacy Backbone list-table.

<img width="1440" height="900" alt="trunk-goal-desktop-fold" src="https://github.com/user-attachments/assets/72472e63-1636-4cc1-a0e1-d3cb382e4629" />


**This PR (after):** same layout, modernized primitives, bulk-actions toolbar above the list.

<img width="1440" height="900" alt="iter2-desktop" src="https://github.com/user-attachments/assets/05583129-85f3-4d48-8634-3ac5328b045a" />
<img width="390" height="844" alt="iter2-mobile" src="https://github.com/user-attachments/assets/cfd6922a-37b5-49e8-8301-e2758e0db797" />

Updated screenshots showing the bulk-actions toolbar and the URL-sync state are available in `.playwright-mcp/modules-smoke/` — `iter4-urlsync-desktop-restored.png` (filters round-tripped via URL), `iter6-bulk-desktop.png` (toolbar at rest), `iter6-bulk-selected.png` (2 rows ticked, "Activate" chosen, Apply enabled), and `iter6-bulk-mobile.png`.

## Related product discussion/links

* Parent effort: admin-page-layout-unification (#48109 plus the My Jetpack adoption in #48310).

## Does this pull request change what data or activity we track or use?

No. The existing `wpa_page_view` tracks event with `path: 'old_settings'` is preserved verbatim. No new events, no new permissions, no new endpoints. The existing nonce-protected URLs (`admin.php?page=jetpack&action=activate|deactivate&module=...` for single-row toggle, `admin.php?page=jetpack&action=bulk-(activate|deactivate)&modules[]=...` for bulk) are reused as-is.

## Testing instructions

### Core layout
1. Install / activate Jetpack on a connected site and log in as an admin.
2. Visit Modules (`admin.php?page=jetpack_modules`).
3. Confirm a single Jetpack header at the top (logo + "Modules" title + Dashboard / Settings buttons on the right) — no double masthead, no double footer.
4. Confirm the layout is two-column at desktop widths (≥960px): module list left, sidebar (search + View / Sort by / Show) right.
5. Confirm active modules render with a light-gray row background; inactive modules with a white background.
6. Toggle a module via its `<ToggleControl>` — the page should reload (server redirect) and reflect the new state.
7. Try a configurable module (e.g. Site Verification when active): the "Configure" link should render to the left of the toggle.
8. Try an offline-mode-only module: it should show "Offline mode" text instead of a toggle.
9. Use the search box, View filter (All / Active / Inactive), Sort by (Alphabetical / Newest / Popular), and a tag in Show — confirm each narrows the list correctly.
10. Resize to ≤960px: list and sidebar should stack into a single column.
11. Resize to ≤782px (mobile): verify nothing overflows horizontally; the Jetpack header collapses appropriately.
12. Click "Dashboard" and "Settings" in the top-right header actions — confirm they link to `admin.php?page=jetpack#/dashboard` and `#/settings` respectively.
13. Visit `admin.php?page=jetpack` (the main dashboard) and confirm it still renders correctly (the wrap_ui bypass change touched both pages).

### URL state sync
14. With the page open, set search to e.g. `share`, View=Active, Sort by=Newest, Show=Social. Confirm the URL becomes `?page=jetpack_modules&search=share&filter=true&sort=introduced&tag=Social`.
15. Refresh: confirm the four filter inputs are restored from the URL and the visible list reflects them.
16. Reset each control to its default. Confirm each default removes its param from the URL — at all-defaults the URL is back to `?page=jetpack_modules`.

### Module name link
17. Click a module name (e.g. Forms). It should open the module's `learn_more_button` URL (a jetpack.com docs / product / wp-admin link) in a new tab, matching trunk.
18. Modules without a `learn_more_button` should keep the static name label (no anchor).

### Bulk activate / deactivate
19. Tick the checkbox on two inactive modules — confirm the "N selected" count appears in the toolbar.
20. Confirm the master checkbox in the toolbar shows an indeterminate state.
21. Set "Bulk actions" to "Activate" and click "Apply". Confirm the page reloads and both modules are now active.
22. Tick those two modules again, set "Bulk actions" to "Deactivate", and click "Apply". Confirm both go inactive again.
23. Click the master checkbox to toggle "select all" — it should select every available + currently visible row.
24. Apply a tag filter (e.g. Social) — selection persists across filter changes (selected modules outside the current view still submit on Apply, which matches the legacy form-serialize behavior).

