### PR TITLE
Connection: forward from and plugins params through Connector REST endpoints

### DIFF
--- a/projects/packages/connection/changelog/add-jetpack-connector-plumbing
+++ b/projects/packages/connection/changelog/add-jetpack-connector-plumbing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Connector: forward `from` and `plugins` parameters to the register and authorize_url REST endpoints, and expose connectedPlugins to the connectors card before registration.

--- a/projects/packages/connection/src/class-rest-connector.php
+++ b/projects/packages/connection/src/class-rest-connector.php
@@ -242,6 +242,10 @@ class REST_Connector {
 						'description' => __( 'Indicates from what plugin the request is coming from', 'jetpack-connection' ),
 						'type'        => 'string',
 					),
+					'plugins'      => array(
+						'description' => __( 'Comma-separated list of plugin slugs currently using the Jetpack connection', 'jetpack-connection' ),
+						'type'        => 'string',
+					),
 				),
 			)
 		);
@@ -257,6 +261,14 @@ class REST_Connector {
 				'args'                => array(
 					'redirect_uri' => array(
 						'description' => __( 'URI of the admin page where the user should be redirected after connection flow', 'jetpack-connection' ),
+						'type'        => 'string',
+					),
+					'from'         => array(
+						'description' => __( 'Tracking/segmentation identifier for this authorize URL request', 'jetpack-connection' ),
+						'type'        => 'string',
+					),
+					'plugins'      => array(
+						'description' => __( 'Comma-separated list of plugin slugs currently using the Jetpack connection', 'jetpack-connection' ),
 						'type'        => 'string',
 					),
 				),
@@ -789,8 +801,9 @@ class REST_Connector {
 	 * @return \WP_REST_Response|WP_Error
 	 */
 	public function connection_register( $request ) {
-		if ( isset( $request['from'] ) ) {
-			$this->connection->add_register_request_param( 'from', (string) $request['from'] );
+		$from = isset( $request['from'] ) ? (string) $request['from'] : '';
+		if ( '' !== $from ) {
+			$this->connection->add_register_request_param( 'from', $from );
 		}
 
 		if ( ! empty( $request['plugin_slug'] ) ) {
@@ -809,7 +822,12 @@ class REST_Connector {
 
 		$redirect_uri = $request->get_param( 'redirect_uri' ) ? admin_url( $request->get_param( 'redirect_uri' ) ) : null;
 
-		$authorize_url = ( new Authorize_Redirect( $this->connection ) )->build_authorize_url( $redirect_uri );
+		$authorize_url = ( new Authorize_Redirect( $this->connection ) )->build_authorize_url( $redirect_uri, '' !== $from ? $from : false );
+
+		$plugins = $request->get_param( 'plugins' );
+		if ( ! empty( $plugins ) ) {
+			$authorize_url = add_query_arg( 'plugins', (string) $plugins, $authorize_url );
+		}
 
 		/**
 		 * Filters the response of jetpack/v4/connection/register endpoint
@@ -842,7 +860,13 @@ class REST_Connector {
 	 */
 	public function connection_authorize_url( $request ) {
 		$redirect_uri  = $request->get_param( 'redirect_uri' ) ? admin_url( $request->get_param( 'redirect_uri' ) ) : null;
-		$authorize_url = $this->connection->get_authorization_url( null, $redirect_uri );
+		$from          = $request->get_param( 'from' );
+		$authorize_url = $this->connection->get_authorization_url( null, $redirect_uri, ! empty( $from ) ? (string) $from : false );
+
+		$plugins = $request->get_param( 'plugins' );
+		if ( ! empty( $plugins ) ) {
+			$authorize_url = add_query_arg( 'plugins', (string) $plugins, $authorize_url );
+		}
 
 		return rest_ensure_response(
 			array(

--- a/projects/packages/connection/src/connectors/class-jetpack-connector.php
+++ b/projects/packages/connection/src/connectors/class-jetpack-connector.php
@@ -153,9 +153,10 @@ class Jetpack_Connector {
 		$data['connectorDescription'] = __( 'Enhanced functionality for Jetpack and WooCommerce with WordPress.com.', 'jetpack-connection' );
 		$data['connectorLogoUrl']     = static::get_connector_logo_url();
 
+		$data['connectedPlugins'] = static::get_connected_plugins_data( $manager );
+
 		if ( $is_registered ) {
-			$data['connectedPlugins'] = static::get_connected_plugins_data( $manager );
-			$data['siteDetails']      = array(
+			$data['siteDetails'] = array(
 				'blogId'  => (int) \Jetpack_Options::get_option( 'id' ),
 				'siteUrl' => site_url(),
 				'homeUrl' => home_url(),

--- a/projects/packages/connection/src/connectors/js/connectors-card.js
+++ b/projects/packages/connection/src/connectors/js/connectors-card.js
@@ -42,6 +42,10 @@ const redirectUri = data.redirectUri || '';
 const currentUser = data.currentUser || null;
 const connectionOwner = data.connectionOwner || null;
 const connectedPlugins = data.connectedPlugins || [];
+const connectedPluginSlugs = connectedPlugins
+	.map( p => p.slug )
+	.filter( Boolean )
+	.join( ',' );
 const siteDetails = data.siteDetails || null;
 const isWoaSite = Boolean( data.isWoaSite );
 const isVipSite = Boolean( data.isVipSite );
@@ -67,6 +71,10 @@ async function startConnectionFlow( siteRegistered ) {
 		if ( redirectUri ) {
 			params.set( 'redirect_uri', redirectUri );
 		}
+		params.set( 'from', 'wpcom-connector' );
+		if ( connectedPluginSlugs ) {
+			params.set( 'plugins', connectedPluginSlugs );
+		}
 		const qs = params.toString();
 		const authRes = await window.fetch(
 			apiRoot + 'jetpack/v4/connection/authorize_url' + ( qs ? '?' + qs : '' ),
@@ -90,6 +98,9 @@ async function startConnectionFlow( siteRegistered ) {
 	const body = { from: 'jetpack-connector' };
 	if ( redirectUri ) {
 		body.redirect_uri = redirectUri;
+	}
+	if ( connectedPluginSlugs ) {
+		body.plugins = connectedPluginSlugs;
 	}
 
 	const response = await window.fetch( apiRoot + 'jetpack/v4/connection/register', {

--- a/projects/packages/connection/src/connectors/js/connectors-card.js
+++ b/projects/packages/connection/src/connectors/js/connectors-card.js
@@ -71,7 +71,7 @@ async function startConnectionFlow( siteRegistered ) {
 		if ( redirectUri ) {
 			params.set( 'redirect_uri', redirectUri );
 		}
-		params.set( 'from', 'wpcom-connector' );
+		params.set( 'from', 'jetpack-connector' );
 		if ( connectedPluginSlugs ) {
 			params.set( 'plugins', connectedPluginSlugs );
 		}

--- a/projects/packages/connection/tests/php/Jetpack_Connector_Test.php
+++ b/projects/packages/connection/tests/php/Jetpack_Connector_Test.php
@@ -170,7 +170,8 @@ class Jetpack_Connector_Test extends TestCase {
 		$this->assertNotEmpty( $data['apiRoot'] );
 		$this->assertNotEmpty( $data['apiNonce'] );
 		$this->assertNotEmpty( $data['redirectUri'] );
-		$this->assertArrayNotHasKey( 'connectedPlugins', $data );
+		$this->assertArrayHasKey( 'connectedPlugins', $data );
+		$this->assertIsArray( $data['connectedPlugins'] );
 		$this->assertArrayNotHasKey( 'siteDetails', $data );
 		$this->assertArrayNotHasKey( 'currentUser', $data );
 		$this->assertArrayNotHasKey( 'connectionOwner', $data );

--- a/projects/packages/connection/tests/php/REST_Endpoints_Test.php
+++ b/projects/packages/connection/tests/php/REST_Endpoints_Test.php
@@ -478,6 +478,98 @@ class REST_Endpoints_Test extends TestCase {
 	}
 
 	/**
+	 * Testing the `connection/register` endpoint forwards the `from` param into
+	 * the authorize URL builder, and appends `plugins` as a query arg on the
+	 * returned authorize URL.
+	 */
+	public function test_connection_register_forwards_from_and_plugins() {
+		add_filter( 'pre_http_request', array( static::class, 'intercept_register_request' ), 10, 3 );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/connection/register' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'registration_nonce' => wp_create_nonce( 'jetpack-registration-nonce' ),
+					'from'               => 'jetpack-connector',
+					'plugins'            => 'jetpack,woocommerce',
+				),
+				JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		remove_filter( 'pre_http_request', array( static::class, 'intercept_register_request' ), 10 );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertStringContainsString( 'from=jetpack-connector', $data['authorizeUrl'] );
+		$this->assertStringContainsString( 'plugins=jetpack,woocommerce', $data['authorizeUrl'] );
+	}
+
+	/**
+	 * Testing the `connection/register` endpoint without the new `from` /
+	 * `plugins` params — older callers should keep working unchanged.
+	 */
+	public function test_connection_register_without_from_or_plugins() {
+		add_filter( 'pre_http_request', array( static::class, 'intercept_register_request' ), 10, 3 );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/connection/register' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array( 'registration_nonce' => wp_create_nonce( 'jetpack-registration-nonce' ) ),
+				JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		remove_filter( 'pre_http_request', array( static::class, 'intercept_register_request' ), 10 );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertStringNotContainsString( 'plugins=', $data['authorizeUrl'] );
+		$this->assertStringNotContainsString( 'from=', $data['authorizeUrl'] );
+	}
+
+	/**
+	 * Testing the `connection/authorize_url` endpoint forwards `from` to the
+	 * underlying authorization URL builder and appends `plugins` as a query arg.
+	 */
+	public function test_connection_authorize_url_with_from_and_plugins() {
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/connection/authorize_url' );
+		$request->set_query_params(
+			array(
+				'from'    => 'jetpack-connector',
+				'plugins' => 'jetpack,woocommerce',
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertStringContainsString( 'from=jetpack-connector', $data['authorizeUrl'] );
+		$this->assertStringContainsString( 'plugins=jetpack,woocommerce', $data['authorizeUrl'] );
+	}
+
+	/**
+	 * Testing the `connection/authorize_url` endpoint without the new params —
+	 * older callers should not see `from` or `plugins` injected.
+	 */
+	public function test_connection_authorize_url_without_from_or_plugins() {
+		$request  = new WP_REST_Request( 'GET', '/jetpack/v4/connection/authorize_url' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertStringNotContainsString( 'plugins=', $data['authorizeUrl'] );
+		$this->assertStringNotContainsString( 'from=', $data['authorizeUrl'] );
+	}
+
+	/**
 	 * Testing the `connection/register` endpoint with alternate_authorization_url
 	 */
 	public function test_connection_register_with_alternate_auth_url() {


### PR DESCRIPTION
Fixes CONNECT-186

## Proposed changes
* Accept a new `plugins` query/body param on `POST /jetpack/v4/connection/register`, and `from`+`plugins` on `GET /jetpack/v4/connection/authorize_url`. `from` is forwarded into the underlying authorize URL builder; `plugins` is appended as a query arg on the resulting authorize URL.
* Expose `connectedPlugins` to the Connectors card data even before the site is registered, so the card can include the slugs in its first register/authorize request.
* Connectors card now sends `from=jetpack-connector` and a comma-separated list of connected plugin slugs to both endpoints when starting a connection.

## Related product discussion/links
* Automattic/wp-calypso#110180 — Calypso "Jetpack Connection - unified flow" consumes the forwarded `from` and `plugins` params.

## Does this pull request change what data or activity we track or use?
* The Connector now forwards a `from=jetpack-connector` segmentation marker and the slugs of plugins already using the Jetpack connection (e.g. `jetpack,woocommerce`) to WordPress.com as part of the connection flow. No new user-level data — both values are already available client-side in the Jetpack runtime; this PR just propagates them through the existing register/authorize endpoints.

## Testing instructions
* Requires a site running WordPress 7.0 or above (the Connectors card is gated on that version).
* Install Jetpack from this branch and activate it on a fresh, disconnected test site. Confirm the WordPress.com connector card shows up under Settings → Connectors.
* From the card, start the connection flow. In the browser network tab:
  * `POST jetpack/v4/connection/register` body includes `plugins=<comma-separated slugs>`. The response `authorizeUrl` (and any subsequent redirect) contains `from=jetpack-connector` and `plugins=<slugs>`.
  * On an already-registered site, `GET jetpack/v4/connection/authorize_url?from=jetpack-connector&plugins=<slugs>` returns a URL containing both params.
* Inspect the data passed to `connectors-card.js` (e.g. via the localized window data) and confirm `connectedPlugins` is present even before site registration.
* Sanity check: hit `register` / `authorize_url` without the new params and confirm older callers still work — `from` defaults to false and `plugins` is only appended when non-empty.
