### PR TITLE
Omnibar: revert site-specific admin bar endpoint

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/omnibar-revert-admin-bar
+++ b/projects/packages/jetpack-mu-wpcom/changelog/omnibar-revert-admin-bar
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Omnibar: remove wpcom/v2/admin-bar endpoint from jetpack-mu-wpcom. We'll move it to Jetpack instead.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-bar.php
@@ -121,5 +121,3 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Bar extends WP_REST_Controller {
 		return $allowed;
 	}
 }
-
-wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Admin_Bar' );


### PR DESCRIPTION
## Proposed changes

Omnibar: remove wpcom/v2/admin-bar endpoint from jetpack-mu-wpcom. We'll move it to Jetpack instead, so that self-hosted sites will have the same feature. 

See also: phcsdm-ED-p2#comment-1267