### PR TITLE
Revert "Disable REST API visibility for simple payments creator email"

### DIFF
--- a/projects/packages/paypal-payments/changelog/revert-48090-fix-remove-spay-email-from-rest
+++ b/projects/packages/paypal-payments/changelog/revert-48090-fix-remove-spay-email-from-rest
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Remove previous work that introduced an error

--- a/projects/packages/paypal-payments/src/legacy/class-simple-payments.php
+++ b/projects/packages/paypal-payments/src/legacy/class-simple-payments.php
@@ -499,7 +499,7 @@ class Simple_Payments {
 				'description'       => esc_html__( 'Simple payments button; paypal email.', 'jetpack-paypal-payments' ),
 				'object_subtype'    => self::$post_type_product,
 				'sanitize_callback' => 'sanitize_email',
-				'show_in_rest'      => false,
+				'show_in_rest'      => true,
 				'single'            => true,
 				'type'              => 'string',
 			)


### PR DESCRIPTION
Reverts Automattic/jetpack#48090

We have gotten some reports of simple payments being sent to the wrong recipient because of the latest fix. This reverses it and should fix the issue.

Fixes https://linear.app/a8c/issue/SHILL-1905/simple-payments-many-transactions-sent-to-helpwordpresscom-instead-of