### PR TITLE
Blaze: register MCP-exposed list-campaigns ability (ADS-952)

### DIFF
--- a/projects/packages/blaze/changelog/add-ads-952-blaze-mcp-ability
+++ b/projects/packages/blaze/changelog/add-ads-952-blaze-mcp-ability
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Blaze: register a read-only `blaze-ads/list-campaigns` ability and opt it into WooCommerce's MCP server tool whitelist when Woo 10.7+ MCP is present.

--- a/projects/packages/blaze/composer.json
+++ b/projects/packages/blaze/composer.json
@@ -11,7 +11,8 @@
 		"automattic/jetpack-plans": "@dev",
 		"automattic/jetpack-redirect": "@dev",
 		"automattic/jetpack-status": "@dev",
-		"automattic/jetpack-sync": "@dev"
+		"automattic/jetpack-sync": "@dev",
+		"automattic/jetpack-wp-abilities": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^4.0.0",

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * Jetpack Blaze Abilities Registration
+ *
+ * Single source of truth for Blaze's WordPress Abilities API registration.
+ * Registers a read-only ability and opts it into WooCommerce's MCP server
+ * tool whitelist so MCP clients (e.g. Claude Desktop) can discover and
+ * invoke it alongside Woo's built-in abilities.
+ *
+ * Both delivery paths invoke this class:
+ * - The Jetpack plugin, via `Automattic\Jetpack\Blaze::init()` in this package.
+ * - The standalone `blaze-ads` plugin, via its own bootstrap.
+ *
+ * v1 scope is intentionally Woo-only: the class bails when a Woo MCP server
+ * is not detected on the site. See ADS-952 for the broader rollout plan.
+ *
+ * @package automattic/jetpack-blaze
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9; we guard with function_exists()/class_exists() so the file is safe on older WP and on sites without Woo MCP.
+
+namespace Automattic\Jetpack\Blaze\Abilities;
+
+use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use WP_REST_Request;
+
+/**
+ * Registers the `blaze-ads` category and the `blaze-ads/list-campaigns`
+ * ability, and opts the ability into WooCommerce's MCP server.
+ */
+class Blaze_Abilities extends Registrar {
+
+	const CATEGORY_SLUG          = 'blaze-ads';
+	const ABILITY_LIST_CAMPAIGNS = 'blaze-ads/list-campaigns';
+
+	/**
+	 * Wire registration into the Abilities API lifecycle and opt the
+	 * ability into Woo's MCP server.
+	 *
+	 * Bails early when WooCommerce 10.7+ with the bundled MCP adapter is
+	 * not present — the v1 surface is Woo-only on purpose.
+	 *
+	 * Note: deliberately does not call `parent::init()`. The Registrar
+	 * base gates registration behind the `jetpack_wp_abilities_enabled`
+	 * filter (default false), and toggling that filter would force-enable
+	 * registration for *every* future Registrar consumer in the monorepo,
+	 * not just Blaze. We mirror parent::init()'s lifecycle wiring directly
+	 * so we only opt in our own abilities.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		if ( ! self::is_woo_mcp_available() ) {
+			return;
+		}
+
+		add_filter( 'jetpack_wp_abilities_should_register', array( __CLASS__, 'guard_against_double_register' ), 10, 3 );
+		add_filter( 'woocommerce_mcp_include_ability', array( __CLASS__, 'opt_into_woo_mcp' ), 10, 2 );
+
+		if ( did_action( self::CATEGORIES_INIT_ACTION ) ) {
+			static::register_category();
+		} else {
+			add_action( self::CATEGORIES_INIT_ACTION, array( static::class, 'register_category' ) );
+		}
+
+		if ( did_action( self::ABILITIES_INIT_ACTION ) ) {
+			static::register_abilities();
+		} else {
+			add_action( self::ABILITIES_INIT_ACTION, array( static::class, 'register_abilities' ) );
+		}
+	}
+
+	/**
+	 * Detect a Woo MCP server on the site. Single signal: the provider class
+	 * was added to WooCommerce in 10.7 and is only loaded when MCP is
+	 * available, so its presence is a sufficient gate.
+	 *
+	 * @return bool
+	 */
+	private static function is_woo_mcp_available(): bool {
+		return class_exists( '\Automattic\WooCommerce\Internal\MCP\MCPAdapterProvider' );
+	}
+
+	/**
+	 * Defensive `wp_get_ability()` check, wired through the Registrar's
+	 * per-slug filter so we skip registration if something else (a previous
+	 * call, another plugin) has already registered the ability. Belt and
+	 * braces: with both delivery paths invoking the same class this should
+	 * be a no-op, but keeps us safe against anyone else registering the slug.
+	 *
+	 * @param bool   $enabled Whether the registrar would proceed.
+	 * @param string $type    'category' or 'ability'.
+	 * @param string $slug    The slug being registered.
+	 * @return bool
+	 */
+	public static function guard_against_double_register( $enabled, $type, $slug ) {
+		if ( ! $enabled ) {
+			return $enabled;
+		}
+		if ( 'ability' === $type && self::ABILITY_LIST_CAMPAIGNS === $slug && function_exists( 'wp_get_ability' ) && wp_get_ability( $slug ) ) {
+			return false;
+		}
+		return $enabled;
+	}
+
+	/**
+	 * Opt our ability into Woo's MCP server tool whitelist.
+	 *
+	 * @param bool   $include    Whether Woo would include the ability by default.
+	 * @param string $ability_id The ability ID being considered.
+	 * @return bool
+	 */
+	public static function opt_into_woo_mcp( $include, $ability_id ) {
+		if ( self::ABILITY_LIST_CAMPAIGNS === $ability_id ) {
+			return true;
+		}
+		return $include;
+	}
+
+	/**
+	 * Category slug owned by this registrar.
+	 *
+	 * @return string
+	 */
+	public static function get_category_slug(): string {
+		return self::CATEGORY_SLUG;
+	}
+
+	/**
+	 * Category definition passed to `wp_register_ability_category()`.
+	 *
+	 * @return array
+	 */
+	public static function get_category_definition(): array {
+		return array(
+			// "Blaze" is a product name and should not be translated.
+			'label'       => 'Blaze',
+			'description' => __( 'Abilities for managing Blaze ad campaigns.', 'jetpack-blaze' ),
+		);
+	}
+
+	/**
+	 * Abilities owned by this registrar, keyed by slug.
+	 *
+	 * @return array<string, array>
+	 */
+	public static function get_abilities(): array {
+		return array(
+			self::ABILITY_LIST_CAMPAIGNS => array(
+				'label'               => __( 'List Blaze campaigns', 'jetpack-blaze' ),
+				'description'         => __( 'List the Blaze advertising campaigns associated with the current site, including status, schedule, spend, and performance metrics.', 'jetpack-blaze' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'default'              => array(),
+					'properties'           => new \stdClass(),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'        => 'object',
+					'description' => __( 'Campaigns payload as returned by the Blaze DSP API.', 'jetpack-blaze' ),
+				),
+				'execute_callback'    => array( __CLASS__, 'list_campaigns' ),
+				'permission_callback' => array( __CLASS__, 'permission_callback' ),
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Permission gate: store-manager capability plus an active Jetpack user
+	 * connection. Both delivery paths route DSP calls through Jetpack
+	 * Connect, so the connection check is meaningful regardless of how the
+	 * package was loaded.
+	 *
+	 * @return bool
+	 */
+	public static function permission_callback() {
+		// `manage_woocommerce` is a WooCommerce-defined capability — sniff lacks it in its known list.
+		if ( ! current_user_can( 'manage_woocommerce' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown
+			return false;
+		}
+
+		$connection = new Jetpack_Connection();
+		if ( ! $connection->is_user_connected() ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Return the campaigns payload by delegating to the existing DSP REST
+	 * route. Using `rest_do_request()` rather than calling the controller
+	 * directly so we inherit the standard request lifecycle, permission
+	 * checks, and any third-party filters wired onto that route.
+	 *
+	 * @param array $args Ability input. Currently unused; reserved for future filtering params.
+	 * @return array|\WP_Error
+	 */
+	public static function list_campaigns( $args = array() ) {
+		unset( $args );
+
+		$site_id = \Automattic\Jetpack\Connection\Manager::get_site_id();
+		if ( is_wp_error( $site_id ) ) {
+			return $site_id;
+		}
+
+		$route   = sprintf( '/jetpack/v4/blaze-app/sites/%d/wordads/dsp/api/v1.1/campaigns', $site_id );
+		$request = new WP_REST_Request( 'GET', $route );
+		$request->set_param( 'api_version', 'v1.1' );
+
+		$response = rest_do_request( $request );
+		if ( $response->is_error() ) {
+			return $response->as_error();
+		}
+
+		return $response->get_data();
+	}
+}

--- a/projects/packages/blaze/src/class-blaze.php
+++ b/projects/packages/blaze/src/class-blaze.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack;
 
+use Automattic\Jetpack\Blaze\Abilities\Blaze_Abilities;
 use Automattic\Jetpack\Blaze\Dashboard as Blaze_Dashboard;
 use Automattic\Jetpack\Blaze\Dashboard_REST_Controller as Blaze_Dashboard_REST_Controller;
 use Automattic\Jetpack\Blaze\REST_Controller;
@@ -59,6 +60,8 @@ class Blaze {
 		add_action( 'rest_api_init', array( new Blaze_Dashboard_REST_Controller(), 'register_rest_routes' ) );
 		// Add general Blaze REST API endpoints.
 		add_action( 'rest_api_init', array( new REST_Controller(), 'register_rest_routes' ) );
+		// Register Blaze abilities and opt them into Woo's MCP server (no-op when Woo MCP isn't present).
+		Blaze_Abilities::init();
 	}
 
 	/**

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Tests for Blaze Abilities registration.
+ *
+ * @package automattic/jetpack-blaze
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9; tests exercise guarded integration points directly.
+
+namespace Automattic\Jetpack\Blaze\Abilities;
+
+use Jetpack_Options;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+
+/**
+ * @covers \Automattic\Jetpack\Blaze\Abilities\Blaze_Abilities
+ */
+#[CoversClass( Blaze_Abilities::class )]
+class Blaze_Abilities_Test extends BaseTestCase {
+
+	/**
+	 * Synthetic site ID used by the Blaze list-campaigns REST delegation.
+	 *
+	 * @var int
+	 */
+	private const TEST_SITE_ID = 12345;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up() {
+		Jetpack_Options::update_option( 'id', self::TEST_SITE_ID );
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down() {
+		Jetpack_Options::delete_option( 'id' );
+		remove_all_filters( 'jetpack_wp_abilities_should_register' );
+	}
+
+	/**
+	 * Category metadata is stable for clients that group MCP tools.
+	 */
+	public function test_category_definition() {
+		$this->assertSame( 'blaze-ads', Blaze_Abilities::get_category_slug() );
+		$this->assertSame(
+			array(
+				'label'       => 'Blaze',
+				'description' => 'Abilities for managing Blaze ad campaigns.',
+			),
+			Blaze_Abilities::get_category_definition()
+		);
+	}
+
+	/**
+	 * The list-campaigns ability is read-only and has the expected public contract.
+	 */
+	public function test_list_campaigns_ability_definition() {
+		$abilities = Blaze_Abilities::get_abilities();
+
+		$this->assertArrayHasKey( Blaze_Abilities::ABILITY_LIST_CAMPAIGNS, $abilities );
+
+		$ability = $abilities[ Blaze_Abilities::ABILITY_LIST_CAMPAIGNS ];
+		$this->assertSame( array( Blaze_Abilities::class, 'list_campaigns' ), $ability['execute_callback'] );
+		$this->assertSame( array( Blaze_Abilities::class, 'permission_callback' ), $ability['permission_callback'] );
+		$this->assertTrue( $ability['meta']['show_in_rest'] );
+		$this->assertTrue( $ability['meta']['annotations']['readonly'] );
+		$this->assertFalse( $ability['meta']['annotations']['destructive'] );
+		$this->assertTrue( $ability['meta']['annotations']['idempotent'] );
+		$this->assertFalse( $ability['input_schema']['additionalProperties'] );
+	}
+
+	/**
+	 * Woo MCP should include the Blaze ability without altering other abilities.
+	 */
+	public function test_opt_into_woo_mcp_for_list_campaigns() {
+		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( false, Blaze_Abilities::ABILITY_LIST_CAMPAIGNS ) );
+		$this->assertFalse( Blaze_Abilities::opt_into_woo_mcp( false, 'woocommerce/list-products' ) );
+		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( true, 'woocommerce/list-products' ) );
+	}
+
+	/**
+	 * The double-register guard preserves an existing disabled decision.
+	 */
+	public function test_guard_against_double_register_preserves_disabled_decision() {
+		$this->assertFalse(
+			Blaze_Abilities::guard_against_double_register( false, 'ability', Blaze_Abilities::ABILITY_LIST_CAMPAIGNS )
+		);
+		$this->assertTrue(
+			Blaze_Abilities::guard_against_double_register( true, 'category', Blaze_Abilities::ABILITY_LIST_CAMPAIGNS )
+		);
+	}
+
+	/**
+	 * List_campaigns delegates to the existing Blaze REST route and returns its data.
+	 */
+	public function test_list_campaigns_delegates_to_blaze_rest_route() {
+		register_rest_route(
+			'jetpack/v4',
+			'/blaze-app/sites/' . self::TEST_SITE_ID . '/wordads/dsp/api/v1.1/campaigns',
+			array(
+				'methods'             => 'GET',
+				'callback'            => static function ( $request ) {
+					return array(
+						'api_version' => $request->get_param( 'api_version' ),
+						'campaigns'   => array(
+							array(
+								'id'     => 'campaign-1',
+								'status' => 'active',
+							),
+						),
+					);
+				},
+				'permission_callback' => '__return_true',
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'api_version' => 'v1.1',
+				'campaigns'   => array(
+					array(
+						'id'     => 'campaign-1',
+						'status' => 'active',
+					),
+				),
+			),
+			Blaze_Abilities::list_campaigns()
+		);
+	}
+}

--- a/projects/plugins/jetpack/changelog/add-ads-952-blaze-mcp-locks
+++ b/projects/plugins/jetpack/changelog/add-ads-952-blaze-mcp-locks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+Comment: Update plugin lockfile for an internal Blaze package dependency.
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -616,7 +616,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/blaze",
-                "reference": "f600123b4b3ab650ab4f927971069b83f52d8ef6"
+                "reference": "07ecff35c9e4445f454e0b2d2977ffd4433e52ef"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -626,6 +626,7 @@
                 "automattic/jetpack-redirect": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-sync": "@dev",
+                "automattic/jetpack-wp-abilities": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-ads-952-blaze-mcp-locks
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-ads-952-blaze-mcp-locks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+Comment: Update plugin lockfile for an internal Blaze package dependency.
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -275,7 +275,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/blaze",
-                "reference": "f600123b4b3ab650ab4f927971069b83f52d8ef6"
+                "reference": "07ecff35c9e4445f454e0b2d2977ffd4433e52ef"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -285,6 +285,7 @@
                 "automattic/jetpack-redirect": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-sync": "@dev",
+                "automattic/jetpack-wp-abilities": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {

--- a/projects/plugins/wpcomsh/changelog/add-ads-952-blaze-mcp-locks
+++ b/projects/plugins/wpcomsh/changelog/add-ads-952-blaze-mcp-locks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+Comment: Update plugin lockfile for an internal Blaze package dependency.
+

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -411,7 +411,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/blaze",
-                "reference": "f600123b4b3ab650ab4f927971069b83f52d8ef6"
+                "reference": "07ecff35c9e4445f454e0b2d2977ffd4433e52ef"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -421,6 +421,7 @@
                 "automattic/jetpack-redirect": "@dev",
                 "automattic/jetpack-status": "@dev",
                 "automattic/jetpack-sync": "@dev",
+                "automattic/jetpack-wp-abilities": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {


### PR DESCRIPTION
## Summary

Phase 1 of ADS-952. Adds a single read-only `blaze-ads/list-campaigns` ability via the WordPress Abilities API and opts it into WooCommerce's MCP server, so MCP clients (Claude Desktop, etc.) can list a merchant's Blaze campaigns alongside Woo's built-in tools.

This class is the single source of truth: both delivery paths (Jetpack itself, and the standalone `blaze-ads` plugin via Automattic/blaze-ads#95) call `Blaze_Abilities::init()`. No-op when WooCommerce 10.7+ MCP isn't present — non-Woo installs see no change.

## How it works

- Extends `Automattic\Jetpack\WP_Abilities\Registrar` (one new composer require: `automattic/jetpack-wp-abilities`).
- `permission_callback`: requires `manage_woocommerce` and `is_user_connected()`.
- `execute_callback`: delegates to the existing DSP route (`/jetpack/v4/blaze-app/sites/<id>/wordads/dsp/api/v1.1/campaigns`) via `rest_do_request()` — inherits the standard request lifecycle, no new auth code.
- Adds the ability to Woo's MCP whitelist via the documented `woocommerce_mcp_include_ability` filter. Zero MCP-server code on our side; Woo handles the protocol layer.
- A defensive `wp_get_ability()` guard via `jetpack_wp_abilities_should_register` prevents double-registration if anything else claims the slug.

## Test plan

Prereqs: a JN site with WooCommerce 10.7+, **MCP Integration** feature toggle on (`WooCommerce → Settings → Advanced → Features`), Jetpack with this branch active and connected, Blaze module on, a user with `manage_woocommerce`, and at least one test campaign created via `Tools → Advertising`.

Two surfaces, two auth schemes:

**1. WP Abilities REST endpoint** — validates the ability is registered and works. Auth: WP Application Password (`Users → Profile → Application Passwords`). Method must be **GET** because the ability is marked `meta.annotations.readonly`.

```sh
curl -u "$USER:$APP_PASS" \
  "$SITE/wp-json/wp-abilities/v1/abilities/blaze-ads/list-campaigns/run"
```

**2. Woo MCP server** — validates Woo's MCP server picks up our ability as a tool (the "real" Phase 1 success signal). Auth: Woo REST API key (`WooCommerce → Settings → Advanced → REST API → Add key`, Read/Write). Setup guide: https://woocommerce.com/posts/woocommerce-mcp/. The MCP route is `$SITE/wp-json/woocommerce/mcp` and clients pass `X-MCP-API-Key: CONSUMER_KEY:CONSUMER_SECRET`. Tool name is `blaze-ads-list-campaigns` (MCP normalises `/` → `-`).

### Checklist

- [x] Abilities REST call (#1) returns the campaigns payload (same shape as `/jetpack/v4/blaze-app/sites/<id>/wordads/dsp/api/v1.1/campaigns`).
- [ ] Same call with a non-`manage_woocommerce` user → 403.
- [ ] Same call with the Jetpack user disconnected → 403.
- [ ] Disable the Woo MCP feature toggle → ability is not registered (call #1 returns 404), no PHP notices.
- [x] Configure Claude Desktop / Claude Code per the blog post and confirm `blaze-ads-list-campaigns` shows up alongside Woo's tools and invokes successfully.
- [ ] If the standalone blaze-ads plugin is also active, `wp ability list | grep blaze-ads` shows exactly one entry (no double-registration).

See the smoke-test comment below for the actual test results.

Companion PR: Automattic/blaze-ads#95
Linear: ADS-952

## Does this pull request change what data or activity we track or use?

This PR exposes the existing Blaze campaigns payload through a new read-only WordPress Ability and Woo MCP tool for authenticated users who already pass the existing `manage_woocommerce` + Jetpack user-connection checks. It does not add new tracking, logging, or stored data.
