### PR TITLE
VideoPress: Fix TUS exception namespace

### DIFF
--- a/projects/packages/videopress/changelog/fix-tus-global-exceptions
+++ b/projects/packages/videopress/changelog/fix-tus-global-exceptions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Fix corrupt resumable uploads triggering a fatal error.

--- a/projects/packages/videopress/src/tus/class-tus-file.php
+++ b/projects/packages/videopress/src/tus/class-tus-file.php
@@ -384,8 +384,8 @@ class Tus_File {
 	 * @param int $total_bytes The total bytes of the file.
 	 *
 	 * @return int
-	 * @throws Out_Of_Range_Exception Various exceptions.
-	 * @throws Connection_Exception Various exceptions.
+	 * @throws \Out_Of_Range_Exception Various exceptions.
+	 * @throws \Connection_Exception Various exceptions.
 	 * @throws File_Exception Various exceptions.
 	 */
 	public function upload( $total_bytes ) {
@@ -407,7 +407,7 @@ class Tus_File {
 
 			while ( ! feof( $input ) ) {
 				if ( CONNECTION_NORMAL !== connection_status() ) {
-					throw new Connection_Exception( 'Connection aborted by user.' );
+					throw new \Connection_Exception( 'Connection aborted by user.' );
 				}
 
 				$data  = $this->read( $input, self::CHUNK_SIZE );
@@ -418,7 +418,7 @@ class Tus_File {
 				$this->cache->set( $key, array( 'offset' => $this->offset ) );
 
 				if ( $this->offset > $total_bytes ) {
-					throw new Out_Of_Range_Exception( 'The uploaded file is corrupt.' );
+					throw new \Out_Of_Range_Exception( 'The uploaded file is corrupt.' );
 				}
 
 				if ( $this->offset === $total_bytes ) {

--- a/projects/packages/videopress/tests/php/Tus_File_Test.php
+++ b/projects/packages/videopress/tests/php/Tus_File_Test.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Tests for VideoPressUploader\Tus_File.
+ *
+ * @package automattic/jetpack-videopress
+ */
+// phpcs:ignoreFile WordPress.Files.FileName.NotHyphenatedLowercase, WordPress.Files.FileName.InvalidClassFileName -- PHPUnit test files use class-matching names.
+
+namespace VideoPressUploader;
+
+use WorDBless\BaseTestCase;
+
+require_once __DIR__ . '/class-out-of-range-exception.php';
+
+/**
+ * Tus_File test suite.
+ */
+class Tus_File_Test extends BaseTestCase {
+
+	/**
+	 * Tests that corrupt uploads throw the global third-party exception.
+	 */
+	public function test_upload_throws_global_out_of_range_exception_when_upload_exceeds_total_bytes() {
+		global $wp_filesystem;
+
+		$input_file  = tempnam( sys_get_temp_dir(), 'videopress-tus-input-' );
+		$output_file = tempnam( sys_get_temp_dir(), 'videopress-tus-output-' );
+		$cache       = new Transient_Store( 1 );
+		$key         = 'test-upload';
+
+		try {
+			$this->assertNotFalse( $input_file );
+			$this->assertNotFalse( $output_file );
+
+			if ( ! function_exists( 'WP_Filesystem' ) ) {
+				require_once ABSPATH . 'wp-admin/includes/file.php';
+			}
+
+			$this->assertTrue( WP_Filesystem() );
+			$this->assertInstanceOf( \WP_Filesystem_Base::class, $wp_filesystem );
+			$this->assertTrue( $wp_filesystem->put_contents( $input_file, 'test' ) );
+			set_transient( $cache->build_key( $key ), wp_json_encode( array(), JSON_UNESCAPED_SLASHES ) );
+
+			$file = new Tus_File( $key, $cache );
+			$file->set_key( $key );
+			$file->set_meta( 0, 4, $output_file );
+			Tus_File::set_input_stream( $input_file );
+
+			$file->upload( 3 );
+			$this->fail( 'Expected an Out_Of_Range_Exception to be thrown.' );
+		} catch ( \Out_Of_Range_Exception $exception ) {
+			$this->assertSame( 'The uploaded file is corrupt.', $exception->getMessage() );
+		} finally {
+			Tus_File::set_input_stream( Tus_File::INPUT_STREAM );
+			delete_transient( $cache->build_key( $key ) );
+
+			if ( is_string( $input_file ) && file_exists( $input_file ) ) {
+				wp_delete_file( $input_file );
+			}
+
+			if ( is_string( $output_file ) && file_exists( $output_file ) ) {
+				wp_delete_file( $output_file );
+			}
+		}
+	}
+}

--- a/projects/packages/videopress/tests/php/class-out-of-range-exception.php
+++ b/projects/packages/videopress/tests/php/class-out-of-range-exception.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Test stub for the global exception provided by the resumable uploader.
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+if ( ! class_exists( 'Out_Of_Range_Exception' ) ) {
+	/**
+	 * Global out of range exception.
+	 */
+	class Out_Of_Range_Exception extends Exception {
+	}
+}


### PR DESCRIPTION
Fixes #

## Proposed changes
* Qualify the TUS uploader's third-party global `Out_Of_Range_Exception` and `Connection_Exception` classes so PHP does not look for them in the `VideoPressUploader` namespace.
* Add PHP regression coverage for corrupt TUS uploads that exceed the expected total bytes.
* Add a VideoPress changelog entry.

## Related product discussion/links
* None.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Run `CI=1 pnpm jetpack test php packages/videopress -v`
* Run `CI=1 pnpm jetpack phan packages/videopress`
