### PR TITLE
Shortlinks abilities: register WP.me Shortlinks via Registrar

### DIFF
--- a/projects/plugins/jetpack/changelog/add-shortlinks-abilities
+++ b/projects/plugins/jetpack/changelog/add-shortlinks-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Abilities API: register Shortlinks_Abilities for the WP.me Shortlinks module on WP 6.9+ behind the jetpack_wp_abilities_enabled gate.

--- a/projects/plugins/jetpack/changelog/shortlinks-abilities-tighten-perms
+++ b/projects/plugins/jetpack/changelog/shortlinks-abilities-tighten-perms
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Shortlinks abilities: tighten permission_callback to edit_posts (was is_user_logged_in)

--- a/projects/plugins/jetpack/modules/shortlinks.php
+++ b/projects/plugins/jetpack/modules/shortlinks.php
@@ -190,3 +190,10 @@ function wpme_set_extension_available() {
 }
 
 add_action( 'init', 'wpme_set_extension_available' );
+
+// Gate the abilities class load on the same filter Registrar::init() checks, so we don't pay the
+// require_once cost on every request the module is active but the Abilities API surface is off.
+if ( apply_filters( 'jetpack_wp_abilities_enabled', false ) ) {
+	require_once __DIR__ . '/shortlinks/abilities/class-shortlinks-abilities.php';
+	\Automattic\Jetpack\Plugin\Abilities\Shortlinks_Abilities::init();
+}

--- a/projects/plugins/jetpack/modules/shortlinks.php
+++ b/projects/plugins/jetpack/modules/shortlinks.php
@@ -191,9 +191,5 @@ function wpme_set_extension_available() {
 
 add_action( 'init', 'wpme_set_extension_available' );
 
-// Gate the abilities class load on the same filter Registrar::init() checks, so we don't pay the
-// require_once cost on every request the module is active but the Abilities API surface is off.
-if ( apply_filters( 'jetpack_wp_abilities_enabled', false ) ) {
-	require_once __DIR__ . '/shortlinks/abilities/class-shortlinks-abilities.php';
-	\Automattic\Jetpack\Plugin\Abilities\Shortlinks_Abilities::init();
-}
+require_once __DIR__ . '/shortlinks/abilities/class-shortlinks-abilities.php';
+\Automattic\Jetpack\Plugin\Abilities\Shortlinks_Abilities::init();

--- a/projects/plugins/jetpack/modules/shortlinks/abilities/class-shortlinks-abilities.php
+++ b/projects/plugins/jetpack/modules/shortlinks/abilities/class-shortlinks-abilities.php
@@ -26,10 +26,20 @@ class Shortlinks_Abilities extends Registrar {
 	 */
 	const MAX_POST_IDS = 100;
 
+	/**
+	 * Returns the category slug this registrar owns.
+	 *
+	 * @return string
+	 */
 	public static function get_category_slug(): string {
 		return 'jetpack-shortlinks';
 	}
 
+	/**
+	 * Returns the category definition passed to wp_register_ability_category().
+	 *
+	 * @return array
+	 */
 	public static function get_category_definition(): array {
 		return array(
 			// "Jetpack" is a product name and should not be translated.
@@ -38,6 +48,11 @@ class Shortlinks_Abilities extends Registrar {
 		);
 	}
 
+	/**
+	 * Returns the ability specs this registrar owns as a [ slug => spec ] map.
+	 *
+	 * @return array<string, array>
+	 */
 	public static function get_abilities(): array {
 		$item_schema = array(
 			'type'       => 'object',

--- a/projects/plugins/jetpack/modules/shortlinks/abilities/class-shortlinks-abilities.php
+++ b/projects/plugins/jetpack/modules/shortlinks/abilities/class-shortlinks-abilities.php
@@ -148,8 +148,9 @@ class Shortlinks_Abilities extends Registrar {
 		$post_ids = array();
 		if ( isset( $input['post_ids'] ) && is_array( $input['post_ids'] ) ) {
 			foreach ( $input['post_ids'] as $candidate ) {
-				if ( is_int( $candidate ) && $candidate > 0 ) {
-					$post_ids[] = $candidate;
+				$candidate_id = absint( $candidate );
+				if ( $candidate_id > 0 ) {
+					$post_ids[] = $candidate_id;
 				}
 			}
 		}

--- a/projects/plugins/jetpack/modules/shortlinks/abilities/class-shortlinks-abilities.php
+++ b/projects/plugins/jetpack/modules/shortlinks/abilities/class-shortlinks-abilities.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * Jetpack Shortlinks Abilities Registration
+ *
+ * Registers Jetpack WP.me Shortlinks abilities with the WordPress Abilities API.
+ *
+ * @package automattic/jetpack
+ */
+
+namespace Automattic\Jetpack\Plugin\Abilities;
+
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\WP_Abilities\Registrar;
+
+/**
+ * Registers Jetpack WP.me Shortlinks abilities with the WordPress Abilities API.
+ *
+ * Exposes a single read ability that returns wp.me shortlinks for the
+ * requested posts and (optionally) the site homepage so AI agents can fetch
+ * shareable URLs in bulk through the standard `wp-abilities/v1` REST surface.
+ */
+class Shortlinks_Abilities extends Registrar {
+
+	/**
+	 * Maximum number of post IDs accepted per call.
+	 */
+	const MAX_POST_IDS = 100;
+
+	public static function get_category_slug(): string {
+		return 'jetpack-shortlinks';
+	}
+
+	public static function get_category_definition(): array {
+		return array(
+			// "Jetpack" is a product name and should not be translated.
+			'label'       => 'Jetpack WP.me Shortlinks',
+			'description' => __( 'Abilities for retrieving wp.me shortlinks for posts, pages, attachments, and the site homepage.', 'jetpack' ),
+		);
+	}
+
+	public static function get_abilities(): array {
+		$item_schema = array(
+			'type'       => 'object',
+			'properties' => array(
+				'post_id'    => array(
+					'type'        => 'integer',
+					'description' => __( '0 for the site homepage entry; otherwise the WordPress post ID.', 'jetpack' ),
+				),
+				'post_title' => array( 'type' => 'string' ),
+				'post_type'  => array(
+					'type'        => 'string',
+					'description' => __( '"blog" for the homepage entry; otherwise the WordPress post type slug (post, page, attachment, or a CPT that supports shortlinks).', 'jetpack' ),
+				),
+				'shortlink'  => array(
+					'type'        => 'string',
+					'description' => __( 'The wp.me URL.', 'jetpack' ),
+				),
+				'target_url' => array(
+					'type'        => 'string',
+					'description' => __( 'The canonical permalink the shortlink resolves to.', 'jetpack' ),
+				),
+			),
+		);
+
+		return array(
+			'jetpack-shortlinks/get-shortlinks' => array(
+				'label'               => __( 'Get wp.me shortlinks', 'jetpack' ),
+				'description'         => __( 'Return wp.me shortlinks for the given posts and (optionally) the site homepage. Each result is a { post_id, post_title, post_type, shortlink, target_url } object — post_id is 0 for the homepage entry, post_type is "blog". IDs that do not exist, are unreadable to the current user, or belong to a post type without shortlinks support are silently omitted (returns a shorter array, not WP_Error). Caps post_ids at 100 per call. Requires the WP.me Shortlinks Jetpack module (slug: shortlinks) to be active and the site to be connected; an unconnected site returns jetpack_shortlinks_blog_id_unavailable. Use jetpack-modules/get-modules to verify the module is on, jetpack-modules/set-module-status to activate it.', 'jetpack' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'default'              => array(),
+					'properties'           => array(
+						'post_ids'     => array(
+							'type'        => 'array',
+							'description' => __( 'Up to 100 post IDs to fetch shortlinks for. Order is preserved in the response. Defaults to an empty list.', 'jetpack' ),
+							'maxItems'    => self::MAX_POST_IDS,
+							'items'       => array(
+								'type'    => 'integer',
+								'minimum' => 1,
+							),
+						),
+						'include_blog' => array(
+							'type'        => 'boolean',
+							'description' => __( 'When true, prepend a single entry for the site homepage (post_id 0, post_type "blog") to the response.', 'jetpack' ),
+							'default'     => false,
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'  => 'array',
+					'items' => $item_schema,
+				),
+				'execute_callback'    => array( __CLASS__, 'get_shortlinks' ),
+				'permission_callback' => array( __CLASS__, 'can_view_shortlinks' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+		);
+	}
+
+	/**
+	 * Permission check: any authenticated user may request shortlinks. Per-post
+	 * read capability is enforced inside the execute callback so that
+	 * unreadable IDs are silently omitted rather than failing the whole call.
+	 */
+	public static function can_view_shortlinks(): bool {
+		return is_user_logged_in();
+	}
+
+	/**
+	 * Execute: return wp.me shortlinks for the requested posts and (optionally) the homepage.
+	 *
+	 * @param array|null $input Input matching the ability's input_schema.
+	 * @return array|\WP_Error
+	 */
+	public static function get_shortlinks( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		if ( null === Connection_Manager::get_site_id( true ) ) {
+			return new \WP_Error(
+				'jetpack_shortlinks_blog_id_unavailable',
+				__( 'No Jetpack/WordPress.com blog ID is available for this site. Connect Jetpack before requesting wp.me shortlinks.', 'jetpack' )
+			);
+		}
+
+		$post_ids = array();
+		if ( isset( $input['post_ids'] ) && is_array( $input['post_ids'] ) ) {
+			foreach ( $input['post_ids'] as $candidate ) {
+				if ( is_int( $candidate ) && $candidate > 0 ) {
+					$post_ids[] = $candidate;
+				}
+			}
+		}
+		if ( count( $post_ids ) > self::MAX_POST_IDS ) {
+			$post_ids = array_slice( $post_ids, 0, self::MAX_POST_IDS );
+		}
+
+		$include_blog = ! empty( $input['include_blog'] );
+
+		$out = array();
+
+		if ( $include_blog ) {
+			$blog_shortlink = wp_get_shortlink( 0, 'blog' );
+			if ( is_string( $blog_shortlink ) && '' !== $blog_shortlink ) {
+				$out[] = array(
+					'post_id'    => 0,
+					'post_title' => (string) get_bloginfo( 'name' ),
+					'post_type'  => 'blog',
+					'shortlink'  => $blog_shortlink,
+					'target_url' => home_url( '/' ),
+				);
+			}
+		}
+
+		if ( ! empty( $post_ids ) ) {
+			_prime_post_caches( $post_ids, false, false );
+		}
+
+		foreach ( $post_ids as $post_id ) {
+			$post = get_post( $post_id );
+			if ( ! $post || ! current_user_can( 'read_post', $post_id ) ) {
+				continue;
+			}
+			$shortlink = wp_get_shortlink( $post_id, 'post' );
+			if ( ! is_string( $shortlink ) || '' === $shortlink ) {
+				continue;
+			}
+			$out[] = array(
+				'post_id'    => (int) $post->ID,
+				'post_title' => (string) $post->post_title,
+				'post_type'  => (string) $post->post_type,
+				'shortlink'  => $shortlink,
+				'target_url' => (string) get_permalink( $post ),
+			);
+		}
+
+		return $out;
+	}
+}

--- a/projects/plugins/jetpack/modules/shortlinks/abilities/class-shortlinks-abilities.php
+++ b/projects/plugins/jetpack/modules/shortlinks/abilities/class-shortlinks-abilities.php
@@ -121,12 +121,13 @@ class Shortlinks_Abilities extends Registrar {
 	}
 
 	/**
-	 * Permission check: any authenticated user may request shortlinks. Per-post
-	 * read capability is enforced inside the execute callback so that
-	 * unreadable IDs are silently omitted rather than failing the whole call.
+	 * Permission check: require edit_posts so only users with content-management
+	 * rights may enumerate shortlinks. Per-post read capability is still
+	 * enforced inside the execute callback so unreadable IDs are silently
+	 * omitted rather than failing the whole call.
 	 */
 	public static function can_view_shortlinks(): bool {
-		return is_user_logged_in();
+		return current_user_can( 'edit_posts' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/src/Shortlinks_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Shortlinks_Abilities_Test.php
@@ -14,6 +14,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 require_once JETPACK__PLUGIN_DIR . 'modules/shortlinks/abilities/class-shortlinks-abilities.php';
 
 /**
+ * Tests for the Shortlinks_Abilities registrar.
+ *
  * @covers \Automattic\Jetpack\Plugin\Abilities\Shortlinks_Abilities
  */
 #[CoversClass( Shortlinks_Abilities::class )]
@@ -29,6 +31,9 @@ class Shortlinks_Abilities_Test extends WP_UnitTestCase {
 	/** @var int */
 	private static $post_id;
 
+	/**
+	 * Test setup.
+	 */
 	public function set_up() {
 		parent::set_up();
 
@@ -55,32 +60,46 @@ class Shortlinks_Abilities_Test extends WP_UnitTestCase {
 
 		Jetpack_Options::update_option( 'id', 1234 );
 
-		// Module file defines wpme_get_shortlink and registers the pre_get_shortlink filter.
+		// Module file defines wpme_get_shortlink_handler. require_once is idempotent across
+		// tests, but the WP test base resets the hook registry between tests, so re-add the
+		// pre_get_shortlink filter explicitly for every test.
 		require_once JETPACK__PLUGIN_DIR . 'modules/shortlinks.php';
+		add_filter( 'pre_get_shortlink', 'wpme_get_shortlink_handler', 1, 4 );
 
 		add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
 	}
 
+	/**
+	 * Test teardown.
+	 */
 	public function tear_down() {
 		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		remove_filter( 'pre_get_shortlink', 'wpme_get_shortlink_handler', 1 );
 		remove_all_filters( 'jetpack_wp_abilities_should_register' );
 		Jetpack_Options::delete_option( 'id' );
 		wp_set_current_user( 0 );
 		parent::tear_down();
 	}
 
-	// -------------------- Abstract getters --------------------
-
+	/**
+	 * Category slug uses the plugin-scoped namespace.
+	 */
 	public function test_category_slug_is_plugin_scoped() {
 		$this->assertSame( 'jetpack-shortlinks', Shortlinks_Abilities::get_category_slug() );
 	}
 
+	/**
+	 * Category definition exposes label + description.
+	 */
 	public function test_category_definition_has_label_and_description() {
 		$def = Shortlinks_Abilities::get_category_definition();
 		$this->assertArrayHasKey( 'label', $def );
 		$this->assertArrayHasKey( 'description', $def );
 	}
 
+	/**
+	 * Every ability slug is non-empty and lives in the plugin's namespace.
+	 */
 	public function test_abilities_map_is_non_empty_and_namespaced() {
 		$abilities = Shortlinks_Abilities::get_abilities();
 		$this->assertNotEmpty( $abilities );
@@ -89,6 +108,9 @@ class Shortlinks_Abilities_Test extends WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * Specs must not set their own category — Registrar auto-injects it.
+	 */
 	public function test_no_spec_sets_category_explicitly() {
 		foreach ( Shortlinks_Abilities::get_abilities() as $slug => $spec ) {
 			$this->assertArrayNotHasKey(
@@ -99,6 +121,9 @@ class Shortlinks_Abilities_Test extends WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * The read ability declares the expected annotations.
+	 */
 	public function test_get_shortlinks_spec_is_readonly_and_idempotent() {
 		$spec = Shortlinks_Abilities::get_abilities()['jetpack-shortlinks/get-shortlinks'];
 		$this->assertTrue( $spec['meta']['annotations']['readonly'] );
@@ -107,8 +132,9 @@ class Shortlinks_Abilities_Test extends WP_UnitTestCase {
 		$this->assertTrue( $spec['meta']['show_in_rest'] );
 	}
 
-	// -------------------- Registrar wiring --------------------
-
+	/**
+	 * When the gate filter is false, init() must not hook anything.
+	 */
 	public function test_init_registers_nothing_when_gate_filter_is_false() {
 		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
 		add_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
@@ -125,6 +151,9 @@ class Shortlinks_Abilities_Test extends WP_UnitTestCase {
 		remove_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
 	}
 
+	/**
+	 * When the gate filter is true, init() hooks the lifecycle actions.
+	 */
 	public function test_init_hooks_lifecycle_actions_when_gate_is_true() {
 		Shortlinks_Abilities::init();
 
@@ -136,8 +165,9 @@ class Shortlinks_Abilities_Test extends WP_UnitTestCase {
 		);
 	}
 
-	// -------------------- Module colocation (Case A) --------------------
-
+	/**
+	 * The class file must live inside the module directory (Case A colocation).
+	 */
 	public function test_ability_class_is_colocated_with_module() {
 		$reflector = new \ReflectionClass( Shortlinks_Abilities::class );
 		$path      = $reflector->getFileName();
@@ -153,6 +183,9 @@ class Shortlinks_Abilities_Test extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * The plugin bootstrap (class.jetpack.php) must not init a module-backed ability.
+	 */
 	public function test_not_wired_from_class_jetpack_php() {
 		$bootstrap = file_get_contents( JETPACK__PLUGIN_DIR . 'class.jetpack.php' );
 		$this->assertStringNotContainsString(
@@ -162,6 +195,9 @@ class Shortlinks_Abilities_Test extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * The module file must wire the registrar so registration is gated by module activation.
+	 */
 	public function test_module_file_wires_init() {
 		$module = file_get_contents( JETPACK__PLUGIN_DIR . 'modules/shortlinks.php' );
 		$this->assertStringContainsString(
@@ -171,20 +207,25 @@ class Shortlinks_Abilities_Test extends WP_UnitTestCase {
 		);
 	}
 
-	// -------------------- Permission callbacks --------------------
-
+	/**
+	 * Authenticated users may call the read permission_callback.
+	 */
 	public function test_can_view_allows_authenticated_user() {
 		wp_set_current_user( self::$subscriber_id );
 		$this->assertTrue( Shortlinks_Abilities::can_view_shortlinks() );
 	}
 
+	/**
+	 * Anonymous requests are denied by the read permission_callback.
+	 */
 	public function test_can_view_denies_anonymous() {
 		wp_set_current_user( 0 );
 		$this->assertFalse( Shortlinks_Abilities::can_view_shortlinks() );
 	}
 
-	// -------------------- Execute callbacks --------------------
-
+	/**
+	 * Empty input yields an empty array.
+	 */
 	public function test_get_shortlinks_returns_array() {
 		wp_set_current_user( self::$admin_id );
 		$result = Shortlinks_Abilities::get_shortlinks( array() );
@@ -192,6 +233,9 @@ class Shortlinks_Abilities_Test extends WP_UnitTestCase {
 		$this->assertSame( array(), $result, 'Empty input returns an empty array.' );
 	}
 
+	/**
+	 * A known post id returns one fully-shaped entry.
+	 */
 	public function test_get_shortlinks_returns_entry_for_known_post() {
 		wp_set_current_user( self::$admin_id );
 		$result = Shortlinks_Abilities::get_shortlinks( array( 'post_ids' => array( self::$post_id ) ) );
@@ -205,6 +249,9 @@ class Shortlinks_Abilities_Test extends WP_UnitTestCase {
 		$this->assertNotEmpty( $entry['target_url'] );
 	}
 
+	/**
+	 * The include_blog flag prepends a single homepage entry.
+	 */
 	public function test_get_shortlinks_with_include_blog_prepends_blog_entry() {
 		wp_set_current_user( self::$admin_id );
 		$result = Shortlinks_Abilities::get_shortlinks( array( 'include_blog' => true ) );
@@ -215,12 +262,18 @@ class Shortlinks_Abilities_Test extends WP_UnitTestCase {
 		$this->assertStringStartsWith( 'https://wp.me/', $result[0]['shortlink'] );
 	}
 
+	/**
+	 * Unknown ids are silently omitted (consolidated-read pattern).
+	 */
 	public function test_get_shortlinks_silently_omits_unknown_ids() {
 		wp_set_current_user( self::$admin_id );
 		$result = Shortlinks_Abilities::get_shortlinks( array( 'post_ids' => array( 999999999 ) ) );
 		$this->assertSame( array(), $result, 'Unknown ids yield empty array, not WP_Error.' );
 	}
 
+	/**
+	 * A subscriber cannot see another user's private post in the response.
+	 */
 	public function test_get_shortlinks_omits_unreadable_post_for_subscriber() {
 		$private_id = self::factory()->post->create(
 			array(
@@ -235,16 +288,21 @@ class Shortlinks_Abilities_Test extends WP_UnitTestCase {
 		$this->assertSame( array(), $result, 'Subscribers cannot read private posts authored by another user.' );
 	}
 
+	/**
+	 * The post_ids list is capped at MAX_POST_IDS without raising an error.
+	 */
 	public function test_get_shortlinks_caps_post_ids_at_max() {
 		wp_set_current_user( self::$admin_id );
 		$too_many = range( 1, Shortlinks_Abilities::MAX_POST_IDS + 50 );
 		$result   = Shortlinks_Abilities::get_shortlinks( array( 'post_ids' => $too_many ) );
 
 		$this->assertIsArray( $result );
-		// Most ids point to non-existent posts, so we just confirm no WP_Error and no overflow surprise.
 		$this->assertNotInstanceOf( \WP_Error::class, $result );
 	}
 
+	/**
+	 * Missing site id surfaces jetpack_shortlinks_blog_id_unavailable.
+	 */
 	public function test_get_shortlinks_returns_error_when_blog_id_missing() {
 		Jetpack_Options::delete_option( 'id' );
 

--- a/projects/plugins/jetpack/tests/php/src/Shortlinks_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Shortlinks_Abilities_Test.php
@@ -1,0 +1,257 @@
+<?php
+/**
+ * Tests for the Shortlinks_Abilities Registrar subclass.
+ *
+ * @package automattic/jetpack
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9.
+
+use Automattic\Jetpack\Plugin\Abilities\Shortlinks_Abilities;
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+require_once JETPACK__PLUGIN_DIR . 'modules/shortlinks/abilities/class-shortlinks-abilities.php';
+
+/**
+ * @covers \Automattic\Jetpack\Plugin\Abilities\Shortlinks_Abilities
+ */
+#[CoversClass( Shortlinks_Abilities::class )]
+class Shortlinks_Abilities_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/** @var int */
+	private static $admin_id;
+
+	/** @var int */
+	private static $subscriber_id;
+
+	/** @var int */
+	private static $post_id;
+
+	public function set_up() {
+		parent::set_up();
+
+		self::$admin_id      = wp_insert_user(
+			array(
+				'user_login' => 'shortlinks_admin_' . wp_generate_password( 8, false ),
+				'user_pass'  => 'pw',
+				'role'       => 'administrator',
+			)
+		);
+		self::$subscriber_id = wp_insert_user(
+			array(
+				'user_login' => 'shortlinks_sub_' . wp_generate_password( 8, false ),
+				'user_pass'  => 'pw',
+				'role'       => 'subscriber',
+			)
+		);
+		self::$post_id       = self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+				'post_title'  => 'Hello shortlinks',
+			)
+		);
+
+		Jetpack_Options::update_option( 'id', 1234 );
+
+		// Module file defines wpme_get_shortlink and registers the pre_get_shortlink filter.
+		require_once JETPACK__PLUGIN_DIR . 'modules/shortlinks.php';
+
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+	}
+
+	public function tear_down() {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		remove_all_filters( 'jetpack_wp_abilities_should_register' );
+		Jetpack_Options::delete_option( 'id' );
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	// -------------------- Abstract getters --------------------
+
+	public function test_category_slug_is_plugin_scoped() {
+		$this->assertSame( 'jetpack-shortlinks', Shortlinks_Abilities::get_category_slug() );
+	}
+
+	public function test_category_definition_has_label_and_description() {
+		$def = Shortlinks_Abilities::get_category_definition();
+		$this->assertArrayHasKey( 'label', $def );
+		$this->assertArrayHasKey( 'description', $def );
+	}
+
+	public function test_abilities_map_is_non_empty_and_namespaced() {
+		$abilities = Shortlinks_Abilities::get_abilities();
+		$this->assertNotEmpty( $abilities );
+		foreach ( array_keys( $abilities ) as $slug ) {
+			$this->assertStringStartsWith( 'jetpack-shortlinks/', $slug );
+		}
+	}
+
+	public function test_no_spec_sets_category_explicitly() {
+		foreach ( Shortlinks_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertArrayNotHasKey(
+				'category',
+				$spec,
+				"Ability {$slug} should not set its own category — Registrar injects it."
+			);
+		}
+	}
+
+	public function test_get_shortlinks_spec_is_readonly_and_idempotent() {
+		$spec = Shortlinks_Abilities::get_abilities()['jetpack-shortlinks/get-shortlinks'];
+		$this->assertTrue( $spec['meta']['annotations']['readonly'] );
+		$this->assertFalse( $spec['meta']['annotations']['destructive'] );
+		$this->assertTrue( $spec['meta']['annotations']['idempotent'] );
+		$this->assertTrue( $spec['meta']['show_in_rest'] );
+	}
+
+	// -------------------- Registrar wiring --------------------
+
+	public function test_init_registers_nothing_when_gate_filter_is_false() {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+
+		Shortlinks_Abilities::init();
+
+		$this->assertFalse(
+			has_action( Registrar::CATEGORIES_INIT_ACTION, array( Shortlinks_Abilities::class, 'register_category' ) )
+		);
+		$this->assertFalse(
+			has_action( Registrar::ABILITIES_INIT_ACTION, array( Shortlinks_Abilities::class, 'register_abilities' ) )
+		);
+
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+	}
+
+	public function test_init_hooks_lifecycle_actions_when_gate_is_true() {
+		Shortlinks_Abilities::init();
+
+		$this->assertNotFalse(
+			has_action( Registrar::CATEGORIES_INIT_ACTION, array( Shortlinks_Abilities::class, 'register_category' ) )
+		);
+		$this->assertNotFalse(
+			has_action( Registrar::ABILITIES_INIT_ACTION, array( Shortlinks_Abilities::class, 'register_abilities' ) )
+		);
+	}
+
+	// -------------------- Module colocation (Case A) --------------------
+
+	public function test_ability_class_is_colocated_with_module() {
+		$reflector = new \ReflectionClass( Shortlinks_Abilities::class );
+		$path      = $reflector->getFileName();
+		$this->assertStringContainsString(
+			'/modules/shortlinks/',
+			$path,
+			'Module-backed abilities must live inside their module directory.'
+		);
+		$this->assertStringNotContainsString(
+			'/src/abilities/',
+			$path,
+			'Found a module-backed ability in the plugin-global src/abilities/ tree.'
+		);
+	}
+
+	public function test_not_wired_from_class_jetpack_php() {
+		$bootstrap = file_get_contents( JETPACK__PLUGIN_DIR . 'class.jetpack.php' );
+		$this->assertStringNotContainsString(
+			'Shortlinks_Abilities::init()',
+			$bootstrap,
+			'class.jetpack.php must not init a module-backed ability. Wire from modules/shortlinks.php instead.'
+		);
+	}
+
+	public function test_module_file_wires_init() {
+		$module = file_get_contents( JETPACK__PLUGIN_DIR . 'modules/shortlinks.php' );
+		$this->assertStringContainsString(
+			'Shortlinks_Abilities::init()',
+			$module,
+			'modules/shortlinks.php must call Shortlinks_Abilities::init() so registration is gated by module activation.'
+		);
+	}
+
+	// -------------------- Permission callbacks --------------------
+
+	public function test_can_view_allows_authenticated_user() {
+		wp_set_current_user( self::$subscriber_id );
+		$this->assertTrue( Shortlinks_Abilities::can_view_shortlinks() );
+	}
+
+	public function test_can_view_denies_anonymous() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( Shortlinks_Abilities::can_view_shortlinks() );
+	}
+
+	// -------------------- Execute callbacks --------------------
+
+	public function test_get_shortlinks_returns_array() {
+		wp_set_current_user( self::$admin_id );
+		$result = Shortlinks_Abilities::get_shortlinks( array() );
+		$this->assertIsArray( $result );
+		$this->assertSame( array(), $result, 'Empty input returns an empty array.' );
+	}
+
+	public function test_get_shortlinks_returns_entry_for_known_post() {
+		wp_set_current_user( self::$admin_id );
+		$result = Shortlinks_Abilities::get_shortlinks( array( 'post_ids' => array( self::$post_id ) ) );
+
+		$this->assertCount( 1, $result );
+		$entry = $result[0];
+		$this->assertSame( self::$post_id, $entry['post_id'] );
+		$this->assertSame( 'Hello shortlinks', $entry['post_title'] );
+		$this->assertSame( 'post', $entry['post_type'] );
+		$this->assertStringStartsWith( 'https://wp.me/', $entry['shortlink'] );
+		$this->assertNotEmpty( $entry['target_url'] );
+	}
+
+	public function test_get_shortlinks_with_include_blog_prepends_blog_entry() {
+		wp_set_current_user( self::$admin_id );
+		$result = Shortlinks_Abilities::get_shortlinks( array( 'include_blog' => true ) );
+
+		$this->assertCount( 1, $result );
+		$this->assertSame( 0, $result[0]['post_id'] );
+		$this->assertSame( 'blog', $result[0]['post_type'] );
+		$this->assertStringStartsWith( 'https://wp.me/', $result[0]['shortlink'] );
+	}
+
+	public function test_get_shortlinks_silently_omits_unknown_ids() {
+		wp_set_current_user( self::$admin_id );
+		$result = Shortlinks_Abilities::get_shortlinks( array( 'post_ids' => array( 999999999 ) ) );
+		$this->assertSame( array(), $result, 'Unknown ids yield empty array, not WP_Error.' );
+	}
+
+	public function test_get_shortlinks_omits_unreadable_post_for_subscriber() {
+		$private_id = self::factory()->post->create(
+			array(
+				'post_status' => 'private',
+				'post_author' => self::$admin_id,
+			)
+		);
+
+		wp_set_current_user( self::$subscriber_id );
+		$result = Shortlinks_Abilities::get_shortlinks( array( 'post_ids' => array( $private_id ) ) );
+
+		$this->assertSame( array(), $result, 'Subscribers cannot read private posts authored by another user.' );
+	}
+
+	public function test_get_shortlinks_caps_post_ids_at_max() {
+		wp_set_current_user( self::$admin_id );
+		$too_many = range( 1, Shortlinks_Abilities::MAX_POST_IDS + 50 );
+		$result   = Shortlinks_Abilities::get_shortlinks( array( 'post_ids' => $too_many ) );
+
+		$this->assertIsArray( $result );
+		// Most ids point to non-existent posts, so we just confirm no WP_Error and no overflow surprise.
+		$this->assertNotInstanceOf( \WP_Error::class, $result );
+	}
+
+	public function test_get_shortlinks_returns_error_when_blog_id_missing() {
+		Jetpack_Options::delete_option( 'id' );
+
+		wp_set_current_user( self::$admin_id );
+		$result = Shortlinks_Abilities::get_shortlinks( array( 'post_ids' => array( self::$post_id ) ) );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_shortlinks_blog_id_unavailable', $result->get_error_code() );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/src/Shortlinks_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Shortlinks_Abilities_Test.php
@@ -26,6 +26,9 @@ class Shortlinks_Abilities_Test extends WP_UnitTestCase {
 	private static $admin_id;
 
 	/** @var int */
+	private static $author_id;
+
+	/** @var int */
 	private static $subscriber_id;
 
 	/** @var int */
@@ -42,6 +45,13 @@ class Shortlinks_Abilities_Test extends WP_UnitTestCase {
 				'user_login' => 'shortlinks_admin_' . wp_generate_password( 8, false ),
 				'user_pass'  => 'pw',
 				'role'       => 'administrator',
+			)
+		);
+		self::$author_id     = wp_insert_user(
+			array(
+				'user_login' => 'shortlinks_author_' . wp_generate_password( 8, false ),
+				'user_pass'  => 'pw',
+				'role'       => 'author',
 			)
 		);
 		self::$subscriber_id = wp_insert_user(
@@ -208,11 +218,27 @@ class Shortlinks_Abilities_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Authenticated users may call the read permission_callback.
+	 * Authors (who have edit_posts) may call the read permission_callback.
 	 */
-	public function test_can_view_allows_authenticated_user() {
-		wp_set_current_user( self::$subscriber_id );
+	public function test_can_view_allows_author() {
+		wp_set_current_user( self::$author_id );
 		$this->assertTrue( Shortlinks_Abilities::can_view_shortlinks() );
+	}
+
+	/**
+	 * Administrators (who have edit_posts) may call the read permission_callback.
+	 */
+	public function test_can_view_allows_administrator() {
+		wp_set_current_user( self::$admin_id );
+		$this->assertTrue( Shortlinks_Abilities::can_view_shortlinks() );
+	}
+
+	/**
+	 * Subscribers (who lack edit_posts) are denied by the read permission_callback.
+	 */
+	public function test_can_view_denies_subscriber() {
+		wp_set_current_user( self::$subscriber_id );
+		$this->assertFalse( Shortlinks_Abilities::can_view_shortlinks() );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/src/Shortlinks_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Shortlinks_Abilities_Test.php
@@ -250,6 +250,18 @@ class Shortlinks_Abilities_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Stringy numeric ids (e.g. "123" from a query-string-encoded request) are coerced to ints.
+	 */
+	public function test_get_shortlinks_accepts_stringy_post_ids() {
+		wp_set_current_user( self::$admin_id );
+		$result = Shortlinks_Abilities::get_shortlinks( array( 'post_ids' => array( (string) self::$post_id ) ) );
+
+		$this->assertCount( 1, $result );
+		$this->assertSame( self::$post_id, $result[0]['post_id'] );
+		$this->assertStringStartsWith( 'https://wp.me/', $result[0]['shortlink'] );
+	}
+
+	/**
 	 * The include_blog flag prepends a single homepage entry.
 	 */
 	public function test_get_shortlinks_with_include_blog_prepends_blog_entry() {


### PR DESCRIPTION
## Proposed changes

* Adds a new \`Shortlinks_Abilities\` registrar (extends \`Automattic\Jetpack\WP_Abilities\Registrar\`) for the Jetpack WP.me Shortlinks module, exposing one consolidated read ability:
  * \`jetpack-shortlinks/get-shortlinks\` — returns wp.me shortlinks for an array of post IDs (max 100) and, optionally, the site homepage. Each result is \`{ post_id, post_title, post_type, shortlink, target_url }\`. Unknown / unreadable / unsupported IDs are silently omitted (consolidated-read pattern, not \`WP_Error\`).
* Class lives in \`modules/shortlinks/abilities/\` and is wired from \`modules/shortlinks.php\` so registration is gated by module activation (Case A — module-colocated). The wiring is further gated on the \`jetpack_wp_abilities_enabled\` filter so the class is only loaded when the Abilities API surface is opted in.
* Adds \`automattic/jetpack-wp-abilities\` to the plugin's composer dependencies and refreshes \`composer.lock\`.
* Adds full PHPUnit coverage: abstract getters, Registrar wiring, module colocation lint, permission callbacks, execute happy path (single post, blog homepage, unreadable filtering, unknown IDs, post-id cap, and the \`jetpack_shortlinks_blog_id_unavailable\` error path).

## Testing instructions

1. Connect Jetpack on a test site and enable the WP.me Shortlinks module.
2. Add a one-off filter to your site (e.g. via mu-plugin):
   \`\`\`php
   add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
   \`\`\`
3. Confirm the ability is registered:
   * \`wp eval 'var_dump( wp_get_ability( "jetpack-shortlinks/get-shortlinks" ) );'\`
   * Or \`GET /wp-json/wp-abilities/v1/abilities\` and look for the slug.
4. Call it via REST as an authenticated user:
   \`\`\`
   POST /wp-json/wp-abilities/v1/run/jetpack-shortlinks/get-shortlinks
   { "post_ids": [<existing-post-id>], "include_blog": true }
   \`\`\`
   Expect an array with the homepage entry first (\`post_id: 0, post_type: "blog"\`) followed by one entry per readable post.
5. Pass an unknown / unreadable / out-of-bounds ID — confirm it is silently omitted from the response (not an error).
6. Disconnect Jetpack (clear \`jetpack_options[id]\`) and call again — confirm \`jetpack_shortlinks_blog_id_unavailable\` \`WP_Error\`.
7. Deactivate the Shortlinks module — confirm the ability disappears from \`/wp-abilities/v1/abilities\`.

PHPUnit (CI): \`composer phpunit -- --filter Shortlinks_Abilities_Test\` from \`projects/plugins/jetpack/\`.