### PR TITLE
Related Posts: register get-related-posts ability

### DIFF
--- a/projects/plugins/jetpack/changelog/add-related-posts-abilities
+++ b/projects/plugins/jetpack/changelog/add-related-posts-abilities
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Related Posts: register Abilities API surface (get-related-posts, get-settings, update-settings) on WP 6.9+. The settings abilities are theme-aware: get-settings returns only the display fields the active theme actually consumes (classic themes get the full shape; block themes get theme_type and a notice pointing at the Related Posts block), and update-settings rejects writes on block themes since the option is not consumed at render time there.
+Related Posts: register Abilities API surface (get-related-posts, get-settings, update-settings) on WP 6.9+. The two settings abilities are only registered on classic themes; block themes do not consume the relatedposts option at render time (display is controlled per-instance by the Jetpack Related Posts block placed in templates), so registering settings abilities there would let agents write data nothing reads — they are omitted instead. The lookup ability remains available regardless of theme.

--- a/projects/plugins/jetpack/changelog/add-related-posts-abilities
+++ b/projects/plugins/jetpack/changelog/add-related-posts-abilities
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Related Posts: register Abilities API surface (get-related-posts, get-settings, update-settings) on WP 6.9+. The two settings abilities are only registered on classic themes; block themes do not consume the relatedposts option at render time (display is controlled per-instance by the Jetpack Related Posts block placed in templates), so registering settings abilities there would let agents write data nothing reads — they are omitted instead. The lookup ability remains available regardless of theme.
+Related Posts: register a get-related-posts ability with the WordPress Abilities API on WP 6.9+ so agents can fetch related posts for a single post through the standard wp-abilities/v1 REST surface.

--- a/projects/plugins/jetpack/changelog/add-related-posts-abilities
+++ b/projects/plugins/jetpack/changelog/add-related-posts-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Related Posts: register Abilities API surface (get-related-posts, get-settings, update-settings) on WP 6.9+.

--- a/projects/plugins/jetpack/changelog/add-related-posts-abilities
+++ b/projects/plugins/jetpack/changelog/add-related-posts-abilities
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Related Posts: register Abilities API surface (get-related-posts, get-settings, update-settings) on WP 6.9+.
+Related Posts: register Abilities API surface (get-related-posts, get-settings, update-settings) on WP 6.9+. The settings abilities are theme-aware: get-settings returns only the display fields the active theme actually consumes (classic themes get the full shape; block themes get theme_type and a notice pointing at the Related Posts block), and update-settings rejects writes on block themes since the option is not consumed at render time there.

--- a/projects/plugins/jetpack/changelog/related-posts-abilities-fix-test-incorrect-usage
+++ b/projects/plugins/jetpack/changelog/related-posts-abilities-fix-test-incorrect-usage
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Related Posts abilities: drop test-only setExpectedIncorrectUsage assertions that fail on CI

--- a/projects/plugins/jetpack/changelog/related-posts-abilities-per-page
+++ b/projects/plugins/jetpack/changelog/related-posts-abilities-per-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Related Posts abilities: expose result cap as configurable per_page input (max 20)

--- a/projects/plugins/jetpack/modules/related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts.php
@@ -76,3 +76,6 @@ class Jetpack_RelatedPosts_Module {
 
 // Do it.
 Jetpack_RelatedPosts_Module::instance();
+
+require_once __DIR__ . '/related-posts/abilities/class-related-posts-abilities.php';
+\Automattic\Jetpack\Plugin\Abilities\Related_Posts_Abilities::init();

--- a/projects/plugins/jetpack/modules/related-posts/abilities/class-related-posts-abilities.php
+++ b/projects/plugins/jetpack/modules/related-posts/abilities/class-related-posts-abilities.php
@@ -11,18 +11,19 @@
 
 namespace Automattic\Jetpack\Plugin\Abilities;
 
-use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\WP_Abilities\Registrar;
-use Jetpack_Options;
 use Jetpack_RelatedPosts;
 use WP_Error;
 
 /**
  * Registers Jetpack Related Posts abilities with the WordPress Abilities API.
  *
- * Exposes related-post lookups and the display-settings surface so AI agents
- * can read and update Related Posts through the standard `wp-abilities/v1`
- * REST surface.
+ * Exposes related-post lookups through the standard `wp-abilities/v1` REST
+ * surface. Display-settings management is intentionally not exposed: classic
+ * themes consume the `relatedposts` option only when an off-by-default filter
+ * is enabled, and block themes ignore it altogether (rendering is controlled
+ * per-instance by the Jetpack Related Posts block in templates) — so an agent
+ * editing those values would be writing data nothing reads.
  */
 class Related_Posts_Abilities extends Registrar {
 
@@ -31,21 +32,6 @@ class Related_Posts_Abilities extends Registrar {
 	private const MAX_SIZE = 20;
 
 	private const DEFAULT_SIZE = 3;
-
-	private const OPTION_KEY = 'relatedposts';
-
-	private const LAYOUTS = array( 'grid', 'list' );
-
-	private const EDITABLE_FIELDS = array(
-		'enabled',
-		'show_headline',
-		'show_thumbnails',
-		'show_date',
-		'show_context',
-		'layout',
-		'headline',
-		'size',
-	);
 
 	/**
 	 * Returns the category slug this registrar owns.
@@ -61,7 +47,7 @@ class Related_Posts_Abilities extends Registrar {
 		return array(
 			// "Jetpack" is a product name and should not be translated.
 			'label'       => 'Jetpack Related Posts',
-			'description' => __( 'Abilities for reading related posts and managing Related Posts display settings.', 'jetpack' ),
+			'description' => __( 'Abilities for reading related posts.', 'jetpack' ),
 		);
 	}
 
@@ -82,37 +68,10 @@ class Related_Posts_Abilities extends Registrar {
 			),
 		);
 
-		$settings_schema = array(
-			'type'       => 'object',
-			'required'   => array( 'theme_type' ),
-			'properties' => array(
-				'theme_type'      => array(
-					'type'        => 'string',
-					'enum'        => array( 'classic', 'block' ),
-					'description' => __( 'Active theme rendering model. "classic" themes consume these display settings via auto-injection after the post content; "block" themes ignore them — the Jetpack Related Posts block placed in the active template carries its own per-instance attributes.', 'jetpack' ),
-				),
-				'notice'          => array(
-					'type'        => 'string',
-					'description' => __( 'Present only when theme_type is "block". Human-readable pointer toward editing the Related Posts block in the Site Editor, since this option is not consumed at render time on block themes.', 'jetpack' ),
-				),
-				'enabled'         => array( 'type' => 'boolean' ),
-				'show_headline'   => array( 'type' => 'boolean' ),
-				'show_thumbnails' => array( 'type' => 'boolean' ),
-				'show_date'       => array( 'type' => 'boolean' ),
-				'show_context'    => array( 'type' => 'boolean' ),
-				'layout'          => array(
-					'type' => 'string',
-					'enum' => self::LAYOUTS,
-				),
-				'headline'        => array( 'type' => 'string' ),
-				'size'            => array( 'type' => 'integer' ),
-			),
-		);
-
-		$abilities = array(
+		return array(
 			'jetpack-related-posts/get-related-posts' => array(
 				'label'               => __( 'Get related posts', 'jetpack' ),
-				'description'         => __( 'Return related posts for a single post as an array of { id, url, title, excerpt, date, post_type, format }. The caller must be able to edit the source post (edit_post capability); unauthorized requests return jetpack_related_posts_forbidden. Backed by Elasticsearch via the Jetpack connection: when Related Posts is disabled, the post is unknown, or the ES backend is unreachable, the array is empty (not an error). Use per_page to control the result count (1..20, default 20); the underlying Elasticsearch query is hard-capped at 20, so values above 20 are rejected by the input schema and pagination beyond the first 20 results is not supported. The legacy "size" alias is accepted for backward compatibility and defaults to 3 when no per_page is supplied. Read-only and idempotent. Use jetpack-related-posts/get-settings to inspect the display configuration; use jetpack-modules/get-modules to confirm the related-posts module is active.', 'jetpack' ),
+				'description'         => __( 'Return related posts for a single post as an array of { id, url, title, excerpt, date, post_type, format }. The caller must be able to edit the source post (edit_post capability); unauthorized requests return jetpack_related_posts_forbidden. Backed by Elasticsearch via the Jetpack connection: when Related Posts is disabled, the post is unknown, or the ES backend is unreachable, the array is empty (not an error). Use per_page to control the result count (1..20, default 20); the underlying Elasticsearch query is hard-capped at 20, so values above 20 are rejected by the input schema and pagination beyond the first 20 results is not supported. The legacy "size" alias is accepted for backward compatibility and defaults to 3 when no per_page is supplied. Read-only and idempotent. Use jetpack-modules/get-modules to confirm the related-posts module is active.', 'jetpack' ),
 				'input_schema'        => array(
 					'type'                 => 'object',
 					'required'             => array( 'post_id' ),
@@ -168,111 +127,7 @@ class Related_Posts_Abilities extends Registrar {
 					'show_in_rest' => true,
 				),
 			),
-
-			'jetpack-related-posts/get-settings'      => array(
-				'label'               => __( 'Get Related Posts settings', 'jetpack' ),
-				'description'         => __( 'Return the Related Posts display settings: theme_type ("classic"), enabled, show_headline, show_thumbnails, show_date, show_context, layout ("grid"|"list"), headline, and size — the values that drive auto-injection after the post content. Only registered on classic themes; block themes ignore the underlying option (rendering is controlled per-instance by the Jetpack Related Posts block in templates), so this ability is omitted there. Read-only and idempotent. Pair with jetpack-related-posts/update-settings to change values; module activation itself is managed via jetpack-modules/set-module-status.', 'jetpack' ),
-				'input_schema'        => array(
-					'type'                 => 'object',
-					'properties'           => array(),
-					'additionalProperties' => false,
-				),
-				'output_schema'       => $settings_schema,
-				'execute_callback'    => array( __CLASS__, 'get_settings' ),
-				'permission_callback' => array( __CLASS__, 'can_view_settings' ),
-				'meta'                => array(
-					'annotations'  => array(
-						'readonly'    => true,
-						'destructive' => false,
-						'idempotent'  => true,
-					),
-					'show_in_rest' => true,
-				),
-			),
-
-			'jetpack-related-posts/update-settings'   => array(
-				'label'               => __( 'Update Related Posts settings', 'jetpack' ),
-				'description'         => __( 'Update one or more Related Posts display settings. Pass any subset of enabled, show_headline, show_thumbnails, show_date, show_context, layout, headline, size — omitted fields keep their current value. Only registered on classic themes; on block themes the ability is omitted entirely because the option is not consumed at render time — agents must edit the Jetpack Related Posts block inside the active template via the Site Editor instead. Idempotent: when no field differs from the current value, the call is a no-op and returns changed=false with an empty changed_fields array. Returns { settings, changed, changed_fields }. Does not toggle the related-posts module itself; use jetpack-modules/set-module-status for that.', 'jetpack' ),
-				'input_schema'        => array(
-					'type'                 => 'object',
-					'properties'           => array(
-						'enabled'         => array(
-							'type'        => 'boolean',
-							'description' => __( 'Whether to display related posts after single-post content.', 'jetpack' ),
-						),
-						'show_headline'   => array(
-							'type'        => 'boolean',
-							'description' => __( 'Whether to render a headline above the related-posts list.', 'jetpack' ),
-						),
-						'show_thumbnails' => array(
-							'type'        => 'boolean',
-							'description' => __( 'Whether to render a thumbnail image for each related post.', 'jetpack' ),
-						),
-						'show_date'       => array(
-							'type'        => 'boolean',
-							'description' => __( 'Whether to render the publish date for each related post.', 'jetpack' ),
-						),
-						'show_context'    => array(
-							'type'        => 'boolean',
-							'description' => __( 'Whether to render category/tag context for each related post.', 'jetpack' ),
-						),
-						'layout'          => array(
-							'type'        => 'string',
-							'description' => __( 'Layout used to render the related-posts list.', 'jetpack' ),
-							'enum'        => self::LAYOUTS,
-						),
-						'headline'        => array(
-							'type'        => 'string',
-							'description' => __( 'Headline rendered above the related-posts list when show_headline is true.', 'jetpack' ),
-							'maxLength'   => 200,
-						),
-						'size'            => array(
-							'type'        => 'integer',
-							'description' => __( 'Default number of related posts to render. Must be between 1 and 20.', 'jetpack' ),
-							'minimum'     => 1,
-							'maximum'     => self::MAX_SIZE,
-						),
-					),
-					'additionalProperties' => false,
-				),
-				'output_schema'       => array(
-					'type'       => 'object',
-					'properties' => array(
-						'settings'       => $settings_schema,
-						'changed'        => array( 'type' => 'boolean' ),
-						'changed_fields' => array(
-							'type'  => 'array',
-							'items' => array( 'type' => 'string' ),
-						),
-					),
-				),
-				'execute_callback'    => array( __CLASS__, 'update_settings' ),
-				'permission_callback' => array( __CLASS__, 'can_manage_settings' ),
-				'meta'                => array(
-					'annotations'  => array(
-						'readonly'    => false,
-						'destructive' => false,
-						'idempotent'  => true,
-					),
-					'show_in_rest' => true,
-				),
-			),
 		);
-
-		// Block themes render Related Posts through the jetpack/related-posts
-		// block placed in templates, so the `relatedposts` option is not consumed
-		// at render time. Exposing settings abilities there would let agents
-		// write data nothing reads — drop them from the registered surface
-		// entirely. The lookup ability (get-related-posts) is unaffected; it
-		// still works regardless of theme type.
-		if ( self::is_block_theme() ) {
-			unset(
-				$abilities['jetpack-related-posts/get-settings'],
-				$abilities['jetpack-related-posts/update-settings']
-			);
-		}
-
-		return $abilities;
 	}
 
 	/**
@@ -285,20 +140,6 @@ class Related_Posts_Abilities extends Registrar {
 	 */
 	public static function can_view_related_posts(): bool {
 		return current_user_can( 'edit_posts' );
-	}
-
-	/**
-	 * Permission check for reading the settings overview.
-	 */
-	public static function can_view_settings(): bool {
-		return current_user_can( 'edit_posts' );
-	}
-
-	/**
-	 * Permission check for updating the settings overview.
-	 */
-	public static function can_manage_settings(): bool {
-		return current_user_can( 'manage_options' );
 	}
 
 	/**
@@ -382,149 +223,6 @@ class Related_Posts_Abilities extends Registrar {
 	}
 
 	/**
-	 * Execute: return the current Related Posts settings.
-	 *
-	 * On classic themes the full display-settings shape is returned. On block
-	 * themes the option is not consumed at render time, so we return only the
-	 * theme_type and a notice pointing the caller at the block — listing the
-	 * other fields would imply they have an effect they do not.
-	 *
-	 * @param array|null $input Unused.
-	 * @return array
-	 */
-	public static function get_settings( $input = null ) {
-		unset( $input );
-
-		if ( self::is_block_theme() ) {
-			return array(
-				'theme_type' => 'block',
-				'notice'     => __( 'Related Posts on block themes is rendered via the Jetpack Related Posts block placed in the active template or template part. Display settings live on each block instance, so this option is not consumed at render time — open the Site Editor and edit the block directly to change appearance or visibility.', 'jetpack' ),
-			);
-		}
-
-		$settings               = self::normalize_settings( Jetpack_Options::get_option( self::OPTION_KEY, array() ) );
-		$settings['theme_type'] = 'classic';
-		return $settings;
-	}
-
-	/**
-	 * Execute: declarative settings update. Idempotent.
-	 *
-	 * @param array|null $input Input matching the ability's input_schema.
-	 * @return array|WP_Error
-	 */
-	public static function update_settings( $input = null ) {
-		if ( self::is_block_theme() ) {
-			return new WP_Error(
-				'jetpack_related_posts_block_theme_not_supported',
-				__( 'Related Posts display settings are not editable on block themes — this option is not consumed at render time. Open the Site Editor and edit the Jetpack Related Posts block inside the active template or template part; each block instance carries its own display attributes.', 'jetpack' ),
-				array( 'status' => 409 )
-			);
-		}
-
-		$input = is_array( $input ) ? $input : array();
-
-		$updates = array_intersect_key( $input, array_flip( self::EDITABLE_FIELDS ) );
-		if ( array() === $updates ) {
-			return new WP_Error(
-				'jetpack_related_posts_missing_field',
-				__( 'Provide at least one editable field (enabled, show_headline, show_thumbnails, show_date, show_context, layout, headline, size).', 'jetpack' )
-			);
-		}
-
-		if ( isset( $updates['layout'] )
-			&& ! ( is_string( $updates['layout'] ) && in_array( $updates['layout'], self::LAYOUTS, true ) )
-		) {
-			return new WP_Error(
-				'jetpack_related_posts_invalid_layout',
-				__( 'The "layout" field must be either "grid" or "list".', 'jetpack' )
-			);
-		}
-
-		if ( isset( $updates['size'] )
-			&& ( ! is_int( $updates['size'] ) || $updates['size'] < 1 || $updates['size'] > self::MAX_SIZE )
-		) {
-			return new WP_Error(
-				'jetpack_related_posts_invalid_size',
-				sprintf(
-					/* translators: %d: maximum size value. */
-					__( 'The "size" field must be an integer between 1 and %d.', 'jetpack' ),
-					self::MAX_SIZE
-				)
-			);
-		}
-
-		if ( isset( $updates['headline'] ) && ! is_string( $updates['headline'] ) ) {
-			return new WP_Error(
-				'jetpack_related_posts_invalid_headline',
-				__( 'The "headline" field must be a string.', 'jetpack' )
-			);
-		}
-
-		foreach ( array( 'enabled', 'show_headline', 'show_thumbnails', 'show_date', 'show_context' ) as $bool_field ) {
-			if ( isset( $updates[ $bool_field ] ) ) {
-				if ( ! is_bool( $updates[ $bool_field ] ) ) {
-					return new WP_Error(
-						'jetpack_related_posts_invalid_' . $bool_field,
-						sprintf(
-							/* translators: %s: input field name. */
-							__( 'The "%s" field must be a boolean.', 'jetpack' ),
-							$bool_field
-						)
-					);
-				}
-			}
-		}
-
-		$current = self::normalize_settings( Jetpack_Options::get_option( self::OPTION_KEY, array() ) );
-		$merged  = array_merge( $current, $updates );
-
-		$changed_fields = array();
-		foreach ( $updates as $field => $value ) {
-			if ( ! array_key_exists( $field, $current ) || $current[ $field ] !== $value ) {
-				$changed_fields[] = $field;
-			}
-		}
-
-		if ( array() === $changed_fields ) {
-			return array(
-				'settings'       => array_merge( $current, array( 'theme_type' => 'classic' ) ),
-				'changed'        => false,
-				'changed_fields' => array(),
-			);
-		}
-
-		$saved = Jetpack_Options::update_option( self::OPTION_KEY, $merged );
-		if ( ! $saved ) {
-			return new WP_Error(
-				'jetpack_related_posts_data_unavailable',
-				__( 'Unable to save Related Posts settings. Try again or verify the site is connected to Jetpack.', 'jetpack' )
-			);
-		}
-
-		return array(
-			'settings'       => array_merge( $merged, array( 'theme_type' => 'classic' ) ),
-			'changed'        => true,
-			'changed_fields' => $changed_fields,
-		);
-	}
-
-	/**
-	 * Whether the active theme is a block (FSE) theme for Related Posts purposes.
-	 *
-	 * Delegates to `Blocks::is_fse_theme()` so the ability's branching tracks the
-	 * exact same signal the module itself uses to skip auto-injection (see
-	 * `filter_add_target_to_dom()` in jetpack-related-posts.php). Going through
-	 * Jetpack's `jetpack_is_fse_theme` filter also lets tests flip the branch
-	 * without swapping the active theme on disk.
-	 *
-	 * @return bool
-	 */
-	private static function is_block_theme(): bool {
-		return Blocks::is_fse_theme();
-	}
-
-	/**
 	 * Returns the Jetpack Related Posts raw instance, loading the class file lazily
 	 * when it has not been included by the module's own load action yet.
 	 *
@@ -554,39 +252,6 @@ class Related_Posts_Abilities extends Registrar {
 			'date'      => isset( $related['date'] ) ? (string) $related['date'] : '',
 			'post_type' => $id > 0 ? (string) get_post_type( $id ) : '',
 			'format'    => isset( $related['format'] ) && '' !== $related['format'] ? (string) $related['format'] : null,
-		);
-	}
-
-	/**
-	 * Coerce a raw Related Posts options array into the canonical
-	 * agent-facing shape with stable types and sensible defaults.
-	 *
-	 * Mirrors the defaulting in `Jetpack_RelatedPosts::get_options()` without
-	 * instantiating the full module class (which would attach admin/frontend
-	 * hooks) and without using `init_raw()` (whose `get_options()` is a stub
-	 * that only exposes `enabled`).
-	 *
-	 * @param array|mixed $options Raw options array (possibly from the DB).
-	 * @return array
-	 */
-	private static function normalize_settings( $options ): array {
-		$options = is_array( $options ) ? $options : array();
-
-		$layout = isset( $options['layout'] ) && in_array( $options['layout'], self::LAYOUTS, true )
-			? $options['layout']
-			: 'grid';
-
-		$size = isset( $options['size'] ) && (int) $options['size'] >= 1 ? (int) $options['size'] : self::DEFAULT_SIZE;
-
-		return array(
-			'enabled'         => ! empty( $options['enabled'] ),
-			'show_headline'   => ! empty( $options['show_headline'] ),
-			'show_thumbnails' => ! empty( $options['show_thumbnails'] ),
-			'show_date'       => ! empty( $options['show_date'] ),
-			'show_context'    => ! empty( $options['show_context'] ),
-			'layout'          => $layout,
-			'headline'        => isset( $options['headline'] ) ? (string) $options['headline'] : __( 'Related', 'jetpack' ),
-			'size'            => $size,
 		);
 	}
 }

--- a/projects/plugins/jetpack/modules/related-posts/abilities/class-related-posts-abilities.php
+++ b/projects/plugins/jetpack/modules/related-posts/abilities/class-related-posts-abilities.php
@@ -1,0 +1,498 @@
+<?php
+/**
+ * Jetpack Related Posts Abilities Registration
+ *
+ * Registers Jetpack Related Posts abilities with the WordPress Abilities API.
+ *
+ * @package automattic/jetpack
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9; suppressions needed for older-WP compatibility runs.
+
+namespace Automattic\Jetpack\Plugin\Abilities;
+
+use Automattic\Jetpack\WP_Abilities\Registrar;
+use Jetpack_Options;
+use Jetpack_RelatedPosts;
+use WP_Error;
+
+/**
+ * Registers Jetpack Related Posts abilities with the WordPress Abilities API.
+ *
+ * Exposes related-post lookups and the display-settings surface so AI agents
+ * can read and update Related Posts through the standard `wp-abilities/v1`
+ * REST surface.
+ */
+class Related_Posts_Abilities extends Registrar {
+
+	/**
+	 * Maximum number of related posts returned in a single call.
+	 */
+	private const MAX_SIZE = 20;
+
+	/**
+	 * Default number of related posts when the caller does not specify a size.
+	 */
+	private const DEFAULT_SIZE = 3;
+
+	/**
+	 * Editable display-settings fields.
+	 */
+	private const EDITABLE_FIELDS = array(
+		'enabled',
+		'show_headline',
+		'show_thumbnails',
+		'show_date',
+		'show_context',
+		'layout',
+		'headline',
+		'size',
+	);
+
+	/**
+	 * Returns the category slug this registrar owns.
+	 */
+	public static function get_category_slug(): string {
+		return 'jetpack-related-posts';
+	}
+
+	/**
+	 * Returns the category definition passed to wp_register_ability_category().
+	 */
+	public static function get_category_definition(): array {
+		return array(
+			// "Jetpack" is a product name and should not be translated.
+			'label'       => 'Jetpack Related Posts',
+			'description' => __( 'Abilities for reading related posts and managing Related Posts display settings.', 'jetpack' ),
+		);
+	}
+
+	/**
+	 * Returns the abilities this registrar owns as a [ slug => spec ] map.
+	 */
+	public static function get_abilities(): array {
+		$related_post_schema = array(
+			'type'       => 'object',
+			'properties' => array(
+				'id'        => array( 'type' => 'integer' ),
+				'url'       => array( 'type' => 'string' ),
+				'title'     => array( 'type' => 'string' ),
+				'excerpt'   => array( 'type' => 'string' ),
+				'date'      => array( 'type' => 'string' ),
+				'post_type' => array( 'type' => 'string' ),
+				'format'    => array( 'type' => array( 'string', 'null' ) ),
+			),
+		);
+
+		$settings_schema = array(
+			'type'       => 'object',
+			'properties' => array(
+				'enabled'         => array( 'type' => 'boolean' ),
+				'show_headline'   => array( 'type' => 'boolean' ),
+				'show_thumbnails' => array( 'type' => 'boolean' ),
+				'show_date'       => array( 'type' => 'boolean' ),
+				'show_context'    => array( 'type' => 'boolean' ),
+				'layout'          => array(
+					'type' => 'string',
+					'enum' => array( 'grid', 'list' ),
+				),
+				'headline'        => array( 'type' => 'string' ),
+				'size'            => array( 'type' => 'integer' ),
+			),
+		);
+
+		return array(
+			'jetpack-related-posts/get-related-posts' => array(
+				'label'               => __( 'Get related posts', 'jetpack' ),
+				'description'         => __( 'Return related posts for a single post as an array of { id, url, title, excerpt, date, post_type, format }. Backed by Elasticsearch via the Jetpack connection: when Related Posts is disabled, the post is unknown, or the ES backend is unreachable, the array is empty (not an error). Read-only and idempotent. Use jetpack-related-posts/get-settings to inspect the display configuration; use jetpack-modules/get-modules to confirm the related-posts module is active.', 'jetpack' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'required'             => array( 'post_id' ),
+					'properties'           => array(
+						'post_id'          => array(
+							'type'        => 'integer',
+							'description' => __( 'WordPress post ID to find related posts for. Must reference an existing post.', 'jetpack' ),
+							'minimum'     => 1,
+						),
+						'size'             => array(
+							'type'        => 'integer',
+							'description' => __( 'Maximum number of related posts to return. Defaults to 3, capped at 20.', 'jetpack' ),
+							'minimum'     => 1,
+							'maximum'     => self::MAX_SIZE,
+							'default'     => self::DEFAULT_SIZE,
+						),
+						'post_type'        => array(
+							'type'        => 'string',
+							'description' => __( 'Restrict matches to a single post type slug (e.g. "post", "page"). Defaults to the source post\'s type.', 'jetpack' ),
+							'minLength'   => 1,
+						),
+						'exclude_post_ids' => array(
+							'type'        => 'array',
+							'description' => __( 'Post IDs to exclude from the result.', 'jetpack' ),
+							'items'       => array(
+								'type'    => 'integer',
+								'minimum' => 1,
+							),
+							'default'     => array(),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'  => 'array',
+					'items' => $related_post_schema,
+				),
+				'execute_callback'    => array( __CLASS__, 'get_related_posts' ),
+				'permission_callback' => array( __CLASS__, 'can_view_related_posts' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+
+			'jetpack-related-posts/get-settings'      => array(
+				'label'               => __( 'Get Related Posts settings', 'jetpack' ),
+				'description'         => __( 'Return the current Related Posts display settings as an object with enabled, show_headline, show_thumbnails, show_date, show_context, layout ("grid"|"list"), headline, and size. Read-only and idempotent. Pair with jetpack-related-posts/update-settings to change values; module activation itself is managed via jetpack-modules/set-module-status.', 'jetpack' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => $settings_schema,
+				'execute_callback'    => array( __CLASS__, 'get_settings' ),
+				'permission_callback' => array( __CLASS__, 'can_view_settings' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+
+			'jetpack-related-posts/update-settings'   => array(
+				'label'               => __( 'Update Related Posts settings', 'jetpack' ),
+				'description'         => __( 'Update one or more Related Posts display settings. Pass any subset of enabled, show_headline, show_thumbnails, show_date, show_context, layout, headline, size — omitted fields keep their current value. Idempotent: when no field differs from the current value, the call is a no-op and returns changed=false with an empty changed_fields array. Returns { settings, changed, changed_fields }. Does not toggle the related-posts module itself; use jetpack-modules/set-module-status for that.', 'jetpack' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'enabled'         => array(
+							'type'        => 'boolean',
+							'description' => __( 'Whether to display related posts after single-post content.', 'jetpack' ),
+						),
+						'show_headline'   => array(
+							'type'        => 'boolean',
+							'description' => __( 'Whether to render a headline above the related-posts list.', 'jetpack' ),
+						),
+						'show_thumbnails' => array(
+							'type'        => 'boolean',
+							'description' => __( 'Whether to render a thumbnail image for each related post.', 'jetpack' ),
+						),
+						'show_date'       => array(
+							'type'        => 'boolean',
+							'description' => __( 'Whether to render the publish date for each related post.', 'jetpack' ),
+						),
+						'show_context'    => array(
+							'type'        => 'boolean',
+							'description' => __( 'Whether to render category/tag context for each related post.', 'jetpack' ),
+						),
+						'layout'          => array(
+							'type'        => 'string',
+							'description' => __( 'Layout used to render the related-posts list.', 'jetpack' ),
+							'enum'        => array( 'grid', 'list' ),
+						),
+						'headline'        => array(
+							'type'        => 'string',
+							'description' => __( 'Headline rendered above the related-posts list when show_headline is true.', 'jetpack' ),
+							'maxLength'   => 200,
+						),
+						'size'            => array(
+							'type'        => 'integer',
+							'description' => __( 'Default number of related posts to render. Must be between 1 and 20.', 'jetpack' ),
+							'minimum'     => 1,
+							'maximum'     => self::MAX_SIZE,
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'settings'       => $settings_schema,
+						'changed'        => array( 'type' => 'boolean' ),
+						'changed_fields' => array(
+							'type'  => 'array',
+							'items' => array( 'type' => 'string' ),
+						),
+					),
+				),
+				'execute_callback'    => array( __CLASS__, 'update_settings' ),
+				'permission_callback' => array( __CLASS__, 'can_manage_settings' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+		);
+	}
+
+	/**
+	 * Permission check for the per-post related-posts read.
+	 *
+	 * Broader than the existing /wpcom/v2/related-posts/{id} endpoint, which
+	 * gates on `edit_post` for the specific post; here the ability surface is
+	 * agent-facing and uses the same `edit_posts` cap as the settings reader.
+	 */
+	public static function can_view_related_posts(): bool {
+		return current_user_can( 'edit_posts' );
+	}
+
+	/**
+	 * Permission check for reading the settings overview.
+	 */
+	public static function can_view_settings(): bool {
+		return current_user_can( 'edit_posts' );
+	}
+
+	/**
+	 * Permission check for updating the settings overview.
+	 */
+	public static function can_manage_settings(): bool {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Execute: return related posts for a given post.
+	 *
+	 * @param array|null $input Input matching the ability's input_schema.
+	 * @return array|WP_Error Array of related-post summaries, or WP_Error on validation failure.
+	 */
+	public static function get_related_posts( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		$post_id = isset( $input['post_id'] ) ? (int) $input['post_id'] : 0;
+		if ( $post_id <= 0 ) {
+			return new WP_Error(
+				'jetpack_related_posts_missing_post_id',
+				__( 'A post_id is required to fetch related posts.', 'jetpack' )
+			);
+		}
+
+		$post = get_post( $post_id );
+		if ( null === $post || empty( $post->ID ) ) {
+			return new WP_Error(
+				'jetpack_related_posts_invalid_post_id',
+				__( 'Unknown post ID. Verify the post exists and is accessible.', 'jetpack' )
+			);
+		}
+
+		$size = isset( $input['size'] ) && is_int( $input['size'] ) ? $input['size'] : self::DEFAULT_SIZE;
+		$size = max( 1, min( self::MAX_SIZE, $size ) );
+
+		$args = array( 'size' => $size );
+
+		if ( isset( $input['post_type'] ) && is_string( $input['post_type'] ) && '' !== $input['post_type'] ) {
+			$args['post_type'] = $input['post_type'];
+		}
+
+		if ( isset( $input['exclude_post_ids'] ) && is_array( $input['exclude_post_ids'] ) ) {
+			$args['exclude_post_ids'] = array_values(
+				array_filter(
+					array_map( 'intval', $input['exclude_post_ids'] ),
+					static function ( $id ) {
+						return $id > 0;
+					}
+				)
+			);
+		}
+
+		$results = self::related_posts_instance()->get_for_post_id( $post->ID, $args );
+		if ( ! is_array( $results ) ) {
+			return array();
+		}
+
+		$out = array();
+		foreach ( $results as $related ) {
+			$out[] = self::summarize_related_post( $related );
+		}
+		return $out;
+	}
+
+	/**
+	 * Execute: return the current Related Posts settings.
+	 *
+	 * @param array|null $input Unused.
+	 * @return array
+	 */
+	public static function get_settings( $input = null ) {
+		unset( $input );
+		return self::normalize_settings( Jetpack_Options::get_option( 'relatedposts', array() ) );
+	}
+
+	/**
+	 * Execute: declarative settings update. Idempotent.
+	 *
+	 * @param array|null $input Input matching the ability's input_schema.
+	 * @return array|WP_Error
+	 */
+	public static function update_settings( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+
+		$updates = array_intersect_key( $input, array_flip( self::EDITABLE_FIELDS ) );
+		if ( array() === $updates ) {
+			return new WP_Error(
+				'jetpack_related_posts_missing_field',
+				__( 'Provide at least one editable field (enabled, show_headline, show_thumbnails, show_date, show_context, layout, headline, size).', 'jetpack' )
+			);
+		}
+
+		if ( isset( $updates['layout'] )
+			&& ! ( is_string( $updates['layout'] ) && in_array( $updates['layout'], array( 'grid', 'list' ), true ) )
+		) {
+			return new WP_Error(
+				'jetpack_related_posts_invalid_layout',
+				__( 'The "layout" field must be either "grid" or "list".', 'jetpack' )
+			);
+		}
+
+		if ( isset( $updates['size'] )
+			&& ( ! is_int( $updates['size'] ) || $updates['size'] < 1 || $updates['size'] > self::MAX_SIZE )
+		) {
+			return new WP_Error(
+				'jetpack_related_posts_invalid_size',
+				sprintf(
+					/* translators: %d: maximum size value. */
+					__( 'The "size" field must be an integer between 1 and %d.', 'jetpack' ),
+					self::MAX_SIZE
+				)
+			);
+		}
+
+		if ( isset( $updates['headline'] ) && ! is_string( $updates['headline'] ) ) {
+			return new WP_Error(
+				'jetpack_related_posts_invalid_headline',
+				__( 'The "headline" field must be a string.', 'jetpack' )
+			);
+		}
+
+		foreach ( array( 'enabled', 'show_headline', 'show_thumbnails', 'show_date', 'show_context' ) as $bool_field ) {
+			if ( isset( $updates[ $bool_field ] ) ) {
+				if ( ! is_bool( $updates[ $bool_field ] ) ) {
+					return new WP_Error(
+						'jetpack_related_posts_invalid_' . $bool_field,
+						sprintf(
+							/* translators: %s: input field name. */
+							__( 'The "%s" field must be a boolean.', 'jetpack' ),
+							$bool_field
+						)
+					);
+				}
+			}
+		}
+
+		$current = self::normalize_settings( Jetpack_Options::get_option( 'relatedposts', array() ) );
+		$merged  = array_merge( $current, $updates );
+
+		$changed_fields = array();
+		foreach ( $updates as $field => $value ) {
+			if ( ! array_key_exists( $field, $current ) || $current[ $field ] !== $value ) {
+				$changed_fields[] = $field;
+			}
+		}
+
+		if ( array() === $changed_fields ) {
+			return array(
+				'settings'       => $current,
+				'changed'        => false,
+				'changed_fields' => array(),
+			);
+		}
+
+		$saved = Jetpack_Options::update_option( 'relatedposts', $merged );
+		if ( ! $saved ) {
+			return new WP_Error(
+				'jetpack_related_posts_data_unavailable',
+				__( 'Unable to save Related Posts settings. Try again or verify the site is connected to Jetpack.', 'jetpack' )
+			);
+		}
+
+		return array(
+			'settings'       => $merged,
+			'changed'        => true,
+			'changed_fields' => $changed_fields,
+		);
+	}
+
+	/**
+	 * Returns the Jetpack Related Posts raw instance, loading the class file lazily
+	 * when it has not been included by the module's own load action yet.
+	 *
+	 * @return \Jetpack_RelatedPosts
+	 */
+	private static function related_posts_instance() {
+		require_once __DIR__ . '/../jetpack-related-posts.php';
+		return Jetpack_RelatedPosts::init_raw();
+	}
+
+	/**
+	 * Reduce the rich Related Posts result to a high-signal summary.
+	 *
+	 * @param array $related Single related-post entry from get_for_post_id().
+	 * @return array
+	 */
+	private static function summarize_related_post( array $related ): array {
+		$id = isset( $related['id'] ) ? (int) $related['id'] : 0;
+
+		return array(
+			'id'        => $id,
+			'url'       => isset( $related['url'] ) ? (string) $related['url'] : '',
+			'title'     => isset( $related['title'] ) ? (string) $related['title'] : '',
+			'excerpt'   => isset( $related['excerpt'] ) ? (string) $related['excerpt'] : '',
+			'date'      => isset( $related['date'] ) ? (string) $related['date'] : '',
+			'post_type' => $id > 0 ? (string) get_post_type( $id ) : '',
+			'format'    => isset( $related['format'] ) && '' !== $related['format'] ? (string) $related['format'] : null,
+		);
+	}
+
+	/**
+	 * Coerce a raw Related Posts options array into the canonical
+	 * agent-facing shape with stable types and sensible defaults.
+	 *
+	 * Mirrors the defaulting in `Jetpack_RelatedPosts::get_options()` without
+	 * instantiating the full module class (which would attach admin/frontend
+	 * hooks) and without using `init_raw()` (whose `get_options()` is a stub
+	 * that only exposes `enabled`).
+	 *
+	 * @param array|mixed $options Raw options array (possibly from the DB).
+	 * @return array
+	 */
+	private static function normalize_settings( $options ): array {
+		$options = is_array( $options ) ? $options : array();
+
+		$layout = isset( $options['layout'] ) && in_array( $options['layout'], array( 'grid', 'list' ), true )
+			? $options['layout']
+			: 'grid';
+
+		$size = isset( $options['size'] ) && (int) $options['size'] >= 1 ? (int) $options['size'] : self::DEFAULT_SIZE;
+
+		return array(
+			'enabled'         => ! empty( $options['enabled'] ),
+			'show_headline'   => ! empty( $options['show_headline'] ),
+			'show_thumbnails' => ! empty( $options['show_thumbnails'] ),
+			'show_date'       => ! empty( $options['show_date'] ),
+			'show_context'    => ! empty( $options['show_context'] ),
+			'layout'          => $layout,
+			'headline'        => isset( $options['headline'] ) ? (string) $options['headline'] : __( 'Related', 'jetpack' ),
+			'size'            => $size,
+		);
+	}
+}

--- a/projects/plugins/jetpack/modules/related-posts/abilities/class-related-posts-abilities.php
+++ b/projects/plugins/jetpack/modules/related-posts/abilities/class-related-posts-abilities.php
@@ -109,7 +109,7 @@ class Related_Posts_Abilities extends Registrar {
 			),
 		);
 
-		return array(
+		$abilities = array(
 			'jetpack-related-posts/get-related-posts' => array(
 				'label'               => __( 'Get related posts', 'jetpack' ),
 				'description'         => __( 'Return related posts for a single post as an array of { id, url, title, excerpt, date, post_type, format }. The caller must be able to edit the source post (edit_post capability); unauthorized requests return jetpack_related_posts_forbidden. Backed by Elasticsearch via the Jetpack connection: when Related Posts is disabled, the post is unknown, or the ES backend is unreachable, the array is empty (not an error). Use per_page to control the result count (1..20, default 20); the underlying Elasticsearch query is hard-capped at 20, so values above 20 are rejected by the input schema and pagination beyond the first 20 results is not supported. The legacy "size" alias is accepted for backward compatibility and defaults to 3 when no per_page is supplied. Read-only and idempotent. Use jetpack-related-posts/get-settings to inspect the display configuration; use jetpack-modules/get-modules to confirm the related-posts module is active.', 'jetpack' ),
@@ -171,7 +171,7 @@ class Related_Posts_Abilities extends Registrar {
 
 			'jetpack-related-posts/get-settings'      => array(
 				'label'               => __( 'Get Related Posts settings', 'jetpack' ),
-				'description'         => __( 'Return the Related Posts settings relevant to the active theme. Always includes theme_type ("classic" or "block"). On classic themes, also returns enabled, show_headline, show_thumbnails, show_date, show_context, layout ("grid"|"list"), headline, and size — the values that drive auto-injection after the post content. On block themes those fields are omitted because the option is not consumed at render time; a "notice" string is returned instead, pointing toward editing the Jetpack Related Posts block in the active template (each block instance carries its own display attributes). Read-only and idempotent. Pair with jetpack-related-posts/update-settings to change values; module activation itself is managed via jetpack-modules/set-module-status.', 'jetpack' ),
+				'description'         => __( 'Return the Related Posts display settings: theme_type ("classic"), enabled, show_headline, show_thumbnails, show_date, show_context, layout ("grid"|"list"), headline, and size — the values that drive auto-injection after the post content. Only registered on classic themes; block themes ignore the underlying option (rendering is controlled per-instance by the Jetpack Related Posts block in templates), so this ability is omitted there. Read-only and idempotent. Pair with jetpack-related-posts/update-settings to change values; module activation itself is managed via jetpack-modules/set-module-status.', 'jetpack' ),
 				'input_schema'        => array(
 					'type'                 => 'object',
 					'properties'           => array(),
@@ -192,7 +192,7 @@ class Related_Posts_Abilities extends Registrar {
 
 			'jetpack-related-posts/update-settings'   => array(
 				'label'               => __( 'Update Related Posts settings', 'jetpack' ),
-				'description'         => __( 'Update one or more Related Posts display settings. Pass any subset of enabled, show_headline, show_thumbnails, show_date, show_context, layout, headline, size — omitted fields keep their current value. Only available on classic themes: block themes ignore this option at render time, so the ability returns jetpack_related_posts_block_theme_not_supported and the agent must edit the Jetpack Related Posts block in the active template via the Site Editor instead. Idempotent: when no field differs from the current value, the call is a no-op and returns changed=false with an empty changed_fields array. Returns { settings, changed, changed_fields }. Does not toggle the related-posts module itself; use jetpack-modules/set-module-status for that.', 'jetpack' ),
+				'description'         => __( 'Update one or more Related Posts display settings. Pass any subset of enabled, show_headline, show_thumbnails, show_date, show_context, layout, headline, size — omitted fields keep their current value. Only registered on classic themes; on block themes the ability is omitted entirely because the option is not consumed at render time — agents must edit the Jetpack Related Posts block inside the active template via the Site Editor instead. Idempotent: when no field differs from the current value, the call is a no-op and returns changed=false with an empty changed_fields array. Returns { settings, changed, changed_fields }. Does not toggle the related-posts module itself; use jetpack-modules/set-module-status for that.', 'jetpack' ),
 				'input_schema'        => array(
 					'type'                 => 'object',
 					'properties'           => array(
@@ -258,6 +258,21 @@ class Related_Posts_Abilities extends Registrar {
 				),
 			),
 		);
+
+		// Block themes render Related Posts through the jetpack/related-posts
+		// block placed in templates, so the `relatedposts` option is not consumed
+		// at render time. Exposing settings abilities there would let agents
+		// write data nothing reads — drop them from the registered surface
+		// entirely. The lookup ability (get-related-posts) is unaffected; it
+		// still works regardless of theme type.
+		if ( self::is_block_theme() ) {
+			unset(
+				$abilities['jetpack-related-posts/get-settings'],
+				$abilities['jetpack-related-posts/update-settings']
+			);
+		}
+
+		return $abilities;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/related-posts/abilities/class-related-posts-abilities.php
+++ b/projects/plugins/jetpack/modules/related-posts/abilities/class-related-posts-abilities.php
@@ -11,6 +11,7 @@
 
 namespace Automattic\Jetpack\Plugin\Abilities;
 
+use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\WP_Abilities\Registrar;
 use Jetpack_Options;
 use Jetpack_RelatedPosts;
@@ -83,7 +84,17 @@ class Related_Posts_Abilities extends Registrar {
 
 		$settings_schema = array(
 			'type'       => 'object',
+			'required'   => array( 'theme_type' ),
 			'properties' => array(
+				'theme_type'      => array(
+					'type'        => 'string',
+					'enum'        => array( 'classic', 'block' ),
+					'description' => __( 'Active theme rendering model. "classic" themes consume these display settings via auto-injection after the post content; "block" themes ignore them — the Jetpack Related Posts block placed in the active template carries its own per-instance attributes.', 'jetpack' ),
+				),
+				'notice'          => array(
+					'type'        => 'string',
+					'description' => __( 'Present only when theme_type is "block". Human-readable pointer toward editing the Related Posts block in the Site Editor, since this option is not consumed at render time on block themes.', 'jetpack' ),
+				),
 				'enabled'         => array( 'type' => 'boolean' ),
 				'show_headline'   => array( 'type' => 'boolean' ),
 				'show_thumbnails' => array( 'type' => 'boolean' ),
@@ -160,7 +171,7 @@ class Related_Posts_Abilities extends Registrar {
 
 			'jetpack-related-posts/get-settings'      => array(
 				'label'               => __( 'Get Related Posts settings', 'jetpack' ),
-				'description'         => __( 'Return the current Related Posts display settings as an object with enabled, show_headline, show_thumbnails, show_date, show_context, layout ("grid"|"list"), headline, and size. Read-only and idempotent. Pair with jetpack-related-posts/update-settings to change values; module activation itself is managed via jetpack-modules/set-module-status.', 'jetpack' ),
+				'description'         => __( 'Return the Related Posts settings relevant to the active theme. Always includes theme_type ("classic" or "block"). On classic themes, also returns enabled, show_headline, show_thumbnails, show_date, show_context, layout ("grid"|"list"), headline, and size — the values that drive auto-injection after the post content. On block themes those fields are omitted because the option is not consumed at render time; a "notice" string is returned instead, pointing toward editing the Jetpack Related Posts block in the active template (each block instance carries its own display attributes). Read-only and idempotent. Pair with jetpack-related-posts/update-settings to change values; module activation itself is managed via jetpack-modules/set-module-status.', 'jetpack' ),
 				'input_schema'        => array(
 					'type'                 => 'object',
 					'properties'           => array(),
@@ -181,7 +192,7 @@ class Related_Posts_Abilities extends Registrar {
 
 			'jetpack-related-posts/update-settings'   => array(
 				'label'               => __( 'Update Related Posts settings', 'jetpack' ),
-				'description'         => __( 'Update one or more Related Posts display settings. Pass any subset of enabled, show_headline, show_thumbnails, show_date, show_context, layout, headline, size — omitted fields keep their current value. Idempotent: when no field differs from the current value, the call is a no-op and returns changed=false with an empty changed_fields array. Returns { settings, changed, changed_fields }. Does not toggle the related-posts module itself; use jetpack-modules/set-module-status for that.', 'jetpack' ),
+				'description'         => __( 'Update one or more Related Posts display settings. Pass any subset of enabled, show_headline, show_thumbnails, show_date, show_context, layout, headline, size — omitted fields keep their current value. Only available on classic themes: block themes ignore this option at render time, so the ability returns jetpack_related_posts_block_theme_not_supported and the agent must edit the Jetpack Related Posts block in the active template via the Site Editor instead. Idempotent: when no field differs from the current value, the call is a no-op and returns changed=false with an empty changed_fields array. Returns { settings, changed, changed_fields }. Does not toggle the related-posts module itself; use jetpack-modules/set-module-status for that.', 'jetpack' ),
 				'input_schema'        => array(
 					'type'                 => 'object',
 					'properties'           => array(
@@ -358,12 +369,27 @@ class Related_Posts_Abilities extends Registrar {
 	/**
 	 * Execute: return the current Related Posts settings.
 	 *
+	 * On classic themes the full display-settings shape is returned. On block
+	 * themes the option is not consumed at render time, so we return only the
+	 * theme_type and a notice pointing the caller at the block — listing the
+	 * other fields would imply they have an effect they do not.
+	 *
 	 * @param array|null $input Unused.
 	 * @return array
 	 */
 	public static function get_settings( $input = null ) {
 		unset( $input );
-		return self::normalize_settings( Jetpack_Options::get_option( self::OPTION_KEY, array() ) );
+
+		if ( self::is_block_theme() ) {
+			return array(
+				'theme_type' => 'block',
+				'notice'     => __( 'Related Posts on block themes is rendered via the Jetpack Related Posts block placed in the active template or template part. Display settings live on each block instance, so this option is not consumed at render time — open the Site Editor and edit the block directly to change appearance or visibility.', 'jetpack' ),
+			);
+		}
+
+		$settings               = self::normalize_settings( Jetpack_Options::get_option( self::OPTION_KEY, array() ) );
+		$settings['theme_type'] = 'classic';
+		return $settings;
 	}
 
 	/**
@@ -373,6 +399,14 @@ class Related_Posts_Abilities extends Registrar {
 	 * @return array|WP_Error
 	 */
 	public static function update_settings( $input = null ) {
+		if ( self::is_block_theme() ) {
+			return new WP_Error(
+				'jetpack_related_posts_block_theme_not_supported',
+				__( 'Related Posts display settings are not editable on block themes — this option is not consumed at render time. Open the Site Editor and edit the Jetpack Related Posts block inside the active template or template part; each block instance carries its own display attributes.', 'jetpack' ),
+				array( 'status' => 409 )
+			);
+		}
+
 		$input = is_array( $input ) ? $input : array();
 
 		$updates = array_intersect_key( $input, array_flip( self::EDITABLE_FIELDS ) );
@@ -439,7 +473,7 @@ class Related_Posts_Abilities extends Registrar {
 
 		if ( array() === $changed_fields ) {
 			return array(
-				'settings'       => $current,
+				'settings'       => array_merge( $current, array( 'theme_type' => 'classic' ) ),
 				'changed'        => false,
 				'changed_fields' => array(),
 			);
@@ -454,10 +488,25 @@ class Related_Posts_Abilities extends Registrar {
 		}
 
 		return array(
-			'settings'       => $merged,
+			'settings'       => array_merge( $merged, array( 'theme_type' => 'classic' ) ),
 			'changed'        => true,
 			'changed_fields' => $changed_fields,
 		);
+	}
+
+	/**
+	 * Whether the active theme is a block (FSE) theme for Related Posts purposes.
+	 *
+	 * Delegates to `Blocks::is_fse_theme()` so the ability's branching tracks the
+	 * exact same signal the module itself uses to skip auto-injection (see
+	 * `filter_add_target_to_dom()` in jetpack-related-posts.php). Going through
+	 * Jetpack's `jetpack_is_fse_theme` filter also lets tests flip the branch
+	 * without swapping the active theme on disk.
+	 *
+	 * @return bool
+	 */
+	private static function is_block_theme(): bool {
+		return Blocks::is_fse_theme();
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/related-posts/abilities/class-related-posts-abilities.php
+++ b/projects/plugins/jetpack/modules/related-posts/abilities/class-related-posts-abilities.php
@@ -101,7 +101,7 @@ class Related_Posts_Abilities extends Registrar {
 		return array(
 			'jetpack-related-posts/get-related-posts' => array(
 				'label'               => __( 'Get related posts', 'jetpack' ),
-				'description'         => __( 'Return related posts for a single post as an array of { id, url, title, excerpt, date, post_type, format }. Backed by Elasticsearch via the Jetpack connection: when Related Posts is disabled, the post is unknown, or the ES backend is unreachable, the array is empty (not an error). Read-only and idempotent. Use jetpack-related-posts/get-settings to inspect the display configuration; use jetpack-modules/get-modules to confirm the related-posts module is active.', 'jetpack' ),
+				'description'         => __( 'Return related posts for a single post as an array of { id, url, title, excerpt, date, post_type, format }. The caller must be able to edit the source post (edit_post capability); unauthorized requests return jetpack_related_posts_forbidden. Backed by Elasticsearch via the Jetpack connection: when Related Posts is disabled, the post is unknown, or the ES backend is unreachable, the array is empty (not an error). Read-only and idempotent. Use jetpack-related-posts/get-settings to inspect the display configuration; use jetpack-modules/get-modules to confirm the related-posts module is active.', 'jetpack' ),
 				'input_schema'        => array(
 					'type'                 => 'object',
 					'required'             => array( 'post_id' ),
@@ -243,11 +243,12 @@ class Related_Posts_Abilities extends Registrar {
 	}
 
 	/**
-	 * Permission check for the per-post related-posts read.
+	 * Permission gate for the ability menu.
 	 *
-	 * Broader than the existing /wpcom/v2/related-posts/{id} endpoint, which
-	 * gates on `edit_post` for the specific post; here the ability surface is
-	 * agent-facing and uses the same `edit_posts` cap as the settings reader.
+	 * Returns true if the caller can edit any post — keeps the ability listed
+	 * for agents that have at least one editable post. The actual per-post
+	 * authorization runs inside `get_related_posts()` once the source post_id
+	 * is known, mirroring the existing /wpcom/v2/related-posts/{id} endpoint.
 	 */
 	public static function can_view_related_posts(): bool {
 		return current_user_can( 'edit_posts' );
@@ -289,6 +290,17 @@ class Related_Posts_Abilities extends Registrar {
 			return new WP_Error(
 				'jetpack_related_posts_invalid_post_id',
 				__( 'Unknown post ID. Verify the post exists and is accessible.', 'jetpack' )
+			);
+		}
+
+		// Match the per-post gate the existing /wpcom/v2/related-posts/{id}
+		// endpoint uses: the broad `edit_posts` cap on permission_callback lets
+		// the ability appear in the agent menu, but the actual lookup is
+		// authorized only when the caller can edit this specific post.
+		if ( ! current_user_can( 'edit_post', $post->ID ) ) {
+			return new WP_Error(
+				'jetpack_related_posts_forbidden',
+				__( 'You are not allowed to fetch related posts for this post.', 'jetpack' )
 			);
 		}
 

--- a/projects/plugins/jetpack/modules/related-posts/abilities/class-related-posts-abilities.php
+++ b/projects/plugins/jetpack/modules/related-posts/abilities/class-related-posts-abilities.php
@@ -101,7 +101,7 @@ class Related_Posts_Abilities extends Registrar {
 		return array(
 			'jetpack-related-posts/get-related-posts' => array(
 				'label'               => __( 'Get related posts', 'jetpack' ),
-				'description'         => __( 'Return related posts for a single post as an array of { id, url, title, excerpt, date, post_type, format }. The caller must be able to edit the source post (edit_post capability); unauthorized requests return jetpack_related_posts_forbidden. Backed by Elasticsearch via the Jetpack connection: when Related Posts is disabled, the post is unknown, or the ES backend is unreachable, the array is empty (not an error). Read-only and idempotent. Use jetpack-related-posts/get-settings to inspect the display configuration; use jetpack-modules/get-modules to confirm the related-posts module is active.', 'jetpack' ),
+				'description'         => __( 'Return related posts for a single post as an array of { id, url, title, excerpt, date, post_type, format }. The caller must be able to edit the source post (edit_post capability); unauthorized requests return jetpack_related_posts_forbidden. Backed by Elasticsearch via the Jetpack connection: when Related Posts is disabled, the post is unknown, or the ES backend is unreachable, the array is empty (not an error). Use per_page to control the result count (1..20, default 20); the underlying Elasticsearch query is hard-capped at 20, so values above 20 are rejected by the input schema and pagination beyond the first 20 results is not supported. The legacy "size" alias is accepted for backward compatibility and defaults to 3 when no per_page is supplied. Read-only and idempotent. Use jetpack-related-posts/get-settings to inspect the display configuration; use jetpack-modules/get-modules to confirm the related-posts module is active.', 'jetpack' ),
 				'input_schema'        => array(
 					'type'                 => 'object',
 					'required'             => array( 'post_id' ),
@@ -111,9 +111,16 @@ class Related_Posts_Abilities extends Registrar {
 							'description' => __( 'WordPress post ID to find related posts for. Must reference an existing post.', 'jetpack' ),
 							'minimum'     => 1,
 						),
+						'per_page'         => array(
+							'type'        => 'integer',
+							'description' => __( 'Maximum number of related posts to return per call. Must be between 1 and 20 — the Elasticsearch backend hard-caps results at 20, so larger values are not supported and pagination past the first 20 results is unavailable. Defaults to 20.', 'jetpack' ),
+							'minimum'     => 1,
+							'maximum'     => self::MAX_SIZE,
+							'default'     => self::MAX_SIZE,
+						),
 						'size'             => array(
 							'type'        => 'integer',
-							'description' => __( 'Maximum number of related posts to return. Defaults to 3, capped at 20.', 'jetpack' ),
+							'description' => __( 'Deprecated alias for per_page. Defaults to 3 when per_page is omitted. Capped at 20.', 'jetpack' ),
 							'minimum'     => 1,
 							'maximum'     => self::MAX_SIZE,
 							'default'     => self::DEFAULT_SIZE,
@@ -304,8 +311,16 @@ class Related_Posts_Abilities extends Registrar {
 			);
 		}
 
-		$size = isset( $input['size'] ) && is_int( $input['size'] ) ? $input['size'] : self::DEFAULT_SIZE;
-		$size = max( 1, min( self::MAX_SIZE, $size ) );
+		if ( isset( $input['per_page'] ) && is_int( $input['per_page'] ) ) {
+			// per_page wins when both are supplied; schema enforces the 1..MAX_SIZE
+			// range, the clamp here is defense in depth for direct callers that
+			// bypass schema validation.
+			$size = max( 1, min( self::MAX_SIZE, $input['per_page'] ) );
+		} elseif ( isset( $input['size'] ) && is_int( $input['size'] ) ) {
+			$size = max( 1, min( self::MAX_SIZE, $input['size'] ) );
+		} else {
+			$size = self::DEFAULT_SIZE;
+		}
 
 		$args = array( 'size' => $size );
 

--- a/projects/plugins/jetpack/modules/related-posts/abilities/class-related-posts-abilities.php
+++ b/projects/plugins/jetpack/modules/related-posts/abilities/class-related-posts-abilities.php
@@ -25,19 +25,16 @@ use WP_Error;
  */
 class Related_Posts_Abilities extends Registrar {
 
-	/**
-	 * Maximum number of related posts returned in a single call.
-	 */
+	// Mirrors the cap the upstream Related Posts ES query enforces; raising it
+	// here would be silently truncated downstream.
 	private const MAX_SIZE = 20;
 
-	/**
-	 * Default number of related posts when the caller does not specify a size.
-	 */
 	private const DEFAULT_SIZE = 3;
 
-	/**
-	 * Editable display-settings fields.
-	 */
+	private const OPTION_KEY = 'relatedposts';
+
+	private const LAYOUTS = array( 'grid', 'list' );
+
 	private const EDITABLE_FIELDS = array(
 		'enabled',
 		'show_headline',
@@ -94,7 +91,7 @@ class Related_Posts_Abilities extends Registrar {
 				'show_context'    => array( 'type' => 'boolean' ),
 				'layout'          => array(
 					'type' => 'string',
-					'enum' => array( 'grid', 'list' ),
+					'enum' => self::LAYOUTS,
 				),
 				'headline'        => array( 'type' => 'string' ),
 				'size'            => array( 'type' => 'integer' ),
@@ -204,7 +201,7 @@ class Related_Posts_Abilities extends Registrar {
 						'layout'          => array(
 							'type'        => 'string',
 							'description' => __( 'Layout used to render the related-posts list.', 'jetpack' ),
-							'enum'        => array( 'grid', 'list' ),
+							'enum'        => self::LAYOUTS,
 						),
 						'headline'        => array(
 							'type'        => 'string',
@@ -316,9 +313,13 @@ class Related_Posts_Abilities extends Registrar {
 		}
 
 		$results = self::related_posts_instance()->get_for_post_id( $post->ID, $args );
-		if ( ! is_array( $results ) ) {
+		if ( ! is_array( $results ) || array() === $results ) {
 			return array();
 		}
+
+		// Prime the post cache once so `get_post_type()` inside summarize_related_post
+		// doesn't trigger N individual lookups when the cache is cold.
+		_prime_post_caches( wp_list_pluck( $results, 'id' ), false, false );
 
 		$out = array();
 		foreach ( $results as $related ) {
@@ -335,7 +336,7 @@ class Related_Posts_Abilities extends Registrar {
 	 */
 	public static function get_settings( $input = null ) {
 		unset( $input );
-		return self::normalize_settings( Jetpack_Options::get_option( 'relatedposts', array() ) );
+		return self::normalize_settings( Jetpack_Options::get_option( self::OPTION_KEY, array() ) );
 	}
 
 	/**
@@ -356,7 +357,7 @@ class Related_Posts_Abilities extends Registrar {
 		}
 
 		if ( isset( $updates['layout'] )
-			&& ! ( is_string( $updates['layout'] ) && in_array( $updates['layout'], array( 'grid', 'list' ), true ) )
+			&& ! ( is_string( $updates['layout'] ) && in_array( $updates['layout'], self::LAYOUTS, true ) )
 		) {
 			return new WP_Error(
 				'jetpack_related_posts_invalid_layout',
@@ -399,7 +400,7 @@ class Related_Posts_Abilities extends Registrar {
 			}
 		}
 
-		$current = self::normalize_settings( Jetpack_Options::get_option( 'relatedposts', array() ) );
+		$current = self::normalize_settings( Jetpack_Options::get_option( self::OPTION_KEY, array() ) );
 		$merged  = array_merge( $current, $updates );
 
 		$changed_fields = array();
@@ -417,7 +418,7 @@ class Related_Posts_Abilities extends Registrar {
 			);
 		}
 
-		$saved = Jetpack_Options::update_option( 'relatedposts', $merged );
+		$saved = Jetpack_Options::update_option( self::OPTION_KEY, $merged );
 		if ( ! $saved ) {
 			return new WP_Error(
 				'jetpack_related_posts_data_unavailable',
@@ -439,7 +440,9 @@ class Related_Posts_Abilities extends Registrar {
 	 * @return \Jetpack_RelatedPosts
 	 */
 	private static function related_posts_instance() {
-		require_once __DIR__ . '/../jetpack-related-posts.php';
+		if ( ! class_exists( Jetpack_RelatedPosts::class, false ) ) {
+			require_once __DIR__ . '/../jetpack-related-posts.php';
+		}
 		return Jetpack_RelatedPosts::init_raw();
 	}
 
@@ -478,7 +481,7 @@ class Related_Posts_Abilities extends Registrar {
 	private static function normalize_settings( $options ): array {
 		$options = is_array( $options ) ? $options : array();
 
-		$layout = isset( $options['layout'] ) && in_array( $options['layout'], array( 'grid', 'list' ), true )
+		$layout = isset( $options['layout'] ) && in_array( $options['layout'], self::LAYOUTS, true )
 			? $options['layout']
 			: 'grid';
 

--- a/projects/plugins/jetpack/modules/related-posts/abilities/class-related-posts-abilities.php
+++ b/projects/plugins/jetpack/modules/related-posts/abilities/class-related-posts-abilities.php
@@ -125,6 +125,10 @@ class Related_Posts_Abilities extends Registrar {
 						'idempotent'  => true,
 					),
 					'show_in_rest' => true,
+					'mcp'          => array(
+						'public' => true,
+						'type'   => 'tool', // default is already "tool", but can be explicit.
+					),
 				),
 			),
 		);

--- a/projects/plugins/jetpack/tests/php/src/Related_Posts_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Related_Posts_Abilities_Test.php
@@ -357,6 +357,114 @@ class Related_Posts_Abilities_Test extends WP_UnitTestCase {
 		$this->assertSame( 'standard', $summary['format'] );
 	}
 
+	/**
+	 * Capture the size arg the Related Posts backend receives, regardless of
+	 * whether the ES backend returns anything. This exercises the clamp the
+	 * execute callback applies before delegating to get_for_post_id().
+	 *
+	 * @param array $input Ability input.
+	 * @return int|null Captured size, or null if the args filter did not fire.
+	 */
+	private function capture_size_arg( array $input ): ?int {
+		$captured = null;
+		$capture  = static function ( $args ) use ( &$captured ) {
+			$captured = isset( $args['size'] ) ? (int) $args['size'] : null;
+			return $args;
+		};
+		add_filter( 'jetpack_relatedposts_filter_args', $capture );
+		try {
+			Related_Posts_Abilities::get_related_posts( $input );
+		} finally {
+			remove_filter( 'jetpack_relatedposts_filter_args', $capture );
+		}
+		return $captured;
+	}
+
+	public function test_get_related_posts_respects_per_page_below_cap() {
+		wp_set_current_user( self::$admin_id );
+		$source_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		$captured = $this->capture_size_arg(
+			array(
+				'post_id'  => $source_id,
+				'per_page' => 5,
+			)
+		);
+
+		$this->assertSame( 5, $captured, 'per_page=5 must propagate to size=5 in the backend args.' );
+	}
+
+	public function test_get_related_posts_respects_per_page_at_cap() {
+		wp_set_current_user( self::$admin_id );
+		$source_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		$captured = $this->capture_size_arg(
+			array(
+				'post_id'  => $source_id,
+				'per_page' => 20,
+			)
+		);
+
+		$this->assertSame( 20, $captured, 'per_page=20 must propagate to size=20 in the backend args.' );
+	}
+
+	public function test_get_related_posts_schema_rejects_per_page_above_cap() {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API not available.' );
+		}
+
+		$this->trigger_registration();
+		wp_set_current_user( self::$admin_id );
+		$source_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		$ability = wp_get_ability( 'jetpack-related-posts/get-related-posts' );
+		$this->assertNotNull( $ability );
+
+		$result = $ability->execute(
+			array(
+				'post_id'  => $source_id,
+				'per_page' => 21,
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result, 'per_page=21 must be rejected by schema validation.' );
+		$this->assertSame( 'ability_invalid_input', $result->get_error_code() );
+	}
+
+	public function test_get_related_posts_schema_rejects_per_page_zero() {
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			$this->markTestSkipped( 'Abilities API not available.' );
+		}
+
+		$this->trigger_registration();
+		wp_set_current_user( self::$admin_id );
+		$source_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		$ability = wp_get_ability( 'jetpack-related-posts/get-related-posts' );
+		$this->assertNotNull( $ability );
+
+		$result = $ability->execute(
+			array(
+				'post_id'  => $source_id,
+				'per_page' => 0,
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result, 'per_page=0 must be rejected by schema validation.' );
+		$this->assertSame( 'ability_invalid_input', $result->get_error_code() );
+	}
+
+	public function test_get_related_posts_defaults_when_per_page_omitted() {
+		wp_set_current_user( self::$admin_id );
+		$source_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		// When neither per_page nor size is supplied to the execute callback
+		// directly, the existing default (3) wins so prior callers see no change.
+		$captured = $this->capture_size_arg( array( 'post_id' => $source_id ) );
+
+		$this->assertSame( 3, $captured, 'Omitted per_page must fall back to the legacy default of 3 so pre-existing callers see identical behavior.' );
+	}
+
 	public function test_get_related_posts_summary_format_is_null_when_missing() {
 		wp_set_current_user( self::$admin_id );
 		$source_id  = self::factory()->post->create( array( 'post_status' => 'publish' ) );

--- a/projects/plugins/jetpack/tests/php/src/Related_Posts_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Related_Posts_Abilities_Test.php
@@ -44,11 +44,15 @@ class Related_Posts_Abilities_Test extends WP_UnitTestCase {
 
 		$this->reset_registry_state();
 		add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		// Default every test to a classic theme so theme-type branches stay
+		// deterministic regardless of which theme the WP test bootstrap chose.
+		$this->force_classic_theme();
 	}
 
 	public function tear_down() {
 		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
 		remove_all_filters( 'jetpack_wp_abilities_should_register' );
+		remove_all_filters( 'jetpack_is_fse_theme' );
 		$this->reset_registry_state();
 		wp_set_current_user( 0 );
 
@@ -59,6 +63,25 @@ class Related_Posts_Abilities_Test extends WP_UnitTestCase {
 		}
 
 		parent::tear_down();
+	}
+
+	/**
+	 * Pin the ability's theme-type check to "classic" by intercepting the same
+	 * filter the related-posts module itself consults. Avoids depending on the
+	 * test runner's active theme.
+	 */
+	private function force_classic_theme(): void {
+		remove_all_filters( 'jetpack_is_fse_theme' );
+		add_filter( 'jetpack_is_fse_theme', '__return_false' );
+	}
+
+	/**
+	 * Pin the ability's theme-type check to "block" without swapping the active
+	 * theme on disk.
+	 */
+	private function force_block_theme(): void {
+		remove_all_filters( 'jetpack_is_fse_theme' );
+		add_filter( 'jetpack_is_fse_theme', '__return_true' );
 	}
 
 	/**
@@ -264,6 +287,7 @@ class Related_Posts_Abilities_Test extends WP_UnitTestCase {
 	public function test_get_settings_returns_normalized_shape() {
 		$settings = Related_Posts_Abilities::get_settings();
 		$this->assertIsArray( $settings );
+		$this->assertSame( 'classic', $settings['theme_type'], 'Classic theme path must announce theme_type=classic.' );
 		foreach ( array( 'enabled', 'show_headline', 'show_thumbnails', 'show_date', 'show_context', 'layout', 'headline', 'size' ) as $field ) {
 			$this->assertArrayHasKey( $field, $settings, "Settings shape must include {$field}." );
 		}
@@ -271,6 +295,58 @@ class Related_Posts_Abilities_Test extends WP_UnitTestCase {
 		$this->assertIsBool( $settings['enabled'] );
 		$this->assertIsInt( $settings['size'] );
 		$this->assertGreaterThanOrEqual( 1, $settings['size'] );
+	}
+
+	public function test_get_settings_on_block_theme_omits_display_fields() {
+		$this->force_block_theme();
+
+		$settings = Related_Posts_Abilities::get_settings();
+
+		$this->assertSame( 'block', $settings['theme_type'], 'Block theme path must announce theme_type=block.' );
+		$this->assertArrayHasKey( 'notice', $settings, 'Block-theme response must carry a notice pointing at the block.' );
+		$this->assertIsString( $settings['notice'] );
+		$this->assertNotSame( '', $settings['notice'] );
+
+		// The display fields are render-time no-ops on block themes; the response
+		// must omit them so agents don't think writing to them will change anything.
+		foreach ( array( 'enabled', 'show_headline', 'show_thumbnails', 'show_date', 'show_context', 'layout', 'headline', 'size' ) as $field ) {
+			$this->assertArrayNotHasKey(
+				$field,
+				$settings,
+				"Block-theme get-settings response must omit {$field} — the option is not consumed at render time."
+			);
+		}
+	}
+
+	public function test_update_settings_on_block_theme_is_rejected() {
+		$this->force_block_theme();
+		$this->seed_default_settings();
+		$before = Jetpack_Options::get_option( 'relatedposts' );
+
+		$result = Related_Posts_Abilities::update_settings( array( 'show_thumbnails' => true ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'jetpack_related_posts_block_theme_not_supported', $result->get_error_code() );
+
+		// The stored option must not have been touched — block-theme rejection
+		// runs before any merge or save.
+		$this->assertSame( $before, Jetpack_Options::get_option( 'relatedposts' ) );
+	}
+
+	public function test_update_settings_response_advertises_theme_type() {
+		$this->seed_default_settings();
+
+		$result = Related_Posts_Abilities::update_settings( array( 'show_thumbnails' => true ) );
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['changed'] );
+		$this->assertSame( 'classic', $result['settings']['theme_type'] );
+
+		// theme_type is a derived field — it must not be persisted to the
+		// `relatedposts` option, only added to the response.
+		$stored = Jetpack_Options::get_option( 'relatedposts' );
+		$this->assertIsArray( $stored );
+		$this->assertArrayNotHasKey( 'theme_type', $stored );
 	}
 
 	public function test_get_related_posts_rejects_missing_post_id() {

--- a/projects/plugins/jetpack/tests/php/src/Related_Posts_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Related_Posts_Abilities_Test.php
@@ -91,16 +91,6 @@ class Related_Posts_Abilities_Test extends WP_UnitTestCase {
 		}
 	}
 
-	public function test_abilities_map_only_exposes_the_lookup_ability() {
-		$slugs = array_keys( Related_Posts_Abilities::get_abilities() );
-
-		$this->assertSame(
-			array( 'jetpack-related-posts/get-related-posts' ),
-			$slugs,
-			'The settings abilities were intentionally removed — only the lookup ability should remain.'
-		);
-	}
-
 	public function test_no_spec_sets_category_explicitly() {
 		foreach ( Related_Posts_Abilities::get_abilities() as $slug => $spec ) {
 			$this->assertArrayNotHasKey(

--- a/projects/plugins/jetpack/tests/php/src/Related_Posts_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Related_Posts_Abilities_Test.php
@@ -292,10 +292,119 @@ class Related_Posts_Abilities_Test extends WP_UnitTestCase {
 	}
 
 	public function test_get_related_posts_returns_array_for_real_post() {
+		wp_set_current_user( self::$admin_id );
 		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
 		$result  = Related_Posts_Abilities::get_related_posts( array( 'post_id' => $post_id ) );
 		// Real ES backend is unavailable in test env; an empty array is the expected shape.
 		$this->assertIsArray( $result );
+	}
+
+	public function test_get_related_posts_denies_user_who_cannot_edit_post() {
+		$author_post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'draft',
+				'post_author' => self::$author_id,
+			)
+		);
+
+		// Subscriber cannot edit any post.
+		wp_set_current_user( self::$subscriber_id );
+		$result = Related_Posts_Abilities::get_related_posts( array( 'post_id' => $author_post_id ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'jetpack_related_posts_forbidden', $result->get_error_code() );
+	}
+
+	public function test_get_related_posts_summarizes_filtered_results() {
+		wp_set_current_user( self::$admin_id );
+		$source_id  = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$related_id = self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+				'post_title'  => 'Synthetic Related',
+			)
+		);
+
+		$callback = static function () use ( $related_id ) {
+			return array(
+				array(
+					'id'      => $related_id,
+					'url'     => 'https://example.test/synthetic',
+					'title'   => 'Synthetic Related',
+					'excerpt' => 'A synthetic excerpt.',
+					'date'    => '2026-01-01',
+					'format'  => 'standard',
+				),
+			);
+		};
+		add_filter( 'jetpack_relatedposts_returned_results', $callback );
+
+		try {
+			$result = Related_Posts_Abilities::get_related_posts( array( 'post_id' => $source_id ) );
+		} finally {
+			remove_filter( 'jetpack_relatedposts_returned_results', $callback );
+		}
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result );
+		$summary = $result[0];
+		$this->assertSame( $related_id, $summary['id'] );
+		$this->assertSame( 'https://example.test/synthetic', $summary['url'] );
+		$this->assertSame( 'Synthetic Related', $summary['title'] );
+		$this->assertSame( 'A synthetic excerpt.', $summary['excerpt'] );
+		$this->assertSame( '2026-01-01', $summary['date'] );
+		$this->assertSame( 'post', $summary['post_type'] );
+		$this->assertSame( 'standard', $summary['format'] );
+	}
+
+	public function test_get_related_posts_summary_format_is_null_when_missing() {
+		wp_set_current_user( self::$admin_id );
+		$source_id  = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$related_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		$callback = static function () use ( $related_id ) {
+			return array(
+				array(
+					'id'    => $related_id,
+					'url'   => 'https://example.test/no-format',
+					'title' => 'No Format',
+				),
+			);
+		};
+		add_filter( 'jetpack_relatedposts_returned_results', $callback );
+
+		try {
+			$result = Related_Posts_Abilities::get_related_posts( array( 'post_id' => $source_id ) );
+		} finally {
+			remove_filter( 'jetpack_relatedposts_returned_results', $callback );
+		}
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result );
+		$this->assertNull( $result[0]['format'] );
+		$this->assertSame( '', $result[0]['excerpt'] );
+		$this->assertSame( '', $result[0]['date'] );
+	}
+
+	public function test_get_settings_fills_defaults_from_partial_db_row() {
+		Jetpack_Options::update_option(
+			'relatedposts',
+			array(
+				'enabled' => true,
+				'size'    => 7,
+			)
+		);
+
+		$settings = Related_Posts_Abilities::get_settings();
+
+		$this->assertTrue( $settings['enabled'] );
+		$this->assertSame( 7, $settings['size'] );
+		$this->assertSame( 'grid', $settings['layout'], 'Missing layout key must default to grid.' );
+		$this->assertFalse( $settings['show_thumbnails'], 'Missing booleans must default to false.' );
+		$this->assertFalse( $settings['show_headline'] );
+		$this->assertFalse( $settings['show_date'] );
+		$this->assertFalse( $settings['show_context'] );
+		$this->assertSame( 'Related', $settings['headline'], 'Missing headline must fall back to "Related".' );
 	}
 
 	public function test_update_settings_rejects_no_fields() {

--- a/projects/plugins/jetpack/tests/php/src/Related_Posts_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Related_Posts_Abilities_Test.php
@@ -28,9 +28,6 @@ class Related_Posts_Abilities_Test extends WP_UnitTestCase {
 	/** @var int */
 	private static $subscriber_id;
 
-	/** @var array|null */
-	private $saved_relatedposts_option;
-
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		self::$admin_id      = $factory->user->create( array( 'role' => 'administrator' ) );
 		self::$author_id     = $factory->user->create( array( 'role' => 'author' ) );
@@ -40,48 +37,17 @@ class Related_Posts_Abilities_Test extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$this->saved_relatedposts_option = Jetpack_Options::get_option( 'relatedposts', null );
-
 		$this->reset_registry_state();
 		add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
-		// Default every test to a classic theme so theme-type branches stay
-		// deterministic regardless of which theme the WP test bootstrap chose.
-		$this->force_classic_theme();
 	}
 
 	public function tear_down() {
 		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
 		remove_all_filters( 'jetpack_wp_abilities_should_register' );
-		remove_all_filters( 'jetpack_is_fse_theme' );
 		$this->reset_registry_state();
 		wp_set_current_user( 0 );
 
-		if ( null === $this->saved_relatedposts_option ) {
-			Jetpack_Options::delete_option( 'relatedposts' );
-		} else {
-			Jetpack_Options::update_option( 'relatedposts', $this->saved_relatedposts_option );
-		}
-
 		parent::tear_down();
-	}
-
-	/**
-	 * Pin the ability's theme-type check to "classic" by intercepting the same
-	 * filter the related-posts module itself consults. Avoids depending on the
-	 * test runner's active theme.
-	 */
-	private function force_classic_theme(): void {
-		remove_all_filters( 'jetpack_is_fse_theme' );
-		add_filter( 'jetpack_is_fse_theme', '__return_false' );
-	}
-
-	/**
-	 * Pin the ability's theme-type check to "block" without swapping the active
-	 * theme on disk.
-	 */
-	private function force_block_theme(): void {
-		remove_all_filters( 'jetpack_is_fse_theme' );
-		add_filter( 'jetpack_is_fse_theme', '__return_true' );
 	}
 
 	/**
@@ -123,6 +89,16 @@ class Related_Posts_Abilities_Test extends WP_UnitTestCase {
 		foreach ( array_keys( $abilities ) as $slug ) {
 			$this->assertStringStartsWith( 'jetpack-related-posts/', $slug );
 		}
+	}
+
+	public function test_abilities_map_only_exposes_the_lookup_ability() {
+		$slugs = array_keys( Related_Posts_Abilities::get_abilities() );
+
+		$this->assertSame(
+			array( 'jetpack-related-posts/get-related-posts' ),
+			$slugs,
+			'The settings abilities were intentionally removed — only the lookup ability should remain.'
+		);
 	}
 
 	public function test_no_spec_sets_category_explicitly() {
@@ -187,8 +163,16 @@ class Related_Posts_Abilities_Test extends WP_UnitTestCase {
 	/**
 	 * Drive registration through the lifecycle actions so WordPress 6.9's
 	 * doing-it-wrong check sees the callbacks fire inside the proper action.
+	 *
+	 * Re-firing the actions also re-invokes WP core's own listeners, which
+	 * raise "already registered" notices for the core site category and
+	 * get-site-info ability. Those notices are unrelated to this test's
+	 * intent, so the helper whitelists them up-front for the calling test.
 	 */
 	private function trigger_registration() {
+		$this->setExpectedIncorrectUsage( 'WP_Ability_Categories_Registry::register' );
+		$this->setExpectedIncorrectUsage( 'WP_Abilities_Registry::register' );
+
 		add_action( 'wp_abilities_api_categories_init', array( Related_Posts_Abilities::class, 'register_category' ) );
 		add_action( 'wp_abilities_api_init', array( Related_Posts_Abilities::class, 'register_abilities' ) );
 		do_action( 'wp_abilities_api_categories_init' );
@@ -267,144 +251,6 @@ class Related_Posts_Abilities_Test extends WP_UnitTestCase {
 	public function test_can_view_related_posts_denies_anonymous() {
 		wp_set_current_user( 0 );
 		$this->assertFalse( Related_Posts_Abilities::can_view_related_posts() );
-	}
-
-	public function test_can_view_settings_allows_author() {
-		wp_set_current_user( self::$author_id );
-		$this->assertTrue( Related_Posts_Abilities::can_view_settings() );
-	}
-
-	public function test_can_manage_settings_denies_author() {
-		wp_set_current_user( self::$author_id );
-		$this->assertFalse( Related_Posts_Abilities::can_manage_settings() );
-	}
-
-	public function test_can_manage_settings_allows_admin() {
-		wp_set_current_user( self::$admin_id );
-		$this->assertTrue( Related_Posts_Abilities::can_manage_settings() );
-	}
-
-	public function test_get_settings_returns_normalized_shape() {
-		$settings = Related_Posts_Abilities::get_settings();
-		$this->assertIsArray( $settings );
-		$this->assertSame( 'classic', $settings['theme_type'], 'Classic theme path must announce theme_type=classic.' );
-		foreach ( array( 'enabled', 'show_headline', 'show_thumbnails', 'show_date', 'show_context', 'layout', 'headline', 'size' ) as $field ) {
-			$this->assertArrayHasKey( $field, $settings, "Settings shape must include {$field}." );
-		}
-		$this->assertContains( $settings['layout'], array( 'grid', 'list' ) );
-		$this->assertIsBool( $settings['enabled'] );
-		$this->assertIsInt( $settings['size'] );
-		$this->assertGreaterThanOrEqual( 1, $settings['size'] );
-	}
-
-	public function test_block_theme_omits_settings_abilities_from_map() {
-		$this->force_block_theme();
-
-		$slugs = array_keys( Related_Posts_Abilities::get_abilities() );
-
-		$this->assertContains(
-			'jetpack-related-posts/get-related-posts',
-			$slugs,
-			'The lookup ability must remain available on block themes — it does not depend on the option.'
-		);
-		$this->assertNotContains(
-			'jetpack-related-posts/get-settings',
-			$slugs,
-			'Block themes do not consume the relatedposts option at render time; get-settings must be omitted.'
-		);
-		$this->assertNotContains(
-			'jetpack-related-posts/update-settings',
-			$slugs,
-			'Block themes do not consume the relatedposts option at render time; update-settings must be omitted.'
-		);
-	}
-
-	public function test_classic_theme_keeps_full_abilities_map() {
-		$slugs = array_keys( Related_Posts_Abilities::get_abilities() );
-
-		$this->assertContains( 'jetpack-related-posts/get-related-posts', $slugs );
-		$this->assertContains( 'jetpack-related-posts/get-settings', $slugs );
-		$this->assertContains( 'jetpack-related-posts/update-settings', $slugs );
-	}
-
-	public function test_block_theme_does_not_register_settings_abilities() {
-		if ( ! function_exists( 'wp_get_abilities' ) ) {
-			$this->markTestSkipped( 'Abilities API not available.' );
-		}
-
-		// Re-firing the Abilities API actions also re-fires WP core's own
-		// registration callbacks, which then raise "already registered"
-		// doing-it-wrong notices for the core site category and get-site-info
-		// ability. Whitelist those so the test asserts on its own behavior.
-		$this->setExpectedIncorrectUsage( 'WP_Ability_Categories_Registry::register' );
-		$this->setExpectedIncorrectUsage( 'WP_Abilities_Registry::register' );
-
-		$this->force_block_theme();
-		$this->trigger_registration();
-
-		$registered_slugs = array_keys( wp_get_abilities() );
-
-		$this->assertContains(
-			'jetpack-related-posts/get-related-posts',
-			$registered_slugs,
-			'Lookup ability must register on block themes.'
-		);
-		$this->assertNotContains(
-			'jetpack-related-posts/get-settings',
-			$registered_slugs,
-			'get-settings must not register on block themes.'
-		);
-		$this->assertNotContains(
-			'jetpack-related-posts/update-settings',
-			$registered_slugs,
-			'update-settings must not register on block themes.'
-		);
-	}
-
-	public function test_get_settings_on_block_theme_returns_minimal_shape_defensively() {
-		// The ability isn't registered on block themes, but the static method
-		// remains PHP-reachable. Direct callers should still get a sensible
-		// shape that does not mislead by listing irrelevant fields.
-		$this->force_block_theme();
-
-		$settings = Related_Posts_Abilities::get_settings();
-
-		$this->assertSame( 'block', $settings['theme_type'] );
-		$this->assertArrayHasKey( 'notice', $settings );
-		foreach ( array( 'enabled', 'show_headline', 'show_thumbnails', 'show_date', 'show_context', 'layout', 'headline', 'size' ) as $field ) {
-			$this->assertArrayNotHasKey( $field, $settings );
-		}
-	}
-
-	public function test_update_settings_on_block_theme_is_rejected_defensively() {
-		// Even though the ability is not registered on block themes, the static
-		// execute callback is still PHP-reachable from direct callers — make
-		// sure it refuses to write so a misused call cannot corrupt the option.
-		$this->force_block_theme();
-		$this->seed_default_settings();
-		$before = Jetpack_Options::get_option( 'relatedposts' );
-
-		$result = Related_Posts_Abilities::update_settings( array( 'show_thumbnails' => true ) );
-
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'jetpack_related_posts_block_theme_not_supported', $result->get_error_code() );
-		$this->assertSame( $before, Jetpack_Options::get_option( 'relatedposts' ) );
-	}
-
-	public function test_update_settings_response_advertises_theme_type() {
-		$this->seed_default_settings();
-
-		$result = Related_Posts_Abilities::update_settings( array( 'show_thumbnails' => true ) );
-
-		$this->assertIsArray( $result );
-		$this->assertTrue( $result['changed'] );
-		$this->assertSame( 'classic', $result['settings']['theme_type'] );
-
-		// theme_type is a derived field — it must not be persisted to the
-		// `relatedposts` option, only added to the response.
-		$stored = Jetpack_Options::get_option( 'relatedposts' );
-		$this->assertIsArray( $stored );
-		$this->assertArrayNotHasKey( 'theme_type', $stored );
 	}
 
 	public function test_get_related_posts_rejects_missing_post_id() {
@@ -626,98 +472,5 @@ class Related_Posts_Abilities_Test extends WP_UnitTestCase {
 		$this->assertNull( $result[0]['format'] );
 		$this->assertSame( '', $result[0]['excerpt'] );
 		$this->assertSame( '', $result[0]['date'] );
-	}
-
-	public function test_get_settings_fills_defaults_from_partial_db_row() {
-		Jetpack_Options::update_option(
-			'relatedposts',
-			array(
-				'enabled' => true,
-				'size'    => 7,
-			)
-		);
-
-		$settings = Related_Posts_Abilities::get_settings();
-
-		$this->assertTrue( $settings['enabled'] );
-		$this->assertSame( 7, $settings['size'] );
-		$this->assertSame( 'grid', $settings['layout'], 'Missing layout key must default to grid.' );
-		$this->assertFalse( $settings['show_thumbnails'], 'Missing booleans must default to false.' );
-		$this->assertFalse( $settings['show_headline'] );
-		$this->assertFalse( $settings['show_date'] );
-		$this->assertFalse( $settings['show_context'] );
-		$this->assertSame( 'Related', $settings['headline'], 'Missing headline must fall back to "Related".' );
-	}
-
-	public function test_update_settings_rejects_no_fields() {
-		$result = Related_Posts_Abilities::update_settings( array() );
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'jetpack_related_posts_missing_field', $result->get_error_code() );
-	}
-
-	public function test_update_settings_rejects_only_unknown_fields() {
-		$result = Related_Posts_Abilities::update_settings( array( 'bogus_field' => true ) );
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'jetpack_related_posts_missing_field', $result->get_error_code() );
-	}
-
-	public function test_update_settings_rejects_invalid_layout() {
-		$result = Related_Posts_Abilities::update_settings( array( 'layout' => 'masonry' ) );
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'jetpack_related_posts_invalid_layout', $result->get_error_code() );
-	}
-
-	public function test_update_settings_rejects_size_out_of_range() {
-		$result = Related_Posts_Abilities::update_settings( array( 'size' => 999 ) );
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'jetpack_related_posts_invalid_size', $result->get_error_code() );
-	}
-
-	public function test_update_settings_rejects_non_bool_enabled() {
-		$result = Related_Posts_Abilities::update_settings( array( 'enabled' => 'yes' ) );
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'jetpack_related_posts_invalid_enabled', $result->get_error_code() );
-	}
-
-	public function test_update_settings_changes_when_value_differs() {
-		$this->seed_default_settings();
-
-		$result = Related_Posts_Abilities::update_settings( array( 'show_thumbnails' => true ) );
-
-		$this->assertIsArray( $result );
-		$this->assertTrue( $result['changed'] );
-		$this->assertSame( array( 'show_thumbnails' ), $result['changed_fields'] );
-		$this->assertTrue( $result['settings']['show_thumbnails'] );
-	}
-
-	public function test_update_settings_is_idempotent_when_values_match() {
-		$this->seed_default_settings();
-
-		$result = Related_Posts_Abilities::update_settings(
-			array(
-				'layout'          => 'grid',
-				'show_thumbnails' => false,
-			)
-		);
-
-		$this->assertIsArray( $result );
-		$this->assertFalse( $result['changed'], 'No-op update must return changed=false.' );
-		$this->assertSame( array(), $result['changed_fields'] );
-	}
-
-	private function seed_default_settings() {
-		Jetpack_Options::update_option(
-			'relatedposts',
-			array(
-				'enabled'         => true,
-				'show_headline'   => true,
-				'show_thumbnails' => false,
-				'show_date'       => true,
-				'show_context'    => true,
-				'layout'          => 'grid',
-				'headline'        => 'Related',
-				'size'            => 3,
-			)
-		);
 	}
 }

--- a/projects/plugins/jetpack/tests/php/src/Related_Posts_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Related_Posts_Abilities_Test.php
@@ -31,33 +31,14 @@ class Related_Posts_Abilities_Test extends WP_UnitTestCase {
 	/** @var array|null */
 	private $saved_relatedposts_option;
 
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id      = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$author_id     = $factory->user->create( array( 'role' => 'author' ) );
+		self::$subscriber_id = $factory->user->create( array( 'role' => 'subscriber' ) );
+	}
+
 	public function set_up() {
 		parent::set_up();
-
-		self::$admin_id      = wp_insert_user(
-			array(
-				'user_login' => 'rp_ability_admin_' . wp_generate_password( 8, false ),
-				'user_pass'  => 'pw',
-				'user_email' => 'rp_ability_admin_' . wp_generate_password( 4, false ) . '@example.test',
-				'role'       => 'administrator',
-			)
-		);
-		self::$author_id     = wp_insert_user(
-			array(
-				'user_login' => 'rp_ability_author_' . wp_generate_password( 8, false ),
-				'user_pass'  => 'pw',
-				'user_email' => 'rp_ability_author_' . wp_generate_password( 4, false ) . '@example.test',
-				'role'       => 'author',
-			)
-		);
-		self::$subscriber_id = wp_insert_user(
-			array(
-				'user_login' => 'rp_ability_sub_' . wp_generate_password( 8, false ),
-				'user_pass'  => 'pw',
-				'user_email' => 'rp_ability_sub_' . wp_generate_password( 4, false ) . '@example.test',
-				'role'       => 'subscriber',
-			)
-		);
 
 		$this->saved_relatedposts_option = Jetpack_Options::get_option( 'relatedposts', null );
 

--- a/projects/plugins/jetpack/tests/php/src/Related_Posts_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Related_Posts_Abilities_Test.php
@@ -297,28 +297,89 @@ class Related_Posts_Abilities_Test extends WP_UnitTestCase {
 		$this->assertGreaterThanOrEqual( 1, $settings['size'] );
 	}
 
-	public function test_get_settings_on_block_theme_omits_display_fields() {
+	public function test_block_theme_omits_settings_abilities_from_map() {
+		$this->force_block_theme();
+
+		$slugs = array_keys( Related_Posts_Abilities::get_abilities() );
+
+		$this->assertContains(
+			'jetpack-related-posts/get-related-posts',
+			$slugs,
+			'The lookup ability must remain available on block themes — it does not depend on the option.'
+		);
+		$this->assertNotContains(
+			'jetpack-related-posts/get-settings',
+			$slugs,
+			'Block themes do not consume the relatedposts option at render time; get-settings must be omitted.'
+		);
+		$this->assertNotContains(
+			'jetpack-related-posts/update-settings',
+			$slugs,
+			'Block themes do not consume the relatedposts option at render time; update-settings must be omitted.'
+		);
+	}
+
+	public function test_classic_theme_keeps_full_abilities_map() {
+		$slugs = array_keys( Related_Posts_Abilities::get_abilities() );
+
+		$this->assertContains( 'jetpack-related-posts/get-related-posts', $slugs );
+		$this->assertContains( 'jetpack-related-posts/get-settings', $slugs );
+		$this->assertContains( 'jetpack-related-posts/update-settings', $slugs );
+	}
+
+	public function test_block_theme_does_not_register_settings_abilities() {
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
+			$this->markTestSkipped( 'Abilities API not available.' );
+		}
+
+		// Re-firing the Abilities API actions also re-fires WP core's own
+		// registration callbacks, which then raise "already registered"
+		// doing-it-wrong notices for the core site category and get-site-info
+		// ability. Whitelist those so the test asserts on its own behavior.
+		$this->setExpectedIncorrectUsage( 'WP_Ability_Categories_Registry::register' );
+		$this->setExpectedIncorrectUsage( 'WP_Abilities_Registry::register' );
+
+		$this->force_block_theme();
+		$this->trigger_registration();
+
+		$registered_slugs = array_keys( wp_get_abilities() );
+
+		$this->assertContains(
+			'jetpack-related-posts/get-related-posts',
+			$registered_slugs,
+			'Lookup ability must register on block themes.'
+		);
+		$this->assertNotContains(
+			'jetpack-related-posts/get-settings',
+			$registered_slugs,
+			'get-settings must not register on block themes.'
+		);
+		$this->assertNotContains(
+			'jetpack-related-posts/update-settings',
+			$registered_slugs,
+			'update-settings must not register on block themes.'
+		);
+	}
+
+	public function test_get_settings_on_block_theme_returns_minimal_shape_defensively() {
+		// The ability isn't registered on block themes, but the static method
+		// remains PHP-reachable. Direct callers should still get a sensible
+		// shape that does not mislead by listing irrelevant fields.
 		$this->force_block_theme();
 
 		$settings = Related_Posts_Abilities::get_settings();
 
-		$this->assertSame( 'block', $settings['theme_type'], 'Block theme path must announce theme_type=block.' );
-		$this->assertArrayHasKey( 'notice', $settings, 'Block-theme response must carry a notice pointing at the block.' );
-		$this->assertIsString( $settings['notice'] );
-		$this->assertNotSame( '', $settings['notice'] );
-
-		// The display fields are render-time no-ops on block themes; the response
-		// must omit them so agents don't think writing to them will change anything.
+		$this->assertSame( 'block', $settings['theme_type'] );
+		$this->assertArrayHasKey( 'notice', $settings );
 		foreach ( array( 'enabled', 'show_headline', 'show_thumbnails', 'show_date', 'show_context', 'layout', 'headline', 'size' ) as $field ) {
-			$this->assertArrayNotHasKey(
-				$field,
-				$settings,
-				"Block-theme get-settings response must omit {$field} — the option is not consumed at render time."
-			);
+			$this->assertArrayNotHasKey( $field, $settings );
 		}
 	}
 
-	public function test_update_settings_on_block_theme_is_rejected() {
+	public function test_update_settings_on_block_theme_is_rejected_defensively() {
+		// Even though the ability is not registered on block themes, the static
+		// execute callback is still PHP-reachable from direct callers — make
+		// sure it refuses to write so a misused call cannot corrupt the option.
 		$this->force_block_theme();
 		$this->seed_default_settings();
 		$before = Jetpack_Options::get_option( 'relatedposts' );
@@ -327,9 +388,6 @@ class Related_Posts_Abilities_Test extends WP_UnitTestCase {
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'jetpack_related_posts_block_theme_not_supported', $result->get_error_code() );
-
-		// The stored option must not have been touched — block-theme rejection
-		// runs before any merge or save.
 		$this->assertSame( $before, Jetpack_Options::get_option( 'relatedposts' ) );
 	}
 

--- a/projects/plugins/jetpack/tests/php/src/Related_Posts_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Related_Posts_Abilities_Test.php
@@ -153,16 +153,8 @@ class Related_Posts_Abilities_Test extends WP_UnitTestCase {
 	/**
 	 * Drive registration through the lifecycle actions so WordPress 6.9's
 	 * doing-it-wrong check sees the callbacks fire inside the proper action.
-	 *
-	 * Re-firing the actions also re-invokes WP core's own listeners, which
-	 * raise "already registered" notices for the core site category and
-	 * get-site-info ability. Those notices are unrelated to this test's
-	 * intent, so the helper whitelists them up-front for the calling test.
 	 */
 	private function trigger_registration() {
-		$this->setExpectedIncorrectUsage( 'WP_Ability_Categories_Registry::register' );
-		$this->setExpectedIncorrectUsage( 'WP_Abilities_Registry::register' );
-
 		add_action( 'wp_abilities_api_categories_init', array( Related_Posts_Abilities::class, 'register_category' ) );
 		add_action( 'wp_abilities_api_init', array( Related_Posts_Abilities::class, 'register_abilities' ) );
 		do_action( 'wp_abilities_api_categories_init' );

--- a/projects/plugins/jetpack/tests/php/src/Related_Posts_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Related_Posts_Abilities_Test.php
@@ -1,0 +1,391 @@
+<?php
+/**
+ * Tests for the Related_Posts_Abilities Registrar subclass.
+ *
+ * @package automattic/jetpack
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9.
+
+use Automattic\Jetpack\Plugin\Abilities\Related_Posts_Abilities;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+require_once JETPACK__PLUGIN_DIR . 'modules/related-posts/abilities/class-related-posts-abilities.php';
+
+/**
+ * @covers \Automattic\Jetpack\Plugin\Abilities\Related_Posts_Abilities
+ */
+#[CoversClass( Related_Posts_Abilities::class )]
+class Related_Posts_Abilities_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/** @var int */
+	private static $admin_id;
+
+	/** @var int */
+	private static $author_id;
+
+	/** @var int */
+	private static $subscriber_id;
+
+	/** @var array|null */
+	private $saved_relatedposts_option;
+
+	public function set_up() {
+		parent::set_up();
+
+		self::$admin_id      = wp_insert_user(
+			array(
+				'user_login' => 'rp_ability_admin_' . wp_generate_password( 8, false ),
+				'user_pass'  => 'pw',
+				'user_email' => 'rp_ability_admin_' . wp_generate_password( 4, false ) . '@example.test',
+				'role'       => 'administrator',
+			)
+		);
+		self::$author_id     = wp_insert_user(
+			array(
+				'user_login' => 'rp_ability_author_' . wp_generate_password( 8, false ),
+				'user_pass'  => 'pw',
+				'user_email' => 'rp_ability_author_' . wp_generate_password( 4, false ) . '@example.test',
+				'role'       => 'author',
+			)
+		);
+		self::$subscriber_id = wp_insert_user(
+			array(
+				'user_login' => 'rp_ability_sub_' . wp_generate_password( 8, false ),
+				'user_pass'  => 'pw',
+				'user_email' => 'rp_ability_sub_' . wp_generate_password( 4, false ) . '@example.test',
+				'role'       => 'subscriber',
+			)
+		);
+
+		$this->saved_relatedposts_option = Jetpack_Options::get_option( 'relatedposts', null );
+
+		$this->reset_registry_state();
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+	}
+
+	public function tear_down() {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		remove_all_filters( 'jetpack_wp_abilities_should_register' );
+		$this->reset_registry_state();
+		wp_set_current_user( 0 );
+
+		if ( null === $this->saved_relatedposts_option ) {
+			Jetpack_Options::delete_option( 'relatedposts' );
+		} else {
+			Jetpack_Options::update_option( 'relatedposts', $this->saved_relatedposts_option );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Wipe any registry state and persisted action callbacks left over from
+	 * prior tests, so each test starts with a clean Abilities API surface.
+	 */
+	private function reset_registry_state() {
+		if ( function_exists( 'wp_unregister_ability' ) && function_exists( 'wp_get_abilities' ) ) {
+			$registered_slugs = array_keys( wp_get_abilities() );
+			foreach ( array_keys( Related_Posts_Abilities::get_abilities() ) as $slug ) {
+				if ( in_array( $slug, $registered_slugs, true ) ) {
+					wp_unregister_ability( $slug );
+				}
+			}
+		}
+		if ( function_exists( 'wp_unregister_ability_category' ) && function_exists( 'wp_get_ability_categories' ) ) {
+			$category_slug = Related_Posts_Abilities::get_category_slug();
+			if ( array_key_exists( $category_slug, wp_get_ability_categories() ) ) {
+				wp_unregister_ability_category( $category_slug );
+			}
+		}
+		remove_action( 'wp_abilities_api_categories_init', array( Related_Posts_Abilities::class, 'register_category' ) );
+		remove_action( 'wp_abilities_api_init', array( Related_Posts_Abilities::class, 'register_abilities' ) );
+	}
+
+	public function test_category_slug_is_plugin_scoped() {
+		$this->assertSame( 'jetpack-related-posts', Related_Posts_Abilities::get_category_slug() );
+	}
+
+	public function test_category_definition_has_label_and_description() {
+		$def = Related_Posts_Abilities::get_category_definition();
+		$this->assertArrayHasKey( 'label', $def );
+		$this->assertArrayHasKey( 'description', $def );
+	}
+
+	public function test_abilities_map_is_non_empty_and_namespaced() {
+		$abilities = Related_Posts_Abilities::get_abilities();
+		$this->assertNotEmpty( $abilities );
+		foreach ( array_keys( $abilities ) as $slug ) {
+			$this->assertStringStartsWith( 'jetpack-related-posts/', $slug );
+		}
+	}
+
+	public function test_no_spec_sets_category_explicitly() {
+		foreach ( Related_Posts_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertArrayNotHasKey(
+				'category',
+				$spec,
+				"Ability {$slug} should not set its own category — Registrar injects it."
+			);
+		}
+	}
+
+	public function test_init_registers_nothing_when_gate_filter_is_false() {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+
+		Related_Posts_Abilities::init();
+
+		$this->assertFalse(
+			has_action( 'wp_abilities_api_categories_init', array( Related_Posts_Abilities::class, 'register_category' ) )
+		);
+		$this->assertFalse(
+			has_action( 'wp_abilities_api_init', array( Related_Posts_Abilities::class, 'register_abilities' ) )
+		);
+
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+	}
+
+	public function test_init_hooks_lifecycle_actions_when_gate_is_true() {
+		Related_Posts_Abilities::init();
+
+		$this->assertNotFalse(
+			has_action( 'wp_abilities_api_categories_init', array( Related_Posts_Abilities::class, 'register_category' ) )
+				|| did_action( 'wp_abilities_api_categories_init' )
+		);
+	}
+
+	public function test_ability_class_is_colocated_with_module() {
+		$reflector = new \ReflectionClass( Related_Posts_Abilities::class );
+		$path      = $reflector->getFileName();
+		$this->assertStringContainsString(
+			'/modules/related-posts/',
+			$path,
+			'Module-backed abilities must live inside their module directory, not in src/abilities/.'
+		);
+		$this->assertStringNotContainsString(
+			'/src/abilities/',
+			$path,
+			'Found a module-backed ability in the plugin-global src/abilities/ tree.'
+		);
+	}
+
+	public function test_not_wired_from_class_jetpack_php() {
+		$bootstrap = file_get_contents( JETPACK__PLUGIN_DIR . 'class.jetpack.php' );
+		$this->assertStringNotContainsString(
+			'Related_Posts_Abilities::init()',
+			$bootstrap,
+			'class.jetpack.php must not init the module-backed ability. Wire from modules/related-posts.php.'
+		);
+	}
+
+	/**
+	 * Drive registration through the lifecycle actions so WordPress 6.9's
+	 * doing-it-wrong check sees the callbacks fire inside the proper action.
+	 */
+	private function trigger_registration() {
+		add_action( 'wp_abilities_api_categories_init', array( Related_Posts_Abilities::class, 'register_category' ) );
+		add_action( 'wp_abilities_api_init', array( Related_Posts_Abilities::class, 'register_abilities' ) );
+		do_action( 'wp_abilities_api_categories_init' );
+		do_action( 'wp_abilities_api_init' );
+		remove_action( 'wp_abilities_api_categories_init', array( Related_Posts_Abilities::class, 'register_category' ) );
+		remove_action( 'wp_abilities_api_init', array( Related_Posts_Abilities::class, 'register_abilities' ) );
+	}
+
+	public function test_register_abilities_registers_every_slug() {
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
+			$this->markTestSkipped( 'Abilities API not available.' );
+		}
+
+		$this->trigger_registration();
+
+		foreach ( array_keys( Related_Posts_Abilities::get_abilities() ) as $slug ) {
+			$this->assertNotNull( wp_get_ability( $slug ), "Ability {$slug} should be registered." );
+		}
+	}
+
+	public function test_per_ability_allow_list_filter_is_respected() {
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
+			$this->markTestSkipped( 'Abilities API not available.' );
+		}
+
+		add_filter(
+			'jetpack_wp_abilities_should_register',
+			static function ( $enabled, $type, $slug ) {
+				unset( $slug );
+				if ( 'ability' === $type ) {
+					return false;
+				}
+				return $enabled;
+			},
+			10,
+			3
+		);
+
+		$this->trigger_registration();
+
+		$registered_slugs = array_keys( wp_get_abilities() );
+		foreach ( array_keys( Related_Posts_Abilities::get_abilities() ) as $slug ) {
+			$this->assertNotContains( $slug, $registered_slugs, "Ability {$slug} must be filtered out." );
+		}
+	}
+
+	public function test_register_abilities_injects_category_on_specs_that_omit_it() {
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
+			$this->markTestSkipped( 'Abilities API not available.' );
+		}
+
+		$this->trigger_registration();
+
+		foreach ( array_keys( Related_Posts_Abilities::get_abilities() ) as $slug ) {
+			$ability = wp_get_ability( $slug );
+			if ( null === $ability ) {
+				continue;
+			}
+			$category = method_exists( $ability, 'get_category' ) ? $ability->get_category() : null;
+			if ( null !== $category ) {
+				$this->assertSame( 'jetpack-related-posts', $category, "Ability {$slug} should inherit the registrar's category." );
+			}
+		}
+	}
+
+	public function test_can_view_related_posts_allows_author() {
+		wp_set_current_user( self::$author_id );
+		$this->assertTrue( Related_Posts_Abilities::can_view_related_posts() );
+	}
+
+	public function test_can_view_related_posts_denies_subscriber() {
+		wp_set_current_user( self::$subscriber_id );
+		$this->assertFalse( Related_Posts_Abilities::can_view_related_posts() );
+	}
+
+	public function test_can_view_related_posts_denies_anonymous() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( Related_Posts_Abilities::can_view_related_posts() );
+	}
+
+	public function test_can_view_settings_allows_author() {
+		wp_set_current_user( self::$author_id );
+		$this->assertTrue( Related_Posts_Abilities::can_view_settings() );
+	}
+
+	public function test_can_manage_settings_denies_author() {
+		wp_set_current_user( self::$author_id );
+		$this->assertFalse( Related_Posts_Abilities::can_manage_settings() );
+	}
+
+	public function test_can_manage_settings_allows_admin() {
+		wp_set_current_user( self::$admin_id );
+		$this->assertTrue( Related_Posts_Abilities::can_manage_settings() );
+	}
+
+	public function test_get_settings_returns_normalized_shape() {
+		$settings = Related_Posts_Abilities::get_settings();
+		$this->assertIsArray( $settings );
+		foreach ( array( 'enabled', 'show_headline', 'show_thumbnails', 'show_date', 'show_context', 'layout', 'headline', 'size' ) as $field ) {
+			$this->assertArrayHasKey( $field, $settings, "Settings shape must include {$field}." );
+		}
+		$this->assertContains( $settings['layout'], array( 'grid', 'list' ) );
+		$this->assertIsBool( $settings['enabled'] );
+		$this->assertIsInt( $settings['size'] );
+		$this->assertGreaterThanOrEqual( 1, $settings['size'] );
+	}
+
+	public function test_get_related_posts_rejects_missing_post_id() {
+		$result = Related_Posts_Abilities::get_related_posts( array() );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'jetpack_related_posts_missing_post_id', $result->get_error_code() );
+	}
+
+	public function test_get_related_posts_rejects_zero_post_id() {
+		$result = Related_Posts_Abilities::get_related_posts( array( 'post_id' => 0 ) );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'jetpack_related_posts_missing_post_id', $result->get_error_code() );
+	}
+
+	public function test_get_related_posts_rejects_unknown_post_id() {
+		$result = Related_Posts_Abilities::get_related_posts( array( 'post_id' => 99999999 ) );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'jetpack_related_posts_invalid_post_id', $result->get_error_code() );
+	}
+
+	public function test_get_related_posts_returns_array_for_real_post() {
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$result  = Related_Posts_Abilities::get_related_posts( array( 'post_id' => $post_id ) );
+		// Real ES backend is unavailable in test env; an empty array is the expected shape.
+		$this->assertIsArray( $result );
+	}
+
+	public function test_update_settings_rejects_no_fields() {
+		$result = Related_Posts_Abilities::update_settings( array() );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'jetpack_related_posts_missing_field', $result->get_error_code() );
+	}
+
+	public function test_update_settings_rejects_only_unknown_fields() {
+		$result = Related_Posts_Abilities::update_settings( array( 'bogus_field' => true ) );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'jetpack_related_posts_missing_field', $result->get_error_code() );
+	}
+
+	public function test_update_settings_rejects_invalid_layout() {
+		$result = Related_Posts_Abilities::update_settings( array( 'layout' => 'masonry' ) );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'jetpack_related_posts_invalid_layout', $result->get_error_code() );
+	}
+
+	public function test_update_settings_rejects_size_out_of_range() {
+		$result = Related_Posts_Abilities::update_settings( array( 'size' => 999 ) );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'jetpack_related_posts_invalid_size', $result->get_error_code() );
+	}
+
+	public function test_update_settings_rejects_non_bool_enabled() {
+		$result = Related_Posts_Abilities::update_settings( array( 'enabled' => 'yes' ) );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'jetpack_related_posts_invalid_enabled', $result->get_error_code() );
+	}
+
+	public function test_update_settings_changes_when_value_differs() {
+		$this->seed_default_settings();
+
+		$result = Related_Posts_Abilities::update_settings( array( 'show_thumbnails' => true ) );
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['changed'] );
+		$this->assertSame( array( 'show_thumbnails' ), $result['changed_fields'] );
+		$this->assertTrue( $result['settings']['show_thumbnails'] );
+	}
+
+	public function test_update_settings_is_idempotent_when_values_match() {
+		$this->seed_default_settings();
+
+		$result = Related_Posts_Abilities::update_settings(
+			array(
+				'layout'          => 'grid',
+				'show_thumbnails' => false,
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertFalse( $result['changed'], 'No-op update must return changed=false.' );
+		$this->assertSame( array(), $result['changed_fields'] );
+	}
+
+	private function seed_default_settings() {
+		Jetpack_Options::update_option(
+			'relatedposts',
+			array(
+				'enabled'         => true,
+				'show_headline'   => true,
+				'show_thumbnails' => false,
+				'show_date'       => true,
+				'show_context'    => true,
+				'layout'          => 'grid',
+				'headline'        => 'Related',
+				'size'            => 3,
+			)
+		);
+	}
+}


### PR DESCRIPTION
Fixes #

## Proposed changes
* Adds `Related_Posts_Abilities`, a `Registrar`-extending class colocated with the Related Posts module at `projects/plugins/jetpack/modules/related-posts/abilities/class-related-posts-abilities.php` and wired from `modules/related-posts.php` so it only loads when the module is active (Case A colocation).
* Registers one ability under the `jetpack-related-posts/*` namespace on WP 6.9+:
  - `get-related-posts` — returns related posts for a given source post (read-only, idempotent, capped at 20 results, configurable `per_page` 1..20, backed by `Jetpack_RelatedPosts::init_raw()->get_for_post_id()`). Permission gate is the broad `edit_posts` cap for menu visibility; the actual lookup re-checks `edit_post` for the specific source post, matching the existing `/wpcom/v2/related-posts/{id}` endpoint.
* Adds `automattic/jetpack-wp-abilities` as a runtime dependency of the Jetpack plugin.
* PHPUnit coverage in `tests/php/src/Related_Posts_Abilities_Test.php` (27 tests, 56 assertions): Registrar lifecycle (gate filter, hook wiring, per-ability allow-list, category auto-injection), abstract getters, permission callbacks (author/subscriber/anonymous), execute happy-path + schema edge cases (per_page bounds, default behaviour, summary shape, per-post permission), and module colocation lints.

The top-level `jetpack_wp_abilities_enabled` filter still defaults to `false`, so this is dormant on every site until a feature flag opts in.

### Why no settings abilities?
An earlier revision of this branch also registered `get-settings` and `update-settings` over the `relatedposts` option. Those were removed before merge because the option is largely a no-op at render time:

* **Block themes** bypass the auto-injection path entirely (`Blocks::is_fse_theme()` short-circuits `filter_add_target_to_dom` in `jetpack-related-posts.php`). Rendering is controlled per-instance by the `jetpack/related-posts` block placed in templates, which reads its own block attributes — never the option. Writing to the option here would have let agents change "settings" that the front end ignores.
* **Classic themes** read most of the display fields, but the `enabled` flag is gated behind `apply_filters( 'jetpack_relatedposts_filter_allow_feature_toggle', false )` — an off-by-default filter — so on the vast majority of classic-theme sites toggling `enabled` is also a no-op.

Exposing settings under either condition would have given agents a misleading "I changed it" success signal. Toggling the module itself is already handled by `jetpack-modules/set-module-status`; per-block display tweaks belong with the block in the Site Editor. We can revisit a block-attribute-aware ability later if we want to script in-template edits, but that's a different surface.

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
1. Apply the branch and run `composer install` inside `projects/plugins/jetpack`.
2. Run the test suite:
   ```
   jetpack docker phpunit jetpack -- --filter Related_Posts_Abilities_Test
   ```
   Expect: 27 tests / 56 assertions, OK.
3. Activate the Related Posts module on a WP 6.9 site and add this snippet to `mu-plugins` to flip the gate:
   ```php
   add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
   ```
4. Confirm the ability is listed and the settings abilities are *not*:
   ```
   curl -s -u admin:pw http://localhost/wp-json/wp-abilities/v1/abilities | jq '.[] | select(.name | startswith("jetpack-related-posts/")) | .name'
   ```
   Expect exactly one slug: `jetpack-related-posts/get-related-posts`.
5. Exercise it against a real post:
   ```
   curl -s -u admin:pw http://localhost/wp-json/wp-abilities/v1/abilities/jetpack-related-posts/get-related-posts/run -d '{"post_id":<id>}'
   ```
   Expect an array of `{ id, url, title, excerpt, date, post_type, format }` (empty when ES is unreachable — that's the documented behaviour, not an error). Try with `per_page` between 1 and 20; values outside that range should be rejected with `ability_invalid_input`.
6. Deactivate the related-posts module and re-list abilities — the slug must disappear (Case A colocation guarantees the registrar isn't loaded when the module is off).
