### PR TITLE
Write: Fix "Tell your story..." placeholder not showing on fresh editor load

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-write-placeholder-text
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-write-placeholder-text
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write: Fix "Tell your story..." placeholder not showing on fresh editor load.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -456,8 +456,15 @@
 	text-wrap: stable;
 }
 
-.bw-content:empty::before {
+.bw-content.bw-is-empty {
+	position: relative;
+}
+
+.bw-content.bw-is-empty::before {
 	content: attr(data-placeholder);
+	position: absolute;
+	top: 0;
+	left: 0;
 	color: #ccc;
 	pointer-events: none;
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -326,10 +326,16 @@ document.execCommand( 'defaultParagraphSeparator', false, 'p' );
 const contentReady2 = setInterval( () => {
 	const contentEl = document.querySelector( '.bw-content' );
 	if ( ! contentEl ) return;
-	clearInterval( contentReady2 );
+	clearInterval( contentReady2 ); // cleared before init runs, so the block below executes exactly once
 
 	if ( ! contentEl.innerHTML.trim() ) {
 		contentEl.innerHTML = '<p><br></p>';
+	}
+	if ( ! contentEl.textContent.trim() && ! contentEl.querySelector( 'img, video, figure' ) ) {
+		contentEl.classList.add( 'bw-is-empty' );
+		contentEl.addEventListener( 'input', () => contentEl.classList.remove( 'bw-is-empty' ), {
+			once: true,
+		} );
 	}
 }, 200 );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -260,7 +260,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 			><?php echo esc_textarea( $edit_title ); ?></textarea>
 			<div class="bw-separator"></div>
 			<div
-				class="bw-content"
+				class="bw-content<?php echo $edit_content ? '' : ' bw-is-empty'; ?>"
 				contenteditable="true"
 				data-wp-on--mouseup="actions.checkFormatting"
 				data-wp-on--keyup="actions.checkFormatting"

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -120,7 +120,7 @@ class Write_Test extends \WorDBless\BaseTestCase {
 
 		$this->assertStringContainsString( 'data-wp-interactive="wpcom-write"', $output );
 		$this->assertStringContainsString( 'class="bw-app"', $output );
-		$this->assertStringContainsString( 'class="bw-content"', $output );
+		$this->assertStringContainsString( 'class="bw-content bw-is-empty"', $output );
 		$this->assertStringContainsString( 'contenteditable="true"', $output );
 		$this->assertStringContainsString( 'Tell your story...', $output );
 		$this->assertStringContainsString( 'Save draft', $output );


### PR DESCRIPTION
Fixes RSM-1359

 ## Proposed changes

   * Fix "Tell your story..." placeholder text not appearing in the Write editor on fresh page load
   * Replace `:empty` CSS selector (which never matched because the editor seeds `<p><br></p>`on init) with a JS-driven `bw-is-empty` class approach
   * Use `position: absolute` on the `::before` pseudo-element so the placeholder overlays the cursor correctly rather than pushing it down
   * Remove the placeholder on the first keystroke via a one-time `input` listener

   ## Related product discussion/links

  N/A

   ## Does this pull request change what data or activity we track or use?

   No.

   ## Testing instructions

   1. Go to the Write editor (`wp-admin/admin.php?page=write`).
   2. On a fresh load with an empty editor, verify the "Tell your story..." placeholder text is visible.
   3. Click into the editor and start typing — the placeholder should disappear immediately.
   4. Verify the cursor sits on the same line as where the placeholder was (not below it)
