### PR TITLE
Write: Fix slash menu Tab key cycling and hover highlight conflict

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-write-tab-nav-slash-menu
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-write-tab-nav-slash-menu
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write: Fix slash menu Tab key cycling and suppress hover highlight during keyboard navigation

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -595,6 +595,11 @@
 	background: #f5f5f5;
 }
 
+/* Suppress hover highlight during keyboard navigation. */
+.bw-slash-menu--keyboard .bw-slash-item:hover {
+	background: #fff;
+}
+
 .bw-slash-item strong {
 	display: block;
 	font-size: 14px;

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -596,7 +596,7 @@
 }
 
 /* Suppress hover highlight during keyboard navigation. */
-.bw-slash-menu--keyboard .bw-slash-item:hover {
+.bw-slash-menu--keyboard .bw-slash-item:not(.bw-slash-item-active):hover {
 	background: #fff;
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -22,6 +22,9 @@ let linkPopoverCloseHandler = null;
 // menu item when the filter text changes, not when the user is navigating.
 let prevSlashFilter = null;
 
+// Prevent enterKeyboardNav from stacking multiple mousemove listeners.
+let keyboardNavListenerActive = false;
+
 /**
  * Save the current text selection so it can be restored after a modal closes.
  */
@@ -208,9 +211,20 @@ function enterKeyboardNav() {
 	const menu = document.querySelector( '.bw-slash-menu' );
 	if ( ! menu ) return;
 	menu.classList.add( 'bw-slash-menu--keyboard' );
-	menu.addEventListener( 'mousemove', () => menu.classList.remove( 'bw-slash-menu--keyboard' ), {
-		once: true,
-	} );
+	if ( ! keyboardNavListenerActive ) {
+		keyboardNavListenerActive = true;
+		menu.addEventListener(
+			'mousemove',
+			() => {
+				keyboardNavListenerActive = false;
+				menu.classList.remove( 'bw-slash-menu--keyboard' );
+				menu
+					.querySelectorAll( '.bw-slash-item-active' )
+					.forEach( el => el.classList.remove( 'bw-slash-item-active' ) );
+			},
+			{ once: true }
+		);
+	}
 }
 
 /**
@@ -676,6 +690,7 @@ const { state } = store( 'wpcom-write', {
 			if ( state.showSlashMenu ) {
 				if ( event.key === 'Escape' ) {
 					event.preventDefault();
+					prevSlashFilter = null;
 					state.showSlashMenu = false;
 					return;
 				}
@@ -709,7 +724,7 @@ const { state } = store( 'wpcom-write', {
 
 				if ( event.key === 'Enter' ) {
 					event.preventDefault();
-					const target = active || visible[ 0 ];
+					const target = active || document.querySelector( '.bw-slash-item:hover' ) || visible[ 0 ];
 					if ( target ) {
 						// Map menu items to actions by their label text.
 						const label = target.querySelector( 'strong' )?.textContent?.toLowerCase();

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -18,6 +18,10 @@ let headingMenuCloseHandler = null;
 let textColorMenuCloseHandler = null;
 let linkPopoverCloseHandler = null;
 
+// Track the previous slash filter so checkSlashCommand only resets the active
+// menu item when the filter text changes, not when the user is navigating.
+let prevSlashFilter = null;
+
 /**
  * Save the current text selection so it can be restored after a modal closes.
  */
@@ -194,6 +198,19 @@ function positionSlashMenu() {
 	menu.style.position = 'absolute';
 	menu.style.left = left + 'px';
 	menu.style.top = top + 'px';
+}
+
+/**
+ * Mark the slash menu as keyboard-navigated to suppress hover highlights,
+ * then restore hover behaviour on the next mousemove.
+ */
+function enterKeyboardNav() {
+	const menu = document.querySelector( '.bw-slash-menu' );
+	if ( ! menu ) return;
+	menu.classList.add( 'bw-slash-menu--keyboard' );
+	menu.addEventListener( 'mousemove', () => menu.classList.remove( 'bw-slash-menu--keyboard' ), {
+		once: true,
+	} );
 }
 
 /**
@@ -672,19 +689,21 @@ const { state } = store( 'wpcom-write', {
 				const active = document.querySelector( '.bw-slash-item-active' );
 				let idx = active ? visible.indexOf( active ) : -1;
 
-				if ( event.key === 'ArrowDown' || event.key === 'Tab' ) {
+				if ( event.key === 'ArrowDown' || ( event.key === 'Tab' && ! event.shiftKey ) ) {
 					event.preventDefault();
 					if ( active ) active.classList.remove( 'bw-slash-item-active' );
 					idx = ( idx + 1 ) % visible.length;
 					visible[ idx ].classList.add( 'bw-slash-item-active' );
+					enterKeyboardNav();
 					return;
 				}
 
-				if ( event.key === 'ArrowUp' ) {
+				if ( event.key === 'ArrowUp' || ( event.key === 'Tab' && event.shiftKey ) ) {
 					event.preventDefault();
 					if ( active ) active.classList.remove( 'bw-slash-item-active' );
 					idx = idx <= 0 ? visible.length - 1 : idx - 1;
 					visible[ idx ].classList.add( 'bw-slash-item-active' );
+					enterKeyboardNav();
 					return;
 				}
 
@@ -768,23 +787,29 @@ const { state } = store( 'wpcom-write', {
 			const text = node.textContent;
 			// Show menu when the line starts with "/" and optionally a filter after it.
 			if ( /^\/\S*$/.test( text.trim() ) ) {
-				state.slashFilter = text.trim().slice( 1 ).toLowerCase();
+				const newFilter = text.trim().slice( 1 ).toLowerCase();
+				// Only reset the active item when the filter text actually changes
+				// (i.e. the user typed a character). Preserve selection when navigating.
+				const filterChanged = newFilter !== prevSlashFilter;
+				state.slashFilter = newFilter;
+				prevSlashFilter = newFilter;
 				state.showSlashMenu = true;
 				requestAnimationFrame( positionSlashMenu );
 
-				// Filter menu items and reset active highlight.
+				// Filter menu items; reset active highlight only on filter change.
 				const items = document.querySelectorAll( '.bw-slash-item' );
 				let firstVisible = null;
 				items.forEach( item => {
-					item.classList.remove( 'bw-slash-item-active' );
+					if ( filterChanged ) item.classList.remove( 'bw-slash-item-active' );
 					const label = item.querySelector( 'strong' ).textContent.toLowerCase();
 					const show = label.includes( state.slashFilter );
 					item.style.display = show ? '' : 'none';
 					if ( show && ! firstVisible ) firstVisible = item;
 				} );
-				// Auto-highlight the first visible item.
-				if ( firstVisible ) firstVisible.classList.add( 'bw-slash-item-active' );
+				// Auto-highlight the first visible item only when filter changes.
+				if ( filterChanged && firstVisible ) firstVisible.classList.add( 'bw-slash-item-active' );
 			} else {
+				prevSlashFilter = null;
 				state.showSlashMenu = false;
 			}
 		},

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -25,6 +25,10 @@ let prevSlashFilter = null;
 // Prevent enterKeyboardNav from stacking multiple mousemove listeners.
 let keyboardNavListenerActive = false;
 
+// Skip one checkSlashCommand cycle after the user dismisses the menu with Escape,
+// preventing the keyup event from immediately reopening it.
+let slashMenuEscaped = false;
+
 /**
  * Save the current text selection so it can be restored after a modal closes.
  */
@@ -690,6 +694,7 @@ const { state } = store( 'wpcom-write', {
 			if ( state.showSlashMenu ) {
 				if ( event.key === 'Escape' ) {
 					event.preventDefault();
+					slashMenuEscaped = true;
 					prevSlashFilter = null;
 					state.showSlashMenu = false;
 					return;
@@ -802,6 +807,12 @@ const { state } = store( 'wpcom-write', {
 			const text = node.textContent;
 			// Show menu when the line starts with "/" and optionally a filter after it.
 			if ( /^\/\S*$/.test( text.trim() ) ) {
+				// User just dismissed the menu with Escape — skip this keyup cycle.
+				if ( slashMenuEscaped ) {
+					slashMenuEscaped = false;
+					return;
+				}
+
 				const newFilter = text.trim().slice( 1 ).toLowerCase();
 				// Only reset the active item when the filter text actually changes
 				// (i.e. the user typed a character). Preserve selection when navigating.
@@ -824,6 +835,7 @@ const { state } = store( 'wpcom-write', {
 				// Auto-highlight the first visible item only when filter changes.
 				if ( filterChanged && firstVisible ) firstVisible.classList.add( 'bw-slash-item-active' );
 			} else {
+				slashMenuEscaped = false;
 				prevSlashFilter = null;
 				state.showSlashMenu = false;
 			}

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -696,6 +696,9 @@ const { state } = store( 'wpcom-write', {
 					event.preventDefault();
 					slashMenuEscaped = true;
 					prevSlashFilter = null;
+					keyboardNavListenerActive = false;
+					const menu = document.querySelector( '.bw-slash-menu' );
+					if ( menu ) menu.classList.remove( 'bw-slash-menu--keyboard' );
 					state.showSlashMenu = false;
 					return;
 				}

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -732,6 +732,10 @@ const { state } = store( 'wpcom-write', {
 
 				if ( event.key === 'Enter' ) {
 					event.preventDefault();
+					prevSlashFilter = null;
+					keyboardNavListenerActive = false;
+					const menu = document.querySelector( '.bw-slash-menu' );
+					if ( menu ) menu.classList.remove( 'bw-slash-menu--keyboard' );
 					const target = active || document.querySelector( '.bw-slash-item:hover' ) || visible[ 0 ];
 					if ( target ) {
 						// Map menu items to actions by their label text.
@@ -820,10 +824,15 @@ const { state } = store( 'wpcom-write', {
 				// Only reset the active item when the filter text actually changes
 				// (i.e. the user typed a character). Preserve selection when navigating.
 				const filterChanged = newFilter !== prevSlashFilter;
+				const menuJustOpened = ! state.showSlashMenu;
 				state.slashFilter = newFilter;
 				prevSlashFilter = newFilter;
 				state.showSlashMenu = true;
 				requestAnimationFrame( positionSlashMenu );
+
+				// Suppress hover highlight when the menu first opens so an item
+				// under the cursor doesn't appear selected before the user moves.
+				if ( menuJustOpened ) enterKeyboardNav();
 
 				// Filter menu items; reset active highlight only on filter change.
 				const items = document.querySelectorAll( '.bw-slash-item' );


### PR DESCRIPTION
Fixes RSM-621

## Proposed changes

* Fix Tab/Shift+Tab not cycling through slash menu items — `checkSlashCommand` (called on every `keyup`) was resetting the active item to the first one, overriding navigation done on `keydown`. Fixed by tracking `prevSlashFilter` and only resetting the highlight when the filter text actually changes.
* Fix Heading item appearing stuck highlighted during keyboard navigation — `:hover` and `bw-slash-item-active` share the same background colour, so if the mouse happened to be over Heading when the menu appeared it stayed visually highlighted even after the active class moved. Fixed by adding a `bw-slash-menu--keyboard` class that suppresses `:hover` during keyboard navigation, removed automatically on the next `mousemove`.
* Add Shift+Tab support to cycle backward through slash menu items.
* Fix active item not highlighted when menu reopens after pressing Escape — `prevSlashFilter` was not reset on Escape, so `filterChanged` was always false on the next open, leaving no item highlighted.
* Fix dual highlight when the mouse is over the keyboard-selected item — tightened the keyboard nav CSS override to exclude `.bw-slash-item-active`, so the active item always shows its highlight.
* Fix mousemove listener accumulation in `enterKeyboardNav` — each Tab/Arrow press was adding a new listener; now guarded by a flag so only one is ever pending.
* Enter now selects the hovered item when no keyboard selection is active, rather than always falling back to the first item.
* Fix slash menu flashing on Escape — `keyup` after Escape was triggering `checkSlashCommand`, which immediately reopened the menu. Fixed with a flag that skips one `checkSlashCommand` cycle after Escape.
* Fix hover suppressed on menu reopen after Escape — `bw-slash-menu--keyboard` was left on the menu element after Escape, causing hover to be broken until the mouse moved. Now cleaned up alongside other Escape state.

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Open the Write editor (`wp-admin/admin.php?page=write` on WordPress.com).
2. In the content area, type `/` to open the slash command menu.
3. Press **Tab** — the highlighted item should advance from Heading → Image → Quote → Video → Divider → Heading (wrapping).
4. Press **Shift+Tab** — the highlight should cycle backward.
5. Confirm **Enter** selects the currently highlighted item.
6. Press **Escape** to close the menu, then type `/` again — the first item should be highlighted on reopen and hover should work immediately without needing to move the mouse.
7. To test the hover bug: open the slash menu, position your mouse over the Heading item without moving it, then Tab through the list. Only the keyboard-selected item should appear highlighted; Heading should lose its highlight as soon as the active class moves away.
8. Tab to an item the mouse is already hovering over — it should appear highlighted (not invisible).
9. Move the mouse over a different item after keyboard navigating — the keyboard selection should clear and only the hovered item highlights.
10. Mouse over an item and press **Enter** — the hovered item should be selected, not always Heading.
11. Tab to Quote, press **Enter** to insert it, then on a new line type `/` again — **Heading** (not Quote) should be highlighted.
