### PR TITLE
Write: Add Tracks event when the Write editor is opened

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-write-editor-open-event
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-write-editor-open-event
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Add Tracks event wpcom_write_editor_open when the Write editor is opened, with is_new_post and source properties.
+Add Tracks event wpcom_write_editor_open when the Write editor is opened, with is_new_post, source, and post_id properties.

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-write-editor-open-event
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-write-editor-open-event
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add Tracks event wpcom_write_editor_open when the Write editor is opened, with is_new_post property.

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-write-editor-open-event
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-write-editor-open-event
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Add Tracks event wpcom_write_editor_open when the Write editor is opened, with is_new_post property.
+Add Tracks event wpcom_write_editor_open when the Write editor is opened, with is_new_post and source properties.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -216,7 +216,7 @@ function wpcom_write_render_admin_page() {
 		Common\wpcom_record_tracks_event(
 			'wpcom_write_editor_open',
 			array(
-				'is_new_post' => 0 === $edit_post_id,
+				'is_new_post' => (int) ( 0 === $edit_post_id ),
 				'source'      => $source,
 			)
 		);

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -13,6 +13,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use Automattic\Jetpack\Jetpack_Mu_Wpcom\Common;
+
 if ( ! defined( 'WPCOM_WRITE_VERSION' ) ) {
 	// Use file modification time to bust CDN caches when files change.
 	define( 'WPCOM_WRITE_VERSION', (string) max( filemtime( __DIR__ . '/view.js' ), filemtime( __DIR__ . '/style.css' ) ) );
@@ -186,6 +188,13 @@ function wpcom_write_render_admin_page() {
 			$edit_post_id = 0;
 		}
 	}
+
+	Common\wpcom_record_tracks_event(
+		'wpcom_write_editor_open',
+		array(
+			'is_new_post' => 0 === $edit_post_id,
+		)
+	);
 
 	// Build categories list for the UI.
 	$all_cats        = get_categories( array( 'hide_empty' => false ) );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -189,12 +189,38 @@ function wpcom_write_render_admin_page() {
 		}
 	}
 
-	Common\wpcom_record_tracks_event(
-		'wpcom_write_editor_open',
-		array(
-			'is_new_post' => 0 === $edit_post_id,
-		)
-	);
+	// Determine how the user arrived at the Write editor.
+	// 1. Explicit query param (highest priority).
+	// 2. Infer from HTTP referer.
+	// 3. Fall back to 'direct' (bookmarks, typed URLs, stripped referers).
+	// Note: When the /write → wp-admin redirect is implemented, it must forward the source query param.
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only GET parameter used for analytics only.
+	$source = isset( $_GET['source'] ) ? sanitize_key( $_GET['source'] ) : '';
+	if ( ! $source ) {
+		$referer = wp_get_referer();
+		if ( $referer ) {
+			$path = wp_parse_url( $referer, PHP_URL_PATH );
+			if ( $path && str_contains( $path, '/wp-admin/index.php' ) ) {
+				$source = 'dashboard';
+			} elseif ( $path && str_contains( $path, '/wp-admin/edit.php' ) ) {
+				$source = 'posts_list';
+			} else {
+				$source = 'referrer';
+			}
+		} else {
+			$source = 'direct';
+		}
+	}
+
+	if ( function_exists( '\Automattic\Jetpack\Jetpack_Mu_Wpcom\Common\wpcom_record_tracks_event' ) ) {
+		Common\wpcom_record_tracks_event(
+			'wpcom_write_editor_open',
+			array(
+				'is_new_post' => 0 === $edit_post_id,
+				'source'      => $source,
+			)
+		);
+	}
 
 	// Build categories list for the UI.
 	$all_cats        = get_categories( array( 'hide_empty' => false ) );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -213,12 +213,18 @@ function wpcom_write_render_admin_page() {
 	}
 
 	if ( function_exists( '\Automattic\Jetpack\Jetpack_Mu_Wpcom\Common\wpcom_record_tracks_event' ) ) {
+		$event_props = array(
+			'is_new_post' => (int) ( 0 === $edit_post_id ),
+			'source'      => $source,
+		);
+
+		if ( $edit_post_id > 0 ) {
+			$event_props['post_id'] = $edit_post_id;
+		}
+
 		Common\wpcom_record_tracks_event(
 			'wpcom_write_editor_open',
-			array(
-				'is_new_post' => (int) ( 0 === $edit_post_id ),
-				'source'      => $source,
-			)
+			$event_props
 		);
 	}
 


### PR DESCRIPTION
Fixes RSM-1159

## Proposed changes

* Add `wpcom_write_editor_open` Tracks event that fires on every page load of the Write editor
* Includes `is_new_post` property to distinguish new post creation from editing an existing post (for future use — editing is not yet fully supported)
* Includes `source` property to identify how the user arrived at the editor:
  - Explicit `?source=` query param (highest priority)
  - Inferred from HTTP referer (`dashboard`, `posts_list`, or generic `referrer`)
  - Falls back to `direct` for bookmarks, typed URLs, or stripped referers
* Includes `post_id` property (only when editing an existing post; omitted for new posts)

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

Yes — adds a new Tracks event `wpcom_write_editor_open` with three properties:
- `is_new_post` (bool): `true` when opening a blank new post, `false` when opening with an existing post ID
- `source` (string): how the user arrived at the editor — `dashboard`, `posts_list`, `referrer`, `direct`, or an explicit value passed via query param
- `post_id` (int, optional): the post ID when editing an existing post; omitted for new posts

## Testing instructions

### Simple sites

* Navigate to `/wp-admin/admin.php?page=write` on a site with the Write editor enabled
* Verify the event fires with `is_new_post: true`, `source: direct`, and no `post_id`
* Navigate to `/wp-admin/admin.php?page=write&post=123` with a valid post ID
* Verify the event fires with `is_new_post: false`, `source: direct`, and `post_id: 123`

### Atomic sites

* Navigate to `/wp-admin/admin.php?page=write` on a site with the Write editor enabled
* Verify the event fires with `is_new_post: true`, `source: direct`, and no `post_id`
* Navigate to `/wp-admin/admin.php?page=write&post=123` with a valid post ID
* Verify the event fires with `is_new_post: false`, `source: direct`, and `post_id: 123`

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>