### PR TITLE
Write: Add Tracks event when a draft is successfully saved

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-write-editor-save-tracks-event
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-write-editor-save-tracks-event
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Add Tracks event wpcom_write_editor_draft_saved when a draft is successfully saved in the Write editor, with is_new_post property.
+Add Tracks event wpcom_write_editor_draft_saved when a draft is successfully saved in the Write editor, with is_new_post and post_id properties.

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-write-editor-save-tracks-event
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-write-editor-save-tracks-event
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add Tracks event wpcom_write_editor_draft_saved when a draft is successfully saved in the Write editor, with is_new_post property.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1796,6 +1796,13 @@ async function savePost( postStatus, isAutosave = false ) {
 			state.isSaving = false;
 			// Clear autosave reference — user explicitly saved.
 			localStorage.removeItem( AUTOSAVE_STORAGE_KEY );
+
+			window._tkq = window._tkq || [];
+			window._tkq.push( [
+				'recordEvent',
+				'wpcom_write_editor_draft_saved',
+				{ is_new_post: ! isEditing },
+			] );
 			setTimeout( () => {
 				state.message = '';
 			}, 2500 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1801,7 +1801,7 @@ async function savePost( postStatus, isAutosave = false ) {
 			window._tkq.push( [
 				'recordEvent',
 				'wpcom_write_editor_draft_saved',
-				{ is_new_post: ! isEditing },
+				{ is_new_post: ! isEditing, post_id: post.id },
 			] );
 			setTimeout( () => {
 				state.message = '';


### PR DESCRIPTION
Fixes RSM-1226

## Proposed changes

* Add `wpcom_write_editor_draft_saved` Tracks event that fires on successful draft save in the Write editor
* Includes `is_new_post` property to distinguish the first save of a new post from subsequent saves to an existing draft
* Includes `post_id` property with the saved post's ID

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

Yes — adds a new Tracks event `wpcom_write_editor_draft_saved` with two properties:
- `is_new_post` (bool): `true` on the first save of a new post, `false` on subsequent saves to an existing draft
- `post_id` (int): the post ID of the saved draft

## Testing instructions

* Go to a WordPress.com site with the Write editor enabled
* Navigate to `/wp-admin/admin.php?page=write`
* Add a title and some content, then click "Save draft"
* Verify the `wpcom_write_editor_draft_saved` event fires with `is_new_post: true` and a valid `post_id` in the Tracks debugger
* Click "Save draft" again on the same post
* Verify the event fires again with `is_new_post: false` and the same `post_id`