### PR TITLE
SSO: Show single sign-on login button on recovery-mode landing page

### DIFF
--- a/projects/packages/connection/changelog/fix-sso-button-on-recovery-mode-landing
+++ b/projects/packages/connection/changelog/fix-sso-button-on-recovery-mode-landing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+SSO: Show the "Log in with WordPress.com" button on the recovery mode landing page.

--- a/projects/packages/connection/changelog/fix-sso-button-on-recovery-mode-landing
+++ b/projects/packages/connection/changelog/fix-sso-button-on-recovery-mode-landing
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-SSO: Show the "Log in with WordPress.com" button on the recovery mode landing page.
+SSO: Render the single sign-on login button on the recovery mode landing page.

--- a/projects/packages/connection/src/sso/class-helpers.php
+++ b/projects/packages/connection/src/sso/class-helpers.php
@@ -268,6 +268,7 @@ class Helpers {
 				'login',
 				'jetpack-sso',
 				'jetpack_json_api_authorization',
+				'entered_recovery_mode',
 			)
 		);
 		return in_array( $action, $allowed_actions_for_sso, true );

--- a/projects/packages/connection/src/sso/class-sso.php
+++ b/projects/packages/connection/src/sso/class-sso.php
@@ -20,6 +20,7 @@ use Automattic\Jetpack\Status\Host;
 use Automattic\Jetpack\Tracking;
 use Jetpack_IXR_Client;
 use WP_Error;
+use WP_Recovery_Mode_Link_Service;
 use WP_User;
 use WP_User_Query;
 
@@ -531,6 +532,8 @@ class SSO {
 				exit( 0 );
 			}
 
+			$this->display_sso_login_form();
+		} elseif ( WP_Recovery_Mode_Link_Service::LOGIN_ACTION_ENTERED === $action ) {
 			$this->display_sso_login_form();
 		}
 	}

--- a/projects/packages/connection/src/sso/class-sso.php
+++ b/projects/packages/connection/src/sso/class-sso.php
@@ -297,14 +297,14 @@ class SSO {
 			 * The SSO module uses the method to display the default login form if we cannot find a user to log in via SSO.
 			 * But, the method could be filtered by a site admin to always show the default login form if that is preferred.
 			 */
-			$user_chose_sso_via_toggle = isset( $_GET['jetpack-sso-show-default-form'] ) && '0' === $_GET['jetpack-sso-show-default-form']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$show_sso_form = empty( $_GET['jetpack-sso-show-default-form'] ) && Helpers::show_sso_login(); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
-			// On the recovery landing, default to the wp-admin password form only when it's a working fallback. When it's hidden, fall through so the SSO panel auto-loads — the toggle isn't rendered to opt in manually.
-			$prefer_password_default_on_recovery = 'entered_recovery_mode' === $action && ! Helpers::should_hide_login_form();
-
-			$show_sso_form = $prefer_password_default_on_recovery
-				? $user_chose_sso_via_toggle
-				: ( empty( $_GET['jetpack-sso-show-default-form'] ) && Helpers::show_sso_login() ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			// Recovery mode is the break-glass fallback, so the wp-admin password form should be the default-visible option. Skip the override when that form is hidden, otherwise no login path would work.
+			if ( 'entered_recovery_mode' === $action
+				&& ! isset( $_GET['jetpack-sso-show-default-form'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				&& ! Helpers::should_hide_login_form() ) {
+				$show_sso_form = false;
+			}
 
 			if ( $show_sso_form ) {
 				$classes[] = 'jetpack-sso-form-display';
@@ -467,7 +467,7 @@ class SSO {
 		// And now the exceptions.
 		$action = isset( $_GET['loggedout'] ) ? 'loggedout' : $action; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
-		// Skip the SSO bypass-redirect on the recovery-mode landing page so the recovery notice stays visible and the wp-admin password fallback remains accessible.
+		// Recovery mode must complete on the local site (token validation, cookie, recovery notice). Skip the bypass-redirect so SSO doesn't carry the user off-site mid-recovery.
 		if ( 'entered_recovery_mode' === $action ) {
 			return false;
 		}

--- a/projects/packages/connection/src/sso/class-sso.php
+++ b/projects/packages/connection/src/sso/class-sso.php
@@ -20,7 +20,6 @@ use Automattic\Jetpack\Status\Host;
 use Automattic\Jetpack\Tracking;
 use Jetpack_IXR_Client;
 use WP_Error;
-use WP_Recovery_Mode_Link_Service;
 use WP_User;
 use WP_User_Query;
 
@@ -533,7 +532,7 @@ class SSO {
 			}
 
 			$this->display_sso_login_form();
-		} elseif ( WP_Recovery_Mode_Link_Service::LOGIN_ACTION_ENTERED === $action ) {
+		} elseif ( 'entered_recovery_mode' === $action ) {
 			$this->display_sso_login_form();
 		}
 	}

--- a/projects/packages/connection/src/sso/class-sso.php
+++ b/projects/packages/connection/src/sso/class-sso.php
@@ -287,7 +287,7 @@ class SSO {
 		// Always add the jetpack-sso class so that we can add SSO specific styling even when the SSO form isn't being displayed.
 		$classes[] = 'jetpack-sso';
 
-		if ( ! ( new Status() )->in_safe_mode() ) {
+		if ( ! ( new Status() )->in_safe_mode() && 'entered_recovery_mode' !== $action ) {
 			/**
 			 * Should we show the SSO login form?
 			 *
@@ -458,6 +458,11 @@ class SSO {
 		// And now the exceptions.
 		$action = isset( $_GET['loggedout'] ) ? 'loggedout' : $action; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
+		// Don't bypass to WordPress.com from the recovery-mode landing page; the user needs to see the recovery notice and have access to the wp-admin password fallback.
+		if ( 'entered_recovery_mode' === $action ) {
+			return false;
+		}
+
 		if ( Helpers::display_sso_form_for_action( $action ) ) {
 			$wants_to_login = true;
 		}
@@ -531,8 +536,6 @@ class SSO {
 				exit( 0 );
 			}
 
-			$this->display_sso_login_form();
-		} elseif ( 'entered_recovery_mode' === $action ) {
 			$this->display_sso_login_form();
 		}
 	}

--- a/projects/packages/connection/src/sso/class-sso.php
+++ b/projects/packages/connection/src/sso/class-sso.php
@@ -287,7 +287,7 @@ class SSO {
 		// Always add the jetpack-sso class so that we can add SSO specific styling even when the SSO form isn't being displayed.
 		$classes[] = 'jetpack-sso';
 
-		if ( ! ( new Status() )->in_safe_mode() && 'entered_recovery_mode' !== $action ) {
+		if ( ! ( new Status() )->in_safe_mode() ) {
 			/**
 			 * Should we show the SSO login form?
 			 *
@@ -297,7 +297,14 @@ class SSO {
 			 * The SSO module uses the method to display the default login form if we cannot find a user to log in via SSO.
 			 * But, the method could be filtered by a site admin to always show the default login form if that is preferred.
 			 */
-			if ( empty( $_GET['jetpack-sso-show-default-form'] ) && Helpers::show_sso_login() ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$user_chose_sso_via_toggle = isset( $_GET['jetpack-sso-show-default-form'] ) && '0' === $_GET['jetpack-sso-show-default-form']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+			if ( 'entered_recovery_mode' === $action ) {
+				// On the recovery-mode landing the wp-admin password form is the recovery fallback. Only show the SSO panel when the user explicitly opts in via the toggle, and honor that opt-in regardless of show_sso_login() so the no-JS fallback always works.
+				if ( $user_chose_sso_via_toggle ) {
+					$classes[] = 'jetpack-sso-form-display';
+				}
+			} elseif ( empty( $_GET['jetpack-sso-show-default-form'] ) && Helpers::show_sso_login() ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				$classes[] = 'jetpack-sso-form-display';
 			}
 		}

--- a/projects/packages/connection/src/sso/class-sso.php
+++ b/projects/packages/connection/src/sso/class-sso.php
@@ -299,12 +299,12 @@ class SSO {
 			 */
 			$user_chose_sso_via_toggle = isset( $_GET['jetpack-sso-show-default-form'] ) && '0' === $_GET['jetpack-sso-show-default-form']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
-			if ( 'entered_recovery_mode' === $action ) {
-				// On the recovery-mode landing the wp-admin password form is the recovery fallback. Only show the SSO panel when the user explicitly opts in via the toggle, and honor that opt-in regardless of show_sso_login() so the no-JS fallback always works.
-				if ( $user_chose_sso_via_toggle ) {
-					$classes[] = 'jetpack-sso-form-display';
-				}
-			} elseif ( empty( $_GET['jetpack-sso-show-default-form'] ) && Helpers::show_sso_login() ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			// On the recovery-mode landing the wp-admin password form is the recovery fallback, so only show the SSO panel when the user explicitly opts in via the toggle.
+			$show_sso_form = 'entered_recovery_mode' === $action
+				? $user_chose_sso_via_toggle
+				: ( empty( $_GET['jetpack-sso-show-default-form'] ) && Helpers::show_sso_login() ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+			if ( $show_sso_form ) {
 				$classes[] = 'jetpack-sso-form-display';
 			}
 		}
@@ -465,7 +465,7 @@ class SSO {
 		// And now the exceptions.
 		$action = isset( $_GET['loggedout'] ) ? 'loggedout' : $action; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
-		// Don't bypass to WordPress.com from the recovery-mode landing page; the user needs to see the recovery notice and have access to the wp-admin password fallback.
+		// Skip the SSO bypass-redirect on the recovery-mode landing page so the recovery notice stays visible and the wp-admin password fallback remains accessible.
 		if ( 'entered_recovery_mode' === $action ) {
 			return false;
 		}

--- a/projects/packages/connection/src/sso/class-sso.php
+++ b/projects/packages/connection/src/sso/class-sso.php
@@ -299,8 +299,10 @@ class SSO {
 			 */
 			$user_chose_sso_via_toggle = isset( $_GET['jetpack-sso-show-default-form'] ) && '0' === $_GET['jetpack-sso-show-default-form']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
-			// On the recovery-mode landing the wp-admin password form is the recovery fallback, so only show the SSO panel when the user explicitly opts in via the toggle.
-			$show_sso_form = 'entered_recovery_mode' === $action
+			// On the recovery landing, default to the wp-admin password form only when it's a working fallback. When it's hidden, fall through so the SSO panel auto-loads — the toggle isn't rendered to opt in manually.
+			$prefer_password_default_on_recovery = 'entered_recovery_mode' === $action && ! Helpers::should_hide_login_form();
+
+			$show_sso_form = $prefer_password_default_on_recovery
 				? $user_chose_sso_via_toggle
 				: ( empty( $_GET['jetpack-sso-show-default-form'] ) && Helpers::show_sso_login() ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 

--- a/projects/packages/connection/src/sso/class-sso.php
+++ b/projects/packages/connection/src/sso/class-sso.php
@@ -297,13 +297,17 @@ class SSO {
 			 * The SSO module uses the method to display the default login form if we cannot find a user to log in via SSO.
 			 * But, the method could be filtered by a site admin to always show the default login form if that is preferred.
 			 */
-			$show_sso_form = empty( $_GET['jetpack-sso-show-default-form'] ) && Helpers::show_sso_login(); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$default_form_preference = isset( $_GET['jetpack-sso-show-default-form'] ) ? sanitize_text_field( wp_unslash( $_GET['jetpack-sso-show-default-form'] ) ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$show_sso_form           = empty( $default_form_preference ) && Helpers::show_sso_login();
 
-			// Recovery mode is the break-glass fallback, so the wp-admin password form should be the default-visible option. Skip the override when that form is hidden, otherwise no login path would work.
-			if ( 'entered_recovery_mode' === $action
-				&& ! isset( $_GET['jetpack-sso-show-default-form'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-				&& ! Helpers::should_hide_login_form() ) {
-				$show_sso_form = false;
+			if ( 'entered_recovery_mode' === $action ) {
+				if ( '0' === $default_form_preference ) {
+					// Explicit user opt-in via the no-JS toggle; honor it regardless of show_sso_login() so the toggle always works.
+					$show_sso_form = true;
+				} elseif ( null === $default_form_preference && ! Helpers::should_hide_login_form() ) {
+					// Recovery is the break-glass fallback, so default to the wp-admin password form. Skip when that form is hidden, otherwise no login path would work.
+					$show_sso_form = false;
+				}
 			}
 
 			if ( $show_sso_form ) {


### PR DESCRIPTION
Fixes #

## Proposed changes

When a site admin enters WordPress recovery mode by clicking the email link, they end up on `wp-login.php?action=entered_recovery_mode`. Until now, Jetpack SSO did not render its login button on that page, leaving only the wp-admin password form. This PR makes SSO available there as well, while keeping the wp-admin password form as the default-visible option (recovery mode is the break-glass fallback).

The fix is three coordinated changes in `projects/packages/connection/src/sso/`:

* **`Helpers::display_sso_form_for_action()`** — added `'entered_recovery_mode'` to the default `jetpack_sso_allowed_actions` array. This is what gates `login_enqueue_scripts` and `login_body_class`, so adding the action lets the SSO JS and CSS load and the toggle UI works on the recovery landing.
* **`SSO::wants_to_login()`** — early `return false` for the recovery-mode action. Without this, sites with `jetpack_sso_bypass_login_forward_wpcom` enabled would auto-redirect users straight to the SSO destination, carrying them off-site mid-recovery before WP's recovery notice is shown.
* **`SSO::login_body_class()`** — on the recovery action, override the default `jetpack-sso-form-display` class assignment:
  * If the user explicitly clicked the "Log in with WordPress.com" toggle (`?jetpack-sso-show-default-form=0`), force the SSO panel on regardless of `Helpers::show_sso_login()` — so the no-JS toggle works on sites that filter `jetpack_sso_default_to_sso_login` to `false`.
  * If there's no preference param, default to the wp-admin password form. Skip this override when the password form is hidden (`jetpack_sso_remove_login_form` sites), otherwise no login path would work.
  * Non-recovery actions: original semantics preserved.

### Why the symptom appeared inconsistent (first click vs second click)

* **First click** of the email link: `WP_Recovery_Mode::run()` finds no cookie, calls `link_service->handle_begin_link()`, which validates the token, sets the recovery-mode cookie, and redirects to `?action=entered_recovery_mode`. Before this PR, that action wasn't in the SSO allow-list, so the SSO button was suppressed.
* **Second click** of the same URL: the cookie is already set, `handle_begin_link()` is never called, no redirect happens, and `wp-login.php` coerces the unrecognized `enter_recovery_mode` action to `login` (which SSO does allow). That's why the second click appeared to work — the `entered_recovery_mode` page was never re-reached.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Set up a Jetpack-connected site with SSO enabled.
2. Trigger a fatal error to generate a real recovery-mode email (or manually create a recovery key via `WP_Recovery_Mode_Email_Service::generate_recovery_mode_email_login_token()`).
3. Click the recovery-mode link from the email — `wp-login.php?action=enter_recovery_mode&rm_token=…&rm_key=…`.
4. You should be redirected to `wp-login.php?action=entered_recovery_mode`.
5. **Expected default state:** the recovery-mode notice is shown, the wp-admin password form is visible by default, and the SSO toggle/button is available below it.
6. Confirm the wp-admin password form still works as the recovery-mode fallback path.
7. Click the SSO toggle and confirm the SSO login flow starts and signs you in successfully.
8. With JavaScript disabled, repeat step 7 — clicking the toggle should reload the page with `?jetpack-sso-show-default-form=0` and reveal the SSO panel.
9. Filter regression: on a site with `jetpack_sso_default_to_sso_login` filtered to `false`, the no-JS toggle (step 8) must still work.
10. Filter regression: on a site with `jetpack_sso_remove_login_form` enabled (password form hidden), the recovery landing should auto-show the SSO panel — there's no other working login path.
11. Filter regression: on a site with `jetpack_sso_bypass_login_forward_wpcom` enabled, the recovery landing should still render the page with the recovery notice (no auto-redirect off-site).
12. Filter regression: a site that filters `jetpack_sso_allowed_actions` to remove `entered_recovery_mode` should see the original password-only recovery landing.
13. As a baseline regression check, log in via SSO normally on `wp-login.php?action=login` and confirm behavior is unchanged.
