### PR TITLE
Claude Code: skip review on AGENTS.md/CLAUDE.md edits

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,13 +39,17 @@ jobs:
       # them so the bot doesn't review under guidance the PR itself is modifying.
       - name: Skip on AGENTS.md/CLAUDE.md edits
         id: trusted_files
-        if: github.event.issue.pull_request != null || github.event_name == 'pull_request_review_comment' || github.event_name == 'pull_request_review'
         env:
           GH_TOKEN: ${{ github.token }}
+          HAS_PR: ${{ github.event.issue.pull_request != null || github.event_name == 'pull_request_review_comment' || github.event_name == 'pull_request_review' }}
           PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          if [ "$HAS_PR" != "true" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           FILES=$(gh pr diff "$PR_NUMBER" --repo "$REPO" --name-only)
           if echo "$FILES" | grep -qiE '(^|/)(AGENTS|CLAUDE)\.md$'; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -64,7 +68,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        if: steps.trusted_files.outputs.skip != 'true'
+        if: steps.trusted_files.outputs.skip == 'false'
         uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,38 +37,29 @@ jobs:
     steps:
       # AGENTS.md / CLAUDE.md are bot instructions; skip review if a PR edits
       # them so the bot doesn't review under guidance the PR itself is modifying.
+      # Only runs in PR contexts; issue triggers fall through.
       - name: Skip on AGENTS.md/CLAUDE.md edits
-        id: trusted_files
+        if: github.event.issue.pull_request != null || github.event_name == 'pull_request_review_comment' || github.event_name == 'pull_request_review'
         env:
           GH_TOKEN: ${{ github.token }}
-          HAS_PR: ${{ github.event.issue.pull_request != null || github.event_name == 'pull_request_review_comment' || github.event_name == 'pull_request_review' }}
           PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          if [ "$HAS_PR" != "true" ]; then
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
           FILES=$(gh pr diff "$PR_NUMBER" --repo "$REPO" --name-only)
           if echo "$FILES" | grep -qiE '(^|/)(AGENTS|CLAUDE)\.md$'; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
             gh pr comment "$PR_NUMBER" --repo "$REPO" --body \
               "AI review skipped: this PR modifies \`AGENTS.md\` or \`CLAUDE.md\` files, which the review bot reads as instructions. Edits to these files require human review."
             exit 1
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
-          persist-credentials: false
 
       - name: Run Claude Code
         id: claude
-        if: steps.trusted_files.outputs.skip == 'false'
         uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,13 +35,36 @@ jobs:
       actions: read
       id-token: write
     steps:
+      # AGENTS.md / CLAUDE.md are bot instructions; skip review if a PR edits
+      # them so the bot doesn't review under guidance the PR itself is modifying.
+      - name: Skip on AGENTS.md/CLAUDE.md edits
+        id: trusted_files
+        if: github.event.issue.pull_request != null || github.event_name == 'pull_request_review_comment' || github.event_name == 'pull_request_review'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          FILES=$(gh pr diff "$PR_NUMBER" --repo "$REPO" --name-only)
+          if echo "$FILES" | grep -qiE '(^|/)(AGENTS|CLAUDE)\.md$'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body \
+              "AI review skipped: this PR modifies \`AGENTS.md\` or \`CLAUDE.md\` files, which the review bot reads as instructions. Edits to these files require human review."
+            exit 1
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code
         id: claude
+        if: steps.trusted_files.outputs.skip != 'true'
         uses: anthropics/claude-code-action@df37d2f0760a4b5683a6e617c9325bc1a36443f6 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
Hi @anomiex @tbradsha, I'm opening this PR with a few learnings from Calypso and Woo AI Code Review hardening, for your consideration as a follow-up to #47665. 

## Proposed changes

* Skip review when a PR modifies any `AGENTS.md` or `CLAUDE.md` file. Posts a comment and fails the workflow.
  * The action's [`restoreConfigFromBase`](https://github.com/anthropics/claude-code-action/blob/main/src/github/operations/restore-config.ts) covers only root `CLAUDE.md` and `.claude/`. `AGENTS.md` and nested `CLAUDE.md` are outside its `SENSITIVE_PATHS` list.
  * Anthropic's OIDC token exchange [validates the workflow file matches the default branch](https://github.com/anthropics/claude-code-action/issues/443#issuecomment-3181136976) - protecting `claude.yml` from PR-side modification - but does not protect `AGENTS.md`.
  * Realistic vector: a contributor adds a tweak to `AGENTS.md` alongside their PR; a member skims and says `@claude`; [`setupBranch` checks out PR head](https://github.com/anthropics/claude-code-action/blob/11a9dadd198803a0cea6bd53da3e0e8a762fc6ea/src/github/operations/branch.ts#L184-L188); the bot reads the contributor's modified instructions.
  * The existing MEMBER/OWNER gate guards the trigger, but not the content.

* SHA-pin `actions/checkout@v6` → `de0fac2e…` (v6.0.2). Mirrors the SHA-pin Kraft already applied to the claude code action. Hardens against supply-chain issues.

* Add `persist-credentials: false` on the checkout step.
  * By default, [`actions/checkout` writes the workflow `GITHUB_TOKEN` into `.git/config`](https://github.com/actions/checkout/blob/main/action.yml#L52-L54) so later git commands can authenticate. With this flag, the token is used during fetch and then discarded.
  * The bot's typical review path (`gh pr diff/view`, `git diff/log/show`) doesn't touch the persisted token, but this will require testing.

The same patterns were shipped on [`wp-calypso#110238`](https://github.com/Automattic/wp-calypso/pull/110238) and [`woocommerce/.github#18`](https://github.com/woocommerce/.github/pull/18) and confirmed to be working.

## Related product discussion/links

* Follow-up to #47665 (JETPACK-1443).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Workflow changes can't be exercised on the modifying PR (OIDC). After merge, verify on follow-ups:

* PR modifying any `AGENTS.md` / `CLAUDE.md`, then `@claude` it. Expected: skip comment posted, Claude Code check fails, bot does not run.
* PR not modifying those files, then `@claude` it. Expected: bot runs normally.
* `@claude` on an issue: unaffected (skip step is gated to PR contexts).
