### PR TITLE
Omnibar: don't send response buffer from the admin-bar endpoint

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-bar.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-bar.php
@@ -100,7 +100,10 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Bar extends WP_REST_Controller {
 
 		add_filter( 'show_admin_bar', '__return_true', 999 );
 		_wp_admin_bar_init();
+
+		ob_start();
 		do_action_ref_array( 'admin_bar_menu', array( &$wp_admin_bar ) );
+		ob_clean();
 
 		$nodes          = $wp_admin_bar->get_nodes() ?? array();
 		$filtered_nodes = $this->filter_nodes( $nodes, self::ALLOWED_TOP_LEVEL_NODES );

--- a/projects/plugins/jetpack/changelog/omnibar-admin-bar-endpoint-clean
+++ b/projects/plugins/jetpack/changelog/omnibar-admin-bar-endpoint-clean
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Omnibar: don't send response buffer from the admin-bar endpoint


### PR DESCRIPTION
## Proposed changes

The `wpcom/v2/admin-bar` endpoint sometimes crashes because some plugin might send JS output in the `admin_bar_menu` hooks.

This PR strips the output from the REST endpoint.

## Related product discussion/links

See: https://wp.me/phcsdm-ED#comment-1267

## Does this pull request change what data or activity we track or use?

No
