### PR TITLE
Admin bar: keep wp-logo node id instead of wpcom-logo

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/omnibar-wpcom-logo-node
+++ b/projects/packages/jetpack-mu-wpcom/changelog/omnibar-wpcom-logo-node
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Admin bar: keep wp-logo node id instead of wpcom-logo

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -162,21 +162,21 @@ function wpcom_replace_wp_logo_with_wpcom_logo_menu( $wp_admin_bar ) {
 	$wp_admin_bar->remove_node( 'wp-logo' );
 	$wp_admin_bar->add_node(
 		array(
-			'id'    => 'wpcom-logo',
+			'id'    => 'wp-logo',
 			'title' => '<span class="ab-icon" aria-hidden="true"></span><span class="screen-reader-text">' .
 						/* translators: Hidden accessibility text. */
-						__( 'All Sites', 'jetpack-mu-wpcom' ) .
+						'WordPress.com' .
 						'</span>',
 			'href'  => add_origin_admin_bar_to_url( Urls::maybe_add_origin_site_id( 'https://wordpress.com/sites' ) ),
 			'meta'  => array(
-				'menu_title' => __( 'All Sites', 'jetpack-mu-wpcom' ),
+				'menu_title' => 'WordPress.com',
 			),
 		)
 	);
 
 	$wp_admin_bar->add_node(
 		array(
-			'parent' => 'wpcom-logo',
+			'parent' => 'wp-logo',
 			'id'     => 'wpcom-sites',
 			'title'  => __( 'Sites', 'jetpack-mu-wpcom' ),
 			'href'   => add_origin_admin_bar_to_url( Urls::maybe_add_origin_site_id( 'https://wordpress.com/sites' ) ),
@@ -185,7 +185,7 @@ function wpcom_replace_wp_logo_with_wpcom_logo_menu( $wp_admin_bar ) {
 
 	$wp_admin_bar->add_node(
 		array(
-			'parent' => 'wpcom-logo',
+			'parent' => 'wp-logo',
 			'id'     => 'wpcom-domains',
 			'title'  => __( 'Domains', 'jetpack-mu-wpcom' ),
 			'href'   => add_origin_admin_bar_to_url( Urls::maybe_add_origin_site_id( 'https://wordpress.com/domains/manage' ) ),
@@ -195,8 +195,8 @@ function wpcom_replace_wp_logo_with_wpcom_logo_menu( $wp_admin_bar ) {
 	if ( ! ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
 		$wp_admin_bar->add_group(
 			array(
-				'parent' => 'wpcom-logo',
-				'id'     => 'wpcom-logo-external',
+				'parent' => 'wp-logo',
+				'id'     => 'wp-logo-external',
 				'meta'   => array(
 					'class' => 'ab-sub-secondary',
 				),
@@ -204,11 +204,11 @@ function wpcom_replace_wp_logo_with_wpcom_logo_menu( $wp_admin_bar ) {
 		);
 
 		if ( $about_node ) {
-			$about_node->parent = 'wpcom-logo-external';
+			$about_node->parent = 'wp-logo-external';
 			$wp_admin_bar->add_node( (array) $about_node );
 		}
 		if ( $contribute_node ) {
-			$contribute_node->parent = 'wpcom-logo-external';
+			$contribute_node->parent = 'wp-logo-external';
 			$wp_admin_bar->add_node( (array) $contribute_node );
 		}
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -12,10 +12,14 @@
 }
 
 /**
- * Always shows WP logo (All Sites)
+ * Always shows WordPress.com logo
  */
-#wpadminbar li#wp-admin-bar-wpcom-logo {
+#wpadminbar li#wp-admin-bar-wp-logo {
 	display: block !important;
+
+	> .ab-item .ab-icon {
+		width: 20px;
+	}
 }
 
 /**
@@ -49,7 +53,7 @@
 /**
  * WP logo menu
  */
-#wpadminbar #wp-admin-bar-wpcom-logo > .ab-item {
+#wpadminbar #wp-admin-bar-wp-logo > .ab-item {
 	padding: 0 10px;
 
 	@media (max-width: 782px) {
@@ -57,7 +61,7 @@
 	}
 }
 
-#wpadminbar #wp-admin-bar-wpcom-logo > .ab-item .ab-icon {
+#wpadminbar #wp-admin-bar-wp-logo > .ab-item .ab-icon {
 	margin-right: 0 !important;
 
 	@media (max-width: 480px) {
@@ -65,7 +69,7 @@
 	}
 }
 
-#wpadminbar #wp-admin-bar-wpcom-logo > .ab-item .ab-icon::before {
+#wpadminbar #wp-admin-bar-wp-logo > .ab-item .ab-icon::before {
 	display: flex;
 	content: "";
 	width: 20px;
@@ -87,7 +91,7 @@
 
 }
 
-#wpadminbar #wp-admin-bar-wpcom-logo:not(:first-child) {
+#wpadminbar #wp-admin-bar-wp-logo:not(:first-child) {
 	// Site admin on mobile viewport (the first child is the hamburger menu)
 	@media (max-width: 480px) {
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-bar/WPCOM_Admin_Bar_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-bar/WPCOM_Admin_Bar_Test.php
@@ -76,13 +76,6 @@ class WPCOM_Admin_Bar_Test extends \WorDBless\BaseTestCase {
 		return $result;
 	}
 
-	public function test_wp_logo_replaced_by_wpcom_logo() {
-		$admin_bar = self::make_test_admin_bar();
-
-		$this->assertNull( $admin_bar->get_node( 'wp-logo' ) );
-		$this->assertNotNull( $admin_bar->get_node( 'wpcom-logo' ) );
-	}
-
 	public function test_origin_admin_bar_param_in_menu_links() {
 		$admin_bar = self::make_test_admin_bar();
 


### PR DESCRIPTION
## Proposed changes

In WordPress.com site's admin bar, keep using the `wp-logo` node id, instead of `wpcom-logo`.

This is important because we have whitelist of the allowed nodes from the `wpcom/v2/admin-bar` endpoint, used to render the omnibar.

## Related product discussion/links
phcsdm-ED-p2#comment-1267

## Does this pull request change what data or activity we track or use?

No