### PR TITLE
CRM: fix week 53 appearing at end of dashboard contact chart

### DIFF
--- a/projects/plugins/crm/admin/dashboard/dashboard.ajax.php
+++ b/projects/plugins/crm/admin/dashboard/dashboard.ajax.php
@@ -99,7 +99,7 @@ function jetpackcrm_dash_refresh() {
 	}
 
 	foreach ( $weekly as $v ) {
-		$yearweek = (string) $v->yearweek; $the_week = substr( $yearweek, 0, 4 ) . ' W' . substr( $yearweek, 4, 2 );
+		$yearweek = str_pad( (int) $v->yearweek, 6, '0', STR_PAD_LEFT ); $the_week = substr( $yearweek, 0, 4 ) . ' W' . substr( $yearweek, 4, 2 );
 		$zeros['week'][ $the_week ] = $v->count;
 	}
 

--- a/projects/plugins/crm/admin/dashboard/dashboard.ajax.php
+++ b/projects/plugins/crm/admin/dashboard/dashboard.ajax.php
@@ -79,7 +79,7 @@ function jetpackcrm_dash_refresh() {
 	$sql     = $wpdb->prepare( 'SELECT count(ID) as count, MONTH(FROM_UNIXTIME(zbsc_created)) as month, YEAR(FROM_UNIXTIME(zbsc_created)) as year FROM ' . $ZBSCRM_t['contacts'] . ' WHERE zbsc_created > %d AND zbsc_created < %d GROUP BY month, year ORDER BY year, month', $start_date, $end_date ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	$monthly = $wpdb->get_results( $sql );
 
-	$sql    = $wpdb->prepare( 'SELECT count(ID) as count, WEEK(FROM_UNIXTIME(zbsc_created), 1) as week, YEAR(FROM_UNIXTIME(zbsc_created)) as year FROM ' . $ZBSCRM_t['contacts'] . ' WHERE zbsc_created > %d AND zbsc_created < %d GROUP BY week, year ORDER BY year, week', $start_date, $end_date ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+	$sql    = $wpdb->prepare( 'SELECT count(ID) as count, YEARWEEK(FROM_UNIXTIME(zbsc_created), 1) as yearweek FROM ' . $ZBSCRM_t['contacts'] . ' WHERE zbsc_created > %d AND zbsc_created < %d GROUP BY yearweek ORDER BY yearweek', $start_date, $end_date ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 	$weekly = $wpdb->get_results( $sql );
 
 	$sql   = $wpdb->prepare( 'SELECT count(ID) as count, DAY(FROM_UNIXTIME(zbsc_created)) as day, MONTH(FROM_UNIXTIME(zbsc_created)) as month, YEAR(FROM_UNIXTIME(zbsc_created)) as year FROM ' . $ZBSCRM_t['contacts'] . ' WHERE zbsc_created > %d AND zbsc_created < %d GROUP BY day, month, year ORDER BY year, month, day', $start_date, $end_date ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
@@ -99,7 +99,7 @@ function jetpackcrm_dash_refresh() {
 	}
 
 	foreach ( $weekly as $v ) {
-		$the_week                   = str_pad( $v->week, 2, '0', STR_PAD_LEFT ) . ' ' . $v->year;
+		$yearweek = (string) $v->yearweek; $the_week = substr( $yearweek, 0, 4 ) . ' W' . substr( $yearweek, 4, 2 );
 		$zeros['week'][ $the_week ] = $v->count;
 	}
 

--- a/projects/plugins/crm/admin/dashboard/dashboard.ajax.php
+++ b/projects/plugins/crm/admin/dashboard/dashboard.ajax.php
@@ -99,8 +99,8 @@ function jetpackcrm_dash_refresh() {
 	}
 
 	foreach ( $weekly as $v ) {
-		$yearweek = str_pad( (int) $v->yearweek, 6, '0', STR_PAD_LEFT );
-		$the_week = substr( $yearweek, 0, 4 ) . ' W' . substr( $yearweek, 4, 2 );
+		$yearweek                   = str_pad( $v->yearweek, 6, '0', STR_PAD_LEFT );
+		$the_week                   = substr( $yearweek, 0, 4 ) . ' W' . substr( $yearweek, 4, 2 );
 		$zeros['week'][ $the_week ] = $v->count;
 	}
 

--- a/projects/plugins/crm/admin/dashboard/dashboard.ajax.php
+++ b/projects/plugins/crm/admin/dashboard/dashboard.ajax.php
@@ -99,7 +99,8 @@ function jetpackcrm_dash_refresh() {
 	}
 
 	foreach ( $weekly as $v ) {
-		$yearweek = str_pad( (int) $v->yearweek, 6, '0', STR_PAD_LEFT ); $the_week = substr( $yearweek, 0, 4 ) . ' W' . substr( $yearweek, 4, 2 );
+		$yearweek = str_pad( (int) $v->yearweek, 6, '0', STR_PAD_LEFT );
+		$the_week = substr( $yearweek, 0, 4 ) . ' W' . substr( $yearweek, 4, 2 );
 		$zeros['week'][ $the_week ] = $v->count;
 	}
 

--- a/projects/plugins/crm/changelog/fix-crm-dashboard-week-53-year
+++ b/projects/plugins/crm/changelog/fix-crm-dashboard-week-53-year
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+CRM: Fix week 53 appearing at end of dashboard contact chart when using weekly view.

--- a/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
@@ -1497,7 +1497,7 @@ function jetpackcrm_create_zeros_array( $start, $end, $zbs_steps = 86400 ) {
 		$the_month                    = date( 'M y', $the_day );
 		$filled_zeros_m[ $the_month ] = 0;
 
-		$the_week                    = date( 'W Y', $the_day );
+		$the_week = date( 'Y', $the_day ) . ' W' . date( 'W', $the_day );
 		$filled_zeros_w[ $the_week ] = 0;
 
 		$the_day_d                    = date( 'd M y', $the_day );

--- a/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
@@ -1491,16 +1491,16 @@ function jetpackcrm_create_zeros_array( $start, $end, $zbs_steps = 86400 ) {
 
 	$the_day = $start;
 	while ( $the_day <= $end ) {
-		$the_year                    = date( 'Y', $the_day );
+		$the_year                    = gmdate( 'Y', $the_day );
 		$filled_zeros_y[ $the_year ] = 0;
 
-		$the_month                    = date( 'M y', $the_day );
+		$the_month                    = gmdate( 'M y', $the_day );
 		$filled_zeros_m[ $the_month ] = 0;
 
-		$the_week                    = date( 'o', $the_day ) . ' W' . date( 'W', $the_day );
+		$the_week                    = gmdate( 'o', $the_day ) . ' W' . gmdate( 'W', $the_day );
 		$filled_zeros_w[ $the_week ] = 0;
 
-		$the_day_d                    = date( 'd M y', $the_day );
+		$the_day_d                    = gmdate( 'd M y', $the_day );
 		$filled_zeros_d[ $the_day_d ] = 0;
 
 		$the_day += $zbs_steps;

--- a/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
@@ -1497,7 +1497,7 @@ function jetpackcrm_create_zeros_array( $start, $end, $zbs_steps = 86400 ) {
 		$the_month                    = date( 'M y', $the_day );
 		$filled_zeros_m[ $the_month ] = 0;
 
-		$the_week = date( 'Y', $the_day ) . ' W' . date( 'W', $the_day );
+		$the_week = date( 'o', $the_day ) . ' W' . date( 'W', $the_day );
 		$filled_zeros_w[ $the_week ] = 0;
 
 		$the_day_d                    = date( 'd M y', $the_day );

--- a/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
@@ -7,7 +7,7 @@
  * Copyright 2020 Automattic
  *
  * Date: 01/11/16
- */
+ */15
 
 defined( 'ZEROBSCRM_PATH' ) || exit( 0 );
 
@@ -1497,7 +1497,7 @@ function jetpackcrm_create_zeros_array( $start, $end, $zbs_steps = 86400 ) {
 		$the_month                    = date( 'M y', $the_day );
 		$filled_zeros_m[ $the_month ] = 0;
 
-		$the_week = date( 'o', $the_day ) . ' W' . date( 'W', $the_day );
+		$the_week                    = date( 'o', $the_day ) . ' W' . date( 'W', $the_day );
 		$filled_zeros_w[ $the_week ] = 0;
 
 		$the_day_d                    = date( 'd M y', $the_day );

--- a/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.GeneralFuncs.php
@@ -7,7 +7,7 @@
  * Copyright 2020 Automattic
  *
  * Date: 01/11/16
- */15
+ */
 
 defined( 'ZEROBSCRM_PATH' ) || exit( 0 );
 


### PR DESCRIPTION
Hey, I was looking through the open issues and came across #45250. Took a look at the code and found the root cause — wanted to submit a fix.

## What was happening

The weekly contacts chart was placing Week 53 of 2024 at the very end of the chart instead of its correct chronological position.

## Why

Two mismatched date formats were causing the issue:

1. The SQL query used `WEEK(..., 1)` + `YEAR()` — `YEAR()` returns the calendar year (2025) for dates like Jan 1 2025, while the ISO week number is still 53 of 2024. This mismatch caused Week 53 to be appended at the end.

2. The zeros array skeleton in PHP used `date('Y')` (calendar year) combined with `date('W')` (ISO week number). For Jan 1 2025, this produced the key `2025 W53`, while the SQL data produced `2024 W53` — so they never matched.

## What I changed

- Replaced `WEEK() + YEAR()` with `YEARWEEK(..., 1)` in the SQL query, which returns a single ISO-correct value like `202453`.
- Updated `dashboard.ajax.php` to parse year and week from the `YEARWEEK` result.
- Updated `ZeroBSCRM.GeneralFuncs.php` to use `date('o')` instead of `date('Y')`. `date('o')` returns the ISO week-numbering year, so `date('o') . ' W' . date('W')` correctly produces `2024 W53` for Jan 1 2025.

## Testing instructions

* Install Jetpack CRM and add contacts spread across late December 2024 and early January 2025.
* Go to the CRM Dashboard and switch the contact chart to weekly view.
* Before this fix: Week 53 of 2024 appears at the very end of the chart out of order.
* After this fix: Week 53 appears in its correct chronological position.

## Does this pull request change what data or activity we track or use?

No, this PR only fixes the SQL query and PHP label generation for the weekly chart. No changes to data collection or privacy.

Fixes #45250