### PR TITLE
Admin bar: keep wp-logo node id instead of wpcom-logo (pt 2)

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/omnibar-wpcom-logo-node
+++ b/projects/packages/jetpack-mu-wpcom/changelog/omnibar-wpcom-logo-node
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Admin bar: keep wp-logo node id instead of wpcom-logo
+Admin bar: keep the id of the top-left node to be `wp-logo`, instead of `wpcom-logo`

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -18,7 +18,7 @@
 	display: block !important;
 
 	> .ab-item .ab-icon {
-		width: 20px;
+		width: revert;
 	}
 }
 


### PR DESCRIPTION
## Proposed changes

Continuation of https://github.com/Automattic/jetpack/pull/48343 -- fixing a broken CSS related to the logo.
