### PR TITLE
Blaze: add MCP-exposed prepare-campaign write ability (ADS-953)

### DIFF
--- a/projects/packages/blaze/changelog/add-ads-953-blaze-create-campaign
+++ b/projects/packages/blaze/changelog/add-ads-953-blaze-create-campaign
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Blaze: register a `blaze-ads/create-campaign` write ability with cross-cutting guardrails (TOS, spend ceiling, audit log) applied via a registration-time wrapper. Returns a draft campaign reference plus a deep-link to the Blaze widget for merchant approval.

--- a/projects/packages/blaze/changelog/add-ads-953-blaze-create-campaign
+++ b/projects/packages/blaze/changelog/add-ads-953-blaze-create-campaign
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Blaze: register a `blaze-ads/create-campaign` write ability with cross-cutting guardrails (TOS, spend ceiling, audit log) applied via a registration-time wrapper. Returns a draft campaign reference plus a deep-link to the Blaze widget for merchant approval.

--- a/projects/packages/blaze/changelog/add-ads-953-blaze-prepare-campaign
+++ b/projects/packages/blaze/changelog/add-ads-953-blaze-prepare-campaign
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Blaze: register a `blaze-ads/prepare-campaign` write ability with cross-cutting guardrails (TOS, spend ceiling, audit log) applied via a registration-time wrapper. Returns a prepared campaign proposal plus a deep-link to the Blaze widget for merchant approval.

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -21,18 +21,28 @@
 
 namespace Automattic\Jetpack\Blaze\Abilities;
 
+use Automattic\Jetpack\Blaze;
 use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
 use Automattic\Jetpack\WP_Abilities\Registrar;
 use WP_REST_Request;
 
 /**
- * Registers the `blaze-ads` category and the `blaze-ads/list-campaigns`
- * ability, and opts the ability into WooCommerce's MCP server.
+ * Registers the `blaze-ads` category and the Blaze abilities, and opts
+ * each ability into WooCommerce's MCP server.
  */
 class Blaze_Abilities extends Registrar {
 
-	const CATEGORY_SLUG          = 'blaze-ads';
-	const ABILITY_LIST_CAMPAIGNS = 'blaze-ads/list-campaigns';
+	const CATEGORY_SLUG           = 'blaze-ads';
+	const ABILITY_LIST_CAMPAIGNS  = 'blaze-ads/list-campaigns';
+	const ABILITY_CREATE_CAMPAIGN = 'blaze-ads/create-campaign';
+
+	/**
+	 * Slugs we own — used by `opt_into_woo_mcp` and the double-register guard.
+	 */
+	const OWNED_ABILITY_SLUGS = array(
+		self::ABILITY_LIST_CAMPAIGNS,
+		self::ABILITY_CREATE_CAMPAIGN,
+	);
 
 	/**
 	 * Wire registration into the Abilities API lifecycle and opt the
@@ -57,6 +67,15 @@ class Blaze_Abilities extends Registrar {
 
 		add_filter( 'jetpack_wp_abilities_should_register', array( __CLASS__, 'guard_against_double_register' ), 10, 3 );
 		add_filter( 'woocommerce_mcp_include_ability', array( __CLASS__, 'opt_into_woo_mcp' ), 10, 2 );
+
+		// Wrap write-path abilities at registration time with cross-cutting
+		// guardrails (TOS, payment, spend ceiling). Inheritable by any future
+		// write ability — see `wrap_write_path_execute_callback` for the policy.
+		add_filter( 'wp_register_ability_args', array( __CLASS__, 'wrap_write_path_execute_callback' ), 10, 2 );
+
+		// Audit log for write-ability invocations. Read-path abilities are
+		// excluded by the listener itself.
+		add_action( 'wp_after_execute_ability', array( __CLASS__, 'audit_log_write_invocation' ), 10, 3 );
 
 		if ( did_action( self::CATEGORIES_INIT_ACTION ) ) {
 			static::register_category();
@@ -98,7 +117,32 @@ class Blaze_Abilities extends Registrar {
 		if ( ! $enabled ) {
 			return $enabled;
 		}
-		if ( 'ability' === $type && self::ABILITY_LIST_CAMPAIGNS === $slug && function_exists( 'wp_get_ability' ) && wp_get_ability( $slug ) ) {
+		if ( 'ability' !== $type || ! in_array( $slug, self::OWNED_ABILITY_SLUGS, true ) ) {
+			return $enabled;
+		}
+
+		// Kill-switch: write abilities default to enabled but can be turned off
+		// centrally via filter without a release if abuse / errors emerge.
+		if ( self::ABILITY_CREATE_CAMPAIGN === $slug ) {
+			/**
+			 * Filters whether the Blaze `create-campaign` write ability is registered.
+			 *
+			 * Default true. Return false to keep the ability out of the registry —
+			 * MCP clients won't see it, REST callers get 404. Use as a kill-switch
+			 * if abuse, error rates, or infra issues require centrally disabling
+			 * the write path without shipping a release.
+			 *
+			 * @since $$next-version$$
+			 *
+			 * @param bool $enabled Whether to register the create-campaign ability. Default true.
+			 */
+			if ( ! apply_filters( 'blaze_abilities_create_campaign_enabled', true ) ) {
+				return false;
+			}
+		}
+
+		// Defensive: skip if something else has already registered the slug.
+		if ( function_exists( 'wp_get_ability' ) && wp_get_ability( $slug ) ) {
 			return false;
 		}
 		return $enabled;
@@ -112,7 +156,7 @@ class Blaze_Abilities extends Registrar {
 	 * @return bool
 	 */
 	public static function opt_into_woo_mcp( $include, $ability_id ) {
-		if ( self::ABILITY_LIST_CAMPAIGNS === $ability_id ) {
+		if ( in_array( $ability_id, self::OWNED_ABILITY_SLUGS, true ) ) {
 			return true;
 		}
 		return $include;
@@ -147,7 +191,7 @@ class Blaze_Abilities extends Registrar {
 	 */
 	public static function get_abilities(): array {
 		return array(
-			self::ABILITY_LIST_CAMPAIGNS => array(
+			self::ABILITY_LIST_CAMPAIGNS  => array(
 				'label'               => __( 'List Blaze campaigns', 'jetpack-blaze' ),
 				'description'         => __( 'List the Blaze advertising campaigns associated with the current site, including status, schedule, spend, and performance metrics.', 'jetpack-blaze' ),
 				'input_schema'        => array(
@@ -168,6 +212,68 @@ class Blaze_Abilities extends Registrar {
 						'readonly'    => true,
 						'destructive' => false,
 						'idempotent'  => true,
+					),
+				),
+			),
+			self::ABILITY_CREATE_CAMPAIGN => array(
+				'label'               => __( 'Draft a new Blaze campaign', 'jetpack-blaze' ),
+				'description'         => __( 'Draft a new Blaze advertising campaign for an existing post or product on the site. The campaign is created in DRAFT state and requires the merchant to explicitly approve it in the Blaze UI before it goes live — the response includes a deep-link to that UI.', 'jetpack-blaze' ),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'required'             => array( 'target_urn', 'budget_total', 'duration_days' ),
+					'properties'           => array(
+						'target_urn'    => array(
+							'type'        => 'string',
+							'description' => __( 'The URN of the post or product to promote (e.g. urn:wpcom:post:123456:42).', 'jetpack-blaze' ),
+						),
+						'budget_total'  => array(
+							'type'        => 'number',
+							'description' => __( 'Total budget for the campaign in the site\'s currency.', 'jetpack-blaze' ),
+							'minimum'     => 1,
+						),
+						'duration_days' => array(
+							'type'        => 'integer',
+							'description' => __( 'Number of days the campaign should run.', 'jetpack-blaze' ),
+							'minimum'     => 1,
+							'maximum'     => 90,
+						),
+						'objective'     => array(
+							'type'        => 'string',
+							'description' => __( 'Campaign objective.', 'jetpack-blaze' ),
+							'enum'        => array( 'VIEWS', 'CLICKS', 'SALES' ),
+							'default'     => 'VIEWS',
+						),
+					),
+					'additionalProperties' => true,
+				),
+				'output_schema'       => array(
+					'type'        => 'object',
+					'description' => __( 'Draft campaign reference plus a deep-link to the Blaze UI for merchant approval.', 'jetpack-blaze' ),
+					'required'    => array( 'campaign_id', 'status', 'approval_url' ),
+					'properties'  => array(
+						'campaign_id'  => array(
+							'type'        => 'string',
+							'description' => __( 'The DSP-assigned ID of the draft campaign.', 'jetpack-blaze' ),
+						),
+						'status'       => array(
+							'type'        => 'string',
+							'description' => __( 'Campaign status. Always "draft" for the immediate response.', 'jetpack-blaze' ),
+						),
+						'approval_url' => array(
+							'type'        => 'string',
+							'format'      => 'uri',
+							'description' => __( 'Deep-link to the Blaze widget where the merchant previews and approves this draft.', 'jetpack-blaze' ),
+						),
+					),
+				),
+				'execute_callback'    => array( __CLASS__, 'create_campaign' ),
+				'permission_callback' => array( __CLASS__, 'permission_callback' ),
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => false,
 					),
 				),
 			),
@@ -223,5 +329,214 @@ class Blaze_Abilities extends Registrar {
 		}
 
 		return $response->get_data();
+	}
+
+	/**
+	 * Draft a new Blaze campaign by delegating to the existing DSP create
+	 * route. Returns a draft reference plus a deep-link to the Blaze widget
+	 * for merchant approval — the campaign does not go live until the
+	 * merchant explicitly approves it there.
+	 *
+	 * Note: cross-cutting guardrails (TOS, payment, spend ceiling) run
+	 * *before* this method via the registration-time wrapper applied in
+	 * `wrap_write_path_execute_callback()`. This method only handles the
+	 * happy-path delegation.
+	 *
+	 * @param array $args Ability input — see `get_abilities()` input_schema.
+	 * @return array|\WP_Error
+	 */
+	public static function create_campaign( $args = array() ) {
+		$site_id = \Automattic\Jetpack\Connection\Manager::get_site_id();
+		if ( is_wp_error( $site_id ) ) {
+			return $site_id;
+		}
+
+		$route   = sprintf( '/jetpack/v4/blaze-app/sites/%d/wordads/dsp/api/v1.1/campaigns', $site_id );
+		$request = new WP_REST_Request( 'POST', $route );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( $args, JSON_UNESCAPED_SLASHES ) );
+
+		$response = rest_do_request( $request );
+		if ( $response->is_error() ) {
+			return $response->as_error();
+		}
+
+		$data = $response->get_data();
+
+		return array(
+			'campaign_id'  => isset( $data['campaign_id'] ) ? (string) $data['campaign_id'] : ( isset( $data['id'] ) ? (string) $data['id'] : '' ),
+			'status'       => 'draft',
+			'approval_url' => self::get_approval_url( $args, $data ),
+			'campaign'     => $data,
+		);
+	}
+
+	/**
+	 * Build the deep-link the merchant follows to preview and approve a
+	 * draft campaign.
+	 *
+	 * Phase 2 punts to the existing Blaze management URL family — that's
+	 * the SPA where drafts can be reviewed today. The exact in-SPA route
+	 * for "approve this specific draft" may need a follow-up with the
+	 * Calypso team; for now we land the merchant in the advertising
+	 * dashboard with the campaign visible.
+	 *
+	 * @param array $args         Original ability input (used for target_urn fallback).
+	 * @param array $dsp_response Response payload from the DSP create route. Reserved for future use (campaign-id-based deep-link lookup).
+	 * @return string
+	 */
+	private static function get_approval_url( array $args, $dsp_response ) {
+		unset( $dsp_response );
+		// Try to extract a post ID from the target URN to leverage the
+		// existing `Blaze::get_campaign_management_url()` helper.
+		$post_id = 0;
+		$urn     = isset( $args['target_urn'] ) ? (string) $args['target_urn'] : '';
+		if ( $urn && preg_match( '/^urn:wpcom:post:\d+:(\d+)$/', $urn, $m ) ) {
+			$post_id = (int) $m[1];
+		}
+
+		if ( $post_id > 0 && class_exists( '\Automattic\Jetpack\Blaze' ) ) {
+			$url_data = Blaze::get_campaign_management_url( $post_id );
+			return is_array( $url_data ) && isset( $url_data['link'] ) ? $url_data['link'] : '';
+		}
+
+		// Fallback: the bare advertising dashboard.
+		return admin_url( 'tools.php?page=advertising' );
+	}
+
+	/**
+	 * Registration-time wrapper for write-path abilities.
+	 *
+	 * Applied via the `wp_register_ability_args` filter. For any of our
+	 * abilities marked `meta.annotations.readonly => false`, replaces the
+	 * configured `execute_callback` with a closure that runs cross-cutting
+	 * guardrails first (TOS / payment, per-session spend ceiling) and only
+	 * delegates to the original callback if all checks pass.
+	 *
+	 * Lives at registration time (not via `wp_before_execute_ability`)
+	 * because the action hook is fire-and-forget and cannot abort the
+	 * call. Lives at the wrapper level (not `permission_callback`)
+	 * because the Abilities API strips structured data from
+	 * permission errors — the merchant needs to receive a deep-link in
+	 * the error data, which only works from the execute path.
+	 *
+	 * Future Phase 3 write abilities inherit this wrapper for free as
+	 * long as they're registered with `meta.annotations.readonly => false`.
+	 *
+	 * @param array  $args         Args being registered for the ability.
+	 * @param string $ability_name The fully-qualified ability slug.
+	 * @return array
+	 */
+	public static function wrap_write_path_execute_callback( array $args, string $ability_name ): array {
+		// Only touch our own abilities.
+		if ( ! in_array( $ability_name, self::OWNED_ABILITY_SLUGS, true ) ) {
+			return $args;
+		}
+
+		$is_write = isset( $args['meta']['annotations']['readonly'] ) && false === $args['meta']['annotations']['readonly'];
+		if ( ! $is_write ) {
+			return $args;
+		}
+
+		$original_callback = isset( $args['execute_callback'] ) ? $args['execute_callback'] : null;
+		if ( ! is_callable( $original_callback ) ) {
+			return $args;
+		}
+
+		$args['execute_callback'] = static function ( $input = array() ) use ( $original_callback ) {
+			$tos_check = self::check_tos_and_payment();
+			if ( is_wp_error( $tos_check ) ) {
+				return $tos_check;
+			}
+
+			$spend_check = self::check_spend_ceiling( $input );
+			if ( is_wp_error( $spend_check ) ) {
+				return $spend_check;
+			}
+
+			return call_user_func( $original_callback, $input );
+		};
+
+		return $args;
+	}
+
+	/**
+	 * Verify the merchant's Blaze TOS acceptance and payment-method
+	 * status are good for write actions.
+	 *
+	 * STUB: implementation pending. Needs a call to the WPCOM Blaze status
+	 * endpoint to check TOS + payment method state. When either is missing,
+	 * return a `WP_Error` whose `data` carries a deep-link the merchant
+	 * follows to fix the issue (Abilities API surfaces `WP_Error` data
+	 * verbatim from `execute_callback`).
+	 *
+	 * @return true|\WP_Error
+	 */
+	private static function check_tos_and_payment() {
+		// TODO(ADS-953): wire to WPCOM Blaze status endpoint.
+		// Example shape of the failure case for the eventual implementation:
+		//
+		// return new WP_Error(
+		// 'blaze_tos_required',
+		// __( 'Blaze terms of service must be accepted before creating campaigns.', 'jetpack-blaze' ),
+		// array(
+		// 'status'    => 403,
+		// 'fix_url'   => admin_url( 'tools.php?page=advertising' ),
+		// 'fix_label' => __( 'Accept terms in the Blaze dashboard', 'jetpack-blaze' ),
+		// )
+		// );
+		return true;
+	}
+
+	/**
+	 * Enforce a per-session spend ceiling on the requested campaign budget.
+	 *
+	 * STUB: "session" semantics are still TBD for MCP — there's no obvious
+	 * server-side session boundary for an MCP client. Likely candidates:
+	 * per-user-per-day, per-application-password-per-day, or a transient
+	 * scoped to the current REST request user. To be decided when wiring.
+	 *
+	 * @param mixed $input Ability input — should include `budget_total`.
+	 * @return true|\WP_Error
+	 */
+	private static function check_spend_ceiling( $input ) {
+		// TODO(ADS-953): decide session model + ceiling, then enforce.
+		unset( $input );
+		return true;
+	}
+
+	/**
+	 * Audit-log listener for write-path ability invocations.
+	 *
+	 * Filters down to slugs we own and that are write-path; ignores
+	 * read-only abilities and anything outside our category. Logs to the
+	 * standard error log for now — a structured audit store is a follow-up.
+	 *
+	 * @param string $ability_name The slug of the executed ability.
+	 * @param mixed  $input        The input passed to the ability.
+	 * @param mixed  $result       The result the ability returned.
+	 * @return void
+	 */
+	public static function audit_log_write_invocation( string $ability_name, $input, $result ): void {
+		if ( ! in_array( $ability_name, self::OWNED_ABILITY_SLUGS, true ) ) {
+			return;
+		}
+		// Skip read-only abilities — only audit writes.
+		if ( self::ABILITY_LIST_CAMPAIGNS === $ability_name ) {
+			return;
+		}
+
+		$entry = array(
+			'ability'   => $ability_name,
+			'user_id'   => get_current_user_id(),
+			'site_id'   => \Automattic\Jetpack\Connection\Manager::get_site_id(),
+			'input'     => $input,
+			'is_error'  => is_wp_error( $result ),
+			'timestamp' => time(),
+		);
+
+		// TODO(ADS-953): replace with structured audit storage. For now, log
+		// to error_log for visibility during development and reviewer testing.
+		error_log( '[blaze-abilities-audit] ' . wp_json_encode( $entry, JSON_UNESCAPED_SLASHES ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 	}
 }

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -466,25 +466,39 @@ class Blaze_Abilities extends Registrar {
 	 *
 	 * STUB: implementation pending. Needs a call to the WPCOM Blaze status
 	 * endpoint to check TOS + payment method state. When either is missing,
-	 * return a `WP_Error` whose `data` carries a deep-link the merchant
-	 * follows to fix the issue (Abilities API surfaces `WP_Error` data
-	 * verbatim from `execute_callback`).
+	 * return a `WP_Error` whose **message** embeds a deep-link as a URL the
+	 * merchant follows to fix the issue.
+	 *
+	 * Why message-text and not the `data` field: the Woo MCP adapter strips
+	 * `WP_Error::data` when forwarding errors to MCP clients
+	 * (see vendor/wordpress/mcp-adapter ToolsHandler.php — only `message` +
+	 * `code` survive). Embedding the URL in the message ensures Claude /
+	 * other MCP clients can present it to the merchant. The `data` field is
+	 * kept too as belt-and-braces for direct WP Abilities REST callers,
+	 * which preserve it via standard WP REST error serialization.
 	 *
 	 * @return true|\WP_Error
 	 */
 	private static function check_tos_and_payment() {
-		// TODO(ADS-953): wire to WPCOM Blaze status endpoint.
-		// Example shape of the failure case for the eventual implementation:
-		//
-		// return new WP_Error(
-		// 'blaze_tos_required',
-		// __( 'Blaze terms of service must be accepted before creating campaigns.', 'jetpack-blaze' ),
-		// array(
-		// 'status'    => 403,
-		// 'fix_url'   => admin_url( 'tools.php?page=advertising' ),
-		// 'fix_label' => __( 'Accept terms in the Blaze dashboard', 'jetpack-blaze' ),
-		// )
-		// );
+		/*
+		 * TODO(ADS-953): wire to WPCOM Blaze status endpoint.
+		 * Example failure shape for the eventual implementation:
+		 *
+		 *   $fix_url = admin_url( 'tools.php?page=advertising' );
+		 *   return new WP_Error(
+		 *       'blaze_tos_required',
+		 *       sprintf(
+		 *           // Deep-link in the message text so MCP clients pass it through.
+		 *           __( 'Blaze terms of service must be accepted before creating campaigns. Accept them here: %s', 'jetpack-blaze' ),
+		 *           $fix_url
+		 *       ),
+		 *       array(
+		 *           'status'    => 403,
+		 *           'fix_url'   => $fix_url,
+		 *           'fix_label' => __( 'Accept terms in the Blaze dashboard', 'jetpack-blaze' ),
+		 *       )
+		 *   );
+		 */
 		return true;
 	}
 

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -410,15 +410,20 @@ class Blaze_Abilities extends Registrar {
 	 * Applied via the `wp_register_ability_args` filter. For any of our
 	 * abilities marked `meta.annotations.readonly => false`, replaces the
 	 * configured `execute_callback` with a closure that runs cross-cutting
-	 * guardrails first (TOS / payment, per-session spend ceiling) and only
-	 * delegates to the original callback if all checks pass.
+	 * guardrails first and only delegates to the original callback if all
+	 * checks pass.
+	 *
+	 * v1 guardrails: TOS / Blaze-eligibility check.
+	 * Deferred guardrails (tracked separately as ADS-989): per-session
+	 * spend ceiling, Picard creative moderation. The wrapper is the
+	 * intended insertion point for both.
 	 *
 	 * Lives at registration time (not via `wp_before_execute_ability`)
 	 * because the action hook is fire-and-forget and cannot abort the
 	 * call. Lives at the wrapper level (not `permission_callback`)
-	 * because the Abilities API strips structured data from
-	 * permission errors — the merchant needs to receive a deep-link in
-	 * the error data, which only works from the execute path.
+	 * because the Abilities API strips structured data from permission
+	 * errors — the merchant needs to receive a deep-link in the error,
+	 * which only works from the execute path.
 	 *
 	 * Future Phase 3 write abilities inherit this wrapper for free as
 	 * long as they're registered with `meta.annotations.readonly => false`.
@@ -449,10 +454,8 @@ class Blaze_Abilities extends Registrar {
 				return $tos_check;
 			}
 
-			$spend_check = self::check_spend_ceiling( $input );
-			if ( is_wp_error( $spend_check ) ) {
-				return $spend_check;
-			}
+			// Future write-path guardrails (per-session spend ceiling, Picard
+			// moderation gating) plug in here. Tracked separately as ADS-989.
 
 			return call_user_func( $original_callback, $input );
 		};
@@ -461,13 +464,16 @@ class Blaze_Abilities extends Registrar {
 	}
 
 	/**
-	 * Verify the merchant's Blaze TOS acceptance and payment-method
-	 * status are good for write actions.
+	 * Verify the site is eligible for Blaze write actions.
 	 *
-	 * STUB: implementation pending. Needs a call to the WPCOM Blaze status
-	 * endpoint to check TOS + payment method state. When either is missing,
-	 * return a `WP_Error` whose **message** embeds a deep-link as a URL the
-	 * merchant follows to fix the issue.
+	 * Uses the existing `Blaze::site_supports_blaze()` helper — a coarse
+	 * single-call boolean that proxies the WPCOM `/sites/<id>/blaze/status`
+	 * endpoint and is true when the site has accepted TOS and is otherwise
+	 * eligible to run campaigns. Result is cached for a day inside that
+	 * helper, so the per-call cost is a transient lookup.
+	 *
+	 * On failure, returns a `WP_Error` whose **message** embeds a deep-link
+	 * URL the merchant can follow to fix the issue in the Blaze UI.
 	 *
 	 * Why message-text and not the `data` field: the Woo MCP adapter strips
 	 * `WP_Error::data` when forwarding errors to MCP clients
@@ -480,43 +486,32 @@ class Blaze_Abilities extends Registrar {
 	 * @return true|\WP_Error
 	 */
 	private static function check_tos_and_payment() {
-		/*
-		 * TODO(ADS-953): wire to WPCOM Blaze status endpoint.
-		 * Example failure shape for the eventual implementation:
-		 *
-		 *   $fix_url = admin_url( 'tools.php?page=advertising' );
-		 *   return new WP_Error(
-		 *       'blaze_tos_required',
-		 *       sprintf(
-		 *           // Deep-link in the message text so MCP clients pass it through.
-		 *           __( 'Blaze terms of service must be accepted before creating campaigns. Accept them here: %s', 'jetpack-blaze' ),
-		 *           $fix_url
-		 *       ),
-		 *       array(
-		 *           'status'    => 403,
-		 *           'fix_url'   => $fix_url,
-		 *           'fix_label' => __( 'Accept terms in the Blaze dashboard', 'jetpack-blaze' ),
-		 *       )
-		 *   );
-		 */
-		return true;
-	}
+		$site_id = \Automattic\Jetpack\Connection\Manager::get_site_id();
+		if ( is_wp_error( $site_id ) || ! $site_id ) {
+			// Without a connected site we can't check, and downstream calls
+			// will fail anyway — let the underlying execute_callback surface
+			// the connection error rather than fabricating one here.
+			return true;
+		}
 
-	/**
-	 * Enforce a per-session spend ceiling on the requested campaign budget.
-	 *
-	 * STUB: "session" semantics are still TBD for MCP — there's no obvious
-	 * server-side session boundary for an MCP client. Likely candidates:
-	 * per-user-per-day, per-application-password-per-day, or a transient
-	 * scoped to the current REST request user. To be decided when wiring.
-	 *
-	 * @param mixed $input Ability input — should include `budget_total`.
-	 * @return true|\WP_Error
-	 */
-	private static function check_spend_ceiling( $input ) {
-		// TODO(ADS-953): decide session model + ceiling, then enforce.
-		unset( $input );
-		return true;
+		if ( Blaze::site_supports_blaze( $site_id ) ) {
+			return true;
+		}
+
+		$fix_url = admin_url( 'tools.php?page=advertising' );
+		return new \WP_Error(
+			'blaze_setup_required',
+			sprintf(
+				/* translators: %s is a URL the merchant follows to set up Blaze. */
+				__( 'This site is not yet eligible to run Blaze campaigns. Complete Blaze setup (accept the terms of service and add a payment method) here: %s', 'jetpack-blaze' ),
+				$fix_url
+			),
+			array(
+				'status'    => 403,
+				'fix_url'   => $fix_url,
+				'fix_label' => __( 'Set up Blaze', 'jetpack-blaze' ),
+			)
+		);
 	}
 
 	/**

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -32,16 +32,18 @@ use WP_REST_Request;
  */
 class Blaze_Abilities extends Registrar {
 
-	const CATEGORY_SLUG           = 'blaze-ads';
-	const ABILITY_LIST_CAMPAIGNS  = 'blaze-ads/list-campaigns';
-	const ABILITY_CREATE_CAMPAIGN = 'blaze-ads/create-campaign';
+	const CATEGORY_SLUG                 = 'blaze-ads';
+	const ABILITY_LIST_CAMPAIGNS        = 'blaze-ads/list-campaigns';
+	const ABILITY_PREPARE_CAMPAIGN      = 'blaze-ads/prepare-campaign';
+	private const DEFAULT_BUDGET_TOTAL  = 50.0;
+	private const DEFAULT_DURATION_DAYS = 7;
 
 	/**
 	 * Slugs we own — used by `opt_into_woo_mcp` and the double-register guard.
 	 */
 	const OWNED_ABILITY_SLUGS = array(
 		self::ABILITY_LIST_CAMPAIGNS,
-		self::ABILITY_CREATE_CAMPAIGN,
+		self::ABILITY_PREPARE_CAMPAIGN,
 	);
 
 	/**
@@ -123,9 +125,9 @@ class Blaze_Abilities extends Registrar {
 
 		// Kill-switch: write abilities default to enabled but can be turned off
 		// centrally via filter without a release if abuse / errors emerge.
-		if ( self::ABILITY_CREATE_CAMPAIGN === $slug ) {
+		if ( self::ABILITY_PREPARE_CAMPAIGN === $slug ) {
 			/**
-			 * Filters whether the Blaze `create-campaign` write ability is registered.
+			 * Filters whether the Blaze `prepare-campaign` write ability is registered.
 			 *
 			 * Default true. Return false to keep the ability out of the registry —
 			 * MCP clients won't see it, REST callers get 404. Use as a kill-switch
@@ -134,9 +136,9 @@ class Blaze_Abilities extends Registrar {
 			 *
 			 * @since $$next-version$$
 			 *
-			 * @param bool $enabled Whether to register the create-campaign ability. Default true.
+			 * @param bool $enabled Whether to register the prepare-campaign ability. Default true.
 			 */
-			if ( ! apply_filters( 'blaze_abilities_create_campaign_enabled', true ) ) {
+			if ( ! apply_filters( 'blaze_abilities_prepare_campaign_enabled', true ) ) {
 				return false;
 			}
 		}
@@ -191,7 +193,7 @@ class Blaze_Abilities extends Registrar {
 	 */
 	public static function get_abilities(): array {
 		return array(
-			self::ABILITY_LIST_CAMPAIGNS  => array(
+			self::ABILITY_LIST_CAMPAIGNS   => array(
 				'label'               => __( 'List Blaze campaigns', 'jetpack-blaze' ),
 				'description'         => __( 'List the Blaze advertising campaigns associated with the current site, including status, schedule, spend, and performance metrics.', 'jetpack-blaze' ),
 				'input_schema'        => array(
@@ -215,48 +217,63 @@ class Blaze_Abilities extends Registrar {
 					),
 				),
 			),
-			self::ABILITY_CREATE_CAMPAIGN => array(
-				'label'               => __( 'Draft a new Blaze campaign', 'jetpack-blaze' ),
-				'description'         => __( 'Draft a Blaze advertising campaign for an existing post or product on the site. The ability does not write to the DSP itself — it derives sensible defaults from the target post (title, excerpt, featured image) and the caller\'s input (budget, duration, optional copy / objective overrides), bundles them into a prefill payload, and returns a deep-link the merchant clicks to land in the existing Blaze UI with every field already populated. The merchant reviews, accepts payment / T&C, and submits from inside the Blaze UI — that\'s where the actual DSP write happens.', 'jetpack-blaze' ),
+			self::ABILITY_PREPARE_CAMPAIGN => array(
+				'label'               => __( 'Prepare a Blaze campaign', 'jetpack-blaze' ),
+				'description'         => __( 'Prepare a Blaze advertising campaign proposal for an existing post or product on the site. The ability does not write to the DSP itself. It takes a target plus optional natural-language goal, budget, duration, copy, image, and audience overrides; derives sensible defaults from the target post; bundles the result into a prefill payload; and returns a deep-link the merchant clicks to review and submit in the existing Blaze UI. The merchant reviews, accepts payment / T&C, and submits from inside the Blaze UI — that\'s where the actual DSP write happens.', 'jetpack-blaze' ),
 				'input_schema'        => array(
 					'type'                 => 'object',
-					'required'             => array( 'target_urn', 'budget_total', 'duration_days' ),
+					'required'             => array( 'target_urn' ),
 					'properties'           => array(
-						'target_urn'    => array(
+						'target_urn'           => array(
 							'type'        => 'string',
 							'description' => __( 'The URN of the post or product to promote (e.g. urn:wpcom:post:123456:42).', 'jetpack-blaze' ),
 						),
-						'budget_total'  => array(
+						'goal'                 => array(
+							'type'        => 'string',
+							'description' => __( 'Optional natural-language campaign goal or intent. Blaze uses this as context while still owning the DSP objective internally.', 'jetpack-blaze' ),
+						),
+						'budget_total'         => array(
 							'type'        => 'number',
-							'description' => __( 'Total budget for the campaign in the site\'s currency.', 'jetpack-blaze' ),
+							'description' => __( 'Optional total budget for the campaign in USD. If omitted, Blaze applies its default budget for this proposal.', 'jetpack-blaze' ),
 							'minimum'     => 1,
 						),
-						'duration_days' => array(
+						'duration_days'        => array(
 							'type'        => 'integer',
-							'description' => __( 'Number of days the campaign should run.', 'jetpack-blaze' ),
+							'description' => __( 'Optional number of days the campaign should run. If omitted, Blaze applies its default duration for this proposal.', 'jetpack-blaze' ),
 							'minimum'     => 1,
 							'maximum'     => 90,
 						),
-						'objective'     => array(
+						'revision_instruction' => array(
 							'type'        => 'string',
-							'description' => __( 'Campaign objective. Defaults to VIEWS.', 'jetpack-blaze' ),
-							'enum'        => array( 'VIEWS', 'CLICKS', 'SALES' ),
-							'default'     => 'VIEWS',
+							'description' => __( 'Optional natural-language instruction for revising a previous proposal, such as “make it less salesy”.', 'jetpack-blaze' ),
 						),
-						'is_evergreen'  => array(
+						'is_evergreen'         => array(
 							'type'        => 'boolean',
 							'description' => __( 'Run until the merchant stops it. Defaults to true.', 'jetpack-blaze' ),
 							'default'     => true,
 						),
-						'site_name'     => array(
+						'site_name'            => array(
 							'type'        => 'string',
 							'description' => __( 'Optional ad heading override. Defaults to the post title.', 'jetpack-blaze' ),
 						),
-						'text_snippet'  => array(
+						'text_snippet'         => array(
 							'type'        => 'string',
 							'description' => __( 'Optional ad copy override. Defaults to the post excerpt (or first ~200 chars of content).', 'jetpack-blaze' ),
 						),
-						'languages'     => array(
+						'cta_text'             => array(
+							'type'        => 'string',
+							'description' => __( 'Optional call-to-action text override. Defaults to a post-type-aware Blaze choice.', 'jetpack-blaze' ),
+						),
+						'main_image_url'       => array(
+							'type'        => 'string',
+							'format'      => 'uri',
+							'description' => __( 'Optional image URL override. Defaults to the target post featured image when available.', 'jetpack-blaze' ),
+						),
+						'main_image_mime_type' => array(
+							'type'        => 'string',
+							'description' => __( 'Optional MIME type for main_image_url. Defaults to image/jpeg when omitted.', 'jetpack-blaze' ),
+						),
+						'languages'            => array(
 							'type'        => 'array',
 							'description' => __( 'Optional ISO 639-1 language codes to target (e.g. ["en", "es"]). Defaults to all languages when omitted; pass a non-empty array to narrow targeting.', 'jetpack-blaze' ),
 							'items'       => array(
@@ -265,7 +282,7 @@ class Blaze_Abilities extends Registrar {
 								'maxLength' => 5,
 							),
 						),
-						'countries'     => array(
+						'countries'            => array(
 							'type'        => 'array',
 							'description' => __( 'Optional ISO 3166-1 alpha-2 country codes to target (e.g. ["US", "GB"]). Defaults to worldwide when omitted; pass a non-empty array to limit reach to those countries.', 'jetpack-blaze' ),
 							'items'       => array(
@@ -298,11 +315,11 @@ class Blaze_Abilities extends Registrar {
 						),
 						'prefill'     => array(
 							'type'        => 'object',
-							'description' => __( 'The structured prefill payload — same data as encoded in prefill_url. Useful for the MCP client to surface a summary of what was drafted before the merchant clicks through.', 'jetpack-blaze' ),
+							'description' => __( 'The structured prefill payload — same data as encoded in prefill_url. Useful for the MCP client to surface a summary of what was prepared before the merchant clicks through.', 'jetpack-blaze' ),
 						),
 					),
 				),
-				'execute_callback'    => array( __CLASS__, 'create_campaign' ),
+				'execute_callback'    => array( __CLASS__, 'prepare_campaign' ),
 				'permission_callback' => array( __CLASS__, 'permission_callback' ),
 				'meta'                => array(
 					'show_in_rest' => true,
@@ -368,7 +385,7 @@ class Blaze_Abilities extends Registrar {
 	}
 
 	/**
-	 * Draft a new Blaze campaign by deriving sensible defaults from the
+	 * Prepare a Blaze campaign proposal by deriving sensible defaults from the
 	 * target post and bundling them into a prefill payload. Returns a
 	 * deep-link the merchant clicks to land in the existing Blaze widget
 	 * with every field already populated; the merchant reviews, accepts
@@ -388,7 +405,7 @@ class Blaze_Abilities extends Registrar {
 	 * @param array $args Ability input — see `get_abilities()` input_schema.
 	 * @return array|\WP_Error
 	 */
-	public static function create_campaign( $args = array() ) {
+	public static function prepare_campaign( $args = array() ) {
 		$args = is_array( $args ) ? $args : array();
 
 		$urn = isset( $args['target_urn'] ) ? (string) $args['target_urn'] : '';
@@ -416,8 +433,8 @@ class Blaze_Abilities extends Registrar {
 		return array(
 			'status'      => 'pending_merchant_review',
 			'message'     => sprintf(
-				/* translators: %s: deep-link URL that opens the Blaze widget pre-populated with the drafted campaign. */
-				__( 'Draft prepared. The merchant must open the Blaze UI to review, accept payment / T&C, and submit. Open here: %s', 'jetpack-blaze' ),
+				/* translators: %s: deep-link URL that opens the Blaze widget pre-populated with the prepared campaign proposal. */
+				__( 'Campaign proposal prepared. The merchant must open the Blaze UI to review, accept payment / T&C, and submit. Open here: %s', 'jetpack-blaze' ),
 				$prefill_url
 			),
 			'prefill_url' => $prefill_url,
@@ -430,7 +447,7 @@ class Blaze_Abilities extends Registrar {
 	 * the resolved target post. Pure function — no I/O — so it's easy to
 	 * test and easy for callers to inspect in the response.
 	 *
-	 * Caller input (`site_name`, `text_snippet`, `objective`, `is_evergreen`)
+	 * Caller input (`site_name`, `text_snippet`, `cta_text`, `is_evergreen`)
 	 * overrides the post-derived defaults. Anything we can't pull from
 	 * the post or the input is left out — the widget will fill blanks
 	 * with its own defaults at submission time.
@@ -463,21 +480,35 @@ class Blaze_Abilities extends Registrar {
 			// Default CTA varies by post type — products get a commerce-flavoured
 			// "Shop Now", everything else gets the neutral "Learn More". The widget
 			// requires a non-empty CTA to clear validation, so we always send one.
-			'cta_text'      => 'product' === (string) $post->post_type ? 'Shop Now' : 'Learn More',
+			'cta_text'      => isset( $args['cta_text'] ) && '' !== (string) $args['cta_text']
+				? (string) $args['cta_text']
+				: ( 'product' === (string) $post->post_type ? 'Shop Now' : 'Learn More' ),
 			'target_url'    => (string) get_permalink( $post ),
 			'budget'        => array(
 				'mode'     => 'total',
-				'amount'   => (float) ( $args['budget_total'] ?? 0 ),
+				'amount'   => (float) ( $args['budget_total'] ?? self::DEFAULT_BUDGET_TOTAL ),
 				'currency' => self::get_site_currency(),
 			),
-			'duration_days' => (int) ( $args['duration_days'] ?? 7 ),
+			'duration_days' => (int) ( $args['duration_days'] ?? self::DEFAULT_DURATION_DAYS ),
 			'is_evergreen'  => isset( $args['is_evergreen'] ) ? (bool) $args['is_evergreen'] : true,
-			'objective'     => isset( $args['objective'] ) && '' !== (string) $args['objective']
-				? (string) $args['objective']
-				: 'VIEWS',
+			'objective'     => 'VIEWS',
 		);
 
-		if ( '' !== $featured_image_url ) {
+		if ( isset( $args['goal'] ) && '' !== (string) $args['goal'] ) {
+			$payload['goal'] = (string) $args['goal'];
+		}
+		if ( isset( $args['revision_instruction'] ) && '' !== (string) $args['revision_instruction'] ) {
+			$payload['revision_instruction'] = (string) $args['revision_instruction'];
+		}
+
+		if ( isset( $args['main_image_url'] ) && '' !== (string) $args['main_image_url'] ) {
+			$payload['main_image'] = array(
+				'url'       => (string) $args['main_image_url'],
+				'mime_type' => isset( $args['main_image_mime_type'] ) && '' !== (string) $args['main_image_mime_type']
+					? (string) $args['main_image_mime_type']
+					: 'image/jpeg',
+			);
+		} elseif ( '' !== $featured_image_url ) {
 			$payload['main_image'] = array(
 				'url'       => $featured_image_url,
 				'mime_type' => $featured_image_mime ? $featured_image_mime : 'image/jpeg',

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -217,7 +217,7 @@ class Blaze_Abilities extends Registrar {
 			),
 			self::ABILITY_CREATE_CAMPAIGN => array(
 				'label'               => __( 'Draft a new Blaze campaign', 'jetpack-blaze' ),
-				'description'         => __( 'Draft a new Blaze advertising campaign for an existing post or product on the site. The campaign is created in DRAFT state and requires the merchant to explicitly approve it in the Blaze UI before it goes live — the response includes a deep-link to that UI.', 'jetpack-blaze' ),
+				'description'         => __( 'Draft a Blaze advertising campaign for an existing post or product on the site. The ability does not write to the DSP itself — it derives sensible defaults from the target post (title, excerpt, featured image) and the caller\'s input (budget, duration, optional copy / objective overrides), bundles them into a prefill payload, and returns a deep-link the merchant clicks to land in the existing Blaze UI with every field already populated. The merchant reviews, accepts payment / T&C, and submits from inside the Blaze UI — that\'s where the actual DSP write happens.', 'jetpack-blaze' ),
 				'input_schema'        => array(
 					'type'                 => 'object',
 					'required'             => array( 'target_urn', 'budget_total', 'duration_days' ),
@@ -239,30 +239,48 @@ class Blaze_Abilities extends Registrar {
 						),
 						'objective'     => array(
 							'type'        => 'string',
-							'description' => __( 'Campaign objective.', 'jetpack-blaze' ),
+							'description' => __( 'Campaign objective. Defaults to VIEWS.', 'jetpack-blaze' ),
 							'enum'        => array( 'VIEWS', 'CLICKS', 'SALES' ),
 							'default'     => 'VIEWS',
 						),
+						'is_evergreen'  => array(
+							'type'        => 'boolean',
+							'description' => __( 'Run until the merchant stops it. Defaults to true.', 'jetpack-blaze' ),
+							'default'     => true,
+						),
+						'site_name'     => array(
+							'type'        => 'string',
+							'description' => __( 'Optional ad heading override. Defaults to the post title.', 'jetpack-blaze' ),
+						),
+						'text_snippet'  => array(
+							'type'        => 'string',
+							'description' => __( 'Optional ad copy override. Defaults to the post excerpt (or first ~200 chars of content).', 'jetpack-blaze' ),
+						),
 					),
-					'additionalProperties' => true,
+					'additionalProperties' => false,
 				),
 				'output_schema'       => array(
 					'type'        => 'object',
-					'description' => __( 'Draft campaign reference plus a deep-link to the Blaze UI for merchant approval.', 'jetpack-blaze' ),
-					'required'    => array( 'campaign_id', 'status', 'approval_url' ),
+					'description' => __( 'Prefill payload plus a deep-link to the Blaze UI for the merchant to review and submit.', 'jetpack-blaze' ),
+					'required'    => array( 'status', 'prefill_url', 'prefill' ),
 					'properties'  => array(
-						'campaign_id'  => array(
+						'status'      => array(
 							'type'        => 'string',
-							'description' => __( 'The DSP-assigned ID of the draft campaign.', 'jetpack-blaze' ),
+							'description' => __( 'Always "pending_merchant_review" for the immediate response. The campaign is not yet on the DSP — it lands there only when the merchant submits from the Blaze UI.', 'jetpack-blaze' ),
+							'enum'        => array( 'pending_merchant_review' ),
 						),
-						'status'       => array(
+						'message'     => array(
 							'type'        => 'string',
-							'description' => __( 'Campaign status. Always "draft" for the immediate response.', 'jetpack-blaze' ),
+							'description' => __( 'Human-readable summary suitable for surfacing back to the merchant in chat. Includes the prefill_url verbatim so MCP clients that strip structured fields still surface the link.', 'jetpack-blaze' ),
 						),
-						'approval_url' => array(
+						'prefill_url' => array(
 							'type'        => 'string',
 							'format'      => 'uri',
-							'description' => __( 'Deep-link to the Blaze widget where the merchant previews and approves this draft.', 'jetpack-blaze' ),
+							'description' => __( 'Deep-link the merchant follows to land in the Blaze UI with the campaign form pre-populated. The prefill payload is encoded in the blaze_prefill query parameter.', 'jetpack-blaze' ),
+						),
+						'prefill'     => array(
+							'type'        => 'object',
+							'description' => __( 'The structured prefill payload — same data as encoded in prefill_url. Useful for the MCP client to surface a summary of what was drafted before the merchant clicks through.', 'jetpack-blaze' ),
 						),
 					),
 				),
@@ -332,76 +350,193 @@ class Blaze_Abilities extends Registrar {
 	}
 
 	/**
-	 * Draft a new Blaze campaign by delegating to the existing DSP create
-	 * route. Returns a draft reference plus a deep-link to the Blaze widget
-	 * for merchant approval — the campaign does not go live until the
-	 * merchant explicitly approves it there.
+	 * Draft a new Blaze campaign by deriving sensible defaults from the
+	 * target post and bundling them into a prefill payload. Returns a
+	 * deep-link the merchant clicks to land in the existing Blaze widget
+	 * with every field already populated; the merchant reviews, accepts
+	 * payment / T&C, and submits from inside the widget.
 	 *
-	 * Note: cross-cutting guardrails (TOS, payment, spend ceiling) run
-	 * *before* this method via the registration-time wrapper applied in
-	 * `wrap_write_path_execute_callback()`. This method only handles the
-	 * happy-path delegation.
+	 * Phase 2 v1 deliberately does NOT call the DSP create endpoint from
+	 * the agent path. The actual DSP write happens when the merchant
+	 * submits via the widget — we trust the existing flow for that.
+	 *
+	 * Cross-cutting guardrails (TOS / Blaze-eligibility) run before this
+	 * method via the wrapper installed in `wrap_write_path_execute_callback()`.
+	 *
+	 * The Blaze widget's prefill-from-URL behaviour is a separate piece
+	 * of work in `dsp-client` that this PR doesn't ship; until that
+	 * lands the merchant can still follow the link and edit manually.
 	 *
 	 * @param array $args Ability input — see `get_abilities()` input_schema.
 	 * @return array|\WP_Error
 	 */
 	public static function create_campaign( $args = array() ) {
-		$site_id = \Automattic\Jetpack\Connection\Manager::get_site_id();
-		if ( is_wp_error( $site_id ) ) {
-			return $site_id;
+		$args = is_array( $args ) ? $args : array();
+
+		$urn = isset( $args['target_urn'] ) ? (string) $args['target_urn'] : '';
+		if ( '' === $urn || ! preg_match( '/^urn:wpcom:post:\d+:(\d+)$/', $urn, $matches ) ) {
+			return new \WP_Error(
+				'blaze_invalid_target_urn',
+				/* translators: %s: the malformed URN value supplied by the caller. */
+				sprintf( __( 'Invalid target_urn %s. Expected format: urn:wpcom:post:<site_id>:<post_id>.', 'jetpack-blaze' ), $urn ),
+				array( 'status' => 400 )
+			);
 		}
 
-		$route   = sprintf( '/jetpack/v4/blaze-app/sites/%d/wordads/dsp/api/v1.1/campaigns', $site_id );
-		$request = new WP_REST_Request( 'POST', $route );
-		$request->set_header( 'Content-Type', 'application/json' );
-		$request->set_body( wp_json_encode( $args, JSON_UNESCAPED_SLASHES ) );
-
-		$response = rest_do_request( $request );
-		if ( $response->is_error() ) {
-			return $response->as_error();
+		$post = get_post( (int) $matches[1] );
+		if ( ! $post ) {
+			return new \WP_Error(
+				'blaze_post_not_found',
+				__( 'Post referenced by target_urn does not exist on this site.', 'jetpack-blaze' ),
+				array( 'status' => 404 )
+			);
 		}
 
-		$data = $response->get_data();
+		$prefill     = self::build_prefill_payload( $args, $post );
+		$prefill_url = self::build_prefill_url( $post->ID, $prefill );
 
 		return array(
-			'campaign_id'  => isset( $data['campaign_id'] ) ? (string) $data['campaign_id'] : ( isset( $data['id'] ) ? (string) $data['id'] : '' ),
-			'status'       => 'draft',
-			'approval_url' => self::get_approval_url( $args, $data ),
-			'campaign'     => $data,
+			'status'      => 'pending_merchant_review',
+			'message'     => sprintf(
+				/* translators: %s: deep-link URL that opens the Blaze widget pre-populated with the drafted campaign. */
+				__( 'Draft prepared. The merchant must open the Blaze UI to review, accept payment / T&C, and submit. Open here: %s', 'jetpack-blaze' ),
+				$prefill_url
+			),
+			'prefill_url' => $prefill_url,
+			'prefill'     => $prefill,
 		);
 	}
 
 	/**
-	 * Build the deep-link the merchant follows to preview and approve a
-	 * draft campaign.
+	 * Build the campaign prefill payload from the caller's MCP input and
+	 * the resolved target post. Pure function — no I/O — so it's easy to
+	 * test and easy for callers to inspect in the response.
 	 *
-	 * Phase 2 punts to the existing Blaze management URL family — that's
-	 * the SPA where drafts can be reviewed today. The exact in-SPA route
-	 * for "approve this specific draft" may need a follow-up with the
-	 * Calypso team; for now we land the merchant in the advertising
-	 * dashboard with the campaign visible.
+	 * Caller input (`site_name`, `text_snippet`, `objective`, `is_evergreen`)
+	 * overrides the post-derived defaults. Anything we can't pull from
+	 * the post or the input is left out — the widget will fill blanks
+	 * with its own defaults at submission time.
 	 *
-	 * @param array $args         Original ability input (used for target_urn fallback).
-	 * @param array $dsp_response Response payload from the DSP create route. Reserved for future use (campaign-id-based deep-link lookup).
+	 * @param array    $args MCP input.
+	 * @param \WP_Post $post The target post.
+	 * @return array
+	 */
+	private static function build_prefill_payload( array $args, $post ): array {
+		$featured_image_id   = (int) get_post_thumbnail_id( $post->ID );
+		$featured_image_url  = $featured_image_id > 0 ? wp_get_attachment_image_url( $featured_image_id, 'full' ) : '';
+		$featured_image_mime = $featured_image_id > 0 ? get_post_mime_type( $featured_image_id ) : '';
+
+		// Sensible default snippet: post excerpt, or first ~200 chars of content stripped of HTML.
+		$default_snippet = (string) get_the_excerpt( $post );
+		if ( '' === $default_snippet ) {
+			$stripped        = trim( wp_strip_all_tags( (string) $post->post_content ) );
+			$default_snippet = function_exists( 'mb_substr' ) ? mb_substr( $stripped, 0, 200 ) : substr( $stripped, 0, 200 );
+		}
+
+		$payload = array(
+			'target_urn'    => (string) $args['target_urn'],
+			'type'          => (string) $post->post_type,
+			'site_name'     => isset( $args['site_name'] ) && '' !== (string) $args['site_name']
+				? (string) $args['site_name']
+				: (string) get_the_title( $post ),
+			'text_snippet'  => isset( $args['text_snippet'] ) && '' !== (string) $args['text_snippet']
+				? (string) $args['text_snippet']
+				: $default_snippet,
+			'target_url'    => (string) get_permalink( $post ),
+			'budget'        => array(
+				'mode'     => 'total',
+				'amount'   => (float) ( $args['budget_total'] ?? 0 ),
+				'currency' => self::get_site_currency(),
+			),
+			'duration_days' => (int) ( $args['duration_days'] ?? 7 ),
+			'is_evergreen'  => isset( $args['is_evergreen'] ) ? (bool) $args['is_evergreen'] : true,
+			'objective'     => isset( $args['objective'] ) && '' !== (string) $args['objective']
+				? (string) $args['objective']
+				: 'VIEWS',
+		);
+
+		if ( '' !== $featured_image_url ) {
+			$payload['main_image'] = array(
+				'url'       => $featured_image_url,
+				'mime_type' => $featured_image_mime ? $featured_image_mime : 'image/jpeg',
+			);
+		}
+
+		return $payload;
+	}
+
+	/**
+	 * Build the deep-link the merchant follows to land in the Blaze
+	 * widget with the campaign form pre-populated.
+	 *
+	 * URL shape: `<admin>/tools.php?page=advertising&blaze_prefill=<base64-json>#!/advertising/posts/promote/post-<id>/<hostname>`.
+	 *
+	 * The base path comes from `Blaze::get_campaign_management_url()` so
+	 * we stay aligned with how Blaze opens the promote-post flow today;
+	 * the `blaze_prefill` query param is the Phase 2 addition the widget
+	 * will read on load. The param goes in the query string (not the
+	 * hash) so it reaches the SPA on initial bootstrap reliably.
+	 *
+	 * @param int   $post_id The target post ID.
+	 * @param array $prefill The prefill payload to encode.
 	 * @return string
 	 */
-	private static function get_approval_url( array $args, $dsp_response ) {
-		unset( $dsp_response );
-		// Try to extract a post ID from the target URN to leverage the
-		// existing `Blaze::get_campaign_management_url()` helper.
-		$post_id = 0;
-		$urn     = isset( $args['target_urn'] ) ? (string) $args['target_urn'] : '';
-		if ( $urn && preg_match( '/^urn:wpcom:post:\d+:(\d+)$/', $urn, $m ) ) {
-			$post_id = (int) $m[1];
-		}
-
-		if ( $post_id > 0 && class_exists( '\Automattic\Jetpack\Blaze' ) ) {
+	private static function build_prefill_url( int $post_id, array $prefill ): string {
+		$base = '';
+		if ( class_exists( '\Automattic\Jetpack\Blaze' ) && method_exists( '\Automattic\Jetpack\Blaze', 'get_campaign_management_url' ) ) {
 			$url_data = Blaze::get_campaign_management_url( $post_id );
-			return is_array( $url_data ) && isset( $url_data['link'] ) ? $url_data['link'] : '';
+			if ( is_array( $url_data ) && isset( $url_data['link'] ) ) {
+				$base = (string) $url_data['link'];
+			}
+		}
+		if ( '' === $base ) {
+			$base = admin_url( 'tools.php?page=advertising' );
 		}
 
-		// Fallback: the bare advertising dashboard.
-		return admin_url( 'tools.php?page=advertising' );
+		$encoded = self::base64url_encode( (string) wp_json_encode( $prefill, JSON_UNESCAPED_SLASHES ) );
+		$param   = 'blaze_prefill=' . rawurlencode( $encoded );
+
+		// Insert the param before the hash if there is one; otherwise append.
+		$hash_pos = strpos( $base, '#' );
+		if ( false === $hash_pos ) {
+			$separator = ( false !== strpos( $base, '?' ) ) ? '&' : '?';
+			return $base . $separator . $param;
+		}
+
+		$pre_hash  = substr( $base, 0, $hash_pos );
+		$hash      = substr( $base, $hash_pos );
+		$separator = ( false !== strpos( $pre_hash, '?' ) ) ? '&' : '?';
+
+		return $pre_hash . $separator . $param . $hash;
+	}
+
+	/**
+	 * URL-safe base64 encode (RFC 4648 §5). Avoids `+` and `/` characters
+	 * that would otherwise need percent-encoding inside a URL.
+	 *
+	 * @param string $input Bytes to encode.
+	 * @return string
+	 */
+	private static function base64url_encode( string $input ): string {
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Encoding a structured prefill payload, not obfuscation.
+		return rtrim( strtr( base64_encode( $input ), '+/', '-_' ), '=' );
+	}
+
+	/**
+	 * Resolve the site's currency code. Uses the WooCommerce currency
+	 * when Woo is active (most relevant for our v1 audience), otherwise
+	 * falls back to USD — DSP defaults to USD too.
+	 *
+	 * @return string ISO 4217 currency code.
+	 */
+	private static function get_site_currency(): string {
+		if ( function_exists( 'get_woocommerce_currency' ) ) {
+			$currency = (string) get_woocommerce_currency();
+			if ( '' !== $currency ) {
+				return $currency;
+			}
+		}
+		return 'USD';
 	}
 
 	/**

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -629,7 +629,7 @@ class Blaze_Abilities extends Registrar {
 			return $args;
 		}
 
-		$original_callback = isset( $args['execute_callback'] ) ? $args['execute_callback'] : null;
+		$original_callback = $args['execute_callback'] ?? null;
 		if ( ! is_callable( $original_callback ) ) {
 			return $args;
 		}

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -442,6 +442,10 @@ class Blaze_Abilities extends Registrar {
 			'text_snippet'  => isset( $args['text_snippet'] ) && '' !== (string) $args['text_snippet']
 				? (string) $args['text_snippet']
 				: $default_snippet,
+			// Default CTA varies by post type — products get a commerce-flavoured
+			// "Shop Now", everything else gets the neutral "Learn More". The widget
+			// requires a non-empty CTA to clear validation, so we always send one.
+			'cta_text'      => 'product' === (string) $post->post_type ? 'Shop Now' : 'Learn More',
 			'target_url'    => (string) get_permalink( $post ),
 			'budget'        => array(
 				'mode'     => 'total',
@@ -523,19 +527,16 @@ class Blaze_Abilities extends Registrar {
 	}
 
 	/**
-	 * Resolve the site's currency code. Uses the WooCommerce currency
-	 * when Woo is active (most relevant for our v1 audience), otherwise
-	 * falls back to USD — DSP defaults to USD too.
+	 * Currency code for the prefill payload.
+	 *
+	 * Always USD: the DSP only supports USD for billing, so reading the
+	 * Woo store currency would just produce a misleading number for
+	 * non-USD merchants (the DSP would re-interpret the amount as USD
+	 * regardless). Until the DSP gains multi-currency, normalize here.
 	 *
 	 * @return string ISO 4217 currency code.
 	 */
 	private static function get_site_currency(): string {
-		if ( function_exists( 'get_woocommerce_currency' ) ) {
-			$currency = (string) get_woocommerce_currency();
-			if ( '' !== $currency ) {
-				return $currency;
-			}
-		}
 		return 'USD';
 	}
 

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -493,7 +493,9 @@ class Blaze_Abilities extends Registrar {
 			$languages = array_values(
 				array_filter(
 					array_map( 'strtolower', array_map( 'strval', $args['languages'] ) ),
-					static fn( $code ) => '' !== $code
+					static function ( $code ) {
+						return '' !== $code;
+					}
 				)
 			);
 			if ( ! empty( $languages ) ) {
@@ -504,7 +506,9 @@ class Blaze_Abilities extends Registrar {
 			$countries = array_values(
 				array_filter(
 					array_map( 'strtoupper', array_map( 'strval', $args['countries'] ) ),
-					static fn( $code ) => 2 === strlen( $code )
+					static function ( $code ) {
+						return 2 === strlen( $code );
+					}
 				)
 			);
 			if ( ! empty( $countries ) ) {

--- a/projects/packages/blaze/src/abilities/class-blaze-abilities.php
+++ b/projects/packages/blaze/src/abilities/class-blaze-abilities.php
@@ -256,6 +256,24 @@ class Blaze_Abilities extends Registrar {
 							'type'        => 'string',
 							'description' => __( 'Optional ad copy override. Defaults to the post excerpt (or first ~200 chars of content).', 'jetpack-blaze' ),
 						),
+						'languages'     => array(
+							'type'        => 'array',
+							'description' => __( 'Optional ISO 639-1 language codes to target (e.g. ["en", "es"]). Defaults to all languages when omitted; pass a non-empty array to narrow targeting.', 'jetpack-blaze' ),
+							'items'       => array(
+								'type'      => 'string',
+								'minLength' => 2,
+								'maxLength' => 5,
+							),
+						),
+						'countries'     => array(
+							'type'        => 'array',
+							'description' => __( 'Optional ISO 3166-1 alpha-2 country codes to target (e.g. ["US", "GB"]). Defaults to worldwide when omitted; pass a non-empty array to limit reach to those countries.', 'jetpack-blaze' ),
+							'items'       => array(
+								'type'      => 'string',
+								'minLength' => 2,
+								'maxLength' => 2,
+							),
+						),
 					),
 					'additionalProperties' => false,
 				),
@@ -464,6 +482,34 @@ class Blaze_Abilities extends Registrar {
 				'url'       => $featured_image_url,
 				'mime_type' => $featured_image_mime ? $featured_image_mime : 'image/jpeg',
 			);
+		}
+
+		// Optional targeting overrides. Pass-through normalisation only — the
+		// widget resolves country codes to its internal geo records and the
+		// language codes map straight to the language picker. Empty arrays
+		// are dropped so the widget keeps its "all languages / worldwide"
+		// defaults instead of being forced to an empty selection.
+		if ( isset( $args['languages'] ) && is_array( $args['languages'] ) ) {
+			$languages = array_values(
+				array_filter(
+					array_map( 'strtolower', array_map( 'strval', $args['languages'] ) ),
+					static fn( $code ) => '' !== $code
+				)
+			);
+			if ( ! empty( $languages ) ) {
+				$payload['languages'] = $languages;
+			}
+		}
+		if ( isset( $args['countries'] ) && is_array( $args['countries'] ) ) {
+			$countries = array_values(
+				array_filter(
+					array_map( 'strtoupper', array_map( 'strval', $args['countries'] ) ),
+					static fn( $code ) => 2 === strlen( $code )
+				)
+			);
+			if ( ! empty( $countries ) ) {
+				$payload['countries'] = $countries;
+			}
 		}
 
 		return $payload;

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -61,7 +61,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		Jetpack_Options::delete_option( 'id' );
 		remove_all_filters( 'wp_register_ability_args' );
 		remove_all_filters( 'jetpack_wp_abilities_should_register' );
-		remove_all_filters( 'blaze_abilities_create_campaign_enabled' );
+		remove_all_filters( 'blaze_abilities_prepare_campaign_enabled' );
 		remove_all_actions( 'wp_after_execute_ability' );
 	}
 
@@ -194,7 +194,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 			'meta' => array( 'annotations' => array( 'readonly' => false ) ),
 		);
 
-		$result = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_CREATE_CAMPAIGN );
+		$result = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN );
 
 		$this->assertSame( $args, $result, 'Missing callback should leave args untouched.' );
 	}
@@ -212,7 +212,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 			'meta'             => array( 'annotations' => array( 'readonly' => false ) ),
 		);
 
-		$result = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_CREATE_CAMPAIGN );
+		$result = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN );
 
 		$this->assertNotSame( $callback, $result['execute_callback'], 'Write-ability callback must be wrapped.' );
 		$this->assertIsCallable( $result['execute_callback'] );
@@ -241,7 +241,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 			'meta'             => array( 'annotations' => array( 'readonly' => false ) ),
 		);
 
-		$wrapped = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_CREATE_CAMPAIGN );
+		$wrapped = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN );
 		$result  = call_user_func( $wrapped['execute_callback'], array( 'budget_total' => 50 ) );
 
 		$this->assertSame( array( 'campaign_id' => 'abc-123' ), $result, 'Original callback result should pass through unchanged.' );
@@ -272,7 +272,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 			'meta'             => array( 'annotations' => array( 'readonly' => false ) ),
 		);
 
-		$wrapped = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_CREATE_CAMPAIGN );
+		$wrapped = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN );
 		$result  = call_user_func( $wrapped['execute_callback'], array( 'budget_total' => 50 ) );
 
 		$this->assertFalse( $called, 'Original callback must not run when TOS check fails.' );
@@ -304,45 +304,45 @@ class Blaze_Abilities_Test extends BaseTestCase {
 	public function test_inheritance_documented_via_owned_slugs_constant() {
 		$owned = Blaze_Abilities::OWNED_ABILITY_SLUGS;
 		$this->assertContains( Blaze_Abilities::ABILITY_LIST_CAMPAIGNS, $owned );
-		$this->assertContains( Blaze_Abilities::ABILITY_CREATE_CAMPAIGN, $owned );
+		$this->assertContains( Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN, $owned );
 
 		// Sanity: anything in OWNED_ABILITY_SLUGS that's a write ability gets
-		// wrapped. We exercise create-campaign here as the canonical write slug.
+		// wrapped. We exercise prepare-campaign here as the canonical write slug.
 		$args = array(
 			'execute_callback' => static function () {
 				return 'x';
 			},
 			'meta'             => array( 'annotations' => array( 'readonly' => false ) ),
 		);
-		$out  = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_CREATE_CAMPAIGN );
+		$out  = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN );
 		$this->assertNotSame( $args['execute_callback'], $out['execute_callback'] );
 	}
 
 	// --- Kill-switch ---
 
 	/**
-	 * Filter returning false on `blaze_abilities_create_campaign_enabled`
+	 * Filter returning false on `blaze_abilities_prepare_campaign_enabled`
 	 * makes the double-register guard refuse to register the slug —
 	 * MCP clients won't see the tool, REST callers get 404.
 	 */
-	public function test_kill_switch_drops_create_campaign_registration() {
-		add_filter( 'blaze_abilities_create_campaign_enabled', '__return_false' );
+	public function test_kill_switch_drops_prepare_campaign_registration() {
+		add_filter( 'blaze_abilities_prepare_campaign_enabled', '__return_false' );
 
-		$enabled = Blaze_Abilities::guard_against_double_register( true, 'ability', Blaze_Abilities::ABILITY_CREATE_CAMPAIGN );
+		$enabled = Blaze_Abilities::guard_against_double_register( true, 'ability', Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN );
 
-		$this->assertFalse( $enabled, 'Kill-switch must drop create-campaign registration when set to false.' );
+		$this->assertFalse( $enabled, 'Kill-switch must drop prepare-campaign registration when set to false.' );
 	}
 
 	/**
-	 * Kill-switch is scoped to create-campaign — the read-only
+	 * Kill-switch is scoped to prepare-campaign — the read-only
 	 * list-campaigns ability is unaffected.
 	 */
 	public function test_kill_switch_does_not_affect_list_campaigns() {
-		add_filter( 'blaze_abilities_create_campaign_enabled', '__return_false' );
+		add_filter( 'blaze_abilities_prepare_campaign_enabled', '__return_false' );
 
 		$enabled = Blaze_Abilities::guard_against_double_register( true, 'ability', Blaze_Abilities::ABILITY_LIST_CAMPAIGNS );
 
-		$this->assertTrue( $enabled, 'Kill-switch must only affect create-campaign.' );
+		$this->assertTrue( $enabled, 'Kill-switch must only affect prepare-campaign.' );
 	}
 
 	// --- Woo MCP opt-in ---
@@ -353,7 +353,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 	 */
 	public function test_opt_into_woo_mcp_for_owned_slugs() {
 		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( false, Blaze_Abilities::ABILITY_LIST_CAMPAIGNS ) );
-		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( false, Blaze_Abilities::ABILITY_CREATE_CAMPAIGN ) );
+		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( false, Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ) );
 
 		// Foreign slug, default false — should remain false (we don't toggle other people's abilities on).
 		$this->assertFalse( Blaze_Abilities::opt_into_woo_mcp( false, 'jetpack-forms/get-responses' ) );
@@ -361,11 +361,41 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( true, 'woocommerce/list-products' ) );
 	}
 
-	// --- create_campaign: prefill payload + URL ---
+	// --- prepare-campaign public schema ---
+
+	/**
+	 * The public write ability is prepare-campaign and its MCP-facing
+	 * input contract requires only the target. Budget/duration are
+	 * optional hints, and the raw DSP objective stays server-owned.
+	 */
+	public function test_prepare_campaign_schema_is_minimal_and_renamed() {
+		$abilities = Blaze_Abilities::get_abilities();
+
+		$this->assertArrayHasKey( 'blaze-ads/prepare-campaign', $abilities );
+
+		$schema     = $abilities[ Blaze_Abilities::ABILITY_PREPARE_CAMPAIGN ]['input_schema'];
+		$properties = $schema['properties'];
+
+		$this->assertSame( array( 'target_urn' ), $schema['required'] );
+		$this->assertFalse( $schema['additionalProperties'] );
+		$this->assertArrayHasKey( 'goal', $properties );
+		$this->assertArrayHasKey( 'budget_total', $properties );
+		$this->assertArrayHasKey( 'duration_days', $properties );
+		$this->assertArrayHasKey( 'revision_instruction', $properties );
+		$this->assertArrayHasKey( 'site_name', $properties );
+		$this->assertArrayHasKey( 'text_snippet', $properties );
+		$this->assertArrayHasKey( 'cta_text', $properties );
+		$this->assertArrayHasKey( 'main_image_url', $properties );
+		$this->assertArrayHasKey( 'languages', $properties );
+		$this->assertArrayHasKey( 'countries', $properties );
+		$this->assertArrayNotHasKey( 'objective', $properties );
+	}
+
+	// --- prepare_campaign: prefill payload + URL ---
 
 	/**
 	 * Helper: insert a test post and return its ID. Returns the
-	 * synthetic URN that callers should pass to create_campaign.
+	 * synthetic URN that callers should pass to prepare_campaign.
 	 */
 	private function make_test_post( array $overrides = array() ): array {
 		$post_id = wp_insert_post(
@@ -387,14 +417,12 @@ class Blaze_Abilities_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Invalid target_urn returns a WP_Error with status 400, not a partial draft.
+	 * Invalid target_urn returns a WP_Error with status 400, not a partial proposal.
 	 */
-	public function test_create_campaign_returns_error_for_invalid_target_urn() {
-		$result = Blaze_Abilities::create_campaign(
+	public function test_prepare_campaign_returns_error_for_invalid_target_urn() {
+		$result = Blaze_Abilities::prepare_campaign(
 			array(
-				'target_urn'    => 'not-a-urn',
-				'budget_total'  => 50,
-				'duration_days' => 7,
+				'target_urn' => 'not-a-urn',
 			)
 		);
 
@@ -407,12 +435,10 @@ class Blaze_Abilities_Test extends BaseTestCase {
 	/**
 	 * URN that parses but references a missing post returns a 404 WP_Error.
 	 */
-	public function test_create_campaign_returns_error_for_missing_post() {
-		$result = Blaze_Abilities::create_campaign(
+	public function test_prepare_campaign_returns_error_for_missing_post() {
+		$result = Blaze_Abilities::prepare_campaign(
 			array(
-				'target_urn'    => sprintf( 'urn:wpcom:post:%d:9999999', self::TEST_SITE_ID ),
-				'budget_total'  => 50,
-				'duration_days' => 7,
+				'target_urn' => sprintf( 'urn:wpcom:post:%d:9999999', self::TEST_SITE_ID ),
 			)
 		);
 
@@ -427,10 +453,10 @@ class Blaze_Abilities_Test extends BaseTestCase {
 	 * prefill_url + prefill payload, and the defaults are pulled from
 	 * the target post.
 	 */
-	public function test_create_campaign_returns_prefill_payload_and_url() {
+	public function test_prepare_campaign_returns_prefill_payload_and_url() {
 		$ctx = $this->make_test_post();
 
-		$result = Blaze_Abilities::create_campaign(
+		$result = Blaze_Abilities::prepare_campaign(
 			array(
 				'target_urn'    => $ctx['target_urn'],
 				'budget_total'  => 50,
@@ -457,20 +483,44 @@ class Blaze_Abilities_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Caller overrides take precedence over post-derived defaults.
+	 * Minimal input is enough to prepare a proposal. Budget/duration
+	 * defaults stay server-owned for this slice.
 	 */
-	public function test_create_campaign_caller_overrides_win() {
+	public function test_prepare_campaign_accepts_minimal_input() {
 		$ctx = $this->make_test_post();
 
-		$result = Blaze_Abilities::create_campaign(
+		$result = Blaze_Abilities::prepare_campaign(
 			array(
-				'target_urn'    => $ctx['target_urn'],
-				'budget_total'  => 100,
-				'duration_days' => 30,
-				'site_name'     => 'Custom heading',
-				'text_snippet'  => 'Custom ad copy.',
-				'objective'     => 'CLICKS',
-				'is_evergreen'  => false,
+				'target_urn' => $ctx['target_urn'],
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$prefill = $result['prefill'];
+		$this->assertSame( 50.0, $prefill['budget']['amount'] );
+		$this->assertSame( 7, $prefill['duration_days'] );
+		$this->assertSame( 'VIEWS', $prefill['objective'] );
+	}
+
+	/**
+	 * Caller overrides take precedence over post-derived defaults.
+	 */
+	public function test_prepare_campaign_caller_overrides_win() {
+		$ctx = $this->make_test_post();
+
+		$result = Blaze_Abilities::prepare_campaign(
+			array(
+				'target_urn'           => $ctx['target_urn'],
+				'budget_total'         => 100,
+				'duration_days'        => 30,
+				'site_name'            => 'Custom heading',
+				'text_snippet'         => 'Custom ad copy.',
+				'cta_text'             => 'Buy now',
+				'goal'                 => 'Drive sales for a spring promotion.',
+				'revision_instruction' => 'Make it less salesy.',
+				'main_image_url'       => 'https://example.com/custom.jpg',
+				'main_image_mime_type' => 'image/jpeg',
+				'is_evergreen'         => false,
 			)
 		);
 
@@ -478,7 +528,11 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$prefill = $result['prefill'];
 		$this->assertSame( 'Custom heading', $prefill['site_name'] );
 		$this->assertSame( 'Custom ad copy.', $prefill['text_snippet'] );
-		$this->assertSame( 'CLICKS', $prefill['objective'] );
+		$this->assertSame( 'Buy now', $prefill['cta_text'] );
+		$this->assertSame( 'Drive sales for a spring promotion.', $prefill['goal'] );
+		$this->assertSame( 'Make it less salesy.', $prefill['revision_instruction'] );
+		$this->assertSame( 'https://example.com/custom.jpg', $prefill['main_image']['url'] );
+		$this->assertSame( 'VIEWS', $prefill['objective'], 'DSP objective is server-owned and not overridden by public input.' );
 		$this->assertFalse( $prefill['is_evergreen'] );
 	}
 
@@ -487,7 +541,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 	 * stripped + truncated post content. This proves we don't return an
 	 * empty snippet (which the widget would surface as an empty heading).
 	 */
-	public function test_create_campaign_falls_back_to_stripped_content_when_no_excerpt() {
+	public function test_prepare_campaign_falls_back_to_stripped_content_when_no_excerpt() {
 		$ctx = $this->make_test_post(
 			array(
 				'post_excerpt' => '',
@@ -495,7 +549,7 @@ class Blaze_Abilities_Test extends BaseTestCase {
 			)
 		);
 
-		$result = Blaze_Abilities::create_campaign(
+		$result = Blaze_Abilities::prepare_campaign(
 			array(
 				'target_urn'    => $ctx['target_urn'],
 				'budget_total'  => 50,

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -1,17 +1,19 @@
 <?php
 /**
- * Tests for Blaze Abilities registration.
+ * Tests for Blaze_Abilities — registration, the write-path wrapper,
+ * inheritance behaviour, and the audit-log listener.
  *
  * @package automattic/jetpack-blaze
  */
 
-// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9; tests exercise guarded integration points directly.
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9; tests gate with markTestSkipped() when the API isn't loaded in the test environment.
 
 namespace Automattic\Jetpack\Blaze\Abilities;
 
 use Jetpack_Options;
 use PHPUnit\Framework\Attributes\CoversClass;
 use WorDBless\BaseTestCase;
+use WP_Error;
 
 /**
  * @covers \Automattic\Jetpack\Blaze\Abilities\Blaze_Abilities
@@ -20,26 +22,50 @@ use WorDBless\BaseTestCase;
 class Blaze_Abilities_Test extends BaseTestCase {
 
 	/**
-	 * Synthetic site ID used by the Blaze list-campaigns REST delegation.
+	 * Synthetic site ID used by Connection_Manager::get_site_id() and
+	 * by the Blaze::site_supports_blaze() transient lookup.
 	 *
 	 * @var int
 	 */
 	private const TEST_SITE_ID = 12345;
 
 	/**
-	 * Set up before each test.
+	 * Original `wp_register_ability_args` filter callbacks, captured so
+	 * we can restore them after each test.
+	 *
+	 * @var array|null
+	 */
+	private $original_args_filter;
+
+	/**
+	 * Set up: connect a synthetic site so Connection_Manager::get_site_id()
+	 * resolves, and pre-populate the Blaze eligibility transient so the
+	 * TOS check has a deterministic answer per test.
 	 */
 	public function set_up() {
 		Jetpack_Options::update_option( 'id', self::TEST_SITE_ID );
+
+		// Default: site is eligible. Individual tests can override.
+		set_transient(
+			'jetpack_blaze_site_supports_blaze_' . self::TEST_SITE_ID,
+			array( 'approved' => true ),
+			DAY_IN_SECONDS
+		);
 	}
 
 	/**
-	 * Tear down after each test.
+	 * Tear down: clear the transient and any filter we may have added.
 	 */
 	public function tear_down() {
+		delete_transient( 'jetpack_blaze_site_supports_blaze_' . self::TEST_SITE_ID );
 		Jetpack_Options::delete_option( 'id' );
+		remove_all_filters( 'wp_register_ability_args' );
 		remove_all_filters( 'jetpack_wp_abilities_should_register' );
+		remove_all_filters( 'blaze_abilities_create_campaign_enabled' );
+		remove_all_actions( 'wp_after_execute_ability' );
 	}
+
+	// --- list-campaigns read ability ---
 
 	/**
 	 * Category metadata is stable for clients that group MCP tools.
@@ -71,15 +97,6 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		$this->assertFalse( $ability['meta']['annotations']['destructive'] );
 		$this->assertTrue( $ability['meta']['annotations']['idempotent'] );
 		$this->assertFalse( $ability['input_schema']['additionalProperties'] );
-	}
-
-	/**
-	 * Woo MCP should include the Blaze ability without altering other abilities.
-	 */
-	public function test_opt_into_woo_mcp_for_list_campaigns() {
-		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( false, Blaze_Abilities::ABILITY_LIST_CAMPAIGNS ) );
-		$this->assertFalse( Blaze_Abilities::opt_into_woo_mcp( false, 'woocommerce/list-products' ) );
-		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( true, 'woocommerce/list-products' ) );
 	}
 
 	/**
@@ -130,5 +147,217 @@ class Blaze_Abilities_Test extends BaseTestCase {
 			),
 			Blaze_Abilities::list_campaigns()
 		);
+	}
+
+	// --- Wrapper: shape and identity behaviour ---
+
+	/**
+	 * Args for an ability we don't own should pass through unchanged.
+	 */
+	public function test_wrapper_passes_through_unowned_abilities() {
+		$callback = static function () {
+			return 'untouched';
+		};
+		$args     = array(
+			'execute_callback' => $callback,
+			'meta'             => array( 'annotations' => array( 'readonly' => false ) ),
+		);
+
+		$result = Blaze_Abilities::wrap_write_path_execute_callback( $args, 'jetpack-forms/get-responses' );
+
+		$this->assertSame( $callback, $result['execute_callback'], 'Unowned-ability callback must be left alone.' );
+	}
+
+	/**
+	 * Args for an owned read-only ability should pass through unchanged.
+	 */
+	public function test_wrapper_passes_through_read_only_owned_abilities() {
+		$callback = static function () {
+			return 'list-result';
+		};
+		$args     = array(
+			'execute_callback' => $callback,
+			'meta'             => array( 'annotations' => array( 'readonly' => true ) ),
+		);
+
+		$result = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_LIST_CAMPAIGNS );
+
+		$this->assertSame( $callback, $result['execute_callback'], 'Read-only owned-ability callback must be left alone.' );
+	}
+
+	/**
+	 * Args missing an execute_callback are returned unchanged (defensive —
+	 * no closure to wrap).
+	 */
+	public function test_wrapper_no_op_when_callback_missing() {
+		$args = array(
+			'meta' => array( 'annotations' => array( 'readonly' => false ) ),
+		);
+
+		$result = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_CREATE_CAMPAIGN );
+
+		$this->assertSame( $args, $result, 'Missing callback should leave args untouched.' );
+	}
+
+	/**
+	 * Args for an owned write ability must come back with a different
+	 * execute_callback (i.e. the wrapper actually swapped it).
+	 */
+	public function test_wrapper_replaces_callback_for_write_abilities() {
+		$callback = static function () {
+			return 'original-result';
+		};
+		$args     = array(
+			'execute_callback' => $callback,
+			'meta'             => array( 'annotations' => array( 'readonly' => false ) ),
+		);
+
+		$result = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_CREATE_CAMPAIGN );
+
+		$this->assertNotSame( $callback, $result['execute_callback'], 'Write-ability callback must be wrapped.' );
+		$this->assertIsCallable( $result['execute_callback'] );
+	}
+
+	// --- Wrapped callback: TOS gate + delegation ---
+
+	/**
+	 * When the site is Blaze-eligible the wrapper delegates to the
+	 * original callback and forwards its return value.
+	 */
+	public function test_wrapped_callback_delegates_when_tos_passes() {
+		set_transient(
+			'jetpack_blaze_site_supports_blaze_' . self::TEST_SITE_ID,
+			array( 'approved' => true ),
+			DAY_IN_SECONDS
+		);
+
+		$received_input = null;
+		$callback       = static function ( $input ) use ( &$received_input ) {
+			$received_input = $input;
+			return array( 'campaign_id' => 'abc-123' );
+		};
+		$args           = array(
+			'execute_callback' => $callback,
+			'meta'             => array( 'annotations' => array( 'readonly' => false ) ),
+		);
+
+		$wrapped = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_CREATE_CAMPAIGN );
+		$result  = call_user_func( $wrapped['execute_callback'], array( 'budget_total' => 50 ) );
+
+		$this->assertSame( array( 'campaign_id' => 'abc-123' ), $result, 'Original callback result should pass through unchanged.' );
+		$this->assertSame( array( 'budget_total' => 50 ), $received_input, 'Original callback should receive the original input.' );
+	}
+
+	/**
+	 * When the site is NOT Blaze-eligible the wrapper short-circuits with
+	 * a WP_Error before invoking the original callback. The deep-link must
+	 * appear in the message text (the Woo MCP adapter strips
+	 * WP_Error::data, so message is the only field that reaches MCP
+	 * clients).
+	 */
+	public function test_wrapped_callback_aborts_when_tos_fails() {
+		set_transient(
+			'jetpack_blaze_site_supports_blaze_' . self::TEST_SITE_ID,
+			array( 'approved' => false ),
+			HOUR_IN_SECONDS
+		);
+
+		$called   = false;
+		$callback = static function () use ( &$called ) {
+			$called = true;
+			return array( 'campaign_id' => 'should-not-happen' );
+		};
+		$args     = array(
+			'execute_callback' => $callback,
+			'meta'             => array( 'annotations' => array( 'readonly' => false ) ),
+		);
+
+		$wrapped = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_CREATE_CAMPAIGN );
+		$result  = call_user_func( $wrapped['execute_callback'], array( 'budget_total' => 50 ) );
+
+		$this->assertFalse( $called, 'Original callback must not run when TOS check fails.' );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'blaze_setup_required', $result->get_error_code() );
+
+		$message = $result->get_error_message();
+		$fix_url = admin_url( 'tools.php?page=advertising' );
+		$this->assertStringContainsString( $fix_url, $message, 'Deep-link URL must be embedded in the error message text — the Woo MCP adapter strips WP_Error::data.' );
+
+		$data = $result->get_error_data();
+		$this->assertIsArray( $data );
+		$this->assertSame( $fix_url, $data['fix_url'] ?? null, 'Belt-and-braces: data field still carries the fix_url for direct REST callers.' );
+	}
+
+	// --- Inheritance: synthetic write ability gets the same treatment ---
+
+	/**
+	 * The wrapper is keyed on `meta.annotations.readonly === false` and
+	 * `OWNED_ABILITY_SLUGS`. To prove future Phase 3 abilities inherit it
+	 * for free, this test uses a fictional slug as if it were owned and
+	 * confirms the wrapper would apply.
+	 *
+	 * (We can't actually add a slug to the OWNED_ABILITY_SLUGS const at
+	 * runtime — instead this test documents that *adding* a new write
+	 * slug to that array is the only step a Phase 3 ability has to take
+	 * to inherit the guardrails.)
+	 */
+	public function test_inheritance_documented_via_owned_slugs_constant() {
+		$owned = Blaze_Abilities::OWNED_ABILITY_SLUGS;
+		$this->assertContains( Blaze_Abilities::ABILITY_LIST_CAMPAIGNS, $owned );
+		$this->assertContains( Blaze_Abilities::ABILITY_CREATE_CAMPAIGN, $owned );
+
+		// Sanity: anything in OWNED_ABILITY_SLUGS that's a write ability gets
+		// wrapped. We exercise create-campaign here as the canonical write slug.
+		$args = array(
+			'execute_callback' => static function () {
+				return 'x';
+			},
+			'meta'             => array( 'annotations' => array( 'readonly' => false ) ),
+		);
+		$out  = Blaze_Abilities::wrap_write_path_execute_callback( $args, Blaze_Abilities::ABILITY_CREATE_CAMPAIGN );
+		$this->assertNotSame( $args['execute_callback'], $out['execute_callback'] );
+	}
+
+	// --- Kill-switch ---
+
+	/**
+	 * Filter returning false on `blaze_abilities_create_campaign_enabled`
+	 * makes the double-register guard refuse to register the slug —
+	 * MCP clients won't see the tool, REST callers get 404.
+	 */
+	public function test_kill_switch_drops_create_campaign_registration() {
+		add_filter( 'blaze_abilities_create_campaign_enabled', '__return_false' );
+
+		$enabled = Blaze_Abilities::guard_against_double_register( true, 'ability', Blaze_Abilities::ABILITY_CREATE_CAMPAIGN );
+
+		$this->assertFalse( $enabled, 'Kill-switch must drop create-campaign registration when set to false.' );
+	}
+
+	/**
+	 * Kill-switch is scoped to create-campaign — the read-only
+	 * list-campaigns ability is unaffected.
+	 */
+	public function test_kill_switch_does_not_affect_list_campaigns() {
+		add_filter( 'blaze_abilities_create_campaign_enabled', '__return_false' );
+
+		$enabled = Blaze_Abilities::guard_against_double_register( true, 'ability', Blaze_Abilities::ABILITY_LIST_CAMPAIGNS );
+
+		$this->assertTrue( $enabled, 'Kill-switch must only affect create-campaign.' );
+	}
+
+	// --- Woo MCP opt-in ---
+
+	/**
+	 * Both owned slugs are opted into Woo's MCP whitelist; foreign slugs
+	 * are passed through unchanged.
+	 */
+	public function test_opt_into_woo_mcp_for_owned_slugs() {
+		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( false, Blaze_Abilities::ABILITY_LIST_CAMPAIGNS ) );
+		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( false, Blaze_Abilities::ABILITY_CREATE_CAMPAIGN ) );
+
+		// Foreign slug, default false — should remain false (we don't toggle other people's abilities on).
+		$this->assertFalse( Blaze_Abilities::opt_into_woo_mcp( false, 'jetpack-forms/get-responses' ) );
+		// Foreign slug, default true (Woo's own) — should remain true.
+		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( true, 'woocommerce/list-products' ) );
 	}
 }

--- a/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
+++ b/projects/packages/blaze/tests/php/abilities/Blaze_Abilities_Test.php
@@ -360,4 +360,153 @@ class Blaze_Abilities_Test extends BaseTestCase {
 		// Foreign slug, default true (Woo's own) — should remain true.
 		$this->assertTrue( Blaze_Abilities::opt_into_woo_mcp( true, 'woocommerce/list-products' ) );
 	}
+
+	// --- create_campaign: prefill payload + URL ---
+
+	/**
+	 * Helper: insert a test post and return its ID. Returns the
+	 * synthetic URN that callers should pass to create_campaign.
+	 */
+	private function make_test_post( array $overrides = array() ): array {
+		$post_id = wp_insert_post(
+			array_merge(
+				array(
+					'post_title'   => 'Test product page',
+					'post_excerpt' => 'A short summary about the product.',
+					'post_content' => 'Long-form content that would otherwise be the fallback snippet source.',
+					'post_status'  => 'publish',
+					'post_type'    => 'post',
+				),
+				$overrides
+			)
+		);
+		return array(
+			'post_id'    => (int) $post_id,
+			'target_urn' => sprintf( 'urn:wpcom:post:%d:%d', self::TEST_SITE_ID, (int) $post_id ),
+		);
+	}
+
+	/**
+	 * Invalid target_urn returns a WP_Error with status 400, not a partial draft.
+	 */
+	public function test_create_campaign_returns_error_for_invalid_target_urn() {
+		$result = Blaze_Abilities::create_campaign(
+			array(
+				'target_urn'    => 'not-a-urn',
+				'budget_total'  => 50,
+				'duration_days' => 7,
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'blaze_invalid_target_urn', $result->get_error_code() );
+		$data = $result->get_error_data();
+		$this->assertSame( 400, $data['status'] ?? null );
+	}
+
+	/**
+	 * URN that parses but references a missing post returns a 404 WP_Error.
+	 */
+	public function test_create_campaign_returns_error_for_missing_post() {
+		$result = Blaze_Abilities::create_campaign(
+			array(
+				'target_urn'    => sprintf( 'urn:wpcom:post:%d:9999999', self::TEST_SITE_ID ),
+				'budget_total'  => 50,
+				'duration_days' => 7,
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'blaze_post_not_found', $result->get_error_code() );
+		$data = $result->get_error_data();
+		$this->assertSame( 404, $data['status'] ?? null );
+	}
+
+	/**
+	 * Happy path: returns the canonical pending-review shape with
+	 * prefill_url + prefill payload, and the defaults are pulled from
+	 * the target post.
+	 */
+	public function test_create_campaign_returns_prefill_payload_and_url() {
+		$ctx = $this->make_test_post();
+
+		$result = Blaze_Abilities::create_campaign(
+			array(
+				'target_urn'    => $ctx['target_urn'],
+				'budget_total'  => 50,
+				'duration_days' => 14,
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'pending_merchant_review', $result['status'] );
+		$this->assertNotEmpty( $result['prefill_url'] );
+		$this->assertStringContainsString( 'blaze_prefill=', $result['prefill_url'] );
+		$this->assertStringContainsString( $result['prefill_url'], $result['message'] );
+
+		$prefill = $result['prefill'];
+		$this->assertSame( $ctx['target_urn'], $prefill['target_urn'] );
+		$this->assertSame( 'post', $prefill['type'] );
+		$this->assertSame( 'Test product page', $prefill['site_name'] );
+		$this->assertSame( 'A short summary about the product.', $prefill['text_snippet'] );
+		$this->assertSame( 50.0, $prefill['budget']['amount'] );
+		$this->assertSame( 'total', $prefill['budget']['mode'] );
+		$this->assertSame( 14, $prefill['duration_days'] );
+		$this->assertTrue( $prefill['is_evergreen'] );
+		$this->assertSame( 'VIEWS', $prefill['objective'] );
+	}
+
+	/**
+	 * Caller overrides take precedence over post-derived defaults.
+	 */
+	public function test_create_campaign_caller_overrides_win() {
+		$ctx = $this->make_test_post();
+
+		$result = Blaze_Abilities::create_campaign(
+			array(
+				'target_urn'    => $ctx['target_urn'],
+				'budget_total'  => 100,
+				'duration_days' => 30,
+				'site_name'     => 'Custom heading',
+				'text_snippet'  => 'Custom ad copy.',
+				'objective'     => 'CLICKS',
+				'is_evergreen'  => false,
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$prefill = $result['prefill'];
+		$this->assertSame( 'Custom heading', $prefill['site_name'] );
+		$this->assertSame( 'Custom ad copy.', $prefill['text_snippet'] );
+		$this->assertSame( 'CLICKS', $prefill['objective'] );
+		$this->assertFalse( $prefill['is_evergreen'] );
+	}
+
+	/**
+	 * When the post has no excerpt, the text_snippet falls back to the
+	 * stripped + truncated post content. This proves we don't return an
+	 * empty snippet (which the widget would surface as an empty heading).
+	 */
+	public function test_create_campaign_falls_back_to_stripped_content_when_no_excerpt() {
+		$ctx = $this->make_test_post(
+			array(
+				'post_excerpt' => '',
+				'post_content' => '<p><strong>Hello world.</strong></p> Long-form HTML body that should be stripped.',
+			)
+		);
+
+		$result = Blaze_Abilities::create_campaign(
+			array(
+				'target_urn'    => $ctx['target_urn'],
+				'budget_total'  => 50,
+				'duration_days' => 7,
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$snippet = $result['prefill']['text_snippet'];
+		$this->assertNotEmpty( $snippet );
+		$this->assertStringContainsString( 'Hello world.', $snippet );
+		$this->assertStringNotContainsString( '<strong>', $snippet );
+	}
 }


### PR DESCRIPTION
> **Stacked on top of #48325** (Phase 1). Re-base to `trunk` once that lands.

## Summary

Phase 2 of ADS-953. Adds a `blaze-ads/prepare-campaign` write ability that lets an MCP client prepare a Blaze campaign proposal on the merchant's behalf.

**This ability deliberately does not write to the DSP.** It derives sensible defaults from the target post (title → ad heading, excerpt → snippet, featured image, permalink) and optional caller input (natural-language goal, budget, duration, copy, image, and audience overrides), bundles the result into a structured `blaze_prefill` payload, and returns a deep-link the merchant clicks to land in the existing Blaze widget with every field already populated. The merchant reviews, accepts payment / T&C, and submits from inside the widget — that's where the actual DSP write happens, through the existing flow.

The Blaze widget's prefill-from-URL behaviour is a separate piece of work in `dsp-client`; until that lands the merchant can still follow the link and edit manually.

## How it works

- **`blaze-ads/prepare-campaign` ability** registered with input/output schema, opted into Woo's MCP via `woocommerce_mcp_include_ability`, and gated behind a `blaze_abilities_prepare_campaign_enabled` kill-switch (default true) so we can disable centrally without a release.
- **Minimal public input.** Only `target_urn` is required. `budget_total`, `duration_days`, `goal`, `revision_instruction`, copy/image overrides, and language/country audience overrides are optional. The raw DSP `objective` is not exposed as MCP input.
- **Shared safety check applied to every write action.** Any ability marked `meta.annotations.readonly => false` runs through a TOS / Blaze-eligibility check (via `Blaze::site_supports_blaze()`) before its execute callback. Future Phase 3 write abilities inherit the safety layer automatically — adding a slug to `OWNED_ABILITY_SLUGS` is the only step needed.
- **Why a registration-time wrapper, not `permission_callback` or `wp_before_execute_ability`?** The Abilities API strips `WP_Error::data` from `permission_callback` returns (security stance) and the before/after action hooks are fire-and-forget so they can't gate the call. The `wp_register_ability_args` filter is the only API-level injection point that lets a guardrail return a structured `WP_Error` and short-circuit the call.
- **Audit log** of every write-path call (ability name, input, caller, result) via `wp_after_execute_ability`, scoped to our slugs.
- **MCP `WP_Error` constraint:** the Woo MCP adapter strips `WP_Error::data` when forwarding errors to MCP clients (only `message` and `code` survive). Deep-links are embedded in the error message text so they reach Claude / other MCP clients; the `data` field is kept too as belt-and-braces for direct REST callers.

## What's deferred (designed to plug into the same wrapper)

- [ADS-989](https://linear.app/a8c/issue/ADS-989) — per-session spend ceiling + Picard moderation passthrough.
- [ADS-988](https://linear.app/a8c/issue/ADS-988) — hybrid chat-native preview UX (in-chat image cards + approve / reject abilities). Phase 2 ships the deep-link approval flow, which is enough for launch.

## Test plan

Prereqs: a JN site with WooCommerce 10.7+, MCP Integration feature toggled on, Jetpack with this branch active and connected, a user with `manage_woocommerce`, and at least one published post on the site.

Two surfaces, two auth schemes:

**1. WP Abilities REST endpoint** (Application Password):

```sh
curl -u "$USER:$APP_PASS" \
  -X POST -H 'Content-Type: application/json' \
  -d '{"input":{"target_urn":"urn:wpcom:post:<blog_id>:<post_id>"}}' \
  "$SITE/wp-json/wp-abilities/v1/abilities/blaze-ads/prepare-campaign/run"
```

Expected: 200 with `{ status: "pending_merchant_review", prefill_url: "...?blaze_prefill=...", prefill: {...}, message: "..." }`.

**2. Woo MCP server** (REST API key + MCP client):

`tools/list` includes `blaze-ads-prepare-campaign`. `tools/call` with the same minimal input returns the same payload.

### Checklist

- [ ] Happy path: response includes `prefill_url`, `prefill` payload with post-derived defaults, and `pending_merchant_review` status.
- [ ] Minimal input: `target_urn` alone prepares a proposal with server-owned defaults.
- [ ] Caller overrides win: passing `site_name` / `text_snippet` / `cta_text` / image / language / country overrides beats post-derived defaults.
- [ ] Public schema exposes no raw DSP `objective` input.
- [ ] Invalid `target_urn` returns a 400 `WP_Error` with code `blaze_invalid_target_urn`.
- [ ] Missing post returns a 404 `WP_Error` with code `blaze_post_not_found`.
- [ ] No-excerpt fallback: post with empty excerpt produces a stripped/truncated content snippet rather than empty `text_snippet`.
- [ ] Permission gate: caller without `manage_woocommerce` → 403. Disconnected Jetpack user → 403.
- [ ] Site not Blaze-eligible: response is a `WP_Error` with the Blaze setup deep-link in the message text (and the same URL in the `data` field for non-MCP REST callers).
- [ ] Kill-switch: `add_filter( 'blaze_abilities_prepare_campaign_enabled', '__return_false' )` removes the ability from the registry; subsequent MCP `tools/list` no longer includes it.
- [ ] Audit log entry written to `error_log` on each invocation, with ability slug, user_id, site_id, input, is_error.

Linear: [ADS-953](https://linear.app/a8c/issue/ADS-953)
