### PR TITLE
Add/pass spay email to create payment

### DIFF
--- a/projects/packages/paypal-payments/changelog/add-pass-spay-email-to-create-payment
+++ b/projects/packages/paypal-payments/changelog/add-pass-spay-email-to-create-payment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+

--- a/projects/packages/paypal-payments/src/legacy/class-simple-payments.php
+++ b/projects/packages/paypal-payments/src/legacy/class-simple-payments.php
@@ -174,14 +174,17 @@ class Simple_Payments {
 	 * @param boolean $is_multiple Whether multiple items of the same product can be purchased.
 	 */
 	public function setup_paypal_checkout_button( $id, $dom_id, $is_multiple ) {
+		$spay_email = sanitize_email( get_post_meta( $id, 'spay_email', true ) );
+
 		wp_add_inline_script(
 			'jetpack-paypal-express-checkout',
 			sprintf(
-				"try{PaypalExpressCheckout.renderButton( '%d', '%d', %s, '%d' );}catch(e){}",
+				"try{PaypalExpressCheckout.renderButton( '%d', '%d', %s, '%d', %s );}catch(e){}",
 				intval( $this->get_blog_id() ),
 				intval( $id ),
 				wp_json_encode( $dom_id, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ),
-				intval( $is_multiple )
+				intval( $is_multiple ),
+				wp_json_encode( $spay_email, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP )
 			)
 		);
 	}

--- a/projects/packages/paypal-payments/src/legacy/paypal-express-checkout.js
+++ b/projects/packages/paypal-payments/src/legacy/paypal-express-checkout.js
@@ -141,7 +141,7 @@ const PaypalExpressCheckout = {
 		domEl.innerHTML = '';
 	},
 
-	renderButton: function ( blogId, buttonId, domId, enableMultiple ) {
+	renderButton: function ( blogId, buttonId, domId, enableMultiple, spayEmail ) {
 		const env = PaypalExpressCheckout.getEnvironment();
 
 		if ( ! paypal ) {
@@ -170,6 +170,7 @@ const PaypalExpressCheckout = {
 						number: PaypalExpressCheckout.getNumberOfItems( domId + '_number', enableMultiple ),
 						buttonId: buttonId,
 						env: env,
+						spay_email: spayEmail,
 					};
 
 					return new paypal.Promise( function ( resolve, reject ) {


### PR DESCRIPTION
Related to [SHILL-1889: Do not show the creator email in Jetpack Simple Payments](https://linear.app/a8c/issue/SHILL-1889/do-not-show-the-creator-email-in-jetpack-simple-payments)

Related to 213528-ghe-Automattic/wpcom


## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Pass spay_email in the create payment endpoint

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

[Not sure how to enable the legacy button]

* Create a post with a Simple payment button 
* Make sure it passes the spay_email in the Payment create endpoint looking in the console