### PR TITLE
AI Assistant: add Get Feature Clip video generation entry point

### DIFF
--- a/projects/plugins/jetpack/changelog/add-ai-sidebar-feature-clip-button
+++ b/projects/plugins/jetpack/changelog/add-ai-sidebar-feature-clip-button
@@ -1,4 +1,4 @@
 Significance: minor
-Type: added
+Type: enhancement
 
 AI Assistant: add a "Get Feature Clip" video generation entry point in the sidebar, alongside "Get Featured Image". Hidden behind a new ai-feature-clip-generator extension flag, currently restricted to internal testing environments while the underlying flow stabilizes.

--- a/projects/plugins/jetpack/changelog/add-ai-sidebar-feature-clip-button
+++ b/projects/plugins/jetpack/changelog/add-ai-sidebar-feature-clip-button
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-AI Assistant: add a "Get Feature Clip" video generation entry point in the sidebar, alongside "Get Featured Image". Hidden behind a new ai-feature-clip-generator extension flag, currently restricted to internal testing environments while the underlying flow stabilizes.
+AI Assistant: Add a "Get Feature Clip" video generation entry point in the sidebar, alongside "Get Featured Image". Hidden behind a new ai-feature-clip-generator extension flag, currently restricted to internal testing environments while the underlying flow stabilizes.

--- a/projects/plugins/jetpack/changelog/add-ai-sidebar-feature-clip-button
+++ b/projects/plugins/jetpack/changelog/add-ai-sidebar-feature-clip-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+AI Assistant: add a "Get Feature Clip" video generation entry point in the sidebar, alongside "Get Featured Image". Hidden behind a new ai-feature-clip-generator extension flag, currently restricted to internal testing environments while the underlying flow stabilizes.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -78,6 +78,10 @@ add_action(
 			Jetpack_Gutenberg::set_extension_available( 'ai-title-optimization-keywords-support' );
 			Jetpack_Gutenberg::set_extension_available( 'ai-assistant-image-extension' );
 
+			if ( function_exists( 'jetpack_is_internal_testing_environment' ) && jetpack_is_internal_testing_environment() ) {
+				Jetpack_Gutenberg::set_extension_available( 'ai-feature-clip-generator' );
+			}
+
 			$site_locale = get_locale();
 			// Only enable Write Brief for sites with an English locale.
 			// Disabled by default; set the 'breve_enabled' filter to true to re-enable.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -140,10 +140,12 @@ const JetpackAndSettingsContent = ( {
 	/**
 	 * Filters the video generation handler for AI-powered video creation entry points.
 	 *
-	 * Allows external plugins (e.g. Image Studio's Generate Feature Clip surface) to
-	 * provide a custom handler that opens an external video generation flow. When a
-	 * handler is returned, the "Generate Feature Clip" button uses it; without a
-	 * handler, the section is not rendered.
+	 * Allows external plugins to provide a custom handler that opens an external
+	 * video generation flow. When a handler is returned, the "Get Feature Clip"
+	 * section renders a "Generate clip" button that invokes it. The section is
+	 * only rendered when both a handler is provided AND the
+	 * `ai-feature-clip-generator` extension flag is available; otherwise the
+	 * section (and this filter) are skipped entirely.
 	 *
 	 * @param {Function|null} handler                 - The handler function, or null if no plugin hooks the filter.
 	 * @param {object}        options                 - Options describing the entry point context.
@@ -157,11 +159,15 @@ const JetpackAndSettingsContent = ( {
 	 * // Register a custom video generation handler from an external plugin.
 	 * import { addFilter } from '@wordpress/hooks';
 	 *
-	 * addFilter( 'jetpack.ai.videoGenerationHandler', 'my-plugin/image-studio', ( handler, options ) => {
-	 *     return () => openImageStudio( options.entryPoint );
+	 * addFilter( 'jetpack.ai.videoGenerationHandler', 'my-plugin/feature-clip', ( handler, options ) => {
+	 *     return () => openFeatureClipFlow( options.entryPoint );
 	 * } );
 	 */
 	const videoGenerationHandler = useMemo( () => {
+		if ( ! isAIFeatureClipAvailable ) {
+			return null;
+		}
+
 		const result = applyFilters( 'jetpack.ai.videoGenerationHandler', null, {
 			entryPoint: 'feature-clip',
 			extra: { placement, disabled: requireUpgrade },

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -240,7 +240,7 @@ const JetpackAndSettingsContent = ( {
 				</PanelRow>
 			) }
 
-			{ videoGenerationHandler && isAIFeatureClipAvailable && (
+			{ videoGenerationHandler && (
 				<PanelRow className="jetpack-ai-sidebar__feature-section">
 					<BaseControl __nextHasNoMarginBottom={ true }>
 						<BaseControl.VisualLabel>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -71,6 +71,10 @@ const isUsagePanelAvailable =
 const isAIFeaturedImageAvailable =
 	window?.Jetpack_Editor_Initial_State?.available_blocks?.[ 'ai-featured-image-generator' ]
 		?.available || false;
+// Determine if the AI Feature Clip (video) generator is available
+const isAIFeatureClipAvailable =
+	window?.Jetpack_Editor_Initial_State?.available_blocks?.[ 'ai-feature-clip-generator' ]
+		?.available || false;
 // Determine if the AI Title Optimization feature is available
 const isAITitleOptimizationAvailable =
 	window?.Jetpack_Editor_Initial_State?.available_blocks?.[ 'ai-title-optimization' ]?.available ||
@@ -133,6 +137,38 @@ const JetpackAndSettingsContent = ( {
 		return typeof result === 'function' ? ( result as () => void ) : null;
 	}, [ onImageSelect, placement, requireUpgrade ] );
 
+	/**
+	 * Filters the video generation handler for AI-powered video creation entry points.
+	 *
+	 * Allows external plugins (e.g. Image Studio's Generate Feature Clip surface) to
+	 * provide a custom handler that opens an external video generation flow. When a
+	 * handler is returned, the "Generate Feature Clip" button uses it; without a
+	 * handler, the section is not rendered.
+	 *
+	 * @param {Function|null} handler                 - The handler function, or null if no plugin hooks the filter.
+	 * @param {object}        options                 - Options describing the entry point context.
+	 * @param {string}        options.entryPoint      - Identifies the UI location ('feature-clip').
+	 * @param {object}        options.extra           - Additional context for the handler.
+	 * @param {string}        options.extra.placement - The placement identifier for the entry point.
+	 * @param {boolean}       options.extra.disabled  - Whether the handler should be disabled (e.g. upgrade required).
+	 * @return {Function|null} A function to invoke the video generation flow, or null to hide the section.
+	 *
+	 * @example
+	 * // Register a custom video generation handler from an external plugin.
+	 * import { addFilter } from '@wordpress/hooks';
+	 *
+	 * addFilter( 'jetpack.ai.videoGenerationHandler', 'my-plugin/image-studio', ( handler, options ) => {
+	 *     return () => openImageStudio( options.entryPoint );
+	 * } );
+	 */
+	const videoGenerationHandler = useMemo( () => {
+		const result = applyFilters( 'jetpack.ai.videoGenerationHandler', null, {
+			entryPoint: 'feature-clip',
+			extra: { placement, disabled: requireUpgrade },
+		} );
+		return typeof result === 'function' ? ( result as () => void ) : null;
+	}, [ placement, requireUpgrade ] );
+
 	const currentTitleOptimizationSectionLabel = __( 'Optimize Publishing', 'jetpack' );
 	const SEOTitleOptimizationSectionLabel = __( 'Optimize Title', 'jetpack' );
 	const titleOptimizationSectionLabel = isAITitleOptimizationKeywordsFeatureAvailable
@@ -194,6 +230,23 @@ const JetpackAndSettingsContent = ( {
 						) : (
 							<FeaturedImage busy={ false } disabled={ requireUpgrade } placement={ placement } />
 						) }
+					</BaseControl>
+				</PanelRow>
+			) }
+
+			{ videoGenerationHandler && isAIFeatureClipAvailable && (
+				<PanelRow className="jetpack-ai-sidebar__feature-section">
+					<BaseControl __nextHasNoMarginBottom={ true }>
+						<BaseControl.VisualLabel>
+							{ __( 'Get Feature Clip', 'jetpack' ) }
+						</BaseControl.VisualLabel>
+						<Button
+							onClick={ videoGenerationHandler }
+							variant="secondary"
+							disabled={ requireUpgrade }
+						>
+							{ __( 'Generate clip', 'jetpack' ) }
+						</Button>
 					</BaseControl>
 				</PanelRow>
 			) }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/test/index.test.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/test/index.test.tsx
@@ -125,6 +125,7 @@ jest.mock( '@wordpress/core-data', () => {
 			available_blocks: {
 				'ai-assistant-usage-panel': { available: false },
 				'ai-featured-image-generator': { available: true },
+				'ai-feature-clip-generator': { available: true },
 				'ai-title-optimization': { available: false },
 				'ai-title-optimization-keywords-support': { available: false },
 			},
@@ -260,6 +261,72 @@ describe( 'AiAssistantPluginSidebar', () => {
 			} );
 
 			expect( mockEditPost ).toHaveBeenCalledWith( { featured_media: 123 } );
+		} );
+	} );
+
+	describe( 'videoGenerationHandler filter', () => {
+		it( 'should call applyFilters with correct arguments for feature-clip entry point', () => {
+			render( <AiAssistantPluginSidebar /> );
+
+			expect( applyFilters ).toHaveBeenCalledWith(
+				'jetpack.ai.videoGenerationHandler',
+				null,
+				expect.objectContaining( {
+					entryPoint: 'feature-clip',
+					extra: expect.objectContaining( {
+						placement: expect.any( String ),
+						disabled: false,
+					} ),
+				} )
+			);
+		} );
+
+		it( 'should render "Get Feature Clip" section with "Generate clip" button when filter provides a handler', () => {
+			const mockHandler = jest.fn();
+			jest.mocked( applyFilters ).mockImplementation( ( filterName: string ) => {
+				if ( filterName === 'jetpack.ai.videoGenerationHandler' ) {
+					return mockHandler;
+				}
+				return null;
+			} );
+
+			render( <AiAssistantPluginSidebar /> );
+
+			expect( screen.getAllByRole( 'button', { name: 'Generate clip' } ).length ).toBeGreaterThan(
+				0
+			);
+		} );
+
+		it( 'should call custom handler when clicking "Generate clip" button', async () => {
+			const user = userEvent.setup();
+			const mockHandler = jest.fn();
+			jest.mocked( applyFilters ).mockImplementation( ( filterName: string ) => {
+				if ( filterName === 'jetpack.ai.videoGenerationHandler' ) {
+					return mockHandler;
+				}
+				return null;
+			} );
+
+			render( <AiAssistantPluginSidebar /> );
+
+			const documentPanel = screen.getByTestId( 'document-panel' );
+			const generateButton = within( documentPanel ).getByRole( 'button', {
+				name: 'Generate clip',
+			} );
+			await user.click( generateButton );
+
+			expect( mockHandler ).toHaveBeenCalled();
+		} );
+
+		it( 'should not render "Get Feature Clip" section when filter returns null', () => {
+			jest.mocked( applyFilters ).mockReturnValue( null );
+
+			render( <AiAssistantPluginSidebar /> );
+
+			const documentPanel = screen.getByTestId( 'document-panel' );
+			expect(
+				within( documentPanel ).queryByRole( 'button', { name: 'Generate clip' } )
+			).not.toBeInTheDocument();
 		} );
 	} );
 } );


### PR DESCRIPTION
## Summary

Adds a "Get Feature Clip" section to the AI Assistant sidebar, sibling to the existing "Get Featured Image" section. It uses the same filter-based handler pattern, so external plugins can register a click handler that opens their own video generation flow without coupling the sidebar to any specific implementation.

See phcsdm-ej-p2

## Changes

- **New filter `jetpack.ai.videoGenerationHandler`** in `ai-assistant-plugin-sidebar/index.tsx`. Mirrors the shape of the existing `jetpack.ai.imageGenerationHandler` filter — a plugin returns a click handler via `addFilter`; if no handler is registered, the section isn't rendered.
- **New extension flag `ai-feature-clip-generator`** registered in `ai-assistant.php`, gated on `jetpack_is_internal_testing_environment()` during rollout. The gate will move out once the feature stabilizes and broader entitlement is decided.
- **New "Get Feature Clip" `PanelRow`** that renders only when both the filter has a handler AND the extension flag is enabled.

## Why this shape

The existing "Get Featured Image" section already establishes a clean integration point for external image-generation surfaces (filter + button + render conditional). Doing the same for video means:

- One pattern to learn for plugin authors (image and video work identically).
- Sidebar code stays generic — no knowledge of any specific external plugin.
- Eligibility remains in PHP at the extension-flag site, where it can be tightened or relaxed without touching the sidebar React.

## Behavior

- **Sites outside the testing environment:** no change. The extension flag is off, the section never renders.
- **Testing environment, no consumer plugin hooks the filter:** still no change. Both conditions must be true.
- **Testing environment with a consumer plugin registered:** the "Get Feature Clip" button appears under "Improve with AI", and clicking it invokes the plugin's handler.

This commit alone is a no-op until a consumer ships its `addFilter('jetpack.ai.videoGenerationHandler', ...)` registration.

## Testing

- [ ] Open the AI Assistant sidebar in the post editor on a site outside the testing environment — confirm "Get Feature Clip" does NOT appear.
- [ ] On a testing environment with no consumer plugin registered — confirm "Get Feature Clip" does NOT appear.
- [ ] On a testing environment with a consumer plugin that hooks `jetpack.ai.videoGenerationHandler` — confirm the section renders, the button is clickable, and clicking invokes the registered handler.
- [ ] Confirm "Get Featured Image" still renders and behaves identically to before (no regression).

## Testing instructions:

- Please follow testing instructions found in wpcom-pr-213521

## Does this pull request change what data or activity we track or use?

No

🤖 Generated with [Claude Code](https://claude.com/claude-code)