### PR TITLE
Write: Create auto-draft on page load and track last editor

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-write-editor-auto-save-on-open
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-write-editor-auto-save-on-open
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Create auto-draft posts on page load in the Write editor, enabling immediate post ID availability and editor tracking via last_editor metadata.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1103,7 +1103,7 @@ async function savePost( postStatus ) {
 		return;
 	}
 
-	const isEditing = state.editPostId > 0;
+	const isEditing = state.editPostId > 0 && state.postStatus !== 'auto-draft';
 	const isUpdate = isEditing && postStatus === 'publish';
 
 	state.isSaving = true;

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -13,6 +13,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use Automattic\Jetpack\Jetpack_Mu_Wpcom\WPCOM_Block_Editor\EditorType;
+
 if ( ! defined( 'WPCOM_WRITE_VERSION' ) ) {
 	define(
 		'WPCOM_WRITE_VERSION',
@@ -152,8 +154,27 @@ function wpcom_write_render_admin_page() {
 			$edit_content     = apply_filters( 'the_content', $edit_post->post_content );
 			$post_status      = $edit_post->post_status;
 			$edit_featured_id = (int) get_post_thumbnail_id( $edit_post_id );
+			EditorType\remember_editor( $edit_post_id, 'write-editor' );
 		} else {
 			$edit_post_id = 0;
+		}
+	}
+
+	// Create an auto-draft for new posts so the post ID is available immediately.
+	if ( ! $edit_post_id ) {
+		$auto_draft_id = wp_insert_post(
+			array(
+				'post_title'  => '',
+				'post_type'   => 'post',
+				'post_status' => 'auto-draft',
+			),
+			true
+		);
+
+		if ( ! is_wp_error( $auto_draft_id ) ) {
+			$edit_post_id = $auto_draft_id;
+			$post_status  = 'auto-draft';
+			EditorType\remember_editor( $edit_post_id, 'write-editor' );
 		}
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -13,8 +13,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use Automattic\Jetpack\Jetpack_Mu_Wpcom\WPCOM_Block_Editor\EditorType;
-
 if ( ! defined( 'WPCOM_WRITE_VERSION' ) ) {
 	define(
 		'WPCOM_WRITE_VERSION',
@@ -154,27 +152,27 @@ function wpcom_write_render_admin_page() {
 			$edit_content     = apply_filters( 'the_content', $edit_post->post_content );
 			$post_status      = $edit_post->post_status;
 			$edit_featured_id = (int) get_post_thumbnail_id( $edit_post_id );
-			EditorType\remember_editor( $edit_post_id, 'write-editor' );
+			update_post_meta( $edit_post_id, '_last_editor_used_jetpack', 'write-editor' );
 		} else {
 			$edit_post_id = 0;
 		}
 	}
 
-	// Create an auto-draft for new posts so the post ID is available immediately.
+	// Create an auto-draft for new posts so the post ID is available immediately,
+	// matching the behavior of the classic and block editors.
 	if ( ! $edit_post_id ) {
 		$auto_draft_id = wp_insert_post(
 			array(
-				'post_title'  => '',
+				'post_title'  => __( 'Auto Draft', 'jetpack-mu-wpcom' ),
 				'post_type'   => 'post',
 				'post_status' => 'auto-draft',
-			),
-			true
+			)
 		);
 
-		if ( ! is_wp_error( $auto_draft_id ) ) {
+		if ( $auto_draft_id ) {
 			$edit_post_id = $auto_draft_id;
 			$post_status  = 'auto-draft';
-			EditorType\remember_editor( $edit_post_id, 'write-editor' );
+			update_post_meta( $edit_post_id, '_last_editor_used_jetpack', 'write-editor' );
 		}
 	}
 
@@ -225,7 +223,7 @@ function wpcom_write_render_admin_page() {
 	);
 
 	// Output the editor UI inside wp-admin's wrapper.
-	wpcom_write_template( $edit_title, $edit_content, $edit_post_id, $categories_data );
+	wpcom_write_template( $edit_title, $edit_content, $edit_post_id, $categories_data, $post_status );
 }
 
 /**
@@ -238,8 +236,9 @@ function wpcom_write_render_admin_page() {
  * @param string $edit_content    The post content when editing.
  * @param int    $edit_post_id    The post ID when editing, 0 for new posts.
  * @param array  $categories_data Array of category data for the picker.
+ * @param string $post_status     The post status (e.g. 'auto-draft', 'draft', 'publish').
  */
-function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_id = 0, $categories_data = array() ) {
+function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_id = 0, $categories_data = array(), $post_status = 'new' ) {
 	?>
 <div data-wp-interactive="wpcom-write" class="bw-app">
 
@@ -264,7 +263,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 				class="bw-btn bw-btn-publish"
 				data-wp-on--click="actions.publish"
 				data-wp-bind--disabled="state.isSaving"
-			><?php echo $edit_post_id ? 'Update' : 'Publish'; ?></button>
+			><?php echo $edit_post_id && 'auto-draft' !== $post_status ? 'Update' : 'Publish'; ?></button>
 		</div>
 	</header>
 


### PR DESCRIPTION
Fixes RSM-1553

## Proposed changes

* Create an auto-draft post on page load when opening the Write editor for a new post, matching the behavior of the classic and block editors
* Set `_last_editor_used_jetpack` to `write-editor` on page load (for both new and existing posts), so `wpcom_post_publish` includes the correct `last_editor` value
* Treat auto-drafts as new posts in the JS save logic so UI messages correctly show "Publishing..." instead of "Updating..."
* Pass `$post_status` to the template so the Publish/Update button text is correct for auto-drafts

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

Yes — sets the existing `_last_editor_used_jetpack` post meta to `write-editor` when the Write editor is used, so the `wpcom_post_publish` Tracks event includes the correct `last_editor` value.

## Testing instructions

* Go to a WordPress.com site with the Write editor enabled
* Navigate to `/wp-admin/admin.php?page=write` to open the Write editor for a new post
* Verify an auto-draft post is created in the database: `SELECT ID, post_status FROM wp_posts WHERE post_status = 'auto-draft' ORDER BY ID DESC LIMIT 1;`
* Verify the meta is set: `SELECT meta_value FROM wp_postmeta WHERE post_id = <ID> AND meta_key = '_last_editor_used_jetpack';` — should return `write-editor`
* Verify the Publish button says "Publish" (not "Update")
* Add a title and content, click "Save draft" — verify the message says "Draft saved" (not "Updated")
* Open a new Write editor page, add content, click "Publish" — verify the message says "Publishing..." then "Published!" (not "Updating...")

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
