### PR TITLE
Omnibar: preserve original node ordering

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-bar.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-bar.php
@@ -33,7 +33,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Bar extends WP_REST_Controller {
 	 *
 	 * @var string[]
 	 */
-	const ALLOWED_TOP_LEVEL_NODES = array( 'wp-logo', 'site-name', 'new-content', 'comments', 'updates', 'my-account' );
+	const ALLOWED_TOP_LEVEL_NODES = array( 'wp-logo', 'site-name', 'updates', 'comments', 'new-content', 'my-account' );
 
 	/**
 	 * WPCOM_REST_API_V2_Endpoint_Admin_Bar constructor.
@@ -122,14 +122,9 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Bar extends WP_REST_Controller {
 	private function filter_nodes( array $nodes, array $allowed_ids ) {
 		$allowed = array();
 
-		foreach ( $allowed_ids as $id ) {
-			if ( isset( $nodes[ $id ] ) ) {
-				$allowed[ $id ] = $nodes[ $id ];
-			}
-		}
-
 		foreach ( $nodes as $id => $node ) {
-			if ( isset( $allowed[ $id ] ) ) {
+			if ( in_array( $id, $allowed_ids, true ) ) {
+				$allowed[ $id ] = $node;
 				continue;
 			}
 

--- a/projects/plugins/jetpack/changelog/omnibar-nodes-order
+++ b/projects/plugins/jetpack/changelog/omnibar-nodes-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Omnibar: preserve original node ordering


### PR DESCRIPTION
## Proposed changes

In the `wpcom/v2/admin-bar` endpoint, return nodes in the original order as wp-admin.

## Related product discussion/links

phcsdm-ED-p2#comment-1267

## Does this pull request change what data or activity we track or use?

No