### PR TITLE
babel-plugin-replace-textdomain: detect aliased imports from the i18n ESM module

### DIFF
--- a/projects/js-packages/babel-plugin-replace-textdomain/README.md
+++ b/projects/js-packages/babel-plugin-replace-textdomain/README.md
@@ -30,6 +30,8 @@ Plugin options are:
 
   The default function list handles the `__`, `_x`, `_n`, and `_nx` functions provided by [@wordpress/i18n]. This list may be accessed as `require( '@automattic/babel-plugin-replace-textdomain' ).defaultFunctions`.
 
+- `i18nModule`: Specify the module name used for resolving import aliases. When a function is imported from this module and called under an alias, the plugin will still recognize it. Defaults to `@wordpress/i18n`.
+
 To report instances of the specified i18n functions called without a domain or with an improper value for the domain, set the `DEBUG` environment variable to include `@automattic/babel-plugin-replace-textdomain`.
 
 ## Security

--- a/projects/js-packages/babel-plugin-replace-textdomain/changelog/detect-esm-import-aliases
+++ b/projects/js-packages/babel-plugin-replace-textdomain/changelog/detect-esm-import-aliases
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Detect aliased imports from the i18n ESM module

--- a/projects/js-packages/babel-plugin-replace-textdomain/src/index.js
+++ b/projects/js-packages/babel-plugin-replace-textdomain/src/index.js
@@ -8,15 +8,16 @@ const defaultFunctions = Object.freeze( {
 	_nx: 4,
 } );
 
-const I18N_MODULE = '@wordpress/i18n';
+const defaultI18nModule = '@wordpress/i18n';
 
 /**
- * Checks whether a given function name is an alias for an `@wordpress/i18n` import.
- * @param {object} path - The Babel path object.
- * @param {string} name - The function name to check.
+ * Checks whether a given function name is an alias for an i18n module import.
+ * @param {object} path       - The Babel path object.
+ * @param {string} name       - The function name to check.
+ * @param {string} i18nModule - The module name to match against.
  * @return {string|null} The resolved function name, or null if the function name is not an alias.
  */
-function resolveI18nAlias( path, name ) {
+function resolveI18nAlias( path, name, i18nModule ) {
 	const binding = path.scope.getBinding( name );
 	if ( ! binding ) {
 		return null;
@@ -26,7 +27,7 @@ function resolveI18nAlias( path, name ) {
 		return null;
 	}
 	const importDecl = bindingPath.parentPath;
-	if ( ! importDecl.isImportDeclaration() || importDecl.node.source.value !== I18N_MODULE ) {
+	if ( ! importDecl.isImportDeclaration() || importDecl.node.source.value !== i18nModule ) {
 		return null;
 	}
 	return bindingPath.node.imported.name;
@@ -37,6 +38,7 @@ module.exports = ( babel, opts ) => {
 	const seenDomains = {};
 
 	let functions = defaultFunctions;
+	let i18nModule = defaultI18nModule;
 	let replacementDomain;
 
 	if ( typeof opts.textdomain === 'undefined' ) {
@@ -65,6 +67,13 @@ module.exports = ( babel, opts ) => {
 		functions = opts.functions;
 	}
 
+	if ( opts.i18nModule !== undefined ) {
+		if ( typeof opts.i18nModule !== 'string' ) {
+			throw new Error( `${ pluginName }: The \`i18nModule\` option must be a string.` );
+		}
+		i18nModule = opts.i18nModule;
+	}
+
 	return {
 		name: pluginName,
 		visitor: {
@@ -80,7 +89,7 @@ module.exports = ( babel, opts ) => {
 					if ( t.isMemberExpression( callee ) ) {
 						return;
 					}
-					funcName = resolveI18nAlias( path, calleeName );
+					funcName = resolveI18nAlias( path, calleeName, i18nModule );
 					if ( ! funcName || ! Object.hasOwn( functions, funcName ) ) {
 						return;
 					}

--- a/projects/js-packages/babel-plugin-replace-textdomain/src/index.js
+++ b/projects/js-packages/babel-plugin-replace-textdomain/src/index.js
@@ -77,6 +77,9 @@ module.exports = ( babel, opts ) => {
 
 				let funcName = calleeName;
 				if ( ! Object.hasOwn( functions, funcName ) ) {
+					if ( t.isMemberExpression( callee ) ) {
+						return;
+					}
 					funcName = resolveI18nAlias( path, calleeName );
 					if ( ! funcName || ! Object.hasOwn( functions, funcName ) ) {
 						return;

--- a/projects/js-packages/babel-plugin-replace-textdomain/src/index.js
+++ b/projects/js-packages/babel-plugin-replace-textdomain/src/index.js
@@ -8,6 +8,30 @@ const defaultFunctions = Object.freeze( {
 	_nx: 4,
 } );
 
+const I18N_MODULE = '@wordpress/i18n';
+
+/**
+ * Checks whether a given function name is an alias for an `@wordpress/i18n` import.
+ * @param {object} path - The Babel path object.
+ * @param {string} name - The function name to check.
+ * @return {string|null} The resolved function name, or null if the function name is not an alias.
+ */
+function resolveI18nAlias( path, name ) {
+	const binding = path.scope.getBinding( name );
+	if ( ! binding ) {
+		return null;
+	}
+	const bindingPath = binding.path;
+	if ( ! bindingPath.isImportSpecifier() ) {
+		return null;
+	}
+	const importDecl = bindingPath.parentPath;
+	if ( ! importDecl.isImportDeclaration() || importDecl.node.source.value !== I18N_MODULE ) {
+		return null;
+	}
+	return bindingPath.node.imported.name;
+}
+
 module.exports = ( babel, opts ) => {
 	const { types: t } = babel;
 	const seenDomains = {};
@@ -49,9 +73,14 @@ module.exports = ( babel, opts ) => {
 				if ( t.isSequenceExpression( callee ) ) {
 					callee = callee.expressions[ callee.expressions.length - 1 ];
 				}
-				const funcName = t.isMemberExpression( callee ) ? callee.property.name : callee.name;
+				const calleeName = t.isMemberExpression( callee ) ? callee.property.name : callee.name;
+
+				let funcName = calleeName;
 				if ( ! Object.hasOwn( functions, funcName ) ) {
-					return;
+					funcName = resolveI18nAlias( path, calleeName );
+					if ( ! funcName || ! Object.hasOwn( functions, funcName ) ) {
+						return;
+					}
 				}
 				const idx = functions[ funcName ];
 

--- a/projects/js-packages/babel-plugin-replace-textdomain/tests/__snapshots__/plugin.test.js.snap
+++ b/projects/js-packages/babel-plugin-replace-textdomain/tests/__snapshots__/plugin.test.js.snap
@@ -444,10 +444,24 @@ exports[`@automattic/babel-plugin-replace-textdomain 17. Import alias: injects m
 ]
 `;
 
-exports[`@automattic/babel-plugin-replace-textdomain 18. Import alias: ignores non-i18n imports: debug calls 1`] = `[]`;
+exports[`@automattic/babel-plugin-replace-textdomain 18. Import alias: custom i18nModule: 18. Import alias: custom i18nModule 1`] = `
 
-exports[`@automattic/babel-plugin-replace-textdomain 19. Import alias: ignores global variables with no binding: debug calls 1`] = `[]`;
+import { __ as __alias } from 'my-i18n';
+__alias( 'Hello', 'old-domain' );
 
-exports[`@automattic/babel-plugin-replace-textdomain 20. Import alias: ignores field accesses with same name: debug calls 1`] = `[]`;
+      ↓ ↓ ↓ ↓ ↓ ↓
 
-exports[`@automattic/babel-plugin-replace-textdomain 21. Import alias: ignores shadowed variables: debug calls 1`] = `[]`;
+import { __ as __alias } from 'my-i18n';
+__alias('Hello', 'new-domain');
+
+`;
+
+exports[`@automattic/babel-plugin-replace-textdomain 18. Import alias: custom i18nModule: debug calls 1`] = `[]`;
+
+exports[`@automattic/babel-plugin-replace-textdomain 19. Import alias: ignores non-i18n imports: debug calls 1`] = `[]`;
+
+exports[`@automattic/babel-plugin-replace-textdomain 20. Import alias: ignores global variables with no binding: debug calls 1`] = `[]`;
+
+exports[`@automattic/babel-plugin-replace-textdomain 21. Import alias: ignores field accesses with same name: debug calls 1`] = `[]`;
+
+exports[`@automattic/babel-plugin-replace-textdomain 22. Import alias: ignores shadowed variables: debug calls 1`] = `[]`;

--- a/projects/js-packages/babel-plugin-replace-textdomain/tests/__snapshots__/plugin.test.js.snap
+++ b/projects/js-packages/babel-plugin-replace-textdomain/tests/__snapshots__/plugin.test.js.snap
@@ -445,3 +445,9 @@ exports[`@automattic/babel-plugin-replace-textdomain 17. Import alias: injects m
 `;
 
 exports[`@automattic/babel-plugin-replace-textdomain 18. Import alias: ignores non-i18n imports: debug calls 1`] = `[]`;
+
+exports[`@automattic/babel-plugin-replace-textdomain 19. Import alias: ignores global variables with no binding: debug calls 1`] = `[]`;
+
+exports[`@automattic/babel-plugin-replace-textdomain 20. Import alias: ignores field accesses with same name: debug calls 1`] = `[]`;
+
+exports[`@automattic/babel-plugin-replace-textdomain 21. Import alias: ignores shadowed variables: debug calls 1`] = `[]`;

--- a/projects/js-packages/babel-plugin-replace-textdomain/tests/__snapshots__/plugin.test.js.snap
+++ b/projects/js-packages/babel-plugin-replace-textdomain/tests/__snapshots__/plugin.test.js.snap
@@ -406,3 +406,42 @@ exports[`@automattic/babel-plugin-replace-textdomain 14. Expression domain: debu
 `;
 
 exports[`@automattic/babel-plugin-replace-textdomain 15. Doesn't try to handle \`toString()\` or the like: debug calls 1`] = `[]`;
+
+exports[`@automattic/babel-plugin-replace-textdomain 16. Import alias: replaces domain: 16. Import alias: replaces domain 1`] = `
+
+import { __ as __alias } from '@wordpress/i18n';
+__alias( 'Hello', 'old-domain' );
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { __ as __alias } from '@wordpress/i18n';
+__alias('Hello', 'new-domain');
+
+`;
+
+exports[`@automattic/babel-plugin-replace-textdomain 16. Import alias: replaces domain: debug calls 1`] = `[]`;
+
+exports[`@automattic/babel-plugin-replace-textdomain 17. Import alias: injects missing domain: 17. Import alias: injects missing domain 1`] = `
+
+import { __ as __alias } from '@wordpress/i18n';
+__alias( 'Hello' );
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { __ as __alias } from '@wordpress/i18n';
+__alias('Hello', 'new-domain');
+
+`;
+
+exports[`@automattic/babel-plugin-replace-textdomain 17. Import alias: injects missing domain: debug calls 1`] = `
+[
+  [
+    Domain argument (index 2) is missing
+  1 | import { __ as __alias } from '@wordpress/i18n';
+> 2 | __alias( 'Hello' );
+    | ^^^^^^^^^^^^^^^^^^,
+  ],
+]
+`;
+
+exports[`@automattic/babel-plugin-replace-textdomain 18. Import alias: ignores non-i18n imports: debug calls 1`] = `[]`;

--- a/projects/js-packages/babel-plugin-replace-textdomain/tests/plugin.test.js
+++ b/projects/js-packages/babel-plugin-replace-textdomain/tests/plugin.test.js
@@ -183,6 +183,36 @@ pluginTester( {
 				textdomain: 'new-domain',
 			},
 		},
+		{
+			title: 'Import alias: ignores global variables with no binding',
+			setup,
+			code: `__alias( 'Hello', 'old-domain' );`,
+			output: `__alias('Hello', 'old-domain');`,
+			snapshot: false,
+			pluginOptions: {
+				textdomain: 'new-domain',
+			},
+		},
+		{
+			title: 'Import alias: ignores field accesses with same name',
+			setup,
+			code: `import { __ as __alias } from '@wordpress/i18n';\nfoo.__alias( 'Hello', 'old-domain' );`,
+			output: `import { __ as __alias } from '@wordpress/i18n';\nfoo.__alias('Hello', 'old-domain');`,
+			snapshot: false,
+			pluginOptions: {
+				textdomain: 'new-domain',
+			},
+		},
+		{
+			title: 'Import alias: ignores shadowed variables',
+			setup,
+			code: `import { __ as __alias } from '@wordpress/i18n';\nfunction f( __alias ) {\n\treturn __alias( 'Hello', 'old-domain' );\n}`,
+			output: `import { __ as __alias } from '@wordpress/i18n';\nfunction f(__alias) {\n\treturn __alias('Hello', 'old-domain');\n}`,
+			snapshot: false,
+			pluginOptions: {
+				textdomain: 'new-domain',
+			},
+		},
 
 		// Invalid option handling.
 		{

--- a/projects/js-packages/babel-plugin-replace-textdomain/tests/plugin.test.js
+++ b/projects/js-packages/babel-plugin-replace-textdomain/tests/plugin.test.js
@@ -157,6 +157,33 @@ pluginTester( {
 			},
 		},
 
+		{
+			title: 'Import alias: replaces domain',
+			setup,
+			code: `import { __ as __alias } from '@wordpress/i18n';\n__alias( 'Hello', 'old-domain' );`,
+			pluginOptions: {
+				textdomain: 'new-domain',
+			},
+		},
+		{
+			title: 'Import alias: injects missing domain',
+			setup,
+			code: `import { __ as __alias } from '@wordpress/i18n';\n__alias( 'Hello' );`,
+			pluginOptions: {
+				textdomain: 'new-domain',
+			},
+		},
+		{
+			title: 'Import alias: ignores non-i18n imports',
+			setup,
+			code: `import { __ as __alias } from 'other-module';\n__alias( 'Hello', 'old-domain' );`,
+			output: `import { __ as __alias } from 'other-module';\n__alias('Hello', 'old-domain');`,
+			snapshot: false,
+			pluginOptions: {
+				textdomain: 'new-domain',
+			},
+		},
+
 		// Invalid option handling.
 		{
 			title: 'Bad options: missing textdomain',

--- a/projects/js-packages/babel-plugin-replace-textdomain/tests/plugin.test.js
+++ b/projects/js-packages/babel-plugin-replace-textdomain/tests/plugin.test.js
@@ -174,6 +174,15 @@ pluginTester( {
 			},
 		},
 		{
+			title: 'Import alias: custom i18nModule',
+			setup,
+			code: `import { __ as __alias } from 'my-i18n';\n__alias( 'Hello', 'old-domain' );`,
+			pluginOptions: {
+				textdomain: 'new-domain',
+				i18nModule: 'my-i18n',
+			},
+		},
+		{
 			title: 'Import alias: ignores non-i18n imports',
 			setup,
 			code: `import { __ as __alias } from 'other-module';\n__alias( 'Hello', 'old-domain' );`,
@@ -230,6 +239,16 @@ pluginTester( {
 			},
 			snapshot: false,
 			error: 'The `textdomain` option is set to an invalid value.',
+		},
+		{
+			title: 'Bad options: bad i18nModule',
+			fixture: 'fixtures/simple.js',
+			pluginOptions: {
+				textdomain: 'foo',
+				i18nModule: 123,
+			},
+			snapshot: false,
+			error: 'The `i18nModule` option must be a string.',
 		},
 		{
 			title: 'Bad options: bad functions',

--- a/projects/js-packages/webpack-config/changelog/remove-i18n-alt-names
+++ b/projects/js-packages/webpack-config/changelog/remove-i18n-alt-names
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Removed the generateI18nVariants helper from replace-textdomain Babel config.

--- a/projects/js-packages/webpack-config/src/webpack/bundled-wp-pkgs-transpile-rules.js
+++ b/projects/js-packages/webpack-config/src/webpack/bundled-wp-pkgs-transpile-rules.js
@@ -2,25 +2,6 @@ const loadTextDomainFromComposerJson = require( './load-textdomain-from-composer
 const TranspileRule = require( './transpile-rule.js' );
 
 /**
- * Generate i18n function variants for `@automattic/babel-plugin-replace-textdomain`.
- *
- * The `@wordpress/dataviews` currently uses the i18n functions under a variety of aliases,
- * which makes it a pain to add the proper textdomain. This function generates an object
- * with the base function and 99 more variants as keys.
- *
- * @param {string} baseFn - Base function name (e.g., '__', '_x', '_n')
- * @param {number} value  - Textdomain argument position (1-based index)
- * @return {object} Object mapping function names to textdomain positions
- */
-const generateI18nVariants = ( baseFn, value ) =>
-	Object.fromEntries(
-		Array.from( { length: 100 }, ( _, i ) => [
-			`${ baseFn }${ i || '' }`, // empty suffix for 0
-			value,
-		] )
-	);
-
-/**
  * Provide transpile rules for bundled `@wordpress/*` packages.
  *
  * If bundled packages contain `@wordpress/i18n` calls, the i18n doesn't actually work due to
@@ -56,17 +37,7 @@ const BundledWpPkgsTranspileRules = ( options = {} ) => {
 		babelOpts: {
 			configFile: false,
 			plugins: [
-				[
-					require.resolve( '@automattic/babel-plugin-replace-textdomain' ),
-					{
-						textdomain,
-						functions: {
-							...generateI18nVariants( '__', 1 ),
-							...generateI18nVariants( '_x', 2 ),
-							...generateI18nVariants( '_n', 3 ),
-						},
-					},
-				],
+				[ require.resolve( '@automattic/babel-plugin-replace-textdomain' ), { textdomain } ],
 			],
 		},
 	} );


### PR DESCRIPTION
## Proposed changes
Enhance the `babel-plugin-replace-textdomain` plugin so that for every function call, it checks if the identifier is coming from the `@wordpress/i18n` import, even with aliased name:
```js
import { __ as __45 } from '@wordpress/i18n';

__45( 'Sort ascending' );
```
This "real" name is then checked agains the `functions` object instead of the alias. Thanks to this, we can reliably detect also the aliased `__45` calls, under any name, and can avoid the much less elegant `generateI18nVariants` helper.

## Related product discussion/links
p1774956551856089-slack-C05Q5HSS013

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
How I tested this:
- `cd projects/packages/newsletter` (many other packages will do, but I used this one)
- run `pnpm build-js`
- check the built file in `build/newsletter.js` and search for `Sort ascending`. That's a translated string from the `dataviews` package. Verify that it has domain appended: the call should be `__( 'Sort ascending', 'jetpack-newsletter' )`.
- if the domain was missing, i.e., the call would be the original `__( 'Sort ascending' )`, that would mean that the Babel plugin is failing to do its job, no matter the method.