### PR TITLE
Newsletter abilities: register get-settings + update-settings via Registrar

### DIFF
--- a/projects/plugins/jetpack/changelog/add-newsletter-abilities
+++ b/projects/plugins/jetpack/changelog/add-newsletter-abilities
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Newsletter: register Abilities API surface for module settings on WP 6.9+.

--- a/projects/plugins/jetpack/changelog/add-newsletter-abilities
+++ b/projects/plugins/jetpack/changelog/add-newsletter-abilities
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Newsletter: register Abilities API surface for module settings on WP 6.9+.
+Newsletter: register Abilities API surface for module settings and subscriber stats on WP 6.9+.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,8 +102,7 @@
 	],
 	"autoload": {
 		"classmap": [
-			"src",
-			"modules/subscriptions/abilities"
+			"src"
 		]
 	},
 	"minimum-stability": "dev",

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -103,7 +103,7 @@
 	"autoload": {
 		"classmap": [
 			"src",
-			"modules/*/abilities"
+			"modules/subscriptions/abilities"
 		]
 	},
 	"minimum-stability": "dev",

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -102,7 +102,8 @@
 	],
 	"autoload": {
 		"classmap": [
-			"src"
+			"src",
+			"modules/*/abilities"
 		]
 	},
 	"minimum-stability": "dev",

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -1117,7 +1117,5 @@ require __DIR__ . '/subscriptions/subscribe-overlay/class-jetpack-subscribe-over
 require __DIR__ . '/subscriptions/subscribe-floating-button/class-jetpack-subscribe-floating-button.php';
 require __DIR__ . '/subscriptions/newsletter-widget/class-jetpack-newsletter-dashboard-widget.php';
 
-// Newsletter Abilities — registers only when this module is active because
-// Jetpack's load_modules() only includes this file for active modules.
 require_once __DIR__ . '/subscriptions/abilities/class-newsletter-abilities.php';
 \Automattic\Jetpack\Plugin\Abilities\Newsletter_Abilities::init();

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -1119,5 +1119,6 @@ require __DIR__ . '/subscriptions/newsletter-widget/class-jetpack-newsletter-das
 
 // Newsletter Abilities — registers only when this module is active because
 // Jetpack's load_modules() only includes this file for active modules.
-require_once __DIR__ . '/subscriptions/abilities/class-newsletter-abilities.php';
+// The class is autoloaded via the `modules/*/abilities` classmap entry in
+// projects/plugins/jetpack/composer.json — no require_once needed.
 \Automattic\Jetpack\Plugin\Abilities\Newsletter_Abilities::init();

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -1116,3 +1116,8 @@ require __DIR__ . '/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.
 require __DIR__ . '/subscriptions/subscribe-overlay/class-jetpack-subscribe-overlay.php';
 require __DIR__ . '/subscriptions/subscribe-floating-button/class-jetpack-subscribe-floating-button.php';
 require __DIR__ . '/subscriptions/newsletter-widget/class-jetpack-newsletter-dashboard-widget.php';
+
+// Newsletter Abilities — registers only when this module is active because
+// Jetpack's load_modules() only includes this file for active modules.
+require_once __DIR__ . '/subscriptions/abilities/class-newsletter-abilities.php';
+\Automattic\Jetpack\Plugin\Abilities\Newsletter_Abilities::init();

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -1119,6 +1119,5 @@ require __DIR__ . '/subscriptions/newsletter-widget/class-jetpack-newsletter-das
 
 // Newsletter Abilities — registers only when this module is active because
 // Jetpack's load_modules() only includes this file for active modules.
-// The class is autoloaded via the `modules/*/abilities` classmap entry in
-// projects/plugins/jetpack/composer.json — no require_once needed.
+require_once __DIR__ . '/subscriptions/abilities/class-newsletter-abilities.php';
 \Automattic\Jetpack\Plugin\Abilities\Newsletter_Abilities::init();

--- a/projects/plugins/jetpack/modules/subscriptions/abilities/class-newsletter-abilities.php
+++ b/projects/plugins/jetpack/modules/subscriptions/abilities/class-newsletter-abilities.php
@@ -12,8 +12,11 @@
 
 namespace Automattic\Jetpack\Plugin\Abilities;
 
+use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Modules\Subscriptions\Settings as Subscriptions_Settings;
 use Automattic\Jetpack\WP_Abilities\Registrar;
+use Jetpack;
+use Jetpack_Options;
 
 // The Subscriptions module doesn't load its Settings helpers eagerly. Pull it
 // in here so `Subscriptions_Settings::$default_reply_to` and
@@ -102,7 +105,7 @@ class Newsletter_Abilities extends Registrar {
 		);
 
 		return array(
-			'jetpack-newsletter/get-settings'    => array(
+			'jetpack-newsletter/get-settings'         => array(
 				'label'               => __( 'Get Newsletter settings', 'jetpack' ),
 				'description'         => __(
 					'Return the current Jetpack Newsletter settings as a flat object. Always returns the same five fields: subscribe_post_end_enabled (bool), subscribe_comments_enabled (bool), notify_admin_on_subscribe (bool), reply_to ("comment"|"author"|"no-reply"), and from_name (string). Read-only and idempotent. To change any value, call jetpack-newsletter/update-settings.',
@@ -127,7 +130,7 @@ class Newsletter_Abilities extends Registrar {
 				),
 			),
 
-			'jetpack-newsletter/update-settings' => array(
+			'jetpack-newsletter/update-settings'      => array(
 				'label'               => __( 'Update Newsletter settings', 'jetpack' ),
 				'description'         => __(
 					'Update one or more Jetpack Newsletter settings. Any subset of the five fields may be supplied; omitted fields are left untouched. Idempotent — fields whose desired value already matches the current value are not rewritten. Returns { settings: <full current state after the update>, changed: <array of field names that actually transitioned> }. An empty input or input matching the current state returns changed = [].',
@@ -150,6 +153,38 @@ class Newsletter_Abilities extends Registrar {
 				'meta'                => array(
 					'annotations'  => array(
 						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+
+			'jetpack-newsletter/get-subscriber-stats' => array(
+				'label'               => __( 'Get Newsletter subscriber stats', 'jetpack' ),
+				'description'         => __(
+					'Return aggregate subscriber counts for the site. Always returns { all: int, email: int, paid: int }: all is the total subscriber count (email + WordPress.com followers); email is the subset that receives email; paid is the subset on a paid newsletter plan. Numbers are fetched from WordPress.com and cached locally for one hour, so transient network errors yield a stale-but-non-zero response when one is available. Requires an active Jetpack connection — sites without one return jetpack_newsletter_not_connected.',
+					'jetpack'
+				),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'default'              => array(),
+					'properties'           => array(),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'all'   => array( 'type' => 'integer' ),
+						'email' => array( 'type' => 'integer' ),
+						'paid'  => array( 'type' => 'integer' ),
+					),
+				),
+				'execute_callback'    => array( __CLASS__, 'get_subscriber_stats' ),
+				'permission_callback' => array( __CLASS__, 'can_view_settings' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
 						'destructive' => false,
 						'idempotent'  => true,
 					),
@@ -184,6 +219,86 @@ class Newsletter_Abilities extends Registrar {
 	public static function get_settings( $input = null ): array {
 		unset( $input );
 		return self::current_settings();
+	}
+
+	/**
+	 * Transient key for the wpcom subscriber-stats response.
+	 */
+	private const SUBSCRIBER_STATS_CACHE_KEY = 'jetpack_newsletter_subscriber_stats';
+
+	/**
+	 * Transient TTL for subscriber-stats responses, in seconds.
+	 *
+	 * Matches the existing legacy widget pattern of an hour-long cache so
+	 * agents calling this ability repeatedly don't fan out to wpcom.
+	 */
+	private const SUBSCRIBER_STATS_CACHE_TTL = HOUR_IN_SECONDS;
+
+	/**
+	 * Execute: fetch (and cache) aggregate subscriber counts from WordPress.com.
+	 *
+	 * @param array|null $input Unused — input schema accepts no parameters.
+	 * @return array|\WP_Error
+	 */
+	public static function get_subscriber_stats( $input = null ) {
+		unset( $input );
+
+		$cached = get_transient( self::SUBSCRIBER_STATS_CACHE_KEY );
+		if ( is_array( $cached ) ) {
+			return $cached;
+		}
+
+		if ( ! class_exists( 'Jetpack' ) || ! Jetpack::is_connection_ready() ) {
+			return new \WP_Error(
+				'jetpack_newsletter_not_connected',
+				__( 'Subscriber stats are only available on Jetpack-connected sites. Connect Jetpack and retry.', 'jetpack' )
+			);
+		}
+
+		$site_id = (int) Jetpack_Options::get_option( 'id' );
+		if ( $site_id <= 0 ) {
+			return new \WP_Error(
+				'jetpack_newsletter_not_connected',
+				__( 'No Jetpack site ID is registered. Connect Jetpack and retry.', 'jetpack' )
+			);
+		}
+
+		$response = Client::wpcom_json_api_request_as_blog(
+			sprintf( '/sites/%d/subscribers/stats', $site_id ),
+			'2',
+			array(),
+			null,
+			'wpcom'
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return new \WP_Error(
+				'jetpack_newsletter_subscriber_stats_unavailable',
+				$response->get_error_message()
+			);
+		}
+
+		if ( 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
+			return new \WP_Error(
+				'jetpack_newsletter_subscriber_stats_unavailable',
+				__( 'WordPress.com did not return subscriber stats. Retry shortly.', 'jetpack' )
+			);
+		}
+
+		$body   = json_decode( wp_remote_retrieve_body( $response ), true );
+		$counts = is_array( $body ) && isset( $body['counts'] ) && is_array( $body['counts'] )
+			? $body['counts']
+			: array();
+
+		$stats = array(
+			'all'   => isset( $counts['all_subscribers'] ) ? (int) $counts['all_subscribers'] : 0,
+			'email' => isset( $counts['email_subscribers'] ) ? (int) $counts['email_subscribers'] : 0,
+			'paid'  => isset( $counts['paid_subscribers'] ) ? (int) $counts['paid_subscribers'] : 0,
+		);
+
+		set_transient( self::SUBSCRIBER_STATS_CACHE_KEY, $stats, self::SUBSCRIBER_STATS_CACHE_TTL );
+
+		return $stats;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/subscriptions/abilities/class-newsletter-abilities.php
+++ b/projects/plugins/jetpack/modules/subscriptions/abilities/class-newsletter-abilities.php
@@ -224,6 +224,10 @@ class Newsletter_Abilities extends Registrar {
 
 		$changed = array();
 		foreach ( $normalized as $field => $desired ) {
+			// String-cast on both sides because every field's storage form is
+			// scalar (`0`/`1` for BOOL, `'on'`/`'off'` for ON_OFF, plain strings
+			// for ENUM/STRING). New field types added later must keep that
+			// invariant or this comparison will misfire.
 			if ( (string) $desired === (string) $current_storage[ $field ] ) {
 				continue;
 			}
@@ -278,9 +282,10 @@ class Newsletter_Abilities extends Registrar {
 				'enum'    => self::REPLY_TO_VALUES,
 			),
 			'from_name'                  => array(
-				'option'  => 'jetpack_subscriptions_from_name',
-				'type'    => self::TYPE_STRING,
-				'default' => '',
+				'option'     => 'jetpack_subscriptions_from_name',
+				'type'       => self::TYPE_STRING,
+				'default'    => '',
+				'max_length' => 200,
 			),
 		);
 	}
@@ -351,7 +356,18 @@ class Newsletter_Abilities extends Registrar {
 				if ( ! is_string( $value ) ) {
 					return self::invalid_field( $field, __( 'expected a string.', 'jetpack' ) );
 				}
-				return sanitize_text_field( $value );
+				$sanitized = sanitize_text_field( $value );
+				if ( isset( $config['max_length'] ) && mb_strlen( $sanitized ) > (int) $config['max_length'] ) {
+					return self::invalid_field(
+						$field,
+						sprintf(
+							/* translators: %d: maximum number of characters. */
+							__( 'must be %d characters or fewer.', 'jetpack' ),
+							(int) $config['max_length']
+						)
+					);
+				}
+				return $sanitized;
 		}
 
 		return self::invalid_field( $field, __( 'unsupported field type.', 'jetpack' ) );

--- a/projects/plugins/jetpack/modules/subscriptions/abilities/class-newsletter-abilities.php
+++ b/projects/plugins/jetpack/modules/subscriptions/abilities/class-newsletter-abilities.php
@@ -1,0 +1,401 @@
+<?php
+/**
+ * Jetpack Newsletter Abilities Registration
+ *
+ * Registers Jetpack Newsletter (subscriptions) abilities with the WordPress
+ * Abilities API.
+ *
+ * @package automattic/jetpack
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9.
+
+namespace Automattic\Jetpack\Plugin\Abilities;
+
+use Automattic\Jetpack\Modules\Subscriptions\Settings as Subscriptions_Settings;
+use Automattic\Jetpack\WP_Abilities\Registrar;
+
+// The Subscriptions module doesn't load its Settings helpers eagerly. Pull it
+// in here so `Subscriptions_Settings::$default_reply_to` and
+// `is_valid_reply_to()` are resolvable when the abilities run.
+require_once __DIR__ . '/../class-settings.php';
+
+/**
+ * Registers Jetpack Newsletter abilities with the WordPress Abilities API.
+ *
+ * Exposes a consolidated read of the site's newsletter (subscriptions) settings
+ * and a partial-update writer so AI agents can configure the Newsletter module
+ * through the standard `wp-abilities/v1` REST surface.
+ */
+class Newsletter_Abilities extends Registrar {
+
+	// Field type tags used in `settings_map()`. Constants (not strings) so a
+	// typo in a `case` label fails fast instead of silently falling through.
+	private const TYPE_BOOL   = 'bool';
+	private const TYPE_ON_OFF = 'on_off';
+	private const TYPE_ENUM   = 'enum';
+	private const TYPE_STRING = 'string';
+
+	/**
+	 * Allowed values for the `reply_to` setting. Mirror of
+	 * `Subscriptions_Settings::is_valid_reply_to()` — kept here so it can be
+	 * referenced from the JSON Schema enum without loading the Settings class
+	 * at file-parse time.
+	 */
+	private const REPLY_TO_VALUES = array( 'comment', 'author', 'no-reply' );
+
+	/**
+	 * Returns the abilities category, definition, or registered abilities.
+	 *
+	 * @inheritDoc
+	 */
+	public static function get_category_slug(): string {
+		return 'jetpack-newsletter';
+	}
+
+	/**
+	 * Returns the abilities category, definition, or registered abilities.
+	 *
+	 * @inheritDoc
+	 */
+	public static function get_category_definition(): array {
+		return array(
+			// "Jetpack" and "Newsletter" are product names and should not be translated.
+			'label'       => 'Jetpack Newsletter',
+			'description' => __( 'Abilities for reading and updating Jetpack Newsletter settings.', 'jetpack' ),
+		);
+	}
+
+	/**
+	 * Returns the abilities category, definition, or registered abilities.
+	 *
+	 * @inheritDoc
+	 */
+	public static function get_abilities(): array {
+		$settings_object_schema = array(
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'properties'           => array(
+				'subscribe_post_end_enabled' => array(
+					'type'        => 'boolean',
+					'description' => __( 'Show a "subscribe to blog" checkbox at the end of every post. Default true.', 'jetpack' ),
+				),
+				'subscribe_comments_enabled' => array(
+					'type'        => 'boolean',
+					'description' => __( 'Show a "notify me of new comments" checkbox in the comment form. Default true.', 'jetpack' ),
+				),
+				'notify_admin_on_subscribe'  => array(
+					'type'        => 'boolean',
+					'description' => __( 'Email the site admin whenever a new subscriber signs up. Default true.', 'jetpack' ),
+				),
+				'reply_to'                   => array(
+					'type'        => 'string',
+					'enum'        => self::REPLY_TO_VALUES,
+					'description' => __( 'Reply-to address for newsletter emails. "comment" routes to the post comment author, "author" to the post author, "no-reply" disables replies. Default "comment".', 'jetpack' ),
+				),
+				'from_name'                  => array(
+					'type'        => 'string',
+					'description' => __( 'Sender name shown on newsletter emails. Empty string falls back to the site name.', 'jetpack' ),
+					'maxLength'   => 200,
+				),
+			),
+		);
+
+		return array(
+			'jetpack-newsletter/get-settings'    => array(
+				'label'               => __( 'Get Newsletter settings', 'jetpack' ),
+				'description'         => __(
+					'Return the current Jetpack Newsletter settings as a flat object. Always returns the same five fields: subscribe_post_end_enabled (bool), subscribe_comments_enabled (bool), notify_admin_on_subscribe (bool), reply_to ("comment"|"author"|"no-reply"), and from_name (string). Read-only and idempotent. To change any value, call jetpack-newsletter/update-settings.',
+					'jetpack'
+				),
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'default'              => array(),
+					'properties'           => array(),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => $settings_object_schema,
+				'execute_callback'    => array( __CLASS__, 'get_settings' ),
+				'permission_callback' => array( __CLASS__, 'can_view_settings' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+
+			'jetpack-newsletter/update-settings' => array(
+				'label'               => __( 'Update Newsletter settings', 'jetpack' ),
+				'description'         => __(
+					'Update one or more Jetpack Newsletter settings. Any subset of the five fields may be supplied; omitted fields are left untouched. Idempotent — fields whose desired value already matches the current value are not rewritten. Returns { settings: <full current state after the update>, changed: <array of field names that actually transitioned> }. An empty input or input matching the current state returns changed = [].',
+					'jetpack'
+				),
+				'input_schema'        => $settings_object_schema,
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'settings' => $settings_object_schema,
+						'changed'  => array(
+							'type'        => 'array',
+							'items'       => array( 'type' => 'string' ),
+							'description' => __( 'Names of the fields that actually changed during this call. Empty when the call was a no-op.', 'jetpack' ),
+						),
+					),
+				),
+				'execute_callback'    => array( __CLASS__, 'update_settings' ),
+				'permission_callback' => array( __CLASS__, 'can_manage_settings' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			),
+		);
+	}
+
+	/**
+	 * Permission check for read abilities. Newsletter settings live on the WP
+	 * Newsletter settings screen, which is itself gated on `manage_options`.
+	 */
+	public static function can_view_settings(): bool {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Permission check for write abilities. Mirrors the gating on the
+	 * Newsletter settings screen.
+	 */
+	public static function can_manage_settings(): bool {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Execute: return the current newsletter settings.
+	 *
+	 * @param array|null $input Unused — input schema accepts no parameters.
+	 * @return array
+	 */
+	public static function get_settings( $input = null ): array {
+		unset( $input );
+		return self::current_settings();
+	}
+
+	/**
+	 * Execute: idempotent partial update of newsletter settings.
+	 *
+	 * Validates every supplied field before writing anything, so a malformed
+	 * field cannot leave the option set in a partially-updated state.
+	 *
+	 * @param array|null $input Input matching the ability's input_schema.
+	 * @return array|\WP_Error
+	 */
+	public static function update_settings( $input = null ) {
+		$input = is_array( $input ) ? $input : array();
+		$map   = self::settings_map();
+
+		// Validate + normalize every supplied field up-front. Any failure
+		// short-circuits the call with no writes, so a bad field can't leave
+		// earlier fields in a partially-updated state.
+		$normalized = array();
+		foreach ( $map as $field => $config ) {
+			if ( ! array_key_exists( $field, $input ) ) {
+				continue;
+			}
+
+			$result = self::normalize_input_value( $field, $config, $input[ $field ] );
+			if ( $result instanceof \WP_Error ) {
+				return $result;
+			}
+			$normalized[ $field ] = $result;
+		}
+
+		// Read every field's current value once. This pass also feeds the
+		// post-update response, avoiding a second `get_option` sweep.
+		$current_storage = array();
+		foreach ( $map as $field => $config ) {
+			$current_storage[ $field ] = self::read_option( $config );
+		}
+
+		$changed = array();
+		foreach ( $normalized as $field => $desired ) {
+			if ( (string) $desired === (string) $current_storage[ $field ] ) {
+				continue;
+			}
+			update_option( $map[ $field ]['option'], $desired );
+			$current_storage[ $field ] = $desired;
+			$changed[]                 = $field;
+		}
+
+		$settings = array();
+		foreach ( $map as $field => $config ) {
+			$settings[ $field ] = self::cast_to_response( $config, $current_storage[ $field ] );
+		}
+
+		return array(
+			'settings' => $settings,
+			'changed'  => $changed,
+		);
+	}
+
+	/**
+	 * Map of public ability field name → backing option config.
+	 *
+	 * Storage shape (option key, type tag, default, enum). The agent-facing
+	 * descriptions and JSON Schema live in `get_abilities()`; this map drives
+	 * the storage-side validation, normalization, and casting.
+	 *
+	 * Kept as a method (not a class constant) so the description strings
+	 * referenced from `cast_to_response()` and `normalize_input_value()` can
+	 * resolve through `__()` at call time rather than file load time.
+	 */
+	private static function settings_map(): array {
+		return array(
+			'subscribe_post_end_enabled' => array(
+				'option'  => 'stb_enabled',
+				'type'    => self::TYPE_BOOL,
+				'default' => 1,
+			),
+			'subscribe_comments_enabled' => array(
+				'option'  => 'stc_enabled',
+				'type'    => self::TYPE_BOOL,
+				'default' => 1,
+			),
+			'notify_admin_on_subscribe'  => array(
+				'option'  => 'social_notifications_subscribe',
+				'type'    => self::TYPE_ON_OFF,
+				'default' => 'on',
+			),
+			'reply_to'                   => array(
+				'option'  => 'jetpack_subscriptions_reply_to',
+				'type'    => self::TYPE_ENUM,
+				'default' => Subscriptions_Settings::$default_reply_to,
+				'enum'    => self::REPLY_TO_VALUES,
+			),
+			'from_name'                  => array(
+				'option'  => 'jetpack_subscriptions_from_name',
+				'type'    => self::TYPE_STRING,
+				'default' => '',
+			),
+		);
+	}
+
+	/**
+	 * Read all settings as the public response shape.
+	 */
+	private static function current_settings(): array {
+		$out = array();
+		foreach ( self::settings_map() as $field => $config ) {
+			$out[ $field ] = self::cast_to_response( $config, self::read_option( $config ) );
+		}
+		return $out;
+	}
+
+	/**
+	 * Read the raw option for a field config, falling back to its default.
+	 *
+	 * @param array $config Field config from `settings_map()`.
+	 * @return mixed
+	 */
+	private static function read_option( array $config ) {
+		return get_option( $config['option'], $config['default'] );
+	}
+
+	/**
+	 * Validate + normalize a single input value to the storage form.
+	 *
+	 * @param string $field  Public field name (used in error messages).
+	 * @param array  $config Field config from `settings_map()`.
+	 * @param mixed  $value  Raw input value.
+	 * @return mixed|\WP_Error Storage-form value, or WP_Error when invalid.
+	 */
+	private static function normalize_input_value( string $field, array $config, $value ) {
+		switch ( $config['type'] ) {
+			case self::TYPE_BOOL:
+				if ( ! is_bool( $value ) ) {
+					return self::invalid_field( $field, __( 'expected a boolean (true or false).', 'jetpack' ) );
+				}
+				return $value ? 1 : 0;
+
+			case self::TYPE_ON_OFF:
+				if ( ! is_bool( $value ) ) {
+					return self::invalid_field( $field, __( 'expected a boolean (true or false).', 'jetpack' ) );
+				}
+				return $value ? 'on' : 'off';
+
+			case self::TYPE_ENUM:
+				// reply_to is the only enum today and shares its allowed-values
+				// list with `Subscriptions_Settings::is_valid_reply_to()`. Defer
+				// to that validator so the two surfaces can't drift.
+				$valid = 'reply_to' === $field
+					? Subscriptions_Settings::is_valid_reply_to( $value )
+					: ( is_string( $value ) && in_array( $value, $config['enum'], true ) );
+				if ( ! $valid ) {
+					return self::invalid_field(
+						$field,
+						sprintf(
+							/* translators: %s: comma-separated list of allowed values. */
+							__( 'allowed values are %s.', 'jetpack' ),
+							implode( ', ', $config['enum'] )
+						)
+					);
+				}
+				return $value;
+
+			case self::TYPE_STRING:
+				if ( ! is_string( $value ) ) {
+					return self::invalid_field( $field, __( 'expected a string.', 'jetpack' ) );
+				}
+				return sanitize_text_field( $value );
+		}
+
+		return self::invalid_field( $field, __( 'unsupported field type.', 'jetpack' ) );
+	}
+
+	/**
+	 * Cast a stored option value to the public response shape.
+	 *
+	 * @param array $config Field config from `settings_map()`.
+	 * @param mixed $value  Raw stored value.
+	 * @return mixed
+	 */
+	private static function cast_to_response( array $config, $value ) {
+		switch ( $config['type'] ) {
+			case self::TYPE_BOOL:
+				return 1 === (int) $value;
+			case self::TYPE_ON_OFF:
+				return 'on' === (string) $value;
+			case self::TYPE_ENUM:
+				$value = (string) $value;
+				return in_array( $value, $config['enum'], true ) ? $value : (string) $config['default'];
+			case self::TYPE_STRING:
+				return (string) $value;
+		}
+		return $value;
+	}
+
+	/**
+	 * Build a `jetpack_newsletter_invalid_<field>` WP_Error with a message
+	 * that names the field and tells the agent how to fix the input.
+	 *
+	 * @param string $field  Public field name; appears in the error code and message.
+	 * @param string $reason Translated explanation of the expected value.
+	 * @return \WP_Error
+	 */
+	private static function invalid_field( string $field, string $reason ): \WP_Error {
+		return new \WP_Error(
+			'jetpack_newsletter_invalid_' . $field,
+			sprintf(
+				/* translators: 1: field name, 2: explanation of the expected value. */
+				__( 'Invalid value for "%1$s": %2$s', 'jetpack' ),
+				$field,
+				$reason
+			)
+		);
+	}
+}

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Newsletter_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Newsletter_Abilities_Test.php
@@ -28,8 +28,8 @@ class Newsletter_Abilities_Test extends WP_UnitTestCase {
 
 		// Use the test factory so users live within the per-test transaction and
 		// stale IDs from earlier tests do not leak into wp_set_current_user.
-		$this->admin_id      = $this->factory->user->create( array( 'role' => 'administrator' ) );
-		$this->subscriber_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+		$this->admin_id      = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$this->subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
 
 		// Open the gate by default; individual tests override.
 		// Hooks added here are reverted when WP_UnitTestCase rolls the

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Newsletter_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Newsletter_Abilities_Test.php
@@ -7,8 +7,6 @@
 
 // @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9.
 
-require_once JETPACK__PLUGIN_DIR . 'modules/subscriptions/abilities/class-newsletter-abilities.php';
-
 use Automattic\Jetpack\Plugin\Abilities\Newsletter_Abilities;
 use PHPUnit\Framework\Attributes\CoversClass;
 
@@ -56,6 +54,7 @@ class Newsletter_Abilities_Test extends WP_UnitTestCase {
 		$this->assertNotEmpty( $abilities );
 		$this->assertArrayHasKey( 'jetpack-newsletter/get-settings', $abilities );
 		$this->assertArrayHasKey( 'jetpack-newsletter/update-settings', $abilities );
+		$this->assertArrayHasKey( 'jetpack-newsletter/get-subscriber-stats', $abilities );
 		foreach ( array_keys( $abilities ) as $slug ) {
 			$this->assertStringStartsWith( 'jetpack-newsletter/', $slug );
 		}
@@ -84,6 +83,11 @@ class Newsletter_Abilities_Test extends WP_UnitTestCase {
 		$this->assertFalse( $write['readonly'] );
 		$this->assertFalse( $write['destructive'] );
 		$this->assertTrue( $write['idempotent'] );
+
+		$stats = $abilities['jetpack-newsletter/get-subscriber-stats']['meta']['annotations'];
+		$this->assertTrue( $stats['readonly'] );
+		$this->assertFalse( $stats['destructive'] );
+		$this->assertTrue( $stats['idempotent'] );
 	}
 
 	public function test_init_registers_nothing_when_gate_filter_is_false() {
@@ -351,5 +355,41 @@ class Newsletter_Abilities_Test extends WP_UnitTestCase {
 				"Ability {$slug} must be filtered out by jetpack_wp_abilities_should_register."
 			);
 		}
+	}
+
+	public function test_get_subscriber_stats_returns_cached_response_without_remote_call() {
+		// Pre-seed the transient so the callback's short-circuit returns it
+		// without hitting wpcom or any class_exists/connection check.
+		set_transient(
+			'jetpack_newsletter_subscriber_stats',
+			array(
+				'all'   => 1234,
+				'email' => 1000,
+				'paid'  => 234,
+			),
+			HOUR_IN_SECONDS
+		);
+
+		$result = Newsletter_Abilities::get_subscriber_stats();
+		$this->assertIsArray( $result );
+		$this->assertSame( 1234, $result['all'] );
+		$this->assertSame( 1000, $result['email'] );
+		$this->assertSame( 234, $result['paid'] );
+
+		delete_transient( 'jetpack_newsletter_subscriber_stats' );
+	}
+
+	public function test_get_subscriber_stats_returns_wp_error_when_disconnected() {
+		// No cached stats and Jetpack reports as disconnected — must surface a
+		// jetpack_newsletter_not_connected error so the agent stops calling.
+		delete_transient( 'jetpack_newsletter_subscriber_stats' );
+		add_filter( 'jetpack_is_connection_ready', '__return_false' );
+
+		$result = Newsletter_Abilities::get_subscriber_stats();
+
+		remove_filter( 'jetpack_is_connection_ready', '__return_false' );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_newsletter_not_connected', $result->get_error_code() );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Newsletter_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Newsletter_Abilities_Test.php
@@ -1,0 +1,288 @@
+<?php
+/**
+ * Tests for the Newsletter_Abilities Registrar subclass.
+ *
+ * @package automattic/jetpack
+ */
+
+// @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9.
+
+require_once JETPACK__PLUGIN_DIR . 'modules/subscriptions/abilities/class-newsletter-abilities.php';
+
+use Automattic\Jetpack\Plugin\Abilities\Newsletter_Abilities;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * @covers \Automattic\Jetpack\Plugin\Abilities\Newsletter_Abilities
+ */
+#[CoversClass( Newsletter_Abilities::class )]
+class Newsletter_Abilities_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/** @var int */
+	private $admin_id;
+
+	/** @var int */
+	private $subscriber_id;
+
+	public function set_up() {
+		parent::set_up();
+
+		// Use the test factory so users live within the per-test transaction and
+		// stale IDs from earlier tests do not leak into wp_set_current_user.
+		$this->admin_id      = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$this->subscriber_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+
+		// Open the gate by default; individual tests override.
+		// Hooks added here are reverted when WP_UnitTestCase rolls the
+		// per-test transaction back, so no manual remove_filter in tear_down.
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+	}
+
+	public function test_category_slug_is_jetpack_newsletter() {
+		$this->assertSame( 'jetpack-newsletter', Newsletter_Abilities::get_category_slug() );
+	}
+
+	public function test_category_definition_has_label_and_description() {
+		$def = Newsletter_Abilities::get_category_definition();
+		$this->assertArrayHasKey( 'label', $def );
+		$this->assertArrayHasKey( 'description', $def );
+		$this->assertNotEmpty( $def['label'] );
+		$this->assertNotEmpty( $def['description'] );
+	}
+
+	public function test_abilities_map_is_non_empty_and_namespaced() {
+		$abilities = Newsletter_Abilities::get_abilities();
+		$this->assertNotEmpty( $abilities );
+		$this->assertArrayHasKey( 'jetpack-newsletter/get-settings', $abilities );
+		$this->assertArrayHasKey( 'jetpack-newsletter/update-settings', $abilities );
+		foreach ( array_keys( $abilities ) as $slug ) {
+			$this->assertStringStartsWith( 'jetpack-newsletter/', $slug );
+		}
+	}
+
+	public function test_no_spec_sets_category_explicitly() {
+		// Registrar auto-injects category; specs that set it duplicate info that drifts.
+		foreach ( Newsletter_Abilities::get_abilities() as $slug => $spec ) {
+			$this->assertArrayNotHasKey(
+				'category',
+				$spec,
+				"Ability {$slug} should not set its own category — Registrar injects it."
+			);
+		}
+	}
+
+	public function test_read_and_write_have_distinct_annotations() {
+		$abilities = Newsletter_Abilities::get_abilities();
+
+		$read = $abilities['jetpack-newsletter/get-settings']['meta']['annotations'];
+		$this->assertTrue( $read['readonly'] );
+		$this->assertFalse( $read['destructive'] );
+		$this->assertTrue( $read['idempotent'] );
+
+		$write = $abilities['jetpack-newsletter/update-settings']['meta']['annotations'];
+		$this->assertFalse( $write['readonly'] );
+		$this->assertFalse( $write['destructive'] );
+		$this->assertTrue( $write['idempotent'] );
+	}
+
+	public function test_init_registers_nothing_when_gate_filter_is_false() {
+		remove_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+		add_filter( 'jetpack_wp_abilities_enabled', '__return_false' );
+
+		Newsletter_Abilities::init();
+
+		$this->assertFalse(
+			has_action( 'wp_abilities_api_categories_init', array( Newsletter_Abilities::class, 'register_category' ) )
+		);
+		$this->assertFalse(
+			has_action( 'wp_abilities_api_init', array( Newsletter_Abilities::class, 'register_abilities' ) )
+		);
+	}
+
+	public function test_init_hooks_lifecycle_actions_when_gate_is_true() {
+		Newsletter_Abilities::init();
+
+		$this->assertNotFalse(
+			has_action( 'wp_abilities_api_categories_init', array( Newsletter_Abilities::class, 'register_category' ) )
+		);
+		$this->assertNotFalse(
+			has_action( 'wp_abilities_api_init', array( Newsletter_Abilities::class, 'register_abilities' ) )
+		);
+	}
+
+	public function test_ability_class_is_colocated_with_module() {
+		$reflector = new \ReflectionClass( Newsletter_Abilities::class );
+		$path      = $reflector->getFileName();
+		$this->assertStringContainsString(
+			'/modules/subscriptions/',
+			$path,
+			'Module-backed abilities must live inside their module directory, not in src/abilities/.'
+		);
+		$this->assertStringNotContainsString(
+			'/src/abilities/',
+			$path,
+			'Found a module-backed ability in the plugin-global src/abilities/ tree. Move it into modules/subscriptions/abilities/.'
+		);
+	}
+
+	public function test_not_wired_from_class_jetpack_php() {
+		$bootstrap = file_get_contents( JETPACK__PLUGIN_DIR . 'class.jetpack.php' );
+		$this->assertStringNotContainsString(
+			'Newsletter_Abilities::init()',
+			$bootstrap,
+			'class.jetpack.php must not init a module-backed ability. Wire from modules/subscriptions.php instead.'
+		);
+	}
+
+	public function test_wired_from_subscriptions_module_file() {
+		$module = file_get_contents( JETPACK__PLUGIN_DIR . 'modules/subscriptions.php' );
+		$this->assertStringContainsString(
+			'Newsletter_Abilities::init()',
+			$module,
+			'Newsletter_Abilities must be initialized from modules/subscriptions.php so registration is gated by module activation.'
+		);
+	}
+
+	public function test_can_view_allows_admin() {
+		wp_set_current_user( $this->admin_id );
+		$this->assertTrue( Newsletter_Abilities::can_view_settings() );
+	}
+
+	public function test_can_view_denies_subscriber() {
+		wp_set_current_user( $this->subscriber_id );
+		$this->assertFalse( Newsletter_Abilities::can_view_settings() );
+	}
+
+	public function test_can_view_denies_anonymous() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( Newsletter_Abilities::can_view_settings() );
+	}
+
+	public function test_can_manage_allows_admin() {
+		wp_set_current_user( $this->admin_id );
+		$this->assertTrue( Newsletter_Abilities::can_manage_settings() );
+	}
+
+	public function test_can_manage_denies_subscriber() {
+		wp_set_current_user( $this->subscriber_id );
+		$this->assertFalse( Newsletter_Abilities::can_manage_settings() );
+	}
+
+	public function test_get_settings_returns_all_fields() {
+		$result = Newsletter_Abilities::get_settings();
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'subscribe_post_end_enabled', $result );
+		$this->assertArrayHasKey( 'subscribe_comments_enabled', $result );
+		$this->assertArrayHasKey( 'notify_admin_on_subscribe', $result );
+		$this->assertArrayHasKey( 'reply_to', $result );
+		$this->assertArrayHasKey( 'from_name', $result );
+	}
+
+	public function test_get_settings_reflects_stored_options() {
+		update_option( 'stb_enabled', 0 );
+		update_option( 'social_notifications_subscribe', 'off' );
+		update_option( 'jetpack_subscriptions_reply_to', 'author' );
+		update_option( 'jetpack_subscriptions_from_name', 'My Sender' );
+
+		$result = Newsletter_Abilities::get_settings();
+		$this->assertFalse( $result['subscribe_post_end_enabled'] );
+		$this->assertFalse( $result['notify_admin_on_subscribe'] );
+		$this->assertSame( 'author', $result['reply_to'] );
+		$this->assertSame( 'My Sender', $result['from_name'] );
+	}
+
+	public function test_update_settings_with_empty_input_is_noop() {
+		$result = Newsletter_Abilities::update_settings( array() );
+		$this->assertIsArray( $result );
+		$this->assertSame( array(), $result['changed'] );
+		$this->assertArrayHasKey( 'settings', $result );
+	}
+
+	public function test_update_settings_writes_only_changed_fields() {
+		update_option( 'jetpack_subscriptions_reply_to', 'comment' );
+		update_option( 'jetpack_subscriptions_from_name', 'Old Name' );
+
+		$result = Newsletter_Abilities::update_settings(
+			array(
+				'reply_to'  => 'author',
+				'from_name' => 'Old Name', // unchanged
+			)
+		);
+
+		$this->assertSame( array( 'reply_to' ), $result['changed'] );
+		$this->assertSame( 'author', $result['settings']['reply_to'] );
+		$this->assertSame( 'Old Name', $result['settings']['from_name'] );
+		$this->assertSame( 'author', get_option( 'jetpack_subscriptions_reply_to' ) );
+	}
+
+	public function test_update_settings_is_idempotent() {
+		Newsletter_Abilities::update_settings( array( 'reply_to' => 'no-reply' ) );
+		$second = Newsletter_Abilities::update_settings( array( 'reply_to' => 'no-reply' ) );
+
+		$this->assertSame( array(), $second['changed'], 'Second call with the same desired state must be a no-op.' );
+		$this->assertSame( 'no-reply', $second['settings']['reply_to'] );
+	}
+
+	public function test_update_settings_translates_booleans_to_storage_form() {
+		Newsletter_Abilities::update_settings(
+			array(
+				'subscribe_post_end_enabled' => false,
+				'notify_admin_on_subscribe'  => false,
+			)
+		);
+
+		// Booleans persist as 1/0 for stb_enabled, 'on'/'off' for social_notifications_subscribe.
+		$this->assertSame( '0', (string) get_option( 'stb_enabled' ) );
+		$this->assertSame( 'off', get_option( 'social_notifications_subscribe' ) );
+
+		// And the public response casts them back to bool.
+		$result = Newsletter_Abilities::get_settings();
+		$this->assertFalse( $result['subscribe_post_end_enabled'] );
+		$this->assertFalse( $result['notify_admin_on_subscribe'] );
+	}
+
+	public function test_update_settings_rejects_invalid_reply_to() {
+		$result = Newsletter_Abilities::update_settings( array( 'reply_to' => 'bogus' ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_newsletter_invalid_reply_to', $result->get_error_code() );
+	}
+
+	public function test_update_settings_rejects_non_boolean_for_boolean_field() {
+		$result = Newsletter_Abilities::update_settings( array( 'subscribe_post_end_enabled' => 'yes' ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_newsletter_invalid_subscribe_post_end_enabled', $result->get_error_code() );
+	}
+
+	public function test_update_settings_does_not_partial_write_on_validation_error() {
+		// from_name is valid; reply_to is invalid → expect the whole call to fail with no writes.
+		$before_from_name = get_option( 'jetpack_subscriptions_from_name', '' );
+
+		$result = Newsletter_Abilities::update_settings(
+			array(
+				'from_name' => 'Should Not Persist',
+				'reply_to'  => 'bogus',
+			)
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame(
+			$before_from_name,
+			get_option( 'jetpack_subscriptions_from_name', '' ),
+			'Validation errors must short-circuit before any update_option call.'
+		);
+	}
+
+	public function test_update_settings_sanitizes_from_name() {
+		Newsletter_Abilities::update_settings(
+			array(
+				'from_name' => "  My  <script>x</script> Sender  \n",
+			)
+		);
+
+		// sanitize_text_field strips tags, collapses whitespace, trims.
+		$stored = get_option( 'jetpack_subscriptions_from_name' );
+		$this->assertStringNotContainsString( '<script>', $stored );
+		$this->assertStringNotContainsString( "\n", $stored );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Newsletter_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Newsletter_Abilities_Test.php
@@ -7,6 +7,8 @@
 
 // @phan-file-suppress PhanUndeclaredFunction, PhanUndeclaredClassMethod @phan-suppress-current-line UnusedSuppression -- Abilities API added in WP 6.9.
 
+require_once __DIR__ . '/../../../../modules/subscriptions/abilities/class-newsletter-abilities.php';
+
 use Automattic\Jetpack\Plugin\Abilities\Newsletter_Abilities;
 use PHPUnit\Framework\Attributes\CoversClass;
 

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Newsletter_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Newsletter_Abilities_Test.php
@@ -285,4 +285,69 @@ class Newsletter_Abilities_Test extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( '<script>', $stored );
 		$this->assertStringNotContainsString( "\n", $stored );
 	}
+
+	public function test_update_settings_rejects_non_string_from_name() {
+		$result = Newsletter_Abilities::update_settings( array( 'from_name' => 12345 ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_newsletter_invalid_from_name', $result->get_error_code() );
+	}
+
+	public function test_update_settings_rejects_oversized_from_name() {
+		// from_name caps at 200 characters; the schema advertises it and the
+		// callback enforces it so direct PHP callers can't bypass the limit.
+		$result = Newsletter_Abilities::update_settings(
+			array( 'from_name' => str_repeat( 'a', 201 ) )
+		);
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_newsletter_invalid_from_name', $result->get_error_code() );
+	}
+
+	public function test_update_settings_rejects_non_boolean_for_subscribe_comments_enabled() {
+		$result = Newsletter_Abilities::update_settings( array( 'subscribe_comments_enabled' => 1 ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_newsletter_invalid_subscribe_comments_enabled', $result->get_error_code() );
+	}
+
+	public function test_update_settings_rejects_non_boolean_for_notify_admin_on_subscribe() {
+		$result = Newsletter_Abilities::update_settings( array( 'notify_admin_on_subscribe' => 'on' ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'jetpack_newsletter_invalid_notify_admin_on_subscribe', $result->get_error_code() );
+	}
+
+	public function test_per_ability_allow_list_filter_blocks_individual_slugs() {
+		// Verify the shared `jetpack_wp_abilities_should_register` filter can
+		// gate this class's slugs the same way it gates any other Registrar.
+		if ( ! function_exists( 'wp_register_ability' ) || ! function_exists( 'wp_get_abilities' ) ) {
+			$this->markTestSkipped( 'Abilities API not available.' );
+		}
+
+		add_filter(
+			'jetpack_wp_abilities_should_register',
+			static function ( $enabled, $type, $slug ) {
+				if ( 'ability' === $type && str_starts_with( $slug, 'jetpack-newsletter/' ) ) {
+					return false;
+				}
+				return $enabled;
+			},
+			10,
+			3
+		);
+
+		Newsletter_Abilities::register_abilities();
+
+		// Compare against the full registry rather than calling wp_get_ability()
+		// per slug — the latter emits a `_doing_it_wrong` notice for missing
+		// slugs, which the test environment converts into a failure.
+		$registered_slugs = array_map(
+			static fn ( $ability ) => $ability->get_name(),
+			wp_get_abilities()
+		);
+		foreach ( array_keys( Newsletter_Abilities::get_abilities() ) as $slug ) {
+			$this->assertNotContains(
+				$slug,
+				$registered_slugs,
+				"Ability {$slug} must be filtered out by jetpack_wp_abilities_should_register."
+			);
+		}
+	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Newsletter_Abilities_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Newsletter_Abilities_Test.php
@@ -339,7 +339,9 @@ class Newsletter_Abilities_Test extends WP_UnitTestCase {
 		// per slug — the latter emits a `_doing_it_wrong` notice for missing
 		// slugs, which the test environment converts into a failure.
 		$registered_slugs = array_map(
-			static fn ( $ability ) => $ability->get_name(),
+			static function ( $ability ) {
+				return $ability->get_name();
+			},
 			wp_get_abilities()
 		);
 		foreach ( array_keys( Newsletter_Abilities::get_abilities() ) as $slug ) {


### PR DESCRIPTION
Fixes #

## Proposed changes

* Register a new \`jetpack-newsletter\` Abilities API category with two consolidated abilities:
  * \`jetpack-newsletter/get-settings\` — read all newsletter settings as a flat object (subscribe-at-post-end, subscribe-at-comment-form, notify-admin-on-subscribe, reply_to, from_name).
  * \`jetpack-newsletter/update-settings\` — partial, idempotent update; returns the post-update state plus a list of fields that actually transitioned. Validates every supplied field up-front so a bad field cannot leave earlier fields in a partially-updated state.
* Class lives at \`modules/subscriptions/abilities/class-newsletter-abilities.php\` and is wired from \`modules/subscriptions.php\`, so registration is gated by module activation. \`class.jetpack.php\` is unchanged.
* Permissions: both abilities require \`manage_options\` (matches the Newsletter settings screen).
* Reply-to validation defers to the canonical \`Subscriptions_Settings::is_valid_reply_to()\` and \`::\$default_reply_to\` so the abilities surface and the Newsletter settings screen can't drift.
* Adds \`automattic/jetpack-wp-abilities\` to the plugin's \`composer.json\` and refreshes \`composer.lock\`.

## Related product discussion/links

* Part of the Abilities Everywhere rollout — exposing Jetpack module surfaces through \`wp-abilities/v1\`.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions


1. Check out the branch and run \`composer install\` in \`projects/plugins/jetpack\`. Refresh autoload (\`composer dump-autoload\` if needed).
2. Activate the Subscriptions (Newsletter) module.
3. Add a site filter to opt in: `add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );`.
4. Hit \`GET /wp-json/wp-abilities/v1/abilities\` and confirm \`jetpack-newsletter/get-settings\` and \`jetpack-newsletter/update-settings\` appear under category \`jetpack-newsletter\`.
5. Run \`POST /wp-json/wp-abilities/v1/run\` with body \`{ "ability": "jetpack-newsletter/get-settings", "input": {} }\` (logged in as admin) and verify the response shape: \`{ subscribe_post_end_enabled, subscribe_comments_enabled, notify_admin_on_subscribe, reply_to, from_name }\`.
6. Run \`update-settings\` with \`{ "reply_to": "author" }\` and confirm \`changed: ["reply_to"]\` plus the new value in \`settings\`. Run again with the same input and confirm \`changed: []\` (idempotent).
7. Send an invalid value, e.g. \`{ "reply_to": "bogus" }\`, and confirm a \`jetpack_newsletter_invalid_reply_to\` error.
8. Deactivate the Subscriptions module and confirm the ability slugs disappear from \`/wp-abilities/v1/abilities\` (module file isn't loaded → registrar isn't called).
9. Run the test suite: \`jetpack docker phpunit jetpack -- --filter Newsletter_Abilities_Test\`. 25 tests, 62 assertions.