### PR TITLE
CRM: Harden Mail Delivery settings permissions

### DIFF
--- a/projects/plugins/crm/admin/settings/mail-delivery.ajax.php
+++ b/projects/plugins/crm/admin/settings/mail-delivery.ajax.php
@@ -225,7 +225,7 @@ function zeroBSCRM_AJAX_mailDelivery_validateWPMail() {
 	check_ajax_referer( 'wpzbs-ajax-nonce', 'sec' );  // nonce to bounce out if not from right page
 
 	// } Perms?
-	if ( ! zeroBSCRM_permsMailCampaigns() ) {
+	if ( ! current_user_can( 'admin_zerobs_manage_options' ) ) {
 		wp_send_json( array( 'permserror' => 1 ), 403, JSON_UNESCAPED_SLASHES );
 	}
 
@@ -345,7 +345,7 @@ function zeroBSCRM_AJAX_mailDelivery_validateSMTP() {
 	check_ajax_referer( 'wpzbs-ajax-nonce', 'sec' );  // nonce to bounce out if not from right page
 
 	// } Perms?
-	if ( ! zeroBSCRM_permsMailCampaigns() ) {
+	if ( ! current_user_can( 'admin_zerobs_manage_options' ) ) {
 		exit( 0 );
 	}
 
@@ -499,7 +499,7 @@ function zeroBSCRM_AJAX_mailDelivery_validateSMTPPorts() {
 	check_ajax_referer( 'wpzbs-ajax-nonce', 'sec' );  // nonce to bounce out if not from right page
 
 	// } Perms?
-	if ( ! zeroBSCRM_permsMailCampaigns() ) {
+	if ( ! current_user_can( 'admin_zerobs_manage_options' ) ) {
 		exit( 0 );
 	}
 
@@ -571,7 +571,7 @@ function jpcrm_ajax_mail_delivery_validate_api_oauth() {
 	check_ajax_referer( 'wpzbs-ajax-nonce', 'sec' );  // nonce to bounce out if not from right page
 
 	// Permission check
-	if ( ! zeroBSCRM_permsMailCampaigns() ) {
+	if ( ! current_user_can( 'admin_zerobs_manage_options' ) ) {
 		wp_send_json( array( 'permserror' => 1 ), 403, JSON_UNESCAPED_SLASHES );
 	}
 
@@ -719,7 +719,7 @@ function zeroBSCRM_AJAX_mailDelivery_testEmail() {
 	check_ajax_referer( 'wpzbs-ajax-nonce', 'sec' );  // nonce to bounce out if not from right page
 
 	// } Perms?
-	if ( ! zeroBSCRM_permsMailCampaigns() ) {
+	if ( ! current_user_can( 'admin_zerobs_manage_options' ) ) {
 		exit( 0 );
 	}
 
@@ -794,7 +794,7 @@ function zeroBSCRM_AJAX_mailDelivery_removeMailDelivery() {
 	check_ajax_referer( 'wpzbs-ajax-nonce', 'sec' );  // nonce to bounce out if not from right page
 
 	// } Perms?
-	if ( ! zeroBSCRM_permsMailCampaigns() ) {
+	if ( ! current_user_can( 'admin_zerobs_manage_options' ) ) {
 		exit( 0 );
 	}
 
@@ -875,7 +875,7 @@ function zeroBSCRM_AJAX_mailDelivery_setMailDeliveryAsDefault() {
 	check_ajax_referer( 'wpzbs-ajax-nonce', 'sec' );  // nonce to bounce out if not from right page
 
 	// } Perms?
-	if ( ! zeroBSCRM_permsMailCampaigns() ) {
+	if ( ! current_user_can( 'admin_zerobs_manage_options' ) ) {
 		exit( 0 );
 	}
 

--- a/projects/plugins/crm/admin/settings/mail-delivery.ajax.php
+++ b/projects/plugins/crm/admin/settings/mail-delivery.ajax.php
@@ -225,7 +225,7 @@ function zeroBSCRM_AJAX_mailDelivery_validateWPMail() {
 	check_ajax_referer( 'wpzbs-ajax-nonce', 'sec' );  // nonce to bounce out if not from right page
 
 	// } Perms?
-	if ( ! current_user_can( 'admin_zerobs_manage_options' ) ) {
+	if ( ! jpcrm_perms_manage_options() ) {
 		wp_send_json( array( 'permserror' => 1 ), 403, JSON_UNESCAPED_SLASHES );
 	}
 
@@ -345,7 +345,7 @@ function zeroBSCRM_AJAX_mailDelivery_validateSMTP() {
 	check_ajax_referer( 'wpzbs-ajax-nonce', 'sec' );  // nonce to bounce out if not from right page
 
 	// } Perms?
-	if ( ! current_user_can( 'admin_zerobs_manage_options' ) ) {
+	if ( ! jpcrm_perms_manage_options() ) {
 		exit( 0 );
 	}
 
@@ -499,7 +499,7 @@ function zeroBSCRM_AJAX_mailDelivery_validateSMTPPorts() {
 	check_ajax_referer( 'wpzbs-ajax-nonce', 'sec' );  // nonce to bounce out if not from right page
 
 	// } Perms?
-	if ( ! current_user_can( 'admin_zerobs_manage_options' ) ) {
+	if ( ! jpcrm_perms_manage_options() ) {
 		exit( 0 );
 	}
 
@@ -571,7 +571,7 @@ function jpcrm_ajax_mail_delivery_validate_api_oauth() {
 	check_ajax_referer( 'wpzbs-ajax-nonce', 'sec' );  // nonce to bounce out if not from right page
 
 	// Permission check
-	if ( ! current_user_can( 'admin_zerobs_manage_options' ) ) {
+	if ( ! jpcrm_perms_manage_options() ) {
 		wp_send_json( array( 'permserror' => 1 ), 403, JSON_UNESCAPED_SLASHES );
 	}
 
@@ -719,7 +719,7 @@ function zeroBSCRM_AJAX_mailDelivery_testEmail() {
 	check_ajax_referer( 'wpzbs-ajax-nonce', 'sec' );  // nonce to bounce out if not from right page
 
 	// } Perms?
-	if ( ! current_user_can( 'admin_zerobs_manage_options' ) ) {
+	if ( ! jpcrm_perms_manage_options() ) {
 		exit( 0 );
 	}
 
@@ -794,7 +794,7 @@ function zeroBSCRM_AJAX_mailDelivery_removeMailDelivery() {
 	check_ajax_referer( 'wpzbs-ajax-nonce', 'sec' );  // nonce to bounce out if not from right page
 
 	// } Perms?
-	if ( ! current_user_can( 'admin_zerobs_manage_options' ) ) {
+	if ( ! jpcrm_perms_manage_options() ) {
 		exit( 0 );
 	}
 
@@ -875,7 +875,7 @@ function zeroBSCRM_AJAX_mailDelivery_setMailDeliveryAsDefault() {
 	check_ajax_referer( 'wpzbs-ajax-nonce', 'sec' );  // nonce to bounce out if not from right page
 
 	// } Perms?
-	if ( ! current_user_can( 'admin_zerobs_manage_options' ) ) {
+	if ( ! jpcrm_perms_manage_options() ) {
 		exit( 0 );
 	}
 

--- a/projects/plugins/crm/changelog/fix-crm-mail_delivery_ajax_caps
+++ b/projects/plugins/crm/changelog/fix-crm-mail_delivery_ajax_caps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Mail Delivery: Harden setting permissions.


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
Mail delivery settings were gated to `zeroBSCRM_permsMailCampaigns()`, which is a trusted permission, but this PR bumps that to only admins (`current_user_can( 'admin_zerobs_manage_options' )`).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* pgvhYc-BV-p2#comment-664

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Go to '..'
*