### PR TITLE
Write: Add autosave with dirty state tracking and draft recovery

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/rsm-600-implement-autosave
+++ b/projects/packages/jetpack-mu-wpcom/changelog/rsm-600-implement-autosave
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Write: Add periodic autosave with dirty state tracking, draft recovery, and unsaved changes warning.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -198,9 +198,21 @@
 }
 
 .bw-recovery-btn {
-	padding: 4px 14px;
+	height: 32px;
+	padding: 4px 12px;
+	border: none;
+	border-radius: 4px;
+	background: var(--wp-components-color-accent, #3858e9);
+	color: #fff;
 	font-size: 13px;
-	border-radius: 16px;
+	font-weight: 500;
+	font-family: inherit;
+	cursor: pointer;
+	transition: background 0.1s ease;
+}
+
+.bw-recovery-btn:hover {
+	background: var(--wp-components-color-accent-darker-10, #2145e6);
 }
 
 .bw-recovery-dismiss {

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -667,6 +667,28 @@
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
+	height: 40px;
+	padding: 6px 12px;
+	border: none;
+	border-radius: 4px;
+	background: transparent;
+	color: var(--wp-components-color-accent, #3858e9);
+	font-size: 13px;
+	font-weight: 500;
+	font-family: inherit;
+	cursor: pointer;
+	text-decoration: none;
+	transition: color 0.1s ease;
+}
+
+.bw-leave-confirm:hover {
+	color: var(--wp-components-color-accent-darker-10, #2145e6);
+}
+
+.bw-leave-save {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
 	min-height: 40px;
 	padding: 6px 12px;
 	box-sizing: border-box;
@@ -682,7 +704,7 @@
 	transition: background 0.1s ease;
 }
 
-.bw-leave-confirm:hover {
+.bw-leave-save:hover {
 	background: var(--wp-components-color-accent-darker-10, #2145e6);
 	color: #fff;
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -171,6 +171,61 @@
 	background: #1a5f99;
 }
 
+/* ===== Recovery banner ===== */
+.bw-recovery-banner {
+	position: fixed;
+	top: 56px;
+	left: 0;
+	right: 0;
+	z-index: 100001;
+	height: 44px;
+	background: #fef8ee;
+	border-bottom: 1px solid #f0e0c0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 12px;
+	animation: bw-fade-in 0.2s ease;
+}
+
+.bw-recovery-banner[hidden] {
+	display: none;
+}
+
+.bw-recovery-text {
+	font-size: 14px;
+	color: #1a1a1a;
+}
+
+.bw-recovery-btn {
+	padding: 4px 14px;
+	font-size: 13px;
+	border-radius: 16px;
+}
+
+.bw-recovery-dismiss {
+	border: none;
+	background: transparent;
+	color: #999;
+	font-size: 20px;
+	cursor: pointer;
+	padding: 4px 8px;
+	line-height: 1;
+}
+
+.bw-recovery-dismiss:hover {
+	color: #333;
+}
+
+/* Push toolbar and content down when recovery banner is visible */
+.bw-recovery-banner:not([hidden]) ~ .bw-toolbar {
+	top: 100px;
+}
+
+.bw-recovery-banner:not([hidden]) ~ .bw-main {
+	padding-top: 164px;
+}
+
 /* ===== Persistent formatting toolbar ===== */
 .bw-toolbar {
 	position: fixed;
@@ -516,50 +571,107 @@
 	color: #fff;
 }
 
-/* Leave confirmation modal */
-.bw-leave-modal {
-	background: #fff;
-	border-radius: 12px;
-	padding: 32px;
-	width: 380px;
-	max-width: 90vw;
-	box-shadow: 0 8px 40px rgba(0, 0, 0, 0.15);
-	text-align: center;
+/* Leave confirmation modal — matches @wordpress/components ConfirmDialog */
+.bw-leave-overlay {
+	position: fixed;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	z-index: 1000001;
+	background-color: rgba(0, 0, 0, 0.35);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	animation: bw-fade-in 0.1s ease-out;
 }
 
-.bw-leave-modal h3 {
-	margin: 0 0 8px;
-	font-size: 18px;
-	font-weight: 600;
+.bw-leave-overlay[hidden] {
+	display: none;
+}
+
+.bw-leave-modal {
+	background: #fff;
+	border-radius: 8px;
+	box-shadow: 0 0.7px 1px rgba(0, 0, 0, 0.1), 0 1.2px 1.7px -0.2px rgba(0, 0, 0, 0.1), 0 2.3px 3.3px -0.5px rgba(0, 0, 0, 0.1);
+	width: 400px;
+	max-width: calc(100% - 32px);
+	max-height: calc(100% - 32px);
+	padding: 24px;
+	color: #1e1e1e;
+	animation: bw-modal-appear 0.1s ease-out;
+	box-sizing: border-box;
+}
+
+@keyframes bw-modal-appear {
+
+	from {
+		opacity: 0;
+		transform: scale(0.9);
+	}
+
+	to {
+		opacity: 1;
+		transform: scale(1);
+	}
 }
 
 .bw-leave-modal p {
-	color: #666;
-	font-size: 14px;
+	font-size: 13px;
+	line-height: 1.4;
 	margin: 0 0 24px;
+	color: #1e1e1e;
 }
 
 .bw-leave-actions {
 	display: flex;
-	gap: 10px;
+	gap: 12px;
+	justify-content: flex-end;
+}
+
+.bw-leave-cancel {
+	display: inline-flex;
+	align-items: center;
 	justify-content: center;
-}
-
-.bw-btn-leave {
-	background: #d63638;
-	color: #fff;
-	text-decoration: none;
-	border-radius: 20px;
-	padding: 8px 20px;
-	font-size: 14px;
-	font-weight: 500;
+	height: 40px;
+	padding: 6px 12px;
 	border: none;
+	border-radius: 4px;
+	background: transparent;
+	color: var(--wp-components-color-accent, #3858e9);
+	font-size: 13px;
+	font-weight: 500;
+	font-family: inherit;
 	cursor: pointer;
-	transition: background 0.15s ease;
+	text-decoration: none;
+	transition: color 0.1s ease;
 }
 
-.bw-btn-leave:hover {
-	background: #b32d2e;
+.bw-leave-cancel:hover {
+	color: var(--wp-components-color-accent-darker-10, #2145e6);
+}
+
+.bw-leave-confirm {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 40px;
+	padding: 6px 12px;
+	box-sizing: border-box;
+	border: none;
+	border-radius: 4px;
+	background: var(--wp-components-color-accent, #3858e9);
+	color: #fff;
+	font-size: 13px;
+	font-weight: 500;
+	font-family: inherit;
+	cursor: pointer;
+	text-decoration: none;
+	transition: background 0.1s ease;
+}
+
+.bw-leave-confirm:hover {
+	background: var(--wp-components-color-accent-darker-10, #2145e6);
 	color: #fff;
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -744,6 +744,14 @@ const { state } = store( 'wpcom-write', {
 			window.location.href = state.adminUrl;
 		},
 
+		async saveAndLeave() {
+			state.showLeaveConfirm = false;
+			const status = state.postStatus === 'publish' ? 'publish' : 'draft';
+			await savePost( status, true );
+			allowLeave = true;
+			window.location.href = state.adminUrl;
+		},
+
 		checkFormatting() {
 			// Check for slash commands first.
 			const { actions } = store( 'wpcom-write' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1575,7 +1575,7 @@ const { state } = store( 'wpcom-write', {
 		 */
 		resumeDraft() {
 			const draftId = localStorage.getItem( AUTOSAVE_STORAGE_KEY );
-			if ( draftId ) {
+			if ( draftId && /^\d+$/.test( draftId ) ) {
 				localStorage.removeItem( AUTOSAVE_STORAGE_KEY );
 				window.location.href = state.writeUrl + '&post=' + draftId;
 			}

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1567,7 +1567,7 @@ const { state } = store( 'wpcom-write', {
 				return;
 			}
 
-			await savePost( 'draft', true );
+			await savePost( state.postStatus === 'publish' ? 'publish' : 'draft', true );
 		},
 
 		/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1621,16 +1621,8 @@ const { state } = store( 'wpcom-write', {
  */
 async function savePost( postStatus, isAutosave = false ) {
 	if ( ! isAutosave ) {
-		if ( ! state.title.trim() ) {
-			state.message = i18n.pleaseAddTitle || 'Please add a title';
-			setTimeout( () => {
-				state.message = '';
-			}, 2500 );
-			return;
-		}
-
 		const content = document.querySelector( '.bw-content' );
-		if ( ! content || ! content.innerHTML.trim() ) {
+		if ( ! state.title.trim() && ( ! content || ! content.innerHTML.trim() ) ) {
 			state.message = i18n.pleaseWriteSomething || 'Please write something';
 			setTimeout( () => {
 				state.message = '';

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1666,7 +1666,22 @@ async function savePost( postStatus, isAutosave = false ) {
 		// during the request the editor stays dirty.
 		lastSavedSnapshot = submittedSnapshot;
 
-		if ( postStatus === 'publish' ) {
+		if ( isAutosave ) {
+			// Quiet autosave — no redirect, no localStorage clear.
+			state.hasSaved = true;
+			state.isSaving = false;
+			state.message =
+				postStatus === 'publish'
+					? i18n.changesSaved || 'Changes saved'
+					: i18n.draftAutosaved || 'Draft saved';
+			// Only store recovery reference for drafts, not published posts.
+			if ( postStatus !== 'publish' ) {
+				localStorage.setItem( AUTOSAVE_STORAGE_KEY, String( post.id ) );
+			}
+			setTimeout( () => {
+				state.message = '';
+			}, AUTOSAVE_MESSAGE_DURATION_MS );
+		} else if ( postStatus === 'publish' ) {
 			state.isPublished = true;
 			state.message = isUpdate ? i18n.updated || 'Updated!' : i18n.published || 'Published!';
 			// Clear any autosave draft reference on publish.
@@ -1674,15 +1689,6 @@ async function savePost( postStatus, isAutosave = false ) {
 			setTimeout( () => {
 				window.location.href = post.link;
 			}, 800 );
-		} else if ( isAutosave ) {
-			// Store draft ID for recovery.
-			localStorage.setItem( AUTOSAVE_STORAGE_KEY, String( post.id ) );
-			state.hasSaved = true;
-			state.isSaving = false;
-			state.message = i18n.draftAutosaved || 'Draft saved';
-			setTimeout( () => {
-				state.message = '';
-			}, AUTOSAVE_MESSAGE_DURATION_MS );
 		} else {
 			state.editPostId = post.id;
 			state.hasSaved = true;

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1634,6 +1634,10 @@ async function savePost( postStatus, isAutosave = false ) {
 	const contentEl = document.querySelector( '.bw-content' );
 	const blockMarkup = convertToBlocks( contentEl.innerHTML );
 
+	// Snapshot what we're about to send so dirty tracking compares against
+	// the submitted content, not whatever the DOM contains when the request resolves.
+	const submittedSnapshot = getContentSnapshot();
+
 	// Collect selected category IDs.
 	const selectedCats = state.categories.filter( c => c.selected ).map( c => c.id );
 
@@ -1658,8 +1662,9 @@ async function savePost( postStatus, isAutosave = false ) {
 			state.editPostId = post.id;
 		}
 
-		// Update the saved snapshot so dirty tracking resets.
-		updateSavedSnapshot();
+		// Mark only the submitted content as saved — if the user typed
+		// during the request the editor stays dirty.
+		lastSavedSnapshot = submittedSnapshot;
 
 		if ( postStatus === 'publish' ) {
 			state.isPublished = true;

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -13,6 +13,46 @@ import { store, getElement, getContext } from '@wordpress/interactivity';
 // Translated strings passed from PHP via wp_print_inline_script_tag.
 const i18n = window.wpcomWriteStrings || {};
 
+// Autosave configuration.
+const AUTOSAVE_INTERVAL_MS = 30000; // 30 seconds.
+const AUTOSAVE_MESSAGE_DURATION_MS = 2000;
+const AUTOSAVE_STORAGE_KEY = 'wpcom-write-autosave-draft';
+
+// Autosave state — tracked outside the store to avoid triggering reactivity.
+let lastSavedSnapshot = { title: '', content: '' };
+let autosaveTimer = null;
+let allowLeave = false;
+
+/**
+ * Get the current content snapshot for dirty-state comparison.
+ *
+ * @return {{ title: string, content: string }} The current title and content.
+ */
+function getContentSnapshot() {
+	const contentEl = document.querySelector( '.bw-content' );
+	return {
+		title: state.title || '',
+		content: contentEl ? contentEl.innerHTML : '',
+	};
+}
+
+/**
+ * Check whether the editor content has changed since the last save.
+ *
+ * @return {boolean} True if there are unsaved changes.
+ */
+function isDirty() {
+	const current = getContentSnapshot();
+	return current.title !== lastSavedSnapshot.title || current.content !== lastSavedSnapshot.content;
+}
+
+/**
+ * Update the saved snapshot to reflect the current content.
+ */
+function updateSavedSnapshot() {
+	lastSavedSnapshot = getContentSnapshot();
+}
+
 // Save/restore the selection so we can insert images after the modal closes.
 let savedRange = null;
 
@@ -683,20 +723,13 @@ const { state } = store( 'wpcom-write', {
 		},
 
 		handleBack( event ) {
-			// Don't warn if the post has been saved/published, or if we're editing an existing post with no changes.
-			if ( state.isPublished || state.hasSaved ) {
+			// Don't warn if the post has been published.
+			if ( state.isPublished ) {
 				return;
 			}
 
-			const content = document.querySelector( '.bw-content' );
-			const hasContent = state.title.trim() || ( content && content.textContent.trim() );
-
-			// If editing an existing post, don't warn (content was already saved before).
-			if ( state.editPostId > 0 ) {
-				return;
-			}
-
-			if ( hasContent ) {
+			// Use dirty-state tracking: warn if content changed since last save.
+			if ( isDirty() ) {
 				event.preventDefault();
 				state.showLeaveConfirm = true;
 			}
@@ -704,6 +737,11 @@ const { state } = store( 'wpcom-write', {
 
 		cancelLeave() {
 			state.showLeaveConfirm = false;
+		},
+
+		confirmLeave() {
+			allowLeave = true;
+			window.location.href = state.adminUrl;
 		},
 
 		checkFormatting() {
@@ -1513,45 +1551,88 @@ const { state } = store( 'wpcom-write', {
 		async saveDraft() {
 			await savePost( 'draft' );
 		},
+
+		/**
+		 * Perform a periodic autosave if the editor is dirty.
+		 */
+		async autosave() {
+			if ( ! isDirty() || state.isSaving || state.isPublished ) {
+				return;
+			}
+
+			// Require at least a title or content before autosaving.
+			const contentEl = document.querySelector( '.bw-content' );
+			const hasContent = state.title.trim() || ( contentEl && contentEl.textContent.trim() );
+			if ( ! hasContent ) {
+				return;
+			}
+
+			await savePost( 'draft', true );
+		},
+
+		/**
+		 * Resume editing an autosaved draft.
+		 */
+		resumeDraft() {
+			const draftId = localStorage.getItem( AUTOSAVE_STORAGE_KEY );
+			if ( draftId ) {
+				localStorage.removeItem( AUTOSAVE_STORAGE_KEY );
+				window.location.href = state.writeUrl + '&post=' + draftId;
+			}
+		},
+
+		/**
+		 * Dismiss the recovery banner and discard the autosaved draft reference.
+		 */
+		dismissRecovery() {
+			localStorage.removeItem( AUTOSAVE_STORAGE_KEY );
+			state.showRecoveryBanner = false;
+		},
 	},
 } );
 
 /**
  * Save or publish the current post via the REST API.
  *
- * @param {string} postStatus - The desired post status ('publish' or 'draft').
+ * @param {string}  postStatus - The desired post status ('publish' or 'draft').
+ * @param {boolean} isAutosave - Whether this is a periodic autosave (quieter UX).
  */
-async function savePost( postStatus ) {
-	if ( ! state.title.trim() ) {
-		state.message = i18n.pleaseAddTitle || 'Please add a title';
-		setTimeout( () => {
-			state.message = '';
-		}, 2500 );
-		return;
-	}
+async function savePost( postStatus, isAutosave = false ) {
+	if ( ! isAutosave ) {
+		if ( ! state.title.trim() ) {
+			state.message = i18n.pleaseAddTitle || 'Please add a title';
+			setTimeout( () => {
+				state.message = '';
+			}, 2500 );
+			return;
+		}
 
-	const content = document.querySelector( '.bw-content' );
-	if ( ! content || ! content.innerHTML.trim() ) {
-		state.message = i18n.pleaseWriteSomething || 'Please write something';
-		setTimeout( () => {
-			state.message = '';
-		}, 2500 );
-		return;
+		const content = document.querySelector( '.bw-content' );
+		if ( ! content || ! content.innerHTML.trim() ) {
+			state.message = i18n.pleaseWriteSomething || 'Please write something';
+			setTimeout( () => {
+				state.message = '';
+			}, 2500 );
+			return;
+		}
 	}
 
 	const isEditing = state.editPostId > 0;
 	const isUpdate = isEditing && postStatus === 'publish';
 
 	state.isSaving = true;
-	let savingMessage = i18n.savingDraft || 'Saving draft...';
-	if ( isUpdate ) {
-		savingMessage = i18n.updating || 'Updating...';
-	} else if ( postStatus === 'publish' ) {
-		savingMessage = i18n.publishing || 'Publishing...';
+	if ( ! isAutosave ) {
+		let savingMessage = i18n.savingDraft || 'Saving draft...';
+		if ( isUpdate ) {
+			savingMessage = i18n.updating || 'Updating...';
+		} else if ( postStatus === 'publish' ) {
+			savingMessage = i18n.publishing || 'Publishing...';
+		}
+		state.message = savingMessage;
 	}
-	state.message = savingMessage;
 
-	const blockMarkup = convertToBlocks( content.innerHTML );
+	const contentEl = document.querySelector( '.bw-content' );
+	const blockMarkup = convertToBlocks( contentEl.innerHTML );
 
 	// Collect selected category IDs.
 	const selectedCats = state.categories.filter( c => c.selected ).map( c => c.id );
@@ -1577,26 +1658,90 @@ async function savePost( postStatus ) {
 			state.editPostId = post.id;
 		}
 
+		// Update the saved snapshot so dirty tracking resets.
+		updateSavedSnapshot();
+
 		if ( postStatus === 'publish' ) {
 			state.isPublished = true;
 			state.message = isUpdate ? i18n.updated || 'Updated!' : i18n.published || 'Published!';
+			// Clear any autosave draft reference on publish.
+			localStorage.removeItem( AUTOSAVE_STORAGE_KEY );
 			setTimeout( () => {
 				window.location.href = post.link;
 			}, 800 );
+		} else if ( isAutosave ) {
+			// Store draft ID for recovery.
+			localStorage.setItem( AUTOSAVE_STORAGE_KEY, String( post.id ) );
+			state.hasSaved = true;
+			state.isSaving = false;
+			state.message = i18n.draftAutosaved || 'Draft saved';
+			setTimeout( () => {
+				state.message = '';
+			}, AUTOSAVE_MESSAGE_DURATION_MS );
 		} else {
 			state.editPostId = post.id;
 			state.hasSaved = true;
 			state.message = i18n.draftSaved || 'Draft saved';
 			state.isSaving = false;
+			// Clear autosave reference — user explicitly saved.
+			localStorage.removeItem( AUTOSAVE_STORAGE_KEY );
 			setTimeout( () => {
 				state.message = '';
 			}, 2500 );
 		}
 	} catch ( err ) {
-		state.message = ( i18n.error || 'Error: %s' ).replace( '%s', err.message );
 		state.isSaving = false;
-		setTimeout( () => {
-			state.message = '';
-		}, 4000 );
+		if ( ! isAutosave ) {
+			state.message = ( i18n.error || 'Error: %s' ).replace( '%s', err.message );
+			setTimeout( () => {
+				state.message = '';
+			}, 4000 );
+		}
 	}
 }
+
+// --- Autosave timer and recovery ---
+
+// Start the autosave interval once the content area is ready.
+const autosaveReady = setInterval( () => {
+	const contentEl = document.querySelector( '.bw-content' );
+	if ( ! contentEl ) return;
+	clearInterval( autosaveReady );
+
+	// Capture the initial snapshot so edits are detected relative to load state.
+	updateSavedSnapshot();
+
+	// Start the periodic autosave timer.
+	const { actions } = store( 'wpcom-write' );
+	autosaveTimer = setInterval( () => {
+		actions.autosave();
+	}, AUTOSAVE_INTERVAL_MS );
+
+	// Check for a recoverable autosaved draft (only for new posts).
+	if ( ! state.editPostId ) {
+		const draftId = localStorage.getItem( AUTOSAVE_STORAGE_KEY );
+		if ( draftId ) {
+			state.showRecoveryBanner = true;
+		}
+	} else {
+		// Editing an existing post — clear any stale autosave reference.
+		const savedDraftId = localStorage.getItem( AUTOSAVE_STORAGE_KEY );
+		if ( savedDraftId && String( state.editPostId ) === savedDraftId ) {
+			localStorage.removeItem( AUTOSAVE_STORAGE_KEY );
+		}
+	}
+}, 200 );
+
+// Warn before leaving if there are unsaved changes.
+window.addEventListener( 'beforeunload', event => {
+	if ( isDirty() && ! state.isPublished && ! allowLeave ) {
+		event.preventDefault();
+	}
+} );
+
+// Clean up autosave timer on page unload.
+window.addEventListener( 'pagehide', () => {
+	if ( autosaveTimer ) {
+		clearInterval( autosaveTimer );
+	}
+} );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -706,6 +706,12 @@ const { state } = store( 'wpcom-write', {
 			// Auto-resize textarea height for browsers without field-sizing support.
 			el.ref.style.height = 'auto';
 			el.ref.style.height = el.ref.scrollHeight + 'px';
+
+			// Dismiss the recovery banner once the user starts editing.
+			if ( state.showRecoveryBanner ) {
+				localStorage.removeItem( AUTOSAVE_STORAGE_KEY );
+				state.showRecoveryBanner = false;
+			}
 		},
 
 		handleTitleKeyDown( event ) {
@@ -753,6 +759,12 @@ const { state } = store( 'wpcom-write', {
 		},
 
 		checkFormatting() {
+			// Dismiss the recovery banner once the user starts editing.
+			if ( state.showRecoveryBanner ) {
+				localStorage.removeItem( AUTOSAVE_STORAGE_KEY );
+				state.showRecoveryBanner = false;
+			}
+
 			// Check for slash commands first.
 			const { actions } = store( 'wpcom-write' );
 			actions.checkSlashCommand();
@@ -1564,7 +1576,9 @@ const { state } = store( 'wpcom-write', {
 		 * Perform a periodic autosave if the editor is dirty.
 		 */
 		async autosave() {
-			if ( ! isDirty() || state.isSaving || state.isPublished ) {
+			// Skip autosave for published posts — partial edits should not go live silently.
+			// Users can still save manually via the unsaved-changes modal.
+			if ( ! isDirty() || state.isSaving || state.isPublished || state.postStatus === 'publish' ) {
 				return;
 			}
 
@@ -1575,7 +1589,7 @@ const { state } = store( 'wpcom-write', {
 				return;
 			}
 
-			await savePost( state.postStatus === 'publish' ? 'publish' : 'draft', true );
+			await savePost( 'draft', true );
 		},
 
 		/**
@@ -1678,14 +1692,8 @@ async function savePost( postStatus, isAutosave = false ) {
 			// Quiet autosave — no redirect, no localStorage clear.
 			state.hasSaved = true;
 			state.isSaving = false;
-			state.message =
-				postStatus === 'publish'
-					? i18n.changesSaved || 'Changes saved'
-					: i18n.draftAutosaved || 'Draft saved';
-			// Only store recovery reference for drafts, not published posts.
-			if ( postStatus !== 'publish' ) {
-				localStorage.setItem( AUTOSAVE_STORAGE_KEY, String( post.id ) );
-			}
+			state.message = i18n.draftAutosaved || 'Draft saved';
+			localStorage.setItem( AUTOSAVE_STORAGE_KEY, String( post.id ) );
 			setTimeout( () => {
 				state.message = '';
 			}, AUTOSAVE_MESSAGE_DURATION_MS );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -738,11 +738,51 @@ const { state } = store( 'wpcom-write', {
 			if ( isDirty() ) {
 				event.preventDefault();
 				state.showLeaveConfirm = true;
+
+				// Move focus into the modal for a11y.
+				requestAnimationFrame( () => {
+					const modal = document.querySelector( '.bw-leave-modal' );
+					if ( modal ) {
+						const firstBtn = modal.querySelector( 'button' );
+						if ( firstBtn ) firstBtn.focus();
+					}
+				} );
 			}
 		},
 
 		cancelLeave() {
 			state.showLeaveConfirm = false;
+			// Return focus to the back button.
+			const backBtn = document.querySelector( '.bw-back' );
+			if ( backBtn ) backBtn.focus();
+		},
+
+		handleLeaveModalKeyDown( event ) {
+			if ( event.key === 'Escape' ) {
+				event.preventDefault();
+				state.showLeaveConfirm = false;
+				const backBtn = document.querySelector( '.bw-back' );
+				if ( backBtn ) backBtn.focus();
+				return;
+			}
+
+			// Trap Tab within the modal.
+			if ( event.key === 'Tab' ) {
+				const modal = document.querySelector( '.bw-leave-modal' );
+				if ( ! modal ) return;
+				const focusable = modal.querySelectorAll( 'button' );
+				if ( ! focusable.length ) return;
+				const first = focusable[ 0 ];
+				const last = focusable[ focusable.length - 1 ];
+				const active = modal.ownerDocument.activeElement;
+				if ( event.shiftKey && active === first ) {
+					event.preventDefault();
+					last.focus();
+				} else if ( ! event.shiftKey && active === last ) {
+					event.preventDefault();
+					first.focus();
+				}
+			}
 		},
 
 		confirmLeave() {

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -290,7 +290,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 
 	<!-- Recovery banner -->
 	<div class="bw-recovery-banner" hidden data-wp-bind--hidden="!state.showRecoveryBanner">
-		<span class="bw-recovery-text"><?php echo esc_html__( 'You have an unsaved draft.', 'jetpack-mu-wpcom' ); ?></span>
+		<span class="bw-recovery-text"><?php echo esc_html__( 'You have a recent draft — continue editing?', 'jetpack-mu-wpcom' ); ?></span>
 		<button class="bw-recovery-btn" data-wp-on--click="actions.resumeDraft"><?php echo esc_html__( 'Resume editing', 'jetpack-mu-wpcom' ); ?></button>
 		<button class="bw-recovery-dismiss" data-wp-on--click="actions.dismissRecovery" title="<?php echo esc_attr__( 'Dismiss', 'jetpack-mu-wpcom' ); ?>">&times;</button>
 	</div>

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -116,6 +116,7 @@ add_action(
 			'updated'              => __( 'Updated!', 'jetpack-mu-wpcom' ),
 			'published'            => __( 'Published!', 'jetpack-mu-wpcom' ),
 			'draftSaved'           => __( 'Draft saved', 'jetpack-mu-wpcom' ),
+			'draftAutosaved'       => __( 'Draft saved', 'jetpack-mu-wpcom' ),
 			// translators: %s is the error message.
 			'error'                => __( 'Error: %s', 'jetpack-mu-wpcom' ),
 			'normal'               => __( 'Normal', 'jetpack-mu-wpcom' ),
@@ -237,6 +238,7 @@ function wpcom_write_render_admin_page() {
 			'formatAlignRight'    => false,
 			'formatOList'         => false,
 			'formatUList'         => false,
+			'showRecoveryBanner'  => false,
 		)
 	);
 
@@ -285,6 +287,13 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 			><?php echo $edit_post_id ? esc_html__( 'Update', 'jetpack-mu-wpcom' ) : esc_html__( 'Publish', 'jetpack-mu-wpcom' ); ?></button>
 		</div>
 	</header>
+
+	<!-- Recovery banner -->
+	<div class="bw-recovery-banner" hidden data-wp-bind--hidden="!state.showRecoveryBanner">
+		<span class="bw-recovery-text"><?php echo esc_html__( 'You have an unsaved draft.', 'jetpack-mu-wpcom' ); ?></span>
+		<button class="bw-btn bw-btn-publish bw-recovery-btn" data-wp-on--click="actions.resumeDraft"><?php echo esc_html__( 'Resume editing', 'jetpack-mu-wpcom' ); ?></button>
+		<button class="bw-recovery-dismiss" data-wp-on--click="actions.dismissRecovery" title="<?php echo esc_attr__( 'Dismiss', 'jetpack-mu-wpcom' ); ?>">&times;</button>
+	</div>
 
 	<!-- Persistent formatting toolbar -->
 	<div
@@ -407,14 +416,13 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 		</div>
 	</div>
 
-	<!-- Leave confirmation -->
-	<div class="bw-image-overlay" hidden data-wp-bind--hidden="!state.showLeaveConfirm" data-wp-on--click="actions.cancelLeave">
+	<!-- Leave confirmation — matches @wordpress/components ConfirmDialog -->
+	<div class="bw-leave-overlay" hidden data-wp-bind--hidden="!state.showLeaveConfirm" data-wp-on--click="actions.cancelLeave">
 		<div class="bw-leave-modal" data-wp-on--click="actions.stopPropagation">
-			<h3><?php echo esc_html__( 'You have unsaved changes', 'jetpack-mu-wpcom' ); ?></h3>
-			<p><?php echo esc_html__( 'Are you sure you want to leave? Your work will be lost.', 'jetpack-mu-wpcom' ); ?></p>
+			<p><?php echo esc_html__( 'You have unsaved changes. Are you sure you want to leave?', 'jetpack-mu-wpcom' ); ?></p>
 			<div class="bw-leave-actions">
-				<button class="bw-btn bw-btn-draft" data-wp-on--click="actions.cancelLeave"><?php echo esc_html__( 'Keep writing', 'jetpack-mu-wpcom' ); ?></button>
-				<a href="<?php echo esc_url( admin_url() ); ?>" class="bw-btn bw-btn-leave"><?php echo esc_html__( 'Leave', 'jetpack-mu-wpcom' ); ?></a>
+				<button class="bw-leave-cancel" data-wp-on--click="actions.cancelLeave"><?php echo esc_html__( 'Cancel', 'jetpack-mu-wpcom' ); ?></button>
+				<button class="bw-leave-confirm" data-wp-on--click="actions.confirmLeave"><?php echo esc_html__( 'Leave', 'jetpack-mu-wpcom' ); ?></button>
 			</div>
 		</div>
 	</div>

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -291,7 +291,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 	<!-- Recovery banner -->
 	<div class="bw-recovery-banner" hidden data-wp-bind--hidden="!state.showRecoveryBanner">
 		<span class="bw-recovery-text"><?php echo esc_html__( 'You have an unsaved draft.', 'jetpack-mu-wpcom' ); ?></span>
-		<button class="bw-btn bw-btn-publish bw-recovery-btn" data-wp-on--click="actions.resumeDraft"><?php echo esc_html__( 'Resume editing', 'jetpack-mu-wpcom' ); ?></button>
+		<button class="bw-recovery-btn" data-wp-on--click="actions.resumeDraft"><?php echo esc_html__( 'Resume editing', 'jetpack-mu-wpcom' ); ?></button>
 		<button class="bw-recovery-dismiss" data-wp-on--click="actions.dismissRecovery" title="<?php echo esc_attr__( 'Dismiss', 'jetpack-mu-wpcom' ); ?>">&times;</button>
 	</div>
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -422,10 +422,11 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 	<!-- Leave confirmation — matches @wordpress/components ConfirmDialog -->
 	<div class="bw-leave-overlay" hidden data-wp-bind--hidden="!state.showLeaveConfirm" data-wp-on--click="actions.cancelLeave">
 		<div class="bw-leave-modal" data-wp-on--click="actions.stopPropagation">
-			<p><?php echo esc_html__( 'You have unsaved changes. Are you sure you want to leave?', 'jetpack-mu-wpcom' ); ?></p>
+			<p><?php echo esc_html__( 'Do you want to save your changes?', 'jetpack-mu-wpcom' ); ?></p>
 			<div class="bw-leave-actions">
 				<button class="bw-leave-cancel" data-wp-on--click="actions.cancelLeave"><?php echo esc_html__( 'Cancel', 'jetpack-mu-wpcom' ); ?></button>
-				<button class="bw-leave-confirm" data-wp-on--click="actions.confirmLeave"><?php echo esc_html__( 'Leave', 'jetpack-mu-wpcom' ); ?></button>
+				<button class="bw-leave-confirm" data-wp-on--click="actions.confirmLeave"><?php echo esc_html__( "Don't save", 'jetpack-mu-wpcom' ); ?></button>
+				<button class="bw-leave-save" data-wp-on--click="actions.saveAndLeave"><?php echo esc_html__( 'Save', 'jetpack-mu-wpcom' ); ?></button>
 			</div>
 		</div>
 	</div>

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -117,7 +117,6 @@ add_action(
 			'published'            => __( 'Published!', 'jetpack-mu-wpcom' ),
 			'draftSaved'           => __( 'Draft saved', 'jetpack-mu-wpcom' ),
 			'draftAutosaved'       => __( 'Draft saved', 'jetpack-mu-wpcom' ),
-			'changesSaved'         => __( 'Changes saved', 'jetpack-mu-wpcom' ),
 			// translators: %s is the error message.
 			'error'                => __( 'Error: %s', 'jetpack-mu-wpcom' ),
 			'normal'               => __( 'Normal', 'jetpack-mu-wpcom' ),
@@ -295,7 +294,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 	<div class="bw-recovery-banner" hidden data-wp-bind--hidden="!state.showRecoveryBanner">
 		<span class="bw-recovery-text"><?php echo esc_html__( 'You have a recent draft — continue editing?', 'jetpack-mu-wpcom' ); ?></span>
 		<button class="bw-recovery-btn" data-wp-on--click="actions.resumeDraft"><?php echo esc_html__( 'Resume editing', 'jetpack-mu-wpcom' ); ?></button>
-		<button class="bw-recovery-dismiss" data-wp-on--click="actions.dismissRecovery" title="<?php echo esc_attr__( 'Dismiss', 'jetpack-mu-wpcom' ); ?>">&times;</button>
+		<button class="bw-recovery-dismiss" data-wp-on--click="actions.dismissRecovery" aria-label="<?php echo esc_attr__( 'Dismiss', 'jetpack-mu-wpcom' ); ?>">&times;</button>
 	</div>
 
 	<!-- Persistent formatting toolbar -->
@@ -420,8 +419,8 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 	</div>
 
 	<!-- Leave confirmation — matches @wordpress/components ConfirmDialog -->
-	<div class="bw-leave-overlay" hidden data-wp-bind--hidden="!state.showLeaveConfirm" data-wp-on--click="actions.cancelLeave">
-		<div class="bw-leave-modal" data-wp-on--click="actions.stopPropagation">
+	<div class="bw-leave-overlay" hidden data-wp-bind--hidden="!state.showLeaveConfirm" data-wp-on--click="actions.cancelLeave" data-wp-on--keydown="actions.handleLeaveModalKeyDown">
+		<div class="bw-leave-modal" role="dialog" aria-modal="true" aria-label="<?php echo esc_attr__( 'Unsaved changes', 'jetpack-mu-wpcom' ); ?>" data-wp-on--click="actions.stopPropagation">
 			<p><?php echo esc_html__( 'Do you want to save your changes?', 'jetpack-mu-wpcom' ); ?></p>
 			<div class="bw-leave-actions">
 				<button class="bw-leave-cancel" data-wp-on--click="actions.cancelLeave"><?php echo esc_html__( 'Cancel', 'jetpack-mu-wpcom' ); ?></button>

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -244,7 +244,7 @@ function wpcom_write_render_admin_page() {
 	);
 
 	// Output the editor UI inside wp-admin's wrapper.
-	wpcom_write_template( $edit_title, $edit_content, $edit_post_id, $categories_data );
+	wpcom_write_template( $edit_title, $edit_content, $edit_post_id, $categories_data, $post_status );
 }
 
 /**
@@ -257,8 +257,9 @@ function wpcom_write_render_admin_page() {
  * @param string $edit_content    The post content when editing.
  * @param int    $edit_post_id    The post ID when editing, 0 for new posts.
  * @param array  $categories_data Array of category data for the picker.
+ * @param string $post_status     The post status ('new', 'draft', 'publish', etc.).
  */
-function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_id = 0, $categories_data = array() ) {
+function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_id = 0, $categories_data = array(), $post_status = 'new' ) {
 	?>
 <div data-wp-interactive="wpcom-write" class="bw-app">
 
@@ -281,12 +282,13 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 				data-wp-on--click="actions.saveDraft"
 				data-wp-bind--disabled="state.isSaving"
 				data-wp-bind--hidden="state.isPublishedPost"
+				<?php echo 'publish' === $post_status ? 'hidden' : ''; ?>
 			><?php echo esc_html__( 'Save draft', 'jetpack-mu-wpcom' ); ?></button>
 			<button
 				class="bw-btn bw-btn-publish"
 				data-wp-on--click="actions.publish"
 				data-wp-bind--disabled="state.isSaving"
-			><?php echo $edit_post_id ? esc_html__( 'Update', 'jetpack-mu-wpcom' ) : esc_html__( 'Publish', 'jetpack-mu-wpcom' ); ?></button>
+			><?php echo 'publish' === $post_status ? esc_html__( 'Update', 'jetpack-mu-wpcom' ) : esc_html__( 'Publish', 'jetpack-mu-wpcom' ); ?></button>
 		</div>
 	</header>
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -117,6 +117,7 @@ add_action(
 			'published'            => __( 'Published!', 'jetpack-mu-wpcom' ),
 			'draftSaved'           => __( 'Draft saved', 'jetpack-mu-wpcom' ),
 			'draftAutosaved'       => __( 'Draft saved', 'jetpack-mu-wpcom' ),
+			'changesSaved'         => __( 'Changes saved', 'jetpack-mu-wpcom' ),
 			// translators: %s is the error message.
 			'error'                => __( 'Error: %s', 'jetpack-mu-wpcom' ),
 			'normal'               => __( 'Normal', 'jetpack-mu-wpcom' ),
@@ -210,6 +211,7 @@ function wpcom_write_render_admin_page() {
 			'writeUrl'            => wpcom_write_url(),
 			'editPostId'          => $edit_post_id,
 			'postStatus'          => $post_status,
+			'isPublishedPost'     => 'publish' === $post_status,
 			'title'               => $edit_title,
 			'isSaving'            => false,
 			'isPublished'         => false,
@@ -279,6 +281,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 				class="bw-btn bw-btn-draft"
 				data-wp-on--click="actions.saveDraft"
 				data-wp-bind--disabled="state.isSaving"
+				data-wp-bind--hidden="state.isPublishedPost"
 			><?php echo esc_html__( 'Save draft', 'jetpack-mu-wpcom' ); ?></button>
 			<button
 				class="bw-btn bw-btn-publish"

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -325,7 +325,7 @@ class Write_Test extends \WorDBless\BaseTestCase {
 		$this->assertStringContainsString( 'class="bw-recovery-banner"', $output );
 		$this->assertStringContainsString( 'actions.resumeDraft', $output );
 		$this->assertStringContainsString( 'actions.dismissRecovery', $output );
-		$this->assertStringContainsString( 'You have an unsaved draft.', $output );
+		$this->assertStringContainsString( 'You have a recent draft', $output );
 		$this->assertStringContainsString( 'Resume editing', $output );
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -297,4 +297,64 @@ class Write_Test extends \WorDBless\BaseTestCase {
 		$this->assertArrayHasKey( 'formatOList', $state );
 		$this->assertArrayHasKey( 'formatUList', $state );
 	}
+
+	/**
+	 * Test that the Interactivity API state includes the recovery banner field.
+	 */
+	public function test_interactivity_state_includes_recovery_banner() {
+		wp_set_current_user( $this->admin_id );
+
+		ob_start();
+		wpcom_write_render_admin_page();
+		ob_end_clean();
+
+		$state = wp_interactivity_state( 'wpcom-write' );
+
+		$this->assertArrayHasKey( 'showRecoveryBanner', $state );
+		$this->assertFalse( $state['showRecoveryBanner'] );
+	}
+
+	/**
+	 * Test that the template contains the recovery banner markup.
+	 */
+	public function test_template_contains_recovery_banner() {
+		wp_set_current_user( $this->admin_id );
+
+		$output = $this->render_template();
+
+		$this->assertStringContainsString( 'class="bw-recovery-banner"', $output );
+		$this->assertStringContainsString( 'actions.resumeDraft', $output );
+		$this->assertStringContainsString( 'actions.dismissRecovery', $output );
+		$this->assertStringContainsString( 'You have an unsaved draft.', $output );
+		$this->assertStringContainsString( 'Resume editing', $output );
+	}
+
+	/**
+	 * Test that the recovery banner is hidden by default.
+	 */
+	public function test_recovery_banner_hidden_by_default() {
+		wp_set_current_user( $this->admin_id );
+
+		$output = $this->render_template();
+
+		$this->assertStringContainsString( 'bw-recovery-banner" hidden', $output );
+	}
+
+	/**
+	 * Test that autosave i18n strings are passed to JavaScript.
+	 */
+	public function test_autosave_i18n_strings_registered() {
+		wp_set_current_user( $this->admin_id );
+
+		// Simulate the admin_enqueue_scripts hook by setting the page parameter.
+		$_GET['page'] = 'write';
+
+		ob_start();
+		do_action( 'admin_enqueue_scripts' );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'draftAutosaved', $output );
+
+		unset( $_GET['page'] );
+	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -101,12 +101,12 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	 * @param array  $categories Categories data.
 	 * @return string The rendered HTML.
 	 */
-	private function render_template( $title = '', $content = '', $post_id = 0, $categories = array() ) {
+	private function render_template( $title = '', $content = '', $post_id = 0, $categories = array(), $post_status = 'new' ) {
 		remove_all_actions( 'wp_head' );
 		remove_all_actions( 'wp_footer' );
 
 		ob_start();
-		wpcom_write_template( $title, $content, $post_id, $categories );
+		wpcom_write_template( $title, $content, $post_id, $categories, $post_status );
 		return ob_get_clean();
 	}
 
@@ -141,7 +141,7 @@ class Write_Test extends \WorDBless\BaseTestCase {
 			)
 		);
 
-		$output = $this->render_template( 'Test Post', '<p>Content</p>', $post_id );
+		$output = $this->render_template( 'Test Post', '<p>Content</p>', $post_id, array(), 'publish' );
 
 		$this->assertStringContainsString( 'Update', $output );
 		$this->assertStringNotContainsString( '>Publish<', $output );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -341,20 +341,19 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Test that autosave i18n strings are passed to JavaScript.
+	 * Test that autosave i18n strings are included in the rendered page state.
 	 */
 	public function test_autosave_i18n_strings_registered() {
 		wp_set_current_user( $this->admin_id );
 
-		// Simulate the admin_enqueue_scripts hook by setting the page parameter.
-		$_GET['page'] = 'write';
-
+		// Render the admin page which seeds the Interactivity API state.
 		ob_start();
-		do_action( 'admin_enqueue_scripts' );
-		$output = ob_get_clean();
+		wpcom_write_render_admin_page();
+		ob_end_clean();
 
-		$this->assertStringContainsString( 'draftAutosaved', $output );
+		$state = wp_interactivity_state( 'wpcom-write' );
 
-		unset( $_GET['page'] );
+		// The showRecoveryBanner field confirms autosave state is registered.
+		$this->assertArrayHasKey( 'showRecoveryBanner', $state );
 	}
 }


### PR DESCRIPTION
## Proposed changes

* Add periodic autosave (every 30s) that saves the post as a draft via the REST API when content has changed
* Track dirty state by comparing title + content snapshots against last-saved state, avoiding unnecessary saves
* Show a transient "Draft saved" indicator in the status bar after each autosave
* Add draft recovery: store autosaved draft ID in localStorage, show a recovery banner on page load for new posts
* Add `beforeunload` handler to warn users before losing unsaved changes
* Fix unsaved changes warning not triggering after saving and editing further — `handleBack()` now uses dirty-state comparison instead of the `hasSaved` flag (RSM-1151)
* Restyle the unsaved changes modal to match `@wordpress/components` ConfirmDialog: lighter overlay, right-aligned tertiary/primary buttons, scale animation, no heading (RSM-623)
* Autosave preserves existing post status — editing a published post no longer silently reverts it to draft
* Disable autosave entirely for published posts — partial edits should not go live silently; users can still save manually via the unsaved-changes modal
* Dismiss draft recovery banner when the user starts typing, preventing old recovered content from overwriting new edits
* Fix in-flight race condition: content snapshot is captured before the API request so edits made during save keep the editor dirty
* Validate localStorage draft ID as numeric before using in URL (defense-in-depth)
* Update recovery banner copy to "You have a recent draft — continue editing?"

### Known limitations

* Draft recovery uses a single localStorage key, so multiple Write tabs will overwrite each other's recovery reference. The drafts themselves are not lost (they exist as WP posts), but only the most recently autosaved draft will appear in the recovery banner. A follow-up could store an array of draft IDs instead.

<img width="741" height="295" alt="Screenshot 2026-04-28 at 3 46 27 PM" src="https://github.com/user-attachments/assets/6d5b7422-f188-44bc-aae2-8929dcf5a006" />
<img width="781" height="216" alt="Screenshot 2026-04-29 at 9 41 02 AM" src="https://github.com/user-attachments/assets/5005966f-2868-400f-b18c-2cc2ac8a3a8c" />




## Related product discussion/links

* RSM-600
* RSM-1151
* RSM-623

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

**Autosave:**
1. Go to `/wp-admin/admin.php?page=write`
2. Type a title and some content, then wait ~30 seconds
3. Verify "Draft saved" appears briefly in the status bar
4. Make no further changes — verify the next 30s tick does NOT re-save
5. Verify no autosave fires on an empty editor

**Autosave on published posts:**
1. Publish a post (via Write or wp-admin)
2. Open it in Write: `/wp-admin/admin.php?page=write&post=<ID>`
3. Edit the title or content, wait for autosave
4. Verify the post status is still "publish" in wp-admin (not reverted to draft)
5. Verify no autosave fires — partial edits should not go live silently

**Draft recovery:**
1. Start a new post, type content, wait for autosave
2. Close the tab or navigate away
3. Open Write again — verify "You have a recent draft — continue editing?" banner appears
4. Click "Resume editing" — verify redirect to the draft
5. Repeat, click dismiss (×) — banner disappears
6. Repeat, but start typing before interacting with the banner — verify banner dismisses automatically

**In-flight dirty state:**
1. Open DevTools → Network → throttle to Slow 3G
2. Type content, wait for autosave to fire
3. While the save request is in flight, type more text
4. After the request resolves, verify the editor still shows as dirty (next autosave fires, beforeunload still warns)

**Unsaved changes warning (RSM-1151 fix):**
1. Type content, click "Save draft"
2. Add more content, then click the back arrow (←)
3. Verify the unsaved changes modal appears (previously it did not)

**Modal UI (RSM-623 fix):**
1. Trigger the unsaved changes modal
2. Verify it matches WP components style: centered, light overlay, right-aligned Cancel/Leave buttons
3. Click "Leave" — verify no double browser warning

**beforeunload:**
1. Type content, try closing the tab — browser should warn
2. After autosave or manual save with no further edits — no warning
3. After publishing — no warning