### PR TITLE
CRM: Allow tag export on objects

### DIFF
--- a/projects/plugins/crm/changelog/add-crm-export-object-tags
+++ b/projects/plugins/crm/changelog/add-crm-export-object-tags
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add tags as an exportable field for contacts, companies, quotes, invoices, and transactions.

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Export.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Export.php
@@ -314,6 +314,13 @@ function jpcrm_export_process_file_export() {
 				}
 
 				if ( is_array( $availObjs ) ) {
+
+					// Bulk-fetch all tags in one go when requested.
+					$tag_map = array();
+					if ( in_array( 'tags', $fields, true ) ) {
+						$tag_map = jpcrm_export_bulk_fetch_tags( $obj_type_id, array_column( $availObjs, 'id' ) );
+					}
+
 					foreach ( $availObjs as $obj ) {
 
 							// per obj
@@ -351,6 +358,11 @@ function jpcrm_export_process_file_export() {
 								if ( isset( $obj[ str_replace( 'sec', 'secaddr_', $fK ) ] ) ) {
 									$v = $obj[ str_replace( 'sec', 'secaddr_', $fK ) ];
 								}
+							}
+
+							// Create pipe-separated tags field.
+							if ( $fK === 'tags' ) {
+								$v = implode( '|', $tag_map[ (int) $obj['id'] ] ?? array() );
 							}
 
 							// here we account for linked objects
@@ -448,6 +460,47 @@ function jpcrm_export_process_file_export() {
 	} // / Check if valid posted export request
 }
 	add_action( 'jpcrm_post_wp_loaded', 'jpcrm_export_process_file_export' );
+
+/**
+ * Fetches tag names for a list of object IDs in a single query.
+ * Returns a map of [obj_id => array of tag names], for fast row-loop lookup during export.
+ *
+ * @param int   $obj_type_id Object type ID.
+ * @param int[] $obj_ids     Array of object IDs.
+ *
+ * @return array<int,string[]>
+ */
+function jpcrm_export_bulk_fetch_tags( $obj_type_id, $obj_ids ) {
+	global $wpdb, $ZBSCRM_t;
+
+	$tag_map = array();
+
+	if ( count( $obj_ids ) === 0 ) {
+		return $tag_map;
+	}
+
+	$placeholders = implode( ',', array_fill( 0, count( $obj_ids ), '%d' ) );
+	$params       = array_merge( array( $obj_type_id ), $obj_ids );
+
+	$rows = $wpdb->get_results(
+		$wpdb->prepare(
+			"SELECT tl.zbstl_objid AS obj_id, t.zbstag_name AS tag_name
+			 FROM {$ZBSCRM_t['taglinks']} tl
+			 INNER JOIN {$ZBSCRM_t['tags']} t ON t.ID = tl.zbstl_tagid
+			 WHERE tl.zbstl_objtype = %d AND tl.zbstl_objid IN ($placeholders)
+			 ORDER BY t.zbstag_name ASC",
+			$params
+		)
+	);
+
+	if ( is_array( $rows ) ) {
+		foreach ( $rows as $row ) {
+			$tag_map[ (int) $row->obj_id ][] = $row->tag_name;
+		}
+	}
+
+	return $tag_map;
+}
 
 /**
  * Takes an object being exported, and a linked object type, and returns the subobject
@@ -659,6 +712,16 @@ function zeroBSCRM_export_produceAvailableFields( $objTypeToExport = false, $inc
 			// simpler
 			$fieldsAvailable[ 'linked_obj_' . $objectType . '_email' ] = $label;
 		}
+	}
+
+	// Tags pseudo-field (works for all object types via taglinks)
+	if ( $includeAreas ) {
+		$fieldsAvailable['tags'] = array(
+			'label' => __( 'Tags', 'zero-bs-crm' ),
+			'area'  => __( 'Tags', 'zero-bs-crm' ),
+		);
+	} else {
+		$fieldsAvailable['tags'] = __( 'Tags', 'zero-bs-crm' );
 	}
 
 	return $fieldsAvailable;

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Export.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Export.php
@@ -482,13 +482,9 @@ function jpcrm_export_bulk_fetch_tags( $obj_type_id, $obj_ids ) {
 	$placeholders = implode( ',', array_fill( 0, count( $obj_ids ), '%d' ) );
 	$params       = array_merge( array( $obj_type_id ), $obj_ids );
 
-	$rows = $wpdb->get_results(
+	$rows = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$wpdb->prepare(
-			"SELECT tl.zbstl_objid AS obj_id, t.zbstag_name AS tag_name
-			 FROM {$ZBSCRM_t['taglinks']} tl
-			 INNER JOIN {$ZBSCRM_t['tags']} t ON t.ID = tl.zbstl_tagid
-			 WHERE tl.zbstl_objtype = %d AND tl.zbstl_objid IN ($placeholders)
-			 ORDER BY t.zbstag_name ASC",
+			"SELECT tl.zbstl_objid AS obj_id, t.zbstag_name AS tag_name FROM {$ZBSCRM_t['taglinks']} tlINNER JOIN {$ZBSCRM_t['tags']} t ON t.ID = tl.zbstl_tagid WHERE tl.zbstl_objtype = %d AND tl.zbstl_objid IN ($placeholders) ORDER BY t.zbstag_name ASC", // phpcs:ignore WordPress.NamingConventions.ValidVariableName.InterpolatedVariableNotSnakeCase,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$params
 		)
 	);

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Export.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Export.php
@@ -484,6 +484,7 @@ function jpcrm_export_bulk_fetch_tags( $obj_type_id, $obj_ids ) {
 
 	$rows = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$wpdb->prepare(
+			// @phan-suppress-next-line PhanTypeArraySuspiciousNullable -- $ZBSCRM_t is defined in includes/ZeroBSCRM.Database.php
 			"SELECT tl.zbstl_objid AS obj_id, t.zbstag_name AS tag_name FROM {$ZBSCRM_t['taglinks']} tlINNER JOIN {$ZBSCRM_t['tags']} t ON t.ID = tl.zbstl_tagid WHERE tl.zbstl_objtype = %d AND tl.zbstl_objid IN ($placeholders) ORDER BY t.zbstag_name ASC", // phpcs:ignore WordPress.NamingConventions.ValidVariableName.InterpolatedVariableNotSnakeCase,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$params
 		)

--- a/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Export.php
+++ b/projects/plugins/crm/includes/ZeroBSCRM.DAL3.Export.php
@@ -485,7 +485,7 @@ function jpcrm_export_bulk_fetch_tags( $obj_type_id, $obj_ids ) {
 	$rows = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$wpdb->prepare(
 			// @phan-suppress-next-line PhanTypeArraySuspiciousNullable -- $ZBSCRM_t is defined in includes/ZeroBSCRM.Database.php
-			"SELECT tl.zbstl_objid AS obj_id, t.zbstag_name AS tag_name FROM {$ZBSCRM_t['taglinks']} tlINNER JOIN {$ZBSCRM_t['tags']} t ON t.ID = tl.zbstl_tagid WHERE tl.zbstl_objtype = %d AND tl.zbstl_objid IN ($placeholders) ORDER BY t.zbstag_name ASC", // phpcs:ignore WordPress.NamingConventions.ValidVariableName.InterpolatedVariableNotSnakeCase,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			"SELECT tl.zbstl_objid AS obj_id, t.zbstag_name AS tag_name FROM {$ZBSCRM_t['taglinks']} tl INNER JOIN {$ZBSCRM_t['tags']} t ON t.ID = tl.zbstl_tagid WHERE tl.zbstl_objtype = %d AND tl.zbstl_objid IN ($placeholders) ORDER BY t.zbstag_name ASC", // phpcs:ignore WordPress.NamingConventions.ValidVariableName.InterpolatedVariableNotSnakeCase,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$params
 		)
 	);


### PR DESCRIPTION
Allow objects to have their associated tags exported.

## Proposed changes
<!--- Explain what functional changes your PR includes -->
This is a common request, but a bit complicated to implement without performance implications.

* I do a single query for all objects instead of one subquery per object.
* Said query only runs when tags are selected, so shouldn't have any negative impact on the status quo.
* Tag names are pipe-separated to match the import format listed [here](https://kb.jetpackcrm.com/knowledge-base/can-i-import-tags-with-csv-importer/)

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* Automattic/zero-bs-crm#422

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

1. Add some objects (e.g. contacts).
2. Add tags to those objects.
3. Export those objects:
    * Try exporting all fields.
    * Try exporting selective fields (including tags).