### PR TITLE
REST API: expose apm_enabled via GET site endpoint options

### DIFF
--- a/projects/plugins/jetpack/changelog/add-apm-enabled-option
+++ b/projects/plugins/jetpack/changelog/add-apm-enabled-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+REST API: expose `apm_enabled` via the GET site endpoint's `?options=` query param.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -990,7 +990,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					$options[ $key ] = $site->get_jetpack_recovery_mode_status();
 					break;
 				case 'apm_enabled':
-					$options[ $key ] = (bool) get_option( 'apm_enabled' );
+					$options[ $key ] = $site->get_apm_enabled();
 					break;
 			}
 		}

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -240,6 +240,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'wpcom_admin_interface',
 		'wpcom_classic_early_release',
 		'jetpack_recovery_mode_status',
+		'apm_enabled',
 	);
 
 	/**
@@ -311,6 +312,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'wpcom_admin_interface',
 		'wpcom_classic_early_release',
 		'jetpack_recovery_mode_status',
+		'apm_enabled',
 	);
 
 	/**
@@ -986,6 +988,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 				case 'jetpack_recovery_mode_status':
 					$options[ $key ] = $site->get_jetpack_recovery_mode_status();
+					break;
+				case 'apm_enabled':
+					$options[ $key ] = (bool) get_option( 'apm_enabled' );
 					break;
 			}
 		}

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1696,6 +1696,18 @@ abstract class SAL_Site {
 	}
 
 	/**
+	 * Returns whether APM (Application Performance Monitoring) is enabled for the site.
+	 *
+	 * APM is an Atomic-only hosting feature. Non-Atomic site types (Simple wpcom, real
+	 * Jetpack) return false; Jetpack_Shadow_Site overrides with the actual read.
+	 *
+	 * @return bool
+	 **/
+	public function get_apm_enabled() {
+		return false;
+	}
+
+	/**
 	 * Get Zendesk site meta.
 	 *
 	 * @return array|null


### PR DESCRIPTION
Fixes # N/A

## Proposed changes
* Add `apm_enabled` to the GET site endpoint's `?options=` allow-list (both `$site_options_format` and `$jetpack_response_option_additions`, so it survives both render passes for Atomic shadow sites).
* New SAL base accessor `SAL_Site::get_apm_enabled()` returning `false`. APM is Atomic-only, so Simple wpcom and real Jetpack sites inherit the safe default; `Jetpack_Shadow_Site` (in the wpcom monorepo) overrides with the actual `get_option()` read.
* `render_option_keys()` arm delegates to `$site->get_apm_enabled()`, matching the file's convention (no direct `get_option()` calls in the switch).

## Related product discussion/links
* Read side for the wpcom `POST /wpcom/v2/sites/{id}/hosting/apm` mutator. Lets the dashboard round-trip the APM toggle via `GET /rest/v1.1/sites/{id}?options=apm_enabled`.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

On a wpcom Atomic sandbox (not WRITE-LIMITED — write-limited mode silently drops `update_option` writes):

1. `POST .../hosting/apm  { "active": true }`
2. `GET .../sites/{id}?options=apm_enabled` → `{ "options": { "apm_enabled": true } }`
3. Flip to `false` and confirm the GET reflects it.
4. Sanity check on a non-Atomic site (Simple or off-wpcom Jetpack): the field reports `false` from the base default.
