### PR TITLE
Search: restyle sort-control radio variant as text-only links

### DIFF
--- a/projects/packages/search/changelog/atlas-sort-control-radio-text-styling
+++ b/projects/packages/search/changelog/atlas-sort-control-radio-text-styling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search: restyle sort-control radio variant as text-only links with a bullet separator.

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/edit.js
@@ -146,7 +146,7 @@ export default function SortControlEdit( { attributes, setAttributes } ) {
 				value: displayAs,
 				options: [
 					{ value: 'select', label: __( 'Dropdown', 'jetpack-search-pkg' ) },
-					{ value: 'radio', label: __( 'Radio buttons', 'jetpack-search-pkg' ) },
+					{ value: 'radio', label: __( 'Inline links', 'jetpack-search-pkg' ) },
 				],
 				onChange: value => setAttributes( { displayAs: value } ),
 			} )

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
@@ -68,7 +68,6 @@
 			padding: 0;
 			border: 0;
 			overflow: hidden;
-			clip: rect(0 0 0 0);
 			clip-path: inset(50%);
 			white-space: nowrap;
 		}

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
@@ -36,15 +36,20 @@
 		margin: 0;
 		padding: 0;
 
+		// Visually hide the legend — the radio variant presents options
+		// inline without a leading label, but assistive tech still needs
+		// the fieldset to have an accessible name. Same off-screen-clip
+		// pattern as the hidden radio input.
 		legend {
-			font-size: 0.9rem;
-			// Match the select variant's `label` so the radio fieldset adapts
-			// to dark themes and the site palette instead of pinning to a
-			// hard-coded grey.
-			color: inherit;
-			opacity: 0.8;
+			position: absolute;
+			width: 1px;
+			height: 1px;
+			margin: 0;
 			padding: 0;
-			margin-inline-end: 0.5rem;
+			border: 0;
+			overflow: hidden;
+			clip-path: inset(50%);
+			white-space: nowrap;
 		}
 	}
 

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
@@ -32,7 +32,6 @@
 		display: flex;
 		align-items: center;
 		flex-wrap: wrap;
-		gap: 0.5rem;
 		border: 0;
 		margin: 0;
 		padding: 0;
@@ -45,13 +44,59 @@
 			color: inherit;
 			opacity: 0.8;
 			padding: 0;
+			margin-inline-end: 0.5rem;
 		}
 	}
 
+	// Visually present the radio variant as text-only sort options, mirroring
+	// the wider-screen instant-search "with-links" variant. The radio inputs
+	// stay in the a11y tree (visually hidden, still focusable for arrow-key
+	// navigation across the group) and the label carries the click target.
+	// Selection is cued with weight + full opacity so the active option rides
+	// the site palette instead of pinning to a fixed accent color.
 	.jetpack-search-sort-control__radio-item {
 		display: flex;
 		align-items: center;
-		gap: 0.25rem;
 		font-size: 0.9rem;
+
+		input[type="radio"] {
+			appearance: none;
+			position: absolute;
+			width: 1px;
+			height: 1px;
+			margin: 0;
+			padding: 0;
+			border: 0;
+			overflow: hidden;
+			clip: rect(0 0 0 0);
+			clip-path: inset(50%);
+			white-space: nowrap;
+		}
+
+		label {
+			cursor: pointer;
+		}
+
+		input[type="radio"]:checked + label {
+			opacity: 1;
+			font-weight: 600;
+		}
+
+		// Mirror the radio's keyboard focus on the label, since the input
+		// itself is visually hidden.
+		input[type="radio"]:focus-visible + label {
+			outline: 2px solid currentColor;
+			outline-offset: 2px;
+		}
+
+		// Bullet separator between options. Decorative — CSS pseudo-content
+		// is ignored by screen readers, and the fieldset/legend already
+		// announces the group.
+		&:not(:last-child)::after {
+			content: "•";
+			margin: 0 0.5rem;
+			opacity: 0.5;
+			font-weight: 300;
+		}
 	}
 }

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/style.scss
@@ -57,6 +57,11 @@
 	.jetpack-search-sort-control__radio-item {
 		display: flex;
 		align-items: center;
+		// Anchor the absolutely-positioned visually-hidden radio to its own
+		// item rather than letting it climb to the nearest positioned
+		// ancestor. No visible effect (the input is 1px clipped) — just
+		// makes the containment intent explicit.
+		position: relative;
 		font-size: 0.9rem;
 
 		input[type="radio"] {
@@ -88,14 +93,17 @@
 			outline-offset: 2px;
 		}
 
-		// Bullet separator between options. Decorative — CSS pseudo-content
-		// is ignored by screen readers, and the fieldset/legend already
-		// announces the group.
+		// Bullet separator between options. Decorative — the empty
+		// alt-text in the `content` value (`"•" / ""`) opts the glyph out
+		// of the assistive-tech accessible name, since some screen-reader
+		// configurations do read CSS-generated content otherwise. The
+		// fieldset/legend already announces the group, so an extra
+		// "bullet" announcement would be noise.
 		&:not(:last-child)::after {
-			content: "•";
-			margin: 0 0.5rem;
+			content: "•" / "";
+			margin-block: 0;
+			margin-inline: 0.5rem;
 			opacity: 0.5;
-			font-weight: 300;
 		}
 	}
 }


### PR DESCRIPTION
Follow-up to #48282.

## Proposed changes
* Restyle the radio variant of the `jetpack/sort-control` block to mirror the wider-screen instant-search "with-links" sort variant — text-only options separated by `•`, no native radio dot, no leading "Sort by" lead-in, selection cued with bold weight + full opacity.
* Native radio inputs are visually hidden but stay focusable, so keyboard arrow-key navigation across the radio group still works. Focus styling moves to the label via `input:focus-visible + label`.
* Visually hide the `<legend>` (kept in the a11y tree via off-screen-clip — same pattern as the hidden radios — so assistive tech still announces the fieldset's accessible name).
* No hard-coded accent color — the active option rides the site palette via opacity (matches the pattern PR #48259 established for this block: `inherit` + opacity + `currentColor`).
* Rename the inspector "Display as" option from "Radio buttons" to "Inline links" — after hiding both the radio dot and the legend, the old name misled authors about what they were enabling. The internal `displayAs: 'radio'` value is unchanged so existing pages keep rendering the same way.
* Existing `<input> + <label>` DOM order already supports the `:checked + label` cue, and the editor preview renders the same DOM so it picks up the new look automatically. `render.php` and `view.js` are untouched.

## Related product discussion/links
* Follows up on review comment / styling-feedback for #48282

## Does this pull request change what data or activity we track or use?
No.

## Screenshots

| Before (`trunk` after #48282) | After (this PR) |
|---|---|
| ![before](https://github.com/user-attachments/assets/30a0753b-14d6-40b0-be5b-f30beae68c5d) | ![after](https://github.com/user-attachments/assets/d03b4e80-10ed-4f5d-875c-e76c6166ca5c) |

## Testing instructions
1. On a page with the Jetpack Search **Sort Control** block, set **Display as** to `Inline links` in the inspector.
2. Save and view on the front end. Confirm:
   * No native radio dots are visible.
   * No "Sort by" lead-in label is visible (the field is still announced as a group by screen readers).
   * Options are separated by a `•` glyph.
   * The currently-selected option is **bold** and reads at full opacity; the others are slightly muted.
   * Clicking another option still updates the selection (label is the click target).
3. Tab into the group from the keyboard and use arrow keys — focus should move across the (invisible) radios and the visible label should show a focus ring.
4. Toggle to a dark-themed block / column — the labels and selected state should adapt to the theme palette (no hard-coded color).
5. Run the search package PHPUnit + JS suites: `cd projects/packages/search && composer phpunit && pnpm test`.