### PR TITLE
Search: WooCommerce Product Filters bridge

### DIFF
--- a/projects/packages/search/changelog/add-search-wc-bridge-stock-status
+++ b/projects/packages/search/changelog/add-search-wc-bridge-stock-status
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-WooCommerce Bridge: stock-status filter now narrows the result set via `meta._stock_status.value.raw` aggregation and term clauses.

--- a/projects/packages/search/changelog/add-search-wc-bridge-stock-status
+++ b/projects/packages/search/changelog/add-search-wc-bridge-stock-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+WooCommerce Bridge: stock-status filter now narrows the result set via `meta._stock_status.value.raw` aggregation and term clauses.

--- a/projects/packages/search/changelog/add-search-woocommerce-filters-bridge-poc
+++ b/projects/packages/search/changelog/add-search-woocommerce-filters-bridge-poc
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-WooCommerce Bridge (PoC): hydrate Product Filters blocks from Jetpack Search aggregations. Off by default behind `jetpack_search_woocommerce_bridge_enabled` filter.
+WooCommerce Bridge (PoC): client-side hydration of Product Filters blocks from Jetpack Search aggregations. Off by default behind `jetpack_search_woocommerce_bridge_enabled` filter.

--- a/projects/packages/search/changelog/add-search-woocommerce-filters-bridge-poc
+++ b/projects/packages/search/changelog/add-search-woocommerce-filters-bridge-poc
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+WooCommerce Bridge (PoC): hydrate Product Filters blocks from Jetpack Search aggregations. Off by default behind `jetpack_search_woocommerce_bridge_enabled` filter.

--- a/projects/packages/search/src/initializers/class-initializer.php
+++ b/projects/packages/search/src/initializers/class-initializer.php
@@ -157,6 +157,10 @@ class Initializer {
 		if ( $success ) {
 			// registers Jetpack Search widget.
 			add_action( 'widgets_init', array( static::class, 'jetpack_search_widget_init' ) );
+
+			// Hydrate WooCommerce Product Filters blocks from Jetpack Search
+			// aggregations. Self-gated by feature flag + WC presence check.
+			WooCommerce_Filters_Bridge::init();
 		}
 
 		return $success;

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -18,7 +18,7 @@ class Search_Blocks {
 	 * Reserved query params that must not be parsed as filter keys. Mirrors
 	 * `RESERVED_PARAMS` in store/url-state.js.
 	 */
-	const RESERVED_QUERY_PARAMS = array( 's', 'orderby' );
+	const RESERVED_QUERY_PARAMS = array( 's', 'orderby', 'min_price', 'max_price' );
 
 	/**
 	 * Template slug used for the Jetpack Search page template.
@@ -490,6 +490,7 @@ class Search_Blocks {
 		$site_id        = class_exists( Helper::class ) ? Helper::get_wpcom_site_id() : 0;
 		$search_query   = function_exists( 'get_search_query' ) ? (string) get_search_query() : '';
 		$active_filters = static::parse_url_filters();
+		$price_range    = static::parse_url_price_range();
 
 		return array(
 			// Connection / routing config.
@@ -514,6 +515,7 @@ class Search_Blocks {
 			'searchQuery'   => $search_query,
 			'sortOrder'     => static::parse_url_sort(),
 			'activeFilters' => $active_filters,
+			'priceRange'    => $price_range,
 
 			// filterConfigs: each filter-checkbox block's render.php merges its
 			// own entry here. Shape: { [filterKey]: { filterKey, filterType,
@@ -532,7 +534,7 @@ class Search_Blocks {
 			// search query or filter selection so the no-results block stays
 			// hidden between first paint and JS hydrating the initial fetch —
 			// otherwise a "No results found" flash appears on deep links.
-			'isLoading'     => '' !== $search_query || ! empty( $active_filters ),
+			'isLoading'     => '' !== $search_query || ! empty( $active_filters ) || null !== $price_range,
 			'isLoadingMore' => false,
 			'hasError'      => false,
 
@@ -583,6 +585,49 @@ class Search_Blocks {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only URL state.
 		$orderby = isset( $_GET['orderby'] ) ? sanitize_key( wp_unslash( $_GET['orderby'] ) ) : '';
 		return in_array( $orderby, array( 'newest', 'oldest' ), true ) ? $orderby : 'relevance';
+	}
+
+	/**
+	 * Parse the price range from the URL, mirroring the contract in
+	 * src/search-blocks/store/url-state.js. Either bound may be null for a
+	 * half-open range; non-numeric or negative values yield null so a
+	 * garbage URL can't drive the API into producing zero results.
+	 *
+	 * Returns null when neither bound is set, so callers can early-out
+	 * without checking individual fields.
+	 *
+	 * @return array{min: float|null, max: float|null}|null
+	 */
+	protected static function parse_url_price_range(): ?array {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- read-only URL state; coerced to float in parse_price_bound() which discards any non-numeric input.
+		$min = self::parse_price_bound( $_GET['min_price'] ?? null );
+		$max = self::parse_price_bound( $_GET['max_price'] ?? null );
+		// phpcs:enable
+
+		if ( null === $min && null === $max ) {
+			return null;
+		}
+		return array(
+			'min' => $min,
+			'max' => $max,
+		);
+	}
+
+	/**
+	 * Coerce a single price-range URL value into a finite, non-negative float.
+	 *
+	 * @param mixed $raw Raw value pulled from $_GET.
+	 * @return float|null
+	 */
+	private static function parse_price_bound( $raw ): ?float {
+		if ( null === $raw || '' === $raw || ! is_scalar( $raw ) ) {
+			return null;
+		}
+		$num = (float) wp_unslash( $raw );
+		if ( ! is_finite( $num ) || $num < 0 ) {
+			return null;
+		}
+		return $num;
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/store/api.js
+++ b/projects/packages/search/src/search-blocks/store/api.js
@@ -85,15 +85,15 @@ export function resolveFilterFields( config ) {
 				bucketFormat: 'slash',
 			};
 		case 'wc_stock_status':
-			// WooCommerce indexes `_stock_status` as a string postmeta — values
-			// are `instock`, `outofstock`, `onbackorder`. The WPCOM ES schema
-			// exposes these as `meta._stock_status.value` for both filtering
-			// and aggregation.
-			return {
-				aggField: 'meta._stock_status.value',
-				filterField: 'meta._stock_status.value',
-				bucketFormat: 'plain',
-			};
+			// The WPCOM v1.3 search index doesn't expose the stock-status
+			// postmeta as a queryable field that's been verified working
+			// (`wc.stock_status` / `meta._stock_status.value` both return
+			// 400 from the API). Until a real field path is identified,
+			// return null so `buildAggregations` and `buildFilterClause`
+			// skip this filter — the bridge still renders the 3 hardcoded
+			// options for discoverability, but selections don't yet narrow
+			// the result set. Tracked as a follow-up.
+			return { aggField: null, filterField: null, bucketFormat: 'plain' };
 	}
 	return { aggField: null, filterField: null, bucketFormat: 'plain' };
 }

--- a/projects/packages/search/src/search-blocks/store/api.js
+++ b/projects/packages/search/src/search-blocks/store/api.js
@@ -94,9 +94,44 @@ export function resolveFilterFields( config ) {
 			// options for discoverability, but selections don't yet narrow
 			// the result set. Tracked as a follow-up.
 			return { aggField: null, filterField: null, bucketFormat: 'plain' };
+		case 'wc_rating':
+			// Rating uses a range aggregation against
+			// `meta._wc_average_rating.double` (the same field
+			// instant-search reads via `fields` for product cards).
+			// `buildAggregations` and `buildFilterClause` special-case
+			// this filterType so they emit a `range` aggregation /
+			// range-OR filter clause instead of the standard `terms`.
+			// Star buckets follow WC's UI: `ROUND(avg_rating, 0)` from
+			// FilterData::get_rating_counts, so star=5 covers
+			// avg ∈ [4.5, ∞), star=4 covers [3.5, 4.5), etc.
+			return {
+				aggField: 'meta._wc_average_rating.double',
+				filterField: 'meta._wc_average_rating.double',
+				bucketFormat: 'plain',
+			};
 	}
 	return { aggField: null, filterField: null, bucketFormat: 'plain' };
 }
+
+/**
+ * Star buckets for `wc_rating` filter clauses. Mirrors WC's
+ * `ROUND(avg_rating, 0)` semantics: star=5 covers avg ∈ [4.5, ∞),
+ * star=4 covers [3.5, 4.5), down to star=1 covering [0.5, 1.5).
+ *
+ * Aggregation uses a histogram (range aggs aren't whitelisted on the
+ * WPCOM v1.3 search API — `[aggs:range] is not whitelisted`). The
+ * `offset: 0.5` shifts histogram bucket boundaries from integer
+ * (default) to half-integer, which is exactly the cutoffs WC's
+ * ROUND uses, so a histogram bucket keyed `4.5` corresponds to star=5,
+ * `3.5` to star=4, etc.
+ */
+const WC_RATING_RANGES = [
+	{ key: '1', from: 0.5, to: 1.5, histogramKey: 0.5 },
+	{ key: '2', from: 1.5, to: 2.5, histogramKey: 1.5 },
+	{ key: '3', from: 2.5, to: 3.5, histogramKey: 2.5 },
+	{ key: '4', from: 3.5, to: 4.5, histogramKey: 3.5 },
+	{ key: '5', from: 4.5, histogramKey: 4.5 },
+];
 
 /**
  * Build ES aggregation requests from the filterConfigs registered by each
@@ -116,6 +151,22 @@ export function resolveFilterFields( config ) {
 export function buildAggregations( filterConfigs ) {
 	const aggregations = {};
 	for ( const [ filterKey, config ] of Object.entries( filterConfigs ?? {} ) ) {
+		// Rating gets a histogram aggregation. `range` aggs aren't
+		// whitelisted; histogram interval=1 with offset=0.5 produces
+		// buckets keyed at .5 boundaries, mirroring WC's
+		// ROUND(avg_rating) star buckets.
+		if ( config?.filterType === 'wc_rating' ) {
+			aggregations[ filterKey ] = {
+				histogram: {
+					field: 'meta._wc_average_rating.double',
+					interval: 1,
+					offset: 0.5,
+					min_doc_count: 0,
+				},
+			};
+			continue;
+		}
+
 		const { aggField } = resolveFilterFields( config );
 		if ( ! aggField ) {
 			continue;
@@ -154,7 +205,29 @@ export function buildFilterClause( activeFilters, filterConfigs ) {
 		if ( ! Array.isArray( values ) || values.length === 0 ) {
 			continue;
 		}
-		const { filterField } = resolveFilterFields( filterConfigs?.[ filterKey ] );
+		const config = filterConfigs?.[ filterKey ];
+
+		// Rating: each selected star level maps to a range clause on
+		// `meta._wc_average_rating.double`; multiple selections OR.
+		if ( config?.filterType === 'wc_rating' ) {
+			const ranges = values
+				.map( value => WC_RATING_RANGES.find( r => r.key === String( value ) ) )
+				.filter( Boolean )
+				.map( r => {
+					const range = { gte: r.from };
+					if ( r.to !== undefined ) {
+						range.lt = r.to;
+					}
+					return { range: { 'meta._wc_average_rating.double': range } };
+				} );
+			if ( ranges.length === 0 ) {
+				continue;
+			}
+			must.push( ranges.length === 1 ? ranges[ 0 ] : { bool: { should: ranges } } );
+			continue;
+		}
+
+		const { filterField } = resolveFilterFields( config );
 		if ( ! filterField ) {
 			continue;
 		}

--- a/projects/packages/search/src/search-blocks/store/api.js
+++ b/projects/packages/search/src/search-blocks/store/api.js
@@ -85,15 +85,22 @@ export function resolveFilterFields( config ) {
 				bucketFormat: 'slash',
 			};
 		case 'wc_stock_status':
-			// The WPCOM v1.3 search index doesn't expose the stock-status
-			// postmeta as a queryable field that's been verified working
-			// (`wc.stock_status` / `meta._stock_status.value` both return
-			// 400 from the API). Until a real field path is identified,
-			// return null so `buildAggregations` and `buildFilterClause`
-			// skip this filter — the bridge still renders the 3 hardcoded
-			// options for discoverability, but selections don't yet narrow
-			// the result set. Tracked as a follow-up.
-			return { aggField: null, filterField: null, bucketFormat: 'plain' };
+			// `_stock_status` is whitelisted in `public_postmeta` on the
+			// indexer (see `Search\Plugin::get_post_meta_whitelist()` and
+			// the post-doc-builder's standard meta path), so it's stored
+			// as `meta._stock_status.value` with a `.raw` keyword
+			// subfield via the `meta_str_template` dynamic mapping. The
+			// terms-aggs whitelist (`meta\..*\.value\.raw` in
+			// class-wpcom-search-engine.php) admits this exact path —
+			// earlier 400s came from probing the wrong subfield names
+			// (`meta._stock_status.value` without `.raw`,
+			// `meta._stock_status.raw`, or `wc.*` paths that don't exist
+			// for stock status).
+			return {
+				aggField: 'meta._stock_status.value.raw',
+				filterField: 'meta._stock_status.value.raw',
+				bucketFormat: 'plain',
+			};
 		case 'wc_rating':
 			// Rating uses a range aggregation against
 			// `meta._wc_average_rating.double` (the same field

--- a/projects/packages/search/src/search-blocks/store/api.js
+++ b/projects/packages/search/src/search-blocks/store/api.js
@@ -169,6 +169,10 @@ export function buildFilterClause( activeFilters, filterConfigs ) {
  * @param {object}      [opts.activeFilters] - { [filterKey]: string[] } selected filters.
  * @param {object}      [opts.filterConfigs] - { [filterKey]: FilterConfig } registered filters.
  * @param {string}      [opts.homeUrl]       - Home URL; required for private WPcom sites.
+ * @param {object|null} [opts.priceRange]    - `{ min, max }` numeric range against the
+ *                                           `wc.price` ES field. Either bound may be null
+ *                                           for a half-open range. WC bridge populates this
+ *                                           from the `min_price` / `max_price` URL params.
  * @return {string} Full URL to call.
  */
 export function buildSearchUrl( {
@@ -182,6 +186,7 @@ export function buildSearchUrl( {
 	activeFilters = {},
 	filterConfigs = {},
 	homeUrl = '',
+	priceRange = null,
 } ) {
 	// `qss.encode()` runs `encodeURIComponent` on every value, so we pass the
 	// raw query here. The instant-search code double-encodes (pre-encodes
@@ -201,7 +206,22 @@ export function buildSearchUrl( {
 		params.aggregations = aggregations;
 	}
 
-	const filter = buildFilterClause( activeFilters, filterConfigs );
+	let filter = buildFilterClause( activeFilters, filterConfigs );
+	if ( priceRange && ( priceRange.min != null || priceRange.max != null ) ) {
+		const range = {};
+		if ( priceRange.min != null ) {
+			range.gte = priceRange.min;
+		}
+		if ( priceRange.max != null ) {
+			range.lte = priceRange.max;
+		}
+		const rangeClause = { range: { 'wc.price': range } };
+		if ( filter ) {
+			filter.bool.must.push( rangeClause );
+		} else {
+			filter = { bool: { must: [ rangeClause ] } };
+		}
+	}
 	if ( filter ) {
 		params.filter = filter;
 	}

--- a/projects/packages/search/src/search-blocks/store/api.js
+++ b/projects/packages/search/src/search-blocks/store/api.js
@@ -84,6 +84,16 @@ export function resolveFilterFields( config ) {
 				filterField: 'author_login',
 				bucketFormat: 'slash',
 			};
+		case 'wc_stock_status':
+			// WooCommerce indexes `_stock_status` as a string postmeta — values
+			// are `instock`, `outofstock`, `onbackorder`. The WPCOM ES schema
+			// exposes these as `meta._stock_status.value` for both filtering
+			// and aggregation.
+			return {
+				aggField: 'meta._stock_status.value',
+				filterField: 'meta._stock_status.value',
+				bucketFormat: 'plain',
+			};
 	}
 	return { aggField: null, filterField: null, bucketFormat: 'plain' };
 }

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -32,6 +32,7 @@ function* fetchResults( pageHandle ) {
 		homeUrl: state.homeUrl,
 		activeFilters: state.activeFilters,
 		filterConfigs: state.filterConfigs,
+		priceRange: state.priceRange,
 	} );
 	const response = yield fetch( url, {
 		headers: state.isPrivateSite ? { 'X-WP-Nonce': state.nonce } : {},
@@ -259,10 +260,13 @@ const { state, actions } = store( NAMESPACE, {
 		 * @yield {Promise} search action.
 		 */
 		*handlePopState() {
-			const { searchQuery, sortOrder, activeFilters } = readStateFromUrl( state.filterConfigs );
+			const { searchQuery, sortOrder, activeFilters, priceRange } = readStateFromUrl(
+				state.filterConfigs
+			);
 			state.searchQuery = searchQuery;
 			state.sortOrder = sortOrder;
 			state.activeFilters = activeFilters;
+			state.priceRange = priceRange;
 			yield actions.search( { syncUrl: false } );
 		},
 	},

--- a/projects/packages/search/src/search-blocks/store/url-state.js
+++ b/projects/packages/search/src/search-blocks/store/url-state.js
@@ -22,9 +22,10 @@ const RESERVED_PARAMS = new Set( [ 's', 'orderby' ] );
 export function stateToUrlParams( { searchQuery, sortOrder, activeFilters = {} } ) {
 	const params = new URLSearchParams();
 
-	if ( searchQuery ) {
-		params.set( 's', searchQuery );
-	}
+	// Always emit `s` (even empty) so a refresh keeps WP routed to the
+	// search template. Dropping the param entirely when the user clears
+	// the input would push the page back to the front-page route.
+	params.set( 's', searchQuery ?? '' );
 
 	if ( sortOrder && sortOrder !== DEFAULT_SORT_ORDER && VALID_SORT_ORDERS.includes( sortOrder ) ) {
 		params.set( 'orderby', sortOrder );

--- a/projects/packages/search/src/search-blocks/store/url-state.js
+++ b/projects/packages/search/src/search-blocks/store/url-state.js
@@ -4,7 +4,26 @@ const DEFAULT_SORT_ORDER = 'relevance';
 
 // Reserved query params — not treated as filter keys on parse. Mirrors the
 // allow-list on the PHP side in Search_Blocks::parse_url_filters().
-const RESERVED_PARAMS = new Set( [ 's', 'orderby' ] );
+const RESERVED_PARAMS = new Set( [ 's', 'orderby', 'min_price', 'max_price' ] );
+
+/**
+ * Parse a `min_price` / `max_price` URL value into a finite number.
+ * Returns null on missing, non-numeric, or negative input so a garbage
+ * URL can't drive the API into producing zero results.
+ *
+ * @param {string|null} raw - Raw URL param value.
+ * @return {number|null} Parsed number or null.
+ */
+function parsePriceBound( raw ) {
+	if ( raw === null || raw === undefined || raw === '' ) {
+		return null;
+	}
+	const num = Number( raw );
+	if ( ! Number.isFinite( num ) || num < 0 ) {
+		return null;
+	}
+	return num;
+}
 
 /**
  * Serialize store state to URLSearchParams.
@@ -13,13 +32,19 @@ const RESERVED_PARAMS = new Set( [ 's', 'orderby' ] );
  * matching the shape instant-search already writes so deep links are
  * interchangeable between the two surfaces.
  *
- * @param {object} state                 - Store state slice.
- * @param {string} state.searchQuery     - Current search query.
- * @param {string} state.sortOrder       - Current sort order.
- * @param {object} [state.activeFilters] - { [filterKey]: string[] } selected filters.
+ * @param {object}      state                 - Store state slice.
+ * @param {string}      state.searchQuery     - Current search query.
+ * @param {string}      state.sortOrder       - Current sort order.
+ * @param {object}      [state.activeFilters] - { [filterKey]: string[] } selected filters.
+ * @param {object|null} [state.priceRange]    - { min, max } price range; either bound may be null.
  * @return {URLSearchParams} URL-ready params.
  */
-export function stateToUrlParams( { searchQuery, sortOrder, activeFilters = {} } ) {
+export function stateToUrlParams( {
+	searchQuery,
+	sortOrder,
+	activeFilters = {},
+	priceRange = null,
+} ) {
 	const params = new URLSearchParams();
 
 	// Always emit `s` (even empty) so a refresh keeps WP routed to the
@@ -36,6 +61,13 @@ export function stateToUrlParams( { searchQuery, sortOrder, activeFilters = {} }
 			continue;
 		}
 		values.forEach( value => params.append( `${ key }[]`, value ) );
+	}
+
+	if ( priceRange?.min != null ) {
+		params.set( 'min_price', String( priceRange.min ) );
+	}
+	if ( priceRange?.max != null ) {
+		params.set( 'max_price', String( priceRange.max ) );
 	}
 
 	return params;
@@ -93,10 +125,16 @@ export function urlParamsToState( params, filterConfigs = {} ) {
 		activeFilters[ filterKey ].push( normalized );
 	}
 
+	const minPrice = parsePriceBound( params.get( 'min_price' ) );
+	const maxPrice = parsePriceBound( params.get( 'max_price' ) );
+	const priceRange =
+		minPrice !== null || maxPrice !== null ? { min: minPrice, max: maxPrice } : null;
+
 	return {
 		searchQuery: params.get( 's' ) ?? '',
 		sortOrder: VALID_SORT_ORDERS.includes( rawOrderby ) ? rawOrderby : DEFAULT_SORT_ORDER,
 		activeFilters,
+		priceRange,
 	};
 }
 

--- a/projects/packages/search/src/search-blocks/store/url-state.js
+++ b/projects/packages/search/src/search-blocks/store/url-state.js
@@ -125,6 +125,27 @@ export function urlParamsToState( params, filterConfigs = {} ) {
 		activeFilters[ filterKey ].push( normalized );
 	}
 
+	// Scalar comma-joined fallback for filterConfigs whose `urlFormat` is
+	// `scalar` (e.g. `?filter_stock_status=instock,outofstock` written by
+	// WC's Product Filter Status block). Reading both formats keeps the
+	// store interoperable with the WC bridge.
+	for ( const [ filterKey, config ] of Object.entries( filterConfigs ?? {} ) ) {
+		if ( config?.urlFormat !== 'scalar' || activeFilters[ filterKey ] ) {
+			continue;
+		}
+		const raw = params.get( filterKey );
+		if ( ! raw ) {
+			continue;
+		}
+		const values = String( raw )
+			.split( ',' )
+			.map( v => v.trim() )
+			.filter( Boolean );
+		if ( values.length > 0 ) {
+			activeFilters[ filterKey ] = Array.from( new Set( values ) );
+		}
+	}
+
 	const minPrice = parsePriceBound( params.get( 'min_price' ) );
 	const maxPrice = parsePriceBound( params.get( 'max_price' ) );
 	const priceRange =

--- a/projects/packages/search/src/woocommerce-bridge/class-woocommerce-filters-bridge.php
+++ b/projects/packages/search/src/woocommerce-bridge/class-woocommerce-filters-bridge.php
@@ -102,6 +102,29 @@ class WooCommerce_Filters_Bridge {
 	 */
 	private function register_hooks() {
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_bridge_assets' ) );
+		add_filter( 'request', array( $this, 'strip_bridge_filter_query_vars' ) );
+	}
+
+	/**
+	 * Stop WordPress from treating bridge filter URL params as tax_query
+	 * arguments.
+	 *
+	 * Product taxonomies (`product_cat`, `product_tag`, `product_brand`,
+	 * `pa_*`) register their slug as a public query var, so a URL like
+	 * `?product_cat[]=shirts` lands in WP_Query's tax_query parser as an
+	 * array — WP_Query::parse_tax_query → wp_basename → urlencode then
+	 * fatals because urlencode requires a string. Strip these vars at
+	 * `request`-filter time so the main query never sees them; the client
+	 * bridge owns this URL state, WP doesn't need to.
+	 *
+	 * @param array $query_vars Parsed query vars from the request.
+	 * @return array
+	 */
+	public function strip_bridge_filter_query_vars( $query_vars ) {
+		foreach ( array_keys( $this->build_filter_configs() ) as $filter_key ) {
+			unset( $query_vars[ $filter_key ] );
+		}
+		return $query_vars;
 	}
 
 	/**
@@ -140,6 +163,23 @@ class WooCommerce_Filters_Bridge {
 
 		if ( function_exists( 'wp_interactivity_state' ) ) {
 			wp_interactivity_state( 'jetpack-search-wc-bridge', $this->build_seed_state() );
+
+			/*
+			 * Merge our taxonomies into the existing `jetpack-search`
+			 * filterConfigs (Search_Blocks::seed_interactivity_state seeds it
+			 * from the post's own filter-checkbox blocks; wp_interactivity_state
+			 * deep-merges across calls). Two effects:
+			 *  1. The jetpack-search store's `urlParamsToState()` gate accepts
+			 *     our `?product_cat[]=foo` etc., so they survive into
+			 *     `state.activeFilters`.
+			 *  2. The result-list search picks them up via `buildSearchUrl()`
+			 *     and applies them as ES filter clauses, so the rendered
+			 *     results reflect WC filter clicks.
+			 */
+			wp_interactivity_state(
+				'jetpack-search',
+				array( 'filterConfigs' => $this->build_filter_configs() )
+			);
 		}
 	}
 

--- a/projects/packages/search/src/woocommerce-bridge/class-woocommerce-filters-bridge.php
+++ b/projects/packages/search/src/woocommerce-bridge/class-woocommerce-filters-bridge.php
@@ -2,21 +2,17 @@
 /**
  * Bridge between the WooCommerce Product Filters blocks and Jetpack Search.
  *
- * Hydrates the Product Filters blocks (Categories, Tags, Brands, Attributes)
- * from Jetpack Search's Elasticsearch aggregations instead of running local
- * MySQL queries. The blocks themselves are unchanged; only their data source
- * is redirected via existing extension points:
+ * Client-side hydration model: drives WooCommerce's Product Filters blocks
+ * from Jetpack Search's Elasticsearch aggregations entirely from the
+ * front-end. The PHP side is bootstrap only — register a script module,
+ * seed runtime config (site ID, API routing, filterConfigs), and let the
+ * JS bridge override `woocommerce/product-filters` actions.navigate at
+ * runtime.
  *
- *   1. `woocommerce_pre_product_filter_data` — short-circuit count queries
- *   2. `jetpack_search_should_handle_query` — widen ES takeover to shop /
- *      product taxonomy archives
- *   3. `jetpack_search_es_wp_query_args` — translate WC URL params
- *      (`filter_<slug>`, `categories`, `tags`, `brands`, `pa_*`) into ES
- *      filter terms
- *   4. `Inline_Search::set_filters()` on `init` — register taxonomy and
- *      attribute aggregations so ES returns bucket counts (the search
- *      instance is resolved via `Inline_Search::get_instance_maybe_fallback_to_classic()`
- *      to handle both Inline and the legacy Classic fallback)
+ * Trade-off: direct URL hits (e.g. `/shop/?categories=foo` from a search
+ * engine or a back-button) render WC's default unfiltered counts until JS
+ * boots and re-fetches from ES. Same constraint the rest of the Jetpack
+ * Search blocks accept (front-end-rendering only).
  *
  * @package automattic/jetpack-search
  */
@@ -28,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Wires WooCommerce Product Filters blocks to Jetpack Search aggregations.
+ * Bootstraps the WooCommerce Product Filters → Jetpack Search client-side bridge.
  *
  * Loaded only when WooCommerce Blocks is active and the Search module is
  * connected. Gated additionally by `jetpack_search_woocommerce_bridge_enabled`
@@ -37,11 +33,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WooCommerce_Filters_Bridge {
 
 	/**
-	 * Prefix used when registering aggregation keys with the search instance so
-	 * we can reverse-map an aggregation result back to a (filter type,
-	 * taxonomy) tuple.
+	 * Script handle used for the bridge view module.
 	 */
-	const AGG_KEY_PREFIX = 'wc_filter_';
+	const SCRIPT_HANDLE = 'jetpack-search-wc-bridge-view';
 
 	/**
 	 * Singleton instance.
@@ -67,8 +61,8 @@ class WooCommerce_Filters_Bridge {
 		 *
 		 * Defaults to false while the bridge is in PoC stage. Returning true
 		 * activates the bridge: WooCommerce Product Filters blocks will be
-		 * hydrated from Jetpack Search's Elasticsearch aggregations on shop
-		 * and product taxonomy archive pages.
+		 * hydrated from Jetpack Search's Elasticsearch aggregations on the
+		 * front end.
 		 *
 		 * @since $$next-version$$
 		 *
@@ -90,14 +84,12 @@ class WooCommerce_Filters_Bridge {
 	 * Whether the runtime environment can support the bridge.
 	 */
 	private static function has_required_dependencies() {
-		// WooCommerce Blocks must be loaded — that's where the filter blocks
-		// and the `woocommerce_pre_product_filter_data` hook live.
+		// WooCommerce Blocks must be loaded — that's where the filter blocks live.
 		if ( ! class_exists( '\Automattic\WooCommerce\Internal\ProductFilters\FilterData' ) ) {
 			return false;
 		}
 
-		// Search module must be active so Inline_Search (or the Classic
-		// fallback) will actually run a query and produce aggregations.
+		// Search module must be active so the WPCOM v1.3 search API will accept aggregation requests for this site.
 		if ( ! ( new Module_Control() )->is_active() ) {
 			return false;
 		}
@@ -106,299 +98,122 @@ class WooCommerce_Filters_Bridge {
 	}
 
 	/**
-	 * Resolve the active search singleton.
-	 *
-	 * Mirrors the initializer's choice between Inline_Search (the current
-	 * implementation) and Classic_Search (the legacy fallback that's still
-	 * used on sites without the inline-search feature flag).
-	 */
-	private function search_instance() {
-		return Inline_Search::get_instance_maybe_fallback_to_classic();
-	}
-
-	/**
 	 * Register all hooks the bridge needs.
 	 */
 	private function register_hooks() {
-		add_action( 'init', array( $this, 'register_search_filters' ), 20 );
-		add_filter( 'jetpack_search_should_handle_query', array( $this, 'handle_wc_archives' ), 10, 2 );
-		add_filter( 'jetpack_search_es_wp_query_args', array( $this, 'translate_wc_url_params' ), 10, 2 );
-		add_filter( 'woocommerce_pre_product_filter_data', array( $this, 'provide_filter_data' ), 10, 4 );
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_bridge_assets' ) );
 	}
 
 	/**
-	 * Register taxonomy + attribute aggregations with the active search
-	 * instance.
+	 * Register and enqueue the front-end bridge module, plus seed its
+	 * runtime config via `wp_interactivity_state`.
 	 *
-	 * Each filter is keyed by `AGG_KEY_PREFIX . <type>_<taxonomy>` so the
-	 * reverse map can later resolve an aggregation bucket back to its
-	 * taxonomy when serving counts to the Product Filters blocks.
+	 * The seed lives under the `jetpack-search-wc-bridge` namespace rather
+	 * than `woocommerce/product-filters` so we don't collide with WC's own
+	 * state shape; the JS bridge reads it on init and uses it to compose
+	 * the WPCOM v1.3 search URL via `buildSearchUrl()` from
+	 * `src/search-blocks/store/api.js`.
 	 */
-	public function register_search_filters() {
-		$filters = array();
-
-		$builtin_taxonomies = array( 'product_cat', 'product_tag' );
-		if ( taxonomy_exists( 'product_brand' ) ) {
-			$builtin_taxonomies[] = 'product_brand';
+	public function enqueue_bridge_assets() {
+		if ( ! function_exists( 'wp_register_script_module' ) ) {
+			return;
 		}
 
-		foreach ( $builtin_taxonomies as $taxonomy ) {
-			$filters[ self::AGG_KEY_PREFIX . 'tax_' . $taxonomy ] = array(
-				'name'     => $taxonomy,
-				'type'     => 'taxonomy',
-				'taxonomy' => $taxonomy,
-				'count'    => 100,
+		$base_path  = Package::get_installed_path() . 'build/search-blocks/';
+		$asset_file = $base_path . 'wc-bridge.asset.php';
+		if ( ! file_exists( $asset_file ) ) {
+			return;
+		}
+		$asset = require $asset_file;
+
+		// plugins_url() walks up to the nearest plugin directory, which
+		// handles the jetpack_vendor location Composer installs the package into.
+		$url = plugins_url( 'wc-bridge.js', $base_path . 'wc-bridge.js' );
+
+		wp_register_script_module(
+			self::SCRIPT_HANDLE,
+			$url,
+			$asset['dependencies'] ?? array( '@wordpress/interactivity' ),
+			$asset['version'] ?? Package::VERSION
+		);
+		wp_enqueue_script_module( self::SCRIPT_HANDLE );
+
+		if ( function_exists( 'wp_interactivity_state' ) ) {
+			wp_interactivity_state( 'jetpack-search-wc-bridge', $this->build_seed_state() );
+		}
+	}
+
+	/**
+	 * Compose the seeded state for the bridge's Interactivity namespace.
+	 *
+	 * Mirrors the keys `buildSearchUrl()` expects (see
+	 * src/search-blocks/store/api.js) plus a `filterConfigs` map keyed by
+	 * the same URL params WC's blocks use, so the JS bridge can translate
+	 * URL → aggregations request → counts without further server help.
+	 */
+	private function build_seed_state() {
+		$home_url = function_exists( 'home_url' ) ? home_url() : '';
+
+		return array(
+			'siteId'        => Helper::get_wpcom_site_id(),
+			'apiRoot'       => function_exists( 'rest_url' ) ? esc_url_raw( rest_url() ) : '',
+			'nonce'         => function_exists( 'wp_create_nonce' ) ? wp_create_nonce( 'wp_rest' ) : '',
+			'isPrivateSite' => class_exists( '\Automattic\Jetpack\Status' )
+				? ( new \Automattic\Jetpack\Status() )->is_private_site()
+				: false,
+			'isWpcom'       => Helper::is_wpcom(),
+			'homeUrl'       => $home_url,
+			'filterConfigs' => $this->build_filter_configs(),
+		);
+	}
+
+	/**
+	 * Build a filterConfigs map matching the WooCommerce Product Filters
+	 * URL contract.
+	 *
+	 * Keys are the WC URL param names (`categories`, `tags`, `brands`,
+	 * `filter_<short_attr>`); values name the underlying taxonomy plus the
+	 * `filterType` enum that `resolveFilterFields()` in
+	 * src/search-blocks/store/api.js consumes when constructing the ES
+	 * aggregation field path.
+	 *
+	 * @return array<string, array{filterType: string, taxonomy: string, maxItems: int}>
+	 */
+	private function build_filter_configs() {
+		$configs = array(
+			'categories' => array(
+				'filterType' => 'taxonomy',
+				'taxonomy'   => 'product_cat',
+				'maxItems'   => 100,
+			),
+			'tags'       => array(
+				'filterType' => 'taxonomy',
+				'taxonomy'   => 'product_tag',
+				'maxItems'   => 100,
+			),
+		);
+
+		if ( taxonomy_exists( 'product_brand' ) ) {
+			$configs['brands'] = array(
+				'filterType' => 'taxonomy',
+				'taxonomy'   => 'product_brand',
+				'maxItems'   => 100,
 			);
 		}
 
 		if ( function_exists( 'wc_get_attribute_taxonomies' ) ) {
 			foreach ( wc_get_attribute_taxonomies() as $attribute_object ) {
-				$taxonomy = wc_attribute_taxonomy_name( $attribute_object->attribute_name );
-
-				$filters[ self::AGG_KEY_PREFIX . 'attr_' . $taxonomy ] = array(
-					'name'      => $taxonomy,
-					'type'      => 'product_attribute',
-					'attribute' => $taxonomy,
-					'count'     => 100,
-				);
-			}
-		}
-
-		$this->search_instance()->set_filters( $filters );
-	}
-
-	/**
-	 * Widen Jetpack Search to take over the main query on WC archive pages.
-	 *
-	 * By default, JP Search only handles `is_search()` queries. Shop /
-	 * product taxonomy archives are normal post-type queries, so we opt them
-	 * in explicitly.
-	 *
-	 * @param bool      $should_handle Current decision.
-	 * @param \WP_Query $query         The query under consideration.
-	 * @return bool
-	 */
-	public function handle_wc_archives( $should_handle, $query ) {
-		if ( $should_handle ) {
-			return true;
-		}
-		if ( ! $query instanceof \WP_Query || ! $query->is_main_query() ) {
-			return $should_handle;
-		}
-
-		if ( function_exists( 'is_shop' ) && is_shop() ) {
-			return true;
-		}
-
-		$wc_taxonomies = array( 'product_cat', 'product_tag' );
-		if ( taxonomy_exists( 'product_brand' ) ) {
-			$wc_taxonomies[] = 'product_brand';
-		}
-		if ( $query->is_tax( $wc_taxonomies ) ) {
-			return true;
-		}
-
-		return $should_handle;
-	}
-
-	/**
-	 * Translate WooCommerce Product Filters URL params into ES query terms.
-	 *
-	 * Runs at `jetpack_search_es_wp_query_args` (priority 10), which fires
-	 * before the WP→ES conversion, so we emit WP_Query-style entries.
-	 *
-	 * Param contract followed (matches WC's Params::get_taxonomy_params):
-	 *   - `categories=foo,bar`            → product_cat slugs
-	 *   - `tags=foo,bar`                  → product_tag slugs
-	 *   - `brands=foo,bar`                → product_brand slugs
-	 *   - `filter_<short_attr>=v1,v2`     → pa_<short_attr> slugs
-	 *   - `query_type_<short_attr>=and`   → noted (see TODO below)
-	 *
-	 * @param array     $es_args ES-bound WP_Query args.
-	 * @param \WP_Query $query   The query being translated.
-	 * @return array
-	 */
-	public function translate_wc_url_params( $es_args, $query ) {
-		unset( $query );
-		$params = $this->get_request_filter_params();
-		if ( empty( $params ) ) {
-			return $es_args;
-		}
-
-		$builtin_map = array(
-			'categories' => 'product_cat',
-			'tags'       => 'product_tag',
-			'brands'     => 'product_brand',
-		);
-		foreach ( $builtin_map as $param_key => $taxonomy ) {
-			if ( ! taxonomy_exists( $taxonomy ) ) {
-				continue;
-			}
-			$slugs = $this->collect_slug_values( $params, array( $param_key, 'filter_' . $taxonomy ) );
-			if ( ! empty( $slugs ) ) {
-				$es_args = $this->merge_term_slugs( $es_args, $taxonomy, $slugs );
-			}
-		}
-
-		if ( function_exists( 'wc_get_attribute_taxonomies' ) ) {
-			foreach ( wc_get_attribute_taxonomies() as $attribute_object ) {
-				$taxonomy   = wc_attribute_taxonomy_name( $attribute_object->attribute_name );
 				$short_name = $attribute_object->attribute_name;
-				$slugs      = $this->collect_slug_values(
-					$params,
-					array( 'filter_' . $short_name, 'filter_' . $taxonomy )
+				$taxonomy   = wc_attribute_taxonomy_name( $short_name );
+
+				$configs[ 'filter_' . $short_name ] = array(
+					'filterType' => 'taxonomy',
+					'taxonomy'   => $taxonomy,
+					'maxItems'   => 100,
 				);
-				if ( ! empty( $slugs ) ) {
-					$es_args = $this->merge_term_slugs( $es_args, $taxonomy, $slugs );
-					// TODO: query_type_<attr>=and is not faithfully translated yet — JP Search
-					// treats multi-term taxonomy filters as OR within a bucket. AND semantics
-					// require raw ES injection at convert_wp_es_to_es_args time.
-				}
 			}
 		}
 
-		return $es_args;
-	}
-
-	/**
-	 * Provide filter counts to the Product Filters blocks.
-	 *
-	 * Returning a non-null array from `woocommerce_pre_product_filter_data`
-	 * short-circuits WooCommerce's local count query.
-	 *
-	 * @param mixed  $pre         Current value (null = continue with default).
-	 * @param string $filter_type One of price|stock|rating|attribute|taxonomy.
-	 * @param array  $query_vars  WP_Query args (unused — ES already filtered).
-	 * @param array  $extra       For taxonomy/attribute: `array{ taxonomy: string }`.
-	 * @return mixed Array of counts when handled, otherwise `$pre`.
-	 */
-	public function provide_filter_data( $pre, $filter_type, $query_vars, $extra ) {
-		unset( $query_vars );
-		if ( null !== $pre ) {
-			return $pre;
-		}
-		if ( ! $this->jp_search_handled_current_query() ) {
-			return $pre;
-		}
-
-		switch ( $filter_type ) {
-			case 'taxonomy':
-				return $this->extract_taxonomy_counts( isset( $extra['taxonomy'] ) ? (string) $extra['taxonomy'] : '', 'taxonomy' );
-
-			case 'attribute':
-				return $this->extract_taxonomy_counts( isset( $extra['taxonomy'] ) ? (string) $extra['taxonomy'] : '', 'attribute' );
-
-			// Out of PoC scope — price/stock/rating need range/term aggregations
-			// that aren't first-class in Inline_Search::set_filters(). Returning
-			// `null` lets WooCommerce's default behavior run for those filters
-			// so the rest of the page still works.
-			case 'price':
-			case 'stock':
-			case 'rating':
-			default:
-				return $pre;
-		}
-	}
-
-	/**
-	 * Pull taxonomy/attribute counts out of the ES aggregation response.
-	 *
-	 * Buckets are keyed by slug; the WC blocks expect term IDs. We resolve
-	 * each slug to a term and drop buckets we can't resolve (deleted /
-	 * untranslatable terms).
-	 *
-	 * @param string $taxonomy Taxonomy slug (e.g. `product_cat`, `pa_color`).
-	 * @param string $wc_type  `taxonomy` or `attribute` (selects the registered key prefix).
-	 * @return array<int,int> term_id → count
-	 */
-	private function extract_taxonomy_counts( $taxonomy, $wc_type ) {
-		if ( '' === $taxonomy ) {
-			return array();
-		}
-
-		$key_infix = ( 'attribute' === $wc_type ) ? 'attr_' : 'tax_';
-		$agg_key   = self::AGG_KEY_PREFIX . $key_infix . $taxonomy;
-
-		$aggregations = $this->search_instance()->get_search_aggregations_results();
-		if ( empty( $aggregations[ $agg_key ]['buckets'] ) ) {
-			return array();
-		}
-
-		$counts = array();
-		foreach ( $aggregations[ $agg_key ]['buckets'] as $bucket ) {
-			if ( empty( $bucket['key'] ) ) {
-				continue;
-			}
-			$term = get_term_by( 'slug', $bucket['key'], $taxonomy );
-			if ( ! $term instanceof \WP_Term ) {
-				continue;
-			}
-			$counts[ $term->term_id ] = isset( $bucket['doc_count'] ) ? (int) $bucket['doc_count'] : 0;
-		}
-		return $counts;
-	}
-
-	/**
-	 * Whether Jetpack Search executed (and produced aggregations for) the
-	 * current query.
-	 *
-	 * The Product Filters blocks may render before any search has run (e.g.
-	 * editor preview). In that case `get_search_aggregations_results()`
-	 * returns an empty array and we should defer to WC's default behavior.
-	 */
-	private function jp_search_handled_current_query() {
-		$aggregations = $this->search_instance()->get_search_aggregations_results();
-		return ! empty( $aggregations );
-	}
-
-	/**
-	 * Read filter params off the request, unslashed but not yet sanitized
-	 * (sanitization happens per-value in `collect_slug_values`).
-	 */
-	private function get_request_filter_params() {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only filter URL params.
-		return is_array( $_GET ) ? wp_unslash( $_GET ) : array();
-	}
-
-	/**
-	 * Collect comma-separated slug values from any of the given URL params.
-	 *
-	 * @param array         $params     Request params (already unslashed).
-	 * @param array<string> $param_keys Candidate URL keys to read from.
-	 * @return array<string> Sanitized, deduplicated slug list.
-	 */
-	private function collect_slug_values( $params, $param_keys ) {
-		$values = array();
-		foreach ( $param_keys as $key ) {
-			if ( empty( $params[ $key ] ) || ! is_string( $params[ $key ] ) ) {
-				continue;
-			}
-			foreach ( explode( ',', $params[ $key ] ) as $raw ) {
-				$slug = sanitize_title( trim( $raw ) );
-				if ( '' !== $slug ) {
-					$values[] = $slug;
-				}
-			}
-		}
-		return array_values( array_unique( $values ) );
-	}
-
-	/**
-	 * Merge a slug list into `$es_args['terms'][$taxonomy]` without duplicates.
-	 *
-	 * @param array  $es_args  Current ES-bound WP_Query args.
-	 * @param string $taxonomy Taxonomy slug.
-	 * @param array  $slugs    Slug list to add.
-	 * @return array
-	 */
-	private function merge_term_slugs( $es_args, $taxonomy, $slugs ) {
-		if ( ! isset( $es_args['terms'] ) || ! is_array( $es_args['terms'] ) ) {
-			$es_args['terms'] = array();
-		}
-		$existing                      = isset( $es_args['terms'][ $taxonomy ] ) && is_array( $es_args['terms'][ $taxonomy ] )
-			? $es_args['terms'][ $taxonomy ]
-			: array();
-		$es_args['terms'][ $taxonomy ] = array_values( array_unique( array_merge( $existing, $slugs ) ) );
-		return $es_args;
+		return $configs;
 	}
 }

--- a/projects/packages/search/src/woocommerce-bridge/class-woocommerce-filters-bridge.php
+++ b/projects/packages/search/src/woocommerce-bridge/class-woocommerce-filters-bridge.php
@@ -269,6 +269,16 @@ class WooCommerce_Filters_Bridge {
 			'maxItems'   => 10,
 		);
 
+		// Rating — values `1`..`5` (rounded star buckets). WC writes
+		// `rating_filter=4,5` scalar comma-joined; the bridge's
+		// `wc_rating` filterType emits an ES range aggregation /
+		// range-OR filter clause against `meta._wc_average_rating.double`.
+		$configs['rating_filter'] = array(
+			'filterType' => 'wc_rating',
+			'urlFormat'  => 'scalar',
+			'maxItems'   => 5,
+		);
+
 		return $configs;
 	}
 }

--- a/projects/packages/search/src/woocommerce-bridge/class-woocommerce-filters-bridge.php
+++ b/projects/packages/search/src/woocommerce-bridge/class-woocommerce-filters-bridge.php
@@ -1,0 +1,390 @@
+<?php
+/**
+ * Bridge between the WooCommerce Product Filters blocks and Jetpack Search.
+ *
+ * Hydrates the Product Filters blocks (Categories, Tags, Brands, Attributes)
+ * from Jetpack Search's Elasticsearch aggregations instead of running local
+ * MySQL queries. The blocks themselves are unchanged; only their data source
+ * is redirected via existing extension points:
+ *
+ *   1. `woocommerce_pre_product_filter_data` — short-circuit count queries
+ *   2. `jetpack_search_should_handle_query` — widen ES takeover to shop /
+ *      product taxonomy archives
+ *   3. `jetpack_search_es_wp_query_args` — translate WC URL params
+ *      (`filter_<slug>`, `categories`, `tags`, `brands`, `pa_*`) into ES
+ *      filter terms
+ *   4. `Classic_Search::set_filters()` on `init` — register taxonomy and
+ *      attribute aggregations so ES returns bucket counts
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Wires WooCommerce Product Filters blocks to Jetpack Search aggregations.
+ *
+ * Loaded only when WooCommerce Blocks is active and the Search module is
+ * connected. Gated additionally by `jetpack_search_woocommerce_bridge_enabled`
+ * (default false) while the bridge is in PoC stage.
+ */
+class WooCommerce_Filters_Bridge {
+
+	/**
+	 * Prefix used when registering aggregation keys with Classic_Search so
+	 * we can reverse-map an aggregation result back to a (filter type,
+	 * taxonomy) tuple.
+	 */
+	const AGG_KEY_PREFIX = 'wc_filter_';
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @var self|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Initialize the bridge if its prerequisites are satisfied.
+	 *
+	 * Called from the search package initializer. No-op when WooCommerce
+	 * Blocks isn't loaded, the Search module isn't active, or the feature
+	 * flag is off.
+	 */
+	public static function init() {
+		if ( null !== self::$instance ) {
+			return;
+		}
+
+		/**
+		 * Filter whether the WooCommerce Product Filters bridge is enabled.
+		 *
+		 * Defaults to false while the bridge is in PoC stage. Returning true
+		 * activates the bridge: WooCommerce Product Filters blocks will be
+		 * hydrated from Jetpack Search's Elasticsearch aggregations on shop
+		 * and product taxonomy archive pages.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool $enabled Default false.
+		 */
+		if ( ! apply_filters( 'jetpack_search_woocommerce_bridge_enabled', false ) ) {
+			return;
+		}
+
+		if ( ! self::has_required_dependencies() ) {
+			return;
+		}
+
+		self::$instance = new self();
+		self::$instance->register_hooks();
+	}
+
+	/**
+	 * Whether the runtime environment can support the bridge.
+	 */
+	private static function has_required_dependencies() {
+		// WooCommerce Blocks must be loaded — that's where the filter blocks
+		// and the `woocommerce_pre_product_filter_data` hook live.
+		if ( ! class_exists( '\Automattic\WooCommerce\Internal\ProductFilters\FilterData' ) ) {
+			return false;
+		}
+
+		// Search module must be active so Classic_Search will actually run a
+		// query and produce aggregations.
+		if ( ! ( new Module_Control() )->is_active() ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Register all hooks the bridge needs.
+	 */
+	private function register_hooks() {
+		add_action( 'init', array( $this, 'register_search_filters' ), 20 );
+		add_filter( 'jetpack_search_should_handle_query', array( $this, 'handle_wc_archives' ), 10, 2 );
+		add_filter( 'jetpack_search_es_wp_query_args', array( $this, 'translate_wc_url_params' ), 10, 2 );
+		add_filter( 'woocommerce_pre_product_filter_data', array( $this, 'provide_filter_data' ), 10, 4 );
+	}
+
+	/**
+	 * Register taxonomy + attribute aggregations with Classic_Search.
+	 *
+	 * Each filter is keyed by `AGG_KEY_PREFIX . <type>_<taxonomy>` so the
+	 * reverse map can later resolve an aggregation bucket back to its
+	 * taxonomy when serving counts to the Product Filters blocks.
+	 */
+	public function register_search_filters() {
+		$filters = array();
+
+		$builtin_taxonomies = array( 'product_cat', 'product_tag' );
+		if ( taxonomy_exists( 'product_brand' ) ) {
+			$builtin_taxonomies[] = 'product_brand';
+		}
+
+		foreach ( $builtin_taxonomies as $taxonomy ) {
+			$filters[ self::AGG_KEY_PREFIX . 'tax_' . $taxonomy ] = array(
+				'name'     => $taxonomy,
+				'type'     => 'taxonomy',
+				'taxonomy' => $taxonomy,
+				'count'    => 100,
+			);
+		}
+
+		if ( function_exists( 'wc_get_attribute_taxonomies' ) ) {
+			foreach ( wc_get_attribute_taxonomies() as $attribute_object ) {
+				$taxonomy = wc_attribute_taxonomy_name( $attribute_object->attribute_name );
+
+				$filters[ self::AGG_KEY_PREFIX . 'attr_' . $taxonomy ] = array(
+					'name'      => $taxonomy,
+					'type'      => 'product_attribute',
+					'attribute' => $taxonomy,
+					'count'     => 100,
+				);
+			}
+		}
+
+		Classic_Search::instance()->set_filters( $filters );
+	}
+
+	/**
+	 * Widen Jetpack Search to take over the main query on WC archive pages.
+	 *
+	 * By default, JP Search only handles `is_search()` queries. Shop /
+	 * product taxonomy archives are normal post-type queries, so we opt them
+	 * in explicitly.
+	 *
+	 * @param bool      $should_handle Current decision.
+	 * @param \WP_Query $query         The query under consideration.
+	 * @return bool
+	 */
+	public function handle_wc_archives( $should_handle, $query ) {
+		if ( $should_handle ) {
+			return true;
+		}
+		if ( ! $query instanceof \WP_Query || ! $query->is_main_query() ) {
+			return $should_handle;
+		}
+
+		if ( function_exists( 'is_shop' ) && is_shop() ) {
+			return true;
+		}
+
+		$wc_taxonomies = array( 'product_cat', 'product_tag' );
+		if ( taxonomy_exists( 'product_brand' ) ) {
+			$wc_taxonomies[] = 'product_brand';
+		}
+		if ( $query->is_tax( $wc_taxonomies ) ) {
+			return true;
+		}
+
+		return $should_handle;
+	}
+
+	/**
+	 * Translate WooCommerce Product Filters URL params into ES query terms.
+	 *
+	 * Runs at `jetpack_search_es_wp_query_args` (priority 10), which fires
+	 * before the WP→ES conversion, so we emit WP_Query-style entries.
+	 *
+	 * Param contract followed (matches WC's Params::get_taxonomy_params):
+	 *   - `categories=foo,bar`            → product_cat slugs
+	 *   - `tags=foo,bar`                  → product_tag slugs
+	 *   - `brands=foo,bar`                → product_brand slugs
+	 *   - `filter_<short_attr>=v1,v2`     → pa_<short_attr> slugs
+	 *   - `query_type_<short_attr>=and`   → noted (see TODO below)
+	 *
+	 * @param array     $es_args ES-bound WP_Query args.
+	 * @param \WP_Query $query   The query being translated.
+	 * @return array
+	 */
+	public function translate_wc_url_params( $es_args, $query ) {
+		unset( $query );
+		$params = $this->get_request_filter_params();
+		if ( empty( $params ) ) {
+			return $es_args;
+		}
+
+		$builtin_map = array(
+			'categories' => 'product_cat',
+			'tags'       => 'product_tag',
+			'brands'     => 'product_brand',
+		);
+		foreach ( $builtin_map as $param_key => $taxonomy ) {
+			if ( ! taxonomy_exists( $taxonomy ) ) {
+				continue;
+			}
+			$slugs = $this->collect_slug_values( $params, array( $param_key, 'filter_' . $taxonomy ) );
+			if ( ! empty( $slugs ) ) {
+				$es_args = $this->merge_term_slugs( $es_args, $taxonomy, $slugs );
+			}
+		}
+
+		if ( function_exists( 'wc_get_attribute_taxonomies' ) ) {
+			foreach ( wc_get_attribute_taxonomies() as $attribute_object ) {
+				$taxonomy   = wc_attribute_taxonomy_name( $attribute_object->attribute_name );
+				$short_name = $attribute_object->attribute_name;
+				$slugs      = $this->collect_slug_values(
+					$params,
+					array( 'filter_' . $short_name, 'filter_' . $taxonomy )
+				);
+				if ( ! empty( $slugs ) ) {
+					$es_args = $this->merge_term_slugs( $es_args, $taxonomy, $slugs );
+					// TODO: query_type_<attr>=and is not faithfully translated yet — JP Search
+					// treats multi-term taxonomy filters as OR within a bucket. AND semantics
+					// require raw ES injection at convert_wp_es_to_es_args time.
+				}
+			}
+		}
+
+		return $es_args;
+	}
+
+	/**
+	 * Provide filter counts to the Product Filters blocks.
+	 *
+	 * Returning a non-null array from `woocommerce_pre_product_filter_data`
+	 * short-circuits WooCommerce's local count query.
+	 *
+	 * @param mixed  $pre         Current value (null = continue with default).
+	 * @param string $filter_type One of price|stock|rating|attribute|taxonomy.
+	 * @param array  $query_vars  WP_Query args (unused — ES already filtered).
+	 * @param array  $extra       For taxonomy/attribute: `array{ taxonomy: string }`.
+	 * @return mixed Array of counts when handled, otherwise `$pre`.
+	 */
+	public function provide_filter_data( $pre, $filter_type, $query_vars, $extra ) {
+		unset( $query_vars );
+		if ( null !== $pre ) {
+			return $pre;
+		}
+		if ( ! $this->jp_search_handled_current_query() ) {
+			return $pre;
+		}
+
+		switch ( $filter_type ) {
+			case 'taxonomy':
+				return $this->extract_taxonomy_counts( isset( $extra['taxonomy'] ) ? (string) $extra['taxonomy'] : '', 'taxonomy' );
+
+			case 'attribute':
+				return $this->extract_taxonomy_counts( isset( $extra['taxonomy'] ) ? (string) $extra['taxonomy'] : '', 'attribute' );
+
+			// Out of PoC scope — price/stock/rating need range/term aggregations
+			// that aren't first-class in Classic_Search::set_filters(). Returning
+			// `null` lets WooCommerce's default behavior run for those filters
+			// so the rest of the page still works.
+			case 'price':
+			case 'stock':
+			case 'rating':
+			default:
+				return $pre;
+		}
+	}
+
+	/**
+	 * Pull taxonomy/attribute counts out of the ES aggregation response.
+	 *
+	 * Buckets are keyed by slug; the WC blocks expect term IDs. We resolve
+	 * each slug to a term and drop buckets we can't resolve (deleted /
+	 * untranslatable terms).
+	 *
+	 * @param string $taxonomy Taxonomy slug (e.g. `product_cat`, `pa_color`).
+	 * @param string $wc_type  `taxonomy` or `attribute` (selects the registered key prefix).
+	 * @return array<int,int> term_id → count
+	 */
+	private function extract_taxonomy_counts( $taxonomy, $wc_type ) {
+		if ( '' === $taxonomy ) {
+			return array();
+		}
+
+		$key_infix = ( 'attribute' === $wc_type ) ? 'attr_' : 'tax_';
+		$agg_key   = self::AGG_KEY_PREFIX . $key_infix . $taxonomy;
+
+		$aggregations = Classic_Search::instance()->get_search_aggregations_results();
+		if ( empty( $aggregations[ $agg_key ]['buckets'] ) ) {
+			return array();
+		}
+
+		$counts = array();
+		foreach ( $aggregations[ $agg_key ]['buckets'] as $bucket ) {
+			if ( empty( $bucket['key'] ) ) {
+				continue;
+			}
+			$term = get_term_by( 'slug', $bucket['key'], $taxonomy );
+			if ( ! $term instanceof \WP_Term ) {
+				continue;
+			}
+			$counts[ $term->term_id ] = isset( $bucket['doc_count'] ) ? (int) $bucket['doc_count'] : 0;
+		}
+		return $counts;
+	}
+
+	/**
+	 * Whether Jetpack Search executed (and produced aggregations for) the
+	 * current query.
+	 *
+	 * The Product Filters blocks may render before any search has run (e.g.
+	 * editor preview). In that case `get_search_aggregations_results()`
+	 * returns an empty array and we should defer to WC's default behavior.
+	 */
+	private function jp_search_handled_current_query() {
+		$aggregations = Classic_Search::instance()->get_search_aggregations_results();
+		return ! empty( $aggregations );
+	}
+
+	/**
+	 * Read filter params off the request, unslashed but not yet sanitized
+	 * (sanitization happens per-value in `collect_slug_values`).
+	 */
+	private function get_request_filter_params() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only filter URL params.
+		return is_array( $_GET ) ? wp_unslash( $_GET ) : array();
+	}
+
+	/**
+	 * Collect comma-separated slug values from any of the given URL params.
+	 *
+	 * @param array         $params     Request params (already unslashed).
+	 * @param array<string> $param_keys Candidate URL keys to read from.
+	 * @return array<string> Sanitized, deduplicated slug list.
+	 */
+	private function collect_slug_values( $params, $param_keys ) {
+		$values = array();
+		foreach ( $param_keys as $key ) {
+			if ( empty( $params[ $key ] ) || ! is_string( $params[ $key ] ) ) {
+				continue;
+			}
+			foreach ( explode( ',', $params[ $key ] ) as $raw ) {
+				$slug = sanitize_title( trim( $raw ) );
+				if ( '' !== $slug ) {
+					$values[] = $slug;
+				}
+			}
+		}
+		return array_values( array_unique( $values ) );
+	}
+
+	/**
+	 * Merge a slug list into `$es_args['terms'][$taxonomy]` without duplicates.
+	 *
+	 * @param array  $es_args  Current ES-bound WP_Query args.
+	 * @param string $taxonomy Taxonomy slug.
+	 * @param array  $slugs    Slug list to add.
+	 * @return array
+	 */
+	private function merge_term_slugs( $es_args, $taxonomy, $slugs ) {
+		if ( ! isset( $es_args['terms'] ) || ! is_array( $es_args['terms'] ) ) {
+			$es_args['terms'] = array();
+		}
+		$existing                      = isset( $es_args['terms'][ $taxonomy ] ) && is_array( $es_args['terms'][ $taxonomy ] )
+			? $es_args['terms'][ $taxonomy ]
+			: array();
+		$es_args['terms'][ $taxonomy ] = array_values( array_unique( array_merge( $existing, $slugs ) ) );
+		return $es_args;
+	}
+}

--- a/projects/packages/search/src/woocommerce-bridge/class-woocommerce-filters-bridge.php
+++ b/projects/packages/search/src/woocommerce-bridge/class-woocommerce-filters-bridge.php
@@ -13,8 +13,10 @@
  *   3. `jetpack_search_es_wp_query_args` — translate WC URL params
  *      (`filter_<slug>`, `categories`, `tags`, `brands`, `pa_*`) into ES
  *      filter terms
- *   4. `Classic_Search::set_filters()` on `init` — register taxonomy and
- *      attribute aggregations so ES returns bucket counts
+ *   4. `Inline_Search::set_filters()` on `init` — register taxonomy and
+ *      attribute aggregations so ES returns bucket counts (the search
+ *      instance is resolved via `Inline_Search::get_instance_maybe_fallback_to_classic()`
+ *      to handle both Inline and the legacy Classic fallback)
  *
  * @package automattic/jetpack-search
  */
@@ -35,7 +37,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WooCommerce_Filters_Bridge {
 
 	/**
-	 * Prefix used when registering aggregation keys with Classic_Search so
+	 * Prefix used when registering aggregation keys with the search instance so
 	 * we can reverse-map an aggregation result back to a (filter type,
 	 * taxonomy) tuple.
 	 */
@@ -94,13 +96,24 @@ class WooCommerce_Filters_Bridge {
 			return false;
 		}
 
-		// Search module must be active so Classic_Search will actually run a
-		// query and produce aggregations.
+		// Search module must be active so Inline_Search (or the Classic
+		// fallback) will actually run a query and produce aggregations.
 		if ( ! ( new Module_Control() )->is_active() ) {
 			return false;
 		}
 
 		return true;
+	}
+
+	/**
+	 * Resolve the active search singleton.
+	 *
+	 * Mirrors the initializer's choice between Inline_Search (the current
+	 * implementation) and Classic_Search (the legacy fallback that's still
+	 * used on sites without the inline-search feature flag).
+	 */
+	private function search_instance() {
+		return Inline_Search::get_instance_maybe_fallback_to_classic();
 	}
 
 	/**
@@ -114,7 +127,8 @@ class WooCommerce_Filters_Bridge {
 	}
 
 	/**
-	 * Register taxonomy + attribute aggregations with Classic_Search.
+	 * Register taxonomy + attribute aggregations with the active search
+	 * instance.
 	 *
 	 * Each filter is keyed by `AGG_KEY_PREFIX . <type>_<taxonomy>` so the
 	 * reverse map can later resolve an aggregation bucket back to its
@@ -150,7 +164,7 @@ class WooCommerce_Filters_Bridge {
 			}
 		}
 
-		Classic_Search::instance()->set_filters( $filters );
+		$this->search_instance()->set_filters( $filters );
 	}
 
 	/**
@@ -275,7 +289,7 @@ class WooCommerce_Filters_Bridge {
 				return $this->extract_taxonomy_counts( isset( $extra['taxonomy'] ) ? (string) $extra['taxonomy'] : '', 'attribute' );
 
 			// Out of PoC scope — price/stock/rating need range/term aggregations
-			// that aren't first-class in Classic_Search::set_filters(). Returning
+			// that aren't first-class in Inline_Search::set_filters(). Returning
 			// `null` lets WooCommerce's default behavior run for those filters
 			// so the rest of the page still works.
 			case 'price':
@@ -305,7 +319,7 @@ class WooCommerce_Filters_Bridge {
 		$key_infix = ( 'attribute' === $wc_type ) ? 'attr_' : 'tax_';
 		$agg_key   = self::AGG_KEY_PREFIX . $key_infix . $taxonomy;
 
-		$aggregations = Classic_Search::instance()->get_search_aggregations_results();
+		$aggregations = $this->search_instance()->get_search_aggregations_results();
 		if ( empty( $aggregations[ $agg_key ]['buckets'] ) ) {
 			return array();
 		}
@@ -333,7 +347,7 @@ class WooCommerce_Filters_Bridge {
 	 * returns an empty array and we should defer to WC's default behavior.
 	 */
 	private function jp_search_handled_current_query() {
-		$aggregations = Classic_Search::instance()->get_search_aggregations_results();
+		$aggregations = $this->search_instance()->get_search_aggregations_results();
 		return ! empty( $aggregations );
 	}
 

--- a/projects/packages/search/src/woocommerce-bridge/class-woocommerce-filters-bridge.php
+++ b/projects/packages/search/src/woocommerce-bridge/class-woocommerce-filters-bridge.php
@@ -257,6 +257,18 @@ class WooCommerce_Filters_Bridge {
 			}
 		}
 
+		// Stock status — slugs `instock`, `outofstock`, `onbackorder`. WC
+		// writes this URL key as `filter_stock_status=instock,outofstock`
+		// (scalar comma-joined) from its Product Filter Status block;
+		// `urlFormat: 'scalar'` opts the bridge JS and the jetpack-search
+		// store's URL parser into that shape so the URL contract stays
+		// compatible with what WC already writes.
+		$configs['filter_stock_status'] = array(
+			'filterType' => 'wc_stock_status',
+			'urlFormat'  => 'scalar',
+			'maxItems'   => 10,
+		);
+
 		return $configs;
 	}
 }

--- a/projects/packages/search/src/woocommerce-bridge/class-woocommerce-filters-bridge.php
+++ b/projects/packages/search/src/woocommerce-bridge/class-woocommerce-filters-bridge.php
@@ -269,13 +269,13 @@ class WooCommerce_Filters_Bridge {
 			'maxItems'   => 10,
 		);
 
-		// Rating — values `1`..`5` (rounded star buckets). WC writes
-		// `rating_filter=4,5` scalar comma-joined; the bridge's
-		// `wc_rating` filterType emits an ES range aggregation /
-		// range-OR filter clause against `meta._wc_average_rating.double`.
+		// Rating — values `1`..`5` (rounded star buckets). Stored in
+		// the URL as array-form `?rating_filter[]=4&rating_filter[]=5`
+		// to match the taxonomy/attribute contract; the bridge JS
+		// converts WC's native comma-joined `state.params` into
+		// array-form when its actions.navigate override fires.
 		$configs['rating_filter'] = array(
 			'filterType' => 'wc_rating',
-			'urlFormat'  => 'scalar',
 			'maxItems'   => 5,
 		);
 

--- a/projects/packages/search/src/woocommerce-bridge/class-woocommerce-filters-bridge.php
+++ b/projects/packages/search/src/woocommerce-bridge/class-woocommerce-filters-bridge.php
@@ -168,12 +168,16 @@ class WooCommerce_Filters_Bridge {
 	}
 
 	/**
-	 * Build a filterConfigs map matching the WooCommerce Product Filters
-	 * URL contract.
+	 * Build a filterConfigs map.
 	 *
-	 * Keys are the WC URL param names (`categories`, `tags`, `brands`,
-	 * `filter_<short_attr>`); values name the underlying taxonomy plus the
-	 * `filterType` enum that `resolveFilterFields()` in
+	 * Keys are the underlying taxonomy slugs (`product_cat`, `product_tag`,
+	 * `product_brand`, `pa_<short_attr>`) so the URL contract matches the
+	 * Jetpack Search blocks' existing pattern (`?<key>[]=<value>`, see
+	 * src/search-blocks/store/url-state.js). That makes filter URLs
+	 * interchangeable between WC's filter UI and any Jetpack Search
+	 * filter-checkbox blocks on the same page.
+	 *
+	 * Values carry the `filterType` enum that `resolveFilterFields()` in
 	 * src/search-blocks/store/api.js consumes when constructing the ES
 	 * aggregation field path.
 	 *
@@ -181,12 +185,12 @@ class WooCommerce_Filters_Bridge {
 	 */
 	private function build_filter_configs() {
 		$configs = array(
-			'categories' => array(
+			'product_cat' => array(
 				'filterType' => 'taxonomy',
 				'taxonomy'   => 'product_cat',
 				'maxItems'   => 100,
 			),
-			'tags'       => array(
+			'product_tag' => array(
 				'filterType' => 'taxonomy',
 				'taxonomy'   => 'product_tag',
 				'maxItems'   => 100,
@@ -194,7 +198,7 @@ class WooCommerce_Filters_Bridge {
 		);
 
 		if ( taxonomy_exists( 'product_brand' ) ) {
-			$configs['brands'] = array(
+			$configs['product_brand'] = array(
 				'filterType' => 'taxonomy',
 				'taxonomy'   => 'product_brand',
 				'maxItems'   => 100,
@@ -203,10 +207,9 @@ class WooCommerce_Filters_Bridge {
 
 		if ( function_exists( 'wc_get_attribute_taxonomies' ) ) {
 			foreach ( wc_get_attribute_taxonomies() as $attribute_object ) {
-				$short_name = $attribute_object->attribute_name;
-				$taxonomy   = wc_attribute_taxonomy_name( $short_name );
+				$taxonomy = wc_attribute_taxonomy_name( $attribute_object->attribute_name );
 
-				$configs[ 'filter_' . $short_name ] = array(
+				$configs[ $taxonomy ] = array(
 					'filterType' => 'taxonomy',
 					'taxonomy'   => $taxonomy,
 					'maxItems'   => 100,

--- a/projects/packages/search/src/woocommerce-bridge/view.js
+++ b/projects/packages/search/src/woocommerce-bridge/view.js
@@ -755,16 +755,18 @@ function bucketsToCountMap( buckets, filterConfig ) {
 	}
 
 	// Rating uses a histogram aggregation with offset 0.5: bucket keys
-	// are 0.5/1.5/2.5/3.5/4.5 — map them to star slugs '1'..'5'. Anything
-	// outside that range (e.g. unrated products bucketing at 0 or above
-	// 5.0) we sum into the nearest star at the boundary.
+	// are 0.5/1.5/2.5/3.5/4.5 → star slugs '1'..'5'. Drop the bucket
+	// keyed at -0.5 (where avg=0 lands — products with no reviews); WC's
+	// FilterData::get_rating_counts does the same via
+	// `WHERE average_rating > 0`. Anything below 0.5 is "unrated" and
+	// shouldn't count as 1-star.
 	if ( filterConfig?.filterType === 'wc_rating' ) {
 		for ( const bucket of buckets ) {
 			const numericKey = Number( bucket.key );
-			if ( ! Number.isFinite( numericKey ) ) {
+			if ( ! Number.isFinite( numericKey ) || numericKey < 0.5 ) {
 				continue;
 			}
-			const star = Math.min( 5, Math.max( 1, Math.floor( numericKey ) + 1 ) );
+			const star = Math.min( 5, Math.floor( numericKey ) + 1 );
 			const slug = String( star );
 			out[ slug ] = ( out[ slug ] ?? 0 ) + ( Number( bucket.doc_count ) || 0 );
 		}

--- a/projects/packages/search/src/woocommerce-bridge/view.js
+++ b/projects/packages/search/src/woocommerce-bridge/view.js
@@ -23,16 +23,15 @@
  * Filter coverage today: taxonomy (product_cat, product_tag,
  * product_brand), attributes (pa_*), stock status
  * (filter_stock_status — scalar URL key, ES field
- * `meta._stock_status.value`), active-filter removable chips driven from
- * URL state, both display variants (checkbox-list and chips), and the
- * price slider via the actions.navigate override.
+ * `meta._stock_status.value.raw`), rating (rating_filter — array URL
+ * key, histogram aggregation on `meta._wc_average_rating.double`),
+ * active-filter removable chips driven from URL state, both display
+ * variants (checkbox-list and chips), and the price slider via the
+ * actions.navigate override.
  *
- * Out of scope (TODOs): rating filter (needs a range aggregation on
- * `meta._wc_average_rating.double` plus star-bucket rendering, which
- * requires `buildAggregations` to learn about non-`terms` aggs); i18n —
- * stock-status labels are hardcoded English, follow-up should read them
- * off the existing server-rendered items or seed via
- * wp_interactivity_state.
+ * Out of scope (TODOs): i18n — stock-status labels are hardcoded
+ * English, follow-up should read them off the existing server-rendered
+ * items or seed via wp_interactivity_state.
  *
  * Runtime config (siteId, apiRoot, isPrivateSite, isWpcom, nonce, homeUrl,
  * filterConfigs) is seeded server-side via `wp_interactivity_state` under

--- a/projects/packages/search/src/woocommerce-bridge/view.js
+++ b/projects/packages/search/src/woocommerce-bridge/view.js
@@ -98,27 +98,62 @@ const VALID_SORT_ORDERS = [ 'relevance', 'newest', 'oldest' ];
 const DEFAULT_SORT_ORDER = 'relevance';
 
 /**
+ * Coerce a `min_price` / `max_price` URL value into a finite,
+ * non-negative number. Returns null for missing, non-numeric, or
+ * negative input so a garbage URL can't drive the API to zero results.
+ *
+ * @param {string|null} raw - Raw URL param value.
+ * @return {number|null} Parsed bound or null.
+ */
+function parsePriceBound( raw ) {
+	if ( raw === null || raw === undefined || raw === '' ) {
+		return null;
+	}
+	const num = Number( raw );
+	if ( ! Number.isFinite( num ) || num < 0 ) {
+		return null;
+	}
+	return num;
+}
+
+/**
+ * Read `min_price` / `max_price` off the URL into the `priceRange` shape
+ * `buildSearchUrl()` expects. Either bound may be null. Returns null
+ * when neither is present so the caller can pass through cleanly.
+ *
+ * @param {URLSearchParams} searchParams - URL search params.
+ * @return {{min: number|null, max: number|null}|null} priceRange shape, or null if absent.
+ */
+function readPriceRangeFromUrl( searchParams ) {
+	const min = parsePriceBound( searchParams.get( 'min_price' ) );
+	const max = parsePriceBound( searchParams.get( 'max_price' ) );
+	if ( min === null && max === null ) {
+		return null;
+	}
+	return { min, max };
+}
+
+/**
  * Issue an aggregation request to the WPCOM v1.3 search API using the
- * same routing as the search-blocks store. Pulls `s` and `orderby` off
- * the URL alongside our taxonomy filters so bucket counts reflect the
- * same query the JP Search result list ran — otherwise filter counts
- * are computed against the entire index instead of the actual search
- * scope and surface stale numbers next to the visible results.
+ * same routing as the search-blocks store. Returns the parsed response
+ * or null on failure.
  *
- * Returns the parsed response or null on failure (so callers can no-op
- * cleanly).
- *
- * @param {URLSearchParams} searchParams - URL params to translate into filters.
+ * @param {object} args                 - Search arguments.
+ * @param {string} [args.searchQuery]   - Empty string yields an unscoped baseline query.
+ * @param {string} [args.sortOrder]     - One of VALID_SORT_ORDERS.
+ * @param {object} [args.activeFilters] - Per-filterKey selected slugs.
+ * @param {object} [args.priceRange]    - `{ min, max }` numeric range (either bound nullable).
  * @return {Promise<object|null>} Parsed v1.3 search response, or null on error.
  */
-async function fetchAggregations( searchParams ) {
+async function fetchSearch( {
+	searchQuery = '',
+	sortOrder = DEFAULT_SORT_ORDER,
+	activeFilters = {},
+	priceRange = null,
+} = {} ) {
 	if ( ! bridgeState?.siteId ) {
 		return null;
 	}
-	const activeFilters = urlToActiveFilters( searchParams, bridgeState.filterConfigs );
-	const searchQuery = searchParams.get( 's' ) ?? '';
-	const rawOrderby = searchParams.get( 'orderby' );
-	const sortOrder = VALID_SORT_ORDERS.includes( rawOrderby ) ? rawOrderby : DEFAULT_SORT_ORDER;
 	const url = buildSearchUrl( {
 		siteId: bridgeState.siteId,
 		searchQuery,
@@ -130,6 +165,7 @@ async function fetchAggregations( searchParams ) {
 		homeUrl: bridgeState.homeUrl,
 		activeFilters,
 		filterConfigs: bridgeState.filterConfigs,
+		priceRange,
 	} );
 	try {
 		const response = await fetch( url, {
@@ -143,6 +179,43 @@ async function fetchAggregations( searchParams ) {
 	} catch {
 		return null;
 	}
+}
+
+/**
+ * Aggregations scoped to the current URL state — counts here drive what's
+ * displayed next to each option ("Red (12)").
+ *
+ * @param {URLSearchParams} searchParams - URL params to translate into filters.
+ * @return {Promise<object|null>} Parsed v1.3 search response, or null on error.
+ */
+async function fetchScopedAggregations( searchParams ) {
+	const rawOrderby = searchParams.get( 'orderby' );
+	return fetchSearch( {
+		searchQuery: searchParams.get( 's' ) ?? '',
+		sortOrder: VALID_SORT_ORDERS.includes( rawOrderby ) ? rawOrderby : DEFAULT_SORT_ORDER,
+		activeFilters: urlToActiveFilters( searchParams, bridgeState.filterConfigs ),
+		priceRange: readPriceRangeFromUrl( searchParams ),
+	} );
+}
+
+// Memoizes the baseline aggregations so the second filter click doesn't
+// re-fetch the universe of options.
+let unscopedAggregationsPromise = null;
+
+/**
+ * Aggregations against the entire indexed corpus — no `s`, no
+ * activeFilters, no priceRange. Provides the *option list* for each
+ * filter so options remain visible (with a 0 count) even when nothing in
+ * the current search scope matches them. Cached for the page lifetime
+ * since the baseline is invariant to filter clicks.
+ *
+ * @return {Promise<object|null>} Parsed v1.3 search response, or null on error.
+ */
+async function fetchUnscopedAggregations() {
+	if ( ! unscopedAggregationsPromise ) {
+		unscopedAggregationsPromise = fetchSearch( {} );
+	}
+	return unscopedAggregationsPromise;
 }
 
 /**
@@ -261,13 +334,24 @@ function renderItemHtml( item, filterKey ) {
  * Walk every filter region on the page that exposes a `filterType` we
  * recognize (taxonomy/* or attribute/*). For each, locate the
  * `…__items` host inside the region's checkbox-list shell and replace
- * its contents with freshly-rendered items derived from `aggregations`.
+ * its contents with freshly-rendered items.
  *
- * @param {object}          aggregations - ES aggregations response, keyed by filterConfig key.
+ * The option list comes from `unscoped` (every taxonomy term that
+ * exists in the index) so users always see the full set of choices —
+ * "Red (0)" is more useful than a missing row when no current-scope
+ * product matches Red. The displayed count comes from `scoped`, the
+ * aggregation under the active search/filter/price state.
+ *
+ * @param {object}          scoped       - Aggregations under the current scope (drives counts).
+ * @param {object}          unscoped     - Aggregations against the entire index (drives the option list).
  * @param {URLSearchParams} searchParams - URL params used to compute selected state.
  */
-function applyToFilterBlocks( aggregations, searchParams ) {
-	if ( ! aggregations || ! bridgeState?.filterConfigs ) {
+function applyToFilterBlocks( scoped, unscoped, searchParams ) {
+	if ( ! bridgeState?.filterConfigs ) {
+		return;
+	}
+	const baseline = unscoped ?? scoped;
+	if ( ! baseline ) {
 		return;
 	}
 
@@ -295,8 +379,8 @@ function applyToFilterBlocks( aggregations, searchParams ) {
 			return;
 		}
 
-		const buckets = aggregations[ filterKey ]?.buckets;
-		if ( ! Array.isArray( buckets ) ) {
+		const universeBuckets = baseline[ filterKey ]?.buckets;
+		if ( ! Array.isArray( universeBuckets ) ) {
 			return;
 		}
 
@@ -306,10 +390,45 @@ function applyToFilterBlocks( aggregations, searchParams ) {
 		}
 		const config = bridgeState.filterConfigs[ filterKey ];
 		const selectedSlugs = new Set( activeFilters[ filterKey ] ?? [] );
-		const items = bucketsToItems( buckets, config, wcFilterType, selectedSlugs );
+
+		// Build a slug → scoped-count map so each baseline option can show
+		// its current-scope count (defaulting to 0 when the option isn't in
+		// the scoped buckets).
+		const scopedCounts = bucketsToCountMap( scoped?.[ filterKey ]?.buckets ?? [], config );
+
+		const items = bucketsToItems( universeBuckets, config, wcFilterType, selectedSlugs ).map(
+			item => ( {
+				...item,
+				count: scopedCounts[ item.value ] ?? 0,
+			} )
+		);
 		itemHost.innerHTML = items.map( item => renderItemHtml( item, filterKey ) ).join( '' );
 		wireItemListeners( itemHost );
 	} );
+}
+
+/**
+ * Build a `{ slug → count }` map from one filterKey's bucket array,
+ * normalizing the bucket key (which may be `slug/Display Name` or just
+ * `slug`) to the underlying slug.
+ *
+ * @param {Array}  buckets      - ES bucket array.
+ * @param {object} filterConfig - filterConfig the buckets belong to.
+ * @return {object} `{ [slug]: count }`
+ */
+function bucketsToCountMap( buckets, filterConfig ) {
+	const out = {};
+	if ( ! Array.isArray( buckets ) ) {
+		return out;
+	}
+	const { bucketFormat } = resolveFilterFields( filterConfig );
+	for ( const bucket of buckets ) {
+		const rawKey = String( bucket.key ?? '' );
+		const slug =
+			bucketFormat === 'slash' && rawKey.includes( '/' ) ? rawKey.split( '/' )[ 0 ] : rawKey;
+		out[ slug ] = Number( bucket.doc_count ) || 0;
+	}
+	return out;
 }
 
 /**
@@ -375,15 +494,17 @@ async function toggleFilterAndNavigate( filterKey, filterValue ) {
 	window.dispatchEvent( new PopStateEvent( 'popstate' ) );
 }
 
-// Initial hydration on every page load. Browser back/forward also fires
-// `popstate`, in which case we rerun without pushing a duplicate history
-// entry.
+// Initial hydration on every page load. Also fires on `popstate`
+// (browser back/forward, plus the synthetic dispatch from
+// `toggleFilterAndNavigate` after a filter click).
 if ( typeof window !== 'undefined' ) {
 	const hydrate = async () => {
-		const data = await fetchAggregations( new URL( window.location.href ).searchParams );
-		if ( data?.aggregations ) {
-			applyToFilterBlocks( data.aggregations, new URL( window.location.href ).searchParams );
-		}
+		const params = new URL( window.location.href ).searchParams;
+		const [ scoped, unscoped ] = await Promise.all( [
+			fetchScopedAggregations( params ),
+			fetchUnscopedAggregations(),
+		] );
+		applyToFilterBlocks( scoped?.aggregations, unscoped?.aggregations, params );
 	};
 	if ( document.readyState === 'loading' ) {
 		document.addEventListener( 'DOMContentLoaded', hydrate, { once: true } );

--- a/projects/packages/search/src/woocommerce-bridge/view.js
+++ b/projects/packages/search/src/woocommerce-bridge/view.js
@@ -889,10 +889,21 @@ if ( typeof window !== 'undefined' ) {
 		] );
 		applyToFilterBlocks( scoped?.aggregations, unscoped?.aggregations, params );
 	};
+	/*
+	 * Defer the first hydrate via `requestAnimationFrame`. Module scripts
+	 * are deferred by default and typically execute before the
+	 * Interactivity runtime walks the DOM and binds `wp_interactivity_state`
+	 * seeds onto the store proxies — running hydrate() synchronously at
+	 * top-level reads `bridgeState.siteId` as undefined and short-circuits
+	 * the entire fetch path with no error. One animation frame is enough
+	 * for Interactivity to finish its initial walk; the popstate listener
+	 * picks up everything after that.
+	 */
+	const scheduleHydrate = () => requestAnimationFrame( () => hydrate() );
 	if ( document.readyState === 'loading' ) {
-		document.addEventListener( 'DOMContentLoaded', hydrate, { once: true } );
+		document.addEventListener( 'DOMContentLoaded', scheduleHydrate, { once: true } );
 	} else {
-		hydrate();
+		scheduleHydrate();
 	}
 	window.addEventListener( 'popstate', hydrate );
 }

--- a/projects/packages/search/src/woocommerce-bridge/view.js
+++ b/projects/packages/search/src/woocommerce-bridge/view.js
@@ -1,35 +1,65 @@
 /**
  * WooCommerce Product Filters → Jetpack Search client-side bridge.
  *
- * Overrides the `woocommerce/product-filters` Interactivity store at
- * runtime so that filter clicks fetch aggregations from the WPCOM v1.3
- * search API instead of triggering a full HTML round-trip via
- * `@wordpress/interactivity-router`. Reuses `buildSearchUrl()` from the
- * existing search-blocks store, which already routes correctly across
- * three site shapes: public sites hit `public-api.wordpress.com/rest/v1.3`
- * unauthenticated, private Jetpack sites use `/wp-json/jetpack/v4/search`
- * with `X-WP-Nonce`, and private WPCOM sites use `/wp-json/wpcom-origin/v1.3/...`
- * with cookie auth.
+ * Drives WC's Product Filters blocks entirely from the front end. Server
+ * renders empty filter shells (no product query exists on a non-product
+ * page, so WC's FilterDataProvider produces zero items). This module then
+ * fetches aggregations from the WPCOM v1.3 search API using the same
+ * routing (`buildSearchUrl()`) the rest of the Jetpack Search blocks use —
+ * public sites hit `public-api.wordpress.com` unauthenticated, private
+ * Jetpack sites use `/wp-json/jetpack/v4/search` with `X-WP-Nonce`, private
+ * WPCOM sites use `/wp-json/wpcom-origin/v1.3/...` with cookie auth.
+ *
+ * Buckets are projected into per-item DOM shape that matches the class
+ * names emitted by ProductFilterCheckboxList.php — so existing WC styles
+ * apply unchanged — and injected into the empty `…__items` host inside
+ * each filter region. Click handling uses native event listeners rather
+ * than WC's `data-wp-on--change` directive: the Interactivity API only
+ * walks the DOM during initial page hydration and does not reprocess
+ * dynamically inserted elements, so directives on injected nodes are
+ * inert. The native listener toggles a slug under the filter key, pushes
+ * the WC-format URL, re-fetches aggregations, and re-renders.
+ *
+ * Out of V2 scope: price (range slider), status (in-stock / out-of-stock),
+ * rating filters. Those need range/term aggregations not exposed by the
+ * standard WPCOM search API and are tracked as follow-ups.
  *
  * Runtime config (siteId, apiRoot, isPrivateSite, isWpcom, nonce, homeUrl,
  * filterConfigs) is seeded server-side via `wp_interactivity_state` under
- * the `jetpack-search-wc-bridge` namespace. See class-woocommerce-filters-bridge.php.
- *
- * Known limitation: WC's ProductFilterCheckboxList renders item counts as
- * static PHP-emitted text, with no `data-wp-text` binding. So mutating
- * the WC store's filterData.items[i].count would update state but not the
- * DOM. Until WC adds reactive bindings, the bridge updates count nodes
- * directly via DOM mutation. The state mutation is still issued so that
- * any future binding will pick it up automatically.
+ * the `jetpack-search-wc-bridge` namespace. See
+ * class-woocommerce-filters-bridge.php.
  */
 
 import { store } from '@wordpress/interactivity';
 import { buildSearchUrl, resolveFilterFields } from '../search-blocks/store/api';
 
 const BRIDGE_NAMESPACE = 'jetpack-search-wc-bridge';
-const WC_NAMESPACE = 'woocommerce/product-filters';
 
 const { state: bridgeState } = store( BRIDGE_NAMESPACE, {} );
+
+/**
+ * Reverse map: WC's `filterType` (e.g. `taxonomy/product_cat`,
+ * `attribute/color`) → our seeded filterConfig key (e.g. `categories`,
+ * `filter_color`). We resolve this at runtime so changes to WC's URL
+ * format only require changes here, not server-side.
+ *
+ * @return {object} `{ [wcFilterType]: filterKey }`
+ */
+function buildWcFilterTypeMap() {
+	const map = {};
+	for ( const [ filterKey, cfg ] of Object.entries( bridgeState?.filterConfigs ?? {} ) ) {
+		if ( cfg.filterType !== 'taxonomy' || ! cfg.taxonomy ) {
+			continue;
+		}
+		// Built-in product taxonomies → `taxonomy/<taxonomy>`.
+		map[ `taxonomy/${ cfg.taxonomy }` ] = filterKey;
+		// pa_* attribute taxonomies are also addressed as `attribute/<short>`.
+		if ( cfg.taxonomy.startsWith( 'pa_' ) ) {
+			map[ `attribute/${ cfg.taxonomy.slice( 3 ) }` ] = filterKey;
+		}
+	}
+	return map;
+}
 
 /**
  * Read WC-format URL params and produce the activeFilters shape that
@@ -66,9 +96,7 @@ async function fetchAggregations( searchParams ) {
 	if ( ! bridgeState?.siteId ) {
 		return null;
 	}
-
 	const activeFilters = urlToActiveFilters( searchParams, bridgeState.filterConfigs );
-
 	const url = buildSearchUrl( {
 		siteId: bridgeState.siteId,
 		searchQuery: '',
@@ -81,7 +109,6 @@ async function fetchAggregations( searchParams ) {
 		activeFilters,
 		filterConfigs: bridgeState.filterConfigs,
 	} );
-
 	try {
 		const response = await fetch( url, {
 			headers: bridgeState.isPrivateSite ? { 'X-WP-Nonce': bridgeState.nonce } : {},
@@ -97,166 +124,241 @@ async function fetchAggregations( searchParams ) {
 }
 
 /**
- * Build a `{ slug → count }` map for one filterConfig from an ES bucket
- * array. Buckets come back keyed by either the slug alone or
- * `slug/Display Name` depending on the agg field — see
- * `resolveFilterFields()` in search-blocks/store/api.js.
+ * Project ES buckets into WC item shape. ES buckets keyed via the
+ * `slug_slash_name` agg field carry both slug and display label; for
+ * plain-keyed aggregations we fall back to the slug for the label.
  *
- * @param {Array}  buckets      - ES bucket array, each `{ key, doc_count }`.
- * @param {object} filterConfig - The filterConfig entry the buckets belong to.
- * @return {object} Map of bucket slug → count.
+ * @param {Array}       buckets       - ES bucket array.
+ * @param {object}      filterConfig  - filterConfig entry the buckets belong to.
+ * @param {string}      wcFilterType  - WC's filterType (e.g. `taxonomy/product_cat`).
+ * @param {Set<string>} selectedSlugs - Slugs currently selected from URL.
+ * @return {Array<object>} Item objects ready to be embedded in `data-wp-context`.
  */
-function bucketsToCountMap( buckets, filterConfig ) {
-	const map = {};
+function bucketsToItems( buckets, filterConfig, wcFilterType, selectedSlugs ) {
 	if ( ! Array.isArray( buckets ) ) {
-		return map;
+		return [];
 	}
 	const { bucketFormat } = resolveFilterFields( filterConfig );
-	for ( const bucket of buckets ) {
-		const key = bucketFormat === 'slash' ? String( bucket.key ).split( '/' )[ 0 ] : bucket.key;
-		map[ key ] = Number( bucket.doc_count ) || 0;
-	}
-	return map;
+	return buckets
+		.map( bucket => {
+			const rawKey = String( bucket.key ?? '' );
+			let value, label;
+			if ( bucketFormat === 'slash' && rawKey.includes( '/' ) ) {
+				const idx = rawKey.indexOf( '/' );
+				value = rawKey.slice( 0, idx );
+				label = rawKey.slice( idx + 1 ) || value;
+			} else {
+				value = rawKey;
+				label = rawKey;
+			}
+			return {
+				value,
+				type: wcFilterType,
+				label,
+				count: Number( bucket.doc_count ) || 0,
+				selected: selectedSlugs.has( value ),
+				ariaLabel: label,
+			};
+		} )
+		.filter( item => item.value !== '' );
 }
 
 /**
- * Update visible count nodes for each WC filter block on the page.
+ * HTML attribute escaping. Conservative — covers the values we emit
+ * (slugs, labels, JSON-encoded contexts) without depending on a runtime.
  *
- * This is a stop-gap until WC's `ProductFilterCheckboxList.php` binds the
- * count via `data-wp-text`. We locate each filter block by its inline
- * `data-wp-context` JSON (which carries `filterData.items` with slug +
- * count), match items against ES buckets, and rewrite the corresponding
- * count `<span>`. Items whose slug isn't returned by ES are zeroed.
- *
- * The matching contract (filterKey ←→ block) relies on `filterData`
- * carrying either a `filterKey` or a `taxonomy` field that we can resolve
- * back to one of our registered filterConfigs. That's the brittle part —
- * WC's exact field names for filterData should be confirmed in a follow-up
- * before this ships beyond a PoC.
- *
- * @param {object} aggregations - ES aggregation buckets keyed by filterConfig key.
+ * @param {string|number} value - Raw value to embed in an attribute.
+ * @return {string} Escaped value.
  */
-function applyAggregationsToDom( aggregations ) {
+function escAttr( value ) {
+	return String( value )
+		.replace( /&/g, '&amp;' )
+		.replace( /"/g, '&quot;' )
+		.replace( /'/g, '&#39;' )
+		.replace( /</g, '&lt;' )
+		.replace( />/g, '&gt;' );
+}
+
+/**
+ * Body-text escaping for label spans.
+ *
+ * @param {string|number} value - Raw text to embed as element content.
+ * @return {string} Escaped text.
+ */
+function escText( value ) {
+	return String( value ).replace( /&/g, '&amp;' ).replace( /</g, '&lt;' ).replace( />/g, '&gt;' );
+}
+
+/**
+ * Build the per-item `<div>` markup. Class names match
+ * ProductFilterCheckboxList.php so existing WC styles apply unchanged.
+ *
+ * Click handling intentionally does NOT use WC's Interactivity directives
+ * (`data-wp-on--change`, `data-wp-bind--checked`): the Interactivity API
+ * walks the DOM once on initial page load and does not re-process
+ * dynamically inserted nodes — directives on injected elements are inert.
+ * Native event listeners are attached after injection by
+ * `wireItemListeners()` instead. The `data-jp-filter-key` /
+ * `data-jp-filter-value` attributes are the listener's identification
+ * channel, kept distinct from the `data-wp-*` namespace.
+ *
+ * @param {object} item      - Item shape produced by `bucketsToItems()`.
+ * @param {string} filterKey - filterConfig key (e.g. `categories`, `filter_color`).
+ * @return {string} HTML for one filter row.
+ */
+function renderItemHtml( item, filterKey ) {
+	const itemId = `${ item.type }-${ item.value }`;
+
+	return [
+		`<div class="wc-block-product-filter-checkbox-list__item">`,
+		`<label class="wc-block-product-filter-checkbox-list__label" for="${ escAttr( itemId ) }">`,
+		'<span class="wc-block-product-filter-checkbox-list__input-wrapper">',
+		`<input id="${ escAttr(
+			itemId
+		) }" class="wc-block-product-filter-checkbox-list__input" type="checkbox"`,
+		` aria-label="${ escAttr( item.ariaLabel ?? item.label ) }"`,
+		` value="${ escAttr( item.value ) }"`,
+		` data-jp-filter-key="${ escAttr( filterKey ) }"`,
+		` data-jp-filter-value="${ escAttr( item.value ) }"`,
+		item.selected ? ' checked' : '',
+		'>',
+		'<svg class="wc-block-product-filter-checkbox-list__mark" viewBox="0 0 10 8" fill="none" xmlns="http://www.w3.org/2000/svg">',
+		'<path d="M9.25 1.19922L3.75 6.69922L1 3.94922" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>',
+		'</svg>',
+		'</span>',
+		'<span class="wc-block-product-filter-checkbox-list__text-wrapper">',
+		`<span class="wc-block-product-filter-checkbox-list__text">${ escText( item.label ) }</span>`,
+		`<span class="wc-block-product-filter-checkbox-list__count">(${ item.count })</span>`,
+		'</span>',
+		'</label>',
+		'</div>',
+	].join( '' );
+}
+
+/**
+ * Walk every filter region on the page that exposes a `filterType` we
+ * recognize (taxonomy/* or attribute/*). For each, locate the
+ * `…__items` host inside the region's checkbox-list shell and replace
+ * its contents with freshly-rendered items derived from `aggregations`.
+ *
+ * @param {object}          aggregations - ES aggregations response, keyed by filterConfig key.
+ * @param {URLSearchParams} searchParams - URL params used to compute selected state.
+ */
+function applyToFilterBlocks( aggregations, searchParams ) {
 	if ( ! aggregations || ! bridgeState?.filterConfigs ) {
 		return;
 	}
 
-	// Reverse map: taxonomy slug → filterConfig key.
-	const taxonomyToFilterKey = {};
-	for ( const [ key, config ] of Object.entries( bridgeState.filterConfigs ) ) {
-		if ( config.taxonomy ) {
-			taxonomyToFilterKey[ config.taxonomy ] = key;
-		}
-	}
+	const wcTypeMap = buildWcFilterTypeMap();
+	const activeFilters = urlToActiveFilters( searchParams, bridgeState.filterConfigs );
 
-	document.querySelectorAll( '[data-wp-context]' ).forEach( node => {
-		let context;
+	const filterRegions = document.querySelectorAll(
+		'[data-wp-interactive*="product-filters"][data-wp-context*="filterType"]'
+	);
+
+	filterRegions.forEach( region => {
+		let wcFilterType;
 		try {
-			context = JSON.parse( node.getAttribute( 'data-wp-context' ) );
+			const ctx = JSON.parse( region.getAttribute( 'data-wp-context' ) );
+			wcFilterType = ctx?.filterType;
 		} catch {
 			return;
 		}
-		const filterData = context?.filterData;
-		if ( ! filterData?.items || ! Array.isArray( filterData.items ) ) {
+		if ( ! wcFilterType ) {
+			return;
+		}
+		const filterKey = wcTypeMap[ wcFilterType ];
+		if ( ! filterKey ) {
+			// Unsupported in V2 (price, status, rating).
 			return;
 		}
 
-		// WC's filterData.taxonomy is the canonical signal we register against;
-		// fall back to filterData.filterKey if present.
-		const filterKey = filterData.filterKey ?? taxonomyToFilterKey[ filterData.taxonomy ] ?? null;
-		if ( ! filterKey ) {
+		const buckets = aggregations[ filterKey ]?.buckets;
+		if ( ! Array.isArray( buckets ) ) {
+			return;
+		}
+
+		const itemHost = region.querySelector( '.wc-block-product-filter-checkbox-list__items' );
+		if ( ! itemHost ) {
 			return;
 		}
 		const config = bridgeState.filterConfigs[ filterKey ];
-		const buckets = aggregations[ filterKey ]?.buckets;
-		if ( ! buckets ) {
-			return;
-		}
-
-		const counts = bucketsToCountMap( buckets, config );
-
-		// 1. Mutate the parsed context so any future data-wp-text binding
-		//    on count gets fresh values.
-		filterData.items = filterData.items.map( item => ( {
-			...item,
-			count: counts[ item.value ] ?? 0,
-		} ) );
-		try {
-			node.setAttribute( 'data-wp-context', JSON.stringify( context ) );
-		} catch {
-			// Setting back is best-effort; failure shouldn't block the DOM
-			// surgery below.
-		}
-
-		// 2. Rewrite the visible count nodes inline.
-		const inputs = node.querySelectorAll( 'input[type="checkbox"][value]' );
-		inputs.forEach( input => {
-			const count = counts[ input.value ] ?? 0;
-			const li = input.closest( 'li' );
-			const countEl = li?.querySelector( '.wc-block-product-filter-checkbox-list__count' );
-			if ( countEl ) {
-				countEl.textContent = `(${ count })`;
-			}
-		} );
+		const selectedSlugs = new Set( activeFilters[ filterKey ] ?? [] );
+		const items = bucketsToItems( buckets, config, wcFilterType, selectedSlugs );
+		itemHost.innerHTML = items.map( item => renderItemHtml( item, filterKey ) ).join( '' );
+		wireItemListeners( itemHost );
 	} );
 }
 
 /**
- * Compose the new URL the user is navigating to, using WC's own state.params
- * getter. Mirrors `actions.navigate` in WC's frontend.ts so the URL format
- * stays identical to what WC writes today.
+ * Attach native change listeners to every input under `host`. Single
+ * delegated listener at the host level — survives item re-renders only
+ * when the host element itself stays in place (which it does, since we
+ * `innerHTML` into it rather than replacing it).
  *
- * @param {object} wcState - Snapshot of `state` inside woocommerce/product-filters.
- * @return {URL} New URL with WC-format filter params.
+ * @param {Element} host - The `…__items` div whose inputs to wire.
  */
-function buildNextUrl( wcState ) {
-	const url = new URL( window.location.href );
-	// Drop existing filter-shaped params, preserve unrelated ones (utm_*, etc.).
-	const known = new Set( Object.keys( bridgeState.filterConfigs ?? {} ) );
-	known.add( 'min_price' );
-	known.add( 'max_price' );
-	known.add( 'rating_filter' );
-	known.add( 'filter_stock_status' );
-	for ( const key of Array.from( url.searchParams.keys() ) ) {
-		if ( known.has( key ) || key.startsWith( 'query_type_' ) ) {
-			url.searchParams.delete( key );
-		}
+function wireItemListeners( host ) {
+	if ( host.dataset.jpListenerBound === '1' ) {
+		return;
 	}
-	for ( const [ key, value ] of Object.entries( wcState?.params ?? {} ) ) {
-		if ( value !== '' && value !== null && value !== undefined ) {
-			url.searchParams.set( key, value );
+	host.dataset.jpListenerBound = '1';
+	host.addEventListener( 'change', event => {
+		const input = event.target;
+		if ( ! ( input instanceof HTMLInputElement ) ) {
+			return;
 		}
-	}
-	return url;
+		const filterKey = input.getAttribute( 'data-jp-filter-key' );
+		const filterValue = input.getAttribute( 'data-jp-filter-value' );
+		if ( ! filterKey || ! filterValue ) {
+			return;
+		}
+		toggleFilterAndNavigate( filterKey, filterValue );
+	} );
 }
 
-// Override WC's `actions.navigate` so filter clicks no longer trigger a
-// full HTML round-trip. Interactivity API merges store definitions
-// last-write-wins on actions, so this replaces WC's implementation.
-store( WC_NAMESPACE, {
-	actions: {
-		*navigate() {
-			const wcState = this?.state ?? {};
-			const url = buildNextUrl( wcState );
+/**
+ * Mutate the URL to toggle one filter value, then push + fetch + render.
+ * Mirrors what WC's `actions.toggleFilter` would do, but driven entirely
+ * from native event listeners since Interactivity directives do not
+ * hydrate on injected items.
+ *
+ * @param {string} filterKey   - filterConfig key (e.g. `categories`).
+ * @param {string} filterValue - Slug being toggled.
+ */
+async function toggleFilterAndNavigate( filterKey, filterValue ) {
+	const url = new URL( window.location.href );
+	const current = ( url.searchParams.get( filterKey ) ?? '' )
+		.split( ',' )
+		.map( s => s.trim() )
+		.filter( Boolean );
+	const idx = current.indexOf( filterValue );
+	if ( idx === -1 ) {
+		current.push( filterValue );
+	} else {
+		current.splice( idx, 1 );
+	}
+	if ( current.length === 0 ) {
+		url.searchParams.delete( filterKey );
+	} else {
+		url.searchParams.set( filterKey, current.join( ',' ) );
+	}
 
-			window.history.pushState( {}, '', url.href );
+	window.history.pushState( {}, '', url.href );
+	const data = await fetchAggregations( url.searchParams );
+	if ( data?.aggregations ) {
+		applyToFilterBlocks( data.aggregations, url.searchParams );
+	}
+}
 
-			const data = yield fetchAggregations( url.searchParams );
-			if ( data?.aggregations ) {
-				applyAggregationsToDom( data.aggregations );
-			}
-		},
-	},
-} );
-
-// Initial hydration: when the page is direct-loaded with filters in the
-// URL (e.g. `/shop/?categories=foo`), WC's server render emits unfiltered
-// counts. Re-fetch from ES on first paint to bring counts into agreement.
+// Initial hydration on every page load. Browser back/forward also fires
+// `popstate`, in which case we rerun without pushing a duplicate history
+// entry.
 if ( typeof window !== 'undefined' ) {
 	const hydrate = async () => {
 		const data = await fetchAggregations( new URL( window.location.href ).searchParams );
 		if ( data?.aggregations ) {
-			applyAggregationsToDom( data.aggregations );
+			applyToFilterBlocks( data.aggregations, new URL( window.location.href ).searchParams );
 		}
 	};
 	if ( document.readyState === 'loading' ) {
@@ -264,4 +366,5 @@ if ( typeof window !== 'undefined' ) {
 	} else {
 		hydrate();
 	}
+	window.addEventListener( 'popstate', hydrate );
 }

--- a/projects/packages/search/src/woocommerce-bridge/view.js
+++ b/projects/packages/search/src/woocommerce-bridge/view.js
@@ -1,0 +1,267 @@
+/**
+ * WooCommerce Product Filters → Jetpack Search client-side bridge.
+ *
+ * Overrides the `woocommerce/product-filters` Interactivity store at
+ * runtime so that filter clicks fetch aggregations from the WPCOM v1.3
+ * search API instead of triggering a full HTML round-trip via
+ * `@wordpress/interactivity-router`. Reuses `buildSearchUrl()` from the
+ * existing search-blocks store, which already routes correctly across
+ * three site shapes: public sites hit `public-api.wordpress.com/rest/v1.3`
+ * unauthenticated, private Jetpack sites use `/wp-json/jetpack/v4/search`
+ * with `X-WP-Nonce`, and private WPCOM sites use `/wp-json/wpcom-origin/v1.3/...`
+ * with cookie auth.
+ *
+ * Runtime config (siteId, apiRoot, isPrivateSite, isWpcom, nonce, homeUrl,
+ * filterConfigs) is seeded server-side via `wp_interactivity_state` under
+ * the `jetpack-search-wc-bridge` namespace. See class-woocommerce-filters-bridge.php.
+ *
+ * Known limitation: WC's ProductFilterCheckboxList renders item counts as
+ * static PHP-emitted text, with no `data-wp-text` binding. So mutating
+ * the WC store's filterData.items[i].count would update state but not the
+ * DOM. Until WC adds reactive bindings, the bridge updates count nodes
+ * directly via DOM mutation. The state mutation is still issued so that
+ * any future binding will pick it up automatically.
+ */
+
+import { store } from '@wordpress/interactivity';
+import { buildSearchUrl, resolveFilterFields } from '../search-blocks/store/api';
+
+const BRIDGE_NAMESPACE = 'jetpack-search-wc-bridge';
+const WC_NAMESPACE = 'woocommerce/product-filters';
+
+const { state: bridgeState } = store( BRIDGE_NAMESPACE, {} );
+
+/**
+ * Read WC-format URL params and produce the activeFilters shape that
+ * `buildSearchUrl()` expects (keyed by filterConfig key, comma-joined
+ * values split into an array).
+ *
+ * @param {URLSearchParams} searchParams  - Current URL search params.
+ * @param {object}          filterConfigs - Map of registered filter configs.
+ * @return {object} `{ [filterKey]: string[] }`
+ */
+function urlToActiveFilters( searchParams, filterConfigs ) {
+	const active = {};
+	for ( const key of Object.keys( filterConfigs ?? {} ) ) {
+		const raw = searchParams.get( key );
+		if ( raw ) {
+			active[ key ] = raw
+				.split( ',' )
+				.map( s => s.trim() )
+				.filter( Boolean );
+		}
+	}
+	return active;
+}
+
+/**
+ * Issue an aggregation request to the WPCOM v1.3 search API using the
+ * same routing as the search-blocks store. Returns the parsed response or
+ * null on failure (so callers can no-op cleanly).
+ *
+ * @param {URLSearchParams} searchParams - URL params to translate into filters.
+ * @return {Promise<object|null>} Parsed v1.3 search response, or null on error.
+ */
+async function fetchAggregations( searchParams ) {
+	if ( ! bridgeState?.siteId ) {
+		return null;
+	}
+
+	const activeFilters = urlToActiveFilters( searchParams, bridgeState.filterConfigs );
+
+	const url = buildSearchUrl( {
+		siteId: bridgeState.siteId,
+		searchQuery: '',
+		sortOrder: 'relevance',
+		pageHandle: null,
+		isPrivateSite: bridgeState.isPrivateSite,
+		isWpcom: bridgeState.isWpcom,
+		apiRoot: bridgeState.apiRoot,
+		homeUrl: bridgeState.homeUrl,
+		activeFilters,
+		filterConfigs: bridgeState.filterConfigs,
+	} );
+
+	try {
+		const response = await fetch( url, {
+			headers: bridgeState.isPrivateSite ? { 'X-WP-Nonce': bridgeState.nonce } : {},
+			credentials: bridgeState.isPrivateSite ? 'include' : 'same-origin',
+		} );
+		if ( ! response.ok ) {
+			return null;
+		}
+		return await response.json();
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Build a `{ slug → count }` map for one filterConfig from an ES bucket
+ * array. Buckets come back keyed by either the slug alone or
+ * `slug/Display Name` depending on the agg field — see
+ * `resolveFilterFields()` in search-blocks/store/api.js.
+ *
+ * @param {Array}  buckets      - ES bucket array, each `{ key, doc_count }`.
+ * @param {object} filterConfig - The filterConfig entry the buckets belong to.
+ * @return {object} Map of bucket slug → count.
+ */
+function bucketsToCountMap( buckets, filterConfig ) {
+	const map = {};
+	if ( ! Array.isArray( buckets ) ) {
+		return map;
+	}
+	const { bucketFormat } = resolveFilterFields( filterConfig );
+	for ( const bucket of buckets ) {
+		const key = bucketFormat === 'slash' ? String( bucket.key ).split( '/' )[ 0 ] : bucket.key;
+		map[ key ] = Number( bucket.doc_count ) || 0;
+	}
+	return map;
+}
+
+/**
+ * Update visible count nodes for each WC filter block on the page.
+ *
+ * This is a stop-gap until WC's `ProductFilterCheckboxList.php` binds the
+ * count via `data-wp-text`. We locate each filter block by its inline
+ * `data-wp-context` JSON (which carries `filterData.items` with slug +
+ * count), match items against ES buckets, and rewrite the corresponding
+ * count `<span>`. Items whose slug isn't returned by ES are zeroed.
+ *
+ * The matching contract (filterKey ←→ block) relies on `filterData`
+ * carrying either a `filterKey` or a `taxonomy` field that we can resolve
+ * back to one of our registered filterConfigs. That's the brittle part —
+ * WC's exact field names for filterData should be confirmed in a follow-up
+ * before this ships beyond a PoC.
+ *
+ * @param {object} aggregations - ES aggregation buckets keyed by filterConfig key.
+ */
+function applyAggregationsToDom( aggregations ) {
+	if ( ! aggregations || ! bridgeState?.filterConfigs ) {
+		return;
+	}
+
+	// Reverse map: taxonomy slug → filterConfig key.
+	const taxonomyToFilterKey = {};
+	for ( const [ key, config ] of Object.entries( bridgeState.filterConfigs ) ) {
+		if ( config.taxonomy ) {
+			taxonomyToFilterKey[ config.taxonomy ] = key;
+		}
+	}
+
+	document.querySelectorAll( '[data-wp-context]' ).forEach( node => {
+		let context;
+		try {
+			context = JSON.parse( node.getAttribute( 'data-wp-context' ) );
+		} catch {
+			return;
+		}
+		const filterData = context?.filterData;
+		if ( ! filterData?.items || ! Array.isArray( filterData.items ) ) {
+			return;
+		}
+
+		// WC's filterData.taxonomy is the canonical signal we register against;
+		// fall back to filterData.filterKey if present.
+		const filterKey = filterData.filterKey ?? taxonomyToFilterKey[ filterData.taxonomy ] ?? null;
+		if ( ! filterKey ) {
+			return;
+		}
+		const config = bridgeState.filterConfigs[ filterKey ];
+		const buckets = aggregations[ filterKey ]?.buckets;
+		if ( ! buckets ) {
+			return;
+		}
+
+		const counts = bucketsToCountMap( buckets, config );
+
+		// 1. Mutate the parsed context so any future data-wp-text binding
+		//    on count gets fresh values.
+		filterData.items = filterData.items.map( item => ( {
+			...item,
+			count: counts[ item.value ] ?? 0,
+		} ) );
+		try {
+			node.setAttribute( 'data-wp-context', JSON.stringify( context ) );
+		} catch {
+			// Setting back is best-effort; failure shouldn't block the DOM
+			// surgery below.
+		}
+
+		// 2. Rewrite the visible count nodes inline.
+		const inputs = node.querySelectorAll( 'input[type="checkbox"][value]' );
+		inputs.forEach( input => {
+			const count = counts[ input.value ] ?? 0;
+			const li = input.closest( 'li' );
+			const countEl = li?.querySelector( '.wc-block-product-filter-checkbox-list__count' );
+			if ( countEl ) {
+				countEl.textContent = `(${ count })`;
+			}
+		} );
+	} );
+}
+
+/**
+ * Compose the new URL the user is navigating to, using WC's own state.params
+ * getter. Mirrors `actions.navigate` in WC's frontend.ts so the URL format
+ * stays identical to what WC writes today.
+ *
+ * @param {object} wcState - Snapshot of `state` inside woocommerce/product-filters.
+ * @return {URL} New URL with WC-format filter params.
+ */
+function buildNextUrl( wcState ) {
+	const url = new URL( window.location.href );
+	// Drop existing filter-shaped params, preserve unrelated ones (utm_*, etc.).
+	const known = new Set( Object.keys( bridgeState.filterConfigs ?? {} ) );
+	known.add( 'min_price' );
+	known.add( 'max_price' );
+	known.add( 'rating_filter' );
+	known.add( 'filter_stock_status' );
+	for ( const key of Array.from( url.searchParams.keys() ) ) {
+		if ( known.has( key ) || key.startsWith( 'query_type_' ) ) {
+			url.searchParams.delete( key );
+		}
+	}
+	for ( const [ key, value ] of Object.entries( wcState?.params ?? {} ) ) {
+		if ( value !== '' && value !== null && value !== undefined ) {
+			url.searchParams.set( key, value );
+		}
+	}
+	return url;
+}
+
+// Override WC's `actions.navigate` so filter clicks no longer trigger a
+// full HTML round-trip. Interactivity API merges store definitions
+// last-write-wins on actions, so this replaces WC's implementation.
+store( WC_NAMESPACE, {
+	actions: {
+		*navigate() {
+			const wcState = this?.state ?? {};
+			const url = buildNextUrl( wcState );
+
+			window.history.pushState( {}, '', url.href );
+
+			const data = yield fetchAggregations( url.searchParams );
+			if ( data?.aggregations ) {
+				applyAggregationsToDom( data.aggregations );
+			}
+		},
+	},
+} );
+
+// Initial hydration: when the page is direct-loaded with filters in the
+// URL (e.g. `/shop/?categories=foo`), WC's server render emits unfiltered
+// counts. Re-fetch from ES on first paint to bring counts into agreement.
+if ( typeof window !== 'undefined' ) {
+	const hydrate = async () => {
+		const data = await fetchAggregations( new URL( window.location.href ).searchParams );
+		if ( data?.aggregations ) {
+			applyAggregationsToDom( data.aggregations );
+		}
+	};
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', hydrate, { once: true } );
+	} else {
+		hydrate();
+	}
+}

--- a/projects/packages/search/src/woocommerce-bridge/view.js
+++ b/projects/packages/search/src/woocommerce-bridge/view.js
@@ -90,9 +90,23 @@ function urlToActiveFilters( searchParams, filterConfigs ) {
 }
 
 /**
+ * Sort orders the WPCOM v1.3 search API accepts. Mirrors
+ * `VALID_SORT_ORDERS` in search-blocks/store/url-state.js so the bridge
+ * and JP Search blocks agree on the URL contract.
+ */
+const VALID_SORT_ORDERS = [ 'relevance', 'newest', 'oldest' ];
+const DEFAULT_SORT_ORDER = 'relevance';
+
+/**
  * Issue an aggregation request to the WPCOM v1.3 search API using the
- * same routing as the search-blocks store. Returns the parsed response or
- * null on failure (so callers can no-op cleanly).
+ * same routing as the search-blocks store. Pulls `s` and `orderby` off
+ * the URL alongside our taxonomy filters so bucket counts reflect the
+ * same query the JP Search result list ran — otherwise filter counts
+ * are computed against the entire index instead of the actual search
+ * scope and surface stale numbers next to the visible results.
+ *
+ * Returns the parsed response or null on failure (so callers can no-op
+ * cleanly).
  *
  * @param {URLSearchParams} searchParams - URL params to translate into filters.
  * @return {Promise<object|null>} Parsed v1.3 search response, or null on error.
@@ -102,10 +116,13 @@ async function fetchAggregations( searchParams ) {
 		return null;
 	}
 	const activeFilters = urlToActiveFilters( searchParams, bridgeState.filterConfigs );
+	const searchQuery = searchParams.get( 's' ) ?? '';
+	const rawOrderby = searchParams.get( 'orderby' );
+	const sortOrder = VALID_SORT_ORDERS.includes( rawOrderby ) ? rawOrderby : DEFAULT_SORT_ORDER;
 	const url = buildSearchUrl( {
 		siteId: bridgeState.siteId,
-		searchQuery: '',
-		sortOrder: 'relevance',
+		searchQuery,
+		sortOrder,
 		pageHandle: null,
 		isPrivateSite: bridgeState.isPrivateSite,
 		isWpcom: bridgeState.isWpcom,

--- a/projects/packages/search/src/woocommerce-bridge/view.js
+++ b/projects/packages/search/src/woocommerce-bridge/view.js
@@ -331,6 +331,175 @@ function renderItemHtml( item, filterKey ) {
 }
 
 /**
+ * Build a `{ [filterKey]: { [slug]: label } }` map for resolving each
+ * active-filter chip's display name. Pulled from the unscoped baseline
+ * because that's the only response guaranteed to contain a bucket for
+ * every selected slug — the scoped response would omit a slug whose
+ * intersection with the current filter set is empty.
+ *
+ * @param {object} unscoped - Unscoped aggregation response, keyed by filterConfig key.
+ * @return {object} `{ [filterKey]: { [slug]: label } }`
+ */
+function buildSlugLabelMap( unscoped ) {
+	const out = {};
+	if ( ! unscoped || ! bridgeState?.filterConfigs ) {
+		return out;
+	}
+	for ( const [ filterKey, agg ] of Object.entries( unscoped ) ) {
+		const config = bridgeState.filterConfigs[ filterKey ];
+		if ( ! config ) {
+			continue;
+		}
+		const { bucketFormat } = resolveFilterFields( config );
+		const slugMap = {};
+		for ( const bucket of agg?.buckets ?? [] ) {
+			const rawKey = String( bucket.key ?? '' );
+			if ( bucketFormat === 'slash' && rawKey.includes( '/' ) ) {
+				const idx = rawKey.indexOf( '/' );
+				slugMap[ rawKey.slice( 0, idx ) ] = rawKey.slice( idx + 1 ) || rawKey.slice( 0, idx );
+			} else {
+				slugMap[ rawKey ] = rawKey;
+			}
+		}
+		out[ filterKey ] = slugMap;
+	}
+	return out;
+}
+
+/**
+ * Build a `{ [filterKey]: activeLabelTemplate }` map by reading every
+ * filter region's `data-wp-context.activeLabelTemplate`. Each WC filter
+ * inner block declares its own template (e.g. `"Category: {{label}}"`)
+ * so chips read right ("Category: Accessories" rather than just
+ * "accessories"). Templates with no `{{label}}` placeholder fall back
+ * to the term's display name.
+ *
+ * @return {object} `{ [filterKey]: string }`
+ */
+function buildLabelTemplateMap() {
+	const wcTypeMap = buildWcFilterTypeMap();
+	const out = {};
+	document.querySelectorAll( '[data-wp-context*="activeLabelTemplate"]' ).forEach( el => {
+		try {
+			const ctx = JSON.parse( el.getAttribute( 'data-wp-context' ) );
+			const filterKey = wcTypeMap[ ctx?.filterType ];
+			if ( filterKey && ctx.activeLabelTemplate && ! out[ filterKey ] ) {
+				out[ filterKey ] = ctx.activeLabelTemplate;
+			}
+		} catch {
+			// ignore malformed context
+		}
+	} );
+	return out;
+}
+
+/**
+ * Render one removable chip's `<li>`. Mirrors the markup in
+ * ProductFilterRemovableChips.php's PHP-rendered fallback (the
+ * `data-wp-each-child` branch — the `<template data-wp-each>` next to
+ * it is for runtime hydration which we don't get on injected nodes).
+ * Click handling uses `data-jp-*` attributes wired up by
+ * `wireChipListeners`.
+ *
+ * @param {object} chip             - Chip data.
+ * @param {string} chip.filterKey   - filterConfig key.
+ * @param {string} chip.value       - Slug being toggled off.
+ * @param {string} chip.activeLabel - Display label (e.g. "Category: Accessories").
+ * @return {string} HTML for one chip row.
+ */
+function renderChipHtml( chip ) {
+	const removeLabel = `Remove filter: ${ chip.activeLabel }`;
+	return [
+		'<li class="wc-block-product-filter-removable-chips__item">',
+		`<span class="wc-block-product-filter-removable-chips__label">${ escText(
+			chip.activeLabel
+		) }</span>`,
+		`<button type="button" class="wc-block-product-filter-removable-chips__remove" aria-label="${ escAttr(
+			removeLabel
+		) }"`,
+		` data-jp-filter-key="${ escAttr( chip.filterKey ) }"`,
+		` data-jp-filter-value="${ escAttr( chip.value ) }">`,
+		'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="25" height="25" class="wc-block-product-filter-removable-chips__remove-icon" aria-hidden="true" focusable="false">',
+		'<path d="M12 13.06l3.712 3.713 1.061-1.06L13.061 12l3.712-3.712-1.06-1.06L12 10.938 8.288 7.227l-1.061 1.06L10.939 12l-3.712 3.712 1.06 1.061L12 13.061z"></path>',
+		'</svg>',
+		`<span class="screen-reader-text">${ escText( removeLabel ) }</span>`,
+		'</button>',
+		'</li>',
+	].join( '' );
+}
+
+/**
+ * Replace removable chips in the active-filter region with chips
+ * derived from the URL state. Single delegated click listener on the
+ * host handles toggle-off via `toggleFilterAndNavigate`. Toggles the
+ * `wc-block-product-filter--hidden` class on the parent active-filter
+ * region so the wrapper itself disappears when there are no chips
+ * (mirrors what WC's `data-wp-class--hidden` directive does, which we
+ * can't rely on for injected nodes).
+ *
+ * @param {URLSearchParams} searchParams - Current URL params.
+ * @param {object}          slugLabels   - `{ [filterKey]: { [slug]: label } }` from baseline.
+ * @param {object}          templates    - `{ [filterKey]: activeLabelTemplate }` from filter regions.
+ */
+function applyChipsToActiveFilterBlock( searchParams, slugLabels, templates ) {
+	const chipHost = document.querySelector( '.wc-block-product-filter-removable-chips__items' );
+	if ( ! chipHost ) {
+		return;
+	}
+
+	const activeFilters = urlToActiveFilters( searchParams, bridgeState.filterConfigs );
+	const chips = [];
+	for ( const [ filterKey, slugs ] of Object.entries( activeFilters ) ) {
+		const template = templates[ filterKey ];
+		for ( const slug of slugs ) {
+			const label = slugLabels[ filterKey ]?.[ slug ] ?? slug;
+			const activeLabel = template ? template.replace( '{{label}}', label ) : label;
+			chips.push( { filterKey, value: slug, activeLabel } );
+		}
+	}
+
+	// Remove only existing rendered <li>s; preserve the sibling <template>
+	// element WC uses for its own hydration path.
+	chipHost
+		.querySelectorAll( 'li.wc-block-product-filter-removable-chips__item' )
+		.forEach( li => li.remove() );
+	if ( chips.length > 0 ) {
+		chipHost.insertAdjacentHTML( 'beforeend', chips.map( renderChipHtml ).join( '' ) );
+	}
+	wireChipListeners( chipHost );
+
+	const region = chipHost.closest( '.wp-block-woocommerce-product-filter-active' );
+	if ( region ) {
+		region.classList.toggle( 'wc-block-product-filter--hidden', chips.length === 0 );
+	}
+}
+
+/**
+ * Wire a single delegated click handler on the chip-host UL. Handles
+ * the "remove this filter" click on each chip's button.
+ *
+ * @param {Element} host - The chips `<ul>` host.
+ */
+function wireChipListeners( host ) {
+	if ( host.dataset.jpListenerBound === '1' ) {
+		return;
+	}
+	host.dataset.jpListenerBound = '1';
+	host.addEventListener( 'click', event => {
+		const button = event.target.closest( '.wc-block-product-filter-removable-chips__remove' );
+		if ( ! button ) {
+			return;
+		}
+		const filterKey = button.getAttribute( 'data-jp-filter-key' );
+		const filterValue = button.getAttribute( 'data-jp-filter-value' );
+		if ( filterKey && filterValue ) {
+			event.preventDefault();
+			toggleFilterAndNavigate( filterKey, filterValue );
+		}
+	} );
+}
+
+/**
  * Walk every filter region on the page that exposes a `filterType` we
  * recognize (taxonomy/* or attribute/*). For each, locate the
  * `…__items` host inside the region's checkbox-list shell and replace
@@ -357,6 +526,10 @@ function applyToFilterBlocks( scoped, unscoped, searchParams ) {
 
 	const wcTypeMap = buildWcFilterTypeMap();
 	const activeFilters = urlToActiveFilters( searchParams, bridgeState.filterConfigs );
+	const slugLabels = buildSlugLabelMap( baseline );
+	const labelTemplates = buildLabelTemplateMap();
+
+	applyChipsToActiveFilterBlock( searchParams, slugLabels, labelTemplates );
 
 	const filterRegions = document.querySelectorAll(
 		'[data-wp-interactive*="product-filters"][data-wp-context*="filterType"]'

--- a/projects/packages/search/src/woocommerce-bridge/view.js
+++ b/projects/packages/search/src/woocommerce-bridge/view.js
@@ -924,31 +924,60 @@ store( WC_NAMESPACE, {
 
 			// Mirror what WC's own navigate does: take every key it
 			// derives from context.activeFilters and write it onto the
-			// URL. WC's state.params getter already produces the right
-			// URL contract for price (min_price / max_price), status
-			// (filter_stock_status), rating (rating_filter), and
-			// attributes — we just push the result without the HTML
-			// round-trip.
+			// URL. WC's state.params getter produces scalar comma-joined
+			// values for everything; the bridge converts to array-form
+			// (`?rating_filter[]=4`) for any filterConfig that doesn't
+			// opt into `urlFormat: 'scalar'` so rating, taxonomy, and
+			// attribute keys all share the same URL contract.
 			for ( const key in params ) {
 				const value = params[ key ];
 				if ( value === undefined || value === null || value === '' ) {
 					continue;
 				}
-				const stringified = String( value );
-				if ( url.searchParams.get( key ) !== stringified ) {
-					url.searchParams.set( key, stringified );
-					changed = true;
+				const config = bridgeState?.filterConfigs?.[ key ];
+				const isArrayForm = config && config.urlFormat !== 'scalar';
+
+				if ( isArrayForm ) {
+					const arrayKey = `${ key }[]`;
+					const next = String( value )
+						.split( ',' )
+						.map( v => v.trim() )
+						.filter( Boolean );
+					const current = url.searchParams.getAll( arrayKey );
+					const same =
+						next.length === current.length && next.every( ( v, i ) => v === current[ i ] );
+					if ( ! same ) {
+						url.searchParams.delete( arrayKey );
+						for ( const v of next ) {
+							url.searchParams.append( arrayKey, v );
+						}
+						url.searchParams.delete( key );
+						changed = true;
+					}
+				} else {
+					const stringified = String( value );
+					if ( url.searchParams.get( key ) !== stringified ) {
+						url.searchParams.set( key, stringified );
+						changed = true;
+					}
 				}
 			}
 
-			// Drop any of the WC-owned scalar keys that have disappeared
-			// from state.params (user cleared a filter). The bridge owns
-			// taxonomy / attribute URL state in array form, so don't
-			// touch those — `categories=...` etc. aren't in our owned
-			// list.
+			// Drop WC-owned keys that have disappeared from state.params
+			// (user cleared a filter). Honors the same scalar/array-form
+			// distinction so we delete the right URL key shape. The
+			// bridge's own taxonomy / attribute URL state lives in array
+			// form too but isn't in WC_OWNED_PARAM_KEYS, so we never
+			// touch it here.
 			for ( const key of WC_OWNED_PARAM_KEYS ) {
-				if ( ! ( key in params ) && url.searchParams.has( key ) ) {
-					url.searchParams.delete( key );
+				if ( key in params ) {
+					continue;
+				}
+				const config = bridgeState?.filterConfigs?.[ key ];
+				const isArrayForm = config && config.urlFormat !== 'scalar';
+				const urlKey = isArrayForm ? `${ key }[]` : key;
+				if ( url.searchParams.has( urlKey ) ) {
+					url.searchParams.delete( urlKey );
 					changed = true;
 				}
 			}

--- a/projects/packages/search/src/woocommerce-bridge/view.js
+++ b/projects/packages/search/src/woocommerce-bridge/view.js
@@ -848,7 +848,13 @@ const WC_OWNED_PARAM_KEYS = [ 'min_price', 'max_price', 'rating_filter', 'filter
 
 store( WC_NAMESPACE, {
 	actions: {
-		navigate() {
+		// Must be a generator: WC's `state.params` getter calls
+		// Interactivity's `getContext()` internally and that requires the
+		// runtime's reactive scope. Regular sync/async functions break
+		// scope and throw "Cannot call getContext() when there is no
+		// scope" when the price slider triggers actions.navigate.
+		// eslint-disable-next-line require-yield -- generator solely for Interactivity scope; no async work to yield on.
+		*navigate() {
 			const params = this?.state?.params ?? {};
 			const url = new URL( window.location.href );
 

--- a/projects/packages/search/src/woocommerce-bridge/view.js
+++ b/projects/packages/search/src/woocommerce-bridge/view.js
@@ -20,9 +20,19 @@
  * inert. The native listener toggles a slug under the filter key, pushes
  * the WC-format URL, re-fetches aggregations, and re-renders.
  *
- * Out of V2 scope: price (range slider), status (in-stock / out-of-stock),
- * rating filters. Those need range/term aggregations not exposed by the
- * standard WPCOM search API and are tracked as follow-ups.
+ * Filter coverage today: taxonomy (product_cat, product_tag,
+ * product_brand), attributes (pa_*), stock status
+ * (filter_stock_status — scalar URL key, ES field
+ * `meta._stock_status.value`), active-filter removable chips driven from
+ * URL state, both display variants (checkbox-list and chips), and the
+ * price slider via the actions.navigate override.
+ *
+ * Out of scope (TODOs): rating filter (needs a range aggregation on
+ * `meta._wc_average_rating.double` plus star-bucket rendering, which
+ * requires `buildAggregations` to learn about non-`terms` aggs); i18n —
+ * stock-status labels are hardcoded English, follow-up should read them
+ * off the existing server-rendered items or seed via
+ * wp_interactivity_state.
  *
  * Runtime config (siteId, apiRoot, isPrivateSite, isWpcom, nonce, homeUrl,
  * filterConfigs) is seeded server-side via `wp_interactivity_state` under
@@ -48,18 +58,34 @@ const { state: bridgeState } = store( BRIDGE_NAMESPACE, {} );
 function buildWcFilterTypeMap() {
 	const map = {};
 	for ( const [ filterKey, cfg ] of Object.entries( bridgeState?.filterConfigs ?? {} ) ) {
-		if ( cfg.filterType !== 'taxonomy' || ! cfg.taxonomy ) {
-			continue;
-		}
-		// Built-in product taxonomies → `taxonomy/<taxonomy>`.
-		map[ `taxonomy/${ cfg.taxonomy }` ] = filterKey;
-		// pa_* attribute taxonomies are also addressed as `attribute/<short>`.
-		if ( cfg.taxonomy.startsWith( 'pa_' ) ) {
-			map[ `attribute/${ cfg.taxonomy.slice( 3 ) }` ] = filterKey;
+		if ( cfg.filterType === 'taxonomy' && cfg.taxonomy ) {
+			// Built-in product taxonomies → `taxonomy/<taxonomy>`.
+			map[ `taxonomy/${ cfg.taxonomy }` ] = filterKey;
+			// pa_* attribute taxonomies are also addressed as `attribute/<short>`.
+			if ( cfg.taxonomy.startsWith( 'pa_' ) ) {
+				map[ `attribute/${ cfg.taxonomy.slice( 3 ) }` ] = filterKey;
+			}
+		} else if ( cfg.filterType === 'wc_stock_status' ) {
+			map.status = filterKey;
 		}
 	}
 	return map;
 }
+
+/**
+ * Friendly labels for known scalar filter slugs. WC server-renders these
+ * with localized strings via `wc_get_product_stock_status_options()`,
+ * but the bridge replaces the items list at innerHTML time and ES
+ * buckets only carry the slug. Hardcoded English labels here mean
+ * status options round-trip readably; a follow-up should read the
+ * localized labels off the existing server-rendered DOM (or seed them
+ * via wp_interactivity_state) so non-English sites get translated.
+ */
+const STOCK_STATUS_LABELS = {
+	instock: 'In stock',
+	outofstock: 'Out of stock',
+	onbackorder: 'On backorder',
+};
 
 /**
  * Read URL params and produce the activeFilters shape that
@@ -77,7 +103,23 @@ function buildWcFilterTypeMap() {
  */
 function urlToActiveFilters( searchParams, filterConfigs ) {
 	const active = {};
-	for ( const key of Object.keys( filterConfigs ?? {} ) ) {
+	for ( const [ key, config ] of Object.entries( filterConfigs ?? {} ) ) {
+		// Scalar comma-joined first (e.g. WC's `?filter_stock_status=instock,outofstock`)
+		// when the filterConfig opts into that URL shape.
+		if ( config?.urlFormat === 'scalar' ) {
+			const raw = searchParams.get( key );
+			if ( raw ) {
+				const values = String( raw )
+					.split( ',' )
+					.map( v => v.trim() )
+					.filter( Boolean );
+				if ( values.length > 0 ) {
+					active[ key ] = Array.from( new Set( values ) );
+					continue;
+				}
+			}
+		}
+		// Default: array-form `?<key>[]=value`.
 		const values = searchParams
 			.getAll( `${ key }[]` )
 			.map( v => String( v ).trim() )
@@ -331,6 +373,56 @@ function renderItemHtml( item, filterKey ) {
 }
 
 /**
+ * Build a chip-variant button matching ProductFilterChips.php. Used when
+ * a filter region renders with `wc-block-product-filter-chips__items`
+ * (instead of the checkbox-list host) — the page editor lets each
+ * filter inner block opt into either display style.
+ *
+ * @param {object} item      - Item shape produced by `bucketsToItems()`.
+ * @param {string} filterKey - filterConfig key (e.g. `pa_color`).
+ * @return {string} HTML for one chip button.
+ */
+function renderChipsItemHtml( item, filterKey ) {
+	const itemId = `${ item.type }-${ item.value }`;
+
+	return [
+		`<button id="${ escAttr( itemId ) }"`,
+		` class="wc-block-product-filter-chips__item${ item.selected ? ' is-selected' : '' }"`,
+		' type="button" role="checkbox"',
+		` aria-label="${ escAttr( item.ariaLabel ?? item.label ) }"`,
+		` aria-checked="${ item.selected ? 'true' : 'false' }"`,
+		` value="${ escAttr( item.value ) }"`,
+		` data-jp-filter-key="${ escAttr( filterKey ) }"`,
+		` data-jp-filter-value="${ escAttr( item.value ) }">`,
+		'<span class="wc-block-product-filter-chips__label">',
+		`<span class="wc-block-product-filter-chips__text">${ escText( item.label ) }</span>`,
+		`<span class="wc-block-product-filter-chips__count">(${ item.count })</span>`,
+		'</span>',
+		'</button>',
+	].join( '' );
+}
+
+/**
+ * Find the items host inside a filter region — supports both display
+ * variants WC offers: checkbox-list and chips.
+ *
+ * @param {Element} region - Filter region (the parent ProductFilter* inner block
+ *                         element with the filterType context).
+ * @return {{ host: Element, kind: 'chips'|'checkbox-list' }|null} Host details, or null if none found.
+ */
+function findItemHost( region ) {
+	const cb = region.querySelector( '.wc-block-product-filter-checkbox-list__items' );
+	if ( cb ) {
+		return { host: cb, kind: 'checkbox-list' };
+	}
+	const chips = region.querySelector( '.wc-block-product-filter-chips__items' );
+	if ( chips ) {
+		return { host: chips, kind: 'chips' };
+	}
+	return null;
+}
+
+/**
  * Build a `{ [filterKey]: { [slug]: label } }` map for resolving each
  * active-filter chip's display name. Pulled from the unscoped baseline
  * because that's the only response guaranteed to contain a bucket for
@@ -352,11 +444,24 @@ function buildSlugLabelMap( unscoped ) {
 		}
 		const { bucketFormat } = resolveFilterFields( config );
 		const slugMap = {};
+
+		// For wc_stock_status, every supported slug should always render
+		// even when the unscoped baseline returns no bucket for it (e.g.
+		// brand-new sites with no out-of-stock products). Pre-seeding
+		// from the hardcoded label map guarantees the user sees the full
+		// set of options.
+		if ( config.filterType === 'wc_stock_status' ) {
+			Object.assign( slugMap, STOCK_STATUS_LABELS );
+		}
+
 		for ( const bucket of agg?.buckets ?? [] ) {
 			const rawKey = String( bucket.key ?? '' );
 			if ( bucketFormat === 'slash' && rawKey.includes( '/' ) ) {
 				const idx = rawKey.indexOf( '/' );
 				slugMap[ rawKey.slice( 0, idx ) ] = rawKey.slice( idx + 1 ) || rawKey.slice( 0, idx );
+			} else if ( config.filterType === 'wc_stock_status' && STOCK_STATUS_LABELS[ rawKey ] ) {
+				// Keep the friendly label rather than falling back to the slug.
+				slugMap[ rawKey ] = STOCK_STATUS_LABELS[ rawKey ];
 			} else {
 				slugMap[ rawKey ] = rawKey;
 			}
@@ -552,31 +657,46 @@ function applyToFilterBlocks( scoped, unscoped, searchParams ) {
 			return;
 		}
 
-		const universeBuckets = baseline[ filterKey ]?.buckets;
-		if ( ! Array.isArray( universeBuckets ) ) {
+		const found = findItemHost( region );
+		if ( ! found ) {
 			return;
 		}
-
-		const itemHost = region.querySelector( '.wc-block-product-filter-checkbox-list__items' );
-		if ( ! itemHost ) {
-			return;
-		}
+		const { host: itemHost, kind: hostKind } = found;
 		const config = bridgeState.filterConfigs[ filterKey ];
 		const selectedSlugs = new Set( activeFilters[ filterKey ] ?? [] );
-
-		// Build a slug → scoped-count map so each baseline option can show
-		// its current-scope count (defaulting to 0 when the option isn't in
-		// the scoped buckets).
 		const scopedCounts = bucketsToCountMap( scoped?.[ filterKey ]?.buckets ?? [], config );
 
-		const items = bucketsToItems( universeBuckets, config, wcFilterType, selectedSlugs ).map(
-			item => ( {
-				...item,
-				count: scopedCounts[ item.value ] ?? 0,
-			} )
-		);
-		itemHost.innerHTML = items.map( item => renderItemHtml( item, filterKey ) ).join( '' );
-		wireItemListeners( itemHost );
+		let items;
+		if ( config.filterType === 'wc_stock_status' ) {
+			// Always render the standard 3 stock-status options in
+			// conventional order, regardless of which buckets came back
+			// from ES — a brand-new site with zero out-of-stock products
+			// should still surface "Out of stock (0)" so the option
+			// remains discoverable.
+			items = [ 'instock', 'outofstock', 'onbackorder' ].map( slug => ( {
+				value: slug,
+				type: wcFilterType,
+				label: STOCK_STATUS_LABELS[ slug ],
+				count: scopedCounts[ slug ] ?? 0,
+				selected: selectedSlugs.has( slug ),
+				ariaLabel: STOCK_STATUS_LABELS[ slug ],
+			} ) );
+		} else {
+			const universeBuckets = baseline[ filterKey ]?.buckets;
+			if ( ! Array.isArray( universeBuckets ) ) {
+				return;
+			}
+			items = bucketsToItems( universeBuckets, config, wcFilterType, selectedSlugs ).map(
+				item => ( {
+					...item,
+					count: scopedCounts[ item.value ] ?? 0,
+				} )
+			);
+		}
+
+		const renderer = hostKind === 'chips' ? renderChipsItemHtml : renderItemHtml;
+		itemHost.innerHTML = items.map( item => renderer( item, filterKey ) ).join( '' );
+		wireItemListeners( itemHost, hostKind );
 	} );
 }
 
@@ -605,18 +725,36 @@ function bucketsToCountMap( buckets, filterConfig ) {
 }
 
 /**
- * Attach native change listeners to every input under `host`. Single
- * delegated listener at the host level — survives item re-renders only
- * when the host element itself stays in place (which it does, since we
- * `innerHTML` into it rather than replacing it).
+ * Attach a native delegated listener to the items host. Checkbox-list
+ * variant listens for `change` on inputs; chips variant listens for
+ * `click` on buttons. Single bound listener per host survives item
+ * re-renders since we `innerHTML` into the host without replacing it.
  *
- * @param {Element} host - The `…__items` div whose inputs to wire.
+ * @param {Element} host     - The `…__items` div whose items to wire.
+ * @param {string}  hostKind - `'checkbox-list'` or `'chips'`.
  */
-function wireItemListeners( host ) {
+function wireItemListeners( host, hostKind ) {
 	if ( host.dataset.jpListenerBound === '1' ) {
 		return;
 	}
 	host.dataset.jpListenerBound = '1';
+
+	if ( hostKind === 'chips' ) {
+		host.addEventListener( 'click', event => {
+			const button = event.target.closest( 'button[data-jp-filter-key]' );
+			if ( ! button ) {
+				return;
+			}
+			event.preventDefault();
+			const filterKey = button.getAttribute( 'data-jp-filter-key' );
+			const filterValue = button.getAttribute( 'data-jp-filter-value' );
+			if ( filterKey && filterValue ) {
+				toggleFilterAndNavigate( filterKey, filterValue );
+			}
+		} );
+		return;
+	}
+
 	host.addEventListener( 'change', event => {
 		const input = event.target;
 		if ( ! ( input instanceof HTMLInputElement ) ) {
@@ -644,17 +782,39 @@ function wireItemListeners( host ) {
  */
 async function toggleFilterAndNavigate( filterKey, filterValue ) {
 	const url = new URL( window.location.href );
-	const arrayParam = `${ filterKey }[]`;
-	const current = url.searchParams.getAll( arrayParam );
-	const idx = current.indexOf( filterValue );
-	if ( idx === -1 ) {
-		current.push( filterValue );
+	const config = bridgeState?.filterConfigs?.[ filterKey ];
+	const isScalar = config?.urlFormat === 'scalar';
+
+	if ( isScalar ) {
+		// Scalar comma-joined URL key (e.g. `?filter_stock_status=instock,outofstock`).
+		const current = ( url.searchParams.get( filterKey ) ?? '' )
+			.split( ',' )
+			.map( s => s.trim() )
+			.filter( Boolean );
+		const idx = current.indexOf( filterValue );
+		if ( idx === -1 ) {
+			current.push( filterValue );
+		} else {
+			current.splice( idx, 1 );
+		}
+		if ( current.length === 0 ) {
+			url.searchParams.delete( filterKey );
+		} else {
+			url.searchParams.set( filterKey, current.join( ',' ) );
+		}
 	} else {
-		current.splice( idx, 1 );
-	}
-	url.searchParams.delete( arrayParam );
-	for ( const value of current ) {
-		url.searchParams.append( arrayParam, value );
+		const arrayParam = `${ filterKey }[]`;
+		const current = url.searchParams.getAll( arrayParam );
+		const idx = current.indexOf( filterValue );
+		if ( idx === -1 ) {
+			current.push( filterValue );
+		} else {
+			current.splice( idx, 1 );
+		}
+		url.searchParams.delete( arrayParam );
+		for ( const value of current ) {
+			url.searchParams.append( arrayParam, value );
+		}
 	}
 
 	window.history.pushState( {}, '', url.href );

--- a/projects/packages/search/src/woocommerce-bridge/view.js
+++ b/projects/packages/search/src/woocommerce-bridge/view.js
@@ -62,9 +62,14 @@ function buildWcFilterTypeMap() {
 }
 
 /**
- * Read WC-format URL params and produce the activeFilters shape that
- * `buildSearchUrl()` expects (keyed by filterConfig key, comma-joined
- * values split into an array).
+ * Read URL params and produce the activeFilters shape that
+ * `buildSearchUrl()` expects (keyed by filterConfig key, values as array).
+ *
+ * URL format is the same array-shape pattern used by the Jetpack Search
+ * blocks (`?<filterKey>[]=value`), so a URL like
+ * `?product_cat[]=shirts&product_cat[]=pants` is interchangeable across
+ * any filter-checkbox block on the page (WC bridge or JP Search) that
+ * registers `product_cat` as a filterKey.
  *
  * @param {URLSearchParams} searchParams  - Current URL search params.
  * @param {object}          filterConfigs - Map of registered filter configs.
@@ -73,12 +78,12 @@ function buildWcFilterTypeMap() {
 function urlToActiveFilters( searchParams, filterConfigs ) {
 	const active = {};
 	for ( const key of Object.keys( filterConfigs ?? {} ) ) {
-		const raw = searchParams.get( key );
-		if ( raw ) {
-			active[ key ] = raw
-				.split( ',' )
-				.map( s => s.trim() )
-				.filter( Boolean );
+		const values = searchParams
+			.getAll( `${ key }[]` )
+			.map( v => String( v ).trim() )
+			.filter( Boolean );
+		if ( values.length > 0 ) {
+			active[ key ] = values;
 		}
 	}
 	return active;
@@ -319,29 +324,28 @@ function wireItemListeners( host ) {
 
 /**
  * Mutate the URL to toggle one filter value, then push + fetch + render.
- * Mirrors what WC's `actions.toggleFilter` would do, but driven entirely
- * from native event listeners since Interactivity directives do not
- * hydrate on injected items.
  *
- * @param {string} filterKey   - filterConfig key (e.g. `categories`).
+ * URL format follows the Jetpack Search blocks' array-shape pattern
+ * (`?<filterKey>[]=value`) — see src/search-blocks/store/url-state.js —
+ * so deep links round-trip cleanly between WC's filter UI and any
+ * JP Search filter-checkbox blocks that share filterKey naming.
+ *
+ * @param {string} filterKey   - filterConfig key (e.g. `product_cat`).
  * @param {string} filterValue - Slug being toggled.
  */
 async function toggleFilterAndNavigate( filterKey, filterValue ) {
 	const url = new URL( window.location.href );
-	const current = ( url.searchParams.get( filterKey ) ?? '' )
-		.split( ',' )
-		.map( s => s.trim() )
-		.filter( Boolean );
+	const arrayParam = `${ filterKey }[]`;
+	const current = url.searchParams.getAll( arrayParam );
 	const idx = current.indexOf( filterValue );
 	if ( idx === -1 ) {
 		current.push( filterValue );
 	} else {
 		current.splice( idx, 1 );
 	}
-	if ( current.length === 0 ) {
-		url.searchParams.delete( filterKey );
-	} else {
-		url.searchParams.set( filterKey, current.join( ',' ) );
+	url.searchParams.delete( arrayParam );
+	for ( const value of current ) {
+		url.searchParams.append( arrayParam, value );
 	}
 
 	window.history.pushState( {}, '', url.href );

--- a/projects/packages/search/src/woocommerce-bridge/view.js
+++ b/projects/packages/search/src/woocommerce-bridge/view.js
@@ -349,10 +349,13 @@ async function toggleFilterAndNavigate( filterKey, filterValue ) {
 	}
 
 	window.history.pushState( {}, '', url.href );
-	const data = await fetchAggregations( url.searchParams );
-	if ( data?.aggregations ) {
-		applyToFilterBlocks( data.aggregations, url.searchParams );
-	}
+	/*
+	 * Dispatch popstate so the `jetpack-search` store's `handlePopState`
+	 * listener (search-blocks/store/index.js) re-runs the search and the
+	 * result list reflects the new filter state. Our own popstate listener
+	 * also fires and rebuilds the filter UI from fresh aggregations.
+	 */
+	window.dispatchEvent( new PopStateEvent( 'popstate' ) );
 }
 
 // Initial hydration on every page load. Browser back/forward also fires

--- a/projects/packages/search/src/woocommerce-bridge/view.js
+++ b/projects/packages/search/src/woocommerce-bridge/view.js
@@ -67,6 +67,8 @@ function buildWcFilterTypeMap() {
 			}
 		} else if ( cfg.filterType === 'wc_stock_status' ) {
 			map.status = filterKey;
+		} else if ( cfg.filterType === 'wc_rating' ) {
+			map.rating = filterKey;
 		}
 	}
 	return map;
@@ -85,6 +87,21 @@ const STOCK_STATUS_LABELS = {
 	instock: 'In stock',
 	outofstock: 'Out of stock',
 	onbackorder: 'On backorder',
+};
+
+/**
+ * Star labels for the rating filter. WC's UI shows filled / unfilled
+ * stars; the bridge uses Unicode glyphs as a simple approximation that
+ * works without a webfont. The text is also fed into `aria-label` so
+ * screen readers get a meaningful description rather than just the
+ * star characters.
+ */
+const RATING_STAR_LABELS = {
+	1: { text: '★☆☆☆☆', aria: '1 star' },
+	2: { text: '★★☆☆☆', aria: '2 stars' },
+	3: { text: '★★★☆☆', aria: '3 stars' },
+	4: { text: '★★★★☆', aria: '4 stars' },
+	5: { text: '★★★★★', aria: '5 stars' },
 };
 
 /**
@@ -453,6 +470,11 @@ function buildSlugLabelMap( unscoped ) {
 		if ( config.filterType === 'wc_stock_status' ) {
 			Object.assign( slugMap, STOCK_STATUS_LABELS );
 		}
+		if ( config.filterType === 'wc_rating' ) {
+			for ( const [ star, meta ] of Object.entries( RATING_STAR_LABELS ) ) {
+				slugMap[ star ] = meta.text;
+			}
+		}
 
 		for ( const bucket of agg?.buckets ?? [] ) {
 			const rawKey = String( bucket.key ?? '' );
@@ -460,8 +482,9 @@ function buildSlugLabelMap( unscoped ) {
 				const idx = rawKey.indexOf( '/' );
 				slugMap[ rawKey.slice( 0, idx ) ] = rawKey.slice( idx + 1 ) || rawKey.slice( 0, idx );
 			} else if ( config.filterType === 'wc_stock_status' && STOCK_STATUS_LABELS[ rawKey ] ) {
-				// Keep the friendly label rather than falling back to the slug.
 				slugMap[ rawKey ] = STOCK_STATUS_LABELS[ rawKey ];
+			} else if ( config.filterType === 'wc_rating' && RATING_STAR_LABELS[ rawKey ] ) {
+				slugMap[ rawKey ] = RATING_STAR_LABELS[ rawKey ].text;
 			} else {
 				slugMap[ rawKey ] = rawKey;
 			}
@@ -681,6 +704,22 @@ function applyToFilterBlocks( scoped, unscoped, searchParams ) {
 				selected: selectedSlugs.has( slug ),
 				ariaLabel: STOCK_STATUS_LABELS[ slug ],
 			} ) );
+		} else if ( config.filterType === 'wc_rating' ) {
+			// Render 5..1 (highest first, mirroring how most ecommerce
+			// rating filters list options). Counts come from the range
+			// aggregation buckets keyed by '1'..'5' (see WC_RATING_RANGES
+			// in api.js).
+			items = [ '5', '4', '3', '2', '1' ].map( star => {
+				const meta = RATING_STAR_LABELS[ star ];
+				return {
+					value: star,
+					type: wcFilterType,
+					label: meta.text,
+					count: scopedCounts[ star ] ?? 0,
+					selected: selectedSlugs.has( star ),
+					ariaLabel: meta.aria,
+				};
+			} );
 		} else {
 			const universeBuckets = baseline[ filterKey ]?.buckets;
 			if ( ! Array.isArray( universeBuckets ) ) {
@@ -714,6 +753,24 @@ function bucketsToCountMap( buckets, filterConfig ) {
 	if ( ! Array.isArray( buckets ) ) {
 		return out;
 	}
+
+	// Rating uses a histogram aggregation with offset 0.5: bucket keys
+	// are 0.5/1.5/2.5/3.5/4.5 — map them to star slugs '1'..'5'. Anything
+	// outside that range (e.g. unrated products bucketing at 0 or above
+	// 5.0) we sum into the nearest star at the boundary.
+	if ( filterConfig?.filterType === 'wc_rating' ) {
+		for ( const bucket of buckets ) {
+			const numericKey = Number( bucket.key );
+			if ( ! Number.isFinite( numericKey ) ) {
+				continue;
+			}
+			const star = Math.min( 5, Math.max( 1, Math.floor( numericKey ) + 1 ) );
+			const slug = String( star );
+			out[ slug ] = ( out[ slug ] ?? 0 ) + ( Number( bucket.doc_count ) || 0 );
+		}
+		return out;
+	}
+
 	const { bucketFormat } = resolveFilterFields( filterConfig );
 	for ( const bucket of buckets ) {
 		const rawKey = String( bucket.key ?? '' );

--- a/projects/packages/search/src/woocommerce-bridge/view.js
+++ b/projects/packages/search/src/woocommerce-bridge/view.js
@@ -846,29 +846,50 @@ async function toggleFilterAndNavigate( filterKey, filterValue ) {
 const WC_NAMESPACE = 'woocommerce/product-filters';
 const WC_OWNED_PARAM_KEYS = [ 'min_price', 'max_price', 'rating_filter', 'filter_stock_status' ];
 
+/*
+ * Closure access to WC's store. The action generator uses this to read
+ * `wcState.params` rather than `this?.state?.params`; calling the
+ * getter via the closure keeps it inside the same Interactivity scope
+ * that actions are dispatched under, which is what its internal
+ * getContext() call relies on.
+ */
+const { state: wcState } = store( WC_NAMESPACE, {} );
+
 store( WC_NAMESPACE, {
 	actions: {
-		// Must be a generator: WC's `state.params` getter calls
-		// Interactivity's `getContext()` internally and that requires the
-		// runtime's reactive scope. Regular sync/async functions break
-		// scope and throw "Cannot call getContext() when there is no
-		// scope" when the price slider triggers actions.navigate.
 		// eslint-disable-next-line require-yield -- generator solely for Interactivity scope; no async work to yield on.
 		*navigate() {
-			const params = this?.state?.params ?? {};
 			const url = new URL( window.location.href );
-
+			const params = wcState.params ?? {};
 			let changed = false;
+
+			// Mirror what WC's own navigate does: take every key it
+			// derives from context.activeFilters and write it onto the
+			// URL. WC's state.params getter already produces the right
+			// URL contract for price (min_price / max_price), status
+			// (filter_stock_status), rating (rating_filter), and
+			// attributes — we just push the result without the HTML
+			// round-trip.
+			for ( const key in params ) {
+				const value = params[ key ];
+				if ( value === undefined || value === null || value === '' ) {
+					continue;
+				}
+				const stringified = String( value );
+				if ( url.searchParams.get( key ) !== stringified ) {
+					url.searchParams.set( key, stringified );
+					changed = true;
+				}
+			}
+
+			// Drop any of the WC-owned scalar keys that have disappeared
+			// from state.params (user cleared a filter). The bridge owns
+			// taxonomy / attribute URL state in array form, so don't
+			// touch those — `categories=...` etc. aren't in our owned
+			// list.
 			for ( const key of WC_OWNED_PARAM_KEYS ) {
-				const next = params[ key ];
-				const current = url.searchParams.get( key );
-				if ( next === undefined || next === null || next === '' ) {
-					if ( current !== null ) {
-						url.searchParams.delete( key );
-						changed = true;
-					}
-				} else if ( String( next ) !== current ) {
-					url.searchParams.set( key, String( next ) );
+				if ( ! ( key in params ) && url.searchParams.has( key ) ) {
+					url.searchParams.delete( key );
 					changed = true;
 				}
 			}

--- a/projects/packages/search/src/woocommerce-bridge/view.js
+++ b/projects/packages/search/src/woocommerce-bridge/view.js
@@ -494,6 +494,56 @@ async function toggleFilterAndNavigate( filterKey, filterValue ) {
 	window.dispatchEvent( new PopStateEvent( 'popstate' ) );
 }
 
+/*
+ * WC's server-rendered controls (Product Filter Price slider, plus the
+ * Status and Rating checkbox-lists when those have items) wire change
+ * handlers via `data-wp-on--*` directives that the Interactivity runtime
+ * hydrates on initial page load. They mutate `context.activeFilters` and
+ * call `actions.navigate`. Bridge owns the taxonomy/attribute URL state
+ * via `?<key>[]=` array params, but defers price / stock / rating params
+ * to whatever WC's `state.params` getter produces (since those use
+ * scalar URL keys and live entirely in WC's store).
+ *
+ * Replacing `actions.navigate` here lets us interpose on those flows:
+ * read just the WC-owned scalar params off `state.params`, merge them
+ * into the URL while preserving our array-format filter state, then
+ * pushState + dispatch popstate so the bridge's hydrate listener and
+ * the jetpack-search store's `handlePopState` both refresh.
+ */
+const WC_NAMESPACE = 'woocommerce/product-filters';
+const WC_OWNED_PARAM_KEYS = [ 'min_price', 'max_price', 'rating_filter', 'filter_stock_status' ];
+
+store( WC_NAMESPACE, {
+	actions: {
+		navigate() {
+			const params = this?.state?.params ?? {};
+			const url = new URL( window.location.href );
+
+			let changed = false;
+			for ( const key of WC_OWNED_PARAM_KEYS ) {
+				const next = params[ key ];
+				const current = url.searchParams.get( key );
+				if ( next === undefined || next === null || next === '' ) {
+					if ( current !== null ) {
+						url.searchParams.delete( key );
+						changed = true;
+					}
+				} else if ( String( next ) !== current ) {
+					url.searchParams.set( key, String( next ) );
+					changed = true;
+				}
+			}
+
+			if ( ! changed ) {
+				return;
+			}
+
+			window.history.pushState( {}, '', url.href );
+			window.dispatchEvent( new PopStateEvent( 'popstate' ) );
+		},
+	},
+} );
+
 // Initial hydration on every page load. Also fires on `popstate`
 // (browser back/forward, plus the synthetic dispatch from
 // `toggleFilterAndNavigate` after a filter click).

--- a/projects/packages/search/tests/js/search-blocks/url-state.test.js
+++ b/projects/packages/search/tests/js/search-blocks/url-state.test.js
@@ -9,12 +9,15 @@ describe( 'stateToUrlParams', () => {
 		expect( params.get( 's' ) ).toBe( 'boots' );
 	} );
 
-	it( 'omits empty search query', () => {
+	it( 'preserves empty s= so a refresh stays on the search route', () => {
+		// Dropping `s` entirely would push WP back to the front-page route on
+		// refresh after the user clears the search input.
 		const params = stateToUrlParams( {
 			searchQuery: '',
 			sortOrder: 'relevance',
 		} );
-		expect( params.has( 's' ) ).toBe( false );
+		expect( params.has( 's' ) ).toBe( true );
+		expect( params.get( 's' ) ).toBe( '' );
 	} );
 
 	it( 'serializes non-default sort order', () => {

--- a/projects/packages/search/tools/webpack.blocks.config.js
+++ b/projects/packages/search/tools/webpack.blocks.config.js
@@ -31,12 +31,19 @@ const blockViewEntries = readBlockViewEntries();
 const storeIndexPath = path.join( __dirname, '../src/search-blocks/store/index.js' );
 const storeEntries = fs.existsSync( storeIndexPath ) ? { 'store/index': storeIndexPath } : {};
 
+// WooCommerce Product Filters bridge: a non-block view module that overrides
+// woocommerce/product-filters actions at runtime. Built into the same output
+// directory as the search blocks so it can be enqueued as a script module.
+const wcBridgePath = path.join( __dirname, '../src/woocommerce-bridge/view.js' );
+const wcBridgeEntries = fs.existsSync( wcBridgePath ) ? { 'wc-bridge': wcBridgePath } : {};
+
 module.exports = {
 	mode: jetpackWebpackConfig.mode,
 	devtool: jetpackWebpackConfig.devtool,
 	entry: {
 		...storeEntries,
 		...blockViewEntries,
+		...wcBridgeEntries,
 	},
 	output: {
 		...jetpackWebpackConfig.output,


### PR DESCRIPTION
Fixes #

## Proposed changes

A bridge that drives WooCommerce's Product Filters blocks from Jetpack Search's Elasticsearch aggregations entirely on the front end. WC's existing filter blocks are unchanged in markup, styling, or block configuration; the bridge intercepts at three points (PHP bootstrap, runtime URL handling, and a JS view module) to redirect their data plane to JP Search.

**Off by default** behind `jetpack_search_woocommerce_bridge_enabled` (`__return_false`). Enable per-site:

```php
add_filter( 'jetpack_search_woocommerce_bridge_enabled', '__return_true' );
```

## How the bridge works (in detail)

### Three pieces

1. **PHP bootstrap** — `class-woocommerce-filters-bridge.php`. Detects WC + active Search module, registers a request-filter to keep WC's URL params out of WP_Query (avoids a `urlencode()` fatal on `?product_cat[]=…`), seeds runtime config (`siteId`, `apiRoot`, `isPrivateSite`, `isWpcom`, `nonce`, `homeUrl`, `filterConfigs`) into `wp_interactivity_state('jetpack-search-wc-bridge', …)`, and additively merges its filterConfigs into the existing `jetpack-search` namespace's filterConfigs so the JP Search store's URL parser also recognizes them.
2. **JS view module** — `src/woocommerce-bridge/view.js`, built into `build/search-blocks/wc-bridge.js`. Runs on every page that has the WC Product Filters block. On hydrate it fetches two ES requests in parallel — a *scoped* one for current-scope counts and an *unscoped* baseline (cached for the page lifetime) for the universe of options — then projects ES buckets into per-item DOM, populating WC's empty filter shells. Click handling on injected items uses native event listeners (Interactivity directives don't hydrate on dynamically-injected nodes). For server-rendered controls like the price slider, the bridge overrides `actions.navigate` (as a generator, since `state.params` calls `getContext()` and needs Interactivity scope) and replaces the HTML round-trip with `pushState` + a synthetic `popstate` so both the bridge and the JP Search store re-fetch.
3. **Shared search-blocks helpers** — small extensions to `src/search-blocks/store/api.js` and `url-state.js` so the same filter contracts work in the JP Search store (which renders the result list). New filterTypes: `wc_stock_status`, `wc_rating`. New URL format option: `urlFormat: 'scalar'` (for keys WC writes as `key=val,val` instead of array form — currently used only for stock status; everything else uses array-form).

### Filter coverage

| Filter | URL contract | Aggregation | Filter clause | Status |
|---|---|---|---|---|
| Categories (`product_cat`) | `?product_cat[]=…` (array) | `terms` on `taxonomy.product_cat.slug_slash_name` | `term` on `taxonomy.product_cat.slug` | ✅ |
| Tags (`product_tag`) | `?product_tag[]=…` | `terms` | `term` | ✅ |
| Brands (`product_brand`) | `?product_brand[]=…` | `terms` | `term` | ✅ |
| Attributes (`pa_*`) | `?pa_color[]=…` | `terms` on `taxonomy.pa_color.slug_slash_name` | `term` on `taxonomy.pa_color.slug` | ✅ |
| Active-filter chips | n/a (read from URL) | n/a | n/a | ✅ |
| Price slider | `?min_price=…&max_price=…` (scalar; single-value-per-bound) | n/a (no count display) | `range` on `wc.price` | ✅ |
| Rating | `?rating_filter[]=4&rating_filter[]=5` (array) | `histogram` on `meta._wc_average_rating.double` with `interval: 1, offset: 0.5` | `range` per selected star OR'd via `bool.should` | ✅ |
| Stock status | `?filter_stock_status=instock,…` (scalar — only filter still using scalar form, mirroring WC's native URL contract) | `terms` on `meta._stock_status.value.raw` | `term` on `meta._stock_status.value.raw` | ✅ |

### Two display variants

WC's filter blocks render as either checkbox-list (`<ul>` of `<li>` items with `<input type="checkbox">`) or chips (`<button class="…__chips__item">`). The bridge detects which host is present per filter region (`findItemHost`) and emits matching markup with a delegated `change` (checkbox) or `click` (chips) listener.

### "Always show all options" UX

Per typical e-commerce facets, the bridge keeps every option visible regardless of how narrow the search gets. The unscoped baseline supplies the option list (every taxonomy term that exists in the index); the scoped response supplies the count next to each option (`Red (0)` when nothing in scope matches). The unscoped fetch is cached for the page lifetime since the universe doesn't change with filter clicks.

### URL contracts in play

- **Array-form** (`?product_cat[]=shirts&product_cat[]=pants`, `?rating_filter[]=4&rating_filter[]=5`) — the default. Matches the JP Search blocks' existing pattern (see `search-blocks/store/url-state.js`) so deep links interoperate with JP Search filter-checkbox blocks on the same page.
- **Scalar comma-joined** — only `?filter_stock_status=instock,outofstock` (mirroring WC's native URL writer), and the inherently single-valued `?min_price=…&max_price=…`. Both bridge and JP Search store read scalar form via the `urlFormat: 'scalar'` filterConfig flag and fall back to array-form otherwise.

The `actions.navigate` override picks the right shape per filterConfig: WC's own `state.params` getter always produces comma-joined values, and the override splits those into one `<key>[]=…` per selection when the bridge config doesn't opt into `urlFormat: 'scalar'`.

## Pros

- **Front-end-only data plane.** No SQL clauses, no `MainQueryController` interception. Filter block items, counts, chips, and the result list are all driven by JP Search's ES index. Same correctness story as the rest of the JP Search blocks.
- **Reuses every JP Search block primitive.** `buildSearchUrl()`, `buildFilterClause()`, `urlParamsToState()` — extending those was a lot less code than maintaining a parallel WC-shaped layer would have been.
- **No fork of WooCommerce blocks.** Class names, block markup, styles, and filter-block configuration in the page editor stay exactly as WC produces them. The bridge only writes into the empty `…__items` host elements WC already emits.
- **Auth handled for free.** The same `buildSearchUrl()` routes to public WPCOM, private Jetpack (with `X-WP-Nonce`), or private WPCOM (cookie auth) — the bridge has no auth code of its own.
- **URL state interoperable with JP Search blocks.** Drop a JP Search filter-checkbox block alongside a WC Product Filter Attribute block on the same page and they share state because both read array-form URLs against the same filterConfigs registry.
- **Behind a feature flag.** Off by default, no impact on sites that don't opt in.

## Cons / trade-offs (and follow-ups)

- **First-paint mismatch on direct URL hits.** A request to `/shop/?categories=foo` lands on the page with WC's default (unfiltered) items rendered server-side; the bridge re-fetches and replaces them within ~100-300 ms after JS boots. SEO crawlers see WC's default render, not the filtered one. Same trade-off the rest of the JP Search blocks ecosystem already accepts.
- **Hardcoded English labels.** Stock-status options ("In stock", "Out of stock", "On backorder") are English-only at the moment. Localization should read from the existing server-rendered items (which already carry `wc_get_product_stock_status_options()` translations) or seed via `wp_interactivity_state`.
- **Result-list rendering still WC's.** The Product Collection block on the same page still renders products via WC's default product query. Aligning the result list with JP Search is a separate piece of work that should happen alongside the broader JP Search blocks roadmap (i.e. a real "product search results" block that renders client-side from ES).
- **Rating bucket boundaries are best-effort.** WC's UI uses `ROUND(avg_rating, 0)` to bucket products into stars. ES `range` aggregations would be a perfect fit but aren't whitelisted (`[aggs:range] is not whitelisted`); the bridge approximates this with `histogram` + `offset: 0.5`, which produces the right bucketing but means the API is being slightly stretched away from its intent. See the rating commit for the full reasoning.
- **The actions.navigate override depends on WC's internal state shape.** The override iterates `wcState.params` directly and splits its comma-joined values for keys whose filterConfig wants array-form. If a future WC release renames `state.params` or changes its key format, the bridge needs to follow.
- **No tests yet.** Filter coverage is verified manually via the live env; unit tests for the new `buildAggregations` / `buildFilterClause` branches and `bucketsToCountMap` rating path would be a good next step.

## Files

- **`src/woocommerce-bridge/class-woocommerce-filters-bridge.php`** — PHP bootstrap, request-filter, runtime config seed.
- **`src/woocommerce-bridge/view.js`** — JS view module: hydrate, item rendering, click handlers, chip rendering, actions.navigate override.
- **`src/search-blocks/store/api.js`** — `resolveFilterFields()` extensions for `wc_stock_status` / `wc_rating`, plus `buildAggregations` / `buildFilterClause` branches for the histogram + range cases.
- **`src/search-blocks/store/url-state.js`** — scalar comma-joined URL parsing fallback for filterConfigs that opt in via `urlFormat: 'scalar'`.
- **`src/search-blocks/class-search-blocks.php`** — price-range URL parsing seed for first paint.
- **`src/initializers/class-initializer.php`** — calls `WooCommerce_Filters_Bridge::init()` after Search initializes.
- **Build entry** in `tools/webpack.blocks.config.js` so `view.js` builds to `build/search-blocks/wc-bridge.js` alongside the other JP Search block view modules.

## Related product discussion / links

* (Internal scoping conversation; not a tracked Linear / P2 issue yet.)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Prerequisites:
- Site with Jetpack Search active and indexed (so the WPCOM search API has products to aggregate over)
- WooCommerce + WooCommerce Blocks active
- A page with the Product Filters block on it (the editor-side Search Page or any custom page using the block)

1. Apply the feature flag in `mu-plugins/`:
   ```php
   add_filter( 'jetpack_search_woocommerce_bridge_enabled', '__return_true' );
   ```
2. From `projects/packages/search/`: `pnpm run build-development`. Then ensure the standalone `jetpack-search` plugin's vendor copy is in sync (or that your dev setup symlinks the package).
3. Visit `/?s=` (or any search page that includes Product Filters blocks).
4. Open DevTools → Network. Two parallel calls fire to `https://public-api.wordpress.com/rest/v1.3/sites/<id>/search` (anonymous) for the bridge filter-UI fetch and the JP Search results fetch. Both should return 200.
5. Confirm:
   - Filter blocks render items (chips or checkboxes depending on display variant) for taxonomies and attributes.
   - Each option carries a count from the current scope.
   - Active-filter chips show selected filters with friendly labels ("Category: Accessories", "Color: Red").
6. Click a checkbox / chip. URL updates to the appropriate format (`?product_cat[]=accessories`, `?pa_color[]=red`, `?rating_filter[]=4`, `?filter_stock_status=instock`, etc.) without a full page reload, and both the filter UI and the result-list re-fetch with the narrower scope.
7. Drag the price slider; on release, URL gains `min_price` / `max_price` and both fetches fire again with `range` filter clauses on `wc.price`.
8. Click a star in the rating filter; URL gains `rating_filter[]=N`, both fetches carry `histogram` + range clauses on `meta._wc_average_rating.double`.
9. Toggle a stock-status option; URL gains `filter_stock_status=…`, both fetches carry a `terms` agg + `term` clause on `meta._stock_status.value.raw`, and the result list narrows to only products with that stock status.
10. Toggle the feature flag off → behavior reverts to default WC (MySQL-driven) filtering on the same page.

## Known follow-ups

- [ ] Stock-status label i18n
- [ ] Product Collection result-list rendering alignment with JP Search (separate effort)
- [ ] Unit tests for new aggregation / filter-clause branches and rating bucket conversion
