### PR TITLE
Search: keep s= in URL when search query is empty

### DIFF
--- a/projects/packages/search/changelog/fix-search-keep-s-on-empty-query
+++ b/projects/packages/search/changelog/fix-search-keep-s-on-empty-query
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks: keep `s=` in the URL when the search query is empty so a refresh stays on the search template instead of falling back to the front-page route.

--- a/projects/packages/search/src/search-blocks/store/url-state.js
+++ b/projects/packages/search/src/search-blocks/store/url-state.js
@@ -22,9 +22,10 @@ const RESERVED_PARAMS = new Set( [ 's', 'orderby' ] );
 export function stateToUrlParams( { searchQuery, sortOrder, activeFilters = {} } ) {
 	const params = new URLSearchParams();
 
-	if ( searchQuery ) {
-		params.set( 's', searchQuery );
-	}
+	// Always emit `s` (even empty) so a refresh keeps WP routed to the
+	// search template. Dropping the param entirely when the user clears
+	// the input would push the page back to the front-page route.
+	params.set( 's', searchQuery ?? '' );
 
 	if ( sortOrder && sortOrder !== DEFAULT_SORT_ORDER && VALID_SORT_ORDERS.includes( sortOrder ) ) {
 		params.set( 'orderby', sortOrder );

--- a/projects/packages/search/tests/js/search-blocks/url-state.test.js
+++ b/projects/packages/search/tests/js/search-blocks/url-state.test.js
@@ -9,12 +9,15 @@ describe( 'stateToUrlParams', () => {
 		expect( params.get( 's' ) ).toBe( 'boots' );
 	} );
 
-	it( 'omits empty search query', () => {
+	it( 'preserves empty s= so a refresh stays on the search route', () => {
+		// Dropping `s` entirely would push WP back to the front-page route on
+		// refresh after the user clears the search input.
 		const params = stateToUrlParams( {
 			searchQuery: '',
 			sortOrder: 'relevance',
 		} );
-		expect( params.has( 's' ) ).toBe( false );
+		expect( params.has( 's' ) ).toBe( true );
+		expect( params.get( 's' ) ).toBe( '' );
 	} );
 
 	it( 'serializes non-default sort order', () => {


### PR DESCRIPTION
Fixes #

## Proposed changes

\`stateToUrlParams\` was dropping \`s\` from the URL whenever \`searchQuery\` was an empty string, so clearing the search input updated history to a query-string without \`s\` at all. On refresh, WordPress routes by the absence of \`s\` and the page falls off the search template back to the front-page route.

Always emit \`s=\` (even when empty) so a refresh stays on the search route.

The unit test for the old behavior (\"omits empty search query\") is replaced with one that asserts the new contract (\"preserves empty s= so a refresh stays on the search route\").

## Related product discussion/links
* Surfaced while integrating the WC product-filters bridge — full story tracked in #48368, but this fix is independent and worth shipping on its own.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. Visit a Jetpack Search 3.0 search page (any page using the \`jetpack/search-input\` block). Type a query so the URL becomes \`?s=foo\`.
2. Clear the search input. Confirm the URL becomes \`?s=\` (with the empty value preserved), not \`/\` or a query-string without \`s\`.
3. Refresh the page. Confirm the search template still renders (no fall-back to the front-page template).

## Tests

\`pnpm test\` in \`projects/packages/search/\` — the updated url-state.test.js case passes.