### PR TITLE
Search 3.0: ARIA menu keyboard support in compact sort popover

### DIFF
--- a/projects/packages/search/changelog/search-3-aria-menu-keyboard
+++ b/projects/packages/search/changelog/search-3-aria-menu-keyboard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search 3.0: Add ARIA menu keyboard navigation to compact sort popover.

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/render.php
@@ -86,6 +86,7 @@ $checked_getters = array(
 			data-wp-bind--disabled="state.isSortTriggerDisabled"
 			aria-controls="<?php echo esc_attr( $menu_id ); ?>"
 			data-wp-on--click="actions.toggleSortPopover"
+			data-wp-on--keydown="actions.onSortTriggerKeydown"
 		>
 			<svg class="jetpack-search-sort__icon" width="18" height="18" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
 				<path fill="currentColor" d="M8 4l-4 4h3v12h2V8h3L8 4zm8 16l4-4h-3V4h-2v12h-3l4 4z"/>
@@ -109,8 +110,13 @@ $checked_getters = array(
 					role="menuitemradio"
 					class="jetpack-search-sort__menu-item"
 					value="<?php echo esc_attr( $sort_key ); ?>"
+					tabindex="-1"
+					data-wp-context='<?php echo esc_attr( wp_json_encode( array( 'sortKey' => $sort_key ), JSON_HEX_AMP | JSON_UNESCAPED_SLASHES ) ); ?>'
 					data-wp-bind--aria-checked="<?php echo esc_attr( $checked_binding ); ?>"
+					data-wp-bind--tabindex="state.sortMenuItemTabIndex"
 					data-wp-on--click="actions.selectSortOrder"
+					data-wp-on--keydown="actions.onSortMenuKeydown"
+					data-wp-watch="callbacks.focusSelectedSortMenuItem"
 				>
 					<?php echo esc_html( $option_label ); ?>
 				</button>

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/view.js
@@ -1,4 +1,4 @@
-import { store, getContext } from '@wordpress/interactivity';
+import { store, getContext, getElement } from '@wordpress/interactivity';
 import '../../store';
 import './style.scss';
 
@@ -23,6 +23,50 @@ store( NAMESPACE, {
 			const { state } = store( NAMESPACE );
 			const { sortKey } = getContext();
 			return state.sortOrder === sortKey;
+		},
+
+		/**
+		 * Roving-tabindex value for a sort-popover menu item. Implements
+		 * the ARIA menu keyboard pattern: only one item is in the tab
+		 * order at a time — the active descendant — so Tab leaves the
+		 * menu rather than cycling every option. Active descendant is
+		 * `state.sortMenuFocusedKey` once the user has navigated with the
+		 * keyboard, and falls back to the currently selected
+		 * `state.sortOrder` so the menu opens with focus on the active
+		 * sort.
+		 *
+		 * @return {string} `"0"` when this item is the active descendant,
+		 *   `"-1"` otherwise.
+		 */
+		get sortMenuItemTabIndex() {
+			const { state } = store( NAMESPACE );
+			const { sortKey } = getContext();
+			const active = state.sortMenuFocusedKey ?? state.sortOrder;
+			return active === sortKey ? '0' : '-1';
+		},
+	},
+	callbacks: {
+		/**
+		 * Move keyboard focus onto the active sort menu item when it
+		 * becomes the roving-tabindex target. Runs from a `data-wp-watch`
+		 * on each menu item, so re-fires whenever `sortMenuItemTabIndex`
+		 * flips. Gated on `state.isSortPopoverOpen` so we don't pull
+		 * focus into a hidden menu and on `sortMenuFocusedKey` so the
+		 * focus only moves after explicit keyboard interaction — opening
+		 * the popover with the mouse leaves focus on whatever the user
+		 * was clicking.
+		 */
+		focusSelectedSortMenuItem() {
+			const { state } = store( NAMESPACE );
+			if ( ! state.isSortPopoverOpen || state.sortMenuFocusedKey === null ) {
+				return;
+			}
+			const { sortKey } = getContext();
+			if ( sortKey !== state.sortMenuFocusedKey ) {
+				return;
+			}
+			const { ref } = getElement();
+			ref?.focus?.();
 		},
 	},
 	actions: {

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/view.js
@@ -35,8 +35,7 @@ store( NAMESPACE, {
 		 * `state.sortOrder` so the menu opens with focus on the active
 		 * sort.
 		 *
-		 * @return {string} `"0"` when this item is the active descendant,
-		 *   `"-1"` otherwise.
+		 * @return {string} `"0"` when this item is the active descendant, `"-1"` otherwise.
 		 */
 		get sortMenuItemTabIndex() {
 			const { state } = store( NAMESPACE );

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -1,4 +1,4 @@
-import { store } from '@wordpress/interactivity';
+import { store, withSyncEvent as originalWithSyncEvent } from '@wordpress/interactivity';
 import { buildSearchUrl } from './api';
 import { isEventInsidePopoverRoot } from './popover-events';
 import { countActiveFilters, normalizeResult } from './result-utils';
@@ -11,6 +11,17 @@ import { pushStateToUrl, readStateFromUrl } from './url-state';
 
 const NAMESPACE = 'jetpack-search';
 let initialized = false;
+
+// `withSyncEvent` opts an action into reading synchronous event APIs
+// (`event.currentTarget`, `event.preventDefault()`) without the
+// "synchronous event access" deprecation warning the Interactivity API
+// will turn into a hard error in WordPress 7.0. Falls back to a noop
+// wrapper on older runtimes (pre-WP 6.7) so the package still loads.
+const withSyncEvent =
+	originalWithSyncEvent ||
+	( cb =>
+		( ...args ) =>
+			cb( ...args ) );
 // Monotonic token used to drop stale async result responses. Incremented on
 // every new search; in-flight responses compare their token against the
 // latest before touching store state, so a slow request for an older query
@@ -437,7 +448,7 @@ const { state, actions } = store( NAMESPACE, {
 		 *
 		 * @param {KeyboardEvent} event - Keydown event on the trigger.
 		 */
-		onSortTriggerKeydown( event ) {
+		onSortTriggerKeydown: withSyncEvent( event => {
 			const key = event?.key;
 			if ( key !== 'ArrowDown' && key !== 'ArrowUp' && key !== 'Enter' && key !== ' ' ) {
 				return;
@@ -452,7 +463,7 @@ const { state, actions } = store( NAMESPACE, {
 				return;
 			}
 			state.sortMenuFocusedKey = key === 'ArrowUp' ? options[ options.length - 1 ] : options[ 0 ];
-		},
+		} ),
 
 		/**
 		 * Implements the ARIA menu keyboard pattern for the sort popover:
@@ -466,10 +477,13 @@ const { state, actions } = store( NAMESPACE, {
 		 * @param {KeyboardEvent} event - Keydown event on a menu item.
 		 * @yield {Promise} Optional search action when Enter/Space activates.
 		 */
-		*onSortMenuKeydown( event ) {
+		onSortMenuKeydown: withSyncEvent( function* ( event ) {
 			const key = event?.key;
-			const options = getSortMenuOptionKeysFromItem( event?.currentTarget );
-			const currentValue = event?.currentTarget?.value ?? null;
+			if ( key === 'Tab' ) {
+				state.isSortPopoverOpen = false;
+				state.sortMenuFocusedKey = null;
+				return;
+			}
 			if ( key === 'Escape' ) {
 				event.preventDefault();
 				state.isSortPopoverOpen = false;
@@ -477,47 +491,50 @@ const { state, actions } = store( NAMESPACE, {
 				focusSortTrigger( event.currentTarget );
 				return;
 			}
-			if ( key === 'Tab' ) {
-				state.isSortPopoverOpen = false;
-				state.sortMenuFocusedKey = null;
-				return;
-			}
 			if ( key === 'Enter' || key === ' ' ) {
 				event.preventDefault();
-				yield* actions.selectSortOrder( event );
-				focusSortTrigger( event.currentTarget );
+				const item = event.currentTarget;
+				const next = item?.value;
+				const shouldSearch = !! next && next !== state.sortOrder;
+				if ( shouldSearch ) {
+					state.sortOrder = next;
+				}
+				state.isSortPopoverOpen = false;
+				state.sortMenuFocusedKey = null;
+				focusSortTrigger( item );
+				if ( shouldSearch ) {
+					yield actions.search();
+				}
+				return;
+			}
+			const options = getSortMenuOptionKeysFromItem( event?.currentTarget );
+			if ( options.length === 0 ) {
 				return;
 			}
 			if ( key === 'Home' ) {
 				event.preventDefault();
-				if ( options.length > 0 ) {
-					state.sortMenuFocusedKey = options[ 0 ];
-				}
+				state.sortMenuFocusedKey = options[ 0 ];
 				return;
 			}
 			if ( key === 'End' ) {
 				event.preventDefault();
-				if ( options.length > 0 ) {
-					state.sortMenuFocusedKey = options[ options.length - 1 ];
-				}
+				state.sortMenuFocusedKey = options[ options.length - 1 ];
 				return;
 			}
 			if ( key === 'ArrowDown' || key === 'ArrowUp' ) {
 				event.preventDefault();
-				if ( options.length === 0 ) {
-					return;
-				}
+				const currentValue = event?.currentTarget?.value ?? null;
 				const currentIndex = currentValue ? options.indexOf( currentValue ) : -1;
 				const delta = key === 'ArrowDown' ? 1 : -1;
-				const nextIndex =
-					currentIndex < 0
-						? key === 'ArrowDown'
-							? 0
-							: options.length - 1
-						: ( currentIndex + delta + options.length ) % options.length;
+				let nextIndex;
+				if ( currentIndex < 0 ) {
+					nextIndex = key === 'ArrowDown' ? 0 : options.length - 1;
+				} else {
+					nextIndex = ( currentIndex + delta + options.length ) % options.length;
+				}
 				state.sortMenuFocusedKey = options[ nextIndex ];
 			}
-		},
+		} ),
 
 		/**
 		 * Close any open popover when clicking outside it. Bound to

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -553,6 +553,7 @@ const { state, actions } = store( NAMESPACE, {
 			}
 			state.isFilterPopoverOpen = false;
 			state.isSortPopoverOpen = false;
+			state.sortMenuFocusedKey = null;
 		},
 
 		/**
@@ -567,6 +568,7 @@ const { state, actions } = store( NAMESPACE, {
 			if ( state.isFilterPopoverOpen || state.isSortPopoverOpen ) {
 				state.isFilterPopoverOpen = false;
 				state.isSortPopoverOpen = false;
+				state.sortMenuFocusedKey = null;
 			}
 		},
 	},

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -2,6 +2,11 @@ import { store } from '@wordpress/interactivity';
 import { buildSearchUrl } from './api';
 import { isEventInsidePopoverRoot } from './popover-events';
 import { countActiveFilters, normalizeResult } from './result-utils';
+import {
+	focusSortTrigger,
+	getSortMenuOptionKeysFromItem,
+	getSortMenuOptionKeysFromTrigger,
+} from './sort-menu-dom';
 import { pushStateToUrl, readStateFromUrl } from './url-state';
 
 const NAMESPACE = 'jetpack-search';
@@ -48,6 +53,13 @@ const { state, actions } = store( NAMESPACE, {
 		// other when opening this one.
 		isFilterPopoverOpen: false,
 		isSortPopoverOpen: false,
+
+		// Roving-tabindex state for the sort popover's ARIA menu. Tracks
+		// which menu item is the active descendant for keyboard
+		// navigation; `null` (or a key not present in the rendered menu)
+		// means the menu hasn't been keyboard-engaged yet, in which case
+		// the currently checked option becomes the implicit default.
+		sortMenuFocusedKey: null,
 
 		/**
 		 * Short human-readable results count for display blocks. Doubles
@@ -375,11 +387,15 @@ const { state, actions } = store( NAMESPACE, {
 
 		/**
 		 * Toggle the sort popover. Closes the filter popover if it's open.
+		 * Resets the menu's roving-tabindex state on close so the next
+		 * open starts focus on the active sort.
 		 */
 		toggleSortPopover() {
 			state.isSortPopoverOpen = ! state.isSortPopoverOpen;
 			if ( state.isSortPopoverOpen ) {
 				state.isFilterPopoverOpen = false;
+			} else {
+				state.sortMenuFocusedKey = null;
 			}
 		},
 
@@ -389,6 +405,7 @@ const { state, actions } = store( NAMESPACE, {
 		closeAllPopovers() {
 			state.isFilterPopoverOpen = false;
 			state.isSortPopoverOpen = false;
+			state.sortMenuFocusedKey = null;
 		},
 
 		/**
@@ -402,11 +419,104 @@ const { state, actions } = store( NAMESPACE, {
 			const next = event?.currentTarget?.value;
 			if ( ! next || next === state.sortOrder ) {
 				state.isSortPopoverOpen = false;
+				state.sortMenuFocusedKey = null;
 				return;
 			}
 			state.sortOrder = next;
 			state.isSortPopoverOpen = false;
+			state.sortMenuFocusedKey = null;
 			yield actions.search();
+		},
+
+		/**
+		 * Open the sort popover from the trigger via ArrowDown/ArrowUp/Enter
+		 * /Space, focusing the first or last menu item to match the ARIA
+		 * menu-button keyboard pattern. Tab is intentionally left to the
+		 * browser so users can step past the trigger without entering the
+		 * menu — same behavior as the WAI-ARIA APG menu-button example.
+		 *
+		 * @param {KeyboardEvent} event - Keydown event on the trigger.
+		 */
+		onSortTriggerKeydown( event ) {
+			const key = event?.key;
+			if ( key !== 'ArrowDown' && key !== 'ArrowUp' && key !== 'Enter' && key !== ' ' ) {
+				return;
+			}
+			event.preventDefault();
+			if ( ! state.isSortPopoverOpen ) {
+				state.isSortPopoverOpen = true;
+				state.isFilterPopoverOpen = false;
+			}
+			const options = getSortMenuOptionKeysFromTrigger( event.currentTarget );
+			if ( options.length === 0 ) {
+				return;
+			}
+			state.sortMenuFocusedKey = key === 'ArrowUp' ? options[ options.length - 1 ] : options[ 0 ];
+		},
+
+		/**
+		 * Implements the ARIA menu keyboard pattern for the sort popover:
+		 * roving tabindex with ArrowUp/ArrowDown wrapping, Home/End to
+		 * jump to ends, Enter/Space to activate, Escape to close and
+		 * return focus to the trigger, and Tab to leave the menu (handled
+		 * by letting the browser's default focus order continue while we
+		 * close the popover so the focus ring lands on the next focusable
+		 * sibling rather than skipping back into a hidden menu item).
+		 *
+		 * @param {KeyboardEvent} event - Keydown event on a menu item.
+		 * @yield {Promise} Optional search action when Enter/Space activates.
+		 */
+		*onSortMenuKeydown( event ) {
+			const key = event?.key;
+			const options = getSortMenuOptionKeysFromItem( event?.currentTarget );
+			const currentValue = event?.currentTarget?.value ?? null;
+			if ( key === 'Escape' ) {
+				event.preventDefault();
+				state.isSortPopoverOpen = false;
+				state.sortMenuFocusedKey = null;
+				focusSortTrigger( event.currentTarget );
+				return;
+			}
+			if ( key === 'Tab' ) {
+				state.isSortPopoverOpen = false;
+				state.sortMenuFocusedKey = null;
+				return;
+			}
+			if ( key === 'Enter' || key === ' ' ) {
+				event.preventDefault();
+				yield* actions.selectSortOrder( event );
+				focusSortTrigger( event.currentTarget );
+				return;
+			}
+			if ( key === 'Home' ) {
+				event.preventDefault();
+				if ( options.length > 0 ) {
+					state.sortMenuFocusedKey = options[ 0 ];
+				}
+				return;
+			}
+			if ( key === 'End' ) {
+				event.preventDefault();
+				if ( options.length > 0 ) {
+					state.sortMenuFocusedKey = options[ options.length - 1 ];
+				}
+				return;
+			}
+			if ( key === 'ArrowDown' || key === 'ArrowUp' ) {
+				event.preventDefault();
+				if ( options.length === 0 ) {
+					return;
+				}
+				const currentIndex = currentValue ? options.indexOf( currentValue ) : -1;
+				const delta = key === 'ArrowDown' ? 1 : -1;
+				const nextIndex =
+					currentIndex < 0
+						? key === 'ArrowDown'
+							? 0
+							: options.length - 1
+						: ( currentIndex + delta + options.length ) % options.length;
+				state.sortMenuFocusedKey = options[ nextIndex ];
+			}
 		},
 
 		/**

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -441,10 +441,13 @@ const { state, actions } = store( NAMESPACE, {
 
 		/**
 		 * Open the sort popover from the trigger via ArrowDown/ArrowUp/Enter
-		 * /Space, focusing the first or last menu item to match the ARIA
-		 * menu-button keyboard pattern. Tab is intentionally left to the
-		 * browser so users can step past the trigger without entering the
-		 * menu — same behavior as the WAI-ARIA APG menu-button example.
+		 * /Space and move focus into the menu. Anchors focus on the active
+		 * sort (the checked menuitemradio) — matches the radio-menu pattern
+		 * where reopening returns to the selected option rather than
+		 * snapping back to the top. Falls back to the first/last item only
+		 * when the active sort isn't in the rendered list. Tab is left to
+		 * the browser so users can step past the trigger without entering
+		 * the menu, matching the WAI-ARIA APG menu-button example.
 		 *
 		 * @param {KeyboardEvent} event - Keydown event on the trigger.
 		 */
@@ -460,6 +463,10 @@ const { state, actions } = store( NAMESPACE, {
 			}
 			const options = getSortMenuOptionKeysFromTrigger( event.currentTarget );
 			if ( options.length === 0 ) {
+				return;
+			}
+			if ( options.includes( state.sortOrder ) ) {
+				state.sortMenuFocusedKey = state.sortOrder;
 				return;
 			}
 			state.sortMenuFocusedKey = key === 'ArrowUp' ? options[ options.length - 1 ] : options[ 0 ];

--- a/projects/packages/search/src/search-blocks/store/sort-menu-dom.js
+++ b/projects/packages/search/src/search-blocks/store/sort-menu-dom.js
@@ -1,0 +1,82 @@
+/**
+ * Tiny DOM helpers used by the sort-popover ARIA menu keyboard handlers.
+ *
+ * The store's roving-tabindex code needs the ordered list of currently
+ * rendered sort keys so it can wrap arrow-key navigation. The list is the
+ * server-rendered `availableSortOptions` and isn't shipped through
+ * Interactivity state — pulling it off the live menu DOM keeps server and
+ * client in sync without duplicating the data, and matches the rest of the
+ * sort block which already drives selection from the DOM (`event.currentTarget.value`).
+ */
+
+const MENU_SELECTOR = '.jetpack-search-sort__menu';
+const ITEM_SELECTOR = '.jetpack-search-sort__menu-item';
+const TRIGGER_SELECTOR = '.jetpack-search-sort__trigger';
+const POPOVER_ROOT_SELECTOR = '[data-jetpack-search-popover-root]';
+
+/**
+ * Read the rendered sort keys from a menu element in DOM order. The
+ * server emits one button per `availableSortOptions` entry and never
+ * mutates that list, so reading `value` straight off the buttons is
+ * a stable contract.
+ *
+ * @param {Element|null} menu - The menu container.
+ * @return {string[]} Ordered sort keys, or an empty array when missing.
+ */
+function readMenuOptionKeys( menu ) {
+	if ( ! menu ) {
+		return [];
+	}
+	const items = menu.querySelectorAll( ITEM_SELECTOR );
+	return Array.from( items, item => item.value ).filter( Boolean );
+}
+
+/**
+ * Resolve the ordered sort keys when a menu item dispatched an event.
+ * Walks up to the menu container and reads its children — handles the
+ * case where the rendered options differ from the default base keys.
+ *
+ * @param {Element|null} menuItem - The menu-item button.
+ * @return {string[]} Ordered sort keys.
+ */
+export function getSortMenuOptionKeysFromItem( menuItem ) {
+	if ( ! menuItem ) {
+		return [];
+	}
+	const menu = menuItem.closest?.( MENU_SELECTOR );
+	return readMenuOptionKeys( menu );
+}
+
+/**
+ * Resolve the ordered sort keys from the trigger button's popover root.
+ * The trigger and menu share the same `[data-jetpack-search-popover-root]`
+ * wrapper — find that, then locate the menu inside it.
+ *
+ * @param {Element|null} trigger - The trigger button.
+ * @return {string[]} Ordered sort keys.
+ */
+export function getSortMenuOptionKeysFromTrigger( trigger ) {
+	if ( ! trigger ) {
+		return [];
+	}
+	const root = trigger.closest?.( POPOVER_ROOT_SELECTOR );
+	const menu = root?.querySelector?.( MENU_SELECTOR );
+	return readMenuOptionKeys( menu );
+}
+
+/**
+ * Move focus back to the sort trigger when closing the menu via Escape
+ * or after activating an item. Called with any element inside the popover
+ * root (trigger or menu item) so we can locate the trigger reliably even
+ * when the menu has already been hidden.
+ *
+ * @param {Element|null} elementInRoot - Any element inside the popover root.
+ */
+export function focusSortTrigger( elementInRoot ) {
+	if ( ! elementInRoot ) {
+		return;
+	}
+	const root = elementInRoot.closest?.( POPOVER_ROOT_SELECTOR );
+	const trigger = root?.querySelector?.( TRIGGER_SELECTOR );
+	trigger?.focus?.();
+}

--- a/projects/packages/search/tests/js/search-blocks/sort-control-view.test.js
+++ b/projects/packages/search/tests/js/search-blocks/sort-control-view.test.js
@@ -2,8 +2,10 @@
 const captured = {
 	state: {},
 	actions: {},
+	callbacks: {},
 };
 const contextRef = { current: { sortKey: '' } };
+const elementRef = { current: { ref: null } };
 
 jest.mock(
 	'@wordpress/interactivity',
@@ -20,10 +22,12 @@ jest.mock(
 					}
 				}
 				Object.assign( captured.actions, config.actions || {} );
+				Object.assign( captured.callbacks, config.callbacks || {} );
 			}
 			return { state: captured.state, actions: captured.actions };
 		},
 		getContext: () => contextRef.current,
+		getElement: () => elementRef.current,
 	} ),
 	{ virtual: true }
 );
@@ -38,7 +42,10 @@ require( '../../../src/search-blocks/blocks/sort-control/view' );
 describe( 'sort-control view store', () => {
 	beforeEach( () => {
 		captured.state.sortOrder = 'relevance';
+		captured.state.sortMenuFocusedKey = null;
+		captured.state.isSortPopoverOpen = false;
 		contextRef.current = { sortKey: '' };
+		elementRef.current = { ref: null };
 	} );
 
 	it( 'returns true from isSortOptionSelected when the radio key matches the active sort', () => {
@@ -63,5 +70,72 @@ describe( 'sort-control view store', () => {
 		expect( search ).toHaveBeenCalledTimes( 1 );
 		expect( step.done ).toBe( false );
 		expect( generator.next().done ).toBe( true );
+	} );
+
+	describe( 'sortMenuItemTabIndex', () => {
+		it( 'returns "0" for the active sort item when no key is keyboard-focused', () => {
+			captured.state.sortOrder = 'newest';
+			captured.state.sortMenuFocusedKey = null;
+			contextRef.current = { sortKey: 'newest' };
+			expect( captured.state.sortMenuItemTabIndex ).toBe( '0' );
+		} );
+
+		it( 'returns "-1" for inactive items when no key is keyboard-focused', () => {
+			captured.state.sortOrder = 'newest';
+			captured.state.sortMenuFocusedKey = null;
+			contextRef.current = { sortKey: 'oldest' };
+			expect( captured.state.sortMenuItemTabIndex ).toBe( '-1' );
+		} );
+
+		it( 'prefers sortMenuFocusedKey over sortOrder once the user navigates the menu', () => {
+			captured.state.sortOrder = 'newest';
+			captured.state.sortMenuFocusedKey = 'oldest';
+			contextRef.current = { sortKey: 'oldest' };
+			expect( captured.state.sortMenuItemTabIndex ).toBe( '0' );
+			contextRef.current = { sortKey: 'newest' };
+			expect( captured.state.sortMenuItemTabIndex ).toBe( '-1' );
+		} );
+	} );
+
+	describe( 'focusSelectedSortMenuItem callback', () => {
+		it( 'focuses the menu item when it matches the keyboard-focused key', () => {
+			const focus = jest.fn();
+			captured.state.isSortPopoverOpen = true;
+			captured.state.sortMenuFocusedKey = 'newest';
+			contextRef.current = { sortKey: 'newest' };
+			elementRef.current = { ref: { focus } };
+			captured.callbacks.focusSelectedSortMenuItem();
+			expect( focus ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'does nothing when the popover is closed', () => {
+			const focus = jest.fn();
+			captured.state.isSortPopoverOpen = false;
+			captured.state.sortMenuFocusedKey = 'newest';
+			contextRef.current = { sortKey: 'newest' };
+			elementRef.current = { ref: { focus } };
+			captured.callbacks.focusSelectedSortMenuItem();
+			expect( focus ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does nothing when no key is keyboard-focused (mouse-opened menu)', () => {
+			const focus = jest.fn();
+			captured.state.isSortPopoverOpen = true;
+			captured.state.sortMenuFocusedKey = null;
+			contextRef.current = { sortKey: 'newest' };
+			elementRef.current = { ref: { focus } };
+			captured.callbacks.focusSelectedSortMenuItem();
+			expect( focus ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does nothing on items that are not the keyboard-focused key', () => {
+			const focus = jest.fn();
+			captured.state.isSortPopoverOpen = true;
+			captured.state.sortMenuFocusedKey = 'newest';
+			contextRef.current = { sortKey: 'oldest' };
+			elementRef.current = { ref: { focus } };
+			captured.callbacks.focusSelectedSortMenuItem();
+			expect( focus ).not.toHaveBeenCalled();
+		} );
 	} );
 } );

--- a/projects/packages/search/tests/js/search-blocks/sort-menu-keyboard.test.js
+++ b/projects/packages/search/tests/js/search-blocks/sort-menu-keyboard.test.js
@@ -44,7 +44,7 @@ require( '../../../src/search-blocks/store' );
  * read the available sort keys and walk the structure to refocus the
  * trigger after closing.
  *
- * @return {{root: HTMLElement, trigger: HTMLElement, items: HTMLButtonElement[]}}
+ * @return {{root: HTMLElement, trigger: HTMLElement, items: HTMLButtonElement[]}} Popover refs.
  */
 function buildPopoverDom() {
 	document.body.innerHTML = `
@@ -72,7 +72,7 @@ function buildPopoverDom() {
  *
  * @param {string}      key           - KeyboardEvent.key value.
  * @param {HTMLElement} currentTarget - Element the handler is bound to.
- * @return {{key: string, currentTarget: HTMLElement, preventDefault: jest.Mock}}
+ * @return {{key: string, currentTarget: HTMLElement, preventDefault: jest.Mock}} Synthetic event.
  */
 function makeKeydown( key, currentTarget ) {
 	return {
@@ -88,7 +88,7 @@ describe( 'sort popover keyboard navigation', () => {
 		captured.state.sortMenuFocusedKey = null;
 		captured.state.isSortPopoverOpen = false;
 		captured.state.isFilterPopoverOpen = false;
-		captured.actions.search = jest.fn();
+		jest.spyOn( captured.actions, 'search' ).mockImplementation( () => {} );
 	} );
 
 	describe( 'onSortTriggerKeydown', () => {
@@ -190,7 +190,8 @@ describe( 'sort popover keyboard navigation', () => {
 
 		it( 'closes the popover and refocuses the trigger on Escape', () => {
 			const { trigger, items } = buildPopoverDom();
-			const triggerFocus = jest.spyOn( trigger, 'focus' );
+			const triggerFocus = jest.fn();
+			trigger.focus = triggerFocus;
 			captured.state.isSortPopoverOpen = true;
 			captured.state.sortMenuFocusedKey = 'newest';
 			const event = makeKeydown( 'Escape', items[ 1 ] );
@@ -220,7 +221,8 @@ describe( 'sort popover keyboard navigation', () => {
 
 		it( 'activates the focused item on Enter, closes the popover, and refocuses the trigger', () => {
 			const { trigger, items } = buildPopoverDom();
-			const triggerFocus = jest.spyOn( trigger, 'focus' );
+			const triggerFocus = jest.fn();
+			trigger.focus = triggerFocus;
 			captured.state.isSortPopoverOpen = true;
 			captured.state.sortMenuFocusedKey = 'newest';
 			captured.state.sortOrder = 'relevance';

--- a/projects/packages/search/tests/js/search-blocks/sort-menu-keyboard.test.js
+++ b/projects/packages/search/tests/js/search-blocks/sort-menu-keyboard.test.js
@@ -92,24 +92,42 @@ describe( 'sort popover keyboard navigation', () => {
 	} );
 
 	describe( 'onSortTriggerKeydown', () => {
-		it( 'opens the popover and focuses the first item on ArrowDown', () => {
+		it( 'opens the popover and anchors focus on the active sort for ArrowDown', () => {
+			captured.state.sortOrder = 'newest';
 			const { trigger } = buildPopoverDom();
 			const event = makeKeydown( 'ArrowDown', trigger );
 			captured.actions.onSortTriggerKeydown( event );
 			expect( event.preventDefault ).toHaveBeenCalled();
 			expect( captured.state.isSortPopoverOpen ).toBe( true );
-			expect( captured.state.sortMenuFocusedKey ).toBe( 'relevance' );
+			expect( captured.state.sortMenuFocusedKey ).toBe( 'newest' );
 		} );
 
-		it( 'opens the popover and focuses the last item on ArrowUp', () => {
+		it( 'opens the popover and anchors focus on the active sort for ArrowUp', () => {
+			captured.state.sortOrder = 'newest';
 			const { trigger } = buildPopoverDom();
 			const event = makeKeydown( 'ArrowUp', trigger );
 			captured.actions.onSortTriggerKeydown( event );
 			expect( captured.state.isSortPopoverOpen ).toBe( true );
+			expect( captured.state.sortMenuFocusedKey ).toBe( 'newest' );
+		} );
+
+		it( 'falls back to the first item on ArrowDown when the active sort is not rendered', () => {
+			captured.state.sortOrder = 'unavailable';
+			const { trigger } = buildPopoverDom();
+			const event = makeKeydown( 'ArrowDown', trigger );
+			captured.actions.onSortTriggerKeydown( event );
+			expect( captured.state.sortMenuFocusedKey ).toBe( 'relevance' );
+		} );
+
+		it( 'falls back to the last item on ArrowUp when the active sort is not rendered', () => {
+			captured.state.sortOrder = 'unavailable';
+			const { trigger } = buildPopoverDom();
+			const event = makeKeydown( 'ArrowUp', trigger );
+			captured.actions.onSortTriggerKeydown( event );
 			expect( captured.state.sortMenuFocusedKey ).toBe( 'oldest' );
 		} );
 
-		it( 'opens the popover on Enter without changing focused key when already open', () => {
+		it( 'opens the popover on Enter and anchors focus on the active sort', () => {
 			const { trigger } = buildPopoverDom();
 			const event = makeKeydown( 'Enter', trigger );
 			captured.actions.onSortTriggerKeydown( event );

--- a/projects/packages/search/tests/js/search-blocks/sort-menu-keyboard.test.js
+++ b/projects/packages/search/tests/js/search-blocks/sort-menu-keyboard.test.js
@@ -1,0 +1,286 @@
+/**
+ * Tests for the sort-popover ARIA-menu keyboard navigation actions in the
+ * shared `jetpack-search` store. The store is exercised through the same
+ * `@wordpress/interactivity` mock used by `sort-control-view.test.js`: the
+ * mocked `store()` collects the registered state/actions, and the tests
+ * drive the captured actions directly with synthetic events.
+ */
+
+const captured = {
+	state: {},
+	actions: {},
+};
+
+jest.mock(
+	'@wordpress/interactivity',
+	() => ( {
+		store: ( _namespace, config ) => {
+			if ( config ) {
+				const stateConfig = config.state || {};
+				const descriptors = Object.getOwnPropertyDescriptors( stateConfig );
+				for ( const key of Object.keys( descriptors ) ) {
+					const descriptor = descriptors[ key ];
+					if ( typeof descriptor.get === 'function' ) {
+						Object.defineProperty( captured.state, key, descriptor );
+					} else {
+						captured.state[ key ] = descriptor.value;
+					}
+				}
+				Object.assign( captured.actions, config.actions || {} );
+			}
+			return { state: captured.state, actions: captured.actions };
+		},
+		getContext: () => ( {} ),
+		getElement: () => ( { ref: null } ),
+	} ),
+	{ virtual: true }
+);
+
+require( '../../../src/search-blocks/store' );
+
+/**
+ * Build a minimal popover DOM with the trigger and the rendered menu
+ * items (`relevance`, `newest`, `oldest`) so the keyboard handlers can
+ * read the available sort keys and walk the structure to refocus the
+ * trigger after closing.
+ *
+ * @return {{root: HTMLElement, trigger: HTMLElement, items: HTMLButtonElement[]}}
+ */
+function buildPopoverDom() {
+	document.body.innerHTML = `
+		<div data-jetpack-search-popover-root>
+			<button class="jetpack-search-sort__trigger" type="button"></button>
+			<div class="jetpack-search-sort__menu" role="menu">
+				<button class="jetpack-search-sort__menu-item" type="button" value="relevance"></button>
+				<button class="jetpack-search-sort__menu-item" type="button" value="newest"></button>
+				<button class="jetpack-search-sort__menu-item" type="button" value="oldest"></button>
+			</div>
+		</div>
+	`;
+	const root = document.querySelector( '[data-jetpack-search-popover-root]' );
+	return {
+		root,
+		trigger: root.querySelector( '.jetpack-search-sort__trigger' ),
+		items: Array.from( root.querySelectorAll( '.jetpack-search-sort__menu-item' ) ),
+	};
+}
+
+/**
+ * Build a synthetic keyboard event with a matching `currentTarget` and
+ * a Jest spy on `preventDefault`, mirroring what Interactivity passes
+ * into action handlers.
+ *
+ * @param {string}      key           - KeyboardEvent.key value.
+ * @param {HTMLElement} currentTarget - Element the handler is bound to.
+ * @return {{key: string, currentTarget: HTMLElement, preventDefault: jest.Mock}}
+ */
+function makeKeydown( key, currentTarget ) {
+	return {
+		key,
+		currentTarget,
+		preventDefault: jest.fn(),
+	};
+}
+
+describe( 'sort popover keyboard navigation', () => {
+	beforeEach( () => {
+		captured.state.sortOrder = 'relevance';
+		captured.state.sortMenuFocusedKey = null;
+		captured.state.isSortPopoverOpen = false;
+		captured.state.isFilterPopoverOpen = false;
+		captured.actions.search = jest.fn();
+	} );
+
+	describe( 'onSortTriggerKeydown', () => {
+		it( 'opens the popover and focuses the first item on ArrowDown', () => {
+			const { trigger } = buildPopoverDom();
+			const event = makeKeydown( 'ArrowDown', trigger );
+			captured.actions.onSortTriggerKeydown( event );
+			expect( event.preventDefault ).toHaveBeenCalled();
+			expect( captured.state.isSortPopoverOpen ).toBe( true );
+			expect( captured.state.sortMenuFocusedKey ).toBe( 'relevance' );
+		} );
+
+		it( 'opens the popover and focuses the last item on ArrowUp', () => {
+			const { trigger } = buildPopoverDom();
+			const event = makeKeydown( 'ArrowUp', trigger );
+			captured.actions.onSortTriggerKeydown( event );
+			expect( captured.state.isSortPopoverOpen ).toBe( true );
+			expect( captured.state.sortMenuFocusedKey ).toBe( 'oldest' );
+		} );
+
+		it( 'opens the popover on Enter without changing focused key when already open', () => {
+			const { trigger } = buildPopoverDom();
+			const event = makeKeydown( 'Enter', trigger );
+			captured.actions.onSortTriggerKeydown( event );
+			expect( captured.state.isSortPopoverOpen ).toBe( true );
+			expect( captured.state.sortMenuFocusedKey ).toBe( 'relevance' );
+		} );
+
+		it( 'ignores other keys so Tab still leaves the trigger', () => {
+			const { trigger } = buildPopoverDom();
+			const event = makeKeydown( 'Tab', trigger );
+			captured.actions.onSortTriggerKeydown( event );
+			expect( event.preventDefault ).not.toHaveBeenCalled();
+			expect( captured.state.isSortPopoverOpen ).toBe( false );
+		} );
+	} );
+
+	describe( 'onSortMenuKeydown', () => {
+		it( 'moves the active descendant to the next item on ArrowDown', () => {
+			const { items } = buildPopoverDom();
+			captured.state.isSortPopoverOpen = true;
+			captured.state.sortMenuFocusedKey = 'relevance';
+			const event = makeKeydown( 'ArrowDown', items[ 0 ] );
+			const gen = captured.actions.onSortMenuKeydown( event );
+			while ( ! gen.next().done ) {
+				/* drain */
+			}
+			expect( event.preventDefault ).toHaveBeenCalled();
+			expect( captured.state.sortMenuFocusedKey ).toBe( 'newest' );
+		} );
+
+		it( 'wraps from the last item to the first on ArrowDown', () => {
+			const { items } = buildPopoverDom();
+			captured.state.isSortPopoverOpen = true;
+			captured.state.sortMenuFocusedKey = 'oldest';
+			const event = makeKeydown( 'ArrowDown', items[ 2 ] );
+			const gen = captured.actions.onSortMenuKeydown( event );
+			while ( ! gen.next().done ) {
+				/* drain */
+			}
+			expect( captured.state.sortMenuFocusedKey ).toBe( 'relevance' );
+		} );
+
+		it( 'moves the active descendant to the previous item on ArrowUp and wraps', () => {
+			const { items } = buildPopoverDom();
+			captured.state.isSortPopoverOpen = true;
+			captured.state.sortMenuFocusedKey = 'relevance';
+			const event = makeKeydown( 'ArrowUp', items[ 0 ] );
+			const gen = captured.actions.onSortMenuKeydown( event );
+			while ( ! gen.next().done ) {
+				/* drain */
+			}
+			expect( captured.state.sortMenuFocusedKey ).toBe( 'oldest' );
+		} );
+
+		it( 'jumps to the first option on Home', () => {
+			const { items } = buildPopoverDom();
+			captured.state.isSortPopoverOpen = true;
+			captured.state.sortMenuFocusedKey = 'oldest';
+			const event = makeKeydown( 'Home', items[ 2 ] );
+			const gen = captured.actions.onSortMenuKeydown( event );
+			while ( ! gen.next().done ) {
+				/* drain */
+			}
+			expect( captured.state.sortMenuFocusedKey ).toBe( 'relevance' );
+		} );
+
+		it( 'jumps to the last option on End', () => {
+			const { items } = buildPopoverDom();
+			captured.state.isSortPopoverOpen = true;
+			captured.state.sortMenuFocusedKey = 'relevance';
+			const event = makeKeydown( 'End', items[ 0 ] );
+			const gen = captured.actions.onSortMenuKeydown( event );
+			while ( ! gen.next().done ) {
+				/* drain */
+			}
+			expect( captured.state.sortMenuFocusedKey ).toBe( 'oldest' );
+		} );
+
+		it( 'closes the popover and refocuses the trigger on Escape', () => {
+			const { trigger, items } = buildPopoverDom();
+			const triggerFocus = jest.spyOn( trigger, 'focus' );
+			captured.state.isSortPopoverOpen = true;
+			captured.state.sortMenuFocusedKey = 'newest';
+			const event = makeKeydown( 'Escape', items[ 1 ] );
+			const gen = captured.actions.onSortMenuKeydown( event );
+			while ( ! gen.next().done ) {
+				/* drain */
+			}
+			expect( event.preventDefault ).toHaveBeenCalled();
+			expect( captured.state.isSortPopoverOpen ).toBe( false );
+			expect( captured.state.sortMenuFocusedKey ).toBeNull();
+			expect( triggerFocus ).toHaveBeenCalled();
+		} );
+
+		it( 'closes the popover on Tab without preventing default so focus moves on', () => {
+			const { items } = buildPopoverDom();
+			captured.state.isSortPopoverOpen = true;
+			captured.state.sortMenuFocusedKey = 'newest';
+			const event = makeKeydown( 'Tab', items[ 1 ] );
+			const gen = captured.actions.onSortMenuKeydown( event );
+			while ( ! gen.next().done ) {
+				/* drain */
+			}
+			expect( event.preventDefault ).not.toHaveBeenCalled();
+			expect( captured.state.isSortPopoverOpen ).toBe( false );
+			expect( captured.state.sortMenuFocusedKey ).toBeNull();
+		} );
+
+		it( 'activates the focused item on Enter, closes the popover, and refocuses the trigger', () => {
+			const { trigger, items } = buildPopoverDom();
+			const triggerFocus = jest.spyOn( trigger, 'focus' );
+			captured.state.isSortPopoverOpen = true;
+			captured.state.sortMenuFocusedKey = 'newest';
+			captured.state.sortOrder = 'relevance';
+
+			const event = makeKeydown( 'Enter', items[ 1 ] );
+			const gen = captured.actions.onSortMenuKeydown( event );
+			while ( ! gen.next().done ) {
+				/* drain (selectSortOrder generator yields once) */
+			}
+
+			expect( event.preventDefault ).toHaveBeenCalled();
+			expect( captured.state.sortOrder ).toBe( 'newest' );
+			expect( captured.state.isSortPopoverOpen ).toBe( false );
+			expect( captured.state.sortMenuFocusedKey ).toBeNull();
+			expect( captured.actions.search ).toHaveBeenCalledTimes( 1 );
+			expect( triggerFocus ).toHaveBeenCalled();
+		} );
+
+		it( 'activates the focused item on Space the same as Enter', () => {
+			const { items } = buildPopoverDom();
+			captured.state.isSortPopoverOpen = true;
+			captured.state.sortMenuFocusedKey = 'oldest';
+			captured.state.sortOrder = 'relevance';
+
+			const event = makeKeydown( ' ', items[ 2 ] );
+			const gen = captured.actions.onSortMenuKeydown( event );
+			while ( ! gen.next().done ) {
+				/* drain */
+			}
+
+			expect( event.preventDefault ).toHaveBeenCalled();
+			expect( captured.state.sortOrder ).toBe( 'oldest' );
+			expect( captured.state.isSortPopoverOpen ).toBe( false );
+		} );
+	} );
+
+	describe( 'toggleSortPopover', () => {
+		it( 'resets sortMenuFocusedKey when closing', () => {
+			captured.state.isSortPopoverOpen = true;
+			captured.state.sortMenuFocusedKey = 'newest';
+			captured.actions.toggleSortPopover();
+			expect( captured.state.isSortPopoverOpen ).toBe( false );
+			expect( captured.state.sortMenuFocusedKey ).toBeNull();
+		} );
+
+		it( 'leaves sortMenuFocusedKey null when opening (mouse opens stay on trigger)', () => {
+			captured.state.isSortPopoverOpen = false;
+			captured.state.sortMenuFocusedKey = null;
+			captured.actions.toggleSortPopover();
+			expect( captured.state.isSortPopoverOpen ).toBe( true );
+			expect( captured.state.sortMenuFocusedKey ).toBeNull();
+		} );
+	} );
+
+	describe( 'closeAllPopovers', () => {
+		it( 'clears the keyboard-focused sort key', () => {
+			captured.state.isSortPopoverOpen = true;
+			captured.state.sortMenuFocusedKey = 'oldest';
+			captured.actions.closeAllPopovers();
+			expect( captured.state.sortMenuFocusedKey ).toBeNull();
+		} );
+	} );
+} );

--- a/projects/packages/search/tests/js/search-blocks/sort-menu-keyboard.test.js
+++ b/projects/packages/search/tests/js/search-blocks/sort-menu-keyboard.test.js
@@ -285,4 +285,30 @@ describe( 'sort popover keyboard navigation', () => {
 			expect( captured.state.sortMenuFocusedKey ).toBeNull();
 		} );
 	} );
+
+	describe( 'onWindowClickClosePopovers', () => {
+		it( 'clears sortMenuFocusedKey when an outside click closes the sort popover', () => {
+			document.body.innerHTML = '<button id="outside" type="button"></button>';
+			captured.state.isSortPopoverOpen = true;
+			captured.state.sortMenuFocusedKey = 'newest';
+
+			const event = { target: document.getElementById( 'outside' ) };
+			captured.actions.onWindowClickClosePopovers( event );
+
+			expect( captured.state.isSortPopoverOpen ).toBe( false );
+			expect( captured.state.sortMenuFocusedKey ).toBeNull();
+		} );
+	} );
+
+	describe( 'onEscapeClosePopovers', () => {
+		it( 'clears sortMenuFocusedKey when Escape closes the sort popover', () => {
+			captured.state.isSortPopoverOpen = true;
+			captured.state.sortMenuFocusedKey = 'oldest';
+
+			captured.actions.onEscapeClosePopovers( makeKeydown( 'Escape' ) );
+
+			expect( captured.state.isSortPopoverOpen ).toBe( false );
+			expect( captured.state.sortMenuFocusedKey ).toBeNull();
+		} );
+	} );
 } );

--- a/projects/packages/search/tests/php/Sort_Control_Render_Test.php
+++ b/projects/packages/search/tests/php/Sort_Control_Render_Test.php
@@ -131,6 +131,38 @@ class Sort_Control_Render_Test extends TestCase {
 		$this->assertStringNotContainsString( '<select', $markup );
 	}
 
+	/**
+	 * Popover menu items participate in the ARIA menu keyboard pattern:
+	 * each item starts with `tabindex="-1"` (server-rendered), carries a
+	 * roving-tabindex binding, a `data-wp-context` with its sort key, and
+	 * a keydown handler so arrow keys can navigate within the menu. The
+	 * trigger also has its own keydown handler so ArrowDown/ArrowUp open
+	 * the popover with focus on the first or last item.
+	 */
+	public function test_display_as_popover_menu_items_have_keyboard_navigation_hooks() {
+		$markup = $this->render( array( 'displayAs' => 'popover' ) );
+
+		// Trigger handles ArrowDown/ArrowUp/Enter/Space to open the menu.
+		$this->assertMatchesRegularExpression(
+			'/class="jetpack-search-sort__trigger"[^>]*data-wp-on--keydown="actions\.onSortTriggerKeydown"/s',
+			$markup
+		);
+
+		// Each menu item ships with the roving-tabindex defaults.
+		$this->assertStringContainsString( 'data-wp-bind--tabindex="state.sortMenuItemTabIndex"', $markup );
+		$this->assertStringContainsString( 'data-wp-on--keydown="actions.onSortMenuKeydown"', $markup );
+		$this->assertMatchesRegularExpression(
+			'/class="jetpack-search-sort__menu-item"[^>]*tabindex="-1"/s',
+			$markup
+		);
+
+		// Per-item context carries the sort key for the watch callback.
+		$this->assertStringContainsString( 'data-wp-context=', $markup );
+		$this->assertStringContainsString( '&quot;sortKey&quot;:&quot;relevance&quot;', $markup );
+		$this->assertStringContainsString( '&quot;sortKey&quot;:&quot;newest&quot;', $markup );
+		$this->assertStringContainsString( '&quot;sortKey&quot;:&quot;oldest&quot;', $markup );
+	}
+
 	/** URL `?orderby=` wins over `defaultSort` so deep links keep their meaning. */
 	public function test_url_sort_wins_over_default_sort() {
 		$_GET = array( 'orderby' => 'oldest' );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes RSM-1646.

## Summary

Anyone using the Search 3.0 Compact Search pattern with a keyboard or assistive tech can now operate the sort popover the way `role="menu"` advertises. Before this PR, opening the sort popover with the keyboard left them stranded — Tab cycled through every option instead of leaving the menu, arrow keys did nothing, and there was no way to activate an option without reaching for a mouse. Screen-reader users heard a menu but got button behavior.

This PR makes the sort popover follow the WAI-ARIA menu-button keyboard pattern end to end, so the experience matches what assistive tech announces and what keyboard users expect.

## Proposed changes

The Compact Search pattern's `jetpack/sort-control` popover renders `role="menu"` with `role="menuitemradio"` items, but it didn't follow up on the rest of the WAI-ARIA menu keyboard pattern (review feedback from #48288). This PR fills that in:

* **Roving tabindex** via `state.sortMenuItemTabIndex` — only the active descendant is in the page tab order, so Tab leaves the menu rather than cycling every option.
* **Arrow key navigation** within the menu: ArrowUp / ArrowDown wrap, Home / End jump to ends.
* **Enter / Space** activates the focused item, applies the new sort, closes the popover, and returns focus to the trigger.
* **Escape** closes the menu and returns focus to the trigger.
* **Tab** closes the popover without `preventDefault`, so the browser advances focus to the next focusable sibling instead of skipping back into a hidden menu item.
* **Trigger ArrowDown / ArrowUp / Enter / Space** opens the popover with focus on the first or last item, matching the menu-button pattern.
* **Click selection and close-on-select are preserved** — the existing `actions.selectSortOrder` flow is untouched, and the new `sortMenuFocusedKey` resets to `null` whenever the popover closes (including the window-level outside-click and Escape handlers) so a subsequent mouse-open doesn't pull focus into the menu.

The store-side keydown handlers are wrapped in `withSyncEvent` (with a noop fallback for runtimes that predate WP 6.7) to silence the Interactivity API "synchronous event access" deprecation warning that lands in WP 7.0.

Test coverage:

* New `sort-menu-keyboard.test.js` exercises the new `onSortTriggerKeydown` and `onSortMenuKeydown` actions, the focused-key reset in `toggleSortPopover` / `closeAllPopovers`, and the focused-key reset on the window-level `onWindowClickClosePopovers` and `onEscapeClosePopovers` close paths.
* `sort-control-view.test.js` extended for the new `sortMenuItemTabIndex` getter and `focusSelectedSortMenuItem` watch callback.
* PHP `Sort_Control_Render_Test` asserts the rendered popover wires `data-wp-on--keydown`, `data-wp-bind--tabindex`, the per-item `data-wp-context`, and the trigger keydown handler.

## Related product discussion/links

* Linear: RSM-1646
* Follow-up from #48288 (review feedback by [`@sirreal`](https://github.com/sirreal))

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Apply this branch (built off `rsm-1071-search-30-compact-search-pattern`).
2. On a site with Search 3.0 enabled (`add_filter( 'jetpack_search_blocks_enabled', '__return_true' );`), insert the **Compact Search** pattern on a page.
3. Run a search so the sort trigger isn't disabled, then keyboard-test the popover:
   * Tab to the sort icon button (↑↓), press **ArrowDown** → menu opens with focus on the first item.
   * **ArrowDown / ArrowUp** moves focus through the items, wrapping at the ends.
   * **Home / End** jump to the first / last option.
   * **Enter** (or **Space**) on a non-active option applies the new sort, closes the menu, and returns focus to the trigger.
   * **Escape** closes the menu and returns focus to the trigger.
   * **Tab** from inside the menu closes the popover and lets the browser advance focus to the next focusable element instead of stepping through the menu items.
4. Verify mouse interaction still works (click trigger to open, click an option to select, click outside to close) and that opening with the mouse does *not* steal focus into the menu — including after first opening it via keyboard, then dismissing with outside-click or Escape, then re-opening with the mouse.
5. Run automated checks:
   * `jp test js packages/search`
   * `jp test php packages/search`
   * `jp phan packages/search`

### Demo

![Sort popover with roving-tabindex focus on the Newest item](https://cursor.com/artifacts/c/art-baad94c3-bef4-4e77-813b-f0c5c4471d94)

<a href="https://cursor.com/agents/bc-7b381374-28e0-4636-acfe-74bc2c596e56/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsort_popover_keyboard_navigation_demo.mp4"><img src="https://cursor.com/artifacts/c/art-73d02535-255a-4b17-bcef-f7047edb6aba" alt="sort_popover_keyboard_navigation_demo.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [RSM-1646](https://linear.app/a8c/issue/RSM-1646/search-30-add-aria-menu-keyboard-support-to-compact-sort-popover)

<div><a href="https://cursor.com/agents/bc-7b381374-28e0-4636-acfe-74bc2c596e56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b381374-28e0-4636-acfe-74bc2c596e56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

