### PR TITLE
CI: install wpcomsh when WITH_WPCOMSH=true even if not in CHANGED

### DIFF
--- a/.github/files/setup-wordpress-env.sh
+++ b/.github/files/setup-wordpress-env.sh
@@ -68,7 +68,8 @@ function _install_plugin {
 	# wpcomsh is copied to mu-plugins below when WITH_WPCOMSH=true, so it must
 	# be installed even when not in CHANGED.
 	if [[ -n "$CHANGED" ]] && ! jq --argjson changed "$CHANGED" --arg p "plugins/$NAME" -ne '$changed[$p] // false' > /dev/null \
-		&& ! [[ "$NAME" == "wpcomsh" && "$WITH_WPCOMSH" == "true" ]]; then
+		&& ! [[ "$NAME" == "wpcomsh" && "$WITH_WPCOMSH" == "true" ]]
+	then
 		echo "::endgroup::"
 		echo "Skipping install of plugin $NAME, not in CHANGED"
 		return 0

--- a/.github/files/setup-wordpress-env.sh
+++ b/.github/files/setup-wordpress-env.sh
@@ -65,7 +65,10 @@ function _install_plugin {
 
 	echo "::group::Installing plugin $NAME into WordPress"
 
-	if [[ -n "$CHANGED" ]] && ! jq --argjson changed "$CHANGED" --arg p "plugins/$NAME" -ne '$changed[$p] // false' > /dev/null; then
+	# wpcomsh is copied to mu-plugins below when WITH_WPCOMSH=true, so it must
+	# be installed even when not in CHANGED.
+	if [[ -n "$CHANGED" ]] && ! jq --argjson changed "$CHANGED" --arg p "plugins/$NAME" -ne '$changed[$p] // false' > /dev/null \
+		&& ! [[ "$NAME" == "wpcomsh" && "$WITH_WPCOMSH" == "true" ]]; then
 		echo "::endgroup::"
 		echo "Skipping install of plugin $NAME, not in CHANGED"
 		return 0


### PR DESCRIPTION
Fixes # N/A

## Proposed changes
* In `.github/files/setup-wordpress-env.sh`, the `_install_plugin` function skips installation when the plugin isn't in `$CHANGED` (added in #48308). For `wpcomsh`, that's wrong when `WITH_WPCOMSH=true`: a later step unconditionally copies `wp-content/plugins/wpcomsh` into `wp-content/mu-plugins/wpcomsh`, and fails with `cp: cannot stat ...` if the plugin was skipped.
* Add a guard so `wpcomsh` is always installed when `WITH_WPCOMSH=true`, even if not in `$CHANGED`.

## Related product discussion/links
* Hit on #48366 — a Jetpack-only PR. The `PHP tests: PHP 8.3 WP latest with wpcomsh` job runs `WITH_WPCOMSH=true` against changed plugins, but `plugins/wpcomsh` itself isn't in `$CHANGED` since the PR doesn't touch it, so the install is skipped and the mu-plugins copy step blows up.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. Find any open PR that changes `plugins/jetpack` (or another plugin tested with wpcomsh) without touching `plugins/wpcomsh`.
2. On trunk, observe `PHP tests: PHP * WP latest with wpcomsh` failing with `cp: cannot stat '/tmp/wordpress-latest/src/wp-content/plugins/wpcomsh': No such file or directory`.
3. With this fix, the same job should install wpcomsh and proceed.
