### PR TITLE
Paywall: fix comp subscribers blocked by tier gate

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-paywall-comp-tier-gate
+++ b/projects/plugins/jetpack/changelog/fix-paywall-comp-tier-gate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Paywall: comp subscribers can now access tier-gated posts regardless of plan price.

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
@@ -433,7 +433,7 @@ abstract class Abstract_Token_Subscription_Service implements Subscription_Servi
 				return false;
 			}
 
-			$end = is_int( $details['end_date'] ) ? $details['end_date'] : strtotime( $details['end_date'] );
+			$end     = is_int( $details['end_date'] ) ? $details['end_date'] : strtotime( $details['end_date'] );
 			if ( $end < time() ) {
 				// subscription not active anymore
 				continue;

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
@@ -428,11 +428,6 @@ abstract class Abstract_Token_Subscription_Service implements Subscription_Servi
 		foreach ( $user_abbreviated_subscriptions as $subscription_plan_id => $details ) {
 			$details = (array) $details;
 
-			// Comp subscriptions are administrative grants and bypass tier price gating.
-			if ( ! empty( $details['is_comp'] ) ) {
-				return false;
-			}
-
 			$end = is_int( $details['end_date'] ) ? $details['end_date'] : strtotime( $details['end_date'] );
 			if ( $end < time() ) {
 				// subscription not active anymore
@@ -451,6 +446,12 @@ abstract class Abstract_Token_Subscription_Service implements Subscription_Servi
 				// No post linked to this plan
 				continue;
 			}
+
+			// Comp grants linked to a plan on this site bypass the tier price comparison.
+			if ( ! empty( $details['is_comp'] ) ) {
+				return false;
+			}
+
 			$subscription_post_id = $subscription_post->ID;
 
 			if ( $subscription_post_id === $tier_id || $subscription_post_id === $annual_tier_id ) {

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
@@ -427,7 +427,13 @@ abstract class Abstract_Token_Subscription_Service implements Subscription_Servi
 
 		foreach ( $user_abbreviated_subscriptions as $subscription_plan_id => $details ) {
 			$details = (array) $details;
-			$end     = is_int( $details['end_date'] ) ? $details['end_date'] : strtotime( $details['end_date'] );
+
+			// Comp subscriptions are administrative grants and bypass tier price gating.
+			if ( ! empty( $details['is_comp'] ) ) {
+				return false;
+			}
+
+			$end = is_int( $details['end_date'] ) ? $details['end_date'] : strtotime( $details['end_date'] );
 			if ( $end < time() ) {
 				// subscription not active anymore
 				continue;
@@ -669,6 +675,9 @@ abstract class Abstract_Token_Subscription_Service implements Subscription_Servi
 			) {
 				$subscriptions[ $subscription['product_id'] ]           = new \stdClass();
 				$subscriptions[ $subscription['product_id'] ]->end_date = empty( $subscription['end_date'] ) ? ( time() + 365 * 24 * 3600 ) : $subscription['end_date'];
+				if ( ! empty( $subscription['is_comp'] ) ) {
+					$subscriptions[ $subscription['product_id'] ]->is_comp = true;
+				}
 			}
 		}
 		return $subscriptions;

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
@@ -433,7 +433,7 @@ abstract class Abstract_Token_Subscription_Service implements Subscription_Servi
 				return false;
 			}
 
-			$end     = is_int( $details['end_date'] ) ? $details['end_date'] : strtotime( $details['end_date'] );
+			$end = is_int( $details['end_date'] ) ? $details['end_date'] : strtotime( $details['end_date'] );
 			if ( $end < time() ) {
 				// subscription not active anymore
 				continue;

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-wpcom-online-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-wpcom-online-subscription-service.php
@@ -155,6 +155,9 @@ class WPCOM_Online_Subscription_Service extends Jetpack_Token_Subscription_Servi
 			) {
 				$subscriptions[ $subscription['product_id'] ]           = new \stdClass();
 				$subscriptions[ $subscription['product_id'] ]->end_date = empty( $subscription['end_date'] ) ? gmdate( 'Y-m-d H:i:s', ( time() + 365 * 24 * 3600 ) ) : $subscription['end_date'];
+				if ( ! empty( $subscription['is_comp'] ) ) {
+					$subscriptions[ $subscription['product_id'] ]->is_comp = true;
+				}
 			}
 		}
 		return $subscriptions;

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
@@ -355,17 +355,20 @@ class Jetpack_Subscriptions_Test extends WP_UnitTestCase {
 	 * @param int    $subscription_end_date
 	 * @param string $status
 	 * @param int    $product_id
+	 * @param bool   $is_comp Whether the subscription represents a complimentary grant.
 	 * @return array
 	 */
-	private function get_payload( $is_subscribed, $is_paid_subscriber = false, $subscription_end_date = null, $status = null, $product_id = 0 ) {
+	private function get_payload( $is_subscribed, $is_paid_subscriber = false, $subscription_end_date = null, $status = null, $product_id = 0, $is_comp = false ) {
 		$product_id    = $product_id ? $product_id : $this->product_id;
-		$subscriptions = ! $is_paid_subscriber ? array() : array(
-			$product_id => array(
-				'status'     => $status ? $status : 'active',
-				'end_date'   => $subscription_end_date ? $subscription_end_date : time() + HOUR_IN_SECONDS,
-				'product_id' => $product_id,
-			),
+		$subscription  = array(
+			'status'     => $status ? $status : 'active',
+			'end_date'   => $subscription_end_date ? $subscription_end_date : time() + HOUR_IN_SECONDS,
+			'product_id' => $product_id,
 		);
+		if ( $is_comp ) {
+			$subscription['is_comp'] = true;
+		}
+		$subscriptions = ! $is_paid_subscriber ? array() : array( $product_id => $subscription );
 
 		return array(
 			'blog_sub'      => $is_subscribed ? 'active' : 'inactive',
@@ -781,6 +784,43 @@ class Jetpack_Subscriptions_Test extends WP_UnitTestCase {
 
 		if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
 			// Removing filter.
+			remove_filter( 'jetpack_is_connection_ready', '__return_true', 1000 );
+		}
+	}
+
+	public function test_newsletter_tier_comp_bypasses_price_gate() {
+		$bronze_tier_plan_id        = 1100;
+		$bronze_tier_annual_plan_id = 2100;
+		$silver_tier_plan_id        = 3100;
+		$silver_tier_annual_plan_id = 5100;
+
+		if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
+			add_filter( 'jetpack_is_connection_ready', '__return_true', 1000 );
+		}
+
+		$this->setup_jetpack_tier( $bronze_tier_plan_id, $bronze_tier_annual_plan_id, 10, 100 );
+		$silver_tier_id = $this->setup_jetpack_tier( $silver_tier_plan_id, $silver_tier_annual_plan_id, 20, 200 );
+
+		$post_access_level       = 'paid_subscribers';
+		$newsletter_paid_post_id = $this->setup_jetpack_paid_newsletters();
+		update_post_meta( $newsletter_paid_post_id, META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS, $post_access_level );
+		update_post_meta( $newsletter_paid_post_id, META_NAME_FOR_POST_TIER_ID_SETTINGS, $silver_tier_id );
+
+		$GLOBALS['post'] = get_post( $newsletter_paid_post_id );
+
+		// A bronze paid subscription is below the silver tier price - normally blocked.
+		$subscription_service = $this->set_returned_token(
+			$this->get_payload( true, true, null, null, $bronze_tier_plan_id )
+		);
+		$this->assertFalse( $subscription_service->visitor_can_view_content( Jetpack_Memberships::get_all_newsletter_plan_ids(), $post_access_level ) );
+
+		// Same bronze plan but flagged as a comp - should bypass the tier price gate.
+		$subscription_service = $this->set_returned_token(
+			$this->get_payload( true, true, null, null, $bronze_tier_plan_id, true )
+		);
+		$this->assertTrue( $subscription_service->visitor_can_view_content( Jetpack_Memberships::get_all_newsletter_plan_ids(), $post_access_level ) );
+
+		if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
 			remove_filter( 'jetpack_is_connection_ready', '__return_true', 1000 );
 		}
 	}

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
@@ -359,8 +359,8 @@ class Jetpack_Subscriptions_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	private function get_payload( $is_subscribed, $is_paid_subscriber = false, $subscription_end_date = null, $status = null, $product_id = 0, $is_comp = false ) {
-		$product_id    = $product_id ? $product_id : $this->product_id;
-		$subscription  = array(
+		$product_id   = $product_id ? $product_id : $this->product_id;
+		$subscription = array(
 			'status'     => $status ? $status : 'active',
 			'end_date'   => $subscription_end_date ? $subscription_end_date : time() + HOUR_IN_SECONDS,
 			'product_id' => $product_id,

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
@@ -820,6 +820,19 @@ class Jetpack_Subscriptions_Test extends WP_UnitTestCase {
 		);
 		$this->assertTrue( $subscription_service->visitor_can_view_content( Jetpack_Memberships::get_all_newsletter_plan_ids(), $post_access_level ) );
 
+		// Expired comp should NOT bypass the tier gate.
+		$subscription_service = $this->set_returned_token(
+			$this->get_payload( true, true, time() - HOUR_IN_SECONDS, null, $bronze_tier_plan_id, true )
+		);
+		$this->assertFalse( $subscription_service->visitor_can_view_content( Jetpack_Memberships::get_all_newsletter_plan_ids(), $post_access_level ) );
+
+		// Comp for a product_id with no matching plan on this site should NOT bypass the tier gate.
+		$unknown_product_id   = 9999;
+		$subscription_service = $this->set_returned_token(
+			$this->get_payload( true, true, null, null, $unknown_product_id, true )
+		);
+		$this->assertFalse( $subscription_service->visitor_can_view_content( Jetpack_Memberships::get_all_newsletter_plan_ids(), $post_access_level ) );
+
 		if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
 			remove_filter( 'jetpack_is_connection_ready', '__return_true', 1000 );
 		}


### PR DESCRIPTION
## Proposed changes
* Comp subscribers were silently blocked from posts gated to a specific tier. The tier gate's price comparison treated comps as paid plans and rejected them when the comp's plan price didn't meet the tier price (common after a site adds a new plan set).
* `WPCOM_Online_Subscription_Service::abbreviate_subscriptions` and the abstract counterpart now preserve an `is_comp` flag on the abbreviated subscription object.
* `Abstract_Token_Subscription_Service::maybe_gate_access_for_user_if_tier` short-circuits with `return false` (no gate) when iterating a comp subscription, since comps are administrative grants and shouldn't be subject to tier price comparison.

This covers both the WPCOM Online path (logged-in page view) and the JWT/email token path — wpcom's `Auth_Endpoint::abbreviate_subscriptions` reuses the same Jetpack-side method when signing tokens, so newly issued tokens carry `is_comp` automatically.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
TBC