### PR TITLE
Contact Info widget: make phone number clickable on all devices

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-contact-info-clickable-phone
+++ b/projects/plugins/jetpack/changelog/fix-contact-info-clickable-phone
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Make phone numbers in the Contact Info widget clickable on all devices, not just mobile.

--- a/projects/plugins/jetpack/modules/widgets/contact-info.php
+++ b/projects/plugins/jetpack/modules/widgets/contact-info.php
@@ -160,11 +160,7 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 			}
 
 			if ( '' !== $instance['phone'] ) {
-				if ( wp_is_mobile() ) {
-					echo '<div class="confit-phone"><span itemprop="telephone"><a href="' . esc_url( 'tel:' . $instance['phone'] ) . '">' . esc_html( $instance['phone'] ) . '</a></span></div>';
-				} else {
-					echo '<div class="confit-phone"><span itemprop="telephone">' . esc_html( $instance['phone'] ) . '</span></div>';
-				}
+				echo '<div class="confit-phone"><span itemprop="telephone"><a href="' . esc_url( 'tel:' . $instance['phone'] ) . '">' . esc_html( $instance['phone'] ) . '</a></span></div>';
 			}
 
 			if (


### PR DESCRIPTION
## What was the problem?

The Contact Info widget only made phone numbers clickable on mobile devices (`wp_is_mobile()` check). Desktop users saw plain text and could not click-to-call.

Closes #6336

## How was it fixed?

Removed the `wp_is_mobile()` conditional so phone numbers are always wrapped in a `<a href="tel:...">` link, making them clickable on all devices.

This aligns with the Contact Info **block** behavior, which already renders phone numbers as clickable `tel:` links unconditionally (see `extensions/blocks/contact-info/phone/save.js`).

## Changes

- `projects/plugins/jetpack/modules/widgets/contact-info.php` — removed `wp_is_mobile()` conditional, always output phone as clickable link
- `projects/plugins/jetpack/changelog/fix-contact-info-clickable-phone` — added changelog entry

## Testing instructions

* Activate the Contact Info & Map widget in Appearance > Widgets (or Appearance > Customize > Widgets)
* Set a phone number (e.g., `1-202-555-1212`)
* View the site on a desktop browser
* Verify the phone number is rendered as a clickable link with `href="tel:1-202-555-1212"`
* Click the link and confirm it opens the default calling application (or prompts to open one)
* View the site on a mobile browser and confirm the phone number remains clickable (no regression)
* If you have the Contact Info block on a page, verify both widget and block show the same clickable phone behavior

## Does this pull request change what data or activity we track or use?

No. This PR only changes the HTML output of the phone number in the Contact Info widget, from plain text to a clickable `tel:` link on all devices. No data collection, tracking, or privacy-related changes.

## Pre-commit checks

- [x] PHP syntax check passes (`php -l`)
- [x] No new PHPCS violations introduced
- [x] Changelog entry added