### PR TITLE
Podcast: add Episode block

### DIFF
--- a/projects/plugins/jetpack/changelog/add-podcast-episode-block
+++ b/projects/plugins/jetpack/changelog/add-podcast-episode-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Podcast Episode block: new block to embed a single podcast episode from an audio or video file with Podcasting 2.0 metadata.

--- a/projects/plugins/jetpack/extensions/blocks/podcast-episode/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-episode/block.json
@@ -10,7 +10,6 @@
 	"category": "embed",
 	"icon": "<svg viewBox='0 0 24 24' width='24' height='24' xmlns='http://www.w3.org/2000/svg'><path d='M12 2a5 5 0 0 0-5 5v5a5 5 0 0 0 10 0V7a5 5 0 0 0-5-5zm0 2a3 3 0 0 1 3 3v5a3 3 0 0 1-6 0V7a3 3 0 0 1 3-3zm-7 8a1 1 0 0 1 1 1 6 6 0 0 0 12 0 1 1 0 1 1 2 0 8 8 0 0 1-7 7.93V22h3v2H8v-2h3v-1.07A8 8 0 0 1 4 13a1 1 0 0 1 1-1z'/></svg>",
 	"supports": {
-		"align": [ "wide", "full" ],
 		"spacing": {
 			"padding": true,
 			"margin": true

--- a/projects/plugins/jetpack/extensions/blocks/podcast-episode/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-episode/block.json
@@ -1,0 +1,135 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "jetpack/podcast-episode",
+	"title": "Podcast Episode",
+	"description": "Embed a single podcast episode from an audio or video file, with Podcasting 2.0 metadata.",
+	"keywords": [ "audio", "podcast", "episode" ],
+	"version": "1.0.0",
+	"textdomain": "jetpack",
+	"category": "embed",
+	"icon": "<svg viewBox='0 0 24 24' width='24' height='24' xmlns='http://www.w3.org/2000/svg'><path d='M12 2a5 5 0 0 0-5 5v5a5 5 0 0 0 10 0V7a5 5 0 0 0-5-5zm0 2a3 3 0 0 1 3 3v5a3 3 0 0 1-6 0V7a3 3 0 0 1 3-3zm-7 8a1 1 0 0 1 1 1 6 6 0 0 0 12 0 1 1 0 1 1 2 0 8 8 0 0 1-7 7.93V22h3v2H8v-2h3v-1.07A8 8 0 0 1 4 13a1 1 0 0 1 1-1z'/></svg>",
+	"supports": {
+		"align": [ "wide", "full" ],
+		"spacing": {
+			"padding": true,
+			"margin": true
+		},
+		"anchor": true,
+		"customClassName": true,
+		"className": true,
+		"html": false,
+		"multiple": true,
+		"reusable": true
+	},
+	"attributes": {
+		"mediaId": {
+			"type": "integer"
+		},
+		"mediaUrl": {
+			"type": "string"
+		},
+		"mediaType": {
+			"type": "string",
+			"enum": [ "audio", "video" ]
+		},
+		"mediaMimeType": {
+			"type": "string"
+		},
+		"mediaSize": {
+			"type": "integer"
+		},
+		"title": {
+			"type": "string",
+			"default": ""
+		},
+		"summary": {
+			"type": "string",
+			"default": ""
+		},
+		"description": {
+			"type": "string",
+			"default": ""
+		},
+		"author": {
+			"type": "string",
+			"default": ""
+		},
+		"episodeNumber": {
+			"type": "integer"
+		},
+		"seasonNumber": {
+			"type": "integer"
+		},
+		"episodeType": {
+			"type": "string",
+			"enum": [ "full", "trailer", "bonus" ],
+			"default": "full"
+		},
+		"explicit": {
+			"type": "boolean",
+			"default": false
+		},
+		"publishDate": {
+			"type": "string"
+		},
+		"guid": {
+			"type": "string"
+		},
+		"duration": {
+			"type": "string",
+			"default": ""
+		},
+		"imageId": {
+			"type": "integer"
+		},
+		"imageUrl": {
+			"type": "string"
+		},
+		"transcriptUrl": {
+			"type": "string",
+			"default": ""
+		},
+		"transcriptType": {
+			"type": "string",
+			"enum": [ "text/vtt", "text/html", "application/srt", "application/json" ],
+			"default": "text/vtt"
+		},
+		"chaptersUrl": {
+			"type": "string",
+			"default": ""
+		},
+		"locationName": {
+			"type": "string",
+			"default": ""
+		},
+		"license": {
+			"type": "string",
+			"default": ""
+		},
+		"licenseUrl": {
+			"type": "string",
+			"default": ""
+		},
+		"people": {
+			"type": "array",
+			"default": []
+		},
+		"showPoster": {
+			"type": "boolean",
+			"default": true
+		}
+	},
+	"example": {
+		"attributes": {
+			"title": "1. Welcome to the Jetpack Example Podcast",
+			"summary": "A short introduction to what this show is all about.",
+			"author": "Jetpack",
+			"episodeNumber": 1,
+			"seasonNumber": 1,
+			"episodeType": "full",
+			"duration": "11:25",
+			"imageUrl": "https://jetpackme.files.wordpress.com/2020/05/jetpack-example-podcast-cover.png?w=320"
+		}
+	}
+}

--- a/projects/plugins/jetpack/extensions/blocks/podcast-episode/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-episode/edit.js
@@ -275,7 +275,6 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, isSelec
 							render={ ( { open } ) =>
 								imageUrl ? (
 									<ToolbarButton
-										aria-label={ __( 'Replace cover art', 'jetpack' ) }
 										onClick={ open }
 										icon={
 											<img
@@ -284,14 +283,10 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, isSelec
 												className="jetpack-podcast-episode__cover-thumbnail"
 											/>
 										}
-										showTooltip
 										label={ __( 'Replace cover art', 'jetpack' ) }
 									/>
 								) : (
-									<ToolbarButton
-										aria-label={ __( 'Add cover art', 'jetpack' ) }
-										onClick={ open }
-									>
+									<ToolbarButton onClick={ open }>
 										{ __( 'Add cover art', 'jetpack' ) }
 									</ToolbarButton>
 								)

--- a/projects/plugins/jetpack/extensions/blocks/podcast-episode/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-episode/edit.js
@@ -272,13 +272,23 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, isSelec
 							onSelect={ onSelectImage }
 							allowedTypes={ [ 'image' ] }
 							value={ imageId }
-							render={ ( { open } ) => (
-								<ToolbarButton aria-label={ __( 'Select cover art', 'jetpack' ) } onClick={ open }>
-									{ imageUrl
-										? __( 'Change cover art', 'jetpack' )
-										: __( 'Add cover art', 'jetpack' ) }
-								</ToolbarButton>
-							) }
+							render={ ( { open } ) =>
+								imageUrl ? (
+									<ToolbarButton
+										aria-label={ __( 'Select cover art', 'jetpack' ) }
+										onClick={ open }
+									>
+										{ __( 'Change cover art', 'jetpack' ) }
+									</ToolbarButton>
+								) : (
+									<ToolbarButton
+										aria-label={ __( 'Select cover art', 'jetpack' ) }
+										onClick={ open }
+									>
+										{ __( 'Add cover art', 'jetpack' ) }
+									</ToolbarButton>
+								)
+							}
 						/>
 					</MediaUploadCheck>
 				</ToolbarGroup>
@@ -402,11 +412,15 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, isSelec
 							value={ imageId }
 							render={ ( { open } ) => (
 								<PanelRow>
-									<Button variant="secondary" onClick={ open } __next40pxDefaultSize>
-										{ imageUrl
-											? __( 'Replace cover art', 'jetpack' )
-											: __( 'Select cover art', 'jetpack' ) }
-									</Button>
+									{ imageUrl ? (
+										<Button variant="secondary" onClick={ open } __next40pxDefaultSize>
+											{ __( 'Replace cover art', 'jetpack' ) }
+										</Button>
+									) : (
+										<Button variant="secondary" onClick={ open } __next40pxDefaultSize>
+											{ __( 'Select cover art', 'jetpack' ) }
+										</Button>
+									) }
 									{ imageUrl && (
 										<Button variant="link" isDestructive onClick={ clearImage }>
 											{ __( 'Remove', 'jetpack' ) }

--- a/projects/plugins/jetpack/extensions/blocks/podcast-episode/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-episode/edit.js
@@ -1,0 +1,583 @@
+import apiFetch from '@wordpress/api-fetch';
+import {
+	BlockControls,
+	InspectorControls,
+	MediaPlaceholder,
+	MediaReplaceFlow,
+	MediaUpload,
+	MediaUploadCheck,
+	RichText,
+	useBlockProps,
+} from '@wordpress/block-editor';
+import {
+	BaseControl,
+	Button,
+	DateTimePicker,
+	Dropdown,
+	PanelBody,
+	PanelRow,
+	SelectControl,
+	TextControl,
+	ToggleControl,
+	ToolbarButton,
+	ToolbarGroup,
+} from '@wordpress/components';
+import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { getValidatedAttributes } from '../../shared/get-validated-attributes';
+import metadata from './block.json';
+import { microphone } from './icons';
+
+const AUDIO_VIDEO_MIME_TYPES = [ 'audio', 'video' ];
+
+const EPISODE_TYPE_OPTIONS = [
+	{ label: __( 'Full', 'jetpack' ), value: 'full' },
+	{ label: __( 'Trailer', 'jetpack' ), value: 'trailer' },
+	{ label: __( 'Bonus', 'jetpack' ), value: 'bonus' },
+];
+
+const TRANSCRIPT_TYPE_OPTIONS = [
+	{ label: 'WebVTT (text/vtt)', value: 'text/vtt' },
+	{ label: 'HTML (text/html)', value: 'text/html' },
+	{ label: 'SRT (application/srt)', value: 'application/srt' },
+	{ label: 'JSON (application/json)', value: 'application/json' },
+];
+
+function formatSeconds( totalSeconds ) {
+	const n = Number( totalSeconds );
+	if ( ! n || Number.isNaN( n ) ) {
+		return '';
+	}
+	const seconds = Math.floor( n % 60 );
+	const minutes = Math.floor( ( n / 60 ) % 60 );
+	const hours = Math.floor( n / 3600 );
+	const pad = v => String( v ).padStart( 2, '0' );
+	return hours > 0
+		? `${ hours }:${ pad( minutes ) }:${ pad( seconds ) }`
+		: `${ minutes }:${ pad( seconds ) }`;
+}
+
+function PeopleEditor( { people, onChange } ) {
+	const updatePerson = ( index, patch ) => {
+		const next = people.map( ( person, i ) => ( i === index ? { ...person, ...patch } : person ) );
+		onChange( next );
+	};
+	const removePerson = index => onChange( people.filter( ( _, i ) => i !== index ) );
+	const addPerson = () => onChange( [ ...people, { name: '', role: '', href: '', img: '' } ] );
+
+	return (
+		<>
+			{ people.map( ( person, index ) => (
+				<div
+					className="jetpack-podcast-episode__person-editor"
+					key={ index }
+					style={ { marginBottom: '1em' } }
+				>
+					<TextControl
+						label={ __( 'Name', 'jetpack' ) }
+						value={ person.name || '' }
+						onChange={ name => updatePerson( index, { name } ) }
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+					/>
+					<TextControl
+						label={ __( 'Role', 'jetpack' ) }
+						help={ __( 'e.g. host, guest, producer.', 'jetpack' ) }
+						value={ person.role || '' }
+						onChange={ role => updatePerson( index, { role } ) }
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+					/>
+					<TextControl
+						label={ __( 'Profile URL', 'jetpack' ) }
+						type="url"
+						value={ person.href || '' }
+						onChange={ href => updatePerson( index, { href } ) }
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+					/>
+					<TextControl
+						label={ __( 'Image URL', 'jetpack' ) }
+						type="url"
+						value={ person.img || '' }
+						onChange={ img => updatePerson( index, { img } ) }
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+					/>
+					<Button variant="link" isDestructive onClick={ () => removePerson( index ) }>
+						{ __( 'Remove person', 'jetpack' ) }
+					</Button>
+				</div>
+			) ) }
+			<Button variant="secondary" onClick={ addPerson }>
+				{ __( 'Add person', 'jetpack' ) }
+			</Button>
+		</>
+	);
+}
+
+export default function PodcastEpisodeEdit( { attributes, setAttributes, isSelected } ) {
+	const validated = getValidatedAttributes( metadata.attributes, attributes );
+	const {
+		mediaId,
+		mediaUrl,
+		mediaType,
+		mediaMimeType,
+		title,
+		summary,
+		description,
+		author,
+		episodeNumber,
+		seasonNumber,
+		episodeType,
+		explicit,
+		publishDate,
+		guid,
+		duration,
+		imageId,
+		imageUrl,
+		transcriptUrl,
+		transcriptType,
+		chaptersUrl,
+		locationName,
+		license,
+		licenseUrl,
+		people,
+		showPoster,
+	} = validated;
+
+	const blockProps = useBlockProps( { className: 'wp-block-jetpack-podcast-episode' } );
+	const [ uploadError, setUploadError ] = useState( null );
+
+	const onSelectMedia = async media => {
+		if ( ! media || ! media.url ) {
+			return;
+		}
+		const type = media.type === 'video' ? 'video' : 'audio';
+
+		// `fileLength` on the attachment shim is the ID3 `length_formatted` string
+		// (e.g. "12:00"); fall back to computing from seconds if only a number is
+		// available.
+		const nextDuration =
+			duration ||
+			( typeof media.fileLength === 'string' && media.fileLength ) ||
+			formatSeconds( media.duration );
+
+		const immediate = {
+			mediaId: media.id,
+			mediaUrl: media.url,
+			mediaType: type,
+			mediaMimeType: media.mime || media.mime_type || '',
+			mediaSize: media.filesizeInBytes || media.filesize_in_bytes || undefined,
+			duration: nextDuration,
+			title: title || media.title || '',
+		};
+		setAttributes( immediate );
+
+		if ( ! media.id ) {
+			return;
+		}
+
+		// Backfill any empty metadata fields from the attachment's ID3 data (parsed
+		// by WordPress via wp_read_audio_metadata on upload). We never overwrite
+		// values the user has already typed.
+		try {
+			const attachment = await apiFetch( { path: `/wp/v2/media/${ media.id }` } );
+			const details = attachment?.media_details || {};
+			const id3 = details.length_formatted || details.length ? details : details.audio || details;
+
+			const patch = {};
+
+			if ( ! immediate.duration && details.length_formatted ) {
+				patch.duration = details.length_formatted;
+			} else if ( ! immediate.duration && details.length ) {
+				patch.duration = formatSeconds( details.length );
+			}
+
+			if ( ! title && id3?.title ) {
+				patch.title = id3.title;
+			}
+
+			if ( ! author && id3?.artist ) {
+				patch.author = id3.artist;
+			}
+
+			if ( ! immediate.mediaSize && details.filesize ) {
+				patch.mediaSize = Number( details.filesize );
+			}
+
+			if ( ! immediate.mediaMimeType && attachment?.mime_type ) {
+				patch.mediaMimeType = attachment.mime_type;
+			}
+
+			if ( Object.keys( patch ).length ) {
+				setAttributes( patch );
+			}
+		} catch {
+			// Non-fatal: media metadata is a nice-to-have, the user can fill fields manually.
+		}
+	};
+
+	const onSelectImage = image => {
+		if ( ! image || ! image.url ) {
+			return;
+		}
+		setAttributes( { imageId: image.id, imageUrl: image.url } );
+	};
+
+	const clearImage = () => setAttributes( { imageId: undefined, imageUrl: undefined } );
+
+	if ( ! mediaUrl ) {
+		return (
+			<div { ...blockProps }>
+				<MediaPlaceholder
+					icon={ microphone }
+					labels={ {
+						title: __( 'Podcast Episode', 'jetpack' ),
+						instructions: __(
+							'Upload an audio or video file, or pick one from the media library, to use as the episode audio.',
+							'jetpack'
+						),
+					} }
+					accept="audio/*,video/*"
+					allowedTypes={ AUDIO_VIDEO_MIME_TYPES }
+					onSelect={ onSelectMedia }
+					onError={ message => setUploadError( message ) }
+					notices={
+						uploadError ? <div className="components-notice is-error">{ uploadError }</div> : null
+					}
+				/>
+			</div>
+		);
+	}
+
+	const dateSettings = getDateSettings();
+
+	return (
+		<div { ...blockProps }>
+			<BlockControls>
+				<ToolbarGroup>
+					<MediaReplaceFlow
+						mediaId={ mediaId }
+						mediaURL={ mediaUrl }
+						allowedTypes={ AUDIO_VIDEO_MIME_TYPES }
+						accept="audio/*,video/*"
+						onSelect={ onSelectMedia }
+						onError={ message => setUploadError( message ) }
+						name={ __( 'Replace audio/video', 'jetpack' ) }
+					/>
+					<MediaUploadCheck>
+						<MediaUpload
+							onSelect={ onSelectImage }
+							allowedTypes={ [ 'image' ] }
+							value={ imageId }
+							render={ ( { open } ) => (
+								<ToolbarButton aria-label={ __( 'Select cover art', 'jetpack' ) } onClick={ open }>
+									{ imageUrl
+										? __( 'Change cover art', 'jetpack' )
+										: __( 'Add cover art', 'jetpack' ) }
+								</ToolbarButton>
+							) }
+						/>
+					</MediaUploadCheck>
+				</ToolbarGroup>
+			</BlockControls>
+
+			<InspectorControls>
+				<PanelBody title={ __( 'Episode details', 'jetpack' ) }>
+					<TextControl
+						label={ __( 'Episode number', 'jetpack' ) }
+						type="number"
+						min={ 0 }
+						value={ episodeNumber ?? '' }
+						onChange={ value =>
+							setAttributes( {
+								episodeNumber: value === '' ? undefined : Number( value ),
+							} )
+						}
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+					/>
+					<TextControl
+						label={ __( 'Season number', 'jetpack' ) }
+						type="number"
+						min={ 0 }
+						value={ seasonNumber ?? '' }
+						onChange={ value =>
+							setAttributes( {
+								seasonNumber: value === '' ? undefined : Number( value ),
+							} )
+						}
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+					/>
+					<SelectControl
+						label={ __( 'Episode type', 'jetpack' ) }
+						value={ episodeType }
+						options={ EPISODE_TYPE_OPTIONS }
+						onChange={ value => setAttributes( { episodeType: value } ) }
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+					/>
+					<ToggleControl
+						label={ __( 'Explicit content', 'jetpack' ) }
+						checked={ !! explicit }
+						onChange={ value => setAttributes( { explicit: value } ) }
+						__nextHasNoMarginBottom
+					/>
+					<TextControl
+						label={ __( 'Author / host', 'jetpack' ) }
+						value={ author }
+						onChange={ value => setAttributes( { author: value } ) }
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+					/>
+					<TextControl
+						label={ __( 'Duration', 'jetpack' ) }
+						help={ __( 'Formatted as HH:MM:SS or MM:SS.', 'jetpack' ) }
+						value={ duration }
+						onChange={ value => setAttributes( { duration: value } ) }
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+					/>
+					<BaseControl
+						id="jetpack-podcast-episode-publish-date"
+						label={ __( 'Publish date', 'jetpack' ) }
+						__nextHasNoMarginBottom
+					>
+						<Dropdown
+							popoverProps={ { placement: 'bottom-start' } }
+							renderToggle={ ( { isOpen, onToggle } ) => (
+								<Button
+									variant="secondary"
+									onClick={ onToggle }
+									aria-expanded={ isOpen }
+									__next40pxDefaultSize
+								>
+									{ publishDate
+										? dateI18n( dateSettings.formats.datetime, publishDate )
+										: __( 'Set date', 'jetpack' ) }
+								</Button>
+							) }
+							renderContent={ () => (
+								<DateTimePicker
+									currentDate={ publishDate }
+									onChange={ value => setAttributes( { publishDate: value } ) }
+									is12Hour={ dateSettings.formats.time.toLowerCase().includes( 'a' ) }
+								/>
+							) }
+						/>
+						{ publishDate && (
+							<Button
+								variant="link"
+								isDestructive
+								onClick={ () => setAttributes( { publishDate: undefined } ) }
+							>
+								{ __( 'Clear date', 'jetpack' ) }
+							</Button>
+						) }
+					</BaseControl>
+					<TextControl
+						label={ __( 'Episode GUID', 'jetpack' ) }
+						help={ __( 'Optional permanent identifier for this episode.', 'jetpack' ) }
+						value={ guid || '' }
+						onChange={ value => setAttributes( { guid: value } ) }
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+					/>
+				</PanelBody>
+
+				<PanelBody title={ __( 'Cover art', 'jetpack' ) } initialOpen={ false }>
+					<ToggleControl
+						label={ __( 'Show cover art', 'jetpack' ) }
+						checked={ !! showPoster }
+						onChange={ value => setAttributes( { showPoster: value } ) }
+						__nextHasNoMarginBottom
+					/>
+					<MediaUploadCheck>
+						<MediaUpload
+							onSelect={ onSelectImage }
+							allowedTypes={ [ 'image' ] }
+							value={ imageId }
+							render={ ( { open } ) => (
+								<PanelRow>
+									<Button variant="secondary" onClick={ open } __next40pxDefaultSize>
+										{ imageUrl
+											? __( 'Replace cover art', 'jetpack' )
+											: __( 'Select cover art', 'jetpack' ) }
+									</Button>
+									{ imageUrl && (
+										<Button variant="link" isDestructive onClick={ clearImage }>
+											{ __( 'Remove', 'jetpack' ) }
+										</Button>
+									) }
+								</PanelRow>
+							) }
+						/>
+					</MediaUploadCheck>
+				</PanelBody>
+
+				<PanelBody title={ __( 'Podcasting 2.0', 'jetpack' ) } initialOpen={ false }>
+					<TextControl
+						label={ __( 'Transcript URL', 'jetpack' ) }
+						type="url"
+						value={ transcriptUrl }
+						onChange={ value => setAttributes( { transcriptUrl: value } ) }
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+					/>
+					<SelectControl
+						label={ __( 'Transcript format', 'jetpack' ) }
+						value={ transcriptType }
+						options={ TRANSCRIPT_TYPE_OPTIONS }
+						onChange={ value => setAttributes( { transcriptType: value } ) }
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+					/>
+					<TextControl
+						label={ __( 'Chapters URL', 'jetpack' ) }
+						help={ __( 'Link to a JSON chapters file (podcast:chapters).', 'jetpack' ) }
+						type="url"
+						value={ chaptersUrl }
+						onChange={ value => setAttributes( { chaptersUrl: value } ) }
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+					/>
+					<TextControl
+						label={ __( 'Location', 'jetpack' ) }
+						help={ __( 'Human-readable location associated with this episode.', 'jetpack' ) }
+						value={ locationName }
+						onChange={ value => setAttributes( { locationName: value } ) }
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+					/>
+					<TextControl
+						label={ __( 'License', 'jetpack' ) }
+						help={ __( 'e.g. CC-BY-4.0 or all rights reserved.', 'jetpack' ) }
+						value={ license }
+						onChange={ value => setAttributes( { license: value } ) }
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+					/>
+					<TextControl
+						label={ __( 'License URL', 'jetpack' ) }
+						type="url"
+						value={ licenseUrl }
+						onChange={ value => setAttributes( { licenseUrl: value } ) }
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+					/>
+					<BaseControl
+						id="jetpack-podcast-episode-people"
+						label={ __( 'People', 'jetpack' ) }
+						help={ __( 'Hosts, guests, and other people featured in this episode.', 'jetpack' ) }
+						__nextHasNoMarginBottom
+					>
+						<PeopleEditor
+							people={ people }
+							onChange={ value => setAttributes( { people: value } ) }
+						/>
+					</BaseControl>
+				</PanelBody>
+			</InspectorControls>
+
+			<article className="jetpack-podcast-episode">
+				{ showPoster && imageUrl && (
+					<figure className="jetpack-podcast-episode__poster">
+						<img src={ imageUrl } alt={ title || '' } />
+					</figure>
+				) }
+				<div className="jetpack-podcast-episode__body">
+					{ ( seasonNumber || episodeNumber || episodeType !== 'full' || explicit ) && (
+						<p className="jetpack-podcast-episode__meta-line">
+							{ seasonNumber ? (
+								<span className="jetpack-podcast-episode__season">
+									{ /* translators: %d: season number */ }
+									{ __( 'Season', 'jetpack' ) } { seasonNumber }
+								</span>
+							) : null }
+							{ episodeNumber ? (
+								<span className="jetpack-podcast-episode__episode-number">
+									{ __( 'Episode', 'jetpack' ) } { episodeNumber }
+								</span>
+							) : null }
+							{ episodeType === 'trailer' && (
+								<span className="jetpack-podcast-episode__badge jetpack-podcast-episode__badge--trailer">
+									{ __( 'Trailer', 'jetpack' ) }
+								</span>
+							) }
+							{ episodeType === 'bonus' && (
+								<span className="jetpack-podcast-episode__badge jetpack-podcast-episode__badge--bonus">
+									{ __( 'Bonus', 'jetpack' ) }
+								</span>
+							) }
+							{ explicit && (
+								<span
+									className="jetpack-podcast-episode__badge jetpack-podcast-episode__badge--explicit"
+									title={ __( 'Explicit content', 'jetpack' ) }
+								>
+									{ __( 'E', 'jetpack' ) }
+								</span>
+							) }
+						</p>
+					) }
+
+					<RichText
+						tagName="h3"
+						className="jetpack-podcast-episode__title"
+						value={ title }
+						onChange={ value => setAttributes( { title: value } ) }
+						placeholder={ __( 'Episode title…', 'jetpack' ) }
+						allowedFormats={ [] }
+					/>
+
+					{ ( author || duration || publishDate || isSelected ) && (
+						<p className="jetpack-podcast-episode__byline">
+							{ author && <span className="jetpack-podcast-episode__author">{ author }</span> }
+							{ publishDate && (
+								<time className="jetpack-podcast-episode__date">
+									{ dateI18n( dateSettings.formats.date, publishDate ) }
+								</time>
+							) }
+							{ duration && (
+								<span className="jetpack-podcast-episode__duration">{ duration }</span>
+							) }
+						</p>
+					) }
+
+					<div className="jetpack-podcast-episode__player">
+						{ mediaType === 'video' ? (
+							<video
+								src={ mediaUrl }
+								controls
+								preload="metadata"
+								poster={ showPoster ? imageUrl : undefined }
+								data-mime={ mediaMimeType || undefined }
+							/>
+						) : (
+							<audio src={ mediaUrl } controls preload="metadata" />
+						) }
+					</div>
+
+					<RichText
+						tagName="p"
+						className="jetpack-podcast-episode__summary"
+						value={ summary }
+						onChange={ value => setAttributes( { summary: value } ) }
+						placeholder={ __( 'Short episode summary (one or two sentences)…', 'jetpack' ) }
+						allowedFormats={ [] }
+					/>
+
+					<RichText
+						tagName="div"
+						className="jetpack-podcast-episode__description"
+						value={ description }
+						onChange={ value => setAttributes( { description: value } ) }
+						placeholder={ __( 'Episode show notes…', 'jetpack' ) }
+					/>
+				</div>
+			</article>
+		</div>
+	);
+}

--- a/projects/plugins/jetpack/extensions/blocks/podcast-episode/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-episode/edit.js
@@ -275,14 +275,21 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, isSelec
 							render={ ( { open } ) =>
 								imageUrl ? (
 									<ToolbarButton
-										aria-label={ __( 'Select cover art', 'jetpack' ) }
+										aria-label={ __( 'Replace cover art', 'jetpack' ) }
 										onClick={ open }
-									>
-										{ __( 'Change cover art', 'jetpack' ) }
-									</ToolbarButton>
+										icon={
+											<img
+												src={ imageUrl }
+												alt=""
+												className="jetpack-podcast-episode__cover-thumbnail"
+											/>
+										}
+										showTooltip
+										label={ __( 'Replace cover art', 'jetpack' ) }
+									/>
 								) : (
 									<ToolbarButton
-										aria-label={ __( 'Select cover art', 'jetpack' ) }
+										aria-label={ __( 'Add cover art', 'jetpack' ) }
 										onClick={ open }
 									>
 										{ __( 'Add cover art', 'jetpack' ) }
@@ -542,7 +549,7 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, isSelec
 						className="jetpack-podcast-episode__title"
 						value={ title }
 						onChange={ value => setAttributes( { title: value } ) }
-						placeholder={ __( 'Episode title…', 'jetpack' ) }
+						placeholder={ __( 'Episode title', 'jetpack' ) }
 						allowedFormats={ [] }
 					/>
 
@@ -579,7 +586,7 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, isSelec
 						className="jetpack-podcast-episode__summary"
 						value={ summary }
 						onChange={ value => setAttributes( { summary: value } ) }
-						placeholder={ __( 'Short episode summary (one or two sentences)…', 'jetpack' ) }
+						placeholder={ __( 'Episode summary (one or two sentences)', 'jetpack' ) }
 						allowedFormats={ [] }
 					/>
 
@@ -588,7 +595,7 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, isSelec
 						className="jetpack-podcast-episode__description"
 						value={ description }
 						onChange={ value => setAttributes( { description: value } ) }
-						placeholder={ __( 'Episode show notes…', 'jetpack' ) }
+						placeholder={ __( 'Show notes: links, timestamps, guests', 'jetpack' ) }
 					/>
 				</div>
 			</article>

--- a/projects/plugins/jetpack/extensions/blocks/podcast-episode/editor.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-episode/editor.js
@@ -1,0 +1,12 @@
+import { registerJetpackBlockFromMetadata } from '../../shared/register-jetpack-block';
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+
+import './style.scss';
+import './editor.scss';
+
+registerJetpackBlockFromMetadata( metadata, {
+	edit,
+	save,
+} );

--- a/projects/plugins/jetpack/extensions/blocks/podcast-episode/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-episode/editor.scss
@@ -16,3 +16,11 @@
 		border-radius: 4px;
 	}
 }
+
+.jetpack-podcast-episode__cover-thumbnail {
+	width: 24px;
+	height: 24px;
+	object-fit: cover;
+	border-radius: 2px;
+	display: block;
+}

--- a/projects/plugins/jetpack/extensions/blocks/podcast-episode/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-episode/editor.scss
@@ -1,0 +1,18 @@
+/**
+ * Podcast Episode block — editor-only styles.
+ */
+
+.wp-block-jetpack-podcast-episode {
+
+	.jetpack-podcast-episode__title[contenteditable="true"]:empty::before,
+	.jetpack-podcast-episode__summary[contenteditable="true"]:empty::before,
+	.jetpack-podcast-episode__description[contenteditable="true"]:empty::before {
+		color: rgba(0, 0, 0, 0.4);
+	}
+
+	.jetpack-podcast-episode__person-editor {
+		padding: 12px;
+		border: 1px solid #ddd;
+		border-radius: 4px;
+	}
+}

--- a/projects/plugins/jetpack/extensions/blocks/podcast-episode/icons/index.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-episode/icons/index.js
@@ -1,0 +1,1 @@
+export { default as microphone } from './microphone';

--- a/projects/plugins/jetpack/extensions/blocks/podcast-episode/icons/microphone.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-episode/icons/microphone.js
@@ -1,0 +1,7 @@
+import { Path, SVG } from '@wordpress/primitives';
+
+export default (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+		<Path d="M12 2a5 5 0 0 0-5 5v5a5 5 0 0 0 10 0V7a5 5 0 0 0-5-5zm0 2a3 3 0 0 1 3 3v5a3 3 0 0 1-6 0V7a3 3 0 0 1 3-3zm-7 8a1 1 0 0 1 1 1 6 6 0 0 0 12 0 1 1 0 1 1 2 0 8 8 0 0 1-7 7.93V22h3v2H8v-2h3v-1.07A8 8 0 0 1 4 13a1 1 0 0 1 1-1z" />
+	</SVG>
+);

--- a/projects/plugins/jetpack/extensions/blocks/podcast-episode/podcast-episode.php
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-episode/podcast-episode.php
@@ -1,0 +1,284 @@
+<?php
+/**
+ * Podcast Episode Block.
+ *
+ * @since $$next-version$$
+ *
+ * @package automattic/jetpack
+ */
+
+namespace Automattic\Jetpack\Extensions\Podcast_Episode;
+
+use Automattic\Jetpack\Blocks;
+use Automattic\Jetpack\Status\Host;
+use Automattic\Jetpack\Status\Request;
+use Jetpack_Gutenberg;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
+/**
+ * Registers the block for use in Gutenberg.
+ *
+ * Only registered on WordPress.com sites (Simple or Atomic/WoA).
+ */
+function register_block() {
+	if ( ! ( new Host() )->is_wpcom_platform() ) {
+		return;
+	}
+
+	Blocks::jetpack_register_block(
+		__DIR__,
+		array(
+			'render_callback' => __NAMESPACE__ . '\render_block',
+			// Reuse the core media element styles for the audio/video player.
+			'style'           => 'wp-mediaelement',
+		)
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\register_block' );
+
+/**
+ * Podcast Episode block render callback.
+ *
+ * @param array  $attributes Block attributes.
+ * @param string $content    Inner content (fallback direct-link markup from save.js).
+ * @return string
+ */
+function render_block( $attributes, $content ) {
+	// Outside the frontend, fall back to the saved direct link so RSS / email / REST export stays
+	// simple and predictable.
+	if ( ! Request::is_frontend() ) {
+		return $content;
+	}
+
+	if ( empty( $attributes['mediaUrl'] ) ) {
+		return '';
+	}
+
+	$media_url = esc_url_raw( $attributes['mediaUrl'] );
+	if ( ! wp_http_validate_url( $media_url ) ) {
+		return '';
+	}
+
+	$media_type     = isset( $attributes['mediaType'] ) && 'video' === $attributes['mediaType'] ? 'video' : 'audio';
+	$mime_type      = isset( $attributes['mediaMimeType'] ) ? (string) $attributes['mediaMimeType'] : '';
+	$title          = isset( $attributes['title'] ) ? (string) $attributes['title'] : '';
+	$summary        = isset( $attributes['summary'] ) ? (string) $attributes['summary'] : '';
+	$description    = isset( $attributes['description'] ) ? (string) $attributes['description'] : '';
+	$author         = isset( $attributes['author'] ) ? (string) $attributes['author'] : '';
+	$episode_number = isset( $attributes['episodeNumber'] ) ? (int) $attributes['episodeNumber'] : 0;
+	$season_number  = isset( $attributes['seasonNumber'] ) ? (int) $attributes['seasonNumber'] : 0;
+	$episode_type   = isset( $attributes['episodeType'] ) ? (string) $attributes['episodeType'] : 'full';
+	$is_explicit    = ! empty( $attributes['explicit'] );
+	$publish_date   = isset( $attributes['publishDate'] ) ? (string) $attributes['publishDate'] : '';
+	$duration       = isset( $attributes['duration'] ) ? (string) $attributes['duration'] : '';
+	$image_url      = isset( $attributes['imageUrl'] ) ? esc_url_raw( $attributes['imageUrl'] ) : '';
+	$show_poster    = ! isset( $attributes['showPoster'] ) || ! empty( $attributes['showPoster'] );
+	$transcript_url = isset( $attributes['transcriptUrl'] ) ? esc_url_raw( $attributes['transcriptUrl'] ) : '';
+	$chapters_url   = isset( $attributes['chaptersUrl'] ) ? esc_url_raw( $attributes['chaptersUrl'] ) : '';
+	$location_name  = isset( $attributes['locationName'] ) ? (string) $attributes['locationName'] : '';
+	$license        = isset( $attributes['license'] ) ? (string) $attributes['license'] : '';
+	$license_url    = isset( $attributes['licenseUrl'] ) ? esc_url_raw( $attributes['licenseUrl'] ) : '';
+	$people         = isset( $attributes['people'] ) && is_array( $attributes['people'] ) ? $attributes['people'] : array();
+
+	$wrapper_attributes = \WP_Block_Supports::get_instance()->apply_block_supports();
+	$wrapper_style      = ! empty( $wrapper_attributes['style'] ) ? $wrapper_attributes['style'] : '';
+	$block_classname    = Blocks::classes( Blocks::get_block_feature( __DIR__ ), $attributes );
+	$is_amp             = Blocks::is_amp_request();
+
+	ob_start();
+	?>
+	<div
+		class="<?php echo esc_attr( $block_classname ); ?>"
+		<?php
+		if ( $wrapper_style ) :
+			?>
+			style="<?php echo esc_attr( $wrapper_style ); ?>"<?php endif; ?>
+	>
+		<article class="jetpack-podcast-episode" itemscope itemtype="https://schema.org/PodcastEpisode">
+			<?php if ( $show_poster && $image_url ) : ?>
+				<figure class="jetpack-podcast-episode__poster">
+					<img
+						src="<?php echo esc_url( $image_url ); ?>"
+						alt="<?php echo esc_attr( $title ); ?>"
+						itemprop="image"
+						loading="lazy"
+					/>
+				</figure>
+			<?php endif; ?>
+
+			<div class="jetpack-podcast-episode__body">
+				<?php if ( $season_number || $episode_number || 'full' !== $episode_type ) : ?>
+					<p class="jetpack-podcast-episode__meta-line">
+						<?php if ( $season_number ) : ?>
+							<span class="jetpack-podcast-episode__season">
+								<?php
+								/* translators: %d: season number. */
+								echo esc_html( sprintf( __( 'Season %d', 'jetpack' ), $season_number ) );
+								?>
+							</span>
+						<?php endif; ?>
+						<?php if ( $episode_number ) : ?>
+							<span class="jetpack-podcast-episode__episode-number" itemprop="episodeNumber">
+								<?php
+								/* translators: %d: episode number. */
+								echo esc_html( sprintf( __( 'Episode %d', 'jetpack' ), $episode_number ) );
+								?>
+							</span>
+						<?php endif; ?>
+						<?php if ( 'trailer' === $episode_type ) : ?>
+							<span class="jetpack-podcast-episode__badge jetpack-podcast-episode__badge--trailer"><?php esc_html_e( 'Trailer', 'jetpack' ); ?></span>
+						<?php elseif ( 'bonus' === $episode_type ) : ?>
+							<span class="jetpack-podcast-episode__badge jetpack-podcast-episode__badge--bonus"><?php esc_html_e( 'Bonus', 'jetpack' ); ?></span>
+						<?php endif; ?>
+						<?php if ( $is_explicit ) : ?>
+							<span class="jetpack-podcast-episode__badge jetpack-podcast-episode__badge--explicit" title="<?php esc_attr_e( 'Explicit content', 'jetpack' ); ?>"><?php esc_html_e( 'E', 'jetpack' ); ?></span>
+						<?php endif; ?>
+					</p>
+				<?php endif; ?>
+
+				<?php if ( $title ) : ?>
+					<h3 class="jetpack-podcast-episode__title" itemprop="name"><?php echo esc_html( $title ); ?></h3>
+				<?php endif; ?>
+
+				<?php if ( $author || $publish_date || $duration ) : ?>
+					<p class="jetpack-podcast-episode__byline">
+						<?php if ( $author ) : ?>
+							<span class="jetpack-podcast-episode__author" itemprop="author"><?php echo esc_html( $author ); ?></span>
+						<?php endif; ?>
+						<?php if ( $publish_date ) : ?>
+							<time
+								class="jetpack-podcast-episode__date"
+								datetime="<?php echo esc_attr( $publish_date ); ?>"
+								itemprop="datePublished"
+							>
+								<?php echo esc_html( mysql2date( get_option( 'date_format' ), $publish_date ) ); ?>
+							</time>
+						<?php endif; ?>
+						<?php if ( $duration ) : ?>
+							<span class="jetpack-podcast-episode__duration" itemprop="duration"><?php echo esc_html( $duration ); ?></span>
+						<?php endif; ?>
+					</p>
+				<?php endif; ?>
+
+				<div class="jetpack-podcast-episode__player">
+					<?php if ( 'video' === $media_type ) : ?>
+						<video
+							class="jetpack-podcast-episode__video"
+							controls
+							preload="metadata"
+							src="<?php echo esc_url( $media_url ); ?>"
+							<?php
+							if ( $show_poster && $image_url ) :
+								?>
+								poster="<?php echo esc_url( $image_url ); ?>"<?php endif; ?>
+							<?php
+							if ( $mime_type ) :
+								?>
+								data-mime="<?php echo esc_attr( $mime_type ); ?>"<?php endif; ?>
+							itemprop="associatedMedia"
+						></video>
+					<?php else : ?>
+						<audio
+							class="jetpack-podcast-episode__audio"
+							controls
+							preload="metadata"
+							src="<?php echo esc_url( $media_url ); ?>"
+							<?php
+							if ( $mime_type ) :
+								?>
+								data-mime="<?php echo esc_attr( $mime_type ); ?>"<?php endif; ?>
+							itemprop="associatedMedia"
+						></audio>
+					<?php endif; ?>
+				</div>
+
+				<?php if ( $summary ) : ?>
+					<p class="jetpack-podcast-episode__summary" itemprop="description"><?php echo esc_html( $summary ); ?></p>
+				<?php endif; ?>
+
+				<?php if ( $description ) : ?>
+					<div class="jetpack-podcast-episode__description">
+						<?php echo wp_kses_post( wpautop( $description ) ); ?>
+					</div>
+				<?php endif; ?>
+
+				<?php if ( ! empty( $people ) ) : ?>
+					<ul class="jetpack-podcast-episode__people">
+						<?php
+						foreach ( $people as $person ) :
+							if ( empty( $person['name'] ) ) {
+								continue;
+							}
+							$person_name = (string) $person['name'];
+							$person_role = isset( $person['role'] ) ? (string) $person['role'] : '';
+							$person_href = isset( $person['href'] ) ? esc_url_raw( $person['href'] ) : '';
+							$person_img  = isset( $person['img'] ) ? esc_url_raw( $person['img'] ) : '';
+							?>
+							<li class="jetpack-podcast-episode__person" itemprop="actor" itemscope itemtype="https://schema.org/Person">
+								<?php if ( $person_img ) : ?>
+									<img src="<?php echo esc_url( $person_img ); ?>" alt="" loading="lazy" />
+								<?php endif; ?>
+								<?php if ( $person_href ) : ?>
+									<a href="<?php echo esc_url( $person_href ); ?>" itemprop="url">
+										<span itemprop="name"><?php echo esc_html( $person_name ); ?></span>
+									</a>
+								<?php else : ?>
+									<span itemprop="name"><?php echo esc_html( $person_name ); ?></span>
+								<?php endif; ?>
+								<?php if ( $person_role ) : ?>
+									<span class="jetpack-podcast-episode__person-role"><?php echo esc_html( $person_role ); ?></span>
+								<?php endif; ?>
+							</li>
+						<?php endforeach; ?>
+					</ul>
+				<?php endif; ?>
+
+				<?php if ( $transcript_url || $chapters_url || $location_name || $license ) : ?>
+					<ul class="jetpack-podcast-episode__links">
+						<?php if ( $transcript_url ) : ?>
+							<li>
+								<a href="<?php echo esc_url( $transcript_url ); ?>" class="jetpack-podcast-episode__transcript-link">
+									<?php esc_html_e( 'Read transcript', 'jetpack' ); ?>
+								</a>
+							</li>
+						<?php endif; ?>
+						<?php if ( $chapters_url ) : ?>
+							<li>
+								<a href="<?php echo esc_url( $chapters_url ); ?>" class="jetpack-podcast-episode__chapters-link">
+									<?php esc_html_e( 'View chapters', 'jetpack' ); ?>
+								</a>
+							</li>
+						<?php endif; ?>
+						<?php if ( $location_name ) : ?>
+							<li class="jetpack-podcast-episode__location" itemprop="contentLocation"><?php echo esc_html( $location_name ); ?></li>
+						<?php endif; ?>
+						<?php if ( $license ) : ?>
+							<li class="jetpack-podcast-episode__license">
+								<?php
+								/* translators: %s: license identifier. */
+								$license_label = sprintf( __( 'License: %s', 'jetpack' ), $license );
+								?>
+								<?php if ( $license_url ) : ?>
+									<a href="<?php echo esc_url( $license_url ); ?>" itemprop="license"><?php echo esc_html( $license_label ); ?></a>
+								<?php else : ?>
+									<?php echo esc_html( $license_label ); ?>
+								<?php endif; ?>
+							</li>
+						<?php endif; ?>
+					</ul>
+				<?php endif; ?>
+			</div>
+		</article>
+	</div>
+	<?php
+
+	if ( ! $is_amp ) {
+		wp_enqueue_style( 'wp-mediaelement' );
+	}
+	Jetpack_Gutenberg::load_assets_as_required( __DIR__, array( 'mediaelement' ) );
+
+	return ob_get_clean();
+}

--- a/projects/plugins/jetpack/extensions/blocks/podcast-episode/save.js
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-episode/save.js
@@ -1,0 +1,20 @@
+import { useBlockProps } from '@wordpress/block-editor';
+import clsx from 'clsx';
+
+export default function save( { attributes } ) {
+	const { mediaUrl, title } = attributes;
+	if ( ! mediaUrl ) {
+		return null;
+	}
+
+	const blockProps = useBlockProps.save();
+	return (
+		<a
+			{ ...blockProps }
+			className={ clsx( blockProps.className, 'jetpack-podcast-episode__direct-link' ) }
+			href={ mediaUrl }
+		>
+			{ title || mediaUrl }
+		</a>
+	);
+}

--- a/projects/plugins/jetpack/extensions/blocks/podcast-episode/style.scss
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-episode/style.scss
@@ -1,0 +1,172 @@
+/**
+ * Podcast Episode block shared styles (editor + front-end).
+ */
+@use "@automattic/jetpack-base-styles/gutenberg-base-styles" as gb;
+
+$jetpack-podcast-episode-radius: 6px;
+$jetpack-podcast-episode-gap: 16px;
+
+.wp-block-jetpack-podcast-episode {
+
+	.jetpack-podcast-episode {
+		display: flex;
+		gap: $jetpack-podcast-episode-gap;
+		align-items: flex-start;
+		padding: $jetpack-podcast-episode-gap;
+		border: 1px solid gb.$gray-200;
+		border-radius: $jetpack-podcast-episode-radius;
+		background-color: gb.$white;
+
+		@media (max-width: 600px) {
+			flex-direction: column;
+		}
+	}
+
+	.jetpack-podcast-episode__poster {
+		flex: 0 0 auto;
+		margin: 0;
+		inline-size: 160px;
+		max-inline-size: 40%;
+
+		img {
+			inline-size: 100%;
+			block-size: auto;
+			border-radius: calc(#{$jetpack-podcast-episode-radius} - 2px);
+			display: block;
+		}
+
+		@media (max-width: 600px) {
+			inline-size: 100%;
+			max-inline-size: 100%;
+		}
+	}
+
+	.jetpack-podcast-episode__body {
+		flex: 1 1 auto;
+		min-inline-size: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	.jetpack-podcast-episode__meta-line {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 8px;
+		margin: 0;
+		font-size: 0.85em;
+		color: gb.$gray-700;
+		text-transform: uppercase;
+		letter-spacing: 0.03em;
+	}
+
+	.jetpack-podcast-episode__badge {
+		display: inline-flex;
+		align-items: center;
+		padding-inline: 8px;
+		padding-block: 2px;
+		font-size: 0.75em;
+		font-weight: 600;
+		line-height: 1.4;
+		border-radius: 999px;
+		background-color: gb.$gray-100;
+		color: gb.$gray-900;
+	}
+
+	.jetpack-podcast-episode__badge--trailer {
+		background-color: #e7f5ff;
+		color: #0073aa;
+	}
+
+	.jetpack-podcast-episode__badge--bonus {
+		background-color: #fff4e6;
+		color: #b35900;
+	}
+
+	.jetpack-podcast-episode__badge--explicit {
+		background-color: gb.$gray-900;
+		color: gb.$white;
+		font-family: monospace;
+	}
+
+	.jetpack-podcast-episode__title {
+		margin: 0;
+		font-size: 1.4em;
+		line-height: 1.3;
+	}
+
+	.jetpack-podcast-episode__byline {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 12px;
+		margin: 0;
+		font-size: 0.9em;
+		color: gb.$gray-700;
+	}
+
+	.jetpack-podcast-episode__player {
+		margin-block: 4px;
+
+		audio,
+		video {
+			inline-size: 100%;
+			max-inline-size: 100%;
+			display: block;
+		}
+
+		video {
+			border-radius: calc(#{$jetpack-podcast-episode-radius} - 2px);
+		}
+	}
+
+	.jetpack-podcast-episode__summary {
+		margin: 0;
+		font-weight: 500;
+	}
+
+	.jetpack-podcast-episode__description {
+		margin: 0;
+
+		p:last-child {
+			margin-block-end: 0;
+		}
+	}
+
+	.jetpack-podcast-episode__people {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-wrap: wrap;
+		gap: 12px;
+	}
+
+	.jetpack-podcast-episode__person {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		font-size: 0.9em;
+
+		img {
+			inline-size: 28px;
+			block-size: 28px;
+			border-radius: 50%;
+			object-fit: cover;
+		}
+	}
+
+	.jetpack-podcast-episode__person-role {
+		color: gb.$gray-700;
+		font-size: 0.85em;
+	}
+
+	.jetpack-podcast-episode__links {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-wrap: wrap;
+		gap: 12px;
+		font-size: 0.9em;
+	}
+}

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -26,6 +26,7 @@
 		"opentable",
 		"payments",
 		"pinterest",
+		"podcast-episode",
 		"podcast-player",
 		"premium-content",
 		"rating-star",


### PR DESCRIPTION
## Proposed changes
* New `jetpack/podcast-episode` block: embeds a single audio or video file as a podcast episode with Podcasting 2.0 metadata (episode/season number, type, explicit flag, transcript URL, chapters URL, location, license, people).
* Registration is gated to WordPress.com sites (Simple + Atomic) via `Host::is_wpcom_platform()`.
* On media selection the block fetches the attachment's `media_details` and backfills empty duration/title/author/size fields from the ID3 tags WordPress parses on upload.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?

## Testing instructions
* Insert the **Podcast Episode** block (Embed category) on a WordPress.com Simple or Atomic site.
* Upload an audio file with ID3 tags and confirm Episode details fields auto-populate.
* Fill in Episode + Podcasting 2.0 panels, save, and verify the rendered front-end card shows the metadata and audio player.
