### PR TITLE
Copy Post: preserve backslashes in duplicated post content

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-copy-post-backslash-stripping
+++ b/projects/plugins/jetpack/changelog/fix-copy-post-backslash-stripping
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fix backslashes being stripped from post content when using the Copy Post (Duplicate) feature.

--- a/projects/plugins/jetpack/modules/copy-post.php
+++ b/projects/plugins/jetpack/modules/copy-post.php
@@ -171,7 +171,12 @@ class Jetpack_Copy_Post {
 		 * @param int     $target_post_id Target post ID.
 		 */
 		$data = apply_filters( 'jetpack_copy_post_data', $data, $source_post, $target_post_id );
-		return wp_update_post( $data );
+
+		// wp_update_post() expects slashed data when passing an array.
+		// Since the data comes from get_post() (which returns unslashed data),
+		// we need to re-slash it to prevent wp_unslash() from stripping
+		// backslashes and other escape sequences from the content.
+		return wp_update_post( wp_slash( $data ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/copy-post/Copy_Post_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/copy-post/Copy_Post_Test.php
@@ -15,9 +15,11 @@ require_once JETPACK__PLUGIN_DIR . 'modules/copy-post.php';
  *
  * @group copy-post
  * @covers Jetpack_Copy_Post::copy_footnotes
+ * @covers Jetpack_Copy_Post::update_content
  */
 #[Group( 'copy-post' )]
 #[CoversMethod( Jetpack_Copy_Post::class, 'copy_footnotes' )]
+#[CoversMethod( Jetpack_Copy_Post::class, 'update_content' )]
 class Copy_Post_Test extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
 
@@ -256,5 +258,67 @@ class Copy_Post_Test extends WP_UnitTestCase {
 		$target_footnotes = json_decode( get_post_meta( $target_post_id, 'footnotes', true ), true );
 		$this->assertIsArray( $target_footnotes );
 		$this->assertEquals( $footnote_content, $target_footnotes[0]['content'] );
+	}
+
+	/**
+	 * Test that backslashes are preserved when copying post content.
+	 *
+	 * @see https://github.com/Automattic/jetpack/issues/46020
+	 */
+	public function test_update_content_preserves_backslashes() {
+		$copy_post = new Jetpack_Copy_Post();
+
+		$content_with_backslashes = '<!-- wp:code -->
+<pre class="wp-block-code"><code>\t is a tab
+\n is newline
+\\ is backslash</code></pre>
+<!-- /wp:code -->';
+
+		$source_post_id = self::factory()->post->create(
+			array(
+				'post_content' => $content_with_backslashes,
+			)
+		);
+		$source_post    = get_post( $source_post_id );
+
+		$target_post_id = self::factory()->post->create();
+
+		// Call update_content which is the method under test.
+		$result = $copy_post->update_content( $source_post, $target_post_id );
+
+		// Assert wp_update_post succeeded.
+		$this->assertNotEquals( 0, $result );
+
+		// Fetch the target post and verify backslashes are preserved.
+		$target_post = get_post( $target_post_id );
+		$this->assertEquals( $content_with_backslashes, $target_post->post_content );
+	}
+
+	/**
+	 * Test that update_content preserves content with special escape sequences.
+	 *
+	 * @see https://github.com/Automattic/jetpack/issues/46020
+	 */
+	public function test_update_content_preserves_escape_sequences() {
+		$copy_post = new Jetpack_Copy_Post();
+
+		// Various backslash sequences that should be preserved.
+		$content = '<p>\t \n \f \\ \9 \ </p>';
+
+		$source_post_id = self::factory()->post->create(
+			array(
+				'post_content' => $content,
+			)
+		);
+		$source_post    = get_post( $source_post_id );
+
+		$target_post_id = self::factory()->post->create();
+
+		$result = $copy_post->update_content( $source_post, $target_post_id );
+
+		$this->assertNotEquals( 0, $result );
+
+		$target_post = get_post( $target_post_id );
+		$this->assertEquals( $content, $target_post->post_content, 'Backslash escape sequences should be preserved when copying posts.' );
 	}
 }


### PR DESCRIPTION
## What was the problem?

When duplicating a post via the Copy Post feature, backslash characters (`\`) were stripped from the post content. For example, `\t is a tab` in a code block became `t is a tab`.

This happened because `wp_update_post()` calls `wp_unslash()` on array input (via `wp_insert_post()` → `sanitize_post()`), but the source data from `get_post()` is already unslashed. The double unslashing removes legitimate backslash characters.

Closes #46020

## How was it fixed?

Added `wp_slash()` to the data array before passing it to `wp_update_post()`. This way, `wp_unslash()` inside `wp_update_post()` restores the original content with backslashes intact.

This matches the documented behavior in WordPress core: `wp_update_post()` only auto-slashes when passed an object, not an array. When passing an array, the caller is responsible for slashing the data.

Reference: https://developer.wordpress.org/reference/functions/wp_update_post/

## Changes

- `projects/plugins/jetpack/modules/copy-post.php` — wrap `$data` in `wp_slash()` before `wp_update_post()`
- `projects/plugins/jetpack/tests/php/modules/copy-post/Copy_Post_Test.php` — added tests for backslash preservation
- `projects/plugins/jetpack/changelog/fix-copy-post-backslash-stripping` — changelog entry

## Testing instructions

* Create a post with a Code block containing `\t is a tab`
* Save the post
* From the post list, click "Duplicate" (Jetpack Copy Post)
* Open the duplicated post
* Verify the backslash is preserved: `\t is a tab` (not `t is a tab`)
* Also test with content containing `\\`, `\n`, `\f` to confirm all are preserved
* Run existing tests: `jetpack test php --filter=copy-post`

## Does this pull request change what data or activity we track or use?

No. This PR only fixes how post content is passed to a WordPress core function. No data collection, tracking, or privacy-related changes.