### PR TITLE
VideoPress: handle missing privacy_setting in access check

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-undefined-privacy-setting
+++ b/projects/packages/videopress/changelog/fix-videopress-undefined-privacy-setting
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-VideoPress: avoid undefined property warning when video info has no privacy_setting
+VideoPress: Avoid undefined property warning when video info has no privacy_setting.

--- a/projects/packages/videopress/changelog/fix-videopress-undefined-privacy-setting
+++ b/projects/packages/videopress/changelog/fix-videopress-undefined-privacy-setting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: avoid undefined property warning when video info has no privacy_setting

--- a/projects/packages/videopress/src/class-access-control.php
+++ b/projects/packages/videopress/src/class-access-control.php
@@ -427,10 +427,16 @@ class Access_Control {
 			return false;
 		}
 
+		/*
+		 * Fall back to SITE_DEFAULT when the property is missing so the site-level
+		 * privacy check applies, rather than treating absence as public access.
+		 */
+		$privacy_setting = $video_info->privacy_setting ?? VIDEOPRESS_PRIVACY::SITE_DEFAULT;
+
 		$embedded_post_id = (int) $embedded_post_id;
 		if (
 			$embedded_post_id
-			&& VIDEOPRESS_PRIVACY::IS_PUBLIC !== $video_info->privacy_setting
+			&& VIDEOPRESS_PRIVACY::IS_PUBLIC !== $privacy_setting
 			&& ! $this->post_embeds_videopress_guid( $embedded_post_id, $guid )
 		) {
 			$embedded_post_id = 0;
@@ -439,7 +445,7 @@ class Access_Control {
 		$is_user_authed = false;
 
 		// Determine if video is public, private or use site default.
-		switch ( $video_info->privacy_setting ) {
+		switch ( $privacy_setting ) {
 			case VIDEOPRESS_PRIVACY::IS_PUBLIC:
 				$is_user_authed = true;
 				break;

--- a/projects/packages/videopress/src/class-access-control.php
+++ b/projects/packages/videopress/src/class-access-control.php
@@ -428,8 +428,8 @@ class Access_Control {
 		}
 
 		/*
-		 * Fall back to SITE_DEFAULT when the property is missing so the site-level
-		 * privacy check applies, rather than treating absence as public access.
+		 * Default missing privacy_setting to SITE_DEFAULT to avoid an
+		 * undefined-property warning and make the site-level fallback explicit.
 		 */
 		$privacy_setting = $video_info->privacy_setting ?? VIDEOPRESS_PRIVACY::SITE_DEFAULT;
 


### PR DESCRIPTION
Fixes #

## Proposed changes
* Fix `Undefined property: stdClass::$privacy_setting` warning in `Access_Control::is_current_user_authed_for_video()` (PHP 8.4) when `video_get_info_by_blogpostid()` returns a stdClass without that property.
* Read the value once into a local with a `VIDEOPRESS_PRIVACY::SITE_DEFAULT` fallback so the site-level privacy check applies — rather than letting the missing property silently slip through to behavior equivalent to public access.

## Related product discussion/links
* Reported via PHP error log on `whosnexttributeusa.com` (PHP 8.4.20) hitting `wp_ajax_nopriv_videopress-get-playback-jwt`.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
1. On a site running PHP 8.4, ensure the VideoPress package is loaded.
2. Enable PHP warnings (e.g. `WP_DEBUG = true`, `WP_DEBUG_LOG = true`).
3. Trigger the AJAX action `wp_ajax_nopriv_videopress-get-playback-jwt` (or call `Access_Control::is_current_user_authed_for_video()` directly) with a `$guid` whose underlying `video_get_info_by_blogpostid()` result is a stdClass lacking a `privacy_setting` property.
4. **Before this change:** an `Undefined property: stdClass::$privacy_setting` warning is logged at `class-access-control.php:433`.
5. **After this change:** no warning is emitted; access falls through to the site-default privacy check, matching pre-PHP-8.4 behavior.
6. Sanity check: videos with explicit `privacy_setting` values (`IS_PUBLIC`, `IS_PRIVATE`, `SITE_DEFAULT`) still resolve to the same authorization outcome as before.
