### PR TITLE
ci: Fix plugin setup for `WITH_WPCOMSH` run

### DIFF
--- a/.github/files/setup-wordpress-env.sh
+++ b/.github/files/setup-wordpress-env.sh
@@ -39,11 +39,14 @@ mkdir -p "/tmp/wordpress-$WP_BRANCH/src/wp-content/uploads"
 chmod -R 777 "/tmp/wordpress-$WP_BRANCH/src/wp-content/uploads"
 echo "::endgroup::"
 
-echo "::endgroup::"
-
 if [[ -n "$GITHUB_ENV" ]]; then
 	echo "WORDPRESS_DEVELOP_DIR=/tmp/wordpress-$WP_BRANCH" >> "$GITHUB_ENV"
 	echo "WORDPRESS_DIR=/tmp/wordpress-$WP_BRANCH/src" >> "$GITHUB_ENV"
+fi
+
+# When running WITH_WPCOMSH, always ensure wpcomsh is installed even if it wasn't actually changed.
+if [[ "$WITH_WPCOMSH" == true && -n "$CHANGED" ]]; then
+	CHANGED=$( jq -c '.["plugins/wpcomsh"] |= true' <<<"$CHANGED" )
 fi
 
 # Don't symlink, it breaks when copied later.
@@ -152,13 +155,6 @@ function _install_plugin {
 
 	echo "::endgroup::"
 }
-
-# When running WITH_WPCOMSH, always ensure wpcomsh is installed even if it wasn't changed.
-# The WITH_WPCOMSH block below copies wpcomsh from plugins/ to mu-plugins/ and will fail
-# if wpcomsh was skipped by the CHANGED filter.
-if [[ "$WITH_WPCOMSH" == true && -n "$CHANGED" ]]; then
-	CHANGED=$(jq -c '. += { "plugins/wpcomsh": true }' <<<"$CHANGED")
-fi
 
 EXIT=0
 PIDS=()

--- a/.github/files/setup-wordpress-env.sh
+++ b/.github/files/setup-wordpress-env.sh
@@ -153,6 +153,13 @@ function _install_plugin {
 	echo "::endgroup::"
 }
 
+# When running WITH_WPCOMSH, always ensure wpcomsh is installed even if it wasn't changed.
+# The WITH_WPCOMSH block below copies wpcomsh from plugins/ to mu-plugins/ and will fail
+# if wpcomsh was skipped by the CHANGED filter.
+if [[ "$WITH_WPCOMSH" == true && -n "$CHANGED" ]]; then
+	CHANGED=$(jq -c '. += { "plugins/wpcomsh": true }' <<<"$CHANGED")
+fi
+
 EXIT=0
 PIDS=()
 TMPFILES=()


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
PR #48308 added logic to skip installing plugins that aren't going to be tested. But for the `WITH_WPCOMSH` run, we need to install wpcomsh even if it wasn't changed.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
bf3315b8dd32ef39acdb7f26f2f3b77d7b23b1fe, #48372

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* CI happy?
* Make a PR based on this one that only changes Jetpack-the-plugin. CI still happy?
  * [x] https://github.com/Automattic/jetpack/actions/runs/25115835210/job/73602488608?pr=48381