### PR TITLE
Write: Track last editor used and fire publish event

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-write_add_last_editor_meta
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-write_add_last_editor_meta
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Write: Set _last_editor_used_jetpack meta for editor attribution and fire client-side publish tracking event.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor/functions.editor-type.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor/functions.editor-type.php
@@ -49,30 +49,29 @@ function remember_block_editor( $editor_settings, $post ) {
 }
 
 /**
- * Register _last_editor_used_jetpack for REST API access so editors (e.g. the
- * Write editor) can set it via the meta field in save requests. Follows the same
- * pattern used by other Jetpack meta keys (e.g. _jetpack_newsletter_access).
+ * Register a write-only REST field so editors (e.g. the Write editor) can set
+ * the last-editor attribution via save requests. The underlying
+ * _last_editor_used_jetpack meta key is never exposed in REST responses.
  */
 \add_action(
-	'init',
+	'rest_api_init',
 	function () {
-		\register_post_meta(
+		\register_rest_field(
 			'post',
-			'_last_editor_used_jetpack',
+			'wpcom_editor_used',
 			array(
-				'show_in_rest'      => array(
-					'schema' => array(
-						'type'    => 'string',
-						'enum'    => array( 'classic-editor', 'block-editor', 'write-editor' ),
-						'context' => array( 'edit' ),
-					),
-				),
-				'single'            => true,
-				'type'              => 'string',
-				'auth_callback'     => function ( $allowed, $meta_key, $object_id ) {
-					return current_user_can( 'edit_post', $object_id );
+				'get_callback'    => null,
+				'update_callback' => function ( $value, $post ) {
+					if ( ! \current_user_can( 'edit_post', $post->ID ) ) {
+						return;
+					}
+					remember_editor( $post->ID, $value );
 				},
-				'sanitize_callback' => 'sanitize_text_field',
+				'schema'          => array(
+					'type'        => 'string',
+					'description' => __( 'Editor used to produce this revision.', 'jetpack-mu-wpcom' ),
+					'enum'        => array( 'classic-editor', 'block-editor', 'write-editor' ),
+				),
 			)
 		);
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor/functions.editor-type.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor/functions.editor-type.php
@@ -57,9 +57,13 @@ function remember_block_editor( $editor_settings, $post ) {
 \add_action(
 	'rest_after_insert_post',
 	function ( $post, $request ) {
-		if ( true === $request['wpcom_write_editor_used'] && \current_user_can( 'edit_post', $post->ID ) ) {
-			remember_editor( $post->ID, 'write-editor' );
+		if ( true !== $request['wpcom_write_editor_used'] ) {
+			return;
 		}
+		if ( ! \current_user_can( 'edit_post', $post->ID ) ) {
+			return;
+		}
+		remember_editor( $post->ID, 'write-editor' );
 	},
 	10,
 	2

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor/functions.editor-type.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor/functions.editor-type.php
@@ -53,21 +53,21 @@ function remember_block_editor( $editor_settings, $post ) {
  * last editor used. The JS client sends wpcom_write_editor_used: true as
  * an extra body param — no REST field registration needed since this is
  * an internal signal, not a public post attribute.
+ *
+ * @param \WP_Post         $post    The post that was inserted or updated.
+ * @param \WP_REST_Request $request The REST request that triggered the save.
  */
-\add_action(
-	'rest_after_insert_post',
-	function ( $post, $request ) {
-		if ( true !== $request['wpcom_write_editor_used'] ) {
-			return;
-		}
-		if ( ! \current_user_can( 'edit_post', $post->ID ) ) {
-			return;
-		}
-		remember_editor( $post->ID, 'write-editor' );
-	},
-	10,
-	2
-);
+function remember_write_editor( $post, $request ) {
+	if ( true !== $request['wpcom_write_editor_used'] ) {
+		return;
+	}
+	if ( ! \current_user_can( 'edit_post', $post->ID ) ) {
+		return;
+	}
+	remember_editor( $post->ID, 'write-editor' );
+}
+
+\add_action( 'rest_after_insert_post', __NAMESPACE__ . '\remember_write_editor', 10, 2 );
 
 /**
  * Sets the metadata for the specified post and editor.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor/functions.editor-type.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor/functions.editor-type.php
@@ -69,8 +69,8 @@ function remember_block_editor( $editor_settings, $post ) {
 				),
 				'single'            => true,
 				'type'              => 'string',
-				'auth_callback'     => function () {
-					return current_user_can( 'edit_posts' );
+				'auth_callback'     => function ( $allowed, $meta_key, $object_id ) {
+					return current_user_can( 'edit_post', $object_id );
 				},
 				'sanitize_callback' => 'sanitize_text_field',
 			)

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor/functions.editor-type.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor/functions.editor-type.php
@@ -49,36 +49,27 @@ function remember_block_editor( $editor_settings, $post ) {
 }
 
 /**
- * Register a write-only REST field so the Write editor can signal that it
- * produced a save. The update callback calls remember_editor() to set the
- * internal _last_editor_used_jetpack meta, which is never exposed in responses.
+ * When the Write editor saves a post via the REST API, record it as the
+ * last editor used. The JS client sends wpcom_write_editor_used: true as
+ * an extra body param — no REST field registration needed since this is
+ * an internal signal, not a public post attribute.
  */
 \add_action(
-	'rest_api_init',
-	function () {
-		\register_rest_field(
-			'post',
-			'wpcom_write_editor_used',
-			array(
-				'get_callback'    => null,
-				'update_callback' => function ( $value, $post ) {
-					if ( $value && \current_user_can( 'edit_post', $post->ID ) ) {
-						remember_editor( $post->ID, 'write-editor' );
-					}
-				},
-				'schema'          => array(
-					'type' => 'boolean',
-				),
-			)
-		);
-	}
+	'rest_after_insert_post',
+	function ( $post, $request ) {
+		if ( true === $request['wpcom_write_editor_used'] && \current_user_can( 'edit_post', $post->ID ) ) {
+			remember_editor( $post->ID, 'write-editor' );
+		}
+	},
+	10,
+	2
 );
 
 /**
  * Sets the metadata for the specified post and editor.
  *
  * @param int    $post_id The ID of the post to set the metadata for.
- * @param string $editor  String name of the editor, 'classic-editor' or 'block-editor'.
+ * @param string $editor  String name of the editor: 'classic-editor', 'block-editor', or 'write-editor'.
  */
 function remember_editor( $post_id, $editor ) {
 	if ( get_post_meta( $post_id, '_last_editor_used_jetpack', true ) !== $editor ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor/functions.editor-type.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor/functions.editor-type.php
@@ -66,10 +66,7 @@ function remember_block_editor( $editor_settings, $post ) {
 				'auth_callback'     => function () {
 					return current_user_can( 'edit_posts' );
 				},
-				'sanitize_callback' => function ( $value ) {
-					$allowed = array( 'classic-editor', 'block-editor', 'write-editor' );
-					return in_array( $value, $allowed, true ) ? $value : '';
-				},
+				'sanitize_callback' => 'sanitize_text_field',
 			)
 		);
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor/functions.editor-type.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor/functions.editor-type.php
@@ -49,6 +49,24 @@ function remember_block_editor( $editor_settings, $post ) {
 }
 
 /**
+ * Register _last_editor_used_jetpack for REST API access so editors (e.g. the
+ * Write editor) can set it via the meta field in save requests. Follows the same
+ * pattern used by other Jetpack meta keys (e.g. _jetpack_newsletter_access).
+ */
+register_post_meta(
+	'post',
+	'_last_editor_used_jetpack',
+	array(
+		'show_in_rest'  => true,
+		'single'        => true,
+		'type'          => 'string',
+		'auth_callback' => function () {
+			return wp_get_current_user()->has_cap( 'edit_posts' );
+		},
+	)
+);
+
+/**
  * Sets the metadata for the specified post and editor.
  *
  * @param int    $post_id The ID of the post to set the metadata for.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor/functions.editor-type.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor/functions.editor-type.php
@@ -53,17 +53,26 @@ function remember_block_editor( $editor_settings, $post ) {
  * Write editor) can set it via the meta field in save requests. Follows the same
  * pattern used by other Jetpack meta keys (e.g. _jetpack_newsletter_access).
  */
-register_post_meta(
-	'post',
-	'_last_editor_used_jetpack',
-	array(
-		'show_in_rest'  => true,
-		'single'        => true,
-		'type'          => 'string',
-		'auth_callback' => function () {
-			return wp_get_current_user()->has_cap( 'edit_posts' );
-		},
-	)
+\add_action(
+	'init',
+	function () {
+		\register_post_meta(
+			'post',
+			'_last_editor_used_jetpack',
+			array(
+				'show_in_rest'      => true,
+				'single'            => true,
+				'type'              => 'string',
+				'auth_callback'     => function () {
+					return current_user_can( 'edit_posts' );
+				},
+				'sanitize_callback' => function ( $value ) {
+					$allowed = array( 'classic-editor', 'block-editor', 'write-editor' );
+					return in_array( $value, $allowed, true ) ? $value : '';
+				},
+			)
+		);
+	}
 );
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor/functions.editor-type.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor/functions.editor-type.php
@@ -49,28 +49,25 @@ function remember_block_editor( $editor_settings, $post ) {
 }
 
 /**
- * Register a write-only REST field so editors (e.g. the Write editor) can set
- * the last-editor attribution via save requests. The underlying
- * _last_editor_used_jetpack meta key is never exposed in REST responses.
+ * Register a write-only REST field so the Write editor can signal that it
+ * produced a save. The update callback calls remember_editor() to set the
+ * internal _last_editor_used_jetpack meta, which is never exposed in responses.
  */
 \add_action(
 	'rest_api_init',
 	function () {
 		\register_rest_field(
 			'post',
-			'wpcom_editor_used',
+			'wpcom_write_editor_used',
 			array(
 				'get_callback'    => null,
 				'update_callback' => function ( $value, $post ) {
-					if ( ! \current_user_can( 'edit_post', $post->ID ) ) {
-						return;
+					if ( $value && \current_user_can( 'edit_post', $post->ID ) ) {
+						remember_editor( $post->ID, 'write-editor' );
 					}
-					remember_editor( $post->ID, $value );
 				},
 				'schema'          => array(
-					'type'        => 'string',
-					'description' => __( 'Editor used to produce this revision.', 'jetpack-mu-wpcom' ),
-					'enum'        => array( 'classic-editor', 'block-editor', 'write-editor' ),
+					'type' => 'boolean',
 				),
 			)
 		);

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor/functions.editor-type.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor/functions.editor-type.php
@@ -60,7 +60,13 @@ function remember_block_editor( $editor_settings, $post ) {
 			'post',
 			'_last_editor_used_jetpack',
 			array(
-				'show_in_rest'      => true,
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type'    => 'string',
+						'enum'    => array( 'classic-editor', 'block-editor', 'write-editor' ),
+						'context' => array( 'edit' ),
+					),
+				),
 				'single'            => true,
 				'type'              => 'string',
 				'auth_callback'     => function () {

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -3695,7 +3695,7 @@ async function savePost( postStatus, isAutosave = false ) {
 				categories: selectedCats,
 				...tagData,
 				featured_media: state.featuredMediaId || 0,
-				meta: { _last_editor_used_jetpack: 'write-editor' },
+				wpcom_editor_used: 'write-editor',
 			},
 		} );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -3695,7 +3695,7 @@ async function savePost( postStatus, isAutosave = false ) {
 				categories: selectedCats,
 				...tagData,
 				featured_media: state.featuredMediaId || 0,
-				wpcom_editor_used: 'write-editor',
+				wpcom_write_editor_used: true,
 			},
 		} );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -3733,7 +3733,7 @@ async function savePost( postStatus, isAutosave = false ) {
 			window._tkq.push( [
 				'recordEvent',
 				'wpcom_write_editor_post_published',
-				{ post_id: post.id },
+				{ post_id: post.id, is_update: isUpdate },
 			] );
 			setTimeout( () => {
 				// Hide the page before navigating so the bfcache snapshot

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -3726,6 +3726,14 @@ async function savePost( postStatus, isAutosave = false ) {
 			state.message = isUpdate ? i18n.updated || 'Updated!' : i18n.published || 'Published!';
 			// Clear any autosave draft reference on publish.
 			localStorage.removeItem( AUTOSAVE_STORAGE_KEY );
+
+			// Track publish event client-side for reliable Write editor attribution.
+			window._tkq = window._tkq || [];
+			window._tkq.push( [
+				'recordEvent',
+				'wpcom_write_editor_post_published',
+				{ post_id: post.id, is_new_post: ! isEditing },
+			] );
 			setTimeout( () => {
 				// Hide the page before navigating so the bfcache snapshot
 				// stores it hidden — prevents a flash of stale content if

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -3695,6 +3695,7 @@ async function savePost( postStatus, isAutosave = false ) {
 				categories: selectedCats,
 				...tagData,
 				featured_media: state.featuredMediaId || 0,
+				meta: { _last_editor_used_jetpack: 'write-editor' },
 			},
 		} );
 
@@ -3732,7 +3733,7 @@ async function savePost( postStatus, isAutosave = false ) {
 			window._tkq.push( [
 				'recordEvent',
 				'wpcom_write_editor_post_published',
-				{ post_id: post.id, is_new_post: ! isEditing },
+				{ post_id: post.id },
 			] );
 			setTimeout( () => {
 				// Hide the page before navigating so the bfcache snapshot

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -89,25 +89,21 @@ add_filter(
 );
 
 /**
- * Set _last_editor_used_jetpack when a post is first created from the Write editor.
- *
- * Checks the HTTP Referer to identify saves originating from the Write page.
- * Only runs on post creation (not updates) — existing posts have their meta
- * set on page load in wpcom_write_render_admin_page() instead.
+ * Register _last_editor_used_jetpack for REST API access so the Write editor
+ * can set it via the meta field in save requests. Follows the same pattern
+ * used by other Jetpack meta keys (e.g. _jetpack_newsletter_access).
  */
-add_action(
-	'rest_after_insert_post',
-	function ( $post, $request, $creating ) {
-		if ( ! $creating ) {
-			return;
-		}
-		$referer = $request->get_header( 'referer' );
-		if ( $referer && strpos( $referer, 'page=write' ) !== false ) {
-			update_post_meta( $post->ID, '_last_editor_used_jetpack', 'write-editor' );
-		}
-	},
-	10,
-	3
+register_post_meta(
+	'post',
+	'_last_editor_used_jetpack',
+	array(
+		'show_in_rest'  => true,
+		'single'        => true,
+		'type'          => 'string',
+		'auth_callback' => function () {
+			return wp_get_current_user()->has_cap( 'edit_posts' );
+		},
+	)
 );
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -89,24 +89,6 @@ add_filter(
 );
 
 /**
- * Register _last_editor_used_jetpack for REST API access so the Write editor
- * can set it via the meta field in save requests. Follows the same pattern
- * used by other Jetpack meta keys (e.g. _jetpack_newsletter_access).
- */
-register_post_meta(
-	'post',
-	'_last_editor_used_jetpack',
-	array(
-		'show_in_rest'  => true,
-		'single'        => true,
-		'type'          => 'string',
-		'auth_callback' => function () {
-			return wp_get_current_user()->has_cap( 'edit_posts' );
-		},
-	)
-);
-
-/**
  * Register the Write admin page.
  *
  * Uses an empty parent to create a hidden page (no menu entry) — access is

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -89,6 +89,28 @@ add_filter(
 );
 
 /**
+ * Set _last_editor_used_jetpack when a post is first created from the Write editor.
+ *
+ * Checks the HTTP Referer to identify saves originating from the Write page.
+ * Only runs on post creation (not updates) — existing posts have their meta
+ * set on page load in wpcom_write_render_admin_page() instead.
+ */
+add_action(
+	'rest_after_insert_post',
+	function ( $post, $request, $creating ) {
+		if ( ! $creating ) {
+			return;
+		}
+		$referer = $request->get_header( 'referer' );
+		if ( $referer && strpos( $referer, 'page=write' ) !== false ) {
+			update_post_meta( $post->ID, '_last_editor_used_jetpack', 'write-editor' );
+		}
+	},
+	10,
+	3
+);
+
+/**
  * Register the Write admin page.
  *
  * Uses an empty parent to create a hidden page (no menu entry) — access is
@@ -465,6 +487,10 @@ function wpcom_write_render_admin_page() {
 			$post_status        = $edit_post->post_status;
 			$edit_featured_id   = (int) get_post_thumbnail_id( $edit_post_id );
 			$unsupported_type   = wpcom_write_detect_unsupported_content( $edit_post->post_content );
+
+			// Track that this post was last edited in the Write editor,
+			// matching the pattern used by the block and classic editors.
+			update_post_meta( $edit_post_id, '_last_editor_used_jetpack', 'write-editor' );
 		} else {
 			$edit_post_id = 0;
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -468,7 +468,7 @@ function wpcom_write_render_admin_page() {
 
 			// Track that this post was last edited in the Write editor,
 			// matching the pattern used by the block and classic editors.
-			update_post_meta( $edit_post_id, '_last_editor_used_jetpack', 'write-editor' );
+			\Automattic\Jetpack\Jetpack_Mu_Wpcom\WPCOM_Block_Editor\EditorType\remember_editor( $edit_post_id, 'write-editor' );
 		} else {
 			$edit_post_id = 0;
 		}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -1117,15 +1117,15 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Test that the sanitize callback rejects invalid editor values.
+	 * Test that the sanitize callback strips unsafe content.
 	 */
-	public function test_sanitize_callback_rejects_invalid_values() {
+	public function test_sanitize_callback_strips_unsafe_content() {
 		do_action( 'init' );
 
 		$this->assertEquals( 'write-editor', sanitize_meta( '_last_editor_used_jetpack', 'write-editor', 'post', 'post' ) );
 		$this->assertEquals( 'block-editor', sanitize_meta( '_last_editor_used_jetpack', 'block-editor', 'post', 'post' ) );
 		$this->assertEquals( 'classic-editor', sanitize_meta( '_last_editor_used_jetpack', 'classic-editor', 'post', 'post' ) );
-		$this->assertSame( '', sanitize_meta( '_last_editor_used_jetpack', 'malicious-value', 'post', 'post' ) );
-		$this->assertSame( '', sanitize_meta( '_last_editor_used_jetpack', '<script>alert(1)</script>', 'post', 'post' ) );
+		$this->assertEquals( 'future-editor', sanitize_meta( '_last_editor_used_jetpack', 'future-editor', 'post', 'post' ) );
+		$this->assertSame( 'alert(1)', sanitize_meta( '_last_editor_used_jetpack', '<script>alert(1)</script>', 'post', 'post' ) );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -1108,15 +1108,55 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Test that wpcom_write_editor_used REST field is registered for posts.
+	 * Test that saving a post via REST with wpcom_write_editor_used sets last-editor meta.
 	 */
-	public function test_write_editor_used_rest_field_registered() {
-		do_action( 'rest_api_init' );
+	public function test_rest_save_with_write_editor_signal_sets_meta() {
+		wp_set_current_user( $this->admin_id );
 
-		$post_type  = get_post_type_object( 'post' );
-		$controller = new \WP_REST_Posts_Controller( $post_type->name );
-		$schema     = $controller->get_item_schema();
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'REST Signal Test',
+				'post_status' => 'draft',
+				'post_author' => $this->admin_id,
+			)
+		);
 
-		$this->assertArrayHasKey( 'wpcom_write_editor_used', $schema['properties'], 'wpcom_write_editor_used should be registered as a REST field.' );
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d', $post_id ) );
+		$request->set_body_params(
+			array(
+				'title'                   => 'Updated via Write',
+				'wpcom_write_editor_used' => true,
+			)
+		);
+
+		rest_get_server()->dispatch( $request );
+
+		$this->assertEquals( 'write-editor', get_post_meta( $post_id, '_last_editor_used_jetpack', true ) );
+	}
+
+	/**
+	 * Test that saving a post via REST without the signal does not set last-editor meta.
+	 */
+	public function test_rest_save_without_write_editor_signal_does_not_set_meta() {
+		wp_set_current_user( $this->admin_id );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'REST No Signal Test',
+				'post_status' => 'draft',
+				'post_author' => $this->admin_id,
+			)
+		);
+
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d', $post_id ) );
+		$request->set_body_params(
+			array(
+				'title' => 'Updated without Write',
+			)
+		);
+
+		rest_get_server()->dispatch( $request );
+
+		$this->assertEmpty( get_post_meta( $post_id, '_last_editor_used_jetpack', true ) );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -1108,15 +1108,15 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Test that wpcom_editor_used REST field is registered for posts.
+	 * Test that wpcom_write_editor_used REST field is registered for posts.
 	 */
-	public function test_editor_used_rest_field_registered() {
+	public function test_write_editor_used_rest_field_registered() {
 		do_action( 'rest_api_init' );
 
 		$post_type  = get_post_type_object( 'post' );
 		$controller = new \WP_REST_Posts_Controller( $post_type->name );
 		$schema     = $controller->get_item_schema();
 
-		$this->assertArrayHasKey( 'wpcom_editor_used', $schema['properties'], 'wpcom_editor_used should be registered as a REST field.' );
+		$this->assertArrayHasKey( 'wpcom_write_editor_used', $schema['properties'], 'wpcom_write_editor_used should be registered as a REST field.' );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -1111,7 +1111,21 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	 * Test that _last_editor_used_jetpack is registered for REST API access.
 	 */
 	public function test_last_editor_meta_registered_for_rest() {
+		do_action( 'init' );
 		$registered = registered_meta_key_exists( 'post', '_last_editor_used_jetpack', 'post' );
 		$this->assertTrue( $registered, '_last_editor_used_jetpack should be registered for the post type.' );
+	}
+
+	/**
+	 * Test that the sanitize callback rejects invalid editor values.
+	 */
+	public function test_sanitize_callback_rejects_invalid_values() {
+		do_action( 'init' );
+
+		$this->assertEquals( 'write-editor', sanitize_meta( '_last_editor_used_jetpack', 'write-editor', 'post', 'post' ) );
+		$this->assertEquals( 'block-editor', sanitize_meta( '_last_editor_used_jetpack', 'block-editor', 'post', 'post' ) );
+		$this->assertEquals( 'classic-editor', sanitize_meta( '_last_editor_used_jetpack', 'classic-editor', 'post', 'post' ) );
+		$this->assertSame( '', sanitize_meta( '_last_editor_used_jetpack', 'malicious-value', 'post', 'post' ) );
+		$this->assertSame( '', sanitize_meta( '_last_editor_used_jetpack', '<script>alert(1)</script>', 'post', 'post' ) );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -7,6 +7,7 @@
 
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/wpcom-block-editor/functions.editor-type.php';
 require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/write/write.php';
 
 /**
@@ -1052,5 +1053,65 @@ class Write_Test extends \WorDBless\BaseTestCase {
 				)
 			);
 		}
+	/**
+	 * Test that loading an existing post in the Write editor sets the last editor meta.
+	 */
+	public function test_existing_post_sets_last_editor_meta() {
+		wp_set_current_user( $this->admin_id );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Test Post',
+				'post_status' => 'publish',
+				'post_author' => $this->admin_id,
+			)
+		);
+
+		// Simulate opening the post in the Write editor.
+		$_GET['post'] = $post_id;
+
+		ob_start();
+		wpcom_write_render_admin_page();
+		ob_end_clean();
+
+		unset( $_GET['post'] );
+
+		$this->assertEquals( 'write-editor', get_post_meta( $post_id, '_last_editor_used_jetpack', true ) );
+	}
+
+	/**
+	 * Test that loading an existing post overwrites a previous editor meta value.
+	 */
+	public function test_existing_post_overwrites_previous_editor_meta() {
+		wp_set_current_user( $this->admin_id );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Test Post',
+				'post_status' => 'publish',
+				'post_author' => $this->admin_id,
+			)
+		);
+
+		// Simulate the post was previously edited in the block editor.
+		update_post_meta( $post_id, '_last_editor_used_jetpack', 'block-editor' );
+
+		$_GET['post'] = $post_id;
+
+		ob_start();
+		wpcom_write_render_admin_page();
+		ob_end_clean();
+
+		unset( $_GET['post'] );
+
+		$this->assertEquals( 'write-editor', get_post_meta( $post_id, '_last_editor_used_jetpack', true ) );
+	}
+
+	/**
+	 * Test that _last_editor_used_jetpack is registered for REST API access.
+	 */
+	public function test_last_editor_meta_registered_for_rest() {
+		$registered = registered_meta_key_exists( 'post', '_last_editor_used_jetpack', 'post' );
+		$this->assertTrue( $registered, '_last_editor_used_jetpack should be registered for the post type.' );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -1053,6 +1053,8 @@ class Write_Test extends \WorDBless\BaseTestCase {
 				)
 			);
 		}
+	}
+
 	/**
 	 * Test that loading an existing post in the Write editor sets the last editor meta.
 	 */
@@ -1156,6 +1158,33 @@ class Write_Test extends \WorDBless\BaseTestCase {
 		);
 
 		rest_get_server()->dispatch( $request );
+
+		$this->assertEmpty( get_post_meta( $post_id, '_last_editor_used_jetpack', true ) );
+	}
+
+	/**
+	 * Test that a user without edit_post capability cannot trigger the meta update.
+	 */
+	public function test_remember_write_editor_without_capability_does_not_set_meta() {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Capability Test',
+				'post_status' => 'draft',
+				'post_author' => $this->admin_id,
+			)
+		);
+
+		// Switch to a subscriber who cannot edit this post.
+		wp_set_current_user( $this->subscriber_id );
+
+		$request = new \WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d', $post_id ) );
+		$request->set_body_params(
+			array(
+				'wpcom_write_editor_used' => true,
+			)
+		);
+
+		\Automattic\Jetpack\Jetpack_Mu_Wpcom\WPCOM_Block_Editor\EditorType\remember_write_editor( get_post( $post_id ), $request );
 
 		$this->assertEmpty( get_post_meta( $post_id, '_last_editor_used_jetpack', true ) );
 	}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -1117,15 +1117,20 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Test that the sanitize callback strips unsafe content.
+	 * Test that _last_editor_used_jetpack sanitizes HTML on save.
 	 */
-	public function test_sanitize_callback_strips_unsafe_content() {
+	public function test_last_editor_meta_sanitizes_html_on_save() {
 		do_action( 'init' );
 
-		$this->assertEquals( 'write-editor', sanitize_meta( '_last_editor_used_jetpack', 'write-editor', 'post', 'post' ) );
-		$this->assertEquals( 'block-editor', sanitize_meta( '_last_editor_used_jetpack', 'block-editor', 'post', 'post' ) );
-		$this->assertEquals( 'classic-editor', sanitize_meta( '_last_editor_used_jetpack', 'classic-editor', 'post', 'post' ) );
-		$this->assertEquals( 'future-editor', sanitize_meta( '_last_editor_used_jetpack', 'future-editor', 'post', 'post' ) );
-		$this->assertSame( 'alert(1)', sanitize_meta( '_last_editor_used_jetpack', '<script>alert(1)</script>', 'post', 'post' ) );
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Test Post',
+				'post_status' => 'publish',
+				'post_author' => $this->admin_id,
+			)
+		);
+
+		update_post_meta( $post_id, '_last_editor_used_jetpack', '<script>alert(1)</script>' );
+		$this->assertStringNotContainsString( '<script>', get_post_meta( $post_id, '_last_editor_used_jetpack', true ) );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -1108,29 +1108,15 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Test that _last_editor_used_jetpack is registered for REST API access.
+	 * Test that wpcom_editor_used REST field is registered for posts.
 	 */
-	public function test_last_editor_meta_registered_for_rest() {
-		do_action( 'init' );
-		$registered = registered_meta_key_exists( 'post', '_last_editor_used_jetpack', 'post' );
-		$this->assertTrue( $registered, '_last_editor_used_jetpack should be registered for the post type.' );
-	}
+	public function test_editor_used_rest_field_registered() {
+		do_action( 'rest_api_init' );
 
-	/**
-	 * Test that _last_editor_used_jetpack sanitizes HTML on save.
-	 */
-	public function test_last_editor_meta_sanitizes_html_on_save() {
-		do_action( 'init' );
+		$post_type  = get_post_type_object( 'post' );
+		$controller = new \WP_REST_Posts_Controller( $post_type->name );
+		$schema     = $controller->get_item_schema();
 
-		$post_id = wp_insert_post(
-			array(
-				'post_title'  => 'Test Post',
-				'post_status' => 'publish',
-				'post_author' => $this->admin_id,
-			)
-		);
-
-		update_post_meta( $post_id, '_last_editor_used_jetpack', '<script>alert(1)</script>' );
-		$this->assertStringNotContainsString( '<script>', get_post_meta( $post_id, '_last_editor_used_jetpack', true ) );
+		$this->assertArrayHasKey( 'wpcom_editor_used', $schema['properties'], 'wpcom_editor_used should be registered as a REST field.' );
 	}
 }


### PR DESCRIPTION
Fixes RSM-773

## Proposed changes

- Set `_last_editor_used_jetpack` to `write-editor` for posts created or edited in the Write editor, so the `wpcom_post_publish` Tracks event includes correct `last_editor` attribution
- For **existing posts opened in the editor**: set meta on page load in `wpcom_write_render_admin_page()`, matching the pattern used by the block and classic editors
- For **posts saved via REST**: hook into `rest_after_insert_post` and check for a `wpcom_write_editor_used: true` body param sent by the JS client on every save (drafts, publishes, autosaves). Gated by an `edit_post` capability check.
- Fire a `wpcom_write_editor_post_published` client-side Tracks event on publish with properties: `post_id`, `is_update`
- Add `remember_write_editor()` as a named function in `functions.editor-type.php` (consistent with `remember_block_editor` and `remember_classic_editor`)
- Add 5 PHPUnit tests covering: existing post meta set, meta overwrite, REST signal sets meta, REST without signal does not set meta, and capability check blocks unauthorized meta update

## Does this pull request change what data or activity we track or use?

Yes:
- Sets `_last_editor_used_jetpack` post meta to `write-editor` when the Write editor is used (existing meta key, new value)
- Fires a new `wpcom_write_editor_post_published` client-side Tracks event on publish with properties: `post_id`, `is_update`

## Testing instructions

### New post

1. Go to a WordPress.com site with the Write editor enabled
2. Navigate to `/wp-admin/admin.php?page=write&flags=a8c-analytics.on`
3. Add a title and some content, click **Save draft**, then click **Publish**
4. Check the Tracks dashboard for a `wpcom_write_editor_post_published` event
5. Check the Tracks dashboard for a `wpcom_post_publish` event with `last_editor: write-editor`

### Existing post

1. Create a post using the block editor and publish it
2. Open the same post in the Write editor: `/wp-admin/admin.php?page=write&post=<ID>&flags=a8c-analytics.on`
3. Make a change and click **Update**
4. Check the Tracks dashboard for a `wpcom_write_editor_post_published` event
5. Check the Tracks dashboard for a `wpcom_post_edit` event with `last_editor: write-editor`

### Negative test — other editors unaffected

1. Create a new post in the **block editor** and publish it
2. Check that the `wpcom_post_publish` event has `last_editor: block-editor` (not `write-editor`)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
