### PR TITLE
Write: Keep selected text highlighted while the link popover is open

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-write-link-selection-highlight
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-write-link-selection-highlight
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write: Keep selected text visually highlighted while the link popover is open.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -708,6 +708,14 @@
 	color: inherit;
 }
 
+/* Persistent highlight shown while the link popover is open.
+   Slightly stronger than ::selection to visually distinguish it
+   as a "target" indicator rather than an active text selection. */
+::highlight(bw-link-highlight) {
+	background-color: rgba(33, 113, 177, 0.25);
+	color: inherit;
+}
+
 /* Content area */
 .bw-content {
 	min-height: 60vh;

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -42,6 +42,31 @@ function restoreSelection() {
 }
 
 /**
+ * Visually highlight the current selection using the CSS Custom Highlight API.
+ *
+ * This avoids mutating the DOM (which would invalidate the saved range),
+ * so the selection can be cleanly restored when the link popover closes.
+ */
+function highlightSelection() {
+	if ( ! self.Highlight || ! CSS.highlights ) return;
+
+	const sel = window.getSelection();
+	if ( ! sel.rangeCount || sel.isCollapsed ) return;
+
+	const range = sel.getRangeAt( 0 ).cloneRange();
+	CSS.highlights.set( 'bw-link-highlight', new Highlight( range ) );
+}
+
+/**
+ * Remove the visual link-highlight overlay.
+ */
+function clearHighlight() {
+	if ( CSS.highlights ) {
+		CSS.highlights.delete( 'bw-link-highlight' );
+	}
+}
+
+/**
  * Normalize color markup from contentEditable before block serialization.
  *
  * The foreColor command creates <font color="..."> (legacy) or
@@ -996,24 +1021,34 @@ const { state } = store( 'wpcom-write', {
 				linkPopoverCloseHandler = null;
 			}
 			if ( state.showLinkInput ) {
+				clearHighlight();
 				state.showLinkInput = false;
 				return;
 			}
 
-			// Save selection before the toolbar steals focus.
-			saveSelection();
-
-			// Pre-fill if cursor is inside a link.
+			// Pre-fill if cursor is inside a link.  When the cursor is
+			// collapsed inside an <a>, expand the selection to cover the
+			// full link text so the highlight shows what will be affected.
 			const sel = window.getSelection();
 			let node = sel.anchorNode;
 			state.linkUrl = '';
 			while ( node && node !== document.body ) {
 				if ( node.nodeType === Node.ELEMENT_NODE && node.tagName === 'A' ) {
 					state.linkUrl = node.getAttribute( 'href' ) || '';
+					if ( sel.isCollapsed ) {
+						const range = document.createRange();
+						range.selectNodeContents( node );
+						sel.removeAllRanges();
+						sel.addRange( range );
+					}
 					break;
 				}
 				node = node.parentNode;
 			}
+
+			// Save and highlight after any selection expansion above.
+			saveSelection();
+			highlightSelection();
 
 			state.showLinkInput = true;
 
@@ -1032,6 +1067,7 @@ const { state } = store( 'wpcom-write', {
 					e.target.closest( '[data-wp-on--click="actions.toggleLinkInput"]' )
 				)
 					return;
+				clearHighlight();
 				state.showLinkInput = false;
 				document.removeEventListener( 'click', linkPopoverCloseHandler );
 				linkPopoverCloseHandler = null;
@@ -1047,6 +1083,7 @@ const { state } = store( 'wpcom-write', {
 		handleLinkKeyDown( event ) {
 			if ( event.key === 'Enter' ) {
 				event.preventDefault();
+				clearHighlight();
 				restoreSelection();
 				if ( state.linkUrl ) {
 					document.execCommand( 'createLink', false, state.linkUrl );
@@ -1061,6 +1098,7 @@ const { state } = store( 'wpcom-write', {
 			}
 			if ( event.key === 'Escape' ) {
 				event.preventDefault();
+				clearHighlight();
 				state.showLinkInput = false;
 				if ( linkPopoverCloseHandler ) {
 					document.removeEventListener( 'click', linkPopoverCloseHandler );
@@ -1072,6 +1110,7 @@ const { state } = store( 'wpcom-write', {
 		},
 
 		applyLink() {
+			clearHighlight();
 			restoreSelection();
 			if ( state.linkUrl ) {
 				document.execCommand( 'createLink', false, state.linkUrl );
@@ -1086,6 +1125,7 @@ const { state } = store( 'wpcom-write', {
 		},
 
 		removeLink() {
+			clearHighlight();
 			restoreSelection();
 			document.execCommand( 'unlink' );
 			state.showLinkInput = false;


### PR DESCRIPTION
Fixes RSM-1599

## Proposed changes

* Use the CSS Custom Highlight API to visually highlight selected text while the link popover is open, so users can see which text will receive the link even though focus moves to the URL input.
* When the cursor is collapsed inside an existing link and the link popover is opened, auto-select the full link text and highlight it.
* Clear the highlight in all close paths (Apply, Remove, Enter, Escape, outside click, toggle off).


https://github.com/user-attachments/assets/277fce7c-d22e-4366-a9d2-3dc80ccc5059



## Related product discussion/links

* RSM-1599

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Go to the Write editor (`/wp-admin/admin.php?page=write`)
* Type some text (e.g. "Hello world foo bar")
* Select a portion of text (e.g. "world foo")
* Click the Link button in the toolbar
* **Verify**: the selected text stays visually highlighted with a blue background while the URL input is focused. It's intentionally slightly different from the selection background (which we can't match exactly with this api).
* Type a URL and press Enter — verify the link is applied to the correct text
* Click inside the linked text, then click the Link button again
* **Verify**: the full link text is highlighted and the URL is pre-filled
* Press Escape — verify the highlight is removed
* Repeat and click outside the popover — verify the highlight is removed
* Test with bold/italic text selections to ensure cross-boundary selections work

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>