### PR TITLE
Open AI sidebar to all paid WPCOM plans [wpcomsh + jetpack-mu-wpcom]

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/open-ai-sidebar-to-all-paid-plans
+++ b/projects/packages/jetpack-mu-wpcom/changelog/open-ai-sidebar-to-all-paid-plans
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+ai-assistant-banner: gate on WPCOM_Features::BIG_SKY instead of the removed BIG_SKY_EXISTING_SITE.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/ai-assistant-banner.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/ai-assistant-banner.php
@@ -23,7 +23,7 @@ function wpcom_should_show_ai_assistant_banner() {
 		return false;
 	}
 
-	if ( ! function_exists( 'wpcom_site_has_feature' ) || ! wpcom_site_has_feature( WPCOM_Features::BIG_SKY_EXISTING_SITE ) ) {
+	if ( ! function_exists( 'wpcom_site_has_feature' ) || ! wpcom_site_has_feature( WPCOM_Features::BIG_SKY ) ) {
 		return false;
 	}
 

--- a/projects/plugins/wpcomsh/changelog/open-ai-sidebar-to-all-paid-plans
+++ b/projects/plugins/wpcomsh/changelog/open-ai-sidebar-to-all-paid-plans
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+wpcom-features: make BIG_SKY the single paid-plan eligibility gate for Big Sky / AI sidebar; remove BIG_SKY_EXISTING_SITE; add Starter to GLOBAL_STYLES.

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -385,7 +385,6 @@ class WPCOM_Features {
 	public const BACKUPS_SELF_SERVE                = 'backups-self-serve';
 	public const BACKUP_ONE_TIME                   = 'backup-one-time';
 	public const BIG_SKY                           = 'big-sky';
-	public const BIG_SKY_EXISTING_SITE             = 'big-sky-existing-site';
 	public const BLAZE_CREDITS_VOUCHER             = 'blaze-credits-voucher';
 	public const BLOG_DOMAIN_ONLY                  = 'blog-domain-only';
 	public const CALENDLY                          = 'calendly';
@@ -644,16 +643,9 @@ class WPCOM_Features {
 		self::BACKUP_ONE_TIME                   => array(
 			self::JETPACK_BACKUP_ONE_TIME,
 		),
-		// Free trials can upgrade to any plan level.
+		// Plans that grant unlimited Big Sky usage and exit the Big Sky free trial.
 		self::BIG_SKY                           => array(
-			self::WPCOM_PERSONAL_PLANS,
-			self::WPCOM_BUSINESS_PLANS,
-			self::WPCOM_PREMIUM_PLANS,
-			self::WPCOM_ECOMMERCE_PLANS,
-		),
-		// Existing sites can only enable it if they have a business or higher plan.
-		self::BIG_SKY_EXISTING_SITE             => array(
-			self::WPCOM_BUSINESS_AND_HIGHER_PLANS,
+			self::WPCOM_PERSONAL_AND_HIGHER_PLANS,
 		),
 		self::BLAZE_CREDITS_VOUCHER             => array(
 			array(
@@ -870,6 +862,7 @@ class WPCOM_Features {
 		),
 		self::GLOBAL_STYLES                     => array(
 			self::WPCOM_PREMIUM_AND_HIGHER_PLANS,
+			self::WPCOM_STARTER_PLANS,
 		),
 		self::GOOGLE_ANALYTICS                  => array(
 			self::JETPACK_PREMIUM_AND_HIGHER,


### PR DESCRIPTION
## Proposed changes

Mirror of 213858-ghe-Automattic/wpcom after 214425-ghe-Automattic/wpcom.

`BIG_SKY` is now the single source of truth for Big Sky plan eligibility. This PR:

1. **wpcomsh `class-wpcom-features.php`** — maps `BIG_SKY` to `WPCOM_PERSONAL_AND_HIGHER_PLANS`, removes the now-redundant `BIG_SKY_EXISTING_SITE` constant + map entry, adds `WPCOM_STARTER_PLANS` to `GLOBAL_STYLES`.

2. **jetpack-mu-wpcom AI assistant banner** — updates the plan-eligibility check from `BIG_SKY_EXISTING_SITE` to `BIG_SKY`. The banner's independent "already-enabled" guards (`big-sky-enabled` sticker, `big_sky_enable` option) are unchanged.

`Automattic/wpcom-site-helper` is a read-only auto-synced mirror of this wpcomsh package and updates automatically.

## Related product discussion/links

* 213858-ghe-Automattic/wpcom
* 214425-ghe-Automattic/wpcom
* DOTCOM-16918

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Functional verification belongs to the wpcom companion PR (213858-ghe-Automattic/wpcom), which has the test suite and manual test plan against Simple/Atomic sandbox sites. The wpcomsh and jetpack-mu-wpcom changes are structurally identical, so once they ship in their respective releases, Atomic sites pick up the same gating Simple sites get from wpcom.

For this PR specifically:

* `git diff trunk -- projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/ai-assistant-banner.php` — confirm the only changes are the `BIG_SKY` / `BIG_SKY_EXISTING_SITE` consolidation and the banner gate switch.
* CI lint / phpcs passes.

## Deploy ordering

The wpcom PR (213858-ghe-Automattic/wpcom) must reach production first, then this one rolls out with the next wpcomsh and jetpack-mu-wpcom releases.