### PR TITLE
Write: Prevent editing post content while image/video modal is open

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-write-modal-focus-trap
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-write-modal-focus-trap
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write: Prevent editing post content while image or video modal is open

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -118,6 +118,19 @@ function clearHighlight() {
 }
 
 /**
+ * Focus the first visible input inside a modal after it becomes visible.
+ * Uses requestAnimationFrame so the element is no longer hidden.
+ */
+function focusModalInput() {
+	requestAnimationFrame( () => {
+		const overlay = document.querySelector( '.bw-image-overlay:not([hidden])' );
+		if ( ! overlay ) return;
+		const input = overlay.querySelector( 'input:not([hidden])' );
+		if ( input ) input.focus();
+	} );
+}
+
+/**
  * Normalize color markup from contentEditable before block serialization.
  *
  * The foreColor command creates <font color="..."> (legacy) or
@@ -869,6 +882,11 @@ const { state } = store( 'wpcom-write', {
 		},
 
 		handleKeyDown( event ) {
+			// Block all keystrokes while a modal overlay is open.
+			if ( state.showImageModal || state.showVideoModal ) {
+				return;
+			}
+
 			// Ctrl+K / Cmd+K to toggle link input.
 			if ( ( event.ctrlKey || event.metaKey ) && event.key === 'k' ) {
 				event.preventDefault();
@@ -1373,6 +1391,7 @@ const { state } = store( 'wpcom-write', {
 			state.uploadedMediaId = 0;
 			resetUploadZone();
 			state.showImageModal = true;
+			focusModalInput();
 		},
 
 		closeImageModal() {
@@ -1501,6 +1520,7 @@ const { state } = store( 'wpcom-write', {
 			saveSelection();
 			state.showImageModal = true;
 			state.imageUrl = '';
+			focusModalInput();
 		},
 
 		insertQuote() {
@@ -1513,6 +1533,7 @@ const { state } = store( 'wpcom-write', {
 			saveSelection();
 			state.showVideoModal = true;
 			state.videoUrl = '';
+			focusModalInput();
 		},
 
 		closeVideoModal() {

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1397,6 +1397,15 @@ const { state } = store( 'wpcom-write', {
 		closeImageModal() {
 			state.showImageModal = false;
 			resetUploadZone();
+			const content = document.querySelector( '.bw-content' );
+			if ( content ) content.focus();
+		},
+
+		handleImageModalKeyDown( event ) {
+			if ( event.key === 'Escape' ) {
+				const { actions: a } = store( 'wpcom-write' );
+				a.closeImageModal();
+			}
 		},
 
 		stopPropagation( event ) {
@@ -1538,6 +1547,15 @@ const { state } = store( 'wpcom-write', {
 
 		closeVideoModal() {
 			state.showVideoModal = false;
+			const content = document.querySelector( '.bw-content' );
+			if ( content ) content.focus();
+		},
+
+		handleVideoModalKeyDown( event ) {
+			if ( event.key === 'Escape' ) {
+				const { actions: a } = store( 'wpcom-write' );
+				a.closeVideoModal();
+			}
 		},
 
 		updateVideoUrl() {

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1336,7 +1336,6 @@ const { state } = store( 'wpcom-write', {
 				)
 					return;
 				clearHighlight();
-				restoreSelection();
 				state.showLinkInput = false;
 				document.removeEventListener( 'click', linkPopoverCloseHandler );
 				linkPopoverCloseHandler = null;

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -584,8 +584,9 @@ async function uploadFileToMedia( file ) {
 		}
 		state.uploadedMediaId = media.id;
 
-		// Show preview.
+		// Show preview and re-focus the modal so Escape still works.
 		showUploadPreview( media.source_url );
+		focusModalInput();
 	} catch ( err ) {
 		state.isUploading = false;
 		if ( zone ) zone.classList.remove( 'bw-uploading' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1289,6 +1289,7 @@ const { state } = store( 'wpcom-write', {
 			}
 			if ( state.showLinkInput ) {
 				clearHighlight();
+				restoreSelection();
 				state.showLinkInput = false;
 				return;
 			}
@@ -1335,6 +1336,7 @@ const { state } = store( 'wpcom-write', {
 				)
 					return;
 				clearHighlight();
+				restoreSelection();
 				state.showLinkInput = false;
 				document.removeEventListener( 'click', linkPopoverCloseHandler );
 				linkPopoverCloseHandler = null;
@@ -1366,6 +1368,7 @@ const { state } = store( 'wpcom-write', {
 			if ( event.key === 'Escape' ) {
 				event.preventDefault();
 				clearHighlight();
+				restoreSelection();
 				state.showLinkInput = false;
 				if ( linkPopoverCloseHandler ) {
 					document.removeEventListener( 'click', linkPopoverCloseHandler );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -784,6 +784,24 @@ const { state } = store( 'wpcom-write', {
 		},
 
 		handleTitleKeyDown( event ) {
+			// Block keystrokes while a modal overlay is open.
+			if ( state.showImageModal || state.showVideoModal ) {
+				if ( event.key === 'Escape' ) {
+					const { actions: a } = store( 'wpcom-write' );
+					if ( state.showImageModal ) {
+						a.closeImageModal();
+					} else {
+						a.closeVideoModal();
+					}
+					return;
+				}
+				if ( event.key === 'Tab' ) {
+					return;
+				}
+				event.preventDefault();
+				return;
+			}
+
 			if ( event.key === 'Enter' ) {
 				event.preventDefault();
 				const content = document.querySelector( '.bw-content' );
@@ -885,6 +903,19 @@ const { state } = store( 'wpcom-write', {
 		handleKeyDown( event ) {
 			// Block all keystrokes while a modal overlay is open.
 			if ( state.showImageModal || state.showVideoModal ) {
+				if ( event.key === 'Escape' ) {
+					const { actions: a } = store( 'wpcom-write' );
+					if ( state.showImageModal ) {
+						a.closeImageModal();
+					} else {
+						a.closeVideoModal();
+					}
+					return;
+				}
+				if ( event.key === 'Tab' ) {
+					return;
+				}
+				event.preventDefault();
 				return;
 			}
 
@@ -1397,7 +1428,12 @@ const { state } = store( 'wpcom-write', {
 
 		closeImageModal() {
 			state.showImageModal = false;
+			state.imageUrl = '';
+			state.imageAlt = '';
+			state.setAsFeatured = false;
+			state.uploadedMediaId = 0;
 			resetUploadZone();
+			restoreSelection();
 			const content = document.querySelector( '.bw-content' );
 			if ( content ) content.focus();
 		},
@@ -1548,6 +1584,8 @@ const { state } = store( 'wpcom-write', {
 
 		closeVideoModal() {
 			state.showVideoModal = false;
+			state.videoUrl = '';
+			restoreSelection();
 			const content = document.querySelector( '.bw-content' );
 			if ( content ) content.focus();
 		},

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1445,6 +1445,25 @@ const { state } = store( 'wpcom-write', {
 			if ( event.key === 'Escape' ) {
 				const { actions: a } = store( 'wpcom-write' );
 				a.closeImageModal();
+				return;
+			}
+			if ( event.key === 'Tab' ) {
+				const modal = event.currentTarget.querySelector( '.bw-image-modal' );
+				if ( ! modal ) return;
+				const focusable = modal.querySelectorAll(
+					'input:not([hidden]):not([type="file"]), button, [tabindex]:not([tabindex="-1"])'
+				);
+				if ( ! focusable.length ) return;
+				const first = focusable[ 0 ];
+				const last = focusable[ focusable.length - 1 ];
+				const active = modal.ownerDocument.activeElement;
+				if ( event.shiftKey && ( active === first || ! modal.contains( active ) ) ) {
+					event.preventDefault();
+					last.focus();
+				} else if ( ! event.shiftKey && ( active === last || ! modal.contains( active ) ) ) {
+					event.preventDefault();
+					first.focus();
+				}
 			}
 		},
 
@@ -1597,6 +1616,25 @@ const { state } = store( 'wpcom-write', {
 			if ( event.key === 'Escape' ) {
 				const { actions: a } = store( 'wpcom-write' );
 				a.closeVideoModal();
+				return;
+			}
+			if ( event.key === 'Tab' ) {
+				const modal = event.currentTarget.querySelector( '.bw-image-modal' );
+				if ( ! modal ) return;
+				const focusable = modal.querySelectorAll(
+					'input:not([hidden]):not([type="file"]), button, [tabindex]:not([tabindex="-1"])'
+				);
+				if ( ! focusable.length ) return;
+				const first = focusable[ 0 ];
+				const last = focusable[ focusable.length - 1 ];
+				const active = modal.ownerDocument.activeElement;
+				if ( event.shiftKey && ( active === first || ! modal.contains( active ) ) ) {
+					event.preventDefault();
+					last.focus();
+				} else if ( ! event.shiftKey && ( active === last || ! modal.contains( active ) ) ) {
+					event.preventDefault();
+					first.focus();
+				}
 			}
 		},
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -404,16 +404,18 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 				class="bw-image-url-input"
 				placeholder="<?php echo esc_attr__( 'Paste an image URL...', 'jetpack-mu-wpcom' ); ?>"
 				data-wp-on--input="actions.updateImageUrl"
+				data-wp-bind--value="state.imageUrl"
 			/>
 			<input
 				type="text"
 				class="bw-image-url-input"
 				placeholder="<?php echo esc_attr__( 'Alt text (describe the image)...', 'jetpack-mu-wpcom' ); ?>"
 				data-wp-on--input="actions.updateImageAlt"
+				data-wp-bind--value="state.imageAlt"
 				style="margin-top:12px;"
 			/>
 			<label class="bw-featured-toggle">
-				<input type="checkbox" data-wp-on--change="actions.toggleFeaturedImage" />
+				<input type="checkbox" data-wp-on--change="actions.toggleFeaturedImage" data-wp-bind--checked="state.setAsFeatured" />
 				<span><?php echo esc_html__( 'Set as featured image', 'jetpack-mu-wpcom' ); ?></span>
 			</label>
 			<button class="bw-btn bw-btn-publish" data-wp-on--click="actions.insertImageFromUrl" style="width:100%;margin-top:12px;"><?php echo esc_html__( 'Insert image', 'jetpack-mu-wpcom' ); ?></button>
@@ -466,6 +468,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 				placeholder="<?php echo esc_attr__( 'Paste a YouTube or Vimeo URL...', 'jetpack-mu-wpcom' ); ?>"
 				data-wp-on--input="actions.updateVideoUrl"
 				data-wp-on--keydown="actions.handleVideoKeyDown"
+				data-wp-bind--value="state.videoUrl"
 			/>
 			<button class="bw-btn bw-btn-publish" data-wp-on--click="actions.insertVideoEmbed" style="width:100%;margin-top:12px;"><?php echo esc_html__( 'Embed video', 'jetpack-mu-wpcom' ); ?></button>
 		</div>

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -390,7 +390,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 	</main>
 
 	<!-- Image modal -->
-	<div class="bw-image-overlay" hidden data-wp-bind--hidden="!state.showImageModal" data-wp-on--click="actions.closeImageModal" data-wp-on--dragover="actions.handleOverlayDragOver" data-wp-on--drop="actions.handleOverlayDrop">
+	<div class="bw-image-overlay" hidden data-wp-bind--hidden="!state.showImageModal" data-wp-on--click="actions.closeImageModal" data-wp-on--keydown="actions.handleImageModalKeyDown" data-wp-on--dragover="actions.handleOverlayDragOver" data-wp-on--drop="actions.handleOverlayDrop">
 		<div class="bw-image-modal" data-wp-on--click="actions.stopPropagation" data-wp-on--dragover="actions.handleOverlayDragOver" data-wp-on--drop="actions.handleOverlayDrop">
 			<h3><?php echo esc_html__( 'Add an image', 'jetpack-mu-wpcom' ); ?></h3>
 			<label class="bw-upload-zone" id="bw-upload-zone" data-wp-on--dragover="actions.handleDragOver" data-wp-on--dragleave="actions.handleDragLeave" data-wp-on--drop="actions.handleDrop">
@@ -457,7 +457,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 	</div>
 
 	<!-- Video modal -->
-	<div class="bw-image-overlay" hidden data-wp-bind--hidden="!state.showVideoModal" data-wp-on--click="actions.closeVideoModal">
+	<div class="bw-image-overlay" hidden data-wp-bind--hidden="!state.showVideoModal" data-wp-on--click="actions.closeVideoModal" data-wp-on--keydown="actions.handleVideoModalKeyDown">
 		<div class="bw-image-modal" data-wp-on--click="actions.stopPropagation">
 			<h3><?php echo esc_html__( 'Embed a video', 'jetpack-mu-wpcom' ); ?></h3>
 			<input


### PR DESCRIPTION
Fixes RSM-1565, RSM-1771

## Proposed changes

* Added a guard in `handleKeyDown` that returns early when the image or video modal is open, preventing keystrokes from modifying the post content behind the overlay
* Added auto-focus on the first input in the modal when it opens, moving focus away from the contenteditable area (follows the same `requestAnimationFrame` pattern used by the link popover)
* Closing either modal now restores focus to the content area so the cursor reappears
* Added Escape key support to dismiss both modals
* **Focus trapping**: Escape dismisses the modal, Tab is allowed for focus cycling, and all other keys are blocked — this prevents Shift+Tab from leaking focus back into the editor content. Applied to both `handleKeyDown` and `handleTitleKeyDown`.
* **Cursor position restored on cancel**: closing the image, video, or link popover without inserting now restores the cursor to its previous position instead of jumping to the top of the editor
* **Modal input state cleared on close**: image modal clears URL, alt text, featured flag, and upload state; video modal clears URL — so stale values don't persist across reopens
* **Link popover cursor fix**: all three dismiss paths (Escape, outside click, Cmd+K toggle) now call `restoreSelection()` before refocusing the content area

## Related product discussion/links

* RSM-1565
* RSM-1771

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Go to the Write editor
* Type `/image` to open the image modal
* Try typing — keystrokes should NOT edit the post behind the modal
* Press Escape — the modal should close and the cursor should return to the editor
* Type `/video` to open the video modal
* Try typing — keystrokes should NOT edit the post behind the modal
* Press Escape — the modal should close and the cursor should return to the editor
* Click the overlay background to close a modal — the cursor should also return to the editor
* Verify the URL input in both modals is auto-focused when opened
* **Cursor restoration**: type some content, place cursor in the middle, open image/video modal, close without inserting — cursor should return to where it was, not the top
* **Input clearing**: open image modal, type a URL, close it, reopen — the URL field should be empty
* **Focus trap**: open image modal, press Shift+Tab repeatedly — focus should not escape into the editor content
* **Link popover**: select text, press Cmd+K to open link popover, press Escape — cursor should return to the selected text, not jump to the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)