### PR TITLE
Protect: fix Firewall disabled notice CTA loading/disabled state

### DIFF
--- a/projects/plugins/protect/changelog/fix-firewall-disabled-notice-cta-state
+++ b/projects/plugins/protect/changelog/fix-firewall-disabled-notice-cta-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Firewall: fix "Enable Firewall" notice CTA missing loading/disabled state, which let users double-click and toggle the WAF back off.

--- a/projects/plugins/protect/src/js/routes/firewall/index.jsx
+++ b/projects/plugins/protect/src/js/routes/firewall/index.jsx
@@ -46,6 +46,7 @@ const FirewallPage = () => {
 		displayUpgradeBadge,
 		wafSupported,
 		isUpdating,
+		isToggling,
 		stats,
 		toggleAutomaticRules,
 		toggleIpAllowList,
@@ -230,8 +231,8 @@ const FirewallPage = () => {
 					key="enable"
 					variant="link"
 					onClick={ toggleWaf }
-					isLoading={ isUpdating }
-					disabled={ isUpdating }
+					isLoading={ isToggling }
+					disabled={ isToggling }
 				>
 					{ __( 'Enable Firewall', 'jetpack-protect' ) }
 				</Button>,


### PR DESCRIPTION
Fixes #

## Proposed changes

* Wire the Firewall "module disabled" notice's **Enable Firewall** CTA to the correct in-flight flag (`isToggling`) instead of `isUpdating`, so the button shows a spinner and is disabled while the WAF toggle mutation is pending.

### Root cause

`useWafData()` exposes two distinct mutation flags:

| flag | source mutation | what it covers |
| --- | --- | --- |
| `isUpdating` | `wafMutation.isPending` | WAF *settings* PUTs (`jetpack/v4/waf` — automatic rules, IP lists, share-data, etc.) |
| `isToggling` | `toggleWafMutation.isPending` | WAF *module* on/off (`jetpack-protect/v1/toggle-waf`) |

The notice's CTA at `projects/plugins/protect/src/js/routes/firewall/index.jsx` calls `toggleWaf` (the module toggle), but its `isLoading` / `disabled` props were wired to `isUpdating` — which tracks the settings mutation, not the module-toggle mutation. Result: the button never showed a spinner and never disabled while the toggle was in flight.

The endpoint is a flip-flop (`POST /toggle-waf`) — every call inverts the current state. With no UI feedback, a user double-clicks the CTA. The first click enables WAF; the second click disables it again. The query then refetches `isEnabled: false`, the notice never dismisses, and the page-level "Automatic firewall protection" toggle stays disabled (greyed out) because `canEditFirewallSettings = isWafModuleEnabled && ! isUpdating` is false.

That also explains the "the CTA does something different than the toggle" symptom: the page-level toggle is `Automatic firewall protection` (a sub-setting), while the CTA toggles the *whole WAF module* — they are genuinely different settings, but the missing CTA feedback amplified the inconsistency.

### Fix

`projects/plugins/protect/src/js/routes/firewall/index.jsx`:

* Destructure `isToggling` from `useWafData()`.
* Wire the notice CTA's `isLoading` and `disabled` to `isToggling` instead of `isUpdating`.

```diff
 wafSupported,
 isUpdating,
+isToggling,
 stats,
...
 onClick={ toggleWaf }
-isLoading={ isUpdating }
-disabled={ isUpdating }
+isLoading={ isToggling }
+disabled={ isToggling }
```

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

### Reproduce on `trunk`

1. Be on a site where the WAF can run (`wafSupported` true) and the WAF module is currently enabled.
2. Go to **Jetpack › Protect › Firewall**.
3. Disable the WAF module so the red "Jetpack Firewall is currently disabled." notice appears. Fastest path: from the browser console run `wp.apiFetch( { method: 'POST', path: 'jetpack-protect/v1/toggle-waf' } )` once, then refresh the page.
4. Click **Enable Firewall** in the notice **twice in quick succession** (mimicking a normal user with no visual feedback).
5. **Expected on trunk (bug):** the second click cancels out the first — the notice stays, and the "Automatic firewall protection" toggle remains disabled (greyed out). A page reload confirms WAF is still off.
6. **With this PR:** the first click immediately disables the button and shows the spinner state, the second click is a no-op, the toggle mutation completes, the notice disappears, and the page-level "Automatic firewall protection" toggle becomes editable.

### Single-click sanity check

1. With the notice visible, click **Enable Firewall** once.
2. **Expected:** button shows loading state briefly → notice dismisses → WAF is enabled.

### Browser/build

* `pnpm jetpack build plugins/protect`, load Jetpack Protect, repeat the steps above.
* No new strings, no a11y changes, no API changes.
