### PR TITLE
Write: Change category picker icon from gear to tag

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-write-category-icon
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-write-category-icon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Write: Change category picker icon from gear to tag for clarity

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -460,7 +460,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 
 	<!-- Floating category picker -->
 	<div class="bw-cat-fab" data-wp-on--click="actions.toggleCatPicker">
-		<span class="bw-cat-fab-icon dashicons dashicons-admin-generic"></span>
+		<span class="bw-cat-fab-icon dashicons dashicons-tag"></span>
 	</div>
 	<div class="bw-cat-popover" hidden data-wp-bind--hidden="!state.showCatPicker">
 		<div class="bw-cat-popover-header"><?php echo esc_html__( 'Categories', 'jetpack-mu-wpcom' ); ?></div>


### PR DESCRIPTION
## Proposed changes

Fixes RSM-1700

* Replaced `dashicons-admin-generic` (gear) with `dashicons-tag` on the floating category picker button
* The gear icon didn't communicate that it opens the category picker — the tag icon better conveys "categorize this post"
* The popover header still reads "Categories" to avoid any confusion with WordPress tags

Before | After
---- | ----
<img width="515" height="334" alt="Screenshot 2026-04-29 at 2 21 50 PM" src="https://github.com/user-attachments/assets/214b3287-9ea2-49b6-9f1f-8d5bfcdb786a" /> | <img width="517" height="324" alt="Screenshot 2026-04-29 at 2 21 31 PM" src="https://github.com/user-attachments/assets/8170df85-14de-490f-8105-64c5a5de0691" />


## Related product discussion/links

* Write Editor for WordPress.com project

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Go to the Write editor
* Look at the floating button in the bottom-right corner
* It should show a tag icon instead of a gear icon
* Click it — the Categories popover should still open and work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)