### PR TITLE
Write editor: fix drag-and-drop image upload in image modal

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-image-modal-drag-and-drop-upload
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-image-modal-drag-and-drop-upload
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write editor: Fix drag-and-drop image upload in the image modal.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -1047,7 +1047,8 @@
 	transition: color 0.3s ease;
 }
 
-.bw-upload-zone:hover {
+.bw-upload-zone:hover,
+.bw-upload-zone.bw-drag-over {
 	border-color: #2171b1;
 	color: #2171b1;
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -429,6 +429,57 @@ function resetUploadZone() {
 }
 
 /**
+ * Upload a file to the media library and update state with the result.
+ *
+ * @param {File} file - The file to upload.
+ */
+async function uploadFileToMedia( file ) {
+	const zone = document.getElementById( 'bw-upload-zone' );
+
+	state.isUploading = true;
+	if ( zone ) {
+		zone.classList.add( 'bw-uploading' );
+		const label = zone.querySelector( '.bw-upload-label' );
+		if ( label ) label.style.display = 'none';
+		const saving = zone.querySelector( '.bw-upload-saving' );
+		if ( saving ) saving.style.display = '';
+	}
+
+	const formData = new FormData();
+	formData.append( 'file', file );
+
+	try {
+		const media = await window.wp.apiFetch( {
+			path: state.mediaPath,
+			method: 'POST',
+			body: formData,
+		} );
+		state.isUploading = false;
+		if ( zone ) zone.classList.remove( 'bw-uploading' );
+
+		// Store the uploaded URL and media ID — wait for "Insert image" click.
+		state.imageUrl = media.source_url;
+		if ( ! state.imageAlt && media.alt_text ) {
+			state.imageAlt = media.alt_text;
+		}
+		if ( state.setAsFeatured ) {
+			state.featuredMediaId = media.id;
+		}
+		state.uploadedMediaId = media.id;
+
+		// Show preview.
+		showUploadPreview( media.source_url );
+	} catch ( err ) {
+		state.isUploading = false;
+		if ( zone ) zone.classList.remove( 'bw-uploading' );
+		state.message = ( i18n.uploadFailed || 'Upload failed: %s' ).replace( '%s', err.message );
+		setTimeout( () => {
+			state.message = '';
+		}, 3000 );
+	}
+}
+
+/**
  * Show a preview image in the upload zone.
  *
  * @param {string} src - The image source URL to preview.
@@ -1189,50 +1240,47 @@ const { state } = store( 'wpcom-write', {
 			const el = getElement();
 			const file = el.ref.files[ 0 ];
 			if ( ! file ) return;
+			await uploadFileToMedia( file );
+		},
 
-			state.isUploading = true;
+		handleDragOver( event ) {
+			event.preventDefault();
+			event.stopPropagation();
 			const zone = document.getElementById( 'bw-upload-zone' );
-			if ( zone ) {
-				zone.classList.add( 'bw-uploading' );
-				const label = zone.querySelector( '.bw-upload-label' );
-				if ( label ) label.style.display = 'none';
-				const saving = zone.querySelector( '.bw-upload-saving' );
-				if ( saving ) saving.style.display = '';
+			if ( zone ) zone.classList.add( 'bw-drag-over' );
+		},
+
+		handleDragLeave( event ) {
+			event.preventDefault();
+			event.stopPropagation();
+			const zone = document.getElementById( 'bw-upload-zone' );
+			if ( zone ) zone.classList.remove( 'bw-drag-over' );
+		},
+
+		async handleDrop( event ) {
+			event.preventDefault();
+			event.stopPropagation();
+			const zone = document.getElementById( 'bw-upload-zone' );
+			if ( zone ) zone.classList.remove( 'bw-drag-over' );
+
+			const file = event.dataTransfer?.files?.[ 0 ];
+			if ( ! file || ! file.type.startsWith( 'image/' ) ) {
+				return;
 			}
+			await uploadFileToMedia( file );
+		},
 
-			const formData = new FormData();
-			formData.append( 'file', file );
+		handleOverlayDragOver( event ) {
+			event.preventDefault();
+		},
 
-			try {
-				const media = await window.wp.apiFetch( {
-					path: state.mediaPath,
-					method: 'POST',
-					body: formData,
-				} );
-				state.imageUrl = media.source_url;
-				state.isUploading = false;
-				if ( zone ) zone.classList.remove( 'bw-uploading' );
-
-				// Store the uploaded URL and media ID — wait for "Insert image" click.
-				state.imageUrl = media.source_url;
-				if ( ! state.imageAlt && media.alt_text ) {
-					state.imageAlt = media.alt_text;
-				}
-				if ( state.setAsFeatured ) {
-					state.featuredMediaId = media.id;
-				}
-				state.uploadedMediaId = media.id;
-
-				// Show preview.
-				showUploadPreview( media.source_url );
-			} catch ( err ) {
-				state.isUploading = false;
-				if ( zone ) zone.classList.remove( 'bw-uploading' );
-				state.message = ( i18n.uploadFailed || 'Upload failed: %s' ).replace( '%s', err.message );
-				setTimeout( () => {
-					state.message = '';
-				}, 3000 );
+		async handleOverlayDrop( event ) {
+			event.preventDefault();
+			const file = event.dataTransfer?.files?.[ 0 ];
+			if ( ! file || ! file.type.startsWith( 'image/' ) ) {
+				return;
 			}
+			await uploadFileToMedia( file );
 		},
 
 		// --- Slash commands ---

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -377,10 +377,10 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 	</main>
 
 	<!-- Image modal -->
-	<div class="bw-image-overlay" hidden data-wp-bind--hidden="!state.showImageModal" data-wp-on--click="actions.closeImageModal">
-		<div class="bw-image-modal" data-wp-on--click="actions.stopPropagation">
+	<div class="bw-image-overlay" hidden data-wp-bind--hidden="!state.showImageModal" data-wp-on--click="actions.closeImageModal" data-wp-on--dragover="actions.handleOverlayDragOver" data-wp-on--drop="actions.handleOverlayDrop">
+		<div class="bw-image-modal" data-wp-on--click="actions.stopPropagation" data-wp-on--dragover="actions.handleOverlayDragOver" data-wp-on--drop="actions.handleOverlayDrop">
 			<h3><?php echo esc_html__( 'Add an image', 'jetpack-mu-wpcom' ); ?></h3>
-			<label class="bw-upload-zone" id="bw-upload-zone">
+			<label class="bw-upload-zone" id="bw-upload-zone" data-wp-on--dragover="actions.handleDragOver" data-wp-on--dragleave="actions.handleDragLeave" data-wp-on--drop="actions.handleDrop">
 				<span class="bw-upload-label"><?php echo esc_html__( 'Drop a file or click to upload', 'jetpack-mu-wpcom' ); ?></span>
 				<span class="bw-upload-saving" style="display:none;"><?php echo esc_html__( 'Uploading...', 'jetpack-mu-wpcom' ); ?></span>
 				<input type="file" accept="image/*" data-wp-on--change="actions.uploadImage" hidden />


### PR DESCRIPTION
Fixes RSM-1718

## Proposed changes

* Fix drag-and-drop image upload in the Write editor's image modal — previously dragging a file onto the upload zone caused the browser to navigate to the file instead of uploading it.
* Extract a shared `uploadFileToMedia()` helper from `uploadImage()` to avoid duplicating upload logic between click and drag-and-drop paths.
* Add `dragover`/`dragleave`/`drop` event handlers on the upload zone with visual feedback (blue border highlight on drag).
* Add `dragover`/`drop` handlers on the overlay and modal to prevent browser default navigation and forward dropped images to the upload flow.
* Validate that dropped files are images (`image/*`) before uploading.

## Related product discussion/links

* Linear: RSM-1718

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Open the Write editor
2. Type `/image` to open the image modal
3. **Drag-and-drop on upload zone**: Drag an image file onto the dashed upload zone → should show "Uploading..." then a preview (browser should NOT navigate away)
4. **Drag visual feedback**: Drag a file over the upload zone without dropping → border turns blue. Drag away → border returns to normal
5. **Drop on modal body**: Drop an image anywhere on the modal (outside the upload zone) → should also trigger the upload
6. **Drop on overlay**: Drop an image on the dark overlay backdrop → should trigger the upload (not navigate away)
7. **Non-image files**: Drag a `.txt` or `.pdf` onto the zone → nothing happens (no upload, no navigation)
8. **Click-to-upload still works**: Click the upload zone → file picker opens, select image → uploads normally
9. **Insert flow**: After a successful drag-and-drop upload, click "Insert image" → image is inserted into the post

🤖 Generated with [Claude Code](https://claude.com/claude-code)