### PR TITLE
Comments API: surface wpcom_id for Highlander wpcom commenters (READ-477)

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-reader-comment-author-links-clickable-read-477
+++ b/projects/plugins/jetpack/changelog/fix-reader-comment-author-links-clickable-read-477
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Comments API: include the WordPress.com user ID for commenters who signed in via the Highlander comment form, so the Reader can render clickable author links.

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -1451,8 +1451,10 @@ abstract class WPCOM_JSON_API_Endpoint {
 		$url        = null;
 		$ip_address = isset( $author->comment_author_IP ) ? $author->comment_author_IP : '';
 		$site_id    = -1;
+		$comment_id = 0;
 
 		if ( isset( $author->comment_author_email ) ) {
+			$comment_id = isset( $author->comment_ID ) ? (int) $author->comment_ID : 0;
 			$id         = empty( $author->user_id ) ? 0 : (int) $author->user_id;
 			$login      = '';
 			$email      = $author->comment_author_email;
@@ -1599,17 +1601,34 @@ abstract class WPCOM_JSON_API_Endpoint {
 		// Only include WordPress.com user data when author_wpcom_data is enabled.
 		$args = $this->query_args();
 
-		if ( ! empty( $id ) && ! empty( $args['author_wpcom_data'] ) ) {
+		if ( ! empty( $args['author_wpcom_data'] ) ) {
 			if ( ( new Host() )->is_wpcom_simple() ) {
-				$user                  = get_user_by( 'id', $id );
-				$author['wpcom_id']    = isset( $user->ID ) ? (int) $user->ID : null;
-				$author['wpcom_login'] = $user->user_login ?? '';
+				if ( ! empty( $id ) ) {
+					$user                  = get_user_by( 'id', $id );
+					$author['wpcom_id']    = isset( $user->ID ) ? (int) $user->ID : null;
+					$author['wpcom_login'] = $user->user_login ?? '';
+				}
 			} else {
-				// If this is a Jetpack site, use the connection manager to get the user data.
-				$wpcom_user_data = ( new Manager() )->get_connected_user_data( $id );
-				if ( $wpcom_user_data && isset( $wpcom_user_data['ID'] ) ) {
-					$author['wpcom_id']    = (int) $wpcom_user_data['ID'];
-					$author['wpcom_login'] = $wpcom_user_data['login'] ?? '';
+				// On Jetpack sites, prefer the WordPress.com user ID stored as comment meta by the
+				// Highlander comment form. Most commenters do not have a Jetpack user token on
+				// this site, so get_connected_user_data would return false for them. Only the
+				// WordPress.com identity source carries a WordPress.com user ID — the Jetpack
+				// source carries the commenter's local site user ID and the Facebook source
+				// carries a Facebook user ID.
+				$hc_wpcom_id  = 0;
+				$wpcom_source = 'wordpress'; // phpcs:ignore WordPress.WP.CapitalPDangit.MisspelledInText -- Highlander stores the source key in lowercase.
+				if ( $comment_id > 0 && $wpcom_source === get_comment_meta( $comment_id, 'hc_post_as', true ) ) {
+					$hc_wpcom_id = (int) get_comment_meta( $comment_id, 'hc_foreign_user_id', true );
+				}
+
+				if ( $hc_wpcom_id > 0 ) {
+					$author['wpcom_id'] = $hc_wpcom_id;
+				} elseif ( ! empty( $id ) ) {
+					$wpcom_user_data = ( new Manager() )->get_connected_user_data( $id );
+					if ( $wpcom_user_data && isset( $wpcom_user_data['ID'] ) ) {
+						$author['wpcom_id']    = (int) $wpcom_user_data['ID'];
+						$author['wpcom_login'] = $wpcom_user_data['login'] ?? '';
+					}
 				}
 			}
 		}

--- a/projects/plugins/jetpack/tests/php/json-api/Jetpack_Base_Json_Api_Endpoints_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/Jetpack_Base_Json_Api_Endpoints_Test.php
@@ -350,6 +350,161 @@ class Jetpack_Base_Json_Api_Endpoints_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test get_author populates wpcom_id from Highlander WordPress.com-source comment meta on Jetpack sites.
+	 *
+	 * On a self-hosted Jetpack-connected site, commenters who authenticate via the WordPress.com
+	 * tab in the Highlander comment form have their WordPress.com user ID stored as the
+	 * `hc_foreign_user_id` comment meta. The Reader needs `wpcom_id` in the API response so it
+	 * can build an in-Reader profile link via the existing user-profile lookup.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_get_author_populates_wpcom_id_from_highlander_wordpress_meta() {
+		$endpoint = $this->get_dummy_endpoint_with_wpcom_data();
+
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_author'       => 'A WPCOM Commenter',
+				'comment_author_email' => 'wpcom-commenter@example.com',
+				'comment_author_url'   => 'https://commenter.example/',
+				'user_id'              => 0,
+			)
+		);
+		add_comment_meta( $comment_id, 'hc_post_as', 'wordpress' ); // phpcs:ignore WordPress.WP.CapitalPDangit.MisspelledInText -- Highlander uses lowercase 'wordpress' as the identity-source key.
+		add_comment_meta( $comment_id, 'hc_foreign_user_id', 123456 );
+
+		$author = $endpoint->get_author( get_comment( $comment_id ) );
+
+		$this->assertSame(
+			123456,
+			$author->wpcom_id,
+			'wpcom_id should be populated from hc_foreign_user_id when hc_post_as is the WordPress.com source.'
+		);
+	}
+
+	/**
+	 * Test get_author does not surface a 'jetpack' Highlander foreign user ID as wpcom_id.
+	 *
+	 * `hc_post_as = 'jetpack'` indicates the commenter was logged in to the local Jetpack site
+	 * (not authenticated against WordPress.com), so `hc_foreign_user_id` holds the local site
+	 * user ID — not a WordPress.com one. It also has no signature stored alongside it. Surfacing
+	 * it as wpcom_id would let the Reader link to an unrelated WordPress.com user account.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_get_author_does_not_populate_wpcom_id_for_jetpack_post_as() {
+		$endpoint = $this->get_dummy_endpoint_with_wpcom_data();
+
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_author'       => 'A Jetpack Commenter',
+				'comment_author_email' => 'jp-commenter@example.com',
+				'user_id'              => 0,
+			)
+		);
+		add_comment_meta( $comment_id, 'hc_post_as', 'jetpack' );
+		add_comment_meta( $comment_id, 'hc_foreign_user_id', 7891011 );
+
+		$author = $endpoint->get_author( get_comment( $comment_id ) );
+
+		$this->assertObjectNotHasProperty(
+			'wpcom_id',
+			$author,
+			'wpcom_id must not be set when hc_post_as is jetpack (the foreign ID is a local site user ID, not a WordPress.com ID).'
+		);
+	}
+
+	/**
+	 * Test get_author does not treat a Facebook foreign user ID as a wpcom_id.
+	 *
+	 * `hc_foreign_user_id` is reused across identity providers; for Facebook commenters it holds
+	 * a Facebook user ID, not a WordPress.com one, and must not leak into wpcom_id.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_get_author_does_not_populate_wpcom_id_for_facebook_post_as() {
+		$endpoint = $this->get_dummy_endpoint_with_wpcom_data();
+
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_author'       => 'A Facebook Commenter',
+				'comment_author_email' => 'fb-commenter@example.com',
+				'user_id'              => 0,
+			)
+		);
+		add_comment_meta( $comment_id, 'hc_post_as', 'facebook' );
+		add_comment_meta( $comment_id, 'hc_foreign_user_id', 999 );
+
+		$author = $endpoint->get_author( get_comment( $comment_id ) );
+
+		$this->assertObjectNotHasProperty(
+			'wpcom_id',
+			$author,
+			'wpcom_id must not be set when hc_post_as is facebook (the foreign ID is not a WordPress.com ID).'
+		);
+	}
+
+	/**
+	 * Test get_author leaves wpcom_id absent for guest commenters without Highlander meta.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_get_author_leaves_wpcom_id_unset_without_highlander_meta() {
+		$endpoint = $this->get_dummy_endpoint_with_wpcom_data();
+
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_author'       => 'A Guest',
+				'comment_author_email' => 'guest@example.com',
+				'user_id'              => 0,
+			)
+		);
+
+		$author = $endpoint->get_author( get_comment( $comment_id ) );
+
+		$this->assertObjectNotHasProperty(
+			'wpcom_id',
+			$author,
+			'wpcom_id must not be set for a guest commenter with no Highlander meta.'
+		);
+	}
+
+	/**
+	 * Test get_author does not surface wpcom_id when author_wpcom_data is not requested.
+	 *
+	 * Regression check: the wpcom-data block must stay gated on the `author_wpcom_data`
+	 * query argument, even when the comment has the Highlander meta available locally.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_get_author_skips_wpcom_id_when_author_wpcom_data_not_requested() {
+		$endpoint = $this->get_dummy_endpoint();
+
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_author'       => 'A WPCOM Commenter',
+				'comment_author_email' => 'wpcom-commenter@example.com',
+				'user_id'              => 0,
+			)
+		);
+		add_comment_meta( $comment_id, 'hc_post_as', 'wordpress' ); // phpcs:ignore WordPress.WP.CapitalPDangit.MisspelledInText -- Highlander uses lowercase 'wordpress' as the identity-source key.
+		add_comment_meta( $comment_id, 'hc_foreign_user_id', 5555 );
+
+		$author = $endpoint->get_author( get_comment( $comment_id ) );
+
+		$this->assertObjectNotHasProperty(
+			'wpcom_id',
+			$author,
+			'wpcom_id must not appear when author_wpcom_data is not in the query args.'
+		);
+	}
+
+	/**
 	 * Generate a dummy endpoint.
 	 */
 	private function get_dummy_endpoint() {
@@ -360,6 +515,17 @@ class Jetpack_Base_Json_Api_Endpoints_Test extends WP_UnitTestCase {
 		);
 
 		return $endpoint;
+	}
+
+	/**
+	 * Generate a dummy endpoint that forces author_wpcom_data on for the wpcom-data branch.
+	 */
+	private function get_dummy_endpoint_with_wpcom_data() {
+		return new Jetpack_JSON_API_Dummy_Endpoint_With_Wpcom_Data(
+			array(
+				'stat' => 'dummy',
+			)
+		);
 	}
 }
 
@@ -372,5 +538,22 @@ class Jetpack_JSON_API_Dummy_Base_Endpoint extends Jetpack_JSON_API_Endpoint {
 	 */
 	public function result() {
 		return 'success';
+	}
+}
+
+/**
+ * Dummy endpoint that always reports author_wpcom_data=true in its query args, used to exercise
+ * the wpcom-data branch of get_author without setting up the full request pipeline.
+ */
+class Jetpack_JSON_API_Dummy_Endpoint_With_Wpcom_Data extends Jetpack_JSON_API_Dummy_Base_Endpoint {
+	/**
+	 * Force author_wpcom_data on regardless of the actual incoming query.
+	 *
+	 * @param bool $return_default_values Unused.
+	 * @param bool $cast_and_filter Unused.
+	 * @return array
+	 */
+	public function query_args( $return_default_values = true, $cast_and_filter = true ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		return array( 'author_wpcom_data' => true );
 	}
 }


### PR DESCRIPTION
Fixes the server-side half of [READ-477](https://linear.app/a8c/issue/READ-477).

## Proposed changes

* In `Jetpack_JSON_API_Endpoint::get_author()`, when serving comment-author data on a self-hosted Jetpack-connected site, populate `wpcom_id` on the response from the `hc_foreign_user_id` comment meta whenever the commenter authenticated via the WordPress.com tab in the Highlander comment form (`hc_post_as = 'wordpress'`).
* Restructure the `author_wpcom_data` block so each platform branch owns its own preconditions: the wpcom-simple branch keeps the existing `! empty( $id )` guard; the Jetpack branch is no longer gated on a local user_id, so guest commenters with WordPress.com identity meta are now covered.
* Add 5 PHPUnit tests for the new branch + a test-only dummy endpoint subclass (`Jetpack_JSON_API_Dummy_Endpoint_With_Wpcom_Data`) that forces `author_wpcom_data` on without setting up the full request pipeline.

## Why this matters

The `comments/replies` endpoint is what the Reader uses to load comment threads. For commenters on self-hosted Jetpack-connected sites (the original bug reports were against bookstooge.com and lifesfinewhine.ca), the previous code path called `Manager::get_connected_user_data( $id )` which requires an active Jetpack user token *for that user on this site*. Comment authors essentially never have such a token, so the call returned `false` and `wpcom_id` / `wpcom_login` were both omitted from the response. The Reader then had nothing to anchor an in-Reader link to and rendered the commenter's name as `<strong>` plus an external icon.

The Highlander comment form already stores the WordPress.com user ID locally in `hc_foreign_user_id` comment meta at submission time, signed via the blog token in `Highlander_Comments_Base::sign_remote_comment_parameters()`. We just need to read it back. This change is purely additive: it adds a new field to the response without modifying any existing behavior.

## What this is paired with

The companion client-side change is [Automattic/wp-calypso#110320](https://github.com/Automattic/wp-calypso/pull/110320) (still open, with a follow-up amendment in progress to consume the new `wpcom_id` field via the existing `userQuery( wpcom_login, wpcom_id, ... )` path). The avatar component already prefetches user data by `wpcom_id` for hovercards — the amendment makes the rendered link use the resolved `user_login` as well. Until that lands, this PR is a no-op (new field on a JSON response with no current consumer).

## Identity-source mapping (intentionally narrow)

Highlander supports several identity sources via `hc_post_as`. Only `'wordpress'` is treated as a WordPress.com identity here:

| Source | `hc_foreign_user_id` is | Has signature? | Treated as wpcom_id? |
|---|---|---|---|
| `wordpress` | a WordPress.com user_id | yes (`hc_wpcom_id_sig`) | **yes** |
| `jetpack` | a *local* Jetpack-site user_id | no | no |
| `facebook` | a Facebook user_id | no | no |

The `'jetpack'` source indicates a commenter who was logged in to the local Jetpack-host site (not WordPress.com), so the foreign ID is a local user_id from that site — surfacing it as `wpcom_id` would link the Reader to an unrelated WordPress.com user. Confirming signals in the existing code: `Highlander_Comments_Base::set_comment_cookies()` at `modules/comments/base.php:318` treats `'wordpress' !== \$id_source` as the not-authenticated-against-wpcom case, and `modules/comments/comments.php:752-779` only stores `hc_wpcom_id_sig` for the `'wordpress'` source.

## Trust boundary note

We don't re-verify `hc_wpcom_id_sig` at read time. The signature is verified at write time in `modules/comments/comments.php:664-672` (`hash_equals( \$check, \$post_array['sig'] )` rejects forged comment submissions). Trusting the stored value at read time matches existing practice for other Highlander meta keys. The residual risk is admin compromise or a buggy plugin that writes comment meta directly — both already broader concerns.

## Related product discussion/links

* [READ-477](https://linear.app/a8c/issue/READ-477) — Reader: commenter name and avatar links not clickable
* [Automattic/wp-calypso#110320](https://github.com/Automattic/wp-calypso/pull/110320) — client-side fix

## Does this pull request change what data or activity we track or use?

No. It exposes an additional field (`wpcom_id`) that is already stored locally in comment meta. No new tracking, no new outbound network calls.

## Testing instructions

### Automated

```
jp docker phpunit jetpack -- --filter=Jetpack_Base_Json_Api_Endpoints_Test
```

All 14 tests pass (28 assertions), including the 5 new ones:

* `test_get_author_populates_wpcom_id_from_highlander_wordpress_meta`
* `test_get_author_does_not_populate_wpcom_id_for_jetpack_post_as`
* `test_get_author_does_not_populate_wpcom_id_for_facebook_post_as`
* `test_get_author_leaves_wpcom_id_unset_without_highlander_meta`
* `test_get_author_skips_wpcom_id_when_author_wpcom_data_not_requested`

### Manual sandbox QA

1. On a self-hosted Jetpack-connected site, comment on a post while logged in to WordPress.com (use the WordPress.com tab in the Highlander comment form).
2. Note the WordPress.com user ID of the commenting account.
3. Fetch the comment via the WordPress.com REST API:
   ```
   curl 'https://public-api.wordpress.com/rest/v1.1/sites/{blog_id}/comments/{comment_id}?author_wpcom_data=true'
   ```
4. Verify the `author.wpcom_id` field in the response matches the commenter's WordPress.com user ID.
5. Verify a guest comment on the same post does NOT have a `wpcom_id` field on its author.

### Pre-existing tests for `get_author` (regression check)

Confirm none of the 9 pre-existing tests in the file changed behavior — the wpcom-simple branch still requires `\$id > 0`, and the Jetpack branch's existing `get_connected_user_data` fallback still runs when no Highlander meta is present.

## Note on how this was authored

The implementation, tests, and changelog were drafted with Claude Code assistance and reviewed against the WordPress.com Systems Review knowledge packs. The systems review caught one bug during the loop (an early version incorrectly treated `'jetpack'` as a wpcom identity); that's been fixed in this branch.