### PR TITLE
Write: fix image captions not saved to block content

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-image-caption-serialization
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-image-caption-serialization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write: Include image captions in block serialization.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -146,7 +146,7 @@ function convertToBlocks( html ) {
 			const alt = img.getAttribute( 'alt' ) || '';
 			const figcaption = node.querySelector( 'figcaption' );
 			const captionHtml = figcaption
-				? `<figcaption class="wp-element-caption" style="text-align:center">${ figcaption.innerHTML }</figcaption>`
+				? `<figcaption class="wp-element-caption">${ figcaption.innerHTML }</figcaption>`
 				: '';
 			blocks.push(
 				`<!-- wp:image -->\n<figure class="wp-block-image"><img src="${ src }" alt="${ alt }"/>${ captionHtml }</figure>\n<!-- /wp:image -->`

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -144,8 +144,12 @@ function convertToBlocks( html ) {
 			const img = node.querySelector( 'img' );
 			const src = img.getAttribute( 'src' ) || '';
 			const alt = img.getAttribute( 'alt' ) || '';
+			const figcaption = node.querySelector( 'figcaption' );
+			const captionHtml = figcaption
+				? `<figcaption class="wp-element-caption" style="text-align:center">${ figcaption.innerHTML }</figcaption>`
+				: '';
 			blocks.push(
-				`<!-- wp:image -->\n<figure class="wp-block-image"><img src="${ src }" alt="${ alt }"/></figure>\n<!-- /wp:image -->`
+				`<!-- wp:image -->\n<figure class="wp-block-image"><img src="${ src }" alt="${ alt }"/>${ captionHtml }</figure>\n<!-- /wp:image -->`
 			);
 		} else if ( tag === 'blockquote' ) {
 			// inner may already contain <p> tags from contentEditable.


### PR DESCRIPTION
Fixes RSM-1720

## Proposed changes

* Include `<figcaption>` in image block serialization in the Write editor's `convertToBlocks()` function, so captions entered by the user are preserved when the post is saved.


## Related product discussion/links

* Linear: RSM-1720

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Go to the Write editor
* Insert an image block
* Click the Caption button and type a caption
* Save/publish the post
* Verify the caption appears on the published post

🤖 Generated with [Claude Code](https://claude.com/claude-code)