### PR TITLE
CRM: Address listview count string replace mismatch

### DIFF
--- a/projects/plugins/crm/changelog/fix-crm-listview-counts-sprintf
+++ b/projects/plugins/crm/changelog/fix-crm-listview-counts-sprintf
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Listview: Fix "Showing X of Y items" text.

--- a/projects/plugins/crm/js/ZeroBSCRM.admin.listview.js
+++ b/projects/plugins/crm/js/ZeroBSCRM.admin.listview.js
@@ -543,8 +543,8 @@ function jpcrm_update_listview_counts() {
 	}
 
 	let html = zeroBSCRMJS_listViewLang( 'listview_counts' );
-	html = html.replace( '%s', current_range );
-	html = html.replace( '%s', zbsListViewCount );
+	html = html.replace( '%1$s', current_range );
+	html = html.replace( '%2$s', zbsListViewCount );
 	listview_count_els.forEach( element => ( element.textContent = html ) );
 }
 


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
In #46809 PHPCS autofixes were applied. This changed two `%s` in a single string to `%1$s` and `%2$s` (which is the typical correct thing to do). However, in this case the string was passed to JS where it was replaced with literal `replace( %s )` calls.

The easy fix is to update the string it's looking for, which is what this PR does. I didn't see any other instances of this problem.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

1. Create a contact.
2. Go to the contact listview.

In `trunk`, it'll look like this:
<img width="670" height="668" alt="image" src="https://github.com/user-attachments/assets/ce9b0571-d0f1-42f2-91c6-c850a2bb0d91" />

In this branch it'll look like this:
<img width="614" height="684" alt="image" src="https://github.com/user-attachments/assets/21fb4da2-0c4d-417e-8f72-60c7b4aa4e60" />
