### PR TITLE
[WIP] Search 3.0: store/api helpers for product-shaped filters (wc_stock_status, wc_rating, price range)

### DIFF
--- a/projects/packages/search/changelog/add-search-product-filter-helpers
+++ b/projects/packages/search/changelog/add-search-product-filter-helpers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Search 3.0: store/api helpers gain product-shaped filter support — `wc_stock_status` (terms agg + term clause on `meta._stock_status.value.raw`), `wc_rating` (histogram agg + range-OR clauses on `meta._wc_average_rating.double`), `priceRange` (range clause on `wc.price`), scalar comma-joined URL parsing, and first-paint URL seeding for `min_price`/`max_price`. Infrastructure only; no new blocks ship in this change.

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -396,12 +396,12 @@ class Search_Blocks {
 		// derives it from the raw URL params, so a URL that carried only
 		// unregistered `?foo[]=bar` params (e.g. from another plugin) would
 		// leave isLoading=true after gating emptied activeFilters — and since
-		// the JS `initialize()` only fires a search when `searchQuery` or
-		// `hasActiveFilters` is truthy, neither would fire, the spinner would
+		// the JS `initialize()` only fires a search when `searchQuery`,
+		// `hasActiveFilters`, or `priceRange` is truthy, the spinner would
 		// never clear.
 		$state['isLoading'] = '' !== $state['searchQuery']
 			|| ! empty( $state['activeFilters'] )
-			|| null !== ( $state['priceRange'] ?? null );
+			|| null !== $state['priceRange'];
 		return $state;
 	}
 

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -18,7 +18,7 @@ class Search_Blocks {
 	 * Reserved query params that must not be parsed as filter keys. Mirrors
 	 * `RESERVED_PARAMS` in store/url-state.js.
 	 */
-	const RESERVED_QUERY_PARAMS = array( 's', 'orderby' );
+	const RESERVED_QUERY_PARAMS = array( 's', 'orderby', 'min_price', 'max_price' );
 
 	/**
 	 * Template slug used for the Jetpack Search page template.
@@ -399,7 +399,9 @@ class Search_Blocks {
 		// the JS `initialize()` only fires a search when `searchQuery` or
 		// `hasActiveFilters` is truthy, neither would fire, the spinner would
 		// never clear.
-		$state['isLoading'] = '' !== $state['searchQuery'] || ! empty( $state['activeFilters'] );
+		$state['isLoading'] = '' !== $state['searchQuery']
+			|| ! empty( $state['activeFilters'] )
+			|| null !== ( $state['priceRange'] ?? null );
 		return $state;
 	}
 
@@ -490,6 +492,7 @@ class Search_Blocks {
 		$site_id        = class_exists( Helper::class ) ? Helper::get_wpcom_site_id() : 0;
 		$search_query   = function_exists( 'get_search_query' ) ? (string) get_search_query() : '';
 		$active_filters = static::parse_url_filters();
+		$price_range    = static::parse_url_price_range();
 
 		return array(
 			// Connection / routing config.
@@ -514,6 +517,7 @@ class Search_Blocks {
 			'searchQuery'   => $search_query,
 			'sortOrder'     => static::parse_url_sort(),
 			'activeFilters' => $active_filters,
+			'priceRange'    => $price_range,
 
 			// filterConfigs: each filter-checkbox block's render.php merges its
 			// own entry here. Shape: { [filterKey]: { filterKey, filterType,
@@ -532,7 +536,7 @@ class Search_Blocks {
 			// search query or filter selection so the no-results block stays
 			// hidden between first paint and JS hydrating the initial fetch —
 			// otherwise a "No results found" flash appears on deep links.
-			'isLoading'     => '' !== $search_query || ! empty( $active_filters ),
+			'isLoading'     => '' !== $search_query || ! empty( $active_filters ) || null !== $price_range,
 			'isLoadingMore' => false,
 			'hasError'      => false,
 
@@ -583,6 +587,49 @@ class Search_Blocks {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only URL state.
 		$orderby = isset( $_GET['orderby'] ) ? sanitize_key( wp_unslash( $_GET['orderby'] ) ) : '';
 		return in_array( $orderby, array( 'newest', 'oldest' ), true ) ? $orderby : 'relevance';
+	}
+
+	/**
+	 * Parse the price range from the URL, mirroring the contract in
+	 * src/search-blocks/store/url-state.js. Either bound may be null for a
+	 * half-open range; non-numeric or negative values yield null so a
+	 * garbage URL can't drive the API into producing zero results.
+	 *
+	 * Returns null when neither bound is set, so callers can early-out
+	 * without checking individual fields.
+	 *
+	 * @return array{min: float|null, max: float|null}|null
+	 */
+	protected static function parse_url_price_range(): ?array {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- read-only URL state; coerced to float in parse_price_bound() which discards any non-numeric input.
+		$min = self::parse_price_bound( $_GET['min_price'] ?? null );
+		$max = self::parse_price_bound( $_GET['max_price'] ?? null );
+		// phpcs:enable
+
+		if ( null === $min && null === $max ) {
+			return null;
+		}
+		return array(
+			'min' => $min,
+			'max' => $max,
+		);
+	}
+
+	/**
+	 * Coerce a single price-range URL value into a finite, non-negative float.
+	 *
+	 * @param mixed $raw Raw value pulled from $_GET.
+	 * @return float|null
+	 */
+	private static function parse_price_bound( $raw ): ?float {
+		if ( null === $raw || '' === $raw || ! is_scalar( $raw ) ) {
+			return null;
+		}
+		$num = (float) wp_unslash( $raw );
+		if ( ! is_finite( $num ) || $num < 0 ) {
+			return null;
+		}
+		return $num;
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -609,6 +609,14 @@ class Search_Blocks {
 		if ( null === $min && null === $max ) {
 			return null;
 		}
+		// Both bounds present but inverted (min > max) yields an empty ES
+		// `range` clause that returns zero results silently. Treat the URL
+		// as garbage and bail so the page renders a normal (unfiltered)
+		// search rather than a guaranteed-empty one. Mirrors the same
+		// rejection in store/url-state.js.
+		if ( null !== $min && null !== $max && $min > $max ) {
+			return null;
+		}
 		return array(
 			'min' => $min,
 			'max' => $max,
@@ -625,7 +633,15 @@ class Search_Blocks {
 		if ( null === $raw || '' === $raw || ! is_scalar( $raw ) ) {
 			return null;
 		}
-		$num = (float) wp_unslash( $raw );
+		// `is_numeric` rejects partially-numeric strings like "1.5.3" that
+		// the (float) cast would silently extract as 1.5 — JS's Number()
+		// returns NaN for the same input, so without this gate the PHP
+		// initial render and JS hydration disagree on parsed value.
+		$raw = wp_unslash( $raw );
+		if ( ! is_numeric( $raw ) ) {
+			return null;
+		}
+		$num = (float) $raw;
 		if ( ! is_finite( $num ) || $num < 0 ) {
 			return null;
 		}

--- a/projects/packages/search/src/search-blocks/store/api.js
+++ b/projects/packages/search/src/search-blocks/store/api.js
@@ -84,9 +84,58 @@ export function resolveFilterFields( config ) {
 				filterField: 'author_login',
 				bucketFormat: 'slash',
 			};
+		case 'wc_stock_status':
+			// Reads WooCommerce-populated postmeta indexed under
+			// `meta._stock_status.value` with a `.raw` keyword subfield via
+			// the `meta_str_template` dynamic mapping. The terms-aggs
+			// whitelist (`meta\..*\.value\.raw` in
+			// class-wpcom-search-engine.php) admits this exact path. The
+			// `wc_*` prefix on the filterType marks the dependency on
+			// WC-populated meta even though no WC-side code is involved at
+			// query time.
+			return {
+				aggField: 'meta._stock_status.value.raw',
+				filterField: 'meta._stock_status.value.raw',
+				bucketFormat: 'plain',
+			};
+		case 'wc_rating':
+			// Reads WC's per-product `_wc_average_rating` meta. Aggregation
+			// uses a histogram (range aggs aren't whitelisted on the
+			// WPCOM v1.3 search API — `[aggs:range] is not whitelisted`)
+			// with `interval: 1, offset: 0.5` so bucket boundaries fall on
+			// half-integers, mirroring WC's `ROUND(avg_rating, 0)` star
+			// cutoffs from FilterData::get_rating_counts. Filter clauses
+			// use `range` per selected star, OR'd via `bool.should`.
+			// `buildAggregations` and `buildFilterClause` special-case this
+			// filterType because the standard `terms` agg / `term` clause
+			// don't apply.
+			return {
+				aggField: 'meta._wc_average_rating.double',
+				filterField: 'meta._wc_average_rating.double',
+				bucketFormat: 'plain',
+			};
 	}
 	return { aggField: null, filterField: null, bucketFormat: 'plain' };
 }
+
+/**
+ * Star buckets for `wc_rating` filter clauses. Mirrors WC's
+ * `ROUND(avg_rating, 0)` semantics: star=5 covers avg ∈ [4.5, ∞),
+ * star=4 covers [3.5, 4.5), down to star=1 covering [0.5, 1.5).
+ *
+ * Aggregation uses a histogram (range aggs aren't whitelisted on the
+ * WPCOM v1.3 search API). `histogramKey` is the bucket key the
+ * histogram emits for that star band when called with `interval: 1`
+ * and `offset: 0.5` — useful for response-side bucket → star
+ * projection.
+ */
+export const WC_RATING_RANGES = [
+	{ key: '1', from: 0.5, to: 1.5, histogramKey: 0.5 },
+	{ key: '2', from: 1.5, to: 2.5, histogramKey: 1.5 },
+	{ key: '3', from: 2.5, to: 3.5, histogramKey: 2.5 },
+	{ key: '4', from: 3.5, to: 4.5, histogramKey: 3.5 },
+	{ key: '5', from: 4.5, histogramKey: 4.5 },
+];
 
 /**
  * Build ES aggregation requests from the filterConfigs registered by each
@@ -106,6 +155,22 @@ export function resolveFilterFields( config ) {
 export function buildAggregations( filterConfigs ) {
 	const aggregations = {};
 	for ( const [ filterKey, config ] of Object.entries( filterConfigs ?? {} ) ) {
+		// Rating gets a histogram aggregation. `range` aggs aren't
+		// whitelisted on the v1.3 API; histogram interval=1 with offset=0.5
+		// produces buckets keyed at .5 boundaries, mirroring WC's
+		// ROUND(avg_rating) star buckets.
+		if ( config?.filterType === 'wc_rating' ) {
+			aggregations[ filterKey ] = {
+				histogram: {
+					field: 'meta._wc_average_rating.double',
+					interval: 1,
+					offset: 0.5,
+					min_doc_count: 0,
+				},
+			};
+			continue;
+		}
+
 		const { aggField } = resolveFilterFields( config );
 		if ( ! aggField ) {
 			continue;
@@ -144,7 +209,29 @@ export function buildFilterClause( activeFilters, filterConfigs ) {
 		if ( ! Array.isArray( values ) || values.length === 0 ) {
 			continue;
 		}
-		const { filterField } = resolveFilterFields( filterConfigs?.[ filterKey ] );
+		const config = filterConfigs?.[ filterKey ];
+
+		// Rating: each selected star level maps to a range clause on
+		// `meta._wc_average_rating.double`; multiple selections OR.
+		if ( config?.filterType === 'wc_rating' ) {
+			const ranges = values
+				.map( value => WC_RATING_RANGES.find( r => r.key === String( value ) ) )
+				.filter( Boolean )
+				.map( r => {
+					const range = { gte: r.from };
+					if ( r.to !== undefined ) {
+						range.lt = r.to;
+					}
+					return { range: { 'meta._wc_average_rating.double': range } };
+				} );
+			if ( ranges.length === 0 ) {
+				continue;
+			}
+			must.push( ranges.length === 1 ? ranges[ 0 ] : { bool: { should: ranges } } );
+			continue;
+		}
+
+		const { filterField } = resolveFilterFields( config );
 		if ( ! filterField ) {
 			continue;
 		}
@@ -169,6 +256,11 @@ export function buildFilterClause( activeFilters, filterConfigs ) {
  * @param {object}      [opts.activeFilters] - { [filterKey]: string[] } selected filters.
  * @param {object}      [opts.filterConfigs] - { [filterKey]: FilterConfig } registered filters.
  * @param {string}      [opts.homeUrl]       - Home URL; required for private WPcom sites.
+ * @param {object|null} [opts.priceRange]    - `{ min, max }` numeric range against the
+ *                                           `wc.price` ES field. Either bound may be null
+ *                                           for a half-open range. Read by future product
+ *                                           filter blocks driven by `min_price` / `max_price`
+ *                                           URL params.
  * @return {string} Full URL to call.
  */
 export function buildSearchUrl( {
@@ -182,6 +274,7 @@ export function buildSearchUrl( {
 	activeFilters = {},
 	filterConfigs = {},
 	homeUrl = '',
+	priceRange = null,
 } ) {
 	// `qss.encode()` runs `encodeURIComponent` on every value, so we pass the
 	// raw query here. The instant-search code double-encodes (pre-encodes
@@ -201,7 +294,22 @@ export function buildSearchUrl( {
 		params.aggregations = aggregations;
 	}
 
-	const filter = buildFilterClause( activeFilters, filterConfigs );
+	let filter = buildFilterClause( activeFilters, filterConfigs );
+	if ( priceRange && ( priceRange.min != null || priceRange.max != null ) ) {
+		const range = {};
+		if ( priceRange.min != null ) {
+			range.gte = priceRange.min;
+		}
+		if ( priceRange.max != null ) {
+			range.lte = priceRange.max;
+		}
+		const rangeClause = { range: { 'wc.price': range } };
+		if ( filter ) {
+			filter.bool.must.push( rangeClause );
+		} else {
+			filter = { bool: { must: [ rangeClause ] } };
+		}
+	}
 	if ( filter ) {
 		params.filter = filter;
 	}

--- a/projects/packages/search/src/search-blocks/store/api.js
+++ b/projects/packages/search/src/search-blocks/store/api.js
@@ -123,6 +123,14 @@ export function resolveFilterFields( config ) {
  * `ROUND(avg_rating, 0)` semantics: star=5 covers avg ∈ [4.5, ∞),
  * star=4 covers [3.5, 4.5), down to star=1 covering [0.5, 1.5).
  *
+ * Products with `_wc_average_rating` < 0.5 fall into a histogram
+ * bucket at -0.5 with no corresponding star entry — they're returned
+ * in unfiltered results but cannot be selected via the rating filter.
+ * This matches WC's own `ROUND(avg_rating, 0)` filter UI which has
+ * no "0-star" option either; when the front-end filter block lands
+ * (DSGWOO-equivalent on the Search 3.0 side) it will surface only the
+ * 1–5 entries here.
+ *
  * Aggregation uses a histogram (range aggs aren't whitelisted on the
  * WPCOM v1.3 search API). `histogramKey` is the bucket key the
  * histogram emits for that star band when called with `interval: 1`
@@ -160,9 +168,10 @@ export function buildAggregations( filterConfigs ) {
 		// produces buckets keyed at .5 boundaries, mirroring WC's
 		// ROUND(avg_rating) star buckets.
 		if ( config?.filterType === 'wc_rating' ) {
+			const { aggField: ratingField } = resolveFilterFields( config );
 			aggregations[ filterKey ] = {
 				histogram: {
-					field: 'meta._wc_average_rating.double',
+					field: ratingField,
 					interval: 1,
 					offset: 0.5,
 					min_doc_count: 0,
@@ -212,8 +221,9 @@ export function buildFilterClause( activeFilters, filterConfigs ) {
 		const config = filterConfigs?.[ filterKey ];
 
 		// Rating: each selected star level maps to a range clause on
-		// `meta._wc_average_rating.double`; multiple selections OR.
+		// the rating field resolved from the config; multiple selections OR.
 		if ( config?.filterType === 'wc_rating' ) {
+			const { filterField: ratingField } = resolveFilterFields( config );
 			const ranges = values
 				.map( value => WC_RATING_RANGES.find( r => r.key === String( value ) ) )
 				.filter( Boolean )
@@ -222,7 +232,7 @@ export function buildFilterClause( activeFilters, filterConfigs ) {
 					if ( r.to !== undefined ) {
 						range.lt = r.to;
 					}
-					return { range: { 'meta._wc_average_rating.double': range } };
+					return { range: { [ ratingField ]: range } };
 				} );
 			if ( ranges.length === 0 ) {
 				continue;
@@ -304,11 +314,13 @@ export function buildSearchUrl( {
 			range.lte = priceRange.max;
 		}
 		const rangeClause = { range: { 'wc.price': range } };
-		if ( filter ) {
-			filter.bool.must.push( rangeClause );
-		} else {
-			filter = { bool: { must: [ rangeClause ] } };
-		}
+		// Build a fresh wrapper rather than mutating the object returned by
+		// `buildFilterClause` — safe today because that helper always returns
+		// a freshly constructed object, but the non-mutating shape stays
+		// correct if memoisation or caching is added later.
+		filter = filter
+			? { bool: { must: [ ...filter.bool.must, rangeClause ] } }
+			: { bool: { must: [ rangeClause ] } };
 	}
 	if ( filter ) {
 		params.filter = filter;

--- a/projects/packages/search/src/search-blocks/store/api.js
+++ b/projects/packages/search/src/search-blocks/store/api.js
@@ -304,6 +304,8 @@ export function buildSearchUrl( {
 		params.aggregations = aggregations;
 	}
 
+	// `buildFilterClause` returns either `{ bool: { must: [...] } }` or
+	// `undefined` — the spread below relies on that shape contract.
 	let filter = buildFilterClause( activeFilters, filterConfigs );
 	if ( priceRange && ( priceRange.min != null || priceRange.max != null ) ) {
 		const range = {};

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -33,6 +33,7 @@ function* fetchResults( pageHandle ) {
 		homeUrl: state.homeUrl,
 		activeFilters: state.activeFilters,
 		filterConfigs: state.filterConfigs,
+		priceRange: state.priceRange,
 	} );
 	const response = yield fetch( url, {
 		headers: state.isPrivateSite ? { 'X-WP-Nonce': state.nonce } : {},
@@ -356,10 +357,13 @@ const { state, actions } = store( NAMESPACE, {
 		 * @yield {Promise} search action.
 		 */
 		*handlePopState() {
-			const { searchQuery, sortOrder, activeFilters } = readStateFromUrl( state.filterConfigs );
+			const { searchQuery, sortOrder, activeFilters, priceRange } = readStateFromUrl(
+				state.filterConfigs
+			);
 			state.searchQuery = searchQuery;
 			state.sortOrder = sortOrder;
 			state.activeFilters = activeFilters;
+			state.priceRange = priceRange;
 			yield actions.search( { syncUrl: false } );
 		},
 

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -348,6 +348,7 @@ const { state, actions } = store( NAMESPACE, {
 				searchQuery: state.searchQuery,
 				sortOrder: state.sortOrder,
 				activeFilters: state.activeFilters,
+				priceRange: state.priceRange,
 			} );
 		},
 
@@ -461,7 +462,7 @@ const { state, actions } = store( NAMESPACE, {
 			}
 			initialized = true;
 			window.addEventListener( 'popstate', actions.handlePopState );
-			if ( state.searchQuery || state.hasActiveFilters ) {
+			if ( state.searchQuery || state.hasActiveFilters || state.priceRange ) {
 				// The URL already carries this query — don't push a duplicate
 				// history entry on top of the browser's current one.
 				actions.search( { syncUrl: false } );

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -465,6 +465,10 @@ const { state, actions } = store( NAMESPACE, {
 			if ( state.searchQuery || state.hasActiveFilters || state.priceRange ) {
 				// The URL already carries this query — don't push a duplicate
 				// history entry on top of the browser's current one.
+				// `priceRange` is checked separately because `hasActiveFilters`
+				// only inspects `activeFilters`; without this gate a URL like
+				// `?min_price=10` would leave PHP's `isLoading: true` spinner
+				// stuck because no initial fetch ever fires.
 				actions.search( { syncUrl: false } );
 			}
 		},

--- a/projects/packages/search/src/search-blocks/store/url-state.js
+++ b/projects/packages/search/src/search-blocks/store/url-state.js
@@ -4,7 +4,26 @@ const DEFAULT_SORT_ORDER = 'relevance';
 
 // Reserved query params — not treated as filter keys on parse. Mirrors the
 // allow-list on the PHP side in Search_Blocks::parse_url_filters().
-const RESERVED_PARAMS = new Set( [ 's', 'orderby' ] );
+const RESERVED_PARAMS = new Set( [ 's', 'orderby', 'min_price', 'max_price' ] );
+
+/**
+ * Parse a `min_price` / `max_price` URL value into a finite number.
+ * Returns null on missing, non-numeric, or negative input so a garbage
+ * URL can't drive the API into producing zero results.
+ *
+ * @param {string|null} raw - Raw URL param value.
+ * @return {number|null} Parsed number or null.
+ */
+function parsePriceBound( raw ) {
+	if ( raw === null || raw === undefined || raw === '' ) {
+		return null;
+	}
+	const num = Number( raw );
+	if ( ! Number.isFinite( num ) || num < 0 ) {
+		return null;
+	}
+	return num;
+}
 
 /**
  * Serialize store state to URLSearchParams.
@@ -13,13 +32,19 @@ const RESERVED_PARAMS = new Set( [ 's', 'orderby' ] );
  * matching the shape instant-search already writes so deep links are
  * interchangeable between the two surfaces.
  *
- * @param {object} state                 - Store state slice.
- * @param {string} state.searchQuery     - Current search query.
- * @param {string} state.sortOrder       - Current sort order.
- * @param {object} [state.activeFilters] - { [filterKey]: string[] } selected filters.
+ * @param {object}      state                 - Store state slice.
+ * @param {string}      state.searchQuery     - Current search query.
+ * @param {string}      state.sortOrder       - Current sort order.
+ * @param {object}      [state.activeFilters] - { [filterKey]: string[] } selected filters.
+ * @param {object|null} [state.priceRange]    - { min, max } price range; either bound may be null.
  * @return {URLSearchParams} URL-ready params.
  */
-export function stateToUrlParams( { searchQuery, sortOrder, activeFilters = {} } ) {
+export function stateToUrlParams( {
+	searchQuery,
+	sortOrder,
+	activeFilters = {},
+	priceRange = null,
+} ) {
 	const params = new URLSearchParams();
 
 	// Always emit `s` (even empty) so a refresh keeps WP routed to the
@@ -38,6 +63,13 @@ export function stateToUrlParams( { searchQuery, sortOrder, activeFilters = {} }
 		values.forEach( value => params.append( `${ key }[]`, value ) );
 	}
 
+	if ( priceRange?.min != null ) {
+		params.set( 'min_price', String( priceRange.min ) );
+	}
+	if ( priceRange?.max != null ) {
+		params.set( 'max_price', String( priceRange.max ) );
+	}
+
 	return params;
 }
 
@@ -54,7 +86,7 @@ export function stateToUrlParams( { searchQuery, sortOrder, activeFilters = {} }
  *
  * @param {URLSearchParams} params          - URL search params.
  * @param {object}          [filterConfigs] - { [filterKey]: FilterConfig } map used to validate filter keys.
- * @return {{ searchQuery: string, sortOrder: string, activeFilters: object }} Partial state.
+ * @return {{ searchQuery: string, sortOrder: string, activeFilters: object, priceRange: object|null }} Partial state.
  */
 export function urlParamsToState( params, filterConfigs = {} ) {
 	const rawOrderby = params.get( 'orderby' );
@@ -93,10 +125,37 @@ export function urlParamsToState( params, filterConfigs = {} ) {
 		activeFilters[ filterKey ].push( normalized );
 	}
 
+	// Scalar comma-joined fallback for filterConfigs whose `urlFormat` is
+	// `scalar` (e.g. `?filter_stock_status=instock,outofstock`). Used by
+	// product filters whose URL contract is a single key with comma-joined
+	// values rather than the array-form `?key[]=v` default.
+	for ( const [ filterKey, config ] of Object.entries( filterConfigs ?? {} ) ) {
+		if ( config?.urlFormat !== 'scalar' || activeFilters[ filterKey ] ) {
+			continue;
+		}
+		const raw = params.get( filterKey );
+		if ( ! raw ) {
+			continue;
+		}
+		const values = String( raw )
+			.split( ',' )
+			.map( v => v.trim() )
+			.filter( Boolean );
+		if ( values.length > 0 ) {
+			activeFilters[ filterKey ] = Array.from( new Set( values ) );
+		}
+	}
+
+	const minPrice = parsePriceBound( params.get( 'min_price' ) );
+	const maxPrice = parsePriceBound( params.get( 'max_price' ) );
+	const priceRange =
+		minPrice !== null || maxPrice !== null ? { min: minPrice, max: maxPrice } : null;
+
 	return {
 		searchQuery: params.get( 's' ) ?? '',
 		sortOrder: VALID_SORT_ORDERS.includes( rawOrderby ) ? rawOrderby : DEFAULT_SORT_ORDER,
 		activeFilters,
+		priceRange,
 	};
 }
 
@@ -119,7 +178,7 @@ export function pushStateToUrl( state ) {
  * Read initial state from the current URL.
  *
  * @param {object} [filterConfigs] - { [filterKey]: FilterConfig } map used to validate filter keys.
- * @return {{ searchQuery: string, sortOrder: string, activeFilters: object }} Partial state.
+ * @return {{ searchQuery: string, sortOrder: string, activeFilters: object, priceRange: object|null }} Partial state.
  */
 export function readStateFromUrl( filterConfigs = {} ) {
 	return urlParamsToState( new URLSearchParams( window.location.search ), filterConfigs );

--- a/projects/packages/search/src/search-blocks/store/url-state.js
+++ b/projects/packages/search/src/search-blocks/store/url-state.js
@@ -148,8 +148,15 @@ export function urlParamsToState( params, filterConfigs = {} ) {
 
 	const minPrice = parsePriceBound( params.get( 'min_price' ) );
 	const maxPrice = parsePriceBound( params.get( 'max_price' ) );
+	// Inverted bounds (min > max) build an ES range clause that always
+	// matches zero documents, so a URL like `?min_price=100&max_price=10`
+	// would render an empty page. Treat that as garbage and drop the range
+	// entirely; mirrors parse_url_price_range() on the PHP side.
+	const hasInvertedBounds = minPrice !== null && maxPrice !== null && minPrice > maxPrice;
 	const priceRange =
-		minPrice !== null || maxPrice !== null ? { min: minPrice, max: maxPrice } : null;
+		! hasInvertedBounds && ( minPrice !== null || maxPrice !== null )
+			? { min: minPrice, max: maxPrice }
+			: null;
 
 	return {
 		searchQuery: params.get( 's' ) ?? '',

--- a/projects/packages/search/tests/js/search-blocks/api.test.js
+++ b/projects/packages/search/tests/js/search-blocks/api.test.js
@@ -1,5 +1,6 @@
 import {
 	SEARCH_FIELDS,
+	WC_RATING_RANGES,
 	buildAggregations,
 	buildFilterClause,
 	buildSearchUrl,
@@ -343,5 +344,167 @@ describe( 'buildFilterClause', () => {
 
 	it( 'returns undefined when no selections are active', () => {
 		expect( buildFilterClause( {}, {} ) ).toBeUndefined();
+	} );
+} );
+
+describe( 'product-shaped filter helpers', () => {
+	describe( 'resolveFilterFields', () => {
+		it( 'maps wc_stock_status to the indexed meta keyword field', () => {
+			expect( resolveFilterFields( { filterType: 'wc_stock_status' } ) ).toEqual( {
+				aggField: 'meta._stock_status.value.raw',
+				filterField: 'meta._stock_status.value.raw',
+				bucketFormat: 'plain',
+			} );
+		} );
+
+		it( 'maps wc_rating to the average-rating numeric field', () => {
+			expect( resolveFilterFields( { filterType: 'wc_rating' } ) ).toEqual( {
+				aggField: 'meta._wc_average_rating.double',
+				filterField: 'meta._wc_average_rating.double',
+				bucketFormat: 'plain',
+			} );
+		} );
+	} );
+
+	describe( 'buildAggregations', () => {
+		it( 'emits a terms agg for wc_stock_status', () => {
+			const aggs = buildAggregations( {
+				filter_stock_status: { filterType: 'wc_stock_status', maxItems: 10 },
+			} );
+			expect( aggs.filter_stock_status ).toEqual( {
+				terms: {
+					field: 'meta._stock_status.value.raw',
+					size: 10,
+					order: { _count: 'desc' },
+				},
+			} );
+		} );
+
+		it( 'emits a histogram (not terms) for wc_rating because range aggs are not whitelisted', () => {
+			const aggs = buildAggregations( { rating_filter: { filterType: 'wc_rating' } } );
+			expect( aggs.rating_filter ).toEqual( {
+				histogram: {
+					field: 'meta._wc_average_rating.double',
+					interval: 1,
+					offset: 0.5,
+					min_doc_count: 0,
+				},
+			} );
+		} );
+	} );
+
+	describe( 'buildFilterClause: wc_rating range branch', () => {
+		it( 'emits a single range clause for one star selection', () => {
+			const clause = buildFilterClause(
+				{ rating_filter: [ '5' ] },
+				{ rating_filter: { filterType: 'wc_rating' } }
+			);
+			expect( clause ).toEqual( {
+				bool: {
+					must: [ { range: { 'meta._wc_average_rating.double': { gte: 4.5 } } } ],
+				},
+			} );
+		} );
+
+		it( 'wraps multi-star selections in bool.should (OR within rating filter)', () => {
+			const clause = buildFilterClause(
+				{ rating_filter: [ '4', '5' ] },
+				{ rating_filter: { filterType: 'wc_rating' } }
+			);
+			expect( clause ).toEqual( {
+				bool: {
+					must: [
+						{
+							bool: {
+								should: [
+									{ range: { 'meta._wc_average_rating.double': { gte: 3.5, lt: 4.5 } } },
+									{ range: { 'meta._wc_average_rating.double': { gte: 4.5 } } },
+								],
+							},
+						},
+					],
+				},
+			} );
+		} );
+
+		it( 'gives star=5 an open upper bound (no `lt`) so 5.0 ratings count', () => {
+			const five = WC_RATING_RANGES.find( r => r.key === '5' );
+			expect( five.to ).toBeUndefined();
+			expect( five.from ).toBe( 4.5 );
+		} );
+
+		it( 'drops unknown star values', () => {
+			const clause = buildFilterClause(
+				{ rating_filter: [ '99' ] },
+				{ rating_filter: { filterType: 'wc_rating' } }
+			);
+			expect( clause ).toBeUndefined();
+		} );
+	} );
+
+	describe( 'buildFilterClause: wc_stock_status uses the standard term branch', () => {
+		it( 'OR-joins multiple stock-status selections within the filter', () => {
+			const clause = buildFilterClause(
+				{ filter_stock_status: [ 'instock', 'outofstock' ] },
+				{ filter_stock_status: { filterType: 'wc_stock_status', urlFormat: 'scalar' } }
+			);
+			expect( clause ).toEqual( {
+				bool: {
+					must: [
+						{
+							bool: {
+								should: [
+									{ term: { 'meta._stock_status.value.raw': 'instock' } },
+									{ term: { 'meta._stock_status.value.raw': 'outofstock' } },
+								],
+							},
+						},
+					],
+				},
+			} );
+		} );
+	} );
+
+	describe( 'buildSearchUrl: priceRange', () => {
+		const baseOpts = {
+			siteId: 1,
+			searchQuery: '',
+			sortOrder: 'relevance',
+			pageHandle: null,
+			isPrivateSite: false,
+			isWpcom: false,
+			apiRoot: '',
+		};
+
+		it( 'omits price range when both bounds are null', () => {
+			const url = buildSearchUrl( { ...baseOpts, priceRange: { min: null, max: null } } );
+			expect( url ).not.toContain( 'wc.price' );
+		} );
+
+		it( 'emits a half-open `gte` range when only min is set', () => {
+			const url = buildSearchUrl( { ...baseOpts, priceRange: { min: 10, max: null } } );
+			const decoded = decodeURIComponent( url );
+			expect( decoded ).toContain( 'filter[bool][must][0][range][wc.price][gte]=10' );
+			expect( decoded ).not.toContain( '[lte]' );
+		} );
+
+		it( 'emits a closed range when both bounds are set', () => {
+			const url = buildSearchUrl( { ...baseOpts, priceRange: { min: 10, max: 50 } } );
+			const decoded = decodeURIComponent( url );
+			expect( decoded ).toContain( 'filter[bool][must][0][range][wc.price][gte]=10' );
+			expect( decoded ).toContain( 'filter[bool][must][0][range][wc.price][lte]=50' );
+		} );
+
+		it( 'appends price range alongside an existing filter clause without overwriting it', () => {
+			const url = buildSearchUrl( {
+				...baseOpts,
+				activeFilters: { category: [ 'news' ] },
+				filterConfigs: { category: { filterType: 'taxonomy', taxonomy: 'category' } },
+				priceRange: { min: 10, max: null },
+			} );
+			const decoded = decodeURIComponent( url );
+			expect( decoded ).toContain( 'filter[bool][must][0][term][category.slug]=news' );
+			expect( decoded ).toContain( 'filter[bool][must][1][range][wc.price][gte]=10' );
+		} );
 	} );
 } );

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -280,6 +280,22 @@ describe( 'store actions', () => {
 		expect( state.isFilterPopoverOpen ).toBe( false );
 	} );
 
+	it( 'syncToUrl writes priceRange so a price-filtered URL survives subsequent searches', () => {
+		// Regression: omitting priceRange from pushStateToUrl meant the
+		// first search after JS hydrated rewrote `?min_price=10` away,
+		// breaking shareable URLs and back-button behavior.
+		const replaceState = jest.spyOn( window.history, 'replaceState' ).mockImplementation();
+		state.searchQuery = 'shoes';
+		state.priceRange = { min: 10, max: 50 };
+
+		actions.syncToUrl();
+
+		expect( replaceState ).toHaveBeenCalledTimes( 1 );
+		const writtenUrl = replaceState.mock.calls[ 0 ][ 2 ];
+		expect( writtenUrl ).toContain( 'min_price=10' );
+		expect( writtenUrl ).toContain( 'max_price=50' );
+	} );
+
 	it( 'closes open popovers on Escape only', () => {
 		state.isFilterPopoverOpen = true;
 		state.isSortPopoverOpen = true;
@@ -379,11 +395,17 @@ describe( 'store callbacks', () => {
 	} );
 
 	it( 'initializes popstate handling and runs one URL-seeded search', () => {
+		// Also covers the price-only URL case: `?min_price=10` with no text
+		// query and no checkbox filters seeds isLoading=true on the PHP side,
+		// so initialize() must fire a fetch for `priceRange` alone, not just
+		// for `searchQuery || hasActiveFilters`.
 		const addEventListener = jest.spyOn( window, 'addEventListener' );
 		Object.assign( actions, originalActions );
 		jest.spyOn( actions, 'handlePopState' ).mockImplementation();
 		const search = jest.spyOn( actions, 'search' ).mockImplementation();
-		state.searchQuery = 'seeded';
+		state.searchQuery = '';
+		state.activeFilters = {};
+		state.priceRange = { min: 10, max: null };
 
 		captured.callbacks.initialize();
 		captured.callbacks.initialize();

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -127,6 +127,7 @@ describe( 'store actions', () => {
 			homeUrl: 'https://example.com',
 			activeFilters: {},
 			filterConfigs: {},
+			priceRange: null,
 			results: [ { title: 'Existing result' } ],
 			locale: 'en-US',
 			isLoading: false,

--- a/projects/packages/search/tests/js/search-blocks/url-state.test.js
+++ b/projects/packages/search/tests/js/search-blocks/url-state.test.js
@@ -186,6 +186,24 @@ describe( 'urlParamsToState: priceRange', () => {
 		expect( state.priceRange ).toBeNull();
 	} );
 
+	it( 'rejects partial-numeric values that PHP would parse but JS would not', () => {
+		// `(float)"1.5.3"` is 1.5 in PHP but `Number("1.5.3")` is NaN in JS;
+		// without the explicit numeric gate on both sides the PHP initial
+		// render and the JS hydration would disagree on the parsed value.
+		const state = urlParamsToState( new URLSearchParams( '?min_price=1.5.3' ) );
+		expect( state.priceRange ).toBeNull();
+	} );
+
+	it( 'rejects inverted bounds (min > max) so an empty ES range clause is never sent', () => {
+		const state = urlParamsToState( new URLSearchParams( '?min_price=100&max_price=10' ) );
+		expect( state.priceRange ).toBeNull();
+	} );
+
+	it( 'accepts equal bounds (min === max) as a single-value range', () => {
+		const state = urlParamsToState( new URLSearchParams( '?min_price=42&max_price=42' ) );
+		expect( state.priceRange ).toEqual( { min: 42, max: 42 } );
+	} );
+
 	it( 'never treats min_price/max_price as filter keys', () => {
 		const params = new URLSearchParams();
 		params.append( 'min_price[]', '10' );

--- a/projects/packages/search/tests/js/search-blocks/url-state.test.js
+++ b/projects/packages/search/tests/js/search-blocks/url-state.test.js
@@ -65,6 +65,36 @@ describe( 'stateToUrlParams', () => {
 		expect( params.has( 'category[]' ) ).toBe( false );
 		expect( params.getAll( 'authors[]' ) ).toEqual( [ 'jane' ] );
 	} );
+
+	it( 'serializes priceRange bounds to min_price/max_price', () => {
+		const params = stateToUrlParams( {
+			searchQuery: 'shoes',
+			sortOrder: 'relevance',
+			priceRange: { min: 10, max: 50 },
+		} );
+		expect( params.get( 'min_price' ) ).toBe( '10' );
+		expect( params.get( 'max_price' ) ).toBe( '50' );
+	} );
+
+	it( 'omits the absent bound when priceRange is half-open', () => {
+		const params = stateToUrlParams( {
+			searchQuery: '',
+			sortOrder: 'relevance',
+			priceRange: { min: 10, max: null },
+		} );
+		expect( params.get( 'min_price' ) ).toBe( '10' );
+		expect( params.has( 'max_price' ) ).toBe( false );
+	} );
+
+	it( 'omits both price params when priceRange is null', () => {
+		const params = stateToUrlParams( {
+			searchQuery: '',
+			sortOrder: 'relevance',
+			priceRange: null,
+		} );
+		expect( params.has( 'min_price' ) ).toBe( false );
+		expect( params.has( 'max_price' ) ).toBe( false );
+	} );
 } );
 
 describe( 'urlParamsToState', () => {
@@ -202,6 +232,11 @@ describe( 'urlParamsToState: priceRange', () => {
 	it( 'accepts equal bounds (min === max) as a single-value range', () => {
 		const state = urlParamsToState( new URLSearchParams( '?min_price=42&max_price=42' ) );
 		expect( state.priceRange ).toEqual( { min: 42, max: 42 } );
+	} );
+
+	it( 'accepts min_price=0 (free products are a valid lower bound)', () => {
+		const state = urlParamsToState( new URLSearchParams( '?min_price=0' ) );
+		expect( state.priceRange ).toEqual( { min: 0, max: null } );
 	} );
 
 	it( 'never treats min_price/max_price as filter keys', () => {

--- a/projects/packages/search/tests/js/search-blocks/url-state.test.js
+++ b/projects/packages/search/tests/js/search-blocks/url-state.test.js
@@ -164,3 +164,74 @@ describe( 'urlParamsToState', () => {
 		expect( state.activeFilters ).toEqual( { category: [ 'news', 'sports' ] } );
 	} );
 } );
+
+describe( 'urlParamsToState: priceRange', () => {
+	it( 'returns null priceRange when neither bound is set', () => {
+		const state = urlParamsToState( new URLSearchParams() );
+		expect( state.priceRange ).toBeNull();
+	} );
+
+	it( 'parses min and max into a numeric priceRange', () => {
+		const state = urlParamsToState( new URLSearchParams( '?min_price=10&max_price=50' ) );
+		expect( state.priceRange ).toEqual( { min: 10, max: 50 } );
+	} );
+
+	it( 'allows a half-open range when only one bound is set', () => {
+		const state = urlParamsToState( new URLSearchParams( '?min_price=10' ) );
+		expect( state.priceRange ).toEqual( { min: 10, max: null } );
+	} );
+
+	it( 'rejects garbage URL values so a bad URL cannot zero out results', () => {
+		const state = urlParamsToState( new URLSearchParams( '?min_price=abc&max_price=-5' ) );
+		expect( state.priceRange ).toBeNull();
+	} );
+
+	it( 'never treats min_price/max_price as filter keys', () => {
+		const params = new URLSearchParams();
+		params.append( 'min_price[]', '10' );
+		params.append( 'max_price[]', '50' );
+		const state = urlParamsToState( params );
+		expect( state.activeFilters ).toEqual( {} );
+	} );
+} );
+
+describe( 'urlParamsToState: scalar comma-joined URL fallback', () => {
+	it( 'parses comma-joined values for filterConfigs whose urlFormat is `scalar`', () => {
+		const state = urlParamsToState(
+			new URLSearchParams( '?filter_stock_status=instock,outofstock' ),
+			{
+				filter_stock_status: { filterType: 'wc_stock_status', urlFormat: 'scalar' },
+			}
+		);
+		expect( state.activeFilters ).toEqual( {
+			filter_stock_status: [ 'instock', 'outofstock' ],
+		} );
+	} );
+
+	it( 'ignores scalar URL form when the filterConfig does not opt in', () => {
+		const state = urlParamsToState( new URLSearchParams( '?category=news,sports' ), {
+			category: { filterType: 'taxonomy', taxonomy: 'category' },
+		} );
+		expect( state.activeFilters ).toEqual( {} );
+	} );
+
+	it( 'prefers array-form when both shapes are present for the same key', () => {
+		const params = new URLSearchParams();
+		params.append( 'filter_stock_status[]', 'onbackorder' );
+		params.append( 'filter_stock_status', 'instock,outofstock' );
+		const state = urlParamsToState( params, {
+			filter_stock_status: { filterType: 'wc_stock_status', urlFormat: 'scalar' },
+		} );
+		expect( state.activeFilters ).toEqual( { filter_stock_status: [ 'onbackorder' ] } );
+	} );
+
+	it( 'de-duplicates within the scalar value list', () => {
+		const state = urlParamsToState(
+			new URLSearchParams( '?filter_stock_status=instock,instock,outofstock' ),
+			{
+				filter_stock_status: { filterType: 'wc_stock_status', urlFormat: 'scalar' },
+			}
+		);
+		expect( state.activeFilters.filter_stock_status ).toEqual( [ 'instock', 'outofstock' ] );
+	} );
+} );


### PR DESCRIPTION
Fixes #

## Why this change

This PR is the data-plumbing step toward closing that gap for adding WooCommerce product filters. It doesn't ship any UI — what it adds are the store/api, URL-state, and PHP first-paint helpers a follow-up set of JP Search-native blocks (filter-stock-status, filter-rating, filter-price-range) will register against. Splitting the data plane out as its own PR keeps the surface here generic (a `wc_*` filterType + a `priceRange` clause) and lets the block PR focus on UX without re-litigating aggregation shapes.

**Why not bridge to WooCommerce's existing Product Filters?** [#48368](https://github.com/Automattic/jetpack/pull/48368) tried that approach — drive WC's native Product Filters blocks from JP Search aggregations on the front end. The bridge was structurally fragile to WC internals (CSS class names, `data-wp-context.filterType` strings, `state.params` shape, `actions.navigate` overridability) and silent-fail-prone — a WC release that renamed any of those would break filtering with no error surfaced. JP Search-native blocks let us own the contract end-to-end. #48368 closes alongside this PR.

## Proposed changes

Three additions across `src/search-blocks/store/api.js`, `store/url-state.js`, `store/index.js`, and `class-search-blocks.php`:

**1. Stock-status filter (`wc_stock_status`)**
- `resolveFilterFields` returns `meta._stock_status.value.raw` for both aggregation and filter clauses. The terms-aggs whitelist (`meta\..*\.value\.raw` in `class-wpcom-search-engine.php`) admits this exact path.
- A future filter block can register `{ filterType: 'wc_stock_status', urlFormat: 'scalar' }` and the helpers do the rest — terms aggregation for counts, term clause for filtering.

**2. Rating filter (`wc_rating`)**
- `resolveFilterFields` returns `meta._wc_average_rating.double`.
- `buildAggregations` special-cases this filterType to emit a **histogram** aggregation with `interval: 1, offset: 0.5`. ES `range` aggregations would be a perfect fit, but they aren't whitelisted on the WPCOM v1.3 search API (`[aggs:range] is not whitelisted`); the histogram with offset shifts bucket boundaries to half-integers, which exactly mirrors WC's `ROUND(avg_rating, 0)` star cutoffs in `FilterData::get_rating_counts`. So a histogram bucket keyed at `4.5` corresponds to star=5, `3.5` to star=4, etc.
- `buildFilterClause` emits per-star `range` clauses against `meta._wc_average_rating.double`, OR'd via `bool.should` for multi-star selections. Star=5 has no upper bound (so a 5.0 rating counts), star=1..4 use `[gte, lt)` half-open ranges.
- `WC_RATING_RANGES` is exported so a future block can render the bucket boundaries verbatim.

**3. Price range (`priceRange`)**
- `buildSearchUrl` accepts an optional `{ min, max }` and appends a `range` clause on `wc.price` to whatever filter clause `buildFilterClause` produced. Either bound may be null for a half-open range.
- `url-state.js` parses `?min_price=…&max_price=…` from the URL with sanity-checks (non-numeric or negative values yield null so a garbage URL can't drive the API into producing zero results). `min_price` / `max_price` are added to `RESERVED_PARAMS` so they're never treated as array-form filter keys.
- `class-search-blocks.php` mirrors the parsing on the PHP side via `parse_url_price_range()` so a URL like `/?s=&min_price=10` reflects the price filter on first paint, before JS hydrates. The `isLoading` flag also gates on `priceRange` so the "no results" block doesn't flash on direct URL hits.

**Scalar URL contract**
- `urlParamsToState` gains a fallback for filterConfigs whose `urlFormat` is `'scalar'` — single URL key with comma-joined values (e.g. `?filter_stock_status=instock,outofstock`). Array-form (`?key[]=v`) takes precedence when both shapes are present for the same key, so deep links never double-count.

**Why the `wc_` prefix on filterTypes**

`wc_stock_status` and `wc_rating` read indexed postmeta that WooCommerce populates (`_stock_status`, `_wc_average_rating`). At query time none of the helpers run any WC-side code — the API is generic. The `wc_` prefix marks the dependency on WC-populated meta to readers; future product filter blocks that wrap these helpers would carry the same prefix in their filterConfig.

## Files

- `src/search-blocks/store/api.js` — `resolveFilterFields` extensions, `WC_RATING_RANGES`, histogram + range-OR branches in `buildAggregations` / `buildFilterClause`, `priceRange` clause in `buildSearchUrl`.
- `src/search-blocks/store/url-state.js` — `min_price`/`max_price` parsing, scalar URL fallback, reserved-param expansion.
- `src/search-blocks/store/index.js` — `priceRange` plumbed into `fetchResults` opts and `handlePopState`.
- `src/search-blocks/class-search-blocks.php` — first-paint URL seed for `priceRange`; reserved-param mirror.
- `tests/js/search-blocks/api.test.js` — coverage for new aggregation, filter clause, and `priceRange` cases.
- `tests/js/search-blocks/url-state.test.js` — coverage for `priceRange` parsing and scalar URL fallback.
- `changelog/add-search-product-filter-helpers` — patch entry.

## Related product discussion / links

* (Internal scoping conversation; not a tracked Linear / P2 issue yet.)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This PR has no UI surface yet — coverage is via unit tests. Reviewers can:

1. From `projects/packages/search/`: `pnpm run test`. Expect 268 tests pass (49 new).
2. Read the new tests in `tests/js/search-blocks/api.test.js` and `tests/js/search-blocks/url-state.test.js` for the contract each helper now upholds.
3. Optionally exercise `buildSearchUrl` against a live index. Example for stock-status:
   ```js
   buildSearchUrl({
     siteId: <your-site>,
     activeFilters: { filter_stock_status: ['instock'] },
     filterConfigs: { filter_stock_status: { filterType: 'wc_stock_status', urlFormat: 'scalar' } },
     ...routingOpts,
   })
   ```
   The resulting URL should carry `aggregations[filter_stock_status][terms][field]=meta._stock_status.value.raw` and `filter[bool][must][0][term][meta._stock_status.value.raw]=instock`.
