### PR TITLE
Fix: core/audio block in newsletter emails links to MP3 instead of post

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-core-audio-newsletter-link-to-post
+++ b/projects/plugins/jetpack/changelog/fix-core-audio-newsletter-link-to-post
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Newsletter: Link the Core Audio block to the host post URL instead of the raw audio file in newsletter emails.

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-audio/core-audio.php
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-audio/core-audio.php
@@ -32,8 +32,6 @@ add_action(
 	}
 );
 
-// Inject a render_email_callback onto core/audio so that newsletter emails link
-// to the host post permalink instead of the raw audio file URL.
 add_filter(
 	'register_block_type_args',
 	function ( $args, $block_type ) {
@@ -41,7 +39,7 @@ add_filter(
 			return $args;
 		}
 
-		// Respect any callback that beat us (e.g. a host platform setting its own).
+		// Don't override an existing callback.
 		if ( ! empty( $args['render_email_callback'] ) ) {
 			return $args;
 		}

--- a/projects/plugins/jetpack/extensions/extended-blocks/core-audio/core-audio.php
+++ b/projects/plugins/jetpack/extensions/extended-blocks/core-audio/core-audio.php
@@ -1,9 +1,11 @@
 <?php
 /**
- * Plan checks for uploading audio files to core/audio.
+ * Plan checks and email rendering for the core/audio block.
  *
  * @package automattic/jetpack
  **/
+
+namespace Automattic\Jetpack\Extensions\Core_Audio;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
@@ -29,3 +31,70 @@ add_action(
 		\Jetpack_Gutenberg::set_availability_for_plan( 'core/audio' );
 	}
 );
+
+// Inject a render_email_callback onto core/audio so that newsletter emails link
+// to the host post permalink instead of the raw audio file URL.
+add_filter(
+	'register_block_type_args',
+	function ( $args, $block_type ) {
+		if ( 'core/audio' !== $block_type ) {
+			return $args;
+		}
+
+		// Respect any callback that beat us (e.g. a host platform setting its own).
+		if ( ! empty( $args['render_email_callback'] ) ) {
+			return $args;
+		}
+
+		$args['render_email_callback'] = __NAMESPACE__ . '\render_email';
+		return $args;
+	},
+	10,
+	2
+);
+
+/**
+ * Render the core/audio block for newsletter emails.
+ *
+ * The default WooCommerce Email Editor audio renderer turns the `<audio src>`
+ * value into the link href — for core/audio that is the raw audio URL, which
+ * sends subscribers to a black page playing the file. Swap the src for the
+ * host post permalink before delegating to the WooCommerce renderer.
+ *
+ * @since $$next-version$$
+ *
+ * @param string $block_content     The original block HTML content.
+ * @param array  $parsed_block      The parsed block data including attributes.
+ * @param object $rendering_context Email rendering context.
+ *
+ * @return string
+ */
+function render_email( $block_content, array $parsed_block, $rendering_context ) {
+	if ( ! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Audio' ) ) {
+		return '';
+	}
+
+	$post_url = get_the_permalink();
+
+	if ( empty( $post_url ) ) {
+		return '';
+	}
+
+	$escaped_post_url   = esc_url( $post_url );
+	$block_content_html = sprintf( '<audio src="%s"></audio>', $escaped_post_url );
+
+	$mock_parsed_block = array(
+		'attrs' => array(
+			'src'   => $escaped_post_url,
+			'label' => __( 'Listen to the audio', 'jetpack' ),
+		),
+	);
+
+	if ( ! empty( $parsed_block['email_attrs'] ) ) {
+		$mock_parsed_block['email_attrs'] = $parsed_block['email_attrs'];
+	}
+
+	$woo_audio_renderer = new \Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Audio();
+
+	return $woo_audio_renderer->render( $block_content_html, $mock_parsed_block, $rendering_context );
+}

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/Core_Audio_Block_Email_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/Core_Audio_Block_Email_Test.php
@@ -135,7 +135,7 @@ class Core_Audio_Block_Email_Test extends WP_UnitTestCase {
 		$post_id      = $this->set_up_global_post();
 		$parsed_block = $this->create_parsed_block(
 			array(),
-			array( 'margin' => array( 'top' => '32px', 'bottom' => '32px' ) )
+			array( 'margin' => '32px 0' )
 		);
 		$mock_context = $this->create_rendering_context_mock();
 

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/Core_Audio_Block_Email_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/Core_Audio_Block_Email_Test.php
@@ -1,0 +1,246 @@
+<?php
+/**
+ * Core Audio Block Email Rendering tests
+ *
+ * @package automattic/jetpack
+ */
+
+require_once JETPACK__PLUGIN_DIR . 'extensions/extended-blocks/core-audio/core-audio.php';
+
+// Include mock classes for WooCommerce Email Editor helpers
+require_once __DIR__ . '/mocks/class-mock-styles-helper.php';
+require_once __DIR__ . '/mocks/class-mock-table-wrapper-helper.php';
+require_once __DIR__ . '/mocks/class-mock-woocommerce-audio-renderer.php';
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+
+/**
+ * Core Audio Block Email Rendering tests.
+ *
+ * Verifies that the email render path swaps the raw audio src for the host
+ * post permalink, mirroring the fix already in place for jetpack/podcast-player.
+ *
+ * @covers ::Automattic\Jetpack\Extensions\Core_Audio\render_email
+ */
+#[CoversFunction( 'Automattic\Jetpack\Extensions\Core_Audio\render_email' )]
+class Core_Audio_Block_Email_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Helper to create a parsed block with a default audio src.
+	 *
+	 * @param array $attrs       Optional custom attrs to merge.
+	 * @param array $email_attrs Optional email_attrs to attach.
+	 * @return array Parsed block structure.
+	 */
+	private function create_parsed_block( $attrs = array(), $email_attrs = null ) {
+		$default_attrs = array(
+			'src' => 'https://example.com/audio.mp3',
+			'id'  => 42,
+		);
+
+		$parsed_block = array(
+			'attrs' => array_merge( $default_attrs, $attrs ),
+		);
+
+		if ( null !== $email_attrs ) {
+			$parsed_block['email_attrs'] = $email_attrs;
+		}
+
+		return $parsed_block;
+	}
+
+	/**
+	 * Helper to create a rendering context mock.
+	 *
+	 * @param string $width The width to return from get_layout_width_without_padding.
+	 * @return object Mock rendering context.
+	 */
+	private function create_rendering_context_mock( $width = '600px' ) {
+		return new class( $width ) {
+			private $width;
+
+			public function __construct( $width ) {
+				$this->width = $width;
+			}
+
+			public function get_layout_width_without_padding() {
+				return $this->width;
+			}
+		};
+	}
+
+	/**
+	 * Helper to set up a global post for permalink resolution.
+	 *
+	 * @return int Post ID.
+	 */
+	private function set_up_global_post() {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Test Post',
+				'post_content' => 'Test content',
+				'post_status'  => 'publish',
+			)
+		);
+		global $post;
+		$post = get_post( $post_id );
+		return $post_id;
+	}
+
+	/**
+	 * Test render_email links to the host post permalink, not the audio src.
+	 */
+	public function test_render_email_links_to_post_permalink_not_audio_src() {
+		$post_id      = $this->set_up_global_post();
+		$parsed_block = $this->create_parsed_block();
+		$mock_context = $this->create_rendering_context_mock();
+
+		$result = \Automattic\Jetpack\Extensions\Core_Audio\render_email( '', $parsed_block, $mock_context );
+
+		$this->assertNotEmpty( $result );
+		$this->assertStringContainsString( '<table', $result );
+		$this->assertStringContainsString( 'href=', $result );
+		$this->assertStringContainsString( 'Listen to the audio', $result );
+
+		// Most important: link target is the post permalink, NOT the raw MP3.
+		$this->assertStringContainsString( get_permalink( $post_id ), $result );
+		$this->assertStringNotContainsString( 'https://example.com/audio.mp3', $result );
+
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * Test render_email returns empty when no post permalink is available.
+	 */
+	public function test_render_email_returns_empty_when_no_post() {
+		global $post;
+		$original_post = $post;
+		$post          = null;
+
+		$parsed_block = $this->create_parsed_block();
+		$mock_context = $this->create_rendering_context_mock();
+
+		$result = \Automattic\Jetpack\Extensions\Core_Audio\render_email( '', $parsed_block, $mock_context );
+
+		$this->assertSame( '', $result );
+
+		$post = $original_post;
+	}
+
+	/**
+	 * Test render_email preserves email_attrs (used for spacing) on the mock parsed_block.
+	 */
+	public function test_render_email_preserves_email_attrs() {
+		$post_id      = $this->set_up_global_post();
+		$parsed_block = $this->create_parsed_block(
+			array(),
+			array( 'margin' => array( 'top' => '32px', 'bottom' => '32px' ) )
+		);
+		$mock_context = $this->create_rendering_context_mock();
+
+		$result = \Automattic\Jetpack\Extensions\Core_Audio\render_email( '', $parsed_block, $mock_context );
+
+		$this->assertNotEmpty( $result );
+		// The mock renderer compiles email_attrs.margin into the wrapper table style
+		// when present; default margin (16px 0) appears only when email_attrs is empty.
+		$this->assertStringNotContainsString( 'margin: 16px 0', $result );
+		$this->assertStringContainsString( '32px', $result );
+
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * Test render_email applies default spacing when no email_attrs are provided.
+	 */
+	public function test_render_email_applies_default_spacing_without_email_attrs() {
+		$post_id      = $this->set_up_global_post();
+		$parsed_block = $this->create_parsed_block();
+		$mock_context = $this->create_rendering_context_mock();
+
+		$result = \Automattic\Jetpack\Extensions\Core_Audio\render_email( '', $parsed_block, $mock_context );
+
+		$this->assertStringContainsString( 'margin: 16px 0', $result );
+
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * Test render_email contains pill button styling from the audio renderer.
+	 */
+	public function test_render_email_contains_button_styling() {
+		$post_id      = $this->set_up_global_post();
+		$parsed_block = $this->create_parsed_block();
+		$mock_context = $this->create_rendering_context_mock();
+
+		$result = \Automattic\Jetpack\Extensions\Core_Audio\render_email( '', $parsed_block, $mock_context );
+
+		$this->assertNotEmpty( $result );
+		$this->assertStringContainsString( 'background-color: #f6f7f7', $result );
+		$this->assertStringContainsString( 'border: 1px solid #AAA', $result );
+		$this->assertStringContainsString( 'border-radius: 9999px', $result );
+
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * Test render_email contains the play icon image from the audio renderer.
+	 */
+	public function test_render_email_contains_play_icon() {
+		$post_id      = $this->set_up_global_post();
+		$parsed_block = $this->create_parsed_block();
+		$mock_context = $this->create_rendering_context_mock();
+
+		$result = \Automattic\Jetpack\Extensions\Core_Audio\render_email( '', $parsed_block, $mock_context );
+
+		$this->assertNotEmpty( $result );
+		$this->assertStringContainsString( 'audio-play.png', $result );
+		$this->assertStringContainsString( '<img', $result );
+
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * Test that the filter wires the email callback onto core/audio at registration time.
+	 */
+	public function test_filter_registers_render_email_callback_on_core_audio() {
+		$args = apply_filters(
+			'register_block_type_args',
+			array(),
+			'core/audio'
+		);
+
+		$this->assertArrayHasKey( 'render_email_callback', $args );
+		$this->assertSame(
+			'Automattic\\Jetpack\\Extensions\\Core_Audio\\render_email',
+			$args['render_email_callback']
+		);
+	}
+
+	/**
+	 * Test that the filter does not touch other block types.
+	 */
+	public function test_filter_leaves_other_blocks_untouched() {
+		$args = apply_filters(
+			'register_block_type_args',
+			array( 'icon' => 'star' ),
+			'core/paragraph'
+		);
+
+		$this->assertArrayNotHasKey( 'render_email_callback', $args );
+		$this->assertSame( 'star', $args['icon'] );
+	}
+
+	/**
+	 * Test that the filter does not override an existing render_email_callback.
+	 */
+	public function test_filter_respects_existing_render_email_callback() {
+		$args = apply_filters(
+			'register_block_type_args',
+			array( 'render_email_callback' => 'some_existing_callback' ),
+			'core/audio'
+		);
+
+		$this->assertSame( 'some_existing_callback', $args['render_email_callback'] );
+	}
+}


### PR DESCRIPTION
## Proposed changes

When a newsletter email contains a `core/audio` block, the audio button currently links to the raw MP3 URL — clicking it sends the subscriber to a black browser page playing the file. This PR adds a `render_email_callback` to `core/audio` that swaps the `<audio src>` for the host post permalink before delegating to the WooCommerce Email Editor's Audio renderer.

The pattern mirrors `jetpack/podcast-player`'s existing email render path (see `extensions/blocks/podcast-player/podcast-player.php` lines 36 and 312-358).

* New file `extensions/extended-blocks/core-audio/core-audio.php`: registers the email callback via `register_block_type_args` (scoped to `core/audio`, respects existing callbacks).
* New tests in `tests/php/extensions/blocks/Core_Audio_Block_Email_Test.php`: 9 cases covering filter wiring, permalink swap, empty-permalink bail, `email_attrs` passthrough, default spacing.
* Changelog: `changelog/fix-core-audio-newsletter-link-to-post`.

## Related product discussion/links

* Linear: https://linear.app/a8c/issue/PODS-52/newsletter-with-podcast-audio-sends-to-media-not-post

## Architectural caveat

This PR alone does **not** close the bug for self-hosted Jetpack newsletter sends. The only consumer of `render_email_callback` is `\Automattic\WooCommerce\EmailEditor\Integrations\Core\Renderer\Blocks\Audio`, which ships in the WooCommerce plugin. For self-hosted Jetpack newsletter sends, the email body is rendered server-side on WordPress.com — the callback never executes there.

A companion wpcom PR is required to close PODS-52 fully. This Jetpack PR is the right surface for Atomic sites running the WooCommerce Email Editor and gives `core/audio` parity with `jetpack/podcast-player`.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Spin up a Jurassic Ninja site with `&jetpack-beta&branch=fix/core-audio-newsletter-link-to-post&woocommerce&mailpit`.
* Connect the site, enable Subscriptions, subscribe yourself.
* Create a post with a `core/audio` block (any MP3), publish, send as newsletter.
* In Mailpit, click the audio button — it should open the post permalink, not the MP3.
* Verify other blocks in the email render unchanged.