### PR TITLE
Wpcomsh fatal-error: route signature records to /logstash under atomic_extension_conflict

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-wpcomsh-log-logstash-routing
+++ b/projects/plugins/wpcomsh/changelog/update-wpcomsh-log-logstash-routing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+WPCOMSH_Log: add `unsafe_direct_log_logstash()` for records that need their own /logstash `feature` bucket; route fatal-error signatures through it under feature `atomic_extension_conflict` (severity `critical`).

--- a/projects/plugins/wpcomsh/class-wpcomsh-log.php
+++ b/projects/plugins/wpcomsh/class-wpcomsh-log.php
@@ -14,7 +14,9 @@
  * do_action( 'wpcomsh_log', "test" );
  * ```
  *
- * You can see logs in Kibana, log2logstash index, `feature:automated_transfer`.
+ * You can see logs in Kibana, log2logstash index, under `feature:automated_transfer`
+ * by default. Records sent via `unsafe_direct_log_logstash()` land under the
+ * caller-supplied `feature:` bucket instead.
  *
  * Note that logging must be enabled for the site for the logs to be sent,
  * which involves enabling the `at_options_logging_on` site option on the
@@ -29,6 +31,15 @@ class WPCOMSH_Log {
 	protected static $log_endpoint = 'https://public-api.wordpress.com/rest/v1.1/automated-transfers/log';
 
 	/**
+	 * Logstash endpoint URL — drained by `unsafe_direct_log_logstash()`,
+	 * which lets each record land under its own Kibana `feature` bucket
+	 * instead of the default `feature:automated_transfer` stream.
+	 *
+	 * @var string
+	 */
+	protected static $logstash_endpoint = 'https://public-api.wordpress.com/rest/v1.1/logstash';
+
+	/**
 	 * Class instance.
 	 *
 	 * @var WPCOMSH_Log
@@ -36,11 +47,19 @@ class WPCOMSH_Log {
 	private static $instance;
 
 	/**
-	 * Queue of log messages.
+	 * Queue of log messages bound for /automated-transfers/log.
 	 *
 	 * @var array
 	 */
 	private $log_queue = array();
+
+	/**
+	 * Queue of log messages bound for /logstash. Each entry carries its own
+	 * feature/severity so the receiver can bucket records distinctly.
+	 *
+	 * @var array
+	 */
+	private $logstash_queue = array();
 
 	/**
 	 * Whether it has a shutdown hook.
@@ -92,6 +111,35 @@ class WPCOMSH_Log {
 	}
 
 	/**
+	 * Direct counterpart to `unsafe_direct_log()` for records that should
+	 * land on the public `/logstash` endpoint under their own
+	 * `feature` bucket instead of the default `feature:automated_transfer`
+	 * stream that `/automated-transfers/log` writes into.
+	 *
+	 * Use this when the record needs to be alertable / dashboarded
+	 * independently from the automated-transfer telemetry firehose.
+	 * Like `unsafe_direct_log()`, this bypasses the
+	 * `at_options_logging_on` site option, so callers must ensure they
+	 * don't fire it off frequently.
+	 *
+	 * @param string $feature Logstash `feature` bucket.
+	 * @param string $message Log message.
+	 * @param array  $options {
+	 *     Optional. Per-record options.
+	 *
+	 *     @type array  $properties Structured key-value data, indexed under `properties.*` in Kibana for filtering / sorting / aggregation.
+	 *     @type string $severity   Severity tag (e.g. 'critical', 'error', 'warning', 'info').
+	 *     @type array  $extra      Unstructured context — preserved on the record but not intended for term-aggregation.
+	 * }
+	 */
+	public static function unsafe_direct_log_logstash( $feature, $message, $options = array() ) {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+		self::$instance->log_to_logstash( $feature, $message, $options );
+	}
+
+	/**
 	 * Constructor.
 	 */
 	private function __construct() {
@@ -116,10 +164,45 @@ class WPCOMSH_Log {
 			'message' => $message,
 			'extra'   => $extra,
 		);
-		if ( ! $this->has_shutdown_hook ) {
-			register_shutdown_function( array( $this, 'send_to_api' ) );
-			$this->has_shutdown_hook = true;
+		$this->ensure_shutdown_hook();
+	}
+
+	/**
+	 * Queue a record for the `/logstash` endpoint. Drained on shutdown by
+	 * `send_to_api()` alongside the `/automated-transfers/log` queue.
+	 *
+	 * @param string $feature Logstash `feature` bucket.
+	 * @param string $message Log message.
+	 * @param array  $options Optional per-record options: `properties`, `severity`, `extra`.
+	 *                        See `unsafe_direct_log_logstash()` for details.
+	 */
+	public function log_to_logstash( $feature, $message, $options = array() ) {
+		$entry = array(
+			'feature' => $feature,
+			'message' => $message,
+		);
+		if ( ! empty( $options['properties'] ) ) {
+			$entry['properties'] = (array) $options['properties'];
 		}
+		if ( ! empty( $options['severity'] ) ) {
+			$entry['severity'] = (string) $options['severity'];
+		}
+		if ( ! empty( $options['extra'] ) ) {
+			$entry['extra'] = (array) $options['extra'];
+		}
+		$this->logstash_queue[] = $entry;
+		$this->ensure_shutdown_hook();
+	}
+
+	/**
+	 * Register the shared shutdown drain on first enqueue.
+	 */
+	private function ensure_shutdown_hook() {
+		if ( $this->has_shutdown_hook ) {
+			return;
+		}
+		register_shutdown_function( array( $this, 'send_to_api' ) );
+		$this->has_shutdown_hook = true;
 	}
 
 	/**
@@ -133,6 +216,13 @@ class WPCOMSH_Log {
 			);
 
 			wp_remote_post( self::$log_endpoint, array( 'body' => array( 'error' => wp_json_encode( $payload, JSON_UNESCAPED_SLASHES ) ) ) );
+		}
+
+		foreach ( $this->logstash_queue as $entry ) {
+			$params            = $entry;
+			$params['siteurl'] = $this->siteurl;
+
+			wp_remote_post( self::$logstash_endpoint, array( 'body' => array( 'params' => wp_json_encode( $params, JSON_UNESCAPED_SLASHES ) ) ) );
 		}
 	}
 }

--- a/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-helpers.php
+++ b/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-helpers.php
@@ -113,8 +113,13 @@ function wpcomsh_fatal_identify_plugin( $error ) {
 
 /**
  * Ship the offending extension's signature to wpcomsh logstash via
- * WPCOMSH_Log::unsafe_direct_log(), alongside the decoded parts so
- * dashboards can aggregate without decoding the signature.
+ * WPCOMSH_Log::unsafe_direct_log_logstash(), alongside the decoded parts
+ * so dashboards can aggregate without decoding the signature.
+ *
+ * Routed to the `/logstash` endpoint under feature
+ * `atomic_extension_conflict` with severity `critical` so these surface
+ * in their own Kibana bucket (the default `feature:automated_transfer`
+ * stream is too noisy to alert on).
  *
  * Manual require: the fatal-error module loads from wpcomsh.php line
  * 1, before the autoloader runs. Direct requires with class_exists(
@@ -175,23 +180,30 @@ function wpcomsh_fatal_log_signature( $plugin ) {
 		return;
 	}
 
-	$extra = array( 'signature' => $signature );
+	$properties = array( 'signature' => $signature );
 
 	// Round-trip through the decoder so the logged parts always agree
 	// with the signature.
 	if ( function_exists( 'wpcom_decode_fatal_error_signature' ) ) {
 		$parts = wpcom_decode_fatal_error_signature( $signature );
 		if ( is_array( $parts ) ) {
-			$extra['kind']              = $parts['kind'];
-			$extra['slug']              = $parts['slug'];
-			$extra['extension_version'] = $parts['version'];
-			$extra['wp_version']        = $parts['wp'];
-			$extra['php_version']       = $parts['php'];
+			$properties['kind']              = $parts['kind'];
+			$properties['slug']              = $parts['slug'];
+			$properties['extension_version'] = $parts['version'];
+			$properties['wp_version']        = $parts['wp'];
+			$properties['php_version']       = $parts['php'];
 		}
 	}
 
 	try {
-		\WPCOMSH_Log::unsafe_direct_log( 'wpcomsh_fatal_signature', $extra );
+		\WPCOMSH_Log::unsafe_direct_log_logstash(
+			'atomic_extension_conflict',
+			'wpcomsh_fatal_signature',
+			array(
+				'severity'   => 'critical',
+				'properties' => $properties,
+			)
+		);
 	} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- best-effort; never escalate a logging failure into another fatal.
 		// Swallow.
 	}


### PR DESCRIPTION
Fixes #

## Proposed changes
* **Add `WPCOMSH_Log::unsafe_direct_log_logstash( $feature, $message, $options = [] )`** — a sibling to `unsafe_direct_log()` that POSTs to `https://public-api.wordpress.com/rest/v1.1/logstash` instead of `/automated-transfers/log`, so records can land under their own Kibana `feature:` bucket rather than the default `feature:automated_transfer` stream.
* `$options` accepts:
  * `properties` — structured key-value data, surfaced under `properties.*` in Kibana for filter / sort / aggregate (the slot dashboards key off).
  * `severity` — severity tag (`critical` / `error` / `warning` / `info`).
  * `extra` — unstructured context, useful to read on a single record but not meant to drive dashboards.
  * Each is omitted from the wire payload when empty so the index mapping stays clean.
* Internally backed by a separate `$logstash_queue`; both queues share the singleton instance and the existing shutdown drain (`send_to_api()` now also iterates the logstash queue and stamps `siteurl` onto each entry).
* Extracted the duplicated "register shutdown function once" block into a private `ensure_shutdown_hook()` helper so both `log()` and `log_to_logstash()` share it.
* **Switch the fatal-error signature emitter** in `wpcomsh_fatal_log_signature()` from `unsafe_direct_log()` to `unsafe_direct_log_logstash( 'atomic_extension_conflict', 'wpcomsh_fatal_signature', [ 'severity' => 'critical', 'properties' => $properties ] )`. The signature + decoded parts (`signature`, `kind`, `slug`, `extension_version`, `wp_version`, `php_version`) now live under top-level `properties.*` so Kibana can filter/sort/aggregate on them directly, instead of being nested under `extra.messages[0].extra.*` as they were behind the `/automated-transfers/log` envelope in the parent PR.
* Existing 8 callers of `unsafe_direct_log()` (woa.php, marketplace, atomic-storage, safeguard) and the `wpcomsh_log` action are untouched — no signature changes, same payload, same endpoint.

## Related product discussion/links
* Follow-up to #48369. The set of fields that gets logged (signature + decoded parts) is unchanged from that PR; only the routing/feature bucket and the field placement (top-level `properties.*` vs nested `extra.*`) change.

## Does this pull request change what data or activity we track or use?

**No new data, but the destination bucket and field layout change.** The fatal-error signature record introduced in #48369 — `signature`, `kind`, `slug`, `extension_version`, `wp_version`, `php_version`, plus the standard top-level `siteurl` — now lands in Kibana under `feature:atomic_extension_conflict` (severity `critical`) instead of being a `wpcomsh_fatal_signature` message inside the `feature:automated_transfer` stream, and those fields live at `properties.*` rather than nested under `extra.messages[0].extra.*`. Same fields, same upstream sha256-based 5-min dedup, same caller — only the index bucket / dashboard surface differs.

`unsafe_direct_log_logstash()` is also available for any future caller that needs its own feature bucket; it bypasses `at_options_logging_on` like `unsafe_direct_log()` does, so callers must keep emit rates low.

## Testing instructions

1. On an Atomic test site, trigger a fatal from a directory-based plugin or mu-plugin (e.g. drop `wp-content/mu-plugins/boom/boom.php` containing `trigger_error( 'boom', E_USER_ERROR )` on `init`).
2. In Kibana (`log2logstash` index), confirm the record now lands under **`feature:atomic_extension_conflict`** with **`severity:critical`** — not under `feature:automated_transfer`. Confirm the structured fields are indexed at top-level `properties.*` (`properties.signature`, `properties.kind`, `properties.slug`, `properties.extension_version`, `properties.wp_version`, `properties.php_version`), filterable / sortable / term-aggregatable directly without an `extra.` prefix.
3. **Verify dedup is still in place**: hit the failing site multiple times in quick succession. Confirm only one logstash record is emitted per signature within the 5-minute TTL window (the upstream `wpcomsh_fatal_sig:` cache gate is unchanged).
4. **Verify no regression for existing callers**: do something that triggers an existing `WPCOMSH_Log::unsafe_direct_log()` caller (e.g. an Atomic Storage error event, a marketplace install error, a WoA setup log line). Confirm those records still arrive in `feature:automated_transfer` as before — same payload, same `/automated-transfers/log` endpoint.
5. Trigger a fatal with no identifiable file path (e.g. an out-of-memory in core) and confirm no `wpcomsh_fatal_signature` record is emitted (pre-existing behavior; the upstream `wpcomsh_fatal_identify_plugin()` returns null and the caller skips the log).