### PR TITLE
Wpcomsh fatal-error: pass site_url as a property; drop unused /logstash siteurl

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-wpcomsh-fatal-error-site-url-property
+++ b/projects/plugins/wpcomsh/changelog/update-wpcomsh-fatal-error-site-url-property
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+WPCOMSH_Log: drop the unused top-level `siteurl` field from /logstash payloads (the receiver doesn't consume it). Fatal-error signatures now pass `site_url` as a property instead, so it lands at `properties.site_url` in Kibana alongside the other indexed fields.

--- a/projects/plugins/wpcomsh/class-wpcomsh-log.php
+++ b/projects/plugins/wpcomsh/class-wpcomsh-log.php
@@ -219,10 +219,7 @@ class WPCOMSH_Log {
 		}
 
 		foreach ( $this->logstash_queue as $entry ) {
-			$params            = $entry;
-			$params['siteurl'] = $this->siteurl;
-
-			wp_remote_post( self::$logstash_endpoint, array( 'body' => array( 'params' => wp_json_encode( $params, JSON_UNESCAPED_SLASHES ) ) ) );
+			wp_remote_post( self::$logstash_endpoint, array( 'body' => array( 'params' => wp_json_encode( $entry, JSON_UNESCAPED_SLASHES ) ) ) );
 		}
 	}
 }

--- a/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-helpers.php
+++ b/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-helpers.php
@@ -182,6 +182,15 @@ function wpcomsh_fatal_log_signature( $plugin ) {
 
 	$properties = array( 'signature' => $signature );
 
+	// `get_site_url()` runs the `site_url` / `option_siteurl` filters, so a
+	// misbehaving filter could throw — keep the lookup in its own guard so
+	// the rest of the signature still makes it to logstash.
+	try {
+		$properties['site_url'] = get_site_url();
+	} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- best-effort; omit site_url if a filter misbehaves.
+		// Fall through.
+	}
+
 	// Round-trip through the decoder so the logged parts always agree
 	// with the signature.
 	if ( function_exists( 'wpcom_decode_fatal_error_signature' ) ) {


### PR DESCRIPTION
Fixes #

## Proposed changes
* **Drop the unused top-level `siteurl` field from `/logstash` payloads.** The wpcom `/logstash` receiver doesn't consume `siteurl` (the convention on that endpoint is `blog_id` / `atomic_site_id`), so stamping it on every drained logstash payload from `WPCOMSH_Log::send_to_api()` was dead weight — the field was simply ignored on the receiver side. The drain loop now JSON-encodes the queue entry as-is.
* **Pass `site_url` as a `property` instead.** `wpcomsh_fatal_log_signature()` now adds `'site_url' => get_site_url()` to its `$properties` array, so the field surfaces at top-level `properties.site_url` in Kibana alongside `properties.signature` / `properties.kind` / `properties.slug` / `properties.extension_version` / `properties.wp_version` / `properties.php_version`. Dashboards can now filter / sort / aggregate on it directly with the same query shape as the other extension-conflict fields.
* `$this->siteurl` is still used by the `/automated-transfers/log` envelope (existing `unsafe_direct_log()` callers) at the top-level `siteurl` field there — that endpoint *does* consume it. Only the unused `/logstash` stamping was dropped.

## Related product discussion/links
* Follow-up to #48399 (which itself is a follow-up to #48369).

## Does this pull request change what data or activity we track or use?

**Yes, but in a strictly subtractive + reshuffling way.** The site URL was already being sent (and ignored by the receiver) at top-level `siteurl` on `/logstash` payloads via #48399. This PR moves it to `properties.site_url` on the fatal-error record only — same value (`get_site_url()`), same site, the only change is that it now lands in a field the receiver actually indexes. No new data is collected; no field is added that wasn't already in the wire payload before.

## Testing instructions

1. On an Atomic test site, trigger a fatal from a directory-based plugin or mu-plugin (e.g. drop `wp-content/mu-plugins/boom/boom.php` containing `trigger_error( 'boom', E_USER_ERROR )` on `init`).
2. In Kibana (`log2logstash` index, `feature:atomic_extension_conflict`), open the resulting record and confirm:
   * **`properties.site_url`** is present, holds the site's URL, and is filterable / sortable directly (e.g. you can build a "top sites by extension fatals" terms aggregation on it).
   * Top-level `siteurl` is **absent** on `/logstash` records (it'd be ignored anyway, but it's no longer occupying the wire payload).
3. Verify the other `properties.*` fields from #48399 (`signature`, `kind`, `slug`, `extension_version`, `wp_version`, `php_version`) are unchanged and still indexed at the same paths.
4. **Verify no regression for `/automated-transfers/log` callers**: do something that triggers an existing `WPCOMSH_Log::unsafe_direct_log()` caller (e.g. an Atomic Storage error, a marketplace install error, a WoA setup log line). Confirm their records still arrive in `feature:automated_transfer` with the standard top-level `siteurl` field intact (that endpoint still consumes it).
