### PR TITLE
Update Admin UI package and adapt to use `visual` prop for Jetpack logo

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4034,8 +4034,8 @@ importers:
         specifier: 5.90.8
         version: 5.90.8(react@18.3.1)
       '@wordpress/admin-ui':
-        specifier: 1.12.0
-        version: 1.12.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 2.0.0
+        version: 2.0.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/api-fetch':
         specifier: 7.44.0
         version: 7.44.0
@@ -25168,7 +25168,7 @@ snapshots:
       '@wordpress/private-apis': 1.44.0
       '@wordpress/router': 1.44.0(react@18.3.1)
       '@wordpress/url': 4.44.0
-      '@wordpress/warning': 3.44.0
+      '@wordpress/warning': 3.45.0
       '@wordpress/wordcount': 4.44.0
       change-case: 4.1.2
       client-zip: 2.5.0
@@ -25208,7 +25208,7 @@ snapshots:
       '@wordpress/private-apis': 1.44.0
       '@wordpress/router': 1.44.0(react@18.3.1)
       '@wordpress/url': 4.44.0
-      '@wordpress/warning': 3.44.0
+      '@wordpress/warning': 3.45.0
       '@wordpress/wordcount': 4.44.0
       change-case: 4.1.2
       client-zip: 2.5.0
@@ -25248,7 +25248,7 @@ snapshots:
       '@wordpress/private-apis': 1.44.0
       '@wordpress/router': 1.44.0(react@18.3.1)
       '@wordpress/url': 4.44.0
-      '@wordpress/warning': 3.44.0
+      '@wordpress/warning': 3.45.0
       '@wordpress/wordcount': 4.44.0
       change-case: 4.1.2
       client-zip: 2.5.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -558,8 +558,8 @@ importers:
         specifier: 0.16.0
         version: 0.16.0
       '@wordpress/admin-ui':
-        specifier: 1.12.0
-        version: 1.12.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 2.0.0
+        version: 2.0.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/browserslist-config':
         specifier: 6.44.0
         version: 6.44.0
@@ -2538,8 +2538,8 @@ importers:
         specifier: 1.0.1
         version: 1.0.1
       '@wordpress/admin-ui':
-        specifier: 1.12.0
-        version: 1.12.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 2.0.0
+        version: 2.0.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/base-styles':
         specifier: 6.20.0
         version: 6.20.0
@@ -4637,8 +4637,8 @@ importers:
         specifier: ^4.40.0
         version: 4.44.0
       '@wordpress/admin-ui':
-        specifier: ^1.9.0
-        version: 1.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 2.0.0
+        version: 2.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/boot':
         specifier: ^0.11.0
         version: 0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -10635,6 +10635,12 @@ packages:
     peerDependencies:
       react: ^18.0.0
 
+  '@wordpress/admin-ui@2.0.0':
+    resolution: {integrity: sha512-ZX6qExEPkdVzkv8gSsfU1NJU9EXdNbWCaPfck1Qo2bMcJWhb1n4zoITkfT+zAPqj3N/Fd2q8a8NOYxh2e/7fDw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
   '@wordpress/annotations@3.44.0':
     resolution: {integrity: sha512-0ie+k+sdIMu+HjTevXNR9Y+5rOtOkjKkV0w7VovU7wVvxRlg4dBQclnpww0QMivuhJNoFFvwym+3NjBn+N/JsA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -10665,6 +10671,10 @@ packages:
 
   '@wordpress/base-styles@6.20.0':
     resolution: {integrity: sha512-Dsug4Zxz2xOFtK6CGThKYXwCqC9Yztw2STKQzwztrX4yW+o6iDbzkxpcwdDhsaVJs0Jt9A4LmJpZPh+pUozzLA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/base-styles@7.0.0':
+    resolution: {integrity: sha512-Q0BbZzfeYbQZKHnyNT4RF8RGVugN5jStGtpRKhBYQW7ut7sS61LbbpP7jR0D0sDPYoEEC8jKZQSZwSM23B4jow==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/blob@4.44.0':
@@ -10743,6 +10753,13 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
+  '@wordpress/components@33.0.0':
+    resolution: {integrity: sha512-VeLDtfz8612bdRqgQiSMtIIEGDi4ZByj0XUvjT7E6RVLgczQyV9DTpGOPyL6PbTyAluIx6hjt9bzsaC+bM6G+w==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
   '@wordpress/compose@7.44.0':
     resolution: {integrity: sha512-NlMSR+sqEkHppjUM3irJhB0PLaWYoAgWFa7BL6xb94ciWxr4C5CIB0pSCXW8B0WNBPgS7q/xCeJGKGSfLkBgIQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -10774,6 +10791,12 @@ packages:
     peerDependencies:
       react: ^18.0.0
 
+  '@wordpress/data@10.45.0':
+    resolution: {integrity: sha512-OR/uMpcEbCh1aBkbzateXffNrL829M+N92qtuD+Gt08Mey129WIEVR9kBC2Tf02VtXs644OKZD6cz77KlxH8XA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
   '@wordpress/dataviews@14.1.0':
     resolution: {integrity: sha512-RDnCbbgNEcTJiLscqn7pN0r9toEI3Pt3L2mvLHrMjMYR8aqdouYwPldM96Sa4j+DZLf+122hQ7wBvYwyn9C4Kw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -10782,6 +10805,10 @@ packages:
 
   '@wordpress/date@5.44.0':
     resolution: {integrity: sha512-8TUnhQKqjnMyQij1dQgVtpiJ5luRueCgu9iXGUwfoYfS6YmTS8u7lACVxn+LtWwGuJNSeZS4Dghsq5DgeW6sUQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/date@5.45.0':
+    resolution: {integrity: sha512-34v3hCxn68kYzWs8bhuAt8cfMxdFX9ukKn3a3FB+tAJXpxafnPCcZoWfJHn4I8hepCbreFrf3UiGdA+id2kQ4A==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/dependency-extraction-webpack-plugin@6.44.0':
@@ -10914,6 +10941,10 @@ packages:
 
   '@wordpress/html-entities@4.44.0':
     resolution: {integrity: sha512-Vejleo4VvES7Ec4qX6p74DL8M6P15p0Law9+A8Wp4Vu8wg4TLtTNZE4Hfet1YoXwY9t6czty+KGISZpEG3Y7RA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/html-entities@4.45.0':
+    resolution: {integrity: sha512-7W95xaOv4UgMSWlEmyO7YkBsUae3QlQu3GKENVH7Pt/osbJGSPInAJ1ruO4oeUwGPygWOL7b7IzRsgTNP0M/Wg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/i18n@6.17.0':
@@ -11091,6 +11122,12 @@ packages:
     peerDependencies:
       redux: '>=4'
 
+  '@wordpress/redux-routine@5.45.0':
+    resolution: {integrity: sha512-6ShpBns4jIBFXrYFBcKA5pnFm/kjr1SqFvLj5DwLgMV61eI3Rr9LyZwIzNR2BGg067ryxu4W172Uqjke/mZjcQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      redux: '>=4'
+
   '@wordpress/reusable-blocks@5.44.0':
     resolution: {integrity: sha512-9dpae0P0sZiCjsJz9Zk+MhjHIllURzD3e72XLzjnRh0r/tmoQt1OJKUyAfDZCM1YS7SgvMkTPlpCgiB+M9c3jw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11104,8 +11141,20 @@ packages:
     peerDependencies:
       react: ^18.0.0
 
+  '@wordpress/rich-text@7.45.0':
+    resolution: {integrity: sha512-C5+JQqNzA3fiQq0hN9pQPKsjcwO/fczouHqubq3847kAUrClROqqI1GJHE34WLl1Vp+/tWQuBkIjQ/95olKteA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
   '@wordpress/route@0.10.0':
     resolution: {integrity: sha512-rNXo4cq+yPlkFzC/bQjZW8qQpaNgh1nAeUVefc4Si079C79pC0JhnXKqPOq4Iy28oJZyRjfdLdFV1FdLhHfmzA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
+  '@wordpress/route@0.11.0':
+    resolution: {integrity: sha512-3P02OKhI6yTlxHo1mLg8l8QNGsKi+e63ICP0KkaMZl5aMumfjzpZr9/fH0+uyuRdS5m2uu3BVMVa0J4QG6gMyg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18.0.0
@@ -18443,7 +18492,7 @@ snapshots:
       '@wordpress/primitives': 4.44.0(react@18.3.1)
       '@wordpress/react-i18n': 4.43.0
       '@wordpress/url': 4.44.0
-      '@wordpress/warning': 3.44.0
+      '@wordpress/warning': 3.45.0
       canvas-confetti: 1.9.4
       clsx: 2.1.1
       colord: 2.9.3
@@ -18482,7 +18531,7 @@ snapshots:
       '@wordpress/api-fetch': 7.44.0
       '@wordpress/data': 10.44.0(react@18.3.1)
       '@wordpress/data-controls': 4.44.0(react@18.3.1)
-      '@wordpress/deprecated': 4.44.0
+      '@wordpress/deprecated': 4.45.0
       '@wordpress/element': 6.44.0
       '@wordpress/i18n': 6.17.0
       '@wordpress/primitives': 4.44.0(react@18.3.1)
@@ -23564,6 +23613,40 @@ snapshots:
       - stylelint
       - supports-color
 
+  '@wordpress/admin-ui@2.0.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/components': 33.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/element': 6.45.0
+      '@wordpress/i18n': 6.18.0
+      '@wordpress/private-apis': 1.45.0
+      '@wordpress/route': 0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/ui': 0.12.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      clsx: 2.1.1
+      react: 18.3.1
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - react-dom
+      - stylelint
+      - supports-color
+
+  '@wordpress/admin-ui@2.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/components': 33.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/element': 6.45.0
+      '@wordpress/i18n': 6.18.0
+      '@wordpress/private-apis': 1.45.0
+      '@wordpress/route': 0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/ui': 0.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      clsx: 2.1.1
+      react: 18.3.1
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - react-dom
+      - stylelint
+      - supports-color
+
   '@wordpress/annotations@3.44.0(react@18.3.1)':
     dependencies:
       '@wordpress/data': 10.44.0(react@18.3.1)
@@ -23603,6 +23686,8 @@ snapshots:
       - supports-color
 
   '@wordpress/base-styles@6.20.0': {}
+
+  '@wordpress/base-styles@7.0.0': {}
 
   '@wordpress/blob@4.44.0': {}
 
@@ -24288,6 +24373,63 @@ snapshots:
       - '@emotion/is-prop-valid'
       - supports-color
 
+  '@wordpress/components@33.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@ariakit/react': 0.4.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@date-fns/utc': 2.1.1
+      '@emotion/cache': 11.14.0
+      '@emotion/css': 11.13.5
+      '@emotion/react': 11.14.0(@types/react@18.3.28)(react@18.3.1)
+      '@emotion/serialize': 1.3.3
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)
+      '@emotion/utils': 1.4.2
+      '@floating-ui/react-dom': 2.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/gradient-parser': 1.1.0
+      '@types/highlight-words-core': 1.2.1
+      '@types/react': 18.3.28
+      '@use-gesture/react': 10.3.1(react@18.3.1)
+      '@wordpress/a11y': 4.45.0
+      '@wordpress/base-styles': 7.0.0
+      '@wordpress/compose': 7.45.0(react@18.3.1)
+      '@wordpress/date': 5.45.0
+      '@wordpress/deprecated': 4.45.0
+      '@wordpress/dom': 4.45.0
+      '@wordpress/element': 6.45.0
+      '@wordpress/escape-html': 3.45.0
+      '@wordpress/hooks': 4.45.0
+      '@wordpress/html-entities': 4.45.0
+      '@wordpress/i18n': 6.18.0
+      '@wordpress/icons': 13.0.0(react@18.3.1)
+      '@wordpress/is-shallow-equal': 5.45.0
+      '@wordpress/keycodes': 4.45.0
+      '@wordpress/primitives': 4.45.0(react@18.3.1)
+      '@wordpress/private-apis': 1.45.0
+      '@wordpress/rich-text': 7.45.0(react@18.3.1)
+      '@wordpress/warning': 3.45.0
+      change-case: 4.1.2
+      clsx: 2.1.1
+      colord: 2.9.3
+      csstype: 3.2.3
+      date-fns: 3.6.0
+      deepmerge: 4.3.1
+      fast-deep-equal: 3.1.3
+      framer-motion: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      gradient-parser: 1.1.1
+      highlight-words-core: 1.2.3
+      is-plain-object: 5.0.0
+      memize: 2.1.1
+      path-to-regexp: 6.3.0
+      re-resizable: 6.11.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-colorful: 5.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-day-picker: 9.14.0(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      remove-accents: 0.5.0
+      uuid: 9.0.1(patch_hash=87a713b75995ed86c0ecd0cadfd1b9f85092ca16fdff7132ff98b62fc3cf2db0)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - supports-color
+
   '@wordpress/compose@7.44.0(react@18.3.1)':
     dependencies:
       '@types/mousetrap': 1.6.15
@@ -24439,6 +24581,24 @@ snapshots:
       rememo: 4.0.2
       use-memo-one: 1.1.3(react@18.3.1)
 
+  '@wordpress/data@10.45.0(react@18.3.1)':
+    dependencies:
+      '@wordpress/compose': 7.45.0(react@18.3.1)
+      '@wordpress/deprecated': 4.45.0
+      '@wordpress/element': 6.45.0
+      '@wordpress/is-shallow-equal': 5.45.0
+      '@wordpress/priority-queue': 3.45.0
+      '@wordpress/private-apis': 1.45.0
+      '@wordpress/redux-routine': 5.45.0(redux@5.0.1)
+      deepmerge: 4.3.1
+      equivalent-key-map: 0.2.2
+      is-plain-object: 5.0.0
+      is-promise: 4.0.0
+      react: 18.3.1
+      redux: 5.0.1
+      rememo: 4.0.2
+      use-memo-one: 1.1.3(react@18.3.1)
+
   '@wordpress/dataviews@14.1.0(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
       '@ariakit/react': 0.4.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -24542,6 +24702,12 @@ snapshots:
       - supports-color
 
   '@wordpress/date@5.44.0':
+    dependencies:
+      '@wordpress/deprecated': 4.45.0
+      moment: 2.30.1
+      moment-timezone: 0.5.48
+
+  '@wordpress/date@5.45.0':
     dependencies:
       '@wordpress/deprecated': 4.45.0
       moment: 2.30.1
@@ -25232,6 +25398,8 @@ snapshots:
 
   '@wordpress/html-entities@4.44.0': {}
 
+  '@wordpress/html-entities@4.45.0': {}
+
   '@wordpress/i18n@6.17.0':
     dependencies:
       '@tannin/sprintf': 1.3.3
@@ -25766,6 +25934,13 @@ snapshots:
       redux: 5.0.1
       rungen: 0.3.2
 
+  '@wordpress/redux-routine@5.45.0(redux@5.0.1)':
+    dependencies:
+      is-plain-object: 5.0.0
+      is-promise: 4.0.0
+      redux: 5.0.1
+      rungen: 0.3.2
+
   '@wordpress/reusable-blocks@5.44.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/base-styles': 6.20.0
@@ -25851,11 +26026,36 @@ snapshots:
       memize: 2.1.1
       react: 18.3.1
 
+  '@wordpress/rich-text@7.45.0(react@18.3.1)':
+    dependencies:
+      '@wordpress/a11y': 4.45.0
+      '@wordpress/compose': 7.45.0(react@18.3.1)
+      '@wordpress/data': 10.45.0(react@18.3.1)
+      '@wordpress/deprecated': 4.45.0
+      '@wordpress/dom': 4.45.0
+      '@wordpress/element': 6.45.0
+      '@wordpress/escape-html': 3.45.0
+      '@wordpress/i18n': 6.18.0
+      '@wordpress/keycodes': 4.45.0
+      '@wordpress/private-apis': 1.45.0
+      colord: 2.9.3
+      memize: 2.1.1
+      react: 18.3.1
+
   '@wordpress/route@0.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@tanstack/history': 1.161.5
       '@tanstack/react-router': 1.167.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/private-apis': 1.44.0
+      react: 18.3.1
+    transitivePeerDependencies:
+      - react-dom
+
+  '@wordpress/route@0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/history': 1.161.5
+      '@tanstack/react-router': 1.167.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/private-apis': 1.45.0
       react: 18.3.1
     transitivePeerDependencies:
       - react-dom
@@ -25997,6 +26197,28 @@ snapshots:
       '@wordpress/primitives': 4.44.0(react@18.3.1)
       '@wordpress/private-apis': 1.44.0
       '@wordpress/theme': 0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      clsx: 2.1.1
+      date-fns: 4.1.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tabbable: 6.4.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - stylelint
+
+  '@wordpress/ui@0.12.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@base-ui/react': 1.4.1(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@date-fns/tz': 1.4.1
+      '@wordpress/a11y': 4.45.0
+      '@wordpress/compose': 7.45.0(react@18.3.1)
+      '@wordpress/element': 6.45.0
+      '@wordpress/i18n': 6.18.0
+      '@wordpress/icons': 13.0.0(react@18.3.1)
+      '@wordpress/keycodes': 4.45.0
+      '@wordpress/primitives': 4.45.0(react@18.3.1)
+      '@wordpress/private-apis': 1.45.0
+      '@wordpress/theme': 0.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
       date-fns: 4.1.0
       react: 18.3.1

--- a/projects/js-packages/base-styles/admin-page-layout.scss
+++ b/projects/js-packages/base-styles/admin-page-layout.scss
@@ -18,7 +18,13 @@
 //   <AdminPage> root:        .jp-admin-page   (added unconditionally by the
 //                                              <AdminPage> component from
 //                                              @automattic/jetpack-components)
-//   @wordpress/admin-ui:     .admin-ui-page, .admin-ui-page__header
+//   admin-ui's <Page>:       .jp-admin-page__page   (className passed through
+//                                                    by <AdminPage>; admin-ui
+//                                                    2.0.0 forwards it onto
+//                                                    the page's outer node)
+//   admin-ui's header:       <header> element rendered by admin-ui's <Page>
+//                            inside `.jp-admin-page__page` (no class hooks —
+//                            we anchor structurally to the HTML5 element)
 //   <JetpackFooter>:         .jetpack-footer
 //   Tabs wrapper convention: .jp-admin-page-tabs   (consumer-applied div that
 //                                                   wraps `@wordpress/ui`
@@ -193,10 +199,16 @@ $jp-breakpoint-mobile: 782px;
 	}
 
 	// ── admin-ui Page internals ───────────────────────────────────────
-	// admin-ui ships `.admin-ui-page` with `height: 100%`, which fills its
+	// admin-ui ships its page node with `height: 100%`, which fills its
 	// parent's computed height. Paired with our flex chain, the element
 	// becomes a viewport-fitted flex column.
-	.admin-ui-page {
+
+	// admin-ui 2.0.0 moved internals to CSS Modules (no `.admin-ui-page*`
+	// class hooks anymore). We pass `className="jp-admin-page__page"` from
+	// <AdminPage>; admin-ui forwards it onto the page's outer node. The
+	// header is a stable `<header>` element directly inside that node, so
+	// we anchor to `> header` instead of a class.
+	.jp-admin-page__page {
 		flex: 1 1 auto;
 		min-height: 0;
 		min-width: 0;
@@ -204,7 +216,7 @@ $jp-breakpoint-mobile: 782px;
 		flex-direction: column;
 	}
 
-	.admin-ui-page__header {
+	.jp-admin-page__page > header {
 		flex-shrink: 0;              // pinned at top of the flex column.
 	}
 
@@ -213,14 +225,14 @@ $jp-breakpoint-mobile: 782px;
 	// strip's own hairline becomes the only divider between header and tab
 	// content. Same `:has()` pattern used elsewhere in this mixin to react
 	// to the page's content shape.
-	.admin-ui-page:has(.jp-admin-page-tabs) .admin-ui-page__header {
+	.jp-admin-page__page:has(.jp-admin-page-tabs) > header {
 		border-bottom: none;
 		padding-bottom: 0;
 	}
 
 	// The scrollable middle. <AdminPage> does not pass `hasPadding` to
-	// admin-ui's <Page>, so `.admin-ui-page__content` is not rendered —
-	// children drop in as direct descendants of `.admin-ui-page`. Target
+	// admin-ui's <Page>, so admin-ui's content wrapper is not rendered —
+	// children drop in as direct descendants of the page node. Target
 	// anything that isn't the header or the footer.
 
 	// `overflow: auto` (both axes) lets any child wider than the column
@@ -241,7 +253,7 @@ $jp-breakpoint-mobile: 782px;
 	// fill their bounded slot. Form-style pages keep working: their
 	// children stay content-sized (default `flex: 0 1 auto`) and any
 	// overflow still falls back to Container's `overflow: auto`.
-	.admin-ui-page > :not(.admin-ui-page__header):not(.jetpack-footer) {
+	.jp-admin-page__page > :not(header):not(.jetpack-footer) {
 		flex: 1 1 auto;
 		min-height: 0;
 		min-width: 0;
@@ -272,16 +284,16 @@ $jp-breakpoint-mobile: 782px;
 	// width of the panel area, so the hairline spans the column.
 
 	// `position: sticky` pins the strip to the top of the scrollable middle
-	// (`.admin-ui-page > :not(.admin-ui-page__header):not(.jetpack-footer)`),
+	// (`.jp-admin-page__page > :not(header):not(.jetpack-footer)`),
 	// which is the local opt-in equivalent of admin-ui's native sticky
 	// header — disabled globally by `<AdminPage>` per JETPACK-1386. Pinning
 	// the tabs strip here keeps cross-section navigation accessible while
 	// content scrolls underneath.
 
 	// Surface + hairline use the same `--wpds-*` design tokens that
-	// `@wordpress/admin-ui` applies to `.admin-ui-page__header`, so the
-	// tabs strip reads as a visual continuation of the page header and
-	// tracks any future token (theme/dark-mode) changes automatically.
+	// `@wordpress/admin-ui` applies to its page header, so the tabs strip
+	// reads as a visual continuation of the page header and tracks any
+	// future token (theme/dark-mode) changes automatically.
 	.jp-admin-page-tabs {
 		position: sticky;
 		top: 0;
@@ -290,8 +302,8 @@ $jp-breakpoint-mobile: 782px;
 		border-bottom: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral-weak);
 
 		// Align tab buttons' inline padding with the page header's
-		// horizontal padding (admin-ui ships `.admin-ui-page__header`
-		// at `padding-inline: var(--wpds-dimension-padding-2xl)`).
+		// horizontal padding (admin-ui ships its page header at
+		// `padding-inline: var(--wpds-dimension-padding-2xl)`).
 		// `@wordpress/ui` Tabs default the buttons to `padding-inline:
 		// var(--wpds-dimension-padding-lg)`; bump them to 2xl so the
 		// first tab's start edge lines up under the page title.

--- a/projects/js-packages/base-styles/changelog/jetpack-page-layout-admin-ui-2x
+++ b/projects/js-packages/base-styles/changelog/jetpack-page-layout-admin-ui-2x
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+admin-page-layout mixin: anchor selectors to the new `.jp-admin-page__page` className and the rendered `<header>` element, replacing the `.admin-ui-page*` global classes that admin-ui 2.0.0 dropped when it moved to CSS Modules. Restores the viewport-fitted scroll chain on every consumer (Boost, Protect, VideoPress, Search, Newsletter, Publicize, Backup, Jetpack network admin).

--- a/projects/js-packages/components/changelog/jetpack-page-layout-admin-ui-2x
+++ b/projects/js-packages/components/changelog/jetpack-page-layout-admin-ui-2x
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AdminPage: pass a stable `jp-admin-page__page` className to admin-ui's Page so layout overrides survive admin-ui 2.0.0's switch to CSS Modules; pin the header heading level to `<h2>` and center the new `visual` slot to keep the Jetpack logo aligned with the title.

--- a/projects/js-packages/components/changelog/update-admin-ui
+++ b/projects/js-packages/components/changelog/update-admin-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AdminPage: Update to @wordpress/admin-ui 2.0.0 and use the new `visual` prop to render the Jetpack logo alongside the page title.

--- a/projects/js-packages/components/components/admin-page/index.tsx
+++ b/projects/js-packages/components/components/admin-page/index.tsx
@@ -1,9 +1,5 @@
 import restApi from '@automattic/jetpack-api';
 import { Page } from '@wordpress/admin-ui';
-import '@wordpress/admin-ui/build-style/style.css';
-import {
-	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-} from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useEffect, useCallback } from 'react';
@@ -74,23 +70,14 @@ const AdminPage: FC< AdminPageProps > = ( {
 		}
 	}, [] );
 
-	// Compose the title with logo for the admin-ui Page header.
-	// Page's Header wraps this in an <h2> tag, so we just pass the content directly.
-	const composedTitle = title ? (
-		<HStack spacing={ 2 } justify="left">
-			{ logo || <JetpackLogo showText={ false } height={ 20 } /> }
-			<span>{ title }</span>
-		</HStack>
-	) : undefined;
-
 	// When title or breadcrumbs are provided, use admin-ui Page for the full page layout.
-	if ( showHeader && ( composedTitle || breadcrumbs ) ) {
+	if ( showHeader && ( title || breadcrumbs ) ) {
 		return (
 			<div className={ rootClassName }>
 				<Page
-					ariaLabel={ title }
+					visual={ logo || <JetpackLogo showText={ false } height={ 20 } /> }
 					breadcrumbs={ breadcrumbs }
-					title={ composedTitle }
+					title={ title }
 					subTitle={ subTitle }
 					actions={ actions }
 					showSidebarToggle={ false }

--- a/projects/js-packages/components/components/admin-page/index.tsx
+++ b/projects/js-packages/components/components/admin-page/index.tsx
@@ -75,6 +75,8 @@ const AdminPage: FC< AdminPageProps > = ( {
 		return (
 			<div className={ rootClassName }>
 				<Page
+					className="jp-admin-page__page"
+					headingLevel={ 2 }
 					visual={ logo || <JetpackLogo showText={ false } height={ 20 } /> }
 					breadcrumbs={ breadcrumbs }
 					title={ title }

--- a/projects/js-packages/components/components/admin-page/index.tsx
+++ b/projects/js-packages/components/components/admin-page/index.tsx
@@ -76,7 +76,6 @@ const AdminPage: FC< AdminPageProps > = ( {
 			<div className={ rootClassName }>
 				<Page
 					className="jp-admin-page__page"
-					headingLevel={ 2 }
 					visual={ logo || <JetpackLogo showText={ false } height={ 20 } /> }
 					breadcrumbs={ breadcrumbs }
 					title={ title }

--- a/projects/js-packages/components/components/admin-page/style.module.scss
+++ b/projects/js-packages/components/components/admin-page/style.module.scss
@@ -13,21 +13,34 @@
 	// or when showBottomBorder is false.
 	// Ideally admin-ui would expose a prop or CSS custom property for this:
 	// https://github.com/WordPress/gutenberg/issues/75428
-	&.without-bottom-border :global(.admin-ui-page__header) {
+
+	// Anchor: `.jp-admin-page__page` is the className we pass to admin-ui's
+	// <Page>; admin-ui 2.0.0 renders the header as a stable <header> element
+	// directly inside that page node — no class hooks anymore.
+	&.without-bottom-border :global(.jp-admin-page__page > header) {
 		border-bottom: none;
 	}
 
 	// Disable sticky header until we make it work better across all pages.
 	// JETPACK-1386
-	:global(.admin-ui-page__header) {
+	:global(.jp-admin-page__page > header) {
 		position: relative;
 		z-index: 1;
 	}
 
 	// Normalize admin headers: implementation of admin-ui needs to
 	// comprehend old wp-admin floating containers, such as Hello Dolly.
-	:global(.admin-ui-page) {
+	:global(.jp-admin-page__page) {
 		clear: both;
+	}
+
+	// admin-ui 2.0.0's header `visual` slot is a 24px grid box but does not
+	// center its contents. Our JetpackLogo is 20px tall, so without this it
+	// pins to the top-left of the cell and looks misaligned vs. the title.
+	// admin-ui ships the slot as `<div aria-hidden="true">` in the header.
+	// TODO: remove once upstream centers contents in `.header-visual`.
+	:global(.jp-admin-page__page > header [aria-hidden="true"]) {
+		place-items: center;
 	}
 
 	.admin-page-header {

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -69,7 +69,7 @@
 		"@automattic/number-formatters": "workspace:*",
 		"@babel/runtime": "^7",
 		"@gravatar-com/hovercards": "0.16.0",
-		"@wordpress/admin-ui": "1.12.0",
+		"@wordpress/admin-ui": "2.0.0",
 		"@wordpress/browserslist-config": "6.44.0",
 		"@wordpress/components": "32.6.0",
 		"@wordpress/compose": "7.44.0",

--- a/projects/js-packages/webpack-config/changelog/update-admin-ui
+++ b/projects/js-packages/webpack-config/changelog/update-admin-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove the @wordpress/admin-ui CSS bundle workaround from the default request map.

--- a/projects/js-packages/webpack-config/src/webpack.js
+++ b/projects/js-packages/webpack-config/src/webpack.js
@@ -115,12 +115,6 @@ const defaultRequestMap = {
 		external: 'JetpackConnection',
 		handle: 'jetpack-connection',
 	},
-	// Bundle admin-ui CSS with our assets. The JS side is already handled by the
-	// DependencyExtractionPlugin's BUNDLED_PACKAGES list, but the CSS subpath import
-	// doesn't match that exact-match check and would be incorrectly externalized.
-	'@wordpress/admin-ui/build-style/style.css': {
-		external: false,
-	},
 };
 
 const DependencyExtractionPlugin = ( { requestMap, ...options } = {} ) => {

--- a/projects/packages/forms/changelog/update-admin-ui
+++ b/projects/packages/forms/changelog/update-admin-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Dashboard: Update to @wordpress/admin-ui 2.0.0 and use the Page component's new `visual` prop for the Jetpack logo.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -50,7 +50,7 @@
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
 		"@automattic/number-formatters": "workspace:*",
 		"@automattic/request-external-access": "1.0.1",
-		"@wordpress/admin-ui": "1.12.0",
+		"@wordpress/admin-ui": "2.0.0",
 		"@wordpress/base-styles": "6.20.0",
 		"@wordpress/block-editor": "15.17.0",
 		"@wordpress/blocks": "15.17.0",

--- a/projects/packages/forms/routes/forms/package.json
+++ b/projects/packages/forms/routes/forms/package.json
@@ -7,7 +7,7 @@
 		"@automattic/jetpack-components": "workspace:*",
 		"@automattic/number-formatters": "workspace:*",
 		"@types/react": "18.3.28",
-		"@wordpress/admin-ui": "1.12.0",
+		"@wordpress/admin-ui": "2.0.0",
 		"@wordpress/api-fetch": "7.44.0",
 		"@wordpress/components": "32.6.0",
 		"@wordpress/core-data": "7.44.0",

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -569,7 +569,7 @@ function StageInner() {
 
 	const {
 		title,
-		ariaLabel,
+		visual,
 		breadcrumbs,
 		subtitle,
 		actions: headerActions,
@@ -595,9 +595,9 @@ function StageInner() {
 
 	return (
 		<Page
+			visual={ visual }
 			breadcrumbs={ breadcrumbs }
 			title={ title }
-			ariaLabel={ ariaLabel }
 			subTitle={ subtitle }
 			actions={ headerActions }
 			hasPadding={ false }

--- a/projects/packages/forms/routes/responses/package.json
+++ b/projects/packages/forms/routes/responses/package.json
@@ -9,7 +9,7 @@
 		"@automattic/number-formatters": "workspace:*",
 		"@tanstack/react-router": ">=1.120.5 <1.121.0",
 		"@types/react": "18.3.28",
-		"@wordpress/admin-ui": "1.12.0",
+		"@wordpress/admin-ui": "2.0.0",
 		"@wordpress/api-fetch": "7.44.0",
 		"@wordpress/block-editor": "15.17.0",
 		"@wordpress/blocks": "15.17.0",

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -660,6 +660,7 @@ function StageInner() {
 		badges,
 		subtitle,
 		title,
+		visual,
 		actions: headerActions,
 	} = usePageHeaderDetails( {
 		screen: 'responses',
@@ -682,6 +683,7 @@ function StageInner() {
 
 	return (
 		<Page
+			visual={ visual }
 			breadcrumbs={ breadcrumbs }
 			badges={ badges }
 			title={ title }

--- a/projects/packages/forms/routes/shared.scss
+++ b/projects/packages/forms/routes/shared.scss
@@ -1,5 +1,4 @@
 @use "sass:meta";
-@include meta.load-css("@wordpress/admin-ui/build-style/style.css");
 @include meta.load-css("@wordpress/dataviews/build-style/style.css");
 
 .jp-forms-dataviews__view-actions {

--- a/projects/packages/forms/src/dashboard/components/layout/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/layout/index.tsx
@@ -12,7 +12,6 @@ import useConfigValue from '../../../hooks/use-config-value.ts';
 import { adjustDashboardHeight } from '../../../util/adjust-dashboard-height.ts';
 import Integrations from '../../integrations/index.tsx';
 import './style.scss';
-import '@wordpress/admin-ui/build-style/style.css';
 
 const Layout = () => {
 	const location = useLocation();

--- a/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/hooks/use-page-header-details.tsx
@@ -18,7 +18,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useNavigate } from '@wordpress/route';
-import { Badge, Stack } from '@wordpress/ui';
+import { Badge } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
@@ -62,7 +62,8 @@ type UsePageHeaderDetailsProps = {
 type UsePageHeaderDetailsReturn = {
 	ariaLabel: string;
 	breadcrumbs: ReactNode;
-	title?: ReactNode;
+	title?: string;
+	visual: ReactNode;
 	badges?: ReactNode;
 	subtitle: ReactNode;
 	actions?: ReactNode;
@@ -458,12 +459,7 @@ export default function usePageHeaderDetails(
 		trackAction,
 	] );
 
-	const WrapWithJetpackLogo = ( { children }: { children: ReactNode } ) => (
-		<Stack align="center" gap="xs">
-			<JetpackLogo showText={ false } width={ 20 } />
-			{ children }
-		</Stack>
-	);
+	const visual = <JetpackLogo showText={ false } width={ 20 } />;
 
 	const ariaLabel = useMemo( () => {
 		if ( isSingleFormScreen ) {
@@ -475,10 +471,10 @@ export default function usePageHeaderDetails(
 
 	const title = useMemo( () => {
 		if ( isSingleFormScreen ) {
-			return null;
+			return undefined;
 		}
 		// "Forms" is a product name, do not translate.
-		return <WrapWithJetpackLogo>Forms</WrapWithJetpackLogo>;
+		return 'Forms';
 	}, [ isSingleFormScreen ] );
 
 	const breadcrumbs = useMemo( () => {
@@ -487,14 +483,12 @@ export default function usePageHeaderDetails(
 		}
 
 		return (
-			<WrapWithJetpackLogo>
-				<Breadcrumbs
-					items={ [
-						{ label: __( 'Forms', 'jetpack-forms' ), to: '/forms' },
-						{ label: formTitle || __( 'Form responses', 'jetpack-forms' ) },
-					] }
-				/>
-			</WrapWithJetpackLogo>
+			<Breadcrumbs
+				items={ [
+					{ label: __( 'Forms', 'jetpack-forms' ), to: '/forms' },
+					{ label: formTitle || __( 'Form responses', 'jetpack-forms' ) },
+				] }
+			/>
 		);
 	}, [ isSingleFormScreen, formTitle ] );
 
@@ -884,5 +878,5 @@ export default function usePageHeaderDetails(
 		trackExportClickResponsesList,
 	] );
 
-	return { ariaLabel, breadcrumbs, title, badges, subtitle, actions };
+	return { ariaLabel, breadcrumbs, title, visual, badges, subtitle, actions };
 }

--- a/projects/packages/forms/tests/js/dashboard/hooks/use-page-header-details.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/hooks/use-page-header-details.test.jsx
@@ -305,10 +305,10 @@ describe( 'usePageHeaderDetails', () => {
 	} );
 
 	describe( 'title and breadcrumbs', () => {
-		it( 'returns null title and breadcrumbs for single form screen', () => {
+		it( 'returns undefined title and non-null breadcrumbs for single form screen', () => {
 			const { result } = renderHook( () => usePageHeaderDetails( defaultProps ) );
 
-			expect( result.current.title ).toBeNull();
+			expect( result.current.title ).toBeUndefined();
 			expect( result.current.breadcrumbs ).not.toBeNull();
 		} );
 
@@ -317,7 +317,7 @@ describe( 'usePageHeaderDetails', () => {
 				usePageHeaderDetails( { ...defaultProps, screen: 'forms', sourceId: undefined } )
 			);
 
-			expect( result.current.title ).not.toBeNull();
+			expect( result.current.title ).toBeDefined();
 			expect( result.current.breadcrumbs ).toBeNull();
 		} );
 	} );

--- a/projects/packages/forms/tools/webpack.config.dashboard.js
+++ b/projects/packages/forms/tools/webpack.config.dashboard.js
@@ -26,15 +26,6 @@ export default {
 		alias: {
 			...jetpackWebpackConfig.resolve.alias,
 			fs: false,
-			'@wordpress/admin-ui/build-style/style.css': path.join(
-				__dirname,
-				'..',
-				'node_modules',
-				'@wordpress',
-				'admin-ui',
-				'build-style',
-				'style.css'
-			),
 		},
 	},
 	externals: {
@@ -94,7 +85,6 @@ export default {
 				requestMap: {
 					// Bundle the package with our assets until WP core exposes wp-admin-ui.
 					'@wordpress/admin-ui': { external: false },
-					'@wordpress/admin-ui/build-style/style.css': { external: false },
 					// Bundle jetpack-connection since it's used by IntegrationsModal
 					'@automattic/jetpack-connection': { external: false },
 				},

--- a/projects/packages/forms/tools/webpack.config.form-editor.js
+++ b/projects/packages/forms/tools/webpack.config.form-editor.js
@@ -25,15 +25,6 @@ export default {
 		alias: {
 			...jetpackWebpackConfig.resolve.alias,
 			fs: false,
-			'@wordpress/admin-ui/build-style/style.css': path.join(
-				__dirname,
-				'..',
-				'node_modules',
-				'@wordpress',
-				'admin-ui',
-				'build-style',
-				'style.css'
-			),
 		},
 	},
 	externals: {

--- a/projects/packages/scan/changelog/jetpack-page-layout-admin-ui-2x
+++ b/projects/packages/scan/changelog/jetpack-page-layout-admin-ui-2x
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Bump `@wordpress/admin-ui` from 1.12.0 to 2.0.0 to match the rest of the monorepo. admin-ui 2.x ships its CSS via runtime DOM injection from the JS module, so the explicit `meta.load-css("@wordpress/admin-ui/build-style/style.css")` in `routes/index/route.scss` is dropped — that path no longer exists in the package's exports.

--- a/projects/packages/scan/package.json
+++ b/projects/packages/scan/package.json
@@ -42,7 +42,7 @@
 		"@automattic/jetpack-script-data": "workspace:*",
 		"@automattic/jetpack-wp-build-polyfills": "workspace:*",
 		"@tanstack/react-query": "5.90.8",
-		"@wordpress/admin-ui": "1.12.0",
+		"@wordpress/admin-ui": "2.0.0",
 		"@wordpress/api-fetch": "7.44.0",
 		"@wordpress/base-styles": "6.20.0",
 		"@wordpress/boot": "0.11.0",

--- a/projects/packages/scan/routes/index/package.json
+++ b/projects/packages/scan/routes/index/package.json
@@ -10,7 +10,7 @@
 		"@automattic/jetpack-script-data": "workspace:*",
 		"@tanstack/react-query": "5.90.8",
 		"@types/react": "18.3.28",
-		"@wordpress/admin-ui": "1.12.0",
+		"@wordpress/admin-ui": "2.0.0",
 		"@wordpress/api-fetch": "7.44.0",
 		"@wordpress/components": "32.6.0",
 		"@wordpress/data": "10.44.0",

--- a/projects/packages/scan/routes/index/route.scss
+++ b/projects/packages/scan/routes/index/route.scss
@@ -1,3 +1,4 @@
 @use "sass:meta";
-@include meta.load-css("@wordpress/admin-ui/build-style/style.css");
+// `@wordpress/admin-ui` 2.x ships its CSS via runtime DOM injection from the
+// JS module — there's no `build-style/style.css` to import anymore.
 @include meta.load-css("@wordpress/dataviews/build-style/style.css");

--- a/projects/packages/wp-build-polyfills/changelog/update-admin-ui
+++ b/projects/packages/wp-build-polyfills/changelog/update-admin-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update @wordpress/admin-ui to 2.0.0.

--- a/projects/packages/wp-build-polyfills/package.json
+++ b/projects/packages/wp-build-polyfills/package.json
@@ -23,7 +23,7 @@
 	"devDependencies": {
 		"@automattic/jetpack-webpack-config": "workspace:*",
 		"@wordpress/a11y": "^4.40.0",
-		"@wordpress/admin-ui": "^1.9.0",
+		"@wordpress/admin-ui": "2.0.0",
 		"@wordpress/boot": "^0.11.0",
 		"@wordpress/icons": "^12.0.0",
 		"@wordpress/lazy-editor": "^1.6.1",

--- a/projects/plugins/jetpack/_inc/client/settings/style.scss
+++ b/projects/plugins/jetpack/_inc/client/settings/style.scss
@@ -1,7 +1,7 @@
 @use "../scss/mixins/breakpoints";
 @use "../scss/functions/rem";
 
-.jp-settings-admin-page .admin-ui-page {
+.jp-settings-admin-page .jp-admin-page__page {
 	background-color: #fcfcfc;
 }
 

--- a/projects/plugins/jetpack/changelog/jetpack-page-layout-admin-ui-2x
+++ b/projects/plugins/jetpack/changelog/jetpack-page-layout-admin-ui-2x
@@ -1,4 +1,4 @@
 Significance: patch
-Type: fixed
+Type: compat
 
 Settings and AI pages: replace the `.admin-ui-page` selector hook (gone in admin-ui 2.0.0) with the stable `.jp-admin-page__page` className passed through by AdminPage, restoring page-specific layout overrides.

--- a/projects/plugins/jetpack/changelog/jetpack-page-layout-admin-ui-2x
+++ b/projects/plugins/jetpack/changelog/jetpack-page-layout-admin-ui-2x
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Settings and AI pages: replace the `.admin-ui-page` selector hook (gone in admin-ui 2.0.0) with the stable `.jp-admin-page__page` className passed through by AdminPage, restoring page-specific layout overrides.

--- a/projects/plugins/search/changelog/fix-search-e2e-jetpack-logo-aria-hidden
+++ b/projects/plugins/search/changelog/fix-search-e2e-jetpack-logo-aria-hidden
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: e2e: relax `Jetpack Logo` role query for admin-ui 2.0's aria-hidden visual slot. Test-only.
+
+

--- a/projects/plugins/search/tests/e2e/specs/search-dashboard.test.ts
+++ b/projects/plugins/search/tests/e2e/specs/search-dashboard.test.ts
@@ -60,11 +60,12 @@ test.describe( 'Search Dashboard', () => {
 				// admin-ui 2.0's <Page> wraps the visual slot in an
 				// `aria-hidden="true"` decorative container, so the logo no
 				// longer surfaces in the accessibility tree by role.
-				// `includeHidden: true` keeps the role-based query while
-				// still asserting the SVG is rendered (and `toBeVisible()`
-				// continues to verify it's painted, not hidden via display
-				// or visibility).
-				page.getByRole( 'img', { name: 'Jetpack Logo', includeHidden: true } ),
+				// `includeHidden: true` keeps the role-based query, and
+				// scoping to `<header>` distinguishes the page logo from the
+				// JetpackFooter logo (which is also aria-hidden + named
+				// "Jetpack Logo"). `toBeVisible()` continues to verify it's
+				// actually painted, not hidden via display/opacity/visibility.
+				page.locator( 'header' ).getByRole( 'img', { name: 'Jetpack Logo', includeHidden: true } ),
 				'Jetpack header logo should be visible'
 			).toBeVisible();
 

--- a/projects/plugins/search/tests/e2e/specs/search-dashboard.test.ts
+++ b/projects/plugins/search/tests/e2e/specs/search-dashboard.test.ts
@@ -57,7 +57,14 @@ test.describe( 'Search Dashboard', () => {
 			await expect( instantSearchToggle, 'Instant search toggle should be visible' ).toBeVisible();
 
 			await expect(
-				page.getByRole( 'img', { name: 'Jetpack Logo' } ),
+				// admin-ui 2.0's <Page> wraps the visual slot in an
+				// `aria-hidden="true"` decorative container, so the logo no
+				// longer surfaces in the accessibility tree by role.
+				// `includeHidden: true` keeps the role-based query while
+				// still asserting the SVG is rendered (and `toBeVisible()`
+				// continues to verify it's painted, not hidden via display
+				// or visibility).
+				page.getByRole( 'img', { name: 'Jetpack Logo', includeHidden: true } ),
 				'Jetpack header logo should be visible'
 			).toBeVisible();
 


### PR DESCRIPTION
Split from https://github.com/Automattic/jetpack/pull/48404
See [v2.0.0 changelog](https://github.com/WordPress/gutenberg/blob/83f8f52b69a8e9a98290dcbb71064d939f498c86/packages/admin-ui/CHANGELOG.md#200-2026-04-29) 

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Update Admin UI package and adapt to use visual prop for Jetpack logo
* Remove bundling admin ui CSS as Page now uses CSS modules for its CSS

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Test all Jetpack dashboards and see that header/canvas/footer continue to work and look good
* Particularly test Forms dashboard as the implementation differs slightly due to full DataViews and WP Build setup.