### PR TITLE
VideoPress: fix runaway render loop on admin library pagination

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-admin-render-loop
+++ b/projects/packages/videopress/changelog/fix-videopress-admin-render-loop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Fix runaway render loop on the admin library page when paginating on WordPress 7.0.

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -18,22 +18,18 @@ import {
 	ConnectionError,
 } from '@automattic/jetpack-connection';
 import { FormFileUpload } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 /**
  * Internal dependencies
  */
-import { STORE_ID } from '../../../state';
-import uid from '../../../utils/uid';
 import { fileInputExtensions } from '../../../utils/video-extensions';
 import useAnalyticsTracks from '../../hooks/use-analytics-tracks';
+import { useDashboardVideos } from '../../hooks/use-dashboard-videos';
 import { usePermission } from '../../hooks/use-permission';
 import { usePlan } from '../../hooks/use-plan';
-import { useSearchParams } from '../../hooks/use-search-params';
 import useSelectVideoFiles from '../../hooks/use-select-video-files';
-import useVideos, { useLocalVideos } from '../../hooks/use-videos';
 import { NeedUserConnectionGlobalNotice } from '../global-notice';
 import PricingSection from '../pricing-section';
 import { ConnectSiteSettingsSection as SettingsSection } from '../site-settings-section';
@@ -41,120 +37,6 @@ import { ConnectVideoStorageMeter } from '../video-storage-meter';
 import VideoUploadArea from '../video-upload-area';
 import { LocalLibrary, VideoPressLibrary } from './libraries';
 import styles from './styles.module.scss';
-
-const useDashboardVideos = () => {
-	const { uploadVideo, uploadVideoFromLibrary, setVideosQuery } = useDispatch( STORE_ID );
-	const {
-		items,
-		uploadErrors,
-		uploading,
-		uploadedVideoCount,
-		isFetching,
-		search,
-		page,
-		itemsPerPage,
-		total,
-	} = useVideos();
-	const { items: localVideos, uploadedLocalVideoCount } = useLocalVideos();
-	const { hasVideoPressPurchase } = usePlan();
-
-	// Use a tempPage to catch changes in page from store and not URL
-	const tempPage = useRef( page );
-
-	/** Get the page number from the search parameters and set it to the state when the state is outdated */
-	const searchParams = useSearchParams();
-	const pageFromSearchParam = parseInt( searchParams.getParam( 'page', '1' ) );
-	const searchFromSearchParam = searchParams.getParam( 'q', '' );
-	const totalOfPages = Math.ceil( total / itemsPerPage );
-
-	useEffect( () => {
-		// when there are no search results, ensure that the current page number is 1
-		if ( total === 0 && pageFromSearchParam !== 1 ) {
-			// go back to page 1
-			searchParams.deleteParam( 'page' );
-			searchParams.update();
-			return;
-		}
-
-		// when there are search results, ensure that the current page is between 1 and totalOfPages, inclusive
-		if ( total > 0 && ( pageFromSearchParam < 1 || pageFromSearchParam > totalOfPages ) ) {
-			// go back to page 1
-			searchParams.deleteParam( 'page' );
-			searchParams.update();
-			return;
-		}
-
-		// react to a page param change
-		if ( page !== pageFromSearchParam ) {
-			// store changed and not url
-			// update url to match store update
-			if ( page !== tempPage.current ) {
-				tempPage.current = page;
-				searchParams.setParam( 'page', page );
-				searchParams.update();
-			} else {
-				tempPage.current = pageFromSearchParam;
-				setVideosQuery( {
-					page: pageFromSearchParam,
-				} );
-			}
-
-			return;
-		}
-
-		// react to a search param change
-		if ( search !== searchFromSearchParam ) {
-			setVideosQuery( {
-				search: searchFromSearchParam,
-			} );
-		}
-	}, [ totalOfPages, page, pageFromSearchParam, search, searchFromSearchParam, tempPage.current ] );
-
-	// Do not show uploading videos if not in the first page or searching
-	let videos = page > 1 || Boolean( search ) ? items : [ ...uploadErrors, ...uploading, ...items ];
-
-	const hasVideos =
-		uploadedVideoCount > 0 || isFetching || uploading?.length > 0 || uploadErrors?.length > 0;
-	const hasLocalVideos = uploadedLocalVideoCount > 0;
-
-	const handleFilesUpload = ( files: File[] ) => {
-		if ( hasVideoPressPurchase ) {
-			files.forEach( file => {
-				uploadVideo( file );
-			} );
-		} else if ( files.length > 0 ) {
-			uploadVideo( files[ 0 ] );
-		}
-	};
-
-	const handleLocalVideoUpload = file => {
-		uploadVideoFromLibrary( file );
-	};
-
-	// Fill with empty videos if loading
-	if ( isFetching ) {
-		const numPlaceholders = Math.max(
-			1, // at least one placeholder
-			Math.min( itemsPerPage, uploadedVideoCount - itemsPerPage * ( page - 1 ) ) // at most the number of videos in the page without query
-		);
-		// Use generated ID to work with React Key
-		videos = new Array( numPlaceholders ).fill( {} ).map( () => ( { id: uid() } ) );
-	}
-
-	return {
-		videos,
-		localVideos,
-		uploadedVideoCount,
-		uploadedLocalVideoCount,
-		hasVideos,
-		hasLocalVideos,
-		handleFilesUpload,
-		handleLocalVideoUpload,
-		loading: isFetching,
-		uploading: uploading?.length > 0 || uploadErrors?.length > 0,
-		hasVideoPressPurchase,
-	};
-};
 
 const Admin = () => {
 	const {

--- a/projects/packages/videopress/src/client/admin/hooks/use-dashboard-videos/index.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-dashboard-videos/index.ts
@@ -32,7 +32,11 @@ export const useDashboardVideos = () => {
 
 	/** Get the page number from the search parameters and set it to the state when the state is outdated */
 	const searchParams = useSearchParams();
-	const pageFromSearchParam = parseInt( searchParams.getParam( 'page', '1' ) );
+	// Fall back to 1 if the URL `?page=` is missing, empty, or non-numeric
+	// (`parseInt` would otherwise yield NaN, which silently propagates through
+	// the bounds checks below since every comparison with NaN is false).
+	const parsedPageParam = parseInt( searchParams.getParam( 'page', '1' ), 10 );
+	const pageFromSearchParam = Number.isNaN( parsedPageParam ) ? 1 : parsedPageParam;
 	const searchFromSearchParam = searchParams.getParam( 'q', '' );
 	const totalOfPages = Math.ceil( total / itemsPerPage );
 

--- a/projects/packages/videopress/src/client/admin/hooks/use-dashboard-videos/index.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-dashboard-videos/index.ts
@@ -32,9 +32,7 @@ export const useDashboardVideos = () => {
 
 	/** Get the page number from the search parameters and set it to the state when the state is outdated */
 	const searchParams = useSearchParams();
-	// Fall back to 1 if the URL `?page=` is missing, empty, or non-numeric
-	// (`parseInt` would otherwise yield NaN, which silently propagates through
-	// the bounds checks below since every comparison with NaN is false).
+	// Fall back to 1: NaN would silently slip past the `< 1`/`> totalOfPages` bounds checks below.
 	const parsedPageParam = parseInt( searchParams.getParam( 'page', '1' ), 10 );
 	const pageFromSearchParam = Number.isNaN( parsedPageParam ) ? 1 : parsedPageParam;
 	const searchFromSearchParam = searchParams.getParam( 'q', '' );
@@ -81,9 +79,7 @@ export const useDashboardVideos = () => {
 				search: searchFromSearchParam,
 			} );
 		}
-		// Note: tempPage is a ref and is intentionally excluded from the deps array.
-		// Refs do not participate in re-render scheduling, and including `.current`
-		// here previously caused this effect to re-fire and mutate the ref in a loop.
+		// `tempPage.current` is intentionally excluded — including a ref's `.current` while mutating it inside the effect re-fires it in a loop.
 	}, [ totalOfPages, page, pageFromSearchParam, search, searchFromSearchParam ] );
 
 	// Stable placeholder list while fetching: deterministic IDs keyed on the
@@ -102,10 +98,9 @@ export const useDashboardVideos = () => {
 	}, [ isFetching, itemsPerPage, uploadedVideoCount, page ] );
 
 	// Do not show uploading videos if not in the first page or searching
-	let videos = page > 1 || Boolean( search ) ? items : [ ...uploadErrors, ...uploading, ...items ];
-	if ( placeholders ) {
-		videos = placeholders;
-	}
+	const videos =
+		placeholders ??
+		( page > 1 || Boolean( search ) ? items : [ ...uploadErrors, ...uploading, ...items ] );
 
 	const hasVideos =
 		uploadedVideoCount > 0 || isFetching || uploading?.length > 0 || uploadErrors?.length > 0;

--- a/projects/packages/videopress/src/client/admin/hooks/use-dashboard-videos/index.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-dashboard-videos/index.ts
@@ -1,0 +1,137 @@
+/**
+ * External dependencies
+ */
+import { useDispatch } from '@wordpress/data';
+import { useEffect, useMemo, useRef } from 'react';
+/**
+ * Internal dependencies
+ */
+import { STORE_ID } from '../../../state';
+import { usePlan } from '../use-plan';
+import { useSearchParams } from '../use-search-params';
+import useVideos, { useLocalVideos } from '../use-videos';
+
+export const useDashboardVideos = () => {
+	const { uploadVideo, uploadVideoFromLibrary, setVideosQuery } = useDispatch( STORE_ID );
+	const {
+		items,
+		uploadErrors,
+		uploading,
+		uploadedVideoCount,
+		isFetching,
+		search,
+		page,
+		itemsPerPage,
+		total,
+	} = useVideos();
+	const { items: localVideos, uploadedLocalVideoCount } = useLocalVideos();
+	const { hasVideoPressPurchase } = usePlan();
+
+	// Use a tempPage to catch changes in page from store and not URL
+	const tempPage = useRef( page );
+
+	/** Get the page number from the search parameters and set it to the state when the state is outdated */
+	const searchParams = useSearchParams();
+	const pageFromSearchParam = parseInt( searchParams.getParam( 'page', '1' ) );
+	const searchFromSearchParam = searchParams.getParam( 'q', '' );
+	const totalOfPages = Math.ceil( total / itemsPerPage );
+
+	useEffect( () => {
+		// when there are no search results, ensure that the current page number is 1
+		if ( total === 0 && pageFromSearchParam !== 1 ) {
+			// go back to page 1
+			searchParams.deleteParam( 'page' );
+			searchParams.update();
+			return;
+		}
+
+		// when there are search results, ensure that the current page is between 1 and totalOfPages, inclusive
+		if ( total > 0 && ( pageFromSearchParam < 1 || pageFromSearchParam > totalOfPages ) ) {
+			// go back to page 1
+			searchParams.deleteParam( 'page' );
+			searchParams.update();
+			return;
+		}
+
+		// react to a page param change
+		if ( page !== pageFromSearchParam ) {
+			// store changed and not url
+			// update url to match store update
+			if ( page !== tempPage.current ) {
+				tempPage.current = page;
+				searchParams.setParam( 'page', page );
+				searchParams.update();
+			} else {
+				tempPage.current = pageFromSearchParam;
+				setVideosQuery( {
+					page: pageFromSearchParam,
+				} );
+			}
+
+			return;
+		}
+
+		// react to a search param change
+		if ( search !== searchFromSearchParam ) {
+			setVideosQuery( {
+				search: searchFromSearchParam,
+			} );
+		}
+		// Note: tempPage is a ref and is intentionally excluded from the deps array.
+		// Refs do not participate in re-render scheduling, and including `.current`
+		// here previously caused this effect to re-fire and mutate the ref in a loop.
+	}, [ totalOfPages, page, pageFromSearchParam, search, searchFromSearchParam ] );
+
+	// Stable placeholder list while fetching: deterministic IDs keyed on the
+	// inputs that determine count, so child keys don't churn every render.
+	const placeholders = useMemo( () => {
+		if ( ! isFetching ) {
+			return null;
+		}
+		const numPlaceholders = Math.max(
+			1, // at least one placeholder
+			Math.min( itemsPerPage, uploadedVideoCount - itemsPerPage * ( page - 1 ) ) // at most the number of videos in the page without query
+		);
+		return Array.from( { length: numPlaceholders }, ( _, i ) => ( {
+			id: `placeholder-${ i }`,
+		} ) );
+	}, [ isFetching, itemsPerPage, uploadedVideoCount, page ] );
+
+	// Do not show uploading videos if not in the first page or searching
+	let videos = page > 1 || Boolean( search ) ? items : [ ...uploadErrors, ...uploading, ...items ];
+	if ( placeholders ) {
+		videos = placeholders;
+	}
+
+	const hasVideos =
+		uploadedVideoCount > 0 || isFetching || uploading?.length > 0 || uploadErrors?.length > 0;
+	const hasLocalVideos = uploadedLocalVideoCount > 0;
+
+	const handleFilesUpload = ( files: File[] ) => {
+		if ( hasVideoPressPurchase ) {
+			files.forEach( file => {
+				uploadVideo( file );
+			} );
+		} else if ( files.length > 0 ) {
+			uploadVideo( files[ 0 ] );
+		}
+	};
+
+	const handleLocalVideoUpload = file => {
+		uploadVideoFromLibrary( file );
+	};
+
+	return {
+		videos,
+		localVideos,
+		uploadedVideoCount,
+		uploadedLocalVideoCount,
+		hasVideos,
+		hasLocalVideos,
+		handleFilesUpload,
+		handleLocalVideoUpload,
+		loading: isFetching,
+		uploading: uploading?.length > 0 || uploadErrors?.length > 0,
+		hasVideoPressPurchase,
+	};
+};

--- a/projects/packages/videopress/src/client/admin/hooks/use-dashboard-videos/test/index.test.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-dashboard-videos/test/index.test.ts
@@ -1,0 +1,158 @@
+import { renderHook } from '@testing-library/react';
+import { useDashboardVideos } from '../index';
+
+const mockUseVideos = jest.fn();
+const mockUseLocalVideos = jest.fn();
+const mockUseSearchParams = jest.fn();
+const mockUsePlan = jest.fn();
+const mockUseDispatch = jest.fn();
+
+jest.mock( '../../use-videos', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockUseVideos( ...args ),
+	useLocalVideos: ( ...args: unknown[] ) => mockUseLocalVideos( ...args ),
+} ) );
+
+jest.mock( '../../use-search-params', () => ( {
+	useSearchParams: ( ...args: unknown[] ) => mockUseSearchParams( ...args ),
+} ) );
+
+jest.mock( '../../use-plan', () => ( {
+	usePlan: ( ...args: unknown[] ) => mockUsePlan( ...args ),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: ( ...args: unknown[] ) => mockUseDispatch( ...args ),
+	useSelect: jest.fn(),
+	dispatch: jest.fn(),
+	combineReducers: ( reducers: unknown ) => reducers,
+	register: jest.fn(),
+	createReduxStore: jest.fn(),
+} ) );
+
+jest.mock( '../../../../state', () => ( {
+	STORE_ID: 'videopress/media',
+} ) );
+
+const baseVideosState = {
+	items: [],
+	uploading: [],
+	uploadErrors: [],
+	uploadedVideoCount: 30,
+	isFetching: false,
+	search: '',
+	page: 1,
+	itemsPerPage: 10,
+	total: 30,
+};
+
+const setupSearchParams = ( pageParam: string | null = '1', qParam: string | null = '' ) => {
+	const setParam = jest.fn();
+	const update = jest.fn();
+	const deleteParam = jest.fn();
+	const getParam = jest.fn( ( name: string, defaultValue: string | null = null ): string | null => {
+		if ( name === 'page' ) {
+			return pageParam ?? defaultValue;
+		}
+		if ( name === 'q' ) {
+			return qParam ?? defaultValue;
+		}
+		return defaultValue;
+	} );
+	mockUseSearchParams.mockReturnValue( { getParam, setParam, update, deleteParam } );
+	return { getParam, setParam, update, deleteParam };
+};
+
+beforeEach( () => {
+	jest.clearAllMocks();
+
+	mockUseLocalVideos.mockReturnValue( { items: [], uploadedLocalVideoCount: 0 } );
+	mockUsePlan.mockReturnValue( { hasVideoPressPurchase: true } );
+	mockUseDispatch.mockReturnValue( {
+		uploadVideo: jest.fn(),
+		uploadVideoFromLibrary: jest.fn(),
+		setVideosQuery: jest.fn(),
+	} );
+	mockUseVideos.mockReturnValue( baseVideosState );
+	setupSearchParams( '1', '' );
+} );
+
+describe( 'useDashboardVideos', () => {
+	it( 'effect does not oscillate when store and URL page disagree', () => {
+		const setVideosQuery = jest.fn();
+		mockUseDispatch.mockReturnValue( {
+			uploadVideo: jest.fn(),
+			uploadVideoFromLibrary: jest.fn(),
+			setVideosQuery,
+		} );
+		const { setParam, update, deleteParam } = setupSearchParams( '1', '' );
+		// store says page 2, URL says page 1 — the two-branch sync logic
+		mockUseVideos.mockReturnValue( {
+			...baseVideosState,
+			page: 2,
+		} );
+
+		const { rerender } = renderHook( () => useDashboardVideos() );
+		rerender();
+		rerender();
+		rerender();
+
+		// With Bug 1, the effect alternates between setParam('page', 2)+update()
+		// and setVideosQuery({ page: 1 }) on every rerender as tempPage.current
+		// flips. After the fix, the effect stabilises to a single dispatch.
+		const totalEffectCalls =
+			setVideosQuery.mock.calls.length +
+			setParam.mock.calls.length +
+			update.mock.calls.length +
+			deleteParam.mock.calls.length;
+		expect( totalEffectCalls ).toBeLessThanOrEqual( 2 );
+	} );
+
+	it( 'resets URL page when total is 0 and URL is past page 1', () => {
+		mockUseVideos.mockReturnValue( {
+			...baseVideosState,
+			total: 0,
+			uploadedVideoCount: 0,
+			page: 1,
+		} );
+		const { deleteParam, update, setParam } = setupSearchParams( '3', '' );
+
+		renderHook( () => useDashboardVideos() );
+
+		expect( deleteParam ).toHaveBeenCalledWith( 'page' );
+		expect( update ).toHaveBeenCalledTimes( 1 );
+		expect( setParam ).not.toHaveBeenCalled();
+	} );
+
+	it( 'pushes store page to URL after store-side page change', () => {
+		mockUseVideos.mockReturnValue( { ...baseVideosState, page: 1 } );
+		const { setParam, update } = setupSearchParams( '1', '' );
+
+		const { rerender } = renderHook( () => useDashboardVideos() );
+
+		// Simulate the store dispatching a new page (e.g. via setPage handler).
+		mockUseVideos.mockReturnValue( { ...baseVideosState, page: 3 } );
+		rerender();
+
+		expect( setParam ).toHaveBeenCalledWith( 'page', 3 );
+		expect( update ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'placeholder IDs are stable across re-renders while fetching', () => {
+		mockUseVideos.mockReturnValue( {
+			...baseVideosState,
+			isFetching: true,
+			page: 2,
+		} );
+		setupSearchParams( '2', '' );
+
+		const { result, rerender } = renderHook( () => useDashboardVideos() );
+		const firstIds = result.current.videos.map( v => v.id );
+
+		rerender();
+		const secondIds = result.current.videos.map( v => v.id );
+
+		expect( firstIds.length ).toBeGreaterThan( 0 );
+		expect( secondIds ).toEqual( firstIds );
+	} );
+} );

--- a/projects/packages/videopress/src/client/admin/hooks/use-dashboard-videos/test/index.test.ts
+++ b/projects/packages/videopress/src/client/admin/hooks/use-dashboard-videos/test/index.test.ts
@@ -138,6 +138,26 @@ describe( 'useDashboardVideos', () => {
 		expect( update ).toHaveBeenCalledTimes( 1 );
 	} );
 
+	it( 'treats a non-numeric URL ?page= as page 1 instead of dispatching NaN', () => {
+		const setVideosQuery = jest.fn();
+		mockUseDispatch.mockReturnValue( {
+			uploadVideo: jest.fn(),
+			uploadVideoFromLibrary: jest.fn(),
+			setVideosQuery,
+		} );
+		mockUseVideos.mockReturnValue( { ...baseVideosState, page: 1 } );
+		const { deleteParam, update } = setupSearchParams( 'foo', '' );
+
+		renderHook( () => useDashboardVideos() );
+
+		expect( setVideosQuery ).not.toHaveBeenCalledWith( expect.objectContaining( { page: NaN } ) );
+		// total > 0 and the parsed page falls back to 1, which is in range, so
+		// no URL reset and no store dispatch happen for this benign input.
+		expect( deleteParam ).not.toHaveBeenCalled();
+		expect( update ).not.toHaveBeenCalled();
+		expect( setVideosQuery ).not.toHaveBeenCalled();
+	} );
+
 	it( 'placeholder IDs are stable across re-renders while fetching', () => {
 		mockUseVideos.mockReturnValue( {
 			...baseVideosState,


### PR DESCRIPTION
Fixes #48408

## Proposed changes

* Extract `useDashboardVideos` from `admin-page/index.tsx` to `projects/packages/videopress/src/client/admin/hooks/use-dashboard-videos/`, matching the project's convention for hooks and decoupling it from the heavy admin-page UI imports so it can be unit-tested in isolation.
* Remove `tempPage.current` from the URL/store sync `useEffect`'s dependency array. Refs do not participate in re-render scheduling; including `.current` while the same effect *mutates* it caused the effect to alternate between its two branches indefinitely on every re-render.
* Replace the per-render `Array(n).fill({}).map(() => ({ id: uid() }))` placeholder with a `useMemo` keyed on the inputs that determine count, using deterministic `placeholder-{i}` IDs so children's `useEffect`/`useMemo` deps stop seeing fresh references every render.
* Add 4 unit tests covering both regressions and pinning down the surviving URL/store sync behaviour (URL reset on `total === 0`, URL push after store-side page change).

Together these stop the ~12k commits/sec render storm reported on WP 7.0-Beta admin pagination, which was starving the REST `.then()` handler of microtask slots and leaving the library stuck on skeleton placeholders.

## Related product discussion/links

* https://github.com/Automattic/jetpack/issues/48408

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Spin up an Atomic site (or other WP install) running **WP 7.0-Beta** with the VideoPress plugin and a library of ~200+ videos.
2. Navigate to `/wp-admin/admin.php?page=jetpack-videopress` and wait for page 1 thumbnails to load fully.
3. Open DevTools → Console and paste the commit-counter snippet from issue #48408 (the `__REACT_DEVTOOLS_GLOBAL_HOOK__.onCommitFiberRoot` version, or the MutationObserver fallback).
4. Click a pagination control other than page 1 (page 5 was the canonical repro).
5. **Expected:** skeleton grid resolves to thumbnails within ~1 s, and the commit counter shows fewer than ~30 commits per pagination click — not the previously-observed 12,000+/sec sustained for minutes.
6. Verify direct-URL pagination (e.g. `?paged=5`) still works.
7. Smoke test on WP 6.9.x to confirm no regression on the previously-working path.
8. Run unit tests: `pnpm jest --testPathPatterns='use-dashboard-videos'` from `projects/packages/videopress/` — 4 tests should pass.
