### PR TITLE
My Jetpack: render interstitials with unified header (breadcrumbs-like back-link + license-key action)

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/add-license-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/add-license-screen/index.jsx
@@ -3,6 +3,7 @@
  */
 import { AdminPage, Container, Col } from '@automattic/jetpack-components';
 import { ActivationScreen } from '@automattic/jetpack-licensing';
+import { __ } from '@wordpress/i18n';
 import { useCallback, useState, useMemo } from 'react';
 /*
  * Internal dependencies
@@ -53,11 +54,17 @@ export default function AddLicenseScreen() {
 	const { siteSuffix = '', adminUrl = '' } = getMyJetpackWindowInitialState();
 
 	return (
-		<AdminPage showHeader={ false } showBackground={ false }>
+		<AdminPage
+			showBackground={ false }
+			breadcrumbs={
+				<GoBackLink
+					onClick={ onClickGoBack }
+					to={ hasActivatedLicense ? '/products?reload=true' : '/products' }
+					label={ __( 'My Jetpack', 'jetpack-my-jetpack' ) }
+				/>
+			}
+		>
 			<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
-				<Col>
-					<GoBackLink onClick={ onClickGoBack } reload={ hasActivatedLicense } />
-				</Col>
 				<Col>
 					<ActivationScreen
 						currentRecommendationsStep={ null }

--- a/projects/packages/my-jetpack/_inc/components/go-back-link/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/go-back-link/index.tsx
@@ -2,29 +2,40 @@ import { __ } from '@wordpress/i18n';
 import { Icon, arrowLeft } from '@wordpress/icons';
 import { Link } from 'react-router';
 import styles from './styles.module.scss';
-import type { MouseEvent } from 'react';
+import type { MouseEvent, ReactNode } from 'react';
 
 /**
  * Go Back Link component.
  *
- * @param {object}   props         - Component props.
- * @param {Function} props.onClick - Optional click handler for the link.
- * @param {boolean}  props.reload  - Whether the link should trigger a reload when clicked.
+ * Used as the page back-link for product interstitials, also rendered into
+ * AdminPage's `breadcrumbs` slot to act as the page title.
+ *
+ * @param props         - Component props.
+ * @param props.onClick - Optional click handler for the link.
+ * @param props.reload  - Whether the link should trigger a reload when clicked.
+ * @param props.to      - Optional explicit destination route. Defaults to `/`
+ *                      (or `/?reload=true` when `reload` is set). When set,
+ *                      takes precedence over `reload`.
+ * @param props.label   - Optional label text. Defaults to "Go back".
  * @return The rendered component.
  */
 function GoBackLink( {
 	onClick,
 	reload,
+	to,
+	label,
 }: {
 	onClick?: ( event: MouseEvent ) => void;
-	reload: boolean;
+	reload?: boolean;
+	to?: string;
+	label?: ReactNode;
 } ) {
-	const to = reload ? '/?reload=true' : '/';
+	const destination = to ?? ( reload ? '/?reload=true' : '/' );
 
 	return (
-		<Link to={ to } className={ styles.link } onClick={ onClick }>
+		<Link to={ destination } className={ styles.link } onClick={ onClick }>
 			<Icon icon={ arrowLeft } className={ styles.icon } />
-			{ __( 'Go back', 'jetpack-my-jetpack' ) }
+			{ label ?? __( 'Go back', 'jetpack-my-jetpack' ) }
 		</Link>
 	);
 }

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/more-requests.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/more-requests.jsx
@@ -42,11 +42,17 @@ export function JetpackAIInterstitialMoreRequests( { onClickGoBack = () => {} } 
 	}, [ recordEvent ] );
 
 	return (
-		<AdminPage showHeader={ false } showBackground={ false }>
+		<AdminPage
+			showBackground={ false }
+			breadcrumbs={
+				<GoBackLink
+					onClick={ onClickGoBack }
+					to="/products"
+					label={ __( 'My Jetpack', 'jetpack-my-jetpack' ) }
+				/>
+			}
+		>
 			<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
-				<Col className={ styles[ 'product-interstitial__header' ] }>
-					<GoBackLink onClick={ onClickGoBack } reload={ false } />
-				</Col>
 				<Col>
 					<Container
 						className={ styles.container }
@@ -63,7 +69,7 @@ export function JetpackAIInterstitialMoreRequests( { onClickGoBack = () => {} } 
 										<Button href={ contactHref } onClick={ trackClickHandler }>
 											{ __( 'Contact Us', 'jetpack-my-jetpack' ) }
 										</Button>
-										<Link to={ '/' } onClick={ onClickGoBack }>
+										<Link to={ '/products' } onClick={ onClickGoBack }>
 											<Button variant="secondary">{ __( 'Back', 'jetpack-my-jetpack' ) }</Button>
 										</Link>
 									</div>

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/product-page.jsx
@@ -37,7 +37,7 @@ const debug = debugFactory( 'my-jetpack:product-interstitial:jetpack-ai-product-
  * @return {object} React component for the product page
  */
 export default function () {
-	const { onClickGoBack } = useGoBack( 'jetpack-ai' );
+	const { onClickGoBack } = useGoBack( { slug: 'jetpack-ai', fallback: '/products' } );
 	const { detail, isLoading } = useProduct( 'jetpack-ai' );
 	const { description, aiAssistantFeature } = detail;
 	const [ showNotice, setShowNotice ] = useState( false );
@@ -200,12 +200,18 @@ export default function () {
 	}, [ showRenewalNotice, showUpgradeNotice ] );
 
 	return (
-		<AdminPage showHeader={ false } showBackground={ true }>
+		<AdminPage
+			showBackground={ true }
+			breadcrumbs={
+				<GoBackLink
+					onClick={ onClickGoBack }
+					to="/products"
+					label={ __( 'My Jetpack', 'jetpack-my-jetpack' ) }
+				/>
+			}
+		>
 			<Container fluid horizontalSpacing={ 3 } horizontalGap={ 2 }>
 				<Col className={ clsx( styles[ 'product-interstitial__section' ] ) }>
-					<div className={ styles[ 'product-interstitial__section-wrapper-wide' ] }>
-						<GoBackLink onClick={ onClickGoBack } />
-					</div>
 					<div
 						className={ clsx(
 							styles[ 'product-interstitial__section-wrapper-wide' ],

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/pricing-interstitial.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/pricing-interstitial.jsx
@@ -47,7 +47,7 @@ export default function PricingInterstitial( { slug } ) {
 	const { detail, isLoading: isProductLoading } = useProduct( slug );
 	const { detail: bundleDetail, isLoading: isBundleLoading } = useProduct( config?.bundle );
 	const { recordEvent } = useAnalytics();
-	const { onClickGoBack } = useGoBack( { slug } );
+	const { onClickGoBack } = useGoBack( { slug, fallback: '/products' } );
 	const { activate, isPending: isActivating } = useActivatePlugins( slug );
 	const myJetpackCheckoutUri = getMyJetpackUrl();
 	const { siteIsRegistering, handleRegisterSite } = useMyJetpackConnection( {
@@ -380,14 +380,22 @@ export default function PricingInterstitial( { slug } ) {
 	const currencyCode = productPricing?.currencyCode || bundlePricing?.currencyCode || 'USD';
 
 	return (
-		<AdminPage showHeader={ false } showBackground={ false }>
+		<AdminPage
+			showBackground={ false }
+			breadcrumbs={
+				<GoBackLink
+					onClick={ handleGoBack }
+					to="/products"
+					label={ __( 'My Jetpack', 'jetpack-my-jetpack' ) }
+				/>
+			}
+		>
 			<Container
 				className={ styles.interstitialContainer }
 				horizontalSpacing={ 3 }
 				horizontalGap={ 2 }
 			>
 				<Col className={ styles[ 'product-interstitial__header' ] }>
-					<GoBackLink onClick={ handleGoBack } />
 					<Text variant="body-small">
 						{ createInterpolateElement(
 							__(

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/pricing-interstitial.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/pricing-interstitial.jsx
@@ -11,12 +11,10 @@ import {
 	PricingTableHeader,
 	PricingTableItem,
 	ProductPrice,
-	Text,
 } from '@automattic/jetpack-components';
 import { useProductCheckoutWorkflow } from '@automattic/jetpack-connection';
 import { getScriptData, getMyJetpackUrl } from '@automattic/jetpack-script-data';
-import { Spinner } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
+import { Button as WPButton, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 /**
@@ -389,32 +387,22 @@ export default function PricingInterstitial( { slug } ) {
 					label={ __( 'My Jetpack', 'jetpack-my-jetpack' ) }
 				/>
 			}
+			actions={
+				<WPButton
+					size="compact"
+					variant="secondary"
+					href={ getMyJetpackUrl( '#/add-license' ) }
+					onClick={ handleLicenseActivationClick }
+				>
+					{ __( 'Use license key', 'jetpack-my-jetpack' ) }
+				</WPButton>
+			}
 		>
 			<Container
 				className={ styles.interstitialContainer }
 				horizontalSpacing={ 3 }
 				horizontalGap={ 2 }
 			>
-				<Col className={ styles[ 'product-interstitial__header' ] }>
-					<Text variant="body-small">
-						{ createInterpolateElement(
-							__(
-								'Already have an existing plan or license key? <a>Click here to get started</a>.',
-								'jetpack-my-jetpack'
-							),
-							{
-								a: (
-									<Button
-										className={ styles[ 'product-interstitial__license-activation-link' ] }
-										href={ getMyJetpackUrl( '#/add-license' ) }
-										variant="link"
-										onClick={ handleLicenseActivationClick }
-									/>
-								),
-							}
-						) }
-					</Text>
-				</Col>
 				<Col>
 					<PricingTable
 						title={ config.title }

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/product-interstitial.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/product-interstitial.jsx
@@ -80,7 +80,7 @@ export default function ProductInterstitial( {
 
 	const { isUpgradableByBundle, pricingForUi, isTieredPricing } = detail;
 	const { recordEvent } = useAnalytics();
-	const { onClickGoBack } = useGoBack( { slug } );
+	const { onClickGoBack } = useGoBack( { slug, fallback: '/products' } );
 	const myJetpackCheckoutUri = getMyJetpackUrl();
 	const { siteIsRegistering, handleRegisterSite } = useMyJetpackConnection( {
 		skipUserConnection: true,
@@ -201,10 +201,18 @@ export default function ProductInterstitial( {
 	);
 
 	return (
-		<AdminPage showHeader={ false } showBackground={ false }>
+		<AdminPage
+			showBackground={ false }
+			breadcrumbs={
+				<GoBackLink
+					onClick={ onClickGoBack }
+					to="/products"
+					label={ __( 'My Jetpack', 'jetpack-my-jetpack' ) }
+				/>
+			}
+		>
 			<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
 				<Col className={ styles[ 'product-interstitial__header' ] }>
-					<GoBackLink onClick={ onClickGoBack } />
 					{ existingLicenseKeyUrl && (
 						<Text variant="body-small">
 							{ createInterpolateElement(

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/product-interstitial.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/product-interstitial.jsx
@@ -1,16 +1,9 @@
 /**
  * External dependencies
  */
-import {
-	AdminPage,
-	Button,
-	Col,
-	Container,
-	Text,
-	TermsOfService,
-} from '@automattic/jetpack-components';
+import { AdminPage, Col, Container, TermsOfService } from '@automattic/jetpack-components';
 import { getMyJetpackUrl } from '@automattic/jetpack-script-data';
-import { createInterpolateElement } from '@wordpress/element';
+import { Button as WPButton } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useCallback, useEffect } from 'react';
@@ -210,29 +203,15 @@ export default function ProductInterstitial( {
 					label={ __( 'My Jetpack', 'jetpack-my-jetpack' ) }
 				/>
 			}
+			actions={
+				existingLicenseKeyUrl ? (
+					<WPButton size="compact" variant="secondary" href={ existingLicenseKeyUrl }>
+						{ __( 'Use license key', 'jetpack-my-jetpack' ) }
+					</WPButton>
+				) : null
+			}
 		>
 			<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
-				<Col className={ styles[ 'product-interstitial__header' ] }>
-					{ existingLicenseKeyUrl && (
-						<Text variant="body-small">
-							{ createInterpolateElement(
-								__(
-									'Already have an existing plan or license key? <a>Click here to get started</a>.',
-									'jetpack-my-jetpack'
-								),
-								{
-									a: (
-										<Button
-											className={ styles[ 'product-interstitial__license-activation-link' ] }
-											href={ existingLicenseKeyUrl }
-											variant="link"
-										/>
-									),
-								}
-							) }
-						</Text>
-					) }
-				</Col>
 				<Col>
 					{ isTieredPricing ? (
 						<ProductDetailTable

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/protect/product-page.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/protect/product-page.tsx
@@ -39,7 +39,7 @@ import styles from './style.module.scss';
  * @return {object} React component for the product page
  */
 export default function ProtectProductPage() {
-	const { onClickGoBack } = useGoBack( { slug: 'protect' } );
+	const { onClickGoBack } = useGoBack( { slug: 'protect', fallback: '/products' } );
 	const { detail, isLoading: isLoadingProduct } = useProduct( 'protect' );
 	const { isSiteConnected } = useMyJetpackConnection();
 	const { recordEvent } = useAnalytics();
@@ -87,13 +87,19 @@ export default function ProtectProductPage() {
 	const securityFeaturesUrl = getRedirectUrl( 'jetpack-security' );
 
 	return (
-		<AdminPage showHeader={ false } showBackground={ true }>
+		<AdminPage
+			showBackground={ true }
+			breadcrumbs={
+				<GoBackLink
+					onClick={ onClickGoBack }
+					to="/products"
+					label={ __( 'My Jetpack', 'jetpack-my-jetpack' ) }
+				/>
+			}
+		>
 			<Container fluid horizontalSpacing={ 3 } horizontalGap={ 2 }>
 				{ /* Header Section */ }
 				<Col className={ clsx( styles[ 'product-interstitial__section' ] ) }>
-					<div className={ styles[ 'product-interstitial__section-wrapper-wide' ] }>
-						<GoBackLink onClick={ onClickGoBack } reload={ false } />
-					</div>
 					<div
 						className={ clsx(
 							styles[ 'product-interstitial__section-wrapper-wide' ],

--- a/projects/packages/my-jetpack/_inc/hooks/use-go-back/index.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-go-back/index.ts
@@ -7,10 +7,19 @@ import type { MouseEvent } from 'react';
 /**
  * Custom React hook to handle back link click with analytics.
  *
- * @param {{ slug: string }} options - Options.
+ * @param options          - Options.
+ * @param options.slug     - Product slug, recorded with the analytics event.
+ * @param options.fallback - Fallback route to navigate to when no allowed referrer
+ *                         is in history. Defaults to the My Jetpack home (`/`).
  * @return Object with back link click handler with analytics.
  */
-export function useGoBack( { slug }: { slug: string } ) {
+export function useGoBack( {
+	slug,
+	fallback = MyJetpackRoutes.Home,
+}: {
+	slug: string;
+	fallback?: string;
+} ) {
 	const { recordEvent } = useAnalytics();
 	const navigate = useNavigate();
 
@@ -40,10 +49,10 @@ export function useGoBack( { slug }: { slug: string } ) {
 			if ( isFromAllowedSite && window.history.length > 1 ) {
 				navigate( -1 );
 			} else {
-				navigate( MyJetpackRoutes.Home );
+				navigate( fallback );
 			}
 		},
-		[ slug, recordEvent, navigate ]
+		[ slug, recordEvent, navigate, fallback ]
 	);
 
 	return { onClickGoBack };

--- a/projects/packages/my-jetpack/changelog/feat-interstitial-unified-header
+++ b/projects/packages/my-jetpack/changelog/feat-interstitial-unified-header
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: render product-interstitial back-link in the unified header's breadcrumbs slot, and move the "Use license key" CTA into the header actions slot. No new dependency or behavior change.


### PR DESCRIPTION
Tracks the My Jetpack header-unification follow-ups noted while reviewing #48378.

## Proposed changes

Brings the **My Jetpack interstitial / product-detail / license-add screens** into the same unified-header treatment used everywhere else in the dashboard (and matches the pattern already shipped by VideoPress's edit-video-details and jetpack-backup).

Before this PR each interstitial passed `showHeader={ false }` to AdminPage and rendered its own `<GoBackLink>` at the top of the body, leaving these pages without a visible page title and bypassing the unified `@wordpress/admin-ui Page` chrome (mixin, breadcrumbs, header actions slot). The "Already have an existing plan or license key? Click here to get started" sentence sat in a flex row alongside the back-link.

This PR:

- **Renders the back-link inside `AdminPage`'s `breadcrumbs` slot** (router-agnostic — just a `<Link>` from `react-router`, no `@wordpress/admin-ui Breadcrumbs` to avoid pulling in `@wordpress/route` and a router refactor). The breadcrumbs slot doubles as the page title, matching the deliberate design call to keep these screens title-less aside from the back affordance.
- **Moves the license-key CTA into `AdminPage`'s `actions` slot** as a single compact secondary "Use license key" button — same pattern as `packages/backup/src/js/components/Admin/index.js`. No more `createInterpolateElement` / `<a>`-in-translation-string boilerplate.
- **Targets `#/products`** for the back-link (the My Jetpack Products tab) instead of the previous `/`. The `reload=true` semantics on `add-license-screen` are preserved.
- **Drive-by**: fixes a pre-existing positional-argument bug in `useGoBack( 'jetpack-ai' )` (the hook destructures `{ slug }`).

### Routes affected (all hash routes inside the My Jetpack admin page)

`/add-akismet`, `/add-backup`, `/add-boost`, `/add-crm`, `/add-jetpack-ai`, `/add-extras`, `/add-protect`, `/add-scan`, `/add-social`, `/add-search`, `/add-videopress`, `/add-stats`, `/add-security`, `/add-growth`, `/add-complete`, `/add-license`, `/jetpack-ai`, `/protect-details`.

## Out of scope

- **`connection-screen/index.tsx`** — uses `<CloseLink>` (X icon dismissal), a different navigation pattern; needs a separate UX call.
- **`packages/backup/src/js/components/Admin/index.js`** — also uses `showHeader={ false }`, but it's a different package and the change is independent.
- **The `jetpack-admin-page-layout` mixin not being applied to MJ.** With the unified header path now in use, the mixin's wp-admin chrome reset (notably `#wpfooter`) is the right next step. Tracked as a separate change so we can sanity-check the main MJ overview page in isolation.

## Related product discussion/links

- Companion to the larger [Jetpack UI Modernization](https://github.com/Automattic/jetpack/issues/48160) tracking issue.

## Does this pull request change what data or activity we track or use?

No. The existing `jetpack_myjetpack_product_interstitial_back_link_click` and `jetpack_myjetpack_interstitial_license_link_click` events are preserved.

## Visual diff

| Screen | Before (desktop · mobile) | After (desktop · mobile) |
|---|---|---|
| `/add-backup` (PricingInterstitial — common path) | <a href="https://github.com/user-attachments/assets/349e9f43-e72b-47e6-b853-0d302c5833f1"><img width="320" alt="add-backup-desktop" src="https://github.com/user-attachments/assets/349e9f43-e72b-47e6-b853-0d302c5833f1"></a> <a href="https://github.com/user-attachments/assets/0addf62e-f4c2-4d9f-a139-831045bb3a0b"><img width="120" alt="add-backup-mobile" src="https://github.com/user-attachments/assets/0addf62e-f4c2-4d9f-a139-831045bb3a0b"></a> | <a href="https://github.com/user-attachments/assets/e2d5196b-6a4c-4e14-892a-3a74b5ff5868"><img width="320" alt="add-backup-desktop" src="https://github.com/user-attachments/assets/e2d5196b-6a4c-4e14-892a-3a74b5ff5868"></a> <a href="https://github.com/user-attachments/assets/986d741d-5c99-4cb8-84cf-66bdf0d561c7"><img width="120" alt="add-backup-mobile" src="https://github.com/user-attachments/assets/986d741d-5c99-4cb8-84cf-66bdf0d561c7"></a> |
| `/add-security` (ProductInterstitial — bundle upsell with license CTA) | <a href="https://github.com/user-attachments/assets/37834717-1e19-4e1a-879c-1b0454a8466a"><img width="320" alt="add-security-desktop" src="https://github.com/user-attachments/assets/37834717-1e19-4e1a-879c-1b0454a8466a"></a> <a href="https://github.com/user-attachments/assets/e986b8f6-b96f-4022-a232-d4ffc7a2942d"><img width="120" alt="add-security-mobile" src="https://github.com/user-attachments/assets/e986b8f6-b96f-4022-a232-d4ffc7a2942d"></a> | <a href="https://github.com/user-attachments/assets/3a5d8aa7-c9bf-459d-8c46-1d0277fd6173"><img width="320" alt="add-security-desktop" src="https://github.com/user-attachments/assets/3a5d8aa7-c9bf-459d-8c46-1d0277fd6173"></a> <a href="https://github.com/user-attachments/assets/e63d6c29-baa2-4d98-8097-beb3f76e6077"><img width="120" alt="add-security-mobile" src="https://github.com/user-attachments/assets/e63d6c29-baa2-4d98-8097-beb3f76e6077"></a> |
| `/add-license` (license activation screen) | <a href="https://github.com/user-attachments/assets/2ac39d69-bd85-43aa-9dbb-b91be470b1f4"><img width="320" alt="add-license-desktop" src="https://github.com/user-attachments/assets/2ac39d69-bd85-43aa-9dbb-b91be470b1f4"></a> <a href="https://github.com/user-attachments/assets/4e22a908-65cc-4aef-9ff5-a1ffffc7c203"><img width="120" alt="add-license-mobile" src="https://github.com/user-attachments/assets/4e22a908-65cc-4aef-9ff5-a1ffffc7c203"></a> | <a href="https://github.com/user-attachments/assets/e00f91ad-49b4-4f32-b0cf-e542c0f5fb74"><img width="320" alt="add-license-desktop" src="https://github.com/user-attachments/assets/e00f91ad-49b4-4f32-b0cf-e542c0f5fb74"></a> <a href="https://github.com/user-attachments/assets/a2539133-6e09-434c-a927-38a649b67a9f"><img width="120" alt="add-license-mobile" src="https://github.com/user-attachments/assets/a2539133-6e09-434c-a927-38a649b67a9f"></a> |
| `/jetpack-ai` (product detail) | <a href="https://github.com/user-attachments/assets/43eabe33-50bf-430f-a00e-afe15cbb49ca"><img width="320" alt="jetpack-ai-desktop" src="https://github.com/user-attachments/assets/43eabe33-50bf-430f-a00e-afe15cbb49ca"></a> <a href="https://github.com/user-attachments/assets/b22da2e9-1bd2-4bb5-831d-e4d51810ca73"><img width="120" alt="jetpack-ai-mobile" src="https://github.com/user-attachments/assets/b22da2e9-1bd2-4bb5-831d-e4d51810ca73"></a> | <a href="https://github.com/user-attachments/assets/0c99d6af-153a-4dbf-ac69-c23b337b0543"><img width="320" alt="jetpack-ai-desktop" src="https://github.com/user-attachments/assets/0c99d6af-153a-4dbf-ac69-c23b337b0543"></a> <a href="https://github.com/user-attachments/assets/8016944f-4521-4040-b3bc-8cc28152ea0a"><img width="120" alt="jetpack-ai-mobile" src="https://github.com/user-attachments/assets/8016944f-4521-4040-b3bc-8cc28152ea0a"></a> |
| `/protect-details` (product detail) | <a href="https://github.com/user-attachments/assets/7b54675b-da18-4a4c-9442-90bb9ea94edd"><img width="320" alt="protect-details-desktop" src="https://github.com/user-attachments/assets/7b54675b-da18-4a4c-9442-90bb9ea94edd"></a> <a href="https://github.com/user-attachments/assets/eb6de546-c5e7-44c0-8e08-9c8d06ef1f01"><img width="120" alt="protect-details-mobile" src="https://github.com/user-attachments/assets/eb6de546-c5e7-44c0-8e08-9c8d06ef1f01"></a> | <a href="https://github.com/user-attachments/assets/90d894b8-466f-4c30-b3ae-7db0b9ac41d9"><img width="320" alt="protect-details-desktop" src="https://github.com/user-attachments/assets/90d894b8-466f-4c30-b3ae-7db0b9ac41d9"></a> <a href="https://github.com/user-attachments/assets/cdc18248-6c6b-47ea-bead-18ddd8964c49"><img width="120" alt="protect-details-mobile" src="https://github.com/user-attachments/assets/cdc18248-6c6b-47ea-bead-18ddd8964c49"></a> |

## Testing instructions

1. Visit each `/wp-admin/admin.php?page=my-jetpack#/add-*` route on a Jetpack-connected site.
2. Confirm the page now has the unified header, with a "← My Jetpack" back-link as the title and a compact "Use license key" button on the right (where applicable).
3. Click "← My Jetpack" — should land on the **Products** tab of the dashboard (not the Overview).
4. On `/add-license`: activate any pending license, then click the back-link. The `reload=true` query string should still trigger a refresh of the home view.
5. On `/jetpack-ai` and `/protect-details`: confirm the back navigation works the same way and the page background remains.
6. Mobile / narrow viewport: header reflows, back-link and actions stack appropriately.

## Changelog

- [x] `packages/my-jetpack` — patch / changed entry covers both the breadcrumbs and actions changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

