### PR TITLE
Activity Log: default to Table layout and fix free-tier upsell layout

### DIFF
--- a/projects/packages/activity-log/changelog/default-table-view-and-fix-upsell-styles
+++ b/projects/packages/activity-log/changelog/default-table-view-and-fix-upsell-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Activity Log: default the page to the Table layout and load the upsell-callout stylesheet from the main entry so its flex rules reach the bundle.

--- a/projects/packages/activity-log/src/js/components/ActivityLog/UpsellCallout.tsx
+++ b/projects/packages/activity-log/src/js/components/ActivityLog/UpsellCallout.tsx
@@ -17,7 +17,8 @@ import { addQueryArgs } from '@wordpress/url';
 import { useCallback } from 'react';
 import { useAnalytics } from '../../hooks/use-analytics';
 import illustrationUrl from './activity-logs-callout-illustration.svg';
-import './upsell-callout.scss';
+// Stylesheet is `@use`d from `src/js/style.scss` so the rules ride the
+// main entry chunk instead of relying on a side-effect JS import.
 
 const PRODUCT_SLUG = 'jetpack_security_t1_yearly';
 const UPSELL_SOURCE = 'activity-log-page-purchase';

--- a/projects/packages/activity-log/src/js/components/ActivityLog/views.ts
+++ b/projects/packages/activity-log/src/js/components/ActivityLog/views.ts
@@ -14,21 +14,14 @@ const TABLE_LAYOUT = {
 };
 
 export const DEFAULT_VIEW: View = {
-	type: 'activity',
+	type: 'table',
 	perPage: 20,
 	sort: {
 		field: 'published',
 		direction: 'desc',
 	},
-	fields: [ 'published', 'actor' ],
-	layout: { density: 'balanced' },
-	titleField: 'event_title',
-	mediaField: 'event_icon',
-	descriptionField: 'event_description',
-	// Group consecutive events that fall on the same calendar day
-	// (site timezone) under a "Apr 24, 2026" header. See the matching
-	// entry in DEFAULT_LAYOUTS.activity below for the full rationale.
-	groupBy: { field: 'published_date', direction: 'desc', showLabel: false },
+	fields: [ 'published', 'event', 'actor' ],
+	layout: TABLE_LAYOUT,
 	showLevels: false,
 };
 

--- a/projects/packages/activity-log/src/js/style.scss
+++ b/projects/packages/activity-log/src/js/style.scss
@@ -1,5 +1,10 @@
 @use "@automattic/jetpack-base-styles/admin-page-layout" as *;
 @use "sass:meta";
+// Component styles are forwarded from this main entry rather than
+// imported via per-component side-effect imports in each .tsx file —
+// that way they live in the same emitted chunk as the wrapper rules
+// below and can't get dropped by chunk splitting.
+@use "./components/ActivityLog/upsell-callout";
 
 // DataViews is a bundled (not externalized) @wordpress package in
 // jetpack-webpack-config, so its stylesheet must be brought in alongside

--- a/projects/plugins/jetpack/changelog/fix-activity-log-default-and-upsell
+++ b/projects/plugins/jetpack/changelog/fix-activity-log-default-and-upsell
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Activity Log: default the page to the Table layout and fix the free-tier upsell callout's flex layout.


### PR DESCRIPTION
Follow-up to #48244.

## Proposed changes

* **Default the Activity Log page to the Table layout.** `DEFAULT_VIEW.type` was `'activity'`; flip it to `'table'` and use the table-side `fields` / `layout` already declared in `DEFAULT_LAYOUTS.table`. Existing visitors keep whatever they had — `usePersistentView` only falls back to the new default for fresh sessions or after the user clicks "Reset view".
* **Fix the free-tier upsell callout layout.** On a fresh JN install the `UpsellCallout` was rendering with the illustration on top of the copy (default block flow) instead of the side-by-side row layout `upsell-callout.scss` prescribes. Forward the stylesheet from the main entry `style.scss` via `@use` so the rules ride the same chunk as the wrapper styles (DataViews CSS, `.jp-activity-log__dataviews-wrapper`, etc.) instead of relying on a side-effect `import` from `UpsellCallout.tsx` that wasn't reaching the deployed bundle. The JS-side `import` is dropped to avoid a double emit.

## Related product discussion/links

* Original feature PR: #48244
* Tracking issue: #48242
* Reference: Calypso Dashboard `client/dashboard/sites/logs-activity/`

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Setup: pull this branch, `jetpack install plugins/jetpack`, `jetpack build packages/activity-log`. Visit `admin.php?page=jetpack-activity-log` on a Jetpack-connected, non-multisite, `manage_options` user.

**Default layout — paid tier (Backup-enabled site):**

1. In DevTools → Application → Local Storage, delete any `jetpack-activity-log:view:*` entry (or use a fresh browser profile).
2. Reload the page. The DataViews surface should render as a **Table** with three columns — Date & time / Event / User — not the vertical Activity timeline.
3. Open the cog popover → confirm the layout switcher shows Table selected. Switching to Activity should still work and surface the timeline + day grouping. Switching back to Table should return to step 2's layout.
4. After any layout change, refresh — the choice persists via localStorage.

**Default layout — free tier (no Backup plan, e.g. fresh JN site):**

5. Same steps as 1–2: the table renders with three columns. Search / filter / cog toolbar is hidden (free tier intentionally strips the toolbar via `<DataViews.Layout />`), pagination is absent, and the table caps at 20 rows.

**Upsell callout layout (free tier, viewport ≥ 782px):**

6. Scroll to the upsell callout below the table. The illustration should sit on the **left** with the title / paragraphs / Upgrade button on the **right**, vertically centered — not stacked.
7. Resize the browser below 782px (or use DevTools' device toolbar). The layout flips to column-reverse: copy on top, illustration below.
8. DevTools → Elements → inspect `.jp-activity-log__upsell-callout` and confirm `display: flex` and `flex-direction: row` (or `column-reverse` on narrow viewports) are computed — i.e. the rules from `upsell-callout.scss` reach the page.

**Regression spot-checks (existing PR #48244 behavior):**

9. Reset view (cog → Reset view) on a paid-tier site after switching to Activity layout — confirm the view returns to the new Table default and the cog "modified" indicator clears.
10. The Activity layout's day-group headers (`Apr 30, 2026`) still render when the user explicitly switches to that layout via the cog.
