### PR TITLE
Write: close slash menu when no items match the filter

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-write-slash-menu-close-no-matches
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-write-slash-menu-close-no-matches
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write: close slash menu when no items match the filter or when trailing spaces are typed

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1000,7 +1000,7 @@ const { state } = store( 'wpcom-write', {
 
 			const text = node.textContent;
 			// Show menu when the line starts with "/" and optionally a filter after it.
-			if ( /^\/\S*$/.test( text.trim() ) ) {
+			if ( /^\/\S*$/.test( text.trimStart() ) ) {
 				// User just dismissed the menu with Escape — skip this keyup cycle.
 				if ( slashMenuEscaped ) {
 					slashMenuEscaped = false;
@@ -1031,8 +1031,13 @@ const { state } = store( 'wpcom-write', {
 					item.style.display = show ? '' : 'none';
 					if ( show && ! firstVisible ) firstVisible = item;
 				} );
+				// Close the menu when no items match the filter.
+				if ( ! firstVisible ) {
+					state.showSlashMenu = false;
+					return;
+				}
 				// Auto-highlight the first visible item only when filter changes.
-				if ( filterChanged && firstVisible ) firstVisible.classList.add( 'bw-slash-item-active' );
+				if ( filterChanged ) firstVisible.classList.add( 'bw-slash-item-active' );
 			} else {
 				slashMenuEscaped = false;
 				prevSlashFilter = null;


### PR DESCRIPTION
Fixes RSM-1487

## Proposed changes

* Close the slash menu when the filter text matches no menu items (e.g. typing `/xyz`)
* Fix the menu staying open when trailing spaces are typed after a slash command (e.g. `/h   `) by using `trimStart()` instead of `trim()` so the regex correctly detects whitespace

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Go to a WordPress.com site with the Write editor enabled
2. Create or edit a post using the Write editor
3. Type `/` — the slash menu should appear with all items (Heading, Image, Quote, Video, Divider)
4. Type `/h` — the menu should filter to show only "Heading"
5. Type `/xyz` — the menu should close since no items match
6. Delete back to `/` — the menu should reopen with all items
7. Type `/h` followed by several spaces — the menu should close when the first space is typed
8. Press Escape while the menu is open — it should close and not reopen until a new `/` is typed

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
