### PR TITLE
wpcomsh: bump wp-php-toolkit reprint exporter/importer to ^0.7.2

### DIFF
--- a/projects/plugins/wpcomsh/changelog/adamziel-bump-wp-php-toolkit-0-7-0
+++ b/projects/plugins/wpcomsh/changelog/adamziel-bump-wp-php-toolkit-0-7-0
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Update wp-php-toolkit/reprint-exporter and reprint-importer to ^0.7.0 for smaller Packagist dist artifacts.
+Update wp-php-toolkit/reprint-exporter and reprint-importer to ^0.7.1, picking up wp-php-toolkit/html ^0.7.2 and wp-php-toolkit/data-liberation ^0.7.2. Smaller Packagist dist artifacts and fixes the WP_Token_Map redeclare fatal that hit wpcomsh's PHPUnit run.

--- a/projects/plugins/wpcomsh/changelog/adamziel-bump-wp-php-toolkit-0-7-0
+++ b/projects/plugins/wpcomsh/changelog/adamziel-bump-wp-php-toolkit-0-7-0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update wp-php-toolkit/reprint-exporter and reprint-importer to ^0.7.0 for smaller Packagist dist artifacts.

--- a/projects/plugins/wpcomsh/changelog/adamziel-bump-wp-php-toolkit-0-7-0
+++ b/projects/plugins/wpcomsh/changelog/adamziel-bump-wp-php-toolkit-0-7-0
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Update wp-php-toolkit/reprint-exporter and reprint-importer to ^0.7.1, picking up wp-php-toolkit/html ^0.7.2 and wp-php-toolkit/data-liberation ^0.7.2. Smaller Packagist dist artifacts and fixes the WP_Token_Map redeclare fatal that hit wpcomsh's PHPUnit run.
+Update wp-php-toolkit/reprint-exporter and reprint-importer to ^0.7.2, picking up wp-php-toolkit/html ^0.7.2 and wp-php-toolkit/data-liberation ^0.7.2. Smaller Packagist dist artifacts and fixes the WP_Token_Map redeclare fatal that hit wpcomsh's PHPUnit run.

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -18,8 +18,8 @@
 		"automattic/jetpack-mu-wpcom": "@dev",
 		"tubalmartin/cssmin": "^4.1",
 		"automattic/jetpack-explat": "@dev",
-		"wp-php-toolkit/reprint-exporter": "^0.7.0",
-		"wp-php-toolkit/reprint-importer": "^0.7.0"
+		"wp-php-toolkit/reprint-exporter": "^0.7.1",
+		"wp-php-toolkit/reprint-importer": "^0.7.1"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^4.0.0",

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -18,8 +18,8 @@
 		"automattic/jetpack-mu-wpcom": "@dev",
 		"tubalmartin/cssmin": "^4.1",
 		"automattic/jetpack-explat": "@dev",
-		"wp-php-toolkit/reprint-exporter": "^0.1.44",
-		"wp-php-toolkit/reprint-importer": "^0.1.44"
+		"wp-php-toolkit/reprint-exporter": "^0.7.0",
+		"wp-php-toolkit/reprint-importer": "^0.7.0"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^4.0.0",

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -18,8 +18,8 @@
 		"automattic/jetpack-mu-wpcom": "@dev",
 		"tubalmartin/cssmin": "^4.1",
 		"automattic/jetpack-explat": "@dev",
-		"wp-php-toolkit/reprint-exporter": "^0.7.1",
-		"wp-php-toolkit/reprint-importer": "^0.7.1"
+		"wp-php-toolkit/reprint-exporter": "^0.7.2",
+		"wp-php-toolkit/reprint-importer": "^0.7.2"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^4.0.0",

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5888fdf5b3ab632a0f07f80f5ca8dc17",
+    "content-hash": "8e1a2a43ff305e456b42b3f583696b00",
     "packages": [
         {
             "name": "automattic/at-pressable-podcasting",
@@ -3243,16 +3243,16 @@
         },
         {
             "name": "wp-php-toolkit/bytestream",
-            "version": "v0.6.2",
+            "version": "v0.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/bytestream.git",
-                "reference": "bf3e28e6f6e51e7abeec16e3f8c3a096e0aa2a02"
+                "reference": "275c423f714e8a16278b939eede1c1c1a21f6561"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/bytestream/zipball/bf3e28e6f6e51e7abeec16e3f8c3a096e0aa2a02",
-                "reference": "bf3e28e6f6e51e7abeec16e3f8c3a096e0aa2a02",
+                "url": "https://api.github.com/repos/wp-php-toolkit/bytestream/zipball/275c423f714e8a16278b939eede1c1c1a21f6561",
+                "reference": "275c423f714e8a16278b939eede1c1c1a21f6561",
                 "shasum": ""
             },
             "require": {
@@ -3287,30 +3287,30 @@
             "description": "ByteStream component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/bytestream/issues",
-                "source": "https://github.com/wp-php-toolkit/bytestream/tree/v0.6.2"
+                "source": "https://github.com/wp-php-toolkit/bytestream/tree/v0.7.1"
             },
-            "time": "2026-04-10T20:16:27+00:00"
+            "time": "2026-04-29T23:59:06+00:00"
         },
         {
             "name": "wp-php-toolkit/data-liberation",
-            "version": "v0.6.2",
+            "version": "v0.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/data-liberation.git",
-                "reference": "3502454cd1c760b929329cb4f744ada6eb08ba73"
+                "reference": "85e527f644bbf66789a4200f093b835ff3abcfd8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/data-liberation/zipball/3502454cd1c760b929329cb4f744ada6eb08ba73",
-                "reference": "3502454cd1c760b929329cb4f744ada6eb08ba73",
+                "url": "https://api.github.com/repos/wp-php-toolkit/data-liberation/zipball/85e527f644bbf66789a4200f093b835ff3abcfd8",
+                "reference": "85e527f644bbf66789a4200f093b835ff3abcfd8",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.6.2",
-                "wp-php-toolkit/filesystem": "^0.6.2",
-                "wp-php-toolkit/http-client": "^0.6.2",
-                "wp-php-toolkit/xml": "^0.6.2"
+                "wp-php-toolkit/bytestream": "^0.7.1",
+                "wp-php-toolkit/filesystem": "^0.7.1",
+                "wp-php-toolkit/http-client": "^0.7.1",
+                "wp-php-toolkit/xml": "^0.7.1"
             },
             "type": "library",
             "autoload": {
@@ -3342,22 +3342,22 @@
             "description": "Data Liberation component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/data-liberation/issues",
-                "source": "https://github.com/wp-php-toolkit/data-liberation/tree/v0.6.2"
+                "source": "https://github.com/wp-php-toolkit/data-liberation/tree/v0.7.1"
             },
-            "time": "2026-04-27T14:15:30+00:00"
+            "time": "2026-04-30T18:11:45+00:00"
         },
         {
             "name": "wp-php-toolkit/encoding",
-            "version": "v0.6.2",
+            "version": "v0.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/encoding.git",
-                "reference": "f814ff6cae957449baa16f7dabe840cca756db6a"
+                "reference": "14ce8b2fed7c1f259f31bde60a11e431ec7fc8c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/encoding/zipball/f814ff6cae957449baa16f7dabe840cca756db6a",
-                "reference": "f814ff6cae957449baa16f7dabe840cca756db6a",
+                "url": "https://api.github.com/repos/wp-php-toolkit/encoding/zipball/14ce8b2fed7c1f259f31bde60a11e431ec7fc8c9",
+                "reference": "14ce8b2fed7c1f259f31bde60a11e431ec7fc8c9",
                 "shasum": ""
             },
             "require": {
@@ -3391,27 +3391,27 @@
             "description": "Encoding component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/encoding/issues",
-                "source": "https://github.com/wp-php-toolkit/encoding/tree/v0.6.2"
+                "source": "https://github.com/wp-php-toolkit/encoding/tree/v0.7.1"
             },
-            "time": "2026-04-10T20:16:27+00:00"
+            "time": "2026-04-29T23:59:06+00:00"
         },
         {
             "name": "wp-php-toolkit/filesystem",
-            "version": "v0.6.2",
+            "version": "v0.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/filesystem.git",
-                "reference": "36c54d8007b949c98a9fc460914367bcdc9b778f"
+                "reference": "ae7f8549909db23b12b3e6c7e0ef2d72d39e1fa2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/filesystem/zipball/36c54d8007b949c98a9fc460914367bcdc9b778f",
-                "reference": "36c54d8007b949c98a9fc460914367bcdc9b778f",
+                "url": "https://api.github.com/repos/wp-php-toolkit/filesystem/zipball/ae7f8549909db23b12b3e6c7e0ef2d72d39e1fa2",
+                "reference": "ae7f8549909db23b12b3e6c7e0ef2d72d39e1fa2",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.6.2"
+                "wp-php-toolkit/bytestream": "^0.7.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -3445,22 +3445,22 @@
             "description": "Filesystem component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/filesystem/issues",
-                "source": "https://github.com/wp-php-toolkit/filesystem/tree/v0.6.2"
+                "source": "https://github.com/wp-php-toolkit/filesystem/tree/v0.7.1"
             },
-            "time": "2026-04-27T14:15:30+00:00"
+            "time": "2026-04-30T18:11:45+00:00"
         },
         {
             "name": "wp-php-toolkit/html",
-            "version": "v0.6.2",
+            "version": "v0.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/html.git",
-                "reference": "d7dac562cdaff693d830ede7f35cf490a397678e"
+                "reference": "139ee6d54ac8e08ad9be75918b01d4fa84fbbec0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/html/zipball/d7dac562cdaff693d830ede7f35cf490a397678e",
-                "reference": "d7dac562cdaff693d830ede7f35cf490a397678e",
+                "url": "https://api.github.com/repos/wp-php-toolkit/html/zipball/139ee6d54ac8e08ad9be75918b01d4fa84fbbec0",
+                "reference": "139ee6d54ac8e08ad9be75918b01d4fa84fbbec0",
                 "shasum": ""
             },
             "require": {
@@ -3471,6 +3471,9 @@
             },
             "type": "library",
             "autoload": {
+                "files": [
+                    "html5-named-character-references.php"
+                ],
                 "classmap": [
                     "./"
                 ],
@@ -3495,29 +3498,29 @@
             "description": "HTML component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/html/issues",
-                "source": "https://github.com/wp-php-toolkit/html/tree/v0.6.2"
+                "source": "https://github.com/wp-php-toolkit/html/tree/v0.7.1"
             },
-            "time": "2026-04-10T20:16:27+00:00"
+            "time": "2026-04-30T18:11:00+00:00"
         },
         {
             "name": "wp-php-toolkit/http-client",
-            "version": "v0.6.2",
+            "version": "v0.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/http-client.git",
-                "reference": "1174f1e20e1f4c60a3274006ebed791ac6bccd77"
+                "reference": "81e2751ce9d1c64c852ae80921ffad2ae8c4dd72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/http-client/zipball/1174f1e20e1f4c60a3274006ebed791ac6bccd77",
-                "reference": "1174f1e20e1f4c60a3274006ebed791ac6bccd77",
+                "url": "https://api.github.com/repos/wp-php-toolkit/http-client/zipball/81e2751ce9d1c64c852ae80921ffad2ae8c4dd72",
+                "reference": "81e2751ce9d1c64c852ae80921ffad2ae8c4dd72",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.6.2",
-                "wp-php-toolkit/data-liberation": "^0.6.2",
-                "wp-php-toolkit/filesystem": "^0.6.2"
+                "wp-php-toolkit/bytestream": "^0.7.1",
+                "wp-php-toolkit/data-liberation": "^0.7.1",
+                "wp-php-toolkit/filesystem": "^0.7.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -3548,30 +3551,30 @@
             "description": "HttpClient component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/http-client/issues",
-                "source": "https://github.com/wp-php-toolkit/http-client/tree/v0.6.2"
+                "source": "https://github.com/wp-php-toolkit/http-client/tree/v0.7.1"
             },
-            "time": "2026-04-27T14:15:30+00:00"
+            "time": "2026-04-30T18:11:45+00:00"
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "v0.1.47",
+            "version": "v0.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/reprint-exporter.git",
-                "reference": "3c56b78f4d19add36f8448421d1ed4fdda135bb6"
+                "reference": "75d1bea83658e13d1d196a1c83276012743a8745"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/reprint-exporter/zipball/3c56b78f4d19add36f8448421d1ed4fdda135bb6",
-                "reference": "3c56b78f4d19add36f8448421d1ed4fdda135bb6",
+                "url": "https://api.github.com/repos/wp-php-toolkit/reprint-exporter/zipball/75d1bea83658e13d1d196a1c83276012743a8745",
+                "reference": "75d1bea83658e13d1d196a1c83276012743a8745",
                 "shasum": ""
             },
             "require": {
                 "ext-pdo": "*",
                 "ext-pdo_mysql": "*",
                 "php": ">=7.4",
-                "wp-php-toolkit/data-liberation": "^0.6.2",
-                "wp-php-toolkit/html": "^0.6.2"
+                "wp-php-toolkit/data-liberation": "^0.7.0",
+                "wp-php-toolkit/html": "^0.7.0"
             },
             "type": "library",
             "autoload": {
@@ -3597,30 +3600,30 @@
             "description": "Streaming export engine used by the Reprint Exporter WordPress plugin",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/reprint-exporter/issues",
-                "source": "https://github.com/wp-php-toolkit/reprint-exporter/tree/v0.1.47"
+                "source": "https://github.com/wp-php-toolkit/reprint-exporter/tree/v0.7.0"
             },
-            "time": "2026-04-27T14:34:36+00:00"
+            "time": "2026-04-30T17:02:22+00:00"
         },
         {
             "name": "wp-php-toolkit/reprint-importer",
-            "version": "v0.1.47",
+            "version": "v0.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/reprint-importer.git",
-                "reference": "e56a796721f559d9a5932bf14d65cab0de51350e"
+                "reference": "645e27a1611811f24a0270d2177326dca4b4d805"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/reprint-importer/zipball/e56a796721f559d9a5932bf14d65cab0de51350e",
-                "reference": "e56a796721f559d9a5932bf14d65cab0de51350e",
+                "url": "https://api.github.com/repos/wp-php-toolkit/reprint-importer/zipball/645e27a1611811f24a0270d2177326dca4b4d805",
+                "reference": "645e27a1611811f24a0270d2177326dca4b4d805",
                 "shasum": ""
             },
             "require": {
                 "ext-pdo": "*",
                 "ext-pdo_mysql": "*",
                 "php": ">=7.4",
-                "wp-php-toolkit/data-liberation": "^0.6.2",
-                "wp-php-toolkit/html": "^0.6.2",
+                "wp-php-toolkit/data-liberation": "^0.7.0",
+                "wp-php-toolkit/html": "^0.7.0",
                 "wp-php-toolkit/reprint-exporter": "*@dev"
             },
             "bin": [
@@ -3634,27 +3637,27 @@
             "description": "Streaming site importer with CLI and PHAR distribution support",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/reprint-importer/issues",
-                "source": "https://github.com/wp-php-toolkit/reprint-importer/tree/v0.1.47"
+                "source": "https://github.com/wp-php-toolkit/reprint-importer/tree/v0.7.0"
             },
-            "time": "2026-04-27T14:34:36+00:00"
+            "time": "2026-04-30T17:02:22+00:00"
         },
         {
             "name": "wp-php-toolkit/xml",
-            "version": "v0.6.2",
+            "version": "v0.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/xml.git",
-                "reference": "65e8a47d350179a3217b4acaf4f3597f977a9194"
+                "reference": "85c376eb2fa2553b933fecf7e60dce0c990ef861"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/xml/zipball/65e8a47d350179a3217b4acaf4f3597f977a9194",
-                "reference": "65e8a47d350179a3217b4acaf4f3597f977a9194",
+                "url": "https://api.github.com/repos/wp-php-toolkit/xml/zipball/85c376eb2fa2553b933fecf7e60dce0c990ef861",
+                "reference": "85c376eb2fa2553b933fecf7e60dce0c990ef861",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/encoding": "^0.6.2"
+                "wp-php-toolkit/encoding": "^0.7.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -3685,9 +3688,9 @@
             "description": "XML component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/xml/issues",
-                "source": "https://github.com/wp-php-toolkit/xml/tree/v0.6.2"
+                "source": "https://github.com/wp-php-toolkit/xml/tree/v0.7.1"
             },
-            "time": "2026-04-27T14:15:30+00:00"
+            "time": "2026-04-30T18:11:45+00:00"
         }
     ],
     "packages-dev": [

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "54c5bc256922d232ff0572569c5a504d",
+    "content-hash": "ca5db4a80577e1a4142f748db93a2f59",
     "packages": [
         {
             "name": "automattic/at-pressable-podcasting",
@@ -3614,7 +3614,7 @@
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "v0.7.1",
+            "version": "v0.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/reprint-exporter.git",
@@ -3657,13 +3657,13 @@
             "description": "Streaming export engine used by the Reprint Exporter WordPress plugin",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/reprint-exporter/issues",
-                "source": "https://github.com/wp-php-toolkit/reprint-exporter/tree/v0.7.1"
+                "source": "https://github.com/wp-php-toolkit/reprint-exporter/tree/v0.7.2"
             },
             "time": "2026-04-30T22:29:29+00:00"
         },
         {
             "name": "wp-php-toolkit/reprint-importer",
-            "version": "v0.7.1",
+            "version": "v0.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/reprint-importer.git",
@@ -3694,7 +3694,7 @@
             "description": "Streaming site importer with CLI and PHAR distribution support",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/reprint-importer/issues",
-                "source": "https://github.com/wp-php-toolkit/reprint-importer/tree/v0.7.1"
+                "source": "https://github.com/wp-php-toolkit/reprint-importer/tree/v0.7.2"
             },
             "time": "2026-04-30T22:29:29+00:00"
         },

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8e1a2a43ff305e456b42b3f583696b00",
+    "content-hash": "54c5bc256922d232ff0572569c5a504d",
     "packages": [
         {
             "name": "automattic/at-pressable-podcasting",
@@ -3243,7 +3243,7 @@
         },
         {
             "name": "wp-php-toolkit/bytestream",
-            "version": "v0.7.1",
+            "version": "v0.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/bytestream.git",
@@ -3287,30 +3287,30 @@
             "description": "ByteStream component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/bytestream/issues",
-                "source": "https://github.com/wp-php-toolkit/bytestream/tree/v0.7.1"
+                "source": "https://github.com/wp-php-toolkit/bytestream/tree/v0.7.2"
             },
             "time": "2026-04-29T23:59:06+00:00"
         },
         {
             "name": "wp-php-toolkit/data-liberation",
-            "version": "v0.7.1",
+            "version": "v0.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/data-liberation.git",
-                "reference": "85e527f644bbf66789a4200f093b835ff3abcfd8"
+                "reference": "24feba2fc83c4ebcf4e50ebfddd19625d154ddba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/data-liberation/zipball/85e527f644bbf66789a4200f093b835ff3abcfd8",
-                "reference": "85e527f644bbf66789a4200f093b835ff3abcfd8",
+                "url": "https://api.github.com/repos/wp-php-toolkit/data-liberation/zipball/24feba2fc83c4ebcf4e50ebfddd19625d154ddba",
+                "reference": "24feba2fc83c4ebcf4e50ebfddd19625d154ddba",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.7.1",
-                "wp-php-toolkit/filesystem": "^0.7.1",
-                "wp-php-toolkit/http-client": "^0.7.1",
-                "wp-php-toolkit/xml": "^0.7.1"
+                "wp-php-toolkit/bytestream": "^0.7.2",
+                "wp-php-toolkit/filesystem": "^0.7.2",
+                "wp-php-toolkit/http-client": "^0.7.2",
+                "wp-php-toolkit/xml": "^0.7.2"
             },
             "type": "library",
             "autoload": {
@@ -3342,13 +3342,13 @@
             "description": "Data Liberation component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/data-liberation/issues",
-                "source": "https://github.com/wp-php-toolkit/data-liberation/tree/v0.7.1"
+                "source": "https://github.com/wp-php-toolkit/data-liberation/tree/v0.7.2"
             },
-            "time": "2026-04-30T18:11:45+00:00"
+            "time": "2026-04-30T22:24:20+00:00"
         },
         {
             "name": "wp-php-toolkit/encoding",
-            "version": "v0.7.1",
+            "version": "v0.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/encoding.git",
@@ -3391,27 +3391,27 @@
             "description": "Encoding component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/encoding/issues",
-                "source": "https://github.com/wp-php-toolkit/encoding/tree/v0.7.1"
+                "source": "https://github.com/wp-php-toolkit/encoding/tree/v0.7.2"
             },
             "time": "2026-04-29T23:59:06+00:00"
         },
         {
             "name": "wp-php-toolkit/filesystem",
-            "version": "v0.7.1",
+            "version": "v0.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/filesystem.git",
-                "reference": "ae7f8549909db23b12b3e6c7e0ef2d72d39e1fa2"
+                "reference": "cb41da281943fac5092019ff71cbb30ec6ad4456"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/filesystem/zipball/ae7f8549909db23b12b3e6c7e0ef2d72d39e1fa2",
-                "reference": "ae7f8549909db23b12b3e6c7e0ef2d72d39e1fa2",
+                "url": "https://api.github.com/repos/wp-php-toolkit/filesystem/zipball/cb41da281943fac5092019ff71cbb30ec6ad4456",
+                "reference": "cb41da281943fac5092019ff71cbb30ec6ad4456",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.7.1"
+                "wp-php-toolkit/bytestream": "^0.7.2"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -3420,59 +3420,6 @@
             "autoload": {
                 "files": [
                     "functions.php"
-                ],
-                "psr-4": {
-                    "WordPress\\Filesystem\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Adam Zielinski",
-                    "email": "adam@adamziel.com"
-                },
-                {
-                    "name": "WordPress Team",
-                    "email": "wordpress@wordpress.org"
-                }
-            ],
-            "description": "Filesystem component for WordPress.",
-            "support": {
-                "issues": "https://github.com/wp-php-toolkit/filesystem/issues",
-                "source": "https://github.com/wp-php-toolkit/filesystem/tree/v0.7.1"
-            },
-            "time": "2026-04-30T18:11:45+00:00"
-        },
-        {
-            "name": "wp-php-toolkit/html",
-            "version": "v0.7.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/wp-php-toolkit/html.git",
-                "reference": "139ee6d54ac8e08ad9be75918b01d4fa84fbbec0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/html/zipball/139ee6d54ac8e08ad9be75918b01d4fa84fbbec0",
-                "reference": "139ee6d54ac8e08ad9be75918b01d4fa84fbbec0",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.5"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "html5-named-character-references.php"
                 ],
                 "classmap": [
                     "./"
@@ -3495,41 +3442,92 @@
                     "email": "wordpress@wordpress.org"
                 }
             ],
-            "description": "HTML component for WordPress.",
+            "description": "Filesystem component for WordPress.",
             "support": {
-                "issues": "https://github.com/wp-php-toolkit/html/issues",
-                "source": "https://github.com/wp-php-toolkit/html/tree/v0.7.1"
+                "issues": "https://github.com/wp-php-toolkit/filesystem/issues",
+                "source": "https://github.com/wp-php-toolkit/filesystem/tree/v0.7.2"
             },
-            "time": "2026-04-30T18:11:00+00:00"
+            "time": "2026-04-30T22:24:20+00:00"
         },
         {
-            "name": "wp-php-toolkit/http-client",
-            "version": "v0.7.1",
+            "name": "wp-php-toolkit/html",
+            "version": "v0.7.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/wp-php-toolkit/http-client.git",
-                "reference": "81e2751ce9d1c64c852ae80921ffad2ae8c4dd72"
+                "url": "https://github.com/wp-php-toolkit/html.git",
+                "reference": "dd97f71d0c46408f26a3d23e75bfb62d1a7e6f65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/http-client/zipball/81e2751ce9d1c64c852ae80921ffad2ae8c4dd72",
-                "reference": "81e2751ce9d1c64c852ae80921ffad2ae8c4dd72",
+                "url": "https://api.github.com/repos/wp-php-toolkit/html/zipball/dd97f71d0c46408f26a3d23e75bfb62d1a7e6f65",
+                "reference": "dd97f71d0c46408f26a3d23e75bfb62d1a7e6f65",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.7.1",
-                "wp-php-toolkit/data-liberation": "^0.7.1",
-                "wp-php-toolkit/filesystem": "^0.7.1"
+                "php": ">=7.2"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "WordPress\\HttpClient\\": ""
+                "classmap": [
+                    "./"
+                ],
+                "exclude-from-classmap": [
+                    "/Tests/",
+                    "/html5-named-character-references.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Adam Zielinski",
+                    "email": "adam@adamziel.com"
                 },
+                {
+                    "name": "WordPress Team",
+                    "email": "wordpress@wordpress.org"
+                }
+            ],
+            "description": "HTML component for WordPress.",
+            "support": {
+                "issues": "https://github.com/wp-php-toolkit/html/issues",
+                "source": "https://github.com/wp-php-toolkit/html/tree/v0.7.2"
+            },
+            "time": "2026-04-30T22:23:42+00:00"
+        },
+        {
+            "name": "wp-php-toolkit/http-client",
+            "version": "v0.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wp-php-toolkit/http-client.git",
+                "reference": "016f1658ca6c8d877769f43ca9b6c4a9dc213a05"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wp-php-toolkit/http-client/zipball/016f1658ca6c8d877769f43ca9b6c4a9dc213a05",
+                "reference": "016f1658ca6c8d877769f43ca9b6c4a9dc213a05",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2",
+                "wp-php-toolkit/bytestream": "^0.7.2",
+                "wp-php-toolkit/data-liberation": "^0.7.2",
+                "wp-php-toolkit/filesystem": "^0.7.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "./"
+                ],
                 "exclude-from-classmap": [
                     "/Tests/"
                 ]
@@ -3551,30 +3549,30 @@
             "description": "HttpClient component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/http-client/issues",
-                "source": "https://github.com/wp-php-toolkit/http-client/tree/v0.7.1"
+                "source": "https://github.com/wp-php-toolkit/http-client/tree/v0.7.2"
             },
-            "time": "2026-04-30T18:11:45+00:00"
+            "time": "2026-04-30T22:24:20+00:00"
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "v0.7.0",
+            "version": "v0.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/reprint-exporter.git",
-                "reference": "75d1bea83658e13d1d196a1c83276012743a8745"
+                "reference": "9564b9d975450f6744ac4171065c935effa3edbc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/reprint-exporter/zipball/75d1bea83658e13d1d196a1c83276012743a8745",
-                "reference": "75d1bea83658e13d1d196a1c83276012743a8745",
+                "url": "https://api.github.com/repos/wp-php-toolkit/reprint-exporter/zipball/9564b9d975450f6744ac4171065c935effa3edbc",
+                "reference": "9564b9d975450f6744ac4171065c935effa3edbc",
                 "shasum": ""
             },
             "require": {
                 "ext-pdo": "*",
                 "ext-pdo_mysql": "*",
                 "php": ">=7.4",
-                "wp-php-toolkit/data-liberation": "^0.7.0",
-                "wp-php-toolkit/html": "^0.7.0"
+                "wp-php-toolkit/data-liberation": "^0.7.2",
+                "wp-php-toolkit/html": "^0.7.2"
             },
             "type": "library",
             "autoload": {
@@ -3600,30 +3598,30 @@
             "description": "Streaming export engine used by the Reprint Exporter WordPress plugin",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/reprint-exporter/issues",
-                "source": "https://github.com/wp-php-toolkit/reprint-exporter/tree/v0.7.0"
+                "source": "https://github.com/wp-php-toolkit/reprint-exporter/tree/v0.7.1"
             },
-            "time": "2026-04-30T17:02:22+00:00"
+            "time": "2026-04-30T22:29:29+00:00"
         },
         {
             "name": "wp-php-toolkit/reprint-importer",
-            "version": "v0.7.0",
+            "version": "v0.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/reprint-importer.git",
-                "reference": "645e27a1611811f24a0270d2177326dca4b4d805"
+                "reference": "c21efef8dfe04db3278c72ae9cef914d5d88d1e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/reprint-importer/zipball/645e27a1611811f24a0270d2177326dca4b4d805",
-                "reference": "645e27a1611811f24a0270d2177326dca4b4d805",
+                "url": "https://api.github.com/repos/wp-php-toolkit/reprint-importer/zipball/c21efef8dfe04db3278c72ae9cef914d5d88d1e1",
+                "reference": "c21efef8dfe04db3278c72ae9cef914d5d88d1e1",
                 "shasum": ""
             },
             "require": {
                 "ext-pdo": "*",
                 "ext-pdo_mysql": "*",
                 "php": ">=7.4",
-                "wp-php-toolkit/data-liberation": "^0.7.0",
-                "wp-php-toolkit/html": "^0.7.0",
+                "wp-php-toolkit/data-liberation": "^0.7.2",
+                "wp-php-toolkit/html": "^0.7.2",
                 "wp-php-toolkit/reprint-exporter": "*@dev"
             },
             "bin": [
@@ -3637,27 +3635,27 @@
             "description": "Streaming site importer with CLI and PHAR distribution support",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/reprint-importer/issues",
-                "source": "https://github.com/wp-php-toolkit/reprint-importer/tree/v0.7.0"
+                "source": "https://github.com/wp-php-toolkit/reprint-importer/tree/v0.7.1"
             },
-            "time": "2026-04-30T17:02:22+00:00"
+            "time": "2026-04-30T22:29:29+00:00"
         },
         {
             "name": "wp-php-toolkit/xml",
-            "version": "v0.7.1",
+            "version": "v0.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/xml.git",
-                "reference": "85c376eb2fa2553b933fecf7e60dce0c990ef861"
+                "reference": "0fddbc2decbf6426ed1ae8387a5970e849b9da63"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/xml/zipball/85c376eb2fa2553b933fecf7e60dce0c990ef861",
-                "reference": "85c376eb2fa2553b933fecf7e60dce0c990ef861",
+                "url": "https://api.github.com/repos/wp-php-toolkit/xml/zipball/0fddbc2decbf6426ed1ae8387a5970e849b9da63",
+                "reference": "0fddbc2decbf6426ed1ae8387a5970e849b9da63",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/encoding": "^0.7.1"
+                "wp-php-toolkit/encoding": "^0.7.2"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -3688,9 +3686,9 @@
             "description": "XML component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/xml/issues",
-                "source": "https://github.com/wp-php-toolkit/xml/tree/v0.7.1"
+                "source": "https://github.com/wp-php-toolkit/xml/tree/v0.7.2"
             },
-            "time": "2026-04-30T18:11:45+00:00"
+            "time": "2026-04-30T22:24:20+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
Bumps `wp-php-toolkit/reprint-exporter` and `wp-php-toolkit/reprint-importer` from `^0.1.44` to `^0.7.0` in wpcomsh.

The 0.7 release trims the Packagist dist artifacts — dev fixtures and test data are no longer bundled in the published zip. Smaller `composer install` downloads, lighter vendor footprint in production. No API changes affecting wpcomsh.

## Testing instructions:

* Check out this branch and run `composer install` in `projects/plugins/wpcomsh`.
* Confirm the toolkit packages are at v0.7.0: `composer show wp-php-toolkit/reprint-exporter` and `composer show wp-php-toolkit/reprint-importer`.
* On a WoA dev site with this branch active, trigger a Reprint export and a Reprint import; both flows should complete without errors.
* Spot-check the WP Cloud PHPUnit job — the wpcomsh suite should pass.

## Does this pull request change what data or activity we track or use?

No. This is a dependency version bump with no behavior change.