### PR TITLE
Search: regression test for overlay/blocks deep-link URL round-trip (RSM-1923)

### DIFF
--- a/projects/packages/search/changelog/raven-rsm-1923-deeplink-roundtrip-test
+++ b/projects/packages/search/changelog/raven-rsm-1923-deeplink-roundtrip-test
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Search Blocks: Add regression test asserting deep-link URL round-trip parity between the instant-search overlay and search-blocks.

--- a/projects/packages/search/tests/js/search-blocks/deeplink-roundtrip.test.js
+++ b/projects/packages/search/tests/js/search-blocks/deeplink-roundtrip.test.js
@@ -1,0 +1,197 @@
+/**
+ * Deep-link round-trip parity test for the URL contract shared by the
+ * legacy instant-search overlay and the new search-blocks Interactivity
+ * blocks (RSM-1923).
+ *
+ * Why: a site mid-migration may render the overlay on one page and the
+ * Search 3.0 blocks on another. A URL produced by either surface — when
+ * shared, bookmarked, or pasted into the address bar — must reconstruct
+ * the same active-filter state on the other surface. Without this
+ * guarantee the two formats can drift silently and shared filtered
+ * URLs stop working with no obvious failure mode.
+ *
+ * Each fixture below describes a representative search state. Per
+ * fixture we exercise four round-trips:
+ *
+ * 1. blocks-serialize  → blocks-parse   → original state (intra-blocks)
+ * 2. overlay-serialize → overlay-parse  → original state (intra-overlay)
+ * 3. overlay-serialize → blocks-parse   → original state (cross)
+ * 4. blocks-serialize  → overlay-parse  → original state (cross)
+ *
+ * The intra-surface cases anchor the test to the production code on each
+ * side. The cross-surface cases assert the deep-link contract — failures
+ * there are the regression this test exists to catch.
+ */
+import { encode as qssEncode } from 'qss';
+import { decode as overlayDecode } from '../../../src/instant-search/external/query-string-decode';
+import { RELEVANCE_SORT_KEY, VALID_SORT_KEYS } from '../../../src/instant-search/lib/constants';
+import { getFilterKeys } from '../../../src/instant-search/lib/filters';
+import { stateToUrlParams, urlParamsToState } from '../../../src/search-blocks/store/url-state';
+
+// Filter configs the blocks-side parser uses to gate which array params
+// are recognized as filters. These mirror the keys the overlay knows
+// about so both sides accept the same vocabulary in this test.
+const FILTER_CONFIGS = {
+	category: { filterType: 'taxonomy', taxonomy: 'category' },
+	post_tag: { filterType: 'taxonomy', taxonomy: 'post_tag' },
+	post_types: { filterType: 'post_type' },
+	authors: { filterType: 'author' },
+};
+
+/**
+ * Serialize state to an overlay-emitted URL search string. Mirrors the
+ * wire format produced by `instant-search/lib/query-string.js#setQuery`
+ * combined with the SET_SEARCH_QUERY / SET_SORT / SET_FILTER effects.
+ *
+ * @param {{ searchQuery: string, sortOrder: string, activeFilters: object }} state - Search state.
+ * @return {string} URL search string, no leading `?`.
+ */
+function overlaySerialize( {
+	searchQuery = '',
+	sortOrder = RELEVANCE_SORT_KEY,
+	activeFilters = {},
+} ) {
+	const queryObject = { s: searchQuery };
+	if ( VALID_SORT_KEYS.includes( sortOrder ) ) {
+		// effects.js#updateSortQueryString writes `sort=` for any valid
+		// key, including the relevance default — preserve that here so
+		// fixtures with an explicit `relevance` round-trip cleanly.
+		queryObject.sort = sortOrder;
+	}
+	for ( const [ key, values ] of Object.entries( activeFilters ) ) {
+		if ( ! Array.isArray( values ) || values.length === 0 ) {
+			continue;
+		}
+		// qss emits a single value as `key=v` and an array as `key=v1&key=v2`,
+		// so collapse singletons to a string to match the production path
+		// where the reducer's value can be either shape.
+		queryObject[ key ] = values.length === 1 ? values[ 0 ] : values;
+	}
+	return qssEncode( queryObject );
+}
+
+/**
+ * Deserialize an overlay-emitted URL search string back to state.
+ * Mirrors `effects.js#initializeQueryValues` against the canonical
+ * filter-key list returned by `getFilterKeys()`.
+ *
+ * @param {string} searchString - URL search string, no leading `?`.
+ * @return {{ searchQuery: string, sortOrder: string, activeFilters: object }} Search state.
+ */
+function overlayDeserialize( searchString ) {
+	const queryObject = overlayDecode( searchString, false, false );
+	const activeFilters = {};
+	for ( const filterKey of getFilterKeys() ) {
+		if ( ! ( filterKey in queryObject ) ) {
+			continue;
+		}
+		const value = queryObject[ filterKey ];
+		// The reducer wraps a string value in a singleton array and
+		// passes an array through unchanged — match that shape here.
+		activeFilters[ filterKey ] = typeof value === 'string' ? [ value ] : [ ...value ];
+	}
+	return {
+		searchQuery: typeof queryObject.s === 'string' ? queryObject.s : '',
+		sortOrder: VALID_SORT_KEYS.includes( queryObject.sort ) ? queryObject.sort : RELEVANCE_SORT_KEY,
+		activeFilters,
+	};
+}
+
+/**
+ * Serialize state to a blocks-emitted URL search string.
+ *
+ * @param {{ searchQuery: string, sortOrder: string, activeFilters: object }} state - Search state.
+ * @return {string} URL search string, no leading `?`.
+ */
+function blocksSerialize( state ) {
+	return stateToUrlParams( state ).toString();
+}
+
+/**
+ * Deserialize a blocks-emitted URL search string back to state.
+ *
+ * @param {string} searchString - URL search string, no leading `?`.
+ * @return {{ searchQuery: string, sortOrder: string, activeFilters: object }} Search state.
+ */
+function blocksDeserialize( searchString ) {
+	return urlParamsToState( new URLSearchParams( searchString ), FILTER_CONFIGS );
+}
+
+const FIXTURES = [
+	{
+		name: 'plain search query, default sort, no filters',
+		state: {
+			searchQuery: 'boots',
+			sortOrder: 'relevance',
+			activeFilters: {},
+		},
+	},
+	{
+		name: 'search query with non-default sort',
+		state: {
+			searchQuery: 'jacket',
+			sortOrder: 'newest',
+			activeFilters: {},
+		},
+	},
+	{
+		name: 'multi-value built-in taxonomy filter',
+		state: {
+			searchQuery: 'tomatoes',
+			sortOrder: 'relevance',
+			activeFilters: { category: [ 'recipes', 'gardening' ] },
+		},
+	},
+	{
+		name: 'taxonomy + post_type + author selections, oldest sort',
+		state: {
+			searchQuery: 'release notes',
+			sortOrder: 'oldest',
+			activeFilters: {
+				category: [ 'announcements' ],
+				post_types: [ 'post', 'page' ],
+				authors: [ '12' ],
+			},
+		},
+	},
+];
+
+describe.each( FIXTURES )( 'deep-link round trip — $name', ( { state } ) => {
+	test( 'blocks → blocks (intra-surface anchor)', () => {
+		expect( blocksDeserialize( blocksSerialize( state ) ) ).toEqual( state );
+	} );
+
+	test( 'overlay → overlay (intra-surface anchor)', () => {
+		expect( overlayDeserialize( overlaySerialize( state ) ) ).toEqual( state );
+	} );
+
+	// The two cross-surface cases below currently fail because the
+	// formats have diverged on three independent axes — see RSM-1928:
+	//   - sort key name: overlay writes `sort=`, blocks expect `orderby=`.
+	//   - filter key shape: overlay writes flat `category=news&category=sports`;
+	//     blocks emit and only recognize bracketed `category[]=...`.
+	//   - search-query encoding: blocks rely on URLSearchParams' form-urlencoded
+	//     `+` for spaces; the overlay's qss-based decoder leaves `+` literal.
+	//
+	// Per RSM-1923, this test exists to flag the regression rather than
+	// to paper over it — the failing assertions describe the contract we
+	// expect to hold once the formats are unified. Skipped (not deleted)
+	// so flipping `.skip` off becomes the regression check the day the
+	// fix in RSM-1928 lands.
+	// eslint-disable-next-line jest/no-disabled-tests
+	test.skip( 'overlay-emitted URL → blocks-parsed state', () => {
+		expect( blocksDeserialize( overlaySerialize( state ) ) ).toEqual( state );
+	} );
+
+	// eslint-disable-next-line jest/no-disabled-tests
+	test.skip( 'blocks-emitted URL → overlay-parsed state', () => {
+		expect( overlayDeserialize( blocksSerialize( state ) ) ).toEqual( state );
+	} );
+} );
+
+// TODO(RSM-1923): once `search-blocks/blocks/filter-date/` ships a
+// date-filter block, append a fixture covering the date-histogram URL
+// keys (`month_post_date`, `year_post_date`, …) so the contract is
+// exercised across that surface too. The block does not exist in this
+// tree yet, so the case is omitted rather than asserted on a half-built
+// API.

--- a/projects/packages/search/tests/js/search-blocks/deeplink-roundtrip.test.js
+++ b/projects/packages/search/tests/js/search-blocks/deeplink-roundtrip.test.js
@@ -28,12 +28,12 @@ import { RELEVANCE_SORT_KEY, VALID_SORT_KEYS } from '../../../src/instant-search
 import { getFilterKeys } from '../../../src/instant-search/lib/filters';
 import { stateToUrlParams, urlParamsToState } from '../../../src/search-blocks/store/url-state';
 
-// Filter configs the blocks-side parser uses to gate which array params
-// are recognized as filters. These mirror the keys the overlay knows
-// about so both sides accept the same vocabulary in this test.
+// A representative subset of the filter keys both sides know about;
+// sufficient to cover the fixtures below. `urlParamsToState` only checks
+// `filterKey in filterConfigs` (it never reads the values), so the
+// `filterType` / `taxonomy` shape here is documentation, not behavior.
 const FILTER_CONFIGS = {
 	category: { filterType: 'taxonomy', taxonomy: 'category' },
-	post_tag: { filterType: 'taxonomy', taxonomy: 'post_tag' },
 	post_types: { filterType: 'post_type' },
 	authors: { filterType: 'author' },
 };
@@ -73,15 +73,17 @@ function overlaySerialize( {
 /**
  * Deserialize an overlay-emitted URL search string back to state.
  * Mirrors `effects.js#initializeQueryValues` against the canonical
- * filter-key list returned by `getFilterKeys()`.
+ * filter-key list. `getFilterKeys` is called with explicit empty widget
+ * lists so the helper is independent of any stray
+ * `window.JetpackInstantSearchOptions` a future test setup might seed.
  *
  * @param {string} searchString - URL search string, no leading `?`.
- * @return {{ searchQuery: string, sortOrder: string, activeFilters: object }} Search state.
+ * @return {{ searchQuery: string, sortOrder: string, activeFilters: object, priceRange: null }} Search state.
  */
 function overlayDeserialize( searchString ) {
 	const queryObject = overlayDecode( searchString, false, false );
 	const activeFilters = {};
-	for ( const filterKey of getFilterKeys() ) {
+	for ( const filterKey of getFilterKeys( [], [] ) ) {
 		if ( ! ( filterKey in queryObject ) ) {
 			continue;
 		}
@@ -94,6 +96,13 @@ function overlayDeserialize( searchString ) {
 		searchQuery: typeof queryObject.s === 'string' ? queryObject.s : '',
 		sortOrder: VALID_SORT_KEYS.includes( queryObject.sort ) ? queryObject.sort : RELEVANCE_SORT_KEY,
 		activeFilters,
+		// The overlay URL format has no concept of price range; surface
+		// the field anyway so the state shape lines up with the blocks
+		// side's `urlParamsToState` for round-trip equality. A blocks
+		// URL carrying `min_price` / `max_price` would lose those bounds
+		// when round-tripped through the overlay — covered as part of
+		// the cross-surface skips tracked in RSM-1928.
+		priceRange: null,
 	};
 }
 
@@ -117,6 +126,11 @@ function blocksDeserialize( searchString ) {
 	return urlParamsToState( new URLSearchParams( searchString ), FILTER_CONFIGS );
 }
 
+// `priceRange: null` is set on every fixture below to match the blocks
+// state shape that `urlParamsToState` returns; none of these fixtures
+// exercises the price-range bound. A dedicated price-range fixture is
+// out of scope here because the overlay format has no encoding for
+// price range — see TODO at end of file.
 const FIXTURES = [
 	{
 		name: 'plain search query, default sort, no filters',
@@ -124,6 +138,7 @@ const FIXTURES = [
 			searchQuery: 'boots',
 			sortOrder: 'relevance',
 			activeFilters: {},
+			priceRange: null,
 		},
 	},
 	{
@@ -132,6 +147,7 @@ const FIXTURES = [
 			searchQuery: 'jacket',
 			sortOrder: 'newest',
 			activeFilters: {},
+			priceRange: null,
 		},
 	},
 	{
@@ -140,6 +156,7 @@ const FIXTURES = [
 			searchQuery: 'tomatoes',
 			sortOrder: 'relevance',
 			activeFilters: { category: [ 'recipes', 'gardening' ] },
+			priceRange: null,
 		},
 	},
 	{
@@ -152,6 +169,7 @@ const FIXTURES = [
 				post_types: [ 'post', 'page' ],
 				authors: [ '12' ],
 			},
+			priceRange: null,
 		},
 	},
 ];
@@ -189,9 +207,11 @@ describe.each( FIXTURES )( 'deep-link round trip — $name', ( { state } ) => {
 	} );
 } );
 
-// TODO(RSM-1923): once `search-blocks/blocks/filter-date/` ships a
-// date-filter block, append a fixture covering the date-histogram URL
-// keys (`month_post_date`, `year_post_date`, …) so the contract is
-// exercised across that surface too. The block does not exist in this
-// tree yet, so the case is omitted rather than asserted on a half-built
-// API.
+// TODO(RSM-1923): append fixtures for any filter type that has yet to
+// land at the time the parallel work concludes:
+//   - date histogram (`month_post_date`, `year_post_date`, …) once the
+//     `search-blocks/blocks/filter-date/` block ships.
+//   - price range (`min_price` / `max_price`) once both surfaces share
+//     a contract for it; today only the blocks side knows about it,
+//     and the overlay format has no encoding for the bound.
+// Each is omitted rather than asserted on a half-built API.


### PR DESCRIPTION
Fixes #

## Proposed changes

* Add a Jest test file (`projects/packages/search/tests/js/search-blocks/deeplink-roundtrip.test.js`) that round-trips representative search states through both the legacy instant-search overlay serializer and the search-blocks `stateToUrlParams` / `urlParamsToState`, in both directions.
* Four representative fixtures cover plain queries, non-default sort, multi-value taxonomy filters, and combined taxonomy + post_type + author selections.
* Intra-surface anchors (overlay → overlay, blocks → blocks) pass on both sides — they pin each side's serializer/parser pair to the production code.
* Cross-surface assertions are `test.skip(...)`-ped pending **[RSM-1928](https://linear.app/a8c/issue/RSM-1928/search-30-overlayblocks-deep-link-url-formats-are-incompatible)** because the two formats have diverged on three independent axes (see Findings below). Skipped — not deleted — so flipping `.skip` off becomes the regression check the day the fix lands.
* `TODO(RSM-1923)` left for a future date-filter fixture once the search-blocks `filter-date` block ships (the block does not exist in this tree yet).
* Production code is unchanged. This PR is test-only.

## Findings — overlay/blocks deep-link divergence (filed as RSM-1928)

Running the test with the four cross-surface skips flipped to `test(...)` produces 6 failures across 4 fixtures, on three independent axes:

1. **Sort key name.** The overlay writes `?sort=newest` (`instant-search/store/effects.js#updateSortQueryString`); the blocks side writes `?orderby=newest` and only reads `orderby` (`search-blocks/store/url-state.js`). A non-default sort silently collapses to the `relevance` default when crossed.
2. **Filter key shape.** The overlay writes filter values as flat repeated keys (`?category=news&category=sports`, `qss.encode` of an array — no brackets). The blocks side serializes as bracketed array params (`?category[]=news&category[]=sports`) and only treats keys ending in `[]` as filters. As a result, `activeFilters` ends up empty when crossed in either direction.
3. **Search-query encoding.** The blocks side uses `URLSearchParams`, which form-urlencodes spaces as `+`. The overlay's `qss`-based decoder does not treat `+` as a space, so `'release notes'` round-trips as `'release+notes'` on the overlay side.

A note in `search-blocks/store/url-state.js` (lines 13–15) currently asserts that the blocks format matches the overlay; the test data shows that comment is no longer accurate. Tracked in **[RSM-1928](https://linear.app/a8c/issue/RSM-1928/search-30-overlayblocks-deep-link-url-formats-are-incompatible)**.

## Related product discussion/links

* Linear: [RSM-1923 — Search 3.0: regression test that deep links round-trip between overlay and blocks](https://linear.app/a8c/issue/RSM-1923/search-30-regression-test-that-deep-links-round-trip-between-overlay)
* Follow-up bug: [RSM-1928 — Search 3.0: overlay/blocks deep-link URL formats are incompatible](https://linear.app/a8c/issue/RSM-1928/search-30-overlayblocks-deep-link-url-formats-are-incompatible)

## Does this pull request change what data or activity we track or use?

No. Test-only addition; no production code paths touched.

## Testing instructions

Test-only change — no browser or live-WP verification required.

* Run the new test:
  ```
  cd projects/packages/search
  pnpm jest tests/js/search-blocks/deeplink-roundtrip.test.js
  ```
  Expected: `8 passed, 8 skipped, 16 total`.
* Run the full Search JS suite to confirm nothing else regressed:
  ```
  jp test js packages/search --verbose
  ```
  Expected: `test-scripts` passes, `test-url-tests` passes, `test-size` passes.
* (Optional) To reproduce the divergence captured by RSM-1928, flip the four `test.skip(...)` calls in `deeplink-roundtrip.test.js` to `test(...)` and re-run. Six of the eight cross-surface assertions will fail along the three axes listed under **Findings**.
