### PR TITLE
Search: human-readable active-filter pills + label-aware alpha bucket sort

### DIFF
--- a/projects/packages/search/changelog/fix-rsm-1922-pill-labels-alpha-sort
+++ b/projects/packages/search/changelog/fix-rsm-1922-pill-labels-alpha-sort
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks: render human-readable labels in active-filter pills and resort `bucketSortOrder=alpha` filter lists by visible label client-side.

--- a/projects/packages/search/src/search-blocks/blocks/active-filters/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/active-filters/view.js
@@ -1,14 +1,14 @@
 import { store, getContext } from '@wordpress/interactivity';
 import { formatDateBucketLabel } from '../../store/api';
 import '../../store';
+import { bucketLabel, bucketValue } from '../../store/bucket-key';
 import './style.scss';
 
 const NAMESPACE = 'jetpack-search';
 
 /**
  * Resolve the display label for a selected filter value. Falls back to the
- * raw slug so a pill doesn't disappear when its bucket falls out of the
- * top-N between queries.
+ * raw slug so a pill stays readable when its bucket falls out of the top-N.
  *
  * @param {object} state       - Store state.
  * @param {string} filterKey   - Filter key.
@@ -21,14 +21,15 @@ function resolveValueLabel( state, filterKey, filterValue ) {
 		const interval = config.interval === 'month' ? 'month' : 'year';
 		return formatDateBucketLabel( filterValue, interval, state.locale || 'en-US' );
 	}
+	const fromConfig = config.valueLabels?.[ filterValue ];
+	if ( fromConfig ) {
+		return fromConfig;
+	}
 	const buckets = state.aggregations?.[ filterKey ]?.buckets;
 	if ( Array.isArray( buckets ) ) {
 		for ( const bucket of buckets ) {
-			const key = String( bucket.key ?? '' );
-			const slashIdx = key.indexOf( '/' );
-			const slug = slashIdx === -1 ? key : key.slice( 0, slashIdx );
-			if ( slug === filterValue ) {
-				return slashIdx === -1 ? key : key.slice( slashIdx + 1 );
+			if ( bucketValue( bucket.key ) === filterValue ) {
+				return bucketLabel( bucket.key, config.valueLabels );
 			}
 		}
 	}
@@ -38,19 +39,11 @@ function resolveValueLabel( state, filterKey, filterValue ) {
 store( NAMESPACE, {
 	state: {
 		/**
-		 * Flatten activeFilters into a list of pill descriptors for
-		 * `data-wp-each`. Pills carry their own filterKey + value so the
-		 * remove handler can toggle the correct selection without looking
-		 * it up from the event target.
+		 * Pill descriptors for `data-wp-each`. `ariaLabel` uses the "Remove %s"
+		 * format seeded from PHP because the view bundle cannot import
+		 * `@wordpress/i18n`.
 		 *
-		 * `ariaLabel` is what screen readers announce — the visible "×" is
-		 * aria-hidden, and the visible label alone ("Category: news") reads
-		 * as a plain noun phrase with no hint that activating the button
-		 * removes the filter. The "Remove %s" format is seeded in PHP via
-		 * `Search_Blocks::build_initial_strings()` because the view bundle
-		 * can't import `@wordpress/i18n`.
-		 *
-		 * @return {Array<object>} Array of pill descriptors with id, filterKey, value, label, ariaLabel.
+		 * @return {Array<object>} Pill descriptors.
 		 */
 		get activePills() {
 			const { state } = store( NAMESPACE );
@@ -79,8 +72,7 @@ store( NAMESPACE, {
 
 	actions: {
 		/**
-		 * Remove the pill currently in `data-wp-each` scope by toggling its
-		 * filter value off.
+		 * Remove the pill currently in `data-wp-each` scope.
 		 *
 		 * @yield {Promise} setFilter action.
 		 */

--- a/projects/packages/search/src/search-blocks/blocks/active-filters/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/active-filters/view.js
@@ -29,7 +29,9 @@ function resolveValueLabel( state, filterKey, filterValue ) {
 	if ( Array.isArray( buckets ) ) {
 		for ( const bucket of buckets ) {
 			if ( bucketValue( bucket.key ) === filterValue ) {
-				return bucketLabel( bucket.key, config.valueLabels );
+				// `valueLabels` already missed above; only the post-slash
+				// split is meaningful at this branch.
+				return bucketLabel( bucket.key );
 			}
 		}
 	}

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/class-filter-checkbox.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/class-filter-checkbox.php
@@ -100,12 +100,11 @@ class Filter_Checkbox {
 			'maxItems'        => max( 1, (int) ( $attributes['maxItems'] ?? 10 ) ),
 			'bucketSortOrder' => static::normalize_bucket_sort_order( $attributes['bucketSortOrder'] ?? null ),
 			// Pre-resolved value→label map used by the active-filters pill list
-			// and the checkbox list to render human-readable labels. Taxonomy
-			// and author aggregations use `slug_slash_name` fields, so each
-			// bucket key already carries both pieces — JS post-slash-splits at
-			// render time. Post-type buckets are bare slugs (`post`, `page`),
-			// so without a lookup the pill would read "post" instead of
-			// "Posts"; we seed the singular_name labels here.
+			// and the checkbox list. Taxonomy and author aggregations use
+			// `slug_slash_name` keys, so the bucket already carries the label
+			// — JS post-slash-splits at render time. Post-type buckets are
+			// bare slugs (`post`, `page`), so without a lookup the pill would
+			// read "post" instead of "Post"; we seed the singular_name here.
 			'valueLabels'     => static::build_value_labels( $filter_type ),
 		);
 	}

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/class-filter-checkbox.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/class-filter-checkbox.php
@@ -119,7 +119,7 @@ class Filter_Checkbox {
 	 * @return array<string, string>
 	 */
 	protected static function build_value_labels( string $filter_type ): array {
-		if ( 'post_type' !== $filter_type || ! function_exists( 'get_post_types' ) ) {
+		if ( 'post_type' !== $filter_type ) {
 			return array();
 		}
 		$labels = array();
@@ -127,7 +127,10 @@ class Filter_Checkbox {
 		// only ones whose buckets can land in `post_types` aggregations.
 		$objects = get_post_types( array( 'exclude_from_search' => false ), 'objects' );
 		foreach ( $objects as $slug => $object ) {
-			$singular = isset( $object->labels->singular_name ) ? (string) $object->labels->singular_name : '';
+			// `singular_name` is plugin/theme-supplied via register_post_type();
+			// run it through the same sanitizer as the block's `label` attribute
+			// so stray HTML or whitespace can never reach the rendered pill.
+			$singular = sanitize_text_field( (string) ( $object->labels->singular_name ?? '' ) );
 			if ( '' !== $singular ) {
 				$labels[ (string) $slug ] = $singular;
 			}

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/class-filter-checkbox.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/class-filter-checkbox.php
@@ -84,6 +84,8 @@ class Filter_Checkbox {
 	 * @return array<string, mixed>
 	 */
 	public static function build_config( array $attributes, string $filter_key ): array {
+		$filter_type = (string) ( $attributes['filterType'] ?? '' );
+
 		$label = sanitize_text_field( (string) ( $attributes['label'] ?? '' ) );
 		if ( '' === $label ) {
 			$label = static::default_label( $attributes );
@@ -91,13 +93,46 @@ class Filter_Checkbox {
 
 		return array(
 			'filterKey'       => $filter_key,
-			'filterType'      => (string) ( $attributes['filterType'] ?? '' ),
+			'filterType'      => $filter_type,
 			'taxonomy'        => sanitize_key( (string) ( $attributes['taxonomy'] ?? '' ) ),
 			'label'           => $label,
 			'showCount'       => (bool) ( $attributes['showCount'] ?? true ),
 			'maxItems'        => max( 1, (int) ( $attributes['maxItems'] ?? 10 ) ),
 			'bucketSortOrder' => static::normalize_bucket_sort_order( $attributes['bucketSortOrder'] ?? null ),
+			// Pre-resolved value→label map used by the active-filters pill list
+			// and the checkbox list to render human-readable labels. Taxonomy
+			// and author aggregations use `slug_slash_name` fields, so each
+			// bucket key already carries both pieces — JS post-slash-splits at
+			// render time. Post-type buckets are bare slugs (`post`, `page`),
+			// so without a lookup the pill would read "post" instead of
+			// "Posts"; we seed the singular_name labels here.
+			'valueLabels'     => static::build_value_labels( $filter_type ),
 		);
+	}
+
+	/**
+	 * Build the value→label map for filter types whose aggregation buckets
+	 * don't carry a display name. Returns an empty array for taxonomy and
+	 * author filters because their `slug_slash_name` buckets already do.
+	 *
+	 * @param string $filter_type Block `filterType` attribute.
+	 * @return array<string, string>
+	 */
+	protected static function build_value_labels( string $filter_type ): array {
+		if ( 'post_type' !== $filter_type || ! function_exists( 'get_post_types' ) ) {
+			return array();
+		}
+		$labels = array();
+		// Match the aggregation scope: post types that opt into search are the
+		// only ones whose buckets can land in `post_types` aggregations.
+		$objects = get_post_types( array( 'exclude_from_search' => false ), 'objects' );
+		foreach ( $objects as $slug => $object ) {
+			$singular = isset( $object->labels->singular_name ) ? (string) $object->labels->singular_name : '';
+			if ( '' !== $singular ) {
+				$labels[ (string) $slug ] = $singular;
+			}
+		}
+		return $labels;
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/store/api.js
+++ b/projects/packages/search/src/search-blocks/store/api.js
@@ -169,13 +169,12 @@ export const WC_RATING_RANGES = [
  * Build ES aggregation requests from the filterConfigs registered by each
  * filter block's render.php.
  *
- * `terms` for filter-checkbox: `bucketSortOrder` maps to the ES order
- * clause. `alpha` sorts by `slug_slash_name` — close enough for built-in
- * variations without a label-aware resort.
+ * `terms` for filter-checkbox: `alpha` → `_key: asc` is just a hint; the
+ * shared store's `checkboxFilterItems` resorts by visible label so slug
+ * and display name can diverge (e.g. `food-news` → "Restaurant Reviews").
  *
  * `date_histogram` for filter-date: format request makes `key_as_string`
- * match the URL slug. No `size` parameter on date_histogram; the client
- * slices to `maxItems`.
+ * match the URL slug. No `size`; the client slices to `maxItems`.
  *
  * @param {object} filterConfigs - { [filterKey]: FilterConfig } map.
  * @return {object} Aggregations payload for the v1.3 search API.

--- a/projects/packages/search/src/search-blocks/store/bucket-key.js
+++ b/projects/packages/search/src/search-blocks/store/bucket-key.js
@@ -1,0 +1,36 @@
+/**
+ * Bucket-key helpers shared by filter-checkbox and active-filters so the two
+ * surfaces never disagree on how a bucket is labelled.
+ */
+
+/**
+ * Slug for an aggregation bucket key.
+ *
+ * @param {unknown} rawKey - Bucket `key` from the search response.
+ * @return {string} Slug.
+ */
+export function bucketValue( rawKey ) {
+	const key = String( rawKey ?? '' );
+	const slashIdx = key.indexOf( '/' );
+	return slashIdx === -1 ? key : key.slice( 0, slashIdx );
+}
+
+/**
+ * Display label for a bucket. `valueLabels[slug]` wins (covers post_type
+ * buckets whose key is just the slug); else the post-slash portion of a
+ * `slug/Name` key; else the slug itself.
+ *
+ * @param {unknown}                               rawKey      - Bucket `key`.
+ * @param {Object<string, string>|null|undefined} valueLabels - Optional slug→label map.
+ * @return {string} Display label.
+ */
+export function bucketLabel( rawKey, valueLabels ) {
+	const key = String( rawKey ?? '' );
+	const slashIdx = key.indexOf( '/' );
+	const value = slashIdx === -1 ? key : key.slice( 0, slashIdx );
+	const fromConfig = valueLabels?.[ value ];
+	if ( fromConfig ) {
+		return fromConfig;
+	}
+	return slashIdx === -1 ? key : key.slice( slashIdx + 1 );
+}

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -4,6 +4,7 @@ import {
 	withSyncEvent as originalWithSyncEvent,
 } from '@wordpress/interactivity';
 import { buildSearchUrl, formatDateBucketLabel } from './api';
+import { bucketLabel, bucketValue } from './bucket-key';
 import { isEventInsidePopoverRoot } from './popover-events';
 import { countActiveFilters, normalizeResult } from './result-utils';
 import {
@@ -55,22 +56,6 @@ export function gateActiveFilters( activeFilters, filterConfigs ) {
 }
 
 /**
- * Parse a `slug/Display Name` bucket key. Plain (no-slash) keys round-trip
- * as { value: key, label: key }.
- *
- * @param {unknown} rawKey - Bucket key from the search response.
- * @return {{ value: string, label: string }} Parsed value and label.
- */
-function parseSlashBucketKey( rawKey ) {
-	const key = String( rawKey ?? '' );
-	const slashIdx = key.indexOf( '/' );
-	if ( slashIdx === -1 ) {
-		return { value: key, label: key };
-	}
-	return { value: key.slice( 0, slashIdx ), label: key.slice( slashIdx + 1 ) };
-}
-
-/**
  * Slug for a date_histogram bucket. Falls back to the numeric key when
  * `key_as_string` is missing.
  *
@@ -88,6 +73,8 @@ function dateBucketSlug( bucket ) {
 /**
  * filterItems for a `slash`-format filter (taxonomy, post_type, author).
  * Drops selected buckets — those appear in the active-filters block.
+ * Resorts by visible label when `bucketSortOrder === 'alpha'` since the
+ * ES `_key: asc` order is by slug, not display label.
  *
  * @param {object} sharedState - Live store state.
  * @param {string} filterKey   - Filter key.
@@ -101,19 +88,25 @@ function checkboxFilterItems( sharedState, filterKey, config ) {
 	}
 	const selected = sharedState.activeFilters?.[ filterKey ] ?? [];
 	const showCount = config.showCount !== false;
-	return buckets.reduce( ( items, bucket ) => {
-		const { value, label } = parseSlashBucketKey( bucket.key );
+	const valueLabels = config.valueLabels;
+	const items = buckets.reduce( ( acc, bucket ) => {
+		const value = bucketValue( bucket.key );
 		if ( selected.includes( value ) ) {
-			return items;
+			return acc;
 		}
-		items.push( {
+		acc.push( {
 			value,
-			label,
+			label: bucketLabel( bucket.key, valueLabels ),
 			showCount,
 			countLabel: String( bucket.doc_count ?? 0 ),
 		} );
-		return items;
+		return acc;
 	}, [] );
+	if ( config.bucketSortOrder === 'alpha' ) {
+		const locale = sharedState.locale || 'en-US';
+		items.sort( ( a, b ) => a.label.localeCompare( b.label, locale, { sensitivity: 'base' } ) );
+	}
+	return items;
 }
 
 /**
@@ -412,10 +405,7 @@ const { state, actions } = store( NAMESPACE, {
 				}
 				return populated.every( bucket => selected.includes( dateBucketSlug( bucket ) ) );
 			}
-			return buckets.every( bucket => {
-				const { value } = parseSlashBucketKey( bucket.key );
-				return selected.includes( value );
-			} );
+			return buckets.every( bucket => selected.includes( bucketValue( bucket.key ) ) );
 		},
 
 		/**

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -71,7 +71,8 @@ function dateBucketSlug( bucket ) {
 }
 
 /**
- * filterItems for a `slash`-format filter (taxonomy, post_type, author).
+ * filterItems for non-date filters. Handles both `slug/Name` keys (taxonomy,
+ * author) and bare-slug keys (post_type) via `bucketLabel`/`bucketValue`.
  * Drops selected buckets — those appear in the active-filters block.
  * Resorts by visible label when `bucketSortOrder === 'alpha'` since the
  * ES `_key: asc` order is by slug, not display label.

--- a/projects/packages/search/tests/js/search-blocks/active-filters-view.test.js
+++ b/projects/packages/search/tests/js/search-blocks/active-filters-view.test.js
@@ -1,0 +1,111 @@
+// `@wordpress/interactivity` is an externalized dep — mock virtually so the
+// view.js file can be required and its getters / actions captured.
+const captured = {
+	state: {},
+	actions: {},
+};
+const contextRef = { current: { pill: null } };
+
+jest.mock(
+	'@wordpress/interactivity',
+	() => ( {
+		store: ( _namespace, config ) => {
+			if ( config ) {
+				const descriptors = Object.getOwnPropertyDescriptors( config.state || {} );
+				for ( const key of Object.keys( descriptors ) ) {
+					const descriptor = descriptors[ key ];
+					if ( typeof descriptor.get === 'function' ) {
+						Object.defineProperty( captured.state, key, descriptor );
+					} else {
+						captured.state[ key ] = descriptor.value;
+					}
+				}
+				Object.assign( captured.actions, config.actions || {} );
+			}
+			return { state: captured.state, actions: captured.actions };
+		},
+		getContext: () => contextRef.current,
+	} ),
+	{ virtual: true }
+);
+
+jest.mock( '../../../src/search-blocks/store', () => ( {} ), { virtual: true } );
+jest.mock( '../../../src/search-blocks/blocks/active-filters/style.scss', () => ( {} ), {
+	virtual: true,
+} );
+
+require( '../../../src/search-blocks/blocks/active-filters/view' );
+
+describe( 'active-filters view store — activePills label resolution', () => {
+	beforeEach( () => {
+		captured.state.activeFilters = {};
+		captured.state.aggregations = {};
+		captured.state.filterConfigs = {};
+		captured.state.strings = { removeFilter: 'Remove %s' };
+		contextRef.current = { pill: null };
+	} );
+
+	it( 'renders taxonomy/author labels via post-slash split of slug_slash_name buckets', () => {
+		captured.state.activeFilters = {
+			category: [ 'news' ],
+			authors: [ 'sarach' ],
+		};
+		captured.state.aggregations = {
+			category: { buckets: [ { key: 'news/News' } ] },
+			authors: { buckets: [ { key: 'sarach/Sarah Chen' } ] },
+		};
+		captured.state.filterConfigs = {
+			category: { label: 'Category', valueLabels: {} },
+			authors: { label: 'Author', valueLabels: {} },
+		};
+		const labels = captured.state.activePills.map( p => p.label );
+		expect( labels ).toEqual( [ 'Category: News', 'Author: Sarah Chen' ] );
+	} );
+
+	it( 'renders post_type labels via the filterConfig valueLabels map', () => {
+		captured.state.activeFilters = { post_types: [ 'post', 'page' ] };
+		captured.state.aggregations = {
+			post_types: { buckets: [ { key: 'post' }, { key: 'page' } ] },
+		};
+		captured.state.filterConfigs = {
+			post_types: {
+				label: 'Post Type',
+				valueLabels: { post: 'Post', page: 'Page' },
+			},
+		};
+		const labels = captured.state.activePills.map( p => p.label );
+		expect( labels ).toEqual( [ 'Post Type: Post', 'Post Type: Page' ] );
+	} );
+
+	it( 'falls back to the slug when no bucket matches and no valueLabels entry exists', () => {
+		// Selected value has dropped out of the top-N agg buckets; the pill
+		// must still render rather than blanking, even without a label.
+		captured.state.activeFilters = { category: [ 'news' ] };
+		captured.state.aggregations = { category: { buckets: [] } };
+		captured.state.filterConfigs = { category: { label: 'Category' } };
+		expect( captured.state.activePills[ 0 ].label ).toBe( 'Category: news' );
+	} );
+
+	it( 'prefers valueLabels over the matching bucket label', () => {
+		// Future filter types (e.g. filter-date, RSM-1921) will seed
+		// valueLabels with the formatted display string the block built. Even
+		// if a matching bucket exists, the config-supplied label wins.
+		captured.state.activeFilters = { post_types: [ 'attachment' ] };
+		captured.state.aggregations = { post_types: { buckets: [ { key: 'attachment' } ] } };
+		captured.state.filterConfigs = {
+			post_types: {
+				label: 'Post Type',
+				valueLabels: { attachment: 'Media file' },
+			},
+		};
+		expect( captured.state.activePills[ 0 ].label ).toBe( 'Post Type: Media file' );
+	} );
+
+	it( 'uses removeFilter format string for the aria-label', () => {
+		captured.state.strings.removeFilter = 'Remove %s filter';
+		captured.state.activeFilters = { category: [ 'news' ] };
+		captured.state.aggregations = { category: { buckets: [ { key: 'news/News' } ] } };
+		captured.state.filterConfigs = { category: { label: 'Category', valueLabels: {} } };
+		expect( captured.state.activePills[ 0 ].ariaLabel ).toBe( 'Remove Category: News filter' );
+	} );
+} );

--- a/projects/packages/search/tests/js/search-blocks/filter-checkbox-view.test.js
+++ b/projects/packages/search/tests/js/search-blocks/filter-checkbox-view.test.js
@@ -1,0 +1,187 @@
+// `@wordpress/interactivity` is an externalized dep — mock virtually so the
+// view.js file can be required and its getters / actions captured.
+const captured = {
+	state: {},
+	actions: {},
+};
+const contextRef = { current: { filterKey: '' } };
+
+jest.mock(
+	'@wordpress/interactivity',
+	() => ( {
+		store: ( _namespace, config ) => {
+			if ( config ) {
+				const descriptors = Object.getOwnPropertyDescriptors( config.state || {} );
+				for ( const key of Object.keys( descriptors ) ) {
+					const descriptor = descriptors[ key ];
+					if ( typeof descriptor.get === 'function' ) {
+						Object.defineProperty( captured.state, key, descriptor );
+					} else {
+						captured.state[ key ] = descriptor.value;
+					}
+				}
+				Object.assign( captured.actions, config.actions || {} );
+			}
+			return { state: captured.state, actions: captured.actions };
+		},
+		getContext: () => contextRef.current,
+	} ),
+	{ virtual: true }
+);
+
+require( '../../../src/search-blocks/store' );
+
+describe( 'filter-checkbox view store — filterItems', () => {
+	beforeEach( () => {
+		captured.state.activeFilters = {};
+		captured.state.aggregations = {};
+		captured.state.filterConfigs = {};
+		captured.state.locale = 'en-US';
+		contextRef.current = { filterKey: '' };
+	} );
+
+	it( 'pulls labels from filterConfig.valueLabels when bucket keys are bare slugs', () => {
+		contextRef.current = { filterKey: 'post_types' };
+		captured.state.aggregations = {
+			post_types: {
+				buckets: [
+					{ key: 'post', doc_count: 12 },
+					{ key: 'page', doc_count: 4 },
+				],
+			},
+		};
+		captured.state.filterConfigs = {
+			post_types: {
+				showCount: true,
+				bucketSortOrder: 'count',
+				valueLabels: { post: 'Post', page: 'Page' },
+			},
+		};
+		expect( captured.state.filterItems ).toEqual( [
+			{ value: 'post', label: 'Post', showCount: true, countLabel: '12' },
+			{ value: 'page', label: 'Page', showCount: true, countLabel: '4' },
+		] );
+	} );
+
+	it( 'post-slash-splits slug_slash_name bucket keys for taxonomy / author', () => {
+		contextRef.current = { filterKey: 'category' };
+		captured.state.aggregations = {
+			category: {
+				buckets: [
+					{ key: 'news/News', doc_count: 7 },
+					{ key: 'reviews/Reviews', doc_count: 3 },
+				],
+			},
+		};
+		captured.state.filterConfigs = {
+			category: { showCount: true, bucketSortOrder: 'count', valueLabels: {} },
+		};
+		const labels = captured.state.filterItems.map( i => i.label );
+		expect( labels ).toEqual( [ 'News', 'Reviews' ] );
+	} );
+
+	it( 'omits buckets already in activeFilters', () => {
+		contextRef.current = { filterKey: 'category' };
+		captured.state.activeFilters = { category: [ 'news' ] };
+		captured.state.aggregations = {
+			category: {
+				buckets: [
+					{ key: 'news/News', doc_count: 7 },
+					{ key: 'reviews/Reviews', doc_count: 3 },
+				],
+			},
+		};
+		captured.state.filterConfigs = {
+			category: { showCount: true, bucketSortOrder: 'count', valueLabels: {} },
+		};
+		expect( captured.state.filterItems.map( i => i.value ) ).toEqual( [ 'reviews' ] );
+	} );
+
+	it( 'preserves the API order when bucketSortOrder is `count`', () => {
+		contextRef.current = { filterKey: 'category' };
+		captured.state.aggregations = {
+			category: {
+				buckets: [
+					{ key: 'restaurant-reviews/Restaurant Reviews', doc_count: 9 },
+					{ key: 'food-news/Food News', doc_count: 5 },
+					{ key: 'apple-pie/Apple Pie', doc_count: 1 },
+				],
+			},
+		};
+		captured.state.filterConfigs = {
+			category: { showCount: true, bucketSortOrder: 'count', valueLabels: {} },
+		};
+		expect( captured.state.filterItems.map( i => i.label ) ).toEqual( [
+			'Restaurant Reviews',
+			'Food News',
+			'Apple Pie',
+		] );
+	} );
+
+	it( 'resorts by display label when bucketSortOrder is `alpha`', () => {
+		// `_key: asc` would sort by slug — `food-news`, `restaurant-reviews`,
+		// `zebra-archive` — placing "Restaurant Reviews" between "Apple Pie"
+		// and "Zebra Archive". Sorting by visible label puts them in true
+		// alphabetical order from the visitor's POV.
+		contextRef.current = { filterKey: 'category' };
+		captured.state.aggregations = {
+			category: {
+				buckets: [
+					{ key: 'food-news/Restaurant Reviews', doc_count: 9 },
+					{ key: 'apple-pie/Apple Pie', doc_count: 1 },
+					{ key: 'zebra-archive/Zebra Archive', doc_count: 5 },
+				],
+			},
+		};
+		captured.state.filterConfigs = {
+			category: { showCount: true, bucketSortOrder: 'alpha', valueLabels: {} },
+		};
+		expect( captured.state.filterItems.map( i => i.label ) ).toEqual( [
+			'Apple Pie',
+			'Restaurant Reviews',
+			'Zebra Archive',
+		] );
+	} );
+
+	it( 'sorts post-type items by valueLabels-derived label, not by slug', () => {
+		// Slug order would be `attachment`, `page`, `post` → "Files", "Page",
+		// "Post". Label order is the trio sorted alphabetically by visible
+		// name: "Files", "Page", "Post" — same in this case, but the test
+		// fixture uses a slug whose first letter differs from its label so
+		// the sort is provably driven by the label.
+		contextRef.current = { filterKey: 'post_types' };
+		captured.state.aggregations = {
+			post_types: {
+				buckets: [
+					{ key: 'post', doc_count: 12 },
+					{ key: 'attachment', doc_count: 8 },
+					{ key: 'page', doc_count: 4 },
+				],
+			},
+		};
+		captured.state.filterConfigs = {
+			post_types: {
+				showCount: true,
+				bucketSortOrder: 'alpha',
+				valueLabels: { post: 'Post', attachment: 'Media file', page: 'Page' },
+			},
+		};
+		expect( captured.state.filterItems.map( i => i.label ) ).toEqual( [
+			'Media file',
+			'Page',
+			'Post',
+		] );
+	} );
+
+	it( 'allBucketsSelected is true once activeFilters covers every bucket value', () => {
+		contextRef.current = { filterKey: 'post_types' };
+		captured.state.activeFilters = { post_types: [ 'post', 'page' ] };
+		captured.state.aggregations = {
+			post_types: { buckets: [ { key: 'post' }, { key: 'page' } ] },
+		};
+		expect( captured.state.allBucketsSelected ).toBe( true );
+
+		captured.state.activeFilters = { post_types: [ 'post' ] };
+		expect( captured.state.allBucketsSelected ).toBe( false );
+	} );
+} );

--- a/projects/packages/search/tests/php/Filter_Checkbox_Test.php
+++ b/projects/packages/search/tests/php/Filter_Checkbox_Test.php
@@ -181,11 +181,11 @@ class Filter_Checkbox_Test extends TestCase {
 
 	/**
 	 * Post-type filters seed a `valueLabels` map keyed by post-type slug so the
-	 * active-filter pill can render "Posts" instead of the raw `post` slug —
-	 * post-type aggregation buckets are bare slugs (no `slug_slash_name`
-	 * field), so without this map the pill has nothing else to display. Other
-	 * filter types skip the map because their `slug_slash_name` buckets carry
-	 * the label inline.
+	 * active-filter pill can render the post type's `singular_name` (e.g.
+	 * "Post Type: Post") instead of the raw `post` slug. Post-type aggregation
+	 * buckets are bare slugs with no `slug_slash_name` variant, so without
+	 * this map the pill has nothing else to display. Other filter types skip
+	 * the map because their `slug_slash_name` buckets carry the label inline.
 	 */
 	public function test_build_config_seeds_value_labels_for_post_type() {
 		register_post_type(

--- a/projects/packages/search/tests/php/Filter_Checkbox_Test.php
+++ b/projects/packages/search/tests/php/Filter_Checkbox_Test.php
@@ -144,6 +144,9 @@ class Filter_Checkbox_Test extends TestCase {
 				'showCount'       => true,
 				'maxItems'        => 10,
 				'bucketSortOrder' => 'count',
+				// Taxonomy buckets carry their label inline (slug_slash_name), so
+				// no value→label seeding is needed.
+				'valueLabels'     => array(),
 			),
 			$config
 		);
@@ -174,6 +177,50 @@ class Filter_Checkbox_Test extends TestCase {
 			'post_types'
 		);
 		$this->assertSame( 1, $clamped['maxItems'] );
+	}
+
+	/**
+	 * Post-type filters seed a `valueLabels` map keyed by post-type slug so the
+	 * active-filter pill can render "Posts" instead of the raw `post` slug —
+	 * post-type aggregation buckets are bare slugs (no `slug_slash_name`
+	 * field), so without this map the pill has nothing else to display. Other
+	 * filter types skip the map because their `slug_slash_name` buckets carry
+	 * the label inline.
+	 */
+	public function test_build_config_seeds_value_labels_for_post_type() {
+		register_post_type(
+			'rsm_book',
+			array(
+				'public'              => true,
+				'exclude_from_search' => false,
+				'labels'              => array( 'singular_name' => 'Book' ),
+			)
+		);
+
+		$config = Filter_Checkbox::build_config(
+			array( 'filterType' => 'post_type' ),
+			'post_types'
+		);
+		$this->assertArrayHasKey( 'valueLabels', $config );
+		$this->assertSame( 'Book', $config['valueLabels']['rsm_book'] ?? null );
+
+		// Taxonomy and author filters skip the map — their buckets carry labels.
+		$taxonomy_config = Filter_Checkbox::build_config(
+			array(
+				'filterType' => 'taxonomy',
+				'taxonomy'   => 'category',
+			),
+			'category'
+		);
+		$this->assertSame( array(), $taxonomy_config['valueLabels'] );
+
+		$author_config = Filter_Checkbox::build_config(
+			array( 'filterType' => 'author' ),
+			'authors'
+		);
+		$this->assertSame( array(), $author_config['valueLabels'] );
+
+		unregister_post_type( 'rsm_book' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes [RSM-1922](https://linear.app/a8c/issue/RSM-1922/search-30-active-filter-pills-show-raw-slugs-and-alphabetical-sort)

## Why

Search 3.0 active-filter pills currently render raw slugs ("Post Type: post", "Author: sarach") because the active-filters view bundle has no source of truth for human labels — taxonomy/author labels live inline in `slug_slash_name` aggregation buckets, but post_type buckets are bare slugs with nothing else to pull from. That's the visible regression in the linked Linear issue.

Two related symptoms share the same root cause: when `bucketSortOrder=alpha` is set on a filter-checkbox, the ES `_key: asc` clause sorts buckets by their stored slug, not by the visible label. For built-in variations whose slug shares a first letter with the label (`block` → "Block") this looks correct; for any case where the two diverge (slug `food-news` → "Restaurant Reviews", or any post_type/author label resolved through a separate map) the alphabetical list lands in the wrong order.

This PR adds a single `valueLabels` lookup as the front-of-the-chain source for the visible label and uses the same map to drive `localeCompare`-based client-side resorting — one source of truth shared by both the pill list and the checkbox list. The hook is also forward-compatible with RSM-1921 (filter-date) and any future filter type whose label has to be computed rather than read from the bucket key.

## Proposed changes
* `activePills` resolves the visible label from a per-filter-type chain — `filterConfig.valueLabels[slug]` first (post_type singular_name; future filter-date display string when the block lands in RSM-1921), then the matching aggregation bucket's `slug_slash_name` post-slash split (taxonomy/author), then the raw slug as a last-resort. Pills now read "Post Type: Post" instead of "Post Type: post" and "Author: Sarah Chen" instead of "Author: sarach".
* `filterItems` resorts buckets client-side by visible label using `localeCompare` whenever `bucketSortOrder === 'alpha'`. The ES `_key: asc` order kept for the API request is just a hint — it isn't label-accurate when slug and display name diverge (e.g. slug `food-news`, label "Restaurant Reviews"; or any post-type / author bucket where the label is resolved from `valueLabels`).
* `class-filter-checkbox.php` `build_config()` seeds a `valueLabels` map for `filterType=post_type` (slug → singular_name from `get_post_types(['exclude_from_search' => false], 'objects')`), and an empty map for taxonomy / author (their `slug_slash_name` buckets carry the label inline).
* Bucket-key parsing is hoisted into a shared `store/bucket-key.js` so the active-filters pill list and the filter-checkbox option list never disagree on how a bucket is labelled.
* Updated the `buildAggregations()` doc comment in `store/api.js` to point at the new client-side resort instead of describing it as a TODO.

## Related product discussion/links
* Linear: [RSM-1922](https://linear.app/a8c/issue/RSM-1922/search-30-active-filter-pills-show-raw-slugs-and-alphabetical-sort)
* The `valueLabels` field is the same hook the parallel filter-date task (RSM-1921) is expected to populate with formatted date-range labels — degrades gracefully (raw key) when that block isn't present.

## Does this pull request change what data or activity we track or use?
No.

## Real-screen before / after

`/?s=hello&post_types[]=post` on `https://jp-sage.jurassic.tube/`, viewport 1440×900. The `Post Type` pill switches from the raw slug `post` to the singular_name `Post`.

| Before (trunk) | After (this PR) |
|---|---|
| ![before](https://github.com/user-attachments/assets/50e40726-8a33-486f-8951-b191a6adda21) | ![after](https://github.com/user-attachments/assets/d76e180e-aba5-44b3-9ea7-428639163273) |

## Testing instructions

Tunnel: <https://jp-sage.jurassic.tube/> · WP admin: `wordpress` / `wordpress`.

### Setup

1. Activate the Jetpack Search plugin (or the monolith `jetpack` plugin with Search 3.0 blocks enabled).
2. Make sure there's content of multiple post types and multiple categories. The default sandbox already has posts, pages, attachments, and WooCommerce products with categories.
3. Open the Site Editor → Templates → "Jetpack Search Results" — this is the template that owns `/?s=...`. It already includes `active-filters`, `filter-checkbox` for category, post_tag, post_type. Optionally add a second `filter-checkbox` block with **Bucket sort order = Alphabetical** in the inspector to exercise the alpha sort.
4. (Optional, for the alpha-sort case) Add a category whose slug differs from its display name — e.g. slug `food-news`, name "Restaurant Reviews". Assign at least one post to it.

### Active-filter pill labels

5. Visit `/?s=test&post_types[]=post&category[]=<slug>` (replace `<slug>` with any category slug from your install).
6. Confirm the pills under "Active filters:" read **"Post Type: Post"** and **"Category: <Display Name>"** — not the raw slugs.
7. With an author filter-checkbox in the sidebar, select an author, then confirm the pill reads **"Author: <Display Name>"**.
8. Refresh the page. The pill should still read the human label even before the first JS-driven aggregation response lands (PHP-seeded `valueLabels` carries post-type labels through the SSR; taxonomy/author labels arrive once the response returns).
9. Edge case: deep-link to a slug that doesn't appear in the current top-N agg buckets (e.g. a tag with very few posts). The pill should still render — falling back to the slug — rather than disappearing.

### Alphabetical bucket sort

10. Configure a `filter-checkbox` for category with **Bucket sort order = Alphabetical**. Make sure the category set includes at least one slug whose first letter differs from its display name (the `food-news` / "Restaurant Reviews" pair from step 4).
11. Reload the search page and inspect the category checkbox list. The buckets should be ordered by visible label — "Apple Pie", "Restaurant Reviews", "Zebra Archive" — not by slug ("apple-pie", "food-news", "zebra-archive").
12. Repeat with a `filter-checkbox` for post_type set to alphabetical: order should be by singular_name ("Page", "Post", "Product"), not the raw slugs.

### Automated coverage

* `pnpm jetpack test js packages/search` — JS tests now include `tests/js/search-blocks/active-filters-view.test.js` and `tests/js/search-blocks/filter-checkbox-view.test.js` that cover the priority order, the slug fallback, and the alpha resort.
* `pnpm jetpack test php packages/search` — `Filter_Checkbox_Test::test_build_config_seeds_value_labels_for_post_type` covers the new `valueLabels` field.

🤖 Generated with sage — orchestrator dispatch
