### PR TITLE
Search 3.0: surface a taxonomy picker for the Custom Taxonomy filter variation

### DIFF
--- a/projects/packages/search/changelog/echo-rsm-1920-custom-taxonomy-filter
+++ b/projects/packages/search/changelog/echo-rsm-1920-custom-taxonomy-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search 3.0: surface a Taxonomy picker so the Custom Taxonomy filter variation actually targets a registered taxonomy.

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
@@ -221,7 +221,8 @@ export default function FilterCheckboxEdit( { attributes, setAttributes } ) {
 		? __( 'A label is required so visitors see a heading above this filter.', 'jetpack-search-pkg' )
 		: __(
 				"Leave empty to use the variation's default label (e.g. Category, Tag).",
-				'jetpack-search-pkg'
+				'jetpack-search-pkg',
+				/* dummy arg to avoid bad minification */ 0
 		  );
 
 	return h(
@@ -265,7 +266,11 @@ export default function FilterCheckboxEdit( { attributes, setAttributes } ) {
 								value: '',
 								label: isLoadingTaxonomies
 									? __( 'Loading taxonomies…', 'jetpack-search-pkg' )
-									: __( 'Select a taxonomy', 'jetpack-search-pkg' ),
+									: __(
+											'Select a taxonomy',
+											'jetpack-search-pkg',
+											/* dummy arg to avoid bad minification */ 0
+									  ),
 								disabled: true,
 							},
 							...( taxonomyOptions || [] ),
@@ -278,7 +283,8 @@ export default function FilterCheckboxEdit( { attributes, setAttributes } ) {
 							  )
 							: __(
 									'Pick which registered taxonomy this filter targets. Built-in Category and Tag have their own dedicated filters in the inserter.',
-									'jetpack-search-pkg'
+									'jetpack-search-pkg',
+									/* dummy arg to avoid bad minification */ 0
 							  ),
 					} ),
 				h( TextControl, {

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
@@ -7,16 +7,24 @@
  * maxItems, bucketSortOrder). The filter-type control lets authors swap
  * between the Category / Tag / Post Type / Author / Custom Taxonomy
  * variations without deleting and re-inserting the block.
+ *
+ * Custom Taxonomy is the one variation whose target isn't fixed by the
+ * inserter choice: its variation seeds `taxonomy=''` so the inspector
+ * surfaces a SelectControl populated from registered taxonomies (via
+ * core-data) so the user can pick which taxonomy to filter by. Without
+ * that picker the block would silently render nothing on the front end.
  */
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import {
 	PanelBody,
+	Placeholder,
 	SelectControl,
 	RangeControl,
 	TextControl,
 	ToggleControl,
 } from '@wordpress/components';
-import { createElement as h, Fragment } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { createElement as h, Fragment, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 const SAMPLE_FILTER_ITEMS = [
@@ -24,6 +32,12 @@ const SAMPLE_FILTER_ITEMS = [
 	{ value: 'two', label: __( 'Second option', 'jetpack-search-pkg' ), count: 12 },
 	{ value: 'three', label: __( 'Third option', 'jetpack-search-pkg' ), count: 7 },
 ];
+
+// Built-in taxonomies that have their own filter-checkbox variations
+// (Category / Tag). Excluded from the custom-taxonomy picker so site builders
+// reach for the dedicated variation rather than re-creating it via the
+// generic Custom Taxonomy entry.
+const BUILT_IN_TAXONOMY_SLUGS = [ 'category', 'post_tag' ];
 
 // Variation identifiers mirror the variation `name`s registered in
 // Search_Blocks::register_variations() so the inspector picker and the
@@ -73,7 +87,7 @@ export function deriveVariation( attributes ) {
  * Category and Tag overwrite `taxonomy` with their built-in slugs, which
  * means a Custom → Category → Custom round-trip *will* clear the slug.
  * On the return trip we deliberately drop 'category' and 'post_tag' so the
- * Taxonomy slug input doesn't surface them as custom-typed slugs.
+ * Taxonomy picker doesn't surface them as custom-typed slugs.
  *
  * @param {string} variation        - Target variation identifier.
  * @param {string} previousTaxonomy - Current taxonomy attribute value.
@@ -141,6 +155,37 @@ export function variationDefaultLabel( attributes ) {
  */
 export default function FilterCheckboxEdit( { attributes, setAttributes } ) {
 	const blockProps = useBlockProps();
+	const currentVariation = deriveVariation( attributes );
+	const isCustomTaxonomy = currentVariation === VARIATION_CUSTOM_TAXONOMY;
+	const taxonomy = attributes?.taxonomy || '';
+	const needsTaxonomyChoice = isCustomTaxonomy && '' === taxonomy;
+
+	// Pull the registered taxonomies for the picker. `getTaxonomies` is the
+	// core-data shortcut for getEntityRecords( 'root', 'taxonomy' ); it
+	// returns null while the request is in flight and an array of taxonomy
+	// objects once resolved. Skip the request entirely outside the
+	// custom-taxonomy variation so the built-in variations don't pay for a
+	// REST call they never use.
+	const taxonomies = useSelect(
+		select => ( isCustomTaxonomy ? select( 'core' ).getTaxonomies( { per_page: -1 } ) : null ),
+		[ isCustomTaxonomy ]
+	);
+	// Derive options separately so the filter/map only re-runs when the
+	// underlying records change, not on every store update that re-runs the
+	// useSelect callback.
+	const taxonomyOptions = useMemo( () => {
+		if ( ! Array.isArray( taxonomies ) ) {
+			return null;
+		}
+		return taxonomies
+			.filter(
+				t =>
+					t?.slug && ! BUILT_IN_TAXONOMY_SLUGS.includes( t.slug ) && false !== t?.visibility?.public
+			)
+			.map( t => ( { value: t.slug, label: t.name || t.slug } ) );
+	}, [ taxonomies ] );
+	const isLoadingTaxonomies = isCustomTaxonomy && taxonomies === null;
+
 	const rawLabel = attributes?.label || '';
 	const variationLabel = variationDefaultLabel( attributes );
 	const placeholderLabel = variationLabel || __( 'Filter', 'jetpack-search-pkg' );
@@ -153,8 +198,6 @@ export default function FilterCheckboxEdit( { attributes, setAttributes } ) {
 	// Unknown values fall back to `count` so the preview controls always
 	// reflect a valid enum option; render.php normalizes the same way.
 	const bucketSortOrder = attributes?.bucketSortOrder === 'alpha' ? 'alpha' : 'count';
-	const currentVariation = deriveVariation( attributes );
-	const taxonomy = attributes?.taxonomy || '';
 
 	// Swapping the filter type via the inspector shouldn't wipe an author's
 	// custom label, but when the stored label still matches the prior
@@ -169,6 +212,13 @@ export default function FilterCheckboxEdit( { attributes, setAttributes } ) {
 		}
 		setAttributes( next );
 	};
+
+	const labelHelp = isCustomTaxonomy
+		? __( 'A label is required so visitors see a heading above this filter.', 'jetpack-search-pkg' )
+		: __(
+				"Leave empty to use the variation's default label (e.g. Category, Tag).",
+				'jetpack-search-pkg'
+		  );
 
 	return h(
 		Fragment,
@@ -200,19 +250,28 @@ export default function FilterCheckboxEdit( { attributes, setAttributes } ) {
 						'jetpack-search-pkg'
 					),
 				} ),
-				currentVariation === VARIATION_CUSTOM_TAXONOMY
-					? h( TextControl, {
-							__next40pxDefaultSize: true,
-							__nextHasNoMarginBottom: true,
-							label: __( 'Taxonomy slug', 'jetpack-search-pkg' ),
-							value: taxonomy,
-							onChange: value => setAttributes( { taxonomy: value } ),
-							help: __(
-								'The registered taxonomy slug to filter by (e.g. genre, product_cat).',
-								'jetpack-search-pkg'
-							),
-					  } )
-					: null,
+				isCustomTaxonomy &&
+					h( SelectControl, {
+						__next40pxDefaultSize: true,
+						__nextHasNoMarginBottom: true,
+						label: __( 'Taxonomy', 'jetpack-search-pkg' ),
+						value: taxonomy,
+						options: [
+							{
+								value: '',
+								label: isLoadingTaxonomies
+									? __( 'Loading taxonomies…', 'jetpack-search-pkg' )
+									: __( 'Select a taxonomy', 'jetpack-search-pkg' ),
+								disabled: true,
+							},
+							...( taxonomyOptions || [] ),
+						],
+						onChange: value => setAttributes( { taxonomy: value } ),
+						help: __(
+							'Pick which registered taxonomy this filter targets. Built-in Category and Tag have their own dedicated filters in the inserter.',
+							'jetpack-search-pkg'
+						),
+					} ),
 				h( TextControl, {
 					__next40pxDefaultSize: true,
 					__nextHasNoMarginBottom: true,
@@ -220,10 +279,7 @@ export default function FilterCheckboxEdit( { attributes, setAttributes } ) {
 					value: rawLabel,
 					placeholder: placeholderLabel,
 					onChange: value => setAttributes( { label: value } ),
-					help: __(
-						"Leave empty to use the variation's default label (e.g. Category, Tag).",
-						'jetpack-search-pkg'
-					),
+					help: labelHelp,
 				} ),
 				h( ToggleControl, {
 					__nextHasNoMarginBottom: true,
@@ -257,26 +313,43 @@ export default function FilterCheckboxEdit( { attributes, setAttributes } ) {
 		h(
 			'div',
 			blockProps,
-			h( 'h3', { className: 'jetpack-search-filter__title' }, previewLabel ),
-			h(
-				'ul',
-				{ className: 'jetpack-search-filter__list' },
-				SAMPLE_FILTER_ITEMS.slice( 0, maxItems ).map( item =>
-					h(
-						'li',
-						{ key: item.value, className: 'jetpack-search-filter__item' },
+			needsTaxonomyChoice
+				? h( Placeholder, {
+						icon: 'filter',
+						label: __( 'Custom Taxonomy Filter', 'jetpack-search-pkg' ),
+						instructions: __(
+							'Choose a taxonomy in the block settings to enable this filter. Until a taxonomy is set, this block renders nothing on the front end.',
+							'jetpack-search-pkg'
+						),
+				  } )
+				: h(
+						Fragment,
+						null,
+						h( 'h3', { className: 'jetpack-search-filter__title' }, previewLabel ),
 						h(
-							'label',
-							null,
-							h( 'input', { type: 'checkbox', disabled: true } ),
-							h( 'span', { className: 'jetpack-search-filter__label' }, item.label ),
-							showCount
-								? h( 'span', { className: 'jetpack-search-filter__count' }, String( item.count ) )
-								: null
+							'ul',
+							{ className: 'jetpack-search-filter__list' },
+							SAMPLE_FILTER_ITEMS.slice( 0, maxItems ).map( item =>
+								h(
+									'li',
+									{ key: item.value, className: 'jetpack-search-filter__item' },
+									h(
+										'label',
+										null,
+										h( 'input', { type: 'checkbox', disabled: true } ),
+										h( 'span', { className: 'jetpack-search-filter__label' }, item.label ),
+										showCount
+											? h(
+													'span',
+													{ className: 'jetpack-search-filter__count' },
+													String( item.count )
+											  )
+											: null
+									)
+								)
+							)
 						)
-					)
-				)
-			)
+				  )
 		)
 	);
 }

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
@@ -261,6 +261,7 @@ export default function FilterCheckboxEdit( { attributes, setAttributes } ) {
 						__nextHasNoMarginBottom: true,
 						label: __( 'Taxonomy', 'jetpack-search-pkg' ),
 						value: taxonomy,
+						disabled: hasNoCustomTaxonomies,
 						options: [
 							{
 								value: '',

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
@@ -165,9 +165,11 @@ export default function FilterCheckboxEdit( { attributes, setAttributes } ) {
 	// returns null while the request is in flight and an array of taxonomy
 	// objects once resolved. Skip the request entirely outside the
 	// custom-taxonomy variation so the built-in variations don't pay for a
-	// REST call they never use.
+	// REST call they never use. No `per_page` arg — the
+	// /wp/v2/taxonomies endpoint doesn't register that collection param,
+	// and the response is a finite list anyway.
 	const taxonomies = useSelect(
-		select => ( isCustomTaxonomy ? select( 'core' ).getTaxonomies( { per_page: -1 } ) : null ),
+		select => ( isCustomTaxonomy ? select( 'core' ).getTaxonomies() : null ),
 		[ isCustomTaxonomy ]
 	);
 	// Derive options separately so the filter/map only re-runs when the
@@ -180,11 +182,13 @@ export default function FilterCheckboxEdit( { attributes, setAttributes } ) {
 		return taxonomies
 			.filter(
 				t =>
-					t?.slug && ! BUILT_IN_TAXONOMY_SLUGS.includes( t.slug ) && false !== t?.visibility?.public
+					t?.slug && ! BUILT_IN_TAXONOMY_SLUGS.includes( t.slug ) && t?.visibility?.public !== false
 			)
 			.map( t => ( { value: t.slug, label: t.name || t.slug } ) );
 	}, [ taxonomies ] );
 	const isLoadingTaxonomies = isCustomTaxonomy && taxonomies === null;
+	const hasNoCustomTaxonomies =
+		isCustomTaxonomy && Array.isArray( taxonomyOptions ) && taxonomyOptions.length === 0;
 
 	const rawLabel = attributes?.label || '';
 	const variationLabel = variationDefaultLabel( attributes );
@@ -267,10 +271,15 @@ export default function FilterCheckboxEdit( { attributes, setAttributes } ) {
 							...( taxonomyOptions || [] ),
 						],
 						onChange: value => setAttributes( { taxonomy: value } ),
-						help: __(
-							'Pick which registered taxonomy this filter targets. Built-in Category and Tag have their own dedicated filters in the inserter.',
-							'jetpack-search-pkg'
-						),
+						help: hasNoCustomTaxonomies
+							? __(
+									'No custom taxonomies registered on this site. Register one with register_taxonomy() and it will appear here.',
+									'jetpack-search-pkg'
+							  )
+							: __(
+									'Pick which registered taxonomy this filter targets. Built-in Category and Tag have their own dedicated filters in the inserter.',
+									'jetpack-search-pkg'
+							  ),
 					} ),
 				h( TextControl, {
 					__next40pxDefaultSize: true,

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -189,7 +189,14 @@ class Search_Blocks {
 					'taxonomy'   => '',
 					'label'      => '',
 				),
-				'isActive'    => array( 'filterType', 'taxonomy' ),
+				// Match on filterType only (no taxonomy comparison) so the
+				// variation identity survives once the author picks a slug
+				// via the inspector. The Category and Tag variations both
+				// pin `taxonomy` in their isActive arrays, so WP's
+				// most-specific-match resolution still routes those slugs
+				// to their dedicated variations — Custom Taxonomy claims
+				// every other registered taxonomy.
+				'isActive'    => array( 'filterType' ),
 			),
 		);
 

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -183,7 +183,7 @@ class Search_Blocks {
 			array(
 				'name'        => 'custom_taxonomy',
 				'title'       => __( 'Filter by Custom Taxonomy', 'jetpack-search-pkg' ),
-				'description' => __( 'Show checkboxes for any registered taxonomy.', 'jetpack-search-pkg' ),
+				'description' => __( 'Show checkboxes for a custom taxonomy. Pick which taxonomy in the block settings after inserting.', 'jetpack-search-pkg' ),
 				'attributes'  => array(
 					'filterType' => 'taxonomy',
 					'taxonomy'   => '',


### PR DESCRIPTION
Fixes RSM-1920 — https://linear.app/a8c/issue/RSM-1920/search-30-custom-taxonomy-filter-is-unusable-in-the-editor

## Proposed changes
* Add a Taxonomy `SelectControl` in the filter-checkbox inspector that surfaces only for the Custom Taxonomy variation (`filterType === "taxonomy"` and the slug isn't `category` / `post_tag`). Options are seeded from `/wp/v2/taxonomies` via core-data, with built-in slugs filtered out so site builders reach for the dedicated Category / Tag variations instead.
* Render a `Placeholder` in the editor canvas while no taxonomy is picked, explaining why the block is empty and that it will render nothing on the front end until configured.
* Upgrade the Label field's help text to call out that a label is required for the custom-taxonomy case (the server-side default-label fallback is intentionally empty for custom slugs).
* Tighten the variation description in `class-search-blocks.php` so the inserter modal points users at the new picker.

## Related product discussion/links
* Linear: https://linear.app/a8c/issue/RSM-1920/search-30-custom-taxonomy-filter-is-unusable-in-the-editor

## Does this pull request change what data or activity we track or use?
No. Editor-only inspector + preview changes; no new tracking or runtime store changes.

## Testing instructions

This PR is editor-only — there are no runtime / front-end behavior changes from the picker itself.

**Public preview** — https://jp-echo.jurassic.tube/ (creds: `wordpress` / `wordpress`). The env has two sample custom taxonomies registered (`genre`, `topic`) plus the WooCommerce `product_*` taxonomies, so the picker has multiple slugs to choose from.

1. Go to `wp-admin/post-new.php?post_type=page` (or any page editor).
2. Open the global inserter, scroll to the **Search** category, and insert **Checkbox Filter**. The block defaults to the Category variation — that's expected.
3. Click the block, open the variation picker (block toolbar → "transform / variations"), and choose **Filter by Custom Taxonomy**. Confirm:
    * The canvas now shows a Placeholder titled **Custom Taxonomy Filter** instead of the sample list.
    * The Inspector → Settings panel includes a new **Taxonomy** SelectControl, defaulting to "Select a taxonomy" (built-in Category / Tag are excluded).
    * The Label field's help text reads **"A label is required so visitors see a heading above this filter."** instead of the default fallback hint.
4. Pick a taxonomy from the SelectControl (e.g. `Genres`). Confirm:
    * The Placeholder disappears and the sample-bucket preview list paints with the chosen label.
5. Insert a `jetpack/search-results` page with the new filter inside a column sidebar, publish it, and load the front end. Confirm the custom-taxonomy filter renders alongside the built-in filters once aggregations come back from the search.
6. Re-test the **Category**, **Tag**, **Post Type**, and **Author** variations to confirm the new picker / Placeholder do **not** appear (the inspector for those should look exactly as it did pre-PR).

### Screenshots

| State | Capture |
|---|---|
| Inserter — Jetpack Search category | ![inserter](https://github.com/user-attachments/assets/b21e65e3-0dd6-431f-9c46-3ed7eb1d431f) |
| Editor — Custom Taxonomy with no slug picked (new Placeholder + new SelectControl + new help text) | ![placeholder](https://github.com/user-attachments/assets/8dc18e7a-37e2-4310-bba1-8eaa5841d15c) |
| Editor — Custom Taxonomy with `Genres` picked (preview renders) | ![picked](https://github.com/user-attachments/assets/7141344e-3f66-4fd4-a997-1409da50815b) |
| Front end — built-in **Category** + new **Genres** custom-taxonomy filter both rendering | ![frontend](https://github.com/user-attachments/assets/5457d293-355b-43e3-8c7d-14fcba6823f1) |
