### PR TITLE
Write: Show delete button on hover for video elements

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-write-video-delete-button
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-write-video-delete-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Show delete button on hover for video elements in the Write editor.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -1019,6 +1019,11 @@
 	transform: scale(1);
 }
 
+.bw-video-figure:hover .bw-img-delete {
+	opacity: 1;
+	transform: scale(1);
+}
+
 .bw-img-controls .bw-img-delete:hover {
 	background: rgba(214, 54, 56, 0.85);
 }


### PR DESCRIPTION
Fixes RSM-1942

## Proposed changes

* Add `.bw-video-figure:hover .bw-img-delete` CSS rule so the delete button appears on hover for videos, matching the existing behavior for images (`.bw-img-controls:hover .bw-img-delete`)

<img width="1502" height="771" alt="Screenshot 2026-04-30 at 11 39 47 PM" src="https://github.com/user-attachments/assets/6fd96dd7-393d-40f0-87e0-749b165772da" />

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Open the Write editor and insert a video
* Hover over the video — the delete (X) button should appear
* Verify the image delete button works

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>