### PR TITLE
Search 3.0: add compact search block template

### DIFF
--- a/projects/packages/search/changelog/add-rsm-1944-compact-search-template
+++ b/projects/packages/search/changelog/add-rsm-1944-compact-search-template
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search 3.0: Register a second block template ("Jetpack Search Results (Compact)") that mirrors the Compact Search pattern, so site owners can opt into the toolbar-style search layout from the Site Editor.

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -39,7 +39,7 @@ class Search_Blocks {
 	const NON_SEARCH_QUERY_PARAM = 'q';
 
 	/**
-	 * Template slug used for the Jetpack Search page template.
+	 * Template slug used for the primary Jetpack Search page template.
 	 *
 	 * Intentionally distinct from WordPress's `search` slug so the plugin
 	 * template never collides with (and gets deduplicated against) a block
@@ -47,6 +47,20 @@ class Search_Blocks {
 	 * slug so it still wins on `/?s=...` requests.
 	 */
 	const SEARCH_TEMPLATE_SLUG = 'jetpack-search';
+
+	/**
+	 * Template slug for the compact-toolbar variant of the search results page.
+	 *
+	 * Registered alongside the primary template so site owners can pick the
+	 * compact layout from the Site Editor's Templates list (Appearance →
+	 * Editor → Templates → Add New). This slug is intentionally NOT prepended
+	 * to `search_template_hierarchy`: only one plugin-registered template
+	 * should win the hierarchy lookup, and the layout-rich `jetpack-search`
+	 * template remains the default. Site owners switch by either assigning
+	 * this template to a page or editing the resolved search template's
+	 * content to match.
+	 */
+	const SEARCH_COMPACT_TEMPLATE_SLUG = 'jetpack-search-compact';
 
 	/**
 	 * Per-request memo backing `is_initial_loading()`. Lifted out of the
@@ -713,72 +727,108 @@ class Search_Blocks {
 	}
 
 	/**
-	 * Build the full search page template content.
+	 * Build the full search page template content for a bundled template file.
 	 *
-	 * Mirrors the "Blog Search Page" pattern's layout (see
-	 * `src/search-blocks/patterns/blog-search.php`) wrapped in header/main/
-	 * footer template parts so the plugin-registered template renders the
-	 * same page users get from inserting the pattern directly. Markup lives
-	 * in `templates/jetpack-search.html` — the canonical block-theme format
-	 * for block templates — with a `{{FILTER_HEADING}}` placeholder for the
-	 * filter-sidebar heading so that string still goes through `esc_html__()`.
+	 * Each template lives in `templates/<slug>.html` — the canonical
+	 * block-theme format for block templates. The default `jetpack-search`
+	 * template mirrors the "Blog Search Page" pattern (see
+	 * `src/search-blocks/patterns/blog-search.php`); the
+	 * `jetpack-search-compact` template mirrors the "Compact Search" pattern
+	 * (see `src/search-blocks/patterns/compact-search.php`). Both are
+	 * wrapped in header/main/footer template parts so the plugin-registered
+	 * templates render the same page users get from inserting the patterns
+	 * directly. The default template uses a `{{FILTER_HEADING}}` placeholder
+	 * for the filter-sidebar heading so that string still goes through
+	 * `esc_html__()`; the compact template has no equivalent placeholder
+	 * because its filter labels live inside individual blocks.
 	 *
-	 * Memoized: `register_search_template()` runs on every `init`, and the
-	 * template markup is identical every request, so read the file and run
-	 * the translation substitution once per process.
+	 * Memoized per slug: `register_search_template()` runs on every `init`,
+	 * and the template markup is identical every request, so read each file
+	 * and run the translation substitution once per process.
 	 *
-	 * @return string Block markup for a complete page template.
+	 * @param string $slug Template slug (basename of the .html file).
+	 * @return string Block markup for a complete page template, or '' when
+	 *                the bundled file is missing/unreadable.
 	 */
-	protected static function get_search_template_content(): string {
-		static $content = null;
-		if ( null !== $content ) {
-			return $content;
+	protected static function get_search_template_content( string $slug = self::SEARCH_TEMPLATE_SLUG ): string {
+		static $cache = array();
+		if ( array_key_exists( $slug, $cache ) ) {
+			return $cache[ $slug ];
 		}
-		$template_path = __DIR__ . '/templates/jetpack-search.html';
+		$template_path = __DIR__ . '/templates/' . $slug . '.html';
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- local, bundled template file; wp_remote_get() is for remote URLs.
-		$raw     = is_readable( $template_path ) ? (string) file_get_contents( $template_path ) : '';
-		$content = str_replace(
+		$raw            = is_readable( $template_path ) ? (string) file_get_contents( $template_path ) : '';
+		$cache[ $slug ] = str_replace(
 			'{{FILTER_HEADING}}',
 			esc_html__( 'Filter options', 'jetpack-search-pkg' ),
 			$raw
 		);
-		return $content;
+		return $cache[ $slug ];
 	}
 
 	/**
-	 * Register the Jetpack Search page template with the block-template
-	 * registry so it surfaces in the Site Editor's Templates list and can be
-	 * resolved via the template hierarchy.
+	 * Register the Jetpack Search page templates with the block-template
+	 * registry so they surface in the Site Editor's Templates list and can
+	 * be resolved via the template hierarchy.
+	 *
+	 * Two templates are registered:
+	 *
+	 * - `jetpack-search` — the default sidebar layout from the "Blog Search
+	 *   Page" pattern. Prepended to `search_template_hierarchy` so it wins
+	 *   `/?s=...` requests automatically.
+	 * - `jetpack-search-compact` — the toolbar layout from the "Compact
+	 *   Search" pattern. Available in the Site Editor's Templates list so
+	 *   site owners can opt into the compact layout, but NOT prepended to
+	 *   the search hierarchy (only one plugin template should win the
+	 *   `/?s=...` lookup, and the sidebar layout remains the default).
 	 *
 	 * Uses `register_block_template()` (WP 6.7+). Jetpack requires WP 6.8+,
 	 * so the function is always present at runtime — the function_exists
 	 * guard is defensive for phpstan/phan and edge environments.
 	 *
 	 * DB-stored customizations continue to take precedence: if a site owner
-	 * edits this template in the Site Editor, the `custom` source wins during
-	 * resolution automatically.
+	 * edits either template in the Site Editor, the `custom` source wins
+	 * during resolution automatically.
 	 */
 	public static function register_search_template() {
 		if ( ! function_exists( 'register_block_template' ) ) {
 			return;
 		}
-		$content = static::get_search_template_content();
+		$namespace = static::get_parent_plugin_slug();
+
+		$default_content = static::get_search_template_content( self::SEARCH_TEMPLATE_SLUG );
 		// Skip registration if the bundled template file is missing or
 		// unreadable. Since this template's slug is prepended to the
 		// search hierarchy, registering with empty content would take
 		// over `/?s=...` and render a blank page; bailing here lets core
 		// fall through to the theme's `search.html` instead.
-		if ( '' === $content ) {
-			return;
+		if ( '' !== $default_content ) {
+			register_block_template(
+				$namespace . '//' . self::SEARCH_TEMPLATE_SLUG,
+				array(
+					'title'       => __( 'Jetpack Search Results', 'jetpack-search-pkg' ),
+					'description' => __( 'Displays search results with Jetpack Search filters.', 'jetpack-search-pkg' ),
+					'content'     => $default_content,
+				)
+			);
 		}
-		register_block_template(
-			static::get_parent_plugin_slug() . '//' . self::SEARCH_TEMPLATE_SLUG,
-			array(
-				'title'       => __( 'Jetpack Search Results', 'jetpack-search-pkg' ),
-				'description' => __( 'Displays search results with Jetpack Search filters.', 'jetpack-search-pkg' ),
-				'content'     => $content,
-			)
-		);
+
+		$compact_content = static::get_search_template_content( self::SEARCH_COMPACT_TEMPLATE_SLUG );
+		// The compact template is opt-in via the Site Editor and is not
+		// prepended to the search hierarchy, so an empty file just hides
+		// the option from the Templates list rather than blanking out
+		// `/?s=...`. Skipping when empty still avoids registering a no-op
+		// entry that would render blank if a site owner did select it.
+		if ( '' !== $compact_content ) {
+			register_block_template(
+				$namespace . '//' . self::SEARCH_COMPACT_TEMPLATE_SLUG,
+				array(
+					'title'       => __( 'Jetpack Search Results (Compact)', 'jetpack-search-pkg' ),
+					'description' => __( 'Displays search results with a compact Jetpack Search toolbar (inline filters and sort).', 'jetpack-search-pkg' ),
+					'content'     => $compact_content,
+				)
+			);
+		}
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search-compact.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search-compact.html
@@ -1,0 +1,36 @@
+<!-- wp:template-part {"slug":"header"} /-->
+
+<!-- wp:group {"tagName":"main","style":{"spacing":{"margin":{"top":"var:preset|spacing|60"}}},"layout":{"type":"constrained"}} -->
+<main class="wp-block-group" style="margin-top:var(--wp--preset--spacing--60)">
+
+<!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"1rem"}}} -->
+<div class="wp-block-group alignwide">
+
+<!-- wp:group {"className":"jetpack-search-compact-toolbar","layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<div class="wp-block-group jetpack-search-compact-toolbar">
+<!-- wp:jetpack-search/search-input /-->
+<!-- wp:jetpack-search/filters-popover -->
+<!-- wp:jetpack-search/active-filters /-->
+<!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"category"} /-->
+<!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"post_tag"} /-->
+<!-- wp:jetpack-search/filter-checkbox {"filterType":"post_type"} /-->
+<!-- wp:jetpack-search/filter-post-type /-->
+<!-- /wp:jetpack-search/filters-popover -->
+<!-- wp:jetpack-search/results-sort {"displayAs":"popover"} /-->
+</div>
+<!-- /wp:group -->
+
+<!-- wp:jetpack-search/search-results -->
+<!-- wp:jetpack-search/results-count /-->
+<!-- wp:jetpack-search/results-list {"layout":"compact"} /-->
+<!-- wp:jetpack-search/results-load-more /-->
+<!-- wp:jetpack-search/powered-by /-->
+<!-- /wp:jetpack-search/search-results -->
+
+</div>
+<!-- /wp:group -->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -493,7 +493,14 @@ class Search_Blocks_Test extends TestCase {
 		// Isolate from any prior registration — the registry is a singleton
 		// across tests, and register_block_template() errors on duplicates.
 		$registry = \WP_Block_Templates_Registry::get_instance();
-		foreach ( array( 'jetpack-search//jetpack-search', 'jetpack//jetpack-search' ) as $name ) {
+		foreach (
+			array(
+				'jetpack-search//jetpack-search',
+				'jetpack//jetpack-search',
+				'jetpack-search//jetpack-search-compact',
+				'jetpack//jetpack-search-compact',
+			) as $name
+		) {
 			if ( $registry->is_registered( $name ) ) {
 				$registry->unregister( $name );
 			}
@@ -517,6 +524,56 @@ class Search_Blocks_Test extends TestCase {
 		$this->assertStringNotContainsString( '{{FILTER_HEADING}}', $registered->content );
 
 		$registry->unregister( $expected );
+		$registry->unregister( $namespace . '//jetpack-search-compact' );
+	}
+
+	/**
+	 * The compact template surfaces an alternative Site Editor layout that
+	 * mirrors the "Compact Search" pattern — single-row toolbar (search
+	 * input + filter popover + sort popover) over a `layout:"compact"`
+	 * search-results list. It must register under the same namespace as
+	 * the default template, but it must NOT be prepended to the search
+	 * hierarchy (only one plugin template should win the `/?s=...` lookup).
+	 */
+	public function test_register_search_template_registers_compact_variant() {
+		if ( ! function_exists( 'register_block_template' ) ) {
+			$this->markTestSkipped( 'register_block_template() unavailable in this test environment.' );
+		}
+		$registry = \WP_Block_Templates_Registry::get_instance();
+		foreach (
+			array(
+				'jetpack-search//jetpack-search',
+				'jetpack//jetpack-search',
+				'jetpack-search//jetpack-search-compact',
+				'jetpack//jetpack-search-compact',
+			) as $name
+		) {
+			if ( $registry->is_registered( $name ) ) {
+				$registry->unregister( $name );
+			}
+		}
+
+		Search_Blocks::register_search_template();
+
+		$namespace = $this->invoke_protected( 'get_parent_plugin_slug' );
+		$expected  = $namespace . '//jetpack-search-compact';
+		$this->assertTrue( $registry->is_registered( $expected ), "Template $expected should be registered." );
+
+		$registered = $registry->get_registered( $expected );
+		$this->assertSame( 'Jetpack Search Results (Compact)', $registered->title );
+		// Compact-toolbar layout markers — guards against an accidental
+		// swap where the default sidebar markup gets registered under the
+		// compact slug.
+		$this->assertStringContainsString( '<!-- wp:jetpack-search/search-input /-->', $registered->content );
+		$this->assertStringContainsString( '<!-- wp:jetpack-search/filters-popover', $registered->content );
+		$this->assertStringContainsString( '"layout":"compact"', $registered->content );
+		// The compact slug must NOT win the search hierarchy — only the
+		// default `jetpack-search` slug is prepended.
+		$hierarchy = Search_Blocks::prepend_search_template( array( 'search', 'index' ) );
+		$this->assertNotContains( 'jetpack-search-compact', $hierarchy );
+
+		$registry->unregister( $expected );
+		$registry->unregister( $namespace . '//jetpack-search' );
 	}
 
 	/**
@@ -532,7 +589,14 @@ class Search_Blocks_Test extends TestCase {
 			$this->markTestSkipped( 'register_block_template() unavailable in this test environment.' );
 		}
 		$registry = \WP_Block_Templates_Registry::get_instance();
-		foreach ( array( 'jetpack-search//jetpack-search', 'jetpack//jetpack-search' ) as $name ) {
+		foreach (
+			array(
+				'jetpack-search//jetpack-search',
+				'jetpack//jetpack-search',
+				'jetpack-search//jetpack-search-compact',
+				'jetpack//jetpack-search-compact',
+			) as $name
+		) {
 			if ( $registry->is_registered( $name ) ) {
 				$registry->unregister( $name );
 			}
@@ -540,15 +604,30 @@ class Search_Blocks_Test extends TestCase {
 
 		// Stub empty content by temporarily overriding the method's output
 		// via a mock subclass. Simplest: run register_search_template on a
-		// subclass that returns '' from get_search_template_content().
+		// subclass that returns '' from get_search_template_content() for
+		// every slug (the default and the compact variant).
 		$anon = new class() extends Search_Blocks {
-			protected static function get_search_template_content(): string {
+			/**
+			 * Stub override returning empty content for every slug.
+			 *
+			 * @param string $slug Required to match parent signature; intentionally unused.
+			 * @return string
+			 */
+			protected static function get_search_template_content( string $slug = self::SEARCH_TEMPLATE_SLUG ): string {
+				unset( $slug );
 				return '';
 			}
 		};
 		$anon::register_search_template();
 
-		foreach ( array( 'jetpack-search//jetpack-search', 'jetpack//jetpack-search' ) as $name ) {
+		foreach (
+			array(
+				'jetpack-search//jetpack-search',
+				'jetpack//jetpack-search',
+				'jetpack-search//jetpack-search-compact',
+				'jetpack//jetpack-search-compact',
+			) as $name
+		) {
 			$this->assertFalse( $registry->is_registered( $name ), "Template $name should NOT be registered when content is empty." );
 		}
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #

## Proposed changes
* Register a second Jetpack Search block template, **"Jetpack Search Results (Compact)"**, that mirrors the [Compact Search pattern](../blob/trunk/projects/packages/search/src/search-blocks/patterns/compact-search.php) (toolbar layout: search input + filter popover + sort popover over a `layout="compact"` results list).
* Surface the new template alongside the existing sidebar template in the Site Editor's **Templates** list (Appearance → Editor → Templates → Add New) so site owners can opt into the compact layout without editing the default template or hand-building the pattern.
* Refactor `Search_Blocks::get_search_template_content()` to take a slug argument (memoized per slug) so `register_search_template()` can register both templates from one code path.

The compact slug is intentionally **not** prepended to `search_template_hierarchy` — only one plugin template should win the `/?s=…` lookup, and the layout-rich sidebar template (`jetpack-search`) remains the default. Site owners who want the compact layout to take over `/?s=…` can either edit the resolved search template in the Site Editor or assign the compact template to a page.

## Related product discussion/links
* Linear issue: RSM-1944 — *Add search template with compact search*

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. Build the search package (or run a Jetpack site that loads it) with `jetpack_search_blocks_enabled` true and the search-blocks bundle registered.
2. In **Appearance → Editor → Templates**, click **Add New Template**.
3. Confirm both **Jetpack Search Results** and **Jetpack Search Results (Compact)** appear in the list of plugin-registered templates.
4. Add the **Jetpack Search Results (Compact)** template to a page (or open it in the Site Editor) and confirm the rendered layout matches the **Compact Search** block pattern: a single-row toolbar (search input + filter popover + sort popover) over a compact result list, no sidebar column.
5. Visit `/?s=test` and confirm the default sidebar layout still resolves (i.e. the compact template did **not** take over the search hierarchy).
6. Run the package PHP tests:
   ```bash
   jp test php packages/search
   ```
   All `Search_Blocks_Test` cases (including the two new ones — `test_register_search_template_registers_compact_variant` and the updated empty-content / hierarchy assertions) should pass.

### Test results

```
PHPUnit 12.5.23 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.18
Configuration: /workspace/projects/packages/search/phpunit.11.xml.dist

...............................................................  63 / 229 ( 27%)
............................................................... 126 / 229 ( 55%)
............................................................... 189 / 229 ( 82%)
........................................                        229 / 229 (100%)

Time: 00:00.268, Memory: 62.50 MB

OK (229 tests, 406 assertions)
```

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [RSM-1944](https://linear.app/a8c/issue/RSM-1944/add-search-template-with-compact-search)

<div><a href="https://cursor.com/agents/bc-f59cc6af-dbd3-434e-8aa4-8fc2ecb9403f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f59cc6af-dbd3-434e-8aa4-8fc2ecb9403f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

