### PR TITLE
Write: Disable undo/redo actions

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-write_disable_undo
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-write_disable_undo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Write: Disable undo/redo actions from keyboard shortcuts and browser Edit menu.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -919,6 +919,12 @@ const { state } = store( 'wpcom-write', {
 				return;
 			}
 
+			// Block undo/redo (Ctrl+Z, Ctrl+Shift+Z, Ctrl+Y).
+			if ( ( event.ctrlKey || event.metaKey ) && ( event.key === 'z' || event.key === 'y' ) ) {
+				event.preventDefault();
+				return;
+			}
+
 			// Ctrl+K / Cmd+K to toggle link input.
 			if ( ( event.ctrlKey || event.metaKey ) && event.key === 'k' ) {
 				event.preventDefault();
@@ -1032,6 +1038,13 @@ const { state } = store( 'wpcom-write', {
 						}
 					}
 				}
+			}
+		},
+
+		handleBeforeInput( event ) {
+			// Block undo/redo triggered via browser Edit menu.
+			if ( event.inputType === 'historyUndo' || event.inputType === 'historyRedo' ) {
+				event.preventDefault();
 			}
 		},
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -920,7 +920,7 @@ const { state } = store( 'wpcom-write', {
 			}
 
 			// Block undo/redo (Ctrl+Z, Ctrl+Shift+Z, Ctrl+Y).
-			if ( ( event.ctrlKey || event.metaKey ) && ( event.key === 'z' || event.key === 'y' ) ) {
+			if ( ( event.ctrlKey || event.metaKey ) && /^[zy]$/i.test( event.key ) ) {
 				event.preventDefault();
 				return;
 			}

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -384,6 +384,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 				data-wp-on--mouseup="actions.checkFormatting"
 				data-wp-on--keyup="actions.checkFormatting"
 				data-wp-on--keydown="actions.handleKeyDown"
+				data-wp-on--beforeinput="actions.handleBeforeInput"
 				data-placeholder="<?php echo esc_attr__( 'Tell your story...', 'jetpack-mu-wpcom' ); ?>"
 			><?php echo $edit_content ? wp_kses_post( $edit_content ) : '<p><br></p>'; ?></div>
 		</div>


### PR DESCRIPTION
Fixes RSM-1947

## Proposed changes

* Disable undo/redo in the Write editor — the browser's contentEditable undo/redo behavior is unpredictable
* Intercept Ctrl/Cmd+Z, Ctrl/Cmd+Shift+Z, and Ctrl/Cmd+Y keyboard shortcuts in `handleKeyDown`
* Add a `beforeinput` handler to block `historyUndo`/`historyRedo` events from the browser Edit menu

## Related product discussion/links

* RSM-1947

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Go to the Write editor on a WordPress.com site
* Type some content
* Press Cmd+Z (Mac) / Ctrl+Z (Windows) — nothing should happen
* Press Cmd+Shift+Z / Ctrl+Shift+Z — nothing should happen
* Press Cmd+Y / Ctrl+Y — nothing should happen
* Open browser Edit menu → Undo/Redo should have no effect
* Verify other keyboard shortcuts still work (Cmd+B, Cmd+I, Cmd+K, slash menu)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>