### PR TITLE
Search: fix hero section crushed under shared admin-page layout mixin

### DIFF
--- a/projects/packages/search/changelog/search-157-search-admin-herotitle-section-is-crushed-by-jetpack-admin
+++ b/projects/packages/search/changelog/search-157-search-admin-herotitle-section-is-crushed-by-jetpack-admin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: fix dashboard hero section being crushed under shared admin page layout mixin.

--- a/projects/packages/search/src/dashboard/components/mocked-search/mocked-instant-search.scss
+++ b/projects/packages/search/src/dashboard/components/mocked-search/mocked-instant-search.scss
@@ -11,7 +11,7 @@ $color-text-lighter: variables.$studio-gray-50;
 /* Mocked Search Container */
 .jp-mocked-instant-search {
 	background: $color-modal-background;
-	border-radius: 3px;
+	border-radius: 3px 3px 0 0;
 	margin: 0 auto;
 	width: 100%;
 	height: 100%;

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.scss
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.scss
@@ -23,8 +23,13 @@
 
 	.jp-search-dashboard-top {
 		background-color: #f9f9f6;
-
-		overflow: hidden;
+		// Clip only the bottom edge so the mocked-search box-shadow doesn't
+		// bleed into the next section, while leaving the shadow visible on
+		// the other sides. Avoids `overflow: hidden` here because the mixin
+		// in @automattic/jetpack-base-styles/admin-page-layout makes this a
+		// flex item; `overflow != visible` would resolve `min-height: auto`
+		// to 0 and let the section get crushed.
+		clip-path: inset(-100px -100px 0 -100px);
 	}
 
 	.jp-search-dashboard-top__title {


### PR DESCRIPTION
Fixes [SEARCH-157](https://linear.app/a8c/issue/SEARCH-157/search-admin-herotitle-section-is-crushed-by-jetpack-admin-page-layout)

## Proposed changes
* Replace `overflow: hidden` on `.jp-search-dashboard-top` with `clip-path: inset(-100px -100px 0 -100px)`. The shared `jetpack-admin-page-layout` mixin (introduced in #48109) makes this section a flex child with `min-height: 0`; per CSS Flexbox spec, `min-height: auto` resolves to `0` whenever `overflow != visible`, so the prior `overflow: hidden` (originally clipping the mocked-search box-shadow) was letting the flex algorithm crush the hero from ~410px down to ~18px. `clip-path` clips visually without changing min-height resolution.
* Clip only at the bottom edge so the mocked-search shadow halo stays visible on top/left/right but doesn't bleed into the next (white) section.
* Square the bottom corners of the mocked-search card (`border-radius: 3px 3px 0 0`) so the card meets the clipped section edge cleanly.

### Screenshots

| Before | After |
|-|-|
| <img width="2468" height="1456" alt="Screenshot 2026-05-01 at 4 03 50 PM" src="https://github.com/user-attachments/assets/f0fd7f34-482c-4044-ab5b-0d3774633bd7" /> | <img width="2470" height="2146" alt="Screenshot 2026-05-01 at 4 27 27 PM" src="https://github.com/user-attachments/assets/3d5d9624-70a2-46c5-9ace-b238feddc212" /> |

## Related product discussion/links
* Linear: [SEARCH-157](https://linear.app/a8c/issue/SEARCH-157/search-admin-herotitle-section-is-crushed-by-jetpack-admin-page-layout)
* Regression caused by: #48109 (commit `2ddb7d5908`, "Admin pages: unify layout under jetpack-admin-page-layout mixin")

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Activate the Jetpack plugin on a site that has Jetpack Search available.
* Visit **wp-admin → Jetpack → Search** (`/wp-admin/admin.php?page=jetpack-search`).
* Verify the hero section at the top of the page renders at full height: the heading "Help your visitors find exactly what they're looking for, fast" is fully visible, and the mocked search interface preview sits below it inside the cream (`#f9f9f6`) section.
* Verify the mocked-search card shows a soft shadow halo on its top, left, and right edges, but the shadow is cleanly clipped at the bottom of the cream section — no shadow bleeds into the white "Your usage" section below.
* Resize the viewport up and down (especially through the `782px` and `960px` breakpoints used by `jetpack-admin-page-layout`) and confirm the hero stays at its natural height in all sizes.
* Sanity check other pages adopting the same mixin (Newsletter, Social, Backup, Protect, VideoPress) to confirm no regression.

## Before / After

Before: hero section collapsed to a thin gray strip — title and mocked search not visible.
After: hero renders at full height; shadow visible on three sides, clipped only at the section's bottom edge.
