### PR TITLE
Write: Fix video embeds not displaying after page reload

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-write_video_display
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-write_video_display
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write: Fix video embeds not displaying after page reload by converting embed blocks to the editor format before the_content filter strips them.

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-write_video_display
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-write_video_display
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Write: Fix video embeds not displaying after page reload by converting embed blocks to the editor format before the_content filter strips them.
+Write: Fix video embeds not displaying after page reload on Simple and Atomic sites.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -161,9 +161,10 @@ add_action(
 /**
  * Convert wp:embed video blocks in raw block markup to bw-video-figure HTML.
  *
- * The the_content filter + wp_kses_post pipeline strips the iframe from embed
- * blocks, leaving an empty wrapper.  By converting video embeds to the Write
- * editor's own markup before that pipeline runs, the iframe is preserved.
+ * The do_blocks() renderer doesn't convert embed blocks into iframes the way
+ * the full the_content pipeline would (via WP_Embed).  This function detects
+ * YouTube / Vimeo embed blocks and rewrites them to the Write editor's own
+ * bw-video-figure markup so videos display on reload.
  *
  * @param string $content Raw post_content (block markup).
  * @return string Content with video embed blocks replaced by bw-video-figure HTML.
@@ -201,7 +202,7 @@ function wpcom_write_convert_video_embeds( $content ) {
 			);
 		},
 		$content
-	);
+	) ?? $content;
 }
 
 /**
@@ -224,11 +225,13 @@ function wpcom_write_render_admin_page() {
 		$edit_post = get_post( $edit_post_id );
 		if ( $edit_post && current_user_can( 'edit_post', $edit_post_id ) ) {
 			$edit_title = $edit_post->post_title;
-			// Convert video embed blocks to the editor's bw-video-figure markup
-			// before the_content + wp_kses_post strip the iframe.
+			// Convert video embed blocks to the editor's bw-video-figure markup.
 			$raw_content = wpcom_write_convert_video_embeds( $edit_post->post_content );
-			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Core filter needed to render blocks.
-			$edit_content     = apply_filters( 'the_content', $raw_content );
+			// Use do_blocks() instead of apply_filters( 'the_content' ) — the Write
+			// editor only produces block markup, so the full the_content pipeline
+			// (oEmbed, shortcodes, wpautop, etc.) is unnecessary and its wpcom-specific
+			// filters can mangle iframes on Simple / Atomic sites.
+			$edit_content     = do_blocks( $raw_content );
 			$post_status      = $edit_post->post_status;
 			$edit_featured_id = (int) get_post_thumbnail_id( $edit_post_id );
 		} else {

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -180,7 +180,7 @@ function wpcom_write_convert_video_embeds( $content ) {
 			$embed_url = '';
 
 			// YouTube.
-			if ( preg_match( '/(?:youtube\.com\/watch\?v=|youtu\.be\/)([a-zA-Z0-9_-]{11})/', $url, $yt ) ) {
+			if ( preg_match( '/(?:youtube\.com\/watch\?(?:[^&]*&)*v=|youtu\.be\/)([a-zA-Z0-9_-]{11})/', $url, $yt ) ) {
 				$embed_url = 'https://www.youtube.com/embed/' . $yt[1];
 			}
 			// Vimeo.
@@ -192,9 +192,12 @@ function wpcom_write_convert_video_embeds( $content ) {
 				return $matches[0];
 			}
 
+			$title = $yt ? 'YouTube video' : 'Vimeo video';
+
 			return sprintf(
-				'<figure class="bw-video-figure"><div class="bw-video-wrap"><iframe src="%s" frameborder="0" allowfullscreen></iframe></div></figure>',
-				esc_url( $embed_url )
+				'<figure class="bw-video-figure"><div class="bw-video-wrap"><iframe src="%s" title="%s" frameborder="0" allowfullscreen></iframe></div></figure>',
+				esc_url( $embed_url ),
+				esc_attr( $title )
 			);
 		},
 		$content

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -192,7 +192,7 @@ function wpcom_write_convert_video_embeds( $content ) {
 				return $matches[0];
 			}
 
-			$title = $yt ? 'YouTube video' : 'Vimeo video';
+			$title = $yt ? __( 'YouTube video', 'jetpack-mu-wpcom' ) : __( 'Vimeo video', 'jetpack-mu-wpcom' );
 
 			return sprintf(
 				'<figure class="bw-video-figure"><div class="bw-video-wrap"><iframe src="%s" title="%s" frameborder="0" allowfullscreen></iframe></div></figure>',

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -159,20 +159,23 @@ add_action(
 );
 
 /**
- * Convert wp:embed video blocks in raw block markup to bw-video-figure HTML.
+ * Convert wp:embed video blocks to placeholder tokens for the Write editor.
  *
- * The do_blocks() renderer doesn't convert embed blocks into iframes the way
- * the full the_content pipeline would (via WP_Embed).  This function detects
- * YouTube / Vimeo embed blocks and rewrites them to the Write editor's own
- * bw-video-figure markup so videos display on reload.
+ * Video embed blocks are replaced with inert HTML comment tokens that survive
+ * the_content filters, wp_kses_post(), and the pre_kses filter chain (which
+ * converts YouTube iframes to shortcodes on non-frontend requests).  The
+ * returned placeholders map is used to swap tokens for real iframe HTML after
+ * all sanitization is complete.
  *
  * @param string $content Raw post_content (block markup).
- * @return string Content with video embed blocks replaced by bw-video-figure HTML.
+ * @return array { content: string, placeholders: array<string,string> }
  */
 function wpcom_write_convert_video_embeds( $content ) {
-	return preg_replace_callback(
+	$placeholders = array();
+
+	$replaced = preg_replace_callback(
 		'/<!-- wp:embed (\{[^}]*"type"\s*:\s*"video"[^}]*\}) -->.+?<!-- \/wp:embed -->/s',
-		static function ( $matches ) {
+		static function ( $matches ) use ( &$placeholders ) {
 			$attrs = json_decode( $matches[1], true );
 			if ( ! is_array( $attrs ) || empty( $attrs['url'] ) ) {
 				return $matches[0];
@@ -194,15 +197,23 @@ function wpcom_write_convert_video_embeds( $content ) {
 			}
 
 			$title = $yt ? __( 'YouTube video', 'jetpack-mu-wpcom' ) : __( 'Vimeo video', 'jetpack-mu-wpcom' );
-
-			return sprintf(
+			$token = '<!--WRITE_VIDEO_' . md5( $embed_url ) . '-->';
+			$html  = sprintf(
 				'<figure class="bw-video-figure"><div class="bw-video-wrap"><iframe src="%s" title="%s" frameborder="0" allowfullscreen></iframe></div></figure>',
 				esc_url( $embed_url ),
 				esc_attr( $title )
 			);
+
+			$placeholders[ $token ] = $html;
+			return $token;
 		},
 		$content
-	) ?? $content;
+	);
+
+	return array(
+		'content'      => $replaced ?? $content,
+		'placeholders' => $placeholders,
+	);
 }
 
 /**
@@ -215,25 +226,26 @@ function wpcom_write_convert_video_embeds( $content ) {
 function wpcom_write_render_admin_page() {
 	// Check if editing an existing post.
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only GET parameter, gated by capability check via add_submenu_page.
-	$edit_post_id     = isset( $_GET['post'] ) ? absint( $_GET['post'] ) : 0;
-	$edit_title       = '';
-	$edit_content     = '';
-	$post_status      = 'new';
-	$edit_featured_id = 0;
+	$edit_post_id       = isset( $_GET['post'] ) ? absint( $_GET['post'] ) : 0;
+	$edit_title         = '';
+	$edit_content       = '';
+	$post_status        = 'new';
+	$edit_featured_id   = 0;
+	$video_placeholders = array();
 
 	if ( $edit_post_id ) {
 		$edit_post = get_post( $edit_post_id );
 		if ( $edit_post && current_user_can( 'edit_post', $edit_post_id ) ) {
 			$edit_title = $edit_post->post_title;
-			// Convert video embed blocks to the editor's bw-video-figure markup.
-			$raw_content = wpcom_write_convert_video_embeds( $edit_post->post_content );
-			// Use do_blocks() instead of apply_filters( 'the_content' ) — the Write
-			// editor only produces block markup, so the full the_content pipeline
-			// (oEmbed, shortcodes, wpautop, etc.) is unnecessary and its wpcom-specific
-			// filters can mangle iframes on Simple / Atomic sites.
-			$edit_content     = do_blocks( $raw_content );
-			$post_status      = $edit_post->post_status;
-			$edit_featured_id = (int) get_post_thumbnail_id( $edit_post_id );
+			// Convert video embed blocks to inert placeholder tokens before the
+			// the_content + wp_kses_post pipeline runs.  Tokens survive all filters;
+			// real iframe HTML is swapped in after sanitization in the template.
+			$video_result = wpcom_write_convert_video_embeds( $edit_post->post_content );
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Core filter needed to render blocks.
+			$edit_content       = apply_filters( 'the_content', $video_result['content'] );
+			$video_placeholders = $video_result['placeholders'];
+			$post_status        = $edit_post->post_status;
+			$edit_featured_id   = (int) get_post_thumbnail_id( $edit_post_id );
 		} else {
 			$edit_post_id = 0;
 		}
@@ -297,7 +309,7 @@ function wpcom_write_render_admin_page() {
 	);
 
 	// Output the editor UI inside wp-admin's wrapper.
-	wpcom_write_template( $edit_title, $edit_content, $edit_post_id, $categories_data, $post_status );
+	wpcom_write_template( $edit_title, $edit_content, $edit_post_id, $categories_data, $post_status, $video_placeholders );
 }
 
 /**
@@ -306,13 +318,14 @@ function wpcom_write_render_admin_page() {
  * This outputs HTML inside wp-admin's page wrapper (not a standalone page).
  * The wp-admin chrome is hidden via CSS added in admin_enqueue_scripts.
  *
- * @param string $edit_title      The post title when editing.
- * @param string $edit_content    The post content when editing.
- * @param int    $edit_post_id    The post ID when editing, 0 for new posts.
- * @param array  $categories_data Array of category data for the picker.
- * @param string $post_status     The post status ('new', 'draft', 'publish', etc.).
+ * @param string $edit_title          The post title when editing.
+ * @param string $edit_content        The post content when editing.
+ * @param int    $edit_post_id        The post ID when editing, 0 for new posts.
+ * @param array  $categories_data     Array of category data for the picker.
+ * @param string $post_status         The post status ('new', 'draft', 'publish', etc.).
+ * @param array  $video_placeholders  Map of comment tokens to iframe HTML for video embeds.
  */
-function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_id = 0, $categories_data = array(), $post_status = 'new' ) {
+function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_id = 0, $categories_data = array(), $post_status = 'new', $video_placeholders = array() ) {
 	?>
 <div data-wp-interactive="wpcom-write" class="bw-app">
 
@@ -443,23 +456,14 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 			>
 			<?php
 			if ( $edit_content ) {
-				// Allow iframe through wp_kses_post so video embeds survive.
-				$wpcom_write_allow_iframe = static function ( $tags, $context ) {
-					if ( 'post' === $context && ! isset( $tags['iframe'] ) ) {
-						$tags['iframe'] = array(
-							'src'             => true,
-							'frameborder'     => true,
-							'allowfullscreen' => true,
-							'width'           => true,
-							'height'          => true,
-							'title'           => true,
-						);
-					}
-					return $tags;
-				};
-				add_filter( 'wp_kses_allowed_html', $wpcom_write_allow_iframe, 10, 2 );
-				echo wp_kses_post( $edit_content );
-				remove_filter( 'wp_kses_allowed_html', $wpcom_write_allow_iframe, 10 );
+				// Sanitize through wp_kses_post — video embed tokens (HTML comments)
+				// pass through untouched, then we swap them for the real iframe HTML.
+				// This avoids the pre_kses filter that converts iframes to shortcodes.
+				$sanitized = wp_kses_post( $edit_content );
+				if ( $video_placeholders ) {
+					$sanitized = str_replace( array_keys( $video_placeholders ), array_values( $video_placeholders ), $sanitized );
+				}
+				echo $sanitized; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Sanitized by wp_kses_post; iframe HTML is self-constructed with esc_url/esc_attr.
 			} else {
 				echo '<p><br></p>';
 			}

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -159,6 +159,49 @@ add_action(
 );
 
 /**
+ * Convert wp:embed video blocks in raw block markup to bw-video-figure HTML.
+ *
+ * The the_content filter + wp_kses_post pipeline strips the iframe from embed
+ * blocks, leaving an empty wrapper.  By converting video embeds to the Write
+ * editor's own markup before that pipeline runs, the iframe is preserved.
+ *
+ * @param string $content Raw post_content (block markup).
+ * @return string Content with video embed blocks replaced by bw-video-figure HTML.
+ */
+function wpcom_write_convert_video_embeds( $content ) {
+	return preg_replace_callback(
+		'/<!-- wp:embed (\{[^}]*"type"\s*:\s*"video"[^}]*\}) -->.+?<!-- \/wp:embed -->/s',
+		static function ( $matches ) {
+			$attrs = json_decode( $matches[1], true );
+			if ( ! is_array( $attrs ) || empty( $attrs['url'] ) ) {
+				return $matches[0];
+			}
+			$url       = $attrs['url'];
+			$embed_url = '';
+
+			// YouTube.
+			if ( preg_match( '/(?:youtube\.com\/watch\?v=|youtu\.be\/)([a-zA-Z0-9_-]{11})/', $url, $yt ) ) {
+				$embed_url = 'https://www.youtube.com/embed/' . $yt[1];
+			}
+			// Vimeo.
+			if ( ! $embed_url && preg_match( '/vimeo\.com\/(\d+)/', $url, $vim ) ) {
+				$embed_url = 'https://player.vimeo.com/video/' . $vim[1];
+			}
+
+			if ( ! $embed_url ) {
+				return $matches[0];
+			}
+
+			return sprintf(
+				'<figure class="bw-video-figure"><div class="bw-video-wrap"><iframe src="%s" frameborder="0" allowfullscreen></iframe></div></figure>',
+				esc_url( $embed_url )
+			);
+		},
+		$content
+	);
+}
+
+/**
  * Render the Write admin page.
  *
  * Called by add_submenu_page as the page callback. Runs inside wp-admin's
@@ -178,8 +221,11 @@ function wpcom_write_render_admin_page() {
 		$edit_post = get_post( $edit_post_id );
 		if ( $edit_post && current_user_can( 'edit_post', $edit_post_id ) ) {
 			$edit_title = $edit_post->post_title;
+			// Convert video embed blocks to the editor's bw-video-figure markup
+			// before the_content + wp_kses_post strip the iframe.
+			$raw_content = wpcom_write_convert_video_embeds( $edit_post->post_content );
 			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Core filter needed to render blocks.
-			$edit_content     = apply_filters( 'the_content', $edit_post->post_content );
+			$edit_content     = apply_filters( 'the_content', $raw_content );
 			$post_status      = $edit_post->post_status;
 			$edit_featured_id = (int) get_post_thumbnail_id( $edit_post_id );
 		} else {
@@ -388,7 +434,31 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 				data-wp-on--keydown="actions.handleKeyDown"
 				data-wp-on--beforeinput="actions.handleBeforeInput"
 				data-placeholder="<?php echo esc_attr__( 'Tell your story...', 'jetpack-mu-wpcom' ); ?>"
-			><?php echo $edit_content ? wp_kses_post( $edit_content ) : '<p><br></p>'; ?></div>
+			>
+			<?php
+			if ( $edit_content ) {
+				// Allow iframe through wp_kses_post so video embeds survive.
+				$wpcom_write_allow_iframe = static function ( $tags, $context ) {
+					if ( 'post' === $context && ! isset( $tags['iframe'] ) ) {
+						$tags['iframe'] = array(
+							'src'             => true,
+							'frameborder'     => true,
+							'allowfullscreen' => true,
+							'width'           => true,
+							'height'          => true,
+							'title'           => true,
+						);
+					}
+					return $tags;
+				};
+				add_filter( 'wp_kses_allowed_html', $wpcom_write_allow_iframe, 10, 2 );
+				echo wp_kses_post( $edit_content );
+				remove_filter( 'wp_kses_allowed_html', $wpcom_write_allow_iframe, 10 );
+			} else {
+				echo '<p><br></p>';
+			}
+			?>
+			</div>
 		</div>
 	</main>
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -398,6 +398,7 @@ class Write_Test extends \WorDBless\BaseTestCase {
 		$this->assertStringContainsString( 'class="bw-video-figure"', $result );
 		$this->assertStringContainsString( 'https://www.youtube.com/embed/dQw4w9WgXcQ', $result );
 		$this->assertStringContainsString( '<iframe', $result );
+		$this->assertStringContainsString( 'title="YouTube video"', $result );
 	}
 
 	/**
@@ -405,6 +406,18 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_convert_video_embeds_youtube_short() {
 		$content = $this->embed_block( 'https://youtu.be/dQw4w9WgXcQ' );
+		$result  = wpcom_write_convert_video_embeds( $content );
+
+		$this->assertStringContainsString( 'class="bw-video-figure"', $result );
+		$this->assertStringContainsString( 'https://www.youtube.com/embed/dQw4w9WgXcQ', $result );
+		$this->assertStringContainsString( 'title="YouTube video"', $result );
+	}
+
+	/**
+	 * Test YouTube URL with v= not as the first query parameter.
+	 */
+	public function test_convert_video_embeds_youtube_v_not_first_param() {
+		$content = $this->embed_block( 'https://www.youtube.com/watch?feature=share&v=dQw4w9WgXcQ' );
 		$result  = wpcom_write_convert_video_embeds( $content );
 
 		$this->assertStringContainsString( 'class="bw-video-figure"', $result );
@@ -421,6 +434,7 @@ class Write_Test extends \WorDBless\BaseTestCase {
 		$this->assertStringContainsString( 'class="bw-video-figure"', $result );
 		$this->assertStringContainsString( 'https://player.vimeo.com/video/123456789', $result );
 		$this->assertStringContainsString( '<iframe', $result );
+		$this->assertStringContainsString( 'title="Vimeo video"', $result );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -506,10 +506,11 @@ class Write_Test extends \WorDBless\BaseTestCase {
 			)
 		);
 
-		// Simulate the render path: convert embeds then apply the_content.
+		// Simulate the render path: convert embeds then do_blocks.
 		$post        = get_post( $post_id );
 		$raw_content = wpcom_write_convert_video_embeds( $post->post_content );
-		$output      = $this->render_template( 'Video Post', $raw_content, $post_id, array(), 'draft' );
+		$rendered    = do_blocks( $raw_content );
+		$output      = $this->render_template( 'Video Post', $rendered, $post_id, array(), 'draft' );
 
 		$this->assertStringContainsString( '<iframe', $output );
 		$this->assertStringContainsString( 'youtube.com/embed/dQw4w9WgXcQ', $output );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -101,12 +101,12 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	 * @param array  $categories Categories data.
 	 * @return string The rendered HTML.
 	 */
-	private function render_template( $title = '', $content = '', $post_id = 0, $categories = array(), $post_status = 'new' ) {
+	private function render_template( $title = '', $content = '', $post_id = 0, $categories = array(), $post_status = 'new', $video_placeholders = array() ) {
 		remove_all_actions( 'wp_head' );
 		remove_all_actions( 'wp_footer' );
 
 		ob_start();
-		wpcom_write_template( $title, $content, $post_id, $categories, $post_status );
+		wpcom_write_template( $title, $content, $post_id, $categories, $post_status, $video_placeholders );
 		return ob_get_clean();
 	}
 
@@ -395,10 +395,16 @@ class Write_Test extends \WorDBless\BaseTestCase {
 		$content = $this->embed_block( 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' );
 		$result  = wpcom_write_convert_video_embeds( $content );
 
-		$this->assertStringContainsString( 'class="bw-video-figure"', $result );
-		$this->assertStringContainsString( 'https://www.youtube.com/embed/dQw4w9WgXcQ', $result );
-		$this->assertStringContainsString( '<iframe', $result );
-		$this->assertStringContainsString( 'title="YouTube video"', $result );
+		$this->assertArrayHasKey( 'content', $result );
+		$this->assertArrayHasKey( 'placeholders', $result );
+		$this->assertCount( 1, $result['placeholders'] );
+		$this->assertStringContainsString( '<!--WRITE_VIDEO_', $result['content'] );
+
+		$html = array_values( $result['placeholders'] )[0];
+		$this->assertStringContainsString( 'class="bw-video-figure"', $html );
+		$this->assertStringContainsString( 'https://www.youtube.com/embed/dQw4w9WgXcQ', $html );
+		$this->assertStringContainsString( '<iframe', $html );
+		$this->assertStringContainsString( 'title="YouTube video"', $html );
 	}
 
 	/**
@@ -408,9 +414,9 @@ class Write_Test extends \WorDBless\BaseTestCase {
 		$content = $this->embed_block( 'https://youtu.be/dQw4w9WgXcQ' );
 		$result  = wpcom_write_convert_video_embeds( $content );
 
-		$this->assertStringContainsString( 'class="bw-video-figure"', $result );
-		$this->assertStringContainsString( 'https://www.youtube.com/embed/dQw4w9WgXcQ', $result );
-		$this->assertStringContainsString( 'title="YouTube video"', $result );
+		$html = array_values( $result['placeholders'] )[0];
+		$this->assertStringContainsString( 'https://www.youtube.com/embed/dQw4w9WgXcQ', $html );
+		$this->assertStringContainsString( 'title="YouTube video"', $html );
 	}
 
 	/**
@@ -420,8 +426,8 @@ class Write_Test extends \WorDBless\BaseTestCase {
 		$content = $this->embed_block( 'https://www.youtube.com/watch?feature=share&v=dQw4w9WgXcQ' );
 		$result  = wpcom_write_convert_video_embeds( $content );
 
-		$this->assertStringContainsString( 'class="bw-video-figure"', $result );
-		$this->assertStringContainsString( 'https://www.youtube.com/embed/dQw4w9WgXcQ', $result );
+		$html = array_values( $result['placeholders'] )[0];
+		$this->assertStringContainsString( 'https://www.youtube.com/embed/dQw4w9WgXcQ', $html );
 	}
 
 	/**
@@ -431,10 +437,11 @@ class Write_Test extends \WorDBless\BaseTestCase {
 		$content = $this->embed_block( 'https://vimeo.com/123456789' );
 		$result  = wpcom_write_convert_video_embeds( $content );
 
-		$this->assertStringContainsString( 'class="bw-video-figure"', $result );
-		$this->assertStringContainsString( 'https://player.vimeo.com/video/123456789', $result );
-		$this->assertStringContainsString( '<iframe', $result );
-		$this->assertStringContainsString( 'title="Vimeo video"', $result );
+		$html = array_values( $result['placeholders'] )[0];
+		$this->assertStringContainsString( 'class="bw-video-figure"', $html );
+		$this->assertStringContainsString( 'https://player.vimeo.com/video/123456789', $html );
+		$this->assertStringContainsString( '<iframe', $html );
+		$this->assertStringContainsString( 'title="Vimeo video"', $html );
 	}
 
 	/**
@@ -444,9 +451,8 @@ class Write_Test extends \WorDBless\BaseTestCase {
 		$content = $this->embed_block( 'https://twitter.com/example/status/123', 'rich' );
 		$result  = wpcom_write_convert_video_embeds( $content );
 
-		$this->assertStringNotContainsString( 'bw-video-figure', $result );
-		$this->assertStringNotContainsString( '<iframe', $result );
-		$this->assertSame( $content, $result );
+		$this->assertEmpty( $result['placeholders'] );
+		$this->assertSame( $content, $result['content'] );
 	}
 
 	/**
@@ -463,7 +469,8 @@ class Write_Test extends \WorDBless\BaseTestCase {
 		$content = '<!-- wp:embed ' . $attrs . ' --><figure class="wp-block-embed"><div class="wp-block-embed__wrapper"></div></figure><!-- /wp:embed -->';
 		$result  = wpcom_write_convert_video_embeds( $content );
 
-		$this->assertSame( $content, $result );
+		$this->assertEmpty( $result['placeholders'] );
+		$this->assertSame( $content, $result['content'] );
 	}
 
 	/**
@@ -473,7 +480,8 @@ class Write_Test extends \WorDBless\BaseTestCase {
 		$content = '<p>Hello world</p>';
 		$result  = wpcom_write_convert_video_embeds( $content );
 
-		$this->assertSame( $content, $result );
+		$this->assertEmpty( $result['placeholders'] );
+		$this->assertSame( $content, $result['content'] );
 	}
 
 	/**
@@ -485,9 +493,11 @@ class Write_Test extends \WorDBless\BaseTestCase {
 			. $this->embed_block( 'https://vimeo.com/987654321' );
 		$result  = wpcom_write_convert_video_embeds( $content );
 
-		$this->assertStringContainsString( 'https://www.youtube.com/embed/dQw4w9WgXcQ', $result );
-		$this->assertStringContainsString( 'https://player.vimeo.com/video/987654321', $result );
-		$this->assertSame( 2, substr_count( $result, 'bw-video-figure' ) );
+		$this->assertCount( 2, $result['placeholders'] );
+		$all_html = implode( "\n", array_values( $result['placeholders'] ) );
+		$this->assertStringContainsString( 'https://www.youtube.com/embed/dQw4w9WgXcQ', $all_html );
+		$this->assertStringContainsString( 'https://player.vimeo.com/video/987654321', $all_html );
+		$this->assertSame( 2, substr_count( $all_html, 'bw-video-figure' ) );
 	}
 
 	/**
@@ -506,11 +516,12 @@ class Write_Test extends \WorDBless\BaseTestCase {
 			)
 		);
 
-		// Simulate the render path: convert embeds then do_blocks.
-		$post        = get_post( $post_id );
-		$raw_content = wpcom_write_convert_video_embeds( $post->post_content );
-		$rendered    = do_blocks( $raw_content );
-		$output      = $this->render_template( 'Video Post', $rendered, $post_id, array(), 'draft' );
+		// Simulate the render path: convert embeds to tokens, run the_content,
+		// then pass placeholders to the template for post-kses replacement.
+		$post         = get_post( $post_id );
+		$video_result = wpcom_write_convert_video_embeds( $post->post_content );
+		$rendered     = apply_filters( 'the_content', $video_result['content'] ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+		$output       = $this->render_template( 'Video Post', $rendered, $post_id, array(), 'draft', $video_result['placeholders'] );
 
 		$this->assertStringContainsString( '<iframe', $output );
 		$this->assertStringContainsString( 'youtube.com/embed/dQw4w9WgXcQ', $output );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -368,4 +368,137 @@ class Write_Test extends \WorDBless\BaseTestCase {
 		// The showRecoveryBanner field confirms autosave state is registered.
 		$this->assertArrayHasKey( 'showRecoveryBanner', $state );
 	}
+
+	/**
+	 * Helper: build a wp:embed block string.
+	 *
+	 * @param string $url  The embed URL.
+	 * @param string $type The embed type attribute (default "video").
+	 * @return string Block markup.
+	 */
+	private function embed_block( $url, $type = 'video' ) {
+		$attrs = wp_json_encode(
+			array(
+				'url'              => $url,
+				'type'             => $type,
+				'providerNameSlug' => 'youtube',
+			),
+			JSON_UNESCAPED_SLASHES
+		);
+		return '<!-- wp:embed ' . $attrs . ' --><figure class="wp-block-embed"><div class="wp-block-embed__wrapper">' . esc_url( $url ) . '</div></figure><!-- /wp:embed -->';
+	}
+
+	/**
+	 * Test YouTube standard URL is converted to an embed iframe.
+	 */
+	public function test_convert_video_embeds_youtube_standard() {
+		$content = $this->embed_block( 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' );
+		$result  = wpcom_write_convert_video_embeds( $content );
+
+		$this->assertStringContainsString( 'class="bw-video-figure"', $result );
+		$this->assertStringContainsString( 'https://www.youtube.com/embed/dQw4w9WgXcQ', $result );
+		$this->assertStringContainsString( '<iframe', $result );
+	}
+
+	/**
+	 * Test YouTube short URL (youtu.be) is converted to an embed iframe.
+	 */
+	public function test_convert_video_embeds_youtube_short() {
+		$content = $this->embed_block( 'https://youtu.be/dQw4w9WgXcQ' );
+		$result  = wpcom_write_convert_video_embeds( $content );
+
+		$this->assertStringContainsString( 'class="bw-video-figure"', $result );
+		$this->assertStringContainsString( 'https://www.youtube.com/embed/dQw4w9WgXcQ', $result );
+	}
+
+	/**
+	 * Test Vimeo URL is converted to an embed iframe.
+	 */
+	public function test_convert_video_embeds_vimeo() {
+		$content = $this->embed_block( 'https://vimeo.com/123456789' );
+		$result  = wpcom_write_convert_video_embeds( $content );
+
+		$this->assertStringContainsString( 'class="bw-video-figure"', $result );
+		$this->assertStringContainsString( 'https://player.vimeo.com/video/123456789', $result );
+		$this->assertStringContainsString( '<iframe', $result );
+	}
+
+	/**
+	 * Test that non-video embed blocks are left unchanged.
+	 */
+	public function test_convert_video_embeds_skips_non_video() {
+		$content = $this->embed_block( 'https://twitter.com/example/status/123', 'rich' );
+		$result  = wpcom_write_convert_video_embeds( $content );
+
+		$this->assertStringNotContainsString( 'bw-video-figure', $result );
+		$this->assertStringNotContainsString( '<iframe', $result );
+		$this->assertSame( $content, $result );
+	}
+
+	/**
+	 * Test that embed blocks with missing URL are left unchanged.
+	 */
+	public function test_convert_video_embeds_skips_missing_url() {
+		$attrs   = wp_json_encode(
+			array(
+				'type'             => 'video',
+				'providerNameSlug' => 'youtube',
+			),
+			JSON_UNESCAPED_SLASHES
+		);
+		$content = '<!-- wp:embed ' . $attrs . ' --><figure class="wp-block-embed"><div class="wp-block-embed__wrapper"></div></figure><!-- /wp:embed -->';
+		$result  = wpcom_write_convert_video_embeds( $content );
+
+		$this->assertSame( $content, $result );
+	}
+
+	/**
+	 * Test that plain content without embed blocks passes through unchanged.
+	 */
+	public function test_convert_video_embeds_plain_content() {
+		$content = '<p>Hello world</p>';
+		$result  = wpcom_write_convert_video_embeds( $content );
+
+		$this->assertSame( $content, $result );
+	}
+
+	/**
+	 * Test that multiple video embeds in one string are all converted.
+	 */
+	public function test_convert_video_embeds_multiple() {
+		$content = $this->embed_block( 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' )
+			. "\n"
+			. $this->embed_block( 'https://vimeo.com/987654321' );
+		$result  = wpcom_write_convert_video_embeds( $content );
+
+		$this->assertStringContainsString( 'https://www.youtube.com/embed/dQw4w9WgXcQ', $result );
+		$this->assertStringContainsString( 'https://player.vimeo.com/video/987654321', $result );
+		$this->assertSame( 2, substr_count( $result, 'bw-video-figure' ) );
+	}
+
+	/**
+	 * Test that editing a post with a video embed renders an iframe in the template.
+	 */
+	public function test_template_renders_video_embed_iframe() {
+		wp_set_current_user( $this->admin_id );
+
+		$video_block = $this->embed_block( 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' );
+		$post_id     = wp_insert_post(
+			array(
+				'post_title'   => 'Video Post',
+				'post_content' => $video_block,
+				'post_status'  => 'draft',
+				'post_author'  => $this->admin_id,
+			)
+		);
+
+		// Simulate the render path: convert embeds then apply the_content.
+		$post        = get_post( $post_id );
+		$raw_content = wpcom_write_convert_video_embeds( $post->post_content );
+		$output      = $this->render_template( 'Video Post', $raw_content, $post_id, array(), 'draft' );
+
+		$this->assertStringContainsString( '<iframe', $output );
+		$this->assertStringContainsString( 'youtube.com/embed/dQw4w9WgXcQ', $output );
+		$this->assertStringContainsString( 'bw-video-figure', $output );
+	}
 }


### PR DESCRIPTION
Fixes RSM-1945

## Proposed changes

* Fix video embeds (YouTube, Vimeo) not displaying when reloading a post in the Write editor.
* The `the_content` filter + `wp_kses_post()` pipeline was stripping the iframe from `wp:embed` blocks, leaving an empty wrapper div on reload.
* Added `wpcom_write_convert_video_embeds()` which converts video embed blocks to the editor's `bw-video-figure` markup (with iframe) before that pipeline runs.
* Temporarily allows `iframe` through `wp_kses_post` for the Write content output to ensure the embed survives sanitization.

## Related product discussion/links

* RSM-1945

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Open the Write editor and add a YouTube or Vimeo video via the slash menu or video button.
* Save the post as a draft.
* Reopen the post in the write editor (get the post ID and add &post={id} to the URL) and verify that the video displays properly.
* Verify the video also displays correctly when editing the same post in the block editor.
* Verify that adding a new video after reload still works as expected.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>