### PR TITLE
Wpcomsh recovery-mode sync: include per-extension error info

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-recovery-mode-sync-errors
+++ b/projects/plugins/wpcomsh/changelog/add-recovery-mode-sync-errors
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Recovery-mode sync: include per-extension error info (kind/slug/version/file/line/message + transportable signature) so wpcom-side consumers can surface what fataled.
+Recovery-mode sync: include per-extension error info (kind/slug/version/file/line/message) so wpcom-side consumers can surface what fataled.

--- a/projects/plugins/wpcomsh/changelog/add-recovery-mode-sync-errors
+++ b/projects/plugins/wpcomsh/changelog/add-recovery-mode-sync-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Recovery-mode sync: include per-extension error info (kind/slug/version/file/line/message + transportable signature) so wpcom-side consumers can surface what fataled.

--- a/projects/plugins/wpcomsh/changelog/add-recovery-mode-sync-errors
+++ b/projects/plugins/wpcomsh/changelog/add-recovery-mode-sync-errors
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Recovery-mode sync: include per-extension error info (kind/slug/version/file/line/message) so wpcom-side consumers can surface what fataled.
+Recovery-mode sync: include per-extension error info so wpcom-side consumers can surface what fataled.

--- a/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
+++ b/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
@@ -15,9 +15,12 @@
  *   - `recovery_session_exited_at`     — wpcomsh-managed; updated on deletion
  *     of `{session_id}_paused_extensions`, i.e. when the admin exits recovery.
  *   - `recovery_session_errors`        — a list of `{kind, slug, version,
- *     errno, message, file, line}` records derived from the live
- *     `*_paused_extensions` option, so wpcom can surface what fataled rather
- *     than just that something fataled. Empty once the admin exits recovery.
+ *     errno, message, file, line}` records, so wpcom can surface what fataled
+ *     rather than just that something fataled. Sourced from the live
+ *     `*_paused_extensions` option once the admin enters recovery; on the
+ *     fatal request itself (before the admin clicks the email link) the list
+ *     is populated from `error_get_last()` so the very first POST already
+ *     carries the error info. Empty once the admin exits recovery.
  *
  * The POST runs from a PHP shutdown function so the signal reaches wpcom even
  * on fatal-error requests, matching the pattern used by migrate-guru-canary.
@@ -47,6 +50,16 @@ class WPCOMSH_Recovery_Mode_Sync {
 	private static $payload = array();
 
 	/**
+	 * Error record captured from `error_get_last()` at email-send time so the
+	 * fatal-request POST carries error info before the admin enters recovery
+	 * and `*_paused_extensions` exists. Null when no fatal has been captured
+	 * (or when the fatal didn't come from a known plugin/theme).
+	 *
+	 * @var array<string,mixed>|null
+	 */
+	private static $transient_fatal = null;
+
+	/**
 	 * Register option-change listeners.
 	 */
 	public static function init() {
@@ -66,6 +79,10 @@ class WPCOMSH_Recovery_Mode_Sync {
 	 * Listener for the recovery-mode email timestamp.
 	 */
 	public static function capture_email_last_sent() {
+		// We're called inside WP's fatal-handler shutdown stack, so
+		// `error_get_last()` still holds the original fatal that caused WP to
+		// send the email. Snapshot it now so the snapshot below picks it up.
+		self::capture_current_fatal();
 		self::snapshot();
 		self::trace(
 			'captured email_last_sent',
@@ -226,15 +243,128 @@ class WPCOMSH_Recovery_Mode_Sync {
 	 * @return array<int,array<string,mixed>>
 	 */
 	private static function current_session_errors() {
-		if ( ! function_exists( 'wp_recovery_mode' ) ) {
-			return array();
+		if ( function_exists( 'wp_recovery_mode' ) ) {
+			$session_id = wp_recovery_mode()->get_session_id();
+			if ( ! empty( $session_id ) ) {
+				$errors = self::extract_errors(
+					get_option( $session_id . self::PAUSED_EXTENSIONS_OPTION_SUFFIX )
+				);
+				if ( ! empty( $errors ) ) {
+					return $errors;
+				}
+			}
 		}
-		$session_id = wp_recovery_mode()->get_session_id();
-		if ( empty( $session_id ) ) {
-			return array();
+		// No active session yet (fatal request, before admin clicks the email
+		// link) — fall back to the fatal we captured from `error_get_last()`.
+		return null !== self::$transient_fatal ? array( self::$transient_fatal ) : array();
+	}
+
+	/**
+	 * Snapshot the currently-pending PHP fatal (if any) into a transportable
+	 * record. Called from `capture_email_last_sent()` so we run inside WP's
+	 * fatal-handler shutdown, when `error_get_last()` still holds the fatal
+	 * that triggered the recovery email. No-op when there's no fatal pending
+	 * or the fatal didn't originate from a known plugin/theme path.
+	 */
+	private static function capture_current_fatal() {
+		if ( null !== self::$transient_fatal ) {
+			return;
 		}
-		$value = get_option( $session_id . self::PAUSED_EXTENSIONS_OPTION_SUFFIX );
-		return self::extract_errors( $value );
+		$err = error_get_last();
+		if ( ! is_array( $err ) ) {
+			return;
+		}
+		$fatal_mask = E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR;
+		if ( ! ( (int) ( $err['type'] ?? 0 ) & $fatal_mask ) ) {
+			return;
+		}
+		$file     = (string) ( $err['file'] ?? '' );
+		$resolved = self::resolve_extension_for_file( $file );
+		if ( null === $resolved ) {
+			return;
+		}
+		list( $kind, $slug ) = $resolved;
+
+		if ( ! function_exists( 'get_plugins' ) && defined( 'ABSPATH' ) ) {
+			$plugin_admin = ABSPATH . 'wp-admin/includes/plugin.php';
+			if ( file_exists( $plugin_admin ) ) {
+				require_once $plugin_admin;
+			}
+		}
+		$plugins = function_exists( 'get_plugins' ) ? get_plugins() : array();
+
+		self::$transient_fatal = array(
+			'kind'    => $kind,
+			'slug'    => $slug,
+			'version' => self::resolve_extension_version( $kind, $slug, $plugins ),
+			'errno'   => (int) $err['type'],
+			'message' => (string) ( $err['message'] ?? '' ),
+			'file'    => '' !== $file ? basename( $file ) : '',
+			'line'    => (int) ( $err['line'] ?? 0 ),
+		);
+	}
+
+	/**
+	 * Identify the plugin or theme a fatal originated from by matching the
+	 * file path against active plugin main files and the active theme
+	 * directories. Returns `[kind, slug]` matching the shape used by WP's own
+	 * `*_paused_extensions` storage (plugin slug = main-file relative path,
+	 * theme slug = stylesheet/template directory name), or null if the file
+	 * doesn't live under a known extension (e.g. core, mu-plugins, drop-ins).
+	 *
+	 * @param string $file Absolute path to the file that fataled.
+	 * @return array{0:string,1:string}|null
+	 */
+	private static function resolve_extension_for_file( $file ) {
+		if ( '' === $file || ! function_exists( 'wp_normalize_path' ) ) {
+			return null;
+		}
+		$normalized = wp_normalize_path( $file );
+
+		if ( defined( 'WP_PLUGIN_DIR' ) ) {
+			$plugin_dir = wp_normalize_path( WP_PLUGIN_DIR ) . '/';
+			if ( str_starts_with( $normalized, $plugin_dir ) ) {
+				$rel = substr( $normalized, strlen( $plugin_dir ) );
+				if ( ! function_exists( 'get_plugins' ) && defined( 'ABSPATH' ) ) {
+					$plugin_admin = ABSPATH . 'wp-admin/includes/plugin.php';
+					if ( file_exists( $plugin_admin ) ) {
+						require_once $plugin_admin;
+					}
+				}
+				$plugins = function_exists( 'get_plugins' ) ? get_plugins() : array();
+				foreach ( $plugins as $main_file => $_data ) {
+					$main_dir = dirname( $main_file );
+					if ( '.' === $main_dir ) {
+						if ( $rel === $main_file ) {
+							return array( 'plugin', $main_file );
+						}
+					} elseif ( str_starts_with( $rel, $main_dir . '/' ) ) {
+						return array( 'plugin', $main_file );
+					}
+				}
+			}
+		}
+
+		if ( function_exists( 'get_stylesheet' ) && function_exists( 'get_stylesheet_directory' ) ) {
+			$candidates = array();
+			$stylesheet = (string) get_stylesheet();
+			if ( '' !== $stylesheet ) {
+				$candidates[ $stylesheet ] = wp_normalize_path( get_stylesheet_directory() ) . '/';
+			}
+			if ( function_exists( 'get_template' ) && function_exists( 'get_template_directory' ) ) {
+				$template = (string) get_template();
+				if ( '' !== $template && $template !== $stylesheet ) {
+					$candidates[ $template ] = wp_normalize_path( get_template_directory() ) . '/';
+				}
+			}
+			foreach ( $candidates as $slug => $dir ) {
+				if ( str_starts_with( $normalized, $dir ) ) {
+					return array( 'theme', $slug );
+				}
+			}
+		}
+
+		return null;
 	}
 
 	/**

--- a/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
+++ b/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
@@ -4,7 +4,8 @@
  * wpcom-side consumers can surface "needs recovery" / "in recovery" states
  * for the site.
  *
- * Three timestamps are POSTed to `/sites/{blog_id}/recovery-mode-status`:
+ * Three timestamps + a per-extension error list are POSTed to
+ * `/sites/{blog_id}/recovery-mode-status`:
  *
  *   - `recovery_mode_email_last_sent`  — written by WP core each time a fatal
  *     triggers a recovery email (rate-limited to ~1/day).
@@ -13,6 +14,12 @@
  *     recovery session by clicking the email link.
  *   - `recovery_session_exited_at`     — wpcomsh-managed; updated on deletion
  *     of `{session_id}_paused_extensions`, i.e. when the admin exits recovery.
+ *   - `recovery_session_errors`        — a list of `{kind, slug, version,
+ *     errno, message, file, line, signature}` records derived from the live
+ *     `*_paused_extensions` option, so wpcom can surface what fataled rather
+ *     than just that something fataled. Empty once the admin exits recovery.
+ *     The signature is the shared transportable token from #48369 for
+ *     cross-surface grouping with the wpcomsh fatal-error screen.
  *
  * The POST runs from a PHP shutdown function so the signal reaches wpcom even
  * on fatal-error requests, matching the pattern used by migrate-guru-canary.
@@ -86,6 +93,7 @@ class WPCOMSH_Recovery_Mode_Sync {
 			array(
 				'option'     => $option,
 				'entered_at' => $now,
+				'errors'     => self::$payload['recovery_session_errors'] ?? array(),
 			)
 		);
 		self::send();
@@ -195,7 +203,9 @@ class WPCOMSH_Recovery_Mode_Sync {
 	}
 
 	/**
-	 * Populate the in-memory state snapshot once per request.
+	 * Populate the in-memory state snapshot once per request. Errors are read
+	 * from the live `*_paused_extensions` option so every capture path (email,
+	 * start, end) emits a complete state — no persistence of our own needed.
 	 */
 	private static function snapshot() {
 		if ( ! empty( self::$payload ) ) {
@@ -205,7 +215,123 @@ class WPCOMSH_Recovery_Mode_Sync {
 			'recovery_mode_email_last_sent' => (int) get_option( self::EMAIL_LAST_SENT_OPTION, 0 ),
 			'recovery_session_entered_at'   => (int) get_option( self::ENTERED_AT_OPTION, 0 ),
 			'recovery_session_exited_at'    => (int) get_option( self::EXITED_AT_OPTION, 0 ),
+			'recovery_session_errors'       => self::current_session_errors(),
 		);
+	}
+
+	/**
+	 * Read the active recovery session's `*_paused_extensions` option and
+	 * normalize it into transportable error records. Returns an empty array
+	 * when the session is gone (e.g. after admin exits) so wpcom sees the
+	 * state cleared rather than stale errors.
+	 *
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function current_session_errors() {
+		if ( ! function_exists( 'wp_recovery_mode' ) ) {
+			return array();
+		}
+		$session_id = wp_recovery_mode()->get_session_id();
+		if ( empty( $session_id ) ) {
+			return array();
+		}
+		$value = get_option( $session_id . self::PAUSED_EXTENSIONS_OPTION_SUFFIX );
+		return self::extract_errors( $value );
+	}
+
+	/**
+	 * Normalize WP's `*_paused_extensions` option into a flat list of records
+	 * suitable for transport. The option is shaped as
+	 * `[ 'plugin' => [ slug => {type,file,line,message} ], 'theme' => [ ... ] ]`.
+	 *
+	 * Each output record carries the kind/slug/version + the captured error
+	 * (file is reduced to its basename so server paths don't leak), plus a
+	 * transportable `signature` token built via the shared helper from #48369
+	 * so consumers can group fatals across the recovery and probe surfaces.
+	 *
+	 * @param mixed $paused_extensions Raw option value.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function extract_errors( $paused_extensions ) {
+		if ( ! is_array( $paused_extensions ) ) {
+			return array();
+		}
+
+		// `get_plugins()` lives in wp-admin/includes/plugin.php — not loaded on
+		// front-end requests, but recovery emails fire there.
+		if ( ! function_exists( 'get_plugins' ) && defined( 'ABSPATH' ) ) {
+			$plugin_admin = ABSPATH . 'wp-admin/includes/plugin.php';
+			if ( file_exists( $plugin_admin ) ) {
+				require_once $plugin_admin;
+			}
+		}
+		$plugins = function_exists( 'get_plugins' ) ? get_plugins() : array();
+
+		$out = array();
+		foreach ( array( 'plugin', 'theme' ) as $kind ) {
+			if ( empty( $paused_extensions[ $kind ] ) || ! is_array( $paused_extensions[ $kind ] ) ) {
+				continue;
+			}
+			foreach ( $paused_extensions[ $kind ] as $slug => $error ) {
+				if ( ! is_string( $slug ) || '' === $slug || ! is_array( $error ) ) {
+					continue;
+				}
+				$version = self::resolve_extension_version( $kind, $slug, $plugins );
+				$record  = array(
+					'kind'    => $kind,
+					'slug'    => $slug,
+					'version' => $version,
+					'errno'   => isset( $error['type'] ) ? (int) $error['type'] : 0,
+					'message' => isset( $error['message'] ) ? (string) $error['message'] : '',
+					'file'    => isset( $error['file'] ) ? basename( (string) $error['file'] ) : '',
+					'line'    => isset( $error['line'] ) ? (int) $error['line'] : 0,
+				);
+				if ( function_exists( 'wpcom_build_fatal_error_signature' ) ) {
+					$signature = wpcom_build_fatal_error_signature(
+						array(
+							'kind'    => $kind,
+							'slug'    => $slug,
+							'version' => $version,
+						)
+					);
+					if ( null !== $signature ) {
+						$record['signature'] = $signature;
+					}
+				}
+				$out[] = $record;
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * Resolve the installed version string for a paused extension.
+	 *
+	 * For plugins, WP keys the paused entry by the plugin's main-file path (or
+	 * its dirname); we match against `get_plugins()` output. For themes,
+	 * `wp_get_theme()` looks up by stylesheet directory name.
+	 *
+	 * @param string $kind    `plugin` or `theme`.
+	 * @param string $slug    Extension slug as recorded by WP recovery mode.
+	 * @param array  $plugins Cached `get_plugins()` output (plugins only).
+	 * @return string Version string, or empty when not resolvable.
+	 */
+	private static function resolve_extension_version( $kind, $slug, $plugins ) {
+		if ( 'plugin' === $kind ) {
+			foreach ( $plugins as $file => $data ) {
+				if ( $slug === $file || $slug === dirname( $file ) ) {
+					return isset( $data['Version'] ) ? (string) $data['Version'] : '';
+				}
+			}
+			return '';
+		}
+		if ( 'theme' === $kind && function_exists( 'wp_get_theme' ) ) {
+			$theme = wp_get_theme( $slug );
+			if ( $theme && $theme->exists() ) {
+				return (string) $theme->get( 'Version' );
+			}
+		}
+		return '';
 	}
 
 	/**

--- a/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
+++ b/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
@@ -44,7 +44,7 @@ class WPCOMSH_Recovery_Mode_Sync {
 	 * Pending state snapshot. Empty until the first capture this request —
 	 * its non-emptiness doubles as the "send needed" flag.
 	 *
-	 * @var array<string,int>
+	 * @var array<string,mixed>
 	 */
 	private static $payload = array();
 

--- a/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
+++ b/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
@@ -15,11 +15,9 @@
  *   - `recovery_session_exited_at`     — wpcomsh-managed; updated on deletion
  *     of `{session_id}_paused_extensions`, i.e. when the admin exits recovery.
  *   - `recovery_session_errors`        — a list of `{kind, slug, version,
- *     errno, message, file, line, signature}` records derived from the live
+ *     errno, message, file, line}` records derived from the live
  *     `*_paused_extensions` option, so wpcom can surface what fataled rather
  *     than just that something fataled. Empty once the admin exits recovery.
- *     The signature is the shared transportable token from #48369 for
- *     cross-surface grouping with the wpcomsh fatal-error screen.
  *
  * The POST runs from a PHP shutdown function so the signal reaches wpcom even
  * on fatal-error requests, matching the pattern used by migrate-guru-canary.
@@ -245,9 +243,7 @@ class WPCOMSH_Recovery_Mode_Sync {
 	 * `[ 'plugin' => [ slug => {type,file,line,message} ], 'theme' => [ ... ] ]`.
 	 *
 	 * Each output record carries the kind/slug/version + the captured error
-	 * (file is reduced to its basename so server paths don't leak), plus a
-	 * transportable `signature` token built via the shared helper from #48369
-	 * so consumers can group fatals across the recovery and probe surfaces.
+	 * (file is reduced to its basename so server paths don't leak).
 	 *
 	 * @param mixed $paused_extensions Raw option value.
 	 * @return array<int,array<string,mixed>>
@@ -276,29 +272,15 @@ class WPCOMSH_Recovery_Mode_Sync {
 				if ( ! is_string( $slug ) || '' === $slug || ! is_array( $error ) ) {
 					continue;
 				}
-				$version = self::resolve_extension_version( $kind, $slug, $plugins );
-				$record  = array(
+				$out[] = array(
 					'kind'    => $kind,
 					'slug'    => $slug,
-					'version' => $version,
+					'version' => self::resolve_extension_version( $kind, $slug, $plugins ),
 					'errno'   => isset( $error['type'] ) ? (int) $error['type'] : 0,
 					'message' => isset( $error['message'] ) ? (string) $error['message'] : '',
 					'file'    => isset( $error['file'] ) ? basename( (string) $error['file'] ) : '',
 					'line'    => isset( $error['line'] ) ? (int) $error['line'] : 0,
 				);
-				if ( function_exists( 'wpcom_build_fatal_error_signature' ) ) {
-					$signature = wpcom_build_fatal_error_signature(
-						array(
-							'kind'    => $kind,
-							'slug'    => $slug,
-							'version' => $version,
-						)
-					);
-					if ( null !== $signature ) {
-						$record['signature'] = $signature;
-					}
-				}
-				$out[] = $record;
 			}
 		}
 		return $out;

--- a/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
+++ b/projects/plugins/wpcomsh/feature-plugins/class-wpcomsh-recovery-mode-sync.php
@@ -306,11 +306,12 @@ class WPCOMSH_Recovery_Mode_Sync {
 
 	/**
 	 * Identify the plugin or theme a fatal originated from by matching the
-	 * file path against active plugin main files and the active theme
-	 * directories. Returns `[kind, slug]` matching the shape used by WP's own
-	 * `*_paused_extensions` storage (plugin slug = main-file relative path,
-	 * theme slug = stylesheet/template directory name), or null if the file
-	 * doesn't live under a known extension (e.g. core, mu-plugins, drop-ins).
+	 * file path against the plugin and active theme directories. Returns
+	 * `[kind, slug]` matching the shape WP's own recovery storage uses — the
+	 * plugin slug is the first path segment under `WP_PLUGIN_DIR` (mirroring
+	 * core's `WP_Recovery_Mode::get_extension_for_error()`), and the theme
+	 * slug is the stylesheet/template directory name. Returns null when the
+	 * file doesn't live under a known extension (core, mu-plugins, drop-ins).
 	 *
 	 * @param string $file Absolute path to the file that fataled.
 	 * @return array{0:string,1:string}|null
@@ -324,23 +325,10 @@ class WPCOMSH_Recovery_Mode_Sync {
 		if ( defined( 'WP_PLUGIN_DIR' ) ) {
 			$plugin_dir = wp_normalize_path( WP_PLUGIN_DIR ) . '/';
 			if ( str_starts_with( $normalized, $plugin_dir ) ) {
-				$rel = substr( $normalized, strlen( $plugin_dir ) );
-				if ( ! function_exists( 'get_plugins' ) && defined( 'ABSPATH' ) ) {
-					$plugin_admin = ABSPATH . 'wp-admin/includes/plugin.php';
-					if ( file_exists( $plugin_admin ) ) {
-						require_once $plugin_admin;
-					}
-				}
-				$plugins = function_exists( 'get_plugins' ) ? get_plugins() : array();
-				foreach ( $plugins as $main_file => $_data ) {
-					$main_dir = dirname( $main_file );
-					if ( '.' === $main_dir ) {
-						if ( $rel === $main_file ) {
-							return array( 'plugin', $main_file );
-						}
-					} elseif ( str_starts_with( $rel, $main_dir . '/' ) ) {
-						return array( 'plugin', $main_file );
-					}
+				$rel   = substr( $normalized, strlen( $plugin_dir ) );
+				$parts = explode( '/', $rel );
+				if ( '' !== $parts[0] ) {
+					return array( 'plugin', $parts[0] );
 				}
 			}
 		}


### PR DESCRIPTION
## Proposed changes

Follow-up to #48213. The recovery-mode state snapshot now also carries a normalized list of per-extension errors so wpcom-side consumers (Calypso) can surface what fataled instead of just that something fataled.

Each record carries:

- `kind` — `plugin` or `theme`
- `slug` — extension slug as recorded by WP recovery mode
- `version` — resolved via `get_plugins()` / `wp_get_theme()`
- `errno`, `message`, `line` — straight from WP's captured error array
- `file` — reduced to the basename so server paths don't leak

## Where the errors come from

Two sources, picked in order:

1. **`*_paused_extensions` option** — once the admin clicks the recovery email link, WP creates a session and writes paused extensions there. We read it live on every snapshot via `wp_recovery_mode()->get_session_id()`.
2. **`error_get_last()` fallback** — on the fatal request itself, before the admin has clicked the link, no paused-extensions option exists yet. We're called inside WP's fatal-handler shutdown stack (via `update_option_recovery_mode_email_last_sent`), so `error_get_last()` still holds the original fatal. We resolve the file path back to a plugin/theme slug and emit one record from that, so the very first POST already carries the error info.

The fallback only fires when WP actually sends a recovery email (rate-limited to ~once/day, skipped if a session is already active). Subsequent fatals are picked up via the paused-extensions path once the admin enters recovery.

## Design choice

Errors live in the snapshot rather than a wpcomsh-side option — symmetric with how entered_at / exited_at are read. No new option, no thread-through arg.

Consequences:

- Every POST (email / session-start / session-end) emits a complete state.
- A persistent recovery session (~daily email re-send) keeps reporting current errors, not just the first day's snapshot.
- On session_end, the paused-extensions option has already been deleted by WP, so the snapshot returns `[]` — wpcom naturally sees the state cleared.

## Privacy

`message` and `line` are admin-visible on WP's recovery email and recovery screen, so the new exposure is the same content already shown to the site admin. `file` is reduced to its basename to avoid leaking server-internal paths. No user identifiers, request URIs, stack traces, or PII.

## Does this pull request change what data or activity we track or use?

Yes. This PR extends the existing `recovery-mode-status` POST (added in #48213) with a new `recovery_session_errors` array containing per-extension fatal info: `kind` (plugin/theme), `slug`, `version`, `errno`, `message`, `file` (basename only), and `line`. The data is sourced from WP's own recovery-mode state (`*_paused_extensions` option, or `error_get_last()` during the fatal-handler shutdown) and mirrors what's already shown to the site admin in WP's recovery email and recovery screen. No user identifiers, request URIs, stack traces, or PII are added.

## Testing instructions

1. Deploy this branch to an Atomic test site (`jetpack rsync plugins/wpcomsh <site>`).
2. Install + activate a plugin that fatals on load (e.g. one that calls `trigger_error( 'boom', E_USER_ERROR );`).
3. Visit the front-end to trigger WP's fatal-error handler.
4. Confirm the outbound POST to `/sites/<blog_id>/recovery-mode-status` already includes `recovery_session_errors` with one entry — `{kind: \"plugin\", slug: <slug>, version: <ver>, errno: <int>, message: \"boom\", file: \"<basename>.php\", line: <int>}`. (This is the `error_get_last()` fallback path.)
5. Click the recovery link in the email. Confirm the session-start POST also carries the same `recovery_session_errors` array, now sourced from `*_paused_extensions`.
6. Exit recovery mode via the admin bar. Confirm the session-end POST carries `recovery_session_errors: []`.
7. Add a second fatal-on-load plugin while in recovery; confirm the next POST that fires picks up both entries.

## Related

- #48213 — the original recovery-mode-sync PR.
- A wpcom-side change is needed to allowlist + persist the new `recovery_session_errors` field on `jetpack_recovery_mode_status`; this PR alone won't make it visible in the GET sites response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)