### PR TITLE
Search 3.0: WC product filter blocks — parent + status / rating / price

### DIFF
--- a/projects/packages/search/changelog/add-search-product-filter-blocks
+++ b/projects/packages/search/changelog/add-search-product-filter-blocks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search 3.0: WooCommerce-style product filter blocks. Adds the parent `jetpack/search-product-filters` (composable InnerBlocks wrapper) plus three filter children: `…-status` (stock status, scalar `?filter_stock_status=…` URL form), `…-rating` (1–5 star rows backed by the histogram agg), and `…-price` (min/max number inputs driving `state.priceRange` via a new `setPriceRange` action). Builds on the data-plane helpers from [#48397]; tracked under epic [RSM-1929]. Attribute, taxonomy, display-variant, and clear-button blocks land in a follow-up.

--- a/projects/packages/search/eslint.config.mjs
+++ b/projects/packages/search/eslint.config.mjs
@@ -1,7 +1,10 @@
 import { makeBaseConfig, defineConfig } from 'jetpack-js-tools/eslintrc/base.mjs';
 
-export default defineConfig( makeBaseConfig( import.meta.url ), {
-	rules: {
-		'react/jsx-no-bind': 'off',
-	},
-} );
+export default defineConfig(
+	makeBaseConfig( import.meta.url, { textdomain: 'jetpack-search-pkg' } ),
+	{
+		rules: {
+			'react/jsx-no-bind': 'off',
+		},
+	}
+);

--- a/projects/packages/search/src/search-blocks/blocks/search-product-filter-price/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/search-product-filter-price/block.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "jetpack/search-product-filter-price",
+	"version": "0.1.0",
+	"title": "Filter by Price",
+	"category": "jetpack-search",
+	"icon": "money-alt",
+	"description": "Let shoppers filter products by minimum and maximum price. Powered by Jetpack Search.",
+	"supports": {
+		"html": false,
+		"interactivity": true,
+		"spacing": {
+			"margin": [ "top", "bottom" ],
+			"padding": true,
+			"blockGap": true
+		}
+	},
+	"textdomain": "jetpack-search-pkg",
+	"attributes": {
+		"label": { "type": "string", "default": "" },
+		"currencySymbol": { "type": "string", "default": "$" }
+	},
+	"render": "file:./render.php",
+	"viewScriptModule": "file:../../../../build/search-blocks/search-product-filter-price.js",
+	"style": "file:../../../../build/search-blocks/search-product-filter-price.css"
+}

--- a/projects/packages/search/src/search-blocks/blocks/search-product-filter-price/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-product-filter-price/edit.js
@@ -1,0 +1,110 @@
+/**
+ * Editor preview for jetpack/search-product-filter-price.
+ *
+ * Mirrors the runtime DOM shape — two disabled number inputs joined by
+ * an em-dash — so designers can style the price field in place.
+ * Inspector exposes the user-tunable attributes (label, currency symbol).
+ */
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, TextControl } from '@wordpress/components';
+import { createElement as h, Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+const DEFAULT_LABEL = __( 'Price', 'jetpack-search-pkg' );
+
+/**
+ * Edit component for the search-product-filter-price block.
+ *
+ * @param {object}   props               - Block props.
+ * @param {object}   props.attributes    - Saved block attributes.
+ * @param {Function} props.setAttributes - Attribute setter.
+ * @return {object} Rendered element.
+ */
+export default function SearchProductFilterPriceEdit( { attributes, setAttributes } ) {
+	const blockProps = useBlockProps( { className: 'jetpack-search-product-filter-price' } );
+	const rawLabel = attributes?.label || '';
+	const previewLabel = rawLabel || DEFAULT_LABEL;
+	const symbol = ( attributes?.currencySymbol || '$' ).slice( 0, 2 );
+
+	return h(
+		Fragment,
+		null,
+		h(
+			InspectorControls,
+			null,
+			h(
+				PanelBody,
+				{ title: __( 'Settings', 'jetpack-search-pkg' ) },
+				h( TextControl, {
+					__next40pxDefaultSize: true,
+					__nextHasNoMarginBottom: true,
+					label: __( 'Label', 'jetpack-search-pkg' ),
+					value: rawLabel,
+					placeholder: DEFAULT_LABEL,
+					onChange: value => setAttributes( { label: value } ),
+				} ),
+				h( TextControl, {
+					__next40pxDefaultSize: true,
+					__nextHasNoMarginBottom: true,
+					label: __( 'Currency symbol', 'jetpack-search-pkg' ),
+					value: attributes?.currencySymbol || '$',
+					maxLength: 2,
+					onChange: value => setAttributes( { currencySymbol: value } ),
+					help: __(
+						'Shown next to each input as a non-interactive adornment.',
+						'jetpack-search-pkg'
+					),
+				} )
+			)
+		),
+		h(
+			'div',
+			blockProps,
+			h( 'h3', { className: 'jetpack-search-filter__title' }, previewLabel ),
+			h(
+				'div',
+				{ className: 'jetpack-search-product-filter-price__inputs' },
+				h(
+					'div',
+					{ className: 'jetpack-search-product-filter-price__field' },
+					h(
+						'span',
+						{ className: 'jetpack-search-product-filter-price__symbol', 'aria-hidden': 'true' },
+						symbol
+					),
+					h( 'input', {
+						className:
+							'jetpack-search-product-filter-price__input jetpack-search-product-filter-price__input--min',
+						type: 'number',
+						placeholder: __( 'Min', 'jetpack-search-pkg' ),
+						disabled: true,
+					} )
+				),
+				h(
+					'span',
+					{
+						className: 'jetpack-search-product-filter-price__separator',
+						'aria-hidden': 'true',
+					},
+					'–'
+				),
+				h(
+					'div',
+					{ className: 'jetpack-search-product-filter-price__field' },
+					h(
+						'span',
+						{ className: 'jetpack-search-product-filter-price__symbol', 'aria-hidden': 'true' },
+						symbol
+					),
+					h( 'input', {
+						className:
+							'jetpack-search-product-filter-price__input jetpack-search-product-filter-price__input--max',
+						type: 'number',
+						placeholder: __( 'Max', 'jetpack-search-pkg' ),
+						disabled: true,
+					} )
+				)
+			)
+		)
+	);
+}

--- a/projects/packages/search/src/search-blocks/blocks/search-product-filter-price/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/search-product-filter-price/render.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Search product filter — price render.
+ *
+ * Two number inputs (min, max) bound to the shared store's `priceRange`
+ * slice. Unlike the other product filter blocks, this one doesn't
+ * register a filterConfig — `priceRange` is its own state branch with a
+ * dedicated `actions.setPriceRange` action and the `min_price` /
+ * `max_price` URL params are already in `RESERVED_QUERY_PARAMS`.
+ *
+ * First-paint values are seeded from `state.priceRange` (which the PHP
+ * state-builder parses from the URL) so a deep link like
+ * `/?s=&min_price=10` shows "10" in the min input before JS hydrates.
+ *
+ * Currency-symbol display uses the block author's chosen symbol; the
+ * stored value is the raw number so URL contracts and ES range clauses
+ * stay locale-agnostic.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+
+if ( ! function_exists( 'wp_interactivity_state' ) ) {
+	return;
+}
+
+// @phan-suppress-next-line PhanUndeclaredGlobalVariable
+$attrs  = (array) $attributes;
+$label  = sanitize_text_field( (string) ( $attrs['label'] ?? '' ) );
+$symbol = (string) ( $attrs['currencySymbol'] ?? '$' );
+if ( '' === $label ) {
+	$label = __( 'Price', 'jetpack-search-pkg' );
+}
+// Trim to two characters so an oversized symbol can't overflow the
+// adornment slot in the input.
+$symbol_short = function_exists( 'mb_substr' ) ? mb_substr( $symbol, 0, 2 ) : substr( $symbol, 0, 2 );
+
+$seeded_state = wp_interactivity_state( 'jetpack-search' );
+$seeded_price = $seeded_state['priceRange'] ?? null;
+$seeded_min   = is_array( $seeded_price ) && null !== ( $seeded_price['min'] ?? null )
+	? (string) $seeded_price['min']
+	: '';
+$seeded_max   = is_array( $seeded_price ) && null !== ( $seeded_price['max'] ?? null )
+	? (string) $seeded_price['max']
+	: '';
+
+$min_id = wp_unique_id( 'jetpack-search-product-filter-price-min-' );
+$max_id = wp_unique_id( 'jetpack-search-product-filter-price-max-' );
+?>
+<div
+	<?php echo wp_kses_data( get_block_wrapper_attributes( array( 'class' => 'jetpack-search-product-filter-price' ) ) ); ?>
+	data-wp-interactive="jetpack-search"
+>
+	<?php if ( '' !== $label ) : ?>
+		<h3 class="jetpack-search-filter__title"><?php echo esc_html( $label ); ?></h3>
+	<?php endif; ?>
+	<div class="jetpack-search-product-filter-price__inputs">
+		<div class="jetpack-search-product-filter-price__field">
+			<label class="screen-reader-text" for="<?php echo esc_attr( $min_id ); ?>">
+				<?php esc_html_e( 'Minimum price', 'jetpack-search-pkg' ); ?>
+			</label>
+			<span class="jetpack-search-product-filter-price__symbol" aria-hidden="true">
+				<?php echo esc_html( $symbol_short ); ?>
+			</span>
+			<input
+				id="<?php echo esc_attr( $min_id ); ?>"
+				class="jetpack-search-product-filter-price__input jetpack-search-product-filter-price__input--min"
+				type="number"
+				inputmode="decimal"
+				min="0"
+				step="any"
+				placeholder="<?php esc_attr_e( 'Min', 'jetpack-search-pkg' ); ?>"
+				value="<?php echo esc_attr( $seeded_min ); ?>"
+				data-wp-bind--value="state.priceRangeMinInputValue"
+				data-wp-on--change="actions.onPriceRangeInputChange"
+				data-wp-on--keydown="actions.onPriceRangeInputKeydown"
+			/>
+		</div>
+		<span class="jetpack-search-product-filter-price__separator" aria-hidden="true">–</span>
+		<div class="jetpack-search-product-filter-price__field">
+			<label class="screen-reader-text" for="<?php echo esc_attr( $max_id ); ?>">
+				<?php esc_html_e( 'Maximum price', 'jetpack-search-pkg' ); ?>
+			</label>
+			<span class="jetpack-search-product-filter-price__symbol" aria-hidden="true">
+				<?php echo esc_html( $symbol_short ); ?>
+			</span>
+			<input
+				id="<?php echo esc_attr( $max_id ); ?>"
+				class="jetpack-search-product-filter-price__input jetpack-search-product-filter-price__input--max"
+				type="number"
+				inputmode="decimal"
+				min="0"
+				step="any"
+				placeholder="<?php esc_attr_e( 'Max', 'jetpack-search-pkg' ); ?>"
+				value="<?php echo esc_attr( $seeded_max ); ?>"
+				data-wp-bind--value="state.priceRangeMaxInputValue"
+				data-wp-on--change="actions.onPriceRangeInputChange"
+				data-wp-on--keydown="actions.onPriceRangeInputKeydown"
+			/>
+		</div>
+	</div>
+</div>

--- a/projects/packages/search/src/search-blocks/blocks/search-product-filter-price/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/search-product-filter-price/style.scss
@@ -1,0 +1,62 @@
+/**
+ * Search product filter — price.
+ *
+ * Side-by-side number inputs joined by an em-dash separator. Currency
+ * symbol sits as a non-interactive adornment inside each field's box so
+ * the visual padding aligns with the input edge regardless of typed
+ * value width.
+ */
+.jetpack-search-product-filter-price {
+
+	&__inputs {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
+	&__field {
+		position: relative;
+		display: flex;
+		align-items: center;
+		flex: 1 1 0;
+		min-width: 0;
+	}
+
+	&__symbol {
+		position: absolute;
+		left: 0.5rem;
+		color: #757575;
+		font-size: 0.95em;
+		pointer-events: none;
+	}
+
+	&__input {
+		width: 100%;
+		min-width: 0;
+		padding: 0.4rem 0.5rem 0.4rem 1.4rem;
+		border: 1px solid #c8c8c8;
+		border-radius: 4px;
+		font: inherit;
+
+		// Drop the spinner buttons. They're unhelpful on price inputs —
+		// shoppers know how to type. Keeping the input as type="number"
+		// for the keyboard hint and validation, but removing the visual
+		// affordance avoids the "tiny up/down arrows" awkwardness.
+		&::-webkit-outer-spin-button,
+		&::-webkit-inner-spin-button {
+			-webkit-appearance: none;
+			margin: 0;
+		}
+
+		// Firefox / standard equivalent.
+		-moz-appearance: textfield;
+		appearance: textfield;
+	}
+
+	&__separator {
+		flex: 0 0 auto;
+		color: #757575;
+		font-size: 1.1em;
+		line-height: 1;
+	}
+}

--- a/projects/packages/search/src/search-blocks/blocks/search-product-filter-price/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-product-filter-price/view.js
@@ -1,0 +1,109 @@
+import { store, getElement } from '@wordpress/interactivity';
+import '../../store';
+import './style.scss';
+
+const NAMESPACE = 'jetpack-search';
+
+/**
+ * Resolve the min and max input elements that share a parent block
+ * wrapper with `el`. Used by the change handler to read both values when
+ * either input changes (the store action takes both bounds together).
+ *
+ * @param {HTMLElement} el - The input that fired the event.
+ * @return {{min: HTMLInputElement|null, max: HTMLInputElement|null}} Sibling inputs.
+ */
+function findRangeInputs( el ) {
+	const wrapper = el?.closest?.( '.jetpack-search-product-filter-price' );
+	if ( ! wrapper ) {
+		return { min: null, max: null };
+	}
+	return {
+		min: wrapper.querySelector( '.jetpack-search-product-filter-price__input--min' ),
+		max: wrapper.querySelector( '.jetpack-search-product-filter-price__input--max' ),
+	};
+}
+
+/**
+ * Coerce an input's `.value` string into the shape the store action
+ * expects: an empty input → null, a numeric input → its Number, anything
+ * else → null (the store action drops invalid bounds anyway, but
+ * normalizing here avoids a redundant search-token bump).
+ *
+ * @param {string|null|undefined} raw - Input value.
+ * @return {number|null} Parsed bound or null.
+ */
+function parseBound( raw ) {
+	if ( raw === null || raw === undefined || raw === '' ) {
+		return null;
+	}
+	const num = Number( raw );
+	return Number.isFinite( num ) && num >= 0 ? num : null;
+}
+
+store( NAMESPACE, {
+	state: {
+		/**
+		 * `data-wp-bind--value` for the min input. Returns an empty string
+		 * when no bound is set so the input renders blank rather than
+		 * "null". `data-wp-bind` only evaluates simple property paths, so
+		 * the null-safe lookup needs to live in a getter.
+		 *
+		 * @return {string} Min value as a string for the input.
+		 */
+		get priceRangeMinInputValue() {
+			const { state } = store( NAMESPACE );
+			const min = state.priceRange?.min;
+			return min === null || min === undefined ? '' : String( min );
+		},
+
+		/**
+		 * `data-wp-bind--value` for the max input. Same null-safe pattern
+		 * as `priceRangeMinInputValue`.
+		 *
+		 * @return {string} Max value as a string for the input.
+		 */
+		get priceRangeMaxInputValue() {
+			const { state } = store( NAMESPACE );
+			const max = state.priceRange?.max;
+			return max === null || max === undefined ? '' : String( max );
+		},
+	},
+
+	actions: {
+		/**
+		 * Apply both bounds to the store. Reads the sibling inputs from
+		 * the DOM rather than tracking each input's value in store state
+		 * so user typing isn't published to other listeners until they
+		 * actually commit a change (blur / Enter / native `change` event).
+		 *
+		 * The native `change` event on `<input type="number">` fires on
+		 * blur and on Enter, so this handler doubles as the submit path.
+		 *
+		 * @yield {Promise} setPriceRange action.
+		 */
+		*onPriceRangeInputChange() {
+			const el = getElement()?.ref;
+			const { min, max } = findRangeInputs( el );
+			yield store( NAMESPACE ).actions.setPriceRange(
+				parseBound( min?.value ),
+				parseBound( max?.value )
+			);
+		},
+
+		/**
+		 * Submit-on-Enter without waiting for blur, so a one-handed
+		 * keyboard flow (type → Enter) commits immediately. Also blurs
+		 * the input so screen-reader focus moves predictably to the next
+		 * page region instead of staying inside a now-stale field value.
+		 *
+		 * @param {KeyboardEvent} event - Keydown event.
+		 */
+		onPriceRangeInputKeydown( event ) {
+			if ( event?.key !== 'Enter' ) {
+				return;
+			}
+			event.preventDefault();
+			event.target?.blur?.();
+		},
+	},
+} );

--- a/projects/packages/search/src/search-blocks/blocks/search-product-filter-rating/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/search-product-filter-rating/block.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "jetpack/search-product-filter-rating",
+	"version": "0.1.0",
+	"title": "Filter by Rating",
+	"category": "jetpack-search",
+	"icon": "star-filled",
+	"description": "Let shoppers filter products by star rating. Powered by Jetpack Search.",
+	"supports": {
+		"html": false,
+		"interactivity": true,
+		"spacing": {
+			"margin": [ "top", "bottom" ],
+			"padding": true,
+			"blockGap": true
+		}
+	},
+	"textdomain": "jetpack-search-pkg",
+	"attributes": {
+		"label": { "type": "string", "default": "" },
+		"showCount": { "type": "boolean", "default": true }
+	},
+	"render": "file:./render.php",
+	"viewScriptModule": "file:../../../../build/search-blocks/search-product-filter-rating.js",
+	"style": "file:../../../../build/search-blocks/search-product-filter-rating.css"
+}

--- a/projects/packages/search/src/search-blocks/blocks/search-product-filter-rating/class-search-product-filter-rating.php
+++ b/projects/packages/search/src/search-blocks/blocks/search-product-filter-rating/class-search-product-filter-rating.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Search product filter — rating block helpers.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+/**
+ * Helper methods for the jetpack/search-product-filter-rating block.
+ *
+ * Filter key + filterConfig shape live here so render.php and the
+ * post-content walker (Search_Blocks::collect_product_filter_configs_from_post)
+ * agree on what this block contributes to the shared store. The
+ * `wc_rating` filterType drives the histogram aggregation + per-star range
+ * filter clauses in store/api.js — see `WC_RATING_RANGES`.
+ */
+class Search_Product_Filter_Rating {
+
+	/**
+	 * URL key + interactivity-state filter key for rating selections.
+	 *
+	 * Mirrors WooCommerce's native URL contract
+	 * (`?rating_filter[]=4&rating_filter[]=5`) so deep links interoperate
+	 * with WC's own rating filter — and so a future bridge would not need
+	 * to translate keys between the two systems.
+	 */
+	const FILTER_KEY = 'rating_filter';
+
+	/**
+	 * Stable star option list for rendering. Highest first matches the
+	 * conventional e-commerce "4 stars & up, 3 stars & up, …" ordering;
+	 * since the underlying ES range clauses are non-overlapping (star=4
+	 * means avg ∈ [3.5, 4.5), not "≥ 3.5"), the visible label may say
+	 * "& up" but the selection semantics are exact buckets — multi-select
+	 * to OR adjacent stars together.
+	 *
+	 * @return int[] Star values 5..1.
+	 */
+	public static function get_star_values(): array {
+		return array( 5, 4, 3, 2, 1 );
+	}
+
+	/**
+	 * Filter key derivation. Constant for this block — the rating field is
+	 * always `meta._wc_average_rating.double`, so there's no per-instance
+	 * variation. Method form mirrors Filter_Checkbox::derive_filter_key.
+	 *
+	 * @return string
+	 */
+	public static function derive_filter_key(): string {
+		return self::FILTER_KEY;
+	}
+
+	/**
+	 * Default group label when the block author leaves the label attribute
+	 * empty.
+	 *
+	 * @return string
+	 */
+	public static function default_label(): string {
+		return __( 'Rating', 'jetpack-search-pkg' );
+	}
+
+	/**
+	 * Build the filterConfig entry this block contributes to the shared
+	 * Interactivity state. JS reads `filterType: 'wc_rating'` to switch
+	 * `buildAggregations` to a histogram and `buildFilterClause` to the
+	 * per-star range path.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return array<string, mixed>
+	 */
+	public static function build_config( array $attributes ): array {
+		$label = sanitize_text_field( (string) ( $attributes['label'] ?? '' ) );
+		if ( '' === $label ) {
+			$label = static::default_label();
+		}
+
+		return array(
+			'filterKey'  => self::FILTER_KEY,
+			'filterType' => 'wc_rating',
+			'label'      => $label,
+			'showCount'  => (bool) ( $attributes['showCount'] ?? true ),
+		);
+	}
+}

--- a/projects/packages/search/src/search-blocks/blocks/search-product-filter-rating/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-product-filter-rating/edit.js
@@ -1,0 +1,120 @@
+/**
+ * Editor preview for jetpack/search-product-filter-rating.
+ *
+ * Mirrors the runtime DOM shape — labeled list with five star rows and
+ * optional count badges — so designers can style the rating filter in
+ * place. Inspector exposes the user-tunable attributes (label, showCount).
+ */
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
+import { createElement as h, Fragment } from '@wordpress/element';
+import { __, _n, sprintf } from '@wordpress/i18n';
+
+const STAR_VALUES = [ 5, 4, 3, 2, 1 ];
+const SAMPLE_COUNTS = { 5: 18, 4: 12, 3: 5, 2: 1, 1: 0 };
+const DEFAULT_LABEL = __( 'Rating', 'jetpack-search-pkg' );
+
+/**
+ * Render a 5-glyph star row showing `filled` of them as filled and the rest empty.
+ *
+ * @param {number} filled - How many stars to render filled (1–5).
+ * @return {object[]} Array of star span elements.
+ */
+function renderStars( filled ) {
+	const stars = [];
+	for ( let i = 1; i <= 5; i++ ) {
+		stars.push(
+			h(
+				'span',
+				{
+					key: i,
+					className:
+						'jetpack-search-filter-rating__star ' + ( i <= filled ? 'is-filled' : 'is-empty' ),
+					'aria-hidden': 'true',
+				},
+				'★'
+			)
+		);
+	}
+	return stars;
+}
+
+/**
+ * Edit component for the search-product-filter-rating block.
+ *
+ * @param {object}   props               - Block props.
+ * @param {object}   props.attributes    - Saved block attributes.
+ * @param {Function} props.setAttributes - Attribute setter.
+ * @return {object} Rendered element.
+ */
+export default function SearchProductFilterRatingEdit( { attributes, setAttributes } ) {
+	const blockProps = useBlockProps( { className: 'jetpack-search-product-filter-rating' } );
+	const rawLabel = attributes?.label || '';
+	const previewLabel = rawLabel || DEFAULT_LABEL;
+	const showCount = attributes?.showCount !== false;
+
+	return h(
+		Fragment,
+		null,
+		h(
+			InspectorControls,
+			null,
+			h(
+				PanelBody,
+				{ title: __( 'Settings', 'jetpack-search-pkg' ) },
+				h( TextControl, {
+					__next40pxDefaultSize: true,
+					__nextHasNoMarginBottom: true,
+					label: __( 'Label', 'jetpack-search-pkg' ),
+					value: rawLabel,
+					placeholder: DEFAULT_LABEL,
+					onChange: value => setAttributes( { label: value } ),
+					help: __(
+						'Heading shown above the star rows. Leave empty for the default.',
+						'jetpack-search-pkg'
+					),
+				} ),
+				h( ToggleControl, {
+					__nextHasNoMarginBottom: true,
+					label: __( 'Show result counts', 'jetpack-search-pkg' ),
+					checked: showCount,
+					onChange: value => setAttributes( { showCount: !! value } ),
+				} )
+			)
+		),
+		h(
+			'div',
+			blockProps,
+			h( 'h3', { className: 'jetpack-search-filter__title' }, previewLabel ),
+			h(
+				'ul',
+				{ className: 'jetpack-search-filter__list' },
+				STAR_VALUES.map( star => {
+					/* translators: %d: number of stars (1-5). */
+					const aria = sprintf( _n( '%d star', '%d stars', star, 'jetpack-search-pkg' ), star );
+					return h(
+						'li',
+						{ key: star, className: 'jetpack-search-filter__item' },
+						h(
+							'label',
+							null,
+							h( 'input', { type: 'checkbox', disabled: true } ),
+							h(
+								'span',
+								{ className: 'jetpack-search-filter__label', 'aria-label': aria },
+								renderStars( star )
+							),
+							showCount
+								? h(
+										'span',
+										{ className: 'jetpack-search-filter__count' },
+										String( SAMPLE_COUNTS[ star ] )
+								  )
+								: null
+						)
+					);
+				} )
+			)
+		)
+	);
+}

--- a/projects/packages/search/src/search-blocks/blocks/search-product-filter-rating/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/search-product-filter-rating/render.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Search product filter — rating render.
+ *
+ * Emits a fixed five-row star list (5..1 stars) and registers the
+ * filterConfig with the shared `jetpack-search` Interactivity store.
+ * Counts come from the histogram aggregation registered in
+ * `buildAggregations` for the `wc_rating` filterType — bucket keys land
+ * on half-integer boundaries (0.5, 1.5, 2.5, 3.5, 4.5), each
+ * corresponding to one star band per WC's `ROUND(avg_rating, 0)` rule.
+ *
+ * Always-show-all-options matches WC's UX: even rows whose count is 0
+ * remain visible and clickable so the user has a stable list to scan.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+
+if ( ! function_exists( 'wp_interactivity_state' ) ) {
+	return;
+}
+
+// @phan-suppress-next-line PhanUndeclaredGlobalVariable
+$config = Search_Product_Filter_Rating::build_config( (array) $attributes );
+
+wp_interactivity_state(
+	'jetpack-search',
+	array(
+		'filterConfigs' => array(
+			Search_Product_Filter_Rating::FILTER_KEY => $config,
+		),
+	)
+);
+
+$seeded_state    = wp_interactivity_state( 'jetpack-search' );
+$seeded_aggs     = (array) ( $seeded_state['aggregations'] ?? array() );
+$seeded_buckets  = (array) ( ( (array) ( $seeded_aggs[ Search_Product_Filter_Rating::FILTER_KEY ] ?? array() ) )['buckets'] ?? array() );
+$seeded_active   = (array) ( $seeded_state['activeFilters'] ?? array() );
+$seeded_selected = (array) ( $seeded_active[ Search_Product_Filter_Rating::FILTER_KEY ] ?? array() );
+
+// Project histogram buckets keyed at .5 boundaries onto star values
+// 1..5. Bucket key 4.5 → star 5, 3.5 → star 4, etc. Anything below 0.5
+// (the "no rating" bucket the histogram emits at -0.5 thanks to
+// min_doc_count: 0) is dropped since there's no UI option for it.
+$counts_by_star = array();
+foreach ( $seeded_buckets as $bucket ) {
+	$key   = (float) ( $bucket['key'] ?? -1 );
+	$count = (int) ( $bucket['doc_count'] ?? 0 );
+	// Map .5-boundary key → star integer. Equivalent to (int) round( $key + 0.5 ).
+	$star = (int) ( $key + 1.0 );
+	if ( $star >= 1 && $star <= 5 ) {
+		$counts_by_star[ (string) $star ] = $count;
+	}
+}
+
+$label      = (string) $config['label'];
+$show_count = (bool) $config['showCount'];
+?>
+<div
+	<?php echo wp_kses_data( get_block_wrapper_attributes( array( 'class' => 'jetpack-search-product-filter-rating' ) ) ); ?>
+	data-wp-interactive="jetpack-search"
+	<?php echo wp_kses_data( wp_interactivity_data_wp_context( array( 'filterKey' => Search_Product_Filter_Rating::FILTER_KEY ) ) ); ?>
+>
+	<?php if ( '' !== $label ) : ?>
+		<h3 class="jetpack-search-filter__title"><?php echo esc_html( $label ); ?></h3>
+	<?php endif; ?>
+	<ul class="jetpack-search-filter__list">
+		<?php foreach ( Search_Product_Filter_Rating::get_star_values() as $star ) : ?>
+			<?php
+			$value      = (string) $star;
+			$is_checked = in_array( $value, $seeded_selected, true );
+			$option_cnt = $counts_by_star[ $value ] ?? 0;
+			/* translators: %d: number of stars (1-5). Used as the accessible name for the star-rating row. */
+			$aria_label = sprintf( _n( '%d star', '%d stars', $star, 'jetpack-search-pkg' ), $star );
+			?>
+			<li class="jetpack-search-filter__item">
+				<label>
+					<input
+						type="checkbox"
+						value="<?php echo esc_attr( $value ); ?>"
+						<?php echo $is_checked ? 'checked' : ''; ?>
+						data-wp-bind--checked="state.isRatingOptionSelected"
+						data-wp-on--change="actions.onRatingFilterChange"
+					/>
+					<span class="jetpack-search-filter__label" aria-label="<?php echo esc_attr( $aria_label ); ?>">
+						<?php
+						// Render the star-row as filled vs. empty stars so the
+						// row is recognizable without JS-side icon code; the
+						// aria-label above carries the accessible text.
+						for ( $i = 1; $i <= 5; $i++ ) :
+							?>
+							<span
+								class="jetpack-search-filter-rating__star <?php echo $i <= $star ? 'is-filled' : 'is-empty'; ?>"
+								aria-hidden="true"
+							>★</span>
+						<?php endfor; ?>
+					</span>
+					<?php if ( $show_count ) : ?>
+						<span
+							class="jetpack-search-filter__count"
+							data-wp-text="state.ratingOptionCount"
+						><?php echo esc_html( (string) $option_cnt ); ?></span>
+					<?php endif; ?>
+				</label>
+			</li>
+		<?php endforeach; ?>
+	</ul>
+</div>

--- a/projects/packages/search/src/search-blocks/blocks/search-product-filter-rating/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/search-product-filter-rating/style.scss
@@ -1,0 +1,34 @@
+/**
+ * Search product filter — rating.
+ *
+ * Inherits the shared `.jetpack-search-filter__list/__item/__label/__count`
+ * styles from the generic filter-checkbox block. This file adds the
+ * filled vs. empty star coloring so the row is visually scannable without
+ * relying on icon assets.
+ */
+.jetpack-search-product-filter-rating {
+
+	.jetpack-search-filter__list {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+
+	// Stars are inline-rendered text glyphs (★) styled with color so the
+	// markup stays SVG-free and survives WP's content-export pipeline.
+	// Matches WC's color cues — gold for filled, muted gray for empty —
+	// without pulling in WC's icon asset.
+	.jetpack-search-filter-rating__star {
+		display: inline-block;
+		font-size: 1.05em;
+		line-height: 1;
+
+		&.is-filled {
+			color: #f0b800;
+		}
+
+		&.is-empty {
+			color: #c8c8c8;
+		}
+	}
+}

--- a/projects/packages/search/src/search-blocks/blocks/search-product-filter-rating/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-product-filter-rating/view.js
@@ -1,0 +1,98 @@
+import { store, getContext, getElement } from '@wordpress/interactivity';
+import '../../store';
+import './style.scss';
+
+const NAMESPACE = 'jetpack-search';
+
+/**
+ * Project a histogram bucket array onto a star → count map.
+ *
+ * Bucket keys land on half-integer boundaries (0.5, 1.5, 2.5, 3.5, 4.5)
+ * thanks to the `interval: 1, offset: 0.5` aggregation. Each maps to one
+ * star band per WC's `ROUND(avg_rating, 0)` rule: 4.5 → star 5, 3.5 →
+ * star 4, etc. Buckets outside that range (the implicit -0.5 "no rating"
+ * bucket from `min_doc_count: 0`) are ignored — there's no UI option
+ * for them. Mirrors the same projection in render.php.
+ *
+ * @param {Array<{key: number, doc_count: number}>} buckets - Aggregation buckets.
+ * @return {Object<string, number>} Star (as string key, "1".."5") → count.
+ */
+function bucketsToStarCountMap( buckets ) {
+	if ( ! Array.isArray( buckets ) ) {
+		return {};
+	}
+	const map = {};
+	for ( const bucket of buckets ) {
+		const key = Number( bucket?.key ?? -1 );
+		const count = Number( bucket?.doc_count ?? 0 );
+		// .5-boundary key → star integer. Equivalent to Math.round(key + 0.5).
+		const star = Math.trunc( key + 1.0 );
+		if ( star >= 1 && star <= 5 ) {
+			map[ String( star ) ] = count;
+		}
+	}
+	return map;
+}
+
+store( NAMESPACE, {
+	state: {
+		/**
+		 * `data-wp-bind--checked` per-star option. Reads the input's
+		 * `value` attribute via `getElement().attributes.value` so one
+		 * getter serves all five rows without per-row context.
+		 *
+		 * @return {boolean} Whether this star value is in activeFilters.
+		 */
+		get isRatingOptionSelected() {
+			const value = getElement()?.attributes?.value;
+			if ( ! value ) {
+				return false;
+			}
+			const { state } = store( NAMESPACE );
+			const { filterKey } = getContext();
+			const selected = state.activeFilters?.[ filterKey ];
+			return Array.isArray( selected ) && selected.includes( value );
+		},
+
+		/**
+		 * `data-wp-text` per-row count badge. Locates the matching
+		 * checkbox input via the shared `<label>` parent, reads the star
+		 * value off its `value` attribute, and returns the projected
+		 * histogram count. Falls back to "0" when the row has no
+		 * matches in the current scope — convention for "always show all
+		 * options" facet UIs.
+		 *
+		 * @return {string} Count as a string for the badge text node.
+		 */
+		get ratingOptionCount() {
+			const el = getElement()?.ref;
+			const label = el?.closest?.( 'label' );
+			const input = label?.querySelector?.( 'input[type="checkbox"]' );
+			const value = input?.getAttribute?.( 'value' );
+			if ( ! value ) {
+				return '0';
+			}
+			const { state } = store( NAMESPACE );
+			const { filterKey } = getContext();
+			const buckets = state.aggregations?.[ filterKey ]?.buckets;
+			const counts = bucketsToStarCountMap( buckets );
+			return String( counts[ value ] ?? 0 );
+		},
+	},
+
+	actions: {
+		/**
+		 * Toggle the star value that owns the change event. The input's
+		 * `value` attribute carries the star (1–5) as a string; filterKey
+		 * comes from the wrapper context.
+		 *
+		 * @param {Event} event - Change event.
+		 * @yield {Promise} setFilter action.
+		 */
+		*onRatingFilterChange( event ) {
+			const { actions } = store( NAMESPACE );
+			const { filterKey } = getContext();
+			yield actions.setFilter( filterKey, event.target.value );
+		},
+	},
+} );

--- a/projects/packages/search/src/search-blocks/blocks/search-product-filter-status/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/search-product-filter-status/block.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "jetpack/search-product-filter-status",
+	"version": "0.1.0",
+	"title": "Filter by Stock Status",
+	"category": "jetpack-search",
+	"icon": "tag",
+	"description": "Let shoppers filter products by stock status (in stock, out of stock, on backorder). Powered by Jetpack Search.",
+	"supports": {
+		"html": false,
+		"interactivity": true,
+		"spacing": {
+			"margin": [ "top", "bottom" ],
+			"padding": true,
+			"blockGap": true
+		}
+	},
+	"textdomain": "jetpack-search-pkg",
+	"attributes": {
+		"label": { "type": "string", "default": "" },
+		"showCount": { "type": "boolean", "default": true }
+	},
+	"render": "file:./render.php",
+	"viewScriptModule": "file:../../../../build/search-blocks/search-product-filter-status.js",
+	"style": "file:../../../../build/search-blocks/search-product-filter-status.css"
+}

--- a/projects/packages/search/src/search-blocks/blocks/search-product-filter-status/class-search-product-filter-status.php
+++ b/projects/packages/search/src/search-blocks/blocks/search-product-filter-status/class-search-product-filter-status.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Search product filter — stock status block helpers.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+/**
+ * Helper methods for the jetpack/search-product-filter-status block.
+ *
+ * Single source of truth for the block's filterKey, fixed option list, and
+ * filterConfig shape. Both render.php (when seeding interactivity state)
+ * and Search_Blocks::collect_product_filter_configs_from_post() rely on
+ * these so the URL gate sees the same key the block registers at render
+ * time, regardless of block order in the post.
+ */
+class Search_Product_Filter_Status {
+
+	/**
+	 * URL key + interactivity-state filter key for stock-status selections.
+	 *
+	 * Mirrors WooCommerce's native URL contract (`?filter_stock_status=…`)
+	 * so a deep link minted on a page with WC's own status filter still
+	 * works against this block — and vice versa.
+	 */
+	const FILTER_KEY = 'filter_stock_status';
+
+	/**
+	 * Fixed option set for the filter. Matches the keys
+	 * `wc_get_product_stock_status_options()` returns; v1 ships hardcoded
+	 * English labels (RSM-1932 will server-render the WC translations into
+	 * `wp_interactivity_state` so locales other than en-US render correctly).
+	 *
+	 * @return array<int, array{value: string, label: string}>
+	 */
+	public static function get_options(): array {
+		return array(
+			array(
+				'value' => 'instock',
+				'label' => 'In stock',
+			),
+			array(
+				'value' => 'outofstock',
+				'label' => 'Out of stock',
+			),
+			array(
+				'value' => 'onbackorder',
+				'label' => 'On backorder',
+			),
+		);
+	}
+
+	/**
+	 * Filter key derivation. Constant for this block — there's only one
+	 * stock-status field per WC store, so no per-instance variation. Kept
+	 * as a method (mirroring Filter_Checkbox::derive_filter_key) so the
+	 * walker in Search_Blocks doesn't need to special-case the API.
+	 *
+	 * @return string
+	 */
+	public static function derive_filter_key(): string {
+		return self::FILTER_KEY;
+	}
+
+	/**
+	 * Default group label when the block author leaves the label attribute
+	 * empty. v1 ships English; RSM-1932 will switch this to read from the
+	 * WC-provided translation map.
+	 *
+	 * @return string
+	 */
+	public static function default_label(): string {
+		return __( 'Stock status', 'jetpack-search-pkg' );
+	}
+
+	/**
+	 * Build the filterConfig entry this block contributes to the shared
+	 * Interactivity state. JS reads filterType + urlFormat to drive the
+	 * scalar URL contract and the `meta._stock_status.value.raw` ES path.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return array<string, mixed>
+	 */
+	public static function build_config( array $attributes ): array {
+		$label = sanitize_text_field( (string) ( $attributes['label'] ?? '' ) );
+		if ( '' === $label ) {
+			$label = static::default_label();
+		}
+
+		return array(
+			'filterKey'  => self::FILTER_KEY,
+			'filterType' => 'wc_stock_status',
+			// Scalar URL form (`?filter_stock_status=instock,outofstock`)
+			// matches WC's native writer; the JS readers and writers in
+			// store/url-state.js dispatch on this flag.
+			'urlFormat'  => 'scalar',
+			'label'      => $label,
+			'showCount'  => (bool) ( $attributes['showCount'] ?? true ),
+		);
+	}
+}

--- a/projects/packages/search/src/search-blocks/blocks/search-product-filter-status/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-product-filter-status/edit.js
@@ -1,0 +1,92 @@
+/**
+ * Editor preview for jetpack/search-product-filter-status.
+ *
+ * Mirrors the runtime DOM shape — labeled list with three checkbox options
+ * and optional count badges — so designers can style the filter list in
+ * place. Inspector exposes the user-tunable attributes (label, showCount).
+ */
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
+import { createElement as h, Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+// Mirror Search_Product_Filter_Status::get_options() — same value/label
+// pairs so the editor preview matches the front-end render shape exactly.
+// Sample counts are illustrative; the live block renders real ES counts.
+const SAMPLE_OPTIONS = [
+	{ value: 'instock', label: __( 'In stock', 'jetpack-search-pkg' ), count: 24 },
+	{ value: 'outofstock', label: __( 'Out of stock', 'jetpack-search-pkg' ), count: 3 },
+	{ value: 'onbackorder', label: __( 'On backorder', 'jetpack-search-pkg' ), count: 1 },
+];
+
+const DEFAULT_LABEL = __( 'Stock status', 'jetpack-search-pkg' );
+
+/**
+ * Edit component for the search-product-filter-status block.
+ *
+ * @param {object}   props               - Block props.
+ * @param {object}   props.attributes    - Saved block attributes.
+ * @param {Function} props.setAttributes - Attribute setter.
+ * @return {object} Rendered element.
+ */
+export default function SearchProductFilterStatusEdit( { attributes, setAttributes } ) {
+	const blockProps = useBlockProps( { className: 'jetpack-search-product-filter-status' } );
+	const rawLabel = attributes?.label || '';
+	const previewLabel = rawLabel || DEFAULT_LABEL;
+	const showCount = attributes?.showCount !== false;
+
+	return h(
+		Fragment,
+		null,
+		h(
+			InspectorControls,
+			null,
+			h(
+				PanelBody,
+				{ title: __( 'Settings', 'jetpack-search-pkg' ) },
+				h( TextControl, {
+					__next40pxDefaultSize: true,
+					__nextHasNoMarginBottom: true,
+					label: __( 'Label', 'jetpack-search-pkg' ),
+					value: rawLabel,
+					placeholder: DEFAULT_LABEL,
+					onChange: value => setAttributes( { label: value } ),
+					help: __(
+						'Heading shown above the options. Leave empty for the default.',
+						'jetpack-search-pkg'
+					),
+				} ),
+				h( ToggleControl, {
+					__nextHasNoMarginBottom: true,
+					label: __( 'Show result counts', 'jetpack-search-pkg' ),
+					checked: showCount,
+					onChange: value => setAttributes( { showCount: !! value } ),
+				} )
+			)
+		),
+		h(
+			'div',
+			blockProps,
+			h( 'h3', { className: 'jetpack-search-filter__title' }, previewLabel ),
+			h(
+				'ul',
+				{ className: 'jetpack-search-filter__list' },
+				SAMPLE_OPTIONS.map( option =>
+					h(
+						'li',
+						{ key: option.value, className: 'jetpack-search-filter__item' },
+						h(
+							'label',
+							null,
+							h( 'input', { type: 'checkbox', disabled: true } ),
+							h( 'span', { className: 'jetpack-search-filter__label' }, option.label ),
+							showCount
+								? h( 'span', { className: 'jetpack-search-filter__count' }, String( option.count ) )
+								: null
+						)
+					)
+				)
+			)
+		)
+	);
+}

--- a/projects/packages/search/src/search-blocks/blocks/search-product-filter-status/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/search-product-filter-status/render.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Search product filter — stock status render.
+ *
+ * Emits a fixed three-option list (in stock / out of stock / on backorder)
+ * and registers the filterConfig with the shared `jetpack-search`
+ * Interactivity store. Counts are looked up at render time from
+ * URL-seeded `state.aggregations.filter_stock_status.buckets` so direct
+ * URL hits show count badges before JS hydrates; bindings update them
+ * once the first JS-driven fetch completes.
+ *
+ * Unlike the generic filter-checkbox block, the option list is fixed
+ * (WC's `wc_get_product_stock_status_options()` keys) and renders even
+ * when the aggregation has zero buckets — the e-commerce facet UX
+ * convention is "always show every option, even at count 0," which
+ * mirrors WC's own filter and matches what shoppers expect.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+
+if ( ! function_exists( 'wp_interactivity_state' ) ) {
+	return;
+}
+
+// @phan-suppress-next-line PhanUndeclaredGlobalVariable
+$config = Search_Product_Filter_Status::build_config( (array) $attributes );
+
+// Register this filter's config into the shared store. JS reads the
+// filterConfigs map to build aggregation requests, ES filter clauses, and
+// the URL writer's per-key shape (scalar vs. array form).
+wp_interactivity_state(
+	'jetpack-search',
+	array(
+		'filterConfigs' => array(
+			Search_Product_Filter_Status::FILTER_KEY => $config,
+		),
+	)
+);
+
+$seeded_state    = wp_interactivity_state( 'jetpack-search' );
+$seeded_aggs     = (array) ( $seeded_state['aggregations'] ?? array() );
+$seeded_buckets  = (array) ( ( (array) ( $seeded_aggs[ Search_Product_Filter_Status::FILTER_KEY ] ?? array() ) )['buckets'] ?? array() );
+$seeded_active   = (array) ( $seeded_state['activeFilters'] ?? array() );
+$seeded_selected = (array) ( $seeded_active[ Search_Product_Filter_Status::FILTER_KEY ] ?? array() );
+
+// Build a slug → count map from the aggregation buckets so the static
+// option list can render count badges on first paint.
+$counts = array();
+foreach ( $seeded_buckets as $bucket ) {
+	$key = (string) ( $bucket['key'] ?? '' );
+	if ( '' === $key ) {
+		continue;
+	}
+	$counts[ $key ] = (int) ( $bucket['doc_count'] ?? 0 );
+}
+
+$label      = (string) $config['label'];
+$show_count = (bool) $config['showCount'];
+?>
+<div
+	<?php echo wp_kses_data( get_block_wrapper_attributes( array( 'class' => 'jetpack-search-product-filter-status' ) ) ); ?>
+	data-wp-interactive="jetpack-search"
+	<?php echo wp_kses_data( wp_interactivity_data_wp_context( array( 'filterKey' => Search_Product_Filter_Status::FILTER_KEY ) ) ); ?>
+>
+	<?php if ( '' !== $label ) : ?>
+		<h3 class="jetpack-search-filter__title"><?php echo esc_html( $label ); ?></h3>
+	<?php endif; ?>
+	<ul class="jetpack-search-filter__list">
+		<?php foreach ( Search_Product_Filter_Status::get_options() as $option ) : ?>
+			<?php
+			$value      = (string) $option['value'];
+			$option_lbl = (string) $option['label'];
+			$is_checked = in_array( $value, $seeded_selected, true );
+			$option_cnt = $counts[ $value ] ?? 0;
+			?>
+			<li class="jetpack-search-filter__item">
+				<label>
+					<input
+						type="checkbox"
+						value="<?php echo esc_attr( $value ); ?>"
+						<?php echo $is_checked ? 'checked' : ''; ?>
+						data-wp-bind--checked="state.isStatusOptionSelected"
+						data-wp-on--change="actions.onStatusFilterChange"
+					/>
+					<span class="jetpack-search-filter__label"><?php echo esc_html( $option_lbl ); ?></span>
+					<?php if ( $show_count ) : ?>
+						<span
+							class="jetpack-search-filter__count"
+							data-wp-text="state.statusOptionCount"
+						><?php echo esc_html( (string) $option_cnt ); ?></span>
+					<?php endif; ?>
+				</label>
+			</li>
+		<?php endforeach; ?>
+	</ul>
+</div>

--- a/projects/packages/search/src/search-blocks/blocks/search-product-filter-status/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/search-product-filter-status/style.scss
@@ -1,0 +1,19 @@
+/**
+ * Search product filter — stock status.
+ *
+ * Inherits the shared `.jetpack-search-filter__list/__item/__label/__count`
+ * styles from the generic filter-checkbox block (loaded as part of the
+ * package CSS), so this file only adds product-filter-specific tweaks.
+ * The parent wrapper class is here so the editor preview and the front-end
+ * markup share the same hook.
+ */
+.jetpack-search-product-filter-status {
+	// Keep the option list compact when the parent wrapper sets a tight
+	// blockGap — vertical option lists shouldn't inherit the parent's
+	// inter-section spacing as item-to-item spacing.
+	.jetpack-search-filter__list {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+}

--- a/projects/packages/search/src/search-blocks/blocks/search-product-filter-status/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-product-filter-status/view.js
@@ -1,0 +1,96 @@
+import { store, getContext, getElement } from '@wordpress/interactivity';
+import '../../store';
+import './style.scss';
+
+const NAMESPACE = 'jetpack-search';
+
+/**
+ * Build a slug → count map from a histogram-or-terms aggregation's buckets.
+ * Returns a plain object so the per-option getter can do a constant-time
+ * lookup and avoid re-scanning the bucket array for every render.
+ *
+ * @param {Array<{key: string, doc_count: number}>} buckets - Aggregation buckets.
+ * @return {object} Slug-keyed count map.
+ */
+function bucketsToCountMap( buckets ) {
+	if ( ! Array.isArray( buckets ) ) {
+		return {};
+	}
+	const map = {};
+	for ( const bucket of buckets ) {
+		const key = String( bucket?.key ?? '' );
+		if ( ! key ) {
+			continue;
+		}
+		map[ key ] = Number( bucket?.doc_count ?? 0 );
+	}
+	return map;
+}
+
+store( NAMESPACE, {
+	state: {
+		/**
+		 * `data-wp-bind--checked` per-option. Reads the input's `value`
+		 * attribute via `getElement().attributes.value` so the same getter
+		 * serves all three options without per-option context. Falls back
+		 * to false when the filter has no selections so unchecking the
+		 * last box re-renders cleanly.
+		 *
+		 * @return {boolean} Whether this option's slug is in activeFilters.
+		 */
+		get isStatusOptionSelected() {
+			const value = getElement()?.attributes?.value;
+			if ( ! value ) {
+				return false;
+			}
+			const { state } = store( NAMESPACE );
+			const { filterKey } = getContext();
+			const selected = state.activeFilters?.[ filterKey ];
+			return Array.isArray( selected ) && selected.includes( value );
+		},
+
+		/**
+		 * `data-wp-text` per-option count badge. Reads the option's slug
+		 * from the option's `<input value=…>` (the count badge sits next
+		 * to the input inside the same `<label>`), then looks the slug up
+		 * in the aggregation. Falls back to "0" when the filter has no
+		 * matches in the current scope — convention for "always show all
+		 * options" facet UIs.
+		 *
+		 * @return {string} Count as a string for the badge text node.
+		 */
+		get statusOptionCount() {
+			// The count <span> sits as a sibling of the <input> inside the
+			// shared <label>. Walk up to the label, then find the input
+			// to read its `value` attribute — the slug we look up below.
+			const el = getElement()?.ref;
+			const label = el?.closest?.( 'label' );
+			const input = label?.querySelector?.( 'input[type="checkbox"]' );
+			const value = input?.getAttribute?.( 'value' );
+			if ( ! value ) {
+				return '0';
+			}
+			const { state } = store( NAMESPACE );
+			const { filterKey } = getContext();
+			const buckets = state.aggregations?.[ filterKey ]?.buckets;
+			const counts = bucketsToCountMap( buckets );
+			return String( counts[ value ] ?? 0 );
+		},
+	},
+
+	actions: {
+		/**
+		 * Toggle the stock-status value that owns the change event. The
+		 * input's `value` attribute carries the slug; filterKey comes from
+		 * the wrapper context.
+		 *
+		 * @param {Event} event - Change event.
+		 * @yield {Promise} setFilter action.
+		 */
+		*onStatusFilterChange( event ) {
+			const { actions } = store( NAMESPACE );
+			const { filterKey } = getContext();
+			yield actions.setFilter( filterKey, event.target.value );
+		},
+	},
+} );

--- a/projects/packages/search/src/search-blocks/blocks/search-product-filters/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/search-product-filters/block.json
@@ -1,0 +1,31 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "jetpack/search-product-filters",
+	"version": "0.1.0",
+	"title": "Product Filters",
+	"category": "jetpack-search",
+	"icon": "filter",
+	"description": "A composable container for WooCommerce-style product filters (status, rating, price, attributes). Powered by Jetpack Search.",
+	"supports": {
+		"html": false,
+		"align": [ "wide", "full" ],
+		"layout": {
+			"default": {
+				"type": "flex",
+				"orientation": "vertical",
+				"flexWrap": "nowrap",
+				"justifyContent": "stretch"
+			},
+			"allowEditing": false
+		},
+		"spacing": {
+			"blockGap": true,
+			"margin": [ "top", "bottom" ],
+			"padding": true
+		}
+	},
+	"textdomain": "jetpack-search-pkg",
+	"render": "file:./render.php",
+	"style": "file:../../../../build/search-blocks/search-product-filters.css"
+}

--- a/projects/packages/search/src/search-blocks/blocks/search-product-filters/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-product-filters/edit.js
@@ -1,0 +1,53 @@
+/**
+ * Editor preview for jetpack/search-product-filters.
+ *
+ * Pure layout container with an InnerBlocks slot. The default template seeds
+ * a useful starter set (status + rating + price); authors can add, reorder,
+ * or delete children freely. The allowedBlocks list restricts insertion to
+ * the product-filter family so unrelated blocks (paragraph, image, …) don't
+ * end up in the filter sidebar by accident.
+ *
+ * Children are *also* registered without an `ancestor` constraint in their
+ * own block.json, so an author can drop e.g. `jetpack/search-product-filter-
+ * status` directly on a page without this wrapper. This block is for
+ * grouping/spacing/layout, not for gating insertion.
+ */
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import { createElement as h } from '@wordpress/element';
+
+const TEMPLATE = [
+	[ 'jetpack/search-product-filter-status' ],
+	[ 'jetpack/search-product-filter-rating' ],
+	[ 'jetpack/search-product-filter-price' ],
+];
+
+const ALLOWED = [
+	'jetpack/search-product-filter-status',
+	'jetpack/search-product-filter-rating',
+	'jetpack/search-product-filter-price',
+	'jetpack/search-product-filter-price-slider',
+	'jetpack/search-product-filter-attribute',
+	'jetpack/search-product-filter-taxonomy',
+	'jetpack/search-product-filter-checkbox-list',
+	'jetpack/search-product-filter-chips',
+	'jetpack/search-product-filter-clear-button',
+	'jetpack/active-filters',
+];
+
+/**
+ * Edit component for the search-product-filters parent block.
+ *
+ * @return {object} Rendered element.
+ */
+export default function SearchProductFiltersEdit() {
+	const blockProps = useBlockProps( { className: 'jetpack-search-product-filters' } );
+	return h( 'div', blockProps, h( InnerBlocks, { template: TEMPLATE, allowedBlocks: ALLOWED } ) );
+}
+
+/**
+ * Save component — only renders InnerBlocks.Content. Server-side render emits
+ * the wrapper around the children's HTML.
+ *
+ * @return {object} Rendered element.
+ */
+export const save = () => h( InnerBlocks.Content, {} );

--- a/projects/packages/search/src/search-blocks/blocks/search-product-filters/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/search-product-filters/render.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Search Product Filters parent block render.
+ *
+ * Pure layout container: emits a wrapper around the inner blocks so the
+ * product-filter children (status, rating, price, attribute, taxonomy) share
+ * one column / spacing context. All search-side behavior lives in the
+ * children — this block has no Interactivity bindings, no view module, and
+ * no client-side state of its own.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+?>
+<div <?php echo wp_kses_data( get_block_wrapper_attributes( array( 'class' => 'jetpack-search-product-filters' ) ) ); ?>>
+	<?php
+	// @phan-suppress-next-line PhanUndeclaredGlobalVariable -- $content is provided by WP at block render.
+	echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Inner block HTML is already escaped by each child block's renderer.
+	?>
+</div>

--- a/projects/packages/search/src/search-blocks/blocks/search-product-filters/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/search-product-filters/style.scss
@@ -1,0 +1,13 @@
+/**
+ * Search Product Filters parent block.
+ *
+ * Layout-only: lets each child filter take its natural width and stack
+ * vertically with the block-gap configured on the wrapper. Spacing controls
+ * are exposed via block.json `supports.spacing` so authors can tune padding
+ * and gap from the editor without theme overrides.
+ */
+.jetpack-search-product-filters {
+	display: flex;
+	flex-direction: column;
+	gap: var(--wp--style--block-gap, 1.5rem);
+}

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -455,9 +455,18 @@ class Search_Blocks {
 	}
 
 	/**
-	 * Recursively walk a parsed block tree and push filter-checkbox configs
+	 * Recursively walk a parsed block tree and push filter-block configs
 	 * into `$configs`. Passing `$configs` by reference keeps the recursion
 	 * flat — callers don't need to merge children's maps back into parents'.
+	 *
+	 * Recognizes:
+	 * - `jetpack/filter-checkbox` (generic taxonomy / post-type / author filters)
+	 * - `jetpack/search-product-filter-status` (WC stock status, scalar URL)
+	 * - `jetpack/search-product-filter-rating` (WC star rating, histogram-driven)
+	 *
+	 * The price filter (`jetpack/search-product-filter-price`) intentionally
+	 * doesn't register a filterConfig — `priceRange` is its own state branch
+	 * with `min_price` / `max_price` already in `RESERVED_QUERY_PARAMS`.
 	 *
 	 * @param array $blocks  Parsed block tree from parse_blocks().
 	 * @param array $configs Accumulator map keyed by filterKey.
@@ -468,13 +477,22 @@ class Search_Blocks {
 			if ( ! is_array( $block ) ) {
 				continue;
 			}
-			if ( 'jetpack/filter-checkbox' === ( $block['blockName'] ?? '' ) ) {
-				$attrs = (array) ( $block['attrs'] ?? array() );
-				$key   = Filter_Checkbox::derive_filter_key( $attrs );
+			$name  = (string) ( $block['blockName'] ?? '' );
+			$attrs = (array) ( $block['attrs'] ?? array() );
+
+			if ( 'jetpack/filter-checkbox' === $name ) {
+				$key = Filter_Checkbox::derive_filter_key( $attrs );
 				if ( '' !== $key ) {
 					$configs[ $key ] = Filter_Checkbox::build_config( $attrs, $key );
 				}
+			} elseif ( 'jetpack/search-product-filter-status' === $name && class_exists( Search_Product_Filter_Status::class ) ) {
+				$key             = Search_Product_Filter_Status::FILTER_KEY;
+				$configs[ $key ] = Search_Product_Filter_Status::build_config( $attrs );
+			} elseif ( 'jetpack/search-product-filter-rating' === $name && class_exists( Search_Product_Filter_Rating::class ) ) {
+				$key             = Search_Product_Filter_Rating::FILTER_KEY;
+				$configs[ $key ] = Search_Product_Filter_Rating::build_config( $attrs );
 			}
+
 			if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
 				static::walk_blocks_for_filter_configs( $block['innerBlocks'], $configs );
 			}

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -25,6 +25,12 @@ import LoadMoreEdit from '../blocks/load-more/edit';
 import NoResultsEdit from '../blocks/no-results/edit';
 import ResultsCountEdit from '../blocks/results-count/edit';
 import SearchInputEdit from '../blocks/search-input/edit';
+import SearchProductFilterPriceEdit from '../blocks/search-product-filter-price/edit';
+import SearchProductFilterRatingEdit from '../blocks/search-product-filter-rating/edit';
+import SearchProductFilterStatusEdit from '../blocks/search-product-filter-status/edit';
+import SearchProductFiltersEdit, {
+	save as searchProductFiltersSave,
+} from '../blocks/search-product-filters/edit';
 import SearchResultsEdit from '../blocks/search-results/edit';
 import SortControlEdit from '../blocks/sort-control/edit';
 
@@ -41,6 +47,10 @@ const BLOCKS = [
 	[ 'jetpack/results-count', ResultsCountEdit ],
 	[ 'jetpack/no-results', NoResultsEdit ],
 	[ 'jetpack/load-more', LoadMoreEdit ],
+	[ 'jetpack/search-product-filters', SearchProductFiltersEdit, searchProductFiltersSave ],
+	[ 'jetpack/search-product-filter-status', SearchProductFilterStatusEdit ],
+	[ 'jetpack/search-product-filter-rating', SearchProductFilterRatingEdit ],
+	[ 'jetpack/search-product-filter-price', SearchProductFilterPriceEdit ],
 ];
 
 // Shape the "Jetpack Search" block category to match the Forms / Monetize /

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -328,15 +328,59 @@ const { state, actions } = store( NAMESPACE, {
 		},
 
 		/**
-		 * Clear all active filters and re-run the search.
+		 * Clear all active filters and re-run the search. Clears `priceRange`
+		 * too so a single "clear all" UI affordance resets every facet — both
+		 * checkbox-shaped selections and the half-open price range.
 		 *
 		 * @yield {Promise} search action.
 		 */
 		*clearFilters() {
-			if ( Object.keys( state.activeFilters ?? {} ).length === 0 ) {
+			const hadFilters = Object.keys( state.activeFilters ?? {} ).length > 0;
+			const hadPriceRange = state.priceRange !== null && state.priceRange !== undefined;
+			if ( ! hadFilters && ! hadPriceRange ) {
 				return;
 			}
 			state.activeFilters = {};
+			state.priceRange = null;
+			yield actions.search();
+		},
+
+		/**
+		 * Update the price range and re-run the search if it changed. Either
+		 * bound may be null for a half-open range; passing both as null clears
+		 * the range. No-ops when the new range matches the current one so a
+		 * blur from an unchanged input doesn't trigger an identical re-fetch.
+		 *
+		 * @param {number|null} min - Lower bound, inclusive.
+		 * @param {number|null} max - Upper bound, inclusive.
+		 * @yield {Promise} search action.
+		 */
+		*setPriceRange( min, max ) {
+			const normalize = v => ( v === null || v === undefined || v === '' ? null : Number( v ) );
+			const nextMin = normalize( min );
+			const nextMax = normalize( max );
+			// Reject NaN bounds so a typo'd input doesn't poison the ES range
+			// clause. Mirrors the parsePriceBound() guard in url-state.js so
+			// the action and the URL reader agree on what "no bound" means.
+			const validMin = nextMin === null || ( Number.isFinite( nextMin ) && nextMin >= 0 );
+			const validMax = nextMax === null || ( Number.isFinite( nextMax ) && nextMax >= 0 );
+			if ( ! validMin || ! validMax ) {
+				return;
+			}
+			// Inverted bounds (min > max) build a guaranteed-empty ES clause.
+			// Drop the call rather than pushing a bad URL or zeroing results.
+			if ( nextMin !== null && nextMax !== null && nextMin > nextMax ) {
+				return;
+			}
+			const next = nextMin === null && nextMax === null ? null : { min: nextMin, max: nextMax };
+			const prev = state.priceRange;
+			const same =
+				( prev === null && next === null ) ||
+				( prev !== null && next !== null && prev.min === next.min && prev.max === next.max );
+			if ( same ) {
+				return;
+			}
+			state.priceRange = next;
 			yield actions.search();
 		},
 
@@ -349,6 +393,7 @@ const { state, actions } = store( NAMESPACE, {
 				sortOrder: state.sortOrder,
 				activeFilters: state.activeFilters,
 				priceRange: state.priceRange,
+				filterConfigs: state.filterConfigs,
 			} );
 		},
 

--- a/projects/packages/search/src/search-blocks/store/url-state.js
+++ b/projects/packages/search/src/search-blocks/store/url-state.js
@@ -28,15 +28,19 @@ function parsePriceBound( raw ) {
 /**
  * Serialize store state to URLSearchParams.
  *
- * Filter keys are written as flat top-level array params (`?category[]=news`),
+ * Filter keys default to flat top-level array params (`?category[]=news`),
  * matching the shape instant-search already writes so deep links are
- * interchangeable between the two surfaces.
+ * interchangeable between the two surfaces. Filters whose registered config
+ * sets `urlFormat: 'scalar'` instead emit a single key with comma-joined
+ * values (`?filter_stock_status=instock,outofstock`) — used by product-shape
+ * filters that need to round-trip with WooCommerce's native URL contract.
  *
  * @param {object}      state                 - Store state slice.
  * @param {string}      state.searchQuery     - Current search query.
  * @param {string}      state.sortOrder       - Current sort order.
  * @param {object}      [state.activeFilters] - { [filterKey]: string[] } selected filters.
  * @param {object|null} [state.priceRange]    - { min, max } price range; either bound may be null.
+ * @param {object}      [state.filterConfigs] - { [filterKey]: FilterConfig } map. Drives per-key URL shape (`scalar` vs default array form).
  * @return {URLSearchParams} URL-ready params.
  */
 export function stateToUrlParams( {
@@ -44,6 +48,7 @@ export function stateToUrlParams( {
 	sortOrder,
 	activeFilters = {},
 	priceRange = null,
+	filterConfigs = {},
 } ) {
 	const params = new URLSearchParams();
 
@@ -58,6 +63,10 @@ export function stateToUrlParams( {
 
 	for ( const [ key, values ] of Object.entries( activeFilters ) ) {
 		if ( ! Array.isArray( values ) || values.length === 0 ) {
+			continue;
+		}
+		if ( filterConfigs?.[ key ]?.urlFormat === 'scalar' ) {
+			params.set( key, values.join( ',' ) );
 			continue;
 		}
 		values.forEach( value => params.append( `${ key }[]`, value ) );

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -220,6 +220,73 @@ describe( 'store actions', () => {
 		expect( search ).toHaveBeenCalledTimes( 1 );
 	} );
 
+	it( 'clearFilters also clears priceRange so a single affordance resets every facet', async () => {
+		// Without this, a sidebar "clear all" button would leave a sticky
+		// price filter behind, surprising users who expect it to wipe state.
+		const search = jest.spyOn( actions, 'search' ).mockResolvedValue();
+		state.activeFilters = {};
+		state.priceRange = { min: 10, max: null };
+
+		await runGenerator( actions.clearFilters() );
+
+		expect( state.activeFilters ).toEqual( {} );
+		expect( state.priceRange ).toBeNull();
+		expect( search ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'setPriceRange updates state and re-runs the search', async () => {
+		const search = jest.spyOn( actions, 'search' ).mockResolvedValue();
+		state.priceRange = null;
+
+		await runGenerator( actions.setPriceRange( 5, 50 ) );
+
+		expect( state.priceRange ).toEqual( { min: 5, max: 50 } );
+		expect( search ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'setPriceRange no-ops when called with the current bounds', async () => {
+		// Prevents a stray blur on an unchanged input from triggering an
+		// identical re-fetch — wasteful and risks burning the search-token
+		// counter on no actual user intent.
+		const search = jest.spyOn( actions, 'search' ).mockResolvedValue();
+		state.priceRange = { min: 5, max: 50 };
+
+		await runGenerator( actions.setPriceRange( 5, 50 ) );
+
+		expect( search ).not.toHaveBeenCalled();
+	} );
+
+	it( 'setPriceRange drops inverted bounds rather than producing zero-result range clauses', async () => {
+		const search = jest.spyOn( actions, 'search' ).mockResolvedValue();
+		state.priceRange = null;
+
+		await runGenerator( actions.setPriceRange( 100, 10 ) );
+
+		expect( state.priceRange ).toBeNull();
+		expect( search ).not.toHaveBeenCalled();
+	} );
+
+	it( 'setPriceRange clears the range when both bounds are null', async () => {
+		const search = jest.spyOn( actions, 'search' ).mockResolvedValue();
+		state.priceRange = { min: 5, max: 50 };
+
+		await runGenerator( actions.setPriceRange( null, null ) );
+
+		expect( state.priceRange ).toBeNull();
+		expect( search ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'setPriceRange rejects negative or non-finite bounds without searching', async () => {
+		const search = jest.spyOn( actions, 'search' ).mockResolvedValue();
+		state.priceRange = null;
+
+		await runGenerator( actions.setPriceRange( -5, 50 ) );
+		await runGenerator( actions.setPriceRange( NaN, 50 ) );
+
+		expect( state.priceRange ).toBeNull();
+		expect( search ).not.toHaveBeenCalled();
+	} );
+
 	it( 'keeps filter and sort popovers mutually exclusive', () => {
 		state.isSortPopoverOpen = true;
 		actions.toggleFilterPopover();
@@ -295,6 +362,27 @@ describe( 'store actions', () => {
 		const writtenUrl = replaceState.mock.calls[ 0 ][ 2 ];
 		expect( writtenUrl ).toContain( 'min_price=10' );
 		expect( writtenUrl ).toContain( 'max_price=50' );
+	} );
+
+	it( 'syncToUrl honors urlFormat:"scalar" filterConfigs and emits comma-joined values', () => {
+		// Without this, status selections would round-trip as the default
+		// array-form (`?filter_stock_status[]=instock`), breaking parity
+		// with WC's native URL contract — a deep link from a WC store
+		// would no longer match this block's URL on first load.
+		const replaceState = jest.spyOn( window.history, 'replaceState' ).mockImplementation();
+		state.searchQuery = 'shirts';
+		state.activeFilters = { filter_stock_status: [ 'instock', 'onbackorder' ] };
+		state.filterConfigs = {
+			filter_stock_status: { filterType: 'wc_stock_status', urlFormat: 'scalar' },
+		};
+
+		actions.syncToUrl();
+
+		expect( replaceState ).toHaveBeenCalledTimes( 1 );
+		const writtenUrl = replaceState.mock.calls[ 0 ][ 2 ];
+		expect( writtenUrl ).toContain( 'filter_stock_status=instock%2Conbackorder' );
+		expect( writtenUrl ).not.toContain( 'filter_stock_status[]' );
+		expect( writtenUrl ).not.toContain( 'filter_stock_status%5B%5D' );
 	} );
 
 	it( 'closes open popovers on Escape only', () => {


### PR DESCRIPTION
## Why

First slice of the [RSM-1929](https://linear.app/a8c/issue/RSM-1929) WC product filter epic. Builds on the data plane that landed in #48397 to ship the four foundational blocks shoppers expect from a WC product search page.

This PR is intentionally scoped to the *blocks themselves* — chip resolution and additional filter shapes (attribute, taxonomy) live in stacked follow-up PRs so reviewers can see one architectural seam at a time.

The bridge approach in #48368 closed because WC's internal filter UI was too fragile to depend on. We now own the filter contract end-to-end: each block contributes a `filterConfig` to the shared Interactivity store, the data plane in #48397 maps it to ES paths, and the URL contract is dictated by the block (scalar form for status mirrors WC's native query string; array form for rating mirrors instant-search).

## Proposed changes

- **`jetpack/search-product-filters`** — composable parent. `<InnerBlocks>` with an `allowedBlocks` whitelist for the entire product-filter family and a 3-filter default template (status / rating / price). No view module, no Interactivity bindings — pure layout container.
- **`jetpack/search-product-filter-status`** — fixed 3-option list (in stock / out of stock / on backorder). `wc_stock_status` filterType with `urlFormat: 'scalar'` so URLs read `?filter_stock_status=instock,outofstock` (mirrors WC's native query contract; deep links interoperate with WC's own status filter).
- **`jetpack/search-product-filter-rating`** — 5 star rows (5..1). `wc_rating` filterType. View-side projects `.5`-boundary histogram bucket keys onto stars (1..5) using the same logic as `WC_RATING_RANGES` in PHP.
- **`jetpack/search-product-filter-price`** — min/max number inputs. Drives a new `setPriceRange(min, max)` action against a dedicated `state.priceRange` slice (not part of `activeFilters`). `min_price` / `max_price` URL params already in `RESERVED_QUERY_PARAMS`.

### Store plumbing
- `setPriceRange(min, max)` action: rejects invalid (NaN, negative) and inverted (min > max) bounds, no-ops on identity, clears the range when both are null.
- `clearFilters` extends to also reset `priceRange` so a single clear-all wipes every facet.
- `stateToUrlParams` honors `urlFormat: 'scalar'` on the writer side; `syncToUrl` passes `filterConfigs` through so the per-key URL shape resolves correctly.

### PHP
- `walk_blocks_for_filter_configs` recognizes the two new helper-class blocks (status, rating). The price block intentionally has no filterConfig — `priceRange` is its own state branch.

### Tests
- 7 new JS tests covering setPriceRange variants, clearFilters extension, scalar URL writer round-trip.

### Verification
- 289 JS tests pass / 228 PHP tests pass (counts at the time of this commit).
- Webpack builds clean.
- Browser-smoked on a docker WC site against `/?s=shirt` — every URL contract round-trips.

## Related product discussion/links

- Epic: [RSM-1929](https://linear.app/a8c/issue/RSM-1929)
- Predecessor PR (data-plane helpers): #48397
- Bridge attempt that closed: #48368

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Spin up Jetpack Search 3.0 on a WC site.
2. Insert the parent block on a page or template — the 3-filter default template seeds status / rating / price.
3. Save and view the front-end with a query that returns products (`/?s=shirt`).
4. Verify:
   - Click an "In stock" checkbox → URL gains `?filter_stock_status=instock` (scalar form).
   - Click a 5-star row → URL gains `?rating_filter[]=5`.
   - Type `10` into Min, blur or press Enter → URL gains `?min_price=10`.
   - Bad values (negative, NaN, inverted) are silently dropped — search doesn't fire.
   - Hit back/forward → all selections restore correctly.
5. Run tests: `pnpm exec jest tests/js/search-blocks` and `composer phpunit` from `projects/packages/search/`.

## Stack

This is **PR-A** of a 3-PR stack closing RSM-1929. Sibling PRs land on top:
- **PR-B**: active-filters product-aware chips + standalone clear-button block
- **PR-C**: attribute (`pa_*`) + taxonomy (`product_cat` / `product_tag` / `product_brand`) filter blocks