### PR TITLE
Search 3.0: active-filters product-aware chips + clear-button block

### DIFF
--- a/projects/packages/search/changelog/add-search-active-filters-product-chips
+++ b/projects/packages/search/changelog/add-search-active-filters-product-chips
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search 3.0: active-filters block now renders product-aware chips ("Stock status: In stock", "Rating: 5 stars", "Price: $10 – $50") and surfaces with a price-only selection. Adds the `state.hasAnyActiveFilters` getter, the `state.wcStockStatusLabels` and `state.priceCurrencySymbol` seeds, and the rating + price chip string templates. Also adds the standalone `jetpack/search-product-filter-clear-button` block — a thin wrapper around `actions.clearFilters` that hides itself when no facet is active. Tracked under epic [RSM-1929].

--- a/projects/packages/search/src/search-blocks/blocks/active-filters/lib.js
+++ b/projects/packages/search/src/search-blocks/blocks/active-filters/lib.js
@@ -1,0 +1,183 @@
+/**
+ * Pure helpers for the active-filters block.
+ *
+ * Split out from view.js so they're directly testable: the view bundle
+ * itself runs inside `@wordpress/interactivity` and is awkward to exercise
+ * in Jest, but the label resolution logic is just data → string and
+ * benefits from focused unit tests.
+ */
+
+/**
+ * Look up the display label for a selected filter value via aggregation
+ * buckets. Generic taxonomy / post-type / author filters store the *slug*
+ * part of each selection; the matching aggregation bucket key is either
+ * the slug itself (post types) or `slug/Name` (taxonomies, authors).
+ *
+ * If we find a matching bucket we return its display name; otherwise the
+ * raw slug stays. Bucket counts can shift with every new query, and a
+ * selected pill should not vanish just because its value fell out of the
+ * top-N agg buckets.
+ *
+ * @param {object} state       - Store state slice (`{ aggregations }`).
+ * @param {string} filterKey   - Filter key this value belongs to.
+ * @param {string} filterValue - Selected slug.
+ * @return {string} Display label.
+ */
+export function resolveBucketValueLabel( state, filterKey, filterValue ) {
+	const buckets = state?.aggregations?.[ filterKey ]?.buckets;
+	if ( Array.isArray( buckets ) ) {
+		for ( const bucket of buckets ) {
+			const key = String( bucket.key ?? '' );
+			const slashIdx = key.indexOf( '/' );
+			const slug = slashIdx === -1 ? key : key.slice( 0, slashIdx );
+			if ( slug === filterValue ) {
+				return slashIdx === -1 ? key : key.slice( slashIdx + 1 );
+			}
+		}
+	}
+	return filterValue;
+}
+
+/**
+ * Resolve a display label for a product-shaped filter value.
+ *
+ * For `wc_stock_status`, the slug is looked up in
+ * `state.wcStockStatusLabels`, seeded from the status block's option list.
+ * For `wc_rating`, the value is formatted via seeded singular / plural
+ * templates (`state.strings.ratingStarsSingle` / `…Plural`); the view
+ * bundle can't import `\@wordpress/i18n`, so plural selection happens
+ * here with a `count === 1` test (degraded plural for languages with
+ * >2 forms — accepted tradeoff). Anything else returns null so the
+ * caller can fall back to the bucket-based generic resolver.
+ *
+ * @param {object} state       - Store state slice.
+ * @param {object} config      - FilterConfig entry (or undefined).
+ * @param {string} filterValue - Selected raw value.
+ * @return {string|null} Resolved label, or null when no product-specific resolution applies.
+ */
+export function resolveProductValueLabel( state, config, filterValue ) {
+	const filterType = config?.filterType;
+	if ( filterType === 'wc_stock_status' ) {
+		const labels = state?.wcStockStatusLabels ?? {};
+		return labels[ filterValue ] ?? filterValue;
+	}
+	if ( filterType === 'wc_rating' ) {
+		const stars = Number( filterValue );
+		// Defensive: a malformed star value (NaN, out of range) falls
+		// through to the raw slug; the chip still renders rather than
+		// silently disappearing.
+		if ( ! Number.isFinite( stars ) || stars < 1 || stars > 5 ) {
+			return filterValue;
+		}
+		const template =
+			stars === 1
+				? state?.strings?.ratingStarsSingle ?? '%d star'
+				: state?.strings?.ratingStarsPlural ?? '%d stars';
+		return template.replace( '%d', String( stars ) );
+	}
+	return null;
+}
+
+/**
+ * Format the current price range as a chip label.
+ *
+ * Picks one of three templates by which bound(s) are set:
+ * - both: "$10 – $50"
+ * - min only: "From $10"
+ * - max only: "Up to $50"
+ *
+ * Currency symbol comes from `state.priceCurrencySymbol` (seeded by the
+ * price block's render.php from its currencySymbol attribute, falling back
+ * to "$" when no price block is on the page). The numeric value is rendered
+ * raw — locale-specific formatting would require Intl.NumberFormat per
+ * currency code, which v1 doesn't carry. Leaving the symbol-only convention
+ * matches the price input's own non-formatting display.
+ *
+ * @param {object}                               state - Store state slice.
+ * @param {{min: number|null, max: number|null}} range - Active price range.
+ * @return {string} Chip label without the leading group prefix; empty string when both bounds are null.
+ */
+export function formatPriceRangeChip( state, range ) {
+	const symbol = state?.priceCurrencySymbol ?? '$';
+	const min = range?.min;
+	const max = range?.max;
+	const hasMin = min !== null && min !== undefined;
+	const hasMax = max !== null && max !== undefined;
+	if ( hasMin && hasMax ) {
+		const template = state?.strings?.priceRangeFromTo ?? '%1$s – %2$s';
+		return template
+			.replace( '%1$s', `${ symbol }${ min }` )
+			.replace( '%2$s', `${ symbol }${ max }` );
+	}
+	if ( hasMin ) {
+		const template = state?.strings?.priceRangeFrom ?? 'From %s';
+		return template.replace( '%s', `${ symbol }${ min }` );
+	}
+	if ( hasMax ) {
+		const template = state?.strings?.priceRangeUpTo ?? 'Up to %s';
+		return template.replace( '%s', `${ symbol }${ max }` );
+	}
+	return '';
+}
+
+/**
+ * Build the pill descriptor list for the active-filters block from the
+ * current store state. Splits the `kind: 'filter'` pills (one per selected
+ * value across every filterKey) and the single `kind: 'priceRange'` pill
+ * appended at the end when a price range is active.
+ *
+ * Pulled out of view.js so the iteration order, label composition, and
+ * remove dispatch shape are unit-testable without an Interactivity API
+ * runtime.
+ *
+ * @param {object} state - Store state slice with `activeFilters`,
+ *                       `filterConfigs`, `aggregations`, `priceRange`,
+ *                       `strings`, `wcStockStatusLabels`,
+ *                       `priceCurrencySymbol`.
+ * @return {Array<object>} Pill descriptors.
+ */
+export function buildActivePills( state ) {
+	const removeFormat = state?.strings?.removeFilter ?? 'Remove %s';
+	const pills = [];
+
+	for ( const [ filterKey, values ] of Object.entries( state?.activeFilters ?? {} ) ) {
+		if ( ! Array.isArray( values ) ) {
+			continue;
+		}
+		const config = state?.filterConfigs?.[ filterKey ];
+		const groupLabel = config?.label ?? filterKey;
+		for ( const value of values ) {
+			const productLabel = resolveProductValueLabel( state, config, value );
+			const valueLabel =
+				productLabel !== null ? productLabel : resolveBucketValueLabel( state, filterKey, value );
+			const label = `${ groupLabel }: ${ valueLabel }`;
+			pills.push( {
+				id: `${ filterKey }:${ value }`,
+				kind: 'filter',
+				filterKey,
+				value,
+				label,
+				ariaLabel: removeFormat.replace( '%s', label ),
+			} );
+		}
+	}
+
+	const range = state?.priceRange;
+	if ( range && ( range.min !== null || range.max !== null ) ) {
+		const valueLabel = formatPriceRangeChip( state, range );
+		if ( valueLabel ) {
+			const groupLabel = state?.strings?.priceLabel ?? 'Price';
+			const label = `${ groupLabel }: ${ valueLabel }`;
+			pills.push( {
+				id: `priceRange:${ range.min ?? '' }:${ range.max ?? '' }`,
+				kind: 'priceRange',
+				filterKey: '',
+				value: '',
+				label,
+				ariaLabel: removeFormat.replace( '%s', label ),
+			} );
+		}
+	}
+
+	return pills;
+}

--- a/projects/packages/search/src/search-blocks/blocks/active-filters/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/active-filters/render.php
@@ -12,14 +12,15 @@ namespace Automattic\Jetpack\Search;
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 
 // Render `hidden` on first paint when no filters are active. JS unhides once
-// `state.hasActiveFilters` flips — relying only on data-wp-bind--hidden leaves
-// the "Active filters:" label and "Clear all" button visible on the server-
-// rendered HTML until hydration, which pushes sibling filter blocks ~30px
-// down and misaligns the sidebar with the adjacent results column.
+// `state.hasAnyActiveFilters` flips — relying only on data-wp-bind--hidden
+// leaves the "Active filters:" label and "Clear all" button visible on the
+// server-rendered HTML until hydration, which pushes sibling filter blocks
+// ~30px down and misaligns the sidebar with the adjacent results column.
 $seeded_state        = function_exists( 'wp_interactivity_state' )
 	? wp_interactivity_state( 'jetpack-search' )
 	: array();
 $seeded_active       = $seeded_state['activeFilters'] ?? array();
+$seeded_price        = $seeded_state['priceRange'] ?? null;
 $has_active_on_paint = false;
 foreach ( (array) $seeded_active as $values ) {
 	if ( is_array( $values ) && ! empty( $values ) ) {
@@ -27,11 +28,19 @@ foreach ( (array) $seeded_active as $values ) {
 		break;
 	}
 }
+// Mirror `hasAnyActiveFilters` on the server: a price-only deep link should
+// keep the wrapper visible so the user has a price chip to remove. Without
+// this branch the wrapper would paint hidden and only unhide on hydration,
+// flashing the price chip into view.
+if ( ! $has_active_on_paint && is_array( $seeded_price ) ) {
+	$has_active_on_paint = ( $seeded_price['min'] ?? null ) !== null
+		|| ( $seeded_price['max'] ?? null ) !== null;
+}
 ?>
 <div
 	<?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>
 	data-wp-interactive="jetpack-search"
-	data-wp-bind--hidden="!state.hasActiveFilters"
+	data-wp-bind--hidden="!state.hasAnyActiveFilters"
 	<?php echo $has_active_on_paint ? '' : 'hidden'; ?>
 >
 	<span class="jetpack-search-active-filters__heading">

--- a/projects/packages/search/src/search-blocks/blocks/active-filters/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/active-filters/view.js
@@ -1,91 +1,46 @@
 import { store, getContext } from '@wordpress/interactivity';
 import '../../store';
+import { buildActivePills } from './lib';
 import './style.scss';
 
 const NAMESPACE = 'jetpack-search';
 
-/**
- * Look up the display label for a selected filter value.
- *
- * Active filters store the *slug* part of each selection; the matching
- * aggregation bucket key is either the slug itself (post types) or
- * `slug/Name` (taxonomies, authors). If we can find a bucket we use its
- * display name, otherwise we fall back to the raw slug — bucket counts can
- * shift with every new query, and we don't want a selected pill to disappear
- * just because its value fell out of the top-N agg buckets.
- *
- * @param {object} state       - Store state.
- * @param {string} filterKey   - Filter key this value belongs to.
- * @param {string} filterValue - Selected slug.
- * @return {string} Display label.
- */
-function resolveValueLabel( state, filterKey, filterValue ) {
-	const buckets = state.aggregations?.[ filterKey ]?.buckets;
-	if ( Array.isArray( buckets ) ) {
-		for ( const bucket of buckets ) {
-			const key = String( bucket.key ?? '' );
-			const slashIdx = key.indexOf( '/' );
-			const slug = slashIdx === -1 ? key : key.slice( 0, slashIdx );
-			if ( slug === filterValue ) {
-				return slashIdx === -1 ? key : key.slice( slashIdx + 1 );
-			}
-		}
-	}
-	return filterValue;
-}
-
 store( NAMESPACE, {
 	state: {
 		/**
-		 * Flatten activeFilters into a list of pill descriptors for
-		 * `data-wp-each`. Pills carry their own filterKey + value so the
-		 * remove handler can toggle the correct selection without looking
-		 * it up from the event target.
+		 * Flatten activeFilters + priceRange into a list of pill descriptors
+		 * for `data-wp-each`. Pills carry their own `kind` discriminator so
+		 * the remove handler can dispatch to the right action without
+		 * peeking at filterKey shape.
 		 *
-		 * `ariaLabel` is what screen readers announce — the visible "×" is
-		 * aria-hidden, and the visible label alone ("Category: news") reads
-		 * as a plain noun phrase with no hint that activating the button
-		 * removes the filter. The "Remove %s" format is seeded in PHP via
-		 * `Search_Blocks::build_initial_strings()` because the view bundle
-		 * can't import `@wordpress/i18n`.
+		 * Heavy lifting (label resolution, plural handling, price chip
+		 * formatting) lives in `./lib.js` so it's directly unit-testable
+		 * without an Interactivity API runtime.
 		 *
-		 * @return {Array<object>} Array of pill descriptors with id, filterKey, value, label, ariaLabel.
+		 * @return {Array<object>} Array of pill descriptors (id, kind, filterKey, value, label, ariaLabel).
 		 */
 		get activePills() {
 			const { state } = store( NAMESPACE );
-			const removeFormat = state.strings?.removeFilter ?? 'Remove %s';
-			const pills = [];
-			for ( const [ filterKey, values ] of Object.entries( state.activeFilters ?? {} ) ) {
-				if ( ! Array.isArray( values ) ) {
-					continue;
-				}
-				const groupLabel = state.filterConfigs?.[ filterKey ]?.label ?? filterKey;
-				for ( const value of values ) {
-					const valueLabel = resolveValueLabel( state, filterKey, value );
-					const label = `${ groupLabel }: ${ valueLabel }`;
-					pills.push( {
-						id: `${ filterKey }:${ value }`,
-						filterKey,
-						value,
-						label,
-						ariaLabel: removeFormat.replace( '%s', label ),
-					} );
-				}
-			}
-			return pills;
+			return buildActivePills( state );
 		},
 	},
 
 	actions: {
 		/**
-		 * Remove the pill currently in `data-wp-each` scope by toggling its
-		 * filter value off.
+		 * Remove the pill currently in `data-wp-each` scope. Dispatches on
+		 * the pill's `kind`: a regular filter pill toggles its value off
+		 * via setFilter (which removes it since the value is currently on),
+		 * a price-range pill clears both bounds.
 		 *
-		 * @yield {Promise} setFilter action.
+		 * @yield {Promise} setFilter or setPriceRange action.
 		 */
 		*onRemovePill() {
 			const { actions } = store( NAMESPACE );
 			const { pill } = getContext();
+			if ( pill.kind === 'priceRange' ) {
+				yield actions.setPriceRange( null, null );
+				return;
+			}
 			yield actions.setFilter( pill.filterKey, pill.value );
 		},
 	},

--- a/projects/packages/search/src/search-blocks/blocks/search-product-filter-clear-button/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/search-product-filter-clear-button/block.json
@@ -1,0 +1,26 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "jetpack/search-product-filter-clear-button",
+	"version": "0.1.0",
+	"title": "Clear Filters Button",
+	"category": "jetpack-search",
+	"icon": "trash",
+	"description": "A button that clears every active filter, including the price range. Powered by Jetpack Search.",
+	"supports": {
+		"html": false,
+		"interactivity": true,
+		"spacing": {
+			"margin": [ "top", "bottom" ],
+			"padding": true
+		}
+	},
+	"textdomain": "jetpack-search-pkg",
+	"attributes": {
+		"label": { "type": "string", "default": "" },
+		"hideWhenInactive": { "type": "boolean", "default": true }
+	},
+	"render": "file:./render.php",
+	"viewScriptModule": "file:../../../../build/search-blocks/search-product-filter-clear-button.js",
+	"style": "file:../../../../build/search-blocks/search-product-filter-clear-button.css"
+}

--- a/projects/packages/search/src/search-blocks/blocks/search-product-filter-clear-button/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-product-filter-clear-button/edit.js
@@ -1,0 +1,73 @@
+/**
+ * Editor preview for jetpack/search-product-filter-clear-button.
+ *
+ * Always renders the button at full opacity in the editor — the live block
+ * hides itself when no filter is active, but a hidden affordance is hard to
+ * style or position. The "hide when inactive" toggle in the inspector is
+ * preview-only here; the runtime visibility binding is set in render.php.
+ */
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
+import { createElement as h, Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+const DEFAULT_LABEL = __( 'Clear filters', 'jetpack-search-pkg' );
+
+/**
+ * Edit component for the clear-button block.
+ *
+ * @param {object}   props               - Block props.
+ * @param {object}   props.attributes    - Saved block attributes.
+ * @param {Function} props.setAttributes - Attribute setter.
+ * @return {object} Rendered element.
+ */
+export default function SearchProductFilterClearButtonEdit( { attributes, setAttributes } ) {
+	const blockProps = useBlockProps( { className: 'jetpack-search-product-filter-clear-button' } );
+	const rawLabel = attributes?.label || '';
+	const previewLabel = rawLabel || DEFAULT_LABEL;
+	const hideWhenInactive = attributes?.hideWhenInactive !== false;
+
+	return h(
+		Fragment,
+		null,
+		h(
+			InspectorControls,
+			null,
+			h(
+				PanelBody,
+				{ title: __( 'Settings', 'jetpack-search-pkg' ) },
+				h( TextControl, {
+					__next40pxDefaultSize: true,
+					__nextHasNoMarginBottom: true,
+					label: __( 'Label', 'jetpack-search-pkg' ),
+					value: rawLabel,
+					placeholder: DEFAULT_LABEL,
+					onChange: value => setAttributes( { label: value } ),
+				} ),
+				h( ToggleControl, {
+					__nextHasNoMarginBottom: true,
+					label: __( 'Hide when no filter is active', 'jetpack-search-pkg' ),
+					checked: hideWhenInactive,
+					onChange: value => setAttributes( { hideWhenInactive: !! value } ),
+					help: __(
+						'Reveal the button only once the shopper selects a filter or price range.',
+						'jetpack-search-pkg'
+					),
+				} )
+			)
+		),
+		h(
+			'div',
+			blockProps,
+			h(
+				'button',
+				{
+					type: 'button',
+					className: 'wp-element-button jetpack-search-product-filter-clear-button__button',
+					disabled: true,
+				},
+				previewLabel
+			)
+		)
+	);
+}

--- a/projects/packages/search/src/search-blocks/blocks/search-product-filter-clear-button/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/search-product-filter-clear-button/render.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Search product filter — clear-button render.
+ *
+ * Standalone "Clear filters" button. Functionally a thin wrapper around the
+ * shared store's `actions.clearFilters` (which already resets both
+ * `activeFilters` and `priceRange` in one shot), exposed as its own block so
+ * authors who don't insert the `jetpack/active-filters` block — or who want
+ * a clear-all affordance in a different layout slot — still have one.
+ *
+ * Visibility defaults to "hidden when no facet is active": the button reveals
+ * itself only once the user has selected a filter or price range, mirroring
+ * the active-filters wrapper. Authors can pin the button visible with the
+ * `hideWhenInactive` toggle so a stable button slot stays in place across
+ * the empty/active states (clicks while inactive are no-ops).
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+
+// @phan-suppress-next-line PhanUndeclaredGlobalVariable
+$attrs              = (array) $attributes;
+$label              = sanitize_text_field( (string) ( $attrs['label'] ?? '' ) );
+$hide_when_inactive = ! isset( $attrs['hideWhenInactive'] ) || (bool) $attrs['hideWhenInactive'];
+if ( '' === $label ) {
+	$label = __( 'Clear filters', 'jetpack-search-pkg' );
+}
+
+// Mirror `state.hasAnyActiveFilters` on the server so the button paints
+// pre-hidden on a fresh URL — otherwise a flash of the button appears
+// before JS hydrates and applies the data-wp-bind--hidden binding.
+$seeded_state   = function_exists( 'wp_interactivity_state' )
+	? wp_interactivity_state( 'jetpack-search' )
+	: array();
+$seeded_active  = (array) ( $seeded_state['activeFilters'] ?? array() );
+$seeded_price   = $seeded_state['priceRange'] ?? null;
+$has_any_active = false;
+foreach ( $seeded_active as $values ) {
+	if ( is_array( $values ) && ! empty( $values ) ) {
+		$has_any_active = true;
+		break;
+	}
+}
+if ( ! $has_any_active && is_array( $seeded_price ) ) {
+	$has_any_active = ( $seeded_price['min'] ?? null ) !== null || ( $seeded_price['max'] ?? null ) !== null;
+}
+
+$initial_hidden_attr = $hide_when_inactive && ! $has_any_active ? 'hidden' : '';
+$bind_hidden_attr    = $hide_when_inactive
+	? 'data-wp-bind--hidden="!state.hasAnyActiveFilters"'
+	: '';
+?>
+<div
+	<?php echo wp_kses_data( get_block_wrapper_attributes( array( 'class' => 'jetpack-search-product-filter-clear-button' ) ) ); ?>
+	data-wp-interactive="jetpack-search"
+	<?php echo wp_kses_data( $bind_hidden_attr ); ?>
+	<?php echo esc_attr( $initial_hidden_attr ); ?>
+>
+	<button
+		type="button"
+		class="wp-element-button jetpack-search-product-filter-clear-button__button"
+		data-wp-on--click="actions.clearFilters"
+	>
+		<?php echo esc_html( $label ); ?>
+	</button>
+</div>

--- a/projects/packages/search/src/search-blocks/blocks/search-product-filter-clear-button/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/search-product-filter-clear-button/style.scss
@@ -1,0 +1,25 @@
+.jetpack-search-product-filter-clear-button {
+	display: flex;
+
+	&[hidden] {
+		display: none;
+	}
+
+	&__button {
+		// Inherit the theme's ghost/secondary button look rather than the
+		// strong primary used by active-filters' inline "Clear all". A
+		// standalone clear-button typically sits next to other filter blocks,
+		// so a quieter affordance keeps the filter sidebar visually balanced.
+		background: transparent;
+		border: 1px solid currentColor;
+		color: inherit;
+		cursor: pointer;
+		font: inherit;
+		padding: 0.5em 1em;
+
+		&:hover,
+		&:focus-visible {
+			background: rgba(0, 0, 0, 0.05);
+		}
+	}
+}

--- a/projects/packages/search/src/search-blocks/blocks/search-product-filter-clear-button/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-product-filter-clear-button/view.js
@@ -1,0 +1,8 @@
+// The clear-button block is a thin wrapper around the shared store's
+// `actions.clearFilters` and `state.hasAnyActiveFilters` getter — both already
+// live in `../../store`. Importing the store here ensures the bundle picks
+// up the shared module so `data-wp-on--click` and `data-wp-bind--hidden`
+// resolve when the block is hydrated in isolation (e.g. dropped onto a
+// page outside the parent wrapper).
+import '../../store';
+import './style.scss';

--- a/projects/packages/search/src/search-blocks/blocks/search-product-filter-price/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/search-product-filter-price/render.php
@@ -47,6 +47,22 @@ $seeded_max   = is_array( $seeded_price ) && null !== ( $seeded_price['max'] ?? 
 	? (string) $seeded_price['max']
 	: '';
 
+// Push the block author's chosen currency symbol and group label into the
+// shared store so the active-filters block can render a price chip ("Price:
+// $10 – $50") that uses the same adornment the user sees on the input. The
+// chip block doesn't know about the price block at render time, so without
+// this seed it would fall back to the generic default. wp_interactivity_state
+// deep-merges, so writing here doesn't disturb other state branches.
+wp_interactivity_state(
+	'jetpack-search',
+	array(
+		'priceCurrencySymbol' => $symbol_short,
+		'strings'             => array(
+			'priceLabel' => $label,
+		),
+	)
+);
+
 $min_id = wp_unique_id( 'jetpack-search-product-filter-price-min-' );
 $max_id = wp_unique_id( 'jetpack-search-product-filter-price-max-' );
 ?>

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -514,49 +514,49 @@ class Search_Blocks {
 
 		return array(
 			// Connection / routing config.
-			'siteId'        => $site_id,
-			'apiRoot'       => function_exists( 'rest_url' ) ? esc_url_raw( rest_url() ) : '',
-			'nonce'         => function_exists( 'wp_create_nonce' ) ? wp_create_nonce( 'wp_rest' ) : '',
-			'isPrivateSite' => $is_private,
-			'isWpcom'       => $is_wpcom,
-			'homeUrl'       => function_exists( 'home_url' ) ? home_url() : '',
+			'siteId'              => $site_id,
+			'apiRoot'             => function_exists( 'rest_url' ) ? esc_url_raw( rest_url() ) : '',
+			'nonce'               => function_exists( 'wp_create_nonce' ) ? wp_create_nonce( 'wp_rest' ) : '',
+			'isPrivateSite'       => $is_private,
+			'isWpcom'             => $is_wpcom,
+			'homeUrl'             => function_exists( 'home_url' ) ? home_url() : '',
 			// BCP47-ish locale (e.g. `en-US`) for Intl.DateTimeFormat on the
 			// client. Converts WP's `en_US` underscore form. Uses the blog
 			// locale (site setting) rather than the viewer's user-profile
 			// locale so formatting is consistent for logged-out visitors
 			// hitting a search page.
-			'locale'        => function_exists( 'get_locale' )
+			'locale'              => function_exists( 'get_locale' )
 				? str_replace( '_', '-', get_locale() )
 				: 'en-US',
 
 			// Search state, seeded from the URL so a deep link like
 			// /?s=boots&orderby=newest&category[]=news renders correctly on
 			// first paint.
-			'searchQuery'   => $search_query,
-			'sortOrder'     => static::parse_url_sort(),
-			'activeFilters' => $active_filters,
-			'priceRange'    => $price_range,
+			'searchQuery'         => $search_query,
+			'sortOrder'           => static::parse_url_sort(),
+			'activeFilters'       => $active_filters,
+			'priceRange'          => $price_range,
 
 			// filterConfigs: each filter-checkbox block's render.php merges its
 			// own entry here. Shape: { [filterKey]: { filterKey, filterType,
 			// taxonomy, label, showCount, maxItems } }.
-			'filterConfigs' => array(),
+			'filterConfigs'       => array(),
 
 			// Results + aggregations are populated by the JS store on hydration —
 			// seed empty defaults so template bindings always have a shape to read.
 			// `aggregations` is a stdClass so JS sees `{}`, not `[]`.
-			'results'       => array(),
-			'aggregations'  => (object) array(),
-			'totalResults'  => 0,
-			'pageHandle'    => null,
+			'results'             => array(),
+			'aggregations'        => (object) array(),
+			'totalResults'        => 0,
+			'pageHandle'          => null,
 
 			// UI state. `isLoading` is seeded true when the URL carries a
 			// search query or filter selection so the no-results block stays
 			// hidden between first paint and JS hydrating the initial fetch —
 			// otherwise a "No results found" flash appears on deep links.
-			'isLoading'     => '' !== $search_query || ! empty( $active_filters ) || null !== $price_range,
-			'isLoadingMore' => false,
-			'hasError'      => false,
+			'isLoading'           => '' !== $search_query || ! empty( $active_filters ) || null !== $price_range,
+			'isLoadingMore'       => false,
+			'hasError'            => false,
 
 			// Translated view-bundle strings. The Interactivity API view bundle
 			// can't import @wordpress/i18n (only @wordpress/interactivity is
@@ -565,8 +565,52 @@ class Search_Blocks {
 			// are seeded so the client can pick based on the live totalResults
 			// without a round trip; languages with more than two plural forms
 			// degrade to "plural for all count > 1" as an accepted tradeoff.
-			'strings'       => static::build_initial_strings(),
+			'strings'             => static::build_initial_strings(),
+
+			// Currency symbol displayed inside the price filter pill rendered
+			// by the active-filters block. Defaults to `$`; the price block's
+			// render.php overrides this with the author's currencySymbol
+			// attribute so a single chip on the page reflects whatever symbol
+			// the price input itself uses. The stored numeric value stays
+			// locale-agnostic — only the display string carries the symbol.
+			'priceCurrencySymbol' => '$',
+
+			// Display labels for `wc_stock_status` selections, keyed by slug.
+			// Seeded from the status block's static option list so an active-
+			// filters chip for "instock" reads "In stock" rather than the raw
+			// slug. RSM-1932 will swap this with WC's translated labels so
+			// non-English locales render correctly; the map shape stays the
+			// same.
+			'wcStockStatusLabels' => static::build_stock_status_labels(),
 		);
+	}
+
+	/**
+	 * Slug → display label map for `wc_stock_status` selections, used by the
+	 * active-filters block to render product-aware chips.
+	 *
+	 * Sourced from the status block's `get_options()` so there's one source of
+	 * truth for the label set; in RSM-1932 we'll switch to WC's translated
+	 * labels (`wc_get_product_stock_status_options()`) without changing this
+	 * shape. Returns an empty array when the status helper class isn't loaded
+	 * — defensive for environments that pull the search package in isolation
+	 * (tests, partial installs).
+	 *
+	 * @return array<string, string>
+	 */
+	protected static function build_stock_status_labels(): array {
+		if ( ! class_exists( Search_Product_Filter_Status::class ) ) {
+			return array();
+		}
+		$labels = array();
+		foreach ( Search_Product_Filter_Status::get_options() as $option ) {
+			$value = (string) ( $option['value'] ?? '' );
+			if ( '' === $value ) {
+				continue;
+			}
+			$labels[ $value ] = (string) ( $option['label'] ?? $value );
+		}
+		return $labels;
 	}
 
 	/**
@@ -581,6 +625,12 @@ class Search_Blocks {
 				'resultsCountSingle' => 'Found %d result',
 				'resultsCountPlural' => 'Found %d results',
 				'removeFilter'       => 'Remove %s',
+				'ratingStarsSingle'  => '%d star',
+				'ratingStarsPlural'  => '%d stars',
+				'priceRangeFromTo'   => '%1$s – %2$s',
+				'priceRangeFrom'     => 'From %s',
+				'priceRangeUpTo'     => 'Up to %s',
+				'priceLabel'         => 'Price',
 			);
 		}
 		return array(
@@ -591,6 +641,18 @@ class Search_Blocks {
 			'resultsCountPlural' => _n( 'Found %d result', 'Found %d results', 2, 'jetpack-search-pkg' ),
 			/* translators: %s: filter label (e.g. "Category: News"). Announced by screen readers when focus lands on a filter pill's remove button. */
 			'removeFilter'       => __( 'Remove %s', 'jetpack-search-pkg' ),
+			/* translators: %d: number of stars (singular form, used for 1). */
+			'ratingStarsSingle'  => _n( '%d star', '%d stars', 1, 'jetpack-search-pkg' ),
+			/* translators: %d: number of stars (plural form). */
+			'ratingStarsPlural'  => _n( '%d star', '%d stars', 2, 'jetpack-search-pkg' ),
+			/* translators: 1: minimum price (already includes the currency symbol). 2: maximum price (already includes the currency symbol). Renders an active "Price: $10 – $50" filter pill. */
+			'priceRangeFromTo'   => __( '%1$s – %2$s', 'jetpack-search-pkg' ),
+			/* translators: %s: minimum price (already includes the currency symbol). Renders an active "Price: From $10" filter pill (no upper bound). */
+			'priceRangeFrom'     => __( 'From %s', 'jetpack-search-pkg' ),
+			/* translators: %s: maximum price (already includes the currency symbol). Renders an active "Price: Up to $50" filter pill (no lower bound). */
+			'priceRangeUpTo'     => __( 'Up to %s', 'jetpack-search-pkg' ),
+			/* translators: Group label for the price filter pill ("Price: $10 – $50"). Mirrors the price block's default heading; falls back to this when no price block is on the page. */
+			'priceLabel'         => __( 'Price', 'jetpack-search-pkg' ),
 		);
 	}
 

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -25,6 +25,7 @@ import LoadMoreEdit from '../blocks/load-more/edit';
 import NoResultsEdit from '../blocks/no-results/edit';
 import ResultsCountEdit from '../blocks/results-count/edit';
 import SearchInputEdit from '../blocks/search-input/edit';
+import SearchProductFilterClearButtonEdit from '../blocks/search-product-filter-clear-button/edit';
 import SearchProductFilterPriceEdit from '../blocks/search-product-filter-price/edit';
 import SearchProductFilterRatingEdit from '../blocks/search-product-filter-rating/edit';
 import SearchProductFilterStatusEdit from '../blocks/search-product-filter-status/edit';
@@ -51,6 +52,7 @@ const BLOCKS = [
 	[ 'jetpack/search-product-filter-status', SearchProductFilterStatusEdit ],
 	[ 'jetpack/search-product-filter-rating', SearchProductFilterRatingEdit ],
 	[ 'jetpack/search-product-filter-price', SearchProductFilterPriceEdit ],
+	[ 'jetpack/search-product-filter-clear-button', SearchProductFilterClearButtonEdit ],
 ];
 
 // Shape the "Jetpack Search" block category to match the Forms / Monetize /

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -134,6 +134,24 @@ const { state, actions } = store( NAMESPACE, {
 		},
 
 		/**
+		 * True when *any* facet is active — selected filter values or a
+		 * price range. The active-filters block, the clear-button block,
+		 * and the filter-popover trigger all key off this rather than
+		 * `hasActiveFilters` (which is `activeFilters`-only); without the
+		 * priceRange branch, a price-only selection leaves the active-
+		 * filters wrapper hidden even though the user has a chip to clear.
+		 *
+		 * @return {boolean} Whether any filter or the price range is active.
+		 */
+		get hasAnyActiveFilters() {
+			if ( state.hasActiveFilters ) {
+				return true;
+			}
+			const range = state.priceRange;
+			return !! range && ( range.min != null || range.max != null );
+		},
+
+		/**
 		 * Total selected filter values across all filter keys. Used by the
 		 * filter-popover trigger to render a count badge.
 		 *
@@ -154,7 +172,7 @@ const { state, actions } = store( NAMESPACE, {
 		 * @return {boolean} Whether the filter trigger is disabled.
 		 */
 		get isFilterTriggerDisabled() {
-			if ( state.hasActiveFilters ) {
+			if ( state.hasAnyActiveFilters ) {
 				return false;
 			}
 			const aggs = state.aggregations ?? {};

--- a/projects/packages/search/tests/js/search-blocks/active-filters-lib.test.js
+++ b/projects/packages/search/tests/js/search-blocks/active-filters-lib.test.js
@@ -1,0 +1,232 @@
+import {
+	buildActivePills,
+	formatPriceRangeChip,
+	resolveBucketValueLabel,
+	resolveProductValueLabel,
+} from '../../../src/search-blocks/blocks/active-filters/lib';
+
+describe( 'resolveBucketValueLabel', () => {
+	it( 'returns the slash-suffix display name when a bucket matches the slug', () => {
+		// Taxonomy / author aggregations use `slug_slash_name` keys — the
+		// chip should read the user-friendly name, not the raw slug.
+		const state = {
+			aggregations: {
+				category: { buckets: [ { key: 'news/News' } ] },
+			},
+		};
+		expect( resolveBucketValueLabel( state, 'category', 'news' ) ).toBe( 'News' );
+	} );
+
+	it( 'returns plain bucket keys verbatim for slash-less aggregations', () => {
+		const state = { aggregations: { post_types: { buckets: [ { key: 'post' } ] } } };
+		expect( resolveBucketValueLabel( state, 'post_types', 'post' ) ).toBe( 'post' );
+	} );
+
+	it( 'falls back to the raw slug when no bucket matches', () => {
+		// Bucket counts shift per query; a selected pill must not vanish
+		// just because its value dropped out of the top-N agg buckets.
+		const state = { aggregations: { category: { buckets: [ { key: 'updates/Updates' } ] } } };
+		expect( resolveBucketValueLabel( state, 'category', 'news' ) ).toBe( 'news' );
+	} );
+} );
+
+describe( 'resolveProductValueLabel', () => {
+	const state = {
+		wcStockStatusLabels: {
+			instock: 'In stock',
+			outofstock: 'Out of stock',
+			onbackorder: 'On backorder',
+		},
+		strings: {
+			ratingStarsSingle: '%d star',
+			ratingStarsPlural: '%d stars',
+		},
+	};
+
+	it( 'maps wc_stock_status slugs to the seeded labels', () => {
+		expect( resolveProductValueLabel( state, { filterType: 'wc_stock_status' }, 'instock' ) ).toBe(
+			'In stock'
+		);
+		expect(
+			resolveProductValueLabel( state, { filterType: 'wc_stock_status' }, 'outofstock' )
+		).toBe( 'Out of stock' );
+	} );
+
+	it( 'falls back to the raw slug when wc_stock_status has no label entry', () => {
+		// Defensive: if RSM-1932 ever ships a partial map (e.g. because WC
+		// added a new status mid-version), the chip stays human-readable.
+		expect( resolveProductValueLabel( state, { filterType: 'wc_stock_status' }, 'preorder' ) ).toBe(
+			'preorder'
+		);
+	} );
+
+	it( 'formats wc_rating values via the singular template at count = 1', () => {
+		expect( resolveProductValueLabel( state, { filterType: 'wc_rating' }, '1' ) ).toBe( '1 star' );
+	} );
+
+	it( 'formats wc_rating values via the plural template at count > 1', () => {
+		expect( resolveProductValueLabel( state, { filterType: 'wc_rating' }, '5' ) ).toBe( '5 stars' );
+	} );
+
+	it( 'falls back to the raw value for malformed wc_rating values', () => {
+		// Out-of-range or non-numeric stars keep the chip rendered rather
+		// than disappearing — same defensive pattern as the bucket fallback.
+		expect( resolveProductValueLabel( state, { filterType: 'wc_rating' }, '7' ) ).toBe( '7' );
+		expect( resolveProductValueLabel( state, { filterType: 'wc_rating' }, 'banana' ) ).toBe(
+			'banana'
+		);
+	} );
+
+	it( 'returns null for non-product filter types so the bucket resolver wins', () => {
+		expect( resolveProductValueLabel( state, { filterType: 'taxonomy' }, 'news' ) ).toBeNull();
+		expect( resolveProductValueLabel( state, { filterType: 'post_type' }, 'post' ) ).toBeNull();
+		expect( resolveProductValueLabel( state, undefined, 'whatever' ) ).toBeNull();
+	} );
+} );
+
+describe( 'formatPriceRangeChip', () => {
+	const state = {
+		priceCurrencySymbol: '$',
+		strings: {
+			priceRangeFromTo: '%1$s – %2$s',
+			priceRangeFrom: 'From %s',
+			priceRangeUpTo: 'Up to %s',
+		},
+	};
+
+	it( 'formats a closed range as "<min> – <max>" with the seeded symbol', () => {
+		expect( formatPriceRangeChip( state, { min: 10, max: 50 } ) ).toBe( '$10 – $50' );
+	} );
+
+	it( 'formats a min-only range as "From <min>"', () => {
+		expect( formatPriceRangeChip( state, { min: 10, max: null } ) ).toBe( 'From $10' );
+	} );
+
+	it( 'formats a max-only range as "Up to <max>"', () => {
+		expect( formatPriceRangeChip( state, { min: null, max: 50 } ) ).toBe( 'Up to $50' );
+	} );
+
+	it( 'returns the empty string when both bounds are null', () => {
+		// Caller uses this to gate the chip — no bound, no chip.
+		expect( formatPriceRangeChip( state, { min: null, max: null } ) ).toBe( '' );
+	} );
+
+	it( 'honors a non-default currency symbol seeded by the price block', () => {
+		expect(
+			formatPriceRangeChip( { ...state, priceCurrencySymbol: '€' }, { min: 5, max: 25 } )
+		).toBe( '€5 – €25' );
+	} );
+} );
+
+describe( 'buildActivePills', () => {
+	const baseState = {
+		strings: {
+			removeFilter: 'Remove %s',
+			ratingStarsSingle: '%d star',
+			ratingStarsPlural: '%d stars',
+			priceRangeFromTo: '%1$s – %2$s',
+			priceRangeFrom: 'From %s',
+			priceRangeUpTo: 'Up to %s',
+			priceLabel: 'Price',
+		},
+		wcStockStatusLabels: {
+			instock: 'In stock',
+			outofstock: 'Out of stock',
+		},
+		priceCurrencySymbol: '$',
+	};
+
+	it( 'builds one filter pill per selected value with the group label prefix', () => {
+		const state = {
+			...baseState,
+			activeFilters: { category: [ 'news', 'updates' ] },
+			filterConfigs: { category: { label: 'Category', filterType: 'taxonomy' } },
+			aggregations: {
+				category: { buckets: [ { key: 'news/News' }, { key: 'updates/Updates' } ] },
+			},
+		};
+		const pills = buildActivePills( state );
+		expect( pills ).toHaveLength( 2 );
+		expect( pills[ 0 ] ).toMatchObject( {
+			id: 'category:news',
+			kind: 'filter',
+			filterKey: 'category',
+			value: 'news',
+			label: 'Category: News',
+			ariaLabel: 'Remove Category: News',
+		} );
+		expect( pills[ 1 ] ).toMatchObject( {
+			id: 'category:updates',
+			kind: 'filter',
+			label: 'Category: Updates',
+		} );
+	} );
+
+	it( 'resolves wc_stock_status pills via the seeded label map, not via aggregation buckets', () => {
+		const state = {
+			...baseState,
+			activeFilters: { filter_stock_status: [ 'instock' ] },
+			filterConfigs: {
+				filter_stock_status: { label: 'Stock status', filterType: 'wc_stock_status' },
+			},
+			aggregations: {},
+		};
+		const pills = buildActivePills( state );
+		expect( pills ).toHaveLength( 1 );
+		expect( pills[ 0 ].label ).toBe( 'Stock status: In stock' );
+	} );
+
+	it( 'resolves wc_rating pills via the singular/plural templates', () => {
+		const state = {
+			...baseState,
+			activeFilters: { rating_filter: [ '1', '5' ] },
+			filterConfigs: { rating_filter: { label: 'Rating', filterType: 'wc_rating' } },
+			aggregations: {},
+		};
+		const pills = buildActivePills( state );
+		expect( pills.map( p => p.label ) ).toEqual( [ 'Rating: 1 star', 'Rating: 5 stars' ] );
+	} );
+
+	it( 'appends a single price-range pill at the end with kind "priceRange"', () => {
+		// Even with two active filters, the price range gets one chip — not
+		// two side-by-side min/max chips. Mirrors WC's own active-filter UI.
+		const state = {
+			...baseState,
+			activeFilters: { category: [ 'news' ] },
+			filterConfigs: { category: { label: 'Category', filterType: 'taxonomy' } },
+			aggregations: { category: { buckets: [ { key: 'news/News' } ] } },
+			priceRange: { min: 10, max: 50 },
+		};
+		const pills = buildActivePills( state );
+		expect( pills ).toHaveLength( 2 );
+		expect( pills[ 1 ] ).toMatchObject( {
+			id: 'priceRange:10:50',
+			kind: 'priceRange',
+			label: 'Price: $10 – $50',
+			ariaLabel: 'Remove Price: $10 – $50',
+		} );
+	} );
+
+	it( 'omits the price chip when both bounds are null', () => {
+		const state = {
+			...baseState,
+			activeFilters: {},
+			filterConfigs: {},
+			aggregations: {},
+			priceRange: { min: null, max: null },
+		};
+		expect( buildActivePills( state ) ).toEqual( [] );
+	} );
+
+	it( 'returns an empty list when no facet is active', () => {
+		expect(
+			buildActivePills( {
+				...baseState,
+				activeFilters: {},
+				filterConfigs: {},
+				aggregations: {},
+				priceRange: null,
+			} )
+		).toEqual( [] );
+	} );
+} );

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -411,6 +411,11 @@ describe( 'store getters', () => {
 			activeFilters: {},
 			aggregations: {},
 			sortOrder: 'relevance',
+			// Explicitly reset priceRange — without this, a `hasAnyActiveFilters`
+			// test that sets a price range leaks into later getter tests
+			// (e.g. `isFilterTriggerDisabled`, which now consults priceRange
+			// via hasAnyActiveFilters).
+			priceRange: null,
 			strings: {
 				searching: 'Looking…',
 				resultsCountSingle: 'Found %d item',
@@ -452,6 +457,29 @@ describe( 'store getters', () => {
 		state.activeFilters = { category: [ 'news', 'updates' ] };
 		expect( state.hasActiveFilters ).toBe( true );
 		expect( state.activeFilterCount ).toBe( 2 );
+	} );
+
+	it( 'hasAnyActiveFilters surfaces with active filters, with a price range, or both', () => {
+		// Drives the active-filters wrapper and the clear-button block's
+		// visibility — keeping all three sources gated behind one getter
+		// keeps the bug where a price-only selection left the wrapper
+		// hidden from regressing.
+		state.activeFilters = {};
+		state.priceRange = null;
+		expect( state.hasAnyActiveFilters ).toBe( false );
+
+		state.activeFilters = { category: [ 'news' ] };
+		expect( state.hasAnyActiveFilters ).toBe( true );
+
+		state.activeFilters = {};
+		state.priceRange = { min: 10, max: null };
+		expect( state.hasAnyActiveFilters ).toBe( true );
+
+		state.priceRange = { min: null, max: null };
+		expect( state.hasAnyActiveFilters ).toBe( false );
+
+		state.priceRange = { min: 0, max: 0 };
+		expect( state.hasAnyActiveFilters ).toBe( true );
 	} );
 
 	it( 'enables the filter trigger for active filters or available aggregation buckets', () => {

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -321,6 +321,65 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
+	 * The active-filters block reads `state.wcStockStatusLabels` to render
+	 * "Stock status: In stock" chips without an extra REST hop. The map is
+	 * sourced from the status block's option list so there's one source of
+	 * truth for the label set; missing keys would cause the chip to fall
+	 * back to the raw slug ("Stock status: instock").
+	 */
+	public function test_build_initial_state_seeds_wc_stock_status_labels() {
+		$state = Search_Blocks::build_initial_state();
+		$this->assertArrayHasKey( 'wcStockStatusLabels', $state );
+		$labels = $state['wcStockStatusLabels'];
+		$this->assertSame( 'In stock', $labels['instock'] ?? null );
+		$this->assertSame( 'Out of stock', $labels['outofstock'] ?? null );
+		$this->assertSame( 'On backorder', $labels['onbackorder'] ?? null );
+	}
+
+	/**
+	 * The active-filters block reads `state.priceCurrencySymbol` to format
+	 * the price chip ("Price: $10 – $50"). Default is `$`; the price block
+	 * overrides this with the author's currencySymbol attribute at render
+	 * time. Without this default, sites with no price block on the page
+	 * would render "Price: 10 – 50".
+	 */
+	public function test_build_initial_state_seeds_default_price_currency_symbol() {
+		$state = Search_Blocks::build_initial_state();
+		$this->assertArrayHasKey( 'priceCurrencySymbol', $state );
+		$this->assertSame( '$', $state['priceCurrencySymbol'] );
+	}
+
+	/**
+	 * The active-filters block can't import @wordpress/i18n (only
+	 *
+	 * @wordpress/interactivity is registered as a script module), so the
+	 * star-row plural templates and price-range format strings must be
+	 * seeded as `state.strings.*` for the view bundle to read.
+	 */
+	public function test_build_initial_state_seeds_product_chip_strings() {
+		$strings = Search_Blocks::build_initial_state()['strings'];
+		foreach (
+			array(
+				'ratingStarsSingle',
+				'ratingStarsPlural',
+				'priceRangeFromTo',
+				'priceRangeFrom',
+				'priceRangeUpTo',
+				'priceLabel',
+			) as $key
+		) {
+			$this->assertArrayHasKey( $key, $strings, "Missing seeded string: $key" );
+			$this->assertNotSame( '', $strings[ $key ], "Empty seeded string: $key" );
+		}
+		$this->assertStringContainsString( '%d', $strings['ratingStarsSingle'] );
+		$this->assertStringContainsString( '%d', $strings['ratingStarsPlural'] );
+		$this->assertStringContainsString( '%1$s', $strings['priceRangeFromTo'] );
+		$this->assertStringContainsString( '%2$s', $strings['priceRangeFromTo'] );
+		$this->assertStringContainsString( '%s', $strings['priceRangeFrom'] );
+		$this->assertStringContainsString( '%s', $strings['priceRangeUpTo'] );
+	}
+
+	/**
 	 * Invoke a protected static on Search_Blocks from test code. Reflection
 	 * is the cheapest way to cover this logic without leaking visibility
 	 * just for testability.


### PR DESCRIPTION
## Why

A WC product search page that reads `Stock status: instock` instead of `Stock status: In stock` advertises the implementation to every shopper. Same for `Rating: 5` instead of `Rating: 5 stars`. This PR makes the active-filters chips speak the language of WC products.

It also fixes a latent bug exposed by the price block from PR-A (#48444): a price-only deep link (`/?s=&min_price=10`) left the active-filters wrapper hidden because the visibility binding only watched `activeFilters`, not `priceRange`. Now both feed into a unified `hasAnyActiveFilters` getter.

The standalone `…-clear-button` block exists for layouts that don't use `jetpack/active-filters` (e.g. a clear-all button below the filter inputs, with no chip strip above the results) — same `clearFilters` behavior, smaller affordance.

## Proposed changes

- **Active-filters product-aware chips**
  - `wc_stock_status` chips resolve via a seeded `state.wcStockStatusLabels` map (sourced from the status block's option list)
  - `wc_rating` chips render with seeded singular/plural templates so "5 stars" / "1 star" pluralize correctly
  - A single price-range chip joins the chips array (one chip for the range, not two side-by-side min/max chips)
  - Pills carry a `kind` discriminator; `onRemovePill` dispatches `setFilter` for filter pills and `setPriceRange(null, null)` for the price pill
- **`hasAnyActiveFilters` getter** — covers `activeFilters` + `priceRange`. Active-filters wrapper, filter-popover trigger now key off this. Fixes the price-only-deep-link bug.
- **PHP state seeds** — `priceCurrencySymbol` (default `$`), `wcStockStatusLabels`, and rating + price chip string templates in `build_initial_strings`. Price block render override seeds the user's currencySymbol attribute so a configured chip uses the same adornment the input does.
- **`jetpack/search-product-filter-clear-button`** — thin wrapper around `actions.clearFilters` (which already wipes priceRange too). Hides itself when no facet is active.

## How

- Pure helpers in `active-filters/lib.js` (label resolution, price-chip formatting, pill builder) so JSDoc/JS tests cover the logic without an Interactivity API runtime. View.js shrinks to a thin `buildActivePills(state)` call + the `kind`-dispatching remove handler.
- The `wcStockStatusLabels` map is built from `Search_Product_Filter_Status::get_options()` so there's one source of truth — RSM-1932 will swap the source for `wc_get_product_stock_status_options()` without changing the seed shape or the consumer.

## Stack

This is **PR-B** of a 3-PR stack closing RSM-1929. Stacked on **PR-A** (#48444). Sibling **PR-C** lands the attribute + taxonomy filter blocks alongside this.

## Related product discussion/links

- Epic: [RSM-1929](https://linear.app/a8c/issue/RSM-1929)
- Sub-issue (i18n the WC stock-status labels): [RSM-1932](https://linear.app/a8c/issue/RSM-1932)
- Original combined PR (now superseded by A/B/C): #48443

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Land or check out PR-A (#48444) so the parent + status/rating/price blocks exist.
2. Insert the parent block on a search page. Verify the default template seeds status / rating / price.
3. With `/?s=shirt`:
   - Click "In stock" → chip reads `Stock status: In stock` (not `Stock status: instock`)
   - Click 5 stars → chip reads `Rating: 5 stars`
   - Type `10` and `100` in the price inputs → single chip reads `Price: $10 – $100`
   - Click any chip's `×` → that single facet clears (price chip clears both bounds)
4. Visit `/?s=&min_price=10` directly (price-only deep link) → active-filters wrapper visible with the price chip.
5. Insert a `jetpack/search-product-filter-clear-button` block on the page. With no filters, button is hidden. With any facet active, button shows; click → all filters wipe.
6. Run tests:
   - `pnpm exec jest tests/js/search-blocks` → 198+ pass
   - `composer phpunit` from `projects/packages/search` → 231+ pass

Verified end-to-end on a docker WC site at `https://jp-echo.jurassic.tube/?s=shirt` — every chip resolves to the expected label, URL contracts round-trip, clear-button wipes everything.