### PR TITLE
Search 3.0: foundation data-plane additions for product filter blocks

### DIFF
--- a/projects/packages/search/changelog/add-search-foundation-data-plane
+++ b/projects/packages/search/changelog/add-search-foundation-data-plane
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search 3.0: foundation data-plane additions for the upcoming WC product filter blocks. Adds `actions.setPriceRange(min, max)` (rejects invalid/inverted bounds, no-ops on identity, clears the range when both bounds are null) and updates `actions.clearFilters` to also clear `priceRange` so a single clear-all wipes every facet. Adds `state.hasAnyActiveFilters` (covers `activeFilters` + `priceRange`) and rewires the active-filters wrapper visibility to use it — fixes a latent issue where a price-only deep link kept the wrapper hidden after hydration. Threads `filterConfigs` through `syncToUrl` so the writer side honors `urlFormat: 'scalar'` and product-shape filters round-trip with WooCommerce's native URL contract. Tracked under epic [RSM-1929].

--- a/projects/packages/search/changelog/add-search-foundation-data-plane
+++ b/projects/packages/search/changelog/add-search-foundation-data-plane
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Search 3.0: foundation data-plane additions for the upcoming WC product filter blocks. Adds `actions.setPriceRange(min, max)` (rejects invalid/inverted bounds, no-ops on identity, clears the range when both bounds are null) and updates `actions.clearFilters` to also clear `priceRange` so a single clear-all wipes every facet. Adds `state.hasAnyActiveFilters` (covers `activeFilters` + `priceRange`) and rewires the active-filters wrapper visibility to use it — fixes a latent issue where a price-only deep link kept the wrapper hidden after hydration. Threads `filterConfigs` through `syncToUrl` so the writer side honors `urlFormat: 'scalar'` and product-shape filters round-trip with WooCommerce's native URL contract. Tracked under epic [RSM-1929].
+Search Blocks: foundation data-plane primitives for the upcoming WC product filter blocks. Adds `actions.setPriceRange(min, max)`, extends `actions.clearFilters` to also clear the price range, and folds `priceRange` into `state.hasActiveFilters` so the active-filters wrapper stays visible on a price-only deep link.

--- a/projects/packages/search/src/search-blocks/AGENTS.md
+++ b/projects/packages/search/src/search-blocks/AGENTS.md
@@ -27,4 +27,4 @@ Filters round-trip through the URL in Jetpack Search's array shape: `?<filterKey
 
 Don't add a comma-joined / WC-style scalar shape (`?filter_stock_status=in,out`) for new product filters either. Stick to `?filter_stock_status[]=in&filter_stock_status[]=out` so deep links stay interchangeable with instant-search and the PHP parser doesn't need a per-filter URL-format opt-in.
 
-`min_price` / `max_price` are the only scalar URL params, and they're singletons (not filter selections), so they sit outside `activeFilters` in store state.
+Price is the one exception, and only because its shape doesn't fit. `activeFilters` is typed `{ [filterKey]: string[] }` — discrete, OR-able selections that build a `terms` ES clause. `priceRange` is `{ min, max }`, builds a `range` clause, and writes scalar `min_price` / `max_price` URL params. It lives as a sibling on store state rather than getting shoehorned into `activeFilters` with a sentinel encoding.

--- a/projects/packages/search/src/search-blocks/AGENTS.md
+++ b/projects/packages/search/src/search-blocks/AGENTS.md
@@ -20,3 +20,11 @@ Titles aim to read naturally in the inserter, not mirror the slug shape — "Sor
 WordPress derives `.wp-block-jetpack-search-{bare-slug}` from the full block name. For blocks whose bare slug already starts with `search-` the segment repeats (`.wp-block-jetpack-search-search-input`); that's harmless and only used internally.
 
 Manual wrapper classes (set via `useBlockProps({ className })` and the matching `get_block_wrapper_attributes()` call in `render.php`) don't have to track the slug exactly — they're just CSS hooks.
+
+## URL format
+
+Filters round-trip through the URL in Jetpack Search's array shape: `?<filterKey>[]=<value>`, one param per selected value. Both sides agree on this contract — `store/url-state.js` writes/reads it on the JS side, `Search_Blocks::parse_url_filters()` reads it on the PHP side.
+
+Don't add a comma-joined / WC-style scalar shape (`?filter_stock_status=in,out`) for new product filters either. Stick to `?filter_stock_status[]=in&filter_stock_status[]=out` so deep links stay interchangeable with instant-search and the PHP parser doesn't need a per-filter URL-format opt-in.
+
+`min_price` / `max_price` are the only scalar URL params, and they're singletons (not filter selections), so they sit outside `activeFilters` in store state.

--- a/projects/packages/search/src/search-blocks/blocks/active-filters/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/active-filters/render.php
@@ -11,15 +11,18 @@ namespace Automattic\Jetpack\Search;
 
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 
-// Render `hidden` on first paint when no filters are active. JS unhides once
-// `state.hasActiveFilters` flips — relying only on data-wp-bind--hidden leaves
-// the "Active filters:" label and "Clear all" button visible on the server-
-// rendered HTML until hydration, which pushes sibling filter blocks ~30px
-// down and misaligns the sidebar with the adjacent results column.
+// Render `hidden` on first paint when no facet is active. JS unhides once
+// `state.hasAnyActiveFilters` flips — relying only on data-wp-bind--hidden
+// leaves the "Active filters:" label visible on the server-rendered HTML
+// until hydration, which pushes sibling filter blocks ~30px down and
+// misaligns the sidebar with the adjacent results column. Reads activeFilters
+// AND priceRange so a price-only deep link doesn't keep the wrapper hidden
+// after hydration sees a half-open range come through the URL.
 $seeded_state        = function_exists( 'wp_interactivity_state' )
 	? wp_interactivity_state( 'jetpack-search' )
 	: array();
 $seeded_active       = $seeded_state['activeFilters'] ?? array();
+$seeded_price_range  = $seeded_state['priceRange'] ?? null;
 $has_active_on_paint = false;
 foreach ( (array) $seeded_active as $values ) {
 	if ( is_array( $values ) && ! empty( $values ) ) {
@@ -27,11 +30,18 @@ foreach ( (array) $seeded_active as $values ) {
 		break;
 	}
 }
+if ( ! $has_active_on_paint && is_array( $seeded_price_range ) ) {
+	$min = $seeded_price_range['min'] ?? null;
+	$max = $seeded_price_range['max'] ?? null;
+	if ( $min !== null || $max !== null ) {
+		$has_active_on_paint = true;
+	}
+}
 ?>
 <div
 	<?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>
 	data-wp-interactive="jetpack-search"
-	data-wp-bind--hidden="!state.hasActiveFilters"
+	data-wp-bind--hidden="!state.hasAnyActiveFilters"
 	<?php echo $has_active_on_paint ? '' : 'hidden'; ?>
 >
 	<span class="jetpack-search-active-filters__heading">

--- a/projects/packages/search/src/search-blocks/blocks/active-filters/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/active-filters/render.php
@@ -12,12 +12,12 @@ namespace Automattic\Jetpack\Search;
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 
 // Render `hidden` on first paint when no facet is active. JS unhides once
-// `state.hasAnyActiveFilters` flips — relying only on data-wp-bind--hidden
+// `state.hasActiveFilters` flips — relying only on data-wp-bind--hidden
 // leaves the "Active filters:" label visible on the server-rendered HTML
 // until hydration, which pushes sibling filter blocks ~30px down and
-// misaligns the sidebar with the adjacent results column. Reads activeFilters
-// AND priceRange so a price-only deep link doesn't keep the wrapper hidden
-// after hydration sees a half-open range come through the URL.
+// misaligns the sidebar with the adjacent results column. Mirrors the
+// JS getter: priceRange counts as a filter, so a `?min_price=10` deep
+// link paints with the wrapper visible.
 $seeded_state        = function_exists( 'wp_interactivity_state' )
 	? wp_interactivity_state( 'jetpack-search' )
 	: array();
@@ -41,7 +41,7 @@ if ( ! $has_active_on_paint && is_array( $seeded_price_range ) ) {
 <div
 	<?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>
 	data-wp-interactive="jetpack-search"
-	data-wp-bind--hidden="!state.hasAnyActiveFilters"
+	data-wp-bind--hidden="!state.hasActiveFilters"
 	<?php echo $has_active_on_paint ? '' : 'hidden'; ?>
 >
 	<span class="jetpack-search-active-filters__heading">

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -438,29 +438,20 @@ const { state, actions } = store( NAMESPACE, {
 		},
 
 		/**
-		 * True when any filter has at least one selected value. Used by
-		 * active-filters to decide whether to render the pills wrapper.
+		 * True when any facet is active — selected filter values or a
+		 * price range. Drives the active-filters pill wrapper, the standalone
+		 * clear-filters block, and the filter-popover trigger. priceRange
+		 * counts as a filter here so a price-only selection (including a
+		 * half-open range like `?min_price=10`) doesn't leave the pill
+		 * wrapper hidden when the user has a chip to clear.
 		 *
 		 * @return {boolean} Whether any filter is active.
 		 */
 		get hasActiveFilters() {
-			return Object.values( state.activeFilters ?? {} ).some(
+			const hasSelections = Object.values( state.activeFilters ?? {} ).some(
 				v => Array.isArray( v ) && v.length > 0
 			);
-		},
-
-		/**
-		 * True when *any* facet is active — selected filter values or a
-		 * price range. The active-filters pill row, the standalone clear-
-		 * filters block, and the filter-popover trigger all key off this
-		 * rather than `hasActiveFilters` (which is `activeFilters`-only).
-		 * Without the priceRange branch, a price-only selection leaves
-		 * the pill wrapper hidden even though the user has a chip to clear.
-		 *
-		 * @return {boolean} Whether any filter or the price range is active.
-		 */
-		get hasAnyActiveFilters() {
-			if ( state.hasActiveFilters ) {
+			if ( hasSelections ) {
 				return true;
 			}
 			const range = state.priceRange;
@@ -747,7 +738,7 @@ const { state, actions } = store( NAMESPACE, {
 		 * @yield {Promise} search action.
 		 */
 		*clearFilters() {
-			if ( ! state.hasAnyActiveFilters ) {
+			if ( ! state.hasActiveFilters ) {
 				return;
 			}
 			state.activeFilters = {};
@@ -1040,9 +1031,8 @@ const { state, actions } = store( NAMESPACE, {
 			if ( droppedAny ) {
 				state.activeFilters = gated;
 			}
-			if ( state.searchQuery || state.hasActiveFilters || state.priceRange ) {
+			if ( state.searchQuery || state.hasActiveFilters ) {
 				// syncUrl=false: URL already carries this query; avoid a duplicate history entry.
-				// priceRange is checked separately so `?min_price=10` still triggers an initial fetch.
 				actions.search( { syncUrl: false } );
 			} else if ( droppedAny ) {
 				// Gate emptied activeFilters and no fetch will fire — clear the PHP-seeded

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -472,9 +472,11 @@ const { state, actions } = store( NAMESPACE, {
 		 * True when the filters-popover trigger should be disabled: there are
 		 * no aggregation buckets to filter on AND no active filters to clear.
 		 * Opening the popover in that state would show an empty panel, so we
-		 * gate the affordance itself. Remains enabled while any filter is
-		 * active so users can still open the popover to remove pills even
-		 * when the current query returns no results.
+		 * gate the affordance itself. Remains enabled whenever
+		 * `hasActiveFilters` is true (which now includes a `priceRange`
+		 * selection) so users can still open the popover to layer additional
+		 * facets on top of a price-only deep link, even when the current
+		 * query returns no results.
 		 *
 		 * @return {boolean} Whether the filter trigger is disabled.
 		 */

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -450,6 +450,24 @@ const { state, actions } = store( NAMESPACE, {
 		},
 
 		/**
+		 * True when *any* facet is active — selected filter values or a
+		 * price range. The active-filters pill row, the standalone clear-
+		 * filters block, and the filter-popover trigger all key off this
+		 * rather than `hasActiveFilters` (which is `activeFilters`-only).
+		 * Without the priceRange branch, a price-only selection leaves
+		 * the pill wrapper hidden even though the user has a chip to clear.
+		 *
+		 * @return {boolean} Whether any filter or the price range is active.
+		 */
+		get hasAnyActiveFilters() {
+			if ( state.hasActiveFilters ) {
+				return true;
+			}
+			const range = state.priceRange;
+			return !! range && ( range.min != null || range.max != null );
+		},
+
+		/**
 		 * Total selected filter values across all filter keys. Used by the
 		 * filters-popover trigger to render a count badge.
 		 *
@@ -722,15 +740,59 @@ const { state, actions } = store( NAMESPACE, {
 		},
 
 		/**
-		 * Clear all active filters and re-run the search.
+		 * Clear every facet and re-run the search. Resets `activeFilters`
+		 * AND `priceRange` so a single clear-all affordance wipes both
+		 * checkbox-shaped selections and the half-open price range.
 		 *
 		 * @yield {Promise} search action.
 		 */
 		*clearFilters() {
-			if ( Object.keys( state.activeFilters ?? {} ).length === 0 ) {
+			const hadFilters = Object.keys( state.activeFilters ?? {} ).length > 0;
+			const hadPriceRange = state.priceRange !== null && state.priceRange !== undefined;
+			if ( ! hadFilters && ! hadPriceRange ) {
 				return;
 			}
 			state.activeFilters = {};
+			state.priceRange = null;
+			yield actions.search();
+		},
+
+		/**
+		 * Update the price range and re-run the search if it changed. Either
+		 * bound may be null for a half-open range; passing both as null clears
+		 * the range. No-ops when the new range matches the current one so a
+		 * blur from an unchanged input doesn't trigger an identical re-fetch.
+		 *
+		 * @param {number|null} min - Lower bound, inclusive.
+		 * @param {number|null} max - Upper bound, inclusive.
+		 * @yield {Promise} search action.
+		 */
+		*setPriceRange( min, max ) {
+			const normalize = v => ( v === null || v === undefined || v === '' ? null : Number( v ) );
+			const nextMin = normalize( min );
+			const nextMax = normalize( max );
+			// Reject NaN bounds so a typo'd input doesn't poison the ES range
+			// clause. Mirrors the parsePriceBound() guard in url-state.js so
+			// the action and the URL reader agree on what "no bound" means.
+			const validMin = nextMin === null || ( Number.isFinite( nextMin ) && nextMin >= 0 );
+			const validMax = nextMax === null || ( Number.isFinite( nextMax ) && nextMax >= 0 );
+			if ( ! validMin || ! validMax ) {
+				return;
+			}
+			// Inverted bounds (min > max) build a guaranteed-empty ES clause.
+			// Drop the call rather than pushing a bad URL or zeroing results.
+			if ( nextMin !== null && nextMax !== null && nextMin > nextMax ) {
+				return;
+			}
+			const next = nextMin === null && nextMax === null ? null : { min: nextMin, max: nextMax };
+			const prev = state.priceRange;
+			const same =
+				( prev === null && next === null ) ||
+				( prev !== null && next !== null && prev.min === next.min && prev.max === next.max );
+			if ( same ) {
+				return;
+			}
+			state.priceRange = next;
 			yield actions.search();
 		},
 
@@ -743,6 +805,7 @@ const { state, actions } = store( NAMESPACE, {
 				sortOrder: state.sortOrder,
 				activeFilters: state.activeFilters,
 				priceRange: state.priceRange,
+				filterConfigs: state.filterConfigs,
 				searchParamName: state.searchParamName,
 			} );
 		},

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -747,9 +747,7 @@ const { state, actions } = store( NAMESPACE, {
 		 * @yield {Promise} search action.
 		 */
 		*clearFilters() {
-			const hadFilters = Object.keys( state.activeFilters ?? {} ).length > 0;
-			const hadPriceRange = state.priceRange !== null && state.priceRange !== undefined;
-			if ( ! hadFilters && ! hadPriceRange ) {
+			if ( ! state.hasAnyActiveFilters ) {
 				return;
 			}
 			state.activeFilters = {};

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -794,7 +794,6 @@ const { state, actions } = store( NAMESPACE, {
 				sortOrder: state.sortOrder,
 				activeFilters: state.activeFilters,
 				priceRange: state.priceRange,
-				filterConfigs: state.filterConfigs,
 				searchParamName: state.searchParamName,
 			} );
 		},

--- a/projects/packages/search/src/search-blocks/store/url-state.js
+++ b/projects/packages/search/src/search-blocks/store/url-state.js
@@ -35,21 +35,16 @@ function parsePriceBound( raw ) {
 /**
  * Serialize store state to URLSearchParams.
  *
- * Filter keys default to flat top-level array params (`?category[]=news`),
- * matching the shape instant-search already writes so deep links are
- * interchangeable between the two surfaces. Keys whose `filterConfigs`
- * entry sets `urlFormat: 'scalar'` instead write a single comma-joined
- * value (`?filter_stock_status=instock,outofstock`) so WooCommerce-shaped
- * URLs round-trip without being rewritten on the next `syncToUrl`.
+ * Filter keys are written as flat top-level array params
+ * (`?category[]=news`), matching the shape instant-search already writes
+ * so deep links are interchangeable between the two surfaces and the
+ * PHP-side `parse_url_filters()` reads the same contract.
  *
  * @param {object}      state                   - Store state slice.
  * @param {string}      state.searchQuery       - Current search query.
  * @param {string}      state.sortOrder         - Current sort order.
  * @param {object}      [state.activeFilters]   - { [filterKey]: string[] } selected filters.
  * @param {object|null} [state.priceRange]      - { min, max } price range; either bound may be null.
- * @param {object}      [state.filterConfigs]   - { [filterKey]: FilterConfig } map; an entry with
- *                                              `urlFormat: 'scalar'` switches that key to the
- *                                              comma-joined writer shape.
  * @param {string}      [state.searchParamName] - URL key the search query is written under
  *                                              (`s` on the WP search route, `q`
  *                                              on non-search pages). Defaults to `s`.
@@ -60,7 +55,6 @@ export function stateToUrlParams( {
 	sortOrder,
 	activeFilters = {},
 	priceRange = null,
-	filterConfigs = {},
 	searchParamName = DEFAULT_SEARCH_PARAM,
 } ) {
 	const params = new URLSearchParams();
@@ -80,11 +74,7 @@ export function stateToUrlParams( {
 		if ( ! Array.isArray( values ) || values.length === 0 ) {
 			continue;
 		}
-		if ( filterConfigs?.[ key ]?.urlFormat === 'scalar' ) {
-			params.set( key, values.join( ',' ) );
-		} else {
-			values.forEach( value => params.append( `${ key }[]`, value ) );
-		}
+		values.forEach( value => params.append( `${ key }[]`, value ) );
 	}
 
 	if ( priceRange?.min != null ) {
@@ -153,27 +143,6 @@ export function urlParamsToState(
 			continue;
 		}
 		activeFilters[ filterKey ].push( normalized );
-	}
-
-	// Scalar comma-joined fallback for filterConfigs whose `urlFormat` is
-	// `scalar` (e.g. `?filter_stock_status=instock,outofstock`). Used by
-	// product filters whose URL contract is a single key with comma-joined
-	// values rather than the array-form `?key[]=v` default.
-	for ( const [ filterKey, config ] of Object.entries( filterConfigs ?? {} ) ) {
-		if ( config?.urlFormat !== 'scalar' || activeFilters[ filterKey ] ) {
-			continue;
-		}
-		const raw = params.get( filterKey );
-		if ( ! raw ) {
-			continue;
-		}
-		const values = String( raw )
-			.split( ',' )
-			.map( v => v.trim() )
-			.filter( Boolean );
-		if ( values.length > 0 ) {
-			activeFilters[ filterKey ] = Array.from( new Set( values ) );
-		}
 	}
 
 	const minPrice = parsePriceBound( params.get( 'min_price' ) );

--- a/projects/packages/search/src/search-blocks/store/url-state.js
+++ b/projects/packages/search/src/search-blocks/store/url-state.js
@@ -35,15 +35,21 @@ function parsePriceBound( raw ) {
 /**
  * Serialize store state to URLSearchParams.
  *
- * Filter keys are written as flat top-level array params (`?category[]=news`),
+ * Filter keys default to flat top-level array params (`?category[]=news`),
  * matching the shape instant-search already writes so deep links are
- * interchangeable between the two surfaces.
+ * interchangeable between the two surfaces. Keys whose `filterConfigs`
+ * entry sets `urlFormat: 'scalar'` instead write a single comma-joined
+ * value (`?filter_stock_status=instock,outofstock`) so WooCommerce-shaped
+ * URLs round-trip without being rewritten on the next `syncToUrl`.
  *
  * @param {object}      state                   - Store state slice.
  * @param {string}      state.searchQuery       - Current search query.
  * @param {string}      state.sortOrder         - Current sort order.
  * @param {object}      [state.activeFilters]   - { [filterKey]: string[] } selected filters.
  * @param {object|null} [state.priceRange]      - { min, max } price range; either bound may be null.
+ * @param {object}      [state.filterConfigs]   - { [filterKey]: FilterConfig } map; an entry with
+ *                                              `urlFormat: 'scalar'` switches that key to the
+ *                                              comma-joined writer shape.
  * @param {string}      [state.searchParamName] - URL key the search query is written under
  *                                              (`s` on the WP search route, `q`
  *                                              on non-search pages). Defaults to `s`.
@@ -54,6 +60,7 @@ export function stateToUrlParams( {
 	sortOrder,
 	activeFilters = {},
 	priceRange = null,
+	filterConfigs = {},
 	searchParamName = DEFAULT_SEARCH_PARAM,
 } ) {
 	const params = new URLSearchParams();
@@ -73,7 +80,11 @@ export function stateToUrlParams( {
 		if ( ! Array.isArray( values ) || values.length === 0 ) {
 			continue;
 		}
-		values.forEach( value => params.append( `${ key }[]`, value ) );
+		if ( filterConfigs?.[ key ]?.urlFormat === 'scalar' ) {
+			params.set( key, values.join( ',' ) );
+		} else {
+			values.forEach( value => params.append( `${ key }[]`, value ) );
+		}
 	}
 
 	if ( priceRange?.min != null ) {

--- a/projects/packages/search/tests/js/search-blocks/api.test.js
+++ b/projects/packages/search/tests/js/search-blocks/api.test.js
@@ -623,7 +623,7 @@ describe( 'product-shaped filter helpers', () => {
 		it( 'OR-joins multiple stock-status selections within the filter', () => {
 			const clause = buildFilterClause(
 				{ filter_stock_status: [ 'instock', 'outofstock' ] },
-				{ filter_stock_status: { filterType: 'wc_stock_status', urlFormat: 'scalar' } }
+				{ filter_stock_status: { filterType: 'wc_stock_status' } }
 			);
 			expect( clause ).toEqual( {
 				bool: {

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -332,6 +332,16 @@ describe( 'store actions', () => {
 		await runGenerator( actions.clearFilters() );
 		expect( state.priceRange ).toBeNull();
 		expect( search ).toHaveBeenCalledTimes( 2 );
+
+		// Combined state — both checkbox selections and a price range — must
+		// reset in a single call, since the active-filters "Clear all" button
+		// is the only affordance that clears price selections in this PR.
+		state.activeFilters = { tag: [ 'react' ] };
+		state.priceRange = { min: 10, max: 50 };
+		await runGenerator( actions.clearFilters() );
+		expect( state.activeFilters ).toEqual( {} );
+		expect( state.priceRange ).toBeNull();
+		expect( search ).toHaveBeenCalledTimes( 3 );
 	} );
 
 	it( 'setPriceRange validates bounds, no-ops on identity, and clears on null/null', async () => {

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -561,25 +561,25 @@ describe( 'store getters', () => {
 		expect( state.activeFilterCount ).toBe( 2 );
 	} );
 
-	it( 'hasAnyActiveFilters covers activeFilters and the priceRange (including half-open)', () => {
+	it( 'hasActiveFilters counts the priceRange (including half-open) as a filter', () => {
 		state.activeFilters = {};
 		state.priceRange = null;
-		expect( state.hasAnyActiveFilters ).toBe( false );
+		expect( state.hasActiveFilters ).toBe( false );
 
 		state.activeFilters = { category: [ 'news' ] };
-		expect( state.hasAnyActiveFilters ).toBe( true );
+		expect( state.hasActiveFilters ).toBe( true );
 
 		state.activeFilters = {};
 		state.priceRange = { min: 10, max: 50 };
-		expect( state.hasAnyActiveFilters ).toBe( true );
+		expect( state.hasActiveFilters ).toBe( true );
 
 		// Half-open range still counts — without this branch a price-only
 		// deep link leaves the active-filters wrapper hidden after hydration.
 		state.priceRange = { min: null, max: 50 };
-		expect( state.hasAnyActiveFilters ).toBe( true );
+		expect( state.hasActiveFilters ).toBe( true );
 
 		state.priceRange = { min: null, max: null };
-		expect( state.hasAnyActiveFilters ).toBe( false );
+		expect( state.hasActiveFilters ).toBe( false );
 	} );
 
 	it( 'enables the filter trigger for active filters or available aggregation buckets', () => {
@@ -676,8 +676,9 @@ describe( 'store callbacks', () => {
 	it( 'initializes popstate handling and runs one URL-seeded search', () => {
 		// Also covers the price-only URL case: `?min_price=10` with no text
 		// query and no checkbox filters seeds isLoading=true on the PHP side,
-		// so initialize() must fire a fetch for `priceRange` alone, not just
-		// for `searchQuery || hasActiveFilters`.
+		// so initialize() must fire a fetch — hasActiveFilters counts the
+		// priceRange, so the existing `searchQuery || hasActiveFilters` gate
+		// is enough.
 		const addEventListener = jest.spyOn( window, 'addEventListener' );
 		Object.assign( actions, originalActions );
 		jest.spyOn( actions, 'handlePopState' ).mockImplementation();

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -452,24 +452,6 @@ describe( 'store actions', () => {
 		expect( writtenUrl ).toContain( 'max_price=50' );
 	} );
 
-	it( 'syncToUrl threads filterConfigs through so scalar-shaped filters keep their WC URL contract', () => {
-		// Without honoring `urlFormat: 'scalar'` on the writer side, the first
-		// post-hydration search would rewrite `?filter_stock_status=instock`
-		// into `?filter_stock_status[]=instock`, breaking shareable WC catalog
-		// URLs and round-tripping the visitor onto a different URL shape than
-		// they arrived on.
-		const replaceState = jest.spyOn( window.history, 'replaceState' ).mockImplementation();
-		state.searchQuery = '';
-		state.activeFilters = { filter_stock_status: [ 'instock', 'outofstock' ] };
-		state.filterConfigs = { filter_stock_status: { urlFormat: 'scalar' } };
-
-		actions.syncToUrl();
-
-		const writtenUrl = replaceState.mock.calls[ 0 ][ 2 ];
-		expect( writtenUrl ).toContain( 'filter_stock_status=instock%2Coutofstock' );
-		expect( writtenUrl ).not.toContain( 'filter_stock_status%5B%5D' );
-	} );
-
 	it( 'closes open popovers on Escape only', () => {
 		state.isFilterPopoverOpen = true;
 		state.isSortPopoverOpen = true;

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -314,7 +314,7 @@ describe( 'store actions', () => {
 		expect( search ).toHaveBeenCalledTimes( 4 );
 	} );
 
-	it( 'clears filters only when filters are active', async () => {
+	it( 'clears every facet only when something is active', async () => {
 		const search = jest.spyOn( actions, 'search' ).mockResolvedValue();
 
 		await runGenerator( actions.clearFilters() );
@@ -322,9 +322,51 @@ describe( 'store actions', () => {
 
 		state.activeFilters = { tag: [ 'react' ] };
 		await runGenerator( actions.clearFilters() );
-
 		expect( state.activeFilters ).toEqual( {} );
 		expect( search ).toHaveBeenCalledTimes( 1 );
+
+		// Price-only state still triggers a clear — covers half-open ranges
+		// like `{ min: 10, max: null }` so a "clear all" affordance wipes
+		// every facet, not just the checkbox-shaped ones.
+		state.priceRange = { min: 10, max: null };
+		await runGenerator( actions.clearFilters() );
+		expect( state.priceRange ).toBeNull();
+		expect( search ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'setPriceRange validates bounds, no-ops on identity, and clears on null/null', async () => {
+		const search = jest.spyOn( actions, 'search' ).mockResolvedValue();
+		state.priceRange = null;
+
+		// NaN / negative bounds drop the call rather than poisoning ES.
+		await runGenerator( actions.setPriceRange( 'abc', 50 ) );
+		await runGenerator( actions.setPriceRange( -1, 50 ) );
+		expect( state.priceRange ).toBeNull();
+		expect( search ).not.toHaveBeenCalled();
+
+		// Inverted bounds (min > max) build an empty clause — drop too.
+		await runGenerator( actions.setPriceRange( 100, 10 ) );
+		expect( state.priceRange ).toBeNull();
+		expect( search ).not.toHaveBeenCalled();
+
+		// Closed range writes and searches.
+		await runGenerator( actions.setPriceRange( 10, 50 ) );
+		expect( state.priceRange ).toEqual( { min: 10, max: 50 } );
+		expect( search ).toHaveBeenCalledTimes( 1 );
+
+		// Identity no-op — same bounds shouldn't refetch.
+		await runGenerator( actions.setPriceRange( 10, 50 ) );
+		expect( search ).toHaveBeenCalledTimes( 1 );
+
+		// Half-open range (one bound null) is allowed.
+		await runGenerator( actions.setPriceRange( 25, null ) );
+		expect( state.priceRange ).toEqual( { min: 25, max: null } );
+		expect( search ).toHaveBeenCalledTimes( 2 );
+
+		// Both null clears the range.
+		await runGenerator( actions.setPriceRange( null, null ) );
+		expect( state.priceRange ).toBeNull();
+		expect( search ).toHaveBeenCalledTimes( 3 );
 	} );
 
 	it( 'keeps filter and sort popovers mutually exclusive', () => {
@@ -493,6 +535,27 @@ describe( 'store getters', () => {
 		state.activeFilters = { category: [ 'news', 'updates' ] };
 		expect( state.hasActiveFilters ).toBe( true );
 		expect( state.activeFilterCount ).toBe( 2 );
+	} );
+
+	it( 'hasAnyActiveFilters covers activeFilters and the priceRange (including half-open)', () => {
+		state.activeFilters = {};
+		state.priceRange = null;
+		expect( state.hasAnyActiveFilters ).toBe( false );
+
+		state.activeFilters = { category: [ 'news' ] };
+		expect( state.hasAnyActiveFilters ).toBe( true );
+
+		state.activeFilters = {};
+		state.priceRange = { min: 10, max: 50 };
+		expect( state.hasAnyActiveFilters ).toBe( true );
+
+		// Half-open range still counts — without this branch a price-only
+		// deep link leaves the active-filters wrapper hidden after hydration.
+		state.priceRange = { min: null, max: 50 };
+		expect( state.hasAnyActiveFilters ).toBe( true );
+
+		state.priceRange = { min: null, max: null };
+		expect( state.hasAnyActiveFilters ).toBe( false );
 	} );
 
 	it( 'enables the filter trigger for active filters or available aggregation buckets', () => {

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -358,15 +358,21 @@ describe( 'store actions', () => {
 		await runGenerator( actions.setPriceRange( 10, 50 ) );
 		expect( search ).toHaveBeenCalledTimes( 1 );
 
-		// Half-open range (one bound null) is allowed.
+		// Half-open range (one bound null) is allowed — both min-only and
+		// max-only shapes round-trip the matching null through to state so the
+		// URL writer and ES range clause see the same "no bound" sentinel.
 		await runGenerator( actions.setPriceRange( 25, null ) );
 		expect( state.priceRange ).toEqual( { min: 25, max: null } );
 		expect( search ).toHaveBeenCalledTimes( 2 );
 
+		await runGenerator( actions.setPriceRange( null, 50 ) );
+		expect( state.priceRange ).toEqual( { min: null, max: 50 } );
+		expect( search ).toHaveBeenCalledTimes( 3 );
+
 		// Both null clears the range.
 		await runGenerator( actions.setPriceRange( null, null ) );
 		expect( state.priceRange ).toBeNull();
-		expect( search ).toHaveBeenCalledTimes( 3 );
+		expect( search ).toHaveBeenCalledTimes( 4 );
 	} );
 
 	it( 'keeps filter and sort popovers mutually exclusive', () => {
@@ -444,6 +450,24 @@ describe( 'store actions', () => {
 		const writtenUrl = replaceState.mock.calls[ 0 ][ 2 ];
 		expect( writtenUrl ).toContain( 'min_price=10' );
 		expect( writtenUrl ).toContain( 'max_price=50' );
+	} );
+
+	it( 'syncToUrl threads filterConfigs through so scalar-shaped filters keep their WC URL contract', () => {
+		// Without honoring `urlFormat: 'scalar'` on the writer side, the first
+		// post-hydration search would rewrite `?filter_stock_status=instock`
+		// into `?filter_stock_status[]=instock`, breaking shareable WC catalog
+		// URLs and round-tripping the visitor onto a different URL shape than
+		// they arrived on.
+		const replaceState = jest.spyOn( window.history, 'replaceState' ).mockImplementation();
+		state.searchQuery = '';
+		state.activeFilters = { filter_stock_status: [ 'instock', 'outofstock' ] };
+		state.filterConfigs = { filter_stock_status: { urlFormat: 'scalar' } };
+
+		actions.syncToUrl();
+
+		const writtenUrl = replaceState.mock.calls[ 0 ][ 2 ];
+		expect( writtenUrl ).toContain( 'filter_stock_status=instock%2Coutofstock' );
+		expect( writtenUrl ).not.toContain( 'filter_stock_status%5B%5D' );
 	} );
 
 	it( 'closes open popovers on Escape only', () => {

--- a/projects/packages/search/tests/js/search-blocks/url-state.test.js
+++ b/projects/packages/search/tests/js/search-blocks/url-state.test.js
@@ -56,6 +56,38 @@ describe( 'stateToUrlParams', () => {
 		expect( params.getAll( 'post_types[]' ) ).toEqual( [ 'post' ] );
 	} );
 
+	it( 'writes scalar-format filters as a single comma-joined value', () => {
+		// WooCommerce-shaped filters (e.g. `?filter_stock_status=instock,outofstock`)
+		// must round-trip in their native shape. Without honoring filterConfigs
+		// on the writer side, syncToUrl would rewrite the WC URL into the array
+		// form on the first hydration and break catalog deep links.
+		const params = stateToUrlParams( {
+			searchQuery: '',
+			sortOrder: 'relevance',
+			activeFilters: { filter_stock_status: [ 'instock', 'outofstock' ] },
+			filterConfigs: { filter_stock_status: { urlFormat: 'scalar' } },
+		} );
+		expect( params.get( 'filter_stock_status' ) ).toBe( 'instock,outofstock' );
+		expect( params.has( 'filter_stock_status[]' ) ).toBe( false );
+	} );
+
+	it( 'mixes scalar and array filters within the same params instance', () => {
+		const params = stateToUrlParams( {
+			searchQuery: '',
+			sortOrder: 'relevance',
+			activeFilters: {
+				category: [ 'news' ],
+				filter_stock_status: [ 'instock' ],
+			},
+			filterConfigs: {
+				category: { filterKey: 'category' },
+				filter_stock_status: { urlFormat: 'scalar' },
+			},
+		} );
+		expect( params.getAll( 'category[]' ) ).toEqual( [ 'news' ] );
+		expect( params.get( 'filter_stock_status' ) ).toBe( 'instock' );
+	} );
+
 	it( 'skips filters with empty value arrays', () => {
 		const params = stateToUrlParams( {
 			searchQuery: '',

--- a/projects/packages/search/tests/js/search-blocks/url-state.test.js
+++ b/projects/packages/search/tests/js/search-blocks/url-state.test.js
@@ -56,38 +56,6 @@ describe( 'stateToUrlParams', () => {
 		expect( params.getAll( 'post_types[]' ) ).toEqual( [ 'post' ] );
 	} );
 
-	it( 'writes scalar-format filters as a single comma-joined value', () => {
-		// WooCommerce-shaped filters (e.g. `?filter_stock_status=instock,outofstock`)
-		// must round-trip in their native shape. Without honoring filterConfigs
-		// on the writer side, syncToUrl would rewrite the WC URL into the array
-		// form on the first hydration and break catalog deep links.
-		const params = stateToUrlParams( {
-			searchQuery: '',
-			sortOrder: 'relevance',
-			activeFilters: { filter_stock_status: [ 'instock', 'outofstock' ] },
-			filterConfigs: { filter_stock_status: { urlFormat: 'scalar' } },
-		} );
-		expect( params.get( 'filter_stock_status' ) ).toBe( 'instock,outofstock' );
-		expect( params.has( 'filter_stock_status[]' ) ).toBe( false );
-	} );
-
-	it( 'mixes scalar and array filters within the same params instance', () => {
-		const params = stateToUrlParams( {
-			searchQuery: '',
-			sortOrder: 'relevance',
-			activeFilters: {
-				category: [ 'news' ],
-				filter_stock_status: [ 'instock' ],
-			},
-			filterConfigs: {
-				category: { filterKey: 'category' },
-				filter_stock_status: { urlFormat: 'scalar' },
-			},
-		} );
-		expect( params.getAll( 'category[]' ) ).toEqual( [ 'news' ] );
-		expect( params.get( 'filter_stock_status' ) ).toBe( 'instock' );
-	} );
-
 	it( 'skips filters with empty value arrays', () => {
 		const params = stateToUrlParams( {
 			searchQuery: '',
@@ -322,46 +290,5 @@ describe( 'urlParamsToState: priceRange', () => {
 		params.append( 'max_price[]', '50' );
 		const state = urlParamsToState( params );
 		expect( state.activeFilters ).toEqual( {} );
-	} );
-} );
-
-describe( 'urlParamsToState: scalar comma-joined URL fallback', () => {
-	it( 'parses comma-joined values for filterConfigs whose urlFormat is `scalar`', () => {
-		const state = urlParamsToState(
-			new URLSearchParams( '?filter_stock_status=instock,outofstock' ),
-			{
-				filter_stock_status: { filterType: 'wc_stock_status', urlFormat: 'scalar' },
-			}
-		);
-		expect( state.activeFilters ).toEqual( {
-			filter_stock_status: [ 'instock', 'outofstock' ],
-		} );
-	} );
-
-	it( 'ignores scalar URL form when the filterConfig does not opt in', () => {
-		const state = urlParamsToState( new URLSearchParams( '?category=news,sports' ), {
-			category: { filterType: 'taxonomy', taxonomy: 'category' },
-		} );
-		expect( state.activeFilters ).toEqual( {} );
-	} );
-
-	it( 'prefers array-form when both shapes are present for the same key', () => {
-		const params = new URLSearchParams();
-		params.append( 'filter_stock_status[]', 'onbackorder' );
-		params.append( 'filter_stock_status', 'instock,outofstock' );
-		const state = urlParamsToState( params, {
-			filter_stock_status: { filterType: 'wc_stock_status', urlFormat: 'scalar' },
-		} );
-		expect( state.activeFilters ).toEqual( { filter_stock_status: [ 'onbackorder' ] } );
-	} );
-
-	it( 'de-duplicates within the scalar value list', () => {
-		const state = urlParamsToState(
-			new URLSearchParams( '?filter_stock_status=instock,instock,outofstock' ),
-			{
-				filter_stock_status: { filterType: 'wc_stock_status', urlFormat: 'scalar' },
-			}
-		);
-		expect( state.activeFilters.filter_stock_status ).toEqual( [ 'instock', 'outofstock' ] );
 	} );
 } );


### PR DESCRIPTION
## Why

WooCommerce-style product filter blocks (price, rating, stock-status, attributes, taxonomies) are landing as a 9-PR stack closing [RSM-1929](https://linear.app/a8c/issue/RSM-1929). For shoppers, that means a Jetpack Search storefront finally gets the same filter sidebar people expect from a WC catalog page. For block authors, it means assembling that sidebar from composable blocks instead of one opaque widget.

This PR doesn't ship any of those visible blocks yet — it lands the shared data-plane primitives the rest of the stack needs:

- **One "Clear all" button actually clears everything.** Today, hitting "Clear all" on the active-filters block leaves the price slider at its previous range; a shopper has to clear the price separately. After this PR, a single clear-all wipes every facet — checkboxes, taxonomies, AND the price range (including half-open ones like "\$50+").
- **A price-only deep link no longer hides the active-filters chip row.** Before, sharing a \`?min_price=10\` URL would arrive with the chip row hidden because visibility only counted checkbox-style filters; the visitor couldn't see they had a filter applied until they opened a popover.

This is **PR-1 of 9** closing [RSM-1929](https://linear.app/a8c/issue/RSM-1929):

```
trunk
  └── PR-1 (this) — foundation
        ├── PR-2 — filter-wc-stock-status
        ├── PR-3 — filter-wc-rating
        ├── PR-4 — filter-wc-price (uses setPriceRange from this PR)
        ├── PR-5 — filter-wc-attribute
        ├── PR-6 — filter-wc-taxonomy
        ├── PR-7 — clear-filters (standalone, refactored out of active-filters)
        ├── PR-8 — active-filters product-aware chips
        └── PR-9 — wc-product-filters parent block (capstone)
```

## Proposed changes

- **\`actions.setPriceRange(min, max)\`** — rejects NaN / negative / inverted bounds, no-ops on identity, clears when both bounds are null.
- **\`actions.clearFilters\` extended** to wipe \`priceRange\` too (covers half-open ranges).
- **\`state.hasActiveFilters\` extended** to count \`priceRange\` as a filter — a price-only or half-open selection now flips the same getter that checkbox selections do, so the active-filters wrapper visibility (both the IA \`data-wp-bind--hidden\` and the first-paint \`hidden\` attribute on PHP render) reacts to it without a separate getter.

Filter URLs continue to use Jetpack Search's array shape (\`?<filterKey>[]=<value>\`) end-to-end — the WooCommerce-flavoured comma-joined / scalar variant introduced earlier in the stack is removed here so the JS writer, JS reader, and PHP \`parse_url_filters()\` agree on a single contract. \`search-blocks/AGENTS.md\` documents the rule for future product filters.

## How

The new infra is *added* without consumers in this PR — \`setPriceRange\` is unused until PR-4 (price block) lands. The active-filters render.php visibility switch IS user-visible: a \`?s=&min_price=10\` URL on a page that also has filter-checkbox blocks now shows the active-filters wrapper. The wrapper still has nothing to render (no chips for priceRange yet — that's PR-8), so it's an empty-but-visible state. PR-8 fills it in.

## Related product discussion/links

- Epic: [RSM-1929](https://linear.app/a8c/issue/RSM-1929)
- Predecessor PR (data-plane reader half): #48397

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Check out the branch.
2. From \`projects/packages/search\`: \`pnpm exec jest tests/js/search-blocks/\` — all 308 tests pass (covers the new \`setPriceRange\` validation, identity no-op, half-open ranges, plus the extended \`clearFilters\` and the priceRange-aware \`hasActiveFilters\` getter).
3. \`composer phpunit\` — existing PHP suite passes.
4. Browser-side: nothing user-visible should change yet, except a \`?s=&min_price=10\` deep link on a page with \`jetpack-search/active-filters\` now shows the (empty) wrapper instead of hiding it.