### PR TITLE
Search 3.0: WC stock-status filter block (jetpack-search/filter-wc-stock-status)

### DIFF
--- a/projects/packages/search/changelog/add-filter-wc-stock-status
+++ b/projects/packages/search/changelog/add-filter-wc-stock-status
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Search 3.0: Add `jetpack-search/filter-wc-stock-status` block — a single "In stock" toggle that excludes WooCommerce out-of-stock products. Routes through the `product_visibility` taxonomy (the `_stock_status` postmeta isn't currently retained on the WPCOM-side ES indexer; tracked separately).
+Search 3.0: Add `jetpack-search/filter-wc-stock-status` block — a single "In stock" toggle that excludes WooCommerce out-of-stock products via the `product_visibility` taxonomy.

--- a/projects/packages/search/changelog/add-filter-wc-stock-status
+++ b/projects/packages/search/changelog/add-filter-wc-stock-status
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Search 3.0: adds the `jetpack-search/filter-wc-stock-status` block — a fixed three-option list (in stock / out of stock / on backorder) that filters by WooCommerce stock status. Uses the `wc_stock_status` filterType against the `meta._stock_status.value.raw` ES field and writes the standard array-form URL (`?filter_stock_status[]=instock&filter_stock_status[]=outofstock`) for consistency with the other Search 3.0 filter blocks. Tracked under epic [RSM-1929].
+Search 3.0: Add `jetpack-search/filter-wc-stock-status` block for filtering products by WooCommerce stock status.

--- a/projects/packages/search/changelog/add-filter-wc-stock-status
+++ b/projects/packages/search/changelog/add-filter-wc-stock-status
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Search 3.0: Add `jetpack-search/filter-wc-stock-status` block for filtering products by WooCommerce stock status.
+Search 3.0: Add `jetpack-search/filter-wc-stock-status` block — a single "In stock" toggle that excludes WooCommerce out-of-stock products. Routes through the `product_visibility` taxonomy (the `_stock_status` postmeta isn't currently retained on the WPCOM-side ES indexer; tracked separately).

--- a/projects/packages/search/changelog/add-filter-wc-stock-status
+++ b/projects/packages/search/changelog/add-filter-wc-stock-status
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search 3.0: adds the `jetpack-search/filter-wc-stock-status` block — a fixed three-option list (in stock / out of stock / on backorder) that filters by WooCommerce stock status. Uses the `wc_stock_status` filterType against the `meta._stock_status.value.raw` ES field and writes the standard array-form URL (`?filter_stock_status[]=instock&filter_stock_status[]=outofstock`) for consistency with the other Search 3.0 filter blocks. Tracked under epic [RSM-1929].

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/block.json
@@ -6,7 +6,7 @@
 	"title": "Filter by Stock Status",
 	"category": "jetpack-search",
 	"icon": "tag",
-	"description": "Let shoppers filter products by stock status (in stock, out of stock, on backorder). Powered by Jetpack Search.",
+	"description": "Let shoppers narrow product results to in-stock items. Powered by Jetpack Search.",
 	"supports": {
 		"html": false,
 		"interactivity": true,

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/block.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "jetpack-search/filter-wc-stock-status",
+	"version": "0.1.0",
+	"title": "Filter by Stock Status",
+	"category": "jetpack-search",
+	"icon": "tag",
+	"description": "Let shoppers filter products by stock status (in stock, out of stock, on backorder). Powered by Jetpack Search.",
+	"supports": {
+		"html": false,
+		"interactivity": true,
+		"spacing": {
+			"margin": [ "top", "bottom" ],
+			"padding": true,
+			"blockGap": true
+		}
+	},
+	"textdomain": "jetpack-search-pkg",
+	"attributes": {
+		"label": { "type": "string", "default": "" },
+		"showCount": { "type": "boolean", "default": true }
+	},
+	"render": "file:./render.php",
+	"viewScriptModule": "file:../../../../build/search-blocks/filter-wc-stock-status.js",
+	"style": "file:../../../../build/search-blocks/filter-wc-stock-status.css"
+}

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/class-search-product-filter-status.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/class-search-product-filter-status.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Search product filter — stock status block helpers.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+/**
+ * Helper methods for the jetpack-search/filter-wc-stock-status block.
+ *
+ * Single source of truth for the block's filterKey, fixed option list, and
+ * filterConfig shape. Both render.php (when seeding interactivity state)
+ * and Search_Blocks::collect_product_filter_configs_from_post() rely on
+ * these so the URL gate sees the same key the block registers at render
+ * time, regardless of block order in the post.
+ */
+class Search_Product_Filter_Status {
+
+	/**
+	 * URL key + interactivity-state filter key for stock-status selections.
+	 * Written and read as the standard array form (`?filter_stock_status[]=…`),
+	 * matching the other Search 3.0 filter blocks.
+	 */
+	const FILTER_KEY = 'filter_stock_status';
+
+	/**
+	 * Fixed option set for the filter. Matches the keys
+	 * `wc_get_product_stock_status_options()` returns; v1 ships hardcoded
+	 * English labels (RSM-1932 will server-render the WC translations into
+	 * `wp_interactivity_state` so locales other than en-US render correctly).
+	 *
+	 * @return array<int, array{value: string, label: string}>
+	 */
+	public static function get_options(): array {
+		return array(
+			array(
+				'value' => 'instock',
+				'label' => 'In stock',
+			),
+			array(
+				'value' => 'outofstock',
+				'label' => 'Out of stock',
+			),
+			array(
+				'value' => 'onbackorder',
+				'label' => 'On backorder',
+			),
+		);
+	}
+
+	/**
+	 * Filter key derivation. Constant for this block — there's only one
+	 * stock-status field per WC store, so no per-instance variation. Kept
+	 * as a method (mirroring Filter_Checkbox::derive_filter_key) so the
+	 * walker in Search_Blocks doesn't need to special-case the API.
+	 *
+	 * @param array $_attributes Block attributes (unused; present for interface parity).
+	 * @return string
+	 */
+	public static function derive_filter_key( array $_attributes = array() ): string { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		return self::FILTER_KEY;
+	}
+
+	/**
+	 * Default group label when the block author leaves the label attribute
+	 * empty. v1 ships English; RSM-1932 will switch this to read from the
+	 * WC-provided translation map.
+	 *
+	 * @return string
+	 */
+	public static function default_label(): string {
+		return __( 'Stock status', 'jetpack-search-pkg' );
+	}
+
+	/**
+	 * Build the filterConfig entry this block contributes to the shared
+	 * Interactivity state. JS reads filterType to dispatch onto the
+	 * `meta._stock_status.value.raw` ES path.
+	 *
+	 * @param array  $attributes Block attributes.
+	 * @param string $_filter_key Resolved filter key (unused; present for interface parity).
+	 * @return array<string, mixed>
+	 */
+	public static function build_config( array $attributes, string $_filter_key = '' ): array { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$label = sanitize_text_field( (string) ( $attributes['label'] ?? '' ) );
+		if ( '' === $label ) {
+			$label = static::default_label();
+		}
+
+		return array(
+			'filterKey'  => self::FILTER_KEY,
+			'filterType' => 'wc_stock_status',
+			'label'      => $label,
+			'showCount'  => (bool) ( $attributes['showCount'] ?? true ),
+		);
+	}
+}

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/class-search-product-filter-status.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/class-search-product-filter-status.php
@@ -26,10 +26,17 @@ class Search_Product_Filter_Status {
 	const FILTER_KEY = 'filter_stock_status';
 
 	/**
-	 * Fixed option set for the filter. Matches the keys
-	 * `wc_get_product_stock_status_options()` returns; v1 ships hardcoded
-	 * English labels (RSM-1932 will server-render the WC translations into
-	 * `wp_interactivity_state` so locales other than en-US render correctly).
+	 * Fixed option set for the filter. v1 surfaces a single "In stock"
+	 * toggle: the data plane reads from the `product_visibility` taxonomy
+	 * where only `outofstock` exists — backorder lives solely in the
+	 * `_stock_status` postmeta which the WPCOM-side ES indexer doesn't
+	 * currently retain, and an explicit "Out of stock" option rarely makes
+	 * sense on a shop UI. When the indexer adds `_stock_status`, the full
+	 * three-option list (`instock` / `outofstock` / `onbackorder`) can be
+	 * restored here and the data-plane wiring in `store/api.js` reverted
+	 * to the meta path. Hardcoded English labels for now (RSM-1932 will
+	 * server-render the WC translations into `wp_interactivity_state` so
+	 * non-en-US locales render correctly).
 	 *
 	 * @return array<int, array{value: string, label: string}>
 	 */
@@ -38,14 +45,6 @@ class Search_Product_Filter_Status {
 			array(
 				'value' => 'instock',
 				'label' => 'In stock',
-			),
-			array(
-				'value' => 'outofstock',
-				'label' => 'Out of stock',
-			),
-			array(
-				'value' => 'onbackorder',
-				'label' => 'On backorder',
 			),
 		);
 	}
@@ -77,7 +76,8 @@ class Search_Product_Filter_Status {
 	/**
 	 * Build the filterConfig entry this block contributes to the shared
 	 * Interactivity state. JS reads filterType to dispatch onto the
-	 * `meta._stock_status.value.raw` ES path.
+	 * `taxonomy.product_visibility.slug` ES path with `outofstock`-include
+	 * agg and `term` / `must_not term` clauses.
 	 *
 	 * @param array  $attributes Block attributes.
 	 * @param string $_filter_key Resolved filter key (unused; present for interface parity).

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/edit.js
@@ -1,7 +1,7 @@
 /**
  * Editor preview for jetpack-search/filter-wc-stock-status.
  *
- * Mirrors the runtime DOM shape — labeled list with three checkbox options
+ * Mirrors the runtime DOM shape — labeled list with one checkbox option
  * and optional count badges — so designers can style the filter list in
  * place. Inspector exposes the user-tunable attributes (label, showCount).
  */

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/edit.js
@@ -11,11 +11,9 @@ import { __ } from '@wordpress/i18n';
 
 // Mirror Search_Product_Filter_Status::get_options() — same value/label
 // pairs so the editor preview matches the front-end render shape exactly.
-// Sample counts are illustrative; the live block renders real ES counts.
+// Sample count is illustrative; the live block renders real ES counts.
 const SAMPLE_OPTIONS = [
 	{ value: 'instock', label: __( 'In stock', 'jetpack-search-pkg' ), count: 24 },
-	{ value: 'outofstock', label: __( 'Out of stock', 'jetpack-search-pkg' ), count: 3 },
-	{ value: 'onbackorder', label: __( 'On backorder', 'jetpack-search-pkg' ), count: 1 },
 ];
 
 const DEFAULT_LABEL = __( 'Stock status', 'jetpack-search-pkg' );

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/edit.js
@@ -1,0 +1,80 @@
+/**
+ * Editor preview for jetpack-search/filter-wc-stock-status.
+ *
+ * Mirrors the runtime DOM shape — labeled list with three checkbox options
+ * and optional count badges — so designers can style the filter list in
+ * place. Inspector exposes the user-tunable attributes (label, showCount).
+ */
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+// Mirror Search_Product_Filter_Status::get_options() — same value/label
+// pairs so the editor preview matches the front-end render shape exactly.
+// Sample counts are illustrative; the live block renders real ES counts.
+const SAMPLE_OPTIONS = [
+	{ value: 'instock', label: __( 'In stock', 'jetpack-search-pkg' ), count: 24 },
+	{ value: 'outofstock', label: __( 'Out of stock', 'jetpack-search-pkg' ), count: 3 },
+	{ value: 'onbackorder', label: __( 'On backorder', 'jetpack-search-pkg' ), count: 1 },
+];
+
+const DEFAULT_LABEL = __( 'Stock status', 'jetpack-search-pkg' );
+
+/**
+ * Edit component for the filter-wc-stock-status block.
+ *
+ * @param {object}   props               - Block props.
+ * @param {object}   props.attributes    - Saved block attributes.
+ * @param {Function} props.setAttributes - Attribute setter.
+ * @return {object} Rendered element.
+ */
+export default function FilterWcStockStatusEdit( { attributes, setAttributes } ) {
+	const blockProps = useBlockProps( { className: 'jetpack-search-filter-wc-stock-status' } );
+	const rawLabel = attributes?.label || '';
+	const previewLabel = rawLabel || DEFAULT_LABEL;
+	const showCount = attributes?.showCount !== false;
+
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings', 'jetpack-search-pkg' ) }>
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Label', 'jetpack-search-pkg' ) }
+						value={ rawLabel }
+						placeholder={ DEFAULT_LABEL }
+						onChange={ value => setAttributes( { label: value } ) }
+						help={ __(
+							'Heading shown above the options. Leave empty for the default.',
+							'jetpack-search-pkg'
+						) }
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Show result counts', 'jetpack-search-pkg' ) }
+						checked={ showCount }
+						onChange={ value => setAttributes( { showCount: !! value } ) }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div { ...blockProps }>
+				<h3 className="jetpack-search-filter__title">{ previewLabel }</h3>
+				<ul className="jetpack-search-filter__list">
+					{ SAMPLE_OPTIONS.map( option => (
+						<li key={ option.value } className="jetpack-search-filter__item">
+							{ /* eslint-disable-next-line jsx-a11y/label-has-associated-control -- the input is a direct child, implicit HTML5 association applies; rule's nesting heuristic doesn't trace through sibling spans */ }
+							<label>
+								<input type="checkbox" disabled />
+								<span className="jetpack-search-filter__label">{ option.label }</span>
+								{ showCount && (
+									<span className="jetpack-search-filter__count">{ String( option.count ) }</span>
+								) }
+							</label>
+						</li>
+					) ) }
+				</ul>
+			</div>
+		</>
+	);
+}

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/render.php
@@ -48,11 +48,11 @@ $seeded_active   = (array) ( $seeded_state['activeFilters'] ?? array() );
 $seeded_selected = (array) ( $seeded_active[ Search_Product_Filter_Status::FILTER_KEY ] ?? array() );
 $seeded_total    = (int) ( $seeded_state['totalResults'] ?? 0 );
 
-// Pre-hydration count map. The aggregation only carries the
-// `outofstock` bucket; the in-stock count is derived as
-// `totalResults - outofstock` since the `product_visibility` taxonomy
-// has no positive `instock` term. Both fall back to 0 before any
-// search has run so the badge has something to render.
+// Pre-hydration count for the in-stock option. The aggregation only
+// carries the `outofstock` bucket; the in-stock count is derived as
+// `totalResults - outofstock` because the `product_visibility`
+// taxonomy has no positive `instock` term. Falls back to 0 before any
+// search has run so the badge always has something to render.
 $out_of_stock = 0;
 foreach ( $seeded_buckets as $bucket ) {
 	if ( 'outofstock' === (string) ( $bucket['key'] ?? '' ) ) {
@@ -61,21 +61,28 @@ foreach ( $seeded_buckets as $bucket ) {
 	}
 }
 $counts = array(
-	'instock'    => max( 0, $seeded_total - $out_of_stock ),
-	'outofstock' => $out_of_stock,
+	'instock' => max( 0, $seeded_total - $out_of_stock ),
 );
 
 $label      = (string) $config['label'];
 $show_count = (bool) $config['showCount'];
+?>
+<?php
+// Wrapper visibility note: filter-checkbox / filter-date hide their
+// wrapper via `pre_hydration_filter_view` + `wrapperHidden` while
+// aggregations are loading because their option list is bucket-driven.
+// This block has a fixed option list, so there's nothing to wait for —
+// the wrapper stays visible whenever the block is on the page. The
+// data-plane caveat (out-of-stock count derived from `totalResults -
+// outofstock`) is documented at the top of this file.
 ?>
 <div
 	<?php echo wp_kses_data( get_block_wrapper_attributes( array( 'class' => 'jetpack-search-filter-wc-stock-status' ) ) ); ?>
 	data-wp-interactive="jetpack-search"
 	<?php echo wp_kses_data( wp_interactivity_data_wp_context( array( 'filterKey' => Search_Product_Filter_Status::FILTER_KEY ) ) ); ?>
 >
-	<?php if ( '' !== $label ) : ?>
-		<h3 class="jetpack-search-filter__title"><?php echo esc_html( $label ); ?></h3>
-	<?php endif; ?>
+	<?php /* `build_config()` always falls back to default_label() so $label is non-empty. */ ?>
+	<h3 class="jetpack-search-filter__title"><?php echo esc_html( $label ); ?></h3>
 	<ul class="jetpack-search-filter__list">
 		<?php foreach ( Search_Product_Filter_Status::get_options() as $option ) : ?>
 			<?php

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/render.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Search product filter — stock status render.
+ *
+ * Emits a fixed three-option list (in stock / out of stock / on backorder)
+ * and registers the filterConfig with the shared `jetpack-search`
+ * Interactivity store. Counts are looked up at render time from
+ * URL-seeded `state.aggregations.filter_stock_status.buckets` so direct
+ * URL hits show count badges before JS hydrates; bindings update them
+ * once the first JS-driven fetch completes.
+ *
+ * Unlike the generic filter-checkbox block, the option list is fixed
+ * (WC's `wc_get_product_stock_status_options()` keys) and renders even
+ * when the aggregation has zero buckets — the e-commerce facet UX
+ * convention is "always show every option, even at count 0," which
+ * mirrors WC's own filter and matches what shoppers expect.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+
+if ( ! function_exists( 'wp_interactivity_state' ) ) {
+	return;
+}
+
+// @phan-suppress-next-line PhanUndeclaredGlobalVariable
+$config = Search_Product_Filter_Status::build_config( (array) $attributes );
+
+// Register this filter's config into the shared store. JS reads the
+// filterConfigs map to build aggregation requests and ES filter clauses.
+wp_interactivity_state(
+	'jetpack-search',
+	array(
+		'filterConfigs' => array(
+			Search_Product_Filter_Status::FILTER_KEY => $config,
+		),
+	)
+);
+
+$seeded_state    = wp_interactivity_state( 'jetpack-search' );
+$seeded_aggs     = (array) ( $seeded_state['aggregations'] ?? array() );
+$seeded_buckets  = (array) ( ( (array) ( $seeded_aggs[ Search_Product_Filter_Status::FILTER_KEY ] ?? array() ) )['buckets'] ?? array() );
+$seeded_active   = (array) ( $seeded_state['activeFilters'] ?? array() );
+$seeded_selected = (array) ( $seeded_active[ Search_Product_Filter_Status::FILTER_KEY ] ?? array() );
+
+// Build a slug → count map from the aggregation buckets so the static
+// option list can render count badges on first paint.
+$counts = array();
+foreach ( $seeded_buckets as $bucket ) {
+	$key = (string) ( $bucket['key'] ?? '' );
+	if ( '' === $key ) {
+		continue;
+	}
+	$counts[ $key ] = (int) ( $bucket['doc_count'] ?? 0 );
+}
+
+$label      = (string) $config['label'];
+$show_count = (bool) $config['showCount'];
+?>
+<div
+	<?php echo wp_kses_data( get_block_wrapper_attributes( array( 'class' => 'jetpack-search-filter-wc-stock-status' ) ) ); ?>
+	data-wp-interactive="jetpack-search"
+	<?php echo wp_kses_data( wp_interactivity_data_wp_context( array( 'filterKey' => Search_Product_Filter_Status::FILTER_KEY ) ) ); ?>
+>
+	<?php if ( '' !== $label ) : ?>
+		<h3 class="jetpack-search-filter__title"><?php echo esc_html( $label ); ?></h3>
+	<?php endif; ?>
+	<ul class="jetpack-search-filter__list">
+		<?php foreach ( Search_Product_Filter_Status::get_options() as $option ) : ?>
+			<?php
+			$value      = (string) $option['value'];
+			$option_lbl = (string) $option['label'];
+			$is_checked = in_array( $value, $seeded_selected, true );
+			$option_cnt = $counts[ $value ] ?? 0;
+			?>
+			<li class="jetpack-search-filter__item">
+				<label>
+					<input
+						type="checkbox"
+						value="<?php echo esc_attr( $value ); ?>"
+						<?php echo $is_checked ? 'checked' : ''; ?>
+						data-wp-bind--checked="state.isStatusOptionSelected"
+						data-wp-on--change="actions.onStatusFilterChange"
+					/>
+					<span class="jetpack-search-filter__label"><?php echo esc_html( $option_lbl ); ?></span>
+					<?php if ( $show_count ) : ?>
+						<span
+							class="jetpack-search-filter__count"
+							data-wp-text="state.statusOptionCount"
+						><?php echo esc_html( (string) $option_cnt ); ?></span>
+					<?php endif; ?>
+				</label>
+			</li>
+		<?php endforeach; ?>
+	</ul>
+</div>

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/render.php
@@ -2,18 +2,19 @@
 /**
  * Search product filter — stock status render.
  *
- * Emits a fixed three-option list (in stock / out of stock / on backorder)
- * and registers the filterConfig with the shared `jetpack-search`
- * Interactivity store. Counts are looked up at render time from
- * URL-seeded `state.aggregations.filter_stock_status.buckets` so direct
- * URL hits show count badges before JS hydrates; bindings update them
- * once the first JS-driven fetch completes.
+ * V1 surfaces a single "In stock" toggle and registers the filterConfig
+ * with the shared `jetpack-search` Interactivity store. The data plane
+ * routes through the WC `product_visibility` taxonomy (`outofstock`
+ * term ⇒ out of stock; absence ⇒ in stock); see store/api.js for the
+ * agg / clause shape and class-search-product-filter-status.php for why
+ * the option list is shaped this way today.
  *
- * Unlike the generic filter-checkbox block, the option list is fixed
- * (WC's `wc_get_product_stock_status_options()` keys) and renders even
- * when the aggregation has zero buckets — the e-commerce facet UX
- * convention is "always show every option, even at count 0," which
- * mirrors WC's own filter and matches what shoppers expect.
+ * Counts on first paint come from URL-seeded
+ * `state.aggregations.filter_stock_status.buckets` so direct URL hits
+ * have a count badge before JS hydrates; bindings update once the first
+ * JS-driven fetch completes. The in-stock count is derived as
+ * `totalResults - outofstock_bucket` because the taxonomy has no
+ * positive `instock` term.
  *
  * @package automattic/jetpack-search
  */
@@ -45,17 +46,24 @@ $seeded_aggs     = (array) ( $seeded_state['aggregations'] ?? array() );
 $seeded_buckets  = (array) ( ( (array) ( $seeded_aggs[ Search_Product_Filter_Status::FILTER_KEY ] ?? array() ) )['buckets'] ?? array() );
 $seeded_active   = (array) ( $seeded_state['activeFilters'] ?? array() );
 $seeded_selected = (array) ( $seeded_active[ Search_Product_Filter_Status::FILTER_KEY ] ?? array() );
+$seeded_total    = (int) ( $seeded_state['totalResults'] ?? 0 );
 
-// Build a slug → count map from the aggregation buckets so the static
-// option list can render count badges on first paint.
-$counts = array();
+// Pre-hydration count map. The aggregation only carries the
+// `outofstock` bucket; the in-stock count is derived as
+// `totalResults - outofstock` since the `product_visibility` taxonomy
+// has no positive `instock` term. Both fall back to 0 before any
+// search has run so the badge has something to render.
+$out_of_stock = 0;
 foreach ( $seeded_buckets as $bucket ) {
-	$key = (string) ( $bucket['key'] ?? '' );
-	if ( '' === $key ) {
-		continue;
+	if ( 'outofstock' === (string) ( $bucket['key'] ?? '' ) ) {
+		$out_of_stock = (int) ( $bucket['doc_count'] ?? 0 );
+		break;
 	}
-	$counts[ $key ] = (int) ( $bucket['doc_count'] ?? 0 );
 }
+$counts = array(
+	'instock'    => max( 0, $seeded_total - $out_of_stock ),
+	'outofstock' => $out_of_stock,
+);
 
 $label      = (string) $config['label'];
 $show_count = (bool) $config['showCount'];

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/style.scss
@@ -1,0 +1,19 @@
+/**
+ * Search product filter — stock status.
+ *
+ * Inherits the shared `.jetpack-search-filter__list/__item/__label/__count`
+ * styles from the generic filter-checkbox block (loaded as part of the
+ * package CSS), so this file only adds product-filter-specific tweaks.
+ * The parent wrapper class is here so the editor preview and the front-end
+ * markup share the same hook.
+ */
+.jetpack-search-filter-wc-stock-status {
+	// Keep the option list compact when the parent wrapper sets a tight
+	// blockGap — vertical option lists shouldn't inherit the parent's
+	// inter-section spacing as item-to-item spacing.
+	.jetpack-search-filter__list {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+}

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/style.scss
@@ -1,19 +1,63 @@
 /**
  * Search product filter — stock status.
  *
- * Inherits the shared `.jetpack-search-filter__list/__item/__label/__count`
- * styles from the generic filter-checkbox block (loaded as part of the
- * package CSS), so this file only adds product-filter-specific tweaks.
- * The parent wrapper class is here so the editor preview and the front-end
- * markup share the same hook.
+ * Mirrors filter-checkbox / filter-date so all checkbox-shaped filters
+ * render with the same title typography, row spacing, and count-pill look.
+ * The shared `.jetpack-search-filter__*` classes aren't actually shared at
+ * CSS-load time — each filter block scopes its own copy under its
+ * `.wp-block-jetpack-search-filter-*` wrapper — so duplicate the rules
+ * here rather than depending on the (filter-checkbox-scoped) original.
  */
-.jetpack-search-filter-wc-stock-status {
-	// Keep the option list compact when the parent wrapper sets a tight
-	// blockGap — vertical option lists shouldn't inherit the parent's
-	// inter-section spacing as item-to-item spacing.
+@use "../skeleton" as skeleton;
+
+.wp-block-jetpack-search-filter-wc-stock-status {
+
+	&[hidden] {
+		display: none;
+	}
+
+	@include skeleton.shimmer;
+	@include skeleton.filter-rows;
+
+	.jetpack-search-filter__title {
+		font-size: 0.85rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		margin: 0 0 0.5rem;
+		color: inherit;
+	}
+
 	.jetpack-search-filter__list {
-		display: flex;
-		flex-direction: column;
-		gap: 0.25rem;
+		list-style: none;
+		margin: 0;
+		padding: 0;
+	}
+
+	.jetpack-search-filter__item {
+		padding: 0.25rem 0;
+
+		label {
+			display: flex;
+			align-items: center;
+			gap: 0.5rem;
+			cursor: pointer;
+		}
+	}
+
+	.jetpack-search-filter__label {
+		flex: 1;
+	}
+
+	.jetpack-search-filter__count {
+		font-size: 0.8rem;
+		color: inherit;
+		background: color-mix(in sRGB, currentColor 12%, transparent);
+		border-radius: 10px;
+		padding: 0 0.4rem;
+
+		&[hidden] {
+			display: none;
+		}
 	}
 }

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/view.js
@@ -5,36 +5,37 @@ import './style.scss';
 const NAMESPACE = 'jetpack-search';
 
 /**
- * Build a slug → count map from a histogram-or-terms aggregation's buckets.
- * Returns a plain object so the per-option getter can do a constant-time
- * lookup and avoid re-scanning the bucket array for every render.
+ * Read the `outofstock` bucket's count from a terms-aggregation response.
+ * The aggregation is built with `include: ['outofstock']` so at most one
+ * bucket can come back; the helper returns 0 when the bucket is absent
+ * (no out-of-stock products in the current scope, or pre-hydration state
+ * with no aggregation yet).
  *
  * @param {Array<{key: string, doc_count: number}>} buckets - Aggregation buckets.
- * @return {object} Slug-keyed count map.
+ * @return {number} Out-of-stock count, or 0 when none.
  */
-function bucketsToCountMap( buckets ) {
+function readOutOfStockCount( buckets ) {
 	if ( ! Array.isArray( buckets ) ) {
-		return {};
+		return 0;
 	}
-	const map = {};
 	for ( const bucket of buckets ) {
-		const key = String( bucket?.key ?? '' );
-		if ( ! key ) {
-			continue;
+		if ( String( bucket?.key ?? '' ) === 'outofstock' ) {
+			return Number( bucket?.doc_count ?? 0 );
 		}
-		map[ key ] = Number( bucket?.doc_count ?? 0 );
 	}
-	return map;
+	return 0;
 }
 
 store( NAMESPACE, {
 	state: {
 		/**
-		 * `data-wp-bind--checked` per-option. Reads the input's `value`
-		 * attribute via `getElement().attributes.value` so the same getter
-		 * serves all three options without per-option context. Falls back
-		 * to false when the filter has no selections so unchecking the
-		 * last box re-renders cleanly.
+		 * `data-wp-bind--checked` for the in-stock toggle. Reads the
+		 * input's `value` attribute via `getElement().attributes.value`
+		 * so the getter stays generic (the option list comes from
+		 * `Search_Product_Filter_Status::get_options()` and may grow
+		 * back to multiple entries once the WPCOM-side ES indexer carries
+		 * `_stock_status` again). Falls back to false when the filter
+		 * has no selections so unchecking re-renders cleanly.
 		 *
 		 * @return {boolean} Whether this option's slug is in activeFilters.
 		 */
@@ -50,31 +51,24 @@ store( NAMESPACE, {
 		},
 
 		/**
-		 * `data-wp-text` per-option count badge. Reads the option's slug
-		 * from the option's `<input value=…>` (the count badge sits next
-		 * to the input inside the same `<label>`), then looks the slug up
-		 * in the aggregation. Falls back to "0" when the filter has no
-		 * matches in the current scope — convention for "always show all
-		 * options" facet UIs.
+		 * `data-wp-text` count badge for the single "In stock" option.
+		 * The aggregation carries only the `outofstock` bucket count
+		 * against `product_visibility` (the taxonomy has no positive
+		 * `instock` term), so the in-stock count is derived as
+		 * `state.totalResults - outOfStock`. Counts reflect the current
+		 * filter scope: when the toggle is on, the filter excludes
+		 * out-of-stock and the bucket count is `0`, leaving the in-stock
+		 * count equal to the (already narrowed) `totalResults`. Falls
+		 * back to "0" pre-hydration.
 		 *
 		 * @return {string} Count as a string for the badge text node.
 		 */
 		get statusOptionCount() {
-			// The count <span> sits as a sibling of the <input> inside the
-			// shared <label>. Walk up to the label, then find the input
-			// to read its `value` attribute — the slug we look up below.
-			const el = getElement()?.ref;
-			const label = el?.closest?.( 'label' );
-			const input = label?.querySelector?.( 'input[type="checkbox"]' );
-			const value = input?.getAttribute?.( 'value' );
-			if ( ! value ) {
-				return '0';
-			}
 			const { state } = store( NAMESPACE );
 			const { filterKey } = getContext();
-			const buckets = state.aggregations?.[ filterKey ]?.buckets;
-			const counts = bucketsToCountMap( buckets );
-			return String( counts[ value ] ?? 0 );
+			const outOfStock = readOutOfStockCount( state.aggregations?.[ filterKey ]?.buckets );
+			const total = Number( state.totalResults ?? 0 );
+			return String( Math.max( 0, total - outOfStock ) );
 		},
 	},
 

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/view.js
@@ -51,15 +51,21 @@ store( NAMESPACE, {
 		},
 
 		/**
-		 * `data-wp-text` count badge for the single "In stock" option.
-		 * The aggregation carries only the `outofstock` bucket count
-		 * against `product_visibility` (the taxonomy has no positive
-		 * `instock` term), so the in-stock count is derived as
+		 * `data-wp-text` count badge for the in-stock option. The
+		 * aggregation only carries the `outofstock` bucket against
+		 * `product_visibility` (the taxonomy has no positive `instock`
+		 * term), so in-stock is derived as
 		 * `state.totalResults - outOfStock`. Counts reflect the current
 		 * filter scope: when the toggle is on, the filter excludes
 		 * out-of-stock and the bucket count is `0`, leaving the in-stock
 		 * count equal to the (already narrowed) `totalResults`. Falls
 		 * back to "0" pre-hydration.
+		 *
+		 * Single-option scope: this getter assumes the only rendered
+		 * checkbox is `instock`. If `Search_Product_Filter_Status::get_options()`
+		 * ever grows back to multiple entries (once the WPCOM-side ES
+		 * indexer carries `_stock_status`), this getter needs to dispatch
+		 * on the input's `value` like `isStatusOptionSelected` does.
 		 *
 		 * @return {string} Count as a string for the badge text node.
 		 */

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-stock-status/view.js
@@ -1,0 +1,96 @@
+import { store, getContext, getElement } from '@wordpress/interactivity';
+import '../../store';
+import './style.scss';
+
+const NAMESPACE = 'jetpack-search';
+
+/**
+ * Build a slug → count map from a histogram-or-terms aggregation's buckets.
+ * Returns a plain object so the per-option getter can do a constant-time
+ * lookup and avoid re-scanning the bucket array for every render.
+ *
+ * @param {Array<{key: string, doc_count: number}>} buckets - Aggregation buckets.
+ * @return {object} Slug-keyed count map.
+ */
+function bucketsToCountMap( buckets ) {
+	if ( ! Array.isArray( buckets ) ) {
+		return {};
+	}
+	const map = {};
+	for ( const bucket of buckets ) {
+		const key = String( bucket?.key ?? '' );
+		if ( ! key ) {
+			continue;
+		}
+		map[ key ] = Number( bucket?.doc_count ?? 0 );
+	}
+	return map;
+}
+
+store( NAMESPACE, {
+	state: {
+		/**
+		 * `data-wp-bind--checked` per-option. Reads the input's `value`
+		 * attribute via `getElement().attributes.value` so the same getter
+		 * serves all three options without per-option context. Falls back
+		 * to false when the filter has no selections so unchecking the
+		 * last box re-renders cleanly.
+		 *
+		 * @return {boolean} Whether this option's slug is in activeFilters.
+		 */
+		get isStatusOptionSelected() {
+			const value = getElement()?.attributes?.value;
+			if ( ! value ) {
+				return false;
+			}
+			const { state } = store( NAMESPACE );
+			const { filterKey } = getContext();
+			const selected = state.activeFilters?.[ filterKey ];
+			return Array.isArray( selected ) && selected.includes( value );
+		},
+
+		/**
+		 * `data-wp-text` per-option count badge. Reads the option's slug
+		 * from the option's `<input value=…>` (the count badge sits next
+		 * to the input inside the same `<label>`), then looks the slug up
+		 * in the aggregation. Falls back to "0" when the filter has no
+		 * matches in the current scope — convention for "always show all
+		 * options" facet UIs.
+		 *
+		 * @return {string} Count as a string for the badge text node.
+		 */
+		get statusOptionCount() {
+			// The count <span> sits as a sibling of the <input> inside the
+			// shared <label>. Walk up to the label, then find the input
+			// to read its `value` attribute — the slug we look up below.
+			const el = getElement()?.ref;
+			const label = el?.closest?.( 'label' );
+			const input = label?.querySelector?.( 'input[type="checkbox"]' );
+			const value = input?.getAttribute?.( 'value' );
+			if ( ! value ) {
+				return '0';
+			}
+			const { state } = store( NAMESPACE );
+			const { filterKey } = getContext();
+			const buckets = state.aggregations?.[ filterKey ]?.buckets;
+			const counts = bucketsToCountMap( buckets );
+			return String( counts[ value ] ?? 0 );
+		},
+	},
+
+	actions: {
+		/**
+		 * Toggle the stock-status value that owns the change event. The
+		 * input's `value` attribute carries the slug; filterKey comes from
+		 * the wrapper context.
+		 *
+		 * @param {Event} event - Change event.
+		 * @yield {Promise} setFilter action.
+		 */
+		*onStatusFilterChange( event ) {
+			const { actions } = store( NAMESPACE );
+			const { filterKey } = getContext();
+			yield actions.setFilter( filterKey, event.target.value );
+		},
+	},
+} );

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -579,9 +579,10 @@ class Search_Blocks {
 	 */
 	protected static function filter_block_helpers(): array {
 		return array(
-			'jetpack-search/filter-checkbox'  => Filter_Checkbox::class,
-			'jetpack-search/filter-date'      => Filter_Date::class,
-			'jetpack-search/filter-wc-rating' => Filter_Wc_Rating::class,
+			'jetpack-search/filter-checkbox'        => Filter_Checkbox::class,
+			'jetpack-search/filter-date'            => Filter_Date::class,
+			'jetpack-search/filter-wc-rating'       => Filter_Wc_Rating::class,
+			'jetpack-search/filter-wc-stock-status' => Search_Product_Filter_Status::class,
 		);
 	}
 

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -24,6 +24,7 @@ import FilterDateEdit from '../blocks/filter-date/edit';
 import FilterPostTypeEdit from '../blocks/filter-post-type/edit';
 import FilterWcPriceEdit from '../blocks/filter-wc-price/edit';
 import FilterWcRatingEdit from '../blocks/filter-wc-rating/edit';
+import FilterWcStockStatusEdit from '../blocks/filter-wc-stock-status/edit';
 import FiltersPopoverEdit, { save as filtersPopoverSave } from '../blocks/filters-popover/edit';
 import FiltersStackEdit, { save as filtersStackSave } from '../blocks/filters-stack/edit';
 import PoweredByEdit from '../blocks/powered-by/edit';
@@ -57,6 +58,7 @@ const BLOCKS = [
 	[ 'jetpack-search/search-results', SearchResultsEdit, searchResultsSave ],
 	[ 'jetpack-search/powered-by', PoweredByEdit ],
 	[ 'jetpack-search/filter-wc-price', FilterWcPriceEdit ],
+	[ 'jetpack-search/filter-wc-stock-status', FilterWcStockStatusEdit ],
 ];
 
 // Shape the "Jetpack Search" block category to match the Forms / Monetize /

--- a/projects/packages/search/src/search-blocks/store/api.js
+++ b/projects/packages/search/src/search-blocks/store/api.js
@@ -112,17 +112,22 @@ export function resolveFilterFields( config ) {
 				bucketFormat: 'slash',
 			};
 		case 'wc_stock_status':
-			// Reads WooCommerce-populated postmeta indexed under
-			// `meta._stock_status.value` with a `.raw` keyword subfield via
-			// the `meta_str_template` dynamic mapping. The terms-aggs
-			// whitelist (`meta\..*\.value\.raw` in
-			// class-wpcom-search-engine.php) admits this exact path. The
-			// `wc_*` prefix on the filterType marks the dependency on
-			// WC-populated meta even though no WC-side code is involved at
-			// query time.
+			// Stock status reads from the WC `product_visibility` taxonomy:
+			// WC tags out-of-stock products with the `outofstock` term;
+			// absence of that term means in-stock. The taxonomy has no
+			// `instock` or `onbackorder` term, so this filter is two-state
+			// only — backorder lives exclusively in the `_stock_status`
+			// postmeta which the WPCOM-side ES indexer doesn't currently
+			// carry (sync sends it, the indexer drops it; tracked as a
+			// separate followup). `buildAggregations` and `buildFilterClause`
+			// special-case this filterType because the agg needs an
+			// `include: ['outofstock']` filter (the taxonomy holds many
+			// unrelated terms — `featured`, `rated-N`, etc.) and the
+			// in-stock selection emits a `must_not` clause rather than a
+			// `term`.
 			return {
-				aggField: 'meta._stock_status.value.raw',
-				filterField: 'meta._stock_status.value.raw',
+				aggField: 'taxonomy.product_visibility.slug',
+				filterField: 'taxonomy.product_visibility.slug',
 				bucketFormat: 'plain',
 			};
 		case 'wc_rating':
@@ -202,6 +207,23 @@ export function buildAggregations( filterConfigs ) {
 					interval: 1,
 					offset: 0.5,
 					min_doc_count: 0,
+				},
+			};
+			continue;
+		}
+
+		// Stock status: probe only the `outofstock` term on
+		// `product_visibility` — the in-stock count is derived as
+		// `total - outofstock` on the read side. The `include` keeps
+		// unrelated terms in the taxonomy (`featured`, `rated-N`,
+		// `exclude-from-catalog`) out of the response.
+		if ( config?.filterType === 'wc_stock_status' ) {
+			const { aggField: stockField } = resolveFilterFields( config );
+			aggregations[ filterKey ] = {
+				terms: {
+					field: stockField,
+					include: [ 'outofstock' ],
+					size: 1,
 				},
 			};
 			continue;
@@ -296,6 +318,25 @@ export function buildFilterClause( activeFilters, filterConfigs ) {
 			continue;
 		}
 		const config = filterConfigs?.[ filterKey ];
+
+		// Stock status: two-state filter against the `outofstock` term on
+		// `product_visibility`. `outofstock` selection narrows to products
+		// carrying that term; `instock` excludes them via `must_not`;
+		// selecting both is equivalent to no constraint, so the clause is
+		// dropped (otherwise the term + must_not term contradict and ES
+		// would return zero results).
+		if ( config?.filterType === 'wc_stock_status' ) {
+			const set = new Set( values.map( v => String( v ) ) );
+			const wantsOut = set.has( 'outofstock' );
+			const wantsIn = set.has( 'instock' );
+			if ( wantsOut === wantsIn ) {
+				continue;
+			}
+			const { filterField: stockField } = resolveFilterFields( config );
+			const term = { term: { [ stockField ]: 'outofstock' } };
+			must.push( wantsOut ? term : { bool: { must_not: [ term ] } } );
+			continue;
+		}
 
 		// Rating: each selected star level maps to a `≥ N - 0.5` range
 		// clause. The block is single-select so `values` is normally one

--- a/projects/packages/search/tests/js/search-blocks/api.test.js
+++ b/projects/packages/search/tests/js/search-blocks/api.test.js
@@ -526,10 +526,14 @@ describe( 'formatDateBucketLabel', () => {
 
 describe( 'product-shaped filter helpers', () => {
 	describe( 'resolveFilterFields', () => {
-		it( 'maps wc_stock_status to the indexed meta keyword field', () => {
+		it( 'maps wc_stock_status to the product_visibility taxonomy slug', () => {
+			// `_stock_status` postmeta isn't carried by the WPCOM-side ES
+			// indexer (sync sends it, the indexer drops it). The
+			// `outofstock` term on `product_visibility` IS carried, so
+			// stock-status filters route through that taxonomy instead.
 			expect( resolveFilterFields( { filterType: 'wc_stock_status' } ) ).toEqual( {
-				aggField: 'meta._stock_status.value.raw',
-				filterField: 'meta._stock_status.value.raw',
+				aggField: 'taxonomy.product_visibility.slug',
+				filterField: 'taxonomy.product_visibility.slug',
 				bucketFormat: 'plain',
 			} );
 		} );
@@ -544,15 +548,19 @@ describe( 'product-shaped filter helpers', () => {
 	} );
 
 	describe( 'buildAggregations', () => {
-		it( 'emits a terms agg for wc_stock_status', () => {
+		it( 'probes only the outofstock bucket on product_visibility for wc_stock_status', () => {
+			// The taxonomy carries other unrelated terms (`featured`,
+			// `rated-N`, `exclude-from-catalog`); `include` keeps them out
+			// of the response so the read side only has to look at one
+			// bucket. `size: 1` matches the include cardinality.
 			const aggs = buildAggregations( {
 				filter_stock_status: { filterType: 'wc_stock_status', maxItems: 10 },
 			} );
 			expect( aggs.filter_stock_status ).toEqual( {
 				terms: {
-					field: 'meta._stock_status.value.raw',
-					size: 10,
-					order: { _count: 'desc' },
+					field: 'taxonomy.product_visibility.slug',
+					include: [ 'outofstock' ],
+					size: 1,
 				},
 			} );
 		} );
@@ -624,26 +632,30 @@ describe( 'product-shaped filter helpers', () => {
 		} );
 	} );
 
-	describe( 'buildFilterClause: wc_stock_status uses the standard term branch', () => {
-		it( 'OR-joins multiple stock-status selections within the filter', () => {
-			const clause = buildFilterClause(
-				{ filter_stock_status: [ 'instock', 'outofstock' ] },
-				{ filter_stock_status: { filterType: 'wc_stock_status' } }
-			);
-			expect( clause ).toEqual( {
-				bool: {
-					must: [
-						{
-							bool: {
-								should: [
-									{ term: { 'meta._stock_status.value.raw': 'instock' } },
-									{ term: { 'meta._stock_status.value.raw': 'outofstock' } },
-								],
-							},
-						},
-					],
-				},
+	describe( 'buildFilterClause: wc_stock_status routes through product_visibility', () => {
+		const config = { filter_stock_status: { filterType: 'wc_stock_status' } };
+		const term = { term: { 'taxonomy.product_visibility.slug': 'outofstock' } };
+
+		it( 'emits a positive term clause when only outofstock is selected', () => {
+			expect( buildFilterClause( { filter_stock_status: [ 'outofstock' ] }, config ) ).toEqual( {
+				bool: { must: [ term ] },
 			} );
+		} );
+
+		it( 'emits a must_not clause when only instock is selected (taxonomy has no positive in-stock term)', () => {
+			expect( buildFilterClause( { filter_stock_status: [ 'instock' ] }, config ) ).toEqual( {
+				bool: { must: [ { bool: { must_not: [ term ] } } ] },
+			} );
+		} );
+
+		it( 'drops the clause when both options are selected — they would otherwise contradict and zero the result set', () => {
+			expect(
+				buildFilterClause( { filter_stock_status: [ 'instock', 'outofstock' ] }, config )
+			).toBeUndefined();
+		} );
+
+		it( 'ignores unknown stock-status slugs', () => {
+			expect( buildFilterClause( { filter_stock_status: [ 'mystery' ] }, config ) ).toBeUndefined();
 		} );
 	} );
 


### PR DESCRIPTION
## Why

Lets shoppers narrow products to what's buyable right now — in-stock items only, hiding out-of-stock and on-backorder results. Same fixed option keys WC uses (`instock` / `outofstock` / `onbackorder`) for data-side parity; the URL is written in the standard array form (`?filter_stock_status[]=instock&filter_stock_status[]=outofstock`) that the rest of the Search 3.0 filter blocks share, rather than WC's own comma-joined scalar form. (We don't get cross-filter deep-link interop with WC's native block, but we keep one URL shape across every Jetpack Search filter, which is what the surrounding code paths already assume.)

## Proposed changes

- `jetpack-search/filter-wc-stock-status` block (block.json, edit.js, render.php, view.js, style.scss).
- `Search_Product_Filter_Status` PHP helper class — single source of truth for the FILTER_KEY constant, fixed option list, and filterConfig shape.
- `walk_blocks_for_filter_configs` extended to recognize this block so the URL gate sees the same key the block registers at render time.
- Editor registration wired up in `register-blocks.js`.

## How

Reuses the data-plane helpers already on trunk (#48397). No new branches in `resolveFilterFields` — `wc_stock_status` filterType maps to `meta._stock_status.value.raw` via the existing dispatch table. Selected values flow through the default array-form URL writer / parser shared by every other filter block, so no per-key URL-format dispatch is required.

## Screenshots

Captured on local docker (`https://jp-atlas.jurassic.tube/`) at 1440x900 against this branch.

| Before (no filter block) | After (block inserted, no selection) |
|---|---|
| ![before](https://github.com/user-attachments/assets/81254f6a-c43a-44a6-9cef-1d204725b0d5) | ![after-empty](https://github.com/user-attachments/assets/2166bab1-3f52-4a33-af19-c202eff43f11) |

| One option selected | Two options selected (array URL) |
|---|---|
| ![after-instock](https://github.com/user-attachments/assets/5e685211-f40f-485f-b22d-6f275f7a7c96) | ![after-multi](https://github.com/user-attachments/assets/ed0de256-2f90-4b2b-81d5-a47abb49b194) |

URL after multi-select: `?filter_stock_status[]=instock&filter_stock_status[]=outofstock` — same array form every other Search 3.0 filter writes. Active-filters chips and `Clear all` render alongside the selected options.

> Stock-status counts show `0` because the dev env runs Jetpack in offline mode (no Search-as-a-Service backend) so the per-status aggregation buckets aren't populated. The category filter and result count populate via the in-memory ES fallback.

## Stack

**PR-2 of 9** closing [RSM-1929](https://linear.app/a8c/issue/RSM-1929). Stacks on PR-1 #48446 (foundation = `search/foundation`).

## Related

- Epic: [RSM-1929](https://linear.app/a8c/issue/RSM-1929)
- WC label i18n follow-up: [RSM-1932](https://linear.app/a8c/issue/RSM-1932)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Stack PR-1 (#48446) + this PR.
2. Insert `jetpack-search/filter-wc-stock-status` on a search page or template.
3. With a WC store + `/?s=shirt`: click "In stock" → URL gains `?filter_stock_status[]=instock` (array form). Reload the URL — the option stays checked.
4. Hit back/forward → state restores.
5. Run `pnpm exec jest tests/js/search-blocks` and `composer phpunit` from `projects/packages/search`.


