### PR TITLE
Search 3.0: add jetpack-search/filter-wc-rating block (RSM-1929)

### DIFF
--- a/projects/packages/search/changelog/add-filter-wc-rating
+++ b/projects/packages/search/changelog/add-filter-wc-rating
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search 3.0: adds the `jetpack-search/filter-wc-rating` block — five star rows (5..1) backed by a histogram aggregation on `meta._wc_average_rating.double` (interval=1, offset=0.5). View and render project the half-integer histogram bucket keys onto star integers via the same logic as `WC_RATING_RANGES` in `store/api.js`. Selecting multiple star levels OR-s their non-overlapping ranges. URL contract is the default `?rating_filter[]=5` array form (mirrors instant-search). Tracked under epic [RSM-1929].

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/block.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "jetpack-search/filter-wc-rating",
+	"version": "0.1.0",
+	"title": "Filter by Rating",
+	"category": "jetpack-search",
+	"icon": "star-filled",
+	"description": "Let shoppers filter products by star rating. Powered by Jetpack Search.",
+	"supports": {
+		"html": false,
+		"interactivity": true,
+		"spacing": {
+			"margin": [ "top", "bottom" ],
+			"padding": true,
+			"blockGap": true
+		}
+	},
+	"textdomain": "jetpack-search-pkg",
+	"attributes": {
+		"label": { "type": "string", "default": "" },
+		"showCount": { "type": "boolean", "default": true }
+	},
+	"render": "file:./render.php",
+	"viewScriptModule": "file:../../../../build/search-blocks/filter-wc-rating.js",
+	"style": "file:../../../../build/search-blocks/filter-wc-rating.css"
+}

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/class-filter-wc-rating.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/class-filter-wc-rating.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Filter by WC rating block helpers.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+/**
+ * Helper methods for the jetpack-search/filter-wc-rating block.
+ *
+ * Filter key + filterConfig shape live here so render.php and the
+ * post-content walker (Search_Blocks::walk_blocks_for_filter_configs)
+ * agree on what this block contributes to the shared store. The
+ * `wc_rating` filterType drives the histogram aggregation + per-star range
+ * filter clauses in store/api.js — see `WC_RATING_RANGES`.
+ */
+class Filter_Wc_Rating {
+
+	/**
+	 * URL key + interactivity-state filter key for rating selections.
+	 *
+	 * Mirrors WooCommerce's native URL contract
+	 * (`?rating_filter[]=4&rating_filter[]=5`) so deep links interoperate
+	 * with WC's own rating filter — and so a future bridge would not need
+	 * to translate keys between the two systems.
+	 */
+	const FILTER_KEY = 'rating_filter';
+
+	/**
+	 * Stable star option list for rendering. Highest first matches the
+	 * conventional e-commerce "4 stars & up, 3 stars & up, …" ordering;
+	 * since the underlying ES range clauses are non-overlapping (star=4
+	 * means avg ∈ [3.5, 4.5), not "≥ 3.5"), the visible label may say
+	 * "& up" but the selection semantics are exact buckets — multi-select
+	 * to OR adjacent stars together.
+	 *
+	 * @return int[] Star values 5..1.
+	 */
+	public static function get_star_values(): array {
+		return array( 5, 4, 3, 2, 1 );
+	}
+
+	/**
+	 * Filter key derivation. Constant for this block — the rating field is
+	 * always `meta._wc_average_rating.double`, so there's no per-instance
+	 * variation. Method form mirrors Filter_Checkbox::derive_filter_key.
+	 *
+	 * @param array $attributes Block attributes (unused; present for interface parity).
+	 * @return string
+	 */
+	public static function derive_filter_key( array $attributes = array() ): string { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		return self::FILTER_KEY;
+	}
+
+	/**
+	 * Default group label when the block author leaves the label attribute
+	 * empty.
+	 *
+	 * @return string
+	 */
+	public static function default_label(): string {
+		return __( 'Rating', 'jetpack-search-pkg' );
+	}
+
+	/**
+	 * Build the filterConfig entry this block contributes to the shared
+	 * Interactivity state. JS reads `filterType: 'wc_rating'` to switch
+	 * `buildAggregations` to a histogram and `buildFilterClause` to the
+	 * per-star range path.
+	 *
+	 * @param array  $attributes Block attributes.
+	 * @param string $key        Filter key (ignored; always FILTER_KEY).
+	 * @return array<string, mixed>
+	 */
+	public static function build_config( array $attributes, string $key = '' ): array { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$label = sanitize_text_field( (string) ( $attributes['label'] ?? '' ) );
+		if ( '' === $label ) {
+			$label = static::default_label();
+		}
+
+		return array(
+			'filterKey'  => self::FILTER_KEY,
+			'filterType' => 'wc_rating',
+			'label'      => $label,
+			'showCount'  => (bool) ( $attributes['showCount'] ?? true ),
+		);
+	}
+}

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/edit.js
@@ -1,0 +1,105 @@
+/**
+ * Editor preview for jetpack-search/filter-wc-rating.
+ *
+ * Mirrors the runtime DOM shape — labeled list with five star rows and
+ * optional count badges — so designers can style the rating filter in
+ * place. Inspector exposes the user-tunable attributes (label, showCount).
+ */
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
+import { __, _n, sprintf } from '@wordpress/i18n';
+
+const STAR_VALUES = [ 5, 4, 3, 2, 1 ];
+const SAMPLE_COUNTS = { 5: 18, 4: 12, 3: 5, 2: 1, 1: 0 };
+const DEFAULT_LABEL = __( 'Rating', 'jetpack-search-pkg' );
+
+/**
+ * Render a 5-glyph star row showing `filled` of them as filled and the rest empty.
+ *
+ * @param {number} filled - How many stars to render filled (1–5).
+ * @return {object[]} Array of star span elements.
+ */
+function renderStars( filled ) {
+	const stars = [];
+	for ( let i = 1; i <= 5; i++ ) {
+		stars.push(
+			<span
+				key={ i }
+				className={
+					'jetpack-search-filter-rating__star ' + ( i <= filled ? 'is-filled' : 'is-empty' )
+				}
+				aria-hidden="true"
+			>
+				★
+			</span>
+		);
+	}
+	return stars;
+}
+
+/**
+ * Edit component for the filter-wc-rating block.
+ *
+ * @param {object}   props               - Block props.
+ * @param {object}   props.attributes    - Saved block attributes.
+ * @param {Function} props.setAttributes - Attribute setter.
+ * @return {object} Rendered element.
+ */
+export default function FilterWcRatingEdit( { attributes, setAttributes } ) {
+	const blockProps = useBlockProps( { className: 'jetpack-search-filter-wc-rating' } );
+	const rawLabel = attributes?.label || '';
+	const previewLabel = rawLabel || DEFAULT_LABEL;
+	const showCount = attributes?.showCount !== false;
+
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings', 'jetpack-search-pkg' ) }>
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Label', 'jetpack-search-pkg' ) }
+						value={ rawLabel }
+						placeholder={ DEFAULT_LABEL }
+						onChange={ value => setAttributes( { label: value } ) }
+						help={ __(
+							'Heading shown above the star rows. Leave empty for the default.',
+							'jetpack-search-pkg'
+						) }
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Show result counts', 'jetpack-search-pkg' ) }
+						checked={ showCount }
+						onChange={ value => setAttributes( { showCount: !! value } ) }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div { ...blockProps }>
+				<h3 className="jetpack-search-filter__title">{ previewLabel }</h3>
+				<ul className="jetpack-search-filter__list">
+					{ STAR_VALUES.map( star => {
+						/* translators: %d: number of stars (1-5). */
+						const aria = sprintf( _n( '%d star', '%d stars', star, 'jetpack-search-pkg' ), star );
+						return (
+							<li key={ star } className="jetpack-search-filter__item">
+								{ /* eslint-disable-next-line jsx-a11y/label-has-associated-control -- the input is a direct child, implicit HTML5 association applies; rule's nesting heuristic doesn't trace through sibling spans */ }
+								<label>
+									<input type="checkbox" disabled />
+									<span className="jetpack-search-filter__label" aria-label={ aria }>
+										{ renderStars( star ) }
+									</span>
+									{ showCount && (
+										<span className="jetpack-search-filter__count">
+											{ String( SAMPLE_COUNTS[ star ] ) }
+										</span>
+									) }
+								</label>
+							</li>
+						);
+					} ) }
+				</ul>
+			</div>
+		</>
+	);
+}

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/render.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Filter by WC rating render.
+ *
+ * Emits a fixed five-row star list (5..1 stars) and registers the
+ * filterConfig with the shared `jetpack-search` Interactivity store.
+ * Counts come from the histogram aggregation registered in
+ * `buildAggregations` for the `wc_rating` filterType — bucket keys land
+ * on half-integer boundaries (0.5, 1.5, 2.5, 3.5, 4.5), each
+ * corresponding to one star band per WC's `ROUND(avg_rating, 0)` rule.
+ *
+ * Always-show-all-options matches WC's UX: even rows whose count is 0
+ * remain visible and clickable so the user has a stable list to scan.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+
+if ( ! function_exists( 'wp_interactivity_state' ) ) {
+	return;
+}
+
+// @phan-suppress-next-line PhanUndeclaredGlobalVariable
+$config = Filter_Wc_Rating::build_config( (array) $attributes );
+
+wp_interactivity_state(
+	'jetpack-search',
+	array(
+		'filterConfigs' => array(
+			Filter_Wc_Rating::FILTER_KEY => $config,
+		),
+	)
+);
+
+$view = Search_Blocks::pre_hydration_filter_view( Filter_Wc_Rating::FILTER_KEY );
+
+$seeded_state    = wp_interactivity_state( 'jetpack-search' );
+$seeded_aggs     = (array) ( $seeded_state['aggregations'] ?? array() );
+$seeded_buckets  = (array) ( ( (array) ( $seeded_aggs[ Filter_Wc_Rating::FILTER_KEY ] ?? array() ) )['buckets'] ?? array() );
+$seeded_active   = (array) ( $seeded_state['activeFilters'] ?? array() );
+$seeded_selected = (array) ( $seeded_active[ Filter_Wc_Rating::FILTER_KEY ] ?? array() );
+
+// Project histogram buckets keyed at .5 boundaries onto star values
+// 1..5. Bucket key 4.5 → star 5, 3.5 → star 4, etc. Anything below 0.5
+// (the "no rating" bucket the histogram emits at -0.5 thanks to
+// min_doc_count: 0) is dropped since there's no UI option for it.
+$counts_by_star = array();
+foreach ( $seeded_buckets as $bucket ) {
+	$key   = (float) ( $bucket['key'] ?? -1 );
+	$count = (int) ( $bucket['doc_count'] ?? 0 );
+	// Map .5-boundary key → star integer. Equivalent to (int) round( $key + 0.5 ).
+	$star = (int) ( $key + 1.0 );
+	if ( $star >= 1 && $star <= 5 ) {
+		$counts_by_star[ (string) $star ] = $count;
+	}
+}
+
+$label      = (string) $config['label'];
+$show_count = (bool) $config['showCount'];
+?>
+<div
+	<?php echo wp_kses_data( get_block_wrapper_attributes( array( 'class' => 'jetpack-search-filter-wc-rating' ) ) ); ?>
+	data-wp-interactive="jetpack-search"
+	<?php Search_Blocks::emit_filter_wrapper_context( Filter_Wc_Rating::FILTER_KEY, $view['show_wrapper'] ); ?>
+	data-wp-bind--hidden="context.wrapperHidden"
+	data-wp-watch="callbacks.syncFilterWrapperVisibility"
+	<?php echo $view['show_wrapper'] ? '' : 'hidden'; ?>
+>
+	<?php if ( '' !== $label ) : ?>
+		<h3 class="jetpack-search-filter__title"><?php echo esc_html( $label ); ?></h3>
+	<?php endif; ?>
+	<?php
+	if ( $view['is_initial_loading'] ) {
+		require __DIR__ . '/../filter-skeleton-partial.php';
+	}
+	?>
+	<ul class="jetpack-search-filter__list">
+		<?php foreach ( Filter_Wc_Rating::get_star_values() as $star ) : ?>
+			<?php
+			$value      = (string) $star;
+			$is_checked = in_array( $value, $seeded_selected, true );
+			$option_cnt = $counts_by_star[ $value ] ?? 0;
+			/* translators: %d: number of stars (1-5). Used as the accessible name for the star-rating row. */
+			$aria_label = sprintf( _n( '%d star', '%d stars', $star, 'jetpack-search-pkg' ), $star );
+			?>
+			<li
+				class="jetpack-search-filter__item"
+				<?php echo wp_kses_data( wp_interactivity_data_wp_context( array( 'starValue' => $value ) ) ); ?>
+			>
+				<label>
+					<input
+						type="checkbox"
+						value="<?php echo esc_attr( $value ); ?>"
+						<?php checked( $is_checked ); ?>
+						data-wp-bind--checked="state.isRatingOptionSelected"
+						data-wp-on--change="actions.onRatingFilterChange"
+					/>
+					<span class="jetpack-search-filter__label" aria-label="<?php echo esc_attr( $aria_label ); ?>">
+						<?php
+						// Render the star-row as filled vs. empty stars so the
+						// row is recognizable without JS-side icon code; the
+						// aria-label above carries the accessible text.
+						for ( $i = 1; $i <= 5; $i++ ) :
+							?>
+							<span
+								class="jetpack-search-filter-rating__star <?php echo $i <= $star ? 'is-filled' : 'is-empty'; ?>"
+								aria-hidden="true"
+							>★</span>
+						<?php endfor; ?>
+					</span>
+					<?php if ( $show_count ) : ?>
+						<span
+							class="jetpack-search-filter__count"
+							data-wp-text="state.ratingOptionCount"
+						><?php echo esc_html( (string) $option_cnt ); ?></span>
+					<?php endif; ?>
+				</label>
+			</li>
+		<?php endforeach; ?>
+	</ul>
+</div>

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/style.scss
@@ -1,17 +1,57 @@
-/**
- * Filter by WC rating.
- *
- * Inherits the shared `.jetpack-search-filter__list/__item/__label/__count`
- * styles from the generic filter-checkbox block. This file adds the
- * filled vs. empty star coloring so the row is visually scannable without
- * relying on icon assets.
- */
+@use "../skeleton" as skeleton;
+
 .jetpack-search-filter-wc-rating {
 
+	&[hidden] {
+		display: none;
+	}
+
+	@include skeleton.shimmer;
+	@include skeleton.filter-rows;
+
+	.jetpack-search-filter__title {
+		font-size: 0.85rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		margin: 0 0 0.5rem;
+		color: inherit;
+	}
+
 	.jetpack-search-filter__list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
 		display: flex;
 		flex-direction: column;
 		gap: 0.25rem;
+	}
+
+	.jetpack-search-filter__item {
+		padding: 0.25rem 0;
+
+		label {
+			display: flex;
+			align-items: center;
+			gap: 0.5rem;
+			cursor: pointer;
+		}
+	}
+
+	.jetpack-search-filter__label {
+		flex: 1;
+	}
+
+	.jetpack-search-filter__count {
+		font-size: 0.8rem;
+		color: inherit;
+		background: color-mix(in sRGB, currentColor 12%, transparent);
+		border-radius: 10px;
+		padding: 0 0.4rem;
+
+		&[hidden] {
+			display: none;
+		}
 	}
 
 	// Stars are inline-rendered text glyphs (★) styled with color so the

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/style.scss
@@ -1,0 +1,34 @@
+/**
+ * Filter by WC rating.
+ *
+ * Inherits the shared `.jetpack-search-filter__list/__item/__label/__count`
+ * styles from the generic filter-checkbox block. This file adds the
+ * filled vs. empty star coloring so the row is visually scannable without
+ * relying on icon assets.
+ */
+.jetpack-search-filter-wc-rating {
+
+	.jetpack-search-filter__list {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+
+	// Stars are inline-rendered text glyphs (★) styled with color so the
+	// markup stays SVG-free and survives WP's content-export pipeline.
+	// Matches WC's color cues — gold for filled, muted gray for empty —
+	// without pulling in WC's icon asset.
+	.jetpack-search-filter-rating__star {
+		display: inline-block;
+		font-size: 1.05em;
+		line-height: 1;
+
+		&.is-filled {
+			color: #f0b800;
+		}
+
+		&.is-empty {
+			color: #c8c8c8;
+		}
+	}
+}

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-rating/view.js
@@ -1,0 +1,93 @@
+import { store, getContext } from '@wordpress/interactivity';
+import '../../store';
+import './style.scss';
+
+const NAMESPACE = 'jetpack-search';
+
+/**
+ * Project a histogram bucket array onto a star → count map.
+ *
+ * Bucket keys land on half-integer boundaries (0.5, 1.5, 2.5, 3.5, 4.5)
+ * thanks to the `interval: 1, offset: 0.5` aggregation. Each maps to one
+ * star band per WC's `ROUND(avg_rating, 0)` rule: 4.5 → star 5, 3.5 →
+ * star 4, etc. Buckets outside that range (the implicit -0.5 "no rating"
+ * bucket from `min_doc_count: 0`) are ignored — there's no UI option
+ * for them. Mirrors the same projection in render.php.
+ *
+ * @param {Array<{key: number, doc_count: number}>} buckets - Aggregation buckets.
+ * @return {Object<string, number>} Star (as string key, "1".."5") → count.
+ */
+function bucketsToStarCountMap( buckets ) {
+	if ( ! Array.isArray( buckets ) ) {
+		return {};
+	}
+	const map = {};
+	for ( const bucket of buckets ) {
+		const key = Number( bucket?.key ?? -1 );
+		const count = Number( bucket?.doc_count ?? 0 );
+		// .5-boundary key → star integer. Equivalent to Math.round(key + 0.5).
+		const star = Math.trunc( key + 1.0 );
+		if ( star >= 1 && star <= 5 ) {
+			map[ String( star ) ] = count;
+		}
+	}
+	return map;
+}
+
+store( NAMESPACE, {
+	state: {
+		/**
+		 * `data-wp-bind--checked` per-star option. Reads the star value
+		 * from the row's `data-wp-context` (set by render.php on each
+		 * `<li>`), so one getter serves all five rows without DOM
+		 * queries or relying on an unstable `attributes` shape.
+		 *
+		 * @return {boolean} Whether this star value is in activeFilters.
+		 */
+		get isRatingOptionSelected() {
+			const { filterKey, starValue } = getContext();
+			if ( ! starValue ) {
+				return false;
+			}
+			const { state } = store( NAMESPACE );
+			const selected = state.activeFilters?.[ filterKey ];
+			return Array.isArray( selected ) && selected.includes( starValue );
+		},
+
+		/**
+		 * `data-wp-text` per-row count badge. Reads the star value from
+		 * the row's `data-wp-context` (set by render.php on each `<li>`)
+		 * and looks up the projected histogram count for that star.
+		 * Falls back to "0" when the row has no matches — convention for
+		 * "always show all options" facet UIs.
+		 *
+		 * @return {string} Count as a string for the badge text node.
+		 */
+		get ratingOptionCount() {
+			const { filterKey, starValue } = getContext();
+			if ( ! starValue ) {
+				return '0';
+			}
+			const { state } = store( NAMESPACE );
+			const buckets = state.aggregations?.[ filterKey ]?.buckets;
+			const counts = bucketsToStarCountMap( buckets );
+			return String( counts[ starValue ] ?? 0 );
+		},
+	},
+
+	actions: {
+		/**
+		 * Toggle the star value that owns the change event. The input's
+		 * `value` attribute carries the star (1–5) as a string; filterKey
+		 * comes from the wrapper context.
+		 *
+		 * @param {Event} event - Change event.
+		 * @yield {Promise} setFilter action.
+		 */
+		*onRatingFilterChange( event ) {
+			const { actions } = store( NAMESPACE );
+			const { filterKey } = getContext();
+			yield actions.setFilter( filterKey, event.target.value );
+		},
+	},
+} );

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -579,8 +579,9 @@ class Search_Blocks {
 	 */
 	protected static function filter_block_helpers(): array {
 		return array(
-			'jetpack-search/filter-checkbox' => Filter_Checkbox::class,
-			'jetpack-search/filter-date'     => Filter_Date::class,
+			'jetpack-search/filter-checkbox'  => Filter_Checkbox::class,
+			'jetpack-search/filter-date'      => Filter_Date::class,
+			'jetpack-search/filter-wc-rating' => Filter_Wc_Rating::class,
 		);
 	}
 

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -22,6 +22,7 @@ import ActiveFiltersEdit from '../blocks/active-filters/edit';
 import FilterCheckboxEdit from '../blocks/filter-checkbox/edit';
 import FilterDateEdit from '../blocks/filter-date/edit';
 import FilterPostTypeEdit from '../blocks/filter-post-type/edit';
+import FilterWcRatingEdit from '../blocks/filter-wc-rating/edit';
 import FiltersPopoverEdit, { save as filtersPopoverSave } from '../blocks/filters-popover/edit';
 import FiltersStackEdit, { save as filtersStackSave } from '../blocks/filters-stack/edit';
 import PoweredByEdit from '../blocks/powered-by/edit';
@@ -53,6 +54,7 @@ const BLOCKS = [
 	[ 'jetpack-search/results-load-more', ResultsLoadMoreEdit ],
 	[ 'jetpack-search/search-results', SearchResultsEdit, searchResultsSave ],
 	[ 'jetpack-search/powered-by', PoweredByEdit ],
+	[ 'jetpack-search/filter-wc-rating', FilterWcRatingEdit ],
 ];
 
 // Shape the "Jetpack Search" block category to match the Forms / Monetize /

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -47,6 +47,7 @@ const BLOCKS = [
 	[ 'jetpack-search/filter-date', FilterDateEdit ],
 	[ 'jetpack-search/active-filters', ActiveFiltersEdit ],
 	[ 'jetpack-search/filter-post-type', FilterPostTypeEdit ],
+	[ 'jetpack-search/filter-wc-rating', FilterWcRatingEdit ],
 	[ 'jetpack-search/filters-stack', FiltersStackEdit, filtersStackSave ],
 	[ 'jetpack-search/filters-popover', FiltersPopoverEdit, filtersPopoverSave ],
 	[ 'jetpack-search/results-sort', ResultsSortEdit ],
@@ -54,7 +55,6 @@ const BLOCKS = [
 	[ 'jetpack-search/results-load-more', ResultsLoadMoreEdit ],
 	[ 'jetpack-search/search-results', SearchResultsEdit, searchResultsSave ],
 	[ 'jetpack-search/powered-by', PoweredByEdit ],
-	[ 'jetpack-search/filter-wc-rating', FilterWcRatingEdit ],
 ];
 
 // Shape the "Jetpack Search" block category to match the Forms / Monetize /

--- a/projects/packages/search/tests/php/Filter_Wc_Rating_Test.php
+++ b/projects/packages/search/tests/php/Filter_Wc_Rating_Test.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Filter_Wc_Rating helper tests.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for Filter_Wc_Rating helpers.
+ */
+class Filter_Wc_Rating_Test extends TestCase {
+
+	/**
+	 * Filter key is `rating_filter` regardless of attributes.
+	 */
+	public function test_derive_filter_key_returns_rating_filter_constant() {
+		$this->assertSame( 'rating_filter', Filter_Wc_Rating::FILTER_KEY );
+		$this->assertSame( 'rating_filter', Filter_Wc_Rating::derive_filter_key( array() ) );
+		$this->assertSame( 'rating_filter', Filter_Wc_Rating::derive_filter_key( array( 'ignored' => 'value' ) ) );
+	}
+
+	/**
+	 * Pin the dev-time invariant that FILTER_KEY isn't reserved.
+	 */
+	public function test_filter_key_does_not_collide_with_reserved_params() {
+		$this->assertNotContains( Filter_Wc_Rating::FILTER_KEY, Search_Blocks::RESERVED_QUERY_PARAMS );
+	}
+
+	/**
+	 * Default label.
+	 */
+	public function test_default_label_returns_rating() {
+		$this->assertSame( 'Rating', Filter_Wc_Rating::default_label() );
+	}
+
+	/**
+	 * Star values list is 5..1 (descending).
+	 */
+	public function test_get_star_values_returns_five_to_one() {
+		$this->assertSame( array( 5, 4, 3, 2, 1 ), Filter_Wc_Rating::get_star_values() );
+	}
+
+	/**
+	 * Config shape and defaults.
+	 */
+	public function test_build_config_shape_and_defaults() {
+		$config = Filter_Wc_Rating::build_config( array() );
+		$this->assertSame(
+			array(
+				'filterKey'  => 'rating_filter',
+				'filterType' => 'wc_rating',
+				'label'      => 'Rating',
+				'showCount'  => true,
+			),
+			$config
+		);
+	}
+
+	/**
+	 * Custom attributes are reflected in the config.
+	 */
+	public function test_build_config_with_custom_attributes() {
+		$config = Filter_Wc_Rating::build_config(
+			array(
+				'label'     => 'Product Rating',
+				'showCount' => false,
+			)
+		);
+		$this->assertSame( 'Product Rating', $config['label'] );
+		$this->assertFalse( $config['showCount'] );
+		$this->assertSame( 'rating_filter', $config['filterKey'] );
+		$this->assertSame( 'wc_rating', $config['filterType'] );
+	}
+
+	/**
+	 * Empty label falls back to the default.
+	 */
+	public function test_build_config_empty_label_falls_back_to_default() {
+		$config = Filter_Wc_Rating::build_config( array( 'label' => '' ) );
+		$this->assertSame( 'Rating', $config['label'] );
+	}
+
+	/**
+	 * Label is sanitize_text_field()'d before it reaches Interactivity state.
+	 */
+	public function test_build_config_sanitizes_label() {
+		$config = Filter_Wc_Rating::build_config(
+			array( 'label' => "  <b>Stars</b>\nextra  " )
+		);
+		$this->assertSame( 'Stars extra', $config['label'] );
+	}
+}


### PR DESCRIPTION
## Why

Lets shoppers narrow results to better-reviewed items — five star rows snap to WooCommerce's average-rating buckets so a single tap shows everything 4+ stars. Multiple stars OR their non-overlapping ranges, matching WC's native rating filter behaviour.

## What

Adds `jetpack-search/filter-wc-rating` — a fixed five-row star list (5..1) backed by a WC-compatible histogram aggregation on `meta._wc_average_rating.double`.

**How the bucket → star mapping works.** The aggregation uses `interval: 1, offset: 0.5`, so bucket keys land at half-integer boundaries (0.5, 1.5, 2.5, 3.5, 4.5). Each bucket key maps to one star band per WC's `ROUND(avg_rating, 0)` rule (4.5 → ★★★★★, 3.5 → ★★★★, …). The "no rating" bucket at -0.5 is dropped — there's no UI option for it, mirroring WC's own filter. View and render use the same projection logic.

Selecting multiple star levels OR-s their non-overlapping `bool.should` clauses via the existing `buildFilterClause` path. URL contract: `?rating_filter[]=5&rating_filter[]=4` (mirrors instant-search).

**PHP:**
- `Filter_Wc_Rating` helper class (`FILTER_KEY`, `get_star_values`, `derive_filter_key`, `default_label`, `build_config`)
- `walk_blocks_for_filter_configs` in `Search_Blocks` extended to recognise this block

## Stack (PR 3 of 9)

> Foundation = #48446 (`search/foundation`). **Merge foundation first.**

| # | Branch | Description | PR |
|---|--------|-------------|-----|
| 1 | `search/foundation` | Data-plane additions for product filter blocks | #48446 |
| 2 | `search/product-filter-attribute` | WC attribute filter block | #48447 |
| **3** | **`search/product-filter-rating`** | **WC rating filter block (this PR)** | **#48448** |
| 4–9 | … | Remaining filter types | … |

## Testing instructions

1. Activate WooCommerce + Jetpack Search on a test site with products that have ratings.
2. Add the **Filter by Rating** block (`jetpack-search/filter-wc-rating`) to a search results template or sidebar.
3. Confirm five star rows (5 down to 1) render with counts.
4. Select "4 stars" — results should show only products with avg rating 3.5–4.5.
5. Select "4 stars" + "5 stars" — results should OR the two buckets.
6. Confirm the URL reflects `?rating_filter[]=4&rating_filter[]=5`.

<img width="1414" height="641" alt="image" src="https://github.com/user-attachments/assets/4685cc7b-1389-49f1-8368-25da8f3971b0" />


## Changelog

`projects/packages/search/changelog/add-filter-wc-rating`

Refs [RSM-1929](https://linear.app/a8c/issue/RSM-1929)