### PR TITLE
Search 3.0: WC price filter block

### DIFF
--- a/projects/packages/search/changelog/add-filter-wc-price
+++ b/projects/packages/search/changelog/add-filter-wc-price
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search 3.0: adds the `jetpack-search/filter-wc-price` block — two number inputs (min, max) bound to the shared store's `priceRange` slice. Drives `actions.setPriceRange` on `change` / Enter. URL contract uses `min_price` / `max_price` reserved query params. The block seeds `priceCurrencySymbol` and `priceLabel` into the shared store so the active-filters chip block can render budget-filtered URLs correctly. Tracked under epic [RSM-1929].

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-price/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-price/block.json
@@ -1,0 +1,28 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "jetpack-search/filter-wc-price",
+	"version": "0.1.0",
+	"title": "Filter by Price",
+	"category": "jetpack-search",
+	"icon": "money-alt",
+	"description": "Let shoppers filter products by minimum and maximum price. Powered by Jetpack Search.",
+	"supports": {
+		"html": false,
+		"interactivity": true,
+		"spacing": {
+			"margin": [ "top", "bottom" ],
+			"padding": true,
+			"blockGap": true
+		}
+	},
+	"textdomain": "jetpack-search-pkg",
+	"attributes": {
+		"label": { "type": "string", "default": "" },
+		"currencySymbol": { "type": "string", "default": "" },
+		"currencySymbolPosition": { "type": "string", "default": "" }
+	},
+	"render": "file:./render.php",
+	"viewScriptModule": "file:../../../../build/search-blocks/filter-wc-price.js",
+	"style": "file:../../../../build/search-blocks/filter-wc-price.css"
+}

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-price/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-price/edit.js
@@ -1,0 +1,124 @@
+/**
+ * Editor preview for jetpack-search/filter-wc-price.
+ *
+ * Mirrors the runtime DOM shape — two disabled number inputs joined by
+ * an em-dash — so designers can style the price field in place.
+ * Inspector exposes the user-tunable attributes (label, currency symbol,
+ * symbol position). When the author leaves the symbol/position blank we
+ * fall through to whatever WooCommerce is configured for this site, so
+ * an AUD store gets `A$` and an SEK store gets `100 kr` out of the box.
+ */
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, SelectControl, TextControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+const DEFAULT_LABEL = __( 'Price', 'jetpack-search-pkg' );
+
+/**
+ * Read currency symbol + position from `window.wcSettings.currency` (set by
+ * WooCommerce's `wc-settings` script). When WC isn't loaded these defaults
+ * keep the editor renderable on a plain WP install.
+ *
+ * @return {{symbol: string, position: 'left'|'right'}} Effective WC defaults.
+ */
+function getWcDefaults() {
+	const currency = ( typeof window !== 'undefined' && window.wcSettings?.currency ) || {};
+	const rawPos = String( currency.position || 'left' );
+	return {
+		symbol: String( currency.symbol || '$' ),
+		position: rawPos.startsWith( 'right' ) ? 'right' : 'left',
+	};
+}
+
+/**
+ * Edit component for the filter-wc-price block.
+ *
+ * @param {object}   props               - Block props.
+ * @param {object}   props.attributes    - Saved block attributes.
+ * @param {Function} props.setAttributes - Attribute setter.
+ * @return {object} Rendered element.
+ */
+export default function FilterWcPriceEdit( { attributes, setAttributes } ) {
+	const blockProps = useBlockProps( { className: 'jetpack-search-filter-wc-price' } );
+	const wcDefaults = getWcDefaults();
+	const rawLabel = attributes?.label || '';
+	const previewLabel = rawLabel || DEFAULT_LABEL;
+	const effectiveSymbol = ( attributes?.currencySymbol || wcDefaults.symbol ).slice( 0, 2 );
+	const effectivePosition = attributes?.currencySymbolPosition || wcDefaults.position;
+	const fieldClass = `jetpack-search-filter-wc-price__field jetpack-search-filter-wc-price__field--${ effectivePosition }`;
+
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings', 'jetpack-search-pkg' ) }>
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Label', 'jetpack-search-pkg' ) }
+						value={ rawLabel }
+						placeholder={ DEFAULT_LABEL }
+						onChange={ value => setAttributes( { label: value } ) }
+					/>
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Currency symbol', 'jetpack-search-pkg' ) }
+						value={ attributes?.currencySymbol || '' }
+						placeholder={ wcDefaults.symbol }
+						maxLength={ 2 }
+						onChange={ value => setAttributes( { currencySymbol: value } ) }
+						help={ __(
+							'Leave blank to use the active WooCommerce currency.',
+							'jetpack-search-pkg'
+						) }
+					/>
+					<SelectControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Symbol position', 'jetpack-search-pkg' ) }
+						value={ attributes?.currencySymbolPosition || '' }
+						options={ [
+							{
+								value: '',
+								label: __( 'Default (WooCommerce)', 'jetpack-search-pkg' ),
+							},
+							{ value: 'left', label: __( 'Before amount', 'jetpack-search-pkg' ) },
+							{ value: 'right', label: __( 'After amount', 'jetpack-search-pkg' ) },
+						] }
+						onChange={ value => setAttributes( { currencySymbolPosition: value } ) }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div { ...blockProps }>
+				<h3 className="jetpack-search-filter__title">{ previewLabel }</h3>
+				<div className="jetpack-search-filter-wc-price__inputs">
+					<div className={ fieldClass }>
+						<span className="jetpack-search-filter-wc-price__symbol" aria-hidden="true">
+							{ effectiveSymbol }
+						</span>
+						<input
+							className="jetpack-search-filter-wc-price__input jetpack-search-filter-wc-price__input--min"
+							type="number"
+							placeholder={ __( 'Min', 'jetpack-search-pkg' ) }
+							disabled
+						/>
+					</div>
+					<span className="jetpack-search-filter-wc-price__separator" aria-hidden="true">
+						–
+					</span>
+					<div className={ fieldClass }>
+						<span className="jetpack-search-filter-wc-price__symbol" aria-hidden="true">
+							{ effectiveSymbol }
+						</span>
+						<input
+							className="jetpack-search-filter-wc-price__input jetpack-search-filter-wc-price__input--max"
+							type="number"
+							placeholder={ __( 'Max', 'jetpack-search-pkg' ) }
+							disabled
+						/>
+					</div>
+				</div>
+			</div>
+		</>
+	);
+}

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-price/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-price/render.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Search product filter — price render.
+ *
+ * Two number inputs (min, max) bound to the shared store's `priceRange`
+ * slice. Unlike the other product filter blocks, this one doesn't
+ * register a filterConfig — `priceRange` is its own state branch with a
+ * dedicated `actions.setPriceRange` action and the `min_price` /
+ * `max_price` URL params are already in `RESERVED_QUERY_PARAMS`.
+ *
+ * First-paint values are seeded from `state.priceRange` (which the PHP
+ * state-builder parses from the URL) so a deep link like
+ * `/?s=&min_price=10` shows "10" in the min input before JS hydrates.
+ *
+ * Currency-symbol display uses the block author's chosen symbol; the
+ * stored value is the raw number so URL contracts and ES range clauses
+ * stay locale-agnostic.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+
+if ( ! function_exists( 'wp_interactivity_state' ) ) {
+	return;
+}
+
+// @phan-suppress-next-line PhanUndeclaredGlobalVariable
+$attrs    = (array) $attributes;
+$label    = sanitize_text_field( (string) ( $attrs['label'] ?? '' ) );
+$symbol   = sanitize_text_field( (string) ( $attrs['currencySymbol'] ?? '' ) );
+$position = sanitize_text_field( (string) ( $attrs['currencySymbolPosition'] ?? '' ) );
+
+if ( '' === $label ) {
+	$label = __( 'Price', 'jetpack-search-pkg' );
+}
+
+// Empty author values fall through to the active WooCommerce settings so a
+// site running AUD gets `A$` adornments out-of-the-box. WC bridges via the
+// public-facing helper / option, both safe to call when WC isn't loaded
+// (the function_exists guard handles that). The `$` / `left` fallbacks
+// keep the block usable on a plain WP install while the author wires WC up.
+if ( '' === $symbol && function_exists( 'get_woocommerce_currency_symbol' ) ) {
+	// @phan-suppress-next-line PhanUndeclaredFunction
+	$wc_symbol = (string) get_woocommerce_currency_symbol();
+	// WC returns symbols as HTML entities (e.g. `&#36;`, `&euro;`). Decode
+	// once so the downstream `mb_substr` operates on a single character
+	// instead of half an entity, and so `esc_html` at output produces a
+	// single round-trip — not double-encoded text.
+	$symbol = html_entity_decode( $wc_symbol, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+}
+if ( '' === $symbol ) {
+	$symbol = '$';
+}
+if ( '' === $position ) {
+	$wc_pos   = (string) get_option( 'woocommerce_currency_pos', 'left' );
+	$position = ( 'right' === $wc_pos || 'right_space' === $wc_pos ) ? 'right' : 'left';
+}
+if ( ! in_array( $position, array( 'left', 'right' ), true ) ) {
+	$position = 'left';
+}
+
+// Trim to two characters so an oversized symbol can't overflow the
+// adornment slot in the input.
+$symbol_short = function_exists( 'mb_substr' ) ? mb_substr( $symbol, 0, 2 ) : substr( $symbol, 0, 2 );
+
+$seeded_state = wp_interactivity_state( 'jetpack-search' );
+$seeded_price = $seeded_state['priceRange'] ?? null;
+$seeded_min   = is_array( $seeded_price ) && null !== ( $seeded_price['min'] ?? null )
+	? (string) $seeded_price['min']
+	: '';
+$seeded_max   = is_array( $seeded_price ) && null !== ( $seeded_price['max'] ?? null )
+	? (string) $seeded_price['max']
+	: '';
+
+// Push the block author's chosen currency symbol and group label into the
+// shared store so the active-filters block can render a price chip ("Price:
+// $10 – $50") that uses the same adornment the user sees on the input. The
+// chip block doesn't know about the price block at render time, so without
+// this seed it would fall back to the generic default. wp_interactivity_state
+// deep-merges, so writing here doesn't disturb other state branches.
+wp_interactivity_state(
+	'jetpack-search',
+	array(
+		'priceCurrencySymbol'         => $symbol_short,
+		'priceCurrencySymbolPosition' => $position,
+		'strings'                     => array(
+			'priceLabel' => $label,
+		),
+	)
+);
+
+$min_id = wp_unique_id( 'jetpack-search-filter-wc-price-min-' );
+$max_id = wp_unique_id( 'jetpack-search-filter-wc-price-max-' );
+?>
+<div
+	<?php echo wp_kses_data( get_block_wrapper_attributes( array( 'class' => 'jetpack-search-filter-wc-price' ) ) ); ?>
+	data-wp-interactive="jetpack-search"
+>
+	<h3 class="jetpack-search-filter__title"><?php echo esc_html( $label ); ?></h3>
+	<div class="jetpack-search-filter-wc-price__inputs">
+		<div class="jetpack-search-filter-wc-price__field jetpack-search-filter-wc-price__field--<?php echo esc_attr( $position ); ?>">
+			<label class="screen-reader-text" for="<?php echo esc_attr( $min_id ); ?>">
+				<?php esc_html_e( 'Minimum price', 'jetpack-search-pkg' ); ?>
+			</label>
+			<span class="jetpack-search-filter-wc-price__symbol" aria-hidden="true">
+				<?php echo esc_html( $symbol_short ); ?>
+			</span>
+			<input
+				id="<?php echo esc_attr( $min_id ); ?>"
+				class="jetpack-search-filter-wc-price__input jetpack-search-filter-wc-price__input--min"
+				type="number"
+				inputmode="decimal"
+				min="0"
+				step="any"
+				placeholder="<?php esc_attr_e( 'Min', 'jetpack-search-pkg' ); ?>"
+				value="<?php echo esc_attr( $seeded_min ); ?>"
+				data-wp-bind--value="state.priceRangeMinInputValue"
+				data-wp-on--change="actions.onPriceRangeInputChange"
+				data-wp-on--keydown="actions.onPriceRangeInputKeydown"
+			/>
+		</div>
+		<span class="jetpack-search-filter-wc-price__separator" aria-hidden="true">–</span>
+		<div class="jetpack-search-filter-wc-price__field jetpack-search-filter-wc-price__field--<?php echo esc_attr( $position ); ?>">
+			<label class="screen-reader-text" for="<?php echo esc_attr( $max_id ); ?>">
+				<?php esc_html_e( 'Maximum price', 'jetpack-search-pkg' ); ?>
+			</label>
+			<span class="jetpack-search-filter-wc-price__symbol" aria-hidden="true">
+				<?php echo esc_html( $symbol_short ); ?>
+			</span>
+			<input
+				id="<?php echo esc_attr( $max_id ); ?>"
+				class="jetpack-search-filter-wc-price__input jetpack-search-filter-wc-price__input--max"
+				type="number"
+				inputmode="decimal"
+				min="0"
+				step="any"
+				placeholder="<?php esc_attr_e( 'Max', 'jetpack-search-pkg' ); ?>"
+				value="<?php echo esc_attr( $seeded_max ); ?>"
+				data-wp-bind--value="state.priceRangeMaxInputValue"
+				data-wp-on--change="actions.onPriceRangeInputChange"
+				data-wp-on--keydown="actions.onPriceRangeInputKeydown"
+			/>
+		</div>
+	</div>
+</div>

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-price/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-price/style.scss
@@ -1,0 +1,75 @@
+/**
+ * Search product filter — price.
+ *
+ * Side-by-side number inputs joined by an em-dash separator. Currency
+ * symbol sits as a non-interactive adornment inside each field's box so
+ * the visual padding aligns with the input edge regardless of typed
+ * value width.
+ */
+.jetpack-search-filter-wc-price {
+
+	&__inputs {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
+	&__field {
+		position: relative;
+		display: flex;
+		align-items: center;
+		flex: 1 1 0;
+		min-width: 0;
+	}
+
+	&__symbol {
+		position: absolute;
+		inset-inline-start: 0.5rem;
+		color: color-mix(in sRGB, currentColor 50%, transparent);
+		font-size: 0.95em;
+		pointer-events: none;
+	}
+
+	// When WooCommerce's price format puts the symbol after the amount
+	// (e.g. `100 kr`) we mirror that — anchor the adornment to the input's
+	// trailing edge and shift the typed-value padding to match.
+	&__field--right &__symbol {
+		inset-inline-start: auto;
+		inset-inline-end: 0.5rem;
+	}
+
+	&__input {
+		width: 100%;
+		min-width: 0;
+		padding-block: 0.4rem;
+		padding-inline: 1.9rem 0.5rem;
+		border: 1px solid color-mix(in sRGB, currentColor 20%, transparent);
+		border-radius: 4px;
+		font: inherit;
+
+		// Drop the spinner buttons. They're unhelpful on price inputs —
+		// shoppers know how to type. Keeping the input as type="number"
+		// for the keyboard hint and validation, but removing the visual
+		// affordance avoids the "tiny up/down arrows" awkwardness.
+		&::-webkit-outer-spin-button,
+		&::-webkit-inner-spin-button {
+			-webkit-appearance: none;
+			margin: 0;
+		}
+
+		// Firefox / standard equivalent.
+		-moz-appearance: textfield;
+		appearance: textfield;
+	}
+
+	&__field--right &__input {
+		padding-inline: 0.5rem 1.9rem;
+	}
+
+	&__separator {
+		flex: 0 0 auto;
+		color: color-mix(in sRGB, currentColor 50%, transparent);
+		font-size: 1.1em;
+		line-height: 1;
+	}
+}

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-price/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-price/view.js
@@ -1,0 +1,109 @@
+import { store, getElement } from '@wordpress/interactivity';
+import '../../store';
+import './style.scss';
+
+const NAMESPACE = 'jetpack-search';
+
+/**
+ * Resolve the min and max input elements that share a parent block
+ * wrapper with `el`. Used by the change handler to read both values when
+ * either input changes (the store action takes both bounds together).
+ *
+ * @param {HTMLElement} el - The input that fired the event.
+ * @return {{min: HTMLInputElement|null, max: HTMLInputElement|null}} Sibling inputs.
+ */
+function findRangeInputs( el ) {
+	const wrapper = el?.closest?.( '.jetpack-search-filter-wc-price' );
+	if ( ! wrapper ) {
+		return { min: null, max: null };
+	}
+	return {
+		min: wrapper.querySelector( '.jetpack-search-filter-wc-price__input--min' ),
+		max: wrapper.querySelector( '.jetpack-search-filter-wc-price__input--max' ),
+	};
+}
+
+/**
+ * Coerce an input's `.value` string into the shape the store action
+ * expects: an empty input → null, a numeric input → its Number, anything
+ * else → null (the store action drops invalid bounds anyway, but
+ * normalizing here avoids a redundant search-token bump).
+ *
+ * @param {string|null|undefined} raw - Input value.
+ * @return {number|null} Parsed bound or null.
+ */
+function parseBound( raw ) {
+	if ( raw === null || raw === undefined || raw === '' ) {
+		return null;
+	}
+	const num = Number( raw );
+	return Number.isFinite( num ) && num >= 0 ? num : null;
+}
+
+store( NAMESPACE, {
+	state: {
+		/**
+		 * `data-wp-bind--value` for the min input. Returns an empty string
+		 * when no bound is set so the input renders blank rather than
+		 * "null". `data-wp-bind` only evaluates simple property paths, so
+		 * the null-safe lookup needs to live in a getter.
+		 *
+		 * @return {string} Min value as a string for the input.
+		 */
+		get priceRangeMinInputValue() {
+			const { state } = store( NAMESPACE );
+			const min = state.priceRange?.min;
+			return min === null || min === undefined ? '' : String( min );
+		},
+
+		/**
+		 * `data-wp-bind--value` for the max input. Same null-safe pattern
+		 * as `priceRangeMinInputValue`.
+		 *
+		 * @return {string} Max value as a string for the input.
+		 */
+		get priceRangeMaxInputValue() {
+			const { state } = store( NAMESPACE );
+			const max = state.priceRange?.max;
+			return max === null || max === undefined ? '' : String( max );
+		},
+	},
+
+	actions: {
+		/**
+		 * Apply both bounds to the store. Reads the sibling inputs from
+		 * the DOM rather than tracking each input's value in store state
+		 * so user typing isn't published to other listeners until they
+		 * actually commit a change (blur / Enter / native `change` event).
+		 *
+		 * The native `change` event on `<input type="number">` fires on
+		 * blur and on Enter, so this handler doubles as the submit path.
+		 *
+		 * @yield {Promise} setPriceRange action.
+		 */
+		*onPriceRangeInputChange() {
+			const el = getElement()?.ref;
+			const { min, max } = findRangeInputs( el );
+			yield store( NAMESPACE ).actions.setPriceRange(
+				parseBound( min?.value ),
+				parseBound( max?.value )
+			);
+		},
+
+		/**
+		 * Submit-on-Enter without waiting for blur, so a one-handed
+		 * keyboard flow (type → Enter) commits immediately. Also blurs
+		 * the input so screen-reader focus moves predictably to the next
+		 * page region instead of staying inside a now-stale field value.
+		 *
+		 * @param {KeyboardEvent} event - Keydown event.
+		 */
+		onPriceRangeInputKeydown( event ) {
+			if ( event?.key !== 'Enter' ) {
+				return;
+			}
+			event.preventDefault();
+			event.target?.blur?.();
+		},
+	},
+} );

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -22,6 +22,7 @@ import ActiveFiltersEdit from '../blocks/active-filters/edit';
 import FilterCheckboxEdit from '../blocks/filter-checkbox/edit';
 import FilterDateEdit from '../blocks/filter-date/edit';
 import FilterPostTypeEdit from '../blocks/filter-post-type/edit';
+import FilterWcPriceEdit from '../blocks/filter-wc-price/edit';
 import FilterWcRatingEdit from '../blocks/filter-wc-rating/edit';
 import FiltersPopoverEdit, { save as filtersPopoverSave } from '../blocks/filters-popover/edit';
 import FiltersStackEdit, { save as filtersStackSave } from '../blocks/filters-stack/edit';
@@ -55,6 +56,7 @@ const BLOCKS = [
 	[ 'jetpack-search/results-load-more', ResultsLoadMoreEdit ],
 	[ 'jetpack-search/search-results', SearchResultsEdit, searchResultsSave ],
 	[ 'jetpack-search/powered-by', PoweredByEdit ],
+	[ 'jetpack-search/filter-wc-price', FilterWcPriceEdit ],
 ];
 
 // Shape the "Jetpack Search" block category to match the Forms / Monetize /


### PR DESCRIPTION
## Why

Lets shoppers narrow products by budget using min/max number inputs. Respects WooCommerce's native `?min_price=` / `?max_price=` URL contract — share-friendly, back-button works, half-open ranges supported (min only or max only). The currency symbol adornment on each input gives immediate context without screen clutter.

## Proposed changes

- `jetpack-search/filter-wc-price` block (block.json, edit.js, render.php, view.js, style.scss).
- Editor registration (Inspector exposes label, currency symbol, symbol position).
- Symbol + position default to the active WooCommerce settings — `get_woocommerce_currency_symbol()` and `woocommerce_currency_pos`. Authors can override per-block; an empty value falls through to WC. Falls back to `$` / `left` on a plain WP install.
- Render seeds `priceCurrencySymbol` + `priceCurrencySymbolPosition` + `priceLabel` into the shared store (forward-looking; consumed by the active-filters chip block — until then unused but harmless).

## How

The price block doesn't register a filterConfig. `priceRange` is its own state branch; `setPriceRange` / `clearFilters` (which also clears `priceRange`) landed in #48446. The URL contract uses the `min_price` / `max_price` reserved query params already in `RESERVED_QUERY_PARAMS`.

## Screenshots

Captured at 1440×900 against a local docker WP env with WooCommerce active (currency: AUD, position: left) and 30 priced products. Frontend search results render "Searching…" indefinitely because the dev env has no Elasticsearch backend wired up — the block UI itself still seeds, hydrates, and writes URL params correctly.

| Editor — block selected (Inspector: Label, Currency Symbol, Symbol Position) | Frontend — empty inputs (symbol auto-detected from WC) |
|---|---|
| ![editor](https://github.com/user-attachments/assets/cafa23d6-c739-491d-8b1e-e39d77e6c6da) | ![empty](https://github.com/user-attachments/assets/4eac5579-f532-4ddb-bdd7-0c6dffab6e1a) |

| Frontend — `?min_price=50&max_price=500` (values seeded from URL) | Frontend — `currencySymbol="kr"` + `currencySymbolPosition="right"` (suffix locale) |
|---|---|
| ![filtered](https://github.com/user-attachments/assets/134b6696-55da-4d8e-9d11-0c5dd974770e) | ![suffix](https://github.com/user-attachments/assets/66fa170e-a310-4e8a-a96c-2c3a9c8947bc) |

## Stack

**PR-4 of 9** closing [RSM-1929](https://linear.app/a8c/issue/RSM-1929). Stacks on PR-1 #48446 (foundation). Independent of PR-2 (#48447) and PR-3 (#48448).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Stack PR-1 (#48446) + this PR.
2. Insert `jetpack-search/filter-wc-price` on a search page with WooCommerce active. Leave the Inspector's Currency Symbol blank — the rendered input should adopt your WC currency's symbol (e.g. `$` for AUD, `€` for EUR, `kr` for SEK). Set Symbol Position to "Default (WooCommerce)" — the rendered input should put the symbol on the side WC's `woocommerce_currency_pos` option says (left for AUD, right for SEK).
3. Override either control — type `€` in Currency Symbol, or pick "After amount" — and confirm the block honors the explicit override on the next render.
4. With priced products + `/?s=shirt`: type `10` in the min input, blur or press Enter → URL gains `?min_price=10`. Reload — value persists.
5. Clear min, type `50` in max — URL becomes `?max_price=50` (half-open range; min omitted).
6. Type a negative value or non-numeric input — search doesn't fire (silently dropped by `setPriceRange`).
7. Type min=100, max=10 (inverted) — search doesn't fire (also dropped by `setPriceRange` validation).
8. Click "Clear all" active-filters pill (once PR-5 lands) — both inputs reset to empty.
