### PR TITLE
Search 3.0: WC attribute filter block (pa_*)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4157,6 +4157,9 @@ importers:
       '@automattic/number-formatters':
         specifier: workspace:*
         version: link:../../js-packages/number-formatters
+      '@wordpress/api-fetch':
+        specifier: 7.44.0
+        version: 7.44.0
       '@wordpress/base-styles':
         specifier: 6.20.0
         version: 6.20.0

--- a/projects/packages/search/changelog/add-filter-wc-attribute
+++ b/projects/packages/search/changelog/add-filter-wc-attribute
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search 3.0: adds the `jetpack-search/filter-wc-attribute` block — a checkbox-list filter targeting a single WooCommerce product attribute (pa_color, pa_size, …). The editor inspector ships a SelectControl seeded from `/wp/v2/taxonomies` via `core-data` and constrained to the `pa_` prefix, so site builders only see actual WC product attributes. Rides the existing `filterType: 'taxonomy'` data plane (`taxonomy.<slug>.slug_slash_name` ES field) and the shared `state.filterItems` getter promoted in the foundation PR — no new branches in `resolveFilterFields`. Tracked under epic [RSM-1929].

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -48,6 +48,7 @@
 		"@automattic/jetpack-connection": "workspace:*",
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
 		"@automattic/number-formatters": "workspace:*",
+		"@wordpress/api-fetch": "7.44.0",
 		"@wordpress/base-styles": "6.20.0",
 		"@wordpress/block-editor": "15.17.0",
 		"@wordpress/blocks": "15.17.0",

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/block.json
@@ -1,0 +1,34 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "jetpack-search/filter-wc-attribute",
+	"version": "0.1.0",
+	"title": "Filter by Attribute",
+	"category": "jetpack-search",
+	"icon": "filter",
+	"description": "Let shoppers filter products by a WooCommerce attribute (color, size, …). Powered by Jetpack Search.",
+	"supports": {
+		"html": false,
+		"interactivity": true,
+		"spacing": {
+			"margin": [ "top", "bottom" ],
+			"padding": true,
+			"blockGap": true
+		}
+	},
+	"textdomain": "jetpack-search-pkg",
+	"attributes": {
+		"attributeTaxonomy": { "type": "string", "default": "" },
+		"label": { "type": "string", "default": "" },
+		"showCount": { "type": "boolean", "default": true },
+		"maxItems": { "type": "integer", "default": 10 },
+		"bucketSortOrder": {
+			"type": "string",
+			"default": "count",
+			"enum": [ "count", "alpha" ]
+		}
+	},
+	"render": "file:./render.php",
+	"viewScriptModule": "file:../../../../build/search-blocks/filter-wc-attribute.js",
+	"style": "file:../../../../build/search-blocks/filter-wc-attribute.css"
+}

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/block.json
@@ -3,7 +3,7 @@
 	"apiVersion": 3,
 	"name": "jetpack-search/filter-wc-attribute",
 	"version": "0.1.0",
-	"title": "Filter by Attribute",
+	"title": "Filter by Product Attribute",
 	"category": "jetpack-search",
 	"icon": "filter",
 	"description": "Let shoppers filter products by a WooCommerce attribute (color, size, …). Powered by Jetpack Search.",

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/class-filter-wc-attribute.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/class-filter-wc-attribute.php
@@ -68,7 +68,11 @@ class Filter_Wc_Attribute {
 	 */
 	public static function default_label( array $attributes ): string {
 		$slug = sanitize_key( (string) ( $attributes['attributeTaxonomy'] ?? '' ) );
-		if ( '' === $slug ) {
+		// Mirror the prefix guard from derive_filter_key() so a non-`pa_*` slug
+		// reaching this method directly (a future caller skipping build_config)
+		// still resolves to '' rather than producing a humanized label for a
+		// taxonomy this block doesn't represent.
+		if ( '' === $slug || 0 !== strpos( $slug, self::ATTRIBUTE_PREFIX ) ) {
 			return '';
 		}
 		if ( function_exists( 'get_taxonomy' ) ) {

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/class-filter-wc-attribute.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/class-filter-wc-attribute.php
@@ -82,7 +82,7 @@ class Filter_Wc_Attribute {
 		// admin would see if the taxonomy had no label registered yet.
 		$bare = preg_replace( '/^' . preg_quote( self::ATTRIBUTE_PREFIX, '/' ) . '/', '', $slug );
 		$bare = (string) str_replace( '_', ' ', (string) $bare );
-		return function_exists( 'ucwords' ) ? ucwords( $bare ) : $bare;
+		return ucwords( $bare );
 	}
 
 	/**
@@ -115,6 +115,7 @@ class Filter_Wc_Attribute {
 			'bucketSortOrder' => Filter_Checkbox::normalize_bucket_sort_order(
 				$attributes['bucketSortOrder'] ?? null
 			),
+			'valueLabels'     => array(),
 		);
 	}
 }

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/class-filter-wc-attribute.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/class-filter-wc-attribute.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Search product filter — WooCommerce attribute block helpers.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+/**
+ * Helper methods for the jetpack-search/filter-wc-attribute block.
+ *
+ * Each block instance targets one WooCommerce attribute taxonomy
+ * (`pa_color`, `pa_size`, …) chosen by the block author. Internally the
+ * filter rides the same `filterType: 'taxonomy'` plumbing as the generic
+ * filter-checkbox block — `resolveFilterFields()` already maps any
+ * `taxonomy.<slug>.slug_slash_name` aggregation field, so the data plane
+ * doesn't need a new branch. The block exists as its own type (rather than
+ * a filter-checkbox variation) so the inserter / inspector can constrain
+ * the picker to `pa_*` taxonomies and surface attribute-specific defaults.
+ */
+class Filter_Wc_Attribute {
+
+	/**
+	 * Common WC product-attribute taxonomy prefix. WooCommerce registers each
+	 * product attribute as a regular WP taxonomy whose slug is prefixed `pa_`
+	 * (Product Attribute). Using a single constant keeps the prefix in one
+	 * place so the picker, the validator, and the editor preview agree.
+	 */
+	const ATTRIBUTE_PREFIX = 'pa_';
+
+	/**
+	 * Derive the URL key + filterConfigs key for this block instance.
+	 *
+	 * Returns the chosen attribute slug verbatim (sanitized). An empty or
+	 * reserved slug short-circuits to '' so render.php can bail early
+	 * without registering a half-formed filter — same pattern as
+	 * Filter_Checkbox::derive_filter_key().
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string
+	 */
+	public static function derive_filter_key( array $attributes ): string {
+		$slug = sanitize_key( (string) ( $attributes['attributeTaxonomy'] ?? '' ) );
+		if ( '' === $slug || in_array( $slug, Search_Blocks::RESERVED_QUERY_PARAMS, true ) ) {
+			return '';
+		}
+		// Defensive prefix check: if a site builder somehow saves a non-`pa_`
+		// taxonomy through the editor (manual block JSON edit, schema drift,
+		// etc.), short-circuit so we don't mint a filter contract that the
+		// attribute block's UX promises will be a WC product attribute.
+		if ( 0 !== strpos( $slug, self::ATTRIBUTE_PREFIX ) ) {
+			return '';
+		}
+		return $slug;
+	}
+
+	/**
+	 * Default group label when the block author leaves the label attribute
+	 * empty. Prefers the registered taxonomy's `singular_name` (so a
+	 * `pa_color` attribute reads "Color"), falls back to a humanized form of
+	 * the slug-stripped name. WC stores attribute labels separately from
+	 * taxonomy labels in some configurations — the taxonomy label is the
+	 * version users actually see in the admin, so we use it.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string
+	 */
+	public static function default_label( array $attributes ): string {
+		$slug = sanitize_key( (string) ( $attributes['attributeTaxonomy'] ?? '' ) );
+		if ( '' === $slug ) {
+			return '';
+		}
+		if ( function_exists( 'get_taxonomy' ) ) {
+			$tax = get_taxonomy( $slug );
+			if ( $tax && ! empty( $tax->labels->singular_name ) ) {
+				return (string) $tax->labels->singular_name;
+			}
+		}
+		// Fall back to the slug with the `pa_` prefix stripped and underscores
+		// upper-cased ("pa_screen_size" → "Screen Size"). Matches what an
+		// admin would see if the taxonomy had no label registered yet.
+		$bare = preg_replace( '/^' . preg_quote( self::ATTRIBUTE_PREFIX, '/' ) . '/', '', $slug );
+		$bare = (string) str_replace( '_', ' ', (string) $bare );
+		return function_exists( 'ucwords' ) ? ucwords( $bare ) : $bare;
+	}
+
+	/**
+	 * Build the filterConfig entry this block contributes to the shared
+	 * Interactivity state. JS reads `filterType: 'taxonomy'` to drive the
+	 * `taxonomy.<slug>.slug_slash_name` aggregation field and the same
+	 * `term` filter clause shape as filter-checkbox.
+	 *
+	 * @param array  $attributes Block attributes.
+	 * @param string $filter_key Result of derive_filter_key().
+	 * @return array<string, mixed>
+	 */
+	public static function build_config( array $attributes, string $filter_key ): array {
+		$label = sanitize_text_field( (string) ( $attributes['label'] ?? '' ) );
+		if ( '' === $label ) {
+			$label = static::default_label( $attributes );
+		}
+
+		return array(
+			'filterKey'       => $filter_key,
+			'filterType'      => 'taxonomy',
+			// resolveFilterFields() reads `taxonomy` to compose the ES path
+			// (`taxonomy.<slug>.slug_slash_name`). Mirror filter-checkbox so
+			// the field shape is identical and any future bridge work doesn't
+			// have to special-case attribute filters.
+			'taxonomy'        => $filter_key,
+			'label'           => $label,
+			'showCount'       => (bool) ( $attributes['showCount'] ?? true ),
+			'maxItems'        => max( 1, (int) ( $attributes['maxItems'] ?? 10 ) ),
+			'bucketSortOrder' => Filter_Checkbox::normalize_bucket_sort_order(
+				$attributes['bucketSortOrder'] ?? null
+			),
+		);
+	}
+}

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/edit.js
@@ -106,17 +106,19 @@ export default function FilterWcAttributeEdit( { attributes, setAttributes } ) {
 							{ value: '', label: __( '— Select an attribute —', 'jetpack-search-pkg' ) },
 							...( attributeOptions ?? [] ),
 						] }
-						disabled={ ! hasAttributes }
+						disabled={ isLoading || ! hasAttributes }
 						help={
-							hasAttributes
-								? __(
-										'Pick which WooCommerce product attribute drives this filter.',
-										'jetpack-search-pkg'
-								  )
-								: __(
-										'No WooCommerce product attributes were found on this site.',
-										'jetpack-search-pkg'
-								  )
+							isLoading
+								? __( 'Loading product attributes…', 'jetpack-search-pkg' )
+								: hasAttributes
+								  ? __(
+											'Pick which WooCommerce product attribute drives this filter.',
+											'jetpack-search-pkg'
+								    )
+								  : __(
+											'No WooCommerce product attributes were found on this site.',
+											'jetpack-search-pkg'
+								    )
 						}
 					/>
 					<TextControl
@@ -164,15 +166,17 @@ export default function FilterWcAttributeEdit( { attributes, setAttributes } ) {
 					<Placeholder
 						label={ __( 'Filter by Attribute', 'jetpack-search-pkg' ) }
 						instructions={
-							hasAttributes
-								? __(
-										'Pick a WooCommerce product attribute in the block sidebar to enable this filter.',
-										'jetpack-search-pkg'
-								  )
-								: __(
-										'No WooCommerce product attributes are registered on this site, so this block has nothing to filter on.',
-										'jetpack-search-pkg'
-								  )
+							isLoading
+								? __( 'Loading product attributes…', 'jetpack-search-pkg' )
+								: hasAttributes
+								  ? __(
+											'Pick a WooCommerce product attribute in the block sidebar to enable this filter.',
+											'jetpack-search-pkg'
+								    )
+								  : __(
+											'No WooCommerce product attributes are registered on this site, so this block has nothing to filter on.',
+											'jetpack-search-pkg'
+								    )
 						}
 					/>
 				</div>

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/edit.js
@@ -2,15 +2,18 @@
  * Editor preview for jetpack-search/filter-wc-attribute.
  *
  * One block instance targets one WC product attribute taxonomy (`pa_color`,
- * `pa_size`, …). The picker is seeded from `/wp/v2/taxonomies` via
- * `core-data` and constrained to the `pa_` prefix so site builders only see
- * actual WC product attributes — non-WC sites get an empty list and a
- * Placeholder explaining the block can't render.
+ * `pa_size`, …). The picker is seeded from the WC Store API
+ * (`/wc/store/v1/products/attributes`) rather than `/wp/v2/taxonomies`
+ * because WooCommerce registers `pa_*` taxonomies without `show_in_rest`,
+ * so they never appear in the core taxonomies endpoint. The Store API is
+ * public and ships with WC Blocks (always-on in modern WC), so non-WC
+ * sites simply 404 and we render the "no attributes" Placeholder.
  *
  * Once an attribute is chosen, the preview mirrors filter-checkbox: a
  * labeled list with sample buckets so designers can style the list in
  * place.
  */
+import apiFetch from '@wordpress/api-fetch';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import {
 	PanelBody,
@@ -20,8 +23,7 @@ import {
 	TextControl,
 	ToggleControl,
 } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
-import { useMemo } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 const ATTRIBUTE_PREFIX = 'pa_';
@@ -118,27 +120,39 @@ export default function FilterWcAttributeEdit( { attributes, setAttributes } ) {
 	const sortOrder = attributes?.bucketSortOrder === 'alpha' ? 'alpha' : 'count';
 	const slug = attributes?.attributeTaxonomy || '';
 
-	// Pull registered taxonomies via core-data. `null` while the request is
-	// in flight, an array once resolved. We keep the request unconditional
-	// because the picker is the block's primary affordance — paying for the
-	// REST call once per editor session is fine.
-	const taxonomies = useSelect( select => select( 'core' ).getTaxonomies( { per_page: -1 } ), [] );
-
-	// Filter to `pa_*` and project into SelectControl options. A non-WC site
-	// resolves to an empty list, so the Placeholder branch below renders the
-	// "no attributes registered" message instead of an empty <select>.
-	const attributeOptions = useMemo( () => {
-		if ( ! Array.isArray( taxonomies ) ) {
-			return null;
-		}
-		return taxonomies
-			.filter( tax => typeof tax?.slug === 'string' && tax.slug.startsWith( ATTRIBUTE_PREFIX ) )
-			.map( tax => ( {
-				value: tax.slug,
-				label: tax?.labels?.singular_name || tax?.name || humanizeAttributeSlug( tax.slug ),
-			} ) )
-			.sort( ( a, b ) => a.label.localeCompare( b.label ) );
-	}, [ taxonomies ] );
+	// `null` while in flight, array once resolved (empty on non-WC sites or
+	// when the Store API 404s). Project into SelectControl options up front
+	// so the render path below stays declarative.
+	const [ attributeOptions, setAttributeOptions ] = useState( null );
+	useEffect( () => {
+		let cancelled = false;
+		apiFetch( { path: '/wc/store/v1/products/attributes' } )
+			.then( attrs => {
+				if ( cancelled ) {
+					return;
+				}
+				const list = Array.isArray( attrs ) ? attrs : [];
+				const options = list
+					.filter(
+						attr =>
+							typeof attr?.taxonomy === 'string' && attr.taxonomy.startsWith( ATTRIBUTE_PREFIX )
+					)
+					.map( attr => ( {
+						value: attr.taxonomy,
+						label: attr?.name || humanizeAttributeSlug( attr.taxonomy ),
+					} ) )
+					.sort( ( a, b ) => a.label.localeCompare( b.label ) );
+				setAttributeOptions( options );
+			} )
+			.catch( () => {
+				if ( ! cancelled ) {
+					setAttributeOptions( [] );
+				}
+			} );
+		return () => {
+			cancelled = true;
+		};
+	}, [] );
 
 	const isLoading = attributeOptions === null;
 	const hasAttributes = ! isLoading && attributeOptions.length > 0;

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/edit.js
@@ -225,7 +225,7 @@ export default function FilterWcAttributeEdit( { attributes, setAttributes } ) {
 			{ ! slug ? (
 				<div { ...blockProps }>
 					<Placeholder
-						label={ __( 'Filter by Attribute', 'jetpack-search-pkg' ) }
+						label={ __( 'Filter by Product Attribute', 'jetpack-search-pkg' ) }
 						instructions={ placeholderInstructions }
 					/>
 				</div>

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/edit.js
@@ -176,7 +176,7 @@ export default function FilterWcAttributeEdit( { attributes, setAttributes } ) {
 						placeholder={ previewLabel }
 						onChange={ value => setAttributes( { label: value } ) }
 						help={ __(
-							'Heading shown above the options. Leave empty to use the attribute's name.',
+							"Heading shown above the options. Leave empty to use the attribute's name.",
 							'jetpack-search-pkg'
 						) }
 					/>

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/edit.js
@@ -1,0 +1,202 @@
+/**
+ * Editor preview for jetpack-search/filter-wc-attribute.
+ *
+ * One block instance targets one WC product attribute taxonomy (`pa_color`,
+ * `pa_size`, …). The picker is seeded from `/wp/v2/taxonomies` via
+ * `core-data` and constrained to the `pa_` prefix so site builders only see
+ * actual WC product attributes — non-WC sites get an empty list and a
+ * Placeholder explaining the block can't render.
+ *
+ * Once an attribute is chosen, the preview mirrors filter-checkbox: a
+ * labeled list with sample buckets so designers can style the list in
+ * place.
+ */
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	PanelBody,
+	Placeholder,
+	RangeControl,
+	SelectControl,
+	TextControl,
+	ToggleControl,
+} from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+const ATTRIBUTE_PREFIX = 'pa_';
+
+const SAMPLE_FILTER_ITEMS = [
+	{ value: 'red', label: __( 'Red', 'jetpack-search-pkg' ), count: 12 },
+	{ value: 'blue', label: __( 'Blue', 'jetpack-search-pkg' ), count: 8 },
+	{ value: 'green', label: __( 'Green', 'jetpack-search-pkg' ), count: 3 },
+];
+
+/**
+ * Strip the `pa_` prefix and humanize the remainder so a fallback label
+ * reads naturally ("pa_screen_size" → "Screen Size") when the registered
+ * taxonomy doesn't carry a singular_name.
+ *
+ * @param {string} slug - Taxonomy slug.
+ * @return {string} Humanized name.
+ */
+function humanizeAttributeSlug( slug ) {
+	const bare = slug.startsWith( ATTRIBUTE_PREFIX ) ? slug.slice( ATTRIBUTE_PREFIX.length ) : slug;
+	return bare
+		.split( '_' )
+		.filter( Boolean )
+		.map( word => word.charAt( 0 ).toUpperCase() + word.slice( 1 ) )
+		.join( ' ' );
+}
+
+/**
+ * Edit component for the filter-wc-attribute block.
+ *
+ * @param {object}   props               - Block props.
+ * @param {object}   props.attributes    - Saved block attributes.
+ * @param {Function} props.setAttributes - Attribute setter.
+ * @return {object} Rendered element.
+ */
+export default function FilterWcAttributeEdit( { attributes, setAttributes } ) {
+	const blockProps = useBlockProps( { className: 'jetpack-search-filter-wc-attribute' } );
+	const rawLabel = attributes?.label || '';
+	const showCount = attributes?.showCount !== false;
+	const maxItems = Math.max( 1, attributes?.maxItems ?? 10 );
+	const sortOrder = attributes?.bucketSortOrder === 'alpha' ? 'alpha' : 'count';
+	const slug = attributes?.attributeTaxonomy || '';
+
+	// Pull registered taxonomies via core-data. `null` while the request is
+	// in flight, an array once resolved. We keep the request unconditional
+	// because the picker is the block's primary affordance — paying for the
+	// REST call once per editor session is fine.
+	const taxonomies = useSelect( select => select( 'core' ).getTaxonomies( { per_page: -1 } ), [] );
+
+	// Filter to `pa_*` and project into SelectControl options. A non-WC site
+	// resolves to an empty list, so the Placeholder branch below renders the
+	// "no attributes registered" message instead of an empty <select>.
+	const attributeOptions = useMemo( () => {
+		if ( ! Array.isArray( taxonomies ) ) {
+			return null;
+		}
+		return taxonomies
+			.filter( tax => typeof tax?.slug === 'string' && tax.slug.startsWith( ATTRIBUTE_PREFIX ) )
+			.map( tax => ( {
+				value: tax.slug,
+				label: tax?.labels?.singular_name || tax?.name || humanizeAttributeSlug( tax.slug ),
+			} ) )
+			.sort( ( a, b ) => a.label.localeCompare( b.label ) );
+	}, [ taxonomies ] );
+
+	const isLoading = attributeOptions === null;
+	const hasAttributes = ! isLoading && attributeOptions.length > 0;
+	const selectedOption = hasAttributes ? attributeOptions.find( opt => opt.value === slug ) : null;
+	const previewLabel = rawLabel || ( selectedOption ? selectedOption.label : '' );
+
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings', 'jetpack-search-pkg' ) }>
+					<SelectControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Attribute', 'jetpack-search-pkg' ) }
+						value={ slug }
+						onChange={ value => setAttributes( { attributeTaxonomy: value } ) }
+						options={ [
+							{ value: '', label: __( '— Select an attribute —', 'jetpack-search-pkg' ) },
+							...( attributeOptions ?? [] ),
+						] }
+						disabled={ ! hasAttributes }
+						help={
+							hasAttributes
+								? __(
+										'Pick which WooCommerce product attribute drives this filter.',
+										'jetpack-search-pkg'
+								  )
+								: __(
+										'No WooCommerce product attributes were found on this site.',
+										'jetpack-search-pkg'
+								  )
+						}
+					/>
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Label', 'jetpack-search-pkg' ) }
+						value={ rawLabel }
+						placeholder={ previewLabel }
+						onChange={ value => setAttributes( { label: value } ) }
+						help={ __(
+							'Heading shown above the options. Leave empty to use the attribute’s name.',
+							'jetpack-search-pkg'
+						) }
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Show result counts', 'jetpack-search-pkg' ) }
+						checked={ showCount }
+						onChange={ value => setAttributes( { showCount: !! value } ) }
+					/>
+					<RangeControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Maximum items shown', 'jetpack-search-pkg' ) }
+						value={ maxItems }
+						min={ 1 }
+						max={ 50 }
+						onChange={ value => setAttributes( { maxItems: Math.max( 1, Number( value ) || 1 ) } ) }
+					/>
+					<SelectControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Sort order', 'jetpack-search-pkg' ) }
+						value={ sortOrder }
+						onChange={ value => setAttributes( { bucketSortOrder: value } ) }
+						options={ [
+							{ value: 'count', label: __( 'By count (most matches first)', 'jetpack-search-pkg' ) },
+							{ value: 'alpha', label: __( 'Alphabetical', 'jetpack-search-pkg' ) },
+						] }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			{ ! slug ? (
+				<div { ...blockProps }>
+					<Placeholder
+						label={ __( 'Filter by Attribute', 'jetpack-search-pkg' ) }
+						instructions={
+							hasAttributes
+								? __(
+										'Pick a WooCommerce product attribute in the block sidebar to enable this filter.',
+										'jetpack-search-pkg'
+								  )
+								: __(
+										'No WooCommerce product attributes are registered on this site, so this block has nothing to filter on.',
+										'jetpack-search-pkg'
+								  )
+						}
+					/>
+				</div>
+			) : (
+				<div { ...blockProps }>
+					{ previewLabel && (
+						<h3 className="jetpack-search-filter__title">{ previewLabel }</h3>
+					) }
+					<ul className="jetpack-search-filter__list">
+						{ SAMPLE_FILTER_ITEMS.map( item => (
+							<li key={ item.value } className="jetpack-search-filter__item">
+								{ /* eslint-disable-next-line jsx-a11y/label-has-associated-control -- input is a direct child; implicit HTML5 association applies */ }
+								<label>
+									<input type="checkbox" disabled />
+									<span className="jetpack-search-filter__label">{ item.label }</span>
+									{ showCount && (
+										<span className="jetpack-search-filter__count">{ String( item.count ) }</span>
+									) }
+								</label>
+							</li>
+						) ) }
+					</ul>
+				</div>
+			) }
+		</>
+	);
+}

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/edit.js
@@ -32,11 +32,26 @@ const SAMPLE_FILTER_ITEMS = [
 	{ value: 'green', label: __( 'Green', 'jetpack-search-pkg' ), count: 3 },
 ];
 
-const LOADING_TEXT = __( 'Loading product attributes…', 'jetpack-search-pkg' );
-const PICKER_HELP = __( 'Pick which WooCommerce product attribute drives this filter.', 'jetpack-search-pkg' );
-const NO_ATTRIBUTES_HELP = __( 'No WooCommerce product attributes were found on this site.', 'jetpack-search-pkg' );
-const PLACEHOLDER_PICK = __( 'Pick a WooCommerce product attribute in the block sidebar to enable this filter.', 'jetpack-search-pkg' );
-const PLACEHOLDER_EMPTY = __( 'No WooCommerce product attributes are registered on this site, so this block has nothing to filter on.', 'jetpack-search-pkg' );
+const LOADING_TEXT = __(
+	'Loading product attributes…',
+	'jetpack-search-pkg'
+);
+const PICKER_HELP = __(
+	'Pick which WooCommerce product attribute drives this filter.',
+	'jetpack-search-pkg'
+);
+const NO_ATTRIBUTES_HELP = __(
+	'No WooCommerce product attributes were found on this site.',
+	'jetpack-search-pkg'
+);
+const PLACEHOLDER_PICK = __(
+	'Pick a WooCommerce product attribute in the block sidebar to enable this filter.',
+	'jetpack-search-pkg'
+);
+const PLACEHOLDER_EMPTY = __(
+	'No WooCommerce product attributes are registered on this site, so this block has nothing to filter on.',
+	'jetpack-search-pkg'
+);
 
 /**
  * Strip the `pa_` prefix and humanize the remainder so a fallback label
@@ -53,6 +68,41 @@ function humanizeAttributeSlug( slug ) {
 		.filter( Boolean )
 		.map( word => word.charAt( 0 ).toUpperCase() + word.slice( 1 ) )
 		.join( ' ' );
+}
+
+/**
+ * Resolve the appropriate help text for the attribute picker, avoiding nested
+ * ternaries which are forbidden by the ESLint `no-nested-ternary` rule.
+ *
+ * @param {boolean} isLoading     - True while taxonomies are being fetched.
+ * @param {boolean} hasAttributes - True when at least one `pa_*` attribute is registered.
+ * @return {string} Help text.
+ */
+function resolvePickerHelp( isLoading, hasAttributes ) {
+	if ( isLoading ) {
+		return LOADING_TEXT;
+	}
+	if ( hasAttributes ) {
+		return PICKER_HELP;
+	}
+	return NO_ATTRIBUTES_HELP;
+}
+
+/**
+ * Resolve the Placeholder instructions text, avoiding nested ternaries.
+ *
+ * @param {boolean} isLoading     - True while taxonomies are being fetched.
+ * @param {boolean} hasAttributes - True when at least one `pa_*` attribute is registered.
+ * @return {string} Instructions text.
+ */
+function resolvePlaceholderInstructions( isLoading, hasAttributes ) {
+	if ( isLoading ) {
+		return LOADING_TEXT;
+	}
+	if ( hasAttributes ) {
+		return PLACEHOLDER_PICK;
+	}
+	return PLACEHOLDER_EMPTY;
 }
 
 /**
@@ -98,10 +148,8 @@ export default function FilterWcAttributeEdit( { attributes, setAttributes } ) {
 	const selectedOption = hasAttributes ? attributeOptions.find( opt => opt.value === slug ) : null;
 	const previewLabel = rawLabel || ( selectedOption ? selectedOption.label : '' );
 
-	// Compute help text and placeholder instructions outside JSX so the
-	// i18n extractor sees each __() call with a static string literal.
-	const pickerHelp = isLoading ? LOADING_TEXT : hasAttributes ? PICKER_HELP : NO_ATTRIBUTES_HELP;
-	const placeholderInstructions = isLoading ? LOADING_TEXT : hasAttributes ? PLACEHOLDER_PICK : PLACEHOLDER_EMPTY;
+	const pickerHelp = resolvePickerHelp( isLoading, hasAttributes );
+	const placeholderInstructions = resolvePlaceholderInstructions( isLoading, hasAttributes );
 
 	return (
 		<>
@@ -128,7 +176,7 @@ export default function FilterWcAttributeEdit( { attributes, setAttributes } ) {
 						placeholder={ previewLabel }
 						onChange={ value => setAttributes( { label: value } ) }
 						help={ __(
-							'Heading shown above the options. Leave empty to use the attribute’s name.',
+							'Heading shown above the options. Leave empty to use the attribute's name.',
 							'jetpack-search-pkg'
 						) }
 					/>
@@ -154,7 +202,10 @@ export default function FilterWcAttributeEdit( { attributes, setAttributes } ) {
 						value={ sortOrder }
 						onChange={ value => setAttributes( { bucketSortOrder: value } ) }
 						options={ [
-							{ value: 'count', label: __( 'By count (most matches first)', 'jetpack-search-pkg' ) },
+							{
+								value: 'count',
+								label: __( 'By count (most matches first)', 'jetpack-search-pkg' ),
+							},
 							{ value: 'alpha', label: __( 'Alphabetical', 'jetpack-search-pkg' ) },
 						] }
 					/>
@@ -169,9 +220,7 @@ export default function FilterWcAttributeEdit( { attributes, setAttributes } ) {
 				</div>
 			) : (
 				<div { ...blockProps }>
-					{ previewLabel && (
-						<h3 className="jetpack-search-filter__title">{ previewLabel }</h3>
-					) }
+					{ previewLabel && <h3 className="jetpack-search-filter__title">{ previewLabel }</h3> }
 					<ul className="jetpack-search-filter__list">
 						{ SAMPLE_FILTER_ITEMS.map( item => (
 							<li key={ item.value } className="jetpack-search-filter__item">

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/edit.js
@@ -32,10 +32,7 @@ const SAMPLE_FILTER_ITEMS = [
 	{ value: 'green', label: __( 'Green', 'jetpack-search-pkg' ), count: 3 },
 ];
 
-const LOADING_TEXT = __(
-	'Loading product attributes…',
-	'jetpack-search-pkg'
-);
+const LOADING_TEXT = __( 'Loading product attributes…', 'jetpack-search-pkg' );
 const PICKER_HELP = __(
 	'Pick which WooCommerce product attribute drives this filter.',
 	'jetpack-search-pkg'

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/edit.js
@@ -32,6 +32,12 @@ const SAMPLE_FILTER_ITEMS = [
 	{ value: 'green', label: __( 'Green', 'jetpack-search-pkg' ), count: 3 },
 ];
 
+const LOADING_TEXT = __( 'Loading product attributes…', 'jetpack-search-pkg' );
+const PICKER_HELP = __( 'Pick which WooCommerce product attribute drives this filter.', 'jetpack-search-pkg' );
+const NO_ATTRIBUTES_HELP = __( 'No WooCommerce product attributes were found on this site.', 'jetpack-search-pkg' );
+const PLACEHOLDER_PICK = __( 'Pick a WooCommerce product attribute in the block sidebar to enable this filter.', 'jetpack-search-pkg' );
+const PLACEHOLDER_EMPTY = __( 'No WooCommerce product attributes are registered on this site, so this block has nothing to filter on.', 'jetpack-search-pkg' );
+
 /**
  * Strip the `pa_` prefix and humanize the remainder so a fallback label
  * reads naturally ("pa_screen_size" → "Screen Size") when the registered
@@ -92,6 +98,11 @@ export default function FilterWcAttributeEdit( { attributes, setAttributes } ) {
 	const selectedOption = hasAttributes ? attributeOptions.find( opt => opt.value === slug ) : null;
 	const previewLabel = rawLabel || ( selectedOption ? selectedOption.label : '' );
 
+	// Compute help text and placeholder instructions outside JSX so the
+	// i18n extractor sees each __() call with a static string literal.
+	const pickerHelp = isLoading ? LOADING_TEXT : hasAttributes ? PICKER_HELP : NO_ATTRIBUTES_HELP;
+	const placeholderInstructions = isLoading ? LOADING_TEXT : hasAttributes ? PLACEHOLDER_PICK : PLACEHOLDER_EMPTY;
+
 	return (
 		<>
 			<InspectorControls>
@@ -107,19 +118,7 @@ export default function FilterWcAttributeEdit( { attributes, setAttributes } ) {
 							...( attributeOptions ?? [] ),
 						] }
 						disabled={ isLoading || ! hasAttributes }
-						help={
-							isLoading
-								? __( 'Loading product attributes…', 'jetpack-search-pkg' )
-								: hasAttributes
-								  ? __(
-											'Pick which WooCommerce product attribute drives this filter.',
-											'jetpack-search-pkg'
-								    )
-								  : __(
-											'No WooCommerce product attributes were found on this site.',
-											'jetpack-search-pkg'
-								    )
-						}
+						help={ pickerHelp }
 					/>
 					<TextControl
 						__next40pxDefaultSize
@@ -165,19 +164,7 @@ export default function FilterWcAttributeEdit( { attributes, setAttributes } ) {
 				<div { ...blockProps }>
 					<Placeholder
 						label={ __( 'Filter by Attribute', 'jetpack-search-pkg' ) }
-						instructions={
-							isLoading
-								? __( 'Loading product attributes…', 'jetpack-search-pkg' )
-								: hasAttributes
-								  ? __(
-											'Pick a WooCommerce product attribute in the block sidebar to enable this filter.',
-											'jetpack-search-pkg'
-								    )
-								  : __(
-											'No WooCommerce product attributes are registered on this site, so this block has nothing to filter on.',
-											'jetpack-search-pkg'
-								    )
-						}
+						instructions={ placeholderInstructions }
 					/>
 				</div>
 			) : (

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/render.php
@@ -89,6 +89,7 @@ $label = (string) $config['label'];
 					<input
 						type="checkbox"
 						data-wp-bind--value="context.item.value"
+						data-wp-bind--checked="context.item.checked"
 						data-wp-on--change="actions.onFilterChange"
 					/>
 					<span

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/render.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Search product filter — WooCommerce attribute render.
+ *
+ * Renders one block instance per chosen attribute taxonomy (`pa_color`,
+ * `pa_size`, …). The DOM shape and Interactivity bindings are deliberately
+ * identical to `jetpack/filter-checkbox` so the shared `state.filterItems`
+ * / `state.hasFilterBuckets` / `actions.onFilterChange` getters drive both
+ * blocks — we don't want two parallel implementations of the same checkbox
+ * list when only the inserter / inspector contract differs.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+
+// @phan-suppress-next-line PhanUndeclaredGlobalVariable
+$filter_key = Filter_Wc_Attribute::derive_filter_key( (array) $attributes );
+// Bail when no attribute is chosen yet (the editor renders a Placeholder in
+// that state) or when the Interactivity API isn't available — wp_interactivity
+// helpers were introduced in WP 6.5.
+if ( '' === $filter_key || ! function_exists( 'wp_interactivity_state' ) ) {
+	return;
+}
+
+// @phan-suppress-next-line PhanUndeclaredGlobalVariable
+$config = Filter_Wc_Attribute::build_config( (array) $attributes, $filter_key );
+
+// Each instance contributes its own filterConfig entry. wp_interactivity_state
+// deep-merges, so multiple attribute blocks (one per attribute) coexist.
+wp_interactivity_state(
+	'jetpack-search',
+	array(
+		'filterConfigs' => array(
+			$filter_key => $config,
+		),
+	)
+);
+
+// Render `hidden` on first paint when no aggregation buckets are available
+// for this filter. Mirrors filter-checkbox so the wrapper doesn't push the
+// sidebar layout while empty.
+$seeded_state      = wp_interactivity_state( 'jetpack-search' );
+$seeded_aggs       = (array) ( $seeded_state['aggregations'] ?? array() );
+$seeded_filter_agg = (array) ( $seeded_aggs[ $filter_key ] ?? array() );
+$seeded_buckets    = $seeded_filter_agg['buckets'] ?? null;
+$has_buckets       = is_array( $seeded_buckets ) && ! empty( $seeded_buckets );
+
+$seeded_selected       = (array) ( ( (array) ( $seeded_state['activeFilters'] ?? array() ) )[ $filter_key ] ?? array() );
+$all_selected_on_paint = false;
+if ( $has_buckets && ! empty( $seeded_selected ) ) {
+	$all_selected_on_paint = true;
+	foreach ( $seeded_buckets as $bucket ) {
+		$raw_key   = (string) ( $bucket['key'] ?? '' );
+		$slash_idx = strpos( $raw_key, '/' );
+		$value     = false === $slash_idx ? $raw_key : substr( $raw_key, 0, $slash_idx );
+		if ( ! in_array( $value, $seeded_selected, true ) ) {
+			$all_selected_on_paint = false;
+			break;
+		}
+	}
+}
+
+$label = (string) $config['label'];
+?>
+<div
+	<?php echo wp_kses_data( get_block_wrapper_attributes( array( 'class' => 'jetpack-search-filter-wc-attribute' ) ) ); ?>
+	data-wp-interactive="jetpack-search"
+	<?php echo wp_kses_data( wp_interactivity_data_wp_context( array( 'filterKey' => $filter_key ) ) ); ?>
+	data-wp-bind--hidden="!state.hasFilterBuckets"
+	<?php echo $has_buckets ? '' : 'hidden'; ?>
+>
+	<?php if ( '' !== $label ) : ?>
+		<h3 class="jetpack-search-filter__title"><?php echo esc_html( $label ); ?></h3>
+	<?php endif; ?>
+	<ul
+		class="jetpack-search-filter__list"
+		data-wp-bind--hidden="state.allBucketsSelected"
+		<?php echo $all_selected_on_paint ? 'hidden' : ''; ?>
+	>
+		<template
+			data-wp-each--item="state.filterItems"
+			data-wp-each-key="context.item.value"
+		>
+			<li class="jetpack-search-filter__item">
+				<label>
+					<input
+						type="checkbox"
+						data-wp-bind--value="context.item.value"
+						data-wp-on--change="actions.onFilterChange"
+					/>
+					<span
+						class="jetpack-search-filter__label"
+						data-wp-text="context.item.label"
+					></span>
+					<span
+						class="jetpack-search-filter__count"
+						data-wp-bind--hidden="!context.item.showCount"
+						data-wp-text="context.item.countLabel"
+					></span>
+				</label>
+			</li>
+		</template>
+	</ul>
+	<p
+		class="jetpack-search-filter__all-selected"
+		data-wp-bind--hidden="!state.allBucketsSelected"
+		<?php echo $all_selected_on_paint ? '' : 'hidden'; ?>
+	>
+		<?php esc_html_e( 'All filters applied', 'jetpack-search-pkg' ); ?>
+	</p>
+</div>

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/render.php
@@ -53,6 +53,10 @@ $all_selected_on_paint = false;
 if ( $has_buckets && ! empty( $seeded_selected ) ) {
 	$all_selected_on_paint = true;
 	foreach ( $seeded_buckets as $bucket ) {
+		// Keep this `slug/Name` → `slug` extraction in lockstep with
+		// bucketValue() in store/bucket-key.js. The JS getter that powers
+		// hydration uses the same split; if either delimiter changes the
+		// other has to follow.
 		$raw_key   = (string) ( $bucket['key'] ?? '' );
 		$slash_idx = strpos( $raw_key, '/' );
 		$value     = false === $slash_idx ? $raw_key : substr( $raw_key, 0, $slash_idx );

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/style.scss
@@ -1,0 +1,12 @@
+// Shape parity with filter-checkbox / filter-status / filter-rating: the
+// list, item, label, and count classes live in the *shared* SCSS shipped
+// from those blocks (they all use `.jetpack-search-filter__list` etc.), so
+// this file only needs the wrapper-level styling that's specific to the
+// attribute filter. Anything more would duplicate styles already loaded
+// via filter-checkbox's stylesheet.
+.jetpack-search-filter-wc-attribute {
+
+	&[hidden] {
+		display: none;
+	}
+}

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/style.scss
@@ -1,12 +1,64 @@
-// Shape parity with filter-checkbox / filter-status / filter-rating: the
-// list, item, label, and count classes live in the *shared* SCSS shipped
-// from those blocks (they all use `.jetpack-search-filter__list` etc.), so
-// this file only needs the wrapper-level styling that's specific to the
-// attribute filter. Anything more would duplicate styles already loaded
-// via filter-checkbox's stylesheet.
-.jetpack-search-filter-wc-attribute {
+/**
+ * Search product filter — WC attribute.
+ *
+ * Mirrors filter-checkbox / filter-wc-stock-status so all checkbox-shaped
+ * filters render with the same title typography, row spacing, and
+ * count-pill look. The shared `.jetpack-search-filter__*` classes aren't
+ * actually shared at CSS-load time — each filter block scopes its own
+ * copy under its `.wp-block-jetpack-search-filter-*` wrapper — so
+ * duplicate the rules here rather than depending on the
+ * (filter-checkbox-scoped) original.
+ */
+@use "../skeleton" as skeleton;
+
+.wp-block-jetpack-search-filter-wc-attribute {
 
 	&[hidden] {
 		display: none;
+	}
+
+	@include skeleton.shimmer;
+	@include skeleton.filter-rows;
+
+	.jetpack-search-filter__title {
+		font-size: 0.85rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		margin: 0 0 0.5rem;
+		color: inherit;
+	}
+
+	.jetpack-search-filter__list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+	}
+
+	.jetpack-search-filter__item {
+		padding: 0.25rem 0;
+
+		label {
+			display: flex;
+			align-items: center;
+			gap: 0.5rem;
+			cursor: pointer;
+		}
+	}
+
+	.jetpack-search-filter__label {
+		flex: 1;
+	}
+
+	.jetpack-search-filter__count {
+		font-size: 0.8rem;
+		color: inherit;
+		background: color-mix(in sRGB, currentColor 12%, transparent);
+		border-radius: 10px;
+		padding: 0 0.4rem;
+
+		&[hidden] {
+			display: none;
+		}
 	}
 }

--- a/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-wc-attribute/view.js
@@ -1,0 +1,7 @@
+// The attribute block reuses every state getter and action of the shared
+// store — same DOM shape as filter-checkbox, same `state.filterItems` /
+// `state.hasFilterBuckets` / `actions.onFilterChange` bindings. This file
+// exists so the block has its own webpack entry (and its own style.scss
+// hook); all behavior lives in `../../store`.
+import '../../store';
+import './style.scss';

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -579,9 +579,10 @@ class Search_Blocks {
 	 */
 	protected static function filter_block_helpers(): array {
 		return array(
-			'jetpack-search/filter-checkbox'  => Filter_Checkbox::class,
-			'jetpack-search/filter-date'      => Filter_Date::class,
-			'jetpack-search/filter-wc-rating' => Filter_Wc_Rating::class,
+			'jetpack-search/filter-checkbox'     => Filter_Checkbox::class,
+			'jetpack-search/filter-date'         => Filter_Date::class,
+			'jetpack-search/filter-wc-rating'    => Filter_Wc_Rating::class,
+			'jetpack-search/filter-wc-attribute' => Filter_Wc_Attribute::class,
 		);
 	}
 
@@ -608,6 +609,7 @@ class Search_Blocks {
 					$configs[ $key ] = $helper::build_config( $attrs, $key );
 				}
 			}
+
 			if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
 				static::walk_blocks_for_filter_configs( $block['innerBlocks'], $configs );
 			}

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -31,6 +31,7 @@ import ResultsListEdit from '../blocks/results-list/edit';
 import ResultsLoadMoreEdit from '../blocks/results-load-more/edit';
 import ResultsSortEdit from '../blocks/results-sort/edit';
 import SearchInputEdit from '../blocks/search-input/edit';
+import FilterWcAttributeEdit from '../blocks/filter-wc-attribute/edit';
 import SearchResultsEdit, { save as searchResultsSave } from '../blocks/search-results/edit';
 
 // Default save for blocks that own no editor-side state — render.php is the
@@ -55,6 +56,7 @@ const BLOCKS = [
 	[ 'jetpack-search/results-load-more', ResultsLoadMoreEdit ],
 	[ 'jetpack-search/search-results', SearchResultsEdit, searchResultsSave ],
 	[ 'jetpack-search/powered-by', PoweredByEdit ],
+	[ 'jetpack-search/filter-wc-attribute', FilterWcAttributeEdit ],
 ];
 
 // Shape the "Jetpack Search" block category to match the Forms / Monetize /

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -22,6 +22,7 @@ import ActiveFiltersEdit from '../blocks/active-filters/edit';
 import FilterCheckboxEdit from '../blocks/filter-checkbox/edit';
 import FilterDateEdit from '../blocks/filter-date/edit';
 import FilterPostTypeEdit from '../blocks/filter-post-type/edit';
+import FilterWcAttributeEdit from '../blocks/filter-wc-attribute/edit';
 import FilterWcRatingEdit from '../blocks/filter-wc-rating/edit';
 import FiltersPopoverEdit, { save as filtersPopoverSave } from '../blocks/filters-popover/edit';
 import FiltersStackEdit, { save as filtersStackSave } from '../blocks/filters-stack/edit';
@@ -31,7 +32,6 @@ import ResultsListEdit from '../blocks/results-list/edit';
 import ResultsLoadMoreEdit from '../blocks/results-load-more/edit';
 import ResultsSortEdit from '../blocks/results-sort/edit';
 import SearchInputEdit from '../blocks/search-input/edit';
-import FilterWcAttributeEdit from '../blocks/filter-wc-attribute/edit';
 import SearchResultsEdit, { save as searchResultsSave } from '../blocks/search-results/edit';
 
 // Default save for blocks that own no editor-side state — render.php is the

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -559,6 +559,26 @@ const { state, actions } = store( NAMESPACE, {
 		},
 
 		/**
+		 * True when every aggregation bucket for the current filter block is
+		 * already selected. Used by the `filter-wc-attribute` block to hide
+		 * the list and show an "All filters applied" message.
+		 *
+		 * @return {boolean} True when all buckets are selected.
+		 */
+		get allBucketsSelected() {
+			const { filterKey } = getContext();
+			const buckets = state.aggregations?.[ filterKey ]?.buckets;
+			if ( ! Array.isArray( buckets ) || buckets.length === 0 ) {
+				return false;
+			}
+			const selected = state.activeFilters?.[ filterKey ] ?? [];
+			if ( selected.length === 0 ) {
+				return false;
+			}
+			return buckets.every( bucket => selected.includes( bucketValue( bucket.key ) ) );
+		},
+
+		/**
 		 * Item descriptors for the current filter block. Dispatches on
 		 * `filterType`. Lives on the shared namespace so per-block view
 		 * bundles don't clobber siblings. Each item carries `value`,

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -5,6 +5,7 @@ const captured = {
 	state: {},
 	actions: {},
 	callbacks: {},
+	context: {},
 };
 const originalFetch = global.fetch;
 
@@ -22,6 +23,7 @@ jest.mock(
 			}
 			return { state: captured.state, actions: captured.actions };
 		},
+		getContext: () => captured.context,
 	} ),
 	{ virtual: true }
 );
@@ -595,6 +597,26 @@ describe( 'store getters', () => {
 
 		state.sortOrder = 'oldest';
 		expect( state.isSortByOldest ).toBe( true );
+	} );
+
+	it( 'allBucketsSelected returns true only when every bucket is in activeFilters', () => {
+		captured.context = { filterKey: 'pa_color' };
+
+		state.aggregations = {};
+		state.activeFilters = {};
+		expect( state.allBucketsSelected ).toBe( false );
+
+		state.aggregations = { pa_color: { buckets: [ { key: 'red' }, { key: 'blue' } ] } };
+		state.activeFilters = {};
+		expect( state.allBucketsSelected ).toBe( false );
+
+		state.activeFilters = { pa_color: [ 'red' ] };
+		expect( state.allBucketsSelected ).toBe( false );
+
+		state.activeFilters = { pa_color: [ 'red', 'blue' ] };
+		expect( state.allBucketsSelected ).toBe( true );
+
+		captured.context = {};
 	} );
 } );
 

--- a/projects/packages/search/tests/php/Filter_Wc_Attribute_Test.php
+++ b/projects/packages/search/tests/php/Filter_Wc_Attribute_Test.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Filter_Wc_Attribute helper tests.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the WC product attribute filter block helper class.
+ *
+ * Covers the slug-derivation guards and the filterConfig shape since both
+ * are load-bearing for the URL gate (`Search_Blocks::gate_active_filters`)
+ * and the JS aggregation/filter-clause builders.
+ */
+class Filter_Wc_Attribute_Test extends TestCase {
+
+	public function test_derive_filter_key_returns_pa_slug() {
+		$this->assertSame(
+			'pa_color',
+			Filter_Wc_Attribute::derive_filter_key(
+				array( 'attributeTaxonomy' => 'pa_color' )
+			)
+		);
+	}
+
+	public function test_derive_filter_key_rejects_empty_slug() {
+		$this->assertSame(
+			'',
+			Filter_Wc_Attribute::derive_filter_key( array( 'attributeTaxonomy' => '' ) )
+		);
+		$this->assertSame( '', Filter_Wc_Attribute::derive_filter_key( array() ) );
+	}
+
+	public function test_derive_filter_key_rejects_non_pa_taxonomy() {
+		// Defensive: a category slug saved through the editor (manual JSON
+		// edit, schema drift) must not mint an attribute-shaped filter
+		// against a taxonomy that isn't a WC product attribute.
+		$this->assertSame(
+			'',
+			Filter_Wc_Attribute::derive_filter_key(
+				array( 'attributeTaxonomy' => 'category' )
+			)
+		);
+	}
+
+	public function test_derive_filter_key_rejects_reserved_query_param() {
+		// `s`, `orderby`, `min_price`, `max_price` are RESERVED_QUERY_PARAMS.
+		// A `pa_*` taxonomy can't collide with them, but the guard is the
+		// same shared one Filter_Checkbox uses, so verify it's wired up.
+		$this->assertSame(
+			'',
+			Filter_Wc_Attribute::derive_filter_key(
+				array( 'attributeTaxonomy' => 'orderby' )
+			)
+		);
+	}
+
+	public function test_build_config_shapes_filter_type_as_taxonomy() {
+		// JS reads filterType=taxonomy + taxonomy=<slug> to compose the ES
+		// `taxonomy.<slug>.slug_slash_name` aggregation field. Mirrors how
+		// filter-checkbox custom-taxonomy variations work so the data plane
+		// is shared.
+		$config = Filter_Wc_Attribute::build_config(
+			array(
+				'attributeTaxonomy' => 'pa_color',
+				'label'             => 'Colour',
+				'showCount'         => true,
+				'maxItems'          => 15,
+				'bucketSortOrder'   => 'alpha',
+			),
+			'pa_color'
+		);
+		$this->assertSame( 'taxonomy', $config['filterType'] );
+		$this->assertSame( 'pa_color', $config['taxonomy'] );
+		$this->assertSame( 'pa_color', $config['filterKey'] );
+		$this->assertSame( 'Colour', $config['label'] );
+		$this->assertTrue( $config['showCount'] );
+		$this->assertSame( 15, $config['maxItems'] );
+		$this->assertSame( 'alpha', $config['bucketSortOrder'] );
+	}
+
+	public function test_build_config_falls_back_to_default_label_when_attribute_label_empty() {
+		// In a non-WP context (no get_taxonomy()) the fallback humanizes
+		// the slug — verify the fallback path so the chip doesn't render
+		// "Pa_screen_size: …" when a registered taxonomy is missing labels.
+		$config = Filter_Wc_Attribute::build_config(
+			array(
+				'attributeTaxonomy' => 'pa_screen_size',
+				'label'             => '',
+			),
+			'pa_screen_size'
+		);
+		$this->assertSame( 'Screen Size', $config['label'] );
+	}
+
+	public function test_build_config_clamps_negative_max_items_to_one() {
+		$config = Filter_Wc_Attribute::build_config(
+			array(
+				'attributeTaxonomy' => 'pa_color',
+				'maxItems'          => -3,
+			),
+			'pa_color'
+		);
+		$this->assertSame( 1, $config['maxItems'] );
+	}
+}

--- a/projects/packages/search/tests/php/Filter_Wc_Attribute_Test.php
+++ b/projects/packages/search/tests/php/Filter_Wc_Attribute_Test.php
@@ -118,4 +118,23 @@ class Filter_Wc_Attribute_Test extends TestCase {
 		);
 		$this->assertSame( 1, $config['maxItems'] );
 	}
+
+	public function test_default_label_returns_empty_for_non_pa_prefixed_slug() {
+		// Mirrors the prefix guard in derive_filter_key() so a future caller
+		// that skips build_config() can't coerce a non-WC taxonomy slug into
+		// a humanized label this block doesn't represent.
+		$this->assertSame( '', Filter_Wc_Attribute::default_label( array( 'attributeTaxonomy' => 'category' ) ) );
+		$this->assertSame( '', Filter_Wc_Attribute::default_label( array( 'attributeTaxonomy' => '' ) ) );
+	}
+
+	public function test_build_config_defaults_bucket_sort_order_to_count() {
+		// When the attribute is omitted, normalize_bucket_sort_order() falls
+		// through to the 'count' default. Locks the wired-up default so a
+		// future refactor to that helper can't silently flip the order.
+		$config = Filter_Wc_Attribute::build_config(
+			array( 'attributeTaxonomy' => 'pa_color' ),
+			'pa_color'
+		);
+		$this->assertSame( 'count', $config['bucketSortOrder'] );
+	}
 }

--- a/projects/packages/search/tests/php/Filter_Wc_Attribute_Test.php
+++ b/projects/packages/search/tests/php/Filter_Wc_Attribute_Test.php
@@ -47,16 +47,15 @@ class Filter_Wc_Attribute_Test extends TestCase {
 		);
 	}
 
-	public function test_derive_filter_key_rejects_reserved_query_param() {
-		// `s`, `orderby`, `min_price`, `max_price` are RESERVED_QUERY_PARAMS.
-		// A `pa_*` taxonomy can't collide with them, but the guard is the
-		// same shared one Filter_Checkbox uses, so verify it's wired up.
-		$this->assertSame(
-			'',
-			Filter_Wc_Attribute::derive_filter_key(
-				array( 'attributeTaxonomy' => 'orderby' )
-			)
-		);
+	public function test_derive_filter_key_rejects_non_pa_prefix_including_reserved_params() {
+		// Reserved params (`s`, `orderby`, etc.) don't start with `pa_`, so
+		// the prefix guard fires first. The reserved-param check is a secondary
+		// safety net that can't be triggered in practice for this block (no
+		// reserved param starts with `pa_`), but the prefix guard rejects
+		// anything outside the `pa_*` namespace, which covers the intent.
+		$this->assertSame( '', Filter_Wc_Attribute::derive_filter_key( array( 'attributeTaxonomy' => 'orderby' ) ) );
+		$this->assertSame( '', Filter_Wc_Attribute::derive_filter_key( array( 'attributeTaxonomy' => 's' ) ) );
+		$this->assertSame( '', Filter_Wc_Attribute::derive_filter_key( array( 'attributeTaxonomy' => 'min_price' ) ) );
 	}
 
 	public function test_build_config_shapes_filter_type_as_taxonomy() {
@@ -81,6 +80,7 @@ class Filter_Wc_Attribute_Test extends TestCase {
 		$this->assertTrue( $config['showCount'] );
 		$this->assertSame( 15, $config['maxItems'] );
 		$this->assertSame( 'alpha', $config['bucketSortOrder'] );
+		$this->assertSame( array(), $config['valueLabels'] );
 	}
 
 	public function test_build_config_falls_back_to_default_label_when_attribute_label_empty() {
@@ -102,6 +102,17 @@ class Filter_Wc_Attribute_Test extends TestCase {
 			array(
 				'attributeTaxonomy' => 'pa_color',
 				'maxItems'          => -3,
+			),
+			'pa_color'
+		);
+		$this->assertSame( 1, $config['maxItems'] );
+	}
+
+	public function test_build_config_clamps_zero_max_items_to_one() {
+		$config = Filter_Wc_Attribute::build_config(
+			array(
+				'attributeTaxonomy' => 'pa_color',
+				'maxItems'          => 0,
 			),
 			'pa_color'
 		);


### PR DESCRIPTION
## Why

Lets shoppers filter products by a specific WooCommerce product attribute — size, color, material, etc. Each block instance targets one `pa_*` taxonomy; a store with multiple attributes drops in one block per attribute. Reuses the existing taxonomy data plane behind the scenes so no new aggregation branches are needed.

## Proposed changes

- `jetpack-search/filter-wc-attribute` block (block.json, edit.js with JSX, render.php, view.js, style.scss).
- `Filter_Wc_Attribute` PHP helper class (slug derivation with `pa_` prefix guard, label fallbacks, config shape).
- Walker entry to register the filterConfig at SSR time.
- Editor registration with a `pa_*`-only SelectControl seeded from core-data.
- 7 PHP tests for the helper class.

## How

Reuses the `filterType: 'taxonomy'` data plane and the shared `state.filterItems` getter promoted in PR-1 (#48446). No new branches in `resolveFilterFields` — `pa_color` resolves to `taxonomy.pa_color.slug_slash_name` via the existing taxonomy path.

## Stack

**PR-5 of 9** closing [RSM-1929](https://linear.app/a8c/issue/RSM-1929). Foundation = #48446. Independent of PR-2/3/4.

| # | PR | Block slug |
|---|---|---|
| 1 | #48446 | foundation |
| 2 | – | filter-wc-price |
| 3 | – | filter-wc-rating |
| 4 | – | filter-wc-status |
| **5** | **#48450** | **filter-wc-attribute** |

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Stack PR-1 (#48446) + this PR.
2. On a WC site (with at least one `pa_*` attribute registered), insert `jetpack-search/filter-wc-attribute`.
3. Block renders a Placeholder until you pick an attribute in the inspector.
4. After picking (e.g. `pa_color`): `/?s=shirt` shows the color list with live counts. Click an option → URL gains `?pa_color[]=red`. Reload → filter restores.
5. On a non-WC site: inspector picker is disabled with "No product attributes registered" help text.
6. Run `pnpm exec jest tests/js/search-blocks` and `composer phpunit`.

## Screenshots

| Editor — placeholder (no attribute picked) | Editor — Settings inspector with the `pa_*` SelectControl |
| --- | --- |
| ![Editor placeholder](https://github.com/user-attachments/assets/16c3f6a9-0e2f-4ddb-9f09-7669fef7aab9) | ![Inspector picker](https://github.com/user-attachments/assets/f8cf4446-cd41-4ffd-b2c6-e595f79c3c67) |

| Editor — block configured (sample preview) |
| --- |
| ![Editor configured](https://github.com/user-attachments/assets/734cc149-16f8-42c7-9bc2-723ffcf71043) |

| Frontend — filters with live counts | Frontend — `?pa_color[]=red` applied |
| --- | --- |
| ![Frontend filters](https://github.com/user-attachments/assets/c3941416-9650-41ed-a674-e3f7d95e362d) | ![Filter applied](https://github.com/user-attachments/assets/b7598f89-8798-42ad-b3bb-b6a2078ceefe) |

<sub>Captured against a local docker WC site (`jp-sage`) with `pa_color` and `pa_size` registered. Aggregations seeded server-side via a tiny mu-plugin since this clone runs offline-mode and can't reach the WPCOM search backend.</sub>
