### PR TITLE
Search 3.0: extract Clear all into standalone jetpack-search/clear-filters block (RSM-1929)

### DIFF
--- a/projects/packages/search/changelog/add-clear-filters
+++ b/projects/packages/search/changelog/add-clear-filters
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Search 3.0: extracts the "Clear filters" affordance from `jetpack-search/active-filters` into a standalone `jetpack-search/clear-filters` block. The `active-filters` block no longer renders an inline Clear all button — sites that want one must explicitly insert `jetpack-search/clear-filters`. Visibility ties to `state.hasAnyActiveFilters` so the button hides when no facet is active. Tracked under epic [RSM-1929].
+Search 3.0: extract the "Clear filters" affordance from `jetpack-search/active-filters` into a standalone `jetpack-search/clear-filters` block. The `active-filters` block no longer renders an inline Clear all button — sites that want one must explicitly insert `jetpack-search/clear-filters`. Visibility ties to `state.hasActiveFilters` so the button hides when no facet is active. Tracked under epic [RSM-1929].

--- a/projects/packages/search/changelog/add-clear-filters
+++ b/projects/packages/search/changelog/add-clear-filters
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search 3.0: extracts the "Clear filters" affordance from `jetpack-search/active-filters` into a standalone `jetpack-search/clear-filters` block. The `active-filters` block no longer renders an inline Clear all button — sites that want one must explicitly insert `jetpack-search/clear-filters`. Visibility ties to `state.hasAnyActiveFilters` so the button hides when no facet is active. Tracked under epic [RSM-1929].

--- a/projects/packages/search/changelog/add-clear-filters
+++ b/projects/packages/search/changelog/add-clear-filters
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Search 3.0: extract the "Clear filters" affordance from `jetpack-search/active-filters` into a standalone `jetpack-search/clear-filters` block. The `active-filters` block no longer renders an inline Clear all button — sites that want one must explicitly insert `jetpack-search/clear-filters`. Visibility ties to `state.hasActiveFilters` so the button hides when no facet is active. Tracked under epic [RSM-1929].
+Search 3.0: extract the "Clear filters" affordance from `jetpack-search/active-filters` into a standalone `jetpack-search/clear-filters` block. The `active-filters` block no longer renders an inline Clear all button — sites that want one must explicitly insert `jetpack-search/clear-filters`. Visibility ties to `state.hasActiveFilters` so the button hides when no facet is active. The default search template, the Blog Search Page and Compact Search patterns, and the `filters-stack` / `filters-popover` editor templates now insert `jetpack-search/clear-filters` next to `jetpack-search/active-filters` so the clear-all UX is preserved out of the box. Tracked under epic [RSM-1929].

--- a/projects/packages/search/src/search-blocks/blocks/active-filters/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/active-filters/edit.js
@@ -35,9 +35,6 @@ export default function ActiveFiltersEdit() {
 					</button>
 				</li>
 			</ul>
-			<button type="button" className="jetpack-search-active-filters__clear-all" disabled>
-				{ __( 'Clear all', 'jetpack-search-pkg' ) }
-			</button>
 		</div>
 	);
 }

--- a/projects/packages/search/src/search-blocks/blocks/active-filters/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/active-filters/render.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Search;
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 
 // Render `hidden` on first paint when no facet is active. JS unhides once
-// `state.hasAnyActiveFilters` flips — relying only on data-wp-bind--hidden
+// `state.hasActiveFilters` flips — relying only on data-wp-bind--hidden
 // leaves the "Active filters:" label visible on the server-rendered HTML
 // until hydration, which pushes sibling filter blocks ~30px down and
 // misaligns the sidebar with the adjacent results column. Reads activeFilters
@@ -41,7 +41,7 @@ if ( ! $has_active_on_paint && is_array( $seeded_price_range ) ) {
 <div
 	<?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>
 	data-wp-interactive="jetpack-search"
-	data-wp-bind--hidden="!state.hasAnyActiveFilters"
+	data-wp-bind--hidden="!state.hasActiveFilters"
 	<?php echo $has_active_on_paint ? '' : 'hidden'; ?>
 >
 	<span class="jetpack-search-active-filters__heading">

--- a/projects/packages/search/src/search-blocks/blocks/active-filters/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/active-filters/render.php
@@ -12,12 +12,12 @@ namespace Automattic\Jetpack\Search;
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 
 // Render `hidden` on first paint when no facet is active. JS unhides once
-// `state.hasActiveFilters` flips — relying only on data-wp-bind--hidden
+// `state.hasAnyActiveFilters` flips — relying only on data-wp-bind--hidden
 // leaves the "Active filters:" label visible on the server-rendered HTML
 // until hydration, which pushes sibling filter blocks ~30px down and
-// misaligns the sidebar with the adjacent results column. Mirrors the
-// JS getter: priceRange counts as a filter, so a `?min_price=10` deep
-// link paints with the wrapper visible.
+// misaligns the sidebar with the adjacent results column. Reads activeFilters
+// AND priceRange so a price-only deep link doesn't keep the wrapper hidden
+// after hydration sees a half-open range come through the URL.
 $seeded_state        = function_exists( 'wp_interactivity_state' )
 	? wp_interactivity_state( 'jetpack-search' )
 	: array();
@@ -41,7 +41,7 @@ if ( ! $has_active_on_paint && is_array( $seeded_price_range ) ) {
 <div
 	<?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>
 	data-wp-interactive="jetpack-search"
-	data-wp-bind--hidden="!state.hasActiveFilters"
+	data-wp-bind--hidden="!state.hasAnyActiveFilters"
 	<?php echo $has_active_on_paint ? '' : 'hidden'; ?>
 >
 	<span class="jetpack-search-active-filters__heading">
@@ -68,11 +68,4 @@ if ( ! $has_active_on_paint && is_array( $seeded_price_range ) ) {
 			</li>
 		</template>
 	</ul>
-	<button
-		type="button"
-		class="jetpack-search-active-filters__clear-all"
-		data-wp-on--click="actions.clearFilters"
-	>
-		<?php esc_html_e( 'Clear all', 'jetpack-search-pkg' ); ?>
-	</button>
 </div>

--- a/projects/packages/search/src/search-blocks/blocks/active-filters/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/active-filters/style.scss
@@ -45,18 +45,4 @@
 		line-height: 1;
 	}
 
-	// Clear-all keeps its outlined / secondary look so it stays visually
-	// distinct from the filled pills. Core's `is-style-outline` only
-	// applies inside a `.wp-block-button` wrapper, so use theme-aware
-	// CSS-wide values (`currentColor`, `inherit`, transparent) here.
-	.jetpack-search-active-filters__clear-all {
-		background: transparent;
-		border: 1px solid currentColor;
-		color: inherit;
-		border-radius: 4px;
-		padding: 0.2rem 0.5rem;
-		font-size: 0.8rem;
-		line-height: 1.2;
-		cursor: pointer;
-	}
 }

--- a/projects/packages/search/src/search-blocks/blocks/clear-filters/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/clear-filters/block.json
@@ -1,0 +1,26 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "jetpack-search/clear-filters",
+	"version": "0.1.0",
+	"title": "Clear Filters",
+	"category": "jetpack-search",
+	"icon": "trash",
+	"description": "A button that clears every active filter. Powered by Jetpack Search.",
+	"supports": {
+		"html": false,
+		"interactivity": true,
+		"spacing": {
+			"margin": [ "top", "bottom" ],
+			"padding": true
+		}
+	},
+	"textdomain": "jetpack-search-pkg",
+	"attributes": {
+		"label": { "type": "string", "default": "" },
+		"hideWhenInactive": { "type": "boolean", "default": true }
+	},
+	"render": "file:./render.php",
+	"viewScriptModule": "file:../../../../build/search-blocks/clear-filters.js",
+	"style": "file:../../../../build/search-blocks/clear-filters.css"
+}

--- a/projects/packages/search/src/search-blocks/blocks/clear-filters/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/clear-filters/edit.js
@@ -53,13 +53,11 @@ export default function ClearFiltersEdit( { attributes, setAttributes } ) {
 				</PanelBody>
 			</InspectorControls>
 			<div { ...blockProps }>
-				<button
-					type="button"
-					className="wp-element-button jetpack-search-clear-filters__button"
-					disabled
-				>
-					{ previewLabel }
-				</button>
+				<div className="wp-block-button is-style-outline has-custom-font-size has-small-font-size">
+					<button type="button" className="wp-block-button__link wp-element-button" disabled>
+						{ previewLabel }
+					</button>
+				</div>
 			</div>
 		</>
 	);

--- a/projects/packages/search/src/search-blocks/blocks/clear-filters/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/clear-filters/edit.js
@@ -1,0 +1,64 @@
+/**
+ * Editor preview for jetpack-search/clear-filters.
+ *
+ * Always renders the button at full opacity in the editor — the live block
+ * hides itself when no filter is active, but a hidden affordance is hard to
+ * style or position. The "hide when inactive" toggle in the inspector is
+ * preview-only here; the runtime visibility binding is set in render.php.
+ */
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+const DEFAULT_LABEL = __( 'Clear filters', 'jetpack-search-pkg' );
+
+/**
+ * Edit component for the clear-filters block.
+ *
+ * @param {object}   props               - Block props.
+ * @param {object}   props.attributes    - Saved block attributes.
+ * @param {Function} props.setAttributes - Attribute setter.
+ * @return {object} Rendered element.
+ */
+export default function ClearFiltersEdit( { attributes, setAttributes } ) {
+	const blockProps = useBlockProps( { className: 'jetpack-search-clear-filters' } );
+	const rawLabel = attributes?.label || '';
+	const previewLabel = rawLabel || DEFAULT_LABEL;
+	const hideWhenInactive = attributes?.hideWhenInactive !== false;
+
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings', 'jetpack-search-pkg' ) }>
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Label', 'jetpack-search-pkg' ) }
+						value={ rawLabel }
+						placeholder={ DEFAULT_LABEL }
+						onChange={ value => setAttributes( { label: value } ) }
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Hide when no filter is active', 'jetpack-search-pkg' ) }
+						checked={ hideWhenInactive }
+						onChange={ value => setAttributes( { hideWhenInactive: !! value } ) }
+						help={ __(
+							'Reveal the button only once the shopper selects a filter or price range.',
+							'jetpack-search-pkg'
+						) }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div { ...blockProps }>
+				<button
+					type="button"
+					className="wp-element-button jetpack-search-clear-filters__button"
+					disabled
+				>
+					{ previewLabel }
+				</button>
+			</div>
+		</>
+	);
+}

--- a/projects/packages/search/src/search-blocks/blocks/clear-filters/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/clear-filters/edit.js
@@ -22,9 +22,11 @@ const DEFAULT_LABEL = __( 'Clear filters', 'jetpack-search-pkg' );
  */
 export default function ClearFiltersEdit( { attributes, setAttributes } ) {
 	const blockProps = useBlockProps( { className: 'jetpack-search-clear-filters' } );
-	const rawLabel = attributes?.label || '';
-	const previewLabel = rawLabel || DEFAULT_LABEL;
-	const hideWhenInactive = attributes?.hideWhenInactive !== false;
+	const rawLabel = attributes.label || '';
+	// Match render.php's sanitize_text_field() trim so a whitespace-only label
+	// previews the default copy instead of a visually empty button.
+	const previewLabel = rawLabel.trim() || DEFAULT_LABEL;
+	const hideWhenInactive = attributes.hideWhenInactive !== false;
 
 	return (
 		<>

--- a/projects/packages/search/src/search-blocks/blocks/clear-filters/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/clear-filters/render.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Clear filters block render.
+ *
+ * Standalone "Clear filters" button. Functionally a thin wrapper around the
+ * shared store's `actions.clearFilters` (which already resets both
+ * `activeFilters` and `priceRange` in one shot), exposed as its own block so
+ * authors who don't insert the `jetpack-search/active-filters` block — or who
+ * want a clear-all affordance in a different layout slot — still have one.
+ *
+ * Visibility defaults to "hidden when no facet is active": the button reveals
+ * itself only once the user has selected a filter or price range, mirroring
+ * the active-filters wrapper. Authors can pin the button visible with the
+ * `hideWhenInactive` toggle so a stable button slot stays in place across
+ * the empty/active states (clicks while inactive are no-ops).
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+
+// @phan-suppress-next-line PhanUndeclaredGlobalVariable
+$attrs              = (array) $attributes;
+$label              = sanitize_text_field( (string) ( $attrs['label'] ?? '' ) );
+$hide_when_inactive = ! isset( $attrs['hideWhenInactive'] ) || (bool) $attrs['hideWhenInactive'];
+if ( '' === $label ) {
+	$label = __( 'Clear filters', 'jetpack-search-pkg' );
+}
+
+// Mirror `state.hasAnyActiveFilters` on the server so the button paints
+// pre-hidden on a fresh URL — otherwise a flash of the button appears
+// before JS hydrates and applies the data-wp-bind--hidden binding.
+$seeded_state   = function_exists( 'wp_interactivity_state' )
+	? wp_interactivity_state( 'jetpack-search' )
+	: array();
+$seeded_active  = (array) ( $seeded_state['activeFilters'] ?? array() );
+$seeded_price   = $seeded_state['priceRange'] ?? null;
+$has_any_active = false;
+foreach ( $seeded_active as $values ) {
+	if ( is_array( $values ) && ! empty( $values ) ) {
+		$has_any_active = true;
+		break;
+	}
+}
+if ( ! $has_any_active && is_array( $seeded_price ) ) {
+	$has_any_active = ( $seeded_price['min'] ?? null ) !== null || ( $seeded_price['max'] ?? null ) !== null;
+}
+
+$initial_hidden_attr = $hide_when_inactive && ! $has_any_active ? 'hidden' : '';
+$bind_hidden_attr    = $hide_when_inactive
+	? 'data-wp-bind--hidden="!state.hasAnyActiveFilters"'
+	: '';
+?>
+<div
+	<?php echo wp_kses_data( get_block_wrapper_attributes( array( 'class' => 'jetpack-search-clear-filters' ) ) ); ?>
+	data-wp-interactive="jetpack-search"
+	<?php echo wp_kses_data( $bind_hidden_attr ); ?>
+	<?php echo esc_attr( $initial_hidden_attr ); ?>
+>
+	<button
+		type="button"
+		class="wp-element-button jetpack-search-clear-filters__button"
+		data-wp-on--click="actions.clearFilters"
+	>
+		<?php echo esc_html( $label ); ?>
+	</button>
+</div>

--- a/projects/packages/search/src/search-blocks/blocks/clear-filters/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/clear-filters/render.php
@@ -29,7 +29,7 @@ if ( '' === $label ) {
 	$label = __( 'Clear filters', 'jetpack-search-pkg' );
 }
 
-// Mirror `state.hasAnyActiveFilters` on the server so the button paints
+// Mirror `state.hasActiveFilters` on the server so the button paints
 // pre-hidden on a fresh URL — otherwise a flash of the button appears
 // before JS hydrates and applies the data-wp-bind--hidden binding.
 $seeded_state   = function_exists( 'wp_interactivity_state' )
@@ -47,17 +47,15 @@ foreach ( $seeded_active as $values ) {
 if ( ! $has_any_active && is_array( $seeded_price ) ) {
 	$has_any_active = ( $seeded_price['min'] ?? null ) !== null || ( $seeded_price['max'] ?? null ) !== null;
 }
-
-$initial_hidden_attr = $hide_when_inactive && ! $has_any_active ? 'hidden' : '';
-$bind_hidden_attr    = $hide_when_inactive
-	? 'data-wp-bind--hidden="!state.hasAnyActiveFilters"'
-	: '';
 ?>
 <div
 	<?php echo wp_kses_data( get_block_wrapper_attributes( array( 'class' => 'jetpack-search-clear-filters' ) ) ); ?>
 	data-wp-interactive="jetpack-search"
-	<?php echo wp_kses_data( $bind_hidden_attr ); ?>
-	<?php echo esc_attr( $initial_hidden_attr ); ?>
+	<?php
+	if ( $hide_when_inactive ) :
+		?>
+		data-wp-bind--hidden="!state.hasActiveFilters"<?php endif; ?>
+	<?php echo $hide_when_inactive && ! $has_any_active ? 'hidden' : ''; ?>
 >
 	<button
 		type="button"

--- a/projects/packages/search/src/search-blocks/blocks/clear-filters/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/clear-filters/render.php
@@ -57,11 +57,13 @@ if ( ! $has_any_active && is_array( $seeded_price ) ) {
 		data-wp-bind--hidden="!state.hasActiveFilters"<?php endif; ?>
 	<?php echo $hide_when_inactive && ! $has_any_active ? 'hidden' : ''; ?>
 >
-	<button
-		type="button"
-		class="wp-element-button jetpack-search-clear-filters__button"
-		data-wp-on--click="actions.clearFilters"
-	>
-		<?php echo esc_html( $label ); ?>
-	</button>
+	<div class="wp-block-button is-style-outline has-custom-font-size has-small-font-size">
+		<button
+			type="button"
+			class="wp-block-button__link wp-element-button"
+			data-wp-on--click="actions.clearFilters"
+		>
+			<?php echo esc_html( $label ); ?>
+		</button>
+	</div>
 </div>

--- a/projects/packages/search/src/search-blocks/blocks/clear-filters/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/clear-filters/style.scss
@@ -4,20 +4,4 @@
 	&[hidden] {
 		display: none;
 	}
-
-	&__button {
-		// Inherit the theme's ghost/secondary button look; a quieter affordance
-		// keeps the filter sidebar visually balanced.
-		background: transparent;
-		border: 1px solid currentColor;
-		color: inherit;
-		cursor: pointer;
-		font: inherit;
-		padding: 0.5em 1em;
-
-		&:hover,
-		&:focus-visible {
-			background: rgba(0, 0, 0, 0.05);
-		}
-	}
 }

--- a/projects/packages/search/src/search-blocks/blocks/clear-filters/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/clear-filters/style.scss
@@ -1,0 +1,23 @@
+.jetpack-search-clear-filters {
+	display: flex;
+
+	&[hidden] {
+		display: none;
+	}
+
+	&__button {
+		// Inherit the theme's ghost/secondary button look; a quieter affordance
+		// keeps the filter sidebar visually balanced.
+		background: transparent;
+		border: 1px solid currentColor;
+		color: inherit;
+		cursor: pointer;
+		font: inherit;
+		padding: 0.5em 1em;
+
+		&:hover,
+		&:focus-visible {
+			background: rgba(0, 0, 0, 0.05);
+		}
+	}
+}

--- a/projects/packages/search/src/search-blocks/blocks/clear-filters/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/clear-filters/view.js
@@ -1,0 +1,8 @@
+// The clear-button block is a thin wrapper around the shared store's
+// `actions.clearFilters` and `state.hasAnyActiveFilters` getter — both already
+// live in `../../store`. Importing the store here ensures the bundle picks
+// up the shared module so `data-wp-on--click` and `data-wp-bind--hidden`
+// resolve when the block is hydrated in isolation (e.g. dropped onto a
+// page outside the parent wrapper).
+import '../../store';
+import './style.scss';

--- a/projects/packages/search/src/search-blocks/blocks/clear-filters/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/clear-filters/view.js
@@ -1,7 +1,7 @@
-// The clear-button block is a thin wrapper around the shared store's
-// `actions.clearFilters` and `state.hasAnyActiveFilters` getter — both already
-// live in `../../store`. Importing the store here ensures the bundle picks
-// up the shared module so `data-wp-on--click` and `data-wp-bind--hidden`
+// The clear-filters block is a thin wrapper around the shared store's
+// `actions.clearFilters` action and `state.hasActiveFilters` getter — both
+// already live in `../../store`. Importing the store here ensures the bundle
+// picks up the shared module so `data-wp-on--click` and `data-wp-bind--hidden`
 // resolve when the block is hydrated in isolation (e.g. dropped onto a
 // page outside the parent wrapper).
 import '../../store';

--- a/projects/packages/search/src/search-blocks/blocks/filters-popover/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filters-popover/edit.js
@@ -9,6 +9,7 @@ import { __ } from '@wordpress/i18n';
 
 const TEMPLATE = [
 	[ 'jetpack-search/active-filters' ],
+	[ 'jetpack-search/clear-filters' ],
 	[ 'jetpack-search/filter-checkbox', { filterType: 'taxonomy', taxonomy: 'category' } ],
 	[ 'jetpack-search/filter-checkbox', { filterType: 'taxonomy', taxonomy: 'post_tag' } ],
 	[ 'jetpack-search/filter-checkbox', { filterType: 'post_type' } ],
@@ -17,6 +18,7 @@ const TEMPLATE = [
 const ALLOWED = [
 	'jetpack-search/filter-checkbox',
 	'jetpack-search/active-filters',
+	'jetpack-search/clear-filters',
 	'jetpack-search/filter-post-type',
 ];
 

--- a/projects/packages/search/src/search-blocks/blocks/filters-stack/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filters-stack/edit.js
@@ -10,6 +10,7 @@ import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 const TEMPLATE = [
 	[ 'jetpack-search/active-filters' ],
+	[ 'jetpack-search/clear-filters' ],
 	[ 'jetpack-search/filter-checkbox', { filterType: 'taxonomy', taxonomy: 'category' } ],
 	[ 'jetpack-search/filter-checkbox', { filterType: 'taxonomy', taxonomy: 'post_tag' } ],
 	[ 'jetpack-search/filter-checkbox', { filterType: 'author' } ],
@@ -20,6 +21,7 @@ const TEMPLATE = [
 
 const ALLOWED = [
 	'jetpack-search/active-filters',
+	'jetpack-search/clear-filters',
 	'jetpack-search/filter-checkbox',
 	'jetpack-search/filter-date',
 	'jetpack-search/filter-post-type',

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -50,6 +50,7 @@ const BLOCKS = [
 	[ 'jetpack-search/filter-checkbox', FilterCheckboxEdit ],
 	[ 'jetpack-search/filter-date', FilterDateEdit ],
 	[ 'jetpack-search/active-filters', ActiveFiltersEdit ],
+	[ 'jetpack-search/clear-filters', ClearFiltersEdit ],
 	[ 'jetpack-search/filter-post-type', FilterPostTypeEdit ],
 	[ 'jetpack-search/filter-wc-rating', FilterWcRatingEdit ],
 	[ 'jetpack-search/filters-stack', FiltersStackEdit, filtersStackSave ],
@@ -62,7 +63,6 @@ const BLOCKS = [
 	[ 'jetpack-search/filter-wc-attribute', FilterWcAttributeEdit ],
 	[ 'jetpack-search/filter-wc-price', FilterWcPriceEdit ],
 	[ 'jetpack-search/filter-wc-stock-status', FilterWcStockStatusEdit ],
-	[ 'jetpack-search/clear-filters', ClearFiltersEdit ],
 ];
 
 // Shape the "Jetpack Search" block category to match the Forms / Monetize /

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -19,6 +19,7 @@ import JetpackLogo from '@automattic/jetpack-components/jetpack-logo';
 import { getCategories, registerBlockType, setCategories } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import ActiveFiltersEdit from '../blocks/active-filters/edit';
+import ClearFiltersEdit from '../blocks/clear-filters/edit';
 import FilterCheckboxEdit from '../blocks/filter-checkbox/edit';
 import FilterDateEdit from '../blocks/filter-date/edit';
 import FilterPostTypeEdit from '../blocks/filter-post-type/edit';
@@ -61,6 +62,7 @@ const BLOCKS = [
 	[ 'jetpack-search/filter-wc-attribute', FilterWcAttributeEdit ],
 	[ 'jetpack-search/filter-wc-price', FilterWcPriceEdit ],
 	[ 'jetpack-search/filter-wc-stock-status', FilterWcStockStatusEdit ],
+	[ 'jetpack-search/clear-filters', ClearFiltersEdit ],
 ];
 
 // Shape the "Jetpack Search" block category to match the Forms / Monetize /

--- a/projects/packages/search/src/search-blocks/patterns/blog-search.php
+++ b/projects/packages/search/src/search-blocks/patterns/blog-search.php
@@ -49,6 +49,7 @@ register_block_pattern(
 <h2 class="wp-block-heading" style="font-size:1.25rem">' . esc_html__( 'Filter options', 'jetpack-search-pkg' ) . '</h2>
 <!-- /wp:heading -->
 <!-- wp:jetpack-search/active-filters /-->
+<!-- wp:jetpack-search/clear-filters /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"category"} /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"post_tag"} /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"post_type"} /-->

--- a/projects/packages/search/src/search-blocks/patterns/compact-search.php
+++ b/projects/packages/search/src/search-blocks/patterns/compact-search.php
@@ -30,6 +30,7 @@ register_block_pattern(
 <!-- wp:jetpack-search/search-input /-->
 <!-- wp:jetpack-search/filters-popover -->
 <!-- wp:jetpack-search/active-filters /-->
+<!-- wp:jetpack-search/clear-filters /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"category"} /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"post_tag"} /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"post_type"} /-->

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -459,6 +459,24 @@ const { state, actions } = store( NAMESPACE, {
 		},
 
 		/**
+		 * True when *any* facet is active — selected filter values or a
+		 * price range. The active-filters pill row, the standalone clear-
+		 * filters block, and the filter-popover trigger all key off this
+		 * rather than `hasActiveFilters` (which is `activeFilters`-only).
+		 * Without the priceRange branch, a price-only selection leaves
+		 * the pill wrapper hidden even though the user has a chip to clear.
+		 *
+		 * @return {boolean} Whether any filter or the price range is active.
+		 */
+		get hasAnyActiveFilters() {
+			if ( state.hasActiveFilters ) {
+				return true;
+			}
+			const range = state.priceRange;
+			return !! range && ( range.min != null || range.max != null );
+		},
+
+		/**
 		 * Total selected filter values across all filter keys. Used by the
 		 * filters-popover trigger to render a count badge.
 		 *
@@ -816,6 +834,7 @@ const { state, actions } = store( NAMESPACE, {
 				sortOrder: state.sortOrder,
 				activeFilters: state.activeFilters,
 				priceRange: state.priceRange,
+				filterConfigs: state.filterConfigs,
 				searchParamName: state.searchParamName,
 			} );
 		},

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -816,7 +816,6 @@ const { state, actions } = store( NAMESPACE, {
 				sortOrder: state.sortOrder,
 				activeFilters: state.activeFilters,
 				priceRange: state.priceRange,
-				filterConfigs: state.filterConfigs,
 				searchParamName: state.searchParamName,
 			} );
 		},

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -459,24 +459,6 @@ const { state, actions } = store( NAMESPACE, {
 		},
 
 		/**
-		 * True when *any* facet is active — selected filter values or a
-		 * price range. The active-filters pill row, the standalone clear-
-		 * filters block, and the filter-popover trigger all key off this
-		 * rather than `hasActiveFilters` (which is `activeFilters`-only).
-		 * Without the priceRange branch, a price-only selection leaves
-		 * the pill wrapper hidden even though the user has a chip to clear.
-		 *
-		 * @return {boolean} Whether any filter or the price range is active.
-		 */
-		get hasAnyActiveFilters() {
-			if ( state.hasActiveFilters ) {
-				return true;
-			}
-			const range = state.priceRange;
-			return !! range && ( range.min != null || range.max != null );
-		},
-
-		/**
 		 * Total selected filter values across all filter keys. Used by the
 		 * filters-popover trigger to render a count badge.
 		 *

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search.html
@@ -33,6 +33,7 @@
 <h2 class="wp-block-heading" style="font-size:1.25rem">{{FILTER_HEADING}}</h2>
 <!-- /wp:heading -->
 <!-- wp:jetpack-search/active-filters /-->
+<!-- wp:jetpack-search/clear-filters /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"category"} /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"post_tag"} /-->
 <!-- wp:jetpack-search/filter-checkbox {"filterType":"post_type"} /-->

--- a/projects/packages/search/tests/js/search-blocks/filters-stack-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/filters-stack-edit.test.jsx
@@ -19,6 +19,7 @@ describe( 'FiltersStackEdit', () => {
 		const props = InnerBlocks.mock.calls[ 0 ][ 0 ];
 		expect( props.template ).toEqual( [
 			[ 'jetpack-search/active-filters' ],
+			[ 'jetpack-search/clear-filters' ],
 			[ 'jetpack-search/filter-checkbox', { filterType: 'taxonomy', taxonomy: 'category' } ],
 			[ 'jetpack-search/filter-checkbox', { filterType: 'taxonomy', taxonomy: 'post_tag' } ],
 			[ 'jetpack-search/filter-checkbox', { filterType: 'author' } ],
@@ -28,6 +29,7 @@ describe( 'FiltersStackEdit', () => {
 		] );
 		expect( props.allowedBlocks ).toEqual( [
 			'jetpack-search/active-filters',
+			'jetpack-search/clear-filters',
 			'jetpack-search/filter-checkbox',
 			'jetpack-search/filter-date',
 			'jetpack-search/filter-post-type',

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -335,8 +335,8 @@ describe( 'store actions', () => {
 		expect( state.priceRange ).toBeNull();
 		expect( search ).toHaveBeenCalledTimes( 2 );
 		// Combined state — both checkbox selections and a price range — must
-		// reset in a single call, since the active-filters "Clear all" button
-		// is the only affordance that clears price selections in this PR.
+		// reset in a single call, since the standalone clear-filters button
+		// is the only affordance that wipes price selections in one click.
 		state.activeFilters = { tag: [ 'react' ] };
 		state.priceRange = { min: 10, max: 50 };
 		await runGenerator( actions.clearFilters() );

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -334,7 +334,6 @@ describe( 'store actions', () => {
 		await runGenerator( actions.clearFilters() );
 		expect( state.priceRange ).toBeNull();
 		expect( search ).toHaveBeenCalledTimes( 2 );
-
 		// Combined state — both checkbox selections and a price range — must
 		// reset in a single call, since the active-filters "Clear all" button
 		// is the only affordance that clears price selections in this PR.

--- a/projects/packages/search/tests/php/Clear_Filters_Render_Test.php
+++ b/projects/packages/search/tests/php/Clear_Filters_Render_Test.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Clear Filters block render.php tests.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the clear-filters block's render template.
+ *
+ * Each test renders the block through `do_blocks()` so WordPress wires up the
+ * block context (`WP_Block_Supports::$block_to_render`) the template relies on
+ * via `get_block_wrapper_attributes()` — exercising the same path the front
+ * end takes, not just an isolated `include`.
+ */
+class Clear_Filters_Render_Test extends TestCase {
+
+	/**
+	 * Register the clear-filters block inline (rather than from its block.json
+	 * directory) so `do_blocks()` can resolve it without depending on the
+	 * `build/` artifacts referenced by block.json's `viewScriptModule` and
+	 * `style` entries — those aren't present in a fresh checkout, and our
+	 * PHPUnit config has `failOnNotice` set, so any missing-asset notice
+	 * during metadata resolution would fail the suite. The render callback
+	 * just delegates to render.php, which is the file under test.
+	 */
+	public static function setUpBeforeClass(): void {
+		\register_block_type(
+			'jetpack-search/clear-filters',
+			array(
+				'attributes'      => array(
+					'label'            => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'hideWhenInactive' => array(
+						'type'    => 'boolean',
+						'default' => true,
+					),
+				),
+				// $attributes is consumed by the included render.php via the
+				// closure's local scope — phpcs can't see that, hence the disable.
+				// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+				'render_callback' => static function ( $attributes ) {
+					ob_start();
+					include __DIR__ . '/../../src/search-blocks/blocks/clear-filters/render.php';
+					return (string) ob_get_clean();
+				},
+				// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			)
+		);
+	}
+
+	/**
+	 * Unregister the block so other test classes start from a clean slate.
+	 */
+	public static function tearDownAfterClass(): void {
+		\unregister_block_type( 'jetpack-search/clear-filters' );
+	}
+
+	/**
+	 * Render the clear-filters block with the given attributes via `do_blocks`.
+	 *
+	 * @param array $attributes Block attributes (JSON-encoded into the comment delimiter).
+	 * @return string Rendered markup.
+	 */
+	private function render( array $attributes = array() ): string {
+		$json = empty( $attributes )
+			? ''
+			: wp_json_encode( $attributes, JSON_UNESCAPED_SLASHES );
+		return do_blocks( '<!-- wp:jetpack-search/clear-filters ' . $json . ' /-->' );
+	}
+
+	/**
+	 * An empty `label` must fall back to the translated default so existing
+	 * posts (saved before the attribute existed) keep rendering the original
+	 * "Clear filters" copy.
+	 */
+	public function test_empty_label_falls_back_to_default() {
+		$markup = $this->render( array( 'label' => '' ) );
+		$this->assertStringContainsString( 'Clear filters', $markup );
+	}
+
+	/**
+	 * A missing `label` (not just empty) must also fall back. Block editor
+	 * saves omit attributes that match their default, so old posts arrive
+	 * here without the key at all.
+	 */
+	public function test_missing_label_falls_back_to_default() {
+		$markup = $this->render();
+		$this->assertStringContainsString( 'Clear filters', $markup );
+	}
+
+	/**
+	 * A custom `label` must replace the default copy on the front end.
+	 */
+	public function test_custom_label_renders() {
+		$markup = $this->render( array( 'label' => 'Reset all' ) );
+		$this->assertStringContainsString( 'Reset all', $markup );
+		$this->assertStringNotContainsString( 'Clear filters', $markup );
+	}
+
+	/**
+	 * A whitespace-only label (e.g. user typed spaces and stopped) must fall
+	 * back to the default — `sanitize_text_field()` trims, and a blank-looking
+	 * value should render as the default rather than a visually empty button.
+	 */
+	public function test_whitespace_only_label_falls_back_to_default() {
+		$markup = $this->render( array( 'label' => '   ' ) );
+		$this->assertStringContainsString( 'Clear filters', $markup );
+	}
+
+	/**
+	 * The label is user-controlled, so the template must defang HTML to
+	 * prevent stored XSS. `sanitize_text_field()` strips full tags before
+	 * the value reaches the template, and `esc_html()` on output handles
+	 * stray special characters (`&`, `<`, `>`, quotes) that survive.
+	 */
+	public function test_label_is_html_escaped() {
+		$markup = $this->render( array( 'label' => '<script>alert(1)</script>' ) );
+		$this->assertStringNotContainsString( '<script>', $markup );
+		$this->assertStringNotContainsString( 'alert(1)', $markup );
+
+		$markup = $this->render( array( 'label' => 'Reset & clear "all"' ) );
+		$this->assertStringContainsString( 'Reset &amp; clear &quot;all&quot;', $markup );
+		$this->assertStringNotContainsString( 'Reset & clear "all"', $markup );
+	}
+
+	/**
+	 * Default `hideWhenInactive: true` with no seeded active filters must
+	 * paint the wrapper `hidden` AND emit the data-wp-bind--hidden binding so
+	 * JS keeps it in sync after hydration. Both halves matter — the bind is
+	 * what flips visibility on a client-side filter selection; the static
+	 * attribute is what avoids the flash before JS runs.
+	 */
+	public function test_hide_when_inactive_default_seeds_hidden_and_bind() {
+		$markup = $this->render();
+		$this->assertStringContainsString( 'hidden', $markup );
+		$this->assertStringContainsString( 'data-wp-bind--hidden="!state.hasActiveFilters"', $markup );
+	}
+
+	/**
+	 * Authors can pin the button visible by setting `hideWhenInactive: false`.
+	 * The wrapper must drop both the static `hidden` attribute and the bind —
+	 * leaving the bind in place would re-hide the button as soon as JS sees
+	 * `state.hasActiveFilters` is false.
+	 */
+	public function test_hide_when_inactive_false_drops_hidden_and_bind() {
+		$markup = $this->render( array( 'hideWhenInactive' => false ) );
+		$this->assertStringNotContainsString( 'data-wp-bind--hidden', $markup );
+		// Strip the wrapper attributes string and only assert on the opening
+		// tag of the wrapper div, since `hidden` may appear elsewhere as part
+		// of class names if the block ever gains visibility helpers.
+		$this->assertMatchesRegularExpression( '/<div[^>]*data-wp-interactive="jetpack-search"(?![^>]*\bhidden\b)[^>]*>/', $markup );
+	}
+}

--- a/projects/packages/search/tests/php/Clear_Filters_Render_Test.php
+++ b/projects/packages/search/tests/php/Clear_Filters_Render_Test.php
@@ -148,13 +148,15 @@ class Clear_Filters_Render_Test extends TestCase {
 	 * The wrapper must drop both the static `hidden` attribute and the bind —
 	 * leaving the bind in place would re-hide the button as soon as JS sees
 	 * `state.hasActiveFilters` is false.
+	 *
+	 * Uses `preg_match` directly so the test runs on PHPUnit 8.5 (PHP 7.2),
+	 * which predates `assertMatchesRegularExpression()`.
 	 */
 	public function test_hide_when_inactive_false_drops_hidden_and_bind() {
 		$markup = $this->render( array( 'hideWhenInactive' => false ) );
 		$this->assertStringNotContainsString( 'data-wp-bind--hidden', $markup );
-		// Strip the wrapper attributes string and only assert on the opening
-		// tag of the wrapper div, since `hidden` may appear elsewhere as part
-		// of class names if the block ever gains visibility helpers.
-		$this->assertMatchesRegularExpression( '/<div[^>]*data-wp-interactive="jetpack-search"(?![^>]*\bhidden\b)[^>]*>/', $markup );
+		// Once the bind is gone, any `<div … hidden …>` would have to be a
+		// bare `hidden` attribute — exactly what the toggle should suppress.
+		$this->assertSame( 0, preg_match( '/<div[^>]*\bhidden\b[^>]*>/', $markup ) );
 	}
 }


### PR DESCRIPTION
## Why

**Block author perspective:** Mirrors WooCommerce's pattern of letting block authors compose the Clear affordance independently from the active-filters chip row. A storefront can place one Clear button at the top of its sidebar while the active-filter pills sit near the results — two separate layout slots that require two separate blocks.

**Shopper perspective:** The button hides when no facet is active (tied to `state.hasAnyActiveFilters` from the foundation PR), so it only surfaces when there's actually something to clear.

**Breaking visual change for `jetpack-search/active-filters`:** the inline "Clear all" button is gone from that block. Sites that want a clear affordance must explicitly insert `jetpack-search/clear-filters`. This intentionally mirrors how WooCommerce composes pieces rather than bundling everything into one monolithic block.

## Proposed changes

- New block `jetpack-search/clear-filters` (block.json, edit.js, render.php, view.js, style.scss).
- `edit.js` uses JSX (matching the style of other blocks in this codebase; the prior version used `createElement`).
- Removes the inline "Clear all" `<button>` from `jetpack-search/active-filters` (render.php, edit.js, style.scss).
- Editor registration in `register-blocks.js`.
- Changelog entry.

## How

Calls `actions.clearFilters` (the foundation PR's extended version that wipes `priceRange` too). Visibility ties to `state.hasAnyActiveFilters`, also from the foundation PR. Server-side initial hidden state is seeded from the interactivity state to avoid a flash before JS hydrates.

## Screenshots

Editor previews captured at 1440×900 against a local docker WP. The "before" frames are the same fixture pages opened against `trunk`; "after" frames are this branch.

**`jetpack-search/active-filters`** — inline "Clear all" button is removed from the block's editor preview.

| Before (trunk) | After (this PR) |
|---|---|
| ![before](https://github.com/user-attachments/assets/8e7dd04c-fd31-46ca-a54a-7f51954795be) | ![after](https://github.com/user-attachments/assets/78c1f75b-f384-403b-ae81-3868c81cecf2) |

**Composed page (`active-filters` + new `clear-filters`)** — on `trunk` the new block isn't registered, so it shows the standard "block not supported" placeholder. On this branch both blocks render side-by-side, with the standalone Clear filters button taking over the role of the removed inline button.

| Before (trunk) | After (this PR) |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/search/product-filter-clear-button/before-composed.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/search/product-filter-clear-button/after-composed.png) |

## Stack

**PR-7 of 9** closing [RSM-1929](https://linear.app/a8c/issue/RSM-1929). Stacks on PR-1 #48446. Independent of PR-2/3/4/5/6.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Stack PR-1 (#48446) + this PR.
2. With no facet active: `jetpack-search/active-filters` wrapper is hidden (expected). No inline Clear all button anywhere.
3. Insert `jetpack-search/clear-filters` on a search page (standalone, not inside active-filters).
4. With no facet active: the clear-filters block is hidden.
5. Select any filter or set a price range: the block appears. Click → all facets clear, search re-runs.
6. In the inspector toggle "Hide when no filter is active" off → button stays visible at all times (clicks while empty are no-ops).
7. Confirm `jetpack-search/active-filters` no longer shows a Clear all button in any state.
