### PR TITLE
Write: Add full list support and fix block formatting inside lists

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-write-list-support
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-write-list-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Write: Add full list support — slash menu entries, keyboard handling (Tab/Shift-Tab/Backspace), proper block serialization, and fix for text style changes getting stuck inside lists

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -972,6 +972,14 @@
 	padding-inline-start: 1.5em;
 }
 
+.bw-content ul {
+	list-style-type: disc;
+}
+
+.bw-content ol {
+	list-style-type: decimal;
+}
+
 .bw-content li {
 	margin-bottom: 0.25em;
 	line-height: inherit;

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -985,6 +985,11 @@
 	line-height: inherit;
 }
 
+.bw-content li ul,
+.bw-content li ol {
+	margin-bottom: 0;
+}
+
 /* Images in content */
 .bw-content figure,
 .bw-content .bw-image-figure {

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -321,6 +321,11 @@
 	color: #1a1a1a;
 }
 
+.bw-tool:disabled {
+	opacity: 0.3;
+	pointer-events: none;
+}
+
 .bw-tool-divider {
 	width: 1px;
 	height: 20px;

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -345,13 +345,17 @@ function convertToBlocks( html ) {
 			blocks.push(
 				`<!-- wp:quote${ quoteAlignJson } -->\n<blockquote class="wp-block-quote"${ quoteAlignAttr }>${ quoteInner }</blockquote>\n<!-- /wp:quote -->`
 			);
-		} else if ( tag === 'ul' ) {
+		} else if ( tag === 'ul' || tag === 'ol' ) {
+			// Wrap each <li> in wp:list-item block comments.
+			const listItems = Array.from( node.querySelectorAll( ':scope > li' ) )
+				.map(
+					li => `<!-- wp:list-item -->\n<li>${ li.innerHTML.trim() }</li>\n<!-- /wp:list-item -->`
+				)
+				.join( '\n' );
+			const listTag = tag === 'ol' ? 'ol' : 'ul';
+			const attrs = tag === 'ol' ? ' {"ordered":true}' : '';
 			blocks.push(
-				`<!-- wp:list -->\n<ul class="wp-block-list">${ inner }</ul>\n<!-- /wp:list -->`
-			);
-		} else if ( tag === 'ol' ) {
-			blocks.push(
-				`<!-- wp:list {"ordered":true} -->\n<ol class="wp-block-list">${ inner }</ol>\n<!-- /wp:list -->`
+				`<!-- wp:list${ attrs } -->\n<${ listTag } class="wp-block-list">${ listItems }</${ listTag }>\n<!-- /wp:list -->`
 			);
 		} else if ( tag === 'hr' ) {
 			blocks.push(
@@ -463,6 +467,127 @@ function placeCursorAt( el ) {
 	const sel = window.getSelection();
 	sel.removeAllRanges();
 	sel.addRange( range );
+}
+
+/**
+ * If the cursor is inside a list item, extract its content into a new
+ * block-level element and remove the list item. If the list becomes
+ * empty, remove the list too. Returns the new element so the caller
+ * can place the cursor, or null if the cursor was not inside a list.
+ *
+ * @param {string} tag - The HTML tag for the replacement element (e.g. 'p', 'h2').
+ * @return {Element|null} The newly created element, or null if not in a list.
+ */
+function exitListAndApplyBlock( tag ) {
+	const sel = window.getSelection();
+	if ( ! sel.rangeCount ) return null;
+
+	// Walk up from the cursor to find a <li> inside a <ul>/<ol>.
+	let li = null;
+	let node = sel.anchorNode;
+	while ( node && node !== document.body ) {
+		if ( node.nodeType === Node.ELEMENT_NODE && node.tagName === 'LI' ) {
+			li = node;
+			break;
+		}
+		node = node.parentNode;
+	}
+
+	if ( ! li ) return null;
+
+	const list = li.parentNode; // <ul> or <ol>
+	const content = getContent();
+	if ( ! list || ! content ) return null;
+
+	const newEl = document.createElement( tag );
+	newEl.innerHTML = li.innerHTML || '<br>';
+
+	// Collect items before and after this <li> so we can split the list.
+	const items = Array.from( list.children );
+	const idx = items.indexOf( li );
+	const before = items.slice( 0, idx );
+	const after = items.slice( idx + 1 );
+
+	if ( before.length > 0 && after.length > 0 ) {
+		// Middle item: split the list into two with the new element between.
+		const newList = document.createElement( list.tagName );
+		after.forEach( item => newList.appendChild( item ) );
+		list.after( newEl );
+		newEl.after( newList );
+	} else if ( after.length > 0 ) {
+		// First item: insert new element before the list.
+		list.before( newEl );
+	} else {
+		// Last (or only) item: insert new element after the list.
+		list.after( newEl );
+	}
+
+	li.remove();
+	if ( list.children.length === 0 ) {
+		list.remove();
+	}
+
+	placeCursorAt( newEl );
+	updateFormattingState();
+	return newEl;
+}
+
+/**
+ * Indent or outdent a list item by nesting/unnesting it in a sub-list.
+ *
+ * Indent: moves the <li> into a new sub-list appended to the previous sibling <li>.
+ * Outdent: moves the <li> out of its nested list back into the parent list.
+ *
+ * @param {Element} li        - The list item to indent/outdent.
+ * @param {string}  direction - 'indent' or 'outdent'.
+ */
+function indentListItem( li, direction ) {
+	const list = li.parentNode;
+	if ( ! list || ! /^(UL|OL)$/i.test( list.tagName ) ) return;
+
+	if ( direction === 'indent' ) {
+		// Can only indent if there's a previous sibling to nest under.
+		const prev = li.previousElementSibling;
+		if ( ! prev || prev.tagName !== 'LI' ) return;
+
+		// Look for an existing sub-list inside the previous <li>, or create one.
+		let subList = prev.querySelector( ':scope > ul, :scope > ol' );
+		if ( ! subList ) {
+			subList = document.createElement( list.tagName );
+			prev.appendChild( subList );
+		}
+		subList.appendChild( li );
+	} else {
+		// Outdent: the list must be nested inside another <li>.
+		const parentLi = list.parentNode;
+		if ( ! parentLi || parentLi.tagName !== 'LI' ) return;
+
+		const parentList = parentLi.parentNode;
+		if ( ! parentList ) return;
+
+		// Move any siblings after this <li> into a new sub-list kept inside the current list.
+		const siblingsAfter = [];
+		let next = li.nextElementSibling;
+		while ( next ) {
+			siblingsAfter.push( next );
+			next = next.nextElementSibling;
+		}
+		if ( siblingsAfter.length > 0 ) {
+			const tailList = document.createElement( list.tagName );
+			siblingsAfter.forEach( s => tailList.appendChild( s ) );
+			li.appendChild( tailList );
+		}
+
+		// Insert the <li> after its parent <li> in the outer list.
+		parentLi.after( li );
+
+		// Clean up empty lists.
+		if ( list.children.length === 0 ) {
+			list.remove();
+		}
+	}
+
+	placeCursorAt( li );
 }
 
 /**
@@ -870,6 +995,44 @@ function insertNewBlock( tag ) {
 	placeCursorAt( newEl );
 
 	state.showSlashMenu = false;
+}
+
+/**
+ * Insert a new list (ul or ol) replacing the slash command line,
+ * with an initial empty list item for the cursor.
+ *
+ * @param {string} listTag - 'ul' or 'ol'.
+ */
+function insertNewList( listTag ) {
+	const content = getContent();
+	if ( ! content ) return;
+
+	const list = document.createElement( listTag );
+	const li = document.createElement( 'li' );
+	li.innerHTML = '<br>';
+	list.appendChild( li );
+
+	// Find the paragraph containing the slash command.
+	let slashBlock = null;
+	for ( const child of content.children ) {
+		if ( /^(P|DIV)$/i.test( child.tagName ) && /^\/\S*$/.test( child.textContent.trim() ) ) {
+			slashBlock = child;
+			break;
+		}
+	}
+
+	if ( slashBlock ) {
+		slashBlock.after( list );
+		slashBlock.remove();
+	} else {
+		content.appendChild( list );
+	}
+
+	placeCursorAt( li );
+
+	state.showSlashMenu = false;
+	state.formatUList = listTag === 'ul';
+	state.formatOList = listTag === 'ol';
 }
 
 /**
@@ -1546,6 +1709,8 @@ const { state } = store( 'wpcom-write', {
 						const actionMap = {
 							heading: a.insertHeading,
 							image: a.insertImage,
+							'bulleted list': a.insertBulletedList,
+							'numbered list': a.insertNumberedList,
 							video: a.insertVideo,
 							quote: a.insertQuote,
 							divider: a.insertDivider,
@@ -1590,6 +1755,54 @@ const { state } = store( 'wpcom-write', {
 					return;
 				}
 				// No adjacent figure — fall through to native Backspace/Delete.
+			}
+
+			// Tab / Shift-Tab inside a list: indent / outdent.
+			if ( event.key === 'Tab' ) {
+				const sel = window.getSelection();
+				let li = null;
+				if ( sel.rangeCount ) {
+					let n = sel.anchorNode;
+					while ( n && ! n.classList?.contains( 'bw-content' ) ) {
+						if ( n.nodeType === Node.ELEMENT_NODE && n.tagName === 'LI' ) {
+							li = n;
+							break;
+						}
+						n = n.parentNode;
+					}
+				}
+				if ( li ) {
+					event.preventDefault();
+					if ( event.shiftKey ) {
+						indentListItem( li, 'outdent' );
+					} else {
+						indentListItem( li, 'indent' );
+					}
+					return;
+				}
+			}
+
+			// Backspace in an empty list item: exit the list.
+			if ( event.key === 'Backspace' ) {
+				const sel = window.getSelection();
+				let li = null;
+				if ( sel.rangeCount ) {
+					let n = sel.anchorNode;
+					while ( n && ! n.classList?.contains( 'bw-content' ) ) {
+						if ( n.nodeType === Node.ELEMENT_NODE && n.tagName === 'LI' ) {
+							li = n;
+							break;
+						}
+						n = n.parentNode;
+					}
+				}
+				if ( li && li.textContent.trim() === '' ) {
+					event.preventDefault();
+					exitListAndApplyBlock( 'p' );
+					state.formatUList = false;
+					state.formatOList = false;
+					return;
+				}
 			}
 
 			// Enter key: break out of blockquotes/headings and ensure paragraphs.
@@ -1804,25 +2017,37 @@ const { state } = store( 'wpcom-write', {
 		},
 
 		setHeadingNormal() {
-			document.execCommand( 'formatBlock', false, 'p' );
+			if ( ! exitListAndApplyBlock( 'p' ) ) {
+				document.execCommand( 'formatBlock', false, 'p' );
+			}
 			state.formatHeading = false;
+			state.formatUList = false;
+			state.formatOList = false;
 			state.headingLabel = i18n.normal || 'Normal';
 			state.showHeadingMenu = false;
 		},
 
 		setHeadingH2() {
-			document.execCommand( 'formatBlock', false, 'h2' );
+			if ( ! exitListAndApplyBlock( 'h2' ) ) {
+				document.execCommand( 'formatBlock', false, 'h2' );
+			}
 			state.formatHeading = true;
 			state.headingLabel = i18n.heading2 || 'Heading 2';
 			state.formatQuote = false;
+			state.formatUList = false;
+			state.formatOList = false;
 			state.showHeadingMenu = false;
 		},
 
 		setHeadingH3() {
-			document.execCommand( 'formatBlock', false, 'h3' );
+			if ( ! exitListAndApplyBlock( 'h3' ) ) {
+				document.execCommand( 'formatBlock', false, 'h3' );
+			}
 			state.formatHeading = true;
 			state.headingLabel = i18n.heading3 || 'Heading 3';
 			state.formatQuote = false;
+			state.formatUList = false;
+			state.formatOList = false;
 			state.showHeadingMenu = false;
 		},
 
@@ -1870,13 +2095,19 @@ const { state } = store( 'wpcom-write', {
 
 		formatQuote() {
 			if ( state.formatQuote ) {
-				document.execCommand( 'formatBlock', false, 'p' );
+				if ( ! exitListAndApplyBlock( 'p' ) ) {
+					document.execCommand( 'formatBlock', false, 'p' );
+				}
 				state.formatQuote = false;
 			} else {
-				document.execCommand( 'formatBlock', false, 'blockquote' );
+				if ( ! exitListAndApplyBlock( 'blockquote' ) ) {
+					document.execCommand( 'formatBlock', false, 'blockquote' );
+				}
 				state.formatQuote = true;
 				state.formatHeading = false;
 			}
+			state.formatUList = false;
+			state.formatOList = false;
 		},
 
 		// --- Link ---
@@ -2160,6 +2391,14 @@ const { state } = store( 'wpcom-write', {
 			state.showImageModal = true;
 			state.imageUrl = '';
 			focusModalInput();
+		},
+
+		insertBulletedList() {
+			insertNewList( 'ul' );
+		},
+
+		insertNumberedList() {
+			insertNewList( 'ol' );
 		},
 
 		insertQuote() {

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1046,6 +1046,7 @@ function updateFormattingState() {
 	state.formatStrikethrough = document.queryCommandState( 'strikeThrough' );
 	state.formatOList = document.queryCommandState( 'insertOrderedList' );
 	state.formatUList = document.queryCommandState( 'insertUnorderedList' );
+	state.insideList = state.formatOList || state.formatUList;
 
 	// Check block-level formatting by walking up from cursor.
 	const sel = window.getSelection();
@@ -1858,7 +1859,8 @@ const { state } = store( 'wpcom-write', {
 
 			const text = node.textContent;
 			// Show menu when the line starts with "/" and optionally a filter after it.
-			if ( /^\/\S*$/.test( text.trimStart() ) ) {
+			// Suppress inside lists — block-level insertions are not supported there.
+			if ( /^\/\S*$/.test( text.trimStart() ) && ! state.insideList ) {
 				// User just dismissed the menu with Escape — skip this keyup cycle.
 				if ( slashMenuEscaped ) {
 					slashMenuEscaped = false;

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -533,6 +533,49 @@ function exitListAndApplyBlock( tag ) {
 }
 
 /**
+ * If the cursor is inside a heading or blockquote, replace it with a
+ * list containing the block's content as the first item. Returns true
+ * if a conversion happened, false otherwise.
+ *
+ * @param {string} listTag - 'ul' or 'ol'.
+ * @return {boolean} Whether a block was converted to a list.
+ */
+function exitBlockAndApplyList( listTag ) {
+	const sel = window.getSelection();
+	if ( ! sel.rangeCount ) return false;
+
+	let block = null;
+	let node = sel.anchorNode;
+	const content = getContent();
+	while ( node && node !== content && node !== document.body ) {
+		if (
+			node.nodeType === Node.ELEMENT_NODE &&
+			( /^H[1-6]$/.test( node.tagName ) || node.tagName === 'BLOCKQUOTE' )
+		) {
+			block = node;
+			break;
+		}
+		node = node.parentNode;
+	}
+
+	if ( ! block ) return false;
+
+	const list = document.createElement( listTag );
+	const li = document.createElement( 'li' );
+	li.innerHTML = block.innerHTML || '<br>';
+	list.appendChild( li );
+
+	block.replaceWith( list );
+
+	placeCursorAt( li );
+	state.formatHeading = false;
+	state.formatQuote = false;
+	state.headingLabel = i18n.normal || 'Normal';
+	updateFormattingState();
+	return true;
+}
+
+/**
  * Indent or outdent a list item by nesting/unnesting it in a sub-list.
  *
  * Indent: moves the <li> into a new sub-list appended to the previous sibling <li>.
@@ -2082,15 +2125,25 @@ const { state } = store( 'wpcom-write', {
 		// --- Lists ---
 
 		formatUList() {
-			document.execCommand( 'insertUnorderedList' );
-			state.formatUList = document.queryCommandState( 'insertUnorderedList' );
-			state.formatOList = document.queryCommandState( 'insertOrderedList' );
+			if ( exitBlockAndApplyList( 'ul' ) ) {
+				state.formatUList = true;
+				state.formatOList = false;
+			} else {
+				document.execCommand( 'insertUnorderedList' );
+				state.formatUList = document.queryCommandState( 'insertUnorderedList' );
+				state.formatOList = document.queryCommandState( 'insertOrderedList' );
+			}
 		},
 
 		formatOList() {
-			document.execCommand( 'insertOrderedList' );
-			state.formatOList = document.queryCommandState( 'insertOrderedList' );
-			state.formatUList = document.queryCommandState( 'insertUnorderedList' );
+			if ( exitBlockAndApplyList( 'ol' ) ) {
+				state.formatOList = true;
+				state.formatUList = false;
+			} else {
+				document.execCommand( 'insertOrderedList' );
+				state.formatOList = document.queryCommandState( 'insertOrderedList' );
+				state.formatUList = document.queryCommandState( 'insertUnorderedList' );
+			}
 		},
 
 		// --- Block formatting ---

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -239,6 +239,7 @@ function wpcom_write_render_admin_page() {
 			'formatAlignRight'    => false,
 			'formatOList'         => false,
 			'formatUList'         => false,
+			'insideList'          => false,
 			'showRecoveryBanner'  => false,
 		)
 	);
@@ -337,9 +338,9 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 			</div>
 			<span class="bw-tool-divider"></span>
 			<!-- Alignment -->
-			<button class="bw-tool" data-wp-on--click="actions.alignLeft" data-wp-class--bw-tool-active="state.formatAlignLeft" title="<?php echo esc_attr__( 'Align left', 'jetpack-mu-wpcom' ); ?>"><span class="dashicons dashicons-editor-alignleft"></span></button>
-			<button class="bw-tool" data-wp-on--click="actions.alignCenter" data-wp-class--bw-tool-active="state.formatAlignCenter" title="<?php echo esc_attr__( 'Align center', 'jetpack-mu-wpcom' ); ?>"><span class="dashicons dashicons-editor-aligncenter"></span></button>
-			<button class="bw-tool" data-wp-on--click="actions.alignRight" data-wp-class--bw-tool-active="state.formatAlignRight" title="<?php echo esc_attr__( 'Align right', 'jetpack-mu-wpcom' ); ?>"><span class="dashicons dashicons-editor-alignright"></span></button>
+			<button class="bw-tool" data-wp-on--click="actions.alignLeft" data-wp-class--bw-tool-active="state.formatAlignLeft" data-wp-bind--disabled="state.insideList" title="<?php echo esc_attr__( 'Align left', 'jetpack-mu-wpcom' ); ?>"><span class="dashicons dashicons-editor-alignleft"></span></button>
+			<button class="bw-tool" data-wp-on--click="actions.alignCenter" data-wp-class--bw-tool-active="state.formatAlignCenter" data-wp-bind--disabled="state.insideList" title="<?php echo esc_attr__( 'Align center', 'jetpack-mu-wpcom' ); ?>"><span class="dashicons dashicons-editor-aligncenter"></span></button>
+			<button class="bw-tool" data-wp-on--click="actions.alignRight" data-wp-class--bw-tool-active="state.formatAlignRight" data-wp-bind--disabled="state.insideList" title="<?php echo esc_attr__( 'Align right', 'jetpack-mu-wpcom' ); ?>"><span class="dashicons dashicons-editor-alignright"></span></button>
 			<span class="bw-tool-divider"></span>
 			<!-- Lists -->
 			<button class="bw-tool" data-wp-on--click="actions.formatUList" data-wp-class--bw-tool-active="state.formatUList" title="<?php echo esc_attr__( 'Bulleted list', 'jetpack-mu-wpcom' ); ?>"><span class="dashicons dashicons-editor-ul"></span></button>
@@ -348,7 +349,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 			<!-- Block-level -->
 			<button class="bw-tool" data-wp-on--click="actions.toggleLinkInput" data-wp-class--bw-tool-active="state.showLinkInput" title="<?php echo esc_attr__( 'Link', 'jetpack-mu-wpcom' ); ?>"><span class="dashicons dashicons-admin-links"></span></button>
 			<button class="bw-tool" data-wp-on--click="actions.formatQuote" data-wp-class--bw-tool-active="state.formatQuote" title="<?php echo esc_attr__( 'Quote', 'jetpack-mu-wpcom' ); ?>"><span class="dashicons dashicons-format-quote"></span></button>
-			<button class="bw-tool" data-wp-on--click="actions.openImageModal" title="<?php echo esc_attr__( 'Image', 'jetpack-mu-wpcom' ); ?>"><span class="dashicons dashicons-format-image"></span></button>
+			<button class="bw-tool" data-wp-on--click="actions.openImageModal" data-wp-bind--disabled="state.insideList" title="<?php echo esc_attr__( 'Image', 'jetpack-mu-wpcom' ); ?>"><span class="dashicons dashicons-format-image"></span></button>
 		</div>
 	</div>
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -449,6 +449,14 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 			<span class="bw-slash-icon">&ldquo;</span>
 			<div><strong><?php echo esc_html__( 'Quote', 'jetpack-mu-wpcom' ); ?></strong><span class="bw-slash-desc"><?php echo esc_html__( 'Highlight a quote', 'jetpack-mu-wpcom' ); ?></span></div>
 		</div>
+		<div class="bw-slash-item" data-wp-on--click="actions.insertBulletedList" data-wp-on--mousedown="actions.preventToolbarBlur">
+			<span class="bw-slash-icon">&bull;</span>
+			<div><strong><?php echo esc_html__( 'Bulleted list', 'jetpack-mu-wpcom' ); ?></strong><span class="bw-slash-desc"><?php echo esc_html__( 'An unordered list', 'jetpack-mu-wpcom' ); ?></span></div>
+		</div>
+		<div class="bw-slash-item" data-wp-on--click="actions.insertNumberedList" data-wp-on--mousedown="actions.preventToolbarBlur">
+			<span class="bw-slash-icon">1.</span>
+			<div><strong><?php echo esc_html__( 'Numbered list', 'jetpack-mu-wpcom' ); ?></strong><span class="bw-slash-desc"><?php echo esc_html__( 'An ordered list', 'jetpack-mu-wpcom' ); ?></span></div>
+		</div>
 		<div class="bw-slash-item" data-wp-on--click="actions.insertVideo" data-wp-on--mousedown="actions.preventToolbarBlur">
 			<span class="bw-slash-icon">&#9654;</span>
 			<div><strong><?php echo esc_html__( 'Video', 'jetpack-mu-wpcom' ); ?></strong><span class="bw-slash-desc"><?php echo esc_html__( 'Embed a YouTube or Vimeo video', 'jetpack-mu-wpcom' ); ?></span></div>

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -261,6 +261,18 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Test that the slash menu contains list entries.
+	 */
+	public function test_slash_menu_contains_list_entries() {
+		wp_set_current_user( $this->admin_id );
+
+		$output = $this->render_template();
+
+		$this->assertStringContainsString( 'actions.insertBulletedList', $output );
+		$this->assertStringContainsString( 'actions.insertNumberedList', $output );
+	}
+
+	/**
 	 * Test that the text color picker is rendered.
 	 */
 	public function test_toolbar_contains_text_color_picker() {


### PR DESCRIPTION
Fixes RSM-590
Fixes RSM-1482
Related to RSM-1708

## Proposed changes

* Add full list support to the Write editor: slash menu entries for "Bulleted list" and "Numbered list", keyboard handling (Tab to indent, Shift-Tab to outdent, Backspace in empty item to exit list), and proper `wp:list-item` block serialization for Gutenberg compatibility.
* Fix text style changes (headings, quotes) getting stuck when applied inside a list — `formatBlock` was nesting inside the `<li>` instead of replacing it. Added `exitListAndApplyBlock()` helper that extracts the list item content, splits the list if needed, and inserts the new block element.
* Add explicit `list-style-type` CSS for `ul` (disc) and `ol` (decimal) to override wp-admin resets that strip default bullets.
* Replace `document.execCommand('indent'/'outdent')` (which wraps in `<blockquote>`) with manual DOM manipulation that properly nests/unnests list items in sub-lists.
* Call `updateFormattingState()` after exiting a list so toolbar buttons (alignment, heading, quote) reflect the actual state.
* Fix nested list margin — remove bottom margin on sub-lists inside list items.
* Disable unsupported toolbar actions (alignment, image) and slash menu inside lists to prevent broken markup from block-level insertions.
* Fix list conversion from headings and blockquotes — clicking a list button while inside an `<h2>`, `<h3>`, or `<blockquote>` now replaces the block with a list containing its content as the first item.

<img width="811" height="350" alt="Screenshot 2026-05-01 at 11 40 40 AM" src="https://github.com/user-attachments/assets/6e9a4eeb-5121-4099-9d25-9001e8adc4a9" />


## Related product discussion/links

* p1729596498285489-slack-C089GQWHV3S (RSM-590)
* p1729596498285489-slack-C089GQWHV3S (RSM-1482)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Go to a WordPress.com site with the Write editor enabled
* **List creation**: Click the bulleted list or numbered list toolbar buttons — verify items appear with visible bullets/numbers
* **Slash menu**: Type `/` in a new line, select "Bulleted list" or "Numbered list" — verify a list is inserted with the cursor in the first item
* **Keyboard — indent**: Inside a list item, press Tab — verify the item nests under the previous sibling (does not disappear)
* **Keyboard — outdent**: Press Shift-Tab on a nested item — verify it moves back to the parent list
* **Keyboard — exit**: Press Backspace in an empty list item — verify it exits to a paragraph
* **Heading inside list**: While in a list item, change to Heading 2 or Heading 3 via the heading dropdown — verify the item exits the list and becomes a heading, and the list splits correctly if the item was in the middle
* **Quote inside list**: While in a list item, click the Quote button — verify same exit behavior
* **List from heading/quote**: While in a heading or blockquote, click a list button — verify it converts to a list and you can add more items
* **Disabled buttons**: While inside a list, verify alignment buttons and image button are dimmed and unclickable, and slash menu does not appear
* **Toolbar state**: After switching from list to heading/quote, verify alignment buttons reset correctly (left should be active, center/right deactivated)
* **Serialization**: Create a post with lists, publish, then open in the block editor — verify it parses correctly with proper `wp:list` and `wp:list-item` blocks
