### PR TITLE
build: Always remove test-only deps from composer.json

### DIFF
--- a/tools/cli/commands/build.js
+++ b/tools/cli/commands/build.js
@@ -706,7 +706,7 @@ async function buildProject( t ) {
 	// We don't need to `composer install` if it's a CI build of a non-plugin with no build script. Except for changelogger.
 	const skipInstall = t.argv.forMirrors && script === null && ! t.project.startsWith( 'plugins/' );
 
-	if ( t.argv.forMirrors && ! skipInstall ) {
+	if ( t.argv.forMirrors ) {
 		// Mirroring needs to munge the project's composer.json to point to the built files..
 		const idx = composerJson.repositories?.findIndex( r => r.options?.monorepo );
 		if ( typeof idx === 'number' && idx >= 0 ) {
@@ -755,8 +755,8 @@ async function buildProject( t ) {
 					JSON.stringify( composerJson, null, '\t' ) + '\n',
 					{ encoding: 'utf8' }
 				);
-				// Update composer.lock too, if any.
-				if ( await fsExists( `${ t.cwd }/composer.lock` ) ) {
+				// Update composer.lock too, if any and if we're installing.
+				if ( ! skipInstall && ( await fsExists( `${ t.cwd }/composer.lock` ) ) ) {
 					await t.execa( 'composer', [ 'update', '--no-install', ...Object.keys( versions ) ], {
 						cwd: t.cwd,
 						stdio: [ 'ignore', 'inherit', 'inherit' ],


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
Previously we were only removing them if we weren't skipping the `composer install`, but still possibly changing the `@dev` versions to built version numbers depending on the build ordering. To be consistent, let's just always remove them.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p1777640351397959/1777621012.398119-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Should be only expected changes to the build artifacts.