### PR TITLE
Donations Block: admin defaults (frequency/amounts/toggles)

### DIFF
--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -9,14 +9,14 @@
  */
 return [
     // # Issue statistics:
-    // PhanTypeMismatchArgument : 430+ occurrences
+    // PhanTypeMismatchArgument : 420+ occurrences
     // PhanPluginDuplicateConditionalNullCoalescing : 260+ occurrences
     // PhanTypeMismatchArgumentProbablyReal : 200+ occurrences
     // PhanTypeMismatchReturn : 140+ occurrences
     // PhanTypeMismatchReturnProbablyReal : 120+ occurrences
     // PhanTypePossiblyInvalidDimOffset : 90+ occurrences
+    // PhanTypeArraySuspiciousNullable : 70+ occurrences
     // PhanDeprecatedFunction : 60+ occurrences
-    // PhanTypeArraySuspiciousNullable : 55+ occurrences
     // PhanRedefineFunction : 45+ occurrences
     // PhanPluginDuplicateAdjacentStatement : 40+ occurrences
     // PhanTypeExpectedObjectPropAccess : 30+ occurrences
@@ -151,7 +151,6 @@ return [
         'extensions/blocks/ai-chat/ai-chat.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchArgument'],
         'extensions/blocks/blog-stats/blog-stats.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'extensions/blocks/calendly/calendly.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturnProbablyReal'],
-        'extensions/blocks/donations/donations.php' => ['PhanTypeMismatchArgument'],
         'extensions/blocks/gif/gif.php' => ['PhanPluginDuplicateConditionalNullCoalescing', 'PhanTypeMismatchReturnProbablyReal'],
         'extensions/blocks/google-calendar/google-calendar.php' => ['PhanPluginDuplicateConditionalNullCoalescing'],
         'extensions/blocks/image-compare/image-compare.php' => ['PhanTypeMismatchArgument'],

--- a/projects/plugins/jetpack/changelog/add-donations-block-style-supports
+++ b/projects/plugins/jetpack/changelog/add-donations-block-style-supports
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Donations Block: Add Gutenberg style settings (border, color, typography, spacing) and custom controls for active tab and selected amount colors.

--- a/projects/plugins/jetpack/changelog/add-donations-hide-one-time-interval
+++ b/projects/plugins/jetpack/changelog/add-donations-hide-one-time-interval
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-Donations Block: Add an admin toggle to hide the One-Time interval, and require at least one frequency (one-time, monthly, or annual) to remain enabled.
+Donations Block: Add admin controls for hiding the One-Time interval, choosing the default frequency, and setting a per-frequency default donation amount. At least one frequency must remain enabled.

--- a/projects/plugins/jetpack/changelog/add-donations-hide-one-time-interval
+++ b/projects/plugins/jetpack/changelog/add-donations-hide-one-time-interval
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-Donations Block: Add admin controls for hiding the One-Time interval, choosing the default frequency, and setting a per-frequency default donation amount. At least one frequency must remain enabled.
+Donations Block: Add admin controls for hiding the One-Time interval, choosing the default frequency, setting a per-frequency default donation amount, and configuring the suggested custom amount. At least one frequency must remain enabled.

--- a/projects/plugins/jetpack/changelog/add-donations-hide-one-time-interval
+++ b/projects/plugins/jetpack/changelog/add-donations-hide-one-time-interval
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-Donations Block: Add an admin toggle to hide the One-Time interval, mirroring the existing monthly/annual toggles.
+Donations Block: Add an admin toggle to hide the One-Time interval, and require at least one frequency (one-time, monthly, or annual) to remain enabled.

--- a/projects/plugins/jetpack/changelog/add-donations-hide-one-time-interval
+++ b/projects/plugins/jetpack/changelog/add-donations-hide-one-time-interval
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Donations Block: Add an admin toggle to hide the One-Time interval, mirroring the existing monthly/annual toggles.

--- a/projects/plugins/jetpack/changelog/update-donations-theme-integration
+++ b/projects/plugins/jetpack/changelog/update-donations-theme-integration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Donations Block: Inherit colors and typography from the active theme, and let the Donate button pick up theme button styles.

--- a/projects/plugins/jetpack/extensions/blocks/donations/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/donations/block.json
@@ -134,6 +134,17 @@
 		},
 		"tabPadding": {
 			"type": "object"
+		},
+		"buttonFontSize": {
+			"type": "string"
+		},
+		"buttonPadding": {
+			"type": "object"
+		},
+		"buttonAlignment": {
+			"type": "string",
+			"enum": [ "", "left", "center", "right", "full" ],
+			"default": ""
 		}
 	},
 	"example": {}

--- a/projects/plugins/jetpack/extensions/blocks/donations/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/donations/block.json
@@ -34,6 +34,10 @@
 	"textdomain": "jetpack",
 	"category": "monetize",
 	"icon": "<svg viewBox='0 0 24 24' width='24' height='24' xmlns='http://www.w3.org/2000/svg'><path d='M16.5 4.5c2.206 0 4 1.794 4 4 0 4.67-5.543 8.94-8.5 11.023C9.043 17.44 3.5 13.17 3.5 8.5c0-2.206 1.794-4 4-4 1.298 0 2.522.638 3.273 1.706L12 7.953l1.227-1.746c.75-1.07 1.975-1.707 3.273-1.707m0-1.5c-1.862 0-3.505.928-4.5 2.344C11.005 3.928 9.362 3 7.5 3 4.462 3 2 5.462 2 8.5c0 5.72 6.5 10.438 10 12.85 3.5-2.412 10-7.13 10-12.85C22 5.462 19.538 3 16.5 3z' /></svg>",
+	"styles": [
+		{ "name": "default", "label": "Default", "isDefault": true },
+		{ "name": "buttons", "label": "Buttons" }
+	],
 	"supports": {
 		"html": false,
 		"color": {

--- a/projects/plugins/jetpack/extensions/blocks/donations/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/donations/block.json
@@ -51,11 +51,6 @@
 			"lineHeight": true,
 			"letterSpacing": true
 		},
-		"spacing": {
-			"padding": true,
-			"margin": true,
-			"blockGap": true
-		},
 		"__experimentalBorder": {
 			"color": true,
 			"radius": true,

--- a/projects/plugins/jetpack/extensions/blocks/donations/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/donations/block.json
@@ -157,6 +157,9 @@
 		},
 		"amountBorderRadius": {
 			"type": [ "string", "object" ]
+		},
+		"buttonBorderRadius": {
+			"type": [ "string", "object" ]
 		}
 	},
 	"example": {}

--- a/projects/plugins/jetpack/extensions/blocks/donations/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/donations/block.json
@@ -124,6 +124,9 @@
 		"selectedAmountTextColor": {
 			"type": "string"
 		},
+		"selectedAmountOutlineColor": {
+			"type": "string"
+		},
 		"tabsAppearance": {
 			"type": "string",
 			"enum": [ "tabs", "buttons" ],

--- a/projects/plugins/jetpack/extensions/blocks/donations/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/donations/block.json
@@ -100,6 +100,9 @@
 		"defaultInterval": {
 			"type": "string"
 		},
+		"customAmountPlaceholder": {
+			"type": "number"
+		},
 		"chooseAmountText": {
 			"type": "string"
 		},

--- a/projects/plugins/jetpack/extensions/blocks/donations/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/donations/block.json
@@ -34,7 +34,41 @@
 	"textdomain": "jetpack",
 	"category": "monetize",
 	"icon": "<svg viewBox='0 0 24 24' width='24' height='24' xmlns='http://www.w3.org/2000/svg'><path d='M16.5 4.5c2.206 0 4 1.794 4 4 0 4.67-5.543 8.94-8.5 11.023C9.043 17.44 3.5 13.17 3.5 8.5c0-2.206 1.794-4 4-4 1.298 0 2.522.638 3.273 1.706L12 7.953l1.227-1.746c.75-1.07 1.975-1.707 3.273-1.707m0-1.5c-1.862 0-3.505.928-4.5 2.344C11.005 3.928 9.362 3 7.5 3 4.462 3 2 5.462 2 8.5c0 5.72 6.5 10.438 10 12.85 3.5-2.412 10-7.13 10-12.85C22 5.462 19.538 3 16.5 3z' /></svg>",
-	"supports": { "html": false },
+	"supports": {
+		"html": false,
+		"color": {
+			"background": true,
+			"text": true,
+			"button": true,
+			"link": true,
+			"gradients": false
+		},
+		"typography": {
+			"fontSize": true,
+			"fontFamily": true,
+			"fontStyle": true,
+			"fontWeight": true,
+			"lineHeight": true,
+			"letterSpacing": true
+		},
+		"spacing": {
+			"padding": true,
+			"margin": true,
+			"blockGap": true
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"style": true,
+			"width": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"style": true,
+				"width": true
+			}
+		}
+	},
 	"attributes": {
 		"currency": {
 			"type": "string",
@@ -75,6 +109,24 @@
 			"type": "string"
 		},
 		"fallbackLinkUrl": {
+			"type": "string"
+		},
+		"activeTabBackgroundColor": {
+			"type": "string"
+		},
+		"activeTabTextColor": {
+			"type": "string"
+		},
+		"inactiveTabBackgroundColor": {
+			"type": "string"
+		},
+		"inactiveTabTextColor": {
+			"type": "string"
+		},
+		"selectedAmountBackgroundColor": {
+			"type": "string"
+		},
+		"selectedAmountTextColor": {
 			"type": "string"
 		}
 	},

--- a/projects/plugins/jetpack/extensions/blocks/donations/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/donations/block.json
@@ -97,6 +97,9 @@
 			"type": "boolean",
 			"default": true
 		},
+		"defaultInterval": {
+			"type": "string"
+		},
 		"chooseAmountText": {
 			"type": "string"
 		},

--- a/projects/plugins/jetpack/extensions/blocks/donations/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/donations/block.json
@@ -160,6 +160,11 @@
 		},
 		"buttonBorderRadius": {
 			"type": [ "string", "object" ]
+		},
+		"contentAlignment": {
+			"type": "string",
+			"enum": [ "", "left", "center", "right" ],
+			"default": ""
 		}
 	},
 	"example": {}

--- a/projects/plugins/jetpack/extensions/blocks/donations/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/donations/block.json
@@ -128,6 +128,12 @@
 		},
 		"selectedAmountTextColor": {
 			"type": "string"
+		},
+		"tabFontSize": {
+			"type": "string"
+		},
+		"tabPadding": {
+			"type": "object"
 		}
 	},
 	"example": {}

--- a/projects/plugins/jetpack/extensions/blocks/donations/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/donations/block.json
@@ -153,6 +153,15 @@
 			"type": "string",
 			"enum": [ "", "left", "center", "right", "full" ],
 			"default": ""
+		},
+		"amountFontSize": {
+			"type": "string"
+		},
+		"amountBorder": {
+			"type": "object"
+		},
+		"amountBorderRadius": {
+			"type": [ "string", "object" ]
 		}
 	},
 	"example": {}

--- a/projects/plugins/jetpack/extensions/blocks/donations/block.json
+++ b/projects/plugins/jetpack/extensions/blocks/donations/block.json
@@ -34,10 +34,6 @@
 	"textdomain": "jetpack",
 	"category": "monetize",
 	"icon": "<svg viewBox='0 0 24 24' width='24' height='24' xmlns='http://www.w3.org/2000/svg'><path d='M16.5 4.5c2.206 0 4 1.794 4 4 0 4.67-5.543 8.94-8.5 11.023C9.043 17.44 3.5 13.17 3.5 8.5c0-2.206 1.794-4 4-4 1.298 0 2.522.638 3.273 1.706L12 7.953l1.227-1.746c.75-1.07 1.975-1.707 3.273-1.707m0-1.5c-1.862 0-3.505.928-4.5 2.344C11.005 3.928 9.362 3 7.5 3 4.462 3 2 5.462 2 8.5c0 5.72 6.5 10.438 10 12.85 3.5-2.412 10-7.13 10-12.85C22 5.462 19.538 3 16.5 3z' /></svg>",
-	"styles": [
-		{ "name": "default", "label": "Default", "isDefault": true },
-		{ "name": "buttons", "label": "Buttons" }
-	],
 	"supports": {
 		"html": false,
 		"color": {
@@ -131,6 +127,14 @@
 			"type": "string"
 		},
 		"selectedAmountTextColor": {
+			"type": "string"
+		},
+		"tabsAppearance": {
+			"type": "string",
+			"enum": [ "tabs", "buttons" ],
+			"default": "tabs"
+		},
+		"tabBorderColor": {
 			"type": "string"
 		},
 		"tabFontSize": {

--- a/projects/plugins/jetpack/extensions/blocks/donations/build-custom-styles.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/build-custom-styles.js
@@ -16,6 +16,7 @@ const buildCustomStyles = ( attributes, scope ) => {
 		inactiveTabTextColor,
 		selectedAmountBackgroundColor,
 		selectedAmountTextColor,
+		tabBorderColor,
 		tabFontSize,
 		tabPadding,
 		buttonFontSize,
@@ -24,6 +25,12 @@ const buildCustomStyles = ( attributes, scope ) => {
 	} = attributes;
 
 	const rules = [];
+
+	if ( tabBorderColor ) {
+		rules.push(
+			`${ scope } .donations__nav,${ scope } .donations__nav-item{border-color:${ tabBorderColor }}`
+		);
+	}
 
 	const tabDecls = [];
 	if ( tabFontSize ) {

--- a/projects/plugins/jetpack/extensions/blocks/donations/build-custom-styles.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/build-custom-styles.js
@@ -1,8 +1,8 @@
 /**
- * Build a CSS string scoping per-state color rules to a single block instance.
- * Returns an empty string when no overrides are set.
+ * Build a CSS string scoping per-state and tab-level style rules to a single
+ * block instance. Returns an empty string when no overrides are set.
  *
- * @param {object} attributes - Block attributes containing optional per-state colors.
+ * @param {object} attributes - Block attributes containing optional per-state colors and tab dimensions.
  * @param {string} scope      - A CSS class selector (with leading dot) unique to this instance.
  * @return {string} CSS string suitable for a <style> element, or empty if no rules.
  */
@@ -14,9 +14,26 @@ const buildCustomStyles = ( attributes, scope ) => {
 		inactiveTabTextColor,
 		selectedAmountBackgroundColor,
 		selectedAmountTextColor,
+		tabFontSize,
+		tabPadding,
 	} = attributes;
 
 	const rules = [];
+
+	const tabDecls = [];
+	if ( tabFontSize ) {
+		tabDecls.push( `font-size:${ tabFontSize }` );
+	}
+	if ( tabPadding ) {
+		[ 'top', 'right', 'bottom', 'left' ].forEach( side => {
+			if ( tabPadding[ side ] ) {
+				tabDecls.push( `padding-${ side }:${ tabPadding[ side ] }` );
+			}
+		} );
+	}
+	if ( tabDecls.length ) {
+		rules.push( `${ scope } .donations__nav-item{${ tabDecls.join( ';' ) }}` );
+	}
 
 	const activeTabDecls = [];
 	if ( activeTabBackgroundColor ) {

--- a/projects/plugins/jetpack/extensions/blocks/donations/build-custom-styles.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/build-custom-styles.js
@@ -71,9 +71,14 @@ const buildCustomStyles = ( attributes, scope ) => {
 		buttonPadding,
 		buttonAlignment,
 		buttonBorderRadius,
+		contentAlignment,
 	} = attributes;
 
 	const rules = [];
+
+	if ( [ 'left', 'center', 'right' ].includes( contentAlignment ) ) {
+		rules.push( `${ scope } .donations__content{text-align:${ contentAlignment }}` );
+	}
 
 	if ( tabBorderColor ) {
 		rules.push(

--- a/projects/plugins/jetpack/extensions/blocks/donations/build-custom-styles.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/build-custom-styles.js
@@ -78,6 +78,10 @@ const buildCustomStyles = ( attributes, scope ) => {
 
 	if ( [ 'left', 'center', 'right' ].includes( contentAlignment ) ) {
 		rules.push( `${ scope } .donations__content{text-align:${ contentAlignment }}` );
+		const justifyMap = { left: 'flex-start', center: 'center', right: 'flex-end' };
+		rules.push(
+			`${ scope } .donations__amounts{justify-content:${ justifyMap[ contentAlignment ] }}`
+		);
 	}
 
 	if ( tabBorderColor ) {

--- a/projects/plugins/jetpack/extensions/blocks/donations/build-custom-styles.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/build-custom-styles.js
@@ -8,6 +8,51 @@
  */
 const ALLOWED_BUTTON_ALIGNMENTS = [ 'left', 'center', 'right', 'full' ];
 
+// Read a uniform-or-split BorderBoxControl value into individual side declarations.
+// Returns an array of CSS declaration strings for inclusion in a single rule.
+const borderDecls = ( border, sidesPrefix = 'border' ) => {
+	if ( ! border || typeof border !== 'object' ) {
+		return [];
+	}
+	const decls = [];
+	const sides = [ 'top', 'right', 'bottom', 'left' ];
+	const isSplit = sides.some( s => border[ s ] );
+	if ( isSplit ) {
+		sides.forEach( side => {
+			const sb = border[ side ];
+			if ( ! sb ) return;
+			if ( sb.color ) decls.push( `${ sidesPrefix }-${ side }-color:${ sb.color }` );
+			if ( sb.style ) decls.push( `${ sidesPrefix }-${ side }-style:${ sb.style }` );
+			if ( sb.width ) decls.push( `${ sidesPrefix }-${ side }-width:${ sb.width }` );
+		} );
+	} else {
+		if ( border.color ) decls.push( `${ sidesPrefix }-color:${ border.color }` );
+		if ( border.style ) decls.push( `${ sidesPrefix }-style:${ border.style }` );
+		if ( border.width ) decls.push( `${ sidesPrefix }-width:${ border.width }` );
+	}
+	return decls;
+};
+
+// Read a uniform-or-per-corner BorderRadiusControl value into declarations.
+const radiusDecls = radius => {
+	if ( ! radius ) return [];
+	if ( typeof radius === 'string' ) {
+		return [ `border-radius:${ radius }` ];
+	}
+	if ( typeof radius === 'object' ) {
+		const corners = {
+			topLeft: 'border-top-left-radius',
+			topRight: 'border-top-right-radius',
+			bottomRight: 'border-bottom-right-radius',
+			bottomLeft: 'border-bottom-left-radius',
+		};
+		return Object.entries( corners )
+			.filter( ( [ key ] ) => radius[ key ] )
+			.map( ( [ key, prop ] ) => `${ prop }:${ radius[ key ] }` );
+	}
+	return [];
+};
+
 const buildCustomStyles = ( attributes, scope ) => {
 	const {
 		activeTabBackgroundColor,
@@ -19,6 +64,9 @@ const buildCustomStyles = ( attributes, scope ) => {
 		tabBorderColor,
 		tabFontSize,
 		tabPadding,
+		amountFontSize,
+		amountBorder,
+		amountBorderRadius,
 		buttonFontSize,
 		buttonPadding,
 		buttonAlignment,
@@ -30,6 +78,16 @@ const buildCustomStyles = ( attributes, scope ) => {
 		rules.push(
 			`${ scope } .donations__nav,${ scope } .donations__nav-item{border-color:${ tabBorderColor }}`
 		);
+	}
+
+	const amountDecls = [];
+	if ( amountFontSize ) {
+		amountDecls.push( `font-size:${ amountFontSize }` );
+	}
+	amountDecls.push( ...borderDecls( amountBorder ) );
+	amountDecls.push( ...radiusDecls( amountBorderRadius ) );
+	if ( amountDecls.length ) {
+		rules.push( `${ scope } .donations__amount{${ amountDecls.join( ';' ) }}` );
 	}
 
 	const tabDecls = [];

--- a/projects/plugins/jetpack/extensions/blocks/donations/build-custom-styles.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/build-custom-styles.js
@@ -47,22 +47,6 @@ const buildCustomStyles = ( attributes, scope ) => {
 		rules.push( `${ scope } .donations__nav-item{${ tabDecls.join( ';' ) }}` );
 	}
 
-	// In the "Buttons" style variation the nav container has its own vertical
-	// padding above the pill row. Mirror the user-set tab padding-top/bottom
-	// onto the nav so the row of pills scales with the pill interior padding.
-	if ( tabPadding ) {
-		const navDecls = [];
-		if ( tabPadding.top ) {
-			navDecls.push( `padding-top:${ tabPadding.top }` );
-		}
-		if ( tabPadding.bottom ) {
-			navDecls.push( `padding-bottom:${ tabPadding.bottom }` );
-		}
-		if ( navDecls.length ) {
-			rules.push( `${ scope }.is-style-buttons .donations__nav{${ navDecls.join( ';' ) }}` );
-		}
-	}
-
 	const activeTabDecls = [];
 	if ( activeTabBackgroundColor ) {
 		activeTabDecls.push( `background:${ activeTabBackgroundColor }` );

--- a/projects/plugins/jetpack/extensions/blocks/donations/build-custom-styles.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/build-custom-styles.js
@@ -40,6 +40,22 @@ const buildCustomStyles = ( attributes, scope ) => {
 		rules.push( `${ scope } .donations__nav-item{${ tabDecls.join( ';' ) }}` );
 	}
 
+	// In the "Buttons" style variation the nav container has its own vertical
+	// padding above the pill row. Mirror the user-set tab padding-top/bottom
+	// onto the nav so the row of pills scales with the pill interior padding.
+	if ( tabPadding ) {
+		const navDecls = [];
+		if ( tabPadding.top ) {
+			navDecls.push( `padding-top:${ tabPadding.top }` );
+		}
+		if ( tabPadding.bottom ) {
+			navDecls.push( `padding-bottom:${ tabPadding.bottom }` );
+		}
+		if ( navDecls.length ) {
+			rules.push( `${ scope }.is-style-buttons .donations__nav{${ navDecls.join( ';' ) }}` );
+		}
+	}
+
 	const activeTabDecls = [];
 	if ( activeTabBackgroundColor ) {
 		activeTabDecls.push( `background:${ activeTabBackgroundColor }` );
@@ -94,7 +110,7 @@ const buildCustomStyles = ( attributes, scope ) => {
 		if ( buttonAlignment === 'full' ) {
 			rules.push(
 				`${ scope } .donations__donate-button-wrapper{display:block;width:100%}` +
-					`${ scope } .donations__donate-button{display:block;width:100%;box-sizing:border-box}`
+					`${ scope } .donations__donate-button{display:block;width:100%;box-sizing:border-box;text-align:center}`
 			);
 		} else {
 			rules.push( `${ scope } .donations__donate-button-wrapper{text-align:${ buttonAlignment }}` );

--- a/projects/plugins/jetpack/extensions/blocks/donations/build-custom-styles.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/build-custom-styles.js
@@ -6,6 +6,8 @@
  * @param {string} scope      - A CSS class selector (with leading dot) unique to this instance.
  * @return {string} CSS string suitable for a <style> element, or empty if no rules.
  */
+const ALLOWED_BUTTON_ALIGNMENTS = [ 'left', 'center', 'right', 'full' ];
+
 const buildCustomStyles = ( attributes, scope ) => {
 	const {
 		activeTabBackgroundColor,
@@ -16,6 +18,9 @@ const buildCustomStyles = ( attributes, scope ) => {
 		selectedAmountTextColor,
 		tabFontSize,
 		tabPadding,
+		buttonFontSize,
+		buttonPadding,
+		buttonAlignment,
 	} = attributes;
 
 	const rules = [];
@@ -68,6 +73,32 @@ const buildCustomStyles = ( attributes, scope ) => {
 	}
 	if ( selectedAmountDecls.length ) {
 		rules.push( `${ scope } .donations__amount.is-selected{${ selectedAmountDecls.join( ';' ) }}` );
+	}
+
+	const buttonDecls = [];
+	if ( buttonFontSize ) {
+		buttonDecls.push( `font-size:${ buttonFontSize }` );
+	}
+	if ( buttonPadding ) {
+		[ 'top', 'right', 'bottom', 'left' ].forEach( side => {
+			if ( buttonPadding[ side ] ) {
+				buttonDecls.push( `padding-${ side }:${ buttonPadding[ side ] }` );
+			}
+		} );
+	}
+	if ( buttonDecls.length ) {
+		rules.push( `${ scope } .donations__donate-button{${ buttonDecls.join( ';' ) }}` );
+	}
+
+	if ( ALLOWED_BUTTON_ALIGNMENTS.includes( buttonAlignment ) ) {
+		if ( buttonAlignment === 'full' ) {
+			rules.push(
+				`${ scope } .donations__donate-button-wrapper{display:block;width:100%}` +
+					`${ scope } .donations__donate-button{display:block;width:100%;box-sizing:border-box}`
+			);
+		} else {
+			rules.push( `${ scope } .donations__donate-button-wrapper{text-align:${ buttonAlignment }}` );
+		}
 	}
 
 	return rules.join( '' );

--- a/projects/plugins/jetpack/extensions/blocks/donations/build-custom-styles.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/build-custom-styles.js
@@ -70,14 +70,22 @@ const buildCustomStyles = ( attributes, scope ) => {
 		buttonFontSize,
 		buttonPadding,
 		buttonAlignment,
+		buttonBorderRadius,
 	} = attributes;
 
 	const rules = [];
 
 	if ( tabBorderColor ) {
 		rules.push(
-			`${ scope } .donations__nav,${ scope } .donations__nav-item{border-color:${ tabBorderColor }}`
+			`${ scope } .donations__nav,${ scope } .donations__nav-item,${ scope } .donations__nav-item.is-active{border-color:${ tabBorderColor }}`
 		);
+	}
+
+	if ( buttonBorderRadius ) {
+		const decls = radiusDecls( buttonBorderRadius );
+		if ( decls.length ) {
+			rules.push( `${ scope } .donations__donate-button{${ decls.join( ';' ) }}` );
+		}
 	}
 
 	const amountDecls = [];

--- a/projects/plugins/jetpack/extensions/blocks/donations/build-custom-styles.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/build-custom-styles.js
@@ -1,0 +1,59 @@
+/**
+ * Build a CSS string scoping per-state color rules to a single block instance.
+ * Returns an empty string when no overrides are set.
+ *
+ * @param {object} attributes - Block attributes containing optional per-state colors.
+ * @param {string} scope      - A CSS class selector (with leading dot) unique to this instance.
+ * @return {string} CSS string suitable for a <style> element, or empty if no rules.
+ */
+const buildCustomStyles = ( attributes, scope ) => {
+	const {
+		activeTabBackgroundColor,
+		activeTabTextColor,
+		inactiveTabBackgroundColor,
+		inactiveTabTextColor,
+		selectedAmountBackgroundColor,
+		selectedAmountTextColor,
+	} = attributes;
+
+	const rules = [];
+
+	const activeTabDecls = [];
+	if ( activeTabBackgroundColor ) {
+		activeTabDecls.push( `background:${ activeTabBackgroundColor }` );
+	}
+	if ( activeTabTextColor ) {
+		activeTabDecls.push( `color:${ activeTabTextColor }` );
+	}
+	if ( activeTabDecls.length ) {
+		rules.push( `${ scope } .donations__nav-item.is-active{${ activeTabDecls.join( ';' ) }}` );
+	}
+
+	const inactiveTabDecls = [];
+	if ( inactiveTabBackgroundColor ) {
+		inactiveTabDecls.push( `background:${ inactiveTabBackgroundColor }` );
+	}
+	if ( inactiveTabTextColor ) {
+		inactiveTabDecls.push( `color:${ inactiveTabTextColor }` );
+	}
+	if ( inactiveTabDecls.length ) {
+		rules.push(
+			`${ scope } .donations__nav-item:not(.is-active){${ inactiveTabDecls.join( ';' ) }}`
+		);
+	}
+
+	const selectedAmountDecls = [];
+	if ( selectedAmountBackgroundColor ) {
+		selectedAmountDecls.push( `background-color:${ selectedAmountBackgroundColor }` );
+	}
+	if ( selectedAmountTextColor ) {
+		selectedAmountDecls.push( `color:${ selectedAmountTextColor }` );
+	}
+	if ( selectedAmountDecls.length ) {
+		rules.push( `${ scope } .donations__amount.is-selected{${ selectedAmountDecls.join( ';' ) }}` );
+	}
+
+	return rules.join( '' );
+};
+
+export default buildCustomStyles;

--- a/projects/plugins/jetpack/extensions/blocks/donations/build-custom-styles.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/build-custom-styles.js
@@ -61,6 +61,7 @@ const buildCustomStyles = ( attributes, scope ) => {
 		inactiveTabTextColor,
 		selectedAmountBackgroundColor,
 		selectedAmountTextColor,
+		selectedAmountOutlineColor,
 		tabBorderColor,
 		tabFontSize,
 		tabPadding,
@@ -152,6 +153,12 @@ const buildCustomStyles = ( attributes, scope ) => {
 	}
 	if ( selectedAmountTextColor ) {
 		selectedAmountDecls.push( `color:${ selectedAmountTextColor }` );
+	}
+	// Override only the outer ring color; the inner 1px white separator stays put.
+	if ( selectedAmountOutlineColor ) {
+		selectedAmountDecls.push(
+			`box-shadow:0 0 0 1px #fff,0 0 0 3px ${ selectedAmountOutlineColor }`
+		);
 	}
 	if ( selectedAmountDecls.length ) {
 		rules.push( `${ scope } .donations__amount.is-selected{${ selectedAmountDecls.join( ';' ) }}` );

--- a/projects/plugins/jetpack/extensions/blocks/donations/common.scss
+++ b/projects/plugins/jetpack/extensions/blocks/donations/common.scss
@@ -9,6 +9,9 @@
 	// Default border. User-set border (via the Border style support) renders as
 	// an inline style on this element, which wins on specificity.
 	border: 1px solid gb.$gray-400;
+	// Clip children to any user-set border-radius; without this, tab corners
+	// extend past the rounded outer corners.
+	overflow: hidden;
 
 	.donations__nav {
 		display: flex;

--- a/projects/plugins/jetpack/extensions/blocks/donations/common.scss
+++ b/projects/plugins/jetpack/extensions/blocks/donations/common.scss
@@ -137,10 +137,5 @@
 			border-inline-start: 1px solid gb.$gray-400;
 		}
 
-		// Match the active border to the active fill so the pill reads as a
-		// solid filled shape, not a bordered shape with a darker inside.
-		.donations__nav-item.is-active {
-			border-color: gb.$gray-900;
-		}
 	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/donations/common.scss
+++ b/projects/plugins/jetpack/extensions/blocks/donations/common.scss
@@ -1,4 +1,8 @@
 // Common styles for both views (editor and frontend).
+// Surfaces (backgrounds, text colors, typography) defer to the active theme
+// by inheriting from the surrounding context. Structural borders and active-
+// state colors remain hardcoded for now; a follow-up that adds Gutenberg
+// style supports will make them user-customizable.
 @use "@automattic/jetpack-base-styles/gutenberg-base-styles" as gb;
 
 .wp-block-jetpack-donations {
@@ -17,11 +21,10 @@
 		display: inline-block;
 		flex: 1;
 		text-align: center;
-		font-size: 16px;
 		padding: 12px;
 		border-inline-start: 1px solid gb.$gray-400;
-		background: gb.$white;
-		color: gb.$gray-900;
+		background: transparent;
+		color: inherit;
 		cursor: pointer;
 
 		@include gb.break-small() {
@@ -69,13 +72,12 @@
 	.donations__amount {
 		display: inline-block;
 		padding: 16px 24px;
-		background-color: gb.$white;
-		color: gb.$gray-900;
+		background-color: transparent;
+		color: inherit;
 		border: 1px solid gb.$gray-400;
 		margin-inline-end: 8px;
 		margin-bottom: 8px;
 		font-weight: 600;
-		font-size: 16px;
 		white-space: nowrap;
 
 		&.has-error {

--- a/projects/plugins/jetpack/extensions/blocks/donations/common.scss
+++ b/projects/plugins/jetpack/extensions/blocks/donations/common.scss
@@ -1,15 +1,14 @@
 // Common styles for both views (editor and frontend).
 // Surfaces (backgrounds, text colors, typography) defer to the active theme
-// by inheriting from the surrounding context. Structural borders and active-
-// state colors remain hardcoded for now; a follow-up that adds Gutenberg
-// style supports will make them user-customizable.
+// by inheriting from the surrounding context. Per-state colors (active tab,
+// selected amount) are rendered via a per-instance scoped <style> element
+// because the postcss build inlines var() fallbacks at compile time.
 @use "@automattic/jetpack-base-styles/gutenberg-base-styles" as gb;
 
 .wp-block-jetpack-donations {
-
-	.donations__container {
-		border: 1px solid gb.$gray-400;
-	}
+	// Default border. User-set border (via the Border style support) renders as
+	// an inline style on this element, which wins on specificity.
+	border: 1px solid gb.$gray-400;
 
 	.donations__nav {
 		display: flex;

--- a/projects/plugins/jetpack/extensions/blocks/donations/common.scss
+++ b/projects/plugins/jetpack/extensions/blocks/donations/common.scss
@@ -109,4 +109,38 @@
 	.donations__donate-button {
 		margin: 0;
 	}
+
+	// "Buttons" style variation: render the frequency selectors as a row of
+	// pill-shaped buttons instead of edge-to-edge tabs. Per-state colors and
+	// tab dimensions set in the inspector still apply on top of these rules.
+	&.is-style-buttons {
+
+		.donations__nav {
+			border-bottom: none;
+			gap: 8px;
+			padding: 16px 16px 0;
+
+			@include gb.break-small() {
+				gap: 12px;
+				padding: 24px 24px 0;
+			}
+		}
+
+		.donations__nav-item {
+			border: 1px solid gb.$gray-400;
+			border-radius: 9999px;
+		}
+
+		// Restore the inline-start border that the default style strips off
+		// the first item — every pill needs a full border.
+		.donations__nav-item:first-child {
+			border-inline-start: 1px solid gb.$gray-400;
+		}
+
+		// Match the active border to the active fill so the pill reads as a
+		// solid filled shape, not a bordered shape with a darker inside.
+		.donations__nav-item.is-active {
+			border-color: gb.$gray-900;
+		}
+	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/donations/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/controls.js
@@ -1,4 +1,4 @@
-import { CURRENCIES } from '@automattic/format-currency';
+import formatCurrency, { CURRENCIES } from '@automattic/format-currency';
 import { getSiteFragment } from '@automattic/jetpack-shared-extension-utils';
 import { AlignmentControl, BlockControls, InspectorControls } from '@wordpress/block-editor';
 import {
@@ -8,6 +8,7 @@ import {
 	MenuGroup,
 	MenuItem,
 	PanelBody,
+	SelectControl,
 	ToggleControl,
 	ToolbarGroup,
 	ToolbarItem,
@@ -20,6 +21,13 @@ import {
 	getDefaultDonationAmountsForCurrency,
 	SUPPORTED_CURRENCIES,
 } from '../../shared/currencies';
+import { firstShownInterval } from './utils';
+
+const INTERVAL_TO_ATTRIBUTE = {
+	'one-time': 'oneTimeDonation',
+	'1 month': 'monthlyDonation',
+	'1 year': 'annualDonation',
+};
 
 const Controls = props => {
 	const { attributes, setAttributes } = props;
@@ -30,30 +38,82 @@ const Controls = props => {
 		annualDonation,
 		showCustomAmount,
 		contentAlignment,
+		defaultInterval,
 	} = attributes;
-
-	const toggleDonation = ( interval, show ) => {
-		const donationAttributes = {
-			'one-time': 'oneTimeDonation',
-			'1 month': 'monthlyDonation',
-			'1 year': 'annualDonation',
-		};
-		const donationAttribute = donationAttributes[ interval ];
-		const donation = attributes[ donationAttribute ];
-
-		setAttributes( {
-			[ donationAttribute ]: {
-				...donation,
-				show,
-			},
-		} );
-	};
 
 	const oneTimeOn = oneTimeDonation.show !== false;
 	const monthlyOn = !! monthlyDonation.show;
 	const annualOn = !! annualDonation.show;
 	const enabledIntervalCount = ( oneTimeOn ? 1 : 0 ) + ( monthlyOn ? 1 : 0 ) + ( annualOn ? 1 : 0 );
 	const lastEnabledHelp = __( 'At least one frequency must be enabled.', 'jetpack' );
+
+	const fallbackInterval = firstShownInterval( oneTimeOn, monthlyOn, annualOn ) ?? 'one-time';
+	const isDefaultIntervalShown =
+		( defaultInterval === 'one-time' && oneTimeOn ) ||
+		( defaultInterval === '1 month' && monthlyOn ) ||
+		( defaultInterval === '1 year' && annualOn );
+	const effectiveDefaultInterval = isDefaultIntervalShown ? defaultInterval : fallbackInterval;
+
+	const toggleDonation = ( interval, show ) => {
+		const donationAttribute = INTERVAL_TO_ATTRIBUTE[ interval ];
+		const donation = attributes[ donationAttribute ];
+		const updates = {
+			[ donationAttribute ]: { ...donation, show },
+		};
+
+		// If we're hiding the frequency that's currently the effective default, shift the
+		// default to the next still-shown interval so the form never points at a hidden one.
+		if ( ! show && effectiveDefaultInterval === interval ) {
+			const stillShown = {
+				oneTime: interval === 'one-time' ? false : oneTimeOn,
+				monthly: interval === '1 month' ? false : monthlyOn,
+				annual: interval === '1 year' ? false : annualOn,
+			};
+			const nextDefault = firstShownInterval(
+				stillShown.oneTime,
+				stillShown.monthly,
+				stillShown.annual
+			);
+			if ( nextDefault ) {
+				updates.defaultInterval = nextDefault;
+			}
+		}
+
+		setAttributes( updates );
+	};
+
+	const setDonationValue = ( interval, key, value ) => {
+		const donationAttribute = INTERVAL_TO_ATTRIBUTE[ interval ];
+		setAttributes( {
+			[ donationAttribute ]: { ...attributes[ donationAttribute ], [ key ]: value },
+		} );
+	};
+
+	const intervalLabels = {
+		'one-time': __( 'One-Time', 'jetpack' ),
+		'1 month': __( 'Monthly', 'jetpack' ),
+		'1 year': __( 'Yearly', 'jetpack' ),
+	};
+	const frequencyOptions = [
+		...( oneTimeOn ? [ { value: 'one-time', label: intervalLabels[ 'one-time' ] } ] : [] ),
+		...( monthlyOn ? [ { value: '1 month', label: intervalLabels[ '1 month' ] } ] : [] ),
+		...( annualOn ? [ { value: '1 year', label: intervalLabels[ '1 year' ] } ] : [] ),
+	];
+	const buildAmountOptions = amounts => [
+		{ value: '', label: __( 'None', 'jetpack' ) },
+		...( amounts || [] ).map( ( amount, idx ) => ( {
+			value: String( idx ),
+			label: formatCurrency( amount, currency ),
+		} ) ),
+	];
+	const amountValue = donation =>
+		donation.defaultAmountIndex !== undefined ? String( donation.defaultAmountIndex ) : '';
+	const onAmountChange = interval => value =>
+		setDonationValue(
+			interval,
+			'defaultAmountIndex',
+			value === '' ? undefined : parseInt( value, 10 )
+		);
 
 	const setContentAlignment = useCallback(
 		value => setAttributes( { contentAlignment: value || '' } ),
@@ -158,6 +218,40 @@ const Controls = props => {
 						label={ __( 'Show custom amount option', 'jetpack' ) }
 						__nextHasNoMarginBottom={ true }
 					/>
+					<SelectControl
+						label={ __( 'Default frequency', 'jetpack' ) }
+						value={ effectiveDefaultInterval }
+						options={ frequencyOptions }
+						onChange={ value => setAttributes( { defaultInterval: value } ) }
+						__nextHasNoMarginBottom={ true }
+					/>
+					{ oneTimeOn && (
+						<SelectControl
+							label={ __( 'Default amount for One-Time', 'jetpack' ) }
+							value={ amountValue( oneTimeDonation ) }
+							options={ buildAmountOptions( oneTimeDonation.amounts ) }
+							onChange={ onAmountChange( 'one-time' ) }
+							__nextHasNoMarginBottom={ true }
+						/>
+					) }
+					{ monthlyOn && (
+						<SelectControl
+							label={ __( 'Default amount for Monthly', 'jetpack' ) }
+							value={ amountValue( monthlyDonation ) }
+							options={ buildAmountOptions( monthlyDonation.amounts ) }
+							onChange={ onAmountChange( '1 month' ) }
+							__nextHasNoMarginBottom={ true }
+						/>
+					) }
+					{ annualOn && (
+						<SelectControl
+							label={ __( 'Default amount for Annual', 'jetpack' ) }
+							value={ amountValue( annualDonation ) }
+							options={ buildAmountOptions( annualDonation.amounts ) }
+							onChange={ onAmountChange( '1 year' ) }
+							__nextHasNoMarginBottom={ true }
+						/>
+					) }
 					<ExternalLink href={ `https://wordpress.com/earn/payments/${ getSiteFragment() }` }>
 						{ __( 'View donation earnings', 'jetpack' ) }
 					</ExternalLink>

--- a/projects/plugins/jetpack/extensions/blocks/donations/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/controls.js
@@ -49,6 +49,12 @@ const Controls = props => {
 		} );
 	};
 
+	const oneTimeOn = oneTimeDonation.show !== false;
+	const monthlyOn = !! monthlyDonation.show;
+	const annualOn = !! annualDonation.show;
+	const enabledIntervalCount = ( oneTimeOn ? 1 : 0 ) + ( monthlyOn ? 1 : 0 ) + ( annualOn ? 1 : 0 );
+	const lastEnabledHelp = __( 'At least one frequency must be enabled.', 'jetpack' );
+
 	const setContentAlignment = useCallback(
 		value => setAttributes( { contentAlignment: value || '' } ),
 		[ setAttributes ]
@@ -123,20 +129,26 @@ const Controls = props => {
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings', 'jetpack' ) }>
 					<ToggleControl
-						checked={ oneTimeDonation.show !== false }
+						checked={ oneTimeOn }
 						onChange={ value => toggleDonation( 'one-time', value ) }
+						disabled={ oneTimeOn && enabledIntervalCount === 1 }
+						help={ oneTimeOn && enabledIntervalCount === 1 ? lastEnabledHelp : undefined }
 						label={ __( 'Show one-time donations', 'jetpack' ) }
 						__nextHasNoMarginBottom={ true }
 					/>
 					<ToggleControl
-						checked={ monthlyDonation.show }
+						checked={ monthlyOn }
 						onChange={ value => toggleDonation( '1 month', value ) }
+						disabled={ monthlyOn && enabledIntervalCount === 1 }
+						help={ monthlyOn && enabledIntervalCount === 1 ? lastEnabledHelp : undefined }
 						label={ __( 'Show monthly donations', 'jetpack' ) }
 						__nextHasNoMarginBottom={ true }
 					/>
 					<ToggleControl
-						checked={ annualDonation.show }
+						checked={ annualOn }
 						onChange={ value => toggleDonation( '1 year', value ) }
+						disabled={ annualOn && enabledIntervalCount === 1 }
+						help={ annualOn && enabledIntervalCount === 1 ? lastEnabledHelp : undefined }
 						label={ __( 'Show annual donations', 'jetpack' ) }
 						__nextHasNoMarginBottom={ true }
 					/>

--- a/projects/plugins/jetpack/extensions/blocks/donations/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/controls.js
@@ -9,6 +9,7 @@ import {
 	MenuItem,
 	PanelBody,
 	SelectControl,
+	TextControl,
 	ToggleControl,
 	ToolbarGroup,
 	ToolbarItem,
@@ -19,6 +20,7 @@ import { __ } from '@wordpress/i18n';
 import { DOWN } from '@wordpress/keycodes';
 import {
 	getDefaultDonationAmountsForCurrency,
+	minimumTransactionAmountForCurrency,
 	SUPPORTED_CURRENCIES,
 } from '../../shared/currencies';
 import { firstShownInterval } from './utils';
@@ -39,7 +41,12 @@ const Controls = props => {
 		showCustomAmount,
 		contentAlignment,
 		defaultInterval,
+		customAmountPlaceholder,
 	} = attributes;
+
+	const computedCustomAmountPlaceholder = minimumTransactionAmountForCurrency( currency ) * 100;
+	const effectiveCustomAmountPlaceholder =
+		customAmountPlaceholder ?? computedCustomAmountPlaceholder;
 
 	const oneTimeOn = oneTimeDonation.show !== false;
 	const monthlyOn = !! monthlyDonation.show;
@@ -128,6 +135,7 @@ const Controls = props => {
 			oneTimeDonation: { ...oneTimeDonation, amounts: defaultAmounts },
 			monthlyDonation: { ...monthlyDonation, amounts: defaultAmounts },
 			annualDonation: { ...annualDonation, amounts: defaultAmounts },
+			customAmountPlaceholder: undefined,
 		} );
 	};
 
@@ -188,6 +196,11 @@ const Controls = props => {
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings', 'jetpack' ) }>
+					<p>
+						<ExternalLink href={ `https://wordpress.com/earn/payments/${ getSiteFragment() }` }>
+							{ __( 'View donation earnings', 'jetpack' ) }
+						</ExternalLink>
+					</p>
 					<ToggleControl
 						checked={ oneTimeOn }
 						onChange={ value => toggleDonation( 'one-time', value ) }
@@ -218,6 +231,26 @@ const Controls = props => {
 						label={ __( 'Show custom amount option', 'jetpack' ) }
 						__nextHasNoMarginBottom={ true }
 					/>
+					{ showCustomAmount && (
+						<TextControl
+							type="number"
+							label={ __( 'Suggested custom amount', 'jetpack' ) }
+							help={ __(
+								'Shown as the placeholder when donors enter a custom amount.',
+								'jetpack'
+							) }
+							value={ effectiveCustomAmountPlaceholder }
+							onChange={ value =>
+								setAttributes( {
+									customAmountPlaceholder:
+										value === '' || value === undefined ? undefined : Number( value ),
+								} )
+							}
+							min={ minimumTransactionAmountForCurrency( currency ) }
+							step={ 0.01 }
+							__nextHasNoMarginBottom={ true }
+						/>
+					) }
 					<SelectControl
 						label={ __( 'Default frequency', 'jetpack' ) }
 						value={ effectiveDefaultInterval }
@@ -252,9 +285,6 @@ const Controls = props => {
 							__nextHasNoMarginBottom={ true }
 						/>
 					) }
-					<ExternalLink href={ `https://wordpress.com/earn/payments/${ getSiteFragment() }` }>
-						{ __( 'View donation earnings', 'jetpack' ) }
-					</ExternalLink>
 				</PanelBody>
 			</InspectorControls>
 		</>

--- a/projects/plugins/jetpack/extensions/blocks/donations/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/controls.js
@@ -229,29 +229,14 @@ const Controls = props => {
 						label={ __( 'Show custom amount option', 'jetpack' ) }
 						__nextHasNoMarginBottom={ true }
 					/>
-					{ showCustomAmount && (
-						<TextControl
-							type="number"
-							label={ __( 'Suggested custom amount', 'jetpack' ) }
-							help={ __(
-								'Shown as the placeholder when donors enter a custom amount.',
-								'jetpack'
-							) }
-							value={ effectiveCustomAmountPlaceholder }
-							onChange={ value =>
-								setAttributes( {
-									customAmountPlaceholder:
-										value === '' || value === undefined ? undefined : Number( value ),
-								} )
-							}
-							min={ minimumTransactionAmountForCurrency( currency ) }
-							step={ 0.01 }
-							__nextHasNoMarginBottom={ true }
-						/>
-					) }
 					<h3
 						className="jp-donations-defaults-heading"
-						style={ { margin: '24px 0 8px', fontSize: 13, fontWeight: 600 } }
+						style={ {
+							margin: '24px 0 8px',
+							fontSize: 13,
+							fontWeight: 600,
+							textTransform: 'none',
+						} }
 					>
 						{ __( 'Defaults', 'jetpack' ) }
 					</h3>
@@ -313,6 +298,28 @@ const Controls = props => {
 									value={ amountValue( annualDonation ) }
 									options={ buildAmountOptions( annualDonation.amounts ) }
 									onChange={ onAmountChange( '1 year' ) }
+									__nextHasNoMarginBottom={ true }
+								/>
+							</FlexBlock>
+						</Flex>
+					) }
+					{ showCustomAmount && (
+						<Flex justify="space-between" align="center" style={ { marginBottom: 8 } }>
+							<FlexItem style={ { minWidth: 80 } }>{ __( 'Custom', 'jetpack' ) }</FlexItem>
+							<FlexBlock>
+								<TextControl
+									type="number"
+									hideLabelFromVision
+									label={ __( 'Suggested custom amount', 'jetpack' ) }
+									value={ effectiveCustomAmountPlaceholder }
+									onChange={ value =>
+										setAttributes( {
+											customAmountPlaceholder:
+												value === '' || value === undefined ? undefined : Number( value ),
+										} )
+									}
+									min={ minimumTransactionAmountForCurrency( currency ) }
+									step={ 0.01 }
 									__nextHasNoMarginBottom={ true }
 								/>
 							</FlexBlock>

--- a/projects/plugins/jetpack/extensions/blocks/donations/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/controls.js
@@ -5,6 +5,9 @@ import {
 	Dashicon,
 	Dropdown,
 	ExternalLink,
+	Flex,
+	FlexBlock,
+	FlexItem,
 	MenuGroup,
 	MenuItem,
 	PanelBody,
@@ -196,11 +199,6 @@ const Controls = props => {
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings', 'jetpack' ) }>
-					<p>
-						<ExternalLink href={ `https://wordpress.com/earn/payments/${ getSiteFragment() }` }>
-							{ __( 'View donation earnings', 'jetpack' ) }
-						</ExternalLink>
-					</p>
 					<ToggleControl
 						checked={ oneTimeOn }
 						onChange={ value => toggleDonation( 'one-time', value ) }
@@ -251,40 +249,80 @@ const Controls = props => {
 							__nextHasNoMarginBottom={ true }
 						/>
 					) }
+					<h3
+						className="jp-donations-defaults-heading"
+						style={ { margin: '24px 0 8px', fontSize: 13, fontWeight: 600 } }
+					>
+						{ __( 'Defaults', 'jetpack' ) }
+					</h3>
 					<SelectControl
-						label={ __( 'Default frequency', 'jetpack' ) }
+						label={ __( 'Frequency', 'jetpack' ) }
 						value={ effectiveDefaultInterval }
 						options={ frequencyOptions }
 						onChange={ value => setAttributes( { defaultInterval: value } ) }
 						__nextHasNoMarginBottom={ true }
 					/>
+					<h4
+						className="jp-donations-defaults-subheading"
+						style={ {
+							margin: '16px 0 8px',
+							fontSize: 11,
+							fontWeight: 500,
+							textTransform: 'uppercase',
+						} }
+					>
+						{ __( 'Amounts', 'jetpack' ) }
+					</h4>
 					{ oneTimeOn && (
-						<SelectControl
-							label={ __( 'Default amount for One-Time', 'jetpack' ) }
-							value={ amountValue( oneTimeDonation ) }
-							options={ buildAmountOptions( oneTimeDonation.amounts ) }
-							onChange={ onAmountChange( 'one-time' ) }
-							__nextHasNoMarginBottom={ true }
-						/>
+						<Flex justify="space-between" align="center" style={ { marginBottom: 8 } }>
+							<FlexItem style={ { minWidth: 80 } }>{ __( 'One-Time', 'jetpack' ) }</FlexItem>
+							<FlexBlock>
+								<SelectControl
+									hideLabelFromVision
+									label={ __( 'Default amount for One-Time', 'jetpack' ) }
+									value={ amountValue( oneTimeDonation ) }
+									options={ buildAmountOptions( oneTimeDonation.amounts ) }
+									onChange={ onAmountChange( 'one-time' ) }
+									__nextHasNoMarginBottom={ true }
+								/>
+							</FlexBlock>
+						</Flex>
 					) }
 					{ monthlyOn && (
-						<SelectControl
-							label={ __( 'Default amount for Monthly', 'jetpack' ) }
-							value={ amountValue( monthlyDonation ) }
-							options={ buildAmountOptions( monthlyDonation.amounts ) }
-							onChange={ onAmountChange( '1 month' ) }
-							__nextHasNoMarginBottom={ true }
-						/>
+						<Flex justify="space-between" align="center" style={ { marginBottom: 8 } }>
+							<FlexItem style={ { minWidth: 80 } }>{ __( 'Monthly', 'jetpack' ) }</FlexItem>
+							<FlexBlock>
+								<SelectControl
+									hideLabelFromVision
+									label={ __( 'Default amount for Monthly', 'jetpack' ) }
+									value={ amountValue( monthlyDonation ) }
+									options={ buildAmountOptions( monthlyDonation.amounts ) }
+									onChange={ onAmountChange( '1 month' ) }
+									__nextHasNoMarginBottom={ true }
+								/>
+							</FlexBlock>
+						</Flex>
 					) }
 					{ annualOn && (
-						<SelectControl
-							label={ __( 'Default amount for Annual', 'jetpack' ) }
-							value={ amountValue( annualDonation ) }
-							options={ buildAmountOptions( annualDonation.amounts ) }
-							onChange={ onAmountChange( '1 year' ) }
-							__nextHasNoMarginBottom={ true }
-						/>
+						<Flex justify="space-between" align="center" style={ { marginBottom: 8 } }>
+							<FlexItem style={ { minWidth: 80 } }>{ __( 'Annual', 'jetpack' ) }</FlexItem>
+							<FlexBlock>
+								<SelectControl
+									hideLabelFromVision
+									label={ __( 'Default amount for Annual', 'jetpack' ) }
+									value={ amountValue( annualDonation ) }
+									options={ buildAmountOptions( annualDonation.amounts ) }
+									onChange={ onAmountChange( '1 year' ) }
+									__nextHasNoMarginBottom={ true }
+								/>
+							</FlexBlock>
+						</Flex>
 					) }
+					<p style={ { marginTop: 24 } }>
+						<ExternalLink href={ `https://wordpress.com/earn/payments/${ getSiteFragment() }` }>
+							{ __( 'View donation earnings', 'jetpack' ) }
+						</ExternalLink>
+					</p>
 				</PanelBody>
 			</InspectorControls>
 		</>

--- a/projects/plugins/jetpack/extensions/blocks/donations/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/controls.js
@@ -34,6 +34,7 @@ const Controls = props => {
 
 	const toggleDonation = ( interval, show ) => {
 		const donationAttributes = {
+			'one-time': 'oneTimeDonation',
 			'1 month': 'monthlyDonation',
 			'1 year': 'annualDonation',
 		};
@@ -121,6 +122,12 @@ const Controls = props => {
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings', 'jetpack' ) }>
+					<ToggleControl
+						checked={ oneTimeDonation.show !== false }
+						onChange={ value => toggleDonation( 'one-time', value ) }
+						label={ __( 'Show one-time donations', 'jetpack' ) }
+						__nextHasNoMarginBottom={ true }
+					/>
 					<ToggleControl
 						checked={ monthlyDonation.show }
 						onChange={ value => toggleDonation( '1 month', value ) }

--- a/projects/plugins/jetpack/extensions/blocks/donations/controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/controls.js
@@ -1,6 +1,6 @@
 import { CURRENCIES } from '@automattic/format-currency';
 import { getSiteFragment } from '@automattic/jetpack-shared-extension-utils';
-import { BlockControls, InspectorControls } from '@wordpress/block-editor';
+import { AlignmentControl, BlockControls, InspectorControls } from '@wordpress/block-editor';
 import {
 	Dashicon,
 	Dropdown,
@@ -13,6 +13,7 @@ import {
 	ToolbarItem,
 	ToolbarButton,
 } from '@wordpress/components';
+import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { DOWN } from '@wordpress/keycodes';
 import {
@@ -22,8 +23,14 @@ import {
 
 const Controls = props => {
 	const { attributes, setAttributes } = props;
-	const { currency, oneTimeDonation, monthlyDonation, annualDonation, showCustomAmount } =
-		attributes;
+	const {
+		currency,
+		oneTimeDonation,
+		monthlyDonation,
+		annualDonation,
+		showCustomAmount,
+		contentAlignment,
+	} = attributes;
 
 	const toggleDonation = ( interval, show ) => {
 		const donationAttributes = {
@@ -41,6 +48,11 @@ const Controls = props => {
 		} );
 	};
 
+	const setContentAlignment = useCallback(
+		value => setAttributes( { contentAlignment: value || '' } ),
+		[ setAttributes ]
+	);
+
 	const changeDefaultDonationAmounts = ccy => {
 		const defaultAmounts = getDefaultDonationAmountsForCurrency( ccy );
 
@@ -55,6 +67,7 @@ const Controls = props => {
 	return (
 		<>
 			<BlockControls>
+				<AlignmentControl value={ contentAlignment } onChange={ setContentAlignment } />
 				<ToolbarGroup>
 					<ToolbarItem>
 						{ () => (

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -201,9 +201,13 @@ function render_block( $attr, $content ) {
 		);
 	}
 
+	$instance_id     = wp_unique_id( 'jp-donations-' );
+	$wrapper_classes = Blocks::classes( Blocks::get_block_feature( __DIR__ ), $attr ) . ' ' . $instance_id;
+	$custom_styles   = build_custom_styles( $attr, '.' . $instance_id );
+
 	return sprintf(
 		'
-<div class="%1$s">
+<div class="%1$s">%9$s
 	<div class="donations__container">
 		%2$s
 		<div class="donations__content">
@@ -220,15 +224,88 @@ function render_block( $attr, $content ) {
 	</div>
 </div>
 ',
-		esc_attr( Blocks::classes( Blocks::get_block_feature( __DIR__ ), $attr ) ),
+		esc_attr( $wrapper_classes ),
 		$nav,
 		$headings,
 		$choose_amount_text,
 		$amounts,
 		$custom_amount,
 		$extra_text,
-		$buttons
+		$buttons,
+		$custom_styles ? '<style>' . $custom_styles . '</style>' : ''
 	);
+}
+
+/**
+ * Build a CSS string scoping per-state color rules to a single block instance.
+ *
+ * @param array  $attr  Block attributes.
+ * @param string $scope CSS class selector (with leading dot) unique to this instance.
+ * @return string CSS rules joined into one string, or '' when no overrides are set.
+ */
+function build_custom_styles( $attr, $scope ) {
+	$groups = array(
+		array(
+			'selector'   => $scope . ' .donations__nav-item.is-active',
+			'properties' => array(
+				'background' => isset( $attr['activeTabBackgroundColor'] ) ? $attr['activeTabBackgroundColor'] : '',
+				'color'      => isset( $attr['activeTabTextColor'] ) ? $attr['activeTabTextColor'] : '',
+			),
+		),
+		array(
+			'selector'   => $scope . ' .donations__nav-item:not(.is-active)',
+			'properties' => array(
+				'background' => isset( $attr['inactiveTabBackgroundColor'] ) ? $attr['inactiveTabBackgroundColor'] : '',
+				'color'      => isset( $attr['inactiveTabTextColor'] ) ? $attr['inactiveTabTextColor'] : '',
+			),
+		),
+		array(
+			'selector'   => $scope . ' .donations__amount.is-selected',
+			'properties' => array(
+				'background-color' => isset( $attr['selectedAmountBackgroundColor'] ) ? $attr['selectedAmountBackgroundColor'] : '',
+				'color'            => isset( $attr['selectedAmountTextColor'] ) ? $attr['selectedAmountTextColor'] : '',
+			),
+		),
+	);
+
+	$rules = array();
+	foreach ( $groups as $group ) {
+		$decls = array();
+		foreach ( $group['properties'] as $property => $value ) {
+			$safe = sanitize_color_for_css( $value );
+			if ( '' !== $safe ) {
+				$decls[] = $property . ':' . $safe;
+			}
+		}
+		if ( $decls ) {
+			$rules[] = $group['selector'] . '{' . implode( ';', $decls ) . '}';
+		}
+	}
+
+	return implode( '', $rules );
+}
+
+/**
+ * Sanitize a user-supplied CSS color value for safe inclusion in a <style> element.
+ * Strips characters that could break out of the style context (<, >, {, }, ;, quotes,
+ * backslash) and caps length, while leaving valid hex / rgb() / hsl() / var() / named
+ * colors intact.
+ *
+ * @param mixed $value Raw attribute value.
+ * @return string Sanitized value, or '' if rejected.
+ */
+function sanitize_color_for_css( $value ) {
+	if ( ! is_string( $value ) || '' === $value ) {
+		return '';
+	}
+	$value = trim( $value );
+	if ( strlen( $value ) > 100 ) {
+		return '';
+	}
+	if ( preg_match( '/[<>{};\\\\\'"]/', $value ) ) {
+		return '';
+	}
+	return $value;
 }
 
 /**

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -93,8 +93,11 @@ function render_block( $attr, $content ) {
 	// edited) fall back to the defaults in the first array. User-cleared
 	// keys (empty strings explicitly saved) win over defaults, so
 	// "blank stays blank" and "never set" gets the default.
-	$donations = array(
-		'one-time' => array_merge(
+	// Treat `show !== false` as on, so legacy blocks (where `show` was never
+	// set on oneTimeDonation) still render the one-time interval by default.
+	$donations = array();
+	if ( false !== ( $attr['oneTimeDonation']['show'] ?? true ) ) {
+		$donations['one-time'] = array_merge(
 			array(
 				'planId'     => null,
 				'title'      => __( 'One-Time', 'jetpack' ),
@@ -103,8 +106,8 @@ function render_block( $attr, $content ) {
 				'buttonText' => $default_texts['oneTimeDonation']['buttonText'],
 			),
 			$attr['oneTimeDonation']
-		),
-	);
+		);
+	}
 	if ( $attr['monthlyDonation']['show'] ) {
 		$donations['1 month'] = array_merge(
 			array(

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -237,14 +237,27 @@ function render_block( $attr, $content ) {
 }
 
 /**
- * Build a CSS string scoping per-state color rules to a single block instance.
+ * Build a CSS string scoping per-state and tab-level style rules to a single
+ * block instance.
  *
  * @param array  $attr  Block attributes.
  * @param string $scope CSS class selector (with leading dot) unique to this instance.
  * @return string CSS rules joined into one string, or '' when no overrides are set.
  */
 function build_custom_styles( $attr, $scope ) {
+	$tab_padding = isset( $attr['tabPadding'] ) && is_array( $attr['tabPadding'] ) ? $attr['tabPadding'] : array();
+
 	$groups = array(
+		array(
+			'selector'   => $scope . ' .donations__nav-item',
+			'properties' => array(
+				'font-size'      => $attr['tabFontSize'] ?? '',
+				'padding-top'    => $tab_padding['top'] ?? '',
+				'padding-right'  => $tab_padding['right'] ?? '',
+				'padding-bottom' => $tab_padding['bottom'] ?? '',
+				'padding-left'   => $tab_padding['left'] ?? '',
+			),
+		),
 		array(
 			'selector'   => $scope . ' .donations__nav-item.is-active',
 			'properties' => array(
@@ -272,7 +285,7 @@ function build_custom_styles( $attr, $scope ) {
 	foreach ( $groups as $group ) {
 		$decls = array();
 		foreach ( $group['properties'] as $property => $value ) {
-			$safe = sanitize_color_for_css( $value );
+			$safe = sanitize_css_value( $value );
 			if ( '' !== $safe ) {
 				$decls[] = $property . ':' . $safe;
 			}
@@ -286,15 +299,15 @@ function build_custom_styles( $attr, $scope ) {
 }
 
 /**
- * Sanitize a user-supplied CSS color value for safe inclusion in a <style> element.
- * Strips characters that could break out of the style context (<, >, {, }, ;, quotes,
- * backslash) and caps length, while leaving valid hex / rgb() / hsl() / var() / named
- * colors intact.
+ * Sanitize a user-supplied CSS value (color, length, etc.) for safe inclusion
+ * in a <style> element. Strips characters that could break out of the style
+ * context (<, >, {, }, ;, quotes, backslash) and caps length, while leaving
+ * valid hex / rgb() / hsl() / var() / named-color / px / rem / em values intact.
  *
  * @param mixed $value Raw attribute value.
  * @return string Sanitized value, or '' if rejected.
  */
-function sanitize_color_for_css( $value ) {
+function sanitize_css_value( $value ) {
 	if ( ! is_string( $value ) || '' === $value ) {
 		return '';
 	}

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -86,16 +86,12 @@ function render_block( $attr, $content ) {
 
 	require_once JETPACK__PLUGIN_DIR . '/_inc/lib/class-jetpack-currencies.php';
 
-	$default_texts = get_default_texts();
-
 	$donations = array(
 		'one-time' => array_merge(
 			array(
-				'planId'     => null,
-				'title'      => __( 'One-Time', 'jetpack' ),
-				'class'      => 'donations__one-time-item',
-				'heading'    => $default_texts['oneTimeDonation']['heading'],
-				'buttonText' => $default_texts['oneTimeDonation']['buttonText'],
+				'planId' => null,
+				'title'  => __( 'One-Time', 'jetpack' ),
+				'class'  => 'donations__one-time-item',
 			),
 			$attr['oneTimeDonation']
 		),
@@ -103,11 +99,9 @@ function render_block( $attr, $content ) {
 	if ( $attr['monthlyDonation']['show'] ) {
 		$donations['1 month'] = array_merge(
 			array(
-				'planId'     => null,
-				'title'      => __( 'Monthly', 'jetpack' ),
-				'class'      => 'donations__monthly-item',
-				'heading'    => $default_texts['monthlyDonation']['heading'],
-				'buttonText' => $default_texts['monthlyDonation']['buttonText'],
+				'planId' => null,
+				'title'  => __( 'Monthly', 'jetpack' ),
+				'class'  => 'donations__monthly-item',
 			),
 			$attr['monthlyDonation']
 		);
@@ -115,18 +109,16 @@ function render_block( $attr, $content ) {
 	if ( $attr['annualDonation']['show'] ) {
 		$donations['1 year'] = array_merge(
 			array(
-				'planId'     => null,
-				'title'      => __( 'Yearly', 'jetpack' ),
-				'class'      => 'donations__annual-item',
-				'heading'    => $default_texts['annualDonation']['heading'],
-				'buttonText' => $default_texts['annualDonation']['buttonText'],
+				'planId' => null,
+				'title'  => __( 'Yearly', 'jetpack' ),
+				'class'  => 'donations__annual-item',
 			),
 			$attr['annualDonation']
 		);
 	}
 
-	$choose_amount_text = isset( $attr['chooseAmountText'] ) && ! empty( $attr['chooseAmountText'] ) ? $attr['chooseAmountText'] : $default_texts['chooseAmountText'];
-	$custom_amount_text = isset( $attr['customAmountText'] ) && ! empty( $attr['customAmountText'] ) ? $attr['customAmountText'] : $default_texts['customAmountText'];
+	$choose_amount_text = $attr['chooseAmountText'] ?? '';
+	$custom_amount_text = $attr['customAmountText'] ?? '';
 	$currency           = $attr['currency'];
 	$nav                = '';
 	$headings           = '';
@@ -150,12 +142,15 @@ function render_block( $attr, $content ) {
 				esc_html( $donation['title'] )
 			);
 		}
-		$headings .= sprintf(
-			'<h4 class="%1$s">%2$s</h4>',
-			esc_attr( $donation['class'] ),
-			wp_kses_post( $donation['heading'] )
-		);
-		$amounts  .= sprintf(
+		$heading_text = wp_kses_post( $donation['heading'] ?? '' );
+		if ( '' !== trim( $heading_text ) ) {
+			$headings .= sprintf(
+				'<h4 class="%1$s">%2$s</h4>',
+				esc_attr( $donation['class'] ),
+				$heading_text
+			);
+		}
+		$amounts .= sprintf(
 			'<div class="donations__amounts %s">',
 			esc_attr( $donation['class'] )
 		);
@@ -166,13 +161,16 @@ function render_block( $attr, $content ) {
 				esc_html( \Jetpack_Currencies::format_price( $amount, $currency ) )
 			);
 		}
-		$amounts    .= '</div>';
-		$extra_text .= sprintf(
-			'<p class="%1$s">%2$s</p>',
-			esc_attr( $donation['class'] ),
-			wp_kses_post( $donation['extraText'] ?? $default_texts['extraText'] )
-		);
-		$buttons    .= sprintf(
+		$amounts        .= '</div>';
+		$extra_text_html = wp_kses_post( $donation['extraText'] ?? '' );
+		if ( '' !== trim( $extra_text_html ) ) {
+			$extra_text .= sprintf(
+				'<p class="%1$s">%2$s</p>',
+				esc_attr( $donation['class'] ),
+				$extra_text_html
+			);
+		}
+		$buttons .= sprintf(
 			'<div class="wp-block-button donations__donate-button-wrapper %1$s"><a class="wp-block-button__link wp-element-button donations__donate-button %1$s" href="%2$s">%3$s</a></div>',
 			esc_attr( $donation['class'] ),
 			esc_url( \Jetpack_Memberships::get_instance()->get_subscription_url( $plan_id ) ),
@@ -185,10 +183,10 @@ function render_block( $attr, $content ) {
 
 	$custom_amount = '';
 	if ( $attr['showCustomAmount'] ) {
-		$custom_amount        .= sprintf(
-			'<p>%s</p>',
-			wp_kses_post( $custom_amount_text )
-		);
+		$custom_amount_html = wp_kses_post( $custom_amount_text );
+		if ( '' !== trim( $custom_amount_html ) ) {
+			$custom_amount .= sprintf( '<p>%s</p>', $custom_amount_html );
+		}
 		$default_custom_amount = ( \Jetpack_Memberships::SUPPORTED_CURRENCIES[ $currency ] ?? 1 ) * 100;
 		$custom_amount        .= sprintf(
 			'<div class="donations__amount donations__custom-amount">
@@ -209,6 +207,9 @@ function render_block( $attr, $content ) {
 	$wrapper_attrs = get_block_wrapper_attributes( array( 'class' => $instance_classes ) );
 	$custom_styles = build_custom_styles( $attr, '.' . $instance_id );
 
+	$choose_amount_html  = wp_kses_post( $choose_amount_text );
+	$choose_amount_block = '' !== trim( $choose_amount_html ) ? '<p>' . $choose_amount_html . '</p>' : '';
+
 	return sprintf(
 		'
 <div %1$s>%9$s
@@ -217,7 +218,7 @@ function render_block( $attr, $content ) {
 		<div class="donations__content">
 			<div class="donations__tab">
 				%3$s
-				<p>%4$s</p>
+				%4$s
 				%5$s
 				%6$s
 				<hr class="donations__separator">
@@ -231,7 +232,7 @@ function render_block( $attr, $content ) {
 		$wrapper_attrs,
 		$nav,
 		$headings,
-		$choose_amount_text,
+		$choose_amount_block,
 		$amounts,
 		$custom_amount,
 		$extra_text,
@@ -297,6 +298,12 @@ function build_custom_styles( $attr, $scope ) {
 	);
 
 	$rules = array();
+
+	$content_alignment = $attr['contentAlignment'] ?? '';
+	if ( in_array( $content_alignment, array( 'left', 'center', 'right' ), true ) ) {
+		$rules[] = $scope . ' .donations__content{text-align:' . $content_alignment . '}';
+	}
+
 	foreach ( $groups as $group ) {
 		$decls = array();
 		foreach ( $group['properties'] as $property => $value ) {

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -317,22 +317,6 @@ function build_custom_styles( $attr, $scope ) {
 		$rules[] = $scope . ' .donations__nav,' . $scope . ' .donations__nav-item{border-color:' . $tab_border_safe . '}';
 	}
 
-	// In the "Buttons" style variation the nav container has its own vertical
-	// padding above the pill row. Mirror the user-set tab padding-top/bottom
-	// onto the nav so the row of pills scales with the pill interior padding.
-	$nav_decls = array();
-	$top_safe  = sanitize_css_value( $tab_padding['top'] ?? '' );
-	if ( '' !== $top_safe ) {
-		$nav_decls[] = 'padding-top:' . $top_safe;
-	}
-	$bottom_safe = sanitize_css_value( $tab_padding['bottom'] ?? '' );
-	if ( '' !== $bottom_safe ) {
-		$nav_decls[] = 'padding-bottom:' . $bottom_safe;
-	}
-	if ( $nav_decls ) {
-		$rules[] = $scope . '.is-style-buttons .donations__nav{' . implode( ';', $nav_decls ) . '}';
-	}
-
 	$button_alignment = $attr['buttonAlignment'] ?? '';
 	if ( in_array( $button_alignment, array( 'left', 'center', 'right' ), true ) ) {
 		$rules[] = $scope . ' .donations__donate-button-wrapper{text-align:' . $button_alignment . '}';

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -173,7 +173,7 @@ function render_block( $attr, $content ) {
 			wp_kses_post( $donation['extraText'] ?? $default_texts['extraText'] )
 		);
 		$buttons    .= sprintf(
-			'<a class="wp-block-button__link donations__donate-button %1$s" href="%2$s">%3$s</a>',
+			'<div class="wp-block-button donations__donate-button-wrapper %1$s"><a class="wp-block-button__link wp-element-button donations__donate-button %1$s" href="%2$s">%3$s</a></div>',
 			esc_attr( $donation['class'] ),
 			esc_url( \Jetpack_Memberships::get_instance()->get_subscription_url( $plan_id ) ),
 			wp_kses_post( $donation['buttonText'] )

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -317,6 +317,21 @@ function build_custom_styles( $attr, $scope ) {
 		$rules[] = $scope . ' .donations__nav,' . $scope . ' .donations__nav-item{border-color:' . $tab_border_safe . '}';
 	}
 
+	// User-set amount tile font size, border (BorderBoxControl shape) and
+	// border radius (BorderRadiusControl shape). Applies to all amount tiles
+	// (preset + custom); selected-state colors above only kick in when an
+	// amount has the is-selected class.
+	$amount_decls = array();
+	$amount_font  = sanitize_css_value( $attr['amountFontSize'] ?? '' );
+	if ( '' !== $amount_font ) {
+		$amount_decls[] = 'font-size:' . $amount_font;
+	}
+	$amount_decls = array_merge( $amount_decls, build_border_decls( $attr['amountBorder'] ?? null ) );
+	$amount_decls = array_merge( $amount_decls, build_radius_decls( $attr['amountBorderRadius'] ?? null ) );
+	if ( $amount_decls ) {
+		$rules[] = $scope . ' .donations__amount{' . implode( ';', $amount_decls ) . '}';
+	}
+
 	$button_alignment = $attr['buttonAlignment'] ?? '';
 	if ( in_array( $button_alignment, array( 'left', 'center', 'right' ), true ) ) {
 		$rules[] = $scope . ' .donations__donate-button-wrapper{text-align:' . $button_alignment . '}';
@@ -326,6 +341,82 @@ function build_custom_styles( $attr, $scope ) {
 	}
 
 	return implode( '', $rules );
+}
+
+/**
+ * Convert a uniform-or-split BorderBoxControl value into individual CSS declarations.
+ * Uniform shape: { color, style, width }. Split shape: { top: {...}, right: ..., etc. }.
+ *
+ * @param mixed $border BorderBoxControl value (or null).
+ * @return array List of CSS declaration strings (e.g. "border-color:#abc"), already sanitized.
+ */
+function build_border_decls( $border ) {
+	if ( ! is_array( $border ) ) {
+		return array();
+	}
+	$decls    = array();
+	$sides    = array( 'top', 'right', 'bottom', 'left' );
+	$is_split = false;
+	foreach ( $sides as $side ) {
+		if ( isset( $border[ $side ] ) ) {
+			$is_split = true;
+			break;
+		}
+	}
+	if ( $is_split ) {
+		foreach ( $sides as $side ) {
+			$sb = $border[ $side ] ?? null;
+			if ( ! is_array( $sb ) ) {
+				continue;
+			}
+			foreach ( array( 'color', 'style', 'width' ) as $prop ) {
+				$safe = sanitize_css_value( $sb[ $prop ] ?? '' );
+				if ( '' !== $safe ) {
+					$decls[] = 'border-' . $side . '-' . $prop . ':' . $safe;
+				}
+			}
+		}
+	} else {
+		foreach ( array( 'color', 'style', 'width' ) as $prop ) {
+			$safe = sanitize_css_value( $border[ $prop ] ?? '' );
+			if ( '' !== $safe ) {
+				$decls[] = 'border-' . $prop . ':' . $safe;
+			}
+		}
+	}
+	return $decls;
+}
+
+/**
+ * Convert a uniform-or-per-corner BorderRadiusControl value into CSS declarations.
+ * Uniform shape: a string like "8px". Per-corner shape:
+ * { topLeft, topRight, bottomRight, bottomLeft } each with string values.
+ *
+ * @param mixed $radius BorderRadiusControl value (or null).
+ * @return array List of CSS declaration strings.
+ */
+function build_radius_decls( $radius ) {
+	if ( is_string( $radius ) && '' !== $radius ) {
+		$safe = sanitize_css_value( $radius );
+		return '' !== $safe ? array( 'border-radius:' . $safe ) : array();
+	}
+	if ( ! is_array( $radius ) ) {
+		return array();
+	}
+	$corners = array(
+		'topLeft'     => 'border-top-left-radius',
+		'topRight'    => 'border-top-right-radius',
+		'bottomRight' => 'border-bottom-right-radius',
+		'bottomLeft'  => 'border-bottom-left-radius',
+	);
+	$decls   = array();
+	foreach ( $corners as $key => $css_prop ) {
+		$safe = sanitize_css_value( $radius[ $key ] ?? '' );
+		if ( '' !== $safe ) {
+			$decls[] = $css_prop . ':' . $safe;
+		}
+	}
+	return $decls;
 }
 
 /**

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -248,22 +248,22 @@ function build_custom_styles( $attr, $scope ) {
 		array(
 			'selector'   => $scope . ' .donations__nav-item.is-active',
 			'properties' => array(
-				'background' => isset( $attr['activeTabBackgroundColor'] ) ? $attr['activeTabBackgroundColor'] : '',
-				'color'      => isset( $attr['activeTabTextColor'] ) ? $attr['activeTabTextColor'] : '',
+				'background' => $attr['activeTabBackgroundColor'] ?? '',
+				'color'      => $attr['activeTabTextColor'] ?? '',
 			),
 		),
 		array(
 			'selector'   => $scope . ' .donations__nav-item:not(.is-active)',
 			'properties' => array(
-				'background' => isset( $attr['inactiveTabBackgroundColor'] ) ? $attr['inactiveTabBackgroundColor'] : '',
-				'color'      => isset( $attr['inactiveTabTextColor'] ) ? $attr['inactiveTabTextColor'] : '',
+				'background' => $attr['inactiveTabBackgroundColor'] ?? '',
+				'color'      => $attr['inactiveTabTextColor'] ?? '',
 			),
 		),
 		array(
 			'selector'   => $scope . ' .donations__amount.is-selected',
 			'properties' => array(
-				'background-color' => isset( $attr['selectedAmountBackgroundColor'] ) ? $attr['selectedAmountBackgroundColor'] : '',
-				'color'            => isset( $attr['selectedAmountTextColor'] ) ? $attr['selectedAmountTextColor'] : '',
+				'background-color' => $attr['selectedAmountBackgroundColor'] ?? '',
+				'color'            => $attr['selectedAmountTextColor'] ?? '',
 			),
 		),
 	);

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -232,7 +232,8 @@ function render_block( $attr, $content ) {
 		if ( '' !== trim( $custom_amount_html ) ) {
 			$custom_amount .= sprintf( '<p>%s</p>', $custom_amount_html );
 		}
-		$default_custom_amount = ( \Jetpack_Memberships::SUPPORTED_CURRENCIES[ $currency ] ?? 1 ) * 100;
+		$default_custom_amount = $attr['customAmountPlaceholder']
+			?? ( \Jetpack_Memberships::SUPPORTED_CURRENCIES[ $currency ] ?? 1 ) * 100;
 		$custom_amount        .= sprintf(
 			'<div class="donations__amount donations__custom-amount">
 				%1$s

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -299,6 +299,15 @@ function build_custom_styles( $attr, $scope ) {
 			),
 		),
 		array(
+			'selector'   => $scope . ' .donations__amount.is-selected',
+			'properties' => array(
+				// Override only the outer ring color; the inner 1px white separator stays put.
+				'box-shadow' => isset( $attr['selectedAmountOutlineColor'] ) && '' !== $attr['selectedAmountOutlineColor']
+					? '0 0 0 1px #fff,0 0 0 3px ' . $attr['selectedAmountOutlineColor']
+					: '',
+			),
+		),
+		array(
 			'selector'   => $scope . ' .donations__donate-button',
 			'properties' => array(
 				'font-size'      => $attr['buttonFontSize'] ?? '',

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -306,12 +306,28 @@ function build_custom_styles( $attr, $scope ) {
 		}
 	}
 
+	// In the "Buttons" style variation the nav container has its own vertical
+	// padding above the pill row. Mirror the user-set tab padding-top/bottom
+	// onto the nav so the row of pills scales with the pill interior padding.
+	$nav_decls = array();
+	$top_safe  = sanitize_css_value( $tab_padding['top'] ?? '' );
+	if ( '' !== $top_safe ) {
+		$nav_decls[] = 'padding-top:' . $top_safe;
+	}
+	$bottom_safe = sanitize_css_value( $tab_padding['bottom'] ?? '' );
+	if ( '' !== $bottom_safe ) {
+		$nav_decls[] = 'padding-bottom:' . $bottom_safe;
+	}
+	if ( $nav_decls ) {
+		$rules[] = $scope . '.is-style-buttons .donations__nav{' . implode( ';', $nav_decls ) . '}';
+	}
+
 	$button_alignment = $attr['buttonAlignment'] ?? '';
 	if ( in_array( $button_alignment, array( 'left', 'center', 'right' ), true ) ) {
 		$rules[] = $scope . ' .donations__donate-button-wrapper{text-align:' . $button_alignment . '}';
 	} elseif ( 'full' === $button_alignment ) {
 		$rules[] = $scope . ' .donations__donate-button-wrapper{display:block;width:100%}'
-			. $scope . ' .donations__donate-button{display:block;width:100%;box-sizing:border-box}';
+			. $scope . ' .donations__donate-button{display:block;width:100%;box-sizing:border-box;text-align:center}';
 	}
 
 	return implode( '', $rules );

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -201,13 +201,13 @@ function render_block( $attr, $content ) {
 		);
 	}
 
-	$instance_id     = wp_unique_id( 'jp-donations-' );
-	$wrapper_classes = Blocks::classes( Blocks::get_block_feature( __DIR__ ), $attr ) . ' ' . $instance_id;
-	$custom_styles   = build_custom_styles( $attr, '.' . $instance_id );
+	$instance_id   = wp_unique_id( 'jp-donations-' );
+	$wrapper_attrs = get_block_wrapper_attributes( array( 'class' => $instance_id ) );
+	$custom_styles = build_custom_styles( $attr, '.' . $instance_id );
 
 	return sprintf(
 		'
-<div class="%1$s">%9$s
+<div %1$s>%9$s
 	<div class="donations__container">
 		%2$s
 		<div class="donations__content">
@@ -224,7 +224,7 @@ function render_block( $attr, $content ) {
 	</div>
 </div>
 ',
-		esc_attr( $wrapper_classes ),
+		$wrapper_attrs,
 		$nav,
 		$headings,
 		$choose_amount_text,

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -245,7 +245,8 @@ function render_block( $attr, $content ) {
  * @return string CSS rules joined into one string, or '' when no overrides are set.
  */
 function build_custom_styles( $attr, $scope ) {
-	$tab_padding = isset( $attr['tabPadding'] ) && is_array( $attr['tabPadding'] ) ? $attr['tabPadding'] : array();
+	$tab_padding    = isset( $attr['tabPadding'] ) && is_array( $attr['tabPadding'] ) ? $attr['tabPadding'] : array();
+	$button_padding = isset( $attr['buttonPadding'] ) && is_array( $attr['buttonPadding'] ) ? $attr['buttonPadding'] : array();
 
 	$groups = array(
 		array(
@@ -279,6 +280,16 @@ function build_custom_styles( $attr, $scope ) {
 				'color'            => $attr['selectedAmountTextColor'] ?? '',
 			),
 		),
+		array(
+			'selector'   => $scope . ' .donations__donate-button',
+			'properties' => array(
+				'font-size'      => $attr['buttonFontSize'] ?? '',
+				'padding-top'    => $button_padding['top'] ?? '',
+				'padding-right'  => $button_padding['right'] ?? '',
+				'padding-bottom' => $button_padding['bottom'] ?? '',
+				'padding-left'   => $button_padding['left'] ?? '',
+			),
+		),
 	);
 
 	$rules = array();
@@ -293,6 +304,14 @@ function build_custom_styles( $attr, $scope ) {
 		if ( $decls ) {
 			$rules[] = $group['selector'] . '{' . implode( ';', $decls ) . '}';
 		}
+	}
+
+	$button_alignment = $attr['buttonAlignment'] ?? '';
+	if ( in_array( $button_alignment, array( 'left', 'center', 'right' ), true ) ) {
+		$rules[] = $scope . ' .donations__donate-button-wrapper{text-align:' . $button_alignment . '}';
+	} elseif ( 'full' === $button_alignment ) {
+		$rules[] = $scope . ' .donations__donate-button-wrapper{display:block;width:100%}'
+			. $scope . ' .donations__donate-button{display:block;width:100%;box-sizing:border-box}';
 	}
 
 	return implode( '', $rules );

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -86,12 +86,21 @@ function render_block( $attr, $content ) {
 
 	require_once JETPACK__PLUGIN_DIR . '/_inc/lib/class-jetpack-currencies.php';
 
+	$default_texts = get_default_texts();
+
+	// `array_merge` lets the user-supplied attributes override only the keys
+	// they actually set. Undefined keys (new blocks that have never been
+	// edited) fall back to the defaults in the first array. User-cleared
+	// keys (empty strings explicitly saved) win over defaults, so
+	// "blank stays blank" and "never set" gets the default.
 	$donations = array(
 		'one-time' => array_merge(
 			array(
-				'planId' => null,
-				'title'  => __( 'One-Time', 'jetpack' ),
-				'class'  => 'donations__one-time-item',
+				'planId'     => null,
+				'title'      => __( 'One-Time', 'jetpack' ),
+				'class'      => 'donations__one-time-item',
+				'heading'    => $default_texts['oneTimeDonation']['heading'],
+				'buttonText' => $default_texts['oneTimeDonation']['buttonText'],
 			),
 			$attr['oneTimeDonation']
 		),
@@ -99,9 +108,11 @@ function render_block( $attr, $content ) {
 	if ( $attr['monthlyDonation']['show'] ) {
 		$donations['1 month'] = array_merge(
 			array(
-				'planId' => null,
-				'title'  => __( 'Monthly', 'jetpack' ),
-				'class'  => 'donations__monthly-item',
+				'planId'     => null,
+				'title'      => __( 'Monthly', 'jetpack' ),
+				'class'      => 'donations__monthly-item',
+				'heading'    => $default_texts['monthlyDonation']['heading'],
+				'buttonText' => $default_texts['monthlyDonation']['buttonText'],
 			),
 			$attr['monthlyDonation']
 		);
@@ -109,16 +120,18 @@ function render_block( $attr, $content ) {
 	if ( $attr['annualDonation']['show'] ) {
 		$donations['1 year'] = array_merge(
 			array(
-				'planId' => null,
-				'title'  => __( 'Yearly', 'jetpack' ),
-				'class'  => 'donations__annual-item',
+				'planId'     => null,
+				'title'      => __( 'Yearly', 'jetpack' ),
+				'class'      => 'donations__annual-item',
+				'heading'    => $default_texts['annualDonation']['heading'],
+				'buttonText' => $default_texts['annualDonation']['buttonText'],
 			),
 			$attr['annualDonation']
 		);
 	}
 
-	$choose_amount_text = $attr['chooseAmountText'] ?? '';
-	$custom_amount_text = $attr['customAmountText'] ?? '';
+	$choose_amount_text = $attr['chooseAmountText'] ?? $default_texts['chooseAmountText'];
+	$custom_amount_text = $attr['customAmountText'] ?? $default_texts['customAmountText'];
 	$currency           = $attr['currency'];
 	$nav                = '';
 	$headings           = '';
@@ -162,7 +175,7 @@ function render_block( $attr, $content ) {
 			);
 		}
 		$amounts        .= '</div>';
-		$extra_text_html = wp_kses_post( $donation['extraText'] ?? '' );
+		$extra_text_html = wp_kses_post( $donation['extraText'] ?? $default_texts['extraText'] );
 		if ( '' !== trim( $extra_text_html ) ) {
 			$extra_text .= sprintf(
 				'<p class="%1$s">%2$s</p>',

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -314,7 +314,12 @@ function build_custom_styles( $attr, $scope ) {
 	// divider, the per-tab dividers, and the buttons-style pill borders.
 	$tab_border_safe = sanitize_css_value( $attr['tabBorderColor'] ?? '' );
 	if ( '' !== $tab_border_safe ) {
-		$rules[] = $scope . ' .donations__nav,' . $scope . ' .donations__nav-item{border-color:' . $tab_border_safe . '}';
+		$rules[] = $scope . ' .donations__nav,' . $scope . ' .donations__nav-item,' . $scope . ' .donations__nav-item.is-active{border-color:' . $tab_border_safe . '}';
+	}
+
+	$button_radius_decls = build_radius_decls( $attr['buttonBorderRadius'] ?? null );
+	if ( $button_radius_decls ) {
+		$rules[] = $scope . ' .donations__donate-button{' . implode( ';', $button_radius_decls ) . '}';
 	}
 
 	// User-set amount tile font size, border (BorderBoxControl shape) and

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -201,8 +201,12 @@ function render_block( $attr, $content ) {
 		);
 	}
 
-	$instance_id   = wp_unique_id( 'jp-donations-' );
-	$wrapper_attrs = get_block_wrapper_attributes( array( 'class' => $instance_id ) );
+	$instance_id      = wp_unique_id( 'jp-donations-' );
+	$instance_classes = $instance_id;
+	if ( isset( $attr['tabsAppearance'] ) && 'buttons' === $attr['tabsAppearance'] ) {
+		$instance_classes .= ' is-style-buttons';
+	}
+	$wrapper_attrs = get_block_wrapper_attributes( array( 'class' => $instance_classes ) );
 	$custom_styles = build_custom_styles( $attr, '.' . $instance_id );
 
 	return sprintf(
@@ -304,6 +308,13 @@ function build_custom_styles( $attr, $scope ) {
 		if ( $decls ) {
 			$rules[] = $group['selector'] . '{' . implode( ';', $decls ) . '}';
 		}
+	}
+
+	// User-set tab border color: applies to the default-style nav bottom
+	// divider, the per-tab dividers, and the buttons-style pill borders.
+	$tab_border_safe = sanitize_css_value( $attr['tabBorderColor'] ?? '' );
+	if ( '' !== $tab_border_safe ) {
+		$rules[] = $scope . ' .donations__nav,' . $scope . ' .donations__nav-item{border-color:' . $tab_border_safe . '}';
 	}
 
 	// In the "Buttons" style variation the nav container has its own vertical

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -301,7 +301,13 @@ function build_custom_styles( $attr, $scope ) {
 
 	$content_alignment = $attr['contentAlignment'] ?? '';
 	if ( in_array( $content_alignment, array( 'left', 'center', 'right' ), true ) ) {
-		$rules[] = $scope . ' .donations__content{text-align:' . $content_alignment . '}';
+		$rules[]     = $scope . ' .donations__content{text-align:' . $content_alignment . '}';
+		$justify_map = array(
+			'left'   => 'flex-start',
+			'center' => 'center',
+			'right'  => 'flex-end',
+		);
+		$rules[]     = $scope . ' .donations__amounts{justify-content:' . $justify_map[ $content_alignment ] . '}';
 	}
 
 	foreach ( $groups as $group ) {

--- a/projects/plugins/jetpack/extensions/blocks/donations/donations.php
+++ b/projects/plugins/jetpack/extensions/blocks/donations/donations.php
@@ -136,26 +136,50 @@ function render_block( $attr, $content ) {
 	$choose_amount_text = $attr['chooseAmountText'] ?? $default_texts['chooseAmountText'];
 	$custom_amount_text = $attr['customAmountText'] ?? $default_texts['customAmountText'];
 	$currency           = $attr['currency'];
-	$nav                = '';
-	$headings           = '';
-	$amounts            = '';
-	$extra_text         = '';
-	$buttons            = '';
+
+	// Drop intervals whose plan no longer resolves so we can compute the active tab
+	// against the actually-rendered set, not the configured set.
+	$valid_donations = array();
+	foreach ( $donations as $interval => $donation ) {
+		$plan = get_post( (int) $donation['planId'] );
+		if ( $plan && ! is_wp_error( $plan ) ) {
+			$valid_donations[ $interval ] = $donation;
+		}
+	}
+	$donations          = $valid_donations;
+	$rendered_intervals = array_keys( $donations );
+
+	// Effective default = configured defaultInterval if it survived plan validation,
+	// otherwise the first rendered interval (one-time → monthly → annual).
+	$default_interval = $attr['defaultInterval'] ?? null;
+	if ( ! in_array( $default_interval, $rendered_intervals, true ) ) {
+		$default_interval = $rendered_intervals[0] ?? null;
+	}
+	$tab_content_class_map = array(
+		'one-time' => 'is-one-time',
+		'1 month'  => 'is-monthly',
+		'1 year'   => 'is-annual',
+	);
+	$tab_content_class     = $default_interval ? $tab_content_class_map[ $default_interval ] : '';
+
+	$nav        = '';
+	$headings   = '';
+	$amounts    = '';
+	$extra_text = '';
+	$buttons    = '';
 	foreach ( $donations as $interval => $donation ) {
 		$plan_id = (int) $donation['planId'];
-		$plan    = get_post( $plan_id );
-		if ( ! $plan || is_wp_error( $plan ) ) {
-			continue;
-		}
 
 		if ( count( $donations ) > 1 ) {
 			if ( ! $nav ) {
 				$nav .= '<div class="donations__nav">';
 			}
-			$nav .= sprintf(
-				'<div role="button" tabindex="0" class="donations__nav-item" data-interval="%1$s">%2$s</div>',
+			$is_active_class = $interval === $default_interval ? ' is-active' : '';
+			$nav            .= sprintf(
+				'<div role="button" tabindex="0" class="donations__nav-item%3$s" data-interval="%1$s">%2$s</div>',
 				esc_attr( $interval ),
-				esc_html( $donation['title'] )
+				esc_html( $donation['title'] ),
+				esc_attr( $is_active_class )
 			);
 		}
 		$heading_text = wp_kses_post( $donation['heading'] ?? '' );
@@ -166,9 +190,14 @@ function render_block( $attr, $content ) {
 				$heading_text
 			);
 		}
+		$default_index_attr = '';
+		if ( isset( $donation['defaultAmountIndex'] ) && is_numeric( $donation['defaultAmountIndex'] ) ) {
+			$default_index_attr = sprintf( ' data-default-index="%d"', (int) $donation['defaultAmountIndex'] );
+		}
 		$amounts .= sprintf(
-			'<div class="donations__amounts %s">',
-			esc_attr( $donation['class'] )
+			'<div class="donations__amounts %s"%s>',
+			esc_attr( $donation['class'] ),
+			$default_index_attr
 		);
 		foreach ( $donation['amounts'] as $amount ) {
 			$amounts .= sprintf(
@@ -220,7 +249,11 @@ function render_block( $attr, $content ) {
 	if ( isset( $attr['tabsAppearance'] ) && 'buttons' === $attr['tabsAppearance'] ) {
 		$instance_classes .= ' is-style-buttons';
 	}
-	$wrapper_attrs = get_block_wrapper_attributes( array( 'class' => $instance_classes ) );
+	$wrapper_attr_array = array( 'class' => $instance_classes );
+	if ( $default_interval ) {
+		$wrapper_attr_array['data-default-interval'] = $default_interval;
+	}
+	$wrapper_attrs = get_block_wrapper_attributes( $wrapper_attr_array );
 	$custom_styles = build_custom_styles( $attr, '.' . $instance_id );
 
 	$choose_amount_html  = wp_kses_post( $choose_amount_text );
@@ -232,7 +265,7 @@ function render_block( $attr, $content ) {
 	<div class="donations__container">
 		%2$s
 		<div class="donations__content">
-			<div class="donations__tab">
+			<div class="donations__tab %10$s">
 				%3$s
 				%4$s
 				%5$s
@@ -253,7 +286,8 @@ function render_block( $attr, $content ) {
 		$custom_amount,
 		$extra_text,
 		$buttons,
-		$custom_styles ? '<style>' . $custom_styles . '</style>' : ''
+		$custom_styles ? '<style>' . $custom_styles . '</style>' : '',
+		esc_attr( $tab_content_class )
 	);
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/donations/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/edit.js
@@ -22,7 +22,25 @@ import Tabs from './tabs';
 
 const Edit = props => {
 	const { attributes, setAttributes } = props;
-	const { currency, tabsAppearance } = attributes;
+	const { currency, tabsAppearance, className } = attributes;
+
+	// Migrate legacy blocks that used the block-style variation
+	// (`is-style-buttons` saved into `className`) over to the new
+	// `tabsAppearance` attribute. Strips the class so the toggle in the
+	// Appearance control reflects reality and can switch back to "Tabs".
+	useEffect( () => {
+		if ( typeof className === 'string' && className.split( ' ' ).includes( 'is-style-buttons' ) ) {
+			const cleaned = className
+				.split( ' ' )
+				.filter( c => c !== 'is-style-buttons' )
+				.join( ' ' )
+				.trim();
+			setAttributes( {
+				tabsAppearance: 'buttons',
+				className: cleaned || undefined,
+			} );
+		}
+	}, [ className, setAttributes ] );
 
 	const instanceId = useInstanceId( Edit, 'jp-donations' );
 	const customStyles = buildCustomStyles( attributes, `.${ instanceId }` );

--- a/projects/plugins/jetpack/extensions/blocks/donations/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/edit.js
@@ -2,7 +2,7 @@ import { useBlockProps } from '@wordpress/block-editor';
 import { Spinner } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useState, useEffect } from '@wordpress/element';
+import { useCallback, useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import ConnectBanner from '../../shared/components/connect-banner';
 import { StripeNudge } from '../../shared/components/stripe-nudge';
@@ -22,12 +22,14 @@ import Tabs from './tabs';
 
 const Edit = props => {
 	const { attributes, setAttributes } = props;
-	const { currency } = attributes;
+	const { currency, tabsAppearance } = attributes;
 
 	const instanceId = useInstanceId( Edit, 'jp-donations' );
 	const customStyles = buildCustomStyles( attributes, `.${ instanceId }` );
 
-	const blockProps = useBlockProps( { className: instanceId } );
+	const wrapperClassName =
+		tabsAppearance === 'buttons' ? `${ instanceId } is-style-buttons` : instanceId;
+	const blockProps = useBlockProps( { className: wrapperClassName } );
 	const [ loadingError, setLoadingError ] = useState( '' );
 	const [ products, setProducts ] = useState( [] );
 	const [ showFirstTimeModal, setShowFirstTimeModal ] = useState( false );
@@ -191,7 +193,7 @@ const Edit = props => {
 	}
 
 	// When the first time modal is closed, update the user meta to mark the donation warning as dismissed
-	const handleModalClose = async () => {
+	const handleModalClose = useCallback( async () => {
 		setShowFirstTimeModal( false );
 
 		if ( ! currentUser?.id ) {
@@ -211,7 +213,7 @@ const Edit = props => {
 			// eslint-disable-next-line no-console
 			console.error( 'Failed to update user meta:', error );
 		}
-	};
+	}, [ currentUser, editEntityRecord, saveEditedEntityRecord ] );
 
 	return (
 		<div { ...blockProps }>

--- a/projects/plugins/jetpack/extensions/blocks/donations/edit.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/edit.js
@@ -1,5 +1,6 @@
 import { useBlockProps } from '@wordpress/block-editor';
 import { Spinner } from '@wordpress/components';
+import { useInstanceId } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -10,18 +11,23 @@ import getConnectUrl from '../../shared/get-connect-url';
 import useIsUserConnected from '../../shared/use-is-user-connected';
 import { store as membershipProductsStore } from '../../store/membership-products';
 import { STORE_NAME as MEMBERSHIPS_PRODUCTS_STORE } from '../../store/membership-products/constants';
+import buildCustomStyles from './build-custom-styles';
 import fetchDefaultProducts from './fetch-default-products';
 import fetchStatus from './fetch-status';
 import FirstTimeModal from './first-time-modal';
 import './first-time-modal.scss';
 import LoadingError from './loading-error';
+import StyleControls from './style-controls';
 import Tabs from './tabs';
 
 const Edit = props => {
 	const { attributes, setAttributes } = props;
 	const { currency } = attributes;
 
-	const blockProps = useBlockProps();
+	const instanceId = useInstanceId( Edit, 'jp-donations' );
+	const customStyles = buildCustomStyles( attributes, `.${ instanceId }` );
+
+	const blockProps = useBlockProps( { className: instanceId } );
 	const [ loadingError, setLoadingError ] = useState( '' );
 	const [ products, setProducts ] = useState( [] );
 	const [ showFirstTimeModal, setShowFirstTimeModal ] = useState( false );
@@ -209,6 +215,8 @@ const Edit = props => {
 
 	return (
 		<div { ...blockProps }>
+			<StyleControls attributes={ attributes } setAttributes={ setAttributes } />
+			{ customStyles && <style>{ customStyles }</style> }
 			{ content }
 			{ showFirstTimeModal && <FirstTimeModal onClose={ handleModalClose } /> }
 		</div>

--- a/projects/plugins/jetpack/extensions/blocks/donations/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/donations/editor.scss
@@ -56,3 +56,12 @@
 .jetpack-donations__currency-popover .components-popover__content {
 	min-width: 130px;
 }
+
+// Apply consistent vertical spacing between top-level controls inside our
+// custom style panels. Default control margins are inconsistent between
+// FontSizePicker, BoxControl, BorderBoxControl, BorderRadiusControl, etc.,
+// which leaves some sections crammed together. The first child (the panel
+// title) is excluded.
+.jp-donations-style-panel.components-panel__body > *:not(:first-child) {
+	margin-block-start: 24px;
+}

--- a/projects/plugins/jetpack/extensions/blocks/donations/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/donations/editor.scss
@@ -74,3 +74,32 @@
 	border-top: 0;
 	border-bottom: 0;
 }
+
+// Match the standard Gutenberg supports-panel look for individual control
+// labels: small uppercase grey labels with a consistent gap between label
+// and control, and controls that fill the panel width.
+.jp-donations-style-panel.components-panel__body {
+
+	.components-base-control__label,
+	.components-input-control__label,
+	.components-toggle-group-control__label,
+	.components-box-control__label,
+	.components-border-box-control__label,
+	.components-border-control__label {
+		color: #757575;
+		text-transform: uppercase;
+		font-size: 11px;
+		font-weight: 499;
+		line-height: 1.4;
+		margin-block-end: 8px;
+		display: block;
+	}
+
+	.components-base-control,
+	.components-input-control,
+	.components-box-control,
+	.components-border-box-control,
+	.components-border-radius-control {
+		width: 100%;
+	}
+}

--- a/projects/plugins/jetpack/extensions/blocks/donations/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/donations/editor.scss
@@ -65,3 +65,12 @@
 .jp-donations-style-panel.components-panel__body > *:not(:first-child) {
 	margin-block-start: 24px;
 }
+
+// Remove dividing border lines on controls inside our panels. Some controls
+// (notably BorderBoxControl, BorderRadiusControl, BoxControl) ship with their
+// own border-top / border-bottom that read as a dividing line above the
+// settings — standard core panels don't draw such a line.
+.jp-donations-style-panel.components-panel__body > *:not(.components-panel__body-title) {
+	border-top: 0;
+	border-bottom: 0;
+}

--- a/projects/plugins/jetpack/extensions/blocks/donations/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/donations/editor.scss
@@ -87,11 +87,26 @@
 		color: inherit;
 	}
 
-	// Hide the inner ToolsPanel section heading (the parent PanelBody title
-	// already labels the whole section, so a sub-heading like "Tab dimensions"
-	// reads as duplicated chrome).
+	// Hide the inner ToolsPanel section heading on non-color panels (the
+	// parent PanelBody title already labels the whole section). The colors
+	// panel keeps its header so users see a "COLORS" label above the rows
+	// like the standard Color block-support panel.
+	.components-tools-panel:not(.color-block-support-panel)
 	.components-tools-panel-header {
 		display: none;
+	}
+
+	// Inside the colors panel header, hide just the per-panel kebab menu
+	// (we provide a panel-level Reset button at the bottom instead).
+	.color-block-support-panel
+	.components-tools-panel-header
+	.components-dropdown-menu {
+		display: none;
+	}
+
+	// Right-align the panel-level Reset button in the bottom PanelRow.
+	.components-panel__row {
+		justify-content: flex-end;
 	}
 
 	// The ToolsPanel emotion-styled wrapper applies its own 16px padding;

--- a/projects/plugins/jetpack/extensions/blocks/donations/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/donations/editor.scss
@@ -75,9 +75,10 @@
 	border-bottom: 0;
 }
 
-// Match the standard Gutenberg supports-panel look for individual control
-// labels: small uppercase grey labels with a consistent gap between label
-// and control, and controls that fill the panel width.
+// Make any uppercase labels inside our custom style panels inherit text
+// color from the inspector sidebar (`.interface-complementary-area`)
+// instead of the hardcoded #757575 the components style picks. Matches
+// the auto-rendered supports panels.
 .jp-donations-style-panel.components-panel__body {
 
 	.components-base-control__label,
@@ -86,20 +87,6 @@
 	.components-box-control__label,
 	.components-border-box-control__label,
 	.components-border-control__label {
-		color: #757575;
-		text-transform: uppercase;
-		font-size: 11px;
-		font-weight: 499;
-		line-height: 1.4;
-		margin-block-end: 8px;
-		display: block;
-	}
-
-	.components-base-control,
-	.components-input-control,
-	.components-box-control,
-	.components-border-box-control,
-	.components-border-radius-control {
-		width: 100%;
+		color: inherit;
 	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/donations/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/donations/editor.scss
@@ -57,12 +57,10 @@
 	min-width: 130px;
 }
 
-// Apply consistent vertical spacing between top-level controls inside our
-// custom style panels. Default control margins are inconsistent between
-// FontSizePicker, BoxControl, BorderBoxControl, BorderRadiusControl, etc.,
-// which leaves some sections crammed together. The first child (the panel
-// title) is excluded.
-.jp-donations-style-panel.components-panel__body > *:not(:first-child) {
+// Spacing between sibling sections inside our panels. The first non-title
+// child (e.g. the first ToolsPanel) sits flush; subsequent siblings get a
+// consistent gap.
+.jp-donations-style-panel.components-panel__body > :nth-child(n+3) {
 	margin-block-start: 24px;
 }
 
@@ -75,10 +73,9 @@
 	border-bottom: 0;
 }
 
-// Make any uppercase labels inside our custom style panels inherit text
-// color from the inspector sidebar (`.interface-complementary-area`)
-// instead of the hardcoded #757575 the components style picks. Matches
-// the auto-rendered supports panels.
+// Make labels inside our custom style panels inherit text color from the
+// inspector sidebar (`.interface-complementary-area`) instead of the
+// component default grey, matching the auto-rendered supports panels.
 .jp-donations-style-panel.components-panel__body {
 
 	.components-base-control__label,
@@ -88,5 +85,29 @@
 	.components-border-box-control__label,
 	.components-border-control__label {
 		color: inherit;
+	}
+
+	// Hide the inner ToolsPanel section heading (the parent PanelBody title
+	// already labels the whole section, so a sub-heading like "Tab dimensions"
+	// reads as duplicated chrome).
+	.components-tools-panel-header {
+		display: none;
+	}
+
+	// The ToolsPanel emotion-styled wrapper applies its own 16px padding;
+	// the PanelBody already provides outer padding, so the inner panel adds
+	// extra space. Drop it here.
+	.components-tools-panel {
+		padding: 0;
+	}
+
+	// Compound color row labels (Active Tab / Inactive Tab / Tab Border /
+	// Selected Amount) are clipped by core CSS at `calc(100% - 44px)` with
+	// ellipsis. Show the full label.
+	.block-editor-panel-color-gradient-settings__color-name {
+		max-width: none;
+		overflow: visible;
+		white-space: normal;
+		text-overflow: clip;
 	}
 }

--- a/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
@@ -2,10 +2,11 @@ import {
 	ContrastChecker,
 	FontSizePicker,
 	InspectorControls,
-	PanelColorSettings,
+	__experimentalBorderRadiusControl as BorderRadiusControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalColorGradientControl as ColorGradientControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/block-editor';
 import {
+	BorderBoxControl,
 	BoxControl,
 	PanelBody,
 	__experimentalToggleGroupControl as ToggleGroupControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
@@ -29,6 +30,9 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 		buttonFontSize,
 		buttonPadding,
 		buttonAlignment,
+		amountFontSize,
+		amountBorder,
+		amountBorderRadius,
 	} = attributes;
 
 	// Stable setter refs so JSX props don't get a new function on every render
@@ -46,27 +50,14 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 			tabPadding: make( 'tabPadding' ),
 			selectedAmountBackgroundColor: make( 'selectedAmountBackgroundColor' ),
 			selectedAmountTextColor: make( 'selectedAmountTextColor' ),
+			amountFontSize: make( 'amountFontSize' ),
+			amountBorder: make( 'amountBorder' ),
+			amountBorderRadius: make( 'amountBorderRadius' ),
 			buttonFontSize: make( 'buttonFontSize' ),
 			buttonPadding: make( 'buttonPadding' ),
 			buttonAlignment: value => setAttributes( { buttonAlignment: value || '' } ),
 		};
 	}, [ setAttributes ] );
-
-	const selectedAmountColorSettings = useMemo(
-		() => [
-			{
-				value: selectedAmountBackgroundColor,
-				onChange: set.selectedAmountBackgroundColor,
-				label: __( 'Background', 'jetpack' ),
-			},
-			{
-				value: selectedAmountTextColor,
-				onChange: set.selectedAmountTextColor,
-				label: __( 'Text', 'jetpack' ),
-			},
-		],
-		[ selectedAmountBackgroundColor, selectedAmountTextColor, set ]
-	);
 
 	return (
 		<InspectorControls group="styles">
@@ -128,16 +119,37 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 					__next40pxDefaultSize={ true }
 				/>
 			</PanelBody>
-			<PanelColorSettings
-				title={ __( 'Selected amount', 'jetpack' ) }
-				initialOpen={ false }
-				colorSettings={ selectedAmountColorSettings }
-			>
+			<PanelBody title={ __( 'Amounts', 'jetpack' ) } initialOpen={ false }>
+				<ColorGradientControl
+					label={ __( 'Selected amount background', 'jetpack' ) }
+					colorValue={ selectedAmountBackgroundColor }
+					onColorChange={ set.selectedAmountBackgroundColor }
+				/>
+				<ColorGradientControl
+					label={ __( 'Selected amount text', 'jetpack' ) }
+					colorValue={ selectedAmountTextColor }
+					onColorChange={ set.selectedAmountTextColor }
+				/>
 				<ContrastChecker
 					backgroundColor={ selectedAmountBackgroundColor }
 					textColor={ selectedAmountTextColor }
 				/>
-			</PanelColorSettings>
+				<FontSizePicker
+					value={ amountFontSize }
+					onChange={ set.amountFontSize }
+					__nextHasNoMarginBottom={ true }
+					__next40pxDefaultSize={ true }
+				/>
+				<BorderBoxControl
+					label={ __( 'Border', 'jetpack' ) }
+					value={ amountBorder }
+					onChange={ set.amountBorder }
+					enableAlpha
+					enableStyle
+					__next40pxDefaultSize
+				/>
+				<BorderRadiusControl values={ amountBorderRadius } onChange={ set.amountBorderRadius } />
+			</PanelBody>
 			<PanelBody title={ __( 'Donate button', 'jetpack' ) } initialOpen={ false }>
 				<FontSizePicker
 					value={ buttonFontSize }

--- a/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
@@ -1,4 +1,10 @@
-import { ContrastChecker, InspectorControls, PanelColorSettings } from '@wordpress/block-editor';
+import {
+	ContrastChecker,
+	FontSizePicker,
+	InspectorControls,
+	PanelColorSettings,
+} from '@wordpress/block-editor';
+import { BoxControl, PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 const StyleControls = ( { attributes, setAttributes } ) => {
@@ -9,6 +15,8 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 		inactiveTabTextColor,
 		selectedAmountBackgroundColor,
 		selectedAmountTextColor,
+		tabFontSize,
+		tabPadding,
 	} = attributes;
 
 	return (
@@ -69,6 +77,20 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 					textColor={ selectedAmountTextColor }
 				/>
 			</PanelColorSettings>
+			<PanelBody title={ __( 'Tab dimensions', 'jetpack' ) } initialOpen={ false }>
+				<FontSizePicker
+					value={ tabFontSize }
+					onChange={ value => setAttributes( { tabFontSize: value } ) }
+					__nextHasNoMarginBottom={ true }
+					__next40pxDefaultSize={ true }
+				/>
+				<BoxControl
+					label={ __( 'Tab padding', 'jetpack' ) }
+					values={ tabPadding }
+					onChange={ value => setAttributes( { tabPadding: value } ) }
+					__next40pxDefaultSize={ true }
+				/>
+			</PanelBody>
 		</InspectorControls>
 	);
 };

--- a/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
@@ -407,6 +407,7 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 							label={ __( 'Padding', 'jetpack' ) }
 							values={ tabPadding }
 							onChange={ set.tabPadding }
+							allowReset={ false }
 							__next40pxDefaultSize={ true }
 						/>
 					</ToolsPanelItem>
@@ -530,6 +531,7 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 							label={ __( 'Padding', 'jetpack' ) }
 							values={ buttonPadding }
 							onChange={ set.buttonPadding }
+							allowReset={ false }
 							__next40pxDefaultSize={ true }
 						/>
 					</ToolsPanelItem>

--- a/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
@@ -157,6 +157,7 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 		buttonFontSize,
 		buttonPadding,
 		buttonAlignment,
+		buttonBorderRadius,
 		amountFontSize,
 		amountBorder,
 		amountBorderRadius,
@@ -183,20 +184,21 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 			buttonFontSize: make( 'buttonFontSize' ),
 			buttonPadding: make( 'buttonPadding' ),
 			buttonAlignment: value => setAttributes( { buttonAlignment: value || '' } ),
+			buttonBorderRadius: make( 'buttonBorderRadius' ),
 		};
 	}, [ setAttributes ] );
 
 	const activeTabSettings = useMemo(
 		() => [
 			{
-				label: __( 'Background', 'jetpack' ),
-				value: activeTabBackgroundColor,
-				onChange: set.activeTabBackgroundColor,
-			},
-			{
 				label: __( 'Text', 'jetpack' ),
 				value: activeTabTextColor,
 				onChange: set.activeTabTextColor,
+			},
+			{
+				label: __( 'Background', 'jetpack' ),
+				value: activeTabBackgroundColor,
+				onChange: set.activeTabBackgroundColor,
 			},
 		],
 		[ activeTabBackgroundColor, activeTabTextColor, set ]
@@ -205,14 +207,14 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 	const inactiveTabSettings = useMemo(
 		() => [
 			{
-				label: __( 'Background', 'jetpack' ),
-				value: inactiveTabBackgroundColor,
-				onChange: set.inactiveTabBackgroundColor,
-			},
-			{
 				label: __( 'Text', 'jetpack' ),
 				value: inactiveTabTextColor,
 				onChange: set.inactiveTabTextColor,
+			},
+			{
+				label: __( 'Background', 'jetpack' ),
+				value: inactiveTabBackgroundColor,
+				onChange: set.inactiveTabBackgroundColor,
 			},
 		],
 		[ inactiveTabBackgroundColor, inactiveTabTextColor, set ]
@@ -232,14 +234,14 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 	const selectedAmountSettings = useMemo(
 		() => [
 			{
-				label: __( 'Background', 'jetpack' ),
-				value: selectedAmountBackgroundColor,
-				onChange: set.selectedAmountBackgroundColor,
-			},
-			{
 				label: __( 'Text', 'jetpack' ),
 				value: selectedAmountTextColor,
 				onChange: set.selectedAmountTextColor,
+			},
+			{
+				label: __( 'Background', 'jetpack' ),
+				value: selectedAmountBackgroundColor,
+				onChange: set.selectedAmountBackgroundColor,
 			},
 		],
 		[ selectedAmountBackgroundColor, selectedAmountTextColor, set ]
@@ -269,6 +271,7 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 	const resetAllButton = useCallback( () => {
 		set.buttonFontSize();
 		set.buttonPadding();
+		set.buttonBorderRadius();
 		set.buttonAlignment( '' );
 	}, [ set ] );
 
@@ -285,6 +288,7 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 			buttonFontSize: () => !! buttonFontSize,
 			buttonPadding: () => !! buttonPadding,
 			buttonAlignment: () => !! buttonAlignment,
+			buttonBorderRadius: () => !! buttonBorderRadius,
 		} ),
 		[
 			tabsAppearance,
@@ -296,6 +300,7 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 			buttonFontSize,
 			buttonPadding,
 			buttonAlignment,
+			buttonBorderRadius,
 		]
 	);
 
@@ -342,7 +347,7 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 				</ToolsPanel>
 				<ToolsPanel
 					className="color-block-support-panel"
-					label={ __( 'Tab colors', 'jetpack' ) }
+					label={ __( 'Colors', 'jetpack' ) }
 					resetAll={ noop }
 					hasInnerWrapper
 					headingLevel={ 3 }
@@ -419,7 +424,7 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 			>
 				<ToolsPanel
 					className="color-block-support-panel"
-					label={ __( 'Amount colors', 'jetpack' ) }
+					label={ __( 'Colors', 'jetpack' ) }
 					resetAll={ noop }
 					hasInnerWrapper
 					headingLevel={ 3 }
@@ -526,6 +531,17 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 							values={ buttonPadding }
 							onChange={ set.buttonPadding }
 							__next40pxDefaultSize={ true }
+						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						label={ __( 'Radius', 'jetpack' ) }
+						hasValue={ has.buttonBorderRadius }
+						onDeselect={ set.buttonBorderRadius }
+						isShownByDefault
+					>
+						<BorderRadiusControl
+							values={ buttonBorderRadius }
+							onChange={ set.buttonBorderRadius }
 						/>
 					</ToolsPanelItem>
 					<ToolsPanelItem

--- a/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
@@ -4,7 +4,12 @@ import {
 	InspectorControls,
 	PanelColorSettings,
 } from '@wordpress/block-editor';
-import { BoxControl, PanelBody } from '@wordpress/components';
+import {
+	BoxControl,
+	PanelBody,
+	__experimentalToggleGroupControl as ToggleGroupControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 const StyleControls = ( { attributes, setAttributes } ) => {
@@ -17,6 +22,9 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 		selectedAmountTextColor,
 		tabFontSize,
 		tabPadding,
+		buttonFontSize,
+		buttonPadding,
+		buttonAlignment,
 	} = attributes;
 
 	return (
@@ -90,6 +98,33 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 					onChange={ value => setAttributes( { tabPadding: value } ) }
 					__next40pxDefaultSize={ true }
 				/>
+			</PanelBody>
+			<PanelBody title={ __( 'Donate button', 'jetpack' ) } initialOpen={ false }>
+				<FontSizePicker
+					value={ buttonFontSize }
+					onChange={ value => setAttributes( { buttonFontSize: value } ) }
+					__nextHasNoMarginBottom={ true }
+					__next40pxDefaultSize={ true }
+				/>
+				<BoxControl
+					label={ __( 'Button padding', 'jetpack' ) }
+					values={ buttonPadding }
+					onChange={ value => setAttributes( { buttonPadding: value } ) }
+					__next40pxDefaultSize={ true }
+				/>
+				<ToggleGroupControl
+					label={ __( 'Button alignment', 'jetpack' ) }
+					value={ buttonAlignment || '' }
+					onChange={ value => setAttributes( { buttonAlignment: value || '' } ) }
+					isBlock
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+				>
+					<ToggleGroupControlOption value="left" label={ __( 'Left', 'jetpack' ) } />
+					<ToggleGroupControlOption value="center" label={ __( 'Center', 'jetpack' ) } />
+					<ToggleGroupControlOption value="right" label={ __( 'Right', 'jetpack' ) } />
+					<ToggleGroupControlOption value="full" label={ __( 'Full width', 'jetpack' ) } />
+				</ToggleGroupControl>
 			</PanelBody>
 		</InspectorControls>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
@@ -2,18 +2,83 @@ import {
 	ContrastChecker,
 	FontSizePicker,
 	InspectorControls,
-	PanelColorSettings,
 	__experimentalBorderRadiusControl as BorderRadiusControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalColorGradientControl as ColorGradientControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/block-editor';
 import {
 	BorderBoxControl,
 	BoxControl,
+	Button,
+	ColorIndicator,
+	Dropdown,
+	FlexItem,
 	PanelBody,
+	__experimentalDropdownContentWrapper as DropdownContentWrapper, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControl as ToggleGroupControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
-import { useMemo } from '@wordpress/element';
+import { useCallback, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * One row of color settings, modeled after the standard Color panel's "Button"
+ * row: a label + 1–N small color swatches that opens a popover with full
+ * pickers when clicked. Used for grouping related colors (e.g. Active tab's
+ * background + text) so they read as a single conceptual setting.
+ */
+const COMPOUND_POPOVER_PROPS = { placement: 'left-start', offset: 36 };
+
+const CompoundColorRow = ( { label, settings } ) => {
+	const renderToggle = useCallback(
+		( { isOpen, onToggle } ) => (
+			<Button
+				onClick={ onToggle }
+				aria-expanded={ isOpen }
+				aria-label={ label }
+				className="block-editor-panel-color-gradient-settings__dropdown"
+			>
+				<HStack justify="flex-start">
+					{ settings.map( ( s, i ) => (
+						<ColorIndicator
+							key={ i }
+							colorValue={ s.value }
+							className="block-editor-panel-color-gradient-settings__color-indicator"
+						/>
+					) ) }
+					<FlexItem className="block-editor-panel-color-gradient-settings__color-name">
+						{ label }
+					</FlexItem>
+				</HStack>
+			</Button>
+		),
+		[ label, settings ]
+	);
+
+	const renderContent = useCallback(
+		() => (
+			<DropdownContentWrapper paddingSize="medium">
+				{ settings.map( ( s, i ) => (
+					<ColorGradientControl
+						key={ i }
+						label={ s.label }
+						colorValue={ s.value }
+						onColorChange={ s.onChange }
+					/>
+				) ) }
+			</DropdownContentWrapper>
+		),
+		[ settings ]
+	);
+
+	return (
+		<Dropdown
+			popoverProps={ COMPOUND_POPOVER_PROPS }
+			renderToggle={ renderToggle }
+			renderContent={ renderContent }
+		/>
+	);
+};
 
 const StyleControls = ( { attributes, setAttributes } ) => {
 	const {
@@ -59,53 +124,58 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 		};
 	}, [ setAttributes ] );
 
-	const tabColorSettings = useMemo(
+	const activeTabSettings = useMemo(
 		() => [
 			{
-				label: __( 'Active tab background', 'jetpack' ),
+				label: __( 'Background', 'jetpack' ),
 				value: activeTabBackgroundColor,
 				onChange: set.activeTabBackgroundColor,
 			},
 			{
-				label: __( 'Active tab text', 'jetpack' ),
+				label: __( 'Text', 'jetpack' ),
 				value: activeTabTextColor,
 				onChange: set.activeTabTextColor,
 			},
+		],
+		[ activeTabBackgroundColor, activeTabTextColor, set ]
+	);
+
+	const inactiveTabSettings = useMemo(
+		() => [
 			{
-				label: __( 'Inactive tab background', 'jetpack' ),
+				label: __( 'Background', 'jetpack' ),
 				value: inactiveTabBackgroundColor,
 				onChange: set.inactiveTabBackgroundColor,
 			},
 			{
-				label: __( 'Inactive tab text', 'jetpack' ),
+				label: __( 'Text', 'jetpack' ),
 				value: inactiveTabTextColor,
 				onChange: set.inactiveTabTextColor,
 			},
+		],
+		[ inactiveTabBackgroundColor, inactiveTabTextColor, set ]
+	);
+
+	const tabBorderSettings = useMemo(
+		() => [
 			{
 				label: __( 'Tab border', 'jetpack' ),
 				value: tabBorderColor,
 				onChange: set.tabBorderColor,
 			},
 		],
-		[
-			activeTabBackgroundColor,
-			activeTabTextColor,
-			inactiveTabBackgroundColor,
-			inactiveTabTextColor,
-			tabBorderColor,
-			set,
-		]
+		[ tabBorderColor, set ]
 	);
 
-	const amountColorSettings = useMemo(
+	const selectedAmountSettings = useMemo(
 		() => [
 			{
-				label: __( 'Selected amount background', 'jetpack' ),
+				label: __( 'Background', 'jetpack' ),
 				value: selectedAmountBackgroundColor,
 				onChange: set.selectedAmountBackgroundColor,
 			},
 			{
-				label: __( 'Selected amount text', 'jetpack' ),
+				label: __( 'Text', 'jetpack' ),
 				value: selectedAmountTextColor,
 				onChange: set.selectedAmountTextColor,
 			},
@@ -115,7 +185,11 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 
 	return (
 		<InspectorControls group="styles">
-			<PanelBody title={ __( 'Tabs', 'jetpack' ) } initialOpen={ false }>
+			<PanelBody
+				title={ __( 'Tabs', 'jetpack' ) }
+				initialOpen={ false }
+				className="jp-donations-style-panel"
+			>
 				<ToggleGroupControl
 					label={ __( 'Appearance', 'jetpack' ) }
 					value={ tabsAppearance || 'tabs' }
@@ -127,16 +201,20 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 					<ToggleGroupControlOption value="tabs" label={ __( 'Tabs', 'jetpack' ) } />
 					<ToggleGroupControlOption value="buttons" label={ __( 'Buttons', 'jetpack' ) } />
 				</ToggleGroupControl>
-				<PanelColorSettings showTitle={ false } colorSettings={ tabColorSettings }>
-					<ContrastChecker
-						backgroundColor={ activeTabBackgroundColor }
-						textColor={ activeTabTextColor }
-					/>
-					<ContrastChecker
-						backgroundColor={ inactiveTabBackgroundColor }
-						textColor={ inactiveTabTextColor }
-					/>
-				</PanelColorSettings>
+				<CompoundColorRow label={ __( 'Active tab', 'jetpack' ) } settings={ activeTabSettings } />
+				<CompoundColorRow
+					label={ __( 'Inactive tab', 'jetpack' ) }
+					settings={ inactiveTabSettings }
+				/>
+				<CompoundColorRow label={ __( 'Tab border', 'jetpack' ) } settings={ tabBorderSettings } />
+				<ContrastChecker
+					backgroundColor={ activeTabBackgroundColor }
+					textColor={ activeTabTextColor }
+				/>
+				<ContrastChecker
+					backgroundColor={ inactiveTabBackgroundColor }
+					textColor={ inactiveTabTextColor }
+				/>
 				<FontSizePicker
 					value={ tabFontSize }
 					onChange={ set.tabFontSize }
@@ -150,13 +228,19 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 					__next40pxDefaultSize={ true }
 				/>
 			</PanelBody>
-			<PanelBody title={ __( 'Amounts', 'jetpack' ) } initialOpen={ false }>
-				<PanelColorSettings showTitle={ false } colorSettings={ amountColorSettings }>
-					<ContrastChecker
-						backgroundColor={ selectedAmountBackgroundColor }
-						textColor={ selectedAmountTextColor }
-					/>
-				</PanelColorSettings>
+			<PanelBody
+				title={ __( 'Amounts', 'jetpack' ) }
+				initialOpen={ false }
+				className="jp-donations-style-panel"
+			>
+				<CompoundColorRow
+					label={ __( 'Selected amount', 'jetpack' ) }
+					settings={ selectedAmountSettings }
+				/>
+				<ContrastChecker
+					backgroundColor={ selectedAmountBackgroundColor }
+					textColor={ selectedAmountTextColor }
+				/>
 				<FontSizePicker
 					value={ amountFontSize }
 					onChange={ set.amountFontSize }
@@ -173,7 +257,11 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 				/>
 				<BorderRadiusControl values={ amountBorderRadius } onChange={ set.amountBorderRadius } />
 			</PanelBody>
-			<PanelBody title={ __( 'Donate button', 'jetpack' ) } initialOpen={ false }>
+			<PanelBody
+				title={ __( 'Donate button', 'jetpack' ) }
+				initialOpen={ false }
+				className="jp-donations-style-panel"
+			>
 				<FontSizePicker
 					value={ buttonFontSize }
 					onChange={ set.buttonFontSize }

--- a/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
@@ -257,6 +257,59 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 		set.selectedAmountTextColor();
 	}, [ set ] );
 
+	const resetTabSettings = useCallback( () => {
+		set.tabsAppearance( 'tabs' );
+		set.tabFontSize();
+		set.tabPadding();
+	}, [ set ] );
+
+	const resetAmountSettings = useCallback( () => {
+		set.amountFontSize();
+		set.amountBorder();
+		set.amountBorderRadius();
+	}, [ set ] );
+
+	const resetButtonSettings = useCallback( () => {
+		set.buttonFontSize();
+		set.buttonPadding();
+		set.buttonAlignment( '' );
+	}, [ set ] );
+
+	// Stable hasValue / onDeselect callbacks for each ToolsPanelItem so JSX
+	// props don't recreate functions on every render (react/jsx-no-bind).
+	const has = useMemo(
+		() => ( {
+			tabsAppearance: () => tabsAppearance === 'buttons',
+			tabFontSize: () => !! tabFontSize,
+			tabPadding: () => !! tabPadding,
+			amountFontSize: () => !! amountFontSize,
+			amountBorder: () => !! amountBorder,
+			amountBorderRadius: () => !! amountBorderRadius,
+			buttonFontSize: () => !! buttonFontSize,
+			buttonPadding: () => !! buttonPadding,
+			buttonAlignment: () => !! buttonAlignment,
+		} ),
+		[
+			tabsAppearance,
+			tabFontSize,
+			tabPadding,
+			amountFontSize,
+			amountBorder,
+			amountBorderRadius,
+			buttonFontSize,
+			buttonPadding,
+			buttonAlignment,
+		]
+	);
+
+	const deselect = useMemo(
+		() => ( {
+			tabsAppearance: () => set.tabsAppearance( 'tabs' ),
+			buttonAlignment: () => set.buttonAlignment( '' ),
+		} ),
+		[ set ]
+	);
+
 	return (
 		<InspectorControls group="styles">
 			<PanelBody
@@ -264,17 +317,6 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 				initialOpen={ false }
 				className="jp-donations-style-panel"
 			>
-				<ToggleGroupControl
-					label={ __( 'Appearance', 'jetpack' ) }
-					value={ tabsAppearance || 'tabs' }
-					onChange={ set.tabsAppearance }
-					isBlock
-					__next40pxDefaultSize
-					__nextHasNoMarginBottom
-				>
-					<ToggleGroupControlOption value="tabs" label={ __( 'Tabs', 'jetpack' ) } />
-					<ToggleGroupControlOption value="buttons" label={ __( 'Buttons', 'jetpack' ) } />
-				</ToggleGroupControl>
 				<ToolsPanel
 					className="color-block-support-panel"
 					label={ __( 'Tab colors', 'jetpack' ) }
@@ -307,18 +349,58 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 					backgroundColor={ inactiveTabBackgroundColor }
 					textColor={ inactiveTabTextColor }
 				/>
-				<FontSizePicker
-					value={ tabFontSize }
-					onChange={ set.tabFontSize }
-					__nextHasNoMarginBottom={ true }
-					__next40pxDefaultSize={ true }
-				/>
-				<BoxControl
-					label={ __( 'Tab padding', 'jetpack' ) }
-					values={ tabPadding }
-					onChange={ set.tabPadding }
-					__next40pxDefaultSize={ true }
-				/>
+				<ToolsPanel
+					label={ __( 'Tab settings', 'jetpack' ) }
+					resetAll={ resetTabSettings }
+					headingLevel={ 3 }
+					__experimentalFirstVisibleItemClass="first"
+					__experimentalLastVisibleItemClass="last"
+				>
+					<ToolsPanelItem
+						label={ __( 'Appearance', 'jetpack' ) }
+						hasValue={ has.tabsAppearance }
+						onDeselect={ deselect.tabsAppearance }
+						isShownByDefault
+					>
+						<ToggleGroupControl
+							label={ __( 'Appearance', 'jetpack' ) }
+							value={ tabsAppearance || 'tabs' }
+							onChange={ set.tabsAppearance }
+							isBlock
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+						>
+							<ToggleGroupControlOption value="tabs" label={ __( 'Tabs', 'jetpack' ) } />
+							<ToggleGroupControlOption value="buttons" label={ __( 'Buttons', 'jetpack' ) } />
+						</ToggleGroupControl>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						label={ __( 'Font size', 'jetpack' ) }
+						hasValue={ has.tabFontSize }
+						onDeselect={ set.tabFontSize }
+						isShownByDefault
+					>
+						<FontSizePicker
+							value={ tabFontSize }
+							onChange={ set.tabFontSize }
+							__nextHasNoMarginBottom={ true }
+							__next40pxDefaultSize={ true }
+						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						label={ __( 'Padding', 'jetpack' ) }
+						hasValue={ has.tabPadding }
+						onDeselect={ set.tabPadding }
+						isShownByDefault
+					>
+						<BoxControl
+							label={ __( 'Padding', 'jetpack' ) }
+							values={ tabPadding }
+							onChange={ set.tabPadding }
+							__next40pxDefaultSize={ true }
+						/>
+					</ToolsPanelItem>
+				</ToolsPanel>
 			</PanelBody>
 			<PanelBody
 				title={ __( 'Amounts', 'jetpack' ) }
@@ -345,52 +427,113 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 					backgroundColor={ selectedAmountBackgroundColor }
 					textColor={ selectedAmountTextColor }
 				/>
-				<FontSizePicker
-					value={ amountFontSize }
-					onChange={ set.amountFontSize }
-					__nextHasNoMarginBottom={ true }
-					__next40pxDefaultSize={ true }
-				/>
-				<BorderBoxControl
-					label={ __( 'Border', 'jetpack' ) }
-					value={ amountBorder }
-					onChange={ set.amountBorder }
-					enableAlpha
-					enableStyle
-					__next40pxDefaultSize
-				/>
-				<BorderRadiusControl values={ amountBorderRadius } onChange={ set.amountBorderRadius } />
+				<ToolsPanel
+					label={ __( 'Amount settings', 'jetpack' ) }
+					resetAll={ resetAmountSettings }
+					headingLevel={ 3 }
+					__experimentalFirstVisibleItemClass="first"
+					__experimentalLastVisibleItemClass="last"
+				>
+					<ToolsPanelItem
+						label={ __( 'Font size', 'jetpack' ) }
+						hasValue={ has.amountFontSize }
+						onDeselect={ set.amountFontSize }
+						isShownByDefault
+					>
+						<FontSizePicker
+							value={ amountFontSize }
+							onChange={ set.amountFontSize }
+							__nextHasNoMarginBottom={ true }
+							__next40pxDefaultSize={ true }
+						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						label={ __( 'Border', 'jetpack' ) }
+						hasValue={ has.amountBorder }
+						onDeselect={ set.amountBorder }
+						isShownByDefault
+					>
+						<BorderBoxControl
+							label={ __( 'Border', 'jetpack' ) }
+							value={ amountBorder }
+							onChange={ set.amountBorder }
+							enableAlpha
+							enableStyle
+							__next40pxDefaultSize
+						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						label={ __( 'Border radius', 'jetpack' ) }
+						hasValue={ has.amountBorderRadius }
+						onDeselect={ set.amountBorderRadius }
+						isShownByDefault
+					>
+						<BorderRadiusControl
+							values={ amountBorderRadius }
+							onChange={ set.amountBorderRadius }
+						/>
+					</ToolsPanelItem>
+				</ToolsPanel>
 			</PanelBody>
 			<PanelBody
 				title={ __( 'Donate button', 'jetpack' ) }
 				initialOpen={ false }
 				className="jp-donations-style-panel"
 			>
-				<FontSizePicker
-					value={ buttonFontSize }
-					onChange={ set.buttonFontSize }
-					__nextHasNoMarginBottom={ true }
-					__next40pxDefaultSize={ true }
-				/>
-				<BoxControl
-					label={ __( 'Button padding', 'jetpack' ) }
-					values={ buttonPadding }
-					onChange={ set.buttonPadding }
-					__next40pxDefaultSize={ true }
-				/>
-				<ToggleGroupControl
-					label={ __( 'Button alignment', 'jetpack' ) }
-					value={ buttonAlignment || '' }
-					onChange={ set.buttonAlignment }
-					isBlock
-					__next40pxDefaultSize
-					__nextHasNoMarginBottom
+				<ToolsPanel
+					label={ __( 'Button settings', 'jetpack' ) }
+					resetAll={ resetButtonSettings }
+					headingLevel={ 3 }
+					__experimentalFirstVisibleItemClass="first"
+					__experimentalLastVisibleItemClass="last"
 				>
-					<ToggleGroupControlOption value="left" label={ __( 'Left', 'jetpack' ) } />
-					<ToggleGroupControlOption value="center" label={ __( 'Center', 'jetpack' ) } />
-					<ToggleGroupControlOption value="right" label={ __( 'Right', 'jetpack' ) } />
-					<ToggleGroupControlOption value="full" label={ __( 'Full width', 'jetpack' ) } />
-				</ToggleGroupControl>
+					<ToolsPanelItem
+						label={ __( 'Font size', 'jetpack' ) }
+						hasValue={ has.buttonFontSize }
+						onDeselect={ set.buttonFontSize }
+						isShownByDefault
+					>
+						<FontSizePicker
+							value={ buttonFontSize }
+							onChange={ set.buttonFontSize }
+							__nextHasNoMarginBottom={ true }
+							__next40pxDefaultSize={ true }
+						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						label={ __( 'Padding', 'jetpack' ) }
+						hasValue={ has.buttonPadding }
+						onDeselect={ set.buttonPadding }
+						isShownByDefault
+					>
+						<BoxControl
+							label={ __( 'Padding', 'jetpack' ) }
+							values={ buttonPadding }
+							onChange={ set.buttonPadding }
+							__next40pxDefaultSize={ true }
+						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						label={ __( 'Alignment', 'jetpack' ) }
+						hasValue={ has.buttonAlignment }
+						onDeselect={ deselect.buttonAlignment }
+						isShownByDefault
+					>
+						<ToggleGroupControl
+							label={ __( 'Alignment', 'jetpack' ) }
+							value={ buttonAlignment || '' }
+							onChange={ set.buttonAlignment }
+							isBlock
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+						>
+							<ToggleGroupControlOption value="left" label={ __( 'Left', 'jetpack' ) } />
+							<ToggleGroupControlOption value="center" label={ __( 'Center', 'jetpack' ) } />
+							<ToggleGroupControlOption value="right" label={ __( 'Right', 'jetpack' ) } />
+							<ToggleGroupControlOption value="full" label={ __( 'Full width', 'jetpack' ) } />
+						</ToggleGroupControl>
+					</ToolsPanelItem>
+				</ToolsPanel>
 			</PanelBody>
 		</InspectorControls>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
@@ -2,6 +2,7 @@ import {
 	ContrastChecker,
 	FontSizePicker,
 	InspectorControls,
+	PanelColorSettings,
 	__experimentalBorderRadiusControl as BorderRadiusControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalColorGradientControl as ColorGradientControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/block-editor';
@@ -59,6 +60,44 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 		};
 	}, [ setAttributes ] );
 
+	const tabColorSettings = useMemo(
+		() => [
+			{
+				label: __( 'Active tab background', 'jetpack' ),
+				value: activeTabBackgroundColor,
+				onChange: set.activeTabBackgroundColor,
+			},
+			{
+				label: __( 'Active tab text', 'jetpack' ),
+				value: activeTabTextColor,
+				onChange: set.activeTabTextColor,
+			},
+			{
+				label: __( 'Inactive tab background', 'jetpack' ),
+				value: inactiveTabBackgroundColor,
+				onChange: set.inactiveTabBackgroundColor,
+			},
+			{
+				label: __( 'Inactive tab text', 'jetpack' ),
+				value: inactiveTabTextColor,
+				onChange: set.inactiveTabTextColor,
+			},
+			{
+				label: __( 'Tab border', 'jetpack' ),
+				value: tabBorderColor,
+				onChange: set.tabBorderColor,
+			},
+		],
+		[
+			activeTabBackgroundColor,
+			activeTabTextColor,
+			inactiveTabBackgroundColor,
+			inactiveTabTextColor,
+			tabBorderColor,
+			set,
+		]
+	);
+
 	return (
 		<InspectorControls group="styles">
 			<PanelBody title={ __( 'Tabs', 'jetpack' ) } initialOpen={ false }>
@@ -73,39 +112,16 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 					<ToggleGroupControlOption value="tabs" label={ __( 'Tabs', 'jetpack' ) } />
 					<ToggleGroupControlOption value="buttons" label={ __( 'Buttons', 'jetpack' ) } />
 				</ToggleGroupControl>
-				<ColorGradientControl
-					label={ __( 'Active tab background', 'jetpack' ) }
-					colorValue={ activeTabBackgroundColor }
-					onColorChange={ set.activeTabBackgroundColor }
-				/>
-				<ColorGradientControl
-					label={ __( 'Active tab text', 'jetpack' ) }
-					colorValue={ activeTabTextColor }
-					onColorChange={ set.activeTabTextColor }
-				/>
-				<ColorGradientControl
-					label={ __( 'Inactive tab background', 'jetpack' ) }
-					colorValue={ inactiveTabBackgroundColor }
-					onColorChange={ set.inactiveTabBackgroundColor }
-				/>
-				<ColorGradientControl
-					label={ __( 'Inactive tab text', 'jetpack' ) }
-					colorValue={ inactiveTabTextColor }
-					onColorChange={ set.inactiveTabTextColor }
-				/>
-				<ColorGradientControl
-					label={ __( 'Tab border', 'jetpack' ) }
-					colorValue={ tabBorderColor }
-					onColorChange={ set.tabBorderColor }
-				/>
-				<ContrastChecker
-					backgroundColor={ activeTabBackgroundColor }
-					textColor={ activeTabTextColor }
-				/>
-				<ContrastChecker
-					backgroundColor={ inactiveTabBackgroundColor }
-					textColor={ inactiveTabTextColor }
-				/>
+				<PanelColorSettings showTitle={ false } colorSettings={ tabColorSettings }>
+					<ContrastChecker
+						backgroundColor={ activeTabBackgroundColor }
+						textColor={ activeTabTextColor }
+					/>
+					<ContrastChecker
+						backgroundColor={ inactiveTabBackgroundColor }
+						textColor={ inactiveTabTextColor }
+					/>
+				</PanelColorSettings>
 				<FontSizePicker
 					value={ tabFontSize }
 					onChange={ set.tabFontSize }

--- a/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
@@ -14,6 +14,7 @@ import {
 	Flex,
 	FlexItem,
 	PanelBody,
+	PanelRow,
 	TabPanel,
 	__experimentalDropdownContentWrapper as DropdownContentWrapper, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
@@ -244,35 +245,28 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 		[ selectedAmountBackgroundColor, selectedAmountTextColor, set ]
 	);
 
-	const resetTabColors = useCallback( () => {
+	const noop = useCallback( () => {}, [] );
+
+	const resetAllTabs = useCallback( () => {
+		set.tabsAppearance( 'tabs' );
 		set.activeTabBackgroundColor();
 		set.activeTabTextColor();
 		set.inactiveTabBackgroundColor();
 		set.inactiveTabTextColor();
 		set.tabBorderColor();
-	}, [ set ] );
-
-	const resetAmountColors = useCallback( () => {
-		set.selectedAmountBackgroundColor();
-		set.selectedAmountTextColor();
-	}, [ set ] );
-
-	const resetTabAppearance = useCallback( () => {
-		set.tabsAppearance( 'tabs' );
-	}, [ set ] );
-
-	const resetTabDimensions = useCallback( () => {
 		set.tabFontSize();
 		set.tabPadding();
 	}, [ set ] );
 
-	const resetAmountSettings = useCallback( () => {
+	const resetAllAmounts = useCallback( () => {
+		set.selectedAmountBackgroundColor();
+		set.selectedAmountTextColor();
 		set.amountFontSize();
 		set.amountBorder();
 		set.amountBorderRadius();
 	}, [ set ] );
 
-	const resetButtonSettings = useCallback( () => {
+	const resetAllButton = useCallback( () => {
 		set.buttonFontSize();
 		set.buttonPadding();
 		set.buttonAlignment( '' );
@@ -322,7 +316,7 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 			>
 				<ToolsPanel
 					label={ __( 'Tab appearance', 'jetpack' ) }
-					resetAll={ resetTabAppearance }
+					resetAll={ noop }
 					headingLevel={ 3 }
 					__experimentalFirstVisibleItemClass="first"
 					__experimentalLastVisibleItemClass="last"
@@ -349,7 +343,7 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 				<ToolsPanel
 					className="color-block-support-panel"
 					label={ __( 'Tab colors', 'jetpack' ) }
-					resetAll={ resetTabColors }
+					resetAll={ noop }
 					hasInnerWrapper
 					headingLevel={ 3 }
 					__experimentalFirstVisibleItemClass="first"
@@ -380,7 +374,7 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 				/>
 				<ToolsPanel
 					label={ __( 'Tab dimensions', 'jetpack' ) }
-					resetAll={ resetTabDimensions }
+					resetAll={ noop }
 					headingLevel={ 3 }
 					__experimentalFirstVisibleItemClass="first"
 					__experimentalLastVisibleItemClass="last"
@@ -412,6 +406,11 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 						/>
 					</ToolsPanelItem>
 				</ToolsPanel>
+				<PanelRow>
+					<Button variant="secondary" onClick={ resetAllTabs }>
+						{ __( 'Reset', 'jetpack' ) }
+					</Button>
+				</PanelRow>
 			</PanelBody>
 			<PanelBody
 				title={ __( 'Amounts', 'jetpack' ) }
@@ -421,7 +420,7 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 				<ToolsPanel
 					className="color-block-support-panel"
 					label={ __( 'Amount colors', 'jetpack' ) }
-					resetAll={ resetAmountColors }
+					resetAll={ noop }
 					hasInnerWrapper
 					headingLevel={ 3 }
 					__experimentalFirstVisibleItemClass="first"
@@ -440,7 +439,7 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 				/>
 				<ToolsPanel
 					label={ __( 'Amount settings', 'jetpack' ) }
-					resetAll={ resetAmountSettings }
+					resetAll={ noop }
 					headingLevel={ 3 }
 					__experimentalFirstVisibleItemClass="first"
 					__experimentalLastVisibleItemClass="last"
@@ -485,6 +484,11 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 						/>
 					</ToolsPanelItem>
 				</ToolsPanel>
+				<PanelRow>
+					<Button variant="secondary" onClick={ resetAllAmounts }>
+						{ __( 'Reset', 'jetpack' ) }
+					</Button>
+				</PanelRow>
 			</PanelBody>
 			<PanelBody
 				title={ __( 'Donate button', 'jetpack' ) }
@@ -493,7 +497,7 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 			>
 				<ToolsPanel
 					label={ __( 'Button settings', 'jetpack' ) }
-					resetAll={ resetButtonSettings }
+					resetAll={ noop }
 					headingLevel={ 3 }
 					__experimentalFirstVisibleItemClass="first"
 					__experimentalLastVisibleItemClass="last"
@@ -545,6 +549,11 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 						</ToggleGroupControl>
 					</ToolsPanelItem>
 				</ToolsPanel>
+				<PanelRow>
+					<Button variant="secondary" onClick={ resetAllButton }>
+						{ __( 'Reset', 'jetpack' ) }
+					</Button>
+				</PanelRow>
 			</PanelBody>
 		</InspectorControls>
 	);

--- a/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
@@ -150,6 +150,7 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 		inactiveTabTextColor,
 		selectedAmountBackgroundColor,
 		selectedAmountTextColor,
+		selectedAmountOutlineColor,
 		tabsAppearance,
 		tabBorderColor,
 		tabFontSize,
@@ -178,6 +179,7 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 			tabPadding: make( 'tabPadding' ),
 			selectedAmountBackgroundColor: make( 'selectedAmountBackgroundColor' ),
 			selectedAmountTextColor: make( 'selectedAmountTextColor' ),
+			selectedAmountOutlineColor: make( 'selectedAmountOutlineColor' ),
 			amountFontSize: make( 'amountFontSize' ),
 			amountBorder: make( 'amountBorder' ),
 			amountBorderRadius: make( 'amountBorderRadius' ),
@@ -243,8 +245,13 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 				value: selectedAmountBackgroundColor,
 				onChange: set.selectedAmountBackgroundColor,
 			},
+			{
+				label: __( 'Outline', 'jetpack' ),
+				value: selectedAmountOutlineColor,
+				onChange: set.selectedAmountOutlineColor,
+			},
 		],
-		[ selectedAmountBackgroundColor, selectedAmountTextColor, set ]
+		[ selectedAmountBackgroundColor, selectedAmountTextColor, selectedAmountOutlineColor, set ]
 	);
 
 	const noop = useCallback( () => {}, [] );
@@ -263,6 +270,7 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 	const resetAllAmounts = useCallback( () => {
 		set.selectedAmountBackgroundColor();
 		set.selectedAmountTextColor();
+		set.selectedAmountOutlineColor();
 		set.amountFontSize();
 		set.amountBorder();
 		set.amountBorderRadius();

--- a/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
@@ -3,6 +3,7 @@ import {
 	FontSizePicker,
 	InspectorControls,
 	PanelColorSettings,
+	__experimentalColorGradientControl as ColorGradientControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/block-editor';
 import {
 	BoxControl,
@@ -10,6 +11,7 @@ import {
 	__experimentalToggleGroupControl as ToggleGroupControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
+import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 const StyleControls = ( { attributes, setAttributes } ) => {
@@ -20,6 +22,8 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 		inactiveTabTextColor,
 		selectedAmountBackgroundColor,
 		selectedAmountTextColor,
+		tabsAppearance,
+		tabBorderColor,
 		tabFontSize,
 		tabPadding,
 		buttonFontSize,
@@ -27,34 +31,82 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 		buttonAlignment,
 	} = attributes;
 
+	// Stable setter refs so JSX props don't get a new function on every render
+	// (required by react/jsx-no-bind).
+	const set = useMemo( () => {
+		const make = name => value => setAttributes( { [ name ]: value } );
+		return {
+			tabsAppearance: make( 'tabsAppearance' ),
+			activeTabBackgroundColor: make( 'activeTabBackgroundColor' ),
+			activeTabTextColor: make( 'activeTabTextColor' ),
+			inactiveTabBackgroundColor: make( 'inactiveTabBackgroundColor' ),
+			inactiveTabTextColor: make( 'inactiveTabTextColor' ),
+			tabBorderColor: make( 'tabBorderColor' ),
+			tabFontSize: make( 'tabFontSize' ),
+			tabPadding: make( 'tabPadding' ),
+			selectedAmountBackgroundColor: make( 'selectedAmountBackgroundColor' ),
+			selectedAmountTextColor: make( 'selectedAmountTextColor' ),
+			buttonFontSize: make( 'buttonFontSize' ),
+			buttonPadding: make( 'buttonPadding' ),
+			buttonAlignment: value => setAttributes( { buttonAlignment: value || '' } ),
+		};
+	}, [ setAttributes ] );
+
+	const selectedAmountColorSettings = useMemo(
+		() => [
+			{
+				value: selectedAmountBackgroundColor,
+				onChange: set.selectedAmountBackgroundColor,
+				label: __( 'Background', 'jetpack' ),
+			},
+			{
+				value: selectedAmountTextColor,
+				onChange: set.selectedAmountTextColor,
+				label: __( 'Text', 'jetpack' ),
+			},
+		],
+		[ selectedAmountBackgroundColor, selectedAmountTextColor, set ]
+	);
+
 	return (
 		<InspectorControls group="styles">
-			<PanelColorSettings
-				title={ __( 'Tabs', 'jetpack' ) }
-				initialOpen={ false }
-				colorSettings={ [
-					{
-						value: activeTabBackgroundColor,
-						onChange: value => setAttributes( { activeTabBackgroundColor: value } ),
-						label: __( 'Active tab background', 'jetpack' ),
-					},
-					{
-						value: activeTabTextColor,
-						onChange: value => setAttributes( { activeTabTextColor: value } ),
-						label: __( 'Active tab text', 'jetpack' ),
-					},
-					{
-						value: inactiveTabBackgroundColor,
-						onChange: value => setAttributes( { inactiveTabBackgroundColor: value } ),
-						label: __( 'Inactive tab background', 'jetpack' ),
-					},
-					{
-						value: inactiveTabTextColor,
-						onChange: value => setAttributes( { inactiveTabTextColor: value } ),
-						label: __( 'Inactive tab text', 'jetpack' ),
-					},
-				] }
-			>
+			<PanelBody title={ __( 'Tabs', 'jetpack' ) } initialOpen={ false }>
+				<ToggleGroupControl
+					label={ __( 'Appearance', 'jetpack' ) }
+					value={ tabsAppearance || 'tabs' }
+					onChange={ set.tabsAppearance }
+					isBlock
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+				>
+					<ToggleGroupControlOption value="tabs" label={ __( 'Tabs', 'jetpack' ) } />
+					<ToggleGroupControlOption value="buttons" label={ __( 'Buttons', 'jetpack' ) } />
+				</ToggleGroupControl>
+				<ColorGradientControl
+					label={ __( 'Active tab background', 'jetpack' ) }
+					colorValue={ activeTabBackgroundColor }
+					onColorChange={ set.activeTabBackgroundColor }
+				/>
+				<ColorGradientControl
+					label={ __( 'Active tab text', 'jetpack' ) }
+					colorValue={ activeTabTextColor }
+					onColorChange={ set.activeTabTextColor }
+				/>
+				<ColorGradientControl
+					label={ __( 'Inactive tab background', 'jetpack' ) }
+					colorValue={ inactiveTabBackgroundColor }
+					onColorChange={ set.inactiveTabBackgroundColor }
+				/>
+				<ColorGradientControl
+					label={ __( 'Inactive tab text', 'jetpack' ) }
+					colorValue={ inactiveTabTextColor }
+					onColorChange={ set.inactiveTabTextColor }
+				/>
+				<ColorGradientControl
+					label={ __( 'Tab border', 'jetpack' ) }
+					colorValue={ tabBorderColor }
+					onColorChange={ set.tabBorderColor }
+				/>
 				<ContrastChecker
 					backgroundColor={ activeTabBackgroundColor }
 					textColor={ activeTabTextColor }
@@ -63,59 +115,46 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 					backgroundColor={ inactiveTabBackgroundColor }
 					textColor={ inactiveTabTextColor }
 				/>
-			</PanelColorSettings>
-			<PanelColorSettings
-				title={ __( 'Selected amount', 'jetpack' ) }
-				initialOpen={ false }
-				colorSettings={ [
-					{
-						value: selectedAmountBackgroundColor,
-						onChange: value => setAttributes( { selectedAmountBackgroundColor: value } ),
-						label: __( 'Background', 'jetpack' ),
-					},
-					{
-						value: selectedAmountTextColor,
-						onChange: value => setAttributes( { selectedAmountTextColor: value } ),
-						label: __( 'Text', 'jetpack' ),
-					},
-				] }
-			>
-				<ContrastChecker
-					backgroundColor={ selectedAmountBackgroundColor }
-					textColor={ selectedAmountTextColor }
-				/>
-			</PanelColorSettings>
-			<PanelBody title={ __( 'Tab dimensions', 'jetpack' ) } initialOpen={ false }>
 				<FontSizePicker
 					value={ tabFontSize }
-					onChange={ value => setAttributes( { tabFontSize: value } ) }
+					onChange={ set.tabFontSize }
 					__nextHasNoMarginBottom={ true }
 					__next40pxDefaultSize={ true }
 				/>
 				<BoxControl
 					label={ __( 'Tab padding', 'jetpack' ) }
 					values={ tabPadding }
-					onChange={ value => setAttributes( { tabPadding: value } ) }
+					onChange={ set.tabPadding }
 					__next40pxDefaultSize={ true }
 				/>
 			</PanelBody>
+			<PanelColorSettings
+				title={ __( 'Selected amount', 'jetpack' ) }
+				initialOpen={ false }
+				colorSettings={ selectedAmountColorSettings }
+			>
+				<ContrastChecker
+					backgroundColor={ selectedAmountBackgroundColor }
+					textColor={ selectedAmountTextColor }
+				/>
+			</PanelColorSettings>
 			<PanelBody title={ __( 'Donate button', 'jetpack' ) } initialOpen={ false }>
 				<FontSizePicker
 					value={ buttonFontSize }
-					onChange={ value => setAttributes( { buttonFontSize: value } ) }
+					onChange={ set.buttonFontSize }
 					__nextHasNoMarginBottom={ true }
 					__next40pxDefaultSize={ true }
 				/>
 				<BoxControl
 					label={ __( 'Button padding', 'jetpack' ) }
 					values={ buttonPadding }
-					onChange={ value => setAttributes( { buttonPadding: value } ) }
+					onChange={ set.buttonPadding }
 					__next40pxDefaultSize={ true }
 				/>
 				<ToggleGroupControl
 					label={ __( 'Button alignment', 'jetpack' ) }
 					value={ buttonAlignment || '' }
-					onChange={ value => setAttributes( { buttonAlignment: value || '' } ) }
+					onChange={ set.buttonAlignment }
 					isBlock
 					__next40pxDefaultSize
 					__nextHasNoMarginBottom

--- a/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
@@ -11,12 +11,16 @@ import {
 	Button,
 	ColorIndicator,
 	Dropdown,
+	Flex,
 	FlexItem,
 	PanelBody,
 	__experimentalDropdownContentWrapper as DropdownContentWrapper, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControl as ToggleGroupControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanel as ToolsPanel, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanelItem as ToolsPanelItem, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalZStack as ZStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
 import { useCallback, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -29,23 +33,42 @@ import { __ } from '@wordpress/i18n';
  */
 const COMPOUND_POPOVER_PROPS = { placement: 'left-start', offset: 36 };
 
+/**
+ * Render a row in our color settings panels with the same look as the
+ * standard "Color (Block support panel)" rows: a labeled-indicators toggle
+ * button (slightly overlapping swatches via ZStack with offset:-8) inside a
+ * ToolsPanelItem so that the standard
+ * `block-editor-tools-panel-color-gradient-settings__item` styles (borders,
+ * rounded corners, kebab-menu reset) apply for free.
+ *
+ * Accepts 1+ settings; one setting renders one swatch, two render an
+ * overlapping pair (matches the standard "Button" row).
+ *
+ * @param {object}   props          - Component props.
+ * @param {string}   props.label    - Row label shown next to the swatches.
+ * @param {object[]} props.settings - Color settings for this row, each with `label`, `value`, `onChange`.
+ * @return {Element} The rendered ToolsPanelItem.
+ */
 const CompoundColorRow = ( { label, settings } ) => {
+	const hasValue = useCallback( () => settings.some( s => !! s.value ), [ settings ] );
+	const onDeselect = useCallback( () => settings.forEach( s => s.onChange() ), [ settings ] );
+
 	const renderToggle = useCallback(
 		( { isOpen, onToggle } ) => (
 			<Button
 				onClick={ onToggle }
 				aria-expanded={ isOpen }
 				aria-label={ label }
-				className="block-editor-panel-color-gradient-settings__dropdown"
+				__next40pxDefaultSize
 			>
 				<HStack justify="flex-start">
-					{ settings.map( ( s, i ) => (
-						<ColorIndicator
-							key={ i }
-							colorValue={ s.value }
-							className="block-editor-panel-color-gradient-settings__color-indicator"
-						/>
-					) ) }
+					<ZStack isLayered={ false } offset={ -8 }>
+						{ settings.map( ( s, i ) => (
+							<Flex key={ i } expanded={ false }>
+								<ColorIndicator colorValue={ s.value } />
+							</Flex>
+						) ) }
+					</ZStack>
 					<FlexItem className="block-editor-panel-color-gradient-settings__color-name">
 						{ label }
 					</FlexItem>
@@ -72,11 +95,20 @@ const CompoundColorRow = ( { label, settings } ) => {
 	);
 
 	return (
-		<Dropdown
-			popoverProps={ COMPOUND_POPOVER_PROPS }
-			renderToggle={ renderToggle }
-			renderContent={ renderContent }
-		/>
+		<ToolsPanelItem
+			className="block-editor-tools-panel-color-gradient-settings__item"
+			label={ label }
+			hasValue={ hasValue }
+			onDeselect={ onDeselect }
+			isShownByDefault
+		>
+			<Dropdown
+				popoverProps={ COMPOUND_POPOVER_PROPS }
+				className="block-editor-tools-panel-color-gradient-settings__dropdown"
+				renderToggle={ renderToggle }
+				renderContent={ renderContent }
+			/>
+		</ToolsPanelItem>
 	);
 };
 
@@ -183,6 +215,19 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 		[ selectedAmountBackgroundColor, selectedAmountTextColor, set ]
 	);
 
+	const resetTabColors = useCallback( () => {
+		set.activeTabBackgroundColor();
+		set.activeTabTextColor();
+		set.inactiveTabBackgroundColor();
+		set.inactiveTabTextColor();
+		set.tabBorderColor();
+	}, [ set ] );
+
+	const resetAmountColors = useCallback( () => {
+		set.selectedAmountBackgroundColor();
+		set.selectedAmountTextColor();
+	}, [ set ] );
+
 	return (
 		<InspectorControls group="styles">
 			<PanelBody
@@ -201,12 +246,24 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 					<ToggleGroupControlOption value="tabs" label={ __( 'Tabs', 'jetpack' ) } />
 					<ToggleGroupControlOption value="buttons" label={ __( 'Buttons', 'jetpack' ) } />
 				</ToggleGroupControl>
-				<CompoundColorRow label={ __( 'Active tab', 'jetpack' ) } settings={ activeTabSettings } />
-				<CompoundColorRow
-					label={ __( 'Inactive tab', 'jetpack' ) }
-					settings={ inactiveTabSettings }
-				/>
-				<CompoundColorRow label={ __( 'Tab border', 'jetpack' ) } settings={ tabBorderSettings } />
+				<ToolsPanel
+					className="color-block-support-panel"
+					label={ __( 'Tab colors', 'jetpack' ) }
+					resetAll={ resetTabColors }
+				>
+					<CompoundColorRow
+						label={ __( 'Active tab', 'jetpack' ) }
+						settings={ activeTabSettings }
+					/>
+					<CompoundColorRow
+						label={ __( 'Inactive tab', 'jetpack' ) }
+						settings={ inactiveTabSettings }
+					/>
+					<CompoundColorRow
+						label={ __( 'Tab border', 'jetpack' ) }
+						settings={ tabBorderSettings }
+					/>
+				</ToolsPanel>
 				<ContrastChecker
 					backgroundColor={ activeTabBackgroundColor }
 					textColor={ activeTabTextColor }
@@ -233,10 +290,16 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 				initialOpen={ false }
 				className="jp-donations-style-panel"
 			>
-				<CompoundColorRow
-					label={ __( 'Selected amount', 'jetpack' ) }
-					settings={ selectedAmountSettings }
-				/>
+				<ToolsPanel
+					className="color-block-support-panel"
+					label={ __( 'Amount colors', 'jetpack' ) }
+					resetAll={ resetAmountColors }
+				>
+					<CompoundColorRow
+						label={ __( 'Selected amount', 'jetpack' ) }
+						settings={ selectedAmountSettings }
+					/>
+				</ToolsPanel>
 				<ContrastChecker
 					backgroundColor={ selectedAmountBackgroundColor }
 					textColor={ selectedAmountTextColor }

--- a/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
@@ -250,19 +250,25 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 					className="color-block-support-panel"
 					label={ __( 'Tab colors', 'jetpack' ) }
 					resetAll={ resetTabColors }
+					hasInnerWrapper
+					headingLevel={ 3 }
+					__experimentalFirstVisibleItemClass="first"
+					__experimentalLastVisibleItemClass="last"
 				>
-					<CompoundColorRow
-						label={ __( 'Active tab', 'jetpack' ) }
-						settings={ activeTabSettings }
-					/>
-					<CompoundColorRow
-						label={ __( 'Inactive tab', 'jetpack' ) }
-						settings={ inactiveTabSettings }
-					/>
-					<CompoundColorRow
-						label={ __( 'Tab border', 'jetpack' ) }
-						settings={ tabBorderSettings }
-					/>
+					<div className="color-block-support-panel__inner-wrapper">
+						<CompoundColorRow
+							label={ __( 'Active tab', 'jetpack' ) }
+							settings={ activeTabSettings }
+						/>
+						<CompoundColorRow
+							label={ __( 'Inactive tab', 'jetpack' ) }
+							settings={ inactiveTabSettings }
+						/>
+						<CompoundColorRow
+							label={ __( 'Tab border', 'jetpack' ) }
+							settings={ tabBorderSettings }
+						/>
+					</div>
 				</ToolsPanel>
 				<ContrastChecker
 					backgroundColor={ activeTabBackgroundColor }
@@ -294,11 +300,17 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 					className="color-block-support-panel"
 					label={ __( 'Amount colors', 'jetpack' ) }
 					resetAll={ resetAmountColors }
+					hasInnerWrapper
+					headingLevel={ 3 }
+					__experimentalFirstVisibleItemClass="first"
+					__experimentalLastVisibleItemClass="last"
 				>
-					<CompoundColorRow
-						label={ __( 'Selected amount', 'jetpack' ) }
-						settings={ selectedAmountSettings }
-					/>
+					<div className="color-block-support-panel__inner-wrapper">
+						<CompoundColorRow
+							label={ __( 'Selected amount', 'jetpack' ) }
+							settings={ selectedAmountSettings }
+						/>
+					</div>
 				</ToolsPanel>
 				<ContrastChecker
 					backgroundColor={ selectedAmountBackgroundColor }

--- a/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
@@ -1,0 +1,62 @@
+import { InspectorControls, PanelColorSettings } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+const StyleControls = ( { attributes, setAttributes } ) => {
+	const {
+		activeTabBackgroundColor,
+		activeTabTextColor,
+		inactiveTabBackgroundColor,
+		inactiveTabTextColor,
+		selectedAmountBackgroundColor,
+		selectedAmountTextColor,
+	} = attributes;
+
+	return (
+		<InspectorControls group="styles">
+			<PanelColorSettings
+				title={ __( 'Tabs', 'jetpack' ) }
+				initialOpen={ false }
+				colorSettings={ [
+					{
+						value: activeTabBackgroundColor,
+						onChange: value => setAttributes( { activeTabBackgroundColor: value } ),
+						label: __( 'Active tab background', 'jetpack' ),
+					},
+					{
+						value: activeTabTextColor,
+						onChange: value => setAttributes( { activeTabTextColor: value } ),
+						label: __( 'Active tab text', 'jetpack' ),
+					},
+					{
+						value: inactiveTabBackgroundColor,
+						onChange: value => setAttributes( { inactiveTabBackgroundColor: value } ),
+						label: __( 'Inactive tab background', 'jetpack' ),
+					},
+					{
+						value: inactiveTabTextColor,
+						onChange: value => setAttributes( { inactiveTabTextColor: value } ),
+						label: __( 'Inactive tab text', 'jetpack' ),
+					},
+				] }
+			/>
+			<PanelColorSettings
+				title={ __( 'Selected amount', 'jetpack' ) }
+				initialOpen={ false }
+				colorSettings={ [
+					{
+						value: selectedAmountBackgroundColor,
+						onChange: value => setAttributes( { selectedAmountBackgroundColor: value } ),
+						label: __( 'Background', 'jetpack' ),
+					},
+					{
+						value: selectedAmountTextColor,
+						onChange: value => setAttributes( { selectedAmountTextColor: value } ),
+						label: __( 'Text', 'jetpack' ),
+					},
+				] }
+			/>
+		</InspectorControls>
+	);
+};
+
+export default StyleControls;

--- a/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
@@ -82,37 +82,43 @@ const CompoundColorRow = ( { label, settings } ) => {
 	const renderContent = useCallback( () => {
 		if ( settings.length === 1 ) {
 			return (
-				<DropdownContentWrapper paddingSize="medium">
-					<ColorGradientControl
-						label={ settings[ 0 ].label }
-						colorValue={ settings[ 0 ].value }
-						onColorChange={ settings[ 0 ].onChange }
-					/>
+				<DropdownContentWrapper paddingSize="none">
+					<div className="block-editor-panel-color-gradient-settings__dropdown-content">
+						<ColorGradientControl
+							label={ settings[ 0 ].label }
+							colorValue={ settings[ 0 ].value }
+							onColorChange={ settings[ 0 ].onChange }
+						/>
+					</div>
 				</DropdownContentWrapper>
 			);
 		}
-		// 2+ settings: tabbed UI matching the standard "Button" row.
+		// 2+ settings: tabbed UI matching the standard "Button" row. The
+		// `block-editor-panel-color-gradient-settings__dropdown-content` wrapper
+		// is required for core CSS to set the picker to width: 260px / padding: 16px.
 		const tabs = settings.map( s => ( {
 			name: s.label.toLowerCase().replace( /\s+/g, '-' ),
 			title: s.label,
 		} ) );
 		return (
 			<DropdownContentWrapper paddingSize="none">
-				<TabPanel tabs={ tabs }>
-					{ tab => {
-						const setting = settings.find(
-							s => s.label.toLowerCase().replace( /\s+/g, '-' ) === tab.name
-						);
-						return (
-							<ColorGradientControl
-								label={ setting.label }
-								colorValue={ setting.value }
-								onColorChange={ setting.onChange }
-								showTitle={ false }
-							/>
-						);
-					} }
-				</TabPanel>
+				<div className="block-editor-panel-color-gradient-settings__dropdown-content">
+					<TabPanel tabs={ tabs }>
+						{ tab => {
+							const setting = settings.find(
+								s => s.label.toLowerCase().replace( /\s+/g, '-' ) === tab.name
+							);
+							return (
+								<ColorGradientControl
+									label={ setting.label }
+									colorValue={ setting.value }
+									onColorChange={ setting.onChange }
+									showTitle={ false }
+								/>
+							);
+						} }
+					</TabPanel>
+				</div>
 			</DropdownContentWrapper>
 		);
 	}, [ settings ] );

--- a/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
@@ -257,8 +257,11 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 		set.selectedAmountTextColor();
 	}, [ set ] );
 
-	const resetTabSettings = useCallback( () => {
+	const resetTabAppearance = useCallback( () => {
 		set.tabsAppearance( 'tabs' );
+	}, [ set ] );
+
+	const resetTabDimensions = useCallback( () => {
 		set.tabFontSize();
 		set.tabPadding();
 	}, [ set ] );
@@ -318,40 +321,8 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 				className="jp-donations-style-panel"
 			>
 				<ToolsPanel
-					className="color-block-support-panel"
-					label={ __( 'Tab colors', 'jetpack' ) }
-					resetAll={ resetTabColors }
-					hasInnerWrapper
-					headingLevel={ 3 }
-					__experimentalFirstVisibleItemClass="first"
-					__experimentalLastVisibleItemClass="last"
-				>
-					<div className="color-block-support-panel__inner-wrapper">
-						<CompoundColorRow
-							label={ __( 'Active tab', 'jetpack' ) }
-							settings={ activeTabSettings }
-						/>
-						<CompoundColorRow
-							label={ __( 'Inactive tab', 'jetpack' ) }
-							settings={ inactiveTabSettings }
-						/>
-						<CompoundColorRow
-							label={ __( 'Tab border', 'jetpack' ) }
-							settings={ tabBorderSettings }
-						/>
-					</div>
-				</ToolsPanel>
-				<ContrastChecker
-					backgroundColor={ activeTabBackgroundColor }
-					textColor={ activeTabTextColor }
-				/>
-				<ContrastChecker
-					backgroundColor={ inactiveTabBackgroundColor }
-					textColor={ inactiveTabTextColor }
-				/>
-				<ToolsPanel
-					label={ __( 'Tab settings', 'jetpack' ) }
-					resetAll={ resetTabSettings }
+					label={ __( 'Tab appearance', 'jetpack' ) }
+					resetAll={ resetTabAppearance }
 					headingLevel={ 3 }
 					__experimentalFirstVisibleItemClass="first"
 					__experimentalLastVisibleItemClass="last"
@@ -374,6 +345,46 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 							<ToggleGroupControlOption value="buttons" label={ __( 'Buttons', 'jetpack' ) } />
 						</ToggleGroupControl>
 					</ToolsPanelItem>
+				</ToolsPanel>
+				<ToolsPanel
+					className="color-block-support-panel"
+					label={ __( 'Tab colors', 'jetpack' ) }
+					resetAll={ resetTabColors }
+					hasInnerWrapper
+					headingLevel={ 3 }
+					__experimentalFirstVisibleItemClass="first"
+					__experimentalLastVisibleItemClass="last"
+				>
+					<div className="color-block-support-panel__inner-wrapper">
+						<CompoundColorRow
+							label={ __( 'Active Tab', 'jetpack' ) }
+							settings={ activeTabSettings }
+						/>
+						<CompoundColorRow
+							label={ __( 'Inactive Tab', 'jetpack' ) }
+							settings={ inactiveTabSettings }
+						/>
+						<CompoundColorRow
+							label={ __( 'Tab Border', 'jetpack' ) }
+							settings={ tabBorderSettings }
+						/>
+					</div>
+				</ToolsPanel>
+				<ContrastChecker
+					backgroundColor={ activeTabBackgroundColor }
+					textColor={ activeTabTextColor }
+				/>
+				<ContrastChecker
+					backgroundColor={ inactiveTabBackgroundColor }
+					textColor={ inactiveTabTextColor }
+				/>
+				<ToolsPanel
+					label={ __( 'Tab dimensions', 'jetpack' ) }
+					resetAll={ resetTabDimensions }
+					headingLevel={ 3 }
+					__experimentalFirstVisibleItemClass="first"
+					__experimentalLastVisibleItemClass="last"
+				>
 					<ToolsPanelItem
 						label={ __( 'Font size', 'jetpack' ) }
 						hasValue={ has.tabFontSize }
@@ -418,7 +429,7 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 				>
 					<div className="color-block-support-panel__inner-wrapper">
 						<CompoundColorRow
-							label={ __( 'Selected amount', 'jetpack' ) }
+							label={ __( 'Selected Amount', 'jetpack' ) }
 							settings={ selectedAmountSettings }
 						/>
 					</div>

--- a/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
@@ -1,4 +1,4 @@
-import { InspectorControls, PanelColorSettings } from '@wordpress/block-editor';
+import { ContrastChecker, InspectorControls, PanelColorSettings } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
 const StyleControls = ( { attributes, setAttributes } ) => {
@@ -38,7 +38,16 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 						label: __( 'Inactive tab text', 'jetpack' ),
 					},
 				] }
-			/>
+			>
+				<ContrastChecker
+					backgroundColor={ activeTabBackgroundColor }
+					textColor={ activeTabTextColor }
+				/>
+				<ContrastChecker
+					backgroundColor={ inactiveTabBackgroundColor }
+					textColor={ inactiveTabTextColor }
+				/>
+			</PanelColorSettings>
 			<PanelColorSettings
 				title={ __( 'Selected amount', 'jetpack' ) }
 				initialOpen={ false }
@@ -54,7 +63,12 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 						label: __( 'Text', 'jetpack' ),
 					},
 				] }
-			/>
+			>
+				<ContrastChecker
+					backgroundColor={ selectedAmountBackgroundColor }
+					textColor={ selectedAmountTextColor }
+				/>
+			</PanelColorSettings>
 		</InspectorControls>
 	);
 };

--- a/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
@@ -14,6 +14,7 @@ import {
 	Flex,
 	FlexItem,
 	PanelBody,
+	TabPanel,
 	__experimentalDropdownContentWrapper as DropdownContentWrapper, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControl as ToggleGroupControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
@@ -78,21 +79,43 @@ const CompoundColorRow = ( { label, settings } ) => {
 		[ label, settings ]
 	);
 
-	const renderContent = useCallback(
-		() => (
-			<DropdownContentWrapper paddingSize="medium">
-				{ settings.map( ( s, i ) => (
+	const renderContent = useCallback( () => {
+		if ( settings.length === 1 ) {
+			return (
+				<DropdownContentWrapper paddingSize="medium">
 					<ColorGradientControl
-						key={ i }
-						label={ s.label }
-						colorValue={ s.value }
-						onColorChange={ s.onChange }
+						label={ settings[ 0 ].label }
+						colorValue={ settings[ 0 ].value }
+						onColorChange={ settings[ 0 ].onChange }
 					/>
-				) ) }
+				</DropdownContentWrapper>
+			);
+		}
+		// 2+ settings: tabbed UI matching the standard "Button" row.
+		const tabs = settings.map( s => ( {
+			name: s.label.toLowerCase().replace( /\s+/g, '-' ),
+			title: s.label,
+		} ) );
+		return (
+			<DropdownContentWrapper paddingSize="none">
+				<TabPanel tabs={ tabs }>
+					{ tab => {
+						const setting = settings.find(
+							s => s.label.toLowerCase().replace( /\s+/g, '-' ) === tab.name
+						);
+						return (
+							<ColorGradientControl
+								label={ setting.label }
+								colorValue={ setting.value }
+								onColorChange={ setting.onChange }
+								showTitle={ false }
+							/>
+						);
+					} }
+				</TabPanel>
 			</DropdownContentWrapper>
-		),
-		[ settings ]
-	);
+		);
+	}, [ settings ] );
 
 	return (
 		<ToolsPanelItem

--- a/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/style-controls.js
@@ -4,7 +4,6 @@ import {
 	InspectorControls,
 	PanelColorSettings,
 	__experimentalBorderRadiusControl as BorderRadiusControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-	__experimentalColorGradientControl as ColorGradientControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/block-editor';
 import {
 	BorderBoxControl,
@@ -98,6 +97,22 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 		]
 	);
 
+	const amountColorSettings = useMemo(
+		() => [
+			{
+				label: __( 'Selected amount background', 'jetpack' ),
+				value: selectedAmountBackgroundColor,
+				onChange: set.selectedAmountBackgroundColor,
+			},
+			{
+				label: __( 'Selected amount text', 'jetpack' ),
+				value: selectedAmountTextColor,
+				onChange: set.selectedAmountTextColor,
+			},
+		],
+		[ selectedAmountBackgroundColor, selectedAmountTextColor, set ]
+	);
+
 	return (
 		<InspectorControls group="styles">
 			<PanelBody title={ __( 'Tabs', 'jetpack' ) } initialOpen={ false }>
@@ -136,20 +151,12 @@ const StyleControls = ( { attributes, setAttributes } ) => {
 				/>
 			</PanelBody>
 			<PanelBody title={ __( 'Amounts', 'jetpack' ) } initialOpen={ false }>
-				<ColorGradientControl
-					label={ __( 'Selected amount background', 'jetpack' ) }
-					colorValue={ selectedAmountBackgroundColor }
-					onColorChange={ set.selectedAmountBackgroundColor }
-				/>
-				<ColorGradientControl
-					label={ __( 'Selected amount text', 'jetpack' ) }
-					colorValue={ selectedAmountTextColor }
-					onColorChange={ set.selectedAmountTextColor }
-				/>
-				<ContrastChecker
-					backgroundColor={ selectedAmountBackgroundColor }
-					textColor={ selectedAmountTextColor }
-				/>
+				<PanelColorSettings showTitle={ false } colorSettings={ amountColorSettings }>
+					<ContrastChecker
+						backgroundColor={ selectedAmountBackgroundColor }
+						textColor={ selectedAmountTextColor }
+					/>
+				</PanelColorSettings>
 				<FontSizePicker
 					value={ amountFontSize }
 					onChange={ set.amountFontSize }

--- a/projects/plugins/jetpack/extensions/blocks/donations/tab.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/tab.js
@@ -6,9 +6,6 @@ import {
 	minimumTransactionAmountForCurrency,
 } from '../../shared/currencies';
 import Amount from './amount';
-import { getDefaultTexts } from './utils';
-
-const DEFAULT_TEXTS = getDefaultTexts();
 
 const Tab = ( { activeTab, attributes, setAttributes } ) => {
 	const {
@@ -17,8 +14,8 @@ const Tab = ( { activeTab, attributes, setAttributes } ) => {
 		monthlyDonation,
 		annualDonation,
 		showCustomAmount,
-		chooseAmountText = DEFAULT_TEXTS.chooseAmountText,
-		customAmountText = DEFAULT_TEXTS.customAmountText,
+		chooseAmountText,
+		customAmountText,
 	} = attributes;
 
 	const donationAttributes = {
@@ -68,7 +65,7 @@ const Tab = ( { activeTab, attributes, setAttributes } ) => {
 			<RichText
 				tagName="h4"
 				placeholder={ __( 'Write a message…', 'jetpack' ) }
-				value={ getDonationValue( 'heading' ) || DEFAULT_TEXTS[ donationAttribute ]?.heading }
+				value={ getDonationValue( 'heading' ) }
 				onChange={ value => setDonationValue( 'heading', value ) }
 			/>
 			<RichText
@@ -114,16 +111,14 @@ const Tab = ( { activeTab, attributes, setAttributes } ) => {
 			<RichText
 				tagName="p"
 				placeholder={ __( 'Write a message…', 'jetpack' ) }
-				value={ getDonationValue( 'extraText' ) ?? DEFAULT_TEXTS.extraText }
+				value={ getDonationValue( 'extraText' ) }
 				onChange={ value => setDonationValue( 'extraText', value ) }
 			/>
 			<div className="wp-block-button donations__donate-button-wrapper">
 				<RichText
 					className="wp-block-button__link wp-element-button donations__donate-button"
 					placeholder={ __( 'Write a message…', 'jetpack' ) }
-					value={
-						getDonationValue( 'buttonText' ) || DEFAULT_TEXTS[ donationAttribute ]?.buttonText
-					}
+					value={ getDonationValue( 'buttonText' ) }
 					onChange={ value => setButtonText( value ) }
 					allowedFormats={ allowedFormatsForButton }
 				/>

--- a/projects/plugins/jetpack/extensions/blocks/donations/tab.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/tab.js
@@ -6,6 +6,9 @@ import {
 	minimumTransactionAmountForCurrency,
 } from '../../shared/currencies';
 import Amount from './amount';
+import { getDefaultTexts } from './utils';
+
+const DEFAULT_TEXTS = getDefaultTexts();
 
 const Tab = ( { activeTab, attributes, setAttributes } ) => {
 	const {
@@ -14,8 +17,10 @@ const Tab = ( { activeTab, attributes, setAttributes } ) => {
 		monthlyDonation,
 		annualDonation,
 		showCustomAmount,
-		chooseAmountText,
-		customAmountText,
+		// Destructure defaults are only applied when the property is `undefined`.
+		// User-cleared empty strings are left as-is, so they render empty.
+		chooseAmountText = DEFAULT_TEXTS.chooseAmountText,
+		customAmountText = DEFAULT_TEXTS.customAmountText,
 	} = attributes;
 
 	const donationAttributes = {
@@ -65,7 +70,7 @@ const Tab = ( { activeTab, attributes, setAttributes } ) => {
 			<RichText
 				tagName="h4"
 				placeholder={ __( 'Write a message…', 'jetpack' ) }
-				value={ getDonationValue( 'heading' ) }
+				value={ getDonationValue( 'heading' ) ?? DEFAULT_TEXTS[ donationAttribute ]?.heading }
 				onChange={ value => setDonationValue( 'heading', value ) }
 			/>
 			<RichText
@@ -111,14 +116,16 @@ const Tab = ( { activeTab, attributes, setAttributes } ) => {
 			<RichText
 				tagName="p"
 				placeholder={ __( 'Write a message…', 'jetpack' ) }
-				value={ getDonationValue( 'extraText' ) }
+				value={ getDonationValue( 'extraText' ) ?? DEFAULT_TEXTS.extraText }
 				onChange={ value => setDonationValue( 'extraText', value ) }
 			/>
 			<div className="wp-block-button donations__donate-button-wrapper">
 				<RichText
 					className="wp-block-button__link wp-element-button donations__donate-button"
 					placeholder={ __( 'Write a message…', 'jetpack' ) }
-					value={ getDonationValue( 'buttonText' ) }
+					value={
+						getDonationValue( 'buttonText' ) ?? DEFAULT_TEXTS[ donationAttribute ]?.buttonText
+					}
 					onChange={ value => setButtonText( value ) }
 					allowedFormats={ allowedFormatsForButton }
 				/>

--- a/projects/plugins/jetpack/extensions/blocks/donations/tab.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/tab.js
@@ -17,6 +17,7 @@ const Tab = ( { activeTab, attributes, setAttributes } ) => {
 		monthlyDonation,
 		annualDonation,
 		showCustomAmount,
+		customAmountPlaceholder,
 		// Destructure defaults are only applied when the property is `undefined`.
 		// User-cleared empty strings are left as-is, so they render empty.
 		chooseAmountText = DEFAULT_TEXTS.chooseAmountText,
@@ -106,7 +107,9 @@ const Tab = ( { activeTab, attributes, setAttributes } ) => {
 					<Amount
 						currency={ currency }
 						label={ __( 'Custom amount', 'jetpack' ) }
-						defaultValue={ minimumTransactionAmountForCurrency( currency ) * 100 }
+						defaultValue={
+							customAmountPlaceholder ?? minimumTransactionAmountForCurrency( currency ) * 100
+						}
 						className="donations__custom-amount"
 						disabled={ true }
 					/>

--- a/projects/plugins/jetpack/extensions/blocks/donations/tab.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/tab.js
@@ -119,7 +119,7 @@ const Tab = ( { activeTab, attributes, setAttributes } ) => {
 			/>
 			<div className="wp-block-button donations__donate-button-wrapper">
 				<RichText
-					className="wp-block-button__link donations__donate-button"
+					className="wp-block-button__link wp-element-button donations__donate-button"
 					placeholder={ __( 'Write a message…', 'jetpack' ) }
 					value={
 						getDonationValue( 'buttonText' ) || DEFAULT_TEXTS[ donationAttribute ]?.buttonText

--- a/projects/plugins/jetpack/extensions/blocks/donations/tabs.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/tabs.js
@@ -3,20 +3,19 @@ import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import Controls from './controls';
 import Tab from './tab';
-
-const firstShownInterval = ( oneTimeShown, monthlyShown, annualShown ) => {
-	if ( oneTimeShown ) return 'one-time';
-	if ( monthlyShown ) return '1 month';
-	if ( annualShown ) return '1 year';
-	return null;
-};
+import { firstShownInterval } from './utils';
 
 const Tabs = props => {
 	const { attributes, products, setAttributes } = props;
-	const { oneTimeDonation, monthlyDonation, annualDonation } = attributes;
+	const { oneTimeDonation, monthlyDonation, annualDonation, defaultInterval } = attributes;
 	const oneTimeShown = oneTimeDonation.show !== false;
-	const initialActiveTab =
+	const fallbackInterval =
 		firstShownInterval( oneTimeShown, monthlyDonation.show, annualDonation.show ) ?? 'one-time';
+	const isDefaultShown =
+		( defaultInterval === 'one-time' && oneTimeShown ) ||
+		( defaultInterval === '1 month' && monthlyDonation.show ) ||
+		( defaultInterval === '1 year' && annualDonation.show );
+	const initialActiveTab = isDefaultShown ? defaultInterval : fallbackInterval;
 	const [ activeTab, setActiveTab ] = useState( initialActiveTab );
 
 	const isTabActive = useCallback( tab => activeTab === tab, [ activeTab ] );

--- a/projects/plugins/jetpack/extensions/blocks/donations/tabs.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/tabs.js
@@ -4,15 +4,25 @@ import clsx from 'clsx';
 import Controls from './controls';
 import Tab from './tab';
 
+const firstShownInterval = ( oneTimeShown, monthlyShown, annualShown ) => {
+	if ( oneTimeShown ) return 'one-time';
+	if ( monthlyShown ) return '1 month';
+	if ( annualShown ) return '1 year';
+	return null;
+};
+
 const Tabs = props => {
 	const { attributes, products, setAttributes } = props;
 	const { oneTimeDonation, monthlyDonation, annualDonation } = attributes;
-	const [ activeTab, setActiveTab ] = useState( 'one-time' );
+	const oneTimeShown = oneTimeDonation.show !== false;
+	const initialActiveTab =
+		firstShownInterval( oneTimeShown, monthlyDonation.show, annualDonation.show ) ?? 'one-time';
+	const [ activeTab, setActiveTab ] = useState( initialActiveTab );
 
 	const isTabActive = useCallback( tab => activeTab === tab, [ activeTab ] );
 
 	const tabs = {
-		'one-time': { title: __( 'One-Time', 'jetpack' ) },
+		...( oneTimeShown && { 'one-time': { title: __( 'One-Time', 'jetpack' ) } } ),
 		...( monthlyDonation.show && { '1 month': { title: __( 'Monthly', 'jetpack' ) } } ),
 		...( annualDonation.show && { '1 year': { title: __( 'Yearly', 'jetpack' ) } } ),
 	};
@@ -40,16 +50,23 @@ const Tabs = props => {
 		} );
 	}, [ oneTimeDonation, monthlyDonation, annualDonation, setAttributes, products ] );
 
-	// Activates the one-time tab if the interval of the current active tab is disabled.
+	// If the current active tab's interval is hidden, fall back to the first
+	// still-shown interval. Tries one-time first, then monthly, then yearly.
 	useEffect( () => {
+		const fallback = firstShownInterval( oneTimeShown, monthlyDonation.show, annualDonation.show );
+		if ( fallback === null ) {
+			return;
+		}
+		if ( ! oneTimeShown && isTabActive( 'one-time' ) ) {
+			setActiveTab( fallback );
+		}
 		if ( ! monthlyDonation.show && isTabActive( '1 month' ) ) {
-			setActiveTab( 'one-time' );
+			setActiveTab( fallback );
 		}
-
 		if ( ! annualDonation.show && isTabActive( '1 year' ) ) {
-			setActiveTab( 'one-time' );
+			setActiveTab( fallback );
 		}
-	}, [ monthlyDonation, annualDonation, setActiveTab, isTabActive ] );
+	}, [ oneTimeShown, monthlyDonation, annualDonation, setActiveTab, isTabActive ] );
 
 	return (
 		<>

--- a/projects/plugins/jetpack/extensions/blocks/donations/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/utils.js
@@ -1,4 +1,19 @@
 /**
+ * Returns the first interval shown in the form, in priority order: one-time, monthly, annual.
+ *
+ * @param {boolean} oneTimeShown - Whether the one-time interval is shown.
+ * @param {boolean} monthlyShown - Whether the monthly interval is shown.
+ * @param {boolean} annualShown  - Whether the annual interval is shown.
+ * @return {?string} The first interval shown, or null if none are shown.
+ */
+export function firstShownInterval( oneTimeShown, monthlyShown, annualShown ) {
+	if ( oneTimeShown ) return 'one-time';
+	if ( monthlyShown ) return '1 month';
+	if ( annualShown ) return '1 year';
+	return null;
+}
+
+/**
  * Return the default texts defined in `donations.php` and injected client side by assigning them
  * to the `Jetpack_DonationsBlock` attribute of the window object.
  *

--- a/projects/plugins/jetpack/extensions/blocks/donations/view.js
+++ b/projects/plugins/jetpack/extensions/blocks/donations/view.js
@@ -6,20 +6,51 @@ import { initializeMembershipButtons } from '../../shared/memberships';
 
 import './view.scss';
 
+const INTERVAL_TO_AMOUNT_CLASS = {
+	'one-time': 'donations__one-time-item',
+	'1 month': 'donations__monthly-item',
+	'1 year': 'donations__annual-item',
+};
+
 class JetpackDonations {
 	constructor( block ) {
 		this.block = block;
 		this.amount = null;
 		this.isCustomAmount = false;
-		this.interval = 'one-time';
+		this.interval = block.dataset.defaultInterval || 'one-time';
 
 		// Initialize block.
 		this.initNavigation();
 		this.handleCustomAmount();
 		this.handleChosenAmount();
+		this.applyDefaultAmount( this.interval );
 
 		// Remove loading spinner.
 		this.block.querySelector( '.donations__container' ).classList.add( 'loaded' );
+	}
+
+	applyDefaultAmount( interval ) {
+		const amountClass = INTERVAL_TO_AMOUNT_CLASS[ interval ];
+		if ( ! amountClass ) {
+			return;
+		}
+		const wrapper = this.block.querySelector( `.donations__amounts.${ amountClass }` );
+		if ( ! wrapper || wrapper.dataset.defaultIndex === undefined ) {
+			return;
+		}
+		const index = parseInt( wrapper.dataset.defaultIndex, 10 );
+		const tile = wrapper.querySelectorAll( '.donations__amount:not( .donations__custom-amount )' )[
+			index
+		];
+		if ( ! tile ) {
+			return;
+		}
+		this.resetSelectedAmount();
+		tile.classList.add( 'is-selected' );
+		this.amount = tile.dataset.amount;
+		this.isCustomAmount = false;
+		this.updateUrl();
+		this.toggleDonateButton( true );
 	}
 
 	getNavItem( interval ) {
@@ -130,6 +161,9 @@ class JetpackDonations {
 
 			// Disable donate button.
 			this.toggleDonateButton( false );
+
+			// Apply the new tab's default amount, if one is configured.
+			this.applyDefaultAmount( newInterval );
 		};
 
 		navItems.forEach( navItem => {

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/Donations_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/Donations_Test.php
@@ -252,6 +252,18 @@ class Donations_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Tab border color applies to both the nav (default-style divider line) and
+	 * the nav items (default-style per-tab dividers and buttons-style pill borders).
+	 */
+	public function test_build_custom_styles_emits_tab_border_color() {
+		$css = Donations\build_custom_styles( array( 'tabBorderColor' => '#abc' ), '.jp-donations-1' );
+		$this->assertStringContainsString(
+			'.jp-donations-1 .donations__nav,.jp-donations-1 .donations__nav-item{border-color:#abc}',
+			$css
+		);
+	}
+
+	/**
 	 * Unknown alignment values are dropped.
 	 */
 	public function test_build_custom_styles_drops_unknown_alignment() {

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/Donations_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/Donations_Test.php
@@ -151,4 +151,80 @@ class Donations_Test extends \WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'padding-left', $css );
 		$this->assertStringNotContainsString( 'padding-right', $css );
 	}
+
+	/**
+	 * Build_custom_styles emits font-size and padding for the donate button.
+	 */
+	public function test_build_custom_styles_emits_button_dimensions() {
+		$attr = array(
+			'buttonFontSize' => '20px',
+			'buttonPadding'  => array(
+				'top'    => '10px',
+				'right'  => '24px',
+				'bottom' => '10px',
+				'left'   => '24px',
+			),
+		);
+
+		$css = Donations\build_custom_styles( $attr, '.jp-donations-1' );
+
+		$this->assertStringContainsString(
+			'.jp-donations-1 .donations__donate-button{font-size:20px;padding-top:10px;padding-right:24px;padding-bottom:10px;padding-left:24px}',
+			$css
+		);
+	}
+
+	/**
+	 * Build_custom_styles emits text-align rule for left/center/right alignment.
+	 *
+	 * @dataProvider button_alignment_provider
+	 *
+	 * @param string $alignment Alignment value.
+	 */
+	#[DataProvider( 'button_alignment_provider' )]
+	public function test_build_custom_styles_emits_text_align( $alignment ) {
+		$attr = array( 'buttonAlignment' => $alignment );
+		$css  = Donations\build_custom_styles( $attr, '.jp-donations-1' );
+		$this->assertStringContainsString(
+			'.jp-donations-1 .donations__donate-button-wrapper{text-align:' . $alignment . '}',
+			$css
+		);
+	}
+
+	/**
+	 * Alignment values that map to a text-align rule.
+	 *
+	 * @return array
+	 */
+	public static function button_alignment_provider() {
+		return array(
+			'left'   => array( 'left' ),
+			'center' => array( 'center' ),
+			'right'  => array( 'right' ),
+		);
+	}
+
+	/**
+	 * Full-width alignment emits block-level width 100% rules instead of text-align.
+	 */
+	public function test_build_custom_styles_emits_full_width() {
+		$css = Donations\build_custom_styles( array( 'buttonAlignment' => 'full' ), '.jp-donations-1' );
+		$this->assertStringContainsString(
+			'.jp-donations-1 .donations__donate-button-wrapper{display:block;width:100%}',
+			$css
+		);
+		$this->assertStringContainsString(
+			'.jp-donations-1 .donations__donate-button{display:block;width:100%;box-sizing:border-box}',
+			$css
+		);
+		$this->assertStringNotContainsString( 'text-align', $css );
+	}
+
+	/**
+	 * Unknown alignment values are dropped.
+	 */
+	public function test_build_custom_styles_drops_unknown_alignment() {
+		$css = Donations\build_custom_styles( array( 'buttonAlignment' => 'wat' ), '.jp-donations-1' );
+		$this->assertStringNotContainsString( 'donate-button-wrapper', $css );
+	}
 }

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/Donations_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/Donations_Test.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Donations Block tests.
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\Extensions\Donations;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+require_once JETPACK__PLUGIN_DIR . '/extensions/blocks/donations/donations.php';
+
+/**
+ * Donations block tests.
+ *
+ * @covers ::Automattic\Jetpack\Extensions\Donations\build_custom_styles
+ * @covers ::Automattic\Jetpack\Extensions\Donations\sanitize_color_for_css
+ */
+#[CoversFunction( 'Automattic\\Jetpack\\Extensions\\Donations\\sanitize_color_for_css' )]
+#[CoversFunction( 'Automattic\\Jetpack\\Extensions\\Donations\\build_custom_styles' )]
+class Donations_Test extends \WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Sanitizer accepts safe color values and rejects unsafe ones.
+	 *
+	 * @dataProvider sanitize_color_for_css_provider
+	 *
+	 * @param mixed  $input    Raw value passed to the sanitizer.
+	 * @param string $expected Expected sanitized return value.
+	 */
+	#[DataProvider( 'sanitize_color_for_css_provider' )]
+	public function test_sanitize_color_for_css( $input, $expected ) {
+		$this->assertSame( $expected, Donations\sanitize_color_for_css( $input ) );
+	}
+
+	/**
+	 * Inputs and expected outputs for sanitize_color_for_css.
+	 *
+	 * @return array
+	 */
+	public static function sanitize_color_for_css_provider() {
+		return array(
+			'hex short'       => array( '#fff', '#fff' ),
+			'hex long'        => array( '#ff0000', '#ff0000' ),
+			'rgb'             => array( 'rgb(255, 0, 0)', 'rgb(255, 0, 0)' ),
+			'rgba'            => array( 'rgba(0, 0, 0, 0.5)', 'rgba(0, 0, 0, 0.5)' ),
+			'hsl'             => array( 'hsl(120, 50%, 50%)', 'hsl(120, 50%, 50%)' ),
+			'named color'     => array( 'transparent', 'transparent' ),
+			'css variable'    => array( 'var(--wp--preset--color--primary)', 'var(--wp--preset--color--primary)' ),
+			'leading spaces'  => array( '   #abc   ', '#abc' ),
+			'empty string'    => array( '', '' ),
+			'whitespace only' => array( '   ', '' ),
+			'null'            => array( null, '' ),
+			'integer'         => array( 42, '' ),
+			'array'           => array( array( '#fff' ), '' ),
+			'angle bracket'   => array( '<script', '' ),
+			'closing brace'   => array( 'red}body{display:none', '' ),
+			'semicolon'       => array( 'red;color:blue', '' ),
+			'single quote'    => array( "red'", '' ),
+			'double quote'    => array( 'red"', '' ),
+			'backslash'       => array( 'red\\', '' ),
+			'too long'        => array( str_repeat( 'a', 101 ), '' ),
+			'exactly 100'     => array( str_repeat( 'a', 100 ), str_repeat( 'a', 100 ) ),
+		);
+	}
+
+	/**
+	 * Build_custom_styles returns an empty string when no per-state colors are set.
+	 */
+	public function test_build_custom_styles_returns_empty_when_no_overrides() {
+		$this->assertSame( '', Donations\build_custom_styles( array(), '.jp-donations-1' ) );
+	}
+
+	/**
+	 * Build_custom_styles produces scoped CSS rules covering each set color.
+	 */
+	public function test_build_custom_styles_emits_rules_for_each_set_color() {
+		$attr = array(
+			'activeTabBackgroundColor'      => '#000',
+			'activeTabTextColor'            => '#fff',
+			'inactiveTabBackgroundColor'    => '#eee',
+			'inactiveTabTextColor'          => '#333',
+			'selectedAmountBackgroundColor' => 'red',
+			'selectedAmountTextColor'       => 'white',
+		);
+
+		$css = Donations\build_custom_styles( $attr, '.jp-donations-1' );
+
+		$this->assertStringContainsString( '.jp-donations-1 .donations__nav-item.is-active{background:#000;color:#fff}', $css );
+		$this->assertStringContainsString( '.jp-donations-1 .donations__nav-item:not(.is-active){background:#eee;color:#333}', $css );
+		$this->assertStringContainsString( '.jp-donations-1 .donations__amount.is-selected{background-color:red;color:white}', $css );
+	}
+
+	/**
+	 * Unsafe values for per-state colors are dropped, not rendered as CSS.
+	 */
+	public function test_build_custom_styles_drops_unsafe_values() {
+		$attr = array(
+			'activeTabBackgroundColor' => 'red;background:url(javascript:alert(1))',
+			'activeTabTextColor'       => '#fff',
+		);
+
+		$css = Donations\build_custom_styles( $attr, '.jp-donations-1' );
+
+		// The unsafe background was rejected, but the safe text color still appears.
+		$this->assertStringNotContainsString( 'javascript', $css );
+		$this->assertStringNotContainsString( 'background:red', $css );
+		$this->assertStringContainsString( 'color:#fff', $css );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/Donations_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/Donations_Test.php
@@ -222,10 +222,11 @@ class Donations_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Buttons-style nav inherits user-set tab padding-top/bottom so the row scales
-	 * with the pill interior padding.
+	 * User-set tab padding only affects the pill interior; it must not also push
+	 * the buttons-style nav container's vertical padding (which controls the
+	 * space between the form border and the top of the pill row).
 	 */
-	public function test_build_custom_styles_buttons_nav_mirrors_tab_padding() {
+	public function test_build_custom_styles_tab_padding_does_not_touch_buttons_nav() {
 		$attr = array(
 			'tabPadding' => array(
 				'top'    => '8px',
@@ -238,16 +239,9 @@ class Donations_Test extends \WP_UnitTestCase {
 		$css = Donations\build_custom_styles( $attr, '.jp-donations-1' );
 
 		$this->assertStringContainsString(
-			'.jp-donations-1.is-style-buttons .donations__nav{padding-top:8px;padding-bottom:8px}',
+			'.jp-donations-1 .donations__nav-item{padding-top:8px;padding-right:20px;padding-bottom:8px;padding-left:20px}',
 			$css
 		);
-	}
-
-	/**
-	 * Without a top or bottom user value, no buttons-style nav rule is emitted.
-	 */
-	public function test_build_custom_styles_no_buttons_nav_rule_without_user_padding() {
-		$css = Donations\build_custom_styles( array(), '.jp-donations-1' );
 		$this->assertStringNotContainsString( 'is-style-buttons', $css );
 	}
 

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/Donations_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/Donations_Test.php
@@ -205,7 +205,8 @@ class Donations_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Full-width alignment emits block-level width 100% rules instead of text-align.
+	 * Full-width alignment emits block-level width 100% rules instead of text-align on
+	 * the wrapper, and centers the text inside the now-block-level button.
 	 */
 	public function test_build_custom_styles_emits_full_width() {
 		$css = Donations\build_custom_styles( array( 'buttonAlignment' => 'full' ), '.jp-donations-1' );
@@ -214,10 +215,40 @@ class Donations_Test extends \WP_UnitTestCase {
 			$css
 		);
 		$this->assertStringContainsString(
-			'.jp-donations-1 .donations__donate-button{display:block;width:100%;box-sizing:border-box}',
+			'.jp-donations-1 .donations__donate-button{display:block;width:100%;box-sizing:border-box;text-align:center}',
 			$css
 		);
-		$this->assertStringNotContainsString( 'text-align', $css );
+		$this->assertStringNotContainsString( 'donate-button-wrapper{text-align', $css );
+	}
+
+	/**
+	 * Buttons-style nav inherits user-set tab padding-top/bottom so the row scales
+	 * with the pill interior padding.
+	 */
+	public function test_build_custom_styles_buttons_nav_mirrors_tab_padding() {
+		$attr = array(
+			'tabPadding' => array(
+				'top'    => '8px',
+				'bottom' => '8px',
+				'left'   => '20px',
+				'right'  => '20px',
+			),
+		);
+
+		$css = Donations\build_custom_styles( $attr, '.jp-donations-1' );
+
+		$this->assertStringContainsString(
+			'.jp-donations-1.is-style-buttons .donations__nav{padding-top:8px;padding-bottom:8px}',
+			$css
+		);
+	}
+
+	/**
+	 * Without a top or bottom user value, no buttons-style nav rule is emitted.
+	 */
+	public function test_build_custom_styles_no_buttons_nav_rule_without_user_padding() {
+		$css = Donations\build_custom_styles( array(), '.jp-donations-1' );
+		$this->assertStringNotContainsString( 'is-style-buttons', $css );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/Donations_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/Donations_Test.php
@@ -14,9 +14,9 @@ require_once JETPACK__PLUGIN_DIR . '/extensions/blocks/donations/donations.php';
  * Donations block tests.
  *
  * @covers ::Automattic\Jetpack\Extensions\Donations\build_custom_styles
- * @covers ::Automattic\Jetpack\Extensions\Donations\sanitize_color_for_css
+ * @covers ::Automattic\Jetpack\Extensions\Donations\sanitize_css_value
  */
-#[CoversFunction( 'Automattic\\Jetpack\\Extensions\\Donations\\sanitize_color_for_css' )]
+#[CoversFunction( 'Automattic\\Jetpack\\Extensions\\Donations\\sanitize_css_value' )]
 #[CoversFunction( 'Automattic\\Jetpack\\Extensions\\Donations\\build_custom_styles' )]
 class Donations_Test extends \WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
@@ -24,22 +24,22 @@ class Donations_Test extends \WP_UnitTestCase {
 	/**
 	 * Sanitizer accepts safe color values and rejects unsafe ones.
 	 *
-	 * @dataProvider sanitize_color_for_css_provider
+	 * @dataProvider sanitize_css_value_provider
 	 *
 	 * @param mixed  $input    Raw value passed to the sanitizer.
 	 * @param string $expected Expected sanitized return value.
 	 */
-	#[DataProvider( 'sanitize_color_for_css_provider' )]
-	public function test_sanitize_color_for_css( $input, $expected ) {
-		$this->assertSame( $expected, Donations\sanitize_color_for_css( $input ) );
+	#[DataProvider( 'sanitize_css_value_provider' )]
+	public function test_sanitize_css_value( $input, $expected ) {
+		$this->assertSame( $expected, Donations\sanitize_css_value( $input ) );
 	}
 
 	/**
-	 * Inputs and expected outputs for sanitize_color_for_css.
+	 * Inputs and expected outputs for sanitize_css_value.
 	 *
 	 * @return array
 	 */
-	public static function sanitize_color_for_css_provider() {
+	public static function sanitize_css_value_provider() {
 		return array(
 			'hex short'       => array( '#fff', '#fff' ),
 			'hex long'        => array( '#ff0000', '#ff0000' ),
@@ -107,5 +107,48 @@ class Donations_Test extends \WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'javascript', $css );
 		$this->assertStringNotContainsString( 'background:red', $css );
 		$this->assertStringContainsString( 'color:#fff', $css );
+	}
+
+	/**
+	 * Build_custom_styles emits font-size and per-side padding for tabs.
+	 */
+	public function test_build_custom_styles_emits_tab_dimensions() {
+		$attr = array(
+			'tabFontSize' => '18px',
+			'tabPadding'  => array(
+				'top'    => '12px',
+				'right'  => '20px',
+				'bottom' => '12px',
+				'left'   => '20px',
+			),
+		);
+
+		$css = Donations\build_custom_styles( $attr, '.jp-donations-1' );
+
+		$this->assertStringContainsString(
+			'.jp-donations-1 .donations__nav-item{font-size:18px;padding-top:12px;padding-right:20px;padding-bottom:12px;padding-left:20px}',
+			$css
+		);
+	}
+
+	/**
+	 * Partial tab padding emits only the sides the user specified.
+	 */
+	public function test_build_custom_styles_partial_tab_padding() {
+		$attr = array(
+			'tabPadding' => array(
+				'top'    => '8px',
+				'bottom' => '8px',
+			),
+		);
+
+		$css = Donations\build_custom_styles( $attr, '.jp-donations-1' );
+
+		$this->assertStringContainsString(
+			'.jp-donations-1 .donations__nav-item{padding-top:8px;padding-bottom:8px}',
+			$css
+		);
+		$this->assertStringNotContainsString( 'padding-left', $css );
+		$this->assertStringNotContainsString( 'padding-right', $css );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/Donations_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/Donations_Test.php
@@ -324,8 +324,11 @@ class Donations_Test extends \WP_UnitTestCase {
 	 */
 	public function test_build_custom_styles_emits_tab_border_color() {
 		$css = Donations\build_custom_styles( array( 'tabBorderColor' => '#abc' ), '.jp-donations-1' );
+		// The user-set Tab Border color also applies to the active pill in the
+		// Buttons appearance, so the rule's selector list includes
+		// `.donations__nav-item.is-active`.
 		$this->assertStringContainsString(
-			'.jp-donations-1 .donations__nav,.jp-donations-1 .donations__nav-item{border-color:#abc}',
+			'.jp-donations-1 .donations__nav,.jp-donations-1 .donations__nav-item,.jp-donations-1 .donations__nav-item.is-active{border-color:#abc}',
 			$css
 		);
 	}

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/Donations_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/Donations_Test.php
@@ -246,6 +246,79 @@ class Donations_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Amount tile styling with a uniform BorderBoxControl value plus a uniform
+	 * radius emits one combined rule on `.donations__amount`.
+	 */
+	public function test_build_custom_styles_emits_amount_uniform_border() {
+		$attr = array(
+			'amountFontSize'     => '18px',
+			'amountBorder'       => array(
+				'color' => '#abc',
+				'style' => 'solid',
+				'width' => '2px',
+			),
+			'amountBorderRadius' => '8px',
+		);
+
+		$css = Donations\build_custom_styles( $attr, '.jp-donations-1' );
+
+		$this->assertStringContainsString(
+			'.jp-donations-1 .donations__amount{font-size:18px;border-color:#abc;border-style:solid;border-width:2px;border-radius:8px}',
+			$css
+		);
+	}
+
+	/**
+	 * Split (per-side) BorderBoxControl values emit individual side declarations.
+	 */
+	public function test_build_custom_styles_emits_amount_split_border() {
+		$attr = array(
+			'amountBorder' => array(
+				'top'    => array(
+					'color' => '#000',
+					'style' => 'solid',
+					'width' => '2px',
+				),
+				'bottom' => array(
+					'color' => '#fff',
+					'style' => 'dashed',
+					'width' => '1px',
+				),
+			),
+		);
+
+		$css = Donations\build_custom_styles( $attr, '.jp-donations-1' );
+
+		$this->assertStringContainsString( 'border-top-color:#000', $css );
+		$this->assertStringContainsString( 'border-top-style:solid', $css );
+		$this->assertStringContainsString( 'border-top-width:2px', $css );
+		$this->assertStringContainsString( 'border-bottom-color:#fff', $css );
+		$this->assertStringContainsString( 'border-bottom-style:dashed', $css );
+		$this->assertStringContainsString( 'border-bottom-width:1px', $css );
+	}
+
+	/**
+	 * Per-corner radius values emit individual corner declarations.
+	 */
+	public function test_build_custom_styles_emits_amount_per_corner_radius() {
+		$attr = array(
+			'amountBorderRadius' => array(
+				'topLeft'     => '8px',
+				'topRight'    => '8px',
+				'bottomRight' => '0',
+				'bottomLeft'  => '0',
+			),
+		);
+
+		$css = Donations\build_custom_styles( $attr, '.jp-donations-1' );
+
+		$this->assertStringContainsString( 'border-top-left-radius:8px', $css );
+		$this->assertStringContainsString( 'border-top-right-radius:8px', $css );
+		$this->assertStringContainsString( 'border-bottom-right-radius:0', $css );
+		$this->assertStringContainsString( 'border-bottom-left-radius:0', $css );
+	}
+
+	/**
 	 * Tab border color applies to both the nav (default-style divider line) and
 	 * the nav items (default-style per-tab dividers and buttons-style pill borders).
 	 */


### PR DESCRIPTION
**Stacked on top of [#48415](https://github.com/Automattic/jetpack/pull/48415).** Reviews can wait until that lands; this PR can be tested on Jetpack Beta in parallel.

## Proposed changes

Adds admin-configurable frequency visibility controls and donation defaults to the Donations Form block.

**Frequency visibility toggles**
* New "Show one-time donations" toggle in the Settings panel, joining the existing monthly and annual toggles, so authors can hide any combination of intervals.
* Last-enabled guard: the final visible toggle is disabled and shows help text ("At least one frequency must be enabled."), preventing an empty/broken form.
* Auto-shift: hiding the interval that is currently set as the default silently shifts `defaultInterval` to the next visible interval in the same `setAttributes` call — no stale or invisible default can persist.
* **Side-effect bug fix:** previously, hiding One-Time while keeping Monthly broke the frontend — `view.js` was hardcoded to `this.interval = 'one-time'`. The fix reads the initial interval from `data-default-interval` on the wrapper instead.

**Frequency and amount defaults**
* New "Defaults" sub-section in the Settings panel with a **Frequency** selector (filtered to currently-shown intervals) and per-frequency **default amount** selects (None + the three configured dollar values).
* Default amount is stored by index, not value, so it survives admin edits to the amount values (e.g. changing $15 → $20 keeps the same slot pre-selected).
* **Suggested custom amount**: a number input for the placeholder value shown in the custom amount tile; currency-aware minimum enforced.
* On load and on each tab switch, the configured default amount tile is highlighted and the Donate button is pre-enabled. Clears and resets correctly when switching tabs.
* Currency change resets `customAmountPlaceholder` along with the existing per-interval amount reset.

## Related product discussion/links

* Part of the same internal RSM project as [#48415](https://github.com/Automattic/jetpack/pull/48415).

## Does this pull request change what data or activity we track or use?

No tracking or data changes.

## Testing instructions

**Frequency toggles**
1. Add a Donations Form block. In the Settings panel, toggle "Show one-time donations" off.
   * The One-Time tab should disappear in the editor; the active tab should fall back to Monthly (or Yearly if Monthly is also off).
   * Save and view on the frontend — the One-Time tab should be gone.
2. Toggle off Monthly as well — only Annual remains. Confirm all three toggle buttons show the last-enabled help text and are disabled, preventing an empty form.
3. Toggle One-Time back on — the tab reappears and the block is functional again.
4. Open a legacy Donations block (created before this branch, where `oneTimeDonation.show` was never set) — the One-Time toggle should show as on and the block should behave normally.

**Defaults section** [screenshot]
5. Expand the Settings panel and locate the **Defaults** sub-section below the Show/hide toggles.
   * Set **Frequency** to Monthly and **Monthly** default amount to the $15 slot.
   * Save and view on the frontend — the Monthly tab should be active on load, with the $15 tile pre-selected and the Donate button enabled without any user interaction. [demo]
6. Set a suggested custom amount (e.g. 50) — the custom amount tile placeholder on the frontend should reflect this value.
7. Change currency — the suggested custom amount should reset.
8. Hide the frequency that is set as the default — the default should automatically shift to the next visible interval without requiring a separate action.