### PR TITLE
Shortcodes: preserve URL-encoded ampersands in [googlemaps] place names

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-googlemaps-ampersand
+++ b/projects/plugins/jetpack/changelog/fix-googlemaps-ampersand
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Shortcodes: Google Maps shortcode now preserves URL-encoded ampersands (%26) in place names.

--- a/projects/plugins/jetpack/modules/shortcodes/googlemaps.php
+++ b/projects/plugins/jetpack/modules/shortcodes/googlemaps.php
@@ -108,8 +108,9 @@ function jetpack_googlemaps_shortcode( $atts ) {
 			} elseif ( 'h' === $key ) {
 				$height = (int) $value;
 			} else {
-				$key  = str_replace( '_', '.', $key );
-				$url .= esc_attr( "$key=$value&amp;" );
+				$key   = str_replace( '_', '.', $key );
+				$value = str_replace( '&', '%26', $value );
+				$url  .= esc_attr( "$key=$value&amp;" );
 			}
 		}
 		$url = substr( $url, 0, -5 );

--- a/projects/plugins/jetpack/modules/shortcodes/googlemaps.php
+++ b/projects/plugins/jetpack/modules/shortcodes/googlemaps.php
@@ -108,9 +108,12 @@ function jetpack_googlemaps_shortcode( $atts ) {
 			} elseif ( 'h' === $key ) {
 				$height = (int) $value;
 			} else {
-				$key   = str_replace( '_', '.', $key );
+				$key = str_replace( '_', '.', $key );
+
+				// Re-encode literal `&` to `%26`: parse_str() URL-decodes `%26` in values, and a stray `&` would be treated as a query separator downstream.
 				$value = str_replace( '&', '%26', $value );
-				$url  .= esc_attr( "$key=$value&amp;" );
+
+				$url .= esc_attr( "$key=$value&amp;" );
 			}
 		}
 		$url = substr( $url, 0, -5 );

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/Jetpack_Shortcodes_Googlemaps_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/Jetpack_Shortcodes_Googlemaps_Test.php
@@ -84,7 +84,10 @@ class Jetpack_Shortcodes_Googlemaps_Test extends WP_UnitTestCase {
 		$shortcode = '[googlemaps https://maps.google.com/maps?q=The%20Westin%20Doha%20Hotel%20%26%20Spa]';
 		$rendered  = do_shortcode( $shortcode );
 
-		$this->assertStringContainsString( '%26', $rendered );
+		$this->assertStringContainsString(
+			'src="https://maps.google.com/maps?q=The%20Westin%20Doha%20Hotel%20%26%20Spa"',
+			$rendered
+		);
 		$this->assertStringNotContainsString( 'Hotel%20&amp;%20Spa', $rendered );
 		$this->assertStringNotContainsString( 'Hotel & Spa', $rendered );
 	}

--- a/projects/plugins/jetpack/tests/php/modules/shortcodes/Jetpack_Shortcodes_Googlemaps_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/shortcodes/Jetpack_Shortcodes_Googlemaps_Test.php
@@ -73,4 +73,19 @@ class Jetpack_Shortcodes_Googlemaps_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( $expected, $actual );
 	}
+
+	/**
+	 * A URL-encoded ampersand (`%26`) inside a query value — e.g. a place
+	 * name like "Hotel & Spa" — must survive the shortcode round-trip
+	 * intact, otherwise Google's API treats the decoded `&` as a query
+	 * separator and the embed 400s.
+	 */
+	public function test_shortcodes_googlemaps_preserves_encoded_ampersand_in_value() {
+		$shortcode = '[googlemaps https://maps.google.com/maps?q=The%20Westin%20Doha%20Hotel%20%26%20Spa]';
+		$rendered  = do_shortcode( $shortcode );
+
+		$this->assertStringContainsString( '%26', $rendered );
+		$this->assertStringNotContainsString( 'Hotel%20&amp;%20Spa', $rendered );
+		$this->assertStringNotContainsString( 'Hotel & Spa', $rendered );
+	}
 }


### PR DESCRIPTION
## Summary
- Fixes the `[googlemaps]` shortcode mangling place names that contain an ampersand (e.g. "The Westin Doha Hotel & Spa"), which broke embeds on non-plugin-enabled WordPress.com sites. `parse_str()` URL-decodes `%26` to a literal `&`, which `esc_attr()` then turns into `&amp;`. The browser HTML-decodes that back to `&`, and Google's API parses it as a query-parameter separator → 400.
- Fix: after `parse_str()` decodes a value, re-encode any literal `&` to `%26` before concatenating into the URL.
- Related Linear issue: [EDI-229](https://linear.app/a8c/issue/EDI-229)

## Does this pull request change what data or activity we track or use?
- No it does not.

## Testing instructions:
- Added a unit test (`test_shortcodes_googlemaps_preserves_encoded_ampersand_in_value`) asserting the rendered output preserves `%26` in the value and does not contain the broken `&amp;`-corrupted form. Local PHPUnit not run (lacked WP test scaffolding); relying on CI.
- Manual end-to-end test on a wpcom sandbox:
  - Pasted a Google Maps "Embed a map" iframe for "The Westin Doha Hotel & Spa" into a Custom HTML block, published, viewed front-end.
  - Before patch: Google returns 400; iframe `src` shows `…Hotel%20&amp;%20Spa…`.
  - After patch: map renders; iframe `src` shows `…Hotel%20%26%20Spa…`.
  - Regression check with "Best Western Plus Doha" (no special chars): still renders correctly.