### PR TITLE
Plugin Search Hints: Open external link in new window and use WP core colors

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-psh_card_link_and_color
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-psh_card_link_and_color
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Plugin Search Hints: Use Core colors.

--- a/projects/plugins/jetpack/modules/plugin-search.php
+++ b/projects/plugins/jetpack/modules/plugin-search.php
@@ -568,6 +568,7 @@ class Jetpack_Plugin_Search {
 				id="plugin-select-settings"
 				class="jetpack-plugin-search__primary jetpack-plugin-search__get-started button"
 				href="' . esc_url( Redirect::get_url( 'plugin-hint-learn-' . $plugin['module'] ) ) . '"
+				target="_blank"
 				data-module="' . esc_attr( $plugin['module'] ) . '"
 				data-track="get_started"
 				>' . esc_html__( 'Get started', 'jetpack' ) . '</a>';
@@ -605,6 +606,7 @@ class Jetpack_Plugin_Search {
 				id="plugin-select-settings"
 				class="jetpack-plugin-search__primary jetpack-plugin-search__get-started button"
 				href="' . esc_url( Redirect::get_url( 'plugin-hint-learn-' . $plugin['module'] ) ) . '"
+				target="_blank"
 				data-module="' . esc_attr( $plugin['module'] ) . '"
 				data-track="get_started"
 				>' . esc_html__( 'Get started', 'jetpack' ) . '</a>';

--- a/projects/plugins/jetpack/modules/plugin-search/plugin-search.css
+++ b/projects/plugins/jetpack/modules/plugin-search/plugin-search.css
@@ -2,19 +2,6 @@
 	white-space: nowrap;
 }
 
-.plugin-card-jetpack-plugin-search .plugin-action-buttons .jetpack-plugin-search__primary {
-	background: #069e08;
-	border-color: #00a523;
-	color: #fff;
-	box-shadow: 0 1px 0 #c5e2c3;
-}
-
-.plugin-card-jetpack-plugin-search .plugin-action-buttons .jetpack-plugin-search__primary:hover {
-	background: #00a523;
-	border-color: #008b1d;
-	color: #fff;
-}
-
 .plugin-card-jetpack-plugin-search .plugin-card-bottom {
 	display: none;
 }

--- a/projects/plugins/jetpack/modules/plugin-search/plugin-search.js
+++ b/projects/plugins/jetpack/modules/plugin-search/plugin-search.js
@@ -213,21 +213,27 @@ var JetpackPSH = {};
 					}
 				} )
 				.on( 'click', '.jetpack-plugin-search__learn-more', function ( event ) {
-					event.preventDefault();
 					var $this = $( this );
+					var opensInNewTab = '_blank' === $this.attr( 'target' );
+					if ( ! opensInNewTab ) {
+						event.preventDefault();
+					}
 					JetpackPSH.trackEvent(
 						'wpa_plugin_search_learn_more',
 						$this.data( 'module' ),
-						$this.get( 0 )
+						opensInNewTab ? undefined : $this.get( 0 )
 					);
 				} )
 				.on( 'click', '.jetpack-plugin-search__support_link', function ( event ) {
-					event.preventDefault();
 					var $this = $( this );
+					var opensInNewTab = '_blank' === $this.attr( 'target' );
+					if ( ! opensInNewTab ) {
+						event.preventDefault();
+					}
 					JetpackPSH.trackEvent(
 						'wpa_plugin_search_support_link',
 						$this.data( 'module' ),
-						$this.get( 0 )
+						opensInNewTab ? undefined : $this.get( 0 )
 					);
 				} );
 		},

--- a/projects/plugins/jetpack/modules/plugin-search/plugin-search.js
+++ b/projects/plugins/jetpack/modules/plugin-search/plugin-search.js
@@ -197,14 +197,18 @@ var JetpackPSH = {};
 					JetpackPSH.ajaxActivateModule( $( this ).data( 'module' ) );
 				} )
 				.on( 'click', '.jetpack-plugin-search__primary', function ( event ) {
-					event.preventDefault();
 					var $this = $( this );
+					var opensInNewTab = '_blank' === $this.attr( 'target' );
+					if ( ! opensInNewTab ) {
+						event.preventDefault();
+					}
 					if ( $this.data( 'track' ) ) {
 						// This catches Purchase, Configure, and Get started. Feature activation is tracked when it ends successfully, in its callback.
 						JetpackPSH.trackEvent(
 							'wpa_plugin_search_' + $this.data( 'track' ),
 							$this.data( 'module' ),
-							$this.get( 0 )
+							// only redirect if not opening in a new tab
+							opensInNewTab ? undefined : $this.get( 0 )
 						);
 					}
 				} )


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
While watching this video, I learned about Plugin Search Hints, and also noticed two things:

1. External links ("Getting started" and "Learn more about these suggestions.") were opening in the current window, taking people out of their site.
2. Buttons were using the green style instead of WP core colors.

This is a simple PR that addresses both. Note that at some point the links will be changed to point into the plugin (p8oabR-1MO-p2#comment-8954), but in the meantime let's make sure something better makes it into Jetpack 15.8.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

1. Connect Jetpack.
2. Ensure Jetpack VideoPress (the standalone plugin) is not active.
3. Search for "videopress" in the plugin search: `/wp-admin/plugin-install.php?s=videopress&tab=search&type=term`

Before:
* <img width="3422" height="1944" alt="image" src="https://github.com/user-attachments/assets/195871a7-3cd9-4239-acfd-4b543635bc4b" />

After:
* <img width="3406" height="1964" alt="image" src="https://github.com/user-attachments/assets/8f7e49a3-b666-4b46-abc8-4185e7024c81" />
