### PR TITLE
AI page: adopt jetpack-admin-page-layout mixin

### DIFF
--- a/projects/plugins/jetpack/_inc/client/ai/style.scss
+++ b/projects/plugins/jetpack/_inc/client/ai/style.scss
@@ -1,6 +1,5 @@
 @use "@automattic/jetpack-base-styles/admin-page-layout" as *;
 
-// phpcs:ignore -- SCSS selector, not a PHP file
 body.jetpack_page_ai {
 
 	@include jetpack-admin-page-layout;

--- a/projects/plugins/jetpack/_inc/client/ai/style.scss
+++ b/projects/plugins/jetpack/_inc/client/ai/style.scss
@@ -1,14 +1,8 @@
-// phpcs:ignore -- SCSS selector, not a PHP file
-.jetpack_page_ai .admin-ui-page {
-	// Fill the viewport height minus the fixed 32px WP admin bar,
-	// so the footer sits at the bottom of the visible screen area.
-	min-height: calc(100vh - 32px);
+@use "@automattic/jetpack-base-styles/admin-page-layout" as *;
 
-	// The fluid container (2nd direct child, between header and footer) should
-	// grow to fill available space, pushing the footer to the bottom.
-	> div:nth-child(2) {
-		flex: 1;
-	}
+// phpcs:ignore -- SCSS selector, not a PHP file
+body.jetpack_page_ai {
+	@include jetpack-admin-page-layout;
 }
 
 .jetpack-ai-admin {

--- a/projects/plugins/jetpack/_inc/client/ai/style.scss
+++ b/projects/plugins/jetpack/_inc/client/ai/style.scss
@@ -2,6 +2,7 @@
 
 // phpcs:ignore -- SCSS selector, not a PHP file
 body.jetpack_page_ai {
+
 	@include jetpack-admin-page-layout;
 }
 

--- a/projects/plugins/jetpack/changelog/jetpack-ai-page-layout-mixin
+++ b/projects/plugins/jetpack/changelog/jetpack-ai-page-layout-mixin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI page: adopt the shared `jetpack-admin-page-layout` mixin so its layout (sticky header, scrollable middle, pinned JetpackFooter) matches the rest of the Jetpack admin pages that use the AdminPage component.


### PR DESCRIPTION
**Hold for review.** This PR is paired with #48410 (admin-ui 2.0.0 upgrade) — please don't merge until #48410 has landed in trunk and this branch is rebased on top. Both pieces touch the same layout machinery in `@automattic/jetpack-base-styles/admin-page-layout`, and the mixin selectors that this PR relies on (`.jp-admin-page__page > header`) are introduced by #48410.

## Proposed changes

* `_inc/client/ai/style.scss`: replace the bespoke `min-height: calc(100vh - 32px); > div:nth-child(2) { flex: 1 }` rule with `@include jetpack-admin-page-layout` from `@automattic/jetpack-base-styles`.
* AI now joins the existing layout-mixin'd consumer set (Boost, Protect, VideoPress, Search, Newsletter, Publicize, Backup, Jetpack network admin), inheriting the full viewport-fitted flex chain: sticky header → internally scrollable middle → JetpackFooter pinned to the viewport bottom.

The previous bespoke rule was a partial reimplementation of the same intent. The shared mixin handles it more thoroughly (sidebar/admin-bar accommodation, responsive breakpoints, consistent footer pinning).

## Related product discussion/links

* Stacks behind #48410 (admin-ui 2.0.0). Should land after that.

## Does this pull request change what data or activity we track or use?
No

## Testing instructions

1. After admin-ui 2.0.0 lands and this PR is rebased on top, hard-refresh wp-admin (CSS cache).
2. Navigate to `admin.php?page=ai`.
3. Verify the layout matches Boost / Protect / VideoPress style: header pinned at top, content scrolls in the middle if it overflows, and the JetpackFooter (Jetpack | Products | Help — An Automattic Airline) is pinned at the bottom of the viewport, not floating in mid-air or pushed off-screen.

## Screenshots

| Before | After |
|--------|--------|
| <img width="1440" height="900" alt="ai" src="https://github.com/user-attachments/assets/f5f0c2b9-8136-4b44-900f-22a5694ce81b" /> | <img width="1440" height="900" alt="ai-after" src="https://github.com/user-attachments/assets/6d3d365b-9ce8-4528-910d-13e41dfcc725" /> | 




🤖 Generated with [Claude Code](https://claude.com/claude-code)
