### PR TITLE
Hello Dolly: normalize centrally, drop per-page duplicates

### DIFF
--- a/projects/js-packages/components/changelog/normalize-hello-dolly-styling
+++ b/projects/js-packages/components/changelog/normalize-hello-dolly-styling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AdminPage: expand the Hello Dolly normalize rule (was a single `background-color`) to cover the full visual treatment (italic, gray text, white background, right-aligned, hidden under 660px) so individual plugins don't need their own per-page overrides. No position/offsets are set so per-page `position: absolute` overrides (e.g. My Jetpack) keep working.

--- a/projects/js-packages/components/components/admin-page/style.module.scss
+++ b/projects/js-packages/components/components/admin-page/style.module.scss
@@ -91,7 +91,7 @@
 // wrapper's `.jp-admin-page` class. Any Jetpack admin page gets the
 // normalized look for free. Per-page overrides can still layer on top
 // via higher-specificity selectors (see e.g. My Jetpack).
-//
+
 // We deliberately do NOT set `position`/`top`/`left`/`right` here:
 // those would become active on any per-page rule that flips Dolly to
 // `position: absolute` (e.g. My Jetpack), causing it to stretch to its

--- a/projects/js-packages/components/components/admin-page/style.module.scss
+++ b/projects/js-packages/components/components/admin-page/style.module.scss
@@ -100,13 +100,14 @@
 // `float: right`; pages that need different positioning add their own
 // position rule on top.
 :global(.jetpack-admin-page #dolly) {
+	// Hello Dolly already ships `padding: 5px 10px; margin: 0; font-size: 12px;
+	// line-height: 1.6666;` — see https://github.com/WordPress/WordPress/blob/trunk/wp-content/plugins/hello.php
+	// We override only the bits that need to differ from those defaults.
 	float: none;
-	padding: 10px;
 	text-align: right;
-	background: #fff;
-	font-size: 12px;
+	background: var(--wpds-color-bg-surface-neutral-strong, #fff);
 	font-style: italic;
-	color: #87a6bc;
+	color: var(--wpds-color-fg-content-neutral-weak, #87a6bc);
 	border-bottom: none;
 
 	@media (max-width: 659px) {

--- a/projects/js-packages/components/components/admin-page/style.module.scss
+++ b/projects/js-packages/components/components/admin-page/style.module.scss
@@ -84,7 +84,32 @@
 	}
 }
 
-// Make Hello Dolly background white for Jetpack admin pages.
+// Normalize Hello Dolly across Jetpack admin pages. The plugin renders
+// `<p id="dolly">` early inside `#wpbody-content`, OUTSIDE our React
+// mount — so we anchor on the `jetpack-admin-page` body class added
+// server-side by Jetpack's admin menu registration, not on the React
+// wrapper's `.jp-admin-page` class. Any Jetpack admin page gets the
+// normalized look for free. Per-page overrides can still layer on top
+// via higher-specificity selectors (see e.g. My Jetpack).
+//
+// We deliberately do NOT set `position`/`top`/`left`/`right` here:
+// those would become active on any per-page rule that flips Dolly to
+// `position: absolute` (e.g. My Jetpack), causing it to stretch to its
+// container's full width and pin to top — which covers the page title.
+// `float: none` alone is enough to break out of Hello Dolly's default
+// `float: right`; pages that need different positioning add their own
+// position rule on top.
 :global(.jetpack-admin-page #dolly) {
-	background-color: #fff;
+	float: none;
+	padding: 10px;
+	text-align: right;
+	background: #fff;
+	font-size: 12px;
+	font-style: italic;
+	color: #87a6bc;
+	border-bottom: none;
+
+	@media (max-width: 659px) {
+		display: none;
+	}
 }

--- a/projects/js-packages/components/components/admin-page/style.module.scss
+++ b/projects/js-packages/components/components/admin-page/style.module.scss
@@ -71,13 +71,14 @@
 // `float: right`; pages that need different positioning add their own
 // position rule on top.
 :global(.jetpack-admin-page #dolly) {
+	// Hello Dolly already ships `padding: 5px 10px; margin: 0; font-size: 12px;
+	// line-height: 1.6666;` — see https://github.com/WordPress/WordPress/blob/trunk/wp-content/plugins/hello.php
+	// We override only the bits that need to differ from those defaults.
 	float: none;
-	padding: 10px;
 	text-align: right;
-	background: #fff;
-	font-size: 12px;
+	background: var(--wpds-color-bg-surface-neutral-strong, #fff);
 	font-style: italic;
-	color: #87a6bc;
+	color: var(--wpds-color-fg-content-neutral-weak, #87a6bc);
 	border-bottom: none;
 
 	@media (max-width: 659px) {

--- a/projects/js-packages/components/components/admin-page/style.module.scss
+++ b/projects/js-packages/components/components/admin-page/style.module.scss
@@ -62,7 +62,7 @@
 // wrapper's `.jp-admin-page` class. Any Jetpack admin page gets the
 // normalized look for free. Per-page overrides can still layer on top
 // via higher-specificity selectors (see e.g. My Jetpack).
-//
+
 // We deliberately do NOT set `position`/`top`/`left`/`right` here:
 // those would become active on any per-page rule that flips Dolly to
 // `position: absolute` (e.g. My Jetpack), causing it to stretch to its

--- a/projects/js-packages/components/components/admin-page/style.module.scss
+++ b/projects/js-packages/components/components/admin-page/style.module.scss
@@ -55,7 +55,32 @@
 	}
 }
 
-// Make Hello Dolly background white for Jetpack admin pages.
+// Normalize Hello Dolly across Jetpack admin pages. The plugin renders
+// `<p id="dolly">` early inside `#wpbody-content`, OUTSIDE our React
+// mount — so we anchor on the `jetpack-admin-page` body class added
+// server-side by Jetpack's admin menu registration, not on the React
+// wrapper's `.jp-admin-page` class. Any Jetpack admin page gets the
+// normalized look for free. Per-page overrides can still layer on top
+// via higher-specificity selectors (see e.g. My Jetpack).
+//
+// We deliberately do NOT set `position`/`top`/`left`/`right` here:
+// those would become active on any per-page rule that flips Dolly to
+// `position: absolute` (e.g. My Jetpack), causing it to stretch to its
+// container's full width and pin to top — which covers the page title.
+// `float: none` alone is enough to break out of Hello Dolly's default
+// `float: right`; pages that need different positioning add their own
+// position rule on top.
 :global(.jetpack-admin-page #dolly) {
-	background-color: #fff;
+	float: none;
+	padding: 10px;
+	text-align: right;
+	background: #fff;
+	font-size: 12px;
+	font-style: italic;
+	color: #87a6bc;
+	border-bottom: none;
+
+	@media (max-width: 659px) {
+		display: none;
+	}
 }

--- a/projects/packages/newsletter/changelog/normalize-hello-dolly-styling
+++ b/projects/packages/newsletter/changelog/normalize-hello-dolly-styling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove the per-page Hello Dolly rule; its content is now covered by the centralized normalize rule shipped with `@automattic/jetpack-components`'s AdminPage component.

--- a/projects/packages/newsletter/src/settings/style.scss
+++ b/projects/packages/newsletter/src/settings/style.scss
@@ -19,11 +19,6 @@ body.jetpack_page_jetpack-newsletter {
 	box-sizing: border-box;
 }
 
-.jetpack_page_jetpack-newsletter #dolly {
-	width: 100%;
-	text-align: right;
-}
-
 .newsletter-jitm-card {
 
 	.jitm-card {

--- a/projects/packages/newsletter/src/settings/style.scss
+++ b/projects/packages/newsletter/src/settings/style.scss
@@ -13,11 +13,6 @@ body.jetpack_page_jetpack-newsletter {
 	box-sizing: border-box;
 }
 
-.jetpack_page_jetpack-newsletter #dolly {
-	width: 100%;
-	text-align: right;
-}
-
 .newsletter-jitm-card {
 
 	.jitm-card {

--- a/projects/plugins/boost/app/assets/src/css/main/wp-admin.scss
+++ b/projects/plugins/boost/app/assets/src/css/main/wp-admin.scss
@@ -90,7 +90,3 @@ p {
 .jetpack_page_jetpack-boost #jb-admin-settings {
 	background: #fff;
 }
-
-.jetpack_page_jetpack-boost #dolly {
-	background: #fff;
-}

--- a/projects/plugins/boost/changelog/normalize-hello-dolly-styling
+++ b/projects/plugins/boost/changelog/normalize-hello-dolly-styling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove the per-page Hello Dolly rule; its content is now covered by the centralized normalize rule shipped with `@automattic/jetpack-components`'s AdminPage component.


### PR DESCRIPTION
Part of #49285.

Rebased on trunk. The two PRs this was stacked behind — #48410 (admin-ui 2.0.0) and companion #48471 (AI page mixin) — have both merged, so this is ready for review.

## Proposed changes

The AdminPage mixin already shipped a partial Hello Dolly normalize rule (just `background-color: #fff`, anchored on the `jetpack-admin-page` body class added server-side by Jetpack's admin menu registration). This PR expands it to the full visual treatment so individual plugin dashboards no longer need per-page overrides.

* `js-packages/components/components/admin-page/style.module.scss`: expand `:global(.jetpack-admin-page #dolly)` from one line (`background-color: #fff`) to the full normalize set:
  - `float: none` (break out of Hello Dolly's default `float: right`)
  - `padding: 10px`, `background: #fff`
  - `italic`, `color: #87a6bc`, `text-align: right`
  - `border-bottom: none`
  - hidden at `<660px`
* `plugins/boost/app/assets/src/css/main/wp-admin.scss`: remove `.jetpack_page_jetpack-boost #dolly { background: #fff }` (covered by the central rule now).
* `packages/newsletter/src/settings/style.scss`: remove `.jetpack_page_jetpack-newsletter #dolly { width: 100%; text-align: right }` (covered by the central rule now).

The broad rules in `plugins/jetpack/_inc/client/scss/shared/_main.scss` (`.jetpack-pagestyles #dolly`) and `admin-static.scss` (`.wp-admin #dolly`) are intentionally left in place — they cover pages that load Jetpack's main admin CSS bundle but not the AdminPage component CSS (e.g. the React Settings/Dashboard pages via `wrap_ui`).

## Why no `position` / `top` / `left` / `right` in the central rule

Inert offsets like `position: relative; left: 0; right: 0; top: 0;` on a normal-flow `<p>` element do nothing visible. **But** they become active on any per-page rule that flips Dolly to `position: absolute` (e.g. My Jetpack's `body.jetpack_page_my-jetpack p#dolly { position: absolute; inset-inline-end: 0; z-index: 2 }`). Combined with the offsets, Dolly stretches to the full container width and pins to top, covering the page title. We tested this — see screenshots. The central rule deliberately omits those properties so My Jetpack's absolute-position rule composes cleanly.

## Related product discussion/links

* #48410 (admin-ui 2.0.0) — merged. This PR was stacked behind it.
* Companion PR #48471 (AI page mixin) — merged — addressed a related concern: the AI page didn't include the layout mixin, which exposed the Dolly strip as a visible separator.

## Does this pull request change what data or activity we track or use?
No

## Testing instructions

Hard-refresh wp-admin and visit:

1. **My Jetpack** (`?page=my-jetpack`): Dolly should appear at top-right corner via My Jetpack's `position: absolute` rule, not as a full-width strip covering the page title.
2. **Boost** (`?page=jetpack-boost`): Dolly normalized — italic, gray, right-aligned, white bg.
3. **Newsletter** (`?page=jetpack-newsletter`): same — italic, gray, right-aligned, white bg.
4. **AI** (`?page=ai`): Dolly normalized.
5. **Mobile (<660px)**: Dolly hidden everywhere.

## Screenshots

| This branch |
|--------|
| <img width="2034" height="1516" alt="cg5 jurassic tube_wp-admin_admin php_page=jetpack-activity-log" src="https://github.com/user-attachments/assets/79f19c18-38ad-4776-bb7e-52c14ad29f05" /> |
| <img width="2034" height="3514" alt="cg5 jurassic tube_wp-admin_admin php_page=jetpack" src="https://github.com/user-attachments/assets/0edd65cd-61ac-43d7-a290-5b0b8aecb0fa" /> |
| <img width="2034" height="1516" alt="cg5 jurassic tube_wp-admin_admin php_page=jetpack-search" src="https://github.com/user-attachments/assets/38f32adc-53c7-465c-ae70-ecddde135f62" /> | 
| <img width="2034" height="1516" alt="cg5 jurassic tube_wp-admin_admin php_page=jetpack-ai" src="https://github.com/user-attachments/assets/dcca5dd1-a88b-4cdf-8390-0431c8409261" /> | 
| <img width="2034" height="1516" alt="cg5 jurassic tube_wp-admin_admin php_page=jetpack-backup" src="https://github.com/user-attachments/assets/9420b8df-ff86-4a54-a088-8735452bc565" /> |
| <img width="2034" height="1516" alt="cg5 jurassic tube_wp-admin_admin php_page=jetpack-protect" src="https://github.com/user-attachments/assets/442d7de5-6b00-46d1-88a1-2aabe3a50f23" /> |
| <img width="2034" height="1516" alt="cg5 jurassic tube_wp-admin_admin php_page=jetpack-social" src="https://github.com/user-attachments/assets/3d547124-b467-45be-bdcc-d47b6703a957" /> |
| <img width="2034" height="1516" alt="cg5 jurassic tube_wp-admin_admin php_page=jetpack-boost" src="https://github.com/user-attachments/assets/5f62b8eb-6ca8-4e52-b1a5-922810a3aebe" /> |
| <img width="2034" height="1516" alt="cg5 jurassic tube_wp-admin_admin php_page=my-jetpack" src="https://github.com/user-attachments/assets/8fb8071e-58e7-46f2-b3a1-60935e3f0fd7" /> |


🤖 Generated with [Claude Code](https://claude.com/claude-code)

