### PR TITLE
Adding auto-complete

### DIFF
--- a/projects/packages/search/changelog/jps3-search-suggestions
+++ b/projects/packages/search/changelog/jps3-search-suggestions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add auto-complete search suggestions feature

--- a/projects/packages/search/src/class-helper.php
+++ b/projects/packages/search/src/class-helper.php
@@ -928,6 +928,7 @@ class Helper {
 			'locale'                      => str_replace( '_', '-', self::is_valid_locale( get_locale() ) ? get_locale() : 'en_US' ),
 			'postsPerPage'                => $posts_per_page,
 			'siteId'                      => self::get_wpcom_site_id(),
+			'searchSuggestionsEnabled'    => (bool) get_option( 'jetpack_search_suggestions_enabled', false ),
 			'postTypes'                   => $post_type_labels,
 			'webpackPublicPath'           => plugins_url( '/build/instant-search/', __DIR__ ),
 			'isPhotonEnabled'             => ( $is_wpcom || $is_jetpack_photon_enabled ) && ! $is_private_site,

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -255,7 +255,9 @@ class REST_Controller {
 		$reader_chat                   = array_key_exists( 'reader_chat', $request_body ) ? (bool) $request_body['reader_chat'] : null;
 		$ai_answers_enabled            = isset( $request_body['ai_answers_enabled'] ) ? (bool) $request_body['ai_answers_enabled'] : null;
 
-		$error = $this->validate_search_settings( $module_active, $instant_search_enabled, $swap_classic_to_inline_search, $experience, $reader_chat, $ai_answers_enabled );
+		$search_suggestions_enabled = isset( $request_body['search_suggestions_enabled'] ) ? (bool) $request_body['search_suggestions_enabled'] : null;
+
+		$error = $this->validate_search_settings( $module_active, $instant_search_enabled, $swap_classic_to_inline_search, $experience, $reader_chat, $ai_answers_enabled, $search_suggestions_enabled );
 
 		if ( is_wp_error( $error ) ) {
 			return $error;
@@ -303,6 +305,9 @@ class REST_Controller {
 		if ( $ai_answers_enabled !== null ) {
 			update_option( 'jetpack_search_ai_answers_enabled', $ai_answers_enabled );
 		}
+		if ( $search_suggestions_enabled !== null ) {
+			update_option( 'jetpack_search_suggestions_enabled', $search_suggestions_enabled );
+		}
 
 		if ( ! empty( $errors ) ) {
 			return new WP_Error(
@@ -331,8 +336,9 @@ class REST_Controller {
 	 * @param string|null $experience - Experience value.
 	 * @param bool|null   $reader_chat - Reader Chat status.
 	 * @param bool|null   $ai_answers_enabled - Whether Jetpack Search AI answers is enabled.
+	 * @param boolean     $search_suggestions_enabled - New search suggestions status.
 	 */
-	protected function validate_search_settings( $module_active, $instant_search_enabled, $swap_classic_to_inline_search, $experience = null, $reader_chat = null, $ai_answers_enabled = null ) {
+	protected function validate_search_settings( $module_active, $instant_search_enabled, $swap_classic_to_inline_search, $experience = null, $reader_chat = null, $ai_answers_enabled = null, $search_suggestions_enabled = null ) {
 		if ( $reader_chat !== null && ! $this->is_reader_chat_setting_registered() ) {
 			return new WP_Error(
 				'rest_invalid_arguments',
@@ -367,6 +373,10 @@ class REST_Controller {
 			// allow updating 'ai_answers_enabled' without updating/validating other settings.
 			return true;
 		}
+		if ( $module_active === null && $instant_search_enabled === null && $swap_classic_to_inline_search === null && $search_suggestions_enabled !== null ) {
+			// allow updating 'search_suggestions_enabled' without updating/validating other settings.
+			return true;
+		}
 		if ( ( true === $instant_search_enabled && false === $module_active ) || ( $module_active === null && $instant_search_enabled === null ) ) {
 			return new WP_Error(
 				'rest_invalid_arguments',
@@ -377,9 +387,9 @@ class REST_Controller {
 		return true;
 	}
 
-	/**
-	 * GET `jetpack/v4/search/settings`
-	 */
+		/**
+		 *     GET `jetpack/v4/search/settings`
+		 */
 	public function get_settings() {
 		$settings = array(
 			'module_active'                 => $this->search_module->is_active(),
@@ -387,6 +397,7 @@ class REST_Controller {
 			'swap_classic_to_inline_search' => $this->search_module->is_swap_classic_to_inline_search(),
 			'experience'                    => $this->search_module->get_experience(),
 			'ai_answers_enabled'            => AI_Answers::is_enabled(),
+			'search_suggestions_enabled'    => (bool) get_option( 'jetpack_search_suggestions_enabled', false ),
 		);
 
 		if ( $this->is_reader_chat_setting_registered() ) {

--- a/projects/packages/search/src/dashboard/components/module-control/index.jsx
+++ b/projects/packages/search/src/dashboard/components/module-control/index.jsx
@@ -47,6 +47,7 @@ const WIDGETS_EDITOR_URL = 'widgets.php';
  * @param {boolean}  props.isTogglingModule               - true if toggling Search module.
  * @param {boolean}  props.isTogglingInstantSearch        - true if toggling Instant Search option.
  * @param {string}   props.readerChatGuidelinesUrl        - Guidelines admin URL, when available.
+ * @param {boolean}  props.isSearchSuggestionsEnabled     - true if search suggestions (autocomplete) is enabled.
  * @return {import('react').Component} Search settings component.
  */
 export default function SearchModuleControl( {
@@ -66,6 +67,7 @@ export default function SearchModuleControl( {
 	isTogglingModule,
 	isTogglingInstantSearch,
 	readerChatGuidelinesUrl,
+	isSearchSuggestionsEnabled,
 } ) {
 	const { isUserConnected } = useConnection( {
 		redirectUri: 'admin.php?page=jetpack-search',
@@ -115,6 +117,15 @@ export default function SearchModuleControl( {
 		analytics.tracks.recordEvent( 'jetpack_search_instant_toggle', newOption );
 	}, [ supportsInstantSearch, isInstantSearchEnabled, updateOptions, isDisabledFromOverLimit ] );
 
+	const toggleSearchSuggestions = useCallback( () => {
+		if ( isDisabledFromOverLimit ) {
+			return;
+		}
+		const newOption = { search_suggestions_enabled: ! isSearchSuggestionsEnabled };
+		updateOptions( newOption );
+		analytics.tracks.recordEvent( 'jetpack_search_suggestions_toggle', newOption );
+	}, [ isSearchSuggestionsEnabled, updateOptions, isDisabledFromOverLimit ] );
+
 	return (
 		<div
 			className={ clsx( {
@@ -158,6 +169,16 @@ export default function SearchModuleControl( {
 						guidelinesUrl={ readerChatGuidelinesUrl }
 						updateOptions={ updateOptions }
 					/>
+
+					{ supportsInstantSearch && isInstantSearchEnabled && (
+						<SearchSuggestionsToggle
+							isSearchSuggestionsEnabled={ isSearchSuggestionsEnabled }
+							isInstantSearchEnabled={ isInstantSearchEnabled }
+							isSavingEitherOption={ isSavingEitherOption }
+							isDisabledFromOverLimit={ isDisabledFromOverLimit }
+							toggleSearchSuggestions={ toggleSearchSuggestions }
+						/>
+					) }
 				</div>
 			</Card>
 		</div>
@@ -306,6 +327,42 @@ const SearchToggle = ( {
 				<div className="jp-form-search-settings-group__toggle-description lg-col-span-7 md-col-span-5 sm-col-span-4">
 					<p className="jp-form-search-settings-group__toggle-explanation">
 						{ SEARCH_DESCRIPTION }
+					</p>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+const SearchSuggestionsToggle = ( {
+	isSearchSuggestionsEnabled,
+	isInstantSearchEnabled,
+	isSavingEitherOption,
+	isDisabledFromOverLimit,
+	toggleSearchSuggestions,
+} ) => {
+	const isToggleDisabled =
+		isSavingEitherOption || ! isInstantSearchEnabled || isDisabledFromOverLimit;
+
+	return (
+		<div className="jp-form-search-settings-group__toggle is-search-suggestions jp-search-dashboard-wrap">
+			<div className="jp-search-dashboard-row">
+				<ToggleControl
+					checked={ !! isSearchSuggestionsEnabled && ! isDisabledFromOverLimit }
+					disabled={ isToggleDisabled }
+					onChange={ toggleSearchSuggestions }
+					className="jp-search-dashboard-toggle lg-col-span-12 md-col-span-8 sm-col-span-4"
+					label={ __( 'Enable search suggestions', 'jetpack-search-pkg' ) }
+					__nextHasNoMarginBottom={ true }
+				/>
+			</div>
+			<div className="jp-search-dashboard-row">
+				<div className="jp-form-search-settings-group__toggle-description lg-col-span-7 md-col-span-5 sm-col-span-4">
+					<p className="jp-form-search-settings-group__toggle-explanation">
+						{ __(
+							'Show autocomplete query suggestions as visitors type, instead of updating search results on every keystroke.',
+							'jetpack-search-pkg'
+						) }
 					</p>
 				</div>
 			</div>

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -120,6 +120,9 @@ export default function DashboardPage( { isLoading = false } ) {
 		select( STORE_ID ).isTogglingInstantSearch()
 	);
 	const isSearchBlocksEnabled = useSelect( select => select( STORE_ID ).isSearchBlocksEnabled() );
+	const isSearchSuggestionsEnabled = useSelect( select =>
+		select( STORE_ID ).isSearchSuggestionsEnabled()
+	);
 
 	// Record Meter data
 	const tierMaximumRecords = useSelect( select => select( STORE_ID ).getTierMaximumRecords() );
@@ -223,47 +226,54 @@ export default function DashboardPage( { isLoading = false } ) {
 					<Tabs.Panel value="settings">
 						{ isPageLoading && <Loading /> }
 						{ ! isPageLoading && (
-							<div className="jp-search-dashboard-bottom">
-								{ isSearchBlocksEnabled ? (
-									<div className="jp-search-dashboard-wrap jp-search-experience-selector-wrap">
-										<div className="jp-search-dashboard-row">
-											<div className="lg-col-span-12 md-col-span-8 sm-col-span-4">
-												<ExperienceSelector />
-												{ isReaderChatAvailable && (
-													<div className="jp-search-reader-chat-card">
-														<ReaderChatControl
-															isAvailable={ isReaderChatAvailable }
-															isEnabled={ isReaderChatEnabled }
-															isSaving={ isSavingEitherOption }
-															guidelinesUrl={ readerChatGuidelinesUrl }
-															updateOptions={ updateOptions }
-														/>
-													</div>
-												) }
+							<>
+								<div className="jp-search-dashboard-bottom">
+									{ isSearchBlocksEnabled ? (
+										<div className="jp-search-dashboard-wrap jp-search-experience-selector-wrap">
+											<div className="jp-search-dashboard-row">
+												<div className="lg-col-span-12 md-col-span-8 sm-col-span-4">
+													<ExperienceSelector />
+													{ isReaderChatAvailable && (
+														<div className="jp-search-reader-chat-card">
+															<ReaderChatControl
+																isAvailable={ isReaderChatAvailable }
+																isEnabled={ isReaderChatEnabled }
+																isSaving={ isSavingEitherOption }
+																guidelinesUrl={ readerChatGuidelinesUrl }
+																updateOptions={ updateOptions }
+															/>
+														</div>
+													) }
+												</div>
 											</div>
 										</div>
-									</div>
-								) : (
-									<ModuleControl
-										siteAdminUrl={ siteAdminUrl }
-										updateOptions={ updateOptions }
-										domain={ domain }
-										isDisabledFromOverLimit={ isOverLimit }
-										isInstantSearchPromotionActive={ isInstantSearchPromotionActive }
-										isReaderChatAvailable={ isReaderChatAvailable }
-										isReaderChatEnabled={ isReaderChatEnabled }
-										supportsOnlyClassicSearch={ supportsOnlyClassicSearch }
-										supportsSearch={ supportsSearch }
-										supportsInstantSearch={ supportsInstantSearch }
-										isModuleEnabled={ isModuleEnabled }
-										isInstantSearchEnabled={ isInstantSearchEnabled }
-										isSavingEitherOption={ isSavingEitherOption }
-										isTogglingModule={ isTogglingModule }
-										isTogglingInstantSearch={ isTogglingInstantSearch }
-										readerChatGuidelinesUrl={ readerChatGuidelinesUrl }
-									/>
-								) }
-							</div>
+									) : (
+										<ModuleControl
+											siteAdminUrl={ siteAdminUrl }
+											updateOptions={ updateOptions }
+											domain={ domain }
+											isDisabledFromOverLimit={ isOverLimit }
+											isInstantSearchPromotionActive={ isInstantSearchPromotionActive }
+											isReaderChatAvailable={ isReaderChatAvailable }
+											isReaderChatEnabled={ isReaderChatEnabled }
+											supportsOnlyClassicSearch={ supportsOnlyClassicSearch }
+											supportsSearch={ supportsSearch }
+											supportsInstantSearch={ supportsInstantSearch }
+											isModuleEnabled={ isModuleEnabled }
+											isInstantSearchEnabled={ isInstantSearchEnabled }
+											isSavingEitherOption={ isSavingEitherOption }
+											isTogglingModule={ isTogglingModule }
+											isTogglingInstantSearch={ isTogglingInstantSearch }
+											readerChatGuidelinesUrl={ readerChatGuidelinesUrl }
+											isSearchSuggestionsEnabled={ isSearchSuggestionsEnabled }
+										/>
+									) }
+								</div>
+								<NoticesList
+									notices={ notices }
+									handleLocalNoticeDismissClick={ handleLocalNoticeDismissClick }
+								/>
+							</>
 						) }
 					</Tabs.Panel>
 					<Tabs.Panel value="ai-answers">

--- a/projects/packages/search/src/dashboard/components/pages/test/dashboard-page.test.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/test/dashboard-page.test.jsx
@@ -85,6 +85,7 @@ const createSelectMethods = () => ( {
 	isReaderChatEnabled: jest.fn( () => true ),
 	isResolving: jest.fn( () => false ),
 	isSearchBlocksEnabled: jest.fn( () => false ),
+	isSearchSuggestionsEnabled: jest.fn( () => false ),
 	isTogglingInstantSearch: jest.fn( () => false ),
 	isTogglingModule: jest.fn( () => false ),
 	isUpdatingJetpackSettings: jest.fn( () => false ),

--- a/projects/packages/search/src/dashboard/store/selectors/jetpack-settings.js
+++ b/projects/packages/search/src/dashboard/store/selectors/jetpack-settings.js
@@ -22,6 +22,7 @@ const jetpackSettingSelectors = {
 		Object.prototype.hasOwnProperty.call( state.jetpackSettings, 'reader_chat' ),
 	isReaderChatEnabled: state => state.jetpackSettings.reader_chat,
 	isAiAnswersEnabled: state => !! state.jetpackSettings.ai_answers_enabled,
+	isSearchSuggestionsEnabled: state => !! state.jetpackSettings.search_suggestions_enabled,
 	isUpdatingJetpackSettings: state => state.jetpackSettings.is_updating,
 	isTogglingModule: state => state.jetpackSettings.is_toggling_module,
 	isTogglingInstantSearch: state => state.jetpackSettings.is_toggling_instant_search,

--- a/projects/packages/search/src/instant-search/components/search-app.jsx
+++ b/projects/packages/search/src/instant-search/components/search-app.jsx
@@ -639,6 +639,10 @@ class SearchApp extends Component {
 							isVisible={ this.state.isVisible }
 							locale={ this.props.options.locale }
 							onChangeSearch={ this.props.setSearchQuery }
+							onSelectFilter={ ( taxonomy, slug ) => {
+								this.props.setFilter( taxonomy, slug );
+								this.props.setSearchQuery( '' );
+							} }
 							onChangeSort={ this.props.setSort }
 							onLoadNextPage={ this.loadNextPage }
 							overlayTrigger={ this.state.overlayOptions.overlayTrigger }
@@ -656,6 +660,8 @@ class SearchApp extends Component {
 							enableFallbackImage={ this.state.overlayOptions.enableFallbackImage }
 							fallbackImageUrl={ this.state.overlayOptions.fallbackImageUrl }
 							showProductPrice={ this.state.overlayOptions.enableProductPrice }
+							suggestionsEnabled={ !! this.props.options.searchSuggestionsEnabled }
+							siteId={ this.props.options.siteId }
 						/>
 					</Overlay>,
 					document.body

--- a/projects/packages/search/src/instant-search/components/search-box.jsx
+++ b/projects/packages/search/src/instant-search/components/search-box.jsx
@@ -43,6 +43,8 @@ const SearchBox = forwardRef( ( props, ref ) => {
 						// IE11 will immediately fire an onChange event when the placeholder contains a unicode character.
 						// Ensure that the search application is visible before invoking the onChange callback to guard against this.
 						onChange={ props.isVisible ? props.onChange : null }
+						onKeyDown={ props.onKeyDown }
+						onBlur={ props.onBlur }
 						ref={ inputRef }
 						placeholder={ __( 'Search…', 'jetpack-search-pkg' ) }
 						type="search"

--- a/projects/packages/search/src/instant-search/components/search-form.jsx
+++ b/projects/packages/search/src/instant-search/components/search-form.jsx
@@ -1,50 +1,181 @@
 import * as React from 'react';
-import { Component, createRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import useSearchSuggestions from '../hooks/use-search-suggestions';
 import SearchBox from './search-box';
+import SearchSuggestions from './search-suggestions';
 
-const noop = event => event.preventDefault();
+/**
+ * Search form with optional autocomplete suggestions dropdown.
+ *
+ * @param {object}   props                    - Component props.
+ * @param {string}   props.searchQuery        - Committed search query (from Redux).
+ * @param {Function} props.onChangeSearch     - Callback to commit a new query.
+ * @param {Function} props.onSelectFilter     - Optional callback to apply a taxonomy filter: (taxonomy, slug) => void.
+ * @param {boolean}  props.isVisible          - Whether the overlay is visible.
+ * @param {string}   props.className          - Optional CSS class for the form element.
+ * @param {boolean}  props.suggestionsEnabled - When true, show autocomplete dropdown.
+ * @param {string}   props.siteId             - Site ID used for the suggestions API.
+ * @return {React.ReactElement} The search form.
+ */
+export default function SearchForm( {
+	searchQuery,
+	onChangeSearch,
+	onSelectFilter = null,
+	isVisible,
+	className,
+	suggestionsEnabled = false,
+	siteId = null,
+} ) {
+	const searchInputRef = useRef( null );
 
-class SearchForm extends Component {
-	constructor( props ) {
-		super( props );
-		this.searchInputRef = createRef();
-	}
+	const [ localQuery, setLocalQuery ] = useState( searchQuery );
+	const [ showSuggestions, setShowSuggestions ] = useState( false );
+	const [ activeIndex, setActiveIndex ] = useState( -1 );
 
-	onClear = () => this.props.onChangeSearch( '' );
-	onChangeSearch = event => {
-		// Safari's "Use advanced tracking and fingerprinting protection" privacy setting
-		// can block access to event.currentTarget.value, returning empty/undefined.
-		// In such cases, fall back to reading the value directly from the input element via ref.
-		let value;
-		try {
-			value = event.currentTarget.value;
-			// Check if the value is actually accessible (Safari may return empty string when blocked)
-			if ( value === undefined || value === null ) {
-				throw new Error( 'Event value blocked by browser privacy settings' );
-			}
-		} catch {
-			// Fallback to ref when event.currentTarget.value is blocked
-			value = this.searchInputRef.current?.value ?? '';
+	useEffect( () => {
+		setLocalQuery( searchQuery );
+	}, [ searchQuery ] );
+
+	const { suggestions } = useSearchSuggestions( {
+		query: suggestionsEnabled ? localQuery : '',
+		siteId,
+		enabled: suggestionsEnabled,
+	} );
+
+	// Total number of selectable suggestion items (labels and separators excluded).
+	const suggestionCount = suggestions.length;
+
+	const onClear = useCallback( () => {
+		if ( suggestionsEnabled ) {
+			setLocalQuery( '' );
+			setShowSuggestions( false );
+			setActiveIndex( -1 );
 		}
-		this.props.onChangeSearch( value );
-	};
+		onChangeSearch( '' );
+	}, [ suggestionsEnabled, onChangeSearch ] );
 
-	render() {
-		return (
-			<form autoComplete="off" onSubmit={ noop } role="search" className={ this.props.className }>
-				<div className="jetpack-instant-search__search-form">
-					<SearchBox
-						ref={ this.searchInputRef }
-						isVisible={ this.props.isVisible }
-						onChange={ this.onChangeSearch }
-						onClear={ this.onClear }
-						shouldRestoreFocus
-						searchQuery={ this.props.searchQuery }
+	const handleChange = useCallback(
+		event => {
+			let value;
+			try {
+				value = event.currentTarget.value;
+				if ( value === undefined || value === null ) {
+					throw new Error( 'value inaccessible' );
+				}
+			} catch {
+				value = searchInputRef.current?.value ?? '';
+			}
+
+			if ( suggestionsEnabled ) {
+				setLocalQuery( value );
+				setShowSuggestions( value.length >= 1 );
+				setActiveIndex( -1 );
+			} else {
+				onChangeSearch( value );
+			}
+		},
+		[ suggestionsEnabled, onChangeSearch ]
+	);
+
+	const handleSelectSuggestion = useCallback(
+		item => {
+			setShowSuggestions( false );
+			setActiveIndex( -1 );
+			if ( item.type === 'taxonomy' && onSelectFilter && item.taxonomy && item.slug ) {
+				setLocalQuery( '' );
+				onChangeSearch( '' );
+				onSelectFilter( item.taxonomy, item.slug );
+			} else if ( item.type === 'post' || item.type === 'taxonomy' ) {
+				window.location.href = item.url;
+			} else {
+				setLocalQuery( item.text );
+				onChangeSearch( item.text );
+			}
+		},
+		[ onChangeSearch, onSelectFilter ]
+	);
+
+	const handleKeyDown = useCallback(
+		event => {
+			if ( ! suggestionsEnabled ) {
+				return;
+			}
+			switch ( event.key ) {
+				case 'ArrowDown':
+					event.preventDefault();
+					setShowSuggestions( true );
+					setActiveIndex( i => ( i < suggestionCount - 1 ? i + 1 : i ) );
+					break;
+				case 'ArrowUp':
+					event.preventDefault();
+					setActiveIndex( i => ( i > 0 ? i - 1 : -1 ) );
+					break;
+				case 'Enter':
+					if ( showSuggestions && activeIndex >= 0 && activeIndex < suggestionCount ) {
+						event.preventDefault();
+						handleSelectSuggestion( suggestions[ activeIndex ] );
+					} else if ( showSuggestions ) {
+						setShowSuggestions( false );
+						onChangeSearch( localQuery );
+					}
+					break;
+				case 'Escape':
+					setShowSuggestions( false );
+					setActiveIndex( -1 );
+					break;
+				default:
+					break;
+			}
+		},
+		[
+			suggestionsEnabled,
+			suggestions,
+			suggestionCount,
+			showSuggestions,
+			activeIndex,
+			localQuery,
+			handleSelectSuggestion,
+			onChangeSearch,
+		]
+	);
+
+	const handleBlur = useCallback( () => {
+		setTimeout( () => {
+			setShowSuggestions( false );
+			setActiveIndex( -1 );
+		}, 150 );
+	}, [] );
+
+	const noop = event => event.preventDefault();
+	const displayQuery = suggestionsEnabled ? localQuery : searchQuery;
+
+	return (
+		<form
+			autoComplete="off"
+			onSubmit={ noop }
+			role="search"
+			className={ className }
+			style={ { position: 'relative' } }
+		>
+			<div className="jetpack-instant-search__search-form">
+				<SearchBox
+					ref={ searchInputRef }
+					isVisible={ isVisible }
+					onChange={ handleChange }
+					onClear={ onClear }
+					onKeyDown={ suggestionsEnabled ? handleKeyDown : undefined }
+					onBlur={ suggestionsEnabled ? handleBlur : undefined }
+					shouldRestoreFocus
+					searchQuery={ displayQuery }
+				/>
+				{ suggestionsEnabled && showSuggestions && suggestions.length > 0 && (
+					<SearchSuggestions
+						suggestions={ suggestions }
+						activeIndex={ activeIndex }
+						onSelect={ handleSelectSuggestion }
 					/>
-				</div>
-			</form>
-		);
-	}
+				) }
+			</div>
+		</form>
+	);
 }
-
-export default SearchForm;

--- a/projects/packages/search/src/instant-search/components/search-results.jsx
+++ b/projects/packages/search/src/instant-search/components/search-results.jsx
@@ -293,7 +293,10 @@ class SearchResults extends Component {
 							className="jetpack-instant-search__search-results-search-form"
 							isVisible={ this.props.isVisible }
 							onChangeSearch={ this.props.onChangeSearch }
+							onSelectFilter={ this.props.onSelectFilter }
 							searchQuery={ this.props.searchQuery }
+							suggestionsEnabled={ this.props.suggestionsEnabled }
+							siteId={ this.props.siteId }
 						/>
 						<button
 							className="jetpack-instant-search__overlay-close"

--- a/projects/packages/search/src/instant-search/components/search-suggestions.jsx
+++ b/projects/packages/search/src/instant-search/components/search-suggestions.jsx
@@ -1,0 +1,92 @@
+import { __ } from '@wordpress/i18n';
+import * as React from 'react';
+import './search-suggestions.scss';
+
+const GROUP_META = {
+	query: { label: __( 'Suggestions', 'jetpack-search-pkg' ) },
+	post: { label: __( 'Articles', 'jetpack-search-pkg' ) },
+	taxonomy: { label: __( 'Popular Filters', 'jetpack-search-pkg' ) },
+};
+
+const TYPE_ORDER = [ 'query', 'taxonomy', 'post' ];
+
+/**
+ * Dropdown list of autocomplete suggestions, grouped by type.
+ *
+ * @param {object}   props             - Component props.
+ * @param {Array}    props.suggestions - Array of SuggestionItem objects.
+ * @param {number}   props.activeIndex - Flat index of the keyboard-highlighted item (-1 for none).
+ * @param {Function} props.onSelect    - Called with the selected SuggestionItem.
+ * @return {React.ReactElement|null} The rendered suggestions list or null.
+ */
+export default function SearchSuggestions( { suggestions, activeIndex, onSelect } ) {
+	if ( ! suggestions || suggestions.length === 0 ) {
+		return null;
+	}
+
+	// Group items while preserving a flat index for keyboard navigation.
+	const groups = [];
+	let flatIndex = 0;
+
+	for ( const type of TYPE_ORDER ) {
+		const items = suggestions
+			.map( ( item, originalIndex ) => ( { item, originalIndex } ) )
+			.filter( ( { item } ) => item.type === type );
+
+		if ( items.length === 0 ) {
+			continue;
+		}
+
+		groups.push( {
+			type,
+			label: GROUP_META[ type ]?.label ?? type,
+			entries: items.map( ( { item } ) => ( { item, flatIndex: flatIndex++ } ) ),
+		} );
+	}
+
+	if ( groups.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<ul
+			className="jetpack-instant-search__search-suggestions"
+			role="listbox"
+			aria-label={ __( 'Search suggestions', 'jetpack-search-pkg' ) }
+		>
+			{ groups.map( ( group, groupIndex ) => (
+				<React.Fragment key={ group.type }>
+					{ groupIndex > 0 && (
+						<li className="jetpack-instant-search__search-suggestions-separator" role="separator" />
+					) }
+					<li className="jetpack-instant-search__search-suggestions-label" role="presentation">
+						{ group.label }
+					</li>
+					{ group.entries.map( ( { item, flatIndex: idx } ) => (
+						<li
+							key={ idx }
+							className={
+								'jetpack-instant-search__search-suggestion' +
+								' jetpack-instant-search__search-suggestion--' +
+								item.type +
+								( idx === activeIndex ? ' is-active' : '' )
+							}
+							role="option"
+							aria-selected={ idx === activeIndex }
+							tabIndex={ -1 }
+							onMouseDown={ e => e.preventDefault() }
+							onClick={ e => {
+								e.preventDefault();
+								e.stopPropagation();
+								onSelect( item );
+							} }
+							onKeyDown={ e => e.key === 'Enter' && onSelect( item ) }
+						>
+							{ item.text }
+						</li>
+					) ) }
+				</React.Fragment>
+			) ) }
+		</ul>
+	);
+}

--- a/projects/packages/search/src/instant-search/components/search-suggestions.scss
+++ b/projects/packages/search/src/instant-search/components/search-suggestions.scss
@@ -1,0 +1,67 @@
+.jetpack-instant-search__search-suggestions {
+	background: #fff;
+	border: 1px solid #dcdcde;
+	border-top: none;
+	border-radius: 0 0 4px 4px;
+	box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+	list-style: none;
+	margin: 0;
+	max-height: 60vh;
+	overflow-y: auto;
+	overscroll-behavior: contain;
+	padding: 4px 0 8px;
+	position: absolute;
+	top: 100%;
+	left: 0;
+	right: 0;
+	z-index: 100;
+
+	@media (max-width: 480px) {
+		max-height: 50vh;
+	}
+}
+
+.jetpack-instant-search__search-suggestions-separator {
+	border: none;
+	border-top: 1px solid #f0f0f0;
+	margin: 4px 0;
+}
+
+.jetpack-instant-search__search-suggestions-label {
+	color: #787c82;
+	font-size: 11px;
+	font-weight: 600;
+	letter-spacing: 0.06em;
+	padding: 8px 16px 4px;
+	text-transform: uppercase;
+}
+
+.jetpack-instant-search__search-suggestion {
+	cursor: pointer;
+	font-size: 14px;
+	line-height: 1.4;
+	color: #1e1e1e;
+	padding: 10px 16px;
+
+	// Larger touch targets on mobile.
+	@media (max-width: 480px) {
+		padding: 13px 16px;
+	}
+
+	&:hover,
+	&.is-active {
+		background: #f0f6fc;
+		color: #0675c4;
+	}
+
+	// Post and taxonomy items are slightly indented to sit visually
+	// under their group label.
+	&--post,
+	&--taxonomy {
+		padding-left: 20px;
+
+		@media (max-width: 480px) {
+			padding-left: 20px;
+		}
+	}
+}

--- a/projects/packages/search/src/instant-search/components/standalone-search-suggestions.jsx
+++ b/projects/packages/search/src/instant-search/components/standalone-search-suggestions.jsx
@@ -1,0 +1,104 @@
+import * as React from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import useSearchSuggestions from '../hooks/use-search-suggestions';
+import SearchSuggestions from './search-suggestions';
+import './search-suggestions.scss';
+
+/**
+ * Attaches a suggestions dropdown to a native WordPress search input.
+ * The native input is left in place; this component listens to its events
+ * and renders a positioned dropdown beneath it.
+ *
+ * @param {object}      props        - Component props.
+ * @param {HTMLElement} props.input  - The native <input> element to enhance.
+ * @param {HTMLElement} props.form   - The native <form> element to submit for query types.
+ * @param {string}      props.siteId - Site ID used for the suggestions API.
+ * @return {React.ReactElement} Suggestion dropdown portal.
+ */
+export default function StandaloneSearchSuggestions( { input, form, siteId } ) {
+	const [ query, setQuery ] = useState( input.value ?? '' );
+	const [ showSuggestions, setShowSuggestions ] = useState( false );
+	const [ activeIndex, setActiveIndex ] = useState( -1 );
+	const enabled = !! siteId;
+
+	const { suggestions } = useSearchSuggestions( { query, siteId, enabled } );
+	const suggestionCount = suggestions.length;
+
+	const handleSelect = useCallback(
+		item => {
+			setShowSuggestions( false );
+			setActiveIndex( -1 );
+			if ( item.type === 'post' || item.type === 'taxonomy' ) {
+				window.location.href = item.url;
+			} else {
+				input.value = item.text;
+				setQuery( item.text );
+				form.submit();
+			}
+		},
+		[ input, form ]
+	);
+
+	// Sync query state from native input events.
+	useEffect( () => {
+		const handleInput = e => {
+			const value = e.target.value ?? '';
+			setQuery( value );
+			setShowSuggestions( value.length >= 1 );
+			setActiveIndex( -1 );
+		};
+		const handleBlur = () => {
+			setTimeout( () => {
+				setShowSuggestions( false );
+				setActiveIndex( -1 );
+			}, 150 );
+		};
+		const handleKeyDown = e => {
+			if ( ! showSuggestions && e.key !== 'ArrowDown' ) {
+				return;
+			}
+			switch ( e.key ) {
+				case 'ArrowDown':
+					e.preventDefault();
+					setShowSuggestions( true );
+					setActiveIndex( i => ( i < suggestionCount - 1 ? i + 1 : i ) );
+					break;
+				case 'ArrowUp':
+					e.preventDefault();
+					setActiveIndex( i => ( i > 0 ? i - 1 : -1 ) );
+					break;
+				case 'Enter':
+					if ( showSuggestions && activeIndex >= 0 && activeIndex < suggestionCount ) {
+						e.preventDefault();
+						handleSelect( suggestions[ activeIndex ] );
+					}
+					break;
+				case 'Escape':
+					setShowSuggestions( false );
+					setActiveIndex( -1 );
+					break;
+			}
+		};
+
+		input.addEventListener( 'input', handleInput );
+		input.addEventListener( 'blur', handleBlur );
+		input.addEventListener( 'keydown', handleKeyDown );
+		return () => {
+			input.removeEventListener( 'input', handleInput );
+			input.removeEventListener( 'blur', handleBlur );
+			input.removeEventListener( 'keydown', handleKeyDown );
+		};
+	}, [ input, showSuggestions, activeIndex, suggestionCount, suggestions, handleSelect ] );
+
+	if ( ! showSuggestions || suggestions.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<SearchSuggestions
+			suggestions={ suggestions }
+			activeIndex={ activeIndex }
+			onSelect={ handleSelect }
+		/>
+	);
+}

--- a/projects/packages/search/src/instant-search/components/test/search-form.test.jsx
+++ b/projects/packages/search/src/instant-search/components/test/search-form.test.jsx
@@ -1,0 +1,247 @@
+/* eslint-disable testing-library/prefer-user-event */
+jest.mock( '@wordpress/i18n', () => ( { __: text => text } ) );
+jest.mock( '../../hooks/use-search-suggestions' );
+jest.mock( '../search-box', () => {
+	const React = require( 'react' );
+
+	return React.forwardRef( ( props, ref ) => (
+		<input
+			data-testid="search-box"
+			ref={ ref }
+			value={ props.searchQuery ?? '' }
+			onChange={ props.onChange }
+			onKeyDown={ props.onKeyDown }
+			onBlur={ props.onBlur }
+		/>
+	) );
+} );
+jest.mock( '../search-suggestions', () => {
+	// Capture the onSelect prop so tests can invoke it directly.
+	const MockSearchSuggestions = ( { suggestions, onSelect } ) => {
+		MockSearchSuggestions._capturedOnSelect = onSelect;
+		const React = require( 'react' );
+		return (
+			<ul data-testid="search-suggestions">
+				{ suggestions.map( ( s, i ) => (
+					<li key={ i } data-testid={ `suggestion-${ i }` }>
+						{ s.text }
+					</li>
+				) ) }
+			</ul>
+		);
+	};
+	MockSearchSuggestions.getCapturedOnSelect = () => MockSearchSuggestions._capturedOnSelect;
+	return MockSearchSuggestions;
+} );
+
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import * as React from 'react';
+import useSearchSuggestions from '../../hooks/use-search-suggestions';
+import SearchForm from '../search-form';
+import SearchSuggestions from '../search-suggestions';
+
+const defaultProps = {
+	searchQuery: '',
+	onChangeSearch: jest.fn(),
+	isVisible: true,
+};
+
+/**
+ * Render SearchForm with a mocked suggestions hook.
+ * @param {Array}  suggestions - suggestion items
+ * @param {object} extraProps  - extra props to pass to SearchForm
+ * @return {object} RTL render result
+ */
+function setupWithSuggestions( suggestions, extraProps = {} ) {
+	useSearchSuggestions.mockReturnValue( { suggestions, isLoading: false } );
+	return render(
+		<SearchForm
+			{ ...defaultProps }
+			suggestionsEnabled
+			siteId="123"
+			onChangeSearch={ jest.fn() }
+			{ ...extraProps }
+		/>
+	);
+}
+
+beforeEach( () => {
+	useSearchSuggestions.mockReturnValue( { suggestions: [], isLoading: false } );
+	jest.clearAllMocks();
+} );
+
+describe( 'SearchForm', () => {
+	it( 'renders a form with role="search"', () => {
+		render( <SearchForm { ...defaultProps } /> );
+		expect( screen.getByRole( 'search' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the SearchBox', () => {
+		render( <SearchForm { ...defaultProps } /> );
+		expect( screen.getByTestId( 'search-box' ) ).toBeInTheDocument();
+	} );
+
+	it( 'does not render SearchSuggestions when suggestionsEnabled is false', () => {
+		useSearchSuggestions.mockReturnValue( {
+			suggestions: [ { type: 'query', text: 'hello' } ],
+			isLoading: false,
+		} );
+		render( <SearchForm { ...defaultProps } suggestionsEnabled={ false } /> );
+		expect( screen.queryByTestId( 'search-suggestions' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'does not render SearchSuggestions when suggestions is empty', () => {
+		useSearchSuggestions.mockReturnValue( { suggestions: [], isLoading: false } );
+		render( <SearchForm { ...defaultProps } suggestionsEnabled siteId="123" /> );
+		const input = screen.getByTestId( 'search-box' );
+		fireEvent.change( input, { target: { value: 'hello' }, currentTarget: { value: 'hello' } } );
+		expect( screen.queryByTestId( 'search-suggestions' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders SearchSuggestions when suggestionsEnabled, showSuggestions=true, and suggestions exist', () => {
+		const suggestions = [ { type: 'query', text: 'foo' } ];
+		useSearchSuggestions.mockReturnValue( { suggestions, isLoading: false } );
+		render( <SearchForm { ...defaultProps } suggestionsEnabled siteId="123" /> );
+
+		const input = screen.getByTestId( 'search-box' );
+		fireEvent.change( input, { target: { value: 'foo' }, currentTarget: { value: 'foo' } } );
+
+		expect( screen.getByTestId( 'search-suggestions' ) ).toBeInTheDocument();
+	} );
+
+	describe( 'handleSelectSuggestion', () => {
+		it( 'calls onSelectFilter and onChangeSearch("") for taxonomy item with onSelectFilter', () => {
+			const onChangeSearch = jest.fn();
+			const onSelectFilter = jest.fn();
+			const suggestions = [
+				{
+					type: 'taxonomy',
+					text: 'News',
+					url: '/category/news/',
+					taxonomy: 'category',
+					slug: 'news',
+				},
+			];
+			setupWithSuggestions( suggestions, { onChangeSearch, onSelectFilter } );
+
+			const input = screen.getByTestId( 'search-box' );
+			fireEvent.change( input, { target: { value: 'n' }, currentTarget: { value: 'n' } } );
+
+			const onSelect = SearchSuggestions.getCapturedOnSelect();
+			act( () => {
+				onSelect( suggestions[ 0 ] );
+			} );
+
+			expect( onSelectFilter ).toHaveBeenCalledWith( 'category', 'news' );
+			expect( onChangeSearch ).toHaveBeenCalledWith( '' );
+		} );
+
+		it( 'navigates to item.url for taxonomy item without onSelectFilter (verifies navigation branch)', () => {
+			const onChangeSearch = jest.fn();
+			const suggestions = [
+				{
+					type: 'taxonomy',
+					text: 'News',
+					url: '/category/news/',
+					taxonomy: 'category',
+					slug: 'news',
+				},
+			];
+			// Suppress jsdom's "Not implemented: navigation" console.error.
+			const errorSpy = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+			setupWithSuggestions( suggestions, { onSelectFilter: null, onChangeSearch } );
+
+			const input = screen.getByTestId( 'search-box' );
+			fireEvent.change( input, { target: { value: 'n' }, currentTarget: { value: 'n' } } );
+
+			const onSelect = SearchSuggestions.getCapturedOnSelect();
+			act( () => {
+				onSelect( suggestions[ 0 ] );
+			} );
+
+			// In the navigation branch: onChangeSearch and onSelectFilter are NOT called.
+			expect( onChangeSearch ).not.toHaveBeenCalled();
+			errorSpy.mockRestore();
+		} );
+
+		it( 'navigates to item.url for taxonomy item missing taxonomy/slug even with onSelectFilter', () => {
+			const onChangeSearch = jest.fn();
+			const onSelectFilter = jest.fn();
+			const suggestions = [ { type: 'taxonomy', text: 'Unknown', url: '/mystery/' } ];
+			// Suppress jsdom's "Not implemented: navigation" console.error.
+			const errorSpy = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+			setupWithSuggestions( suggestions, { onSelectFilter, onChangeSearch } );
+
+			const input = screen.getByTestId( 'search-box' );
+			fireEvent.change( input, { target: { value: 'u' }, currentTarget: { value: 'u' } } );
+
+			const onSelect = SearchSuggestions.getCapturedOnSelect();
+			act( () => {
+				onSelect( suggestions[ 0 ] );
+			} );
+
+			// Missing taxonomy/slug → falls through to navigation branch, not onSelectFilter.
+			expect( onSelectFilter ).not.toHaveBeenCalled();
+			expect( onChangeSearch ).not.toHaveBeenCalled();
+			errorSpy.mockRestore();
+		} );
+
+		it( 'navigates to item.url for post item (verifies navigation branch)', () => {
+			const onChangeSearch = jest.fn();
+			const suggestions = [ { type: 'post', text: 'Getting Started', url: '/getting-started/' } ];
+			// Suppress jsdom's "Not implemented: navigation" console.error.
+			const errorSpy = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+			setupWithSuggestions( suggestions, { onChangeSearch } );
+
+			const input = screen.getByTestId( 'search-box' );
+			fireEvent.change( input, { target: { value: 'g' }, currentTarget: { value: 'g' } } );
+
+			const onSelect = SearchSuggestions.getCapturedOnSelect();
+			act( () => {
+				onSelect( suggestions[ 0 ] );
+			} );
+
+			// In the navigation branch: onChangeSearch is NOT called.
+			expect( onChangeSearch ).not.toHaveBeenCalled();
+			errorSpy.mockRestore();
+		} );
+
+		it( 'calls onChangeSearch with item.text for query item', () => {
+			const onChangeSearch = jest.fn();
+			const suggestions = [ { type: 'query', text: 'wordpress hooks' } ];
+			setupWithSuggestions( suggestions, { onChangeSearch } );
+
+			const input = screen.getByTestId( 'search-box' );
+			fireEvent.change( input, { target: { value: 'w' }, currentTarget: { value: 'w' } } );
+
+			const onSelect = SearchSuggestions.getCapturedOnSelect();
+			act( () => {
+				onSelect( suggestions[ 0 ] );
+			} );
+
+			expect( onChangeSearch ).toHaveBeenCalledWith( 'wordpress hooks' );
+		} );
+	} );
+
+	describe( 'when suggestionsEnabled is false', () => {
+		it( 'calls onChangeSearch directly on input change', () => {
+			const onChangeSearch = jest.fn();
+			useSearchSuggestions.mockReturnValue( { suggestions: [], isLoading: false } );
+			render(
+				<SearchForm
+					{ ...defaultProps }
+					suggestionsEnabled={ false }
+					onChangeSearch={ onChangeSearch }
+				/>
+			);
+
+			const input = screen.getByTestId( 'search-box' );
+			fireEvent.change( input, {
+				target: { value: 'hello' },
+				currentTarget: { value: 'hello' },
+			} );
+
+			expect( onChangeSearch ).toHaveBeenCalledWith( 'hello' );
+		} );
+	} );
+} );

--- a/projects/packages/search/src/instant-search/components/test/search-suggestions.test.jsx
+++ b/projects/packages/search/src/instant-search/components/test/search-suggestions.test.jsx
@@ -1,0 +1,210 @@
+/* eslint-disable testing-library/prefer-user-event */
+jest.mock( '@wordpress/i18n', () => ( { __: text => text } ) );
+jest.mock( '../search-suggestions.scss', () => {} );
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import * as React from 'react';
+import SearchSuggestions from '../search-suggestions';
+
+const querySuggestion = { type: 'query', text: 'wordpress plugins' };
+const taxonomySuggestion = {
+	type: 'taxonomy',
+	text: 'News',
+	url: '/category/news/',
+	taxonomy: 'category',
+	slug: 'news',
+};
+const postSuggestion = { type: 'post', text: 'Getting started', url: '/getting-started/' };
+
+describe( 'SearchSuggestions', () => {
+	it( 'returns null when suggestions is empty array', () => {
+		const { container } = render(
+			<SearchSuggestions suggestions={ [] } activeIndex={ -1 } onSelect={ jest.fn() } />
+		);
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'returns null when suggestions is null', () => {
+		const { container } = render(
+			<SearchSuggestions suggestions={ null } activeIndex={ -1 } onSelect={ jest.fn() } />
+		);
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'renders a listbox with items when suggestions are provided', () => {
+		render(
+			<SearchSuggestions
+				suggestions={ [ querySuggestion ] }
+				activeIndex={ -1 }
+				onSelect={ jest.fn() }
+			/>
+		);
+		expect( screen.getByRole( 'listbox' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'option' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders group label "Suggestions" for query type', () => {
+		render(
+			<SearchSuggestions
+				suggestions={ [ querySuggestion ] }
+				activeIndex={ -1 }
+				onSelect={ jest.fn() }
+			/>
+		);
+		expect( screen.getByText( 'Suggestions' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders group label "Popular Filters" for taxonomy type', () => {
+		render(
+			<SearchSuggestions
+				suggestions={ [ taxonomySuggestion ] }
+				activeIndex={ -1 }
+				onSelect={ jest.fn() }
+			/>
+		);
+		expect( screen.getByText( 'Popular Filters' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders group label "Articles" for post type', () => {
+		render(
+			<SearchSuggestions
+				suggestions={ [ postSuggestion ] }
+				activeIndex={ -1 }
+				onSelect={ jest.fn() }
+			/>
+		);
+		expect( screen.getByText( 'Articles' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders items in TYPE_ORDER: query, taxonomy, post', () => {
+		const suggestions = [ postSuggestion, taxonomySuggestion, querySuggestion ];
+		render(
+			<SearchSuggestions suggestions={ suggestions } activeIndex={ -1 } onSelect={ jest.fn() } />
+		);
+		const items = screen.getAllByRole( 'option' );
+		expect( items[ 0 ] ).toHaveTextContent( 'wordpress plugins' );
+		expect( items[ 1 ] ).toHaveTextContent( 'News' );
+		expect( items[ 2 ] ).toHaveTextContent( 'Getting started' );
+	} );
+
+	it( 'shows a separator between groups but not before the first group', () => {
+		const suggestions = [ querySuggestion, taxonomySuggestion ];
+		render(
+			<SearchSuggestions suggestions={ suggestions } activeIndex={ -1 } onSelect={ jest.fn() } />
+		);
+		const separators = screen.getAllByRole( 'separator' );
+		expect( separators ).toHaveLength( 1 );
+	} );
+
+	it( 'shows two separators when all three groups are present', () => {
+		const suggestions = [ querySuggestion, taxonomySuggestion, postSuggestion ];
+		render(
+			<SearchSuggestions suggestions={ suggestions } activeIndex={ -1 } onSelect={ jest.fn() } />
+		);
+		const separators = screen.getAllByRole( 'separator' );
+		expect( separators ).toHaveLength( 2 );
+	} );
+
+	it( 'shows no separator when only one group is present', () => {
+		render(
+			<SearchSuggestions
+				suggestions={ [ querySuggestion ] }
+				activeIndex={ -1 }
+				onSelect={ jest.fn() }
+			/>
+		);
+		expect( screen.queryByRole( 'separator' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'marks the active item with aria-selected=true and is-active class', () => {
+		const suggestions = [ querySuggestion, taxonomySuggestion, postSuggestion ];
+		render(
+			<SearchSuggestions suggestions={ suggestions } activeIndex={ 1 } onSelect={ jest.fn() } />
+		);
+		const items = screen.getAllByRole( 'option' );
+		expect( items[ 0 ] ).toHaveAttribute( 'aria-selected', 'false' );
+		expect( items[ 0 ] ).not.toHaveClass( 'is-active' );
+		expect( items[ 1 ] ).toHaveAttribute( 'aria-selected', 'true' );
+		expect( items[ 1 ] ).toHaveClass( 'is-active' );
+		expect( items[ 2 ] ).toHaveAttribute( 'aria-selected', 'false' );
+		expect( items[ 2 ] ).not.toHaveClass( 'is-active' );
+	} );
+
+	it( 'assigns flat indices across groups (query first, then taxonomy, then post)', () => {
+		const suggestions = [ querySuggestion, taxonomySuggestion, postSuggestion ];
+		// activeIndex=2 → third flat index → post item
+		render(
+			<SearchSuggestions suggestions={ suggestions } activeIndex={ 2 } onSelect={ jest.fn() } />
+		);
+		const items = screen.getAllByRole( 'option' );
+		expect( items[ 2 ] ).toHaveAttribute( 'aria-selected', 'true' );
+		expect( items[ 2 ] ).toHaveClass( 'is-active' );
+	} );
+
+	it( 'calls onSelect with the item when clicked', () => {
+		const onSelect = jest.fn();
+		render(
+			<SearchSuggestions
+				suggestions={ [ querySuggestion ] }
+				activeIndex={ -1 }
+				onSelect={ onSelect }
+			/>
+		);
+		fireEvent.click( screen.getByRole( 'option' ) );
+		expect( onSelect ).toHaveBeenCalledWith( querySuggestion );
+	} );
+
+	it( 'calls e.preventDefault and e.stopPropagation on click', () => {
+		const onSelect = jest.fn();
+		render(
+			<SearchSuggestions
+				suggestions={ [ querySuggestion ] }
+				activeIndex={ -1 }
+				onSelect={ onSelect }
+			/>
+		);
+		const item = screen.getByRole( 'option' );
+		const preventDefault = jest.fn();
+		const stopPropagation = jest.fn();
+		fireEvent.click( item, { preventDefault, stopPropagation } );
+		// fireEvent synthesizes the event object; verify via the mock calls after the click handler
+		expect( onSelect ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'calls onSelect when Enter key is pressed on an item', () => {
+		const onSelect = jest.fn();
+		render(
+			<SearchSuggestions
+				suggestions={ [ querySuggestion ] }
+				activeIndex={ -1 }
+				onSelect={ onSelect }
+			/>
+		);
+		fireEvent.keyDown( screen.getByRole( 'option' ), { key: 'Enter' } );
+		expect( onSelect ).toHaveBeenCalledWith( querySuggestion );
+	} );
+
+	it( 'does NOT call onSelect when a non-Enter key is pressed on an item', () => {
+		const onSelect = jest.fn();
+		render(
+			<SearchSuggestions
+				suggestions={ [ querySuggestion ] }
+				activeIndex={ -1 }
+				onSelect={ onSelect }
+			/>
+		);
+		fireEvent.keyDown( screen.getByRole( 'option' ), { key: 'ArrowDown' } );
+		expect( onSelect ).not.toHaveBeenCalled();
+	} );
+
+	it( 'renders item text content', () => {
+		render(
+			<SearchSuggestions
+				suggestions={ [ querySuggestion ] }
+				activeIndex={ -1 }
+				onSelect={ jest.fn() }
+			/>
+		);
+		expect( screen.getByText( 'wordpress plugins' ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/search/src/instant-search/components/test/standalone-search-suggestions.test.jsx
+++ b/projects/packages/search/src/instant-search/components/test/standalone-search-suggestions.test.jsx
@@ -1,0 +1,325 @@
+jest.mock( '../../hooks/use-search-suggestions' );
+jest.mock( '../search-suggestions', () => {
+	const React = require( 'react' );
+	return ( { suggestions, activeIndex, onSelect } ) => (
+		<ul data-testid="search-suggestions" data-active-index={ activeIndex }>
+			{ suggestions.map( ( s, i ) => (
+				<li
+					key={ i }
+					data-testid={ `suggestion-${ i }` }
+					role="option"
+					onClick={ () => onSelect( s ) }
+					onKeyDown={ e => e.key === 'Enter' && onSelect( s ) }
+				>
+					{ s.text }
+				</li>
+			) ) }
+		</ul>
+	);
+} );
+jest.mock( '../search-suggestions.scss', () => {} );
+
+import { render, screen, act } from '@testing-library/react';
+import * as React from 'react';
+import useSearchSuggestions from '../../hooks/use-search-suggestions';
+import StandaloneSearchSuggestions from '../standalone-search-suggestions';
+
+/**
+ * Creates a mock DOM input element.
+ * @param {string} [initialValue=''] - initial value for the input
+ * @return {object} Mock input element with addEventListener/_trigger helpers
+ */
+function makeMockInput( initialValue = '' ) {
+	const listeners = {};
+	return {
+		value: initialValue,
+		addEventListener: ( event, handler ) => {
+			listeners[ event ] = listeners[ event ] || [];
+			listeners[ event ].push( handler );
+		},
+		removeEventListener: ( event, handler ) => {
+			if ( listeners[ event ] ) {
+				listeners[ event ] = listeners[ event ].filter( h => h !== handler );
+			}
+		},
+		_trigger: ( event, eventObj ) => {
+			( listeners[ event ] || [] ).forEach( h => h( eventObj ) );
+		},
+	};
+}
+
+/**
+ * Creates a mock form element.
+ * @return {object} Mock form element with a jest.fn() submit method
+ */
+function makeMockForm() {
+	return {
+		submit: jest.fn(),
+	};
+}
+
+beforeEach( () => {
+	jest.useFakeTimers();
+	useSearchSuggestions.mockReturnValue( { suggestions: [], isLoading: false } );
+} );
+
+afterEach( () => {
+	jest.runAllTimers();
+	jest.useRealTimers();
+	jest.clearAllMocks();
+} );
+
+describe( 'StandaloneSearchSuggestions', () => {
+	it( 'returns null when suggestions list is empty', () => {
+		const input = makeMockInput();
+		const form = makeMockForm();
+		useSearchSuggestions.mockReturnValue( { suggestions: [], isLoading: false } );
+
+		const { container } = render(
+			<StandaloneSearchSuggestions input={ input } form={ form } siteId="123" />
+		);
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'returns null when showSuggestions is false (initial state)', () => {
+		const input = makeMockInput();
+		const form = makeMockForm();
+		useSearchSuggestions.mockReturnValue( {
+			suggestions: [ { type: 'query', text: 'hello' } ],
+			isLoading: false,
+		} );
+
+		const { container } = render(
+			<StandaloneSearchSuggestions input={ input } form={ form } siteId="123" />
+		);
+		// showSuggestions starts false, so nothing is rendered even with suggestions
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'shows SearchSuggestions after input event with non-empty text', () => {
+		const input = makeMockInput();
+		const form = makeMockForm();
+		const suggestions = [ { type: 'query', text: 'wordpress' } ];
+		useSearchSuggestions.mockReturnValue( { suggestions, isLoading: false } );
+
+		render( <StandaloneSearchSuggestions input={ input } form={ form } siteId="123" /> );
+
+		act( () => {
+			input._trigger( 'input', { target: { value: 'word' } } );
+		} );
+
+		expect( screen.getByTestId( 'search-suggestions' ) ).toBeInTheDocument();
+	} );
+
+	it( 'does not show suggestions after input event with empty text', () => {
+		const input = makeMockInput();
+		const form = makeMockForm();
+		const suggestions = [ { type: 'query', text: 'something' } ];
+		useSearchSuggestions.mockReturnValue( { suggestions, isLoading: false } );
+
+		render( <StandaloneSearchSuggestions input={ input } form={ form } siteId="123" /> );
+
+		act( () => {
+			input._trigger( 'input', { target: { value: '' } } );
+		} );
+
+		expect( screen.queryByTestId( 'search-suggestions' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'hides suggestions after Escape key', () => {
+		const input = makeMockInput();
+		const form = makeMockForm();
+		const suggestions = [ { type: 'query', text: 'wordpress' } ];
+		useSearchSuggestions.mockReturnValue( { suggestions, isLoading: false } );
+
+		render( <StandaloneSearchSuggestions input={ input } form={ form } siteId="123" /> );
+
+		// Show suggestions first
+		act( () => {
+			input._trigger( 'input', { target: { value: 'word' } } );
+		} );
+		expect( screen.getByTestId( 'search-suggestions' ) ).toBeInTheDocument();
+
+		// Press Escape to hide
+		act( () => {
+			input._trigger( 'keydown', { key: 'Escape', preventDefault: jest.fn() } );
+		} );
+		expect( screen.queryByTestId( 'search-suggestions' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'increments activeIndex on ArrowDown', () => {
+		const input = makeMockInput();
+		const form = makeMockForm();
+		const suggestions = [
+			{ type: 'query', text: 'first' },
+			{ type: 'query', text: 'second' },
+		];
+		useSearchSuggestions.mockReturnValue( { suggestions, isLoading: false } );
+
+		render( <StandaloneSearchSuggestions input={ input } form={ form } siteId="123" /> );
+
+		// Reveal suggestions first
+		act( () => {
+			input._trigger( 'input', { target: { value: 'f' } } );
+		} );
+
+		act( () => {
+			input._trigger( 'keydown', { key: 'ArrowDown', preventDefault: jest.fn() } );
+		} );
+
+		const list = screen.getByTestId( 'search-suggestions' );
+		expect( list ).toHaveAttribute( 'data-active-index', '0' );
+	} );
+
+	it( 'increments activeIndex further on repeated ArrowDown', () => {
+		const input = makeMockInput();
+		const form = makeMockForm();
+		const suggestions = [
+			{ type: 'query', text: 'first' },
+			{ type: 'query', text: 'second' },
+		];
+		useSearchSuggestions.mockReturnValue( { suggestions, isLoading: false } );
+
+		render( <StandaloneSearchSuggestions input={ input } form={ form } siteId="123" /> );
+
+		act( () => {
+			input._trigger( 'input', { target: { value: 'f' } } );
+		} );
+		act( () => {
+			input._trigger( 'keydown', { key: 'ArrowDown', preventDefault: jest.fn() } );
+		} );
+		act( () => {
+			input._trigger( 'keydown', { key: 'ArrowDown', preventDefault: jest.fn() } );
+		} );
+
+		const list = screen.getByTestId( 'search-suggestions' );
+		expect( list ).toHaveAttribute( 'data-active-index', '1' );
+	} );
+
+	it( 'does not go above last item on ArrowDown when at end', () => {
+		const input = makeMockInput();
+		const form = makeMockForm();
+		const suggestions = [ { type: 'query', text: 'only' } ];
+		useSearchSuggestions.mockReturnValue( { suggestions, isLoading: false } );
+
+		render( <StandaloneSearchSuggestions input={ input } form={ form } siteId="123" /> );
+
+		act( () => {
+			input._trigger( 'input', { target: { value: 'o' } } );
+		} );
+		act( () => {
+			input._trigger( 'keydown', { key: 'ArrowDown', preventDefault: jest.fn() } );
+		} );
+		act( () => {
+			input._trigger( 'keydown', { key: 'ArrowDown', preventDefault: jest.fn() } );
+		} );
+
+		const list = screen.getByTestId( 'search-suggestions' );
+		expect( list ).toHaveAttribute( 'data-active-index', '0' );
+	} );
+
+	it( 'decrements activeIndex on ArrowUp but not below -1', () => {
+		const input = makeMockInput();
+		const form = makeMockForm();
+		const suggestions = [
+			{ type: 'query', text: 'first' },
+			{ type: 'query', text: 'second' },
+		];
+		useSearchSuggestions.mockReturnValue( { suggestions, isLoading: false } );
+
+		render( <StandaloneSearchSuggestions input={ input } form={ form } siteId="123" /> );
+
+		act( () => {
+			input._trigger( 'input', { target: { value: 'f' } } );
+		} );
+		// Go down to index 0
+		act( () => {
+			input._trigger( 'keydown', { key: 'ArrowDown', preventDefault: jest.fn() } );
+		} );
+		// Go back up to -1
+		act( () => {
+			input._trigger( 'keydown', { key: 'ArrowUp', preventDefault: jest.fn() } );
+		} );
+
+		const list = screen.getByTestId( 'search-suggestions' );
+		expect( list ).toHaveAttribute( 'data-active-index', '-1' );
+
+		// Try to go further up — should stay at -1
+		act( () => {
+			input._trigger( 'keydown', { key: 'ArrowUp', preventDefault: jest.fn() } );
+		} );
+		expect( list ).toHaveAttribute( 'data-active-index', '-1' );
+	} );
+
+	it( 'selects active query item on Enter: sets input.value and submits form', () => {
+		const input = makeMockInput();
+		const form = makeMockForm();
+		const suggestions = [ { type: 'query', text: 'wordpress hooks' } ];
+		useSearchSuggestions.mockReturnValue( { suggestions, isLoading: false } );
+
+		render( <StandaloneSearchSuggestions input={ input } form={ form } siteId="123" /> );
+
+		act( () => {
+			input._trigger( 'input', { target: { value: 'w' } } );
+		} );
+		act( () => {
+			input._trigger( 'keydown', { key: 'ArrowDown', preventDefault: jest.fn() } );
+		} );
+		act( () => {
+			input._trigger( 'keydown', { key: 'Enter', preventDefault: jest.fn() } );
+		} );
+
+		expect( input.value ).toBe( 'wordpress hooks' );
+		expect( form.submit ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'selects active post item on Enter: navigates to item.url (verifies navigation branch)', () => {
+		const errorSpy = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+
+		const input = makeMockInput();
+		const form = makeMockForm();
+		const suggestions = [ { type: 'post', text: 'Getting Started', url: '/getting-started/' } ];
+		useSearchSuggestions.mockReturnValue( { suggestions, isLoading: false } );
+
+		render( <StandaloneSearchSuggestions input={ input } form={ form } siteId="123" /> );
+
+		act( () => {
+			input._trigger( 'input', { target: { value: 'g' } } );
+		} );
+		act( () => {
+			input._trigger( 'keydown', { key: 'ArrowDown', preventDefault: jest.fn() } );
+		} );
+		act( () => {
+			input._trigger( 'keydown', { key: 'Enter', preventDefault: jest.fn() } );
+		} );
+
+		// Verify the navigation branch: form.submit is NOT called for post items.
+		expect( form.submit ).not.toHaveBeenCalled();
+		errorSpy.mockRestore();
+	} );
+
+	it( 'hides suggestions after blur with timeout', () => {
+		const input = makeMockInput();
+		const form = makeMockForm();
+		const suggestions = [ { type: 'query', text: 'hello' } ];
+		useSearchSuggestions.mockReturnValue( { suggestions, isLoading: false } );
+
+		render( <StandaloneSearchSuggestions input={ input } form={ form } siteId="123" /> );
+
+		act( () => {
+			input._trigger( 'input', { target: { value: 'h' } } );
+		} );
+		expect( screen.getByTestId( 'search-suggestions' ) ).toBeInTheDocument();
+
+		act( () => {
+			input._trigger( 'blur', {} );
+		} );
+		// Suggestions still showing before the timeout fires
+		expect( screen.getByTestId( 'search-suggestions' ) ).toBeInTheDocument();
+
+		act( () => {
+			jest.runAllTimers();
+		} );
+		expect( screen.queryByTestId( 'search-suggestions' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/search/src/instant-search/hooks/test/use-search-suggestions.test.js
+++ b/projects/packages/search/src/instant-search/hooks/test/use-search-suggestions.test.js
@@ -1,5 +1,6 @@
 jest.mock( 'debounce', () => fn => {
 	const wrapped = ( ...args ) => fn( ...args );
+	wrapped.clear = () => {};
 	jest.spyOn( wrapped, 'clear' ).mockImplementation();
 	return wrapped;
 } );
@@ -28,9 +29,9 @@ function makeOkResponse( data ) {
 function makeErrorResponse() {
 	return Promise.resolve( { ok: false } );
 }
-
 beforeEach( () => {
-	jest.spyOn( global, 'fetch' ).mockImplementation();
+	// eslint-disable-next-line jest/prefer-spy-on
+	global.fetch = jest.fn();
 	window.JetpackInstantSearchOptions = {};
 } );
 

--- a/projects/packages/search/src/instant-search/hooks/test/use-search-suggestions.test.js
+++ b/projects/packages/search/src/instant-search/hooks/test/use-search-suggestions.test.js
@@ -1,0 +1,298 @@
+jest.mock( 'debounce', () => fn => {
+	const wrapped = ( ...args ) => fn( ...args );
+	jest.spyOn( wrapped, 'clear' ).mockImplementation();
+	return wrapped;
+} );
+
+import { renderHook, waitFor } from '@testing-library/react';
+import useSearchSuggestions from '../use-search-suggestions';
+
+const SITE_ID = '12345';
+
+/**
+ * Creates a mock fetch response that resolves with ok:true.
+ * @param {object} data - response body to resolve with
+ * @return {Promise} Resolved fetch response
+ */
+function makeOkResponse( data ) {
+	return Promise.resolve( {
+		ok: true,
+		json: () => Promise.resolve( data ),
+	} );
+}
+
+/**
+ * Creates a mock fetch response that resolves with ok:false.
+ * @return {Promise} Resolved fetch response
+ */
+function makeErrorResponse() {
+	return Promise.resolve( { ok: false } );
+}
+
+beforeEach( () => {
+	jest.spyOn( global, 'fetch' ).mockImplementation();
+	window.JetpackInstantSearchOptions = {};
+} );
+
+afterEach( () => {
+	delete window.JetpackInstantSearchOptions;
+	jest.clearAllMocks();
+} );
+
+describe( 'useSearchSuggestions', () => {
+	it( 'returns empty suggestions and isLoading false when disabled', () => {
+		const { result } = renderHook( () =>
+			useSearchSuggestions( { query: 'test', siteId: SITE_ID, enabled: false } )
+		);
+		expect( result.current.suggestions ).toEqual( [] );
+		expect( result.current.isLoading ).toBe( false );
+		expect( global.fetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'fetches from the public API URL when isPrivateSite is false', async () => {
+		window.JetpackInstantSearchOptions = { isPrivateSite: false, isWpcom: false };
+		global.fetch.mockReturnValue(
+			makeOkResponse( { query_suggestions: [], taxonomy_suggestions: [], title_suggestions: [] } )
+		);
+
+		renderHook( () => useSearchSuggestions( { query: 'hello', siteId: SITE_ID, enabled: true } ) );
+
+		await waitFor( () => expect( global.fetch ).toHaveBeenCalled() );
+
+		const [ url ] = global.fetch.mock.calls[ 0 ];
+		expect( url ).toMatch( /^https:\/\/public-api\.wordpress\.com\/wpcom\/v2\/sites\// );
+		expect( url ).toContain( encodeURIComponent( SITE_ID ) );
+		expect( url ).toContain( 'query=hello' );
+	} );
+
+	it( 'fetches from homeUrl-based URL when isPrivateSite and isWpcom are true', async () => {
+		window.JetpackInstantSearchOptions = {
+			isPrivateSite: true,
+			isWpcom: true,
+			homeUrl: 'https://my.private.site',
+			apiNonce: 'abc123',
+		};
+		global.fetch.mockReturnValue(
+			makeOkResponse( { query_suggestions: [], taxonomy_suggestions: [], title_suggestions: [] } )
+		);
+
+		renderHook( () => useSearchSuggestions( { query: 'hello', siteId: SITE_ID, enabled: true } ) );
+
+		await waitFor( () => expect( global.fetch ).toHaveBeenCalled() );
+
+		const [ url ] = global.fetch.mock.calls[ 0 ];
+		expect( url ).toMatch(
+			/^https:\/\/my\.private\.site\/wp-json\/wpcom-origin\/wpcom\/v2\/sites\//
+		);
+	} );
+
+	it( 'includes nonce header and credentials for private sites', async () => {
+		window.JetpackInstantSearchOptions = {
+			isPrivateSite: true,
+			isWpcom: true,
+			homeUrl: 'https://my.private.site',
+			apiNonce: 'nonce-xyz',
+		};
+		global.fetch.mockReturnValue(
+			makeOkResponse( { query_suggestions: [], taxonomy_suggestions: [], title_suggestions: [] } )
+		);
+
+		renderHook( () => useSearchSuggestions( { query: 'hello', siteId: SITE_ID, enabled: true } ) );
+
+		await waitFor( () => expect( global.fetch ).toHaveBeenCalled() );
+
+		const [ , fetchOptions ] = global.fetch.mock.calls[ 0 ];
+		expect( fetchOptions.headers[ 'X-WP-Nonce' ] ).toBe( 'nonce-xyz' );
+		expect( fetchOptions.credentials ).toBe( 'include' );
+	} );
+
+	it( 'returns parsed query, taxonomy, and post items in correct order', async () => {
+		global.fetch.mockReturnValue(
+			makeOkResponse( {
+				query_suggestions: [ { text: 'react hooks' } ],
+				taxonomy_suggestions: [
+					{ text: 'News', url: '/category/news/', taxonomy: 'category', slug: 'news' },
+				],
+				title_suggestions: [ { text: 'Getting Started', url: '/getting-started/' } ],
+			} )
+		);
+
+		const { result } = renderHook( () =>
+			useSearchSuggestions( { query: 'react', siteId: SITE_ID, enabled: true } )
+		);
+
+		await waitFor( () => expect( result.current.suggestions ).toHaveLength( 3 ) );
+
+		const [ q, t, p ] = result.current.suggestions;
+		expect( q ).toEqual( { type: 'query', text: 'react hooks' } );
+		expect( t.type ).toBe( 'taxonomy' );
+		expect( t.text ).toBe( 'News' );
+		expect( p ).toEqual( { type: 'post', text: 'Getting Started', url: '/getting-started/' } );
+	} );
+
+	it( 'parses taxonomy and slug from WPCOM-style URL (?taxonomy=category&term=unix)', async () => {
+		global.fetch.mockReturnValue(
+			makeOkResponse( {
+				query_suggestions: [],
+				taxonomy_suggestions: [
+					{
+						text: 'Unix',
+						url: 'https://example.com/?taxonomy=category&term=unix',
+					},
+				],
+				title_suggestions: [],
+			} )
+		);
+
+		const { result } = renderHook( () =>
+			useSearchSuggestions( { query: 'unix', siteId: SITE_ID, enabled: true } )
+		);
+
+		await waitFor( () => expect( result.current.suggestions ).toHaveLength( 1 ) );
+
+		const item = result.current.suggestions[ 0 ];
+		expect( item.taxonomy ).toBe( 'category' );
+		expect( item.slug ).toBe( 'unix' );
+	} );
+
+	it( 'parses taxonomy and slug from pretty-permalink category URL (/category/news/)', async () => {
+		global.fetch.mockReturnValue(
+			makeOkResponse( {
+				query_suggestions: [],
+				taxonomy_suggestions: [ { text: 'News', url: 'https://example.com/category/news/' } ],
+				title_suggestions: [],
+			} )
+		);
+
+		const { result } = renderHook( () =>
+			useSearchSuggestions( { query: 'news', siteId: SITE_ID, enabled: true } )
+		);
+
+		await waitFor( () => expect( result.current.suggestions ).toHaveLength( 1 ) );
+
+		const item = result.current.suggestions[ 0 ];
+		expect( item.taxonomy ).toBe( 'category' );
+		expect( item.slug ).toBe( 'news' );
+	} );
+
+	it( 'parses taxonomy and slug from pretty-permalink tag URL (/tag/wordpress/)', async () => {
+		global.fetch.mockReturnValue(
+			makeOkResponse( {
+				query_suggestions: [],
+				taxonomy_suggestions: [ { text: 'WordPress', url: 'https://example.com/tag/wordpress/' } ],
+				title_suggestions: [],
+			} )
+		);
+
+		const { result } = renderHook( () =>
+			useSearchSuggestions( { query: 'wp', siteId: SITE_ID, enabled: true } )
+		);
+
+		await waitFor( () => expect( result.current.suggestions ).toHaveLength( 1 ) );
+
+		const item = result.current.suggestions[ 0 ];
+		expect( item.taxonomy ).toBe( 'post_tag' );
+		expect( item.slug ).toBe( 'wordpress' );
+	} );
+
+	it( 'parses taxonomy and slug from ?tag=slug URL', async () => {
+		global.fetch.mockReturnValue(
+			makeOkResponse( {
+				query_suggestions: [],
+				taxonomy_suggestions: [
+					{ text: 'Open Source', url: 'https://example.com/?tag=open-source' },
+				],
+				title_suggestions: [],
+			} )
+		);
+
+		const { result } = renderHook( () =>
+			useSearchSuggestions( { query: 'open', siteId: SITE_ID, enabled: true } )
+		);
+
+		await waitFor( () => expect( result.current.suggestions ).toHaveLength( 1 ) );
+
+		const item = result.current.suggestions[ 0 ];
+		expect( item.taxonomy ).toBe( 'post_tag' );
+		expect( item.slug ).toBe( 'open-source' );
+	} );
+
+	it( 'returns empty array when response.ok is false', async () => {
+		global.fetch.mockReturnValue( makeErrorResponse() );
+
+		const { result } = renderHook( () =>
+			useSearchSuggestions( { query: 'error', siteId: SITE_ID, enabled: true } )
+		);
+
+		await waitFor( () => expect( global.fetch ).toHaveBeenCalled() );
+		// Allow the promise chain to settle
+		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+
+		expect( result.current.suggestions ).toEqual( [] );
+	} );
+
+	it( 'returns empty array on non-AbortError fetch failure', async () => {
+		global.fetch.mockRejectedValue( new Error( 'Network failure' ) );
+
+		const { result } = renderHook( () =>
+			useSearchSuggestions( { query: 'fail', siteId: SITE_ID, enabled: true } )
+		);
+
+		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+
+		expect( result.current.suggestions ).toEqual( [] );
+	} );
+
+	it( 'does NOT reset suggestions on AbortError', async () => {
+		// First, seed some suggestions from a successful fetch
+		global.fetch.mockReturnValueOnce(
+			makeOkResponse( {
+				query_suggestions: [ { text: 'initial result' } ],
+				taxonomy_suggestions: [],
+				title_suggestions: [],
+			} )
+		);
+
+		const { result, rerender } = renderHook(
+			( { query } ) => useSearchSuggestions( { query, siteId: SITE_ID, enabled: true } ),
+			{ initialProps: { query: 'init' } }
+		);
+
+		await waitFor( () => expect( result.current.suggestions ).toHaveLength( 1 ) );
+
+		// Now make fetch throw an AbortError
+		const abortError = new Error( 'Aborted' );
+		abortError.name = 'AbortError';
+		global.fetch.mockRejectedValueOnce( abortError );
+
+		rerender( { query: 'new query' } );
+
+		await waitFor( () => expect( global.fetch ).toHaveBeenCalledTimes( 2 ) );
+
+		// Suggestions should not have been cleared by the AbortError
+		// (isLoading goes false via finally, but setSuggestions([]) is NOT called)
+		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+		expect( result.current.suggestions ).toHaveLength( 1 );
+	} );
+
+	it( 'sets suggestions to empty when enabled is toggled to false', async () => {
+		global.fetch.mockReturnValue(
+			makeOkResponse( {
+				query_suggestions: [ { text: 'result' } ],
+				taxonomy_suggestions: [],
+				title_suggestions: [],
+			} )
+		);
+
+		const { result, rerender } = renderHook(
+			( { enabled } ) => useSearchSuggestions( { query: 'test', siteId: SITE_ID, enabled } ),
+			{ initialProps: { enabled: true } }
+		);
+
+		await waitFor( () => expect( result.current.suggestions ).toHaveLength( 1 ) );
+
+		rerender( { enabled: false } );
+
+		expect( result.current.suggestions ).toEqual( [] );
+	} );
+} );

--- a/projects/packages/search/src/instant-search/hooks/use-search-suggestions.js
+++ b/projects/packages/search/src/instant-search/hooks/use-search-suggestions.js
@@ -1,0 +1,170 @@
+import debounce from 'debounce';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { SERVER_OBJECT_NAME } from '../lib/constants';
+
+/**
+ * Attempts to extract a taxonomy name and term slug from a WordPress archive URL.
+ * Works for default permalink structures (/category/slug/, /tag/slug/, ?tag=slug).
+ *
+ * @param {string} url - Archive URL.
+ * @return {{taxonomy: string, slug: string}|null} Parsed result or null.
+ */
+function parseTaxonomyFromUrl( url ) {
+	try {
+		const u = new URL( url );
+		// WPCOM suggestions API format: ?taxonomy=category&term=slug
+		const taxonomyParam = u.searchParams.get( 'taxonomy' );
+		const termParam = u.searchParams.get( 'term' );
+		if ( taxonomyParam && termParam ) {
+			return { taxonomy: taxonomyParam, slug: termParam };
+		}
+		// Pretty permalink format: /tag/slug/ or /category/slug/
+		const tagSlug = u.searchParams.get( 'tag' );
+		if ( tagSlug ) {
+			return { taxonomy: 'post_tag', slug: tagSlug };
+		}
+		const parts = u.pathname.replace( /\/$/, '' ).split( '/' ).filter( Boolean );
+		if ( parts.length >= 2 ) {
+			const base = parts[ parts.length - 2 ];
+			const slug = parts[ parts.length - 1 ];
+			if ( base === 'category' ) return { taxonomy: 'category', slug };
+			if ( base === 'tag' ) return { taxonomy: 'post_tag', slug };
+		}
+	} catch {
+		// ignore malformed URLs
+	}
+	return null;
+}
+
+/**
+ * @typedef {object} SuggestionItem
+ * @property {'query'|'post'|'taxonomy'} type       - The kind of suggestion.
+ * @property {string}                    text       - Display text.
+ * @property {string}                    [url]      - Navigation URL (post and taxonomy types).
+ * @property {string}                    [taxonomy] - Taxonomy name for taxonomy items (e.g. 'category', 'post_tag').
+ * @property {string}                    [slug]     - Term slug for taxonomy items.
+ */
+
+/**
+ * Fetches all suggestion types from the WPCOM suggestions API in a single request.
+ *
+ * @param {string}      q       - Search query.
+ * @param {string}      sId     - Site ID.
+ * @param {object}      options - Server options (apiNonce, homeUrl, isPrivateSite, isWpcom).
+ * @param {AbortSignal} signal  - Abort signal.
+ * @return {Promise<SuggestionItem[]>} Resolved suggestion items.
+ */
+async function fetchSuggestionsFromApi( q, sId, options, signal ) {
+	const { apiNonce, homeUrl, isPrivateSite, isWpcom } = options;
+	const path = `/${ encodeURIComponent( sId ) }/search-suggestions?query=${ encodeURIComponent(
+		q
+	) }&size=5`;
+	const url =
+		isPrivateSite && isWpcom
+			? `${ homeUrl }/wp-json/wpcom-origin/wpcom/v2/sites${ path }`
+			: `https://public-api.wordpress.com/wpcom/v2/sites${ path }`;
+	const fetchOptions = {
+		signal,
+		...( isPrivateSite && {
+			headers: { 'X-WP-Nonce': apiNonce },
+			credentials: 'include',
+		} ),
+	};
+	const response = await fetch( url, fetchOptions );
+	if ( ! response.ok ) {
+		return [];
+	}
+	const data = await response.json();
+
+	const toItems = ( items, type ) =>
+		( items ?? [] )
+			.map( item => {
+				const text = item.text ?? '';
+				if ( ! text ) {
+					return null;
+				}
+				if ( type === 'post' || type === 'taxonomy' ) {
+					const itemUrl = item.url ?? null;
+					if ( ! itemUrl ) {
+						return null;
+					}
+					if ( type === 'taxonomy' ) {
+						const taxonomy = item.taxonomy ?? parseTaxonomyFromUrl( itemUrl )?.taxonomy ?? null;
+						const slug = item.slug ?? parseTaxonomyFromUrl( itemUrl )?.slug ?? null;
+						return { type, text, url: itemUrl, taxonomy, slug };
+					}
+					return { type, text, url: itemUrl };
+				}
+				return { type: 'query', text };
+			} )
+			.filter( Boolean );
+
+	return [
+		...toItems( data.query_suggestions, 'query' ),
+		...toItems( data.taxonomy_suggestions, 'taxonomy' ),
+		...toItems( data.title_suggestions, 'post' ),
+	];
+}
+
+/**
+ * Fetches search query suggestions from the WPCOM suggestions API.
+ *
+ * @param {object}  args         - Arguments.
+ * @param {string}  args.query   - Current input value.
+ * @param {string}  args.siteId  - The site ID used in the API URL.
+ * @param {boolean} args.enabled - Whether suggestions are enabled.
+ * @return {{ suggestions: SuggestionItem[], isLoading: boolean }} Suggestions state.
+ */
+export default function useSearchSuggestions( { query, siteId, enabled } ) {
+	const [ suggestions, setSuggestions ] = useState( [] );
+	const [ isLoading, setIsLoading ] = useState( false );
+	const abortRef = useRef( null );
+
+	// eslint-disable-next-line react-hooks/exhaustive-deps
+	const fetchSuggestions = useCallback(
+		debounce( async ( q, sId ) => {
+			if ( ! q || ! sId ) {
+				setSuggestions( [] );
+				return;
+			}
+
+			if ( abortRef.current ) {
+				abortRef.current.abort();
+			}
+			abortRef.current = new AbortController();
+			setIsLoading( true );
+
+			try {
+				const options = window[ SERVER_OBJECT_NAME ] ?? {};
+				const results = await fetchSuggestionsFromApi( q, sId, options, abortRef.current.signal );
+				setSuggestions( results );
+			} catch ( err ) {
+				if ( err.name !== 'AbortError' ) {
+					setSuggestions( [] );
+				}
+			} finally {
+				setIsLoading( false );
+			}
+		}, 0 ),
+		[]
+	);
+
+	useEffect( () => {
+		if ( ! enabled ) {
+			setSuggestions( [] );
+			return;
+		}
+		fetchSuggestions( query, siteId );
+	}, [ query, siteId, enabled, fetchSuggestions ] );
+
+	useEffect( () => {
+		return () => {
+			fetchSuggestions.clear?.();
+			if ( abortRef.current ) {
+				abortRef.current.abort();
+			}
+		};
+	}, [ fetchSuggestions ] );
+
+	return { suggestions, isLoading };
+}

--- a/projects/packages/search/src/instant-search/index.jsx
+++ b/projects/packages/search/src/instant-search/index.jsx
@@ -7,6 +7,7 @@ import { render } from 'preact';
 import * as React from 'preact/compat';
 import { Provider } from 'react-redux';
 import SearchApp from './components/search-app';
+import StandaloneSearchSuggestions from './components/standalone-search-suggestions';
 import { buildFilterAggregations } from './lib/api';
 import { SERVER_OBJECT_NAME } from './lib/constants';
 import { isInCustomizer } from './lib/customize';
@@ -38,11 +39,40 @@ const injectSearchApp = () => {
 	);
 };
 
+const injectStandaloneSuggestions = () => {
+	const options = window[ SERVER_OBJECT_NAME ];
+	const { siteId, searchSuggestionsEnabled } = options;
+	if ( ! searchSuggestionsEnabled || ! siteId ) {
+		return;
+	}
+	const { searchInputSelector } = getThemeOptions( options );
+	const inputs = document.querySelectorAll( searchInputSelector );
+	inputs.forEach( input => {
+		const form = input.closest( 'form' );
+		if ( ! form ) {
+			return;
+		}
+		// Wrap the input in a positioned container so the dropdown can anchor to it.
+		const wrapper = document.createElement( 'div' );
+		wrapper.style.position = 'relative';
+		input.parentNode.insertBefore( wrapper, input );
+		wrapper.appendChild( input );
+		// Render into a separate mount point so Preact doesn't evict the input.
+		const mountPoint = document.createElement( 'div' );
+		wrapper.appendChild( mountPoint );
+		render(
+			<StandaloneSearchSuggestions input={ input } form={ form } siteId={ siteId } />,
+			mountPoint
+		);
+	} );
+};
+
 /**
  * Main function.
  */
 export function initialize() {
 	if ( window[ SERVER_OBJECT_NAME ] && 'siteId' in window[ SERVER_OBJECT_NAME ] ) {
 		injectSearchApp();
+		injectStandaloneSuggestions();
 	}
 }

--- a/projects/packages/search/tests/php/REST_Controller_Test.php
+++ b/projects/packages/search/tests/php/REST_Controller_Test.php
@@ -140,7 +140,13 @@ class REST_Controller_Test extends Search_TestCase {
 			'swap_classic_to_inline_search' => false,
 			'ai_answers_enabled'            => false,
 		);
-		$expected     = array_merge( $new_settings, array( 'experience' => 'overlay' ) );
+		$expected     = array_merge(
+			$new_settings,
+			array(
+				'experience'                 => 'overlay',
+				'search_suggestions_enabled' => false,
+			)
+		);
 
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/settings' );
 		$request->set_header( 'content-type', 'application/json' );
@@ -193,7 +199,13 @@ class REST_Controller_Test extends Search_TestCase {
 			'swap_classic_to_inline_search' => false,
 			'ai_answers_enabled'            => false,
 		);
-		$expected     = array_merge( $new_settings, array( 'experience' => 'off' ) );
+		$expected     = array_merge(
+			$new_settings,
+			array(
+				'experience'                 => 'off',
+				'search_suggestions_enabled' => false,
+			)
+		);
 
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/settings' );
 		$request->set_header( 'content-type', 'application/json' );
@@ -217,6 +229,7 @@ class REST_Controller_Test extends Search_TestCase {
 			'swap_classic_to_inline_search' => false,
 			'experience'                    => 'off',
 			'ai_answers_enabled'            => false,
+			'search_suggestions_enabled'    => false,
 		);
 
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/settings' );
@@ -241,6 +254,7 @@ class REST_Controller_Test extends Search_TestCase {
 			'swap_classic_to_inline_search' => false,
 			'experience'                    => 'overlay',
 			'ai_answers_enabled'            => false,
+			'search_suggestions_enabled'    => false,
 		);
 
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/settings' );
@@ -265,6 +279,7 @@ class REST_Controller_Test extends Search_TestCase {
 			'swap_classic_to_inline_search' => true,
 			'experience'                    => 'off',
 			'ai_answers_enabled'            => false,
+			'search_suggestions_enabled'    => false,
 		);
 
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/settings' );
@@ -289,6 +304,7 @@ class REST_Controller_Test extends Search_TestCase {
 			'swap_classic_to_inline_search' => false,
 			'experience'                    => 'off',
 			'ai_answers_enabled'            => false,
+			'search_suggestions_enabled'    => false,
 		);
 
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/settings' );

--- a/projects/plugins/jetpack/changelog/jps3-search-suggestions
+++ b/projects/plugins/jetpack/changelog/jps3-search-suggestions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Search: Adding auto-complete feature to suggest search queries

--- a/projects/plugins/search/changelog/jps3-search-suggestions
+++ b/projects/plugins/search/changelog/jps3-search-suggestions
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search: Adding auto-complete search query feature


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/236c367f-215b-4134-90d0-781263cfc2ac


Adds an option to use auto-complete instead of search-as-you-type. So instead of getting search results as you type, you get suggestions for search queries as you type. 

Hits a new REST API endpoint, and a new Elasticsearch index.

## Testing instructions

Apply this 214458-ghe-Automattic/wpcom on your sandbox. 

Sandbox the public API

Must use a Jurassic Tube or Jurassic Ninja (or other site with an active Jetpack connection and a Jetpack Search subscription). 
Enable the option in jetpack search settings to enable search suggestions
<img width="593" height="87" alt="Bildschirmfoto 2026-05-03 um 17 03 46" src="https://github.com/user-attachments/assets/3dbdf463-d9b2-4bdd-8e95-3f3b41a6dd74" />

Try typing a search query. You should see some suggestions for search queries. If you click on one, it will execute the search. 

If you want to test on the fieldguide, do the following
Sandbox these sites:
fieldguide.automattic.com
automattictraining.wordpress.com

Run this on your sandbox to get this branch for jetpack
```
~/public_html/bin/jetpack-downloader test jetpack jps3-search-suggestions
```

Do not checkout trunk, but rather stay on the jetpack-search-auto-complete branch.

You must visit the fieldguide while logged in, but you must also avoid HSTS / SSL errors. Search the field guide for "ssl chrome" to see suggestions on how to avoid SSL issues.