### PR TITLE
Sitemaps: wrap column names in backticks to prevent SQL errors with reserved words

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-sitemap-backtick-column-names
+++ b/projects/plugins/jetpack/changelog/fix-sitemap-backtick-column-names
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Sitemaps: wrap column names in backticks to prevent SQL errors when a column name matches a MySQL reserved word.

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-librarian.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-librarian.php
@@ -480,6 +480,6 @@ class Jetpack_Sitemap_Librarian {
 			}
 		);
 
-		return implode( ',', array_map( 'esc_sql', $columns ) );
+		return '`' . implode( '`,`', array_map( 'esc_sql', $columns ) ) . '`';
 	}
 }


### PR DESCRIPTION
Fixes #48202

## Proposed changes

The `get_sanitized_post_columns()` method in `Jetpack_Sitemap_Librarian` returns column names without backtick quoting. If a `wp_posts` column name matches a MySQL reserved word (e.g. `order`), the generated `SELECT` query fails with a SQL error.

This PR wraps each column name in backticks to ensure compatibility regardless of column names.

**Before:**
```php
return implode( ',', array_map( 'esc_sql', $columns ) );
```
Produces: `ID,post_author,post_date,...,order` (breaks SQL)

**After:**
```php
return '`' . implode( '`,`', array_map( 'esc_sql', $columns ) ) . '`';
```
Produces: `ID`,`post_author`,`post_date`,...,`order` (works correctly)

## Related product discussion/links

* Issue #48202 reported the bug with a suggested fix.

## Does this pull request change what data or activity we track or use?

No. This change only affects how SQL column names are quoted in sitemap queries. No data collection, tracking, or privacy-related changes.

## Testing instructions

1. Add a custom column to the `wp_posts` table with a MySQL reserved word name (e.g. `order`):
   ```sql
   ALTER TABLE wp_posts ADD COLUMN `order` INT DEFAULT 0;
   ```
2. Enable Jetpack Sitemaps (Settings > Traffic > Sitemaps).
3. Trigger sitemap generation by visiting a sitemap URL (e.g. `/sitemap.xml`).
4. **Before this fix:** A SQL error occurs because `order` is interpreted as the SQL `ORDER` keyword rather than a column name.
5. **After this fix:** The query succeeds because the column name is properly backtick-quoted as `` `order` ``.
6. Remove the test column: `ALTER TABLE wp_posts DROP COLUMN `order`;`

Alternatively, review the code change directly — it adds backtick wrapping to column names in the return value of `get_sanitized_post_columns()`, which is used in two `SELECT` queries in the same file.