### PR TITLE
Search: gate URL-seeded activeFilters on the client, not at PHP seed time

### DIFF
--- a/projects/packages/search/changelog/fix-rsm-2107-gate-active-filters-on-client
+++ b/projects/packages/search/changelog/fix-rsm-2107-gate-active-filters-on-client
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks: gate URL-seeded activeFilters on the client instead of at PHP seed time, so deep links work for filter blocks placed in templates / template parts (not just post content).

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -377,16 +377,10 @@ class Search_Blocks {
 	}
 
 	/**
-	 * Compose the final seeded state for `wp_interactivity_state()`. Seeds
-	 * `activeFilters` from the raw URL params (no PHP-side gating) — every
-	 * filter block contributes its filterConfig at render time via
-	 * `wp_interactivity_state()`'s deep-merge, so the JS-side store has the
-	 * complete registry by hydration. Gating happens once there, in
-	 * `store/index.js`'s `initialize()` callback, which can correctly drop
-	 * stray params regardless of whether the filter block lives in post
-	 * content or in a template / template part. Doing the same gate here
-	 * could only use a partial registry, and would wrongly drop URL params
-	 * for filter blocks placed outside post_content.
+	 * Compose the final seeded state for `wp_interactivity_state()`.
+	 *
+	 * `activeFilters` is passed through from the URL — the JS store gates
+	 * against the complete `filterConfigs` registry on hydration.
 	 *
 	 * @param array<string, array<string, mixed>> $filter_configs Map of filter
 	 *   configs collected from the current post (or injected by tests).

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -359,12 +359,10 @@ class Search_Blocks {
 	 * — core deep-merges each call, so each block can contribute its own
 	 * entries (e.g. filter-checkbox writes its filterConfig).
 	 *
-	 * Pre-populates `filterConfigs` by scanning the current post content for
-	 * jetpack/filter-checkbox blocks so the seeded state always carries the
-	 * known filter schema regardless of block order in the tree. That in turn
-	 * lets `gate_active_filters()` drop URL-derived `activeFilters` keys that
-	 * aren't registered anywhere on the post, preventing unrelated array
-	 * params from round-tripping into subsequent search URLs.
+	 * URL-derived `activeFilters` is passed straight through; the JS store
+	 * gates it against the complete `filterConfigs` registry on hydration
+	 * (see `gateActiveFilters()` in `store/index.js`), so any stray params
+	 * don't round-trip back into subsequent search URLs.
 	 */
 	public static function seed_interactivity_state() {
 		if ( ! function_exists( 'wp_interactivity_state' ) ) {

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -377,9 +377,16 @@ class Search_Blocks {
 	}
 
 	/**
-	 * Compose the final seeded state for `wp_interactivity_state()`. Takes
-	 * $filter_configs as an argument so tests can exercise the full gating +
-	 * isLoading recomputation path without a WP post lookup.
+	 * Compose the final seeded state for `wp_interactivity_state()`. Seeds
+	 * `activeFilters` from the raw URL params (no PHP-side gating) — every
+	 * filter block contributes its filterConfig at render time via
+	 * `wp_interactivity_state()`'s deep-merge, so the JS-side store has the
+	 * complete registry by hydration. Gating happens once there, in
+	 * `store/index.js`'s `initialize()` callback, which can correctly drop
+	 * stray params regardless of whether the filter block lives in post
+	 * content or in a template / template part. Doing the same gate here
+	 * could only use a partial registry, and would wrongly drop URL params
+	 * for filter blocks placed outside post_content.
 	 *
 	 * @param array<string, array<string, mixed>> $filter_configs Map of filter
 	 *   configs collected from the current post (or injected by tests).
@@ -388,45 +395,7 @@ class Search_Blocks {
 	public static function build_seed_state( array $filter_configs ): array {
 		$state                  = static::build_initial_state();
 		$state['filterConfigs'] = $filter_configs;
-		$state['activeFilters'] = static::gate_active_filters(
-			$state['activeFilters'] ?? array(),
-			$filter_configs
-		);
-		// Recompute isLoading from the *post-gating* state. build_initial_state()
-		// derives it from the raw URL params, so a URL that carried only
-		// unregistered `?foo[]=bar` params (e.g. from another plugin) would
-		// leave isLoading=true after gating emptied activeFilters — and since
-		// the JS `initialize()` only fires a search when `searchQuery`,
-		// `hasActiveFilters`, or `priceRange` is truthy, the spinner would
-		// never clear.
-		$state['isLoading'] = '' !== $state['searchQuery']
-			|| ! empty( $state['activeFilters'] )
-			|| null !== $state['priceRange'];
 		return $state;
-	}
-
-	/**
-	 * Drop active-filter keys that aren't registered by any filter-checkbox
-	 * block on the current post. parse_url_filters() accepts any array-shaped
-	 * top-level URL param, so without this gate a stray `?foo[]=bar` seeded
-	 * by another plugin would get merged into `activeFilters` and then
-	 * re-serialized back into subsequent search URLs. Mirrors the same gating
-	 * that store/url-state.js applies on the client side.
-	 *
-	 * Skipped when `$filter_configs` is empty — no filter blocks means we
-	 * don't know what's valid, and we don't want to silently drop filters
-	 * a filter block placed inside a template part would accept after hydration.
-	 *
-	 * @param array<string, string[]>             $active_filters Parsed active filters.
-	 * @param array<string, array<string, mixed>> $filter_configs Known filter configs keyed by filterKey.
-	 * @return array<string, string[]>
-	 */
-	public static function gate_active_filters( array $active_filters, array $filter_configs ): array {
-		if ( empty( $filter_configs ) ) {
-			return $active_filters;
-		}
-		$allowed = array_fill_keys( array_keys( $filter_configs ), true );
-		return array_intersect_key( $active_filters, $allowed );
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -26,20 +26,26 @@ const withSyncEvent =
 /**
  * Drop activeFilters keys not present in filterConfigs.
  *
+ * Uses `Object.hasOwn` rather than `allowedKeys[key]` so prototype-chain
+ * keys (`__proto__`, `constructor`, `toString`, …) can't survive the gate
+ * via inherited properties. Output uses a null prototype for the same
+ * reason — assigning `gated.__proto__` on a plain object would trigger
+ * the prototype setter instead of writing a regular property.
+ *
  * @param {object} activeFilters - { [filterKey]: string[] } URL-seeded selections.
  * @param {object} filterConfigs - { [filterKey]: FilterConfig } registered filters.
  * @return {{ gated: object, droppedAny: boolean }} Filtered selections plus a drop flag.
  */
 export function gateActiveFilters( activeFilters, filterConfigs ) {
 	const allowedKeys = filterConfigs ?? {};
-	const gated = {};
+	const gated = Object.create( null );
 	let droppedAny = false;
 	for ( const [ key, values ] of Object.entries( activeFilters ?? {} ) ) {
-		if ( allowedKeys[ key ] ) {
-			gated[ key ] = values;
+		if ( ! Object.hasOwn( allowedKeys, key ) ) {
+			droppedAny = true;
 			continue;
 		}
-		droppedAny = true;
+		gated[ key ] = values;
 	}
 	return { gated, droppedAny };
 }

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -22,6 +22,36 @@ const withSyncEvent =
 	( cb =>
 		( ...args ) =>
 			cb( ...args ) );
+
+/**
+ * Drop activeFilters keys whose filter is not in the filterConfigs registry.
+ *
+ * The PHP seed runs before any filter block has rendered, so any gate it
+ * could apply on its own would use a partial registry — and would wrongly
+ * drop URL params for blocks placed in templates / template parts. By the
+ * time `initialize()` fires every block's render.php has contributed its
+ * filterConfig via `wp_interactivity_state()`, so the registry here is
+ * complete. The gate also keeps stray params from another plugin (e.g.
+ * `?foo[]=bar`) out of the URL state that pushStateToUrl will re-emit.
+ *
+ * @param {object} activeFilters - { [filterKey]: string[] } selections from the seed.
+ * @param {object} filterConfigs - { [filterKey]: FilterConfig } registered filters.
+ * @return {{ gated: object, droppedAny: boolean }} Subset of `activeFilters`
+ * keyed by registered filter keys, plus a flag indicating whether anything was dropped.
+ */
+export function gateActiveFilters( activeFilters, filterConfigs ) {
+	const allowedKeys = filterConfigs ?? {};
+	const gated = {};
+	let droppedAny = false;
+	for ( const [ key, values ] of Object.entries( activeFilters ?? {} ) ) {
+		if ( allowedKeys[ key ] ) {
+			gated[ key ] = values;
+			continue;
+		}
+		droppedAny = true;
+	}
+	return { gated, droppedAny };
+}
 // Monotonic token used to drop stale async result responses. Incremented on
 // every new search; in-flight responses compare their token against the
 // latest before touching store state, so a slow request for an older query
@@ -598,26 +628,7 @@ const { state, actions } = store( NAMESPACE, {
 			}
 			initialized = true;
 			window.addEventListener( 'popstate', actions.handlePopState );
-			// Drop activeFilters keys that aren't in the now-complete
-			// filterConfigs registry. PHP seed runs before any filter block
-			// renders, so any gate it could apply on its own would use a
-			// partial registry — and would wrongly drop URL params for
-			// blocks placed in templates / template parts. By the time this
-			// callback fires every block's render.php has contributed its
-			// filterConfig via wp_interactivity_state(), so the registry
-			// here is complete. The gate also keeps stray params from
-			// another plugin (e.g. `?foo[]=bar`) out of the URL state that
-			// pushStateToUrl will later re-emit.
-			const allowedKeys = state.filterConfigs ?? {};
-			const gated = {};
-			let droppedAny = false;
-			for ( const [ key, values ] of Object.entries( state.activeFilters ?? {} ) ) {
-				if ( allowedKeys[ key ] ) {
-					gated[ key ] = values;
-					continue;
-				}
-				droppedAny = true;
-			}
+			const { gated, droppedAny } = gateActiveFilters( state.activeFilters, state.filterConfigs );
 			if ( droppedAny ) {
 				state.activeFilters = gated;
 			}

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -598,6 +598,29 @@ const { state, actions } = store( NAMESPACE, {
 			}
 			initialized = true;
 			window.addEventListener( 'popstate', actions.handlePopState );
+			// Drop activeFilters keys that aren't in the now-complete
+			// filterConfigs registry. PHP seed runs before any filter block
+			// renders, so any gate it could apply on its own would use a
+			// partial registry — and would wrongly drop URL params for
+			// blocks placed in templates / template parts. By the time this
+			// callback fires every block's render.php has contributed its
+			// filterConfig via wp_interactivity_state(), so the registry
+			// here is complete. The gate also keeps stray params from
+			// another plugin (e.g. `?foo[]=bar`) out of the URL state that
+			// pushStateToUrl will later re-emit.
+			const allowedKeys = state.filterConfigs ?? {};
+			const gated = {};
+			let droppedAny = false;
+			for ( const [ key, values ] of Object.entries( state.activeFilters ?? {} ) ) {
+				if ( allowedKeys[ key ] ) {
+					gated[ key ] = values;
+					continue;
+				}
+				droppedAny = true;
+			}
+			if ( droppedAny ) {
+				state.activeFilters = gated;
+			}
 			if ( state.searchQuery || state.hasActiveFilters || state.priceRange ) {
 				// The URL already carries this query — don't push a duplicate
 				// history entry on top of the browser's current one.
@@ -606,6 +629,12 @@ const { state, actions } = store( NAMESPACE, {
 				// `?min_price=10` would leave PHP's `isLoading: true` spinner
 				// stuck because no initial fetch ever fires.
 				actions.search( { syncUrl: false } );
+			} else if ( droppedAny ) {
+				// PHP seeded `isLoading: true` based on the URL's raw
+				// activeFilters; the gate above just emptied them. With no
+				// fetch about to flip the flag, clear it here so the
+				// spinner doesn't stick.
+				state.isLoading = false;
 			}
 		},
 	},

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -407,7 +407,11 @@ const { state, actions } = store( NAMESPACE, {
 			);
 			state.searchQuery = searchQuery;
 			state.sortOrder = sortOrder;
-			state.activeFilters = activeFilters;
+			// urlParamsToState bypasses its own gate when filterConfigs is empty;
+			// re-gate here so popstate matches initialize() and stray URL keys
+			// can't round-trip back into pushStateToUrl on a page with no
+			// registered filters.
+			state.activeFilters = gateActiveFilters( activeFilters, state.filterConfigs ).gated;
 			state.priceRange = priceRange;
 			yield actions.search( { syncUrl: false } );
 		},

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -24,20 +24,11 @@ const withSyncEvent =
 			cb( ...args ) );
 
 /**
- * Drop activeFilters keys whose filter is not in the filterConfigs registry.
+ * Drop activeFilters keys not present in filterConfigs.
  *
- * The PHP seed runs before any filter block has rendered, so any gate it
- * could apply on its own would use a partial registry — and would wrongly
- * drop URL params for blocks placed in templates / template parts. By the
- * time `initialize()` fires every block's render.php has contributed its
- * filterConfig via `wp_interactivity_state()`, so the registry here is
- * complete. The gate also keeps stray params from another plugin (e.g.
- * `?foo[]=bar`) out of the URL state that pushStateToUrl will re-emit.
- *
- * @param {object} activeFilters - { [filterKey]: string[] } selections from the seed.
+ * @param {object} activeFilters - { [filterKey]: string[] } URL-seeded selections.
  * @param {object} filterConfigs - { [filterKey]: FilterConfig } registered filters.
- * @return {{ gated: object, droppedAny: boolean }} Subset of `activeFilters`
- * keyed by registered filter keys, plus a flag indicating whether anything was dropped.
+ * @return {{ gated: object, droppedAny: boolean }} Filtered selections plus a drop flag.
  */
 export function gateActiveFilters( activeFilters, filterConfigs ) {
 	const allowedKeys = filterConfigs ?? {};
@@ -633,18 +624,11 @@ const { state, actions } = store( NAMESPACE, {
 				state.activeFilters = gated;
 			}
 			if ( state.searchQuery || state.hasActiveFilters || state.priceRange ) {
-				// The URL already carries this query — don't push a duplicate
-				// history entry on top of the browser's current one.
-				// `priceRange` is checked separately because `hasActiveFilters`
-				// only inspects `activeFilters`; without this gate a URL like
-				// `?min_price=10` would leave PHP's `isLoading: true` spinner
-				// stuck because no initial fetch ever fires.
+				// syncUrl=false: URL already carries this query; avoid a duplicate history entry.
+				// priceRange is checked separately so `?min_price=10` still triggers an initial fetch.
 				actions.search( { syncUrl: false } );
 			} else if ( droppedAny ) {
-				// PHP seeded `isLoading: true` based on the URL's raw
-				// activeFilters; the gate above just emptied them. With no
-				// fetch about to flip the flag, clear it here so the
-				// spinner doesn't stick.
+				// Gate emptied activeFilters and no fetch will fire — clear the PHP-seeded spinner.
 				state.isLoading = false;
 			}
 		},

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -26,7 +26,7 @@ jest.mock(
 	{ virtual: true }
 );
 
-import { actions, state } from '../../../src/search-blocks/store';
+import { actions, gateActiveFilters, state } from '../../../src/search-blocks/store';
 import { stateToUrlParams, urlParamsToState } from '../../../src/search-blocks/store/url-state';
 
 const originalActions = { ...actions };
@@ -390,6 +390,38 @@ describe( 'store getters', () => {
 	} );
 } );
 
+describe( 'gateActiveFilters', () => {
+	it( 'drops keys that are not in the registered filterConfigs', () => {
+		const { gated, droppedAny } = gateActiveFilters(
+			{ category: [ 'news' ], post_date: [ '2024-08' ], foo: [ 'bar' ] },
+			{ category: { filterKey: 'category' }, post_date: { filterKey: 'post_date' } }
+		);
+		expect( gated ).toEqual( { category: [ 'news' ], post_date: [ '2024-08' ] } );
+		expect( droppedAny ).toBe( true );
+	} );
+
+	it( 'keeps every key when filterConfigs covers them all', () => {
+		const { gated, droppedAny } = gateActiveFilters(
+			{ category: [ 'news' ] },
+			{ category: { filterKey: 'category' }, post_date: { filterKey: 'post_date' } }
+		);
+		expect( gated ).toEqual( { category: [ 'news' ] } );
+		expect( droppedAny ).toBe( false );
+	} );
+
+	it( 'returns droppedAny=false when activeFilters is empty', () => {
+		const { gated, droppedAny } = gateActiveFilters( {}, { category: { filterKey: 'category' } } );
+		expect( gated ).toEqual( {} );
+		expect( droppedAny ).toBe( false );
+	} );
+
+	it( 'drops everything when filterConfigs is empty', () => {
+		const { gated, droppedAny } = gateActiveFilters( { category: [ 'news' ] }, {} );
+		expect( gated ).toEqual( {} );
+		expect( droppedAny ).toBe( true );
+	} );
+} );
+
 describe( 'store callbacks', () => {
 	afterEach( () => {
 		jest.restoreAllMocks();
@@ -415,5 +447,47 @@ describe( 'store callbacks', () => {
 		expect( addEventListener ).toHaveBeenCalledWith( 'popstate', actions.handlePopState );
 		expect( search ).toHaveBeenCalledTimes( 1 );
 		expect( search ).toHaveBeenCalledWith( { syncUrl: false } );
+	} );
+
+	it( 'drops unknown activeFilters keys before running the URL-seeded search', () => {
+		jest.isolateModules( () => {
+			const fresh = require( '../../../src/search-blocks/store' );
+			jest.spyOn( window, 'addEventListener' ).mockImplementation();
+			jest.spyOn( fresh.actions, 'handlePopState' ).mockImplementation();
+			const search = jest.spyOn( fresh.actions, 'search' ).mockImplementation();
+			fresh.state.searchQuery = 'wordpress';
+			fresh.state.priceRange = null;
+			fresh.state.filterConfigs = { category: { filterKey: 'category' } };
+			fresh.state.activeFilters = { category: [ 'news' ], foo: [ 'bar' ] };
+
+			captured.callbacks.initialize();
+
+			expect( fresh.state.activeFilters ).toEqual( { category: [ 'news' ] } );
+			expect( search ).toHaveBeenCalledTimes( 1 );
+			expect( search ).toHaveBeenCalledWith( { syncUrl: false } );
+		} );
+	} );
+
+	it( 'clears isLoading when gating empties activeFilters and no fetch will fire', () => {
+		jest.isolateModules( () => {
+			const fresh = require( '../../../src/search-blocks/store' );
+			jest.spyOn( window, 'addEventListener' ).mockImplementation();
+			jest.spyOn( fresh.actions, 'handlePopState' ).mockImplementation();
+			const search = jest.spyOn( fresh.actions, 'search' ).mockImplementation();
+			// No searchQuery / priceRange, only a stray URL key — gating empties
+			// activeFilters, no fetch fires, and the spinner must be cleared
+			// otherwise the page stays in its PHP-seeded `isLoading: true` state.
+			fresh.state.searchQuery = '';
+			fresh.state.priceRange = null;
+			fresh.state.filterConfigs = { category: { filterKey: 'category' } };
+			fresh.state.activeFilters = { foo: [ 'bar' ] };
+			fresh.state.isLoading = true;
+
+			captured.callbacks.initialize();
+
+			expect( fresh.state.activeFilters ).toEqual( {} );
+			expect( search ).not.toHaveBeenCalled();
+			expect( fresh.state.isLoading ).toBe( false );
+		} );
 	} );
 } );

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -488,3 +488,29 @@ describe( 'store callbacks', () => {
 		} );
 	} );
 } );
+
+describe( 'handlePopState gating', () => {
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	it( 'drops unknown activeFilters keys even when filterConfigs is empty', async () => {
+		// Empty filterConfigs is the case where urlParamsToState bypasses its
+		// own gate — handlePopState must still drop stray keys before they
+		// land in state and round-trip via pushStateToUrl.
+		const stub = require( '../../../src/search-blocks/store/url-state' );
+		jest.spyOn( stub, 'readStateFromUrl' ).mockReturnValue( {
+			searchQuery: 'hello',
+			sortOrder: 'relevance',
+			activeFilters: { foo: [ 'bar' ] },
+			priceRange: null,
+		} );
+		Object.assign( actions, originalActions );
+		jest.spyOn( actions, 'search' ).mockImplementation();
+		state.filterConfigs = {};
+
+		await runGenerator( actions.handlePopState() );
+
+		expect( state.activeFilters ).toEqual( {} );
+	} );
+} );

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -474,9 +474,6 @@ describe( 'store callbacks', () => {
 			jest.spyOn( window, 'addEventListener' ).mockImplementation();
 			jest.spyOn( fresh.actions, 'handlePopState' ).mockImplementation();
 			const search = jest.spyOn( fresh.actions, 'search' ).mockImplementation();
-			// No searchQuery / priceRange, only a stray URL key — gating empties
-			// activeFilters, no fetch fires, and the spinner must be cleared
-			// otherwise the page stays in its PHP-seeded `isLoading: true` state.
 			fresh.state.searchQuery = '';
 			fresh.state.priceRange = null;
 			fresh.state.filterConfigs = { category: { filterKey: 'category' } };

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -420,6 +420,36 @@ describe( 'gateActiveFilters', () => {
 		expect( gated ).toEqual( {} );
 		expect( droppedAny ).toBe( true );
 	} );
+
+	it( 'drops prototype-chain keys regardless of filterConfigs contents', () => {
+		// `__proto__`, `constructor`, `toString`, `hasOwnProperty` etc. are
+		// inherited from Object.prototype; a naive `allowedKeys[key]` lookup
+		// would treat them as truthy and let them survive the gate. Use
+		// JSON.parse so `__proto__` lands as an own property (object literals
+		// would set the prototype instead).
+		const activeFilters = JSON.parse(
+			'{"__proto__":["pwn"],"constructor":["x"],"toString":["y"],"category":["news"]}'
+		);
+		const { gated, droppedAny } = gateActiveFilters( activeFilters, {
+			category: { filterKey: 'category' },
+		} );
+		expect( gated ).toEqual( { category: [ 'news' ] } );
+		expect( droppedAny ).toBe( true );
+		// Output must not have inherited the polluted prototype value either.
+		expect( Object.getPrototypeOf( gated ) ).toBeNull();
+	} );
+
+	it( 'does not allow Object.prototype keys to act as registered filter keys', () => {
+		// Even if filterConfigs only mentions `category`, an attacker URL of
+		// `?toString[]=…` should not survive because `toString` is inherited,
+		// not own.
+		const activeFilters = JSON.parse( '{"toString":["bad"]}' );
+		const { gated, droppedAny } = gateActiveFilters( activeFilters, {
+			category: { filterKey: 'category' },
+		} );
+		expect( gated ).toEqual( {} );
+		expect( droppedAny ).toBe( true );
+	} );
 } );
 
 describe( 'store callbacks', () => {

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -96,12 +96,12 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * Build_seed_state() seeds activeFilters from the raw URL — gating moved
-	 * to store/index.js's `initialize()` callback, which can apply it once
+	 * Seeded `activeFilters` is the raw URL params — gating moved to
+	 * store/index.js's `initialize()` callback, which can apply it once
 	 * every filter block's render.php has contributed its filterConfig (and
-	 * the registry is complete). PHP seed must therefore pass URL params
-	 * through unchanged regardless of whether the matching filter block was
-	 * found in post content.
+	 * the registry is complete). `build_seed_state()` must therefore pass
+	 * URL params through unchanged regardless of whether the matching filter
+	 * block was found in post content.
 	 */
 	public function test_build_seed_state_passes_url_filters_through() {
 		$original_get   = $_GET;

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -96,63 +96,36 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * Only filter keys registered by a filter-checkbox block on the current
-	 * post may survive into the seeded state. An unrelated `?foo[]=bar`
-	 * param (e.g. from another plugin) must be dropped so it doesn't get
-	 * echoed back into subsequent search URLs.
+	 * Build_seed_state() seeds activeFilters from the raw URL — gating moved
+	 * to store/index.js's `initialize()` callback, which can apply it once
+	 * every filter block's render.php has contributed its filterConfig (and
+	 * the registry is complete). PHP seed must therefore pass URL params
+	 * through unchanged regardless of whether the matching filter block was
+	 * found in post content.
 	 */
-	public function test_gate_active_filters_keeps_only_registered_keys() {
-		$gated = Search_Blocks::gate_active_filters(
-			array(
-				'category'   => array( 'news' ),
-				'post_types' => array( 'post' ),
-				'foo'        => array( 'bar' ),
-			),
-			array(
-				'category'   => array( 'filterKey' => 'category' ),
-				'post_types' => array( 'filterKey' => 'post_types' ),
-			)
-		);
-		$this->assertSame(
-			array(
-				'category'   => array( 'news' ),
-				'post_types' => array( 'post' ),
-			),
-			$gated
-		);
-	}
-
-	/**
-	 * When no filter-checkbox blocks contribute a filterConfig (e.g. the
-	 * post uses a template part instead of the bundled pattern), leave
-	 * activeFilters alone — hydration may still register them client-side.
-	 */
-	public function test_gate_active_filters_passthrough_when_configs_empty() {
-		$input = array( 'category' => array( 'news' ) );
-		$this->assertSame( $input, Search_Blocks::gate_active_filters( $input, array() ) );
-	}
-
-	/**
-	 * When the URL carries only unregistered array params (e.g. from another
-	 * plugin) and no search query, gating drops them — and build_seed_state
-	 * must recompute isLoading so the JS store doesn't leave the loading
-	 * spinner stuck forever (JS initialize() only fires a search when
-	 * searchQuery or hasActiveFilters is truthy).
-	 */
-	public function test_build_seed_state_recomputes_is_loading_after_gating() {
+	public function test_build_seed_state_passes_url_filters_through() {
 		$original_get   = $_GET;
 		$original_query = $GLOBALS['wp_query'] ?? null;
-		$_GET           = array( 'foo' => array( 'bar' ) );
-		// Reset the WP_Query global so `get_search_query()` can't leak an `s`
-		// value from an earlier test and make isLoading look stuck on its own.
+		// post_date isn't in the filterConfigs passed to build_seed_state
+		// below — simulating a filter-date block placed in a template
+		// rather than post content. PHP must still seed it through; JS
+		// gates against the complete registry on hydration.
+		$_GET                = array(
+			'category'  => array( 'news' ),
+			'post_date' => array( '2024-08' ),
+		);
 		$GLOBALS['wp_query'] = new \WP_Query( array( 's' => '' ) );
 		try {
 			$state = Search_Blocks::build_seed_state(
 				array( 'category' => array( 'filterKey' => 'category' ) )
 			);
-			$this->assertSame( '', $state['searchQuery'] );
-			$this->assertSame( array(), $state['activeFilters'] );
-			$this->assertFalse( $state['isLoading'] );
+			$this->assertSame(
+				array(
+					'category'  => array( 'news' ),
+					'post_date' => array( '2024-08' ),
+				),
+				$state['activeFilters']
+			);
 		} finally {
 			$_GET                = $original_get;
 			$GLOBALS['wp_query'] = $original_query;
@@ -160,10 +133,12 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * A URL carrying a registered filter must leave isLoading=true so the
-	 * JS store shows the spinner until the first fetch resolves.
+	 * A URL carrying a filter selection must leave isLoading=true so the JS
+	 * store shows the spinner until the first fetch resolves. JS-side gating
+	 * may later flip it back to false if every key gets dropped, but the
+	 * seed should default to true whenever activeFilters is non-empty.
 	 */
-	public function test_build_seed_state_keeps_is_loading_for_registered_filter() {
+	public function test_build_seed_state_keeps_is_loading_for_active_filter() {
 		$original_get        = $_GET;
 		$original_query      = $GLOBALS['wp_query'] ?? null;
 		$_GET                = array( 'category' => array( 'news' ) );


### PR DESCRIPTION
Fixes [RSM-2107](https://linear.app/a8c/issue/RSM-2107/search-30-gate-url-seeded-activefilters-on-the-client-not-at-php-seed)

## Proposed changes
* Move the `activeFilters` URL gate from PHP seed (`wp_enqueue_scripts` → `Search_Blocks::seed_interactivity_state()` → `gate_active_filters()`) to JS hydration (`store/index.js` → `initialize()` callback).
* Remove `gate_active_filters()` and the seed-time `isLoading` recomputation — both are dead code after the move.
* JS-side gate also clears `isLoading` if every URL key got dropped, so a stray `?foo[]=bar`-only URL doesn't leave the spinner stuck.

## Why
The PHP seed runs before any filter block has rendered. `collect_filter_configs_from_post()` only walks `get_post()->post_content`, so any filter block placed in a block template, template part, or custom Site Editor template is invisible to it — and `gate_active_filters()` then drops the matching URL-supplied selections. Each block's `render.php` contributes its `filterConfig` at render time via `wp_interactivity_state()` deep-merge, so by JS hydration the registry IS complete; the gate just needs to run there instead.

This bug surfaced while testing filter-date placed in a Site Editor sidebar (RSM-1921), but it's pre-existing — filter-checkbox in a template has the same symptom. Splitting out from the filter-date PR so this fix can be reviewed on its own and so the date PR stays scoped to the new block.

## Related product discussion/links
* [RSM-2107](https://linear.app/a8c/issue/RSM-2107/search-30-gate-url-seeded-activefilters-on-the-client-not-at-php-seed)
* Filter-date PR (where this surfaced): atlas/rsm-1921-filter-date

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

Reproduces on `trunk` (with any active Search 3.0 page), fixed on this branch.

1. Insert a filter-checkbox block (e.g. `<!-- wp:jetpack/filter-checkbox {"filterType":"author"} /-->`) into the Jetpack Search **template** (Site Editor → Templates → Search), not into the queried post's content.
2. Visit `/?s=foo&authors[]=alice`.
3. **Before**: no `Author: alice` pill appears, results aren't filtered, the URL param silently does nothing.
4. **After**: pill renders, results are filtered, removing the pill clears the URL param.

Stray-param check (regression guard for the gate behaviour itself):

1. Visit `/?s=foo&category[]=news&random[]=garbage`.
2. Expected: only `Category: news` pill renders; `random` is dropped from `state.activeFilters`; the URL is cleaned up the next time a filter is changed.

## Tests
- 226 PHP tests pass (one flow-specific test was rewritten — `test_gate_active_filters_*` removed since `gate_active_filters()` is gone, replaced by `test_build_seed_state_passes_url_filters_through`).
- 186 JS tests pass.