### PR TITLE
Search: render visible error message when a search request fails

### DIFF
--- a/projects/packages/search/changelog/atlas-rsm-271-search-error-block
+++ b/projects/packages/search/changelog/atlas-rsm-271-search-error-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Search: render a visible error message when a search or load-more request fails.

--- a/projects/packages/search/src/search-blocks/blocks/search-error/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/search-error/block.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "jetpack/search-error",
+	"version": "0.1.0",
+	"title": "Search Error",
+	"category": "jetpack-search",
+	"icon": "warning",
+	"description": "Message shown when a Jetpack Search request fails.",
+	"supports": { "html": false, "interactivity": true },
+	"textdomain": "jetpack-search-pkg",
+	"render": "file:./render.php",
+	"viewScriptModule": "file:../../../../build/search-blocks/search-error.js",
+	"attributes": {
+		"message": { "type": "string", "default": "" }
+	}
+}

--- a/projects/packages/search/src/search-blocks/blocks/search-error/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-error/edit.js
@@ -1,0 +1,46 @@
+/**
+ * Editor preview for jetpack/search-error.
+ *
+ * The front end hides this block unless the store reports a failed fetch.
+ * The editor keeps the successful-results preview clean while still
+ * exposing the message setting in the Inspector.
+ */
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, TextControl } from '@wordpress/components';
+import { createElement as h, Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Edit component for the search-error block.
+ *
+ * @param {object}   props               - Block props.
+ * @param {object}   props.attributes    - Saved block attributes.
+ * @param {Function} props.setAttributes - Attribute setter.
+ * @return {object} Rendered element.
+ */
+export default function SearchErrorEdit( { attributes, setAttributes } ) {
+	const blockProps = useBlockProps();
+	const defaultMessage = __( 'Something went wrong. Please try again.', 'jetpack-search-pkg' );
+	return h(
+		Fragment,
+		null,
+		h(
+			InspectorControls,
+			null,
+			h(
+				PanelBody,
+				{ title: __( 'Settings', 'jetpack-search-pkg' ) },
+				h( TextControl, {
+					__next40pxDefaultSize: true,
+					__nextHasNoMarginBottom: true,
+					label: __( 'Message', 'jetpack-search-pkg' ),
+					value: attributes.message || '',
+					placeholder: defaultMessage,
+					onChange: value => setAttributes( { message: value } ),
+					help: __( 'Leave empty to use the default translated message.', 'jetpack-search-pkg' ),
+				} )
+			)
+		),
+		h( 'div', { ...blockProps, hidden: true, 'aria-hidden': 'true' } )
+	);
+}

--- a/projects/packages/search/src/search-blocks/blocks/search-error/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/search-error/render.php
@@ -11,7 +11,9 @@ namespace Automattic\Jetpack\Search;
 
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 
-$message = (string) ( $attributes['message'] ?? '' );
+// `trim()` so a whitespace-only attribute (e.g. an author saved spaces)
+// still falls back to the default copy instead of rendering a blank alert.
+$message = trim( (string) ( $attributes['message'] ?? '' ) );
 if ( '' === $message ) {
 	$message = __( 'Something went wrong. Please try again.', 'jetpack-search-pkg' );
 }

--- a/projects/packages/search/src/search-blocks/blocks/search-error/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/search-error/render.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Search Error block render.
+ *
+ * WordPress passes $attributes, $content, $block to render.php at runtime.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+
+$message = (string) ( $attributes['message'] ?? '' );
+if ( '' === $message ) {
+	$message = __( 'Something went wrong. Please try again.', 'jetpack-search-pkg' );
+}
+?>
+<div
+	<?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>
+	data-wp-interactive="jetpack-search"
+	data-wp-bind--hidden="!state.showError"
+	role="alert"
+>
+	<p><?php echo esc_html( $message ); ?></p>
+</div>

--- a/projects/packages/search/src/search-blocks/blocks/search-error/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-error/view.js
@@ -1,0 +1,3 @@
+// Display-only block. View module pulls in the shared store so
+// state.showError is defined on pages that only use this block.
+import '../../store';

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -25,6 +25,7 @@ import FilterPopoverEdit, { save as filterPopoverSave } from '../blocks/filter-p
 import LoadMoreEdit from '../blocks/load-more/edit';
 import NoResultsEdit from '../blocks/no-results/edit';
 import ResultsCountEdit from '../blocks/results-count/edit';
+import SearchErrorEdit from '../blocks/search-error/edit';
 import SearchInputEdit from '../blocks/search-input/edit';
 import SearchResultsEdit from '../blocks/search-results/edit';
 import SortControlEdit from '../blocks/sort-control/edit';
@@ -42,6 +43,7 @@ const BLOCKS = [
 	[ 'jetpack/sort-control', SortControlEdit ],
 	[ 'jetpack/results-count', ResultsCountEdit ],
 	[ 'jetpack/no-results', NoResultsEdit ],
+	[ 'jetpack/search-error', SearchErrorEdit ],
 	[ 'jetpack/load-more', LoadMoreEdit ],
 ];
 

--- a/projects/packages/search/src/search-blocks/patterns/blog-search.php
+++ b/projects/packages/search/src/search-blocks/patterns/blog-search.php
@@ -36,6 +36,7 @@ register_block_pattern(
 <!-- /wp:group -->
 
 <!-- wp:jetpack/search-results /-->
+<!-- wp:jetpack/search-error /-->
 <!-- wp:jetpack/no-results /-->
 <!-- wp:jetpack/load-more /-->
 </div>

--- a/projects/packages/search/src/search-blocks/patterns/compact-search.php
+++ b/projects/packages/search/src/search-blocks/patterns/compact-search.php
@@ -40,6 +40,7 @@ register_block_pattern(
 
 <!-- wp:jetpack/results-count /-->
 <!-- wp:jetpack/search-results {"layout":"compact"} /-->
+<!-- wp:jetpack/search-error /-->
 <!-- wp:jetpack/no-results /-->
 <!-- wp:jetpack/load-more /-->
 

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -248,7 +248,8 @@ const { state, actions } = store( NAMESPACE, {
 		 * Gated on `searchQuery` (so the message doesn't flash on a bare
 		 * `/search/` page where the user hasn't typed) and on `!hasError`
 		 * (so "No results found" doesn't display when the fetch actually
-		 * failed — there is no dedicated error block yet).
+		 * failed — the dedicated `jetpack/search-error` block owns that
+		 * message instead).
 		 *
 		 * @return {boolean} True when the no-results message should show.
 		 */
@@ -256,6 +257,20 @@ const { state, actions } = store( NAMESPACE, {
 			return (
 				!! state.searchQuery && ! state.isLoading && ! state.hasError && state.results.length === 0
 			);
+		},
+
+		/**
+		 * Visibility flag for the `jetpack/search-error` block. Hidden while
+		 * a fetch is in flight so the message doesn't linger over the next
+		 * query — `search()` and `loadMore()` already clear `hasError` at
+		 * the start of every request, but binding through a single getter
+		 * keeps the template `data-wp-bind` simple (the Interactivity API
+		 * only evaluates simple property paths).
+		 *
+		 * @return {boolean} True when the error message should show.
+		 */
+		get showError() {
+			return !! state.hasError && ! state.isLoading;
 		},
 
 		/**

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -260,17 +260,19 @@ const { state, actions } = store( NAMESPACE, {
 		},
 
 		/**
-		 * Visibility flag for the `jetpack/search-error` block. Hidden while
-		 * a fetch is in flight so the message doesn't linger over the next
-		 * query — `search()` and `loadMore()` already clear `hasError` at
-		 * the start of every request, but binding through a single getter
-		 * keeps the template `data-wp-bind` simple (the Interactivity API
-		 * only evaluates simple property paths).
+		 * Visibility flag for the `jetpack/search-error` block. Gated on
+		 * both `!isLoading` and `!isLoadingMore` so the message hides the
+		 * moment the user retries — covering the `loadMore()` failure path
+		 * (where `isLoading` stays false but `isLoadingMore` toggles)
+		 * symmetrically with the `search()` path. `hasError` itself is also
+		 * cleared at the start of each action, but binding through a single
+		 * getter keeps the template `data-wp-bind` simple (the Interactivity
+		 * API only evaluates simple property paths).
 		 *
 		 * @return {boolean} True when the error message should show.
 		 */
 		get showError() {
-			return !! state.hasError && ! state.isLoading;
+			return !! state.hasError && ! state.isLoading && ! state.isLoadingMore;
 		},
 
 		/**

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search.html
@@ -20,6 +20,7 @@
 <!-- /wp:group -->
 
 <!-- wp:jetpack/search-results /-->
+<!-- wp:jetpack/search-error /-->
 <!-- wp:jetpack/no-results /-->
 <!-- wp:jetpack/load-more /-->
 </div>

--- a/projects/packages/search/tests/js/search-blocks/search-error-block.test.js
+++ b/projects/packages/search/tests/js/search-blocks/search-error-block.test.js
@@ -1,0 +1,13 @@
+// The search-error block's attribute defaults live in block.json. This test
+// locks the `message` default in place so an accidental edit can't ship a
+// non-empty default that would override every existing post's copy.
+import blockJson from '../../../src/search-blocks/blocks/search-error/block.json';
+
+describe( 'search-error block.json attributes', () => {
+	it( 'declares a string `message` attribute with an empty default', () => {
+		expect( blockJson.attributes.message ).toEqual( {
+			type: 'string',
+			default: '',
+		} );
+	} );
+} );

--- a/projects/packages/search/tests/js/search-blocks/search-error-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/search-error-edit.test.jsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import SearchErrorEdit from '../../../src/search-blocks/blocks/search-error/edit';
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	useBlockProps: () => ( { className: 'wp-block-jetpack-search-error' } ),
+	InspectorControls: ( { children } ) => <div data-testid="inspector">{ children }</div>,
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	PanelBody: ( { title, children } ) => (
+		<section data-testid="panel" aria-label={ title }>
+			{ children }
+		</section>
+	),
+	TextControl: ( { label, value, onChange, placeholder } ) => {
+		const id = 'search-error-message-control';
+		return (
+			<>
+				<label htmlFor={ id }>{ label }</label>
+				<input
+					id={ id }
+					type="text"
+					value={ value || '' }
+					placeholder={ placeholder }
+					onChange={ event => onChange( event.target.value ) }
+				/>
+			</>
+		);
+	},
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: text => text,
+} ) );
+
+describe( 'SearchErrorEdit', () => {
+	it( 'keeps the error message out of the successful-results preview', () => {
+		render( <SearchErrorEdit attributes={ {} } setAttributes={ jest.fn() } /> );
+
+		expect( screen.getByRole( 'textbox', { name: 'Message' } ) ).toBeInTheDocument();
+		expect(
+			screen.queryByText( 'Something went wrong. Please try again.' )
+		).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -75,6 +75,9 @@ function createResult( title ) {
 
 /**
  * Resolve each promise yielded by an Interactivity API action generator.
+ * Rejected yields are propagated back into the generator via `.throw()` so
+ * the action's own try/catch can absorb them — without this, awaiting a
+ * rejected fetch outside the generator would surface the error to the test.
  *
  * @param {Generator} generator - Action generator.
  * @return {Promise<*>} Final generator return value.
@@ -82,7 +85,11 @@ function createResult( title ) {
 async function runGenerator( generator ) {
 	let step = generator.next();
 	while ( ! step.done ) {
-		step = generator.next( await step.value );
+		try {
+			step = generator.next( await step.value );
+		} catch ( err ) {
+			step = generator.throw( err );
+		}
 	}
 	return step.value;
 }
@@ -157,6 +164,28 @@ describe( 'store actions', () => {
 			delete global.fetch;
 		}
 		jest.restoreAllMocks();
+	} );
+
+	it( 'sets hasError on a failed loadMore and clears it on the next loadMore', async () => {
+		state.pageHandle = 'next-page';
+		global.fetch.mockRejectedValueOnce( new Error( 'network down' ) ).mockResolvedValueOnce(
+			createResponse( {
+				results: [ createResult( 'Recovered result' ) ],
+				page_handle: null,
+			} )
+		);
+
+		await runGenerator( actions.loadMore() );
+		expect( state.hasError ).toBe( true );
+		expect( state.isLoadingMore ).toBe( false );
+
+		// Re-enable pagination so the second call doesn't early-out (the
+		// failed request leaves pageHandle untouched, but the action also
+		// short-circuits when pageHandle is null).
+		state.pageHandle = 'next-page';
+		await runGenerator( actions.loadMore() );
+		expect( state.hasError ).toBe( false );
+		expect( state.results.map( r => r.title ) ).toContain( 'Recovered result' );
 	} );
 
 	it( 'drops load-more responses superseded by a new search', async () => {
@@ -355,12 +384,18 @@ describe( 'store getters', () => {
 		expect( state.showNoResults ).toBe( false );
 		expect( state.showError ).toBe( true );
 
-		// While a fetch is in flight the error block stays hidden so the
-		// previous-query message doesn't linger over the next request.
+		// While a fresh search is in flight the error block stays hidden so
+		// the previous-query message doesn't linger over the next request.
 		state.isLoading = true;
 		expect( state.showError ).toBe( false );
 
+		// Same when paginating an existing query — keeps the symmetry with
+		// loadMore()'s lifecycle (which only flips isLoadingMore).
 		state.isLoading = false;
+		state.isLoadingMore = true;
+		expect( state.showError ).toBe( false );
+
+		state.isLoadingMore = false;
 		state.hasError = false;
 		expect( state.showError ).toBe( false );
 

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -349,11 +349,21 @@ describe( 'store getters', () => {
 	it( 'derives result, load-more, and filter visibility flags', () => {
 		state.results = [];
 		expect( state.showNoResults ).toBe( true );
+		expect( state.showError ).toBe( false );
 
 		state.hasError = true;
 		expect( state.showNoResults ).toBe( false );
+		expect( state.showError ).toBe( true );
 
+		// While a fetch is in flight the error block stays hidden so the
+		// previous-query message doesn't linger over the next request.
+		state.isLoading = true;
+		expect( state.showError ).toBe( false );
+
+		state.isLoading = false;
 		state.hasError = false;
+		expect( state.showError ).toBe( false );
+
 		state.pageHandle = 'next-page';
 		expect( state.showLoadMore ).toBe( true );
 

--- a/projects/packages/search/tests/php/Search_Error_Render_Test.php
+++ b/projects/packages/search/tests/php/Search_Error_Render_Test.php
@@ -87,6 +87,18 @@ class Search_Error_Render_Test extends TestCase {
 	}
 
 	/**
+	 * A whitespace-only `message` must fall back to the default — otherwise
+	 * an author who typed spaces would ship a blank alert. The Inspector
+	 * help text already tells authors to leave the field empty for the
+	 * default; the fallback is the belt-and-suspenders for anyone who
+	 * misses that.
+	 */
+	public function test_whitespace_message_falls_back_to_default() {
+		$markup = $this->render( array( 'message' => "  \t\n " ) );
+		$this->assertStringContainsString( 'Something went wrong. Please try again.', $markup );
+	}
+
+	/**
 	 * A custom `message` must replace the default copy on the front end.
 	 */
 	public function test_custom_message_renders() {

--- a/projects/packages/search/tests/php/Search_Error_Render_Test.php
+++ b/projects/packages/search/tests/php/Search_Error_Render_Test.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Search Error block render.php tests.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the search-error block's render template.
+ *
+ * Mirrors No_Results_Render_Test: the block is registered inline (rather
+ * than from its block.json) so `do_blocks()` can resolve it without
+ * depending on `build/` artifacts that aren't present in a fresh checkout.
+ */
+class Search_Error_Render_Test extends TestCase {
+
+	/**
+	 * Register the search-error block inline for the whole test class.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		\register_block_type(
+			'jetpack/search-error',
+			array(
+				'attributes'      => array(
+					'message' => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+				),
+				// $attributes is consumed by the included render.php via the
+				// closure's local scope — phpcs can't see that, hence the disable.
+				// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+				'render_callback' => static function ( $attributes ) {
+					ob_start();
+					include __DIR__ . '/../../src/search-blocks/blocks/search-error/render.php';
+					return (string) ob_get_clean();
+				},
+				// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			)
+		);
+	}
+
+	/**
+	 * Unregister the block so other test classes start from a clean slate.
+	 */
+	public static function tearDownAfterClass(): void {
+		\unregister_block_type( 'jetpack/search-error' );
+		parent::tearDownAfterClass();
+	}
+
+	/**
+	 * Render the search-error block with the given attributes via `do_blocks`.
+	 *
+	 * @param array $attributes Block attributes (JSON-encoded into the comment delimiter).
+	 * @return string Rendered markup.
+	 */
+	private function render( array $attributes = array() ): string {
+		$json = empty( $attributes )
+			? ''
+			: wp_json_encode( $attributes, JSON_UNESCAPED_SLASHES );
+		return do_blocks( '<!-- wp:jetpack/search-error ' . $json . ' /-->' );
+	}
+
+	/**
+	 * An empty `message` must fall back to the translated default so existing
+	 * posts (saved before the attribute existed) keep rendering the original
+	 * copy.
+	 */
+	public function test_empty_message_falls_back_to_default() {
+		$markup = $this->render( array( 'message' => '' ) );
+		$this->assertStringContainsString( 'Something went wrong. Please try again.', $markup );
+	}
+
+	/**
+	 * A missing `message` (not just empty) must also fall back. Block editor
+	 * saves omit attributes that match their default, so old posts arrive
+	 * here without the key at all.
+	 */
+	public function test_missing_message_falls_back_to_default() {
+		$markup = $this->render();
+		$this->assertStringContainsString( 'Something went wrong. Please try again.', $markup );
+	}
+
+	/**
+	 * A custom `message` must replace the default copy on the front end.
+	 */
+	public function test_custom_message_renders() {
+		$markup = $this->render( array( 'message' => 'Search is offline right now.' ) );
+		$this->assertStringContainsString( 'Search is offline right now.', $markup );
+		$this->assertStringNotContainsString( 'Something went wrong. Please try again.', $markup );
+	}
+
+	/**
+	 * The message is user-controlled, so the template must escape HTML to
+	 * prevent stored XSS through a crafted attribute value.
+	 */
+	public function test_message_is_html_escaped() {
+		$markup = $this->render( array( 'message' => '<script>alert(1)</script>' ) );
+		$this->assertStringNotContainsString( '<script>alert(1)</script>', $markup );
+		$this->assertStringContainsString( '&lt;script&gt;alert(1)&lt;/script&gt;', $markup );
+	}
+
+	/**
+	 * Assistive tech needs to know the message is an alert, otherwise a
+	 * silently-appearing error wouldn't be announced. The role lives on
+	 * the wrapper so the announcement carries the full message text.
+	 */
+	public function test_wrapper_carries_alert_role() {
+		$markup = $this->render();
+		$this->assertStringContainsString( 'role="alert"', $markup );
+	}
+}


### PR DESCRIPTION
Fixes RSM-271 — https://linear.app/a8c/issue/RSM-271

## Why this matters

When a visitor searches a site running Jetpack Search 3.0 and the request fails — they're offline, the API returns an error, the response is malformed — they currently see nothing. The page goes silent. There's no spinner, no message, no indication anything went wrong. Visitors can't tell whether their query is still loading, returned no matches, or actually broke, so they're left guessing whether to wait, refine, or give up. After this change they see a clear "Something went wrong. Please try again." message (which site authors can override) and can decide what to do next instead of staring at an empty page.

## Proposed changes

* Add a new display-only `jetpack/search-error` block that mirrors `jetpack/no-results`: author-configurable `message` attribute (default `Something went wrong. Please try again.`), hidden unless the new `state.showError` getter is true. The wrapper carries `role="alert"` so assistive tech announces a silent failure.
* Add a `showError` getter to the shared Interactivity API store next to `showNoResults` (`!! state.hasError && ! state.isLoading`). The `isLoading` gate keeps the message from lingering over the next request.
* Insert the new block between `search-results` and `no-results` in both the Blog Search Page pattern and the bundled `jetpack-search.html` template.
* Tests: a new `Search_Error_Render_Test` PHP suite covering default/missing/custom/escaped messages and the alert role; new Jest suites locking the `message` attribute default and verifying the editor preview stays clean; an extension to `store.test.js` covering `showError` for hasError + isLoading combinations.

## Related product discussion/links

* Linear: [RSM-271](https://linear.app/a8c/issue/RSM-271)
* Original review comment: [Automattic/jetpack#48198 (r3114855712)](https://github.com/Automattic/jetpack/pull/48198#discussion_r3114855712)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Insert the **Blog Search Page** pattern (or activate the bundled **Jetpack Search Results** template) on a site running this branch.
2. Open the site's search page (`/?s=anything`) in a browser with DevTools open.
3. In the **Network** panel set throttling to **Offline**.
4. Type a query in the search input and wait for the request to fail.
5. **Expected:** the new error message ("Something went wrong. Please try again.") renders and the "No results found." block stays hidden.
6. Set throttling back to **Online**, edit the query, and trigger a new search.
7. **Expected:** the error message disappears as soon as the new fetch starts and either real results or the no-results message renders on success.
8. Open the search-error block in the editor and confirm the **Settings** panel exposes a **Message** override; setting a custom string and re-triggering the failure shows the custom copy on the front end.

Automated coverage:

* `jp test php packages/search` — 240 PHP tests pass (includes new `Search_Error_Render_Test`).
* `jp test js packages/search` — 352 Jest tests + 249 url-tests + size-limit pass (includes new search-error suites and the extended store test).


<img width="882" height="255" alt="image" src="https://github.com/user-attachments/assets/d620434d-9c48-4146-bc07-b4928be90094" />


## Out of scope (follow-up)

The Linear issue's **Secondary** scope item — seeding `state.errorMessage` from a whitelist of known causes (network failure vs HTTP 4xx/5xx vs bad JSON) so the rendered message can be more specific — is intentionally deferred. This PR delivers the visible-state fix; cause categorization can layer on top without changing the block contract.
