### PR TITLE
Search 3.0: add jetpack/common-filters block (RSM-2112)

### DIFF
--- a/projects/packages/search/changelog/add-rsm-2112-common-filters-block
+++ b/projects/packages/search/changelog/add-rsm-2112-common-filters-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search 3.0: add common-filters block — Group-like container for stacking filter blocks (active filters, taxonomy/author/post-type checkboxes, date).

--- a/projects/packages/search/changelog/add-rsm-2112-common-filters-block
+++ b/projects/packages/search/changelog/add-rsm-2112-common-filters-block
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Search 3.0: add common-filters block — Group-like container for stacking filter blocks (active filters, taxonomy/author/post-type checkboxes, date).
+Search 3.0: Add common-filters block — Group-like container for stacking filter blocks (active filters, taxonomy/author/post-type checkboxes, date).

--- a/projects/packages/search/src/search-blocks/blocks/common-filters/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/common-filters/block.json
@@ -1,0 +1,39 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "jetpack/common-filters",
+	"version": "0.1.0",
+	"title": "Filters",
+	"category": "jetpack-search",
+	"icon": "filter",
+	"description": "Container for a stack of Jetpack Search filter blocks. Pre-populated with the most common filters; rearrange, remove, or add more from the inserter.",
+	"supports": {
+		"html": false,
+		"interactivity": true,
+		"color": {
+			"background": true,
+			"text": true,
+			"link": true
+		},
+		"spacing": {
+			"padding": true,
+			"margin": true,
+			"blockGap": true
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"style": true,
+			"width": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"fontFamily": true
+		}
+	},
+	"textdomain": "jetpack-search-pkg",
+	"render": "file:./render.php",
+	"viewScriptModule": "file:../../../../build/search-blocks/common-filters.js",
+	"style": "file:../../../../build/search-blocks/common-filters.css"
+}

--- a/projects/packages/search/src/search-blocks/blocks/common-filters/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/common-filters/block.json
@@ -7,9 +7,9 @@
 	"category": "jetpack-search",
 	"icon": "filter",
 	"description": "Container for a stack of Jetpack Search filter blocks. Pre-populated with the most common filters; rearrange, remove, or add more from the inserter.",
+	"keywords": [ "search", "filter", "filters" ],
 	"supports": {
 		"html": false,
-		"interactivity": true,
 		"color": {
 			"background": true,
 			"text": true,
@@ -20,7 +20,7 @@
 			"margin": true,
 			"blockGap": true
 		},
-		"__experimentalBorder": {
+		"border": {
 			"color": true,
 			"radius": true,
 			"style": true,

--- a/projects/packages/search/src/search-blocks/blocks/common-filters/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/common-filters/edit.js
@@ -1,0 +1,38 @@
+/**
+ * Editor preview for jetpack/common-filters.
+ *
+ * Renders an InnerBlocks region pre-populated with the most common Jetpack
+ * Search filters. The container itself owns no behavior — it's a Group-like
+ * wrapper, so the front-end render.php just emits `$content` inside the
+ * block-wrapper div and lets each inner filter contribute its own markup.
+ */
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import { createElement as h } from '@wordpress/element';
+
+const TEMPLATE = [
+	[ 'jetpack/active-filters' ],
+	[ 'jetpack/filter-checkbox', { filterType: 'taxonomy', taxonomy: 'category' } ],
+	[ 'jetpack/filter-checkbox', { filterType: 'taxonomy', taxonomy: 'post_tag' } ],
+	[ 'jetpack/filter-checkbox', { filterType: 'author' } ],
+	[ 'jetpack/filter-checkbox', { filterType: 'post_type' } ],
+	[ 'jetpack/filter-date', { interval: 'year' } ],
+];
+
+const ALLOWED = [ 'jetpack/active-filters', 'jetpack/filter-checkbox', 'jetpack/filter-date' ];
+
+/**
+ * Edit component for the common-filters block.
+ *
+ * @return {object} Rendered element.
+ */
+export default function CommonFiltersEdit() {
+	const blockProps = useBlockProps( { className: 'jetpack-search-common-filters' } );
+	return h( 'div', blockProps, h( InnerBlocks, { template: TEMPLATE, allowedBlocks: ALLOWED } ) );
+}
+
+/**
+ * Save component — only renders InnerBlocks.Content.
+ *
+ * @return {object} Rendered element.
+ */
+export const save = () => h( InnerBlocks.Content, {} );

--- a/projects/packages/search/src/search-blocks/blocks/common-filters/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/common-filters/render.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Common Filters block render.
+ *
+ * Group-like wrapper that emits `$content` (the serialized inner block
+ * markup). Each inner filter handles its own state via the Interactivity API
+ * store; this block contributes only the surrounding chrome (block-wrapper
+ * attrs derived from color/spacing/border/typography supports).
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+?>
+<div <?php echo wp_kses_data( get_block_wrapper_attributes( array( 'class' => 'jetpack-search-common-filters' ) ) ); ?>>
+	<?php
+	// @phan-suppress-next-line PhanUndeclaredGlobalVariable -- $content is provided by WP at block render.
+	echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Inner block HTML is already escaped by each child block's renderer.
+	?>
+</div>

--- a/projects/packages/search/src/search-blocks/blocks/common-filters/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/common-filters/style.scss
@@ -1,0 +1,8 @@
+.jetpack-search-common-filters {
+	display: flex;
+	flex-direction: column;
+	// Default inter-filter spacing. Themes / block supports override this via
+	// the `--wp--style--block-gap` custom property emitted by the
+	// spacing.blockGap support.
+	gap: var(--wp--style--block-gap, 1rem);
+}

--- a/projects/packages/search/src/search-blocks/blocks/common-filters/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/common-filters/view.js
@@ -1,0 +1,1 @@
+import './style.scss';

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -19,6 +19,7 @@ import JetpackLogo from '@automattic/jetpack-components/jetpack-logo';
 import { getCategories, registerBlockType, setCategories } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import ActiveFiltersEdit from '../blocks/active-filters/edit';
+import CommonFiltersEdit, { save as commonFiltersSave } from '../blocks/common-filters/edit';
 import FilterCheckboxEdit from '../blocks/filter-checkbox/edit';
 import FilterDateEdit from '../blocks/filter-date/edit';
 import FilterPopoverEdit, { save as filterPopoverSave } from '../blocks/filter-popover/edit';
@@ -38,6 +39,7 @@ const BLOCKS = [
 	[ 'jetpack/filter-checkbox', FilterCheckboxEdit ],
 	[ 'jetpack/filter-date', FilterDateEdit ],
 	[ 'jetpack/active-filters', ActiveFiltersEdit ],
+	[ 'jetpack/common-filters', CommonFiltersEdit, commonFiltersSave ],
 	[ 'jetpack/filter-popover', FilterPopoverEdit, filterPopoverSave ],
 	[ 'jetpack/sort-control', SortControlEdit ],
 	[ 'jetpack/results-count', ResultsCountEdit ],

--- a/projects/packages/search/tests/js/search-blocks/common-filters-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/common-filters-edit.test.jsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import { InnerBlocks } from '@wordpress/block-editor';
+import CommonFiltersEdit from '../../../src/search-blocks/blocks/common-filters/edit';
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	useBlockProps: props => ( { ...props, className: props?.className } ),
+	InnerBlocks: jest.fn( () => <div data-testid="common-filters-inner-blocks" /> ),
+} ) );
+
+describe( 'CommonFiltersEdit', () => {
+	beforeEach( () => {
+		InnerBlocks.mockClear();
+	} );
+
+	it( 'renders InnerBlocks with the default filter template + allowedBlocks contract', () => {
+		render( <CommonFiltersEdit /> );
+
+		expect( screen.getByTestId( 'common-filters-inner-blocks' ) ).toBeInTheDocument();
+		const props = InnerBlocks.mock.calls[ 0 ][ 0 ];
+		expect( props.template ).toEqual( [
+			[ 'jetpack/active-filters' ],
+			[ 'jetpack/filter-checkbox', { filterType: 'taxonomy', taxonomy: 'category' } ],
+			[ 'jetpack/filter-checkbox', { filterType: 'taxonomy', taxonomy: 'post_tag' } ],
+			[ 'jetpack/filter-checkbox', { filterType: 'author' } ],
+			[ 'jetpack/filter-checkbox', { filterType: 'post_type' } ],
+			[ 'jetpack/filter-date', { interval: 'year' } ],
+		] );
+		expect( props.allowedBlocks ).toEqual( [
+			'jetpack/active-filters',
+			'jetpack/filter-checkbox',
+			'jetpack/filter-date',
+		] );
+	} );
+} );


### PR DESCRIPTION
## Why this matters
Building a search page with a filter sidebar today means dropping each filter block in by hand — active filters, then a checkbox per taxonomy, then post-type, then a date filter — and re-styling the lot every time. **Site owners** get a one-click starting point: insert the **Filters** block and the most common filters are already there, ready to be reordered, removed, or extended. **Search visitors** get a consistent inline filter UI that's the natural counterpart to the existing compact `filter-popover` (which only fits the dialog/popover layout). Themes and authors keep full control via the standard color / spacing / border / typography block supports.

Fixes RSM-2112 — https://linear.app/a8c/issue/RSM-2112/

## Proposed changes
* Adds `jetpack/common-filters`, a Group-like container block that holds a stack of common Jetpack Search filter inner blocks. Pre-populated with active-filters, category / tag / author / post-type checkboxes, and a year date filter. Users can rearrange, remove, or add filters via the inserter; each inner filter remains independently customizable through its own attributes.
* The container owns no behavior — `render.php` emits `get_block_wrapper_attributes()` + `$content`, so color / spacing / border / typography block supports flow through unchanged and the Interactivity API store the inner filters share continues to drive their state. `Search_Blocks::walk_blocks_for_filter_configs()` already recurses into `innerBlocks`, so filter configs nested inside `common-filters` are collected at seed time without any PHP changes.
* Differs from `jetpack/filter-popover` in interaction model: `filter-popover` is the compact trigger + dialog; `common-filters` is the always-visible inline stack. A follow-up issue tracks refactoring `filter-popover` to wrap a `common-filters` inner block once both ship.

## Related product discussion/links
* Linear issue: [RSM-2112](https://linear.app/a8c/issue/RSM-2112/add-jetpackcommon-filters-block-group-like-container-for-filter-inner)
* Project: [Jetpack Search blocks](https://linear.app/a8c/project/jetpack-search-blocks-be3579bef586/overview)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
1. Pull this branch, run `pnpm install`, then build the package:
   - `cd projects/packages/search && pnpm run build-blocks && pnpm run build-blocks-editor`
2. Open a page in the Site Editor (or a regular page edit screen).
3. In the inserter, type "Filters" and pick the new **Filters** block under the Search category.
4. Confirm the block inserts with the default template: active-filters pill row, then Category / Tag / Author / Post Type checkbox filters, then a Year date filter.
5. Confirm you can:
   - Reorder inner filter blocks.
   - Remove any inner filter and re-add it from the block's appender.
   - Add another `filter-checkbox` variation (e.g. Custom Taxonomy) or another `filter-date` instance.
6. Open the block's sidebar and apply Color (background / text), Spacing (padding / margin / block-gap), Border, and Typography settings — confirm they take effect in the editor preview.
7. Save the page and view it on the front end with `?s=anything`. Confirm:
   - The block renders as a flex column of filter blocks.
   - Each inner filter still hydrates and updates the URL on selection (i.e. no regression vs. dropping the filter blocks individually).
   - The block-supports styling (background / spacing / border / typography) is applied to the front-end wrapper.


## Screenshots

Captured against the per-agent local docker WP (`https://jp-echo.jurassic.tube/`) at 1440×900 with the new block inserted via the standard inserter.

### Editor — block discoverable in inserter

`Search` category surfaces the new **Filters** block alongside existing `Active Filters` / `Product Filters`.

<img width="599" height="570" alt="image" src="https://github.com/user-attachments/assets/d23ac9a6-2fd4-4ff3-b5ed-91f2f8307a3f" />


### Front end — inner filters hydrate against live aggregations

The `twentytwentyfive//jetpack-search` template's right column was swapped to a single `<!-- wp:jetpack/common-filters /-->` (with the default inner blocks) and `?s=wordpress` was visited. All five inner filters render with real bucket counts — Category, Tag, Author, Post Type, and Year — proving the seed-time `walk_blocks_for_filter_configs()` recursion picks up filter configs nested inside the new container.

![frontend](https://github.com/user-attachments/assets/088cd23e-be51-414a-83e1-bd47fc37fbcd)
