### PR TITLE
Wpcomsh fatal-error: log deactivate clicks; stamp atomic_site_id

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-wpcomsh-fatal-error-deactivate-log
+++ b/projects/plugins/wpcomsh/changelog/add-wpcomsh-fatal-error-deactivate-log
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Wpcomsh fatal-error: log a `wpcomsh_fatal_deactivate` event when an admin clicks the Deactivate button on the fatal-error screen, so we can tell which fatals lead to user-initiated deactivations. Both the deactivate event and the existing `wpcomsh_fatal_signature` event now also carry `properties.atomic_site_id` for site-axis grouping.

--- a/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-helpers.php
+++ b/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-helpers.php
@@ -112,33 +112,56 @@ function wpcomsh_fatal_identify_plugin( $error ) {
 }
 
 /**
- * Ship the offending extension's signature to wpcomsh logstash via
- * WPCOMSH_Log::unsafe_direct_log_logstash(), alongside the decoded parts
- * so dashboards can aggregate without decoding the signature.
+ * Log that an admin clicked the "Deactivate" button on the fatal-error screen.
+ * Identifies the extension from its basename so the deactivate event carries
+ * the same shape as the signature event; falls through silently if the plugin
+ * file is no longer on disk.
  *
- * Routed to the `/logstash` endpoint under feature
- * `atomic_extension_conflict` with severity `critical` so these surface
- * in their own Kibana bucket (the default `feature:automated_transfer`
- * stream is too noisy to alert on).
- *
- * Manual require: the fatal-error module loads from wpcomsh.php line
- * 1, before the autoloader runs. Direct requires with class_exists(
- * …, false ) skip the autoloader during fatal handling, where its
- * filesystem reads could compound a bad state.
- *
- * Best-effort: silently no-ops if either dependency is unreachable.
- * A logging failure must never escalate into a second fatal.
- *
- * @param array|null $plugin Extension metadata from wpcomsh_fatal_identify_plugin().
+ * @param string $plugin_basename Plugin basename relative to WP_PLUGIN_DIR (e.g. "akismet/akismet.php").
  * @return void
  */
-function wpcomsh_fatal_log_signature( $plugin ) {
+function wpcomsh_fatal_log_deactivate( $plugin_basename ) {
+	if ( ! is_string( $plugin_basename ) || '' === $plugin_basename ) {
+		return;
+	}
+
+	$plugin = wpcomsh_fatal_identify_plugin( array( 'file' => WP_PLUGIN_DIR . '/' . $plugin_basename ) );
+	if ( ! is_array( $plugin ) ) {
+		return;
+	}
+
+	wpcomsh_fatal_log_event( $plugin, 'wpcomsh_fatal_deactivate' );
+}
+
+/**
+ * Emit a fatal-error event via WPCOMSH_Log::unsafe_direct_log_logstash(),
+ * alongside the decoded signature parts so consumers don't have to decode
+ * the signature themselves.
+ *
+ * Callable from both the fatal-screen render path and the deactivator
+ * endpoint at mu-plugin load time. The deactivator path runs before
+ * constants.php, so we resolve the wpcomsh root via `dirname(__DIR__)`
+ * rather than WPCOMSH__PLUGIN_DIR_PATH.
+ *
+ * Manual require with `class_exists( …, false )` skips the autoloader during
+ * fatal handling, where its filesystem reads could compound a bad state.
+ *
+ * Best-effort: silently no-ops if either dependency is unreachable. A logging
+ * failure must never escalate into a second fatal.
+ *
+ * @param array|null $plugin  Extension metadata from wpcomsh_fatal_identify_plugin().
+ * @param string     $message Event message slug (e.g. `wpcomsh_fatal_signature`, `wpcomsh_fatal_deactivate`).
+ * @return void
+ */
+function wpcomsh_fatal_log_event( $plugin, $message ) {
 	if ( ! is_array( $plugin ) || empty( $plugin['slug'] ) || empty( $plugin['kind'] ) ) {
 		return;
 	}
 
-	if ( ! function_exists( 'wpcom_build_fatal_error_signature' ) && defined( 'WPCOMSH__PLUGIN_DIR_PATH' ) ) {
-		$helper = WPCOMSH__PLUGIN_DIR_PATH . '/jetpack_vendor/automattic/jetpack-mu-wpcom/src/common/fatal-error-signature.php';
+	$wpcomsh_root = dirname( __DIR__ );
+
+	if ( ! function_exists( 'wpcom_build_fatal_error_signature' ) ) {
+		$helper = $wpcomsh_root . '/jetpack_vendor/automattic/jetpack-mu-wpcom/src/common/fatal-error-signature.php';
 		if ( is_readable( $helper ) ) {
 			require_once $helper;
 		}
@@ -158,10 +181,11 @@ function wpcomsh_fatal_log_signature( $plugin ) {
 		return;
 	}
 
-	// Dedup per signature for 5 min so a persistent fatal doesn't emit
-	// one logstash row + one outbound HTTP per visitor. Gated before
-	// the WPCOMSH_Log require so dedup hits skip the file load too.
-	$cache_key = 'wpcomsh_fatal_sig:' . hash( 'sha256', $signature );
+	// Dedup per (message, signature) for 5 min so a persistent fatal doesn't
+	// emit one log row + one outbound HTTP per visitor. $message is part of
+	// the key so a deactivate event isn't suppressed by a recent signature
+	// event for the same extension.
+	$cache_key = 'wpcomsh_fatal_event:' . hash( 'sha256', $message . '|' . $signature );
 	try {
 		if ( ! wp_cache_add( $cache_key, 1, 'wpcomsh', 5 * MINUTE_IN_SECONDS ) ) {
 			return;
@@ -170,8 +194,8 @@ function wpcomsh_fatal_log_signature( $plugin ) {
 		// Fall through and log.
 	}
 
-	if ( ! class_exists( 'WPCOMSH_Log', false ) && defined( 'WPCOMSH__PLUGIN_DIR_PATH' ) ) {
-		$log_file = WPCOMSH__PLUGIN_DIR_PATH . '/class-wpcomsh-log.php';
+	if ( ! class_exists( 'WPCOMSH_Log', false ) ) {
+		$log_file = $wpcomsh_root . '/class-wpcomsh-log.php';
 		if ( is_readable( $log_file ) ) {
 			require_once $log_file;
 		}
@@ -191,6 +215,23 @@ function wpcomsh_fatal_log_signature( $plugin ) {
 		// Fall through.
 	}
 
+	// Prefer the constant: it's set on Atomic and avoids the apply_filters()
+	// dispatch inside wpcomsh_get_atomic_site_id(). Fall back to the helper
+	// only when the constant isn't defined; guard the call because the helper
+	// runs the `wpcomsh_get_atomic_site_id` filter, and a misbehaving callback
+	// must not bubble out of this best-effort logger.
+	$atomic_site_id = defined( 'ATOMIC_SITE_ID' ) ? (int) ATOMIC_SITE_ID : 0;
+	if ( 0 === $atomic_site_id && function_exists( 'wpcomsh_get_atomic_site_id' ) ) {
+		try {
+			$atomic_site_id = (int) wpcomsh_get_atomic_site_id();
+		} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- best-effort; omit atomic_site_id if a filter misbehaves.
+			// Fall through.
+		}
+	}
+	if ( $atomic_site_id > 0 ) {
+		$properties['atomic_site_id'] = $atomic_site_id;
+	}
+
 	// Round-trip through the decoder so the logged parts always agree
 	// with the signature.
 	if ( function_exists( 'wpcom_decode_fatal_error_signature' ) ) {
@@ -207,7 +248,7 @@ function wpcomsh_fatal_log_signature( $plugin ) {
 	try {
 		\WPCOMSH_Log::unsafe_direct_log_logstash(
 			'atomic_extension_conflict',
-			'wpcomsh_fatal_signature',
+			$message,
 			array(
 				'severity'   => 'critical',
 				'properties' => $properties,

--- a/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-screen.php
+++ b/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-screen.php
@@ -40,7 +40,7 @@ function wpcomsh_customize_fatal_error_message( $message, $error = array() ) { /
 
 	if ( $is_admin ) {
 		$plugin = wpcomsh_fatal_identify_plugin( $error );
-		wpcomsh_fatal_log_signature( $plugin );
+		wpcomsh_fatal_log_event( $plugin, 'wpcomsh_fatal_signature' );
 	} elseif ( ! empty( $error['file'] ) ) {
 		$coarse_key = 'wpcomsh_fatal_file:' . hash( 'sha256', (string) $error['file'] );
 		$do_log     = true;
@@ -52,7 +52,7 @@ function wpcomsh_customize_fatal_error_message( $message, $error = array() ) { /
 		}
 
 		if ( $do_log ) {
-			wpcomsh_fatal_log_signature( wpcomsh_fatal_identify_plugin( $error ) );
+			wpcomsh_fatal_log_event( wpcomsh_fatal_identify_plugin( $error ), 'wpcomsh_fatal_signature' );
 		}
 	}
 

--- a/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-plugin-deactivator.php
+++ b/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-plugin-deactivator.php
@@ -90,6 +90,10 @@ function wpcomsh_fatal_maybe_deactivate_plugin() {
 		return;
 	}
 
+	// Logged via WPCOMSH_Log's shutdown drain, which runs after the redirect's
+	// exit — the queued payload still ships.
+	wpcomsh_fatal_log_deactivate( $plugin );
+
 	// Persist + redirect immediately at mu-plugin load, before core enters the
 	// regular plugin-include pass. Deferring this to plugins_loaded would mean
 	// any *other* broken plugin in active_plugins fatals before our callback


### PR DESCRIPTION
Fixes #

## Proposed changes

Follow-up to #48401. Two related additions to wpcomsh fatal-error telemetry:

* **`wpcomsh_fatal_deactivate` event.** When a logged-in admin clicks the *Deactivate* button on the fatal-error screen, the signed deactivator endpoint (`fatal-plugin-deactivator.php`) now emits a `wpcomsh_fatal_deactivate` event via `WPCOMSH_Log::unsafe_direct_log_logstash()` before persisting the option update. Pairs with the existing `wpcomsh_fatal_signature` event so we can tell which fatals lead to user-initiated deactivations vs. recovery-mode entry vs. abandonment. Logged via `WPCOMSH_Log`'s shutdown drain, which runs after the redirect's `exit` — the queued payload still ships.
* **`properties.atomic_site_id` on both events.** Both `wpcomsh_fatal_signature` (existing) and `wpcomsh_fatal_deactivate` (new) now stamp `properties.atomic_site_id`, sourced from the `ATOMIC_SITE_ID` constant first (avoids an `apply_filters()` dispatch on the common path) and falling back to `wpcomsh_get_atomic_site_id()` when the constant is undefined. Stamps are skipped when the resolved id is 0 (off-Atomic / unresolved).

### Implementation notes

* The previous single-purpose `wpcomsh_fatal_log_signature()` was refactored into `wpcomsh_fatal_log_event( \$plugin, \$message )` so both events share the signature / dedup / properties pipeline. The dedup cache key now includes the message (`wpcomsh_fatal_event:HASH(message|signature)`) so a recent signature event for an extension doesn't suppress the matching deactivate event.
* The deactivator endpoint runs at mu-plugin load time, *before* `wpcomsh.php` line 28 loads `constants.php`, so `WPCOMSH__PLUGIN_DIR_PATH` is undefined when it fires. Manual requires now resolve the wpcomsh root via \`dirname(__DIR__)\` instead, which is correct in both the deactivator path and the fatal-screen render path.
* The `wpcomsh_get_atomic_site_id()` fallback is wrapped in `try { … } catch ( \Throwable )` because the helper runs the `wpcomsh_get_atomic_site_id` filter — a misbehaving callback must not bubble out of a best-effort logger.

## Related product discussion/links

* Follow-up to #48401 (which is itself a follow-up to #48399 / #48369).

## Does this pull request change what data or activity we track or use?

**Yes — additively.** Two new fields ship in the `feature:atomic_extension_conflict` log stream:

* A new event message, `wpcomsh_fatal_deactivate`, fires only when a logged-in admin (passing the existing `deactivate_plugin` capability check + HMAC signature on the deactivator endpoint) clicks *Deactivate* on the fatal-error screen. Payload shape mirrors `wpcomsh_fatal_signature`: `signature`, `kind`, `slug`, `extension_version`, `wp_version`, `php_version`, `site_url`, plus the new `atomic_site_id`.
* `properties.atomic_site_id` (integer site id from the `ATOMIC_SITE_ID` constant or `wpcomsh_get_atomic_site_id()` filter) is stamped on both events. This is the same site id already exposed at \`atomic_site_id\` in the `feature:atomic_global_styles_gate` payload elsewhere in this plugin — no new per-site identifier is being introduced, just included on these two records.

Both fields are non-PII server-side metadata about the site itself. No user-level data is collected.

## Testing instructions

1. On an Atomic test site, trigger a fatal from a directory-based plugin (e.g. drop a `boom/boom.php` containing `trigger_error( 'boom', E_USER_ERROR )` on `init`).
2. Visit the site as an admin and confirm the fatal-error screen renders the Deactivate action.
3. Open the wpcomsh log stream (`feature:atomic_extension_conflict`) and confirm the initial `wpcomsh_fatal_signature` record now carries `properties.atomic_site_id` alongside the other indexed fields.
4. Click *Deactivate*. You should land on `wp-admin/plugins.php?wpcomsh_deactivated=…`. In the same log stream, confirm a `wpcomsh_fatal_deactivate` record arrives with the same `signature` / `slug` / `kind` / `extension_version` as the corresponding fatal record, plus `atomic_site_id` and `site_url`.
5. **Verify dedup.** Re-trigger the fatal within 5 minutes and confirm no duplicate `wpcomsh_fatal_signature` row arrives. Re-submit a deactivate form within the same window and confirm no duplicate `wpcomsh_fatal_deactivate` row arrives. The two events do *not* dedup against each other (the cache key includes the message).
6. **Verify off-Atomic safety.** On a non-Atomic dev site (no `ATOMIC_SITE_ID` constant, no `wpcomsh_get_atomic_site_id` filter), trigger a fatal and confirm the event payload omits `atomic_site_id` rather than emitting `0`.
7. **Verify deactivator load order.** Confirm the deactivator path (POST to `home_url('/')` with `wpcomsh_deactivate=…&wpcomsh_sig=…&wpcomsh_exp=…`) still completes the redirect normally and produces a `wpcomsh_fatal_deactivate` log row, even though it runs before `constants.php` loads `WPCOMSH__PLUGIN_DIR_PATH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)