### PR TITLE
Social: surface available placeholders in the custom message field

### DIFF
--- a/projects/packages/publicize/_inc/components/message-box-control/index.tsx
+++ b/projects/packages/publicize/_inc/components/message-box-control/index.tsx
@@ -1,13 +1,28 @@
+import { siteHasFeature } from '@automattic/jetpack-script-data';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { TextareaControl } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useCallback, useRef } from 'react';
+import { features } from '../../utils/constants';
+import PlaceholdersHelp from './placeholders-help';
 import styles from './styles.module.scss';
 
 export const getPlaceholderText = () =>
 	__(
 		'Write a custom message for your social audience here. This message will override your social post content.',
 		'jetpack-publicize-pkg'
+	);
+
+export const getTemplatesPlaceholderText = () =>
+	sprintf(
+		/* translators: %1$s and %2$s are placeholders for the post. e.g. {title} and {url}. */
+		__(
+			'Customize how this post is shared. Use placeholders like %1$s or %2$s - those will be filled in when the post is shared.',
+			'jetpack-publicize-pkg'
+		),
+		'{title}',
+		'{url}'
 	);
 
 export const getDefaultLabel = () => __( 'Message', 'jetpack-publicize-pkg' );
@@ -47,7 +62,7 @@ export type MessageBoxControlProps = {
  */
 export default function MessageBoxControl( {
 	label = getDefaultLabel(),
-	placeholder = getPlaceholderText(),
+	placeholder,
 	message = '',
 	onChange,
 	disabled,
@@ -56,6 +71,8 @@ export default function MessageBoxControl( {
 }: MessageBoxControlProps ) {
 	const { recordEvent } = useAnalytics();
 	const isFirstChange = useRef( true );
+
+	const templatesEnabled = siteHasFeature( features.MESSAGE_TEMPLATES );
 
 	const charactersRemaining = maxLength - message.length;
 
@@ -70,16 +87,26 @@ export default function MessageBoxControl( {
 		[ analyticsData, isFirstChange, onChange, recordEvent ]
 	);
 
-	return (
-		<TextareaControl
-			value={ message }
-			label={ label }
-			onChange={ handleChange }
-			disabled={ disabled }
-			maxLength={ maxLength }
-			placeholder={ placeholder }
-			rows={ 4 }
-			help={ sprintf(
+	const resolvedPlaceholder =
+		placeholder ?? ( templatesEnabled ? getTemplatesPlaceholderText() : getPlaceholderText() );
+
+	// When templates are enabled, the message can contain placeholders that expand
+	// at share time, so the raw textarea length isn't a meaningful character budget.
+	// Skip both the maxLength cap and the "characters remaining" counter, and instead
+	// wire the help slot to a placeholder-aware description that screen readers will
+	// announce via aria-describedby (which BaseControl sets on the textarea).
+	const help = templatesEnabled
+		? createInterpolateElement(
+				__(
+					'Supports placeholders like <title/> and <url/>. See the list below for all options.',
+					'jetpack-publicize-pkg'
+				),
+				{
+					title: <code>{ '{title}' }</code>,
+					url: <code>{ '{url}' }</code>,
+				}
+		  )
+		: sprintf(
 				/* translators: %d: the number of characters remaining. */
 				_n(
 					'%d character remaining',
@@ -88,9 +115,22 @@ export default function MessageBoxControl( {
 					'jetpack-publicize-pkg'
 				),
 				charactersRemaining
-			) }
-			__nextHasNoMarginBottom={ true }
-			className={ styles[ 'message-box-control' ] }
-		/>
+		  );
+
+	return (
+		<div className={ styles[ 'message-box-control' ] }>
+			<TextareaControl
+				value={ message }
+				label={ label }
+				onChange={ handleChange }
+				disabled={ disabled }
+				maxLength={ templatesEnabled ? undefined : maxLength }
+				placeholder={ resolvedPlaceholder }
+				rows={ 4 }
+				help={ help }
+				__nextHasNoMarginBottom={ true }
+			/>
+			{ templatesEnabled && <PlaceholdersHelp /> }
+		</div>
 	);
 }

--- a/projects/packages/publicize/_inc/components/message-box-control/placeholders-help.tsx
+++ b/projects/packages/publicize/_inc/components/message-box-control/placeholders-help.tsx
@@ -1,0 +1,78 @@
+import { Button, Dropdown } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useCallback, useMemo } from 'react';
+import styles from './styles.module.scss';
+
+type DropdownProps = React.ComponentProps< typeof Dropdown >;
+
+type Placeholder = {
+	token: string;
+	description: string;
+};
+
+// TODO: SOCIAL-471 — replace this hardcoded list with a fetch from WPCOM.
+const getPlaceholders = (): Placeholder[] => [
+	{ token: '{title}', description: __( 'Post title', 'jetpack-publicize-pkg' ) },
+	{ token: '{excerpt}', description: __( 'Post excerpt', 'jetpack-publicize-pkg' ) },
+	{ token: '{content}', description: __( 'Full post content', 'jetpack-publicize-pkg' ) },
+	{ token: '{url}', description: __( 'Permalink to the post', 'jetpack-publicize-pkg' ) },
+	{ token: '{short_url}', description: __( 'Short URL of the post', 'jetpack-publicize-pkg' ) },
+	{ token: '{tags}', description: __( 'Post tags as hashtags', 'jetpack-publicize-pkg' ) },
+	{ token: '{categories}', description: __( 'Post categories', 'jetpack-publicize-pkg' ) },
+	{ token: '{author}', description: __( 'Author display name', 'jetpack-publicize-pkg' ) },
+	{ token: '{date}', description: __( 'Publication date', 'jetpack-publicize-pkg' ) },
+	{ token: '{site_name}', description: __( 'Site title', 'jetpack-publicize-pkg' ) },
+	{ token: '{site_url}', description: __( 'Site URL', 'jetpack-publicize-pkg' ) },
+	{ token: '{meta:<key>}', description: __( 'Custom field value', 'jetpack-publicize-pkg' ) },
+];
+
+/**
+ * Toggle that reveals the list of placeholders supported in the custom message field.
+ *
+ * @return Element rendered next to the textarea help text.
+ */
+export default function PlaceholdersHelp() {
+	const placeholders = useMemo( getPlaceholders, [] );
+
+	const renderToggle = useCallback< DropdownProps[ 'renderToggle' ] >(
+		( { onToggle, isOpen } ) => (
+			<Button variant="link" onClick={ onToggle } aria-expanded={ isOpen }>
+				{ __( 'Available placeholders', 'jetpack-publicize-pkg' ) }
+			</Button>
+		),
+		[]
+	);
+
+	const renderContent = useCallback(
+		() => (
+			<div className={ styles[ 'placeholders-help-content' ] }>
+				<p>
+					{ __(
+						'Use placeholders to automatically insert post details.',
+						'jetpack-publicize-pkg'
+					) }
+				</p>
+				<ul>
+					{ placeholders.map( ( { token, description } ) => (
+						<li key={ token }>
+							<code>{ token }</code>
+							<span>{ description }</span>
+						</li>
+					) ) }
+				</ul>
+			</div>
+		),
+		[ placeholders ]
+	);
+
+	return (
+		<Dropdown
+			focusOnMount
+			popoverProps={ { placement: 'bottom-start' } }
+			renderToggle={ renderToggle }
+			renderContent={ renderContent }
+			className={ styles[ 'placeholders-help' ] }
+			contentClassName={ styles[ 'placeholders-help-popover' ] }
+		/>
+	);
+}

--- a/projects/packages/publicize/_inc/components/message-box-control/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/message-box-control/styles.module.scss
@@ -6,3 +6,49 @@
 		background-color: gb.$gray-100;
 	}
 }
+
+.placeholders-help {
+
+	&:global(.components-dropdown) {
+		display: inline-flex;
+		margin-top: 4px;
+	}
+}
+
+.placeholders-help-popover {
+
+	:global(.components-popover__content) {
+		max-width: 22rem;
+		min-width: 16rem;
+		padding: 1rem;
+	}
+}
+
+.placeholders-help-content {
+
+	p {
+		margin: 0 0 0.75rem;
+	}
+
+	ul {
+		display: grid;
+		grid-template-columns: max-content 1fr;
+		gap: 0.25rem 0.75rem;
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	li {
+		display: contents;
+
+		code {
+			font-size: 0.85em;
+			white-space: nowrap;
+		}
+
+		span {
+			color: var(--jp-gray-70, gb.$gray-700);
+		}
+	}
+}

--- a/projects/packages/publicize/_inc/components/message-box-control/tests/index.test.js
+++ b/projects/packages/publicize/_inc/components/message-box-control/tests/index.test.js
@@ -1,12 +1,21 @@
-import { render, screen } from '@testing-library/react';
+import { siteHasFeature } from '@automattic/jetpack-script-data';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import MessageBoxControl, { getDefaultLabel, getPlaceholderText } from '../';
+import MessageBoxControl, {
+	getDefaultLabel,
+	getPlaceholderText,
+	getTemplatesPlaceholderText,
+} from '../';
 
 const mockRecordEvent = jest.fn();
 jest.mock( '@automattic/jetpack-shared-extension-utils', () => ( {
 	useAnalytics: () => ( {
 		recordEvent: mockRecordEvent,
 	} ),
+} ) );
+
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	siteHasFeature: jest.fn().mockReturnValue( false ),
 } ) );
 
 describe( 'MessageBoxControl', () => {
@@ -17,6 +26,7 @@ describe( 'MessageBoxControl', () => {
 
 	beforeEach( () => {
 		jest.clearAllMocks();
+		siteHasFeature.mockReturnValue( false );
 	} );
 
 	it( 'renders with the provided message', () => {
@@ -122,12 +132,100 @@ describe( 'MessageBoxControl', () => {
 		expect( textArea ).toHaveAttribute( 'maxLength', shortMaxLength.toString() );
 	} );
 
-	it( 'shows correct placeholder text', () => {
+	it( 'shows the default placeholder text when templates feature is off', () => {
 		render(
 			<MessageBoxControl message="" onChange={ mockOnChange } maxLength={ mockMaxLength } />
 		);
 
 		const textArea = screen.getByPlaceholderText( getPlaceholderText() );
 		expect( textArea ).toBeInTheDocument();
+	} );
+
+	it( 'does not show the placeholders help when templates feature is off', () => {
+		render(
+			<MessageBoxControl message="" onChange={ mockOnChange } maxLength={ mockMaxLength } />
+		);
+
+		expect(
+			screen.queryByRole( 'button', { name: 'Available placeholders' } )
+		).not.toBeInTheDocument();
+	} );
+
+	describe( 'when templates feature is on', () => {
+		beforeEach( () => {
+			siteHasFeature.mockReturnValue( true );
+		} );
+
+		it( 'shows the templates-aware placeholder text', () => {
+			render(
+				<MessageBoxControl message="" onChange={ mockOnChange } maxLength={ mockMaxLength } />
+			);
+
+			const textArea = screen.getByPlaceholderText( getTemplatesPlaceholderText() );
+			expect( textArea ).toBeInTheDocument();
+		} );
+
+		it( 'shows the placeholders help toggle', () => {
+			render(
+				<MessageBoxControl message="" onChange={ mockOnChange } maxLength={ mockMaxLength } />
+			);
+
+			expect(
+				screen.getByRole( 'button', { name: 'Available placeholders' } )
+			).toBeInTheDocument();
+		} );
+
+		it( 'reveals the placeholder list when toggle is clicked', async () => {
+			render(
+				<MessageBoxControl message="" onChange={ mockOnChange } maxLength={ mockMaxLength } />
+			);
+
+			await userEvent.click( screen.getByRole( 'button', { name: 'Available placeholders' } ) );
+
+			// Scope queries to the popover-rendered list — `{title}` and `{url}`
+			// also appear in the textarea help text via createInterpolateElement.
+			const list = screen.getByRole( 'list' );
+			expect( within( list ).getByText( '{title}' ) ).toBeInTheDocument();
+			expect( within( list ).getByText( '{url}' ) ).toBeInTheDocument();
+			expect( within( list ).getByText( '{tags}' ) ).toBeInTheDocument();
+		} );
+
+		it( 'still respects an explicit placeholder prop', () => {
+			render(
+				<MessageBoxControl
+					message=""
+					onChange={ mockOnChange }
+					maxLength={ mockMaxLength }
+					placeholder="Custom placeholder"
+				/>
+			);
+
+			expect( screen.getByPlaceholderText( 'Custom placeholder' ) ).toBeInTheDocument();
+		} );
+
+		it( 'does not enforce a maxLength on the textarea', () => {
+			render(
+				<MessageBoxControl
+					message={ mockMessage }
+					onChange={ mockOnChange }
+					maxLength={ mockMaxLength }
+				/>
+			);
+
+			expect( screen.getByLabelText( getDefaultLabel() ) ).not.toHaveAttribute( 'maxLength' );
+		} );
+
+		it( 'does not show the characters-remaining counter', () => {
+			render(
+				<MessageBoxControl
+					message={ mockMessage }
+					onChange={ mockOnChange }
+					maxLength={ mockMaxLength }
+				/>
+			);
+
+			expect( screen.queryByText( /characters remaining/ ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( /character remaining/ ) ).not.toBeInTheDocument();
+		} );
 	} );
 } );

--- a/projects/packages/publicize/changelog/social-447-add-placeholder-support-to-custom-message-field
+++ b/projects/packages/publicize/changelog/social-447-add-placeholder-support-to-custom-message-field
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Custom message field: Surface available placeholders for Message Templates feature.

--- a/projects/packages/publicize/src/class-publicize-ui.php
+++ b/projects/packages/publicize/src/class-publicize-ui.php
@@ -411,6 +411,9 @@ jQuery( function($) {
 	font-size: 16px;
 	text-decoration: none;
 }
+.publicize-placeholders-help {
+	margin: 0.5rem 0 1rem;
+}
 </style>
 		<?php
 	}
@@ -580,14 +583,36 @@ jQuery( function($) {
 
 		$is_post_published = 'publish' === get_post_status( $post->ID );
 
+		$templates_enabled = Current_Plan::supports( 'social-message-templates' );
+
+		$placeholders = $this->get_message_placeholders();
+
 		?>
 
 			</ul>
 
 			<?php if ( ! $is_social_note ) : ?>
 				<label for="wpas-title"><?php esc_html_e( 'Custom Message:', 'jetpack-publicize-pkg' ); ?></label>
-				<span id="wpas-title-counter" class="alignright hide-if-no-js">0</span>
+				<?php if ( ! $templates_enabled ) : ?>
+					<span id="wpas-title-counter" class="alignright hide-if-no-js">0</span>
+				<?php endif; ?>
 				<textarea name="wpas_title" id="wpas-title"><?php echo esc_textarea( $title ); ?></textarea>
+				<?php if ( $templates_enabled ) : ?>
+					<details class="publicize-placeholders-help">
+						<summary><?php esc_html_e( 'Available placeholders', 'jetpack-publicize-pkg' ); ?></summary>
+						<p>
+							<?php esc_html_e( 'Use placeholders to automatically insert post details.', 'jetpack-publicize-pkg' ); ?>
+						</p>
+						<ul>
+							<?php foreach ( $placeholders as $placeholder ) : ?>
+								<li>
+									<code><?php echo esc_html( $placeholder['token'] ); ?></code>
+									&mdash; <?php echo esc_html( $placeholder['description'] ); ?>
+								</li>
+							<?php endforeach; ?>
+						</ul>
+					</details>
+				<?php endif; ?>
 				<a href="#" class="hide-if-no-js button" id="publicize-form-hide"><?php esc_html_e( 'OK', 'jetpack-publicize-pkg' ); ?></a>
 				<input type="hidden" name="wpas[0]" value="1" />
 			<?php endif; ?>
@@ -604,5 +629,65 @@ jQuery( function($) {
 		<?php
 
 		return ob_get_clean();
+	}
+
+	/**
+	 * Get the list of placeholders supported in custom Publicize messages.
+	 *
+	 * TODO: SOCIAL-471 — replace this hardcoded list with a fetch from WPCOM.
+	 *
+	 * @return array<int, array{token: string, description: string}>
+	 */
+	private function get_message_placeholders() {
+		return array(
+			array(
+				'token'       => '{title}',
+				'description' => __( 'Post title', 'jetpack-publicize-pkg' ),
+			),
+			array(
+				'token'       => '{excerpt}',
+				'description' => __( 'Post excerpt', 'jetpack-publicize-pkg' ),
+			),
+			array(
+				'token'       => '{content}',
+				'description' => __( 'Full post content', 'jetpack-publicize-pkg' ),
+			),
+			array(
+				'token'       => '{url}',
+				'description' => __( 'Permalink to the post', 'jetpack-publicize-pkg' ),
+			),
+			array(
+				'token'       => '{short_url}',
+				'description' => __( 'Short URL of the post', 'jetpack-publicize-pkg' ),
+			),
+			array(
+				'token'       => '{tags}',
+				'description' => __( 'Post tags as hashtags', 'jetpack-publicize-pkg' ),
+			),
+			array(
+				'token'       => '{categories}',
+				'description' => __( 'Post categories', 'jetpack-publicize-pkg' ),
+			),
+			array(
+				'token'       => '{author}',
+				'description' => __( 'Author display name', 'jetpack-publicize-pkg' ),
+			),
+			array(
+				'token'       => '{date}',
+				'description' => __( 'Publication date', 'jetpack-publicize-pkg' ),
+			),
+			array(
+				'token'       => '{site_name}',
+				'description' => __( 'Site title', 'jetpack-publicize-pkg' ),
+			),
+			array(
+				'token'       => '{site_url}',
+				'description' => __( 'Site URL', 'jetpack-publicize-pkg' ),
+			),
+			array(
+				'token'       => '{meta:<key>}',
+				'description' => __( 'Custom field value', 'jetpack-publicize-pkg' ),
+			),
+		);
 	}
 }


### PR DESCRIPTION
Completes SOCIAL-447
## Proposed changes
* When the `social-message-templates` feature is enabled, the custom message textarea now surfaces the placeholders supported by the template engine (`{title}`, `{url}`, `{tags}`, …) on both surfaces:
  * **Block editor**: a `Dropdown` next to `MessageBoxControl` reveals the full list. The textarea help slot is wired to a placeholder-aware description (announced via `aria-describedby` that `BaseControl` already adds), and the per-network character cap and counter are dropped because placeholders expand at share time.
  * **Classic editor metabox**: an inline `<details>` block lists the same placeholders, sourced from a shared `get_message_placeholders()` method; the title-counter span is also skipped when the feature is on.
* When the flag is off, both surfaces look and behave exactly as today.
* Both placeholder lists carry a `TODO: SOCIAL-471` referencing the planned WPCOM REST endpoint that will become the single source of truth.

## Related product discussion/links
* SOCIAL-447

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

**Block editor**
1. Open a post in the block editor on a site that has the `social-message-templates` feature.
2. Click "Preview and customize" on the Jetpack Social panel.
3. In the **Message** field, confirm:
   * The placeholder text mentions placeholders.
   * The "characters remaining" counter is gone, and typing past the network limit is no longer blocked.
   * Below the textarea, an "Available placeholders" link reveals a popover with the full list.
   * Clicking outside the popover closes it.
4. Toggle the feature flag off and confirm the field reverts to the legacy placeholder text + character counter.

**Classic editor metabox**
1. Disable Gutenberg for a post type (or use the Classic Editor plugin) on a site with the feature on.
2. Edit a post and open the "Jetpack Social" metabox in the publish sidebar.
3. Confirm the `<details>` "Available placeholders" disclosure appears under the textarea, the same placeholders are listed, and the character counter span is gone.
4. Toggle the flag off and confirm the legacy metabox renders unchanged.

| Block editor | Classic editor |
|--------|-------|
| <img width="395" height="747" alt="Screenshot 2026-05-04 at 9 44 48 AM" src="https://github.com/user-attachments/assets/bc5b7610-178c-4c65-ae51-ddae43fc9aad" /> | <img width="288" height="439" alt="Screenshot 2026-05-04 at 10 08 31 AM" src="https://github.com/user-attachments/assets/3c93092e-7971-4a27-9369-50f9cb4432ca" /> |

🤖 Generated with [Claude Code](https://claude.com/claude-code)