### PR TITLE
Connection: Fix connector card UI and redirect issues

### DIFF
--- a/projects/packages/connection/changelog/fix-connector-card-improvements
+++ b/projects/packages/connection/changelog/fix-connector-card-improvements
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Connector card: Fix description padding not reserving space in Chrome, reset connecting state on back-button navigation, use text label instead of busy stripes on link-style disconnect button, and honor redirect parameter after already-authorized webhook.

--- a/projects/packages/connection/src/class-webhooks.php
+++ b/projects/packages/connection/src/class-webhooks.php
@@ -101,6 +101,16 @@ class Webhooks {
 	public function handle_authorize() {
 		if ( $this->connection->is_connected() && $this->connection->is_user_connected() ) {
 			$redirect_url = apply_filters( 'jetpack_client_authorize_already_authorized_url', admin_url() );
+
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only; redirect is validated below.
+			if ( ! empty( $_GET['redirect'] ) ) {
+				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- sanitized by esc_url_raw.
+				$explicit = esc_url_raw( wp_unslash( $_GET['redirect'] ) );
+				if ( wp_validate_redirect( $explicit ) ) {
+					$redirect_url = $explicit;
+				}
+			}
+
 			wp_safe_redirect( $redirect_url );
 
 			return;

--- a/projects/packages/connection/src/connectors/class-jetpack-connector.php
+++ b/projects/packages/connection/src/connectors/class-jetpack-connector.php
@@ -146,6 +146,7 @@ class Jetpack_Connector {
 
 		$data['isConnected']          = $is_connected;
 		$data['isRegistered']         = $is_registered;
+		$data['isFirstConnection']    = ! $is_registered && ! (bool) \Jetpack_Options::get_option( 'id' );
 		$data['apiRoot']              = esc_url_raw( rest_url() );
 		$data['apiNonce']             = wp_create_nonce( 'wp_rest' );
 		$data['redirectUri']          = static::get_connectors_page_path();

--- a/projects/packages/connection/src/connectors/css/connectors-card.css
+++ b/projects/packages/connection/src/connectors/css/connectors-card.css
@@ -37,7 +37,7 @@
 	background-color: #eff8f0;
 }
 
-.jetpack-connector__status-badge--site-connected {
+.jetpack-connector__status-badge--site-registered {
 	color: #1e4c5e;
 	background-color: #e9f0f5;
 }
@@ -169,4 +169,12 @@
 .jetpack-connector__error .components-button {
 	color: #cc1818;
 	flex-shrink: 0;
+}
+
+.jetpack-connector__tos-notice {
+	margin-block-start: 8px;
+}
+
+.jetpack-connector__tos-notice a {
+	color: inherit;
 }

--- a/projects/packages/connection/src/connectors/css/connectors-card.css
+++ b/projects/packages/connection/src/connectors/css/connectors-card.css
@@ -11,6 +11,7 @@
  */
 
 .jetpack-connector__description-padded {
+	display: block;
 	padding-inline-end: 40px;
 }
 

--- a/projects/packages/connection/src/connectors/js/connectors-card.js
+++ b/projects/packages/connection/src/connectors/js/connectors-card.js
@@ -54,6 +54,7 @@ const CONNECTOR_LOGO = data.connectorLogoUrl
 	? createElement( 'img', { src: data.connectorLogoUrl, alt: '', width: 36, height: 36 } )
 	: null;
 const ssoStatus = data.ssoStatus ?? null;
+const isFirstConnection = Boolean( data.isFirstConnection );
 
 /**
  * Start the Jetpack connection flow: register the site (if needed),
@@ -203,6 +204,61 @@ function ErrorNotice( { message, onDismiss = null } ) {
 					__( 'Dismiss', 'jetpack-connection' )
 			  )
 			: null
+	);
+}
+
+/**
+ * Terms of Service and Privacy Policy notice for first-time connections.
+ *
+ * Uses a translatable template string with {{tos}} and {{privacy}} placeholders
+ * that get replaced with link elements.
+ *
+ * @return {object} React element.
+ */
+function TosNotice() {
+	const tosUrl = 'https://wordpress.com/tos/';
+	const privacyUrl = 'https://automattic.com/privacy/';
+
+	const template = __(
+		'By connecting, you agree to our {{tos}} and have read our {{privacy}}.',
+		'jetpack-connection'
+	);
+
+	const parts = [];
+	let remaining = template;
+
+	const placeholders = {
+		'{{tos}}': createElement(
+			'a',
+			{ key: 'tos', href: tosUrl, target: '_blank', rel: 'noopener noreferrer' },
+			__( 'Terms of Service', 'jetpack-connection' )
+		),
+		'{{privacy}}': createElement(
+			'a',
+			{ key: 'privacy', href: privacyUrl, target: '_blank', rel: 'noopener noreferrer' },
+			__( 'Privacy Policy', 'jetpack-connection' )
+		),
+	};
+
+	for ( const [ placeholder, element ] of Object.entries( placeholders ) ) {
+		const idx = remaining.indexOf( placeholder );
+		if ( idx === -1 ) {
+			continue;
+		}
+		if ( idx > 0 ) {
+			parts.push( remaining.slice( 0, idx ) );
+		}
+		parts.push( element );
+		remaining = remaining.slice( idx + placeholder.length );
+	}
+	if ( remaining ) {
+		parts.push( remaining );
+	}
+
+	return createElement(
+		Text,
+		{ variant: 'muted', size: 12, className: 'jetpack-connector__tos-notice' },
+		...parts
 	);
 }
 
@@ -778,8 +834,8 @@ function JetpackConnectorCard( { name, label, description, logo, icon } ) {
 		const badgeProps = isConnected
 			? { label: __( 'Connected', 'jetpack-connection' ) }
 			: {
-					label: __( 'Site connected', 'jetpack-connection' ),
-					modifier: 'site-connected',
+					label: __( 'Site registered', 'jetpack-connection' ),
+					modifier: 'site-registered',
 			  };
 
 		actionArea = createElement(
@@ -848,7 +904,8 @@ function JetpackConnectorCard( { name, label, description, logo, icon } ) {
 					message: connectError,
 					onDismiss: () => setConnectError( null ),
 			  } )
-			: null
+			: null,
+		isFirstConnection && ! isConnected && ! isSiteRegistered ? createElement( TosNotice ) : null
 	);
 }
 

--- a/projects/packages/connection/src/connectors/js/connectors-card.js
+++ b/projects/packages/connection/src/connectors/js/connectors-card.js
@@ -23,7 +23,7 @@ const registerConnector =
 	connectors.__experimentalRegisterConnector || connectors.registerConnector;
 const ConnectorItem = connectors.__experimentalConnectorItem || connectors.ConnectorItem;
 
-const { createElement, useState, useEffect, useRef } = window.wp.element;
+const { createElement, createInterpolateElement, useState, useEffect, useRef } = window.wp.element;
 const { __ } = window.wp.i18n;
 const { Button, Modal } = window.wp.components;
 const HStack = window.wp.components.__experimentalHStack || window.wp.components.HStack;
@@ -210,55 +210,32 @@ function ErrorNotice( { message, onDismiss = null } ) {
 /**
  * Terms of Service and Privacy Policy notice for first-time connections.
  *
- * Uses a translatable template string with {{tos}} and {{privacy}} placeholders
- * that get replaced with link elements.
- *
  * @return {object} React element.
  */
 function TosNotice() {
-	const tosUrl = 'https://wordpress.com/tos/';
-	const privacyUrl = 'https://automattic.com/privacy/';
-
-	const template = __(
-		'By connecting, you agree to our {{tos}} and have read our {{privacy}}.',
-		'jetpack-connection'
+	const message = createInterpolateElement(
+		__(
+			'By connecting, you agree to our <tos>Terms of Service</tos> and have read our <privacy>Privacy Policy</privacy>.',
+			'jetpack-connection'
+		),
+		{
+			tos: createElement( 'a', {
+				href: 'https://wordpress.com/tos/',
+				target: '_blank',
+				rel: 'noopener noreferrer',
+			} ),
+			privacy: createElement( 'a', {
+				href: 'https://automattic.com/privacy/',
+				target: '_blank',
+				rel: 'noopener noreferrer',
+			} ),
+		}
 	);
-
-	const parts = [];
-	let remaining = template;
-
-	const placeholders = {
-		'{{tos}}': createElement(
-			'a',
-			{ key: 'tos', href: tosUrl, target: '_blank', rel: 'noopener noreferrer' },
-			__( 'Terms of Service', 'jetpack-connection' )
-		),
-		'{{privacy}}': createElement(
-			'a',
-			{ key: 'privacy', href: privacyUrl, target: '_blank', rel: 'noopener noreferrer' },
-			__( 'Privacy Policy', 'jetpack-connection' )
-		),
-	};
-
-	for ( const [ placeholder, element ] of Object.entries( placeholders ) ) {
-		const idx = remaining.indexOf( placeholder );
-		if ( idx === -1 ) {
-			continue;
-		}
-		if ( idx > 0 ) {
-			parts.push( remaining.slice( 0, idx ) );
-		}
-		parts.push( element );
-		remaining = remaining.slice( idx + placeholder.length );
-	}
-	if ( remaining ) {
-		parts.push( remaining );
-	}
 
 	return createElement(
 		Text,
 		{ variant: 'muted', size: 12, className: 'jetpack-connector__tos-notice' },
-		...parts
+		message
 	);
 }
 

--- a/projects/packages/connection/src/connectors/js/connectors-card.js
+++ b/projects/packages/connection/src/connectors/js/connectors-card.js
@@ -23,7 +23,7 @@ const registerConnector =
 	connectors.__experimentalRegisterConnector || connectors.registerConnector;
 const ConnectorItem = connectors.__experimentalConnectorItem || connectors.ConnectorItem;
 
-const { createElement, useState, useRef } = window.wp.element;
+const { createElement, useState, useEffect, useRef } = window.wp.element;
 const { __ } = window.wp.i18n;
 const { Button, Modal } = window.wp.components;
 const HStack = window.wp.components.__experimentalHStack || window.wp.components.HStack;
@@ -620,12 +620,13 @@ function ExpandedDetails( { isConnecting = false, onConnect = null } ) {
 										ref: disconnectAccountRef,
 										variant: 'link',
 										isDestructive: true,
-										isBusy: isUnlinking,
 										disabled: isUnlinking || isDisconnecting,
 										onClick: handleUnlinkUser,
 										className: 'jetpack-connector__inline-action',
 									},
-									__( 'Disconnect account', 'jetpack-connection' )
+									isUnlinking
+										? __( 'Disconnecting…', 'jetpack-connection' )
+										: __( 'Disconnect account', 'jetpack-connection' )
 							  ),
 			  } )
 			: null,
@@ -742,6 +743,18 @@ function JetpackConnectorCard( { name, label, description, logo, icon } ) {
 	const isSiteRegistered = initialIsRegistered;
 	const [ isConnecting, setIsConnecting ] = useState( false );
 	const [ connectError, setConnectError ] = useState( data.authError || null );
+
+	// Reset "Connecting…" state when the page is restored from bfcache
+	// (e.g. user hits Back after being redirected to the auth page).
+	useEffect( () => {
+		const onPageShow = e => {
+			if ( e.persisted ) {
+				setIsConnecting( false );
+			}
+		};
+		window.addEventListener( 'pageshow', onPageShow );
+		return () => window.removeEventListener( 'pageshow', onPageShow );
+	}, [] );
 
 	const handleConnect = async () => {
 		setIsConnecting( true );


### PR DESCRIPTION
Related to p8oabR-1MO-p2#comment-8943 

## Proposed changes

* **CSS cross-browser fix:** Add `display: block` to `.jetpack-connector__description-padded` so that `padding-inline-end` correctly reserves space in Chrome. The `<span>` element is inline by default, and Chrome does not factor inline padding into line-box layout, causing the card to reflow when the Connect button or Connected badge appears.
* **Back-button state reset:** Listen for the `pageshow` event with `event.persisted` to reset the "Connecting…" spinner when the page is restored from the browser's back-forward cache (e.g. user hits Back after being redirected to the WordPress.com auth page).
* **Disconnect button busy state:** Replace `isBusy` (striped animated background) with a "Disconnecting…" text label on the link-variant disconnect button, since the busy stripes look broken on borderless link-style buttons.
* **Post-auth redirect fix:** Honor the `redirect` query parameter in the webhook's "already authorized" branch. Previously, when WordPress.com authorized the user via XML-RPC before the browser redirect arrived, `handle_authorize()` would hit the early return and redirect to `Jetpack::admin_url()` (My Jetpack) instead of the Connectors page.
* **Add TOS agreement** if site is creating the first connection. While this should be a very rare thing we should still cover it.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Navigate to **Settings > Connectors** on a WP 7.0+ site with Jetpack installed.
2. **CSS fix:** With the site disconnected, verify the description text has proper right padding and the card height does not change when the "Connect" button is visible.
3. **Back-button fix:** Click "Connect", wait for the redirect to WordPress.com, then hit the browser Back button. Verify the button shows "Connect" (not stuck on "Connecting…").
4. **Disconnect button:** Expand a connected connector card and click "Disconnect account". Verify it shows "Disconnecting…" text instead of animated stripes.
5. **Redirect fix:** Complete a full connect flow from the Connectors page. Verify you are redirected back to the Connectors page after authorization, not to My Jetpack.
6. **TOS** If the site has been connected before there should be no TOS text in the connector. To test the first connection, Use Jetpack Debug Tools plugin (Broken token utils) to delete the blog id.


Made with [Cursor](https://cursor.com)