### PR TITLE
AI: fix menu slug conflict and translated product name

### DIFF
--- a/projects/plugins/jetpack/_inc/client/ai/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/main.jsx
@@ -20,7 +20,7 @@ import McpWrite from './mcp/write';
 const { blogId, activityLogUrl, apiRoot, apiNonce } = window?.jetpackAiSettings ?? {};
 
 const VIEW_TITLES = {
-	hub: __( 'AI', 'jetpack' ),
+	hub: 'AI', // "AI" is a product name and should not be translated.
 	read: __( 'Read', 'jetpack' ),
 	write: __( 'Write', 'jetpack' ),
 	setup: __( 'Connect external AI agent', 'jetpack' ),
@@ -53,7 +53,8 @@ function Breadcrumbs( { view, onNavigate } ) {
 						onClick={ onNavigate }
 					>
 						<JetpackLogo showText={ false } height={ 20 } />
-						{ __( 'AI', 'jetpack' ) }
+						{ /** "AI" is a product name and should not be translated. */ }
+						AI
 					</button>
 				</li>
 				<li>

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/index.jsx
@@ -1,5 +1,5 @@
 /**
- * MCP Settings hub — main view shown at wp-admin/admin.php?page=ai.
+ * MCP Settings hub — main view shown at wp-admin/admin.php?page=jetpack-ai.
  * Shows the enable/disable toggle and navigation to Read, Write, and Setup sub-views.
  */
 

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
@@ -43,7 +43,7 @@ class Jetpack_AI_Page extends Jetpack_Admin_Page {
 			__( 'Jetpack AI', 'jetpack' ),
 			__( 'AI', 'jetpack' ),
 			'manage_options',
-			'ai',
+			'jetpack-ai',
 			array( $this, 'render' ),
 			4
 		);

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
@@ -40,8 +40,9 @@ class Jetpack_AI_Page extends Jetpack_Admin_Page {
 	 */
 	public function get_page_hook() {
 		return Admin_Menu::add_menu(
-			__( 'Jetpack AI', 'jetpack' ),
-			__( 'AI', 'jetpack' ),
+			// "Jetpack AI" is a product name and should not be translated.
+			'Jetpack AI',
+			'AI',
 			'manage_options',
 			'jetpack-ai',
 			array( $this, 'render' ),

--- a/projects/plugins/jetpack/changelog/fix-ai-page-slug
+++ b/projects/plugins/jetpack/changelog/fix-ai-page-slug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI: Change admin page slug from 'ai' to 'jetpack-ai' to avoid conflicts with the WordPress core AI plugin.


### PR DESCRIPTION
Follow-up fix to https://github.com/Automattic/jetpack/pull/48048

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Fix too generic page slug conflicting with the [Core AI plugin](https://wordpress.org/plugins/ai/).
* Don't translate "AI" as a product name (ref p1HpG7-wSr-p2)


Before

https://github.com/user-attachments/assets/7d9b6349-0c8c-4e3e-beed-821122677355


After

https://github.com/user-attachments/assets/1a22efd8-4f64-430e-bfa8-ae4ba0ac1f77



## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* While [Core AI plugin](https://wordpress.org/plugins/ai/) is installed and active
* Go to Jetpack → AI; with PR you should end up to Jetpack page. Without PR you end up in AI plugin's settings

Note that Hello Dolly cutting out is fixed in https://github.com/Automattic/jetpack/pull/48472