### PR TITLE
Social admin page: prevent stacked sections from collapsing

### DIFF
--- a/projects/packages/publicize/_inc/components/admin-page/index.tsx
+++ b/projects/packages/publicize/_inc/components/admin-page/index.tsx
@@ -93,51 +93,56 @@ export const SocialAdminPage = () => {
 			actions={ licenseAction }
 		>
 			<GlobalNotices />
-			{ isJetpackSite && ! hasSocialPaidFeatures() && showPricingPage && ! pricingPageDismissed ? (
-				<AdminSectionHero>
-					<Container horizontalSpacing={ 0 }>
-						{ hasConnectionError && (
-							<Col className={ styles[ 'connection-error-col' ] }>
-								<ConnectionError />
+			<div className={ styles.content }>
+				{ isJetpackSite &&
+				! hasSocialPaidFeatures() &&
+				showPricingPage &&
+				! pricingPageDismissed ? (
+					<AdminSectionHero>
+						<Container horizontalSpacing={ 0 }>
+							{ hasConnectionError && (
+								<Col className={ styles[ 'connection-error-col' ] }>
+									<ConnectionError />
+								</Col>
+							) }
+							<Col>
+								<div id="jp-admin-notices" className="jetpack-social-jitm-card" />
 							</Col>
-						) }
-						<Col>
-							<div id="jp-admin-notices" className="jetpack-social-jitm-card" />
-						</Col>
-					</Container>
-					<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
-						<Col>
-							<PricingPage onDismiss={ onPricingPageDismiss } />
-						</Col>
-					</Container>
-				</AdminSectionHero>
-			) : (
-				<>
-					<AdminSectionHero>
-						<Header />
+						</Container>
+						<Container horizontalSpacing={ 3 } horizontalGap={ 3 }>
+							<Col>
+								<PricingPage onDismiss={ onPricingPageDismiss } />
+							</Col>
+						</Container>
 					</AdminSectionHero>
-					<AdminSection>
-						<SocialModuleToggle />
-						{ canManageOptions && (
-							<>
-								{ isModuleEnabled && <UtmToggle /> }
-								{
-									// Only show the Social Notes toggle if Social plugin is active
-									social.version && isModuleEnabled && (
-										<SocialNotesToggle disabled={ isUpdatingJetpackSettings } />
-									)
-								}
-								{ isModuleEnabled && siteHasFeature( features.IMAGE_GENERATOR ) && (
-									<SocialImageGeneratorToggle disabled={ isUpdatingJetpackSettings } />
-								) }
-							</>
-						) }
-					</AdminSection>
-					<AdminSectionHero>
-						<InfoSection />
-					</AdminSectionHero>
-				</>
-			) }
+				) : (
+					<>
+						<AdminSectionHero>
+							<Header />
+						</AdminSectionHero>
+						<AdminSection>
+							<SocialModuleToggle />
+							{ canManageOptions && (
+								<>
+									{ isModuleEnabled && <UtmToggle /> }
+									{
+										// Only show the Social Notes toggle if Social plugin is active
+										social.version && isModuleEnabled && (
+											<SocialNotesToggle disabled={ isUpdatingJetpackSettings } />
+										)
+									}
+									{ isModuleEnabled && siteHasFeature( features.IMAGE_GENERATOR ) && (
+										<SocialImageGeneratorToggle disabled={ isUpdatingJetpackSettings } />
+									) }
+								</>
+							) }
+						</AdminSection>
+						<AdminSectionHero>
+							<InfoSection />
+						</AdminSectionHero>
+					</>
+				) }
+			</div>
 		</AdminPage>
 	);
 };

--- a/projects/packages/publicize/_inc/components/admin-page/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/admin-page/styles.module.scss
@@ -34,3 +34,16 @@
 .connection-error-col {
 	margin-top: 25px;
 }
+
+// The shared admin-page-layout mixin makes the wrapping `<Col>` a flex
+// column so DataViews-style consumers can fill the bounded slot. With
+// multiple direct children — `<AdminSectionHero>` (overflow: hidden, so
+// its automatic flex `min-height` resolves to 0) and a tall
+// `<AdminSection>` — flex shrinks the heroes to nothing and the column
+// can't scroll out of it. Wrapping the page sections in a single block
+// child gives Col one flow item with `min-height: auto` (overflow
+// visible), so siblings stack at content size and overflow falls back
+// to the middle's `overflow: auto`.
+.content {
+	display: block;
+}

--- a/projects/packages/publicize/changelog/fix-social-admin-page-header-collapse
+++ b/projects/packages/publicize/changelog/fix-social-admin-page-header-collapse
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social admin page: prevent stacked content sections from collapsing when the page content overflows the scrollable area.


### PR DESCRIPTION
Fixes #

## Proposed changes
* Wrap the Social admin page sections in a single block `<div>` so the wrapping `<Col>` (made `display: flex; flex-direction: column` by the shared `jetpack-admin-page-layout` mixin) sees one flow item instead of multiple flex siblings.
* Without this, `<AdminSectionHero>`'s `overflow: hidden` resolves its automatic flex `min-height` to 0, and flex shrinks both the "Write once, post everywhere" hero and the "Did you know?" info section to 1px whenever `<AdminSection>`'s content (e.g. the connected accounts list) pushes total content past `<Col>`'s bounded height.
* Affects both module-on and module-off states; trunk-only regression introduced in #48109 (2026-04-19) when Social adopted the unified admin layout. No released Social version is affected.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* On a site where Jetpack Social is active, go to **Jetpack → Social** in wp-admin.
* With the module **on**: confirm the "Automatically share..." toggle, the connected accounts list, the "Write once, post everywhere" hero, and the "Did you know?" info section all render at full height. The middle area scrolls if content is taller than the viewport.
* With the module **off**: confirm the same hero and info section still render at full height. Scrolling still works.
* Resize the window to verify the heroes don't get clipped at narrower heights.