### PR TITLE
Move eslint to tools/js-tools

### DIFF
--- a/.vscode/settings.dist.jsonc
+++ b/.vscode/settings.dist.jsonc
@@ -55,6 +55,8 @@
 	},
 	// Use this wp-prettier from this path.
 	"prettier.prettierPath": "tools/js-tools/node_modules/prettier/index.cjs",
+	// Use ESLint from this path.
+	"eslint.nodePath": "tools/js-tools/node_modules",
 
 	// Set to the target minimum PHP version for the codebase. Unrelated to the monorepo tooling.
 	"intelephense.environment.phpVersion": "7.2.24",

--- a/.vscode/settings.dist.jsonc
+++ b/.vscode/settings.dist.jsonc
@@ -53,7 +53,7 @@
 		"source.fixAll.eslint": "explicit",
 		"source.fixAll.stylelint": "explicit"
 	},
-	// Use this wp-prettier from this path.
+	// Use Prettier from this path.
 	"prettier.prettierPath": "tools/js-tools/node_modules/prettier/index.cjs",
 	// Use ESLint from this path.
 	"eslint.nodePath": "tools/js-tools/node_modules",
@@ -66,5 +66,5 @@
 	},
 	"stylelint.validate": [ "css", "scss" ],
 	// Use Native TypeScript
-	"typescript.experimental.useTsgo": true
+	"js/ts.experimental.useTsgo": true
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
 		"version-packages": "bash ./tools/version-packages.sh"
 	},
 	"devDependencies": {
-		"eslint": "9.39.4",
 		"husky": "9.1.7",
 		"jetpack-cli": "workspace:*",
 		"jetpack-js-tools": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,9 +18,6 @@ importers:
 
   .:
     devDependencies:
-      eslint:
-        specifier: 9.39.4
-        version: 9.39.4
       husky:
         specifier: 9.1.7
         version: 9.1.7

--- a/tools/js-tools/eslint
+++ b/tools/js-tools/eslint
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+exec "$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"/node_modules/.bin/eslint "$@"

--- a/tools/js-tools/package.json
+++ b/tools/js-tools/package.json
@@ -3,6 +3,7 @@
 	"private": true,
 	"description": "Avoid cluttering the monorepo root with random JS script deps by putting them in a workspace. This is intended for simple scripts and third-party scripts that we will only run directly or from the monorepo root.",
 	"bin": {
+		"eslint": "eslint",
 		"eslint-changed": "eslint-changed",
 		"prettier": "prettier",
 		"semver": "semver",


### PR DESCRIPTION
Since ESLint extension for VS Code now has `eslint.nodePath` option, we no linger need `eslint` in the root. [I added it there 4 years ago](https://github.com/Automattic/jetpack/pull/23773), but it's no longer needed.

See p1777897150139159-slack-C05Q5HSS013

## Proposed changes
<!--- Explain what functional changes your PR includes -->
*  Remove `eslint` from root
* Create a shim for `eslint` from `tools/js-tools`
* Update VS Code config

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Mess up some JS file to simulate lints
* Run `pnpm lint` to see those caught
* Reload VS Code and confim those lints are highlighted