### PR TITLE
Generate Feature Clip: expose VideoPress capability flag to client

### DIFF
--- a/projects/plugins/jetpack/changelog/add-feature-clip-videopress-capability-flag
+++ b/projects/plugins/jetpack/changelog/add-feature-clip-videopress-capability-flag
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-Generate Feature Clip: expose VideoPress capability flag to client so the sidebar entry point can hide itself on sites where video generation is not available.
+Image Studio: expose a strict VideoPress capability flag (`canGenerateVideoClips`) on the localized data so the client can hide the video clip generation entry point on sites where the server-side pipeline cannot run.

--- a/projects/plugins/jetpack/changelog/add-feature-clip-videopress-capability-flag
+++ b/projects/plugins/jetpack/changelog/add-feature-clip-videopress-capability-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Generate Feature Clip: expose VideoPress capability flag to client so the sidebar entry point can hide itself on sites where video generation is not available.

--- a/projects/plugins/jetpack/changelog/add-feature-clip-videopress-capability-flag
+++ b/projects/plugins/jetpack/changelog/add-feature-clip-videopress-capability-flag
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-Image Studio: expose a strict VideoPress capability flag (`canGenerateVideoClips`) on the localized data so the client can hide the video clip generation entry point on sites where the server-side pipeline cannot run.
+Image Studio: expose a video clip generation capability flag (`canGenerateVideoClips`) on the localized data so the client can hide the entry point on WordPress.com sites that cannot upload videos. On WordPress.com the value mirrors `wpcom_site_can_upload_videos()`; on other environments the flag is `true` and the server is the source of truth.

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -126,6 +126,22 @@ function has_jetpack_ai_features() {
  * @return bool
  */
 function site_can_upload_videos_for_image_studio() {
+	/**
+	 * Filter the Image Studio video-upload capability determination.
+	 *
+	 * Return null to fall through to the default capability detection;
+	 * return a boolean to override. Useful for environments that need to
+	 * force the answer (custom hosts, integration tests, etc.).
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param bool|null $override Override value, or null to use default detection.
+	 */
+	$override = apply_filters( 'jetpack_image_studio_can_upload_videos', null );
+	if ( null !== $override ) {
+		return (bool) $override;
+	}
+
 	if ( function_exists( 'wpcom_site_can_upload_videos' ) ) {
 		return (bool) wpcom_site_can_upload_videos();
 	}

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -107,27 +107,26 @@ function has_jetpack_ai_features() {
 }
 
 /**
- * Check whether the Image Studio video generation flow can run on the current site.
+ * Check whether the video clip generation flow can run on the current site.
  *
- * This is feature-scoped, not a general "can this site upload any video" check —
- * self-hosted Jetpack sites without VideoPress can still upload videos through
- * the standard WordPress media flow, but the Image Studio video generation
- * pipeline writes to VideoPress and would fail there.
+ * Strictly VideoPress-scoped: the server-side generation pipeline writes the
+ * generated video to VideoPress specifically, so this must not return true
+ * for sites that only have generic video-upload capability (e.g. WordPress.com
+ * Premium plans without VideoPress). Self-hosted sites can still upload
+ * videos through the standard WordPress media flow when this is false; this
+ * flag is exclusively about the video clip generation entry point.
  *
- * Mirrors the capability check used by the server-side video generation ability
- * so the client can hide entry points on sites where generation would fail.
- *
- * - On WordPress.com Simple and Atomic, defers to wpcom_site_can_upload_videos()
- *   which accounts for both VideoPress and the general video upload feature
- *   (Premium+ plans).
- * - On self-hosted Jetpack and standalone VideoPress, checks whether VideoPress
- *   is active as a Jetpack module or stand-alone plugin.
+ * - On WordPress.com Simple and Atomic, checks the strict VideoPress feature
+ *   via wpcom_site_has_feature( 'videopress' ), which is available on both
+ *   environments (loaded by mu-plugins on Simple, by WPCOMSH on Atomic).
+ * - On self-hosted Jetpack and standalone VideoPress, checks whether
+ *   VideoPress is active as a Jetpack module or stand-alone plugin.
  *
  * @return bool
  */
-function site_can_upload_videos_for_image_studio() {
+function image_studio_can_generate_video_clips() {
 	/**
-	 * Filter the Image Studio video-upload capability determination.
+	 * Filter the video clip generation capability determination.
 	 *
 	 * Return null to fall through to the default capability detection;
 	 * return a boolean to override. Useful for environments that need to
@@ -137,13 +136,14 @@ function site_can_upload_videos_for_image_studio() {
 	 *
 	 * @param bool|null $override Override value, or null to use default detection.
 	 */
-	$override = apply_filters( 'jetpack_image_studio_can_upload_videos', null );
+	$override = apply_filters( 'jetpack_image_studio_can_generate_video_clips', null );
 	if ( null !== $override ) {
 		return (bool) $override;
 	}
 
-	if ( function_exists( 'wpcom_site_can_upload_videos' ) ) {
-		return (bool) wpcom_site_can_upload_videos();
+	// Strict VideoPress check; wpcom_site_can_upload_videos() is too broad (also true for the generic UPLOAD_VIDEO_FILES feature on Premium plans without VideoPress).
+	if ( function_exists( 'wpcom_site_has_feature' ) ) {
+		return (bool) wpcom_site_has_feature( 'videopress' );
 	}
 
 	return VideoPress_Status::is_active();
@@ -319,10 +319,10 @@ function do_enqueue_assets() {
 	);
 
 	$image_studio_data = array(
-		'enabled'         => true,
-		'version'         => '1.0',
-		'isDevMode'       => jetpack_is_internal_testing_environment(),
-		'canUploadVideos' => site_can_upload_videos_for_image_studio(),
+		'enabled'               => true,
+		'version'               => '1.0',
+		'isDevMode'             => jetpack_is_internal_testing_environment(),
+		'canGenerateVideoClips' => image_studio_can_generate_video_clips(),
 	);
 
 	wp_add_inline_script(

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -309,36 +309,12 @@ function do_enqueue_assets() {
 		true
 	);
 
-	$is_dev_mode = jetpack_is_internal_testing_environment();
-
 	$image_studio_data = array(
 		'enabled'               => true,
 		'version'               => '1.0',
-		'isDevMode'             => $is_dev_mode,
+		'isDevMode'             => jetpack_is_internal_testing_environment(),
 		'canGenerateVideoClips' => image_studio_can_generate_video_clips(),
 	);
-
-	// Temporary diagnostic block — gated on dev mode only. Remove once the
-	// canGenerateVideoClips wiring is verified end-to-end across site types.
-	if ( $is_dev_mode ) {
-		$host = new Host();
-
-		$has_can_upload_videos = function_exists( 'wpcom_site_can_upload_videos' );
-		$has_has_videopress    = function_exists( 'wpcom_site_has_videopress' );
-		$has_has_feature       = function_exists( 'wpcom_site_has_feature' );
-
-		$image_studio_data['_debug'] = array(
-			'is_wpcom_simple'                              => $host->is_wpcom_simple(),
-			'is_woa_site'                                  => $host->is_woa_site(),
-			'function_exists_wpcom_site_can_upload_videos' => $has_can_upload_videos,
-			'wpcom_site_can_upload_videos_result'          => $has_can_upload_videos ? (bool) wpcom_site_can_upload_videos() : null,
-			'function_exists_wpcom_site_has_videopress'    => $has_has_videopress,
-			'wpcom_site_has_videopress_result'             => $has_has_videopress ? (bool) wpcom_site_has_videopress() : null,
-			'function_exists_wpcom_site_has_feature'       => $has_has_feature,
-			'wpcom_site_has_feature_videopress'            => $has_has_feature ? (bool) wpcom_site_has_feature( 'videopress' ) : null,
-			'wpcom_site_has_feature_upload_video_files'    => $has_has_feature ? (bool) wpcom_site_has_feature( 'upload_video_files' ) : null,
-		);
-	}
 
 	wp_add_inline_script(
 		FEATURE_NAME,

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -116,14 +116,16 @@ function has_jetpack_ai_features() {
  * videos through the standard WordPress media flow when this is false; this
  * flag is exclusively about the video clip generation entry point.
  *
- * Detection is environment-aware:
- * - On WordPress.com Simple and Atomic, the strict VideoPress feature flag
- *   via wpcom_site_has_feature( 'videopress' ) is the canonical signal. The
- *   local VideoPress\Status::is_active() check is NOT used here — on Simple
- *   it would give false positives because Jetpack modules are nominally
- *   active regardless of plan eligibility.
- * - On self-hosted Jetpack and standalone VideoPress, VideoPress\Status::is_active()
- *   reports VideoPress is active as a Jetpack module or stand-alone plugin.
+ * Detection is environment-aware and mirrors the canonical "site has
+ * VideoPress" pattern used by `wpcom_site_can_upload_videos` on WPCOM:
+ * - On WordPress.com Simple, prefer wpcom_site_has_videopress() — it respects
+ *   the additional `wpcom_site_has_videopress` filter that consumers rely on.
+ * - On Atomic (WPCOMSH), fall back to wpcom_site_has_feature( 'videopress' )
+ *   since wpcom_site_has_videopress() isn't loaded there.
+ * - On self-hosted Jetpack and standalone VideoPress, defer to
+ *   VideoPress\Status::is_active(). The local module-state check would give
+ *   false positives on WPCOM (where modules are nominally active regardless
+ *   of plan eligibility), so it is only consulted off-WPCOM.
  *
  * @return bool
  */
@@ -146,6 +148,9 @@ function image_studio_can_generate_video_clips() {
 
 	$host = new Host();
 	if ( $host->is_wpcom_simple() || $host->is_woa_site() ) {
+		if ( function_exists( 'wpcom_site_has_videopress' ) ) {
+			return (bool) wpcom_site_has_videopress();
+		}
 		return function_exists( 'wpcom_site_has_feature' ) && (bool) wpcom_site_has_feature( 'videopress' );
 	}
 

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -116,16 +116,14 @@ function has_jetpack_ai_features() {
  * videos through the standard WordPress media flow when this is false; this
  * flag is exclusively about the video clip generation entry point.
  *
- * Returns true if EITHER check passes:
+ * Detection is environment-aware:
  * - On WordPress.com Simple and Atomic, the strict VideoPress feature flag
- *   via wpcom_site_has_feature( 'videopress' ) (available on both
- *   environments — loaded by mu-plugins on Simple, by WPCOMSH on Atomic).
- * - On self-hosted Jetpack and standalone VideoPress, VideoPress_Status::is_active()
+ *   via wpcom_site_has_feature( 'videopress' ) is the canonical signal. The
+ *   local VideoPress\Status::is_active() check is NOT used here — on Simple
+ *   it would give false positives because Jetpack modules are nominally
+ *   active regardless of plan eligibility.
+ * - On self-hosted Jetpack and standalone VideoPress, VideoPress\Status::is_active()
  *   reports VideoPress is active as a Jetpack module or stand-alone plugin.
- *
- * Using OR semantics ensures that environments where the WPCOM helper is
- * loaded but the site itself is not WPCOM (e.g. mixed local/dev setups) still
- * fall through to the local VideoPress check instead of short-circuiting to false.
  *
  * @return bool
  */
@@ -146,10 +144,9 @@ function image_studio_can_generate_video_clips() {
 		return (bool) $override;
 	}
 
-	// Strict VideoPress check; wpcom_site_can_upload_videos() is too broad (also true for the generic UPLOAD_VIDEO_FILES feature on Premium plans without VideoPress).
-	// OR semantics: on WPCOM-with-VideoPress this short-circuits to true; otherwise fall through to the local VideoPress check so self-hosted/standalone/mixed environments still resolve correctly.
-	if ( function_exists( 'wpcom_site_has_feature' ) && wpcom_site_has_feature( 'videopress' ) ) {
-		return true;
+	$host = new Host();
+	if ( $host->is_wpcom_simple() || $host->is_woa_site() ) {
+		return function_exists( 'wpcom_site_has_feature' ) && (bool) wpcom_site_has_feature( 'videopress' );
 	}
 
 	return VideoPress_Status::is_active();

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -107,7 +107,12 @@ function has_jetpack_ai_features() {
 }
 
 /**
- * Check whether the current site can upload videos.
+ * Check whether the Image Studio video generation flow can run on the current site.
+ *
+ * This is feature-scoped, not a general "can this site upload any video" check —
+ * self-hosted Jetpack sites without VideoPress can still upload videos through
+ * the standard WordPress media flow, but the Image Studio video generation
+ * pipeline writes to VideoPress and would fail there.
  *
  * Mirrors the capability check used by the server-side video generation ability
  * so the client can hide entry points on sites where generation would fail.
@@ -120,7 +125,7 @@ function has_jetpack_ai_features() {
  *
  * @return bool
  */
-function site_can_upload_videos() {
+function site_can_upload_videos_for_image_studio() {
 	if ( function_exists( 'wpcom_site_can_upload_videos' ) ) {
 		return (bool) wpcom_site_can_upload_videos();
 	}
@@ -301,7 +306,7 @@ function do_enqueue_assets() {
 		'enabled'         => true,
 		'version'         => '1.0',
 		'isDevMode'       => jetpack_is_internal_testing_environment(),
-		'canUploadVideos' => site_can_upload_videos(),
+		'canUploadVideos' => site_can_upload_videos_for_image_studio(),
 	);
 
 	wp_add_inline_script(

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -10,6 +10,7 @@ namespace Automattic\Jetpack\Extensions\ImageStudio;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
+use Automattic\Jetpack\VideoPress\Status as VideoPress_Status;
 use function Automattic\Jetpack\Extensions\Shared\determine_iso_639_locale;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -103,6 +104,28 @@ function has_jetpack_ai_features() {
 	return ( new Connection_Manager( 'jetpack' ) )->has_connected_owner()
 		&& ! ( new Status() )->is_offline_mode()
 		&& apply_filters( 'jetpack_ai_enabled', true );
+}
+
+/**
+ * Check whether the current site can upload videos.
+ *
+ * Mirrors the capability check used by the server-side video generation ability
+ * so the client can hide entry points on sites where generation would fail.
+ *
+ * - On WordPress.com Simple and Atomic, defers to wpcom_site_can_upload_videos()
+ *   which accounts for both VideoPress and the general video upload feature
+ *   (Premium+ plans).
+ * - On self-hosted Jetpack and standalone VideoPress, checks whether VideoPress
+ *   is active as a Jetpack module or stand-alone plugin.
+ *
+ * @return bool
+ */
+function site_can_upload_videos() {
+	if ( function_exists( 'wpcom_site_can_upload_videos' ) ) {
+		return (bool) wpcom_site_can_upload_videos();
+	}
+
+	return VideoPress_Status::is_active();
 }
 
 /**
@@ -275,9 +298,10 @@ function do_enqueue_assets() {
 	);
 
 	$image_studio_data = array(
-		'enabled'   => true,
-		'version'   => '1.0',
-		'isDevMode' => jetpack_is_internal_testing_environment(),
+		'enabled'         => true,
+		'version'         => '1.0',
+		'isDevMode'       => jetpack_is_internal_testing_environment(),
+		'canUploadVideos' => site_can_upload_videos(),
 	);
 
 	wp_add_inline_script(

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -10,7 +10,6 @@ namespace Automattic\Jetpack\Extensions\ImageStudio;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
-use Automattic\Jetpack\VideoPress\Status as VideoPress_Status;
 use function Automattic\Jetpack\Extensions\Shared\determine_iso_639_locale;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -109,23 +108,11 @@ function has_jetpack_ai_features() {
 /**
  * Check whether the video clip generation flow can run on the current site.
  *
- * Strictly VideoPress-scoped: the server-side generation pipeline writes the
- * generated video to VideoPress specifically, so this must not return true
- * for sites that only have generic video-upload capability (e.g. WordPress.com
- * Premium plans without VideoPress). Self-hosted sites can still upload
- * videos through the standard WordPress media flow when this is false; this
- * flag is exclusively about the video clip generation entry point.
- *
- * Detection is environment-aware and mirrors the canonical "site has
- * VideoPress" pattern used by `wpcom_site_can_upload_videos` on WPCOM:
- * - On WordPress.com Simple, prefer wpcom_site_has_videopress() — it respects
- *   the additional `wpcom_site_has_videopress` filter that consumers rely on.
- * - On Atomic (WPCOMSH), fall back to wpcom_site_has_feature( 'videopress' )
- *   since wpcom_site_has_videopress() isn't loaded there.
- * - On self-hosted Jetpack and standalone VideoPress, defer to
- *   VideoPress\Status::is_active(). The local module-state check would give
- *   false positives on WPCOM (where modules are nominally active regardless
- *   of plan eligibility), so it is only consulted off-WPCOM.
+ * Mirrors the WordPress.com server-side gate: defers to
+ * `wpcom_site_can_upload_videos()` when available so the client and server
+ * agree on capability. Off-WPCOM (self-hosted Jetpack, standalone VideoPress,
+ * dev environments) the helper isn't loaded; we don't gate the entry point in
+ * those contexts and let the server respond if generation is unsupported.
  *
  * @return bool
  */
@@ -146,15 +133,11 @@ function image_studio_can_generate_video_clips() {
 		return (bool) $override;
 	}
 
-	$host = new Host();
-	if ( $host->is_wpcom_simple() || $host->is_woa_site() ) {
-		if ( function_exists( 'wpcom_site_has_videopress' ) ) {
-			return (bool) wpcom_site_has_videopress();
-		}
-		return function_exists( 'wpcom_site_has_feature' ) && (bool) wpcom_site_has_feature( 'videopress' );
+	if ( function_exists( 'wpcom_site_can_upload_videos' ) ) {
+		return (bool) wpcom_site_can_upload_videos();
 	}
 
-	return VideoPress_Status::is_active();
+	return true;
 }
 
 /**

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -309,12 +309,36 @@ function do_enqueue_assets() {
 		true
 	);
 
+	$is_dev_mode = jetpack_is_internal_testing_environment();
+
 	$image_studio_data = array(
 		'enabled'               => true,
 		'version'               => '1.0',
-		'isDevMode'             => jetpack_is_internal_testing_environment(),
+		'isDevMode'             => $is_dev_mode,
 		'canGenerateVideoClips' => image_studio_can_generate_video_clips(),
 	);
+
+	// Temporary diagnostic block — gated on dev mode only. Remove once the
+	// canGenerateVideoClips wiring is verified end-to-end across site types.
+	if ( $is_dev_mode ) {
+		$host = new Host();
+
+		$has_can_upload_videos = function_exists( 'wpcom_site_can_upload_videos' );
+		$has_has_videopress    = function_exists( 'wpcom_site_has_videopress' );
+		$has_has_feature       = function_exists( 'wpcom_site_has_feature' );
+
+		$image_studio_data['_debug'] = array(
+			'is_wpcom_simple'                              => $host->is_wpcom_simple(),
+			'is_woa_site'                                  => $host->is_woa_site(),
+			'function_exists_wpcom_site_can_upload_videos' => $has_can_upload_videos,
+			'wpcom_site_can_upload_videos_result'          => $has_can_upload_videos ? (bool) wpcom_site_can_upload_videos() : null,
+			'function_exists_wpcom_site_has_videopress'    => $has_has_videopress,
+			'wpcom_site_has_videopress_result'             => $has_has_videopress ? (bool) wpcom_site_has_videopress() : null,
+			'function_exists_wpcom_site_has_feature'       => $has_has_feature,
+			'wpcom_site_has_feature_videopress'            => $has_has_feature ? (bool) wpcom_site_has_feature( 'videopress' ) : null,
+			'wpcom_site_has_feature_upload_video_files'    => $has_has_feature ? (bool) wpcom_site_has_feature( 'upload_video_files' ) : null,
+		);
+	}
 
 	wp_add_inline_script(
 		FEATURE_NAME,

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -116,11 +116,16 @@ function has_jetpack_ai_features() {
  * videos through the standard WordPress media flow when this is false; this
  * flag is exclusively about the video clip generation entry point.
  *
- * - On WordPress.com Simple and Atomic, checks the strict VideoPress feature
- *   via wpcom_site_has_feature( 'videopress' ), which is available on both
- *   environments (loaded by mu-plugins on Simple, by WPCOMSH on Atomic).
- * - On self-hosted Jetpack and standalone VideoPress, checks whether
- *   VideoPress is active as a Jetpack module or stand-alone plugin.
+ * Returns true if EITHER check passes:
+ * - On WordPress.com Simple and Atomic, the strict VideoPress feature flag
+ *   via wpcom_site_has_feature( 'videopress' ) (available on both
+ *   environments — loaded by mu-plugins on Simple, by WPCOMSH on Atomic).
+ * - On self-hosted Jetpack and standalone VideoPress, VideoPress_Status::is_active()
+ *   reports VideoPress is active as a Jetpack module or stand-alone plugin.
+ *
+ * Using OR semantics ensures that environments where the WPCOM helper is
+ * loaded but the site itself is not WPCOM (e.g. mixed local/dev setups) still
+ * fall through to the local VideoPress check instead of short-circuiting to false.
  *
  * @return bool
  */
@@ -142,8 +147,9 @@ function image_studio_can_generate_video_clips() {
 	}
 
 	// Strict VideoPress check; wpcom_site_can_upload_videos() is too broad (also true for the generic UPLOAD_VIDEO_FILES feature on Premium plans without VideoPress).
-	if ( function_exists( 'wpcom_site_has_feature' ) ) {
-		return (bool) wpcom_site_has_feature( 'videopress' );
+	// OR semantics: on WPCOM-with-VideoPress this short-circuits to true; otherwise fall through to the local VideoPress check so self-hosted/standalone/mixed environments still resolve correctly.
+	if ( function_exists( 'wpcom_site_has_feature' ) && wpcom_site_has_feature( 'videopress' ) ) {
+		return true;
 	}
 
 	return VideoPress_Status::is_active();

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -604,18 +604,45 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 
 	/**
 	 * Test that the helper falls back to VideoPress\Status::is_active() when
-	 * neither the filter nor wpcom_site_has_feature() short-circuit.
+	 * wpcom_site_has_feature( 'videopress' ) returns false.
 	 *
-	 * In the standard self-hosted PHPUnit environment wpcom_site_has_feature
-	 * is not defined, so the call goes through the VideoPress fallback. We only
-	 * assert that the result type matches what VideoPress\Status::is_active()
-	 * would return — covering the fallback wiring without binding to a specific
-	 * VideoPress activation state in CI.
+	 * Runs in a separate process so we can stub wpcom_site_has_feature to
+	 * return false for the VideoPress feature without leaking the definition
+	 * into the main test process. With the OR-semantics logic, a false
+	 * result from the WPCOM helper must NOT short-circuit — the helper
+	 * should consult VideoPress\Status::is_active() and return whatever it
+	 * reports. This guards the self-hosted / mixed-environment branch (where
+	 * the WPCOM helper is loaded but the site is not actually a WPCOM site)
+	 * against a regression that would silently hide the feature.
+	 *
+	 * The default Jetpack PHPUnit bootstrap (tests/php/lib/mock-functions.php)
+	 * defines wpcom_site_has_feature returning false for 'videopress' anyway,
+	 * but we stub it explicitly here so the assertion documents the behavior
+	 * the test relies on. We assert the result equals
+	 * VideoPress\Status::is_active() rather than a fixed boolean so the test
+	 * stays valid regardless of CI's VideoPress activation state.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
 	public function test_can_generate_video_clips_falls_back_to_videopress_status() {
-		if ( function_exists( 'wpcom_site_has_feature' ) ) {
-			$this->markTestSkipped( 'wpcom_site_has_feature is defined; fallback path is unreachable here.' );
+		require_once JETPACK__PLUGIN_DIR . '/extensions/plugins/image-studio/image-studio.php';
+
+		// In the sub-process the bootstrap re-runs and defines wpcom_site_has_feature
+		// (mock returns false for 'videopress' by default). That already forces the
+		// helper through the fallback, which is exactly what we want to assert.
+		// If the function is somehow undefined, define a stub returning false so the
+		// test still exercises the fallback path deterministically.
+		if ( ! function_exists( 'wpcom_site_has_feature' ) ) {
+			// phpcs:ignore Generic.Files.OneObjectStructurePerFile.MultipleFound
+			eval( 'function wpcom_site_has_feature( $feature, $blog_id = 0 ) { return false; }' ); // @codingStandardsIgnoreLine — process-isolated stub.
 		}
+
+		// Sanity-check the precondition: the WPCOM helper must report false for VideoPress
+		// so we know the helper actually fell through to VideoPress_Status::is_active().
+		$this->assertFalse( (bool) wpcom_site_has_feature( 'videopress' ), 'wpcom_site_has_feature(videopress) must be false to exercise the fallback path.' );
 
 		$expected = \Automattic\Jetpack\VideoPress\Status::is_active();
 		$this->assertSame( $expected, ImageStudio\image_studio_can_generate_video_clips() );

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -667,6 +667,9 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	#[RunInSeparateProcess]
 	#[PreserveGlobalState( false )]
 	public function test_can_generate_video_clips_true_on_wpcom_with_videopress() {
+		if ( ! defined( 'IS_WPCOM' ) ) {
+			define( 'IS_WPCOM', true );
+		}
 		require_once JETPACK__PLUGIN_DIR . '/extensions/plugins/image-studio/image-studio.php';
 
 		if ( function_exists( 'wpcom_site_has_feature' ) ) {
@@ -691,6 +694,9 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	#[RunInSeparateProcess]
 	#[PreserveGlobalState( false )]
 	public function test_can_generate_video_clips_false_on_wpcom_without_videopress() {
+		if ( ! defined( 'IS_WPCOM' ) ) {
+			define( 'IS_WPCOM', true );
+		}
 		require_once JETPACK__PLUGIN_DIR . '/extensions/plugins/image-studio/image-studio.php';
 
 		if ( function_exists( 'wpcom_site_has_feature' ) ) {

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -81,6 +81,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	public function tear_down() {
 		delete_transient( ImageStudio\ASSET_TRANSIENT );
 		remove_all_filters( 'jetpack_image_studio_enabled' );
+		remove_all_filters( 'jetpack_image_studio_can_upload_videos' );
 		remove_all_filters( 'pre_http_request' );
 		remove_all_filters( 'locale' );
 		remove_all_filters( 'jetpack_ai_enabled' );
@@ -530,6 +531,92 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 			}
 		}
 		$this->assertTrue( $found, 'Inline script with imageStudioData not found.' );
+	}
+
+	/**
+	 * Test inline script includes canUploadVideos property.
+	 */
+	public function test_inline_script_includes_can_upload_videos() {
+		$this->enable_and_enqueue_block_editor();
+
+		$inline = $GLOBALS['wp_scripts']->get_data( ImageStudio\FEATURE_NAME, 'before' );
+
+		$this->assertIsArray( $inline );
+		$found = false;
+		foreach ( $inline as $line ) {
+			if ( is_string( $line ) && strpos( $line, 'imageStudioData' ) !== false ) {
+				$found = true;
+				$this->assertStringContainsString( '"canUploadVideos":', $line );
+			}
+		}
+		$this->assertTrue( $found, 'Inline script with imageStudioData not found.' );
+	}
+
+	/**
+	 * Test inline script reflects canUploadVideos = true when forced via filter.
+	 */
+	public function test_inline_script_can_upload_videos_true_via_filter() {
+		add_filter( 'jetpack_image_studio_can_upload_videos', '__return_true' );
+		$this->enable_and_enqueue_block_editor();
+
+		$inline  = $GLOBALS['wp_scripts']->get_data( ImageStudio\FEATURE_NAME, 'before' );
+		$matched = false;
+		foreach ( (array) $inline as $line ) {
+			if ( is_string( $line ) && strpos( $line, 'imageStudioData' ) !== false ) {
+				$matched = true;
+				$this->assertStringContainsString( '"canUploadVideos":true', $line );
+			}
+		}
+		$this->assertTrue( $matched, 'Inline script with imageStudioData not found.' );
+	}
+
+	/**
+	 * Test inline script reflects canUploadVideos = false when forced via filter.
+	 */
+	public function test_inline_script_can_upload_videos_false_via_filter() {
+		add_filter( 'jetpack_image_studio_can_upload_videos', '__return_false' );
+		$this->enable_and_enqueue_block_editor();
+
+		$inline  = $GLOBALS['wp_scripts']->get_data( ImageStudio\FEATURE_NAME, 'before' );
+		$matched = false;
+		foreach ( (array) $inline as $line ) {
+			if ( is_string( $line ) && strpos( $line, 'imageStudioData' ) !== false ) {
+				$matched = true;
+				$this->assertStringContainsString( '"canUploadVideos":false', $line );
+			}
+		}
+		$this->assertTrue( $matched, 'Inline script with imageStudioData not found.' );
+	}
+
+	/**
+	 * Test that site_can_upload_videos_for_image_studio() honors the override filter.
+	 */
+	public function test_site_can_upload_videos_filter_override() {
+		add_filter( 'jetpack_image_studio_can_upload_videos', '__return_true' );
+		$this->assertTrue( ImageStudio\site_can_upload_videos_for_image_studio() );
+
+		remove_all_filters( 'jetpack_image_studio_can_upload_videos' );
+		add_filter( 'jetpack_image_studio_can_upload_videos', '__return_false' );
+		$this->assertFalse( ImageStudio\site_can_upload_videos_for_image_studio() );
+	}
+
+	/**
+	 * Test that the helper falls back to VideoPress\Status::is_active() when
+	 * neither the filter nor wpcom_site_can_upload_videos() short-circuit.
+	 *
+	 * In the standard self-hosted PHPUnit environment wpcom_site_can_upload_videos
+	 * is not defined, so the call goes through the VideoPress fallback. We only
+	 * assert that the result type matches what VideoPress\Status::is_active()
+	 * would return — covering the fallback wiring without binding to a specific
+	 * VideoPress activation state in CI.
+	 */
+	public function test_site_can_upload_videos_falls_back_to_videopress_status() {
+		if ( function_exists( 'wpcom_site_can_upload_videos' ) ) {
+			$this->markTestSkipped( 'wpcom_site_can_upload_videos is defined; fallback path is unreachable here.' );
+		}
+
+		$expected = \Automattic\Jetpack\VideoPress\Status::is_active();
+		$this->assertSame( $expected, ImageStudio\site_can_upload_videos_for_image_studio() );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -603,167 +603,71 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the helper falls back to VideoPress\Status::is_active() when
-	 * wpcom_site_has_feature( 'videopress' ) returns false.
+	 * Test that the helper returns true when wpcom_site_can_upload_videos() reports true.
 	 *
-	 * Runs in a separate process so we can stub wpcom_site_has_feature to
-	 * return false for the VideoPress feature without leaking the definition
-	 * into the main test process. With the OR-semantics logic, a false
-	 * result from the WPCOM helper must NOT short-circuit — the helper
-	 * should consult VideoPress\Status::is_active() and return whatever it
-	 * reports. This guards the self-hosted / mixed-environment branch (where
-	 * the WPCOM helper is loaded but the site is not actually a WPCOM site)
-	 * against a regression that would silently hide the feature.
-	 *
-	 * The default Jetpack PHPUnit bootstrap (tests/php/lib/mock-functions.php)
-	 * defines wpcom_site_has_feature returning false for 'videopress' anyway,
-	 * but we stub it explicitly here so the assertion documents the behavior
-	 * the test relies on. We assert the result equals
-	 * VideoPress\Status::is_active() rather than a fixed boolean so the test
-	 * stays valid regardless of CI's VideoPress activation state.
+	 * Runs in a separate process so we can stub wpcom_site_can_upload_videos
+	 * without leaking the definition into the main test process. Skipped in
+	 * environments where the helper is already defined (e.g. WPCOMSH job)
+	 * since we cannot redefine an existing function.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
 	#[RunInSeparateProcess]
 	#[PreserveGlobalState( false )]
-	public function test_can_generate_video_clips_falls_back_to_videopress_status() {
+	public function test_can_generate_video_clips_true_when_wpcom_helper_true() {
 		require_once JETPACK__PLUGIN_DIR . '/extensions/plugins/image-studio/image-studio.php';
 
-		// In the sub-process the bootstrap re-runs and defines wpcom_site_has_feature
-		// (mock returns false for 'videopress' by default). That already forces the
-		// helper through the fallback, which is exactly what we want to assert.
-		// If the function is somehow undefined, define a stub returning false so the
-		// test still exercises the fallback path deterministically.
-		if ( ! function_exists( 'wpcom_site_has_feature' ) ) {
-			// phpcs:ignore Generic.Files.OneObjectStructurePerFile.MultipleFound
-			eval( 'function wpcom_site_has_feature( $feature, $blog_id = 0 ) { return false; }' ); // @codingStandardsIgnoreLine — process-isolated stub.
-		}
-
-		// Sanity-check the precondition: the WPCOM helper must report false for VideoPress
-		// so we know the helper actually fell through to VideoPress_Status::is_active().
-		$this->assertFalse( (bool) wpcom_site_has_feature( 'videopress' ), 'wpcom_site_has_feature(videopress) must be false to exercise the fallback path.' );
-
-		$expected = \Automattic\Jetpack\VideoPress\Status::is_active();
-		$this->assertSame( $expected, ImageStudio\image_studio_can_generate_video_clips() );
-	}
-
-	/**
-	 * Test that on WPCOM (Simple/Atomic) the helper returns true when
-	 * wpcom_site_has_feature( 'videopress' ) returns true.
-	 *
-	 * Runs in a separate process so we can stub wpcom_site_has_feature without
-	 * leaking the definition into the main test process. This exercises the
-	 * Simple/Atomic branch (the main behavior introduced by this PR) in the
-	 * standalone PHPUnit job, where the helper would otherwise be undefined
-	 * and the test would silently take the self-hosted fallback path.
-	 *
-	 * Skipped in environments where wpcom_site_has_feature is already defined
-	 * (e.g. WPCOMSH test job) since we cannot redefine an existing function.
-	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	#[RunInSeparateProcess]
-	#[PreserveGlobalState( false )]
-	public function test_can_generate_video_clips_true_on_wpcom_with_videopress() {
-		if ( ! defined( 'IS_WPCOM' ) ) {
-			define( 'IS_WPCOM', true );
-		}
-		require_once JETPACK__PLUGIN_DIR . '/extensions/plugins/image-studio/image-studio.php';
-
-		if ( function_exists( 'wpcom_site_has_feature' ) ) {
-			$this->markTestSkipped( 'wpcom_site_has_feature already defined; cannot stub.' );
+		if ( function_exists( 'wpcom_site_can_upload_videos' ) ) {
+			$this->markTestSkipped( 'wpcom_site_can_upload_videos already defined; cannot stub.' );
 		}
 
 		// phpcs:ignore Generic.Files.OneObjectStructurePerFile.MultipleFound
-		eval( 'function wpcom_site_has_feature( $feature, $blog_id = 0 ) { return $feature === "videopress"; }' ); // @codingStandardsIgnoreLine — process-isolated stub.
+		eval( 'function wpcom_site_can_upload_videos( $blog_id = 0 ) { return true; }' ); // @codingStandardsIgnoreLine — process-isolated stub.
 
 		$this->assertTrue( ImageStudio\image_studio_can_generate_video_clips() );
 	}
 
 	/**
-	 * Test that on WPCOM (Simple/Atomic) the helper returns false when
-	 * wpcom_site_has_feature( 'videopress' ) returns false — even on sites
-	 * that have the broader UPLOAD_VIDEO_FILES feature (Premium plans without
-	 * VideoPress). This is the regression guard for the strict-VideoPress check.
+	 * Test that the helper returns false when wpcom_site_can_upload_videos() reports false.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
 	#[RunInSeparateProcess]
 	#[PreserveGlobalState( false )]
-	public function test_can_generate_video_clips_false_on_wpcom_without_videopress() {
-		if ( ! defined( 'IS_WPCOM' ) ) {
-			define( 'IS_WPCOM', true );
-		}
+	public function test_can_generate_video_clips_false_when_wpcom_helper_false() {
 		require_once JETPACK__PLUGIN_DIR . '/extensions/plugins/image-studio/image-studio.php';
 
-		if ( function_exists( 'wpcom_site_has_feature' ) ) {
-			$this->markTestSkipped( 'wpcom_site_has_feature already defined; cannot stub.' );
+		if ( function_exists( 'wpcom_site_can_upload_videos' ) ) {
+			$this->markTestSkipped( 'wpcom_site_can_upload_videos already defined; cannot stub.' );
 		}
 
-		// Simulate a Premium-without-VideoPress site: only UPLOAD_VIDEO_FILES is true,
-		// VIDEOPRESS is false. The helper must return false because the generation
-		// pipeline writes to VideoPress specifically.
 		// phpcs:ignore Generic.Files.OneObjectStructurePerFile.MultipleFound
-		eval( 'function wpcom_site_has_feature( $feature, $blog_id = 0 ) { return $feature === "upload_video_files"; }' ); // @codingStandardsIgnoreLine — process-isolated stub.
+		eval( 'function wpcom_site_can_upload_videos( $blog_id = 0 ) { return false; }' ); // @codingStandardsIgnoreLine — process-isolated stub.
 
 		$this->assertFalse( ImageStudio\image_studio_can_generate_video_clips() );
 	}
 
 	/**
-	 * Test that on WPCOM Simple the helper consults wpcom_site_has_videopress()
-	 * preferentially (matching the canonical wpcom_site_can_upload_videos pattern)
-	 * and returns true when that helper reports true.
+	 * Test that off WPCOM (no wpcom_site_can_upload_videos) the helper returns
+	 * true so the entry point is not gated on environments where we have no
+	 * way to determine capability up-front. The server is the source of truth
+	 * in that case.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
 	#[RunInSeparateProcess]
 	#[PreserveGlobalState( false )]
-	public function test_can_generate_video_clips_uses_wpcom_site_has_videopress_when_available() {
-		if ( ! defined( 'IS_WPCOM' ) ) {
-			define( 'IS_WPCOM', true );
-		}
+	public function test_can_generate_video_clips_true_off_wpcom() {
 		require_once JETPACK__PLUGIN_DIR . '/extensions/plugins/image-studio/image-studio.php';
 
-		if ( function_exists( 'wpcom_site_has_videopress' ) ) {
-			$this->markTestSkipped( 'wpcom_site_has_videopress already defined; cannot stub.' );
+		if ( function_exists( 'wpcom_site_can_upload_videos' ) ) {
+			$this->markTestSkipped( 'wpcom_site_can_upload_videos defined; cannot exercise off-WPCOM branch.' );
 		}
-
-		// phpcs:ignore Generic.Files.OneObjectStructurePerFile.MultipleFound
-		eval( 'function wpcom_site_has_videopress( $blog_id = 0 ) { return true; }' ); // @codingStandardsIgnoreLine — process-isolated stub.
 
 		$this->assertTrue( ImageStudio\image_studio_can_generate_video_clips() );
-	}
-
-	/**
-	 * Test that on WPCOM Simple the helper returns false when
-	 * wpcom_site_has_videopress() reports false — and crucially does NOT fall
-	 * back to wpcom_site_has_feature() or VideoPress\Status::is_active().
-	 * Regression guard for the Simple-without-VideoPress case where the local
-	 * module-state check would otherwise give a false positive.
-	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	#[RunInSeparateProcess]
-	#[PreserveGlobalState( false )]
-	public function test_can_generate_video_clips_false_on_wpcom_simple_without_videopress() {
-		if ( ! defined( 'IS_WPCOM' ) ) {
-			define( 'IS_WPCOM', true );
-		}
-		require_once JETPACK__PLUGIN_DIR . '/extensions/plugins/image-studio/image-studio.php';
-
-		if ( function_exists( 'wpcom_site_has_videopress' ) ) {
-			$this->markTestSkipped( 'wpcom_site_has_videopress already defined; cannot stub.' );
-		}
-
-		// phpcs:ignore Generic.Files.OneObjectStructurePerFile.MultipleFound
-		eval( 'function wpcom_site_has_videopress( $blog_id = 0 ) { return false; }' ); // @codingStandardsIgnoreLine — process-isolated stub.
-
-		$this->assertFalse( ImageStudio\image_studio_can_generate_video_clips() );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -713,6 +713,60 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that on WPCOM Simple the helper consults wpcom_site_has_videopress()
+	 * preferentially (matching the canonical wpcom_site_can_upload_videos pattern)
+	 * and returns true when that helper reports true.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_can_generate_video_clips_uses_wpcom_site_has_videopress_when_available() {
+		if ( ! defined( 'IS_WPCOM' ) ) {
+			define( 'IS_WPCOM', true );
+		}
+		require_once JETPACK__PLUGIN_DIR . '/extensions/plugins/image-studio/image-studio.php';
+
+		if ( function_exists( 'wpcom_site_has_videopress' ) ) {
+			$this->markTestSkipped( 'wpcom_site_has_videopress already defined; cannot stub.' );
+		}
+
+		// phpcs:ignore Generic.Files.OneObjectStructurePerFile.MultipleFound
+		eval( 'function wpcom_site_has_videopress( $blog_id = 0 ) { return true; }' ); // @codingStandardsIgnoreLine — process-isolated stub.
+
+		$this->assertTrue( ImageStudio\image_studio_can_generate_video_clips() );
+	}
+
+	/**
+	 * Test that on WPCOM Simple the helper returns false when
+	 * wpcom_site_has_videopress() reports false — and crucially does NOT fall
+	 * back to wpcom_site_has_feature() or VideoPress\Status::is_active().
+	 * Regression guard for the Simple-without-VideoPress case where the local
+	 * module-state check would otherwise give a false positive.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_can_generate_video_clips_false_on_wpcom_simple_without_videopress() {
+		if ( ! defined( 'IS_WPCOM' ) ) {
+			define( 'IS_WPCOM', true );
+		}
+		require_once JETPACK__PLUGIN_DIR . '/extensions/plugins/image-studio/image-studio.php';
+
+		if ( function_exists( 'wpcom_site_has_videopress' ) ) {
+			$this->markTestSkipped( 'wpcom_site_has_videopress already defined; cannot stub.' );
+		}
+
+		// phpcs:ignore Generic.Files.OneObjectStructurePerFile.MultipleFound
+		eval( 'function wpcom_site_has_videopress( $blog_id = 0 ) { return false; }' ); // @codingStandardsIgnoreLine — process-isolated stub.
+
+		$this->assertFalse( ImageStudio\image_studio_can_generate_video_clips() );
+	}
+
+	/**
 	 * Test style is enqueued with wp-components dependency.
 	 */
 	public function test_style_enqueued_with_wp_components() {

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -7,6 +7,8 @@
 
 use Automattic\Jetpack\Extensions\ImageStudio;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 require_once JETPACK__PLUGIN_DIR . '/extensions/plugins/image-studio/image-studio.php';
 require_once JETPACK__PLUGIN_DIR . '/extensions/plugins/ai-assistant-plugin/ai-assistant-plugin.php';
@@ -81,7 +83,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	public function tear_down() {
 		delete_transient( ImageStudio\ASSET_TRANSIENT );
 		remove_all_filters( 'jetpack_image_studio_enabled' );
-		remove_all_filters( 'jetpack_image_studio_can_upload_videos' );
+		remove_all_filters( 'jetpack_image_studio_can_generate_video_clips' );
 		remove_all_filters( 'pre_http_request' );
 		remove_all_filters( 'locale' );
 		remove_all_filters( 'jetpack_ai_enabled' );
@@ -534,9 +536,9 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test inline script includes canUploadVideos property.
+	 * Test inline script includes canGenerateVideoClips property.
 	 */
-	public function test_inline_script_includes_can_upload_videos() {
+	public function test_inline_script_includes_can_generate_video_clips() {
 		$this->enable_and_enqueue_block_editor();
 
 		$inline = $GLOBALS['wp_scripts']->get_data( ImageStudio\FEATURE_NAME, 'before' );
@@ -546,17 +548,17 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 		foreach ( $inline as $line ) {
 			if ( is_string( $line ) && strpos( $line, 'imageStudioData' ) !== false ) {
 				$found = true;
-				$this->assertStringContainsString( '"canUploadVideos":', $line );
+				$this->assertStringContainsString( '"canGenerateVideoClips":', $line );
 			}
 		}
 		$this->assertTrue( $found, 'Inline script with imageStudioData not found.' );
 	}
 
 	/**
-	 * Test inline script reflects canUploadVideos = true when forced via filter.
+	 * Test inline script reflects canGenerateVideoClips = true when forced via filter.
 	 */
-	public function test_inline_script_can_upload_videos_true_via_filter() {
-		add_filter( 'jetpack_image_studio_can_upload_videos', '__return_true' );
+	public function test_inline_script_can_generate_video_clips_true_via_filter() {
+		add_filter( 'jetpack_image_studio_can_generate_video_clips', '__return_true' );
 		$this->enable_and_enqueue_block_editor();
 
 		$inline  = $GLOBALS['wp_scripts']->get_data( ImageStudio\FEATURE_NAME, 'before' );
@@ -564,17 +566,17 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 		foreach ( (array) $inline as $line ) {
 			if ( is_string( $line ) && strpos( $line, 'imageStudioData' ) !== false ) {
 				$matched = true;
-				$this->assertStringContainsString( '"canUploadVideos":true', $line );
+				$this->assertStringContainsString( '"canGenerateVideoClips":true', $line );
 			}
 		}
 		$this->assertTrue( $matched, 'Inline script with imageStudioData not found.' );
 	}
 
 	/**
-	 * Test inline script reflects canUploadVideos = false when forced via filter.
+	 * Test inline script reflects canGenerateVideoClips = false when forced via filter.
 	 */
-	public function test_inline_script_can_upload_videos_false_via_filter() {
-		add_filter( 'jetpack_image_studio_can_upload_videos', '__return_false' );
+	public function test_inline_script_can_generate_video_clips_false_via_filter() {
+		add_filter( 'jetpack_image_studio_can_generate_video_clips', '__return_false' );
 		$this->enable_and_enqueue_block_editor();
 
 		$inline  = $GLOBALS['wp_scripts']->get_data( ImageStudio\FEATURE_NAME, 'before' );
@@ -582,41 +584,99 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 		foreach ( (array) $inline as $line ) {
 			if ( is_string( $line ) && strpos( $line, 'imageStudioData' ) !== false ) {
 				$matched = true;
-				$this->assertStringContainsString( '"canUploadVideos":false', $line );
+				$this->assertStringContainsString( '"canGenerateVideoClips":false', $line );
 			}
 		}
 		$this->assertTrue( $matched, 'Inline script with imageStudioData not found.' );
 	}
 
 	/**
-	 * Test that site_can_upload_videos_for_image_studio() honors the override filter.
+	 * Test that image_studio_can_generate_video_clips() honors the override filter.
 	 */
-	public function test_site_can_upload_videos_filter_override() {
-		add_filter( 'jetpack_image_studio_can_upload_videos', '__return_true' );
-		$this->assertTrue( ImageStudio\site_can_upload_videos_for_image_studio() );
+	public function test_can_generate_video_clips_filter_override() {
+		add_filter( 'jetpack_image_studio_can_generate_video_clips', '__return_true' );
+		$this->assertTrue( ImageStudio\image_studio_can_generate_video_clips() );
 
-		remove_all_filters( 'jetpack_image_studio_can_upload_videos' );
-		add_filter( 'jetpack_image_studio_can_upload_videos', '__return_false' );
-		$this->assertFalse( ImageStudio\site_can_upload_videos_for_image_studio() );
+		remove_all_filters( 'jetpack_image_studio_can_generate_video_clips' );
+		add_filter( 'jetpack_image_studio_can_generate_video_clips', '__return_false' );
+		$this->assertFalse( ImageStudio\image_studio_can_generate_video_clips() );
 	}
 
 	/**
 	 * Test that the helper falls back to VideoPress\Status::is_active() when
-	 * neither the filter nor wpcom_site_can_upload_videos() short-circuit.
+	 * neither the filter nor wpcom_site_has_feature() short-circuit.
 	 *
-	 * In the standard self-hosted PHPUnit environment wpcom_site_can_upload_videos
+	 * In the standard self-hosted PHPUnit environment wpcom_site_has_feature
 	 * is not defined, so the call goes through the VideoPress fallback. We only
 	 * assert that the result type matches what VideoPress\Status::is_active()
 	 * would return — covering the fallback wiring without binding to a specific
 	 * VideoPress activation state in CI.
 	 */
-	public function test_site_can_upload_videos_falls_back_to_videopress_status() {
-		if ( function_exists( 'wpcom_site_can_upload_videos' ) ) {
-			$this->markTestSkipped( 'wpcom_site_can_upload_videos is defined; fallback path is unreachable here.' );
+	public function test_can_generate_video_clips_falls_back_to_videopress_status() {
+		if ( function_exists( 'wpcom_site_has_feature' ) ) {
+			$this->markTestSkipped( 'wpcom_site_has_feature is defined; fallback path is unreachable here.' );
 		}
 
 		$expected = \Automattic\Jetpack\VideoPress\Status::is_active();
-		$this->assertSame( $expected, ImageStudio\site_can_upload_videos_for_image_studio() );
+		$this->assertSame( $expected, ImageStudio\image_studio_can_generate_video_clips() );
+	}
+
+	/**
+	 * Test that on WPCOM (Simple/Atomic) the helper returns true when
+	 * wpcom_site_has_feature( 'videopress' ) returns true.
+	 *
+	 * Runs in a separate process so we can stub wpcom_site_has_feature without
+	 * leaking the definition into the main test process. This exercises the
+	 * Simple/Atomic branch (the main behavior introduced by this PR) in the
+	 * standalone PHPUnit job, where the helper would otherwise be undefined
+	 * and the test would silently take the self-hosted fallback path.
+	 *
+	 * Skipped in environments where wpcom_site_has_feature is already defined
+	 * (e.g. WPCOMSH test job) since we cannot redefine an existing function.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_can_generate_video_clips_true_on_wpcom_with_videopress() {
+		require_once JETPACK__PLUGIN_DIR . '/extensions/plugins/image-studio/image-studio.php';
+
+		if ( function_exists( 'wpcom_site_has_feature' ) ) {
+			$this->markTestSkipped( 'wpcom_site_has_feature already defined; cannot stub.' );
+		}
+
+		// phpcs:ignore Generic.Files.OneObjectStructurePerFile.MultipleFound
+		eval( 'function wpcom_site_has_feature( $feature, $blog_id = 0 ) { return $feature === "videopress"; }' ); // @codingStandardsIgnoreLine — process-isolated stub.
+
+		$this->assertTrue( ImageStudio\image_studio_can_generate_video_clips() );
+	}
+
+	/**
+	 * Test that on WPCOM (Simple/Atomic) the helper returns false when
+	 * wpcom_site_has_feature( 'videopress' ) returns false — even on sites
+	 * that have the broader UPLOAD_VIDEO_FILES feature (Premium plans without
+	 * VideoPress). This is the regression guard for the strict-VideoPress check.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_can_generate_video_clips_false_on_wpcom_without_videopress() {
+		require_once JETPACK__PLUGIN_DIR . '/extensions/plugins/image-studio/image-studio.php';
+
+		if ( function_exists( 'wpcom_site_has_feature' ) ) {
+			$this->markTestSkipped( 'wpcom_site_has_feature already defined; cannot stub.' );
+		}
+
+		// Simulate a Premium-without-VideoPress site: only UPLOAD_VIDEO_FILES is true,
+		// VIDEOPRESS is false. The helper must return false because the generation
+		// pipeline writes to VideoPress specifically.
+		// phpcs:ignore Generic.Files.OneObjectStructurePerFile.MultipleFound
+		eval( 'function wpcom_site_has_feature( $feature, $blog_id = 0 ) { return $feature === "upload_video_files"; }' ); // @codingStandardsIgnoreLine — process-isolated stub.
+
+		$this->assertFalse( ImageStudio\image_studio_can_generate_video_clips() );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Add `canGenerateVideoClips` (boolean) to the `imageStudioData` localized object so the Generate Feature Clip sidebar panel can hide itself on sites where the video clip generation flow can't run.
- The flag mirrors the canonical WPCOM `wpcom_site_can_upload_videos()` helper when available, so client and server use a single source of truth for video-upload capability. Off-WPCOM (self-hosted, standalone VideoPress, dev) the helper isn't loaded; we don't gate the entry point in those contexts and let the server respond if generation is unsupported.
- Filter `jetpack_image_studio_can_generate_video_clips` lets environments (custom hosts, integration tests) override the determination.

## Companion / breaking change for downstream consumers

The localized property is named `canGenerateVideoClips` (rather than the more general-sounding `canUploadVideos`) so the client contract reflects exactly what it gates: the AI video-clip generation entry point, not generic media uploads.

The downstream Calypso branch (Automattic/wp-calypso#110413) reads `window.imageStudioData.canGenerateVideoClips === false` to hide the panel.

## Testing instructions

**On a site that can upload videos (e.g. WordPress.com Premium+ Simple, Atomic with the VideoPress feature, or a Jetpack-connected site with VideoPress active):**

1. Apply this branch on the test site.
2. Open the block editor for any post.
3. Open the browser devtools console.
4. Run: `window.imageStudioData.canGenerateVideoClips`.
5. Expect: `true`.

**On a site that cannot upload videos (e.g. a free WordPress.com Simple site, or self-hosted Jetpack without VideoPress):**

1. Apply this branch on the test site.
2. Open the block editor for any post.
3. Open the browser devtools console.
4. Run: `window.imageStudioData.canGenerateVideoClips`.
5. Expect: `false`.

**Regression check (existing image generation entry points):**

1. On any site where Image Studio entry points were visible before this branch, verify they are still visible and clickable. The new flag only affects the video clip generation surface; it must not gate any image-only flows.

## Does this pull request change what data or activity we track or use?

No. This PR exposes a server-side capability check to the client as a boolean property on an existing localized object. It does not add any new tracking events, does not collect new data from the user, and does not change any existing data flows. The boolean reflects capability that WPCOM already evaluates today.