### PR TITLE
Write: Fix media-only post editability and duplicate paragraph insertion

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-media-only-post-editable-element
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-media-only-post-editable-element
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write: Run block-structure audit on post load so media-only posts have editable elements immediately.

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-media-only-post-editable-element
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-media-only-post-editable-element
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Write: Run block-structure audit on post load so media-only posts have editable elements immediately.
+Write: Run block-structure audit on post load so media-only posts have editable elements immediately, and avoid inserting duplicate empty paragraphs below non-editable blocks.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -707,6 +707,11 @@ const contentReady2 = setInterval( () => {
 	if ( ! contentEl.innerHTML.trim() ) {
 		contentEl.innerHTML = '<p><br></p>';
 	}
+	// When reopening a media-only post, the content may contain only
+	// non-editable blocks (e.g. figures) with no editable paragraphs.
+	// Run the block-structure audit immediately so gap paragraphs are
+	// inserted and the user can start editing right away.
+	ensureBlockStructure();
 	if ( ! contentEl.textContent.trim() && ! contentEl.querySelector( 'img, video, figure' ) ) {
 		contentEl.classList.add( 'bw-is-empty' );
 		contentEl.addEventListener( 'input', () => contentEl.classList.remove( 'bw-is-empty' ), {

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1111,17 +1111,22 @@ function ensureBlockStructure() {
 		}
 	}
 	// Check if every block is a gap paragraph (e.g. after all figures
-	// were deleted). Without a real editable block the save cleanup
-	// would strip all gaps and serialize empty content.
+	// were deleted) and no non-editable blocks remain.  When figures
+	// or HRs still exist the gap paragraphs are sufficient cursor
+	// targets and no additional editable block is needed.
 	if ( ! needsRepair ) {
 		let hasRealEditable = false;
+		let hasNonEditableBlock = false;
 		for ( const el of content.children ) {
 			if ( EDITABLE_BLOCK_TAGS.test( el.tagName ) && ! el.classList.contains( 'bw-block-gap' ) ) {
 				hasRealEditable = true;
 				break;
 			}
+			if ( isNonEditableBlock( el ) ) {
+				hasNonEditableBlock = true;
+			}
 		}
-		if ( ! hasRealEditable ) {
+		if ( ! hasRealEditable && ! hasNonEditableBlock ) {
 			needsRepair = true;
 		}
 	}
@@ -1230,15 +1235,23 @@ function ensureBlockStructure() {
 		content.appendChild( gap );
 	}
 
-	// Guarantee at least one text-editable block exists.
+	// Guarantee at least one text-editable block exists.  When
+	// non-editable blocks (figures, HRs) are present, the surrounding
+	// gap paragraphs already provide editable cursor targets that can
+	// be promoted on click — adding another paragraph here would create
+	// a visible duplicate once the trailing gap is promoted.
 	let hasEditable = false;
+	let hasNonEditable = false;
 	for ( const el of content.children ) {
 		if ( EDITABLE_BLOCK_TAGS.test( el.tagName ) && ! el.classList.contains( 'bw-block-gap' ) ) {
 			hasEditable = true;
 			break;
 		}
+		if ( isNonEditableBlock( el ) ) {
+			hasNonEditable = true;
+		}
 	}
-	if ( ! hasEditable && content.firstChild ) {
+	if ( ! hasEditable && ! hasNonEditable && content.firstChild ) {
 		const p = document.createElement( 'p' );
 		p.innerHTML = '<br>';
 		content.appendChild( p );


### PR DESCRIPTION
Fixes RSM-2046, RSM-2047

## Proposed changes

* Call `ensureBlockStructure()` during content initialization so that media-only posts have editable gap paragraphs immediately on load, instead of requiring a 30-second autosave cycle to fix the block structure.
* Skip the "guarantee at least one editable block" paragraph when non-editable blocks (figures, HRs) exist, since gap paragraphs already serve as promotable cursor targets. This prevents two visible empty paragraphs from appearing when the trailing gap is promoted by clicking on it. The guarantee paragraph is still added for the all-gaps-no-figures case (e.g., after deleting all media).

## Related product discussion/links

* RSM-2046: Media only post doesn't have an editable element after reopening
* RSM-2047: There are sometimes two empty paragraphs inserted below a media element

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

**RSM-2046 — Media-only post editability**
1. Create a new post in the Write editor, add only an image, save it.
2. Reopen the post — you should immediately be able to click above/below the image and type (no 30s wait).

**RSM-2047 — No duplicate paragraphs**
1. Enter some text, then add an image, save the post.
2. Reopen the post.
3. Click Save Draft, then click below the image — should be only **one** empty paragraph, not two.
4. Same test but with only an image (no text) — click below the image after reopening, still only one typing area.

**Regression checks**
- Insert an image between two text paragraphs — gaps should appear around the figure, cursor navigable.
- Delete all images from a post that had only images — should get a single editable paragraph (not left with only collapsed gaps).
- Type text in a gap paragraph, click away, click back — text should persist, no weird collapsing.
- Save a media-only post, reopen — the image should still be there (not lost by save stripping gaps).
- Insert a horizontal rule — same gap behavior as images, no duplicates.