### PR TITLE
My Jetpack: migrate interstitial Buttons to @wordpress/ui

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/more-requests.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/more-requests.jsx
@@ -3,7 +3,6 @@
  */
 import {
 	AdminPage,
-	Button,
 	Col,
 	Container,
 	Text,
@@ -11,6 +10,7 @@ import {
 	getRedirectUrl,
 } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useCallback } from 'react';
 import { Link } from 'react-router';
@@ -66,12 +66,20 @@ export function JetpackAIInterstitialMoreRequests( { onClickGoBack = () => {} } 
 									<H3>{ title }</H3>
 									<Text mb={ 3 }>{ longDescription }</Text>
 									<div className={ styles[ 'buttons-row' ] }>
-										<Button href={ contactHref } onClick={ trackClickHandler }>
+										<Button
+											nativeButton={ false }
+											render={ <a href={ contactHref } /> }
+											onClick={ trackClickHandler }
+										>
 											{ __( 'Contact Us', 'jetpack-my-jetpack' ) }
 										</Button>
-										<Link to={ '/products' } onClick={ onClickGoBack }>
-											<Button variant="secondary">{ __( 'Back', 'jetpack-my-jetpack' ) }</Button>
-										</Link>
+										<Button
+											variant="outline"
+											nativeButton={ false }
+											render={ <Link to="/products" onClick={ onClickGoBack } /> }
+										>
+											{ __( 'Back', 'jetpack-my-jetpack' ) }
+										</Button>
 									</div>
 								</div>
 							</div>

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/pricing-interstitial.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/pricing-interstitial.jsx
@@ -3,7 +3,6 @@
  */
 import {
 	AdminPage,
-	Button,
 	Col,
 	Container,
 	PricingTable,
@@ -14,8 +13,9 @@ import {
 } from '@automattic/jetpack-components';
 import { useProductCheckoutWorkflow } from '@automattic/jetpack-connection';
 import { getScriptData, getMyJetpackUrl } from '@automattic/jetpack-script-data';
-import { Button as WPButton, Spinner } from '@wordpress/components';
+import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/ui';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 /**
  * Internal dependencies
@@ -388,14 +388,15 @@ export default function PricingInterstitial( { slug } ) {
 				/>
 			}
 			actions={
-				<WPButton
+				<Button
 					size="compact"
-					variant="secondary"
-					href={ getMyJetpackUrl( '#/add-license' ) }
+					variant="outline"
+					nativeButton={ false }
+					render={ <a href={ getMyJetpackUrl( '#/add-license' ) } /> }
 					onClick={ handleLicenseActivationClick }
 				>
 					{ __( 'Use license key', 'jetpack-my-jetpack' ) }
-				</WPButton>
+				</Button>
 			}
 		>
 			<Container
@@ -421,10 +422,10 @@ export default function PricingInterstitial( { slug } ) {
 										variant="simple"
 									/>
 									<Button
-										fullWidth
-										variant="secondary"
+										className={ styles[ 'tier-cta' ] }
+										variant="outline"
 										onClick={ handleFreeActivation }
-										isLoading={ loadingButton === 'free' }
+										loading={ loadingButton === 'free' }
 										disabled={ buttonsDisabled }
 									>
 										{ config.tiers.free.cta }
@@ -458,9 +459,9 @@ export default function PricingInterstitial( { slug } ) {
 									<Spinner className={ styles.spinner } />
 								) }
 								<Button
-									fullWidth
+									className={ styles[ 'tier-cta' ] }
 									onClick={ handleGetProduct }
-									isLoading={ loadingButton === 'paid' }
+									loading={ loadingButton === 'paid' }
 									disabled={ buttonsDisabled }
 								>
 									{ config.tiers.paid.cta }
@@ -489,10 +490,10 @@ export default function PricingInterstitial( { slug } ) {
 									<Spinner className={ styles.spinner } />
 								) }
 								<Button
-									fullWidth
-									variant="secondary"
+									className={ styles[ 'tier-cta' ] }
+									variant="outline"
 									onClick={ handleGetBundle }
-									isLoading={ loadingButton === 'bundle' }
+									loading={ loadingButton === 'bundle' }
 									disabled={ buttonsDisabled || isBundleLoading }
 								>
 									{ config.tiers.bundle.cta }

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/product-interstitial.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/product-interstitial.jsx
@@ -3,8 +3,8 @@
  */
 import { AdminPage, Col, Container, TermsOfService } from '@automattic/jetpack-components';
 import { getMyJetpackUrl } from '@automattic/jetpack-script-data';
-import { Button as WPButton } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import { Button } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useCallback, useEffect } from 'react';
 /**
@@ -205,9 +205,14 @@ export default function ProductInterstitial( {
 			}
 			actions={
 				existingLicenseKeyUrl ? (
-					<WPButton size="compact" variant="secondary" href={ existingLicenseKeyUrl }>
+					<Button
+						size="compact"
+						variant="outline"
+						nativeButton={ false }
+						render={ <a href={ existingLicenseKeyUrl } /> }
+					>
 						{ __( 'Use license key', 'jetpack-my-jetpack' ) }
-					</WPButton>
+					</Button>
 				) : null
 			}
 		>

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/style.module.scss
@@ -49,6 +49,11 @@
 	}
 }
 
+.tier-cta {
+	width: 100%;
+	justify-content: center;
+}
+
 .not-strong {
 	font-weight: 400 !important;
 }

--- a/projects/packages/my-jetpack/_inc/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/style.module.scss
@@ -1,5 +1,14 @@
 :global {
 
+	// @wordpress/ui Button styles live inside `@layer wp-ui-components`, which
+	// loses to wp-admin's un-layered `a { color: ... }` rule when the Button is
+	// rendered via base-ui's `render={<a/>}` prop. Re-assert the button's own
+	// foreground color outside of any layer so the `<a>` variant renders with
+	// the correct text color.
+	body.jetpack_page_my-jetpack a[class*="__button"][class*="__is-"] {
+		color: var(--wp-ui-button-foreground-color);
+	}
+
 	// Hello Dolly compatibility fix
 	body.jetpack_page_my-jetpack p#dolly {
 		position: absolute;

--- a/projects/packages/my-jetpack/_inc/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/style.module.scss
@@ -1,14 +1,5 @@
 :global {
 
-	// @wordpress/ui Button styles live inside `@layer wp-ui-components`, which
-	// loses to wp-admin's un-layered `a { color: ... }` rule when the Button is
-	// rendered via base-ui's `render={<a/>}` prop. Re-assert the button's own
-	// foreground color outside of any layer so the `<a>` variant renders with
-	// the correct text color.
-	body.jetpack_page_my-jetpack a[class*="__button"][class*="__is-"] {
-		color: var(--wp-ui-button-foreground-color);
-	}
-
 	// Hello Dolly compatibility fix
 	body.jetpack_page_my-jetpack p#dolly {
 		position: absolute;

--- a/projects/packages/my-jetpack/changelog/feat-interstitial-buttons-wp-ui
+++ b/projects/packages/my-jetpack/changelog/feat-interstitial-buttons-wp-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Migrate interstitial Buttons from `@automattic/jetpack-components` and `@wordpress/components` to `@wordpress/ui`.


### PR DESCRIPTION
Fixes #

## Proposed changes

Follow-up to #48414. Migrates the Button imports in the My Jetpack interstitials away from `@automattic/jetpack-components` and `@wordpress/components` to the new `Button` from `@wordpress/ui`, in line with the broader [Jetpack UI Modernization](https://github.com/Automattic/jetpack/issues/48160) effort.

NOTE: disregard the Dolly quotes overlapping with action buttons, that is being worked on #48472 

<img width="1280" height="900" alt="mj-button-add-akismet-desktop" src="https://github.com/user-attachments/assets/ccde879f-0dd2-4f78-8534-752df62daac3" />
<img width="1280" height="1252" alt="mj-button-add-jetpack-ai-desktop" src="https://github.com/user-attachments/assets/8a5e3b99-a5f1-4845-a2a9-a0195cc232af" />
<img width="390" height="844" alt="mj-button-add-jetpack-ai-mobile" src="https://github.com/user-attachments/assets/d3329265-e67d-48f7-8e7c-1034a93d040f" />
<img width="1280" height="946" alt="mj-button-add-license-desktop" src="https://github.com/user-attachments/assets/2247fc14-3782-467c-adf8-ec72bc4848c4" />
<img width="1280" height="946" alt="mj-button-add-security-desktop" src="https://github.com/user-attachments/assets/f7d10ca9-ce91-4e5f-8bb9-0464d070e75e" />
<img width="390" height="844" alt="mj-button-add-security-mobile" src="https://github.com/user-attachments/assets/f6563786-778f-484d-8bb6-dec882265f01" />
<img width="1280" height="900" alt="mj-button-loading-state-desktop" src="https://github.com/user-attachments/assets/1bf865e2-315a-430a-ae6a-8d2af01f1aad" />
<img width="1280" height="900" alt="mj-button-more-requests-desktop" src="https://github.com/user-attachments/assets/ba890d1d-d315-4bcc-97cc-d0eaf351bd8f" />


### Files touched

- **`pricing-interstitial.jsx`** — free / paid / bundle tier CTAs and the actions-slot **"Use license key"** button.
- **`product-interstitial.jsx`** — actions-slot **"Use license key"** button.
- **`jetpack-ai/more-requests.jsx`** — **"Contact Us"** + **"Back"** buttons.

### Prop migration

| Old (`@automattic/jetpack-components` / `@wordpress/components`) | New (`@wordpress/ui`) |
| --- | --- |
| `variant="primary"` (default) | `variant="solid"` (default) |
| `variant="secondary"` | `variant="outline"` |
| `isLoading={ … }` | `loading={ … }` |
| `fullWidth` | small `tier-cta` width:100% class |
| `href={ url }` | `render={ <a href={ url } /> }` + `nativeButton={ false }` |
| `<Link to="..."><Button/></Link>` (invalid HTML) | `<Button render={ <Link to="..." /> } />` |

### CSS layer workaround

`@wordpress/ui` Button styles live inside `@layer wp-ui-components`. wp-admin ships an un-layered `a { color: var(--wp-admin-theme-color) }` rule which **wins** over the layered button rule (un-layered styles always beat layered ones), so any Button rendered as an anchor (via `render={<a/>}` or `render={<Link/>}`) ends up with admin link blue text instead of the button's intended foreground colour — solid-variant buttons in particular render with invisible text (blue on blue).

This PR adds a single non-layered rule in `_inc/style.module.scss` that re-asserts `--wp-ui-button-foreground-color` on anchor-rendered `@wordpress/ui` Buttons, scoped to `body.jetpack_page_my-jetpack`.

### Drive-bys

- The "Back" button in `more-requests.jsx` previously rendered as `<a><button/></a>` (invalid HTML). Moving react-router's `<Link>` into the Button's `render` prop produces a single, valid `<a>` element.

## Related product discussion/links

- [#48414](https://github.com/Automattic/jetpack/pull/48414) — interstitials unified header (PR being followed up)
- [#48160](https://github.com/Automattic/jetpack/issues/48160) — Jetpack UI Modernization tracking issue

## Does this pull request change what data or activity we track or use?

No. All `onClick` analytics handlers (`jetpack_myjetpack_interstitial_license_link_click`, `jetpack_myjetpack_product_interstitial_back_link_click`, `jetpack_ai_upgrade_contact_us`) are preserved.

## Testing instructions

1. Visit each `/wp-admin/admin.php?page=my-jetpack#/add-*` route on a Jetpack-connected site (e.g. `/add-akismet`, `/add-security`, `/add-jetpack-ai`).
2. Confirm the "Use license key" action button in the page header renders as a compact outlined button and navigates to `#/add-license`.
3. On a tiered-pricing page (e.g. `/add-akismet`, `/add-jetpack-ai`), confirm the **Free / Paid / Bundle** tier CTAs render full-width with the right primary/outline treatment.
4. Click any tier CTA; confirm only the clicked button shows the loading spinner while all three buttons disable until the action settles.
5. Force-render the Jetpack AI **"more requests"** interstitial (it's reached when the AI request quota is exhausted). Confirm the "Contact Us" button is solid-blue with white text (the layer override is what makes that work) and that "Back" is outlined.
6. Mobile / narrow viewport: header reflows, tier CTAs stack appropriately.

## Changelog

- [x] `packages/my-jetpack` — patch / changed entry covers the Button migration.

