### PR TITLE
Write: Fix slash commands inside headings and blockquotes

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-slash-command-in-heading-or-quote
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-slash-command-in-heading-or-quote
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write: Fix slash commands inside headings and blockquotes leaving behind command text instead of converting the block

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1023,10 +1023,14 @@ function insertNewBlock( tag ) {
 	const newEl = document.createElement( tag );
 	newEl.innerHTML = '<br>';
 
-	// Find the paragraph containing the slash command by scanning direct children.
+	// Find the block containing the slash command by scanning direct children.
+	// Include headings and blockquotes so slash commands work inside them.
 	let slashBlock = null;
 	for ( const child of content.children ) {
-		if ( /^(P|DIV)$/i.test( child.tagName ) && /^\/\S*$/.test( child.textContent.trim() ) ) {
+		if (
+			/^(P|DIV|H[1-6]|BLOCKQUOTE)$/i.test( child.tagName ) &&
+			/^\/\S*$/.test( child.textContent.trim() )
+		) {
 			slashBlock = child;
 			break;
 		}
@@ -1060,10 +1064,14 @@ function insertNewList( listTag ) {
 	li.innerHTML = '<br>';
 	list.appendChild( li );
 
-	// Find the paragraph containing the slash command.
+	// Find the block containing the slash command.
+	// Include headings and blockquotes so slash commands work inside them.
 	let slashBlock = null;
 	for ( const child of content.children ) {
-		if ( /^(P|DIV)$/i.test( child.tagName ) && /^\/\S*$/.test( child.textContent.trim() ) ) {
+		if (
+			/^(P|DIV|H[1-6]|BLOCKQUOTE)$/i.test( child.tagName ) &&
+			/^\/\S*$/.test( child.textContent.trim() )
+		) {
 			slashBlock = child;
 			break;
 		}
@@ -1506,7 +1514,7 @@ function insertMediaBlock( mediaEl ) {
 		insertAfter.after( mediaEl );
 		mediaEl.after( p );
 		if (
-			insertAfter.tagName === 'P' &&
+			/^(P|H[1-6]|BLOCKQUOTE)$/i.test( insertAfter.tagName ) &&
 			( ! insertAfter.textContent || ! insertAfter.textContent.trim() )
 		) {
 			insertAfter.remove();


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/RSM-2042

## Proposed changes

* Fix slash commands (e.g. `/heading`, `/quote`, `/list`) leaving behind command text when used inside headings or blockquotes
* Expand tag matching in `insertNewBlock()`, `insertNewList()`, and `insertMediaBlock()` to recognize `H1-H6` and `BLOCKQUOTE` elements as valid slash command containers — not just `P` and `DIV`
* Previously the current block was not found/replaced, leaving the slash text behind and appending the new block at the end of the document

## Related product discussion/links

* https://linear.app/a8c/issue/RSM-2042/slash-command-within-heading-or-quote-leaves-behind-command-text

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Go to a Write-enabled site and open the Write editor
2. Create a heading (type `/heading` in an empty paragraph, or use the toolbar)
3. Inside the heading, clear the text and type `/quote` — the heading should convert to a blockquote with no leftover slash text
4. Inside the blockquote, type `/heading` — the blockquote should convert to a heading
5. Inside a heading, type `/image` — the heading should be removed and the image modal should appear
6. Inside a heading, type `/divider` — the heading should be replaced with an `<hr>` (this already worked but verify)
7. Confirm normal slash commands in paragraphs still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)