### PR TITLE
Write editor: add empty paragraph when clicking below last element

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-empty-paragraph-click-below
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-empty-paragraph-click-below
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Write editor: add an empty paragraph when clicking below the last element

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1269,6 +1269,41 @@ function promoteGapAtCursor() {
 }
 
 /**
+ * Focus the end of the content area. If the last child is already an
+ * empty paragraph, place the cursor there; otherwise append a new one.
+ *
+ * @param {HTMLElement} content   - The .bw-content element.
+ * @param {Element}     lastChild - The last child element in the content.
+ */
+function focusEndOfContent( content, lastChild ) {
+	let target;
+
+	// Don't stack empty paragraphs — reuse an existing empty trailing <p>.
+	if (
+		lastChild.tagName === 'P' &&
+		! lastChild.classList.contains( 'bw-block-gap' ) &&
+		( ! lastChild.textContent || ! lastChild.textContent.trim() )
+	) {
+		target = lastChild;
+	} else {
+		target = document.createElement( 'p' );
+		target.innerHTML = '<br>';
+		content.appendChild( target );
+	}
+
+	const sel = window.getSelection();
+	const range = document.createRange();
+	range.setStart( target, 0 );
+	range.collapse( true );
+	sel.removeAllRanges();
+	sel.addRange( range );
+
+	// Focus after setting the selection so the browser doesn't
+	// scroll to the top of the contenteditable area.
+	content.focus( { preventScroll: true } );
+}
+
+/**
  * Ensure the content area always has proper block structure.
  *
  * Native contentEditable can leave bare text nodes or <br> elements as
@@ -1688,33 +1723,32 @@ const { state } = store( 'wpcom-write', {
 			const lastRect = lastChild.getBoundingClientRect();
 			if ( event.clientY <= lastRect.bottom ) return;
 
-			// Don't stack empty paragraphs — if the last element is
-			// already an empty paragraph, just place the cursor there.
+			focusEndOfContent( content, lastChild );
+		},
+
+		handleMainClick( event ) {
+			const content = getContent();
+			if ( ! content ) return;
+
+			// Only handle clicks directly on .bw-main or .bw-editor
+			// (the padding area below the content), not on child elements
+			// like the content area itself or the title.
+			const tag = event.target.tagName;
+			const cls = event.target.classList;
 			if (
-				lastChild.tagName === 'P' &&
-				! lastChild.classList.contains( 'bw-block-gap' ) &&
-				( ! lastChild.textContent || ! lastChild.textContent.trim() )
+				! ( tag === 'MAIN' && cls.contains( 'bw-main' ) ) &&
+				! ( tag === 'DIV' && cls.contains( 'bw-editor' ) )
 			) {
-				const sel = window.getSelection();
-				const range = document.createRange();
-				range.setStart( lastChild, 0 );
-				range.collapse( true );
-				sel.removeAllRanges();
-				sel.addRange( range );
 				return;
 			}
 
-			// Append a new empty paragraph and place the cursor in it.
-			const p = document.createElement( 'p' );
-			p.innerHTML = '<br>';
-			content.appendChild( p );
+			const contentRect = content.getBoundingClientRect();
+			if ( event.clientY <= contentRect.bottom ) return;
 
-			const sel = window.getSelection();
-			const range = document.createRange();
-			range.setStart( p, 0 );
-			range.collapse( true );
-			sel.removeAllRanges();
-			sel.addRange( range );
+			const lastChild = content.lastElementChild;
+			if ( ! lastChild ) return;
+
+			focusEndOfContent( content, lastChild );
 		},
 
 		repairStructure() {

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1677,6 +1677,46 @@ const { state } = store( 'wpcom-write', {
 			updateFormattingState();
 		},
 
+		handleContentClick( event ) {
+			const content = getContent();
+			if ( ! content ) return;
+
+			const lastChild = content.lastElementChild;
+			if ( ! lastChild ) return;
+
+			// Check if the click landed below the last child element.
+			const lastRect = lastChild.getBoundingClientRect();
+			if ( event.clientY <= lastRect.bottom ) return;
+
+			// Don't stack empty paragraphs — if the last element is
+			// already an empty paragraph, just place the cursor there.
+			if (
+				lastChild.tagName === 'P' &&
+				! lastChild.classList.contains( 'bw-block-gap' ) &&
+				( ! lastChild.textContent || ! lastChild.textContent.trim() )
+			) {
+				const sel = window.getSelection();
+				const range = document.createRange();
+				range.setStart( lastChild, 0 );
+				range.collapse( true );
+				sel.removeAllRanges();
+				sel.addRange( range );
+				return;
+			}
+
+			// Append a new empty paragraph and place the cursor in it.
+			const p = document.createElement( 'p' );
+			p.innerHTML = '<br>';
+			content.appendChild( p );
+
+			const sel = window.getSelection();
+			const range = document.createRange();
+			range.setStart( p, 0 );
+			range.collapse( true );
+			sel.removeAllRanges();
+			sel.addRange( range );
+		},
+
 		repairStructure() {
 			// Fires on the `input` event — after the browser mutates the DOM
 			// but before the next paint. Wraps any bare text/inline nodes that

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1269,23 +1269,39 @@ function promoteGapAtCursor() {
 }
 
 /**
- * Focus the end of the content area. If the last child is already an
- * empty paragraph, place the cursor there; otherwise append a new one.
+ * Focus the end of the content area. Reuses an existing empty trailing
+ * element when possible; otherwise appends a new empty paragraph.
  *
  * @param {HTMLElement} content   - The .bw-content element.
  * @param {Element}     lastChild - The last child element in the content.
  */
 function focusEndOfContent( content, lastChild ) {
+	const isEmpty = ! lastChild.textContent || ! lastChild.textContent.trim();
 	let target;
 
-	// Don't stack empty paragraphs — reuse an existing empty trailing <p>.
-	if (
-		lastChild.tagName === 'P' &&
-		! lastChild.classList.contains( 'bw-block-gap' ) &&
-		( ! lastChild.textContent || ! lastChild.textContent.trim() )
-	) {
-		target = lastChild;
-	} else {
+	if ( isEmpty ) {
+		const tag = lastChild.tagName;
+
+		// Reuse an empty trailing paragraph (non-gap).
+		// Reuse an empty trailing heading — the user likely wants to
+		// type into it rather than create a new paragraph below.
+		if (
+			( tag === 'P' && ! lastChild.classList.contains( 'bw-block-gap' ) ) ||
+			tag === 'H2' ||
+			tag === 'H3'
+		) {
+			target = lastChild;
+		}
+
+		// Promote a trailing gap paragraph instead of stacking a
+		// second empty paragraph beneath it.
+		if ( tag === 'P' && lastChild.classList.contains( 'bw-block-gap' ) ) {
+			lastChild.classList.remove( 'bw-block-gap' );
+			target = lastChild;
+		}
+	}
+
+	if ( ! target ) {
 		target = document.createElement( 'p' );
 		target.innerHTML = '<br>';
 		content.appendChild( target );
@@ -1716,6 +1732,10 @@ const { state } = store( 'wpcom-write', {
 			const content = getContent();
 			if ( ! content ) return;
 
+			// Don't interfere with drag selections.
+			const sel = window.getSelection();
+			if ( sel && ! sel.isCollapsed ) return;
+
 			const lastChild = content.lastElementChild;
 			if ( ! lastChild ) return;
 
@@ -1729,6 +1749,10 @@ const { state } = store( 'wpcom-write', {
 		handleMainClick( event ) {
 			const content = getContent();
 			if ( ! content ) return;
+
+			// Don't interfere with drag selections.
+			const sel = window.getSelection();
+			if ( sel && ! sel.isCollapsed ) return;
 
 			// Only handle clicks directly on .bw-main or .bw-editor
 			// (the padding area below the content), not on child elements

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -384,6 +384,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 				contenteditable="true"
 				data-wp-on--mouseup="actions.checkFormatting"
 				data-wp-on--keyup="actions.checkFormatting"
+				data-wp-on--click="actions.handleContentClick"
 				data-wp-on--input="actions.repairStructure"
 				data-wp-on--keydown="actions.handleKeyDown"
 				data-wp-on--beforeinput="actions.handleBeforeInput"

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -368,7 +368,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 	</div>
 
 	<!-- Writing area -->
-	<main class="bw-main">
+	<main class="bw-main" data-wp-on--click="actions.handleMainClick">
 		<div class="bw-editor">
 			<textarea
 				class="bw-title"


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/RSM-2194

## Proposed changes

* When a user clicks in the empty space below the last content block in the Write editor, a new empty `<p>` is appended and the cursor is placed in it.
* If the last element is already an empty paragraph, the cursor is moved there instead of stacking empty paragraphs.
* Adds a `data-wp-on--click` directive to `.bw-content` wired to a new `handleContentClick` action.
* Also handles clicks in the `.bw-main` padding area (40vh below the editor) via a `handleMainClick` action, so the cursor is never lost when clicking anywhere below the content.
* Uses `focus({ preventScroll: true })` to avoid the cursor jumping to the top of the editor on focus.
* Preserves drag selections — both click handlers bail out when the selection is non-collapsed, so drag-selecting text that ends below the last element doesn't lose the selection.
* Reuses empty trailing headings (H2/H3) — places the cursor there instead of appending a new paragraph, since the user likely intends to type into the heading.
* Promotes trailing gap paragraphs — removes the `bw-block-gap` class and reuses the element instead of stacking a second empty paragraph below a figure.

## Related product discussion/links

* RSM-2194

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Go to the Write editor (e.g. `/wp-admin/post-new.php?write=true` or the Write entry point)
* Type some text in a paragraph, then click well below the paragraph in the empty space
* **Expected**: A new empty paragraph is created and the cursor is placed in it
* Add a heading or image, then click below it in the empty space
* **Expected**: A new empty paragraph is created below the heading/image
* Click below the content area again when the last element is already an empty paragraph
* **Expected**: The cursor moves to the existing empty paragraph (no stacking)
* Click far below the editor content, in the large padding area at the bottom of the page
* **Expected**: A new paragraph is created (or existing empty one reused) and the cursor is placed in it without jumping to the top
* Add an empty heading as the last element, then click below it
* **Expected**: The cursor is placed in the existing empty heading (no new paragraph created)
* Add an image, click the gap paragraph above the image, then click well below the image
* **Expected**: The trailing gap paragraph is promoted and reused (no second empty paragraph)
* Type a few paragraphs of text, drag-select some text, and release the mouse below the last element
* **Expected**: The text selection is preserved (not replaced by a new paragraph)

🤖 Generated with [Claude Code](https://claude.com/claude-code)