### PR TITLE
Search Blocks: add hidden Post Type Scope block (Include OR Exclude)

### DIFF
--- a/projects/packages/search/changelog/add-search-blocks-post-type-filter
+++ b/projects/packages/search/changelog/add-search-blocks-post-type-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search Blocks: add a hidden Post Type Scope block that constrains results to an include/exclude post-type list.

--- a/projects/packages/search/changelog/add-search-blocks-post-type-filter
+++ b/projects/packages/search/changelog/add-search-blocks-post-type-filter
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Search Blocks: add a hidden Post Type Scope block that constrains results to an include/exclude post-type list.
+Search Blocks: Add a hidden Post Type Scope block that constrains results to an include/exclude post-type list.

--- a/projects/packages/search/src/search-blocks/blocks/post-type-filter/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/post-type-filter/block.json
@@ -1,0 +1,29 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "jetpack/post-type-filter",
+	"version": "0.1.0",
+	"title": "Post Type Scope",
+	"category": "jetpack-search",
+	"icon": "filter",
+	"description": "Constrain Jetpack Search results to a fixed set of post types, or remove specific post types from results. Renders nothing on the front end.",
+	"supports": {
+		"html": false,
+		"interactivity": true,
+		"inserter": true
+	},
+	"textdomain": "jetpack-search-pkg",
+	"attributes": {
+		"include": {
+			"type": "array",
+			"default": [],
+			"items": { "type": "string" }
+		},
+		"exclude": {
+			"type": "array",
+			"default": [],
+			"items": { "type": "string" }
+		}
+	},
+	"render": "file:./render.php"
+}

--- a/projects/packages/search/src/search-blocks/blocks/post-type-filter/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/post-type-filter/block.json
@@ -6,7 +6,7 @@
 	"title": "Post Type Scope",
 	"category": "jetpack-search",
 	"icon": "filter",
-	"description": "Constrain Jetpack Search results to a fixed set of post types, or remove specific post types from results. Renders nothing on the front end.",
+	"description": "Constrain Jetpack Search results to a fixed set of post types, or remove specific post types from results. Visible in the editor inserter and inspector for configuration; renders nothing on the front end.",
 	"supports": {
 		"html": false,
 		"interactivity": true,

--- a/projects/packages/search/src/search-blocks/blocks/post-type-filter/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/post-type-filter/block.json
@@ -14,12 +14,12 @@
 	},
 	"textdomain": "jetpack-search-pkg",
 	"attributes": {
-		"include": {
-			"type": "array",
-			"default": [],
-			"items": { "type": "string" }
+		"mode": {
+			"type": "string",
+			"enum": [ "include", "exclude" ],
+			"default": "exclude"
 		},
-		"exclude": {
+		"postTypes": {
 			"type": "array",
 			"default": [],
 			"items": { "type": "string" }

--- a/projects/packages/search/src/search-blocks/blocks/post-type-filter/class-post-type-filter.php
+++ b/projects/packages/search/src/search-blocks/blocks/post-type-filter/class-post-type-filter.php
@@ -24,10 +24,27 @@ namespace Automattic\Jetpack\Search;
 class Post_Type_Filter {
 
 	/**
+	 * Per-request cache of slugs of post types registered with
+	 * `exclude_from_search => false`. Built lazily by
+	 * `searchable_post_type_slugs()` on first call.
+	 *
+	 * Test-only: tests reset this via Reflection across `setUp`/`tearDown`
+	 * so newly-registered fixture post types take effect. Production code
+	 * never mutates this directly.
+	 *
+	 * @var string[]|null
+	 */
+	private static $searchable_cache = null;
+
+	/**
 	 * Normalize and sanitize include/exclude lists from raw block attributes.
 	 *
 	 * Output guarantees:
 	 *  - Each value is a non-empty `sanitize_key`'d string.
+	 *  - Each value is a registered post type whose `exclude_from_search`
+	 *    flag is `false` — anything else (typo, retired CPT, private type)
+	 *    is dropped silently so a stray slug can't collapse every search on
+	 *    the page to zero results by reaching ES.
 	 *  - Lists are deduplicated and re-indexed.
 	 *  - `exclude` does not contain any slug that also appears in `include`.
 	 *
@@ -35,8 +52,9 @@ class Post_Type_Filter {
 	 * @return array{include: string[], exclude: string[]}
 	 */
 	public static function build_lists( array $attributes ): array {
-		$include = static::sanitize_slug_list( $attributes['include'] ?? array() );
-		$exclude = static::sanitize_slug_list( $attributes['exclude'] ?? array() );
+		$searchable = static::searchable_post_type_slugs();
+		$include    = static::sanitize_slug_list( $attributes['include'] ?? array(), $searchable );
+		$exclude    = static::sanitize_slug_list( $attributes['exclude'] ?? array(), $searchable );
 
 		if ( ! empty( $include ) && ! empty( $exclude ) ) {
 			$exclude = array_values( array_diff( $exclude, $include ) );
@@ -52,12 +70,15 @@ class Post_Type_Filter {
 	 * Coerce a raw attribute value into a sanitized, deduped, re-indexed
 	 * list of post-type slugs. Non-arrays, non-scalars, and empty values
 	 * are dropped silently so a malformed attribute can never reach the ES
-	 * filter clause.
+	 * filter clause. When `$allowed` is provided, slugs not present in the
+	 * allowlist are also dropped — see `build_lists()` for the boundary
+	 * where this is enforced against the live post-type registry.
 	 *
-	 * @param mixed $raw Raw attribute value.
+	 * @param mixed         $raw     Raw attribute value.
+	 * @param string[]|null $allowed Optional allowlist of slugs to keep; null skips the check.
 	 * @return string[]
 	 */
-	protected static function sanitize_slug_list( $raw ): array {
+	private static function sanitize_slug_list( $raw, ?array $allowed = null ): array {
 		if ( ! is_array( $raw ) ) {
 			return array();
 		}
@@ -67,11 +88,39 @@ class Post_Type_Filter {
 				continue;
 			}
 			$slug = sanitize_key( (string) $value );
-			if ( '' !== $slug && ! in_array( $slug, $clean, true ) ) {
-				$clean[] = $slug;
+			if ( '' === $slug || in_array( $slug, $clean, true ) ) {
+				continue;
 			}
+			if ( null !== $allowed && ! in_array( $slug, $allowed, true ) ) {
+				continue;
+			}
+			$clean[] = $slug;
 		}
 		return $clean;
+	}
+
+	/**
+	 * Slugs of post types that participate in search — i.e. registered with
+	 * `exclude_from_search => false`. Cached per-request so repeated lookups
+	 * (one per attribute list per render) don't re-walk the registry.
+	 *
+	 * Returns null if `get_post_types` is unavailable (very early load,
+	 * isolated test runtime); callers treat null as "no allowlist" and
+	 * skip the registry-membership check.
+	 *
+	 * @return string[]|null
+	 */
+	private static function searchable_post_type_slugs(): ?array {
+		if ( null !== static::$searchable_cache ) {
+			return static::$searchable_cache;
+		}
+		if ( ! function_exists( 'get_post_types' ) ) {
+			return null;
+		}
+		static::$searchable_cache = array_values(
+			get_post_types( array( 'exclude_from_search' => false ) )
+		);
+		return static::$searchable_cache;
 	}
 
 	/**
@@ -90,6 +139,10 @@ class Post_Type_Filter {
 	 * @return array{include: string[], exclude: string[]}
 	 */
 	public static function merge_state( array $existing, array $contribution ): array {
+		// Existing state may be malformed (forward-compat with an older
+		// state shape); sanitize_slug_list strips bad entries. The
+		// contribution itself was already passed through `build_lists()`
+		// so it's clean at this point.
 		$existing_include = static::sanitize_slug_list( $existing['include'] ?? array() );
 		$existing_exclude = static::sanitize_slug_list( $existing['exclude'] ?? array() );
 

--- a/projects/packages/search/src/search-blocks/blocks/post-type-filter/class-post-type-filter.php
+++ b/projects/packages/search/src/search-blocks/blocks/post-type-filter/class-post-type-filter.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Post-type-filter block helpers.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+/**
+ * Helpers for the jetpack/post-type-filter hidden constraint block.
+ *
+ * The block renders nothing on the front end; it only contributes a
+ * `staticPostTypes` constraint to the shared Interactivity store, which the JS
+ * search-URL builder folds into the ES filter clause as `must.should` (include)
+ * and `must_not` (exclude).
+ *
+ * Both lists may be set on the same block. They compose as AND: results must
+ * be in the include set AND must not be in the exclude set. Excludes that also
+ * appear in the include list are dropped during normalization — the include
+ * clause already restricts to that set, so listing a slug in both is
+ * contradictory user input rather than a meaningful intent.
+ */
+class Post_Type_Filter {
+
+	/**
+	 * Normalize and sanitize include/exclude lists from raw block attributes.
+	 *
+	 * Output guarantees:
+	 *  - Each value is a non-empty `sanitize_key`'d string.
+	 *  - Lists are deduplicated and re-indexed.
+	 *  - `exclude` does not contain any slug that also appears in `include`.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return array{include: string[], exclude: string[]}
+	 */
+	public static function build_lists( array $attributes ): array {
+		$include = static::sanitize_slug_list( $attributes['include'] ?? array() );
+		$exclude = static::sanitize_slug_list( $attributes['exclude'] ?? array() );
+
+		if ( ! empty( $include ) && ! empty( $exclude ) ) {
+			$exclude = array_values( array_diff( $exclude, $include ) );
+		}
+
+		return array(
+			'include' => $include,
+			'exclude' => $exclude,
+		);
+	}
+
+	/**
+	 * Coerce a raw attribute value into a sanitized, deduped, re-indexed
+	 * list of post-type slugs. Non-arrays, non-scalars, and empty values
+	 * are dropped silently so a malformed attribute can never reach the ES
+	 * filter clause.
+	 *
+	 * @param mixed $raw Raw attribute value.
+	 * @return string[]
+	 */
+	protected static function sanitize_slug_list( $raw ): array {
+		if ( ! is_array( $raw ) ) {
+			return array();
+		}
+		$clean = array();
+		foreach ( $raw as $value ) {
+			if ( ! is_scalar( $value ) ) {
+				continue;
+			}
+			$slug = sanitize_key( (string) $value );
+			if ( '' !== $slug && ! in_array( $slug, $clean, true ) ) {
+				$clean[] = $slug;
+			}
+		}
+		return $clean;
+	}
+
+	/**
+	 * Merge a block's contribution into the existing `staticPostTypes` shape
+	 * already on the Interactivity state. Composition rule: union both lists,
+	 * then re-apply the include/exclude exclusivity normalization so a later
+	 * include doesn't leave a contradictory entry in the exclude list.
+	 *
+	 * Multiple instances of the block on the same page therefore broaden the
+	 * include set rather than intersecting it — picking intersection here
+	 * would silently zero out results when an editor stacks two blocks
+	 * configured for non-overlapping post types.
+	 *
+	 * @param array{include?: mixed, exclude?: mixed}     $existing     Current state slot value.
+	 * @param array{include: string[], exclude: string[]} $contribution New block lists.
+	 * @return array{include: string[], exclude: string[]}
+	 */
+	public static function merge_state( array $existing, array $contribution ): array {
+		$existing_include = static::sanitize_slug_list( $existing['include'] ?? array() );
+		$existing_exclude = static::sanitize_slug_list( $existing['exclude'] ?? array() );
+
+		$include = array_values( array_unique( array_merge( $existing_include, $contribution['include'] ) ) );
+		$exclude = array_values( array_unique( array_merge( $existing_exclude, $contribution['exclude'] ) ) );
+
+		if ( ! empty( $include ) && ! empty( $exclude ) ) {
+			$exclude = array_values( array_diff( $exclude, $include ) );
+		}
+
+		return array(
+			'include' => $include,
+			'exclude' => $exclude,
+		);
+	}
+}

--- a/projects/packages/search/src/search-blocks/blocks/post-type-filter/class-post-type-filter.php
+++ b/projects/packages/search/src/search-blocks/blocks/post-type-filter/class-post-type-filter.php
@@ -11,68 +11,65 @@ namespace Automattic\Jetpack\Search;
  * Helpers for the jetpack/post-type-filter hidden constraint block.
  *
  * The block renders nothing on the front end; it only contributes a
- * `staticPostTypes` constraint to the shared Interactivity store, which the JS
- * search-URL builder folds into the ES filter clause as `must.should` (include)
- * and `must_not` (exclude).
+ * single-mode (`include` OR `exclude`, never both) post-type constraint to
+ * the shared Interactivity store. The JS search-URL builder folds it into
+ * the ES filter clause as `must.should` (include) or `bool.must_not` (exclude).
  *
- * Both lists may be set on the same block. They compose as AND: results must
- * be in the include set AND must not be in the exclude set. Excludes that also
- * appear in the include list are dropped during normalization — the include
- * clause already restricts to that set, so listing a slug in both is
- * contradictory user input rather than a meaningful intent.
+ * The store slot stays the `{ include: [], exclude: [] }` shape that
+ * `store/api.js`'s `buildStaticPostTypeClauses()` consumes — this PHP
+ * helper just picks which side to populate from the block's `mode`
+ * attribute. Multi-instance composition continues to union by side, so
+ * multiple Include blocks broaden the include set and multiple Exclude
+ * blocks broaden the exclude set.
  */
 class Post_Type_Filter {
 
 	/**
 	 * Per-request cache of slugs of post types registered with
 	 * `exclude_from_search => false`. Built lazily by
-	 * `searchable_post_type_slugs()` on first call.
-	 *
-	 * Test-only: tests reset this via Reflection across `setUp`/`tearDown`
-	 * so newly-registered fixture post types take effect. Production code
-	 * never mutates this directly.
+	 * `searchable_post_type_slugs()` on first call. Tests reset this via
+	 * Reflection across `setUp`/`tearDown`; production code never mutates
+	 * it directly.
 	 *
 	 * @var string[]|null
 	 */
 	private static $searchable_cache = null;
 
 	/**
-	 * Normalize and sanitize include/exclude lists from raw block attributes.
+	 * Translate raw block attributes into the `{ include, exclude }` store
+	 * slot shape. Exactly one side will be non-empty (or both empty when
+	 * the block has no selection), matching the block's single-mode UX.
 	 *
 	 * Output guarantees:
 	 *  - Each value is a non-empty `sanitize_key`'d string.
 	 *  - Each value is a registered post type whose `exclude_from_search`
-	 *    flag is `false` — anything else (typo, retired CPT, private type)
-	 *    is dropped silently so a stray slug can't collapse every search on
-	 *    the page to zero results by reaching ES.
+	 *    flag is `false`. Anything else (typo, retired CPT, private type)
+	 *    is dropped silently so a stray slug can't collapse every search
+	 *    on the page to zero results by reaching ES.
 	 *  - Lists are deduplicated and re-indexed.
-	 *  - `exclude` does not contain any slug that also appears in `include`.
 	 *
 	 * @param array $attributes Block attributes.
 	 * @return array{include: string[], exclude: string[]}
 	 */
-	public static function build_lists( array $attributes ): array {
-		$searchable = static::searchable_post_type_slugs();
-		$include    = static::sanitize_slug_list( $attributes['include'] ?? array(), $searchable );
-		$exclude    = static::sanitize_slug_list( $attributes['exclude'] ?? array(), $searchable );
-
-		if ( ! empty( $include ) && ! empty( $exclude ) ) {
-			$exclude = array_values( array_diff( $exclude, $include ) );
-		}
+	public static function build_constraint( array $attributes ): array {
+		$mode  = ( $attributes['mode'] ?? 'exclude' ) === 'include' ? 'include' : 'exclude';
+		$slugs = static::sanitize_slug_list(
+			$attributes['postTypes'] ?? array(),
+			static::searchable_post_type_slugs()
+		);
 
 		return array(
-			'include' => $include,
-			'exclude' => $exclude,
+			'include' => 'include' === $mode ? $slugs : array(),
+			'exclude' => 'exclude' === $mode ? $slugs : array(),
 		);
 	}
 
 	/**
 	 * Coerce a raw attribute value into a sanitized, deduped, re-indexed
 	 * list of post-type slugs. Non-arrays, non-scalars, and empty values
-	 * are dropped silently so a malformed attribute can never reach the ES
-	 * filter clause. When `$allowed` is provided, slugs not present in the
-	 * allowlist are also dropped — see `build_lists()` for the boundary
-	 * where this is enforced against the live post-type registry.
+	 * are dropped silently so a malformed attribute can never reach the
+	 * ES filter clause. When `$allowed` is provided, slugs not present in
+	 * the allowlist are also dropped.
 	 *
 	 * @param mixed         $raw     Raw attribute value.
 	 * @param string[]|null $allowed Optional allowlist of slugs to keep; null skips the check.
@@ -102,11 +99,9 @@ class Post_Type_Filter {
 	/**
 	 * Slugs of post types that participate in search — i.e. registered with
 	 * `exclude_from_search => false`. Cached per-request so repeated lookups
-	 * (one per attribute list per render) don't re-walk the registry.
-	 *
-	 * Returns null if `get_post_types` is unavailable (very early load,
-	 * isolated test runtime); callers treat null as "no allowlist" and
-	 * skip the registry-membership check.
+	 * (one per render call) don't re-walk the registry. Returns null when
+	 * `get_post_types` is unavailable so callers treat that as "no allowlist"
+	 * and skip the registry-membership check.
 	 *
 	 * @return string[]|null
 	 */
@@ -125,12 +120,10 @@ class Post_Type_Filter {
 
 	/**
 	 * Merge a block's contribution into the existing `staticPostTypes` shape
-	 * already on the Interactivity state. Composition rule: union both lists,
-	 * then re-apply the include/exclude exclusivity normalization so a later
-	 * include doesn't leave a contradictory entry in the exclude list.
+	 * already on the Interactivity state. Composition rule: union both lists.
 	 *
-	 * Multiple instances of the block on the same page therefore broaden the
-	 * include set rather than intersecting it — picking intersection here
+	 * Multiple instances of the block on the same page therefore broaden
+	 * each side rather than intersecting it — picking intersection here
 	 * would silently zero out results when an editor stacks two blocks
 	 * configured for non-overlapping post types.
 	 *
@@ -139,23 +132,16 @@ class Post_Type_Filter {
 	 * @return array{include: string[], exclude: string[]}
 	 */
 	public static function merge_state( array $existing, array $contribution ): array {
-		// Existing state may be malformed (forward-compat with an older
-		// state shape); sanitize_slug_list strips bad entries. The
-		// contribution itself was already passed through `build_lists()`
+		// Existing state may be malformed (forward-compat with a future
+		// shape change); sanitize_slug_list strips bad entries. The
+		// contribution itself was already passed through `build_constraint()`
 		// so it's clean at this point.
 		$existing_include = static::sanitize_slug_list( $existing['include'] ?? array() );
 		$existing_exclude = static::sanitize_slug_list( $existing['exclude'] ?? array() );
 
-		$include = array_values( array_unique( array_merge( $existing_include, $contribution['include'] ) ) );
-		$exclude = array_values( array_unique( array_merge( $existing_exclude, $contribution['exclude'] ) ) );
-
-		if ( ! empty( $include ) && ! empty( $exclude ) ) {
-			$exclude = array_values( array_diff( $exclude, $include ) );
-		}
-
 		return array(
-			'include' => $include,
-			'exclude' => $exclude,
+			'include' => array_values( array_unique( array_merge( $existing_include, $contribution['include'] ) ) ),
+			'exclude' => array_values( array_unique( array_merge( $existing_exclude, $contribution['exclude'] ) ) ),
 		);
 	}
 }

--- a/projects/packages/search/src/search-blocks/blocks/post-type-filter/class-post-type-filter.php
+++ b/projects/packages/search/src/search-blocks/blocks/post-type-filter/class-post-type-filter.php
@@ -8,45 +8,27 @@
 namespace Automattic\Jetpack\Search;
 
 /**
- * Helpers for the jetpack/post-type-filter hidden constraint block.
+ * Server-side helpers for jetpack/post-type-filter.
  *
- * The block renders nothing on the front end; it only contributes a
- * single-mode (`include` OR `exclude`, never both) post-type constraint to
- * the shared Interactivity store. The JS search-URL builder folds it into
- * the ES filter clause as `must.should` (include) or `bool.must_not` (exclude).
- *
- * The store slot stays the `{ include: [], exclude: [] }` shape that
- * `store/api.js`'s `buildStaticPostTypeClauses()` consumes — this PHP
- * helper just picks which side to populate from the block's `mode`
- * attribute. Multi-instance composition continues to union by side, so
- * multiple Include blocks broaden the include set and multiple Exclude
- * blocks broaden the exclude set.
+ * Single-mode block (`include` OR `exclude`); the helper translates the
+ * `{ mode, postTypes }` attributes into the `{ include, exclude }` shape
+ * `store/api.js`'s `buildStaticPostTypeClauses()` consumes.
  */
 class Post_Type_Filter {
 
 	/**
-	 * Per-request cache of slugs of post types registered with
-	 * `exclude_from_search => false`. Built lazily by
-	 * `searchable_post_type_slugs()` on first call. Tests reset this via
-	 * Reflection across `setUp`/`tearDown`; production code never mutates
-	 * it directly.
+	 * Per-request cache of slugs registered with `exclude_from_search => false`.
+	 * Tests reset this via Reflection.
 	 *
 	 * @var string[]|null
 	 */
 	private static $searchable_cache = null;
 
 	/**
-	 * Translate raw block attributes into the `{ include, exclude }` store
-	 * slot shape. Exactly one side will be non-empty (or both empty when
-	 * the block has no selection), matching the block's single-mode UX.
-	 *
-	 * Output guarantees:
-	 *  - Each value is a non-empty `sanitize_key`'d string.
-	 *  - Each value is a registered post type whose `exclude_from_search`
-	 *    flag is `false`. Anything else (typo, retired CPT, private type)
-	 *    is dropped silently so a stray slug can't collapse every search
-	 *    on the page to zero results by reaching ES.
-	 *  - Lists are deduplicated and re-indexed.
+	 * Translate block attributes into `{ include, exclude }`. Slugs are
+	 * sanitized and validated against the live searchable-post-type
+	 * registry — typos / retired CPTs / private types are dropped before
+	 * reaching ES.
 	 *
 	 * @param array $attributes Block attributes.
 	 * @return array{include: string[], exclude: string[]}
@@ -65,14 +47,10 @@ class Post_Type_Filter {
 	}
 
 	/**
-	 * Coerce a raw attribute value into a sanitized, deduped, re-indexed
-	 * list of post-type slugs. Non-arrays, non-scalars, and empty values
-	 * are dropped silently so a malformed attribute can never reach the
-	 * ES filter clause. When `$allowed` is provided, slugs not present in
-	 * the allowlist are also dropped.
+	 * Sanitize, dedupe, optionally allowlist-filter a slug list.
 	 *
 	 * @param mixed         $raw     Raw attribute value.
-	 * @param string[]|null $allowed Optional allowlist of slugs to keep; null skips the check.
+	 * @param string[]|null $allowed Optional allowlist of slugs to keep.
 	 * @return string[]
 	 */
 	private static function sanitize_slug_list( $raw, ?array $allowed = null ): array {
@@ -97,13 +75,9 @@ class Post_Type_Filter {
 	}
 
 	/**
-	 * Slugs of post types that participate in search — i.e. registered with
-	 * `exclude_from_search => false`. Cached per-request so repeated lookups
-	 * (one per render call) don't re-walk the registry. Returns null when
-	 * `get_post_types` is unavailable so callers treat that as "no allowlist"
-	 * and skip the registry-membership check.
+	 * Searchable post-type slugs (lazy + cached per request).
 	 *
-	 * @return string[]|null
+	 * @return string[]|null Slug list, or null when get_post_types is unavailable.
 	 */
 	private static function searchable_post_type_slugs(): ?array {
 		if ( null !== static::$searchable_cache ) {
@@ -119,23 +93,16 @@ class Post_Type_Filter {
 	}
 
 	/**
-	 * Merge a block's contribution into the existing `staticPostTypes` shape
-	 * already on the Interactivity state. Composition rule: union both lists.
+	 * Union a block's contribution into the existing `staticPostTypes`
+	 * state slot. Multi-instance composition broadens (rather than
+	 * intersects) each side so stacked blocks cannot silently produce
+	 * zero results.
 	 *
-	 * Multiple instances of the block on the same page therefore broaden
-	 * each side rather than intersecting it — picking intersection here
-	 * would silently zero out results when an editor stacks two blocks
-	 * configured for non-overlapping post types.
-	 *
-	 * @param array{include?: mixed, exclude?: mixed}     $existing     Current state slot value.
+	 * @param array{include?: mixed, exclude?: mixed}     $existing     Current slot value.
 	 * @param array{include: string[], exclude: string[]} $contribution New block lists.
 	 * @return array{include: string[], exclude: string[]}
 	 */
 	public static function merge_state( array $existing, array $contribution ): array {
-		// Existing state may be malformed (forward-compat with a future
-		// shape change); sanitize_slug_list strips bad entries. The
-		// contribution itself was already passed through `build_constraint()`
-		// so it's clean at this point.
 		$existing_include = static::sanitize_slug_list( $existing['include'] ?? array() );
 		$existing_exclude = static::sanitize_slug_list( $existing['exclude'] ?? array() );
 

--- a/projects/packages/search/src/search-blocks/blocks/post-type-filter/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/post-type-filter/edit.js
@@ -15,10 +15,11 @@
  * one mode, then pick the post types that belong to it.
  */
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
-import { FormTokenField, PanelBody, Placeholder, RadioControl } from '@wordpress/components';
+import { FormTokenField, Icon, PanelBody, RadioControl } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useMemo, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { unseen } from '@wordpress/icons';
 
 const MODE_INCLUDE = 'include';
 const MODE_EXCLUDE = 'exclude';
@@ -240,11 +241,36 @@ export default function PostTypeFilterEdit( { attributes, setAttributes } ) {
 				</PanelBody>
 			</InspectorControls>
 			<div { ...blockProps }>
-				<Placeholder label={ __( 'Post Type Scope', 'jetpack-search-pkg' ) }>
-					<p style={ { margin: 0 } }>
-						<strong>{ previewState.label }</strong> { previewState.value }
-					</p>
-				</Placeholder>
+				{ /* Flat preview, no card chrome — matches the filter-checkbox
+				     and search-results editor previews (just an h3 + content,
+				     letting the editor's own selection outline frame it). The
+				     "Hidden on front end" eyebrow is the only addition: this
+				     block writes to interactivity state and emits no markup,
+				     and that is otherwise invisible in the canvas. */ }
+				<p
+					style={ {
+						display: 'flex',
+						alignItems: 'center',
+						gap: '4px',
+						margin: '0 0 4px',
+						fontSize: '11px',
+						textTransform: 'uppercase',
+						letterSpacing: '0.4px',
+						color: 'rgba(30, 30, 30, 0.55)',
+					} }
+				>
+					<Icon icon={ unseen } size={ 14 } />
+					<span>{ __( 'Hidden on the front end', 'jetpack-search-pkg' ) }</span>
+				</p>
+				<h3
+					className="jetpack-search-post-type-filter__title"
+					style={ { margin: '0 0 4px', fontSize: '14px', fontWeight: 600 } }
+				>
+					{ __( 'Post Type Scope', 'jetpack-search-pkg' ) }
+				</h3>
+				<p style={ { margin: 0, fontSize: '13px' } }>
+					<strong>{ previewState.label }</strong> { previewState.value }
+				</p>
 			</div>
 		</>
 	);

--- a/projects/packages/search/src/search-blocks/blocks/post-type-filter/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/post-type-filter/edit.js
@@ -1,18 +1,5 @@
 /**
  * Editor preview for jetpack/post-type-filter.
- *
- * Hidden filter: the front-end render is empty by design — this block only
- * contributes a single-mode constraint (Include OR Exclude, never both) to
- * the shared search state. The editor preview is a small Placeholder card
- * so the editor can see and configure the block without it being invisible
- * in the canvas.
- *
- * Single-mode rather than two attribute lists: combining Include and
- * Exclude on one block is technically valid (Include narrows, Exclude
- * subtracts inside it), but it confuses authors — Exclude visibly does
- * "nothing" most of the time when Include is set, since the include set
- * is already restrictive. A toggle keeps the mental model simple: pick
- * one mode, then pick the post types that belong to it.
  */
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { FormTokenField, Icon, PanelBody, RadioControl } from '@wordpress/components';
@@ -25,12 +12,12 @@ const MODE_INCLUDE = 'include';
 const MODE_EXCLUDE = 'exclude';
 
 /**
- * sanitize_key() (PHP) approximation: lowercase + strip anything that is not
- * `[a-z0-9_-]`. Mirrors how the server normalizes attribute slugs so the
- * editor's stored attribute matches what eventually reaches ES.
+ * `sanitize_key()` (PHP) approximation: lowercase + strip everything that
+ * is not `[a-z0-9_-]`. Mirrors the server normalizer so editor-stored
+ * attributes match what eventually reaches ES.
  *
  * @param {string} value - Raw token string.
- * @return {string} Sanitized slug, or empty string when nothing remains.
+ * @return {string} Sanitized slug.
  */
 function sanitizeKey( value ) {
 	return String( value || '' )
@@ -39,14 +26,12 @@ function sanitizeKey( value ) {
 }
 
 /**
- * Build a unique-by-construction display label for each post type. When two
- * types share the same `singular_name` (a plugin can register an entirely
- * different CPT with the same human label as a built-in), append the slug
- * in parentheses so the FormTokenField suggestion list stays one-to-one
- * with the underlying slug.
+ * Append `(slug)` to any label that occurs more than once so each suggestion
+ * label maps 1:1 to a slug — without this the FormTokenField label→slug
+ * lookup picks an arbitrary winner when two CPTs share a `singular_name`.
  *
  * @param {Array<{value: string, label: string}>} options - Raw slug/label list.
- * @return {Array<{value: string, label: string}>} Same shape with disambiguated labels.
+ * @return {Array<{value: string, label: string}>} Disambiguated.
  */
 function disambiguateLabels( options ) {
 	const counts = new Map();
@@ -59,13 +44,11 @@ function disambiguateLabels( options ) {
 }
 
 /**
- * Map a list of post-type slugs to the labelled token shape FormTokenField
- * expects for displayed values, falling back to the raw slug when the type
- * isn't (yet) loaded by core-data.
+ * Map slugs to FormTokenField's `{value, title}` shape.
  *
  * @param {string[]} slugs       - Stored slug list.
- * @param {Map}      labelBySlug - slug -> singular label map.
- * @return {Array<{ value: string, title: string }>} Token shape for FormTokenField.
+ * @param {Map}      labelBySlug - slug → label.
+ * @return {Array<{ value: string, title: string }>} Token shape.
  */
 function toTokens( slugs, labelBySlug ) {
 	return ( slugs || [] ).map( slug => ( {
@@ -75,15 +58,12 @@ function toTokens( slugs, labelBySlug ) {
 }
 
 /**
- * Convert FormTokenField output back into a sanitized slug list. Tokens
- * may come back as strings (free entry or label picked from suggestions)
- * or as `{ value }` objects; both resolve to the slug we store on the
- * attribute. Free-typed values pass through `sanitizeKey` so the saved
- * attribute matches what the server normalizer will produce.
+ * Convert FormTokenField output back to a sanitized, deduped slug list.
+ * Free-typed values pass through `sanitizeKey` so editor and server agree.
  *
- * @param {Array<string|{value: string}>}         tokens  - Tokens emitted by onChange.
- * @param {Array<{value: string, label: string}>} options - Resolved post-type options for label→slug lookup.
- * @return {string[]} Deduped, non-empty, sanitize_key-equivalent slug list.
+ * @param {Array<string|{value: string}>}         tokens  - Tokens from onChange.
+ * @param {Array<{value: string, label: string}>} options - Resolved options for label→slug lookup.
+ * @return {string[]} Sanitized slugs.
  */
 function tokensToSlugs( tokens, options ) {
 	const out = [];
@@ -113,11 +93,9 @@ export default function PostTypeFilterEdit( { attributes, setAttributes } ) {
 		[ attributes?.postTypes ]
 	);
 
-	// `getPostTypes()` proxies getEntityRecords( 'root', 'postType' ); it
-	// returns null until resolved and a finite list once loaded. We further
-	// drop `attachment` and any type whose `viewable` flag is `false` here;
-	// the *server* normalizer (`Post_Type_Filter::build_constraint()`) is
-	// the canonical allowlist gate against `exclude_from_search => false`.
+	// `viewable !== false` filter is a UX nicety; the canonical allowlist
+	// (`exclude_from_search => false`) is enforced server-side because the
+	// REST endpoint does not expose that flag.
 	const registeredTypes = useSelect(
 		select => select( 'core' ).getPostTypes( { per_page: -1 } ),
 		[]
@@ -150,12 +128,8 @@ export default function PostTypeFilterEdit( { attributes, setAttributes } ) {
 
 	const previewState = describePreview( mode, postTypes, labelBySlug );
 
-	// Per-mode draft cache. Lets the author flip Exclude ⇄ Include, edit
-	// each side independently, and have the previously-typed list come back
-	// when they flip back. Only the active mode's `postTypes` is persisted
-	// to attributes — the inactive draft is local to this editor session
-	// and is discarded on save / reload (matching "only the saved mode
-	// survives a page refresh").
+	// Per-mode draft cache. Flipping back to a previously-used mode restores
+	// the typed list; only the active mode's `postTypes` is persisted.
 	const draftRef = useRef( null );
 	if ( draftRef.current === null ) {
 		draftRef.current = {
@@ -168,9 +142,6 @@ export default function PostTypeFilterEdit( { attributes, setAttributes } ) {
 		if ( nextMode === mode ) {
 			return;
 		}
-		// Stash the slugs the author had under the current mode, restore
-		// whatever they had previously typed under the new mode (or an
-		// empty list when this is the first switch into that mode).
 		draftRef.current = { ...draftRef.current, [ mode ]: postTypes };
 		setAttributes( {
 			mode: nextMode,
@@ -245,12 +216,6 @@ export default function PostTypeFilterEdit( { attributes, setAttributes } ) {
 				</PanelBody>
 			</InspectorControls>
 			<div { ...blockProps }>
-				{ /* Flat preview, no card chrome — matches the filter-checkbox
-				     and search-results editor previews (just an h3 + content,
-				     letting the editor's own selection outline frame it). The
-				     "Hidden on front end" eyebrow is the only addition: this
-				     block writes to interactivity state and emits no markup,
-				     and that is otherwise invisible in the canvas. */ }
 				<p
 					style={ {
 						display: 'flex',
@@ -281,14 +246,13 @@ export default function PostTypeFilterEdit( { attributes, setAttributes } ) {
 }
 
 /**
- * Translate a label string emitted by FormTokenField back to the matching
- * post-type slug. Labels are disambiguated upstream by `disambiguateLabels()`,
- * so each label in `options` resolves to exactly one slug.
+ * Reverse `disambiguateLabels()`: a picked-suggestion label resolves back
+ * to its slug.
  *
- * @param {string} token   - Token string from FormTokenField.
+ * @param {string} token   - Token from FormTokenField.
  * @param {Array}  options - { value, label } option list.
- * @return {string} Slug, or the original token if no match. Free-typed input is
- * left untouched here; `tokensToSlugs` runs it through `sanitizeKey` before saving.
+ * @return {string} Slug, or the original token (free-typed input is
+ * sanitized later in `tokensToSlugs`).
  */
 function labelFromTokenString( token, options ) {
 	if ( ! Array.isArray( options ) ) {
@@ -299,18 +263,14 @@ function labelFromTokenString( token, options ) {
 }
 
 /**
- * Build the canvas preview copy for the current mode + selection. Returns a
- * `{ label, value }` pair that the JSX renders as `<strong>{label}</strong> {value}`.
- *
- * Mode-specific labels keep the canvas text aligned with the Inspector
- * (Include/Exclude) instead of restating "Results limited to..."  copy that
- * has to be re-read every time. Empty selections render a clear "(none
- * selected)" so the unconfigured state is unambiguous.
+ * Build the canvas preview's `{ label, value }` for the current mode +
+ * selection. An empty selection renders "(none selected)" so the
+ * unconfigured state stays explicit.
  *
  * @param {string}   mode        - 'include' | 'exclude'.
  * @param {string[]} postTypes   - Selected slug list.
- * @param {Map}      labelBySlug - slug -> label map.
- * @return {{label: string, value: string}} Preview rows.
+ * @param {Map}      labelBySlug - slug → label.
+ * @return {{label: string, value: string}} Preview row.
  */
 function describePreview( mode, postTypes, labelBySlug ) {
 	const valueText =
@@ -319,16 +279,10 @@ function describePreview( mode, postTypes, labelBySlug ) {
 			: __( '(none selected)', 'jetpack-search-pkg' );
 
 	if ( mode === MODE_INCLUDE ) {
-		return {
-			label: __( 'Include only:', 'jetpack-search-pkg' ),
-			value: valueText,
-		};
+		return { label: __( 'Include only:', 'jetpack-search-pkg' ), value: valueText };
 	}
-	return {
-		label: __( 'Exclude:', 'jetpack-search-pkg' ),
-		value: valueText,
-	};
+	return { label: __( 'Exclude:', 'jetpack-search-pkg' ), value: valueText };
 }
 
-// Re-export internals for unit tests.
+// Unit-test re-exports.
 export { sanitizeKey, disambiguateLabels, tokensToSlugs, describePreview };

--- a/projects/packages/search/src/search-blocks/blocks/post-type-filter/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/post-type-filter/edit.js
@@ -17,7 +17,7 @@
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { FormTokenField, PanelBody, Placeholder, RadioControl } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { useMemo } from '@wordpress/element';
+import { useMemo, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 const MODE_INCLUDE = 'include';
@@ -149,6 +149,40 @@ export default function PostTypeFilterEdit( { attributes, setAttributes } ) {
 
 	const previewState = describePreview( mode, postTypes, labelBySlug );
 
+	// Per-mode draft cache. Lets the author flip Exclude ⇄ Include, edit
+	// each side independently, and have the previously-typed list come back
+	// when they flip back. Only the active mode's `postTypes` is persisted
+	// to attributes — the inactive draft is local to this editor session
+	// and is discarded on save / reload (matching "only the saved mode
+	// survives a page refresh").
+	const draftRef = useRef( null );
+	if ( draftRef.current === null ) {
+		draftRef.current = {
+			[ MODE_INCLUDE ]: mode === MODE_INCLUDE ? postTypes : [],
+			[ MODE_EXCLUDE ]: mode === MODE_EXCLUDE ? postTypes : [],
+		};
+	}
+
+	const handleModeChange = nextMode => {
+		if ( nextMode === mode ) {
+			return;
+		}
+		// Stash the slugs the author had under the current mode, restore
+		// whatever they had previously typed under the new mode (or an
+		// empty list when this is the first switch into that mode).
+		draftRef.current = { ...draftRef.current, [ mode ]: postTypes };
+		setAttributes( {
+			mode: nextMode,
+			postTypes: draftRef.current[ nextMode ] || [],
+		} );
+	};
+
+	const handlePostTypesChange = tokens => {
+		const slugs = tokensToSlugs( tokens, options );
+		draftRef.current = { ...draftRef.current, [ mode ]: slugs };
+		setAttributes( { postTypes: slugs } );
+	};
+
 	return (
 		<>
 			<InspectorControls>
@@ -172,14 +206,7 @@ export default function PostTypeFilterEdit( { attributes, setAttributes } ) {
 								value: MODE_INCLUDE,
 							},
 						] }
-						onChange={ value => {
-							// Keep the slug list across mode switches so the
-							// author can flip the meaning of a typed list
-							// without re-entering it. The label and helper
-							// text on the radio + picker make the new
-							// interpretation explicit.
-							setAttributes( { mode: value } );
-						} }
+						onChange={ handleModeChange }
 					/>
 					<FormTokenField
 						__next40pxDefaultSize
@@ -193,7 +220,7 @@ export default function PostTypeFilterEdit( { attributes, setAttributes } ) {
 						suggestions={ suggestionList }
 						__experimentalExpandOnFocus
 						__experimentalShowHowTo={ false }
-						onChange={ tokens => setAttributes( { postTypes: tokensToSlugs( tokens, options ) } ) }
+						onChange={ handlePostTypesChange }
 					/>
 					<p
 						className="jetpack-search-post-type-filter__hint"

--- a/projects/packages/search/src/search-blocks/blocks/post-type-filter/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/post-type-filter/edit.js
@@ -15,13 +15,7 @@
  * one mode, then pick the post types that belong to it.
  */
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
-import {
-	__experimentalToggleGroupControl as ToggleGroupControl,
-	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
-	FormTokenField,
-	PanelBody,
-	Placeholder,
-} from '@wordpress/components';
+import { FormTokenField, PanelBody, Placeholder, RadioControl } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -159,12 +153,25 @@ export default function PostTypeFilterEdit( { attributes, setAttributes } ) {
 		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings', 'jetpack-search-pkg' ) }>
-					<ToggleGroupControl
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-						isBlock
+					<RadioControl
 						label={ __( 'Mode', 'jetpack-search-pkg' ) }
-						value={ mode }
+						selected={ mode }
+						options={ [
+							{
+								label: __(
+									'Exclude — remove the selected post types from results',
+									'jetpack-search-pkg'
+								),
+								value: MODE_EXCLUDE,
+							},
+							{
+								label: __(
+									'Include only — search will return only the selected post types',
+									'jetpack-search-pkg'
+								),
+								value: MODE_INCLUDE,
+							},
+						] }
 						onChange={ value => {
 							// Clear the slug list when switching modes so the
 							// previously-typed list can not silently flip
@@ -172,27 +179,7 @@ export default function PostTypeFilterEdit( { attributes, setAttributes } ) {
 							// "include only these" list is a footgun).
 							setAttributes( { mode: value, postTypes: [] } );
 						} }
-						help={
-							mode === MODE_INCLUDE
-								? __(
-										'Include is restrictive: only the selected post types will appear in results.',
-										'jetpack-search-pkg'
-								  )
-								: __(
-										'Exclude is subtractive: the selected post types are removed from results; everything else stays searchable.',
-										'jetpack-search-pkg'
-								  )
-						}
-					>
-						<ToggleGroupControlOption
-							value={ MODE_EXCLUDE }
-							label={ __( 'Exclude', 'jetpack-search-pkg' ) }
-						/>
-						<ToggleGroupControlOption
-							value={ MODE_INCLUDE }
-							label={ __( 'Include only', 'jetpack-search-pkg' ) }
-						/>
-					</ToggleGroupControl>
+					/>
 					<FormTokenField
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom

--- a/projects/packages/search/src/search-blocks/blocks/post-type-filter/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/post-type-filter/edit.js
@@ -173,11 +173,12 @@ export default function PostTypeFilterEdit( { attributes, setAttributes } ) {
 							},
 						] }
 						onChange={ value => {
-							// Clear the slug list when switching modes so the
-							// previously-typed list can not silently flip
-							// meaning (an "exclude these" list becoming an
-							// "include only these" list is a footgun).
-							setAttributes( { mode: value, postTypes: [] } );
+							// Keep the slug list across mode switches so the
+							// author can flip the meaning of a typed list
+							// without re-entering it. The label and helper
+							// text on the radio + picker make the new
+							// interpretation explicit.
+							setAttributes( { mode: value } );
 						} }
 					/>
 					<FormTokenField

--- a/projects/packages/search/src/search-blocks/blocks/post-type-filter/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/post-type-filter/edit.js
@@ -174,7 +174,7 @@ export default function PostTypeFilterEdit( { attributes, setAttributes } ) {
 		[ conflictingSlugs, labelBySlug ]
 	);
 
-	const previewText = describePreview( include, exclude, labelBySlug );
+	const previewState = describePreview( include, exclude, labelBySlug );
 
 	return (
 		<>
@@ -243,11 +243,29 @@ export default function PostTypeFilterEdit( { attributes, setAttributes } ) {
 				</PanelBody>
 			</InspectorControls>
 			<div { ...blockProps }>
-				<Placeholder
-					icon="filter"
-					label={ __( 'Post Type Scope', 'jetpack-search-pkg' ) }
-					instructions={ previewText }
-				/>
+				{ /* No `icon` on Placeholder: passing one offsets the label
+				     to the right of the icon while the children stay flush-
+				     left, so the title and the include/exclude rows visibly
+				     drift apart. Without an icon every line shares the same
+				     left column. */ }
+				<Placeholder label={ __( 'Post Type Scope', 'jetpack-search-pkg' ) }>
+					{ previewState.empty ? (
+						<p style={ { margin: 0 } }>
+							{ __(
+								'No constraint configured. Add post types to Include or Exclude in the block settings.',
+								'jetpack-search-pkg'
+							) }
+						</p>
+					) : (
+						<p style={ { margin: 0, lineHeight: 1.6 } }>
+							<strong>{ __( 'Include:', 'jetpack-search-pkg' ) }</strong>{ ' ' }
+							{ previewState.includeText }
+							<br />
+							<strong>{ __( 'Exclude:', 'jetpack-search-pkg' ) }</strong>{ ' ' }
+							{ previewState.excludeText }
+						</p>
+					) }
+				</Placeholder>
 			</div>
 		</>
 	);
@@ -277,44 +295,47 @@ function labelFromTokenString( token, options ) {
 }
 
 /**
- * Build the human-readable summary line for the editor preview card. Always
- * renders labels (via `labelBySlug`) rather than raw slugs so the canvas
- * preview matches the FormTokenField token display in the Inspector.
+ * Build the structured state the canvas preview renders from. Returns
+ * three pieces in one call:
+ *
+ * `empty` is true only when neither list has any values; signals the
+ * Placeholder to render the "Not set" hint instead of the include/
+ * exclude rows. `includeText` is comma-joined human labels (via
+ * `labelBySlug`) when Include has values, or a localized "(any post
+ * type)" fallback so the row's state is explicit rather than appearing
+ * blank. `excludeText` is the same shape for the Exclude side, with
+ * "(none)" as the empty-row fallback — Include and Exclude carry
+ * different semantics when empty: an empty Include means no
+ * restriction, while an empty Exclude means no exclusion.
+ *
+ * Always renders labels (via `labelBySlug`) rather than raw slugs so the
+ * canvas preview matches the FormTokenField token display in the Inspector.
  *
  * @param {string[]} include     - Include list.
  * @param {string[]} exclude     - Exclude list.
  * @param {Map}      labelBySlug - slug -> label map.
- * @return {string} Summary text.
+ * @return {{empty: boolean, includeText: string, excludeText: string}} Structured preview state.
  */
 function describePreview( include, exclude, labelBySlug ) {
 	const formatList = list => list.map( slug => labelBySlug.get( slug ) || slug ).join( ', ' );
 
-	if ( include.length === 0 && exclude.length === 0 ) {
-		return __(
-			'No constraint configured. Add post types to Include or Exclude in the block settings.',
-			'jetpack-search-pkg'
-		);
-	}
-	if ( include.length > 0 && exclude.length === 0 ) {
-		return sprintf(
-			/* translators: %s: comma-separated list of post-type labels. */
-			__( 'Results limited to: %s', 'jetpack-search-pkg' ),
-			formatList( include )
-		);
-	}
-	if ( include.length === 0 && exclude.length > 0 ) {
-		return sprintf(
-			/* translators: %s: comma-separated list of post-type labels. */
-			__( 'Results exclude: %s', 'jetpack-search-pkg' ),
-			formatList( exclude )
-		);
-	}
-	return sprintf(
-		/* translators: 1: include list, 2: exclude list. */
-		__( 'Results limited to: %1$s · Excluding: %2$s', 'jetpack-search-pkg' ),
-		formatList( include ),
-		formatList( exclude )
-	);
+	const empty = include.length === 0 && exclude.length === 0;
+
+	const includeText =
+		include.length > 0
+			? formatList( include )
+			: // Translators: shown in the editor preview when no Include
+			  // constraint is set — meaning every post type is searchable.
+			  __( '(any post type)', 'jetpack-search-pkg' );
+
+	const excludeText =
+		exclude.length > 0
+			? formatList( exclude )
+			: // Translators: shown in the editor preview when no Exclude
+			  // constraint is set — meaning nothing is removed from results.
+			  __( '(none)', 'jetpack-search-pkg' );
+
+	return { empty, includeText, excludeText };
 }
 
 // Re-export internals for unit tests (jest's module-cache picks them up via

--- a/projects/packages/search/src/search-blocks/blocks/post-type-filter/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/post-type-filter/edit.js
@@ -215,7 +215,11 @@ export default function PostTypeFilterEdit( { attributes, setAttributes } ) {
 						label={
 							mode === MODE_INCLUDE
 								? __( 'Post types to include', 'jetpack-search-pkg' )
-								: __( 'Post types to exclude', 'jetpack-search-pkg' )
+								: __(
+										'Post types to exclude',
+										'jetpack-search-pkg',
+										/* dummy arg to avoid bad minification */ 0
+								  )
 						}
 						value={ toTokens( postTypes, labelBySlug ) }
 						suggestions={ suggestionList }

--- a/projects/packages/search/src/search-blocks/blocks/post-type-filter/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/post-type-filter/edit.js
@@ -2,29 +2,37 @@
  * Editor preview for jetpack/post-type-filter.
  *
  * Hidden filter: the front-end render is empty by design — this block only
- * contributes an include/exclude constraint to the shared search state. The
- * editor preview is a small Placeholder card so the editor can see and
- * configure the block without it being invisible in the canvas.
+ * contributes a single-mode constraint (Include OR Exclude, never both) to
+ * the shared search state. The editor preview is a small Placeholder card
+ * so the editor can see and configure the block without it being invisible
+ * in the canvas.
  *
- * The Inspector exposes two FormTokenField pickers — Include and Exclude —
- * populated from registered post types via core-data. When a slug appears in
- * both lists the include side wins and we visually flag the conflict; the
- * server normalizer drops the duplicate from the exclude list before it
- * reaches the ES filter clause.
+ * Single-mode rather than two attribute lists: combining Include and
+ * Exclude on one block is technically valid (Include narrows, Exclude
+ * subtracts inside it), but it confuses authors — Exclude visibly does
+ * "nothing" most of the time when Include is set, since the include set
+ * is already restrictive. A toggle keeps the mental model simple: pick
+ * one mode, then pick the post types that belong to it.
  */
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
-import { FormTokenField, PanelBody, Placeholder } from '@wordpress/components';
+import {
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	FormTokenField,
+	PanelBody,
+	Placeholder,
+} from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
+
+const MODE_INCLUDE = 'include';
+const MODE_EXCLUDE = 'exclude';
 
 /**
  * sanitize_key() (PHP) approximation: lowercase + strip anything that is not
- * `[a-z0-9_]`. Mirrors how the server normalizes attribute slugs so the
+ * `[a-z0-9_-]`. Mirrors how the server normalizes attribute slugs so the
  * editor's stored attribute matches what eventually reaches ES.
- *
- * Hyphens — common in CPT slugs (`jetpack-portfolio`) — are preserved
- * (sanitize_key allows them too).
  *
  * @param {string} value - Raw token string.
  * @return {string} Sanitized slug, or empty string when nothing remains.
@@ -40,8 +48,7 @@ function sanitizeKey( value ) {
  * types share the same `singular_name` (a plugin can register an entirely
  * different CPT with the same human label as a built-in), append the slug
  * in parentheses so the FormTokenField suggestion list stays one-to-one
- * with the underlying slug. Without this the label→slug round-trip in
- * `labelFromTokenString()` would silently always pick the first match.
+ * with the underlying slug.
  *
  * @param {Array<{value: string, label: string}>} options - Raw slug/label list.
  * @return {Array<{value: string, label: string}>} Same shape with disambiguated labels.
@@ -73,13 +80,11 @@ function toTokens( slugs, labelBySlug ) {
 }
 
 /**
- * Convert the FormTokenField output back into a sanitized slug list. Tokens
- * may come back as strings (free entry or, in our setup, a label picked
- * from suggestions) or as `{ value }` objects; both resolve to the slug we
- * store on the attribute. Free-typed values are passed through `sanitizeKey`
- * so the saved attribute matches what the server normalizer will produce —
- * otherwise a typed `"Post"` and a typed `"post"` would both end up sent to
- * ES as `post` while the editor saw them as distinct entries.
+ * Convert FormTokenField output back into a sanitized slug list. Tokens
+ * may come back as strings (free entry or label picked from suggestions)
+ * or as `{ value }` objects; both resolve to the slug we store on the
+ * attribute. Free-typed values pass through `sanitizeKey` so the saved
+ * attribute matches what the server normalizer will produce.
  *
  * @param {Array<string|{value: string}>}         tokens  - Tokens emitted by onChange.
  * @param {Array<{value: string, label: string}>} options - Resolved post-type options for label→slug lookup.
@@ -88,9 +93,6 @@ function toTokens( slugs, labelBySlug ) {
 function tokensToSlugs( tokens, options ) {
 	const out = [];
 	for ( const token of tokens || [] ) {
-		// Strings come from FormTokenField when the user picks a suggestion
-		// or types freely; objects only show up when we round-trip our own
-		// `{value, title}` shape from `toTokens()`.
 		const raw = typeof token === 'string' ? labelFromTokenString( token, options ) : token?.value;
 		const slug = sanitizeKey( raw );
 		if ( slug && ! out.includes( slug ) ) {
@@ -110,40 +112,35 @@ function tokensToSlugs( tokens, options ) {
  */
 export default function PostTypeFilterEdit( { attributes, setAttributes } ) {
 	const blockProps = useBlockProps();
-	// Memoize the array reads: a fresh `[]` on each render would otherwise
-	// invalidate every downstream useMemo that lists these as dependencies.
-	const include = useMemo(
-		() => ( Array.isArray( attributes?.include ) ? attributes.include : [] ),
-		[ attributes?.include ]
-	);
-	const exclude = useMemo(
-		() => ( Array.isArray( attributes?.exclude ) ? attributes.exclude : [] ),
-		[ attributes?.exclude ]
+	const mode = attributes?.mode === MODE_INCLUDE ? MODE_INCLUDE : MODE_EXCLUDE;
+	const postTypes = useMemo(
+		() => ( Array.isArray( attributes?.postTypes ) ? attributes.postTypes : [] ),
+		[ attributes?.postTypes ]
 	);
 
 	// `getPostTypes()` proxies getEntityRecords( 'root', 'postType' ); it
 	// returns null until resolved and a finite list once loaded. We further
-	// drop `attachment` and any type whose `viewable` flag is `false` here.
-	// We can't filter by `exclude_from_search` from JS — the REST endpoint
-	// does not expose that flag — so the *server* normalizer
-	// (`Post_Type_Filter::build_lists()`) is the canonical allowlist gate.
-	// The editor list may include a few search-excluded types; saving them
-	// is harmless because they'll be dropped on render.
-	const postTypes = useSelect( select => select( 'core' ).getPostTypes( { per_page: -1 } ), [] );
+	// drop `attachment` and any type whose `viewable` flag is `false` here;
+	// the *server* normalizer (`Post_Type_Filter::build_constraint()`) is
+	// the canonical allowlist gate against `exclude_from_search => false`.
+	const registeredTypes = useSelect(
+		select => select( 'core' ).getPostTypes( { per_page: -1 } ),
+		[]
+	);
 
 	const options = useMemo( () => {
-		if ( ! Array.isArray( postTypes ) ) {
+		if ( ! Array.isArray( registeredTypes ) ) {
 			return null;
 		}
 		return disambiguateLabels(
-			postTypes
+			registeredTypes
 				.filter( type => type?.slug && type.slug !== 'attachment' && type?.viewable !== false )
 				.map( type => ( {
 					value: type.slug,
 					label: type?.labels?.singular_name || type?.name || type.slug,
 				} ) )
 		);
-	}, [ postTypes ] );
+	}, [ registeredTypes ] );
 
 	const labelBySlug = useMemo( () => {
 		const map = new Map();
@@ -156,75 +153,60 @@ export default function PostTypeFilterEdit( { attributes, setAttributes } ) {
 		[ options ]
 	);
 
-	const onChangeList = key => tokens => {
-		setAttributes( { [ key ]: tokensToSlugs( tokens, options ) } );
-	};
-
-	// Compare via `sanitizeKey` so case/punctuation differences that the
-	// server normalizer collapses to the same slug also flag here. Without
-	// this, `Post` in Include and `post` in Exclude would not surface a
-	// conflict in the editor even though the server drops one of them.
-	const conflictingSlugs = useMemo( () => {
-		const includeNorm = new Set( include.map( sanitizeKey ).filter( Boolean ) );
-		return exclude.map( sanitizeKey ).filter( slug => slug && includeNorm.has( slug ) );
-	}, [ include, exclude ] );
-
-	const conflictingLabels = useMemo(
-		() => conflictingSlugs.map( slug => labelBySlug.get( slug ) || slug ),
-		[ conflictingSlugs, labelBySlug ]
-	);
-
-	const previewState = describePreview( include, exclude, labelBySlug );
+	const previewState = describePreview( mode, postTypes, labelBySlug );
 
 	return (
 		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings', 'jetpack-search-pkg' ) }>
+					<ToggleGroupControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						isBlock
+						label={ __( 'Mode', 'jetpack-search-pkg' ) }
+						value={ mode }
+						onChange={ value => {
+							// Clear the slug list when switching modes so the
+							// previously-typed list can not silently flip
+							// meaning (an "exclude these" list becoming an
+							// "include only these" list is a footgun).
+							setAttributes( { mode: value, postTypes: [] } );
+						} }
+						help={
+							mode === MODE_INCLUDE
+								? __(
+										'Include is restrictive: only the selected post types will appear in results.',
+										'jetpack-search-pkg'
+								  )
+								: __(
+										'Exclude is subtractive: the selected post types are removed from results; everything else stays searchable.',
+										'jetpack-search-pkg'
+								  )
+						}
+					>
+						<ToggleGroupControlOption
+							value={ MODE_EXCLUDE }
+							label={ __( 'Exclude', 'jetpack-search-pkg' ) }
+						/>
+						<ToggleGroupControlOption
+							value={ MODE_INCLUDE }
+							label={ __( 'Include only', 'jetpack-search-pkg' ) }
+						/>
+					</ToggleGroupControl>
 					<FormTokenField
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom
-						label={ __( 'Include only these post types', 'jetpack-search-pkg' ) }
-						value={ toTokens( include, labelBySlug ) }
+						label={
+							mode === MODE_INCLUDE
+								? __( 'Post types to include', 'jetpack-search-pkg' )
+								: __( 'Post types to exclude', 'jetpack-search-pkg' )
+						}
+						value={ toTokens( postTypes, labelBySlug ) }
 						suggestions={ suggestionList }
 						__experimentalExpandOnFocus
 						__experimentalShowHowTo={ false }
-						onChange={ onChangeList( 'include' ) }
+						onChange={ tokens => setAttributes( { postTypes: tokensToSlugs( tokens, options ) } ) }
 					/>
-					<FormTokenField
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-						label={ __( 'Exclude these post types', 'jetpack-search-pkg' ) }
-						value={ toTokens( exclude, labelBySlug ) }
-						suggestions={ suggestionList }
-						__experimentalExpandOnFocus
-						__experimentalShowHowTo={ false }
-						onChange={ onChangeList( 'exclude' ) }
-					/>
-					{ conflictingLabels.length > 0 && (
-						<p
-							className="jetpack-search-post-type-filter__conflict"
-							style={ {
-								// Inline because the editor build pipeline has no CSS
-								// loader — see tools/webpack.blocks-editor.config.js. The
-								// warning tone (matches WP admin notice color #d63638)
-								// lifts the conflict notice off the picker stack so
-								// authors see it before saving.
-								color: '#d63638',
-								fontSize: '12px',
-								marginTop: '8px',
-								marginBottom: 0,
-							} }
-						>
-							{ sprintf(
-								/* translators: %s: comma-separated list of post-type labels appearing in both Include and Exclude. */
-								__(
-									'These post types are listed in both Include and Exclude — Include wins, the duplicate is dropped from Exclude: %s',
-									'jetpack-search-pkg'
-								),
-								conflictingLabels.join( ', ' )
-							) }
-						</p>
-					) }
 					<p
 						className="jetpack-search-post-type-filter__hint"
 						style={ {
@@ -243,28 +225,10 @@ export default function PostTypeFilterEdit( { attributes, setAttributes } ) {
 				</PanelBody>
 			</InspectorControls>
 			<div { ...blockProps }>
-				{ /* No `icon` on Placeholder: passing one offsets the label
-				     to the right of the icon while the children stay flush-
-				     left, so the title and the include/exclude rows visibly
-				     drift apart. Without an icon every line shares the same
-				     left column. */ }
 				<Placeholder label={ __( 'Post Type Scope', 'jetpack-search-pkg' ) }>
-					{ previewState.empty ? (
-						<p style={ { margin: 0 } }>
-							{ __(
-								'No constraint configured. Add post types to Include or Exclude in the block settings.',
-								'jetpack-search-pkg'
-							) }
-						</p>
-					) : (
-						<p style={ { margin: 0, lineHeight: 1.6 } }>
-							<strong>{ __( 'Include:', 'jetpack-search-pkg' ) }</strong>{ ' ' }
-							{ previewState.includeText }
-							<br />
-							<strong>{ __( 'Exclude:', 'jetpack-search-pkg' ) }</strong>{ ' ' }
-							{ previewState.excludeText }
-						</p>
-					) }
+					<p style={ { margin: 0 } }>
+						<strong>{ previewState.label }</strong> { previewState.value }
+					</p>
 				</Placeholder>
 			</div>
 		</>
@@ -273,13 +237,8 @@ export default function PostTypeFilterEdit( { attributes, setAttributes } ) {
 
 /**
  * Translate a label string emitted by FormTokenField back to the matching
- * post-type slug. FormTokenField returns the label rather than the slug
- * because we feed it labels in the suggestions array; this is the inverse
- * lookup so attributes stay slug-keyed.
- *
- * Labels are disambiguated upstream by `disambiguateLabels()`, so each label
- * in `options` resolves to exactly one slug — `Array.find()` is unambiguous
- * even when two CPTs share a `singular_name`.
+ * post-type slug. Labels are disambiguated upstream by `disambiguateLabels()`,
+ * so each label in `options` resolves to exactly one slug.
  *
  * @param {string} token   - Token string from FormTokenField.
  * @param {Array}  options - { value, label } option list.
@@ -295,49 +254,36 @@ function labelFromTokenString( token, options ) {
 }
 
 /**
- * Build the structured state the canvas preview renders from. Returns
- * three pieces in one call:
+ * Build the canvas preview copy for the current mode + selection. Returns a
+ * `{ label, value }` pair that the JSX renders as `<strong>{label}</strong> {value}`.
  *
- * `empty` is true only when neither list has any values; signals the
- * Placeholder to render the "Not set" hint instead of the include/
- * exclude rows. `includeText` is comma-joined human labels (via
- * `labelBySlug`) when Include has values, or a localized "(any post
- * type)" fallback so the row's state is explicit rather than appearing
- * blank. `excludeText` is the same shape for the Exclude side, with
- * "(none)" as the empty-row fallback — Include and Exclude carry
- * different semantics when empty: an empty Include means no
- * restriction, while an empty Exclude means no exclusion.
+ * Mode-specific labels keep the canvas text aligned with the Inspector
+ * (Include/Exclude) instead of restating "Results limited to..."  copy that
+ * has to be re-read every time. Empty selections render a clear "(none
+ * selected)" so the unconfigured state is unambiguous.
  *
- * Always renders labels (via `labelBySlug`) rather than raw slugs so the
- * canvas preview matches the FormTokenField token display in the Inspector.
- *
- * @param {string[]} include     - Include list.
- * @param {string[]} exclude     - Exclude list.
+ * @param {string}   mode        - 'include' | 'exclude'.
+ * @param {string[]} postTypes   - Selected slug list.
  * @param {Map}      labelBySlug - slug -> label map.
- * @return {{empty: boolean, includeText: string, excludeText: string}} Structured preview state.
+ * @return {{label: string, value: string}} Preview rows.
  */
-function describePreview( include, exclude, labelBySlug ) {
-	const formatList = list => list.map( slug => labelBySlug.get( slug ) || slug ).join( ', ' );
+function describePreview( mode, postTypes, labelBySlug ) {
+	const valueText =
+		postTypes.length > 0
+			? postTypes.map( slug => labelBySlug.get( slug ) || slug ).join( ', ' )
+			: __( '(none selected)', 'jetpack-search-pkg' );
 
-	const empty = include.length === 0 && exclude.length === 0;
-
-	const includeText =
-		include.length > 0
-			? formatList( include )
-			: // Translators: shown in the editor preview when no Include
-			  // constraint is set — meaning every post type is searchable.
-			  __( '(any post type)', 'jetpack-search-pkg' );
-
-	const excludeText =
-		exclude.length > 0
-			? formatList( exclude )
-			: // Translators: shown in the editor preview when no Exclude
-			  // constraint is set — meaning nothing is removed from results.
-			  __( '(none)', 'jetpack-search-pkg' );
-
-	return { empty, includeText, excludeText };
+	if ( mode === MODE_INCLUDE ) {
+		return {
+			label: __( 'Include only:', 'jetpack-search-pkg' ),
+			value: valueText,
+		};
+	}
+	return {
+		label: __( 'Exclude:', 'jetpack-search-pkg' ),
+		value: valueText,
+	};
 }
 
-// Re-export internals for unit tests (jest's module-cache picks them up via
-// `import * as`).
+// Re-export internals for unit tests.
 export { sanitizeKey, disambiguateLabels, tokensToSlugs, describePreview };

--- a/projects/packages/search/src/search-blocks/blocks/post-type-filter/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/post-type-filter/edit.js
@@ -1,0 +1,239 @@
+/**
+ * Editor preview for jetpack/post-type-filter.
+ *
+ * Hidden filter: the front-end render is empty by design — this block only
+ * contributes an include/exclude constraint to the shared search state. The
+ * editor preview is a small Placeholder card so the editor can see and
+ * configure the block without it being invisible in the canvas.
+ *
+ * The Inspector exposes two FormTokenField pickers — Include and Exclude —
+ * populated from registered post types via core-data. When a slug appears in
+ * both lists the include side wins and we visually flag the conflict; the
+ * server normalizer drops the duplicate from the exclude list before it
+ * reaches the ES filter clause.
+ */
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { FormTokenField, PanelBody, Placeholder } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { Fragment, useMemo } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Map a list of post-type slugs to the labelled token shape FormTokenField
+ * expects for displayed values, falling back to the raw slug when the type
+ * isn't (yet) loaded by core-data.
+ *
+ * @param {string[]} slugs       - Stored slug list.
+ * @param {Map}      labelBySlug - slug -> singular label map.
+ * @return {Array<{ value: string, title: string }>} Token shape for FormTokenField.
+ */
+function toTokens( slugs, labelBySlug ) {
+	return ( slugs || [] ).map( slug => ( {
+		value: slug,
+		title: labelBySlug.get( slug ) || slug,
+	} ) );
+}
+
+/**
+ * Convert the FormTokenField output back into a sanitized slug list. Tokens
+ * may come back as strings (free entry) or as `{ value }` objects (suggestion
+ * pick); both resolve to the slug we store on the attribute.
+ *
+ * @param {Array<string|{value: string}>} tokens - Tokens emitted by onChange.
+ * @return {string[]} Deduped, non-empty slug list.
+ */
+function tokensToSlugs( tokens ) {
+	const out = [];
+	for ( const token of tokens || [] ) {
+		const slug = typeof token === 'string' ? token : token?.value || '';
+		const trimmed = slug.trim();
+		if ( trimmed && ! out.includes( trimmed ) ) {
+			out.push( trimmed );
+		}
+	}
+	return out;
+}
+
+/**
+ * Edit component for the post-type-filter block.
+ *
+ * @param {object}   props               - Block props.
+ * @param {object}   props.attributes    - Saved block attributes.
+ * @param {Function} props.setAttributes - Attribute setter.
+ * @return {object} Rendered element.
+ */
+export default function PostTypeFilterEdit( { attributes, setAttributes } ) {
+	const blockProps = useBlockProps();
+	// Memoize the array reads: a fresh `[]` on each render would otherwise
+	// invalidate every downstream useMemo that lists these as dependencies.
+	const include = useMemo(
+		() => ( Array.isArray( attributes?.include ) ? attributes.include : [] ),
+		[ attributes?.include ]
+	);
+	const exclude = useMemo(
+		() => ( Array.isArray( attributes?.exclude ) ? attributes.exclude : [] ),
+		[ attributes?.exclude ]
+	);
+
+	// `getPostTypes()` proxies getEntityRecords( 'root', 'postType' ); it
+	// returns null until resolved and a finite list once loaded. The result
+	// already excludes private / non-public types in the default REST view,
+	// so we only need to filter out `attachment` and any type that opts out
+	// of search to match the aggregation surface.
+	const postTypes = useSelect( select => select( 'core' ).getPostTypes( { per_page: -1 } ), [] );
+
+	const options = useMemo( () => {
+		if ( ! Array.isArray( postTypes ) ) {
+			return null;
+		}
+		return postTypes
+			.filter( type => type?.slug && type.slug !== 'attachment' && type?.viewable !== false )
+			.map( type => ( {
+				value: type.slug,
+				label: type?.labels?.singular_name || type?.name || type.slug,
+			} ) );
+	}, [ postTypes ] );
+
+	const labelBySlug = useMemo( () => {
+		const map = new Map();
+		( options || [] ).forEach( option => map.set( option.value, option.label ) );
+		return map;
+	}, [ options ] );
+
+	const suggestionList = useMemo(
+		() => ( options || [] ).map( option => option.label ),
+		[ options ]
+	);
+
+	const onChangeList = key => tokens => {
+		const slugs = tokensToSlugs(
+			tokens.map( token => {
+				// FormTokenField emits the suggestion *label* on pick (because we
+				// pass labels in `suggestions`). Translate that label back to the
+				// canonical slug so the attribute stores stable values.
+				const slug =
+					typeof token === 'string' ? labelFromTokenString( token, options ) : token?.value;
+				return slug || token;
+			} )
+		);
+		setAttributes( { [ key ]: slugs } );
+	};
+
+	const conflictingSlugs = useMemo(
+		() => include.filter( slug => exclude.includes( slug ) ),
+		[ include, exclude ]
+	);
+
+	const previewText = describePreview( include, exclude, labelBySlug );
+
+	return (
+		<Fragment>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings', 'jetpack-search-pkg' ) }>
+					<FormTokenField
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Include only these post types', 'jetpack-search-pkg' ) }
+						value={ toTokens( include, labelBySlug ) }
+						suggestions={ suggestionList }
+						__experimentalExpandOnFocus
+						__experimentalShowHowTo={ false }
+						onChange={ onChangeList( 'include' ) }
+					/>
+					<FormTokenField
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Exclude these post types', 'jetpack-search-pkg' ) }
+						value={ toTokens( exclude, labelBySlug ) }
+						suggestions={ suggestionList }
+						__experimentalExpandOnFocus
+						__experimentalShowHowTo={ false }
+						onChange={ onChangeList( 'exclude' ) }
+					/>
+					{ conflictingSlugs.length > 0 && (
+						<p className="jetpack-search-post-type-filter__conflict">
+							{ sprintf(
+								/* translators: %s: comma-separated list of conflicting post-type slugs. */
+								__(
+									'These post types are listed in both Include and Exclude — Include wins, the duplicate is dropped from Exclude: %s',
+									'jetpack-search-pkg'
+								),
+								conflictingSlugs.join( ', ' )
+							) }
+						</p>
+					) }
+					<p className="jetpack-search-post-type-filter__hint">
+						{ __(
+							'This block does not render anything on the front end — it only constrains which post types Jetpack Search returns.',
+							'jetpack-search-pkg'
+						) }
+					</p>
+				</PanelBody>
+			</InspectorControls>
+			<div { ...blockProps }>
+				<Placeholder
+					icon="filter"
+					label={ __( 'Post Type Scope', 'jetpack-search-pkg' ) }
+					instructions={ previewText }
+				/>
+			</div>
+		</Fragment>
+	);
+}
+
+/**
+ * Translate a label string emitted by FormTokenField back to the matching
+ * post-type slug. FormTokenField returns the label rather than the slug
+ * because we feed it labels in the suggestions array; this is the inverse
+ * lookup so attributes stay slug-keyed.
+ *
+ * @param {string} token   - Token string from FormTokenField.
+ * @param {Array}  options - { value, label } option list.
+ * @return {string} Slug, or the original token if no match.
+ */
+function labelFromTokenString( token, options ) {
+	if ( ! Array.isArray( options ) ) {
+		return token;
+	}
+	const match = options.find( option => option.label === token || option.value === token );
+	return match ? match.value : token;
+}
+
+/**
+ * Build the human-readable summary line for the editor preview card.
+ *
+ * @param {string[]} include     - Include list.
+ * @param {string[]} exclude     - Exclude list.
+ * @param {Map}      labelBySlug - slug -> label map.
+ * @return {string} Summary text.
+ */
+function describePreview( include, exclude, labelBySlug ) {
+	const formatList = list => list.map( slug => labelBySlug.get( slug ) || slug ).join( ', ' );
+
+	if ( include.length === 0 && exclude.length === 0 ) {
+		return __(
+			'No constraint configured. Add post types to Include or Exclude in the block settings.',
+			'jetpack-search-pkg'
+		);
+	}
+	if ( include.length > 0 && exclude.length === 0 ) {
+		return sprintf(
+			/* translators: %s: comma-separated list of post-type labels. */
+			__( 'Results limited to: %s', 'jetpack-search-pkg' ),
+			formatList( include )
+		);
+	}
+	if ( include.length === 0 && exclude.length > 0 ) {
+		return sprintf(
+			/* translators: %s: comma-separated list of post-type labels. */
+			__( 'Results exclude: %s', 'jetpack-search-pkg' ),
+			formatList( exclude )
+		);
+	}
+	return sprintf(
+		/* translators: 1: include list, 2: exclude list. */
+		__( 'Results limited to: %1$s · Excluding: %2$s', 'jetpack-search-pkg' ),
+		formatList( include ),
+		formatList( exclude )
+	);
+}

--- a/projects/packages/search/src/search-blocks/blocks/post-type-filter/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/post-type-filter/edit.js
@@ -15,8 +15,46 @@
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { FormTokenField, PanelBody, Placeholder } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { Fragment, useMemo } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * sanitize_key() (PHP) approximation: lowercase + strip anything that is not
+ * `[a-z0-9_]`. Mirrors how the server normalizes attribute slugs so the
+ * editor's stored attribute matches what eventually reaches ES.
+ *
+ * Hyphens — common in CPT slugs (`jetpack-portfolio`) — are preserved
+ * (sanitize_key allows them too).
+ *
+ * @param {string} value - Raw token string.
+ * @return {string} Sanitized slug, or empty string when nothing remains.
+ */
+function sanitizeKey( value ) {
+	return String( value || '' )
+		.toLowerCase()
+		.replace( /[^a-z0-9_-]+/g, '' );
+}
+
+/**
+ * Build a unique-by-construction display label for each post type. When two
+ * types share the same `singular_name` (a plugin can register an entirely
+ * different CPT with the same human label as a built-in), append the slug
+ * in parentheses so the FormTokenField suggestion list stays one-to-one
+ * with the underlying slug. Without this the label→slug round-trip in
+ * `labelFromTokenString()` would silently always pick the first match.
+ *
+ * @param {Array<{value: string, label: string}>} options - Raw slug/label list.
+ * @return {Array<{value: string, label: string}>} Same shape with disambiguated labels.
+ */
+function disambiguateLabels( options ) {
+	const counts = new Map();
+	for ( const { label } of options ) {
+		counts.set( label, ( counts.get( label ) || 0 ) + 1 );
+	}
+	return options.map( opt =>
+		counts.get( opt.label ) > 1 ? { ...opt, label: `${ opt.label } (${ opt.value })` } : opt
+	);
+}
 
 /**
  * Map a list of post-type slugs to the labelled token shape FormTokenField
@@ -36,19 +74,27 @@ function toTokens( slugs, labelBySlug ) {
 
 /**
  * Convert the FormTokenField output back into a sanitized slug list. Tokens
- * may come back as strings (free entry) or as `{ value }` objects (suggestion
- * pick); both resolve to the slug we store on the attribute.
+ * may come back as strings (free entry or, in our setup, a label picked
+ * from suggestions) or as `{ value }` objects; both resolve to the slug we
+ * store on the attribute. Free-typed values are passed through `sanitizeKey`
+ * so the saved attribute matches what the server normalizer will produce —
+ * otherwise a typed `"Post"` and a typed `"post"` would both end up sent to
+ * ES as `post` while the editor saw them as distinct entries.
  *
- * @param {Array<string|{value: string}>} tokens - Tokens emitted by onChange.
- * @return {string[]} Deduped, non-empty slug list.
+ * @param {Array<string|{value: string}>}         tokens  - Tokens emitted by onChange.
+ * @param {Array<{value: string, label: string}>} options - Resolved post-type options for label→slug lookup.
+ * @return {string[]} Deduped, non-empty, sanitize_key-equivalent slug list.
  */
-function tokensToSlugs( tokens ) {
+function tokensToSlugs( tokens, options ) {
 	const out = [];
 	for ( const token of tokens || [] ) {
-		const slug = typeof token === 'string' ? token : token?.value || '';
-		const trimmed = slug.trim();
-		if ( trimmed && ! out.includes( trimmed ) ) {
-			out.push( trimmed );
+		// Strings come from FormTokenField when the user picks a suggestion
+		// or types freely; objects only show up when we round-trip our own
+		// `{value, title}` shape from `toTokens()`.
+		const raw = typeof token === 'string' ? labelFromTokenString( token, options ) : token?.value;
+		const slug = sanitizeKey( raw );
+		if ( slug && ! out.includes( slug ) ) {
+			out.push( slug );
 		}
 	}
 	return out;
@@ -76,22 +122,27 @@ export default function PostTypeFilterEdit( { attributes, setAttributes } ) {
 	);
 
 	// `getPostTypes()` proxies getEntityRecords( 'root', 'postType' ); it
-	// returns null until resolved and a finite list once loaded. The result
-	// already excludes private / non-public types in the default REST view,
-	// so we only need to filter out `attachment` and any type that opts out
-	// of search to match the aggregation surface.
+	// returns null until resolved and a finite list once loaded. We further
+	// drop `attachment` and any type whose `viewable` flag is `false` here.
+	// We can't filter by `exclude_from_search` from JS — the REST endpoint
+	// does not expose that flag — so the *server* normalizer
+	// (`Post_Type_Filter::build_lists()`) is the canonical allowlist gate.
+	// The editor list may include a few search-excluded types; saving them
+	// is harmless because they'll be dropped on render.
 	const postTypes = useSelect( select => select( 'core' ).getPostTypes( { per_page: -1 } ), [] );
 
 	const options = useMemo( () => {
 		if ( ! Array.isArray( postTypes ) ) {
 			return null;
 		}
-		return postTypes
-			.filter( type => type?.slug && type.slug !== 'attachment' && type?.viewable !== false )
-			.map( type => ( {
-				value: type.slug,
-				label: type?.labels?.singular_name || type?.name || type.slug,
-			} ) );
+		return disambiguateLabels(
+			postTypes
+				.filter( type => type?.slug && type.slug !== 'attachment' && type?.viewable !== false )
+				.map( type => ( {
+					value: type.slug,
+					label: type?.labels?.singular_name || type?.name || type.slug,
+				} ) )
+		);
 	}, [ postTypes ] );
 
 	const labelBySlug = useMemo( () => {
@@ -106,28 +157,27 @@ export default function PostTypeFilterEdit( { attributes, setAttributes } ) {
 	);
 
 	const onChangeList = key => tokens => {
-		const slugs = tokensToSlugs(
-			tokens.map( token => {
-				// FormTokenField emits the suggestion *label* on pick (because we
-				// pass labels in `suggestions`). Translate that label back to the
-				// canonical slug so the attribute stores stable values.
-				const slug =
-					typeof token === 'string' ? labelFromTokenString( token, options ) : token?.value;
-				return slug || token;
-			} )
-		);
-		setAttributes( { [ key ]: slugs } );
+		setAttributes( { [ key ]: tokensToSlugs( tokens, options ) } );
 	};
 
-	const conflictingSlugs = useMemo(
-		() => include.filter( slug => exclude.includes( slug ) ),
-		[ include, exclude ]
+	// Compare via `sanitizeKey` so case/punctuation differences that the
+	// server normalizer collapses to the same slug also flag here. Without
+	// this, `Post` in Include and `post` in Exclude would not surface a
+	// conflict in the editor even though the server drops one of them.
+	const conflictingSlugs = useMemo( () => {
+		const includeNorm = new Set( include.map( sanitizeKey ).filter( Boolean ) );
+		return exclude.map( sanitizeKey ).filter( slug => slug && includeNorm.has( slug ) );
+	}, [ include, exclude ] );
+
+	const conflictingLabels = useMemo(
+		() => conflictingSlugs.map( slug => labelBySlug.get( slug ) || slug ),
+		[ conflictingSlugs, labelBySlug ]
 	);
 
 	const previewText = describePreview( include, exclude, labelBySlug );
 
 	return (
-		<Fragment>
+		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings', 'jetpack-search-pkg' ) }>
 					<FormTokenField
@@ -150,19 +200,41 @@ export default function PostTypeFilterEdit( { attributes, setAttributes } ) {
 						__experimentalShowHowTo={ false }
 						onChange={ onChangeList( 'exclude' ) }
 					/>
-					{ conflictingSlugs.length > 0 && (
-						<p className="jetpack-search-post-type-filter__conflict">
+					{ conflictingLabels.length > 0 && (
+						<p
+							className="jetpack-search-post-type-filter__conflict"
+							style={ {
+								// Inline because the editor build pipeline has no CSS
+								// loader — see tools/webpack.blocks-editor.config.js. The
+								// warning tone (matches WP admin notice color #d63638)
+								// lifts the conflict notice off the picker stack so
+								// authors see it before saving.
+								color: '#d63638',
+								fontSize: '12px',
+								marginTop: '8px',
+								marginBottom: 0,
+							} }
+						>
 							{ sprintf(
-								/* translators: %s: comma-separated list of conflicting post-type slugs. */
+								/* translators: %s: comma-separated list of post-type labels appearing in both Include and Exclude. */
 								__(
 									'These post types are listed in both Include and Exclude — Include wins, the duplicate is dropped from Exclude: %s',
 									'jetpack-search-pkg'
 								),
-								conflictingSlugs.join( ', ' )
+								conflictingLabels.join( ', ' )
 							) }
 						</p>
 					) }
-					<p className="jetpack-search-post-type-filter__hint">
+					<p
+						className="jetpack-search-post-type-filter__hint"
+						style={ {
+							color: 'rgba(30, 30, 30, 0.62)',
+							fontSize: '12px',
+							fontStyle: 'italic',
+							marginTop: '12px',
+							marginBottom: 0,
+						} }
+					>
 						{ __(
 							'This block does not render anything on the front end — it only constrains which post types Jetpack Search returns.',
 							'jetpack-search-pkg'
@@ -177,7 +249,7 @@ export default function PostTypeFilterEdit( { attributes, setAttributes } ) {
 					instructions={ previewText }
 				/>
 			</div>
-		</Fragment>
+		</>
 	);
 }
 
@@ -187,9 +259,14 @@ export default function PostTypeFilterEdit( { attributes, setAttributes } ) {
  * because we feed it labels in the suggestions array; this is the inverse
  * lookup so attributes stay slug-keyed.
  *
+ * Labels are disambiguated upstream by `disambiguateLabels()`, so each label
+ * in `options` resolves to exactly one slug — `Array.find()` is unambiguous
+ * even when two CPTs share a `singular_name`.
+ *
  * @param {string} token   - Token string from FormTokenField.
  * @param {Array}  options - { value, label } option list.
- * @return {string} Slug, or the original token if no match.
+ * @return {string} Slug, or the original token if no match. Free-typed input is
+ * left untouched here; `tokensToSlugs` runs it through `sanitizeKey` before saving.
  */
 function labelFromTokenString( token, options ) {
 	if ( ! Array.isArray( options ) ) {
@@ -200,7 +277,9 @@ function labelFromTokenString( token, options ) {
 }
 
 /**
- * Build the human-readable summary line for the editor preview card.
+ * Build the human-readable summary line for the editor preview card. Always
+ * renders labels (via `labelBySlug`) rather than raw slugs so the canvas
+ * preview matches the FormTokenField token display in the Inspector.
  *
  * @param {string[]} include     - Include list.
  * @param {string[]} exclude     - Exclude list.
@@ -237,3 +316,7 @@ function describePreview( include, exclude, labelBySlug ) {
 		formatList( exclude )
 	);
 }
+
+// Re-export internals for unit tests (jest's module-cache picks them up via
+// `import * as`).
+export { sanitizeKey, disambiguateLabels, tokensToSlugs, describePreview };

--- a/projects/packages/search/src/search-blocks/blocks/post-type-filter/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/post-type-filter/render.php
@@ -1,11 +1,7 @@
 <?php
 /**
- * Post-type-filter block render.
- *
- * Hidden block: contributes an include/exclude constraint to the shared
- * Interactivity state and emits no markup. JS reads `state.staticPostTypes`
- * when building the search URL and merges it into the ES filter clause as
- * `bool.should` (include) and `bool.must_not` (exclude) clauses.
+ * Post-type-filter block render: writes a `staticPostTypes` constraint to
+ * the Interactivity store and emits no markup.
  *
  * @package automattic/jetpack-search
  */
@@ -22,9 +18,6 @@ if ( ! function_exists( 'wp_interactivity_state' ) ) {
 $constraint = Post_Type_Filter::build_constraint( (array) $attributes );
 
 if ( empty( $constraint['include'] ) && empty( $constraint['exclude'] ) ) {
-	// Nothing to contribute. Bailing keeps the seeded `staticPostTypes` shape
-	// untouched so an empty / unconfigured block can't accidentally widen or
-	// narrow results.
 	return;
 }
 
@@ -32,7 +25,4 @@ $current         = wp_interactivity_state( 'jetpack-search' );
 $existing_static = (array) ( $current['staticPostTypes'] ?? array() );
 $merged          = Post_Type_Filter::merge_state( $existing_static, $constraint );
 
-wp_interactivity_state(
-	'jetpack-search',
-	array( 'staticPostTypes' => $merged )
-);
+wp_interactivity_state( 'jetpack-search', array( 'staticPostTypes' => $merged ) );

--- a/projects/packages/search/src/search-blocks/blocks/post-type-filter/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/post-type-filter/render.php
@@ -19,9 +19,9 @@ if ( ! function_exists( 'wp_interactivity_state' ) ) {
 }
 
 // @phan-suppress-next-line PhanUndeclaredGlobalVariable
-$lists = Post_Type_Filter::build_lists( (array) $attributes );
+$constraint = Post_Type_Filter::build_constraint( (array) $attributes );
 
-if ( empty( $lists['include'] ) && empty( $lists['exclude'] ) ) {
+if ( empty( $constraint['include'] ) && empty( $constraint['exclude'] ) ) {
 	// Nothing to contribute. Bailing keeps the seeded `staticPostTypes` shape
 	// untouched so an empty / unconfigured block can't accidentally widen or
 	// narrow results.
@@ -30,7 +30,7 @@ if ( empty( $lists['include'] ) && empty( $lists['exclude'] ) ) {
 
 $current         = wp_interactivity_state( 'jetpack-search' );
 $existing_static = (array) ( $current['staticPostTypes'] ?? array() );
-$merged          = Post_Type_Filter::merge_state( $existing_static, $lists );
+$merged          = Post_Type_Filter::merge_state( $existing_static, $constraint );
 
 wp_interactivity_state(
 	'jetpack-search',

--- a/projects/packages/search/src/search-blocks/blocks/post-type-filter/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/post-type-filter/render.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Post-type-filter block render.
+ *
+ * Hidden block: contributes an include/exclude constraint to the shared
+ * Interactivity state and emits no markup. JS reads `state.staticPostTypes`
+ * when building the search URL and merges it into the ES filter clause as
+ * `bool.should` (include) and `bool.must_not` (exclude) clauses.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+
+if ( ! function_exists( 'wp_interactivity_state' ) ) {
+	return;
+}
+
+// @phan-suppress-next-line PhanUndeclaredGlobalVariable
+$lists = Post_Type_Filter::build_lists( (array) $attributes );
+
+if ( empty( $lists['include'] ) && empty( $lists['exclude'] ) ) {
+	// Nothing to contribute. Bailing keeps the seeded `staticPostTypes` shape
+	// untouched so an empty / unconfigured block can't accidentally widen or
+	// narrow results.
+	return;
+}
+
+$current         = wp_interactivity_state( 'jetpack-search' );
+$existing_static = (array) ( $current['staticPostTypes'] ?? array() );
+$merged          = Post_Type_Filter::merge_state( $existing_static, $lists );
+
+wp_interactivity_state(
+	'jetpack-search',
+	array( 'staticPostTypes' => $merged )
+);

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -487,60 +487,58 @@ class Search_Blocks {
 
 		return array(
 			// Connection / routing config.
-			'siteId'          => $site_id,
-			'apiRoot'         => function_exists( 'rest_url' ) ? esc_url_raw( rest_url() ) : '',
-			'nonce'           => function_exists( 'wp_create_nonce' ) ? wp_create_nonce( 'wp_rest' ) : '',
-			'isPrivateSite'   => $is_private,
-			'isWpcom'         => $is_wpcom,
-			'homeUrl'         => function_exists( 'home_url' ) ? home_url() : '',
+			'siteId'        => $site_id,
+			'apiRoot'       => function_exists( 'rest_url' ) ? esc_url_raw( rest_url() ) : '',
+			'nonce'         => function_exists( 'wp_create_nonce' ) ? wp_create_nonce( 'wp_rest' ) : '',
+			'isPrivateSite' => $is_private,
+			'isWpcom'       => $is_wpcom,
+			'homeUrl'       => function_exists( 'home_url' ) ? home_url() : '',
 			// BCP47-ish locale (e.g. `en-US`) for Intl.DateTimeFormat on the
 			// client. Converts WP's `en_US` underscore form. Uses the blog
 			// locale (site setting) rather than the viewer's user-profile
 			// locale so formatting is consistent for logged-out visitors
 			// hitting a search page.
-			'locale'          => function_exists( 'get_locale' )
+			'locale'        => function_exists( 'get_locale' )
 				? str_replace( '_', '-', get_locale() )
 				: 'en-US',
 
 			// Search state, seeded from the URL so a deep link like
 			// /?s=boots&orderby=newest&category[]=news renders correctly on
 			// first paint.
-			'searchQuery'     => $search_query,
-			'sortOrder'       => static::parse_url_sort(),
-			'activeFilters'   => $active_filters,
-			'priceRange'      => $price_range,
+			'searchQuery'   => $search_query,
+			'sortOrder'     => static::parse_url_sort(),
+			'activeFilters' => $active_filters,
+			'priceRange'    => $price_range,
 
 			// filterConfigs: each filter-checkbox block's render.php merges its
 			// own entry here. Shape: { [filterKey]: { filterKey, filterType,
 			// taxonomy, label, showCount, maxItems } }.
-			'filterConfigs'   => array(),
+			'filterConfigs' => array(),
 
-			// staticPostTypes: include/exclude post-type lists contributed by
-			// the hidden `jetpack/post-type-filter` block. Folded into the ES
-			// filter clause client-side (see store/api.js) — never surfaced in
-			// the active-filters pill list. Seeded as a stable shape so the
-			// first-paint store has predictable defaults even before any block
-			// renders.
-			'staticPostTypes' => array(
-				'include' => array(),
-				'exclude' => array(),
-			),
+			// Note: `staticPostTypes` (contributed by `jetpack/post-type-filter`)
+			// is intentionally NOT seeded here. FSE block templates can render
+			// before `wp_enqueue_scripts` fires (where this seed runs), so
+			// pre-seeding the slot with `{ include: [], exclude: [] }` would
+			// merge AFTER the block contribution and clobber it. Letting
+			// render.php own the slot keeps template-rendered blocks working;
+			// the JS reader treats `state.staticPostTypes` undefined as
+			// "no constraint" via Array.isArray() checks in store/api.js.
 
 			// Results + aggregations are populated by the JS store on hydration —
 			// seed empty defaults so template bindings always have a shape to read.
 			// `aggregations` is a stdClass so JS sees `{}`, not `[]`.
-			'results'         => array(),
-			'aggregations'    => (object) array(),
-			'totalResults'    => 0,
-			'pageHandle'      => null,
+			'results'       => array(),
+			'aggregations'  => (object) array(),
+			'totalResults'  => 0,
+			'pageHandle'    => null,
 
 			// UI state. `isLoading` is seeded true when the URL carries a
 			// search query or filter selection so the no-results block stays
 			// hidden between first paint and JS hydrating the initial fetch —
 			// otherwise a "No results found" flash appears on deep links.
-			'isLoading'       => '' !== $search_query || ! empty( $active_filters ) || null !== $price_range,
-			'isLoadingMore'   => false,
-			'hasError'        => false,
+			'isLoading'     => '' !== $search_query || ! empty( $active_filters ) || null !== $price_range,
+			'isLoadingMore' => false,
+			'hasError'      => false,
 
 			// Translated view-bundle strings. The Interactivity API view bundle
 			// can't import @wordpress/i18n (only @wordpress/interactivity is
@@ -549,7 +547,7 @@ class Search_Blocks {
 			// are seeded so the client can pick based on the live totalResults
 			// without a round trip; languages with more than two plural forms
 			// degrade to "plural for all count > 1" as an accepted tradeoff.
-			'strings'         => static::build_initial_strings(),
+			'strings'       => static::build_initial_strings(),
 		);
 	}
 

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -487,49 +487,60 @@ class Search_Blocks {
 
 		return array(
 			// Connection / routing config.
-			'siteId'        => $site_id,
-			'apiRoot'       => function_exists( 'rest_url' ) ? esc_url_raw( rest_url() ) : '',
-			'nonce'         => function_exists( 'wp_create_nonce' ) ? wp_create_nonce( 'wp_rest' ) : '',
-			'isPrivateSite' => $is_private,
-			'isWpcom'       => $is_wpcom,
-			'homeUrl'       => function_exists( 'home_url' ) ? home_url() : '',
+			'siteId'          => $site_id,
+			'apiRoot'         => function_exists( 'rest_url' ) ? esc_url_raw( rest_url() ) : '',
+			'nonce'           => function_exists( 'wp_create_nonce' ) ? wp_create_nonce( 'wp_rest' ) : '',
+			'isPrivateSite'   => $is_private,
+			'isWpcom'         => $is_wpcom,
+			'homeUrl'         => function_exists( 'home_url' ) ? home_url() : '',
 			// BCP47-ish locale (e.g. `en-US`) for Intl.DateTimeFormat on the
 			// client. Converts WP's `en_US` underscore form. Uses the blog
 			// locale (site setting) rather than the viewer's user-profile
 			// locale so formatting is consistent for logged-out visitors
 			// hitting a search page.
-			'locale'        => function_exists( 'get_locale' )
+			'locale'          => function_exists( 'get_locale' )
 				? str_replace( '_', '-', get_locale() )
 				: 'en-US',
 
 			// Search state, seeded from the URL so a deep link like
 			// /?s=boots&orderby=newest&category[]=news renders correctly on
 			// first paint.
-			'searchQuery'   => $search_query,
-			'sortOrder'     => static::parse_url_sort(),
-			'activeFilters' => $active_filters,
-			'priceRange'    => $price_range,
+			'searchQuery'     => $search_query,
+			'sortOrder'       => static::parse_url_sort(),
+			'activeFilters'   => $active_filters,
+			'priceRange'      => $price_range,
 
 			// filterConfigs: each filter-checkbox block's render.php merges its
 			// own entry here. Shape: { [filterKey]: { filterKey, filterType,
 			// taxonomy, label, showCount, maxItems } }.
-			'filterConfigs' => array(),
+			'filterConfigs'   => array(),
+
+			// staticPostTypes: include/exclude post-type lists contributed by
+			// the hidden `jetpack/post-type-filter` block. Folded into the ES
+			// filter clause client-side (see store/api.js) — never surfaced in
+			// the active-filters pill list. Seeded as a stable shape so the
+			// first-paint store has predictable defaults even before any block
+			// renders.
+			'staticPostTypes' => array(
+				'include' => array(),
+				'exclude' => array(),
+			),
 
 			// Results + aggregations are populated by the JS store on hydration —
 			// seed empty defaults so template bindings always have a shape to read.
 			// `aggregations` is a stdClass so JS sees `{}`, not `[]`.
-			'results'       => array(),
-			'aggregations'  => (object) array(),
-			'totalResults'  => 0,
-			'pageHandle'    => null,
+			'results'         => array(),
+			'aggregations'    => (object) array(),
+			'totalResults'    => 0,
+			'pageHandle'      => null,
 
 			// UI state. `isLoading` is seeded true when the URL carries a
 			// search query or filter selection so the no-results block stays
 			// hidden between first paint and JS hydrating the initial fetch —
 			// otherwise a "No results found" flash appears on deep links.
-			'isLoading'     => '' !== $search_query || ! empty( $active_filters ) || null !== $price_range,
-			'isLoadingMore' => false,
-			'hasError'      => false,
+			'isLoading'       => '' !== $search_query || ! empty( $active_filters ) || null !== $price_range,
+			'isLoadingMore'   => false,
+			'hasError'        => false,
 
 			// Translated view-bundle strings. The Interactivity API view bundle
 			// can't import @wordpress/i18n (only @wordpress/interactivity is
@@ -538,7 +549,7 @@ class Search_Blocks {
 			// are seeded so the client can pick based on the live totalResults
 			// without a round trip; languages with more than two plural forms
 			// degrade to "plural for all count > 1" as an accepted tradeoff.
-			'strings'       => static::build_initial_strings(),
+			'strings'         => static::build_initial_strings(),
 		);
 	}
 

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -25,6 +25,7 @@ import FilterDateEdit from '../blocks/filter-date/edit';
 import FilterPopoverEdit, { save as filterPopoverSave } from '../blocks/filter-popover/edit';
 import LoadMoreEdit from '../blocks/load-more/edit';
 import NoResultsEdit from '../blocks/no-results/edit';
+import PostTypeFilterEdit from '../blocks/post-type-filter/edit';
 import ResultsCountEdit from '../blocks/results-count/edit';
 import ResultsPanelEdit, { save as resultsPanelSave } from '../blocks/results-panel/edit';
 import SearchErrorEdit from '../blocks/search-error/edit';
@@ -41,6 +42,7 @@ const BLOCKS = [
 	[ 'jetpack/filter-checkbox', FilterCheckboxEdit ],
 	[ 'jetpack/filter-date', FilterDateEdit ],
 	[ 'jetpack/active-filters', ActiveFiltersEdit ],
+	[ 'jetpack/post-type-filter', PostTypeFilterEdit ],
 	[ 'jetpack/common-filters', CommonFiltersEdit, commonFiltersSave ],
 	[ 'jetpack/filter-popover', FilterPopoverEdit, filterPopoverSave ],
 	[ 'jetpack/sort-control', SortControlEdit ],

--- a/projects/packages/search/src/search-blocks/store/api.js
+++ b/projects/packages/search/src/search-blocks/store/api.js
@@ -404,6 +404,13 @@ function getMonthLabelFormatter( locale ) {
  * as separate `must` entries so the include and exclude semantics stay
  * orthogonal in ES — same shape used by instant-search's `excludedPostTypes`.
  *
+ * Asymmetry: a single-slug include emits a bare `{ term: { post_type: T } }`
+ * rather than wrapping it in `{ bool: { should: [...] } }`. Inside the outer
+ * `bool.must` array those are semantically identical (a single-clause
+ * `should` behaves like `must`), and the bare form keeps the URL shorter and
+ * the test assertions readable. A single-slug exclude *always* wraps in
+ * `bool.must_not` because ES has no bare-term equivalent for negation.
+ *
  * @param {object|null} staticPostTypes - `{ include, exclude }` slug lists.
  * @return {Array<object>} ES filter clauses, possibly empty.
  */

--- a/projects/packages/search/src/search-blocks/store/api.js
+++ b/projects/packages/search/src/search-blocks/store/api.js
@@ -395,25 +395,66 @@ function getMonthLabelFormatter( locale ) {
 }
 
 /**
+ * Build the ES `bool.must` clauses contributed by the hidden
+ * `jetpack/post-type-filter` block. Returns an empty array when no constraint
+ * is configured so callers can spread the result unconditionally.
+ *
+ * Includes are wrapped in `bool.should` (OR within the include set), excludes
+ * in `bool.must_not` (negate every excluded slug). Both wrappers are pushed
+ * as separate `must` entries so the include and exclude semantics stay
+ * orthogonal in ES — same shape used by instant-search's `excludedPostTypes`.
+ *
+ * @param {object|null} staticPostTypes - `{ include, exclude }` slug lists.
+ * @return {Array<object>} ES filter clauses, possibly empty.
+ */
+export function buildStaticPostTypeClauses( staticPostTypes ) {
+	if ( ! staticPostTypes ) {
+		return [];
+	}
+	const clauses = [];
+	const include = Array.isArray( staticPostTypes.include ) ? staticPostTypes.include : [];
+	const exclude = Array.isArray( staticPostTypes.exclude ) ? staticPostTypes.exclude : [];
+
+	if ( include.length > 0 ) {
+		const should = include.map( slug => ( { term: { post_type: slug } } ) );
+		clauses.push( should.length === 1 ? should[ 0 ] : { bool: { should } } );
+	}
+	if ( exclude.length > 0 ) {
+		clauses.push( {
+			bool: {
+				must_not: exclude.map( slug => ( { term: { post_type: slug } } ) ),
+			},
+		} );
+	}
+	return clauses;
+}
+
+/**
  * Build the full search API URL with query params.
  * Mirrors the 3-path routing in src/instant-search/lib/api.js.
  *
- * @param {object}      opts                 - Options.
- * @param {number}      opts.siteId          - Site ID.
- * @param {string}      opts.searchQuery     - Search query string.
- * @param {string}      opts.sortOrder       - 'relevance' | 'newest' | 'oldest'.
- * @param {string|null} opts.pageHandle      - Cursor for pagination.
- * @param {boolean}     opts.isPrivateSite   - Whether the site is private.
- * @param {boolean}     opts.isWpcom         - Whether the site runs on WordPress.com.
- * @param {string}      opts.apiRoot         - WordPress REST API root URL.
- * @param {object}      [opts.activeFilters] - { [filterKey]: string[] } selected filters.
- * @param {object}      [opts.filterConfigs] - { [filterKey]: FilterConfig } registered filters.
- * @param {string}      [opts.homeUrl]       - Home URL; required for private WPcom sites.
- * @param {object|null} [opts.priceRange]    - `{ min, max }` numeric range against the
- *                                           `wc.price` ES field. Either bound may be null
- *                                           for a half-open range. Read by future product
- *                                           filter blocks driven by `min_price` / `max_price`
- *                                           URL params.
+ * @param {object}      opts                   - Options.
+ * @param {number}      opts.siteId            - Site ID.
+ * @param {string}      opts.searchQuery       - Search query string.
+ * @param {string}      opts.sortOrder         - 'relevance' | 'newest' | 'oldest'.
+ * @param {string|null} opts.pageHandle        - Cursor for pagination.
+ * @param {boolean}     opts.isPrivateSite     - Whether the site is private.
+ * @param {boolean}     opts.isWpcom           - Whether the site runs on WordPress.com.
+ * @param {string}      opts.apiRoot           - WordPress REST API root URL.
+ * @param {object}      [opts.activeFilters]   - { [filterKey]: string[] } selected filters.
+ * @param {object}      [opts.filterConfigs]   - { [filterKey]: FilterConfig } registered filters.
+ * @param {string}      [opts.homeUrl]         - Home URL; required for private WPcom sites.
+ * @param {object|null} [opts.priceRange]      - `{ min, max }` numeric range against the
+ *                                             `wc.price` ES field. Either bound may be null
+ *                                             for a half-open range. Read by future product
+ *                                             filter blocks driven by `min_price` / `max_price`
+ *                                             URL params.
+ * @param {object|null} [opts.staticPostTypes] - `{ include, exclude }` post-type slug lists
+ *                                             contributed by `jetpack/post-type-filter`. Folded
+ *                                             into the ES filter clause as `bool.should` (include)
+ *                                             and `bool.must_not` (exclude). Hidden from visitors —
+ *                                             not represented in `activeFilters` and not surfaced
+ *                                             in the active-filters pill list.
  * @return {string} Full URL to call.
  */
 export function buildSearchUrl( {
@@ -428,6 +469,7 @@ export function buildSearchUrl( {
 	filterConfigs = {},
 	homeUrl = '',
 	priceRange = null,
+	staticPostTypes = null,
 } ) {
 	// `qss.encode()` runs `encodeURIComponent` on every value, so we pass the
 	// raw query here. The instant-search code double-encodes (pre-encodes
@@ -450,6 +492,12 @@ export function buildSearchUrl( {
 	// `buildFilterClause` returns either `{ bool: { must: [...] } }` or
 	// `undefined` — the spread below relies on that shape contract.
 	let filter = buildFilterClause( activeFilters, filterConfigs );
+	const staticPostTypeClauses = buildStaticPostTypeClauses( staticPostTypes );
+	if ( staticPostTypeClauses.length > 0 ) {
+		filter = filter
+			? { bool: { must: [ ...filter.bool.must, ...staticPostTypeClauses ] } }
+			: { bool: { must: [ ...staticPostTypeClauses ] } };
+	}
 	if ( priceRange && ( priceRange.min != null || priceRange.max != null ) ) {
 		const range = {};
 		if ( priceRange.min != null ) {

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -178,6 +178,7 @@ function* fetchResults( pageHandle ) {
 		activeFilters: state.activeFilters,
 		filterConfigs: state.filterConfigs,
 		priceRange: state.priceRange,
+		staticPostTypes: state.staticPostTypes,
 	} );
 	const response = yield fetch( url, {
 		headers: state.isPrivateSite ? { 'X-WP-Nonce': state.nonce } : {},

--- a/projects/packages/search/tests/js/search-blocks/api.test.js
+++ b/projects/packages/search/tests/js/search-blocks/api.test.js
@@ -4,6 +4,7 @@ import {
 	buildAggregations,
 	buildFilterClause,
 	buildSearchUrl,
+	buildStaticPostTypeClauses,
 	formatDateBucketLabel,
 	resolveFilterFields,
 } from '../../../src/search-blocks/store/api';
@@ -669,6 +670,107 @@ describe( 'product-shaped filter helpers', () => {
 			const decoded = decodeURIComponent( url );
 			expect( decoded ).toContain( 'filter[bool][must][0][term][category.slug]=news' );
 			expect( decoded ).toContain( 'filter[bool][must][1][range][wc.price][gte]=10' );
+		} );
+	} );
+
+	describe( 'buildStaticPostTypeClauses', () => {
+		it( 'returns an empty array for null / empty input', () => {
+			expect( buildStaticPostTypeClauses( null ) ).toEqual( [] );
+			expect( buildStaticPostTypeClauses( {} ) ).toEqual( [] );
+			expect( buildStaticPostTypeClauses( { include: [], exclude: [] } ) ).toEqual( [] );
+		} );
+
+		it( 'emits a bare `term` clause when include has a single slug', () => {
+			expect( buildStaticPostTypeClauses( { include: [ 'post' ] } ) ).toEqual( [
+				{ term: { post_type: 'post' } },
+			] );
+		} );
+
+		it( 'wraps multi-slug includes in a `bool.should`', () => {
+			expect( buildStaticPostTypeClauses( { include: [ 'post', 'page' ] } ) ).toEqual( [
+				{
+					bool: {
+						should: [ { term: { post_type: 'post' } }, { term: { post_type: 'page' } } ],
+					},
+				},
+			] );
+		} );
+
+		it( 'emits a `bool.must_not` for excludes regardless of length', () => {
+			expect( buildStaticPostTypeClauses( { exclude: [ 'jetpack-portfolio' ] } ) ).toEqual( [
+				{ bool: { must_not: [ { term: { post_type: 'jetpack-portfolio' } } ] } },
+			] );
+		} );
+
+		it( 'concatenates include and exclude clauses when both are set', () => {
+			expect(
+				buildStaticPostTypeClauses( { include: [ 'post', 'page' ], exclude: [ 'product' ] } )
+			).toEqual( [
+				{
+					bool: {
+						should: [ { term: { post_type: 'post' } }, { term: { post_type: 'page' } } ],
+					},
+				},
+				{ bool: { must_not: [ { term: { post_type: 'product' } } ] } },
+			] );
+		} );
+	} );
+
+	describe( 'buildSearchUrl: staticPostTypes', () => {
+		const baseOpts = {
+			siteId: 1,
+			searchQuery: '',
+			sortOrder: 'relevance',
+			pageHandle: null,
+			isPrivateSite: false,
+			isWpcom: false,
+			apiRoot: '',
+		};
+
+		it( 'omits the static clause when both lists are empty', () => {
+			const url = buildSearchUrl( {
+				...baseOpts,
+				staticPostTypes: { include: [], exclude: [] },
+			} );
+			// `post_type` also appears as a result field, so assert against
+			// the filter clause specifically.
+			expect( decodeURIComponent( url ) ).not.toContain( 'filter[bool][must]' );
+		} );
+
+		it( 'restricts results to the include set', () => {
+			const url = buildSearchUrl( {
+				...baseOpts,
+				staticPostTypes: { include: [ 'post', 'page' ], exclude: [] },
+			} );
+			const decoded = decodeURIComponent( url );
+			expect( decoded ).toContain( 'filter[bool][must][0][bool][should][0][term][post_type]=post' );
+			expect( decoded ).toContain( 'filter[bool][must][0][bool][should][1][term][post_type]=page' );
+		} );
+
+		it( 'subtracts the exclude set via must_not', () => {
+			const url = buildSearchUrl( {
+				...baseOpts,
+				staticPostTypes: { include: [], exclude: [ 'product' ] },
+			} );
+			const decoded = decodeURIComponent( url );
+			expect( decoded ).toContain(
+				'filter[bool][must][0][bool][must_not][0][term][post_type]=product'
+			);
+		} );
+
+		it( 'composes alongside an existing filter clause without overwriting it', () => {
+			const url = buildSearchUrl( {
+				...baseOpts,
+				activeFilters: { category: [ 'news' ] },
+				filterConfigs: { category: { filterType: 'taxonomy', taxonomy: 'category' } },
+				staticPostTypes: { include: [ 'post' ], exclude: [ 'product' ] },
+			} );
+			const decoded = decodeURIComponent( url );
+			expect( decoded ).toContain( 'filter[bool][must][0][term][category.slug]=news' );
+			expect( decoded ).toContain( 'filter[bool][must][1][term][post_type]=post' );
+			expect( decoded ).toContain(
+				'filter[bool][must][2][bool][must_not][0][term][post_type]=product'
+			);
 		} );
 	} );
 } );

--- a/projects/packages/search/tests/js/search-blocks/api.test.js
+++ b/projects/packages/search/tests/js/search-blocks/api.test.js
@@ -702,6 +702,22 @@ describe( 'product-shaped filter helpers', () => {
 			] );
 		} );
 
+		it( 'treats a non-array include as empty and skips the clause', () => {
+			// The defensive `Array.isArray` guard exists so a forward-compat
+			// state-shape change can not crash the URL builder. Locking it
+			// in via a test makes the contract explicit.
+			expect( buildStaticPostTypeClauses( { include: 'post', exclude: [] } ) ).toEqual( [] );
+			expect( buildStaticPostTypeClauses( { include: null, exclude: [ 'product' ] } ) ).toEqual( [
+				{ bool: { must_not: [ { term: { post_type: 'product' } } ] } },
+			] );
+		} );
+
+		it( 'treats a non-array exclude as empty and emits only the include clause', () => {
+			expect( buildStaticPostTypeClauses( { include: [ 'post' ], exclude: 'page' } ) ).toEqual( [
+				{ term: { post_type: 'post' } },
+			] );
+		} );
+
 		it( 'concatenates include and exclude clauses when both are set', () => {
 			expect(
 				buildStaticPostTypeClauses( { include: [ 'post', 'page' ], exclude: [ 'product' ] } )

--- a/projects/packages/search/tests/js/search-blocks/post-type-filter-edit.test.js
+++ b/projects/packages/search/tests/js/search-blocks/post-type-filter-edit.test.js
@@ -1,12 +1,11 @@
 /**
  * Editor-only helpers for jetpack/post-type-filter.
  *
- * The block's edit component does meaningful work outside the React render —
- * label/slug round-tripping, conflict detection across case-different inputs,
- * disambiguating duplicate post-type labels, and `sanitize_key`-equivalent
- * normalization on save. These tests lock in those contracts so the editor
- * can't drift from what the server normalizer (`Post_Type_Filter::build_lists`)
- * eventually applies on render.
+ * Single-mode UX: the block carries one `mode` ('include'|'exclude') plus
+ * one `postTypes` slug list, never both lists at once. The editor's
+ * algorithmic surface (slug normalization, label disambiguation, preview
+ * copy) is unit-tested here; component-level rendering follows the same
+ * approach the rest of the package uses (no React-Testing-Library mounts).
  */
 import {
 	sanitizeKey,
@@ -43,9 +42,6 @@ describe( 'disambiguateLabels', () => {
 	} );
 
 	it( 'appends the slug to every collision so labels round-trip 1:1 to slugs', () => {
-		// Two CPTs share the singular_name "Portfolio" — without
-		// disambiguation, picking either suggestion would always resolve
-		// to whichever appears first in the list.
 		const opts = [
 			{ value: 'jetpack-portfolio', label: 'Portfolio' },
 			{ value: 'custom-portfolio', label: 'Portfolio' },
@@ -78,8 +74,6 @@ describe( 'tokensToSlugs', () => {
 	} );
 
 	it( 'collapses case-different free-typed values to the same slug', () => {
-		// Without normalization, `Post` (free-typed) and `post` (picked) would
-		// both store as distinct entries in the attribute list.
 		expect( tokensToSlugs( [ 'Post', 'post' ], options ) ).toEqual( [ 'post' ] );
 	} );
 
@@ -108,35 +102,31 @@ describe( 'describePreview', () => {
 		[ 'product', 'Product' ],
 	] );
 
-	it( 'flags the empty state when neither list has values', () => {
-		expect( describePreview( [], [], labelBySlug ) ).toEqual( {
-			empty: true,
-			includeText: '(any post type)',
-			excludeText: '(none)',
+	it( 'renders the Exclude label and value when mode is exclude', () => {
+		expect( describePreview( 'exclude', [ 'product' ], labelBySlug ) ).toEqual( {
+			label: 'Exclude:',
+			value: 'Product',
 		} );
 	} );
 
-	it( 'renders Include labels (not raw slugs) and the empty-Exclude fallback', () => {
-		expect( describePreview( [ 'post', 'page' ], [], labelBySlug ) ).toEqual( {
-			empty: false,
-			includeText: 'Post, Page',
-			excludeText: '(none)',
+	it( 'renders the Include label and value when mode is include', () => {
+		expect( describePreview( 'include', [ 'post', 'page' ], labelBySlug ) ).toEqual( {
+			label: 'Include only:',
+			value: 'Post, Page',
 		} );
 	} );
 
-	it( 'renders Exclude labels and the empty-Include fallback', () => {
-		expect( describePreview( [], [ 'product' ], labelBySlug ) ).toEqual( {
-			empty: false,
-			includeText: '(any post type)',
-			excludeText: 'Product',
+	it( 'shows "(none selected)" when no post types are configured (Exclude mode)', () => {
+		expect( describePreview( 'exclude', [], labelBySlug ) ).toEqual( {
+			label: 'Exclude:',
+			value: '(none selected)',
 		} );
 	} );
 
-	it( 'renders both label lists when include and exclude are both set', () => {
-		expect( describePreview( [ 'post' ], [ 'product' ], labelBySlug ) ).toEqual( {
-			empty: false,
-			includeText: 'Post',
-			excludeText: 'Product',
+	it( 'shows "(none selected)" when no post types are configured (Include mode)', () => {
+		expect( describePreview( 'include', [], labelBySlug ) ).toEqual( {
+			label: 'Include only:',
+			value: '(none selected)',
 		} );
 	} );
 
@@ -144,10 +134,9 @@ describe( 'describePreview', () => {
 		// Simulates the brief window where core-data has not resolved
 		// `getPostTypes()` yet — the picker shows raw slugs as token
 		// titles, and the preview should match.
-		expect( describePreview( [ 'unknown-cpt' ], [], new Map() ) ).toEqual( {
-			empty: false,
-			includeText: 'unknown-cpt',
-			excludeText: '(none)',
+		expect( describePreview( 'exclude', [ 'unknown-cpt' ], new Map() ) ).toEqual( {
+			label: 'Exclude:',
+			value: 'unknown-cpt',
 		} );
 	} );
 } );

--- a/projects/packages/search/tests/js/search-blocks/post-type-filter-edit.test.js
+++ b/projects/packages/search/tests/js/search-blocks/post-type-filter-edit.test.js
@@ -108,34 +108,46 @@ describe( 'describePreview', () => {
 		[ 'product', 'Product' ],
 	] );
 
-	it( 'returns the empty-state hint when neither list has values', () => {
-		expect( describePreview( [], [], labelBySlug ) ).toMatch( /No constraint configured/ );
+	it( 'flags the empty state when neither list has values', () => {
+		expect( describePreview( [], [], labelBySlug ) ).toEqual( {
+			empty: true,
+			includeText: '(any post type)',
+			excludeText: '(none)',
+		} );
 	} );
 
-	it( 'renders labels (not raw slugs) for include-only configs', () => {
-		expect( describePreview( [ 'post', 'page' ], [], labelBySlug ) ).toMatch(
-			/Results limited to: Post, Page/
-		);
+	it( 'renders Include labels (not raw slugs) and the empty-Exclude fallback', () => {
+		expect( describePreview( [ 'post', 'page' ], [], labelBySlug ) ).toEqual( {
+			empty: false,
+			includeText: 'Post, Page',
+			excludeText: '(none)',
+		} );
 	} );
 
-	it( 'renders labels (not raw slugs) for exclude-only configs', () => {
-		expect( describePreview( [], [ 'product' ], labelBySlug ) ).toMatch(
-			/Results exclude: Product/
-		);
+	it( 'renders Exclude labels and the empty-Include fallback', () => {
+		expect( describePreview( [], [ 'product' ], labelBySlug ) ).toEqual( {
+			empty: false,
+			includeText: '(any post type)',
+			excludeText: 'Product',
+		} );
 	} );
 
 	it( 'renders both label lists when include and exclude are both set', () => {
-		expect( describePreview( [ 'post' ], [ 'product' ], labelBySlug ) ).toMatch(
-			/Results limited to: Post · Excluding: Product/
-		);
+		expect( describePreview( [ 'post' ], [ 'product' ], labelBySlug ) ).toEqual( {
+			empty: false,
+			includeText: 'Post',
+			excludeText: 'Product',
+		} );
 	} );
 
 	it( 'falls back to the raw slug when the type is not yet loaded', () => {
 		// Simulates the brief window where core-data has not resolved
 		// `getPostTypes()` yet — the picker shows raw slugs as token
 		// titles, and the preview should match.
-		expect( describePreview( [ 'unknown-cpt' ], [], new Map() ) ).toMatch(
-			/Results limited to: unknown-cpt/
-		);
+		expect( describePreview( [ 'unknown-cpt' ], [], new Map() ) ).toEqual( {
+			empty: false,
+			includeText: 'unknown-cpt',
+			excludeText: '(none)',
+		} );
 	} );
 } );

--- a/projects/packages/search/tests/js/search-blocks/post-type-filter-edit.test.js
+++ b/projects/packages/search/tests/js/search-blocks/post-type-filter-edit.test.js
@@ -1,0 +1,141 @@
+/**
+ * Editor-only helpers for jetpack/post-type-filter.
+ *
+ * The block's edit component does meaningful work outside the React render —
+ * label/slug round-tripping, conflict detection across case-different inputs,
+ * disambiguating duplicate post-type labels, and `sanitize_key`-equivalent
+ * normalization on save. These tests lock in those contracts so the editor
+ * can't drift from what the server normalizer (`Post_Type_Filter::build_lists`)
+ * eventually applies on render.
+ */
+import {
+	sanitizeKey,
+	disambiguateLabels,
+	tokensToSlugs,
+	describePreview,
+} from '../../../src/search-blocks/blocks/post-type-filter/edit';
+
+describe( 'sanitizeKey', () => {
+	it( 'lowercases and strips disallowed characters', () => {
+		expect( sanitizeKey( 'Post' ) ).toBe( 'post' );
+		expect( sanitizeKey( 'My Custom Type' ) ).toBe( 'mycustomtype' );
+	} );
+
+	it( 'preserves underscores and hyphens (PHP sanitize_key allows both)', () => {
+		expect( sanitizeKey( 'shop_order' ) ).toBe( 'shop_order' );
+		expect( sanitizeKey( 'jetpack-portfolio' ) ).toBe( 'jetpack-portfolio' );
+	} );
+
+	it( 'returns an empty string for null / undefined / non-string input', () => {
+		expect( sanitizeKey( null ) ).toBe( '' );
+		expect( sanitizeKey( undefined ) ).toBe( '' );
+		expect( sanitizeKey( '' ) ).toBe( '' );
+	} );
+} );
+
+describe( 'disambiguateLabels', () => {
+	it( 'leaves unique labels untouched', () => {
+		const opts = [
+			{ value: 'post', label: 'Post' },
+			{ value: 'page', label: 'Page' },
+		];
+		expect( disambiguateLabels( opts ) ).toEqual( opts );
+	} );
+
+	it( 'appends the slug to every collision so labels round-trip 1:1 to slugs', () => {
+		// Two CPTs share the singular_name "Portfolio" — without
+		// disambiguation, picking either suggestion would always resolve
+		// to whichever appears first in the list.
+		const opts = [
+			{ value: 'jetpack-portfolio', label: 'Portfolio' },
+			{ value: 'custom-portfolio', label: 'Portfolio' },
+			{ value: 'page', label: 'Page' },
+		];
+		expect( disambiguateLabels( opts ) ).toEqual( [
+			{ value: 'jetpack-portfolio', label: 'Portfolio (jetpack-portfolio)' },
+			{ value: 'custom-portfolio', label: 'Portfolio (custom-portfolio)' },
+			{ value: 'page', label: 'Page' },
+		] );
+	} );
+} );
+
+describe( 'tokensToSlugs', () => {
+	const options = [
+		{ value: 'post', label: 'Post' },
+		{ value: 'page', label: 'Page' },
+		{ value: 'jetpack-portfolio', label: 'Portfolio (jetpack-portfolio)' },
+	];
+
+	it( 'resolves picked-suggestion labels back to their slugs', () => {
+		expect( tokensToSlugs( [ 'Post', 'Portfolio (jetpack-portfolio)' ], options ) ).toEqual( [
+			'post',
+			'jetpack-portfolio',
+		] );
+	} );
+
+	it( 'sanitize_key-normalizes free-typed strings', () => {
+		expect( tokensToSlugs( [ 'My Custom Type' ], options ) ).toEqual( [ 'mycustomtype' ] );
+	} );
+
+	it( 'collapses case-different free-typed values to the same slug', () => {
+		// Without normalization, `Post` (free-typed) and `post` (picked) would
+		// both store as distinct entries in the attribute list.
+		expect( tokensToSlugs( [ 'Post', 'post' ], options ) ).toEqual( [ 'post' ] );
+	} );
+
+	it( 'accepts the {value, title} object shape we emit from toTokens', () => {
+		expect(
+			tokensToSlugs(
+				[
+					{ value: 'post', title: 'Post' },
+					{ value: 'page', title: 'Page' },
+				],
+				options
+			)
+		).toEqual( [ 'post', 'page' ] );
+	} );
+
+	it( 'returns an empty list for null / undefined input', () => {
+		expect( tokensToSlugs( null, options ) ).toEqual( [] );
+		expect( tokensToSlugs( undefined, options ) ).toEqual( [] );
+	} );
+} );
+
+describe( 'describePreview', () => {
+	const labelBySlug = new Map( [
+		[ 'post', 'Post' ],
+		[ 'page', 'Page' ],
+		[ 'product', 'Product' ],
+	] );
+
+	it( 'returns the empty-state hint when neither list has values', () => {
+		expect( describePreview( [], [], labelBySlug ) ).toMatch( /No constraint configured/ );
+	} );
+
+	it( 'renders labels (not raw slugs) for include-only configs', () => {
+		expect( describePreview( [ 'post', 'page' ], [], labelBySlug ) ).toMatch(
+			/Results limited to: Post, Page/
+		);
+	} );
+
+	it( 'renders labels (not raw slugs) for exclude-only configs', () => {
+		expect( describePreview( [], [ 'product' ], labelBySlug ) ).toMatch(
+			/Results exclude: Product/
+		);
+	} );
+
+	it( 'renders both label lists when include and exclude are both set', () => {
+		expect( describePreview( [ 'post' ], [ 'product' ], labelBySlug ) ).toMatch(
+			/Results limited to: Post · Excluding: Product/
+		);
+	} );
+
+	it( 'falls back to the raw slug when the type is not yet loaded', () => {
+		// Simulates the brief window where core-data has not resolved
+		// `getPostTypes()` yet — the picker shows raw slugs as token
+		// titles, and the preview should match.
+		expect( describePreview( [ 'unknown-cpt' ], [], new Map() ) ).toMatch(
+			/Results limited to: unknown-cpt/
+		);
+	} );
+} );

--- a/projects/packages/search/tests/php/Post_Type_Filter_Test.php
+++ b/projects/packages/search/tests/php/Post_Type_Filter_Test.php
@@ -71,11 +71,15 @@ class Post_Type_Filter_Test extends TestCase {
 	 * cache `protected`/`public` purely for test access.
 	 */
 	private function reset_searchable_cache(): void {
-		// PHP 8.1+ no longer requires setAccessible() for non-public
-		// reflection access; calling it triggers a deprecation on 8.5+.
-		( new \ReflectionClass( Post_Type_Filter::class ) )
-			->getProperty( 'searchable_cache' )
-			->setValue( null, null );
+		// PHP 7.2–8.0 require setAccessible(true) to read/write private
+		// statics via Reflection; PHP 8.1 made the call a no-op and 8.5
+		// emits a deprecation. Gate on the version so the package's full
+		// CI matrix (PHP 7.2 through 8.5) stays green.
+		$prop = ( new \ReflectionClass( Post_Type_Filter::class ) )->getProperty( 'searchable_cache' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$prop->setAccessible( true );
+		}
+		$prop->setValue( null, null );
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Post_Type_Filter_Test.php
+++ b/projects/packages/search/tests/php/Post_Type_Filter_Test.php
@@ -10,8 +10,8 @@ namespace Automattic\Jetpack\Search;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Tests for Post_Type_Filter helpers — list normalization, conflict
- * resolution between include / exclude, and multi-instance state merging.
+ * Tests for Post_Type_Filter helpers — single-mode constraint building,
+ * registry-allowlist enforcement, and multi-instance state merging.
  */
 class Post_Type_Filter_Test extends TestCase {
 
@@ -22,7 +22,7 @@ class Post_Type_Filter_Test extends TestCase {
 	 *
 	 * `setUp` runs after the in-class static cache for `searchable_post_type_slugs`
 	 * may have been seeded by prior tests, so each test re-resets the cache via
-	 * the helper below.
+	 * Reflection below.
 	 */
 	protected function setUp(): void {
 		parent::setUp();
@@ -42,8 +42,7 @@ class Post_Type_Filter_Test extends TestCase {
 				'labels'              => array( 'singular_name' => 'Order' ),
 			)
 		);
-		// A type opted out of search; build_lists() must drop it from
-		// include and exclude lists alike.
+		// A type opted out of search; build_constraint() must drop it.
 		register_post_type(
 			'private_doc',
 			array(
@@ -52,8 +51,6 @@ class Post_Type_Filter_Test extends TestCase {
 				'labels'              => array( 'singular_name' => 'Private Doc' ),
 			)
 		);
-		// Reset the cached registry on each test so a register/unregister
-		// in another test can't leak through.
 		$this->reset_searchable_cache();
 	}
 
@@ -66,9 +63,8 @@ class Post_Type_Filter_Test extends TestCase {
 	}
 
 	/**
-	 * Reset the static cache `searchable_post_type_slugs()` keeps. Uses
-	 * Reflection because the helper is private — preferable to making the
-	 * cache `protected`/`public` purely for test access.
+	 * Reset the static cache `searchable_post_type_slugs()` keeps so tests
+	 * that register/unregister fixtures see fresh registry data.
 	 */
 	private function reset_searchable_cache(): void {
 		// PHP 7.2–8.0 require setAccessible(true) to read/write private
@@ -83,17 +79,75 @@ class Post_Type_Filter_Test extends TestCase {
 	}
 
 	/**
-	 * Empty / missing attributes produce empty include and exclude lists so
-	 * an unconfigured block contributes nothing to the search constraint.
+	 * Empty / missing attributes produce an all-empty constraint so an
+	 * unconfigured block contributes nothing to the search query.
 	 */
-	public function test_build_lists_returns_empty_for_missing_attributes() {
+	public function test_build_constraint_returns_empty_for_missing_attributes() {
 		$this->assertSame(
 			array(
 				'include' => array(),
 				'exclude' => array(),
 			),
-			Post_Type_Filter::build_lists( array() )
+			Post_Type_Filter::build_constraint( array() )
 		);
+	}
+
+	/**
+	 * Default mode is `exclude` — matches the SEARCH-145 motivating use
+	 * case (the legacy `excluded_post_types` option). A block with only
+	 * `postTypes` set populates the `exclude` side.
+	 */
+	public function test_build_constraint_defaults_to_exclude_mode() {
+		$constraint = Post_Type_Filter::build_constraint(
+			array( 'postTypes' => array( 'product' ) )
+		);
+		$this->assertSame( array(), $constraint['include'] );
+		$this->assertSame( array( 'product' ), $constraint['exclude'] );
+	}
+
+	/**
+	 * `mode: include` populates the `include` side and leaves `exclude`
+	 * empty — single-mode UX guarantees only one side is ever set per block.
+	 */
+	public function test_build_constraint_include_mode_populates_include_only() {
+		$constraint = Post_Type_Filter::build_constraint(
+			array(
+				'mode'      => 'include',
+				'postTypes' => array( 'post', 'page' ),
+			)
+		);
+		$this->assertSame( array( 'post', 'page' ), $constraint['include'] );
+		$this->assertSame( array(), $constraint['exclude'] );
+	}
+
+	/**
+	 * `mode: exclude` populates the `exclude` side and leaves `include` empty.
+	 */
+	public function test_build_constraint_exclude_mode_populates_exclude_only() {
+		$constraint = Post_Type_Filter::build_constraint(
+			array(
+				'mode'      => 'exclude',
+				'postTypes' => array( 'product' ),
+			)
+		);
+		$this->assertSame( array(), $constraint['include'] );
+		$this->assertSame( array( 'product' ), $constraint['exclude'] );
+	}
+
+	/**
+	 * Unknown mode values fall back to `exclude` so a malformed attribute
+	 * (older block schema, hand-edited markup) can't silently flip
+	 * Exclude into Include and broaden results in the wrong direction.
+	 */
+	public function test_build_constraint_unknown_mode_falls_back_to_exclude() {
+		$constraint = Post_Type_Filter::build_constraint(
+			array(
+				'mode'      => 'something-else',
+				'postTypes' => array( 'product' ),
+			)
+		);
+		$this->assertSame( array(), $constraint['include'] );
+		$this->assertSame( array( 'product' ), $constraint['exclude'] );
 	}
 
 	/**
@@ -102,86 +156,58 @@ class Post_Type_Filter_Test extends TestCase {
 	 * with `exclude_from_search => false` is dropped so a stray slug can't
 	 * collapse every search to zero results by reaching ES.
 	 */
-	public function test_build_lists_sanitizes_dedupes_and_validates_slugs() {
-		$lists = Post_Type_Filter::build_lists(
+	public function test_build_constraint_sanitizes_dedupes_and_validates_slugs() {
+		$constraint = Post_Type_Filter::build_constraint(
 			array(
-				'include' => array( 'Post', 'page', 'page', '<bad>', '', 'unregistered_cpt' ),
-				'exclude' => array( 'product', 'product' ),
+				'mode'      => 'include',
+				'postTypes' => array( 'Post', 'page', 'page', '<bad>', '', 'unregistered_cpt' ),
 			)
 		);
 		// `Post` lowercases to `post`; `<bad>` sanitizes to `bad` and gets
-		// dropped because no `bad` post type is registered. The blank entry
-		// and the duplicate `page` are silently filtered.
-		$this->assertSame( array( 'post', 'page' ), $lists['include'] );
-		$this->assertSame( array( 'product' ), $lists['exclude'] );
+		// dropped because no `bad` post type is registered.
+		$this->assertSame( array( 'post', 'page' ), $constraint['include'] );
+		$this->assertSame( array(), $constraint['exclude'] );
 	}
 
 	/**
-	 * Post types registered with `exclude_from_search => true` are dropped
-	 * from both lists. Listing one would either zero results (if in
-	 * include — the type is invisible to search) or be a no-op (if in
-	 * exclude — the type is already absent from the result set).
+	 * Post types registered with `exclude_from_search => true` are dropped.
+	 * In include mode, listing one would zero results (the type is invisible
+	 * to search); in exclude mode it would be a no-op (already absent).
 	 */
-	public function test_build_lists_drops_search_excluded_post_types() {
-		$lists = Post_Type_Filter::build_lists(
+	public function test_build_constraint_drops_search_excluded_post_types() {
+		$exclude_constraint = Post_Type_Filter::build_constraint(
 			array(
-				'include' => array( 'post', 'private_doc' ),
-				'exclude' => array( 'private_doc', 'product' ),
+				'mode'      => 'exclude',
+				'postTypes' => array( 'private_doc', 'product' ),
 			)
 		);
-		$this->assertSame( array( 'post' ), $lists['include'] );
-		$this->assertSame( array( 'product' ), $lists['exclude'] );
+		$this->assertSame( array( 'product' ), $exclude_constraint['exclude'] );
+
+		$include_constraint = Post_Type_Filter::build_constraint(
+			array(
+				'mode'      => 'include',
+				'postTypes' => array( 'post', 'private_doc' ),
+			)
+		);
+		$this->assertSame( array( 'post' ), $include_constraint['include'] );
 	}
 
 	/**
-	 * Non-array / non-scalar values are dropped silently — an attribute
+	 * Non-array / non-scalar postTypes are dropped silently — an attribute
 	 * stored as a string or an object would otherwise trip a fatal in
 	 * `sanitize_key`. Normalization is the boundary at which malformed
 	 * input is contained.
 	 */
-	public function test_build_lists_drops_non_scalar_values() {
-		$lists = Post_Type_Filter::build_lists(
-			array(
-				'include' => 'not-an-array',
-				'exclude' => array( 'page', array( 'nested' ), null, false, 'product' ),
-			)
+	public function test_build_constraint_drops_non_scalar_values() {
+		$string_input = Post_Type_Filter::build_constraint(
+			array( 'postTypes' => 'not-an-array' )
 		);
-		$this->assertSame( array(), $lists['include'] );
-		$this->assertSame( array( 'page', 'product' ), $lists['exclude'] );
-	}
+		$this->assertSame( array(), $string_input['exclude'] );
 
-	/**
-	 * Slugs that appear in both include and exclude are dropped from the
-	 * exclude list. Listing a slug in both is contradictory user input —
-	 * the include clause already restricts results to that set, so the
-	 * exclude entry is at best redundant and at worst confusing for
-	 * future readers of the saved attributes.
-	 */
-	public function test_build_lists_drops_excludes_that_collide_with_includes() {
-		$lists = Post_Type_Filter::build_lists(
-			array(
-				'include' => array( 'post', 'page' ),
-				'exclude' => array( 'page', 'product' ),
-			)
+		$mixed_input = Post_Type_Filter::build_constraint(
+			array( 'postTypes' => array( 'page', array( 'nested' ), null, false, 'product' ) )
 		);
-		$this->assertSame( array( 'post', 'page' ), $lists['include'] );
-		$this->assertSame( array( 'product' ), $lists['exclude'] );
-	}
-
-	/**
-	 * Exclusion-only configs leave the exclude list untouched — the
-	 * include-collision normalization only applies when the include list
-	 * is non-empty.
-	 */
-	public function test_build_lists_keeps_exclude_when_include_is_empty() {
-		$lists = Post_Type_Filter::build_lists(
-			array(
-				'include' => array(),
-				'exclude' => array( 'product', 'shop_order' ),
-			)
-		);
-		$this->assertSame( array(), $lists['include'] );
-		$this->assertSame( array( 'product', 'shop_order' ), $lists['exclude'] );
+		$this->assertSame( array( 'page', 'product' ), $mixed_input['exclude'] );
 	}
 
 	/**
@@ -205,32 +231,12 @@ class Post_Type_Filter_Test extends TestCase {
 	}
 
 	/**
-	 * After merge, the include/exclude exclusivity normalization is
-	 * re-applied: a slug newly added to the include set must not stay in
-	 * the exclude set inherited from a previous instance.
-	 */
-	public function test_merge_state_reapplies_include_exclude_normalization() {
-		$merged = Post_Type_Filter::merge_state(
-			array(
-				'include' => array( 'post' ),
-				'exclude' => array( 'page' ),
-			),
-			array(
-				'include' => array( 'page' ),
-				'exclude' => array(),
-			)
-		);
-		$this->assertSame( array( 'post', 'page' ), $merged['include'] );
-		$this->assertSame( array(), $merged['exclude'] );
-	}
-
-	/**
-	 * Existing state may carry malformed entries (e.g. from a future field
-	 * shape change); the merge sanitizes both sides before unioning so a
-	 * stray non-array value can't poison the merged output. `merge_state`
-	 * does not enforce the registry allowlist on the existing-state side
-	 * (already-filtered by the contributing block's own `build_lists()`
-	 * call) — `42` survives sanitize_key as the string `"42"`.
+	 * Existing state may carry malformed entries (forward-compat with a
+	 * future shape change); the merge sanitizes both sides before unioning
+	 * so a stray non-array value can't poison the merged output.
+	 * `merge_state` does not enforce the registry allowlist on the
+	 * existing-state side (already-filtered by the contributing block's
+	 * own `build_constraint()` call).
 	 */
 	public function test_merge_state_sanitizes_existing_state() {
 		$merged = Post_Type_Filter::merge_state(

--- a/projects/packages/search/tests/php/Post_Type_Filter_Test.php
+++ b/projects/packages/search/tests/php/Post_Type_Filter_Test.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Post_Type_Filter helper tests.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for Post_Type_Filter helpers — list normalization, conflict
+ * resolution between include / exclude, and multi-instance state merging.
+ */
+class Post_Type_Filter_Test extends TestCase {
+
+	/**
+	 * Empty / missing attributes produce empty include and exclude lists so
+	 * an unconfigured block contributes nothing to the search constraint.
+	 */
+	public function test_build_lists_returns_empty_for_missing_attributes() {
+		$this->assertSame(
+			array(
+				'include' => array(),
+				'exclude' => array(),
+			),
+			Post_Type_Filter::build_lists( array() )
+		);
+	}
+
+	/**
+	 * Slugs are sanitized via `sanitize_key`, deduplicated, and re-indexed
+	 * so a malformed attribute can never reach the ES filter clause.
+	 */
+	public function test_build_lists_sanitizes_and_dedupes_slugs() {
+		$lists = Post_Type_Filter::build_lists(
+			array(
+				'include' => array( 'Post', 'page', 'page', '<bad>', '' ),
+				'exclude' => array( 'product', 'product' ),
+			)
+		);
+		// `sanitize_key` lowercases and strips disallowed characters.
+		$this->assertSame( array( 'post', 'page', 'bad' ), $lists['include'] );
+		$this->assertSame( array( 'product' ), $lists['exclude'] );
+	}
+
+	/**
+	 * Non-array / non-scalar values are dropped silently — an attribute
+	 * stored as a string or an object would otherwise trip a fatal in
+	 * `sanitize_key`. Normalization is the boundary at which malformed
+	 * input is contained.
+	 */
+	public function test_build_lists_drops_non_scalar_values() {
+		$lists = Post_Type_Filter::build_lists(
+			array(
+				'include' => 'not-an-array',
+				'exclude' => array( 'page', array( 'nested' ), null, false, 'product' ),
+			)
+		);
+		$this->assertSame( array(), $lists['include'] );
+		$this->assertSame( array( 'page', 'product' ), $lists['exclude'] );
+	}
+
+	/**
+	 * Slugs that appear in both include and exclude are dropped from the
+	 * exclude list. Listing a slug in both is contradictory user input —
+	 * the include clause already restricts results to that set, so the
+	 * exclude entry is at best redundant and at worst confusing for
+	 * future readers of the saved attributes.
+	 */
+	public function test_build_lists_drops_excludes_that_collide_with_includes() {
+		$lists = Post_Type_Filter::build_lists(
+			array(
+				'include' => array( 'post', 'page' ),
+				'exclude' => array( 'page', 'product' ),
+			)
+		);
+		$this->assertSame( array( 'post', 'page' ), $lists['include'] );
+		$this->assertSame( array( 'product' ), $lists['exclude'] );
+	}
+
+	/**
+	 * Exclusion-only configs leave the exclude list untouched — the
+	 * include-collision normalization only applies when the include list
+	 * is non-empty.
+	 */
+	public function test_build_lists_keeps_exclude_when_include_is_empty() {
+		$lists = Post_Type_Filter::build_lists(
+			array(
+				'include' => array(),
+				'exclude' => array( 'product', 'shop_order' ),
+			)
+		);
+		$this->assertSame( array(), $lists['include'] );
+		$this->assertSame( array( 'product', 'shop_order' ), $lists['exclude'] );
+	}
+
+	/**
+	 * Multi-instance composition is union, not intersection — picking
+	 * intersection would silently zero out results when an editor stacks
+	 * two blocks configured for non-overlapping post types.
+	 */
+	public function test_merge_state_unions_lists_across_instances() {
+		$merged = Post_Type_Filter::merge_state(
+			array(
+				'include' => array( 'post' ),
+				'exclude' => array( 'product' ),
+			),
+			array(
+				'include' => array( 'page' ),
+				'exclude' => array( 'shop_order' ),
+			)
+		);
+		$this->assertSame( array( 'post', 'page' ), $merged['include'] );
+		$this->assertSame( array( 'product', 'shop_order' ), $merged['exclude'] );
+	}
+
+	/**
+	 * After merge, the include/exclude exclusivity normalization is
+	 * re-applied: a slug newly added to the include set must not stay in
+	 * the exclude set inherited from a previous instance.
+	 */
+	public function test_merge_state_reapplies_include_exclude_normalization() {
+		$merged = Post_Type_Filter::merge_state(
+			array(
+				'include' => array( 'post' ),
+				'exclude' => array( 'page' ),
+			),
+			array(
+				'include' => array( 'page' ),
+				'exclude' => array(),
+			)
+		);
+		$this->assertSame( array( 'post', 'page' ), $merged['include'] );
+		$this->assertSame( array(), $merged['exclude'] );
+	}
+
+	/**
+	 * Existing state may carry malformed entries (e.g. from a future field
+	 * shape change); the merge sanitizes both sides before unioning so a
+	 * stray non-array value can't poison the merged output.
+	 */
+	public function test_merge_state_sanitizes_existing_state() {
+		$merged = Post_Type_Filter::merge_state(
+			array(
+				'include' => 'malformed',
+				'exclude' => array( 'product', 42 ),
+			),
+			array(
+				'include' => array( 'post' ),
+				'exclude' => array( 'shop_order' ),
+			)
+		);
+		$this->assertSame( array( 'post' ), $merged['include'] );
+		$this->assertSame( array( 'product', '42', 'shop_order' ), $merged['exclude'] );
+	}
+}

--- a/projects/packages/search/tests/php/Post_Type_Filter_Test.php
+++ b/projects/packages/search/tests/php/Post_Type_Filter_Test.php
@@ -16,6 +16,69 @@ use PHPUnit\Framework\TestCase;
 class Post_Type_Filter_Test extends TestCase {
 
 	/**
+	 * Register the fixture post types each test relies on. `product` and
+	 * `shop_order` mirror common WooCommerce CPTs the block is most likely
+	 * to scope. Built-in `post` / `page` are always registered.
+	 *
+	 * `setUp` runs after the in-class static cache for `searchable_post_type_slugs`
+	 * may have been seeded by prior tests, so each test re-resets the cache via
+	 * the helper below.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		register_post_type(
+			'product',
+			array(
+				'public'              => true,
+				'exclude_from_search' => false,
+				'labels'              => array( 'singular_name' => 'Product' ),
+			)
+		);
+		register_post_type(
+			'shop_order',
+			array(
+				'public'              => true,
+				'exclude_from_search' => false,
+				'labels'              => array( 'singular_name' => 'Order' ),
+			)
+		);
+		// A type opted out of search; build_lists() must drop it from
+		// include and exclude lists alike.
+		register_post_type(
+			'private_doc',
+			array(
+				'public'              => false,
+				'exclude_from_search' => true,
+				'labels'              => array( 'singular_name' => 'Private Doc' ),
+			)
+		);
+		// Reset the cached registry on each test so a register/unregister
+		// in another test can't leak through.
+		$this->reset_searchable_cache();
+	}
+
+	protected function tearDown(): void {
+		unregister_post_type( 'product' );
+		unregister_post_type( 'shop_order' );
+		unregister_post_type( 'private_doc' );
+		$this->reset_searchable_cache();
+		parent::tearDown();
+	}
+
+	/**
+	 * Reset the static cache `searchable_post_type_slugs()` keeps. Uses
+	 * Reflection because the helper is private — preferable to making the
+	 * cache `protected`/`public` purely for test access.
+	 */
+	private function reset_searchable_cache(): void {
+		// PHP 8.1+ no longer requires setAccessible() for non-public
+		// reflection access; calling it triggers a deprecation on 8.5+.
+		( new \ReflectionClass( Post_Type_Filter::class ) )
+			->getProperty( 'searchable_cache' )
+			->setValue( null, null );
+	}
+
+	/**
 	 * Empty / missing attributes produce empty include and exclude lists so
 	 * an unconfigured block contributes nothing to the search constraint.
 	 */
@@ -30,18 +93,39 @@ class Post_Type_Filter_Test extends TestCase {
 	}
 
 	/**
-	 * Slugs are sanitized via `sanitize_key`, deduplicated, and re-indexed
-	 * so a malformed attribute can never reach the ES filter clause.
+	 * Slugs are sanitized via `sanitize_key`, deduplicated, re-indexed, and
+	 * filtered against the live post-type registry — anything not registered
+	 * with `exclude_from_search => false` is dropped so a stray slug can't
+	 * collapse every search to zero results by reaching ES.
 	 */
-	public function test_build_lists_sanitizes_and_dedupes_slugs() {
+	public function test_build_lists_sanitizes_dedupes_and_validates_slugs() {
 		$lists = Post_Type_Filter::build_lists(
 			array(
-				'include' => array( 'Post', 'page', 'page', '<bad>', '' ),
+				'include' => array( 'Post', 'page', 'page', '<bad>', '', 'unregistered_cpt' ),
 				'exclude' => array( 'product', 'product' ),
 			)
 		);
-		// `sanitize_key` lowercases and strips disallowed characters.
-		$this->assertSame( array( 'post', 'page', 'bad' ), $lists['include'] );
+		// `Post` lowercases to `post`; `<bad>` sanitizes to `bad` and gets
+		// dropped because no `bad` post type is registered. The blank entry
+		// and the duplicate `page` are silently filtered.
+		$this->assertSame( array( 'post', 'page' ), $lists['include'] );
+		$this->assertSame( array( 'product' ), $lists['exclude'] );
+	}
+
+	/**
+	 * Post types registered with `exclude_from_search => true` are dropped
+	 * from both lists. Listing one would either zero results (if in
+	 * include — the type is invisible to search) or be a no-op (if in
+	 * exclude — the type is already absent from the result set).
+	 */
+	public function test_build_lists_drops_search_excluded_post_types() {
+		$lists = Post_Type_Filter::build_lists(
+			array(
+				'include' => array( 'post', 'private_doc' ),
+				'exclude' => array( 'private_doc', 'product' ),
+			)
+		);
+		$this->assertSame( array( 'post' ), $lists['include'] );
 		$this->assertSame( array( 'product' ), $lists['exclude'] );
 	}
 
@@ -139,7 +223,10 @@ class Post_Type_Filter_Test extends TestCase {
 	/**
 	 * Existing state may carry malformed entries (e.g. from a future field
 	 * shape change); the merge sanitizes both sides before unioning so a
-	 * stray non-array value can't poison the merged output.
+	 * stray non-array value can't poison the merged output. `merge_state`
+	 * does not enforce the registry allowlist on the existing-state side
+	 * (already-filtered by the contributing block's own `build_lists()`
+	 * call) — `42` survives sanitize_key as the string `"42"`.
 	 */
 	public function test_merge_state_sanitizes_existing_state() {
 		$merged = Post_Type_Filter::merge_state(


### PR DESCRIPTION
Fixes #
Linear: [SEARCH-145](https://linear.app/a8c/issue/SEARCH-145/surface-excluded-post-types-outside-customberg)

## Why

Site builders using the Jetpack Search blocks (Search 3.0) currently have no way to scope results to a specific subset of post types — that knob lives in Customberg (the legacy admin panel) as a single sitewide `excluded_post_types` option, which means a Blog page and a Knowledge-base page on the same site can not differ in scope.

This PR exposes the same concept as a regular block, so each search page can carry its own constraint (or none). It is a hidden block: visitors see no new UI, but the ES query that backs the search results gets a `must.should` (Include mode) or `bool.must_not` (Exclude mode) clause appended.

**Why a single-mode toggle instead of two attribute lists:**

The first iteration offered both Include and Exclude lists on one block, ANDed together. Technically valid, but a UX footgun — when Include was set, Exclude visibly did "nothing" most of the time (the include set already restricts the results), so authors saw a control that appeared broken. A radio toggle (`Exclude` / `Include only`) keeps the mental model simple: pick one mode, then pick the post types that belong to it. `Exclude` is the default to match the SEARCH-145 motivating use case.

**Per-mode draft cache:**

Each mode keeps its own draft local to the editor session. Flipping to a mode the author has not used yet shows an empty picker; flipping back restores the previously-typed list. Only the active mode's `postTypes` is persisted to attributes, so the inactive draft is discarded on save / reload. Lets the author compare modes without re-typing each time, but still prevents an "exclude these" list from silently flipping into "include only these" with inverted meaning at save time.

## Proposed changes

- New block `jetpack/post-type-filter` (`Post Type Scope` in the inserter) with attributes `mode: 'include' | 'exclude'` (default `'exclude'`) and `postTypes: string[]`.
- Inspector: `RadioControl` for the mode (each radio label spells out the semantics) plus a single `FormTokenField` whose label adapts (`POST TYPES TO EXCLUDE` / `POST TYPES TO INCLUDE`). Suggestions sourced from registered post types via `wp.data`.
- Canvas preview is flat (matches the `filter-checkbox` and `search-results` previews — `<h3>` + content, no extra card chrome) with a small eye-off icon + "HIDDEN ON THE FRONT END" eyebrow so the block's nature is unmistakable.
- Per-mode draft cache (`useRef`-backed) restores the previously-typed list when the author flips modes back.
- Server-side `Post_Type_Filter::build_constraint()` validates each slug against the live registry (`exclude_from_search => false`), drops typos / retired CPTs / private types, and routes the slug list to either the `include` or `exclude` side of a shared `staticPostTypes` state slot. Multi-instance composition unions each side.
- New `buildStaticPostTypeClauses()` helper in `store/api.js`, folded into `buildSearchUrl()` alongside the existing filter and price-range paths.
- Block renders nothing on the front end (`render.php` writes to the store and returns no markup).
- Tests: 251 PHP / 261 JS, all green.

## Related product discussion/links

* Linear: [SEARCH-145 — Surface excluded post types outside Customberg](https://linear.app/a8c/issue/SEARCH-145/surface-excluded-post-types-outside-customberg)

## Does this pull request change what data or activity we track or use?

No. Adds a server-side filter on existing search queries; no new tracking, no new data.

## Testing instructions

1. Spin up a local Jetpack Search-enabled site with the search-blocks feature flag on (`apply_filters( 'jetpack_search_blocks_enabled', true )`).
2. Build the package + plugin: `pnpm jetpack build packages/search` and `pnpm jetpack build plugins/jetpack`.
3. Edit (or create) a page that uses the Jetpack Search blocks (e.g., insert the **Blog Search Page** pattern).
4. Insert the **Post Type Scope** block from the Jetpack Search category. Confirm the canvas shows the eye-off icon + "HIDDEN ON THE FRONT END" eyebrow above the title and a "Exclude: (none selected)" line.
5. In the Inspector, confirm the mode radio defaults to **Exclude**. Add a slug to the picker (e.g., `attachment`, `product`). Save and visit a search page — confirm those types are absent from results.
6. Switch the radio to **Include only**. The picker should clear. Add `post`, `page`. Reload — confirm only those post types appear in results.
7. Flip back to **Exclude** before saving — the previously-typed `attachment`, `product` should reappear in the picker. Flip to **Include only** again — `post`, `page` should reappear. Save — only the active mode's list is persisted.
8. Try entering a non-existent slug (e.g., `unknown_cpt`) — the editor accepts it, but the server normalizer drops it on render so it never reaches ES.
9. Confirm the front-end render of the block is empty (`view-source:` shows nothing for the wrapper).

## Real-screen captures

| Default state (Exclude mode, with selections) |
|---|
| ![exclude](https://github.com/user-attachments/assets/dd66adce-3fb3-4d24-8c15-9bbbf8da3bd5) |

| Include-only mode |
|---|
| ![include](https://github.com/user-attachments/assets/517e8ed8-b107-49b8-955d-3fa9f643b9e1) |

<img width="393" height="246" alt="image" src="https://github.com/user-attachments/assets/c5c75547-54bc-4727-be62-88a233efdd97" />
