### PR TITLE
Search blocks: convert createElement/h calls to JSX for readability

### DIFF
--- a/projects/packages/search/changelog/atlas-rsm-2109-search-blocks-jsx
+++ b/projects/packages/search/changelog/atlas-rsm-2109-search-blocks-jsx
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search blocks: convert createElement/h calls to JSX in editor preview components for readability.

--- a/projects/packages/search/src/search-blocks/blocks/active-filters/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/active-filters/edit.js
@@ -5,7 +5,6 @@
  * render a sample pill so designers can style the block in place.
  */
 import { useBlockProps } from '@wordpress/block-editor';
-import { createElement as h } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -15,48 +14,30 @@ import { __ } from '@wordpress/i18n';
  */
 export default function ActiveFiltersEdit() {
 	const blockProps = useBlockProps();
-	return h(
-		'div',
-		blockProps,
-		h(
-			'span',
-			{ className: 'jetpack-search-active-filters__heading' },
-			__( 'Active filters:', 'jetpack-search-pkg' )
-		),
-		h(
-			'ul',
-			{ className: 'jetpack-search-active-filters__pills' },
-			h(
-				'li',
-				null,
-				h(
-					'button',
-					{
-						type: 'button',
-						className: 'wp-element-button jetpack-search-active-filters__pill',
-						disabled: true,
-					},
-					h(
-						'span',
-						{ className: 'jetpack-search-active-filters__pill-label' },
-						__( 'Example filter', 'jetpack-search-pkg' )
-					),
-					h(
-						'span',
-						{ className: 'jetpack-search-active-filters__pill-remove', 'aria-hidden': 'true' },
-						'×'
-					)
-				)
-			)
-		),
-		h(
-			'button',
-			{
-				type: 'button',
-				className: 'jetpack-search-active-filters__clear-all',
-				disabled: true,
-			},
-			__( 'Clear all', 'jetpack-search-pkg' )
-		)
+	return (
+		<div { ...blockProps }>
+			<span className="jetpack-search-active-filters__heading">
+				{ __( 'Active filters:', 'jetpack-search-pkg' ) }
+			</span>
+			<ul className="jetpack-search-active-filters__pills">
+				<li>
+					<button
+						type="button"
+						className="wp-element-button jetpack-search-active-filters__pill"
+						disabled
+					>
+						<span className="jetpack-search-active-filters__pill-label">
+							{ __( 'Example filter', 'jetpack-search-pkg' ) }
+						</span>
+						<span className="jetpack-search-active-filters__pill-remove" aria-hidden="true">
+							×
+						</span>
+					</button>
+				</li>
+			</ul>
+			<button type="button" className="jetpack-search-active-filters__clear-all" disabled>
+				{ __( 'Clear all', 'jetpack-search-pkg' ) }
+			</button>
+		</div>
 	);
 }

--- a/projects/packages/search/src/search-blocks/blocks/common-filters/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/common-filters/edit.js
@@ -7,7 +7,6 @@
  * block-wrapper div and lets each inner filter contribute its own markup.
  */
 import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
-import { createElement as h } from '@wordpress/element';
 
 const TEMPLATE = [
 	[ 'jetpack/active-filters' ],
@@ -27,7 +26,11 @@ const ALLOWED = [ 'jetpack/active-filters', 'jetpack/filter-checkbox', 'jetpack/
  */
 export default function CommonFiltersEdit() {
 	const blockProps = useBlockProps( { className: 'jetpack-search-common-filters' } );
-	return h( 'div', blockProps, h( InnerBlocks, { template: TEMPLATE, allowedBlocks: ALLOWED } ) );
+	return (
+		<div { ...blockProps }>
+			<InnerBlocks template={ TEMPLATE } allowedBlocks={ ALLOWED } />
+		</div>
+	);
 }
 
 /**
@@ -35,4 +38,4 @@ export default function CommonFiltersEdit() {
  *
  * @return {object} Rendered element.
  */
-export const save = () => h( InnerBlocks.Content, {} );
+export const save = () => <InnerBlocks.Content />;

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/edit.js
@@ -24,7 +24,7 @@ import {
 	ToggleControl,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { createElement as h, Fragment, useMemo } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 const SAMPLE_FILTER_ITEMS = [
@@ -225,147 +225,136 @@ export default function FilterCheckboxEdit( { attributes, setAttributes } ) {
 				/* dummy arg to avoid bad minification */ 0
 		  );
 
-	return h(
-		Fragment,
-		null,
-		h(
-			InspectorControls,
-			null,
-			h(
-				PanelBody,
-				{ title: __( 'Settings', 'jetpack-search-pkg' ) },
-				h( SelectControl, {
-					__next40pxDefaultSize: true,
-					__nextHasNoMarginBottom: true,
-					label: __( 'Filter type', 'jetpack-search-pkg' ),
-					value: currentVariation,
-					options: [
-						{ value: VARIATION_CATEGORY, label: __( 'Category', 'jetpack-search-pkg' ) },
-						{ value: VARIATION_POST_TAG, label: __( 'Tag', 'jetpack-search-pkg' ) },
-						{ value: VARIATION_POST_TYPE, label: __( 'Post Type', 'jetpack-search-pkg' ) },
-						{ value: VARIATION_AUTHOR, label: __( 'Author', 'jetpack-search-pkg' ) },
-						{
-							value: VARIATION_CUSTOM_TAXONOMY,
-							label: __( 'Custom taxonomy', 'jetpack-search-pkg' ),
-						},
-					],
-					onChange: onVariationChange,
-					help: __(
-						'What this filter groups results by. Switch without deleting the block.',
-						'jetpack-search-pkg'
-					),
-				} ),
-				isCustomTaxonomy &&
-					h( SelectControl, {
-						__next40pxDefaultSize: true,
-						__nextHasNoMarginBottom: true,
-						label: __( 'Taxonomy', 'jetpack-search-pkg' ),
-						value: taxonomy,
-						disabled: hasNoCustomTaxonomies,
-						options: [
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings', 'jetpack-search-pkg' ) }>
+					<SelectControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Filter type', 'jetpack-search-pkg' ) }
+						value={ currentVariation }
+						options={ [
+							{ value: VARIATION_CATEGORY, label: __( 'Category', 'jetpack-search-pkg' ) },
+							{ value: VARIATION_POST_TAG, label: __( 'Tag', 'jetpack-search-pkg' ) },
+							{ value: VARIATION_POST_TYPE, label: __( 'Post Type', 'jetpack-search-pkg' ) },
+							{ value: VARIATION_AUTHOR, label: __( 'Author', 'jetpack-search-pkg' ) },
 							{
-								value: '',
-								label: isLoadingTaxonomies
-									? __( 'Loading taxonomies…', 'jetpack-search-pkg' )
+								value: VARIATION_CUSTOM_TAXONOMY,
+								label: __( 'Custom taxonomy', 'jetpack-search-pkg' ),
+							},
+						] }
+						onChange={ onVariationChange }
+						help={ __(
+							'What this filter groups results by. Switch without deleting the block.',
+							'jetpack-search-pkg'
+						) }
+					/>
+					{ isCustomTaxonomy && (
+						<SelectControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							label={ __( 'Taxonomy', 'jetpack-search-pkg' ) }
+							value={ taxonomy }
+							disabled={ hasNoCustomTaxonomies }
+							options={ [
+								{
+									value: '',
+									label: isLoadingTaxonomies
+										? __( 'Loading taxonomies…', 'jetpack-search-pkg' )
+										: __(
+												'Select a taxonomy',
+												'jetpack-search-pkg',
+												/* dummy arg to avoid bad minification */ 0
+										  ),
+									disabled: true,
+								},
+								...( taxonomyOptions || [] ),
+							] }
+							onChange={ value => setAttributes( { taxonomy: value } ) }
+							help={
+								hasNoCustomTaxonomies
+									? __(
+											'No custom taxonomies registered on this site. Register one with register_taxonomy() and it will appear here.',
+											'jetpack-search-pkg'
+									  )
 									: __(
-											'Select a taxonomy',
+											'Pick which registered taxonomy this filter targets. Built-in Category and Tag have their own dedicated filters in the inserter.',
 											'jetpack-search-pkg',
 											/* dummy arg to avoid bad minification */ 0
-									  ),
-								disabled: true,
-							},
-							...( taxonomyOptions || [] ),
-						],
-						onChange: value => setAttributes( { taxonomy: value } ),
-						help: hasNoCustomTaxonomies
-							? __(
-									'No custom taxonomies registered on this site. Register one with register_taxonomy() and it will appear here.',
-									'jetpack-search-pkg'
-							  )
-							: __(
-									'Pick which registered taxonomy this filter targets. Built-in Category and Tag have their own dedicated filters in the inserter.',
-									'jetpack-search-pkg',
-									/* dummy arg to avoid bad minification */ 0
-							  ),
-					} ),
-				h( TextControl, {
-					__next40pxDefaultSize: true,
-					__nextHasNoMarginBottom: true,
-					label: __( 'Label', 'jetpack-search-pkg' ),
-					value: rawLabel,
-					placeholder: placeholderLabel,
-					onChange: value => setAttributes( { label: value } ),
-					help: labelHelp,
-				} ),
-				h( ToggleControl, {
-					__nextHasNoMarginBottom: true,
-					label: __( 'Show result counts', 'jetpack-search-pkg' ),
-					checked: showCount,
-					onChange: value => setAttributes( { showCount: !! value } ),
-				} ),
-				h( RangeControl, {
-					__next40pxDefaultSize: true,
-					__nextHasNoMarginBottom: true,
-					label: __( 'Maximum items', 'jetpack-search-pkg' ),
-					value: maxItems,
-					min: 1,
-					max: 50,
-					onChange: value => setAttributes( { maxItems: Math.max( 1, value || 1 ) } ),
-				} ),
-				h( SelectControl, {
-					__next40pxDefaultSize: true,
-					__nextHasNoMarginBottom: true,
-					label: __( 'Sort order', 'jetpack-search-pkg' ),
-					value: bucketSortOrder,
-					options: [
-						{ value: 'count', label: __( 'Most results first', 'jetpack-search-pkg' ) },
-						{ value: 'alpha', label: __( 'Alphabetical', 'jetpack-search-pkg' ) },
-					],
-					onChange: value =>
-						setAttributes( { bucketSortOrder: value === 'alpha' ? 'alpha' : 'count' } ),
-				} )
-			)
-		),
-		h(
-			'div',
-			blockProps,
-			needsTaxonomyChoice
-				? h( Placeholder, {
-						icon: 'filter',
-						label: __( 'Custom Taxonomy Filter', 'jetpack-search-pkg' ),
-						instructions: __(
+									  )
+							}
+						/>
+					) }
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Label', 'jetpack-search-pkg' ) }
+						value={ rawLabel }
+						placeholder={ placeholderLabel }
+						onChange={ value => setAttributes( { label: value } ) }
+						help={ labelHelp }
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Show result counts', 'jetpack-search-pkg' ) }
+						checked={ showCount }
+						onChange={ value => setAttributes( { showCount: !! value } ) }
+					/>
+					<RangeControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Maximum items', 'jetpack-search-pkg' ) }
+						value={ maxItems }
+						min={ 1 }
+						max={ 50 }
+						onChange={ value => setAttributes( { maxItems: Math.max( 1, value || 1 ) } ) }
+					/>
+					<SelectControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Sort order', 'jetpack-search-pkg' ) }
+						value={ bucketSortOrder }
+						options={ [
+							{ value: 'count', label: __( 'Most results first', 'jetpack-search-pkg' ) },
+							{ value: 'alpha', label: __( 'Alphabetical', 'jetpack-search-pkg' ) },
+						] }
+						onChange={ value =>
+							setAttributes( { bucketSortOrder: value === 'alpha' ? 'alpha' : 'count' } )
+						}
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div { ...blockProps }>
+				{ needsTaxonomyChoice ? (
+					<Placeholder
+						icon="filter"
+						label={ __( 'Custom Taxonomy Filter', 'jetpack-search-pkg' ) }
+						instructions={ __(
 							'Choose a taxonomy in the block settings to enable this filter. Until a taxonomy is set, this block renders nothing on the front end.',
 							'jetpack-search-pkg'
-						),
-				  } )
-				: h(
-						Fragment,
-						null,
-						h( 'h3', { className: 'jetpack-search-filter__title' }, previewLabel ),
-						h(
-							'ul',
-							{ className: 'jetpack-search-filter__list' },
-							SAMPLE_FILTER_ITEMS.slice( 0, maxItems ).map( item =>
-								h(
-									'li',
-									{ key: item.value, className: 'jetpack-search-filter__item' },
-									h(
-										'label',
-										null,
-										h( 'input', { type: 'checkbox', disabled: true } ),
-										h( 'span', { className: 'jetpack-search-filter__label' }, item.label ),
-										showCount
-											? h(
-													'span',
-													{ className: 'jetpack-search-filter__count' },
-													String( item.count )
-											  )
-											: null
-									)
-								)
-							)
-						)
-				  )
-		)
+						) }
+					/>
+				) : (
+					<>
+						<h3 className="jetpack-search-filter__title">{ previewLabel }</h3>
+						<ul className="jetpack-search-filter__list">
+							{ SAMPLE_FILTER_ITEMS.slice( 0, maxItems ).map( item => (
+								<li key={ item.value } className="jetpack-search-filter__item">
+									{ /* eslint-disable-next-line jsx-a11y/label-has-associated-control -- the input is a direct child, implicit HTML5 association applies; rule's nesting heuristic doesn't trace through sibling spans */ }
+									<label>
+										<input type="checkbox" disabled />
+										<span className="jetpack-search-filter__label">{ item.label }</span>
+										{ showCount && (
+											<span className="jetpack-search-filter__count">{ String( item.count ) }</span>
+										) }
+									</label>
+								</li>
+							) ) }
+						</ul>
+					</>
+				) }
+			</div>
+		</>
 	);
 }

--- a/projects/packages/search/src/search-blocks/blocks/filter-date/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-date/edit.js
@@ -9,7 +9,6 @@ import {
 	TextControl,
 	ToggleControl,
 } from '@wordpress/components';
-import { createElement as h, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 const SAMPLE_BUCKETS_YEAR = [
@@ -48,93 +47,82 @@ export default function FilterDateEdit( { attributes, setAttributes } ) {
 		: 'newest';
 	const sampleBuckets = interval === 'month' ? SAMPLE_BUCKETS_MONTH : SAMPLE_BUCKETS_YEAR;
 
-	return h(
-		Fragment,
-		null,
-		h(
-			InspectorControls,
-			null,
-			h(
-				PanelBody,
-				{ title: __( 'Settings', 'jetpack-search-pkg' ) },
-				h( SelectControl, {
-					__next40pxDefaultSize: true,
-					__nextHasNoMarginBottom: true,
-					label: __( 'Interval', 'jetpack-search-pkg' ),
-					value: interval,
-					options: [
-						{ value: 'year', label: __( 'Year', 'jetpack-search-pkg' ) },
-						{ value: 'month', label: __( 'Month', 'jetpack-search-pkg' ) },
-					],
-					onChange: value => setAttributes( { interval: value === 'month' ? 'month' : 'year' } ),
-					help: __(
-						'Bucket size: yearly suits long-running blogs; monthly suits archive-heavy news sites.',
-						'jetpack-search-pkg'
-					),
-				} ),
-				h( TextControl, {
-					__next40pxDefaultSize: true,
-					__nextHasNoMarginBottom: true,
-					label: __( 'Label', 'jetpack-search-pkg' ),
-					value: rawLabel,
-					placeholder: placeholderLabel,
-					onChange: value => setAttributes( { label: value } ),
-					help: __( 'Leave empty to use the default "Date" label.', 'jetpack-search-pkg' ),
-				} ),
-				h( ToggleControl, {
-					__nextHasNoMarginBottom: true,
-					label: __( 'Show result counts', 'jetpack-search-pkg' ),
-					checked: showCount,
-					onChange: value => setAttributes( { showCount: !! value } ),
-				} ),
-				h( RangeControl, {
-					__next40pxDefaultSize: true,
-					__nextHasNoMarginBottom: true,
-					label: __( 'Maximum items', 'jetpack-search-pkg' ),
-					value: maxItems,
-					min: 1,
-					max: 50,
-					onChange: value => setAttributes( { maxItems: Math.max( 1, value || 1 ) } ),
-				} ),
-				h( SelectControl, {
-					__next40pxDefaultSize: true,
-					__nextHasNoMarginBottom: true,
-					label: __( 'Sort order', 'jetpack-search-pkg' ),
-					value: bucketSortOrder,
-					options: [
-						{ value: 'newest', label: __( 'Most recent first', 'jetpack-search-pkg' ) },
-						{ value: 'oldest', label: __( 'Oldest first', 'jetpack-search-pkg' ) },
-						{ value: 'count', label: __( 'Most results first', 'jetpack-search-pkg' ) },
-					],
-					onChange: value => setAttributes( { bucketSortOrder: value } ),
-				} )
-			)
-		),
-		h(
-			'div',
-			blockProps,
-			h( 'h3', { className: 'jetpack-search-filter__title' }, previewLabel ),
-			h(
-				'ul',
-				{ className: 'jetpack-search-filter__list' },
-				sampleBuckets
-					.slice( 0, maxItems )
-					.map( item =>
-						h(
-							'li',
-							{ key: item.value, className: 'jetpack-search-filter__item' },
-							h(
-								'label',
-								null,
-								h( 'input', { type: 'checkbox', disabled: true } ),
-								h( 'span', { className: 'jetpack-search-filter__label' }, item.label ),
-								showCount
-									? h( 'span', { className: 'jetpack-search-filter__count' }, String( item.count ) )
-									: null
-							)
-						)
-					)
-			)
-		)
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings', 'jetpack-search-pkg' ) }>
+					<SelectControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Interval', 'jetpack-search-pkg' ) }
+						value={ interval }
+						options={ [
+							{ value: 'year', label: __( 'Year', 'jetpack-search-pkg' ) },
+							{ value: 'month', label: __( 'Month', 'jetpack-search-pkg' ) },
+						] }
+						onChange={ value =>
+							setAttributes( { interval: value === 'month' ? 'month' : 'year' } )
+						}
+						help={ __(
+							'Bucket size: yearly suits long-running blogs; monthly suits archive-heavy news sites.',
+							'jetpack-search-pkg'
+						) }
+					/>
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Label', 'jetpack-search-pkg' ) }
+						value={ rawLabel }
+						placeholder={ placeholderLabel }
+						onChange={ value => setAttributes( { label: value } ) }
+						help={ __( 'Leave empty to use the default "Date" label.', 'jetpack-search-pkg' ) }
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Show result counts', 'jetpack-search-pkg' ) }
+						checked={ showCount }
+						onChange={ value => setAttributes( { showCount: !! value } ) }
+					/>
+					<RangeControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Maximum items', 'jetpack-search-pkg' ) }
+						value={ maxItems }
+						min={ 1 }
+						max={ 50 }
+						onChange={ value => setAttributes( { maxItems: Math.max( 1, value || 1 ) } ) }
+					/>
+					<SelectControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Sort order', 'jetpack-search-pkg' ) }
+						value={ bucketSortOrder }
+						options={ [
+							{ value: 'newest', label: __( 'Most recent first', 'jetpack-search-pkg' ) },
+							{ value: 'oldest', label: __( 'Oldest first', 'jetpack-search-pkg' ) },
+							{ value: 'count', label: __( 'Most results first', 'jetpack-search-pkg' ) },
+						] }
+						onChange={ value => setAttributes( { bucketSortOrder: value } ) }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div { ...blockProps }>
+				<h3 className="jetpack-search-filter__title">{ previewLabel }</h3>
+				<ul className="jetpack-search-filter__list">
+					{ sampleBuckets.slice( 0, maxItems ).map( item => (
+						<li key={ item.value } className="jetpack-search-filter__item">
+							{ /* eslint-disable-next-line jsx-a11y/label-has-associated-control -- the input is a direct child, implicit HTML5 association applies; rule's nesting heuristic doesn't trace through sibling spans */ }
+							<label>
+								<input type="checkbox" disabled />
+								<span className="jetpack-search-filter__label">{ item.label }</span>
+								{ showCount && (
+									<span className="jetpack-search-filter__count">{ String( item.count ) }</span>
+								) }
+							</label>
+						</li>
+					) ) }
+				</ul>
+			</div>
+		</>
 	);
 }

--- a/projects/packages/search/src/search-blocks/blocks/filter-popover/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-popover/edit.js
@@ -5,7 +5,6 @@
  * pattern preview mirrors the front-end default state.
  */
 import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
-import { createElement as h } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 const TEMPLATE = [
@@ -24,43 +23,36 @@ const ALLOWED = [ 'jetpack/filter-checkbox', 'jetpack/active-filters' ];
  */
 export default function FilterPopoverEdit() {
 	const blockProps = useBlockProps( { className: 'jetpack-search-filter-popover' } );
-	return h(
-		'div',
-		blockProps,
-		h(
-			'button',
-			{
-				type: 'button',
-				className: 'jetpack-search-filter-popover__trigger',
-				'aria-haspopup': 'dialog',
-				'aria-expanded': 'false',
-				disabled: true,
-			},
-			h(
-				'svg',
-				{
-					className: 'jetpack-search-filter-popover__icon',
-					width: 18,
-					height: 18,
-					viewBox: '0 0 24 24',
-					'aria-hidden': 'true',
-					focusable: 'false',
-				},
-				h( 'path', { fill: 'currentColor', d: 'M3 6h18v2H3V6Zm3 5h12v2H6v-2Zm3 5h6v2H9v-2Z' } )
-			),
-			h( 'span', { className: 'screen-reader-text' }, __( 'Filter results', 'jetpack-search-pkg' ) )
-		),
-		h(
-			'div',
-			{
-				className:
-					'jetpack-search-filter-popover__panel jetpack-search-filter-popover__panel--editor',
-				role: 'dialog',
-				'aria-label': __( 'Filters', 'jetpack-search-pkg' ),
-				hidden: true,
-			},
-			h( InnerBlocks, { template: TEMPLATE, allowedBlocks: ALLOWED } )
-		)
+	return (
+		<div { ...blockProps }>
+			<button
+				type="button"
+				className="jetpack-search-filter-popover__trigger"
+				aria-haspopup="dialog"
+				aria-expanded="false"
+				disabled
+			>
+				<svg
+					className="jetpack-search-filter-popover__icon"
+					width={ 18 }
+					height={ 18 }
+					viewBox="0 0 24 24"
+					aria-hidden="true"
+					focusable="false"
+				>
+					<path fill="currentColor" d="M3 6h18v2H3V6Zm3 5h12v2H6v-2Zm3 5h6v2H9v-2Z" />
+				</svg>
+				<span className="screen-reader-text">{ __( 'Filter results', 'jetpack-search-pkg' ) }</span>
+			</button>
+			<div
+				className="jetpack-search-filter-popover__panel jetpack-search-filter-popover__panel--editor"
+				role="dialog"
+				aria-label={ __( 'Filters', 'jetpack-search-pkg' ) }
+				hidden
+			>
+				<InnerBlocks template={ TEMPLATE } allowedBlocks={ ALLOWED } />
+			</div>
+		</div>
 	);
 }
 
@@ -69,4 +61,4 @@ export default function FilterPopoverEdit() {
  *
  * @return {object} Rendered element.
  */
-export const save = () => h( InnerBlocks.Content, {} );
+export const save = () => <InnerBlocks.Content />;

--- a/projects/packages/search/src/search-blocks/blocks/load-more/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/load-more/edit.js
@@ -9,7 +9,6 @@
  */
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { PanelBody, TextControl } from '@wordpress/components';
-import { createElement as h, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -27,43 +26,33 @@ export default function LoadMoreEdit( { attributes, setAttributes } ) {
 	// in the preview so the editor mirrors the front-end behaviour the
 	// "Leave empty…" help text describes. The raw input is still stored.
 	const buttonLabel = ( attributes?.buttonLabel || '' ).trim() || defaultLabel;
-	return h(
-		Fragment,
-		null,
-		h(
-			InspectorControls,
-			null,
-			h(
-				PanelBody,
-				{ title: __( 'Settings', 'jetpack-search-pkg' ) },
-				h( TextControl, {
-					__next40pxDefaultSize: true,
-					__nextHasNoMarginBottom: true,
-					label: __( 'Button label', 'jetpack-search-pkg' ),
-					value: attributes?.buttonLabel || '',
-					placeholder: defaultLabel,
-					onChange: value => setAttributes( { buttonLabel: value } ),
-					help: __( 'Leave empty to use the default translated label.', 'jetpack-search-pkg' ),
-				} )
-			)
-		),
-		h(
-			'div',
-			blockProps,
-			h(
-				'button',
-				{
-					type: 'button',
-					className: 'wp-element-button jetpack-search-load-more__button',
-					disabled: true,
-				},
-				buttonLabel
-			),
-			h(
-				'span',
-				{ className: 'jetpack-search-load-more__spinner', hidden: true },
-				__( 'Loading…', 'jetpack-search-pkg' )
-			)
-		)
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings', 'jetpack-search-pkg' ) }>
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Button label', 'jetpack-search-pkg' ) }
+						value={ attributes?.buttonLabel || '' }
+						placeholder={ defaultLabel }
+						onChange={ value => setAttributes( { buttonLabel: value } ) }
+						help={ __( 'Leave empty to use the default translated label.', 'jetpack-search-pkg' ) }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div { ...blockProps }>
+				<button
+					type="button"
+					className="wp-element-button jetpack-search-load-more__button"
+					disabled
+				>
+					{ buttonLabel }
+				</button>
+				<span className="jetpack-search-load-more__spinner" hidden>
+					{ __( 'Loading…', 'jetpack-search-pkg' ) }
+				</span>
+			</div>
+		</>
 	);
 }

--- a/projects/packages/search/src/search-blocks/blocks/no-results/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/no-results/edit.js
@@ -7,7 +7,6 @@
  */
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { PanelBody, TextControl } from '@wordpress/components';
-import { createElement as h, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -21,26 +20,25 @@ import { __ } from '@wordpress/i18n';
 export default function NoResultsEdit( { attributes, setAttributes } ) {
 	const blockProps = useBlockProps();
 	const defaultMessage = __( 'No results found. Try a different search.', 'jetpack-search-pkg' );
-	return h(
-		Fragment,
-		null,
-		h(
-			InspectorControls,
-			null,
-			h(
-				PanelBody,
-				{ title: __( 'Settings', 'jetpack-search-pkg' ) },
-				h( TextControl, {
-					__next40pxDefaultSize: true,
-					__nextHasNoMarginBottom: true,
-					label: __( 'Message', 'jetpack-search-pkg' ),
-					value: attributes.message || '',
-					placeholder: defaultMessage,
-					onChange: value => setAttributes( { message: value } ),
-					help: __( 'Leave empty to use the default translated message.', 'jetpack-search-pkg' ),
-				} )
-			)
-		),
-		h( 'div', { ...blockProps, hidden: true, 'aria-hidden': 'true' } )
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings', 'jetpack-search-pkg' ) }>
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Message', 'jetpack-search-pkg' ) }
+						value={ attributes.message || '' }
+						placeholder={ defaultMessage }
+						onChange={ value => setAttributes( { message: value } ) }
+						help={ __(
+							'Leave empty to use the default translated message.',
+							'jetpack-search-pkg'
+						) }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div { ...blockProps } hidden aria-hidden="true" />
+		</>
 	);
 }

--- a/projects/packages/search/src/search-blocks/blocks/results-count/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/results-count/edit.js
@@ -6,7 +6,6 @@
  * style on the front end.
  */
 import { useBlockProps } from '@wordpress/block-editor';
-import { createElement as h } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -16,5 +15,5 @@ import { __ } from '@wordpress/i18n';
  */
 export default function ResultsCountEdit() {
 	const blockProps = useBlockProps();
-	return h( 'p', blockProps, __( '42 results', 'jetpack-search-pkg' ) );
+	return <p { ...blockProps }>{ __( '42 results', 'jetpack-search-pkg' ) }</p>;
 }

--- a/projects/packages/search/src/search-blocks/blocks/search-error/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-error/edit.js
@@ -7,7 +7,6 @@
  */
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { PanelBody, TextControl } from '@wordpress/components';
-import { createElement as h, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -21,26 +20,25 @@ import { __ } from '@wordpress/i18n';
 export default function SearchErrorEdit( { attributes, setAttributes } ) {
 	const blockProps = useBlockProps();
 	const defaultMessage = __( 'Something went wrong. Please try again.', 'jetpack-search-pkg' );
-	return h(
-		Fragment,
-		null,
-		h(
-			InspectorControls,
-			null,
-			h(
-				PanelBody,
-				{ title: __( 'Settings', 'jetpack-search-pkg' ) },
-				h( TextControl, {
-					__next40pxDefaultSize: true,
-					__nextHasNoMarginBottom: true,
-					label: __( 'Message', 'jetpack-search-pkg' ),
-					value: attributes.message || '',
-					placeholder: defaultMessage,
-					onChange: value => setAttributes( { message: value } ),
-					help: __( 'Leave empty to use the default translated message.', 'jetpack-search-pkg' ),
-				} )
-			)
-		),
-		h( 'div', { ...blockProps, hidden: true, 'aria-hidden': 'true' } )
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings', 'jetpack-search-pkg' ) }>
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Message', 'jetpack-search-pkg' ) }
+						value={ attributes.message || '' }
+						placeholder={ defaultMessage }
+						onChange={ value => setAttributes( { message: value } ) }
+						help={ __(
+							'Leave empty to use the default translated message.',
+							'jetpack-search-pkg'
+						) }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div { ...blockProps } hidden aria-hidden="true" />
+		</>
 	);
 }

--- a/projects/packages/search/src/search-blocks/blocks/search-input/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-input/edit.js
@@ -9,7 +9,7 @@
  */
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
-import { createElement as h, Fragment, useId } from '@wordpress/element';
+import { useId } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -19,20 +19,18 @@ import { __ } from '@wordpress/i18n';
  * @return {object} Rendered SVG element.
  */
 function SearchGlyph() {
-	return h(
-		'svg',
-		{
-			className: 'jetpack-search-input__icon',
-			'aria-hidden': 'true',
-			focusable: 'false',
-			xmlns: 'http://www.w3.org/2000/svg',
-			width: 24,
-			height: 24,
-			viewBox: '0 0 24 24',
-		},
-		h( 'path', {
-			d: 'M13 5c-3.3 0-6 2.7-6 6 0 1.4.5 2.7 1.3 3.7l-3.8 3.8 1.1 1.1 3.8-3.8c1 .8 2.3 1.3 3.7 1.3 3.3 0 6-2.7 6-6s-2.7-6-6-6zm0 10.5c-2.5 0-4.5-2-4.5-4.5s2-4.5 4.5-4.5 4.5 2 4.5 4.5-2 4.5-4.5 4.5z',
-		} )
+	return (
+		<svg
+			className="jetpack-search-input__icon"
+			aria-hidden="true"
+			focusable="false"
+			xmlns="http://www.w3.org/2000/svg"
+			width={ 24 }
+			height={ 24 }
+			viewBox="0 0 24 24"
+		>
+			<path d="M13 5c-3.3 0-6 2.7-6 6 0 1.4.5 2.7 1.3 3.7l-3.8 3.8 1.1 1.1 3.8-3.8c1 .8 2.3 1.3 3.7 1.3 3.3 0 6-2.7 6-6s-2.7-6-6-6zm0 10.5c-2.5 0-4.5-2-4.5-4.5s2-4.5 4.5-4.5 4.5 2 4.5 4.5-2 4.5-4.5 4.5z" />
+		</svg>
 	);
 }
 
@@ -55,80 +53,65 @@ export default function SearchInputEdit( { attributes, setAttributes } ) {
 	const placeholder = ( attributes?.placeholder || '' ).trim() || defaultPlaceholder;
 	const showIcon = attributes?.showIcon !== false;
 	const submitOnly = !! attributes?.submitOnly;
-	return h(
-		Fragment,
-		null,
-		h(
-			InspectorControls,
-			null,
-			h(
-				PanelBody,
-				{ title: __( 'Settings', 'jetpack-search-pkg' ) },
-				h( TextControl, {
-					__next40pxDefaultSize: true,
-					__nextHasNoMarginBottom: true,
-					label: __( 'Placeholder', 'jetpack-search-pkg' ),
-					value: attributes?.placeholder || '',
-					placeholder: defaultPlaceholder,
-					onChange: value => setAttributes( { placeholder: value } ),
-					help: __(
-						'Leave empty to use the default translated placeholder.',
-						'jetpack-search-pkg'
-					),
-				} ),
-				h( ToggleControl, {
-					__nextHasNoMarginBottom: true,
-					label: __( 'Show search icon', 'jetpack-search-pkg' ),
-					checked: showIcon,
-					onChange: value => setAttributes( { showIcon: value } ),
-				} ),
-				h( ToggleControl, {
-					__nextHasNoMarginBottom: true,
-					label: __( 'Search on submit only', 'jetpack-search-pkg' ),
-					checked: submitOnly,
-					onChange: value => setAttributes( { submitOnly: value } ),
-					help: __(
-						'When enabled, queries fire on Enter or when clearing the field, instead of on every keystroke.',
-						'jetpack-search-pkg'
-					),
-				} )
-			)
-		),
-		h(
-			'div',
-			blockProps,
-			h(
-				'label',
-				{
-					className: 'jetpack-search-input__label screen-reader-text',
-					htmlFor: inputId,
-				},
-				__( 'Search', 'jetpack-search-pkg' )
-			),
-			h(
-				'div',
-				{ className: 'jetpack-search-input__inside-wrapper' },
-				showIcon && h( SearchGlyph, null ),
-				h( 'input', {
-					id: inputId,
-					type: 'search',
-					className: 'jetpack-search-input__field',
-					placeholder,
-					disabled: true,
-					readOnly: true,
-				} ),
-				h(
-					'button',
-					{
-						type: 'button',
-						className: 'jetpack-search-input__clear',
-						hidden: true,
-						disabled: true,
-						'aria-label': __( 'Clear search', 'jetpack-search-pkg' ),
-					},
-					'✕'
-				)
-			)
-		)
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings', 'jetpack-search-pkg' ) }>
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Placeholder', 'jetpack-search-pkg' ) }
+						value={ attributes?.placeholder || '' }
+						placeholder={ defaultPlaceholder }
+						onChange={ value => setAttributes( { placeholder: value } ) }
+						help={ __(
+							'Leave empty to use the default translated placeholder.',
+							'jetpack-search-pkg'
+						) }
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Show search icon', 'jetpack-search-pkg' ) }
+						checked={ showIcon }
+						onChange={ value => setAttributes( { showIcon: value } ) }
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Search on submit only', 'jetpack-search-pkg' ) }
+						checked={ submitOnly }
+						onChange={ value => setAttributes( { submitOnly: value } ) }
+						help={ __(
+							'When enabled, queries fire on Enter or when clearing the field, instead of on every keystroke.',
+							'jetpack-search-pkg'
+						) }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div { ...blockProps }>
+				<label className="jetpack-search-input__label screen-reader-text" htmlFor={ inputId }>
+					{ __( 'Search', 'jetpack-search-pkg' ) }
+				</label>
+				<div className="jetpack-search-input__inside-wrapper">
+					{ showIcon && <SearchGlyph /> }
+					<input
+						id={ inputId }
+						type="search"
+						className="jetpack-search-input__field"
+						placeholder={ placeholder }
+						disabled
+						readOnly
+					/>
+					<button
+						type="button"
+						className="jetpack-search-input__clear"
+						hidden
+						disabled
+						aria-label={ __( 'Clear search', 'jetpack-search-pkg' ) }
+					>
+						✕
+					</button>
+				</div>
+			</div>
+		</>
 	);
 }

--- a/projects/packages/search/src/search-blocks/blocks/search-results/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/search-results/edit.js
@@ -2,7 +2,6 @@
  * Editor preview for jetpack/search-results.
  */
 import { useBlockProps } from '@wordpress/block-editor';
-import { createElement as h } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 const SAMPLE_RESULTS = [
@@ -36,40 +35,31 @@ export default function SearchResultsEdit( { attributes } ) {
 	const blockProps = useBlockProps( {
 		className: isCompact ? 'jetpack-search-results--compact' : 'jetpack-search-results--card',
 	} );
-	return h(
-		'div',
-		blockProps,
-		h(
-			'ul',
-			{ className: 'jetpack-search-results__list' },
-			SAMPLE_RESULTS.map( result =>
-				h(
-					'li',
-					{ key: result.path, className: 'jetpack-search-results__item' },
-					h(
-						'div',
-						{ className: 'jetpack-search-results__copy' },
-						h( 'h3', { className: 'jetpack-search-results__title' }, result.title ),
-						! isCompact && h( 'div', { className: 'jetpack-search-results__path' }, result.path ),
-						h(
-							'div',
-							{ className: 'jetpack-search-results__meta' },
-							h( 'span', { className: 'jetpack-search-results__date' }, result.date )
-						)
-					),
-					! isCompact &&
-						h(
-							'a',
-							{
-								className: 'jetpack-search-results__image-link',
-								hidden: true,
-								tabIndex: -1,
-								'aria-hidden': 'true',
-							},
-							h( 'img', { className: 'jetpack-search-results__image', alt: '' } )
-						)
-				)
-			)
-		)
+	return (
+		<div { ...blockProps }>
+			<ul className="jetpack-search-results__list">
+				{ SAMPLE_RESULTS.map( result => (
+					<li key={ result.path } className="jetpack-search-results__item">
+						<div className="jetpack-search-results__copy">
+							<h3 className="jetpack-search-results__title">{ result.title }</h3>
+							{ ! isCompact && <div className="jetpack-search-results__path">{ result.path }</div> }
+							<div className="jetpack-search-results__meta">
+								<span className="jetpack-search-results__date">{ result.date }</span>
+							</div>
+						</div>
+						{ ! isCompact && (
+							<a
+								className="jetpack-search-results__image-link"
+								hidden
+								tabIndex={ -1 }
+								aria-hidden="true"
+							>
+								<img className="jetpack-search-results__image" alt="" />
+							</a>
+						) }
+					</li>
+				) ) }
+			</ul>
+		</div>
 	);
 }

--- a/projects/packages/search/src/search-blocks/blocks/sort-control/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/sort-control/edit.js
@@ -8,7 +8,7 @@
  */
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { CheckboxControl, PanelBody, SelectControl, TextControl } from '@wordpress/components';
-import { createElement as h, Fragment, useId } from '@wordpress/element';
+import { useId } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 // Mirror Sort_Control::BASE_SORT_KEYS. Product-format keys rejoin in RSM-1082.
@@ -109,134 +109,132 @@ export default function SortControlEdit( { attributes, setAttributes } ) {
 		setAttributes( update );
 	};
 
-	const inspector = h(
-		InspectorControls,
-		null,
-		h(
-			PanelBody,
-			{ title: __( 'Sort Settings', 'jetpack-search-pkg' ) },
-			h( TextControl, {
-				__next40pxDefaultSize: true,
-				__nextHasNoMarginBottom: true,
-				label: __( 'Label', 'jetpack-search-pkg' ),
-				value: attributes?.label || '',
-				placeholder: __( 'Sort by', 'jetpack-search-pkg' ),
-				onChange: value => setAttributes( { label: value } ),
-				help: __( 'Leave empty to use the default translated label.', 'jetpack-search-pkg' ),
-			} ),
-			h( SelectControl, {
-				__next40pxDefaultSize: true,
-				__nextHasNoMarginBottom: true,
-				label: __( 'Default sort', 'jetpack-search-pkg' ),
-				// Use the `defaultSort` attribute when it's still in `available`
-				// so the <select> stays bound to its persisted value. When the
-				// author has just unchecked the current default from the list,
-				// fall back to the first available option so the control binds
-				// to something visible instead of rendering a blank selection.
-				value: available.includes( defaultSort ) ? defaultSort : available[ 0 ],
-				// Only offer keys the author has actually enabled. Showing the
-				// full list here would let the author pick a default that
-				// `availableSortOptions` excludes — the render callback already
-				// falls back gracefully, but the editor would misleadingly show
-				// a "saved default" the front end never honors.
-				options: available.map( key => ( { value: key, label: labels[ key ] } ) ),
-				onChange: value => setAttributes( { defaultSort: value } ),
-				help: __(
-					'Applied on first load when the URL carries no sort parameter.',
-					'jetpack-search-pkg'
-				),
-			} ),
-			h( SelectControl, {
-				__next40pxDefaultSize: true,
-				__nextHasNoMarginBottom: true,
-				label: __( 'Display as', 'jetpack-search-pkg' ),
-				value: displayAs,
-				options: [
-					{ value: 'select', label: __( 'Dropdown', 'jetpack-search-pkg' ) },
-					{ value: 'radio', label: __( 'Inline links', 'jetpack-search-pkg' ) },
-					{ value: 'popover', label: __( 'Popover', 'jetpack-search-pkg' ) },
-				],
-				onChange: value => setAttributes( { displayAs: value, display: undefined } ),
-			} )
-		),
-		h(
-			PanelBody,
-			{ title: __( 'Available options', 'jetpack-search-pkg' ) },
-			ALL_SORT_KEYS.map( key =>
-				h( CheckboxControl, {
-					key,
-					__nextHasNoMarginBottom: true,
-					label: labels[ key ],
-					checked: storedAvailable.includes( key ),
-					onChange: checked => toggleAvailable( key, checked ),
-				} )
-			)
-		)
+	const inspector = (
+		<InspectorControls>
+			<PanelBody title={ __( 'Sort Settings', 'jetpack-search-pkg' ) }>
+				<TextControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ __( 'Label', 'jetpack-search-pkg' ) }
+					value={ attributes?.label || '' }
+					placeholder={ __( 'Sort by', 'jetpack-search-pkg' ) }
+					onChange={ value => setAttributes( { label: value } ) }
+					help={ __( 'Leave empty to use the default translated label.', 'jetpack-search-pkg' ) }
+				/>
+				<SelectControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ __( 'Default sort', 'jetpack-search-pkg' ) }
+					// Use the `defaultSort` attribute when it's still in `available`
+					// so the <select> stays bound to its persisted value. When the
+					// author has just unchecked the current default from the list,
+					// fall back to the first available option so the control binds
+					// to something visible instead of rendering a blank selection.
+					value={ available.includes( defaultSort ) ? defaultSort : available[ 0 ] }
+					// Only offer keys the author has actually enabled. Showing the
+					// full list here would let the author pick a default that
+					// `availableSortOptions` excludes — the render callback already
+					// falls back gracefully, but the editor would misleadingly show
+					// a "saved default" the front end never honors.
+					options={ available.map( key => ( { value: key, label: labels[ key ] } ) ) }
+					onChange={ value => setAttributes( { defaultSort: value } ) }
+					help={ __(
+						'Applied on first load when the URL carries no sort parameter.',
+						'jetpack-search-pkg'
+					) }
+				/>
+				<SelectControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ __( 'Display as', 'jetpack-search-pkg' ) }
+					value={ displayAs }
+					options={ [
+						{ value: 'select', label: __( 'Dropdown', 'jetpack-search-pkg' ) },
+						{ value: 'radio', label: __( 'Inline links', 'jetpack-search-pkg' ) },
+						{ value: 'popover', label: __( 'Popover', 'jetpack-search-pkg' ) },
+					] }
+					onChange={ value => setAttributes( { displayAs: value, display: undefined } ) }
+				/>
+			</PanelBody>
+			<PanelBody title={ __( 'Available options', 'jetpack-search-pkg' ) }>
+				{ ALL_SORT_KEYS.map( key => (
+					<CheckboxControl
+						key={ key }
+						__nextHasNoMarginBottom
+						label={ labels[ key ] }
+						checked={ storedAvailable.includes( key ) }
+						onChange={ checked => toggleAvailable( key, checked ) }
+					/>
+				) ) }
+			</PanelBody>
+		</InspectorControls>
 	);
 
 	let preview;
 	if ( 'popover' === displayAs ) {
-		preview = h(
-			'button',
-			{
-				type: 'button',
-				className: 'jetpack-search-sort__trigger',
-				'aria-haspopup': 'menu',
-				'aria-expanded': 'false',
-				disabled: true,
-			},
-			h(
-				'svg',
-				{
-					className: 'jetpack-search-sort__icon',
-					width: 18,
-					height: 18,
-					viewBox: '0 0 24 24',
-					'aria-hidden': 'true',
-					focusable: 'false',
-				},
-				h( 'path', {
-					fill: 'currentColor',
-					d: 'M8 4l-4 4h3v12h2V8h3L8 4zm8 16l4-4h-3V4h-2v12h-3l4 4z',
-				} )
-			),
-			h( 'span', { className: 'screen-reader-text' }, __( 'Sort results', 'jetpack-search-pkg' ) )
+		preview = (
+			<button
+				type="button"
+				className="jetpack-search-sort__trigger"
+				aria-haspopup="menu"
+				aria-expanded="false"
+				disabled
+			>
+				<svg
+					className="jetpack-search-sort__icon"
+					width={ 18 }
+					height={ 18 }
+					viewBox="0 0 24 24"
+					aria-hidden="true"
+					focusable="false"
+				>
+					<path fill="currentColor" d="M8 4l-4 4h3v12h2V8h3L8 4zm8 16l4-4h-3V4h-2v12h-3l4 4z" />
+				</svg>
+				<span className="screen-reader-text">{ __( 'Sort results', 'jetpack-search-pkg' ) }</span>
+			</button>
 		);
 	} else if ( 'radio' === displayAs ) {
-		preview = h(
-			'fieldset',
-			{ className: 'jetpack-search-sort-control__radio-group' },
-			h( 'legend', null, labelText ),
-			available.map( key => {
-				const radioId = `${ baseId }-${ key }`;
-				return h(
-					'div',
-					{ key, className: 'jetpack-search-sort-control__radio-item' },
-					h( 'input', {
-						type: 'radio',
-						id: radioId,
-						name: baseId,
-						value: key,
-						checked: previewSelected === key,
-						disabled: true,
-						readOnly: true,
-					} ),
-					h( 'label', { htmlFor: radioId }, labels[ key ] )
-				);
-			} )
+		preview = (
+			<fieldset className="jetpack-search-sort-control__radio-group">
+				<legend>{ labelText }</legend>
+				{ available.map( key => {
+					const radioId = `${ baseId }-${ key }`;
+					return (
+						<div key={ key } className="jetpack-search-sort-control__radio-item">
+							<input
+								type="radio"
+								id={ radioId }
+								name={ baseId }
+								value={ key }
+								checked={ previewSelected === key }
+								disabled
+								readOnly
+							/>
+							<label htmlFor={ radioId }>{ labels[ key ] }</label>
+						</div>
+					);
+				} ) }
+			</fieldset>
 		);
 	} else {
-		preview = h(
-			Fragment,
-			null,
-			h( 'label', { htmlFor: baseId }, labelText ),
-			h(
-				'select',
-				{ id: baseId, disabled: true, value: previewSelected, onChange: () => {} },
-				available.map( key => h( 'option', { key, value: key }, labels[ key ] ) )
-			)
+		preview = (
+			<>
+				<label htmlFor={ baseId }>{ labelText }</label>
+				<select id={ baseId } disabled value={ previewSelected } onChange={ () => {} }>
+					{ available.map( key => (
+						<option key={ key } value={ key }>
+							{ labels[ key ] }
+						</option>
+					) ) }
+				</select>
+			</>
 		);
 	}
 
-	return h( Fragment, null, inspector, h( 'div', blockProps, preview ) );
+	return (
+		<>
+			{ inspector }
+			<div { ...blockProps }>{ preview }</div>
+		</>
+	);
 }


### PR DESCRIPTION
Fixes [RSM-2109](https://linear.app/a8c/issue/RSM-2109/search-blocks-convert-createelementh-calls-to-jsx-for-readability)

## Why

The 12 editor `edit.js` files under `projects/packages/search/src/search-blocks/blocks/` each aliased `createElement as h` and built their preview trees through deeply nested `h(type, props, children)` calls — readable enough for a leaf node, exhausting once you hit an Inspector with five Controls or a list mapped to a label-and-checkbox pattern. JSX renders the same React tree but lets a reader scan the markup top-to-bottom the same way they would the rendered HTML, which is the form maintainers reach for first when debugging an editor preview.

The babel preset already enables the automatic JSX runtime (`@automattic/jetpack-webpack-config/babel/preset` → `@babel/preset-react` with `runtime: 'automatic'`), so the conversion is a pure source-form change: no `import React`, no pragma, no runtime behavior delta.

## Proposed changes

* Convert every `h(...)` call across the 12 search-block `edit.js` files to JSX.
* Drop the `createElement as h` (and `Fragment` where it was only used as a top-level wrapper) imports — keep `useId` / `useMemo` re-imports that are still needed.
* Net diff: **555 insertions, 643 deletions** across 12 files (~92 fewer lines).
* No DOM, attribute, attribute order, or event-binding change.

The conversion surfaces two pre-existing `<label>` patterns (`filter-date`, `filter-checkbox`) where the input is a direct child of the label — implicit HTML5 association that `eslint-plugin-jsx-a11y`'s nesting heuristic doesn't trace through sibling spans. A targeted `eslint-disable-next-line` with rationale preserves the existing markup; an explicit `htmlFor` association can come in a follow-up.

## Editor preview screenshots

Block previews on this branch in the local docker editor — the rendered output matches trunk because the React tree is identical:

| Search Input | Sort Control | Checkbox Filter (Category) |
|---|---|---|
| ![Search Input](https://github.com/user-attachments/assets/6e6b0f14-549d-44a8-b1a0-5a271fcef6f0) | ![Sort Control](https://github.com/user-attachments/assets/19bce096-2a6a-4a8c-810a-140989efcb3f) | ![Checkbox Filter](https://github.com/user-attachments/assets/0ddf4e61-1f29-48e9-892c-792cbb3321dd) |

## Related product discussion/links

* [RSM-2109](https://linear.app/a8c/issue/RSM-2109/search-blocks-convert-createelementh-calls-to-jsx-for-readability)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The change is a pure refactor — same React elements, same props, same children — so verification is "the editor preview renders identically and the bundle still builds."

1. \`pnpm jetpack build packages/search\`
2. Drop into a docker WP env with Jetpack Search blocks enabled and edit any post.
3. Insert each of the 12 search blocks via the inserter (Search Input, Sort Control, Checkbox Filter, Date Filter, Filter Popover, Common Filters, Active Filters, Search Results, Results Count, No Results, Search Error, Load More).
4. Confirm each renders its preview identically to trunk and that all Inspector controls work (toggling settings updates the preview).

I spot-checked **Search Input**, **Sort Control**, and **Checkbox Filter (Category variation)** in a local docker editor — the preview, Inspector layout, and live attribute updates all match trunk. Build (\`pnpm run build-blocks-editor\`) and lint (\`pnpm exec eslint\`) are clean.

## Pre-merge checklist

- [x] Changelog entry added (\`projects/packages/search/changelog/atlas-rsm-2109-search-blocks-jsx\`)
- [x] Build passes (\`pnpm run build-blocks-editor\`)
- [x] Lint passes (\`pnpm exec eslint\`)
- [x] No DOM/runtime behavior change