### PR TITLE
My Jetpack: adopt jetpack-admin-page-layout mixin on the main page

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/help/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/help/styles.module.scss
@@ -32,23 +32,11 @@
 }
 
 .footer {
-	width: 100vw;
-	margin-inline-start: calc(-50vw + 50%);
 	background: var(--studio-white, #fff);
 
 	/* Center the content within the full-width background */
 	display: flex;
 	justify-content: center;
-
-	// 1128 + 3rem (96px) = 1224px + 64px (no idea what that is) = 1288px
-	@media (max-width: 1288px) {
-		// I have to hardcode --max-container-width because
-		// media queries don't work with CSS variables
-		margin-inline-start: -3rem; // Match the parent's padding-inline
-		margin-inline-end: -3rem;
-		width: calc(100% + 6rem); // Compensate for the negative margins
-		padding-inline: 3rem;
-	}
 
 	section {
 		max-width: 35rem;

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/overview/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/overview/styles.module.scss
@@ -10,23 +10,11 @@
 }
 
 .footer {
-	width: 100vw;
-	margin-inline-start: calc(-50vw + 50%);
 	background: var(--studio-white, #fff);
 
 	/* Center the content within the full-width background */
 	display: flex;
 	justify-content: center;
-
-	// 1128 + 3rem (96px) = 1224px + 64px (no idea what that is) = 1288px
-	@media ( max-width: 1288px ) {
-		// I have to hardcode --max-container-width
-		// because media queries don't work with CSS variables
-		margin-inline-start: -3rem; // Match the parent's padding-inline
-		margin-inline-end: -3rem;
-		width: calc(100% + 6rem); // Compensate for the negative margins
-		padding-inline: 3rem;
-	}
 }
 
 .footer-inner {

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/styles.module.scss
@@ -35,10 +35,6 @@
 
 .full-width-separator {
 	border-top: 1px solid var(--jp-gray);
-	width: 100vw;
-	position: relative;
-	inset-inline-start: 50%;
-	margin-inline-start: -50vw;
 }
 
 @mixin full-width-container {

--- a/projects/packages/my-jetpack/_inc/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/style.module.scss
@@ -6,13 +6,14 @@
 	// (sticky header, internally scrollable middle, JetpackFooter pinned at
 	// viewport bottom) matches Boost / Protect / VideoPress / Search /
 	// Newsletter / Publicize / Backup / Jetpack network admin / AI.
-	//
+
 	// Excluded: My Jetpack's `.jetpack-admin-full-screen` interstitial mode,
 	// which hides the admin bar and takes over the whole viewport; its
 	// existing rules (further down in this file) override wp-admin chrome
 	// directly and should keep doing so. The `:has(.jetpack-admin-full-screen)`
 	// selector scopes the mixin to the regular dashboard view only.
 	body.jetpack_page_my-jetpack:not(:has(.jetpack-admin-full-screen)) {
+
 		@include jetpack-admin-page-layout;
 	}
 

--- a/projects/packages/my-jetpack/_inc/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/style.module.scss
@@ -1,14 +1,19 @@
+@use "@automattic/jetpack-base-styles/admin-page-layout" as *;
+
 :global {
 
-	// Hello Dolly compatibility fix
-	body.jetpack_page_my-jetpack p#dolly {
-		position: absolute;
-		inset-inline-end: 0;
-		z-index: 2;
-
-		@media (max-width: 782px) {
-			padding-inline-end: 10px;
-		}
+	// Apply the shared admin-page-layout mixin so the main My Jetpack page
+	// (sticky header, internally scrollable middle, JetpackFooter pinned at
+	// viewport bottom) matches Boost / Protect / VideoPress / Search /
+	// Newsletter / Publicize / Backup / Jetpack network admin / AI.
+	//
+	// Excluded: My Jetpack's `.jetpack-admin-full-screen` interstitial mode,
+	// which hides the admin bar and takes over the whole viewport; its
+	// existing rules (further down in this file) override wp-admin chrome
+	// directly and should keep doing so. The `:has(.jetpack-admin-full-screen)`
+	// selector scopes the mixin to the regular dashboard view only.
+	body.jetpack_page_my-jetpack:not(:has(.jetpack-admin-full-screen)) {
+		@include jetpack-admin-page-layout;
 	}
 
 	#my-jetpack-container {

--- a/projects/packages/my-jetpack/changelog/my-jetpack-page-layout-mixin
+++ b/projects/packages/my-jetpack/changelog/my-jetpack-page-layout-mixin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: adopt the shared `jetpack-admin-page-layout` mixin on the main dashboard page so its layout (sticky header, internally scrollable middle, JetpackFooter pinned at viewport bottom) matches the rest of the Jetpack admin pages. Drop the bespoke Hello Dolly position-absolute override — Dolly now uses the same centralized normalize as every other Jetpack admin page. The full-width tab separator no longer uses `width: 100vw` (which overflowed the new viewport-fitted column by the wp-admin sidebar width); it now spans the page column instead. Interstitial / full-screen mode (`.jetpack-admin-full-screen`) is intentionally excluded from the mixin so it keeps its current take-over-the-viewport behavior.


### PR DESCRIPTION
Brings the My Jetpack dashboard in line with the rest of the layout-mixin'd consumer pages (Boost, Protect, VideoPress, Search, Newsletter, Publicize, Backup, Jetpack network admin, AI). The shared mixin gives every page the same viewport-fitted flex chain — sticky page header, internally scrollable middle, JetpackFooter pinned at the viewport bottom — so My Jetpack now reads as a peer with the rest of the Jetpack admin surface.

Companion to #48472 (Hello Dolly normalize) — that PR's central rule replaces the bespoke `position: absolute` Dolly override this PR drops. Either order works; merging both gets the most consistent visual.

## Proposed changes

* `_inc/style.module.scss`: add `@include jetpack-admin-page-layout` scoped via `body.jetpack_page_my-jetpack:not(:has(.jetpack-admin-full-screen))`. The `:not(:has(...))` guard keeps the interstitial / `.jetpack-admin-full-screen` mode unaffected (signup, Add-X interstitials keep their take-over-the-viewport behavior).
* Drop the bespoke `body.jetpack_page_my-jetpack p#dolly` `position: absolute` override. Dolly now uses the centralized `.jetpack-admin-page #dolly` rule, like every other Jetpack admin page.
* Drop three viewport-breakout patterns (`width: 100vw + margin-inline-start: calc(-50vw + 50%)` and the `<= 1288px` `width: calc(100% + 6rem)` variant) that produced horizontal scroll inside the mixin's viewport-fitted column:
  * `my-jetpack-tab-panel/styles.module.scss`: `.full-width-separator` now renders as a plain block-level `border-top` instead of a viewport-spanning element.
  * `my-jetpack-tab-panel/overview/styles.module.scss`: `.footer` (Plans + Connections band) drops the breakout. Its background now spans the page column.
  * `my-jetpack-tab-panel/help/styles.module.scss`: same change on the Help tab's `.footer`.

Net effect: page renders with the same flex chain as the other layout-mixin'd pages, and `document.documentElement.scrollWidth === document.documentElement.clientWidth` at every viewport (verified at 1440 and 390).


| Before | After |
|--------|--------|
| <img width="1440" height="2142" alt="desktop" src="https://github.com/user-attachments/assets/e0266ed9-1fc0-4a13-b1c8-2bdb98ae6339" /> | <img width="1440" height="2142" alt="desktop" src="https://github.com/user-attachments/assets/1da8c75d-0c10-4639-a4c0-4f45bd87b143" /> |
| <img width="390" height="4201" alt="mobile" src="https://github.com/user-attachments/assets/28eb358f-510a-457a-ac77-7f83e183fb69" /> | <img width="390" height="4201" alt="mobile" src="https://github.com/user-attachments/assets/1de2cdfc-f3b1-4933-a713-78c687c9b898" /> | 

## Related product discussion/links

* Companion: #48472 (Hello Dolly normalize). Either order works; merging both produces the cleanest visual.
* Followed-on from #48471 (AI page mixin), already merged to trunk.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

Hard-refresh wp-admin (CSS cache) and verify:

1. **`?page=my-jetpack` (Overview tab)** — header pinned, content scrolls in the middle if it overflows, JetpackFooter pinned to viewport bottom. Same shape as Boost / Protect / VideoPress.
2. **No horizontal scrollbar** at any viewport. Test 1440 (desktop) and 390 (mobile) at minimum.
3. **Help tab** — same — no horizontal scroll, footer band background spans the page column.
4. **Interstitials** (`#/add-protect`, `#/add-jetpack-ai`, `#/connection`, etc.) — should look exactly the same as before. The mixin is gated behind `:not(:has(.jetpack-admin-full-screen))`; full-screen mode keeps its own chrome.
5. **Hello Dolly** — appears as the centralized normalize style (italic gray strip at top). Once #48472 lands, the strip becomes white-bg with text-align right; without #48472 it's the default Hello Dolly float-right look.







🤖 Generated with [Claude Code](https://claude.com/claude-code)
