### PR TITLE
Search blocks: add jetpack/results-panel container block

### DIFF
--- a/projects/packages/search/changelog/atlas-rsm-2277-results-panel-block
+++ b/projects/packages/search/changelog/atlas-rsm-2277-results-panel-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Search blocks: add jetpack/results-panel container block bundling the result-display stack (count, sort, results, error, empty state, load-more).

--- a/projects/packages/search/src/search-blocks/blocks/results-panel/block.json
+++ b/projects/packages/search/src/search-blocks/blocks/results-panel/block.json
@@ -1,0 +1,39 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "jetpack/results-panel",
+	"version": "0.1.0",
+	"title": "Results Panel",
+	"category": "jetpack-search",
+	"icon": "list-view",
+	"description": "Container for a stack of Jetpack Search result blocks (count, sort, results, error, empty state, load-more). Pre-populated with a sensible default; rearrange, remove, or add more from the inserter.",
+	"keywords": [ "search", "results", "panel" ],
+	"supports": {
+		"html": false,
+		"color": {
+			"background": true,
+			"text": true,
+			"link": true
+		},
+		"spacing": {
+			"padding": true,
+			"margin": true,
+			"blockGap": true
+		},
+		"border": {
+			"color": true,
+			"radius": true,
+			"style": true,
+			"width": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"fontFamily": true
+		}
+	},
+	"textdomain": "jetpack-search-pkg",
+	"render": "file:./render.php",
+	"viewScriptModule": "file:../../../../build/search-blocks/results-panel.js",
+	"style": "file:../../../../build/search-blocks/results-panel.css"
+}

--- a/projects/packages/search/src/search-blocks/blocks/results-panel/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/results-panel/edit.js
@@ -1,0 +1,53 @@
+/**
+ * Editor preview for jetpack/results-panel.
+ *
+ * Renders an InnerBlocks region pre-populated with the result-display stack
+ * (count + sort row, results list, error, empty state, load-more). Container
+ * owns no behavior — render.php is a Group-like wrapper that emits `$content`
+ * and lets each inner block contribute its own markup and Interactivity API
+ * directives.
+ */
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+
+const TEMPLATE = [
+	[
+		'core/group',
+		{ layout: { type: 'flex', flexWrap: 'nowrap', justifyContent: 'space-between' } },
+		[ [ 'jetpack/results-count' ], [ 'jetpack/sort-control' ] ],
+	],
+	[ 'jetpack/search-results' ],
+	[ 'jetpack/search-error' ],
+	[ 'jetpack/no-results' ],
+	[ 'jetpack/load-more' ],
+];
+
+const ALLOWED = [
+	'core/group',
+	'jetpack/results-count',
+	'jetpack/sort-control',
+	'jetpack/search-results',
+	'jetpack/search-error',
+	'jetpack/no-results',
+	'jetpack/load-more',
+];
+
+/**
+ * Edit component for the results-panel block.
+ *
+ * @return {object} Rendered element.
+ */
+export default function ResultsPanelEdit() {
+	const blockProps = useBlockProps( { className: 'jetpack-search-results-panel' } );
+	return (
+		<div { ...blockProps }>
+			<InnerBlocks template={ TEMPLATE } allowedBlocks={ ALLOWED } />
+		</div>
+	);
+}
+
+/**
+ * Save component — only renders InnerBlocks.Content.
+ *
+ * @return {object} Rendered element.
+ */
+export const save = () => <InnerBlocks.Content />;

--- a/projects/packages/search/src/search-blocks/blocks/results-panel/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/results-panel/render.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Results Panel block render.
+ *
+ * Group-like wrapper that emits `$content` (the serialized inner block
+ * markup). Each inner result block handles its own state via the
+ * Interactivity API store; this block contributes only the surrounding
+ * chrome (block-wrapper attrs derived from color/spacing/border/typography
+ * supports).
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+?>
+<div <?php echo wp_kses_data( get_block_wrapper_attributes( array( 'class' => 'jetpack-search-results-panel' ) ) ); ?>>
+	<?php
+	// @phan-suppress-next-line PhanUndeclaredGlobalVariable -- $content is provided by WP at block render.
+	echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Inner block HTML is already escaped by each child block's renderer.
+	?>
+</div>

--- a/projects/packages/search/src/search-blocks/blocks/results-panel/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/results-panel/style.scss
@@ -1,0 +1,8 @@
+.jetpack-search-results-panel {
+	display: flex;
+	flex-direction: column;
+	// Default inter-block spacing. Themes / block supports override this via
+	// the `--wp--style--block-gap` custom property emitted by the
+	// spacing.blockGap support.
+	gap: var(--wp--style--block-gap, 1.5rem);
+}

--- a/projects/packages/search/src/search-blocks/blocks/results-panel/view.js
+++ b/projects/packages/search/src/search-blocks/blocks/results-panel/view.js
@@ -1,0 +1,1 @@
+import './style.scss';

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -26,6 +26,7 @@ import FilterPopoverEdit, { save as filterPopoverSave } from '../blocks/filter-p
 import LoadMoreEdit from '../blocks/load-more/edit';
 import NoResultsEdit from '../blocks/no-results/edit';
 import ResultsCountEdit from '../blocks/results-count/edit';
+import ResultsPanelEdit, { save as resultsPanelSave } from '../blocks/results-panel/edit';
 import SearchErrorEdit from '../blocks/search-error/edit';
 import SearchInputEdit from '../blocks/search-input/edit';
 import SearchResultsEdit from '../blocks/search-results/edit';
@@ -47,6 +48,7 @@ const BLOCKS = [
 	[ 'jetpack/no-results', NoResultsEdit ],
 	[ 'jetpack/search-error', SearchErrorEdit ],
 	[ 'jetpack/load-more', LoadMoreEdit ],
+	[ 'jetpack/results-panel', ResultsPanelEdit, resultsPanelSave ],
 ];
 
 // Shape the "Jetpack Search" block category to match the Forms / Monetize /

--- a/projects/packages/search/src/search-blocks/patterns/blog-search.php
+++ b/projects/packages/search/src/search-blocks/patterns/blog-search.php
@@ -28,6 +28,8 @@ register_block_pattern(
 
 <!-- wp:column -->
 <div class="wp-block-column">
+<!-- wp:jetpack/results-panel -->
+<div class="wp-block-jetpack-results-panel jetpack-search-results-panel">
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
 <div class="wp-block-group">
 <!-- wp:jetpack/results-count /-->
@@ -39,6 +41,8 @@ register_block_pattern(
 <!-- wp:jetpack/search-error /-->
 <!-- wp:jetpack/no-results /-->
 <!-- wp:jetpack/load-more /-->
+</div>
+<!-- /wp:jetpack/results-panel -->
 </div>
 <!-- /wp:column -->
 

--- a/projects/packages/search/src/search-blocks/patterns/compact-search.php
+++ b/projects/packages/search/src/search-blocks/patterns/compact-search.php
@@ -38,11 +38,15 @@ register_block_pattern(
 </div>
 <!-- /wp:group -->
 
+<!-- wp:jetpack/results-panel -->
+<div class="wp-block-jetpack-results-panel jetpack-search-results-panel">
 <!-- wp:jetpack/results-count /-->
 <!-- wp:jetpack/search-results {"layout":"compact"} /-->
 <!-- wp:jetpack/search-error /-->
 <!-- wp:jetpack/no-results /-->
 <!-- wp:jetpack/load-more /-->
+</div>
+<!-- /wp:jetpack/results-panel -->
 
 </div>
 <!-- /wp:group -->',

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search.html
@@ -12,6 +12,8 @@
 
 <!-- wp:column -->
 <div class="wp-block-column">
+<!-- wp:jetpack/results-panel -->
+<div class="wp-block-jetpack-results-panel jetpack-search-results-panel">
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
 <div class="wp-block-group">
 <!-- wp:jetpack/results-count /-->
@@ -23,6 +25,8 @@
 <!-- wp:jetpack/search-error /-->
 <!-- wp:jetpack/no-results /-->
 <!-- wp:jetpack/load-more /-->
+</div>
+<!-- /wp:jetpack/results-panel -->
 </div>
 <!-- /wp:column -->
 

--- a/projects/packages/search/tests/js/search-blocks/results-panel-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/results-panel-edit.test.jsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import { InnerBlocks } from '@wordpress/block-editor';
+import ResultsPanelEdit from '../../../src/search-blocks/blocks/results-panel/edit';
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	useBlockProps: props => ( { ...props, className: props?.className } ),
+	InnerBlocks: jest.fn( () => <div data-testid="results-panel-inner-blocks" /> ),
+} ) );
+
+describe( 'ResultsPanelEdit', () => {
+	beforeEach( () => {
+		InnerBlocks.mockClear();
+	} );
+
+	it( 'renders InnerBlocks with the default result-stack template + allowedBlocks contract', () => {
+		render( <ResultsPanelEdit /> );
+
+		expect( screen.getByTestId( 'results-panel-inner-blocks' ) ).toBeInTheDocument();
+		const props = InnerBlocks.mock.calls[ 0 ][ 0 ];
+		expect( props.template ).toEqual( [
+			[
+				'core/group',
+				{ layout: { type: 'flex', flexWrap: 'nowrap', justifyContent: 'space-between' } },
+				[ [ 'jetpack/results-count' ], [ 'jetpack/sort-control' ] ],
+			],
+			[ 'jetpack/search-results' ],
+			[ 'jetpack/search-error' ],
+			[ 'jetpack/no-results' ],
+			[ 'jetpack/load-more' ],
+		] );
+		expect( props.allowedBlocks ).toEqual( [
+			'core/group',
+			'jetpack/results-count',
+			'jetpack/sort-control',
+			'jetpack/search-results',
+			'jetpack/search-error',
+			'jetpack/no-results',
+			'jetpack/load-more',
+		] );
+	} );
+} );


### PR DESCRIPTION
Fixes [RSM-2277](https://linear.app/a8c/issue/RSM-2277/search-blocks-add-jetpackresults-panel-container-block-sibling-to)

## Why

Authors building a Jetpack Search page used to assemble the entire result-display side by hand — drop in `results-count`, `sort-control`, `search-results`, `search-error`, `no-results`, and `load-more` separately, and wrap the count + sort row in a flex group themselves. That's the same tedium we already removed from the filter side with `jetpack/common-filters`.

This PR adds a sibling container — `jetpack/results-panel` — that ships the working composition out of the box. One block in the inserter populates the full result stack and is ready to customize.

## Proposed changes

* New block `jetpack/results-panel` under `projects/packages/search/src/search-blocks/blocks/results-panel/`. Group-like wrapper with color / spacing / border / typography supports; container itself owns no behavior.
* `InnerBlocks` default template mirrors the blog-search pattern's right column: a flex group with `results-count` + `sort-control`, then `search-results`, `search-error`, `no-results`, `load-more`.
* `allowedBlocks` lets authors rearrange / remove children but constrains the block to the result-display family (plus `core/group` for the count + sort row).
* Patterns updated to use the new block: `patterns/blog-search.php`, `patterns/compact-search.php`, and `templates/jetpack-search.html`. Markup adds one wrapper div per pattern; visual output is unchanged (verified via screenshots below).
* Editor registration wired in `editor/register-blocks.js`. Server-side registration is automatic via the `blocks/*` glob.
* Jest test mirroring `common-filters-edit.test.jsx` to lock the default template + `allowedBlocks` contract.

## Related product discussion/links

* Linear: [RSM-2277](https://linear.app/a8c/issue/RSM-2277/search-blocks-add-jetpackresults-panel-container-block-sibling-to)

## Does this pull request change what data or activity we track or use?

No. The block is a layout container; all data flow continues to come from the existing inner blocks via the Interactivity API store.

## Screenshots

### Editor — Results Panel block dropped on canvas (default template populated)

The author drops a single `Results Panel` block; the InnerBlocks template fills in the full result stack with the count + sort row, results list, error, empty state, and load-more.

![editor preview after](https://github.com/user-attachments/assets/bc02b23f-e8e5-4906-b08d-2352d15ecd98)

### Front-end — `/?s=hello`, before vs. after

Visual output is unchanged. The DOM gains one `<div class="wp-block-jetpack-results-panel">` wrapper around the result column; the panel's default styling (`display: flex; flex-direction: column; gap: var(--wp--style--block-gap, 1.5rem)`) matches the column's existing block-gap so the rendered page is effectively identical.

| Before (trunk) | After (this PR) |
|---|---|
| ![before](https://github.com/user-attachments/assets/c69a78a8-3035-4f38-8323-d9227fbb3f1c) | ![after](https://github.com/user-attachments/assets/be90ac35-e588-4630-8190-7de584880d3c) |

## Testing instructions

1. Install + activate the Jetpack plugin on this branch in a site that has the search-blocks feature flag enabled (`add_filter( 'jetpack_search_blocks_enabled', '__return_true' )` in a mu-plugin).
2. In the block editor for any post or page, open the inserter and search for "Results Panel" — the new block should appear under the **Jetpack Search** category.
3. Drop the block on the canvas. The default template should populate immediately: a flex row with `Results Count` on the left and `Sort Control` on the right, followed by `Search Results`, `Search Error`, `No Results`, and `Load More`.
4. Confirm rearranging / removing inner blocks works, and that only result-display blocks (plus `core/group`) can be inserted inside.
5. Visit any front-end search URL (e.g. `/?s=hello`) — the registered Jetpack search template now wraps the result stack in a `wp-block-jetpack-results-panel` div. Visual output should be unchanged from trunk.
6. (Pattern check) Insert the **Blog Search Page** or **Compact Search** pattern from the inserter — both now use the new container; the rendered page should be visually identical to the prior version.

