### PR TITLE
Search blocks: render skeleton placeholders pre-hydration

### DIFF
--- a/projects/packages/search/changelog/change-search-blocks-pre-hydration-loading-states
+++ b/projects/packages/search/changelog/change-search-blocks-pre-hydration-loading-states
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search blocks: render skeleton placeholders pre-hydration so deep-linked search pages don't flash blank columns before the JS view bundle loads.

--- a/projects/packages/search/src/search-blocks/blocks/_skeleton.scss
+++ b/projects/packages/search/src/search-blocks/blocks/_skeleton.scss
@@ -1,0 +1,58 @@
+// Pre-hydration skeleton placeholder primitives. Each block scopes the
+// mixins under its own wrapper so the unscoped class name
+// `.jetpack-search-skeleton` can't leak to non-search content. See
+// `Search_Blocks::is_initial_loading()` for the PHP-side gate that
+// decides whether to emit skeleton DOM at all.
+
+@mixin shimmer {
+
+	@keyframes jetpack-search-skeleton-shimmer {
+
+		from {
+			background-position: -200% 0;
+		}
+
+		to {
+			background-position: 200% 0;
+		}
+	}
+
+	.jetpack-search-skeleton {
+		display: block;
+		border-radius: 4px;
+		background: color-mix(in sRGB, currentColor 8%, transparent) linear-gradient(90deg, transparent 0%, color-mix(in sRGB, currentColor 6%, transparent) 50%, transparent 100%) repeat;
+		background-size: 200% 100%;
+		animation: jetpack-search-skeleton-shimmer 1.5s linear infinite;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+
+		.jetpack-search-skeleton {
+			animation: none;
+		}
+	}
+}
+
+// Filter-specific skeleton shapes. Pulled in by both filter-checkbox and
+// filter-date so the placeholder rows render at the same dimensions.
+@mixin filter-rows {
+
+	.jetpack-search-skeleton--filter-row {
+		height: 1rem;
+		width: 80%;
+	}
+
+	.jetpack-search-filter__list--skeleton {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+
+		&[hidden] {
+			display: none;
+		}
+	}
+
+	.jetpack-search-filter__item--skeleton {
+		padding: 0.25rem 0;
+	}
+}

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/render.php
@@ -42,31 +42,19 @@ wp_interactivity_state(
 	)
 );
 
-// Render `hidden` on first paint when no aggregation buckets are available
-// for this filter and no fetch is in flight. Seeded `state.aggregations` is
-// empty before the first JS fetch — but on a deep-link load where a fetch
-// IS coming, we keep the wrapper visible so it can host a skeleton list
-// (otherwise the entire sidebar collapses to just the heading and pops in
-// when results arrive). The `callbacks.syncFilterWrapperVisibility` watcher
-// (see `store/index.js`) keeps `context.wrapperHidden` in sync after JS
-// hydrates, so empty filter sections still hide once the first fetch
-// resolves with no buckets.
-$seeded_state = wp_interactivity_state( 'jetpack-search' );
-// aggregations is seeded as stdClass when empty (so JS sees `{}` not `[]`);
-// cast here so the nested subscript works in either shape.
-$seeded_aggs        = (array) ( $seeded_state['aggregations'] ?? array() );
-$seeded_filter_agg  = (array) ( $seeded_aggs[ $filter_key ] ?? array() );
-$seeded_buckets     = $seeded_filter_agg['buckets'] ?? null;
-$has_buckets        = is_array( $seeded_buckets ) && ! empty( $seeded_buckets );
-$is_initial_loading = Search_Blocks::is_initial_loading();
-$show_wrapper       = $has_buckets || $is_initial_loading;
+$view = Search_Blocks::pre_hydration_filter_view( $filter_key );
 
-// First-paint "all selected" flag: mirrors the `allBucketsSelected` state
-// getter so the list and the fallback message come out pre-hidden correctly
-// and there's no flicker during hydration.
-$seeded_selected       = (array) ( ( (array) ( $seeded_state['activeFilters'] ?? array() ) )[ $filter_key ] ?? array() );
+// `allBucketsSelected` first-paint mirror: read the same seeded buckets +
+// activeFilters the JS getter consults so the list and the fallback message
+// come out pre-hidden in the right state and don't flicker on hydration.
+// `aggregations` is seeded as `stdClass` when empty — cast before subscripting.
+$seeded_state          = wp_interactivity_state( 'jetpack-search' );
+$seeded_aggs           = (array) ( $seeded_state['aggregations'] ?? array() );
+$seeded_buckets        = (array) ( $seeded_aggs[ $filter_key ]['buckets'] ?? array() );
+$seeded_active_filters = (array) ( $seeded_state['activeFilters'] ?? array() );
+$seeded_selected       = (array) ( $seeded_active_filters[ $filter_key ] ?? array() );
 $all_selected_on_paint = false;
-if ( $has_buckets && ! empty( $seeded_selected ) ) {
+if ( $view['has_buckets'] && ! empty( $seeded_selected ) ) {
 	$all_selected_on_paint = true;
 	foreach ( $seeded_buckets as $bucket ) {
 		$raw_key   = (string) ( $bucket['key'] ?? '' );
@@ -84,43 +72,19 @@ $label = $config['label'];
 <div
 	<?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>
 	data-wp-interactive="jetpack-search"
-	<?php
-	// Per-block visibility flag carried in the local context so the wrapper's
-	// `data-wp-bind--hidden` resolves against a single seeded value (data-wp-bind
-	// only evaluates direct property paths). `wrapperHidden` is seeded to
-	// `! $show_wrapper` so the SSR pass and PHP-time `hidden` agree, and the
-	// `syncFilterWrapperVisibility` callback keeps it in sync once buckets
-	// arrive — preserving the legacy "hide empty filter sections" UX without
-	// fighting the IA SSR evaluator.
-	echo wp_kses_data(
-		wp_interactivity_data_wp_context(
-			array(
-				'filterKey'     => $filter_key,
-				'wrapperHidden' => ! $show_wrapper,
-			)
-		)
-	);
-	?>
+	<?php Search_Blocks::emit_filter_wrapper_context( $filter_key, $view['show_wrapper'] ); ?>
 	data-wp-bind--hidden="context.wrapperHidden"
 	data-wp-watch="callbacks.syncFilterWrapperVisibility"
-	<?php echo $show_wrapper ? '' : 'hidden'; ?>
+	<?php echo $view['show_wrapper'] ? '' : 'hidden'; ?>
 >
 	<?php if ( '' !== $label ) : ?>
 		<h3 class="jetpack-search-filter__title"><?php echo esc_html( $label ); ?></h3>
 	<?php endif; ?>
-	<?php if ( $is_initial_loading ) : ?>
-		<ul
-			class="jetpack-search-filter__list jetpack-search-filter__list--skeleton"
-			data-wp-bind--hidden="state.skeletonHidden"
-			aria-hidden="true"
-		>
-			<?php for ( $i = 0; $i < 4; $i++ ) : ?>
-				<li class="jetpack-search-filter__item jetpack-search-filter__item--skeleton">
-					<span class="jetpack-search-skeleton jetpack-search-skeleton--filter-row"></span>
-				</li>
-			<?php endfor; ?>
-		</ul>
-	<?php endif; ?>
+	<?php
+	if ( $view['is_initial_loading'] ) {
+		require __DIR__ . '/../filter-skeleton-partial.php';
+	}
+	?>
 	<ul
 		class="jetpack-search-filter__list"
 		data-wp-bind--hidden="state.allBucketsSelected"

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/render.php
@@ -47,8 +47,10 @@ wp_interactivity_state(
 // empty before the first JS fetch — but on a deep-link load where a fetch
 // IS coming, we keep the wrapper visible so it can host a skeleton list
 // (otherwise the entire sidebar collapses to just the heading and pops in
-// when results arrive). JS-side `state.showFilterWrapper` mirrors the same
-// rule and takes over after hydration.
+// when results arrive). The `callbacks.syncFilterWrapperVisibility` watcher
+// (see `store/index.js`) keeps `context.wrapperHidden` in sync after JS
+// hydrates, so empty filter sections still hide once the first fetch
+// resolves with no buckets.
 $seeded_state = wp_interactivity_state( 'jetpack-search' );
 // aggregations is seeded as stdClass when empty (so JS sees `{}` not `[]`);
 // cast here so the nested subscript works in either shape.

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/render.php
@@ -43,17 +43,21 @@ wp_interactivity_state(
 );
 
 // Render `hidden` on first paint when no aggregation buckets are available
-// for this filter. Seeded `state.aggregations` is empty before the first JS
-// fetch, so on the server we default to hidden — otherwise an empty filter
-// title would occupy the top of the sidebar during the load and misalign
-// with the adjacent results column. JS unhides once buckets arrive.
+// for this filter and no fetch is in flight. Seeded `state.aggregations` is
+// empty before the first JS fetch — but on a deep-link load where a fetch
+// IS coming, we keep the wrapper visible so it can host a skeleton list
+// (otherwise the entire sidebar collapses to just the heading and pops in
+// when results arrive). JS-side `state.showFilterWrapper` mirrors the same
+// rule and takes over after hydration.
 $seeded_state = wp_interactivity_state( 'jetpack-search' );
 // aggregations is seeded as stdClass when empty (so JS sees `{}` not `[]`);
 // cast here so the nested subscript works in either shape.
-$seeded_aggs       = (array) ( $seeded_state['aggregations'] ?? array() );
-$seeded_filter_agg = (array) ( $seeded_aggs[ $filter_key ] ?? array() );
-$seeded_buckets    = $seeded_filter_agg['buckets'] ?? null;
-$has_buckets       = is_array( $seeded_buckets ) && ! empty( $seeded_buckets );
+$seeded_aggs        = (array) ( $seeded_state['aggregations'] ?? array() );
+$seeded_filter_agg  = (array) ( $seeded_aggs[ $filter_key ] ?? array() );
+$seeded_buckets     = $seeded_filter_agg['buckets'] ?? null;
+$has_buckets        = is_array( $seeded_buckets ) && ! empty( $seeded_buckets );
+$is_initial_loading = Search_Blocks::is_initial_loading();
+$show_wrapper       = $has_buckets || $is_initial_loading;
 
 // First-paint "all selected" flag: mirrors the `allBucketsSelected` state
 // getter so the list and the fallback message come out pre-hidden correctly
@@ -78,12 +82,42 @@ $label = $config['label'];
 <div
 	<?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>
 	data-wp-interactive="jetpack-search"
-	<?php echo wp_kses_data( wp_interactivity_data_wp_context( array( 'filterKey' => $filter_key ) ) ); ?>
-	data-wp-bind--hidden="!state.hasFilterBuckets"
-	<?php echo $has_buckets ? '' : 'hidden'; ?>
+	<?php
+	// Per-block visibility flag carried in the local context so the wrapper's
+	// `data-wp-bind--hidden` resolves against a single seeded value (data-wp-bind
+	// only evaluates direct property paths). `wrapperHidden` is seeded to
+	// `! $show_wrapper` so the SSR pass and PHP-time `hidden` agree, and the
+	// `syncFilterWrapperVisibility` callback keeps it in sync once buckets
+	// arrive — preserving the legacy "hide empty filter sections" UX without
+	// fighting the IA SSR evaluator.
+	echo wp_kses_data(
+		wp_interactivity_data_wp_context(
+			array(
+				'filterKey'     => $filter_key,
+				'wrapperHidden' => ! $show_wrapper,
+			)
+		)
+	);
+	?>
+	data-wp-bind--hidden="context.wrapperHidden"
+	data-wp-watch="callbacks.syncFilterWrapperVisibility"
+	<?php echo $show_wrapper ? '' : 'hidden'; ?>
 >
 	<?php if ( '' !== $label ) : ?>
 		<h3 class="jetpack-search-filter__title"><?php echo esc_html( $label ); ?></h3>
+	<?php endif; ?>
+	<?php if ( $is_initial_loading ) : ?>
+		<ul
+			class="jetpack-search-filter__list jetpack-search-filter__list--skeleton"
+			data-wp-bind--hidden="state.skeletonHidden"
+			aria-hidden="true"
+		>
+			<?php for ( $i = 0; $i < 4; $i++ ) : ?>
+				<li class="jetpack-search-filter__item jetpack-search-filter__item--skeleton">
+					<span class="jetpack-search-skeleton jetpack-search-skeleton--filter-row"></span>
+				</li>
+			<?php endfor; ?>
+		</ul>
 	<?php endif; ?>
 	<ul
 		class="jetpack-search-filter__list"

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/style.scss
@@ -4,6 +4,53 @@
 		display: none;
 	}
 
+	@keyframes jetpack-search-skeleton-shimmer {
+
+		from {
+			background-position: -200% 0;
+		}
+
+		to {
+			background-position: 200% 0;
+		}
+	}
+
+	.jetpack-search-skeleton {
+		display: block;
+		border-radius: 4px;
+		background: color-mix(in sRGB, currentColor 8%, transparent) linear-gradient(90deg, transparent 0%, color-mix(in sRGB, currentColor 6%, transparent) 50%, transparent 100%) repeat;
+		background-size: 200% 100%;
+		animation: jetpack-search-skeleton-shimmer 1.5s linear infinite;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+
+		.jetpack-search-skeleton {
+			animation: none;
+		}
+	}
+
+	.jetpack-search-skeleton--filter-row {
+		height: 1rem;
+		width: 80%;
+	}
+
+	.jetpack-search-filter__list--skeleton {
+		// Match the real list spacing exactly so skeleton-to-real swap
+		// doesn't shift the items vertically.
+		list-style: none;
+		margin: 0;
+		padding: 0;
+
+		&[hidden] {
+			display: none;
+		}
+	}
+
+	.jetpack-search-filter__item--skeleton {
+		padding: 0.25rem 0;
+	}
+
 	.jetpack-search-filter__title {
 		font-size: 0.85rem;
 		font-weight: 700;

--- a/projects/packages/search/src/search-blocks/blocks/filter-checkbox/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filter-checkbox/style.scss
@@ -1,55 +1,13 @@
+@use "../skeleton" as skeleton;
+
 .wp-block-jetpack-filter-checkbox {
 
 	&[hidden] {
 		display: none;
 	}
 
-	@keyframes jetpack-search-skeleton-shimmer {
-
-		from {
-			background-position: -200% 0;
-		}
-
-		to {
-			background-position: 200% 0;
-		}
-	}
-
-	.jetpack-search-skeleton {
-		display: block;
-		border-radius: 4px;
-		background: color-mix(in sRGB, currentColor 8%, transparent) linear-gradient(90deg, transparent 0%, color-mix(in sRGB, currentColor 6%, transparent) 50%, transparent 100%) repeat;
-		background-size: 200% 100%;
-		animation: jetpack-search-skeleton-shimmer 1.5s linear infinite;
-	}
-
-	@media (prefers-reduced-motion: reduce) {
-
-		.jetpack-search-skeleton {
-			animation: none;
-		}
-	}
-
-	.jetpack-search-skeleton--filter-row {
-		height: 1rem;
-		width: 80%;
-	}
-
-	.jetpack-search-filter__list--skeleton {
-		// Match the real list spacing exactly so skeleton-to-real swap
-		// doesn't shift the items vertically.
-		list-style: none;
-		margin: 0;
-		padding: 0;
-
-		&[hidden] {
-			display: none;
-		}
-	}
-
-	.jetpack-search-filter__item--skeleton {
-		padding: 0.25rem 0;
-	}
+	@include skeleton.shimmer;
+	@include skeleton.filter-rows;
 
 	.jetpack-search-filter__title {
 		font-size: 0.85rem;

--- a/projects/packages/search/src/search-blocks/blocks/filter-date/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-date/render.php
@@ -30,17 +30,55 @@ wp_interactivity_state(
 	)
 );
 
+// Pre-hydration loading state — mirrors filter-checkbox/render.php. On a
+// deep-link load `state.aggregations` is empty until the JS fetch resolves,
+// so without this the date-filter wrapper would collapse to nothing and
+// pop in once buckets arrive. `$show_wrapper` keeps it visible during the
+// initial-loading window so the skeleton list inside has somewhere to
+// render; `callbacks.syncFilterWrapperVisibility` (in the shared store)
+// keeps `context.wrapperHidden` in sync after JS hydrates.
+$seeded_state       = wp_interactivity_state( 'jetpack-search' );
+$seeded_aggs        = (array) ( $seeded_state['aggregations'] ?? array() );
+$seeded_filter_agg  = (array) ( $seeded_aggs[ $filter_key ] ?? array() );
+$seeded_buckets     = $seeded_filter_agg['buckets'] ?? null;
+$has_buckets        = is_array( $seeded_buckets ) && ! empty( $seeded_buckets );
+$is_initial_loading = Search_Blocks::is_initial_loading();
+$show_wrapper       = $has_buckets || $is_initial_loading;
+
 $label = $config['label'];
 ?>
 <div
 	<?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>
 	data-wp-interactive="jetpack-search"
-	<?php echo wp_kses_data( wp_interactivity_data_wp_context( array( 'filterKey' => $filter_key ) ) ); ?>
-	data-wp-bind--hidden="!state.hasFilterBuckets"
-	hidden
+	<?php
+	echo wp_kses_data(
+		wp_interactivity_data_wp_context(
+			array(
+				'filterKey'     => $filter_key,
+				'wrapperHidden' => ! $show_wrapper,
+			)
+		)
+	);
+	?>
+	data-wp-bind--hidden="context.wrapperHidden"
+	data-wp-watch="callbacks.syncFilterWrapperVisibility"
+	<?php echo $show_wrapper ? '' : 'hidden'; ?>
 >
 	<?php if ( '' !== $label ) : ?>
 		<h3 class="jetpack-search-filter__title"><?php echo esc_html( $label ); ?></h3>
+	<?php endif; ?>
+	<?php if ( $is_initial_loading ) : ?>
+		<ul
+			class="jetpack-search-filter__list jetpack-search-filter__list--skeleton"
+			data-wp-bind--hidden="state.skeletonHidden"
+			aria-hidden="true"
+		>
+			<?php for ( $i = 0; $i < 4; $i++ ) : ?>
+				<li class="jetpack-search-filter__item jetpack-search-filter__item--skeleton">
+					<span class="jetpack-search-skeleton jetpack-search-skeleton--filter-row"></span>
+				</li>
+			<?php endfor; ?>
+		</ul>
 	<?php endif; ?>
 	<ul
 		class="jetpack-search-filter__list"

--- a/projects/packages/search/src/search-blocks/blocks/filter-date/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-date/render.php
@@ -30,56 +30,25 @@ wp_interactivity_state(
 	)
 );
 
-// Pre-hydration loading state — mirrors filter-checkbox/render.php. On a
-// deep-link load `state.aggregations` is empty until the JS fetch resolves,
-// so without this the date-filter wrapper would collapse to nothing and
-// pop in once buckets arrive. `$show_wrapper` keeps it visible during the
-// initial-loading window so the skeleton list inside has somewhere to
-// render; `callbacks.syncFilterWrapperVisibility` (in the shared store)
-// keeps `context.wrapperHidden` in sync after JS hydrates.
-$seeded_state       = wp_interactivity_state( 'jetpack-search' );
-$seeded_aggs        = (array) ( $seeded_state['aggregations'] ?? array() );
-$seeded_filter_agg  = (array) ( $seeded_aggs[ $filter_key ] ?? array() );
-$seeded_buckets     = $seeded_filter_agg['buckets'] ?? null;
-$has_buckets        = is_array( $seeded_buckets ) && ! empty( $seeded_buckets );
-$is_initial_loading = Search_Blocks::is_initial_loading();
-$show_wrapper       = $has_buckets || $is_initial_loading;
-
+$view  = Search_Blocks::pre_hydration_filter_view( $filter_key );
 $label = $config['label'];
 ?>
 <div
 	<?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>
 	data-wp-interactive="jetpack-search"
-	<?php
-	echo wp_kses_data(
-		wp_interactivity_data_wp_context(
-			array(
-				'filterKey'     => $filter_key,
-				'wrapperHidden' => ! $show_wrapper,
-			)
-		)
-	);
-	?>
+	<?php Search_Blocks::emit_filter_wrapper_context( $filter_key, $view['show_wrapper'] ); ?>
 	data-wp-bind--hidden="context.wrapperHidden"
 	data-wp-watch="callbacks.syncFilterWrapperVisibility"
-	<?php echo $show_wrapper ? '' : 'hidden'; ?>
+	<?php echo $view['show_wrapper'] ? '' : 'hidden'; ?>
 >
 	<?php if ( '' !== $label ) : ?>
 		<h3 class="jetpack-search-filter__title"><?php echo esc_html( $label ); ?></h3>
 	<?php endif; ?>
-	<?php if ( $is_initial_loading ) : ?>
-		<ul
-			class="jetpack-search-filter__list jetpack-search-filter__list--skeleton"
-			data-wp-bind--hidden="state.skeletonHidden"
-			aria-hidden="true"
-		>
-			<?php for ( $i = 0; $i < 4; $i++ ) : ?>
-				<li class="jetpack-search-filter__item jetpack-search-filter__item--skeleton">
-					<span class="jetpack-search-skeleton jetpack-search-skeleton--filter-row"></span>
-				</li>
-			<?php endfor; ?>
-		</ul>
-	<?php endif; ?>
+	<?php
+	if ( $view['is_initial_loading'] ) {
+		require __DIR__ . '/../filter-skeleton-partial.php';
+	}
+	?>
 	<ul
 		class="jetpack-search-filter__list"
 		data-wp-bind--hidden="state.allBucketsSelected"

--- a/projects/packages/search/src/search-blocks/blocks/filter-date/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filter-date/style.scss
@@ -1,53 +1,13 @@
+@use "../skeleton" as skeleton;
+
 .wp-block-jetpack-filter-date {
 
 	&[hidden] {
 		display: none;
 	}
 
-	@keyframes jetpack-search-skeleton-shimmer {
-
-		from {
-			background-position: -200% 0;
-		}
-
-		to {
-			background-position: 200% 0;
-		}
-	}
-
-	.jetpack-search-skeleton {
-		display: block;
-		border-radius: 4px;
-		background: color-mix(in sRGB, currentColor 8%, transparent) linear-gradient(90deg, transparent 0%, color-mix(in sRGB, currentColor 6%, transparent) 50%, transparent 100%) repeat;
-		background-size: 200% 100%;
-		animation: jetpack-search-skeleton-shimmer 1.5s linear infinite;
-	}
-
-	@media (prefers-reduced-motion: reduce) {
-
-		.jetpack-search-skeleton {
-			animation: none;
-		}
-	}
-
-	.jetpack-search-skeleton--filter-row {
-		height: 1rem;
-		width: 80%;
-	}
-
-	.jetpack-search-filter__list--skeleton {
-		list-style: none;
-		margin: 0;
-		padding: 0;
-
-		&[hidden] {
-			display: none;
-		}
-	}
-
-	.jetpack-search-filter__item--skeleton {
-		padding: 0.25rem 0;
-	}
+	@include skeleton.shimmer;
+	@include skeleton.filter-rows;
 
 	.jetpack-search-filter__title {
 		font-size: 0.85rem;

--- a/projects/packages/search/src/search-blocks/blocks/filter-date/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/filter-date/style.scss
@@ -4,6 +4,51 @@
 		display: none;
 	}
 
+	@keyframes jetpack-search-skeleton-shimmer {
+
+		from {
+			background-position: -200% 0;
+		}
+
+		to {
+			background-position: 200% 0;
+		}
+	}
+
+	.jetpack-search-skeleton {
+		display: block;
+		border-radius: 4px;
+		background: color-mix(in sRGB, currentColor 8%, transparent) linear-gradient(90deg, transparent 0%, color-mix(in sRGB, currentColor 6%, transparent) 50%, transparent 100%) repeat;
+		background-size: 200% 100%;
+		animation: jetpack-search-skeleton-shimmer 1.5s linear infinite;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+
+		.jetpack-search-skeleton {
+			animation: none;
+		}
+	}
+
+	.jetpack-search-skeleton--filter-row {
+		height: 1rem;
+		width: 80%;
+	}
+
+	.jetpack-search-filter__list--skeleton {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+
+		&[hidden] {
+			display: none;
+		}
+	}
+
+	.jetpack-search-filter__item--skeleton {
+		padding: 0.25rem 0;
+	}
+
 	.jetpack-search-filter__title {
 		font-size: 0.85rem;
 		font-weight: 700;

--- a/projects/packages/search/src/search-blocks/blocks/filter-skeleton-partial.php
+++ b/projects/packages/search/src/search-blocks/blocks/filter-skeleton-partial.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Pre-hydration skeleton list shared by filter-checkbox and filter-date
+ * render.php. Included with `require __DIR__ . '/../filter-skeleton.partial.php';`
+ * inside the wrapper element when `Search_Blocks::is_initial_loading()` is true.
+ *
+ * Visibility flips off via `state.skeletonHidden` once the first fetch
+ * resolves on the client (see `actions.search()` in `store/index.js`).
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+defined( 'ABSPATH' ) || exit;
+
+$rows = 4;
+?>
+<ul
+	class="jetpack-search-filter__list jetpack-search-filter__list--skeleton"
+	data-wp-bind--hidden="state.skeletonHidden"
+	aria-hidden="true"
+>
+	<?php for ( $i = 0; $i < $rows; $i++ ) : ?>
+		<li class="jetpack-search-filter__item jetpack-search-filter__item--skeleton">
+			<span class="jetpack-search-skeleton jetpack-search-skeleton--filter-row"></span>
+		</li>
+	<?php endfor; ?>
+</ul>

--- a/projects/packages/search/src/search-blocks/blocks/load-more/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/load-more/render.php
@@ -21,6 +21,7 @@ if ( '' === $button_label ) {
 	<?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>
 	data-wp-interactive="jetpack-search"
 	data-wp-bind--hidden="!state.showLoadMore"
+	hidden
 >
 	<button
 		type="button"

--- a/projects/packages/search/src/search-blocks/blocks/no-results/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/no-results/render.php
@@ -20,6 +20,7 @@ if ( '' === $message ) {
 	<?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>
 	data-wp-interactive="jetpack-search"
 	data-wp-bind--hidden="!state.showNoResults"
+	hidden
 >
 	<p><?php echo esc_html( $message ); ?></p>
 </div>

--- a/projects/packages/search/src/search-blocks/blocks/results-count/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/results-count/render.php
@@ -16,6 +16,12 @@ namespace Automattic\Jetpack\Search;
 // flow when there are no results would collapse that layout, snapping the
 // sort control to the left. An always-present (but text-empty) paragraph
 // keeps the two controls at the outer edges of the row.
+//
+// Pre-hydration text: `state.resultsCountText` is seeded with the localized
+// "Searching…" string when the URL is going to trigger an initial fetch
+// (see `Search_Blocks::build_initial_state()`), and the IA SSR pass writes
+// that string into the body via `data-wp-text` — so a deep link no longer
+// flashes a blank line before JS hydrates.
 ?>
 <p
 	<?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>

--- a/projects/packages/search/src/search-blocks/blocks/search-error/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/search-error/render.php
@@ -23,6 +23,7 @@ if ( '' === $message ) {
 	data-wp-interactive="jetpack-search"
 	data-wp-bind--hidden="!state.showError"
 	role="alert"
+	hidden
 >
 	<p><?php echo esc_html( $message ); ?></p>
 </div>

--- a/projects/packages/search/src/search-blocks/blocks/search-results/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/search-results/render.php
@@ -14,6 +14,14 @@ $layout        = ( (array) $attributes )['layout'] ?? 'card';
 $is_compact    = 'compact' === $layout;
 $wrapper_class = $is_compact ? 'jetpack-search-results--compact' : 'jetpack-search-results--card';
 $wrapper_attrs = get_block_wrapper_attributes( array( 'class' => $wrapper_class ) );
+
+// Pre-hydration loading state. Skeleton items below render server-side only
+// when the URL carries a query/filter that will trigger an initial fetch on
+// hydration; otherwise emitting them would freeze placeholder rows on a bare
+// /search/ page where no fetch ever fires. Once JS hydrates,
+// `data-wp-bind--hidden="!state.showResultsSkeleton"` takes over visibility.
+$is_initial_loading = Search_Blocks::is_initial_loading();
+$skeleton_count     = $is_compact ? 6 : 4;
 ?>
 <div
 	<?php echo wp_kses_data( $wrapper_attrs ); ?>
@@ -25,6 +33,26 @@ $wrapper_attrs = get_block_wrapper_attributes( array( 'class' => $wrapper_class 
 		class="jetpack-search-results__list"
 		aria-live="polite"
 	>
+		<?php if ( $is_initial_loading ) : ?>
+			<?php for ( $i = 0; $i < $skeleton_count; $i++ ) : ?>
+				<li
+					class="jetpack-search-results__item jetpack-search-results__item--skeleton"
+					data-wp-bind--hidden="state.skeletonHidden"
+					aria-hidden="true"
+				>
+					<div class="jetpack-search-results__copy">
+						<div class="jetpack-search-skeleton jetpack-search-skeleton--title"></div>
+						<?php if ( ! $is_compact ) : ?>
+							<div class="jetpack-search-skeleton jetpack-search-skeleton--path"></div>
+							<div class="jetpack-search-skeleton jetpack-search-skeleton--meta"></div>
+						<?php endif; ?>
+					</div>
+					<?php if ( ! $is_compact ) : ?>
+						<div class="jetpack-search-skeleton jetpack-search-skeleton--image"></div>
+					<?php endif; ?>
+				</li>
+			<?php endfor; ?>
+		<?php endif; ?>
 		<template
 			data-wp-each--result="state.results"
 			data-wp-key="context.result.id"

--- a/projects/packages/search/src/search-blocks/blocks/search-results/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/search-results/render.php
@@ -19,7 +19,7 @@ $wrapper_attrs = get_block_wrapper_attributes( array( 'class' => $wrapper_class 
 // when the URL carries a query/filter that will trigger an initial fetch on
 // hydration; otherwise emitting them would freeze placeholder rows on a bare
 // /search/ page where no fetch ever fires. Once JS hydrates,
-// `data-wp-bind--hidden="!state.showResultsSkeleton"` takes over visibility.
+// `data-wp-bind--hidden="state.skeletonHidden"` takes over visibility.
 $is_initial_loading = Search_Blocks::is_initial_loading();
 $skeleton_count     = $is_compact ? 6 : 4;
 ?>

--- a/projects/packages/search/src/search-blocks/blocks/search-results/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/search-results/style.scss
@@ -1,33 +1,8 @@
-// Shared skeleton placeholder used pre-hydration. Kept inside the block-
-// scoped wrapper so the keyframe + base class never leak to other blocks
-// or page content.
+@use "../skeleton" as skeleton;
+
 .wp-block-jetpack-search-results {
 
-	@keyframes jetpack-search-skeleton-shimmer {
-
-		from {
-			background-position: -200% 0;
-		}
-
-		to {
-			background-position: 200% 0;
-		}
-	}
-
-	.jetpack-search-skeleton {
-		display: block;
-		border-radius: 4px;
-		background: color-mix(in sRGB, currentColor 8%, transparent) linear-gradient(90deg, transparent 0%, color-mix(in sRGB, currentColor 6%, transparent) 50%, transparent 100%) repeat;
-		background-size: 200% 100%;
-		animation: jetpack-search-skeleton-shimmer 1.5s linear infinite;
-	}
-
-	@media (prefers-reduced-motion: reduce) {
-
-		.jetpack-search-skeleton {
-			animation: none;
-		}
-	}
+	@include skeleton.shimmer;
 
 	.jetpack-search-skeleton--title {
 		height: 1.5rem;

--- a/projects/packages/search/src/search-blocks/blocks/search-results/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/search-results/style.scss
@@ -1,4 +1,64 @@
+// Shared skeleton placeholder used pre-hydration. Kept inside the block-
+// scoped wrapper so the keyframe + base class never leak to other blocks
+// or page content.
 .wp-block-jetpack-search-results {
+
+	@keyframes jetpack-search-skeleton-shimmer {
+
+		from {
+			background-position: -200% 0;
+		}
+
+		to {
+			background-position: 200% 0;
+		}
+	}
+
+	.jetpack-search-skeleton {
+		display: block;
+		border-radius: 4px;
+		background: color-mix(in sRGB, currentColor 8%, transparent) linear-gradient(90deg, transparent 0%, color-mix(in sRGB, currentColor 6%, transparent) 50%, transparent 100%) repeat;
+		background-size: 200% 100%;
+		animation: jetpack-search-skeleton-shimmer 1.5s linear infinite;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+
+		.jetpack-search-skeleton {
+			animation: none;
+		}
+	}
+
+	.jetpack-search-skeleton--title {
+		height: 1.5rem;
+		width: 65%;
+	}
+
+	.jetpack-search-skeleton--path {
+		height: 0.95rem;
+		width: 40%;
+		margin-top: 0.5rem;
+	}
+
+	.jetpack-search-skeleton--meta {
+		height: 0.9rem;
+		width: 25%;
+		margin-top: 1rem;
+	}
+
+	.jetpack-search-skeleton--image {
+		flex: 0 0 auto;
+		width: 200px;
+		max-width: 30%;
+		aspect-ratio: 16 / 10;
+	}
+
+	.jetpack-search-results__item--skeleton {
+
+		&[hidden] {
+			display: none;
+		}
+	}
 
 	.jetpack-search-results__list {
 		list-style: none;

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -41,6 +41,19 @@ class Search_Blocks {
 		add_action( 'init', array( static::class, 'register_search_template' ) );
 		add_filter( 'block_categories_all', array( static::class, 'register_block_category' ) );
 		add_filter( 'search_template_hierarchy', array( static::class, 'prepend_search_template' ) );
+		// Seed on `template_redirect` (fires before block-template rendering)
+		// AND on `wp_enqueue_scripts` (covers classic-theme paths and admin
+		// previews where `template_redirect` doesn't run). The IA store
+		// deep-merges, so calling twice is idempotent — the second call's
+		// values overwrite the first with the same data. The earlier hook is
+		// what makes pre-hydration values like `state.resultsCountText` and
+		// `state.skeletonHidden` visible to the SSR pass on FSE block themes,
+		// which call `get_the_block_template_html()` *before* `wp_head()` so
+		// blocks can register scripts/styles for the head — which means our
+		// individual block render.php files would otherwise see an unseeded
+		// state when their `data-wp-bind` / `data-wp-text` directives are
+		// resolved.
+		add_action( 'template_redirect', array( static::class, 'seed_interactivity_state' ) );
 		add_action( 'wp_enqueue_scripts', array( static::class, 'seed_interactivity_state' ) );
 		add_action( 'enqueue_block_editor_assets', array( static::class, 'enqueue_editor_assets' ) );
 	}
@@ -478,58 +491,82 @@ class Search_Blocks {
 	 * @return array<string, mixed>
 	 */
 	public static function build_initial_state() {
-		$is_private     = class_exists( Status::class ) ? ( new Status() )->is_private_site() : false;
-		$is_wpcom       = class_exists( Helper::class ) ? Helper::is_wpcom() : false;
-		$site_id        = class_exists( Helper::class ) ? Helper::get_wpcom_site_id() : 0;
-		$search_query   = function_exists( 'get_search_query' ) ? (string) get_search_query() : '';
-		$active_filters = static::parse_url_filters();
-		$price_range    = static::parse_url_price_range();
+		$is_private         = class_exists( Status::class ) ? ( new Status() )->is_private_site() : false;
+		$is_wpcom           = class_exists( Helper::class ) ? Helper::is_wpcom() : false;
+		$site_id            = class_exists( Helper::class ) ? Helper::get_wpcom_site_id() : 0;
+		$search_query       = function_exists( 'get_search_query' ) ? (string) get_search_query() : '';
+		$active_filters     = static::parse_url_filters();
+		$price_range        = static::parse_url_price_range();
+		$is_initial_loading = '' !== $search_query || ! empty( $active_filters ) || null !== $price_range;
+		$searching_text     = function_exists( '__' ) ? __( 'Searching…', 'jetpack-search-pkg' ) : 'Searching…';
 
 		return array(
 			// Connection / routing config.
-			'siteId'        => $site_id,
-			'apiRoot'       => function_exists( 'rest_url' ) ? esc_url_raw( rest_url() ) : '',
-			'nonce'         => function_exists( 'wp_create_nonce' ) ? wp_create_nonce( 'wp_rest' ) : '',
-			'isPrivateSite' => $is_private,
-			'isWpcom'       => $is_wpcom,
-			'homeUrl'       => function_exists( 'home_url' ) ? home_url() : '',
+			'siteId'           => $site_id,
+			'apiRoot'          => function_exists( 'rest_url' ) ? esc_url_raw( rest_url() ) : '',
+			'nonce'            => function_exists( 'wp_create_nonce' ) ? wp_create_nonce( 'wp_rest' ) : '',
+			'isPrivateSite'    => $is_private,
+			'isWpcom'          => $is_wpcom,
+			'homeUrl'          => function_exists( 'home_url' ) ? home_url() : '',
 			// BCP47-ish locale (e.g. `en-US`) for Intl.DateTimeFormat on the
 			// client. Converts WP's `en_US` underscore form. Uses the blog
 			// locale (site setting) rather than the viewer's user-profile
 			// locale so formatting is consistent for logged-out visitors
 			// hitting a search page.
-			'locale'        => function_exists( 'get_locale' )
+			'locale'           => function_exists( 'get_locale' )
 				? str_replace( '_', '-', get_locale() )
 				: 'en-US',
 
 			// Search state, seeded from the URL so a deep link like
 			// /?s=boots&orderby=newest&category[]=news renders correctly on
 			// first paint.
-			'searchQuery'   => $search_query,
-			'sortOrder'     => static::parse_url_sort(),
-			'activeFilters' => $active_filters,
-			'priceRange'    => $price_range,
+			'searchQuery'      => $search_query,
+			'sortOrder'        => static::parse_url_sort(),
+			'activeFilters'    => $active_filters,
+			'priceRange'       => $price_range,
 
 			// filterConfigs: each filter-checkbox block's render.php merges its
 			// own entry here. Shape: { [filterKey]: { filterKey, filterType,
 			// taxonomy, label, showCount, maxItems } }.
-			'filterConfigs' => array(),
+			'filterConfigs'    => array(),
 
 			// Results + aggregations are populated by the JS store on hydration —
 			// seed empty defaults so template bindings always have a shape to read.
 			// `aggregations` is a stdClass so JS sees `{}`, not `[]`.
-			'results'       => array(),
-			'aggregations'  => (object) array(),
-			'totalResults'  => 0,
-			'pageHandle'    => null,
+			'results'          => array(),
+			'aggregations'     => (object) array(),
+			'totalResults'     => 0,
+			'pageHandle'       => null,
 
 			// UI state. `isLoading` is seeded true when the URL carries a
 			// search query or filter selection so the no-results block stays
 			// hidden between first paint and JS hydrating the initial fetch —
 			// otherwise a "No results found" flash appears on deep links.
-			'isLoading'     => '' !== $search_query || ! empty( $active_filters ) || null !== $price_range,
-			'isLoadingMore' => false,
-			'hasError'      => false,
+			'isLoading'        => $is_initial_loading,
+			'isLoadingMore'    => false,
+			'hasError'         => false,
+
+			// Pre-hydration skeleton gate. `data-wp-bind` directives are
+			// evaluated at SSR time using only the seeded state — derived
+			// getters can't run server-side, so the skeleton blocks bind
+			// directly to this single seeded boolean. Stays false until the
+			// first search() action resolves on the client; the IA SSR pass
+			// then leaves the `hidden` attribute off so the skeletons paint
+			// immediately. Once JS flips it to true the same binding hides
+			// the placeholders for the rest of the session — subsequent
+			// re-searches keep the live results visible without a skeleton
+			// flash.
+			'skeletonHidden'   => false,
+
+			// Live results-count copy. Same SSR rationale as `skeletonHidden`:
+			// the JS-side `data-wp-text="state.resultsCountText"` directive is
+			// resolved at SSR time, so the value must be a seeded string rather
+			// than a derived JS getter. Pre-hydration we mirror the JS-side
+			// `computeResultsCountText()` loading branch so the line reads
+			// "Searching…" on a deep link instead of staying blank until JS
+			// hydrates. Every action that mutates `isLoading` / `totalResults`
+			// re-runs the computer to keep this in lockstep.
+			'resultsCountText' => $is_initial_loading ? $searching_text : '',
 
 			// Translated view-bundle strings. The Interactivity API view bundle
 			// can't import @wordpress/i18n (only @wordpress/interactivity is
@@ -538,8 +575,38 @@ class Search_Blocks {
 			// are seeded so the client can pick based on the live totalResults
 			// without a round trip; languages with more than two plural forms
 			// degrade to "plural for all count > 1" as an accepted tradeoff.
-			'strings'       => static::build_initial_strings(),
+			'strings'          => static::build_initial_strings(),
 		);
+	}
+
+	/**
+	 * Whether the page starts in a loading state — i.e. the URL carries a
+	 * search query, filter selection, or price range, so the JS store will
+	 * fire an initial fetch on hydration.
+	 *
+	 * Render.php callers branch on this to emit pre-hydration affordances
+	 * (skeleton placeholders, seeded "Searching…" text). The value is derived
+	 * from the request URL rather than read back through
+	 * `wp_interactivity_state()` because in block themes individual block
+	 * renders can run before `seed_interactivity_state()` finishes (FSE
+	 * pre-resolves template attributes by walking blocks before the
+	 * `wp_enqueue_scripts` hook fires) — so a state-read fallback would
+	 * silently return false on the very pages this helper is meant to flag.
+	 * The condition mirrors the `isLoading` value seeded into
+	 * `build_initial_state()` exactly so PHP-time and JS-side answers stay
+	 * in lockstep.
+	 *
+	 * @return bool
+	 */
+	public static function is_initial_loading(): bool {
+		$search_query = function_exists( 'get_search_query' ) ? (string) get_search_query() : '';
+		if ( '' !== $search_query ) {
+			return true;
+		}
+		if ( ! empty( static::parse_url_filters() ) ) {
+			return true;
+		}
+		return null !== static::parse_url_price_range();
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -497,7 +497,7 @@ class Search_Blocks {
 		$search_query       = function_exists( 'get_search_query' ) ? (string) get_search_query() : '';
 		$active_filters     = static::parse_url_filters();
 		$price_range        = static::parse_url_price_range();
-		$is_initial_loading = '' !== $search_query || ! empty( $active_filters ) || null !== $price_range;
+		$is_initial_loading = static::is_initial_loading();
 		$searching_text     = function_exists( '__' ) ? __( 'Searching…', 'jetpack-search-pkg' ) : 'Searching…';
 
 		return array(

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -41,18 +41,12 @@ class Search_Blocks {
 		add_action( 'init', array( static::class, 'register_search_template' ) );
 		add_filter( 'block_categories_all', array( static::class, 'register_block_category' ) );
 		add_filter( 'search_template_hierarchy', array( static::class, 'prepend_search_template' ) );
-		// Seed on `template_redirect` (fires before block-template rendering)
-		// AND on `wp_enqueue_scripts` (covers classic-theme paths and admin
-		// previews where `template_redirect` doesn't run). The IA store
-		// deep-merges, so calling twice is idempotent — the second call's
-		// values overwrite the first with the same data. The earlier hook is
-		// what makes pre-hydration values like `state.resultsCountText` and
-		// `state.skeletonHidden` visible to the SSR pass on FSE block themes,
-		// which call `get_the_block_template_html()` *before* `wp_head()` so
-		// blocks can register scripts/styles for the head — which means our
-		// individual block render.php files would otherwise see an unseeded
-		// state when their `data-wp-bind` / `data-wp-text` directives are
-		// resolved.
+		// FSE block-template rendering runs *before* `wp_head()` (see
+		// `wp-includes/template-canvas.php`), so blocks would resolve
+		// `data-wp-bind` / `data-wp-text` against an unseeded IA store if we
+		// only hooked `wp_enqueue_scripts`. Seeding on `template_redirect`
+		// closes that gap; the second call from `wp_enqueue_scripts` is a
+		// deep-merge no-op and keeps classic-theme paths covered.
 		add_action( 'template_redirect', array( static::class, 'seed_interactivity_state' ) );
 		add_action( 'wp_enqueue_scripts', array( static::class, 'seed_interactivity_state' ) );
 		add_action( 'enqueue_block_editor_assets', array( static::class, 'enqueue_editor_assets' ) );
@@ -546,26 +540,17 @@ class Search_Blocks {
 			'isLoadingMore'    => false,
 			'hasError'         => false,
 
-			// Pre-hydration skeleton gate. `data-wp-bind` directives are
-			// evaluated at SSR time using only the seeded state — derived
-			// getters can't run server-side, so the skeleton blocks bind
-			// directly to this single seeded boolean. Stays false until the
-			// first search() action resolves on the client; the IA SSR pass
-			// then leaves the `hidden` attribute off so the skeletons paint
-			// immediately. Once JS flips it to true the same binding hides
-			// the placeholders for the rest of the session — subsequent
-			// re-searches keep the live results visible without a skeleton
-			// flash.
+			// One-shot pre-hydration skeleton gate. The IA SSR pass evaluates
+			// `data-wp-bind--hidden` against literal seeded values (it can't
+			// run JS getters), so skeleton elements bind directly to this
+			// boolean. JS flips it to true once `actions.search()` resolves
+			// and never resets it — subsequent re-searches keep live results
+			// on screen without re-flashing placeholders.
 			'skeletonHidden'   => false,
 
-			// Live results-count copy. Same SSR rationale as `skeletonHidden`:
-			// the JS-side `data-wp-text="state.resultsCountText"` directive is
-			// resolved at SSR time, so the value must be a seeded string rather
-			// than a derived JS getter. Pre-hydration we mirror the JS-side
-			// `computeResultsCountText()` loading branch so the line reads
-			// "Searching…" on a deep link instead of staying blank until JS
-			// hydrates. Every action that mutates `isLoading` / `totalResults`
-			// re-runs the computer to keep this in lockstep.
+			// Seeded so the SSR pass can resolve `data-wp-text` to a real
+			// string on first paint; `actions.search()` keeps it in lockstep
+			// with `isLoading` / `totalResults` via `computeResultsCountText`.
 			'resultsCountText' => $is_initial_loading ? $searching_text : '',
 
 			// Translated view-bundle strings. The Interactivity API view bundle
@@ -618,6 +603,59 @@ class Search_Blocks {
 		}
 		$cached = null !== static::parse_url_price_range();
 		return $cached;
+	}
+
+	/**
+	 * Pre-hydration view state for a filter block's wrapper. Centralizes the
+	 * seeded-state read shared by filter-checkbox and filter-date so each
+	 * render.php branches on a single struct rather than re-deriving the
+	 * same flags inline.
+	 *
+	 * @param string $filter_key The filter key (e.g. `category`, `post_type`).
+	 * @return array{has_buckets:bool,is_initial_loading:bool,show_wrapper:bool}
+	 */
+	public static function pre_hydration_filter_view( string $filter_key ): array {
+		if ( ! function_exists( 'wp_interactivity_state' ) ) {
+			return array(
+				'has_buckets'        => false,
+				'is_initial_loading' => false,
+				'show_wrapper'       => false,
+			);
+		}
+		// `aggregations` is seeded as `stdClass` when empty (so JS sees `{}`,
+		// not `[]`); cast before subscripting so the read works in either shape.
+		$state              = wp_interactivity_state( 'jetpack-search' );
+		$aggs               = (array) ( $state['aggregations'] ?? array() );
+		$has_buckets        = ! empty( $aggs[ $filter_key ]['buckets'] ?? array() );
+		$is_initial_loading = static::is_initial_loading();
+		return array(
+			'has_buckets'        => $has_buckets,
+			'is_initial_loading' => $is_initial_loading,
+			'show_wrapper'       => $has_buckets || $is_initial_loading,
+		);
+	}
+
+	/**
+	 * Emit the `data-wp-context` attribute for a filter block's wrapper. The
+	 * seeded `wrapperHidden` value is what the IA SSR pass evaluates
+	 * `data-wp-bind--hidden="context.wrapperHidden"` against, and what the
+	 * `syncFilterWrapperVisibility` callback updates after hydration.
+	 *
+	 * @param string $filter_key   The filter key.
+	 * @param bool   $show_wrapper Whether the wrapper should be visible on first paint.
+	 */
+	public static function emit_filter_wrapper_context( string $filter_key, bool $show_wrapper ): void {
+		if ( ! function_exists( 'wp_interactivity_data_wp_context' ) ) {
+			return;
+		}
+		echo wp_kses_data(
+			wp_interactivity_data_wp_context(
+				array(
+					'filterKey'     => $filter_key,
+					'wrapperHidden' => ! $show_wrapper,
+				)
+			)
+		);
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -599,14 +599,25 @@ class Search_Blocks {
 	 * @return bool
 	 */
 	public static function is_initial_loading(): bool {
+		// Memoize per-request: the URL doesn't change mid-request, and this
+		// helper is hit by every block render.php (one per filter block plus
+		// search-results, results-count, etc.) AND by `build_initial_state()`,
+		// each of which would otherwise re-parse `$_GET` independently.
+		static $cached = null;
+		if ( null !== $cached ) {
+			return $cached;
+		}
 		$search_query = function_exists( 'get_search_query' ) ? (string) get_search_query() : '';
 		if ( '' !== $search_query ) {
+			$cached = true;
 			return true;
 		}
 		if ( ! empty( static::parse_url_filters() ) ) {
+			$cached = true;
 			return true;
 		}
-		return null !== static::parse_url_price_range();
+		$cached = null !== static::parse_url_price_range();
+		return $cached;
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -157,6 +157,34 @@ function dateFilterItems( sharedState, filterKey, config ) {
 let searchToken = 0;
 
 /**
+ * Build the human-readable results-count string from the live store state.
+ * Returns "Searching…" while a search is in flight, "Found 42 results" once
+ * a query resolves with hits, or an empty string in every other case
+ * (pre-search, error, or zero hits — the no-results block owns the empty-
+ * state copy). Called by every action that mutates `isLoading` or
+ * `totalResults` so the seeded `state.resultsCountText` stays in lockstep
+ * with the counters; SSR resolves `data-wp-text` against that seeded value
+ * directly, so the string can't live on a JS getter.
+ *
+ * @param {object} liveState - The IA store state.
+ * @return {string} Localized results-count or status string.
+ */
+function computeResultsCountText( liveState ) {
+	if ( liveState.isLoading ) {
+		return liveState.strings?.searching ?? 'Searching…';
+	}
+	const total = liveState.totalResults;
+	if ( total === 0 ) {
+		return '';
+	}
+	const template =
+		total === 1
+			? liveState.strings?.resultsCountSingle ?? 'Found %d result'
+			: liveState.strings?.resultsCountPlural ?? 'Found %d results';
+	return template.replace( '%d', total );
+}
+
+/**
  * Request a page of results. Shared between the initial search and
  * subsequent load-more calls; the caller owns the loading flag and
  * decides how to merge the response into state.
@@ -201,42 +229,12 @@ const { state, actions } = store( NAMESPACE, {
 		// the currently checked option becomes the implicit default.
 		sortMenuFocusedKey: null,
 
-		/**
-		 * Short human-readable results count for display blocks. Doubles
-		 * as the loading indicator: returning the "searching" string
-		 * in-place keeps the results-count element populated across the
-		 * transition from one query to the next, so the flex row
-		 * containing it doesn't collapse and re-expand on every
-		 * keystroke-triggered search. There is no separate
-		 * spinner/skeleton — this text is the loading state, and the
-		 * search-results wrapper carries `aria-busy` for assistive tech.
-		 *
-		 * Strings are seeded from PHP via `wp_interactivity_state()`
-		 * (see `Search_Blocks::build_initial_strings()`) because the
-		 * view bundle can't import `@wordpress/i18n` — WP only registers
-		 * `@wordpress/interactivity` as a script module. Languages with
-		 * more than two plural forms degrade to "plural for all count
-		 * > 1" since the count is dynamic on the client.
-		 *
-		 * @return {string} Translated "Searching…" while a search is in
-		 * flight, "Found 42 results" once a query resolves with hits,
-		 * or an empty string in every other case — pre-search, error,
-		 * or zero hits. The no-results block owns the empty-state copy.
-		 */
-		get resultsCountText() {
-			if ( state.isLoading ) {
-				return state.strings?.searching ?? 'Searching…';
-			}
-			const total = state.totalResults;
-			if ( total === 0 ) {
-				return '';
-			}
-			const template =
-				total === 1
-					? state.strings?.resultsCountSingle ?? 'Found %d result'
-					: state.strings?.resultsCountPlural ?? 'Found %d results';
-			return template.replace( '%d', total );
-		},
+		// `resultsCountText` lives on the seeded state (PHP-side), not as a
+		// getter, so the IA SSR pass can resolve `data-wp-text="state.resultsCountText"`
+		// to the right initial string on a deep-link load. See
+		// `computeResultsCountText()` below for the full string-selection logic;
+		// every action that mutates `isLoading` / `totalResults` calls it to
+		// keep this value in lockstep with the underlying counters.
 
 		/**
 		 * `data-wp-bind` only evaluates simple property paths (with an
@@ -475,6 +473,7 @@ const { state, actions } = store( NAMESPACE, {
 			state.isLoading = true;
 			state.isLoadingMore = false;
 			state.hasError = false;
+			state.resultsCountText = computeResultsCountText( state );
 			try {
 				const data = yield* fetchResults( null );
 				// A newer `search()` started while this one was in-flight — its
@@ -497,6 +496,12 @@ const { state, actions } = store( NAMESPACE, {
 			} finally {
 				if ( myToken === searchToken ) {
 					state.isLoading = false;
+					state.resultsCountText = computeResultsCountText( state );
+					// First fetch (success or error) ends the pre-hydration window;
+					// hide the skeleton placeholders for the rest of the session.
+					// Idempotent — flipping a true flag to true is a no-op in the
+					// IA store, so subsequent searches don't re-trigger a re-render.
+					state.skeletonHidden = true;
 				}
 			}
 		},
@@ -831,9 +836,29 @@ const { state, actions } = store( NAMESPACE, {
 				// priceRange is checked separately so `?min_price=10` still triggers an initial fetch.
 				actions.search( { syncUrl: false } );
 			} else if ( droppedAny ) {
-				// Gate emptied activeFilters and no fetch will fire — clear the PHP-seeded spinner.
+				// Gate emptied activeFilters and no fetch will fire — clear the PHP-seeded
+				// spinner and also drop the skeleton, since no fetch is coming.
 				state.isLoading = false;
+				state.skeletonHidden = true;
 			}
+		},
+
+		/**
+		 * Reactively syncs `context.wrapperHidden` for each filter-checkbox
+		 * block. Pre-hydration / first-fetch the wrapper stays visible so the
+		 * skeleton list inside has somewhere to render; once the first fetch
+		 * resolves it falls back to the legacy "hide empty filter sections"
+		 * behaviour. Runs in each block's local context, so this single
+		 * callback handles all filter blocks on the page.
+		 */
+		syncFilterWrapperVisibility() {
+			const ctx = getContext();
+			if ( ! state.skeletonHidden ) {
+				ctx.wrapperHidden = false;
+				return;
+			}
+			const buckets = state.aggregations?.[ ctx.filterKey ]?.buckets;
+			ctx.wrapperHidden = ! Array.isArray( buckets ) || buckets.length === 0;
 		},
 	},
 } );

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -166,10 +166,13 @@ let searchToken = 0;
  * with the counters; SSR resolves `data-wp-text` against that seeded value
  * directly, so the string can't live on a JS getter.
  *
+ * Exported so tests can verify the formatting in isolation without driving
+ * the full `actions.search()` lifecycle.
+ *
  * @param {object} liveState - The IA store state.
  * @return {string} Localized results-count or status string.
  */
-function computeResultsCountText( liveState ) {
+export function computeResultsCountText( liveState ) {
 	if ( liveState.isLoading ) {
 		return liveState.strings?.searching ?? 'Searching…';
 	}

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -500,11 +500,12 @@ const { state, actions } = store( NAMESPACE, {
 				if ( myToken === searchToken ) {
 					state.isLoading = false;
 					state.resultsCountText = computeResultsCountText( state );
-					// First fetch (success or error) ends the pre-hydration window;
-					// hide the skeleton placeholders for the rest of the session.
-					// Idempotent — flipping a true flag to true is a no-op in the
-					// IA store, so subsequent searches don't re-trigger a re-render.
-					state.skeletonHidden = true;
+					// First fetch (success or error) ends the pre-hydration window —
+					// guard the write so subsequent re-searches don't trigger an IA
+					// re-render of every skeleton-bound element.
+					if ( ! state.skeletonHidden ) {
+						state.skeletonHidden = true;
+					}
 				}
 			}
 		},

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -171,6 +171,35 @@ describe( 'store actions', () => {
 		jest.restoreAllMocks();
 	} );
 
+	it( 'flips skeletonHidden once the first search resolves (success or error)', async () => {
+		// `skeletonHidden` gates the pre-hydration placeholders. Once the
+		// first fetch completes, JS owns the DOM and the skeleton must
+		// disappear for the rest of the session — both the success path
+		// and the error path of `search()` need to flip the flag.
+		state.skeletonHidden = false;
+		global.fetch.mockResolvedValueOnce(
+			createResponse( {
+				results: [ createResult( 'Fresh hit' ) ],
+				total: 1,
+				page_handle: null,
+				aggregations: {},
+			} )
+		);
+		await runGenerator( actions.search( { syncUrl: false } ) );
+		expect( state.skeletonHidden ).toBe( true );
+		expect( state.isLoading ).toBe( false );
+
+		// Reset and confirm the error path also closes the skeleton —
+		// otherwise a connection failure would leave placeholders on screen
+		// indefinitely with no visible loading indicator.
+		state.skeletonHidden = false;
+		global.fetch.mockRejectedValueOnce( new Error( 'network down' ) );
+		await runGenerator( actions.search( { syncUrl: false } ) );
+		expect( state.skeletonHidden ).toBe( true );
+		expect( state.hasError ).toBe( true );
+		expect( state.isLoading ).toBe( false );
+	} );
+
 	it( 'sets hasError on a failed loadMore and clears it on the next loadMore', async () => {
 		state.pageHandle = 'next-page';
 		global.fetch.mockRejectedValueOnce( new Error( 'network down' ) ).mockResolvedValueOnce(
@@ -565,12 +594,17 @@ describe( 'store callbacks', () => {
 			fresh.state.filterConfigs = { category: { filterKey: 'category' } };
 			fresh.state.activeFilters = { foo: [ 'bar' ] };
 			fresh.state.isLoading = true;
+			fresh.state.skeletonHidden = false;
 
 			captured.callbacks.initialize();
 
 			expect( fresh.state.activeFilters ).toEqual( {} );
 			expect( search ).not.toHaveBeenCalled();
 			expect( fresh.state.isLoading ).toBe( false );
+			// Skeleton flips closed even though no fetch fires — otherwise the
+			// pre-hydration placeholders would linger forever on a deep link
+			// whose only filter keys are stale and get gated out.
+			expect( fresh.state.skeletonHidden ).toBe( true );
 		} );
 	} );
 } );

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -26,7 +26,12 @@ jest.mock(
 	{ virtual: true }
 );
 
-import { actions, gateActiveFilters, state } from '../../../src/search-blocks/store';
+import {
+	actions,
+	computeResultsCountText,
+	gateActiveFilters,
+	state,
+} from '../../../src/search-blocks/store';
 import { stateToUrlParams, urlParamsToState } from '../../../src/search-blocks/store/url-state';
 
 const originalActions = { ...actions };
@@ -361,18 +366,24 @@ describe( 'store getters', () => {
 	} );
 
 	it( 'formats the results count for loading, singular, plural, and empty states', () => {
+		// `resultsCountText` is now a regular state value updated by
+		// `actions.search()` rather than a getter — the SSR pass needs to
+		// read a literal string off the seeded state, and JS getters don't
+		// resolve server-side. Exercising `computeResultsCountText` directly
+		// keeps the formatting contract under test without driving the full
+		// fetch lifecycle.
 		state.isLoading = true;
-		expect( state.resultsCountText ).toBe( 'Looking…' );
+		expect( computeResultsCountText( state ) ).toBe( 'Looking…' );
 
 		state.isLoading = false;
 		state.totalResults = 1;
-		expect( state.resultsCountText ).toBe( 'Found 1 item' );
+		expect( computeResultsCountText( state ) ).toBe( 'Found 1 item' );
 
 		state.totalResults = 3;
-		expect( state.resultsCountText ).toBe( 'Found 3 items' );
+		expect( computeResultsCountText( state ) ).toBe( 'Found 3 items' );
 
 		state.totalResults = 0;
-		expect( state.resultsCountText ).toBe( '' );
+		expect( computeResultsCountText( state ) ).toBe( '' );
 	} );
 
 	it( 'derives result, load-more, and filter visibility flags', () => {


### PR DESCRIPTION
Fixes RSM-272 / [Linear](https://linear.app/a8c/issue/RSM-272/search-30-reconcile-loading-indicators-between-search-results-and-load).

## Why

Today, opening a search-blocks deep link (`/?s=hello`, `?<filterKey>[]=…`, or `?min_price=…`) renders blank content between first paint and JS hydration: the results column is an empty `<ul>`, the filter sidebar collapses to just its `<h2>` heading, and the results-count line is empty. The blocks know they're going to fetch on hydration — they just don't tell the user.

Root cause is two-fold:

1. **FSE template-canvas renders blocks before `wp_head()`.** `template-canvas.php` calls `get_the_block_template_html()` *before* `wp_head()` runs ("so blocks can add scripts and styles in `wp_head()`"). That means each block's `render.php` — and the IA SSR pass that processes its `data-wp-bind` / `data-wp-text` directives — runs against an unseeded `jetpack-search` store. Anything that depended on the seeded state (results count, "Searching…" text, derived flags) resolved to `null` server-side.
2. **`data-wp-bind` SSR can only resolve direct property paths against seeded values, not JS getters.** Binding skeleton visibility to a derived getter like `state.showResultsSkeleton` made SSR add `hidden` to every skeleton element, defeating the point of rendering them.

## What changed

- **`Search_Blocks::is_initial_loading()`** — derives "is the page about to fetch?" from the request URL directly, so `render.php` callers can branch on it without depending on hook ordering.
- **Single seeded boolean `state.skeletonHidden`** + seeded `state.resultsCountText` — every skeleton element binds to the boolean (no derived getters), and the results-count `<p>` reads its initial body from the seeded string. Both flip on the client when `actions.search()` resolves.
- **`seed_interactivity_state` also runs on `template_redirect`** — earliest hook before block rendering. Combined with the existing `wp_enqueue_scripts` hook (idempotent — IA store deep-merges) so non-FSE paths still get seeded.
- **Per-block render.php** updates:
  - `search-results` emits N skeleton `<li>`s on initial loading.
  - `filter-checkbox` emits a skeleton list inside the wrapper. Wrapper visibility moves to a per-block `context.wrapperHidden` synced by a `data-wp-watch` callback so the legacy "hide empty filter sections post-fetch" UX is preserved without fighting the SSR evaluator. Templates still bind to a single variable.
  - `results-count` drops its JS-side `resultsCountText` getter; actions update `state.resultsCountText` explicitly via `computeResultsCountText()`.
  - `no-results` / `search-error` / `load-more` emit `hidden` on first paint so they never flash before JS confirms their visibility flags.

## Real-screen before / after

Captured at `/?s=hello` on the local nova docker env at 1440×900 with all `<script>` requests blocked (simulates the pre-hydration window users see on slow connections).

| Before (trunk) | After (this PR) |
|---|---|
| ![before](https://github.com/user-attachments/assets/b935a406-d42f-40b6-89e3-ccfef4a79cad) | ![after](https://github.com/user-attachments/assets/0eedc730-2026-4224-9ab7-cd2b53c9fcd4) |

## Proposed changes

- Add `Search_Blocks::is_initial_loading()` URL-derived helper.
- Seed `skeletonHidden` and `resultsCountText` into the IA store; flip both from `actions.search()` once the first response (success or error) resolves.
- Hook `seed_interactivity_state` to `template_redirect` in addition to `wp_enqueue_scripts`.
- Render skeleton placeholders in `search-results` and `filter-checkbox` when the page is initially loading.
- Switch `filter-checkbox` wrapper visibility to a per-block `context.wrapperHidden` driven by a `data-wp-watch` callback.
- Echo seeded "Searching…" copy through the results-count block via SSR.
- Pre-hide `no-results`, `search-error`, and `load-more` on first paint.
- Skeleton CSS with shimmer (respects `prefers-reduced-motion`) in the two affected block stylesheets.

## Related product discussion/links

* [Linear RSM-272](https://linear.app/a8c/issue/RSM-272/search-30-reconcile-loading-indicators-between-search-results-and-load)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Enable the search-blocks feature on a Jetpack-Search-active site:
   ```php
   add_filter( 'jetpack_search_blocks_enabled', '__return_true' );
   ```
2. Open the search-blocks template (FSE site editor → Templates → "Jetpack Search Results") and confirm the layout has at least one filter-checkbox in the sidebar and the search-results block in the main column.
3. In Chrome DevTools, throttle the network to "Slow 3G" (or check "Disable JavaScript" temporarily), then load `/?s=<some-term>`. Without the PR you should see a blank results column and a sidebar collapsed to just its heading. With the PR you should see four skeleton result rows, four skeleton filter rows under the heading, and a "Searching…" status above the results.
4. Reload normally — the skeletons should disappear cleanly as soon as the first fetch resolves; subsequent searches should NOT re-show the skeletons (they only appear on the very first load).
5. Visit a bare `/?s=` (no query) and confirm: no skeleton rows, no `Searching…` text, and the empty filter sections are still PHP-hidden.
6. Try a query that returns zero results — `no-results` should appear once the fetch resolves and `load-more` should never appear.
7. With `prefers-reduced-motion: reduce` enabled in the OS, the skeleton shimmer should freeze.