### PR TITLE
Search blocks: allow Post Type Scope inside Filters container

### DIFF
--- a/projects/packages/search/changelog/update-search-blocks-allow-post-type-filter-in-common-filters
+++ b/projects/packages/search/changelog/update-search-blocks-allow-post-type-filter-in-common-filters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search Blocks: allow the Post Type Scope block to be inserted inside the Filters container.

--- a/projects/packages/search/src/search-blocks/blocks/common-filters/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/common-filters/edit.js
@@ -17,7 +17,12 @@ const TEMPLATE = [
 	[ 'jetpack/filter-date', { interval: 'year' } ],
 ];
 
-const ALLOWED = [ 'jetpack/active-filters', 'jetpack/filter-checkbox', 'jetpack/filter-date' ];
+const ALLOWED = [
+	'jetpack/active-filters',
+	'jetpack/filter-checkbox',
+	'jetpack/filter-date',
+	'jetpack/post-type-filter',
+];
 
 /**
  * Edit component for the common-filters block.

--- a/projects/packages/search/src/search-blocks/blocks/common-filters/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/common-filters/edit.js
@@ -15,6 +15,7 @@ const TEMPLATE = [
 	[ 'jetpack/filter-checkbox', { filterType: 'author' } ],
 	[ 'jetpack/filter-checkbox', { filterType: 'post_type' } ],
 	[ 'jetpack/filter-date', { interval: 'year' } ],
+	[ 'jetpack/post-type-filter' ],
 ];
 
 const ALLOWED = [

--- a/projects/packages/search/src/search-blocks/blocks/filter-popover/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-popover/edit.js
@@ -14,7 +14,7 @@ const TEMPLATE = [
 	[ 'jetpack/filter-checkbox', { filterType: 'post_type' } ],
 ];
 
-const ALLOWED = [ 'jetpack/filter-checkbox', 'jetpack/active-filters' ];
+const ALLOWED = [ 'jetpack/filter-checkbox', 'jetpack/active-filters', 'jetpack/post-type-filter' ];
 
 /**
  * Edit component for the filter-popover block.

--- a/projects/packages/search/src/search-blocks/patterns/blog-search.php
+++ b/projects/packages/search/src/search-blocks/patterns/blog-search.php
@@ -55,6 +55,7 @@ register_block_pattern(
 <!-- wp:jetpack/filter-checkbox {"filterType":"taxonomy","taxonomy":"category"} /-->
 <!-- wp:jetpack/filter-checkbox {"filterType":"taxonomy","taxonomy":"post_tag"} /-->
 <!-- wp:jetpack/filter-checkbox {"filterType":"post_type"} /-->
+<!-- wp:jetpack/post-type-filter /-->
 </div>
 <!-- /wp:column -->
 

--- a/projects/packages/search/src/search-blocks/patterns/compact-search.php
+++ b/projects/packages/search/src/search-blocks/patterns/compact-search.php
@@ -33,6 +33,7 @@ register_block_pattern(
 <!-- wp:jetpack/filter-checkbox {"filterType":"taxonomy","taxonomy":"category"} /-->
 <!-- wp:jetpack/filter-checkbox {"filterType":"taxonomy","taxonomy":"post_tag"} /-->
 <!-- wp:jetpack/filter-checkbox {"filterType":"post_type"} /-->
+<!-- wp:jetpack/post-type-filter /-->
 <!-- /wp:jetpack/filter-popover -->
 <!-- wp:jetpack/sort-control {"displayAs":"popover"} /-->
 </div>

--- a/projects/packages/search/tests/js/search-blocks/common-filters-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/common-filters-edit.test.jsx
@@ -24,11 +24,13 @@ describe( 'CommonFiltersEdit', () => {
 			[ 'jetpack/filter-checkbox', { filterType: 'author' } ],
 			[ 'jetpack/filter-checkbox', { filterType: 'post_type' } ],
 			[ 'jetpack/filter-date', { interval: 'year' } ],
+			[ 'jetpack/post-type-filter' ],
 		] );
 		expect( props.allowedBlocks ).toEqual( [
 			'jetpack/active-filters',
 			'jetpack/filter-checkbox',
 			'jetpack/filter-date',
+			'jetpack/post-type-filter',
 		] );
 	} );
 } );


### PR DESCRIPTION
Fixes #

A site owner running a multi-CPT site (blog posts + WooCommerce products + a documentation CPT, say) might want a Filters sidebar — or the Filters popover in the Compact Search pattern — that only searches blog content. Until now, "exclude products from this sidebar" meant a trip to Customberg or a snippet in the theme. After this PR, the **Post Type Scope** block is reachable from inside both the **Filters** container and the **filter-popover**, and is pre-seeded into the default templates plus the two built-in patterns (Blog Search Page and Compact Search) so authors discover it without knowing to reach for the inserter for a hidden constraint.

The Post Type Scope block itself shipped in #48501; it just wasn't reachable from inside Filters or filter-popover (their `allowedBlocks` lists didn't include it) and wasn't surfaced in the default templates or patterns.

## Proposed changes

* `common-filters/edit.js`: add `jetpack/post-type-filter` to `allowedBlocks`, and append it to the default `TEMPLATE` so it's pre-seeded when authors insert a new Filters container.
* `filter-popover/edit.js`: add `jetpack/post-type-filter` to `allowedBlocks` (the popover's `TEMPLATE` is intentionally left lean — the seed comes from the Compact Search pattern below).
* `patterns/blog-search.php`: append `jetpack/post-type-filter` to the sidebar filter list.
* `patterns/compact-search.php`: append `jetpack/post-type-filter` inside the `filter-popover`.

The block's defaults (`mode=exclude`, `postTypes=[]`) make it a no-op until the author configures it, so existing Filters / popover instances and the built-in patterns are unchanged on the front end.

## Related product discussion/links

* Linear: [RSM-2115](https://linear.app/a8c/issue/RSM-2115/new-block-search-excluded-post-types-constraint-inner-block-of-common)
* Parent epic: [RSM-2114](https://linear.app/a8c/issue/RSM-2114)
* Block introduced in: #48501
* Filters container introduced in: #48478
* Related: [SEARCH-145](https://linear.app/a8c/issue/SEARCH-145/surface-excluded-post-types-outside-customberg)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. `jp build search --deps` so the block editor picks up the updated `common-filters` / `filter-popover` definitions and the patterns refresh.
2. **Filters container (`common-filters`):**
   - Insert a new **Filters** block in any post / page. Confirm the seeded inner blocks now end with **Post Type Scope**.
   - Inside an existing Filters block, click the `+` inserter — **Post Type Scope** should appear alongside Active Filters / Filter Checkbox / Filter Date.
3. **Filter popover (`filter-popover`):**
   - Inside an existing Filter Popover block, click the `+` inserter — **Post Type Scope** should now appear alongside Filter Checkbox / Active Filters.
4. **Patterns:**
   - Insert the **Blog Search Page** pattern. Confirm the sidebar now ends with a **Post Type Scope** block.
   - Insert the **Compact Search** pattern. Open the filter-popover entry and confirm the inner list ends with a **Post Type Scope** block.
5. **Behavior:**
   - Pick a Post Type Scope block, set Mode = `Exclude`, choose at least one searchable post type. Save and view the front end. The block itself should render nothing visible. Submit a search and confirm the excluded post type is dropped from results, and the Post Type filter-checkbox aggregation no longer lists it.
   - Flip Mode to `Include only` and pick a single post type — only that post type should come back in results.
   - Remove the Post Type Scope block; behavior should be identical to today's container / popover (no regression).