### PR TITLE
Search blocks: clear is_initial_loading() memo between PHPUnit tests

### DIFF
--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -49,6 +49,18 @@ class Search_Blocks {
 	const SEARCH_TEMPLATE_SLUG = 'jetpack-search';
 
 	/**
+	 * Per-request memo backing `is_initial_loading()`. Lifted out of the
+	 * method's local `static` so tests can clear it between cases via
+	 * `reset_initial_loading_cache()` — function-local statics aren't
+	 * reachable from outside the function, so they'd otherwise leak the
+	 * first test's URL state into every subsequent test in the same
+	 * PHPUnit process.
+	 *
+	 * @var bool|null
+	 */
+	private static $is_initial_loading_cache = null;
+
+	/**
 	 * Register block types and hook into WordPress.
 	 *
 	 * The caller (Initializer) is responsible for gating this behind the
@@ -638,21 +650,39 @@ class Search_Blocks {
 		// helper is hit by every block render.php (one per filter block plus
 		// search-results, results-count, etc.) AND by `build_initial_state()`,
 		// each of which would otherwise re-parse `$_GET` independently.
-		static $cached = null;
-		if ( null !== $cached ) {
-			return $cached;
+		if ( null !== self::$is_initial_loading_cache ) {
+			return self::$is_initial_loading_cache;
 		}
 		$search_query = static::parse_url_search_query();
 		if ( '' !== $search_query ) {
-			$cached = true;
+			self::$is_initial_loading_cache = true;
 			return true;
 		}
 		if ( ! empty( static::parse_url_filters() ) ) {
-			$cached = true;
+			self::$is_initial_loading_cache = true;
 			return true;
 		}
-		$cached = null !== static::parse_url_price_range();
-		return $cached;
+		self::$is_initial_loading_cache = null !== static::parse_url_price_range();
+		return self::$is_initial_loading_cache;
+	}
+
+	/**
+	 * Reset the `is_initial_loading()` memo. Test-only — production WP runs
+	 * a single request per process, so the memo never needs clearing there.
+	 * The PHPUnit harness reuses one process across every test method, so
+	 * without this hook a `$_GET` set by an earlier test would pin the
+	 * memoized value and silently override later tests' URL fixtures.
+	 *
+	 * Guarded so a misconfigured production caller can't accidentally drop
+	 * the cache mid-request: bail when running under WordPress (`ABSPATH`
+	 * defined) but not under PHPUnit (`PHPUNIT_COMPOSER_INSTALL` is set by
+	 * PHPUnit's composer-installed autoloader).
+	 */
+	public static function reset_initial_loading_cache(): void {
+		if ( defined( 'ABSPATH' ) && ! defined( 'PHPUNIT_COMPOSER_INSTALL' ) ) {
+			return;
+		}
+		self::$is_initial_loading_cache = null;
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -15,6 +15,18 @@ use PHPUnit\Framework\TestCase;
 class Search_Blocks_Test extends TestCase {
 
 	/**
+	 * Clear `Search_Blocks::is_initial_loading()`'s per-request memo between
+	 * tests. PHPUnit runs every test in a single process, so without this
+	 * the first test that exercises a query/filter/price URL would pin the
+	 * cached value and every later test that sets `$_GET` would silently
+	 * read stale state.
+	 */
+	protected function tearDown(): void {
+		Search_Blocks::reset_initial_loading_cache();
+		parent::tearDown();
+	}
+
+	/**
 	 * Verify that the keys required by the Interactivity API store are present.
 	 */
 	public function test_build_initial_state_shape() {


### PR DESCRIPTION
The helper memoized URL-derived state in a function-local `static`, which persisted across test methods in PHPUnit's single-process run and pinned the first test's $_GET state for every later test. Lift the cache to a class property and add a guarded reset hook called from Search_Blocks_Test::tearDown().

Fixes #

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* 

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Go to '..'
*
