### PR TITLE
Fatal error screen: log Enter recovery mode clicks

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-wpcomsh-fatal-recovery-click-log
+++ b/projects/plugins/wpcomsh/changelog/add-wpcomsh-fatal-recovery-click-log
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Fatal error screen: log when an admin clicks Enter recovery mode.

--- a/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-helpers.php
+++ b/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-helpers.php
@@ -170,13 +170,7 @@ function wpcomsh_fatal_log_event( $plugin, $message ) {
 		return;
 	}
 
-	$signature = wpcom_build_fatal_error_signature(
-		array(
-			'kind'    => (string) $plugin['kind'],
-			'slug'    => (string) $plugin['slug'],
-			'version' => isset( $plugin['version'] ) ? (string) $plugin['version'] : '',
-		)
-	);
+	$signature = wpcom_build_fatal_error_signature( wpcomsh_fatal_normalize_plugin_parts( $plugin ) );
 	if ( null === $signature ) {
 		return;
 	}
@@ -299,43 +293,167 @@ function wpcomsh_fatal_classify_plugin_path( $abs_file ) {
 }
 
 /**
+ * Coerce a plugin-info array (or null) into the canonical kind/slug/version
+ * triple, with missing keys defaulting to ''. Used wherever we need to feed
+ * those three fields into a signature, log, or template — so the empty-key
+ * handling stays in one place.
+ *
+ * @param array|null $plugin Extension info from wpcomsh_fatal_identify_plugin(), or null.
+ * @return array{kind:string,slug:string,version:string}
+ */
+function wpcomsh_fatal_normalize_plugin_parts( $plugin ) {
+	$plugin = is_array( $plugin ) ? $plugin : array();
+	return array(
+		'kind'    => isset( $plugin['kind'] ) ? (string) $plugin['kind'] : '',
+		'slug'    => isset( $plugin['slug'] ) ? (string) $plugin['slug'] : '',
+		'version' => isset( $plugin['version'] ) ? (string) $plugin['version'] : '',
+	);
+}
+
+/**
+ * Map an extension kind to the recovery-mode capability that gates it.
+ * Theme-origin fatals need `resume_themes`; everything else (plugins,
+ * mu-plugins, unknown) needs `resume_plugins`.
+ *
+ * @param string $kind Extension kind from wpcomsh_fatal_identify_plugin().
+ * @return string Core capability slug.
+ */
+function wpcomsh_fatal_recovery_cap_for_kind( $kind ) {
+	return 'themes' === $kind ? 'resume_themes' : 'resume_plugins';
+}
+
+/**
+ * Sign a payload bound to the current logged-in session.
+ *
+ * The HMAC covers `parts | exp | logged_in_cookie`, using AUTH_SALT. Binding
+ * to the cookie means a leaked URL/form can't be replayed across sessions
+ * (or after the admin logs out), and can't be forged without AUTH_SALT.
+ *
+ * Returns '' when prerequisites are missing (no AUTH_SALT, no cookie); the
+ * caller treats that as "can't sign right now" and skips rendering.
+ *
+ * Centralized here so the sign + verify sides can't diverge on payload
+ * shape — every part list passed in is the canonical input to the matching
+ * `wpcomsh_fatal_verify_signed_payload()` call.
+ *
+ * Cookie-host implication: the HMAC verifies only on requests where
+ * LOGGED_IN_COOKIE is sent. On installs where WP_SITEURL and WP_HOME are on
+ * different hosts (and no explicit COOKIE_DOMAIN is set), that cookie is
+ * host-only to wherever wp-login.php lives. Wrapper URLs/forms must target
+ * site_url(), not home_url(), or the verifier silently fails.
+ *
+ * @param string[] $parts Ordered string parts to bind into the signature.
+ * @param int      $exp   Absolute unix timestamp at which the signature expires.
+ * @return string Lowercase hex sha256 HMAC, or '' when unavailable.
+ */
+function wpcomsh_fatal_sign_payload( array $parts, $exp ) {
+	if ( ! defined( 'AUTH_SALT' ) || ! defined( 'LOGGED_IN_COOKIE' ) ) {
+		return '';
+	}
+	if ( empty( $_COOKIE[ LOGGED_IN_COOKIE ] ) ) {
+		return '';
+	}
+	// Per-session secret inside an HMAC we never output; needs the exact
+	// byte-for-byte cookie value to match at verify time.
+	$cookie_value = (string) wp_unslash( $_COOKIE[ LOGGED_IN_COOKIE ] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+	$payload      = implode( '|', array_merge( $parts, array( (string) (int) $exp, $cookie_value ) ) );
+	return hash_hmac( 'sha256', $payload, (string) AUTH_SALT );
+}
+
+/**
+ * Verify an HMAC produced by wpcomsh_fatal_sign_payload().
+ *
+ * Bootstraps cookie constants because the signed-URL endpoints run at
+ * mu-plugin load time, before wp-settings.php defines them. Returns false on
+ * any failure — missing AUTH_SALT/cookie, expired timestamp, or HMAC
+ * mismatch — so callers can `if ( ! verify(...) ) return;` as a single gate.
+ *
+ * @param string   $sig   Signature from the request.
+ * @param string[] $parts Ordered string parts the URL claims to have signed.
+ * @param int      $exp   Expiry timestamp from the request.
+ * @return bool True iff the signature is valid for this session and unexpired.
+ */
+function wpcomsh_fatal_verify_signed_payload( $sig, array $parts, $exp ) {
+	if ( ! is_string( $sig ) || '' === $sig || (int) $exp < time() ) {
+		return false;
+	}
+	if ( ! defined( 'LOGGED_IN_COOKIE' ) && function_exists( 'wp_cookie_constants' ) ) {
+		wp_cookie_constants();
+	}
+	$expected = wpcomsh_fatal_sign_payload( $parts, (int) $exp );
+	return '' !== $expected && hash_equals( $expected, $sig );
+}
+
+/**
  * Build the form action + signed fields the fatal-plugin-deactivator endpoint
  * validates, without relying on pluggable functions or WP nonces.
  *
- * Signature: HMAC over (plugin, expiry, logged_in cookie) using AUTH_SALT.
- * Binding to the cookie ensures the request can't be replayed by another
- * user or after the admin logs out, and can't be forged without AUTH_SALT.
- *
  * Returned as form fields (rather than a signed URL) so the screen can submit
  * via POST — destructive actions should not live in a GET-able link.
+ *
+ * Posts to site_url() (admin/login host); see wpcomsh_fatal_sign_payload()
+ * for the cookie-host rationale.
  *
  * @param string $plugin_basename Plugin file relative to WP_PLUGIN_DIR (e.g. "akismet/akismet.php").
  * @return array{action:string,fields:array<string,string>}|null Form data, or null when prerequisites are missing.
  */
 function wpcomsh_fatal_build_deactivate_form( $plugin_basename ) {
-	if ( ! defined( 'AUTH_SALT' ) || ! defined( 'LOGGED_IN_COOKIE' ) ) {
+	$exp = time() + 5 * MINUTE_IN_SECONDS;
+	$sig = wpcomsh_fatal_sign_payload( array( $plugin_basename ), $exp );
+	if ( '' === $sig ) {
 		return null;
 	}
-	if ( empty( $_COOKIE[ LOGGED_IN_COOKIE ] ) ) {
-		return null;
-	}
-	// The cookie is used only as a per-session secret inside an HMAC we
-	// never output, so sanitization is irrelevant here — we need its exact
-	// byte-for-byte value to match at verification time.
-	$cookie_value = (string) wp_unslash( $_COOKIE[ LOGGED_IN_COOKIE ] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-	$exp          = time() + 5 * MINUTE_IN_SECONDS;
-	$sig          = hash_hmac(
-		'sha256',
-		$plugin_basename . '|' . $exp . '|' . $cookie_value,
-		(string) AUTH_SALT
-	);
 	return array(
-		'action' => home_url( '/' ),
+		'action' => site_url( '/' ),
 		'fields' => array(
 			'wpcomsh_deactivate' => $plugin_basename,
 			'wpcomsh_exp'        => (string) $exp,
 			'wpcomsh_sig'        => $sig,
 		),
+	);
+}
+
+/**
+ * Build the wrapper URL the fatal screen renders for "Enter recovery mode".
+ *
+ * The link doesn't point at core's recovery URL directly. It points at a
+ * signed `site_url('/')` query that fatal-recovery-click.php intercepts at
+ * mu-plugin load time so we can log the click and *then* mint a fresh
+ * recovery URL on the redirect. Plugin metadata is embedded so the click
+ * endpoint can emit a per-extension signature event without re-identifying
+ * from disk.
+ *
+ * Targets site_url() (admin/login host); see wpcomsh_fatal_sign_payload()
+ * for the cookie-host rationale.
+ *
+ * Returns '' when prerequisites are missing (multisite, no cookie, no
+ * AUTH_SALT) — the template treats '' as "hide the link".
+ *
+ * @param array|null $plugin Extension info from wpcomsh_fatal_identify_plugin(), or null.
+ * @return string Wrapper URL, or '' when unavailable.
+ */
+function wpcomsh_fatal_build_recovery_link( $plugin ) {
+	if ( is_multisite() ) {
+		return '';
+	}
+	$parts = wpcomsh_fatal_normalize_plugin_parts( $plugin );
+	// Day-long TTL: navigation-only action; further bounded by LOGGED_IN_COOKIE.
+	$exp = time() + DAY_IN_SECONDS;
+	$sig = wpcomsh_fatal_sign_payload( array_values( $parts ), $exp );
+	if ( '' === $sig ) {
+		return '';
+	}
+
+	return add_query_arg(
+		array(
+			'wpcomsh_recovery'      => '1',
+			'wpcomsh_recovery_kind' => $parts['kind'],
+			'wpcomsh_recovery_slug' => $parts['slug'],
+			'wpcomsh_recovery_ver'  => $parts['version'],
+			'wpcomsh_recovery_exp'  => (string) $exp,
+			'wpcomsh_recovery_sig'  => $sig,
+		),
+		site_url( '/' )
 	);
 }
 

--- a/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-screen.php
+++ b/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-error-screen.php
@@ -33,7 +33,7 @@ function wpcomsh_customize_fatal_error_message( $message, $error = array() ) { /
 	$is_admin = $user_id && user_can( $user_id, 'manage_options' );
 
 	// Identify only when used: admins need $plugin for the rendered
-	// notice; the anonymous path identifies once per (file, 5-min) for
+	// notice; the anonymous path identifies once per (file, hour) for
 	// telemetry. Signature-level dedup downstream catches duplicates
 	// this gate misses.
 	$plugin = null;
@@ -46,7 +46,7 @@ function wpcomsh_customize_fatal_error_message( $message, $error = array() ) { /
 		$do_log     = true;
 
 		try {
-			$do_log = wp_cache_add( $coarse_key, 1, 'wpcomsh', 5 * MINUTE_IN_SECONDS );
+			$do_log = wp_cache_add( $coarse_key, 1, 'wpcomsh', HOUR_IN_SECONDS );
 		} catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- fail open: a cache failure should not silence telemetry.
 			// Fail open.
 		}
@@ -104,12 +104,7 @@ function wpcomsh_fatal_build_render_context( $error, $plugin = null, $user_id = 
 		&& ! empty( $plugin['basename'] )
 		&& user_can( $user_id, 'deactivate_plugin', $plugin['basename'] );
 
-	// Recovery-mode capability depends on the kind of extension that
-	// fataled: a theme-origin fatal needs `resume_themes`, everything
-	// else (plugins, mu-plugins, unknown) needs `resume_plugins`.
-	$recover_cap = ( $plugin && 'themes' === $plugin['kind'] )
-		? 'resume_themes'
-		: 'resume_plugins';
+	$recover_cap = wpcomsh_fatal_recovery_cap_for_kind( $plugin ? (string) $plugin['kind'] : '' );
 	$can_recover = $user_id && user_can( $user_id, $recover_cap );
 
 	return array(
@@ -117,7 +112,7 @@ function wpcomsh_fatal_build_render_context( $error, $plugin = null, $user_id = 
 		'plugin'          => $plugin,
 		'error_message'   => $is_admin ? (string) ( $error['message'] ?? '' ) : '',
 		'deactivate_form' => $can_deactivate ? wpcomsh_fatal_build_deactivate_form( $plugin['basename'] ) : null,
-		'recovery_url'    => $can_recover ? wpcomsh_fatal_build_recovery_url() : '',
+		'recovery_url'    => $can_recover ? wpcomsh_fatal_build_recovery_link( $plugin ) : '',
 		'support_url'     => 'https://wordpress.com/help/contact',
 		'environment'     => $is_admin ? wpcomsh_fatal_get_environment_lines() : array(),
 	);

--- a/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-plugin-deactivator.php
+++ b/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-plugin-deactivator.php
@@ -31,53 +31,23 @@
  */
 function wpcomsh_fatal_maybe_deactivate_plugin() {
 	// Nonces aren't usable in this endpoint (pluggable.php hasn't loaded yet);
-	// we validate an HMAC signature below instead. The early-return check only
-	// reads the parameter *presence* — actual values are validated after.
-	// phpcs:ignore WordPress.Security.NonceVerification.Missing
+	// wpcomsh_fatal_verify_signed_payload() validates an HMAC signature below
+	// instead. Inputs are sanitized / cast / regex-constrained before trust.
+	// phpcs:disable WordPress.Security.NonceVerification.Missing
 	if ( empty( $_POST['wpcomsh_deactivate'] ) || empty( $_POST['wpcomsh_sig'] ) || empty( $_POST['wpcomsh_exp'] ) ) {
 		return;
 	}
-	if ( ! defined( 'AUTH_SALT' ) ) {
-		return;
-	}
-	// Cookie constants (LOGGED_IN_COOKIE etc.) are defined later in wp-settings.php
-	// — between muplugins_loaded and active_plugins iteration. At mu-plugin load
-	// time they don't exist yet, but wp_cookie_constants() is already available.
-	if ( ! defined( 'LOGGED_IN_COOKIE' ) && function_exists( 'wp_cookie_constants' ) ) {
-		wp_cookie_constants();
-	}
-	if ( ! defined( 'LOGGED_IN_COOKIE' ) ) {
-		return;
-	}
-
-	// Nonces aren't usable here because pluggable.php hasn't loaded yet — we
-	// validate an HMAC signature below instead. Inputs are constrained by
-	// regex / cast to int before being trusted.
-	// phpcs:disable WordPress.Security.NonceVerification.Missing
 	$plugin = isset( $_POST['wpcomsh_deactivate'] ) ? sanitize_text_field( wp_unslash( $_POST['wpcomsh_deactivate'] ) ) : '';
 	$sig    = isset( $_POST['wpcomsh_sig'] ) ? sanitize_text_field( wp_unslash( $_POST['wpcomsh_sig'] ) ) : '';
 	$exp    = isset( $_POST['wpcomsh_exp'] ) ? (int) $_POST['wpcomsh_exp'] : 0;
 	// phpcs:enable WordPress.Security.NonceVerification.Missing
 
-	// Reject expired or malformed plugin paths (no traversal; slug/file.php only).
-	if ( $exp < time() ) {
-		return;
-	}
+	// Constrain plugin paths to "slug/file.php" — no traversal, no nested dirs.
 	if ( ! preg_match( '#^[a-zA-Z0-9][a-zA-Z0-9_.-]*/[a-zA-Z0-9][a-zA-Z0-9_.-]*\.php$#', $plugin ) ) {
 		return;
 	}
 
-	// The cookie is used only as a per-session secret inside an HMAC we
-	// never output; sanitization would destroy the byte-for-byte match.
-	$cookie_value = isset( $_COOKIE[ LOGGED_IN_COOKIE ] )
-		? (string) wp_unslash( $_COOKIE[ LOGGED_IN_COOKIE ] ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		: '';
-	if ( '' === $cookie_value ) {
-		return;
-	}
-
-	$expected = hash_hmac( 'sha256', $plugin . '|' . $exp . '|' . $cookie_value, (string) AUTH_SALT );
-	if ( ! hash_equals( $expected, $sig ) ) {
+	if ( ! wpcomsh_fatal_verify_signed_payload( $sig, array( $plugin ), $exp ) ) {
 		return;
 	}
 

--- a/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-recovery-click.php
+++ b/projects/plugins/wpcomsh/wpcom-fatal-error/fatal-recovery-click.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Logging endpoint for the "Enter recovery mode" link on the fatal-error screen.
+ *
+ * The screen renders a signed wrapper URL (built by
+ * wpcomsh_fatal_build_recovery_link()) instead of pointing at core's recovery
+ * URL directly. Clicking it lands here. We:
+ *
+ *   1) Validate the HMAC-signed URL.
+ *   2) Emit `wpcomsh_fatal_recovery_click` so we can measure how often admins
+ *      reach for recovery mode for a given extension.
+ *   3) Mint a fresh recovery URL and redirect.
+ *
+ * Runs at mu-plugin load time so the still-fataling site never finishes
+ * loading — same constraint as fatal-plugin-deactivator.php. If the recovery
+ * URL can't be minted (multisite, link service throws), we return without
+ * redirecting and let the request fall through to the regular fatal screen.
+ *
+ * Security: see wpcomsh_fatal_verify_signed_payload() for the HMAC contract;
+ * the handler additionally gates on core's per-extension recovery cap via
+ * user_can() once the user/cap stack is bootstrapped.
+ *
+ * @package wpcomsh
+ */
+
+/**
+ * Validate the request and, if trusted, log the click and redirect to a
+ * freshly-generated recovery URL before the regular plugin-load pass runs.
+ *
+ * @return void
+ */
+function wpcomsh_fatal_maybe_handle_recovery_click() {
+	// Nonces aren't usable in this endpoint (pluggable.php hasn't loaded yet);
+	// wpcomsh_fatal_verify_signed_payload() validates an HMAC signature below
+	// instead. Inputs are sanitized / cast before trust.
+	// phpcs:disable WordPress.Security.NonceVerification.Recommended
+	if ( empty( $_GET['wpcomsh_recovery'] ) ) {
+		return;
+	}
+
+	$sig  = isset( $_GET['wpcomsh_recovery_sig'] ) ? sanitize_text_field( wp_unslash( $_GET['wpcomsh_recovery_sig'] ) ) : '';
+	$exp  = isset( $_GET['wpcomsh_recovery_exp'] ) ? (int) $_GET['wpcomsh_recovery_exp'] : 0;
+	$kind = isset( $_GET['wpcomsh_recovery_kind'] ) ? sanitize_text_field( wp_unslash( $_GET['wpcomsh_recovery_kind'] ) ) : '';
+	$slug = isset( $_GET['wpcomsh_recovery_slug'] ) ? sanitize_text_field( wp_unslash( $_GET['wpcomsh_recovery_slug'] ) ) : '';
+	$ver  = isset( $_GET['wpcomsh_recovery_ver'] ) ? sanitize_text_field( wp_unslash( $_GET['wpcomsh_recovery_ver'] ) ) : '';
+	// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+	if ( ! wpcomsh_fatal_verify_signed_payload( $sig, array( $kind, $slug, $ver ), $exp ) ) {
+		return;
+	}
+
+	// HMAC proves the URL came from a screen we rendered to the same
+	// authenticated session, but we still want core's per-extension recovery
+	// gate.
+	$user_id = wpcomsh_fatal_current_user_id();
+	if ( ! $user_id || ! user_can( $user_id, wpcomsh_fatal_recovery_cap_for_kind( $kind ) ) ) {
+		return;
+	}
+
+	if ( '' !== $kind && '' !== $slug ) {
+		wpcomsh_fatal_log_event(
+			array(
+				'kind'    => $kind,
+				'slug'    => $slug,
+				'version' => $ver,
+			),
+			'wpcomsh_fatal_recovery_click'
+		);
+	}
+
+	$recovery_url = wpcomsh_fatal_build_recovery_url();
+	if ( '' === $recovery_url ) {
+		return;
+	}
+
+	// wp_redirect (not wp_safe_redirect): URL minted locally above by core's
+	// recovery-mode service; safe-redirect's home-host allowlist would reject
+	// it on split SITEURL/HOME installs and bounce the admin back into the fatal.
+	wp_redirect( $recovery_url ); // phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
+	exit;
+}
+
+wpcomsh_fatal_maybe_handle_recovery_click();

--- a/projects/plugins/wpcomsh/wpcom-fatal-error/load.php
+++ b/projects/plugins/wpcomsh/wpcom-fatal-error/load.php
@@ -13,6 +13,9 @@
  *                                 the admin notification copy.
  *   fatal-plugin-deactivator.php  Early-running endpoint that honors the
  *                                 signed deactivation URL the screen renders.
+ *   fatal-recovery-click.php      Early-running endpoint that logs the
+ *                                 "Enter recovery mode" click and redirects
+ *                                 to a freshly-minted core recovery URL.
  *
  * @package wpcomsh
  */
@@ -22,3 +25,4 @@ require_once __DIR__ . '/fatal-error-helpers.php';
 require_once __DIR__ . '/fatal-error-screen.php';
 require_once __DIR__ . '/fatal-error-email.php';
 require_once __DIR__ . '/fatal-plugin-deactivator.php';
+require_once __DIR__ . '/fatal-recovery-click.php';


### PR DESCRIPTION
## Summary
- Add click telemetry for the **"Enter recovery mode"** link on the fatal-error screen: the link now points at a signed wrapper that an mu-plugin endpoint intercepts, emits a `wpcomsh_fatal_recovery_click` log, then redirects to a freshly-minted core recovery URL.
- Bump the anonymous file-dedup cache window from 5 min → 1 hour (downstream signature dedup still applies).
- Target `site_url()` on the deactivate form action and the new recovery wrapper so they reach the `LOGGED_IN_COOKIE` host on split `SITEURL`/`HOME` installs — otherwise the HMAC silently fails verification.
- Internal cleanup: extracted shared `wpcomsh_fatal_sign_payload()` / `wpcomsh_fatal_verify_signed_payload()` helpers and routed the existing deactivator through them so the sign + verify sides can't diverge on payload shape. Also added small `normalize_plugin_parts()` and `recovery_cap_for_kind()` helpers used in two call sites each.

## Test plan
- [ ] Force a fatal on a non-multisite test site as an admin → fatal screen renders. Click **Enter recovery mode** → lands in recovery mode, and a `wpcomsh_fatal_recovery_click` row arrives in logstash.
- [ ] Same fatal as a non-admin / anonymous → minimal public view, no Enter recovery link.
- [ ] Anonymous visit to the same fataling file twice within an hour → only one telemetry row (was 5 min).
- [ ] Leave the fatal screen open > 5 min, then click recovery → still works (wrapper TTL is now a day; previously 5 min would have rejected).
- [ ] On a split-host install (`WP_HOME` ≠ `WP_SITEURL`), verify both recovery click and plugin deactivation succeed end-to-end.
- [ ] Existing deactivator flow still works after the helper refactor: clicking **Deactivate** on the fatal screen deactivates the plugin and redirects to `wp-admin/plugins.php`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)