### PR TITLE
Remove translation functions from product names; Boost, Protect, CR

### DIFF
--- a/projects/plugins/boost/app/admin/class-admin.php
+++ b/projects/plugins/boost/app/admin/class-admin.php
@@ -49,7 +49,7 @@ class Admin {
 		}
 
 		$page_suffix = Admin_Menu::add_menu(
-			'Jetpack Boost - Settings', // "Jetpack Boost" is a product name, do not translate.
+			__( 'Jetpack Boost - Settings', 'jetpack-boost' ),
 			$menu_label,
 			'manage_options',
 			JETPACK_BOOST_SLUG,

--- a/projects/plugins/boost/app/admin/class-admin.php
+++ b/projects/plugins/boost/app/admin/class-admin.php
@@ -43,13 +43,13 @@ class Admin {
 		 * @since   1.0.0
 		 */
 		$total_problems = apply_filters( 'jetpack_boost_total_problem_count', 0 );
-		$menu_label     = _x( 'Boost', 'The Jetpack Boost product name, without the Jetpack prefix', 'jetpack-boost' );
+		$menu_label     = 'Boost'; // "Boost" is a product name, do not translate.
 		if ( $total_problems ) {
 			$menu_label .= sprintf( ' <span class="menu-counter count-%d"><span class="count">%d</span></span>', $total_problems, $total_problems );
 		}
 
 		$page_suffix = Admin_Menu::add_menu(
-			__( 'Jetpack Boost - Settings', 'jetpack-boost' ),
+			'Jetpack Boost - Settings', // "Jetpack Boost" is a product name, do not translate.
 			$menu_label,
 			'manage_options',
 			JETPACK_BOOST_SLUG,

--- a/projects/plugins/boost/changelog/update-untranslate-product-names
+++ b/projects/plugins/boost/changelog/update-untranslate-product-names
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Boost: Remove translation wrappers from the "Boost" product name.

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
@@ -7,7 +7,7 @@ import {
 import { BoostScoreBar, getRedirectUrl } from '@automattic/jetpack-components';
 import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { __, _x, sprintf } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import { useCallback, useEffect, useState } from 'react';
@@ -69,11 +69,8 @@ const DashBoost = ( {
 	// Don't show score bars until we know if they already have boost installed and activated, the site is online, and we have the scores.
 	const shouldShowScoreBars =
 		! hasBoost && ! isSiteOffline && ! fetchingPluginsData && ! isSpeedScoreError;
-	const pluginName = _x(
-		'Boost',
-		'The Jetpack Boost product name, without the Jetpack prefix',
-		'jetpack'
-	);
+	// "Boost" is a product name, do not translate.
+	const pluginName = 'Boost';
 
 	const setScoresFromCache = () => {
 		setMobileSpeedScore( latestSpeedScores.scores.mobile );

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/crm/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/crm/index.jsx
@@ -1,7 +1,7 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import PluginDashItem from 'components/plugin-dash-item';
@@ -19,11 +19,7 @@ class DashCRM extends Component {
 	render() {
 		return (
 			<PluginDashItem
-				pluginName={ _x(
-					'CRM',
-					'The Jetpack CRM product name, without the Jetpack prefix',
-					'jetpack'
-				) }
+				pluginName="CRM" /* "CRM" is a product name, do not translate. */
 				pluginFiles={ CRM_PLUGIN_FILES }
 				pluginSlug={ CRM_PLUGIN_SLUG }
 				pluginLink={ this.props.siteAdminUrl + CRM_PLUGIN_DASH }

--- a/projects/plugins/jetpack/changelog/update-untranslate-product-names
+++ b/projects/plugins/jetpack/changelog/update-untranslate-product-names
@@ -1,4 +1,4 @@
 Significance: patch
-Type: changed
+Type: other
 
 Remove translation wrappers from "Boost" and "CRM" product names in the at-a-glance dashboard.

--- a/projects/plugins/jetpack/changelog/update-untranslate-product-names
+++ b/projects/plugins/jetpack/changelog/update-untranslate-product-names
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove translation wrappers from "Boost" and "CRM" product names in the at-a-glance dashboard.

--- a/projects/plugins/protect/changelog/update-untranslate-product-names
+++ b/projects/plugins/protect/changelog/update-untranslate-product-names
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Protect: Remove translation wrappers from the "Protect" product name.

--- a/projects/plugins/protect/src/class-jetpack-protect.php
+++ b/projects/plugins/protect/src/class-jetpack-protect.php
@@ -150,13 +150,13 @@ class Jetpack_Protect {
 	 */
 	public function admin_page_init() {
 		$total_threats = Status::get_total_threats();
-		$menu_label    = _x( 'Protect', 'The Jetpack Protect product name, without the Jetpack prefix', 'jetpack-protect' );
+		$menu_label    = 'Protect'; // "Protect" is a product name, do not translate.
 		if ( $total_threats ) {
 			$menu_label .= sprintf( ' <span class="update-plugins">%d</span>', $total_threats );
 		}
 
 		$page_suffix = Admin_Menu::add_menu(
-			__( 'Jetpack Protect', 'jetpack-protect' ),
+			'Jetpack Protect', // "Jetpack Protect" is a product name, do not translate.
 			$menu_label,
 			'manage_options',
 			'jetpack-protect',


### PR DESCRIPTION

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Remove the translation function from Boost, Protect and CRM product names, which we don't translate. 

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*  See ref p1HpG7-wSr-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

*  N/A