### PR TITLE
Fix regression introduced in wpcomsh wp-php-toolkit dependencies

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-wpcomsh-restore-wp-php-toolkit-0.1.47
+++ b/projects/plugins/wpcomsh/changelog/fix-wpcomsh-restore-wp-php-toolkit-0.1.47
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fixed a regression added on https://github.com/Automattic/jetpack/pull/48286

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -18,8 +18,8 @@
 		"automattic/jetpack-mu-wpcom": "@dev",
 		"tubalmartin/cssmin": "^4.1",
 		"automattic/jetpack-explat": "@dev",
-		"wp-php-toolkit/reprint-exporter": "^0.1.44",
-		"wp-php-toolkit/reprint-importer": "^0.1.44"
+		"wp-php-toolkit/reprint-exporter": "^0.1.47",
+		"wp-php-toolkit/reprint-importer": "^0.1.47"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^4.0.0",

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5888fdf5b3ab632a0f07f80f5ca8dc17",
+    "content-hash": "92c91b9f92fa4ddc44de6deea3a1a051",
     "packages": [
         {
             "name": "automattic/at-pressable-podcasting",
@@ -3302,16 +3302,16 @@
         },
         {
             "name": "wp-php-toolkit/bytestream",
-            "version": "v0.5.1",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/bytestream.git",
-                "reference": "664b3f6930afcd057acd3eb92370ba99853858f0"
+                "reference": "bf3e28e6f6e51e7abeec16e3f8c3a096e0aa2a02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/bytestream/zipball/664b3f6930afcd057acd3eb92370ba99853858f0",
-                "reference": "664b3f6930afcd057acd3eb92370ba99853858f0",
+                "url": "https://api.github.com/repos/wp-php-toolkit/bytestream/zipball/bf3e28e6f6e51e7abeec16e3f8c3a096e0aa2a02",
+                "reference": "bf3e28e6f6e51e7abeec16e3f8c3a096e0aa2a02",
                 "shasum": ""
             },
             "require": {
@@ -3346,30 +3346,30 @@
             "description": "ByteStream component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/bytestream/issues",
-                "source": "https://github.com/wp-php-toolkit/bytestream/tree/v0.5.1"
+                "source": "https://github.com/wp-php-toolkit/bytestream/tree/v0.6.2"
             },
-            "time": "2025-09-11T23:53:08+00:00"
+            "time": "2026-04-10T20:16:27+00:00"
         },
         {
             "name": "wp-php-toolkit/data-liberation",
-            "version": "v0.5.1",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/data-liberation.git",
-                "reference": "b42d4b045a3a0b124ec361de3b5873d85c9bb549"
+                "reference": "3502454cd1c760b929329cb4f744ada6eb08ba73"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/data-liberation/zipball/b42d4b045a3a0b124ec361de3b5873d85c9bb549",
-                "reference": "b42d4b045a3a0b124ec361de3b5873d85c9bb549",
+                "url": "https://api.github.com/repos/wp-php-toolkit/data-liberation/zipball/3502454cd1c760b929329cb4f744ada6eb08ba73",
+                "reference": "3502454cd1c760b929329cb4f744ada6eb08ba73",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.5.1",
-                "wp-php-toolkit/filesystem": "^0.5.1",
-                "wp-php-toolkit/http-client": "^0.5.1",
-                "wp-php-toolkit/xml": "^0.5.1"
+                "wp-php-toolkit/bytestream": "^0.6.2",
+                "wp-php-toolkit/filesystem": "^0.6.2",
+                "wp-php-toolkit/http-client": "^0.6.2",
+                "wp-php-toolkit/xml": "^0.6.2"
             },
             "type": "library",
             "autoload": {
@@ -3401,22 +3401,22 @@
             "description": "Data Liberation component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/data-liberation/issues",
-                "source": "https://github.com/wp-php-toolkit/data-liberation/tree/v0.5.1"
+                "source": "https://github.com/wp-php-toolkit/data-liberation/tree/v0.6.2"
             },
-            "time": "2026-04-02T14:37:51+00:00"
+            "time": "2026-04-27T14:15:30+00:00"
         },
         {
             "name": "wp-php-toolkit/encoding",
-            "version": "v0.5.1",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/encoding.git",
-                "reference": "aafe834847cc45133836b0462f22fa1511eb3b5a"
+                "reference": "f814ff6cae957449baa16f7dabe840cca756db6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/encoding/zipball/aafe834847cc45133836b0462f22fa1511eb3b5a",
-                "reference": "aafe834847cc45133836b0462f22fa1511eb3b5a",
+                "url": "https://api.github.com/repos/wp-php-toolkit/encoding/zipball/f814ff6cae957449baa16f7dabe840cca756db6a",
+                "reference": "f814ff6cae957449baa16f7dabe840cca756db6a",
                 "shasum": ""
             },
             "require": {
@@ -3450,27 +3450,27 @@
             "description": "Encoding component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/encoding/issues",
-                "source": "https://github.com/wp-php-toolkit/encoding/tree/v0.5.1"
+                "source": "https://github.com/wp-php-toolkit/encoding/tree/v0.6.2"
             },
-            "time": "2025-11-20T12:04:55+00:00"
+            "time": "2026-04-10T20:16:27+00:00"
         },
         {
             "name": "wp-php-toolkit/filesystem",
-            "version": "v0.5.1",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/filesystem.git",
-                "reference": "900e4d8e1a8ef79e59e6efa52a1e0d46eb47e8e2"
+                "reference": "36c54d8007b949c98a9fc460914367bcdc9b778f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/filesystem/zipball/900e4d8e1a8ef79e59e6efa52a1e0d46eb47e8e2",
-                "reference": "900e4d8e1a8ef79e59e6efa52a1e0d46eb47e8e2",
+                "url": "https://api.github.com/repos/wp-php-toolkit/filesystem/zipball/36c54d8007b949c98a9fc460914367bcdc9b778f",
+                "reference": "36c54d8007b949c98a9fc460914367bcdc9b778f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.5.1"
+                "wp-php-toolkit/bytestream": "^0.6.2"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -3504,22 +3504,22 @@
             "description": "Filesystem component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/filesystem/issues",
-                "source": "https://github.com/wp-php-toolkit/filesystem/tree/v0.5.1"
+                "source": "https://github.com/wp-php-toolkit/filesystem/tree/v0.6.2"
             },
-            "time": "2026-04-02T14:37:51+00:00"
+            "time": "2026-04-27T14:15:30+00:00"
         },
         {
             "name": "wp-php-toolkit/html",
-            "version": "v0.5.1",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/html.git",
-                "reference": "7b3863dfd82d76bd9c54e6e10a3ba317110a6e92"
+                "reference": "d7dac562cdaff693d830ede7f35cf490a397678e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/html/zipball/7b3863dfd82d76bd9c54e6e10a3ba317110a6e92",
-                "reference": "7b3863dfd82d76bd9c54e6e10a3ba317110a6e92",
+                "url": "https://api.github.com/repos/wp-php-toolkit/html/zipball/d7dac562cdaff693d830ede7f35cf490a397678e",
+                "reference": "d7dac562cdaff693d830ede7f35cf490a397678e",
                 "shasum": ""
             },
             "require": {
@@ -3554,29 +3554,29 @@
             "description": "HTML component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/html/issues",
-                "source": "https://github.com/wp-php-toolkit/html/tree/v0.5.1"
+                "source": "https://github.com/wp-php-toolkit/html/tree/v0.6.2"
             },
-            "time": "2025-09-08T13:34:24+00:00"
+            "time": "2026-04-10T20:16:27+00:00"
         },
         {
             "name": "wp-php-toolkit/http-client",
-            "version": "v0.5.1",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/http-client.git",
-                "reference": "c9f79808c164578c6080ac87a4ecc335c78dd947"
+                "reference": "1174f1e20e1f4c60a3274006ebed791ac6bccd77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/http-client/zipball/c9f79808c164578c6080ac87a4ecc335c78dd947",
-                "reference": "c9f79808c164578c6080ac87a4ecc335c78dd947",
+                "url": "https://api.github.com/repos/wp-php-toolkit/http-client/zipball/1174f1e20e1f4c60a3274006ebed791ac6bccd77",
+                "reference": "1174f1e20e1f4c60a3274006ebed791ac6bccd77",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/bytestream": "^0.5.1",
-                "wp-php-toolkit/data-liberation": "^0.5.1",
-                "wp-php-toolkit/filesystem": "^0.5.1"
+                "wp-php-toolkit/bytestream": "^0.6.2",
+                "wp-php-toolkit/data-liberation": "^0.6.2",
+                "wp-php-toolkit/filesystem": "^0.6.2"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -3607,30 +3607,30 @@
             "description": "HttpClient component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/http-client/issues",
-                "source": "https://github.com/wp-php-toolkit/http-client/tree/v0.5.1"
+                "source": "https://github.com/wp-php-toolkit/http-client/tree/v0.6.2"
             },
-            "time": "2026-04-02T14:37:51+00:00"
+            "time": "2026-04-27T14:15:30+00:00"
         },
         {
             "name": "wp-php-toolkit/reprint-exporter",
-            "version": "v0.1.44",
+            "version": "v0.1.47",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/reprint-exporter.git",
-                "reference": "80f0e0b6cd809ac81f45a13af627681bb46a3557"
+                "reference": "3c56b78f4d19add36f8448421d1ed4fdda135bb6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/reprint-exporter/zipball/80f0e0b6cd809ac81f45a13af627681bb46a3557",
-                "reference": "80f0e0b6cd809ac81f45a13af627681bb46a3557",
+                "url": "https://api.github.com/repos/wp-php-toolkit/reprint-exporter/zipball/3c56b78f4d19add36f8448421d1ed4fdda135bb6",
+                "reference": "3c56b78f4d19add36f8448421d1ed4fdda135bb6",
                 "shasum": ""
             },
             "require": {
                 "ext-pdo": "*",
                 "ext-pdo_mysql": "*",
                 "php": ">=7.4",
-                "wp-php-toolkit/data-liberation": "^0.5.1",
-                "wp-php-toolkit/html": "^0.5.1"
+                "wp-php-toolkit/data-liberation": "^0.6.2",
+                "wp-php-toolkit/html": "^0.6.2"
             },
             "type": "library",
             "autoload": {
@@ -3656,30 +3656,30 @@
             "description": "Streaming export engine used by the Reprint Exporter WordPress plugin",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/reprint-exporter/issues",
-                "source": "https://github.com/wp-php-toolkit/reprint-exporter/tree/v0.1.44"
+                "source": "https://github.com/wp-php-toolkit/reprint-exporter/tree/v0.1.47"
             },
-            "time": "2026-04-16T16:07:42+00:00"
+            "time": "2026-04-27T14:34:36+00:00"
         },
         {
             "name": "wp-php-toolkit/reprint-importer",
-            "version": "v0.1.44",
+            "version": "v0.1.47",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/reprint-importer.git",
-                "reference": "9aa2108c7fa7050f5f589cd61887e50c70c00763"
+                "reference": "e56a796721f559d9a5932bf14d65cab0de51350e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/reprint-importer/zipball/9aa2108c7fa7050f5f589cd61887e50c70c00763",
-                "reference": "9aa2108c7fa7050f5f589cd61887e50c70c00763",
+                "url": "https://api.github.com/repos/wp-php-toolkit/reprint-importer/zipball/e56a796721f559d9a5932bf14d65cab0de51350e",
+                "reference": "e56a796721f559d9a5932bf14d65cab0de51350e",
                 "shasum": ""
             },
             "require": {
                 "ext-pdo": "*",
                 "ext-pdo_mysql": "*",
                 "php": ">=7.4",
-                "wp-php-toolkit/data-liberation": "^0.5.1",
-                "wp-php-toolkit/html": "^0.5.1",
+                "wp-php-toolkit/data-liberation": "^0.6.2",
+                "wp-php-toolkit/html": "^0.6.2",
                 "wp-php-toolkit/reprint-exporter": "*@dev"
             },
             "bin": [
@@ -3693,27 +3693,27 @@
             "description": "Streaming site importer with CLI and PHAR distribution support",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/reprint-importer/issues",
-                "source": "https://github.com/wp-php-toolkit/reprint-importer/tree/v0.1.44"
+                "source": "https://github.com/wp-php-toolkit/reprint-importer/tree/v0.1.47"
             },
-            "time": "2026-04-16T14:19:55+00:00"
+            "time": "2026-04-27T14:34:36+00:00"
         },
         {
             "name": "wp-php-toolkit/xml",
-            "version": "v0.5.1",
+            "version": "v0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-php-toolkit/xml.git",
-                "reference": "8ec4e2f16b18313d52c8a61a6528afacf1ceb34a"
+                "reference": "65e8a47d350179a3217b4acaf4f3597f977a9194"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-php-toolkit/xml/zipball/8ec4e2f16b18313d52c8a61a6528afacf1ceb34a",
-                "reference": "8ec4e2f16b18313d52c8a61a6528afacf1ceb34a",
+                "url": "https://api.github.com/repos/wp-php-toolkit/xml/zipball/65e8a47d350179a3217b4acaf4f3597f977a9194",
+                "reference": "65e8a47d350179a3217b4acaf4f3597f977a9194",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "wp-php-toolkit/encoding": "^0.5.1"
+                "wp-php-toolkit/encoding": "^0.6.2"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.5"
@@ -3744,9 +3744,9 @@
             "description": "XML component for WordPress.",
             "support": {
                 "issues": "https://github.com/wp-php-toolkit/xml/issues",
-                "source": "https://github.com/wp-php-toolkit/xml/tree/v0.5.1"
+                "source": "https://github.com/wp-php-toolkit/xml/tree/v0.6.2"
             },
-            "time": "2026-04-02T14:37:51+00:00"
+            "time": "2026-04-27T14:15:30+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
The fix in https://github.com/Automattic/jetpack/pull/48321 has been removed later in https://github.com/Automattic/jetpack/pull/48286, which switched back the `composer.lock` to:

1. `reprint-exporter` v0.1.47 → v0.1.44
2. `wp-php-toolkit` packages v0.6.2 → v0.5.1

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Fix composer

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* p1777972346572519/1777014500.360739-slack-C03TY6J1A

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Go to '..'
*