### PR TITLE
Publicize: register message template settings and REST endpoints

### DIFF
--- a/projects/packages/publicize/changelog/2026-05-05-09-39-05-650106
+++ b/projects/packages/publicize/changelog/2026-05-05-09-39-05-650106
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add support for global and per-connection message templates via REST API.

--- a/projects/packages/publicize/src/class-connections.php
+++ b/projects/packages/publicize/src/class-connections.php
@@ -228,6 +228,8 @@ class Connections {
 		$connection_meta = $publicize->get_connection_meta( $connection );
 		$connection_data = $connection_meta['connection_data'];
 
+		$row_meta = $connection_data['meta'] ?? array();
+
 		return array(
 			'connection_id'        => (string) $connection_id,
 			'display_name'         => (string) $publicize->get_display_name( $service_name, $connection ),
@@ -238,6 +240,7 @@ class Connections {
 			'service_label'        => (string) Publicize::get_service_label( $service_name ),
 			'service_name'         => $service_name,
 			'shared'               => ! $connection_data['user_id'],
+			'template'             => (string) ( $row_meta['template'] ?? '' ),
 			'wpcom_user_id'        => (int) $connection_data['user_id'],
 
 			// Deprecated fields.

--- a/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
+++ b/projects/packages/publicize/src/jetpack-social-settings/class-settings.php
@@ -45,6 +45,18 @@ class Settings {
 		'append_link' => true,
 	);
 
+	const MESSAGE_TEMPLATE = 'message_template';
+
+	/**
+	 * Default global message template.
+	 */
+	const DEFAULT_MESSAGE_TEMPLATE = "{title}\n\n{excerpt}\n\n{url}";
+
+	/**
+	 * Storage cap for message templates, in characters. Real-world templates are a few hundred characters at most.
+	 */
+	const MESSAGE_TEMPLATE_MAX_LENGTH = 8000;
+
 	// Legacy named options.
 	const JETPACK_SOCIAL_NOTE_CPT_ENABLED   = 'jetpack-social-note';
 	const JETPACK_SOCIAL_SHOW_PRICING_PAGE  = 'jetpack-social_show_pricing_page';
@@ -226,7 +238,43 @@ class Settings {
 			)
 		);
 
+		register_setting(
+			'jetpack_social',
+			self::OPTION_PREFIX . self::MESSAGE_TEMPLATE,
+			array(
+				'type'              => 'string',
+				'default'           => self::DEFAULT_MESSAGE_TEMPLATE,
+				'sanitize_callback' => array( __CLASS__, 'sanitize_message_template' ),
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type'    => 'string',
+						'context' => array( 'view', 'edit' ),
+					),
+				),
+			)
+		);
+
 		add_filter( 'rest_pre_update_setting', array( $this, 'update_settings' ), 10, 3 );
+	}
+
+	/**
+	 * Sanitize a user-authored message template string.
+	 *
+	 * @param mixed $value The raw setting input. Non-string values coerce to ''.
+	 * @return string The sanitised template.
+	 */
+	public static function sanitize_message_template( $value ) {
+		if ( ! is_string( $value ) ) {
+			return '';
+		}
+
+		$value = sanitize_textarea_field( $value );
+
+		if ( mb_strlen( $value, 'UTF-8' ) > self::MESSAGE_TEMPLATE_MAX_LENGTH ) {
+			$value = mb_substr( $value, 0, self::MESSAGE_TEMPLATE_MAX_LENGTH, 'UTF-8' );
+		}
+
+		return $value;
 	}
 
 	/**

--- a/projects/packages/publicize/src/rest-api/class-connections-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-connections-controller.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Publicize\REST_API;
 
 use Automattic\Jetpack\Connection\Traits\WPCOM_REST_API_Proxy_Request;
 use Automattic\Jetpack\Publicize\Connections;
+use Automattic\Jetpack\Publicize\Jetpack_Social_Settings\Settings;
 use Automattic\Jetpack\Publicize\Publicize_Utils;
 use WP_Error;
 use WP_REST_Request;
@@ -233,6 +234,15 @@ class Connections_Controller extends Base_Controller {
 					null,
 				),
 			),
+			'template'        => array(
+				'type'        => 'string',
+				'description' => __( 'Per-connection message template override. Empty string means fall back to the global template.', 'jetpack-publicize-pkg' ),
+				'default'     => '',
+				'maxLength'   => Settings::MESSAGE_TEMPLATE_MAX_LENGTH,
+				'arg_options' => array(
+					'sanitize_callback' => array( Settings::class, 'sanitize_message_template' ),
+				),
+			),
 			'wpcom_user_id'   => array(
 				'type'        => 'integer',
 				'description' => __( 'wordpress.com ID of the user the connection belongs to.', 'jetpack-publicize-pkg' ),
@@ -402,6 +412,27 @@ class Connections_Controller extends Base_Controller {
 			$input = array(
 				'shared' => $request->get_param( 'shared' ),
 			);
+
+			if ( $request->has_param( 'template' ) ) {
+				require_lib( 'publicize/util/message-templates' );
+
+				$template_value = Settings::sanitize_message_template( $request->get_param( 'template' ) );
+
+				/**
+				 * Only gate non-empty values. Clearing an existing override
+				 * must be allowed regardless of plan — otherwise users who
+				 * downgrade can't remove a previously-set template.
+				 */
+				if ( '' !== $template_value && ! \Publicize\can_use_per_connection_templates() ) {
+					return new WP_Error(
+						'rest_forbidden_per_connection_template',
+						__( 'Per-connection message templates require an upgraded plan.', 'jetpack-publicize-pkg' ),
+						array( 'status' => rest_authorization_required_code() )
+					);
+				}
+
+				$input['template'] = $template_value;
+			}
 
 			$result = Connections::wpcom_update_connection( $connection_id, $input );
 


### PR DESCRIPTION
Related to SOCIAL-449

> [!NOTE]
> This will need the WPCOM stub from 214848-ghe-Automattic/wpcom 

## Proposed changes
* Register a new global site option `jetpack_social_message_template` (string, default `{title}\n\n{excerpt}\n\n{url}`) and expose it via the WordPress Settings REST API.
* Add a `template` field to the connections REST schema (`wpcom/v2/publicize/connections`) so per-connection template overrides can be read and written.
* Sanitize template input (`sanitize_textarea_field` + 8000-char cap) via a shared `Settings::sanitize_message_template()` helper used by both the setting and the connection schema.
* Plan-gate per-connection overrides on the update path. Clearing an override (empty string) is intentionally allowed regardless of plan, so users on downgraded plans can still remove a previously-set template.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

- Apply this PR on top of the WPCOM PR to your sandbox
- Sandbox your site and the public API
- Run these from the browser console in the block editor or Social admin page

### 1. Global template setting

Read the current value:
```js
const settings = await wp.apiFetch( { path: '/wp/v2/settings' } );
settings.jetpack_social_message_template;
// → "{title}\n\n{excerpt}\n\n{url}"   (default)
```

Update it:
```js
await wp.apiFetch( {
    path: '/wp/v2/settings',
    method: 'POST',
    data: { jetpack_social_message_template: 'Hello {title} — {url}' },
} );
```

XSS sanitization — tags are stripped:
```js
const r = await wp.apiFetch( {
    path: '/wp/v2/settings',
    method: 'POST',
    data: { jetpack_social_message_template: '<script>alert(1)</script>{title}' },
} );
r.jetpack_social_message_template;
// → "{title}"
```

Length cap (8000 chars):
```js
const big = 'a'.repeat( 9000 );
const r = await wp.apiFetch( {
    path: '/wp/v2/settings',
    method: 'POST',
    data: { jetpack_social_message_template: big },
} );
r.jetpack_social_message_template.length;
// → 8000
```

Restore default:
```js
await wp.apiFetch( {
    path: '/wp/v2/settings',
    method: 'POST',
    data: { jetpack_social_message_template: '{title}\n\n{excerpt}\n\n{url}' },
} );
```

### 2. Per-connection template

List connections and pick one:
```js
const conns = await wp.apiFetch( { path: '/wpcom/v2/publicize/connections' } );
console.table( conns.map( c => ( {
    id: c.connection_id,
    service: c.service_name,
    handle: c.display_name,
    template: c.template,
} ) ) );
const id = conns[ 0 ].connection_id;
```

Set an override (paid plan):
```js
await wp.apiFetch( {
    path: `/wpcom/v2/publicize/connections/${ id }`,
    method: 'POST',
    data: { template: 'Custom {title} for this account' },
} );
```

Verify it stuck:
```js
const after = await wp.apiFetch( { path: '/wpcom/v2/publicize/connections' } );
after.find( c => c.connection_id === id ).template;
// → "Custom {title} for this account"
```

Clear the override (must succeed on any plan):
```js
await wp.apiFetch( {
    path: `/wpcom/v2/publicize/connections/${ id }`,
    method: 'POST',
    data: { template: '' },
} );
```

### 3. Plan gating (free plan only)

Setting a non-empty template must reject:
```js
try {
    await wp.apiFetch( {
        path: `/wpcom/v2/publicize/connections/${ id }`,
        method: 'POST',
        data: { template: 'Should fail' },
    } );
} catch ( err ) {
    console.log( err.code, err.message );
    // → "rest_forbidden_per_connection_template"
}
```

Clearing must still succeed on the same site:
```js
await wp.apiFetch( {
    path: `/wpcom/v2/publicize/connections/${ id }`,
    method: 'POST',
    data: { template: '' },
} );
// → resolves; no error
```