### PR TITLE
fix(ai): UI polish fixes for Jetpack MCP settings page

### DIFF
--- a/projects/packages/my-jetpack/changelog/aiint-392-jetpack-ai-mcp-settings-ui-polish-fixes
+++ b/projects/packages/my-jetpack/changelog/aiint-392-jetpack-ai-mcp-settings-ui-polish-fixes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix PHP deprecated notice: cast $tier to int before using as array offset in get_long_description_by_usage_tier() to handle null from get_next_usage_tier()

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -244,7 +244,7 @@ class Jetpack_Ai extends Product {
 		);
 		$tiered_description = __( 'Upgrade and increase the amount of your available monthly requests to continue using the most advanced AI technology Jetpack has to offer.', 'jetpack-my-jetpack' );
 
-		return isset( $long_descriptions[ $tier ] ) ? $long_descriptions[ $tier ] : $tiered_description;
+		return isset( $long_descriptions[ (int) $tier ] ) ? $long_descriptions[ (int) $tier ] : $tiered_description;
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -234,17 +234,18 @@ class Jetpack_Ai extends Product {
 	/**
 	 * Get the internationalized usage tier long description by tier
 	 *
-	 * @param int $tier The usage tier.
+	 * @param int|null $tier The usage tier.
 	 * @return string
 	 */
 	public static function get_long_description_by_usage_tier( $tier ) {
-		$long_descriptions  = array(
-			1   => __( 'Jetpack AI Assistant brings the power of AI right into your WordPress editor, letting your content creation soar to new heights.', 'jetpack-my-jetpack' ),
-			100 => __( 'The most advanced AI technology Jetpack has to offer.', 'jetpack-my-jetpack' ),
-		);
-		$tiered_description = __( 'Upgrade and increase the amount of your available monthly requests to continue using the most advanced AI technology Jetpack has to offer.', 'jetpack-my-jetpack' );
-
-		return isset( $long_descriptions[ (int) $tier ] ) ? $long_descriptions[ (int) $tier ] : $tiered_description;
+		switch ( (int) $tier ) {
+			case 1:
+				return __( 'Jetpack AI Assistant brings the power of AI right into your WordPress editor, letting your content creation soar to new heights.', 'jetpack-my-jetpack' );
+			case 100:
+				return __( 'The most advanced AI technology Jetpack has to offer.', 'jetpack-my-jetpack' );
+			default:
+				return __( 'Upgrade and increase the amount of your available monthly requests to continue using the most advanced AI technology Jetpack has to offer.', 'jetpack-my-jetpack' );
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/_inc/client/ai/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/main.jsx
@@ -4,7 +4,7 @@
  * Manages the view stack (hub → read | write | setup) and owns the MCP settings state.
  */
 
-import { AdminPage, JetpackLogo } from '@automattic/jetpack-components';
+import { AdminPage } from '@automattic/jetpack-components';
 import { Spinner } from '@wordpress/components';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -59,7 +59,6 @@ function Breadcrumbs( { view, onNavigate } ) {
 						className="jetpack-ai-admin__breadcrumb-link"
 						onClick={ onNavigate }
 					>
-						<JetpackLogo showText={ false } height={ 20 } />
 						{ /** "AI" is a product name and should not be translated. */ }
 						AI
 					</button>

--- a/projects/plugins/jetpack/_inc/client/ai/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/main.jsx
@@ -19,6 +19,13 @@ import McpWrite from './mcp/write';
 
 const { blogId, activityLogUrl, apiRoot, apiNonce } = window?.jetpackAiSettings ?? {};
 
+const VALID_VIEWS = [ 'read', 'write', 'setup' ];
+
+const getViewFromHash = () => {
+	const hash = window.location.hash.replace( /^#\//, '' );
+	return VALID_VIEWS.includes( hash ) ? hash : 'hub';
+};
+
 const VIEW_TITLES = {
 	hub: 'AI', // "AI" is a product name and should not be translated.
 	read: __( 'Read', 'jetpack' ),
@@ -71,10 +78,18 @@ function Breadcrumbs( { view, onNavigate } ) {
  * @return {object} Component markup.
  */
 export default function App() {
-	const [ view, setView ] = useState( 'hub' );
+	const [ view, setView ] = useState( getViewFromHash );
 	const [ saveError, setSaveError ] = useState( null );
 	const { isLoading, savingToolIds, mcpAbilities, hasMcpAccess, error, updateMcpAbilities } =
 		useMcpSettings();
+
+	useEffect( () => {
+		// Tag the initial history entry so the popstate handler can restore the hub view.
+		window.history.replaceState( { view: getViewFromHash() }, '' );
+		const handlePopState = event => setView( event.state?.view ?? 'hub' );
+		window.addEventListener( 'popstate', handlePopState );
+		return () => window.removeEventListener( 'popstate', handlePopState );
+	}, [] );
 
 	useEffect( () => {
 		if ( ! isLoading && hasMcpAccess ) {
@@ -93,7 +108,15 @@ export default function App() {
 	);
 
 	const dismissSaveError = useCallback( () => setSaveError( null ), [] );
-	const navigateBack = useCallback( () => setView( 'hub' ), [] );
+
+	const navigateToView = useCallback( newView => {
+		window.history.pushState( { view: newView }, '', '#/' + newView );
+		setView( newView );
+	}, [] );
+
+	// The breadcrumb back link mirrors the browser Back button so the history
+	// entry for the sub-view is popped rather than a new hub entry being pushed.
+	const navigateBack = useCallback( () => window.history.back(), [] );
 
 	const isSubView = view !== 'hub';
 
@@ -148,7 +171,7 @@ export default function App() {
 								blogId={ blogId }
 								activityLogUrl={ activityLogUrl }
 								savingToolIds={ savingToolIds }
-								onNavigate={ setView }
+								onNavigate={ navigateToView }
 								onUpdate={ handleUpdate }
 							/>
 						) }

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/categories.js
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/categories.js
@@ -151,11 +151,10 @@ export function getSubCategory( toolId, ability ) {
 				return subCategory;
 			}
 		}
-		// 'sites'-category tools with no Design prefix stay in the Sites card's sub-group.
-		if ( apiCategory === 'sites' ) {
-			return API_CATEGORY_TO_SUB_CATEGORY.sites;
-		}
-		return undefined;
+		// Tools in these API categories should still be rendered even when their
+		// IDs do not match a known Design prefix, so fall back to the category's
+		// default sub-category instead of returning undefined.
+		return API_CATEGORY_TO_SUB_CATEGORY[ apiCategory ];
 	}
 
 	if ( apiCategory ) {

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/categories.js
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/categories.js
@@ -33,12 +33,14 @@ const SUB_CATEGORIES = {
 	POSTS: __( 'Posts', 'jetpack' ),
 	COMMENTS: __( 'Comments', 'jetpack' ),
 	CATEGORIES_TAGS: __( 'Categories & tags', 'jetpack' ),
-	SITES: __( 'Sites', 'jetpack' ),
+	SITE_INFO: __( 'Site info', 'jetpack' ),
+	NAVIGATION: __( 'Navigation', 'jetpack' ),
 	MEDIA: __( 'Media', 'jetpack' ),
 	SITE_SETTINGS: __( 'Site settings', 'jetpack' ),
 	ANALYTICS: __( 'Analytics', 'jetpack' ),
-	ACCOUNT: __( 'Account', 'jetpack' ),
+	PROFILE: __( 'Profile', 'jetpack' ),
 	NOTIFICATIONS: __( 'Notifications', 'jetpack' ),
+	BILLING: __( 'Billing', 'jetpack' ),
 };
 
 export const SUB_CATEGORY_ORDER = {
@@ -48,12 +50,17 @@ export const SUB_CATEGORY_ORDER = {
 		SUB_CATEGORIES.CATEGORIES_TAGS,
 	],
 	[ DISPLAY_CATEGORIES.SITES ]: [
-		SUB_CATEGORIES.SITES,
+		SUB_CATEGORIES.SITE_INFO,
+		SUB_CATEGORIES.NAVIGATION,
 		SUB_CATEGORIES.SITE_SETTINGS,
 		SUB_CATEGORIES.MEDIA,
 		SUB_CATEGORIES.ANALYTICS,
 	],
-	[ DISPLAY_CATEGORIES.ACCOUNT ]: [ SUB_CATEGORIES.ACCOUNT, SUB_CATEGORIES.NOTIFICATIONS ],
+	[ DISPLAY_CATEGORIES.ACCOUNT ]: [
+		SUB_CATEGORIES.PROFILE,
+		SUB_CATEGORIES.NOTIFICATIONS,
+		SUB_CATEGORIES.BILLING,
+	],
 };
 
 const API_CATEGORY_TO_DISPLAY = {
@@ -79,15 +86,28 @@ const API_CATEGORY_TO_SUB_CATEGORY = {
 	posts: SUB_CATEGORIES.POSTS,
 	comments: SUB_CATEGORIES.COMMENTS,
 	'categories-tags': SUB_CATEGORIES.CATEGORIES_TAGS,
-	sites: SUB_CATEGORIES.SITES,
+	sites: SUB_CATEGORIES.SITE_INFO,
 	media: SUB_CATEGORIES.MEDIA,
 	users: SUB_CATEGORIES.SITE_SETTINGS,
 	plugins: SUB_CATEGORIES.SITE_SETTINGS,
 	'site-settings': SUB_CATEGORIES.SITE_SETTINGS,
 	analytics: SUB_CATEGORIES.ANALYTICS,
-	account: SUB_CATEGORIES.ACCOUNT,
+	account: SUB_CATEGORIES.PROFILE,
 	notifications: SUB_CATEGORIES.NOTIFICATIONS,
-	billing: SUB_CATEGORIES.ACCOUNT,
+	billing: SUB_CATEGORIES.BILLING,
+};
+
+const TOOL_ID_TO_SUB_CATEGORY = {
+	list_menus: SUB_CATEGORIES.NAVIGATION,
+	get_menu: SUB_CATEGORIES.NAVIGATION,
+	list_menu_items: SUB_CATEGORIES.NAVIGATION,
+	get_menu_item: SUB_CATEGORIES.NAVIGATION,
+	list_navigation: SUB_CATEGORIES.NAVIGATION,
+	get_navigation: SUB_CATEGORIES.NAVIGATION,
+	create_navigation: SUB_CATEGORIES.NAVIGATION,
+	update_navigation: SUB_CATEGORIES.NAVIGATION,
+	delete_navigation: SUB_CATEGORIES.NAVIGATION,
+	list_themes: SUB_CATEGORIES.SITE_SETTINGS,
 };
 
 /**
@@ -98,6 +118,9 @@ const API_CATEGORY_TO_SUB_CATEGORY = {
  * @return {string | undefined} Sub-category display name, or undefined if none.
  */
 export function getSubCategory( toolId, ability ) {
+	if ( toolId && TOOL_ID_TO_SUB_CATEGORY[ toolId ] ) {
+		return TOOL_ID_TO_SUB_CATEGORY[ toolId ];
+	}
 	const apiCategory = ability?.category;
 	if ( apiCategory ) {
 		return API_CATEGORY_TO_SUB_CATEGORY[ apiCategory ];

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/categories.js
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/categories.js
@@ -30,17 +30,26 @@ export const CATEGORY_ORDER = [
 ];
 
 const SUB_CATEGORIES = {
+	// Posts sub-categories
 	POSTS: __( 'Posts', 'jetpack' ),
 	COMMENTS: __( 'Comments', 'jetpack' ),
 	CATEGORIES_TAGS: __( 'Categories & tags', 'jetpack' ),
-	SITE_INFO: __( 'Site info', 'jetpack' ),
-	NAVIGATION: __( 'Navigation', 'jetpack' ),
+	// Sites sub-categories
+	SITES: __( 'Sites', 'jetpack' ),
+	PLUGINS: __( 'Plugins', 'jetpack' ),
 	MEDIA: __( 'Media', 'jetpack' ),
 	SITE_SETTINGS: __( 'Site settings', 'jetpack' ),
 	ANALYTICS: __( 'Analytics', 'jetpack' ),
-	PROFILE: __( 'Profile', 'jetpack' ),
+	// Account sub-categories
+	ACCOUNT: __( 'Account', 'jetpack' ),
 	NOTIFICATIONS: __( 'Notifications', 'jetpack' ),
-	BILLING: __( 'Billing', 'jetpack' ),
+	// Design sub-categories
+	THEMES: __( 'Themes', 'jetpack' ),
+	PATTERNS: __( 'Patterns', 'jetpack' ),
+	TEMPLATES: __( 'Templates', 'jetpack' ),
+	GLOBAL_STYLES: __( 'Global styles', 'jetpack' ),
+	NAVIGATION: __( 'Navigation', 'jetpack' ),
+	BLOCKS: __( 'Blocks', 'jetpack' ),
 };
 
 export const SUB_CATEGORY_ORDER = {
@@ -50,16 +59,20 @@ export const SUB_CATEGORY_ORDER = {
 		SUB_CATEGORIES.CATEGORIES_TAGS,
 	],
 	[ DISPLAY_CATEGORIES.SITES ]: [
-		SUB_CATEGORIES.SITE_INFO,
-		SUB_CATEGORIES.NAVIGATION,
+		SUB_CATEGORIES.SITES,
+		SUB_CATEGORIES.PLUGINS,
 		SUB_CATEGORIES.SITE_SETTINGS,
 		SUB_CATEGORIES.MEDIA,
 		SUB_CATEGORIES.ANALYTICS,
 	],
-	[ DISPLAY_CATEGORIES.ACCOUNT ]: [
-		SUB_CATEGORIES.PROFILE,
-		SUB_CATEGORIES.NOTIFICATIONS,
-		SUB_CATEGORIES.BILLING,
+	[ DISPLAY_CATEGORIES.ACCOUNT ]: [ SUB_CATEGORIES.ACCOUNT, SUB_CATEGORIES.NOTIFICATIONS ],
+	[ DISPLAY_CATEGORIES.DESIGN ]: [
+		SUB_CATEGORIES.THEMES,
+		SUB_CATEGORIES.PATTERNS,
+		SUB_CATEGORIES.TEMPLATES,
+		SUB_CATEGORIES.GLOBAL_STYLES,
+		SUB_CATEGORIES.NAVIGATION,
+		SUB_CATEGORIES.BLOCKS,
 	],
 };
 
@@ -83,28 +96,38 @@ const API_CATEGORY_TO_DISPLAY = {
 };
 
 const API_CATEGORY_TO_SUB_CATEGORY = {
+	// Posts card sub-categories
 	posts: SUB_CATEGORIES.POSTS,
 	comments: SUB_CATEGORIES.COMMENTS,
 	'categories-tags': SUB_CATEGORIES.CATEGORIES_TAGS,
-	sites: SUB_CATEGORIES.SITE_INFO,
+	// Sites card sub-categories
+	sites: SUB_CATEGORIES.SITES,
 	media: SUB_CATEGORIES.MEDIA,
 	users: SUB_CATEGORIES.SITE_SETTINGS,
-	plugins: SUB_CATEGORIES.SITE_SETTINGS,
+	plugins: SUB_CATEGORIES.PLUGINS,
 	'site-settings': SUB_CATEGORIES.SITE_SETTINGS,
 	analytics: SUB_CATEGORIES.ANALYTICS,
-	account: SUB_CATEGORIES.PROFILE,
+	// Account card sub-categories
+	account: SUB_CATEGORIES.ACCOUNT,
 	notifications: SUB_CATEGORIES.NOTIFICATIONS,
-	billing: SUB_CATEGORIES.BILLING,
+	billing: SUB_CATEGORIES.ACCOUNT,
 };
 
-// Sites-card tools that share the `sites` API category but belong in finer sub-groups.
-// Prefix matching mirrors the approach used in wp-calypso categories.ts.
-const SITES_TOOL_ID_PREFIX_TO_SUB_CATEGORY = {
+// Design-card tools all share `design` as their API category, so sub-groups within the
+// Design card are derived from tool ID prefixes. This also covers `sites`-category tools
+// that are routed to the Design card (navigation, menus, themes).
+const TOOL_ID_PREFIX_TO_DESIGN_SUB_CATEGORY = {
+	'wpcom-mcp/theme-': SUB_CATEGORIES.THEMES,
+	'wpcom-mcp/themes-': SUB_CATEGORIES.THEMES,
+	'wpcom-mcp/patterns-': SUB_CATEGORIES.PATTERNS,
+	'wpcom-mcp/synced-patterns-': SUB_CATEGORIES.PATTERNS,
+	'wpcom-mcp/templates-': SUB_CATEGORIES.TEMPLATES,
+	'wpcom-mcp/template-parts-': SUB_CATEGORIES.TEMPLATES,
+	'wpcom-mcp/global-styles-': SUB_CATEGORIES.GLOBAL_STYLES,
 	'wpcom-mcp/navigation-': SUB_CATEGORIES.NAVIGATION,
 	'wpcom-mcp/menus-': SUB_CATEGORIES.NAVIGATION,
 	'wpcom-mcp/menu-items-': SUB_CATEGORIES.NAVIGATION,
-	'wpcom-mcp/themes-': SUB_CATEGORIES.SITE_SETTINGS,
-	'wpcom-mcp/theme-': SUB_CATEGORIES.SITE_SETTINGS,
+	'wpcom-mcp/blocks-': SUB_CATEGORIES.BLOCKS,
 };
 
 /**
@@ -117,15 +140,22 @@ const SITES_TOOL_ID_PREFIX_TO_SUB_CATEGORY = {
 export function getSubCategory( toolId, ability ) {
 	const apiCategory = ability?.category;
 
-	if ( apiCategory === 'sites' ) {
+	// Design-card tools use tool ID prefix for sub-grouping. This covers both
+	// 'design'-category tools and 'sites'-category tools that are routed to the
+	// Design card by getDisplayCategory (e.g. navigation, menus, themes).
+	if ( apiCategory === 'design' || apiCategory === 'sites' ) {
 		for ( const [ prefix, subCategory ] of Object.entries(
-			SITES_TOOL_ID_PREFIX_TO_SUB_CATEGORY
+			TOOL_ID_PREFIX_TO_DESIGN_SUB_CATEGORY
 		) ) {
 			if ( toolId.startsWith( prefix ) ) {
 				return subCategory;
 			}
 		}
-		return API_CATEGORY_TO_SUB_CATEGORY.sites;
+		// 'sites'-category tools with no Design prefix stay in the Sites card's sub-group.
+		if ( apiCategory === 'sites' ) {
+			return API_CATEGORY_TO_SUB_CATEGORY.sites;
+		}
+		return undefined;
 	}
 
 	if ( apiCategory ) {
@@ -148,12 +178,24 @@ export function isWriteTool( toolId, ability ) {
 /**
  * Get the display category name for a tool.
  *
+ * For 'design' and 'sites' category tools, check if the tool ID prefix indicates
+ * it belongs in the Design card (navigation, menus, themes mirror calypso's approach).
+ *
  * @param {string} toolId  - Tool identifier.
  * @param {object} ability - Tool descriptor from the API.
  * @return {string} Display category name, falling back to Uncategorized.
  */
 export function getDisplayCategory( toolId, ability ) {
 	const apiCategory = ability?.category;
+
+	if ( apiCategory === 'design' || apiCategory === 'sites' ) {
+		for ( const prefix of Object.keys( TOOL_ID_PREFIX_TO_DESIGN_SUB_CATEGORY ) ) {
+			if ( toolId.startsWith( prefix ) ) {
+				return DISPLAY_CATEGORIES.DESIGN;
+			}
+		}
+	}
+
 	if ( apiCategory && API_CATEGORY_TO_DISPLAY[ apiCategory ] ) {
 		return API_CATEGORY_TO_DISPLAY[ apiCategory ];
 	}

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/categories.js
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/categories.js
@@ -97,17 +97,14 @@ const API_CATEGORY_TO_SUB_CATEGORY = {
 	billing: SUB_CATEGORIES.BILLING,
 };
 
-const TOOL_ID_TO_SUB_CATEGORY = {
-	list_menus: SUB_CATEGORIES.NAVIGATION,
-	get_menu: SUB_CATEGORIES.NAVIGATION,
-	list_menu_items: SUB_CATEGORIES.NAVIGATION,
-	get_menu_item: SUB_CATEGORIES.NAVIGATION,
-	list_navigation: SUB_CATEGORIES.NAVIGATION,
-	get_navigation: SUB_CATEGORIES.NAVIGATION,
-	create_navigation: SUB_CATEGORIES.NAVIGATION,
-	update_navigation: SUB_CATEGORIES.NAVIGATION,
-	delete_navigation: SUB_CATEGORIES.NAVIGATION,
-	list_themes: SUB_CATEGORIES.SITE_SETTINGS,
+// Sites-card tools that share the `sites` API category but belong in finer sub-groups.
+// Prefix matching mirrors the approach used in wp-calypso categories.ts.
+const SITES_TOOL_ID_PREFIX_TO_SUB_CATEGORY = {
+	'wpcom-mcp/navigation-': SUB_CATEGORIES.NAVIGATION,
+	'wpcom-mcp/menus-': SUB_CATEGORIES.NAVIGATION,
+	'wpcom-mcp/menu-items-': SUB_CATEGORIES.NAVIGATION,
+	'wpcom-mcp/themes-': SUB_CATEGORIES.SITE_SETTINGS,
+	'wpcom-mcp/theme-': SUB_CATEGORIES.SITE_SETTINGS,
 };
 
 /**
@@ -118,10 +115,19 @@ const TOOL_ID_TO_SUB_CATEGORY = {
  * @return {string | undefined} Sub-category display name, or undefined if none.
  */
 export function getSubCategory( toolId, ability ) {
-	if ( toolId && TOOL_ID_TO_SUB_CATEGORY[ toolId ] ) {
-		return TOOL_ID_TO_SUB_CATEGORY[ toolId ];
-	}
 	const apiCategory = ability?.category;
+
+	if ( apiCategory === 'sites' ) {
+		for ( const [ prefix, subCategory ] of Object.entries(
+			SITES_TOOL_ID_PREFIX_TO_SUB_CATEGORY
+		) ) {
+			if ( toolId.startsWith( prefix ) ) {
+				return subCategory;
+			}
+		}
+		return API_CATEGORY_TO_SUB_CATEGORY.sites;
+	}
+
 	if ( apiCategory ) {
 		return API_CATEGORY_TO_SUB_CATEGORY[ apiCategory ];
 	}

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/index.jsx
@@ -291,12 +291,7 @@ export default function McpHub( {
 
 			{ isMcpEnabled && activityLogUrl && (
 				<Card className="jetpack-ai-mcp__action-card">
-					<a
-						className="jetpack-ai-mcp__connect-row"
-						href={ activityLogUrl }
-						target="_blank"
-						rel="noopener noreferrer"
-					>
+					<a className="jetpack-ai-mcp__connect-row" href={ activityLogUrl }>
 						<span className="jetpack-ai-mcp__connect-row-icon">
 							<Icon icon={ list } size={ 24 } />
 						</span>

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/setup.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/setup.jsx
@@ -126,7 +126,7 @@ export default function McpSetup() {
 							</Text>
 
 							{ selectedClient === 'claude' && (
-								<ul className="jetpack-ai-mcp-setup__steps">
+								<ol className="jetpack-ai-mcp-setup__steps">
 									<li>
 										<Text as="p" variant="muted">
 											{ createInterpolateElement( __( 'Open <ClaudeSettings/>.', 'jetpack' ), {
@@ -151,7 +151,7 @@ export default function McpSetup() {
 											{ __( 'Select WordPress.com and follow the prompts.', 'jetpack' ) }
 										</Text>
 									</li>
-								</ul>
+								</ol>
 							) }
 
 							{ selectedClient === 'claude-code' && (
@@ -162,7 +162,7 @@ export default function McpSetup() {
 											'jetpack'
 										) }
 									</Text>
-									<ul className="jetpack-ai-mcp-setup__steps">
+									<ol className="jetpack-ai-mcp-setup__steps">
 										<li>
 											<Text as="p" variant="muted">
 												{ createInterpolateElement(
@@ -206,7 +206,7 @@ export default function McpSetup() {
 												) }
 											</Text>
 										</li>
-									</ul>
+									</ol>
 								</Stack>
 							) }
 

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/setup.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/setup.jsx
@@ -126,7 +126,7 @@ export default function McpSetup() {
 							</Text>
 
 							{ selectedClient === 'claude' && (
-								<ul className="jetpack-ai-mcp-setup__steps">
+								<ol className="jetpack-ai-mcp-setup__steps">
 									<li>
 										<Text as="p" variant="muted">
 											{ createInterpolateElement( __( 'Open <ClaudeSettings/>.', 'jetpack' ), {
@@ -151,7 +151,7 @@ export default function McpSetup() {
 											{ __( 'Select WordPress.com and follow the prompts.', 'jetpack' ) }
 										</Text>
 									</li>
-								</ul>
+								</ol>
 							) }
 
 							{ selectedClient === 'claude-code' && (

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/setup.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/setup.jsx
@@ -126,7 +126,7 @@ export default function McpSetup() {
 							</Text>
 
 							{ selectedClient === 'claude' && (
-								<ol className="jetpack-ai-mcp-setup__steps">
+								<ul className="jetpack-ai-mcp-setup__steps">
 									<li>
 										<Text as="p" variant="muted">
 											{ createInterpolateElement( __( 'Open <ClaudeSettings/>.', 'jetpack' ), {
@@ -151,7 +151,7 @@ export default function McpSetup() {
 											{ __( 'Select WordPress.com and follow the prompts.', 'jetpack' ) }
 										</Text>
 									</li>
-								</ol>
+								</ul>
 							) }
 
 							{ selectedClient === 'claude-code' && (
@@ -162,7 +162,7 @@ export default function McpSetup() {
 											'jetpack'
 										) }
 									</Text>
-									<ol className="jetpack-ai-mcp-setup__steps">
+									<ul className="jetpack-ai-mcp-setup__steps">
 										<li>
 											<Text as="p" variant="muted">
 												{ createInterpolateElement(
@@ -206,7 +206,7 @@ export default function McpSetup() {
 												) }
 											</Text>
 										</li>
-									</ol>
+									</ul>
 								</Stack>
 							) }
 

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/style.scss
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/style.scss
@@ -106,11 +106,11 @@
 		margin: 0;
 	}
 
-	// Tighten the gap between each tool toggle's help text and the next toggle.
-	// WP's BaseControl adds margin-top: 8px on the help text; bump overall
-	// row gap down slightly so the combined visual spacing feels even.
+	// Tool toggle descriptions hug their setting title; override WP's
+	// BaseControl default 8px gap so the help text reads as part of the
+	// row rather than as a separate paragraph.
 	.components-base-control__help {
-		margin-top: 4px;
+		margin-top: 0;
 	}
 
 	&__access-card {
@@ -183,9 +183,15 @@
 	}
 }
 
-// wp-admin resets list-style on ul; restore bullets for the steps list.
+// wp-admin resets list-style on list elements; restore defaults for the
+// setup steps list. Claude uses an ordered list (decimal); Claude Code
+// uses unordered (disc) since some of its steps are "or" alternatives.
 ul.jetpack-ai-mcp-setup__steps {
 	list-style: disc;
+}
+
+ol.jetpack-ai-mcp-setup__steps {
+	list-style: decimal;
 }
 
 .jetpack-ai-mcp-setup {

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/style.scss
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/style.scss
@@ -83,9 +83,7 @@
 		display: inline-flex;
 		align-items: center;
 		gap: 4px;
-		// Collapse line-height descender space so the flex container sits flush
-		// with the badge's padding-block rather than drifting off-baseline.
-		line-height: 1;
+		vertical-align: center;
 	}
 
 	&__category-header-row {

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/style.scss
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/style.scss
@@ -91,10 +91,25 @@
 		justify-content: space-between;
 		align-items: center;
 		width: 100%;
+
+		// The ToggleControl label uses line-height equal to the toggle height for
+		// vertical alignment, but the FlexBlock wrapper defaults to align-items:
+		// stretch. Force center so the "Enable all" text sits mid-toggle.
+		.components-toggle-control__label {
+			display: flex;
+			align-items: center;
+		}
 	}
 
 	&__tool-group-divider {
 		margin: 0;
+	}
+
+	// Tighten the gap between each tool toggle's help text and the next toggle.
+	// WP's BaseControl adds margin-top: 8px on the help text; bump overall
+	// row gap down slightly so the combined visual spacing feels even.
+	.components-base-control__help {
+		margin-top: 4px;
 	}
 
 	&__access-card {

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/style.scss
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/style.scss
@@ -83,9 +83,9 @@
 		display: inline-flex;
 		align-items: center;
 		gap: 4px;
-		// inline-flex aligns to the text baseline by default, which shifts the
-		// container down relative to the badge's line box — middle centres it.
-		vertical-align: middle;
+		// Collapse line-height descender space so the flex container sits flush
+		// with the badge's padding-block rather than drifting off-baseline.
+		line-height: 1;
 	}
 
 	&__category-header-row {

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/style.scss
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/style.scss
@@ -193,6 +193,11 @@
 		}
 	}
 
+	// wp-admin resets list-style globally; restore bullets.
+	ul.jetpack-ai-mcp-setup__steps {
+		list-style: disc;
+	}
+
 	&__code {
 		font-size: 12px;
 		background: var(--color-neutral-5, #f0f0f1);

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/style.scss
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/style.scss
@@ -183,6 +183,11 @@
 	}
 }
 
+// wp-admin resets list-style on ul; restore bullets for the steps list.
+ul.jetpack-ai-mcp-setup__steps {
+	list-style: disc;
+}
+
 .jetpack-ai-mcp-setup {
 
 	&__steps {
@@ -192,11 +197,6 @@
 		li {
 			margin-bottom: 8px;
 		}
-	}
-
-	// wp-admin resets list-style globally; restore bullets.
-	ul.jetpack-ai-mcp-setup__steps {
-		list-style: disc;
 	}
 
 	&__code {

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/style.scss
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/style.scss
@@ -83,6 +83,9 @@
 		display: inline-flex;
 		align-items: center;
 		gap: 4px;
+		// inline-flex aligns to the text baseline by default, which shifts the
+		// container down relative to the badge's line box — middle centres it.
+		vertical-align: middle;
 	}
 
 	&__category-header-row {

--- a/projects/plugins/jetpack/_inc/client/ai/style.scss
+++ b/projects/plugins/jetpack/_inc/client/ai/style.scss
@@ -46,9 +46,18 @@ body.jetpack_page_jetpack-ai {
 		}
 	}
 
-	// Both pieces of the breadcrumb match the page-heading weight so the
-	// header on sub-views reads as "AI / Read" with the same visual heft as
-	// the hub's "AI" h1 title.
+	// Both pieces of the breadcrumb match the wpds `heading-lg` type token
+	// (the same one admin-ui's Page uses for the hub's "AI" h1 title), so
+	// the header on sub-views reads as "AI / Read" with the same size and
+	// weight as the hub heading.
+	&__breadcrumb-link,
+	&__breadcrumb-current {
+		font-family: var(--wpds-typography-font-family-heading, inherit);
+		font-size: var(--wpds-typography-font-size-lg, 15px);
+		font-weight: var(--wpds-typography-font-weight-medium, 500);
+		line-height: var(--wpds-typography-line-height-sm, 20px);
+	}
+
 	&__breadcrumb-link {
 		display: inline-flex;
 		align-items: center;
@@ -58,9 +67,6 @@ body.jetpack_page_jetpack-ai {
 		padding: 0;
 		cursor: pointer;
 		color: inherit;
-		font-size: inherit;
-		font-weight: 600;
-		line-height: inherit;
 		text-decoration: none;
 
 		&:hover {
@@ -69,9 +75,6 @@ body.jetpack_page_jetpack-ai {
 	}
 
 	&__breadcrumb-current {
-		font-size: inherit;
-		font-weight: 600;
-		line-height: inherit;
 		margin: 0;
 	}
 

--- a/projects/plugins/jetpack/_inc/client/ai/style.scss
+++ b/projects/plugins/jetpack/_inc/client/ai/style.scss
@@ -32,6 +32,17 @@ body.jetpack_page_jetpack-ai {
 			display: flex;
 			align-items: center;
 			margin-bottom: 0;
+
+		}
+
+		// Render a "/" separator between adjacent breadcrumb items.
+		// Mirrors @wordpress/admin-ui's Breadcrumbs component, which we
+		// can't drop in directly because it requires @wordpress/route
+		// for navigation — we use hash-based routing here.
+		li + li::before {
+			content: "/";
+			margin: 0 8px;
+			color: var(--wpds-color-stroke-surface-neutral, #c3c4c7);
 		}
 	}
 

--- a/projects/plugins/jetpack/_inc/client/ai/style.scss
+++ b/projects/plugins/jetpack/_inc/client/ai/style.scss
@@ -46,6 +46,9 @@ body.jetpack_page_jetpack-ai {
 		}
 	}
 
+	// Both pieces of the breadcrumb match the page-heading weight so the
+	// header on sub-views reads as "AI / Read" with the same visual heft as
+	// the hub's "AI" h1 title.
 	&__breadcrumb-link {
 		display: inline-flex;
 		align-items: center;
@@ -56,7 +59,7 @@ body.jetpack_page_jetpack-ai {
 		cursor: pointer;
 		color: inherit;
 		font-size: inherit;
-		font-weight: inherit;
+		font-weight: 600;
 		line-height: inherit;
 		text-decoration: none;
 
@@ -67,7 +70,7 @@ body.jetpack_page_jetpack-ai {
 
 	&__breadcrumb-current {
 		font-size: inherit;
-		font-weight: inherit;
+		font-weight: 600;
 		line-height: inherit;
 		margin: 0;
 	}

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
@@ -10,7 +10,6 @@
 
 use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
-use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
 
@@ -86,13 +85,12 @@ class Jetpack_AI_Page extends Jetpack_Admin_Page {
 		// Use the plain hostname for the Atomic activity log URL — get_site_suffix() can
 		// include '::' for subdirectory installs, which would break the URL. This matches
 		// the approach used by jetpack-mu-wpcom for the sidebar Activity Log link.
-		$site_host = wp_parse_url( home_url(), PHP_URL_HOST );
-		// On Atomic, jetpack-mu-wpcom replaces the cloud redirect with a direct WPCOM URL.
-		// Mirror that behaviour here so the activity log link resolves consistently.
+		$site_host         = wp_parse_url( home_url(), PHP_URL_HOST );
 		$activity_log_site = ( is_string( $site_host ) && '' !== $site_host ) ? $site_host : $site_suffix;
-		$activity_log_url  = ( new Host() )->is_woa_site()
+		// On Atomic link to WPCOM activity log; on self-hosted link to the local wp-admin page.
+		$activity_log_url = ( new Host() )->is_woa_site()
 			? 'https://wordpress.com/activity-log/' . $activity_log_site
-			: Redirect::get_url( 'cloud-activity-log-wp-menu', array( 'site' => $blog_id ? $blog_id : $site_suffix ) );
+			: admin_url( 'admin.php?page=jetpack-activity-log' );
 
 		wp_enqueue_script(
 			'jetpack-ai-admin',

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
@@ -10,6 +10,7 @@
 
 use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
 

--- a/projects/plugins/jetpack/changelog/aiint-392-jetpack-ai-mcp-settings-ui-polish-fixes
+++ b/projects/plugins/jetpack/changelog/aiint-392-jetpack-ai-mcp-settings-ui-polish-fixes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+fix(ai): UI polish for MCP settings — fix browser Back button navigation, change setup instructions to unordered lists, fix 'All enabled' label vertical alignment, and tighten toggle help-text spacing

--- a/projects/plugins/jetpack/changelog/aiint-392-jetpack-ai-mcp-settings-ui-polish-fixes
+++ b/projects/plugins/jetpack/changelog/aiint-392-jetpack-ai-mcp-settings-ui-polish-fixes
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-fix(ai): UI polish for MCP settings — fix browser Back button navigation, change setup instructions to unordered lists, fix 'All enabled' label vertical alignment, and tighten toggle help-text spacing
+Improved the MCP settings UI by fixing browser Back button navigation, changing setup instructions to unordered lists, correcting the 'All enabled' label vertical alignment, and tightening toggle help-text spacing.


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/AIINT-392/jetpack-ai-mcp-settings-ui-polish-fixes

## Proposed changes

* **Browser Back button:** navigating to a sub-view (Read/Write/Setup) now uses `pushState` so the browser Back button returns to the MCP hub rather than leaving the AI admin page entirely. The breadcrumb "AI" link calls `history.back()` to pop the same entry, keeping history clean.
* **Setup unordered list:** Quick setup instructions changed from `<ol>` (numbered) to `<ul>` (bulleted) for Claude and Claude Code clients. Added `ul.jetpack-ai-mcp-setup__steps { list-style: disc }` at top-level scope to restore bullets overridden by the wp-admin global reset.
* **Toggle help-text spacing:** Reduce `margin-top` on `.components-base-control__help` from 8px to 4px for more even visual rhythm between tool toggle rows.
* **MCP tool sub-grouping:** Align `categories.js` with wp-calypso — navigation, menus, and themes tools (API category `sites`) are moved to the Design card using tool ID prefix matching (`wpcom-mcp/navigation-*`, `wpcom-mcp/menus-*`, `wpcom-mcp/menu-items-*`, `wpcom-mcp/theme-*`, `wpcom-mcp/themes-*`). The Design card gains sub-categories: Themes, Patterns, Templates, Global styles, Navigation, Blocks (divided by CardDividers, no visible labels). Sites and Posts cards also get sub-category dividers.
* **Badge vertical alignment:** Fix the "All enabled" badge icon+text being off-centre — set `vertical-align: center` on `.jetpack-ai-mcp__badge-content` to counteract the inline-flex baseline shift inside the Badge component.
* **Activity log URL:** On self-hosted (non-Atomic) sites, the activity log link now points to the local `wp-admin/admin.php?page=jetpack-activity-log` page instead of the cloud.jetpack.com redirect.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Go to `wp-admin/admin.php?page=ai` on a site with an AI account that has MCP access.
2. **Browser Back button:** Click "Read" or "Write" to navigate to a sub-view. Press the browser Back button — you should return to the MCP hub (not leave the page). Click "Read" again, then click the "AI" breadcrumb — you should also return to hub.
3. **Setup unordered list:** Click "Connect external AI agent", select "Claude" or "Claude Code". The Quick setup steps should be bulleted (unordered) with visible bullet points.
4. **Tool sub-grouping:** In the Read or Write views, the Sites card should have sub-groups divided by lines (Site info / Site settings / Media / Analytics). The Design card should have sub-groups for Themes, Patterns, Templates, Global styles, Navigation, Blocks. Navigation and menus tools should appear under Design → Navigation, not under Sites.
5. **"All enabled" badge:** In the hub view, verify the badge icon and text are vertically centred within the green pill.
6. **Activity log link (self-hosted only):** Verify the activity log link in the hub goes to the local Jetpack activity log page, not cloud.jetpack.com.
7. **"Enable all" toggle:** In Read/Write category headers, verify the "Enable all" label is vertically centred with the toggle switch.
