### PR TITLE
jetpack-mu-wpcom: Enable Classic block inserter support via sticker

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/enable-classic-block-inserter-support
+++ b/projects/packages/jetpack-mu-wpcom/changelog/enable-classic-block-inserter-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Classic block: Allow sites with the enable-classic-block-inserter-support sticker to insert the Classic block.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -91,8 +91,8 @@ class Jetpack_Mu_Wpcom {
 		// Filter to populate JetpackScriptData.site.wpcom.blog_id with the actual WP.com blog ID.
 		add_filter( 'jetpack_admin_js_script_data', array( __CLASS__, 'set_wpcom_blog_id_script_data' ), 10, 1 );
 
-		// Allow sites with the `enable-classic-block-inserter-support` blog sticker to insert the Classic block.
-		if ( wpcom_has_blog_sticker( 'enable-classic-block-inserter-support', get_wpcom_blog_id() ) ) {
+		// Allow sites with the `classic-block-inserter-support` blog sticker to insert the Classic block.
+		if ( wpcom_has_blog_sticker( 'classic-block-inserter-support', get_wpcom_blog_id() ) ) {
 			add_filter( 'wp_classic_block_supports_inserter', '__return_true' );
 		}
 

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -91,6 +91,11 @@ class Jetpack_Mu_Wpcom {
 		// Filter to populate JetpackScriptData.site.wpcom.blog_id with the actual WP.com blog ID.
 		add_filter( 'jetpack_admin_js_script_data', array( __CLASS__, 'set_wpcom_blog_id_script_data' ), 10, 1 );
 
+		// Allow sites with the `enable-classic-block-inserter-support` blog sticker to insert the Classic block.
+		if ( wpcom_has_blog_sticker( 'enable-classic-block-inserter-support', get_wpcom_blog_id() ) ) {
+			add_filter( 'gutenberg_classic_block_supports_inserter', '__return_true' );
+		}
+
 		/**
 		 * Runs right after the Jetpack_Mu_Wpcom package is initialized.
 		 *

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -94,6 +94,13 @@ class Jetpack_Mu_Wpcom {
 		// Allow sites with the `enable-classic-block-inserter-support` blog sticker to insert the Classic block.
 		if ( wpcom_has_blog_sticker( 'enable-classic-block-inserter-support', get_wpcom_blog_id() ) ) {
 			add_filter( 'gutenberg_classic_block_supports_inserter', '__return_true' );
+
+			/*
+			 * Gutenberg uses the `gutenberg_` filter while the change is in the plugin.
+			 * Once the new Gutenberg version lands in Core, the filter will be renamed
+			 * to use the `wp_` prefix, and the `gutenberg_` filter can be removed.
+			 */
+			add_filter( 'wp_classic_block_supports_inserter', '__return_true' );
 		}
 
 		/**

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -93,13 +93,6 @@ class Jetpack_Mu_Wpcom {
 
 		// Allow sites with the `enable-classic-block-inserter-support` blog sticker to insert the Classic block.
 		if ( wpcom_has_blog_sticker( 'enable-classic-block-inserter-support', get_wpcom_blog_id() ) ) {
-			add_filter( 'gutenberg_classic_block_supports_inserter', '__return_true' );
-
-			/*
-			 * Gutenberg uses the `gutenberg_` filter while the change is in the plugin.
-			 * Once the new Gutenberg version lands in Core, the filter will be renamed
-			 * to use the `wp_` prefix, and the `gutenberg_` filter can be removed.
-			 */
 			add_filter( 'wp_classic_block_supports_inserter', '__return_true' );
 		}
 


### PR DESCRIPTION
## Proposed changes
* Allow sites with the `enable-classic-block-inserter-support` sticker to opt in to Classic block inserter support.
* When the sticker is present, add the `wp_classic_block_supports_inserter` filter with `__return_true`.

**Related:**
* https://github.com/WordPress/gutenberg/pull/77838
* https://github.com/WordPress/gutenberg/pull/77845

**Previous attempt to allow enabling Classic block support:**
* https://github.com/Automattic/jetpack/pull/48317

## Related product discussion/links
phcsdm-1cI-p2#comment-1711

## Does this pull request change what data or activity we track or use?
No

## Testing instructions
* Use a site running a Gutenberg build that includes the `wp_classic_block_supports_inserter` filter. If the filter is wrapped in an experiment, make sure the experiment is enabled.
* Confirm the site does not have the `enable-classic-block-inserter-support` sticker.
* Open the block editor for a post or page.
* Open the block inserter and search for "Classic".
* Confirm the Classic block is not available for manual insertion.
* Add the `enable-classic-block-inserter-support` sticker to the site.
* Reload the editor.
* Open the block inserter and search for "Classic".
* Confirm the Classic block is available and can be inserted.