### PR TITLE
wpcomsh: footer credit

### DIFF
--- a/projects/plugins/wpcomsh/changelog/DOTTHEM-343-footer-credit
+++ b/projects/plugins/wpcomsh/changelog/DOTTHEM-343-footer-credit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Added word boundary to prevent replacing first instance of the word theme with an empty string when a theme doesn't have a valid style.css

--- a/projects/plugins/wpcomsh/footer-credit/footer-credit-optimizations.php
+++ b/projects/plugins/wpcomsh/footer-credit/footer-credit-optimizations.php
@@ -126,7 +126,7 @@ function wpcom_better_footer_links( $footer ) {
 	$theme_regex = array(
 		'(?:\s*\|\s*)?',       // Optional pipe with spaces (non-capturing)
 		'(?:<span\s[^>]+>)?',  // Optional opening span tag (non-capturing)
-		'(Theme|%s)',          // $1: "Theme" or the localized equivalent
+		'(\bTheme\b|%s)',      // $1: "Theme" or the localized equivalent (word boundaries prevent partial match)
 		'\s*(?:&nbsp;)?:?\s*', // Zero or more whitespace characters, an optional colon, zero or more whitespace characters
 		'(%s|<a[^>]+>%s</a>)', // $2: The theme name, or link
 		'\.?',                 // Optional period


### PR DESCRIPTION
Fixes [DOTTHEM-343](https://linear.app/a8c/issue/DOTTHEM-343/first-instance-of-theme-is-replaced-with-an-empty-string-in-footerphp)

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Adds a word boundary to prevent improper replacement of the first instance of "theme" within a footer.php when the active theme does not follow coding standards and have a valid style.css. 
* We may want to also just early return entirely if the theme name can't be detected.

## Related product discussion/links
- https://linear.app/a8c/issue/DOTTHEM-343/first-instance-of-theme-is-replaced-with-an-empty-string-in-footerphp

## Testing instructions
1. Install and activate the following test theme manually via SFTP/SSH (wp-admin has guards to prevent installing a theme with invalid style.css) `wp theme activate testtheme` - [testtheme.zip](https://github.com/user-attachments/files/27402495/testtheme.zip)
2. Review the footer area on the frontend and see if the screenshot.png image displays or is broken.
3. Review the source code of the page in your browser and search for `wp-content/s/` to ensure an improper string replacement hasn't been made. 

## Does this pull request change what data or activity we track or use?
No