### PR TITLE
Activity Log: free-tier follow-ups (inert overlay + branded illustration)

### DIFF
--- a/projects/packages/activity-log/changelog/free-tier-search-overlay-use-inert
+++ b/projects/packages/activity-log/changelog/free-tier-search-overlay-use-inert
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Activity Log: free-tier DataViews search overlay now uses the `inert` attribute instead of `aria-disabled` + `tabindex="-1"` + `pointer-events: none`.

--- a/projects/packages/activity-log/changelog/free-tier-search-overlay-use-inert
+++ b/projects/packages/activity-log/changelog/free-tier-search-overlay-use-inert
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Activity Log: free-tier DataViews search overlay now uses the `inert` attribute instead of `aria-disabled` + `tabindex="-1"` + `pointer-events: none`.

--- a/projects/packages/activity-log/changelog/manage-backup-action-deep-link-calypso
+++ b/projects/packages/activity-log/changelog/manage-backup-action-deep-link-calypso
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Activity Log: the "Manage backup" row action now opens the Calypso Backup restore flow for that point in time, instead of being a disabled placeholder.
+Activity Log: the "Manage backup" row action now opens the Jetpack Cloud Backup restore flow for that point in time, instead of being a disabled placeholder.

--- a/projects/packages/activity-log/changelog/manage-backup-action-deep-link-calypso
+++ b/projects/packages/activity-log/changelog/manage-backup-action-deep-link-calypso
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Activity Log: the "Manage backup" row action now opens the Calypso Backup restore flow for that point in time, instead of being a disabled placeholder.

--- a/projects/packages/activity-log/changelog/restore-backup-action-label-and-temp-doc
+++ b/projects/packages/activity-log/changelog/restore-backup-action-label-and-temp-doc
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Activity Log: rename the row action to "Restore backup" so the label matches what clicking it actually does — open the restore flow.

--- a/projects/packages/activity-log/changelog/upsell-illustration-and-title-casing
+++ b/projects/packages/activity-log/changelog/upsell-illustration-and-title-casing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Activity Log: refreshed the free-tier upsell illustration to match Jetpack's branding.

--- a/projects/packages/activity-log/src/js/components/ActivityLog/UpsellCallout.tsx
+++ b/projects/packages/activity-log/src/js/components/ActivityLog/UpsellCallout.tsx
@@ -78,7 +78,7 @@ export function UpsellCallout() {
 		<div className="jp-activity-log__upsell-callout">
 			<div className="jp-activity-log__upsell-callout-content">
 				<h2 className="jp-activity-log__upsell-callout-title">
-					{ __( 'Track every action with Activity logs', 'jetpack-activity-log' ) }
+					{ __( 'Track every action with activity logs', 'jetpack-activity-log' ) }
 				</h2>
 				<Text as="p" variant="muted">
 					{ __(

--- a/projects/packages/activity-log/src/js/components/ActivityLog/actions.tsx
+++ b/projects/packages/activity-log/src/js/components/ActivityLog/actions.tsx
@@ -5,24 +5,42 @@ import { useMemo } from 'react';
 import type { Activity } from './types';
 import type { Action } from '@wordpress/dataviews';
 
+interface InitialStateWithCalypsoSlug {
+	jetpackStatus?: { calypsoSlug?: string };
+}
+
+declare const JPACTIVITYLOG_INITIAL_STATE: InitialStateWithCalypsoSlug | undefined;
+
+// Read once at module load; the value doesn't change within a session.
+const calypsoSlug: string =
+	( typeof JPACTIVITYLOG_INITIAL_STATE !== 'undefined'
+		? JPACTIVITYLOG_INITIAL_STATE?.jetpackStatus?.calypsoSlug
+		: undefined ) ?? '';
+
+type Tracks = { recordEvent: ( name: string, props?: Record< string, unknown > ) => void };
+
 type UseActivityActionsOptions = {
 	isLoading: boolean;
+	tracks?: Tracks;
 };
 
 /**
- * Row actions for the DataViews table. Phase 5 wires the "Manage backup"
- * action into the Backup package's admin page; for now the action is
- * present but disabled so the column space is preserved and the planned
- * feature is visible.
+ * Row actions for the DataViews table. The single primary action deep-
+ * links into the Calypso Backup restore flow for the row's rewind point
+ * (`https://wordpress.com/backup/{slug}/restore/{rewindId}`) and opens
+ * in a new tab. Eligibility requires `activityIsRewindable`, a
+ * `rewindId`, and a `calypsoSlug` from Initial_State; rows missing any
+ * of those don't render the action.
  *
  * @param options           - Hook options.
  * @param options.isLoading - Whether the list is currently fetching. Kept
- *                          in the API so Phase 5 doesn't need to refactor
- *                          the call site.
+ *                          in the API for symmetry with the call site.
+ * @param options.tracks    - Optional analytics handle for the click event.
  * @return The actions array for `<DataViews actions=… />`.
  */
 export function useActivityActions( {
 	isLoading,
+	tracks,
 }: UseActivityActionsOptions ): Action< Activity >[] {
 	return useMemo( () => {
 		const backupAction: Action< Activity > = {
@@ -30,11 +48,20 @@ export function useActivityActions( {
 			isPrimary: true,
 			label: __( 'Manage backup', 'jetpack-activity-log' ),
 			icon: <Icon icon={ backup } />,
-			// Phase 5: enable and deep-link into the Backup package's admin page.
-			disabled: true,
-			isEligible: item => item.activityIsRewindable,
-			callback: async () => {
-				/* no-op until Phase 5 */
+			isEligible: item => Boolean( item.activityIsRewindable && item.rewindId && calypsoSlug ),
+			callback: async items => {
+				const item = items[ 0 ];
+				if ( ! item?.rewindId || ! calypsoSlug ) {
+					return;
+				}
+				const url = `https://wordpress.com/backup/${ encodeURIComponent(
+					calypsoSlug
+				) }/restore/${ encodeURIComponent( item.rewindId ) }`;
+				tracks?.recordEvent( 'jetpack_activity_log_manage_backup_click', {
+					rewind_id: item.rewindId,
+					activity_name: item.activityName,
+				} );
+				window.open( url, '_blank', 'noopener,noreferrer' );
 			},
 		};
 
@@ -42,5 +69,5 @@ export function useActivityActions( {
 		void isLoading;
 
 		return [ backupAction ];
-	}, [ isLoading ] );
+	}, [ isLoading, tracks ] );
 }

--- a/projects/packages/activity-log/src/js/components/ActivityLog/actions.tsx
+++ b/projects/packages/activity-log/src/js/components/ActivityLog/actions.tsx
@@ -27,7 +27,7 @@ type UseActivityActionsOptions = {
 /**
  * Row actions for the DataViews table. The single primary action deep-
  * links into the Calypso Backup restore flow for the row's rewind point
- * (`https://wordpress.com/backup/{slug}/restore/{rewindId}`) and opens
+ * (`https://cloud.jetpack.com/backup/{slug}/restore/{rewindId}`) and opens
  * in a new tab. Eligibility requires `activityIsRewindable`, a
  * `rewindId`, and a `calypsoSlug` from Initial_State; rows missing any
  * of those don't render the action.
@@ -54,7 +54,7 @@ export function useActivityActions( {
 				if ( ! item?.rewindId || ! calypsoSlug ) {
 					return;
 				}
-				const url = `https://wordpress.com/backup/${ encodeURIComponent(
+				const url = `https://cloud.jetpack.com/backup/${ encodeURIComponent(
 					calypsoSlug
 				) }/restore/${ encodeURIComponent( item.rewindId ) }`;
 				tracks?.recordEvent( 'jetpack_activity_log_manage_backup_click', {

--- a/projects/packages/activity-log/src/js/components/ActivityLog/actions.tsx
+++ b/projects/packages/activity-log/src/js/components/ActivityLog/actions.tsx
@@ -26,11 +26,17 @@ type UseActivityActionsOptions = {
 
 /**
  * Row actions for the DataViews table. The single primary action deep-
- * links into the Calypso Backup restore flow for the row's rewind point
- * (`https://cloud.jetpack.com/backup/{slug}/restore/{rewindId}`) and opens
- * in a new tab. Eligibility requires `activityIsRewindable`, a
- * `rewindId`, and a `calypsoSlug` from Initial_State; rows missing any
- * of those don't render the action.
+ * links into the Jetpack Cloud Backup restore flow for the row's rewind
+ * point (`https://cloud.jetpack.com/backup/{slug}/restore/{rewindId}`)
+ * and opens in a new tab. Eligibility requires `activityIsRewindable`,
+ * a `rewindId`, and a `calypsoSlug` from Initial_State; rows missing
+ * any of those don't render the action.
+ *
+ * TEMPORARY: this off-site link is a stop-gap until the Backup wp-admin
+ * port (https://github.com/Automattic/jetpack/pull/48236) lands. Once
+ * that ships, every row action here should point at the in-admin
+ * Backup page instead of cloud.jetpack.com so users stay inside their
+ * own wp-admin for the restore flow.
  *
  * @param options           - Hook options.
  * @param options.isLoading - Whether the list is currently fetching. Kept
@@ -46,7 +52,7 @@ export function useActivityActions( {
 		const backupAction: Action< Activity > = {
 			id: 'backup',
 			isPrimary: true,
-			label: __( 'Manage backup', 'jetpack-activity-log' ),
+			label: __( 'Restore backup', 'jetpack-activity-log' ),
 			icon: <Icon icon={ backup } />,
 			isEligible: item => Boolean( item.activityIsRewindable && item.rewindId && calypsoSlug ),
 			callback: async items => {
@@ -57,7 +63,7 @@ export function useActivityActions( {
 				const url = `https://cloud.jetpack.com/backup/${ encodeURIComponent(
 					calypsoSlug
 				) }/restore/${ encodeURIComponent( item.rewindId ) }`;
-				tracks?.recordEvent( 'jetpack_activity_log_manage_backup_click', {
+				tracks?.recordEvent( 'jetpack_activity_log_restore_backup_click', {
 					rewind_id: item.rewindId,
 					activity_name: item.activityName,
 				} );

--- a/projects/packages/activity-log/src/js/components/ActivityLog/activity-logs-callout-illustration.svg
+++ b/projects/packages/activity-log/src/js/components/ActivityLog/activity-logs-callout-illustration.svg
@@ -1,52 +1,45 @@
-<svg width="399" height="244" viewBox="0 0 399 244" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<g clip-path="url(#clip0_6231_1560)">
-<path d="M0 4C0 1.79086 1.79086 0 4 0H395C397.209 0 399 1.79086 399 4V240C399 242.209 397.209 244 395 244H4.00001C1.79087 244 0 242.209 0 240V4Z" fill="#F6F7F7"/>
-<rect opacity="0.8" x="75" y="-25" width="419" height="301" fill="url(#pattern0_6231_1560)"/>
-<ellipse cx="200.146" cy="121.793" rx="75.6176" ry="75.4105" transform="rotate(45 200.146 121.793)" fill="#101517"/>
-<ellipse cx="200.146" cy="121.793" rx="75.6176" ry="75.4105" transform="rotate(45 200.146 121.793)" fill="#F6F7F7"/>
-<circle cx="200.293" cy="122.586" r="27" transform="rotate(45 200.293 122.586)" stroke="url(#paint0_linear_6231_1560)"/>
-<circle cx="200.293" cy="122.586" r="39" transform="rotate(45 200.293 122.586)" stroke="url(#paint1_linear_6231_1560)"/>
-<circle cx="200.293" cy="122.586" r="51" transform="rotate(45 200.293 122.586)" stroke="url(#paint2_linear_6231_1560)"/>
-<circle cx="200.293" cy="122.586" r="63" transform="rotate(45 200.293 122.586)" stroke="url(#paint3_linear_6231_1560)"/>
-<circle cx="200.293" cy="122.586" r="75" transform="rotate(45 200.293 122.586)" stroke="url(#paint4_linear_6231_1560)"/>
-<path d="M200 118V47.0001C200 47.0001 215.5 45.9574 232 53.5C249.5 61.4999 255.452 69.595 263.5 81.5001C272.217 94.3951 274 118 274 118L200 118Z" fill="url(#paint5_linear_6231_1560)"/>
-<path d="M303.5 18.5V225.5H96.5V18.5H303.5Z" stroke="#3858E9"/>
-<circle cx="303" cy="20" r="4.25" fill="white" stroke="#3858E9" stroke-width="1.5"/>
-<circle cx="303" cy="226" r="4.25" fill="white" stroke="#3858E9" stroke-width="1.5"/>
-<circle cx="97" cy="19" r="4.25" fill="white" stroke="#3858E9" stroke-width="1.5"/>
-<circle cx="97" cy="225" r="4.25" fill="white" stroke="#3858E9" stroke-width="1.5"/>
-</g>
+<svg width="399" height="244" viewBox="0 0 399 244" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="399" height="244" fill="#003010"/>
+<path d="M181.201 141.678C191.745 152.222 208.841 152.222 219.385 141.678C229.929 131.134 229.929 114.038 219.385 103.494C208.841 92.9499 191.745 92.9499 181.201 103.494C170.657 114.038 170.657 131.134 181.201 141.678Z" stroke="url(#paint0_linear_6208_69986)"/>
+<path d="M172.716 150.163C187.946 165.394 212.64 165.394 227.87 150.163C243.101 134.933 243.101 110.239 227.87 95.0088C212.64 79.7784 187.946 79.7784 172.716 95.0088C157.485 110.239 157.485 134.933 172.716 150.163Z" stroke="url(#paint1_linear_6208_69986)"/>
+<path d="M164.231 158.648C184.147 178.565 216.439 178.565 236.355 158.648C256.272 138.732 256.272 106.44 236.355 86.5236C216.439 66.6068 184.147 66.6068 164.231 86.5236C144.314 106.44 144.314 138.732 164.231 158.648Z" stroke="url(#paint2_linear_6208_69986)"/>
+<path d="M155.745 167.134C180.348 191.737 220.238 191.737 244.841 167.134C269.444 142.531 269.444 102.641 244.841 78.0383C220.238 53.4352 180.348 53.4352 155.745 78.0383C131.142 102.641 131.142 142.531 155.745 167.134Z" stroke="url(#paint3_linear_6208_69986)"/>
+<path d="M147.26 175.619C176.549 204.908 224.037 204.908 253.326 175.619C282.615 146.33 282.615 98.8423 253.326 69.553C224.037 40.2636 176.549 40.2636 147.26 69.553C117.971 98.8423 117.971 146.33 147.26 175.619Z" stroke="url(#paint4_linear_6208_69986)"/>
+<path d="M200 123V46.053C200 46.053 216.757 44.923 234.595 53.0974C253.514 61.7673 259.948 70.5405 268.649 83.4428C278.072 97.4179 280 123 280 123H200Z" fill="url(#paint5_linear_6208_69986)"/>
+<path d="M303.5 18.5V225.5H96.5V18.5H303.5Z" stroke="#069E08"/>
+<path d="M303 24.25C305.347 24.25 307.25 22.3472 307.25 20C307.25 17.6528 305.347 15.75 303 15.75C300.653 15.75 298.75 17.6528 298.75 20C298.75 22.3472 300.653 24.25 303 24.25Z" fill="#003010" stroke="#069E08" stroke-width="1.5"/>
+<path d="M303 230.25C305.347 230.25 307.25 228.347 307.25 226C307.25 223.653 305.347 221.75 303 221.75C300.653 221.75 298.75 223.653 298.75 226C298.75 228.347 300.653 230.25 303 230.25Z" fill="#003010" stroke="#069E08" stroke-width="1.5"/>
+<path d="M97 23.25C99.3472 23.25 101.25 21.3472 101.25 19C101.25 16.6528 99.3472 14.75 97 14.75C94.6528 14.75 92.75 16.6528 92.75 19C92.75 21.3472 94.6528 23.25 97 23.25Z" fill="#003010" stroke="#069E08" stroke-width="1.5"/>
+<path d="M97 229.25C99.3472 229.25 101.25 227.347 101.25 225C101.25 222.653 99.3472 220.75 97 220.75C94.6528 220.75 92.75 222.653 92.75 225C92.75 227.347 94.6528 229.25 97 229.25Z" fill="#003010" stroke="#069E08" stroke-width="1.5"/>
 <defs>
-<pattern id="pattern0_6231_1560" patternContentUnits="objectBoundingBox" width="0.0324582" height="0.0451827">
-<use xlink:href="#image0_6231_1560" transform="scale(0.000477327 0.000664452)"/>
-</pattern>
-<linearGradient id="paint0_linear_6231_1560" x1="220.452" y1="122.586" x2="178.857" y2="122.637" gradientUnits="userSpaceOnUse">
-<stop stop-color="#3858E9"/>
-<stop offset="1" stop-color="#069E08"/>
+<linearGradient id="paint0_linear_6208_69986" x1="219.385" y1="141.678" x2="181.201" y2="103.494" gradientUnits="userSpaceOnUse">
+<stop stop-color="#2E38FA"/>
+<stop offset="0.528154" stop-color="#48FF50"/>
+<stop offset="1" stop-color="#DAFFDC"/>
 </linearGradient>
-<linearGradient id="paint1_linear_6231_1560" x1="229.411" y1="122.585" x2="169.33" y2="122.66" gradientUnits="userSpaceOnUse">
-<stop stop-color="#3858E9"/>
-<stop offset="1" stop-color="#069E08"/>
+<linearGradient id="paint1_linear_6208_69986" x1="227.87" y1="150.163" x2="172.716" y2="95.0088" gradientUnits="userSpaceOnUse">
+<stop stop-color="#2E38FA"/>
+<stop offset="0.528154" stop-color="#48FF50"/>
+<stop offset="1" stop-color="#DAFFDC"/>
 </linearGradient>
-<linearGradient id="paint2_linear_6231_1560" x1="238.371" y1="122.585" x2="159.803" y2="122.682" gradientUnits="userSpaceOnUse">
-<stop stop-color="#3858E9"/>
-<stop offset="1" stop-color="#069E08"/>
+<linearGradient id="paint2_linear_6208_69986" x1="236.355" y1="158.648" x2="164.231" y2="86.5236" gradientUnits="userSpaceOnUse">
+<stop stop-color="#2E38FA"/>
+<stop offset="0.528154" stop-color="#48FF50"/>
+<stop offset="1" stop-color="#DAFFDC"/>
 </linearGradient>
-<linearGradient id="paint3_linear_6231_1560" x1="247.33" y1="122.584" x2="150.276" y2="122.705" gradientUnits="userSpaceOnUse">
-<stop stop-color="#3858E9"/>
-<stop offset="1" stop-color="#069E08"/>
+<linearGradient id="paint3_linear_6208_69986" x1="244.841" y1="167.134" x2="155.745" y2="78.0383" gradientUnits="userSpaceOnUse">
+<stop stop-color="#2E38FA"/>
+<stop offset="0.528154" stop-color="#48FF50"/>
+<stop offset="1" stop-color="#DAFFDC"/>
 </linearGradient>
-<linearGradient id="paint4_linear_6231_1560" x1="256.29" y1="122.584" x2="140.749" y2="122.727" gradientUnits="userSpaceOnUse">
-<stop stop-color="#3858E9"/>
-<stop offset="1" stop-color="#069E08"/>
+<linearGradient id="paint4_linear_6208_69986" x1="253.326" y1="175.619" x2="147.26" y2="69.553" gradientUnits="userSpaceOnUse">
+<stop stop-color="#2E38FA"/>
+<stop offset="0.528154" stop-color="#48FF50"/>
+<stop offset="1" stop-color="#DAFFDC"/>
 </linearGradient>
-<linearGradient id="paint5_linear_6231_1560" x1="237.267" y1="117.019" x2="220.235" y2="95.6324" gradientUnits="userSpaceOnUse">
-<stop stop-color="#F6F7F7" stop-opacity="0"/>
-<stop offset="1" stop-color="#F6F7F7"/>
+<linearGradient id="paint5_linear_6208_69986" x1="240.289" y1="121.937" x2="221.82" y2="98.8034" gradientUnits="userSpaceOnUse">
+<stop stop-color="#003010" stop-opacity="0"/>
+<stop offset="1" stop-color="#003010"/>
 </linearGradient>
-<clipPath id="clip0_6231_1560">
-<path d="M0 4C0 1.79086 1.79086 0 4 0H395C397.209 0 399 1.79086 399 4V240C399 242.209 397.209 244 395 244H4.00001C1.79087 244 0 242.209 0 240V4Z" fill="white"/>
-</clipPath>
-<image id="image0_6231_1560" width="68" height="68" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEQAAABECAYAAAA4E5OyAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAylpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDkuMC1jMDAxIDc5LmMwMjA0YjJkZWYsIDIwMjMvMDIvMDItMTI6MTQ6MjQgICAgICAgICI+IDxyZGY6UkRGIHhtbG5zOnJkZj0iaHR0cDovL3d3dy53My5vcmcvMTk5OS8wMi8yMi1yZGYtc3ludGF4LW5zIyI+IDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiIHhtbG5zOnhtcD0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wLyIgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iIHhtbG5zOnN0UmVmPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VSZWYjIiB4bXA6Q3JlYXRvclRvb2w9IkFkb2JlIFBob3Rvc2hvcCAyNC41IChNYWNpbnRvc2gpIiB4bXBNTTpJbnN0YW5jZUlEPSJ4bXAuaWlkOkU4MTBCRTc4NkI2QTExRjBCOTI1QjRCNzdDOENGRkMzIiB4bXBNTTpEb2N1bWVudElEPSJ4bXAuZGlkOkU4MTBCRTc5NkI2QTExRjBCOTI1QjRCNzdDOENGRkMzIj4gPHhtcE1NOkRlcml2ZWRGcm9tIHN0UmVmOmluc3RhbmNlSUQ9InhtcC5paWQ6RTgxMEJFNzY2QjZBMTFGMEI5MjVCNEI3N0M4Q0ZGQzMiIHN0UmVmOmRvY3VtZW50SUQ9InhtcC5kaWQ6RTgxMEJFNzc2QjZBMTFGMEI5MjVCNEI3N0M4Q0ZGQzMiLz4gPC9yZGY6RGVzY3JpcHRpb24+IDwvcmRmOlJERj4gPC94OnhtcG1ldGE+IDw/eHBhY2tldCBlbmQ9InIiPz5uSzX6AAAA2UlEQVR42uzaTQ6CMBAGUMaw0FtwET28XoRb6K6OCYk/29aC5n3JBFYd+gIlaRqllEGe2SEAAgQIECBAgAABAgQIECBA/j1j7QARMeXllPXYWLlkzZ3n8Na/lDKv/YYcs/ZZh+XBeqdp/xYg8XK/xvZb0/4tQM5Z16zb8sn0TtP+UbunmmvIphbF2vn4ywABAgQIECBAgAABAgQIECBAgAARIECAAAECBAgQIBvM2GCMadjQ+ZDa/s6HfAHE+ZCPOB/iLwMEiAABAgQIECBAgAABAgTID+cuwADKAy+BgXQl5gAAAABJRU5ErkJggg=="/>
 </defs>
 </svg>

--- a/projects/packages/activity-log/src/js/components/ActivityLog/index.tsx
+++ b/projects/packages/activity-log/src/js/components/ActivityLog/index.tsx
@@ -134,15 +134,15 @@ export default function ActivityLog() {
 	// On free tier, neutralize DataViews' real search + filter cluster
 	// (the `.dataviews__search` Stack rendered by `DataViews`'s default
 	// UI). We let DataViews ship its own toolbar so the page tracks
-	// upstream changes for free, then attach: `aria-disabled` for
-	// assistive tech, a `title` attribute that surfaces the upgrade
-	// nudge as a native browser tooltip on hover, and `tabindex="-1"`
-	// on every focusable descendant so the cluster is unreachable via
-	// keyboard. Pointer-event blocking on the children is handled in
-	// CSS via the `[aria-disabled="true"]` rule.
-	// `MutationObserver` re-applies after DataViews remounts the
-	// toolbar / re-renders the input (e.g., on initial fetch resolution
-	// or layout switch) so React's render doesn't strip the attributes.
+	// upstream changes for free, then mark the cluster `inert` — which
+	// blocks pointer + keyboard interaction and removes descendants from
+	// the a11y tree in one shot — and add a `title` attribute that
+	// surfaces the upgrade nudge as a native browser tooltip on hover.
+	// Tradeoff: Firefox suppresses `title` tooltips inside an inert
+	// subtree, so the nudge doesn't appear there; accepted per #48527.
+	// `MutationObserver` re-applies after DataViews remounts the toolbar
+	// / re-renders the input (e.g., on initial fetch resolution or
+	// layout switch) so React's render doesn't strip the attributes.
 	useEffect( () => {
 		if ( hasActivityLogsAccess ) {
 			return;
@@ -157,20 +157,12 @@ export default function ActivityLog() {
 
 		const apply = ( root: ParentNode ) => {
 			const cluster = root.querySelector< HTMLElement >( '.dataviews__search' );
-			if ( ! cluster ) {
+			if ( ! cluster || cluster.hasAttribute( 'inert' ) ) {
 				return;
 			}
 
-			if ( cluster.getAttribute( 'aria-disabled' ) !== 'true' ) {
-				cluster.setAttribute( 'aria-disabled', 'true' );
-				cluster.setAttribute( 'title', tooltipText );
-			}
-
-			cluster.querySelectorAll< HTMLElement >( 'input, button, [tabindex]' ).forEach( el => {
-				if ( el.getAttribute( 'tabindex' ) !== '-1' ) {
-					el.setAttribute( 'tabindex', '-1' );
-				}
-			} );
+			cluster.setAttribute( 'inert', '' );
+			cluster.setAttribute( 'title', tooltipText );
 		};
 
 		apply( wrapper );

--- a/projects/packages/activity-log/src/js/components/ActivityLog/index.tsx
+++ b/projects/packages/activity-log/src/js/components/ActivityLog/index.tsx
@@ -93,44 +93,6 @@ export default function ActivityLog() {
 	const { tracks } = useAnalytics();
 	const wrapperRef = useRef< HTMLDivElement >( null );
 
-	// DataViews' `Action` API doesn't expose a tooltip prop, so the
-	// disabled "Manage backup" stub renders without any hint as to *why*
-	// it can't be clicked. Attach a `title` to those buttons after each
-	// render so users hovering get the "Coming soon" context — and
-	// screen readers pick it up too. The MutationObserver re-runs on
-	// pagination / filter changes, when DataViews swaps the row DOM.
-	//
-	// TODO(#48236): drop this whole effect. Once the Backup wp-admin
-	// page lands the action stops being a stub and the row will render
-	// as an enabled link, so this textContent-matching DOM hack — which
-	// is fragile across translations and re-fires on every DataViews
-	// mutation — won't be needed at all.
-	useEffect( () => {
-		const wrapper = wrapperRef.current;
-		if ( ! wrapper ) {
-			return;
-		}
-		const manageBackupLabel = __( 'Manage backup', 'jetpack-activity-log' );
-		const tooltipText = __( 'Coming soon', 'jetpack-activity-log' );
-		const apply = ( root: ParentNode ) => {
-			const buttons = root.querySelectorAll< HTMLButtonElement >(
-				'.dataviews-item-actions button[disabled]'
-			);
-			buttons.forEach( btn => {
-				if (
-					btn.textContent?.trim() === manageBackupLabel &&
-					btn.getAttribute( 'title' ) !== tooltipText
-				) {
-					btn.setAttribute( 'title', tooltipText );
-				}
-			} );
-		};
-		apply( wrapper );
-		const observer = new MutationObserver( () => apply( wrapper ) );
-		observer.observe( wrapper, { subtree: true, childList: true } );
-		return () => observer.disconnect();
-	}, [] );
-
 	// On free tier, neutralize DataViews' real search + filter cluster
 	// (the `.dataviews__search` Stack rendered by `DataViews`'s default
 	// UI). We let DataViews ship its own toolbar so the page tracks
@@ -274,7 +236,7 @@ export default function ActivityLog() {
 		activityLogTypes: groupCountsData?.groups,
 	} );
 
-	const actions = useActivityActions( { isLoading: isFetching } );
+	const actions = useActivityActions( { isLoading: isFetching, tracks } );
 
 	const onChangeView = useCallback(
 		( next: View ) => {

--- a/projects/packages/activity-log/src/js/style.scss
+++ b/projects/packages/activity-log/src/js/style.scss
@@ -57,21 +57,15 @@ body.jetpack_page_jetpack-activity-log {
 		}
 	}
 
-	// Visual + click-blocking half of the free-tier "overlay" approach:
-	// the effect in ActivityLog/index.tsx toggles `aria-disabled` and
-	// `tabindex="-1"` on DataViews' real `.dataviews__search` cluster
-	// (search input + filter toggle), and adds a `title` for the
-	// upgrade tooltip. This rule dims the cluster, shows a not-allowed
-	// cursor, and shuts off pointer events on the controls inside so
-	// clicks fall through to the cluster (keeping it hoverable for the
-	// browser-native title tooltip).
-	.dataviews__search[aria-disabled="true"] {
+	// Visual half of the free-tier "overlay" approach: the effect in
+	// ActivityLog/index.tsx marks DataViews' real `.dataviews__search`
+	// cluster (search input + filter toggle) `inert` and adds a `title`
+	// for the upgrade tooltip. `inert` natively blocks pointer +
+	// keyboard interaction and hides descendants from a11y, so this
+	// rule only carries the visual disabled state.
+	.dataviews__search[inert] {
 		opacity: 0.5;
 		cursor: not-allowed;
-
-		> * {
-			pointer-events: none;
-		}
 	}
 
 	// DataViews renders its own surface; don't double-pad it.


### PR DESCRIPTION
Fixes #48527

## Proposed changes
* Free-tier search overlay (Activity Log): swap the `aria-disabled` + `tabindex="-1"` + `pointer-events: none` triple for a single `inert` attribute on `.dataviews__search`. `inert` natively blocks pointer + keyboard interaction and removes descendants from the a11y tree. Tradeoff: Firefox suppresses `title` tooltips inside an inert subtree, so the upgrade nudge won't appear there — accepted per the issue.
* Refresh the free-tier upsell illustration to the Jetpack-branded SVG (per [PR #48418 review](https://github.com/Automattic/jetpack/pull/48418#issuecomment-4357424303)). Filename kept so the webpack import resolves untouched.
* Lowercase "activity logs" in the upsell title — sentence case to match Jetpack copy conventions.
* Wire up the row action — relabelled **"Restore backup"** so the copy matches what the click does. Instead of being a disabled placeholder, it now opens the Jetpack Cloud Backup restore flow for that rewind point in a new tab (`https://cloud.jetpack.com/backup/{calypsoSlug}/restore/{rewindId}`). Drops the "Coming soon" tooltip MutationObserver hack the placeholder needed.
  * **Note:** the off-site cloud.jetpack.com link is a stop-gap until the Backup wp-admin port (#48236) lands. Once that ships, every row action here should point at the in-admin Backup page so users stay inside their own wp-admin for the restore flow. Documented in the `useActivityActions` docblock.

## Related product discussion/links
* Issue #48527
* Original PR #48418
* Backup wp-admin port (follow-up that will replace the off-site link): #48236

## Does this pull request change what data or activity we track or use?
Adds a new Tracks event: `jetpack_activity_log_restore_backup_click` (props: `rewind_id`, `activity_name`) when the user clicks the "Restore backup" row action.

## Testing instructions
**Free-tier follow-ups:**
1. Activate Jetpack on a site **without** an active Backup / VaultPress plan (free tier).
2. Navigate to **Jetpack → Activity Log** in wp-admin.
3. Confirm the new Jetpack-branded illustration appears in the upsell card below the table.
4. Confirm the title reads "Track every action with activity logs" (lowercase "activity").
5. In Chrome / Safari, hover the disabled search input/filter cluster — the "Upgrade your plan to use this feature." tooltip should appear. In Firefox, the tooltip is intentionally suppressed (inert subtree limitation).
6. Try to focus the search input via Tab — focus should skip the cluster.
7. Try to click into the search input or filter button — clicks should be inert.
8. The view-config (cog) on the right of the toolbar should still be fully usable.

**Restore backup action:**
9. On a site **with** Backup access, navigate to **Jetpack → Activity Log**.
10. Hover a rewindable activity row (one with a backup icon in Calypso) — the "Restore backup" action should be present and enabled.
11. Click it — a new tab should open at `https://cloud.jetpack.com/backup/{your-site-slug}/restore/{rewind-id}`.
12. Rows that aren't rewindable should not show the action at all (not even disabled).
13. Confirm a `jetpack_activity_log_restore_backup_click` Tracks event fires on click.
