### PR TITLE
Sitemaps: backtick column names via `%i` placeholders 

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-48202-sitemap-backtick-columns
+++ b/projects/plugins/jetpack/changelog/fix-48202-sitemap-backtick-columns
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Sitemaps: Fix SQL error when wp_posts has a column whose name is a reserved SQL keyword.

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-librarian.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-librarian.php
@@ -306,6 +306,7 @@ class Jetpack_Sitemap_Librarian {
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- WPCS: db call ok; no-cache ok.
 		return $wpdb->get_results(
+			// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- Sniff is confused by both the interpolation of `$columns['placeholders']` and the spread.
 			$wpdb->prepare(
 				"SELECT {$columns['placeholders']}
 					FROM $wpdb->posts
@@ -448,6 +449,7 @@ class Jetpack_Sitemap_Librarian {
 
 		// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.QuotedSimplePlaceholder,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- WPCS: db call ok; no-cache ok.
 		return $wpdb->get_results(
+			// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- Sniff is confused by both the interpolation of `$columns['placeholders']` and the spread.
 			$wpdb->prepare(
 				"SELECT {$columns['placeholders']}
 					FROM $wpdb->posts

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-librarian.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-librarian.php
@@ -302,18 +302,19 @@ class Jetpack_Sitemap_Librarian {
 		}
 		$post_types_list = implode( ',', $post_types );
 
-		$columns_list = $this->get_sanitized_post_columns( $wpdb );
+		$columns = $this->get_sanitized_post_columns( $wpdb );
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- WPCS: db call ok; no-cache ok.
 		return $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT $columns_list
+				"SELECT {$columns['placeholders']}
 					FROM $wpdb->posts
 					WHERE post_status='publish'
 						AND post_type IN ($post_types_list)
 						AND ID>%d
 					ORDER BY ID ASC
 					LIMIT %d;",
+				...$columns['columns'],
 				$from_id,
 				$num_posts
 			)
@@ -445,18 +446,19 @@ class Jetpack_Sitemap_Librarian {
 
 		$post_types_list = implode( ',', $post_types );
 
-		$columns_list = $this->get_sanitized_post_columns( $wpdb );
+		$columns = $this->get_sanitized_post_columns( $wpdb );
 
 		// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.QuotedSimplePlaceholder,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- WPCS: db call ok; no-cache ok.
 		return $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT $columns_list
+				"SELECT {$columns['placeholders']}
 					FROM $wpdb->posts
 					WHERE post_status='publish'
 						AND post_date >= '%s'
 						AND post_type IN ($post_types_list)
 					ORDER BY post_date DESC
 					LIMIT %d;",
+				...$columns['columns'],
 				$two_days_ago,
 				$num_posts
 			)
@@ -465,21 +467,33 @@ class Jetpack_Sitemap_Librarian {
 	}
 
 	/**
-	 * Returns all columns from the posts table,
-	 * except post_content and post_content_filtered.
+	 * Returns all columns from the posts table, except post_content and post_content_filtered,
+	 * along with a matching list of %i placeholders for safe use in wpdb::prepare().
+	 *
+	 * Using %i identifier placeholders ensures column names are correctly backtick-quoted,
+	 * which avoids SQL errors when a column name happens to be a reserved keyword
+	 * (e.g. `order`, `key`, `group`).
 	 *
 	 * @param object $wpdb The WordPress database object.
-	 * @return string The sanitized post columns.
+	 * @return array {
+	 *     @type string   $placeholders Comma-separated list of %i placeholders, one per column.
+	 *     @type string[] $columns      The column names to feed into wpdb::prepare().
+	 * }
 	 */
 	private function get_sanitized_post_columns( $wpdb ) {
-		$columns = array_filter(
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-			$wpdb->get_col( "SHOW COLUMNS FROM $wpdb->posts" ),
-			function ( $column ) {
-				return $column !== 'post_content' && $column !== 'post_content_filtered';
-			}
+		$columns = array_values(
+			array_filter(
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+				$wpdb->get_col( "SHOW COLUMNS FROM $wpdb->posts" ),
+				function ( $column ) {
+					return $column !== 'post_content' && $column !== 'post_content_filtered';
+				}
+			)
 		);
 
-		return implode( ',', array_map( 'esc_sql', $columns ) );
+		return array(
+			'placeholders' => implode( ',', array_fill( 0, count( $columns ), '%i' ) ),
+			'columns'      => $columns,
+		);
 	}
 }

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-librarian.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-librarian.php
@@ -314,9 +314,7 @@ class Jetpack_Sitemap_Librarian {
 						AND ID>%d
 					ORDER BY ID ASC
 					LIMIT %d;",
-				...$columns['columns'],
-				$from_id,
-				$num_posts
+				...array_merge( $columns['columns'], array( $from_id, $num_posts ) )
 			)
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
@@ -458,9 +456,7 @@ class Jetpack_Sitemap_Librarian {
 						AND post_type IN ($post_types_list)
 					ORDER BY post_date DESC
 					LIMIT %d;",
-				...$columns['columns'],
-				$two_days_ago,
-				$num_posts
+				...array_merge( $columns['columns'], array( $two_days_ago, $num_posts ) )
 			)
 		);
 		// phpcs:enable WordPress.DB.PreparedSQLPlaceholders.QuotedSimplePlaceholder,WordPress.DB.PreparedSQL.InterpolatedNotPrepared

--- a/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Librarian_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Librarian_Test.php
@@ -164,4 +164,45 @@ class Jetpack_Sitemap_Librarian_Test extends WP_UnitTestCase {
 		$this->assertTrue( $librarian->read_sitemap_data( 'name-2', 'type' ) === null );
 		$this->assertTrue( $librarian->read_sitemap_data( 'name-3', 'type' ) === null );
 	}
+
+	/**
+	 * Regression test for https://github.com/Automattic/jetpack/issues/48202
+	 *
+	 * If wp_posts has a column whose name is a reserved SQL keyword (e.g. `order`),
+	 * the SELECT used by the sitemap query must still succeed because column names
+	 * are passed as %i identifier placeholders to wpdb::prepare().
+	 *
+	 * @group jetpack-sitemap
+	 */
+	#[Group( 'jetpack-sitemap' )]
+	public function test_query_posts_after_id_handles_reserved_keyword_columns() {
+		global $wpdb;
+
+		// Add a column whose name is a reserved SQL keyword.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->query( "ALTER TABLE {$wpdb->posts} ADD COLUMN `order` INT NULL" );
+
+		try {
+			$post_id = self::factory()->post->create(
+				array(
+					'post_status' => 'publish',
+					'post_type'   => 'post',
+				)
+			);
+
+			$librarian = new Jetpack_Sitemap_Librarian();
+			$results   = $librarian->query_posts_after_id( 0, 10 );
+
+			// The query must run without raising a SQL error.
+			$this->assertSame( '', $wpdb->last_error );
+			$this->assertIsArray( $results );
+
+			// And the post we just created should come back.
+			$ids = wp_list_pluck( $results, 'ID' );
+			$this->assertContains( (string) $post_id, array_map( 'strval', $ids ) );
+		} finally {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->query( "ALTER TABLE {$wpdb->posts} DROP COLUMN `order`" );
+		}
+	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Librarian_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Librarian_Test.php
@@ -178,9 +178,15 @@ class Jetpack_Sitemap_Librarian_Test extends WP_UnitTestCase {
 	public function test_query_posts_after_id_handles_reserved_keyword_columns() {
 		global $wpdb;
 
-		// Add a column whose name is a reserved SQL keyword.
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$wpdb->query( "ALTER TABLE {$wpdb->posts} ADD COLUMN `order` INT NULL" );
+		// Check whether the column already exists before adding it.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$column_existed = (bool) $wpdb->get_var( "SHOW COLUMNS FROM {$wpdb->posts} LIKE 'order'" );
+
+		if ( ! $column_existed ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->query( "ALTER TABLE {$wpdb->posts} ADD COLUMN `order` INT NULL" );
+			$this->assertEmpty( $wpdb->last_error, 'ALTER TABLE to add `order` column failed.' );
+		}
 
 		try {
 			$post_id = self::factory()->post->create(
@@ -201,8 +207,11 @@ class Jetpack_Sitemap_Librarian_Test extends WP_UnitTestCase {
 			$ids = wp_list_pluck( $results, 'ID' );
 			$this->assertContains( (string) $post_id, array_map( 'strval', $ids ) );
 		} finally {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange,WordPress.DB.DirectDatabaseQuery.NoCaching
-			$wpdb->query( "ALTER TABLE {$wpdb->posts} DROP COLUMN `order`" );
+			// Only drop the column if we added it — don't mutate a pre-existing schema.
+			if ( ! $column_existed ) {
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.SchemaChange,WordPress.DB.DirectDatabaseQuery.NoCaching
+				$wpdb->query( "ALTER TABLE {$wpdb->posts} DROP COLUMN `order`" );
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes #48202

`Jetpack_Sitemap_Librarian::get_sanitized_post_columns()` was running column names through `esc_sql()`, which is for string values, not identifiers. If `wp_posts` had a column whose name was a reserved SQL keyword (e.g. order), the resulting SELECT would error out.

As suggested in the issue thread, switching to `%i` identifier placeholders in `wpdb::prepare() is the idiomatic fix`. 
It backtick-quotes and escapes identifiers correctly. The helper now returns both the placeholder string and the column array; both call sites splat the array into prepare().

Includes a regression test that adds an order column to `wp_posts`, runs the query, and asserts it succeeds.
Reported by @nebbens, with the suggested approach from @anomiex.

## Testing instructions

1. On a Jetpack-enabled WordPress test site, run:
```sql
   ALTER TABLE wp_posts ADD COLUMN `order` INT NULL;
```
2. Trigger sitemap regeneration (e.g. visit `/sitemap.xml` or `wp jetpack sitemap_build`).
3. Confirm the sitemap is generated without SQL errors.
4. Drop the column afterwards:
```sql
   ALTER TABLE wp_posts DROP COLUMN `order`;
```

The included regression test (`test_query_posts_after_id_handles_reserved_keyword_columns`) automates this end-to-end.

## Does this pull request change what data or activity we track or use?

No.
