### PR TITLE
My Jetpack: fix onboarding interstitial squeezed by admin-page-layout mixin

### DIFF
--- a/projects/packages/my-jetpack/_inc/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/style.module.scss
@@ -7,12 +7,16 @@
 	// viewport bottom) matches Boost / Protect / VideoPress / Search /
 	// Newsletter / Publicize / Backup / Jetpack network admin / AI.
 
-	// Excluded: My Jetpack's `.jetpack-admin-full-screen` interstitial mode,
-	// which hides the admin bar and takes over the whole viewport; its
-	// existing rules (further down in this file) override wp-admin chrome
-	// directly and should keep doing so. The `:has(.jetpack-admin-full-screen)`
-	// selector scopes the mixin to the regular dashboard view only.
-	body.jetpack_page_my-jetpack:not(:has(.jetpack-admin-full-screen)) {
+	// Excluded: My Jetpack's `.jetpack-admin-full-screen` interstitial mode
+	// (e.g. the `step=onboarding` "Supercharge my site" screen), which hides
+	// the admin bar and takes over the whole viewport; its existing rules
+	// (further down in this file) override wp-admin chrome directly and
+	// should keep doing so. The class lives on `<body>` itself — added
+	// server-side via `admin_body_class` for `step=onboarding` and
+	// client-side by the `useFullScreen` hook for other full-screen routes —
+	// so the opt-out matches it as a sibling class on `<body>`, not as a
+	// descendant via `:has()`.
+	body.jetpack_page_my-jetpack:not(.jetpack-admin-full-screen) {
 
 		@include jetpack-admin-page-layout;
 	}

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-fullscreen-mixin-opt-out
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-fullscreen-mixin-opt-out
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: fix `.jetpack-admin-full-screen` interstitial pages (e.g. the `step=onboarding` "Supercharge my site" screen) being constrained by the shared admin-page-layout mixin. The opt-out selector was looking for `.jetpack-admin-full-screen` as a descendant of `<body>` via `:has()`, but the class is added directly to `<body>`, so the predicate never matched and the mixin applied to onboarding too.


### PR DESCRIPTION
Fixes a regression introduced by #48109 (the shared `jetpack-admin-page-layout` mixin).

## Proposed changes

* Switch the My Jetpack mixin opt-out from `body.jetpack_page_my-jetpack:not(:has(.jetpack-admin-full-screen))` to `body.jetpack_page_my-jetpack:not(.jetpack-admin-full-screen)`.

`.jetpack-admin-full-screen` is added directly to `<body>` — server-side in `Initializer::add_onboarding_admin_body_class()` for the `step=onboarding` route, and client-side in `useFullScreen` via `document.body.classList.add(…)` for any other full-screen view. The previous `:has()` predicate looked for the class on a *descendant* of `<body>`, which never matched, so `:not(:has(…))` was always true and the mixin's `position: fixed; top; left:160px;` rules clobbered the existing `.jetpack-admin-full-screen` chrome-overrides — squeezing the onboarding "Supercharge my site" CTA into the regular content slot instead of letting it take over the viewport.

The bespoke `.jetpack-admin-full-screen { … }` block further down the same file is unchanged and continues to handle the take-over-the-viewport rendering.

## Related product discussion/links

* JETPACK-1391 (Jetpack Experience Unification)
* Original mixin PR: #48109

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The onboarding interstitial only renders the first time a fresh, never-connected site visits My Jetpack — so the easiest path is a brand-new Jurassic Ninja site:

1. Spin up a JN site from this branch and log into wp-admin.
2. Navigate to **Jetpack → My Jetpack** (or any URL that resolves to `wp-admin/admin.php?page=my-jetpack`).
3. The site will redirect to `wp-admin/admin.php?page=my-jetpack&step=onboarding`.

**Expected:** The "Start with Jetpack for free / Supercharge my site" interstitial fills the entire viewport edge-to-edge. The wp-admin sidebar and admin bar are hidden, the testimonial panel reaches the right edge of the screen, and there's no left/top inset where wp-admin chrome used to be.

**Before this fix (current trunk):** the interstitial is constrained to a `position: fixed` box offset by the (hidden) sidebar (160px from the left) and admin bar (32px from the top), so the layout reads as a half-rendered modal on top of empty space.

Smoke-test the regular dashboard too:

4. Click **Supercharge my site** to start the connection flow, complete it, and land on the normal My Jetpack dashboard.
5. The dashboard should still use the unified layout (sticky header, internally scrollable middle, JetpackFooter pinned at the bottom) — i.e. the mixin is still applied when `.jetpack-admin-full-screen` is *not* on `<body>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
