### PR TITLE
Search Blocks: clear stale results when a search request errors out

### DIFF
--- a/projects/packages/search/changelog/atlas-search-170-clear-stale-results-on-error
+++ b/projects/packages/search/changelog/atlas-search-170-clear-stale-results-on-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search blocks: clear the previous query's results, total count, and aggregation buckets when a search request errors out so the error message no longer renders alongside stale data.

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -495,7 +495,21 @@ const { state, actions } = store( NAMESPACE, {
 				}
 			} catch {
 				if ( myToken === searchToken ) {
+					// Clear the result-shape fields alongside `hasError` so a
+					// failed query doesn't leave the previous query's results,
+					// total count, or aggregation buckets visible underneath
+					// the error message — the page would otherwise show a
+					// "Found N results" count and stale filter buckets next to
+					// a `role="alert"` "Something went wrong" message, which
+					// reads as both successful and broken at the same time.
+					// `loadMore()` deliberately does NOT do this — its catch
+					// block leaves the existing pages alone since they're
+					// still valid; only the next page failed to fetch.
 					state.hasError = true;
+					state.results = [];
+					state.totalResults = 0;
+					state.pageHandle = null;
+					state.aggregations = {};
 				}
 			} finally {
 				if ( myToken === searchToken ) {

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -222,6 +222,50 @@ describe( 'store actions', () => {
 		expect( state.results.map( r => r.title ) ).toContain( 'Recovered result' );
 	} );
 
+	it( 'clears the previous query results when search() errors out', async () => {
+		// Seed the store as if a successful query had just resolved, so we
+		// can prove the error path tears that data down. Without this, a
+		// subsequent failed search would render its `role="alert"` message
+		// underneath stale results and a stale "Found N results" count.
+		state.results = [ { id: 'old-1', title: 'Stale result' } ];
+		state.totalResults = 5;
+		state.pageHandle = 'old-page';
+		state.aggregations = { category: { buckets: [ { key: 'news', doc_count: 3 } ] } };
+		state.hasError = false;
+
+		global.fetch.mockRejectedValueOnce( new Error( 'network down' ) );
+		await runGenerator( actions.search( { syncUrl: false } ) );
+
+		expect( state.hasError ).toBe( true );
+		expect( state.results ).toEqual( [] );
+		expect( state.totalResults ).toBe( 0 );
+		expect( state.pageHandle ).toBeNull();
+		expect( state.aggregations ).toEqual( {} );
+		// `resultsCountText` reads from `totalResults` via `computeResultsCountText`,
+		// so an empty count string falls out for free — no extra wiring.
+		expect( state.resultsCountText ).toBe( '' );
+	} );
+
+	it( 'leaves the existing results in place when loadMore() errors out', async () => {
+		// loadMore failures must not clear the first-page results — they're
+		// still valid; only the *next* page failed to fetch. The success
+		// path of the first search seeded the list; loadMore's catch must
+		// not regress that.
+		state.results = [ { id: 'page1-1', title: 'Page 1 result' } ];
+		state.totalResults = 50;
+		state.pageHandle = 'next-page';
+		state.aggregations = { category: { buckets: [ { key: 'news', doc_count: 3 } ] } };
+
+		global.fetch.mockRejectedValueOnce( new Error( 'network down' ) );
+		await runGenerator( actions.loadMore() );
+
+		expect( state.hasError ).toBe( true );
+		expect( state.results ).toHaveLength( 1 );
+		expect( state.results[ 0 ].title ).toBe( 'Page 1 result' );
+		expect( state.totalResults ).toBe( 50 );
+		expect( state.aggregations.category.buckets[ 0 ].key ).toBe( 'news' );
+	} );
+
 	it( 'drops load-more responses superseded by a new search', async () => {
 		const loadMoreResponse = createDeferredResponse();
 		global.fetch.mockReturnValueOnce( loadMoreResponse.promise ).mockResolvedValueOnce(


### PR DESCRIPTION
Fixes [SEARCH-170](https://linear.app/a8c/issue/SEARCH-170/search-blocks-clear-stale-results-when-a-search-request-errors-out)

## Why

When a Jetpack Search request fails — network drop, server error, anything that lands in the action's `catch` — the visitor sees a page that reads as both successful and broken at once: the previous query's results, a *"Found N results"* count, and the prior filter buckets are still rendered, with a `role="alert"` *"Something went wrong"* message underneath. Screen-reader users hear an alert announcement while sighted users see what looks like a normal result page; neither group can tell the data they're looking at is stale.

Clearing the result-shape fields when the search errors makes the error message stand alone — the page now matches the alert.

## Proposed changes

* In `actions.search()` in `projects/packages/search/src/search-blocks/store/index.js`, the catch block now clears `state.results`, `state.totalResults`, `state.pageHandle`, and `state.aggregations` alongside flipping `state.hasError`. `state.resultsCountText` falls out for free since `computeResultsCountText` already returns an empty string when `totalResults === 0`.
* `actions.loadMore()`'s catch is intentionally unchanged — when pagination fails, the previously-fetched pages are still valid and clearing them would discard correct data. A new test locks that contract in.
* New unit-test coverage in `tests/js/search-blocks/store.test.js`:
  * `search()` errors must clear the four result-shape fields and `resultsCountText`.
  * `loadMore()` errors must leave the existing first-page results, total, and aggregations in place.

## Related product discussion/links

* [SEARCH-170](https://linear.app/a8c/issue/SEARCH-170/search-blocks-clear-stale-results-when-a-search-request-errors-out)
* Surfaced while reviewing [#48513](https://github.com/Automattic/jetpack/pull/48513) — that PR consolidated the result-state blocks; this one fixes the stale-data problem in the underlying error path.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The user-visible diff requires a real search-fetch failure, so the easiest manual repro is via DevTools network throttling.

1. Build the package: `pnpm jetpack build packages/search` (or run the four-layer matrix from the [`jetpack-build-matrix`](../../.claude/skills/jetpack-build-matrix.md) skill if you're testing in a live env).
2. On a page rendering the Jetpack Search results region (e.g. the `Blog Search Page` pattern, or a built-in `?s=...` search), perform a query that returns at least a few results. Confirm the results list, the count block, and any filter buckets render normally.
3. Open DevTools → Network → set throttling to **Offline** (or block the search REST endpoint via the request-blocking panel).
4. Submit a new query (or change a filter to trigger a re-fetch).
5. Confirm the **error region** appears with `role="alert"` and the default "Something went wrong" copy, **and** that the previous query's results, count, and filter buckets are no longer visible — the error message should stand alone.
6. Set throttling back to **Online** and re-run the query. The results should come back as expected (no lingering "error" state).
7. **Pagination edge case:** with throttling Online, run a query that has multiple pages, click *Load more*, then set throttling Offline and click *Load more* again. The error region should appear, but the first page's results should still be visible — `loadMore()` must not clear them.
8. Run the unit suite: `pnpm exec jest --testPathPatterns=store.test` (75 tests pass, including the two new error-path assertions).
