### PR TITLE
docker: resolve monorepo plugins_url via composer.json name

### DIFF
--- a/tools/docker/mu-plugins/fix-monorepo-plugins-url.php
+++ b/tools/docker/mu-plugins/fix-monorepo-plugins-url.php
@@ -35,9 +35,20 @@ function jetpack_docker_plugins_url( $url, $path, $plugin ) {
 	$packages = ( new Monorepo() )->get( 'packages' );
 
 	if ( strpos( $url, $packages ) !== false && strpos( $plugin, $packages ) === 0 ) {
-		// Look through available monorepo plugins until we find one with the plugin symlink.
-		$suffix1     = '/jetpack_vendor/automattic/jetpack-' . substr( $plugin, strlen( $packages ) );
-		$suffix2     = '/vendor/automattic/jetpack-' . substr( $plugin, strlen( $packages ) );
+		// The vendor symlink follows the package's composer name, which usually —
+		// but not always — matches the directory name (e.g., packages/scan/ has
+		// composer name automattic/jetpack-scan-page). Read composer.json to find
+		// the actual name; fall back to the directory-name convention when the
+		// composer.json can't be read.
+		$relative      = substr( $plugin, strlen( $packages ) );
+		$slash_pos     = strpos( $relative, '/' );
+		$package_dir   = false === $slash_pos ? $relative : substr( $relative, 0, $slash_pos );
+		$sub_path      = false === $slash_pos ? '' : substr( $relative, $slash_pos );
+		$composer_name = jetpack_docker_resolve_composer_name( $packages . $package_dir )
+			?? 'automattic/jetpack-' . $package_dir;
+
+		$suffix1     = '/jetpack_vendor/' . $composer_name . $sub_path;
+		$suffix2     = '/vendor/' . $composer_name . $sub_path;
 		$real_plugin = realpath( $plugin );
 		if ( false !== $real_plugin ) {
 			foreach ( $wp_plugin_paths as $dir ) {
@@ -54,3 +65,32 @@ function jetpack_docker_plugins_url( $url, $path, $plugin ) {
 	return $url;
 }
 add_filter( 'plugins_url', __NAMESPACE__ . '\jetpack_docker_plugins_url', 1, 3 );
+
+/**
+ * Resolve a monorepo package's composer name from its composer.json.
+ *
+ * Cached per-request so a single page load doesn't re-read the same composer.json
+ * for every URL the package generates.
+ *
+ * @param string $package_dir Absolute path to the package directory.
+ * @return string|null The composer name (e.g., "automattic/jetpack-scan-page"),
+ *                     or null if composer.json is missing/unreadable/malformed.
+ */
+function jetpack_docker_resolve_composer_name( $package_dir ) {
+	static $cache = array();
+	if ( array_key_exists( $package_dir, $cache ) ) {
+		return $cache[ $package_dir ];
+	}
+
+	$name          = null;
+	$composer_path = $package_dir . '/composer.json';
+	if ( is_readable( $composer_path ) ) {
+		$contents = json_decode( file_get_contents( $composer_path ), true );
+		if ( is_array( $contents ) && isset( $contents['name'] ) && is_string( $contents['name'] ) ) {
+			$name = $contents['name'];
+		}
+	}
+
+	$cache[ $package_dir ] = $name;
+	return $name;
+}

--- a/tools/docker/mu-plugins/fix-monorepo-plugins-url.php
+++ b/tools/docker/mu-plugins/fix-monorepo-plugins-url.php
@@ -86,7 +86,7 @@ function jetpack_docker_resolve_composer_name( $package_dir ) {
 	$composer_path = $package_dir . '/composer.json';
 	if ( is_readable( $composer_path ) ) {
 		$contents = json_decode( file_get_contents( $composer_path ), true );
-		if ( is_array( $contents ) && isset( $contents['name'] ) && is_string( $contents['name'] ) ) {
+		if ( ! empty( $contents['name'] ) && is_string( $contents['name'] ) ) {
 			$name = $contents['name'];
 		}
 	}


### PR DESCRIPTION
Fixes #

## Proposed changes
* In the Docker dev environment, fix `plugins_url` translation for monorepo packages whose Composer `name` diverges from their directory name.
* Read the package's `composer.json` to determine the canonical vendor symlink name (e.g. `packages/scan/` → `automattic/jetpack-scan-page`), instead of hard-coding `automattic/jetpack-{dirname}`.
* Cache the lookup per-request so a single page load doesn't re-read the same `composer.json` for every URL the package generates.
* Keep the old directory-name convention as a defensive fallback when `composer.json` is missing/malformed.

Without this, `realpath()` matching in the filter never succeeds for divergent packages, so `plugins_url` returns the unresolved monorepo path and asset URLs 404. The most visible symptom is the gated Scan page (`wp-admin/admin.php?page=jetpack-scan`) failing to load its React app.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. Boot the Jetpack Docker dev environment (`jetpack docker up -d`) on `trunk` (i.e. without this fix).
2. Enable the gated Scan page (feature flag for the new Scan UI in the Jetpack plugin):
```
add_filter( 'rsm_jetpack_ui_modernization_scan', '__return_true' );
```
3. Visit `wp-admin/admin.php?page=jetpack-scan` and confirm the page fails to render (blank container / 404s on the package's assets in DevTools → Network).
4. Check out this branch and reload the Scan page — the React app should now render correctly with assets loading from `/wp-content/plugins/jetpack/jetpack_vendor/automattic/jetpack-scan-page/...`.
5. Spot-check other monorepo-package-driven admin pages (e.g. anything using `packages/*` assets in dev) to confirm there are no regressions in `plugins_url` resolution.
