### PR TITLE
Search Blocks: replace results-count "Searching…" text with a skeleton bar

### DIFF
--- a/projects/packages/search/changelog/atlas-search-172-results-count-skeleton-loading
+++ b/projects/packages/search/changelog/atlas-search-172-results-count-skeleton-loading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search blocks: replace the results-count "Searching…" text-swap loading state with a skeleton bar so the block no longer flickers from text to empty when a query returns zero results.

--- a/projects/packages/search/src/search-blocks/blocks/results-count/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/results-count/render.php
@@ -8,23 +8,33 @@
 namespace Automattic\Jetpack\Search;
 
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
-?>
-<?php
-// Intentionally render the element even when the count text is empty. The
-// Blog Search Page pattern places results-count and sort-control in a flex
-// group with `justifyContent: space-between`; removing the element from the
-// flow when there are no results would collapse that layout, snapping the
-// sort control to the left. An always-present (but text-empty) paragraph
-// keeps the two controls at the outer edges of the row.
+
+// The wrapper is intentionally rendered even when the count text is empty.
+// The Blog Search Page pattern places results-count and sort-control in a
+// flex group with `justifyContent: space-between`; removing the element
+// from the flow when there are no results would collapse that layout,
+// snapping the sort control to the left. An always-present (but text-empty)
+// element keeps the two controls at the outer edges of the row.
 //
-// Pre-hydration text: `state.resultsCountText` is seeded with the localized
-// "Searching…" string when the URL is going to trigger an initial fetch
-// (see `Search_Blocks::build_initial_state()`), and the IA SSR pass writes
-// that string into the body via `data-wp-text` — so a deep link no longer
-// flashes a blank line before JS hydrates.
+// Loading affordance: a skeleton bar paints while a fetch is in flight,
+// gated by `state.isLoading`. Replaces the previous "Searching…" text-swap
+// (same DOM node going from a localized word to an empty string), which
+// flickered visibly when the resolved count was zero. The text node is
+// gated by `!state.isLoading` so the two states never co-exist on screen.
+// `aria-busy` + `aria-live="polite"` give assistive tech a single
+// non-flickering loading→content announcement instead of "Searching…"
+// then a separate count.
 ?>
 <p
 	<?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>
 	data-wp-interactive="jetpack-search"
-	data-wp-text="state.resultsCountText"
-></p>
+	data-wp-bind--aria-busy="state.isLoading"
+	aria-live="polite"
+><span
+		class="jetpack-search-skeleton jetpack-search-skeleton--count"
+		data-wp-bind--hidden="!state.isLoading"
+		aria-hidden="true"
+	></span><span
+		data-wp-text="state.resultsCountText"
+		data-wp-bind--hidden="state.isLoading"
+	></span></p>

--- a/projects/packages/search/src/search-blocks/blocks/results-count/style.scss
+++ b/projects/packages/search/src/search-blocks/blocks/results-count/style.scss
@@ -1,3 +1,5 @@
+@use "../skeleton" as skeleton;
+
 .wp-block-jetpack-results-count {
 	font-size: 0.85rem;
 	// Inherit the theme's text color so the block adapts to the site palette
@@ -5,4 +7,21 @@
 	color: inherit;
 	opacity: 0.7;
 	margin: 0;
+
+	@include skeleton.shimmer;
+
+	// Inline skeleton bar that paints during the initial load — sized to
+	// roughly match the resolved "Found N results" string at the wrapper's
+	// 0.85rem font-size, so the block doesn't change height when the text
+	// swaps in.
+	.jetpack-search-skeleton--count {
+		display: inline-block;
+		width: 8rem;
+		height: 1em;
+		vertical-align: middle;
+
+		&[hidden] {
+			display: none;
+		}
+	}
 }

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -613,7 +613,7 @@ class Search_Blocks {
 			// Seeded empty so the SSR pass can resolve `data-wp-text` to a
 			// real string on first paint; the loading affordance is owned by
 			// the skeleton bar inside the results-count block (gated by
-			// `state.skeletonHidden`), not by a "Searching…" text seed that
+			// `state.isLoading`), not by a "Searching…" text seed that
 			// would flicker to empty when the resolved count is zero.
 			// `actions.search()` keeps this value in lockstep with
 			// `totalResults` via `computeResultsCountText`.

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -539,7 +539,6 @@ class Search_Blocks {
 		$active_filters     = static::parse_url_filters();
 		$price_range        = static::parse_url_price_range();
 		$is_initial_loading = static::is_initial_loading();
-		$searching_text     = function_exists( '__' ) ? __( 'Searching…', 'jetpack-search-pkg' ) : 'Searching…';
 
 		return array(
 			// Connection / routing config.
@@ -611,10 +610,14 @@ class Search_Blocks {
 			// on screen without re-flashing placeholders.
 			'skeletonHidden'   => false,
 
-			// Seeded so the SSR pass can resolve `data-wp-text` to a real
-			// string on first paint; `actions.search()` keeps it in lockstep
-			// with `isLoading` / `totalResults` via `computeResultsCountText`.
-			'resultsCountText' => $is_initial_loading ? $searching_text : '',
+			// Seeded empty so the SSR pass can resolve `data-wp-text` to a
+			// real string on first paint; the loading affordance is owned by
+			// the skeleton bar inside the results-count block (gated by
+			// `state.skeletonHidden`), not by a "Searching…" text seed that
+			// would flicker to empty when the resolved count is zero.
+			// `actions.search()` keeps this value in lockstep with
+			// `totalResults` via `computeResultsCountText`.
+			'resultsCountText' => '',
 
 			// Translated view-bundle strings. The Interactivity API view bundle
 			// can't import @wordpress/i18n (only @wordpress/interactivity is
@@ -747,14 +750,12 @@ class Search_Blocks {
 	protected static function build_initial_strings(): array {
 		if ( ! function_exists( '__' ) || ! function_exists( '_n' ) ) {
 			return array(
-				'searching'          => 'Searching…',
 				'resultsCountSingle' => 'Found %d result',
 				'resultsCountPlural' => 'Found %d results',
 				'removeFilter'       => 'Remove %s',
 			);
 		}
 		return array(
-			'searching'          => __( 'Searching…', 'jetpack-search-pkg' ),
 			/* translators: %d: number of results. */
 			'resultsCountSingle' => _n( 'Found %d result', 'Found %d results', 1, 'jetpack-search-pkg' ),
 			/* translators: %d: number of results. */

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -158,24 +158,24 @@ let searchToken = 0;
 
 /**
  * Build the human-readable results-count string from the live store state.
- * Returns "Searching…" while a search is in flight, "Found 42 results" once
- * a query resolves with hits, or an empty string in every other case
- * (pre-search, error, or zero hits — the empty-state region inside
- * `jetpack/search-results` owns that copy). Called by every action that mutates `isLoading` or
- * `totalResults` so the seeded `state.resultsCountText` stays in lockstep
- * with the counters; SSR resolves `data-wp-text` against that seeded value
- * directly, so the string can't live on a JS getter.
+ * Returns "Found 42 results" once a query resolves with hits, or an empty
+ * string in every other case (pre-search, loading, error, or zero hits —
+ * the empty-state region inside `jetpack/search-results` owns the empty
+ * copy, and the results-count block paints a skeleton bar gated by
+ * `state.skeletonHidden` for the loading affordance instead of a "Searching…"
+ * text swap that visibly flickers when the resolved count is empty).
+ * Called by every action that mutates `isLoading` or `totalResults` so the
+ * seeded `state.resultsCountText` stays in lockstep with the counters; SSR
+ * resolves `data-wp-text` against that seeded value directly, so the string
+ * can't live on a JS getter.
  *
  * Exported so tests can verify the formatting in isolation without driving
  * the full `actions.search()` lifecycle.
  *
  * @param {object} liveState - The IA store state.
- * @return {string} Localized results-count or status string.
+ * @return {string} Localized results-count string, or empty when there's nothing to count yet.
  */
 export function computeResultsCountText( liveState ) {
-	if ( liveState.isLoading ) {
-		return liveState.strings?.searching ?? 'Searching…';
-	}
 	const total = liveState.totalResults;
 	if ( total === 0 ) {
 		return '';

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -162,7 +162,7 @@ let searchToken = 0;
  * string in every other case (pre-search, loading, error, or zero hits —
  * the empty-state region inside `jetpack/search-results` owns the empty
  * copy, and the results-count block paints a skeleton bar gated by
- * `state.skeletonHidden` for the loading affordance instead of a "Searching…"
+ * `state.isLoading` for the loading affordance instead of a "Searching…"
  * text swap that visibly flickers when the resolved count is empty).
  * Called by every action that mutates `isLoading` or `totalResults` so the
  * seeded `state.resultsCountText` stays in lockstep with the counters; SSR

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -431,7 +431,6 @@ describe( 'store getters', () => {
 			aggregations: {},
 			sortOrder: 'relevance',
 			strings: {
-				searching: 'Looking…',
 				resultsCountSingle: 'Found %d item',
 				resultsCountPlural: 'Found %d items',
 			},
@@ -445,8 +444,15 @@ describe( 'store getters', () => {
 		// resolve server-side. Exercising `computeResultsCountText` directly
 		// keeps the formatting contract under test without driving the full
 		// fetch lifecycle.
+		//
+		// Loading deliberately returns the empty string — the results-count
+		// block paints a skeleton bar gated by `state.skeletonHidden` for
+		// the loading affordance instead of swapping a "Searching…" string
+		// into the same DOM node, which used to flicker to empty when the
+		// resolved count was zero.
 		state.isLoading = true;
-		expect( computeResultsCountText( state ) ).toBe( 'Looking…' );
+		state.totalResults = 0;
+		expect( computeResultsCountText( state ) ).toBe( '' );
 
 		state.isLoading = false;
 		state.totalResults = 1;

--- a/projects/packages/search/tests/php/Results_Count_Render_Test.php
+++ b/projects/packages/search/tests/php/Results_Count_Render_Test.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Results Count block render.php tests.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the results-count block's render template.
+ *
+ * Mirrors the other block render tests: registered inline so `do_blocks()`
+ * can resolve it without depending on built artifacts in `build/`.
+ */
+class Results_Count_Render_Test extends TestCase {
+
+	/**
+	 * Register the results-count block inline for the whole test class.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		\register_block_type(
+			'jetpack/results-count',
+			array(
+				// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+				'render_callback' => static function ( $attributes ) {
+					ob_start();
+					include __DIR__ . '/../../src/search-blocks/blocks/results-count/render.php';
+					return (string) ob_get_clean();
+				},
+				// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			)
+		);
+	}
+
+	/**
+	 * Unregister the block so other test classes start from a clean slate.
+	 */
+	public static function tearDownAfterClass(): void {
+		\unregister_block_type( 'jetpack/results-count' );
+		parent::tearDownAfterClass();
+	}
+
+	/**
+	 * Render the results-count block via `do_blocks`.
+	 *
+	 * @return string Rendered markup.
+	 */
+	private function render(): string {
+		return do_blocks( '<!-- wp:jetpack/results-count /-->' );
+	}
+
+	/**
+	 * The wrapper carries `aria-busy` bound to the live `isLoading` flag and
+	 * `aria-live="polite"` so assistive tech announces the resolved count
+	 * once it lands instead of "Searching…" then a separate count.
+	 */
+	public function test_wrapper_carries_aria_busy_and_aria_live() {
+		$markup = $this->render();
+		$this->assertStringContainsString( 'data-wp-bind--aria-busy="state.isLoading"', $markup );
+		$this->assertStringContainsString( 'aria-live="polite"', $markup );
+	}
+
+	/**
+	 * The text node that paints the resolved count binds to
+	 * `state.resultsCountText` — the only DOM affordance for the count
+	 * string post-hydration. Hidden while a fetch is in flight so it
+	 * never co-exists with the skeleton bar on screen.
+	 */
+	public function test_renders_text_node_bound_to_results_count_text() {
+		$markup = $this->render();
+		$this->assertStringContainsString( 'data-wp-text="state.resultsCountText"', $markup );
+		$this->assertStringContainsString( 'data-wp-bind--hidden="state.isLoading"', $markup );
+	}
+
+	/**
+	 * The skeleton bar is always emitted (not gated server-side on the
+	 * URL-driven `is_initial_loading` heuristic) so it remains in the DOM
+	 * for re-searches triggered post-hydration — filter changes, sort
+	 * changes, etc. Visibility is owned by `data-wp-bind--hidden` against
+	 * the live `state.isLoading` flag.
+	 */
+	public function test_renders_skeleton_bar_gated_by_is_loading() {
+		$markup = $this->render();
+		$this->assertStringContainsString( 'jetpack-search-skeleton--count', $markup );
+		$this->assertStringContainsString( 'data-wp-bind--hidden="!state.isLoading"', $markup );
+	}
+
+	/**
+	 * Pre-rename markup seeded `data-wp-text="state.resultsCountText"` on
+	 * the wrapper itself with a "Searching…" string seeded into the same
+	 * value, which flickered to empty when the resolved count was zero.
+	 * The wrapper now owns no `data-wp-text` of its own — only the inner
+	 * text node carries that binding — so a stale seed can't paint string
+	 * content next to the skeleton bar.
+	 */
+	public function test_wrapper_does_not_carry_data_wp_text() {
+		$markup = $this->render();
+		// The match is anchored to the wrapper opening tag (the first `<p`
+		// in the markup). The inner span's `data-wp-text` is fine; what we
+		// guard against is the wrapper itself binding text.
+		$this->assertMatchesRegularExpression(
+			'/<p\b[^>]*>(?![^<]*data-wp-text)/',
+			$markup,
+			'Wrapper <p> must not carry data-wp-text — that binding lives on the inner text span.'
+		);
+	}
+}

--- a/projects/packages/search/tests/php/Results_Count_Render_Test.php
+++ b/projects/packages/search/tests/php/Results_Count_Render_Test.php
@@ -7,7 +7,7 @@
 
 namespace Automattic\Jetpack\Search;
 
-use PHPUnit\Framework\TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
  * Tests for the results-count block's render template.
@@ -99,11 +99,14 @@ class Results_Count_Render_Test extends TestCase {
 	 */
 	public function test_wrapper_does_not_carry_data_wp_text() {
 		$markup = $this->render();
-		// The match is anchored to the wrapper opening tag (the first `<p`
-		// in the markup). The inner span's `data-wp-text` is fine; what we
-		// guard against is the wrapper itself binding text.
-		$this->assertMatchesRegularExpression(
-			'/<p\b[^>]*>(?![^<]*data-wp-text)/',
+		// Asserts the opening `<p …>` tag's attribute list itself does not
+		// include `data-wp-text`. The inner text span is allowed to carry
+		// it; what we guard against is the wrapper rebinding text and
+		// reintroducing the flicker. Anchor inside the tag (between `<p`
+		// and the closing `>`) so a future regression on the wrapper would
+		// fail the assertion.
+		$this->assertDoesNotMatchRegularExpression(
+			'/<p\b[^>]*\bdata-wp-text\b[^>]*>/',
 			$markup,
 			'Wrapper <p> must not carry data-wp-text — that binding lives on the inner text span.'
 		);

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -67,14 +67,25 @@ class Search_Blocks_Test extends TestCase {
 		$state = Search_Blocks::build_initial_state();
 		$this->assertArrayHasKey( 'strings', $state );
 		$strings = $state['strings'];
-		$this->assertArrayHasKey( 'searching', $strings );
 		$this->assertArrayHasKey( 'resultsCountSingle', $strings );
 		$this->assertArrayHasKey( 'resultsCountPlural', $strings );
 		$this->assertArrayHasKey( 'removeFilter', $strings );
-		$this->assertNotSame( '', $strings['searching'] );
 		$this->assertStringContainsString( '%d', $strings['resultsCountSingle'] );
 		$this->assertStringContainsString( '%d', $strings['resultsCountPlural'] );
 		$this->assertStringContainsString( '%s', $strings['removeFilter'] );
+	}
+
+	/**
+	 * `resultsCountText` is seeded as an empty string regardless of whether
+	 * the URL is going to trigger an initial fetch — the loading affordance
+	 * lives in the results-count block's skeleton bar (gated by
+	 * `state.skeletonHidden`), not in a "Searching…" text seed that used to
+	 * flicker to empty when the resolved count was zero.
+	 */
+	public function test_build_initial_state_seeds_empty_results_count_text() {
+		$state = Search_Blocks::build_initial_state();
+		$this->assertArrayHasKey( 'resultsCountText', $state );
+		$this->assertSame( '', $state['resultsCountText'] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes [SEARCH-172](https://linear.app/a8c/issue/SEARCH-172/search-blocks-results-count-flickers-from-searching-to-empty-when-a)

## Why

The results-count block flickered visibly between a localized `"Searching…"` text and an empty paragraph in the same DOM node every time a query resolved with zero results — the most-common error/empty-state surface. After [#48541](https://github.com/Automattic/jetpack/pull/48541) cleared stale data on the search-error path, the same flicker showed up there too: `"Searching…"` then nothing. Replacing the text-swap with a skeleton bar separates the loading and resolved states into different DOM nodes, so the count area now shows a single non-flickering loading→content transition that matches the rest of the search blocks.

## Proposed changes

* `projects/packages/search/src/search-blocks/blocks/results-count/render.php` now emits **two** child nodes inside the wrapper: a `.jetpack-search-skeleton--count` shimmer bar gated by `data-wp-bind--hidden="!state.isLoading"`, and a text `<span>` bound to `state.resultsCountText` gated by `data-wp-bind--hidden="state.isLoading"`. The two states never co-exist on screen.
* The wrapper `<p>` is unchanged in the DOM (still always present so the Blog Search Page pattern's flex `space-between` layout doesn't collapse) but no longer carries `data-wp-text` itself — the text binding moved to the inner `<span>`. The wrapper picks up `data-wp-bind--aria-busy="state.isLoading"` and `aria-live="polite"` so assistive tech announces the resolved count once it lands rather than "Searching…" then a separate count.
* `computeResultsCountText` in `store/index.js` drops the `isLoading` branch — the loading affordance now lives in the skeleton bar, not in the text. `state.resultsCountText` is `''` while loading and during the zero-results / error paths.
* `Search_Blocks::build_initial_state()` seeds `resultsCountText` as the empty string regardless of the URL — the previous `is_initial_loading ? "Searching…" : ""` ternary was the source of the SSR-time flicker seed. The `searching` key is dropped from `build_initial_strings()` since nothing reads it anymore.
* New `Results_Count_Render_Test` covers the `aria-busy` / `aria-live` wrapper, the inner skeleton + text bindings, and that the wrapper itself no longer carries `data-wp-text`. `Search_Blocks_Test` gains a regression for the empty `resultsCountText` seed.
* `store.test.js` updated to assert `computeResultsCountText` returns `''` while loading.

## Related product discussion/links

* [SEARCH-172](https://linear.app/a8c/issue/SEARCH-172/search-blocks-results-count-flickers-from-searching-to-empty-when-a)
* Surfaced after [#48541](https://github.com/Automattic/jetpack/pull/48541) cleared stale data on the error path — same root cause (one DOM node carrying two semantic states), now visible across both the empty-results and error paths.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The change is most easily verified visually by exercising the loading → resolved transition.

1. Build the package: `pnpm jetpack build packages/search` (or run the four-layer matrix from the [`jetpack-build-matrix`](../../.claude/skills/jetpack-build-matrix.md) skill if you're testing in a live env).
2. On a page rendering the Jetpack Search results region (the `Blog Search Page` pattern works, or visit `/?s=...` against a site with search blocks installed), perform a query that returns at least a few hits.
   * **Before**: during the fetch, the count area shows the localized `"Searching…"` text — and the moment the response lands with `total: 0` (or any failure), the text disappears, leaving a 0-height empty paragraph. That's the flicker.
   * **After**: during the fetch, the count area shows a shimmer skeleton bar at roughly the same width as the resolved count would occupy. Once the response lands, the skeleton hides and the text node fades in with the count (or stays empty for the zero-results / error path — no flicker, the wrapper stays in DOM either way so the flex `space-between` layout holds).
3. **Re-search:** while results are visible, change a filter or sort. The count should swap back to the skeleton, then back to the new count once the new fetch resolves — same shape as the initial-load case.
4. **Empty-results query:** search for something with no hits (e.g. `?s=zzznoresults`). The count area transitions skeleton → empty (no `"Searching…"` flash, no leftover count from the previous query).
5. **Error path:** with DevTools network throttling set to **Offline**, run a new query. The count area transitions skeleton → empty (the `role="alert"` message inside `jetpack/search-results` carries the user-facing error copy).
6. **Pre-hydration / deep link:** open `/?s=foo` directly (no JS yet) and confirm the seeded SSR markup paints a skeleton — not a text flash — in the count area.
7. Run the test suites:
   * JS: `pnpm exec jest --testPathPatterns=store.test` (75 tests).
   * PHP: `composer phpunit -- --filter 'Results_Count_Render_Test|Search_Blocks_Test'` (the new render test plus the seed regression).
