### PR TITLE
Write: fix empty heading and blockquote block markup in convertToBlocks

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-write-empty-gb-blocks
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-write-empty-gb-blocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write: strip lone br placeholders in convertToBlocks to fix empty heading and blockquote block markup

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -287,7 +287,9 @@ function convertToBlocks( html ) {
 		if ( node.nodeType !== Node.ELEMENT_NODE ) continue;
 
 		const tag = node.tagName.toLowerCase();
-		const inner = node.innerHTML.trim();
+		// Strip lone <br> placeholders left by contentEditable so empty
+		// blocks are not serialized with stale markup.
+		const inner = node.innerHTML.trim().replace( /^<br\s*\/?>$/, '' );
 
 		if ( ! inner && ! [ 'figure', 'img', 'hr' ].includes( tag ) ) continue;
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -291,7 +291,12 @@ function convertToBlocks( html ) {
 		// blocks are not serialized with stale markup.
 		const inner = node.innerHTML.trim().replace( /^<br\s*\/?>$/, '' );
 
-		if ( ! inner && ! [ 'figure', 'img', 'hr' ].includes( tag ) ) continue;
+		if (
+			! inner &&
+			! [ 'figure', 'img', 'hr', 'blockquote', 'ul', 'ol' ].includes( tag ) &&
+			! /^h[1-6]$/.test( tag )
+		)
+			continue;
 
 		// Check for text alignment.
 		const align = node.style && node.style.textAlign;
@@ -349,11 +354,15 @@ function convertToBlocks( html ) {
 			);
 		} else if ( tag === 'ul' || tag === 'ol' ) {
 			// Wrap each <li> in wp:list-item block comments.
-			const listItems = Array.from( node.querySelectorAll( ':scope > li' ) )
-				.map(
-					li => `<!-- wp:list-item -->\n<li>${ li.innerHTML.trim() }</li>\n<!-- /wp:list-item -->`
-				)
-				.join( '\n' );
+			const liNodes = Array.from( node.querySelectorAll( ':scope > li' ) );
+			const listItems = liNodes.length
+				? liNodes
+						.map(
+							li =>
+								`<!-- wp:list-item -->\n<li>${ li.innerHTML.trim() }</li>\n<!-- /wp:list-item -->`
+						)
+						.join( '\n' )
+				: '<!-- wp:list-item -->\n<li></li>\n<!-- /wp:list-item -->';
 			const listTag = tag === 'ol' ? 'ol' : 'ul';
 			const attrs = tag === 'ol' ? ' {"ordered":true}' : '';
 			blocks.push(


### PR DESCRIPTION
Fixes RSM-2297

## Proposed changes

* Strip lone `<br>` placeholders from `innerHTML` in `convertToBlocks()` before the empty-content check — these are left by contentEditable for focus but produce invalid Gutenberg block markup
* Preserve empty headings, blockquotes, and lists as valid empty Gutenberg blocks instead of skipping them, matching how the block editor handles empty content
* Empty paragraphs are still skipped as they are typically whitespace noise from pressing Enter
* Empty lists with no `<li>` children get a single empty list item to produce valid markup

## Related product discussion/links

* RSM-2297

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Open a Write post in the editor
2. Type `/heading` and press Enter to insert an empty heading — do not type any text into it
3. Type `/quote` and press Enter to insert an empty blockquote — do not type any text into it
4. Add some content in other blocks (e.g. a paragraph with text)
5. Save or publish the post, then open it in the Gutenberg block editor
6. Verify that each empty heading/blockquote appears as a single empty block (not two split blocks)
7. Verify that non-empty headings and blockquotes still convert correctly
8. Verify that empty paragraphs are not carried over

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
