### PR TITLE
Search Blocks: fix block-validation error on container blocks (RSM-2378)

### DIFF
--- a/projects/packages/search/changelog/fix-search-blocks-results-panel-validation
+++ b/projects/packages/search/changelog/fix-search-blocks-results-panel-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks: fix block-validation error on results-panel, filter-popover, and common-filters when inserted via patterns

--- a/projects/packages/search/src/search-blocks/blocks/common-filters/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/common-filters/edit.js
@@ -39,9 +39,4 @@ export default function CommonFiltersEdit() {
 	);
 }
 
-/**
- * Save component — only renders InnerBlocks.Content.
- *
- * @return {object} Rendered element.
- */
 export const save = () => <InnerBlocks.Content />;

--- a/projects/packages/search/src/search-blocks/blocks/filter-popover/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/filter-popover/edit.js
@@ -56,9 +56,4 @@ export default function FilterPopoverEdit() {
 	);
 }
 
-/**
- * Save component — only renders InnerBlocks.Content.
- *
- * @return {object} Rendered element.
- */
 export const save = () => <InnerBlocks.Content />;

--- a/projects/packages/search/src/search-blocks/blocks/results-panel/edit.js
+++ b/projects/packages/search/src/search-blocks/blocks/results-panel/edit.js
@@ -42,9 +42,4 @@ export default function ResultsPanelEdit() {
 	);
 }
 
-/**
- * Save component — only renders InnerBlocks.Content.
- *
- * @return {object} Rendered element.
- */
 export const save = () => <InnerBlocks.Content />;

--- a/projects/packages/search/src/search-blocks/editor/register-blocks.js
+++ b/projects/packages/search/src/search-blocks/editor/register-blocks.js
@@ -31,7 +31,11 @@ import SearchInputEdit from '../blocks/search-input/edit';
 import SearchResultsEdit from '../blocks/search-results/edit';
 import SortControlEdit from '../blocks/sort-control/edit';
 
-// Dynamic blocks — render.php produces all front-end markup, so save() is a no-op.
+// Default save for blocks that own no editor-side state — render.php is the
+// source of truth on the front end, so save returns null. Container blocks
+// that hold InnerBlocks pass their own `() => <InnerBlocks.Content />` save
+// instead, since `save: null` would self-close their delimiter and drop the
+// children on serialize.
 const save = () => null;
 
 const BLOCKS = [

--- a/projects/packages/search/src/search-blocks/patterns/blog-search.php
+++ b/projects/packages/search/src/search-blocks/patterns/blog-search.php
@@ -29,7 +29,6 @@ register_block_pattern(
 <!-- wp:column -->
 <div class="wp-block-column">
 <!-- wp:jetpack/results-panel -->
-<div class="wp-block-jetpack-results-panel jetpack-search-results-panel">
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
 <div class="wp-block-group">
 <!-- wp:jetpack/results-count /-->
@@ -39,7 +38,6 @@ register_block_pattern(
 
 <!-- wp:jetpack/search-results /-->
 <!-- wp:jetpack/load-more /-->
-</div>
 <!-- /wp:jetpack/results-panel -->
 </div>
 <!-- /wp:column -->

--- a/projects/packages/search/src/search-blocks/patterns/compact-search.php
+++ b/projects/packages/search/src/search-blocks/patterns/compact-search.php
@@ -40,11 +40,9 @@ register_block_pattern(
 <!-- /wp:group -->
 
 <!-- wp:jetpack/results-panel -->
-<div class="wp-block-jetpack-results-panel jetpack-search-results-panel">
 <!-- wp:jetpack/results-count /-->
 <!-- wp:jetpack/search-results {"layout":"compact"} /-->
 <!-- wp:jetpack/load-more /-->
-</div>
 <!-- /wp:jetpack/results-panel -->
 
 </div>

--- a/projects/packages/search/src/search-blocks/templates/jetpack-search.html
+++ b/projects/packages/search/src/search-blocks/templates/jetpack-search.html
@@ -13,7 +13,6 @@
 <!-- wp:column -->
 <div class="wp-block-column">
 <!-- wp:jetpack/results-panel -->
-<div class="wp-block-jetpack-results-panel jetpack-search-results-panel">
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
 <div class="wp-block-group">
 <!-- wp:jetpack/results-count /-->
@@ -23,7 +22,6 @@
 
 <!-- wp:jetpack/search-results /-->
 <!-- wp:jetpack/load-more /-->
-</div>
 <!-- /wp:jetpack/results-panel -->
 </div>
 <!-- /wp:column -->


### PR DESCRIPTION
Fixes [RSM-2378](https://linear.app/a8c/issue/RSM-2378/results-panel-block-fails-validation-in-inserted-pattern)

## Why

Inserting either of the new Jetpack Search patterns ("Compact Search" or "Blog Search Page") on any post immediately triggered "Block contains unexpected or invalid content" with an "Attempt recovery" prompt — making the patterns unusable out of the box. The patterns now insert cleanly with no validation prompt, and authors can start arranging them right away.

## Proposed changes

* Wrap `<InnerBlocks.Content />` with a `useBlockProps.save()` div in the three search container blocks: `jetpack/results-panel`, `jetpack/filter-popover`, and `jetpack/common-filters`. Bare `save = () => <InnerBlocks.Content />` doesn't survive WP's block-validation comparison when serialized inside a pattern.
* Add the matching `<div class="wp-block-jetpack-filter-popover jetpack-search-filter-popover">…</div>` wrapper around `filter-popover`'s inner blocks in the Compact Search pattern so its serialized markup matches the new save output. (`results-panel`'s wrapper was already in the patterns / template — those start matching once save is fixed.)

## Screenshots

### Before
![before](https://github.com/user-attachments/assets/8d626257-fe1d-48a9-aa94-4e28020c1736)

### After
![after](https://github.com/user-attachments/assets/f34f08d4-1379-48e6-a4ff-a3ab4615c66b)

## Related product discussion/links

* Linear: [RSM-2378](https://linear.app/a8c/issue/RSM-2378/results-panel-block-fails-validation-in-inserted-pattern)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. On a Jetpack-Search-enabled site, create a new post or page.
2. Open the inserter, go to **Patterns → Jetpack Search**, and insert **Compact Search**.
   * Expected: the toolbar (search input + filter / sort buttons) and the result list (count + items + Load more) render in the editor with no warning.
   * Without the fix: the inserted block shows "Block contains unexpected or invalid content" with an "Attempt recovery" button.
3. Repeat with **Blog Search Page** — both columns (search results on the left, filter sidebar on the right) should render without the validation prompt.
4. Save / reload the post. The blocks should still load cleanly with no validation prompt.
5. Sanity-check the front end: visit the saved post and confirm the search UI renders and the result list paints (no behavior changes, only the editor-side validation was broken).
