### PR TITLE
Search Blocks: keep results-count text non-empty across loading, error, and zero-results paths

### DIFF
--- a/projects/packages/search/changelog/atlas-search-172-results-count-no-flicker
+++ b/projects/packages/search/changelog/atlas-search-172-results-count-no-flicker
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search blocks: results-count now stays non-empty across the loading, error, and zero-results paths so the text never visibly flickers from "Searching…" to a blank paragraph as a query resolves.

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -748,17 +748,21 @@ class Search_Blocks {
 		if ( ! function_exists( '__' ) || ! function_exists( '_n' ) ) {
 			return array(
 				'searching'          => 'Searching…',
+				'searchError'        => 'Search error',
 				'resultsCountSingle' => 'Found %d result',
 				'resultsCountPlural' => 'Found %d results',
+				'resultsCountEmpty'  => 'No results',
 				'removeFilter'       => 'Remove %s',
 			);
 		}
 		return array(
 			'searching'          => __( 'Searching…', 'jetpack-search-pkg' ),
+			'searchError'        => __( 'Search error', 'jetpack-search-pkg' ),
 			/* translators: %d: number of results. */
 			'resultsCountSingle' => _n( 'Found %d result', 'Found %d results', 1, 'jetpack-search-pkg' ),
 			/* translators: %d: number of results. */
 			'resultsCountPlural' => _n( 'Found %d result', 'Found %d results', 2, 'jetpack-search-pkg' ),
+			'resultsCountEmpty'  => __( 'No results', 'jetpack-search-pkg' ),
 			/* translators: %s: filter label (e.g. "Category: News"). Announced by screen readers when focus lands on a filter pill's remove button. */
 			'removeFilter'       => __( 'Remove %s', 'jetpack-search-pkg' ),
 		);

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -158,13 +158,18 @@ let searchToken = 0;
 
 /**
  * Build the human-readable results-count string from the live store state.
- * Returns "Searching…" while a search is in flight, "Found 42 results" once
- * a query resolves with hits, or an empty string in every other case
- * (pre-search, error, or zero hits — the empty-state region inside
- * `jetpack/search-results` owns that copy). Called by every action that mutates `isLoading` or
- * `totalResults` so the seeded `state.resultsCountText` stays in lockstep
- * with the counters; SSR resolves `data-wp-text` against that seeded value
- * directly, so the string can't live on a JS getter.
+ * Always returns a non-empty string once a search has been performed —
+ * "Searching…" while in flight, "Search error" when the fetch fails,
+ * "No results" when the query resolves with zero hits, and "Found N
+ * results" otherwise. The only case where this returns an empty string
+ * is the pre-search state (no query yet); after that, the count area
+ * always has text content so it can't visibly flicker text → empty as
+ * a fetch resolves with zero hits or fails.
+ *
+ * Called by every action that mutates `isLoading` / `totalResults` /
+ * `hasError` so the seeded `state.resultsCountText` stays in lockstep
+ * with the counters; SSR resolves `data-wp-text` against that seeded
+ * value directly, so the string can't live on a JS getter.
  *
  * Exported so tests can verify the formatting in isolation without driving
  * the full `actions.search()` lifecycle.
@@ -176,9 +181,19 @@ export function computeResultsCountText( liveState ) {
 	if ( liveState.isLoading ) {
 		return liveState.strings?.searching ?? 'Searching…';
 	}
+	if ( liveState.hasError ) {
+		return liveState.strings?.searchError ?? 'Search error';
+	}
 	const total = liveState.totalResults;
 	if ( total === 0 ) {
-		return '';
+		// Bare /search/ page with nothing typed yet — leave the count
+		// blank rather than announcing "No results" before the user has
+		// done anything. There's no flicker to worry about here because
+		// the text was empty all along.
+		if ( ! liveState.searchQuery ) {
+			return '';
+		}
+		return liveState.strings?.resultsCountEmpty ?? 'No results';
 	}
 	const template =
 		total === 1

--- a/projects/packages/search/tests/js/search-blocks/store.test.js
+++ b/projects/packages/search/tests/js/search-blocks/store.test.js
@@ -241,9 +241,11 @@ describe( 'store actions', () => {
 		expect( state.totalResults ).toBe( 0 );
 		expect( state.pageHandle ).toBeNull();
 		expect( state.aggregations ).toEqual( {} );
-		// `resultsCountText` reads from `totalResults` via `computeResultsCountText`,
-		// so an empty count string falls out for free — no extra wiring.
-		expect( state.resultsCountText ).toBe( '' );
+		// `resultsCountText` resolves to the localized error string rather
+		// than the empty string — keeps the count area non-empty so the
+		// resolved text doesn't flicker from "Searching…" to a blank
+		// paragraph the moment the fetch fails.
+		expect( state.resultsCountText ).toBe( 'Search error' );
 	} );
 
 	it( 'leaves the existing results in place when loadMore() errors out', async () => {
@@ -432,13 +434,15 @@ describe( 'store getters', () => {
 			sortOrder: 'relevance',
 			strings: {
 				searching: 'Looking…',
+				searchError: 'Something broke',
 				resultsCountSingle: 'Found %d item',
 				resultsCountPlural: 'Found %d items',
+				resultsCountEmpty: 'Nothing matched',
 			},
 		} );
 	} );
 
-	it( 'formats the results count for loading, singular, plural, and empty states', () => {
+	it( 'formats the results count for loading, error, singular, plural, and empty states', () => {
 		// `resultsCountText` is now a regular state value updated by
 		// `actions.search()` rather than a getter — the SSR pass needs to
 		// read a literal string off the seeded state, and JS getters don't
@@ -448,14 +452,33 @@ describe( 'store getters', () => {
 		state.isLoading = true;
 		expect( computeResultsCountText( state ) ).toBe( 'Looking…' );
 
+		// Error path takes precedence over `totalResults`; an in-flight error
+		// has the loading text, and a resolved error has the error string —
+		// not the empty string the prior version would have produced once
+		// `actions.search()` reset `totalResults` to 0 in its catch block.
 		state.isLoading = false;
+		state.hasError = true;
+		state.totalResults = 0;
+		expect( computeResultsCountText( state ) ).toBe( 'Something broke' );
+
+		state.hasError = false;
 		state.totalResults = 1;
 		expect( computeResultsCountText( state ) ).toBe( 'Found 1 item' );
 
 		state.totalResults = 3;
 		expect( computeResultsCountText( state ) ).toBe( 'Found 3 items' );
 
+		// Zero hits with an active query: the count area announces the
+		// empty result rather than going to an empty string. The dedicated
+		// empty-state region inside `jetpack/search-results` still owns the
+		// longer-form "Try a different search." copy below.
+		state.searchQuery = 'react';
 		state.totalResults = 0;
+		expect( computeResultsCountText( state ) ).toBe( 'Nothing matched' );
+
+		// Pre-search state — no query yet, so the count stays empty. There's
+		// no flicker to worry about here because the text was always empty.
+		state.searchQuery = '';
 		expect( computeResultsCountText( state ) ).toBe( '' );
 	} );
 

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -68,10 +68,17 @@ class Search_Blocks_Test extends TestCase {
 		$this->assertArrayHasKey( 'strings', $state );
 		$strings = $state['strings'];
 		$this->assertArrayHasKey( 'searching', $strings );
+		$this->assertArrayHasKey( 'searchError', $strings );
 		$this->assertArrayHasKey( 'resultsCountSingle', $strings );
 		$this->assertArrayHasKey( 'resultsCountPlural', $strings );
+		$this->assertArrayHasKey( 'resultsCountEmpty', $strings );
 		$this->assertArrayHasKey( 'removeFilter', $strings );
 		$this->assertNotSame( '', $strings['searching'] );
+		// `searchError` and `resultsCountEmpty` keep the count area non-empty
+		// across the error and zero-results paths so the resolved text never
+		// flickers from a localized status string to an empty paragraph.
+		$this->assertNotSame( '', $strings['searchError'] );
+		$this->assertNotSame( '', $strings['resultsCountEmpty'] );
 		$this->assertStringContainsString( '%d', $strings['resultsCountSingle'] );
 		$this->assertStringContainsString( '%d', $strings['resultsCountPlural'] );
 		$this->assertStringContainsString( '%s', $strings['removeFilter'] );


### PR DESCRIPTION
Fixes [SEARCH-172](https://linear.app/a8c/issue/SEARCH-172/search-blocks-results-count-flickers-from-searching-to-empty-when-a)

(Replaces #48543 — the skeleton-bar approach didn't fully solve the flicker. This is the simpler "just always show something" fix Jasper asked for.)

## Why

The results-count area's `<p>` flashed visibly between a localized `"Searching…"` text and an empty paragraph in the same DOM node any time a query resolved with zero results — the most-common error/empty surface. After [#48541](https://github.com/Automattic/jetpack/pull/48541) cleared stale data on the error path, the same flicker showed up there too: `"Searching…"` → nothing. Keep the count text non-empty across all states *once a search has been performed* and there's nothing left to flicker into.

## Before / After

Same `?s=zzznoresult` query, captured against the local docker env at the moment the fetch resolves with zero hits:

| Before (trunk) | After (this PR) |
|---|---|
| ![before](https://github.com/user-attachments/assets/bf13d0cf-44c7-4162-bc04-ae6175bc6f7e) | ![after](https://github.com/user-attachments/assets/89a24b55-3ed8-44d9-87a6-dea36fc663ce) |
| Count area is empty — the `<p>` paragraph went from `"Searching…"` to `""` and there's nothing left to read. | Count area reads **"No results"** — non-empty, no transition into a blank node. |

The error path swaps the same way: trunk dropped the count to empty, this PR shows **"Search error"** instead.

## Proposed changes

* `computeResultsCountText` in `projects/packages/search/src/search-blocks/store/index.js` gains a `hasError` branch returning a localized `"Search error"` string, and the `totalResults === 0` branch returns a localized `"No results"` string instead of `''` — gated on `state.searchQuery` so a bare `/search/` page with nothing typed yet still renders an empty count (no "No results" announcement before the user has done anything; nothing was searched).
* `Search_Blocks::build_initial_strings()` seeds two new keys: `searchError` and `resultsCountEmpty`. Both fall back to English defaults when `__()` / `_n()` aren't available, mirroring the existing pattern.
* `Search_Blocks_Test::test_build_initial_state_seeds_translated_strings` asserts both new keys are present and non-empty.
* `store.test.js` covers the new branches: error path returns the error string, zero-results-with-active-query returns the empty string, and bare `/search/` still returns `''`. The error-clearing test from #48541 is updated so its `state.resultsCountText` assertion expects the localized error fallback rather than `''`.

## Related product discussion/links

* [SEARCH-172](https://linear.app/a8c/issue/SEARCH-172/search-blocks-results-count-flickers-from-searching-to-empty-when-a)
* Replaces [#48543](https://github.com/Automattic/jetpack/pull/48543) (closed) — that PR tried a skeleton-bar approach which didn't fully eliminate the flicker (the wrapper still transitioned skeleton → empty on the zero-results path).
* Surfaced after [#48541](https://github.com/Automattic/jetpack/pull/48541) cleared stale data on the error path.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Build the package: `pnpm jetpack build packages/search` (or run the four-layer matrix from the [`jetpack-build-matrix`](../../.claude/skills/jetpack-build-matrix.md) skill if you're testing in a live env).
2. On a page rendering the Jetpack Search results region, perform a query that returns at least a few hits and watch the count area:
   * **Before** (trunk): "Searching…" appears during the fetch, then snaps to either "Found N results" (success) or to an empty paragraph (zero results / error). The empty cases were the visible flicker.
   * **After** (this PR): "Searching…" → "Found N results" / "No results" / "Search error". Always non-empty post-fetch, no transition to empty.
3. **Empty-results query:** search for something with no hits (`?s=zzznoresults`). The count area should read "No results" — no flicker through empty.
4. **Error path:** with DevTools network throttling set to **Offline**, run a new query. The count should read "Search error" rather than dropping to empty.
5. **Pre-search state:** open `/search/` with no query (or a clean WP `/?s=`). The count should remain empty — nothing has been searched yet, so there's nothing to announce.
6. Run the test suites:
   * JS: `pnpm exec jest --testPathPatterns=store.test` (75 tests pass).
   * PHP: `composer phpunit -- --filter Search_Blocks_Test` (19 tests pass, including the new `searchError` / `resultsCountEmpty` seed assertions).
